### PR TITLE
fix: reduce start-all CPU usage and event-driven SSE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Pre-pull integration test images
+        if: ${{ matrix.suite == 'intg' }}
+        shell: bash
+        run: |
+          images=(
+            "alpine:3"
+            "busybox:latest"
+            "redis:7-alpine"
+            "minio/minio:RELEASE.2024-10-02T17-50-41Z"
+          )
+
+          for image in "${images[@]}"; do
+            for attempt in 1 2 3 4; do
+              if docker pull "${image}"; then
+                break
+              fi
+              if [[ "${attempt}" -eq 4 ]]; then
+                echo "failed to pull ${image}" >&2
+                exit 1
+              fi
+              sleep "$((attempt * 5))"
+            done
+          done
+
       - name: Resolve test packages
         id: test-packages
         shell: bash

--- a/internal/cmn/backoff/retry_test.go
+++ b/internal/cmn/backoff/retry_test.go
@@ -78,23 +78,26 @@ func TestRetry(t *testing.T) {
 
 		op := func(_ context.Context) error {
 			attempts++
-			if attempts == 1 {
-				// Cancel after first attempt
-				go func() {
-					time.Sleep(20 * time.Millisecond)
-					cancel()
-				}()
-			}
 			return errors.New("error")
 		}
 
-		policy := NewConstantBackoffPolicy(100 * time.Millisecond)
+		enteredBackoff := make(chan struct{}, 1)
+		go func() {
+			<-enteredBackoff
+			cancel()
+		}()
+
+		policy := &signalingRetryPolicy{
+			interval:       time.Second,
+			enteredBackoff: enteredBackoff,
+		}
 		start := time.Now()
 		err := Retry(ctx, op, policy, nil)
 		elapsed := time.Since(start)
 
 		assert.Equal(t, context.Canceled, err)
-		assert.Less(t, elapsed, 50*time.Millisecond) // Should exit quickly
+		assert.Equal(t, 1, attempts)
+		assert.Less(t, elapsed, 200*time.Millisecond)
 	})
 
 	t.Run("RetriesExhausted", func(t *testing.T) {
@@ -156,6 +159,19 @@ func TestRetry(t *testing.T) {
 		// With jitter, timing is unpredictable but should be relatively quick
 		assert.Less(t, elapsed, 200*time.Millisecond)
 	})
+}
+
+type signalingRetryPolicy struct {
+	interval       time.Duration
+	enteredBackoff chan<- struct{}
+}
+
+func (p *signalingRetryPolicy) ComputeNextInterval(_ int, _ time.Duration, _ error) (time.Duration, error) {
+	select {
+	case p.enteredBackoff <- struct{}{}:
+	default:
+	}
+	return p.interval, nil
 }
 
 func TestRetryFailureLogLevelOverride(t *testing.T) {

--- a/internal/core/exec/distributed.go
+++ b/internal/core/exec/distributed.go
@@ -221,7 +221,19 @@ func LeaseMatchesStatus(
 	if !lease.IsFresh(now, staleThreshold) {
 		return false
 	}
+	return LeaseIdentityMatchesStatus(lease, status, fallbackAttemptID)
+}
 
+// LeaseIdentityMatchesStatus reports whether the lease belongs to the same
+// persisted distributed attempt as status, independent of freshness.
+func LeaseIdentityMatchesStatus(
+	lease *DAGRunLease,
+	status *DAGRunStatus,
+	fallbackAttemptID string,
+) bool {
+	if lease == nil || status == nil {
+		return false
+	}
 	attemptKey := AttemptKeyForStatus(status, fallbackAttemptID)
 	if attemptKey != "" && lease.AttemptKey != attemptKey {
 		return false

--- a/internal/persis/filedagrun/attempt_test.go
+++ b/internal/persis/filedagrun/attempt_test.go
@@ -897,7 +897,7 @@ func TestAttempt_WorkDir(t *testing.T) {
 	assert.Equal(t, filepath.Join(dagRunDir, "work"), att.WorkDir())
 }
 
-func TestAttempt_WriteEmitsLifecycleTransitionsOnce(t *testing.T) {
+func TestAttempt_WriteEmitsLifecycleTransitionsAndStatusUpdates(t *testing.T) {
 	t.Parallel()
 
 	dir := createTempDir(t)
@@ -929,11 +929,14 @@ func TestAttempt_WriteEmitsLifecycleTransitionsOnce(t *testing.T) {
 	require.NoError(t, att.Write(ctx, succeeded))
 	require.NoError(t, att.Write(ctx, succeeded))
 
-	require.Len(t, store.events, 3)
+	require.Len(t, store.events, 6)
 	assert.Equal(t, []eventstore.EventType{
 		eventstore.TypeDAGRunQueued,
+		eventstore.TypeDAGRunUpdated,
 		eventstore.TypeDAGRunRunning,
+		eventstore.TypeDAGRunUpdated,
 		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunUpdated,
 	}, captureEventTypes(store.events))
 
 	snapshot, err := eventstore.DAGRunSnapshotFromEvent(store.events[0])
@@ -973,9 +976,10 @@ func TestAttempt_OpenRestoresLastEmittedLifecycleState(t *testing.T) {
 	running.StartedAt = time.Now().UTC().Format(time.RFC3339)
 	require.NoError(t, reopened.Write(ctx, running))
 
-	require.Len(t, store.events, 2)
+	require.Len(t, store.events, 3)
 	assert.Equal(t, []eventstore.EventType{
 		eventstore.TypeDAGRunQueued,
+		eventstore.TypeDAGRunUpdated,
 		eventstore.TypeDAGRunRunning,
 	}, captureEventTypes(store.events))
 }

--- a/internal/persis/fileeventstore/collector.go
+++ b/internal/persis/fileeventstore/collector.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -138,6 +139,9 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 			break
 		}
 		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), inboxSuffix) {
 			continue
 		}
 		processed++

--- a/internal/persis/fileeventstore/collector_test.go
+++ b/internal/persis/fileeventstore/collector_test.go
@@ -70,6 +70,32 @@ func TestCollectorDrainOnceQuarantinesMalformedInbox(t *testing.T) {
 	require.Len(t, entries, 1)
 }
 
+func TestCollectorDrainOnceIgnoresAtomicWriteTempFiles(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store, err := New(baseDir)
+	require.NoError(t, err)
+
+	event := testEvent("evt-final", time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, store.Emit(context.Background(), event))
+
+	tmpFile := filepath.Join(store.inboxDir, "pending.json.tmp.123")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("{partial"), filePermissions))
+
+	collector, err := NewCollector(baseDir, 10)
+	require.NoError(t, err)
+	require.NoError(t, collector.DrainOnce(context.Background()))
+
+	assertFileExists(t, tmpFile, true)
+	assertInboxCount(t, store.inboxDir, 1)
+	assertLogLineCount(t, filepath.Join(baseDir, "_2026032912.jsonl"), 1)
+
+	entries, err := os.ReadDir(store.quarantineDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
 func TestCollectorDrainOnceDropsDuplicateInboxEventsWithinSinglePass(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -170,7 +170,7 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 		called := calls
 		mu.Unlock()
 		return called >= 1 && secondMonitor.IsDelivered("dest-1", status)
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -259,7 +259,7 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 		default:
 			return false
 		}
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	firstStatus := &exec.DAGRunStatus{
 		Name:       "briefing",

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -404,7 +404,7 @@ func NotificationClassForEvent(eventType eventstore.EventType, status core.Statu
 		return NotificationClassInformational, true
 	case eventstore.TypeDAGRunAborted, eventstore.TypeDAGRunRejected:
 		return NotificationClassUrgent, true
-	case eventstore.TypeLLMUsageRecorded:
+	case eventstore.TypeDAGRunUpdated, eventstore.TypeLLMUsageRecorded:
 		return NotificationClassUnknown, false
 	default:
 		switch status { //nolint:exhaustive // legacy direct notifications may only pass status

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2040,7 +2040,6 @@ func (h *Handler) StartZombieDetector(ctx context.Context, interval time.Duratio
 
 	go func() {
 		defer close(h.zombieDetectorDone)
-		h.backfillActiveDistributedRuns(ctx)
 		h.detectAndCleanupZombies(ctx)
 
 		ticker := time.NewTicker(interval)
@@ -2086,10 +2085,10 @@ func (h *Handler) detectAndCleanupZombies(ctx context.Context) {
 	h.detectStaleLeases(ctx)
 }
 
-// detectStaleLeases scans all persisted active runs and marks any distributed
-// run with a stale lease as FAILED. This covers scenarios that heartbeat-based
-// detection misses: coordinator restarts (in-memory heartbeats lost), tasks
-// lost between heartbeats, and multi-coordinator shuffling.
+// detectStaleLeases reconciles durable distributed-run leases and marks stale
+// attempts as failed. When the active-run index is available, recovery is
+// bounded by the number of active distributed attempts instead of historical
+// DAG-run status files.
 func (h *Handler) detectStaleLeases(ctx context.Context) {
 	if h.dagRunStore == nil {
 		return
@@ -2116,65 +2115,105 @@ func (h *Handler) detectStaleLeases(ctx context.Context) {
 		return
 	}
 
+	now := time.Now().UTC()
+	h.detectLeasedDistributedRuns(ctx, now)
+
+	if h.activeDistributedRunStore != nil {
+		h.detectIndexedDistributedStatuses(ctx, now)
+		return
+	}
+
+	h.detectOrphanedDistributedStatuses(ctx, now)
+}
+
+func (h *Handler) detectLeasedDistributedRuns(ctx context.Context, now time.Time) {
 	leases, err := h.dagRunLeaseStore.ListAll(ctx)
 	if err != nil {
 		logger.Error(ctx, "Failed to list active distributed leases", tag.Error(err))
 		return
 	}
 
-	now := time.Now().UTC()
 	for _, lease := range leases {
+		h.reconcileDistributedLease(ctx, lease, now)
+	}
+}
+
+func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGRunLease, now time.Time) {
+	if lease.AttemptKey == "" {
+		logger.Warn(ctx, "Skipping distributed lease reconciliation due to missing attempt key",
+			tag.DAG(lease.DAGRun.Name),
+			tag.RunID(lease.DAGRun.ID),
+		)
+		return
+	}
+
+	attempt, runStatus, err := h.resolveLatestAttempt(ctx, lease.DAGRun.Name, lease.DAGRun.ID, lease.Root)
+	switch {
+	case err == nil:
+	case errors.Is(err, exec.ErrDAGRunIDNotFound), errors.Is(err, exec.ErrNoStatusData):
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete distributed lease for missing leased run",
+			"Failed to delete active distributed run for missing leased run",
+		)
+		return
+	default:
+		logger.Error(ctx, "Failed to resolve leased distributed run",
+			tag.DAG(lease.DAGRun.Name),
+			tag.RunID(lease.DAGRun.ID),
+			tag.AttemptKey(lease.AttemptKey),
+			tag.Error(err),
+		)
+		return
+	}
+
+	attemptID := lease.AttemptID
+	if attemptID == "" && runStatus != nil {
+		attemptID = runStatus.AttemptID
+	}
+	if attemptID == "" && attempt != nil {
+		attemptID = attempt.ID()
+	}
+
+	if runStatus == nil {
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete distributed lease for empty leased status",
+			"Failed to delete active distributed run for empty leased status",
+		)
+		return
+	}
+
+	if !exec.IsRemoteWorkerID(runStatus.WorkerID) ||
+		!exec.LeaseIdentityMatchesStatus(&lease, runStatus, attemptID) {
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete superseded distributed lease",
+			"Failed to delete superseded active distributed run",
+		)
+		return
+	}
+
+	switch runStatus.Status {
+	case core.Running, core.NotStarted:
 		if lease.IsFresh(now, h.staleLeaseThreshold) {
-			continue
+			h.upsertActiveDistributedRun(ctx, runStatus, lease.WorkerID, attemptID)
+			return
 		}
-		reason := staleDistributedLeaseReason(lease.WorkerID)
-		h.markLeaseRunFailed(ctx, lease, reason)
+	case core.Queued:
+		if lease.IsFresh(now, h.staleLeaseThreshold) {
+			return
+		}
+	default:
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete inactive distributed lease",
+			"Failed to delete inactive active distributed run",
+		)
+		return
 	}
 
-	if h.activeDistributedRunStore != nil {
-		h.detectIndexedDistributedStatuses(ctx, now)
-	}
-
-	h.detectOrphanedDistributedStatuses(ctx, now)
+	h.markStatusLeaseRunFailed(ctx, runStatus, attemptID, lease.AttemptKey, staleDistributedLeaseReason(lease.WorkerID))
 }
 
 func staleDistributedLeaseReason(workerID string) string {
 	return exec.DistributedLeaseExpiredReason(workerID)
-}
-
-func (h *Handler) backfillActiveDistributedRuns(ctx context.Context) {
-	if h.dagRunStore == nil || h.dagRunLeaseStore == nil || h.activeDistributedRunStore == nil {
-		return
-	}
-
-	statuses, err := h.dagRunStore.ListStatuses(ctx,
-		exec.WithStatuses([]core.Status{core.Running, core.NotStarted}),
-		exec.WithoutLimit(),
-		exec.WithAllHistory(),
-	)
-	if err != nil {
-		logger.Error(ctx, "Failed to list distributed statuses for active-run backfill", tag.Error(err))
-		return
-	}
-
-	now := time.Now().UTC()
-	for _, runStatus := range statuses {
-		if runStatus == nil || !exec.IsRemoteWorkerID(runStatus.WorkerID) {
-			continue
-		}
-
-		leaseState, ok := h.loadDistributedLeaseForStatus(ctx, runStatus)
-		if !ok {
-			continue
-		}
-
-		if exec.LeaseMatchesStatus(leaseState.lease, runStatus, leaseState.attemptID, now, h.staleLeaseThreshold) {
-			h.upsertActiveDistributedRun(ctx, runStatus, runStatus.WorkerID, leaseState.attemptID)
-			continue
-		}
-
-		h.markStatusLeaseRunFailed(ctx, runStatus, leaseState.attemptID, leaseState.attemptKey, staleDistributedLeaseReason(runStatus.WorkerID))
-	}
 }
 
 func (h *Handler) detectOrphanedDistributedStatuses(ctx context.Context, now time.Time) {
@@ -2379,21 +2418,6 @@ func (h *Handler) indexedDistributedRunMatchesStatus(
 		}
 	}
 	return true
-}
-
-// markLeaseRunFailed marks a stale distributed attempt failed if and only if it
-// is still the latest attempt for the DAG run and still active.
-func (h *Handler) markLeaseRunFailed(ctx context.Context, lease exec.DAGRunLease, reason string) {
-	h.failDistributedAttemptIfCurrent(
-		ctx,
-		lease.DAGRun,
-		lease.AttemptID,
-		lease.AttemptKey,
-		reason,
-		core.Running,
-		core.NotStarted,
-		core.Queued,
-	)
 }
 
 func (h *Handler) markStatusLeaseRunFailed(

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2151,7 +2151,9 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 	attempt, runStatus, err := h.resolveLatestAttempt(ctx, lease.DAGRun.Name, lease.DAGRun.ID, lease.Root)
 	switch {
 	case err == nil:
-	case errors.Is(err, exec.ErrDAGRunIDNotFound), errors.Is(err, exec.ErrNoStatusData):
+	case errors.Is(err, exec.ErrDAGRunIDNotFound),
+		errors.Is(err, exec.ErrNoStatusData),
+		errors.Is(err, exec.ErrCorruptedStatusFile):
 		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
 			"Failed to delete distributed lease for missing leased run",
 			"Failed to delete active distributed run for missing leased run",
@@ -2267,7 +2269,9 @@ func (h *Handler) detectIndexedDistributedStatuses(ctx context.Context, now time
 		_, runStatus, err := h.resolveLatestAttempt(ctx, record.DAGRun.Name, record.DAGRun.ID, record.Root)
 		switch {
 		case err == nil:
-		case errors.Is(err, exec.ErrDAGRunIDNotFound), errors.Is(err, exec.ErrNoStatusData):
+		case errors.Is(err, exec.ErrDAGRunIDNotFound),
+			errors.Is(err, exec.ErrNoStatusData),
+			errors.Is(err, exec.ErrCorruptedStatusFile):
 			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), record.DAGRun, record.AttemptKey,
 				"Failed to delete distributed lease for missing indexed run",
 				"Failed to delete active distributed run for missing indexed run",

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2195,12 +2195,7 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 	}
 
 	switch runStatus.Status {
-	case core.Running, core.NotStarted:
-		if lease.IsFresh(now, h.staleLeaseThreshold) {
-			h.upsertActiveDistributedRun(ctx, runStatus, workerID, attemptID)
-			return
-		}
-	case core.Queued:
+	case core.Running, core.NotStarted, core.Queued:
 		if lease.IsFresh(now, h.staleLeaseThreshold) {
 			h.upsertActiveDistributedRun(ctx, runStatus, workerID, attemptID)
 			return

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -917,6 +917,7 @@ func (h *Handler) AckTaskClaim(ctx context.Context, req *coordinatorv1.AckTaskCl
 	if err := h.dagRunLeaseStore.Upsert(ctx, buildLeaseFromTask(claimed.Task, req.WorkerId, h.owner, now)); err != nil {
 		return nil, status.Error(codes.Internal, "failed to create run lease: "+err.Error())
 	}
+	h.upsertActiveDistributedRunFromTask(ctx, claimed.Task, req.WorkerId, now)
 	if err := h.dispatchTaskStore.DeleteClaim(ctx, req.ClaimToken); err != nil {
 		return nil, status.Error(codes.Internal, "failed to finalize task claim: "+err.Error())
 	}
@@ -2182,8 +2183,8 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 		return
 	}
 
-	if !exec.IsRemoteWorkerID(runStatus.WorkerID) ||
-		!exec.LeaseIdentityMatchesStatus(&lease, runStatus, attemptID) {
+	workerID, ok := distributedWorkerIDForStatus(runStatus, lease.WorkerID)
+	if !ok || !exec.LeaseIdentityMatchesStatus(&lease, runStatus, attemptID) {
 		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
 			"Failed to delete superseded distributed lease",
 			"Failed to delete superseded active distributed run",
@@ -2194,22 +2195,29 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 	switch runStatus.Status {
 	case core.Running, core.NotStarted:
 		if lease.IsFresh(now, h.staleLeaseThreshold) {
-			h.upsertActiveDistributedRun(ctx, runStatus, lease.WorkerID, attemptID)
+			h.upsertActiveDistributedRun(ctx, runStatus, workerID, attemptID)
 			return
 		}
 	case core.Queued:
 		if lease.IsFresh(now, h.staleLeaseThreshold) {
+			h.upsertActiveDistributedRun(ctx, runStatus, workerID, attemptID)
 			return
 		}
-	default:
+	case core.Failed, core.Aborted, core.Succeeded, core.PartiallySucceeded, core.Waiting, core.Rejected:
 		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
 			"Failed to delete inactive distributed lease",
 			"Failed to delete inactive active distributed run",
 		)
 		return
+	default:
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete unknown-state distributed lease",
+			"Failed to delete unknown-state active distributed run",
+		)
+		return
 	}
 
-	h.markStatusLeaseRunFailed(ctx, runStatus, attemptID, lease.AttemptKey, staleDistributedLeaseReason(lease.WorkerID))
+	h.markStatusLeaseRunFailed(ctx, runStatus, attemptID, lease.AttemptKey, staleDistributedLeaseReason(workerID))
 }
 
 func staleDistributedLeaseReason(workerID string) string {
@@ -2275,7 +2283,8 @@ func (h *Handler) detectIndexedDistributedStatuses(ctx context.Context, now time
 			continue
 		}
 
-		if !h.indexedDistributedRunMatchesStatus(record, runStatus) {
+		workerID, ok := distributedWorkerIDForStatus(runStatus, record.WorkerID)
+		if !ok || !h.indexedDistributedRunMatchesStatus(record, runStatus) {
 			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), record.DAGRun, record.AttemptKey,
 				"Failed to delete superseded distributed lease from active index",
 				"Failed to delete superseded active distributed run",
@@ -2297,11 +2306,11 @@ func (h *Handler) detectIndexedDistributedStatuses(ctx context.Context, now time
 		}
 
 		if exec.LeaseMatchesStatus(lease, runStatus, record.AttemptID, now, h.staleLeaseThreshold) {
-			h.upsertActiveDistributedRun(ctx, runStatus, runStatus.WorkerID, record.AttemptID)
+			h.upsertActiveDistributedRun(ctx, runStatus, workerID, record.AttemptID)
 			continue
 		}
 
-		h.markStatusLeaseRunFailed(ctx, runStatus, record.AttemptID, record.AttemptKey, staleDistributedLeaseReason(runStatus.WorkerID))
+		h.markStatusLeaseRunFailed(ctx, runStatus, record.AttemptID, record.AttemptKey, staleDistributedLeaseReason(workerID))
 	}
 }
 
@@ -2393,14 +2402,55 @@ func (h *Handler) upsertActiveDistributedRun(
 	}
 }
 
+func (h *Handler) upsertActiveDistributedRunFromTask(
+	ctx context.Context,
+	task *coordinatorv1.Task,
+	workerID string,
+	now time.Time,
+) {
+	if h.activeDistributedRunStore == nil || task == nil || task.AttemptKey == "" {
+		return
+	}
+	if !exec.IsRemoteWorkerID(workerID) {
+		return
+	}
+
+	root := exec.DAGRunRef{Name: task.RootDagRunName, ID: task.RootDagRunId}
+	if root.Zero() {
+		root = exec.DAGRunRef{Name: task.Target, ID: task.DagRunId}
+	}
+
+	record := exec.ActiveDistributedRun{
+		AttemptKey: task.AttemptKey,
+		DAGRun: exec.DAGRunRef{
+			Name: task.Target,
+			ID:   task.DagRunId,
+		},
+		Root:      root,
+		AttemptID: task.AttemptId,
+		WorkerID:  workerID,
+		Status:    core.Queued,
+		UpdatedAt: now.UnixMilli(),
+	}
+	if err := h.activeDistributedRunStore.Upsert(ctx, record); err != nil {
+		logger.Warn(ctx, "Failed to upsert active distributed run from task claim",
+			tag.RunID(task.DagRunId),
+			tag.AttemptKey(task.AttemptKey),
+			tag.Error(err),
+		)
+	}
+}
+
 func (h *Handler) indexedDistributedRunMatchesStatus(
 	record exec.ActiveDistributedRun,
 	runStatus *exec.DAGRunStatus,
 ) bool {
-	if runStatus == nil || !exec.IsRemoteWorkerID(runStatus.WorkerID) {
+	if _, ok := distributedWorkerIDForStatus(runStatus, record.WorkerID); !ok {
 		return false
 	}
-	if runStatus.Status != core.Running && runStatus.Status != core.NotStarted {
+	if runStatus.Status != core.Running &&
+		runStatus.Status != core.NotStarted &&
+		runStatus.Status != core.Queued {
 		return false
 	}
 
@@ -2418,6 +2468,25 @@ func (h *Handler) indexedDistributedRunMatchesStatus(
 		}
 	}
 	return true
+}
+
+func distributedWorkerIDForStatus(status *exec.DAGRunStatus, fallbackWorkerID string) (string, bool) {
+	if status == nil {
+		return "", false
+	}
+	if exec.IsRemoteWorkerID(status.WorkerID) {
+		return status.WorkerID, true
+	}
+	if status.WorkerID != "" {
+		return "", false
+	}
+	if status.Status != core.Queued && status.Status != core.NotStarted {
+		return "", false
+	}
+	if !exec.IsRemoteWorkerID(fallbackWorkerID) {
+		return "", false
+	}
+	return fallbackWorkerID, true
 }
 
 func (h *Handler) markStatusLeaseRunFailed(

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -477,23 +477,6 @@ func (m *mockDAGRunAttempt) WasClosed() bool {
 	return m.closed
 }
 
-func createStoredAttemptStatus(
-	t *testing.T,
-	store exec.DAGRunStore,
-	ts time.Time,
-	dagName string,
-	dagRunID string,
-	runStatus exec.DAGRunStatus,
-) {
-	t.Helper()
-
-	attempt, err := store.CreateAttempt(context.Background(), &core.DAG{Name: dagName}, ts, dagRunID, exec.NewDAGRunAttemptOptions{})
-	require.NoError(t, err)
-	require.NoError(t, attempt.Open(context.Background()))
-	require.NoError(t, attempt.Write(context.Background(), runStatus))
-	require.NoError(t, attempt.Close(context.Background()))
-}
-
 func TestHandler_Poll(t *testing.T) {
 	t.Parallel()
 
@@ -1788,10 +1771,13 @@ func TestHandler_ZombieDetection(t *testing.T) {
 			name       string
 			status     core.Status
 			nodeStatus core.NodeStatus
+			workerID   string
 		}{
-			{name: "Running", status: core.Running, nodeStatus: core.NodeRunning},
-			{name: "NotStarted", status: core.NotStarted, nodeStatus: core.NodeNotStarted},
-			{name: "Queued", status: core.Queued, nodeStatus: core.NodeNotStarted},
+			{name: "Running", status: core.Running, nodeStatus: core.NodeRunning, workerID: "worker-1"},
+			{name: "NotStarted", status: core.NotStarted, nodeStatus: core.NodeNotStarted, workerID: "worker-1"},
+			{name: "NotStartedWithoutPersistedWorkerID", status: core.NotStarted, nodeStatus: core.NodeNotStarted},
+			{name: "Queued", status: core.Queued, nodeStatus: core.NodeNotStarted, workerID: "worker-1"},
+			{name: "QueuedWithoutPersistedWorkerID", status: core.Queued, nodeStatus: core.NodeNotStarted},
 		}
 
 		for _, tc := range testCases {
@@ -1814,7 +1800,7 @@ func TestHandler_ZombieDetection(t *testing.T) {
 					AttemptID:  "attempt-1",
 					AttemptKey: "lease-key-1",
 					Status:     tc.status,
-					WorkerID:   "worker-1",
+					WorkerID:   tc.workerID,
 					Nodes: []*exec.Node{
 						{Status: tc.nodeStatus},
 					},
@@ -2725,10 +2711,12 @@ func TestHandler_ReportStatus(t *testing.T) {
 		baseDir := filepath.Join(t.TempDir(), "distributed")
 		dispatchStore := filedistributed.NewDispatchTaskStore(baseDir)
 		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		activeStore := filedistributed.NewActiveDistributedRunStore(baseDir)
 		h := NewHandler(HandlerConfig{
-			DispatchTaskStore: dispatchStore,
-			DAGRunLeaseStore:  leaseStore,
-			Owner:             exec.CoordinatorEndpoint{ID: "coord-a", Host: "127.0.0.1", Port: 1234},
+			DispatchTaskStore:         dispatchStore,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+			Owner:                     exec.CoordinatorEndpoint{ID: "coord-a", Host: "127.0.0.1", Port: 1234},
 		})
 		ctx := context.Background()
 
@@ -2763,6 +2751,14 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.Equal(t, "queue-a", lease.QueueName)
 		assert.Equal(t, "worker-1", lease.WorkerID)
 		assert.Equal(t, "coord-a", lease.Owner.ID)
+
+		record, err := activeStore.Get(ctx, "attempt-key-1")
+		require.NoError(t, err)
+		assert.Equal(t, "test-dag", record.DAGRun.Name)
+		assert.Equal(t, "run-123", record.DAGRun.ID)
+		assert.Equal(t, "attempt-1", record.AttemptID)
+		assert.Equal(t, "worker-1", record.WorkerID)
+		assert.Equal(t, core.Queued, record.Status)
 
 		_, err = dispatchStore.GetClaim(ctx, claimed.ClaimToken)
 		assert.ErrorIs(t, err, exec.ErrDispatchTaskNotFound)

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -33,6 +33,7 @@ type mockDAGRunStore struct {
 	subAttempts         map[string]*mockDAGRunAttempt // key: rootID:subID
 	createAttemptErr    error
 	createSubAttemptErr error
+	listStatusesCalls   int
 	mu                  sync.Mutex
 }
 
@@ -117,6 +118,7 @@ func (m *mockDAGRunStore) ListStatuses(_ context.Context, opts ...exec.ListDAGRu
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.listStatusesCalls++
 
 	var statuses []*exec.DAGRunStatus
 	appendStatus := func(status *exec.DAGRunStatus) {
@@ -150,6 +152,12 @@ func (m *mockDAGRunStore) ListStatuses(_ context.Context, opts ...exec.ListDAGRu
 	}
 
 	return statuses, nil
+}
+
+func (m *mockDAGRunStore) ListStatusesCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.listStatusesCalls
 }
 
 func (m *mockDAGRunStore) ListStatusesPage(ctx context.Context, opts ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
@@ -1839,6 +1847,60 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		}
 	})
 
+	t.Run("DetectStaleLeasesFailsLeasedRunWithoutStatusScan", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		activeStore := filedistributed.NewActiveDistributedRunStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:               store,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+			StaleLeaseThreshold:       time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-lease",
+			AttemptID:  "attempt-1",
+			AttemptKey: "lease-key-1",
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      "lease-key-1",
+			DAGRun:          ref,
+			Root:            ref,
+			AttemptID:       "attempt-1",
+			QueueName:       "lease-dag",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: staleAt.UnixMilli(),
+			ClaimedAt:       staleAt.UnixMilli(),
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		assert.Zero(t, store.ListStatusesCallCount())
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, core.Failed, status.Status)
+		assert.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
+		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+
+		_, err = leaseStore.Get(ctx, "lease-key-1")
+		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+	})
+
 	t.Run("DetectStaleLeasesFailsOrphanedDistributedStatusWithoutLease", func(t *testing.T) {
 		t.Parallel()
 
@@ -1873,25 +1935,26 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
 	})
 
-	t.Run("BackfillActiveDistributedRunsRepairsHistoricalOrphanedRemoteStatus", func(t *testing.T) {
+	t.Run("DetectStaleLeasesRebuildsActiveIndexFromLeasesWithoutStatusScan", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		baseDir := t.TempDir()
-		store := filedagrun.New(filepath.Join(baseDir, "dag-runs"))
-		leaseStore := filedistributed.NewDAGRunLeaseStore(filepath.Join(baseDir, "distributed"))
-		activeStore := filedistributed.NewActiveDistributedRunStore(filepath.Join(baseDir, "distributed"))
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		activeStore := filedistributed.NewActiveDistributedRunStore(baseDir)
 		h := NewHandler(HandlerConfig{
 			DAGRunStore:               store,
 			DAGRunLeaseStore:          leaseStore,
 			ActiveDistributedRunStore: activeStore,
-			StaleLeaseThreshold:       time.Second,
+			StaleLeaseThreshold:       time.Minute,
 		})
 
-		attemptKey := exec.GenerateAttemptKey("lease-dag", "run-old", "lease-dag", "run-old", "attempt-1")
-		createStoredAttemptStatus(t, store, time.Now().UTC().Add(-48*time.Hour), "lease-dag", "run-old", exec.DAGRunStatus{
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attemptKey := "lease-key-1"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
 			Name:       "lease-dag",
-			DAGRunID:   "run-old",
+			DAGRunID:   "run-lease",
 			AttemptID:  "attempt-1",
 			AttemptKey: attemptKey,
 			Status:     core.Running,
@@ -1900,20 +1963,31 @@ func TestHandler_ZombieDetection(t *testing.T) {
 				{Status: core.NodeRunning},
 			},
 		})
+		freshAt := time.Now().UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      attemptKey,
+			DAGRun:          ref,
+			Root:            ref,
+			AttemptID:       "attempt-1",
+			QueueName:       "lease-dag",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: freshAt.UnixMilli(),
+			ClaimedAt:       freshAt.UnixMilli(),
+		}))
 
-		h.backfillActiveDistributedRuns(ctx)
+		h.detectStaleLeases(ctx)
 
-		attempt, err := store.FindAttempt(ctx, exec.DAGRunRef{Name: "lease-dag", ID: "run-old"})
-		require.NoError(t, err)
+		assert.Zero(t, store.ListStatusesCallCount())
+
 		status, err := attempt.ReadStatus(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, core.Failed, status.Status)
-		assert.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
-		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+		assert.Equal(t, core.Running, status.Status)
 
-		records, err := activeStore.ListAll(ctx)
+		record, err := activeStore.Get(ctx, attemptKey)
 		require.NoError(t, err)
-		assert.Empty(t, records)
+		assert.Equal(t, ref, record.DAGRun)
+		assert.Equal(t, "attempt-1", record.AttemptID)
+		assert.Equal(t, "worker-1", record.WorkerID)
 	})
 
 	t.Run("DetectIndexedDistributedStatusesFailsActiveEntryWhenLeaseMissing", func(t *testing.T) {
@@ -1964,7 +2038,7 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		assert.Empty(t, records)
 	})
 
-	t.Run("DetectStaleLeasesFallsBackToStatusScanWhenActiveIndexMissesRun", func(t *testing.T) {
+	t.Run("DetectStaleLeasesDoesNotScanStatusesWhenActiveIndexMissesRun", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
@@ -1996,9 +2070,8 @@ func TestHandler_ZombieDetection(t *testing.T) {
 
 		status, err := attempt.ReadStatus(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, core.Failed, status.Status)
-		assert.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
-		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+		assert.Equal(t, core.Running, status.Status)
+		assert.Zero(t, store.ListStatusesCallCount())
 
 		records, err := activeStore.ListAll(ctx)
 		require.NoError(t, err)

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -2063,6 +2063,62 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, records)
 	})
+
+	t.Run("DetectStaleLeasesDeletesTrackingForCorruptedStatus", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		activeStore := filedistributed.NewActiveDistributedRunStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:               store,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+			StaleLeaseThreshold:       time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-corrupted"}
+		attemptKey := "lease-key-corrupted"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-corrupted",
+			AttemptID:  "attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+		})
+		attempt.readStatusError = exec.ErrCorruptedStatusFile
+
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      attemptKey,
+			DAGRun:          ref,
+			Root:            ref,
+			AttemptID:       "attempt-1",
+			QueueName:       "lease-dag",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: staleAt.UnixMilli(),
+			ClaimedAt:       staleAt.UnixMilli(),
+		}))
+		require.NoError(t, activeStore.Upsert(ctx, exec.ActiveDistributedRun{
+			AttemptKey: attemptKey,
+			DAGRun:     ref,
+			Root:       ref,
+			AttemptID:  "attempt-1",
+			WorkerID:   "worker-1",
+			Status:     core.Running,
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		assert.Zero(t, store.ListStatusesCallCount())
+		_, err := leaseStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+		_, err = activeStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrActiveRunNotFound)
+	})
 }
 
 func TestHandler_ReportStatus(t *testing.T) {

--- a/internal/service/eventstore/context.go
+++ b/internal/service/eventstore/context.go
@@ -60,15 +60,16 @@ func EmitPersistedStatusTransitionFromContext(
 	if !ok || service == nil || status == nil {
 		return previous, false, nil
 	}
-	eventType, ok := PersistedDAGRunEventTypeForStatus(status.Status)
+	lifecycleEventType, ok := PersistedDAGRunEventTypeForStatus(status.Status)
 	if !ok {
 		return previous, false, nil
 	}
-	if eventType == previous {
-		return previous, false, nil
+	eventType := lifecycleEventType
+	if lifecycleEventType == previous {
+		eventType = TypeDAGRunUpdated
 	}
 	if err := service.Emit(context.WithoutCancel(ctx), NewDAGRunEvent(source, eventType, status, data)); err != nil {
 		return previous, false, err
 	}
-	return eventType, true, nil
+	return lifecycleEventType, true, nil
 }

--- a/internal/service/eventstore/eventstore.go
+++ b/internal/service/eventstore/eventstore.go
@@ -212,6 +212,8 @@ func DAGRunEventID(eventType EventType, dagName, dagRunID, attemptID string) str
 }
 
 func DAGRunUpdateEventID(dagName, dagRunID, attemptID string, recordedAt time.Time) string {
+	// Same-status updates are invalidation edges. The file collector deduplicates
+	// by event ID globally, so update IDs must remain unique across writes.
 	return "dag_update_" + stableID(
 		string(TypeDAGRunUpdated),
 		dagName,

--- a/internal/service/eventstore/eventstore.go
+++ b/internal/service/eventstore/eventstore.go
@@ -36,6 +36,7 @@ type EventType string
 const (
 	TypeDAGRunQueued    EventType = "dag.run.queued"
 	TypeDAGRunRunning   EventType = "dag.run.running"
+	TypeDAGRunUpdated   EventType = "dag.run.updated"
 	TypeDAGRunWaiting   EventType = "dag.run.waiting"
 	TypeDAGRunSucceeded EventType = "dag.run.succeeded"
 	TypeDAGRunFailed    EventType = "dag.run.failed"
@@ -210,6 +211,16 @@ func DAGRunEventID(eventType EventType, dagName, dagRunID, attemptID string) str
 	return "dag_" + stableID(string(eventType), dagName, dagRunID, attemptID)
 }
 
+func DAGRunUpdateEventID(dagName, dagRunID, attemptID string, recordedAt time.Time) string {
+	return "dag_update_" + stableID(
+		string(TypeDAGRunUpdated),
+		dagName,
+		dagRunID,
+		attemptID,
+		recordedAt.UTC().Format(time.RFC3339Nano),
+	)
+}
+
 func LLMUsageEventID(sessionID, messageID string) string {
 	return "llm_" + stableID(string(TypeLLMUsageRecorded), sessionID, messageID)
 }
@@ -219,6 +230,15 @@ func NewDAGRunEvent(source Source, eventType EventType, status *exec.DAGRunStatu
 		return nil
 	}
 	source = normalizeSource(source)
+	recordedAt := time.Now().UTC()
+	eventID := DAGRunEventID(eventType, status.Name, status.DAGRunID, status.AttemptID)
+	if eventType == TypeDAGRunUpdated {
+		eventID = DAGRunUpdateEventID(status.Name, status.DAGRunID, status.AttemptID, recordedAt)
+	}
+	occurredAt := dagRunOccurredAt(status, eventType)
+	if eventType == TypeDAGRunUpdated {
+		occurredAt = recordedAt
+	}
 	data = cloneData(data)
 	if snapshot := newDAGRunStatusSnapshot(status, dagRunFileNameFromData(data)); snapshot != nil {
 		if data == nil {
@@ -227,10 +247,10 @@ func NewDAGRunEvent(source Source, eventType EventType, status *exec.DAGRunStatu
 		data[dagRunStatusSnapshotDataKey] = snapshot
 	}
 	event := &Event{
-		ID:             DAGRunEventID(eventType, status.Name, status.DAGRunID, status.AttemptID),
+		ID:             eventID,
 		SchemaVersion:  SchemaVersion,
-		OccurredAt:     dagRunOccurredAt(status, eventType),
-		RecordedAt:     time.Now().UTC(),
+		OccurredAt:     occurredAt,
+		RecordedAt:     recordedAt,
 		Kind:           KindDAGRun,
 		Type:           eventType,
 		SourceService:  source.Service,
@@ -340,6 +360,8 @@ func dagRunOccurredAt(status *exec.DAGRunStatus, eventType EventType) time.Time 
 		if t, err := stringutil.ParseTime(status.QueuedAt); err == nil && !t.IsZero() {
 			return t.UTC()
 		}
+	case TypeDAGRunUpdated:
+		return time.Now().UTC()
 	case TypeDAGRunWaiting, TypeDAGRunSucceeded, TypeDAGRunFailed, TypeDAGRunAborted, TypeDAGRunRejected:
 		if t, err := stringutil.ParseTime(status.FinishedAt); err == nil && !t.IsZero() {
 			return t.UTC()

--- a/internal/service/eventstore/eventstore_test.go
+++ b/internal/service/eventstore/eventstore_test.go
@@ -213,6 +213,16 @@ func TestEmitPersistedStatusTransitionFromContextEmitsUpdateForRepeatedStatus(t 
 	assert.False(t, IsNotificationEventType(store.event.Kind, store.event.Type))
 }
 
+func TestDAGRunUpdateEventIDIncludesRecordedAt(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 4, 23, 1, 2, 3, 0, time.UTC)
+	first := DAGRunUpdateEventID("briefing", "run-1", "attempt-1", base)
+	second := DAGRunUpdateEventID("briefing", "run-1", "attempt-1", base.Add(time.Nanosecond))
+
+	assert.NotEqual(t, first, second)
+}
+
 func TestNewDAGRunEventDeepClonesData(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/eventstore/eventstore_test.go
+++ b/internal/service/eventstore/eventstore_test.go
@@ -181,6 +181,38 @@ func TestDAGRunSnapshotFromEventBackfillsLegacyDAGFile(t *testing.T) {
 	assert.Equal(t, "run-1", status.DAGRunID)
 }
 
+func TestEmitPersistedStatusTransitionFromContextEmitsUpdateForRepeatedStatus(t *testing.T) {
+	t.Parallel()
+
+	store := &captureStore{}
+	service := New(store)
+	ctx := WithContext(context.Background(), service, Source{Service: SourceServiceServer})
+	status := &exec.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    core.Running,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	previous, emitted, err := EmitPersistedStatusTransitionFromContext(ctx, "", status, nil)
+	require.NoError(t, err)
+	require.True(t, emitted)
+	require.NotNil(t, store.event)
+	assert.Equal(t, TypeDAGRunRunning, store.event.Type)
+	assert.Equal(t, TypeDAGRunRunning, previous)
+
+	store.event = nil
+	next, emitted, err := EmitPersistedStatusTransitionFromContext(ctx, previous, status, nil)
+	require.NoError(t, err)
+	require.True(t, emitted)
+	require.NotNil(t, store.event)
+	assert.Equal(t, TypeDAGRunUpdated, store.event.Type)
+	assert.Equal(t, TypeDAGRunRunning, next)
+	assert.True(t, IsDAGRunEventType(store.event.Kind, store.event.Type))
+	assert.False(t, IsNotificationEventType(store.event.Kind, store.event.Type))
+}
+
 func TestNewDAGRunEventDeepClonesData(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/eventstore/notifications.go
+++ b/internal/service/eventstore/notifications.go
@@ -210,7 +210,14 @@ func IsDAGRunEventType(kind EventKind, eventType EventType) bool {
 		return false
 	}
 	switch eventType {
-	case TypeDAGRunQueued, TypeDAGRunRunning, TypeDAGRunWaiting, TypeDAGRunSucceeded, TypeDAGRunFailed, TypeDAGRunAborted, TypeDAGRunRejected:
+	case TypeDAGRunQueued,
+		TypeDAGRunRunning,
+		TypeDAGRunUpdated,
+		TypeDAGRunWaiting,
+		TypeDAGRunSucceeded,
+		TypeDAGRunFailed,
+		TypeDAGRunAborted,
+		TypeDAGRunRejected:
 		return true
 	case TypeLLMUsageRecorded:
 		return false
@@ -226,7 +233,7 @@ func IsNotificationEventType(kind EventKind, eventType EventType) bool {
 	switch eventType {
 	case TypeDAGRunWaiting, TypeDAGRunSucceeded, TypeDAGRunFailed, TypeDAGRunAborted, TypeDAGRunRejected:
 		return true
-	case TypeDAGRunQueued, TypeDAGRunRunning, TypeLLMUsageRecorded:
+	case TypeDAGRunQueued, TypeDAGRunRunning, TypeDAGRunUpdated, TypeLLMUsageRecorded:
 		return false
 	default:
 		return false

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1161,14 +1161,23 @@ func (srv *Server) registerDedicatedSSEFetchers(registrar *sse.Multiplexer) {
 	registrar.RegisterFetcher(sse.TopicTypeDoc, srv.apiV1.GetDocContentData)
 	registrar.RegisterFetcher(sse.TopicTypeDocTree, srv.apiV1.GetDocTreeData)
 
-	// Queue views have an eventstore-backed invalidation path. DAG-run list
-	// topics intentionally stay on the default polling mode: cockpit/dashboard
-	// views depend on summaries that can change without a reliable lifecycle
-	// event for every visible field, and manual step mutations can leave the
-	// aggregate DAG-run lifecycle unchanged.
+	// Run-driven topics have an event-store invalidation path. Keeping them on
+	// demand avoids repeated full-list and history reads while browsers are
+	// connected; DAG-run event collection wakes the exact and aggregate topics.
 	if srv.eventService != nil {
-		registrar.SetRefreshMode(sse.TopicTypeQueues, sse.TopicRefreshModeOnDemand)
+		for _, topicType := range []sse.TopicType{
+			sse.TopicTypeDAGRun,
+			sse.TopicTypeSubDAGRun,
+			sse.TopicTypeDAGHistory,
+			sse.TopicTypeDAGRuns,
+			sse.TopicTypeQueues,
+			sse.TopicTypeDAGsList,
+		} {
+			registrar.SetRefreshMode(topicType, sse.TopicRefreshModeOnDemand)
+		}
+		registrar.SetPublishOnWake(sse.TopicTypeDAGsList, true)
 		registrar.SetPublishOnWake(sse.TopicTypeDAGRuns, true)
+		registrar.SetPublishOnWake(sse.TopicTypeQueues, true)
 	}
 }
 

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -62,33 +62,50 @@ func testConfig(tmpDir string, ia config.InitialAdmin) *config.Config {
 	}
 }
 
-func TestRegisterDedicatedSSEFetchersKeepsDAGRunTopicsPollingWithEventStore(t *testing.T) {
+func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		topicType sse.TopicType
-		topic     string
+		name       string
+		topicType  sse.TopicType
+		topic      string
+		identifier string
 	}{
 		{
-			name:      "dag run details",
-			topicType: sse.TopicTypeDAGRun,
-			topic:     "dagrun:test/run-1",
+			name:       "dag run details",
+			topicType:  sse.TopicTypeDAGRun,
+			topic:      "dagrun:test/run-1",
+			identifier: "test/run-1",
 		},
 		{
-			name:      "sub dag run details",
-			topicType: sse.TopicTypeSubDAGRun,
-			topic:     "subdagrun:test/run-1/sub-1",
+			name:       "sub dag run details",
+			topicType:  sse.TopicTypeSubDAGRun,
+			topic:      "subdagrun:test/run-1/sub-1",
+			identifier: "test/run-1/sub-1",
 		},
 		{
-			name:      "dag history",
-			topicType: sse.TopicTypeDAGHistory,
-			topic:     "daghistory:test.yaml",
+			name:       "dag history",
+			topicType:  sse.TopicTypeDAGHistory,
+			topic:      "daghistory:test.yaml",
+			identifier: "test.yaml",
 		},
 		{
-			name:      "dag runs list",
-			topicType: sse.TopicTypeDAGRuns,
-			topic:     "dagruns:limit=10&status=4",
+			name:       "dag runs list",
+			topicType:  sse.TopicTypeDAGRuns,
+			topic:      "dagruns:limit=10&status=4",
+			identifier: "limit=10&status=4",
+		},
+		{
+			name:       "queues list",
+			topicType:  sse.TopicTypeQueues,
+			topic:      "queues:",
+			identifier: "",
+		},
+		{
+			name:       "dags list",
+			topicType:  sse.TopicTypeDAGsList,
+			topic:      "dagslist:page=1&perPage=100",
+			identifier: "page=1&perPage=100",
 		},
 	}
 
@@ -129,8 +146,16 @@ func TestRegisterDedicatedSSEFetchersKeepsDAGRunTopicsPollingWithEventStore(t *t
 			}()
 
 			require.Eventually(t, func() bool {
-				return fetches.Load() >= 2
-			}, 3*time.Second, 10*time.Millisecond)
+				return fetches.Load() == 1
+			}, time.Second, 10*time.Millisecond)
+			require.Never(t, func() bool {
+				return fetches.Load() > 1
+			}, 1200*time.Millisecond, 20*time.Millisecond)
+
+			mux.WakeTopic(tt.topicType, tt.identifier)
+			require.Eventually(t, func() bool {
+				return fetches.Load() == 2
+			}, time.Second, 10*time.Millisecond)
 
 			cancel()
 			require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary
- replace coordinator startup historical DAG-run scans with lease and active-index reconciliation
- switch run-driven SSE topics to event-store-driven on-demand refresh
- emit non-notification DAG-run update events so same-status progress still wakes browser subscribers

## Root Cause
`start-all` started the coordinator zombie detector by backfilling active distributed runs through a history-wide `ListStatuses(... WithAllHistory, WithoutLimit)` scan. On large local stores this made startup CPU scale with all historical DAG runs instead of active distributed attempts.

## Validation
- `go test ./internal/service/eventstore ./internal/persis/fileeventstore ./internal/persis/filedagrun`
- `go test ./internal/core/exec ./internal/service/coordinator`
- `go test ./internal/service/frontend ./internal/service/frontend/sse ./internal/service/frontend/api/v1`
- `make bin`
- CPU profile of `dagu start-all --cpu-profile` against `~/.dagu` after the fix: coordinator backfill no longer appears in the profile; `filedagrun.(*Store).ListStatuses` dropped to a 10ms scheduler retry-scanner sample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DAG-run "updated" event type and deterministic update event IDs.

* **Improvements**
  * Durable stale-lease reconciliation with stricter lease identity/freshness handling and faster recovery.
  * SSE run-related topics use on-demand invalidation; more topics publish on wake.
  * Collector ignores non-inbox temp files; task claims upsert active run tracking immediately.
  * Notification filtering now excludes DAG-run update events.

* **Tests**
  * Expanded coverage for events, lease handling, SSE, collector edge cases, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->