### PR TITLE
fix: allow env: to reference params: values

### DIFF
--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -408,14 +408,15 @@ var metadataTransformers = []transform{
 	{"description", newTransformer("Description", buildDescription)},
 	{"type", newTransformer("Type", buildType)},
 	{"tags", newTransformer("Tags", buildTags)},
-	{"env", newTransformer("Env", buildEnvs)},
-	{"schedule", newTransformer("Schedule", buildSchedule)},
-	{"stop_schedule", newTransformer("StopSchedule", buildStopSchedule)},
-	{"restart_schedule", newTransformer("RestartSchedule", buildRestartSchedule)},
+	// params must run BEFORE env so that env: values can reference ${param_name}
 	{"params", newTransformer("Params", buildParams)},
 	{"default_params", newTransformer("DefaultParams", buildDefaultParams)},
 	{"param_defs", newTransformer("ParamDefs", buildParamDefs)},
 	{"params_json", newTransformer("ParamsJSON", buildParamsJSON)},
+	{"env", newTransformer("Env", buildEnvs)},
+	{"schedule", newTransformer("Schedule", buildSchedule)},
+	{"stop_schedule", newTransformer("StopSchedule", buildStopSchedule)},
+	{"restart_schedule", newTransformer("RestartSchedule", buildRestartSchedule)},
 	{"worker_selector", &workerSelectorTransformer{}},
 	{"timeout", newTransformer("Timeout", buildTimeout)},
 	{"delay", newTransformer("Delay", buildDelay)},
@@ -819,6 +820,16 @@ func buildParams(ctx BuildContext, d *dag) ([]string, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return nil, err
+	}
+	// Add resolved params to envScope so env: can reference ${param_name}
+	if ctx.envScope != nil && len(result.Params) > 0 {
+		paramVars := make(map[string]string, len(result.Params))
+		for _, p := range result.Params {
+			if k, v, ok := strings.Cut(p, "="); ok {
+				paramVars[k] = v
+			}
+		}
+		ctx.envScope.scope = ctx.envScope.scope.WithEntries(paramVars, eval.EnvSourceParam)
 	}
 	return result.Params, nil
 }

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -4,7 +4,9 @@
 package spec
 
 import (
+	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -2554,6 +2556,78 @@ func TestChainTypeDependsValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildEnvReferencesParams(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+params:
+  data_dir: /tmp/foo
+env:
+  - FULL_PATH: "${data_dir}/output"
+steps:
+  - command: echo test
+`
+	d, err := LoadYAML(context.Background(), []byte(yamlData))
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range d.Env {
+		if strings.HasPrefix(e, "FULL_PATH=") {
+			require.Equal(t, "FULL_PATH=/tmp/foo/output", e)
+			found = true
+		}
+	}
+	require.True(t, found, "FULL_PATH env var not found")
+}
+
+func TestBuildEnvReferencesParamsWithoutEval(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+params:
+  data_dir: /tmp/foo
+env:
+  - FULL_PATH: "${data_dir}/output"
+steps:
+  - command: echo test
+`
+	d, err := LoadYAML(context.Background(), []byte(yamlData), WithoutEval())
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range d.Env {
+		if strings.HasPrefix(e, "FULL_PATH=") {
+			require.Equal(t, "FULL_PATH=${data_dir}/output", e)
+			found = true
+		}
+	}
+	require.True(t, found, "FULL_PATH env var not found")
+}
+
+func TestBuildEnvReferencesParamsOnlyMetadata(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+params:
+  data_dir: /tmp/foo
+env:
+  - FULL_PATH: "${data_dir}/output"
+steps:
+  - command: echo test
+`
+	d, err := LoadYAML(context.Background(), []byte(yamlData), OnlyMetadata())
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range d.Env {
+		if strings.HasPrefix(e, "FULL_PATH=") {
+			require.Equal(t, "FULL_PATH=/tmp/foo/output", e)
+			found = true
+		}
+	}
+	require.True(t, found, "FULL_PATH env var not found")
 }
 
 func TestRouterNotAllowedInChainType(t *testing.T) {

--- a/internal/core/spec/variables.go
+++ b/internal/core/spec/variables.go
@@ -81,7 +81,13 @@ func evaluatePairs(ctx BuildContext, pairs []pair) (map[string]string, error) {
 	var scope *eval.EnvScope
 	var evalCtx context.Context
 	if !ctx.opts.Has(BuildFlagNoEval) {
-		scope = eval.NewEnvScope(nil, true)
+		// Use the shared build scope (which includes resolved params)
+		// instead of a fresh OS-only scope, so env: can reference ${param_name}.
+		if ctx.envScope != nil && ctx.envScope.scope != nil {
+			scope = ctx.envScope.scope
+		} else {
+			scope = eval.NewEnvScope(nil, true)
+		}
 		evalCtx = ctx.ctx
 		if evalCtx == nil {
 			evalCtx = context.Background()

--- a/internal/intg/env_test.go
+++ b/internal/intg/env_test.go
@@ -6,7 +6,13 @@ package intg_test
 import (
 	"testing"
 
+	"github.com/dagu-org/dagu/internal/cmd"
+	"github.com/dagu-org/dagu/internal/core"
+	exec1 "github.com/dagu-org/dagu/internal/core/exec"
 	"github.com/dagu-org/dagu/internal/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnv(t *testing.T) {
@@ -127,6 +133,43 @@ steps:
 		})
 	})
 
+	t.Run("EnvReferencesParams", func(t *testing.T) {
+		th := test.Setup(t)
+		dag := th.DAG(t, `
+params:
+  data_dir: /tmp/foo
+env:
+  - FULL_PATH: "${data_dir}/output"
+steps:
+  - command: echo "${FULL_PATH}"
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "/tmp/foo/output",
+		})
+	})
+
+	t.Run("EnvReferencesParamsChained", func(t *testing.T) {
+		th := test.Setup(t)
+		dag := th.DAG(t, `
+params:
+  base: /data
+env:
+  - DIR: "${base}/subdir"
+  - FULL: "${DIR}/file.txt"
+steps:
+  - command: echo "${FULL}"
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "/data/subdir/file.txt",
+		})
+	})
+
 	t.Run("StepOutputSubstrings", func(t *testing.T) {
 		th := test.Setup(t)
 		dag := th.DAG(t, `
@@ -155,4 +198,53 @@ steps:
 			"SUBSTRING_VALIDATION": "OK",
 		})
 	})
