### PR TITLE
added-aborted-count

### DIFF
--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -318,7 +318,7 @@ function Dashboard(): React.ReactElement | null {
             <span className="text-xs">failed</span>
           </div>
           <div className="flex items-baseline gap-1">
-            <span className={`text-lg sm:text-xl font-light tabular-nums ${hasFailures ? 'text-foreground' : 'text-muted-foreground/50'}`}>{metrics[Status.Aborted]}</span>
+            <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">{metrics[Status.Aborted]}</span>
             <span className="text-xs">aborted</span>
           </div>
           {hasRunning && (


### PR DESCRIPTION
#1720 
 Added an aborted DAG runs count to the dashboard metrics.
This complements the existing counts for successful and failed DAG runs.
Helps users quickly identify how many DAG executions were aborted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Aborted statistics block to the Dashboard. This new block displays the count of aborted runs and complements existing status indicators including runs, successes, failures, and active runs. The block features adaptive text coloring based on whether failures are present, ensuring appropriate visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->