### PR TITLE
refactor: isolate manifest decoding and standardize local transport

### DIFF
--- a/internal/cmn/sock/client.go
+++ b/internal/cmn/sock/client.go
@@ -4,12 +4,14 @@
 package sock
 
 import (
-	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -27,44 +29,71 @@ func NewClient(addr string) *Client {
 	return &Client{addr: addr}
 }
 
-const (
-	defaultTimeout = time.Millisecond * 3000
-)
+const defaultTimeout = 3 * time.Second
 
 func wrapTimeout(op string, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("%s: %w", op, ErrTimeout)
+	}
+
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return fmt.Errorf("%s: %w", op, ErrTimeout)
 	}
+
 	return fmt.Errorf("%s: %w", op, err)
 }
 
+func normalizePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}
+
+func (cl *Client) httpClient() *http.Client {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			dialer := &net.Dialer{Timeout: defaultTimeout}
+			conn, err := dialer.DialContext(ctx, "unix", cl.addr)
+			if err != nil {
+				return nil, wrapTimeout("dial unix socket", err)
+			}
+			return conn, nil
+		},
+		DisableCompression: true,
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   defaultTimeout,
+	}
+}
+
 // Request sends a request to the frontend and returns the response.
-func (cl *Client) Request(method, url string) (string, error) {
-	conn, err := net.DialTimeout("unix", cl.addr, defaultTimeout)
-	if err != nil {
-		return "", fmt.Errorf("dial unix socket: %w", err)
-	}
-	defer func() {
-		_ = conn.Close()
-	}()
+func (cl *Client) Request(method, path string) (string, error) {
+	client := cl.httpClient()
+	defer client.CloseIdleConnections()
 
-	if err := conn.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
-		return "", fmt.Errorf("set connection deadline: %w", err)
+	requestURL := &url.URL{
+		Scheme: "http",
+		Host:   "unix",
+		Path:   normalizePath(path),
 	}
-
-	request, err := http.NewRequest(method, url, nil)
+	request, err := http.NewRequest(method, requestURL.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}
 
-	if err := request.Write(conn); err != nil {
-		return "", wrapTimeout("write request", err)
-	}
-
-	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	response, err := client.Do(request)
 	if err != nil {
-		return "", wrapTimeout("read response", err)
+		return "", wrapTimeout("send request", err)
 	}
 	defer func() {
 		_ = response.Body.Close()

--- a/internal/cmn/sock/client.go
+++ b/internal/cmn/sock/client.go
@@ -22,15 +22,32 @@ var (
 // Client is a unix socket client that can send requests
 // to the frontend over HTTP.
 type Client struct {
-	addr string
+	addr   string
+	client *http.Client
 }
 
+// NewClient creates a unix socket HTTP client with a reusable transport.
 func NewClient(addr string) *Client {
-	return &Client{addr: addr}
+	cl := &Client{addr: addr}
+	cl.client = &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, "unix", cl.addr)
+				if err != nil {
+					return nil, wrapTimeout("dial unix socket", err)
+				}
+				return conn, nil
+			},
+			DisableCompression: true,
+		},
+		Timeout: defaultTimeout,
+	}
+	return cl
 }
 
 const defaultTimeout = 3 * time.Second
 
