### PR TITLE
fix: preserve edited schedules across suspension rewrites

### DIFF
--- a/internal/intg/issue_2042_test.go
+++ b/internal/intg/issue_2042_test.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue2042_EditedSuspendedScheduleDispatchesWithSkipIfSuccessful(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dagsDir := filepath.Join(tmpDir, "dags")
+	require.NoError(t, os.MkdirAll(dagsDir, 0o755))
+
+	const dagName = "issue-2042-skip-if-successful"
+	dagFile := filepath.Join(dagsDir, dagName+".yaml")
+	require.NoError(t, os.WriteFile(dagFile, []byte(issue2042DAGSpec(dagName, "34 * * * *")), 0o600))
+
+	th := test.SetupScheduler(t, test.WithDAGsDir(dagsDir))
+
+	dispatchedAt := make(chan time.Time, 4)
+	dispatchStub := func(ctx context.Context, dag *core.DAG, runID string, trigger core.TriggerType, scheduleTime time.Time) error {
+		attempt, err := th.DAGRunStore.CreateAttempt(ctx, dag, scheduleTime, runID, exec.NewDAGRunAttemptOptions{})
+		if err != nil {
+			return err
+		}
+
+		status := transform.NewStatusBuilder(dag).Create(
+			runID,
+			core.Succeeded,
+			0,
+			scheduleTime,
+			transform.WithAttemptID(attempt.ID()),
+			transform.WithHierarchyRefs(exec.NewDAGRunRef(dag.Name, runID), exec.DAGRunRef{}),
+			transform.WithFinishedAt(scheduleTime.Add(time.Second)),
+			transform.WithScheduleTime(exec.FormatTime(scheduleTime)),
+			transform.WithTriggerType(trigger),
+		)
+
+		if err := attempt.Open(ctx); err != nil {
+			return err
+		}
+		if err := attempt.Write(ctx, status); err != nil {
+			return err
+		}
+		if err := attempt.Close(ctx); err != nil {
+			return err
+		}
+
+		dispatchedAt <- scheduleTime
+		return nil
+	}
+
+	runScheduledTick := func(tickTime time.Time) time.Time {
+		t.Helper()
+
+		schedulerInstance, err := th.NewSchedulerInstance(t)
+		require.NoError(t, err)
+		schedulerInstance.SetClock(func() time.Time { return tickTime })
+		schedulerInstance.SetDispatchFunc(dispatchStub)
+
+		ctx, cancel := context.WithCancel(th.Context)
+		defer cancel()
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- schedulerInstance.Start(ctx) }()
+
+		var (
+			schedulerErr     error
+			schedulerStopped bool
+		)
+		pollSchedulerErr := func() error {
+			if schedulerStopped {
+				return schedulerErr
+			}
+			select {
+			case err := <-errCh:
+				schedulerStopped = true
+				if err == nil {
+					err = errors.New("scheduler exited unexpectedly before test completed")
+				}
+				schedulerErr = err
+			default:
+			}
+			return schedulerErr
+		}
+
+		var dispatched time.Time
+		require.Eventually(t, func() bool {
+			if err := pollSchedulerErr(); err != nil {
+				return true
+			}
+			select {
+			case dispatched = <-dispatchedAt:
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, 50*time.Millisecond)
+		require.NoError(t, schedulerErr)
+
+		schedulerInstance.Stop(ctx)
+		cancel()
+
+		if !schedulerStopped {
+			select {
+			case err := <-errCh:
+				require.True(t,
+					err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+					"unexpected scheduler shutdown error: %v", err,
+				)
+			case <-time.After(5 * time.Second):
+				t.Fatal("scheduler did not stop within 5 seconds")
+			}
+		}
+
+		return dispatched
+	}
+
+	firstDispatch := runScheduledTick(time.Date(2026, 2, 7, 12, 34, 0, 0, time.UTC))
+	require.Equal(t, time.Date(2026, 2, 7, 12, 34, 0, 0, time.UTC), firstDispatch)
+
+	require.NoError(t, th.DAGStore.ToggleSuspend(th.Context, dagName, true))
+	require.NoError(t, os.WriteFile(dagFile, []byte(issue2042DAGSpec(dagName, "43 * * * *")), 0o600))
+	require.NoError(t, th.DAGStore.ToggleSuspend(th.Context, dagName, false))
+
+	secondDispatch := runScheduledTick(time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC))
+	require.Equal(t, time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC), secondDispatch)
+}
+
+func issue2042DAGSpec(name, schedule string) string {
+	return "name: " + name + "\n" +
+		"schedule: \"" + schedule + "\"\n" +
+		"skip_if_successful: true\n" +
+		"steps:\n" +
+		"  - command: echo issue-2042\n"
+}

--- a/internal/intg/sched_test.go
+++ b/internal/intg/sched_test.go
@@ -189,7 +189,7 @@ func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
 		return nil
 	})
 
-	clockBase := time.Date(2026, 4, 27, 10, 4, 59, 0, time.UTC)
+	clockBase := time.Date(2026, 4, 27, 10, 4, 30, 0, time.UTC)
 	clockStart := time.Now()
 	sc.SetClock(func() time.Time {
 		return clockBase.Add(time.Since(clockStart))
@@ -219,9 +219,23 @@ func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
 		return schedulerErr
 	}
 
+	schedulerHasSchedule := func(expression string) bool {
+		for _, loaded := range th.EntryReader.DAGs() {
+			if loaded.Name != dagName || len(loaded.Schedule) != 1 {
+				continue
+			}
+			return loaded.Schedule[0].Expression == expression
+		}
+		return false
+	}
+
 	require.Eventually(t, func() bool {
-		return sc.IsRunning()
+		if err := pollSchedulerErr(); err != nil {
+			return true
+		}
+		return sc.IsRunning() && schedulerHasSchedule("0 10 * * *")
 	}, intgTestTimeout(2*time.Second), 50*time.Millisecond)
+	require.NoError(t, schedulerErr)
 
 	writeSpec("5 10 * * *")
 
@@ -229,13 +243,7 @@ func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
 		if err := pollSchedulerErr(); err != nil {
 			return true
 		}
-		for _, loaded := range th.EntryReader.DAGs() {
-			if loaded.Name != dagName || len(loaded.Schedule) != 1 {
-				continue
-			}
-			return loaded.Schedule[0].Expression == "5 10 * * *"
-		}
-		return false
+		return schedulerHasSchedule("5 10 * * *")
 	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
 	require.NoError(t, schedulerErr)
 
@@ -246,7 +254,7 @@ func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
 			return true
 		}
 		return dispatchCount.Load() > 0
