### PR TITLE
docs: fix double-negative in comment in internal/runtime/condition.go

### DIFF
--- a/internal/runtime/condition.go
+++ b/internal/runtime/condition.go
@@ -20,7 +20,7 @@ var (
 	ErrConditionNotMet = fmt.Errorf("condition was not met")
 )
 
-// Error message for the case not all condition was not met
+// Error message for when not all conditions are met
 const ErrMsgOtherConditionNotMet = "other condition was not met"
 
 // EvalConditions evaluates a list of conditions and checks the results.


### PR DESCRIPTION
## Summary

Fixes a confusing double-negative comment in `internal/runtime/condition.go`.

## Change

**Before:**
```go
// Error message for the case not all condition was not met
```

**After:**
```go
// Error message for when not all conditions are met
```

## Explanation

The original comment has two issues:
1. **Double-negative**: "not all condition was **not** met" — the two negatives cancel each other, making the sentence mean the opposite of the intent.
2. **Singular/plural**: "condition" should be "conditions" since this relates to multiple conditions.

The fix makes the comment clear and grammatically correct.

Closes #2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity of internal documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->