### PR TITLE
fix(agent): add Windows fallback for bash tool

### DIFF
--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -268,10 +268,7 @@ func (w *cappedWriter) String() string {
 	}
 
 	s := w.buf.String()
-	keep := w.limit - len(outputTruncationMarker)
-	if keep > len(s) {
-		keep = len(s)
-	}
+	keep := min(w.limit-len(outputTruncationMarker), len(s))
 	return s[:keep] + outputTruncationMarker
 }
 

--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -7,10 +7,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/llm"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 func init() {
@@ -28,6 +34,14 @@ const (
 	maxBashTimeout     = 10 * time.Minute
 	maxOutputLength    = 100000
 )
+
+type bashPathFinder func() (string, bool)
+
+type commandRunResult struct {
+	stdout string
+	stderr string
+	err    error
+}
 
 // BashToolInput defines the input parameters for the bash tool.
 type BashToolInput struct {
@@ -83,6 +97,10 @@ func bashRun(toolCtx ToolContext, input json.RawMessage) ToolOut {
 }
 
 func executeCommand(toolCtx ToolContext, args BashToolInput) ToolOut {
+	return executeCommandWithFinder(toolCtx, args, findBashPath)
+}
+
+func executeCommandWithFinder(toolCtx ToolContext, args BashToolInput, findPath bashPathFinder) ToolOut {
 	timeout := resolveTimeout(args.Timeout)
 	parentCtx := toolCtx.Context
 	if parentCtx == nil {
@@ -91,28 +109,136 @@ func executeCommand(toolCtx ToolContext, args BashToolInput) ToolOut {
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bash", "-c", args.Command)
-	if toolCtx.WorkingDir != "" {
-		cmd.Dir = toolCtx.WorkingDir
+	var result commandRunResult
+	if bashPath, ok := findPath(); ok {
+		result = executeWithBash(ctx, bashPath, args.Command, toolCtx.WorkingDir)
+	} else {
+		result = executeWithInterpreter(ctx, args.Command, toolCtx.WorkingDir)
 	}
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	output := buildOutput(result.stdout, result.stderr)
 
-	err := cmd.Run()
-	output := buildOutput(stdout.String(), stderr.String())
-
-	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return toolError("Command timed out after %v\n%s", timeout, output)
-		}
-		return toolError("Command failed: %v\n%s", err, output)
+	if result.err != nil {
+		return buildCommandError(result.err, output, timeout, parentCtx)
 	}
 	if output == "" {
 		return ToolOut{Content: "(no output)"}
 	}
 	return ToolOut{Content: output}
+}
+
+func findBashPath() (string, bool) {
+	path, err := exec.LookPath("bash")
+	if err != nil {
+		return "", false
+	}
+	return path, true
+}
+
+func executeWithBash(ctx context.Context, bashPath, command, workDir string) commandRunResult {
+	var stdout, stderr bytes.Buffer
+
+	cmd := exec.Command(bashPath, "-c", command) //nolint:gosec // command is intentionally interpreted by the configured shell tool
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmdutil.SetupCommand(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return commandRunResult{
+			stdout: stdout.String(),
+			stderr: stderr.String(),
+			err:    err,
+		}
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-waitCh:
+		return commandRunResult{
+			stdout: stdout.String(),
+			stderr: stderr.String(),
+			err:    err,
+		}
+	case <-ctx.Done():
+		select {
+		case err := <-waitCh:
+			return commandRunResult{
+				stdout: stdout.String(),
+				stderr: stderr.String(),
+				err:    err,
+			}
+		default:
+		}
+
+		_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+		<-waitCh
+
+		return commandRunResult{
+			stdout: stdout.String(),
+			stderr: stderr.String(),
+			err:    ctx.Err(),
+		}
+	}
+}
+
+func executeWithInterpreter(ctx context.Context, command, workDir string) commandRunResult {
+	var stdout, stderr bytes.Buffer
+
+	file, err := syntax.NewParser(syntax.Variant(syntax.LangBash)).Parse(bytes.NewBufferString(command), "")
+	if err != nil {
+		return commandRunResult{
+			err: fmt.Errorf("failed to parse command: %w", err),
+		}
+	}
+
+	opts := []interp.RunnerOption{
+		interp.Env(nil),
+		interp.StdIO(nil, &stdout, &stderr),
+	}
+	if workDir != "" {
+		opts = append(opts, interp.Dir(workDir))
+	}
+
+	runner, err := interp.New(opts...)
+	if err != nil {
+		return commandRunResult{
+			err: fmt.Errorf("failed to initialize shell interpreter: %w", err),
+		}
+	}
+
+	err = runner.Run(ctx, file)
+	return commandRunResult{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}
+
+func buildCommandError(err error, output string, timeout time.Duration, parentCtx context.Context) ToolOut {
+	if parentCtx != nil && parentCtx.Err() != nil {
+		return toolErrorWithOutput(fmt.Sprintf("Command canceled: %v", parentCtx.Err()), output)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return toolErrorWithOutput(fmt.Sprintf("Command timed out after %v", timeout), output)
+	}
+	if errors.Is(err, context.Canceled) {
+		return toolErrorWithOutput(fmt.Sprintf("Command canceled: %v", err), output)
+	}
+	return toolErrorWithOutput(fmt.Sprintf("Command failed: %v", err), output)
+}
+
+func toolErrorWithOutput(message, output string) ToolOut {
+	if output == "" {
+		return toolError("%s", message)
+	}
+	return toolError("%s\n%s", message, output)
 }
 
 func resolveTimeout(seconds int) time.Duration {

--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -37,6 +37,12 @@ const (
 
 type bashPathFinder func() (string, bool)
 
+type cappedWriter struct {
+	limit     int
+	buf       bytes.Buffer
+	truncated bool
+}
+
 type commandRunResult struct {
 	stdout string
 	stderr string
@@ -136,14 +142,15 @@ func findBashPath() (string, bool) {
 }
 
 func executeWithBash(ctx context.Context, bashPath, command, workDir string) commandRunResult {
-	var stdout, stderr bytes.Buffer
+	stdout := newCappedWriter(maxOutputLength)
+	stderr := newCappedWriter(maxOutputLength)
 
 	cmd := exec.Command(bashPath, "-c", command) //nolint:gosec // command is intentionally interpreted by the configured shell tool
 	if workDir != "" {
 		cmd.Dir = workDir
 	}
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	cmdutil.SetupCommand(cmd)
 
 	if err := cmd.Start(); err != nil {
@@ -189,7 +196,8 @@ func executeWithBash(ctx context.Context, bashPath, command, workDir string) com
 }
 
 func executeWithInterpreter(ctx context.Context, command, workDir string) commandRunResult {
-	var stdout, stderr bytes.Buffer
+	stdout := newCappedWriter(maxOutputLength)
+	stderr := newCappedWriter(maxOutputLength)
 
 	file, err := syntax.NewParser(syntax.Variant(syntax.LangBash)).Parse(bytes.NewBufferString(command), "")
 	if err != nil {
@@ -200,7 +208,7 @@ func executeWithInterpreter(ctx context.Context, command, workDir string) comman
 
 	opts := []interp.RunnerOption{
 		interp.Env(nil),
-		interp.StdIO(nil, &stdout, &stderr),
+		interp.StdIO(nil, stdout, stderr),
 	}
 	if workDir != "" {
 		opts = append(opts, interp.Dir(workDir))
@@ -219,6 +227,52 @@ func executeWithInterpreter(ctx context.Context, command, workDir string) comman
 		stderr: stderr.String(),
 		err:    err,
 	}
+}
+
+func newCappedWriter(limit int) *cappedWriter {
+	return &cappedWriter{limit: limit}
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		if len(p) > 0 {
+			w.truncated = true
+		}
+		return len(p), nil
+	}
+	if w.truncated {
+		return len(p), nil
+	}
+
+	remaining := w.limit - w.buf.Len()
+	if remaining <= 0 {
+		w.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = w.buf.Write(p[:remaining])
+		w.truncated = true
+		return len(p), nil
+	}
+
+	_, _ = w.buf.Write(p)
+	return len(p), nil
+}
+
+func (w *cappedWriter) String() string {
+	if !w.truncated {
+		return w.buf.String()
+	}
+	if w.limit <= len(outputTruncationMarker) {
+		return outputTruncationMarker[:w.limit]
+	}
+
+	s := w.buf.String()
+	keep := w.limit - len(outputTruncationMarker)
+	if keep > len(s) {
+		keep = len(s)
+	}
+	return s[:keep] + outputTruncationMarker
 }
 
 func buildCommandError(err error, output string, timeout time.Duration, parentCtx context.Context) ToolOut {
@@ -264,7 +318,9 @@ func buildOutput(stdout, stderr string) string {
 
 func truncateOutput(s string) string {
 	if len(s) > maxOutputLength {
-		return s[:maxOutputLength] + "\n... [output truncated]"
+		return s[:maxOutputLength] + outputTruncationMarker
 	}
 	return s
 }
+
+const outputTruncationMarker = "\n... [output truncated]"

--- a/internal/agent/bash_test.go
+++ b/internal/agent/bash_test.go
@@ -6,8 +6,10 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,21 @@ import (
 
 func backgroundCtx() ToolContext {
 	return ToolContext{Context: context.Background()}
+}
+
+func createPathHelper(tb testing.TB, dir string) string {
+	tb.Helper()
+
+	name := "path-helper"
+	path := filepath.Join(dir, name)
+	content := "#!/bin/sh\nprintf 'path-helper-marker\\n'\n"
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+		content = "@echo off\r\necho path-helper-marker\r\n"
+	}
+
+	require.NoError(tb, os.WriteFile(path, []byte(content), 0o700))
+	return name
 }
 
 func noBashPath() (string, bool) {
@@ -300,6 +317,19 @@ func TestExecuteCommand_InterpreterFallback(t *testing.T) {
 		assert.Contains(t, result.Content, "yes")
 	})
 
+	t.Run("runs PATH-installed executables", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		helper := createPathHelper(t, dir)
+		command := fmt.Sprintf("PATH=%q; %s", dir+string(os.PathListSeparator)+"$PATH", helper)
+
+		result := runCommandWithFinder(t, context.Background(), "", command, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "path-helper-marker")
+	})
+
 	t.Run("reports parse errors", func(t *testing.T) {
 		t.Parallel()
 
@@ -521,5 +551,31 @@ func TestTruncateOutput(t *testing.T) {
 		result := truncateOutput(exactString)
 
 		assert.Equal(t, exactString, result)
+	})
+}
+
+func TestCappedWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves short output", func(t *testing.T) {
+		t.Parallel()
+
+		writer := newCappedWriter(16)
+		n, err := writer.Write([]byte("short"))
+
+		require.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "short", writer.String())
+	})
+
+	t.Run("caps long output and appends marker", func(t *testing.T) {
+		t.Parallel()
+
+		writer := newCappedWriter(len(outputTruncationMarker) + 5)
+		n, err := writer.Write([]byte(strings.Repeat("x", len(outputTruncationMarker)+10)))
+
+		require.NoError(t, err)
+		assert.Equal(t, len(outputTruncationMarker)+10, n)
+		assert.Equal(t, strings.Repeat("x", 5)+outputTruncationMarker, writer.String())
 	})
 }

--- a/internal/agent/bash_test.go
+++ b/internal/agent/bash_test.go
@@ -6,16 +6,51 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func backgroundCtx() ToolContext {
 	return ToolContext{Context: context.Background()}
+}
+
+func noBashPath() (string, bool) {
+	return "", false
+}
+
+func bashPathForTests(tb testing.TB) bashPathFinder {
+	tb.Helper()
+
+	path, ok := findBashPath()
+	if !ok {
+		tb.Skip("bash is not available")
+	}
+	return func() (string, bool) { return path, true }
+}
+
+func runCommandWithFinder(
+	tb testing.TB,
+	ctx context.Context,
+	workDir, command string,
+	timeout int,
+	findPath bashPathFinder,
+) ToolOut {
+	tb.Helper()
+
+	return executeCommandWithFinder(ToolContext{
+		Context:    ctx,
+		WorkingDir: workDir,
+	}, BashToolInput{
+		Command: command,
+		Timeout: timeout,
+	}, findPath)
 }
 
 func TestBashTool_Run(t *testing.T) {
@@ -147,7 +182,7 @@ func TestBashTool_Timeout(t *testing.T) {
 		t.Parallel()
 
 		tool := NewBashTool()
-		input := json.RawMessage(`{"command": "sleep 2", "timeout": 1}`)
+		input := json.RawMessage(`{"command": "while :; do :; done", "timeout": 1}`)
 
 		start := time.Now()
 		result := tool.Run(backgroundCtx(), input)
@@ -162,7 +197,7 @@ func TestBashTool_Timeout(t *testing.T) {
 		t.Parallel()
 
 		tool := NewBashTool()
-		input := json.RawMessage(`{"command": "sleep 10"}`)
+		input := json.RawMessage(`{"command": "while :; do :; done", "timeout": 10}`)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
@@ -172,7 +207,202 @@ func TestBashTool_Timeout(t *testing.T) {
 		elapsed := time.Since(start)
 
 		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "canceled")
 		assert.Less(t, elapsed, time.Second)
+	})
+}
+
+func TestExecuteCommand_InterpreterFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("executes simple echo", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `echo hello`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "hello")
+	})
+
+	t.Run("returns no output for silent commands", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `true`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Equal(t, "(no output)", result.Content)
+	})
+
+	t.Run("captures stderr", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `echo error >&2`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "STDERR")
+		assert.Contains(t, result.Content, "error")
+	})
+
+	t.Run("reports exit failure", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `exit 1`, 0, noBashPath)
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "failed")
+	})
+
+	t.Run("supports pipelines with builtins", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `printf 'hello\n' | while IFS= read -r line; do echo "${line}!"; done`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "hello!")
+	})
+
+	t.Run("respects working directory", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("ok"), 0o600))
+
+		result := runCommandWithFinder(t, context.Background(), dir, `test -f marker.txt && echo found`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "found")
+	})
+
+	t.Run("supports variable expansion", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `X=hello; echo "$X"`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "hello")
+	})
+
+	t.Run("supports command substitution", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `echo "$(echo nested)"`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "nested")
+	})
+
+	t.Run("supports bash syntax mode", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `value=hello; [[ "$value" == hello ]] && echo yes`, 0, noBashPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "yes")
+	})
+
+	t.Run("reports parse errors", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `if then`, 0, noBashPath)
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, strings.ToLower(result.Content), "parse")
+	})
+}
+
+func TestExecuteCommand_InterpreterFallback_Timeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("internal timeout is reported as timeout", func(t *testing.T) {
+		t.Parallel()
+
+		start := time.Now()
+		result := runCommandWithFinder(t, context.Background(), "", `while :; do :; done`, 1, noBashPath)
+		elapsed := time.Since(start)
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "timed out")
+		assert.Less(t, elapsed, 2*time.Second)
+	})
+
+	t.Run("parent deadline is reported as cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		result := runCommandWithFinder(t, ctx, "", `while :; do :; done`, 10, noBashPath)
+		elapsed := time.Since(start)
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "canceled")
+		assert.Contains(t, result.Content, "deadline exceeded")
+		assert.Less(t, elapsed, time.Second)
+	})
+}
+
+func TestExecuteCommand_BashPath(t *testing.T) {
+	t.Parallel()
+
+	findPath := bashPathForTests(t)
+
+	t.Run("executes simple echo", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `echo hello`, 0, findPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "hello")
+	})
+
+	t.Run("captures stderr", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `echo error >&2`, 0, findPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "STDERR")
+		assert.Contains(t, result.Content, "error")
+	})
+
+	t.Run("reports exit failure", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `exit 1`, 0, findPath)
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "failed")
+	})
+
+	t.Run("supports pipelines", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `printf 'hello\n' | while IFS= read -r line; do echo "${line}!"; done`, 0, findPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "hello!")
+	})
+
+	t.Run("respects working directory", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("ok"), 0o600))
+
+		result := runCommandWithFinder(t, context.Background(), dir, `test -f marker.txt && echo found`, 0, findPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "found")
+	})
+
+	t.Run("supports bash syntax", func(t *testing.T) {
+		t.Parallel()
+
+		result := runCommandWithFinder(t, context.Background(), "", `value=hello; [[ "$value" == hello ]] && echo yes`, 0, findPath)
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "yes")
 	})
 }
 

