### PR TITLE
fix: corroborate stale distributed run repair with worker heartbeats

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -599,6 +599,9 @@ func (c *Context) NewServer(rs *resource.Service, opts ...frontend.ServerOption)
 	if c.DAGRunLeaseStore != nil {
 		opts = append(opts, frontend.WithAPIOption(apiv1.WithDAGRunLeaseStore(c.DAGRunLeaseStore)))
 	}
+	if c.WorkerHeartbeatStore != nil {
+		opts = append(opts, frontend.WithAPIOption(apiv1.WithWorkerHeartbeatStore(c.WorkerHeartbeatStore)))
+	}
 	opts = append(opts, frontend.WithAPIOption(apiv1.WithSchedulerStateStore(
 		filewatermark.New(filepath.Join(c.Config.Paths.DataDir, "scheduler")),
 	)))

--- a/internal/core/exec/distributed.go
+++ b/internal/core/exec/distributed.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	ErrDispatchTaskNotFound = errors.New("dispatch task claim not found")
-	ErrDAGRunLeaseNotFound  = errors.New("dag-run lease not found")
-	ErrActiveRunNotFound    = errors.New("active distributed run not found")
+	ErrDispatchTaskNotFound    = errors.New("dispatch task claim not found")
+	ErrDAGRunLeaseNotFound     = errors.New("dag-run lease not found")
+	ErrActiveRunNotFound       = errors.New("active distributed run not found")
+	ErrWorkerHeartbeatNotFound = errors.New("worker heartbeat not found")
 )
 
 // CoordinatorEndpoint identifies a coordinator instance that owns a
