### PR TITLE
test: reduce fixed waits in slow suites

### DIFF
--- a/internal/cmd/cleanup_test.go
+++ b/internal/cmd/cleanup_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -114,10 +115,11 @@ func TestCleanupCommand(t *testing.T) {
 		th := test.SetupCommand(t)
 
 		// Create a DAG that runs for a while
-		dag := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dag := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    command: sleep 30
-`)
+    command: %q
+`, holdUntilFileExistsCommand(release)))
 
 		done := make(chan struct{})
 		go func() {
@@ -139,11 +141,7 @@ func TestCleanupCommand(t *testing.T) {
 		// Verify the running DAG is still there (should be preserved)
 		dag.AssertLatestStatus(t, core.Running)
 
-		// Stop the DAG
-		th.RunCommand(t, cmd.Stop(), test.CmdTest{
-			Args: []string{"stop", dag.Location},
-		})
-
+		releaseHoldFile(t, release)
 		<-done
 	})
 

--- a/internal/cmd/restart_test.go
+++ b/internal/cmd/restart_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,13 +21,14 @@ func TestRestartCommand(t *testing.T) {
 
 	th := test.SetupCommand(t)
 
-	dag := th.DAG(t, `params: "p1"
+	release := newHoldFile(t)
+	dag := th.DAG(t, fmt.Sprintf(`params: "p1"
 steps:
   - name: "1"
     script: "echo $1"
   - name: "2"
-    script: "sleep 5"
-`)
+    script: %q
+`, holdUntilFileExistsCommand(release)))
 
 	// Start the DAG to restart.
 	done1 := make(chan struct{})
@@ -46,8 +48,10 @@ steps:
 		th.RunCommand(t, cmd.Restart(), test.CmdTest{Args: args})
 		close(done2)
 	}()
+	releaseDone := releaseHoldFileWhenRecentStatusCountAtLeast(t, th, dag.Name, 2, release)
 
 	// Wait for both executions to complete.
+	require.NoError(t, <-releaseDone)
 	<-done1
 	<-done2
 
@@ -67,16 +71,17 @@ func TestRestartCommand_BuiltExecutableRestoresExplicitEnv(t *testing.T) {
 	th := test.SetupCommand(t, test.WithBuiltExecutable())
 	t.Setenv("CMD_RESTART_EXPLICIT_ENV", "from-host")
 
-	dag := th.DAG(t, `name: built-restart-explicit-env
+	release := newHoldFile(t)
+	dag := th.DAG(t, fmt.Sprintf(`name: built-restart-explicit-env
 env:
   - EXPORTED_SECRET: ${CMD_RESTART_EXPLICIT_ENV}
 steps:
   - name: "hold"
-    command: sleep 5
+    command: %q
   - name: "capture"
-    command: printf '%s|%s' "$EXPORTED_SECRET" "${CMD_RESTART_EXPLICIT_ENV:-}"
+    command: printf '%%s|%%s' "$EXPORTED_SECRET" "${CMD_RESTART_EXPLICIT_ENV:-}"
     output: RESULT
-`)
+`, holdUntilFileExistsCommand(release)))
 
 	startDone := make(chan error, 1)
 	go func() {
@@ -90,7 +95,9 @@ steps:
 		return err == nil && status != nil && status.Status == core.Running
 	}, 10*time.Second, 100*time.Millisecond)
 
+	releaseDone := releaseHoldFileWhenRecentStatusCountAtLeast(t, th, dag.Name, 2, release)
 	test.RunBuiltCLI(t, th.Helper, []string{"CMD_RESTART_EXPLICIT_ENV=from-host"}, "restart", dag.Name)
+	require.NoError(t, <-releaseDone)
 
 	require.NoError(t, <-startDone)
 

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -46,22 +46,16 @@ func waitForDAGRunning(t *testing.T, th test.Command, dagLocation string) {
 	}, time.Second*3, time.Millisecond*50)
 }
 
