### PR TITLE
fix: stop dashboard and cockpit dag run refetch loop

### DIFF
--- a/ui/src/features/cockpit/hooks/useDateKanbanData.ts
+++ b/ui/src/features/cockpit/hooks/useDateKanbanData.ts
@@ -79,15 +79,19 @@ export function useDateKanbanData(
     () => dayBounds(date, tzOffsetInSec),
     [date, tzOffsetInSec]
   );
-
-  useLiveConnection(isToday);
-  const { data, error, refresh } = useExactDAGRuns({
-    query: {
+  const dagRunsQuery = useMemo(
+    () => ({
       remoteNode,
       tags: tag,
       fromDate,
       toDate,
-    },
+    }),
+    [fromDate, remoteNode, tag, toDate]
+  );
+
+  useLiveConnection(isToday);
+  const { data, error, refresh } = useExactDAGRuns({
+    query: dagRunsQuery,
     liveEnabled: isLive,
     fallbackIntervalMs: isToday ? 2000 : 0,
   });

--- a/ui/src/features/dag-runs/hooks/__tests__/useExactDAGRuns.test.tsx
+++ b/ui/src/features/dag-runs/hooks/__tests__/useExactDAGRuns.test.tsx
@@ -1,0 +1,232 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExactDAGRuns, type DAGRunListQuery } from '../dagRunPagination';
+
+const getMock = vi.fn();
+const client = {
+  GET: getMock,
+};
+
+vi.mock('@/hooks/api', () => ({
+  useClient: () => client,
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAppLive', () => ({
+  liveFallbackOptions: vi.fn(),
+  useLiveConnection: vi.fn(() => ({
+    isConnected: false,
+    isConnecting: false,
+    shouldUseFallback: true,
+    error: null,
+  })),
+  useLiveDAGRuns: vi.fn(),
+  useLiveInvalidation: vi.fn(),
+}));
+
+function createQuery(overrides: Partial<DAGRunListQuery> = {}): DAGRunListQuery {
+  return {
+    remoteNode: 'local',
+    fromDate: 100,
+    ...overrides,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useExactDAGRuns', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not refetch when rerendered with an equivalent inline query object', async () => {
+    getMock.mockResolvedValue({ data: { dagRuns: [] } });
+
+    const { rerender } = renderHook(({ query }) => useExactDAGRuns({ query }), {
+      initialProps: { query: createQuery() },
+    });
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ query: createQuery() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches exactly once when the semantic query changes', async () => {
+    getMock.mockResolvedValue({ data: { dagRuns: [] } });
+
+    const { rerender } = renderHook(({ query }) => useExactDAGRuns({ query }), {
+      initialProps: { query: createQuery() },
+    });
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ query: createQuery({ fromDate: 200, name: 'billing' }) });
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(getMock.mock.calls[1]?.[1]).toMatchObject({
+      params: {
+        query: expect.objectContaining({
+          fromDate: 200,
+          name: 'billing',
+          remoteNode: 'local',
+        }),
+      },
+    });
+  });
+
+  it('refresh uses the latest query after rerender instead of a stale closure', async () => {
+    getMock.mockResolvedValue({ data: { dagRuns: [] } });
+
+    const { result, rerender } = renderHook(
+      ({ query }) => useExactDAGRuns({ query }),
+      {
+        initialProps: { query: createQuery({ fromDate: 100 }) },
+      }
+    );
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ query: createQuery({ fromDate: 300, name: 'ops' }) });
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(3);
+    expect(getMock.mock.calls[2]?.[1]).toMatchObject({
+      params: {
+        query: expect.objectContaining({
+          fromDate: 300,
+          name: 'ops',
+          remoteNode: 'local',
+        }),
+      },
+    });
+  });
+
+  it('ignores stale responses after a query change and aborts the older request', async () => {
+    const firstRequest = createDeferred<{ data: { dagRuns: Array<{ name: string; dagRunId: string }> } }>();
+    const secondRequest = createDeferred<{ data: { dagRuns: Array<{ name: string; dagRunId: string }> } }>();
+
+    getMock
+      .mockImplementationOnce(
+        (_path: string, request?: { signal?: AbortSignal }) => {
+          return firstRequest.promise.then((value) => {
+            if (request?.signal?.aborted) {
+              throw new DOMException('Aborted', 'AbortError');
+            }
+            return value;
+          });
+        }
+      )
+      .mockImplementationOnce(
+        (_path: string, request?: { signal?: AbortSignal }) => {
+          return secondRequest.promise.then((value) => {
+            if (request?.signal?.aborted) {
+              throw new DOMException('Aborted', 'AbortError');
+            }
+            return value;
+          });
+        }
+      );
+
+    const { result, rerender } = renderHook(
+      ({ query }) => useExactDAGRuns({ query }),
+      {
+        initialProps: { query: createQuery({ fromDate: 100 }) },
+      }
+    );
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    const firstSignal = getMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+
+    rerender({ query: createQuery({ fromDate: 400, name: 'new-dag' }) });
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(firstSignal.aborted).toBe(true);
+
+    firstRequest.resolve({
+      data: {
+        dagRuns: [{ name: 'stale', dagRunId: 'old' }],
+      },
+    });
+    secondRequest.resolve({
+      data: {
+        dagRuns: [{ name: 'fresh', dagRunId: 'new' }],
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ name: 'fresh', dagRunId: 'new' }]);
+    });
+  });
+
+  it('polls only on the configured fallback interval instead of every rerender', async () => {
+    vi.useFakeTimers();
+    getMock.mockResolvedValue({ data: { dagRuns: [] } });
+
+    renderHook(() =>
+      useExactDAGRuns({
+        query: createQuery(),
+        fallbackIntervalMs: 2000,
+      })
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1999);
+    });
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(getMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/ui/src/features/dag-runs/hooks/dagRunPagination.ts
+++ b/ui/src/features/dag-runs/hooks/dagRunPagination.ts
@@ -15,6 +15,19 @@ export type DAGRunListQuery = paths['/dag-runs']['get']['parameters']['query'];
 
 const MAX_DAG_RUN_PAGE_LIMIT = 500;
 
+function normalizeDAGRunListQuery(
+  query: DAGRunListQuery | undefined
+): Record<string, unknown> {
+  const normalizedEntries = Object.entries(query ?? {})
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return Object.fromEntries(normalizedEntries);
+}
+
+function getDAGRunListQueryKey(query: DAGRunListQuery | undefined): string {
+  return JSON.stringify(normalizeDAGRunListQuery(query));
+}
+
 export function mergeUniqueDAGRuns(
   head: DAGRunSummary[],
   older: DAGRunSummary[]
@@ -135,9 +148,11 @@ export function useExactDAGRuns({
   const dataRef = useRef<DAGRunSummary[]>([]);
   const controllerRef = useRef<AbortController | null>(null);
   const requestIDRef = useRef(0);
-  const queryKey = useMemo(() => JSON.stringify(query), [query]);
+  const queryRef = useRef(query);
+  const queryKey = useMemo(() => getDAGRunListQueryKey(query), [query]);
 
   dataRef.current = data;
+  queryRef.current = query;
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!enabled) {
@@ -159,7 +174,11 @@ export function useExactDAGRuns({
     }
 
     try {
-      const next = await fetchAllDAGRuns(client, query, controller.signal);
+      const next = await fetchAllDAGRuns(
+        client,
+        queryRef.current,
+        controller.signal
+      );
       if (controller.signal.aborted || requestID !== requestIDRef.current) {
         return;
       }
@@ -187,7 +206,7 @@ export function useExactDAGRuns({
         setIsValidating(false);
       }
     }
-  }, [client, enabled, query]);
+  }, [client, enabled]);
 
   useEffect(() => {
     if (!enabled) {
@@ -200,6 +219,8 @@ export function useExactDAGRuns({
       return;
     }
 
+    // Trigger reloads only when the semantic query changes, not when callers
+    // allocate a fresh but equivalent query object during rerenders.
     void refresh();
 
     return () => {
@@ -269,7 +290,7 @@ export function usePaginatedDAGRuns({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
 
-  const queryKey = useMemo(() => JSON.stringify(query), [query]);
+  const stableQueryKey = useMemo(() => getDAGRunListQueryKey(query), [query]);
   const {
     data: headPage,
     mutate,
@@ -292,7 +313,7 @@ export function usePaginatedDAGRuns({
     setContinuationCursorOverride(undefined);
     setLoadMoreError(null);
     setIsLoadingMore(false);
-  }, [queryKey]);
+  }, [stableQueryKey]);
 
   const dagRuns = useMemo(
     () => mergeUniqueDAGRuns(headPage?.dagRuns ?? [], olderRuns),

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -173,6 +173,20 @@ function Dashboard(): React.ReactElement | null {
   };
 
   const selectedDAGName = selectedDAGRun !== 'all' ? selectedDAGRun : undefined;
+  const dagRunsQuery = React.useMemo(
+    () => ({
+      remoteNode: appBarContext.selectedRemoteNode || 'local',
+      fromDate: dateRange.startDate,
+      toDate: dateRange.endDate,
+      name: selectedDAGName,
+    }),
+    [
+      appBarContext.selectedRemoteNode,
+      dateRange.endDate,
+      dateRange.startDate,
+      selectedDAGName,
+    ]
+  );
 
   useLiveConnection();
   const {
@@ -181,12 +195,7 @@ function Dashboard(): React.ReactElement | null {
     isLoading,
     refresh,
   } = useExactDAGRuns({
-    query: {
-      remoteNode: appBarContext.selectedRemoteNode || 'local',
-      fromDate: dateRange.startDate,
-      toDate: dateRange.endDate,
-      name: selectedDAGName,
-    },
+    query: dagRunsQuery,
     fallbackIntervalMs: 5000,
   });
 


### PR DESCRIPTION
## Summary
- stabilize exact DAG run fetching against semantically identical query rerenders
- memoize dashboard and cockpit DAG run queries so callers stay explicit and easy to reason about
- add regression coverage for rerender stability, stale request handling, and fallback polling cadence

## Testing
- `make fmt`
- `cd ui && pnpm exec vitest run src/features/dag-runs/hooks/__tests__/useExactDAGRuns.test.tsx`
- `cd ui && pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved query handling efficiency to reduce unnecessary re-renders and API calls.

* **Tests**
  * Added comprehensive test coverage for query request behavior, including caching, polling, and cancellation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->