### PR TITLE
fix(api): ensure retry endpoint returns immediately without blocking

### DIFF
--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1715,7 +1715,7 @@ func (a *API) waitForRetryStarted(ctx context.Context, dag *core.DAG, dagRunID s
 			return
 		default:
 			status, _ := a.dagRunMgr.GetCurrentStatus(ctx, dag, dagRunID)
-			if status != nil && status.Status == core.Running {
+			if status != nil && (status.Status == core.Running || status.Status == core.Queued) {
 				return
 			}
 			time.Sleep(pollInterval)


### PR DESCRIPTION
## Summary
- Fix the retry API endpoint (`POST /dag-runs/{name}/{dagRunId}/retry`) blocking until the DAG run completes instead of returning 200 immediately
- Add `waitForRetryStarted` to the local retry path that briefly polls (up to 3s) for the subprocess to reach Running status before returning, matching the pattern used by the start endpoint
- The wait is best-effort: if the timeout elapses the handler still returns 200 since `runtime.Start` already spawned the subprocess asynchronously

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify `go vet ./internal/service/frontend/api/v1/...` passes
- [ ] Manual test: call the retry endpoint on a long-running DAG and confirm the API returns within seconds

Fixes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Retry operations now complete more quickly with asynchronous processing instead of blocking.
  * Improved retry startup confirmation to ensure the operation has begun before responding to requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->