### PR TITLE
refactor: simplify loader and execution boundaries

### DIFF
--- a/internal/cmn/mailer/mailer.go
+++ b/internal/cmn/mailer/mailer.go
@@ -64,11 +64,17 @@ func (m *Client) Send(
 	subject, body string,
 	attachments []string,
 ) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, mailTimeout)
+	defer cancel()
+
 	logger.Info(ctx, "Sending email", slog.Any("to", to), tag.Subject(subject))
 	if m.username == "" && m.password == "" {
-		return m.sendWithNoAuth(from, to, subject, body, attachments)
+		return m.send(ctx, from, to, subject, body, attachments, false)
 	}
-	return m.sendWithAuth(from, to, subject, body, attachments)
+	return m.send(ctx, from, to, subject, body, attachments, true)
 }
 
 func (m *Client) sendWithNoAuth(
@@ -77,57 +83,9 @@ func (m *Client) sendWithNoAuth(
 	subject, body string,
 	attachments []string,
 ) error {
-	// Create a dialer with timeout
-	dialer := &net.Dialer{
-		Timeout: mailTimeout,
-	}
-
-	// Dial with timeout
-	conn, err := dialer.Dial("tcp", m.host+":"+m.port)
-	if err != nil {
-		return err
-	}
-
-	// Set deadline for all operations
-	deadline := time.Now().Add(mailTimeout)
-	if err := conn.SetDeadline(deadline); err != nil {
-		_ = conn.Close()
-		return err
-	}
-
-	c, err := smtp.NewClient(conn, m.host)
-	if err != nil {
-		_ = conn.Close()
-		return err
-	}
-	defer func() {
-		_ = c.Close()
-	}()
-
-	if err = c.Mail(replacer.Replace(from)); err != nil {
-		return err
-	}
-	for i := range to {
-		to[i] = replacer.Replace(to[i])
-		if err = c.Rcpt(to[i]); err != nil {
-			return err
-		}
-	}
-	wc, err := c.Data()
-	if err != nil {
-		return err
-	}
-	body = processEmailBody(body)
-	_, err = wc.Write(
-		m.composeMail(to, from, subject, body, attachments),
-	)
-	if err != nil {
-		return err
-	}
-	if err := wc.Close(); err != nil {
-		return err
-	}
-	return c.Quit()
+	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
+	defer cancel()
+	return m.send(ctx, from, to, subject, body, attachments, false)
 }
 
 func (m *Client) sendWithAuth(
@@ -136,120 +94,126 @@ func (m *Client) sendWithAuth(
 	subject, body string,
 	attachments []string,
 ) error {
-	// Create a context with timeout for cancellation support
 	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
 	defer cancel()
-
-	// Create a channel to receive the result
-	type result struct {
-		err error
-	}
-	resultChan := make(chan result, 1)
-
-	// Run the mail sending in a goroutine with proper STARTTLS and auth support
-	go func() {
-		err := m.sendWithSTARTTLS(ctx, from, to, subject, body, attachments)
-		resultChan <- result{err: err}
-	}()
-
-	// Wait for either completion or context cancellation
-	select {
-	case res := <-resultChan:
-		return res.err
-	case <-ctx.Done():
-		return fmt.Errorf("mail sending timeout after %v", mailTimeout)
-	}
+	return m.send(ctx, from, to, subject, body, attachments, true)
 }
 
-// sendWithSTARTTLS connects to the SMTP server, negotiates STARTTLS if available,
-// and authenticates using LOGIN auth (falling back to PLAIN if LOGIN is unavailable).
-func (m *Client) sendWithSTARTTLS(
+func (m *Client) send(
 	ctx context.Context,
 	from string,
 	to []string,
 	subject, body string,
 	attachments []string,
+	useAuth bool,
 ) error {
-	addr := m.host + ":" + m.port
-
-	// Use a dialer with context for cancellation support
 	dialer := &net.Dialer{
 		Timeout: mailTimeout,
 	}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(m.host, m.port))
 	if err != nil {
-		return fmt.Errorf("failed to connect to SMTP server: %w", err)
+		return err
 	}
+	defer func() {
+		_ = conn.Close()
+	}()
 
-	// Set deadline based on context deadline for cleaner shutdown
 	if deadline, ok := ctx.Deadline(); ok {
 		if err := conn.SetDeadline(deadline); err != nil {
-			_ = conn.Close()
 			return err
 		}
 	}
 
-	// Create SMTP client
 	c, err := smtp.NewClient(conn, m.host)
 	if err != nil {
-		_ = conn.Close()
-		return fmt.Errorf("failed to create SMTP client: %w", err)
+		return err
 	}
 	defer func() {
 		_ = c.Close()
 	}()
 
-	// Send EHLO/HELO
-	if err = c.Hello("localhost"); err != nil {
+	if useAuth {
+		if err := m.enableAuth(ctx, c); err != nil {
+			return err
+		}
+	}
+
+	recipients := sanitizeAddresses(to)
+	if err := c.Mail(replacer.Replace(from)); err != nil {
+		if useAuth {
+			return fmt.Errorf("MAIL FROM failed: %w", err)
+		}
+		return err
+	}
+	for _, recipient := range recipients {
+		if err := c.Rcpt(recipient); err != nil {
+			if useAuth {
+				return fmt.Errorf("RCPT TO failed: %w", err)
+			}
+			return err
+		}
+	}
+
+	wc, err := c.Data()
+	if err != nil {
+		if useAuth {
+			return fmt.Errorf("DATA command failed: %w", err)
+		}
+		return err
+	}
+	defer func() {
+		_ = wc.Close()
+	}()
+
+	payload := m.composeMail(recipients, from, subject, processEmailBody(body), attachments)
+	_, err = wc.Write(payload)
+	if err != nil {
+		if useAuth {
+			return fmt.Errorf("failed to write email body: %w", err)
+		}
+		return err
+	}
+	if err := wc.Close(); err != nil {
+		if useAuth {
+			return fmt.Errorf("failed to close data writer: %w", err)
+		}
+		return err
+	}
+
+	return c.Quit()
+}
+
+func sanitizeAddresses(addresses []string) []string {
+	if len(addresses) == 0 {
+		return nil
+	}
+	cleaned := make([]string, len(addresses))
+	for i, address := range addresses {
+		cleaned[i] = replacer.Replace(address)
+	}
+	return cleaned
+}
+
+// enableAuth negotiates STARTTLS if available and then authenticates.
+func (m *Client) enableAuth(ctx context.Context, c *smtp.Client) error {
+	if err := c.Hello("localhost"); err != nil {
 		return fmt.Errorf("HELO failed: %w", err)
 	}
 
-	// Check if STARTTLS is supported and upgrade connection
 	if ok, _ := c.Extension("STARTTLS"); ok {
 		tlsConfig := &tls.Config{
 			ServerName: m.host,
 			MinVersion: tls.VersionTLS12,
 		}
-		if err = c.StartTLS(tlsConfig); err != nil {
+		if err := c.StartTLS(tlsConfig); err != nil {
 			return fmt.Errorf("STARTTLS failed: %w", err)
 		}
 	}
 
-	// Authenticate using LOGIN auth (more widely supported than PLAIN for "basic auth")
-	if err = m.authenticate(ctx, c); err != nil {
+	if err := m.authenticate(ctx, c); err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
-
-	// Set sender
-	if err = c.Mail(replacer.Replace(from)); err != nil {
-		return fmt.Errorf("MAIL FROM failed: %w", err)
-	}
-
-	// Set recipients
-	for i := range to {
-		to[i] = replacer.Replace(to[i])
-		if err = c.Rcpt(to[i]); err != nil {
-			return fmt.Errorf("RCPT TO failed: %w", err)
-		}
-	}
-
-	// Send the email body
-	wc, err := c.Data()
-	if err != nil {
-		return fmt.Errorf("DATA command failed: %w", err)
-	}
-
-	body = processEmailBody(body)
-	_, err = wc.Write(m.composeMail(to, from, subject, body, attachments))
-	if err != nil {
-		return fmt.Errorf("failed to write email body: %w", err)
-	}
-
-	if err = wc.Close(); err != nil {
-		return fmt.Errorf("failed to close data writer: %w", err)
-	}
-
-	return c.Quit()
+	return nil
 }
 
 // authenticate tries LOGIN auth first, then falls back to PLAIN auth.
@@ -338,26 +302,17 @@ func (m *Client) composeMail(
 	to []string,
 	from, subject, body string,
 	attachments []string,
-) (b []byte) {
-	msg := m.composeHeader(to, from, subject) +
-		"\r\n" + base64.StdEncoding.EncodeToString([]byte(body))
-	b = joinBytes([]byte(msg), addAttachments(attachments))
-	b = joinBytes(b, []byte("\r\n\r\n--"+boundary+"--\r\n\r\n"))
-	b = joinBytes(b, []byte("\r\n\r\n"))
-	return b
-}
-
-func joinBytes(s ...[]byte) []byte {
-	n := 0
-	for _, v := range s {
-		n += len(v)
-	}
-
-	b, i := make([]byte, n), 0
-	for _, v := range s {
-		i += copy(b[i:], v)
-	}
-	return b
+) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(m.composeHeader(to, from, subject))
+	buf.WriteString("\r\n")
+	buf.WriteString(base64.StdEncoding.EncodeToString([]byte(body)))
+	buf.Write(addAttachments(attachments))
+	buf.WriteString("\r\n\r\n--")
+	buf.WriteString(boundary)
+	buf.WriteString("--\r\n\r\n")
+	buf.WriteString("\r\n\r\n")
+	return buf.Bytes()
 }
 
 func newlineToBrTag(body string) string {
@@ -394,9 +349,7 @@ func addAttachments(attachments []string) []byte {
 					filepath.Base(fileName) + "\r\n",
 			)
 			_, _ = buf.WriteString("Content-Transfer-Encoding: base64\r\n\n")
-			b := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
-			base64.StdEncoding.Encode(b, data)
-			_, _ = buf.Write(b)
+			_, _ = buf.WriteString(base64.StdEncoding.EncodeToString(data))
 		}
 	}
 	return buf.Bytes()

--- a/internal/cmn/mailer/mailer.go
+++ b/internal/cmn/mailer/mailer.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
@@ -54,6 +55,7 @@ var (
 	boundary     = "==simple-boundary-dagu-mailer"
 	errFileEmpty = errors.New("file is empty")
 	mailTimeout  = 30 * time.Second
+	maxHeaderLen = 256
 )
 
 // SendMail sends an email.
@@ -74,28 +76,6 @@ func (m *Client) Send(
 	if m.username == "" && m.password == "" {
 		return m.send(ctx, from, to, subject, body, attachments, false)
 	}
-	return m.send(ctx, from, to, subject, body, attachments, true)
-}
-
-func (m *Client) sendWithNoAuth(
-	from string,
-	to []string,
-	subject, body string,
-	attachments []string,
-) error {
-	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
-	defer cancel()
-	return m.send(ctx, from, to, subject, body, attachments, false)
-}
-
-func (m *Client) sendWithAuth(
-	from string,
-	to []string,
-	subject, body string,
-	attachments []string,
-) error {
-	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
-	defer cancel()
 	return m.send(ctx, from, to, subject, body, attachments, true)
 }
 
@@ -132,52 +112,42 @@ func (m *Client) send(
 		_ = c.Close()
 	}()
 
-	if err := m.prepareSession(ctx, c, useAuth); err != nil {
-		return err
+	if useAuth {
+		if err := m.prepareSession(ctx, c); err != nil {
+			return err
+		}
 	}
 
 	recipients := sanitizeAddresses(to)
 	safeFrom := sanitizeHeaderField(from)
 	safeSubject := sanitizeHeaderField(subject)
 	if err := c.Mail(safeFrom); err != nil {
-		if useAuth {
-			return fmt.Errorf("MAIL FROM failed: %w", err)
-		}
-		return err
+		return fmt.Errorf("MAIL FROM failed: %w", err)
 	}
 	for _, recipient := range recipients {
 		if err := c.Rcpt(recipient); err != nil {
-			if useAuth {
-				return fmt.Errorf("RCPT TO failed: %w", err)
-			}
-			return err
+			return fmt.Errorf("RCPT TO failed: %w", err)
 		}
 	}
 
 	wc, err := c.Data()
 	if err != nil {
-		if useAuth {
-			return fmt.Errorf("DATA command failed: %w", err)
-		}
-		return err
+		return fmt.Errorf("DATA command failed: %w", err)
 	}
 
 	payload := m.composeMail(recipients, safeFrom, safeSubject, processEmailBody(body), attachments)
 	_, err = wc.Write(payload)
 	if err != nil {
-		if useAuth {
-			return fmt.Errorf("failed to write email body: %w", err)
-		}
-		return err
+		return fmt.Errorf("failed to write email body: %w", err)
 	}
 	if err := wc.Close(); err != nil {
-		if useAuth {
-			return fmt.Errorf("failed to close data writer: %w", err)
-		}
-		return err
+		return fmt.Errorf("failed to close data writer: %w", err)
 	}
 
-	return c.Quit()
+	if err := c.Quit(); err != nil {
+		return fmt.Errorf("QUIT failed: %w", err)
+	}
+	return nil
 }
 
 func sanitizeAddresses(addresses []string) []string {
@@ -192,11 +162,24 @@ func sanitizeAddresses(addresses []string) []string {
 }
 
 func sanitizeHeaderField(value string) string {
-	return replacer.Replace(value)
+	value = replacer.Replace(value)
+	var b strings.Builder
+	b.Grow(min(len(value), maxHeaderLen))
+	for _, r := range value {
+		if r != '\t' && (r < 0x20 || r == 0x7f) {
+			continue
+		}
+		size := utf8.RuneLen(r)
+		if size < 0 || b.Len()+size > maxHeaderLen {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
-// prepareSession negotiates STARTTLS if available and authenticates when enabled.
-func (m *Client) prepareSession(ctx context.Context, c *smtp.Client, useAuth bool) error {
+// prepareSession negotiates STARTTLS and authenticates authenticated sessions.
+func (m *Client) prepareSession(ctx context.Context, c *smtp.Client) error {
 	if err := c.Hello("localhost"); err != nil {
 		return fmt.Errorf("HELO failed: %w", err)
 	}
@@ -209,10 +192,6 @@ func (m *Client) prepareSession(ctx context.Context, c *smtp.Client, useAuth boo
 		if err := c.StartTLS(tlsConfig); err != nil {
 			return fmt.Errorf("STARTTLS failed: %w", err)
 		}
-	}
-
-	if !useAuth {
-		return nil
 	}
 
 	if err := m.authenticate(ctx, c); err != nil {
@@ -316,10 +295,9 @@ func (m *Client) composeMail(
 	buf.WriteString("\r\n")
 	buf.WriteString(base64.StdEncoding.EncodeToString([]byte(body)))
 	buf.Write(addAttachments(attachments))
-	buf.WriteString("\r\n\r\n--")
+	buf.WriteString("\r\n--")
 	buf.WriteString(boundary)
-	buf.WriteString("--\r\n\r\n")
-	buf.WriteString("\r\n\r\n")
+	buf.WriteString("--\r\n")
 	return buf.Bytes()
 }
 
@@ -349,14 +327,14 @@ func addAttachments(attachments []string) []byte {
 	for _, fileName := range attachments {
 		data, err := readFile(fileName)
 		if err == nil {
-			_, _ = fmt.Fprintf(&buf, "\r\n\n--%s\r\n", boundary)
-			_, _ = buf.WriteString("Content-Type: text/plain;" + "\r\n")
-			_, _ = buf.WriteString("Content-Transfer-Encoding: base64" + "\r\n")
+			_, _ = fmt.Fprintf(&buf, "\r\n--%s\r\n", boundary)
+			_, _ = buf.WriteString("Content-Type: text/plain\r\n")
+			_, _ = buf.WriteString("Content-Transfer-Encoding: base64\r\n")
 			_, _ = buf.WriteString(
 				"Content-Disposition: attachment; filename=" +
 					filepath.Base(fileName) + "\r\n",
 			)
-			_, _ = buf.WriteString("Content-Transfer-Encoding: base64\r\n\n")
+			_, _ = buf.WriteString("\r\n")
 			_, _ = buf.WriteString(base64.StdEncoding.EncodeToString(data))
 		}
 	}

--- a/internal/cmn/mailer/mailer.go
+++ b/internal/cmn/mailer/mailer.go
@@ -132,14 +132,14 @@ func (m *Client) send(
 		_ = c.Close()
 	}()
 
-	if useAuth {
-		if err := m.enableAuth(ctx, c); err != nil {
-			return err
-		}
+	if err := m.prepareSession(ctx, c, useAuth); err != nil {
+		return err
 	}
 
 	recipients := sanitizeAddresses(to)
-	if err := c.Mail(replacer.Replace(from)); err != nil {
+	safeFrom := sanitizeHeaderField(from)
+	safeSubject := sanitizeHeaderField(subject)
+	if err := c.Mail(safeFrom); err != nil {
 		if useAuth {
 			return fmt.Errorf("MAIL FROM failed: %w", err)
 		}
@@ -161,11 +161,8 @@ func (m *Client) send(
 		}
 		return err
 	}
-	defer func() {
-		_ = wc.Close()
-	}()
 
-	payload := m.composeMail(recipients, from, subject, processEmailBody(body), attachments)
+	payload := m.composeMail(recipients, safeFrom, safeSubject, processEmailBody(body), attachments)
 	_, err = wc.Write(payload)
 	if err != nil {
 		if useAuth {
@@ -194,8 +191,12 @@ func sanitizeAddresses(addresses []string) []string {
 	return cleaned
 }
 
-// enableAuth negotiates STARTTLS if available and then authenticates.
-func (m *Client) enableAuth(ctx context.Context, c *smtp.Client) error {
+func sanitizeHeaderField(value string) string {
+	return replacer.Replace(value)
+}
+
+// prepareSession negotiates STARTTLS if available and authenticates when enabled.
+func (m *Client) prepareSession(ctx context.Context, c *smtp.Client, useAuth bool) error {
 	if err := c.Hello("localhost"); err != nil {
 		return fmt.Errorf("HELO failed: %w", err)
 	}
@@ -208,6 +209,10 @@ func (m *Client) enableAuth(ctx context.Context, c *smtp.Client) error {
 		if err := c.StartTLS(tlsConfig); err != nil {
 			return fmt.Errorf("STARTTLS failed: %w", err)
 		}
+	}
+
+	if !useAuth {
+		return nil
 	}
 
 	if err := m.authenticate(ctx, c); err != nil {
@@ -287,6 +292,9 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 func (*Client) composeHeader(
 	to []string, from string, subject string,
 ) string {
+	to = sanitizeAddresses(to)
+	from = sanitizeHeaderField(from)
+	subject = sanitizeHeaderField(subject)
 	return "To: " + strings.Join(to, ",") + "\r\n" +
 		"From: " + from + "\r\n" +
 		"Subject: " + subject + "\r\n" +

--- a/internal/cmn/mailer/mailer_test.go
+++ b/internal/cmn/mailer/mailer_test.go
@@ -200,6 +200,26 @@ Please check the configuration.`,
 	}
 }
 
+func TestComposeMailSanitizesHeaders(t *testing.T) {
+	t.Parallel()
+
+	client := New(Config{})
+	payload := string(client.composeMail(
+		[]string{"to@example.com\r\nX-Dagu-To: injected"},
+		"from@example.com\r\nX-Dagu-From: injected",
+		"subject\r\nX-Dagu-Subject: injected",
+		"body",
+		nil,
+	))
+
+	assert.NotContains(t, payload, "\r\nX-Dagu-To:")
+	assert.NotContains(t, payload, "\r\nX-Dagu-From:")
+	assert.NotContains(t, payload, "\r\nX-Dagu-Subject:")
+	assert.Contains(t, payload, "To: to@example.comX-Dagu-To: injected")
+	assert.Contains(t, payload, "From: from@example.comX-Dagu-From: injected")
+	assert.Contains(t, payload, "Subject: subjectX-Dagu-Subject: injected")
+}
+
 // mockSMTPServer creates a mock SMTP server for testing
 type mockSMTPServer struct {
 	listener      net.Listener

--- a/internal/cmn/mailer/mailer_test.go
+++ b/internal/cmn/mailer/mailer_test.go
@@ -5,9 +5,13 @@ package mailer
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -218,6 +222,311 @@ func TestComposeMailSanitizesHeaders(t *testing.T) {
 	assert.Contains(t, payload, "To: to@example.comX-Dagu-To: injected")
 	assert.Contains(t, payload, "From: from@example.comX-Dagu-From: injected")
 	assert.Contains(t, payload, "Subject: subjectX-Dagu-Subject: injected")
+}
+
+func TestSanitizeHeaderFieldRemovesControlCharactersAndTruncates(t *testing.T) {
+	t.Parallel()
+
+	value := strings.Repeat("a", 300) + "\r\n" + "b" + string([]byte{0x00, 0x1f, 0x7f}) + "\t"
+	sanitized := sanitizeHeaderField(value)
+
+	require.Len(t, sanitized, 256)
+	require.NotContains(t, sanitized, "\r")
+	require.NotContains(t, sanitized, "\n")
+	for _, r := range sanitized {
+		require.False(t, r < 0x20 && r != '\t')
+		require.NotEqual(t, rune(0x7f), r)
+	}
+}
+
+func TestComposeMailAttachmentTransferEncodingHeaderAppearsOncePerPart(t *testing.T) {
+	t.Parallel()
+
+	attachment := filepath.Join(t.TempDir(), "attachment.txt")
+	require.NoError(t, os.WriteFile(attachment, []byte("hello"), 0600))
+
+	client := New(Config{})
+	payload := string(client.composeMail(
+		[]string{"to@example.com"},
+		"from@example.com",
+		"subject",
+		"body",
+		[]string{attachment},
+	))
+
+	require.Equal(t, 2, strings.Count(payload, "Content-Transfer-Encoding: base64"))
+}
+
+func TestComposeMailEndsWithClosingBoundary(t *testing.T) {
+	t.Parallel()
+
+	client := New(Config{})
+	payload := string(client.composeMail(
+		[]string{"to@example.com"},
+		"from@example.com",
+		"subject",
+		"body",
+		nil,
+	))
+
+	require.True(t, strings.HasSuffix(payload, "--"+boundary+"--\r\n"))
+	require.NotContains(t, payload, "--"+boundary+"--\r\n\r\n")
+}
+
+func TestSendWithoutAuthSkipsStartTLS(t *testing.T) {
+	t.Parallel()
+
+	server, err := newSMTPRecordingServer()
+	require.NoError(t, err)
+	server.advertiseSTARTTLS = true
+	defer func() {
+		_ = server.Close()
+	}()
+
+	go server.Serve()
+
+	host, port, err := net.SplitHostPort(server.Address())
+	require.NoError(t, err)
+
+	mailer := New(Config{Host: host, Port: port})
+	err = mailer.Send(
+		context.Background(),
+		"from@example.com",
+		[]string{"to@example.com"},
+		"Subject",
+		"Body",
+		nil,
+	)
+	require.NoError(t, err)
+	require.Zero(t, server.StartTLSCount())
+}
+
+func TestSendWrapsSMTPCommandErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		configure      func(*smtpRecordingServer)
+		expectedSubstr string
+	}{
+		{
+			name: "MailFrom",
+			configure: func(server *smtpRecordingServer) {
+				server.mailFromResponse = "550 sender rejected\r\n"
+			},
+			expectedSubstr: "MAIL FROM failed",
+		},
+		{
+			name: "RcptTo",
+			configure: func(server *smtpRecordingServer) {
+				server.rcptToResponse = "550 recipient rejected\r\n"
+			},
+			expectedSubstr: "RCPT TO failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, err := newSMTPRecordingServer()
+			require.NoError(t, err)
+			tt.configure(server)
+			defer func() {
+				_ = server.Close()
+			}()
+
+			go server.Serve()
+
+			host, port, err := net.SplitHostPort(server.Address())
+			require.NoError(t, err)
+
+			mailer := New(Config{Host: host, Port: port})
+			err = mailer.Send(
+				context.Background(),
+				"from@example.com",
+				[]string{"to@example.com"},
+				"Subject",
+				"Body",
+				nil,
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.expectedSubstr)
+		})
+	}
+}
+
+func TestSendSanitizesHeaders(t *testing.T) {
+	t.Parallel()
+
+	server, err := newSMTPRecordingServer()
+	require.NoError(t, err)
+	defer func() {
+		_ = server.Close()
+	}()
+
+	go server.Serve()
+
+	host, port, err := net.SplitHostPort(server.Address())
+	require.NoError(t, err)
+
+	mailer := New(Config{Host: host, Port: port})
+	err = mailer.Send(
+		context.Background(),
+		"from@example.com\r\nX-Dagu-From: injected",
+		[]string{"to@example.com\r\nX-Dagu-To: injected"},
+		"Subject\r\nX-Dagu-Subject: injected",
+		"Body",
+		nil,
+	)
+	require.NoError(t, err)
+
+	payloads := server.RecordedDataBodies()
+	require.Len(t, payloads, 1)
+	payload := payloads[0]
+	require.NotContains(t, payload, "\r\nX-Dagu-From:")
+	require.NotContains(t, payload, "\r\nX-Dagu-To:")
+	require.NotContains(t, payload, "\r\nX-Dagu-Subject:")
+	require.Contains(t, payload, "From: from@example.comX-Dagu-From: injected")
+	require.Contains(t, payload, "To: to@example.comX-Dagu-To: injected")
+	require.Contains(t, payload, "Subject: SubjectX-Dagu-Subject: injected")
+}
+
+type smtpRecordingServer struct {
+	listener           net.Listener
+	advertiseSTARTTLS  bool
+	mailFromResponse   string
+	rcptToResponse     string
+	startTLSResponse   string
+	mu                 sync.Mutex
+	startTLSCount      int
+	recordedDataBodies []string
+}
+
+func newSMTPRecordingServer() (*smtpRecordingServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	return &smtpRecordingServer{
+		listener:         listener,
+		mailFromResponse: "250 OK\r\n",
+		rcptToResponse:   "250 OK\r\n",
+		startTLSResponse: "454 TLS not available\r\n",
+	}, nil
+}
+
+func (s *smtpRecordingServer) Address() string {
+	return s.listener.Addr().String()
+}
+
+func (s *smtpRecordingServer) Close() error {
+	return s.listener.Close()
+}
+
+func (s *smtpRecordingServer) StartTLSCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.startTLSCount
+}
+
+func (s *smtpRecordingServer) RecordedDataBodies() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.recordedDataBodies...)
+}
+
+func (s *smtpRecordingServer) Serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *smtpRecordingServer) handleConnection(conn net.Conn) {
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	writer := bufio.NewWriter(conn)
+	reader := bufio.NewReader(conn)
+
+	_, _ = writer.WriteString("220 mock.server ESMTP\r\n")
+	_ = writer.Flush()
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+
+		switch {
+		case strings.HasPrefix(line, "HELO") || strings.HasPrefix(line, "EHLO"):
+			_, _ = writer.WriteString("250-mock.server\r\n")
+			if s.advertiseSTARTTLS {
+				_, _ = writer.WriteString("250-STARTTLS\r\n")
+			}
+			_, _ = writer.WriteString("250 OK\r\n")
+		case strings.HasPrefix(line, "STARTTLS"):
+			s.mu.Lock()
+			s.startTLSCount++
+			s.mu.Unlock()
+			_, _ = writer.WriteString(s.startTLSResponse)
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			_, _ = writer.WriteString(s.mailFromResponse)
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, _ = writer.WriteString(s.rcptToResponse)
+		case strings.HasPrefix(line, "DATA"):
+			_, _ = writer.WriteString("354 Start mail input\r\n")
+			_ = writer.Flush()
+
+			var payload bytes.Buffer
+			for {
+				dataLine, err := reader.ReadString('\n')
+				if err != nil {
+					return
+				}
+				if strings.TrimSpace(dataLine) == "." {
+					s.mu.Lock()
+					s.recordedDataBodies = append(s.recordedDataBodies, payload.String())
+					s.mu.Unlock()
+					_, _ = writer.WriteString("250 OK\r\n")
+					break
+				}
+				payload.WriteString(dataLine)
+			}
+		case strings.HasPrefix(line, "QUIT"):
+			_, _ = writer.WriteString("221 Bye\r\n")
+			_ = writer.Flush()
+			return
+		default:
+			_, _ = writer.WriteString("500 Unknown command\r\n")
+		}
+		_ = writer.Flush()
+	}
+}
+
+func (m *Client) sendWithNoAuth(
+	from string,
+	to []string,
+	subject, body string,
+	attachments []string,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
+	defer cancel()
+	return m.send(ctx, from, to, subject, body, attachments, false)
+}
+
+func (m *Client) sendWithAuth(
+	from string,
+	to []string,
+	subject, body string,
+	attachments []string,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), mailTimeout)
+	defer cancel()
+	return m.send(ctx, from, to, subject, body, attachments, true)
 }
 
 // mockSMTPServer creates a mock SMTP server for testing

--- a/internal/cmn/sock/client.go
+++ b/internal/cmn/sock/client.go
@@ -5,6 +5,7 @@ package sock
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,8 +14,7 @@ import (
 )
 
 var (
-	ErrTimeout           = fmt.Errorf("unix socket timeout")
-	ErrConnectionRefused = fmt.Errorf("unix socket connection failed")
+	ErrTimeout = errors.New("unix socket timeout")
 )
 
 // Client is a unix socket client that can send requests
@@ -31,36 +31,40 @@ const (
 	defaultTimeout = time.Millisecond * 3000
 )
 
+func wrapTimeout(op string, err error) error {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("%s: %w", op, ErrTimeout)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
 // Request sends a request to the frontend and returns the response.
 func (cl *Client) Request(method, url string) (string, error) {
 	conn, err := net.DialTimeout("unix", cl.addr, defaultTimeout)
 	if err != nil {
-		return "", fmt.Errorf("dial failed: %w", err)
+		return "", fmt.Errorf("dial unix socket: %w", err)
 	}
-
 	defer func() {
 		_ = conn.Close()
 	}()
 
-	if err := conn.SetDeadline((time.Now().Add(defaultTimeout))); err != nil {
-		return "", fmt.Errorf("set deadline failed: %w", err)
+	if err := conn.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
+		return "", fmt.Errorf("set connection deadline: %w", err)
 	}
 
 	request, err := http.NewRequest(method, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("create request failed: %w", err)
+		return "", fmt.Errorf("build request: %w", err)
 	}
 
 	if err := request.Write(conn); err != nil {
-		return "", fmt.Errorf("write request failed: %w", err)
+		return "", wrapTimeout("write request", err)
 	}
 
 	response, err := http.ReadResponse(bufio.NewReader(conn), request)
 	if err != nil {
-		if err, ok := err.(net.Error); ok && err.Timeout() {
-			return "", fmt.Errorf("request timeout: %w", ErrTimeout)
-		}
-		return "", fmt.Errorf("read response failed: %w", err)
+		return "", wrapTimeout("read response", err)
 	}
 	defer func() {
 		_ = response.Body.Close()
@@ -68,7 +72,7 @@ func (cl *Client) Request(method, url string) (string, error) {
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", fmt.Errorf("read body failed: %w", err)
+		return "", wrapTimeout("read response body", err)
 	}
 
 	return string(body), nil

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -29,6 +30,7 @@ type Server struct {
 	handlerFunc HTTPHandlerFunc
 	listener    net.Listener
 	quit        atomic.Bool
+	connWG      sync.WaitGroup
 	mu          sync.Mutex
 }
 
@@ -83,13 +85,20 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 			}
 			return err
 		}
+		srv.connWG.Add(1)
 		go srv.serveConn(ctx, conn)
 	}
 }
 
 func (srv *Server) serveConn(ctx context.Context, conn net.Conn) {
 	defer func() {
+		srv.connWG.Done()
 		_ = conn.Close()
+	}()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error(ctx, "Socket handler panicked", slog.Any("panic", recovered))
+		}
 	}()
 
 	request, err := http.ReadRequest(bufio.NewReader(conn))
@@ -124,8 +133,11 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 			logger.Error(ctx, "Failed to close listener",
 				tag.Error(err))
 		}
-		return err
+		if err != nil {
+			return err
+		}
 	}
+	srv.connWG.Wait()
 	return nil
 }
 

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -154,7 +154,6 @@ type httpResponseWriter struct {
 	header     http.Header
 	statusCode int
 	body       bytes.Buffer
-	wroteBody  bool
 }
 
 func newHTTPResponseWriter(conn net.Conn) *httpResponseWriter {
@@ -166,15 +165,10 @@ func newHTTPResponseWriter(conn net.Conn) *httpResponseWriter {
 }
 
 func (w *httpResponseWriter) Write(data []byte) (int, error) {
-	w.wroteBody = true
 	return w.body.Write(data)
 }
 
 func (w *httpResponseWriter) flush() error {
-	if !w.wroteBody {
-		return nil
-	}
-
 	response := http.Response{
 		StatusCode:    w.statusCode,
 		ProtoMajor:    1,

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -5,13 +5,13 @@ package sock
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -83,16 +83,28 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 			}
 			return err
 		}
-		go func() {
-			request, err := http.ReadRequest(bufio.NewReader(conn))
-			if err != nil {
-				logger.Error(ctx, "Failed to read request",
-					tag.Error(err))
-			} else {
-				srv.handlerFunc(newHTTPResponseWriter(&conn), request)
-			}
-			_ = conn.Close()
-		}()
+		go srv.serveConn(ctx, conn)
+	}
+}
+
+func (srv *Server) serveConn(ctx context.Context, conn net.Conn) {
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	request, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		logger.Error(ctx, "Failed to read request", tag.Error(err))
+		return
+	}
+	defer func() {
+		_ = request.Body.Close()
+	}()
+
+	writer := newHTTPResponseWriter(conn)
+	srv.handlerFunc(writer, request)
+	if err := writer.flush(); err != nil {
+		logger.Error(ctx, "Failed to write response", tag.Error(err))
 	}
 }
 
@@ -138,12 +150,14 @@ func (srv *Server) clearListener(listener net.Listener) {
 var _ http.ResponseWriter = (*httpResponseWriter)(nil)
 
 type httpResponseWriter struct {
-	conn       *net.Conn
+	conn       net.Conn
 	header     http.Header
 	statusCode int
+	body       bytes.Buffer
+	wroteBody  bool
 }
 
-func newHTTPResponseWriter(conn *net.Conn) http.ResponseWriter {
+func newHTTPResponseWriter(conn net.Conn) *httpResponseWriter {
 	return &httpResponseWriter{
 		conn:       conn,
 		header:     make(http.Header),
@@ -152,18 +166,24 @@ func newHTTPResponseWriter(conn *net.Conn) http.ResponseWriter {
 }
 
 func (w *httpResponseWriter) Write(data []byte) (int, error) {
+	w.wroteBody = true
+	return w.body.Write(data)
+}
+
+func (w *httpResponseWriter) flush() error {
+	if !w.wroteBody {
+		return nil
+	}
+
 	response := http.Response{
 		StatusCode:    w.statusCode,
 		ProtoMajor:    1,
 		ProtoMinor:    0,
-		Body:          io.NopCloser(strings.NewReader(string(data))),
-		Header:        w.header,
-		ContentLength: int64(len(data)),
+		Body:          io.NopCloser(bytes.NewReader(w.body.Bytes())),
+		Header:        w.header.Clone(),
+		ContentLength: int64(w.body.Len()),
 	}
-	if err := response.Write(*w.conn); err != nil {
-		return 0, err
-	}
-	return len(data), nil
+	return response.Write(w.conn)
 }
 
 func (w *httpResponseWriter) Header() http.Header {

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sock
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeConnRecoversFromHandlerPanic(t *testing.T) {
+	t.Parallel()
+
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		_ = clientConn.Close()
+	}()
+
+	srv, err := NewServer(
+		"ignored",
+		func(http.ResponseWriter, *http.Request) {
+			panic("boom")
+		},
+	)
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	go func() {
+		_ = request.Write(clientConn)
+		_ = clientConn.Close()
+	}()
+
+	srv.connWG.Add(1)
+	require.NotPanics(t, func() {
+		srv.serveConn(context.Background(), serverConn)
+	})
+}

--- a/internal/cmn/sock/server_test.go
+++ b/internal/cmn/sock/server_test.go
@@ -4,8 +4,11 @@
 package sock_test
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -68,7 +71,7 @@ func TestStartAndShutdownServer(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-func TestNoResponse(t *testing.T) {
+func TestHeaderOnlyResponse(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_error_response")
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
@@ -84,7 +87,6 @@ func TestNoResponse(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	client := sock.NewClient(tmpFile.Name())
 	listen := make(chan error, 1)
 
 	go func() {
@@ -95,11 +97,30 @@ func TestNoResponse(t *testing.T) {
 	// Wait for the server to signal it is ready.
 	require.NoError(t, <-listen)
 
-	_, err = client.Request(http.MethodGet, "/")
-	require.Error(t, err)
+	conn, err := net.DialTimeout("unix", tmpFile.Name(), 3*time.Second)
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(3*time.Second)))
+
+	request, err := http.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, err)
+	require.NoError(t, request.Write(conn))
+
+	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	require.NoError(t, err)
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, response.StatusCode)
+	require.Empty(t, body)
 }
 
-func TestErrorResponse(t *testing.T) {
+func TestEmptyResponse(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_error_response")
 	require.NoError(t, err)
 	require.NoError(t, tmpFile.Close())
@@ -124,8 +145,9 @@ func TestErrorResponse(t *testing.T) {
 	// Wait for the server to signal it is ready.
 	require.NoError(t, <-listen)
 
-	_, err = client.Request(http.MethodGet, "/")
-	require.Error(t, err)
+	body, err := client.Request(http.MethodGet, "/")
+	require.NoError(t, err)
+	require.Empty(t, body)
 }
 
 func TestShutdownWhileServerStarts(t *testing.T) {

--- a/internal/cmn/sock/server_test.go
+++ b/internal/cmn/sock/server_test.go
@@ -163,3 +163,39 @@ func TestShutdownWhileServerStarts(t *testing.T) {
 		t.Fatal("timed out waiting for socket server to stop")
 	}
 }
+
+func TestMultipleWritesProduceSingleResponseBody(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test_server_multiple_writes")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	unixServer, err := sock.NewServer(
+		tmpFile.Name(),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("O"))
+			_, _ = w.Write([]byte("K"))
+		},
+	)
+	require.NoError(t, err)
+
+	client := sock.NewClient(tmpFile.Name())
+	listen := make(chan error, 1)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- unixServer.Serve(context.Background(), listen)
+	}()
+
+	require.NoError(t, <-listen)
+
+	body, err := client.Request(http.MethodGet, "/")
+	require.NoError(t, err)
+	require.Equal(t, "OK", body)
+
+	require.NoError(t, unixServer.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
+}

--- a/internal/cmn/sock/server_test.go
+++ b/internal/cmn/sock/server_test.go
@@ -49,10 +49,10 @@ func TestStartAndShutdownServer(t *testing.T) {
 
 	client := sock.NewClient(tmpFile.Name())
 	listen := make(chan error, 1)
+	done := make(chan error, 1)
 
 	go func() {
-		err := unixServer.Serve(context.Background(), listen)
-		require.True(t, errors.Is(err, sock.ErrServerRequestedShutdown))
+		done <- unixServer.Serve(context.Background(), listen)
 	}()
 
 	// Wait for the server to signal it is ready.
@@ -69,6 +69,7 @@ func TestStartAndShutdownServer(t *testing.T) {
 		_, err := client.Request(http.MethodPost, "/")
 		return err != nil
 	}, 5*time.Second, 10*time.Millisecond)
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
 func TestHeaderOnlyResponse(t *testing.T) {
@@ -88,10 +89,10 @@ func TestHeaderOnlyResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	listen := make(chan error, 1)
+	done := make(chan error, 1)
 
 	go func() {
-		err = unixServer.Serve(context.Background(), listen)
-		_ = unixServer.Shutdown(context.Background())
+		done <- unixServer.Serve(context.Background(), listen)
 	}()
 
 	// Wait for the server to signal it is ready.
@@ -118,6 +119,8 @@ func TestHeaderOnlyResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusForbidden, response.StatusCode)
 	require.Empty(t, body)
+	require.NoError(t, unixServer.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
 func TestEmptyResponse(t *testing.T) {
@@ -136,10 +139,10 @@ func TestEmptyResponse(t *testing.T) {
 
 	client := sock.NewClient(tmpFile.Name())
 	listen := make(chan error, 1)
+	done := make(chan error, 1)
 
 	go func() {
-		err = unixServer.Serve(context.Background(), listen)
-		_ = unixServer.Shutdown(context.Background())
+		done <- unixServer.Serve(context.Background(), listen)
 	}()
 
 	// Wait for the server to signal it is ready.
@@ -148,6 +151,8 @@ func TestEmptyResponse(t *testing.T) {
 	body, err := client.Request(http.MethodGet, "/")
 	require.NoError(t, err)
 	require.Empty(t, body)
+	require.NoError(t, unixServer.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
 func TestShutdownWhileServerStarts(t *testing.T) {
@@ -219,5 +224,62 @@ func TestMultipleWritesProduceSingleResponseBody(t *testing.T) {
 	require.Equal(t, "OK", body)
 
 	require.NoError(t, unixServer.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
+}
+
+func TestShutdownWaitsForActiveHandlers(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test_server_shutdown_waits_for_handlers")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+
+	unixServer, err := sock.NewServer(
+		tmpFile.Name(),
+		func(w http.ResponseWriter, _ *http.Request) {
+			close(handlerStarted)
+			<-releaseHandler
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		},
+	)
+	require.NoError(t, err)
+
+	client := sock.NewClient(tmpFile.Name())
+	listen := make(chan error, 1)
+	done := make(chan error, 1)
+	requestDone := make(chan error, 1)
+	shutdownDone := make(chan error, 1)
+
+	go func() {
+		done <- unixServer.Serve(context.Background(), listen)
+	}()
+
+	require.NoError(t, <-listen)
+
+	go func() {
+		_, err := client.Request(http.MethodGet, "/")
+		requestDone <- err
+	}()
+
+	<-handlerStarted
+
+	go func() {
+		shutdownDone <- unixServer.Shutdown(context.Background())
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown returned before the active handler finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+	require.NoError(t, <-requestDone)
+	require.NoError(t, <-shutdownDone)
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }

--- a/internal/core/condition.go
+++ b/internal/core/condition.go
@@ -14,7 +14,7 @@ import (
 // The condition can be a command substitution or an environment variable.
 // The expected value must be a string without any substitutions.
 type Condition struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	Condition    string // Condition to evaluate
 	Expected     string // Expected value
@@ -22,38 +22,27 @@ type Condition struct {
 	errorMessage string // Error message if the condition is not met
 }
 
-func (c *Condition) MarshalJSON() ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return json.Marshal(struct {
-		Condition    string `json:"condition,omitempty"`
-		Expected     string `json:"expected,omitempty"`
-		Negate       bool   `json:"negate,omitempty"`
-		ErrorMessage string `json:"error,omitempty"`
-	}{
-		Condition:    c.Condition,
-		Expected:     c.Expected,
-		Negate:       c.Negate,
-		ErrorMessage: c.errorMessage,
-	})
+type conditionJSON struct {
+	Condition    string `json:"condition,omitempty"`
+	Expected     string `json:"expected,omitempty"`
+	Negate       bool   `json:"negate,omitempty"`
+	ErrorMessage string `json:"error,omitempty"`
 }
 
+func (c *Condition) MarshalJSON() ([]byte, error) { return json.Marshal(c.snapshot()) }
+
 func (c *Condition) UnmarshalJSON(data []byte) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	var tmp struct {
-		Condition    string `json:"condition,omitempty"`
-		Expected     string `json:"expected,omitempty"`
-		Negate       bool   `json:"negate,omitempty"`
-		ErrorMessage string `json:"error,omitempty"`
-	}
-	if err := json.Unmarshal(data, &tmp); err != nil {
+	var decoded conditionJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
 	}
-	c.Condition = tmp.Condition
-	c.Expected = tmp.Expected
-	c.Negate = tmp.Negate
-	c.errorMessage = tmp.ErrorMessage
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Condition = decoded.Condition
+	c.Expected = decoded.Expected
+	c.Negate = decoded.Negate
+	c.errorMessage = decoded.ErrorMessage
 	return nil
 }
 
@@ -71,7 +60,18 @@ func (c *Condition) SetErrorMessage(msg string) {
 }
 
 func (c *Condition) GetErrorMessage() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.errorMessage
+}
+
+func (c *Condition) snapshot() conditionJSON {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return conditionJSON{
+		Condition:    c.Condition,
+		Expected:     c.Expected,
+		Negate:       c.Negate,
+		ErrorMessage: c.errorMessage,
+	}
 }

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -24,13 +24,13 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-// Execution type constants
+// Supported DAG execution types.
 const (
-	// TypeGraph is the execution type using dependency-based parallel execution
+	// TypeGraph runs dependency-aware steps in parallel where possible.
 	TypeGraph = "graph"
-	// TypeChain executes steps sequentially in the order they are defined
+	// TypeChain runs steps strictly in declaration order.
 	TypeChain = "chain"
-	// TypeAgent is reserved for future agent-based execution
+	// TypeAgent is reserved for agent-oriented execution flows.
 	TypeAgent = "agent"
 )
 
@@ -51,14 +51,13 @@ const (
 // EffectiveLogOutput returns the effective log output mode for a step.
 // Priority: step-level > DAG-level > default (LogOutputSeparate).
 func EffectiveLogOutput(dag *DAG, step *Step) LogOutputMode {
-	switch {
-	case step != nil && step.LogOutput != "":
+	if step != nil && step.LogOutput != "" {
 		return step.LogOutput
-	case dag != nil && dag.LogOutput != "":
-		return dag.LogOutput
-	default:
-		return LogOutputSeparate
 	}
+	if dag != nil && dag.LogOutput != "" {
+		return dag.LogOutput
+	}
+	return LogOutputSeparate
 }
 
 // DAG contains all information about a DAG.

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -628,7 +628,10 @@ func validateUniqueNames(dags []*core.DAG) error {
 		return nil
 	}
 
-	names := make(map[string]struct{}, len(dags)-1)
+	names := make(map[string]struct{}, len(dags))
+	if dags[0].Name != "" {
+		names[dags[0].Name] = struct{}{}
+	}
 	for i, dag := range dags[1:] {
 		index := i + 1
 		if dag.Name == "" {

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -221,54 +221,17 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*core.DAG, 
 func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.DAG, error) {
 	baseDef, baseRaw, err := loadBaseDefinition(opts)
 	if err != nil {
-		if opts.Has(BuildFlagAllowBuildErrors) {
-			return &core.DAG{
-				Name:        opts.Name,
-				BuildErrors: []error{err},
-			}, nil
-		}
-		return nil, core.ErrorList{err}
+		return loadYAMLFailure(opts, err)
 	}
 
-	buildCtx := BuildContext{ctx: ctx, opts: opts}
-	dags, err := loadDAGsFromData(buildCtx, data, "", baseDef)
+	dags, err := loadDAGsFromData(BuildContext{ctx: ctx, opts: opts}, data, "", baseDef)
 	if err != nil {
-		if opts.Has(BuildFlagAllowBuildErrors) {
-			return &core.DAG{
-				Name:        opts.Name,
-				BuildErrors: []error{err},
-			}, nil
-		}
-		return nil, core.ErrorList{err}
-	}
-	if len(dags) == 0 {
-		err := fmt.Errorf("no DAGs found in YAML data")
-		if opts.Has(BuildFlagAllowBuildErrors) {
-			return &core.DAG{
-				Name:        opts.Name,
-				BuildErrors: []error{err},
-			}, nil
-		}
-		return nil, core.ErrorList{err}
+		return loadYAMLFailure(opts, err)
 	}
 
-	mainDAG := dags[0]
-	if len(dags) > 1 {
-		mainDAG.LocalDAGs = make(map[string]*core.DAG, len(dags)-1)
-		for i := 1; i < len(dags); i++ {
-			subDAG := dags[i]
-			if subDAG.Name == "" {
-				err := fmt.Errorf("child core.DAG at index %d must have a name", i)
-				if opts.Has(BuildFlagAllowBuildErrors) {
-					return &core.DAG{
-						Name:        opts.Name,
-						BuildErrors: []error{err},
-					}, nil
-				}
-				return nil, core.ErrorList{err}
-			}
-			mainDAG.LocalDAGs[subDAG.Name] = subDAG
-		}
+	mainDAG, err := assembleLoadedDAGs(dags, fmt.Errorf("no DAGs found in YAML data"))
+	if err != nil {
+		return loadYAMLFailure(opts, err)
 	}
 
 	mainDAG.YamlData = data
@@ -277,6 +240,31 @@ func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.D
 	}
 
 	return mainDAG, nil
+}
+
+func loadYAMLFailure(opts BuildOpts, err error) (*core.DAG, error) {
+	if dag := buildLoadErrorDAG(opts, "", err); dag != nil {
+		return dag, nil
+	}
+	return nil, core.ErrorList{err}
+}
+
+func buildLoadErrorDAG(opts BuildOpts, filePath string, err error) *core.DAG {
+	if !opts.Has(BuildFlagAllowBuildErrors) {
+		return nil
+	}
+
+	name := opts.Name
+	if name == "" {
+		name = defaultName(filePath)
+	}
+
+	return &core.DAG{
+		Name:        name,
+		Location:    filePath,
+		SourceFile:  filePath,
+		BuildErrors: []error{err},
+	}
 }
 
 // LoadBaseConfig loads the global configuration from the given file.
@@ -315,171 +303,141 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 
 	ctx = ctx.WithFile(filePath)
 
-	// errorDAG returns a minimal DAG with the error recorded when
-	// BuildFlagAllowBuildErrors is set, or the raw error otherwise.
-	errorDAG := func(err error) (*core.DAG, error) {
-		if ctx.opts.Has(BuildFlagAllowBuildErrors) {
-			name := ctx.opts.Name
-			if name == "" {
-				name = defaultName(filePath)
-			}
-			return &core.DAG{
-				Name:        name,
-				Location:    filePath,
-				SourceFile:  filePath,
-				BuildErrors: []error{err},
-			}, nil
-		}
-		return nil, err
+	baseDef, baseRaw, err := loadBaseDefinition(ctx.opts)
+	if err != nil {
+		return loadDAGFailure(ctx, filePath, err)
 	}
 
-	// Load base manifest if specified.
-	// Priority: embedded content (BaseConfigContent) > file path (Base).
-	var baseDef *dag
-	var baseRaw []byte
-	if !ctx.opts.Has(BuildFlagOnlyMetadata) {
-		if len(ctx.opts.BaseConfigContent) > 0 {
-			// Use embedded base config content (distributed mode / sub-DAG propagation)
-			baseRaw = ctx.opts.BaseConfigContent
-			raw, err := unmarshalData(baseRaw)
-			if err != nil {
-				return errorDAG(fmt.Errorf("failed to unmarshal embedded base config: %w", err))
-			}
-			baseDef, err = decode(raw)
-			if err != nil {
-				return errorDAG(fmt.Errorf("failed to decode embedded base config: %w", err))
-			}
-		} else if ctx.opts.Base != "" {
-			baseRaw, err = os.ReadFile(ctx.opts.Base) //nolint:gosec
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return errorDAG(fmt.Errorf("failed to read base config: %w", err))
-				}
-				// File doesn't exist — skip base config gracefully
-			} else {
-				raw, err := unmarshalData(baseRaw)
-				if err != nil {
-					return errorDAG(fmt.Errorf("failed to unmarshal base config: %w", err))
-				}
-				baseDef, err = decode(raw)
-				if err != nil {
-					return errorDAG(fmt.Errorf("failed to decode base config: %w", err))
-				}
-			}
-		}
-	}
-
-	// Load all DAGs from the file
 	dags, err := loadDAGsFromFile(ctx, filePath, baseDef)
 	if err != nil {
-		return errorDAG(err)
+		return loadDAGFailure(ctx, filePath, err)
 	}
 
-	if len(dags) == 0 {
-		return errorDAG(fmt.Errorf("no DAGs found in file %q", filePath))
+	mainDAG, err := assembleLoadedDAGs(dags, fmt.Errorf("no DAGs found in file %q", filePath))
+	if err != nil {
+		return loadDAGFailure(ctx, filePath, err)
 	}
 
-	// Get the main core.DAG (first one)
-	mainDAG := dags[0]
-
-	// If there are sub DAGs, add them to the main core.DAG
-	if len(dags) > 1 {
-		mainDAG.LocalDAGs = make(map[string]*core.DAG)
-		for i := 1; i < len(dags); i++ {
-			subDAG := dags[i]
-			if subDAG.Name == "" {
-				return errorDAG(fmt.Errorf("child core.DAG at index %d must have a name", i))
-			}
-			mainDAG.LocalDAGs[subDAG.Name] = subDAG
-		}
-	}
-
-	// Store base config data for propagation through distributed execution
 	if len(baseRaw) > 0 {
 		mainDAG.BaseConfigData = baseRaw
 	}
 
 	core.InitializeDefaults(mainDAG)
-
-	// Apply working directory fallback if not set by YAML, base config, or DefaultWorkingDir.
-	if mainDAG.WorkingDir == "" {
-		if filePath != "" {
-			mainDAG.WorkingDir = filepath.Dir(filePath)
-		} else {
-			wd, err := getDefaultWorkingDir()
-			if err != nil {
-				return nil, fmt.Errorf("failed to determine working directory: %w", err)
-			}
-			mainDAG.WorkingDir = wd
-		}
-	} else {
-		mainDAG.WorkingDirExplicit = true
+	if err := applyWorkingDirFallback(mainDAG, filePath); err != nil {
+		return nil, err
 	}
 
 	return mainDAG, nil
 }
 
-// loadDAGsFromFile loads all DAGs from a multi-document YAML file
-func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag) ([]*core.DAG, error) {
-	// Open the file
-	f, err := os.Open(filePath) //nolint:gosec
-	if err != nil {
-		return nil, fmt.Errorf("failed to open file %q: %w", filePath, err)
+func loadDAGFailure(ctx BuildContext, filePath string, err error) (*core.DAG, error) {
+	if dag := buildLoadErrorDAG(ctx.opts, filePath, err); dag != nil {
+		return dag, nil
 	}
-	defer func() { _ = f.Close() }()
-
-	// Read data from the file
-	dat, err := io.ReadAll(f)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %q", filePath)
-	}
-
-	return loadDAGsFromData(ctx, dat, filePath, baseDef)
+	return nil, err
 }
 
-func loadDAGsFromData(ctx BuildContext, dat []byte, filePath string, baseDef *dag) ([]*core.DAG, error) {
-	var dags []*core.DAG
-	decoder := yaml.NewDecoder(bytes.NewReader(dat))
+func assembleLoadedDAGs(dags []*core.DAG, emptyErr error) (*core.DAG, error) {
+	if len(dags) == 0 {
+		return nil, emptyErr
+	}
 
-	// Read all documents from the file
-	docIndex := 0
-	for {
+	mainDAG := dags[0]
+	if err := attachLocalDAGs(mainDAG, dags[1:]); err != nil {
+		return nil, err
+	}
+
+	return mainDAG, nil
+}
+
+func attachLocalDAGs(mainDAG *core.DAG, localDAGs []*core.DAG) error {
+	if len(localDAGs) == 0 {
+		return nil
+	}
+
+	mainDAG.LocalDAGs = make(map[string]*core.DAG, len(localDAGs))
+	for i, dag := range localDAGs {
+		index := i + 1
+		if dag.Name == "" {
+			return fmt.Errorf("child core.DAG at index %d must have a name", index)
+		}
+		mainDAG.LocalDAGs[dag.Name] = dag
+	}
+	return nil
+}
+
+func applyWorkingDirFallback(dag *core.DAG, filePath string) error {
+	if dag.WorkingDir != "" {
+		dag.WorkingDirExplicit = true
+		return nil
+	}
+
+	if filePath != "" {
+		dag.WorkingDir = filepath.Dir(filePath)
+		return nil
+	}
+
+	wd, err := getDefaultWorkingDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine working directory: %w", err)
+	}
+	dag.WorkingDir = wd
+	return nil
+}
+
+// loadDAGsFromFile loads all DAGs from a multi-document YAML file.
+func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag) ([]*core.DAG, error) {
+	data, err := os.ReadFile(filePath) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
+	}
+	return loadDAGsFromData(ctx, data, filePath, baseDef)
+}
+
+type dagDocument struct {
+	index int
+	data  map[string]any
+}
+
+func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *dag) ([]*core.DAG, error) {
+	docs, err := decodeDocuments(data)
+	if err != nil {
+		return nil, err
+	}
+
+	dags := make([]*core.DAG, 0, len(docs))
+	for _, doc := range docs {
+		dag, err := processDAGDocument(buildDocumentContext(ctx, doc.index), doc.data, baseDef, filePath, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process document %d: %w", doc.index, err)
+		}
+		dags = append(dags, dag)
+	}
+
+	if err := validateUniqueNames(dags); err != nil {
+		return nil, err
+	}
+	return dags, nil
+}
+
+func decodeDocuments(data []byte) ([]dagDocument, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	docs := make([]dagDocument, 0, 1)
+
+	for index := 0; ; index++ {
 		var doc map[string]any
 		err := decoder.Decode(&doc)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				break
+				return docs, nil
 			}
-			// Note: The YAML decoder has limitations with empty documents
-			// and may return errors for them. We skip and continue.
-			return nil, fmt.Errorf("failed to decode document %d: %w", docIndex, err)
+			return nil, fmt.Errorf("failed to decode document %d: %w", index, err)
 		}
-
-		// Skip empty documents
 		if len(doc) == 0 {
-			docIndex++
 			continue
 		}
-
-		// Update the context with the current document index
-		ctx.index = docIndex
-
-		// Process the document
-		dag, err := processDAGDocument(ctx, doc, baseDef, filePath, dat, docIndex)
-		if err != nil {
-			return nil, fmt.Errorf("failed to process document %d: %w", docIndex, err)
-		}
-
-		dags = append(dags, dag)
-		docIndex++
+		docs = append(docs, dagDocument{index: index, data: doc})
 	}
-
-	// Validate unique names in multi-DAG files
-	if err := validateUniqueNames(dags); err != nil {
-		return nil, err
-	}
-
-	return dags, nil
 }
 
 func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
@@ -487,40 +445,46 @@ func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
 		return nil, nil, nil
 	}
 
-	if len(opts.BaseConfigContent) > 0 {
-		raw, err := unmarshalData(opts.BaseConfigContent)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to unmarshal embedded base config: %w", err)
-		}
-		baseDef, err := decode(raw)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to decode embedded base config: %w", err)
-		}
-		return baseDef, opts.BaseConfigContent, nil
+	baseRaw, description, err := readBaseDefinitionData(opts)
+	if err != nil || len(baseRaw) == 0 {
+		return nil, nil, err
 	}
 
+	baseDef, err := decodeDefinitionData(baseRaw, description)
+	if err != nil {
+		return nil, nil, err
+	}
+	return baseDef, baseRaw, nil
+}
+
+func readBaseDefinitionData(opts BuildOpts) ([]byte, string, error) {
+	if len(opts.BaseConfigContent) > 0 {
+		return opts.BaseConfigContent, "embedded base config", nil
+	}
 	if opts.Base == "" {
-		return nil, nil, nil
+		return nil, "", nil
 	}
 
 	baseRaw, err := os.ReadFile(opts.Base) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, nil
+			return nil, "", nil
 		}
-		return nil, nil, fmt.Errorf("failed to read base config: %w", err)
+		return nil, "", fmt.Errorf("failed to read base config: %w", err)
 	}
+	return baseRaw, "base config", nil
+}
 
-	raw, err := unmarshalData(baseRaw)
+func decodeDefinitionData(data []byte, description string) (*dag, error) {
+	raw, err := unmarshalData(data)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal base config: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal %s: %w", description, err)
 	}
-	baseDef, err := decode(raw)
+	def, err := decode(raw)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to decode base config: %w", err)
+		return nil, fmt.Errorf("failed to decode %s: %w", description, err)
 	}
-
-	return baseDef, baseRaw, nil
+	return def, nil
 }
 
 // processDAGDocument processes a single DAG document from the YAML file.
@@ -530,91 +494,104 @@ func processDAGDocument(
 	baseDef *dag,
 	filePath string,
 	fullData []byte,
-	docIndex int,
 ) (*core.DAG, error) {
-	// Decode the document into manifest
 	spec, err := decode(doc)
 	if err != nil {
 		return nil, err
 	}
 
-	docCtx := ctx
-	if docIndex > 0 {
-		docCtx.opts.Parameters = ""
-		docCtx.opts.ParametersList = nil
-		docCtx.opts.Flags &^= BuildFlagValidateRuntimeParams
-	}
-
-	customStepTypes, err := buildCustomStepTypeRegistry(stepTypesOf(baseDef), stepTypesOf(spec))
+	docCtx, dest, err := prepareDocumentContext(ctx, baseDef, spec)
 	if err != nil {
 		return nil, err
-	}
-	docCtx = docCtx.WithCustomStepTypes(customStepTypes)
-
-	// Build a fresh base core.DAG from base manifest if provided
-	var dest *core.DAG
-	if baseDef != nil {
-		dest, err = buildBaseDAG(docCtx, baseDef)
-		if err != nil {
-			return nil, err
-		}
-		docCtx.baseDefaults, err = decodeDefaults(baseDef.Defaults)
-		if err != nil {
-			return nil, err
-		}
-		docCtx.baseDAG = dest
-	} else {
-		dest = new(core.DAG)
 	}
 
 	if shouldInheritType(doc, baseDef, spec) {
 		spec.Type = baseDef.Type
 	}
 
-	// Build the core.DAG from the current document
 	dag, err := spec.build(docCtx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Merge the current core.DAG into the base core.DAG
 	if err := merge(dest, dag); err != nil {
 		return nil, err
 	}
 
-	// Preserve runtime location separately from source provenance.
 	dest.Location = filePath
 	dest.SourceFile = filePath
+	dest.YamlData, err = documentYAML(ctx.index, doc, fullData)
+	if err != nil {
+		return nil, err
+	}
+	return dest, nil
+}
 
-	if docIndex == 0 {
-		// If this is the first document, set the entire core.DAG
-		dest.YamlData = fullData
-	} else {
-		// Marshal the document back to YAML to preserve original data
-		yamlData, err := yaml.Marshal(doc)
-		if err != nil {
-			return nil, err
-		}
-		dest.YamlData = yamlData
+func buildDocumentContext(ctx BuildContext, index int) BuildContext {
+	ctx.index = index
+	if index == 0 {
+		return ctx
 	}
 
-	return dest, nil
+	opts := ctx.opts
+	opts.Parameters = ""
+	opts.ParametersList = nil
+	opts.Flags &^= BuildFlagValidateRuntimeParams
+	return ctx.WithOpts(opts)
+}
+
+func prepareDocumentContext(ctx BuildContext, baseDef, spec *dag) (BuildContext, *core.DAG, error) {
+	customStepTypes, err := buildCustomStepTypeRegistry(stepTypesOf(baseDef), stepTypesOf(spec))
+	if err != nil {
+		return ctx, nil, err
+	}
+	ctx = ctx.WithCustomStepTypes(customStepTypes)
+
+	if baseDef == nil {
+		return ctx, new(core.DAG), nil
+	}
+
+	baseDAG, baseDefaults, err := buildDocumentBase(ctx, baseDef)
+	if err != nil {
+		return ctx, nil, err
+	}
+	ctx.baseDAG = baseDAG
+	ctx.baseDefaults = baseDefaults
+	return ctx, baseDAG, nil
+}
+
+func buildDocumentBase(ctx BuildContext, baseDef *dag) (*core.DAG, *defaults, error) {
+	baseDAG, err := buildBaseDAG(ctx, baseDef)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseDefaults, err := decodeDefaults(baseDef.Defaults)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return baseDAG, baseDefaults, nil
+}
+
+func documentYAML(index int, doc map[string]any, fullData []byte) ([]byte, error) {
+	if index == 0 {
+		return fullData, nil
+	}
+	return yaml.Marshal(doc)
 }
 
 // buildBaseDAG builds a new base DAG from the base definition.
 func buildBaseDAG(ctx BuildContext, baseDef *dag) (*core.DAG, error) {
-	buildCtx := ctx
-	// Don't parse parameters for the base core.DAG
-	buildCtx.opts.Parameters = ""
-	buildCtx.opts.ParametersList = nil
+	buildOpts := ctx.opts
+	buildOpts.Parameters = ""
+	buildOpts.ParametersList = nil
+
 	customStepTypes, err := buildCustomStepTypeRegistry(stepTypesOf(baseDef), nil)
 	if err != nil {
 		return nil, err
 	}
-	buildCtx = buildCtx.WithCustomStepTypes(customStepTypes)
 
-	// Build the base core.DAG
-	baseDAG, err := baseDef.build(buildCtx)
+	baseDAG, err := baseDef.build(ctx.WithOpts(buildOpts).WithCustomStepTypes(customStepTypes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build base core.DAG: %w", err)
 	}
@@ -647,21 +624,20 @@ func shouldInheritType(doc map[string]any, baseDef, spec *dag) bool {
 
 // validateUniqueNames ensures all DAGs in a multi-DAG file have unique names.
 func validateUniqueNames(dags []*core.DAG) error {
-	if len(dags) > 1 {
-		names := make(map[string]bool)
-		for i, dag := range dags {
-			// Skip validation for the first core.DAG as it's the main core.DAG
-			if i == 0 {
-				continue
-			}
-			if dag.Name == "" {
-				return fmt.Errorf("DAG at index %d must have a name in multi-DAG file", i)
-			}
-			if names[dag.Name] {
-				return fmt.Errorf("duplicate DAG name %q found", dag.Name)
-			}
-			names[dag.Name] = true
+	if len(dags) < 2 {
+		return nil
+	}
+
+	names := make(map[string]struct{}, len(dags)-1)
+	for i, dag := range dags[1:] {
+		index := i + 1
+		if dag.Name == "" {
+			return fmt.Errorf("DAG at index %d must have a name in multi-DAG file", index)
 		}
+		if _, exists := names[dag.Name]; exists {
+			return fmt.Errorf("duplicate DAG name %q found", dag.Name)
+		}
+		names[dag.Name] = struct{}{}
 	}
 	return nil
 }
@@ -678,43 +654,42 @@ func defaultName(file string) string {
 // resolveYamlFilePath resolves the YAML file path.
 // If the file name does not have an extension, it appends ".yaml".
 func resolveYamlFilePath(ctx BuildContext, file string) (string, error) {
+	file = strings.TrimSpace(file)
 	if file == "" {
 		return "", errors.New("file path is required")
 	}
 
-	file = strings.TrimSpace(file) // Remove leading and trailing whitespace
+	file = expandHomeDir(file)
 
 	if filepath.IsAbs(file) {
-		// If the file is an absolute path, return it as is.
 		return file, nil
 	}
 
-	// Replace '~' with the user's home directory if present.
-	if strings.HasPrefix(file, "~") {
-		if homeDir, err := os.UserHomeDir(); err == nil {
-			file = strings.Replace(file, "~", homeDir, 1)
-		}
-	}
-
-	// Check if the file exists in the current Directory.
-	absFile, err := filepath.Abs(file)
-	if err == nil && fileutil.FileExists(absFile) {
-		// If	the file exists, return the absolute path.
+	if absFile, err := filepath.Abs(file); err == nil && fileutil.FileExists(absFile) {
 		return absFile, nil
 	}
 
-	// If the file does not exist, check if it exists in the DAGsDir.
 	if ctx.opts.DAGsDir != "" {
-		// If the file is not an absolute path, prepend the DAGsDir to the file name.
 		file = filepath.Join(ctx.opts.DAGsDir, file)
 	}
 
-	// The file name can be specified without the extension.
 	if !strings.HasSuffix(file, ".yaml") && !strings.HasSuffix(file, ".yml") {
-		file = fmt.Sprintf("%s.yaml", file)
+		file += ".yaml"
 	}
 
 	return filepath.Abs(file)
+}
+
+func expandHomeDir(file string) string {
+	if !strings.HasPrefix(file, "~") {
+		return file
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return file
+	}
+	return strings.Replace(file, "~", homeDir, 1)
 }
 
 type mergeTransformer struct{}

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -436,7 +436,7 @@ func decodeDocuments(data []byte) ([]dagDocument, error) {
 		if len(doc) == 0 {
 			continue
 		}
-		docs = append(docs, dagDocument{index: index, data: doc})
+		docs = append(docs, dagDocument{index: len(docs), data: doc})
 	}
 }
 
@@ -684,7 +684,7 @@ func resolveYamlFilePath(ctx BuildContext, file string) (string, error) {
 }
 
 func expandHomeDir(file string) string {
-	if !strings.HasPrefix(file, "~") {
+	if file != "~" && !strings.HasPrefix(file, "~/") && !strings.HasPrefix(file, `~\`) {
 		return file
 	}
 

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -19,6 +19,10 @@ func TestExpandHomeDir(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, homeDir, expandHomeDir("~"))
-	assert.Equal(t, filepath.Join(homeDir, "dags", "test.yaml"), expandHomeDir("~/dags/test.yaml"))
+	assert.Equal(
+		t,
+		filepath.Clean(filepath.Join(homeDir, "dags", "test.yaml")),
+		filepath.Clean(expandHomeDir("~/dags/test.yaml")),
+	)
 	assert.Equal(t, "~alice/dags/test.yaml", expandHomeDir("~alice/dags/test.yaml"))
 }

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandHomeDir(t *testing.T) {
+	t.Parallel()
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	assert.Equal(t, homeDir, expandHomeDir("~"))
+	assert.Equal(t, filepath.Join(homeDir, "dags", "test.yaml"), expandHomeDir("~/dags/test.yaml"))
+	assert.Equal(t, "~alice/dags/test.yaml", expandHomeDir("~alice/dags/test.yaml"))
+}

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -1106,6 +1106,39 @@ steps:
 	assert.NotContains(t, string(childDAG.YamlData), "call: child-task")
 }
 
+func TestLoad_MultiDocumentFileWithLeadingSeparatorPreservesMainDocumentProvenance(t *testing.T) {
+	t.Parallel()
+
+	dagFile := createTempYAMLFile(t, `---
+steps:
+  - name: call-child
+    call: child-task
+
+---
+name: child-task
+steps:
+  - name: work
+    command: echo "child"
+`)
+
+	dag, err := spec.Load(context.Background(), dagFile)
+	require.NoError(t, err)
+	require.NotNil(t, dag.LocalDAGs)
+
+	childDAG, ok := dag.LocalDAGs["child-task"]
+	require.True(t, ok)
+
+	assert.Equal(t, dagFile, dag.Location)
+	assert.Equal(t, dagFile, dag.SourceFile)
+	assert.Contains(t, string(dag.YamlData), "call: child-task")
+	assert.Contains(t, string(dag.YamlData), "name: child-task")
+
+	assert.Equal(t, dagFile, childDAG.Location)
+	assert.Equal(t, dagFile, childDAG.SourceFile)
+	assert.Contains(t, string(childDAG.YamlData), "name: child-task")
+	assert.NotContains(t, string(childDAG.YamlData), "call: child-task")
+}
+
 func TestLoadYAMLWithOpts_TypeInheritanceInMultiDocumentYAML(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -1391,6 +1391,21 @@ steps:
 			errContains: "duplicate DAG name",
 		},
 		{
+			name: "DuplicateMainAndSubDAGNames",
+			content: `name: duplicate-name
+steps:
+  - name: step1
+    command: echo "main"
+
+---
+name: duplicate-name
+steps:
+  - name: step1
+    command: echo "child"
+`,
+			errContains: "duplicate DAG name",
+		},
+		{
 			name: "SubDAGWithoutName",
 			content: `steps:
   - name: step1

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -1073,6 +1073,39 @@ steps:
 	assert.Equal(t, core.TypeChain, childDAG.Type)
 }
 
+func TestLoad_MultiDocumentFilePreservesDocumentProvenance(t *testing.T) {
+	t.Parallel()
+
+	dagFile := createTempYAMLFile(t, `
+steps:
+  - name: call-child
+    call: child-task
+
+---
+name: child-task
+steps:
+  - name: work
+    command: echo "child"
+`)
+
+	dag, err := spec.Load(context.Background(), dagFile)
+	require.NoError(t, err)
+	require.NotNil(t, dag.LocalDAGs)
+
+	childDAG, ok := dag.LocalDAGs["child-task"]
+	require.True(t, ok)
+
+	assert.Equal(t, dagFile, dag.Location)
+	assert.Equal(t, dagFile, dag.SourceFile)
+	assert.Contains(t, string(dag.YamlData), "call: child-task")
+	assert.Contains(t, string(dag.YamlData), "name: child-task")
+
+	assert.Equal(t, dagFile, childDAG.Location)
+	assert.Equal(t, dagFile, childDAG.SourceFile)
+	assert.Contains(t, string(childDAG.YamlData), "name: child-task")
+	assert.NotContains(t, string(childDAG.YamlData), "call: child-task")
+}
+
 func TestLoadYAMLWithOpts_TypeInheritanceInMultiDocumentYAML(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -191,7 +191,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 func (s *Step) legacyCommandEntry() CommandEntry {
 	return CommandEntry{
 		Command:     s.Command,
-		Args:        s.Args,
+		Args:        append([]string(nil), s.Args...),
 		CmdWithArgs: s.CmdWithArgs,
 	}
 }

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -121,23 +121,13 @@ type Step struct {
 
 // String returns a formatted string representation of the step
 func (s *Step) String() string {
-	fields := []struct {
-		name  string
-		value string
-	}{
-		{"Name", s.Name},
-		{"Dir", s.Dir},
-		{"Command", s.Command},
-		{"Args", fmt.Sprintf("%v", s.Args)},
-		{"Depends", fmt.Sprintf("[%s]", strings.Join(s.Depends, ", "))},
-	}
-
-	var parts []string
-	for _, field := range fields {
-		parts = append(parts, fmt.Sprintf("%s: %s", field.name, field.value))
-	}
-
-	return strings.Join(parts, "\t")
+	return strings.Join([]string{
+		fmt.Sprintf("Name: %s", s.Name),
+		fmt.Sprintf("Dir: %s", s.Dir),
+		fmt.Sprintf("Command: %s", s.Command),
+		fmt.Sprintf("Args: %v", s.Args),
+		fmt.Sprintf("Depends: [%s]", strings.Join(s.Depends, ", ")),
+	}, "\t")
 }
 
 // SubDAG contains information about a sub DAG to be executed.
@@ -179,33 +169,31 @@ func (s *Step) HasMultipleCommands() bool {
 // UnmarshalJSON implements json.Unmarshaler for backward compatibility.
 // It handles old JSON format where command/args fields were used instead of commands.
 func (s *Step) UnmarshalJSON(data []byte) error {
-	// Use type alias to avoid infinite recursion
-	type Alias Step
+	type alias Step
 	aux := &struct {
-		*Alias
+		*alias
 	}{
-		Alias: (*Alias)(s),
+		alias: (*alias)(s),
 	}
 
 	if err := json.Unmarshal(data, aux); err != nil {
 		return err
 	}
 
-	// If Commands is already populated, we're done (new format)
-	if len(s.Commands) > 0 {
+	if len(s.Commands) > 0 || (s.Command == "" && len(s.Args) == 0 && s.CmdWithArgs == "") {
 		return nil
 	}
 
-	// Migrate legacy fields to Commands only when legacy command data exists.
-	if s.Command != "" || len(s.Args) > 0 || s.CmdWithArgs != "" {
-		s.Commands = []CommandEntry{{
-			Command:     s.Command,
-			Args:        s.Args,
-			CmdWithArgs: s.CmdWithArgs,
-		}}
-	}
-
+	s.Commands = []CommandEntry{s.legacyCommandEntry()}
 	return nil
+}
+
+func (s *Step) legacyCommandEntry() CommandEntry {
+	return CommandEntry{
+		Command:     s.Command,
+		Args:        s.Args,
+		CmdWithArgs: s.CmdWithArgs,
+	}
 }
 
 // ExecutorConfig contains the configuration for the executor.

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -6,6 +6,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -191,7 +192,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 func (s *Step) legacyCommandEntry() CommandEntry {
 	return CommandEntry{
 		Command:     s.Command,
-		Args:        append([]string(nil), s.Args...),
+		Args:        slices.Clone(s.Args),
 		CmdWithArgs: s.CmdWithArgs,
 	}
 }

--- a/internal/core/step_test.go
+++ b/internal/core/step_test.go
@@ -343,3 +343,16 @@ func TestCommandEntry_String(t *testing.T) {
 		})
 	}
 }
+
+func TestStepUnmarshalJSONCopiesLegacyArgs(t *testing.T) {
+	t.Parallel()
+
+	var step Step
+	err := json.Unmarshal([]byte(`{"command":"echo","args":["hello"],"cmdWithArgs":"echo hello"}`), &step)
+	require.NoError(t, err)
+	require.Len(t, step.Commands, 1)
+	require.Equal(t, []string{"hello"}, step.Commands[0].Args)
+
+	step.Args[0] = "changed"
+	assert.Equal(t, []string{"hello"}, step.Commands[0].Args)
+}

--- a/internal/persis/filedagrun/writer.go
+++ b/internal/persis/filedagrun/writer.go
@@ -19,29 +19,16 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 )
 
-// WriterState represents the current state of a writer
-type WriterState int
-
-// WriterState constants
-const (
-	WriterStateClosed WriterState = iota
-	WriterStateOpen
-)
-
-// Error definitions
 var (
 	ErrWriterNotOpen = errors.New("writer is not open")
 )
 
-// Writer manages writing status to a local file.
-// It provides thread-safe operations and ensures data durability.
 type Writer struct {
-	target     string        // Path to the target file
-	state      WriterState   // Current state of the writer
-	writer     *bufio.Writer // Buffered writer for performance
-	file       *os.File      // Underlying file handle
-	mu         sync.Mutex    // Mutex for thread safety
-	bufferSize int           // Size of the write buffer
+	target     string
+	writer     *bufio.Writer
+	file       *os.File
+	mu         sync.Mutex
+	bufferSize int
 }
 
 // WriterOption defines functional options for configuring a Writer.
@@ -51,8 +38,7 @@ type WriterOption func(*Writer)
 func NewWriter(target string, opts ...WriterOption) *Writer {
 	w := &Writer{
 		target:     target,
-		state:      WriterStateClosed,
-		bufferSize: 4096, // Default buffer size
+		bufferSize: 4096,
 	}
 
 	for _, opt := range opts {
@@ -68,17 +54,15 @@ func (w *Writer) Open() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.state == WriterStateOpen {
-		return nil // Already open, no need to reopen
+	if w.isOpenLocked() {
+		return nil
 	}
 
-	// Create directories if needed
 	dir := filepath.Dir(w.target)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
-	// Open or create file
 	file, err := fileutil.OpenOrCreateFile(w.target)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", w.target, err)
@@ -86,14 +70,12 @@ func (w *Writer) Open() error {
 
 	w.file = file
 	w.writer = bufio.NewWriterSize(file, w.bufferSize)
-	w.state = WriterStateOpen
 	return nil
 }
 
 // Write serializes the status to JSON and appends it to the file.
 // It automatically flushes data to ensure durability.
 func (w *Writer) Write(ctx context.Context, st exec.DAGRunStatus) error {
-	// Add context info to logs if write fails
 	if err := w.write(st); err != nil {
 		logger.Error(ctx, "Failed to write status", tag.Error(err))
 		return err
@@ -106,32 +88,27 @@ func (w *Writer) write(st exec.DAGRunStatus) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.state != WriterStateOpen {
+	if !w.isOpenLocked() {
 		return ErrWriterNotOpen
 	}
 
-	// Marshal status to JSON
 	jsonBytes, err := json.Marshal(st)
 	if err != nil {
 		return fmt.Errorf("failed to marshal status: %w", err)
 	}
 
-	// Write JSON line
 	if _, err := w.writer.Write(jsonBytes); err != nil {
 		return fmt.Errorf("failed to write JSON: %w", err)
 	}
 
-	// Add newline
 	if err := w.writer.WriteByte('\n'); err != nil {
 		return fmt.Errorf("failed to write newline: %w", err)
 	}
 
-	// Flush to ensure data is written to the underlying file
 	if err := w.writer.Flush(); err != nil {
 		return fmt.Errorf("failed to flush data: %w", err)
 	}
 
-	// Sync to ensure data is persisted to disk (important for multi-coordinator visibility)
 	if err := w.file.Sync(); err != nil {
 		return fmt.Errorf("failed to sync data: %w", err)
 	}
@@ -142,7 +119,6 @@ func (w *Writer) write(st exec.DAGRunStatus) error {
 // Close flushes any buffered data and closes the underlying file.
 // It's safe to call close multiple times.
 func (w *Writer) Close(ctx context.Context) error {
-	// Add context info to logs if close fails
 	if err := w.close(); err != nil {
 		logger.Error(ctx, "Failed to close writer", tag.Error(err))
 		return err
@@ -156,36 +132,27 @@ func (w *Writer) close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if w.state == WriterStateClosed {
-		return nil // Already closed
+	if !w.isOpenLocked() {
+		return nil
 	}
 
 	var errs []error
 
-	// Flush any buffered data
-	if w.writer != nil {
-		if err := w.writer.Flush(); err != nil {
-			errs = append(errs, fmt.Errorf("flush error: %w", err))
-		}
+	if err := w.writer.Flush(); err != nil {
+		errs = append(errs, fmt.Errorf("flush error: %w", err))
 	}
 
-	// Ensure data is synced to disk
-	if w.file != nil {
-		if err := w.file.Sync(); err != nil {
-			errs = append(errs, fmt.Errorf("sync error: %w", err))
-		}
-
-		if err := w.file.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("close error: %w", err))
-		}
+	if err := w.file.Sync(); err != nil {
+		errs = append(errs, fmt.Errorf("sync error: %w", err))
 	}
 
-	// Reset writer state
-	w.writer = nil
+	if err := w.file.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("close error: %w", err))
+	}
+
 	w.file = nil
-	w.state = WriterStateClosed
+	w.writer = nil
 
-	// Return combined errors if any
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
@@ -197,5 +164,9 @@ func (w *Writer) close() error {
 func (w *Writer) IsOpen() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.state == WriterStateOpen
+	return w.isOpenLocked()
+}
+
+func (w *Writer) isOpenLocked() bool {
+	return w.file != nil && w.writer != nil
 }

--- a/internal/persis/filedagrun/writer_test.go
+++ b/internal/persis/filedagrun/writer_test.go
@@ -97,6 +97,15 @@ func TestWriterErrorHandling(t *testing.T) {
 		require.NoError(t, writer.close())
 		assert.NoError(t, writer.close()) // Second close should not return an error
 	})
+
+	t.Run("IsOpenTracksLifecycle", func(t *testing.T) {
+		writer := NewWriter(filepath.Join(th.TmpDir, "lifecycle.dat"))
+		assert.False(t, writer.IsOpen())
+		require.NoError(t, writer.Open())
+		assert.True(t, writer.IsOpen())
+		require.NoError(t, writer.close())
+		assert.False(t, writer.IsOpen())
+	})
 }
 
 func TestWriterRename(t *testing.T) {

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -462,24 +462,12 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	// Resolve per-run work directory
-	if attempt != nil {
-		a.workDir = attempt.WorkDir()
-		if a.workDir == "" {
-			// Shared-nothing mode: create a temp directory as fallback
-			a.workDir = filepath.Join(os.TempDir(), fmt.Sprintf("dagu_%s_%s", fileutil.SafeName(a.dag.Name), a.dagRunID))
-			if err := os.MkdirAll(a.workDir, 0o750); err != nil {
-				return fmt.Errorf("failed to create work directory: %w", err)
-			}
-			// Register cleanup immediately so the temp dir is removed even if
-			// later initialization (attempt.Open, config evaluation, etc.) fails.
-			defer func() {
-				if a.dagRunStore == nil && a.workDir != "" {
-					if err := os.RemoveAll(a.workDir); err != nil {
-						logger.Warn(ctx, "Failed to remove temp work dir", tag.Error(err))
-					}
-				}
-			}()
-		}
+	cleanupWorkDir, err := a.prepareWorkDir(ctx, attempt)
+	if err != nil {
+		return err
+	}
+	if cleanupWorkDir != nil {
+		defer cleanupWorkDir()
 	}
 	if a.artifactDir != "" {
 		if err := os.MkdirAll(a.artifactDir, 0o750); err != nil {
@@ -1243,34 +1231,69 @@ func (a *Agent) statusSourceTarget() *exec.DAGRunStatus {
 	return a.retryTarget
 }
 
+func (a *Agent) prepareWorkDir(ctx context.Context, attempt exec.DAGRunAttempt) (func(), error) {
+	if attempt == nil {
+		return nil, nil
+	}
+
+	a.workDir = attempt.WorkDir()
+	if a.workDir != "" {
+		return nil, nil
+	}
+
+	a.workDir = filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("dagu_%s_%s", fileutil.SafeName(a.dag.Name), a.dagRunID),
+	)
+	if err := os.MkdirAll(a.workDir, 0o750); err != nil {
+		return nil, fmt.Errorf("failed to create work directory: %w", err)
+	}
+	if a.dagRunStore != nil {
+		return nil, nil
+	}
+
+	return func() {
+		if a.workDir == "" {
+			return
+		}
+		if err := os.RemoveAll(a.workDir); err != nil {
+			logger.Warn(ctx, "Failed to remove temp work dir", tag.Error(err))
+		}
+	}, nil
+}
+
 // writeStatus writes the current status to storage.
 // In shared-nothing mode (statusPusher is set), it only pushes to the coordinator.
 // In local mode, it writes to local storage via attempt.Write.
 func (a *Agent) writeStatus(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) {
-	// In shared-nothing mode, only push to coordinator (coordinator writes to its storage)
 	if a.statusPusher != nil {
-		// Use a context that won't be cancelled, so final status is always pushed
-		// even when the execution was cancelled (e.g., via heartbeat directive).
-		pushCtx := context.WithoutCancel(ctx)
-		if err := a.statusPusher.Push(pushCtx, status); err != nil {
-			logger.Error(ctx, "Failed to push status to coordinator", tag.Error(err))
-			var rejectedErr *remote.AttemptRejectedError
-			if errors.As(err, &rejectedErr) && !a.finished.Load() {
-				logger.Warn(ctx, "Coordinator rejected the worker attempt; stopping execution",
-					tag.AttemptID(a.dagRunAttemptID),
-					slog.String("reason", rejectedErr.Reason),
-				)
-				a.signal(context.Background(), syscall.SIGTERM, true)
-			}
-		}
+		a.pushStatus(ctx, status)
 		return
 	}
+	a.writeStatusLocally(ctx, attempt, status)
+}
 
-	// In local mode, write to local storage
-	if attempt != nil {
-		if err := attempt.Write(ctx, status); err != nil {
-			logger.Error(ctx, "Failed to write status to local storage", tag.Error(err))
+func (a *Agent) pushStatus(ctx context.Context, status exec.DAGRunStatus) {
+	pushCtx := context.WithoutCancel(ctx)
+	if err := a.statusPusher.Push(pushCtx, status); err != nil {
+		logger.Error(ctx, "Failed to push status to coordinator", tag.Error(err))
+		var rejectedErr *remote.AttemptRejectedError
+		if errors.As(err, &rejectedErr) && !a.finished.Load() {
+			logger.Warn(ctx, "Coordinator rejected the worker attempt; stopping execution",
+				tag.AttemptID(a.dagRunAttemptID),
+				slog.String("reason", rejectedErr.Reason),
+			)
+			a.signal(context.Background(), syscall.SIGTERM, true)
 		}
+	}
+}
+
+func (a *Agent) writeStatusLocally(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) {
+	if attempt == nil {
+		return
+	}
+	if err := attempt.Write(ctx, status); err != nil {
+		logger.Error(ctx, "Failed to write status to local storage", tag.Error(err))
 	}
 }
 
@@ -1652,8 +1675,10 @@ func (a *Agent) signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 		a.runner.Signal(ctx, a.plan, sig, done, allowOverride)
 	}()
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
+	resendTicker := time.NewTicker(5 * time.Second)
+	defer resendTicker.Stop()
+	probeTicker := time.NewTicker(500 * time.Millisecond)
+	defer probeTicker.Stop()
 
 	for {
 		select {
@@ -1663,18 +1688,16 @@ func (a *Agent) signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 
 		case <-signalCtx.Done():
 			logger.Info(ctx, "Max cleanup time reached, sending SIGKILL to force termination")
-			// Force kill with SIGKILL and don't wait for completion
 			a.runner.Signal(ctx, a.plan, syscall.SIGKILL, nil, false)
 			return
 
-		case <-ticker.C:
+		case <-resendTicker.C:
 			logger.Info(ctx, "Resending signal to processes that haven't terminated",
 				tag.Signal(sig.String()),
 			)
 			a.runner.Signal(ctx, a.plan, sig, nil, false)
 
-		case <-time.After(500 * time.Millisecond):
-			// Quick check to avoid busy waiting, but still responsive
+		case <-probeTicker.C:
 			if a.plan != nil && !a.plan.HasActiveNodes() {
 				logger.Info(ctx, "No running processes detected, termination complete")
 				return
@@ -1689,20 +1712,12 @@ func (a *Agent) setupPlan(ctx context.Context) error {
 	if a.retryTarget != nil {
 		return a.setupRetryPlan(ctx)
 	}
-	plan, err := runtime.NewPlan(a.dag.Steps...)
-	if err != nil {
-		return err
-	}
-	a.plan = plan
-	return nil
+	return a.setupFreshPlan()
 }
 
 // setupRetryPlan sets up the plan for retry.
 func (a *Agent) setupRetryPlan(ctx context.Context) error {
-	nodes := make([]*runtime.Node, 0, len(a.retryTarget.Nodes))
-	for _, n := range a.retryTarget.Nodes {
-		nodes = append(nodes, transform.ToNode(n))
-	}
+	nodes := a.retryNodes()
 	// If the previous run was killed before writing node data to the status
 	// (e.g., SIGKILL before the initial 100ms status write), retryTarget.Nodes
 	// will be empty. Fall back to a fresh plan from the DAG definition so that
@@ -1712,17 +1727,29 @@ func (a *Agent) setupRetryPlan(ctx context.Context) error {
 		if a.stepRetry != "" {
 			return fmt.Errorf("cannot retry step %q: previous attempt has no node state", a.stepRetry)
 		}
-		plan, err := runtime.NewPlan(a.dag.Steps...)
-		if err != nil {
-			return err
-		}
-		a.plan = plan
-		return nil
+		return a.setupFreshPlan()
 	}
 	if a.stepRetry != "" {
 		return a.setupStepRetryPlan(nodes)
 	}
 	return a.setupDefaultRetryPlan(ctx, nodes)
+}
+
+func (a *Agent) setupFreshPlan() error {
+	plan, err := runtime.NewPlan(a.dag.Steps...)
+	if err != nil {
+		return err
+	}
+	a.plan = plan
+	return nil
+}
+
+func (a *Agent) retryNodes() []*runtime.Node {
+	nodes := make([]*runtime.Node, 0, len(a.retryTarget.Nodes))
+	for _, node := range a.retryTarget.Nodes {
+		nodes = append(nodes, transform.ToNode(node))
+	}
+	return nodes
 }
 
 // setupStepRetryPlan sets up the plan for retrying a specific step.
@@ -1746,15 +1773,9 @@ func (a *Agent) setupDefaultRetryPlan(ctx context.Context, nodes []*runtime.Node
 }
 
 func (a *Agent) setupDAGRunAttempt(ctx context.Context) (exec.DAGRunAttempt, error) {
-	// In shared-nothing mode, dagRunStore is nil - return no-op attempt.
-	// Status updates are handled by statusPusher instead.
 	if a.dagRunStore == nil {
 		logger.Debug(ctx, "Using no-op DAGRunAttempt in shared-nothing mode")
-		attemptID := a.attemptID
-		if attemptID == "" {
-			attemptID = a.dagRunID
-		}
-		return exec.NewNoopDAGRunAttempt(attemptID, a.dag), nil
+		return exec.NewNoopDAGRunAttempt(a.noopAttemptID(), a.dag), nil
 	}
 
 	retentionDays := a.dag.HistRetentionDays
@@ -1774,9 +1795,17 @@ func (a *Agent) setupDAGRunAttempt(ctx context.Context) (exec.DAGRunAttempt, err
 		return a.preparedAttempt, nil
 	}
 
-	// Retry is true when:
-	// 1. Retrying a failed execution (retryTarget != nil)
-	// 2. Running from queue (queuedRun = true) - the dag-run was already created by enqueue
+	return a.dagRunStore.CreateAttempt(ctx, a.dag, time.Now(), a.dagRunID, a.attemptOptions())
+}
+
+func (a *Agent) noopAttemptID() string {
+	if a.attemptID != "" {
+		return a.attemptID
+	}
+	return a.dagRunID
+}
+
+func (a *Agent) attemptOptions() exec.NewDAGRunAttemptOptions {
 	opts := exec.NewDAGRunAttemptOptions{
 		Retry:     a.retryTarget != nil || a.queuedRun,
 		AttemptID: a.attemptID,
@@ -1784,18 +1813,12 @@ func (a *Agent) setupDAGRunAttempt(ctx context.Context) (exec.DAGRunAttempt, err
 	if a.isSubDAGRun.Load() {
 		opts.RootDAGRun = &a.rootDAGRun
 	}
-
-	return a.dagRunStore.CreateAttempt(ctx, a.dag, time.Now(), a.dagRunID, opts)
+	return opts
 }
 
 // setupSocketServer creates a socket server instance.
 func (a *Agent) setupSocketServer(ctx context.Context) error {
-	socketAddr := a.dag.SockAddr(a.dagRunID)
-	if a.isSubDAGRun.Load() {
-		socketAddr = a.dag.SockAddrForSubDAGRun(a.dagRunID)
-	}
-
-	socketServer, err := sock.NewServer(socketAddr, a.HandleHTTP(ctx))
+	socketServer, err := sock.NewServer(a.socketAddr(), a.HandleHTTP(ctx))
 	if err != nil {
 		return err
 	}
@@ -1803,29 +1826,40 @@ func (a *Agent) setupSocketServer(ctx context.Context) error {
 	return nil
 }
 
+func (a *Agent) socketAddr() string {
+	if a.isSubDAGRun.Load() {
+		return a.dag.SockAddrForSubDAGRun(a.dagRunID)
+	}
+	return a.dag.SockAddr(a.dagRunID)
+}
+
 // checkIsAlreadyRunning returns error if the DAG is already running.
 func (a *Agent) checkIsAlreadyRunning(ctx context.Context) error {
 	if a.isSubDAGRun.Load() {
-		return nil // Skip the check for sub dag-runs
+		return nil
 	}
-	if a.dagRunMgr.IsRunning(ctx, a.dag, a.dagRunID) {
-		return fmt.Errorf("already running. dag-run ID=%s, socket=%s", a.dagRunID, a.dag.SockAddr(a.dagRunID))
+	if !a.dagRunMgr.IsRunning(ctx, a.dag, a.dagRunID) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("already running. dag-run ID=%s, socket=%s", a.dagRunID, a.dag.SockAddr(a.dagRunID))
 }
 
 // execWithRecovery executes a function with panic recovery and logs any panics.
 func execWithRecovery(ctx context.Context, fn func()) {
 	defer func() {
 		if panicObj := recover(); panicObj != nil {
-			logger.Error(ctx, "Recovered from panic",
-				slog.String("err", panicToError(panicObj).Error()),
-				slog.String("errType", fmt.Sprintf("%T", panicObj)),
-				slog.String("stackTrace", string(debug.Stack())),
-			)
+			logRecoveredPanic(ctx, panicObj)
 		}
 	}()
 	fn()
+}
+
+func logRecoveredPanic(ctx context.Context, panicObj any) {
+	logger.Error(ctx, "Recovered from panic",
+		slog.String("err", panicToError(panicObj).Error()),
+		slog.String("errType", fmt.Sprintf("%T", panicObj)),
+		slog.String("stackTrace", string(debug.Stack())),
+	)
 }
 
 // panicToError converts a panic value to an error.
@@ -1847,9 +1881,9 @@ func (e *httpError) Error() string { return e.Message }
 // encodeError returns error to the HTTP client.
 func encodeError(w http.ResponseWriter, err error) {
 	var httpErr *httpError
-	if errors.As(err, &httpErr) {
-		http.Error(w, httpErr.Error(), httpErr.Code)
+	if !errors.As(err, &httpErr) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	http.Error(w, httpErr.Error(), httpErr.Code)
 }

--- a/internal/runtime/agent/reporter.go
+++ b/internal/runtime/agent/reporter.go
@@ -64,25 +64,28 @@ func newReporter(f SenderFn, cfg reporterConfig) *reporter {
 func (r *reporter) reportStep(
 	ctx context.Context, dag *core.DAG, dagStatus exec.DAGRunStatus, node *runtime.Node,
 ) error {
-	nodeStatus := node.State().Status
-	if nodeStatus == core.NodeFailed && node.NodeData().Step.MailOnError && r.errorMail != nil {
-		fromAddress := r.errorMail.From
-		toAddresses := r.errorMail.To
-		subject := fmt.Sprintf("%s %s (%s)", r.errorMail.Prefix, dag.Name, dagStatus.Status)
-		html := renderHTMLWithDAGInfo(dagStatus)
-		attachments := addAttachments(r.errorMail.AttachLogs, dagStatus.Nodes)
-		return r.senderFn(ctx, fromAddress, toAddresses, subject, html, attachments)
+	if r == nil {
+		return nil
+	}
+	if r.errorMail == nil {
+		return nil
+	}
+	if node.State().Status == core.NodeFailed && node.NodeData().Step.MailOnError {
+		return r.sendConfiguredMail(ctx, r.errorMail, dag.Name, dagStatus)
 	}
 	return nil
 }
 
 // send is a function that sends a report mail.
 func (r *reporter) send(ctx context.Context, dag *core.DAG, dagStatus exec.DAGRunStatus, err error) error {
+	if r == nil {
+		return nil
+	}
 	mailConfig := r.selectMailConfig(dag, dagStatus, err)
 	if mailConfig == nil {
 		return nil
 	}
-	return r.sendMail(ctx, mailConfig, dag.Name, dagStatus)
+	return r.sendConfiguredMail(ctx, mailConfig, dag.Name, dagStatus)
 }
 
 // selectMailConfig returns the appropriate mail config based on status, or nil if no mail should be sent.
@@ -103,27 +106,59 @@ func (r *reporter) selectMailConfig(dag *core.DAG, dagStatus exec.DAGRunStatus, 
 	}
 }
 
-// sendMail sends an email using the provided mail configuration.
-func (r *reporter) sendMail(ctx context.Context, mailConfig *core.MailConfig, dagName string, dagStatus exec.DAGRunStatus) error {
-	subject := fmt.Sprintf("%s %s (%s)", mailConfig.Prefix, dagName, dagStatus.Status)
-	html := renderHTMLWithDAGInfo(dagStatus)
-	attachments := addAttachments(mailConfig.AttachLogs, dagStatus.Nodes)
-	return r.senderFn(ctx, mailConfig.From, mailConfig.To, subject, html, attachments)
+func (r *reporter) sendConfiguredMail(ctx context.Context, mailConfig *core.MailConfig, dagName string, dagStatus exec.DAGRunStatus) error {
+	return r.senderFn(
+		ctx,
+		mailConfig.From,
+		mailConfig.To,
+		buildMailSubject(mailConfig.Prefix, dagName, dagStatus.Status),
+		renderHTMLWithDAGInfo(dagStatus),
+		addAttachments(mailConfig.AttachLogs, dagStatus.Nodes),
+	)
 }
 
-// statusToClass maps a status string to its CSS class.
+func buildMailSubject(prefix, dagName string, status core.Status) string {
+	return fmt.Sprintf("%s %s (%s)", prefix, dagName, status)
+}
+
 func statusToClass(status string) string {
-	statusClasses := map[string]string{
-		"finished":            "status-finished",
-		"succeeded":           "status-finished",
-		"failed":              "status-failed",
-		"running":             "status-running",
-		"skipped":             "status-skipped",
-		"partially_succeeded": "status-partial-success",
-		"aborted":             "status-aborted",
-		"waiting":             "status-waiting",
+	switch status {
+	case "finished", "succeeded":
+		return "status-finished"
+	case "failed":
+		return "status-failed"
+	case "running":
+		return "status-running"
+	case "skipped":
+		return "status-skipped"
+	case "partially_succeeded":
+		return "status-partial-success"
+	case "aborted":
+		return "status-aborted"
+	case "waiting":
+		return "status-waiting"
+	default:
+		return ""
 	}
-	return statusClasses[status]
+}
+
+func statusBadgeClass(status string) string {
+	switch status {
+	case "finished", "succeeded":
+		return "success"
+	case "failed":
+		return "failed"
+	case "running":
+		return "running"
+	case "skipped":
+		return "skipped"
+	case "aborted":
+		return "aborted"
+	case "waiting":
+		return "wait"
+	default:
+		return ""
+	}
 }
 
 var dagHeader = table.Row{
@@ -137,6 +172,11 @@ var dagHeader = table.Row{
 }
 
 func renderDAGSummary(dagStatus exec.DAGRunStatus, err error) string {
+	errText := ""
+	if err != nil {
+		errText = err.Error()
+	}
+
 	dataRow := table.Row{
 		dagStatus.DAGRunID,
 		dagStatus.Name,
@@ -144,11 +184,7 @@ func renderDAGSummary(dagStatus exec.DAGRunStatus, err error) string {
 		dagStatus.FinishedAt,
 		dagStatus.Status,
 		dagStatus.Params,
-	}
-	if err != nil {
-		dataRow = append(dataRow, err.Error())
-	} else {
-		dataRow = append(dataRow, "")
+		errText,
 	}
 
 	reportTable := table.NewWriter()
@@ -172,17 +208,15 @@ func renderStepSummary(nodes []*exec.Node) string {
 	stepTable.AppendHeader(stepHeader)
 
 	for i, n := range nodes {
-		number := fmt.Sprintf("%d", i+1)
-		dataRow := table.Row{
-			number,
+		stepTable.AppendRow(table.Row{
+			fmt.Sprintf("%d", i+1),
 			n.Step.Name,
 			n.StartedAt,
 			n.FinishedAt,
 			n.Status.String(),
-		}
-		dataRow = append(dataRow, formatCommands(n.Step.Commands))
-		dataRow = append(dataRow, n.Error)
-		stepTable.AppendRow(dataRow)
+			formatCommands(n.Step.Commands),
+			n.Error,
+		})
 	}
 
 	return stepTable.Render()
@@ -249,25 +283,31 @@ func renderHTML(nodes []*exec.Node) string {
     </style>
 </head>
 <body>
-<table>
-<thead>
-<tr>`)
-
-	// Add table headers
-	headers := []string{"#", "Step", "Started At", "Finished At", "Status", "Command", "Error"}
-	for _, header := range headers {
-		_, _ = buffer.WriteString(fmt.Sprintf("<th>%s</th>", header))
-	}
-	_, _ = buffer.WriteString("</tr></thead><tbody>")
-
-	// Add table rows
-	for i, n := range nodes {
-		writeNodeRow(&buffer, i, n)
-	}
-
-	_, _ = buffer.WriteString("</tbody></table></body></html>")
+`)
+	writeHTMLTable(&buffer, nodes)
+	_, _ = buffer.WriteString("</body></html>")
 
 	return buffer.String()
+}
+
+var htmlTableHeaders = []string{"#", "Step", "Started At", "Finished At", "Status", "Command", "Error"}
+
+func writeHTMLTable(buffer *bytes.Buffer, nodes []*exec.Node) {
+	_, _ = buffer.WriteString("<table><thead><tr>")
+	writeHTMLHeaderCells(buffer, htmlTableHeaders)
+	_, _ = buffer.WriteString("</tr></thead><tbody>")
+	for i, n := range nodes {
+		writeNodeRow(buffer, i, n)
+	}
+	_, _ = buffer.WriteString("</tbody></table>")
+}
+
+func writeHTMLHeaderCells(buffer *bytes.Buffer, headers []string) {
+	for _, header := range headers {
+		_, _ = buffer.WriteString("<th>")
+		_, _ = buffer.WriteString(header)
+		_, _ = buffer.WriteString("</th>")
+	}
 }
 
 // writeNodeRow writes a single node row to the HTML buffer.
@@ -476,18 +516,8 @@ func renderHTMLWithDAGInfo(dagStatus exec.DAGRunStatus) string {
     <div class="dag-info">
         <div class="status-badge `)
 
-	// Add status class
 	statusStr := dagStatus.Status.String()
-	badgeClasses := map[string]string{
-		"finished":  "success",
-		"succeeded": "success",
-		"failed":    "failed",
-		"running":   "running",
-		"skipped":   "skipped",
-		"aborted":   "aborted",
-		"waiting":   "wait",
-	}
-	_, _ = buffer.WriteString(badgeClasses[statusStr])
+	_, _ = buffer.WriteString(statusBadgeClass(statusStr))
 	_, _ = buffer.WriteString(`">`)
 	_, _ = buffer.WriteString(strings.ToUpper(statusStr))
 	_, _ = buffer.WriteString(`</div>
@@ -539,24 +569,9 @@ func renderHTMLWithDAGInfo(dagStatus exec.DAGRunStatus) string {
             </div>
         </div>
     </div>
-    
-    <table>
-    <thead>
-    <tr>`)
-
-	// Add table headers
-	headers := []string{"#", "Step", "Started At", "Finished At", "Status", "Command", "Error"}
-	for _, header := range headers {
-		_, _ = buffer.WriteString(fmt.Sprintf("<th>%s</th>", header))
-	}
-	_, _ = buffer.WriteString("</tr></thead><tbody>")
-
-	// Add table rows
-	for i, n := range dagStatus.Nodes {
-		writeNodeRow(&buffer, i, n)
-	}
-
-	_, _ = buffer.WriteString("</tbody></table></div></body></html>")
+`)
+	writeHTMLTable(&buffer, dagStatus.Nodes)
+	_, _ = buffer.WriteString("</div></body></html>")
 
 	return buffer.String()
 }

--- a/internal/runtime/agent/reporter.go
+++ b/internal/runtime/agent/reporter.go
@@ -146,6 +146,8 @@ func statusBadgeClass(status string) string {
 	switch status {
 	case "finished", "succeeded":
 		return "success"
+	case "partially_succeeded":
+		return "success"
 	case "failed":
 		return "failed"
 	case "running":

--- a/internal/runtime/agent/reporter_test.go
+++ b/internal/runtime/agent/reporter_test.go
@@ -452,3 +452,9 @@ func TestRenderHTMLComprehensive(t *testing.T) {
 		require.NotContains(t, html, "style=")
 	})
 }
+
+func TestStatusBadgeClassPartiallySucceeded(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "success", statusBadgeClass("partially_succeeded"))
+}

--- a/internal/runtime/agent/reporter_test.go
+++ b/internal/runtime/agent/reporter_test.go
@@ -453,8 +453,28 @@ func TestRenderHTMLComprehensive(t *testing.T) {
 	})
 }
 
-func TestStatusBadgeClassPartiallySucceeded(t *testing.T) {
+func TestStatusBadgeClass(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "success", statusBadgeClass("partially_succeeded"))
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{name: "Finished", status: "finished", want: "success"},
+		{name: "Succeeded", status: "succeeded", want: "success"},
+		{name: "PartiallySucceeded", status: "partially_succeeded", want: "success"},
+		{name: "Failed", status: "failed", want: "failed"},
+		{name: "Running", status: "running", want: "running"},
+		{name: "Skipped", status: "skipped", want: "skipped"},
+		{name: "Aborted", status: "aborted", want: "aborted"},
+		{name: "Waiting", status: "waiting", want: "wait"},
+		{name: "Unknown", status: "unknown", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, statusBadgeClass(tt.status))
+		})
+	}
 }

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -656,8 +656,8 @@ func (n *Node) signalToSend(sig os.Signal, allowOverride bool) os.Signal {
 func (n *Node) Cancel() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	switch n.Status() {
-	case core.NodeRunning, core.NodeWaiting:
+	status := n.Status()
+	if status == core.NodeRunning || status == core.NodeWaiting {
 		n.SetStatus(core.NodeAborted)
 	}
 }

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -48,16 +48,10 @@ type Node struct {
 }
 
 func NewNode(step core.Step, state NodeState) *Node {
-	return &Node{
-		Data: newSafeData(NodeData{Step: step, State: state}),
-	}
+	return &Node{Data: newSafeData(NodeData{Step: step, State: state})}
 }
 
-func NodeWithData(data NodeData) *Node {
-	return &Node{
-		Data: newSafeData(data),
-	}
-}
+func NodeWithData(data NodeData) *Node { return &Node{Data: newSafeData(data)} }
 
 func (n *Node) NodeData() NodeData {
 	return n.Data.Data()
@@ -536,38 +530,46 @@ func (n *Node) setupExecutor(ctx context.Context) (executor.Executor, error) {
 		}
 		n.SetSubRuns(subRuns)
 
-		// Setup the executor with sub DAG run information
-		if n.Step().Parallel == nil {
-			// Single sub DAG execution
-			exec, ok := cmd.(executor.DAGExecutor)
-			if !ok {
-				return nil, fmt.Errorf("executor %T does not support sub DAG execution", cmd)
-			}
-			exec.SetParams(executor.RunParams{
-				RunID:   subRuns[0].DAGRunID,
-				Params:  subRuns[0].Params,
-				DAGName: subRuns[0].DAGName,
-			})
-		} else {
-			// Parallel sub DAG execution
-			exec, ok := cmd.(executor.ParallelExecutor)
-			if !ok {
-				return nil, fmt.Errorf("executor %T does not support parallel execution", cmd)
-			}
-			// Convert SubDAGRun to executor.RunParams
-			var runParamsList []executor.RunParams
-			for _, subRun := range subRuns {
-				runParamsList = append(runParamsList, executor.RunParams{
-					RunID:   subRun.DAGRunID,
-					Params:  subRun.Params,
-					DAGName: subRun.DAGName,
-				})
-			}
-			exec.SetParamsList(runParamsList)
+		if err := n.configureSubDAGExecutor(cmd, subRuns); err != nil {
+			return nil, err
 		}
 	}
 
 	return cmd, nil
+}
+
+func (n *Node) configureSubDAGExecutor(cmd executor.Executor, subRuns []SubDAGRun) error {
+	if n.Step().Parallel == nil {
+		dagExecutor, ok := cmd.(executor.DAGExecutor)
+		if !ok {
+			return fmt.Errorf("executor %T does not support sub DAG execution", cmd)
+		}
+		dagExecutor.SetParams(runParams(subRuns[0]))
+		return nil
+	}
+
+	parallelExecutor, ok := cmd.(executor.ParallelExecutor)
+	if !ok {
+		return fmt.Errorf("executor %T does not support parallel execution", cmd)
+	}
+	parallelExecutor.SetParamsList(runParamsList(subRuns))
+	return nil
+}
+
+func runParams(subRun SubDAGRun) executor.RunParams {
+	return executor.RunParams{
+		RunID:   subRun.DAGRunID,
+		Params:  subRun.Params,
+		DAGName: subRun.DAGName,
+	}
+}
+
+func runParamsList(subRuns []SubDAGRun) []executor.RunParams {
+	params := make([]executor.RunParams, 0, len(subRuns))
+	for _, subRun := range subRuns {
+		params = append(params, runParams(subRun))
+	}
+	return params
 }
 
 // evaluateCommandArgs evaluates the command and arguments of the node.
@@ -625,17 +627,14 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	s := n.Status()
-	if s == core.NodeRunning && n.cmd != nil {
-		sigsig := sig
-		if allowOverride && n.SignalOnStop() != "" {
-			sigsig = syscall.Signal(signal.GetSignalNum(n.SignalOnStop()))
-		}
+	status := n.Status()
+	if status == core.NodeRunning && n.cmd != nil {
+		killSignal := n.signalToSend(sig, allowOverride)
 		logger.Info(ctx, "Sending signal",
-			tag.Signal(sigsig.String()),
+			tag.Signal(killSignal.String()),
 			tag.Step(n.Name()),
 		)
-		if err := n.cmd.Kill(sigsig); err != nil {
+		if err := n.cmd.Kill(killSignal); err != nil {
 			logger.Error(ctx, "Failed to send signal",
 				tag.Error(err),
 				tag.Step(n.Name()),
@@ -643,18 +642,22 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 		}
 	}
 
-	if signal.IsTerminationSignalOS(sig) {
-		if s == core.NodeRunning {
-			n.SetStatus(core.NodeAborted)
-		}
+	if status == core.NodeRunning && signal.IsTerminationSignalOS(sig) {
+		n.SetStatus(core.NodeAborted)
 	}
+}
+
+func (n *Node) signalToSend(sig os.Signal, allowOverride bool) os.Signal {
+	if allowOverride && n.SignalOnStop() != "" {
+		return syscall.Signal(signal.GetSignalNum(n.SignalOnStop()))
+	}
+	return sig
 }
 
 func (n *Node) Cancel() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	s := n.Status()
-	if s == core.NodeRunning {
+	if n.Status() == core.NodeRunning {
 		n.SetStatus(core.NodeAborted)
 	}
 }
@@ -792,10 +795,9 @@ func getNextNodeID() int {
 func (n *Node) Init() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.id != 0 {
-		return
+	if n.id == 0 {
+		n.id = getNextNodeID()
 	}
-	n.id = getNextNodeID()
 }
 
 // BuildSubDAGRuns constructs the sub DAG runs based on parallel configuration

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -640,10 +640,9 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 				tag.Step(n.Name()),
 			)
 		}
-	}
-
-	if status == core.NodeRunning && signal.IsTerminationSignalOS(sig) {
-		n.SetStatus(core.NodeAborted)
+		if signal.IsTerminationSignalOS(killSignal) {
+			n.SetStatus(core.NodeAborted)
+		}
 	}
 }
 
@@ -657,7 +656,8 @@ func (n *Node) signalToSend(sig os.Signal, allowOverride bool) os.Signal {
 func (n *Node) Cancel() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.Status() == core.NodeRunning {
+	switch n.Status() {
+	case core.NodeRunning, core.NodeWaiting:
 		n.SetStatus(core.NodeAborted)
 	}
 }

--- a/internal/runtime/node_test.go
+++ b/internal/runtime/node_test.go
@@ -157,7 +157,7 @@ func TestNode(t *testing.T) {
 		go func() {
 			exec := <-execCh
 			<-exec.ready
-			node.Signal(node.Context, syscall.SIGTERM, true) // allow override signal
+			node.Signal(node.Context, syscall.Signal(0), true) // allow override signal
 		}()
 
 		node.SetStatus(core.NodeRunning)
@@ -167,6 +167,13 @@ func TestNode(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "signal: interrupt")
 		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
+	})
+	t.Run("CancelWaiting", func(t *testing.T) {
+		t.Parallel()
+
+		node := runtime.NewNode(core.Step{Name: core.NodeWaiting.String()}, runtime.NodeState{Status: core.NodeWaiting})
+		node.Cancel()
+		require.Equal(t, core.NodeAborted, node.State().Status)
 	})
 	t.Run("LogOutput", func(t *testing.T) {
 		t.Parallel()

--- a/internal/runtime/node_test.go
+++ b/internal/runtime/node_test.go
@@ -168,12 +168,27 @@ func TestNode(t *testing.T) {
 		require.Contains(t, err.Error(), "signal: interrupt")
 		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
 	})
-	t.Run("CancelWaiting", func(t *testing.T) {
+	t.Run("CancelUpdatesOnlyRunningOrWaiting", func(t *testing.T) {
 		t.Parallel()
 
-		node := runtime.NewNode(core.Step{Name: core.NodeWaiting.String()}, runtime.NodeState{Status: core.NodeWaiting})
-		node.Cancel()
-		require.Equal(t, core.NodeAborted, node.State().Status)
+		tests := []struct {
+			name   string
+			status core.NodeStatus
+			want   core.NodeStatus
+		}{
+			{name: "Running", status: core.NodeRunning, want: core.NodeAborted},
+			{name: "Waiting", status: core.NodeWaiting, want: core.NodeAborted},
+			{name: "Succeeded", status: core.NodeSucceeded, want: core.NodeSucceeded},
+			{name: "NotStarted", status: core.NodeNotStarted, want: core.NodeNotStarted},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				node := runtime.NewNode(core.Step{Name: tt.name}, runtime.NodeState{Status: tt.status})
+				node.Cancel()
+				require.Equal(t, tt.want, node.State().Status)
+			})
+		}
 	})
 	t.Run("LogOutput", func(t *testing.T) {
 		t.Parallel()

--- a/internal/service/frontend/templates.go
+++ b/internal/service/frontend/templates.go
@@ -87,15 +87,23 @@ func (srv *Server) useTemplate(ctx context.Context, layout, name string) func(ht
 	}
 
 	return func(w http.ResponseWriter, data any) {
-		var buf bytes.Buffer
-		if err := tmpl.ExecuteTemplate(&buf, baseTemplateName, data); err != nil {
+		rendered, err := executeTemplate(tmpl, baseTemplateName, data)
+		if err != nil {
 			logger.Error(ctx, "Template execution failed", tag.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = io.Copy(w, &buf)
+		_, _ = io.Copy(w, rendered)
 	}
+}
+
+func executeTemplate(tmpl *template.Template, name string, data any) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, name, data); err != nil {
+		return nil, err
+	}
+	return &buf, nil
 }
 
 // SetupRequiredChecker determines whether initial admin setup is still needed.

--- a/internal/service/frontend/templates/base.gohtml
+++ b/internal/service/frontend/templates/base.gohtml
@@ -8,8 +8,7 @@
     <link rel="icon" href="{{ basePath }}/assets/favicon.ico" />
     <title>{{ navbarTitle }}</title>
     <script>
-      function getConfig() {
-        return {
+      const getConfig = () => ({
           apiURL: "{{ apiURL }}",
           basePath: "{{ basePath }}",
           title: "{{ navbarTitle }}",
@@ -59,8 +58,7 @@
             gitSyncDir: "{{ js pathGitSyncDir }}",
             auditLogsDir: "{{ js pathAuditLogsDir }}",
           },
-        };
-      }
+        });
     </script>
     <script
       defer="defer"

--- a/internal/service/frontend/templates/base.gohtml
+++ b/internal/service/frontend/templates/base.gohtml
@@ -8,7 +8,8 @@
     <link rel="icon" href="{{ basePath }}/assets/favicon.ico" />
     <title>{{ navbarTitle }}</title>
     <script>
-      const getConfig = () => ({
+      function getConfig() {
+        return {
           apiURL: "{{ apiURL }}",
           basePath: "{{ basePath }}",
           title: "{{ navbarTitle }}",
@@ -58,7 +59,8 @@
             gitSyncDir: "{{ js pathGitSyncDir }}",
             auditLogsDir: "{{ js pathAuditLogsDir }}",
           },
-        });
+        };
+      }
     </script>
     <script
       defer="defer"

--- a/internal/service/frontend/templates/index.gohtml
+++ b/internal/service/frontend/templates/index.gohtml
@@ -1,3 +1,3 @@
 {{define "content"}}
-<div id="root"></div>
+<main id="root"></main>
 {{ end }}

--- a/internal/service/frontend/templates/index.gohtml
+++ b/internal/service/frontend/templates/index.gohtml
@@ -1,3 +1,3 @@
 {{define "content"}}
-<main id="root"></main>
+<div id="root"></div>
 {{ end }}

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -666,39 +666,43 @@ func (s *Scheduler) startRetryScanner(ctx context.Context) {
 // cronLoop runs the main scheduler loop to invoke jobs at scheduled times.
 func (s *Scheduler) cronLoop(ctx context.Context, sig chan os.Signal) {
 	tickTime := s.clock().Truncate(time.Minute)
-
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 
 	s.running.Store(true)
 	defer s.running.Store(false)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-sig:
-			return
-		case <-s.quit:
-			return
-		case <-timer.C:
-			_ = timer.Stop()
-
-			// Plan and dispatch all schedules (start, stop, restart)
-			for _, run := range s.planner.Plan(ctx, tickTime) {
-				s.dispatchRun(ctx, run)
-			}
-			s.planner.Advance(tickTime)
-
-			tickTime = s.NextTick(tickTime)
-			timer.Reset(tickTime.Sub(s.clock()))
-		}
+	for s.waitForTick(ctx, sig, timer) {
+		s.runTick(ctx, tickTime)
+		tickTime = s.NextTick(tickTime)
+		timer.Reset(tickTime.Sub(s.clock()))
 	}
+}
+
+func (s *Scheduler) waitForTick(ctx context.Context, sig chan os.Signal, timer *time.Timer) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-sig:
+		return false
+	case <-s.quit:
+		return false
+	case <-timer.C:
+		_ = timer.Stop()
+		return true
+	}
+}
+
+func (s *Scheduler) runTick(ctx context.Context, tickTime time.Time) {
+	for _, run := range s.planner.Plan(ctx, tickTime) {
+		s.dispatchRun(ctx, run)
+	}
+	s.planner.Advance(tickTime)
 }
 
 // NextTick returns the next tick time for the scheduler.
 func (*Scheduler) NextTick(now time.Time) time.Time {
-	return now.Add(time.Minute).Truncate(time.Second * 60)
+	return now.Truncate(time.Minute).Add(time.Minute)
 }
 
 // IsRunning returns whether the scheduler is currently running.
@@ -772,20 +776,21 @@ func (s *Scheduler) stopCron(ctx context.Context) {
 // we need the result to decide whether to advance the watermark).
 // Non-catchup runs are dispatched in a goroutine (process spawn can be slow).
 func (s *Scheduler) dispatchRun(ctx context.Context, run PlannedRun) {
-	dispatch := func() {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.Error(ctx, "Run dispatch panicked",
-					tag.DAG(run.DAG.Name),
-					tag.Error(panicToError(r)),
-				)
-			}
-		}()
-		s.planner.DispatchRun(ctx, run)
-	}
 	if run.TriggerType == core.TriggerTypeCatchUp {
-		dispatch()
+		s.dispatchPlannedRun(ctx, run)
 		return
 	}
-	go dispatch()
+	go s.dispatchPlannedRun(ctx, run)
+}
+
+func (s *Scheduler) dispatchPlannedRun(ctx context.Context, run PlannedRun) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(ctx, "Run dispatch panicked",
+				tag.DAG(run.DAG.Name),
+				tag.Error(panicToError(r)),
+			)
+		}
+	}()
+	s.planner.DispatchRun(ctx, run)
 }

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -684,6 +684,7 @@ func (s *Scheduler) waitForTick(ctx context.Context, sig chan os.Signal, timer *
 	case <-ctx.Done():
 		return false
 	case <-sig:
+		s.Stop(ctx)
 		return false
 	case <-s.quit:
 		return false

--- a/internal/service/scheduler/scheduler_test.go
+++ b/internal/service/scheduler/scheduler_test.go
@@ -122,14 +122,33 @@ func TestScheduler(t *testing.T) {
 		}, 5*time.Second, 10*time.Millisecond, "dispatch should have been called for start schedule")
 	})
 	t.Run("NextTick", func(t *testing.T) {
-		now := time.Date(2020, 1, 1, 1, 0, 50, 0, time.UTC)
-
 		th := test.SetupScheduler(t)
 		schedulerInstance, err := scheduler.New(th.Config, newMockJobManager(), th.DAGRunMgr, th.DAGRunStore, th.QueueStore, th.ProcStore, th.ServiceRegistry, th.CoordinatorCli, nil)
 		require.NoError(t, err)
 
-		next := schedulerInstance.NextTick(now)
-		require.Equal(t, time.Date(2020, 1, 1, 1, 1, 0, 0, time.UTC), next)
+		tests := []struct {
+			name     string
+			now      time.Time
+			expected time.Time
+		}{
+			{
+				name:     "MidMinute",
+				now:      time.Date(2020, 1, 1, 1, 0, 50, 0, time.UTC),
+				expected: time.Date(2020, 1, 1, 1, 1, 0, 0, time.UTC),
+			},
+			{
+				name:     "OnMinuteBoundary",
+				now:      time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC),
+				expected: time.Date(2020, 1, 1, 1, 1, 0, 0, time.UTC),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				next := schedulerInstance.NextTick(tt.now)
+				require.Equal(t, tt.expected, next)
+			})
+		}
 	})
 }
 

--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForTickSignalStopsScheduler(t *testing.T) {
+	t.Parallel()
+
+	sc := &Scheduler{
+		entryReader:    &staticEntryReader{},
+		quit:           make(chan any),
+		queueProcessor: NewQueueProcessor(nil, nil, nil, nil, config.Queues{}),
+		planner:        &TickPlanner{},
+	}
+
+	sig := make(chan os.Signal, 1)
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	sig <- syscall.SIGTERM
+	require.False(t, sc.waitForTick(context.Background(), sig, timer))
+
+	select {
+	case <-sc.quit:
+	default:
+		t.Fatal("expected scheduler quit channel to close on signal")
+	}
+}

--- a/internal/testdata/runtime/runner/testfile.sh
+++ b/internal/testdata/runtime/runner/testfile.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if [ -f "$1" ]; then
-    echo "file exists"
-    exit 0
-fi
-echo "file not found"
-exit 1
+test -f "$1" || {
+    echo "file not found"
+    exit 1
+}
+
+echo "file exists"


### PR DESCRIPTION
## Summary

- simplify DAG loading and execution-path control flow across socket, mailer, persistence, runtime, and scheduler boundaries
- add characterization coverage for socket response handling, multi-document DAG provenance, and writer lifecycle
- clean up a small set of shared core helpers, frontend template plumbing, and test fixtures while preserving intended behavior

## Verification

- go test ./internal/cmn/sock -count=1
- go test ./internal/cmn/mailer -count=1
- go test ./internal/core/spec -count=1
- go test ./internal/persis/filedagrun -count=1
- go test ./internal/runtime/... -count=1
- go test ./internal/service/scheduler -count=1
- go test ./internal/core -count=1
- go test ./internal/service/frontend -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timeout detection and error messaging for network operations
  * Enhanced nil-safety checks in mail reporting
  * Fixed multi-document YAML payload separation in DAG loading

* **New Features**
  * Added comprehensive response buffering for improved HTTP handling

* **Improvements**
  * Refined scheduler tick timing calculations
  * Enhanced mail report HTML formatting with better structure
  * Optimized condition concurrency with read-write locking
  * Improved DAG specification loading and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->