### PR TITLE
fix(config): preserve implicit local timezone behavior

### DIFF
--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -149,7 +149,7 @@ type MonitoringConfig struct {
 type Core struct {
 	Debug         bool
 	LogFormat     string // "json" or "text"
-	TZ            string // e.g., "UTC", "America/New_York"
+	TZ            string // e.g., "UTC", "UTC+9", "America/New_York"
 	TzOffsetInSec int
 	Location      *time.Location
 	DefaultShell  string // Platform default if empty

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -310,6 +310,13 @@ func (l *ConfigLoader) loadCoreConfig(cfg *Config, def Definition) error {
 	if err := setTimezone(&cfg.Core); err != nil {
 		return fmt.Errorf("failed to set timezone: %w", err)
 	}
+	if def.TZ != "" {
+		// Only propagate an explicit timezone configuration to child
+		// processes. The implicit local-time cfg.TZ value is a legacy
+		// display string and must not overwrite an inherited TZ env var.
+		baseEnv.variables = withEnvOverrides(baseEnv.variables, fmt.Sprintf("TZ=%s", cfg.Core.TZ))
+		cfg.Core.BaseEnv = baseEnv
+	}
 
 	return nil
 }
@@ -328,9 +335,6 @@ func (l *ConfigLoader) finalizeBaseEnv(cfg *Config) {
 	}
 	if cfg.Core.DefaultShell != "" {
 		overrides = append(overrides, fmt.Sprintf("SHELL=%s", cfg.Core.DefaultShell))
-	}
-	if cfg.Core.TZ != "" {
-		overrides = append(overrides, fmt.Sprintf("TZ=%s", cfg.Core.TZ))
 	}
 
 	cfg.Core.BaseEnv.variables = withEnvOverrides(cfg.Core.BaseEnv.variables, overrides...)

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -29,6 +29,44 @@ func testLoadWithError(t *testing.T, opts ...ConfigLoaderOption) error {
 	return err
 }
 
+func preserveTZEnv(t *testing.T) {
+	t.Helper()
+
+	oldTZ, hadTZ := os.LookupEnv("TZ")
+	t.Cleanup(func() {
+		if hadTZ {
+			if err := os.Setenv("TZ", oldTZ); err != nil {
+				t.Fatalf("restore TZ: %v", err)
+			}
+			return
+		}
+		if err := os.Unsetenv("TZ"); err != nil {
+			t.Fatalf("unset TZ: %v", err)
+		}
+	})
+}
+
+func envValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if after, ok := strings.CutPrefix(entry, prefix); ok {
+			return after, true
+		}
+	}
+	return "", false
+}
+
+func envKeyCount(env []string, key string) int {
+	prefix := key + "="
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
 func TestLoad_Env(t *testing.T) {
 	tempDir := t.TempDir()
 	configFile := filepath.Join(tempDir, "config.yaml")
@@ -328,6 +366,8 @@ func TestLoad_BaseEnvIncludesConfigDerivedOverrides(t *testing.T) {
 	tempDir := t.TempDir()
 	configFile := filepath.Join(tempDir, "config.yaml")
 	executablePath := filepath.Join(tempDir, "bin", "dagu")
+	preserveTZEnv(t)
+	require.NoError(t, os.Setenv("TZ", "America/Los_Angeles"))
 	err := os.WriteFile(configFile, fmt.Appendf(nil, `
 default_shell: /bin/sh
 tz: UTC
@@ -344,6 +384,45 @@ paths:
 	require.Contains(t, baseEnv, fmt.Sprintf("DAGU_EXECUTABLE=%s", executablePath))
 	require.Contains(t, baseEnv, "SHELL=/bin/sh")
 	require.Contains(t, baseEnv, "TZ=UTC")
+	require.NotContains(t, baseEnv, "TZ=America/Los_Angeles")
+	require.Equal(t, 1, envKeyCount(baseEnv, "TZ"))
+}
+
+func TestLoad_BaseEnvPreservesInheritedTZWhenTimezoneConfigUnset(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config.yaml")
+	preserveTZEnv(t)
+	require.NoError(t, os.Setenv("TZ", "America/Los_Angeles"))
+	require.NoError(t, os.WriteFile(configFile, []byte("# minimal config"), 0o600))
+
+	cfg := testLoad(t, WithConfigFile(configFile), WithAppHomeDir(tempDir))
+	baseEnv := cfg.Core.BaseEnv.AsSlice()
+
+	tzValue, ok := envValue(baseEnv, "TZ")
+	require.True(t, ok)
+	require.Equal(t, "America/Los_Angeles", tzValue)
+	require.Equal(t, 1, envKeyCount(baseEnv, "TZ"))
+	require.NotEmpty(t, cfg.Core.TZ)
+}
+
+func TestLoad_BaseEnvDoesNotInjectSyntheticTZWhenTimezoneConfigUnset(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config.yaml")
+	preserveTZEnv(t)
+	require.NoError(t, os.Unsetenv("TZ"))
+	require.NoError(t, os.WriteFile(configFile, []byte("# minimal config"), 0o600))
+
+	cfg := testLoad(t, WithConfigFile(configFile), WithAppHomeDir(tempDir))
+	baseEnv := cfg.Core.BaseEnv.AsSlice()
+
+	_, ok := envValue(baseEnv, "TZ")
+	require.False(t, ok)
+
+	expectedTZ := "UTC"
+	if cfg.Core.TzOffsetInSec != 0 {
+		expectedTZ = fmt.Sprintf("UTC%+d", cfg.Core.TzOffsetInSec/3600)
+	}
+	require.Equal(t, expectedTZ, cfg.Core.TZ)
 }
 
 func TestLoad_YAML(t *testing.T) {

--- a/internal/cmn/config/timezone_test.go
+++ b/internal/cmn/config/timezone_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -11,10 +12,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func preserveTimezoneState(t *testing.T) {
+	t.Helper()
+
+	oldLocal := time.Local
+	oldTZ, hadTZ := os.LookupEnv("TZ")
+
+	t.Cleanup(func() {
+		time.Local = oldLocal
+		if hadTZ {
+			if err := os.Setenv("TZ", oldTZ); err != nil {
+				t.Fatalf("restore TZ: %v", err)
+			}
+			return
+		}
+		if err := os.Unsetenv("TZ"); err != nil {
+			t.Fatalf("unset TZ: %v", err)
+		}
+	})
+}
+
 func TestSetTimezone(t *testing.T) {
-	t.Parallel()
 	t.Run("ValidTimezone", func(t *testing.T) {
-		t.Parallel()
+		preserveTimezoneState(t)
 		g := &Core{TZ: "America/New_York"}
 		err := setTimezone(g)
 		require.NoError(t, err)
@@ -22,12 +42,13 @@ func TestSetTimezone(t *testing.T) {
 		assert.Equal(t, "America/New_York", g.TZ)
 		assert.NotNil(t, g.Location)
 		assert.Equal(t, "America/New_York", g.Location.String())
+		assert.Equal(t, "America/New_York", os.Getenv("TZ"))
 		// New York is UTC-5 or UTC-4 depending on DST
 		assert.NotEqual(t, 0, g.TzOffsetInSec)
 	})
 
 	t.Run("UTCTimezone", func(t *testing.T) {
-		t.Parallel()
+		preserveTimezoneState(t)
 		g := &Core{TZ: "UTC"}
 		err := setTimezone(g)
 		require.NoError(t, err)
@@ -35,10 +56,11 @@ func TestSetTimezone(t *testing.T) {
 		assert.Equal(t, "UTC", g.TZ)
 		assert.NotNil(t, g.Location)
 		assert.Equal(t, 0, g.TzOffsetInSec)
+		assert.Equal(t, "UTC", os.Getenv("TZ"))
 	})
 
 	t.Run("AsiaTokyoTimezone", func(t *testing.T) {
-		t.Parallel()
+		preserveTimezoneState(t)
 		g := &Core{TZ: "Asia/Tokyo"}
 		err := setTimezone(g)
 		require.NoError(t, err)
@@ -46,29 +68,32 @@ func TestSetTimezone(t *testing.T) {
 		assert.Equal(t, "Asia/Tokyo", g.TZ)
 		assert.NotNil(t, g.Location)
 		assert.Equal(t, 9*3600, g.TzOffsetInSec) // Tokyo is UTC+9
+		assert.Equal(t, "Asia/Tokyo", os.Getenv("TZ"))
 	})
 
 	t.Run("InvalidTimezone", func(t *testing.T) {
-		t.Parallel()
+		preserveTimezoneState(t)
 		g := &Core{TZ: "Invalid/Timezone"}
 		err := setTimezone(g)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load timezone")
 	})
 
-	t.Run("EmptyTimezoneUsesLocal", func(t *testing.T) {
-		t.Parallel()
+	t.Run("EmptyTimezoneUsesLegacyLocalDisplay", func(t *testing.T) {
+		preserveTimezoneState(t)
+		time.Local = time.FixedZone("JST", 9*3600)
+		require.NoError(t, os.Unsetenv("TZ"))
+
 		g := &Core{TZ: ""}
 		err := setTimezone(g)
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, g.TZ)
+		assert.Equal(t, "UTC+9", g.TZ)
 		assert.NotNil(t, g.Location)
+		assert.Same(t, time.Local, g.Location)
+		assert.Equal(t, 9*3600, g.TzOffsetInSec)
 
-		// The TZ value must be loadable so child processes get correct local time.
-		if g.TZ != "UTC" {
-			_, loadErr := time.LoadLocation(g.TZ)
-			assert.NoError(t, loadErr, "cfg.TZ %q should be a valid timezone", g.TZ)
-		}
+		_, exists := os.LookupEnv("TZ")
+		assert.False(t, exists)
 	})
 }

--- a/internal/cmn/config/timzone.go
+++ b/internal/cmn/config/timzone.go
@@ -18,7 +18,9 @@ import (
 //
 // If cfg.TZ is empty, it uses the system local timezone: cfg.Location is set to time.Local,
 // cfg.TzOffsetInSec is set to the current local offset in seconds, and cfg.TZ is populated with
-// the IANA zone name (e.g. "Asia/Tokyo") or a POSIX fallback (e.g. "UTC-5") when unavailable.
+// the legacy display string "UTC" or "UTC±H" where H is the offset in hours (e.g. "UTC+2"
+// or "UTC-5"). This value is for configuration/UI display and is not required to be a
+// loadable IANA timezone.
 //
 // Returns an error only when loading a specified timezone or setting the TZ environment variable fails.
 func setTimezone(cfg *Core) error {
@@ -36,24 +38,16 @@ func setTimezone(cfg *Core) error {
 		return nil
 	}
 
-	// Use local timezone when TZ is not specified
-	cfg.Location = time.Local
-	_, cfg.TzOffsetInSec = time.Now().Zone()
-
-	// Prefer the IANA zone name (e.g. "Asia/Tokyo") so that child
-	// processes see a correct TZ value.  time.Local.String() returns the
-	// IANA name on most platforms; fall back to a POSIX-style string only
-	// when it is unavailable.  Note: POSIX TZ signs are inverted relative
-	// to ISO 8601 (east-of-UTC is negative), so we negate the offset.
-	name := time.Local.String()
-	if name == "Local" || name == "" {
-		if cfg.TzOffsetInSec != 0 {
-			name = fmt.Sprintf("UTC%+d", -cfg.TzOffsetInSec/3600)
-		} else {
-			name = "UTC"
-		}
+	// Use local timezone when TZ is not specified.
+	_, tzOffsetInSec := time.Now().Zone()
+	tz := "UTC"
+	if tzOffsetInSec != 0 {
+		tz = fmt.Sprintf("UTC%+d", tzOffsetInSec/3600)
 	}
-	cfg.TZ = name
+
+	cfg.Location = time.Local
+	cfg.TZ = tz
+	cfg.TzOffsetInSec = tzOffsetInSec
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- restore the legacy implicit-local `cfg.TZ` display contract (`UTC` / `UTC±H`)
- stop propagating that derived display string into child-process `TZ` unless the timezone was explicitly configured
- harden timezone/config loader coverage around explicit overrides and inherited `TZ` preservation

## Testing
- `DAGU_HOME=/tmp/dagu-config-home GOCACHE=/tmp/go-build-configfix2 go test ./internal/cmn/config -count=1`
- `GOCACHE=/tmp/go-build-configfix3 go test ./internal/cmn/config -run "TestSetTimezone|TestLoad_BaseEnv" -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples showing UTC offset notation for timezone configuration.

* **Tests**
  * Added test cases verifying timezone inheritance and fallback behavior.
  * Added test helpers to prevent timezone-related test contamination.

* **Refactor**
  * Refined timezone configuration propagation to prioritize config-specified values over inherited system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->