### PR TITLE
fix: handle Windows file persistence races

### DIFF
--- a/internal/cmn/fileutil/replace_unix.go
+++ b/internal/cmn/fileutil/replace_unix.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package fileutil
+
+import "os"
+
+func replaceFile(source, target string) error {
+	return os.Rename(source, target)
+}

--- a/internal/cmn/fileutil/replace_windows.go
+++ b/internal/cmn/fileutil/replace_windows.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package fileutil
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(source, target string) error {
+	sourcePtr, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	targetPtr, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		sourcePtr,
+		targetPtr,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/internal/cmn/fileutil/retry.go
+++ b/internal/cmn/fileutil/retry.go
@@ -5,7 +5,6 @@ package fileutil
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -51,24 +50,8 @@ func RenameWithRetry(oldPath, newPath string) error {
 // sharing violations that can happen while another process is still releasing
 // the target file handle.
 func ReplaceFileWithRetry(source, target string) error {
-	if runtime.GOOS != "windows" {
-		return os.Rename(source, target)
-	}
-
 	return retryWindowsFileOp(func() error {
-		info, err := os.Stat(target)
-		switch {
-		case err == nil:
-			if info.IsDir() {
-				return fmt.Errorf("target path is a directory: %s", target)
-			}
-			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-		case !os.IsNotExist(err):
-			return err
-		}
-		return os.Rename(source, target)
+		return replaceFile(source, target)
 	})
 }
 

--- a/internal/cmn/fileutil/retry_test.go
+++ b/internal/cmn/fileutil/retry_test.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceFileWithRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("overwrites existing target", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		source := filepath.Join(dir, "source.txt")
+		target := filepath.Join(dir, "target.txt")
+		require.NoError(t, os.WriteFile(source, []byte("new"), 0o600))
+		require.NoError(t, os.WriteFile(target, []byte("old"), 0o600))
+
+		require.NoError(t, ReplaceFileWithRetry(source, target))
+
+		data, err := os.ReadFile(target)
+		require.NoError(t, err)
+		require.Equal(t, []byte("new"), data)
+		require.NoFileExists(t, source)
+	})
+
+	t.Run("creates missing target", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		source := filepath.Join(dir, "source.txt")
+		target := filepath.Join(dir, "target.txt")
+		require.NoError(t, os.WriteFile(source, []byte("new"), 0o600))
+
+		require.NoError(t, ReplaceFileWithRetry(source, target))
+
+		data, err := os.ReadFile(target)
+		require.NoError(t, err)
+		require.Equal(t, []byte("new"), data)
+		require.NoFileExists(t, source)
+	})
+}

--- a/internal/persis/fileproc/handle.go
+++ b/internal/persis/fileproc/handle.go
@@ -215,7 +215,7 @@ func (p *ProcHandle) openInitializedProcFile(heartbeatUnix int64) (*os.File, err
 	// Keep the temporary name short. Proc file names already include encoded
 	// run and attempt IDs, and deriving the temp name from them can exceed
 	// Windows path limits even when the final proc path is still valid.
-	tmpFile, err := os.CreateTemp(dir, ".proc-*.tmp")
+	tmpFile, err := createTempProcFile(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp proc file: %w", err)
 	}
@@ -248,4 +248,18 @@ func (p *ProcHandle) openInitializedProcFile(heartbeatUnix int64) (*os.File, err
 		return nil, fmt.Errorf("failed to reopen proc file: %w", err)
 	}
 	return fd, nil
+}
+
+func createTempProcFile(dir string) (*os.File, error) {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, err
+	}
+	tmpFile, err := os.CreateTemp(dir, ".proc-*.tmp")
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return tmpFile, err
+	}
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, err
+	}
+	return os.CreateTemp(dir, ".proc-*.tmp")
 }

--- a/internal/persis/fileproc/handle_test.go
+++ b/internal/persis/fileproc/handle_test.go
@@ -137,3 +137,27 @@ func TestProcHandle_StartPublishesInitializedFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, meta, entry.Meta)
 }
+
+func TestProcHandle_OpenInitializedProcFileRecreatesMissingParentDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	meta := testProcMetaFromRun(exec.NewDAGRunRef("test_proc", "run-1"))
+	fileName := procFilePath(tmpDir, exec.NewUTC(time.Now()), meta)
+	proc := NewProcHandler(fileName, meta, 0, 0)
+	dagDir := filepath.Dir(fileName)
+
+	require.NoError(t, os.MkdirAll(dagDir, 0750))
+	require.NoError(t, os.Remove(dagDir))
+
+	fd, err := proc.openInitializedProcFile(time.Now().Unix())
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+	t.Cleanup(func() {
+		_ = os.Remove(fileName)
+	})
+
+	_, err = os.Stat(fileName)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- replace Windows status-file compaction with MoveFileEx so readers never observe a removed status file between compact and rename
- make proc heartbeat publication recreate its parent directory if concurrent restart cleanup removes it between directory creation and temp-file creation
- add coverage for status-file replacement and proc heartbeat publication with a missing parent directory

## Testing
- go test ./internal/cmn/fileutil -count=1
- go test ./internal/persis/fileproc -count=1
- go test ./internal/cmd -run TestRestartCommand_BuiltExecutableRestoresExplicitEnv -count=5
- go test ./internal/cmd -count=1
- go test ./internal/service/frontend/api/v1 -run 'TestApproveDAGRunStep|TestApproveDAGRunStepWithInputs|TestApproveDAGRunStepMissingRequired' -count=5
- go test ./internal/persis/filedagrun -count=1
- go test ./internal/service/frontend/api/v1 -count=1
- go test ./internal/cmn/fileutil ./internal/persis/fileproc ./internal/persis/filedagrun ./internal/service/frontend/api/v1 -count=1
- env GOOS=windows GOARCH=amd64 go test -c -o /tmp/fileutil.test.exe ./internal/cmn/fileutil
- env GOOS=windows GOARCH=amd64 go test -c -o /tmp/api-v1.test.exe ./internal/service/frontend/api/v1
- env GOOS=windows GOARCH=amd64 go test -c -o /tmp/filedagrun.test.exe ./internal/persis/filedagrun
- env GOOS=windows GOARCH=amd64 go test -c -o /tmp/fileproc.test.exe ./internal/persis/fileproc
- env GOOS=windows GOARCH=amd64 go test -c -o /tmp/cmd.test.exe ./internal/cmd
- git diff --check