### PR TITLE
[ui] stop step retry while dag is running.

### DIFF
--- a/internal/persistence/filequeue/queuefile.go
+++ b/internal/persistence/filequeue/queuefile.go
@@ -354,22 +354,11 @@ func parseQueueFileName(path, fileName string) (ItemData, error) {
 	}
 	timestamp = timestamp.Add(time.Duration(nanos) * time.Nanosecond)
 
-	// Read the JSON file to get the actual DAG name
-	var itemData ItemData
-	fileData, err := os.ReadFile(path) // nolint: gosec
-	if err != nil {
-		return ItemData{}, fmt.Errorf("failed to read queue file %s: %w", path, err)
-	}
-
-	if err := json.Unmarshal(fileData, &itemData); err != nil {
-		return ItemData{}, fmt.Errorf("failed to unmarshal queue file %s: %w", path, err)
-	}
-
-	// Create the ItemData struct with the correct DAG name from the file
+	// Create the ItemData struct
 	item := ItemData{
 		FileName: fileName,
 		DAGRun: execution.DAGRunRef{
-			Name: itemData.DAGRun.Name,
+			Name: filepath.Base(filepath.Dir(path)),
 			ID:   matches[4],
 		},
 		QueuedAt: timestamp,


### PR DESCRIPTION
1. ui fix to stop step retry while dag is running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry controls are now disabled while a DAG run is actively running, preventing accidental retry attempts.
* **Style**
  * Disabled retry buttons show reduced opacity and a not-allowed cursor for clearer visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->