### PR TITLE
fix: SubDAG step shows no "View Sub DAG Run" link while child DAG is …

### DIFF
--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -677,3 +677,58 @@ steps:
 	require.NotContains(t, outputs["response"], secretValue, "secret should be masked")
 	require.Contains(t, outputs["response"], "*******", "masked placeholder expected")
 }
+
+func TestAgent_SubDAGRunVisibleWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+
+	// Create a child DAG that sleeps long enough for the parent to be observed mid-run
+	th.CreateDAGFile(t, th.Config.Paths.DAGsDir, "child-slow", []byte(`
+steps:
+  - name: slow-step
+    command: "sleep 3"
+`))
+
+	// The preceding step must run long enough for the one-shot 100ms status timer
+	// to fire (and exhaust itself) BEFORE run-child starts. This replicates the
+	// production scenario where the bug manifests.
+	parent := th.DAG(t, `
+type: graph
+steps:
+  - name: pre-step
+    command: "sleep 0.3"
+  - name: run-child
+    call: child-slow
+    depends:
+      - pre-step
+`)
+
+	a := parent.Agent()
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- a.Run(parent.Context)
+	}()
+
+	// SubRuns must be visible in the *stored* status BEFORE the child DAG completes.
+	// We use ListRecentStatus which reads from the status.jsonl file on disk, not from
+	// the live socket, so it accurately reflects what the API handler would return.
+	// Before the fix, this would never become true because SetSubRuns() was called
+	// after the progressCh notification, so the children field was never written
+	// to status.jsonl while the subdag was running.
+	require.Eventually(t, func() bool {
+		statuses := th.DAGRunMgr.ListRecentStatus(th.Context, parent.Name, 1)
+		if len(statuses) == 0 || statuses[0].Status != core.Running {
+			return false
+		}
+		for _, node := range statuses[0].Nodes {
+			if node.Step.Name == "run-child" && node.Status == core.NodeRunning {
+				return len(node.SubRuns) > 0
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond,
+		"SubRuns must be present in stored status while subDAG step is running")
+
+	require.NoError(t, <-runErr)
+}

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -170,7 +170,7 @@ func (n *Node) ShouldContinue(ctx context.Context) bool {
 	return false
 }
 
-func (n *Node) Execute(ctx context.Context) error {
+func (n *Node) Execute(ctx context.Context, onSetup ...func()) error {
 	ctx, cancel, stepTimeout := n.setupContextWithTimeout(ctx)
 	defer cancel()
 
@@ -178,6 +178,14 @@ func (n *Node) Execute(ctx context.Context) error {
 	if err != nil {
 		n.SetError(fmt.Errorf("failed to setup executor: %w", err))
 		return err
+	}
+
+	// Notify after executor setup so SubRuns (set for subDAG steps) are
+	// persisted to storage before the executor starts running.
+	for _, fn := range onSetup {
+		if fn != nil {
+			fn()
+		}
 	}
 
 	// Ensure executor cleanup happens (releases connections, etc.)

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -435,7 +435,7 @@ func (r *Runner) runNodeExecution(ctx context.Context, plan *Plan, node *Node, p
 ExecRepeat: // repeat execution
 	for !r.isCanceled() {
 		logger.Debug(ctx, "Executing node loop")
-		execErr := r.execNode(ctx, node)
+		execErr := r.execNode(ctx, node, progressCh)
 		isRetriable := r.handleNodeExecutionError(ctx, plan, node, execErr)
 		if isRetriable {
 			continue ExecRepeat
@@ -678,9 +678,14 @@ func (r *Runner) setupEnvironEventHandler(ctx context.Context, plan *Plan, node 
 	return WithEnv(ctx, env)
 }
 
-func (r *Runner) execNode(ctx context.Context, node *Node) error {
+func (r *Runner) execNode(ctx context.Context, node *Node, progressCh chan *Node) error {
 	if r.dry {
 		return nil
+	}
+	if progressCh != nil && node.Step().SubDAG != nil {
+		// Send an additional progress notification after the executor is set up
+		// so that SubRuns are persisted to storage before the subDAG starts running.
+		return node.Execute(ctx, func() { progressCh <- node })
 	}
 	return node.Execute(ctx)
 }


### PR DESCRIPTION
Fix for #1747.

New test to check visibility of sub runs and a fix for the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-DAG runs are now visible in the execution status while the parent DAG is still running, improving real-time progress visibility.

* **Improvements**
  * Enhanced progress tracking during node execution setup to ensure sub-run state is properly persisted before execution begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->