### PR TITLE
fix: preserve kubernetes discovery env for worker command steps

### DIFF
--- a/internal/cmn/config/env.go
+++ b/internal/cmn/config/env.go
@@ -28,6 +28,7 @@ var defaultPrefixes = []string{
 	strings.ToUpper(AppName) + "_", // e.g., "DAGU_"
 	"DAG_",                         // Special DAG-related variables
 	"LC_",                          // Locale-related variables
+	"KUBERNETES_",                  // In-cluster API discovery vars for Kubernetes clients
 }
 
 // LoadBaseEnv loads and filters current environment variables.

--- a/internal/cmn/config/env_test.go
+++ b/internal/cmn/config/env_test.go
@@ -27,6 +27,12 @@ func TestLoadBaseEnv(t *testing.T) {
 
 		// Docker credentials must NOT leak through the global env.
 		{"DOCKER_AUTH_CONFIG", false},
+
+		// Kubernetes in-cluster discovery vars must pass through so kubectl and
+		// client-go based tools do not fall back to localhost:8080.
+		{"KUBERNETES_SERVICE_HOST", true},
+		{"KUBERNETES_SERVICE_PORT", true},
+		{"KUBERNETES_SERVICE_PORT_HTTPS", true},
 	}
 
 	for _, tc := range testCases {

--- a/internal/core/exec/context_test.go
+++ b/internal/core/exec/context_test.go
@@ -237,6 +237,8 @@ func TestNewContext_AllEnvsUsesFilteredBaseEnv(t *testing.T) {
 	cfg.Core.BaseEnv = config.NewBaseEnv([]string{
 		"PATH=/usr/bin:/bin",
 		"EXEC_CONTEXT_ALLOWED=allowed",
+		"KUBERNETES_SERVICE_HOST=10.0.0.1",
+		"KUBERNETES_SERVICE_PORT=443",
 	})
 
 	ctx := config.WithConfig(context.Background(), cfg)
@@ -251,6 +253,8 @@ func TestNewContext_AllEnvsUsesFilteredBaseEnv(t *testing.T) {
 
 	assert.Contains(t, envs, "PATH=/usr/bin:/bin")
 	assert.Contains(t, envs, "EXEC_CONTEXT_ALLOWED=allowed")
+	assert.Contains(t, envs, "KUBERNETES_SERVICE_HOST=10.0.0.1")
+	assert.Contains(t, envs, "KUBERNETES_SERVICE_PORT=443")
 	assert.Contains(t, envs, "DAG_VAR=dag")
 	assert.NotContains(t, envs, "EXEC_CONTEXT_HOST_ONLY=host-value")
 }

--- a/internal/service/worker/handler_test.go
+++ b/internal/service/worker/handler_test.go
@@ -286,6 +286,85 @@ steps:
 		require.Equal(t, core.Succeeded, retriedStatus.Status)
 		require.Equal(t, "from-host|", workerStatusOutputValue(t, retriedStatus, "RESULT"))
 	})
+
+	t.Run("HandleTaskStartPreservesKubernetesDiscoveryEnv", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+		t.Setenv("WORKER_TASK_HOST_ONLY_ENV", "host-only")
+
+		dagContent := `steps:
+  - name: capture
+    command: printf '%s|%s|%s' "${KUBERNETES_SERVICE_HOST:-}" "${KUBERNETES_SERVICE_PORT:-}" "${WORKER_TASK_HOST_ONLY_ENV:-}"
+    output: RESULT
+`
+		dag := th.DAG(t, dagContent)
+		runID := uuid.Must(uuid.NewV7()).String()
+		task := runtimeexec.CreateTask(
+			dag.Name,
+			dagContent,
+			coordinatorv1.Operation_OPERATION_START,
+			runID,
+		)
+
+		handler := NewTaskHandler(th.Config)
+		err := handler.Handle(th.Context, task)
+		require.NoError(t, err)
+
+		status, err := th.DAGRunMgr.GetCurrentStatus(th.Context, dag.DAG, runID)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.Equal(t, core.Succeeded, status.Status)
+		require.Equal(t, "10.43.0.1|443|", workerStatusOutputValue(t, status, "RESULT"))
+	})
+
+	t.Run("HandleTaskRetryPreservesKubernetesDiscoveryEnv", func(t *testing.T) {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+		t.Setenv("WORKER_TASK_HOST_ONLY_ENV", "host-only")
+
+		dagContent := `steps:
+  - name: capture
+    command: printf '%s|%s|%s' "${KUBERNETES_SERVICE_HOST:-}" "${KUBERNETES_SERVICE_PORT:-}" "${WORKER_TASK_HOST_ONLY_ENV:-}"
+    output: RESULT
+`
+		dag := th.DAG(t, dagContent)
+		runID := uuid.Must(uuid.NewV7()).String()
+		handler := NewTaskHandler(th.Config)
+
+		startTask := runtimeexec.CreateTask(
+			dag.Name,
+			dagContent,
+			coordinatorv1.Operation_OPERATION_START,
+			runID,
+		)
+		err := handler.Handle(th.Context, startTask)
+		require.NoError(t, err)
+
+		initialAttempt, err := th.DAGRunStore.FindAttempt(th.Context, exec.NewDAGRunRef(dag.Name, runID))
+		require.NoError(t, err)
+		initialStatus, err := initialAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, "10.43.0.1|443|", workerStatusOutputValue(t, initialStatus, "RESULT"))
+
+		retryTask := runtimeexec.CreateTask(
+			dag.Name,
+			dagContent,
+			coordinatorv1.Operation_OPERATION_RETRY,
+			runID,
+			runtimeexec.WithPreviousStatus(initialStatus),
+		)
+		err = handler.Handle(th.Context, retryTask)
+		require.NoError(t, err)
+
+		retriedAttempt, err := th.DAGRunStore.FindAttempt(th.Context, exec.NewDAGRunRef(dag.Name, runID))
+		require.NoError(t, err)
+		require.NotEqual(t, initialAttempt.ID(), retriedAttempt.ID())
+
+		retriedStatus, err := retriedAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Succeeded, retriedStatus.Status)
+		require.Equal(t, "10.43.0.1|443|", workerStatusOutputValue(t, retriedStatus, "RESULT"))
+	})
 }
 
 func TestCreateTempDAGFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow `KUBERNETES_` discovery env vars through the filtered base env used for step execution
- preserve the existing isolated step env model for unrelated host env vars
- add regression coverage for base env loading, exec context env composition, and worker task start/retry execution

## Testing
- go test ./internal/cmn/config ./internal/core/exec ./internal/service/worker

Related to #1922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kubernetes environment variables. Variables starting with `KUBERNETES_` (such as service host and port information) are now preserved and passed to child processes, enabling better Kubernetes in-cluster discovery support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->