### PR TITLE
ci: split ubuntu and windows tests by suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,12 +155,10 @@ jobs:
           - suite: unit
             suite_index: 1
             suite_total: 2
-            packages_cmd: go list ./... | grep -Ev '^github.com/dagucloud/dagu/internal/intg(/|$)'
             codecov_name: ubuntu-unit
           - suite: intg
             suite_index: 2
             suite_total: 2
-            packages_cmd: go list ./internal/intg/...
             codecov_name: ubuntu-intg
     steps:
       - name: Check out code
@@ -175,11 +173,24 @@ jobs:
         id: test-packages
         shell: bash
         run: |
-          packages="$(
-            ${{ matrix.packages_cmd }} | xargs
-          )"
+          suite="${{ matrix.suite }}"
+          module_path="$(go list -m)"
+          case "${suite}" in
+            unit)
+              packages="$(
+                go list ./... | awk -v prefix="${module_path}/internal/intg" '$0 != prefix && index($0, prefix "/") != 1' | xargs
+              )"
+              ;;
+            intg)
+              packages="$(go list ./internal/intg/... | xargs)"
+              ;;
+            *)
+              echo "unknown test suite: ${suite}" >&2
+              exit 1
+              ;;
+          esac
           if [[ -z "${packages}" ]]; then
-            echo "failed to resolve packages for ${{ matrix.suite }}" >&2
+            echo "failed to resolve packages for ${suite}" >&2
             exit 1
           fi
           echo "packages=${packages}" >> "${GITHUB_OUTPUT}"
@@ -282,11 +293,9 @@ jobs:
           - suite: unit
             suite_index: 1
             suite_total: 2
-            packages_cmd: go list ./... | grep -Ev '^github.com/dagucloud/dagu/internal/intg(/|$)'
           - suite: intg
             suite_index: 2
             suite_total: 2
-            packages_cmd: go list ./internal/intg/...
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -300,11 +309,24 @@ jobs:
         id: test-packages
         shell: bash
         run: |
-          packages="$(
-            ${{ matrix.packages_cmd }} | xargs
-          )"
+          suite="${{ matrix.suite }}"
+          module_path="$(go list -m)"
+          case "${suite}" in
+            unit)
+              packages="$(
+                go list ./... | awk -v prefix="${module_path}/internal/intg" '$0 != prefix && index($0, prefix "/") != 1' | xargs
+              )"
+              ;;
+            intg)
+              packages="$(go list ./internal/intg/... | xargs)"
+              ;;
+            *)
+              echo "unknown test suite: ${suite}" >&2
+              exit 1
+              ;;
+          esac
           if [[ -z "${packages}" ]]; then
-            echo "failed to resolve packages for ${{ matrix.suite }}" >&2
+            echo "failed to resolve packages for ${suite}" >&2
             exit 1
           fi
           echo "packages=${packages}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,10 +144,24 @@ jobs:
           args: --timeout=10m
 
   test-ubuntu:
-    name: Test on ubuntu-latest
+    name: Test on ubuntu-latest (${{ matrix.suite_index }}/${{ matrix.suite_total }})
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            suite_index: 1
+            suite_total: 2
+            packages_cmd: go list ./... | grep -Ev '^github.com/dagucloud/dagu/internal/intg(/|$)'
+            codecov_name: ubuntu-unit
+          - suite: intg
+            suite_index: 2
+            suite_total: 2
+            packages_cmd: go list ./internal/intg/...
+            codecov_name: ubuntu-intg
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -157,18 +171,33 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Resolve test packages
+        id: test-packages
+        shell: bash
+        run: |
+          packages="$(
+            ${{ matrix.packages_cmd }} | xargs
+          )"
+          if [[ -z "${packages}" ]]; then
+            echo "failed to resolve packages for ${{ matrix.suite }}" >&2
+            exit 1
+          fi
+          echo "packages=${packages}" >> "${GITHUB_OUTPUT}"
+
       - name: Build
         run: |
           make bin
 
       - name: Test
         run: |
