### PR TITLE
fix: warning if dagu is using legacy directory structure (Fixes #858)

### DIFF
--- a/internal/common/config/path_test.go
+++ b/internal/common/config/path_test.go
@@ -32,7 +32,7 @@ func TestResolver(t *testing.T) {
 			BaseConfigFile:  filepath.Join(tmpDir, config.AppSlug, "base.yaml"),
 		}, paths)
 	})
-	t.Run("LegacyHomeDirectory", func(t *testing.T) {
+	t.Run("UnifiedHomeDirectory", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := fileutil.MustTempDir("test")
 		defer os.RemoveAll(tmpDir)
@@ -52,6 +52,7 @@ func TestResolver(t *testing.T) {
 			LogsDir:         filepath.Join(tmpDir, hiddenDir, "logs"),
 			AdminLogsDir:    filepath.Join(tmpDir, hiddenDir, "logs", "admin"),
 			BaseConfigFile:  filepath.Join(tmpDir, hiddenDir, "base.yaml"),
+			Warnings:        []string{"Warning: Dagu legacy directory (" + legacyPath + ") structure detected. This is deprecated."},
 		}, paths)
 	})
 	t.Run("XDGCONFIGHOME", func(t *testing.T) {


### PR DESCRIPTION
Add warning for legacy directory structure is detected on startup.

## Description

<!-- Provide a clear and concise description of the changes -->

## Related Issue

<!-- Link to related issue(s), e.g., Fixes #123, Closes #456 -->

## Checklist

Before submitting this PR, please ensure:

- [x] Tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New code includes tests
- [x] Documentation updated if applicable

## Additional Notes

<!-- Any additional information, context, or screenshots -->