--- a/internal/agent/inputspill.go
+++ b/internal/agent/inputspill.go
@@ -149,7 +149,7 @@ func buildChatInputSpillWrapper(path, raw string) string {
 		b.WriteString("\n")
 	}
 	b.WriteString("---\n\n")
-	b.WriteString("Treat the file contents as the user's full message. Inspect it selectively with `read` or shell tools like `rg`, `head`, `tail`, or `sed -n`. Do not blindly `cat` the entire file unless necessary.")
+	b.WriteString("Treat the file contents as the user's full message. Inspect it selectively with `read` first, or with shell commands that are actually installed on the host. Do not assume Unix-only helper binaries are available, and do not dump the entire file unless necessary.")
 	return b.String()
 }
 

--- a/internal/agent/inputspill_test.go
+++ b/internal/agent/inputspill_test.go
@@ -42,8 +42,9 @@ func TestBuildChatInputSpillWrapper_IncludesTruncatedPreviewAndInstructions(t *t
 	assert.Contains(t, wrapper, "Preview (truncated):")
 	assert.Contains(t, wrapper, "Treat the file contents as the user's full message.")
 	assert.Contains(t, wrapper, "`read`")
-	assert.Contains(t, wrapper, "`rg`")
-	assert.Contains(t, wrapper, "Do not blindly `cat` the entire file")
+	assert.Contains(t, wrapper, "installed on the host")
+	assert.Contains(t, wrapper, "Do not assume Unix-only helper binaries are available")
+	assert.Contains(t, wrapper, "do not dump the entire file unless necessary")
 	assert.True(t, utf8.ValidString(wrapper))
 }
 

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -75,7 +75,7 @@ Use any loaded memory as context only. Do not attempt to create, update, or dele
 <task_to_dag>
 When the user asks you to do something (a task, action, or request), before taking any action:
 1. Check your memory for any previously saved task-to-DAG mappings.