+}
+
+func TestSubDAGParamsReferencedInChildEnv(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "subdag-env-from-params.yaml", `
+name: subdag-env-parent
+steps:
+  - name: invoke-child
+    call: subdag-env-child
+    params: "data_dir=/mnt/data"
+
+---
+name: subdag-env-child
+params:
+  - name: data_dir
+    type: string
+    required: true
+env:
+  - OUTPUT_PATH: "${data_dir}/results"
+steps:
+  - name: check-env
+    command: echo "${OUTPUT_PATH}"
+    output: RESULT
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	th.RunCommand(t, cmd.Start(), test.CmdTest{
+		Args:        []string{"start", "--run-id", runID, dagFile},
+		ExpectedOut: []string{"DAG run finished"},
+	})
+
+	rootRef := exec1.NewDAGRunRef("subdag-env-parent", runID)
+	parentAttempt, err := th.DAGRunStore.FindAttempt(th.Context, rootRef)
+	require.NoError(t, err)
+
+	parentStatus, err := parentAttempt.ReadStatus(th.Context)
+	require.NoError(t, err)
+	require.Equal(t, core.Succeeded, parentStatus.Status)
+	require.Len(t, parentStatus.Nodes, 1)
+	require.Len(t, parentStatus.Nodes[0].SubRuns, 1)
+
+	subRunID := parentStatus.Nodes[0].SubRuns[0].DAGRunID
+	subStatus, subOutputs := readSubAttemptStatusAndOutputs(t, th, rootRef, subRunID)
+	require.Equal(t, core.Succeeded, subStatus.Status)
+
+	require.Contains(t, subOutputs.Outputs, "result")
+	assert.Equal(t, "/mnt/data/results", subOutputs.Outputs["result"])
 }


### PR DESCRIPTION
## Summary
- Reorder metadata transformers so `params` is resolved before `env`, enabling `env:` values to reference `${param_name}` variables
- Inject resolved params into the shared `envScope` so variable expansion works during env evaluation
- Update `evaluatePairs` to use the shared build scope (which includes params) instead of a fresh OS-only scope
- Add unit tests for env referencing params (with eval, without eval, metadata-only modes)
- Add integration tests for env referencing params, chained env references, and sub-DAG param-to-env propagation

## Testing
- `make test TEST_TARGET=./internal/core/spec/...`
- `make test TEST_TARGET=./internal/intg/...`

Closes #1805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables can now reference parameter values within DAG definitions, enabling dynamic variable resolution based on parameter inputs.
  * Added support for chained environment variable references where one env var can reference another derived from parameters.
  * Environment variable and parameter resolution now works correctly across parent and child DAGs in nested workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->