### PR TITLE
Fix worker selector for sub-DAG calls

### DIFF
--- a/internal/intg/distr/subdag_test.go
+++ b/internal/intg/distr/subdag_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,46 @@ steps:
 		agent := f.dagWrapper.Agent()
 		agent.RunSuccess(t)
 		f.dagWrapper.AssertLatestStatus(t, core.Succeeded)
+	})
+}
+
+func TestSubDAG_CallStepWorkerSelector(t *testing.T) {
+	t.Run("immediateParentDispatchesChildUsingCallStepSelector", func(t *testing.T) {
+		f := newTestFixture(t, `
+steps:
+  - name: run-child-on-selected-worker
+    call: selected-child
+    worker_selector:
+      host: serverA
+
+---
+name: selected-child
+steps:
+  - name: child-task
+    command: echo "child executed on selected worker"
+`, withLabels(map[string]string{"host": "serverA"}))
+		defer f.cleanup()
+
+		agent := f.dagWrapper.Agent()
+		agent.RunSuccess(t)
+
+		parentStatus := agent.Status(f.coord.Context)
+		require.Len(t, parentStatus.Nodes, 1)
+		require.Len(t, parentStatus.Nodes[0].SubRuns, 1)
+
+		subRunID := parentStatus.Nodes[0].SubRuns[0].DAGRunID
+		subAttempt, err := f.coord.DAGRunStore.FindSubAttempt(
+			f.coord.Context,
+			exec.NewDAGRunRef(parentStatus.Name, parentStatus.DAGRunID),
+			subRunID,
+		)
+		require.NoError(t, err)
+
+		childStatus, err := subAttempt.ReadStatus(f.coord.Context)
+		require.NoError(t, err)
+		require.NotNil(t, childStatus)
+		require.Equal(t, core.Succeeded, childStatus.Status)
+		require.Equal(t, "worker-1", childStatus.WorkerID)
 	})
 }
 

