### PR TITLE
Fix OIDC dashboard lock-out after expired cookie

### DIFF
--- a/internal/service/frontend/auth/oidc.go
+++ b/internal/service/frontend/auth/oidc.go
@@ -196,7 +196,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, name, value string, expir
 		MaxAge:   expire,
 		Path:     "/",
 		SameSite: http.SameSiteLaxMode,
-		Secure:   r.TLS != nil,
+		Secure:   isSecureRequest(r),
 		HttpOnly: true,
 	}
 	http.SetCookie(w, c)
@@ -204,4 +204,11 @@ func setCookie(w http.ResponseWriter, r *http.Request, name, value string, expir
 
 func clearCookie(w http.ResponseWriter, r *http.Request, name string) {
 	setCookie(w, r, name, "", -1)
+}
+
+func isSecureRequest(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }


### PR DESCRIPTION
Issue #1394 

- align the `oidcToken` cookie lifetime with the ID token expiry so browsers don’t keep stale tokens
- verify the cookie for every UI request, logging + clearing it when verification fails before redirecting to the IdP
- clear invalid cookies in the API middleware so follow-up requests immediately trigger re-authentication
