### PR TITLE
fix: retry dispatch on transient coordinator failures (#1837)

### DIFF
--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -161,7 +162,16 @@ func (cli *clientImpl) Dispatch(ctx context.Context, task *coordinatorv1.Task) e
 					slog.String("coordinator-id", member.ID),
 				)
 
-				return fmt.Errorf("failed to dispatch task to coordinator %s: %w", member.ID, err)
+				wrapped := fmt.Errorf("failed to dispatch task to coordinator %s: %w", member.ID, err)
+
+				// FailedPrecondition means permanent misconfiguration (e.g. selector mismatch).
+				// Stop retrying across coordinators and across the outer backoff loop.
+				if st, ok := status.FromError(err); ok && st.Code() == codes.FailedPrecondition {
+					return backoff.PermanentError(wrapped)
+				}
+
+				// Unavailable and other transient errors will be retried.
+				return wrapped
 			}
 
 			logger.Info(ctx, "Task dispatched successfully",
@@ -259,8 +269,14 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 				tag.Host(member.Host),
 				tag.Port(member.Port),
 				tag.Error(err))
-			lastErr = err
 			cli.recordFailure(err)
+
+			// Permanent errors (e.g. selector mismatch) should not try other coordinators.
+			if errors.Is(err, backoff.ErrPermanent) {
+				return err
+			}
+
+			lastErr = err
 		} else {
 			// Success - record and return immediately
 			cli.recordSuccess(ctx)

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -242,7 +242,7 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	if len(req.Task.WorkerSelector) > 0 {
 		return nil, status.Error(codes.FailedPrecondition, "no workers match the required selector")
 	}
-	return nil, status.Error(codes.FailedPrecondition, "no available workers")
+	return nil, status.Error(codes.Unavailable, "no available workers")
 }
 
 // matchesSelector checks if worker labels match all required selector labels

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -338,7 +338,7 @@ func TestHandler_Poll(t *testing.T) {
 		require.Error(t, err)
 		st, ok := status.FromError(err)
 		require.True(t, ok)
-		require.Equal(t, codes.FailedPrecondition, st.Code())
+		require.Equal(t, codes.Unavailable, st.Code())
 		require.Contains(t, st.Message(), "no available workers")
 	})
 

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -188,6 +188,11 @@ func (e *DAGExecutor) shouldUseDistributedExecution(dag *core.DAG) bool {
 	return core.ShouldDispatchToCoordinator(dag, e.coordinatorCli != nil, e.defaultExecMode)
 }
 
+// IsDistributed returns whether the given DAG would use distributed execution.
+func (e *DAGExecutor) IsDistributed(dag *core.DAG) bool {
+	return e.shouldUseDistributedExecution(dag)
+}
+
 // dispatchToCoordinator dispatches a task to the coordinator for distributed execution.
 // This is called after the job has been persisted (for START operations via HandleJob)
 // or when retrying dispatch (for RETRY operations from queue handler).

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"log/slog"
 	osexec "os/exec"
 	"sync"
 	"sync/atomic"
@@ -19,6 +20,8 @@ import (
 	"github.com/dagu-org/dagu/internal/core/exec"
 	coordinatorv1 "github.com/dagu-org/dagu/proto/coordinator/v1"
 )
