### PR TITLE
fix: reject unknown named DAG start parameters

### DIFF
--- a/internal/core/spec/dag_params_inline.go
+++ b/internal/core/spec/dag_params_inline.go
@@ -324,8 +324,9 @@ func validateInlineDefault(def core.ParamDef, compiledPattern *regexp.Regexp) er
 
 func compileInlineParamSchema(defs []core.ParamDef) (*compiledInlineParamSchema, error) {
 	root := &jsonschema.Schema{
-		Type:       "object",
-		Properties: map[string]*jsonschema.Schema{},
+		Type:                 "object",
+		Properties:           map[string]*jsonschema.Schema{},
+		AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
 	}
 	properties := map[string]*jsonschema.Schema{}
 	order := make([]string, 0, len(defs))

--- a/internal/core/spec/dag_params_runtime.go
+++ b/internal/core/spec/dag_params_runtime.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -81,7 +82,9 @@ func resolveLegacyRuntimePairs(entries []dagParamEntry, rawParams string, params
 		if err != nil {
 			return nil, core.NewValidationError("params", rawParams, fmt.Errorf("%w: %s", ErrInvalidParamValue, err))
 		}
-		overrideParams(&finalPairs, overridePairs)
+		if err := overrideParams(&finalPairs, overridePairs); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(paramsList) > 0 {
@@ -89,7 +92,9 @@ func resolveLegacyRuntimePairs(entries []dagParamEntry, rawParams string, params
 		if err != nil {
 			return nil, core.NewValidationError("params", paramsList, fmt.Errorf("%w: %s", ErrInvalidParamValue, err))
 		}
-		overrideParams(&finalPairs, overridePairs)
+		if err := overrideParams(&finalPairs, overridePairs); err != nil {
+			return nil, err
+		}
 	}
 
 	return finalPairs, nil
@@ -161,6 +166,10 @@ func parseOverridePairs(rawParams string, paramsList []string) ([]paramPair, err
 }
 
 func applyOverridePairsTracked(entries []dagParamEntry, override []paramPair) ([]dagParamEntry, []bool, error) {
+	if err := rejectUnknownNamedParamsForEntries(entries, override); err != nil {
+		return nil, nil, err
+	}
+
 	result := cloneParamEntries(entries)
 	overridden := make([]bool, len(result))
 	positionalIndex := 0
@@ -200,6 +209,46 @@ func applyOverridePairsTracked(entries []dagParamEntry, override []paramPair) ([
 	}
 
 	return result, overridden, nil
+}
+
+// rejectUnknownNamedParamsForEntries checks that all named overrides match a
+// declared entry name. Only enforced when at least one entry has a non-empty,
+// non-numeric Name (the DAG declares named params).
+func rejectUnknownNamedParamsForEntries(entries []dagParamEntry, overrides []paramPair) error {
+	declaredNames := make(map[string]struct{})
+	for _, e := range entries {
+		if e.Name != "" && !isPositionalName(e.Name) {
+			declaredNames[e.Name] = struct{}{}
+		}
+	}
+	if len(declaredNames) == 0 {
+		return nil
+	}
+
+	var unknown []string
+	for _, p := range overrides {
+		if p.Name == "" || isPositionalName(p.Name) {
+			continue
+		}
+		if _, ok := declaredNames[p.Name]; !ok {
+			unknown = append(unknown, p.Name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	accepted := make([]string, 0, len(declaredNames))
+	for name := range declaredNames {
+		accepted = append(accepted, name)
+	}
+	sort.Strings(accepted)
+
+	return fmt.Errorf(
+		"unknown parameter(s): %s; accepted parameters are: %s",
+		quotedNames(unknown),
+		strings.Join(accepted, ", "),
+	)
 }
 
 func runtimePairsFromEntries(entries []dagParamEntry) []paramPair {

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -96,9 +96,9 @@ func TestBuildParamsJSON(t *testing.T) {
 		},
 		{
 			name: "OverridesMergedAndSerialized",
-			ctx:  testBuildContextWithOpts(BuildOpts{Parameters: "FOO=baz EXTRA=qux"}),
+			ctx:  testBuildContextWithOpts(BuildOpts{Parameters: "FOO=baz COUNT=2"}),
 			dag:  &dag{Params: "FOO=bar COUNT=1"},
-			want: `{"FOO":"baz","COUNT":"1","EXTRA":"qux"}`,
+			want: `{"FOO":"baz","COUNT":"2"}`,
 		},
 		{
 			name: "PreservesRawJSONInput",

--- a/internal/core/spec/params.go
+++ b/internal/core/spec/params.go
@@ -14,7 +14,11 @@ import (
 	"github.com/dagu-org/dagu/internal/core"
 )
 
-func overrideParams(paramPairs *[]paramPair, override []paramPair) {
+func overrideParams(paramPairs *[]paramPair, override []paramPair) error {
+	if err := rejectUnknownNamedParams(*paramPairs, override); err != nil {
+		return err
+	}
+
 	// Override the default parameters with the command line parameters
 	pairsIndex := make(map[string]int)
 	for i, paramPair := range *paramPairs {
@@ -39,6 +43,65 @@ func overrideParams(paramPairs *[]paramPair, override []paramPair) {
 			*paramPairs = append(*paramPairs, paramPair)
 		}
 	}
+	return nil
+}
+
+// rejectUnknownNamedParams checks that all named overrides match a declared
+// parameter name. It only enforces this when at least one default has a
+// non-empty, non-numeric Name (i.e. the DAG declares named params).
+// Positional defaults get numeric names like "1", "2" from parseParams;
+// these are excluded from the declared set so they don't block named overrides.
+func rejectUnknownNamedParams(declared []paramPair, overrides []paramPair) error {
+	declaredNames := make(map[string]struct{})
+	for _, p := range declared {
+		if p.Name != "" && !isPositionalName(p.Name) {
+			declaredNames[p.Name] = struct{}{}
+		}
+	}
+	if len(declaredNames) == 0 {
+		return nil // all positional or no defaults — accept everything
+	}
+
+	var unknown []string
+	for _, p := range overrides {
+		if p.Name == "" || isPositionalName(p.Name) {
+			continue
+		}
+		if _, ok := declaredNames[p.Name]; !ok {
+			unknown = append(unknown, p.Name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	accepted := make([]string, 0, len(declaredNames))
+	for name := range declaredNames {
+		accepted = append(accepted, name)
+	}
+	sort.Strings(accepted)
+
+	return fmt.Errorf(
+		"unknown parameter(s): %s; accepted parameters are: %s",
+		quotedNames(unknown),
+		strings.Join(accepted, ", "),
+	)
+}
+
+// isPositionalName returns true if the name is a numeric index assigned to
+// positional params (e.g. "1", "2", "3").
+func isPositionalName(name string) bool {
+	_, err := strconv.Atoi(name)
+	return err == nil
+}
+
+func quotedNames(names []string) string {
+	sort.Strings(names)
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = fmt.Sprintf("%q", n)
+	}
+	return strings.Join(quoted, ", ")
 }
 
 // parseParams parses and processes the parameters for the DAG.

--- a/internal/core/spec/params_test.go
+++ b/internal/core/spec/params_test.go
@@ -648,14 +648,14 @@ func TestOverrideParams(t *testing.T) {
 		override := []paramPair{
 			{Name: "foo", Value: "overridden"},
 		}
-		overrideParams(&params, override)
+		require.NoError(t, overrideParams(&params, override))
 		assert.Equal(t, []paramPair{
 			{Name: "foo", Value: "overridden"},
 			{Name: "bar", Value: "keep"},
 		}, params)
 	})
 
-	t.Run("AddNewNamedParam", func(t *testing.T) {
+	t.Run("RejectsUnknownNamedParam", func(t *testing.T) {
 		t.Parallel()
 		params := []paramPair{
 			{Name: "foo", Value: "bar"},
@@ -663,11 +663,10 @@ func TestOverrideParams(t *testing.T) {
 		override := []paramPair{
 			{Name: "baz", Value: "qux"},
 		}
-		overrideParams(&params, override)
-		assert.Equal(t, []paramPair{
-			{Name: "foo", Value: "bar"},
-			{Name: "baz", Value: "qux"},
-		}, params)
+		err := overrideParams(&params, override)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"baz"`)
+		assert.Contains(t, err.Error(), "accepted parameters are: foo")
 	})
 
 	t.Run("OverrideByPosition", func(t *testing.T) {
@@ -679,7 +678,7 @@ func TestOverrideParams(t *testing.T) {
 		override := []paramPair{
 			{Name: "", Value: "new-first"},
 		}
-		overrideParams(&params, override)
+		require.NoError(t, overrideParams(&params, override))
 		assert.Equal(t, []paramPair{
 			{Name: "", Value: "new-first"},
 			{Name: "", Value: "second"},
@@ -695,7 +694,7 @@ func TestOverrideParams(t *testing.T) {
 			{Name: "", Value: "new-first"},
 			{Name: "", Value: "new-second"},
 		}
-		overrideParams(&params, override)
+		require.NoError(t, overrideParams(&params, override))
 		assert.Equal(t, []paramPair{
 			{Name: "", Value: "new-first"},
 			{Name: "", Value: "new-second"},
@@ -707,7 +706,7 @@ func TestOverrideParams(t *testing.T) {
 		params := []paramPair{
 			{Name: "foo", Value: "bar"},
 		}
-		overrideParams(&params, []paramPair{})
+		require.NoError(t, overrideParams(&params, []paramPair{}))
 		assert.Equal(t, []paramPair{
 			{Name: "foo", Value: "bar"},
 		}, params)
@@ -719,10 +718,23 @@ func TestOverrideParams(t *testing.T) {
 		override := []paramPair{
 			{Name: "foo", Value: "bar"},
 		}
-		overrideParams(&params, override)
+		require.NoError(t, overrideParams(&params, override))
 		assert.Equal(t, []paramPair{
 			{Name: "foo", Value: "bar"},
 		}, params)
+	})
+
+	t.Run("PositionalOnlyDefaultsAcceptNamedOverrides", func(t *testing.T) {
+		t.Parallel()
+		params := []paramPair{
+			{Name: "", Value: "val1"},
+			{Name: "", Value: "val2"},
+		}
+		override := []paramPair{
+			{Name: "foo", Value: "bar"},
+		}
+		require.NoError(t, overrideParams(&params, override))
+		assert.Len(t, params, 3)
 	})
 }
 

--- a/internal/core/spec/runtime_params_test.go
+++ b/internal/core/spec/runtime_params_test.go
@@ -235,6 +235,177 @@ params:
 	assert.JSONEq(t, `{"base_dir":"/custom/base","output_dir":"/custom/base/output"}`, resolved.ParamsJSON)
 }
 
+func TestResolveRuntimeParams_RejectsUnknownNamedParam_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+name: reject-unknown
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "$region"
+`)
+
+	dag, err := LoadYAML(context.Background(), yaml, WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yaml
+
+	_, err = ResolveRuntimeParams(context.Background(), dag, "region=us-west-2 regoin=typo", ResolveRuntimeParamsOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regoin")
+}
+
+func TestResolveRuntimeParams_AcceptsKnownNamedParam_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+name: accept-known
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "$region"
+`)
+
+	dag, err := LoadYAML(context.Background(), yaml, WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yaml
+
+	resolved, err := ResolveRuntimeParams(context.Background(), dag, "region=us-west-2", ResolveRuntimeParamsOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"region=us-west-2"}, resolved.Params)
+}
+
+func TestResolveRuntimeParams_RejectsUnknownNamedParam_LegacyNamed(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+name: reject-unknown-legacy
+params:
+  - region: us-east-1
+steps:
+  - name: echo
+    command: echo "$region"
+`)
+
+	dag, err := LoadYAML(context.Background(), yaml, WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yaml
+
+	_, err = ResolveRuntimeParams(context.Background(), dag, "region=us-west-2 regoin=typo", ResolveRuntimeParamsOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regoin")
+}
+
+func TestResolveRuntimeParams_AcceptsAnythingWhenNoParamsDeclared(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+name: no-params
+steps:
+  - name: echo
+    command: echo hello
+`)
+
+	dag, err := LoadYAML(context.Background(), yaml, WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yaml
+
+	resolved, err := ResolveRuntimeParams(context.Background(), dag, "foo=bar baz=qux", ResolveRuntimeParamsOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, resolved)
+}
+
+func TestResolveRuntimeParams_RejectsUnknownViaJSON_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	yaml := []byte(`
+name: reject-json-unknown
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "$region"
+`)
+
+	dag, err := LoadYAML(context.Background(), yaml, WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yaml
+
+	_, err = ResolveRuntimeParams(context.Background(), dag, `{"region":"us-west-2","regoin":"typo"}`, ResolveRuntimeParamsOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regoin")
+}
+
+func TestResolveRuntimeParams_ExternalSchemaRejectsUnknownWhenForbidden(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "params.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{
+  "type": "object",
+  "properties": {
+    "region": {
+      "type": "string"
+    }
+  },
+  "required": ["region"],
+  "additionalProperties": false
+}`), 0o600))
+
+	dagPath := filepath.Join(dir, "external-reject.yaml")
+	require.NoError(t, os.WriteFile(dagPath, []byte(`
+name: external-reject
+params:
+  schema: params.schema.json
+`), 0o600))
+
+	dag, err := Load(context.Background(), dagPath, WithoutEval())
+	require.NoError(t, err)
+
+	_, err = ResolveRuntimeParams(context.Background(), dag, "region=us-west-2 regoin=typo", ResolveRuntimeParamsOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regoin")
+}
+
+func TestResolveRuntimeParams_ExternalSchemaAllowsExtraWhenPermitted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "params.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{
+  "type": "object",
+  "properties": {
+    "region": {
+      "type": "string"
+    }
+  },
+  "required": ["region"],
+  "additionalProperties": true
+}`), 0o600))
+
+	dagPath := filepath.Join(dir, "external-allow.yaml")
+	require.NoError(t, os.WriteFile(dagPath, []byte(`
+name: external-allow
+params:
+  schema: params.schema.json
+`), 0o600))
+
+	dag, err := Load(context.Background(), dagPath, WithoutEval())
+	require.NoError(t, err)
+
+	resolved, err := ResolveRuntimeParams(context.Background(), dag, "region=us-west-2 extra=ok", ResolveRuntimeParamsOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, resolved)
+}
+
 func TestToFloat64_RejectsUnsafeIntegerPrecision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/params_reject_unknown_test.go
+++ b/internal/intg/params_reject_unknown_test.go
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/cmd"
+	"github.com/dagu-org/dagu/internal/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParams_RejectsUnknownNamedParam_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "reject-unknown-inline.yaml", `
+name: reject-unknown-inline
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	err := th.RunCommandWithError(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", "region=us-west-2 regoin=typo",
+			dagFile,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "regoin")
+}
+
+func TestParams_AcceptsValidParams_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "accept-valid-inline.yaml", `
+name: accept-valid-inline
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	th.RunCommand(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", "region=us-west-2",
+			dagFile,
+		},
+		ExpectedOut: []string{"DAG run finished"},
+	})
+}
+
+func TestParams_AcceptsAnythingWithNoParamsSection(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "no-params.yaml", `
+name: no-params
+steps:
+  - name: echo
+    command: echo hello
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	th.RunCommand(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			dagFile,
+			"--",
+			"foo=bar",
+		},
+		ExpectedOut: []string{"DAG run finished"},
+	})
+}
+
+func TestParams_RejectsUnknownNamedParam_LegacyNamed(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "reject-unknown-legacy.yaml", `
+name: reject-unknown-legacy
+params:
+  - region: us-east-1
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	err := th.RunCommandWithError(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", "region=us-west-2 regoin=typo",
+			dagFile,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "regoin")
+}
+
+func TestParams_RejectsUnknownViaJSON_InlineTyped(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, "reject-json-unknown.yaml", `
+name: reject-json-unknown
+params:
+  - name: region
+    type: string
+    required: true
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	err := th.RunCommandWithError(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", `{"region":"us-west-2","regoin":"typo"}`,
+			dagFile,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "regoin")
+}
+
+func TestParams_ExternalSchemaRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+
+	schemaContent := `{
+  "type": "object",
+  "properties": {
+    "region": { "type": "string" }
+  },
+  "required": ["region"],
+  "additionalProperties": false
+}`
+
+	dagDir := filepath.Dir(th.CreateDAGFile(t, "dummy.yaml", ""))
+	schemaPath := filepath.Join(dagDir, "params.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(schemaContent), 0o600))
+
+	dagFile := th.CreateDAGFile(t, "external-reject.yaml", `
+name: external-reject
+params:
+  schema: params.schema.json
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	err := th.RunCommandWithError(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", "region=us-west-2 regoin=typo",
+			dagFile,
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "regoin")
+}
+
+func TestParams_ExternalSchemaAllowsExtraWhenPermitted(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+
+	schemaContent := `{
+  "type": "object",
+  "properties": {
+    "region": { "type": "string" }
+  },
+  "required": ["region"],
+  "additionalProperties": true
+}`
+
+	dagDir := filepath.Dir(th.CreateDAGFile(t, "dummy2.yaml", ""))
+	schemaPath := filepath.Join(dagDir, "params-allow.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(schemaContent), 0o600))
+
+	dagFile := th.CreateDAGFile(t, "external-allow.yaml", `
+name: external-allow
+params:
+  schema: params-allow.schema.json
+steps:
+  - name: echo
+    command: echo "region=$region"
+`)
+
+	runID := uuid.Must(uuid.NewV7()).String()
+	th.RunCommand(t, cmd.Start(), test.CmdTest{
+		Args: []string{
+			"start",
+			"--run-id", runID,
+			"--params", "region=us-west-2 extra=ok",
+			dagFile,
+		},
+		ExpectedOut: []string{"DAG run finished"},
+	})
+}

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1165,6 +1165,16 @@ func (a *API) enqueueDAGRun(ctx context.Context, dag *core.DAG, params, dagRunID
 		return err
 	}
 
+	if err := core.ValidateStartParams(dag.DefaultParams, core.StartParamInput{
+		RawParams: params,
+	}); err != nil {
+		return &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Code:       api.ErrorCodeBadRequest,
+			Message:    err.Error(),
+		}
+	}
+
 	// Only pass trigger type if it's a known value (not TriggerTypeUnknown)
 	triggerTypeStr := ""
 	if triggerType != core.TriggerTypeUnknown {


### PR DESCRIPTION
## Summary
- Reject unknown named parameters when starting a DAG that declares named params, preventing typos from being silently ignored
- Add validation in both CLI (`overrideParams`, `applyOverridePairsTracked`) and API (`enqueueDAGRun`) code paths
- Set `additionalProperties: false` on compiled inline param JSON schemas to reject unknown fields in JSON input
- Keep backward compatibility: positional-only or no-params DAGs still accept arbitrary parameters

## Testing
- `make test TEST_TARGET=./internal/core/spec/...`
- `make test TEST_TARGET=./internal/intg/...`
- `make test TEST_TARGET=./internal/agent/...`
- `make test TEST_TARGET=./internal/service/frontend/api/v1/...`

Closes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Unknown or undeclared named parameters are now rejected with clear error messages listing accepted parameter names.
  * Parameter validation now enforced at API endpoints to prevent invalid inputs.

* **Tests**
  * Added comprehensive test coverage for parameter validation across multiple input formats and schema configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->