--- a/internal/runtime/builtin/dag/dag.go
+++ b/internal/runtime/builtin/dag/dag.go
@@ -55,6 +55,7 @@ func newDAGExecutor(ctx context.Context, step core.Step) (executor.Executor, err
 	if len(step.WorkerSelector) > 0 && child.DAG.HasApprovalSteps() {
 		return nil, fmt.Errorf("%w: %s", ErrApprovalStepsWithWorker, step.SubDAG.Name)
 	}
+	child.SetWorkerSelector(step.WorkerSelector)
 
 	dir := runtime.GetEnv(ctx).WorkingDir
 	if dir != "" && !fileutil.FileExists(dir) {

--- a/internal/runtime/builtin/dag/parallel.go
+++ b/internal/runtime/builtin/dag/parallel.go
@@ -566,6 +566,7 @@ func (e *parallelExecutor) newChildExecutor(
 		return nil, fmt.Errorf("%w: %s", ErrApprovalStepsWithWorker, target)
 	}
 
+	child.SetWorkerSelector(e.step.WorkerSelector)
 	child.SetExternalStepRetry(true)
 	return child, nil
 }

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -48,6 +48,9 @@ type SubDAGExecutor struct {
 	// coordinatorCli is used for distributed execution
 	coordinatorCli exec.Dispatcher
 
+	// workerSelector overrides the child DAG's selector for this invocation.
+	workerSelector map[string]string
+
 	// Process tracking for ALL executions
 	mu              sync.Mutex
 	cmds            map[string]*osexec.Cmd // runID -> cmd for local processes
@@ -188,6 +191,42 @@ func (e *SubDAGExecutor) SetExternalStepRetry(enabled bool) {
 	e.externalStepRetry = enabled
 }
 
+// SetWorkerSelector sets a per-invocation worker selector for the sub DAG.
+func (e *SubDAGExecutor) SetWorkerSelector(selector map[string]string) {
+	e.workerSelector = cloneWorkerSelector(selector)
+}
+
+func (e *SubDAGExecutor) effectiveWorkerSelector() map[string]string {
+	if len(e.workerSelector) > 0 {
+		return e.workerSelector
+	}
+	return e.DAG.WorkerSelector
+}
+
+func (e *SubDAGExecutor) shouldDispatchToCoordinator(defaultMode config.ExecutionMode) bool {
+	if e.DAG.ForceLocal {
+		return false
+	}
+	if e.coordinatorCli == nil {
+		return false
+	}
+	if len(e.effectiveWorkerSelector()) > 0 {
+		return true
+	}
+	return defaultMode == config.ExecutionModeDistributed
+}
+
+func cloneWorkerSelector(selector map[string]string) map[string]string {
+	if len(selector) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(selector))
+	for key, value := range selector {
+		clone[key] = value
+	}
+	return clone
+}
+
 func (e *SubDAGExecutor) newLocalCLICommand(
 	ctx context.Context,
 	workDir string,
@@ -276,7 +315,7 @@ func (e *SubDAGExecutor) BuildCoordinatorTask(ctx context.Context, runParams Run
 		tag.Target(e.DAG.Name),
 	)
 	logger.Info(taskCtx, "Built coordinator task for sub DAG",
-		slog.Any("worker-selector", e.DAG.WorkerSelector),
+		slog.Any("worker-selector", e.effectiveWorkerSelector()),
 	)
 
 	return task, nil
@@ -330,7 +369,7 @@ func (e *SubDAGExecutor) coordinatorTaskOptions(ctx context.Context, extra ...Ta
 			Name: rCtx.DAG.Name,
 			ID:   rCtx.DAGRunID,
 		}),
-		WithWorkerSelector(e.DAG.WorkerSelector),
+		WithWorkerSelector(e.effectiveWorkerSelector()),
 		WithBaseConfig(baseConfig),
 	}
 	if e.DAG.SourceFile != "" {
@@ -374,7 +413,7 @@ func (e *SubDAGExecutor) Execute(ctx context.Context, runParams RunParams, workD
 	ctx = logger.WithValues(ctx, tag.SubDAG(e.DAG.Name), tag.SubRunID(runParams.RunID))
 
 	rCtx := exec.GetContext(ctx)
-	if core.ShouldDispatchToCoordinator(e.DAG, e.coordinatorCli != nil, rCtx.DefaultExecMode) {
+	if e.shouldDispatchToCoordinator(rCtx.DefaultExecMode) {
 		// Handle distributed execution
 		logger.Info(ctx, "Executing sub DAG via distributed execution")
 
@@ -397,7 +436,7 @@ func (e *SubDAGExecutor) Retry(ctx context.Context, runParams RunParams, stepNam
 	ctx = logger.WithValues(ctx, tag.SubDAG(e.DAG.Name), tag.SubRunID(runParams.RunID))
 
 	rCtx := exec.GetContext(ctx)
-	if core.ShouldDispatchToCoordinator(e.DAG, e.coordinatorCli != nil, rCtx.DefaultExecMode) {
+	if e.shouldDispatchToCoordinator(rCtx.DefaultExecMode) {
 		logger.Info(ctx, "Retrying sub DAG via distributed execution", tag.Step(stepName))
 		if err := e.dispatchRetryToCoordinator(ctx, runParams, stepName); err != nil {
 			return nil, fmt.Errorf("distributed step retry failed: %w", err)

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -437,6 +437,11 @@ func (e *SubDAGExecutor) Retry(ctx context.Context, runParams RunParams, stepNam
 	rCtx := exec.GetContext(ctx)
 	if e.shouldDispatchToCoordinator(rCtx.DefaultExecMode) {
 		logger.Info(ctx, "Retrying sub DAG via distributed execution", tag.Step(stepName))
+
+		e.mu.Lock()
+		e.distributedRuns[runParams.RunID] = true
+		e.mu.Unlock()
+
 		if err := e.dispatchRetryToCoordinator(ctx, runParams, stepName); err != nil {
 			return nil, fmt.Errorf("distributed step retry failed: %w", err)
 		}

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	osexec "os/exec"
 	"strings"
@@ -221,9 +222,7 @@ func cloneWorkerSelector(selector map[string]string) map[string]string {
 		return nil
 	}
 	clone := make(map[string]string, len(selector))
-	for key, value := range selector {
-		clone[key] = value
-	}
+	maps.Copy(clone, selector)
 	return clone
 }
 

--- a/internal/runtime/executor/dag_runner_test.go
+++ b/internal/runtime/executor/dag_runner_test.go
@@ -379,6 +379,7 @@ func TestRetry_Distributed(t *testing.T) {
 		externalStepRetry: true,
 		distributedRuns:   make(map[string]bool),
 		cmds:              make(map[string]*exec.Cmd),
+		dagCtx:            dagCtx,
 		killed:            make(chan struct{}),
 	}
 
@@ -393,6 +394,10 @@ func TestRetry_Distributed(t *testing.T) {
 	assert.Equal(t, "flaky", task.Step)
 	assert.True(t, task.ExternalStepRetry)
 	require.NotNil(t, task.PreviousStatus)
+	assert.True(t, executor.distributedRuns["child-789"])
+
+	require.NoError(t, executor.Kill(os.Interrupt))
+	assert.Equal(t, 1, dispatcher.requestCancelCalled)
 }
 
 func TestBuildRetryCommand_NoRootDAGRun(t *testing.T) {


### PR DESCRIPTION
## Summary
- pass step-level `worker_selector` through sub-DAG and parallel sub-DAG execution
- use the effective per-invocation selector for sub-DAG dispatch decisions and coordinator task construction
- add a distributed integration regression test for a `call` step whose child DAG has no DAG-level selector

## Root Cause
`worker_selector` on `call` steps was parsed and validated, but `SubDAGExecutor` only consulted the child DAG's own `WorkerSelector`. When the selector existed only on the parent step, the child DAG was treated as local and the coordinator task was never created with the requested worker labels.

## Testing
- `go test ./internal/intg/distr -run 'TestSubDAG_CallStepWorkerSelector/immediateParentDispatchesChildUsingCallStepSelector' -count=1 -v`
- `go test ./internal/intg/distr -run 'TestSubDAG' -count=1`
- `go test ./internal/runtime/executor ./internal/runtime/builtin/dag -count=1`
- `go test ./internal/intg/distr -count=1`

Closes #1638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parent DAG worker selection settings now propagate to child DAGs (sub-DAGs) when executed, providing improved control over distributed task execution routing.
  * Sub-DAGs called from parent DAGs inherit and respect the parent's worker selector constraints.

* **Tests**
  * Added integration test validating worker selection propagation for sub-DAG execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->