+
+const queueAgeWarningThreshold = 2 * time.Minute
 
 var (
 	errProcessorClosed = errors.New("processor closed")
@@ -395,9 +398,26 @@ func (p *QueueProcessor) processDAG(ctx context.Context, item exec.QueuedItemDat
 		return false
 	}
 
+	// Log a warning if the item has been queued for too long.
+	if schedTime, err := time.Parse(time.RFC3339, status.ScheduleTime); err == nil {
+		if queueAge := time.Since(schedTime); queueAge > queueAgeWarningThreshold {
+			logger.Warn(ctx, "Queued item has been waiting for dispatch",
+				tag.DAG(runRef.Name),
+				slog.Duration("queue_age", queueAge),
+			)
+		}
+	}
+
 	incInflight()
 	defer decInflight()
 
+	// For distributed execution, dispatch synchronously inside the retry loop
+	// so transient "no available workers" errors are retried with backoff.
+	if p.dagExecutor.IsDistributed(dag) {
+		return p.dispatchAndWaitForStartup(ctx, queueName, runRef, dag, runID, status)
+	}
+
+	// For local execution, launch in a goroutine and poll for startup.
 	execErrCh := make(chan error, 1)
 	go func() {
 		defer p.wakeUp()
@@ -416,6 +436,88 @@ func (p *QueueProcessor) processDAG(ctx context.Context, item exec.QueuedItemDat
 		launchedAt: time.Now(),
 		execErrCh:  execErrCh,
 	})
+}
+
+// dispatchAndWaitForStartup handles distributed DAG execution by retrying
+// dispatch within the backoff loop. This ensures transient "no available workers"
+// errors are retried rather than immediately failing.
+func (p *QueueProcessor) dispatchAndWaitForStartup(
+	ctx context.Context,
+	queueName string,
+	runRef exec.DAGRunRef,
+	dag *core.DAG,
+	runID string,
+	dagStatus *exec.DAGRunStatus,
+) bool {
+	policy := backoff.NewExponentialBackoffPolicy(p.backoffConfig.InitialInterval)
+	policy.MaxInterval = p.backoffConfig.MaxInterval
+	policy.MaxRetries = p.backoffConfig.MaxRetries
+
+	launchedAt := time.Now()
+	var started bool
+	dispatched := false
+
+	operation := func(ctx context.Context) error {
+		if err := p.checkContextAndQuit(ctx); err != nil {
+			return err
+		}
+
+		// If not yet dispatched (or last dispatch was a transient failure), try dispatch.
+		if !dispatched {
+			err := p.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY,
+				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime)
+			if err != nil {
+				// Permanent dispatch error (e.g. selector mismatch): stop retrying.
+				if errors.Is(err, backoff.ErrPermanent) {
+					logger.Error(ctx, "Permanent dispatch failure", tag.Error(err))
+					return backoff.PermanentError(err)
+				}
+				// Transient dispatch error (e.g. no available workers): retry.
+				logger.Warn(ctx, "Transient dispatch failure, will retry", tag.Error(err))
+				return err
+			}
+			dispatched = true
+		}
+
+		// Dispatch succeeded, now poll for startup.
+		isAlive, err := p.procStore.IsRunAlive(ctx, queueName, runRef)
+		if err != nil {
+			logger.Warn(ctx, "Failed to check run liveness", tag.Error(err))
+		} else if isAlive {
+			started = true
+			return nil
+		}
+		if p.inStartupGracePeriod(launchedAt) {
+			return errNotStarted
+		}
+
+		// After grace period, check status for completion.
+		attempt, err := p.dagRunStore.FindAttempt(ctx, runRef)
+		if err != nil {
+			logger.Debug(ctx, "Failed to read attempt, keep checking")
+			return err
+		}
+
+		status, err := attempt.ReadStatus(ctx)
+		if err != nil {
+			return err
+		}
+
+		if status.Status != core.Queued && status.Status != core.Running {
+			logger.Info(ctx, "DAG execution started or finished", tag.Status(status.Status.String()))
+			started = true
+			return nil
+		}
+
+		return errNotStarted
+	}
+
+	if err := backoff.Retry(ctx, operation, policy, nil); err != nil {
+		logger.Error(ctx, "Failed to dispatch DAG after retries", tag.Error(err))
+	}
+
+	defer p.wakeUp()
+	return started
 }
 
 func (p *QueueProcessor) wakeUp() {

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"errors"
 	osexec "os/exec"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/dagu-org/dagu/internal/cmn/backoff"
+	"github.com/dagu-org/dagu/internal/cmn/config"
 	"github.com/dagu-org/dagu/internal/core"
 	"github.com/dagu-org/dagu/internal/core/exec"
+	coordinatorv1 "github.com/dagu-org/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -159,4 +162,107 @@ func TestIsPreStartExecutionFailure(t *testing.T) {
 			require.Equal(t, tc.want, isPreStartExecutionFailure(tc.err))
 		})
 	}
