### PR TITLE
fix: keep doc folders alphabetical under file sorting

### DIFF
--- a/internal/persis/filedoc/store.go
+++ b/internal/persis/filedoc/store.go
@@ -749,30 +749,79 @@ func propagateModTime(nodes []*agent.DocTreeNode) time.Time {
 	return maxTime
 }
 
+func compareNodeNames(a, b *agent.DocTreeNode) int {
+	if cmp := strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name)); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(a.ID, b.ID)
+}
+
+func compareNodeModTime(a, b *agent.DocTreeNode) int {
+	switch {
+	case a.ModTime.Before(b.ModTime):
+		return -1
+	case a.ModTime.After(b.ModTime):
+		return 1
+	default:
+		return compareNodeNames(a, b)
+	}
+}
+
+func reverseCompare(cmp int) int {
+	switch {
+	case cmp < 0:
+		return 1
+	case cmp > 0:
+		return -1
+	default:
+		return 0
+	}
+}
+
+func compareTreeNodes(a, b *agent.DocTreeNode, sortField, sortOrder string) int {
+	switch sortField {
+	case "type":
+		var cmp int
+		switch a.Type {
+		case b.Type:
+			cmp = compareNodeNames(a, b)
+		case "directory":
+			cmp = -1
+		default:
+			cmp = 1
+		}
+		if sortOrder == "desc" {
+			return reverseCompare(cmp)
+		}
+		return cmp
+	case "mtime":
+		if a.Type != b.Type {
+			if a.Type == "directory" {
+				return -1
+			}
+			return 1
+		}
+		if a.Type == "directory" {
+			return compareNodeNames(a, b)
+		}
+		cmp := compareNodeModTime(a, b)
+		if sortOrder == "desc" {
+			return reverseCompare(cmp)
+		}
+		return cmp
+	default: // "name"
+		cmp := compareNodeNames(a, b)
+		if sortOrder == "desc" {
+			return reverseCompare(cmp)
+		}
+		return cmp
+	}
+}
+
 // sortTreeNodes sorts nodes recursively according to the given sort field and order.
 func sortTreeNodes(nodes []*agent.DocTreeNode, sortField, sortOrder string) {
 	sort.Slice(nodes, func(i, j int) bool {
-		var less bool
-		switch sortField {
-		case "type":
-			if nodes[i].Type != nodes[j].Type {
-				less = nodes[i].Type == "directory"
-			} else {
-				less = strings.ToLower(nodes[i].Name) < strings.ToLower(nodes[j].Name)
-			}
-		case "mtime":
-			if nodes[i].ModTime.Equal(nodes[j].ModTime) {
-				less = strings.ToLower(nodes[i].Name) < strings.ToLower(nodes[j].Name)
-			} else {
-				less = nodes[i].ModTime.Before(nodes[j].ModTime)
-			}
-		default: // "name"
-			less = strings.ToLower(nodes[i].Name) < strings.ToLower(nodes[j].Name)
-		}
-		if sortOrder == "desc" {
-			return !less
-		}
-		return less
+		return compareTreeNodes(nodes[i], nodes[j], sortField, sortOrder) < 0
 	})
 	for _, node := range nodes {
 		if len(node.Children) > 0 {

--- a/internal/persis/filedoc/store_test.go
+++ b/internal/persis/filedoc/store_test.go
@@ -1817,6 +1817,36 @@ func TestListTreeSortNestedChildren(t *testing.T) {
 	assert.Equal(t, "dir/c-child", result.Items[0].Children[2].ID)
 }
 
+func TestListTreeSortMtimeKeepsDirectoriesAlphabetical(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, "alpha/child", "alpha"))
+	require.NoError(t, store.Create(ctx, "beta/child", "beta"))
+	require.NoError(t, store.Create(ctx, "old-file", "old"))
+	require.NoError(t, store.Create(ctx, "new-file", "new"))
+
+	now := time.Now()
+	setModTime(t, filepath.Join(store.baseDir, "alpha", "child.md"), now.Add(-4*time.Hour))
+	setModTime(t, filepath.Join(store.baseDir, "beta", "child.md"), now.Add(-1*time.Hour))
+	setModTime(t, filepath.Join(store.baseDir, "old-file.md"), now.Add(-3*time.Hour))
+	setModTime(t, filepath.Join(store.baseDir, "new-file.md"), now)
+
+	result, err := store.List(ctx, agent.ListDocsOptions{
+		Page:    1,
+		PerPage: 50,
+		Sort:    agent.DocSortFieldMTime,
+		Order:   agent.DocSortOrderDesc,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 4)
+
+	assert.Equal(t, "alpha", result.Items[0].ID)
+	assert.Equal(t, "beta", result.Items[1].ID)
+	assert.Equal(t, "new-file", result.Items[2].ID)
+	assert.Equal(t, "old-file", result.Items[3].ID)
+}
+
 func TestListTreeSortPaginationConsistency(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- keep document tree directories alphabetized when sorting by modified time
- continue sorting files by the selected file sort order
- add regression coverage for mixed directory and file ordering

## Testing
- go test ./internal/persis/filedoc -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sorting implementation for file and directory listings.

* **Tests**
  * Added tests for sorting files by modification time while preserving directory ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->