### PR TITLE
fix: correct environment variable mapping for coordinator host and port

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -595,8 +595,8 @@ func (l *ConfigLoader) bindEnvironmentVariables() {
 	l.bindEnv("queues.enabled", "QUEUE_ENABLED")
 
 	// Coordinator service configuration (flat structure)
-	l.bindEnv("coordinatorHost", "COORDINATOR_HOST")
-	l.bindEnv("coordinatorPort", "COORDINATOR_PORT")
+	l.bindEnv("coordinator.host", "COORDINATOR_HOST")
+	l.bindEnv("coordinator.port", "COORDINATOR_PORT")
 
 	// Worker configuration (nested structure)
 	l.bindEnv("worker.id", "WORKER_ID")


### PR DESCRIPTION
**Changes**
- Fixes incorrect environment variable binding for coordinator configuration

**Why**
- The environment variables `DAGU_COORDINATOR_HOST` and `DAGU_COORDINATOR_PORT` were incorrectly mapped to flat config keys (`coordinatorHost`, `coordinatorPort`) instead of the proper nested structure (`coordinator.host`, `coordinator.port`).