### PR TITLE
fix: add Docker daemon connection vars to env whitelist

### DIFF
--- a/internal/cmn/config/env_test.go
+++ b/internal/cmn/config/env_test.go
@@ -4,7 +4,6 @@
 package config_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -13,21 +12,25 @@ import (
 )
 
 func TestLoadBaseEnv(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		name     string
 		expected bool
 	}{
 		{"TEST_VAR_BASE_ENV", false},
 		{"DAGU_TEST_BASE_ENV", true},
+
+		// Docker daemon connection vars must pass through.
+		{"DOCKER_HOST", true},
+		{"DOCKER_TLS_VERIFY", true},
+		{"DOCKER_CERT_PATH", true},
+		{"DOCKER_API_VERSION", true},
+
+		// Docker credentials must NOT leak through the global env.
+		{"DOCKER_AUTH_CONFIG", false},
 	}
 
 	for _, tc := range testCases {
-		os.Setenv(tc.name, "value")
-		t.Cleanup(func() {
-			os.Unsetenv(tc.name)
-		})
+		t.Setenv(tc.name, "value")
 	}
 
 	baseEnv := config.LoadBaseEnv()

--- a/internal/cmn/config/env_unix.go
+++ b/internal/cmn/config/env_unix.go
@@ -36,6 +36,12 @@ func init() {
 		"XDG_CONFIG_HOME", // User config (usually ~/.config)
 		"XDG_DATA_HOME",   // User data (usually ~/.local/share)
 		"XDG_CACHE_HOME",  // User cache (usually ~/.cache)
+
+		// Docker daemon connection (used by Docker SDK's client.FromEnv)
+		"DOCKER_HOST",        // Docker daemon address
+		"DOCKER_TLS_VERIFY",  // Enable TLS verification
+		"DOCKER_CERT_PATH",   // Path to TLS certificates
+		"DOCKER_API_VERSION", // Pin Docker API version
 	} {
 		defaultWhitelist[key] = true
 	}

--- a/internal/cmn/config/env_windows.go
+++ b/internal/cmn/config/env_windows.go
@@ -29,6 +29,12 @@ func init() {
 		"PATH",         // System path
 		"PSMODULEPATH", // PowerShell specific
 		"HOME",         // Used by Go, Git, and ported tools
+
+		// Docker daemon connection (used by Docker SDK's client.FromEnv)
+		"DOCKER_HOST",        // Docker daemon address
+		"DOCKER_TLS_VERIFY",  // Enable TLS verification
+		"DOCKER_CERT_PATH",   // Path to TLS certificates
+		"DOCKER_API_VERSION", // Pin Docker API version
 	} {
 		defaultWhitelist[key] = true
 	}

--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1482,4 +1483,14 @@ func TestWrapCommandWithShell(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestDockerClientRespectsDockerHostEnv(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://test-host:2375")
+
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	require.NoError(t, err)
+	defer cli.Close()
+
+	assert.Equal(t, "tcp://test-host:2375", cli.DaemonHost())
 }

--- a/internal/runtime/subcmd_test.go
+++ b/internal/runtime/subcmd_test.go
@@ -40,6 +40,48 @@ func TestNewSubCmdBuilder(t *testing.T) {
 	require.NotNil(t, builder)
 }
 
+func TestSubCmdBuilderEnvIncludesDockerVars(t *testing.T) {
+	t.Parallel()
+
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"DOCKER_HOST=tcp://remote:2375",
+		"DOCKER_TLS_VERIFY=1",
+		"DOCKER_CERT_PATH=/certs",
+		"DOCKER_API_VERSION=1.41",
+	}
+
+	cfg := &config.Config{
+		Paths: config.PathsConfig{
+			Executable:     "/path/to/dagu",
+			ConfigFileUsed: "/path/to/config.yaml",
+		},
+		Core: config.Core{
+			BaseEnv: config.NewBaseEnv(baseEnv),
+		},
+	}
+
+	builder := runtime.NewSubCmdBuilder(cfg)
+	dag := &core.DAG{Location: "/tmp/test.yaml"}
+	spec := builder.Start(dag, runtime.StartOptions{})
+
+	envMap := make(map[string]string)
+	for _, e := range spec.Env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			envMap[k] = v
+		}
+	}
+
+	assert.Equal(t, "tcp://remote:2375", envMap["DOCKER_HOST"])
+	assert.Equal(t, "1", envMap["DOCKER_TLS_VERIFY"])
+	assert.Equal(t, "/certs", envMap["DOCKER_CERT_PATH"])
+	assert.Equal(t, "1.41", envMap["DOCKER_API_VERSION"])
+
+	// DOCKER_AUTH_CONFIG should not be present (it was never in baseEnv).
+	_, found := envMap["DOCKER_AUTH_CONFIG"]
+	assert.False(t, found, "DOCKER_AUTH_CONFIG must not appear in subprocess env")
+}
+
 func TestRunRetryWithBuiltExecutable(t *testing.T) {
 	th := test.Setup(t, test.WithBuiltExecutable())
 


### PR DESCRIPTION
## Summary
- Add `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, `DOCKER_CERT_PATH`, and `DOCKER_API_VERSION` to the environment variable whitelist on both Unix and Windows so the Docker executor can connect to remote/custom Docker daemons
- Explicitly exclude `DOCKER_AUTH_CONFIG` to prevent credential leakage through the global environment
- Add tests verifying Docker vars pass through to subprocess environments and that the Docker client respects `DOCKER_HOST`

## Testing
- `make test TEST_TARGET=./internal/cmn/config/... -count=1`
- `make test TEST_TARGET=./internal/runtime/... -count=1`
- `make test TEST_TARGET=./internal/runtime/builtin/docker/... -count=1`

Closes #1843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment variable management with improved cleanup practices.
  * Added tests to verify Docker daemon connection variables (DOCKER_HOST, DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, DOCKER_API_VERSION) are correctly handled and passed through subprocess execution across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->