### PR TITLE
fix(runtime): include queue name in dequeue command

### DIFF
--- a/internal/runtime/subcmd.go
+++ b/internal/runtime/subcmd.go
@@ -104,8 +104,9 @@ func (b *SubCmdBuilder) Enqueue(dag *core.DAG, opts EnqueueOptions) CmdSpec {
 }
 
 // Dequeue creates a dequeue command spec.
-func (b *SubCmdBuilder) Dequeue(_ *core.DAG, dagRun execution.DAGRunRef) CmdSpec {
-	args := []string{"dequeue", fmt.Sprintf("--dag-run=%s", dagRun.String())}
+func (b *SubCmdBuilder) Dequeue(dag *core.DAG, dagRun execution.DAGRunRef) CmdSpec {
+	queueName := dag.ProcGroup()
+	args := []string{"dequeue", queueName, fmt.Sprintf("--dag-run=%s", dagRun.String())}
 
 	if b.configFile != "" {
 		args = append(args, "--config", b.configFile)


### PR DESCRIPTION
The SubCmdBuilder.Dequeue method was missing the queue name parameter when building the dequeue command. The CLI command expects the queue name as the first positional argument after "dequeue", but it was not being included, causing dequeue operations via the API to fail.

This change:
- Updates Dequeue to use dag.ProcGroup() to get the queue name
- Includes the queue name as the first argument after "dequeue"
- Updates tests to verify the queue name is included
- Adds test case for DAGs with custom queue names

Fixes the issue where dequeuing from the API failed because the queue name was not being passed to the CLI command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dequeue command now correctly incorporates queue name from DAG configuration, allowing proper queue identification during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->