@@ -95,6 +96,7 @@ func (r WorkerHeartbeatRecord) LastHeartbeatTime() time.Time {
 // WorkerHeartbeatStore persists shared worker presence across coordinators.
 type WorkerHeartbeatStore interface {
 	Upsert(ctx context.Context, record WorkerHeartbeatRecord) error
+	Get(ctx context.Context, workerID string) (*WorkerHeartbeatRecord, error)
 	List(ctx context.Context) ([]WorkerHeartbeatRecord, error)
 	DeleteStale(ctx context.Context, before time.Time) (int, error)
 }

--- a/internal/persis/filedistributed/stores_test.go
+++ b/internal/persis/filedistributed/stores_test.go
@@ -391,6 +391,14 @@ func TestWorkerHeartbeatStore_UpsertListAndDeleteStale(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	assert.Equal(t, "worker-fresh", records[0].WorkerID)
+
+	record, err := store.Get(ctx, "worker-fresh")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, "worker-fresh", record.WorkerID)
+
+	_, err = store.Get(ctx, "worker-stale")
+	assert.ErrorIs(t, err, exec.ErrWorkerHeartbeatNotFound)
 }
 
 func TestDAGRunLeaseStore_UpsertTouchListAndDelete(t *testing.T) {

--- a/internal/persis/filedistributed/worker_heartbeat_store.go
+++ b/internal/persis/filedistributed/worker_heartbeat_store.go
@@ -35,6 +35,24 @@ func (s *WorkerHeartbeatStore) Upsert(_ context.Context, record exec.WorkerHeart
 	return writeJSONAtomic(s.recordPath(record.WorkerID), record)
 }
 
+func (s *WorkerHeartbeatStore) Get(_ context.Context, workerID string) (*exec.WorkerHeartbeatRecord, error) {
+	if workerID == "" {
+		return nil, exec.ErrWorkerHeartbeatNotFound
+	}
+
+	var record exec.WorkerHeartbeatRecord
+	if err := readJSONFile(s.recordPath(workerID), &record); err != nil {
+		if os.IsNotExist(err) {
+			return nil, exec.ErrWorkerHeartbeatNotFound
+		}
+		return nil, err
+	}
+	if record.WorkerID == "" {
+		return nil, exec.ErrWorkerHeartbeatNotFound
+	}
+	return &record, nil
+}
+
 func (s *WorkerHeartbeatStore) List(_ context.Context) ([]exec.WorkerHeartbeatRecord, error) {
 	files, err := sortedFiles(filepath.Join(s.baseDir, "workers"))
 	if err != nil {

--- a/internal/runtime/distributed_stale_run.go
+++ b/internal/runtime/distributed_stale_run.go
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+const defaultStaleWorkerHeartbeatThreshold = 30 * time.Second
+
+// DistributedRunRepairConfig configures conservative stale distributed-run repair.
+type DistributedRunRepairConfig struct {
+	DAGRunStore                   exec.DAGRunStore
+	DAGRunLeaseStore              exec.DAGRunLeaseStore
+	WorkerHeartbeatStore          exec.WorkerHeartbeatStore
+	StaleLeaseThreshold           time.Duration
+	StaleWorkerHeartbeatThreshold time.Duration
+	Now                           func() time.Time
+}
+
+// ConfirmAndRepairStaleDistributedRun marks a remote active attempt failed only
+// when both the run lease and worker evidence confirm that the exact attempt is gone.
+func ConfirmAndRepairStaleDistributedRun(
+	ctx context.Context,
+	cfg DistributedRunRepairConfig,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+	fallbackWorkerID string,
+) (*exec.DAGRunStatus, bool, error) {
+	if status == nil || cfg.DAGRunStore == nil || cfg.DAGRunLeaseStore == nil || cfg.WorkerHeartbeatStore == nil {
+		return status, false, nil
+	}
+
+	workerID, ok := remoteWorkerIDForStatus(status, fallbackWorkerID)
+	if !ok {
+		return status, false, nil
+	}
+	if !statusEligibleForDistributedRepair(status.Status) {
+		return status, false, nil
+	}
+
+	attemptID := status.AttemptID
+	if attemptID == "" {
+		attemptID = fallbackAttemptID
+	}
+	if attemptID == "" {
+		return status, false, nil
+	}
+
+	attemptKey := exec.AttemptKeyForStatus(status, attemptID)
+	if attemptKey == "" {
+		return status, false, nil
+	}
+
+	now := time.Now().UTC()
+	if cfg.Now != nil {
+		now = cfg.Now().UTC()
+	}
+
+	lease, err := cfg.DAGRunLeaseStore.Get(ctx, attemptKey)
+	switch {
+	case err == nil:
+		if exec.LeaseMatchesStatus(lease, status, attemptID, now, staleLeaseThresholdOrDefault(cfg.StaleLeaseThreshold)) {
+			return status, false, nil
+		}
+		if lease != nil && !exec.LeaseIdentityMatchesStatus(lease, status, attemptID) {
+			return status, false, nil
+		}
+	case errors.Is(err, exec.ErrDAGRunLeaseNotFound):
+		lease = nil
+	default:
+		return status, false, err
+	}
+
+	record, err := cfg.WorkerHeartbeatStore.Get(ctx, workerID)
+	switch {
+	case err == nil:
+		if workerHeartbeatFresh(record, now, staleWorkerHeartbeatThresholdOrDefault(cfg.StaleWorkerHeartbeatThreshold)) {
+			if record.Stats == nil {
+				return status, false, nil
+			}
+			if workerHeartbeatReportsAttempt(record, status, attemptKey) {
+				return status, false, nil
+			}
+		}
+	case errors.Is(err, exec.ErrWorkerHeartbeatNotFound):
+	default:
+		return status, false, err
+	}
+
+	reason := exec.DistributedLeaseExpiredReason(workerID)
+	currentStatus, swapped, err := cfg.DAGRunStore.CompareAndSwapLatestAttemptStatus(
+		ctx,
+		status.DAGRun(),
+		attemptID,
+		status.Status,
+		func(current *exec.DAGRunStatus) error {
+			markActiveStatusFailed(current, reason, now)
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	if !swapped {
+		if currentStatus != nil {
+			return currentStatus, false, nil
+		}
+		return status, false, nil
+	}
+	return currentStatus, true, nil
+}
+
+func remoteWorkerIDForStatus(status *exec.DAGRunStatus, fallbackWorkerID string) (string, bool) {
+	if status == nil {
+		return "", false
+	}
+	if exec.IsRemoteWorkerID(status.WorkerID) {
+		return status.WorkerID, true
+	}
+	if status.WorkerID != "" {
+		return "", false
+	}
+	if status.Status != core.Queued && status.Status != core.NotStarted {
+		return "", false
+	}
+	if !exec.IsRemoteWorkerID(fallbackWorkerID) {
+		return "", false
+	}
+	return fallbackWorkerID, true
+}
+
+func statusEligibleForDistributedRepair(status core.Status) bool {
+	return status == core.Running || status == core.Queued || status == core.NotStarted
+}
+
+func workerHeartbeatFresh(record *exec.WorkerHeartbeatRecord, now time.Time, threshold time.Duration) bool {
+	if record == nil || record.LastHeartbeatAt == 0 || threshold <= 0 {
+		return false
+	}
+	return now.Sub(record.LastHeartbeatTime()) < threshold
+}
+
+func workerHeartbeatReportsAttempt(record *exec.WorkerHeartbeatRecord, status *exec.DAGRunStatus, attemptKey string) bool {
+	if record == nil || record.Stats == nil {
+		return false
+	}
+
+	for _, task := range record.Stats.RunningTasks {
+		if task == nil {
+			continue
+		}
+		if task.AttemptKey != "" && task.AttemptKey == attemptKey {
+			return true
+		}
+		if task.AttemptKey == "" && task.DagRunId == status.DAGRunID && task.DagName == status.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func staleLeaseThresholdOrDefault(threshold time.Duration) time.Duration {
+	if threshold <= 0 {
+		return exec.DefaultStaleLeaseThreshold
+	}
+	return threshold
+}
+
+func staleWorkerHeartbeatThresholdOrDefault(threshold time.Duration) time.Duration {
+	if threshold <= 0 {
+		return defaultStaleWorkerHeartbeatThreshold
+	}
+	return threshold
+}

--- a/internal/runtime/distributed_stale_run.go
+++ b/internal/runtime/distributed_stale_run.go
@@ -73,7 +73,6 @@ func ConfirmAndRepairStaleDistributedRun(
 			return status, false, nil
 		}
 	case errors.Is(err, exec.ErrDAGRunLeaseNotFound):
-		lease = nil
 	default:
 		return status, false, err
 	}

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1717,52 +1717,101 @@ func (h *Handler) syncLeaseFromStatus(
 	if h.dagRunLeaseStore == nil || status == nil {
 		return
 	}
-	attemptKey := exec.AttemptKeyForStatus(status, fallbackAttemptID)
-	if attemptKey == "" {
-		return
-	}
-	attemptID := status.AttemptID
-	if attemptID == "" {
-		attemptID = fallbackAttemptID
-	}
 
 	switch status.Status {
 	case core.Running, core.NotStarted:
-		queueName := queueNameForStatus(status)
-		lease := exec.DAGRunLease{
-			AttemptKey: attemptKey,
-			DAGRun: exec.DAGRunRef{
-				Name: status.Name,
-				ID:   status.DAGRunID,
-			},
-			Root:            status.Root,
-			AttemptID:       attemptID,
-			QueueName:       queueName,
-			WorkerID:        workerID,
-			Owner:           h.owner,
-			ClaimedAt:       time.Now().UTC().UnixMilli(),
-			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-		}
-		if existing, err := h.dagRunLeaseStore.Get(ctx, attemptKey); err == nil && existing != nil {
-			lease.ClaimedAt = existing.ClaimedAt
-			if status.ProcGroup == "" && existing.QueueName != "" {
-				lease.QueueName = existing.QueueName
-			}
-		}
-		if err := h.dagRunLeaseStore.Upsert(ctx, lease); err != nil {
-			logger.Warn(ctx, "Failed to upsert distributed run lease",
-				tag.RunID(status.DAGRunID),
-				tag.Error(err),
-			)
-		}
+		h.upsertDistributedLeaseFromStatus(ctx, workerID, status, fallbackAttemptID)
 	case core.Failed, core.Aborted, core.Succeeded, core.Queued,
 		core.PartiallySucceeded, core.Waiting, core.Rejected:
+		attemptKey := exec.AttemptKeyForStatus(status, fallbackAttemptID)
+		if attemptKey == "" {
+			return
+		}
 		if err := h.dagRunLeaseStore.Delete(ctx, attemptKey); err != nil {
 			logger.Warn(ctx, "Failed to delete distributed run lease",
 				tag.RunID(status.DAGRunID),
 				tag.Error(err),
 			)
 		}
+	}
+}
+
+func (h *Handler) upsertDistributedLeaseFromStatus(
+	ctx context.Context,
+	workerID string,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+) {
+	if h.dagRunLeaseStore == nil || status == nil {
+		return
+	}
+
+	attemptKey := exec.AttemptKeyForStatus(status, fallbackAttemptID)
+	if attemptKey == "" {
+		return
+	}
+
+	attemptID := status.AttemptID
+	if attemptID == "" {
+		attemptID = fallbackAttemptID
+	}
+	if attemptID == "" {
+		return
+	}
+
+	if workerID == "" {
+		workerID = status.WorkerID
+	}
+	if !exec.IsRemoteWorkerID(workerID) {
+		return
+	}
+
+	queueName := queueNameForStatus(status)
+	now := time.Now().UTC()
+	lease := exec.DAGRunLease{
+		AttemptKey: attemptKey,
+		DAGRun: exec.DAGRunRef{
+			Name: status.Name,
+			ID:   status.DAGRunID,
+		},
+		Root:            status.Root,
+		AttemptID:       attemptID,
+		QueueName:       queueName,
+		WorkerID:        workerID,
+		Owner:           h.owner,
+		ClaimedAt:       now.UnixMilli(),
+		LastHeartbeatAt: now.UnixMilli(),
+	}
+	if existing, err := h.dagRunLeaseStore.Get(ctx, attemptKey); err == nil && existing != nil {
+		lease.ClaimedAt = existing.ClaimedAt
+		if status.ProcGroup == "" && existing.QueueName != "" {
+			lease.QueueName = existing.QueueName
+		}
+	}
+	if err := h.dagRunLeaseStore.Upsert(ctx, lease); err != nil {
+		logger.Warn(ctx, "Failed to upsert distributed run lease",
+			tag.RunID(status.DAGRunID),
+			tag.Error(err),
+		)
+	}
+}
+
+func (h *Handler) restoreConfirmedDistributedRunTrackingFromStatus(
+	ctx context.Context,
+	workerID string,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+) {
+	if status == nil {
+		return
+	}
+
+	switch status.Status {
+	case core.Running, core.NotStarted, core.Queued:
+		h.upsertDistributedLeaseFromStatus(ctx, workerID, status, fallbackAttemptID)
+		h.upsertActiveDistributedRun(ctx, status, workerID, fallbackAttemptID)
+	case core.Failed, core.Aborted, core.Succeeded,
+		core.PartiallySucceeded, core.Waiting, core.Rejected:
 	}
 }
 
@@ -2253,7 +2302,7 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 		return
 	}
 	if reconciledWorkerID, ok := distributedWorkerIDForStatus(reconciledStatus, workerID); ok {
-		h.upsertActiveDistributedRun(ctx, reconciledStatus, reconciledWorkerID, attemptID)
+		h.restoreConfirmedDistributedRunTrackingFromStatus(ctx, reconciledWorkerID, reconciledStatus, attemptID)
 	}
 }
 
@@ -2331,6 +2380,9 @@ func (h *Handler) detectOrphanedDistributedStatuses(ctx context.Context, now tim
 				"Failed to delete superseded orphaned active distributed run after reconciliation",
 			)
 			continue
+		}
+		if reconciledWorkerID, ok := distributedWorkerIDForStatus(reconciledStatus, status.WorkerID); ok {
+			h.restoreConfirmedDistributedRunTrackingFromStatus(ctx, reconciledWorkerID, reconciledStatus, leaseState.attemptID)
 		}
 
 	}
@@ -2429,7 +2481,7 @@ func (h *Handler) detectIndexedDistributedStatuses(ctx context.Context, now time
 			continue
 		}
 		if reconciledWorkerID, ok := distributedWorkerIDForStatus(reconciledStatus, workerID); ok {
-			h.upsertActiveDistributedRun(ctx, reconciledStatus, reconciledWorkerID, record.AttemptID)
+			h.restoreConfirmedDistributedRunTrackingFromStatus(ctx, reconciledWorkerID, reconciledStatus, record.AttemptID)
 			continue
 		}
 

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/google/uuid"
@@ -2214,11 +2215,65 @@ func (h *Handler) reconcileDistributedLease(ctx context.Context, lease exec.DAGR
 		return
 	}
 
-	h.markStatusLeaseRunFailed(ctx, runStatus, attemptID, lease.AttemptKey, staleDistributedLeaseReason(workerID))
+	if h.workerHeartbeatStore == nil {
+		h.markStatusLeaseRunFailed(ctx, runStatus, attemptID, lease.AttemptKey, staleDistributedLeaseReason(workerID))
+		return
+	}
+
+	reconciledStatus, repaired, err := h.confirmAndRepairStaleDistributedRun(ctx, runStatus, attemptID, workerID)
+	if err != nil {
+		logger.Error(ctx, "Failed to confirm stale distributed run from lease reconciliation",
+			tag.DAG(lease.DAGRun.Name),
+			tag.RunID(lease.DAGRun.ID),
+			tag.AttemptKey(lease.AttemptKey),
+			tag.Error(err),
+		)
+		return
+	}
+	if repaired {
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete stale distributed lease after confirmed failure",
+			"Failed to delete active distributed run after confirmed failure",
+		)
+		logger.Warn(ctx, "Marked stale distributed run as FAILED",
+			tag.DAG(lease.DAGRun.Name),
+			tag.RunID(lease.DAGRun.ID),
+			slog.String("reason", staleDistributedLeaseReason(workerID)),
+		)
+		return
+	}
+	if reconciledStatus == nil {
+		return
+	}
+	if reconciledStatus.AttemptID != attemptID || (!reconciledStatus.Status.IsActive() && reconciledStatus.Status != core.NotStarted) {
+		h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), lease.DAGRun, lease.AttemptKey,
+			"Failed to delete superseded distributed lease after reconciliation",
+			"Failed to delete superseded active distributed run after reconciliation",
+		)
+		return
+	}
+	if reconciledWorkerID, ok := distributedWorkerIDForStatus(reconciledStatus, workerID); ok {
+		h.upsertActiveDistributedRun(ctx, reconciledStatus, reconciledWorkerID, attemptID)
+	}
 }
 
 func staleDistributedLeaseReason(workerID string) string {
 	return exec.DistributedLeaseExpiredReason(workerID)
+}
+
+func (h *Handler) confirmAndRepairStaleDistributedRun(
+	ctx context.Context,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+	fallbackWorkerID string,
+) (*exec.DAGRunStatus, bool, error) {
+	return runtime.ConfirmAndRepairStaleDistributedRun(ctx, runtime.DistributedRunRepairConfig{
+		DAGRunStore:                   h.dagRunStore,
+		DAGRunLeaseStore:              h.dagRunLeaseStore,
+		WorkerHeartbeatStore:          h.workerHeartbeatStore,
+		StaleLeaseThreshold:           h.staleLeaseThreshold,
+		StaleWorkerHeartbeatThreshold: h.staleHeartbeatThreshold,
+	}, status, fallbackAttemptID, fallbackWorkerID)
 }
 
 func (h *Handler) detectOrphanedDistributedStatuses(ctx context.Context, now time.Time) {
@@ -2245,7 +2300,39 @@ func (h *Handler) detectOrphanedDistributedStatuses(ctx context.Context, now tim
 			continue
 		}
 
-		h.markStatusLeaseRunFailed(ctx, status, leaseState.attemptID, leaseState.attemptKey, staleDistributedLeaseReason(status.WorkerID))
+		if h.workerHeartbeatStore == nil {
+			h.markStatusLeaseRunFailed(ctx, status, leaseState.attemptID, leaseState.attemptKey, staleDistributedLeaseReason(status.WorkerID))
+			continue
+		}
+
+		reconciledStatus, repaired, err := h.confirmAndRepairStaleDistributedRun(ctx, status, leaseState.attemptID, status.WorkerID)
+		if err != nil {
+			logger.Error(ctx, "Failed to confirm stale orphaned distributed run",
+				tag.DAG(status.Name),
+				tag.RunID(status.DAGRunID),
+				tag.AttemptKey(leaseState.attemptKey),
+				tag.Error(err),
+			)
+			continue
+		}
+		if repaired {
+			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), status.DAGRun(), leaseState.attemptKey,
+				"Failed to delete orphaned distributed lease after confirmed failure",
+				"Failed to delete orphaned active distributed run after confirmed failure",
+			)
+			continue
+		}
+		if reconciledStatus == nil {
+			continue
+		}
+		if reconciledStatus.AttemptID != leaseState.attemptID || (!reconciledStatus.Status.IsActive() && reconciledStatus.Status != core.NotStarted) {
+			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), status.DAGRun(), leaseState.attemptKey,
+				"Failed to delete superseded orphaned distributed lease after reconciliation",
+				"Failed to delete superseded orphaned active distributed run after reconciliation",
+			)
+			continue
+		}
+
 	}
 }
 
