### PR TITLE
Fix raw output mode for large numbers in the jq step.

### DIFF
--- a/internal/runtime/builtin/jq/jq.go
+++ b/internal/runtime/builtin/jq/jq.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/dagu-org/dagu/internal/core"
 	"github.com/dagu-org/dagu/internal/runtime/executor"
@@ -98,9 +99,9 @@ func (e *jq) Run(_ context.Context) error {
 				} else {
 					_, _ = fmt.Fprintln(e.stdout, "false")
 				}
-			case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			case float64:
 				// For numbers, print without quotes
-				_, _ = fmt.Fprintln(e.stdout, v)
+				_, _ = fmt.Fprintln(e.stdout, strconv.FormatFloat(v, 'f', -1, 64))
 			default:
 				// For arrays/objects or other types, marshal to JSON
 				val, err := json.Marshal(v)

--- a/internal/runtime/builtin/jq/jq_test.go
+++ b/internal/runtime/builtin/jq/jq_test.go
@@ -157,6 +157,20 @@ func TestJQExecutor_RawOutput(t *testing.T) {
 			raw:            true,
 			expectedOutput: "-10\n",
 		},
+		{
+			name:           "LargeFloatWithRawTrue",
+			query:          ".big",
+			script:         `{"big": 13786123706}`,
+			raw:            true,
+			expectedOutput: "13786123706\n",
+		},
+		{
+			name:           "LargeFloatWithRawTrue",
+			query:          ".big",
+			script:         `{"big": 13786123706.101}`,
+			raw:            true,
+			expectedOutput: "13786123706.101\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
gojq parses numbers as float64, and printing them with the default formatters results in scientific notation. Switch to using FormatFloat instead.

Fixes #1648 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Updated numeric value handling in raw output mode. Different numeric types now receive distinct processing, with separate handling for each numeric category when raw output is enabled.

**Tests**
- Added new test cases validating large numeric values in raw output mode, providing comprehensive coverage for both integer and floating-point numeric scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->