### PR TITLE
fix: track installer tmpfiles in parent shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,6 @@ jobs:
       - name: Test
         if: runner.os != 'Windows'
         run: |
-          make test-installer
           make test-coverage
 
       - name: Test (Windows)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ run-server-https: ${SERVER_CERT_FILE} ${SERVER_KEY_FILE}
 
 # test runs all tests.
 .PHONY: test
-test: bin
+test: test-installer bin
 	@printf '%b\n' "${COLOR_GREEN}Running tests...${COLOR_RESET}"
 	@GOBIN=${LOCAL_BIN_DIR} go install ${PKG_gotestsum}
 	@go clean -testcache
@@ -157,7 +157,7 @@ test: bin
 
 # test-coverage runs all tests with coverage.
 .PHONY: test-coverage
-test-coverage:
+test-coverage: test-installer
 	@printf '%b\n' "${COLOR_GREEN}Running tests with coverage...${COLOR_RESET}"
 	@GOBIN=${LOCAL_BIN_DIR} go install ${PKG_gotestsum}
 	@${LOCAL_BIN_DIR}/gotestsum ${GOTESTSUM_ARGS} -- ${GO_TEST_FLAGS} -coverpkg=./... -coverprofile="coverage.out" -covermode=atomic ${TEST_TARGET}

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -2,8 +2,6 @@
 # Copyright (C) 2026 Yota Hamada
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-set -euo pipefail
-
 RELEASES_URL="https://github.com/dagu-org/dagu/releases"
 GITHUB_API_URL="https://api.github.com/repos/dagu-org/dagu/releases/latest"
 FILE_BASENAME="dagu"
@@ -26,7 +24,11 @@ cleanup_tmpfiles() {
         rm -rf "$f" 2>/dev/null || true
     done
 }
