### PR TITLE
fix: initialize compacted session loop immediately

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -530,6 +530,16 @@ func (a *API) newManagedSession(ctx context.Context, id string, user UserIdentit
 	return mgr
 }
 
+func (a *API) ensureSessionLoop(mgr *SessionManager, provider llm.Provider, cfg sessionRuntimeConfig) error {
+	if mgr == nil {
+		return errors.New("session manager is required")
+	}
+	if provider == nil {
+		return errors.New("LLM provider is required")
+	}
+	return mgr.ensureLoop(provider, cfg.modelID, cfg.resolvedModel)
+}
+
 func (a *API) buildSystemPrompt(ctx context.Context, role auth.Role, dagName string, enabledSkills []string, soul *Soul) string {
 	return GenerateSystemPrompt(SystemPromptParams{
 		Env:             a.environment,
@@ -1253,6 +1263,15 @@ func (a *API) CompactSessionIfNeeded(ctx context.Context, sessionID string, user
 		newMgr.queuedChatMessages = append(newMgr.queuedChatMessages, queuedChatMessages...)
 		newMgr.flushingQueuedChat = flushingQueuedChat
 		newMgr.mu.Unlock()
+	}
+	if err := a.ensureSessionLoop(newMgr, provider, runtimeCfg); err != nil {
+		a.sessions.Delete(newID)
+		if a.store != nil {
+			if delErr := a.store.DeleteSession(ctx, newID); delErr != nil && !errors.Is(delErr, ErrSessionNotFound) {
+				a.logger.Warn("Failed to roll back compacted session after loop init error", "session_id", newID, "error", delErr)
+			}
+		}
+		return "", false, err
 	}
 
 	_ = mgr.Cancel(ctx)

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -1166,8 +1166,27 @@ func TestAPI_CompactSessionIfNeeded_CreatesSummarySession(t *testing.T) {
 	mgrVal, ok := api.sessions.Load(newSessionID)
 	require.True(t, ok)
 	mgr := mgrVal.(*SessionManager)
+	t.Cleanup(func() {
+		_ = mgr.Cancel(context.Background())
+	})
 	assert.Equal(t, "briefing", mgr.dagName)
 	assert.True(t, mgr.safeMode)
+	require.NotNil(t, mgr.loop)
+
+	skillCount := len(mgr.enabledSkills)
+	var skillSummaries []SkillSummary
+	if skillCount > 0 && skillCount <= SkillListThreshold {
+		skillSummaries = LoadSkillSummaries(context.Background(), mgr.skillStore, mgr.enabledSkills)
+	}
+	expectedPrompt := GenerateSystemPrompt(SystemPromptParams{
+		Env:             mgr.environment,
+		Memory:          mgr.loadMemory(),
+		Role:            mgr.user.Role,
+		AvailableSkills: skillSummaries,
+		SkillCount:      skillCount,
+		Soul:            mgr.soul,
+	})
+	assert.Equal(t, expectedPrompt, mgr.loop.systemPrompt)
 
 	detail, err := api.GetSessionDetail(context.Background(), newSessionID, user.UserID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- initialize the continuation session loop immediately after compaction
- ensure the normal generated Dagu system prompt is already active for the compacted session
- add regression coverage for compacted-session loop initialization and prompt generation

## Testing
- go test ./internal/agent -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling robustness by adding validation checks and automatic cleanup when session creation encounters errors. Failed sessions are now properly rolled back to prevent orphaned data.

* **Tests**
  * Enhanced test coverage for session initialization and system prompt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->