### PR TITLE
feat: add embedded Dagu API

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -17,14 +17,3 @@ Commercial embedding rights are not granted by this repository, this document, o
 Under the public GPL license, users may use, modify, and distribute Dagu under the GPL terms. The GPL permits commercial activity, including selling copies or services, but distribution must comply with GPL obligations.
 
 Using the Dagu CLI or server as a separate program is different from importing the embedded Go API into another distributed binary. Projects embedding Dagu should review their distribution model and license obligations.
-
-## Commercial License Boundary
-
-The commercial embedding boundary has not been finalized in source form. Before any broader relicensing or public dual-license grant, the project should complete:
-
-- an import-graph audit for the embedded API;
-- a contributor-rights review for files in that import graph;
-- a third-party dependency license review;
-- a written definition of what commercial embedding rights include.
-
-Future source-code license changes should not be inferred from this document.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,30 @@
+# Licensing
+
+Dagu source code is distributed under the GNU General Public License version 3 or later (`GPL-3.0-or-later`). See [LICENSE](./LICENSE).
+
+This document does not relicense any source file. Files that currently carry `SPDX-License-Identifier: GPL-3.0-or-later` remain GPL-licensed unless a separate written agreement says otherwise.
+
+## Embedded Go API
+
+The Go package `github.com/dagucloud/dagu` exposes an experimental embedded API. Applications that import or link this package and distribute the resulting binary should evaluate GPL obligations for the combined work.
+
+For proprietary products that need to distribute Dagu as part of a non-GPL application, contact `contact@dagu.cloud` to discuss a separate commercial embedding license.
+
+Commercial embedding rights are not granted by this repository, this document, or the public GPL license. They require a separate written agreement with the copyright holder or authorized licensor.
+
+## Current Public License
+
+Under the public GPL license, users may use, modify, and distribute Dagu under the GPL terms. The GPL permits commercial activity, including selling copies or services, but distribution must comply with GPL obligations.
+
+Using the Dagu CLI or server as a separate program is different from importing the embedded Go API into another distributed binary. Projects embedding Dagu should review their distribution model and license obligations.
+
+## Commercial License Boundary
+
+The commercial embedding boundary has not been finalized in source form. Before any broader relicensing or public dual-license grant, the project should complete:
+
+- an import-graph audit for the embedded API;
+- a contributor-rights review for files in that import graph;
+- a third-party dependency license review;
+- a written definition of what commercial embedding rights include.
+
+Future source-code license changes should not be inferred from this document.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,48 @@ dagu start-all
 
 Visit http://localhost:8080
 
