### PR TITLE
fix(readme): Updated hello.yaml to newer format

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ npm install -g --ignore-scripts=false @dagu-org/dagu
 ```bash
 cat > ./hello.yaml << 'EOF'
 steps:
-  - echo "Hello from Dagu!"
-  - echo "Running step 2"
+  - name: Step 1
+    command: echo "Hello from Dagu!"
+  - name: Step 2
+    command: echo "Running step 2"
 EOF
 ```
 


### PR DESCRIPTION
I just tried Dagu for the first time and the example given in the `README.md` gave me the following error:

```
time=2025-12-15T09:58:16.499+01:00 level=ERROR msg="Failed to load DAG" path=hello.yaml err="field 'steps': field 'steps': decoding failed due to the following error(s):\n\n'[0]' expected a map, got 'string'\n'[1]' expected a map, got 'string' (value: [echo \"Hello from Dagu!\" echo \"Running step 2\"])"
```

I have updated this hello example to the format given in cli demos shown in the `README.md`. This runs successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated YAML configuration example in README with structured step format, now using explicit names and commands for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->