### PR TITLE
Fix stop operation to handle case where RunID is not specified

### DIFF
--- a/internal/digraph/scheduler/scheduler.go
+++ b/internal/digraph/scheduler/scheduler.go
@@ -438,9 +438,11 @@ func (sc *Scheduler) Signal(
 	for _, node := range graph.nodes {
 		// for a repetitive task, we'll wait for the job to finish
 		// until time reaches max wait time
-		if node.Step().RepeatPolicy.RepeatMode == "" {
-			node.Signal(ctx, sig, allowOverride)
+		if node.Step().RepeatPolicy.RepeatMode != "" {
+			logger.Info(ctx, "Waiting the repeat node finish", "step", node.Step().Name)
+			continue
 		}
+		node.Signal(ctx, sig, allowOverride)
 	}
 
 	if done != nil {

--- a/internal/models/proc.go
+++ b/internal/models/proc.go
@@ -16,6 +16,8 @@ type ProcStore interface {
 	CountAlive(ctx context.Context, name string) (int, error)
 	// IsRunAlive checks if a specific DAG run is currently alive.
 	IsRunAlive(ctx context.Context, dagRun digraph.DAGRunRef) (bool, error)
+	// ListAlive returns list of running DAG runs by the name.
+	ListAlive(ctx context.Context, name string) ([]digraph.DAGRunRef, error)
 }
 
 // ProcHandle represents a process that is associated with a dag-run.

--- a/internal/persistence/fileproc/store.go
+++ b/internal/persistence/fileproc/store.go
@@ -39,6 +39,17 @@ func (s *Store) CountAlive(ctx context.Context, name string) (int, error) {
 	return procGroup.Count(ctx)
 }
 
+// ListAlive implements models.ProcStore.
+func (s *Store) ListAlive(ctx context.Context, name string) ([]digraph.DAGRunRef, error) {
+	pgBaseDir := filepath.Join(s.baseDir, name)
+	pg, _ := s.procGroups.LoadOrStore(name, NewProcGroup(pgBaseDir, name, s.staleTime))
+	procGroup, ok := pg.(*ProcGroup)
+	if !ok {
+		return nil, fmt.Errorf("invalid type in procGroups map: expected *ProcGroup, got %T", pg)
+	}
+	return procGroup.ListAlive(ctx)
+}
+
 // Acquire implements models.ProcStore.
 func (s *Store) Acquire(ctx context.Context, dagRun digraph.DAGRunRef) (models.ProcHandle, error) {
 	pgBaseDir := filepath.Join(s.baseDir, dagRun.Name)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -389,13 +389,13 @@ func (s *Scheduler) handleQueue(ctx context.Context, ch chan models.QueuedItem, 
 					result = models.QueuedItemProcessingResultDiscard
 					break WAIT_FOR_RUN
 				}
-				
+
 				// Check timeout
 				if time.Since(startedAt) > 10*time.Second {
 					logger.Error(ctx, "Timeout waiting for run to start", "data", data)
 					break WAIT_FOR_RUN
 				}
-				
+
 				select {
 				case <-time.After(500 * time.Millisecond):
 				case <-ctx.Done():

--- a/internal/scheduler/zombie_detector_test.go
+++ b/internal/scheduler/zombie_detector_test.go
@@ -432,6 +432,14 @@ func (m *mockProcStore) IsRunAlive(ctx context.Context, dagRun digraph.DAGRunRef
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *mockProcStore) ListAlive(ctx context.Context, name string) ([]digraph.DAGRunRef, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]digraph.DAGRunRef), args.Error(1)
+}
+
 // Mock DAGRunAttempt
 type mockDAGRunAttempt struct {
 	mock.Mock


### PR DESCRIPTION
Fixes the stop operation to properly handle multiple running instances of the same DAG, ensuring all matching instances are stopped when no specific run ID is provided.

Ref #1151
Reported-by: @jeremydelattre59 

**Changes**
- Updated `Stop` function in `Manager` to stop all matching DAG runs when `dagRunID` is empty
