### PR TITLE
fix(installer): remove --ignore-missing flag from sha256sum for BusyBox compatibility

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -262,7 +262,10 @@ gum_is_tty() {
 verify_sha256sum_file() {
     local checksums="$1"
     if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum --ignore-missing -c "$checksums" >/dev/null 2>&1
+        # NOTE: Callers must pre-filter $checksums to contain only the entry
+        # for the file being verified. This avoids --ignore-missing, which is
+        # not supported by all sha256sum implementations (e.g., BusyBox).
+        sha256sum -c "$checksums" >/dev/null 2>&1
         return $?
     fi
     if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Remove `--ignore-missing` flag from `sha256sum` in the installer's `verify_sha256sum_file` function
- BusyBox's `sha256sum` does not support `--ignore-missing`, causing checksum verification to fail on minimal/Alpine-based environments
- Callers are expected to pre-filter the checksums file to contain only the relevant entry, making the flag unnecessary

## Testing
- Run the installer script on a BusyBox-based system (e.g., Alpine Linux Docker container) and verify checksum validation succeeds
- Run the installer on a standard Linux distribution to confirm no regression

Closes #1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer checksum verification to strictly validate target files without ignoring missing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->