-          make test-coverage
+          make test-coverage TEST_TARGET="${{ steps.test-packages.outputs.packages }}"
 
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: ./coverage.out
+          flags: ${{ matrix.codecov_name }}
+          name: ${{ matrix.codecov_name }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -242,10 +271,22 @@ jobs:
           retention-days: 7
 
   test-windows:
-    name: Test on windows-latest
+    name: Test on windows-latest (${{ matrix.suite_index }}/${{ matrix.suite_total }})
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            suite_index: 1
+            suite_total: 2
+            packages_cmd: go list ./... | grep -Ev '^github.com/dagucloud/dagu/internal/intg(/|$)'
+          - suite: intg
+            suite_index: 2
+            suite_total: 2
+            packages_cmd: go list ./internal/intg/...
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -254,6 +295,19 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Resolve test packages
+        id: test-packages
+        shell: bash
+        run: |
+          packages="$(
+            ${{ matrix.packages_cmd }} | xargs
+          )"
+          if [[ -z "${packages}" ]]; then
+            echo "failed to resolve packages for ${{ matrix.suite }}" >&2
+            exit 1
+          fi
+          echo "packages=${packages}" >> "${GITHUB_OUTPUT}"
 
       - name: Build (Windows)
         shell: bash
@@ -267,4 +321,4 @@ jobs:
           go test \
             -timeout=20m \
             -ldflags=-extldflags=-Wl \
-            ./...
+            ${{ steps.test-packages.outputs.packages }}

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -210,7 +210,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, 20*time.Second)
+		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -237,7 +237,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Failed, 20*time.Second)
+		status := f.waitForStatus(core.Failed, executionStatusTimeout())
 
 		require.Equal(t, core.Failed, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -264,7 +264,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, 20*time.Second)
+		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -294,7 +294,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, 20*time.Second)
+		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -321,7 +321,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, 20*time.Second)
+		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
 		require.Equal(t, core.Succeeded, status.Status)
 
 		stream, err := f.coordinatorClient.StreamArtifacts(f.coord.Context)

--- a/internal/intg/distr/zombie_recovery_test.go
+++ b/internal/intg/distr/zombie_recovery_test.go
@@ -508,6 +508,7 @@ steps:
 
 	opts := []fixtureOption{
 		withWorkerCount(0),
+		withWorkerMaxActiveRuns(1),
 		withStaleThresholds(testStaleHeartbeatThreshold, testStaleLeaseThreshold),
 		withZombieDetectionInterval(testZombieDetectorInterval),
 	}
@@ -519,20 +520,14 @@ steps:
 	defer f.cleanup()
 
 	release := make(chan struct{})
-	var blockOnce sync.Once
 	afterAckHook := func(ctx context.Context, _ *coordinatorv1.Task) bool {
-		shouldBlock := false
-		blockOnce.Do(func() {
-			shouldBlock = true
-		})
-		if !shouldBlock {
-			return false
-		}
+		// Keep duplicate claims stalled too; Windows can observe a retry after
+		// the first claim was already picked up.
 		select {
 		case <-release:
 			return false
 		case <-ctx.Done():
-			return false
+			return true
 		}
 	}
 

--- a/internal/intg/parallel_test.go
+++ b/internal/intg/parallel_test.go
@@ -472,7 +472,7 @@ steps:
 			return started >= 1
 		}
 		return started == 1
-	}, 10*time.Second, 50*time.Millisecond, "expected exactly one started sub-run before abort")
+	}, intgTestTimeout(10*time.Second), 50*time.Millisecond, "expected exactly one started sub-run before abort")
 
 	agent.Abort()
 


### PR DESCRIPTION
## Summary
- split the `ubuntu-latest` Go test job into parallel `(1/2)` unit and `(2/2)` `internal/intg/...` runs
- split the `windows-latest` Go test job the same way so both suites run independently on that runner too
- keep Ubuntu coverage uploads per suite so Codecov can aggregate the reports across the split jobs
- use existing platform-aware integration timeouts for Windows-sensitive parallel abort, distributed artifact waits, and delayed-ack stale cleanup exposed by the split
- resolve review feedback by deriving the module path in the package resolver and keeping empty-package failures on the explicit guard path

## Testing
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- verified unit resolver returns 137 non-`internal/intg` packages
- verified integration resolver returns `./internal/intg/...` packages
- verified the empty unit-filter case reaches the explicit guard under `set -e -o pipefail`
- `go test ./internal/intg -run TestParallelExecution_AbortStopsPendingLaunches -count=5`
- `go test ./internal/intg/distr -run TestExecution_Artifacts -count=1`
- `go test ./internal/intg/distr -run TestDistributedRun_DelayedAfterAck_DoesNotExecuteAfterStaleCleanup -count=1`
- GitHub Actions `CI` run `24491182777`