-2. If no mapping is found, use bash to list DAG files in the DAGs directory (e.g., `ls {{.DAGsDir}}`) and read any DAG files whose names seem relevant to the user's request.
+2. If no mapping is found, use bash to inspect the DAGs directory and read any DAG files whose names seem relevant to the user's request.
 3. If you find a DAG that can fulfill the request, present it to the user and ask for confirmation before executing.
 4. If no matching DAG exists, proceed with the task normally (create a new DAG if appropriate).
 {{if .Memory.ReadOnly}}
@@ -94,12 +94,12 @@ Confirm before actions with side effects (editing production DAGs, deleting file
 <security>
 Do not read environment variables via bash (echo $VAR, env, printenv)—they may contain secrets that would be exposed in logs or outputs.
 
+The `bash` tool may run via a built-in POSIX shell interpreter when no system `bash` binary is available. Prefer shell builtins and installed CLIs, and do not assume Unix-only helper binaries like `ls`, `sed`, `cat`, `head`, `tail`, `mktemp`, or `sleep` are present on every host.
+
 Treat anything that looks like a secret as sensitive (API keys, tokens, passwords).
 
-When passing user-generated content (emails, file contents, API responses, etc.) to external CLI tools, never embed the variable directly in shell arguments. The content may contain quotes or special characters that break shell parsing. Always write the content to a temp file and use stdin redirection:
+When passing user-generated content (emails, file contents, API responses, etc.) to external CLI tools, never embed the variable directly in shell arguments. The content may contain quotes or special characters that break shell parsing. Write it to a temp file using a host-appropriate mechanism and pass it via stdin redirection:
 ```sh
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
 printf '%s' "${CONTENT}" > "$TMPFILE"
 some-cli-tool < "$TMPFILE"
 ```
@@ -141,7 +141,7 @@ Use `script:` (not `command:`) when a step needs multi-line shell logic, pipes, 
 
 **Passing data between steps:**
 - `output: VAR` captures stdout **content** into `${VAR}`. For JSON output, extract fields with `${VAR.key}`.
-- `${step_id.stdout}` is a **file path** to the step's stdout log, not the content. Use `cat "${step_id.stdout}"` to read it.
+- `${step_id.stdout}` is a **file path** to the step's stdout log, not the content. Prefer the `read` tool to inspect it; only use shell commands when necessary.
 - Use `output:` + `${VAR}` for small safe values (IDs, counts). Use `${step_id.stdout}` (file path) for large or untrusted content.
 - Resolution priority: `${foo.bar}` checks step references first, then JSON path on variables.
 
@@ -182,7 +182,7 @@ Actively report your progress during multi-step work so the user is not left wai
 </rules>
 
 <tools>
-- `bash`: Run shell commands (120s timeout). Use for dagu CLI commands.
+- `bash`: Run shell commands (120s timeout). It uses system `bash` when available and a built-in shell interpreter otherwise, so do not assume Unix-only helper binaries are installed. Use it for Dagu CLI commands and other installed CLIs.
 - `read`: Read file contents. Use before editing any file.
 - `patch`: Create or edit files using unified diff format.
 - `think`: Reason through complex multi-step tasks before acting.

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -94,12 +94,13 @@ Confirm before actions with side effects (editing production DAGs, deleting file
 <security>
 Do not read environment variables via bash (echo $VAR, env, printenv)—they may contain secrets that would be exposed in logs or outputs.
 
-The `bash` tool may run via a built-in POSIX shell interpreter when no system `bash` binary is available. Prefer shell builtins and installed CLIs, and do not assume Unix-only helper binaries like `ls`, `sed`, `cat`, `head`, `tail`, `mktemp`, or `sleep` are present on every host.
+The `bash` tool may run via a built-in shell interpreter when no system `bash` binary is available. Prefer shell builtins and installed CLIs, and do not assume Unix-only helper binaries like `ls`, `sed`, `cat`, `head`, `tail`, `mktemp`, or `sleep` are present on every host.
 
 Treat anything that looks like a secret as sensitive (API keys, tokens, passwords).
 
-When passing user-generated content (emails, file contents, API responses, etc.) to external CLI tools, never embed the variable directly in shell arguments. The content may contain quotes or special characters that break shell parsing. Write it to a temp file using a host-appropriate mechanism and pass it via stdin redirection:
+When passing user-generated content (emails, file contents, API responses, etc.) to external CLI tools, never embed the variable directly in shell arguments. The content may contain quotes or special characters that break shell parsing. Create a temp file using a host-appropriate mechanism, store its path in `$TMPFILE`, then write `${CONTENT}` into it and pass it via stdin redirection:
 ```sh
+# Assume TMPFILE already points to a temp file created for this host.
 printf '%s' "${CONTENT}" > "$TMPFILE"
 some-cli-tool < "$TMPFILE"
 ```


### PR DESCRIPTION
## Summary
- prefer system `bash` for the agent bash tool and fall back to the built-in `mvdan/sh` interpreter when `bash` is unavailable
- preserve timeout, cancellation, working-directory, and output handling across both execution paths
- update agent prompt guidance and tests so fallback hosts are no longer assumed to have Unix-only helper binaries installed

## Why
The agent bash tool was hardcoded to `bash -c`, which made it unusable on Windows hosts without Git Bash. The surrounding prompt guidance also nudged the agent toward Unix-only helper commands, so even a shell fallback needed clearer host-agnostic instructions.

## Test plan
- [x] `go test ./internal/agent -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bash tool now automatically uses a built-in interpreter when system bash is unavailable, improving compatibility across environments.

* **Documentation**
  * Updated guidance to avoid assuming Unix-only tools are installed, with clearer instructions for handling large inputs and inter-step data passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->