-trap cleanup_tmpfiles EXIT
+
+init_runtime() {
+    set -euo pipefail
+    trap cleanup_tmpfiles EXIT
+}
 
 set_outvar() {
     local __dagu_set_outvar_name="${1:?missing output variable}"
@@ -136,82 +138,84 @@ Options:
 EOF
 }
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --version)
-            shift
-            VERSION="${1:-}"
-            ;;
-        --install-dir|--prefix)
-            shift
-            DAGU_INSTALL_DIR="${1:-}"
-            ;;
-        --working-dir)
-            shift
-            WORKING_ROOT_DIR="${1:-}"
-            ;;
-        --service)
-            shift
-            SERVICE_MODE="${1:-}"
-            ;;
-        --service-scope)
-            shift
-            SERVICE_SCOPE="${1:-}"
-            ;;
-        --host)
-            shift
-            HOST="${1:-}"
-            ;;
-        --port)
-            shift
-            PORT="${1:-}"
-            ;;
-        --skills-dir)
-            shift
-            EXPLICIT_SKILL_DIRS+=("${1:-}")
-            ;;
-        --admin-username)
-            shift
-            ADMIN_USERNAME="${1:-}"
-            ;;
-        --admin-password)
-            shift
-            ADMIN_PASSWORD="${1:-}"
-            ;;
-        --open-browser)
-            shift
-            OPEN_BROWSER="${1:-}"
-            ;;
-        --no-prompt)
-            NO_PROMPT=1
-            ;;
-        --dry-run)
-            DRY_RUN=1
-            ;;
-        --verbose)
-            VERBOSE=1
-            ;;
-        --uninstall)
-            UNINSTALL_MODE=1
-            ;;
-        --purge-data)
-            PURGE_DATA=1
-            ;;
-        --remove-skill)
-            REMOVE_SKILL=1
-            ;;
-        --help|-h)
-            usage
-            exit 0
-            ;;
-        *)
-            printf '%s\n' "Unknown argument: $1" >&2
-            usage >&2
-            exit 2
-            ;;
-    esac
-    shift
-done
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version)
+                shift
+                VERSION="${1:-}"
+                ;;
+            --install-dir|--prefix)
+                shift
+                DAGU_INSTALL_DIR="${1:-}"
+                ;;
+            --working-dir)
+                shift
+                WORKING_ROOT_DIR="${1:-}"
+                ;;
+            --service)
+                shift
+                SERVICE_MODE="${1:-}"
+                ;;
+            --service-scope)
+                shift
+                SERVICE_SCOPE="${1:-}"
+                ;;
+            --host)
+                shift
+                HOST="${1:-}"
+                ;;
+            --port)
+                shift
+                PORT="${1:-}"
+                ;;
+            --skills-dir)
+                shift
+                EXPLICIT_SKILL_DIRS+=("${1:-}")
+                ;;
+            --admin-username)
+                shift
+                ADMIN_USERNAME="${1:-}"
+                ;;
+            --admin-password)
+                shift
+                ADMIN_PASSWORD="${1:-}"
+                ;;
+            --open-browser)
+                shift
+                OPEN_BROWSER="${1:-}"
+                ;;
+            --no-prompt)
+                NO_PROMPT=1
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                ;;
+            --verbose)
+                VERBOSE=1
+                ;;
+            --uninstall)
+                UNINSTALL_MODE=1
+                ;;
+            --purge-data)
+                PURGE_DATA=1
+                ;;
+            --remove-skill)
+                REMOVE_SKILL=1
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                printf '%s\n' "Unknown argument: $1" >&2
+                usage >&2
+                exit 2
+                ;;
+        esac
+        shift
+    done
+}
 
 detect_downloader() {
     if command -v curl >/dev/null 2>&1; then
@@ -2152,6 +2156,8 @@ print_summary() {
 }
 
 main() {
+    init_runtime
+    parse_args "$@"
     bootstrap_gum_temp || true
     print_banner
     detect_os_arch

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -11,11 +11,25 @@ fixture_dir="$(mktemp -d)"
 trap 'rm -rf "${fixture_dir}"' EXIT
 
 bash -c '
-    set -euo pipefail
-
     installer_path="$1"
-    set --
+    set -- keep positional args
+    trap '\''true'\'' EXIT
+    before_flags="$(set +o)"
+    before_exit_trap="$(trap -p EXIT)"
+
     source "${installer_path}"
+
+    after_flags="$(set +o)"
+    after_exit_trap="$(trap -p EXIT)"
+
+    [[ "$#" -eq 3 ]]
+    [[ "$1" == "keep" ]]
+    [[ "$2" == "positional" ]]
+    [[ "$3" == "args" ]]
+    [[ "${before_flags}" == "${after_flags}" ]]
+    [[ "${before_exit_trap}" == "${after_exit_trap}" ]]
+
+    set -euo pipefail
 
     mktempdir tmpdir
     mktempfile tmpfile
@@ -37,12 +51,11 @@ DAGU_AUTH_BUILTIN_INITIAL_ADMIN_PASSWORD=supersecret
 EOF
 
 bash -c '
-    set -euo pipefail
-
     installer_path="$1"
     bootstrap_path="$2"
-    set --
     source "${installer_path}"
+
+    set -euo pipefail
 
     OS="linux"
     SERVICE_SCOPE="user"


### PR DESCRIPTION
## Summary
- refactor `scripts/installer.sh` temp file helpers to assign paths in the parent shell, track bootstrap backups for cleanup, and only call `main` when the script is executed directly so sourced helper tests work correctly
- add `scripts/test-installer.sh`, wire it into `make test-installer`, and run it from CI so installer tmpfile cleanup regressions are covered automatically
- refresh the bundled `dagu` skill reference with a new pitfalls guide and update prompts, docs, and Go tests so installed and embedded skill assets stay complete and in sync

## Testing
- `make test-installer`
- `go test ./internal/cmd -count=1`

Closes #1868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CI pipeline to automatically run installer tests when installer scripts change
  * Added comprehensive regression test suite for installer validation
* **Chores**
  * Refactored installer script for improved reliability and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->