@@ -2309,7 +2396,43 @@ func (h *Handler) detectIndexedDistributedStatuses(ctx context.Context, now time
 			continue
 		}
 
-		h.markStatusLeaseRunFailed(ctx, runStatus, record.AttemptID, record.AttemptKey, staleDistributedLeaseReason(workerID))
+		if h.workerHeartbeatStore == nil {
+			h.markStatusLeaseRunFailed(ctx, runStatus, record.AttemptID, record.AttemptKey, staleDistributedLeaseReason(workerID))
+			continue
+		}
+
+		reconciledStatus, repaired, err := h.confirmAndRepairStaleDistributedRun(ctx, runStatus, record.AttemptID, workerID)
+		if err != nil {
+			logger.Error(ctx, "Failed to confirm stale indexed distributed run",
+				tag.DAG(record.DAGRun.Name),
+				tag.RunID(record.DAGRun.ID),
+				tag.AttemptKey(record.AttemptKey),
+				tag.Error(err),
+			)
+			continue
+		}
+		if repaired {
+			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), record.DAGRun, record.AttemptKey,
+				"Failed to delete stale indexed distributed lease after confirmed failure",
+				"Failed to delete stale indexed active distributed run after confirmed failure",
+			)
+			continue
+		}
+		if reconciledStatus == nil {
+			continue
+		}
+		if reconciledStatus.AttemptID != record.AttemptID || (!reconciledStatus.Status.IsActive() && reconciledStatus.Status != core.NotStarted) {
+			h.deleteDistributedTracking(ctx, context.WithoutCancel(ctx), record.DAGRun, record.AttemptKey,
+				"Failed to delete superseded indexed distributed lease after reconciliation",
+				"Failed to delete superseded indexed active distributed run after reconciliation",
+			)
+			continue
+		}
+		if reconciledWorkerID, ok := distributedWorkerIDForStatus(reconciledStatus, workerID); ok {
+			h.upsertActiveDistributedRun(ctx, reconciledStatus, reconciledWorkerID, record.AttemptID)
+			continue
+		}
+
 	}
 }
 

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -1887,6 +1887,136 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
 	})
 
