### PR TITLE
feat(ui): add inherited custom step editor hints

### DIFF
--- a/internal/core/spec/editor_hints.go
+++ b/internal/core/spec/editor_hints.go
@@ -53,14 +53,26 @@ func InheritedCustomStepTypeEditorHints(baseConfig []byte) ([]CustomStepTypeEdit
 	hints := make([]CustomStepTypeEditorHint, 0, len(names))
 	for _, name := range names {
 		entry := registry.entries[name]
-		hint, ok, err := editorHintForCustomStepType(entry)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
+		if entry == nil || entry.InputSchema == nil || entry.InputSchema.Schema() == nil {
 			continue
 		}
-		hints = append(hints, hint)
+
+		schemaData, err := json.Marshal(entry.InputSchema.Schema())
+		if err != nil {
+			return nil, fmt.Errorf("marshal input schema for %q: %w", entry.Name, err)
+		}
+
+		var schemaMap map[string]any
+		if err := json.Unmarshal(schemaData, &schemaMap); err != nil {
+			return nil, fmt.Errorf("unmarshal input schema for %q: %w", entry.Name, err)
+		}
+
+		hints = append(hints, CustomStepTypeEditorHint{
+			Name:        entry.Name,
+			TargetType:  entry.Type,
+			Description: entry.Description,
+			InputSchema: schemaMap,
+		})
 	}
 
 	return hints, nil

--- a/internal/core/spec/editor_hints.go
+++ b/internal/core/spec/editor_hints.go
@@ -53,26 +53,14 @@ func InheritedCustomStepTypeEditorHints(baseConfig []byte) ([]CustomStepTypeEdit
 	hints := make([]CustomStepTypeEditorHint, 0, len(names))
 	for _, name := range names {
 		entry := registry.entries[name]
-		if entry == nil || entry.InputSchema == nil || entry.InputSchema.Schema() == nil {
+		hint, ok, err := editorHintForCustomStepType(entry)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
 			continue
 		}
-
-		schemaData, err := json.Marshal(entry.InputSchema.Schema())
-		if err != nil {
-			return nil, fmt.Errorf("marshal input schema for %q: %w", entry.Name, err)
-		}
-
-		var schemaMap map[string]any
-		if err := json.Unmarshal(schemaData, &schemaMap); err != nil {
-			return nil, fmt.Errorf("unmarshal input schema for %q: %w", entry.Name, err)
-		}
-
-		hints = append(hints, CustomStepTypeEditorHint{
-			Name:        entry.Name,
-			TargetType:  entry.Type,
-			Description: entry.Description,
-			InputSchema: schemaMap,
-		})
+		hints = append(hints, hint)
 	}
 
 	return hints, nil

--- a/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Maximize2, X } from 'lucide-react';
@@ -239,6 +242,7 @@ function DAGDetailsPanel({
                 isModal={true}
                 navigateToStatusTab={() => setActiveTab('status')}
                 localDags={data.localDags}
+                editorHints={data.editorHints}
               />
             </div>
           </div>

--- a/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';

--- a/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
@@ -386,6 +386,7 @@ function DAGDetailsSidePanel({
                     isModal={true}
                     navigateToStatusTab={navigateToStatusTab}
                     localDags={data.localDags}
+                    editorHints={data.editorHints}
                     onEnqueue={onEnqueue ? handleEnqueue : undefined}
                     forceEnqueue={forceEnqueue}
                     autoOpenStartModal={false}

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { PageContextProvider } from '@/contexts/PageContext';
+import { useQuery } from '@/hooks/api';
+import { useDAGSSE } from '@/hooks/useDAGSSE';
+import DAGDetailsPanel from '../DAGDetailsPanel';
+
+vi.mock('@/hooks/api', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDAGSSE', () => ({
+  useDAGSSE: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSSECacheSync', () => ({
+  sseFallbackOptions: vi.fn(() => ({})),
+  useSSECacheSync: vi.fn(),
+}));
+
+vi.mock('../DAGDetailsContent', () => ({
+  default: ({
+    dag,
+    activeTab,
+    editorHints,
+  }: {
+    dag: { name: string };
+    activeTab: string;
+    editorHints?: { inheritedCustomStepTypes?: unknown[] };
+  }) => (
+    <div>
+      <div>
+        Previewing {dag.name} [{activeTab}]
+      </div>
+      <div>Inherited hints: {editorHints?.inheritedCustomStepTypes?.length ?? 0}</div>
+    </div>
+  ),
+}));
+
+const appBarValue = {
+  title: 'DAGs',
+  setTitle: vi.fn(),
+  remoteNodes: ['local'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'local',
+  selectRemoteNode: vi.fn(),
+};
+
+const liveState = {
+  data: null,
+  error: null,
+  isConnected: false,
+  isConnecting: false,
+  shouldUseFallback: true,
+};
+
+const useQueryMock = useQuery as unknown as {
+  mockImplementation: (fn: (path: string, init?: unknown) => unknown) => void;
+};
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <PageContextProvider>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGDetailsPanel
+            fileName="example"
+            onClose={vi.fn()}
+          />
+        </AppBarContext.Provider>
+      </PageContextProvider>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DAGDetailsPanel', () => {
+  it('passes editor hints through to the dag list detail panel spec flow', () => {
+    vi.mocked(useDAGSSE).mockReturnValue(liveState);
+    useQueryMock.mockImplementation((path) => {
+      if (path === '/dags/{fileName}') {
+        return {
+          data: {
+            dag: { name: 'example-dag' },
+            filePath: '/tmp/example.yaml',
+            latestDAGRun: undefined,
+            localDags: [],
+            editorHints: {
+              inheritedCustomStepTypes: [{ name: 'greet' }],
+            },
+          },
+          error: undefined,
+          mutate: vi.fn(),
+        } as never;
+      }
+
+      return {
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+      } as never;
+    });
+
+    renderPanel();
+
+    expect(screen.getByText('Previewing example-dag [status]')).toBeInTheDocument();
+    expect(screen.getByText('Inherited hints: 1')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsSidePanel.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsSidePanel.test.tsx
@@ -33,12 +33,14 @@ vi.mock('../DAGDetailsContent', () => ({
     dag,
     activeTab,
     dagRunId,
+    editorHints,
     forceEnqueue,
     onEnqueue,
   }: {
     dag: { name: string };
     activeTab: string;
     dagRunId?: string;
+    editorHints?: { inheritedCustomStepTypes?: unknown[] };
     forceEnqueue?: boolean;
     onEnqueue?: (
       params: string,
@@ -51,6 +53,7 @@ vi.mock('../DAGDetailsContent', () => ({
         Previewing {dag.name} [{activeTab}]{' '}
         {forceEnqueue ? 'forced' : 'default'} {dagRunId || 'latest'}
       </div>
+      <div>Inherited hints: {editorHints?.inheritedCustomStepTypes?.length ?? 0}</div>
       {onEnqueue ? (
         <button
           type="button"
@@ -228,6 +231,36 @@ describe('DAGDetailsSidePanel', () => {
     expect(
       screen.getByText('Previewing example-dag [history] forced latest')
     ).toBeInTheDocument();
+  });
+
+  it('passes editor hints through to the modal DAG spec flow', () => {
+    vi.mocked(useDAGSSE).mockReturnValue(liveState);
+    vi.mocked(useDAGRunSSE).mockReturnValue(liveState);
+    useQueryMock.mockImplementation((path) => {
+      if (path === '/dags/{fileName}') {
+        return {
+          data: {
+            dag: { name: 'example-dag' },
+            filePath: '/tmp/example.yaml',
+            latestDAGRun: undefined,
+            localDags: [],
+            editorHints: {
+              inheritedCustomStepTypes: [{ name: 'greet' }],
+            },
+          },
+          error: undefined,
+          mutate: vi.fn(),
+        } as never;
+      }
+
+      return {
+        data: undefined,
+      } as never;
+    });
+
+    renderPanel();
+
+    expect(screen.getByText('Inherited hints: 1')).toBeInTheDocument();
   });
 
   it('tracks the returned dag run, switches to status, and revalidates after enqueue', async () => {

--- a/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
@@ -3,6 +3,7 @@
  *
  * @module features/dags/components/dag-editor
  */
+import type { JSONSchema } from '@/lib/schema-utils';
 import { cn } from '@/lib/utils';
 import MonacoEditor, { loader } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor';
@@ -11,7 +12,6 @@ import {
   type JSONSchema as MonacoJSONSchema,
 } from 'monaco-yaml';
 import { useEffect, useRef } from 'react';
-import type { JSONSchema } from '@/lib/schema-utils';
 
 // Get schema URL from config (getConfig() is available at module load time)
 declare function getConfig(): { basePath: string };

--- a/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
@@ -181,10 +181,13 @@ function DAGEditor({
       editor.addAction({
         id: 'dagu.triggerSuggest',
         label: 'Trigger Autocomplete',
+        precondition:
+          '!editorReadonly && editorHasCompletionItemProvider && !suggestWidgetVisible',
         keybindings: [
           monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
           monaco.KeyMod.WinCtrl | monaco.KeyCode.Space,
         ],
+        keybindingContext: 'textInputFocus',
         run: async (activeEditor) => {
           await activeEditor.getAction('editor.action.triggerSuggest')?.run();
         },

--- a/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
@@ -177,6 +177,20 @@ function DAGEditor({
   const editorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
     editorRef.current = editor;
 
+    if (!readOnly) {
+      editor.addAction({
+        id: 'dagu.triggerSuggest',
+        label: 'Trigger Autocomplete',
+        keybindings: [
+          monaco.KeyMod.CtrlCmd | monaco.KeyCode.Space,
+          monaco.KeyMod.WinCtrl | monaco.KeyCode.Space,
+        ],
+        run: async (activeEditor) => {
+          await activeEditor.getAction('editor.action.triggerSuggest')?.run();
+        },
+      });
+    }
+
     // Format document after a short delay
     setTimeout(() => {
       editor.getAction('editor.action.formatDocument')?.run();
@@ -236,6 +250,7 @@ function DAGEditor({
           quickSuggestions: readOnly
             ? false
             : { other: true, comments: false, strings: true },
+          suggestOnTriggerCharacters: !readOnly,
           formatOnType: !readOnly,
           formatOnPaste: !readOnly,
           renderValidationDecorations: readOnly ? 'off' : 'on',

--- a/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /**
  * DAGEditor component provides a Monaco editor for editing DAG YAML definitions.
  *

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -27,7 +27,6 @@ import LoadingIndicator from '../../../../ui/LoadingIndicator';
 import { DAGContext } from '../../contexts/DAGContext';
 import { DAGStepTable } from '../dag-details';
 import { FlowchartType, Graph } from '../visualization';
-import DAGAttributes from './DAGAttributes';
 import {
   buildAugmentedDAGSchema,
   customStepTypeHintsEqual,
@@ -35,6 +34,7 @@ import {
   mergeCustomStepTypeHints,
   toInheritedCustomStepTypeHints,
 } from './customStepSchema';
+import DAGAttributes from './DAGAttributes';
 import DAGEditorWithDocs from './DAGEditorWithDocs';
 import ExternalChangeDialog from './ExternalChangeDialog';
 

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /**
  * DAGSpec component displays and allows editing of a DAG specification.
  *

--- a/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
+++ b/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
@@ -113,6 +113,72 @@ const baseSchemaWithExecutorObject: JSONSchema = {
 
 const dereferencedBaseSchema = dereferenceSchema(baseSchema);
 
+const baseSchemaWithConditionalRules = dereferenceSchema({
+  type: 'object',
+  properties: {
+    steps: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/step',
+      },
+    },
+  },
+  definitions: {
+    executorType: {
+      anyOf: [
+        {
+          type: 'string',
+          enum: ['command', 'http'],
+        },
+        {
+          type: 'string',
+          pattern: '^[A-Za-z][A-Za-z0-9_-]*$',
+        },
+      ],
+    },
+    httpConfig: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+        },
+      },
+    },
+    step: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        type: {
+          $ref: '#/definitions/executorType',
+        },
+        config: {
+          type: 'object',
+        },
+      },
+      allOf: [
+        {
+          if: {
+            properties: {
+              type: {
+                const: 'http',
+              },
+            },
+          },
+          then: {
+            properties: {
+              config: {
+                $ref: '#/definitions/httpConfig',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+});
+
 describe('customStepSchema', () => {
   it('extracts local custom step types from YAML', () => {
     const result = extractLocalCustomStepTypeHints(`
@@ -372,6 +438,48 @@ steps:
 
     expect(nestedTypeSchema).toEqual({ type: 'string' });
     expect(nestedConfigSchema).toEqual({ type: 'string' });
+  });
+
+  it('marks conditional step properties as non-suggestable to avoid duplicate completions', () => {
+    const schema = buildAugmentedDAGSchema(baseSchemaWithConditionalRules, [
+      {
+        name: 'greet',
+        targetType: 'command',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            message: { type: 'string' },
+          },
+        },
+      },
+    ]);
+
+    const stepSchema = getSchemaAtPath(schema, ['steps', '0']) as JSONSchema;
+    expect(Array.isArray(stepSchema.allOf)).toBe(true);
+
+    const httpRule = stepSchema.allOf?.find(
+      (rule) =>
+        (rule.if as JSONSchema | undefined)?.properties?.type?.const === 'http'
+    ) as JSONSchema | undefined;
+    const greetRule = stepSchema.allOf?.find(
+      (rule) =>
+        (rule.if as JSONSchema | undefined)?.properties?.type?.const === 'greet'
+    ) as JSONSchema | undefined;
+
+    expect(httpRule?.if?.properties?.type).toMatchObject({
+      const: 'http',
+      doNotSuggest: true,
+    });
+    expect(httpRule?.then?.properties?.config).toMatchObject({
+      doNotSuggest: true,
+    });
+    expect(greetRule?.if?.properties?.type).toMatchObject({
+      const: 'greet',
+      doNotSuggest: true,
+    });
+    expect(greetRule?.then?.properties?.config).toMatchObject({
+      doNotSuggest: true,
+    });
   });
 
   it('handles recursive internal refs without infinite recursion', () => {

--- a/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
+++ b/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
@@ -40,11 +40,70 @@ const baseSchema: JSONSchema = {
     step: {
       type: 'object',
       properties: {
+        name: {
+          type: 'string',
+        },
         type: {
           $ref: '#/definitions/executorType',
         },
         config: {
           type: 'object',
+        },
+      },
+      allOf: [],
+    },
+  },
+};
+
+const baseSchemaWithExecutorObject: JSONSchema = {
+  type: 'object',
+  properties: {
+    steps: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/step',
+      },
+    },
+  },
+  definitions: {
+    executorType: {
+      anyOf: [
+        {
+          type: 'string',
+          enum: ['command'],
+        },
+        {
+          type: 'string',
+          pattern: '^[A-Za-z][A-Za-z0-9_-]*$',
+        },
+      ],
+    },
+    executorObject: {
+      type: 'object',
+      properties: {
+        type: {
+          $ref: '#/definitions/executorType',
+        },
+        config: {
+          type: 'object',
+        },
+      },
+      allOf: [],
+    },
+    step: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        type: {
+          $ref: '#/definitions/executorType',
+        },
+        config: {
+          type: 'object',
+        },
+        executor: {
+          $ref: '#/definitions/executorObject',
         },
       },
       allOf: [],
@@ -187,6 +246,40 @@ steps:
     expect(propertyInfo?.enum).toEqual(
       expect.arrayContaining(['command', 'greet'])
     );
+  });
+
+  it('does not augment executor objects that only reuse type/config fields', () => {
+    const schema = buildAugmentedDAGSchema(baseSchemaWithExecutorObject, [
+      {
+        name: 'greet',
+        targetType: 'command',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            message: { type: 'string' },
+          },
+        },
+      },
+    ]);
+
+    const typeSchema = getSchemaAtPath(
+      schema,
+      ['steps', '0', 'executor', 'type'],
+      `
+steps:
+  - name: example
+    executor:
+      type: command
+`
+    );
+    const propertyInfo = toPropertyInfo(typeSchema, 'type', [
+      'steps',
+      '0',
+      'executor',
+      'type',
+    ]);
+
+    expect(propertyInfo?.enum).toEqual(['command']);
   });
 
   it('resolves internal refs inside local custom input schemas', () => {

--- a/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
+++ b/ui/src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts
@@ -1,18 +1,18 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { describe, expect, it } from 'vitest';
-import {
-  buildAugmentedDAGSchema,
-  extractLocalCustomStepTypeHints,
-  mergeCustomStepTypeHints,
-} from '../customStepSchema';
 import {
   dereferenceSchema,
   getSchemaAtPath,
   toPropertyInfo,
   type JSONSchema,
 } from '@/lib/schema-utils';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAugmentedDAGSchema,
+  extractLocalCustomStepTypeHints,
+  mergeCustomStepTypeHints,
+} from '../customStepSchema';
 
 const baseSchema: JSONSchema = {
   type: 'object',
@@ -178,11 +178,11 @@ steps:
   - type: greet
 `
     );
-    const propertyInfo = toPropertyInfo(
-      typeSchema,
+    const propertyInfo = toPropertyInfo(typeSchema, 'type', [
+      'steps',
+      '0',
       'type',
-      ['steps', '0', 'type']
-    );
+    ]);
 
     expect(propertyInfo?.enum).toEqual(
       expect.arrayContaining(['command', 'greet'])
@@ -304,10 +304,11 @@ steps:
       },
     });
 
-    const valueSchema = getSchemaAtPath(
-      recursiveSchema,
-      ['node', 'next', 'value']
-    );
+    const valueSchema = getSchemaAtPath(recursiveSchema, [
+      'node',
+      'next',
+      'value',
+    ]);
     const propertyInfo = toPropertyInfo(
       recursiveSchema.properties?.node as JSONSchema,
       'node',

--- a/ui/src/features/dags/components/dag-editor/customStepSchema.ts
+++ b/ui/src/features/dags/components/dag-editor/customStepSchema.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import type { components } from '../../../../api/v1/schema';
-import { parse as parseYaml } from 'yaml';
 import { dereferenceSchema, type JSONSchema } from '@/lib/schema-utils';
+import { parse as parseYaml } from 'yaml';
+import type { components } from '../../../../api/v1/schema';
 
 export interface EditorCustomStepTypeHint {
   name: string;
@@ -212,7 +212,10 @@ function collectStepSchemaPaths(schema: JSONSchema): string[][] {
   const pathMap = new Map<string, string[]>();
 
   visitSchemas(schema, (candidate, path) => {
-    if (candidate.$ref === '#/definitions/step' || isStepSchemaCandidate(candidate)) {
+    if (
+      candidate.$ref === '#/definitions/step' ||
+      isStepSchemaCandidate(candidate)
+    ) {
       pathMap.set(path.join('/'), path);
     }
   });

--- a/ui/src/features/dags/components/dag-editor/customStepSchema.ts
+++ b/ui/src/features/dags/components/dag-editor/customStepSchema.ts
@@ -150,8 +150,28 @@ function isStepLikeSchema(schema: JSONSchema): boolean {
   );
 }
 
+function hasStepSpecificProperties(schema: JSONSchema): boolean {
+  const properties = schema.properties;
+  if (!properties) {
+    return false;
+  }
+
+  return (
+    'name' in properties ||
+    'command' in properties ||
+    'script' in properties ||
+    'depends' in properties ||
+    'working_dir' in properties ||
+    'parallel' in properties ||
+    'call' in properties
+  );
+}
+
 function isStepSchemaCandidate(schema: JSONSchema): boolean {
   if (!isStepLikeSchema(schema)) {
+    return false;
+  }
+  if (!hasStepSpecificProperties(schema)) {
     return false;
   }
 
@@ -177,8 +197,13 @@ function augmentStepSchema(
 
   const typeSchema = stepSchema.properties?.type;
   if (isRecord(typeSchema)) {
+    const clonedTypeSchema = cloneJson(typeSchema as JSONSchema);
+    stepSchema.properties = {
+      ...stepSchema.properties,
+      type: clonedTypeSchema,
+    };
     augmentExecutorTypeSchema(
-      typeSchema as JSONSchema,
+      clonedTypeSchema,
       customTypeNames,
       customTypeDescriptions
     );

--- a/ui/src/features/dags/components/dag-editor/customStepSchema.ts
+++ b/ui/src/features/dags/components/dag-editor/customStepSchema.ts
@@ -194,6 +194,7 @@ function augmentStepSchema(
   customTypeDescriptions: string[]
 ) {
   stepSchema.allOf = appendUniqueAllOf(stepSchema.allOf, customStepRules);
+  suppressConditionalPropertySuggestions(stepSchema);
 
   const typeSchema = stepSchema.properties?.type;
   if (isRecord(typeSchema)) {
@@ -207,6 +208,38 @@ function augmentStepSchema(
       customTypeNames,
       customTypeDescriptions
     );
+  }
+}
+
+function markPropertiesAsDoNotSuggest(schema: JSONSchema | undefined) {
+  if (!isRecord(schema?.properties)) {
+    return;
+  }
+
+  for (const [propertyName, propertySchema] of Object.entries(schema.properties)) {
+    if (!isRecord(propertySchema)) {
+      continue;
+    }
+
+    schema.properties[propertyName] = {
+      ...(propertySchema as JSONSchema),
+      doNotSuggest: true,
+    };
+  }
+}
+
+function suppressConditionalPropertySuggestions(stepSchema: JSONSchema) {
+  if (!Array.isArray(stepSchema.allOf)) {
+    return;
+  }
+
+  for (const rule of stepSchema.allOf) {
+    if (!isRecord(rule)) {
+      continue;
+    }
+
+    markPropertiesAsDoNotSuggest(rule.if as JSONSchema | undefined);
+    markPropertiesAsDoNotSuggest(rule.then as JSONSchema | undefined);
   }
 }
 
@@ -393,16 +426,23 @@ export function buildAugmentedDAGSchema(
   baseSchema: JSONSchema,
   stepTypes: EditorCustomStepTypeHint[]
 ): JSONSchema {
-  if (stepTypes.length === 0) {
-    return baseSchema;
-  }
-
   const augmented = cloneJson(baseSchema);
   const definitions = augmented.definitions;
-  const stepSchemaPaths = collectStepSchemaPaths(augmented);
+
+  if (stepTypes.length === 0) {
+    for (const path of collectStepSchemaPaths(augmented)) {
+      const schema = getNodeAtPath(augmented, path);
+      if (!schema || !isStepLikeSchema(schema)) {
+        continue;
+      }
+      suppressConditionalPropertySuggestions(schema);
+    }
+
+    return augmented;
+  }
 
   if (!definitions) {
-    return baseSchema;
+    return augmented;
   }
 
   const customDefinitions: Record<string, JSONSchema> = {};
@@ -454,7 +494,7 @@ export function buildAugmentedDAGSchema(
       allOf: cloneJson(customStepRules),
     }).allOf ?? customStepRules;
 
-  for (const path of stepSchemaPaths) {
+  for (const path of collectStepSchemaPaths(resolved)) {
     const schema = getNodeAtPath(resolved, path);
     if (!schema || !isStepLikeSchema(schema)) {
       continue;


### PR DESCRIPTION
## Summary
- add inherited custom step editor hints from base config to the document-specific DAG editor schema
- keep custom step `type` and `config` inference working when the editor schema is dereferenced inline
- scope the custom `Ctrl/Cmd+Space` Monaco action to focused writable editors with completion providers

## Why
The DAG editor still needed inherited custom step metadata from base config so autocomplete and schema docs could resolve custom step types beyond the local `step_types` block. The Monaco shortcut follow-up fixes a regression from the custom suggest action being registered without the built-in focus and provider guards, which made `Ctrl/Cmd+Space` broader than the default suggest command.

## Testing
- `go test ./internal/core/spec -count=1`
- `go test ./internal/service/frontend/api/v1 -count=1`
- `cd ui && pnpm typecheck`
- `cd ui && pnpm test -- src/features/dags/components/dag-editor/__tests__/customStepSchema.test.ts` (the target test passed, but Vitest exited non-zero because of an unrelated existing unhandled error in `src/features/dags/components/dag-details/__tests__/DAGDetailsSidePanel.test.tsx`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Ctrl/Cmd+Space) to trigger code suggestions in the DAG editor.

* **Improvements**
  * Enhanced error handling and validation for editor hints with better error messages.
  * Refined suggestion behavior in the YAML editor based on read-only state.

* **Chores**
  * Internal code organization and formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->