### PR TITLE
fix: quote param values when restoring DAG from status to prevent space-splitting

### DIFF
--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/dagu-org/dagu/internal/cmn/logger"
@@ -39,9 +40,27 @@ func parseTriggerTypeParam(ctx *Context) (core.TriggerType, error) {
 // It restores params from the status, loads dotenv, and rebuilds fields excluded
 // from JSON serialization (env, shell, workingDir, registryAuths, etc.).
 func restoreDAGFromStatus(ctx context.Context, dag *core.DAG, status *exec.DAGRunStatus) (*core.DAG, error) {
-	dag.Params = status.ParamsList
+	dag.Params = quoteParamValues(status.ParamsList)
 	dag.LoadDotEnv(ctx)
 	return rebuildDAGFromYAML(ctx, dag)
+}
+
+// quoteParamValues quotes the value portion of each parameter so that
+// values containing spaces survive re-parsing by parseStringParams.
+//
+// ParamsList stores unquoted "key=value" strings (produced by paramPair.String()),
+// but the rebuild path feeds them back through parseStringParams which splits
+// on whitespace. Quoting each value prevents that re-split.
+func quoteParamValues(params []string) []string {
+	quoted := make([]string, len(params))
+	for i, p := range params {
+		if k, v, ok := strings.Cut(p, "="); ok {
+			quoted[i] = k + "=" + strconv.Quote(v)
+		} else {
+			quoted[i] = strconv.Quote(p)
+		}
+	}
+	return quoted
 }
 
 // rebuildDAGFromYAML rebuilds a DAG from its YamlData using the spec loader.

--- a/internal/cmd/helper_test.go
+++ b/internal/cmd/helper_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/dagu-org/dagu/internal/core"
+	"github.com/dagu-org/dagu/internal/core/exec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +57,80 @@ func TestRebuildDAGFromYAML_EmptyYAML(t *testing.T) {
 
 	assert.Same(t, dag, result)
 	assert.Equal(t, "Default", result.Queue)
+}
+
+func TestQuoteParamValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "named param with spaces",
+			input:  []string{"topic=hello world"},
+			expect: []string{`topic="hello world"`},
+		},
+		{
+			name:   "named param without spaces",
+			input:  []string{"topic=hello"},
+			expect: []string{`topic="hello"`},
+		},
+		{
+			name:   "positional param with spaces",
+			input:  []string{"hello world"},
+			expect: []string{`"hello world"`},
+		},
+		{
+			name:   "positional param without spaces",
+			input:  []string{"hello"},
+			expect: []string{`"hello"`},
+		},
+		{
+			name:   "multiple params",
+			input:  []string{"topic=hello world", "count=42", "greeting"},
+			expect: []string{`topic="hello world"`, `count="42"`, `"greeting"`},
+		},
+		{
+			name:   "empty slice",
+			input:  []string{},
+			expect: []string{},
+		},
+		{
+			name:   "param with quotes in value",
+			input:  []string{`msg=say "hi"`},
+			expect: []string{`msg="say \"hi\""`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := quoteParamValues(tt.input)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestRestoreDAGFromStatus_ParamsWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Name:     "test-dag",
+		YamlData: []byte("params:\n  - topic: \"\"\nsteps:\n  - name: test\n    command: echo $topic"),
+	}
+
+	status := &exec.DAGRunStatus{
+		ParamsList: []string{"topic=hello world"},
+	}
+
+	result, err := restoreDAGFromStatus(context.Background(), dag, status)
+	require.NoError(t, err)
+
+	// The restored params should preserve "hello world" as a single value
+	found := slices.Contains(result.Params, "topic=hello world")
+	assert.True(t, found, "expected 'topic=hello world' in params, got: %v", result.Params)
 }
 
 func TestRebuildDAGFromYAML_RebuildEnvFromYAML(t *testing.T) {


### PR DESCRIPTION
ParamsList stores unquoted "key=value" strings, but the rebuild path re-parses them through parseStringParams which splits on whitespace. This caused "topic=hello world" to become "topic=hello" + "2=world" when a DAG was enqueued and later dequeued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter values containing spaces to be properly preserved during restoration and parsing operations.

* **Tests**
  * Added test coverage for parameter handling with spaces and various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->