+## Embedded Go API (Experimental)
+
+Go applications can import Dagu and start DAG runs from the host process:
+
+```go
+import "github.com/dagucloud/dagu"
+```
+
+```go
+engine, err := dagu.New(ctx, dagu.Options{
+	HomeDir: "/var/lib/myapp/dagu",
+})
+if err != nil {
+	return err
+}
+defer engine.Close(context.Background())
+
+run, err := engine.RunYAML(ctx, []byte(`
+name: embedded
+params:
+  - MESSAGE
+steps:
+  - name: hello
+    command: echo "${MESSAGE}"
+`), dagu.WithParams(map[string]string{
+	"MESSAGE": "hello from the host app",
+}))
+if err != nil {
+	return err
+}
+
+status, err := run.Wait(ctx)
+if err != nil {
+	return err
+}
+fmt.Println(status.Status)
+```
+
+The embedded API is experimental and may change before it is declared stable. It uses Dagu's YAML loader, built-in executors, and file-backed state. `RunFile` and `RunYAML` start runs asynchronously and return a run handle for `Wait`, `Status`, and `Stop`. Distributed embedded runs require an existing Dagu coordinator; embedded workers can be started with `NewWorker`.
+
+See the [embedded API documentation](https://docs.dagu.sh/getting-started/embedded) and [examples/embedded](./examples/embedded).
+
 ## Workflow Examples
 
 ### Sequential execution

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ fmt.Println(status.Status)
 
 The embedded API is experimental and may change before it is declared stable. It uses Dagu's YAML loader, built-in executors, and file-backed state. `RunFile` and `RunYAML` start runs asynchronously and return a run handle for `Wait`, `Status`, and `Stop`. Distributed embedded runs require an existing Dagu coordinator; embedded workers can be started with `NewWorker`.
 
-See the [embedded API documentation](https://docs.dagu.sh/getting-started/embedded) and [examples/embedded](./examples/embedded).
+See the [embedded API documentation](https://docs.dagu.sh/embedding/go-api) and [examples/embedded](./examples/embedded).
 
 ## Workflow Examples
 
@@ -638,4 +638,4 @@ We welcome contributions of all kinds. See our [Contribution Guide](./CONTRIBUTI
 
 ## License
 
-GNU GPLv3 - See [LICENSE](./LICENSE)
+GNU GPLv3 - See [LICENSE](./LICENSE). See [LICENSING.md](./LICENSING.md) for embedded API and commercial embedding notes.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package dagu provides an experimental embedded engine API for running Dagu
+// DAGs from Go applications.
+//
+// The embedding API is experimental and may change before it is declared
+// stable. It currently supports local file-backed execution and shared-nothing
+// distributed execution against existing Dagu coordinators.
+package dagu

--- a/engine.go
+++ b/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"time"
 
 	iengine "github.com/dagucloud/dagu/internal/engine"
@@ -66,10 +67,15 @@ type DistributedOptions struct {
 
 // TLSOptions configures TLS for coordinator and worker peer clients.
 type TLSOptions struct {
-	Insecure      bool
-	CertFile      string
-	KeyFile       string
-	ClientCAFile  string
+	// Insecure explicitly allows plaintext coordinator connections.
+	Insecure bool
+	// CertFile is the client certificate file for TLS connections.
+	CertFile string
+	// KeyFile is the client private key file for TLS connections.
+	KeyFile string
+	// ClientCAFile is the CA file used to verify coordinator certificates.
+	ClientCAFile string
+	// SkipTLSVerify skips coordinator certificate verification.
 	SkipTLSVerify bool
 }
 
@@ -96,12 +102,21 @@ type Status struct {
 
 // WorkerOptions configures an embedded shared-nothing worker.
 type WorkerOptions struct {
-	ID            string
+	// ID is the worker identifier. A host and process based ID is generated when empty.
+	ID string
+	// MaxActiveRuns limits concurrent DAG runs. A default is used when zero or negative.
 	MaxActiveRuns int
-	Labels        map[string]string
-	Coordinators  []string
-	TLS           TLSOptions
-	HealthPort    int
+	// Labels are advertised to coordinators and matched by worker selectors.
+	Labels map[string]string
+	// Coordinators overrides DistributedOptions.Coordinators when non-empty.
+	// If empty, the worker falls back to the engine-level DistributedOptions.
+	// The resolved coordinator list must contain at least one non-empty address.
+	Coordinators []string
+	// TLS overrides DistributedOptions.TLS when non-zero. If zero, the worker
+	// falls back to the engine-level DistributedOptions TLS settings.
+	TLS TLSOptions
+	// HealthPort starts the worker health endpoint on the given port. Zero disables it.
+	HealthPort int
 }
 
 // Engine is an embedded Dagu engine backed by the configured file stores.
@@ -239,10 +254,7 @@ func (r *Run) Wait(ctx context.Context) (*Status, error) {
 		return nil, fmt.Errorf("run is not initialized")
 	}
 	status, err := r.inner.Wait(ctx)
-	if err != nil {
-		return publicStatus(status), err
-	}
-	return publicStatus(status), nil
+	return publicStatus(status), err
 }
 
 // Status returns the current run status.
@@ -251,10 +263,7 @@ func (r *Run) Status(ctx context.Context) (*Status, error) {
 		return nil, fmt.Errorf("run is not initialized")
 	}
 	status, err := r.inner.Status(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return publicStatus(status), nil
+	return publicStatus(status), err
 }
 
 // Stop requests cancellation for this run.
@@ -280,6 +289,14 @@ func (w *Worker) Stop(ctx context.Context) error {
 		return nil
 	}
 	return w.inner.Stop(ctx)
+}
+
+// WaitReady blocks until the worker has registered with a coordinator.
+func (w *Worker) WaitReady(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return fmt.Errorf("worker is not initialized")
+	}
+	return w.inner.WaitReady(ctx)
 }
 
 func applyRunOptions(opts []RunOption) runOptions {
@@ -314,7 +331,7 @@ func WithParams(params map[string]string) RunOption {
 // WithParamsList sets DAG parameters from Dagu-style KEY=VALUE entries.
 func WithParamsList(params []string) RunOption {
 	return func(o *runOptions) {
-		o.paramsList = append([]string{}, params...)
+		o.paramsList = cloneSlice(params)
 	}
 }
 
@@ -342,7 +359,7 @@ func WithWorkerSelector(selector map[string]string) RunOption {
 // WithTags adds tags to one run.
 func WithTags(tags ...string) RunOption {
 	return func(o *runOptions) {
-		o.tags = append([]string{}, tags...)
+		o.tags = cloneSlice(tags)
 	}
 }
 
@@ -374,7 +391,7 @@ func internalOptions(opts Options) iengine.Options {
 
 func internalDistributedOptions(opts DistributedOptions) iengine.DistributedOptions {
 	return iengine.DistributedOptions{
-		Coordinators:    append([]string{}, opts.Coordinators...),
+		Coordinators:    cloneSlice(opts.Coordinators),
 		TLS:             internalTLSOptions(opts.TLS),
 		WorkerSelector:  cloneMap(opts.WorkerSelector),
 		PollInterval:    opts.PollInterval,
@@ -396,12 +413,12 @@ func internalRunOptions(opts runOptions) iengine.RunOptions {
 	return iengine.RunOptions{
 		RunID:             opts.runID,
 		Name:              opts.name,
-		Params:            cloneMap(opts.params),
-		ParamsList:        append([]string{}, opts.paramsList...),
+		Params:            opts.params,
+		ParamsList:        opts.paramsList,
 		DefaultWorkingDir: opts.defaultWorkingDir,
 		Mode:              iengine.ExecutionMode(opts.mode),
-		WorkerSelector:    cloneMap(opts.workerSelector),
-		Tags:              append([]string{}, opts.tags...),
+		WorkerSelector:    opts.workerSelector,
+		Tags:              opts.tags,
 		DryRun:            opts.dryRun,
 	}
 }
@@ -419,7 +436,7 @@ func internalWorkerOptions(opts WorkerOptions) iengine.WorkerOptions {
 		ID:            opts.ID,
 		MaxActiveRuns: opts.MaxActiveRuns,
 		Labels:        cloneMap(opts.Labels),
-		Coordinators:  append([]string{}, opts.Coordinators...),
+		Coordinators:  cloneSlice(opts.Coordinators),
 		TLS:           internalTLSOptions(opts.TLS),
 		HealthPort:    opts.HealthPort,
 	}
@@ -451,4 +468,11 @@ func cloneMap(values map[string]string) map[string]string {
 	out := make(map[string]string, len(values))
 	maps.Copy(out, values)
 	return out
+}
+
+func cloneSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return slices.Clone(values)
 }

--- a/engine.go
+++ b/engine.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"time"
 
 	iengine "github.com/dagucloud/dagu/internal/engine"
@@ -448,8 +449,6 @@ func cloneMap(values map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(values))
-	for key, value := range values {
-		out[key] = value
-	}
+	maps.Copy(out, values)
 	return out
 }

--- a/engine.go
+++ b/engine.go
@@ -1,0 +1,455 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagu
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	iengine "github.com/dagucloud/dagu/internal/engine"
+
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin" // Register built-in executors for embedded use.
+)
+
+// ExecutionMode controls how a DAG run is dispatched.
+type ExecutionMode string
+
+const (
+	// ExecutionModeLocal runs the DAG in the current process.
+	ExecutionModeLocal ExecutionMode = "local"
+	// ExecutionModeDistributed dispatches the DAG to configured coordinators.
+	ExecutionModeDistributed ExecutionMode = "distributed"
+)
+
+// Options configures an embedded Dagu engine.
+type Options struct {
+	// HomeDir is the Dagu application home used for default config and data paths.
+	HomeDir string
+	// ConfigFile loads Dagu configuration from an explicit config file.
+	ConfigFile string
+	// DAGsDir overrides the directory used to resolve named DAGs and sub-DAGs.
+	DAGsDir string
+	// DataDir overrides the file-backed state directory.
+	DataDir string
+	// LogDir overrides the run log directory.
+	LogDir string
+	// ArtifactDir overrides the artifact directory.
+	ArtifactDir string
+	// BaseConfig points at a base configuration file applied during DAG loading.
+	BaseConfig string
+	// Logger receives embedded engine logs. A quiet logger is used when nil.
+	Logger *slog.Logger
+
+	// DefaultMode is used when a run does not set WithMode.
+	DefaultMode ExecutionMode
+	// Distributed configures dispatch and worker clients for shared-nothing mode.
+	Distributed *DistributedOptions
+}
+
+// DistributedOptions configures shared-nothing distributed execution.
+type DistributedOptions struct {
+	// Coordinators are coordinator gRPC addresses.
+	Coordinators []string
+	// TLS configures coordinator client TLS.
+	TLS TLSOptions
+	// WorkerSelector constrains distributed runs to matching workers.
+	WorkerSelector map[string]string
+	// PollInterval controls distributed run status polling.
+	PollInterval time.Duration
+	// MaxStatusErrors is the number of consecutive status failures before Wait fails.
+	MaxStatusErrors int
+}
+
+// TLSOptions configures TLS for coordinator and worker peer clients.
+type TLSOptions struct {
+	Insecure      bool
+	CertFile      string
+	KeyFile       string
+	ClientCAFile  string
+	SkipTLSVerify bool
+}
+
+// RunRef identifies a DAG run.
+type RunRef struct {
+	Name string
+	ID   string
+}
+
+// Status is a stable snapshot of a DAG run.
+type Status struct {
+	Name        string
+	RunID       string
+	AttemptID   string
+	Status      string
+	StartedAt   time.Time
+	FinishedAt  time.Time
+	Error       string
+	LogFile     string
+	ArchiveDir  string
+	WorkerID    string
+	TriggerType string
+}
+
+// WorkerOptions configures an embedded shared-nothing worker.
+type WorkerOptions struct {
+	ID            string
+	MaxActiveRuns int
+	Labels        map[string]string
+	Coordinators  []string
+	TLS           TLSOptions
+	HealthPort    int
+}
+
+// Engine is an embedded Dagu engine backed by the configured file stores.
+type Engine struct {
+	inner *iengine.Engine
+}
+
+// Run is a handle for an asynchronous DAG run.
+type Run struct {
+	inner *iengine.Run
+}
+
+// Worker is a shared-nothing worker connected to configured coordinators.
+type Worker struct {
+	inner *iengine.Worker
+}
+
+// RunOption customizes a single DAG run.
+type RunOption func(*runOptions)
+
+type runOptions struct {
+	runID             string
+	name              string
+	params            map[string]string
+	paramsList        []string
+	defaultWorkingDir string
+	mode              ExecutionMode
+	workerSelector    map[string]string
+	tags              []string
+	dryRun            bool
+}
+
+// New creates an embedded Dagu engine.
+func New(ctx context.Context, opts Options) (*Engine, error) {
+	inner, err := iengine.New(ctx, internalOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return &Engine{inner: inner}, nil
+}
+
+// Close releases engine resources.
+func (e *Engine) Close(ctx context.Context) error {
+	if e == nil || e.inner == nil {
+		return nil
+	}
+	return e.inner.Close(ctx)
+}
+
+// RunFile loads a DAG definition from a file and starts it asynchronously.
+func (e *Engine) RunFile(ctx context.Context, path string, opts ...RunOption) (*Run, error) {
+	if e == nil || e.inner == nil {
+		return nil, fmt.Errorf("engine is not initialized")
+	}
+	runOpts := applyRunOptions(opts)
+	inner, err := e.inner.RunFile(ctx, path, internalRunOptions(runOpts))
+	if err != nil {
+		return nil, err
+	}
+	return &Run{inner: inner}, nil
+}
+
+// RunYAML loads a DAG definition from YAML bytes and starts it asynchronously.
+func (e *Engine) RunYAML(ctx context.Context, yaml []byte, opts ...RunOption) (*Run, error) {
+	if e == nil || e.inner == nil {
+		return nil, fmt.Errorf("engine is not initialized")
+	}
+	runOpts := applyRunOptions(opts)
+	inner, err := e.inner.RunYAML(ctx, yaml, internalRunOptions(runOpts))
+	if err != nil {
+		return nil, err
+	}
+	return &Run{inner: inner}, nil
+}
+
+// Status reads the latest file-backed status for a local DAG run.
+func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
+	if e == nil || e.inner == nil {
+		return nil, fmt.Errorf("engine is not initialized")
+	}
+	status, err := e.inner.Status(ctx, internalRunRef(ref))
+	if err != nil {
+		return nil, err
+	}
+	return publicStatus(status), nil
+}
+
+// Stop requests cancellation for a local DAG run.
+func (e *Engine) Stop(ctx context.Context, ref RunRef) error {
+	if e == nil || e.inner == nil {
+		return fmt.Errorf("engine is not initialized")
+	}
+	return e.inner.Stop(ctx, internalRunRef(ref))
+}
+
+// NewWorker creates an embedded worker for shared-nothing distributed execution.
+func (e *Engine) NewWorker(opts WorkerOptions) (*Worker, error) {
+	if e == nil || e.inner == nil {
+		return nil, fmt.Errorf("engine is not initialized")
+	}
+	inner, err := e.inner.NewWorker(internalWorkerOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+	return &Worker{inner: inner}, nil
+}
+
+// Ref returns the run reference.
+func (r *Run) Ref() RunRef {
+	if r == nil || r.inner == nil {
+		return RunRef{}
+	}
+	return publicRunRef(r.inner.Ref())
+}
+
+// ID returns the DAG run ID.
+func (r *Run) ID() string {
+	if r == nil || r.inner == nil {
+		return ""
+	}
+	return r.inner.ID()
+}
+
+// Name returns the DAG name.
+func (r *Run) Name() string {
+	if r == nil || r.inner == nil {
+		return ""
+	}
+	return r.inner.Name()
+}
+
+// Wait blocks until the DAG run reaches a terminal state or ctx is canceled.
+func (r *Run) Wait(ctx context.Context) (*Status, error) {
+	if r == nil || r.inner == nil {
+		return nil, fmt.Errorf("run is not initialized")
+	}
+	status, err := r.inner.Wait(ctx)
+	if err != nil {
+		return publicStatus(status), err
+	}
+	return publicStatus(status), nil
+}
+
+// Status returns the current run status.
+func (r *Run) Status(ctx context.Context) (*Status, error) {
+	if r == nil || r.inner == nil {
+		return nil, fmt.Errorf("run is not initialized")
+	}
+	status, err := r.inner.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return publicStatus(status), nil
+}
+
+// Stop requests cancellation for this run.
+func (r *Run) Stop(ctx context.Context) error {
+	if r == nil || r.inner == nil {
+		return fmt.Errorf("run is not initialized")
+	}
+	return r.inner.Stop(ctx)
+}
+
+// Start registers and starts the worker. It blocks until ctx is canceled or the
+// worker exits with an error.
+func (w *Worker) Start(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return fmt.Errorf("worker is not initialized")
+	}
+	return w.inner.Start(ctx)
+}
+
+// Stop stops the worker.
+func (w *Worker) Stop(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return nil
+	}
+	return w.inner.Stop(ctx)
+}
+
+func applyRunOptions(opts []RunOption) runOptions {
+	var runOpts runOptions
+	for _, opt := range opts {
+		opt(&runOpts)
+	}
+	return runOpts
+}
+
+// WithRunID sets an explicit DAG run ID.
+func WithRunID(id string) RunOption {
+	return func(o *runOptions) {
+		o.runID = id
+	}
+}
+
+// WithName overrides the loaded DAG name.
+func WithName(name string) RunOption {
+	return func(o *runOptions) {
+		o.name = name
+	}
+}
+
+// WithParams sets DAG parameters from a key-value map.
+func WithParams(params map[string]string) RunOption {
+	return func(o *runOptions) {
+		o.params = cloneMap(params)
+	}
+}
+
+// WithParamsList sets DAG parameters from Dagu-style KEY=VALUE entries.
+func WithParamsList(params []string) RunOption {
+	return func(o *runOptions) {
+		o.paramsList = append([]string{}, params...)
+	}
+}
+
+// WithDefaultWorkingDir sets the default working directory while loading a DAG.
+func WithDefaultWorkingDir(dir string) RunOption {
+	return func(o *runOptions) {
+		o.defaultWorkingDir = dir
+	}
+}
+
+// WithMode overrides the engine default execution mode.
+func WithMode(mode ExecutionMode) RunOption {
+	return func(o *runOptions) {
+		o.mode = mode
+	}
+}
+
+// WithWorkerSelector sets the distributed worker selector for one run.
+func WithWorkerSelector(selector map[string]string) RunOption {
+	return func(o *runOptions) {
+		o.workerSelector = cloneMap(selector)
+	}
+}
+
+// WithTags adds tags to one run.
+func WithTags(tags ...string) RunOption {
+	return func(o *runOptions) {
+		o.tags = append([]string{}, tags...)
+	}
+}
+
+// WithDryRun enables or disables dry-run mode.
+func WithDryRun(enabled bool) RunOption {
+	return func(o *runOptions) {
+		o.dryRun = enabled
+	}
+}
+
+func internalOptions(opts Options) iengine.Options {
+	out := iengine.Options{
+		HomeDir:     opts.HomeDir,
+		ConfigFile:  opts.ConfigFile,
+		DAGsDir:     opts.DAGsDir,
+		DataDir:     opts.DataDir,
+		LogDir:      opts.LogDir,
+		ArtifactDir: opts.ArtifactDir,
+		BaseConfig:  opts.BaseConfig,
+		Logger:      opts.Logger,
+		DefaultMode: iengine.ExecutionMode(opts.DefaultMode),
+	}
+	if opts.Distributed != nil {
+		distributed := internalDistributedOptions(*opts.Distributed)
+		out.Distributed = &distributed
+	}
+	return out
+}
+
+func internalDistributedOptions(opts DistributedOptions) iengine.DistributedOptions {
+	return iengine.DistributedOptions{
+		Coordinators:    append([]string{}, opts.Coordinators...),
+		TLS:             internalTLSOptions(opts.TLS),
+		WorkerSelector:  cloneMap(opts.WorkerSelector),
+		PollInterval:    opts.PollInterval,
+		MaxStatusErrors: opts.MaxStatusErrors,
+	}
+}
+
+func internalTLSOptions(opts TLSOptions) iengine.TLSOptions {
+	return iengine.TLSOptions{
+		Insecure:      opts.Insecure,
+		CertFile:      opts.CertFile,
+		KeyFile:       opts.KeyFile,
+		ClientCAFile:  opts.ClientCAFile,
+		SkipTLSVerify: opts.SkipTLSVerify,
+	}
+}
+
+func internalRunOptions(opts runOptions) iengine.RunOptions {
+	return iengine.RunOptions{
+		RunID:             opts.runID,
+		Name:              opts.name,
+		Params:            cloneMap(opts.params),
+		ParamsList:        append([]string{}, opts.paramsList...),
+		DefaultWorkingDir: opts.defaultWorkingDir,
+		Mode:              iengine.ExecutionMode(opts.mode),
+		WorkerSelector:    cloneMap(opts.workerSelector),
+		Tags:              append([]string{}, opts.tags...),
+		DryRun:            opts.dryRun,
+	}
+}
+
+func internalRunRef(ref RunRef) iengine.RunRef {
+	return iengine.RunRef{Name: ref.Name, ID: ref.ID}
+}
+
+func publicRunRef(ref iengine.RunRef) RunRef {
+	return RunRef{Name: ref.Name, ID: ref.ID}
+}
+
+func internalWorkerOptions(opts WorkerOptions) iengine.WorkerOptions {
+	return iengine.WorkerOptions{
+		ID:            opts.ID,
+		MaxActiveRuns: opts.MaxActiveRuns,
+		Labels:        cloneMap(opts.Labels),
+		Coordinators:  append([]string{}, opts.Coordinators...),
+		TLS:           internalTLSOptions(opts.TLS),
+		HealthPort:    opts.HealthPort,
+	}
+}
+
+func publicStatus(status *iengine.Status) *Status {
+	if status == nil {
+		return nil
+	}
+	return &Status{
+		Name:        status.Name,
+		RunID:       status.RunID,
+		AttemptID:   status.AttemptID,
+		Status:      status.Status,
+		StartedAt:   status.StartedAt,
+		FinishedAt:  status.FinishedAt,
+		Error:       status.Error,
+		LogFile:     status.LogFile,
+		ArchiveDir:  status.ArchiveDir,
+		WorkerID:    status.WorkerID,
+		TriggerType: status.TriggerType,
+	}
+}
+
+func cloneMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -60,6 +60,11 @@ func TestEngineRunYAML(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
+	originalWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -88,6 +93,13 @@ steps:
 	}
 	if status.Name != "embedded-yaml" {
 		t.Fatalf("name = %q, want embedded-yaml", status.Name)
+	}
+	currentWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() after run error = %v", err)
+	}
+	if currentWorkingDir != originalWorkingDir {
+		t.Fatalf("working directory = %q, want %q", currentWorkingDir, originalWorkingDir)
 	}
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -5,13 +5,16 @@ package dagu_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dagucloud/dagu"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEngineRunFile(t *testing.T) {
@@ -20,40 +23,30 @@ func TestEngineRunFile(t *testing.T) {
 
 	home := t.TempDir()
 	dagFile := filepath.Join(home, "embedded-file.yaml")
-	writeDAG(t, dagFile, `
+	checkParamCommand := `test "$FOO" = "bar"`
+	if runtime.GOOS == "windows" {
+		checkParamCommand = `cmd /C if "%FOO%"=="bar" (exit /b 0) else (exit /b 1)`
+	}
+	writeDAG(t, dagFile, fmt.Sprintf(`
 name: embedded-file
 steps:
   - name: check-param
-    command: test "$FOO" = "bar"
-`)
+    command: %q
+`, checkParamCommand))
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: home})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	require.NoError(t, err, "New()")
 	defer func() {
-		if err := engine.Close(context.Background()); err != nil {
-			t.Fatalf("Close() error = %v", err)
-		}
+		require.NoError(t, engine.Close(context.Background()))
 	}()
 
 	run, err := engine.RunFile(ctx, dagFile, dagu.WithParams(map[string]string{"FOO": "bar"}))
-	if err != nil {
-		t.Fatalf("RunFile() error = %v", err)
-	}
+	require.NoError(t, err, "RunFile()")
 	status, err := run.Wait(ctx)
-	if err != nil {
-		t.Fatalf("Wait() error = %v", err)
-	}
-	if status.Status != "succeeded" {
-		t.Fatalf("status = %q, want succeeded", status.Status)
-	}
-	if status.Name != "embedded-file" {
-		t.Fatalf("name = %q, want embedded-file", status.Name)
-	}
-	if status.RunID == "" {
-		t.Fatal("run ID is empty")
-	}
+	require.NoError(t, err, "Wait()")
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-file", status.Name)
+	require.NotEmpty(t, status.RunID)
 }
 
 func TestEngineRunYAML(t *testing.T) {
@@ -61,18 +54,12 @@ func TestEngineRunYAML(t *testing.T) {
 	defer cancel()
 
 	originalWorkingDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() error = %v", err)
-	}
+	require.NoError(t, err, "Getwd()")
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	require.NoError(t, err, "New()")
 	defer func() {
-		if err := engine.Close(context.Background()); err != nil {
-			t.Fatalf("Close() error = %v", err)
-		}
+		require.NoError(t, engine.Close(context.Background()))
 	}()
 
 	run, err := engine.RunYAML(ctx, []byte(`
@@ -81,26 +68,14 @@ steps:
   - name: hello
     command: echo hello
 `))
-	if err != nil {
-		t.Fatalf("RunYAML() error = %v", err)
-	}
+	require.NoError(t, err, "RunYAML()")
 	status, err := run.Wait(ctx)
-	if err != nil {
-		t.Fatalf("Wait() error = %v", err)
-	}
-	if status.Status != "succeeded" {
-		t.Fatalf("status = %q, want succeeded", status.Status)
-	}
-	if status.Name != "embedded-yaml" {
-		t.Fatalf("name = %q, want embedded-yaml", status.Name)
-	}
+	require.NoError(t, err, "Wait()")
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-yaml", status.Name)
 	currentWorkingDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd() after run error = %v", err)
-	}
-	if currentWorkingDir != originalWorkingDir {
-		t.Fatalf("working directory = %q, want %q", currentWorkingDir, originalWorkingDir)
-	}
+	require.NoError(t, err, "Getwd() after run")
+	require.Equal(t, originalWorkingDir, currentWorkingDir)
 }
 
 func TestEngineDistributedRequiresCoordinator(t *testing.T) {
@@ -108,13 +83,9 @@ func TestEngineDistributedRequiresCoordinator(t *testing.T) {
 	defer cancel()
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	require.NoError(t, err, "New()")
 	defer func() {
-		if err := engine.Close(context.Background()); err != nil {
-			t.Fatalf("Close() error = %v", err)
-		}
+		require.NoError(t, engine.Close(context.Background()))
 	}()
 
 	_, err = engine.RunYAML(ctx, []byte(`
@@ -123,12 +94,8 @@ steps:
   - name: hello
     command: echo hello
 `), dagu.WithMode(dagu.ExecutionModeDistributed))
-	if err == nil {
-		t.Fatal("RunYAML() error = nil, want coordinator error")
-	}
-	if !strings.Contains(err.Error(), "coordinator") {
-		t.Fatalf("RunYAML() error = %v, want coordinator error", err)
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "coordinator")
 }
 
 func writeDAG(t *testing.T, path, content string) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -24,15 +24,18 @@ func TestEngineRunFile(t *testing.T) {
 	home := t.TempDir()
 	dagFile := filepath.Join(home, "embedded-file.yaml")
 	checkParamCommand := `test "$FOO" = "bar"`
+	checkParamShell := ""
 	if runtime.GOOS == "windows" {
-		checkParamCommand = `cmd /C if "%FOO%"=="bar" (exit /b 0) else (exit /b 1)`
+		checkParamCommand = `if ($env:FOO -ne "bar") { exit 1 }`
+		checkParamShell = `
+    shell: powershell`
 	}
 	writeDAG(t, dagFile, fmt.Sprintf(`
 name: embedded-file
 steps:
   - name: check-param
-    command: %q
-`, checkParamCommand))
+    command: %q%s
+`, checkParamCommand, checkParamShell))
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: home})
 	require.NoError(t, err, "New()")

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagu_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu"
+)
+
+func TestEngineRunFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	home := t.TempDir()
+	dagFile := filepath.Join(home, "embedded-file.yaml")
+	writeDAG(t, dagFile, `
+name: embedded-file
+steps:
+  - name: check-param
+    command: test "$FOO" = "bar"
+`)
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: home})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
+
+	run, err := engine.RunFile(ctx, dagFile, dagu.WithParams(map[string]string{"FOO": "bar"}))
+	if err != nil {
+		t.Fatalf("RunFile() error = %v", err)
+	}
+	status, err := run.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if status.Status != "succeeded" {
+		t.Fatalf("status = %q, want succeeded", status.Status)
+	}
+	if status.Name != "embedded-file" {
+		t.Fatalf("name = %q, want embedded-file", status.Name)
+	}
+	if status.RunID == "" {
+		t.Fatal("run ID is empty")
+	}
+}
+
+func TestEngineRunYAML(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
+
+	run, err := engine.RunYAML(ctx, []byte(`
+name: embedded-yaml
+steps:
+  - name: hello
+    command: echo hello
+`))
+	if err != nil {
+		t.Fatalf("RunYAML() error = %v", err)
+	}
+	status, err := run.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if status.Status != "succeeded" {
+		t.Fatalf("status = %q, want succeeded", status.Status)
+	}
+	if status.Name != "embedded-yaml" {
+		t.Fatalf("name = %q, want embedded-yaml", status.Name)
+	}
+}
+
+func TestEngineDistributedRequiresCoordinator(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
+
+	_, err = engine.RunYAML(ctx, []byte(`
+name: embedded-distributed
+steps:
+  - name: hello
+    command: echo hello
+`), dagu.WithMode(dagu.ExecutionModeDistributed))
+	if err == nil {
+		t.Fatal("RunYAML() error = nil, want coordinator error")
+	}
+	if !strings.Contains(err.Error(), "coordinator") {
+		t.Fatalf("RunYAML() error = %v, want coordinator error", err)
+	}
+}
+
+func writeDAG(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		t.Fatalf("write DAG: %v", err)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagu_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/dagucloud/dagu"
+)
+
+func Example() {
+	ctx := context.Background()
+
+	engine, err := dagu.New(ctx, dagu.Options{
+		HomeDir: "/var/lib/myapp/dagu",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	run, err := engine.RunYAML(ctx, []byte(`
+name: embedded
+steps:
+  - name: hello
+    command: echo "$MESSAGE"
+`), dagu.WithParams(map[string]string{"MESSAGE": "hello"}))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	status, err := run.Wait(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = status
+}
+
+func Example_distributed() {
+	ctx := context.Background()
+
+	engine, err := dagu.New(ctx, dagu.Options{
+		HomeDir:     "/var/lib/myapp/dagu-worker",
+		DefaultMode: dagu.ExecutionModeDistributed,
+		Distributed: &dagu.DistributedOptions{
+			Coordinators: []string{"127.0.0.1:50055"},
+			WorkerSelector: map[string]string{
+				"pool": "default",
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	worker, err := engine.NewWorker(dagu.WorkerOptions{
+		Labels: map[string]string{"pool": "default"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	workerCtx, stopWorker := context.WithCancel(ctx)
+	defer stopWorker()
+	go func() {
+		if err := worker.Start(workerCtx); err != nil {
+			log.Print(err)
+		}
+	}()
+
+	run, err := engine.RunFile(ctx, "daily-report.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	status, err := run.Wait(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = status
+}

--- a/example_test.go
+++ b/example_test.go
@@ -50,6 +50,7 @@ func Example_distributed() {
 		DefaultMode: dagu.ExecutionModeDistributed,
 		Distributed: &dagu.DistributedOptions{
 			Coordinators: []string{"127.0.0.1:50055"},
+			TLS:          dagu.TLSOptions{Insecure: true},
 			WorkerSelector: map[string]string{
 				"pool": "default",
 			},
@@ -78,6 +79,9 @@ func Example_distributed() {
 			log.Print(err)
 		}
 	}()
+	if err := worker.WaitReady(ctx); err != nil {
+		log.Fatal(err)
+	}
 
 	run, err := engine.RunFile(ctx, "daily-report.yaml")
 	if err != nil {

--- a/examples/embedded/README.md
+++ b/examples/embedded/README.md
@@ -43,5 +43,5 @@ DAGU_COORDINATORS=127.0.0.1:50055 go run ./examples/embedded/distributed
 
 The example starts an embedded worker and dispatches a DAG through the
 coordinator. Set `DAGU_COORDINATORS` to a comma-separated list when using more
-than one coordinator.
-
+than one coordinator. The sample opts into plaintext coordinator transport for
+local development; production embedders should provide TLS files instead.

--- a/examples/embedded/README.md
+++ b/examples/embedded/README.md
@@ -1,0 +1,47 @@
+# Embedded Dagu Examples
+
+These examples show how another Go application can import Dagu as a library:
+
+```go
+import "github.com/dagucloud/dagu"
+```
+
+The embedded API is experimental. It is intended for applications that want to
+run Dagu DAGs in-process or dispatch them to existing Dagu coordinators while
+keeping Dagu's CLI and server behavior unchanged.
+
+## Local Execution
+
+Run a DAG in the current process with file-backed state:
+
+```sh
+go run ./examples/embedded/local
+```
+
+The example creates a temporary Dagu home directory, loads
+`examples/embedded/local/workflow.yaml`, passes parameters, waits for completion,
+and prints the final status.
+
+## Custom Executor
+
+Register a process-local executor and use it from DAG YAML:
+
+```sh
+go run ./examples/embedded/custom-executor
+```
+
+This is useful when the embedding application already has domain-specific Go
+code and wants DAG steps to call that code without shelling out.
+
+## Shared-Nothing Distributed Execution
+
+Run against an existing Dagu coordinator:
+
+```sh
+DAGU_COORDINATORS=127.0.0.1:50055 go run ./examples/embedded/distributed
+```
+
+The example starts an embedded worker and dispatches a DAG through the
+coordinator. Set `DAGU_COORDINATORS` to a comma-separated list when using more
+than one coordinator.
+

--- a/examples/embedded/custom-executor/main.go
+++ b/examples/embedded/custom-executor/main.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/dagucloud/dagu"
+)
+
+func main() {
+	dagu.RegisterExecutor(
+		"embedded_echo",
+		func(_ context.Context, step dagu.Step) (dagu.Executor, error) {
+			return &embeddedEchoExecutor{step: step}, nil
+		},
+		dagu.WithExecutorCapabilities(dagu.ExecutorCapabilities{Command: true}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	homeDir, err := os.MkdirTemp("", "dagu-embedded-custom-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(homeDir); err != nil {
+			log.Printf("remove temp home: %v", err)
+		}
+	}()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: homeDir})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			log.Printf("close engine: %v", err)
+		}
+	}()
+
+	run, err := engine.RunFile(ctx, examplePath("workflow.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	status, err := run.Wait(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s finished with %s\n", status.Name, status.Status)
+}
+
+type embeddedEchoExecutor struct {
+	step   dagu.Step
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (e *embeddedEchoExecutor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *embeddedEchoExecutor) SetStderr(out io.Writer) {
+	e.stderr = out
+}
+
+func (e *embeddedEchoExecutor) Kill(os.Signal) error {
+	return nil
+}
+
+func (e *embeddedEchoExecutor) Run(context.Context) error {
+	out := e.stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	command := e.step.Command
+	if command == "" && len(e.step.Commands) > 0 {
+		command = e.step.Commands[0].CmdWithArgs
+	}
+	_, err := fmt.Fprintf(out, "custom executor handled step %q with command %q\n", e.step.Name, command)
+	return err
+}
+
+func examplePath(name string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("resolve example path")
+	}
+	return filepath.Join(filepath.Dir(file), name)
+}

--- a/examples/embedded/custom-executor/workflow.yaml
+++ b/examples/embedded/custom-executor/workflow.yaml
@@ -1,0 +1,7 @@
+name: embedded-custom-executor-example
+type: graph
+steps:
+  - name: call-go-code
+    type: embedded_echo
+    command: domain operation from DAG YAML
+

--- a/examples/embedded/distributed/main.go
+++ b/examples/embedded/distributed/main.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu"
+)
+
+func main() {
+	coordinators := coordinatorAddrs()
+	if len(coordinators) == 0 {
+		log.Fatal("set DAGU_COORDINATORS, for example: DAGU_COORDINATORS=127.0.0.1:50055")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	homeDir, err := os.MkdirTemp("", "dagu-embedded-distributed-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(homeDir); err != nil {
+			log.Printf("remove temp home: %v", err)
+		}
+	}()
+
+	engine, err := dagu.New(ctx, dagu.Options{
+		HomeDir:     homeDir,
+		DefaultMode: dagu.ExecutionModeDistributed,
+		Distributed: &dagu.DistributedOptions{
+			Coordinators:   coordinators,
+			PollInterval:   time.Second,
+			WorkerSelector: map[string]string{"pool": "embedded-example"},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			log.Printf("close engine: %v", err)
+		}
+	}()
+
+	worker, err := engine.NewWorker(dagu.WorkerOptions{
+		ID:            "embedded-example-worker",
+		MaxActiveRuns: 4,
+		Labels:        map[string]string{"pool": "embedded-example"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	workerCtx, stopWorker := context.WithCancel(ctx)
+	defer stopWorker()
+	go func() {
+		if err := worker.Start(workerCtx); err != nil && !errors.Is(err, context.Canceled) {
+			log.Printf("worker stopped: %v", err)
+		}
+	}()
+
+	run, err := engine.RunFile(ctx, examplePath("workflow.yaml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	status, err := run.Wait(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s %s finished with %s on worker %s\n", status.Name, status.RunID, status.Status, status.WorkerID)
+}
+
+func coordinatorAddrs() []string {
+	value := os.Getenv("DAGU_COORDINATORS")
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if addr := strings.TrimSpace(part); addr != "" {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func examplePath(name string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("resolve example path")
+	}
+	return filepath.Join(filepath.Dir(file), name)
+}

--- a/examples/embedded/distributed/main.go
+++ b/examples/embedded/distributed/main.go
@@ -41,6 +41,7 @@ func main() {
 		DefaultMode: dagu.ExecutionModeDistributed,
 		Distributed: &dagu.DistributedOptions{
 			Coordinators:   coordinators,
+			TLS:            dagu.TLSOptions{Insecure: true},
 			PollInterval:   time.Second,
 			WorkerSelector: map[string]string{"pool": "embedded-example"},
 		},
@@ -70,6 +71,9 @@ func main() {
 			log.Printf("worker stopped: %v", err)
 		}
 	}()
+	if err := worker.WaitReady(ctx); err != nil {
+		log.Fatal(err)
+	}
 
 	run, err := engine.RunFile(ctx, examplePath("workflow.yaml"))
 	if err != nil {

--- a/examples/embedded/distributed/workflow.yaml
+++ b/examples/embedded/distributed/workflow.yaml
@@ -1,0 +1,9 @@
+name: embedded-distributed-example
+type: graph
+steps:
+  - name: worker-host
+    command: hostname
+  - name: finish
+    command: echo "distributed embedded run complete"
+    depends: [worker-host]
+

--- a/examples/embedded/local/main.go
+++ b/examples/embedded/local/main.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/dagucloud/dagu"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	homeDir, err := os.MkdirTemp("", "dagu-embedded-local-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(homeDir); err != nil {
+			log.Printf("remove temp home: %v", err)
+		}
+	}()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: homeDir})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := engine.Close(context.Background()); err != nil {
+			log.Printf("close engine: %v", err)
+		}
+	}()
+
+	run, err := engine.RunFile(ctx, examplePath("workflow.yaml"),
+		dagu.WithParams(map[string]string{
+			"TARGET": "embedded Dagu",
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	status, err := run.Wait(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s %s finished with %s\n", status.Name, status.RunID, status.Status)
+}
+
+func examplePath(name string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("resolve example path")
+	}
+	return filepath.Join(filepath.Dir(file), name)
+}

--- a/examples/embedded/local/workflow.yaml
+++ b/examples/embedded/local/workflow.yaml
@@ -1,0 +1,9 @@
+name: embedded-local-example
+type: graph
+steps:
+  - name: greet
+    command: echo "hello ${TARGET}"
+  - name: finish
+    command: echo "local embedded run complete"
+    depends: [greet]
+

--- a/examples/embedded/local/workflow.yaml
+++ b/examples/embedded/local/workflow.yaml
@@ -1,9 +1,11 @@
 name: embedded-local-example
 type: graph
+params:
+  - TARGET
 steps:
   - name: greet
+    # Dagu resolves ${TARGET} from run parameters before the shell sees it.
     command: echo "hello ${TARGET}"
   - name: finish
     command: echo "local embedded run complete"
     depends: [greet]
-

--- a/executor.go
+++ b/executor.go
@@ -5,26 +5,51 @@ package dagu
 
 import (
 	"context"
+	"strings"
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 )
 
+// Step is the public alias for a Dagu step passed to custom executors.
 type Step = core.Step
+
+// Executor is implemented by custom step executors.
 type Executor = runtimeexec.Executor
+
+// ExecutorFactory creates an Executor for a loaded step.
 type ExecutorFactory func(context.Context, Step) (Executor, error)
+
+// StepValidator validates custom executor step configuration during DAG loading.
 type StepValidator = core.StepValidator
+
+// ExecutorCapabilities declares which step fields a custom executor supports.
 type ExecutorCapabilities = core.ExecutorCapabilities
 
+// ExecutorOption customizes custom executor registration.
 type ExecutorOption func(*executorRegistration)
 
+// executorRegistration holds optional custom executor metadata.
 type executorRegistration struct {
 	validator StepValidator
 	caps      ExecutorCapabilities
 }
 
+// RegisterExecutor registers a custom executor type before engine or runtime use.
+// It panics when name is empty, invalid, or factory is nil. Registration mutates
+// global process state and must be completed before concurrent DAG execution.
 func RegisterExecutor(name string, factory ExecutorFactory, opts ...ExecutorOption) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		panic("dagu: RegisterExecutor called with empty name")
+	}
+	if !spec.IsValidExecutorTypeName(name) {
+		panic("dagu: RegisterExecutor called with invalid name " + name)
+	}
+	if factory == nil {
+		panic("dagu: RegisterExecutor called with nil factory")
+	}
 	var registration executorRegistration
 	for _, opt := range opts {
 		opt(&registration)
@@ -38,12 +63,27 @@ func RegisterExecutor(name string, factory ExecutorFactory, opts ...ExecutorOpti
 	spec.RegisterExecutorTypeName(name)
 }
 
+// UnregisterExecutor removes a custom executor type registered by RegisterExecutor.
+// It is intended for tests and should not run concurrently with engine use.
+func UnregisterExecutor(name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	runtimeexec.UnregisterExecutor(name)
+	core.UnregisterStepValidator(name)
+	core.UnregisterExecutorCapabilities(name)
+	spec.UnregisterExecutorTypeName(name)
+}
+
+// WithStepValidator registers a validation function for the custom executor.
 func WithStepValidator(validator StepValidator) ExecutorOption {
 	return func(r *executorRegistration) {
 		r.validator = validator
 	}
 }
 
+// WithExecutorCapabilities registers supported step fields for the custom executor.
 func WithExecutorCapabilities(caps ExecutorCapabilities) ExecutorOption {
 	return func(r *executorRegistration) {
 		r.caps = caps

--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagu
+
+import (
+	"context"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+)
+
+type Step = core.Step
+type Executor = runtimeexec.Executor
+type ExecutorFactory func(context.Context, Step) (Executor, error)
+type StepValidator = core.StepValidator
+type ExecutorCapabilities = core.ExecutorCapabilities
+
+type ExecutorOption func(*executorRegistration)
+
+type executorRegistration struct {
+	validator StepValidator
+	caps      ExecutorCapabilities
+}
+
+func RegisterExecutor(name string, factory ExecutorFactory, opts ...ExecutorOption) {
+	var registration executorRegistration
+	for _, opt := range opts {
+		opt(&registration)
+	}
+	runtimeexec.RegisterExecutor(
+		name,
+		runtimeexec.ExecutorFactory(factory),
+		registration.validator,
+		registration.caps,
+	)
+	spec.RegisterExecutorTypeName(name)
+}
+
+func WithStepValidator(validator StepValidator) ExecutorOption {
+	return func(r *executorRegistration) {
+		r.validator = validator
+	}
+}
+
+func WithExecutorCapabilities(caps ExecutorCapabilities) ExecutorOption {
+	return func(r *executorRegistration) {
+		r.caps = caps
+	}
+}

--- a/internal/core/capabilities.go
+++ b/internal/core/capabilities.go
@@ -52,6 +52,13 @@ func (r *executorCapabilitiesRegistry) Register(executorType string, caps Execut
 	r.caps[executorType] = caps
 }
 
+// Unregister removes capabilities for an executor type.
+func (r *executorCapabilitiesRegistry) Unregister(executorType string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.caps, executorType)
+}
+
 // Get returns capabilities for an executor type.
 // Returns an empty ExecutorCapabilities if not registered.
 func (r *executorCapabilitiesRegistry) Get(executorType string) ExecutorCapabilities {
@@ -67,6 +74,11 @@ func (r *executorCapabilitiesRegistry) Get(executorType string) ExecutorCapabili
 // RegisterExecutorCapabilities registers capabilities for an executor type.
 func RegisterExecutorCapabilities(executorType string, caps ExecutorCapabilities) {
 	executorCapabilities.Register(executorType, caps)
+}
+
+// UnregisterExecutorCapabilities removes capabilities for an executor type.
+func UnregisterExecutorCapabilities(executorType string) {
+	executorCapabilities.Unregister(executorType)
 }
 
 // SupportsCommand returns whether the executor type supports the command field.

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -83,18 +83,44 @@ var builtinStepTypeNames = map[string]struct{}{
 	"template":      {},
 }
 
+var registeredExecutorTypeNames = map[string]struct{}{}
+
 var stepTypeNamesMu sync.RWMutex
+
+// IsValidExecutorTypeName reports whether name is valid for an executor type.
+func IsValidExecutorTypeName(name string) bool {
+	return customStepTypeNameRegexp.MatchString(strings.TrimSpace(name))
+}
 
 // RegisterExecutorTypeName registers a runtime executor type name so DAG
 // loading accepts steps that use it directly in the type field.
 func RegisterExecutorTypeName(name string) {
+	name = strings.TrimSpace(name)
+	if !IsValidExecutorTypeName(name) {
+		return
+	}
+	stepTypeNamesMu.Lock()
+	defer stepTypeNamesMu.Unlock()
+	if _, builtin := builtinStepTypeNames[name]; !builtin {
+		registeredExecutorTypeNames[name] = struct{}{}
+	}
+	builtinStepTypeNames[name] = struct{}{}
+}
+
+// UnregisterExecutorTypeName removes a runtime executor type name that was
+// registered by RegisterExecutorTypeName. Built-in names are retained.
+func UnregisterExecutorTypeName(name string) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return
 	}
 	stepTypeNamesMu.Lock()
 	defer stepTypeNamesMu.Unlock()
-	builtinStepTypeNames[name] = struct{}{}
+	if _, registered := registeredExecutorTypeNames[name]; !registered {
+		return
+	}
+	delete(registeredExecutorTypeNames, name)
+	delete(builtinStepTypeNames, name)
 }
 
 var customStepForbiddenCallSiteFields = map[string]struct{}{

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	gotemplate "text/template"
 
 	"github.com/dagucloud/dagu/internal/core"
@@ -80,6 +81,20 @@ var builtinStepTypeNames = map[string]struct{}{
 	"ssh":           {},
 	"subworkflow":   {},
 	"template":      {},
+}
+
+var stepTypeNamesMu sync.RWMutex
+
+// RegisterExecutorTypeName registers a runtime executor type name so DAG
+// loading accepts steps that use it directly in the type field.
+func RegisterExecutorTypeName(name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	stepTypeNamesMu.Lock()
+	defer stepTypeNamesMu.Unlock()
+	builtinStepTypeNames[name] = struct{}{}
 }
 
 var customStepForbiddenCallSiteFields = map[string]struct{}{
@@ -270,6 +285,8 @@ func schemaDeclaresObject(root *jsonschema.Schema) bool {
 }
 
 func isBuiltinStepTypeName(name string) bool {
+	stepTypeNamesMu.RLock()
+	defer stepTypeNamesMu.RUnlock()
 	_, ok := builtinStepTypeNames[strings.TrimSpace(name)]
 	return ok
 }

--- a/internal/core/validator.go
+++ b/internal/core/validator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // Constants for validation limits.
@@ -58,9 +59,20 @@ type StepValidator func(step Step) error
 // stepValidators holds registered validators for each executor type.
 var stepValidators = make(map[string]StepValidator)
 
+var stepValidatorsMu sync.RWMutex
+
 // RegisterStepValidator registers a validator for a specific executor type.
 func RegisterStepValidator(executorType string, validator StepValidator) {
+	stepValidatorsMu.Lock()
+	defer stepValidatorsMu.Unlock()
 	stepValidators[executorType] = validator
+}
+
+// UnregisterStepValidator removes a validator for a specific executor type.
+func UnregisterStepValidator(executorType string) {
+	stepValidatorsMu.Lock()
+	defer stepValidatorsMu.Unlock()
+	delete(stepValidators, executorType)
 }
 
 // ValidateSteps validates all steps in a DAG, collecting all validation errors.
@@ -213,7 +225,7 @@ func validateParallelConfig(step Step) ErrorList {
 }
 
 func validateStepWithValidator(step Step) error {
-	validator := stepValidators[step.ExecutorConfig.Type]
+	validator := stepValidator(step.ExecutorConfig.Type)
 	if validator == nil {
 		return nil
 	}
@@ -221,6 +233,12 @@ func validateStepWithValidator(step Step) error {
 		return NewValidationError("executor_config", step.ExecutorConfig, err)
 	}
 	return nil
+}
+
+func stepValidator(executorType string) StepValidator {
+	stepValidatorsMu.RLock()
+	defer stepValidatorsMu.RUnlock()
+	return stepValidators[executorType]
 }
 
 func isValidStepID(id string) bool {

--- a/internal/core/validator_test.go
+++ b/internal/core/validator_test.go
@@ -431,7 +431,7 @@ func TestRegisterStepValidator(t *testing.T) {
 
 	t.Run("register validator for new type", func(t *testing.T) {
 		// Clean up after test
-		defer delete(stepValidators, "test-executor")
+		defer UnregisterStepValidator("test-executor")
 
 		validatorCalled := false
 		validator := func(_ Step) error {
@@ -457,7 +457,7 @@ func TestRegisterStepValidator(t *testing.T) {
 	})
 
 	t.Run("validator returning error propagates", func(t *testing.T) {
-		defer delete(stepValidators, "error-executor")
+		defer UnregisterStepValidator("error-executor")
 
 		expectedErr := errors.New("validation failed")
 		validator := func(_ Step) error {
@@ -481,7 +481,7 @@ func TestRegisterStepValidator(t *testing.T) {
 	})
 
 	t.Run("overwrite existing validator", func(t *testing.T) {
-		defer delete(stepValidators, "overwrite-executor")
+		defer UnregisterStepValidator("overwrite-executor")
 
 		firstCalled := false
 		secondCalled := false
@@ -682,8 +682,8 @@ func TestValidateStepWithValidator(t *testing.T) {
 	})
 
 	t.Run("nil validator returns nil", func(t *testing.T) {
-		defer delete(stepValidators, "nil-validator-type")
-		stepValidators["nil-validator-type"] = nil
+		defer UnregisterStepValidator("nil-validator-type")
+		RegisterStepValidator("nil-validator-type", nil)
 
 		step := Step{
 			Name:           "step1",
@@ -693,12 +693,12 @@ func TestValidateStepWithValidator(t *testing.T) {
 	})
 
 	t.Run("validator error is wrapped", func(t *testing.T) {
-		defer delete(stepValidators, "wrap-error-type")
+		defer UnregisterStepValidator("wrap-error-type")
 
 		customErr := errors.New("custom validation error")
-		stepValidators["wrap-error-type"] = func(_ Step) error {
+		RegisterStepValidator("wrap-error-type", func(_ Step) error {
 			return customErr
-		}
+		})
 
 		step := Step{
 			Name:           "step1",

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -214,7 +214,7 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 	cfg.KeyFile = opts.TLS.KeyFile
 	cfg.SkipTLSVerify = opts.TLS.SkipTLSVerify
 	cfg.Insecure = opts.TLS.Insecure
-	if cfg.Insecure == false && cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == "" && !cfg.SkipTLSVerify {
+	if !cfg.Insecure && cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == "" && !cfg.SkipTLSVerify {
 		cfg.Insecure = true
 	}
 	if err := cfg.Validate(); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -214,8 +214,9 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 	cfg.KeyFile = opts.TLS.KeyFile
 	cfg.SkipTLSVerify = opts.TLS.SkipTLSVerify
 	cfg.Insecure = opts.TLS.Insecure
-	if !cfg.Insecure && cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == "" && !cfg.SkipTLSVerify {
-		cfg.Insecure = true
+	noTLSMaterial := cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == ""
+	if !cfg.Insecure && !cfg.SkipTLSVerify && noTLSMaterial {
+		return nil, fmt.Errorf("coordinator TLS is not configured; provide TLS files or set TLS.Insecure=true for plaintext coordinator connections")
 	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,274 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/filedag"
+	"github.com/dagucloud/dagu/internal/persis/filedagrun"
+	"github.com/dagucloud/dagu/internal/persis/fileproc"
+	"github.com/dagucloud/dagu/internal/persis/fileserviceregistry"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/spf13/viper"
+)
+
+type Engine struct {
+	cfg             *config.Config
+	dagRunStore     coreexec.DAGRunStore
+	procStore       coreexec.ProcStore
+	serviceRegistry coreexec.ServiceRegistry
+	dagStore        coreexec.DAGStore
+	dagRunMgr       runtime.Manager
+	defaultMode     ExecutionMode
+	distributed     DistributedOptions
+	logger          logger.Logger
+}
+
+func New(ctx context.Context, opts Options) (*Engine, error) {
+	cfg, err := loadConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	applyOptions(cfg, opts)
+
+	log := logger.NewLogger(logger.WithQuiet())
+	if opts.Logger != nil {
+		log = newSlogAdapter(opts.Logger)
+	}
+	ctx = logger.WithLogger(config.WithConfig(ctx, cfg), log)
+
+	if err := os.MkdirAll(cfg.Paths.DataDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create data directory: %w", err)
+	}
+	if err := os.MkdirAll(cfg.Paths.LogDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
+	}
+	if err := os.MkdirAll(cfg.Paths.ArtifactDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create artifact directory: %w", err)
+	}
+
+	procStore := fileproc.New(
+		cfg.Paths.ProcDir,
+		fileproc.WithStaleThreshold(cfg.Proc.StaleThreshold),
+		fileproc.WithHeartbeatInterval(cfg.Proc.HeartbeatInterval),
+		fileproc.WithHeartbeatSyncInterval(cfg.Proc.HeartbeatSyncInterval),
+	)
+	if err := procStore.Validate(ctx); err != nil {
+		return nil, err
+	}
+
+	dagRunStore := filedagrun.New(
+		cfg.Paths.DAGRunsDir,
+		filedagrun.WithArtifactDir(cfg.Paths.ArtifactDir),
+		filedagrun.WithLatestStatusToday(false),
+		filedagrun.WithLocation(cfg.Core.Location),
+	)
+	serviceRegistry := fileserviceregistry.New(cfg.Paths.ServiceRegistryDir)
+	dagRunMgr := runtime.NewManager(dagRunStore, procStore, cfg)
+
+	dagStore, err := newDAGStore(cfg, nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	mode := opts.DefaultMode
+	if mode == "" {
+		mode = ExecutionModeLocal
+	}
+	distributed := DistributedOptions{}
+	if opts.Distributed != nil {
+		distributed = cloneDistributedOptions(*opts.Distributed)
+	}
+
+	return &Engine{
+		cfg:             cfg,
+		dagRunStore:     dagRunStore,
+		procStore:       procStore,
+		serviceRegistry: serviceRegistry,
+		dagStore:        dagStore,
+		dagRunMgr:       dagRunMgr,
+		defaultMode:     mode,
+		distributed:     distributed,
+		logger:          log,
+	}, nil
+}
+
+func (e *Engine) Close(ctx context.Context) error {
+	if e == nil {
+		return nil
+	}
+	e.serviceRegistry.Unregister(ctx)
+	return nil
+}
+
+func (e *Engine) context(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = config.WithConfig(ctx, e.cfg)
+	if e.logger != nil {
+		ctx = logger.WithLogger(ctx, e.logger)
+	}
+	return ctx
+}
+
+func loadConfig(opts Options) (*config.Config, error) {
+	var loaderOpts []config.ConfigLoaderOption
+	if opts.HomeDir != "" {
+		loaderOpts = append(loaderOpts, config.WithAppHomeDir(opts.HomeDir))
+	}
+	if opts.ConfigFile != "" {
+		loaderOpts = append(loaderOpts, config.WithConfigFile(opts.ConfigFile))
+	}
+	loader := config.NewConfigLoader(viper.New(), loaderOpts...)
+	cfg, err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func applyOptions(cfg *config.Config, opts Options) {
+	cfg.Core.SkipExamples = true
+	if opts.DAGsDir != "" {
+		cfg.Paths.DAGsDir = resolvePath(opts.DAGsDir)
+	}
+	if opts.DataDir != "" {
+		cfg.Paths.DataDir = resolvePath(opts.DataDir)
+		cfg.Paths.DAGRunsDir = filepath.Join(cfg.Paths.DataDir, "dag-runs")
+		cfg.Paths.ProcDir = filepath.Join(cfg.Paths.DataDir, "proc")
+		cfg.Paths.QueueDir = filepath.Join(cfg.Paths.DataDir, "queue")
+		cfg.Paths.ServiceRegistryDir = filepath.Join(cfg.Paths.DataDir, "service-registry")
+		cfg.Paths.ContextsDir = filepath.Join(cfg.Paths.DataDir, "contexts")
+	}
+	if opts.LogDir != "" {
+		cfg.Paths.LogDir = resolvePath(opts.LogDir)
+	}
+	if opts.ArtifactDir != "" {
+		cfg.Paths.ArtifactDir = resolvePath(opts.ArtifactDir)
+	}
+	if opts.BaseConfig != "" {
+		cfg.Paths.BaseConfig = resolvePath(opts.BaseConfig)
+	}
+	if opts.DefaultMode != "" {
+		cfg.DefaultExecMode = config.ExecutionMode(opts.DefaultMode)
+	}
+	if opts.Distributed != nil {
+		cfg.Worker.Coordinators = append([]string{}, opts.Distributed.Coordinators...)
+	}
+}
+
+func cloneDistributedOptions(opts DistributedOptions) DistributedOptions {
+	return DistributedOptions{
+		Coordinators:    append([]string{}, opts.Coordinators...),
+		TLS:             opts.TLS,
+		WorkerSelector:  cloneStringMap(opts.WorkerSelector),
+		PollInterval:    opts.PollInterval,
+		MaxStatusErrors: opts.MaxStatusErrors,
+	}
+}
+
+func resolvePath(path string) string {
+	if resolved := fileutil.ResolvePathOrBlank(path); resolved != "" {
+		return resolved
+	}
+	return path
+}
+
+func newDAGStore(cfg *config.Config, searchPaths []string, skipDirectoryCreation bool) (coreexec.DAGStore, error) {
+	store := filedag.New(
+		cfg.Paths.DAGsDir,
+		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
+		filedag.WithSearchPaths(searchPaths),
+		filedag.WithBaseConfig(cfg.Paths.BaseConfig),
+		filedag.WithSkipExamples(cfg.Core.SkipExamples),
+		filedag.WithSkipDirectoryCreation(skipDirectoryCreation),
+	)
+	if s, ok := store.(*filedag.Storage); ok {
+		if err := s.Initialize(); err != nil {
+			return nil, fmt.Errorf("initialize DAG store: %w", err)
+		}
+	}
+	return store, nil
+}
+
+func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client, error) {
+	if len(opts.Coordinators) == 0 {
+		return nil, fmt.Errorf("distributed execution requires at least one coordinator address")
+	}
+	cfg := coordinator.DefaultConfig()
+	cfg.CAFile = opts.TLS.ClientCAFile
+	cfg.CertFile = opts.TLS.CertFile
+	cfg.KeyFile = opts.TLS.KeyFile
+	cfg.SkipTLSVerify = opts.TLS.SkipTLSVerify
+	cfg.Insecure = opts.TLS.Insecure
+	if cfg.Insecure == false && cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == "" && !cfg.SkipTLSVerify {
+		cfg.Insecure = true
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	registry, err := coordinator.NewStaticRegistry(opts.Coordinators)
+	if err != nil {
+		return nil, err
+	}
+	return coordinator.New(registry, cfg), nil
+}
+
+func runStatusToPublic(status *coreexec.DAGRunStatus) (*Status, error) {
+	if status == nil {
+		return nil, nil
+	}
+	startedAt, err := parseStatusTime(status.StartedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse startedAt: %w", err)
+	}
+	finishedAt, err := parseStatusTime(status.FinishedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse finishedAt: %w", err)
+	}
+	return &Status{
+		Name:        status.Name,
+		RunID:       status.DAGRunID,
+		AttemptID:   status.AttemptID,
+		Status:      status.Status.String(),
+		StartedAt:   startedAt,
+		FinishedAt:  finishedAt,
+		Error:       status.Error,
+		LogFile:     status.Log,
+		ArchiveDir:  status.ArchiveDir,
+		WorkerID:    status.WorkerID,
+		TriggerType: status.TriggerType.String(),
+	}, nil
+}
+
+func parseStatusTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func statusFromValue(status coreexec.DAGRunStatus) (*Status, error) {
+	return runStatusToPublic(&status)
+}
+
+func isSuccess(status *Status) bool {
+	return status != nil && (status.Status == core.Succeeded.String() || status.Status == core.PartiallySucceeded.String())
+}

--- a/internal/engine/logger.go
+++ b/internal/engine/logger.go
@@ -26,12 +26,16 @@ func (l *slogAdapter) Debug(msg string, tags ...slog.Attr) { l.log(slog.LevelDeb
 func (l *slogAdapter) Info(msg string, tags ...slog.Attr)  { l.log(slog.LevelInfo, msg, tags...) }
 func (l *slogAdapter) Warn(msg string, tags ...slog.Attr)  { l.log(slog.LevelWarn, msg, tags...) }
 func (l *slogAdapter) Error(msg string, tags ...slog.Attr) { l.log(slog.LevelError, msg, tags...) }
+
+// Fatal logs without exiting so embedded engines cannot terminate the host process.
 func (l *slogAdapter) Fatal(msg string, tags ...slog.Attr) { l.log(slog.LevelError, msg, tags...) }
 
 func (l *slogAdapter) Debugf(format string, v ...any) { l.Debug(fmt.Sprintf(format, v...)) }
 func (l *slogAdapter) Infof(format string, v ...any)  { l.Info(fmt.Sprintf(format, v...)) }
 func (l *slogAdapter) Warnf(format string, v ...any)  { l.Warn(fmt.Sprintf(format, v...)) }
 func (l *slogAdapter) Errorf(format string, v ...any) { l.Error(fmt.Sprintf(format, v...)) }
+
+// Fatalf logs without exiting so embedded engines cannot terminate the host process.
 func (l *slogAdapter) Fatalf(format string, v ...any) { l.Fatal(fmt.Sprintf(format, v...)) }
 
 func (l *slogAdapter) Write(msg string) {
@@ -39,9 +43,9 @@ func (l *slogAdapter) Write(msg string) {
 }
 
 func (l *slogAdapter) With(attrs ...slog.Attr) logger.Logger {
-	args := make([]any, 0, len(attrs)*2)
-	for _, attr := range attrs {
-		args = append(args, attr.Key, attr.Value.Any())
+	args := make([]any, len(attrs))
+	for i, attr := range attrs {
+		args[i] = attr
 	}
 	return &slogAdapter{logger: l.logger.With(args...)}
 }
@@ -51,9 +55,9 @@ func (l *slogAdapter) WithGroup(name string) logger.Logger {
 }
 
 func (l *slogAdapter) log(level slog.Level, msg string, tags ...slog.Attr) {
-	args := make([]any, 0, len(tags)*2)
-	for _, attr := range tags {
-		args = append(args, attr.Key, attr.Value.Any())
+	args := make([]any, len(tags))
+	for i, attr := range tags {
+		args[i] = attr
 	}
 	l.logger.Log(context.Background(), level, msg, args...)
 }

--- a/internal/engine/logger.go
+++ b/internal/engine/logger.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+)
+
+type slogAdapter struct {
+	logger *slog.Logger
+}
+
+func newSlogAdapter(logger *slog.Logger) *slogAdapter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &slogAdapter{logger: logger}
+}
+
+func (l *slogAdapter) Debug(msg string, tags ...slog.Attr) { l.log(slog.LevelDebug, msg, tags...) }
+func (l *slogAdapter) Info(msg string, tags ...slog.Attr)  { l.log(slog.LevelInfo, msg, tags...) }
+func (l *slogAdapter) Warn(msg string, tags ...slog.Attr)  { l.log(slog.LevelWarn, msg, tags...) }
+func (l *slogAdapter) Error(msg string, tags ...slog.Attr) { l.log(slog.LevelError, msg, tags...) }
+func (l *slogAdapter) Fatal(msg string, tags ...slog.Attr) { l.log(slog.LevelError, msg, tags...) }
+
+func (l *slogAdapter) Debugf(format string, v ...any) { l.Debug(fmt.Sprintf(format, v...)) }
+func (l *slogAdapter) Infof(format string, v ...any)  { l.Info(fmt.Sprintf(format, v...)) }
+func (l *slogAdapter) Warnf(format string, v ...any)  { l.Warn(fmt.Sprintf(format, v...)) }
+func (l *slogAdapter) Errorf(format string, v ...any) { l.Error(fmt.Sprintf(format, v...)) }
+func (l *slogAdapter) Fatalf(format string, v ...any) { l.Fatal(fmt.Sprintf(format, v...)) }
+
+func (l *slogAdapter) Write(msg string) {
+	l.Info(msg)
+}
+
+func (l *slogAdapter) With(attrs ...slog.Attr) logger.Logger {
+	args := make([]any, 0, len(attrs)*2)
+	for _, attr := range attrs {
+		args = append(args, attr.Key, attr.Value.Any())
+	}
+	return &slogAdapter{logger: l.logger.With(args...)}
+}
+
+func (l *slogAdapter) WithGroup(name string) logger.Logger {
+	return &slogAdapter{logger: l.logger.WithGroup(name)}
+}
+
+func (l *slogAdapter) log(level slog.Level, msg string, tags ...slog.Attr) {
+	args := make([]any, 0, len(tags)*2)
+	for _, attr := range tags {
+		args = append(args, attr.Key, attr.Value.Any())
+	}
+	l.logger.Log(context.Background(), level, msg, args...)
+}

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -1,0 +1,625 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	agentstores "github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/agentoauth"
+	"github.com/dagucloud/dagu/internal/agentsnapshot"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/logpath"
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/persis/fileagentconfig"
+	"github.com/dagucloud/dagu/internal/persis/fileagentmodel"
+	"github.com/dagucloud/dagu/internal/persis/fileagentoauth"
+	"github.com/dagucloud/dagu/internal/persis/fileagentsoul"
+	"github.com/dagucloud/dagu/internal/persis/filememory"
+	"github.com/dagucloud/dagu/internal/proto/convert"
+	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
+	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+)
+
+func (e *Engine) RunFile(ctx context.Context, path string, opts RunOptions) (*Run, error) {
+	ctx = e.context(ctx)
+	dag, err := e.loadFile(ctx, path, opts)
+	if err != nil {
+		return nil, err
+	}
+	return e.runLoaded(ctx, dag, opts)
+}
+
+func (e *Engine) RunYAML(ctx context.Context, data []byte, opts RunOptions) (*Run, error) {
+	ctx = e.context(ctx)
+	dag, err := e.loadYAML(ctx, data, opts)
+	if err != nil {
+		return nil, err
+	}
+	return e.runLoaded(ctx, dag, opts)
+}
+
+func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
+	ctx = e.context(ctx)
+	if ref.Name == "" || ref.ID == "" {
+		return nil, fmt.Errorf("run name and ID are required")
+	}
+	status, err := e.dagRunMgr.GetSavedStatus(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+	if err != nil {
+		return nil, err
+	}
+	return runStatusToPublic(status)
+}
+
+func (e *Engine) Stop(ctx context.Context, ref RunRef) error {
+	ctx = e.context(ctx)
+	if ref.Name == "" || ref.ID == "" {
+		return fmt.Errorf("run name and ID are required")
+	}
+	attempt, err := e.dagRunStore.FindAttempt(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+	if err != nil {
+		return err
+	}
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil {
+		return err
+	}
+	return e.dagRunMgr.Stop(ctx, dag, ref.ID)
+}
+
+func (r *Run) Ref() RunRef {
+	return r.ref
+}
+
+func (r *Run) ID() string {
+	return r.ref.ID
+}
+
+func (r *Run) Name() string {
+	return r.ref.Name
+}
+
+func (r *Run) Wait(ctx context.Context) (*Status, error) {
+	if r.mode == ExecutionModeDistributed {
+		return r.waitDistributed(ctx)
+	}
+	return r.waitLocal(ctx)
+}
+
+func (r *Run) Status(ctx context.Context) (*Status, error) {
+	if r.mode == ExecutionModeDistributed {
+		resp, err := r.coordinator.GetDAGRunStatus(ctx, r.ref.Name, r.ref.ID, nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil || resp.Status == nil {
+			return nil, nil
+		}
+		status, err := convert.ProtoToDAGRunStatus(resp.Status)
+		if err != nil {
+			return nil, err
+		}
+		return runStatusToPublic(status)
+	}
+	if r.agent != nil {
+		select {
+		case <-r.done:
+		default:
+			status := r.agent.Status(ctx)
+			return statusFromValue(status)
+		}
+	}
+	return r.engine.Status(ctx, r.ref)
+}
+
+func (r *Run) Stop(ctx context.Context) error {
+	if r.mode == ExecutionModeDistributed {
+		if r.cancel != nil {
+			r.cancel()
+		}
+		err := r.coordinator.RequestCancel(ctx, r.ref.Name, r.ref.ID, nil)
+		if cleanupErr := r.coordinator.Cleanup(context.Background()); err == nil && cleanupErr != nil {
+			err = cleanupErr
+		}
+		return err
+	}
+	if r.agent != nil {
+		r.agent.Signal(ctx, syscall.SIGTERM)
+	}
+	if r.cancel != nil {
+		r.cancel()
+	}
+	return r.engine.Stop(ctx, r.ref)
+}
+
+func (r *Run) waitLocal(ctx context.Context) (*Status, error) {
+	select {
+	case <-r.done:
+		err := r.doneError()
+		status, statusErr := r.Status(context.Background())
+		if statusErr != nil && err == nil {
+			err = statusErr
+		}
+		if err != nil {
+			return status, err
+		}
+		if !isSuccess(status) {
+			return status, fmt.Errorf("DAG run finished with status %s", status.Status)
+		}
+		return status, nil
+	case <-ctx.Done():
+		status, _ := r.Status(context.Background())
+		return status, ctx.Err()
+	}
+}
+
+func (r *Run) waitDistributed(ctx context.Context) (*Status, error) {
+	defer func() {
+		_ = r.coordinator.Cleanup(context.Background())
+	}()
+	poll := r.engine.distributed.PollInterval
+	if poll <= 0 {
+		poll = time.Second
+	}
+	maxErrors := r.engine.distributed.MaxStatusErrors
+	if maxErrors <= 0 {
+		maxErrors = 10
+	}
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+	consecutiveErrors := 0
+	for {
+		select {
+		case <-ctx.Done():
+			status, _ := r.Status(context.Background())
+			return status, ctx.Err()
+		case <-ticker.C:
+			status, err := r.Status(ctx)
+			if err != nil {
+				consecutiveErrors++
+				if consecutiveErrors >= maxErrors {
+					return nil, fmt.Errorf("lost connection to coordinator after %d attempts: %w", consecutiveErrors, err)
+				}
+				continue
+			}
+			consecutiveErrors = 0
+			if status == nil {
+				continue
+			}
+			if !isActiveStatus(status.Status) {
+				if isSuccess(status) {
+					return status, nil
+				}
+				if status.Error != "" {
+					return status, fmt.Errorf("DAG run failed with status %s: %s", status.Status, status.Error)
+				}
+				return status, fmt.Errorf("DAG run failed with status %s", status.Status)
+			}
+		}
+	}
+}
+
+func (e *Engine) loadFile(ctx context.Context, path string, opts RunOptions) (*core.DAG, error) {
+	loadOpts := e.loadOptions(opts)
+	dag, err := spec.Load(ctx, path, loadOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if dag.SourceFile == "" {
+		dag.SourceFile = path
+	}
+	applyRunOverrides(dag, opts)
+	return dag, nil
+}
+
+func (e *Engine) loadYAML(ctx context.Context, data []byte, opts RunOptions) (*core.DAG, error) {
+	loadOpts := e.loadOptions(opts)
+	dag, err := spec.LoadYAML(ctx, data, loadOpts...)
+	if err != nil {
+		return nil, err
+	}
+	applyRunOverrides(dag, opts)
+	return dag, nil
+}
+
+func (e *Engine) loadOptions(opts RunOptions) []spec.LoadOption {
+	loadOpts := []spec.LoadOption{
+		spec.WithBaseConfig(e.cfg.Paths.BaseConfig),
+		spec.WithDAGsDir(e.cfg.Paths.DAGsDir),
+	}
+	if opts.Name != "" {
+		loadOpts = append(loadOpts, spec.WithName(opts.Name))
+	}
+	if opts.DefaultWorkingDir != "" {
+		loadOpts = append(loadOpts, spec.WithDefaultWorkingDir(opts.DefaultWorkingDir))
+	}
+	if len(opts.ParamsList) > 0 {
+		loadOpts = append(loadOpts, spec.WithParams(opts.ParamsList))
+	} else {
+		loadOpts = append(loadOpts, spec.WithParams(paramsMapToList(opts.Params)))
+	}
+	return loadOpts
+}
+
+func applyRunOverrides(dag *core.DAG, opts RunOptions) {
+	if len(opts.WorkerSelector) > 0 {
+		dag.WorkerSelector = cloneStringMap(opts.WorkerSelector)
+	}
+	if len(opts.Tags) > 0 {
+		dag.Tags = append(dag.Tags, core.NewTags(opts.Tags)...)
+	}
+}
+
+func (e *Engine) runLoaded(ctx context.Context, dag *core.DAG, opts RunOptions) (*Run, error) {
+	if err := dag.Validate(); err != nil {
+		return nil, err
+	}
+	runID := opts.RunID
+	if runID == "" {
+		id, err := e.dagRunMgr.GenDAGRunID(ctx)
+		if err != nil {
+			return nil, err
+		}
+		runID = id
+	} else if err := coreexec.ValidateDAGRunID(runID); err != nil {
+		return nil, err
+	}
+	mode := opts.Mode
+	if mode == "" {
+		mode = e.defaultMode
+	}
+	if mode == "" {
+		mode = ExecutionModeLocal
+	}
+	switch mode {
+	case ExecutionModeLocal:
+		return e.runLocal(ctx, dag, runID, opts)
+	case ExecutionModeDistributed:
+		return e.runDistributed(ctx, dag, runID, opts)
+	default:
+		return nil, fmt.Errorf("unsupported execution mode %q", mode)
+	}
+}
+
+func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts RunOptions) (*Run, error) {
+	logFile, err := e.openLogFile(ctx, dag, runID)
+	if err != nil {
+		return nil, err
+	}
+	artifactDir, err := e.artifactDir(ctx, dag, runID)
+	if err != nil {
+		_ = logFile.Close()
+		return nil, err
+	}
+	dagStore, err := newDAGStore(e.cfg, []string{filepath.Dir(dag.Location)}, false)
+	if err != nil {
+		_ = logFile.Close()
+		return nil, err
+	}
+	root := coreexec.NewDAGRunRef(dag.Name, runID)
+	var prepared *localPreparation
+	if !opts.DryRun {
+		prepared, err = e.prepareLocal(ctx, dag, runID, root)
+		if err != nil {
+			_ = logFile.Close()
+			return nil, err
+		}
+	}
+
+	stores := e.agentStores(ctx)
+	agentInstance := rtagent.New(
+		runID,
+		dag,
+		filepath.Dir(logFile.Name()),
+		logFile.Name(),
+		e.dagRunMgr,
+		dagStore,
+		rtagent.Options{
+			Dry:                        opts.DryRun,
+			WorkerID:                   "local",
+			PreparedAttempt:            preparedAttempt(prepared),
+			DAGRunStore:                e.dagRunStore,
+			ServiceRegistry:            e.serviceRegistry,
+			RootDAGRun:                 root,
+			PeerConfig:                 e.cfg.Core.Peer,
+			TriggerType:                core.TriggerTypeManual,
+			DefaultExecMode:            configExecutionMode(e.defaultMode),
+			AgentConfigStore:           stores.ConfigStore,
+			AgentModelStore:            stores.ModelStore,
+			AgentMemoryStore:           stores.MemoryStore,
+			AgentSoulStore:             stores.SoulStore,
+			AgentOAuthManager:          stores.OAuthManager,
+			AgentRemoteContextResolver: stores.ContextResolver,
+			ArtifactDir:                artifactDir,
+		},
+	)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	run := &Run{
+		engine: e,
+		ref:    RunRef{Name: dag.Name, ID: runID},
+		mode:   ExecutionModeLocal,
+		cancel: cancel,
+		done:   done,
+		agent:  agentInstance,
+		dag:    dag,
+	}
+
+	go func() {
+		defer func() {
+			_ = logFile.Close()
+			if prepared != nil && prepared.proc != nil {
+				_ = prepared.proc.Stop(context.Background())
+			}
+		}()
+		runCtx = logger.WithLogger(config.WithConfig(runCtx, e.cfg), e.logger)
+		err := agentInstance.Run(runCtx)
+		if err != nil {
+			logger.Error(runCtx, "Embedded DAG run failed",
+				tag.DAG(dag.Name),
+				tag.RunID(runID),
+				tag.Error(err),
+			)
+		}
+		run.setDoneError(err)
+		close(done)
+	}()
+
+	return run, nil
+}
+
+func (e *Engine) runDistributed(ctx context.Context, dag *core.DAG, runID string, opts RunOptions) (*Run, error) {
+	dist := e.distributed
+	if len(opts.WorkerSelector) > 0 {
+		dist.WorkerSelector = cloneStringMap(opts.WorkerSelector)
+	}
+	client, err := e.coordinatorClient(dist)
+	if err != nil {
+		return nil, err
+	}
+	taskOpts := []runtimeexec.TaskOption{
+		runtimeexec.WithBaseConfig(runtimeexec.ResolveBaseConfig(dag.BaseConfigData, e.cfg.Paths.BaseConfig)),
+	}
+	if len(dist.WorkerSelector) > 0 {
+		taskOpts = append(taskOpts, runtimeexec.WithWorkerSelector(dist.WorkerSelector))
+	}
+	if len(dag.Tags) > 0 {
+		taskOpts = append(taskOpts, runtimeexec.WithTags(strings.Join(dag.Tags.Strings(), ",")))
+	}
+	if dag.SourceFile != "" {
+		taskOpts = append(taskOpts, runtimeexec.WithSourceFile(dag.SourceFile))
+	}
+	if snapshot, snapErr := agentsnapshot.BuildFromPaths(ctx, dag, e.cfg.Paths, e.dagStore); snapErr != nil {
+		_ = client.Cleanup(ctx)
+		return nil, fmt.Errorf("build agent snapshot: %w", snapErr)
+	} else if len(snapshot) > 0 {
+		taskOpts = append(taskOpts, runtimeexec.WithAgentSnapshot(snapshot))
+	}
+	task := runtimeexec.CreateTask(
+		dag.Name,
+		string(dag.YamlData),
+		coordinatorv1.Operation_OPERATION_START,
+		runID,
+		taskOpts...,
+	)
+	if len(dag.Params) > 0 {
+		task.Params = strings.Join(dag.Params, " ")
+	}
+	if err := client.Dispatch(ctx, task); err != nil {
+		_ = client.Cleanup(ctx)
+		return nil, fmt.Errorf("dispatch DAG run: %w", err)
+	}
+	return &Run{
+		engine:      e,
+		ref:         RunRef{Name: dag.Name, ID: runID},
+		mode:        ExecutionModeDistributed,
+		done:        make(chan struct{}),
+		dag:         dag,
+		coordinator: client,
+	}, nil
+}
+
+func (r *Run) setDoneError(err error) {
+	r.doneErrMu.Lock()
+	defer r.doneErrMu.Unlock()
+	r.doneErr = err
+}
+
+func (r *Run) doneError() error {
+	r.doneErrMu.RLock()
+	defer r.doneErrMu.RUnlock()
+	return r.doneErr
+}
+
+func (e *Engine) prepareLocal(ctx context.Context, dag *core.DAG, runID string, root coreexec.DAGRunRef) (*localPreparation, error) {
+	if err := e.procStore.Lock(ctx, dag.ProcGroup()); err != nil {
+		return nil, fmt.Errorf("lock process group: %w", err)
+	}
+	defer e.procStore.Unlock(ctx, dag.ProcGroup())
+
+	attempt, err := e.dagRunStore.CreateAttempt(ctx, dag, time.Now(), runID, coreexec.NewDAGRunAttemptOptions{})
+	if err != nil {
+		if errors.Is(err, coreexec.ErrDAGRunAlreadyExists) {
+			return nil, fmt.Errorf("dag-run ID %s already exists for DAG %s: %w", runID, dag.Name, err)
+		}
+		return nil, fmt.Errorf("create DAG run attempt: %w", err)
+	}
+	attempt.SetDAG(dag)
+	proc, err := e.procStore.Acquire(ctx, dag.ProcGroup(), coreexec.ProcMeta{
+		StartedAt:    time.Now().Unix(),
+		Name:         dag.Name,
+		DAGRunID:     runID,
+		AttemptID:    attempt.ID(),
+		RootName:     root.Name,
+		RootDAGRunID: root.ID,
+	})
+	if err != nil {
+		_ = e.recordPreparedFailure(ctx, attempt, dag, runID, root, err)
+		return nil, fmt.Errorf("acquire process handle: %w", err)
+	}
+	return &localPreparation{attempt: attempt, proc: proc}, nil
+}
+
+func (e *Engine) recordPreparedFailure(
+	ctx context.Context,
+	attempt coreexec.DAGRunAttempt,
+	dag *core.DAG,
+	runID string,
+	root coreexec.DAGRunRef,
+	runErr error,
+) error {
+	logFile, logErr := logpath.Generate(ctx, e.cfg.Paths.LogDir, dag.LogDir, dag.Name, runID)
+	if logErr != nil {
+		logger.Warn(ctx, "Failed to generate log path for prepared local execution failure", tag.Error(logErr))
+	}
+	artifactDir, artifactErr := e.artifactDir(ctx, dag, runID)
+	if artifactErr != nil {
+		logger.Warn(ctx, "Failed to generate artifact path for prepared local execution failure", tag.Error(artifactErr))
+	}
+	status := transform.NewStatusBuilder(dag).Create(
+		runID,
+		core.Failed,
+		0,
+		time.Now(),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithHierarchyRefs(root, coreexec.DAGRunRef{}),
+		transform.WithLogFilePath(logFile),
+		transform.WithArchiveDir(artifactDir),
+		transform.WithFinishedAt(time.Now()),
+		transform.WithError(runErr.Error()),
+		transform.WithWorkerID("local"),
+		transform.WithTriggerType(core.TriggerTypeManual),
+	)
+	if err := attempt.Open(ctx); err != nil {
+		return err
+	}
+	defer func() {
+		_ = attempt.Close(ctx)
+	}()
+	return attempt.Write(ctx, status)
+}
+
+func (e *Engine) openLogFile(ctx context.Context, dag *core.DAG, runID string) (*os.File, error) {
+	path, err := logpath.Generate(ctx, e.cfg.Paths.LogDir, dag.LogDir, dag.Name, runID)
+	if err != nil {
+		return nil, err
+	}
+	return fileutil.OpenOrCreateFile(path)
+}
+
+func (e *Engine) artifactDir(ctx context.Context, dag *core.DAG, runID string) (string, error) {
+	if dag == nil || !dag.ArtifactsEnabled() {
+		return "", nil
+	}
+	dagArtifactDir := ""
+	if dag.Artifacts != nil {
+		dagArtifactDir = dag.Artifacts.Dir
+	}
+	return logpath.GenerateDir(ctx, e.cfg.Paths.ArtifactDir, dagArtifactDir, dag.Name, runID)
+}
+
+type agentStoresResult struct {
+	ConfigStore     agentstores.ConfigStore
+	ModelStore      agentstores.ModelStore
+	MemoryStore     agentstores.MemoryStore
+	SoulStore       agentstores.SoulStore
+	OAuthManager    *agentoauth.Manager
+	ContextResolver agentstores.RemoteContextResolver
+}
+
+func (e *Engine) agentStores(ctx context.Context) agentStoresResult {
+	var result agentStoresResult
+	if store, err := fileagentconfig.New(e.cfg.Paths.DataDir); err == nil {
+		result.ConfigStore = store
+	} else {
+		logger.Warn(ctx, "Failed to create agent config store", tag.Error(err))
+	}
+	if store, err := fileagentmodel.New(filepath.Join(e.cfg.Paths.DataDir, "agent", "models")); err == nil {
+		result.ModelStore = store
+	} else {
+		logger.Warn(ctx, "Failed to create agent model store", tag.Error(err))
+	}
+	if store, err := filememory.New(e.cfg.Paths.DAGsDir); err == nil {
+		result.MemoryStore = store
+	} else {
+		logger.Warn(ctx, "Failed to create agent memory store", tag.Error(err))
+	}
+	if store, err := fileagentsoul.New(ctx, filepath.Join(e.cfg.Paths.DAGsDir, "souls")); err == nil {
+		result.SoulStore = store
+	} else {
+		logger.Warn(ctx, "Failed to create agent soul store", tag.Error(err))
+	}
+	if manager, err := fileagentoauth.NewManager(e.cfg.Paths.DataDir); err == nil {
+		result.OAuthManager = manager
+	} else {
+		logger.Warn(ctx, "Failed to create agent OAuth manager", tag.Error(err))
+	}
+	return result
+}
+
+func preparedAttempt(prepared *localPreparation) coreexec.DAGRunAttempt {
+	if prepared == nil {
+		return nil
+	}
+	return prepared.attempt
+}
+
+func paramsMapToList(params map[string]string) []string {
+	if len(params) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(params))
+	for _, key := range keys {
+		out = append(out, key+"="+params[key])
+	}
+	return out
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func configExecutionMode(mode ExecutionMode) config.ExecutionMode {
+	if mode == "" {
+		return config.ExecutionModeLocal
+	}
+	return config.ExecutionMode(mode)
+}
+
+func isActiveStatus(status string) bool {
+	switch status {
+	case core.Running.String(), core.Queued.String(), core.Waiting.String(), core.NotStarted.String():
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -364,14 +364,17 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 	}
 
 	go func() {
+		var err error
 		defer func() {
 			_ = logFile.Close()
 			if prepared != nil && prepared.proc != nil {
 				_ = prepared.proc.Stop(context.Background())
 			}
+			run.setDoneError(err)
+			close(done)
 		}()
 		runCtx = logger.WithLogger(config.WithConfig(runCtx, e.cfg), e.logger)
-		err := agentInstance.Run(runCtx)
+		err = agentInstance.Run(runCtx)
 		if err != nil {
 			logger.Error(runCtx, "Embedded DAG run failed",
 				tag.DAG(dag.Name),
@@ -379,8 +382,6 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 				tag.Error(err),
 			)
 		}
-		run.setDoneError(err)
-		close(done)
 	}()
 
 	return run, nil

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -602,9 +603,7 @@ func cloneStringMap(values map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(values))
-	for key, value := range values {
-		out[key] = value
-	}
+	maps.Copy(out, values)
 	return out
 }
 

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -18,7 +19,9 @@ import (
 	agentstores "github.com/dagucloud/dagu/internal/agent"
 	"github.com/dagucloud/dagu/internal/agentoauth"
 	"github.com/dagucloud/dagu/internal/agentsnapshot"
+	"github.com/dagucloud/dagu/internal/clicontext"
 	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/crypto"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
@@ -135,7 +138,7 @@ func (r *Run) Stop(ctx context.Context) error {
 			r.cancel()
 		}
 		err := r.coordinator.RequestCancel(ctx, r.ref.Name, r.ref.ID, nil)
-		if cleanupErr := r.coordinator.Cleanup(context.Background()); err == nil && cleanupErr != nil {
+		if cleanupErr := r.cleanupCoordinator(context.Background()); err == nil && cleanupErr != nil {
 			err = cleanupErr
 		}
 		return err
@@ -153,7 +156,7 @@ func (r *Run) waitLocal(ctx context.Context) (*Status, error) {
 	select {
 	case <-r.done:
 		err := r.doneError()
-		status, statusErr := r.Status(context.Background())
+		status, statusErr := r.statusWithFinalTimeout()
 		if statusErr != nil && err == nil {
 			err = statusErr
 		}
@@ -165,14 +168,14 @@ func (r *Run) waitLocal(ctx context.Context) (*Status, error) {
 		}
 		return status, nil
 	case <-ctx.Done():
-		status, _ := r.Status(context.Background())
+		status, _ := r.statusWithFinalTimeout()
 		return status, ctx.Err()
 	}
 }
 
 func (r *Run) waitDistributed(ctx context.Context) (*Status, error) {
 	defer func() {
-		_ = r.coordinator.Cleanup(context.Background())
+		_ = r.cleanupCoordinator(context.Background())
 	}()
 	poll := r.engine.distributed.PollInterval
 	if poll <= 0 {
@@ -188,7 +191,7 @@ func (r *Run) waitDistributed(ctx context.Context) (*Status, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			status, _ := r.Status(context.Background())
+			status, _ := r.statusWithFinalTimeout()
 			return status, ctx.Err()
 		case <-ticker.C:
 			status, err := r.Status(ctx)
@@ -205,15 +208,26 @@ func (r *Run) waitDistributed(ctx context.Context) (*Status, error) {
 			}
 			if !isActiveStatus(status.Status) {
 				if isSuccess(status) {
+					r.markDone(nil)
 					return status, nil
 				}
 				if status.Error != "" {
-					return status, fmt.Errorf("DAG run failed with status %s: %s", status.Status, status.Error)
+					err := fmt.Errorf("DAG run failed with status %s: %s", status.Status, status.Error)
+					r.markDone(err)
+					return status, err
 				}
-				return status, fmt.Errorf("DAG run failed with status %s", status.Status)
+				err := fmt.Errorf("DAG run failed with status %s", status.Status)
+				r.markDone(err)
+				return status, err
 			}
 		}
 	}
+}
+
+func (r *Run) statusWithFinalTimeout() (*Status, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return r.Status(ctx)
 }
 
 func (e *Engine) loadFile(ctx context.Context, path string, opts RunOptions) (*core.DAG, error) {
@@ -259,11 +273,24 @@ func (e *Engine) loadOptions(opts RunOptions) []spec.LoadOption {
 }
 
 func applyRunOverrides(dag *core.DAG, opts RunOptions) {
+	// Name, DefaultWorkingDir, and params are handled during loading; only
+	// overrides that must mutate the loaded DAG belong here.
 	if len(opts.WorkerSelector) > 0 {
 		dag.WorkerSelector = cloneStringMap(opts.WorkerSelector)
 	}
 	if len(opts.Tags) > 0 {
-		dag.Tags = append(dag.Tags, core.NewTags(opts.Tags)...)
+		seen := make(map[string]struct{}, len(dag.Tags)+len(opts.Tags))
+		for _, existing := range dag.Tags {
+			seen[existing.String()] = struct{}{}
+		}
+		for _, candidate := range core.NewTags(opts.Tags) {
+			key := candidate.String()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			dag.Tags = append(dag.Tags, candidate)
+		}
 	}
 }
 
@@ -370,8 +397,7 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 			if prepared != nil && prepared.proc != nil {
 				_ = prepared.proc.Stop(context.Background())
 			}
-			run.setDoneError(err)
-			close(done)
+			run.markDone(err)
 		}()
 		runCtx = logger.WithLogger(config.WithConfig(runCtx, e.cfg), e.logger)
 		err = agentInstance.Run(runCtx)
@@ -428,14 +454,37 @@ func (e *Engine) runDistributed(ctx context.Context, dag *core.DAG, runID string
 		_ = client.Cleanup(ctx)
 		return nil, fmt.Errorf("dispatch DAG run: %w", err)
 	}
-	return &Run{
+	run := &Run{
 		engine:      e,
 		ref:         RunRef{Name: dag.Name, ID: runID},
 		mode:        ExecutionModeDistributed,
 		done:        make(chan struct{}),
 		dag:         dag,
 		coordinator: client,
-	}, nil
+	}
+	goruntime.SetFinalizer(run, func(r *Run) {
+		_ = r.cleanupCoordinator(context.Background())
+	})
+	return run, nil
+}
+
+func (r *Run) markDone(err error) {
+	r.setDoneError(err)
+	if r.done == nil {
+		return
+	}
+	r.doneOnce.Do(func() {
+		close(r.done)
+	})
+}
+
+func (r *Run) cleanupCoordinator(ctx context.Context) error {
+	if r == nil || r.coordinator == nil {
+		return nil
+	}
+	err := r.coordinator.Cleanup(ctx)
+	goruntime.SetFinalizer(r, nil)
+	return err
 }
 
 func (r *Run) setDoneError(err error) {
@@ -573,7 +622,28 @@ func (e *Engine) agentStores(ctx context.Context) agentStoresResult {
 	} else {
 		logger.Warn(ctx, "Failed to create agent OAuth manager", tag.Error(err))
 	}
+	if resolver, err := e.buildRemoteContextResolver(); err == nil {
+		result.ContextResolver = resolver
+	} else {
+		logger.Warn(ctx, "Failed to create agent remote context resolver", tag.Error(err))
+	}
 	return result
+}
+
+func (e *Engine) buildRemoteContextResolver() (agentstores.RemoteContextResolver, error) {
+	encKey, err := crypto.ResolveKey(e.cfg.Paths.DataDir)
+	if err != nil {
+		return nil, err
+	}
+	enc, err := crypto.NewEncryptor(encKey)
+	if err != nil {
+		return nil, err
+	}
+	store, err := clicontext.NewStore(e.cfg.Paths.ContextsDir, enc)
+	if err != nil {
+		return nil, err
+	}
+	return &agentstores.RemoteContextResolverAdapter{Store: store}, nil
 }
 
 func preparedAttempt(prepared *localPreparation) coreexec.DAGRunAttempt {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -92,6 +92,7 @@ type Run struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
+	doneOnce  sync.Once
 	doneErrMu sync.RWMutex
 	doneErr   error
 

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/agent"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker"
+)
+
+type ExecutionMode string
+
+const (
+	ExecutionModeLocal       ExecutionMode = "local"
+	ExecutionModeDistributed ExecutionMode = "distributed"
+)
+
+type Options struct {
+	HomeDir     string
+	ConfigFile  string
+	DAGsDir     string
+	DataDir     string
+	LogDir      string
+	ArtifactDir string
+	BaseConfig  string
+	Logger      *slog.Logger
+
+	DefaultMode ExecutionMode
+	Distributed *DistributedOptions
+}
+
+type DistributedOptions struct {
+	Coordinators    []string
+	TLS             TLSOptions
+	WorkerSelector  map[string]string
+	PollInterval    time.Duration
+	MaxStatusErrors int
+}
+
+type TLSOptions struct {
+	Insecure      bool
+	CertFile      string
+	KeyFile       string
+	ClientCAFile  string
+	SkipTLSVerify bool
+}
+
+type RunOptions struct {
+	RunID             string
+	Name              string
+	Params            map[string]string
+	ParamsList        []string
+	DefaultWorkingDir string
+	Mode              ExecutionMode
+	WorkerSelector    map[string]string
+	Tags              []string
+	DryRun            bool
+}
+
+type RunRef struct {
+	Name string
+	ID   string
+}
+
+type Status struct {
+	Name        string
+	RunID       string
+	AttemptID   string
+	Status      string
+	StartedAt   time.Time
+	FinishedAt  time.Time
+	Error       string
+	LogFile     string
+	ArchiveDir  string
+	WorkerID    string
+	TriggerType string
+}
+
+type Run struct {
+	engine *Engine
+	ref    RunRef
+	mode   ExecutionMode
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	doneErrMu sync.RWMutex
+	doneErr   error
+
+	agent *agent.Agent
+	dag   *core.DAG
+
+	coordinator coordinator.Client
+}
+
+type WorkerOptions struct {
+	ID            string
+	MaxActiveRuns int
+	Labels        map[string]string
+	Coordinators  []string
+	TLS           TLSOptions
+	HealthPort    int
+}
+
+type Worker struct {
+	inner *worker.Worker
+}
+
+type localPreparation struct {
+	attempt coreexec.DAGRunAttempt
+	proc    coreexec.ProcHandle
+}

--- a/internal/engine/worker.go
+++ b/internal/engine/worker.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/dagucloud/dagu/internal/service/worker"
+)
+
+func (e *Engine) NewWorker(opts WorkerOptions) (*Worker, error) {
+	coordinators := opts.Coordinators
+	if len(coordinators) == 0 {
+		coordinators = append([]string{}, e.distributed.Coordinators...)
+	}
+	if len(coordinators) == 0 {
+		return nil, fmt.Errorf("worker requires at least one coordinator address")
+	}
+	tls := opts.TLS
+	if tls == (TLSOptions{}) {
+		tls = e.distributed.TLS
+	}
+
+	cfg := *e.cfg
+	cfg.Worker.Coordinators = append([]string{}, coordinators...)
+	cfg.Worker.HealthPort = opts.HealthPort
+	cfg.Core.Peer.Insecure = tls.Insecure
+	cfg.Core.Peer.CertFile = tls.CertFile
+	cfg.Core.Peer.KeyFile = tls.KeyFile
+	cfg.Core.Peer.ClientCaFile = tls.ClientCAFile
+	cfg.Core.Peer.SkipTLSVerify = tls.SkipTLSVerify
+
+	workerID := opts.ID
+	if workerID == "" {
+		hostname, err := os.Hostname()
+		if err != nil || hostname == "" {
+			hostname = "unknown"
+		}
+		workerID = fmt.Sprintf("%s@%d", hostname, os.Getpid())
+	}
+	maxActiveRuns := opts.MaxActiveRuns
+	if maxActiveRuns <= 0 {
+		maxActiveRuns = 100
+	}
+	client, err := e.coordinatorClient(DistributedOptions{
+		Coordinators: coordinators,
+		TLS:          tls,
+	})
+	if err != nil {
+		return nil, err
+	}
+	labels := cloneStringMap(opts.Labels)
+	w := worker.NewWorker(workerID, maxActiveRuns, client, labels, &cfg)
+	w.SetHandler(worker.NewRemoteTaskHandler(worker.RemoteTaskHandlerConfig{
+		WorkerID:          workerID,
+		CoordinatorClient: client,
+		DAGRunStore:       nil,
+		DAGStore:          e.dagStore,
+		DAGRunMgr:         e.dagRunMgr,
+		ServiceRegistry:   e.serviceRegistry,
+		PeerConfig:        cfg.Core.Peer,
+		Config:            &cfg,
+	}))
+	return &Worker{inner: w}, nil
+}
+
+func (w *Worker) Start(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return fmt.Errorf("worker is not initialized")
+	}
+	return w.inner.Start(ctx)
+}
+
+func (w *Worker) Stop(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return nil
+	}
+	return w.inner.Stop(ctx)
+}

--- a/internal/engine/worker.go
+++ b/internal/engine/worker.go
@@ -80,3 +80,10 @@ func (w *Worker) Stop(ctx context.Context) error {
 	}
 	return w.inner.Stop(ctx)
 }
+
+func (w *Worker) WaitReady(ctx context.Context) error {
+	if w == nil || w.inner == nil {
+		return fmt.Errorf("worker is not initialized")
+	}
+	return w.inner.WaitReady(ctx)
+}

--- a/internal/intg/embed/embed_test.go
+++ b/internal/intg/embed/embed_test.go
@@ -71,6 +71,9 @@ func TestEmbeddedCustomExecutorRunYAML(t *testing.T) {
 		},
 		dagu.WithExecutorCapabilities(dagu.ExecutorCapabilities{Command: true}),
 	)
+	t.Cleanup(func() {
+		dagu.UnregisterExecutor(executorType)
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), embeddedTimeout(20*time.Second))
 	defer cancel()
@@ -108,6 +111,7 @@ func TestEmbeddedDistributedSharedNothingRunYAML(t *testing.T) {
 		DefaultMode: dagu.ExecutionModeDistributed,
 		Distributed: &dagu.DistributedOptions{
 			Coordinators:    []string{coord.Address()},
+			TLS:             dagu.TLSOptions{Insecure: true},
 			WorkerSelector:  map[string]string{"pool": "embedded-intg"},
 			PollInterval:    100 * time.Millisecond,
 			MaxStatusErrors: 20,
@@ -136,7 +140,7 @@ func TestEmbeddedDistributedSharedNothingRunYAML(t *testing.T) {
 		_ = worker.Stop(context.Background())
 	})
 
-	waitForWorker(t, coord, "embedded-intg-worker")
+	require.NoError(t, worker.WaitReady(ctx))
 
 	run, err := engine.RunYAML(ctx, []byte(`
 name: embedded-intg-distributed
@@ -189,26 +193,4 @@ func (e *echoExecutor) Run(context.Context) error {
 	}
 	_, err := fmt.Fprintf(out, "embedded executor ran %s: %s\n", e.step.Name, command)
 	return err
-}
-
-func waitForWorker(t *testing.T, coord *test.Coordinator, workerID string) {
-	t.Helper()
-
-	client := coord.GetCoordinatorClient(t)
-	t.Cleanup(func() {
-		_ = client.Cleanup(context.Background())
-	})
-
-	require.Eventually(t, func() bool {
-		workers, err := client.GetWorkers(context.Background())
-		if err != nil {
-			return false
-		}
-		for _, worker := range workers {
-			if worker.WorkerId == workerID {
-				return true
-			}
-		}
-		return false
-	}, embeddedTimeout(5*time.Second), 50*time.Millisecond, "worker %s should register", workerID)
 }

--- a/internal/intg/embed/embed_test.go
+++ b/internal/intg/embed/embed_test.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package embed_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func embeddedTimeout(timeout time.Duration) time.Duration {
+	if runtime.GOOS == "windows" {
+		return timeout * 3
+	}
+	return timeout
+}
+
+func TestEmbeddedLocalRunYAML(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), embeddedTimeout(20*time.Second))
+	defer cancel()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, engine.Close(context.Background()))
+	})
+
+	run, err := engine.RunYAML(ctx, []byte(`
+name: embedded-intg-local
+type: graph
+steps:
+  - name: first
+    command: echo first
+  - name: second
+    command: echo second
+    depends: [first]
+`))
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "embedded-intg-local", status.Name)
+	require.Equal(t, "succeeded", status.Status)
+	require.NotEmpty(t, status.RunID)
+	require.NotEmpty(t, status.AttemptID)
+	require.NotEmpty(t, status.LogFile)
+	require.FileExists(t, status.LogFile)
+
+	saved, err := engine.Status(ctx, run.Ref())
+	require.NoError(t, err)
+	require.Equal(t, status.RunID, saved.RunID)
+	require.Equal(t, "succeeded", saved.Status)
+}
+
+func TestEmbeddedCustomExecutorRunYAML(t *testing.T) {
+	const executorType = "embedded_intg_echo"
+
+	dagu.RegisterExecutor(
+		executorType,
+		func(_ context.Context, step dagu.Step) (dagu.Executor, error) {
+			return &echoExecutor{step: step}, nil
+		},
+		dagu.WithExecutorCapabilities(dagu.ExecutorCapabilities{Command: true}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), embeddedTimeout(20*time.Second))
+	defer cancel()
+
+	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, engine.Close(context.Background()))
+	})
+
+	run, err := engine.RunYAML(ctx, []byte(`
+name: embedded-intg-custom-executor
+type: graph
+steps:
+  - name: go-step
+    type: embedded_intg_echo
+    command: called from YAML
+`))
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "embedded-intg-custom-executor", status.Name)
+	require.Equal(t, "succeeded", status.Status)
+}
+
+func TestEmbeddedDistributedSharedNothingRunYAML(t *testing.T) {
+	coord := test.SetupCoordinator(t, test.WithStatusPersistence())
+
+	ctx, cancel := context.WithTimeout(context.Background(), embeddedTimeout(45*time.Second))
+	defer cancel()
+
+	engine, err := dagu.New(ctx, dagu.Options{
+		HomeDir:     t.TempDir(),
+		DefaultMode: dagu.ExecutionModeDistributed,
+		Distributed: &dagu.DistributedOptions{
+			Coordinators:    []string{coord.Address()},
+			WorkerSelector:  map[string]string{"pool": "embedded-intg"},
+			PollInterval:    100 * time.Millisecond,
+			MaxStatusErrors: 20,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, engine.Close(context.Background()))
+	})
+
+	worker, err := engine.NewWorker(dagu.WorkerOptions{
+		ID:            "embedded-intg-worker",
+		MaxActiveRuns: 2,
+		Labels:        map[string]string{"pool": "embedded-intg"},
+		HealthPort:    0,
+	})
+	require.NoError(t, err)
+
+	workerCtx, stopWorker := context.WithCancel(ctx)
+	workerErrCh := make(chan error, 1)
+	go func() {
+		workerErrCh <- worker.Start(workerCtx)
+	}()
+	t.Cleanup(func() {
+		stopWorker()
+		_ = worker.Stop(context.Background())
+	})
+
+	waitForWorker(t, coord, "embedded-intg-worker")
+
+	run, err := engine.RunYAML(ctx, []byte(`
+name: embedded-intg-distributed
+type: graph
+steps:
+  - name: worker-step
+    command: echo distributed
+`))
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "embedded-intg-distributed", status.Name)
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-intg-worker", status.WorkerID)
+
+	stopWorker()
+	require.NoError(t, worker.Stop(context.Background()))
+	select {
+	case err := <-workerErrCh:
+		require.NoError(t, err)
+	case <-time.After(embeddedTimeout(5 * time.Second)):
+		t.Fatal("embedded worker did not stop")
+	}
+}
+
+type echoExecutor struct {
+	step   dagu.Step
+	stdout io.Writer
+}
+
+func (e *echoExecutor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *echoExecutor) SetStderr(io.Writer) {}
+
+func (e *echoExecutor) Kill(os.Signal) error {
+	return nil
+}
+
+func (e *echoExecutor) Run(context.Context) error {
+	out := e.stdout
+	if out == nil {
+		out = io.Discard
+	}
+	command := e.step.Command
+	if command == "" && len(e.step.Commands) > 0 {
+		command = e.step.Commands[0].CmdWithArgs
+	}
+	_, err := fmt.Fprintf(out, "embedded executor ran %s: %s\n", e.step.Name, command)
+	return err
+}
+
+func waitForWorker(t *testing.T, coord *test.Coordinator, workerID string) {
+	t.Helper()
+
+	client := coord.GetCoordinatorClient(t)
+	t.Cleanup(func() {
+		_ = client.Cleanup(context.Background())
+	})
+
+	require.Eventually(t, func() bool {
+		workers, err := client.GetWorkers(context.Background())
+		if err != nil {
+			return false
+		}
+		for _, worker := range workers {
+			if worker.WorkerId == workerID {
+				return true
+			}
+		}
+		return false
+	}, embeddedTimeout(5*time.Second), 50*time.Millisecond, "worker %s should register", workerID)
+}

