### PR TITLE
feat: add template executor for inline text rendering

### DIFF
--- a/internal/cmn/eval/options.go
+++ b/internal/cmn/eval/options.go
@@ -18,6 +18,11 @@ type Options struct {
 	// in variable values from being interpreted when the script executes.
 	DeferShellVars bool
 
+	// NoExpansion skips all expansion and returns the input unchanged.
+	// Used by executors like template that treat the script body as a
+	// literal template, not a shell expression.
+	NoExpansion bool
+
 	Variables []map[string]string // Ordered variable maps for expansion
 	StepMap   map[string]StepInfo // Step info map for step reference expansion
 }
@@ -84,6 +89,14 @@ func WithoutDollarEscape() Option {
 func WithOSExpansion() Option {
 	return func(opts *Options) {
 		opts.ExpandOS = true
+	}
+}
+
+// WithNoExpansion skips all expansion phases and returns the input unchanged.
+// Used by executors that treat the script body as a literal template.
+func WithNoExpansion() Option {
+	return func(opts *Options) {
+		opts.NoExpansion = true
 	}
 }
 

--- a/internal/cmn/eval/pipeline.go
+++ b/internal/cmn/eval/pipeline.go
@@ -24,6 +24,9 @@ type pipeline struct {
 
 // execute runs all enabled phases in order on the input string.
 func (p *pipeline) execute(ctx context.Context, input string, opts *Options) (string, error) {
+	if opts.NoExpansion {
+		return input, nil
+	}
 	value := input
 	if opts.EscapeDollar {
 		ctx, value = withDollarEscapes(ctx, input)

--- a/internal/intg/template_test.go
+++ b/internal/intg/template_test.go
@@ -1,0 +1,254 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/core"
+	"github.com/dagu-org/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateExecutor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StdoutOnly", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        greeting: hello
+    script: |
+      {{ .greeting }}, world!
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": test.Contains("hello, world!"),
+		})
+	})
+
+	t.Run("FileOnly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		outFile := filepath.Join(tmpDir, "report.md")
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      output: "`+outFile+`"
+      data:
+        title: Test Report
+    script: |
+      # {{ .title }}
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+
+		content, err := os.ReadFile(outFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "# Test Report")
+	})
+
+	t.Run("RelativeOutputPath", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    working_dir: "`+tmpDir+`"
+    config:
+      output: "subdir/output.txt"
+      data:
+        msg: relative
+    script: "{{ .msg }}"
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+
+		content, err := os.ReadFile(filepath.Join(tmpDir, "subdir", "output.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "relative", string(content))
+	})
+
+	t.Run("DataFromPriorStep", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `
+type: graph
+steps:
+  - id: producer
+    command: 'echo -n "Alice"'
+    output: NAME
+
+  - id: render
+    depends:
+      - producer
+    type: template
+    config:
+      data:
+        name: ${NAME}
+    script: "Hello, {{ .name }}!"
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "Hello, Alice!",
+		})
+	})
+
+	t.Run("LiteralDollarPreservation", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        name: test
+    script: |
+      export FOO=${BAR}
+      echo "{{ .name }}"
+      value=`+"`command`"+`
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": []test.Contains{
+				test.Contains("${BAR}"),
+				test.Contains("`command`"),
+			},
+		})
+	})
+
+	t.Run("MissingKeyError", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        name: test
+    script: "{{ .undefined_key }}"
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunCheckErr(t, "execution error")
+
+		dag.AssertLatestStatus(t, core.Failed)
+	})
+
+	t.Run("ComplexTemplate", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        title: Domain Report
+        domains: "example.com,test.org,demo.net"
+    script: |
+      # {{ .title }}
+      {{ $items := .domains | split "," }}
+      Total: {{ $items | count }}
+      {{ range $i, $d := $items }}
+      {{ $i | add 1 }}. {{ $d | upper }}
+      {{ end }}
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": []test.Contains{
+				test.Contains("# Domain Report"),
+				test.Contains("Total: 3"),
+				test.Contains("EXAMPLE.COM"),
+				test.Contains("TEST.ORG"),
+				test.Contains("DEMO.NET"),
+			},
+		})
+	})
+
+	t.Run("ConditionalAndEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        items: ""
+    script: |
+      {{ if .items | empty }}No items found.{{ else }}Has items.{{ end }}
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": test.Contains("No items found."),
+		})
+	})
+
+	t.Run("DefaultFunction", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    config:
+      data:
+        name: ""
+        title: Admin
+    script: '{{ .name | default "Anonymous" }} ({{ .title | default "User" }})'
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "Anonymous (Admin)",
+		})
+	})
+}

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -21,4 +21,5 @@ import (
 	_ "github.com/dagu-org/dagu/internal/runtime/builtin/sql/drivers/postgres"
 	_ "github.com/dagu-org/dagu/internal/runtime/builtin/sql/drivers/sqlite"
 	_ "github.com/dagu-org/dagu/internal/runtime/builtin/ssh"
+	_ "github.com/dagu-org/dagu/internal/runtime/builtin/template"
 )

--- a/internal/runtime/builtin/template/config.go
+++ b/internal/runtime/builtin/template/config.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package template
+
+import (
+	"github.com/dagu-org/dagu/internal/core"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+var configSchema = &jsonschema.Schema{
+	Type: "object",
+	Properties: map[string]*jsonschema.Schema{
+		"data":   {Type: "object", Description: "Template data variables accessible as {{ .key }} in the template"},
+		"output": {Type: "string", Description: "File path to write the rendered output to. If empty, output is written to stdout."},
+	},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema("template", configSchema)
+}

--- a/internal/runtime/builtin/template/template.go
+++ b/internal/runtime/builtin/template/template.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package template
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/dagu-org/dagu/internal/cmn/eval"
+	"github.com/dagu-org/dagu/internal/core"
+	"github.com/dagu-org/dagu/internal/runtime"
+	"github.com/dagu-org/dagu/internal/runtime/executor"
+	"github.com/go-viper/mapstructure/v2"
+)
+
+const defaultDirPermissions = 0750
+
+var _ executor.Executor = (*templateExec)(nil)
+
+type templateExec struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	script     string
+	data       map[string]any
+	outputFile string
+}
+
+type templateConfig struct {
+	Data   map[string]any `mapstructure:"data"`
+	Output string         `mapstructure:"output"`
+}
+
+func newTemplate(ctx context.Context, step core.Step) (executor.Executor, error) {
+	var cfg templateConfig
+	if step.ExecutorConfig.Config != nil {
+		if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+			return nil, fmt.Errorf("template: %w", err)
+		}
+	}
+
+	if step.Script == "" {
+		return nil, fmt.Errorf("template: script field is required")
+	}
+
+	outputFile := cfg.Output
+	if outputFile != "" && !filepath.IsAbs(outputFile) {
+		env := runtime.GetEnv(ctx)
+		outputFile = filepath.Join(env.WorkingDir, outputFile)
+	}
+
+	data := cfg.Data
+	if data == nil {
+		data = make(map[string]any)
+	}
+
+	return &templateExec{
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+		script:     step.Script,
+		data:       data,
+		outputFile: outputFile,
+	}, nil
+}
+
+func (e *templateExec) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *templateExec) SetStderr(out io.Writer) {
+	e.stderr = out
+}
+
+func (*templateExec) Kill(_ os.Signal) error {
+	return nil
+}
+
+func (e *templateExec) Run(_ context.Context) error {
+	tmpl, err := template.New("template").
+		Option("missingkey=error").
+		Funcs(funcMap).
+		Parse(e.script)
+	if err != nil {
+		return fmt.Errorf("template: parse error: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, e.data); err != nil {
+		return fmt.Errorf("template: execution error: %w", err)
+	}
+
+	if e.outputFile != "" {
+		return e.writeToFile(buf.Bytes())
+	}
+
+	_, err = e.stdout.Write(buf.Bytes())
+	return err
+}
+
+func (e *templateExec) writeToFile(data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(e.outputFile), defaultDirPermissions); err != nil {
+		return fmt.Errorf("template: failed to create output directory: %w", err)
+	}
+
+	tmpFile := e.outputFile + ".tmp"
+	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
+		return fmt.Errorf("template: failed to write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile, e.outputFile); err != nil {
+		_ = os.Remove(tmpFile)
+		return fmt.Errorf("template: failed to rename output file: %w", err)
+	}
+
+	return nil
+}
+
+func decodeConfig(dat map[string]any, cfg *templateConfig) error {
+	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Result:           cfg,
+	})
+	return md.Decode(dat)
+}
+
+func validateTemplate(step core.Step) error {
+	if step.Script == "" {
+		return fmt.Errorf("template executor requires a script field")
+	}
+	return nil
+}
+
+// funcMap provides template functions for pipeline-compatible usage.
+// Functions that accept a pipeline value take it as the last argument.
+var funcMap = template.FuncMap{
+	"split": func(sep, s string) []string {
+		return strings.Split(s, sep)
+	},
+	"join": func(sep string, elems []string) string {
+		return strings.Join(elems, sep)
+	},
+	"count": func(v any) (int, error) {
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Array:
+			return rv.Len(), nil
+		case reflect.String:
+			return rv.Len(), nil
+		default:
+			return 0, fmt.Errorf("count: unsupported type %T", v)
+		}
+	},
+	"add": func(b, a int) int {
+		return a + b
+	},
+	"empty": func(v any) bool {
+		if v == nil {
+			return true
+		}
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.String:
+			return rv.Len() == 0
+		case reflect.Slice, reflect.Map, reflect.Array:
+			return rv.Len() == 0
+		default:
+			return rv.IsZero()
+		}
+	},
+	"upper": func(s string) string {
+		return strings.ToUpper(s)
+	},
+	"lower": func(s string) string {
+		return strings.ToLower(s)
+	},
+	"trim": func(s string) string {
+		return strings.TrimSpace(s)
+	},
+	"default": func(def, val any) any {
+		if val == nil {
+			return def
+		}
+		rv := reflect.ValueOf(val)
+		switch rv.Kind() {
+		case reflect.String:
+			if rv.Len() == 0 {
+				return def
+			}
+		case reflect.Slice, reflect.Map, reflect.Array:
+			if rv.Len() == 0 {
+				return def
+			}
+		default:
+			if rv.IsZero() {
+				return def
+			}
+		}
+		return val
+	},
+}
+
+func init() {
+	executor.RegisterExecutor("template", newTemplate, validateTemplate, core.ExecutorCapabilities{
+		Script: true,
+		GetEvalOptions: func(_ context.Context, _ core.Step) []eval.Option {
+			return []eval.Option{eval.WithNoExpansion()}
+		},
+	})
+}

--- a/internal/runtime/builtin/template/template_test.go
+++ b/internal/runtime/builtin/template/template_test.go
@@ -1,0 +1,355 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package template
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateExec_BasicStdout(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: "Hello, World!",
+		data:   map[string]any{},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!", stdout.String())
+}
+
+func TestTemplateExec_DataVariables(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: "Hello, {{ .name }}! You have {{ .count }} items.",
+		data: map[string]any{
+			"name":  "Alice",
+			"count": 42,
+		},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, Alice! You have 42 items.", stdout.String())
+}
+
+func TestTemplateExec_OutputToFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "output.txt")
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout:     &stdout,
+		stderr:     os.Stderr,
+		script:     "File content: {{ .msg }}",
+		data:       map[string]any{"msg": "hello"},
+		outputFile: outFile,
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+
+	// stdout should be empty when writing to file
+	assert.Empty(t, stdout.String())
+
+	// file should contain the rendered content
+	content, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, "File content: hello", string(content))
+}
+
+func TestTemplateExec_OutputToFileCreatesSubdirs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "sub", "dir", "output.txt")
+
+	e := &templateExec{
+		stdout:     &bytes.Buffer{},
+		stderr:     os.Stderr,
+		script:     "nested",
+		data:       map[string]any{},
+		outputFile: outFile,
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(content))
+}
+
+func TestTemplateExec_MissingKeyError(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: "{{ .undefined_key }}",
+		data:   map[string]any{},
+	}
+
+	err := e.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "execution error")
+}
+
+func TestTemplateExec_InvalidSyntax(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: "{{ .foo",
+		data:   map[string]any{},
+	}
+
+	err := e.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse error")
+}
+
+func TestTemplateExec_EmptyDataLiterals(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: "Just literal text, no variables.",
+		data:   map[string]any{},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Just literal text, no variables.", stdout.String())
+}
+
+func TestFuncMap_Split(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ range .items | split "," }}[{{ . }}]{{ end }}`,
+		data:   map[string]any{"items": "a,b,c"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "[a][b][c]", stdout.String())
+}
+
+func TestFuncMap_Join(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .items | join ", " }}`,
+		data:   map[string]any{"items": []string{"a", "b", "c"}},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "a, b, c", stdout.String())
+}
+
+func TestFuncMap_Count(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .items | count }}`,
+		data:   map[string]any{"items": []string{"a", "b", "c"}},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "3", stdout.String())
+}
+
+func TestFuncMap_Add(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ 5 | add 3 }}`,
+		data:   map[string]any{},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "8", stdout.String())
+}
+
+func TestFuncMap_Empty(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `empty={{ .val | empty }},notempty={{ .other | empty }}`,
+		data:   map[string]any{"val": "", "other": "hello"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "empty=true,notempty=false", stdout.String())
+}
+
+func TestFuncMap_Upper(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | upper }}`,
+		data:   map[string]any{"val": "hello"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "HELLO", stdout.String())
+}
+
+func TestFuncMap_Lower(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | lower }}`,
+		data:   map[string]any{"val": "HELLO"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "hello", stdout.String())
+}
+
+func TestFuncMap_Trim(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `[{{ .val | trim }}]`,
+		data:   map[string]any{"val": "  hello  "},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "[hello]", stdout.String())
+}
+
+func TestFuncMap_Default_WithEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | default "N/A" }}`,
+		data:   map[string]any{"val": ""},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "N/A", stdout.String())
+}
+
+func TestFuncMap_Default_WithNonEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | default "N/A" }}`,
+		data:   map[string]any{"val": "present"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "present", stdout.String())
+}
+
+func TestFuncMap_PipelineChaining(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | split "\n" | count }}`,
+		data:   map[string]any{"val": "a\nb\nc"},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "3", stdout.String())
+}
+
+func TestFuncMap_EmptySlice(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .items | empty }}`,
+		data:   map[string]any{"items": []string{}},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "true", stdout.String())
+}
+
+func TestFuncMap_EmptyNil(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	e := &templateExec{
+		stdout: &stdout,
+		stderr: os.Stderr,
+		script: `{{ .val | empty }}`,
+		data:   map[string]any{"val": nil},
+	}
+
+	err := e.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "true", stdout.String())
+}


### PR DESCRIPTION
## Summary
- Add a new `template` built-in executor that renders Go `text/template` scripts with data variables, supporting output to stdout or file
- Include helper template functions (`split`, `join`, `count`, `add`, `empty`, `upper`, `lower`, `trim`, `default`) for pipeline-compatible usage
- Add `NoExpansion` eval option to skip shell variable expansion, preserving literal `${}` and backtick syntax in template scripts
- Register executor config schema for UI/validation support
- Add comprehensive unit tests for the executor and template functions, plus integration tests covering file output, prior-step data, literal dollar preservation, and complex templates

## Testing
- `make test TEST_TARGET=./internal/runtime/builtin/template/... -count=1`
- `make test TEST_TARGET=./internal/intg/... -count=1 -run TestTemplateExecutor`
- `make test TEST_TARGET=./internal/cmn/eval/... -count=1`

Closes #1842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added template executor step for rendering Go templates with configurable data variables
  * Supports output to stdout or file with relative path resolution
  * Includes template functions: `split`, `join`, `count`, `add`, `empty`, `upper`, `lower`, `trim`, and `default`
  * Enables data interpolation from previous step outputs

* **Tests**
  * Comprehensive unit and integration test coverage for template executor functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->