+	t.Run("DetectStaleLeasesKeepsLeasedRunWhenFreshWorkerHeartbeatStillReportsAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		heartbeatStore := filedistributed.NewWorkerHeartbeatStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:             store,
+			WorkerHeartbeatStore:    heartbeatStore,
+			DAGRunLeaseStore:        leaseStore,
+			StaleHeartbeatThreshold: time.Minute,
+			StaleLeaseThreshold:     time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attemptKey := "lease-key-1"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-lease",
+			AttemptID:  "attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      attemptKey,
+			DAGRun:          ref,
+			Root:            ref,
+			AttemptID:       "attempt-1",
+			QueueName:       "lease-dag",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: staleAt.UnixMilli(),
+			ClaimedAt:       staleAt.UnixMilli(),
+		}))
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+			Stats: &coordinatorv1.WorkerStats{
+				RunningTasks: []*coordinatorv1.RunningTask{
+					{
+						DagRunId:       "run-lease",
+						DagName:        "lease-dag",
+						RootDagRunId:   "run-lease",
+						RootDagRunName: "lease-dag",
+						AttemptKey:     attemptKey,
+					},
+				},
+			},
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, core.Running, status.Status)
+		assert.Equal(t, core.NodeRunning, status.Nodes[0].Status)
+
+		lease, err := leaseStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.NotNil(t, lease)
+	})
+
+	t.Run("DetectStaleLeasesFailsLeasedRunWhenFreshWorkerHeartbeatDropsAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		heartbeatStore := filedistributed.NewWorkerHeartbeatStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:             store,
+			WorkerHeartbeatStore:    heartbeatStore,
+			DAGRunLeaseStore:        leaseStore,
+			StaleHeartbeatThreshold: time.Minute,
+			StaleLeaseThreshold:     time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attemptKey := "lease-key-1"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-lease",
+			AttemptID:  "attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      attemptKey,
+			DAGRun:          ref,
+			Root:            ref,
+			AttemptID:       "attempt-1",
+			QueueName:       "lease-dag",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: staleAt.UnixMilli(),
+			ClaimedAt:       staleAt.UnixMilli(),
+		}))
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+			Stats: &coordinatorv1.WorkerStats{
+				RunningTasks: []*coordinatorv1.RunningTask{},
+			},
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, core.Failed, status.Status)
+		assert.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
+		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+
+		_, err = leaseStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+	})
+
 	t.Run("DetectStaleLeasesFailsOrphanedDistributedStatusWithoutLease", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -1953,7 +1953,68 @@ func TestHandler_ZombieDetection(t *testing.T) {
 
 		lease, err := leaseStore.Get(ctx, attemptKey)
 		require.NoError(t, err)
-		assert.NotNil(t, lease)
+		assert.Equal(t, attemptKey, lease.AttemptKey)
+		assert.Equal(t, "worker-1", lease.WorkerID)
+		assert.Greater(t, lease.LastHeartbeatAt, staleAt.UnixMilli())
+	})
+
+	t.Run("DetectStaleLeasesRestoresMissingLeaseWhenFreshWorkerHeartbeatStillReportsOrphanedRun", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		heartbeatStore := filedistributed.NewWorkerHeartbeatStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:             store,
+			WorkerHeartbeatStore:    heartbeatStore,
+			DAGRunLeaseStore:        leaseStore,
+			StaleHeartbeatThreshold: time.Minute,
+			StaleLeaseThreshold:     time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attemptKey := "lease-key-1"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-lease",
+			AttemptID:  "attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+			Stats: &coordinatorv1.WorkerStats{
+				RunningTasks: []*coordinatorv1.RunningTask{
+					{
+						DagRunId:       "run-lease",
+						DagName:        "lease-dag",
+						RootDagRunId:   "run-lease",
+						RootDagRunName: "lease-dag",
+						AttemptKey:     attemptKey,
+					},
+				},
+			},
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, core.Running, status.Status)
+		assert.Equal(t, core.NodeRunning, status.Nodes[0].Status)
+
+		lease, err := leaseStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.Equal(t, attemptKey, lease.AttemptKey)
+		assert.Equal(t, "worker-1", lease.WorkerID)
 	})
 
 	t.Run("DetectStaleLeasesFailsLeasedRunWhenFreshWorkerHeartbeatDropsAttempt", func(t *testing.T) {
@@ -2049,6 +2110,81 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		assert.Equal(t, core.Failed, status.Status)
 		assert.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
 		assert.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+	})
+
+	t.Run("DetectStaleLeasesRestoresMissingLeaseFromActiveIndexWhenFreshWorkerHeartbeatStillReportsAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		heartbeatStore := filedistributed.NewWorkerHeartbeatStore(baseDir)
+		activeStore := filedistributed.NewActiveDistributedRunStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:               store,
+			WorkerHeartbeatStore:      heartbeatStore,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+			StaleHeartbeatThreshold:   time.Minute,
+			StaleLeaseThreshold:       time.Second,
+		})
+
+		ref := exec.DAGRunRef{Name: "lease-dag", ID: "run-lease"}
+		attemptKey := "lease-key-1"
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:       "lease-dag",
+			DAGRunID:   "run-lease",
+			AttemptID:  "attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, activeStore.Upsert(ctx, exec.ActiveDistributedRun{
+			AttemptKey: attemptKey,
+			DAGRun:     ref,
+			Root:       ref,
+			AttemptID:  "attempt-1",
+			WorkerID:   "worker-1",
+			Status:     core.Running,
+			UpdatedAt:  staleAt.UnixMilli(),
+		}))
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+			Stats: &coordinatorv1.WorkerStats{
+				RunningTasks: []*coordinatorv1.RunningTask{
+					{
+						DagRunId:       "run-lease",
+						DagName:        "lease-dag",
+						RootDagRunId:   "run-lease",
+						RootDagRunName: "lease-dag",
+						AttemptKey:     attemptKey,
+					},
+				},
+			},
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, core.Running, status.Status)
+		assert.Equal(t, core.NodeRunning, status.Nodes[0].Status)
+
+		lease, err := leaseStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.Equal(t, attemptKey, lease.AttemptKey)
+		assert.Equal(t, "worker-1", lease.WorkerID)
+
+		record, err := activeStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.Equal(t, attemptKey, record.AttemptKey)
+		assert.Equal(t, "worker-1", record.WorkerID)
 	})
 
 	t.Run("DetectStaleLeasesRebuildsActiveIndexFromLeasesWithoutStatusScan", func(t *testing.T) {

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -48,40 +48,41 @@ import (
 var _ api.StrictServerInterface = (*API)(nil)
 
 type API struct {
-	dagStore            exec.DAGStore
-	dagRunStore         exec.DAGRunStore
-	dagRunMgr           runtime.Manager
-	queueStore          exec.QueueStore
-	procStore           exec.ProcStore
-	dagRunLeaseStore    exec.DAGRunLeaseStore
-	remoteNodeResolver  *remotenode.Resolver
-	remoteNodeStore     remotenode.Store
-	logEncodingCharset  string
-	config              *config.Config
-	metricsRegistry     *prometheus.Registry
-	coordinatorCli      coordinator.Client
-	serviceRegistry     exec.ServiceRegistry
-	subCmdBuilder       *runtime.SubCmdBuilder
-	resourceService     *resource.Service
-	authService         AuthService
-	auditService        *audit.Service
-	eventService        *eventstore.Service
-	syncService         SyncService
-	tunnelService       *tunnel.Service
-	defaultExecMode     config.ExecutionMode
-	dagWritesDisabled   bool // True when git sync read-only mode is active
-	agentConfigStore    agent.ConfigStore
-	agentModelStore     agent.ModelStore
-	agentMemoryStore    agent.MemoryStore
-	agentSoulStore      agent.SoulStore
-	agentOAuthManager   *agentoauth.Manager
-	agentAPI            *agent.API
-	docStore            agent.DocStore
-	baseConfigStore     baseconfig.Store
-	licenseManager      *license.Manager
-	workspaceStore      workspace.Store
-	leaseStaleThreshold time.Duration
-	schedulerStateStore scheduler.WatermarkStore
+	dagStore             exec.DAGStore
+	dagRunStore          exec.DAGRunStore
+	dagRunMgr            runtime.Manager
+	queueStore           exec.QueueStore
+	procStore            exec.ProcStore
+	dagRunLeaseStore     exec.DAGRunLeaseStore
+	workerHeartbeatStore exec.WorkerHeartbeatStore
+	remoteNodeResolver   *remotenode.Resolver
+	remoteNodeStore      remotenode.Store
+	logEncodingCharset   string
+	config               *config.Config
+	metricsRegistry      *prometheus.Registry
+	coordinatorCli       coordinator.Client
+	serviceRegistry      exec.ServiceRegistry
+	subCmdBuilder        *runtime.SubCmdBuilder
+	resourceService      *resource.Service
+	authService          AuthService
+	auditService         *audit.Service
+	eventService         *eventstore.Service
+	syncService          SyncService
+	tunnelService        *tunnel.Service
+	defaultExecMode      config.ExecutionMode
+	dagWritesDisabled    bool // True when git sync read-only mode is active
+	agentConfigStore     agent.ConfigStore
+	agentModelStore      agent.ModelStore
+	agentMemoryStore     agent.MemoryStore
+	agentSoulStore       agent.SoulStore
+	agentOAuthManager    *agentoauth.Manager
+	agentAPI             *agent.API
+	docStore             agent.DocStore
+	baseConfigStore      baseconfig.Store
+	licenseManager       *license.Manager
+	workspaceStore       workspace.Store
+	leaseStaleThreshold  time.Duration
+	schedulerStateStore  scheduler.WatermarkStore
 }
 
 // AuthService defines the interface for authentication operations.
@@ -245,6 +246,14 @@ func WithSchedulerStateStore(store scheduler.WatermarkStore) APIOption {
 func WithDAGRunLeaseStore(store exec.DAGRunLeaseStore) APIOption {
 	return func(a *API) {
 		a.dagRunLeaseStore = store
+	}
+}
+
+// WithWorkerHeartbeatStore sets the shared worker heartbeat store used for
+// conservative distributed run auto-repair on single-run reads.
+func WithWorkerHeartbeatStore(store exec.WorkerHeartbeatStore) APIOption {
+	return func(a *API) {
+		a.workerHeartbeatStore = store
 	}
 }
 

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1849,6 +1849,7 @@ func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string
 		if status == nil {
 			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
 		}
+		status = a.repairConfirmedStaleDistributedRunOnRead(ctx, status)
 		if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(status)); err != nil {
 			return api.GetDAGRunDetails200JSONResponse{}, err
 		}
@@ -1866,12 +1867,39 @@ func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string
 	if err != nil {
 		return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
+	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus)
 	if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(dagStatus)); err != nil {
 		return api.GetDAGRunDetails200JSONResponse{}, err
 	}
 	return api.GetDAGRunDetails200JSONResponse{
 		DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),
 	}, nil
+}
+
+func (a *API) repairConfirmedStaleDistributedRunOnRead(ctx context.Context, status *exec.DAGRunStatus) *exec.DAGRunStatus {
+	if status == nil || a.dagRunLeaseStore == nil || a.workerHeartbeatStore == nil {
+		return status
+	}
+
+	reconciled, _, err := runtime.ConfirmAndRepairStaleDistributedRun(ctx, runtime.DistributedRunRepairConfig{
+		DAGRunStore:          a.dagRunStore,
+		DAGRunLeaseStore:     a.dagRunLeaseStore,
+		WorkerHeartbeatStore: a.workerHeartbeatStore,
+		StaleLeaseThreshold:  a.leaseStaleThreshold,
+	}, status, status.AttemptID, status.WorkerID)
+	if err != nil {
+		logger.Warn(ctx, "Failed to auto-repair stale distributed run on read",
+			tag.DAG(status.Name),
+			tag.RunID(status.DAGRunID),
+			tag.AttemptID(status.AttemptID),
+			tag.Error(err),
+		)
+		return status
+	}
+	if reconciled != nil {
+		return reconciled
+	}
+	return status
 }
 
 func (a *API) toDAGRunDetailsWithSpecSource(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) api.DAGRunDetails {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1849,10 +1849,10 @@ func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string
 		if status == nil {
 			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
 		}
-		status = a.repairConfirmedStaleDistributedRunOnRead(ctx, status)
 		if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(status)); err != nil {
 			return api.GetDAGRunDetails200JSONResponse{}, err
 		}
