### PR TITLE
fix: zombie detector now reads full status from attempt before overwriting

### DIFF
--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1496,6 +1496,9 @@ func (a *Agent) setupRetryPlan(ctx context.Context) error {
 	// the retry actually runs all steps instead of producing a 0-node run.
 	if len(nodes) == 0 {
 		logger.Warn(ctx, "Retry target has no nodes; falling back to fresh plan from DAG definition")
+		if a.stepRetry != "" {
+			return fmt.Errorf("cannot retry step %q: previous attempt has no node state", a.stepRetry)
+		}
 		plan, err := runtime.NewPlan(a.dag.Steps...)
 		if err != nil {
 			return err

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -179,10 +179,7 @@ func (z *ZombieDetector) checkAndCleanZombie(ctx context.Context, st *exec.DAGRu
 	// the complete status (nodes, logs, params, etc.) when updating.
 	fullStatus, err := attempt.ReadStatus(ctx)
 	if err != nil {
-		logger.Warn(ctx, "Failed to read full status from attempt, using summary",
-			tag.Error(err),
-		)
-		fullStatus = st
+		return fmt.Errorf("read full status: %w", err)
 	}
 
 	fullStatus.Status = core.Failed

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -375,6 +375,48 @@ func TestZombieDetector_checkAndCleanZombie_errors(t *testing.T) {
 		procStore.AssertExpectations(t)
 		attempt.AssertExpectations(t)
 	})
+
+	t.Run("ErrorReadingFullStatus", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		status := &exec.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   core.Running,
+		}
+
+		attempt := &exec.MockDAGRunAttempt{}
+		dagRunRef := exec.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", mock.Anything, dagRunRef).Return(attempt, nil)
+
+		dag := &core.DAG{Name: "test-dag"}
+		attempt.On("ReadDAG", mock.Anything).Return(dag, nil)
+
+		procRef := exec.DAGRunRef{
+			Name: dag.Name,
+			ID:   "run-123",
+		}
+		procStore.On("IsRunAlive", mock.Anything, dag.ProcGroup(), procRef).Return(false, nil)
+
+		// ReadStatus fails — should return error, not fall back to summary
+		attempt.On("ReadStatus", mock.Anything).Return((*exec.DAGRunStatus)(nil), errors.New("corrupted file"))
+
+		err := detector.checkAndCleanZombie(ctx, status)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "read full status")
+
+		// Should NOT have tried to write the truncated summary
+		attempt.AssertNotCalled(t, "Open", mock.Anything)
+		attempt.AssertNotCalled(t, "Write", mock.Anything, mock.Anything)
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
 }
 
 func TestZombieDetector_concurrency(t *testing.T) {


### PR DESCRIPTION
ListStatuses returns a lightweight index summary that lacks node data. The zombie detector was using this nodeless summary when writing the Failed status, which caused compaction to overwrite the original status (with nodes, logs, pid, etc.) with a stripped-down version. This left DAG run detail pages blank in the UI.

Now the zombie detector calls attempt.ReadStatus() to get the complete status before modifying and writing it back. Also populates nodes from the DAG definition when the process was killed before writing any node data, and marks NotStarted nodes as Failed in addition to Running ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry behavior to execute all steps when previous run data is incomplete or missing
  * Improved handling of incomplete status information during automatic recovery operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->