### PR TITLE
fix(ui): show onAbort label in lifecycle hooks

### DIFF
--- a/ui/src/features/dags/lib/__tests__/getEventHandlers.test.ts
+++ b/ui/src/features/dags/lib/__tests__/getEventHandlers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getEventHandlers } from '../getEventHandlers';
+
+describe('getEventHandlers', () => {
+  it('renames onCancel lifecycle hook to onAbort for display', () => {
+    const dagRun = {
+      onCancel: {
+        step: { name: 'onCancel' },
+      },
+    } as any;
+
+    const handlers = getEventHandlers(dagRun);
+
+    expect(handlers).toHaveLength(1);
+    expect(handlers[0].step.name).toBe('onAbort');
+    expect(dagRun.onCancel.step.name).toBe('onCancel');
+  });
+
+  it('preserves non-cancel handlers as-is', () => {
+    const dagRun = {
+      onSuccess: {
+        step: { name: 'onSuccess' },
+      },
+      onFailure: {
+        step: { name: 'onFailure' },
+      },
+      onExit: {
+        step: { name: 'onExit' },
+      },
+    } as any;
+
+    const handlers = getEventHandlers(dagRun);
+
+    expect(handlers.map((h: any) => h.step.name)).toEqual([
+      'onSuccess',
+      'onFailure',
+      'onExit',
+    ]);
+  });
+});

--- a/ui/src/features/dags/lib/getEventHandlers.ts
+++ b/ui/src/features/dags/lib/getEventHandlers.ts
@@ -1,5 +1,19 @@
 import { components } from '../../../api/v1/schema';
 
+function normalizeLifecycleHookName(node: components['schemas']['Node']) {
+  if (node.step.name !== 'onCancel') {
+    return node;
+  }
+
+  return {
+    ...node,
+    step: {
+      ...node.step,
+      name: 'onAbort',
+    },
+  };
+}
+
 export function getEventHandlers(s: components['schemas']['DAGRunDetails']) {
   const ret: components['schemas']['Node'][] = [];
   if (s.onSuccess) {
@@ -9,7 +23,7 @@ export function getEventHandlers(s: components['schemas']['DAGRunDetails']) {
     ret.push(s.onFailure);
   }
   if (s.onCancel) {
-    ret.push(s.onCancel);
+    ret.push(normalizeLifecycleHookName(s.onCancel));
   }
   if (s.onExit) {
     ret.push(s.onExit);


### PR DESCRIPTION
## Summary
- rename the lifecycle hook label from `onCancel` to `onAbort` in the UI event-handler list
- keep API/backward compatibility unchanged by only normalizing the display name in `getEventHandlers`
- add a small unit test to verify `onCancel` is shown as `onAbort` and non-cancel hooks are unchanged

## Testing
- `git diff --check`
- attempted: `npm test -- src/features/dags/lib/__tests__/getEventHandlers.test.ts`
  - not runnable in this environment due missing optional frontend runtime dependencies / local disk constraints

## Related
Fixes #1476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Event handlers now display 'onAbort' instead of 'onCancel' for canceled events, while original data remains unchanged.

* **Tests**
  - Added test coverage for event handler transformation behavior and mixed cancel/non-cancel event hook handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->