### PR TITLE
feat(bots): add Discord bot integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/adrg/xdg v0.5.3
 	github.com/bmatcuk/doublestar/v4 v4.8.1
+	github.com/bwmarrin/discordgo v0.29.0
 	github.com/coder/websocket v1.8.14
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/butuzov/ireturn v0.4.0 h1:+s76bF/PfeKEdbG8b54aCocxXmi0wvYdOVsWxVO7n8E
 github.com/butuzov/ireturn v0.4.0/go.mod h1:ghI0FrCmap8pDWZwfPisFD1vEc56VKH4NpQUxDHta70=
 github.com/butuzov/mirror v1.3.0 h1:HdWCXzmwlQHdVhwvsfBb2Au0r3HyINry3bDWLYXiKoc=
 github.com/butuzov/mirror v1.3.0/go.mod h1:AEij0Z8YMALaq4yQj9CPPVYOyJQyiexpQEQgihajRfI=
+github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
+github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/catenacyber/perfsprint v0.10.1 h1:u7Riei30bk46XsG8nknMhKLXG9BcXz3+3tl/WpKm0PQ=
 github.com/catenacyber/perfsprint v0.10.1/go.mod h1:DJTGsi/Zufpuus6XPGJyKOTMELe347o6akPvWG9Zcsc=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
@@ -502,6 +504,7 @@ github.com/gordonklaus/ineffassign v0.2.0 h1:Uths4KnmwxNJNzq87fwQQDDnbNb7De00VOk
 github.com/gordonklaus/ineffassign v0.2.0/go.mod h1:TIpymnagPSexySzs7F9FnO1XFTy8IT3a59vmZp5Y9Lw=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gostaticanalysis/analysisutil v0.7.1 h1:ZMCjoue3DtDWQ5WyU16YbjbQEQ3VuzwxALrpYd+HeKk=
@@ -1118,6 +1121,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/service/discord"
 	"github.com/dagucloud/dagu/internal/service/frontend"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	daguslack "github.com/dagucloud/dagu/internal/service/slack"
@@ -170,6 +171,31 @@ func runServer(ctx *Context, _ []string) error {
 					}
 				}()
 				logger.Info(serviceCtx, "Slack bot started")
+			}
+
+		case config.BotProviderDiscord:
+			discordBot, discordErr := discord.New(
+				discord.Config{
+					Token:                 ctx.Config.Bots.Discord.Token,
+					AllowedChannelIDs:     ctx.Config.Bots.Discord.AllowedChannelIDs,
+					InterestedEventTypes:  ctx.Config.Bots.Discord.InterestedEventTypes,
+					RespondToAll:          ctx.Config.Bots.Discord.RespondToAll,
+					SafeMode:              ctx.Config.Bots.SafeMode,
+					EventService:          ctx.EventService,
+					NotificationStateFile: filepath.Join(ctx.Config.Paths.DataDir, "bots", "discord", "notifications.json"),
+				},
+				agentAPI,
+				slog.Default(),
+			)
+			if discordErr != nil {
+				logger.Warn(serviceCtx, "Failed to initialize Discord bot", tag.Error(discordErr))
+			} else {
+				go func() {
+					if runErr := discordBot.Run(signalCtx); runErr != nil {
+						logger.Error(serviceCtx, "Discord bot failed", tag.Error(runErr))
+					}
+				}()
+				logger.Info(serviceCtx, "Discord bot started")
 			}
 
 		case config.BotProviderNone:

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/discord"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
 	"github.com/dagucloud/dagu/internal/service/frontend"
 	"github.com/dagucloud/dagu/internal/service/resource"
