### PR TITLE
fix: require basic auth credentials for SSE endpoints

### DIFF
--- a/internal/service/frontend/api/v1/auth_test.go
+++ b/internal/service/frontend/api/v1/auth_test.go
@@ -117,6 +117,37 @@ func TestAuth_Combinations(t *testing.T) {
 	}
 }
 
+// TestAuth_BasicAuth_SSE_Requires_Credentials verifies that SSE endpoints
+// require basic auth when auth.mode is "basic" (regression test for auth bypass).
+func TestAuth_BasicAuth_SSE_Requires_Credentials(t *testing.T) {
+	t.Parallel()
+
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Server.Auth.Mode = config.AuthModeBasic
+		cfg.Server.Auth.Basic.Username = "admin"
+		cfg.Server.Auth.Basic.Password = "secret"
+	}))
+
+	sseEndpoints := []string{
+		"/api/v1/events/dags",
+		"/api/v1/events/dag-runs",
+		"/api/v1/events/queues",
+	}
+
+	for _, endpoint := range sseEndpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			// No credentials — must be rejected (not bypassed)
+			server.Client().Get(endpoint).
+				ExpectStatus(http.StatusUnauthorized).Send(t)
+
+			// Wrong credentials — must be rejected
+			server.Client().Get(endpoint).
+				WithBasicAuth("wrong", "wrong").
+				ExpectStatus(http.StatusUnauthorized).Send(t)
+		})
+	}
+}
+
 func TestAuth_BuiltinMode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1188,17 +1188,15 @@ func (srv *Server) buildStreamAuthOptions(realm string) auth.Options {
 		return auth.Options{Realm: realm}
 	}
 
-	// Basic auth mode: The browser EventSource API cannot send custom headers,
-	// so it cannot provide Basic credentials. We enable Basic auth validation
-	// (so programmatic clients like curl are authenticated) but set
-	// AuthRequired=false so browser SSE connections without credentials are
-	// not blocked with 401.
-	// FIXME: add a session-token mechanism for basic-auth users so browser
-	// EventSource requests can authenticate via the ?token= query parameter.
+	// Basic auth mode: require credentials for SSE endpoints just like REST.
+	// Browsers handle 401 + WWW-Authenticate: Basic challenges natively,
+	// caching credentials per origin/realm, so EventSource requests will
+	// include Basic auth automatically after the user authenticates once.
 	if authCfg.Mode == config.AuthModeBasic {
 		return auth.Options{
 			Realm:            realm,
 			BasicAuthEnabled: true,
+			AuthRequired:     true,
 			Creds:            map[string]string{authCfg.Basic.Username: authCfg.Basic.Password},
 		}
 	}


### PR DESCRIPTION
SSE endpoints were accessible without credentials when auth.mode=basic because AuthRequired defaulted to false. This allowed unauthenticated access to real-time DAG execution data, workflow configs, and logs.

Browsers handle 401 Basic challenges natively and cache credentials per origin/realm, so EventSource requests authenticate automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSE endpoints now require credentials when using Basic authentication mode

* **Tests**
  * Added test coverage for Basic auth credential requirements on streaming endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->