+		status = a.repairConfirmedStaleDistributedRunOnRead(ctx, status, attempt.ID())
 		return api.GetDAGRunDetails200JSONResponse{
 			DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *status),
 		}, nil
@@ -1867,18 +1867,31 @@ func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string
 	if err != nil {
 		return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
-	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus)
 	if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(dagStatus)); err != nil {
 		return api.GetDAGRunDetails200JSONResponse{}, err
 	}
+	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID())
 	return api.GetDAGRunDetails200JSONResponse{
 		DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),
 	}, nil
 }
 
-func (a *API) repairConfirmedStaleDistributedRunOnRead(ctx context.Context, status *exec.DAGRunStatus) *exec.DAGRunStatus {
+func (a *API) repairConfirmedStaleDistributedRunOnRead(
+	ctx context.Context,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+) *exec.DAGRunStatus {
 	if status == nil || a.dagRunLeaseStore == nil || a.workerHeartbeatStore == nil {
 		return status
+	}
+
+	attemptID := status.AttemptID
+	if attemptID == "" {
+		attemptID = fallbackAttemptID
+	}
+	fallbackWorkerID := status.WorkerID
+	if fallbackWorkerID == "" {
+		fallbackWorkerID = a.distributedFallbackWorkerIDFromLease(ctx, status, attemptID)
 	}
 
 	reconciled, _, err := runtime.ConfirmAndRepairStaleDistributedRun(ctx, runtime.DistributedRunRepairConfig{
@@ -1886,7 +1899,7 @@ func (a *API) repairConfirmedStaleDistributedRunOnRead(ctx context.Context, stat
 		DAGRunLeaseStore:     a.dagRunLeaseStore,
 		WorkerHeartbeatStore: a.workerHeartbeatStore,
 		StaleLeaseThreshold:  a.leaseStaleThreshold,
-	}, status, status.AttemptID, status.WorkerID)
+	}, status, attemptID, fallbackWorkerID)
 	if err != nil {
 		logger.Warn(ctx, "Failed to auto-repair stale distributed run on read",
 			tag.DAG(status.Name),
@@ -1900,6 +1913,28 @@ func (a *API) repairConfirmedStaleDistributedRunOnRead(ctx context.Context, stat
 		return reconciled
 	}
 	return status
+}
+
+func (a *API) distributedFallbackWorkerIDFromLease(
+	ctx context.Context,
+	status *exec.DAGRunStatus,
+	fallbackAttemptID string,
+) string {
+	if status == nil || status.WorkerID != "" || a.dagRunLeaseStore == nil {
+		return ""
+	}
+
+	attemptKey := exec.AttemptKeyForStatus(status, fallbackAttemptID)
+	if attemptKey == "" {
+		return ""
+	}
+
+	lease, err := a.dagRunLeaseStore.Get(ctx, attemptKey)
+	if err != nil || lease == nil || !exec.IsRemoteWorkerID(lease.WorkerID) {
+		return ""
+	}
+
+	return lease.WorkerID
 }
 
 func (a *API) toDAGRunDetailsWithSpecSource(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) api.DAGRunDetails {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1837,52 +1837,63 @@ func isDAGRunLookupNotFound(err error) bool {
 
 // getDAGRunDetailsData returns DAG run details data. Used by both HTTP handler and SSE fetcher.
 func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string) (api.GetDAGRunDetails200JSONResponse, error) {
+	attempt, dagStatus, err := a.loadRootDAGRunDetailsAttemptAndStatus(ctx, dagName, dagRunId)
+	if err != nil {
+		return api.GetDAGRunDetails200JSONResponse{}, err
+	}
+	return api.GetDAGRunDetails200JSONResponse{
+		DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),
+	}, nil
+}
+
+func (a *API) loadRootDAGRunDetailsAttemptAndStatus(
+	ctx context.Context,
+	dagName, dagRunId string,
+) (exec.DAGRunAttempt, *exec.DAGRunStatus, error) {
 	if dagRunId == "latest" {
 		attempt, err := a.dagRunStore.LatestAttempt(ctx, dagName)
 		if err != nil {
-			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("no dag-runs found for DAG %s", dagName)
+			return nil, nil, fmt.Errorf("no dag-runs found for DAG %s", dagName)
 		}
+
 		status, err := attempt.ReadStatus(ctx)
 		if err != nil {
-			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("error getting latest status: %w", err)
+			return nil, nil, fmt.Errorf("error getting latest status: %w", err)
 		}
 		if status == nil {
-			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
+			return nil, nil, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
 		}
 		if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(status)); err != nil {
-			return api.GetDAGRunDetails200JSONResponse{}, err
+			return nil, nil, err
 		}
 
 		ref := exec.NewDAGRunRef(dagName, status.DAGRunID)
-		status, err = a.dagRunMgr.GetSavedStatus(ctx, ref)
+		dagStatus, err := a.dagRunMgr.GetSavedStatus(ctx, ref)
 		if err != nil {
-			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("error getting latest status: %w", err)
+			return nil, nil, fmt.Errorf("error getting latest status: %w", err)
 		}
-		if status == nil {
-			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
+		if dagStatus == nil {
+			return nil, nil, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
 		}
-		status = a.repairConfirmedStaleDistributedRunOnRead(ctx, status, attempt.ID())
-		return api.GetDAGRunDetails200JSONResponse{
-			DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *status),
-		}, nil
+
+		return attempt, a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID()), nil
 	}
 
 	ref := exec.NewDAGRunRef(dagName, dagRunId)
 	attempt, err := a.dagRunStore.FindAttempt(ctx, ref)
 	if err != nil {
-		return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
+		return nil, nil, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
+
 	dagStatus, err := a.dagRunMgr.GetSavedStatus(ctx, ref)
 	if err != nil {
-		return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
+		return nil, nil, fmt.Errorf("dag-run ID %s not found for DAG %s", dagRunId, dagName)
 	}
 	if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(dagStatus)); err != nil {
-		return api.GetDAGRunDetails200JSONResponse{}, err
+		return nil, nil, err
 	}
-	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID())
-	return api.GetDAGRunDetails200JSONResponse{
-		DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),
-	}, nil
+
+	return attempt, a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID()), nil
 }
 
 func (a *API) repairConfirmedStaleDistributedRunOnRead(

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1852,6 +1852,15 @@ func (a *API) getDAGRunDetailsData(ctx context.Context, dagName, dagRunId string
 		if err := a.requireWorkspaceVisible(ctx, statusWorkspaceName(status)); err != nil {
 			return api.GetDAGRunDetails200JSONResponse{}, err
 		}
+
+		ref := exec.NewDAGRunRef(dagName, status.DAGRunID)
+		status, err = a.dagRunMgr.GetSavedStatus(ctx, ref)
+		if err != nil {
+			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("error getting latest status: %w", err)
+		}
+		if status == nil {
+			return api.GetDAGRunDetails200JSONResponse{}, fmt.Errorf("latest dag-run status is unavailable for DAG %s", dagName)
+		}
 		status = a.repairConfirmedStaleDistributedRunOnRead(ctx, status, attempt.ID())
 		return api.GetDAGRunDetails200JSONResponse{
 			DagRunDetails: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *status),

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -852,6 +852,7 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 			}
 			return nil, fmt.Errorf("error getting latest attempt: %w", err)
 		}