@@ -164,6 +165,7 @@ func runStartAll(ctx *Context, _ []string) error {
 	// Initialize bot if selected as provider
 	var tgBot *telegram.Bot
 	var slackBot *daguslack.Bot
+	var discordBot *discord.Bot
 	if agentAPI != nil {
 		switch ctx.Config.Bots.Provider {
 		case config.BotProviderTelegram:
@@ -206,6 +208,26 @@ func runStartAll(ctx *Context, _ []string) error {
 				logger.Info(serviceCtx, "Slack bot initialized")
 			}
 
+		case config.BotProviderDiscord:
+			discordBot, err = discord.New(
+				discord.Config{
+					Token:                 ctx.Config.Bots.Discord.Token,
+					AllowedChannelIDs:     ctx.Config.Bots.Discord.AllowedChannelIDs,
+					InterestedEventTypes:  ctx.Config.Bots.Discord.InterestedEventTypes,
+					RespondToAll:          ctx.Config.Bots.Discord.RespondToAll,
+					SafeMode:              ctx.Config.Bots.SafeMode,
+					EventService:          ctx.EventService,
+					NotificationStateFile: filepath.Join(ctx.Config.Paths.DataDir, "bots", "discord", "notifications.json"),
+				},
+				agentAPI,
+				slog.Default(),
+			)
+			if err != nil {
+				logger.Warn(serviceCtx, "Failed to initialize Discord bot", tag.Error(err))
+			} else {
+				logger.Info(serviceCtx, "Discord bot initialized")
+			}
+
 		case config.BotProviderNone:
 			// No bot configured
 		}
@@ -226,6 +248,9 @@ func runStartAll(ctx *Context, _ []string) error {
 		serviceCount++
 	}
 	if slackBot != nil {
+		serviceCount++
+	}
+	if discordBot != nil {
 		serviceCount++
 	}
 	errCh := make(chan error, serviceCount)
@@ -272,6 +297,18 @@ func runStartAll(ctx *Context, _ []string) error {
 			if err := slackBot.Run(signalCtx); err != nil {
 				select {
 				case errCh <- fmt.Errorf("slack bot failed: %w", err):
+				default:
+				}
+			}
+		})
+	}
+
+	// Start Discord bot
+	if discordBot != nil {
+		wg.Go(func() {
+			if err := discordBot.Run(signalCtx); err != nil {
+				select {
+				case errCh <- fmt.Errorf("discord bot failed: %w", err):
 				default:
 				}
 			}

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -41,6 +41,7 @@ const (
 	BotProviderNone     BotProvider = ""
 	BotProviderTelegram BotProvider = "telegram"
 	BotProviderSlack    BotProvider = "slack"
+	BotProviderDiscord  BotProvider = "discord"
 )
 
 var DefaultBotInterestedEventTypes = []string{
@@ -57,6 +58,7 @@ type BotsConfig struct {
 	SafeMode bool
 	Telegram TelegramBotConfig
 	Slack    SlackBotConfig
+	Discord  DiscordBotConfig
 }
 
 // TelegramBotConfig holds the Telegram-specific bot configuration.
@@ -70,6 +72,14 @@ type TelegramBotConfig struct {
 type SlackBotConfig struct {
 	BotToken             string
 	AppToken             string
+	AllowedChannelIDs    []string
+	InterestedEventTypes []string
+	RespondToAll         bool // respond to all channel messages, not just @mentions
+}
+
+// DiscordBotConfig holds the Discord-specific bot configuration.
+type DiscordBotConfig struct {
+	Token                string
 	AllowedChannelIDs    []string
 	InterestedEventTypes []string
 	RespondToAll         bool // respond to all channel messages, not just @mentions
@@ -588,6 +598,9 @@ func (c *Config) validateBots() error {
 		return err
 	}
 	if err := validateInterestedEventTypes("bots.slack.interested_event_types", c.Bots.Slack.InterestedEventTypes); err != nil {
+		return err
+	}
+	if err := validateInterestedEventTypes("bots.discord.interested_event_types", c.Bots.Discord.InterestedEventTypes); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -444,10 +444,11 @@ type TunnelRateLimitDef struct {
 
 // BotsDef configures bot integrations.
 type BotsDef struct {
-	Provider string          `mapstructure:"provider"`  // "telegram", "slack", etc.
+	Provider string          `mapstructure:"provider"`  // "telegram", "slack", "discord", etc.
 	SafeMode *bool           `mapstructure:"safe_mode"` // Default: true
 	Telegram *TelegramBotDef `mapstructure:"telegram"`
 	Slack    *SlackBotDef    `mapstructure:"slack"`
+	Discord  *DiscordBotDef  `mapstructure:"discord"`
 }
 
 // TelegramBotDef configures the Telegram bot.
@@ -461,6 +462,14 @@ type TelegramBotDef struct {
 type SlackBotDef struct {
 	BotToken             string   `mapstructure:"bot_token"`
 	AppToken             string   `mapstructure:"app_token"`
+	AllowedChannelIDs    []string `mapstructure:"allowed_channel_ids"`
+	InterestedEventTypes []string `mapstructure:"interested_event_types"`
+	RespondToAll         *bool    `mapstructure:"respond_to_all"` // Default: true
+}
+
+// DiscordBotDef configures the Discord bot.
+type DiscordBotDef struct {
+	Token                string   `mapstructure:"token"`
 	AllowedChannelIDs    []string `mapstructure:"allowed_channel_ids"`
 	InterestedEventTypes []string `mapstructure:"interested_event_types"`
 	RespondToAll         *bool    `mapstructure:"respond_to_all"` // Default: true

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -1167,6 +1167,13 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 	cfg.Bots.Telegram.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Slack.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Discord.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
+	cfg.Bots.Slack.RespondToAll = true
+	cfg.Bots.Discord.RespondToAll = true
+
+	botsDef := def.Bots
+	if botsDef == nil {
+		botsDef = &BotsDef{}
+	}
 
 	// Check env var override for provider
 	if provider := l.v.GetString("bots.provider"); provider != "" {
@@ -1181,33 +1188,26 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 		cfg.Bots.Telegram.InterestedEventTypes = parseInterestedEventTypes(raw)
 	}
 
-	if def.Bots == nil {
-		return
-	}
-
 	if cfg.Bots.Provider == BotProviderNone {
-		cfg.Bots.Provider = BotProvider(def.Bots.Provider)
+		cfg.Bots.Provider = BotProvider(botsDef.Provider)
 	}
 
-	if def.Bots.SafeMode != nil {
-		cfg.Bots.SafeMode = *def.Bots.SafeMode
+	if botsDef.SafeMode != nil {
+		cfg.Bots.SafeMode = *botsDef.SafeMode
 	}
 
-	if def.Bots.Telegram != nil {
+	if botsDef.Telegram != nil {
 		if cfg.Bots.Telegram.Token == "" {
-			cfg.Bots.Telegram.Token = def.Bots.Telegram.Token
+			cfg.Bots.Telegram.Token = botsDef.Telegram.Token
 		}
-		if len(def.Bots.Telegram.AllowedChatIDs) > 0 {
-			cfg.Bots.Telegram.AllowedChatIDs = def.Bots.Telegram.AllowedChatIDs
+		if len(botsDef.Telegram.AllowedChatIDs) > 0 {
+			cfg.Bots.Telegram.AllowedChatIDs = botsDef.Telegram.AllowedChatIDs
 		}
-		if def.Bots.Telegram.InterestedEventTypes != nil &&
+		if botsDef.Telegram.InterestedEventTypes != nil &&
 			!hasInterestedEventTypesEnv("BOTS_TELEGRAM_INTERESTED_EVENT_TYPES") {
-			cfg.Bots.Telegram.InterestedEventTypes = parseInterestedEventTypesSlice(def.Bots.Telegram.InterestedEventTypes)
+			cfg.Bots.Telegram.InterestedEventTypes = parseInterestedEventTypesSlice(botsDef.Telegram.InterestedEventTypes)
 		}
 	}
-
-	// Default Slack respond_to_all to true
-	cfg.Bots.Slack.RespondToAll = true
 
 	// Check env var override for Slack tokens
 	if botToken := l.v.GetString("bots.slack.bot_token"); botToken != "" {
@@ -1220,49 +1220,52 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 		cfg.Bots.Slack.InterestedEventTypes = parseInterestedEventTypes(raw)
 	}
 
-	if def.Bots.Slack != nil {
+	if botsDef.Slack != nil {
 		if cfg.Bots.Slack.BotToken == "" {
-			cfg.Bots.Slack.BotToken = def.Bots.Slack.BotToken
+			cfg.Bots.Slack.BotToken = botsDef.Slack.BotToken
 		}
 		if cfg.Bots.Slack.AppToken == "" {
-			cfg.Bots.Slack.AppToken = def.Bots.Slack.AppToken
+			cfg.Bots.Slack.AppToken = botsDef.Slack.AppToken
 		}
-		if len(def.Bots.Slack.AllowedChannelIDs) > 0 {
-			cfg.Bots.Slack.AllowedChannelIDs = def.Bots.Slack.AllowedChannelIDs
+		if len(botsDef.Slack.AllowedChannelIDs) > 0 {
+			cfg.Bots.Slack.AllowedChannelIDs = botsDef.Slack.AllowedChannelIDs
 		}
-		if def.Bots.Slack.InterestedEventTypes != nil &&
+		if botsDef.Slack.InterestedEventTypes != nil &&
 			!hasInterestedEventTypesEnv("BOTS_SLACK_INTERESTED_EVENT_TYPES") {
-			cfg.Bots.Slack.InterestedEventTypes = parseInterestedEventTypesSlice(def.Bots.Slack.InterestedEventTypes)
+			cfg.Bots.Slack.InterestedEventTypes = parseInterestedEventTypesSlice(botsDef.Slack.InterestedEventTypes)
 		}
-		if def.Bots.Slack.RespondToAll != nil {
-			cfg.Bots.Slack.RespondToAll = *def.Bots.Slack.RespondToAll
+		if botsDef.Slack.RespondToAll != nil {
+			cfg.Bots.Slack.RespondToAll = *botsDef.Slack.RespondToAll
 		}
 	}
-
-	// Default Discord respond_to_all to true
-	cfg.Bots.Discord.RespondToAll = true
 
 	// Check env var override for Discord token
 	if token := l.v.GetString("bots.discord.token"); token != "" {
 		cfg.Bots.Discord.Token = token
 	}
+	if _, ok := os.LookupEnv(strings.ToUpper(AppSlug) + "_BOTS_DISCORD_ALLOWED_CHANNEL_IDS"); ok {
+		cfg.Bots.Discord.AllowedChannelIDs = parseStringList(l.v.Get("bots.discord.allowed_channel_ids"))
+	}
 	if raw, ok := lookupInterestedEventTypesEnv("BOTS_DISCORD_INTERESTED_EVENT_TYPES"); ok {
 		cfg.Bots.Discord.InterestedEventTypes = parseInterestedEventTypes(raw)
 	}
+	if _, ok := os.LookupEnv(strings.ToUpper(AppSlug) + "_BOTS_DISCORD_RESPOND_TO_ALL"); ok {
+		cfg.Bots.Discord.RespondToAll = l.v.GetBool("bots.discord.respond_to_all")
+	}
 
-	if def.Bots.Discord != nil {
+	if botsDef.Discord != nil {
 		if cfg.Bots.Discord.Token == "" {
-			cfg.Bots.Discord.Token = def.Bots.Discord.Token
+			cfg.Bots.Discord.Token = botsDef.Discord.Token
 		}
-		if len(def.Bots.Discord.AllowedChannelIDs) > 0 {
-			cfg.Bots.Discord.AllowedChannelIDs = def.Bots.Discord.AllowedChannelIDs
+		if len(botsDef.Discord.AllowedChannelIDs) > 0 {
+			cfg.Bots.Discord.AllowedChannelIDs = botsDef.Discord.AllowedChannelIDs
 		}
-		if def.Bots.Discord.InterestedEventTypes != nil &&
+		if botsDef.Discord.InterestedEventTypes != nil &&
 			!hasInterestedEventTypesEnv("BOTS_DISCORD_INTERESTED_EVENT_TYPES") {
-			cfg.Bots.Discord.InterestedEventTypes = parseInterestedEventTypesSlice(def.Bots.Discord.InterestedEventTypes)
+			cfg.Bots.Discord.InterestedEventTypes = parseInterestedEventTypesSlice(botsDef.Discord.InterestedEventTypes)
 		}
-		if def.Bots.Discord.RespondToAll != nil {
-			cfg.Bots.Discord.RespondToAll = *def.Bots.Discord.RespondToAll
+		if botsDef.Discord.RespondToAll != nil {
+			cfg.Bots.Discord.RespondToAll = *botsDef.Discord.RespondToAll
 		}
 	}
 }

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -1166,6 +1166,7 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 	cfg.Bots.SafeMode = true
 	cfg.Bots.Telegram.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Slack.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
+	cfg.Bots.Discord.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 
 	// Check env var override for provider
 	if provider := l.v.GetString("bots.provider"); provider != "" {
@@ -1235,6 +1236,33 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 		}
 		if def.Bots.Slack.RespondToAll != nil {
 			cfg.Bots.Slack.RespondToAll = *def.Bots.Slack.RespondToAll
+		}
+	}
+
+	// Default Discord respond_to_all to true
+	cfg.Bots.Discord.RespondToAll = true
+
+	// Check env var override for Discord token
+	if token := l.v.GetString("bots.discord.token"); token != "" {
+		cfg.Bots.Discord.Token = token
+	}
+	if raw, ok := lookupInterestedEventTypesEnv("BOTS_DISCORD_INTERESTED_EVENT_TYPES"); ok {
+		cfg.Bots.Discord.InterestedEventTypes = parseInterestedEventTypes(raw)
+	}
+
+	if def.Bots.Discord != nil {
+		if cfg.Bots.Discord.Token == "" {
+			cfg.Bots.Discord.Token = def.Bots.Discord.Token
+		}
+		if len(def.Bots.Discord.AllowedChannelIDs) > 0 {
+			cfg.Bots.Discord.AllowedChannelIDs = def.Bots.Discord.AllowedChannelIDs
+		}
+		if def.Bots.Discord.InterestedEventTypes != nil &&
+			!hasInterestedEventTypesEnv("BOTS_DISCORD_INTERESTED_EVENT_TYPES") {
+			cfg.Bots.Discord.InterestedEventTypes = parseInterestedEventTypesSlice(def.Bots.Discord.InterestedEventTypes)
+		}
+		if def.Bots.Discord.RespondToAll != nil {
+			cfg.Bots.Discord.RespondToAll = *def.Bots.Discord.RespondToAll
 		}
 	}
 }
@@ -1751,6 +1779,10 @@ var envBindings = []envBinding{
 	{key: "bots.slack.allowed_channel_ids", env: "BOTS_SLACK_ALLOWED_CHANNEL_IDS"},
 	{key: "bots.slack.interested_event_types", env: "BOTS_SLACK_INTERESTED_EVENT_TYPES"},
 	{key: "bots.slack.respond_to_all", env: "BOTS_SLACK_RESPOND_TO_ALL"},
+	{key: "bots.discord.token", env: "BOTS_DISCORD_TOKEN"},
+	{key: "bots.discord.allowed_channel_ids", env: "BOTS_DISCORD_ALLOWED_CHANNEL_IDS"},
+	{key: "bots.discord.interested_event_types", env: "BOTS_DISCORD_INTERESTED_EVENT_TYPES"},
+	{key: "bots.discord.respond_to_all", env: "BOTS_DISCORD_RESPOND_TO_ALL"},
 
 	// License
 	{key: "license.key", env: "LICENSE_KEY"},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -330,6 +330,9 @@ func TestLoad_Env(t *testing.T) {
 			Slack: SlackBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
 			},
+			Discord: DiscordBotConfig{
+				InterestedEventTypes: DefaultBotInterestedEventTypes,
+			},
 		},
 		DefaultExecMode: ExecutionModeLocal,
 		Warnings:        nil,
@@ -758,6 +761,9 @@ scheduler:
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
 			},
 			Slack: SlackBotConfig{
+				InterestedEventTypes: DefaultBotInterestedEventTypes,
+			},
+			Discord: DiscordBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
 			},
 		},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -329,9 +329,11 @@ func TestLoad_Env(t *testing.T) {
 			},
 			Slack: SlackBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
 			},
 			Discord: DiscordBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
 			},
 		},
 		DefaultExecMode: ExecutionModeLocal,
@@ -762,9 +764,11 @@ scheduler:
 			},
 			Slack: SlackBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
 			},
 			Discord: DiscordBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
 			},
 		},
 		DefaultExecMode: ExecutionModeLocal,
@@ -1224,6 +1228,35 @@ bots:
 
 		assert.Empty(t, cfg.Bots.Slack.InterestedEventTypes)
 	})
+
+	t.Run("discord env overrides config", func(t *testing.T) {
+		cfg := loadWithEnv(t, `
+bots:
+  discord:
+    interested_event_types:
+      - dag.run.failed
+      - dag.run.succeeded
+`, map[string]string{
+			"DAGU_BOTS_DISCORD_INTERESTED_EVENT_TYPES": "dag.run.running,dag.run.queued",
+		})
+
+		assert.Equal(t, []string{"dag.run.running", "dag.run.queued"}, cfg.Bots.Discord.InterestedEventTypes)
+	})
+}
+
+func TestLoad_DiscordBotEnvOnlyConfig(t *testing.T) {
+	cfg := loadWithEnv(t, "# empty", map[string]string{
+		"DAGU_BOTS_PROVIDER":                    "discord",
+		"DAGU_BOTS_DISCORD_TOKEN":               "discord-token",
+		"DAGU_BOTS_DISCORD_ALLOWED_CHANNEL_IDS": "chan-1,chan-2",
+		"DAGU_BOTS_DISCORD_RESPOND_TO_ALL":      "false",
+	})
+
+	assert.Equal(t, BotProviderDiscord, cfg.Bots.Provider)
+	assert.Equal(t, "discord-token", cfg.Bots.Discord.Token)
+	assert.Equal(t, []string{"chan-1", "chan-2"}, cfg.Bots.Discord.AllowedChannelIDs)
+	assert.False(t, cfg.Bots.Discord.RespondToAll)
+	assert.Equal(t, DefaultBotInterestedEventTypes, cfg.Bots.Discord.InterestedEventTypes)
 }
 
 func TestLoad_Monitoring(t *testing.T) {

--- a/internal/service/discord/bot.go
+++ b/internal/service/discord/bot.go
@@ -130,7 +130,7 @@ func (b *Bot) Run(ctx context.Context) error {
 	b.session.AddHandler(func(_ *discordgo.Session, i *discordgo.InteractionCreate) {
 		b.handleInteractionCreate(ctx, i)
 	})
-	b.session.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+	b.session.AddHandler(func(_ *discordgo.Session, r *discordgo.Ready) {
 		b.selfID = r.User.ID
 		b.logger.Info("Discord bot ready",
 			slog.String("username", r.User.Username),

--- a/internal/service/discord/bot.go
+++ b/internal/service/discord/bot.go
@@ -1,0 +1,849 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package discord provides a Discord bot service that bridges Discord
+// channels with the Dagu AI agent, allowing users to interact with the agent
+// via Discord messages.
+package discord
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+)
+
+// maxDiscordMessageLen is the maximum length for a single Discord message.
+const maxDiscordMessageLen = 2000
+const defaultIncomingBatchDelay = 750 * time.Millisecond
+const defaultTypingRefreshInterval = 7 * time.Second
+
+// AgentService is the subset of the agent API that the Discord bot requires.
+type AgentService = chatbridge.AgentService
+
+// discordClientAPI is the subset of the discordgo Session that the bot needs,
+// extracted so the implementation can be tested without a live gateway.
+type discordClientAPI interface {
+	ChannelMessageSend(channelID, content string, options ...discordgo.RequestOption) (*discordgo.Message, error)
+	ChannelMessageSendComplex(channelID string, data *discordgo.MessageSend, options ...discordgo.RequestOption) (*discordgo.Message, error)
+	ChannelMessageEditComplex(m *discordgo.MessageEdit, options ...discordgo.RequestOption) (*discordgo.Message, error)
+	ChannelTyping(channelID string, options ...discordgo.RequestOption) error
+	InteractionRespond(interaction *discordgo.Interaction, resp *discordgo.InteractionResponse, options ...discordgo.RequestOption) error
+}
+
+// Config holds configuration for the Discord bot.
+type Config struct {
+	Token                 string
+	AllowedChannelIDs     []string
+	InterestedEventTypes  []string
+	SafeMode              bool
+	RespondToAll          bool // respond to all channel messages, not just @mentions
+	EventService          *eventstore.Service
+	NotificationStateFile string
+}
+
+// chatState tracks the agent session state for a single Discord channel.
+type chatState struct {
+	chatbridge.State
+
+	channelID string
+
+	typingMu      sync.Mutex
+	typingCancel  context.CancelFunc
+	typingDone    chan struct{}
+	typingLoopGen uint64
+}
+
+// Bot is a Discord bot that forwards messages to the Dagu agent API.
+type Bot struct {
+	cfg                   Config
+	agentAPI              AgentService
+	session               *discordgo.Session
+	client                discordClientAPI
+	selfID                string
+	chats                 sync.Map // channelID (string) -> *chatState
+	allowedChannels       map[string]struct{}
+	eventService          *eventstore.Service
+	notificationStateFile string
+	logger                *slog.Logger
+	incomingDelay         time.Duration
+	typingDelay           time.Duration
+}
+
+// New creates a new Discord bot instance.
+func New(cfg Config, agentAPI AgentService, logger *slog.Logger) (*Bot, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("discord bot token is required (set DAGU_BOTS_DISCORD_TOKEN)")
+	}
+	if len(cfg.AllowedChannelIDs) == 0 {
+		return nil, fmt.Errorf("at least one allowed channel ID is required (set DAGU_BOTS_DISCORD_ALLOWED_CHANNEL_IDS)")
+	}
+
+	session, err := discordgo.New("Bot " + cfg.Token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Discord session: %w", err)
+	}
+
+	// We need message content intent to read user messages, plus guild and DM
+	// messages to actually receive them.
+	session.Identify.Intents = discordgo.IntentsGuildMessages |
+		discordgo.IntentsDirectMessages |
+		discordgo.IntentsMessageContent
+
+	allowed := make(map[string]struct{}, len(cfg.AllowedChannelIDs))
+	for _, id := range cfg.AllowedChannelIDs {
+		allowed[id] = struct{}{}
+	}
+
+	return &Bot{
+		cfg:                   cfg,
+		agentAPI:              agentAPI,
+		session:               session,
+		client:                session,
+		allowedChannels:       allowed,
+		eventService:          cfg.EventService,
+		notificationStateFile: cfg.NotificationStateFile,
+		logger:                logger,
+		incomingDelay:         defaultIncomingBatchDelay,
+		typingDelay:           defaultTypingRefreshInterval,
+	}, nil
+}
+
+// Run starts the bot and blocks until the context is cancelled.
+func (b *Bot) Run(ctx context.Context) error {
+	b.logger.Info("Discord bot starting",
+		slog.Int("allowed_channels", len(b.allowedChannels)),
+		slog.Bool("respond_to_all", b.cfg.RespondToAll),
+	)
+
+	b.session.AddHandler(func(_ *discordgo.Session, m *discordgo.MessageCreate) {
+		b.handleMessageCreate(ctx, m)
+	})
+	b.session.AddHandler(func(_ *discordgo.Session, i *discordgo.InteractionCreate) {
+		b.handleInteractionCreate(ctx, i)
+	})
+	b.session.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+		b.selfID = r.User.ID
+		b.logger.Info("Discord bot ready",
+			slog.String("username", r.User.Username),
+			slog.String("user_id", r.User.ID),
+		)
+	})
+
+	if err := b.session.Open(); err != nil {
+		return fmt.Errorf("failed to open Discord gateway connection: %w", err)
+	}
+	defer func() {
+		if err := b.session.Close(); err != nil {
+			b.logger.Warn("Failed to close Discord session", slog.String("error", err.Error()))
+		}
+	}()
+
+	// Start DAG run monitor if the event store is available.
+	if b.eventService != nil {
+		monitor := NewDAGRunMonitor(b.eventService, b.notificationStateFile, b.agentAPI, b, b.logger)
+		go monitor.Run(ctx)
+	} else {
+		b.logger.Warn("Event store is not configured; DAG run notifications are disabled")
+	}
+
+	<-ctx.Done()
+	b.logger.Info("Discord bot stopped")
+	return nil
+}
+
+// handleMessageCreate processes an incoming Discord message.
+func (b *Bot) handleMessageCreate(ctx context.Context, m *discordgo.MessageCreate) {
+	if m.Author == nil {
+		return
+	}
+	// Ignore our own messages and messages from other bots.
+	if m.Author.Bot || (b.selfID != "" && m.Author.ID == b.selfID) {
+		return
+	}
+
+	channelID := m.ChannelID
+	if channelID == "" {
+		return
+	}
+
+	// DMs are always handled regardless of the allow list, so long as the
+	// token owner opened the DM.
+	isDM := m.GuildID == ""
+	if !isDM && !b.isChannelAllowed(channelID) {
+		return
+	}
+
+	text := strings.TrimSpace(m.Content)
+	if text == "" {
+		return
+	}
+
+	// @mention handling: strip "<@selfID>" / "<@!selfID>" prefixes when present.
+	wasMentioned := false
+	if b.selfID != "" {
+		mentions := []string{"<@" + b.selfID + ">", "<@!" + b.selfID + ">"}
+		for _, prefix := range mentions {
+			if trimmed, ok := strings.CutPrefix(text, prefix); ok {
+				text = strings.TrimSpace(trimmed)
+				wasMentioned = true
+				break
+			}
+		}
+		if !wasMentioned {
+			for _, u := range m.Mentions {
+				if u.ID == b.selfID {
+					wasMentioned = true
+					break
+				}
+			}
+		}
+	}
+
+	if text == "" {
+		return
+	}
+
+	// In guild channels, when respond_to_all is disabled, only handle
+	// messages that @mention the bot.
+	if !isDM && !b.cfg.RespondToAll && !wasMentioned {
+		return
+	}
+
+	cs := b.getOrCreateChat(channelID)
+
+	// Handle text commands (works in both DMs and guild channels).
+	if fields := strings.Fields(text); len(fields) > 0 {
+		if cmd := fields[0]; cmd == "new" || cmd == "cancel" {
+			b.clearPendingMessages(cs)
+			b.handleTextCommand(ctx, cs, channelID, cmd)
+			return
+		}
+	}
+
+	pendingPrompt := cs.PendingPromptID()
+	if pendingPrompt != "" {
+		b.submitPromptResponse(ctx, cs, channelID, pendingPrompt, text)
+		return
+	}
+
+	b.enqueueIncomingMessage(ctx, cs, channelID, text)
+}
+
+// handleInteractionCreate handles button interactions.
+func (b *Bot) handleInteractionCreate(ctx context.Context, i *discordgo.InteractionCreate) {
+	if i.Interaction == nil || i.Type != discordgo.InteractionMessageComponent {
+		return
+	}
+
+	data := i.MessageComponentData()
+
+	// Parse custom_id: "prompt:<promptID>:<optionID>"
+	parts := strings.SplitN(data.CustomID, ":", 3)
+	if len(parts) != 3 || parts[0] != "prompt" {
+		return
+	}
+
+	promptID := parts[1]
+	optionID := parts[2]
+
+	channelID := i.ChannelID
+	cs := b.getOrCreateChat(channelID)
+	sid, ownerUID := cs.ActiveSession()
+	cs.ClearPendingPrompt()
+
+	if sid == "" {
+		b.ackInteraction(i.Interaction)
+		return
+	}
+
+	resp := agent.UserPromptResponse{
+		PromptID:          promptID,
+		SelectedOptionIDs: []string{optionID},
+	}
+
+	if err := b.agentAPI.SubmitUserResponse(ctx, sid, ownerUID, resp); err != nil {
+		b.logger.Warn("Failed to submit prompt response",
+			slog.String("session", sid),
+			slog.String("user", ownerUID),
+			slog.String("prompt", promptID),
+			slog.String("error", err.Error()),
+		)
+		b.ackInteraction(i.Interaction)
+		b.sendText(channelID, fmt.Sprintf("Failed to submit response: %s", err.Error()))
+		return
+	}
+
+	// Update the original message in-place to show the selection and remove
+	// the now-consumed buttons.
+	updatedContent := ""
+	if i.Message != nil {
+		updatedContent = i.Message.Content + "\n\nSelected: " + optionID
+	} else {
+		updatedContent = "Selected: " + optionID
+	}
+
+	emptyComponents := []discordgo.MessageComponent{}
+	err := b.client.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content:    updatedContent,
+			Components: emptyComponents,
+		},
+	})
+	if err != nil {
+		b.logger.Warn("Failed to update interaction message", slog.String("error", err.Error()))
+	}
+}
+
+func (b *Bot) ackInteraction(interaction *discordgo.Interaction) {
+	err := b.client.InteractionRespond(interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredMessageUpdate,
+	})
+	if err != nil {
+		b.logger.Debug("Failed to ack interaction", slog.String("error", err.Error()))
+	}
+}
+
+// handleTextCommand processes text commands ("new", "cancel").
+func (b *Bot) handleTextCommand(ctx context.Context, cs *chatState, channelID, cmd string) {
+	switch cmd {
+	case "new":
+		b.resetChat(cs)
+		b.sendText(channelID, "Session cleared. Send a message to start a new conversation.")
+
+	case "cancel":
+		b.stopTypingLoop(cs)
+		sid, ownerUID := cs.ActiveSession()
+
+		if sid == "" {
+			b.sendText(channelID, "No active session.")
+			return
+		}
+
+		if err := b.agentAPI.CancelSession(ctx, sid, ownerUID); err != nil {
+			b.sendText(channelID, "Failed to cancel session: "+err.Error())
+			return
+		}
+		b.sendText(channelID, "Session cancelled.")
+	}
+}
+
+func (b *Bot) enqueueIncomingMessage(ctx context.Context, cs *chatState, channelID, text string) {
+	if text == "" {
+		return
+	}
+
+	b.startTypingLoop(ctx, cs, channelID)
+	gen := cs.EnqueuePendingMessage(text)
+
+	delay := b.incomingDelay
+	if delay <= 0 {
+		delay = defaultIncomingBatchDelay
+	}
+	time.AfterFunc(delay, func() {
+		b.flushIncomingMessages(ctx, cs, channelID, gen)
+	})
+}
+
+func (b *Bot) flushIncomingMessages(ctx context.Context, cs *chatState, channelID string, gen uint64) {
+	text, ok := cs.TakePendingMessages(gen, "\n\n")
+	if !ok {
+		return
+	}
+
+	user := b.userIdentity(channelID)
+	if cs.SessionID() == "" {
+		b.createSession(ctx, cs, channelID, user, text)
+		return
+	}
+
+	b.sendAgentMessage(ctx, cs, channelID, user, text)
+}
+
+// ---------------------------------------------------------------------------
+// Agent session management
+// ---------------------------------------------------------------------------
+
+// createSession creates a new agent session and starts listening for responses.
+func (b *Bot) createSession(ctx context.Context, cs *chatState, channelID string, user agent.UserIdentity, text string) {
+	b.startTypingLoop(ctx, cs, channelID)
+
+	req := agent.ChatRequest{
+		Message:  text,
+		SafeMode: b.cfg.SafeMode,
+	}
+
+	sessionID, _, err := b.agentAPI.CreateSession(ctx, user, req)
+	if err != nil {
+		b.stopTypingLoop(cs)
+		b.logger.Error("Failed to create session", slog.String("error", err.Error()))
+		b.sendText(channelID, "Failed to start session: "+err.Error())
+		return
+	}
+
+	b.setActiveSession(cs, sessionID, user.UserID)
+	b.startSubscription(ctx, cs, channelID, user.UserID, sessionID)
+}
+
+// sendAgentMessage sends a message to an existing session.
+func (b *Bot) sendAgentMessage(ctx context.Context, cs *chatState, channelID string, user agent.UserIdentity, text string) {
+	b.startTypingLoop(ctx, cs, channelID)
+
+	req := agent.ChatRequest{
+		Message:  text,
+		SafeMode: b.cfg.SafeMode,
+	}
+
+	result, err := chatbridge.EnqueueMessage(ctx, b.agentAPI, &cs.State, user, req)
+	if err != nil {
+		b.stopTypingLoop(cs)
+		b.logger.Error("Failed to enqueue message", slog.String("error", err.Error()))
+		b.sendText(channelID, "Failed to send message: "+err.Error())
+		return
+	}
+	if result.Missing {
+		b.logger.Warn("Session missing during Discord send, recreating chat",
+			slog.String("session", result.SessionID),
+			slog.String("user", user.UserID),
+		)
+		b.resetChat(cs)
+		b.createSession(ctx, cs, channelID, user, text)
+		return
+	}
+	sid := result.SessionID
+	if sid == "" {
+		sid = cs.SessionID()
+	}
+	if result.Queued {
+		b.startTypingLoop(ctx, cs, channelID)
+	}
+	if sid != "" {
+		b.ensureSubscription(ctx, cs, channelID, user.UserID, sid)
+	}
+}
+
+// submitPromptResponse submits a text response to a pending agent prompt.
+func (b *Bot) submitPromptResponse(ctx context.Context, cs *chatState, channelID, promptID, text string) {
+	sid, ownerUserID := cs.ActiveSession()
+	cs.ClearPendingPrompt()
+
+	if sid == "" {
+		return
+	}
+
+	resp := agent.UserPromptResponse{
+		PromptID:         promptID,
+		FreeTextResponse: text,
+	}
+
+	b.startTypingLoop(ctx, cs, channelID)
+	if err := b.agentAPI.SubmitUserResponse(ctx, sid, ownerUserID, resp); err != nil {
+		b.stopTypingLoop(cs)
+		b.sendText(channelID, "Failed to submit response: "+err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscription management
+// ---------------------------------------------------------------------------
+
+// ensureSubscription starts a subscription only if one isn't already running
+// for the given session.
+func (b *Bot) ensureSubscription(ctx context.Context, cs *chatState, channelID, userID, sessionID string) {
+	subCtx, cancel := context.WithCancel(ctx)
+	cleanup, started := cs.PrepareSubscription(sessionID, cancel, false)
+	if !started {
+		if cleanup != nil {
+			cleanup()
+		}
+		return
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+
+	go b.subscribeLoop(subCtx, cs, channelID, userID, sessionID)
+}
+
+// startSubscription cancels any existing subscription and starts a fresh one.
+func (b *Bot) startSubscription(ctx context.Context, cs *chatState, channelID, userID, sessionID string) {
+	subCtx, cancel := context.WithCancel(ctx)
+	cleanup, _ := cs.PrepareSubscription(sessionID, cancel, true)
+	if cleanup != nil {
+		cleanup()
+	}
+
+	go b.subscribeLoop(subCtx, cs, channelID, userID, sessionID)
+}
+
+// subscribeLoop uses the agent's built-in pub-sub to receive session updates
+// in real time and forward them to Discord.
+func (b *Bot) subscribeLoop(ctx context.Context, cs *chatState, channelID, userID, sessionID string) {
+	user := agent.UserIdentity{
+		UserID:   userID,
+		Username: "discord",
+		Role:     auth.RoleAdmin,
+	}
+
+	snapshot, next, err := b.agentAPI.SubscribeSession(ctx, sessionID, user)
+	if err != nil {
+		b.logger.Warn("Failed to subscribe to session",
+			slog.String("session", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	b.processStreamResponse(ctx, cs, channelID, snapshot)
+
+	for {
+		resp, ok := next()
+		if !ok {
+			b.stopTypingLoop(cs)
+			// Session ended — clear the session ID so the next message
+			// creates a fresh session instead of reusing a dead one.
+			cs.ClearSessionIfActive(sessionID)
+			return
+		}
+		b.processStreamResponse(ctx, cs, channelID, resp)
+	}
+}
+
+// processStreamResponse handles a stream response and sends relevant content to Discord.
+func (b *Bot) processStreamResponse(ctx context.Context, cs *chatState, channelID string, resp agent.StreamResponse) {
+	var shouldFlushQueued bool
+	chatbridge.ProcessStreamResponse(&cs.State, resp, chatbridge.StreamHandlers{
+		OnSessionState: func(state agent.SessionState) {
+			if !state.Working && state.HasQueuedUserInput {
+				shouldFlushQueued = true
+				b.startTypingLoop(ctx, cs, channelID)
+			}
+		},
+		OnWorking: func(working bool) {
+			if working {
+				b.startTypingLoop(ctx, cs, channelID)
+			} else if !cs.HasQueuedUserInput() {
+				b.stopTypingLoop(cs)
+			}
+		},
+		OnAssistant: func(msg agent.Message) {
+			b.stopTypingLoop(cs)
+			b.sendLongText(channelID, msg.Content)
+		},
+		OnError: func(msg agent.Message) {
+			b.stopTypingLoop(cs)
+			b.sendText(channelID, "Error: "+msg.Content)
+		},
+		OnPrompt: func(prompt *agent.UserPrompt) {
+			b.stopTypingLoop(cs)
+			b.sendPrompt(cs, channelID, prompt)
+		},
+	})
+	if shouldFlushQueued {
+		_, ownerUserID := cs.ActiveSession()
+		if ownerUserID == "" {
+			return
+		}
+		user := agent.UserIdentity{
+			UserID:   ownerUserID,
+			Username: "discord",
+			Role:     auth.RoleAdmin,
+		}
+		result, err := chatbridge.FlushQueuedMessage(ctx, b.agentAPI, &cs.State, user)
+		if err != nil {
+			b.logger.Warn("Failed to flush queued Discord message",
+				slog.String("session", result.SessionID),
+				slog.String("user", user.UserID),
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+		if result.Missing {
+			b.logger.Warn("Session missing during queued Discord flush",
+				slog.String("session", result.SessionID),
+				slog.String("user", user.UserID),
+			)
+			b.resetChat(cs)
+			return
+		}
+		if result.SessionID != "" {
+			b.ensureSubscription(ctx, cs, channelID, user.UserID, result.SessionID)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Discord messaging helpers
+// ---------------------------------------------------------------------------
+
+// sendPrompt sends a user prompt with interactive buttons.
+func (b *Bot) sendPrompt(cs *chatState, channelID string, prompt *agent.UserPrompt) {
+	cs.SetPendingPrompt(prompt.PromptID)
+
+	text := prompt.Question
+	if prompt.Command != "" {
+		text += "\n\nCommand: " + prompt.Command
+	}
+	if prompt.AllowFreeText {
+		text += "\n\n(You can also reply with text)"
+	}
+
+	if len(prompt.Options) == 0 {
+		b.sendText(channelID, text)
+		return
+	}
+
+	// Discord allows up to 5 components per action row and up to 5 rows per message.
+	var rows []discordgo.MessageComponent
+	var current []discordgo.MessageComponent
+	for _, opt := range prompt.Options {
+		customID := fmt.Sprintf("prompt:%s:%s", prompt.PromptID, opt.ID)
+		label := opt.Label
+		if opt.Description != "" {
+			label += " - " + opt.Description
+		}
+		// Discord button label limit is 80 characters.
+		if len(label) > 80 {
+			label = label[:77] + "..."
+		}
+		current = append(current, discordgo.Button{
+			Label:    label,
+			Style:    discordgo.PrimaryButton,
+			CustomID: customID,
+		})
+		if len(current) == 5 {
+			rows = append(rows, discordgo.ActionsRow{Components: current})
+			current = nil
+			if len(rows) == 5 {
+				break
+			}
+		}
+	}
+	if len(current) > 0 && len(rows) < 5 {
+		rows = append(rows, discordgo.ActionsRow{Components: current})
+	}
+
+	// If the message body is too long for Discord, split it and only attach
+	// buttons to the final chunk.
+	chunks := splitMessage(text, maxDiscordMessageLen)
+	for i, chunk := range chunks {
+		if i < len(chunks)-1 {
+			b.sendText(channelID, chunk)
+			continue
+		}
+		if _, err := b.client.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
+			Content:    chunk,
+			Components: rows,
+		}); err != nil {
+			b.logger.Warn("Failed to send prompt",
+				slog.String("channel_id", channelID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// sendLongText sends a message, splitting it if it exceeds Discord's limit.
+func (b *Bot) sendLongText(channelID, text string) {
+	chunks := splitMessage(text, maxDiscordMessageLen)
+	for _, chunk := range chunks {
+		b.sendText(channelID, chunk)
+	}
+}
+
+// sendText sends a simple text message to a Discord channel.
+func (b *Bot) sendText(channelID, text string) {
+	if text == "" {
+		return
+	}
+	if _, err := b.client.ChannelMessageSend(channelID, text); err != nil {
+		b.logger.Warn("Failed to send Discord message",
+			slog.String("channel_id", channelID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Typing indicator management
+// ---------------------------------------------------------------------------
+
+// sendTyping sends a "typing..." indicator to the Discord channel.
+func (b *Bot) sendTyping(channelID string) {
+	if err := b.client.ChannelTyping(channelID); err != nil {
+		b.logger.Debug("Failed to send typing indicator", slog.String("error", err.Error()))
+	}
+}
+
+func (b *Bot) startTypingLoop(ctx context.Context, cs *chatState, channelID string) {
+	cs.typingMu.Lock()
+	if cs.typingCancel != nil {
+		cs.typingMu.Unlock()
+		return
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	cs.typingLoopGen++
+	gen := cs.typingLoopGen
+	cs.typingCancel = cancel
+	cs.typingDone = done
+	cs.typingMu.Unlock()
+
+	if !b.sendTypingIfCurrent(cs, gen, channelID) {
+		close(done)
+		b.finishTypingLoop(cs, gen)
+		return
+	}
+
+	refresh := b.typingDelay
+	if refresh <= 0 {
+		refresh = defaultTypingRefreshInterval
+	}
+
+	go func() {
+		ticker := time.NewTicker(refresh)
+		defer ticker.Stop()
+		defer close(done)
+		defer b.finishTypingLoop(cs, gen)
+
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				select {
+				case <-loopCtx.Done():
+					return
+				default:
+				}
+				if !b.sendTypingIfCurrent(cs, gen, channelID) {
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (b *Bot) stopTypingLoop(cs *chatState) {
+	cs.typingMu.Lock()
+	cancel := cs.typingCancel
+	done := cs.typingDone
+	cs.typingCancel = nil
+	cs.typingDone = nil
+	cs.typingMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (b *Bot) finishTypingLoop(cs *chatState, gen uint64) {
+	cs.typingMu.Lock()
+	defer cs.typingMu.Unlock()
+	if cs.typingLoopGen == gen {
+		cs.typingCancel = nil
+		cs.typingDone = nil
+	}
+}
+
+func (b *Bot) sendTypingIfCurrent(cs *chatState, gen uint64, channelID string) bool {
+	cs.typingMu.Lock()
+	defer cs.typingMu.Unlock()
+	if cs.typingLoopGen != gen || cs.typingCancel == nil {
+		return false
+	}
+	b.sendTyping(channelID)
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// State management
+// ---------------------------------------------------------------------------
+
+// isChannelAllowed checks if a channel ID is authorized to use the bot.
+func (b *Bot) isChannelAllowed(channelID string) bool {
+	_, ok := b.allowedChannels[channelID]
+	return ok
+}
+
+// getOrCreateChat returns or creates a chatState for the given channel ID.
+func (b *Bot) getOrCreateChat(channelID string) *chatState {
+	val, _ := b.chats.LoadOrStore(channelID, &chatState{channelID: channelID})
+	return val.(*chatState)
+}
+
+// resetChat clears the session state for a chat.
+func (b *Bot) resetChat(cs *chatState) {
+	if cancel := cs.Reset(); cancel != nil {
+		cancel()
+	}
+	b.stopTypingLoop(cs)
+}
+
+// userIdentity creates a channel-scoped UserIdentity so the entire channel shares one session.
+func (b *Bot) userIdentity(channelID string) agent.UserIdentity {
+	return agent.UserIdentity{
+		UserID:   fmt.Sprintf("discord:%s", channelID),
+		Username: "discord",
+		Role:     auth.RoleAdmin,
+	}
+}
+
+func (b *Bot) setActiveSession(cs *chatState, sessionID, ownerUserID string) {
+	cs.SetActiveSession(sessionID, ownerUserID)
+}
+
+func (b *Bot) markDelivered(cs *chatState, seq int64) {
+	cs.MarkDelivered(seq)
+}
+
+func (b *Bot) clearPendingMessages(cs *chatState) {
+	cs.ClearPendingMessages()
+}
+
+func (b *Bot) subscriptionActive(cs *chatState, sessionID string) bool {
+	return cs.SubscriptionActive(sessionID)
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+// splitMessage splits text into chunks that fit within the Discord message limit.
+func splitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+
+		cut := maxLen
+		if idx := strings.LastIndex(text[:maxLen], "\n\n"); idx > maxLen/2 {
+			cut = idx + 2
+		} else if idx := strings.LastIndex(text[:maxLen], "\n"); idx > maxLen/2 {
+			cut = idx + 1
+		}
+
+		chunks = append(chunks, text[:cut])
+		text = text[cut:]
+	}
+
+	return chunks
+}

--- a/internal/service/discord/bot.go
+++ b/internal/service/discord/bot.go
@@ -25,6 +25,9 @@ import (
 const maxDiscordMessageLen = 2000
 const defaultIncomingBatchDelay = 750 * time.Millisecond
 const defaultTypingRefreshInterval = 7 * time.Second
+const maxDiscordButtonsPerRow = 5
+const maxDiscordActionRows = 5
+const maxDiscordPromptOptions = maxDiscordButtonsPerRow * maxDiscordActionRows
 
 // AgentService is the subset of the agent API that the Discord bot requires.
 type AgentService = chatbridge.AgentService
@@ -56,10 +59,13 @@ type chatState struct {
 
 	channelID string
 
-	typingMu      sync.Mutex
-	typingCancel  context.CancelFunc
-	typingDone    chan struct{}
-	typingLoopGen uint64
+	promptMu              sync.Mutex
+	pendingPromptOptions  map[string]string
+	pendingPromptFreeText bool
+	typingMu              sync.Mutex
+	typingCancel          context.CancelFunc
+	typingDone            chan struct{}
+	typingLoopGen         uint64
 }
 
 // Bot is a Discord bot that forwards messages to the Dagu agent API.
@@ -263,11 +269,14 @@ func (b *Bot) handleInteractionCreate(ctx context.Context, i *discordgo.Interact
 	channelID := i.ChannelID
 	cs := b.getOrCreateChat(channelID)
 	sid, ownerUID := cs.ActiveSession()
-	cs.ClearPendingPrompt()
 
 	b.ackInteraction(i.Interaction)
 
 	if sid == "" {
+		return
+	}
+	if cs.PendingPromptID() != promptID {
+		b.sendText(channelID, "That prompt is no longer active.")
 		return
 	}
 
@@ -287,25 +296,19 @@ func (b *Bot) handleInteractionCreate(ctx context.Context, i *discordgo.Interact
 		return
 	}
 
+	cs.clearPendingPromptState()
 	b.updateInteractionMessage(channelID, i.Message, optionID)
 }
 
 func (b *Bot) updateInteractionMessage(channelID string, msg *discordgo.Message, optionID string) {
 	// Update the original message in-place to show the selection and remove
 	// the now-consumed buttons.
-	updatedContent := ""
-	if msg != nil {
-		updatedContent = msg.Content + "\n\nSelected: " + optionID
-	} else {
-		updatedContent = "Selected: " + optionID
-	}
-
 	emptyComponents := []discordgo.MessageComponent{}
 	if msg == nil {
 		return
 	}
 
-	edit := discordgo.NewMessageEdit(channelID, msg.ID).SetContent(updatedContent)
+	edit := discordgo.NewMessageEdit(channelID, msg.ID).SetContent("Selection received: " + optionID)
 	edit.Components = &emptyComponents
 	if _, err := b.client.ChannelMessageEditComplex(edit); err != nil {
 		b.logger.Warn("Failed to update interaction message", slog.String("error", err.Error()))
@@ -341,6 +344,7 @@ func (b *Bot) handleTextCommand(ctx context.Context, cs *chatState, channelID, c
 			b.sendText(channelID, "Failed to cancel session: "+err.Error())
 			return
 		}
+		b.resetChat(cs)
 		b.sendText(channelID, "Session cancelled.")
 	}
 }
@@ -442,22 +446,27 @@ func (b *Bot) sendAgentMessage(ctx context.Context, cs *chatState, channelID str
 // submitPromptResponse submits a text response to a pending agent prompt.
 func (b *Bot) submitPromptResponse(ctx context.Context, cs *chatState, channelID, promptID, text string) {
 	sid, ownerUserID := cs.ActiveSession()
-	cs.ClearPendingPrompt()
-
 	if sid == "" {
 		return
 	}
+	if cs.PendingPromptID() != promptID {
+		b.sendText(channelID, "That prompt is no longer active.")
+		return
+	}
 
-	resp := agent.UserPromptResponse{
-		PromptID:         promptID,
-		FreeTextResponse: text,
+	resp, ok := cs.promptResponse(promptID, text)
+	if !ok {
+		b.sendText(channelID, "Please use one of the prompt options.")
+		return
 	}
 
 	b.startTypingLoop(ctx, cs, channelID)
 	if err := b.agentAPI.SubmitUserResponse(ctx, sid, ownerUserID, resp); err != nil {
 		b.stopTypingLoop(cs)
 		b.sendText(channelID, "Failed to submit response: "+err.Error())
+		return
 	}
+	cs.clearPendingPromptState()
 }
 
 // ---------------------------------------------------------------------------
@@ -595,7 +604,7 @@ func (b *Bot) processStreamResponse(ctx context.Context, cs *chatState, channelI
 
 // sendPrompt sends a user prompt with interactive buttons.
 func (b *Bot) sendPrompt(cs *chatState, channelID string, prompt *agent.UserPrompt) {
-	cs.SetPendingPrompt(prompt.PromptID)
+	cs.setPendingPrompt(prompt)
 
 	text := prompt.Question
 	if prompt.Command != "" {
@@ -606,7 +615,12 @@ func (b *Bot) sendPrompt(cs *chatState, channelID string, prompt *agent.UserProm
 	}
 
 	if len(prompt.Options) == 0 {
-		b.sendText(channelID, text)
+		b.sendLongText(channelID, text)
+		return
+	}
+	if len(prompt.Options) > maxDiscordPromptOptions {
+		text += "\n\nReply with one of these option IDs:\n" + formatPromptOptions(prompt.Options)
+		b.sendLongText(channelID, text)
 		return
 	}
 
@@ -628,15 +642,12 @@ func (b *Bot) sendPrompt(cs *chatState, channelID string, prompt *agent.UserProm
 			Style:    discordgo.PrimaryButton,
 			CustomID: customID,
 		})
-		if len(current) == 5 {
+		if len(current) == maxDiscordButtonsPerRow {
 			rows = append(rows, discordgo.ActionsRow{Components: current})
 			current = nil
-			if len(rows) == 5 {
-				break
-			}
 		}
 	}
-	if len(current) > 0 && len(rows) < 5 {
+	if len(current) > 0 && len(rows) < maxDiscordActionRows {
 		rows = append(rows, discordgo.ActionsRow{Components: current})
 	}
 
@@ -811,6 +822,7 @@ func (b *Bot) resetChat(cs *chatState) {
 	if cancel := cs.Reset(); cancel != nil {
 		cancel()
 	}
+	cs.clearPendingPromptMetadata()
 	b.stopTypingLoop(cs)
 }
 
@@ -843,9 +855,77 @@ func notificationChatKey(channelID string) string {
 	return "notifications:" + channelID
 }
 
+func (cs *chatState) setPendingPrompt(prompt *agent.UserPrompt) {
+	cs.SetPendingPrompt(prompt.PromptID)
+
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+
+	cs.pendingPromptFreeText = prompt.AllowFreeText || len(prompt.Options) == 0
+	if len(prompt.Options) == 0 {
+		cs.pendingPromptOptions = nil
+		return
+	}
+
+	options := make(map[string]string, len(prompt.Options))
+	for _, opt := range prompt.Options {
+		if key := normalizePromptOptionInput(opt.ID); key != "" {
+			options[key] = opt.ID
+		}
+	}
+	cs.pendingPromptOptions = options
+}
+
+func (cs *chatState) clearPendingPromptState() {
+	cs.ClearPendingPrompt()
+	cs.clearPendingPromptMetadata()
+}
+
+func (cs *chatState) clearPendingPromptMetadata() {
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+	cs.pendingPromptOptions = nil
+	cs.pendingPromptFreeText = false
+}
+
+func (cs *chatState) promptResponse(promptID, text string) (agent.UserPromptResponse, bool) {
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+
+	resp := agent.UserPromptResponse{PromptID: promptID}
+	if optionID, ok := cs.pendingPromptOptions[normalizePromptOptionInput(text)]; ok {
+		resp.SelectedOptionIDs = []string{optionID}
+		return resp, true
+	}
+	if len(cs.pendingPromptOptions) > 0 && !cs.pendingPromptFreeText {
+		return agent.UserPromptResponse{}, false
+	}
+	resp.FreeTextResponse = text
+	return resp, true
+}
+
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
+
+func formatPromptOptions(options []agent.UserPromptOption) string {
+	var b strings.Builder
+	for _, opt := range options {
+		fmt.Fprintf(&b, "- %s", opt.ID)
+		if opt.Label != "" {
+			fmt.Fprintf(&b, ": %s", opt.Label)
+		}
+		if opt.Description != "" {
+			fmt.Fprintf(&b, " - %s", opt.Description)
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func normalizePromptOptionInput(text string) string {
+	return strings.ToLower(strings.TrimSpace(text))
+}
 
 // splitMessage splits text into chunks that fit within the Discord message limit.
 func splitMessage(text string, maxLen int) []string {

--- a/internal/service/discord/bot.go
+++ b/internal/service/discord/bot.go
@@ -212,9 +212,15 @@ func (b *Bot) handleMessageCreate(ctx context.Context, m *discordgo.MessageCreat
 		return
 	}
 
+	var pendingPrompt string
+	if cs, ok := b.getChat(channelID); ok {
+		pendingPrompt = cs.PendingPromptID()
+	}
+
 	// In guild channels, when respond_to_all is disabled, only handle
-	// messages that @mention the bot.
-	if !isDM && !b.cfg.RespondToAll && !wasMentioned {
+	// messages that @mention the bot. Pending prompt replies are the only
+	// exception so button flows can be completed with plain text.
+	if !isDM && !b.cfg.RespondToAll && !wasMentioned && pendingPrompt == "" {
 		return
 	}
 
@@ -229,7 +235,6 @@ func (b *Bot) handleMessageCreate(ctx context.Context, m *discordgo.MessageCreat
 		}
 	}
 
-	pendingPrompt := cs.PendingPromptID()
 	if pendingPrompt != "" {
 		b.submitPromptResponse(ctx, cs, channelID, pendingPrompt, text)
 		return
@@ -260,8 +265,9 @@ func (b *Bot) handleInteractionCreate(ctx context.Context, i *discordgo.Interact
 	sid, ownerUID := cs.ActiveSession()
 	cs.ClearPendingPrompt()
 
+	b.ackInteraction(i.Interaction)
+
 	if sid == "" {
-		b.ackInteraction(i.Interaction)
 		return
 	}
 
@@ -277,29 +283,31 @@ func (b *Bot) handleInteractionCreate(ctx context.Context, i *discordgo.Interact
 			slog.String("prompt", promptID),
 			slog.String("error", err.Error()),
 		)
-		b.ackInteraction(i.Interaction)
 		b.sendText(channelID, fmt.Sprintf("Failed to submit response: %s", err.Error()))
 		return
 	}
 
+	b.updateInteractionMessage(channelID, i.Message, optionID)
+}
+
+func (b *Bot) updateInteractionMessage(channelID string, msg *discordgo.Message, optionID string) {
 	// Update the original message in-place to show the selection and remove
 	// the now-consumed buttons.
 	updatedContent := ""
-	if i.Message != nil {
-		updatedContent = i.Message.Content + "\n\nSelected: " + optionID
+	if msg != nil {
+		updatedContent = msg.Content + "\n\nSelected: " + optionID
 	} else {
 		updatedContent = "Selected: " + optionID
 	}
 
 	emptyComponents := []discordgo.MessageComponent{}
-	err := b.client.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseUpdateMessage,
-		Data: &discordgo.InteractionResponseData{
-			Content:    updatedContent,
-			Components: emptyComponents,
-		},
-	})
-	if err != nil {
+	if msg == nil {
+		return
+	}
+
+	edit := discordgo.NewMessageEdit(channelID, msg.ID).SetContent(updatedContent)
+	edit.Components = &emptyComponents
+	if _, err := b.client.ChannelMessageEditComplex(edit); err != nil {
 		b.logger.Warn("Failed to update interaction message", slog.String("error", err.Error()))
 	}
 }
@@ -784,6 +792,20 @@ func (b *Bot) getOrCreateChat(channelID string) *chatState {
 	return val.(*chatState)
 }
 
+func (b *Bot) getOrCreateNotificationChat(channelID string) *chatState {
+	key := notificationChatKey(channelID)
+	val, _ := b.chats.LoadOrStore(key, &chatState{channelID: channelID})
+	return val.(*chatState)
+}
+
+func (b *Bot) getChat(channelID string) (*chatState, bool) {
+	val, ok := b.chats.Load(channelID)
+	if !ok {
+		return nil, false
+	}
+	return val.(*chatState), true
+}
+
 // resetChat clears the session state for a chat.
 func (b *Bot) resetChat(cs *chatState) {
 	if cancel := cs.Reset(); cancel != nil {
@@ -815,6 +837,10 @@ func (b *Bot) clearPendingMessages(cs *chatState) {
 
 func (b *Bot) subscriptionActive(cs *chatState, sessionID string) bool {
 	return cs.SubscriptionActive(sessionID)
+}
+
+func notificationChatKey(channelID string) string {
+	return "notifications:" + channelID
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/service/discord/bot_test.go
+++ b/internal/service/discord/bot_test.go
@@ -24,8 +24,14 @@ import (
 type fakeDiscordClient struct {
 	mu                   sync.Mutex
 	sentMessages         []string
+	sentComplexMessages  []sentDiscordMessage
 	editedMessages       []editedDiscordMessage
 	interactionResponses []discordgo.InteractionResponseType
+}
+
+type sentDiscordMessage struct {
+	content       string
+	componentsLen int
 }
 
 type editedDiscordMessage struct {
@@ -44,12 +50,18 @@ func (c *fakeDiscordClient) ChannelMessageSend(_ string, content string, _ ...di
 
 func (c *fakeDiscordClient) ChannelMessageSendComplex(channelID string, data *discordgo.MessageSend, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
 	content := ""
+	componentsLen := 0
 	if data != nil {
 		content = data.Content
+		componentsLen = len(data.Components)
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.sentMessages = append(c.sentMessages, content)
+	c.sentComplexMessages = append(c.sentComplexMessages, sentDiscordMessage{
+		content:       content,
+		componentsLen: componentsLen,
+	})
 	return &discordgo.Message{ID: "sent", ChannelID: channelID, Content: content}, nil
 }
 
@@ -97,8 +109,10 @@ type fakeDiscordAgentService struct {
 	nextSequenceID   int64
 	createEmptyCalls int
 	appendSessionIDs []string
+	cancelCalls      int
 	submitResponses  []agent.UserPromptResponse
 	onSubmit         func()
+	submitErr        error
 }
 
 func (s *fakeDiscordAgentService) CreateSession(_ context.Context, _ agent.UserIdentity, _ agent.ChatRequest) (string, string, error) {
@@ -129,6 +143,9 @@ func (s *fakeDiscordAgentService) FlushQueuedChatMessage(_ context.Context, sess
 }
 
 func (s *fakeDiscordAgentService) CancelSession(context.Context, string, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelCalls++
 	return nil
 }
 
@@ -138,6 +155,9 @@ func (s *fakeDiscordAgentService) SubmitUserResponse(_ context.Context, _ string
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.submitErr != nil {
+		return s.submitErr
+	}
 	s.submitResponses = append(s.submitResponses, resp)
 	return nil
 }
@@ -216,7 +236,7 @@ func TestHandleMessageCreate_AllowsPendingPromptReplyWithoutMention(t *testing.T
 
 	cs := bot.getOrCreateChat("C1")
 	bot.setActiveSession(cs, "session-1", "discord:C1")
-	cs.SetPendingPrompt("prompt-1")
+	cs.setPendingPrompt(&agent.UserPrompt{PromptID: "prompt-1", AllowFreeText: true})
 
 	bot.handleMessageCreate(context.Background(), &discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -254,7 +274,12 @@ func TestHandleInteractionCreate_AcksBeforeSubmittingAndEditsMessage(t *testing.
 
 	cs := bot.getOrCreateChat("C1")
 	bot.setActiveSession(cs, "session-1", "discord:C1")
-	cs.SetPendingPrompt("prompt-1")
+	cs.setPendingPrompt(&agent.UserPrompt{
+		PromptID: "prompt-1",
+		Options: []agent.UserPromptOption{
+			{ID: "option-a", Label: "Option A"},
+		},
+	})
 
 	bot.handleInteractionCreate(context.Background(), &discordgo.InteractionCreate{
 		Interaction: &discordgo.Interaction{
@@ -276,8 +301,138 @@ func TestHandleInteractionCreate_AcksBeforeSubmittingAndEditsMessage(t *testing.
 	require.Len(t, client.editedMessages, 1)
 	assert.Equal(t, "C1", client.editedMessages[0].channelID)
 	assert.Equal(t, "message-1", client.editedMessages[0].messageID)
-	assert.Contains(t, client.editedMessages[0].content, "Selected: option-a")
+	assert.Equal(t, "Selection received: option-a", client.editedMessages[0].content)
 	assert.Equal(t, 0, client.editedMessages[0].componentsLen)
+	assert.Empty(t, cs.PendingPromptID())
+}
+
+func TestHandleInteractionCreate_RejectsStalePromptClick(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeDiscordClient{}
+	service := &fakeDiscordAgentService{}
+	bot := &Bot{
+		cfg:             Config{RespondToAll: false},
+		agentAPI:        service,
+		client:          client,
+		allowedChannels: map[string]struct{}{"C1": {}},
+		logger:          testDiscordLogger(),
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	cs.setPendingPrompt(&agent.UserPrompt{
+		PromptID: "prompt-2",
+		Options: []agent.UserPromptOption{
+			{ID: "option-a", Label: "Option A"},
+		},
+	})
+
+	bot.handleInteractionCreate(context.Background(), &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			ID:        "interaction-1",
+			Type:      discordgo.InteractionMessageComponent,
+			ChannelID: "C1",
+			Data: discordgo.MessageComponentInteractionData{
+				CustomID: "prompt:prompt-1:option-a",
+			},
+			Message: &discordgo.Message{
+				ID:      "message-1",
+				Content: "Choose an option",
+			},
+		},
+	})
+
+	require.Equal(t, []discordgo.InteractionResponseType{discordgo.InteractionResponseDeferredMessageUpdate}, client.interactionResponses)
+	assert.Empty(t, client.editedMessages)
+	assert.Equal(t, []string{"That prompt is no longer active."}, client.sentMessages)
+	service.mu.Lock()
+	assert.Empty(t, service.submitResponses)
+	service.mu.Unlock()
+	assert.Equal(t, "prompt-2", cs.PendingPromptID())
+}
+
+func TestSubmitPromptResponse_PreservesPendingPromptOnError(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeDiscordClient{}
+	service := &fakeDiscordAgentService{submitErr: assert.AnError}
+	bot := &Bot{
+		agentAPI: service,
+		client:   client,
+		logger:   testDiscordLogger(),
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	cs.setPendingPrompt(&agent.UserPrompt{PromptID: "prompt-1", AllowFreeText: true})
+
+	bot.submitPromptResponse(context.Background(), cs, "C1", "prompt-1", "free-form answer")
+
+	assert.Equal(t, "prompt-1", cs.PendingPromptID())
+	assert.Equal(t, []string{"Failed to submit response: assert.AnError general error for testing"}, client.sentMessages)
+}
+
+func TestHandleTextCommand_CancelResetsChatState(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeDiscordAgentService{}
+	bot := &Bot{
+		agentAPI: service,
+		client:   &fakeDiscordClient{},
+		logger:   testDiscordLogger(),
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	cs.setPendingPrompt(&agent.UserPrompt{PromptID: "prompt-1", AllowFreeText: true})
+
+	bot.handleTextCommand(context.Background(), cs, "C1", "cancel")
+
+	assert.Empty(t, cs.SessionID())
+	assert.Empty(t, cs.PendingPromptID())
+	service.mu.Lock()
+	assert.Equal(t, 1, service.cancelCalls)
+	service.mu.Unlock()
+}
+
+func TestSendPrompt_OverflowFallsBackToTextOptionIDs(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeDiscordClient{}
+	service := &fakeDiscordAgentService{}
+	bot := &Bot{
+		cfg:      Config{RespondToAll: true},
+		agentAPI: service,
+		client:   client,
+		logger:   testDiscordLogger(),
+	}
+
+	options := make([]agent.UserPromptOption, 0, maxDiscordPromptOptions+1)
+	for i := 1; i <= maxDiscordPromptOptions+1; i++ {
+		options = append(options, agent.UserPromptOption{
+			ID:    fmt.Sprintf("opt-%02d", i),
+			Label: fmt.Sprintf("Option %02d", i),
+		})
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	bot.sendPrompt(cs, "C1", &agent.UserPrompt{
+		PromptID: "prompt-1",
+		Question: "Choose an option",
+		Options:  options,
+	})
+	bot.submitPromptResponse(context.Background(), cs, "C1", "prompt-1", "opt-26")
+
+	assert.Empty(t, client.sentComplexMessages)
+	require.NotEmpty(t, client.sentMessages)
+	assert.Contains(t, client.sentMessages[0], "Reply with one of these option IDs:")
+	assert.Contains(t, client.sentMessages[0], "opt-26")
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	require.Len(t, service.submitResponses, 1)
+	assert.Equal(t, []string{"opt-26"}, service.submitResponses[0].SelectedOptionIDs)
 }
 
 func TestDAGRunMonitor_UsesDedicatedNotificationState(t *testing.T) {

--- a/internal/service/discord/bot_test.go
+++ b/internal/service/discord/bot_test.go
@@ -1,0 +1,328 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package discord
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDiscordClient struct {
+	mu                   sync.Mutex
+	sentMessages         []string
+	editedMessages       []editedDiscordMessage
+	interactionResponses []discordgo.InteractionResponseType
+}
+
+type editedDiscordMessage struct {
+	channelID     string
+	messageID     string
+	content       string
+	componentsLen int
+}
+
+func (c *fakeDiscordClient) ChannelMessageSend(_ string, content string, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sentMessages = append(c.sentMessages, content)
+	return &discordgo.Message{Content: content}, nil
+}
+
+func (c *fakeDiscordClient) ChannelMessageSendComplex(channelID string, data *discordgo.MessageSend, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	content := ""
+	if data != nil {
+		content = data.Content
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sentMessages = append(c.sentMessages, content)
+	return &discordgo.Message{ID: "sent", ChannelID: channelID, Content: content}, nil
+}
+
+func (c *fakeDiscordClient) ChannelMessageEditComplex(m *discordgo.MessageEdit, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	content := ""
+	if m.Content != nil {
+		content = *m.Content
+	}
+	componentsLen := -1
+	if m.Components != nil {
+		componentsLen = len(*m.Components)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.editedMessages = append(c.editedMessages, editedDiscordMessage{
+		channelID:     m.Channel,
+		messageID:     m.ID,
+		content:       content,
+		componentsLen: componentsLen,
+	})
+	return &discordgo.Message{ID: m.ID, ChannelID: m.Channel, Content: content}, nil
+}
+
+func (c *fakeDiscordClient) ChannelTyping(string, ...discordgo.RequestOption) error {
+	return nil
+}
+
+func (c *fakeDiscordClient) InteractionRespond(_ *discordgo.Interaction, resp *discordgo.InteractionResponse, _ ...discordgo.RequestOption) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.interactionResponses = append(c.interactionResponses, resp.Type)
+	return nil
+}
+
+func (c *fakeDiscordClient) interactionResponseCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.interactionResponses)
+}
+
+type fakeDiscordAgentService struct {
+	mu               sync.Mutex
+	nextSessionID    int
+	nextSequenceID   int64
+	createEmptyCalls int
+	appendSessionIDs []string
+	submitResponses  []agent.UserPromptResponse
+	onSubmit         func()
+}
+
+func (s *fakeDiscordAgentService) CreateSession(_ context.Context, _ agent.UserIdentity, _ agent.ChatRequest) (string, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSessionID++
+	return fmt.Sprintf("created-%d", s.nextSessionID), "", nil
+}
+
+func (s *fakeDiscordAgentService) CreateEmptySession(_ context.Context, _ agent.UserIdentity, _ string, _ bool) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSessionID++
+	s.createEmptyCalls++
+	return fmt.Sprintf("notify-%d", s.nextSessionID), nil
+}
+
+func (s *fakeDiscordAgentService) SendMessage(context.Context, string, agent.UserIdentity, agent.ChatRequest) error {
+	return nil
+}
+
+func (s *fakeDiscordAgentService) EnqueueChatMessage(_ context.Context, sessionID string, _ agent.UserIdentity, _ agent.ChatRequest) (agent.ChatQueueResult, error) {
+	return agent.ChatQueueResult{SessionID: sessionID, Started: true}, nil
+}
+
+func (s *fakeDiscordAgentService) FlushQueuedChatMessage(_ context.Context, sessionID string, _ agent.UserIdentity) (agent.ChatQueueResult, error) {
+	return agent.ChatQueueResult{SessionID: sessionID, Started: true}, nil
+}
+
+func (s *fakeDiscordAgentService) CancelSession(context.Context, string, string) error {
+	return nil
+}
+
+func (s *fakeDiscordAgentService) SubmitUserResponse(_ context.Context, _ string, _ string, resp agent.UserPromptResponse) error {
+	if s.onSubmit != nil {
+		s.onSubmit()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.submitResponses = append(s.submitResponses, resp)
+	return nil
+}
+
+func (s *fakeDiscordAgentService) GenerateAssistantMessage(context.Context, string, agent.UserIdentity, string, string) (agent.Message, error) {
+	return agent.Message{
+		Type:      agent.MessageTypeAssistant,
+		Content:   "notification",
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+func (s *fakeDiscordAgentService) AppendExternalMessage(_ context.Context, sessionID string, _ agent.UserIdentity, msg agent.Message) (agent.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msg.SessionID = sessionID
+	msg.SequenceID = s.nextSequenceID
+	s.nextSequenceID++
+	s.appendSessionIDs = append(s.appendSessionIDs, sessionID)
+	return msg, nil
+}
+
+func (s *fakeDiscordAgentService) CompactSessionIfNeeded(_ context.Context, sessionID string, _ agent.UserIdentity) (string, bool, error) {
+	return sessionID, false, nil
+}
+
+func (s *fakeDiscordAgentService) GetSessionDetail(context.Context, string, string) (*agent.StreamResponse, error) {
+	return &agent.StreamResponse{}, nil
+}
+
+func (s *fakeDiscordAgentService) SubscribeSession(context.Context, string, agent.UserIdentity) (agent.StreamResponse, func() (agent.StreamResponse, bool), error) {
+	return agent.StreamResponse{}, func() (agent.StreamResponse, bool) { return agent.StreamResponse{}, false }, nil
+}
+
+func testDiscordLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestHandleMessageCreate_StillRequiresMentionWithoutPendingPrompt(t *testing.T) {
+	t.Parallel()
+
+	bot := &Bot{
+		cfg:             Config{RespondToAll: false},
+		agentAPI:        &fakeDiscordAgentService{},
+		client:          &fakeDiscordClient{},
+		selfID:          "bot-1",
+		allowedChannels: map[string]struct{}{"C1": {}},
+		logger:          testDiscordLogger(),
+	}
+
+	bot.handleMessageCreate(context.Background(), &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			Author:    &discordgo.User{ID: "user-1"},
+			ChannelID: "C1",
+			GuildID:   "G1",
+			Content:   "hello",
+		},
+	})
+
+	_, exists := bot.chats.Load("C1")
+	assert.False(t, exists)
+}
+
+func TestHandleMessageCreate_AllowsPendingPromptReplyWithoutMention(t *testing.T) {
+	t.Parallel()
+
+	service := &fakeDiscordAgentService{}
+	bot := &Bot{
+		cfg:             Config{RespondToAll: false},
+		agentAPI:        service,
+		client:          &fakeDiscordClient{},
+		selfID:          "bot-1",
+		allowedChannels: map[string]struct{}{"C1": {}},
+		logger:          testDiscordLogger(),
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	cs.SetPendingPrompt("prompt-1")
+
+	bot.handleMessageCreate(context.Background(), &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			Author:    &discordgo.User{ID: "user-1"},
+			ChannelID: "C1",
+			GuildID:   "G1",
+			Content:   "free-form answer",
+		},
+	})
+
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	require.Len(t, service.submitResponses, 1)
+	assert.Equal(t, "prompt-1", service.submitResponses[0].PromptID)
+	assert.Equal(t, "free-form answer", service.submitResponses[0].FreeTextResponse)
+}
+
+func TestHandleInteractionCreate_AcksBeforeSubmittingAndEditsMessage(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeDiscordClient{}
+	service := &fakeDiscordAgentService{}
+	seenResponses := 0
+	service.onSubmit = func() {
+		seenResponses = client.interactionResponseCount()
+	}
+
+	bot := &Bot{
+		cfg:             Config{RespondToAll: false},
+		agentAPI:        service,
+		client:          client,
+		allowedChannels: map[string]struct{}{"C1": {}},
+		logger:          testDiscordLogger(),
+	}
+
+	cs := bot.getOrCreateChat("C1")
+	bot.setActiveSession(cs, "session-1", "discord:C1")
+	cs.SetPendingPrompt("prompt-1")
+
+	bot.handleInteractionCreate(context.Background(), &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			ID:        "interaction-1",
+			Type:      discordgo.InteractionMessageComponent,
+			ChannelID: "C1",
+			Data: discordgo.MessageComponentInteractionData{
+				CustomID: "prompt:prompt-1:option-a",
+			},
+			Message: &discordgo.Message{
+				ID:      "message-1",
+				Content: "Choose an option",
+			},
+		},
+	})
+
+	assert.Equal(t, 1, seenResponses, "interaction should be acknowledged before the agent call")
+	require.Equal(t, []discordgo.InteractionResponseType{discordgo.InteractionResponseDeferredMessageUpdate}, client.interactionResponses)
+	require.Len(t, client.editedMessages, 1)
+	assert.Equal(t, "C1", client.editedMessages[0].channelID)
+	assert.Equal(t, "message-1", client.editedMessages[0].messageID)
+	assert.Contains(t, client.editedMessages[0].content, "Selected: option-a")
+	assert.Equal(t, 0, client.editedMessages[0].componentsLen)
+}
+
+func TestDAGRunMonitor_UsesDedicatedNotificationState(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeDiscordClient{}
+	service := &fakeDiscordAgentService{nextSequenceID: 1}
+	bot := &Bot{
+		cfg:             Config{SafeMode: true},
+		agentAPI:        service,
+		client:          client,
+		allowedChannels: map[string]struct{}{"C1": {}},
+		logger:          testDiscordLogger(),
+	}
+
+	liveChat := bot.getOrCreateChat("C1")
+	bot.setActiveSession(liveChat, "live-session", "discord:C1")
+
+	monitor := &DAGRunMonitor{
+		agentAPI: service,
+		bot:      bot,
+		logger:   testDiscordLogger(),
+	}
+
+	ok := monitor.flushChannel(context.Background(), "C1", chatbridge.NotificationBatch{
+		Class: chatbridge.NotificationClassSuccessDigest,
+		Events: []chatbridge.NotificationEvent{
+			{
+				Status: &exec.DAGRunStatus{
+					Name:   "build",
+					Status: core.Succeeded,
+				},
+			},
+		},
+	}, false)
+	require.True(t, ok)
+
+	service.mu.Lock()
+	require.Len(t, service.appendSessionIDs, 1)
+	assert.Equal(t, 1, service.createEmptyCalls)
+	assert.NotEqual(t, "live-session", service.appendSessionIDs[0])
+	notificationSessionID := service.appendSessionIDs[0]
+	service.mu.Unlock()
+
+	assert.Equal(t, "live-session", liveChat.SessionID())
+	assert.Equal(t, notificationSessionID, bot.getOrCreateNotificationChat("C1").SessionID())
+	assert.Len(t, client.sentMessages, 1)
+}

--- a/internal/service/discord/monitor.go
+++ b/internal/service/discord/monitor.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package discord
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+)
+
+// DAGRunMonitor watches for DAG run completions and sends notifications via Discord.
+type DAGRunMonitor struct {
+	core     *chatbridge.NotificationMonitor
+	agentAPI AgentService
+	bot      *Bot
+	logger   *slog.Logger
+}
+
+// NewDAGRunMonitor creates a new monitor instance.
+func NewDAGRunMonitor(eventService *eventstore.Service, stateFile string, agentAPI AgentService, bot *Bot, logger *slog.Logger) *DAGRunMonitor {
+	return newDAGRunMonitorWithWindows(
+		eventService,
+		stateFile,
+		agentAPI,
+		bot,
+		logger,
+		chatbridge.DefaultUrgentNotificationWindow,
+		chatbridge.DefaultSuccessNotificationWindow,
+	)
+}
+
+func newDAGRunMonitorWithWindows(
+	eventService *eventstore.Service,
+	stateFile string,
+	agentAPI AgentService,
+	bot *Bot,
+	logger *slog.Logger,
+	urgentWindow, successWindow time.Duration,
+) *DAGRunMonitor {
+	monitor := &DAGRunMonitor{
+		agentAPI: agentAPI,
+		bot:      bot,
+		logger:   logger,
+	}
+	cfg := chatbridge.DefaultNotificationMonitorConfig()
+	cfg.UrgentWindow = urgentWindow
+	cfg.SuccessWindow = successWindow
+	cfg.InterestedEventTypes = discordInterestedEventTypes(bot.cfg.InterestedEventTypes)
+	monitor.core = chatbridge.NewNotificationMonitor(eventService, stateFile, monitor, logger, cfg)
+	return monitor
+}
+
+func discordInterestedEventTypes(values []string) []eventstore.EventType {
+	if values == nil {
+		return nil
+	}
+	result := make([]eventstore.EventType, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		result = append(result, eventstore.EventType(value))
+	}
+	return result
+}
+
+// Run starts the monitor loop.
+func (m *DAGRunMonitor) Run(ctx context.Context) {
+	m.core.Run(ctx)
+}
+
+// NotificationDestinations returns the configured Discord channel IDs.
+func (m *DAGRunMonitor) NotificationDestinations() []string {
+	destinations := make([]string, 0, len(m.bot.allowedChannels))
+	for channelID := range m.bot.allowedChannels {
+		destinations = append(destinations, channelID)
+	}
+	return destinations
+}
+
+// FlushNotificationBatch delivers a single notification batch to Discord.
+func (m *DAGRunMonitor) FlushNotificationBatch(ctx context.Context, channelID string, batch chatbridge.NotificationBatch, allowLLM bool) bool {
+	return m.flushChannel(ctx, channelID, batch, allowLLM)
+}
+
+// flushChannel appends the notification batch into the channel-scoped session.
+func (m *DAGRunMonitor) flushChannel(ctx context.Context, channelID string, batch chatbridge.NotificationBatch, allowLLM bool) bool {
+	user := m.bot.userIdentity(channelID)
+	cs := m.bot.getOrCreateChat(channelID)
+	sessionID := m.currentSessionID(cs)
+	msg := m.buildNotificationMessage(ctx, sessionID, user, batch, allowLLM)
+	sessionID, stored, ok := m.appendNotification(ctx, cs, sessionID, user, chatbridge.NotificationBatchDAGName(batch), msg)
+	if !ok {
+		return false
+	}
+	if m.bot.subscriptionActive(cs, sessionID) {
+		return true
+	}
+
+	m.bot.sendLongText(channelID, msg.Content)
+	m.bot.markDelivered(cs, stored.SequenceID)
+	return true
+}
+
+func (m *DAGRunMonitor) currentSessionID(cs *chatState) string {
+	return cs.SessionID()
+}
+
+func (m *DAGRunMonitor) appendNotification(ctx context.Context, cs *chatState, sessionID string, user agent.UserIdentity, dagName string, msg agent.Message) (string, agent.Message, bool) {
+	newSessionID, stored, err := chatbridge.AppendNotification(ctx, m.agentAPI, &cs.State, user, dagName, m.bot.cfg.SafeMode, msg)
+	if err != nil {
+		m.logger.Warn("Failed to append notification message",
+			slog.String("session", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return "", agent.Message{}, false
+	}
+	return newSessionID, stored, true
+}
+
+func (m *DAGRunMonitor) buildNotificationMessage(ctx context.Context, sessionID string, user agent.UserIdentity, batch chatbridge.NotificationBatch, allowLLM bool) agent.Message {
+	service := m.agentAPI
+	if !allowLLM {
+		service = nil
+	}
+
+	msg, err := chatbridge.GenerateNotificationMessage(ctx, service, sessionID, user, batch)
+	if err != nil && len(batch.Events) > 0 && batch.Events[0].Status != nil {
+		m.logger.Warn("Failed to generate AI notification, using deterministic fallback",
+			slog.String("dag", batch.Events[0].Status.Name),
+			slog.String("status", batch.Events[0].Status.Status.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+	return msg
+}

--- a/internal/service/discord/monitor.go
+++ b/internal/service/discord/monitor.go
@@ -91,7 +91,7 @@ func (m *DAGRunMonitor) FlushNotificationBatch(ctx context.Context, channelID st
 // flushChannel appends the notification batch into the channel-scoped session.
 func (m *DAGRunMonitor) flushChannel(ctx context.Context, channelID string, batch chatbridge.NotificationBatch, allowLLM bool) bool {
 	user := m.bot.userIdentity(channelID)
-	cs := m.bot.getOrCreateChat(channelID)
+	cs := m.bot.getOrCreateNotificationChat(channelID)
 	sessionID := m.currentSessionID(cs)
 	msg := m.buildNotificationMessage(ctx, sessionID, user, batch, allowLLM)
 	sessionID, stored, ok := m.appendNotification(ctx, cs, sessionID, user, chatbridge.NotificationBatchDAGName(batch), msg)


### PR DESCRIPTION
## Summary

- Add Discord as a third Workflow Operator platform alongside Telegram and Slack, following the existing `chatbridge` pattern.
- Connects over Discord's gateway (WebSocket) via `bwmarrin/discordgo`, mapping each allowed channel (and DMs) to a persistent agent session.
- Renders agent `UserPrompt` options as Discord buttons (`ActionsRow` + `Button` with `custom_id: prompt:<promptID>:<optionID>`) and updates the message in-place on click.
- New config block `bots.discord` (token, allowed_channel_ids, respond_to_all, interested_event_types) with matching `DAGU_BOTS_DISCORD_*` env vars.
- Wires the bot into both `dagu server` and `dagu start-all` via the same agent-API callback path Telegram/Slack use, with per-provider notification state at `$DATA_DIR/bots/discord/notifications.json`.
- Reuses `chatbridge.NotificationMonitor` for DAG run notifications (succeeded / failed / aborted / rejected / waiting).

### Example config

```yaml
bots:
  provider: discord
  safe_mode: true
  discord:
    token: "your-discord-bot-token"
    allowed_channel_ids:
      - "1234567890123456789"
    respond_to_all: true
```

Docs for setup (app creation, MESSAGE CONTENT intent, invite URL, channel ID discovery) live in the separate docs repo.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (only pre-existing unrelated warning in `internal/core/dag.go`)
- [x] `go test ./internal/cmn/config/...` — updated `TestLoad_YAML` / `TestLoad_Env` fixtures for the new `Discord` field
- [x] `go test ./internal/service/discord/... ./internal/service/slack/... ./internal/service/telegram/... ./internal/service/chatbridge/...`
- [x] `go test ./internal/cmd/...`
- [ ] Manual smoke test against a real Discord app (token + allowed channel) — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord bot integration enabling users to interact with agents through Discord channels and direct messages.
  * Discord bot supports text commands (`new`, `cancel`), interactive prompts via button responses, and message notifications for DAG run completion events.
  * Configurable Discord bot settings including allowed channels, interested event types, and response modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->