### PR TITLE
Windows specific test to verify HTTP executor works

### DIFF
--- a/internal/digraph/executor/http_test.go
+++ b/internal/digraph/executor/http_test.go
@@ -194,7 +194,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
 					// Echo back some request info
-					response := map[string]interface{}{
+					response := map[string]any{
 						"method":   r.Method,
 						"platform": runtime.GOOS,
 						"headers":  r.Header,
@@ -229,7 +229,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Parse response to verify it contains expected data
-				var response map[string]interface{}
+				var response map[string]any
 				err = json.Unmarshal([]byte(out.String()), &response)
 				assert.NoError(t, err)
 				assert.Equal(t, tc.method, response["method"])
@@ -243,7 +243,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 	})
 
 	t.Run("JSON response formatting consistency", func(t *testing.T) {
-		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("X-Test-Header", "cross-platform")
 			w.WriteHeader(nethttp.StatusOK)
@@ -288,7 +288,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 		assert.Contains(t, jsonResponse.Headers, "X-Test-Header")
 		
 		// Verify response body structure
-		bodyMap, ok := jsonResponse.Body.(map[string]interface{})
+		bodyMap, ok := jsonResponse.Body.(map[string]any)
 		assert.True(t, ok)
 		assert.Equal(t, "JSON response test", bodyMap["message"])
 		assert.Equal(t, runtime.GOOS, bodyMap["platform"])
@@ -297,7 +297,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 	})
 
 	t.Run("Error handling consistency", func(t *testing.T) {
-		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
 			w.WriteHeader(nethttp.StatusInternalServerError)
 			_, _ = w.Write([]byte("Server error for cross-platform test"))
 		}))

--- a/internal/digraph/executor/http_windows_test.go
+++ b/internal/digraph/executor/http_windows_test.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package executor
 
 import (
@@ -17,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
 
 // TestHTTPExecutor_WindowsSpecific tests the HTTP executor specifically on Windows
 func TestHTTPExecutor_WindowsSpecific(t *testing.T) {


### PR DESCRIPTION
Results from the running the whole HTTPExecutor test and windows specific ones:

```
PS C:\Users\doronila\git\dagu> go test .\internal\digraph\executor\ -v -run TestHTTPExecutor
=== RUN   TestHTTPExecutor_SkipTLSVerify
=== RUN   TestHTTPExecutor_SkipTLSVerify/HTTPS_request_with_self-signed_certificate
=== RUN   TestHTTPExecutor_SkipTLSVerify/HTTPS_request_without_skipTLSVerify
2025/06/29 11:31:20 http: TLS handshake error from 127.0.0.1:50894: remote error: tls: bad certificate
=== RUN   TestHTTPExecutor_SkipTLSVerify/Config_parsing_with_skipTLSVerify
--- PASS: TestHTTPExecutor_SkipTLSVerify (0.03s)
    --- PASS: TestHTTPExecutor_SkipTLSVerify/HTTPS_request_with_self-signed_certificate (0.01s)
    --- PASS: TestHTTPExecutor_SkipTLSVerify/HTTPS_request_without_skipTLSVerify (0.02s)
    --- PASS: TestHTTPExecutor_SkipTLSVerify/Config_parsing_with_skipTLSVerify (0.00s)
=== RUN   TestHTTPExecutor_StandardFeatures
=== RUN   TestHTTPExecutor_StandardFeatures/GET_request_with_headers_and_query_params
--- PASS: TestHTTPExecutor_StandardFeatures (0.00s)
    --- PASS: TestHTTPExecutor_StandardFeatures/GET_request_with_headers_and_query_params (0.00s)
=== RUN   TestHTTPExecutor_CrossPlatform
=== RUN   TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms
=== RUN   TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/Simple_GET
    http_test.go:239: Platform: windows, Method: GET, Response length: 155
=== RUN   TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/POST_with_JSON
    http_test.go:239: Platform: windows, Method: POST, Response length: 246
=== RUN   TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/GET_with_custom_headers
    http_test.go:239: Platform: windows, Method: GET, Response length: 188
=== RUN   TestHTTPExecutor_CrossPlatform/JSON_response_formatting_consistency
    http_test.go:296: Platform: windows, JSON response verified
=== RUN   TestHTTPExecutor_CrossPlatform/Error_handling_consistency
    http_test.go:339: Platform: windows, Error handling verified
--- PASS: TestHTTPExecutor_CrossPlatform (0.01s)
    --- PASS: TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms (0.00s)
        --- PASS: TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/Simple_GET (0.00s)
        --- PASS: TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/POST_with_JSON (0.00s)
        --- PASS: TestHTTPExecutor_CrossPlatform/Behavior_consistency_across_platforms/GET_with_custom_headers (0.00s)
    --- PASS: TestHTTPExecutor_CrossPlatform/JSON_response_formatting_consistency (0.00s)
    --- PASS: TestHTTPExecutor_CrossPlatform/Error_handling_consistency (0.00s)
=== RUN   TestHTTPExecutor_WindowsSpecific
=== RUN   TestHTTPExecutor_WindowsSpecific/Basic_GET_request_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/POST_request_with_JSON_body_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/Headers_and_query_parameters_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/Timeout_handling_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_200
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_201
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_299
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_400
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_401
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_404
=== RUN   TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_500
=== RUN   TestHTTPExecutor_WindowsSpecific/HTTPS_with_self-signed_certificate_on_Windows
=== RUN   TestHTTPExecutor_WindowsSpecific/Process_cancellation_on_Windows
--- PASS: TestHTTPExecutor_WindowsSpecific (8.01s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/Basic_GET_request_on_Windows (0.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/POST_request_with_JSON_body_on_Windows (0.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/Headers_and_query_parameters_on_Windows (0.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/Timeout_handling_on_Windows (3.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows (0.01s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_200 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_201 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_299 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_400 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_401 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_404 (0.00s)
        --- PASS: TestHTTPExecutor_WindowsSpecific/Error_status_codes_on_Windows/Status_500 (0.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/HTTPS_with_self-signed_certificate_on_Windows (0.00s)
    --- PASS: TestHTTPExecutor_WindowsSpecific/Process_cancellation_on_Windows (5.00s)
=== RUN   TestHTTPExecutor_WindowsPerformance
    http_windows_test.go:398: Windows HTTP executor average execution time: 1.24346ms
--- PASS: TestHTTPExecutor_WindowsPerformance (0.01s)
PASS
ok      github.com/dagu-org/dagu/internal/digraph/executor      8.132s
``` 

