### PR TITLE
docs: add special variables reference

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -133,6 +133,7 @@ const fullSidebar = [
       { text: "REST API", link: "/reference/api" },
       { text: "Configuration", link: "/reference/config" },
       { text: "Variables", link: "/reference/variables" },
+      { text: "Special Variables", link: "/reference/special-environment-variables" },
       { text: "Executors", link: "/reference/executors" },
     ],
   },

--- a/docs/configurations/reference.md
+++ b/docs/configurations/reference.md
@@ -286,14 +286,7 @@ DAGU_HOME=/opt/dagu dagu --dagu-home=/tmp/dagu-test start my-workflow.yaml
 
 ## Special Environment Variables
 
-Automatically set during DAG execution:
-
-- `DAG_NAME` - Current DAG name
-- `DAG_RUN_ID` - Unique execution ID
-- `DAG_RUN_LOG_FILE` - Main log file path
-- `DAG_RUN_STEP_NAME` - Current step name
-- `DAG_RUN_STEP_STDOUT_FILE` - Step stdout log
-- `DAG_RUN_STEP_STDERR_FILE` - Step stderr log
+Dagu sets metadata like `DAG_RUN_ID`, `DAG_RUN_LOG_FILE`, and the active `DAG_RUN_STEP_NAME` while each workflow runs. Consult [Special Environment Variables](/reference/special-environment-variables) for the full list and examples of how to use them in automations.
 
 ## Directory Structure
 

--- a/docs/features/data-flow.md
+++ b/docs/features/data-flow.md
@@ -328,16 +328,7 @@ steps:
 
 ## Special Environment Variables
 
-Dagu automatically sets these variables:
-
-| Variable | Description |
-|----------|-------------|
-| `DAG_NAME` | Name of the current DAG |
-| `DAG_RUN_ID` | Unique execution ID |
-| `DAG_RUN_STEP_NAME` | Current step name |
-| `DAG_RUN_LOG_FILE` | Main log file path |
-| `DAG_RUN_STEP_STDOUT_FILE` | Step's stdout log path |
-| `DAG_RUN_STEP_STDERR_FILE` | Step's stderr log path |
+Dagu automatically injects run metadata such as `DAG_RUN_ID`, `DAG_RUN_STEP_NAME`, and log file locations. See [Special Environment Variables](/reference/special-environment-variables) for the complete reference.
 
 Example usage:
 ```yaml

--- a/docs/reference/special-environment-variables.md
+++ b/docs/reference/special-environment-variables.md
@@ -1,0 +1,23 @@
+# Special Environment Variables
+
+Dagu injects a small set of read-only environment variables whenever it runs a workflow. These variables carry metadata about the current DAG run (name, run identifier, log locations, status) and are available for interpolation inside commands, arguments, lifecycle handlers, and most other places where you can reference environment variables.
+
+## Availability
+
+- **Step execution** – Every step receives the run-level variables plus a step-specific name and log file paths while it executes.
+- **Lifecycle handlers** – `onExit`, `onSuccess`, `onFailure`, and `onCancel` handlers inherit the same variables. They additionally receive the final `DAG_RUN_STATUS` so that post-run automation can branch on success or failure.
+- **Nested contexts** – When a step launches a child DAG through the `dagu` CLI, the child run gets its own identifiers and log locations; the parent identifiers remain accessible in the parent process for chaining or notifications.
+
+Values are refreshed for each step, so `DAG_RUN_STEP_NAME`, `DAG_RUN_STEP_STDOUT_FILE`, and `DAG_RUN_STEP_STDERR_FILE` always point at whichever step (or handler) is currently running.
+
+## Reference
+
+| Variable | Provided In | Description | Example |
+|----------|-------------|-------------|---------|
+| `DAG_NAME` | All steps & handlers | Name of the DAG definition being executed. | `daily-backup` |
+| `DAG_RUN_ID` | All steps & handlers | Unique identifier for the current run. Combines timestamp and a short suffix. | `20241012_040000_c1f4b2` |
+| `DAG_RUN_LOG_FILE` | All steps & handlers | Absolute path to the aggregated DAG run log. Useful for attaching to alerts. | `/var/log/dagu/daily-backup/20241012_040000.log` |
+| `DAG_RUN_STEP_NAME` | Current step or handler only | Name field of the step that is currently executing. | `upload-artifacts` |
+| `DAG_RUN_STEP_STDOUT_FILE` | Current step or handler only | File path backing the step’s captured stdout stream. | `/var/log/dagu/daily-backup/upload-artifacts.stdout.log` |
+| `DAG_RUN_STEP_STDERR_FILE` | Current step or handler only | File path backing the step’s captured stderr stream. | `/var/log/dagu/daily-backup/upload-artifacts.stderr.log` |
+| `DAG_RUN_STATUS` | Lifecycle handlers only | Canonical completion status (`succeeded`, `partially_succeeded`, `failed`, `canceled`). | `failed` |

--- a/docs/reference/variables.md
+++ b/docs/reference/variables.md
@@ -1,36 +1,6 @@
 # Variables Reference
 
-## Special Environment Variables
-
-Dagu automatically sets canonical environment variables while workflows run. Some are available to every step, while others are injected only for lifecycle handlers.
-
-### Per-step variables
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DAG_NAME` | Name of the current DAG | `my-workflow` |
-| `DAG_RUN_ID` | Unique ID for this execution | `20240115_140000_abc123` |
-| `DAG_RUN_STEP_NAME` | Name of the current step | `process-data` |
-| `DAG_RUN_LOG_FILE` | Path to the main log file | `/logs/my-workflow/20240115_140000.log` |
-| `DAG_RUN_STEP_STDOUT_FILE` | Path to step's stdout log | `/logs/my-workflow/process-data.stdout.log` |
-| `DAG_RUN_STEP_STDERR_FILE` | Path to step's stderr log | `/logs/my-workflow/process-data.stderr.log` |
-
-### Handler-only variables
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DAG_RUN_STATUS` | Final canonical status for the DAG run (`succeeded`, `partially_succeeded`, `failed`, `canceled`) | `succeeded` |
-
-Example usage:
-```yaml
-steps:
-  - name: log-context
-    command: |
-      echo "Running DAG: ${DAG_NAME}"
-      echo "Execution ID: ${DAG_RUN_ID}"
-      echo "Current step: ${DAG_RUN_STEP_NAME}"
-      echo "Logs at: ${DAG_RUN_LOG_FILE}"
-```
+For a complete list of the automatically injected run metadata, see [Special Environment Variables](/reference/special-environment-variables).
 
 ## Environment Variables
 


### PR DESCRIPTION
- add a dedicated Special Environment Variables reference page under docs/reference
- update existing docs to point at the centralized page instead of duplicating tables