### PR TITLE
Fix: [Windows] Failure to Execute DAG from Queue

### DIFF
--- a/internal/common/config/env.go
+++ b/internal/common/config/env.go
@@ -23,6 +23,9 @@ var defaultWhitelist = map[string]bool{
 	"TZ":              true,
 	"SHELL":           true,
 	"LD_LIBRARY_PATH": true,
+	"USERPROFILE":     true, // Windows Specifics equivalent of HOME
+	"PSModulePath":    true, // Windows Specifics, powershell modules path
+	"Path":            true, // Windows Specifics equivalent of PATH
 }
 
 // defaultPrefixes defines prefixes of env vars allowed to propagate.


### PR DESCRIPTION
## Description

Fixes a missing environment variables required to run an enqueued DAG.

## Additional notes

I cross-checked the environment variables between Windows and Linux. These three appear to be the only ones needed to successfully run an enqueued DAG.
I verified the fix by testing both the Cmd and PowerShell execution.

## Related Issue
Fix  #1372 

