### PR TITLE
feat: add kubernetes secret provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Login to Docker Hub
+        if: ${{ matrix.suite == 'intg' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Resolve test packages
         id: test-packages
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,7 +224,14 @@ jobs:
     needs:
       - changes
       - golint
-    if: needs.changes.outputs.e2e == 'true' && (needs.golint.result == 'success' || needs.golint.result == 'skipped')
+      - test-ubuntu
+      - test-windows
+    if: >-
+      always() &&
+      needs.changes.outputs.e2e == 'true' &&
+      (needs.golint.result == 'success' || needs.golint.result == 'skipped') &&
+      (needs.test-ubuntu.result == 'success' || needs.test-ubuntu.result == 'skipped') &&
+      (needs.test-windows.result == 'success' || needs.test-windows.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1103,9 +1103,12 @@ func (sm *SessionManager) startPromptWaitHeartbeat(ctx context.Context) func() {
 	}
 
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 	var once sync.Once
 
 	go func() {
+		defer close(stopped)
+
 		ticker := time.NewTicker(sm.promptWaitInterval)
 		defer ticker.Stop()
 
@@ -1124,6 +1127,7 @@ func (sm *SessionManager) startPromptWaitHeartbeat(ctx context.Context) func() {
 	return func() {
 		once.Do(func() {
 			close(done)
+			<-stopped
 		})
 	}
 }

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1213,7 +1213,7 @@ func TestSessionManager_CreateWaitUserResponseFunc(t *testing.T) {
 			Question:   "Need more details?",
 		})
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
 		resultCh := make(chan waitResult, 1)

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -369,13 +369,21 @@ type PathsConfig struct {
 
 // SecretsConfig holds global defaults for external secret providers.
 type SecretsConfig struct {
-	Vault VaultSecretsConfig
+	Vault      VaultSecretsConfig
+	Kubernetes KubernetesSecretsConfig
 }
 
 // VaultSecretsConfig holds shared HashiCorp Vault client defaults.
 type VaultSecretsConfig struct {
 	Address string
 	Token   string
+}
+
+// KubernetesSecretsConfig holds shared Kubernetes client defaults.
+type KubernetesSecretsConfig struct {
+	Namespace  string
+	Kubeconfig string
+	Context    string
 }
 
 // UI holds user interface configuration.

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -206,13 +206,21 @@ type PathsDef struct {
 
 // SecretsDef configures shared defaults for secret providers.
 type SecretsDef struct {
-	Vault *VaultSecretsDef `mapstructure:"vault"`
+	Vault      *VaultSecretsDef      `mapstructure:"vault"`
+	Kubernetes *KubernetesSecretsDef `mapstructure:"kubernetes"`
 }
 
 // VaultSecretsDef configures global HashiCorp Vault client defaults.
 type VaultSecretsDef struct {
 	Address string `mapstructure:"address"`
 	Token   string `mapstructure:"token"`
+}
+
+// KubernetesSecretsDef configures global Kubernetes client defaults.
+type KubernetesSecretsDef struct {
+	Namespace  string `mapstructure:"namespace"`
+	Kubeconfig string `mapstructure:"kubeconfig"`
+	Context    string `mapstructure:"context"`
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -407,13 +407,31 @@ func (l *ConfigLoader) loadPathsConfig(cfg *Config, def Definition) error {
 }
 
 func (l *ConfigLoader) loadSecretsConfig(cfg *Config, def Definition) {
-	if def.Secrets == nil || def.Secrets.Vault == nil {
+	if def.Secrets == nil {
 		return
 	}
 
-	cfg.Secrets.Vault = VaultSecretsConfig{
-		Address: def.Secrets.Vault.Address,
-		Token:   def.Secrets.Vault.Token,
+	if def.Secrets.Vault != nil {
+		cfg.Secrets.Vault = VaultSecretsConfig{
+			Address: def.Secrets.Vault.Address,
+			Token:   def.Secrets.Vault.Token,
+		}
+	}
+
+	if def.Secrets.Kubernetes != nil {
+		kubeconfig := def.Secrets.Kubernetes.Kubeconfig
+		resolved, err := l.resolvePath("secrets.kubernetes.kubeconfig", kubeconfig)
+		if err != nil {
+			l.warnings = append(l.warnings, err.Error())
+		} else {
+			kubeconfig = resolved
+		}
+
+		cfg.Secrets.Kubernetes = KubernetesSecretsConfig{
+			Namespace:  def.Secrets.Kubernetes.Namespace,
+			Kubeconfig: kubeconfig,
+			Context:    def.Secrets.Kubernetes.Context,
+		}
 	}
 }
 
@@ -1643,6 +1661,9 @@ var envBindings = []envBinding{
 	// Secrets
 	{key: "secrets.vault.address", env: "SECRETS_VAULT_ADDRESS"},
 	{key: "secrets.vault.token", env: "SECRETS_VAULT_TOKEN"},
+	{key: "secrets.kubernetes.namespace", env: "SECRETS_KUBERNETES_NAMESPACE"},
+	{key: "secrets.kubernetes.kubeconfig", env: "SECRETS_KUBERNETES_KUBECONFIG", isPath: true},
+	{key: "secrets.kubernetes.context", env: "SECRETS_KUBERNETES_CONTEXT"},
 
 	// Scheduler
 	{key: "scheduler.port", env: "SCHEDULER_PORT"},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -97,9 +97,12 @@ func TestLoad_Env(t *testing.T) {
 		"DAGU_HEADLESS":      "true",
 		"DAGU_CHECK_UPDATES": "false",
 
-		"DAGU_DEFAULT_SHELL":         "/bin/zsh",
-		"DAGU_SECRETS_VAULT_ADDRESS": "https://vault.example.com",
-		"DAGU_SECRETS_VAULT_TOKEN":   "vault-token",
+		"DAGU_DEFAULT_SHELL":                 "/bin/zsh",
+		"DAGU_SECRETS_VAULT_ADDRESS":         "https://vault.example.com",
+		"DAGU_SECRETS_VAULT_TOKEN":           "vault-token",
+		"DAGU_SECRETS_KUBERNETES_NAMESPACE":  "secret-ns",
+		"DAGU_SECRETS_KUBERNETES_KUBECONFIG": filepath.Join(testPaths, "kubeconfig"),
+		"DAGU_SECRETS_KUBERNETES_CONTEXT":    "secret-context",
 
 		"DAGU_UI_MAX_DASHBOARD_PAGE_LIMIT": "250",
 		"DAGU_UI_LOG_ENCODING_CHARSET":     "iso-8859-1",
@@ -269,6 +272,11 @@ func TestLoad_Env(t *testing.T) {
 			Vault: VaultSecretsConfig{
 				Address: "https://vault.example.com",
 				Token:   "vault-token",
+			},
+			Kubernetes: KubernetesSecretsConfig{
+				Namespace:  "secret-ns",
+				Kubeconfig: filepath.Join(testPaths, "kubeconfig"),
+				Context:    "secret-context",
 			},
 		},
 		UI: UI{
@@ -1317,27 +1325,41 @@ monitoring:
 	})
 }
 
-func TestLoad_SecretsVaultConfig(t *testing.T) {
+func TestLoad_SecretsConfig(t *testing.T) {
 	t.Run("FromYAML", func(t *testing.T) {
 		cfg := loadFromYAML(t, `
 secrets:
   vault:
     address: "https://vault.example.com"
     token: "yaml-token"
+  kubernetes:
+    namespace: "secret-ns"
+    kubeconfig: "relative/kubeconfig"
+    context: "prod"
 `)
 
 		assert.Equal(t, "https://vault.example.com", cfg.Secrets.Vault.Address)
 		assert.Equal(t, "yaml-token", cfg.Secrets.Vault.Token)
+		assert.Equal(t, "secret-ns", cfg.Secrets.Kubernetes.Namespace)
+		assert.Equal(t, resolvedTestPath(t, "relative/kubeconfig"), cfg.Secrets.Kubernetes.Kubeconfig)
+		assert.Equal(t, "prod", cfg.Secrets.Kubernetes.Context)
 	})
 
 	t.Run("FromEnv", func(t *testing.T) {
+		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
 		cfg := loadWithEnv(t, "# empty", map[string]string{
-			"DAGU_SECRETS_VAULT_ADDRESS": "https://vault.example.com",
-			"DAGU_SECRETS_VAULT_TOKEN":   "env-token",
+			"DAGU_SECRETS_VAULT_ADDRESS":         "https://vault.example.com",
+			"DAGU_SECRETS_VAULT_TOKEN":           "env-token",
+			"DAGU_SECRETS_KUBERNETES_NAMESPACE":  "env-ns",
+			"DAGU_SECRETS_KUBERNETES_KUBECONFIG": kubeconfig,
+			"DAGU_SECRETS_KUBERNETES_CONTEXT":    "env-context",
 		})
 
 		assert.Equal(t, "https://vault.example.com", cfg.Secrets.Vault.Address)
 		assert.Equal(t, "env-token", cfg.Secrets.Vault.Token)
+		assert.Equal(t, "env-ns", cfg.Secrets.Kubernetes.Namespace)
+		assert.Equal(t, kubeconfig, cfg.Secrets.Kubernetes.Kubeconfig)
+		assert.Equal(t, "env-context", cfg.Secrets.Kubernetes.Context)
 	})
 
 	t.Run("OldEnvNamesIgnored", func(t *testing.T) {
@@ -1370,6 +1392,10 @@ secrets:
   vault:
     address: "https://vault.example.com"
     token: "scoped-token"
+  kubernetes:
+    namespace: "scoped-ns"
+    kubeconfig: "relative/scoped-kubeconfig"
+    context: "scoped-context"
 `), 0600)
 				require.NoError(t, err)
 
@@ -1377,6 +1403,9 @@ secrets:
 
 				assert.Equal(t, "https://vault.example.com", cfg.Secrets.Vault.Address)
 				assert.Equal(t, "scoped-token", cfg.Secrets.Vault.Token)
+				assert.Equal(t, "scoped-ns", cfg.Secrets.Kubernetes.Namespace)
+				assert.Equal(t, resolvedTestPath(t, "relative/scoped-kubeconfig"), cfg.Secrets.Kubernetes.Kubeconfig)
+				assert.Equal(t, "scoped-context", cfg.Secrets.Kubernetes.Context)
 			})
 		}
 	})

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -503,6 +503,9 @@
       "properties": {
         "vault": {
           "$ref": "#/definitions/VaultSecretsDef"
+        },
+        "kubernetes": {
+          "$ref": "#/definitions/KubernetesSecretsDef"
         }
       }
     },
@@ -518,6 +521,25 @@
         "token": {
           "type": "string",
           "description": "Default Vault token."
+        }
+      }
+    },
+    "KubernetesSecretsDef": {
+      "type": "object",
+      "description": "Global Kubernetes Secret client defaults.",
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Default Kubernetes namespace for secret lookups."
+        },
+        "kubeconfig": {
+          "type": "string",
+          "description": "Default kubeconfig path for secret lookups."
+        },
+        "context": {
+          "type": "string",
+          "description": "Default kubeconfig context for secret lookups."
         }
       }
     },

--- a/internal/cmn/secrets/kubernetes.go
+++ b/internal/cmn/secrets/kubernetes.go
@@ -1,0 +1,305 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const defaultKubernetesNamespace = "default"
+
+func init() {
+	registerResolver("kubernetes", func(_ []string) Resolver {
+		return &kubernetesResolver{}
+	})
+}
+
+// kubernetesResolver fetches values from Kubernetes Secret resources.
+type kubernetesResolver struct {
+	client        kubernetesSecretClient // For testing
+	clientFactory func(kubernetesClientSettings) (kubernetesSecretClient, error)
+	mu            sync.Mutex
+
+	cachedClient   kubernetesSecretClient
+	cachedSettings kubernetesClientSettings
+}
+
+type kubernetesClientSettings struct {
+	kubeconfig string
+	context    string
+}
+
+type kubernetesSecretRef struct {
+	namespace  string
+	secretName string
+	dataKey    string
+}
+
+// Name returns the provider identifier.
+func (r *kubernetesResolver) Name() string {
+	return "kubernetes"
+}
+
+// Validate checks if the secret reference is valid for Kubernetes Secret access.
+func (r *kubernetesResolver) Validate(ref core.SecretRef) error {
+	_, err := r.parseReference(context.Background(), ref)
+	return err
+}
+
+// Resolve fetches the value from a Kubernetes Secret data key.
+func (r *kubernetesResolver) Resolve(ctx context.Context, ref core.SecretRef) (string, error) {
+	parsed, err := r.parseReference(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := r.getClient(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := client.GetSecret(ctx, parsed.namespace, parsed.secretName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("kubernetes secret %q not found in namespace %q", parsed.secretName, parsed.namespace)
+		}
+		if apierrors.IsForbidden(err) {
+			return "", fmt.Errorf("permission denied reading kubernetes secret %q in namespace %q: %w", parsed.secretName, parsed.namespace, err)
+		}
+		return "", fmt.Errorf("failed to read kubernetes secret %q in namespace %q: %w", parsed.secretName, parsed.namespace, err)
+	}
+	if secret == nil {
+		return "", fmt.Errorf("kubernetes secret %q not found in namespace %q", parsed.secretName, parsed.namespace)
+	}
+
+	value, ok := secret.Data[parsed.dataKey]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in kubernetes secret %q in namespace %q", parsed.dataKey, parsed.secretName, parsed.namespace)
+	}
+
+	return string(value), nil
+}
+
+// CheckAccessibility verifies the Kubernetes Secret and data key can be read.
+func (r *kubernetesResolver) CheckAccessibility(ctx context.Context, ref core.SecretRef) error {
+	_, err := r.Resolve(ctx, ref)
+	return err
+}
+
+func (r *kubernetesResolver) getClient(ctx context.Context, ref core.SecretRef) (kubernetesSecretClient, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.client != nil {
+		return r.client, nil
+	}
+
+	settings := r.resolveClientSettings(ctx, ref)
+	if r.cachedClient != nil && r.cachedSettings == settings {
+		return r.cachedClient, nil
+	}
+
+	client, err := r.newClient(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	r.cachedClient = client
+	r.cachedSettings = settings
+
+	return client, nil
+}
+
+func (r *kubernetesResolver) resolveClientSettings(ctx context.Context, ref core.SecretRef) kubernetesClientSettings {
+	settings := kubernetesClientSettings{}
+
+	cfg := config.GetConfig(ctx)
+	if cfg.Secrets.Kubernetes.Kubeconfig != "" {
+		settings.kubeconfig = cfg.Secrets.Kubernetes.Kubeconfig
+	}
+	if cfg.Secrets.Kubernetes.Context != "" {
+		settings.context = cfg.Secrets.Kubernetes.Context
+	}
+	if kubeconfig := strings.TrimSpace(ref.Options["kubeconfig"]); kubeconfig != "" {
+		settings.kubeconfig = kubeconfig
+	}
+	if contextName := strings.TrimSpace(ref.Options["context"]); contextName != "" {
+		settings.context = contextName
+	}
+
+	return settings
+}
+
+func (r *kubernetesResolver) newClient(settings kubernetesClientSettings) (kubernetesSecretClient, error) {
+	if r.clientFactory != nil {
+		return r.clientFactory(settings)
+	}
+
+	restCfg, err := buildKubernetesRESTConfig(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := k8sclient.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return &realKubernetesSecretClient{clientset: clientset}, nil
+}
+
+func (r *kubernetesResolver) parseReference(ctx context.Context, ref core.SecretRef) (kubernetesSecretRef, error) {
+	if strings.TrimSpace(ref.Key) == "" {
+		return kubernetesSecretRef{}, fmt.Errorf("key (kubernetes secret reference) is required")
+	}
+
+	namespace := r.resolveNamespace(ctx, ref)
+	secretName := firstNonEmpty(
+		ref.Options["secret_name"],
+		ref.Options["name"],
+	)
+	dataKey := firstNonEmpty(
+		ref.Options["secret_key"],
+		ref.Options["field"],
+	)
+
+	key := strings.Trim(strings.TrimSpace(ref.Key), "/")
+	if secretName != "" {
+		if dataKey == "" {
+			dataKey = key
+		}
+		return newKubernetesSecretRef(namespace, secretName, dataKey)
+	}
+
+	if dataKey != "" {
+		return newKubernetesSecretRef(namespace, key, dataKey)
+	}
+
+	secretName, dataKey, ok := strings.Cut(key, "/")
+	if !ok {
+		return kubernetesSecretRef{}, fmt.Errorf("secret name and data key are required; use key as secret-name/data-key or set options.secret_name")
+	}
+
+	secretName = strings.TrimSpace(secretName)
+	dataKey = strings.Trim(strings.TrimSpace(dataKey), "/")
+	if strings.Contains(dataKey, "/") {
+		return kubernetesSecretRef{}, fmt.Errorf("key must be secret-name/data-key")
+	}
+
+	return newKubernetesSecretRef(namespace, secretName, dataKey)
+}
+
+func newKubernetesSecretRef(namespace, secretName, dataKey string) (kubernetesSecretRef, error) {
+	ref := kubernetesSecretRef{
+		namespace:  namespace,
+		secretName: strings.TrimSpace(secretName),
+		dataKey:    strings.TrimSpace(dataKey),
+	}
+	if ref.secretName == "" {
+		return kubernetesSecretRef{}, fmt.Errorf("secret name is required")
+	}
+	if strings.Contains(ref.secretName, "/") {
+		return kubernetesSecretRef{}, fmt.Errorf("secret name must not contain '/'")
+	}
+	if ref.dataKey == "" {
+		return kubernetesSecretRef{}, fmt.Errorf("secret data key is required")
+	}
+	if strings.Contains(ref.dataKey, "/") {
+		return kubernetesSecretRef{}, fmt.Errorf("secret data key must not contain '/'")
+	}
+	return ref, nil
+}
+
+func (r *kubernetesResolver) resolveNamespace(ctx context.Context, ref core.SecretRef) string {
+	if namespace := strings.TrimSpace(ref.Options["namespace"]); namespace != "" {
+		return namespace
+	}
+
+	cfg := config.GetConfig(ctx)
+	if namespace := strings.TrimSpace(cfg.Secrets.Kubernetes.Namespace); namespace != "" {
+		return namespace
+	}
+
+	return defaultKubernetesNamespace
+}
+
+func buildKubernetesRESTConfig(settings kubernetesClientSettings) (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	explicitKubeconfig := settings.kubeconfig != ""
+	explicitKubeconfigEnv := hasExplicitKubeconfigEnv()
+	if explicitKubeconfig {
+		loadingRules.ExplicitPath = settings.kubeconfig
+	}
+
+	overrides := &clientcmd.ConfigOverrides{}
+	explicitContext := settings.context != ""
+	if explicitContext {
+		overrides.CurrentContext = settings.context
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+	restCfg, err := kubeConfig.ClientConfig()
+	if err != nil {
+		if explicitKubeconfig || explicitKubeconfigEnv || explicitContext || hasAnyKubeconfigFile(loadingRules.GetLoadingPrecedence()) {
+			return nil, fmt.Errorf("kubeconfig error: %w", err)
+		}
+
+		restCfg, inClusterErr := rest.InClusterConfig()
+		if inClusterErr != nil {
+			return nil, fmt.Errorf("kubeconfig error: %w; in-cluster error: %w", err, inClusterErr)
+		}
+		return restCfg, nil
+	}
+	return restCfg, nil
+}
+
+func hasExplicitKubeconfigEnv() bool {
+	return strings.TrimSpace(os.Getenv(clientcmd.RecommendedConfigPathEnvVar)) != ""
+}
+
+func hasAnyKubeconfigFile(paths []string) bool {
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+type kubernetesSecretClient interface {
+	GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error)
+}
+
+type realKubernetesSecretClient struct {
+	clientset k8sclient.Interface
+}
+
+func (c *realKubernetesSecretClient) GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
+	return c.clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/cmn/secrets/kubernetes_test.go
+++ b/internal/cmn/secrets/kubernetes_test.go
@@ -1,0 +1,309 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubernetesResolver_Validate(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kubernetesResolver{}
+
+	tests := []struct {
+		name        string
+		ref         core.SecretRef
+		errContains string
+	}{
+		{
+			name: "SecretNameSlashDataKey",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "app-secrets/db-password",
+			},
+		},
+		{
+			name: "SecretNameOption",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "db-password",
+				Options:  map[string]string{"secret_name": "app-secrets"},
+			},
+		},
+		{
+			name: "FieldOption",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "app-secrets",
+				Options:  map[string]string{"field": "db-password"},
+			},
+		},
+		{
+			name: "MissingKey",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+			},
+			errContains: "key (kubernetes secret reference) is required",
+		},
+		{
+			name: "NoSecretName",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "db-password",
+			},
+			errContains: "secret name and data key are required",
+		},
+		{
+			name: "TooManyPathSegments",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "team/app-secrets/db-password",
+			},
+			errContains: "key must be secret-name/data-key",
+		},
+		{
+			name: "MissingDataKey",
+			ref: core.SecretRef{
+				Name:     "DB_PASSWORD",
+				Provider: "kubernetes",
+				Key:      "/",
+				Options:  map[string]string{"secret_name": "app-secrets"},
+			},
+			errContains: "secret data key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := resolver.Validate(tt.ref)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+		})
+	}
+}
+
+func TestKubernetesResolver_Resolve(t *testing.T) {
+	t.Parallel()
+
+	client := &mockKubernetesSecretClient{
+		secrets: map[string]*corev1.Secret{
+			"prod/app-secrets": {
+				ObjectMeta: metav1.ObjectMeta{Name: "app-secrets", Namespace: "prod"},
+				Data: map[string][]byte{
+					"db-password": []byte("secret-password"),
+					"api-token":   []byte("secret-token"),
+				},
+			},
+		},
+	}
+	resolver := &kubernetesResolver{client: client}
+
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Secrets: config.SecretsConfig{
+			Kubernetes: config.KubernetesSecretsConfig{Namespace: "prod"},
+		},
+	})
+
+	value, err := resolver.Resolve(ctx, core.SecretRef{
+		Name:     "DB_PASSWORD",
+		Provider: "kubernetes",
+		Key:      "app-secrets/db-password",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "secret-password", value)
+	assert.Equal(t, []mockKubernetesSecretCall{{namespace: "prod", name: "app-secrets"}}, client.calls)
+}
+
+func TestKubernetesResolver_ResolveWithOptions(t *testing.T) {
+	t.Parallel()
+
+	client := &mockKubernetesSecretClient{
+		secrets: map[string]*corev1.Secret{
+			"staging/app-secrets": {
+				ObjectMeta: metav1.ObjectMeta{Name: "app-secrets", Namespace: "staging"},
+				Data:       map[string][]byte{"api-token": []byte("secret-token")},
+			},
+		},
+	}
+	resolver := &kubernetesResolver{client: client}
+
+	value, err := resolver.Resolve(context.Background(), core.SecretRef{
+		Name:     "API_TOKEN",
+		Provider: "kubernetes",
+		Key:      "api-token",
+		Options: map[string]string{
+			"secret_name": "app-secrets",
+			"namespace":   "staging",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "secret-token", value)
+	assert.Equal(t, []mockKubernetesSecretCall{{namespace: "staging", name: "app-secrets"}}, client.calls)
+}
+
+func TestKubernetesResolver_ResolveErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SecretNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		resolver := &kubernetesResolver{client: &mockKubernetesSecretClient{}}
+		_, err := resolver.Resolve(context.Background(), core.SecretRef{
+			Name:     "DB_PASSWORD",
+			Provider: "kubernetes",
+			Key:      "app-secrets/db-password",
+			Options:  map[string]string{"namespace": "prod"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `kubernetes secret "app-secrets" not found in namespace "prod"`)
+	})
+
+	t.Run("DataKeyNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		resolver := &kubernetesResolver{client: &mockKubernetesSecretClient{
+			secrets: map[string]*corev1.Secret{
+				"default/app-secrets": {
+					ObjectMeta: metav1.ObjectMeta{Name: "app-secrets", Namespace: "default"},
+					Data:       map[string][]byte{"api-token": []byte("secret-token")},
+				},
+			},
+		}}
+
+		_, err := resolver.Resolve(context.Background(), core.SecretRef{
+			Name:     "DB_PASSWORD",
+			Provider: "kubernetes",
+			Key:      "app-secrets/db-password",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `key "db-password" not found`)
+		assert.NotContains(t, err.Error(), "api-token")
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		t.Parallel()
+
+		resolver := &kubernetesResolver{client: &mockKubernetesSecretClient{
+			err: apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "app-secrets", errors.New("denied")),
+		}}
+
+		_, err := resolver.Resolve(context.Background(), core.SecretRef{
+			Name:     "DB_PASSWORD",
+			Provider: "kubernetes",
+			Key:      "app-secrets/db-password",
+			Options:  map[string]string{"namespace": "prod"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied reading kubernetes secret")
+	})
+}
+
+func TestKubernetesResolver_ResolveClientSettings(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kubernetesResolver{}
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Secrets: config.SecretsConfig{
+			Kubernetes: config.KubernetesSecretsConfig{
+				Kubeconfig: "/global/kubeconfig",
+				Context:    "global-context",
+			},
+		},
+	})
+
+	settings := resolver.resolveClientSettings(ctx, core.SecretRef{
+		Options: map[string]string{
+			"kubeconfig": "/override/kubeconfig",
+			"context":    "override-context",
+		},
+	})
+
+	assert.Equal(t, kubernetesClientSettings{
+		kubeconfig: "/override/kubeconfig",
+		context:    "override-context",
+	}, settings)
+}
+
+func TestKubernetesResolver_ClientCache(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	resolver := &kubernetesResolver{
+		clientFactory: func(_ kubernetesClientSettings) (kubernetesSecretClient, error) {
+			calls++
+			return &mockKubernetesSecretClient{}, nil
+		},
+	}
+
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Secrets: config.SecretsConfig{
+			Kubernetes: config.KubernetesSecretsConfig{
+				Kubeconfig: "/global/kubeconfig",
+				Context:    "global-context",
+			},
+		},
+	})
+	ref := core.SecretRef{
+		Name:     "DB_PASSWORD",
+		Provider: "kubernetes",
+		Key:      "app-secrets/db-password",
+	}
+
+	_, err := resolver.getClient(ctx, ref)
+	require.NoError(t, err)
+	_, err = resolver.getClient(ctx, ref)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+type mockKubernetesSecretClient struct {
+	secrets map[string]*corev1.Secret
+	err     error
+	calls   []mockKubernetesSecretCall
+}
+
+type mockKubernetesSecretCall struct {
+	namespace string
+	name      string
+}
+
+func (c *mockKubernetesSecretClient) GetSecret(_ context.Context, namespace, name string) (*corev1.Secret, error) {
+	c.calls = append(c.calls, mockKubernetesSecretCall{namespace: namespace, name: name})
+	if c.err != nil {
+		return nil, c.err
+	}
+	if c.secrets == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+	}
+	secret := c.secrets[namespace+"/"+name]
+	if secret == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+	}
+	return secret, nil
+}

--- a/internal/cmn/secrets/resolver_test.go
+++ b/internal/cmn/secrets/resolver_test.go
@@ -21,7 +21,8 @@ func TestNewRegistry(t *testing.T) {
 	assert.Contains(t, providers, "env")
 	assert.Contains(t, providers, "file")
 	assert.Contains(t, providers, "vault")
-	assert.Len(t, providers, 3)
+	assert.Contains(t, providers, "kubernetes")
+	assert.Len(t, providers, 4)
 }
 
 func TestRegistry_Register(t *testing.T) {
@@ -212,17 +213,18 @@ func TestRegistry_Providers(t *testing.T) {
 	registry := NewRegistry("/tmp")
 
 	providers := registry.Providers()
-	assert.Len(t, providers, 3)
 	assert.Contains(t, providers, "env")
 	assert.Contains(t, providers, "file")
 	assert.Contains(t, providers, "vault")
+	assert.Contains(t, providers, "kubernetes")
+	assert.Len(t, providers, 4)
 
 	// Add custom provider
 	mock := &mockResolver{mockName: "custom"}
 	registry.Register("custom", mock)
 
 	providers = registry.Providers()
-	assert.Len(t, providers, 4)
+	assert.Len(t, providers, 5)
 	assert.Contains(t, providers, "custom")
 }
 

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -296,7 +296,7 @@ type DAGRetryPolicy struct {
 type SecretRef struct {
 	// Name is the environment variable name to set (required).
 	Name string `json:"name"`
-	// Provider specifies the secret backend (e.g., "env", "file", "vault") (required).
+	// Provider specifies the secret backend (e.g., "env", "file", "vault", "kubernetes") (required).
 	Provider string `json:"provider"`
 	// Key is the provider-specific identifier for the secret (required).
 	Key string `json:"key"`

--- a/internal/intg/distr/lifecycle_test.go
+++ b/internal/intg/distr/lifecycle_test.go
@@ -5,6 +5,7 @@ package distr_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"syscall"
 	"testing"
@@ -19,14 +20,14 @@ import (
 
 func TestCancellation_SingleTask(t *testing.T) {
 	t.Run("cancellationPropagatesToRemoteWorker", func(t *testing.T) {
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 name: cancel-test
 worker_selector:
   test: "true"
 steps:
   - name: long-task
-    command: sleep 60
-`)
+    command: %s
+`, test.ShellQuote(test.Sleep(60*time.Second))))
 		defer f.cleanup()
 
 		require.NoError(t, f.enqueue())
@@ -59,7 +60,7 @@ steps:
 
 func TestCancellation_SubDAG(t *testing.T) {
 	t.Run("parentCancelPropagatesToChildOnWorker", func(t *testing.T) {
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 steps:
   - call: dotest
 params:
@@ -70,8 +71,8 @@ worker_selector:
   foo: bar
 steps:
   - name: long-sleep
-    command: sleep 30
-`, withLabels(map[string]string{"foo": "bar"}))
+    command: %s
+`, test.ShellQuote(test.Sleep(30*time.Second))), withLabels(map[string]string{"foo": "bar"}))
 		defer f.cleanup()
 
 		require.NoError(t, f.start())
@@ -106,7 +107,7 @@ steps:
 	})
 
 	t.Run("cancelPropagatesToSubDAGOnWorker", func(t *testing.T) {
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 steps:
   - name: run-local-on-worker
     call: local-sub
@@ -118,9 +119,9 @@ worker_selector:
   type: test-worker
 steps:
   - name: worker-task
-    command: sleep 1000
+    command: %s
     output: MESSAGE
-`, withLabels(map[string]string{"type": "test-worker"}))
+`, test.ShellQuote(test.Sleep(1000*time.Second))), withLabels(map[string]string{"type": "test-worker"}))
 
 		runID := uuid.New().String()
 		agent := f.dagWrapper.Agent(test.WithDAGRunID(runID))
@@ -150,7 +151,7 @@ steps:
 func TestCancellation_ConcurrentWorkers(t *testing.T) {
 	t.Run("cancellationWithHighConcurrency", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 steps:
   - name: high-concurrency
     call: child-task
@@ -170,11 +171,8 @@ worker_selector:
   type: test-worker
 steps:
   - name: process
-    command: |
-      echo "Starting task $1"
-      sleep 0.3
-      echo "Completed task $1"
-`, withWorkerCount(3), withLabels(map[string]string{"type": "test-worker"}),
+    command: %s
+`, test.ShellQuote(test.Sleep(30*time.Second))), withWorkerCount(3), withLabels(map[string]string{"type": "test-worker"}),
 			withDAGsDir(tmpDir), withLogPersistence())
 
 		agent := f.dagWrapper.Agent()
@@ -213,18 +211,18 @@ steps:
 
 func TestCancellation_GracefulShutdown(t *testing.T) {
 	t.Run("gracefulShutdownOnSIGTERM", func(t *testing.T) {
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 type: graph
 name: graceful-cancel-test
 worker_selector:
   test: "true"
 steps:
   - name: task1
-    command: sleep 30
+    command: %s
   - name: task2
     command: echo "should not run"
     depends: [task1]
-`)
+`, test.ShellQuote(test.Sleep(30*time.Second))))
 		defer f.cleanup()
 
 		require.NoError(t, f.enqueue())
@@ -250,7 +248,7 @@ steps:
 func TestCancellation_ParallelItems(t *testing.T) {
 	t.Run("cancelParallelExecutionOnWorkers", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		f := newTestFixture(t, `
+		f := newTestFixture(t, fmt.Sprintf(`
 steps:
   - name: process-items
     call: child-sleep
@@ -268,8 +266,8 @@ worker_selector:
   type: test-worker
 steps:
   - name: sleep
-    command: sleep $1
-`, withWorkerCount(2), withLabels(map[string]string{"type": "test-worker"}),
+    command: %s
+`, test.ShellQuote(test.Sleep(100*time.Second))), withWorkerCount(2), withLabels(map[string]string{"type": "test-worker"}),
 			withDAGsDir(tmpDir), withLogPersistence())
 
 		agent := f.dagWrapper.Agent()

--- a/internal/intg/queue/proc_liveness_test.go
+++ b/internal/intg/queue/proc_liveness_test.go
@@ -111,14 +111,28 @@ steps:
 
 	fakeRunID := uuid.Must(uuid.NewV7()).String()
 	fakeRef := exec.NewDAGRunRef(f.dag.Name, fakeRunID)
+	staleStartedAt := time.Now().Add(-30 * time.Second)
 	procFile := test.CreateStaleProcFile(
 		t,
 		f.th.Config.Paths.ProcDir,
 		f.dag.ProcGroup(),
 		fakeRef,
-		time.Now().Add(-2*time.Second),
-		time.Second,
+		staleStartedAt,
+		30*time.Second,
 	)
+
+	require.Eventually(t, func() bool {
+		entries, err := f.th.ProcStore.ListEntries(f.th.Context, f.dag.ProcGroup())
+		if err != nil {
+			return false
+		}
+		for _, entry := range entries {
+			if entry.Meta.DAGRunID == fakeRunID {
+				return !entry.Fresh
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "stale proc file should be visible before scheduler starts")
 
 	f.StartScheduler(30 * time.Second)
 	f.WaitForStatus(f.runIDs[0], core.Succeeded, 20*time.Second)

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -48,10 +48,12 @@ func TestManager(t *testing.T) {
 			},
 		)
 
+		listen := make(chan error, 1)
 		go func() {
-			_ = socketServer.Serve(ctx, nil)
+			_ = socketServer.Serve(ctx, listen)
 			_ = socketServer.Shutdown(ctx)
 		}()
+		require.NoError(t, <-listen)
 
 		dag.AssertCurrentStatus(t, core.Running)
 

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -641,7 +641,7 @@ func (d *DAG) AssertCurrentStatus(t *testing.T, expected core.Status) {
 		}
 		t.Logf("current status=%s errors=%v", curr.Status.String(), curr.Errors())
 		return curr.Status == expected
-	}, time.Second*5, time.Second)
+	}, latestStatusAssertTimeout, latestStatusAssertInterval)
 }
 
 // AssertOutputs checks the given outputs against the actual outputs of the DAG


### PR DESCRIPTION
## Summary
- add a Kubernetes Secret resolver for DAG `secrets:` entries
- support global and per-secret Kubernetes namespace, kubeconfig, and context settings
- update config schema and focused resolver/config tests

## Testing
- go test ./internal/cmn/secrets ./internal/cmn/config ./internal/cmn/schema ./internal/core/spec -count=1
- go test ./internal/intg -run 'Secret|Secrets' -count=1
- go test ./internal/runtime/agent ./internal/runtime -run 'Secret|Secrets|Env' -count=1
- go test ./internal/cmd -run 'Secret|Config' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes as a built-in secrets provider.
  * Support configuring Kubernetes secrets defaults: namespace, kubeconfig, and context (config file, env, and YAML).
* **Bug Fixes**
  * Fixed secrets-loading so non-Vault providers (including Kubernetes) are properly honored.
  * Improved user-facing errors for missing secrets, missing keys, not-found and permission-denied cases.
* **Tests**
  * Added tests covering Kubernetes secrets parsing, resolution, client caching, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->