+
 		latestStatus, err := a.dagRunMgr.GetLatestStatus(ctx, dag)
 		if err != nil {
 			return nil, fmt.Errorf("error getting latest status: %w", err)
@@ -888,6 +889,7 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 		}
 		return nil, fmt.Errorf("error getting status by dag-run ID: %w", err)
 	}
+
 	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID())
 
 	return &api.GetDAGDAGRunDetails200JSONResponse{

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -856,6 +856,10 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 		if err != nil {
 			return nil, fmt.Errorf("error getting latest status: %w", err)
 		}
+		latestStatusPtr := a.repairConfirmedStaleDistributedRunOnRead(ctx, &latestStatus)
+		if latestStatusPtr != nil {
+			latestStatus = *latestStatusPtr
+		}
 		return &api.GetDAGDAGRunDetails200JSONResponse{
 			DagRun: a.toDAGRunDetailsWithSpecSource(ctx, attempt, latestStatus),
 		}, nil
@@ -884,6 +888,7 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 		}
 		return nil, fmt.Errorf("error getting status by dag-run ID: %w", err)
 	}
+	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus)
 
 	return &api.GetDAGDAGRunDetails200JSONResponse{
 		DagRun: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -856,7 +856,7 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 		if err != nil {
 			return nil, fmt.Errorf("error getting latest status: %w", err)
 		}
-		latestStatusPtr := a.repairConfirmedStaleDistributedRunOnRead(ctx, &latestStatus)
+		latestStatusPtr := a.repairConfirmedStaleDistributedRunOnRead(ctx, &latestStatus, attempt.ID())
 		if latestStatusPtr != nil {
 			latestStatus = *latestStatusPtr
 		}
@@ -888,7 +888,7 @@ func (a *API) GetDAGDAGRunDetails(ctx context.Context, request api.GetDAGDAGRunD
 		}
 		return nil, fmt.Errorf("error getting status by dag-run ID: %w", err)
 	}
-	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus)
+	dagStatus = a.repairConfirmedStaleDistributedRunOnRead(ctx, dagStatus, attempt.ID())
 
 	return &api.GetDAGDAGRunDetails200JSONResponse{
 		DagRun: a.toDAGRunDetailsWithSpecSource(ctx, attempt, *dagStatus),

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -35,6 +35,13 @@ func apiProcEventuallyTimeout(base time.Duration) time.Duration {
 	return base
 }
 
+type staleLocalRunFixture struct {
+	server   test.Server
+	dag      test.DAG
+	dagRunID string
+	ref      exec.DAGRunRef
+}
+
 func TestServerProcHeartbeat_StartAPI(t *testing.T) {
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = apiTestProcHeartbeatInterval
@@ -90,81 +97,61 @@ steps:
 }
 
 func TestServerRepairsStaleLocalRunOnRead(t *testing.T) {
-	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
-		cfg.Proc.HeartbeatInterval = 50 * time.Millisecond
-		cfg.Proc.HeartbeatSyncInterval = 50 * time.Millisecond
-		cfg.Proc.StaleThreshold = 100 * time.Millisecond
-	}))
+	fixture := setupStaleLocalRun(t, "api-stale-local-repair")
 
-	dag := server.DAG(t, `
-name: api-stale-local-repair
-steps:
-  - name: step1
-    command: sleep 2
-`)
-
-	dagRunID := uuid.Must(uuid.NewV7()).String()
-	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
-	attempt, err := server.DAGRunStore.CreateAttempt(server.Context, dag.DAG, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{})
-	require.NoError(t, err)
-
-	logFile := filepath.Join(server.Config.Paths.LogDir, dag.Name, dagRunID+".log")
-	require.NoError(t, os.MkdirAll(filepath.Dir(logFile), 0o750))
-
-	status := transform.NewStatusBuilder(dag.DAG).Create(
-		dagRunID,
-		core.Running,
-		0,
-		time.Now().Add(-2*time.Second),
-		transform.WithAttemptID(attempt.ID()),
-		transform.WithHierarchyRefs(ref, exec.DAGRunRef{}),
-		transform.WithLogFilePath(logFile),
-	)
-	require.NotEmpty(t, status.Nodes)
-	status.Nodes[0].Status = core.NodeRunning
-
-	require.NoError(t, attempt.Open(server.Context))
-	require.NoError(t, attempt.Write(server.Context, status))
-	require.NoError(t, attempt.Close(server.Context))
-
-	_ = test.CreateStaleProcFileWithAttempt(
-		t,
-		server.Config.Paths.ProcDir,
-		dag.ProcGroup(),
-		ref,
-		attempt.ID(),
-		time.Now().Add(-2*time.Second),
-		time.Second,
-	)
-
-	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", dag.Name, dagRunID)).
+	resp := fixture.server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", fixture.dag.Name, fixture.dagRunID)).
 		ExpectStatus(http.StatusOK).
 		Send(t)
 
 	var details api.GetDAGRunDetails200JSONResponse
 	resp.Unmarshal(t, &details)
 	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
-
-	repaired := test.ReadRunStatus(server.Context, t, server.DAGRunStore, ref)
-	require.Equal(t, core.Failed, repaired.Status)
-	require.Len(t, repaired.Nodes, 1)
-	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
-	require.Contains(t, repaired.Nodes[0].Error, "stale local process detected")
+	requireFailedStaleLocalRun(t, fixture.server, fixture.ref)
 }
 
 func TestServerRepairsStaleLocalLatestRunOnRead(t *testing.T) {
+	fixture := setupStaleLocalRun(t, "api-stale-local-latest-repair")
+
+	resp := fixture.server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/latest", fixture.dag.Name)).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+
+	var details api.GetDAGRunDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
+	require.Equal(t, fixture.dagRunID, details.DagRunDetails.DagRunId)
+	requireFailedStaleLocalRun(t, fixture.server, fixture.ref)
+}
+
+func TestServerRepairsStaleLocalLatestScopedRunOnRead(t *testing.T) {
+	fixture := setupStaleLocalRun(t, "api-stale-local-scoped-latest-repair")
+
+	resp := fixture.server.Client().Get(fmt.Sprintf("/api/v1/dags/%s/dag-runs/latest", fixture.dag.FileName())).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+
+	var details api.GetDAGDAGRunDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.Equal(t, api.Status(core.Failed), details.DagRun.Status)
+	require.Equal(t, fixture.dagRunID, details.DagRun.DagRunId)
+	requireFailedStaleLocalRun(t, fixture.server, fixture.ref)
+}
+
+func setupStaleLocalRun(t *testing.T, dagName string) staleLocalRunFixture {
+	t.Helper()
+
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = 50 * time.Millisecond
 		cfg.Proc.HeartbeatSyncInterval = 50 * time.Millisecond
 		cfg.Proc.StaleThreshold = 100 * time.Millisecond
 	}))
 
