### PR TITLE
fix: route local dag-run stop correctly

### DIFF
--- a/internal/intg/dagruns_stop_api_test.go
+++ b/internal/intg/dagruns_stop_api_test.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	api "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPITerminateLocalRun_DoesNotRequireCoordinator(t *testing.T) {
+	server := test.SetupServer(t)
+
+	const dagName = "intg_local_stop_regression"
+	spec := `steps:
+  - name: hold
+    command: sleep 30
+`
+
+	server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &spec,
+	}).ExpectStatus(http.StatusCreated).Send(t)
+
+	startResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dags/%s/start", dagName),
+		api.ExecuteDAGJSONRequestBody{},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+
+	waitForAPIRunStatus(t, server, dagName, startBody.DagRunId, []core.Status{core.Running}, 10*time.Second)
+
+	server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/stop", dagName, startBody.DagRunId),
+		nil,
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	waitForAPIRunStatus(t, server, dagName, startBody.DagRunId, []core.Status{core.Aborted, core.Failed}, 15*time.Second)
+}
+
+func waitForAPIRunStatus(
+	t *testing.T,
+	server test.Server,
+	dagName, runID string,
+	expected []core.Status,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		resp := server.Client().Get(
+			fmt.Sprintf("/api/v1/dag-runs/%s/%s", dagName, runID),
+		).ExpectStatus(http.StatusOK).Send(t)
+
+		var body api.GetDAGRunDetails200JSONResponse
+		resp.Unmarshal(t, &body)
+		for _, status := range expected {
+			if body.DagRunDetails.Status == api.Status(status) {
+				return true
+			}
+		}
+		return false
+	}, timeout, 200*time.Millisecond, "run %s should reach one of %v", runID, expected)
+}

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -2204,8 +2204,12 @@ func (a *API) TerminateDAGRun(ctx context.Context, request api.TerminateDAGRunRe
 		}
 		terminateMode = "failed_auto_retry_cancel"
 	} else {
-		// Check if it's a distributed DAG (has WorkerID)
-		if savedStatus.WorkerID != "" {
+		dag, err := attempt.ReadDAG(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error reading DAG: %w", err)
+		}
+
+		if core.ShouldDispatchToCoordinator(dag, a.coordinatorCli != nil, a.defaultExecMode) {
 			// For distributed DAGs, use saved status for running check
 			if savedStatus.Status != core.Running {
 				return nil, &Error{
@@ -2227,10 +2231,6 @@ func (a *API) TerminateDAGRun(ctx context.Context, request api.TerminateDAGRunRe
 			}
 		} else {
 			// For local DAGs, use existing logic with GetCurrentStatus and socket
-			dag, err := attempt.ReadDAG(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("error reading DAG: %w", err)
-			}
 			dagStatus, err := a.dagRunMgr.GetCurrentStatus(ctx, dag, request.DagRunId)
 			if err != nil {
 				return nil, &Error{


### PR DESCRIPTION
## Summary
- determine whether a DAG run should stop locally or through the coordinator from the DAG definition and execution mode
- keep coordinator cancellation for distributed DAGs and route local stop requests through the local DAG run manager

## Why
A local DAG run could still have a non-empty `WorkerID` in its saved status. The stop endpoint used that field as the distributed/local switch, which made local stop requests attempt coordinator cancellation and fail with `500 error requesting cancel: no coordinators available`.

## Test plan
- [x] `go test ./internal/service/frontend/api/v1 -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved DAG run termination handling to correctly identify and route cancellation requests based on execution environment, ensuring proper termination behavior in both distributed and local deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->