+// wrapTimeout normalizes timeout errors to the exported socket timeout sentinel.
 func wrapTimeout(op string, err error) error {
 	switch {
 	case err == nil:
@@ -47,6 +64,7 @@ func wrapTimeout(op string, err error) error {
 	return fmt.Errorf("%s: %w", op, err)
 }
 
+// normalizePath ensures requests always use an absolute HTTP path.
 func normalizePath(path string) string {
 	if path == "" {
 		return "/"
@@ -57,30 +75,8 @@ func normalizePath(path string) string {
 	return "/" + path
 }
 
-func (cl *Client) httpClient() *http.Client {
-	transport := &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			dialer := &net.Dialer{Timeout: defaultTimeout}
-			conn, err := dialer.DialContext(ctx, "unix", cl.addr)
-			if err != nil {
-				return nil, wrapTimeout("dial unix socket", err)
-			}
-			return conn, nil
-		},
-		DisableCompression: true,
-	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   defaultTimeout,
-	}
-}
-
 // Request sends a request to the frontend and returns the response.
 func (cl *Client) Request(method, path string) (string, error) {
-	client := cl.httpClient()
-	defer client.CloseIdleConnections()
-
 	requestURL := &url.URL{
 		Scheme: "http",
 		Host:   "unix",
@@ -91,7 +87,7 @@ func (cl *Client) Request(method, path string) (string, error) {
 		return "", fmt.Errorf("build request: %w", err)
 	}
 
-	response, err := client.Do(request)
+	response, err := cl.client.Do(request)
 	if err != nil {
 		return "", wrapTimeout("send request", err)
 	}

--- a/internal/cmn/sock/client_internal_test.go
+++ b/internal/cmn/sock/client_internal_test.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientInitializesReusableHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("unix.sock")
+
+	require.NotNil(t, client.client)
+	require.Equal(t, defaultTimeout, client.client.Timeout)
+	require.NotNil(t, client.client.Transport)
+}

--- a/internal/cmn/sock/client_internal_test.go
+++ b/internal/cmn/sock/client_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestNewClientInitializesReusableHTTPClient verifies the cached HTTP client setup.
 func TestNewClientInitializesReusableHTTPClient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
@@ -20,6 +21,8 @@ import (
 var ErrServerRequestedShutdown = errors.New(
 	"socket frontend is requested to shutdown",
 )
+
+const idleTimeout = 30 * time.Second
 
 // Server is a unix socket frontend that passes http requests to HandlerFunc.
 type Server struct {
@@ -58,12 +61,7 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 		return err
 	}
 
-	httpServer := &http.Server{
-		Handler: srv.httpHandler(ctx),
-		BaseContext: func(net.Listener) context.Context {
-			return ctx
-		},
-	}
+	httpServer := srv.newHTTPServer(ctx)
 
 	if !srv.install(listener, httpServer) {
 		if listen != nil {
@@ -85,18 +83,25 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 	}()
 
 	err = httpServer.Serve(listener)
-	switch {
-	case err == nil && srv.quit.Load():
+	if isClosedServerError(err) && srv.quit.Load() {
 		return ErrServerRequestedShutdown
-	case isClosedServerError(err) && srv.quit.Load():
-		return ErrServerRequestedShutdown
-	case err == nil:
-		return nil
-	default:
-		return err
+	}
+	return err
+}
+
+// newHTTPServer builds the HTTP server used for unix socket requests.
+func (srv *Server) newHTTPServer(ctx context.Context) *http.Server {
+	return &http.Server{
+		Handler:           srv.httpHandler(ctx),
+		ReadHeaderTimeout: defaultTimeout,
+		IdleTimeout:       idleTimeout,
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
 	}
 }
 
+// httpHandler adapts the raw handler and recovers panics into HTTP 500 responses.
 func (srv *Server) httpHandler(ctx context.Context) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -114,7 +119,6 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 	srv.mu.Lock()
 	srv.quit.Store(true)
 	httpServer := srv.httpServer
-	listener := srv.listener
 	srv.httpServer = nil
 	srv.listener = nil
 	srv.mu.Unlock()
@@ -127,16 +131,10 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	if listener != nil {
-		if err := listener.Close(); err != nil && !isClosedServerError(err) {
-			logger.Error(ctx, "Failed to close listener", tag.Error(err))
-			return err
-		}
-	}
-
 	return nil
 }
 
+// install records the live listener/server pair if shutdown has not started.
 func (srv *Server) install(listener net.Listener, httpServer *http.Server) bool {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
@@ -148,6 +146,7 @@ func (srv *Server) install(listener net.Listener, httpServer *http.Server) bool 
 	return true
 }
 
+// clear drops the listener/server pair that finished serving.
 func (srv *Server) clear(listener net.Listener, httpServer *http.Server) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
@@ -159,6 +158,7 @@ func (srv *Server) clear(listener net.Listener, httpServer *http.Server) {
 	}
 }
 
+// isClosedServerError reports whether an error is expected during graceful shutdown.
 func isClosedServerError(err error) bool {
 	return errors.Is(err, http.ErrServerClosed) ||
 		errors.Is(err, net.ErrClosed) ||

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -4,11 +4,8 @@
 package sock
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -28,10 +25,12 @@ var ErrServerRequestedShutdown = errors.New(
 type Server struct {
 	addr        string
 	handlerFunc HTTPHandlerFunc
-	listener    net.Listener
-	quit        atomic.Bool
-	connWG      sync.WaitGroup
-	mu          sync.Mutex
+
+	listener   net.Listener
+	httpServer *http.Server
+
+	quit atomic.Bool
+	mu   sync.Mutex
 }
 
 // HTTPHandlerFunc is a function that handles HTTP requests.
@@ -58,7 +57,15 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 		}
 		return err
 	}
-	if !srv.setListener(listener) {
+
+	httpServer := &http.Server{
+		Handler: srv.httpHandler(ctx),
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	if !srv.install(listener, httpServer) {
 		if listen != nil {
 			listen <- nil
 		}
@@ -66,136 +73,94 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 		_ = os.Remove(srv.addr)
 		return ErrServerRequestedShutdown
 	}
+
 	if listen != nil {
 		listen <- nil
 	}
-	logger.Debug(ctx, "Unix socket is listening",
-		tag.Addr(srv.addr))
+	logger.Debug(ctx, "Unix socket is listening", tag.Addr(srv.addr))
 
 	defer func() {
-		srv.clearListener(listener)
-		_ = srv.Shutdown(ctx)
+		srv.clear(listener, httpServer)
 		_ = os.Remove(srv.addr)
 	}()
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			if srv.quit.Load() {
-				return ErrServerRequestedShutdown
-			}
-			return err
-		}
-		srv.connWG.Add(1)
-		go srv.serveConn(ctx, conn)
+
+	err = httpServer.Serve(listener)
+	switch {
+	case err == nil && srv.quit.Load():
+		return ErrServerRequestedShutdown
+	case isClosedServerError(err) && srv.quit.Load():
+		return ErrServerRequestedShutdown
+	case err == nil:
+		return nil
+	default:
+		return err
 	}
 }
 
-func (srv *Server) serveConn(ctx context.Context, conn net.Conn) {
-	defer func() {
-		srv.connWG.Done()
-		_ = conn.Close()
-	}()
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			logger.Error(ctx, "Socket handler panicked", slog.Any("panic", recovered))
-		}
-	}()
-
-	request, err := http.ReadRequest(bufio.NewReader(conn))
-	if err != nil {
-		logger.Error(ctx, "Failed to read request", tag.Error(err))
-		return
-	}
-	defer func() {
-		_ = request.Body.Close()
-	}()
-
-	writer := newHTTPResponseWriter(conn)
-	srv.handlerFunc(writer, request)
-	if err := writer.flush(); err != nil {
-		logger.Error(ctx, "Failed to write response", tag.Error(err))
-	}
+func (srv *Server) httpHandler(ctx context.Context) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logger.Error(ctx, "Socket handler panicked", slog.Any("panic", recovered))
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+		}()
+		srv.handlerFunc(w, r)
+	})
 }
 
 // Shutdown stops the frontend.
 func (srv *Server) Shutdown(ctx context.Context) error {
 	srv.mu.Lock()
-	if !srv.quit.Load() {
-		srv.quit.Store(true)
-	}
+	srv.quit.Store(true)
+	httpServer := srv.httpServer
 	listener := srv.listener
+	srv.httpServer = nil
 	srv.listener = nil
 	srv.mu.Unlock()
 
-	if listener != nil {
-		err := listener.Close()
-		if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, os.ErrClosed) {
-			logger.Error(ctx, "Failed to close listener",
-				tag.Error(err))
+	if httpServer != nil {
+		if err := httpServer.Shutdown(ctx); err != nil && !isClosedServerError(err) {
+			logger.Error(ctx, "Failed to shutdown HTTP server", tag.Error(err))
+			return err
 		}
-		if err != nil {
+		return nil
+	}
+
+	if listener != nil {
+		if err := listener.Close(); err != nil && !isClosedServerError(err) {
+			logger.Error(ctx, "Failed to close listener", tag.Error(err))
 			return err
 		}
 	}
-	srv.connWG.Wait()
+
 	return nil
 }
 
-func (srv *Server) setListener(listener net.Listener) bool {
+func (srv *Server) install(listener net.Listener, httpServer *http.Server) bool {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	if srv.quit.Load() {
 		return false
 	}
 	srv.listener = listener
+	srv.httpServer = httpServer
 	return true
 }
 
-func (srv *Server) clearListener(listener net.Listener) {
+func (srv *Server) clear(listener net.Listener, httpServer *http.Server) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	if srv.listener == listener {
 		srv.listener = nil
 	}
-}
-
-var _ http.ResponseWriter = (*httpResponseWriter)(nil)
-
-type httpResponseWriter struct {
-	conn       net.Conn
-	header     http.Header
-	statusCode int
-	body       bytes.Buffer
-}
-
-func newHTTPResponseWriter(conn net.Conn) *httpResponseWriter {
-	return &httpResponseWriter{
-		conn:       conn,
-		header:     make(http.Header),
-		statusCode: http.StatusOK,
+	if srv.httpServer == httpServer {
+		srv.httpServer = nil
 	}
 }
 
-func (w *httpResponseWriter) Write(data []byte) (int, error) {
-	return w.body.Write(data)
-}
-
-func (w *httpResponseWriter) flush() error {
-	response := http.Response{
-		StatusCode:    w.statusCode,
-		ProtoMajor:    1,
-		ProtoMinor:    0,
-		Body:          io.NopCloser(bytes.NewReader(w.body.Bytes())),
-		Header:        w.header.Clone(),
-		ContentLength: int64(w.body.Len()),
-	}
-	return response.Write(w.conn)
-}
-
-func (w *httpResponseWriter) Header() http.Header {
-	return w.header
-}
-
-func (w *httpResponseWriter) WriteHeader(statusCode int) {
-	w.statusCode = statusCode
+func isClosedServerError(err error) bool {
+	return errors.Is(err, http.ErrServerClosed) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, os.ErrClosed)
 }

--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -106,7 +107,12 @@ func (srv *Server) httpHandler(ctx context.Context) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				logger.Error(ctx, "Socket handler panicked", slog.Any("panic", recovered))
+				logger.Error(
+					ctx,
+					"Socket handler panicked",
+					slog.Any("panic", recovered),
+					slog.String("stack", string(debug.Stack())),
+				)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 		}()

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -5,20 +5,15 @@ package sock
 
 import (
 	"context"
-	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestServeConnRecoversFromHandlerPanic(t *testing.T) {
+func TestHTTPHandlerRecoversFromHandlerPanic(t *testing.T) {
 	t.Parallel()
-
-	serverConn, clientConn := net.Pipe()
-	defer func() {
-		_ = clientConn.Close()
-	}()
 
 	srv, err := NewServer(
 		"ignored",
@@ -28,16 +23,11 @@ func TestServeConnRecoversFromHandlerPanic(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, "/", nil)
-	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
 
-	go func() {
-		_ = request.Write(clientConn)
-		_ = clientConn.Close()
-	}()
-
-	srv.connWG.Add(1)
 	require.NotPanics(t, func() {
-		srv.serveConn(context.Background(), serverConn)
+		srv.httpHandler(context.Background()).ServeHTTP(recorder, request)
 	})
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
 }

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -4,14 +4,17 @@
 package sock
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/stretchr/testify/require"
 )
 
+// TestHTTPHandlerRecoversFromHandlerPanic verifies panic recovery logs context and returns HTTP 500.
 func TestHTTPHandlerRecoversFromHandlerPanic(t *testing.T) {
 	t.Parallel()
 
@@ -23,15 +26,28 @@ func TestHTTPHandlerRecoversFromHandlerPanic(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	var logs bytes.Buffer
+	ctx := logger.WithLogger(
+		context.Background(),
+		logger.NewLogger(
+			logger.WithQuiet(),
+			logger.WithFormat("text"),
+			logger.WithWriter(&logs),
+		),
+	)
+
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	recorder := httptest.NewRecorder()
 
 	require.NotPanics(t, func() {
-		srv.httpHandler(context.Background()).ServeHTTP(recorder, request)
+		srv.httpHandler(ctx).ServeHTTP(recorder, request)
 	})
 	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.Contains(t, logs.String(), "panic=boom")
+	require.Contains(t, logs.String(), "stack=")
 }
 
+// TestNewHTTPServerConfiguresTimeouts verifies the unix socket server installs defensive timeouts.
 func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -31,3 +31,17 @@ func TestHTTPHandlerRecoversFromHandlerPanic(t *testing.T) {
 	})
 	require.Equal(t, http.StatusInternalServerError, recorder.Code)
 }
+
+func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewServer(
+		"ignored",
+		func(http.ResponseWriter, *http.Request) {},
+	)
+	require.NoError(t, err)
+
+	httpServer := srv.newHTTPServer(context.Background())
+	require.Equal(t, defaultTimeout, httpServer.ReadHeaderTimeout)
+	require.Equal(t, idleTimeout, httpServer.IdleTimeout)
+}

--- a/internal/cmn/sock/server_test.go
+++ b/internal/cmn/sock/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMain installs an isolated HOME directory for socket integration tests.
 func TestMain(m *testing.M) {
 	testHomeDir, err := os.MkdirTemp("", "controller_test")
 	if err != nil {
@@ -30,6 +31,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// TestStartAndShutdownServer verifies the server accepts requests and shuts down cleanly.
 func TestStartAndShutdownServer(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_server_start_shutdown")
 	require.NoError(t, err)
@@ -72,6 +74,7 @@ func TestStartAndShutdownServer(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+// TestHeaderOnlyResponse verifies responses without a body are preserved over the unix socket transport.
 func TestHeaderOnlyResponse(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_error_response")
 	require.NoError(t, err)
@@ -123,6 +126,7 @@ func TestHeaderOnlyResponse(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+// TestEmptyResponse verifies empty HTTP responses round-trip without synthetic data.
 func TestEmptyResponse(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_error_response")
 	require.NoError(t, err)
@@ -155,6 +159,7 @@ func TestEmptyResponse(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+// TestShutdownWhileServerStarts verifies shutdown wins even if serving has only just started.
 func TestShutdownWhileServerStarts(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_shutdown_while_server_starts")
 	require.NoError(t, err)
@@ -191,6 +196,7 @@ func TestShutdownWhileServerStarts(t *testing.T) {
 	}
 }
 
+// TestMultipleWritesProduceSingleResponseBody verifies multiple handler writes are concatenated once.
 func TestMultipleWritesProduceSingleResponseBody(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_server_multiple_writes")
 	require.NoError(t, err)
@@ -227,6 +233,7 @@ func TestMultipleWritesProduceSingleResponseBody(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+// TestResponseHeadersAreReturnedToClient verifies response headers survive the unix socket transport.
 func TestResponseHeadersAreReturnedToClient(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_server_response_headers")
 	require.NoError(t, err)
@@ -281,6 +288,7 @@ func TestResponseHeadersAreReturnedToClient(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+// TestShutdownWaitsForActiveHandlers verifies graceful shutdown waits for in-flight handlers to finish.
 func TestShutdownWaitsForActiveHandlers(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_server_shutdown_waits_for_handlers")
 	require.NoError(t, err)

--- a/internal/cmn/sock/server_test.go
+++ b/internal/cmn/sock/server_test.go
@@ -227,6 +227,60 @@ func TestMultipleWritesProduceSingleResponseBody(t *testing.T) {
 	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
 }
 
+func TestResponseHeadersAreReturnedToClient(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test_server_response_headers")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	unixServer, err := sock.NewServer(
+		tmpFile.Name(),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("X-Dagu-Test", "present")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte("accepted"))
+		},
+	)
+	require.NoError(t, err)
+
+	listen := make(chan error, 1)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- unixServer.Serve(context.Background(), listen)
+	}()
+
+	require.NoError(t, <-listen)
+
+	conn, err := net.DialTimeout("unix", tmpFile.Name(), 3*time.Second)
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(3*time.Second)))
+
+	request, err := http.NewRequest(http.MethodGet, "/headers", nil)
+	require.NoError(t, err)
+	require.NoError(t, request.Write(conn))
+
+	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	require.NoError(t, err)
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, response.StatusCode)
+	require.Equal(t, "present", response.Header.Get("X-Dagu-Test"))
+	require.Equal(t, "accepted", string(body))
+
+	require.NoError(t, unixServer.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
+}
+
 func TestShutdownWaitsForActiveHandlers(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test_server_shutdown_waits_for_handlers")
 	require.NoError(t, err)

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -842,38 +842,12 @@ func readYAMLFile(file string) (cfg map[string]any, err error) {
 
 // unmarshalData unmarshals the data into a map.
 func unmarshalData(data []byte) (map[string]any, error) {
-	var cm map[string]any
-	err := yaml.NewDecoder(bytes.NewReader(data)).Decode(&cm)
-	if errors.Is(err, io.EOF) {
-		err = nil
-	}
-
-	return cm, err
+	return newManifestDecoder().Unmarshal(data)
 }
 
 // decode decodes the configuration map into a manifest.
 func decode(cm map[string]any) (*dag, error) {
-	if _, hasLabels := cm["labels"]; hasLabels {
-		if _, hasTags := cm["tags"]; hasTags {
-			return nil, fmt.Errorf("labels and deprecated tags cannot both be set")
-		}
-	}
-
-	c := new(dag)
-	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: true,
-		Result:      c,
-		TagName:     "yaml",
-		DecodeHook:  TypedUnionDecodeHook(),
-	})
-	err := md.Decode(cm)
-	err = withSnakeCaseKeyHint(err)
-	if err == nil {
-		c.handlerOnRaw = extractRawHandlerOn(cm)
-		c.defaultsRaw = extractRawDefaults(cm)
-	}
-
-	return c, err
+	return newManifestDecoder().Decode(cm)
 }
 
 func extractRawHandlerOn(cm map[string]any) map[string]map[string]any {

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -242,6 +242,7 @@ func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.D
 	return mainDAG, nil
 }
 
+// loadYAMLFailure returns a placeholder DAG when YAML loading is allowed to fail.
 func loadYAMLFailure(opts BuildOpts, err error) (*core.DAG, error) {
 	if dag := buildLoadErrorDAG(opts, "", err); dag != nil {
 		return dag, nil
@@ -249,6 +250,7 @@ func loadYAMLFailure(opts BuildOpts, err error) (*core.DAG, error) {
 	return nil, core.ErrorList{err}
 }
 
+// buildLoadErrorDAG creates a placeholder DAG when build errors are allowed.
 func buildLoadErrorDAG(opts BuildOpts, filePath string, err error) *core.DAG {
 	if !opts.Has(BuildFlagAllowBuildErrors) {
 		return nil
@@ -330,6 +332,7 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 	return mainDAG, nil
 }
 
+// loadDAGFailure returns a placeholder DAG when file loading is allowed to fail.
 func loadDAGFailure(ctx BuildContext, filePath string, err error) (*core.DAG, error) {
 	if dag := buildLoadErrorDAG(ctx.opts, filePath, err); dag != nil {
 		return dag, nil
@@ -337,6 +340,7 @@ func loadDAGFailure(ctx BuildContext, filePath string, err error) (*core.DAG, er
 	return nil, err
 }
 
+// assembleLoadedDAGs returns the first DAG and attaches later documents as locals.
 func assembleLoadedDAGs(dags []*core.DAG, emptyErr error) (*core.DAG, error) {
 	if len(dags) == 0 {
 		return nil, emptyErr
@@ -350,6 +354,7 @@ func assembleLoadedDAGs(dags []*core.DAG, emptyErr error) (*core.DAG, error) {
 	return mainDAG, nil
 }
 
+// attachLocalDAGs registers secondary documents as named local DAGs.
 func attachLocalDAGs(mainDAG *core.DAG, localDAGs []*core.DAG) error {
 	if len(localDAGs) == 0 {
 		return nil
@@ -366,6 +371,7 @@ func attachLocalDAGs(mainDAG *core.DAG, localDAGs []*core.DAG) error {
 	return nil
 }
 
+// applyWorkingDirFallback sets a working directory when the manifest omits one.
 func applyWorkingDirFallback(dag *core.DAG, filePath string) error {
 	if dag.WorkingDir != "" {
 		dag.WorkingDirExplicit = true
@@ -399,6 +405,7 @@ type dagDocument struct {
 	data  map[string]any
 }
 
+// loadDAGsFromData builds DAGs from every non-empty YAML document in the input.
 func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *dag) ([]*core.DAG, error) {
 	docs, err := decodeDocuments(data)
 	if err != nil {
@@ -420,6 +427,7 @@ func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *d
 	return dags, nil
 }
 
+// decodeDocuments splits a YAML stream into non-empty manifest documents.
 func decodeDocuments(data []byte) ([]dagDocument, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	docs := make([]dagDocument, 0, 1)
@@ -440,6 +448,7 @@ func decodeDocuments(data []byte) ([]dagDocument, error) {
 	}
 }
 
+// loadBaseDefinition loads and decodes the optional base manifest.
 func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
 	if opts.Has(BuildFlagOnlyMetadata) {
 		return nil, nil, nil
@@ -457,6 +466,7 @@ func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
 	return baseDef, baseRaw, nil
 }
 
+// readBaseDefinitionData returns the raw bytes and label for the base manifest.
 func readBaseDefinitionData(opts BuildOpts) ([]byte, string, error) {
 	if len(opts.BaseConfigContent) > 0 {
 		return opts.BaseConfigContent, "embedded base config", nil
@@ -475,6 +485,7 @@ func readBaseDefinitionData(opts BuildOpts) ([]byte, string, error) {
 	return baseRaw, "base config", nil
 }
 
+// decodeDefinitionData parses manifest data into the internal dag definition.
 func decodeDefinitionData(data []byte, description string) (*dag, error) {
 	raw, err := unmarshalData(data)
 	if err != nil {
@@ -526,6 +537,7 @@ func processDAGDocument(
 	return dest, nil
 }
 
+// buildDocumentContext applies per-document overrides for multi-DAG files.
 func buildDocumentContext(ctx BuildContext, index int) BuildContext {
 	ctx.index = index
 	if index == 0 {
@@ -539,6 +551,7 @@ func buildDocumentContext(ctx BuildContext, index int) BuildContext {
 	return ctx.WithOpts(opts)
 }
 
+// prepareDocumentContext builds the inherited context and destination DAG.
 func prepareDocumentContext(ctx BuildContext, baseDef, spec *dag) (BuildContext, *core.DAG, error) {
 	customStepTypes, err := buildCustomStepTypeRegistry(stepTypesOf(baseDef), stepTypesOf(spec))
 	if err != nil {
@@ -559,6 +572,7 @@ func prepareDocumentContext(ctx BuildContext, baseDef, spec *dag) (BuildContext,
 	return ctx, baseDAG, nil
 }
 
+// buildDocumentBase builds the reusable base DAG and decoded defaults.
 func buildDocumentBase(ctx BuildContext, baseDef *dag) (*core.DAG, *defaults, error) {
 	baseDAG, err := buildBaseDAG(ctx, baseDef)
 	if err != nil {
@@ -573,6 +587,7 @@ func buildDocumentBase(ctx BuildContext, baseDef *dag) (*core.DAG, *defaults, er
 	return baseDAG, baseDefaults, nil
 }
 
+// documentYAML returns the YAML payload stored for a specific document.
 func documentYAML(index int, doc map[string]any, fullData []byte) ([]byte, error) {
 	if index == 0 {
 		return fullData, nil
@@ -605,6 +620,7 @@ func buildBaseDAG(ctx BuildContext, baseDef *dag) (*core.DAG, error) {
 	return baseDAG, nil
 }
 
+// stepTypesOf returns the custom step type declarations for a manifest.
 func stepTypesOf(d *dag) map[string]customStepTypeSpec {
 	if d == nil {
 		return nil
@@ -612,6 +628,7 @@ func stepTypesOf(d *dag) map[string]customStepTypeSpec {
 	return d.StepTypes
 }
 
+// shouldInheritType reports whether a document should reuse the base DAG type.
 func shouldInheritType(doc map[string]any, baseDef, spec *dag) bool {
 	if baseDef == nil || spec == nil {
 		return false
@@ -683,6 +700,7 @@ func resolveYamlFilePath(ctx BuildContext, file string) (string, error) {
 	return filepath.Abs(file)
 }
 
+// expandHomeDir expands a leading tilde when the caller used a home-relative path.
 func expandHomeDir(file string) string {
 	if file != "~" && !strings.HasPrefix(file, "~/") && !strings.HasPrefix(file, `~\`) {
 		return file
@@ -699,6 +717,7 @@ type mergeTransformer struct{}
 
 var _ mergo.Transformers = (*mergeTransformer)(nil)
 
+// Transformer customizes merge behavior for fields that need non-default semantics.
 func (*mergeTransformer) Transformer(
 	typ reflect.Type,
 ) func(dst, src reflect.Value) error {
@@ -850,6 +869,7 @@ func decode(cm map[string]any) (*dag, error) {
 	return newManifestDecoder().Decode(cm)
 }
 
+// extractRawHandlerOn copies raw handler definitions for later processing.
 func extractRawHandlerOn(cm map[string]any) map[string]map[string]any {
 	rawHandlers, ok := cm["handler_on"].(map[string]any)
 	if !ok || len(rawHandlers) == 0 {
@@ -870,6 +890,7 @@ func extractRawHandlerOn(cm map[string]any) map[string]map[string]any {
 	return cloned
 }
 
+// extractRawDefaults copies raw defaults from the decoded manifest map.
 func extractRawDefaults(cm map[string]any) map[string]any {
 	rawDefaults, ok := cm["defaults"].(map[string]any)
 	if !ok || len(rawDefaults) == 0 {

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -4,6 +4,7 @@
 package spec
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,4 +26,81 @@ func TestExpandHomeDir(t *testing.T) {
 		filepath.Clean(expandHomeDir("~/dags/test.yaml")),
 	)
 	assert.Equal(t, "~alice/dags/test.yaml", expandHomeDir("~alice/dags/test.yaml"))
+}
+
+func TestUnmarshalData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyDocument", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := unmarshalData(nil)
+		require.NoError(t, err)
+		assert.Nil(t, data)
+	})
+
+	t.Run("RejectsMalformedYAML", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := unmarshalData([]byte("steps: ["))
+		require.Error(t, err)
+	})
+}
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RejectsLabelsAndTagsTogether", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := decode(map[string]any{
+			"labels": map[string]any{"team": "core"},
+			"tags":   []any{"legacy"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "labels and deprecated tags cannot both be set")
+	})
+
+	t.Run("CapturesRawHandlerOnAndDefaults", func(t *testing.T) {
+		t.Parallel()
+
+		manifest, err := decode(map[string]any{
+			"steps": []any{
+				map[string]any{
+					"name":    "step-1",
+					"command": "echo hello",
+				},
+			},
+			"handler_on": map[string]any{
+				"failure": map[string]any{
+					"command": "echo fail",
+				},
+			},
+			"defaults": map[string]any{
+				"shell": "bash",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, manifest)
+		require.Contains(t, manifest.handlerOnRaw, "failure")
+		require.Equal(t, "echo fail", manifest.handlerOnRaw["failure"]["command"])
+		require.Equal(t, "bash", manifest.defaultsRaw["shell"])
+	})
+
+	t.Run("ReportsUnknownKeys", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := decode(map[string]any{
+			"steps": []any{
+				map[string]any{
+					"name":    "step-1",
+					"command": "echo hello",
+				},
+			},
+			"unknown_key": true,
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNameOrPathRequired))
+		assert.Contains(t, err.Error(), "unknown_key")
+	})
 }

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -104,3 +104,12 @@ func TestDecode(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown_key")
 	})
 }
+
+func TestNewManifestDecoderSharesInstance(t *testing.T) {
+	t.Parallel()
+
+	first := newManifestDecoder()
+	second := newManifestDecoder()
+
+	require.Same(t, first, second)
+}

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestExpandHomeDir verifies the loader expands only the current user's home shorthand.
 func TestExpandHomeDir(t *testing.T) {
 	t.Parallel()
 
@@ -28,6 +29,7 @@ func TestExpandHomeDir(t *testing.T) {
 	assert.Equal(t, "~alice/dags/test.yaml", expandHomeDir("~alice/dags/test.yaml"))
 }
 
+// TestUnmarshalData verifies manifest decoding handles empty and malformed YAML inputs.
 func TestUnmarshalData(t *testing.T) {
 	t.Parallel()
 
@@ -47,6 +49,7 @@ func TestUnmarshalData(t *testing.T) {
 	})
 }
 
+// TestDecode verifies manifest decoding preserves raw fields and surfaces validation errors.
 func TestDecode(t *testing.T) {
 	t.Parallel()
 
@@ -105,6 +108,7 @@ func TestDecode(t *testing.T) {
 	})
 }
 
+// TestNewManifestDecoderSharesInstance verifies callers reuse the shared decoder instance.
 func TestNewManifestDecoderSharesInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/manifest_decoder.go
+++ b/internal/core/spec/manifest_decoder.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/goccy/go-yaml"
+)
+
+type manifestDecoder struct {
+	decodeHook mapstructure.DecodeHookFunc
+}
+
+func newManifestDecoder() *manifestDecoder {
+	return &manifestDecoder{
+		decodeHook: TypedUnionDecodeHook(),
+	}
+}
+
+func (d *manifestDecoder) Unmarshal(data []byte) (map[string]any, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	parsed := make(map[string]any)
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&parsed); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if len(parsed) == 0 {
+		return nil, nil
+	}
+	return parsed, nil
+}
+
+func (d *manifestDecoder) Decode(input map[string]any) (*dag, error) {
+	if err := validateManifestAliases(input); err != nil {
+		return nil, err
+	}
+
+	decoded := new(dag)
+	mapDecoder, err := d.newMapDecoder(decoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := withSnakeCaseKeyHint(mapDecoder.Decode(input)); err != nil {
+		return nil, err
+	}
+
+	decoded.handlerOnRaw = extractRawHandlerOn(input)
+	decoded.defaultsRaw = extractRawDefaults(input)
+	return decoded, nil
+}
+
+func (d *manifestDecoder) newMapDecoder(target *dag) (*mapstructure.Decoder, error) {
+	return mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      target,
+		TagName:     "yaml",
+		DecodeHook:  d.decodeHook,
+	})
+}
+
+func validateManifestAliases(input map[string]any) error {
+	if _, hasLabels := input["labels"]; hasLabels {
+		if _, hasTags := input["tags"]; hasTags {
+			return fmt.Errorf("labels and deprecated tags cannot both be set")
+		}
+	}
+	return nil
+}

--- a/internal/core/spec/manifest_decoder.go
+++ b/internal/core/spec/manifest_decoder.go
@@ -6,23 +6,27 @@ package spec
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/goccy/go-yaml"
 )
 
+// manifestDecoder converts raw YAML maps into internal manifest structures.
 type manifestDecoder struct {
 	decodeHook mapstructure.DecodeHookFunc
 }
 
-func newManifestDecoder() *manifestDecoder {
-	return &manifestDecoder{
-		decodeHook: TypedUnionDecodeHook(),
-	}
+var defaultManifestDecoder = &manifestDecoder{
+	decodeHook: TypedUnionDecodeHook(),
 }
 
+// newManifestDecoder returns the shared manifest decoder instance.
+func newManifestDecoder() *manifestDecoder {
+	return defaultManifestDecoder
+}
+
+// Unmarshal decodes raw YAML bytes into a generic manifest map.
 func (d *manifestDecoder) Unmarshal(data []byte) (map[string]any, error) {
 	if len(data) == 0 {
 		return nil, nil
@@ -43,6 +47,7 @@ func (d *manifestDecoder) Unmarshal(data []byte) (map[string]any, error) {
 	return parsed, nil
 }
 
+// Decode converts a manifest map into the internal DAG representation.
 func (d *manifestDecoder) Decode(input map[string]any) (*dag, error) {
 	if err := validateManifestAliases(input); err != nil {
 		return nil, err
@@ -63,6 +68,7 @@ func (d *manifestDecoder) Decode(input map[string]any) (*dag, error) {
 	return decoded, nil
 }
 
+// newMapDecoder creates a mapstructure decoder for the target manifest.
 func (d *manifestDecoder) newMapDecoder(target *dag) (*mapstructure.Decoder, error) {
 	return mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		ErrorUnused: true,
@@ -72,10 +78,11 @@ func (d *manifestDecoder) newMapDecoder(target *dag) (*mapstructure.Decoder, err
 	})
 }
 
+// validateManifestAliases checks for incompatible legacy and current alias usage.
 func validateManifestAliases(input map[string]any) error {
 	if _, hasLabels := input["labels"]; hasLabels {
 		if _, hasTags := input["tags"]; hasTags {
-			return fmt.Errorf("labels and deprecated tags cannot both be set")
+			return errors.New("labels and deprecated tags cannot both be set")
 		}
 	}
 	return nil

--- a/internal/persis/filedagrun/writer.go
+++ b/internal/persis/filedagrun/writer.go
@@ -87,6 +87,7 @@ func (w *Writer) Write(ctx context.Context, st exec.DAGRunStatus) error {
 	return nil
 }
 
+// write encodes a single status entry and persists it to disk.
 func (w *Writer) write(st exec.DAGRunStatus) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/persis/filedagrun/writer.go
+++ b/internal/persis/filedagrun/writer.go
@@ -25,7 +25,8 @@ var (
 
 type Writer struct {
 	target     string
-	writer     *bufio.Writer
+	buffer     *bufio.Writer
+	encoder    *json.Encoder
 	file       *os.File
 	mu         sync.Mutex
 	bufferSize int
@@ -69,7 +70,9 @@ func (w *Writer) Open() error {
 	}
 
 	w.file = file
-	w.writer = bufio.NewWriterSize(file, w.bufferSize)
+	w.buffer = bufio.NewWriterSize(file, w.bufferSize)
+	w.encoder = json.NewEncoder(w.buffer)
+	w.encoder.SetEscapeHTML(false)
 	return nil
 }
 
@@ -92,28 +95,11 @@ func (w *Writer) write(st exec.DAGRunStatus) error {
 		return ErrWriterNotOpen
 	}
 
-	jsonBytes, err := json.Marshal(st)
-	if err != nil {
-		return fmt.Errorf("failed to marshal status: %w", err)
+	if err := w.encoder.Encode(st); err != nil {
+		return fmt.Errorf("failed to encode status: %w", err)
 	}
 
-	if _, err := w.writer.Write(jsonBytes); err != nil {
-		return fmt.Errorf("failed to write JSON: %w", err)
-	}
-
-	if err := w.writer.WriteByte('\n'); err != nil {
-		return fmt.Errorf("failed to write newline: %w", err)
-	}
-
-	if err := w.writer.Flush(); err != nil {
-		return fmt.Errorf("failed to flush data: %w", err)
-	}
-
-	if err := w.file.Sync(); err != nil {
-		return fmt.Errorf("failed to sync data: %w", err)
-	}
-
-	return nil
+	return w.flushAndSyncLocked()
 }
 
 // Close flushes any buffered data and closes the underlying file.
@@ -138,12 +124,8 @@ func (w *Writer) close() error {
 
 	var errs []error
 
-	if err := w.writer.Flush(); err != nil {
-		errs = append(errs, fmt.Errorf("flush error: %w", err))
-	}
-
-	if err := w.file.Sync(); err != nil {
-		errs = append(errs, fmt.Errorf("sync error: %w", err))
+	if err := w.flushAndSyncLocked(); err != nil {
+		errs = append(errs, err)
 	}
 
 	if err := w.file.Close(); err != nil {
@@ -151,7 +133,26 @@ func (w *Writer) close() error {
 	}
 
 	w.file = nil
-	w.writer = nil
+	w.buffer = nil
+	w.encoder = nil
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (w *Writer) flushAndSyncLocked() error {
+	var errs []error
+
+	if err := w.buffer.Flush(); err != nil {
+		errs = append(errs, fmt.Errorf("flush error: %w", err))
+	}
+
+	if err := w.file.Sync(); err != nil {
+		errs = append(errs, fmt.Errorf("sync error: %w", err))
+	}
 
 	if len(errs) > 0 {
 		return errors.Join(errs...)
@@ -168,5 +169,5 @@ func (w *Writer) IsOpen() bool {
 }
 
 func (w *Writer) isOpenLocked() bool {
-	return w.file != nil && w.writer != nil
+	return w.file != nil && w.buffer != nil && w.encoder != nil
 }

--- a/internal/persis/filedagrun/writer.go
+++ b/internal/persis/filedagrun/writer.go
@@ -143,6 +143,7 @@ func (w *Writer) close() error {
 	return nil
 }
 
+// flushAndSyncLocked flushes the buffered encoder output and syncs the file.
 func (w *Writer) flushAndSyncLocked() error {
 	var errs []error
 
@@ -168,6 +169,7 @@ func (w *Writer) IsOpen() bool {
 	return w.isOpenLocked()
 }
 
+// isOpenLocked reports whether the writer has an active file and encoder.
 func (w *Writer) isOpenLocked() bool {
 	return w.file != nil && w.buffer != nil && w.encoder != nil
 }

--- a/internal/persis/filedagrun/writer_test.go
+++ b/internal/persis/filedagrun/writer_test.go
@@ -4,7 +4,9 @@
 package filedagrun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,6 +125,10 @@ func TestWriterErrorHandling(t *testing.T) {
 		data, err := os.ReadFile(writerPath)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(bytes.TrimRight(data, "\n"), &decoded))
+
 		assert.Equal(t, byte('\n'), data[len(data)-1])
 	})
 }

--- a/internal/persis/filedagrun/writer_test.go
+++ b/internal/persis/filedagrun/writer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestWriter verifies writer persistence to new and existing status files.
 func TestWriter(t *testing.T) {
 	th := setupTestStore(t)
 
@@ -71,6 +72,7 @@ func TestWriter(t *testing.T) {
 	})
 }
 
+// TestWriterErrorHandling verifies writer lifecycle and error paths.
 func TestWriterErrorHandling(t *testing.T) {
 	th := setupTestStore(t)
 
@@ -133,6 +135,7 @@ func TestWriterErrorHandling(t *testing.T) {
 	})
 }
 
+// TestWriterRename verifies status files follow DAG rename operations.
 func TestWriterRename(t *testing.T) {
 	th := setupTestStore(t)
 

--- a/internal/persis/filedagrun/writer_test.go
+++ b/internal/persis/filedagrun/writer_test.go
@@ -5,6 +5,7 @@ package filedagrun
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -105,6 +106,24 @@ func TestWriterErrorHandling(t *testing.T) {
 		assert.True(t, writer.IsOpen())
 		require.NoError(t, writer.close())
 		assert.False(t, writer.IsOpen())
+	})
+
+	t.Run("WritesNewlineDelimitedJSON", func(t *testing.T) {
+		writerPath := filepath.Join(th.TmpDir, "ndjson.dat")
+		writer := NewWriter(writerPath)
+		require.NoError(t, writer.Open())
+
+		dag := th.DAG("test_newline_delimited_json")
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		dagRunStatus := transform.NewStatusBuilder(dag.DAG).Create(dagRunID, core.Running, 1, time.Now())
+
+		require.NoError(t, writer.write(dagRunStatus))
+		require.NoError(t, writer.close())
+
+		data, err := os.ReadFile(writerPath)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+		assert.Equal(t, byte('\n'), data[len(data)-1])
 	})
 }
 


### PR DESCRIPTION
## Summary
- isolate manifest decoding into a dedicated decoder component and extend loader characterization coverage
- standardize unix socket request handling on the net/http client and server stack
- streamline DAG run status persistence with buffered JSON encoding and regression tests

## Testing
- go test ./internal/runtime ./internal/core/spec ./internal/cmn/sock ./internal/persis/filedagrun -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Socket client/server now use standard HTTP client/server internals for robust request handling, timeouts, idle handling, and graceful shutdown; server logs panics with stack traces.
  * Spec loader centralized around a manifest decoder for clearer decoding and validation.
  * JSON writer now uses a persistent encoder and buffered writer for efficient, consistent serialization.

* **Bug Fixes**
  * Improved timeout detection/propagation and ensured handler panics result in 500 responses.
  * Guaranteed newline-delimited JSON output formatting.

* **Tests**
  * Added/refactored tests for handler recovery, response headers, server timeouts, manifest decoding, client init, and writer format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->