### PR TITLE
spec: stabilize default param ordering

### DIFF
--- a/internal/core/spec/params.go
+++ b/internal/core/spec/params.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -357,7 +358,15 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 			params = append(params, parsedParams...)
 
 		case map[string]any:
-			for name, value := range m {
+			// Iterate deterministically to avoid random param order from Go maps.
+			keys := make([]string, 0, len(m))
+			for name := range m {
+				keys = append(keys, name)
+			}
+			sort.Strings(keys)
+
+			for _, name := range keys {
+				value := m[name]
 				var valueStr string
 
 				switch v := value.(type) {


### PR DESCRIPTION
- sort map-backed params during DAG spec parsing so the backend emits defaultParams in a deterministic order
- prevents the Start DAG modal from reshuffling inputs while users type

issue: #1395