### PR TITLE
feat(spec): resolve relative jsonschema path

### DIFF
--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -129,7 +129,7 @@ params:
   - BASE: ${SOURCE_ID}
   - PREFIX: ${BASE:0:5}
 `)
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{NoEval: true})
+		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagNoEval})
 		require.NoError(t, err)
 
 		th := DAG{t: t, DAG: dag}
@@ -339,6 +339,25 @@ params:
 
 		// Should prefer schema.json from CWD (default 99) over workingDir (default 11)
 		require.Contains(t, th.Params, "batch_size=99")
+	})
+
+	t.Run("ParamsSkipSchemaValidationFlag", func(t *testing.T) {
+		data := []byte(`
+params:
+  schema: "missing-schema.json"
+  values:
+    foo: "bar"
+`)
+		_, err := spec.LoadYAML(context.Background(), data)
+		require.Error(t, err)
+
+		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{
+			Flags: spec.BuildFlagSkipSchemaValidation,
+		})
+		require.NoError(t, err)
+
+		th := DAG{t: t, DAG: dag}
+		th.AssertParam(t, "foo=bar")
 	})
 	t.Run("ParamsWithSchemaAndOverrideValidation", func(t *testing.T) {
 		schemaContent := `{
@@ -3379,7 +3398,7 @@ steps:
   - echo hello
 `, tempDir)
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{NoEval: true})
+		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 
@@ -3408,7 +3427,7 @@ env:
 steps:
   - echo hello
 `
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{NoEval: true})
+		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -27,14 +27,12 @@ var (
 
 // LoadOptions contains options for loading a DAG.
 type LoadOptions struct {
-	name             string   // Name of the DAG.
-	baseConfig       string   // Path to the base core.DAG configuration file.
-	params           string   // Parameters to override default parameters in the DAG.
-	paramsList       []string // List of parameters to override default parameters in the DAG.
-	noEval           bool     // Flag to disable evaluation of dynamic fields.
-	onlyMetadata     bool     // Flag to load only metadata without full core.DAG details.
-	dagsDir          string   // Directory containing the core.DAG files.
-	allowBuildErrors bool     // Flag to allow build errors.
+	name       string   // Name of the DAG.
+	baseConfig string   // Path to the base core.DAG configuration file.
+	params     string   // Parameters to override default parameters in the DAG.
+	paramsList []string // List of parameters to override default parameters in the DAG.
+	flags      BuildFlag
+	dagsDir    string // Directory containing the core.DAG files.
 }
 
 // LoadOption is a function type for setting LoadOptions.
@@ -64,14 +62,14 @@ func WithParams(params any) LoadOption {
 // WithoutEval disables the evaluation of dynamic fields.
 func WithoutEval() LoadOption {
 	return func(o *LoadOptions) {
-		o.noEval = true
+		o.flags |= BuildFlagNoEval
 	}
 }
 
 // OnlyMetadata sets the flag to load only metadata.
 func OnlyMetadata() LoadOption {
 	return func(o *LoadOptions) {
-		o.onlyMetadata = true
+		o.flags |= BuildFlagOnlyMetadata
 	}
 }
 
@@ -100,7 +98,14 @@ func WithDAGsDir(dagsDir string) LoadOption {
 // and will not fail the loading process.
 func WithAllowBuildErrors() LoadOption {
 	return func(o *LoadOptions) {
-		o.allowBuildErrors = true
+		o.flags |= BuildFlagAllowBuildErrors
+	}
+}
+
+// SkipSchemaValidation disables schema resolution/validation during build.
+func SkipSchemaValidation() LoadOption {
+	return func(o *LoadOptions) {
+		o.flags |= BuildFlagSkipSchemaValidation
 	}
 }
 
@@ -130,14 +135,12 @@ func Load(ctx context.Context, nameOrPath string, opts ...LoadOption) (*core.DAG
 	buildContext := BuildContext{
 		ctx: ctx,
 		opts: BuildOpts{
-			Base:             options.baseConfig,
-			Parameters:       options.params,
-			ParametersList:   options.paramsList,
-			OnlyMetadata:     options.onlyMetadata,
-			NoEval:           options.noEval,
-			Name:             options.name,
-			DAGsDir:          options.dagsDir,
-			AllowBuildErrors: options.allowBuildErrors,
+			Base:           options.baseConfig,
+			Parameters:     options.params,
+			ParametersList: options.paramsList,
+			Name:           options.name,
+			DAGsDir:        options.dagsDir,
+			Flags:          options.flags,
 		},
 	}
 	return loadDAG(buildContext, nameOrPath)
@@ -150,14 +153,12 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*core.DAG, 
 		opt(&options)
 	}
 	return LoadYAMLWithOpts(ctx, data, BuildOpts{
-		Base:             options.baseConfig,
-		Parameters:       options.params,
-		ParametersList:   options.paramsList,
-		OnlyMetadata:     options.onlyMetadata,
-		NoEval:           options.noEval,
-		Name:             options.name,
-		DAGsDir:          options.dagsDir,
-		AllowBuildErrors: options.allowBuildErrors,
+		Base:           options.baseConfig,
+		Parameters:     options.params,
+		ParametersList: options.paramsList,
+		Name:           options.name,
+		DAGsDir:        options.dagsDir,
+		Flags:          options.flags,
 	})
 }
 
@@ -165,7 +166,7 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*core.DAG, 
 func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.DAG, error) {
 	raw, err := unmarshalData(data)
 	if err != nil {
-		if opts.AllowBuildErrors {
+		if opts.Has(BuildFlagAllowBuildErrors) {
 			// Return a minimal core.DAG with the error recorded
 			return &core.DAG{
 				Name:        opts.Name,
@@ -177,7 +178,7 @@ func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.D
 
 	def, err := decode(raw)
 	if err != nil {
-		if opts.AllowBuildErrors {
+		if opts.Has(BuildFlagAllowBuildErrors) {
 			// Return a minimal core.DAG with the error recorded
 			return &core.DAG{
 				Name:        opts.Name,
@@ -210,7 +211,7 @@ func LoadBaseConfig(ctx BuildContext, file string) (*core.DAG, error) {
 		return nil, core.ErrorList{err}
 	}
 
-	ctx = ctx.WithOpts(BuildOpts{NoEval: ctx.opts.NoEval}).WithFile(file)
+	ctx = ctx.WithOpts(BuildOpts{Flags: ctx.opts.Flags}).WithFile(file)
 	dag, err := build(ctx, def)
 
 	if err != nil {
@@ -230,7 +231,7 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 
 	// Load base config definition if specified
 	var baseDef *definition
-	if !ctx.opts.OnlyMetadata && ctx.opts.Base != "" && fileutil.FileExists(ctx.opts.Base) {
+	if !ctx.opts.Has(BuildFlagOnlyMetadata) && ctx.opts.Base != "" && fileutil.FileExists(ctx.opts.Base) {
 		raw, err := readYAMLFile(ctx.opts.Base)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read base config: %w", err)
@@ -244,7 +245,7 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 	// Load all DAGs from the file
 	dags, err := loadDAGsFromFile(ctx, filePath, baseDef)
 	if err != nil {
-		if ctx.opts.AllowBuildErrors {
+		if ctx.opts.Has(BuildFlagAllowBuildErrors) {
 			// Return a minimal core.DAG with the error recorded
 			dag := &core.DAG{
 				Name:        defaultName(filePath),

--- a/internal/core/spec/params.go
+++ b/internal/core/spec/params.go
@@ -64,14 +64,16 @@ func buildParams(ctx BuildContext, spec *definition, dag *core.DAG) error {
 	}
 
 	// Validate the parameters against a resolved schema (if declared)
-	if resolvedSchema, err := resolveSchemaFromParams(spec.Params, spec.WorkingDir, dag.Location); err != nil {
-		return fmt.Errorf("failed to get JSON schema: %w", err)
-	} else if resolvedSchema != nil {
-		updatedPairs, err := validateParams(paramPairs, resolvedSchema)
-		if err != nil {
-			return err
+	if !ctx.opts.Has(BuildFlagSkipSchemaValidation) {
+		if resolvedSchema, err := resolveSchemaFromParams(spec.Params, spec.WorkingDir, dag.Location); err != nil {
+			return fmt.Errorf("failed to get JSON schema: %w", err)
+		} else if resolvedSchema != nil {
+			updatedPairs, err := validateParams(paramPairs, resolvedSchema)
+			if err != nil {
+				return err
+			}
+			paramPairs = updatedPairs
 		}
-		paramPairs = updatedPairs
 	}
 
 	for _, paramPair := range paramPairs {
@@ -293,7 +295,7 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 	accumulatedVars := make(map[string]string)
 
 	for index, paramPair := range paramPairs {
-		if !ctx.opts.NoEval {
+		if !ctx.opts.Has(BuildFlagNoEval) {
 			evaluated, err := evalParamValue(ctx, paramPair.Value, accumulatedVars)
 			if err != nil {
 				return core.NewValidationError("params", paramPair.Value, fmt.Errorf("%w: %s", ErrInvalidParamValue, err))
@@ -313,7 +315,7 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 			accumulatedVars[paramPair.Name] = paramPair.Value
 		}
 
-		if !ctx.opts.NoEval && paramPair.Name != "" {
+		if !ctx.opts.Has(BuildFlagNoEval) && paramPair.Name != "" {
 			*envs = append(*envs, paramString)
 		}
 
@@ -456,7 +458,7 @@ func parseStringParams(ctx BuildContext, input string) ([]paramPair, error) {
 				value = strings.ReplaceAll(value, `\"`, `"`)
 			}
 
-			if !ctx.opts.NoEval {
+			if !ctx.opts.Has(BuildFlagNoEval) {
 				// Perform backtick command substitution
 				backtickRegex := regexp.MustCompile("`[^`]*`")
 

--- a/internal/core/spec/variables.go
+++ b/internal/core/spec/variables.go
@@ -56,7 +56,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 	for _, pair := range pairs {
 		value := pair.val
 
-		if !ctx.opts.NoEval {
+		if !ctx.opts.Has(BuildFlagNoEval) {
 			// Evaluate the value of the environment variable.
 			// This also executes command substitution.
 			// Pass accumulated vars so ${VAR} can reference previously defined vars

--- a/internal/persistence/filedag/store.go
+++ b/internal/persistence/filedag/store.go
@@ -112,10 +112,18 @@ func (store *Storage) GetMetadata(ctx context.Context, name string) (*core.DAG, 
 		return nil, fmt.Errorf("failed to locate DAG %s in search paths (%v): %w", name, store.searchPaths, err)
 	}
 	if store.fileCache == nil {
-		return spec.Load(ctx, filePath, spec.OnlyMetadata(), spec.WithoutEval())
+		return spec.Load(ctx, filePath,
+			spec.OnlyMetadata(),
+			spec.WithoutEval(),
+			spec.SkipSchemaValidation(),
+		)
 	}
 	return store.fileCache.LoadLatest(filePath, func() (*core.DAG, error) {
-		return spec.Load(ctx, filePath, spec.OnlyMetadata(), spec.WithoutEval())
+		return spec.Load(ctx, filePath,
+			spec.OnlyMetadata(),
+			spec.WithoutEval(),
+			spec.SkipSchemaValidation(),
+		)
 	})
 }
 
@@ -276,7 +284,12 @@ func (store *Storage) List(ctx context.Context, opts execution.ListDAGsOptions) 
 		// Read the file and parse the DAG.
 		// Use WithAllowBuildErrors to include DAGs with errors in the list
 		filePath := filepath.Join(store.baseDir, entry.Name())
-		dag, err := spec.Load(ctx, filePath, spec.OnlyMetadata(), spec.WithoutEval(), spec.WithAllowBuildErrors())
+		dag, err := spec.Load(ctx, filePath,
+			spec.OnlyMetadata(),
+			spec.WithoutEval(),
+			spec.SkipSchemaValidation(),
+			spec.WithAllowBuildErrors(),
+		)
 		if err != nil {
 			// If it completely fails to load, skip it
 			errList = append(errList, fmt.Sprintf("reading %s failed: %s", dagName, err))
@@ -406,7 +419,11 @@ func (store *Storage) Grep(ctx context.Context, pattern string) (
 				errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.Name(), err))
 				continue
 			}
-			dag, err := spec.Load(ctx, filePath, spec.OnlyMetadata(), spec.WithoutEval())
+			dag, err := spec.Load(ctx, filePath,
+				spec.OnlyMetadata(),
+				spec.WithoutEval(),
+				spec.SkipSchemaValidation(),
+			)
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("check %s failed: %s", entry.Name(), err))
 				continue

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -133,7 +133,13 @@ func (er *entryReaderImpl) initialize(ctx context.Context) error {
 	var dags []string
 	for _, fi := range fis {
 		if fileutil.IsYAMLFile(fi.Name()) {
-			dag, err := spec.Load(ctx, filepath.Join(er.targetDir, fi.Name()), spec.OnlyMetadata(), spec.WithoutEval())
+			dag, err := spec.Load(
+				ctx,
+				filepath.Join(er.targetDir, fi.Name()),
+				spec.OnlyMetadata(),
+				spec.WithoutEval(),
+				spec.SkipSchemaValidation(),
+			)
 			if err != nil {
 				logger.Error(ctx, "DAG load failed", "err", err, "name", fi.Name())
 				continue
@@ -177,7 +183,13 @@ func (er *entryReaderImpl) watchDags(ctx context.Context, done chan any) {
 			er.lock.Lock()
 			if event.Op == fsnotify.Create || event.Op == fsnotify.Write {
 				filePath := filepath.Join(er.targetDir, filepath.Base(event.Name))
-				dag, err := spec.Load(ctx, filePath, spec.OnlyMetadata(), spec.WithoutEval())
+				dag, err := spec.Load(
+					ctx,
+					filePath,
+					spec.OnlyMetadata(),
+					spec.WithoutEval(),
+					spec.SkipSchemaValidation(),
+				)
 				if err != nil {
 					logger.Error(ctx, "DAG load failed", "err", err, "file", event.Name)
 				} else {


### PR DESCRIPTION
## What does this PR do?
This PR adds JSON Schema validation support for params.

## Why is this needed?
It addresses issue https://github.com/dagu-org/dagu/issues/1291.

## What changed?
- Updated `buildParams` to resolve declared schema paths by checking the DAG’s cwd/`WorkingDir`/DAG file directory

I couldn't find any docs to update, the previous ones have been deleted I think. r? @yottahmd 