--- a/internal/persis/fileproc/handle.go
+++ b/internal/persis/fileproc/handle.go
@@ -64,14 +64,15 @@ func NewProcHandler(file string, meta exec.ProcMeta, heartbeatInterval, syncInte
 
 // Stop implements models.Proc.
 func (p *ProcHandle) Stop(_ context.Context) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	if !p.started.Load() {
 		return fmt.Errorf("heartbeat not started")
 	}
 	if p.canceled.CompareAndSwap(false, true) {
-		if p.cancel != nil {
-			p.cancel()
+		p.mu.Lock()
+		cancel := p.cancel
+		p.mu.Unlock()
+		if cancel != nil {
+			cancel()
 		}
 		// Wait for the heartbeat goroutine to finish
 		p.wg.Wait()
@@ -106,7 +107,9 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 	}
 
 	hbCtx, cancel := context.WithCancel(ctx)
+	p.mu.Lock()
 	p.cancel = cancel
+	p.mu.Unlock()
 	p.canceled.Store(false)
 
 	p.wg.Add(1)
@@ -138,7 +141,9 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 				logger.Error(ctx, "Failed to remove heartbeat file",
 					tag.Error(err))
 			}
+			p.mu.Lock()
 			p.cancel = nil
+			p.mu.Unlock()
 			p.started.Store(false)
 			p.wg.Done()
 		}()

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -640,11 +640,22 @@ func (a *Agent) Run(ctx context.Context) error {
 		return initErr
 	}
 
