### PR TITLE
fix: NPM module exit code handling

### DIFF
--- a/npm/dagu/bin/cli
+++ b/npm/dagu/bin/cli
@@ -5,21 +5,40 @@ const childProcess = require("child_process");
 
 const { getPlatformPackage } = require("../lib/platform");
 
-// Windows binaries end with .exe so we need to special case them.
 const binaryName = process.platform === "win32" ? "dagu.exe" : "dagu";
 
 function getBinaryPath() {
-  // Determine package name for this platform
   const platformSpecificPackageName = getPlatformPackage();
 
   try {
-    // Resolving will fail if the optionalDependency was not installed
     return require.resolve(`${platformSpecificPackageName}/bin/${binaryName}`);
   } catch (e) {
     return path.join(__dirname, "..", binaryName);
   }
 }
 
-childProcess.execFileSync(getBinaryPath(), process.argv.slice(2), {
-  stdio: "inherit",
-});
+function exitForError(error) {
+  if (error && typeof error.status === "number") {
+    process.exit(error.status);
+  }
+
+  if (error && error.signal) {
+    process.kill(process.pid, error.signal);
+    return;
+  }
+
+  const message = error && typeof error.message === "string" ? error.message : "dagu execution failed";
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+
+  process.exit(1);
+}
+
+try {
+  childProcess.execFileSync(getBinaryPath(), process.argv.slice(2), {
+    stdio: "inherit",
+  });
+} catch (error) {
+  exitForError(error);
+}

--- a/npm/dagu/index.js
+++ b/npm/dagu/index.js
@@ -3,18 +3,41 @@ const childProcess = require("child_process");
 
 const { getPlatformPackage } = require("./lib/platform");
 
+const binaryName = process.platform === "win32" ? "dagu.exe" : "dagu";
+
 function getBinaryPath() {
   try {
     const platformSpecificPackageName = getPlatformPackage();
-    // Resolving will fail if the optionalDependency was not installed
     return require.resolve(`${platformSpecificPackageName}/bin/${binaryName}`);
   } catch (e) {
     return path.join(__dirname, "..", binaryName);
   }
 }
 
+function exitForError(error) {
+  if (error && typeof error.status === "number") {
+    process.exit(error.status);
+  }
+
+  if (error && error.signal) {
+    process.kill(process.pid, error.signal);
+    return;
+  }
+
+  const message = error && typeof error.message === "string" ? error.message : "dagu execution failed";
+  if (message) {
+    process.stderr.write(`${message}\n`);
+  }
+
+  process.exit(1);
+}
+
 module.exports.runBinary = function (...args) {
-  childProcess.execFileSync(getBinaryPath(), args, {
-    stdio: "inherit",
-  });
+  try {
+    childProcess.execFileSync(getBinaryPath(), args, {
+      stdio: "inherit",
+    });
+  } catch (error) {
+    exitForError(error);
+  }
 };


### PR DESCRIPTION
- ensure both CLI and runBinary wrapper reuse the child exit status or signal
- fall back to a short stderr message when we lack status info instead of printing the entire Node error object