### PR TITLE
fix: resolve env-provider secrets in parent before subprocess filtering

### DIFF
--- a/internal/cmn/eval/envscope.go
+++ b/internal/cmn/eval/envscope.go
@@ -11,6 +11,10 @@ import (
 	"sync"
 )
 
+// internalSecretPrefix must match secrets.PresolvedEnvPrefix.
+// Duplicated here to avoid a circular import (eval <- secrets).
+const internalSecretPrefix = "_DAGU_PRESOLVED_SECRET_" //nolint:gosec // Not a credential; this is an env var prefix for transport.
+
 // EnvSource tracks where an environment variable came from (for debugging)
 type EnvSource string
 
@@ -53,6 +57,14 @@ func NewEnvScope(parent *EnvScope, includeOS bool) *EnvScope {
 	if includeOS {
 		for _, env := range os.Environ() {
 			if k, v, ok := strings.Cut(env, "="); ok {
+				// Skip internal transport vars for pre-resolved secrets.
+				// These are only consumed by the env secret resolver via
+				// direct os.LookupEnv; they must not appear in step environments.
+				// Must match secrets.PresolvedEnvPrefix (duplicated to avoid
+				// circular import: eval <- secrets).
+				if strings.HasPrefix(k, internalSecretPrefix) {
+					continue
+				}
 				e.entries[k] = EnvEntry{Key: k, Value: v, Source: EnvSourceOS}
 			}
 		}

--- a/internal/cmn/eval/envscope_test.go
+++ b/internal/cmn/eval/envscope_test.go
@@ -838,3 +838,17 @@ func TestCollectBySource_WithParent(t *testing.T) {
 	assert.Equal(t, "pval", result["PKEY"])
 	assert.Equal(t, "cval", result["CKEY"])
 }
+
+func TestEnvScope_ExcludesPresolvedSecrets(t *testing.T) {
+	t.Setenv("_DAGU_PRESOLVED_SECRET_FOO", "bar")
+	t.Setenv("NORMAL_VAR", "visible")
+
+	scope := NewEnvScope(nil, true)
+
+	_, exists := scope.Get("_DAGU_PRESOLVED_SECRET_FOO")
+	require.False(t, exists, "presolved secret vars must not enter scope")
+
+	val, exists := scope.Get("NORMAL_VAR")
+	require.True(t, exists)
+	require.Equal(t, "visible", val)
+}

--- a/internal/cmn/secrets/env.go
+++ b/internal/cmn/secrets/env.go
@@ -12,6 +12,13 @@ import (
 	"github.com/dagu-org/dagu/internal/core"
 )
 
+// PresolvedEnvPrefix is the env var prefix used to transport pre-resolved
+// env-provider secret values from the parent process to the subprocess.
+// The parent looks up the original env var and passes it as
+// _DAGU_PRESOLVED_SECRET_<KEY>=<value> so the subprocess can resolve
+// env secrets without needing the original variable in the whitelist.
+const PresolvedEnvPrefix = "_DAGU_PRESOLVED_SECRET_"
+
 func init() {
 	registerResolver("env", func(_ []string) Resolver {
 		return &envResolver{}
@@ -51,6 +58,11 @@ func (r *envResolver) Resolve(ctx context.Context, ref core.SecretRef) (string, 
 		}
 	}
 
+	// Check for value pre-resolved by parent process.
+	if value, exists := os.LookupEnv(PresolvedEnvPrefix + ref.Key); exists {
+		return value, nil
+	}
+
 	// Fall back to global OS environment
 	value, exists := os.LookupEnv(ref.Key)
 	if !exists {
@@ -67,6 +79,11 @@ func (r *envResolver) CheckAccessibility(ctx context.Context, ref core.SecretRef
 		if _, exists := scope.Get(ref.Key); exists {
 			return nil
 		}
+	}
+
+	// Check for value pre-resolved by parent process.
+	if _, exists := os.LookupEnv(PresolvedEnvPrefix + ref.Key); exists {
+		return nil
 	}
 
 	// Fall back to global OS environment

--- a/internal/cmn/secrets/env_test.go
+++ b/internal/cmn/secrets/env_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dagu-org/dagu/internal/cmn/eval"
 	"github.com/dagu-org/dagu/internal/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,6 +183,59 @@ func TestEnvResolver_CheckAccessibility(t *testing.T) {
 
 		err := resolver.CheckAccessibility(ctx, ref)
 		require.NoError(t, err, "empty variables should be considered accessible")
+	})
+}
+
+func TestEnvResolver_PresolvedPrefix(t *testing.T) {
+	ctx := context.Background()
+	registry := NewRegistry("/tmp")
+	resolver := registry.Get("env")
+	require.NotNil(t, resolver)
+
+	t.Run("ResolveFromPresolved", func(t *testing.T) {
+		// The original var is NOT set, only the presolved transport var
+		t.Setenv("_DAGU_PRESOLVED_SECRET_SMTP_PASS", "from-parent")
+
+		ref := core.SecretRef{
+			Name:     "SMTP_PASSWORD",
+			Provider: "env",
+			Key:      "SMTP_PASS",
+		}
+
+		value, err := resolver.Resolve(ctx, ref)
+		require.NoError(t, err)
+		assert.Equal(t, "from-parent", value)
+	})
+
+	t.Run("CheckAccessibilityFromPresolved", func(t *testing.T) {
+		t.Setenv("_DAGU_PRESOLVED_SECRET_CHECK_VAR", "val")
+
+		ref := core.SecretRef{
+			Name:     "SECRET",
+			Provider: "env",
+			Key:      "CHECK_VAR",
+		}
+
+		err := resolver.CheckAccessibility(ctx, ref)
+		require.NoError(t, err)
+	})
+
+	t.Run("ScopeWinsOverPresolved", func(t *testing.T) {
+		// If the scope has the value, it should take precedence
+		t.Setenv("_DAGU_PRESOLVED_SECRET_MY_KEY", "presolved-value")
+
+		scope := eval.NewEnvScope(nil, false).WithEntry("MY_KEY", "scope-value", eval.EnvSourceDAGEnv)
+		scopeCtx := eval.WithEnvScope(ctx, scope)
+
+		ref := core.SecretRef{
+			Name:     "SECRET",
+			Provider: "env",
+			Key:      "MY_KEY",
+		}
+
+		value, err := resolver.Resolve(scopeCtx, ref)
+		require.NoError(t, err)
+		assert.Equal(t, "scope-value", value)
 	})
 }
 

--- a/internal/runtime/presolved_secrets_test.go
+++ b/internal/runtime/presolved_secrets_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagu-org/dagu/internal/core"
+)
+
+func TestPreResolveEnvSecrets(t *testing.T) {
+	t.Setenv("MY_REAL_SECRET", "s3cret")
+
+	refs := []core.SecretRef{
+		{Name: "SECRET_A", Provider: "env", Key: "MY_REAL_SECRET"},
+		{Name: "SECRET_B", Provider: "env", Key: "NONEXISTENT_VAR"},
+		{Name: "SECRET_C", Provider: "file", Key: "/path/to/file"},
+	}
+	result := preResolveEnvSecrets(refs)
+	require.Len(t, result, 1)
+	require.Equal(t, "_DAGU_PRESOLVED_SECRET_MY_REAL_SECRET=s3cret", result[0])
+}
+
+func TestPreResolveEnvSecrets_NilRefs(t *testing.T) {
+	result := preResolveEnvSecrets(nil)
+	require.Nil(t, result)
+}
+
+func TestPreResolveEnvSecrets_EmptyRefs(t *testing.T) {
+	result := preResolveEnvSecrets([]core.SecretRef{})
+	require.Nil(t, result)
+}

--- a/internal/runtime/subcmd.go
+++ b/internal/runtime/subcmd.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dagu-org/dagu/internal/cmn/cmdutil"
 	"github.com/dagu-org/dagu/internal/cmn/config"
+	"github.com/dagu-org/dagu/internal/cmn/secrets"
 	"github.com/dagu-org/dagu/internal/core"
 	exec1 "github.com/dagu-org/dagu/internal/core/exec"
 	coordinatorv1 "github.com/dagu-org/dagu/proto/coordinator/v1"
@@ -104,6 +105,22 @@ func (b *SubCmdBuilder) env(extra ...string) []string {
 	return env
 }
 
+// preResolveEnvSecrets looks up env-provider secret source variables in the
+// current process environment and returns them with the presolved prefix.
+// Returns nil if no env-provider secrets reference accessible variables.
+func preResolveEnvSecrets(refs []core.SecretRef) []string {
+	var extra []string
+	for _, ref := range refs {
+		if ref.Provider != "env" || ref.Key == "" {
+			continue
+		}
+		if val, ok := os.LookupEnv(ref.Key); ok {
+			extra = append(extra, secrets.PresolvedEnvPrefix+ref.Key+"="+val)
+		}
+	}
+	return extra
+}
+
 // Start creates a start command spec.
 func (b *SubCmdBuilder) Start(dag *core.DAG, opts StartOptions) CmdSpec {
 	args := []string{"start"}
@@ -145,7 +162,7 @@ func (b *SubCmdBuilder) Start(dag *core.DAG, opts StartOptions) CmdSpec {
 	return CmdSpec{
 		Executable: b.executable,
 		Args:       args,
-		Env:        b.env(),
+		Env:        b.env(preResolveEnvSecrets(dag.Secrets)...),
 	}
 }
 
@@ -227,7 +244,7 @@ func (b *SubCmdBuilder) Restart(dag *core.DAG, opts RestartOptions) CmdSpec {
 	return CmdSpec{
 		Executable: b.executable,
 		Args:       args,
-		Env:        b.env(),
+		Env:        b.env(preResolveEnvSecrets(dag.Secrets)...),
 	}
 }
 
@@ -247,14 +264,16 @@ func (b *SubCmdBuilder) Retry(dag *core.DAG, dagRunID string, stepName string) C
 	return CmdSpec{
 		Executable: b.executable,
 		Args:       args,
-		Env:        b.env(),
+		Env:        b.env(preResolveEnvSecrets(dag.Secrets)...),
 	}
 }
 
 // TaskStart creates a start command spec for coordinator tasks.
-func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task) CmdSpec {
+// secretHints optionally provides secret refs for pre-resolving env-provider
+// secrets. Pass nil if the DAG has not been loaded yet in the caller.
+func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task, secretHints []core.SecretRef) CmdSpec {
 	args := []string{"start", "-q"}
-	env := b.env()
+	env := b.env(preResolveEnvSecrets(secretHints)...)
 
 	// Add hierarchy flags for sub DAGs
 	if task.RootDagRunId != "" {
@@ -303,9 +322,11 @@ func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task) CmdSpec {
 }
 
 // TaskRetry creates a retry command spec for coordinator tasks.
-func (b *SubCmdBuilder) TaskRetry(task *coordinatorv1.Task) CmdSpec {
+// secretHints optionally provides secret refs for pre-resolving env-provider
+// secrets. Pass nil if the DAG has not been loaded yet in the caller.
+func (b *SubCmdBuilder) TaskRetry(task *coordinatorv1.Task, secretHints []core.SecretRef) CmdSpec {
 	args := []string{"retry", fmt.Sprintf("--run-id=%s", task.DagRunId), "-q"}
-	env := b.env()
+	env := b.env(preResolveEnvSecrets(secretHints)...)
 
 	if task.Step != "" {
 		args = append(args, fmt.Sprintf("--step=%s", task.Step))

--- a/internal/runtime/subcmd_test.go
+++ b/internal/runtime/subcmd_test.go
@@ -630,7 +630,7 @@ func TestTaskStart(t *testing.T) {
 			DagRunId: "task-run-id",
 			Target:   "/path/to/task.yaml",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Equal(t, "/usr/bin/dagu", spec.Executable)
 		assert.Contains(t, spec.Args, "start")
@@ -652,7 +652,7 @@ func TestTaskStart(t *testing.T) {
 			ParentDagRunId:   "parent-id",
 			ParentDagRunName: "parent-dag",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--root=root-dag:root-id")
 		assert.Contains(t, spec.Args, "--parent=parent-dag:parent-id")
@@ -667,7 +667,7 @@ func TestTaskStart(t *testing.T) {
 			Target:   "/path/to/task.yaml",
 			Params:   "env=production",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--")
 		assert.Contains(t, spec.Args, "env=production")
@@ -681,7 +681,7 @@ func TestTaskStart(t *testing.T) {
 			RootDagRunId:   "root-id",
 			RootDagRunName: "root-dag",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--root=root-dag:root-id")
 		// Should not contain parent flags
@@ -698,7 +698,7 @@ func TestTaskStart(t *testing.T) {
 			ParentDagRunId:   "parent-id",
 			ParentDagRunName: "parent-dag",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--parent=parent-dag:parent-id")
 		// Should not contain root flags
@@ -714,7 +714,7 @@ func TestTaskStart(t *testing.T) {
 			Target:   "/path/to/task.yaml",
 			Tags:     "env=prod,team=backend",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--tags=env=prod,team=backend")
 	})
@@ -726,7 +726,7 @@ func TestTaskStart(t *testing.T) {
 			Target:       "/path/to/task.yaml",
 			ScheduleTime: "2026-03-13T10:00:00Z",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Args, "--schedule-time=2026-03-13T10:00:00Z")
 	})
@@ -738,7 +738,7 @@ func TestTaskStart(t *testing.T) {
 			Target:            "/path/to/task.yaml",
 			ExternalStepRetry: true,
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		assert.Contains(t, spec.Env, exec.EnvKeyExternalStepRetry+"=1")
 	})
@@ -749,7 +749,7 @@ func TestTaskStart(t *testing.T) {
 			DagRunId: "task-run-id",
 			Target:   "/path/to/task.yaml",
 		}
-		spec := builder.TaskStart(task)
+		spec := builder.TaskStart(task, nil)
 
 		for _, arg := range spec.Args {
 			assert.NotContains(t, arg, "--tags=")
@@ -768,7 +768,7 @@ func TestTaskStart(t *testing.T) {
 			DagRunId: "task-run-id",
 			Target:   "/path/to/task.yaml",
 		}
-		spec := builderNoFile.TaskStart(task)
+		spec := builderNoFile.TaskStart(task, nil)
 
 		assert.NotContains(t, spec.Args, "--config")
 	})
@@ -796,7 +796,7 @@ func TestTaskRetry(t *testing.T) {
 			Target:         "/path/to/task.yaml",
 			RootDagRunName: "root-dag",
 		}
-		spec := builder.TaskRetry(task)
+		spec := builder.TaskRetry(task, nil)
 
 		assert.Equal(t, "/usr/bin/dagu", spec.Executable)
 		assert.Contains(t, spec.Args, "retry")
@@ -814,7 +814,7 @@ func TestTaskRetry(t *testing.T) {
 			Target:   "/path/to/task.yaml",
 			Step:     "failed-step",
 		}
-		spec := builder.TaskRetry(task)
+		spec := builder.TaskRetry(task, nil)
 
 		assert.Contains(t, spec.Args, "--step=failed-step")
 	})
@@ -827,7 +827,7 @@ func TestTaskRetry(t *testing.T) {
 			RootDagRunName:    "root-dag",
 			ExternalStepRetry: true,
 		}
-		spec := builder.TaskRetry(task)
+		spec := builder.TaskRetry(task, nil)
 
 		assert.Contains(t, spec.Env, "PATH=/usr/bin")
 		assert.Contains(t, spec.Env, "HOME=/tmp/test-home")
@@ -846,7 +846,7 @@ func TestTaskRetry(t *testing.T) {
 			DagRunId: "retry-run-id",
 			Target:   "/path/to/task.yaml",
 		}
-		spec := builderNoFile.TaskRetry(task)
+		spec := builderNoFile.TaskRetry(task, nil)
 
 		assert.NotContains(t, spec.Args, "--config")
 	})

