### PR TITLE
ingest yaml with filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Full documentation is available at [docs.daguit.dev](https://docs.daguit.dev/).
 |---------------------|---------|-------------|
 | `DAGU_HOME` | - | Base directory that overrides all path configurations |
 | `DAGU_DAGS_DIR` | `~/.config/dagu/dags` | Directory for DAG definitions |
+| `DAGU_ALT_DAGS_DIR` | - | Additional directory to search for DAG definitions |
 | `DAGU_LOG_DIR` | `~/.local/share/dagu/logs` | Directory for log files |
 | `DAGU_DATA_DIR` | `~/.local/share/dagu/data` | Directory for application data |
 | `DAGU_SUSPEND_FLAGS_DIR` | `~/.local/share/dagu/suspend` | Directory for suspend flags |

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -377,10 +377,16 @@ type dagStoreConfig struct {
 
 // dagStore returns a new DAGRepository instance.
 func (c *Context) dagStore(cfg dagStoreConfig) (exec.DAGStore, error) {
+	// Merge configured alternate DAGs directory into search paths if provided
+	searchPaths := append([]string{}, cfg.SearchPaths...)
+	if c.Config != nil && c.Config.Paths.AltDAGsDir != "" {
+		searchPaths = append(searchPaths, c.Config.Paths.AltDAGsDir)
+	}
+
 	store := filedag.New(
 		c.Config.Paths.DAGsDir,
 		filedag.WithFlagsBaseDir(c.Config.Paths.SuspendFlagsDir),
-		filedag.WithSearchPaths(cfg.SearchPaths),
+		filedag.WithSearchPaths(searchPaths),
 		filedag.WithFileCache(cfg.Cache),
 		filedag.WithSkipExamples(c.Config.Core.SkipExamples),
 		filedag.WithSkipDirectoryCreation(cfg.SkipDirectoryCreation),

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -250,6 +250,7 @@ type PathsConfig struct {
 	SuspendFlagsDir    string
 	AdminLogsDir       string
 	BaseConfig         string
+	AltDAGsDir         string
 	DAGRunsDir         string
 	QueueDir           string
 	ProcDir            string

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -181,6 +181,7 @@ type PathsDef struct {
 	SuspendFlagsDir    string `mapstructure:"suspendFlagsDir"`
 	AdminLogsDir       string `mapstructure:"adminLogsDir"`
 	BaseConfig         string `mapstructure:"baseConfig"`
+	AltDagsDir         string `mapstructure:"altDagsDir"`
 	DAGRunsDir         string `mapstructure:"dagRunsDir"`
 	QueueDir           string `mapstructure:"queueDir"`
 	ProcDir            string `mapstructure:"procDir"`

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -312,6 +312,7 @@ func (l *ConfigLoader) loadPathsConfig(cfg *Config, def Definition) error {
 		source string
 	}{
 		{"DAGsDir", &cfg.Paths.DAGsDir, def.Paths.DAGsDir},
+		{"AltDAGsDir", &cfg.Paths.AltDAGsDir, def.Paths.AltDagsDir},
 		{"SuspendFlagsDir", &cfg.Paths.SuspendFlagsDir, def.Paths.SuspendFlagsDir},
 		{"DataDir", &cfg.Paths.DataDir, def.Paths.DataDir},
 		{"LogDir", &cfg.Paths.LogDir, def.Paths.LogDir},
@@ -1250,6 +1251,7 @@ var envBindings = []envBinding{
 	// Paths
 	{key: "paths.dagsDir", env: "DAGS", isPath: true},
 	{key: "paths.dagsDir", env: "DAGS_DIR", isPath: true},
+	{key: "paths.altDagsDir", env: "ALT_DAGS_DIR", isPath: true},
 	{key: "paths.executable", env: "EXECUTABLE", isPath: true},
 	{key: "paths.logDir", env: "LOG_DIR", isPath: true},
 	{key: "paths.dataDir", env: "DATA_DIR", isPath: true},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -68,6 +68,7 @@ func TestLoad_Env(t *testing.T) {
 		"DAGU_PROC_DIR":             filepath.Join(testPaths, "proc"),
 		"DAGU_QUEUE_DIR":            filepath.Join(testPaths, "queue"),
 		"DAGU_SERVICE_REGISTRY_DIR": filepath.Join(testPaths, "service-registry"),
+		"DAGU_ALT_DAGS_DIR":         filepath.Join(testPaths, "alt-dags"),
 
 		"DAGU_LATEST_STATUS_TODAY": "true",
 
@@ -168,6 +169,7 @@ func TestLoad_Env(t *testing.T) {
 		},
 		Paths: PathsConfig{
 			DAGsDir:            filepath.Join(testPaths, "dags"),
+			AltDAGsDir:         filepath.Join(testPaths, "alt-dags"),
 			Executable:         filepath.Join(testPaths, "bin", "dagu"),
 			LogDir:             filepath.Join(testPaths, "logs"),
 			DataDir:            filepath.Join(testPaths, "data"),


### PR DESCRIPTION
now dags can only be ingest with the name.
user has to define ALT_DAGS_DIR variable in base.yaml 
Spec is still working. #1609 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DAG run enqueue now supports filename-based references: Users can trigger DAG execution by specifying an existing YAML DAG filename, in addition to providing inline specifications. The enqueue endpoint accepts either a spec or filename, but not both.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->