### PR TITLE
fix: unexpand unknown variables

### DIFF
--- a/internal/cmn/cmdutil/envscope_test.go
+++ b/internal/cmn/cmdutil/envscope_test.go
@@ -352,11 +352,27 @@ func TestEnvScope_Expand(t *testing.T) {
 		assert.Equal(t, "Hello, World!", result)
 	})
 
-	t.Run("VariableNotFoundReturnsEmpty", func(t *testing.T) {
+	t.Run("VariableNotFoundPreserved", func(t *testing.T) {
 		scope := NewEnvScope(nil, false)
 
+		// $VAR syntax preserved
 		result := scope.Expand("Hello, $UNKNOWN!")
-		assert.Equal(t, "Hello, !", result)
+		assert.Equal(t, "Hello, $UNKNOWN!", result)
+
+		// ${VAR} syntax preserved
+		result = scope.Expand("Hello, ${UNKNOWN}!")
+		assert.Equal(t, "Hello, ${UNKNOWN}!", result)
+	})
+
+	t.Run("MixedKnownAndUnknown", func(t *testing.T) {
+		scope := NewEnvScope(nil, false).
+			WithEntry("KNOWN", "found", EnvSourceDAGEnv)
+
+		result := scope.Expand("$KNOWN and $UNKNOWN")
+		assert.Equal(t, "found and $UNKNOWN", result)
+
+		result = scope.Expand("${KNOWN} and ${UNKNOWN}")
+		assert.Equal(t, "found and ${UNKNOWN}", result)
 	})
 
 	t.Run("MultipleVariables", func(t *testing.T) {

--- a/internal/cmn/cmdutil/eval_test.go
+++ b/internal/cmn/cmdutil/eval_test.go
@@ -2335,10 +2335,10 @@ func TestWithoutExpandShell(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "ShellExpansionDisabledSkipsSubstring",
+			name:    "ShellExpansionDisabledPreservesSubstring",
 			input:   "${VAR:0:3}",
 			opts:    []EvalOption{WithVariables(map[string]string{"VAR": "HelloWorld"}), WithoutExpandShell()},
-			want:    "", // When shell expansion is disabled, substring syntax is not processed
+			want:    "${VAR:0:3}", // When shell expansion is disabled, preserve substring syntax for remote shell
 			wantErr: false,
 		},
 		{

--- a/internal/cmn/cmdutil/expand.go
+++ b/internal/cmn/cmdutil/expand.go
@@ -6,11 +6,13 @@ import (
 )
 
 // ExpandEnvContext expands ${VAR} and $VAR in s using EnvScope from context,
-// falling back to os.ExpandEnv if no scope in context.
+// falling back to os.LookupEnv if no scope in context.
+// Variables not found are preserved in their original form.
 func ExpandEnvContext(ctx context.Context, s string) string {
 	scope := GetEnvScope(ctx)
 	if scope == nil {
-		return os.ExpandEnv(s)
+		// No scope - use OS lookup but preserve unknown vars
+		return expandWithLookup(s, os.LookupEnv)
 	}
 	return scope.Expand(s)
 }

--- a/internal/cmn/cmdutil/expand_test.go
+++ b/internal/cmn/cmdutil/expand_test.go
@@ -51,12 +51,17 @@ func TestExpandEnvContext(t *testing.T) {
 		assert.Equal(t, "Value is nil_ctx_value", result)
 	})
 
-	t.Run("VariableNotFoundReturnsEmpty", func(t *testing.T) {
+	t.Run("VariableNotFoundPreserved", func(t *testing.T) {
 		scope := NewEnvScope(nil, false)
 		ctx := WithEnvScope(context.Background(), scope)
 
+		// $VAR syntax preserved
 		result := ExpandEnvContext(ctx, "Hello $NONEXISTENT!")
-		assert.Equal(t, "Hello !", result)
+		assert.Equal(t, "Hello $NONEXISTENT!", result)
+
+		// ${VAR} syntax preserved
+		result = ExpandEnvContext(ctx, "Hello ${NONEXISTENT}!")
+		assert.Equal(t, "Hello ${NONEXISTENT}!", result)
 	})
 
 	t.Run("BracedVariableSyntax", func(t *testing.T) {

--- a/internal/runtime/builtin/s3/s3_test.go
+++ b/internal/runtime/builtin/s3/s3_test.go
@@ -533,7 +533,7 @@ func TestS3ConfigVariableEvaluation(t *testing.T) {
 		assert.Equal(t, "http://minio.local:9000", evaluated.Endpoint)
 	})
 
-	t.Run("EvalObject_missing_variable_becomes_empty", func(t *testing.T) {
+	t.Run("EvalObject_missing_variable_preserved", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := core.S3Config{
@@ -547,8 +547,8 @@ func TestS3ConfigVariableEvaluation(t *testing.T) {
 		evaluated, err := cmdutil.EvalObject(ctx, cfg, vars)
 		require.NoError(t, err)
 
-		// Undefined variables are replaced with empty strings
-		assert.Equal(t, "", evaluated.Region)
+		// Undefined variables are preserved as-is
+		assert.Equal(t, "${UNDEFINED_VAR}", evaluated.Region)
 		assert.Equal(t, "static-bucket", evaluated.Bucket)
 	})
 

--- a/internal/runtime/eval_test.go
+++ b/internal/runtime/eval_test.go
@@ -522,13 +522,13 @@ func TestEvalStringEdgeCases(t *testing.T) {
 		{
 			name:     "NestedVariableReferences",
 			input:    "${${EMPTY}}",
-			expected: "}",
+			expected: "${${EMPTY}}", // Complex nested syntax preserved (not evaluated)
 			wantErr:  false,
 		},
 		{
 			name:     "MalformedVariable",
 			input:    "${",
-			expected: "",
+			expected: "${", // Malformed syntax preserved as-is
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Variable expansion now preserves unknown or undefined variables in their literal form (e.g., `$VAR`, `${VAR}`) instead of expanding them to empty strings.

* **Tests**
  * Updated test cases to validate the new variable preservation behavior across environment and shell expansion functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->