### PR TITLE
fix: restore DAG status live updates

### DIFF
--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -2342,7 +2342,7 @@ func deriveManualDAGRunStatus(nodes []*exec.Node, fallback core.Status) core.Sta
 			hasRejected = true
 		case core.NodeFailed:
 			hasFailed = true
-			if node.Step.ContinueOn.Failure && !node.Step.ContinueOn.MarkSuccess {
+			if node.Step.ContinueOn.Failure {
 				hasContinuableFailure = true
 			} else {
 				hasUncontinuableFailure = true
@@ -2363,7 +2363,7 @@ func deriveManualDAGRunStatus(nodes []*exec.Node, fallback core.Status) core.Sta
 	case hasRunning:
 		return core.Running
 	case hasRetrying:
-		return core.Queued
+		return core.Running
 	case hasWaiting:
 		return core.Waiting
 	case hasRejected:
@@ -3437,7 +3437,13 @@ func (a *API) GetDAGRunDetailsData(ctx context.Context, identifier string) (any,
 	if !ok {
 		return nil, fmt.Errorf("invalid identifier format: %s (expected 'dagName/dagRunId')", identifier)
 	}
-	return a.getDAGRunDetailsData(ctx, dagName, dagRunId)
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dag-runs/{name}/{dagRunId}",
+		dagName:  dagName,
+		dagRunID: dagRunId,
+	}, func(readCtx context.Context) (api.GetDAGRunDetails200JSONResponse, error) {
+		return a.getDAGRunDetailsData(readCtx, dagName, dagRunId)
+	})
 }
 
 // GetSubDAGRunDetailsData returns sub DAG run details for SSE.