+	originalWorkingDir, err := os.Getwd()
+	if err != nil {
+		initErr = fmt.Errorf("failed to get current working directory: %w", err)
+		return initErr
+	}
+
 	// Move to the working directory
 	if err := os.Chdir(a.evaluatedWorkingDir); err != nil {
 		initErr = fmt.Errorf("failed to change working directory: %w", err)
 		return initErr
 	}
+	defer func() {
+		if err := os.Chdir(originalWorkingDir); err != nil {
+			logger.Error(ctx, "Failed to restore working directory", tag.Error(err))
+		}
+	}()
 
 	// Create a new container if the DAG has a container configuration.
 	if a.dag.Container != nil {

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -640,22 +640,9 @@ func (a *Agent) Run(ctx context.Context) error {
 		return initErr
 	}
 
-	originalWorkingDir, err := os.Getwd()
-	if err != nil {
-		initErr = fmt.Errorf("failed to get current working directory: %w", err)
-		return initErr
-	}
-
-	// Move to the working directory
-	if err := os.Chdir(a.evaluatedWorkingDir); err != nil {
-		initErr = fmt.Errorf("failed to change working directory: %w", err)
-		return initErr
-	}
-	defer func() {
-		if err := os.Chdir(originalWorkingDir); err != nil {
-			logger.Error(ctx, "Failed to restore working directory", tag.Error(err))
-		}
-	}()
+	// Do not change the process working directory here. Agent runs can execute
+	// concurrently in the same process, so step executors receive WorkingDir
+	// through the runtime context and set per-command working directories.
 
 	// Create a new container if the DAG has a container configuration.
 	if a.dag.Container != nil {

--- a/internal/runtime/executor/executor.go
+++ b/internal/runtime/executor/executor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
@@ -41,7 +42,9 @@ type ExecutorFactory func(ctx context.Context, step core.Step) (Executor, error)
 
 // NewExecutor creates a new Executor based on the step's executor type.
 func NewExecutor(ctx context.Context, step core.Step) (Executor, error) {
+	executorRegistryMu.RLock()
 	factory, ok := executorRegistry[step.ExecutorConfig.Type]
+	executorRegistryMu.RUnlock()
 	if ok {
 		return factory(ctx, step)
 	}
@@ -55,14 +58,25 @@ func NewExecutor(ctx context.Context, step core.Step) (Executor, error) {
 
 // RegisterExecutor registers a new executor type with its factory, validator, and capabilities.
 func RegisterExecutor(executorType string, factory ExecutorFactory, validator core.StepValidator, caps core.ExecutorCapabilities) {
+	executorRegistryMu.Lock()
 	executorRegistry[executorType] = factory
+	executorRegistryMu.Unlock()
 	if validator != nil {
 		core.RegisterStepValidator(executorType, validator)
 	}
 	core.RegisterExecutorCapabilities(executorType, caps)
 }
 
+// UnregisterExecutor removes a registered executor type.
+func UnregisterExecutor(executorType string) {
+	executorRegistryMu.Lock()
+	defer executorRegistryMu.Unlock()
+	delete(executorRegistry, executorType)
+}
+
 var executorRegistry = make(map[string]ExecutorFactory)
+
+var executorRegistryMu sync.RWMutex
 
 // ExitCoder is an interface for executors that can return an exit code.
 type ExitCoder interface {

--- a/internal/service/worker/worker.go
+++ b/internal/service/worker/worker.go
@@ -247,6 +247,33 @@ func (w *Worker) Stop(ctx context.Context) error {
 	return err
 }
 
+// WaitReady blocks until the worker appears in coordinator registration.
+func (w *Worker) WaitReady(ctx context.Context) error {
+	if w == nil {
+		return fmt.Errorf("worker is not initialized")
+	}
+	if w.coordinatorCli == nil {
+		return fmt.Errorf("worker coordinator client is not configured")
+	}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		workers, err := w.coordinatorCli.GetWorkers(ctx)
+		if err == nil {
+			for _, item := range workers {
+				if item != nil && item.WorkerId == w.id {
+					return nil
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for worker %q registration: %w", w.id, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
 // trackingHandler wraps a TaskHandler to track running task state
 type trackingHandler struct {
 	worker      *Worker

--- a/tools.go
+++ b/tools.go
@@ -3,7 +3,7 @@
 
 //go:build tools
 
-package tools
+package dagu
 
 // This package keeps track of tool dependencies, see:
 // https://github.com/golang/go/issues/25922


### PR DESCRIPTION
## Summary
- add an experimental root `github.com/dagucloud/dagu` embedded engine API for local and shared-nothing distributed DAG execution
- expose async run handles, status/stop operations, embedded worker startup, and custom executor registration
- add runnable embedded examples and integration coverage for local, custom executor, and distributed embedded execution

## Testing
- `go test ./internal/intg/embed -count=1`
- `go test ./examples/embedded/... ./internal/core/spec ./internal/engine . -count=1`
- `GOOS=linux GOARCH=amd64 go test -c ./internal/intg/embed -o /tmp/dagu-embed-linux-amd64.test`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/intg/embed -o /tmp/dagu-embed-windows-amd64.test.exe`
- `go test ./... -run '^$'`

## Notes
- Linux and Windows runtime coverage should be validated by CI runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Embedded engine API enabling DAG workflow execution from Go applications
  * Local execution mode for single-machine workflow runs
  * Distributed execution mode with coordinator support for multi-worker deployments
  * Custom executor registration capability for extended functionality
  * Parameter injection and workflow configuration management
  * Worker lifecycle management for distributed architectures

* **Documentation**
  * Comprehensive usage guide with local, distributed, and custom executor examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->