+}
+
+// mockDispatcher implements exec.Dispatcher for testing dispatch behavior.
+type mockDispatcher struct {
+	callCount atomic.Int32
+	errFunc   func(callNum int32) error
+}
+
+func (m *mockDispatcher) Dispatch(_ context.Context, _ *coordinatorv1.Task) error {
+	n := m.callCount.Add(1)
+	if m.errFunc != nil {
+		return m.errFunc(n)
+	}
+	return nil
+}
+
+func (m *mockDispatcher) Cleanup(_ context.Context) error { return nil }
+
+func (m *mockDispatcher) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+	return nil, nil
+}
+
+func (m *mockDispatcher) RequestCancel(_ context.Context, _, _ string, _ *exec.DAGRunRef) error {
+	return nil
+}
+
+func TestDispatchAndWaitForStartup_TransientRetryThenSuccess(t *testing.T) {
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	runRef := exec.NewDAGRunRef("test-dag", "run-1")
+
+	// Dispatcher fails twice with a transient error, then succeeds.
+	disp := &mockDispatcher{
+		errFunc: func(n int32) error {
+			if n <= 2 {
+				return errors.New("no available workers")
+			}
+			return nil
+		},
+	}
+
+	dagExec := NewDAGExecutor(disp, nil, config.ExecutionModeDistributed, "")
+	dag := &core.DAG{Name: "test-dag"}
+	status := &exec.DAGRunStatus{Status: core.Queued, TriggerType: core.TriggerTypeScheduler}
+
+	// After dispatch succeeds, the process should become alive.
+	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(true, nil).Once()
+
+	p := &QueueProcessor{
+		dagRunStore: dagRunStore,
+		procStore:   procStore,
+		dagExecutor: dagExec,
+		quit:        make(chan struct{}),
+		wakeUpCh:    make(chan struct{}, 1),
+		backoffConfig: BackoffConfig{
+			InitialInterval:    10 * time.Millisecond,
+			MaxInterval:        50 * time.Millisecond,
+			MaxRetries:         5,
+			StartupGracePeriod: 10 * time.Millisecond,
+		},
+	}
+
+	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	require.True(t, started)
+	require.GreaterOrEqual(t, disp.callCount.Load(), int32(3))
+	procStore.AssertExpectations(t)
+}
+
+func TestDispatchAndWaitForStartup_PermanentErrorStopsRetry(t *testing.T) {
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+
+	// Dispatcher always returns a permanent error (selector mismatch).
+	disp := &mockDispatcher{
+		errFunc: func(_ int32) error {
+			return backoff.PermanentError(errors.New("no workers match the required selector"))
+		},
+	}
+
+	dagExec := NewDAGExecutor(disp, nil, config.ExecutionModeDistributed, "")
+	dag := &core.DAG{Name: "test-dag"}
+	status := &exec.DAGRunStatus{Status: core.Queued, TriggerType: core.TriggerTypeScheduler}
+	runRef := exec.NewDAGRunRef("test-dag", "run-1")
+
+	p := &QueueProcessor{
+		dagRunStore: dagRunStore,
+		procStore:   procStore,
+		dagExecutor: dagExec,
+		quit:        make(chan struct{}),
+		wakeUpCh:    make(chan struct{}, 1),
+		backoffConfig: BackoffConfig{
+			InitialInterval:    10 * time.Millisecond,
+			MaxInterval:        50 * time.Millisecond,
+			MaxRetries:         5,
+			StartupGracePeriod: 10 * time.Millisecond,
+		},
+	}
+
+	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	require.False(t, started)
+	// Should have been called exactly once (permanent error stops retries).
+	require.Equal(t, int32(1), disp.callCount.Load())
+	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }


### PR DESCRIPTION
When no worker poller is waiting at the exact moment of dispatch, the coordinator returns an error that was previously treated as permanent, causing queued items to wait until the next processing cycle (~30s) for re-dispatch. This race can recur indefinitely, leaving tasks stuck in "Queued" state.

Split coordinator error codes: use codes.Unavailable for transient "no available workers" (retry later) and keep codes.FailedPrecondition for permanent "selector mismatch" (fix your request). The client now wraps FailedPrecondition as a permanent error to short-circuit retries.

Restructure the queue processor to retry dispatch within the backoff loop for distributed execution, so transient failures are retried with exponential backoff rather than waiting for the next processing cycle. Local execution retains the existing goroutine + poll pattern.

Add queue-age warning logging when items have been waiting beyond 2 minutes, providing observability without auto-failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinator failover handling to stop retrying on permanent errors, reducing unnecessary retry attempts.
  * Corrected gRPC status code for unavailable workers scenarios.

* **Improvements**
  * Added queue age monitoring to warn when DAG items exceed wait time threshold before dispatch.
  * Enhanced distributed execution dispatch with automatic retry logic for transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->