--- a/internal/service/worker/handler.go
+++ b/internal/service/worker/handler.go
@@ -87,10 +87,10 @@ func (e *taskHandler) Handle(ctx context.Context, task *coordinatorv1.Task) erro
 func (e *taskHandler) buildCommandSpec(task *coordinatorv1.Task) (runtime.CmdSpec, error) {
 	switch task.Operation {
 	case coordinatorv1.Operation_OPERATION_START:
-		return e.subCmdBuilder.TaskStart(task), nil
+		return e.subCmdBuilder.TaskStart(task, nil), nil
 
 	case coordinatorv1.Operation_OPERATION_RETRY:
-		return e.subCmdBuilder.TaskRetry(task), nil
+		return e.subCmdBuilder.TaskRetry(task, nil), nil
 
 	case coordinatorv1.Operation_OPERATION_UNSPECIFIED:
 		return runtime.CmdSpec{}, fmt.Errorf("operation not specified")


### PR DESCRIPTION
## Summary
- When Dagu spawns a subprocess (start, restart, retry), the child process inherits a filtered environment that may exclude variables used by env-provider secrets, causing secret resolution to fail
- Added `preResolveEnvSecrets()` which looks up env-provider secret source variables in the parent process and passes them to the subprocess via `_DAGU_PRESOLVED_SECRET_<KEY>` transport env vars
- Updated the env secret resolver to check for presolved prefix vars as a fallback when the original env var is not in scope
- Filtered `_DAGU_PRESOLVED_SECRET_*` vars from `EnvScope` so they never leak into step environments
- Updated `TaskStart` and `TaskRetry` signatures to accept optional secret hints for distributed worker mode

## Testing
- `make test TEST_TARGET=./internal/cmn/eval/... -count=1`
- `make test TEST_TARGET=./internal/cmn/secrets/... -count=1`
- `make test TEST_TARGET=./internal/runtime/... -count=1`

Closes #1852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced support for pre-resolved environment-based secrets that are injected into subprocess environments
  * Pre-resolved secrets now take precedence during secret resolution over standard environment variables
  * Internal secret transport variables are excluded from normal environment scopes to prevent interference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->