-	dag := server.DAG(t, `
-name: api-stale-local-latest-repair
+	dag := server.DAG(t, fmt.Sprintf(`
+name: %s
 steps:
   - name: step1
     command: sleep 2
-`)
+`, dagName))
 
 	dagRunID := uuid.Must(uuid.NewV7()).String()
 	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
@@ -200,14 +187,16 @@ steps:
 		time.Second,
 	)
 
-	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/latest", dag.Name)).
-		ExpectStatus(http.StatusOK).
-		Send(t)
+	return staleLocalRunFixture{
+		server:   server,
+		dag:      dag,
+		dagRunID: dagRunID,
+		ref:      ref,
+	}
+}
 
-	var details api.GetDAGRunDetails200JSONResponse
-	resp.Unmarshal(t, &details)
-	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
-	require.Equal(t, dagRunID, details.DagRunDetails.DagRunId)
+func requireFailedStaleLocalRun(t *testing.T, server test.Server, ref exec.DAGRunRef) {
+	t.Helper()
 
 	repaired := test.ReadRunStatus(server.Context, t, server.DAGRunStore, ref)
 	require.Equal(t, core.Failed, repaired.Status)

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/test"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -149,4 +150,75 @@ steps:
 	require.Len(t, repaired.Nodes, 1)
 	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
 	require.Contains(t, repaired.Nodes[0].Error, "stale local process detected")
+}
+
+func TestServerRepairsConfirmedStaleDistributedRunOnDetailsRead(t *testing.T) {
+	server := test.SetupServer(t)
+
+	dag := server.DAG(t, `
+name: api-stale-distributed-repair
+steps:
+  - name: step1
+    command: sleep 2
+`)
+
+	dagRunID := uuid.Must(uuid.NewV7()).String()
+	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
+	attempt, err := server.DAGRunStore.CreateAttempt(server.Context, dag.DAG, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+
+	logFile := filepath.Join(server.Config.Paths.LogDir, dag.Name, dagRunID+".log")
+	require.NoError(t, os.MkdirAll(filepath.Dir(logFile), 0o750))
+
+	status := transform.NewStatusBuilder(dag.DAG).Create(
+		dagRunID,
+		core.Running,
+		0,
+		time.Now().Add(-2*time.Second),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithHierarchyRefs(ref, exec.DAGRunRef{}),
+		transform.WithLogFilePath(logFile),
+	)
+	status.AttemptID = attempt.ID()
+	status.AttemptKey = exec.GenerateAttemptKey(dag.Name, dagRunID, dag.Name, dagRunID, attempt.ID())
+	status.WorkerID = "worker-1"
+	require.NotEmpty(t, status.Nodes)
+	status.Nodes[0].Status = core.NodeRunning
+
+	require.NoError(t, attempt.Open(server.Context))
+	require.NoError(t, attempt.Write(server.Context, status))
+	require.NoError(t, attempt.Close(server.Context))
+
+	staleAt := time.Now().Add(-2 * time.Minute).UTC()
+	require.NoError(t, server.DAGRunLeaseStore.Upsert(server.Context, exec.DAGRunLease{
+		AttemptKey:      status.AttemptKey,
+		DAGRun:          ref,
+		Root:            ref,
+		AttemptID:       status.AttemptID,
+		QueueName:       dag.Name,
+		WorkerID:        status.WorkerID,
+		ClaimedAt:       staleAt.UnixMilli(),
+		LastHeartbeatAt: staleAt.UnixMilli(),
+	}))
+	require.NoError(t, server.WorkerHeartbeatStore.Upsert(server.Context, exec.WorkerHeartbeatRecord{
+		WorkerID:        status.WorkerID,
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+		Stats: &coordinatorv1.WorkerStats{
+			RunningTasks: []*coordinatorv1.RunningTask{},
+		},
+	}))
+
+	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", dag.Name, dagRunID)).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+
+	var details api.GetDAGRunDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
+
+	repaired := test.ReadRunStatus(server.Context, t, server.DAGRunStore, ref)
+	require.Equal(t, core.Failed, repaired.Status)
+	require.Len(t, repaired.Nodes, 1)
+	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
+	require.Contains(t, repaired.Nodes[0].Error, "distributed run lease expired")
 }

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -152,6 +152,70 @@ steps:
 	require.Contains(t, repaired.Nodes[0].Error, "stale local process detected")
 }
 
+func TestServerRepairsStaleLocalLatestRunOnRead(t *testing.T) {
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Proc.HeartbeatInterval = 50 * time.Millisecond
+		cfg.Proc.HeartbeatSyncInterval = 50 * time.Millisecond
+		cfg.Proc.StaleThreshold = 100 * time.Millisecond
+	}))
+
+	dag := server.DAG(t, `
+name: api-stale-local-latest-repair
+steps:
+  - name: step1
+    command: sleep 2
+`)
+
+	dagRunID := uuid.Must(uuid.NewV7()).String()
+	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
+	attempt, err := server.DAGRunStore.CreateAttempt(server.Context, dag.DAG, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+
+	logFile := filepath.Join(server.Config.Paths.LogDir, dag.Name, dagRunID+".log")
+	require.NoError(t, os.MkdirAll(filepath.Dir(logFile), 0o750))
+
+	status := transform.NewStatusBuilder(dag.DAG).Create(
+		dagRunID,
+		core.Running,
+		0,
+		time.Now().Add(-2*time.Second),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithHierarchyRefs(ref, exec.DAGRunRef{}),
+		transform.WithLogFilePath(logFile),
+	)
+	require.NotEmpty(t, status.Nodes)
+	status.Nodes[0].Status = core.NodeRunning
+
+	require.NoError(t, attempt.Open(server.Context))
+	require.NoError(t, attempt.Write(server.Context, status))
+	require.NoError(t, attempt.Close(server.Context))
+
+	_ = test.CreateStaleProcFileWithAttempt(
+		t,
+		server.Config.Paths.ProcDir,
+		dag.ProcGroup(),
+		ref,
+		attempt.ID(),
+		time.Now().Add(-2*time.Second),
+		time.Second,
+	)
+
+	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/latest", dag.Name)).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+
+	var details api.GetDAGRunDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
+	require.Equal(t, dagRunID, details.DagRunDetails.DagRunId)
+
+	repaired := test.ReadRunStatus(server.Context, t, server.DAGRunStore, ref)
+	require.Equal(t, core.Failed, repaired.Status)
+	require.Len(t, repaired.Nodes, 1)
+	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
+	require.Contains(t, repaired.Nodes[0].Error, "stale local process detected")
+}
+
 func TestServerRepairsConfirmedStaleDistributedRunOnDetailsRead(t *testing.T) {
 	server := test.SetupServer(t)
 

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -222,3 +222,73 @@ steps:
 	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
 	require.Contains(t, repaired.Nodes[0].Error, "distributed run lease expired")
 }