-// stopDAGAndWait stops a DAG and waits for the goroutine to complete.
-func stopDAGAndWait(t *testing.T, th test.Command, dagLocation string, done <-chan struct{}) {
-	t.Helper()
-	th.RunCommand(t, cmd.Stop(), test.CmdTest{Args: []string{"stop", dagLocation}})
-	<-done
-}
-
 func TestStatusCommand(t *testing.T) {
 	t.Run("StatusDAGRunning", func(t *testing.T) {
 		t.Parallel()
 
 		th := test.SetupCommand(t)
-		dagFile := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dagFile := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    command: sleep 10
-`)
+    command: %q
+`, holdUntilFileExistsCommand(release)))
 		done := make(chan struct{})
 		go func() {
 			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
@@ -73,7 +67,8 @@ func TestStatusCommand(t *testing.T) {
 		err := executeCommand(th.Context, cmd.Status(), []string{dagFile.Location})
 		require.NoError(t, err)
 
-		stopDAGAndWait(t, th, dagFile.Location, done)
+		releaseHoldFile(t, release)
+		<-done
 	})
 
 	t.Run("StatusDAGSuccess", func(t *testing.T) {
@@ -262,10 +257,11 @@ steps:
 		t.Parallel()
 
 		th := test.SetupCommand(t)
-		dagFile := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dagFile := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    command: sleep 10
-`)
+    command: %q
+`, holdUntilFileExistsCommand(release)))
 		done := make(chan struct{})
 		go func() {
 			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
@@ -326,10 +322,11 @@ steps:
 		t.Parallel()
 
 		th := test.SetupCommand(t)
-		dagFile := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dagFile := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    command: sleep 10
-`)
+    command: %q
+`, holdUntilFileExistsCommand(release)))
 		done := make(chan struct{})
 		go func() {
 			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
@@ -341,7 +338,8 @@ steps:
 		err := executeCommand(th.Context, cmd.Status(), []string{dagFile.Location})
 		require.NoError(t, err)
 
-		stopDAGAndWait(t, th, dagFile.Location, done)
+		releaseHoldFile(t, release)
+		<-done
 	})
 
 	t.Run("StatusDAGWithAttemptID", func(t *testing.T) {

--- a/internal/cmd/stop_test.go
+++ b/internal/cmd/stop_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,12 +19,14 @@ import (
 
 func TestStopCommand(t *testing.T) {
 	t.Run("StopDAGRun", func(t *testing.T) {
+		t.Parallel()
 		th := test.SetupCommand(t)
 
-		dag := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dag := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    script: "sleep 10"
-`)
+    script: %q
+`, holdUntilFileExistsCommand(release)))
 
 		done := make(chan struct{})
 		go func() {
@@ -46,12 +49,14 @@ func TestStopCommand(t *testing.T) {
 		<-done
 	})
 	t.Run("StopDAGRunWithRunID", func(t *testing.T) {
+		t.Parallel()
 		th := test.SetupCommand(t)
 
-		dag := th.DAG(t, `steps:
+		release := newHoldFile(t)
+		dag := th.DAG(t, fmt.Sprintf(`steps:
   - name: "1"
-    script: "sleep 10"
-`)
+    script: %q
+`, holdUntilFileExistsCommand(release)))
 
 		done := make(chan struct{})
 		dagRunID := uuid.Must(uuid.NewV7()).String()
@@ -75,6 +80,7 @@ func TestStopCommand(t *testing.T) {
 		<-done
 	})
 	t.Run("CancelFailedAutoRetryPendingDAGRunWithRunID", func(t *testing.T) {
+		t.Parallel()
 		th := test.SetupCommand(t)
 
 		dag := th.DAG(t, `name: cancel-stop-retry
@@ -97,6 +103,7 @@ steps:
 		dag.AssertLatestStatus(t, core.Aborted)
 	})
 	t.Run("StopWithoutRunIDDoesNotCancelFailedAutoRetryPendingDAGRun", func(t *testing.T) {
+		t.Parallel()
 		th := test.SetupCommand(t)
 
 		dag := th.DAG(t, `name: stop-running-only

--- a/internal/cmd/test_helpers_test.go
+++ b/internal/cmd/test_helpers_test.go
@@ -4,6 +4,9 @@
 package cmd_test
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -49,4 +52,52 @@ func commandLogWaitTimeout() time.Duration {
 		return 30 * time.Second
 	}
 	return 10 * time.Second
+}
+
+func newHoldFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "release")
+	t.Cleanup(func() {
+		_ = os.WriteFile(path, []byte("release"), 0o600)
+	})
+	return path
+}
+
+func releaseHoldFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("release"), 0o600))
+}
+
+func holdUntilFileExistsCommand(path string) string {
+	iterations := int(commandLogWaitTimeout() / (50 * time.Millisecond))
+	return test.ForOS(
+		fmt.Sprintf("for i in $(seq 1 %d); do [ -f %s ] && exit 0; sleep 0.05; done; exit 124", iterations, test.PosixQuote(path)),
+		fmt.Sprintf("for ($i = 0; $i -lt %d; $i++) { if (Test-Path %s) { exit 0 }; Start-Sleep -Milliseconds 50 }; exit 124", iterations, test.PowerShellQuote(path)),
+	)
+}
+
+func releaseHoldFileWhenRecentStatusCountAtLeast(
+	t *testing.T,
+	th test.Command,
+	dagName string,
+	count int,
+	path string,
+) <-chan error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(commandLogWaitTimeout())
+		for time.Now().Before(deadline) {
+			if len(th.DAGRunMgr.ListRecentStatus(th.Context, dagName, count)) >= count {
+				done <- os.WriteFile(path, []byte("release"), 0o600)
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		_ = os.WriteFile(path, []byte("release"), 0o600)
+		done <- fmt.Errorf("timed out waiting for %d recent statuses for %s", count, dagName)
+	}()
+	return done
 }

--- a/internal/intg/distr/parallel_test.go
+++ b/internal/intg/distr/parallel_test.go
@@ -6,7 +6,9 @@ package distr_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -209,6 +211,8 @@ steps:
 func TestParallel_MixedLocalAndDistributed(t *testing.T) {
 	t.Run("mixedLocalAndDistributedExecution", func(t *testing.T) {
 		tmpDir := t.TempDir()
+		releaseFile := filepath.Join(t.TempDir(), "release")
+		waitForReleaseFile := strings.ReplaceAll(waitForReleaseFileScript(releaseFile), "\n", "\n      ")
 		f := newTestFixture(t, `
 type: graph
 steps:
@@ -228,16 +232,18 @@ steps:
 ---
 name: child-local
 steps:
-  - name: sleep
-    command: sleep $1
+  - name: wait
+    command: |
+      `+waitForReleaseFile+`
 
 ---
 name: child-distributed
 worker_selector:
   type: test-worker
 steps:
-  - name: sleep
-    command: sleep $1
+  - name: wait
+    command: |
+      `+waitForReleaseFile+`
 `, withLabels(map[string]string{"type": "test-worker"}), withDAGsDir(tmpDir), withLogPersistence())
 
 		agent := f.dagWrapper.Agent()
@@ -247,6 +253,14 @@ steps:
 			agent.Context = f.coord.Context
 			_ = agent.Run(agent.Context)
 			close(done)
+		}()
+		defer func() {
+			_ = os.WriteFile(releaseFile, []byte("release"), 0o644)
+			select {
+			case <-done:
+			case <-time.After(distrTestTimeout(5 * time.Second)):
+				t.Log("agent did not stop during cleanup")
+			}
 		}()
 
 		require.Eventually(t, func() bool {
@@ -264,11 +278,16 @@ steps:
 				}
 			}
 			return started == 2
-		}, 5*time.Second, 100*time.Millisecond)
+		}, distrTestTimeout(5*time.Second), 100*time.Millisecond)
 
 		agent.Signal(f.coord.Context, os.Signal(syscall.SIGTERM))
 
