### PR TITLE
fix: allow keyless local agent setup

### DIFF
--- a/internal/service/frontend/api/v1/agent_models_test.go
+++ b/internal/service/frontend/api/v1/agent_models_test.go
@@ -836,6 +836,30 @@ func TestApplyModelUpdates(t *testing.T) {
 		assert.Equal(t, "gpt-4", updateResp.Model)
 	})
 
+	t.Run("empty api key clears stored key", func(t *testing.T) {
+		t.Parallel()
+
+		setup := newAgentTestSetup(t)
+		setup.modelStore.addModel(&agent.ModelConfig{
+			ID: "m1", Name: "Test", Provider: "local", Model: "llama3.2",
+			APIKey: "placeholder-key",
+		})
+
+		emptyKey := ""
+		resp, err := setup.api.UpdateAgentModel(adminCtx(), apigen.UpdateAgentModelRequestObject{
+			ModelId: "m1",
+			Body: &apigen.UpdateModelConfigRequest{
+				ApiKey: &emptyKey,
+			},
+		})
+		require.NoError(t, err)
+
+		updateResp, ok := resp.(apigen.UpdateAgentModel200JSONResponse)
+		require.True(t, ok)
+		assert.False(t, valueOrZero(updateResp.ApiKeyConfigured))
+		assert.Empty(t, setup.modelStore.models["m1"].APIKey)
+	})
+
 	t.Run("all fields applied when set", func(t *testing.T) {
 		t.Parallel()
 

--- a/ui/src/features/agent/modelProviders.ts
+++ b/ui/src/features/agent/modelProviders.ts
@@ -1,0 +1,107 @@
+export const AGENT_MODEL_PROVIDER_VALUES = [
+  'anthropic',
+  'openai',
+  'openai-codex',
+  'gemini',
+  'openrouter',
+  'local',
+  'zai',
+] as const;
+
+export type AgentModelProvider = (typeof AGENT_MODEL_PROVIDER_VALUES)[number];
+export type AgentModelProviderAuthMode = 'direct' | 'subscription';
+export type AgentModelProviderAPIKeyMode = 'hidden' | 'required' | 'optional';
+
+export type AgentModelProviderMeta = {
+  value: AgentModelProvider;
+  label: string;
+  authMode: AgentModelProviderAuthMode;
+  apiKeyMode: AgentModelProviderAPIKeyMode;
+  modelPlaceholder: string;
+  baseUrlPlaceholder?: string;
+  apiKeyHelperText?: string;
+};
+
+export const AGENT_MODEL_PROVIDERS: readonly AgentModelProviderMeta[] = [
+  {
+    value: 'anthropic',
+    label: 'Anthropic',
+    authMode: 'direct',
+    apiKeyMode: 'required',
+    modelPlaceholder: 'claude-sonnet-4-6',
+    baseUrlPlaceholder: 'Custom API endpoint',
+  },
+  {
+    value: 'openai',
+    label: 'OpenAI',
+    authMode: 'direct',
+    apiKeyMode: 'required',
+    modelPlaceholder: 'gpt-5.4',
+    baseUrlPlaceholder: 'Custom API endpoint',
+  },
+  {
+    value: 'openai-codex',
+    label: 'OpenAI Codex',
+    authMode: 'subscription',
+    apiKeyMode: 'hidden',
+    modelPlaceholder: 'gpt-5.4',
+  },
+  {
+    value: 'gemini',
+    label: 'Google Gemini',
+    authMode: 'direct',
+    apiKeyMode: 'required',
+    modelPlaceholder: 'gemini-3-pro-preview',
+    baseUrlPlaceholder: 'Custom API endpoint',
+  },
+  {
+    value: 'openrouter',
+    label: 'OpenRouter',
+    authMode: 'direct',
+    apiKeyMode: 'required',
+    modelPlaceholder: 'anthropic/claude-sonnet-4-6',
+    baseUrlPlaceholder: 'Defaults to https://openrouter.ai/api/v1',
+  },
+  {
+    value: 'local',
+    label: 'Local',
+    authMode: 'direct',
+    apiKeyMode: 'optional',
+    modelPlaceholder: 'llama3.2',
+    baseUrlPlaceholder: 'Defaults to http://localhost:11434/v1',
+    apiKeyHelperText: 'Leave empty for local endpoints that do not require authentication.',
+  },
+  {
+    value: 'zai',
+    label: 'Z.AI',
+    authMode: 'direct',
+    apiKeyMode: 'required',
+    modelPlaceholder: 'glm-5',
+    baseUrlPlaceholder: 'Custom API endpoint',
+  },
+] as const;
+
+const AGENT_MODEL_PROVIDER_META_MAP: Readonly<
+  Record<AgentModelProvider, AgentModelProviderMeta>
+> = Object.fromEntries(
+  AGENT_MODEL_PROVIDERS.map((provider) => [provider.value, provider])
+) as Record<AgentModelProvider, AgentModelProviderMeta>;
+
+export function isAgentModelProvider(
+  value: string
+): value is AgentModelProvider {
+  return (AGENT_MODEL_PROVIDER_VALUES as readonly string[]).includes(value);
+}
+
+export function getAgentModelProviderMeta(
+  provider: AgentModelProvider
+): AgentModelProviderMeta {
+  return AGENT_MODEL_PROVIDER_META_MAP[provider];
+}
+
+export function getAgentModelProviderLabel(provider: string): string {
+  if (!isAgentModelProvider(provider)) {
+    return provider.charAt(0).toUpperCase() + provider.slice(1);
+  }
+  return getAgentModelProviderMeta(provider).label;
+}

--- a/ui/src/pages/__tests__/setup.test.tsx
+++ b/ui/src/pages/__tests__/setup.test.tsx
@@ -1,0 +1,318 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '@/contexts/ConfigContext';
+import { ConfigContext, ConfigUpdateContext } from '@/contexts/ConfigContext';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { useAgentAuthProviders } from '@/features/agent/hooks/useAgentAuthProviders';
+import { useClient } from '@/hooks/api';
+import SetupPage from '../setup';
+
+const navigateMock = vi.fn();
+const setupMock = vi.fn();
+const completeSetupMock = vi.fn();
+const updateConfigMock = vi.fn();
+const getMock = vi.fn();
+const patchMock = vi.fn();
+const postMock = vi.fn();
+const putMock = vi.fn();
+const startLoginMock = vi.fn();
+const completeLoginMock = vi.fn();
+const disconnectMock = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/api', () => ({
+  useClient: vi.fn(),
+}));
+
+vi.mock('@/features/agent/hooks/useAgentAuthProviders', () => ({
+  useAgentAuthProviders: vi.fn(),
+}));
+
+const useAuthMock = vi.mocked(useAuth);
+const useClientMock = vi.mocked(useClient);
+const useAgentAuthProvidersMock = vi.mocked(useAgentAuthProviders);
+
+const config: Config = {
+  apiURL: '/api/v1',
+  basePath: '/',
+  title: 'Dagu',
+  navbarColor: '',
+  tz: 'UTC',
+  tzOffsetInSec: 0,
+  version: 'test',
+  maxDashboardPageLimit: 100,
+  remoteNodes: '',
+  initialWorkspaces: [],
+  authMode: 'builtin',
+  setupRequired: true,
+  oidcEnabled: false,
+  oidcButtonLabel: '',
+  terminalEnabled: false,
+  gitSyncEnabled: false,
+  agentEnabled: false,
+  updateAvailable: false,
+  latestVersion: '',
+  permissions: {
+    writeDags: true,
+    runDags: true,
+  },
+  license: {
+    valid: true,
+    plan: 'community',
+    expiry: '',
+    features: [],
+    gracePeriod: false,
+    community: true,
+    source: 'test',
+    warningCode: '',
+  },
+  paths: {
+    dagsDir: '',
+    logDir: '',
+    suspendFlagsDir: '',
+    adminLogsDir: '',
+    baseConfig: '',
+    dagRunsDir: '',
+    queueDir: '',
+    procDir: '',
+    serviceRegistryDir: '',
+    configFileUsed: '',
+    gitSyncDir: '',
+    auditLogsDir: '',
+  },
+};
+
+const appBarContextValue = {
+  title: '',
+  setTitle: vi.fn(),
+  remoteNodes: ['local'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'local',
+  selectRemoteNode: vi.fn(),
+};
+
+const presets = [
+  {
+    name: 'Claude Sonnet 4.6',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    description: 'Best balance of speed and intelligence.',
+    contextWindow: 200_000,
+    maxOutputTokens: 64_000,
+    inputCostPer1M: 3,
+    outputCostPer1M: 15,
+    supportsThinking: true,
+  },
+  {
+    name: 'GPT-5.4 Codex',
+    provider: 'openai-codex',
+    model: 'gpt-5.4',
+    description: 'Latest Codex model via your ChatGPT Plus/Pro subscription.',
+    contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
+    inputCostPer1M: 0,
+    outputCostPer1M: 0,
+    supportsThinking: true,
+  },
+];
+
+function renderPage() {
+  return render(
+    <ConfigContext.Provider value={config}>
+      <ConfigUpdateContext.Provider value={updateConfigMock}>
+        <AppBarContext.Provider value={appBarContextValue}>
+          <SetupPage />
+        </AppBarContext.Provider>
+      </ConfigUpdateContext.Provider>
+    </ConfigContext.Provider>
+  );
+}
+
+async function moveToAgentStep() {
+  fireEvent.change(screen.getByLabelText('Username'), {
+    target: { value: 'admin-user' },
+  });
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'password123' },
+  });
+  fireEvent.change(screen.getByLabelText('Confirm Password'), {
+    target: { value: 'password123' },
+  });
+
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  await screen.findByText('Enable AI Agent');
+  await waitFor(() => {
+    expect(getMock).toHaveBeenCalledWith('/settings/agent/model-presets', {
+      params: { query: { remoteNode: 'local' } },
+    });
+  });
+}
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  setupMock.mockReset();
+  completeSetupMock.mockReset();
+  updateConfigMock.mockReset();
+  getMock.mockReset();
+  patchMock.mockReset();
+  postMock.mockReset();
+  putMock.mockReset();
+  startLoginMock.mockReset();
+  completeLoginMock.mockReset();
+  disconnectMock.mockReset();
+
+  setupMock.mockResolvedValue({
+    token: 'token-1',
+    user: { id: '1', username: 'admin-user', role: 'admin' },
+  });
+  getMock.mockResolvedValue({ data: { presets } });
+  patchMock.mockResolvedValue({});
+  postMock.mockResolvedValue({ data: { id: 'created-model' } });
+  putMock.mockResolvedValue({});
+
+  useAuthMock.mockReturnValue({
+    user: null,
+    token: null,
+    isAuthenticated: false,
+    isLoading: false,
+    setupRequired: true,
+    login: vi.fn(),
+    setup: setupMock,
+    logout: vi.fn(),
+    refreshUser: vi.fn(),
+    completeSetup: completeSetupMock,
+  });
+
+  useClientMock.mockReturnValue({
+    GET: getMock,
+    PATCH: patchMock,
+    POST: postMock,
+    PUT: putMock,
+  } as never);
+
+  useAgentAuthProvidersMock.mockReturnValue({
+    providers: [],
+    providerMap: {
+      'openai-codex': {
+        id: 'openai-codex',
+        name: 'OpenAI Codex',
+        connected: false,
+        expiresAt: '',
+        accountId: '',
+      },
+    },
+    remoteNode: 'local',
+    isLoading: false,
+    error: null,
+    refreshProviders: vi.fn(),
+    startLogin: startLoginMock,
+    completeLogin: completeLoginMock,
+    disconnect: disconnectMock,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SetupPage', () => {
+  it('allows local onboarding without an API key and omits blank credentials', async () => {
+    renderPage();
+    await moveToAgentStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Local' }));
+
+    expect(screen.getByText('API Key (optional)')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Leave empty for local endpoints that do not require authentication.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Defaults to http://localhost:11434/v1')
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Model'), {
+      target: { value: 'llama3.2' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Setup' }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+
+    expect(patchMock).toHaveBeenCalledWith('/settings/agent', {
+      params: { query: { remoteNode: 'local' } },
+      body: { enabled: true },
+    });
+    expect(postMock).toHaveBeenCalledWith('/settings/agent/models', {
+      params: { query: { remoteNode: 'local' } },
+      body: expect.objectContaining({
+        id: 'llama3-2',
+        name: 'llama3.2',
+        provider: 'local',
+        model: 'llama3.2',
+        supportsThinking: false,
+      }),
+    });
+    const createBody = postMock.mock.calls[0]![1]!.body as Record<
+      string,
+      unknown
+    >;
+    expect(createBody.apiKey).toBeUndefined();
+    expect(createBody.baseUrl).toBeUndefined();
+    expect(putMock).toHaveBeenCalledWith('/settings/agent/default-model', {
+      params: { query: { remoteNode: 'local' } },
+      body: { modelId: 'created-model' },
+    });
+    expect(updateConfigMock).toHaveBeenCalledWith({ agentEnabled: true });
+    expect(navigateMock).toHaveBeenCalledWith('/', {
+      replace: true,
+      state: { openAgent: true },
+    });
+  });
+
+  it('requires an API key for manual OpenRouter setup', async () => {
+    renderPage();
+    await moveToAgentStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'OpenRouter' }));
+    fireEvent.change(screen.getByLabelText('Model'), {
+      target: { value: 'anthropic/claude-sonnet-4-6' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete Setup' }));
+
+    expect(
+      await screen.findByText('Please enter an API key')
+    ).toBeInTheDocument();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps preset selection and subscription auth for OpenAI Codex', async () => {
+    renderPage();
+    await moveToAgentStep();
+
+    fireEvent.click(screen.getByRole('button', { name: 'OpenAI Codex' }));
+
+    expect(screen.queryByLabelText('API Key')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument();
+    expect(screen.getByText('Select a model...')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Complete Setup' })
+    ).toBeDisabled();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/agent-settings/ModelFormModal.tsx
+++ b/ui/src/pages/agent-settings/ModelFormModal.tsx
@@ -3,6 +3,7 @@ import { useConfig } from '@/contexts/ConfigContext';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { components } from '@/api/v1/schema';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -21,6 +22,11 @@ import {
 } from '@/components/ui/dialog';
 import { Switch } from '@/components/ui/switch';
 import { ProviderAuthCard } from '@/features/agent/components/ProviderAuthCard';
+import {
+  AGENT_MODEL_PROVIDERS,
+  type AgentModelProvider,
+  getAgentModelProviderMeta,
+} from '@/features/agent/modelProviders';
 import { getAuthHeaders } from '@/lib/authHeaders';
 
 type ModelConfig = components['schemas']['ModelConfigResponse'];
@@ -33,16 +39,6 @@ type CompleteAgentAuthProviderLoginRequest = components['schemas']['CompleteAgen
 function generateSlugId(name: string): string {
   return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
-
-const LLM_PROVIDERS = [
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'openai-codex', label: 'OpenAI Codex' },
-  { value: 'gemini', label: 'Google Gemini' },
-  { value: 'openrouter', label: 'OpenRouter' },
-  { value: 'local', label: 'Local' },
-  { value: 'zai', label: 'Z.AI' },
-];
 
 const REASONING_DEFAULT_VALUE = '__default__';
 const REASONING_EFFORT_OPTIONS = [
@@ -88,9 +84,10 @@ export function ModelFormModal({
   const [configId, setConfigId] = useState('');
   const [customId, setCustomId] = useState(false);
   const [name, setName] = useState('');
-  const [provider, setProvider] = useState('anthropic');
+  const [provider, setProvider] = useState<AgentModelProvider>('anthropic');
   const [modelId, setModelId] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [clearStoredAPIKey, setClearStoredAPIKey] = useState(false);
   const [baseUrl, setBaseUrl] = useState('');
   const [description, setDescription] = useState('');
   const [contextWindow, setContextWindow] = useState<number | ''>('');
@@ -101,7 +98,8 @@ export function ModelFormModal({
   const [thinkingEffort, setThinkingEffort] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const usesSubscriptionAuth = provider === 'openai-codex';
+  const providerMeta = getAgentModelProviderMeta(provider);
+  const usesSubscriptionAuth = providerMeta.authMode === 'subscription';
   const codexConnected = codexProvider?.connected ?? false;
 
   useEffect(() => {
@@ -119,6 +117,7 @@ export function ModelFormModal({
       setSupportsThinking(model.supportsThinking ?? false);
       setThinkingEffort(model.thinkingEffort ?? '');
       setApiKey('');
+      setClearStoredAPIKey(false);
     } else if (open && !model) {
       resetForm();
     }
@@ -134,6 +133,7 @@ export function ModelFormModal({
     setProvider('anthropic');
     setModelId('');
     setApiKey('');
+    setClearStoredAPIKey(false);
     setBaseUrl('');
     setDescription('');
     setContextWindow('');
@@ -160,16 +160,18 @@ export function ModelFormModal({
       setSupportsThinking(preset.supportsThinking ?? false);
       setThinkingEffort(preset.thinkingEffort ?? '');
       setApiKey('');
+      setClearStoredAPIKey(false);
       setBaseUrl('');
     }
   };
 
   useEffect(() => {
-    if (provider === 'openai-codex') {
+    if (usesSubscriptionAuth) {
       setApiKey('');
+      setClearStoredAPIKey(false);
       setBaseUrl('');
     }
-  }, [provider]);
+  }, [usesSubscriptionAuth]);
 
   useEffect(() => {
     if (!supportsThinking) {
@@ -203,12 +205,15 @@ export function ModelFormModal({
         thinkingEffort: supportsThinking ? thinkingEffort : '',
       };
 
-      if (!usesSubscriptionAuth && baseUrl) {
-        body.baseUrl = baseUrl;
+      const trimmedBaseURL = baseUrl.trim();
+      if (!usesSubscriptionAuth && trimmedBaseURL !== '') {
+        body.baseUrl = trimmedBaseURL;
       }
 
       if (!usesSubscriptionAuth && apiKey) {
         body.apiKey = apiKey;
+      } else if (!usesSubscriptionAuth && isEditing && clearStoredAPIKey) {
+        body.apiKey = '';
       }
 
       const url = isEditing
@@ -309,12 +314,15 @@ export function ModelFormModal({
 
             <div className="space-y-1.5">
               <Label htmlFor="model-provider" className="text-sm">Provider</Label>
-              <Select value={provider} onValueChange={setProvider}>
+              <Select
+                value={provider}
+                onValueChange={(value) => setProvider(value as AgentModelProvider)}
+              >
                 <SelectTrigger id="model-provider" className="h-8">
                   <SelectValue placeholder="Select provider" />
                 </SelectTrigger>
                 <SelectContent>
-                  {LLM_PROVIDERS.map((p) => (
+                  {AGENT_MODEL_PROVIDERS.map((p) => (
                     <SelectItem key={p.value} value={p.value}>
                       {p.label}
                     </SelectItem>
@@ -329,7 +337,7 @@ export function ModelFormModal({
                 id="model-id"
                 value={modelId}
                 onChange={(e) => setModelId(e.target.value)}
-                placeholder="claude-sonnet-4-5"
+                placeholder={providerMeta.modelPlaceholder}
                 className="h-8"
                 required
               />
@@ -353,18 +361,56 @@ export function ModelFormModal({
             ) : (
               <>
                 <div className="space-y-1.5">
-                  <Label htmlFor="model-api-key" className="text-sm">API Key</Label>
+                  <Label htmlFor="model-api-key" className="text-sm">
+                    {providerMeta.apiKeyMode === 'optional'
+                      ? 'API Key (optional)'
+                      : 'API Key'}
+                  </Label>
                   <Input
                     id="model-api-key"
                     type="password"
                     value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      if (clearStoredAPIKey) {
+                        setClearStoredAPIKey(false);
+                      }
+                    }}
                     placeholder={isEditing && model?.apiKeyConfigured ? '********' : 'Enter API key'}
                     className="h-8"
+                    disabled={clearStoredAPIKey}
                   />
-                  {isEditing && model?.apiKeyConfigured && (
+                  {providerMeta.apiKeyHelperText && (
                     <p className="text-xs text-muted-foreground">
-                      Leave empty to keep existing key
+                      {providerMeta.apiKeyHelperText}
+                    </p>
+                  )}
+                  {isEditing && model?.apiKeyConfigured && !clearStoredAPIKey && (
+                    <p className="text-xs text-muted-foreground">
+                      Leave empty to keep existing key, or clear it below.
+                    </p>
+                  )}
+                  {isEditing && model?.apiKeyConfigured && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="clear-api-key"
+                        checked={clearStoredAPIKey}
+                        onCheckedChange={(checked) => {
+                          const enabled = checked === true;
+                          setClearStoredAPIKey(enabled);
+                          if (enabled) {
+                            setApiKey('');
+                          }
+                        }}
+                      />
+                      <Label htmlFor="clear-api-key" className="text-xs">
+                        Clear stored API key
+                      </Label>
+                    </div>
+                  )}
+                  {clearStoredAPIKey && (
+                    <p className="text-xs text-muted-foreground">
+                      Save changes to remove the stored key.
                     </p>
                   )}
                 </div>
@@ -375,7 +421,9 @@ export function ModelFormModal({
                     id="model-base-url"
                     value={baseUrl}
                     onChange={(e) => setBaseUrl(e.target.value)}
-                    placeholder="Custom API endpoint"
+                    placeholder={
+                      providerMeta.baseUrlPlaceholder ?? 'Custom API endpoint'
+                    }
                     className="h-8"
                   />
                 </div>

--- a/ui/src/pages/agent-settings/__tests__/ModelFormModal.test.tsx
+++ b/ui/src/pages/agent-settings/__tests__/ModelFormModal.test.tsx
@@ -1,0 +1,174 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ModelConfigResponseProvider } from '@/api/v1/schema';
+import type { Config } from '@/contexts/ConfigContext';
+import { ConfigContext } from '@/contexts/ConfigContext';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { ModelFormModal } from '../ModelFormModal';
+
+const fetchMock = vi.fn();
+
+vi.mock('@/lib/authHeaders', () => ({
+  getAuthHeaders: () => ({
+    'Content-Type': 'application/json',
+  }),
+}));
+
+const config: Config = {
+  apiURL: '/api/v1',
+  basePath: '/',
+  title: 'Dagu',
+  navbarColor: '',
+  tz: 'UTC',
+  tzOffsetInSec: 0,
+  version: 'test',
+  maxDashboardPageLimit: 100,
+  remoteNodes: '',
+  initialWorkspaces: [],
+  authMode: 'builtin',
+  setupRequired: false,
+  oidcEnabled: false,
+  oidcButtonLabel: '',
+  terminalEnabled: false,
+  gitSyncEnabled: false,
+  agentEnabled: true,
+  updateAvailable: false,
+  latestVersion: '',
+  permissions: {
+    writeDags: true,
+    runDags: true,
+  },
+  license: {
+    valid: true,
+    plan: 'community',
+    expiry: '',
+    features: [],
+    gracePeriod: false,
+    community: true,
+    source: 'test',
+    warningCode: '',
+  },
+  paths: {
+    dagsDir: '',
+    logDir: '',
+    suspendFlagsDir: '',
+    adminLogsDir: '',
+    baseConfig: '',
+    dagRunsDir: '',
+    queueDir: '',
+    procDir: '',
+    serviceRegistryDir: '',
+    configFileUsed: '',
+    gitSyncDir: '',
+    auditLogsDir: '',
+  },
+};
+
+const appBarContextValue = {
+  title: '',
+  setTitle: vi.fn(),
+  remoteNodes: ['local'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'local',
+  selectRemoteNode: vi.fn(),
+};
+
+const baseModel = {
+  id: 'local-model',
+  name: 'Local Model',
+  provider: ModelConfigResponseProvider.local,
+  model: 'llama3.2',
+  apiKeyConfigured: true,
+  baseUrl: '',
+  contextWindow: 0,
+  maxOutputTokens: 0,
+  inputCostPer1M: 0,
+  outputCostPer1M: 0,
+  supportsThinking: false,
+  description: '',
+};
+
+function renderModal() {
+  return render(
+    <ConfigContext.Provider value={config}>
+      <AppBarContext.Provider value={appBarContextValue}>
+        <ModelFormModal
+          open
+          model={baseModel}
+          presets={[]}
+          codexProvider={null}
+          onStartProviderLogin={vi.fn()}
+          onCompleteProviderLogin={vi.fn()}
+          onDisconnectProvider={vi.fn()}
+          onClose={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      </AppBarContext.Provider>
+    </ConfigContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({}),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ModelFormModal', () => {
+  it('shows local optional-auth metadata from the shared provider helper', async () => {
+    renderModal();
+
+    expect(await screen.findByText('API Key (optional)')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Leave empty for local endpoints that do not require authentication.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Defaults to http://localhost:11434/v1')
+    ).toBeInTheDocument();
+  });
+
+  it('sends an explicit empty apiKey when clearing a stored key', async () => {
+    renderModal();
+
+    fireEvent.click(await screen.findByLabelText('Clear stored API key'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/settings/agent/models/local-model?remoteNode=local',
+      expect.objectContaining({
+        method: 'PATCH',
+      })
+    );
+
+    const requestBody = JSON.parse(
+      fetchMock.mock.calls[0]![1]!.body as string
+    );
+    expect(requestBody.apiKey).toBe('');
+    expect(requestBody.provider).toBe('local');
+    expect(requestBody.model).toBe('llama3.2');
+  });
+});

--- a/ui/src/pages/agent-settings/index.tsx
+++ b/ui/src/pages/agent-settings/index.tsx
@@ -36,6 +36,7 @@ import { useIsAdmin } from '@/contexts/AuthContext';
 import { useUpdateConfig } from '@/contexts/ConfigContext';
 import { ProviderAuthCard } from '@/features/agent/components/ProviderAuthCard';
 import { useAgentAuthProviders } from '@/features/agent/hooks/useAgentAuthProviders';
+import { getAgentModelProviderLabel } from '@/features/agent/modelProviders';
 import { useClient } from '@/hooks/api';
 import ConfirmModal from '@/ui/ConfirmModal';
 import { ModelFormModal } from './ModelFormModal';
@@ -113,19 +114,6 @@ function canonicalizeToolPolicy(policy: AgentToolPolicy | undefined, tools: Tool
       denyBehavior: normalized.bash?.denyBehavior || AgentBashPolicyDenyBehavior.ask_user,
     },
   };
-}
-
-function getProviderLabel(provider: string): string {
-  switch (provider) {
-    case 'openai-codex':
-      return 'OpenAI Codex';
-    case 'openai':
-      return 'OpenAI';
-    case 'zai':
-      return 'Z.AI';
-    default:
-      return provider.charAt(0).toUpperCase() + provider.slice(1);
-  }
 }
 
 export default function AgentSettingsPage(): ReactNode {
@@ -887,7 +875,7 @@ export default function AgentSettingsPage(): ReactNode {
                     </TableCell>
                     <TableCell>
                       <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                        {getProviderLabel(m.provider)}
+                        {getAgentModelProviderLabel(m.provider)}
                       </span>
                     </TableCell>
                     <TableCell className="max-w-[180px]">

--- a/ui/src/pages/setup.tsx
+++ b/ui/src/pages/setup.tsx
@@ -5,8 +5,14 @@ import { useConfig, useUpdateConfig } from '@/contexts/ConfigContext';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { ProviderAuthCard } from '@/features/agent/components/ProviderAuthCard';
 import { useAgentAuthProviders } from '@/features/agent/hooks/useAgentAuthProviders';
+import {
+  AGENT_MODEL_PROVIDERS,
+  type AgentModelProvider,
+  getAgentModelProviderMeta,
+  isAgentModelProvider,
+} from '@/features/agent/modelProviders';
 import { useClient } from '@/hooks/api';
-import { components, CreateModelConfigRequestProvider } from '@/api/v1/schema';
+import { components } from '@/api/v1/schema';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -28,14 +34,7 @@ import {
 } from 'lucide-react';
 
 type ModelPreset = components['schemas']['ModelPreset'];
-
-const PROVIDERS = [
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'openai-codex', label: 'OpenAI Codex' },
-  { value: 'gemini', label: 'Google Gemini' },
-  { value: 'zai', label: 'Z.AI' },
-] as const;
+type CreateModelConfigRequest = components['schemas']['CreateModelConfigRequest'];
 
 function generateSlugId(name: string): string {
   const slug = name
@@ -64,9 +63,11 @@ export default function SetupPage() {
 
   // Step 2 state
   const [agentEnabled, setAgentEnabled] = useState(true);
-  const [selectedProvider, setSelectedProvider] = useState('anthropic');
+  const [selectedProvider, setSelectedProvider] =
+    useState<AgentModelProvider>('anthropic');
   const [selectedModel, setSelectedModel] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
   const [step2Error, setStep2Error] = useState<string | null>(null);
   const [step2Loading, setStep2Loading] = useState(false);
   const [presets, setPresets] = useState<ModelPreset[]>([]);
@@ -83,8 +84,9 @@ export default function SetupPage() {
     disconnect,
   } = useAgentAuthProviders();
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
+  const providerMeta = getAgentModelProviderMeta(selectedProvider);
   const codexProvider = providerMap['openai-codex'] || null;
-  const usesCodexSubscription = selectedProvider === 'openai-codex';
+  const usesCodexSubscription = providerMeta.authMode === 'subscription';
   const codexConnected = codexProvider?.connected ?? false;
 
   // Redirect away if setup is already complete (e.g., user navigated here directly).
@@ -171,17 +173,18 @@ export default function SetupPage() {
       return;
     }
 
-    if (!selectedModel) {
+    const manualModel = selectedModel.trim();
+    if (!manualModel) {
       setStep2Error('Please select a model');
       return;
     }
 
-    if (selectedProvider === 'openai-codex' && !codexConnected) {
+    if (usesCodexSubscription && !codexConnected) {
       setStep2Error('Connect OpenAI Codex before completing setup');
       return;
     }
 
-    if (selectedProvider !== 'openai-codex' && !apiKey.trim()) {
+    if (providerMeta.apiKeyMode === 'required' && !apiKey.trim()) {
       setStep2Error('Please enter an API key');
       return;
     }
@@ -198,41 +201,58 @@ export default function SetupPage() {
         throw new Error(enableError.message || 'Failed to enable agent');
       }
 
-      // 2. Find the selected preset to populate model details
-      const preset = presets.find((p) => p.name === selectedModel);
-      if (!preset) {
-        throw new Error('Selected model not found');
+      const preset = filteredPresets.find((p) => p.name === selectedModel);
+      const requestedProvider = preset?.provider ?? selectedProvider;
+      if (!isAgentModelProvider(requestedProvider)) {
+        throw new Error(`Unsupported provider: ${requestedProvider}`);
       }
 
-      // 3. Create model config
-      const supportedProviders = [
-        CreateModelConfigRequestProvider.anthropic,
-        CreateModelConfigRequestProvider.openai,
-        CreateModelConfigRequestProvider.openaiCodex,
-        CreateModelConfigRequestProvider.gemini,
-        CreateModelConfigRequestProvider.zai,
-      ] as const;
-      const isValidProvider = (v: string): v is CreateModelConfigRequestProvider =>
-        (supportedProviders as readonly string[]).includes(v);
-      if (!isValidProvider(preset.provider)) {
-        throw new Error(`Unsupported provider: ${preset.provider}`);
-      }
-      const { data: createdModel, error: createError } = await client.POST(
-        '/settings/agent/models',
-        {
-          params: { query: { remoteNode } },
-          body: {
+      const modelConfig: Omit<
+        CreateModelConfigRequest,
+        'apiKey' | 'baseUrl'
+      > = preset
+        ? {
             id: generateSlugId(preset.name),
             name: preset.name,
-            provider: preset.provider,
+            provider: requestedProvider as CreateModelConfigRequest['provider'],
             model: preset.model,
-            apiKey: preset.provider === 'openai-codex' ? undefined : apiKey.trim(),
             description: preset.description || undefined,
             contextWindow: preset.contextWindow || undefined,
             maxOutputTokens: preset.maxOutputTokens || undefined,
             inputCostPer1M: preset.inputCostPer1M || undefined,
             outputCostPer1M: preset.outputCostPer1M || undefined,
             supportsThinking: preset.supportsThinking || false,
+          }
+        : {
+            id: generateSlugId(manualModel),
+            name: manualModel,
+            provider: requestedProvider as CreateModelConfigRequest['provider'],
+            model: manualModel,
+            description: undefined,
+            contextWindow: undefined,
+            maxOutputTokens: undefined,
+            inputCostPer1M: undefined,
+            outputCostPer1M: undefined,
+            supportsThinking: false,
+          };
+
+      const trimmedAPIKey = apiKey.trim();
+      const trimmedBaseURL = baseUrl.trim();
+
+      const { data: createdModel, error: createError } = await client.POST(
+        '/settings/agent/models',
+        {
+          params: { query: { remoteNode } },
+          body: {
+            ...modelConfig,
+            apiKey:
+              providerMeta.apiKeyMode === 'hidden' || trimmedAPIKey === ''
+                ? undefined
+                : trimmedAPIKey,
+            baseUrl:
+              !usesManualModelConfig || trimmedBaseURL === ''
+                ? undefined
+                : trimmedBaseURL,
           },
         }
       );
@@ -241,7 +261,8 @@ export default function SetupPage() {
       }
 
       // 4. Set as default model
-      const modelId = createdModel?.id || generateSlugId(preset.name);
+      const modelId =
+        createdModel?.id ?? modelConfig.id ?? generateSlugId(modelConfig.name);
       const { error: defaultError } = await client.PUT(
         '/settings/agent/default-model',
         {
@@ -272,6 +293,8 @@ export default function SetupPage() {
   const filteredPresets = presets.filter(
     (p) => p.provider === selectedProvider
   );
+  const usesManualModelConfig =
+    !usesCodexSubscription && filteredPresets.length === 0;
 
   // Reset model selection when provider changes
   useEffect(() => {
@@ -279,10 +302,11 @@ export default function SetupPage() {
   }, [selectedProvider]);
 
   useEffect(() => {
-    if (selectedProvider === 'openai-codex') {
+    if (usesCodexSubscription) {
       setApiKey('');
+      setBaseUrl('');
     }
-  }, [selectedProvider]);
+  }, [usesCodexSubscription]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-muted/50">
@@ -447,7 +471,7 @@ export default function SetupPage() {
                       <div className="space-y-1.5">
                         <Label className="text-sm">Provider</Label>
                         <div className="grid grid-cols-3 gap-2">
-                          {PROVIDERS.map((p) => (
+                          {AGENT_MODEL_PROVIDERS.map((p) => (
                             <button
                               key={p.value}
                               type="button"
@@ -469,7 +493,20 @@ export default function SetupPage() {
                         <Label htmlFor="model-select" className="text-sm">
                           Model
                         </Label>
-                        {filteredPresets.length > 0 ? (
+                        {usesManualModelConfig ? (
+                          <div className="space-y-1.5">
+                            <Input
+                              id="model-select"
+                              value={selectedModel}
+                              onChange={(e) => setSelectedModel(e.target.value)}
+                              placeholder={providerMeta.modelPlaceholder}
+                              className="h-9"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                              Enter the model ID served by {providerMeta.label}.
+                            </p>
+                          </div>
+                        ) : (
                           <Select
                             value={selectedModel}
                             onValueChange={setSelectedModel}
@@ -490,10 +527,6 @@ export default function SetupPage() {
                               ))}
                             </SelectContent>
                           </Select>
-                        ) : (
-                          <p className="text-xs text-muted-foreground py-2">
-                            No presets available for this provider.
-                          </p>
                         )}
                       </div>
 
@@ -520,20 +553,45 @@ export default function SetupPage() {
                           )}
                         </div>
                       ) : (
-                        <div className="space-y-1.5">
-                          <Label htmlFor="api-key" className="text-sm">
-                            API Key
-                          </Label>
-                          <Input
-                            id="api-key"
-                            type="password"
-                            value={apiKey}
-                            onChange={(e) => setApiKey(e.target.value)}
-                            placeholder="Enter your API key"
-                            autoComplete="off"
-                            className="h-9"
-                          />
-                        </div>
+                        <>
+                          <div className="space-y-1.5">
+                            <Label htmlFor="api-key" className="text-sm">
+                              {providerMeta.apiKeyMode === 'optional'
+                                ? 'API Key (optional)'
+                                : 'API Key'}
+                            </Label>
+                            <Input
+                              id="api-key"
+                              type="password"
+                              value={apiKey}
+                              onChange={(e) => setApiKey(e.target.value)}
+                              placeholder="Enter your API key"
+                              autoComplete="off"
+                              className="h-9"
+                            />
+                            {providerMeta.apiKeyHelperText && (
+                              <p className="text-xs text-muted-foreground">
+                                {providerMeta.apiKeyHelperText}
+                              </p>
+                            )}
+                          </div>
+
+                          {usesManualModelConfig && (
+                            <div className="space-y-1.5">
+                              <Label htmlFor="base-url" className="text-sm">
+                                Base URL (optional)
+                              </Label>
+                              <Input
+                                id="base-url"
+                                value={baseUrl}
+                                onChange={(e) => setBaseUrl(e.target.value)}
+                                placeholder={providerMeta.baseUrlPlaceholder}
+                                autoComplete="off"
+                                className="h-9"
+                              />
+                            </div>
+                          )}
+                        </>
                       )}
                     </>
                   )}


### PR DESCRIPTION
## Summary
- unify onboarding and agent settings provider capability metadata for agent model providers
- allow onboarding to configure local and other non-preset providers without forcing placeholder API keys, while omitting blank optional credentials
- add explicit stored-key clearing for edited models and regression coverage for setup and agent model updates

## Root Cause
- the setup page had stale duplicated provider logic that assumed every non-Codex provider required an API key and that setup only supported preset-backed cloud providers
- the backend already accepted `local` with optional auth, so the reported failure came from onboarding drift rather than provider validation

## Testing
- `cd ui && pnpm typecheck`
- `cd ui && pnpm test src/pages/__tests__/setup.test.tsx src/pages/agent-settings/__tests__/ModelFormModal.test.tsx`
- `go test ./internal/service/frontend/api/v1 -run 'Test(CreateAgentModel|UpdateAgentModel|ListModelPresets|ApplyModelUpdates)$'`
- `go test ./internal/llm -run 'Test(DefaultAPIKeyEnvVar|GetAPIKeyFromEnv|NewProvider)$'`

Closes #1882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to clear stored API keys when editing agent models.
  * Improved agent setup and configuration experience with better provider-specific handling for authentication and API key requirements.

* **Tests**
  * Added comprehensive test coverage for setup page onboarding workflows and model configuration form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->