-	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
+	}, intgTestTimeout(35*time.Second), 50*time.Millisecond)
 	require.NoError(t, schedulerErr)
 	require.Equal(t, int32(1), dispatchCount.Load(), "edited schedules should dispatch exactly once")
 	lastDispatchMu.Lock()

--- a/internal/intg/sched_test.go
+++ b/internal/intg/sched_test.go
@@ -9,11 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/test"
 	"github.com/stretchr/testify/require"
@@ -118,4 +121,151 @@ steps:
 	}
 
 	require.GreaterOrEqual(t, dispatchCount.Load(), int32(2))
+}
+
+func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
+	tmpDir := t.TempDir()
+	dagsDir := filepath.Join(tmpDir, "dags")
+	require.NoError(t, os.MkdirAll(dagsDir, 0o755))
+
+	const dagName = "issue-2042-skip-success"
+	dagPath := filepath.Join(dagsDir, dagName+".yaml")
+
+	writeSpec := func(schedule string) {
+		spec := "name: " + dagName + "\n" +
+			"schedule: \"" + schedule + "\"\n" +
+			"skip_if_successful: true\n" +
+			"steps:\n" +
+			"  - name: step\n" +
+			"    command: echo \"hello\"\n"
+		require.NoError(t, fileutil.WriteFileAtomic(dagPath, []byte(spec), 0o644))
+	}
+
+	oldSlot := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	newSlot := time.Date(2026, 4, 27, 10, 5, 0, 0, time.UTC)
+	writeSpec("0 10 * * *")
+
+	th := test.SetupScheduler(t, test.WithDAGsDir(dagsDir))
+	dag, err := th.DAGStore.GetDetails(th.Context, dagName)
+	require.NoError(t, err)
+
+	require.NoError(t, os.MkdirAll(th.Config.Paths.SuspendFlagsDir, 0o755))
+	suspendFlag := filepath.Join(th.Config.Paths.SuspendFlagsDir, dag.SuspendFlagName())
+	require.NoError(t, os.WriteFile(suspendFlag, []byte{}, 0o644))
+
+	attempt, err := th.DAGRunStore.CreateAttempt(th.Context, dag, oldSlot, "old-success", exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+
+	status := exec.InitialStatus(dag)
+	status.DAGRunID = "old-success"
+	status.AttemptID = attempt.ID()
+	status.Status = core.Succeeded
+	status.TriggerType = core.TriggerTypeScheduler
+	status.ScheduleTime = exec.FormatTime(oldSlot)
+	status.StartedAt = exec.FormatTime(oldSlot.Add(15 * time.Second))
+	status.FinishedAt = exec.FormatTime(oldSlot.Add(45 * time.Second))
+
+	require.NoError(t, attempt.Open(th.Context))
+	require.NoError(t, attempt.Write(th.Context, status))
+	require.NoError(t, attempt.Close(th.Context))
+
+	sc, err := th.NewSchedulerInstance(t)
+	require.NoError(t, err)
+
+	var (
+		dispatchCount    atomic.Int32
+		lastDispatchMu   sync.Mutex
+		lastDispatchTime time.Time
+		lastDispatchType core.TriggerType
+	)
+	sc.SetDispatchFunc(func(_ context.Context, dag *core.DAG, _ string, trigger core.TriggerType, scheduleTime time.Time) error {
+		if dag != nil && dag.Name == dagName {
+			dispatchCount.Add(1)
+			lastDispatchMu.Lock()
+			lastDispatchType = trigger
+			lastDispatchTime = scheduleTime
+			lastDispatchMu.Unlock()
+		}
+		return nil
+	})
+
+	clockBase := time.Date(2026, 4, 27, 10, 4, 59, 0, time.UTC)
+	clockStart := time.Now()
+	sc.SetClock(func() time.Time {
+		return clockBase.Add(time.Since(clockStart))
+	})
+
+	ctx, cancel := context.WithCancel(th.Context)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- sc.Start(ctx) }()
+
+	var schedulerErr error
+	var schedulerStopped bool
+	pollSchedulerErr := func() error {
+		if schedulerStopped {
+			return schedulerErr
+		}
+		select {
+		case err := <-errCh:
+			schedulerStopped = true
+			if err == nil {
+				err = errors.New("scheduler exited unexpectedly before test completed")
+			}
+			schedulerErr = err
+		default:
+		}
+		return schedulerErr
+	}
+
+	require.Eventually(t, func() bool {
+		return sc.IsRunning()
+	}, intgTestTimeout(2*time.Second), 50*time.Millisecond)
+
+	writeSpec("5 10 * * *")
+
+	require.Eventually(t, func() bool {
+		if err := pollSchedulerErr(); err != nil {
+			return true
+		}
+		for _, loaded := range th.EntryReader.DAGs() {
+			if loaded.Name != dagName || len(loaded.Schedule) != 1 {
+				continue
+			}
+			return loaded.Schedule[0].Expression == "5 10 * * *"
+		}
+		return false
+	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
+	require.NoError(t, schedulerErr)
+
+	require.NoError(t, os.Remove(suspendFlag))
+
+	require.Eventually(t, func() bool {
+		if err := pollSchedulerErr(); err != nil {
+			return true
+		}
+		return dispatchCount.Load() > 0
+	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
+	require.NoError(t, schedulerErr)
+	require.Equal(t, int32(1), dispatchCount.Load(), "edited schedules should dispatch exactly once")
+	lastDispatchMu.Lock()
+	require.Equal(t, core.TriggerTypeScheduler, lastDispatchType)
+	require.Equal(t, newSlot, lastDispatchTime)
+	lastDispatchMu.Unlock()
+
+	sc.Stop(context.Background())
+	cancel()
+
+	if !schedulerStopped {
+		select {
+		case err := <-errCh:
+			require.True(t,
+				err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+				"unexpected scheduler shutdown error: %v", err,
+			)
+		case <-time.After(intgTestTimeout(5 * time.Second)):
+			t.Fatal("scheduler did not stop within 5 seconds")
+		}
+	}
 }

--- a/internal/persis/filewatermark/store.go
+++ b/internal/persis/filewatermark/store.go
@@ -55,7 +55,7 @@ func (s *Store) Load(ctx context.Context) (*scheduler.SchedulerState, error) {
 	const expectedVersion = scheduler.SchedulerStateVersion
 	switch state.Version {
 	case expectedVersion:
-	case 0, 1:
+	case 0, 1, 2:
 		migrated, migrateErr := migrateWatermarkState(state.Version, &state)
 		if migrateErr != nil {
 			logger.Warn(ctx, "Failed to migrate watermark state, starting fresh",
@@ -154,6 +154,9 @@ func migrateWatermarkState(version int, state *scheduler.SchedulerState) (*sched
 		migrated.Version = 1
 		return migrateWatermarkState(1, &migrated)
 	case 1:
+		migrated.Version = 2
+		return migrateWatermarkState(2, &migrated)
+	case 2:
 		migrated.Version = scheduler.SchedulerStateVersion
 		if migrated.DAGs == nil {
 			migrated.DAGs = make(map[string]scheduler.DAGWatermark)

--- a/internal/persis/filewatermark/store_test.go
+++ b/internal/persis/filewatermark/store_test.go
@@ -169,6 +169,21 @@ func TestStore_LoadMigratesVersionOneState(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 2, 7, 11, 0, 0, 0, time.UTC), state.DAGs["legacy"].LastScheduledTime)
 }
 
+func TestStore_LoadMigratesVersionTwoState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := New(dir)
+
+	data := []byte(`{"version":2,"lastTick":"2026-02-07T12:00:00Z","dags":{"legacy":{"lastScheduledTime":"2026-02-07T11:00:00Z"}}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, stateFileName), data, 0o600))
+
+	state, err := store.Load(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, scheduler.SchedulerStateVersion, state.Version)
+	assert.Equal(t, time.Date(2026, 2, 7, 11, 0, 0, 0, time.UTC), state.DAGs["legacy"].LastScheduledTime)
+}
+
 func TestStore_LoadMigratesVersionZeroState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dagucloud/dagu/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis/fileeventstore"
@@ -741,22 +740,14 @@ func TestNotificationMonitor_LockTheftSelfFencesActiveOwner(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return monitor.ownsNotificationLock() && monitor.notificationSessionActive()
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	lockDir := notificationStateLockDir(stateFile)
 	lockTokenPath := filepath.Join(lockDir, ".dagu_lock", "owner")
 	require.NoError(t, os.WriteFile(lockTokenPath, []byte("replacement-owner"), 0o600))
 	require.Eventually(t, func() bool {
 		return !monitor.ownsNotificationLock() && !monitor.notificationSessionActive()
-	}, 2*time.Second, 10*time.Millisecond)
-
-	require.NoError(t, dirlock.ForceUnlock(lockDir))
-	replacement := dirlock.New(lockDir, &dirlock.LockOptions{
-		StaleThreshold: time.Hour,
-		RetryInterval:  10 * time.Millisecond,
-	})
-	require.NoError(t, replacement.TryLock())
-	defer func() { _ = replacement.Unlock() }()
+	}, notificationMonitorEventuallyTimeout(2*time.Second), 10*time.Millisecond)
 
 	status := &exec.DAGRunStatus{
 		Name:       "briefing",

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -83,6 +83,7 @@ type API struct {
 	workspaceStore       workspace.Store
 	leaseStaleThreshold  time.Duration
 	schedulerStateStore  scheduler.WatermarkStore
+	dagMutationNotifier  func(fileName string)
 }
 
 // AuthService defines the interface for authentication operations.
@@ -242,6 +243,14 @@ func WithSchedulerStateStore(store scheduler.WatermarkStore) APIOption {
 	}
 }
 
+// WithDAGMutationNotifier returns an APIOption that is called after successful
+// DAG definition mutations that should invalidate live DAG views.
+func WithDAGMutationNotifier(fn func(fileName string)) APIOption {
+	return func(a *API) {
+		a.dagMutationNotifier = fn
+	}
+}
+
 // WithDAGRunLeaseStore sets the shared distributed run lease store.
 func WithDAGRunLeaseStore(store exec.DAGRunLeaseStore) APIOption {
 	return func(a *API) {
@@ -315,6 +324,12 @@ func New(
 	a.dagWritesDisabled = cfg.GitSync.Enabled && !cfg.GitSync.PushEnabled
 
 	return a
+}
+
+func (a *API) notifyDAGMutation(fileName string) {
+	if a.dagMutationNotifier != nil {
+		a.dagMutationNotifier(fileName)
+	}
 }
 
 func (a *API) ConfigureRoutes(ctx context.Context, r chi.Router) error {

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -317,6 +317,7 @@ func (a *API) UpdateDAGSpec(ctx context.Context, request api.UpdateDAGSpecReques
 	}
 
 	a.logAudit(ctx, audit.CategoryDAG, "dag_update", map[string]any{"dag_name": request.FileName})
+	a.notifyDAGMutation(request.FileName)
 
 	return api.UpdateDAGSpec200JSONResponse{
 		Errors: errs,
@@ -1615,6 +1616,7 @@ func (a *API) UpdateDAGSuspensionState(ctx context.Context, request api.UpdateDA
 		"dag_name":  request.FileName,
 		"suspended": request.Body.Suspend,
 	})
+	a.notifyDAGMutation(request.FileName)
 
 	return api.UpdateDAGSuspensionState200Response{}, nil
 }

--- a/internal/service/frontend/api/v1/dags_internal_test.go
+++ b/internal/service/frontend/api/v1/dags_internal_test.go
@@ -399,6 +399,94 @@ func TestUpdateDAGSpec_ReturnsFatalLoadSpecError(t *testing.T) {
 	require.False(t, dagStore.updateCalled)
 }
 
+func TestUpdateDAGSpec_NotifiesDAGMutation(t *testing.T) {
+	t.Parallel()
+
+	helper := test.Setup(t, test.WithStatusPersistence())
+	helper.CreateDAGFile(t, helper.Config.Paths.DAGsDir, "dag-update-notify", []byte(`
+name: dag-update-notify
+schedule: "34 * * * *"
+steps:
+  - command: echo original
+`))
+
+	var notified []string
+	api := localapi.New(
+		helper.DAGStore,
+		helper.DAGRunStore,
+		helper.QueueStore,
+		helper.ProcStore,
+		helper.DAGRunMgr,
+		helper.Config,
+		nil,
+		helper.ServiceRegistry,
+		nil,
+		nil,
+		localapi.WithDAGMutationNotifier(func(fileName string) {
+			notified = append(notified, fileName)
+		}),
+	)
+
+	respObj, err := api.UpdateDAGSpec(context.Background(), openapi.UpdateDAGSpecRequestObject{
+		FileName: "dag-update-notify",
+		Body: &openapi.UpdateDAGSpecJSONRequestBody{
+			Spec: `
+name: dag-update-notify
+schedule: "43 * * * *"
+steps:
+  - command: echo updated
+`,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, ok := respObj.(openapi.UpdateDAGSpec200JSONResponse)
+	require.True(t, ok, "expected 200 response, got %T", respObj)
+	require.Empty(t, resp.Errors)
+	require.Equal(t, []string{"dag-update-notify"}, notified)
+}
+
+func TestUpdateDAGSuspensionState_NotifiesDAGMutation(t *testing.T) {
+	t.Parallel()
+
+	helper := test.Setup(t, test.WithStatusPersistence())
+	dag := helper.DAG(t, `
+name: dag-suspend-notify
+schedule: "43 * * * *"
+steps:
+  - command: echo original
+`)
+
+	var notified []string
+	api := localapi.New(
+		helper.DAGStore,
+		helper.DAGRunStore,
+		helper.QueueStore,
+		helper.ProcStore,
+		helper.DAGRunMgr,
+		helper.Config,
+		nil,
+		helper.ServiceRegistry,
+		nil,
+		nil,
+		localapi.WithDAGMutationNotifier(func(fileName string) {
+			notified = append(notified, fileName)
+		}),
+	)
+
+	respObj, err := api.UpdateDAGSuspensionState(context.Background(), openapi.UpdateDAGSuspensionStateRequestObject{
+		FileName: dag.FileName(),
+		Body: &openapi.UpdateDAGSuspensionStateJSONRequestBody{
+			Suspend: true,
+		},
+	})
+	require.NoError(t, err)
+
+	_, ok := respObj.(openapi.UpdateDAGSuspensionState200Response)
+	require.True(t, ok, "expected 200 response, got %T", respObj)
+	require.Equal(t, []string{dag.FileName()}, notified)
+}
+
 func TestGetDAGDetails_EditorHintsIncludeInheritedCustomStepTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -472,6 +472,13 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 	if eventSvc != nil {
 		apiOpts = append(apiOpts, apiv1.WithEventService(eventSvc))
 	}
+	apiOpts = append(apiOpts, apiv1.WithDAGMutationNotifier(func(fileName string) {
+		if srv.sseMultiplexer == nil {
+			return
+		}
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
+		srv.sseMultiplexer.WakeTopic(sse.TopicTypeDAG, fileName)
+	}))
 
 	// Pass license manager to API
 	if srv.licenseManager != nil {

--- a/internal/service/scheduler/schedule_state.go
+++ b/internal/service/scheduler/schedule_state.go
@@ -4,23 +4,35 @@
 package scheduler
 
 import (
+	"fmt"
 	"maps"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
 )
 
-const SchedulerStateVersion = 2
+const SchedulerStateVersion = 3
 
 func cloneDAGWatermark(w DAGWatermark) DAGWatermark {
 	cloned := DAGWatermark{
-		LastScheduledTime: w.LastScheduledTime,
+		LastScheduledTime:        w.LastScheduledTime,
+		StartScheduleFingerprint: w.StartScheduleFingerprint,
+		SkipSuccessResetAt:       w.SkipSuccessResetAt,
 	}
 	if len(w.OneOffs) > 0 {
 		cloned.OneOffs = make(map[string]OneOffScheduleState, len(w.OneOffs))
 		maps.Copy(cloned.OneOffs, w.OneOffs)
 	}
 	return cloned
+}
+
+func isZeroDAGWatermark(w DAGWatermark) bool {
+	return w.LastScheduledTime.IsZero() &&
+		w.StartScheduleFingerprint == "" &&
+		w.SkipSuccessResetAt.IsZero() &&
+		len(w.OneOffs) == 0
 }
 
 func oneOffSchedules(dag *core.DAG) []core.Schedule {
@@ -90,6 +102,58 @@ func reconcileOneOffState(current DAGWatermark, dag *core.DAG, now time.Time) (D
 	}
 
 	return next, changed
+}
+
+func startScheduleFingerprint(dag *core.DAG) string {
+	if dag == nil {
+		return ""
+	}
+
+	fingerprints := make([]string, 0, len(dag.Schedule))
+	for _, schedule := range dag.Schedule {
+		if !schedule.IsCron() {
+			continue
+		}
+		fingerprint := schedule.Fingerprint()
+		if fingerprint == "" {
+			continue
+		}
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	if len(fingerprints) == 0 {
+		return ""
+	}
+
+	slices.Sort(fingerprints)
+	return fmt.Sprintf("skip:%t|%s", dag.SkipIfSuccessful, strings.Join(fingerprints, ","))
+}
+
+func reconcileStartScheduleState(current DAGWatermark, dag *core.DAG, observedAt time.Time) (DAGWatermark, bool) {
+	next := cloneDAGWatermark(current)
+	fingerprint := startScheduleFingerprint(dag)
+
+	if next.StartScheduleFingerprint == fingerprint {
+		return next, false
+	}
+	if fingerprint == "" {
+		if next.StartScheduleFingerprint == "" && next.SkipSuccessResetAt.IsZero() {
+			return next, false
+		}
+		next.StartScheduleFingerprint = ""
+		next.SkipSuccessResetAt = time.Time{}
+		return next, true
+	}
+
+	// Empty fingerprints come from pre-v3 watermark state where schedule identity
+	// was not persisted, so seed the current fingerprint without forcing a reset.
+	if next.StartScheduleFingerprint == "" {
+		next.StartScheduleFingerprint = fingerprint
+		return next, true
+	}
+
+	next.StartScheduleFingerprint = fingerprint
+	next.SkipSuccessResetAt = observedAt
+	return next, true
 }
 
 // NextPlannedRun projects the next scheduler-aware run time for DAG listing/sorting.

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -35,6 +35,8 @@ type DAGChangeEvent struct {
 	DAGName string    // always set (needed for delete)
 }
 
+const deletedWatermarkGrace = 2 * time.Minute
+
 // PlannedRun represents a run that the TickPlanner has decided should be dispatched.
 type PlannedRun struct {
 	DAG           *core.DAG
@@ -106,8 +108,8 @@ type TickPlannerConfig struct {
 // tracks progress via watermarks, and reacts to DAG lifecycle changes.
 //
 // Thread safety:
-//   - entries and buffers are protected by entryMu (accessed from drainEvents
-//     goroutine and cronLoop's Plan).
+//   - entries, buffers, and deletedGrace are protected by entryMu (accessed
+//     from drainEvents goroutine and cronLoop's Plan).
 //   - watermarkState is shared with the flusher goroutine and protected by mu.
 //   - Plan() holds entryMu during I/O calls (IsSuspended, IsRunning,
 //     GetLatestStatus, GenRunID). This is intentional: the lock prevents
@@ -124,9 +126,10 @@ type TickPlanner struct {
 	watermarkDirty atomic.Bool
 
 	// per-DAG tracking (protected by entryMu)
-	entryMu sync.Mutex
-	entries map[string]*plannerEntry
-	buffers map[string]*ScheduleBuffer
+	entryMu      sync.Mutex
+	entries      map[string]*plannerEntry
+	buffers      map[string]*ScheduleBuffer
+	deletedGrace map[string]time.Time
 
 	// lastPlanResult holds the runs from the most recent Plan() call.
 	// It is written by Plan() and read by Advance(). Both are called
@@ -204,9 +207,10 @@ func NewTickPlanner(cfg TickPlannerConfig) *TickPlanner {
 		}
 	}
 	return &TickPlanner{
-		cfg:     cfg,
-		entries: make(map[string]*plannerEntry),
-		buffers: make(map[string]*ScheduleBuffer),
+		cfg:          cfg,
+		entries:      make(map[string]*plannerEntry),
+		buffers:      make(map[string]*ScheduleBuffer),
+		deletedGrace: make(map[string]time.Time),
 	}
 }
 
@@ -382,6 +386,8 @@ func (tp *TickPlanner) initBuffers(ctx context.Context, dags []*core.DAG) {
 func (tp *TickPlanner) Plan(ctx context.Context, now time.Time) []PlannedRun {
 	tp.entryMu.Lock()
 	defer tp.entryMu.Unlock()
+
+	tp.pruneExpiredDeletedWatermarks(now)
 
 	var candidates []PlannedRun
 
@@ -649,6 +655,9 @@ func (tp *TickPlanner) shouldRun(ctx context.Context, dag *core.DAG, scheduledTi
 		// The latest run belongs to a removed/edited slot. Do not let its runtime
 		// timestamps suppress the current schedule.
 		return true
+	case latestScheduledSlotUnknown:
+		// Fall back to runtime-based suppression when the latest run does not carry
+		// a trustworthy scheduled slot identity.
 	}
 
 	// Guard 2 fallback: legacy/manual runs without an authoritative schedule slot.
@@ -1047,6 +1056,7 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 		if event.DAG == nil {
 			return
 		}
+		delete(tp.deletedGrace, event.DAGName)
 		tp.entries[event.DAGName] = &plannerEntry{dag: event.DAG}
 		// Set watermark to now (new DAGs have no catchup)
 		flushNow = tp.advanceDAGWatermark(event.DAGName, tp.cfg.Clock())
@@ -1058,6 +1068,7 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 		if event.DAG == nil {
 			return
 		}
+		delete(tp.deletedGrace, event.DAGName)
 		tp.entries[event.DAGName] = &plannerEntry{dag: event.DAG}
 		// Remove existing buffer and recompute if catchupWindow > 0
 		delete(tp.buffers, event.DAGName)
@@ -1071,9 +1082,11 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 	case DAGChangeDeleted:
 		delete(tp.entries, event.DAGName)
 		delete(tp.buffers, event.DAGName)
-		// Preserve persisted watermark state across delete+add rewrite cycles so
-		// the re-added DAG can detect schedule edits before its next slot. Truly
-		// deleted DAG watermarks are pruned on the next Init.
+		if tp.hasDAGWatermark(event.DAGName) {
+			tp.deletedGrace[event.DAGName] = tp.cfg.Clock().Add(deletedWatermarkGrace)
+		}
+		// Preserve watermark state briefly across delete+add rewrite cycles so
+		// the re-added DAG can detect schedule edits before its next slot.
 		logger.Info(ctx, "Planner: DAG deleted", tag.DAG(event.DAGName))
 	}
 
@@ -1126,6 +1139,50 @@ func (tp *TickPlanner) reconcileStartScheduleState(dag *core.DAG) bool {
 	}
 	tp.watermarkDirty.Store(true)
 	return true
+}
+
+func (tp *TickPlanner) hasDAGWatermark(dagName string) bool {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+
+	if tp.watermarkState == nil {
+		return false
+	}
+	_, ok := tp.watermarkState.DAGs[dagName]
+	return ok
+}
+
+func (tp *TickPlanner) pruneExpiredDeletedWatermarks(now time.Time) {
+	if len(tp.deletedGrace) == 0 {
+		return
+	}
+
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	if tp.watermarkState == nil || tp.watermarkState.DAGs == nil {
+		return
+	}
+
+	changed := false
+	for dagName, expiresAt := range tp.deletedGrace {
+		if now.Before(expiresAt) {
+			continue
+		}
+		delete(tp.deletedGrace, dagName)
+		if _, active := tp.entries[dagName]; active {
+			continue
+		}
+		if _, ok := tp.watermarkState.DAGs[dagName]; !ok {
+			continue
+		}
+		delete(tp.watermarkState.DAGs, dagName)
+		changed = true
+	}
+
+	if changed {
+		tp.watermarkDirty.Store(true)
+	}
 }
 
 // reinsertCatchupItem puts a failed catchup run back at the front of the

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -142,6 +142,14 @@ type TickPlanner struct {
 	wg          sync.WaitGroup
 }
 
+type latestScheduledSlotState int
+
+const (
+	latestScheduledSlotUnknown latestScheduledSlotState = iota
+	latestScheduledSlotCurrent
+	latestScheduledSlotStale
+)
+
 // plannerEntry tracks a single DAG's scheduling metadata.
 type plannerEntry struct {
 	dag *core.DAG
@@ -611,22 +619,41 @@ func (tp *TickPlanner) shouldRun(ctx context.Context, dag *core.DAG, scheduledTi
 		return false
 	}
 
-	// Guard 2: alreadyFinished — check if last run started at/after scheduled time
-	latestStartedAt, err := stringutil.ParseTime(latestStatus.StartedAt)
-	if err == nil {
-		// Consider queued time as well
-		if latestStatus.QueuedAt != "" {
-			queuedAt, parseErr := stringutil.ParseTime(latestStatus.QueuedAt)
-			if parseErr == nil && queuedAt.Before(latestStartedAt) {
-				latestStartedAt = queuedAt
+	latestScheduleTime, slotState := latestScheduledSlot(latestStatus, schedule)
+	switch slotState {
+	case latestScheduledSlotCurrent:
+		// Guard 2: alreadyFinished — exact scheduled slot already completed.
+		if !latestScheduleTime.Before(scheduledTime) {
+			return false
+		}
+
+		// Guard 3: skipIfSuccessful — only the current schedule's own slots may suppress.
+		if dag.SkipIfSuccessful && latestStatus.Status == core.Succeeded && schedule.Parsed != nil {
+			prevExecTime := computePrevExecTime(scheduledTime, schedule)
+			if !latestScheduleTime.Before(prevExecTime) && latestScheduleTime.Before(scheduledTime) {
+				logger.Info(ctx, "Skipping job due to successful prior run",
+					tag.DAG(dag.Name),
+					slog.String("schedule-time", latestScheduleTime.Format(time.RFC3339)),
+				)
+				return false
 			}
 		}
-		latestStartedAt = latestStartedAt.Truncate(time.Minute)
+
+		return true
+	case latestScheduledSlotStale:
+		// The latest run belongs to a removed/edited slot. Do not let its runtime
+		// timestamps suppress the current schedule.
+		return true
+	}
+
+	// Guard 2 fallback: legacy/manual runs without an authoritative schedule slot.
+	latestStartedAt, ok := latestRunReferenceTime(latestStatus)
+	if ok {
 		if !latestStartedAt.Before(scheduledTime) {
 			return false
 		}
 
-		// Guard 3: skipIfSuccessful
+		// Guard 3 fallback: preserve manual-run semantics when no slot identity exists.
 		if dag.SkipIfSuccessful && latestStatus.Status == core.Succeeded && schedule.Parsed != nil {
 			prevExecTime := computePrevExecTime(scheduledTime, schedule)
 			if !latestStartedAt.Before(prevExecTime) && latestStartedAt.Before(scheduledTime) {
@@ -640,6 +667,43 @@ func (tp *TickPlanner) shouldRun(ctx context.Context, dag *core.DAG, scheduledTi
 	}
 
 	return true
+}
+
+func latestRunReferenceTime(status exec.DAGRunStatus) (time.Time, bool) {
+	latestStartedAt, err := stringutil.ParseTime(status.StartedAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if status.QueuedAt != "" {
+		queuedAt, parseErr := stringutil.ParseTime(status.QueuedAt)
+		if parseErr == nil && queuedAt.Before(latestStartedAt) {
+			latestStartedAt = queuedAt
+		}
+	}
+	return latestStartedAt.Truncate(time.Minute), true
+}
+
+func latestScheduledSlot(status exec.DAGRunStatus, schedule core.Schedule) (time.Time, latestScheduledSlotState) {
+	if status.ScheduleTime == "" {
+		return time.Time{}, latestScheduledSlotUnknown
+	}
+
+	scheduledAt, err := stringutil.ParseTime(status.ScheduleTime)
+	if err != nil {
+		return time.Time{}, latestScheduledSlotUnknown
+	}
+
+	scheduledAt = scheduledAt.Truncate(time.Minute)
+	if !scheduleMatchesFireTime(schedule, scheduledAt) {
+		return scheduledAt, latestScheduledSlotStale
+	}
+
+	return scheduledAt, latestScheduledSlotCurrent
+}
+
+func scheduleMatchesFireTime(schedule core.Schedule, scheduledTime time.Time) bool {
+	next, due := scheduleDueAt(schedule, scheduledTime)
+	return due && next.Equal(scheduledTime)
 }
 
 func (tp *TickPlanner) shouldRunOneOff(ctx context.Context, dag *core.DAG) bool {

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -250,11 +250,13 @@ func (tp *TickPlanner) Init(ctx context.Context, dags []*core.DAG) error {
 	for _, dag := range dags {
 		current := state.DAGs[dag.Name]
 		next, changed := reconcileOneOffState(current, dag, observedAt)
+		next, startChanged := reconcileStartScheduleState(next, dag, observedAt)
+		changed = changed || startChanged
 		if !changed {
 			continue
 		}
 		stateChanged = true
-		if next.LastScheduledTime.IsZero() && len(next.OneOffs) == 0 {
+		if isZeroDAGWatermark(next) {
 			delete(state.DAGs, dag.Name)
 			continue
 		}
@@ -629,6 +631,9 @@ func (tp *TickPlanner) shouldRun(ctx context.Context, dag *core.DAG, scheduledTi
 
 		// Guard 3: skipIfSuccessful — only the current schedule's own slots may suppress.
 		if dag.SkipIfSuccessful && latestStatus.Status == core.Succeeded && schedule.Parsed != nil {
+			if tp.isPreEditSuccess(dag.Name, latestStatus) {
+				return true
+			}
 			prevExecTime := computePrevExecTime(scheduledTime, schedule)
 			if !latestScheduleTime.Before(prevExecTime) && latestScheduleTime.Before(scheduledTime) {
 				logger.Info(ctx, "Skipping job due to successful prior run",
@@ -655,6 +660,9 @@ func (tp *TickPlanner) shouldRun(ctx context.Context, dag *core.DAG, scheduledTi
 
 		// Guard 3 fallback: preserve manual-run semantics when no slot identity exists.
 		if dag.SkipIfSuccessful && latestStatus.Status == core.Succeeded && schedule.Parsed != nil {
+			if tp.isPreEditSuccess(dag.Name, latestStatus) {
+				return true
+			}
 			prevExecTime := computePrevExecTime(scheduledTime, schedule)
 			if !latestStartedAt.Before(prevExecTime) && latestStartedAt.Before(scheduledTime) {
 				logger.Info(ctx, "Skipping job due to successful prior run",
@@ -683,6 +691,16 @@ func latestRunReferenceTime(status exec.DAGRunStatus) (time.Time, bool) {
 	return latestStartedAt.Truncate(time.Minute), true
 }
 
+func latestSuccessReferenceTime(status exec.DAGRunStatus) (time.Time, bool) {
+	if finishedAt, err := stringutil.ParseTime(status.FinishedAt); err == nil && !finishedAt.IsZero() {
+		return finishedAt, true
+	}
+	if startedAt, err := stringutil.ParseTime(status.StartedAt); err == nil && !startedAt.IsZero() {
+		return startedAt, true
+	}
+	return time.Time{}, false
+}
+
 func latestScheduledSlot(status exec.DAGRunStatus, schedule core.Schedule) (time.Time, latestScheduledSlotState) {
 	if status.ScheduleTime == "" {
 		return time.Time{}, latestScheduledSlotUnknown
@@ -704,6 +722,26 @@ func latestScheduledSlot(status exec.DAGRunStatus, schedule core.Schedule) (time
 func scheduleMatchesFireTime(schedule core.Schedule, scheduledTime time.Time) bool {
 	next, due := scheduleDueAt(schedule, scheduledTime)
 	return due && next.Equal(scheduledTime)
+}
+
+func (tp *TickPlanner) isPreEditSuccess(dagName string, status exec.DAGRunStatus) bool {
+	resetAt := tp.skipSuccessResetAt(dagName)
+	if resetAt.IsZero() {
+		return false
+	}
+
+	successAt, ok := latestSuccessReferenceTime(status)
+	return ok && successAt.Before(resetAt)
+}
+
+func (tp *TickPlanner) skipSuccessResetAt(dagName string) time.Time {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+
+	if tp.watermarkState == nil {
+		return time.Time{}
+	}
+	return tp.watermarkState.DAGs[dagName].SkipSuccessResetAt
 }
 
 func (tp *TickPlanner) shouldRunOneOff(ctx context.Context, dag *core.DAG) bool {
@@ -1012,6 +1050,7 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 		tp.entries[event.DAGName] = &plannerEntry{dag: event.DAG}
 		// Set watermark to now (new DAGs have no catchup)
 		flushNow = tp.advanceDAGWatermark(event.DAGName, tp.cfg.Clock())
+		flushNow = tp.reconcileStartScheduleState(event.DAG) || flushNow
 		flushNow = tp.reconcileOneOffSchedules(event.DAG) || flushNow
 		logger.Info(ctx, "Planner: DAG added", tag.DAG(event.DAGName))
 
@@ -1025,17 +1064,16 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 		if event.DAG.CatchupWindow > 0 {
 			flushNow = tp.recomputeBuffer(ctx, event.DAG)
 		}
+		flushNow = tp.reconcileStartScheduleState(event.DAG) || flushNow
 		flushNow = tp.reconcileOneOffSchedules(event.DAG) || flushNow
 		logger.Info(ctx, "Planner: DAG updated", tag.DAG(event.DAGName))
 
 	case DAGChangeDeleted:
 		delete(tp.entries, event.DAGName)
 		delete(tp.buffers, event.DAGName)
-		tp.mu.Lock()
-		delete(tp.watermarkState.DAGs, event.DAGName)
-		tp.watermarkDirty.Store(true)
-		tp.mu.Unlock()
-		flushNow = true
+		// Preserve persisted watermark state across delete+add rewrite cycles so
+		// the re-added DAG can detect schedule edits before its next slot. Truly
+		// deleted DAG watermarks are pruned on the next Init.
 		logger.Info(ctx, "Planner: DAG deleted", tag.DAG(event.DAGName))
 	}
 
@@ -1058,7 +1096,30 @@ func (tp *TickPlanner) reconcileOneOffSchedules(dag *core.DAG) bool {
 		return false
 	}
 
-	if next.LastScheduledTime.IsZero() && len(next.OneOffs) == 0 {
+	if isZeroDAGWatermark(next) {
+		delete(tp.watermarkState.DAGs, dag.Name)
+	} else {
+		tp.watermarkState.DAGs[dag.Name] = next
+	}
+	tp.watermarkDirty.Store(true)
+	return true
+}
+
+func (tp *TickPlanner) reconcileStartScheduleState(dag *core.DAG) bool {
+	if dag == nil {
+		return false
+	}
+
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	current := tp.watermarkState.DAGs[dag.Name]
+	next, changed := reconcileStartScheduleState(current, dag, tp.cfg.Clock())
+	if !changed {
+		return false
+	}
+
+	if isZeroDAGWatermark(next) {
 		delete(tp.watermarkState.DAGs, dag.Name)
 	} else {
 		tp.watermarkState.DAGs[dag.Name] = next

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -1350,6 +1350,80 @@ func TestTickPlanner_ShouldRunSkipIfSuccessful(t *testing.T) {
 	assert.Len(t, runs, 0, "should skip when SkipIfSuccessful and last run succeeded in interval")
 }
 
+func TestTickPlanner_ShouldRunSkipIfSuccessfulIgnoresStaleEditedScheduleSlot(t *testing.T) {
+	t.Parallel()
+
+	eventCh := make(chan DAGChangeEvent, 256)
+	tp := NewTickPlanner(TickPlannerConfig{
+		IsSuspended: func(_ context.Context, _ string) bool { return false },
+		GetLatestStatus: func(_ context.Context, _ *core.DAG) (exec.DAGRunStatus, error) {
+			return exec.DAGRunStatus{
+				Status:       core.Succeeded,
+				StartedAt:    "2026-02-07T12:34:00Z",
+				ScheduleTime: "2026-02-07T12:34:00Z",
+				TriggerType:  core.TriggerTypeScheduler,
+			}, nil
+		},
+		IsRunning: func(_ context.Context, _ *core.DAG) (bool, error) { return false, nil },
+		GenRunID:  func(_ context.Context) (string, error) { return "run-1", nil },
+		Clock:     func() time.Time { return time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC) },
+		Events:    eventCh,
+	})
+
+	dag := &core.DAG{
+		Name:             "skip-success-edited-schedule-dag",
+		SkipIfSuccessful: true,
+		Schedule:         []core.Schedule{mustParseSchedule(t, "43 * * * *")},
+	}
+	require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+	now := time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC)
+	runs := tp.Plan(context.Background(), now)
+	assert.Len(t, runs, 1, "should not skip when the last success belongs to a removed schedule slot")
+}
+
+func TestTickPlanner_ShouldRunSkipIfSuccessfulFallsBackToManualRunStartTime(t *testing.T) {
+	t.Parallel()
+
+	eventCh := make(chan DAGChangeEvent, 256)
+	tp := NewTickPlanner(TickPlannerConfig{
+		IsSuspended: func(_ context.Context, _ string) bool { return false },
+		GetLatestStatus: func(_ context.Context, _ *core.DAG) (exec.DAGRunStatus, error) {
+			return exec.DAGRunStatus{
+				Status:      core.Succeeded,
+				StartedAt:   "2026-02-07T12:34:00Z",
+				TriggerType: core.TriggerTypeManual,
+			}, nil
+		},
+		IsRunning: func(_ context.Context, _ *core.DAG) (bool, error) { return false, nil },
+		GenRunID:  func(_ context.Context) (string, error) { return "run-1", nil },
+		Clock:     func() time.Time { return time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC) },
+		Events:    eventCh,
+	})
+
+	dag := &core.DAG{
+		Name:             "skip-success-manual-fallback-dag",
+		SkipIfSuccessful: true,
+		Schedule:         []core.Schedule{mustParseSchedule(t, "43 * * * *")},
+	}
+	require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+	now := time.Date(2026, 2, 7, 12, 43, 0, 0, time.UTC)
+	runs := tp.Plan(context.Background(), now)
+	assert.Len(t, runs, 0, "should still skip when a manual run already succeeded in the current interval")
+}
+
+func TestLatestScheduledSlotMarksRemovedScheduleSlotStale(t *testing.T) {
+	t.Parallel()
+
+	scheduledAt, state := latestScheduledSlot(exec.DAGRunStatus{
+		ScheduleTime: "2026-02-07T12:34:00Z",
+	}, mustParseSchedule(t, "43 * * * *"))
+
+	assert.Equal(t, latestScheduledSlotStale, state)
+	assert.Equal(t, time.Date(2026, 2, 7, 12, 34, 0, 0, time.UTC), scheduledAt)
+}
+
 func TestTickPlanner_ShouldRunAlreadyFinished(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -459,6 +459,80 @@ func TestTickPlanner_HandleEvent_Deleted(t *testing.T) {
 	// Verify entry was removed
 	_, ok = tp.entries["del-dag"]
 	assert.False(t, ok, "del-dag should be removed from entries")
+
+	tp.mu.RLock()
+	_, hasWM := tp.watermarkState.DAGs["del-dag"]
+	tp.mu.RUnlock()
+	assert.True(t, hasWM, "del-dag watermark should be retained during the rewrite grace window")
+}
+
+func TestTickPlanner_DeletedWatermarkExpiresAfterGraceWindow(t *testing.T) {
+	t.Parallel()
+
+	const graceWindow = 2 * time.Minute
+
+	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	clock := now
+	eventCh := make(chan DAGChangeEvent, 256)
+	store := &mockWatermarkStore{}
+	tp := NewTickPlanner(TickPlannerConfig{
+		WatermarkStore: store,
+		QueuesEnabled:  true,
+		IsSuspended: func(_ context.Context, _ string) bool {
+			return false
+		},
+		GetLatestStatus: func(_ context.Context, _ *core.DAG) (exec.DAGRunStatus, error) {
+			return exec.DAGRunStatus{}, nil
+		},
+		Dispatch: func(_ context.Context, _ *core.DAG, _ string, _ core.TriggerType, _ time.Time) error {
+			return nil
+		},
+		GenRunID: func(_ context.Context) (string, error) {
+			return "test-run-id", nil
+		},
+		IsRunning: func(_ context.Context, _ *core.DAG) (bool, error) {
+			return false, nil
+		},
+		RunExists: func(_ context.Context, _ *core.DAG, _ string) (bool, error) {
+			return false, nil
+		},
+		Clock: func() time.Time {
+			return clock
+		},
+		Events: eventCh,
+	})
+
+	dag := &core.DAG{
+		Name:     "deleted-after-grace",
+		Schedule: []core.Schedule{mustParseSchedule(t, "0 * * * *")},
+	}
+	require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+	tp.entryMu.Lock()
+	tp.handleEvent(context.Background(), DAGChangeEvent{
+		Type:    DAGChangeDeleted,
+		DAGName: dag.Name,
+	})
+	tp.entryMu.Unlock()
+
+	tp.mu.RLock()
+	_, hasWM := tp.watermarkState.DAGs[dag.Name]
+	tp.mu.RUnlock()
+	require.True(t, hasWM, "watermark should remain available during the rewrite grace window")
+
+	clock = now.Add(graceWindow + time.Second)
+	tp.Plan(context.Background(), clock)
+	tp.Flush(context.Background())
+
+	tp.mu.RLock()
+	_, hasWM = tp.watermarkState.DAGs[dag.Name]
+	tp.mu.RUnlock()
+	assert.False(t, hasWM, "watermark should be pruned after the grace window expires")
+
+	saved := store.lastSaved()
+	require.NotNil(t, saved)
+	_, hasPersisted := saved.DAGs[dag.Name]
+	assert.False(t, hasPersisted, "expired deleted watermark should not be persisted")
 }
 
 func TestTickPlanner_HandleEvent_Updated(t *testing.T) {

--- a/internal/service/scheduler/watermark.go
+++ b/internal/service/scheduler/watermark.go
@@ -20,7 +20,7 @@ type SchedulerState struct {
 type DAGWatermark struct {
 	LastScheduledTime        time.Time                      `json:"lastScheduledTime"`
 	StartScheduleFingerprint string                         `json:"startScheduleFingerprint,omitempty"`
-	SkipSuccessResetAt       time.Time                      `json:"skipSuccessResetAt,omitempty"`
+	SkipSuccessResetAt       time.Time                      `json:"skipSuccessResetAt"`
 	OneOffs                  map[string]OneOffScheduleState `json:"oneOffs,omitempty"`
 }
 

--- a/internal/service/scheduler/watermark.go
+++ b/internal/service/scheduler/watermark.go
@@ -18,8 +18,10 @@ type SchedulerState struct {
 
 // DAGWatermark tracks cron progress and one-off schedule state for a single DAG.
 type DAGWatermark struct {
-	LastScheduledTime time.Time                      `json:"lastScheduledTime"`
-	OneOffs           map[string]OneOffScheduleState `json:"oneOffs,omitempty"`
+	LastScheduledTime        time.Time                      `json:"lastScheduledTime"`
+	StartScheduleFingerprint string                         `json:"startScheduleFingerprint,omitempty"`
+	SkipSuccessResetAt       time.Time                      `json:"skipSuccessResetAt,omitempty"`
+	OneOffs                  map[string]OneOffScheduleState `json:"oneOffs,omitempty"`
 }
 
 // OneOffScheduleStatus is the persisted state of a one-off schedule.


### PR DESCRIPTION
## Summary
- wake DAG list/detail SSE streams after spec and suspension mutations so edited schedules refresh immediately
- preserve scheduler watermark state across delete-add DAG rewrites and reset skip-if-successful suppression when cron schedule fingerprints change
- add regression coverage for suspended schedule edits, watermark migration, and DAG mutation notifications

## Testing
- go test ./internal/service/scheduler ./internal/persis/filewatermark ./internal/service/frontend/api/v1 -count=1
- go test ./internal/intg -run 'TestIssue2042|TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot' -count=1

Closes #2042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DAG mutations now trigger real-time notifications, enabling clients to refresh immediately when specs or suspension state change.

* **Bug Fixes**
  * Improved handling of edited schedules when DAGs are suspended and resumed.
  * Enhanced `skip_if_successful` logic to correctly identify and skip runs from edited or removed schedules.

* **Tests**
  * Added integration and unit tests for schedule editing during suspension and skip-if-successful behavior with schedule changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->