### PR TITLE
scheduler: reduce queue startup lookup churn

### DIFF
--- a/internal/persis/filedagrun/dataroot.go
+++ b/internal/persis/filedagrun/dataroot.go
@@ -93,6 +93,8 @@ func NewDataRootWithPrefix(baseDir, prefix string) DataRoot {
 	}
 }
 
+const dagRunTimestampLen = len("20060102_150405Z")
+
 // FindByDAGRunID locates a dag-run by its ID.
 // It scans the year/month/day hierarchy in reverse chronological order and
 // returns the first exact match, which preserves the "newest run wins" behavior
@@ -157,8 +159,34 @@ func findDAGRunInDay(dayPath, dagRunID string) (*DAGRun, error) {
 }
 
 func isMatchingDAGRunDir(dirName, dagRunID string) bool {
-	matches := reDAGRunDir.FindStringSubmatch(dirName)
-	return len(matches) == 3 && matches[2] == dagRunID
+	if !strings.HasPrefix(dirName, DAGRunDirPrefix) {
+		return false
+	}
+
+	remainder := strings.TrimPrefix(dirName, DAGRunDirPrefix)
+	if len(remainder) <= dagRunTimestampLen || remainder[dagRunTimestampLen] != '_' {
+		return false
+	}
+
+	return isDAGRunTimestamp(remainder[:dagRunTimestampLen]) &&
+		remainder[dagRunTimestampLen+1:] == dagRunID
+}
+
+func isDAGRunTimestamp(ts string) bool {
+	if len(ts) != dagRunTimestampLen || ts[8] != '_' || ts[15] != 'Z' {
+		return false
+	}
+
+	for i := range len(ts) {
+		if i == 8 || i == 15 {
+			continue
+		}
+		if ts[i] < '0' || ts[i] > '9' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Latest returns the most recent dag-runs up to the specified limit.
@@ -199,12 +227,6 @@ func (dr *DataRoot) CreateDAGRun(ts exec.TimeInUTC, dagRunID string) (*DAGRun, e
 	}
 
 	return NewDAGRun(dir)
-}
-
-// GlobPatternWithDAGRunID returns a glob pattern for finding dag-run directories
-// that contain the specified dag-run ID in their name.
-func (dr DataRoot) GlobPatternWithDAGRunID(dagRunID string) string {
-	return filepath.Join(dr.dagRunsDir, "2*", "*", "*", DAGRunDirPrefix+"*"+dagRunID)
 }
 
 // Exists checks if the dag-runs directory exists in the file system.

--- a/internal/persis/filedagrun/dataroot_test.go
+++ b/internal/persis/filedagrun/dataroot_test.go
@@ -92,8 +92,22 @@ func TestDataRootRuns(t *testing.T) {
 		actual, err := dr.FindByDAGRunID(ctx, "duplicate-id")
 		require.NoError(t, err)
 
-		assert.NotEqual(t, oldRun.DAGRun.baseDir, actual.baseDir, "older duplicate should not be returned")
-		assert.Equal(t, newRun.DAGRun.baseDir, actual.baseDir, "newest duplicate should be returned")
+		assert.NotEqual(t, oldRun.baseDir, actual.baseDir, "older duplicate should not be returned")
+		assert.Equal(t, newRun.baseDir, actual.baseDir, "newest duplicate should be returned")
+	})
+
+	t.Run("FindByDAGRunIDReturnsNewestDuplicateOnSameDay", func(t *testing.T) {
+		ctx := context.Background()
+		dr := setupTestDataRoot(t)
+
+		oldRun := dr.CreateTestDAGRun(t, "same-day-duplicate-id", exec.NewUTC(time.Date(2021, 1, 2, 1, 0, 0, 0, time.UTC)))
+		newRun := dr.CreateTestDAGRun(t, "same-day-duplicate-id", exec.NewUTC(time.Date(2021, 1, 2, 2, 0, 0, 0, time.UTC)))
+
+		actual, err := dr.FindByDAGRunID(ctx, "same-day-duplicate-id")
+		require.NoError(t, err)
+
+		assert.NotEqual(t, oldRun.baseDir, actual.baseDir, "older same-day duplicate should not be returned")
+		assert.Equal(t, newRun.baseDir, actual.baseDir, "newest same-day duplicate should be returned")
 	})
 
 	t.Run("FindByDAGRunIDUsesExactMatch", func(t *testing.T) {
@@ -106,7 +120,7 @@ func TestDataRootRuns(t *testing.T) {
 		actual, err := dr.FindByDAGRunID(ctx, "123")
 		require.NoError(t, err)
 
-		assert.Equal(t, exactRun.DAGRun.baseDir, actual.baseDir, "suffix matches should not win over exact dag-run ID matches")
+		assert.Equal(t, exactRun.baseDir, actual.baseDir, "suffix matches should not win over exact dag-run ID matches")
 	})
 
 	t.Run("FindByDAGRunIDNotFound", func(t *testing.T) {

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -6,7 +6,7 @@ package scheduler
 import (
 	"context"
 	"errors"
-	osExec "os/exec"
+	osexec "os/exec"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -403,7 +403,7 @@ func (p *QueueProcessor) processDAG(ctx context.Context, item exec.QueuedItemDat
 		defer p.wakeUp()
 		if err := p.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType); err != nil {
 			logger.Error(ctx, "Failed to execute DAG", tag.Error(err))
-			if shouldAbortStartupWait(err) {
+			if isPreStartExecutionFailure(err) {
 				select {
 				case execErrCh <- err:
 				default:
@@ -521,11 +521,16 @@ func readStartupExecutionError(execErrCh <-chan error) error {
 	}
 }
 
-func shouldAbortStartupWait(err error) bool {
-	if err == nil {
+// isPreStartExecutionFailure reports whether an execution error proves the DAG
+// never reached an observable started state. Spawn and dispatch failures should
+// abort the startup wait immediately, while process exit errors should continue
+// to rely on heartbeat/status because the attempt did start.
+func isPreStartExecutionFailure(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
-	var exitErr *osExec.ExitError
+
+	var exitErr *osexec.ExitError
 	return !errors.As(err, &exitErr)
 }
 

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	osexec "os/exec"
 	"testing"
 	"time"
 
@@ -134,6 +135,28 @@ func TestQueueProcessor_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testin
 
 			dagRunStore.AssertExpectations(t)
 			procStore.AssertExpectations(t)
+		})
+	}
+}
+
+func TestIsPreStartExecutionFailure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "Nil", err: nil, want: false},
+		{name: "ContextCanceled", err: context.Canceled, want: false},
+		{name: "DeadlineExceeded", err: context.DeadlineExceeded, want: false},
+		{name: "ExitError", err: &osexec.ExitError{}, want: false},
+		{name: "DispatchFailure", err: errors.New("dispatch failed"), want: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isPreStartExecutionFailure(tc.err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- replace root dag-run lookup in `FindByDAGRunID` with a reverse-chronological exact-match scan instead of `filepath.Glob + sort`
- reduce queue startup polling churn by skipping status-store fallback during a short startup grace period and only aborting early on true pre-start execution failures
- add focused regression coverage for duplicate run IDs, exact matching, startup grace behavior, and pre-start failure classification

## Motivation
This change targets the scheduler memory-growth investigation around repeated queue startup polling and repeated filesystem scans of the growing `dag-runs` tree.

Related to #546.

## Risk Areas
- queue startup acknowledgment semantics in the scheduler retry path
- dag-run lookup correctness when duplicate run IDs exist across days or within the same day
- classification of execution failures that should stop startup polling immediately versus failures that should still rely on heartbeat/status observation

## Validation
- `make fmt`
- `go test ./internal/persis/filedagrun`
- `go test ./internal/service/scheduler -run '^TestQueueProcessor_'`
- `go test ./internal/persis/filedagrun ./internal/service/scheduler -run '^(TestDataRootRuns|TestQueueProcessor_CheckStartupStatus_|TestIsPreStartExecutionFailure)'`

## Additional Notes
- I did not rely on the full `go test ./internal/service/scheduler` result because this environment still has existing scheduler test dependencies on a local `dagu` binary and broader port-sharing behavior unrelated to this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * DAG run lookup now uses hierarchical, reverse-chronological directory traversal instead of full-scan search.

* **Improvements**
  * Scheduler startup logic now includes grace period configuration and enhanced error detection.
  * Improved startup failure handling with pre-execution error monitoring.

* **Tests**
  * Added test coverage for startup grace period behavior and DAG run lookup accuracy with duplicate IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->