### PR TITLE
fix: correct queue counts for distributed runs

### DIFF
--- a/internal/service/frontend/api/v1/queues.go
+++ b/internal/service/frontend/api/v1/queues.go
@@ -267,7 +267,7 @@ func (a *API) collectQueues(ctx context.Context, onlyQueue string) (map[string]*
 		}
 		if count > 0 {
 			queue := getOrCreateQueue(queueMap, onlyQueue, a.config)
-			queue.queuedCount = max(count-len(queue.running), 0)
+			queue.queuedCount = count
 		}
 	} else {
 		queueNames, err := a.queueStore.QueueList(ctx)
@@ -287,7 +287,7 @@ func (a *API) collectQueues(ctx context.Context, onlyQueue string) (map[string]*
 				continue
 			}
 			queue := getOrCreateQueue(queueMap, queueName, a.config)
-			queue.queuedCount = max(count-len(queue.running), 0)
+			queue.queuedCount = count
 		}
 	}
 

--- a/internal/service/frontend/api/v1/queues_internal_test.go
+++ b/internal/service/frontend/api/v1/queues_internal_test.go
@@ -83,6 +83,39 @@ func TestGetQueueFallsBackToDAGNameWhenLeaseQueueIsEmpty(t *testing.T) {
 	assert.Equal(t, "fresh-run", queueResp.Running[0].DagRunId)
 }
 
+func TestGetQueueCountsQueuedItemsSeparatelyFromRunningItems(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dagRunStore := filedagrun.New(filepath.Join(tmpDir, "dag-runs"))
+	leaseStore := filedistributed.NewDAGRunLeaseStore(filepath.Join(tmpDir, "distributed"))
+	queueStore := filequeue.New(filepath.Join(tmpDir, "queue"))
+	procStore := fileproc.New(filepath.Join(tmpDir, "proc"))
+
+	createDistributedQueueRun(t, ctx, dagRunStore, leaseStore, "mixed-q", "running-run", "mixed-q", time.Now().Add(-time.Second))
+	createQueuedQueueRun(t, ctx, dagRunStore, queueStore, "mixed-q", "queued-run", core.Queued)
+
+	a := &API{
+		dagRunStore:         dagRunStore,
+		dagRunLeaseStore:    leaseStore,
+		queueStore:          queueStore,
+		procStore:           procStore,
+		config:              &config.Config{},
+		leaseStaleThreshold: 5 * time.Second,
+	}
+
+	resp, err := a.GetQueue(ctx, openapiv1.GetQueueRequestObject{
+		Name: "mixed-q",
+	})
+	require.NoError(t, err)
+
+	queueResp, ok := resp.(openapiv1.GetQueue200JSONResponse)
+	require.True(t, ok)
+	assert.Equal(t, 1, queueResp.RunningCount)
+	assert.Equal(t, 1, queueResp.QueuedCount)
+}
+
 func TestListQueueItemsUsesCursorPaginationAndSkipsRunningEntries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- stop subtracting running distributed DAG runs from `queueStore.Len()`, which already reports only queued items
- add regression coverage for a queue that has both one distributed running run and one queued run
- keep the queue API aligned with the queue details UI so mixed running/queued states report the correct counts

## Test plan
- [x] `go test ./internal/service/frontend/api/v1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed queue status reporting to accurately count running and queued items separately, ensuring metrics properly reflect the distribution of items across different queue states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->