### PR TITLE
fix: make sure queue directory is created before start watch

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -309,6 +309,14 @@ func (a *Agent) Run(ctx context.Context) error {
 	if err := attempt.Open(ctx); err != nil {
 		return fmt.Errorf("failed to open execution history: %w", err)
 	}
+
+	// Update the status to running
+	st := a.Status(ctx)
+	st.Status = status.Running
+	if err := attempt.Write(ctx, st); err != nil {
+		logger.Error(ctx, "Status write failed", "err", err)
+	}
+
 	defer func() {
 		if initErr != nil {
 			logger.Error(ctx, "Failed to initialize DAG execution", "err", err)

--- a/internal/persistence/filequeue/reader.go
+++ b/internal/persistence/filequeue/reader.go
@@ -45,8 +45,8 @@ const (
 
 const (
 	// Longer intervals since we use file events as primary notification
-	reloadInterval    = 30 * time.Second      // Backup polling interval
-	processingDelay   = 10 * time.Millisecond // Small delay to prevent busy loop
+	reloadInterval    = 10 * time.Second // Backup polling interval
+	processingDelay   = 1 * time.Second  // Small delay to prevent busy loop
 	shutdownTimeout   = 5 * time.Second
 	pollingInterval   = 2 * time.Second // For filenotify poller fallback
 	processingTimeout = 8 * time.Second
@@ -372,14 +372,14 @@ func (q *queueReaderImpl) IsRunning() bool {
 
 // setupWatcher sets up the file watcher for the base directory and existing subdirectories
 func (q *queueReaderImpl) setupWatcher(ctx context.Context, watcher filenotify.FileWatcher, baseDir string) error {
-	// Watch the base directory for new queue files and subdirectories
-	if err := watcher.Add(baseDir); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to watch base directory %s: %w", baseDir, err)
-	}
-
 	// Create base directory if it doesn't exist
 	if err := os.MkdirAll(baseDir, 0750); err != nil {
 		return fmt.Errorf("failed to create base directory %s: %w", baseDir, err)
+	}
+
+	// Watch the base directory for new queue files and subdirectories
+	if err := watcher.Add(baseDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to watch base directory %s: %w", baseDir, err)
 	}
 
 	// Watch existing

--- a/internal/persistence/filequeue/reader_test.go
+++ b/internal/persistence/filequeue/reader_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestQueueReader(t *testing.T) {
 	th := test.Setup(t)
-	ctx, cancel := context.WithTimeout(th.Context, 3*time.Second) // Allow for processing delay
+	ctx, cancel := context.WithTimeout(th.Context, 5*time.Second) // Allow for processing delay
 	defer cancel()
 
 	// Create a new store
@@ -45,7 +45,7 @@ func TestQueueReader(t *testing.T) {
 
 	// Wait for items to be received
 	receivedItems := make([]models.QueuedItem, 0, 2)
-	timeout := time.After(3 * time.Second) // Account for processingDelay between items
+	timeout := time.After(5 * time.Second) // Account for processingDelay between items
 
 	for i := 0; i < 2; i++ {
 		select {
@@ -181,7 +181,7 @@ func TestQueueReaderContextCancellation(t *testing.T) {
 
 func TestQueueReaderRetryDelay(t *testing.T) {
 	th := test.Setup(t)
-	ctx, cancel := context.WithTimeout(th.Context, 3*time.Second)
+	ctx, cancel := context.WithTimeout(th.Context, 5*time.Second)
 	defer cancel()
 
 	// Create a new store
@@ -209,7 +209,7 @@ func TestQueueReaderRetryDelay(t *testing.T) {
 	select {
 	case item := <-ch:
 		item.Result <- models.QueuedItemProcessingResultRetry
-	case <-time.After(1 * time.Second):
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for first item")
 	}
 
@@ -225,7 +225,7 @@ func TestQueueReaderRetryDelay(t *testing.T) {
 	select {
 	case item := <-ch:
 		item.Result <- models.QueuedItemProcessingResultSuccess
-	case <-time.After(2500 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Fatal("timeout waiting for retry")
 	}
 
@@ -235,7 +235,7 @@ func TestQueueReaderRetryDelay(t *testing.T) {
 
 func TestQueueReaderRetryDelayPerQueue(t *testing.T) {
 	th := test.Setup(t)
-	ctx, cancel := context.WithTimeout(th.Context, 3*time.Second)
+	ctx, cancel := context.WithTimeout(th.Context, 5*time.Second)
 	defer cancel()
 
 	// Create a new store
@@ -276,7 +276,7 @@ func TestQueueReaderRetryDelayPerQueue(t *testing.T) {
 		case item := <-ch:
 			seenQueues[item.Data().Name] = true
 			item.Result <- models.QueuedItemProcessingResultRetry
-		case <-time.After(1 * time.Second):
+		case <-time.After(2 * time.Second):
 			t.Fatal("timeout waiting for item")
 		}
 	}


### PR DESCRIPTION
Fix bug that file queue reader does not create base directory before start watching file events.