+
+func TestServerRepairsConfirmedStaleDistributedRunOnDetailsReadWithoutSavedWorkerID(t *testing.T) {
+	server := test.SetupServer(t)
+
+	dag := server.DAG(t, `
+name: api-stale-distributed-repair-no-worker
+steps:
+  - name: step1
+    command: sleep 2
+`)
+
+	dagRunID := uuid.Must(uuid.NewV7()).String()
+	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
+	attempt, err := server.DAGRunStore.CreateAttempt(server.Context, dag.DAG, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+
+	logFile := filepath.Join(server.Config.Paths.LogDir, dag.Name, dagRunID+".log")
+	require.NoError(t, os.MkdirAll(filepath.Dir(logFile), 0o750))
+
+	status := transform.NewStatusBuilder(dag.DAG).Create(
+		dagRunID,
+		core.NotStarted,
+		0,
+		time.Now().Add(-2*time.Second),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithHierarchyRefs(ref, exec.DAGRunRef{}),
+		transform.WithLogFilePath(logFile),
+	)
+	status.AttemptID = attempt.ID()
+	status.AttemptKey = exec.GenerateAttemptKey(dag.Name, dagRunID, dag.Name, dagRunID, attempt.ID())
+	require.NotEmpty(t, status.Nodes)
+	status.Nodes[0].Status = core.NodeRunning
+
+	require.NoError(t, attempt.Open(server.Context))
+	require.NoError(t, attempt.Write(server.Context, status))
+	require.NoError(t, attempt.Close(server.Context))
+
+	staleAt := time.Now().Add(-2 * time.Minute).UTC()
+	require.NoError(t, server.DAGRunLeaseStore.Upsert(server.Context, exec.DAGRunLease{
+		AttemptKey:      status.AttemptKey,
+		DAGRun:          ref,
+		Root:            ref,
+		AttemptID:       status.AttemptID,
+		QueueName:       dag.Name,
+		WorkerID:        "worker-1",
+		ClaimedAt:       staleAt.UnixMilli(),
+		LastHeartbeatAt: staleAt.UnixMilli(),
+	}))
+	require.NoError(t, server.WorkerHeartbeatStore.Upsert(server.Context, exec.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+		Stats: &coordinatorv1.WorkerStats{
+			RunningTasks: []*coordinatorv1.RunningTask{},
+		},
+	}))
+
+	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", dag.Name, dagRunID)).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+
+	var details api.GetDAGRunDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.Equal(t, api.Status(core.Failed), details.DagRunDetails.Status)
+
+	repaired := test.ReadRunStatus(server.Context, t, server.DAGRunStore, ref)
+	require.Equal(t, core.Failed, repaired.Status)
+	require.Len(t, repaired.Nodes, 1)
+	require.Equal(t, core.NodeFailed, repaired.Nodes[0].Status)
+	require.Contains(t, repaired.Nodes[0].Error, "distributed run lease expired")
+}

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -278,7 +278,13 @@ func (z *ZombieDetector) cleanupOrphanedStaleEntry(ctx context.Context, entry ex
 		return fmt.Errorf("find attempt: %w", findErr)
 	}
 
-	logger.Info(ctx, "Removing orphaned stale proc entry with missing persisted DAG run state", tag.Error(findErr))
+	if errors.Is(findErr, exec.ErrCorruptedStatusFile) {
+		logger.Warn(ctx, "Removing orphaned stale proc entry with corrupted persisted DAG run state", tag.Error(findErr))
+	} else {
+		logger.Info(ctx, "Removing orphaned stale proc entry with missing persisted DAG run state", tag.Error(findErr))
+	}
+	// A corrupted or missing status snapshot cannot be used for recovery, so the
+	// stale proc entry must be dropped to stop reporting the run as active.
 	z.clearAttemptState(attemptKey)
 	if err := z.procStore.RemoveIfStale(ctx, entry); err != nil {
 		return fmt.Errorf("remove orphaned stale proc: %w", err)

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -272,11 +272,13 @@ func (z *ZombieDetector) checkAndCleanZombie(ctx context.Context, entry exec.Pro
 }
 
 func (z *ZombieDetector) cleanupOrphanedStaleEntry(ctx context.Context, entry exec.ProcEntry, attemptKey string, findErr error) error {
-	if !errors.Is(findErr, exec.ErrDAGRunIDNotFound) {
+	if !errors.Is(findErr, exec.ErrDAGRunIDNotFound) &&
+		!errors.Is(findErr, exec.ErrNoStatusData) &&
+		!errors.Is(findErr, exec.ErrCorruptedStatusFile) {
 		return fmt.Errorf("find attempt: %w", findErr)
 	}
 
-	logger.Info(ctx, "Removing orphaned stale proc entry with no persisted DAG run", tag.Error(findErr))
+	logger.Info(ctx, "Removing orphaned stale proc entry with missing persisted DAG run state", tag.Error(findErr))
 	z.clearAttemptState(attemptKey)
 	if err := z.procStore.RemoveIfStale(ctx, entry); err != nil {
 		return fmt.Errorf("remove orphaned stale proc: %w", err)

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -227,6 +227,26 @@ func TestZombieDetectorDetectAndCleanZombies_OrphanedStaleEntryIsRemoved(t *test
 	dagRunStore.AssertExpectations(t)
 }
 
+func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithMissingStatusIsRemoved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	detector := NewZombieDetector(dagRunStore, procStore, time.Second, 1)
+
+	entry := testRootProcEntry("queue", "test-dag", "run-1", "attempt-1", false)
+
+	procStore.On("ListAllEntries", ctx).Return([]exec.ProcEntry{entry}, nil).Once()
+	dagRunStore.On("FindAttempt", mock.Anything, exec.NewDAGRunRef("test-dag", "run-1")).Return(nil, exec.ErrNoStatusData).Once()
+	procStore.On("RemoveIfStale", mock.Anything, entry).Return(nil).Once()
+
+	detector.detectAndCleanZombies(ctx)
+
+	procStore.AssertExpectations(t)
+	dagRunStore.AssertExpectations(t)
+}
+
 func testRootProcEntry(groupName, dagName, dagRunID, attemptID string, fresh bool) exec.ProcEntry {
 	return exec.ProcEntry{
 		GroupName: groupName,

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -247,6 +247,26 @@ func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithMissingStatusIsRemove
 	dagRunStore.AssertExpectations(t)
 }
 
+func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithCorruptedStatusIsRemoved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	detector := NewZombieDetector(dagRunStore, procStore, time.Second, 1)
+
+	entry := testRootProcEntry("queue", "test-dag", "run-1", "attempt-1", false)
+
+	procStore.On("ListAllEntries", ctx).Return([]exec.ProcEntry{entry}, nil).Once()
+	dagRunStore.On("FindAttempt", mock.Anything, exec.NewDAGRunRef("test-dag", "run-1")).Return(nil, exec.ErrCorruptedStatusFile).Once()
+	procStore.On("RemoveIfStale", mock.Anything, entry).Return(nil).Once()
+
+	detector.detectAndCleanZombies(ctx)
+
+	procStore.AssertExpectations(t)
+	dagRunStore.AssertExpectations(t)
+}
+
 func testRootProcEntry(groupName, dagName, dagRunID, attemptID string, fresh bool) exec.ProcEntry {
 	return exec.ProcEntry{
 		GroupName: groupName,

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/telemetry"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/frontend"
+	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -94,7 +95,11 @@ func (srv *Server) runServer(t *testing.T, listener net.Listener, errChan chan<-
 	mr := telemetry.NewRegistry(collector)
 
 	// Pass the pre-bound listener to the server to avoid port race conditions
-	serverOpts := append([]frontend.ServerOption{frontend.WithListener(listener)}, srv.ServerOptions...)
+	serverOpts := append([]frontend.ServerOption{
+		frontend.WithListener(listener),
+		frontend.WithAPIOption(apiv1.WithDAGRunLeaseStore(srv.DAGRunLeaseStore)),
+		frontend.WithAPIOption(apiv1.WithWorkerHeartbeatStore(srv.WorkerHeartbeatStore)),
+	}, srv.ServerOptions...)
 	server, err := frontend.NewServer(
 		srv.Context, srv.Config, srv.DAGStore, srv.DAGRunStore,
 		srv.QueueStore, srv.ProcStore, srv.DAGRunMgr, cc,


### PR DESCRIPTION
## Summary
- require corroborating worker-heartbeat evidence before failing stale distributed runs
- repair confirmed stale distributed runs on single-run details reads without adding list-endpoint repair work
- add regression coverage for worker heartbeat lookup, coordinator zombie reconciliation, and frontend read-time repair

## Testing
- go test ./internal/persis/filedistributed -count=1
- go test ./internal/service/coordinator -count=1
- go test ./internal/service/frontend/api/v1 -count=1
- go test ./internal/intg/distr -run 'TestDistributedRun_AckedTaskWithoutInitialStatus_MarkedFailedAndCleansLease|TestZombieRecovery|TestCoordinatorAPI' -count=1

Closes #2040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic reconciliation of stale distributed run statuses, checking worker heartbeat data to determine if repair is needed.

* **Bug Fixes**
  * Improved detection of truly abandoned distributed runs by validating worker heartbeat activity before marking runs as failed, reducing false-positive failures from stale lease records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->