### PR TITLE
fix: clean up failed command temp scripts

### DIFF
--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -30,12 +30,11 @@ var _ executor.Executor = (*commandExecutor)(nil)
 var _ executor.ExitCoder = (*commandExecutor)(nil)
 
 type commandExecutor struct {
-	mu           sync.Mutex
-	config       *commandConfig
-	cmd          *exec.Cmd
-	scriptFile   string
-	exitCode     int
-	scriptFailed bool // set on failure to prevent temp script cleanup
+	mu         sync.Mutex
+	config     *commandConfig
+	cmd        *exec.Cmd
+	scriptFile string
+	exitCode   int
 	// stderrTail stores a rolling tail of recent stderr lines
 	stderrTail *executor.TailWriter
 }
@@ -56,9 +55,7 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 		}
 		e.scriptFile = scriptFile
 		defer func() {
-			if !e.scriptFailed {
-				_ = os.Remove(scriptFile)
-			}
+			_ = os.Remove(scriptFile)
 		}()
 	}
 	// Wrap stderr with a tailing writer so we can include recent
@@ -88,9 +85,6 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 	if err := e.cmd.Start(); err != nil {
 		e.exitCode = exitCodeFromError(err)
 		e.mu.Unlock()
-		if e.config.Script != "" && e.scriptFile != "" {
-			e.scriptFailed = true
-		}
 		if tail := e.stderrTail.Tail(); tail != "" {
 			tail = e.annotateStderrTail(tail)
 			return fmt.Errorf("%w\nrecent stderr (tail):\n%s", err, tail)
@@ -119,9 +113,6 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 	case err := <-waitDone:
 		if err != nil {
 			e.exitCode = exitCodeFromError(err)
-			if e.config.Script != "" && e.scriptFile != "" {
-				e.scriptFailed = true
-			}
 			if tail := e.stderrTail.Tail(); tail != "" {
 				tail = e.annotateStderrTail(tail)
 				return fmt.Errorf("%w\nrecent stderr (tail):\n%s", err, tail)

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dagu-org/dagu/internal/core"
 	"github.com/dagu-org/dagu/internal/runtime"
@@ -987,11 +988,16 @@ func TestCommandExecutor_ScriptErrorAnnotation(t *testing.T) {
 	assert.Contains(t, stderrOutput, "echo line4")
 	// Failing line should be marked with >>
 	assert.Contains(t, stderrOutput, " >>    3: nonexistent_command_xyz_12345")
+
+	ce := exec.(*commandExecutor)
+	assert.NotEmpty(t, ce.scriptFile)
+	_, statErr := os.Stat(ce.scriptFile)
+	assert.True(t, os.IsNotExist(statErr), "script file should be deleted after failure")
 }
 
-// TestCommandExecutor_ScriptPreservedOnFailure tests that temp script files
-// are preserved when execution fails.
-func TestCommandExecutor_ScriptPreservedOnFailure(t *testing.T) {
+// TestCommandExecutor_ScriptCleanedOnFailure tests that temp script files
+// are cleaned up when execution fails.
+func TestCommandExecutor_ScriptCleanedOnFailure(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("Skipping Unix-specific test on Windows")
 	}
@@ -1016,9 +1022,7 @@ func TestCommandExecutor_ScriptPreservedOnFailure(t *testing.T) {
 	ce := exec.(*commandExecutor)
 	assert.NotEmpty(t, ce.scriptFile)
 	_, statErr := os.Stat(ce.scriptFile)
-	assert.NoError(t, statErr, "script file should be preserved on failure")
-
-	t.Cleanup(func() { _ = os.Remove(ce.scriptFile) })
+	assert.True(t, os.IsNotExist(statErr), "script file should be deleted on failure")
 }
 
 // TestCommandExecutor_ScriptCleanedOnSuccess tests that temp script files
@@ -1047,6 +1051,48 @@ func TestCommandExecutor_ScriptCleanedOnSuccess(t *testing.T) {
 	ce := exec.(*commandExecutor)
 	_, statErr := os.Stat(ce.scriptFile)
 	assert.True(t, os.IsNotExist(statErr), "script file should be deleted on success")
+}
+
+// TestCommandExecutor_ScriptCleanedOnCancel tests that temp script files
+// are cleaned up when execution stops via context cancellation.
+func TestCommandExecutor_ScriptCleanedOnCancel(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipping Unix-specific test on Windows")
+	}
+
+	tmpDir := t.TempDir()
+
+	step := core.Step{
+		Name:   "test",
+		Script: "sleep 10",
+		Dir:    tmpDir,
+	}
+
+	baseCtx := setupTestContext(t, nil, step)
+	env := runtime.GetEnv(baseCtx)
+	env.WorkingDir = tmpDir
+	baseCtx = runtime.WithEnv(baseCtx, env)
+
+	ctx, cancel := context.WithTimeout(baseCtx, 50*time.Millisecond)
+	defer cancel()
+
+	exec, err := NewCommand(ctx, step)
+	require.NoError(t, err)
+
+	err = exec.Run(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	ce := exec.(*commandExecutor)
+	assert.NotEmpty(t, ce.scriptFile)
+	_, statErr := os.Stat(ce.scriptFile)
+	assert.True(t, os.IsNotExist(statErr), "script file should be deleted after cancellation")
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), "dagu_script-"),
+			"temporary script file should be cleaned up after cancellation: %s", entry.Name())
+	}
 }
 
 // TestCommandExecutor_WorkingDirectory tests working directory is set correctly


### PR DESCRIPTION
## Summary
- always remove generated `dagu_script-*` wrapper files after command execution returns
- keep script error annotation behavior intact while deleting temp scripts on failure
- add regressions for failure and timeout cleanup paths

## Testing
- go test ./internal/runtime/builtin/command -count=1
- make fmt
- go test ./internal/runtime/builtin/command -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary script file cleanup to ensure files are reliably deleted in all execution scenarios, including when commands fail or are cancelled, preventing accumulation of temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->