### PR TITLE
fix: pass runtime environment to precondition shell commands

### DIFF
--- a/internal/intg/precondition_env_test.go
+++ b/internal/intg/precondition_env_test.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/test"
+)
+
+func TestPreconditionWithDAGEnvVars(t *testing.T) {
+	t.Parallel()
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+env:
+  - DEV_PCENT: "90"
+  - DEV_ALERT: "80"
+steps:
+  - name: check-threshold
+    command: echo "alert triggered"
+    output: RESULT
+    preconditions:
+      - condition: "test ${DEV_PCENT} -ge ${DEV_ALERT}"
+`)
+	agent := dag.Agent()
+	agent.RunSuccess(t)
+	dag.AssertOutputs(t, map[string]any{
+		"RESULT": "alert triggered",
+	})
+}
+
+func TestPreconditionWithDAGEnvVarsNotMet(t *testing.T) {
+	t.Parallel()
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+type: graph
+env:
+  - DEV_PCENT: "50"
+  - DEV_ALERT: "80"
+steps:
+  - name: check-threshold
+    command: echo "alert triggered"
+    output: RESULT
+    preconditions:
+      - condition: "test ${DEV_PCENT} -ge ${DEV_ALERT}"
+`)
+	agent := dag.Agent()
+	agent.RunSuccess(t)
+	dag.AssertOutputs(t, map[string]any{
+		"RESULT": "",
+	})
+}
+
+func TestDAGLevelPreconditionWithEnvVars(t *testing.T) {
+	t.Parallel()
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+env:
+  - ENABLED: "yes"
+preconditions:
+  - condition: "test ${ENABLED} = yes"
+steps:
+  - name: run
+    command: echo "executed"
+    output: RESULT
+`)
+	agent := dag.Agent()
+	agent.RunSuccess(t)
+	dag.AssertOutputs(t, map[string]any{
+		"RESULT": "executed",
+	})
+}
+
+func TestPreconditionWithStepOutput(t *testing.T) {
+	t.Parallel()
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+type: graph
+steps:
+  - name: produce
+    command: echo "go"
+    output: STEP_RESULT
+  - name: consume
+    command: echo "ran"
+    output: FINAL
+    preconditions:
+      - condition: "test ${STEP_RESULT} = go"
+    depends: produce
+`)
+	agent := dag.Agent()
+	agent.RunSuccess(t)
+	dag.AssertOutputs(t, map[string]any{
+		"STEP_RESULT": "go",
+		"FINAL":       "ran",
+	})
+}

--- a/internal/runtime/condition.go
+++ b/internal/runtime/condition.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 
 	"github.com/dagu-org/dagu/internal/cmn/eval"
 	"github.com/dagu-org/dagu/internal/cmn/stringutil"
@@ -104,11 +105,7 @@ func matchCondition(ctx context.Context, c *core.Condition) error {
 }
 
 func evalCommand(ctx context.Context, shell []string, c *core.Condition) error {
-	var opts []eval.Option
-	if len(shell) > 0 {
-		opts = append(opts, eval.OnlyReplaceVars())
-	}
-	commandToRun, err := EvalString(ctx, c.Condition, opts...)
+	commandToRun, err := EvalString(ctx, c.Condition, eval.OnlyReplaceVars())
 	if err != nil {
 		return fmt.Errorf("failed to evaluate command: %w", err)
 	}
@@ -119,8 +116,14 @@ func evalCommand(ctx context.Context, shell []string, c *core.Condition) error {
 }
 
 func runShellCommand(ctx context.Context, shell []string, commandToRun string) error {
-	args := append(shell[1:], "-c", commandToRun)
+	args := make([]string, len(shell)-1)
+	copy(args, shell[1:])
+	if !slices.Contains(args, "-c") {
+		args = append(args, "-c")
+	}
+	args = append(args, commandToRun)
 	cmd := exec.CommandContext(ctx, shell[0], args...) // nolint:gosec
+	cmd.Env = append(cmd.Env, AllEnvs(ctx)...)
 	_, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrConditionNotMet, err)
@@ -130,6 +133,7 @@ func runShellCommand(ctx context.Context, shell []string, commandToRun string) e
 
 func runDirectCommand(ctx context.Context, commandToRun string) error {
 	cmd := exec.CommandContext(ctx, commandToRun)
+	cmd.Env = append(cmd.Env, AllEnvs(ctx)...)
 	_, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrConditionNotMet, err)

--- a/internal/runtime/condition_test.go
+++ b/internal/runtime/condition_test.go
@@ -151,6 +151,17 @@ func TestEvalConditions(t *testing.T) {
 				},
 			},
 		},
+		// Environment variable passthrough tests
+		{
+			name:       "CommandWithDAGEnvVars",
+			conditions: []*core.Condition{{Condition: "test ${TEST_CONDITION} -eq 100"}},
+		},
+		{
+			name:                "CommandWithDAGEnvVarsNotMet",
+			conditions:          []*core.Condition{{Condition: "test ${TEST_CONDITION} -eq 999"}},
+			wantErr:             true,
+			wantConditionNotMet: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -177,4 +188,23 @@ func TestEvalConditions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEvalConditions_ShellWithDuplicateCFlag(t *testing.T) {
+	ctx := newTestContext()
+	// Shell already includes -c; should not get doubled
+	err := runtime.EvalConditions(ctx, []string{"sh", "-c"}, []*core.Condition{
+		{Condition: "true"},
+	})
+	require.NoError(t, err)
+}
+
+func TestEvalConditions_NilShell(t *testing.T) {
+	ctx := newTestContext()
+	// With nil shell, OnlyReplaceVars should still be applied and
+	// the condition should run as a direct command
+	err := runtime.EvalConditions(ctx, nil, []*core.Condition{
+		{Condition: "true"},
+	})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- Precondition shell commands now receive the DAG's runtime environment variables (defined via `env:` or step `output:`), fixing cases where `${VAR}` references in precondition conditions resolved to empty strings
- Fixed `runShellCommand` and `runDirectCommand` to propagate `AllEnvs(ctx)` to the spawned process
- Always apply `OnlyReplaceVars()` in `evalCommand` regardless of shell presence for consistent variable evaluation
- Prevented duplicate `-c` flag when the configured shell already includes it
- Added unit tests for env passthrough, duplicate `-c` handling, and nil shell edge cases
- Added integration tests covering DAG-level env vars in preconditions, unmet preconditions, and step output variables used in downstream preconditions

## Testing
- `make test TEST_TARGET=./internal/runtime/... -count=1`
- `make test TEST_TARGET=./internal/intg/... -count=1 -run TestPrecondition`

Closes #1838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Preconditions now support environment-variable interpolation at step and DAG levels.
  * Preconditions can reference outputs from previous steps using dependency handling.
  * Improved environment variable availability in command execution contexts.

* **Tests**
  * Added comprehensive integration tests for precondition evaluation with environment variables and cross-step dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->