### PR TITLE
feat: add optional seconds field to cron schedule parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __debug_bin*
 # Go cache
 .gocache
 .gomodcache
+dagu

--- a/internal/core/spec/schedule.go
+++ b/internal/core/spec/schedule.go
@@ -8,7 +8,7 @@ import (
 )
 
 var cronParser = cron.NewParser(
-	cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
 )
 
 // buildScheduler parses the schedule values and returns a list of schedules.

--- a/internal/service/scheduler/dagrunjob.go
+++ b/internal/service/scheduler/dagrunjob.go
@@ -93,7 +93,7 @@ func (j *DAGRunJob) Ready(ctx context.Context, latestStatus execution.DAGRunStat
 	}
 
 	// Skip if the last successful run time is on or after the next scheduled time.
-	latestStartedAt = latestStartedAt.Truncate(time.Minute)
+	latestStartedAt = latestStartedAt.Truncate(time.Second)
 	if latestStartedAt.After(j.Next) || j.Next.Equal(latestStartedAt) {
 		return ErrJobFinished
 	}

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -280,7 +280,7 @@ func (s *Scheduler) startHeartbeat(ctx context.Context) {
 
 // cronLoop runs the main scheduler loop to invoke jobs at scheduled times.
 func (s *Scheduler) cronLoop(ctx context.Context, sig chan os.Signal) {
-	tickTime := s.clock().Truncate(time.Minute)
+	tickTime := s.clock().Truncate(time.Second)
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -307,7 +307,7 @@ func (s *Scheduler) cronLoop(ctx context.Context, sig chan os.Signal) {
 
 // NextTick returns the next tick time for the scheduler.
 func (*Scheduler) NextTick(now time.Time) time.Time {
-	return now.Add(time.Minute).Truncate(time.Second * 60)
+	return now.Add(time.Second).Truncate(time.Second)
 }
 
 // IsRunning returns whether the scheduler is currently running.

--- a/internal/service/scheduler/scheduler_test.go
+++ b/internal/service/scheduler/scheduler_test.go
@@ -81,7 +81,7 @@ func TestScheduler(t *testing.T) {
 }
 
 func TestJobReady(t *testing.T) {
-	cronParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	cronParser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
 	tests := []struct {
 		name           string
@@ -192,7 +192,7 @@ func TestPrevExecTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cronParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+			cronParser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 			schedule, err := cronParser.Parse(tt.schedule)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Enables sub-minute scheduling by adding `SecondOptional` to the cron parser. This allows schedules like `*/5 * * * * *` to run every 5 seconds.

## Changes

- Add `cron.SecondOptional` flag to parser in `spec/schedule.go`
- Update scheduler tick precision from minute to second
- Update `NextTick` to advance by seconds instead of minutes
- Update `dagrunjob` to use second-level truncation

## Motivation

As discussed in #676, the underlying `robfig/cron` library already supports seconds parsing via the `SecondOptional` flag. This PR enables that functionality.

## Usage

Standard 5-field cron expressions continue to work as before:
```yaml
schedule: "*/5 * * * *"  # Every 5 minutes
```

With this change, 6-field expressions with seconds are now supported:
```yaml
schedule: "*/5 * * * * *"  # Every 5 seconds
```

Fixes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling granularity increased from minute-based to second-based, enabling more frequent task execution. Cron expressions now support optional seconds fields for enhanced scheduling precision and control.

* **Chores**
  * Updated configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->