### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
   # Spell check
   codespell:
     name: Check for spelling errors
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -44,7 +44,7 @@ jobs:
   # Lint Go code
   golint:
     name: Go Linter
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-4vcpu-ubuntu-2404
+          - ubuntu-latest
           # - windows-latest
     steps:
       - name: Check out code

--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   docker-default:
     name: Build and push default image
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -61,7 +61,7 @@ jobs:
 
   docker-dev:
     name: Build and push dev image
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -112,7 +112,7 @@ jobs:
 
   docker-alpine:
     name: Build and push alpine image
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Build and push ubuntu-based latest image
   docker-latest:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -52,7 +52,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
   # Build and push alpine-based dev image
   docker-dev:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -95,7 +95,7 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}-dev
   # Build and push ubuntu-based dev image
   docker-alpine:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   # Build release binaries
   goreleaser:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5

--- a/.github/workflows/npm-publish-test.yaml
+++ b/.github/workflows/npm-publish-test.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test-workflow-syntax:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -76,7 +76,7 @@ jobs:
           cat package.json
 
   test-platform-matrix:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # First, publish all platform-specific packages
   publish-platform-packages:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +154,7 @@ jobs:
   publish-main-package:
     needs: publish-platform-packages
     if: always()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -228,7 +228,7 @@ jobs:
             test-install: 'npm install -g @dagu-org/dagu'
           - os: macos-latest
             test-install: 'npm install -g @dagu-org/dagu'
-          - os: blacksmith-4vcpu-windows-2025
+          - os: windows-latest
             test-install: 'npm install -g @dagu-org/dagu'
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   # Build release binaries
   goreleaser:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5


### PR DESCRIPTION
Reverts dagu-org/dagu#1523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all CI/CD workflows to use standard GitHub-hosted runners instead of custom infrastructure across continuous integration, build, test, and release jobs. This transition includes code quality checks, Docker image builds, frontend testing, npm package publishing, and release automation. Infrastructure changes improve reliability and consistency while maintaining all existing build processes and workflow logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->