### PR TITLE
fix(ui): enable live updates for Yesterday section in cockpit

### DIFF
--- a/ui/src/features/cockpit/components/DateKanbanSection.tsx
+++ b/ui/src/features/cockpit/components/DateKanbanSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { components } from '@/api/v1/schema';
 import dayjs from '@/lib/dayjs';
 import { useDateKanbanData } from '../hooks/useDateKanbanData';
@@ -23,11 +23,17 @@ export function DateKanbanSection({
   selectedWorkspace,
   onCardClick,
 }: Props): React.ReactElement {
+  const yesterdayStr = useMemo(
+    () => dayjs(todayStr).subtract(1, 'day').format('YYYY-MM-DD'),
+    [todayStr]
+  );
   const isToday = date === todayStr;
+  const isLive = isToday || date === yesterdayStr;
   const { columns, error, isLoading, isEmpty, retry } = useDateKanbanData(
     date,
     selectedWorkspace,
-    isToday
+    isToday,
+    isLive
   );
 
   return (

--- a/ui/src/features/cockpit/components/__tests__/DateKanbanSection.test.tsx
+++ b/ui/src/features/cockpit/components/__tests__/DateKanbanSection.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DateKanbanSection } from '../DateKanbanSection';
+import { useDateKanbanData } from '../../hooks/useDateKanbanData';
+
+vi.mock('../../hooks/useDateKanbanData', () => ({
+  useDateKanbanData: vi.fn(),
+}));
+
+vi.mock('../KanbanBoard', () => ({
+  KanbanBoard: () => <div>board</div>,
+}));
+
+const useDateKanbanDataMock = vi.mocked(useDateKanbanData);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const defaultReturn = {
+  columns: { queued: [], running: [], review: [], done: [], failed: [] },
+  error: null,
+  isLoading: false,
+  isEmpty: true,
+  retry: vi.fn(),
+};
+
+describe('DateKanbanSection live-update flags', () => {
+  it('passes isToday=true and isLive=true for today', () => {
+    useDateKanbanDataMock.mockReturnValue(defaultReturn);
+
+    render(
+      <DateKanbanSection
+        date="2026-03-22"
+        todayStr="2026-03-22"
+        selectedWorkspace=""
+        onCardClick={() => {}}
+      />
+    );
+
+    expect(useDateKanbanDataMock).toHaveBeenCalledWith(
+      '2026-03-22',
+      '',
+      true,
+      true
+    );
+  });
+
+  it('passes isToday=false and isLive=true for yesterday', () => {
+    useDateKanbanDataMock.mockReturnValue(defaultReturn);
+
+    render(
+      <DateKanbanSection
+        date="2026-03-21"
+        todayStr="2026-03-22"
+        selectedWorkspace=""
+        onCardClick={() => {}}
+      />
+    );
+
+    expect(useDateKanbanDataMock).toHaveBeenCalledWith(
+      '2026-03-21',
+      '',
+      false,
+      true
+    );
+  });
+
+  it('passes isToday=false and isLive=false for older dates', () => {
+    useDateKanbanDataMock.mockReturnValue(defaultReturn);
+
+    render(
+      <DateKanbanSection
+        date="2026-03-20"
+        todayStr="2026-03-22"
+        selectedWorkspace=""
+        onCardClick={() => {}}
+      />
+    );
+
+    expect(useDateKanbanDataMock).toHaveBeenCalledWith(
+      '2026-03-20',
+      '',
+      false,
+      false
+    );
+  });
+});

--- a/ui/src/features/cockpit/hooks/useDateKanbanData.ts
+++ b/ui/src/features/cockpit/hooks/useDateKanbanData.ts
@@ -65,7 +65,8 @@ function groupByStatus(runs: DAGRunSummary[]): KanbanColumns {
 export function useDateKanbanData(
   date: string,
   selectedWorkspace: string,
-  isToday: boolean
+  isToday: boolean,
+  isLive: boolean
 ) {
   const appBarContext = useContext(AppBarContext);
   const { tzOffsetInSec } = useConfig();
@@ -102,7 +103,7 @@ export function useDateKanbanData(
           }),
     }
   );
-  useLiveDAGRuns(mutate, isToday);
+  useLiveDAGRuns(mutate, isLive);
 
   const typedError = useMemo(() => {
     if (!error) {


### PR DESCRIPTION
## Summary
- The cockpit's Yesterday section was not receiving live updates because only the Today section had SSE polling enabled
- Added an `isLive` flag that is true for both Today and Yesterday dates, and passed it to `useLiveDAGRuns` instead of `isToday`
- Computed yesterday's date from `todayStr` using a memoized `dayjs` calculation
- Added unit tests verifying the correct `isToday` and `isLive` flags for today, yesterday, and older dates

## Testing
- `cd ui && pnpm test -- --run src/features/cockpit/components/__tests__/DateKanbanSection.test.tsx`

Closes #1823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for date-based Kanban board functionality.

* **Chores**
  * Optimized date computation performance and improved internal code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->