### PR TITLE
feat(http): add format string config option for response output

### DIFF
--- a/internal/runtime/builtin/http/http.go
+++ b/internal/runtime/builtin/http/http.go
@@ -39,6 +39,7 @@ type httpConfig struct {
 	Body          string            `json:"body" mapstructure:"body"`
 	Silent        bool              `json:"silent" mapstructure:"silent"`
 	Debug         bool              `json:"debug" mapstructure:"debug"`
+	Format        string            `json:"format" mapstructure:"format"`
 	JSON          bool              `json:"json" mapstructure:"json"`
 	SkipTLSVerify bool              `json:"skip_tls_verify" mapstructure:"skip_tls_verify"`
 }
@@ -173,6 +174,10 @@ func (e *http) writeTextResult(rsp *resty.Response) error {
 	return nil
 }
 
+func (e *http) isJSONFormat() bool {
+	return e.cfg.Format == "json" || e.cfg.JSON
+}
+
 func (e *http) Run(_ context.Context) error {
 	rsp, err := e.req.Execute(strings.ToUpper(e.method), e.url)
 	if err != nil {
@@ -181,7 +186,7 @@ func (e *http) Run(_ context.Context) error {
 
 	resCode := rsp.StatusCode()
 
-	if e.cfg.JSON {
+	if e.isJSONFormat() {
 		if err = e.writeJSONResult(rsp); err != nil {
 			return err
 		}

--- a/internal/runtime/builtin/http/http_test.go
+++ b/internal/runtime/builtin/http/http_test.go
@@ -35,7 +35,7 @@ func TestHTTPExecutor_SkipTLSVerify(t *testing.T) {
 				Config: map[string]any{
 					"skip_tls_verify": true,
 					"silent":          true,
-					"json":            true,
+					"format":          "json",
 				},
 			},
 		}
@@ -257,7 +257,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 			ExecutorConfig: core.ExecutorConfig{
 				Type: "http",
 				Config: map[string]any{
-					"json":   true,
+					"format": "json",
 					"silent": false, // Don't suppress headers for this test
 				},
 			},
@@ -333,6 +333,42 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 		assert.Contains(t, output, "Internal Server Error")
 
 		t.Logf("Platform: %s, Error handling verified", runtime.GOOS)
+	})
+
+	t.Run("LegacyJSONBooleanCompatibility", func(t *testing.T) {
+		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "legacy"})
+		}))
+		defer server.Close()
+
+		step := core.Step{
+			Commands: []core.CommandEntry{{Command: "GET", Args: []string{server.URL}}},
+			ExecutorConfig: core.ExecutorConfig{
+				Type: "http",
+				Config: map[string]any{
+					"json": true,
+				},
+			},
+		}
+
+		executor, err := newHTTP(context.Background(), step)
+		require.NoError(t, err)
+
+		out := &testWriter{}
+		httpExec, ok := executor.(*http)
+		require.True(t, ok)
+		httpExec.SetStdout(out)
+		httpExec.SetStderr(&testWriter{})
+
+		err = httpExec.Run(context.Background())
+		assert.NoError(t, err)
+
+		var jsonResponse httpJSONResult
+		err = json.Unmarshal([]byte(out.String()), &jsonResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, jsonResponse.StatusCode)
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds a `format` string field to the HTTP executor config, so users can write `format: "json"` instead of `json: true`. The existing `json` boolean continues to work for backwards compatibility.

## Why this matters

Issue #578 requested changing from `json: boolean` to `format: string` to support future output format options. The current `json: true` config works but limits extensibility.

## Changes

- Added `Format string` field to `httpConfig` struct in `internal/runtime/builtin/http/http.go`
- Added `isJSONFormat()` helper that returns true when `Format == "json"` OR legacy `JSON == true`
- Updated `Run()` to use `isJSONFormat()` instead of checking `e.cfg.JSON` directly
- Updated existing tests to use `format: "json"` config
- Added `LegacyJSONBooleanCompatibility` test to verify `json: true` still works

## Testing

- `go vet ./internal/runtime/builtin/http/...` - passed
- `go test ./internal/runtime/builtin/http/... -v` - all tests pass, including new legacy compatibility test

Fixes #578

This contribution was developed with AI assistance (Claude Code + Codex CLI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP executor now accepts a `format` configuration option, providing greater flexibility in specifying desired response output formatting.

* **Improvements**
  * Full backward compatibility ensured: existing configurations using the legacy `json` boolean flag remain fully supported without any changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->