### PR TITLE
Fix log file path migration from legacy format

### DIFF
--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -291,12 +291,7 @@ func (m *HistoryMigrator) convertNode(legacy *legacymodel.Node) *models.Node {
 		StartedAt:  legacy.StartedAt,
 		FinishedAt: legacy.FinishedAt,
 		RetriedAt:  legacy.RetriedAt,
-	}
-
-	// Legacy format stored logs inline, new format uses file paths
-	// We'll store the log content as a note that it was migrated
-	if legacy.Log != "" {
-		node.Stdout = "(migrated - log content was inline)"
+		Stdout:     legacy.Log,
 	}
 
 	return node


### PR DESCRIPTION
The legacy format already stored logs as file paths, not inline content. This PR fixes the migration to properly copy the log file path instead of replacing it with a placeholder message.

Issue: #1112