@@ -3483,6 +3489,14 @@ func (a *API) GetSubDAGRunDetailsData(ctx context.Context, identifier string) (a
 // GetDAGRunLogsData returns DAG run logs for SSE.
 // Identifier format: "dagName/dagRunId" or "dagName/dagRunId?tail=N"
 func (a *API) GetDAGRunLogsData(ctx context.Context, identifier string) (any, error) {
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dag-runs/{name}/{dagRunId}/logs",
+	}, func(readCtx context.Context) (DAGRunLogsResponse, error) {
+		return a.getDAGRunLogsData(readCtx, identifier)
+	})
+}
+
+func (a *API) getDAGRunLogsData(ctx context.Context, identifier string) (DAGRunLogsResponse, error) {
 	// Parse query params if present
 	pathPart := identifier
 	var queryParams url.Values
@@ -3500,16 +3514,16 @@ func (a *API) GetDAGRunLogsData(ctx context.Context, identifier string) (any, er
 
 	dagName, dagRunId, ok := strings.Cut(pathPart, "/")
 	if !ok {
-		return nil, fmt.Errorf("invalid identifier format: %s (expected 'dagName/dagRunId')", identifier)
+		return DAGRunLogsResponse{}, fmt.Errorf("invalid identifier format: %s (expected 'dagName/dagRunId')", identifier)
 	}
 
 	ref := exec.NewDAGRunRef(dagName, dagRunId)
 	dagStatus, err := a.dagRunMgr.GetSavedStatus(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
+		return DAGRunLogsResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
 	if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(dagStatus)); err != nil {
-		return nil, err
+		return DAGRunLogsResponse{}, err
 	}
 
 	// Parse tail parameter with bounds validation (100-10000, default 500)
@@ -3525,7 +3539,7 @@ func (a *API) GetDAGRunLogsData(ctx context.Context, identifier string) (any, er
 
 	content, lineCount, totalLines, hasMore, _, err := fileutil.ReadLogContent(dagStatus.Log, options)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("error reading scheduler log: %w", err)
+		return DAGRunLogsResponse{}, fmt.Errorf("error reading scheduler log: %w", err)
 	}
 
 	schedulerLog := SchedulerLogInfo{
@@ -3559,24 +3573,32 @@ func (a *API) GetDAGRunLogsData(ctx context.Context, identifier string) (any, er
 // GetStepLogData returns step log for SSE.
 // Identifier format: "dagName/dagRunId/stepName"
 func (a *API) GetStepLogData(ctx context.Context, identifier string) (any, error) {
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dag-runs/{name}/{dagRunId}/logs/steps/{stepName}",
+	}, func(readCtx context.Context) (StepLogResponse, error) {
+		return a.getStepLogData(readCtx, identifier)
+	})
+}
+
+func (a *API) getStepLogData(ctx context.Context, identifier string) (StepLogResponse, error) {
 	parts := strings.SplitN(identifier, "/", 3)
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid identifier format: %s (expected 'dagName/dagRunId/stepName')", identifier)
+		return StepLogResponse{}, fmt.Errorf("invalid identifier format: %s (expected 'dagName/dagRunId/stepName')", identifier)
 	}
 	dagName, dagRunId, stepName := parts[0], parts[1], parts[2]
 
 	ref := exec.NewDAGRunRef(dagName, dagRunId)
 	dagStatus, err := a.dagRunMgr.GetSavedStatus(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
+		return StepLogResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
 	if err := a.requireDAGRunStatusVisible(ctx, dagStatus); err != nil {
-		return nil, err
+		return StepLogResponse{}, err
 	}
 
 	node, err := dagStatus.NodeByName(stepName)
 	if err != nil {
-		return nil, fmt.Errorf("step %s not found in DAG %s", stepName, dagName)
+		return StepLogResponse{}, fmt.Errorf("step %s not found in DAG %s", stepName, dagName)
 	}
 
 	options := fileutil.LogReadOptions{
@@ -3591,7 +3613,7 @@ func (a *API) GetStepLogData(ctx context.Context, identifier string) (any, error
 	if node.Stdout != "" {
 		stdoutContent, lineCount, totalLines, hasMore, _, err = fileutil.ReadLogContent(node.Stdout, options)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("error reading stdout: %w", err)
+			return StepLogResponse{}, fmt.Errorf("error reading stdout: %w", err)
 		}
 	}
 

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1148,6 +1148,7 @@ func (a *API) UpdateDAGRunStepStatus(ctx context.Context, request api.UpdateDAGR
 	}
 
 	dagStatus.Nodes[stepIdx].Status = nodeStatusMapping[request.Body.Status]
+	dagStatus.Status = deriveManualDAGRunStatus(dagStatus.Nodes, dagStatus.Status)
 
 	if err := a.updateDAGRunStatus(ctx, ref, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating status: %w", err)
@@ -2277,6 +2278,7 @@ func (a *API) UpdateSubDAGRunStepStatus(ctx context.Context, request api.UpdateS
 	}
 
 	dagStatus.Nodes[stepIdx].Status = nodeStatusMapping[request.Body.Status]
+	dagStatus.Status = deriveManualDAGRunStatus(dagStatus.Nodes, dagStatus.Status)
 
 	if err := a.updateDAGRunStatus(ctx, root, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating status: %w", err)
@@ -2304,6 +2306,85 @@ var nodeStatusMapping = map[api.NodeStatus]core.NodeStatus{
 	api.NodeStatusWaiting:        core.NodeWaiting,
 	api.NodeStatusRejected:       core.NodeRejected,
 	api.NodeStatusRetrying:       core.NodeRetrying,
+}
+
+func deriveManualDAGRunStatus(nodes []*exec.Node, fallback core.Status) core.Status {
+	if len(nodes) == 0 {
+		return fallback
+	}
+
+	var (
+		hasRunning              bool
+		hasRetrying             bool
+		hasWaiting              bool
+		hasRejected             bool
+		hasFailed               bool
+		hasUncontinuableFailure bool
+		hasContinuableFailure   bool
+		hasAborted              bool
+		hasPartial              bool
+		hasSuccess              bool
+		hasNotStarted           bool
+	)
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		switch node.Status {
+		case core.NodeRunning:
+			hasRunning = true
+		case core.NodeRetrying:
+			hasRetrying = true
+		case core.NodeWaiting:
+			hasWaiting = true
+		case core.NodeRejected:
+			hasRejected = true
+		case core.NodeFailed:
+			hasFailed = true
+			if node.Step.ContinueOn.Failure && !node.Step.ContinueOn.MarkSuccess {
+				hasContinuableFailure = true
+			} else {
+				hasUncontinuableFailure = true
+			}
+		case core.NodeAborted:
+			hasAborted = true
+		case core.NodePartiallySucceeded:
+			hasPartial = true
+			hasSuccess = true
+		case core.NodeSucceeded, core.NodeSkipped:
+			hasSuccess = true
+		case core.NodeNotStarted:
+			hasNotStarted = true
+		}
+	}
+
+	switch {
+	case hasRunning:
+		return core.Running
+	case hasRetrying:
+		return core.Queued
+	case hasWaiting:
+		return core.Waiting
+	case hasRejected:
+		return core.Rejected
+	case hasFailed && hasUncontinuableFailure:
+		return core.Failed
+	case hasFailed && hasContinuableFailure && hasSuccess:
+		return core.PartiallySucceeded
+	case hasFailed:
+		return core.Failed
+	case hasAborted:
+		return core.Aborted
+	case hasPartial:
+		return core.PartiallySucceeded
+	case hasNotStarted && !hasSuccess:
+		return core.NotStarted
+	case hasNotStarted:
+		return core.Running
+	default:
+		return core.Succeeded
+	}
 }
 
 func (a *API) RetryDAGRun(ctx context.Context, request api.RetryDAGRunRequestObject) (api.RetryDAGRunResponseObject, error) {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -2381,7 +2381,7 @@ func deriveManualDAGRunStatus(nodes []*exec.Node, fallback core.Status) core.Sta
 	case hasNotStarted && !hasSuccess:
 		return core.NotStarted
 	case hasNotStarted:
-		return core.Running
+		return core.PartiallySucceeded
 	default:
 		return core.Succeeded
 	}
@@ -3923,20 +3923,24 @@ func artifactPreviewLimit(kind api.ArtifactPreviewKind) int64 {
 // GetDAGRunsListData returns DAG runs list for SSE.
 // Identifier format: URL query string (e.g., "status=running&name=mydag")
 func (a *API) GetDAGRunsListData(ctx context.Context, queryString string) (any, error) {
-	opts, err := a.dagRunListOptionsFromQueryString(ctx, queryString)
-	if err != nil {
-		return nil, err
-	}
-
-	page, err := a.dagRunStore.ListStatusesPage(ctx, opts.query...)
-	if err != nil {
-		if errors.Is(err, filedagrun.ErrInvalidQueryCursor) {
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dag-runs",
+	}, func(readCtx context.Context) (any, error) {
+		opts, err := a.dagRunListOptionsFromQueryString(readCtx, queryString)
+		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("error listing dag-runs: %w", err)
-	}
 
-	return toDAGRunsPageResponse(page), nil
+		page, err := a.dagRunStore.ListStatusesPage(readCtx, opts.query...)
+		if err != nil {
+			if errors.Is(err, filedagrun.ErrInvalidQueryCursor) {
+				return nil, err
+			}
+			return nil, fmt.Errorf("error listing dag-runs: %w", err)
+		}
+
+		return toDAGRunsPageResponse(page), nil
+	})
 }
 
 func (a *API) dagRunListOptionsFromQueryString(ctx context.Context, queryString string) (dagRunListOptions, error) {

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -42,6 +42,42 @@ func requireNoDeprecatedTagsKey(t *testing.T, data []byte) {
 	require.False(t, ok)
 }
 
+func TestDeriveManualDAGRunStatusRetryingIsRunning(t *testing.T) {
+	t.Parallel()
+
+	status := deriveManualDAGRunStatus([]*exec.Node{
+		{
+			Step:   core.Step{Name: "retrying"},
+			Status: core.NodeRetrying,
+		},
+	}, core.Failed)
+
+	assert.Equal(t, core.Running, status)
+}
+
+func TestDeriveManualDAGRunStatusContinueOnMarkSuccessIsContinuable(t *testing.T) {
+	t.Parallel()
+
+	status := deriveManualDAGRunStatus([]*exec.Node{
+		{
+			Step: core.Step{
+				Name: "failed-continuable",
+				ContinueOn: core.ContinueOn{
+					Failure:     true,
+					MarkSuccess: true,
+				},
+			},
+			Status: core.NodeFailed,
+		},
+		{
+			Step:   core.Step{Name: "succeeded"},
+			Status: core.NodeSucceeded,
+		},
+	}, core.Running)
+
+	assert.Equal(t, core.PartiallySucceeded, status)
+}
+
 func TestApplyInlineEnqueueLabels_ArrayLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -78,6 +78,23 @@ func TestDeriveManualDAGRunStatusContinueOnMarkSuccessIsContinuable(t *testing.T
 	assert.Equal(t, core.PartiallySucceeded, status)
 }
 
+func TestDeriveManualDAGRunStatusMixedNotStartedAndSucceededIsNonRunning(t *testing.T) {
+	t.Parallel()
+
+	status := deriveManualDAGRunStatus([]*exec.Node{
+		{
+			Step:   core.Step{Name: "succeeded"},
+			Status: core.NodeSucceeded,
+		},
+		{
+			Step:   core.Step{Name: "reset"},
+			Status: core.NodeNotStarted,
+		},
+	}, core.Succeeded)
+
+	assert.Equal(t, core.PartiallySucceeded, status)
+}
+
 func TestApplyInlineEnqueueLabels_ArrayLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1388,6 +1388,50 @@ func seedLatestDAGRunStatus(
 	return ref
 }
 
+func TestUpdateDAGRunStepStatusRecomputesAggregateStatus(t *testing.T) {
+	server := test.SetupServer(t)
+
+	dag := &core.DAG{
+		Name: "manual_step_status_aggregate",
+		Steps: []core.Step{
+			{Name: "step1"},
+			{Name: "step2"},
+		},
+	}
+	const dagRunID = "manual-step-status-run"
+	seedLatestDAGRunStatus(
+		t,
+		server,
+		dag,
+		dagRunID,
+		core.Succeeded,
+		seedDAGRunStatusOptions{
+			nodeStatuses: map[string]core.NodeStatus{
+				"step1": core.NodeSucceeded,
+				"step2": core.NodeSucceeded,
+			},
+		},
+	)
+
+	server.Client().Patch(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/steps/%s/status", dag.Name, dagRunID, "step1"),
+		api.UpdateDAGRunStepStatusJSONRequestBody{Status: api.NodeStatusFailed},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	status := waitForStoredDAGRunStatus(
+		t,
+		server,
+		dag.Name,
+		dagRunID,
+		5*time.Second,
+		func(status *exec.DAGRunStatus) bool {
+			return status.Status == core.Failed &&
+				hasNodeWithStatus(status, "step1", core.NodeFailed)
+		},
+	)
+	require.Equal(t, core.Failed, status.Status)
+}
+
 func TestDeleteDAGRun(t *testing.T) {
 	server := test.SetupServer(t)
 	dag := &core.DAG{Name: "delete_run_dag"}

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1713,27 +1713,32 @@ func (a *API) GetDAGDetailsData(ctx context.Context, fileName string) (any, erro
 // GetDAGHistoryData returns DAG execution history for SSE.
 // Identifier format: "fileName"
 func (a *API) GetDAGHistoryData(ctx context.Context, fileName string) (any, error) {
-	dag, err := a.dagStore.GetDetails(ctx, fileName, spec.WithAllowBuildErrors())
-	if err != nil {
-		return nil, err
-	}
-	if err := a.requireWorkspaceVisible(ctx, dagWorkspaceName(dag)); err != nil {
-		return nil, err
-	}
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dags/{fileName}/dag-runs",
+		dagName:  fileName,
+	}, func(readCtx context.Context) (api.GetDAGDAGRunHistory200JSONResponse, error) {
+		dag, err := a.dagStore.GetDetails(readCtx, fileName, spec.WithAllowBuildErrors())
+		if err != nil {
+			return api.GetDAGDAGRunHistory200JSONResponse{}, err
+		}
+		if err := a.requireWorkspaceVisible(readCtx, dagWorkspaceName(dag)); err != nil {
+			return api.GetDAGDAGRunHistory200JSONResponse{}, err
+		}
 
-	dagName := a.resolveDAGName(ctx, fileName)
-	recentHistory := a.dagRunMgr.ListRecentStatus(ctx, dagName, defaultHistoryLimit)
+		dagName := a.resolveDAGName(readCtx, fileName)
+		recentHistory := a.dagRunMgr.ListRecentStatus(readCtx, dagName, defaultHistoryLimit)
 
-	var dagRuns []api.DAGRunDetails
-	for _, status := range recentHistory {
-		dagRuns = append(dagRuns, ToDAGRunDetails(status))
-	}
+		var dagRuns []api.DAGRunDetails
+		for _, status := range recentHistory {
+			dagRuns = append(dagRuns, ToDAGRunDetails(status))
+		}
 
-	gridData := a.readHistoryData(ctx, dag, recentHistory)
-	return api.GetDAGDAGRunHistory200JSONResponse{
-		DagRuns:  dagRuns,
-		GridData: gridData,
-	}, nil
+		gridData := a.readHistoryData(readCtx, dag, recentHistory)
+		return api.GetDAGDAGRunHistory200JSONResponse{
+			DagRuns:  dagRuns,
+			GridData: gridData,
+		}, nil
+	})
 }
 
 // GetDAGsListData returns DAGs list for SSE.

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1744,55 +1744,59 @@ func (a *API) GetDAGHistoryData(ctx context.Context, fileName string) (any, erro
 // GetDAGsListData returns DAGs list for SSE.
 // Identifier format: URL query string (e.g., "page=1&perPage=100&name=mydag")
 func (a *API) GetDAGsListData(ctx context.Context, queryString string) (any, error) {
-	params, err := url.ParseQuery(queryString)
-	if err != nil {
-		logger.Warn(ctx, "Failed to parse query string for DAGs list",
-			tag.Error(err),
-			slog.String("queryString", queryString),
-		)
-	}
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/dags",
+	}, func(readCtx context.Context) (any, error) {
+		params, err := url.ParseQuery(queryString)
+		if err != nil {
+			logger.Warn(readCtx, "Failed to parse query string for DAGs list",
+				tag.Error(err),
+				slog.String("queryString", queryString),
+			)
+		}
 
-	page := parseIntParam(params.Get("page"), 1)
-	perPage := parseIntParam(params.Get("perPage"), 100)
+		page := parseIntParam(params.Get("page"), 1)
+		perPage := parseIntParam(params.Get("perPage"), 100)
 
-	sortField := params.Get("sort")
-	if sortField == "" {
-		sortField = "name"
-	}
-	sortOrder := params.Get("order")
-	if sortOrder == "" {
-		sortOrder = "asc"
-	}
+		sortField := params.Get("sort")
+		if sortField == "" {
+			sortField = "name"
+		}
+		sortOrder := params.Get("order")
+		if sortOrder == "" {
+			sortOrder = "asc"
+		}
 
-	var labelsParam, deprecatedTagsParam *string
-	if rawLabels := params.Get("labels"); rawLabels != "" {
-		labelsParam = &rawLabels
-	}
-	if rawTags := params.Get("tags"); rawTags != "" {
-		deprecatedTagsParam = &rawTags
-	}
-	labelQueryParam, labelErr := queryLabelsParam(labelsParam, deprecatedTagsParam)
-	if labelErr != nil {
-		return nil, labelErr
-	}
-	labels := parseCommaSeparatedLabels(labelQueryParam)
+		var labelsParam, deprecatedTagsParam *string
+		if rawLabels := params.Get("labels"); rawLabels != "" {
+			labelsParam = &rawLabels
+		}
+		if rawTags := params.Get("tags"); rawTags != "" {
+			deprecatedTagsParam = &rawTags
+		}
+		labelQueryParam, labelErr := queryLabelsParam(labelsParam, deprecatedTagsParam)
+		if labelErr != nil {
+			return nil, labelErr
+		}
+		labels := parseCommaSeparatedLabels(labelQueryParam)
 
-	pg := exec.NewPaginator(page, perPage)
-	workspaceParam := workspaceParamFromValues(params)
-	workspaceFilter, err := a.workspaceFilterForParams(ctx, workspaceParam)
-	if err != nil {
-		return nil, err
-	}
-	listOpts := exec.ListDAGsOptions{
-		Paginator:       &pg,
-		Name:            params.Get("name"),
-		Labels:          labels,
-		Sort:            sortField,
-		Order:           sortOrder,
-		WorkspaceFilter: workspaceFilter,
-	}
+		pg := exec.NewPaginator(page, perPage)
+		workspaceParam := workspaceParamFromValues(params)
+		workspaceFilter, err := a.workspaceFilterForParams(readCtx, workspaceParam)
+		if err != nil {
+			return nil, err
+		}
+		listOpts := exec.ListDAGsOptions{
+			Paginator:       &pg,
+			Name:            params.Get("name"),
+			Labels:          labels,
+			Sort:            sortField,
+			Order:           sortOrder,
+			WorkspaceFilter: workspaceFilter,
+		}
 
-	return a.listDAGsData(ctx, listOpts)
+		return a.listDAGsData(readCtx, listOpts)
+	})
 }
 
 func (a *API) listDAGsData(ctx context.Context, listOpts exec.ListDAGsOptions) (api.ListDAGs200JSONResponse, error) {

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1758,13 +1758,19 @@ func (a *API) GetDAGsListData(ctx context.Context, queryString string) (any, err
 		page := parseIntParam(params.Get("page"), 1)
 		perPage := parseIntParam(params.Get("perPage"), 100)
 
-		sortField := params.Get("sort")
+		sortField := a.config.UI.DAGs.SortField
 		if sortField == "" {
 			sortField = "name"
 		}
-		sortOrder := params.Get("order")
+		if rawSort := params.Get("sort"); rawSort != "" {
+			sortField = rawSort
+		}
+		sortOrder := a.config.UI.DAGs.SortOrder
 		if sortOrder == "" {
 			sortOrder = "asc"
+		}
+		if rawOrder := params.Get("order"); rawOrder != "" {
+			sortOrder = rawOrder
 		}
 
 		var labelsParam, deprecatedTagsParam *string

--- a/internal/service/frontend/api/v1/dags_internal_test.go
+++ b/internal/service/frontend/api/v1/dags_internal_test.go
@@ -117,6 +117,56 @@ steps:
 	require.True(t, listResp.Dags[0].NextRun.Equal(*sseResp.Dags[0].NextRun))
 }
 
+func TestGetDAGsListDataUsesConfiguredListDefaults(t *testing.T) {
+	t.Parallel()
+
+	helper := test.Setup(t, test.WithStatusPersistence())
+	helper.Config.UI.DAGs.SortField = "name"
+	helper.Config.UI.DAGs.SortOrder = "desc"
+	helper.DAG(t, `
+name: sse-sort-alpha
+steps:
+  - command: echo alpha
+`)
+	helper.DAG(t, `
+name: sse-sort-zulu
+steps:
+  - command: echo zulu
+`)
+
+	api := localapi.New(
+		helper.DAGStore,
+		helper.DAGRunStore,
+		helper.QueueStore,
+		helper.ProcStore,
+		helper.DAGRunMgr,
+		helper.Config,
+		nil,
+		helper.ServiceRegistry,
+		nil,
+		nil,
+	)
+
+	listRespObj, err := api.ListDAGs(context.Background(), openapi.ListDAGsRequestObject{
+		Params: openapi.ListDAGsParams{},
+	})
+	require.NoError(t, err)
+
+	listResp, ok := listRespObj.(*openapi.ListDAGs200JSONResponse)
+	require.True(t, ok)
+	require.Len(t, listResp.Dags, 2)
+	require.Equal(t, "sse-sort-zulu", listResp.Dags[0].Dag.Name)
+
+	sseRespAny, err := api.GetDAGsListData(context.Background(), "")
+	require.NoError(t, err)
+
+	sseResp, ok := sseRespAny.(openapi.ListDAGs200JSONResponse)
+	require.True(t, ok)
+	require.Len(t, sseResp.Dags, 2)
+	require.Equal(t, listResp.Dags[0].Dag.Name, sseResp.Dags[0].Dag.Name)
+	require.Equal(t, listResp.Dags[1].Dag.Name, sseResp.Dags[1].Dag.Name)
+}
+
 func TestGetDAGDetails_InvalidYAML_Returns200WithErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/api/v1/docs.go
+++ b/internal/service/frontend/api/v1/docs.go
@@ -690,94 +690,102 @@ func (a *API) DeleteDocBatch(ctx context.Context, request api.DeleteDocBatchRequ
 // GetDocTreeData is the SSE data method for the doc tree.
 // Identifier format: URL query string (e.g., "page=1&perPage=200")
 func (a *API) GetDocTreeData(ctx context.Context, queryString string) (any, error) {
-	if a.docStore == nil {
-		return nil, errDocStoreNotAvailable
-	}
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/docs/tree",
+	}, func(readCtx context.Context) (any, error) {
+		if a.docStore == nil {
+			return nil, errDocStoreNotAvailable
+		}
 
-	params, err := url.ParseQuery(queryString)
-	if err != nil {
-		params = url.Values{}
-	}
+		params, err := url.ParseQuery(queryString)
+		if err != nil {
+			params = url.Values{}
+		}
 
-	page := parseIntParam(params.Get("page"), 1)
-	perPage := min(parseIntParam(params.Get("perPage"), 200), 200)
-	workspaceParam := workspaceParamFromValues(params)
-	workspaceName, visibility, err := a.docReadScopeForParams(ctx, workspaceParam)
-	if err != nil {
-		return nil, err
-	}
+		page := parseIntParam(params.Get("page"), 1)
+		perPage := min(parseIntParam(params.Get("perPage"), 200), 200)
+		workspaceParam := workspaceParamFromValues(params)
+		workspaceName, visibility, err := a.docReadScopeForParams(readCtx, workspaceParam)
+		if err != nil {
+			return nil, err
+		}
 
-	sortField, sortOrder := docSortParamsFromQuery(params)
+		sortField, sortOrder := docSortParamsFromQuery(params)
 
-	result, err := a.docStore.List(ctx, agent.ListDocsOptions{
-		Page:             page,
-		PerPage:          perPage,
-		Sort:             sortField,
-		Order:            sortOrder,
-		PathPrefix:       workspaceName,
-		ExcludePathRoots: visibility.excludedPathRoots(),
+		result, err := a.docStore.List(readCtx, agent.ListDocsOptions{
+			Page:             page,
+			PerPage:          perPage,
+			Sort:             sortField,
+			Order:            sortOrder,
+			PathPrefix:       workspaceName,
+			ExcludePathRoots: visibility.excludedPathRoots(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		tree := make([]api.DocTreeNodeResponse, 0, len(result.Items))
+		for _, node := range result.Items {
+			tree = append(tree, toDocTreeResponseWithWorkspace(node, workspaceName, visibility))
+		}
+
+		return api.ListDocs200JSONResponse{
+			Tree:       &tree,
+			Pagination: toPagination(*result),
+		}, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	tree := make([]api.DocTreeNodeResponse, 0, len(result.Items))
-	for _, node := range result.Items {
-		tree = append(tree, toDocTreeResponseWithWorkspace(node, workspaceName, visibility))
-	}
-
-	return api.ListDocs200JSONResponse{
-		Tree:       &tree,
-		Pagination: toPagination(*result),
-	}, nil
 }
 
 // GetDocContentData is the SSE data method for doc content.
 func (a *API) GetDocContentData(ctx context.Context, docID string) (any, error) {
-	if a.docStore == nil {
-		return nil, errDocStoreNotAvailable
-	}
-	path, queryString, hasQuery := strings.Cut(docID, "?")
-	var (
-		workspaceName string
-		visibility    docWorkspaceVisibility
-		err           error
-		params        url.Values
-	)
-	if hasQuery {
-		params, err = url.ParseQuery(queryString)
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/docs/{docID}",
+	}, func(readCtx context.Context) (any, error) {
+		if a.docStore == nil {
+			return nil, errDocStoreNotAvailable
+		}
+		path, queryString, hasQuery := strings.Cut(docID, "?")
+		var (
+			workspaceName string
+			visibility    docWorkspaceVisibility
+			err           error
+			params        url.Values
+		)
+		if hasQuery {
+			params, err = url.ParseQuery(queryString)
+			if err != nil {
+				return nil, err
+			}
+			workspaceParam := workspaceParamFromValues(params)
+			workspaceName, visibility, err = a.docPointReadScopeForParams(readCtx, workspaceParam)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			workspaceName, visibility, err = a.docPointReadScopeForParams(readCtx, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		scopedID, err := scopedDocPath(workspaceName, path)
 		if err != nil {
 			return nil, err
 		}
-		workspaceParam := workspaceParamFromValues(params)
-		workspaceName, visibility, err = a.docPointReadScopeForParams(ctx, workspaceParam)
+		doc, err := a.docStore.Get(readCtx, scopedID)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		workspaceName, visibility, err = a.docPointReadScopeForParams(ctx, nil)
-		if err != nil {
-			return nil, err
+		if workspaceName == "" && !visibility.all {
+			if !visibility.visible(doc.ID) {
+				return nil, errDocNotFound
+			}
 		}
-	}
-	scopedID, err := scopedDocPath(workspaceName, path)
-	if err != nil {
-		return nil, err
-	}
-	doc, err := a.docStore.Get(ctx, scopedID)
-	if err != nil {
-		return nil, err
-	}
-	if workspaceName == "" && !visibility.all {
-		if !visibility.visible(doc.ID) {
-			return nil, errDocNotFound
-		}
-	}
-	rawID := doc.ID
-	doc.ID = visibleDocPath(workspaceName, doc.ID)
-	resp := toDocResponse(doc)
-	resp.Workspace = docWorkspaceValue(workspaceName, rawID, visibility, false)
-	return resp, nil
+		rawID := doc.ID
+		doc.ID = visibleDocPath(workspaceName, doc.ID)
+		resp := toDocResponse(doc)
+		resp.Workspace = docWorkspaceValue(workspaceName, rawID, visibility, false)
+		return resp, nil
+	})
 }
 
 func toDocResponse(doc *agent.Doc) api.DocResponse {

--- a/internal/service/frontend/api/v1/queues.go
+++ b/internal/service/frontend/api/v1/queues.go
@@ -408,11 +408,15 @@ func (a *API) countVisibleQueuedItems(ctx context.Context, queueName string) (in
 // GetQueuesListData returns queue list for SSE.
 // Identifier format: URL query string (ignored for now)
 func (a *API) GetQueuesListData(ctx context.Context, _ string) (any, error) {
-	response, err := a.ListQueues(ctx, api.ListQueuesRequestObject{})
-	if err != nil {
-		return nil, fmt.Errorf("error listing queues: %w", err)
-	}
-	return response, nil
+	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
+		endpoint: "/queues",
+	}, func(readCtx context.Context) (api.ListQueuesResponseObject, error) {
+		response, err := a.ListQueues(readCtx, api.ListQueuesRequestObject{})
+		if err != nil {
+			return nil, fmt.Errorf("error listing queues: %w", err)
+		}
+		return response, nil
+	})
 }
 
 func (a *API) effectiveLeaseStaleThreshold() time.Duration {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1161,13 +1161,12 @@ func (srv *Server) registerDedicatedSSEFetchers(registrar *sse.Multiplexer) {
 	registrar.RegisterFetcher(sse.TopicTypeDoc, srv.apiV1.GetDocContentData)
 	registrar.RegisterFetcher(sse.TopicTypeDocTree, srv.apiV1.GetDocTreeData)
 
-	// DAG-run and queue live views have an explicit eventstore-backed invalidation
-	// path, so they should not keep background polling once the SSE topic is live.
+	// Queue views have an eventstore-backed invalidation path. DAG-run list
+	// topics intentionally stay on the default polling mode: cockpit/dashboard
+	// views depend on summaries that can change without a reliable lifecycle
+	// event for every visible field, and manual step mutations can leave the
+	// aggregate DAG-run lifecycle unchanged.
 	if srv.eventService != nil {
-		registrar.SetRefreshMode(sse.TopicTypeDAGRun, sse.TopicRefreshModeOnDemand)
-		registrar.SetRefreshMode(sse.TopicTypeSubDAGRun, sse.TopicRefreshModeOnDemand)
-		registrar.SetRefreshMode(sse.TopicTypeDAGHistory, sse.TopicRefreshModeOnDemand)
-		registrar.SetRefreshMode(sse.TopicTypeDAGRuns, sse.TopicRefreshModeOnDemand)
 		registrar.SetRefreshMode(sse.TopicTypeQueues, sse.TopicRefreshModeOnDemand)
 		registrar.SetPublishOnWake(sse.TopicTypeDAGRuns, true)
 	}

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,7 +22,10 @@ import (
 	authmodel "github.com/dagucloud/dagu/internal/auth"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/persis/fileuser"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
 	frontendauth "github.com/dagucloud/dagu/internal/service/frontend/auth"
+	"github.com/dagucloud/dagu/internal/service/frontend/sse"
 )
 
 // testContext returns a context that is cancelled when the test ends,
@@ -54,6 +59,89 @@ func testConfig(tmpDir string, ia config.InitialAdmin) *config.Config {
 				},
 			},
 		},
+	}
+}
+
+func TestRegisterDedicatedSSEFetchersKeepsDAGRunTopicsPollingWithEventStore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		topicType sse.TopicType
+		topic     string
+	}{
+		{
+			name:      "dag run details",
+			topicType: sse.TopicTypeDAGRun,
+			topic:     "dagrun:test/run-1",
+		},
+		{
+			name:      "sub dag run details",
+			topicType: sse.TopicTypeSubDAGRun,
+			topic:     "subdagrun:test/run-1/sub-1",
+		},
+		{
+			name:      "dag history",
+			topicType: sse.TopicTypeDAGHistory,
+			topic:     "daghistory:test.yaml",
+		},
+		{
+			name:      "dag runs list",
+			topicType: sse.TopicTypeDAGRuns,
+			topic:     "dagruns:limit=10&status=4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux := sse.NewMultiplexer(sse.StreamConfig{HeartbeatInterval: time.Hour}, nil)
+			t.Cleanup(mux.Shutdown)
+
+			srv := &Server{
+				apiV1:        &apiv1.API{},
+				eventService: eventstore.New(nil),
+			}
+			srv.registerDedicatedSSEFetchers(mux)
+
+			var fetches atomic.Int64
+			mux.RegisterFetcher(tt.topicType, func(_ context.Context, identifier string) (any, error) {
+				return map[string]any{
+					"id":      identifier,
+					"fetches": fetches.Add(1),
+				}, nil
+			})
+
+			handler := sse.NewMultiplexHandler(mux, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				req := httptest.NewRequest(
+					http.MethodGet,
+					"/api/v1/events/stream?topic="+url.QueryEscape(tt.topic),
+					nil,
+				).WithContext(ctx)
+				handler.HandleStream(httptest.NewRecorder(), req)
+			}()
+
+			require.Eventually(t, func() bool {
+				return fetches.Load() >= 2
+			}, time.Second, 10*time.Millisecond)
+
+			cancel()
+			require.Eventually(t, func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, time.Second, 10*time.Millisecond)
+		})
 	}
 }
 

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -130,7 +130,7 @@ func TestRegisterDedicatedSSEFetchersKeepsDAGRunTopicsPollingWithEventStore(t *t
 
 			require.Eventually(t, func() bool {
 				return fetches.Load() >= 2
-			}, time.Second, 10*time.Millisecond)
+			}, 3*time.Second, 10*time.Millisecond)
 
 			cancel()
 			require.Eventually(t, func() bool {

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -248,7 +248,7 @@ func (m *Multiplexer) Context() context.Context {
 
 // createSession creates a multiplexed SSE session and applies the initial topic set.
 func (m *Multiplexer) createSession(ctx context.Context, w http.ResponseWriter, requested []string, lastEventID uint64) (createSessionResult, error) {
-	session, err := newStreamSession(w, m)
+	session, err := newStreamSession(w, m, context.WithoutCancel(ctx))
 	if err != nil {
 		return createSessionResult{}, err
 	}
@@ -671,10 +671,13 @@ func parseTopicList(rawTopics []string) ([]ParsedTopic, error) {
 	return parsed, nil
 }
 
-func newStreamSession(w http.ResponseWriter, mux *Multiplexer) (*streamSession, error) {
+func newStreamSession(w http.ResponseWriter, mux *Multiplexer, fetchCtx context.Context) (*streamSession, error) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		return nil, ErrStreamingNotSupported
+	}
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
 	}
 
 	return &streamSession{
@@ -683,6 +686,7 @@ func newStreamSession(w http.ResponseWriter, mux *Multiplexer) (*streamSession, 
 		flusher:           flusher,
 		controller:        http.NewResponseController(w),
 		mux:               mux,
+		fetchCtx:          fetchCtx,
 		topics:            make(map[string]*multiplexTopic),
 		ready:             make(chan struct{}, 1),
 		heartbeatInterval: mux.heartbeatInterval,
@@ -697,6 +701,7 @@ type streamSession struct {
 	flusher           http.Flusher
 	controller        *http.ResponseController
 	mux               *Multiplexer
+	fetchCtx          context.Context
 	heartbeatInterval time.Duration
 	writeBufferSize   int
 	slowClientTimeout time.Duration
@@ -1015,7 +1020,7 @@ type multiplexTopic struct {
 	clientsMu         sync.RWMutex
 	sessions          map[*streamSession]struct{}
 	retiring          bool
-	lastHash          string
+	lastHashBySession map[*streamSession]string
 	lastChangeEventID uint64
 	stopCh            chan struct{}
 	notifyCh          chan struct{}
@@ -1036,18 +1041,19 @@ func newMultiplexTopic(
 	policy.MaxInterval = 30 * time.Second
 
 	return &multiplexTopic{
-		mux:             mux,
-		key:             parsed.Key,
-		topicType:       parsed.Type,
-		identifier:      parsed.Identifier,
-		fetcher:         fetcher,
-		refreshMode:     refreshMode,
-		publishOnWake:   publishOnWake,
-		sessions:        make(map[*streamSession]struct{}),
-		stopCh:          make(chan struct{}),
-		notifyCh:        make(chan struct{}, 1),
-		errorBackoff:    backoff.NewRetrier(policy),
-		currentInterval: mux.watcherBaseInterval,
+		mux:               mux,
+		key:               parsed.Key,
+		topicType:         parsed.Type,
+		identifier:        parsed.Identifier,
+		fetcher:           fetcher,
+		refreshMode:       refreshMode,
+		publishOnWake:     publishOnWake,
+		sessions:          make(map[*streamSession]struct{}),
+		lastHashBySession: make(map[*streamSession]string),
+		stopCh:            make(chan struct{}),
+		notifyCh:          make(chan struct{}, 1),
+		errorBackoff:      backoff.NewRetrier(policy),
+		currentInterval:   mux.watcherBaseInterval,
 	}
 }
 
@@ -1072,6 +1078,7 @@ func (t *multiplexTopic) removeSession(session *streamSession) {
 	t.clientsMu.Lock()
 	defer t.clientsMu.Unlock()
 	delete(t.sessions, session)
+	delete(t.lastHashBySession, session)
 }
 
 func (t *multiplexTopic) sessionCount() int {
@@ -1192,50 +1199,75 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		return
 	}
 
-	start := time.Now()
-	payload, err := t.fetchPayload(t.mux.ctx)
-	fetchDuration := time.Since(start)
-	if err != nil {
-		interval, _ := t.errorBackoff.Next(err)
-		t.backoffUntil = time.Now().Add(interval)
-		if t.mux.metrics != nil {
-			t.mux.metrics.FetchError(string(t.topicType))
+	t.clientsMu.RLock()
+	sessions := make([]*streamSession, 0, len(t.sessions))
+	for session := range t.sessions {
+		sessions = append(sessions, session)
+	}
+	t.clientsMu.RUnlock()
+
+	var totalFetchDuration time.Duration
+	var successCount int
+	var firstErr error
+
+	for _, session := range sessions {
+		start := time.Now()
+		payload, err := t.fetchPayload(session.fetchCtx)
+		fetchDuration := time.Since(start)
+		totalFetchDuration += fetchDuration
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if t.mux.metrics != nil {
+				t.mux.metrics.FetchError(string(t.topicType))
+			}
+			continue
 		}
+		successCount++
+
+		hash := computeHash(payload)
+		t.clientsMu.Lock()
+		if _, ok := t.sessions[session]; !ok {
+			t.clientsMu.Unlock()
+			continue
+		}
+		if hash == t.lastHashBySession[session] && !forcePublish {
+			t.clientsMu.Unlock()
+			continue
+		}
+		t.lastHashBySession[session] = hash
+		eventID := t.mux.nextID()
+		t.lastChangeEventID = eventID
+		t.clientsMu.Unlock()
+
+		data, err := buildMessageData(t.key, payload)
+		if err != nil {
+			continue
+		}
+		session.enqueueMessage(t.key, eventID, data)
+	}
+
+	if successCount == 0 && firstErr != nil {
+		interval, _ := t.errorBackoff.Next(firstErr)
+		t.backoffUntil = time.Now().Add(interval)
+		return
+	}
+	if successCount == 0 {
 		return
 	}
 
+	fetchDuration := totalFetchDuration / time.Duration(successCount)
 	if t.mux.metrics != nil {
 		t.mux.metrics.RecordFetchDuration(string(t.topicType), fetchDuration)
 	}
+
 	t.backoffUntil = time.Time{}
 	t.errorBackoff.Reset()
 	t.currentInterval = time.Duration(
 		float64(max(t.mux.watcherBaseInterval, min(intervalMultiplier*fetchDuration, t.mux.watcherMaxInterval)))*smoothingFactor +
 			float64(t.currentInterval)*(1-smoothingFactor),
 	)
-
-	hash := computeHash(payload)
-	t.clientsMu.Lock()
-	if hash == t.lastHash && !forcePublish {
-		t.clientsMu.Unlock()
-		return
-	}
-	t.lastHash = hash
-	eventID := t.mux.nextID()
-	t.lastChangeEventID = eventID
-	sessions := make([]*streamSession, 0, len(t.sessions))
-	for session := range t.sessions {
-		sessions = append(sessions, session)
-	}
-	t.clientsMu.Unlock()
-
-	data, err := buildMessageData(t.key, payload)
-	if err != nil {
-		return
-	}
-	for _, session := range sessions {
-		session.enqueueMessage(t.key, eventID, data)
-	}
 }
 
 func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSession, eventID uint64) error {
@@ -1245,8 +1277,12 @@ func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSessio
 	}
 	hash := computeHash(payload)
 	t.clientsMu.Lock()
+	if _, ok := t.sessions[session]; !ok {
+		t.clientsMu.Unlock()
+		return nil
+	}
+	t.lastHashBySession[session] = hash
 	if t.lastChangeEventID == 0 {
-		t.lastHash = hash
 		t.lastChangeEventID = eventID
 	}
 	t.clientsMu.Unlock()

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -1206,7 +1206,7 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 	}
 	t.clientsMu.RUnlock()
 
-	var totalFetchDuration time.Duration
+	var totalSuccessFetchDuration time.Duration
 	var successCount int
 	var firstErr error
 
@@ -1214,17 +1214,17 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		start := time.Now()
 		payload, err := t.fetchPayload(session.fetchCtx)
 		fetchDuration := time.Since(start)
-		totalFetchDuration += fetchDuration
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
-			if t.mux.metrics != nil {
-				t.mux.metrics.FetchError(string(t.topicType))
-			}
 			continue
 		}
+		totalSuccessFetchDuration += fetchDuration
 		successCount++
+		if t.mux.metrics != nil {
+			t.mux.metrics.RecordFetchDuration(string(t.topicType), fetchDuration)
+		}
 
 		hash := computeHash(payload)
 		t.clientsMu.Lock()
@@ -1248,6 +1248,9 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		session.enqueueMessage(t.key, eventID, data)
 	}
 
+	if firstErr != nil && t.mux.metrics != nil {
+		t.mux.metrics.FetchError(string(t.topicType))
+	}
 	if successCount == 0 && firstErr != nil {
 		interval, _ := t.errorBackoff.Next(firstErr)
 		t.backoffUntil = time.Now().Add(interval)
@@ -1257,11 +1260,7 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		return
 	}
 
-	fetchDuration := totalFetchDuration / time.Duration(successCount)
-	if t.mux.metrics != nil {
-		t.mux.metrics.RecordFetchDuration(string(t.topicType), fetchDuration)
-	}
-
+	fetchDuration := totalSuccessFetchDuration / time.Duration(successCount)
 	t.backoffUntil = time.Time{}
 	t.errorBackoff.Reset()
 	t.currentInterval = time.Duration(

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -272,7 +272,7 @@ func TestMultiplexerRetiresUnusedTopicsBeforeReuse(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, created)
 
-	session, err := newStreamSession(httptest.NewRecorder(), mux)
+	session, err := newStreamSession(httptest.NewRecorder(), mux, context.Background())
 	require.NoError(t, err)
 	require.True(t, session.addTopic(topic))
 	require.True(t, topic.addSession(session))
@@ -295,7 +295,7 @@ func TestMultiplexTopicSendSnapshotDropsRemovedTopics(t *testing.T) {
 	topic := newMultiplexTopic(mux, parsed, func(_ context.Context, identifier string) (any, error) {
 		return map[string]string{"id": identifier}, nil
 	}, TopicRefreshModePolling, false)
-	session, err := newStreamSession(httptest.NewRecorder(), mux)
+	session, err := newStreamSession(httptest.NewRecorder(), mux, context.Background())
 	require.NoError(t, err)
 	require.True(t, session.addTopic(topic))
 
@@ -466,6 +466,67 @@ func TestMultiplexerOnDemandTopicOnlyRefetchesOnWake(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return fetches.Load() == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMultiplexerWakeTopicFetchesWithDetachedSessionContext(t *testing.T) {
+	type ctxKey string
+	const userKey ctxKey = "user"
+
+	mux := NewMultiplexer(StreamConfig{}, nil)
+	t.Cleanup(mux.Shutdown)
+
+	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, identifier string) (any, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		user, _ := ctx.Value(userKey).(string)
+		if user == "" {
+			return nil, errors.New("missing user in fetch context")
+		}
+		return map[string]string{
+			"id":   identifier,
+			"user": user,
+		}, nil
+	})
+	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
+
+	topicKey := "dagruns:workspace=all"
+	aliceCtx, cancelAlice := context.WithCancel(context.WithValue(context.Background(), userKey, "alice"))
+	aliceResult, err := mux.createSession(aliceCtx, httptest.NewRecorder(), []string{topicKey}, 0)
+	require.NoError(t, err)
+	require.NotNil(t, aliceResult.session)
+	defer mux.removeSession(aliceResult.session)
+	cancelAlice()
+
+	bobCtx, cancelBob := context.WithCancel(context.WithValue(context.Background(), userKey, "bob"))
+	bobResult, err := mux.createSession(bobCtx, httptest.NewRecorder(), []string{topicKey}, 0)
+	require.NoError(t, err)
+	require.NotNil(t, bobResult.session)
+	defer mux.removeSession(bobResult.session)
+	cancelBob()
+
+	mux.WakeTopic(TopicTypeDAGRuns, "workspace=all")
+
+	assertSessionPayloadUser := func(session *streamSession, expected string) bool {
+		msg := session.popNext()
+		if msg == nil {
+			return false
+		}
+		var envelope struct {
+			Payload struct {
+				User string `json:"user"`
+			} `json:"payload"`
+		}
+		require.NoError(t, json.Unmarshal(msg.data, &envelope))
+		return envelope.Payload.User == expected
+	}
+
+	require.Eventually(t, func() bool {
+		return assertSessionPayloadUser(aliceResult.session, "alice")
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return assertSessionPayloadUser(bobResult.session, "bob")
 	}, time.Second, 10*time.Millisecond)
 }
 

--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { useErrorModal } from '@/components/ui/error-modal';
 import { Tab, Tabs } from '@/components/ui/tabs';
 import {

--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -28,6 +28,7 @@ import BorderedBox from '../../../ui/BorderedBox';
 import { DAGRunOutputs } from '../../dag-runs/components/dag-run-details';
 import { DAGContext } from '../contexts/DAGContext';
 import { getEventHandlers } from '../lib/getEventHandlers';
+import { updateDAGRunNodeStatus } from '../lib/nodeStatus';
 import { ApprovalTab } from './approval';
 import ArtifactsTab from './artifacts/ArtifactsTab';
 import { ChatHistoryTab } from './chat-history';
@@ -74,11 +75,17 @@ function DAGStatus({
   fillHeight = false,
 }: Props) {
   const appBarContext = React.useContext(AppBarContext);
+  const dagContext = React.useContext(DAGContext);
   const config = useConfig();
   const navigate = useNavigate();
   const { showError } = useErrorModal();
   const [modal, setModal] = useState(false);
   const [activeTab, setActiveTab] = useState<StatusTab>(initialTab);
+  const [displayDAGRun, setDisplayDAGRun] = useState(dagRun);
+
+  useEffect(() => {
+    setDisplayDAGRun(dagRun);
+  }, [dagRun]);
 
   // Flowchart direction preference stored in cookies
   const [cookie, setCookie] = useCookies(['flowchart']);
@@ -146,18 +153,27 @@ function DAGStatus({
     setFlowchart(value);
   };
 
+  const applyDisplayNodeStatus = React.useCallback(
+    (stepName: string, status: NodeStatus) => {
+      setDisplayDAGRun((current) =>
+        updateDAGRunNodeStatus(current, stepName, status)
+      );
+    },
+    []
+  );
+
   const onUpdateStatus = async (
     step: components['schemas']['Step'],
     status: NodeStatus
   ) => {
-    const isSubRun = isSubDAGRun(dagRun);
+    const isSubRun = isSubDAGRun(displayDAGRun);
 
     // Define path parameters with proper typing
     const pathParams = {
-      name: isSubRun ? dagRun.rootDAGRunName : dagRun.name,
-      dagRunId: isSubRun ? dagRun.rootDAGRunId : dagRun.dagRunId,
+      name: isSubRun ? displayDAGRun.rootDAGRunName : displayDAGRun.name,
+      dagRunId: isSubRun ? displayDAGRun.rootDAGRunId : displayDAGRun.dagRunId,
       stepName: step.name,
-      ...(isSubRun ? { subDAGRunId: dagRun.dagRunId } : {}),
+      ...(isSubRun ? { subDAGRunId: displayDAGRun.dagRunId } : {}),
     };
 
     // Use the appropriate endpoint based on whether this is a sub DAG-run
@@ -183,13 +199,17 @@ function DAGStatus({
       );
       return;
     }
+    applyDisplayNodeStatus(step.name, status);
+    dagContext.refresh();
     dismissModal();
   };
   // Handle double-click on graph node (navigate to sub dagRun)
   const onSelectStepOnGraph = React.useCallback(
     async (id: string) => {
       // find the clicked step
-      const n = dagRun.nodes?.find((n) => toMermaidNodeId(n.step.name) == id);
+      const n = displayDAGRun.nodes?.find(
+        (n) => toMermaidNodeId(n.step.name) == id
+      );
       if (!n) return;
 
       // Combine both regular children and repeated children
@@ -211,7 +231,7 @@ function DAGStatus({
         }
       }
     },
-    [dagRun, navigate, fileName]
+    [displayDAGRun, navigate, fileName]
   );
 
   // Helper function to navigate to a specific sub DAG run
@@ -230,7 +250,7 @@ function DAGStatus({
 
       if (subDAGRun && subDAGRun.dagRunId) {
         // Navigate to the sub DAG-run status page
-        const dagRunId = dagRun.rootDAGRunId || dagRun.dagRunId;
+        const dagRunId = displayDAGRun.rootDAGRunId || displayDAGRun.dagRunId;
 
         // Check if we're in a dagRun context or a DAG context
         const currentPath = window.location.pathname;
@@ -245,22 +265,22 @@ function DAGStatus({
           searchParams.set('subDAGRunId', subDAGRun.dagRunId);
 
           // Use root DAG-run information
-          if (dagRun.rootDAGRunId) {
-            searchParams.set('dagRunId', dagRun.rootDAGRunId);
-            searchParams.set('dagRunName', dagRun.rootDAGRunName);
+          if (displayDAGRun.rootDAGRunId) {
+            searchParams.set('dagRunId', displayDAGRun.rootDAGRunId);
+            searchParams.set('dagRunName', displayDAGRun.rootDAGRunName);
           } else {
-            searchParams.set('dagRunId', dagRun.dagRunId);
-            searchParams.set('dagRunName', dagRun.name);
+            searchParams.set('dagRunId', displayDAGRun.dagRunId);
+            searchParams.set('dagRunName', displayDAGRun.name);
           }
 
           searchParams.set('step', node.step.name);
 
           // Determine root DAG name
-          const rootDAGName = dagRun.rootDAGRunName || dagRun.name;
+          const rootDAGName = displayDAGRun.rootDAGRunName || displayDAGRun.name;
           url = `/dag-runs/${rootDAGName}/${dagRunId}?${searchParams.toString()}`;
         } else {
           // For DAGs, use the existing approach with query parameters
-          url = `/dags/${fileName}?subDAGRunId=${subDAGRun.dagRunId}&dagRunId=${dagRunId}&step=${node.step.name}&dagRunName=${encodeURIComponent(dagRun.rootDAGRunName || dagRun.name)}`;
+          url = `/dags/${fileName}?subDAGRunId=${subDAGRun.dagRunId}&dagRunId=${dagRunId}&step=${node.step.name}&dagRunName=${encodeURIComponent(displayDAGRun.rootDAGRunName || displayDAGRun.name)}`;
         }
 
         if (openInNewTab) {
@@ -270,7 +290,7 @@ function DAGStatus({
         }
       }
     },
-    [dagRun, navigate, fileName]
+    [displayDAGRun, navigate, fileName]
   );
 
   // Handle right-click on graph node (show status update modal)
@@ -281,12 +301,14 @@ function DAGStatus({
         return;
       }
 
-      const status = dagRun.status;
+      const status = displayDAGRun.status;
 
       // Only allow status updates for completed DAG runs
       if (status !== Status.Running && status !== Status.NotStarted) {
         // find the right-clicked step
-        const n = dagRun.nodes?.find((n) => toMermaidNodeId(n.step.name) == id);
+        const n = displayDAGRun.nodes?.find(
+          (n) => toMermaidNodeId(n.step.name) == id
+        );
 
         if (n) {
           // Show the modal (it will be centered by default)
@@ -295,10 +317,10 @@ function DAGStatus({
         }
       }
     },
-    [dagRun, config.permissions.runDags]
+    [displayDAGRun, config.permissions.runDags]
   );
 
-  const handlers = getEventHandlers(dagRun);
+  const handlers = getEventHandlers(displayDAGRun);
 
   // Handler for opening log viewer
   const handleViewLog = (
@@ -314,30 +336,31 @@ function DAGStatus({
       isOpen: true,
       logType: 'step',
       stepName: actualStepName,
-      dagRunId: dagRunId || dagRun.dagRunId,
+      dagRunId: dagRunId || displayDAGRun.dagRunId,
       stream: isStderr ? Stream.stderr : Stream.stdout,
       node,
     });
   };
 
   // Check if timeline should be shown (any status except not started)
-  const showTimeline = dagRun.status !== Status.NotStarted;
+  const showTimeline = displayDAGRun.status !== Status.NotStarted;
 
   // Check if there are any chat steps
-  const hasChatSteps = !!dagRun.nodes?.some(
+  const hasChatSteps = !!displayDAGRun.nodes?.some(
     (node) => node.step.executorConfig?.type === 'chat'
   );
 
   // Check if there are any steps awaiting approval
   const waitingStepCount =
-    dagRun.nodes?.filter((node) => node.status === NodeStatus.Waiting).length ||
+    displayDAGRun.nodes?.filter((node) => node.status === NodeStatus.Waiting)
+      .length ||
     0;
   const hasWaitingSteps = waitingStepCount > 0;
-  const hasArtifacts = artifactEnabled || !!dagRun.artifactsAvailable;
+  const hasArtifacts = artifactEnabled || !!displayDAGRun.artifactsAvailable;
 
   useEffect(() => {
     setActiveTab(initialTab);
-  }, [dagRun.dagRunId, initialTab]);
+  }, [displayDAGRun.dagRunId, initialTab]);
 
   // Reset to status tab if selected tab is not available
   useEffect(() => {
@@ -448,7 +471,7 @@ function DAGStatus({
       {activeTab === 'status' && (
         <div className={cn('space-y-6', scrollPaneClassName)}>
           {/* DAG Graph Visualization */}
-          {dagRun.nodes && dagRun.nodes.length > 0 && (
+          {displayDAGRun.nodes && displayDAGRun.nodes.length > 0 && (
             <div className="flex flex-col">
               <BorderedBox className="pt-4 px-4 pb-0 flex flex-col items-stretch overflow-hidden">
                 <div className="flex justify-end mb-2">
@@ -473,7 +496,7 @@ function DAGStatus({
                 </div>
                 <div className="overflow-x-auto -mx-4 px-4">
                   <Graph
-                    steps={dagRun.nodes}
+                    steps={displayDAGRun.nodes}
                     type="status"
                     flowchart={flowchart}
                     onChangeFlowchart={onChangeFlowchart}
@@ -483,8 +506,8 @@ function DAGStatus({
                         ? onRightClickStepOnGraph
                         : undefined
                     }
-                    showIcons={dagRun.status > Status.NotStarted}
-                    animate={dagRun.status == Status.Running}
+                    showIcons={displayDAGRun.status > Status.NotStarted}
+                    animate={displayDAGRun.status == Status.Running}
                     height={graphHeight}
                   />
                 </div>
@@ -505,7 +528,7 @@ function DAGStatus({
                   {/* Status Overview */}
                   <div className="bg-surface border border-border rounded-lg p-4">
                     <DAGStatusOverview
-                      status={dagRun}
+                      status={displayDAGRun}
                       onViewLog={(dagRunId) => {
                         setLogViewer({
                           isOpen: true,
@@ -520,10 +543,11 @@ function DAGStatus({
 
                   {/* Steps Table */}
                   <NodeStatusTable
-                    nodes={dagRun.nodes}
-                    status={dagRun}
+                    nodes={displayDAGRun.nodes}
+                    status={displayDAGRun}
                     {...props}
                     onViewLog={handleViewLog}
+                    onNodeStatusUpdated={applyDisplayNodeStatus}
                   />
                 </div>
 
@@ -531,9 +555,10 @@ function DAGStatus({
                 {handlers?.length ? (
                   <NodeStatusTable
                     nodes={handlers}
-                    status={dagRun}
+                    status={displayDAGRun}
                     {...props}
                     onViewLog={handleViewLog}
+                    onNodeStatusUpdated={applyDisplayNodeStatus}
                   />
                 ) : null}
               </>
@@ -545,27 +570,30 @@ function DAGStatus({
       {/* Approval Tab Content */}
       {activeTab === 'approval' && hasWaitingSteps && (
         <div className={scrollPaneClassName}>
-          <ApprovalTab dagRun={dagRun} dagName={fileName} />
+          <ApprovalTab dagRun={displayDAGRun} dagName={fileName} />
         </div>
       )}
 
       {/* Timeline Tab Content */}
       {activeTab === 'timeline' && showTimeline && (
         <div className={scrollPaneClassName}>
-          <TimelineChart status={dagRun} />
+          <TimelineChart status={displayDAGRun} />
         </div>
       )}
 
       {/* Outputs Tab Content */}
       {activeTab === 'outputs' && (
         <div className={scrollPaneClassName}>
-          <DAGRunOutputs dagName={dagRun.name} dagRunId={dagRun.dagRunId} />
+          <DAGRunOutputs
+            dagName={displayDAGRun.name}
+            dagRunId={displayDAGRun.dagRunId}
+          />
         </div>
       )}
 
       {activeTab === 'artifacts' && hasArtifacts && (
         <ArtifactsTab
-          dagRun={dagRun}
+          dagRun={displayDAGRun}
           artifactEnabled={artifactEnabled}
           className={fillHeight ? 'min-h-0 flex-1' : undefined}
           fillHeight={fillHeight}
@@ -575,7 +603,7 @@ function DAGStatus({
       {/* Chat Tab Content */}
       {activeTab === 'chat' && (
         <div className={scrollPaneClassName}>
-          <ChatHistoryTab dagRun={dagRun} />
+          <ChatHistoryTab dagRun={displayDAGRun} />
         </div>
       )}
 
@@ -583,13 +611,23 @@ function DAGStatus({
       {activeTab === 'spec' && (
         <div className={scrollPaneClassName}>
           <DAGSpecReadOnly
-            dagName={isSubDAGRun(dagRun) ? dagRun.rootDAGRunName : dagRun.name}
-            dagRunId={
-              isSubDAGRun(dagRun) ? dagRun.rootDAGRunId : dagRun.dagRunId
+            dagName={
+              isSubDAGRun(displayDAGRun)
+                ? displayDAGRun.rootDAGRunName
+                : displayDAGRun.name
             }
-            subDAGRunId={isSubDAGRun(dagRun) ? dagRun.dagRunId : undefined}
+            dagRunId={
+              isSubDAGRun(displayDAGRun)
+                ? displayDAGRun.rootDAGRunId
+                : displayDAGRun.dagRunId
+            }
+            subDAGRunId={
+              isSubDAGRun(displayDAGRun) ? displayDAGRun.dagRunId : undefined
+            }
             sourceFileName={
-              isSubDAGRun(dagRun) ? undefined : dagRun.sourceFileName
+              isSubDAGRun(displayDAGRun)
+                ? undefined
+                : displayDAGRun.sourceFileName
             }
           />
         </div>
@@ -607,10 +645,10 @@ function DAGStatus({
         isOpen={logViewer.isOpen}
         onClose={() => setLogViewer((prev) => ({ ...prev, isOpen: false }))}
         logType={logViewer.logType}
-        dagName={dagRun.name}
+        dagName={displayDAGRun.name}
         dagRunId={logViewer.dagRunId}
         stepName={logViewer.stepName}
-        dagRun={dagRun}
+        dagRun={displayDAGRun}
         stream={logViewer.stream}
         node={logViewer.node}
       />
@@ -626,9 +664,9 @@ function DAGStatus({
             ...(parallelExecutionModal.node.subRuns || []),
             ...(parallelExecutionModal.node.subRunsRepeated || []),
           ]}
-          rootDagName={dagRun.rootDAGRunName}
-          rootDagRunId={dagRun.rootDAGRunId}
-          parentDagRunId={dagRun.dagRunId}
+          rootDagName={displayDAGRun.rootDAGRunName}
+          rootDagRunId={displayDAGRun.rootDAGRunId}
+          parentDagRunId={displayDAGRun.dagRunId}
           onSelectSubRun={(subRunIndex, openInNewTab) => {
             navigateToSubDagRun(
               parallelExecutionModal.node!,

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  components,
+  NodeStatus,
+  NodeStatusLabel,
+  Status,
+  StatusLabel,
+} from '@/api/v1/schema';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { useClient } from '@/hooks/api';
+import { DAGContext } from '../../contexts/DAGContext';
+import DAGStatus from '../DAGStatus';
+
+const patchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/api', () => ({
+  useClient: vi.fn(),
+}));
+
+vi.mock('@/contexts/ConfigContext', () => ({
+  useConfig: () => ({
+    permissions: {
+      runDags: true,
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/error-modal', () => ({
+  useErrorModal: () => ({
+    showError: vi.fn(),
+  }),
+}));
+
+vi.mock('react-cookie', () => ({
+  useCookies: () => [{}, vi.fn()],
+}));
+
+vi.mock('../visualization', () => ({
+  Graph: ({
+    onRightClickNode,
+    steps,
+  }: {
+    onRightClickNode?: (id: string) => void;
+    steps?: components['schemas']['Node'][];
+  }) => (
+    <div>
+      <div>Graph status: {steps?.[0]?.status}</div>
+      <button type="button" onClick={() => onRightClickNode?.('step')}>
+        Open status modal
+      </button>
+    </div>
+  ),
+  TimelineChart: () => <div>Timeline</div>,
+}));
+
+vi.mock('../dag-execution', () => ({
+  LogViewer: () => null,
+  ParallelExecutionModal: () => null,
+  StatusUpdateModal: ({
+    visible,
+    step,
+    onSubmit,
+  }: {
+    visible: boolean;
+    step?: components['schemas']['Step'];
+    onSubmit: (
+      step: components['schemas']['Step'],
+      status: NodeStatus
+    ) => void | Promise<void>;
+  }) =>
+    visible && step ? (
+      <button
+        type="button"
+        onClick={() => void onSubmit(step, NodeStatus.Failed)}
+      >
+        Mark failed
+      </button>
+    ) : null,
+}));
+
+vi.mock('../dag-details', () => ({
+  DAGStatusOverview: () => <div>Status overview</div>,
+  NodeStatusTable: () => <div>Node status table</div>,
+}));
+
+vi.mock('../approval', () => ({
+  ApprovalTab: () => null,
+}));
+
+vi.mock('../artifacts/ArtifactsTab', () => ({
+  default: () => null,
+}));
+
+vi.mock('../chat-history', () => ({
+  ChatHistoryTab: () => null,
+}));
+
+vi.mock('../dag-editor', () => ({
+  DAGSpecReadOnly: () => null,
+}));
+
+vi.mock('../../../dag-runs/components/dag-run-details', () => ({
+  DAGRunOutputs: () => null,
+}));
+
+const appBarValue = {
+  title: 'DAGs',
+  setTitle: vi.fn(),
+  remoteNodes: ['local'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'local',
+  selectRemoteNode: vi.fn(),
+};
+
+const dagRun = {
+  name: 'example',
+  dagRunId: 'run-1',
+  status: Status.Failed,
+  statusLabel: StatusLabel.failed,
+  autoRetryCount: 0,
+  startedAt: '',
+  finishedAt: '',
+  artifactsAvailable: false,
+  nodes: [
+    {
+      step: {
+        name: 'step',
+      },
+      status: NodeStatus.Success,
+      statusLabel: NodeStatusLabel.succeeded,
+    },
+  ],
+} as components['schemas']['DAGRunDetails'];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DAGStatus', () => {
+  it('updates the rendered graph immediately after graph status updates succeed', async () => {
+    const refresh = vi.fn();
+    vi.mocked(useClient).mockReturnValue({
+      PATCH: patchMock.mockResolvedValue({ error: undefined }),
+    } as unknown as ReturnType<typeof useClient>);
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGContext.Provider
+            value={{
+              refresh,
+              name: 'example',
+              fileName: 'example.yaml',
+            }}
+          >
+            <DAGStatus dagRun={dagRun} fileName="example.yaml" />
+          </DAGContext.Provider>
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open status modal' })
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Mark failed' })
+    );
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        '/dag-runs/{name}/{dagRunId}/steps/{stepName}/status',
+        expect.objectContaining({
+          body: {
+            status: NodeStatus.Failed,
+          },
+        })
+      );
+    });
+    expect(
+      screen.getByText(`Graph status: ${NodeStatus.Failed}`)
+    ).toBeInTheDocument();
+    await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  });
+});

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -187,4 +187,54 @@ describe('DAGStatus', () => {
     ).toBeInTheDocument();
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
   });
+
+  it('does not optimistically update the graph when graph status updates fail', async () => {
+    const refresh = vi.fn();
+    vi.mocked(useClient).mockReturnValue({
+      PATCH: patchMock.mockResolvedValue({
+        error: { message: 'update failed' },
+      }),
+    } as unknown as ReturnType<typeof useClient>);
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGContext.Provider
+            value={{
+              refresh,
+              name: 'example',
+              fileName: 'example.yaml',
+            }}
+          >
+            <DAGStatus dagRun={dagRun} fileName="example.yaml" />
+          </DAGContext.Provider>
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open status modal' })
+    );
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Mark failed' })
+    );
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith(
+        '/dag-runs/{name}/{dagRunId}/steps/{stepName}/status',
+        expect.objectContaining({
+          body: {
+            status: NodeStatus.Failed,
+          },
+        })
+      );
+    });
+    expect(
+      screen.queryByText(`Graph status: ${NodeStatus.Failed}`)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(`Graph status: ${NodeStatus.Success}`)
+    ).toBeInTheDocument();
+    expect(refresh).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/features/dags/components/common/DAGActions.tsx
+++ b/ui/src/features/dags/components/common/DAGActions.tsx
@@ -818,7 +818,16 @@ function DAGActions({
           action={dagContext.forceEnqueue ? 'enqueue' : undefined}
           onSubmit={async (params, dagRunId, immediate) => {
             if (dagContext.onEnqueue) {
-              await dagContext.onEnqueue(params, dagRunId, immediate);
+              const result = await dagContext.onEnqueue(
+                params,
+                dagRunId,
+                immediate
+              );
+              const startedRunId =
+                typeof result === 'string' && result ? result : dagRunId;
+              if (startedRunId) {
+                await dagContext.onRunStarted?.(startedRunId);
+              }
               return;
             }
 
@@ -828,7 +837,7 @@ function DAGActions({
             }
 
             // Use /start endpoint if immediate is true, otherwise use /enqueue
-            const { error } = await (immediate
+            const { data, error } = await (immediate
               ? client.POST('/dags/{fileName}/start', {
                   params: {
                     path: {
@@ -857,6 +866,9 @@ function DAGActions({
               );
             }
 
+            if (data?.dagRunId) {
+              await dagContext.onRunStarted?.(data.dagRunId);
+            }
             // Just refresh the current page data
             reloadData();
             // Navigate to status tab after execution (if available)

--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -46,6 +46,7 @@ type DAGDetailsContentProps = {
     dagRunId?: string,
     immediate?: boolean
   ) => string | void | Promise<string | void>;
+  onRunStarted?: (dagRunId: string) => void | Promise<void>;
   /** When true, forces enqueue mode in DAGContext (used by cockpit) */
   forceEnqueue?: boolean;
   /** When true, automatically opens the start/enqueue modal on mount */
@@ -76,6 +77,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
   localDags,
   editorHints,
   onEnqueue,
+  onRunStarted,
   forceEnqueue = false,
   autoOpenStartModal = false,
 }) => {
@@ -127,6 +129,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
         forceEnqueue,
         autoOpenStartModal,
         onEnqueue,
+        onRunStarted,
       }}
     >
       <div className="w-full flex flex-col">

--- a/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Maximize2, X } from 'lucide-react';
 
@@ -11,7 +11,9 @@ import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { usePageContext } from '../../../../contexts/PageContext';
 import { UnsavedChangesProvider } from '../../../../contexts/UnsavedChangesContext';
 import { useQuery } from '../../../../hooks/api';
+import { useDAGRunSSE } from '../../../../hooks/useDAGRunSSE';
 import { useDAGSSE } from '../../../../hooks/useDAGSSE';
+import { whenEnabled } from '../../../../hooks/queryUtils';
 import {
   sseFallbackOptions,
   useSSECacheSync,
@@ -62,6 +64,7 @@ function DAGDetailsPanel({
   const [currentDAGRun, setCurrentDAGRun] = useState<
     DAGRunDetails | undefined
   >();
+  const [trackedDagRunId, setTrackedDagRunId] = useState<string>();
   const [activeTab, setActiveTab] = useState('status');
   const [notFound, setNotFound] = useState(false);
 
@@ -94,6 +97,26 @@ function DAGDetailsPanel({
   );
   useSSECacheSync(dagSSE, mutate);
 
+  const dagName = data?.dag?.name || '';
+  const trackedRunEnabled = !!dagName && !!trackedDagRunId;
+  const trackedRunSSE = useDAGRunSSE(
+    dagName,
+    trackedDagRunId || '',
+    trackedRunEnabled,
+    remoteNode
+  );
+  const { data: trackedRunData, mutate: mutateTrackedRun } = useQuery(
+    '/dag-runs/{name}/{dagRunId}',
+    whenEnabled(trackedRunEnabled, {
+      params: {
+        path: { name: dagName, dagRunId: trackedDagRunId || '' },
+        query: { remoteNode },
+      },
+    }),
+    sseFallbackOptions(trackedRunSSE)
+  );
+  useSSECacheSync(trackedRunSSE, mutateTrackedRun);
+
   // Track data loading state and handle 404 errors
   useEffect(() => {
     if (error) {
@@ -110,11 +133,25 @@ function DAGDetailsPanel({
   useEffect(() => {
     setNotFound(false);
     setActiveTab('status');
+    setTrackedDagRunId(undefined);
+    setCurrentDAGRun(undefined);
   }, [fileName, remoteNode]);
 
   function refreshFn(): void {
     setTimeout(() => mutate(), 500);
+    if (trackedDagRunId) {
+      setTimeout(() => mutateTrackedRun(), 500);
+    }
   }
+
+  const handleRunStarted = useCallback(
+    (dagRunId: string) => {
+      setTrackedDagRunId(dagRunId);
+      setActiveTab('status');
+      void mutate();
+    },
+    [mutate]
+  );
 
   function handleFullscreenClick(e?: React.MouseEvent): void {
     const tabPath = activeTab === 'status' ? '' : `/${activeTab}`;
@@ -128,10 +165,14 @@ function DAGDetailsPanel({
   }
 
   useEffect(() => {
-    if (data) {
+    if (trackedRunData?.dagRunDetails) {
+      setCurrentDAGRun(trackedRunData.dagRunDetails);
+    } else if (data) {
       setCurrentDAGRun(data.latestDAGRun);
     }
-  }, [data]);
+  }, [data, trackedRunData]);
+
+  const displayDAGRun = currentDAGRun || data?.latestDAGRun;
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -196,7 +237,7 @@ function DAGDetailsPanel({
       >
         <RootDAGRunContext.Provider
           value={{
-            data: currentDAGRun,
+            data: displayDAGRun,
             setData: setCurrentDAGRun,
           }}
         >
@@ -231,18 +272,19 @@ function DAGDetailsPanel({
                 fileName={fileName}
                 filePath={data.filePath}
                 dag={data.dag}
-                currentDAGRun={data.latestDAGRun}
+                currentDAGRun={displayDAGRun}
                 latestDAGRun={data.latestDAGRun}
                 refreshFn={refreshFn}
                 formatDuration={formatDuration}
                 activeTab={activeTab}
                 onTabChange={setActiveTab}
-                dagRunId="latest"
+                dagRunId={trackedDagRunId ?? 'latest'}
                 stepName={null}
                 isModal={true}
                 navigateToStatusTab={() => setActiveTab('status')}
                 localDags={data.localDags}
                 editorHints={data.editorHints}
+                onRunStarted={handleRunStarted}
               />
             </div>
           </div>

--- a/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
@@ -155,7 +155,18 @@ function DAGDetailsPanel({
 
   function handleFullscreenClick(e?: React.MouseEvent): void {
     const tabPath = activeTab === 'status' ? '' : `/${activeTab}`;
-    const url = `/dags/${fileName}${tabPath}`;
+    const searchParams = new URLSearchParams();
+    if (trackedDagRunId) {
+      searchParams.set('dagRunId', trackedDagRunId);
+      if (data?.dag?.name) {
+        searchParams.set('dagRunName', data.dag.name);
+      }
+    }
+    if (remoteNode && remoteNode !== 'local') {
+      searchParams.set('remoteNode', remoteNode);
+    }
+    const query = searchParams.toString();
+    const url = `/dags/${fileName}${tabPath}${query ? `?${query}` : ''}`;
 
     if (e?.metaKey || e?.ctrlKey) {
       window.open(url, '_blank');
@@ -202,7 +213,16 @@ function DAGDetailsPanel({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose, onNavigate, activeTab, fileName, navigate]);
+  }, [
+    onClose,
+    onNavigate,
+    activeTab,
+    fileName,
+    navigate,
+    trackedDagRunId,
+    data?.dag?.name,
+    remoteNode,
+  ]);
 
   // Show error state if DAG not found
   if (notFound) {

--- a/ui/src/features/dags/components/dag-details/NodeStatusTable.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTable.tsx
@@ -10,7 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { components } from '../../../../api/v1/schema';
+import { components, NodeStatus } from '../../../../api/v1/schema';
 import NodeStatusTableRow from './NodeStatusTableRow';
 
 /**
@@ -29,12 +29,20 @@ type Props = {
     dagRunId: string,
     node?: components['schemas']['Node']
   ) => void;
+  /** Function called after a row status update succeeds */
+  onNodeStatusUpdated?: (stepName: string, status: NodeStatus) => void;
 };
 
 /**
  * NodeStatusTable displays execution status information for all nodes in a DAG run
  */
-function NodeStatusTable({ nodes, status, fileName, onViewLog }: Props) {
+function NodeStatusTable({
+  nodes,
+  status,
+  fileName,
+  onViewLog,
+  onNodeStatusUpdated,
+}: Props) {
   // Don't render if there are no nodes
   if (!nodes || !nodes.length) {
     return null;
@@ -81,6 +89,7 @@ function NodeStatusTable({ nodes, status, fileName, onViewLog }: Props) {
                   node={n}
                   name={fileName}
                   onViewLog={onViewLog}
+                  onNodeStatusUpdated={onNodeStatusUpdated}
                   dagRun={status}
                   view="desktop"
                 />
@@ -99,6 +108,7 @@ function NodeStatusTable({ nodes, status, fileName, onViewLog }: Props) {
             node={n}
             name={fileName}
             onViewLog={onViewLog}
+            onNodeStatusUpdated={onNodeStatusUpdated}
             dagRun={status}
             view="mobile"
           />

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -46,6 +46,7 @@ import {
   Stream,
 } from '../../../../api/v1/schema';
 import StyledTableRow from '../../../../ui/StyledTableRow';
+import { DAGContext } from '../../contexts/DAGContext';
 import { NodeStatusChip } from '../common';
 import { InlineLogViewer } from '../common/InlineLogViewer';
 import StatusUpdateModal from '../dag-execution/StatusUpdateModal';
@@ -68,6 +69,8 @@ type Props = {
     dagRunId: string,
     node?: components['schemas']['Node']
   ) => void;
+  /** Function called after this row's status update succeeds */
+  onNodeStatusUpdated?: (stepName: string, status: NodeStatus) => void;
   /** Full dagRun details (optional) - used to determine if this is a sub dagRun */
   dagRun: components['schemas']['DAGRunDetails'];
   /** View mode: desktop or mobile */
@@ -131,6 +134,7 @@ function NodeStatusTableRow({
   rownum,
   node,
   onViewLog,
+  onNodeStatusUpdated,
   dagRun,
   view = 'desktop',
 }: Props) {
@@ -138,6 +142,7 @@ function NodeStatusTableRow({
   const navigate = useNavigate();
   const client = useClient();
   const appBarContext = useContext(AppBarContext);
+  const dagContext = useContext(DAGContext);
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
   const { showError } = useErrorModal();
   // State to store the current duration for running tasks
@@ -367,6 +372,8 @@ function NodeStatusTableRow({
       return;
     }
 
+    onNodeStatusUpdated?.(step.name, status);
+    dagContext.refresh();
     setShowStatusModal(false);
   };
 

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
@@ -1,13 +1,14 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { PageContextProvider } from '@/contexts/PageContext';
 import { useQuery } from '@/hooks/api';
+import { useDAGRunSSE } from '@/hooks/useDAGRunSSE';
 import { useDAGSSE } from '@/hooks/useDAGSSE';
 import DAGDetailsPanel from '../DAGDetailsPanel';
 
@@ -19,6 +20,10 @@ vi.mock('@/hooks/useDAGSSE', () => ({
   useDAGSSE: vi.fn(),
 }));
 
+vi.mock('@/hooks/useDAGRunSSE', () => ({
+  useDAGRunSSE: vi.fn(),
+}));
+
 vi.mock('@/hooks/useSSECacheSync', () => ({
   sseFallbackOptions: vi.fn(() => ({})),
   useSSECacheSync: vi.fn(),
@@ -28,17 +33,26 @@ vi.mock('../DAGDetailsContent', () => ({
   default: ({
     dag,
     activeTab,
+    dagRunId,
     editorHints,
+    onRunStarted,
   }: {
     dag: { name: string };
     activeTab: string;
+    dagRunId?: string;
     editorHints?: { inheritedCustomStepTypes?: unknown[] };
+    onRunStarted?: (dagRunId: string) => void;
   }) => (
     <div>
       <div>
-        Previewing {dag.name} [{activeTab}]
+        Previewing {dag.name} [{activeTab}] {dagRunId || 'latest'}
       </div>
       <div>Inherited hints: {editorHints?.inheritedCustomStepTypes?.length ?? 0}</div>
+      {onRunStarted ? (
+        <button type="button" onClick={() => onRunStarted('started-run')}>
+          Mark Started
+        </button>
+      ) : null}
     </div>
   ),
 }));
@@ -86,6 +100,7 @@ afterEach(() => {
 describe('DAGDetailsPanel', () => {
   it('passes editor hints through to the dag list detail panel spec flow', () => {
     vi.mocked(useDAGSSE).mockReturnValue(liveState);
+    vi.mocked(useDAGRunSSE).mockReturnValue(liveState);
     useQueryMock.mockImplementation((path) => {
       if (path === '/dags/{fileName}') {
         return {
@@ -112,7 +127,64 @@ describe('DAGDetailsPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByText('Previewing example-dag [status]')).toBeInTheDocument();
+    expect(
+      screen.getByText('Previewing example-dag [status] latest')
+    ).toBeInTheDocument();
     expect(screen.getByText('Inherited hints: 1')).toBeInTheDocument();
+  });
+
+  it('tracks a just-started DAG-run and reads its exact live status', async () => {
+    const dagData = {
+      dag: { name: 'example-dag' },
+      filePath: '/tmp/example.yaml',
+      latestDAGRun: undefined,
+      localDags: [],
+    };
+    const trackedRunData = {
+      dagRunDetails: {
+        name: 'example-dag',
+        dagRunId: 'started-run',
+      },
+    };
+
+    vi.mocked(useDAGSSE).mockReturnValue(liveState);
+    vi.mocked(useDAGRunSSE).mockReturnValue(liveState);
+    useQueryMock.mockImplementation((path) => {
+      if (path === '/dags/{fileName}') {
+        return {
+          data: dagData,
+          error: undefined,
+          mutate: vi.fn(),
+        } as never;
+      }
+
+      if (path === '/dag-runs/{name}/{dagRunId}') {
+        return {
+          data: trackedRunData,
+          error: undefined,
+          mutate: vi.fn(),
+        } as never;
+      }
+
+      return {
+        data: undefined,
+        error: undefined,
+        mutate: vi.fn(),
+      } as never;
+    });
+
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Started' }));
+
+    expect(
+      await screen.findByText('Previewing example-dag [status] started-run')
+    ).toBeInTheDocument();
+    expect(useDAGRunSSE).toHaveBeenCalledWith(
+      'example-dag',
+      'started-run',
+      true,
+      'local'
+    );
   });
 });

--- a/ui/src/features/dags/components/dag-execution/DAGExecutionHistory.tsx
+++ b/ui/src/features/dags/components/dag-execution/DAGExecutionHistory.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /**
  * DAGExecutionHistory component displays the execution history of a DAG.
  *
@@ -82,6 +85,7 @@ function DAGExecutionHistory({
       fileName={fileName}
       dagRuns={data.dagRuns}
       gridData={data.gridData}
+      refreshHistory={() => void mutate()}
     />
   );
 }
@@ -96,12 +100,19 @@ type HistoryTableProps = {
   gridData: components['schemas']['DAGGridItem'][] | null;
   /** List of DAG dagRuns */
   dagRuns: components['schemas']['DAGRunDetails'][] | null;
+  /** Refresh execution history list */
+  refreshHistory: () => void;
 };
 
 /**
  * DAGHistoryTable displays detailed execution history with interactive elements
  */
-function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
+function DAGHistoryTable({
+  fileName,
+  gridData,
+  dagRuns,
+  refreshHistory,
+}: HistoryTableProps) {
   const appBarContext = React.useContext(AppBarContext);
   const dagContext = React.useContext(DAGContext);
   const client = useClient();
@@ -286,6 +297,7 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
         status
       )
     );
+    refreshHistory();
     dagContext.refresh();
     dismissModal();
   };

--- a/ui/src/features/dags/components/dag-execution/DAGExecutionHistory.tsx
+++ b/ui/src/features/dags/components/dag-execution/DAGExecutionHistory.tsx
@@ -23,6 +23,7 @@ import { toMermaidNodeId } from '../../../../lib/utils';
 import LoadingIndicator from '../../../../ui/LoadingIndicator';
 import { DAGContext } from '../../contexts/DAGContext';
 import { getEventHandlers } from '../../lib/getEventHandlers';
+import { updateDAGRunsNodeStatus } from '../../lib/nodeStatus';
 import { DAGStatusOverview, NodeStatusTable } from '../dag-details';
 import { DAGGraph } from '../visualization';
 import { HistoryTable, LogViewer, StatusUpdateModal } from './';
@@ -102,10 +103,16 @@ type HistoryTableProps = {
  */
 function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
   const appBarContext = React.useContext(AppBarContext);
+  const dagContext = React.useContext(DAGContext);
   const client = useClient();
   const navigate = useNavigate();
   const { showError } = useErrorModal();
   const [modal, setModal] = React.useState(false);
+  const [displayDAGRuns, setDisplayDAGRuns] = React.useState(dagRuns);
+
+  React.useEffect(() => {
+    setDisplayDAGRuns(dagRuns);
+  }, [dagRuns]);
 
   // State for log viewer
   const [logViewer, setLogViewer] = useState<{
@@ -137,10 +144,10 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
 
   // Ensure index is valid when dagRuns change (e.g., when switching DAGs)
   React.useEffect(() => {
-    if (!dagRuns || dagRuns.length === 0) return;
+    if (!displayDAGRuns || displayDAGRuns.length === 0) return;
 
     // Clamp the index to be within valid range
-    const maxIdx = dagRuns.length - 1;
+    const maxIdx = displayDAGRuns.length - 1;
     const validIdx = Math.max(0, Math.min(idx, maxIdx));
 
     // Only update if the index needs adjustment
@@ -150,19 +157,19 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
       setSearchParams(newParams);
       setIdx(validIdx);
     }
-  }, [dagRuns, idx]);
+  }, [displayDAGRuns, idx]);
 
   /**
    * Update the selected dagRun index and update URL parameters
    */
   const updateIdx = (newIdx: number) => {
     // Ensure newIdx is within valid range
-    if (newIdx < 0 || !dagRuns || newIdx >= dagRuns.length) {
+    if (newIdx < 0 || !displayDAGRuns || newIdx >= displayDAGRuns.length) {
       return;
     }
 
     setIdx(newIdx);
-    const reversedDAGRuns = [...(dagRuns || [])].reverse();
+    const reversedDAGRuns = [...(displayDAGRuns || [])].reverse();
 
     if (reversedDAGRuns && reversedDAGRuns[newIdx]) {
       // Instead of directly updating the context, update the URL with the dagRun ID
@@ -206,7 +213,7 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
         updateIdx(idx + 1);
       }
     },
-    [idx, dagRuns, updateIdx]
+    [idx, displayDAGRuns, updateIdx]
   );
 
   // Add and remove keyboard event listener
@@ -217,14 +224,10 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
     };
   }, [handleKeyDown]);
 
-  // Get event handlers for the selected dagRun
-  let handlers: components['schemas']['Node'][] | null = null;
-  if (dagRuns && idx < dagRuns.length && dagRuns[idx]) {
-    handlers = getEventHandlers(dagRuns[idx]);
-  }
-
   // Reverse the dagRuns array for display (newest first)
-  const reversedDAGRuns = [...(dagRuns || [])].reverse();
+  const reversedDAGRuns = [...(displayDAGRuns || [])].reverse();
+  const selectedDAGRun = reversedDAGRuns[idx];
+  const handlers = selectedDAGRun ? getEventHandlers(selectedDAGRun) : null;
 
   // State for the selected step in the status update modal
   const [selectedStep, setSelectedStep] = React.useState<
@@ -243,12 +246,7 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
     _step: components['schemas']['Step'],
     status: NodeStatus
   ) => {
-    if (
-      !selectedStep ||
-      !reversedDAGRuns ||
-      idx >= reversedDAGRuns.length ||
-      !reversedDAGRuns[idx]
-    ) {
+    if (!selectedStep || !selectedDAGRun) {
       return;
     }
 
@@ -258,8 +256,8 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
       {
         params: {
           path: {
-            name: reversedDAGRuns[idx].name,
-            dagRunId: reversedDAGRuns[idx].dagRunId,
+            name: selectedDAGRun.name,
+            dagRunId: selectedDAGRun.dagRunId,
             stepName: selectedStep.name,
           },
           query: {
@@ -280,8 +278,26 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
       return;
     }
 
+    setDisplayDAGRuns((current) =>
+      updateDAGRunsNodeStatus(
+        current,
+        selectedDAGRun.dagRunId,
+        selectedStep.name,
+        status
+      )
+    );
+    dagContext.refresh();
     dismissModal();
   };
+
+  const applyDisplayedNodeStatus = React.useCallback(
+    (dagRunId: string, stepName: string, status: NodeStatus) => {
+      setDisplayDAGRuns((current) =>
+        updateDAGRunsNodeStatus(current, dagRunId, stepName, status)
+      );
+    },
+    []
+  );
 
   // Removed the effect that updates the DAG status context
   // The status details page will handle this based on URL parameters
@@ -360,17 +376,17 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
             idx={idx}
           />
 
-          {reversedDAGRuns && reversedDAGRuns[idx] ? (
+          {selectedDAGRun ? (
             <React.Fragment>
               <DAGGraph
-                dagRun={reversedDAGRuns[idx]}
+                dagRun={selectedDAGRun}
                 onSelectStep={onSelectStepOnGraph}
                 onRightClickStep={onRightClickStepOnGraph}
               />
 
               <div className="bg-surface border border-border rounded-lg p-4">
                 <DAGStatusOverview
-                  status={reversedDAGRuns[idx]}
+                  status={selectedDAGRun}
                   onViewLog={(dagRunId) => {
                     setLogViewer({
                       isOpen: true,
@@ -384,9 +400,16 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
               </div>
 
               <NodeStatusTable
-                nodes={reversedDAGRuns[idx].nodes}
-                status={reversedDAGRuns[idx]}
+                nodes={selectedDAGRun.nodes}
+                status={selectedDAGRun}
                 {...props}
+                onNodeStatusUpdated={(stepName, status) =>
+                  applyDisplayedNodeStatus(
+                    selectedDAGRun.dagRunId,
+                    stepName,
+                    status
+                  )
+                }
                 onViewLog={(stepName, dagRunId) => {
                   const isStderr = stepName.endsWith('_stderr');
                   const actualStepName = isStderr
@@ -397,7 +420,7 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
                     isOpen: true,
                     logType: 'step',
                     stepName: actualStepName,
-                    dagRunId: dagRunId || reversedDAGRuns[idx]?.dagRunId || '',
+                    dagRunId: dagRunId || selectedDAGRun.dagRunId,
                     stream: isStderr ? Stream.stderr : Stream.stdout,
                   });
                 }}
@@ -405,9 +428,16 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
 
               {handlers && handlers.length ? (
                 <NodeStatusTable
-                  nodes={getEventHandlers(reversedDAGRuns[idx])}
-                  status={reversedDAGRuns[idx]}
+                  nodes={handlers}
+                  status={selectedDAGRun}
                   {...props}
+                  onNodeStatusUpdated={(stepName, status) =>
+                    applyDisplayedNodeStatus(
+                      selectedDAGRun.dagRunId,
+                      stepName,
+                      status
+                    )
+                  }
                   onViewLog={(stepName, dagRunId) => {
                     const isStderr = stepName.endsWith('_stderr');
                     const actualStepName = isStderr
@@ -418,8 +448,7 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
                       isOpen: true,
                       logType: 'step',
                       stepName: actualStepName,
-                      dagRunId:
-                        dagRunId || reversedDAGRuns[idx]?.dagRunId || '',
+                      dagRunId: dagRunId || selectedDAGRun.dagRunId,
                       stream: isStderr ? Stream.stderr : Stream.stdout,
                     });
                   }}
@@ -434,13 +463,11 @@ function DAGHistoryTable({ fileName, gridData, dagRuns }: HistoryTableProps) {
                 }
                 logType={logViewer.logType}
                 dagName={
-                  reversedDAGRuns && reversedDAGRuns[idx]
-                    ? reversedDAGRuns[idx].name
-                    : ''
+                  selectedDAGRun.name
                 }
                 dagRunId={logViewer.dagRunId}
                 stepName={logViewer.stepName}
-                dagRun={reversedDAGRuns[idx]}
+                dagRun={selectedDAGRun}
                 stream={logViewer.stream}
               />
             </React.Fragment>

--- a/ui/src/features/dags/components/dag-execution/StatusUpdateModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StatusUpdateModal.tsx
@@ -24,7 +24,10 @@ type Props = {
   /** Step to update status for */
   step?: components['schemas']['Step'];
   /** Function called when the user submits the status update */
-  onSubmit: (step: components['schemas']['Step'], status: NodeStatus) => void;
+  onSubmit: (
+    step: components['schemas']['Step'],
+    status: NodeStatus
+  ) => void | Promise<void>;
   /** Optional position for the modal (x, y coordinates) */
   position?: { x: number; y: number };
 };
@@ -61,9 +64,9 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
         case 'Enter':
           e.preventDefault();
           if (selectedButton === 0) {
-            onSubmit(step, NodeStatus.Success);
+            void onSubmit(step, NodeStatus.Success);
           } else {
-            onSubmit(step, NodeStatus.Failed);
+            void onSubmit(step, NodeStatus.Failed);
           }
           break;
           
@@ -106,7 +109,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
                   : 'border-border hover:border-success hover:bg-success-muted'
                 }
               `}
-              onClick={() => onSubmit(step, NodeStatus.Success)}
+              onClick={() => void onSubmit(step, NodeStatus.Success)}
               onMouseEnter={() => setSelectedButton(0)}
             >
               <div className="flex flex-col items-center gap-2">
@@ -124,7 +127,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
                   : 'border-border hover:border-error hover:bg-error-muted'
                 }
               `}
-              onClick={() => onSubmit(step, NodeStatus.Failed)}
+              onClick={() => void onSubmit(step, NodeStatus.Failed)}
               onMouseEnter={() => setSelectedButton(1)}
             >
               <div className="flex flex-col items-center gap-2">

--- a/ui/src/features/dags/components/dag-execution/StatusUpdateModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StatusUpdateModal.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /**
  * StatusUpdateModal component provides a modal dialog for manually updating a step's status.
  *
@@ -44,9 +47,21 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
   // Create refs for the buttons
   const successButtonRef = React.useRef<HTMLButtonElement>(null);
   const failedButtonRef = React.useRef<HTMLButtonElement>(null);
-  
+
   // Track which button is selected (0 = success, 1 = failed)
   const [selectedButton, setSelectedButton] = React.useState(0);
+  const submitStatus = React.useCallback(
+    (status: NodeStatus) => {
+      void (async () => {
+        try {
+          await onSubmit(step, status);
+        } catch {
+          // Submit handlers are expected to surface their own user-facing errors.
+        }
+      })();
+    },
+    [onSubmit, step]
+  );
 
   // Handle keyboard events
   React.useEffect(() => {
@@ -60,16 +75,16 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
           e.preventDefault();
           setSelectedButton(selectedButton === 0 ? 1 : 0);
           break;
-          
+
         case 'Enter':
           e.preventDefault();
           if (selectedButton === 0) {
-            void onSubmit(step, NodeStatus.Success);
+            submitStatus(NodeStatus.Success);
           } else {
-            void onSubmit(step, NodeStatus.Failed);
+            submitStatus(NodeStatus.Failed);
           }
           break;
-          
+
         case 'Escape':
           e.preventDefault();
           dismissModal();
@@ -81,7 +96,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [visible, step, onSubmit, dismissModal, selectedButton]);
+  }, [visible, step, submitStatus, dismissModal, selectedButton]);
 
   // We're not using the position prop anymore as we want the modal to be centered
   // The Dialog component from shadcn/ui will center the modal by default
@@ -109,7 +124,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
                   : 'border-border hover:border-success hover:bg-success-muted'
                 }
               `}
-              onClick={() => void onSubmit(step, NodeStatus.Success)}
+              onClick={() => submitStatus(NodeStatus.Success)}
               onMouseEnter={() => setSelectedButton(0)}
             >
               <div className="flex flex-col items-center gap-2">
@@ -117,7 +132,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
                 <span className="font-mono text-sm">Success</span>
               </div>
             </button>
-            
+
             <button
               ref={failedButtonRef}
               className={`
@@ -127,7 +142,7 @@ function StatusUpdateModal({ visible, dismissModal, step, onSubmit }: Props) {
                   : 'border-border hover:border-error hover:bg-error-muted'
                 }
               `}
-              onClick={() => void onSubmit(step, NodeStatus.Failed)}
+              onClick={() => submitStatus(NodeStatus.Failed)}
               onMouseEnter={() => setSelectedButton(1)}
             >
               <div className="flex flex-col items-center gap-2">

--- a/ui/src/features/dags/contexts/DAGContext.ts
+++ b/ui/src/features/dags/contexts/DAGContext.ts
@@ -11,6 +11,7 @@ export const DAGContext = React.createContext<{
     dagRunId?: string,
     immediate?: boolean
   ) => string | void | Promise<string | void>;
+  onRunStarted?: (dagRunId: string) => void | Promise<void>;
 }>({
   refresh: () => {
     return;

--- a/ui/src/features/dags/lib/nodeStatus.ts
+++ b/ui/src/features/dags/lib/nodeStatus.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import {
+  components,
+  NodeStatus,
+  NodeStatusLabel,
+} from '../../../api/v1/schema';
+
+function nodeStatusLabel(status: NodeStatus): NodeStatusLabel {
+  switch (status) {
+    case NodeStatus.NotStarted:
+      return NodeStatusLabel.not_started;
+    case NodeStatus.Running:
+      return NodeStatusLabel.running;
+    case NodeStatus.Failed:
+      return NodeStatusLabel.failed;
+    case NodeStatus.Aborted:
+      return NodeStatusLabel.aborted;
+    case NodeStatus.Success:
+      return NodeStatusLabel.succeeded;
+    case NodeStatus.Skipped:
+      return NodeStatusLabel.skipped;
+    case NodeStatus.PartialSuccess:
+      return NodeStatusLabel.partially_succeeded;
+    case NodeStatus.Waiting:
+      return NodeStatusLabel.waiting;
+    case NodeStatus.Rejected:
+      return NodeStatusLabel.rejected;
+    case NodeStatus.Retrying:
+      return NodeStatusLabel.retrying;
+    default:
+      return NodeStatusLabel.not_started;
+  }
+}
+
+function updateRequiredNodeStatus(
+  node: components['schemas']['Node'],
+  stepName: string,
+  status: NodeStatus
+): components['schemas']['Node'] {
+  if (node.step.name !== stepName) {
+    return node;
+  }
+
+  return {
+    ...node,
+    status,
+    statusLabel: nodeStatusLabel(status),
+  };
+}
+
+function updateOptionalNodeStatus(
+  node: components['schemas']['Node'] | undefined,
+  stepName: string,
+  status: NodeStatus
+): components['schemas']['Node'] | undefined {
+  return node ? updateRequiredNodeStatus(node, stepName, status) : undefined;
+}
+
+export function updateDAGRunNodeStatus(
+  dagRun: components['schemas']['DAGRunDetails'],
+  stepName: string,
+  status: NodeStatus
+): components['schemas']['DAGRunDetails'] {
+  return {
+    ...dagRun,
+    nodes: dagRun.nodes?.map((node) =>
+      updateRequiredNodeStatus(node, stepName, status)
+    ),
+    onSuccess: updateOptionalNodeStatus(dagRun.onSuccess, stepName, status),
+    onFailure: updateOptionalNodeStatus(dagRun.onFailure, stepName, status),
+    onAbort: updateOptionalNodeStatus(dagRun.onAbort, stepName, status),
+    onExit: updateOptionalNodeStatus(dagRun.onExit, stepName, status),
+  };
+}
+
+export function updateDAGRunsNodeStatus(
+  dagRuns: components['schemas']['DAGRunDetails'][] | null,
+  dagRunId: string,
+  stepName: string,
+  status: NodeStatus
+): components['schemas']['DAGRunDetails'][] | null {
+  return (
+    dagRuns?.map((dagRun) =>
+      dagRun.dagRunId === dagRunId
+        ? updateDAGRunNodeStatus(dagRun, stepName, status)
+        : dagRun
+    ) ?? null
+  );
+}

--- a/ui/src/features/dags/lib/nodeStatus.ts
+++ b/ui/src/features/dags/lib/nodeStatus.ts
@@ -29,9 +29,9 @@ function nodeStatusLabel(status: NodeStatus): NodeStatusLabel {
       return NodeStatusLabel.rejected;
     case NodeStatus.Retrying:
       return NodeStatusLabel.retrying;
-    default:
-      return NodeStatusLabel.not_started;
   }
+  const exhaustive: never = status;
+  return exhaustive;
 }
 
 function updateRequiredNodeStatus(

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -50,6 +50,7 @@ function DAGDetails() {
   const stepName = searchParams.get('step');
   const subDAGRunId = searchParams.get('subDAGRunId');
   const queriedDAGRunName = searchParams.get('dagRunName');
+  const [trackedDagRunId, setTrackedDagRunId] = useState<string>();
   const remoteNode =
     searchParams.get('remoteNode') ||
     appBarContext.selectedRemoteNode ||
@@ -171,14 +172,15 @@ function DAGDetails() {
 
   // Use dagRunName from URL if available, otherwise use the name from dagData
   const dagRunName = queriedDAGRunName || dagData?.dag?.name || '';
+  const effectiveDAGRunId = dagRunId || trackedDagRunId;
   const dagRunQueryEnabled = Boolean(
-    dagRunName && dagRunId && !subDAGRunId && dagMatchesWorkspace
+    dagRunName && effectiveDAGRunId && !subDAGRunId && dagMatchesWorkspace
   );
 
   // Fetch specific DAG-run data if dagRunId is provided
   const dagRunSSE = useDAGRunSSE(
     dagRunName,
-    dagRunId || '',
+    effectiveDAGRunId || '',
     dagRunQueryEnabled,
     remoteNode
   );
@@ -188,7 +190,7 @@ function DAGDetails() {
       params: {
         path: {
           name: dagRunName,
-          dagRunId: dagRunId || '',
+          dagRunId: effectiveDAGRunId || '',
         },
         query: scopedQuery,
       },
@@ -229,7 +231,7 @@ function DAGDetails() {
     if (subDAGRunId) {
       return subDAGRunResponse?.dagRunDetails;
     }
-    if (dagRunId) {
+    if (effectiveDAGRunId) {
       return dagRunResponse?.dagRunDetails;
     }
     return dagData?.latestDAGRun;
@@ -254,10 +256,29 @@ function DAGDetails() {
     mutateDag();
     if (subDAGRunId) {
       mutateSubDagRun();
-    } else if (dagRunId) {
+    } else if (effectiveDAGRunId) {
       mutateDagRun();
     }
-  }, [mutateDag, mutateDagRun, mutateSubDagRun, dagRunId, subDAGRunId]);
+  }, [
+    mutateDag,
+    mutateDagRun,
+    mutateSubDagRun,
+    effectiveDAGRunId,
+    subDAGRunId,
+  ]);
+
+  const handleRunStarted = useCallback(
+    (nextDAGRunId: string) => {
+      setTrackedDagRunId(nextDAGRunId);
+      navigateToStatusTab();
+      void mutateDag();
+    },
+    [mutateDag, navigateToStatusTab]
+  );
+
+  useEffect(() => {
+    setTrackedDagRunId(undefined);
+  }, [fileName, remoteNode]);
 
   // Determine which DAG-run to display - fallback to latest when specific run is loading
   const displayDAGRun = currentDAGRun || dagData?.latestDAGRun;
@@ -306,6 +327,7 @@ function DAGDetails() {
                   skipHeader={true}
                   localDags={dagData?.localDags}
                   editorHints={dagData?.editorHints}
+                  onRunStarted={handleRunStarted}
                 />
               </>
             )}

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -1,7 +1,14 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { components } from '../../../api/v1/schema';
 import { AppBarContext } from '../../../contexts/AppBarContext';
@@ -51,6 +58,7 @@ function DAGDetails() {
   const subDAGRunId = searchParams.get('subDAGRunId');
   const queriedDAGRunName = searchParams.get('dagRunName');
   const [trackedDagRunId, setTrackedDagRunId] = useState<string>();
+  const previousURLDagRunId = useRef<string | null>(dagRunId);
   const remoteNode =
     searchParams.get('remoteNode') ||
     appBarContext.selectedRemoteNode ||
@@ -172,7 +180,7 @@ function DAGDetails() {
 
   // Use dagRunName from URL if available, otherwise use the name from dagData
   const dagRunName = queriedDAGRunName || dagData?.dag?.name || '';
-  const effectiveDAGRunId = dagRunId || trackedDagRunId;
+  const effectiveDAGRunId = trackedDagRunId || dagRunId;
   const dagRunQueryEnabled = Boolean(
     dagRunName && effectiveDAGRunId && !subDAGRunId && dagMatchesWorkspace
   );
@@ -270,11 +278,39 @@ function DAGDetails() {
   const handleRunStarted = useCallback(
     (nextDAGRunId: string) => {
       setTrackedDagRunId(nextDAGRunId);
-      navigateToStatusTab();
+      const nextSearchParams = new URLSearchParams();
+      nextSearchParams.set('dagRunId', nextDAGRunId);
+      nextSearchParams.set('dagRunName', dagData?.dag?.name || dagRunName);
+      if (remoteNode && remoteNode !== 'local') {
+        nextSearchParams.set('remoteNode', remoteNode);
+      }
+      if (queryWorkspace) {
+        nextSearchParams.set('workspace', queryWorkspace);
+      }
+      navigate(`/dags/${fileName}?${nextSearchParams.toString()}`);
       void mutateDag();
     },
-    [mutateDag, navigateToStatusTab]
+    [
+      dagData?.dag?.name,
+      dagRunName,
+      fileName,
+      mutateDag,
+      navigate,
+      queryWorkspace,
+      remoteNode,
+    ]
   );
+
+  useEffect(() => {
+    const previous = previousURLDagRunId.current;
+    previousURLDagRunId.current = dagRunId;
+    if (!dagRunId || dagRunId === trackedDagRunId) {
+      return;
+    }
+    if (previous !== dagRunId) {
+      setTrackedDagRunId(undefined);
+    }
+  }, [dagRunId, trackedDagRunId]);
 
   useEffect(() => {
     setTrackedDagRunId(undefined);


### PR DESCRIPTION
## Summary
- preserve request-scoped SSE payloads while keeping browser clients on the existing multiplexed stream
- restore live updates for DAG-run list, DAG definition, and exact DAG-run status views
- recompute aggregate run status after manual step status changes so UI state reflects backend mutations

## Root Cause
The SSE multiplexer shared one topic payload/hash across sessions even when fetchers depended on request context such as auth, workspace, or remote node. Some DAG-run list topics were also moved to pure event-driven invalidation even though their visible summaries can change without a reliable event for every field. On the DAG definition page, the start/enqueue flow discarded the returned `dagRunId`, so the page stayed on the DAG definition topic instead of subscribing to the exact newly-started DAG-run.

## Validation
- `go test ./internal/service/frontend/... -count=1`
- `pnpm typecheck`
- `pnpm exec vitest run src/features/dags/components/__tests__/DAGStatus.test.tsx src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx src/features/dags/components/dag-details/__tests__/DAGDetailsSidePanel.test.tsx src/features/dags/components/common/__tests__/DAGActions.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track newly started DAG runs and follow a specific run in the UI; expose a callback when a run is started.

* **Improvements**
  * Aggregate DAG-run status now recomputes automatically when individual step statuses change.
  * UI applies status updates optimistically and triggers targeted refreshes for affected views.
  * Real-time updates refined: per-session streaming behaves more reliably and queue views use on-demand invalidation while DAG-run topics remain polling.

* **Tests**
  * Added tests covering status recomputation, streaming/polling behavior, and related UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->