-		<-done
+		select {
+		case <-done:
+		case <-time.After(distrTestTimeout(5 * time.Second)):
+			_ = os.WriteFile(releaseFile, []byte("release"), 0o644)
+			t.Fatal("agent did not stop within timeout")
+		}
 
 		st := agent.Status(f.coord.Context)
 

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -47,6 +47,21 @@ func holdUntilFileExistsCommand(path string) string {
 	)
 }
 
+func newHoldFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "release")
+	t.Cleanup(func() {
+		_ = os.WriteFile(path, []byte("release"), 0o600)
+	})
+	return path
+}
+
+func releaseHoldFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("release"), 0o600))
+}
+
 func waitForDAGRunStatus(
 	t *testing.T,
 	server test.Server,

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -41,11 +41,12 @@ func TestServerProcHeartbeat_StartAPI(t *testing.T) {
 		cfg.Proc.StaleThreshold = apiTestProcStaleThreshold
 	}))
 
-	spec := `
+	release := newHoldFile(t)
+	spec := fmt.Sprintf(`
 steps:
   - name: sleep
-    command: sleep 6
-`
+    command: |
+%s`, indentCommandBlock(holdUntilFileExistsCommand(release), 6))
 	dagName := "api-proc-heartbeat"
 	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
 		Name: dagName,
@@ -74,6 +75,8 @@ steps:
 		alive, err := server.ProcStore.IsRunAlive(server.Context, dagName, ref)
 		return err == nil && alive
 	}, apiProcEventuallyTimeout(10*time.Second), 50*time.Millisecond)
