### PR TITLE
fix: align embedded engine run labels

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -145,7 +145,7 @@ type runOptions struct {
 	defaultWorkingDir string
 	mode              ExecutionMode
 	workerSelector    map[string]string
-	tags              []string
+	labels            []string
 	dryRun            bool
 }
 
@@ -356,11 +356,18 @@ func WithWorkerSelector(selector map[string]string) RunOption {
 	}
 }
 
-// WithTags adds tags to one run.
-func WithTags(tags ...string) RunOption {
+// WithLabels adds labels to one run.
+func WithLabels(labels ...string) RunOption {
 	return func(o *runOptions) {
-		o.tags = cloneSlice(tags)
+		o.labels = cloneSlice(labels)
 	}
+}
+
+// WithTags adds labels to one run.
+//
+// Deprecated: use WithLabels.
+func WithTags(tags ...string) RunOption {
+	return WithLabels(tags...)
 }
 
 // WithDryRun enables or disables dry-run mode.
@@ -418,7 +425,7 @@ func internalRunOptions(opts runOptions) iengine.RunOptions {
 		DefaultWorkingDir: opts.defaultWorkingDir,
 		Mode:              iengine.ExecutionMode(opts.mode),
 		WorkerSelector:    opts.workerSelector,
-		Tags:              opts.tags,
+		Labels:            opts.labels,
 		DryRun:            opts.dryRun,
 	}
 }

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -278,18 +278,18 @@ func applyRunOverrides(dag *core.DAG, opts RunOptions) {
 	if len(opts.WorkerSelector) > 0 {
 		dag.WorkerSelector = cloneStringMap(opts.WorkerSelector)
 	}
-	if len(opts.Tags) > 0 {
-		seen := make(map[string]struct{}, len(dag.Tags)+len(opts.Tags))
-		for _, existing := range dag.Tags {
+	if len(opts.Labels) > 0 {
+		seen := make(map[string]struct{}, len(dag.Labels)+len(opts.Labels))
+		for _, existing := range dag.Labels {
 			seen[existing.String()] = struct{}{}
 		}
-		for _, candidate := range core.NewTags(opts.Tags) {
+		for _, candidate := range core.NewLabels(opts.Labels) {
 			key := candidate.String()
 			if _, ok := seen[key]; ok {
 				continue
 			}
 			seen[key] = struct{}{}
-			dag.Tags = append(dag.Tags, candidate)
+			dag.Labels = append(dag.Labels, candidate)
 		}
 	}
 }
@@ -428,8 +428,8 @@ func (e *Engine) runDistributed(ctx context.Context, dag *core.DAG, runID string
 	if len(dist.WorkerSelector) > 0 {
 		taskOpts = append(taskOpts, runtimeexec.WithWorkerSelector(dist.WorkerSelector))
 	}
-	if len(dag.Tags) > 0 {
-		taskOpts = append(taskOpts, runtimeexec.WithTags(strings.Join(dag.Tags.Strings(), ",")))
+	if len(dag.Labels) > 0 {
+		taskOpts = append(taskOpts, runtimeexec.WithLabels(strings.Join(dag.Labels.Strings(), ",")))
 	}
 	if dag.SourceFile != "" {
 		taskOpts = append(taskOpts, runtimeexec.WithSourceFile(dag.SourceFile))

--- a/internal/engine/run_test.go
+++ b/internal/engine/run_test.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRunOverridesMergesLabels(t *testing.T) {
+	dag := &core.DAG{
+		Labels: core.NewLabels([]string{"env=prod"}),
+	}
+
+	applyRunOverrides(dag, RunOptions{
+		Labels: []string{"env=prod", "team=platform"},
+	})
+
+	require.Equal(t, []string{"env=prod", "team=platform"}, dag.Labels.Strings())
+}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -61,7 +61,7 @@ type RunOptions struct {
 	DefaultWorkingDir string
 	Mode              ExecutionMode
 	WorkerSelector    map[string]string
-	Tags              []string
+	Labels            []string
 	DryRun            bool
 }
 


### PR DESCRIPTION
## Summary
- align embedded run label overrides with `core.DAG.Labels`
- add `WithLabels` for embedded runs while keeping `WithTags` as a deprecated alias
- pass distributed embedded run labels through `executor.WithLabels`

## Testing
- make fmt
- go test . ./internal/engine
- make check (local go fix/go fmt passed; local golangci-lint exited before analysis with `no go files to analyze`, so GitHub CI should validate lint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration for run metadata now uses labels instead of tags, providing updated support for specifying metadata
  * Deprecated tags option remains fully available for backward compatibility with existing implementations
  * Labels are now properly integrated across the entire execution pipeline including distributed task handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->