### PR TITLE
feat: add npm package verification after publishing

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -210,3 +210,51 @@ jobs:
           }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Verify the published packages
+  verify-packages:
+    needs: [publish-platform-packages, publish-main-package]
+    if: always()
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            test-install: npm install -g dagu
+          - os: macos-latest
+            test-install: npm install -g dagu
+          - os: windows-latest
+            test-install: npm install -g dagu
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Wait for npm propagation
+        shell: bash
+        run: |
+          # Wait for package to be available with retries
+          echo "Checking npm package availability..."
+          for i in {1..30}; do
+            if npm view dagu version 2>/dev/null; then
+              echo "Package is available!"
+              break
+            fi
+            echo "Attempt $i/30: Package not yet available, waiting 10 seconds..."
+            sleep 10
+          done
+
+      - name: Test installation
+        run: |
+          ${{ matrix.test-install }}
+
+      - name: Verify installation
+        run: |
+          dagu version
+
+      - name: Test basic functionality
+        run: |
+          dagu help


### PR DESCRIPTION
**Overview:**
When publishing npm packages, there's no verification that the packages are actually installable and functional after publishing. This could lead to broken releases going unnoticed. This verification step was previously removed due to errors but is now being re-added with fixes.

Refs: https://github.com/dagu-org/dagu/commit/8a78db9c8c4971d6744e3e028ab87bd65058cda0#commitcomment-163066899

**Changes:**
- Added `verify-packages` job that runs after platform and main package publishing
- Tests installation on Ubuntu, macOS, and Windows
- Includes npm propagation wait logic with 30 retry attempts
- Verifies the binary works by running `dagu version` and `dagu help`