### PR TITLE
sec: harden workflow files against shell injection and over-privileged tokens

### DIFF
--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -35,6 +35,12 @@ on:
       - "charts/dagu/crds/**"
       - ".github/workflows/chart-ci.yaml"
 
+# Restrict to read-only: this workflow only lints and packages the chart,
+# it never pushes or creates releases. An explicit block prevents the default
+# broad token permissions from being available if the workflow is ever compromised.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Helm chart

--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -9,8 +9,30 @@ on:
         type: string
 
 jobs:
+  # Validate the user-supplied ref before any job that pushes images or uses secrets.
+  # A ref containing shell metacharacters could otherwise be injected into the
+  # "Resolve version" run step via ${{ inputs.ref }}.
+  validate-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate ref input
+        env:
+          # Pass via env so the value is treated as data, not interpolated code.
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          # Reject refs containing shell metacharacters (space, ;, &, |, $, (, ), `, <, >, !).
+          if echo "$INPUT_REF" | grep -qE '[[:space:];|&$`()<>!]'; then
+            echo "::error::inputs.ref contains invalid characters: ${INPUT_REF}"
+            exit 1
+          fi
+          if [ -z "$INPUT_REF" ]; then
+            echo "::error::inputs.ref must not be empty"
+            exit 1
+          fi
+
   docker-default:
     name: Build and push default image
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,13 +58,17 @@ jobs:
       - name: Resolve version
         id: get_version
         shell: bash
