### PR TITLE
fix(exec): expand base config env vars in command evaluation

### DIFF
--- a/internal/core/exec/context.go
+++ b/internal/core/exec/context.go
@@ -259,8 +259,12 @@ func NewContext(
 	secretEnvs := stringutil.KeyValuesToMap(options.secretEnvs)
 
 	// Build EnvScope with proper source tracking and layering
-	// Precedence (highest to lowest): Secrets > DAG Env > Params > OS
+	// Precedence (highest to lowest): Secrets > DAG Env/Params > BaseEnv > OS
 	scope := eval.NewEnvScope(nil, true) // OS layer
+	baseEnvs := stringutil.KeyValuesToMap(config.GetBaseEnv(ctx).AsSlice())
+	if len(baseEnvs) > 0 {
+		scope = scope.WithEntries(baseEnvs, eval.EnvSourceDAGEnv)
+	}
 	scope = scope.WithEntries(envs, eval.EnvSourceDAGEnv)
 	if len(secretEnvs) > 0 {
 		scope = scope.WithEntries(secretEnvs, eval.EnvSourceSecret)

--- a/internal/core/exec/context_test.go
+++ b/internal/core/exec/context_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/dagu-org/dagu/internal/cmn/config"
+	"github.com/dagu-org/dagu/internal/cmn/eval"
 	"github.com/dagu-org/dagu/internal/core"
 	"github.com/dagu-org/dagu/internal/core/exec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDAGContext_UserEnvsMap(t *testing.T) {
@@ -222,4 +224,23 @@ func TestNewContext_DAGRunWorkDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewContext_BaseEnvUsedForExpansion(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	cfg.Core.BaseEnv = config.NewBaseEnv([]string{"GITHUB_URL=github.com"})
+
+	ctx := config.WithConfig(context.Background(), cfg)
+	dag := &core.DAG{Name: "test-dag"}
+	ctx = exec.NewContext(ctx, dag, "run-1", "test.log")
+
+	rCtx := exec.GetContext(ctx)
+	require.NotNil(t, rCtx.EnvScope)
+
+	evalCtx := eval.WithEnvScope(context.Background(), rCtx.EnvScope)
+	out, err := eval.String(evalCtx, "https://${GITHUB_URL}/dagu-org/dagu")
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/dagu-org/dagu", out)
 }


### PR DESCRIPTION
## Summary
- include configured base environment variables in the runtime EnvScope used for variable substitution
- keep precedence conservative by layering base env below DAG/params and above OS env
- add a regression test proving `${GITHUB_URL}` expansion works when the value comes from base config env

## Testing
- `go test ./internal/core/exec -run TestNewContext_BaseEnvUsedForExpansion` *(could not run locally: this environment cannot download required Go toolchain `go1.26`, so validation is limited to static review of the new test)*

## Related
Fixes #1739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Base environment variables are now supported in configurations. Environment variable resolution follows updated precedence order: Secrets > DAG Environment/Parameters > Base Environment > Operating System variables.

* **Tests**
  * Added test coverage for base environment variable expansion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->