### PR TITLE
fix(secrets): rename vault environment variable

### DIFF
--- a/internal/cmn/secrets/vault.go
+++ b/internal/cmn/secrets/vault.go
@@ -130,6 +130,8 @@ func (r *vaultResolver) getClient(ref core.SecretRef) (vaultClient, error) {
 	config := api.DefaultConfig()
 	if addr != "" {
 		config.Address = addr
+	} else {
+		config.Address = api.DefaultAddress
 	}
 
 	client, err := api.NewClient(config)
@@ -139,6 +141,8 @@ func (r *vaultResolver) getClient(ref core.SecretRef) (vaultClient, error) {
 
 	if token != "" {
 		client.SetToken(token)
+	} else {
+		client.ClearToken()
 	}
 
 	realClient := &realVaultClient{client: client}


### PR DESCRIPTION
Prefix Vault environment variables with DAGU.

I completely forgot that environment variables related to existing configurations are prefixed with `DAGU_`.

This pull request also edge case where `VAULT_ADDR` and `VAULT_TOKEN` are used with the built-in env provider.

apologize for requesting another change so soon after https://github.com/dagu-org/dagu/pull/1757 was merged, but I would appreciate it if you could check this. orz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Vault connection settings resolution now supports alternative environment variable naming conventions for more flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->