### PR TITLE
feat(coordinator): support IPv6 address format and improve address pa…

### DIFF
--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net"
 	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -391,7 +393,7 @@ func (cli *clientImpl) createClient(member exec.HostInfo) (*client, error) {
 	}
 
 	// Construct address from host and port
-	address := fmt.Sprintf("%s:%d", member.Host, member.Port)
+	address := net.JoinHostPort(member.Host, strconv.Itoa(member.Port))
 
 	// Create gRPC connection
 	conn, err := grpc.NewClient(address, dialOpts...)

--- a/internal/service/coordinator/static_registry.go
+++ b/internal/service/coordinator/static_registry.go
@@ -6,6 +6,7 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -21,7 +22,7 @@ type StaticRegistry struct {
 }
 
 // NewStaticRegistry creates a new StaticRegistry from a list of address strings.
-// Each address should be in the format "host:port" (e.g., "coordinator-1:50055").
+// Each address should be in the format "host[:port]" or "[ipv6]:port".
 func NewStaticRegistry(addresses []string) (*StaticRegistry, error) {
 	hosts := make([]exec.HostInfo, 0, len(addresses))
 
@@ -51,33 +52,56 @@ func NewStaticRegistry(addresses []string) (*StaticRegistry, error) {
 	return &StaticRegistry{coordinators: hosts}, nil
 }
 
-// parseAddress parses a "host:port" address string.
+// parseAddress parses a "host[:port]" or "[ipv6]:port" address string.
 func parseAddress(addr string) (host string, port int, err error) {
-	// Handle addresses with or without port
-	parts := strings.Split(addr, ":")
-	if len(parts) > 2 {
-		return "", 0, fmt.Errorf("invalid address format, expected host:port")
-	}
-
-	host = parts[0]
-	if host == "" {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
 		return "", 0, fmt.Errorf("host cannot be empty")
 	}
 
-	// Default port for coordinator
-	port = 50055
-	if len(parts) == 2 {
-		p, err := strconv.Atoi(parts[1])
+	if host, portStr, err := net.SplitHostPort(addr); err == nil {
+		p, err := strconv.Atoi(portStr)
 		if err != nil {
 			return "", 0, fmt.Errorf("invalid port: %w", err)
 		}
 		if p <= 0 || p > 65535 {
 			return "", 0, fmt.Errorf("port must be between 1 and 65535")
 		}
-		port = p
+		if host == "" {
+			return "", 0, fmt.Errorf("host cannot be empty")
+		}
+		return host, p, nil
 	}
 
-	return host, port, nil
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		host = strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
+		if !isIPv6Host(host) {
+			return "", 0, fmt.Errorf("invalid address format, expected host[:port] or [ipv6]:port")
+		}
+		if host == "" {
+			return "", 0, fmt.Errorf("host cannot be empty")
+		}
+		return host, 50055, nil
+	}
+
+	if !strings.Contains(addr, ":") || isIPv6Host(addr) {
+		if addr == "" {
+			return "", 0, fmt.Errorf("host cannot be empty")
+		}
+		return addr, 50055, nil
+	}
+
+	return "", 0, fmt.Errorf("invalid address format, expected host[:port] or [ipv6]:port")
+}
+
+func isIPv6Host(host string) bool {
+	if strings.Count(host, ":") < 2 {
+		return false
+	}
+	if i := strings.LastIndex(host, "%"); i >= 0 {
+		host = host[:i]
+	}
+	return net.ParseIP(host) != nil
 }
 
 // Register is a no-op for StaticRegistry since we don't support registration.

--- a/internal/service/coordinator/static_registry_test.go
+++ b/internal/service/coordinator/static_registry_test.go
@@ -51,6 +51,20 @@ func TestNewStaticRegistry(t *testing.T) {
 		assert.Equal(t, 50055, members[0].Port) // Default port
 	})
 
+	t.Run("ipv6 address with port", func(t *testing.T) {
+		addresses := []string{"[fdbd:dc02:1a:e12::31]:50055"}
+
+		registry, err := NewStaticRegistry(addresses)
+		require.NoError(t, err)
+
+		members, err := registry.GetServiceMembers(context.Background(), exec.ServiceNameCoordinator)
+		require.NoError(t, err)
+		require.Len(t, members, 1)
+
+		assert.Equal(t, "fdbd:dc02:1a:e12::31", members[0].Host)
+		assert.Equal(t, 50055, members[0].Port)
+	})
+
 	t.Run("empty addresses list", func(t *testing.T) {
 		addresses := []string{}
 
@@ -192,6 +206,24 @@ func TestParseAddress(t *testing.T) {
 			name:     "localhost",
 			addr:     "localhost:50055",
 			wantHost: "localhost",
+			wantPort: 50055,
+		},
+		{
+			name:     "ipv6 with port",
+			addr:     "[fdbd:dc02:1a:e12::31]:50055",
+			wantHost: "fdbd:dc02:1a:e12::31",
+			wantPort: 50055,
+		},
+		{
+			name:     "ipv6 without port uses default port",
+			addr:     "fdbd:dc02:1a:e12::31",
+			wantHost: "fdbd:dc02:1a:e12::31",
+			wantPort: 50055,
+		},
+		{
+			name:     "bracketed ipv6 without port uses default port",
+			addr:     "[fdbd:dc02:1a:e12::31]",
+			wantHost: "fdbd:dc02:1a:e12::31",
 			wantPort: 50055,
 		},
 		{


### PR DESCRIPTION
…rsing

- Replace manual parsing with net.SplitHostPort and net.ParseIP
- Add IPv6 test cases (with and without ports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IPv6 address formats in coordinator configuration, including bracketed IPv6 notation with explicit ports and default port handling.

* **Bug Fixes**
  * Improved address parsing robustness with enhanced validation for host-port combinations and better handling of edge cases.

* **Tests**
  * Extended test coverage for IPv6 address parsing and registry member construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->