+        env:
+          # Pass inputs.ref via env so it's treated as a plain string in the shell,
+          # not code. Writing ${{ inputs.ref }} directly inside `run:` would let a
+          # crafted ref value execute arbitrary commands.
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          REF="${{ inputs.ref }}"
-          case "$REF" in
-            refs/tags/v*) VERSION="${REF#refs/tags/v}" ;;
-            v*)           VERSION="${REF#v}" ;;
-            refs/tags/*)  VERSION="${REF#refs/tags/}" ;;
-            *)            VERSION="${REF}" ;;
+          case "$INPUT_REF" in
+            refs/tags/v*) VERSION="${INPUT_REF#refs/tags/v}" ;;
+            v*)           VERSION="${INPUT_REF#v}" ;;
+            refs/tags/*)  VERSION="${INPUT_REF#refs/tags/}" ;;
+            *)            VERSION="${INPUT_REF}" ;;
           esac
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
@@ -60,6 +86,7 @@ jobs:
 
   docker-dev:
     name: Build and push dev image
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,13 +112,15 @@ jobs:
       - name: Resolve version
         id: get_version
         shell: bash
+        env:
+          # Pass inputs.ref via env — same injection-prevention rationale as docker-default.
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          REF="${{ inputs.ref }}"
-          case "$REF" in
-            refs/tags/v*) VERSION="${REF#refs/tags/v}" ;;
-            v*)           VERSION="${REF#v}" ;;
-            refs/tags/*)  VERSION="${REF#refs/tags/}" ;;
-            *)            VERSION="${REF}" ;;
+          case "$INPUT_REF" in
+            refs/tags/v*) VERSION="${INPUT_REF#refs/tags/v}" ;;
+            v*)           VERSION="${INPUT_REF#v}" ;;
+            refs/tags/*)  VERSION="${INPUT_REF#refs/tags/}" ;;
+            *)            VERSION="${INPUT_REF}" ;;
           esac
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
@@ -110,6 +139,7 @@ jobs:
 
   docker-alpine:
     name: Build and push alpine image
+    needs: validate-inputs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -135,13 +165,15 @@ jobs:
       - name: Resolve version
         id: get_version
         shell: bash
+        env:
+          # Pass inputs.ref via env — same injection-prevention rationale as docker-default.
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          REF="${{ inputs.ref }}"
-          case "$REF" in
-            refs/tags/v*) VERSION="${REF#refs/tags/v}" ;;
-            v*)           VERSION="${REF#v}" ;;
-            refs/tags/*)  VERSION="${REF#refs/tags/}" ;;
-            *)            VERSION="${REF}" ;;
+          case "$INPUT_REF" in
+            refs/tags/v*) VERSION="${INPUT_REF#refs/tags/v}" ;;
+            v*)           VERSION="${INPUT_REF#v}" ;;
+            refs/tags/*)  VERSION="${INPUT_REF#refs/tags/}" ;;
+            *)            VERSION="${INPUT_REF}" ;;
           esac
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 

--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -14,6 +14,7 @@ jobs:
   # "Resolve version" run step via ${{ inputs.ref }}.
   validate-inputs:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate ref input
         env:

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -18,6 +18,12 @@ on:
       - "ui/**"
       - ".github/workflows/frontend-ci.yaml"
 
+# Restrict to read-only: this workflow only runs tests and builds the frontend,
+# it never pushes or deploys anything. An explicit block prevents the default
+# broad token permissions from being available if the workflow is ever compromised.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -8,9 +8,35 @@ on:
         required: true
         type: string
 
+# contents: write is required for GoReleaser to create the GitHub release and
+# upload assets. Restrict everything else to the minimum.
+permissions:
+  contents: write
+
 jobs:
+  # Validate the tag before any step that runs GoReleaser or checks out code.
+  # Passing an unsanitised ${{ github.event.inputs.tag }} into a checkout ref or
+  # shell command could otherwise allow injection of arbitrary git refs or commands.
+  validate-inputs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate tag format
+        env:
+          # Pass via env so the value is treated as plain data, not interpolated code.
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          # Tags must be vX.Y.Z (with optional pre-release suffix like -rc.1).
+          # Reject anything else — in particular shell metacharacters.
+          if ! echo "$INPUT_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([.\-][a-zA-Z0-9._-]+)?$'; then
+            echo "::error::inputs.tag must be a semver tag (e.g. v1.0.0), got: ${INPUT_TAG}"
+            exit 1
+          fi
+
   # Build release binaries
   goreleaser:
+    needs: validate-inputs
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/npm-publish-test.yaml
+++ b/.github/workflows/npm-publish-test.yaml
@@ -9,6 +9,10 @@ on:
         type: string
         default: '1.16.4'
 
+# Read-only: this workflow only tests logic and never publishes anything.
+permissions:
+  contents: read
+
 env:
   VERSION: ${{ inputs.version }}
 
@@ -20,27 +24,34 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test version handling
+        env:
+          # Pass user input via env so the shell receives a plain string.
+          # Writing ${{ inputs.version }} directly inside `run:` would let a crafted
+          # value execute arbitrary shell commands when the expression is interpolated.
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          echo "Input version: ${{ inputs.version }}"
-          echo "ENV version: ${{ env.VERSION }}"
-          
+          echo "Input version: ${INPUT_VERSION}"
+          # $VERSION is the top-level env var — reference it directly in the shell
+          # rather than re-interpolating ${{ env.VERSION }}, which re-opens the
+          # injection window.
+          echo "ENV version: ${VERSION}"
+
           # Test version stripping
-          VERSION="${{ env.VERSION }}"
-          VERSION="${VERSION#v}"
-          echo "Stripped version: ${VERSION}"
+          PKG_VERSION="${VERSION#v}"
+          echo "Stripped version: ${PKG_VERSION}"
 
       - name: Test matrix values
         run: |
-          # Test asset name generation
+          # Test asset name generation using the shell env var, not the template expression.
           echo "Testing asset names..."
-          echo "Linux x64: dagu_${{ env.VERSION }}_Linux_x86_64.tar.gz"
-          echo "Darwin arm64: dagu_${{ env.VERSION }}_Darwin_arm64.tar.gz"
-          echo "Windows x64: dagu_${{ env.VERSION }}_Windows_x86_64.zip"
+          echo "Linux x64: dagu_${VERSION}_Linux_x86_64.tar.gz"
+          echo "Darwin arm64: dagu_${VERSION}_Darwin_arm64.tar.gz"
+          echo "Windows x64: dagu_${VERSION}_Windows_x86_64.zip"
 
       - name: Test Node.js script
         run: |
           cd /tmp
-          
+
           # Create test package.json
           cat > package.json << 'EOF'
           {
@@ -52,26 +63,25 @@ jobs:
             }
           }
           EOF
-          
+
           # Create update script
           cat > update-deps.js << 'EOF'
           const fs = require('fs');
           const pkg = require('./package.json');
           const version = process.argv[2];
-          
+
           Object.keys(pkg.optionalDependencies || {}).forEach(dep => {
             pkg.optionalDependencies[dep] = version;
           });
-          
+
           fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
           console.log('Updated:', JSON.stringify(pkg.optionalDependencies, null, 2));
           EOF
-          
-          # Test the script
-          VERSION="${{ env.VERSION }}"
-          VERSION="${VERSION#v}"
-          node update-deps.js "${VERSION}"
-          
+
+          # Test the script using the shell env var directly.
+          PKG_VERSION="${VERSION#v}"
+          node update-deps.js "${PKG_VERSION}"
+
           # Verify result
           cat package.json
 
@@ -89,8 +99,13 @@ jobs:
             package: dagu-darwin-arm64
     steps:
       - name: Test matrix variables
+        env:
+          # Matrix values passed via env for the same injection-prevention reason.
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          echo "Platform: ${{ matrix.platform }}"
-          echo "Arch: ${{ matrix.arch }}"
-          echo "Package: ${{ matrix.package }}"
-          echo "Asset would be: dagu_${{ env.VERSION }}_${{ matrix.platform }}_${{ matrix.arch }}.tar.gz"
+          echo "Platform: ${MATRIX_PLATFORM}"
+          echo "Arch: ${MATRIX_ARCH}"
+          echo "Package: ${MATRIX_PACKAGE}"
+          echo "Asset would be: dagu_${VERSION}_${MATRIX_PLATFORM}_${MATRIX_ARCH}.tar.gz"

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -22,6 +22,7 @@ jobs:
   # arbitrary code when interpolated into shell via ${{ inputs.version }}.
   validate-inputs:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate version format
         env:
@@ -168,8 +169,11 @@ jobs:
           npm version "${PKG_VERSION}" --no-git-tag-version --allow-same-version
 
       - name: Publish to NPM
+        env:
+          PACKAGE_NAME: ${{ matrix.package }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cd npm/${{ matrix.package }}
+          cd "npm/${PACKAGE_NAME}"
           # Try to publish, but don't fail if version already exists
           npm publish --access public --provenance 2>&1 | tee publish.log || {
             if grep -q "cannot publish over the previously published versions" publish.log; then
@@ -179,14 +183,12 @@ jobs:
               exit 1
             fi
           }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         continue-on-error: ${{ matrix.arch == 'ppc64' || matrix.arch == 's390x' || matrix.arch == 'armv6' }}
 
   # Then publish the main package that depends on platform packages
   publish-main-package:
-    needs: publish-platform-packages
-    if: always()
+    needs: [validate-inputs, publish-platform-packages]
+    if: ${{ always() && needs.validate-inputs.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -251,8 +253,8 @@ jobs:
 
   # Verify the published packages
   verify-packages:
-    needs: [publish-platform-packages, publish-main-package]
-    if: always()
+    needs: [validate-inputs, publish-platform-packages, publish-main-package]
+    if: ${{ always() && needs.validate-inputs.result == 'success' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,8 +17,27 @@ permissions:
   id-token: write
 
 jobs:
+  # Validate user-supplied inputs before any job that uses secrets or publish steps.
+  # This prevents shell injection: a crafted version string could otherwise execute
+  # arbitrary code when interpolated into shell via ${{ inputs.version }}.
+  validate-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        env:
+          # Pass through env so the shell sees a plain string, not an interpolated expression.
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # Allow bare semver (1.2.3) or with pre-release/build suffix (1.2.3-rc.1).
+          # Reject anything else — especially characters that are shell metacharacters.
+          if [ -n "$INPUT_VERSION" ] && ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.\-][a-zA-Z0-9._-]+)?$'; then
+            echo "::error::inputs.version must be semver (e.g. 1.16.4), got: ${INPUT_VERSION}"
+            exit 1
+          fi
+
   # First, publish all platform-specific packages
   publish-platform-packages:
+    needs: validate-inputs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,31 +114,42 @@ jobs:
       - name: Download release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Context values are passed via env so they're treated as data, not code.
+          # Writing ${{ expr }} directly inside `run:` would let a crafted value
+          # execute arbitrary shell commands before the runner sees the script.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          ASSET_NAME: ${{ matrix.asset }}
         run: |
-          # For workflow_dispatch, we need to find the release
-          if [ -z "${{ github.event.release.tag_name }}" ]; then
-            echo "Finding release for version v${{ inputs.version }}"
-            RELEASE_TAG="v${{ inputs.version }}"
+          # For workflow_dispatch, we need to find the release.
+          if [ -z "$RELEASE_TAG_NAME" ]; then
+            echo "Finding release for version v${INPUT_VERSION}"
+            RELEASE_TAG="v${INPUT_VERSION}"
           else
-            RELEASE_TAG="${{ github.event.release.tag_name }}"
+            RELEASE_TAG="$RELEASE_TAG_NAME"
           fi
 
-          echo "Downloading asset: ${{ matrix.asset }}"
+          echo "Downloading asset: ${ASSET_NAME}"
           gh release download "${RELEASE_TAG}" \
-            --repo ${{ github.repository }} \
-            --pattern "${{ matrix.asset }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "${ASSET_NAME}" \
             --dir /tmp
 
       - name: Extract binary
+        env:
+          # Matrix values passed via env for the same injection-prevention reason.
+          PACKAGE_NAME: ${{ matrix.package }}
+          ASSET_NAME: ${{ matrix.asset }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          mkdir -p npm/${{ matrix.package }}/bin
-          cd npm/${{ matrix.package }}/bin
+          mkdir -p "npm/${PACKAGE_NAME}/bin"
+          cd "npm/${PACKAGE_NAME}/bin"
 
           # All assets are now .tar.gz
-          tar -xzf /tmp/${{ matrix.asset }} dagu || tar -xzf /tmp/${{ matrix.asset }} dagu.exe
+          tar -xzf "/tmp/${ASSET_NAME}" dagu || tar -xzf "/tmp/${ASSET_NAME}" dagu.exe
 
           # Verify binary exists
-          if [[ "${{ matrix.platform }}" == "win32" ]]; then
+          if [[ "$PLATFORM" == "win32" ]]; then
             test -f dagu.exe
           else
             test -f dagu
@@ -127,12 +157,15 @@ jobs:
           fi
 
       - name: Update package version
+        env:
+          PACKAGE_NAME: ${{ matrix.package }}
         run: |
-          cd npm/${{ matrix.package }}
-          # Strip 'v' prefix if present
-          VERSION="${{ env.VERSION }}"
-          VERSION="${VERSION#v}"
-          npm version "${VERSION}" --no-git-tag-version --allow-same-version
+          cd "npm/${PACKAGE_NAME}"
+          # Strip 'v' prefix if present. $VERSION comes from the top-level env block —
+          # reference the shell variable directly instead of re-interpolating ${{ env.VERSION }},
+          # which would re-open the injection window.
+          PKG_VERSION="${VERSION#v}"
+          npm version "${PKG_VERSION}" --no-git-tag-version --allow-same-version
 
       - name: Publish to NPM
         run: |
@@ -169,12 +202,13 @@ jobs:
         run: |
           cd npm/dagu
 
-          # Strip 'v' prefix if present
-          VERSION="${{ env.VERSION }}"
-          VERSION="${VERSION#v}"
+          # Strip 'v' prefix if present. Reference $VERSION (top-level env) directly
+          # in shell rather than via ${{ env.VERSION }} to avoid re-opening the
+          # template injection path.
+          PKG_VERSION="${VERSION#v}"
 
           # Update package version
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          npm version "$PKG_VERSION" --no-git-tag-version --allow-same-version
 
           # Update all optionalDependencies to match the version
           cat > update-deps.js << 'EOF'
@@ -193,7 +227,7 @@ jobs:
           console.log(JSON.stringify(pkg, null, 2));
           EOF
 
-          node update-deps.js "${VERSION}"
+          node update-deps.js "${PKG_VERSION}"
 
       - name: Wait for npm registry propagation
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-*"
 
+# contents: write is required for GoReleaser to create the GitHub release and
+# upload assets. Restrict everything else to the minimum.
+permissions:
+  contents: write
+
 jobs:
   # Build release binaries
   goreleaser:


### PR DESCRIPTION
- Add validate-inputs jobs to npm-publish, docker-manual, and manual-release workflows; user-supplied inputs are checked against strict patterns before any step that touches secrets or publishes artefacts.
- Replace every ${{ inputs.* }} / ${{ env.* }} / ${{ matrix.* }} interpolation inside run: blocks with env: block assignments + plain shell variable references, eliminating the script-injection vector where a crafted dispatch input could execute arbitrary commands.
- Add explicit permissions: contents: read blocks to chart-ci, frontend-ci, npm-publish-test, and release workflows so the default broad GITHUB_TOKEN scope is not silently inherited.
- Set permissions: contents: write on release and manual-release (minimum needed for GoReleaser to create releases and upload assets).

Claude Code with Opus 4.7. Not a blocker, just flagging. Happy to split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security of CI/CD infrastructure through explicit permission restrictions across GitHub Actions workflows, limiting automated operations to minimum necessary access.
  * Implemented input validation gates for release and deployment workflows to prevent invalid parameters from proceeding.
  * Improved workflow reliability with standardized environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->