+
+	releaseHoldFile(t, release)
 
 	require.Eventually(t, func() bool {
 		statusResp := server.Client().Get(fmt.Sprintf("/api/v1/dags/%s/dag-runs/%s", dagName, execResp.DagRunId)).

--- a/internal/service/frontend/api/v1/singleton_test.go
+++ b/internal/service/frontend/api/v1/singleton_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dagucloud/dagu/api/v1"
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -19,11 +20,12 @@ func TestSingleton(t *testing.T) {
 	server := test.SetupServer(t)
 
 	t.Run("ExecuteDAGConflict", func(t *testing.T) {
-		spec := `
+		release := newHoldFile(t)
+		spec := fmt.Sprintf(`
 steps:
   - name: sleep
-    command: sleep 10
-`
+    command: |
+%s`, indentCommandBlock(holdUntilFileExistsCommand(release), 6))
 		// Create a new DAG
 		_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
 			Name: "singleton_exec_dag",
@@ -54,16 +56,22 @@ steps:
 			Singleton: &singleton,
 		}).ExpectStatus(http.StatusConflict).Send(t)
 
+		releaseHoldFile(t, release)
+		waitForDAGRunStatus(t, server, "singleton_exec_dag", execResp.DagRunId, 5*time.Second, func(status *exec.DAGRunStatus) bool {
+			return status.Status == core.Succeeded
+		})
+
 		// Clean up (deleting the DAG will eventually stop the run)
 		_ = server.Client().Delete("/api/v1/dags/singleton_exec_dag").ExpectStatus(http.StatusNoContent).Send(t)
 	})
 
 	t.Run("EnqueueDAGConflict_Running", func(t *testing.T) {
-		spec := `
+		release := newHoldFile(t)
+		spec := fmt.Sprintf(`
 steps:
   - name: sleep
-    command: sleep 10
-`
+    command: |
+%s`, indentCommandBlock(holdUntilFileExistsCommand(release), 6))
 		// Create a new DAG
 		_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
 			Name: "singleton_enq_run_dag",
@@ -91,6 +99,11 @@ steps:
 		server.Client().Post("/api/v1/dags/singleton_enq_run_dag/enqueue", api.EnqueueDAGDAGRunJSONRequestBody{
 			Singleton: &singleton,
 		}).ExpectStatus(http.StatusConflict).Send(t)
+
+		releaseHoldFile(t, release)
+		waitForDAGRunStatus(t, server, "singleton_enq_run_dag", execResp.DagRunId, 5*time.Second, func(status *exec.DAGRunStatus) bool {
+			return status.Status == core.Succeeded
+		})
 
 		// Clean up
 		_ = server.Client().Delete("/api/v1/dags/singleton_enq_run_dag").ExpectStatus(http.StatusNoContent).Send(t)

--- a/internal/service/worker/worker_test.go
+++ b/internal/service/worker/worker_test.go
@@ -566,22 +566,27 @@ func TestWorkerConnectionFailure(t *testing.T) {
 		w := worker.NewWorker("test-worker", 1, mockCoordinatorCli, labels, &config.Config{})
 		w.SetHandler(&mockHandler{})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		// Start worker
+		done := make(chan struct{})
 		go func() {
 			_ = w.Start(ctx)
+			close(done)
 		}()
 
-		// Wait for context timeout
-		<-ctx.Done()
+		require.Eventually(t, func() bool {
+			return pollCount.Load() > 1
+		}, 2*time.Second, 10*time.Millisecond, "Should retry on connection failures")
 
 		// Should have attempted multiple polls despite failures
 		assert.Greater(t, pollCount.Load(), int32(1), "Should retry on connection failures")
 
 		// Stop worker
+		cancel()
 		_ = w.Stop(context.Background())
+		<-done
 
 		// Verify coordinator client is in failed state
 		metrics := mockCoordinatorCli.Metrics()

--- a/internal/service/worker/worker_test.go
+++ b/internal/service/worker/worker_test.go
@@ -585,8 +585,14 @@ func TestWorkerConnectionFailure(t *testing.T) {
 
 		// Stop worker
 		cancel()
-		_ = w.Stop(context.Background())
-		<-done
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		require.NoError(t, w.Stop(stopCtx))
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Worker did not stop within timeout")
+		}
 
 		// Verify coordinator client is in failed state
 		metrics := mockCoordinatorCli.Metrics()


### PR DESCRIPTION
## Summary
- Replace fixed sleep-based test delays with release-file gates in slow cmd and API tests.
- Parallelize isolated stop command subtests.
- Stop waiting for the full worker retry timeout once a retry is observed.
- Bound worker shutdown waits and replace the mixed local/distributed integration sleep gate with a release-file gate.

## Local timing
- `internal/cmd`: 27.5s before, 15.3s after on this machine.
- `internal/service/worker`: 14.1s before, 11.3s after on this machine.
- `internal/service/frontend/api/v1`: 35.2s before, 23.9s after on this machine.
- `internal/intg/distr -run TestParallel_MixedLocalAndDistributed`: 1.5s after replacing fixed sleeps.

## Testing
- `go test -count=1 ./internal/cmd`
- `go test -json -count=1 ./internal/service/worker > /tmp/worker-mainbranch.jsonl`
- `go test -json -count=1 ./internal/service/frontend/api/v1 > /tmp/api-v1-mainbranch.jsonl`
- `go test -count=1 ./internal/service/worker`
- `go test -count=1 ./internal/intg/distr -run TestParallel_MixedLocalAndDistributed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability and consistency by implementing improved synchronization mechanisms across test suites. Reduced reliance on fixed timeouts and increased test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
