### PR TITLE
fix(chart): align shared storage paths in k8s

### DIFF
--- a/charts/dagu/README.md
+++ b/charts/dagu/README.md
@@ -38,6 +38,7 @@ The chart deploys four components:
 - **UI**: Web interface for managing DAGs (port 8080)
 
 All components share a single PersistentVolumeClaim with `ReadWriteMany` access mode.
+The chart mounts that shared volume at `/data`, sets `DAGU_HOME=/data`, and stores the shared base config at `/data/base.yaml` so fallback paths and inherited env stay aligned across UI, scheduler, coordinator, and workers.
 
 ## Configuration
 

--- a/charts/dagu/templates/configmap.yaml
+++ b/charts/dagu/templates/configmap.yaml
@@ -31,6 +31,7 @@ data:
       data_dir: /data
       dags_dir: /data/dags
       log_dir: /data/logs
+      base_config: /data/base.yaml
       suspend_flags_dir: /data/suspend
       admin_logs_dir: /data/admin/logs
       dag_runs_dir: /data/dag-runs

--- a/charts/dagu/templates/coordinator-deployment.yaml
+++ b/charts/dagu/templates/coordinator-deployment.yaml
@@ -30,6 +30,8 @@ spec:
             - --config
             - /etc/dagu/dagu.yaml
           env:
+            - name: DAGU_HOME
+              value: /data
             - name: DAGU_COORDINATOR_HOST
               value: "0.0.0.0"
             - name: DAGU_COORDINATOR_ADVERTISE

--- a/charts/dagu/templates/scheduler-deployment.yaml
+++ b/charts/dagu/templates/scheduler-deployment.yaml
@@ -29,6 +29,9 @@ spec:
             - scheduler
             - --config
             - /etc/dagu/dagu.yaml
+          env:
+            - name: DAGU_HOME
+              value: /data
           ports:
             - name: health
               containerPort: 8090

--- a/charts/dagu/templates/ui-deployment.yaml
+++ b/charts/dagu/templates/ui-deployment.yaml
@@ -30,6 +30,8 @@ spec:
             - --config
             - /etc/dagu/dagu.yaml
           env:
+            - name: DAGU_HOME
+              value: /data
             - name: DAGU_PORT
               value: {{ .Values.ui.service.port | quote }}
           ports:

--- a/charts/dagu/templates/worker-deployment.yaml
+++ b/charts/dagu/templates/worker-deployment.yaml
@@ -42,6 +42,8 @@ spec:
             - {{ include "dagu.workerLabels" $pool.labels | quote }}
             {{- end }}
           env:
+            - name: DAGU_HOME
+              value: /data
             - name: WORKER_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart configuration to set `DAGU_HOME=/data` environment variable across coordinator, scheduler, UI, and worker components.
  * Added base configuration file path pointing to `/data/base.yaml` in the deployment settings.
  * Updated documentation for shared volume and configuration mount points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->