### PR TITLE
fix: suppress success digest bot notifications

### DIFF
--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -1261,7 +1261,7 @@
         },
         "interested_event_types": {
           "type": "array",
-          "description": "DAG-run lifecycle event types that should generate Telegram notifications. Defaults to waiting, succeeded, failed, aborted, and rejected.",
+          "description": "DAG-run lifecycle event types that the bot tracks for notification delivery. Defaults to waiting, succeeded, failed, aborted, and rejected. Succeeded events are used to suppress stale pending alerts and do not send a chat message.",
           "items": {
             "type": "string",
             "enum": [
@@ -1299,7 +1299,7 @@
         },
         "interested_event_types": {
           "type": "array",
-          "description": "DAG-run lifecycle event types that should generate Slack notifications. Defaults to waiting, succeeded, failed, aborted, and rejected.",
+          "description": "DAG-run lifecycle event types that the bot tracks for notification delivery. Defaults to waiting, succeeded, failed, aborted, and rejected. Succeeded events are used to suppress stale pending alerts and do not send a chat message.",
           "items": {
             "type": "string",
             "enum": [

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -551,6 +551,13 @@ func (m *NotificationMonitor) flushPendingBatch(ctx context.Context, pending Not
 		return false
 	}
 
+	// Successful completions still flow through the notification state machine so
+	// they can replace pending wait alerts, but they should not post chat digests.
+	if pending.Batch.Class == NotificationClassSuccessDigest {
+		m.markBatchDelivered(ctx, pending.Destination, pending.Batch)
+		return true
+	}
+
 	flushCtx := ctx
 	cancel := func() {}
 	if allowLLM {

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -52,12 +52,13 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 		Name:       "briefing",
 		DAGRunID:   "run-old",
 		AttemptID:  "attempt-old",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "old failure",
 		FinishedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		oldStatus,
 		nil,
 	)))
@@ -95,12 +96,13 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 		Name:       "briefing",
 		DAGRunID:   "run-new",
 		AttemptID:  "attempt-new",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "new failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		newStatus,
 		nil,
 	)))
@@ -264,12 +266,13 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 		Name:       "briefing",
 		DAGRunID:   "run-first",
 		AttemptID:  "attempt-first",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "first failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		firstStatus,
 		nil,
 	)))
@@ -328,12 +331,13 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 		Name:       "briefing",
 		DAGRunID:   "run-second",
 		AttemptID:  "attempt-second",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "second failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		secondStatus,
 		nil,
 	)))
@@ -367,12 +371,13 @@ func TestNotificationMonitor_CorruptStateIsQuarantinedAndOnlyFutureEventsAreDeli
 		Name:       "briefing",
 		DAGRunID:   "run-old",
 		AttemptID:  "attempt-old",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "old failure",
 		FinishedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		oldStatus,
 		nil,
 	)))
@@ -416,12 +421,13 @@ func TestNotificationMonitor_CorruptStateIsQuarantinedAndOnlyFutureEventsAreDeli
 		Name:       "briefing",
 		DAGRunID:   "run-new",
 		AttemptID:  "attempt-new",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "new failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		newStatus,
 		nil,
 	)))
@@ -506,12 +512,13 @@ func TestNotificationMonitor_SaveFailureDoesNotLoseUnreadEvents(t *testing.T) {
 		Name:       "briefing",
 		DAGRunID:   "run-save-retry",
 		AttemptID:  "attempt-save-retry",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "retry failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		status,
 		nil,
 	)))
@@ -753,12 +760,13 @@ func TestNotificationMonitor_LockTheftSelfFencesActiveOwner(t *testing.T) {
 		Name:       "briefing",
 		DAGRunID:   "run-stolen-lock",
 		AttemptID:  "attempt-stolen-lock",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "lock failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		status,
 		nil,
 	)))

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
+	"github.com/dagucloud/dagu/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -239,12 +240,13 @@ func TestNotificationMonitor_BootstrapFailureDoesNotReplayFromZeroCursor(t *test
 		Name:       "briefing",
 		DAGRunID:   "run-old",
 		AttemptID:  "attempt-old",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "old failure",
 		FinishedAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		oldStatus,
 		nil,
 	)))
@@ -273,12 +275,13 @@ func TestNotificationMonitor_BootstrapFailureDoesNotReplayFromZeroCursor(t *test
 		Name:       "briefing",
 		DAGRunID:   "run-new",
 		AttemptID:  "attempt-new",
-		Status:     core.Succeeded,
+		Status:     core.Failed,
+		Error:      "new failure",
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
-		eventstore.TypeDAGRunSucceeded,
+		eventstore.TypeDAGRunFailed,
 		newStatus,
 		nil,
 	)))
@@ -328,9 +331,10 @@ func TestNotificationMonitor_ShutdownDrainFlushesPendingBatchWithoutLLM(t *testi
 
 	status := &exec.DAGRunStatus{
 		Name:      "briefing",
-		Status:    core.Succeeded,
+		Status:    core.Failed,
 		DAGRunID:  "run-2",
 		AttemptID: "attempt-2",
+		Error:     "boom",
 	}
 	require.True(t, monitor.NotifyCompletion(status))
 	cancel()
@@ -346,6 +350,58 @@ func TestNotificationMonitor_ShutdownDrainFlushesPendingBatchWithoutLLM(t *testi
 	require.Len(t, calls, 1)
 	assert.Equal(t, call{destination: "dest-1", allowLLM: false}, calls[0])
 	assert.True(t, monitor.IsDelivered("dest-1", status))
+}
+
+func TestNotificationMonitor_SuccessEventsAreAcknowledgedWithoutDelivery(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		calls []string
+	)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(_ context.Context, destination string, _ NotificationBatch, _ bool) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, destination)
+			return true
+		},
+	}
+
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.UrgentWindow = 10 * time.Millisecond
+	cfg.SuccessWindow = 10 * time.Millisecond
+	cfg.PollInterval = time.Hour
+	cfg.SeenEvictInterval = time.Hour
+
+	monitor := NewNotificationMonitor(nil, "", transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	first := &exec.DAGRunStatus{
+		Name:      "briefing",
+		Status:    core.Succeeded,
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+	}
+	second := &exec.DAGRunStatus{
+		Name:      "briefing",
+		Status:    core.Succeeded,
+		DAGRunID:  "run-2",
+		AttemptID: "attempt-2",
+	}
+
+	require.True(t, monitor.NotifyCompletion(first))
+	require.True(t, monitor.NotifyCompletion(second))
+
+	require.Eventually(t, func() bool {
+		return monitor.IsDelivered("dest-1", first) && monitor.IsDelivered("dest-1", second)
+	}, time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, calls, "successful completions should be acknowledged without transport delivery")
 }
 
 func TestNotificationMonitor_PollSourceFiltersInterestedEventTypes(t *testing.T) {

--- a/internal/service/slack/bot_test.go
+++ b/internal/service/slack/bot_test.go
@@ -217,7 +217,7 @@ func (s *fakeSlackAgentService) SubscribeSession(context.Context, string, agent.
 	return agent.StreamResponse{}, func() (agent.StreamResponse, bool) { return agent.StreamResponse{}, false }, nil
 }
 
-func TestDAGRunMonitor_FlushesSuccessDigestIntoSingleThreadAndSkipsReplay(t *testing.T) {
+func TestDAGRunMonitor_SuppressesSuccessDigestAndMarksRunsDelivered(t *testing.T) {
 	t.Parallel()
 
 	client := &fakeSlackClient{}
@@ -234,54 +234,30 @@ func TestDAGRunMonitor_FlushesSuccessDigestIntoSingleThreadAndSkipsReplay(t *tes
 	stopMonitor := testutil.StartContextRunner(t, monitor)
 	defer stopMonitor()
 
-	ok := monitor.notifyCompletion(context.Background(), &exec.DAGRunStatus{
+	first := &exec.DAGRunStatus{
 		Name:      "briefing",
 		Status:    core.Succeeded,
 		DAGRunID:  "run-1",
 		AttemptID: "attempt-1",
-	})
-	require.True(t, ok)
-	ok = monitor.notifyCompletion(context.Background(), &exec.DAGRunStatus{
+	}
+	second := &exec.DAGRunStatus{
 		Name:      "briefing",
 		Status:    core.Succeeded,
 		DAGRunID:  "run-2",
 		AttemptID: "attempt-2",
-	})
-	require.True(t, ok)
+	}
+	require.True(t, monitor.notifyCompletion(context.Background(), first))
+	require.True(t, monitor.notifyCompletion(context.Background(), second))
 
 	require.Eventually(t, func() bool {
-		service.mu.Lock()
-		appended := len(service.appendMessages) == 1
-		service.mu.Unlock()
-		val, exists := bot.chats.Load("C123:1")
-		if !exists {
-			return false
-		}
-		cs := val.(*chatState)
-		return appended && client.postCount() == 1 && bot.lastDeliveredSeq(cs) == 1
+		return monitor.isSeen("C123", first) && monitor.isSeen("C123", second)
 	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, 1, client.postCount(), "digest should be delivered once as a single thread root")
-
-	val, exists := bot.chats.Load("C123:1")
-	require.True(t, exists)
-	cs := val.(*chatState)
-	assert.Equal(t, "sess-1", cs.SessionID())
-	assert.Equal(t, "1", cs.threadTS)
-	assert.Equal(t, int64(1), bot.lastDeliveredSeq(cs))
+	assert.Zero(t, client.postCount(), "successful completions should not post a Slack digest")
+	_, exists := bot.chats.Load("C123:1")
+	assert.False(t, exists, "successful completions should not open a Slack thread")
 	service.mu.Lock()
-	require.Len(t, service.appendMessages, 1)
-	assert.Contains(t, service.appendMessages[0].Content, "DAG completion digest")
-	assert.Contains(t, service.appendMessages[0].Content, "briefing: succeeded x2")
+	assert.Empty(t, service.appendMessages)
 	service.mu.Unlock()
-
-	bot.processStreamResponse(context.Background(), cs, agent.StreamResponse{
-		Messages: []agent.Message{
-			{Type: agent.MessageTypeAssistant, SequenceID: 1, Content: "digest"},
-			{Type: agent.MessageTypeAssistant, SequenceID: 2, Content: "follow-up answer"},
-		},
-	})
-
-	assert.Equal(t, 2, client.postCount(), "snapshot replay should skip the already delivered digest")
 }
 
 func TestDAGRunMonitor_FlushesUrgentSingleIntoExistingDMSession(t *testing.T) {

--- a/internal/service/telegram/bot_test.go
+++ b/internal/service/telegram/bot_test.go
@@ -212,7 +212,7 @@ func (s *fakeTelegramAgentService) SubscribeSession(context.Context, string, age
 	return agent.StreamResponse{}, func() (agent.StreamResponse, bool) { return agent.StreamResponse{}, false }, nil
 }
 
-func TestDAGRunMonitor_FlushesSuccessDigestIntoExistingChatAndSkipsReplay(t *testing.T) {
+func TestDAGRunMonitor_SuppressesSuccessDigestAndMarksRunsDelivered(t *testing.T) {
 	t.Parallel()
 
 	api := &fakeTelegramAPI{}
@@ -232,48 +232,32 @@ func TestDAGRunMonitor_FlushesSuccessDigestIntoExistingChatAndSkipsReplay(t *tes
 	cs := bot.getOrCreateChat(123)
 	bot.setActiveSession(cs, "existing-session", "telegram:123")
 
-	ok := monitor.notifyCompletion(context.Background(), &exec.DAGRunStatus{
+	first := &exec.DAGRunStatus{
 		Name:      "briefing",
 		Status:    core.Succeeded,
 		DAGRunID:  "run-1",
 		AttemptID: "attempt-1",
-	})
-	require.True(t, ok)
-	ok = monitor.notifyCompletion(context.Background(), &exec.DAGRunStatus{
+	}
+	second := &exec.DAGRunStatus{
 		Name:      "briefing",
 		Status:    core.Succeeded,
 		DAGRunID:  "run-2",
 		AttemptID: "attempt-2",
-	})
-	require.True(t, ok)
+	}
+	require.True(t, monitor.notifyCompletion(context.Background(), first))
+	require.True(t, monitor.notifyCompletion(context.Background(), second))
 
 	require.Eventually(t, func() bool {
-		service.mu.Lock()
-		defer service.mu.Unlock()
-		return len(service.appendMessages) == 1
+		return monitor.isSeen("123", first) && monitor.isSeen("123", second)
 	}, time.Second, 10*time.Millisecond)
 
 	service.mu.Lock()
-	assert.Equal(t, 0, service.createEmptyCalls, "existing chat session should be reused")
-	require.Len(t, service.appendSessionIDs, 1)
-	assert.Equal(t, "existing-session", service.appendSessionIDs[0])
+	assert.Zero(t, service.createEmptyCalls)
+	assert.Empty(t, service.appendSessionIDs)
+	assert.Empty(t, service.appendMessages)
 	service.mu.Unlock()
-	assert.Equal(t, int64(1), bot.lastDeliveredSeq(cs))
-	assert.Equal(t, 1, api.sendCount())
-	service.mu.Lock()
-	require.Len(t, service.appendMessages, 1)
-	assert.Contains(t, service.appendMessages[0].Content, "DAG completion digest")
-	assert.Contains(t, service.appendMessages[0].Content, "briefing: succeeded x2")
-	service.mu.Unlock()
-
-	bot.processStreamResponse(context.Background(), cs, 123, agent.StreamResponse{
-		Messages: []agent.Message{
-			{Type: agent.MessageTypeAssistant, SequenceID: 1, Content: "digest"},
-			{Type: agent.MessageTypeAssistant, SequenceID: 2, Content: "actual reply"},
-		},
-	})
-
-	assert.Equal(t, 2, api.sendCount(), "the manually delivered digest must not be replayed")
+	assert.Equal(t, int64(0), bot.lastDeliveredSeq(cs))
+	assert.Zero(t, api.sendCount(), "successful completions should not send a Telegram digest")
 }
 
 func TestDAGRunMonitor_FlushesUrgentSingleCreatesSessionWhenMissing(t *testing.T) {

--- a/internal/service/telegram/monitor_test.go
+++ b/internal/service/telegram/monitor_test.go
@@ -42,9 +42,10 @@ func TestDAGRunMonitor_RetriesOnlyUndeliveredTelegramChat(t *testing.T) {
 
 	status := &exec.DAGRunStatus{
 		Name:      "briefing",
-		Status:    core.Succeeded,
+		Status:    core.Failed,
 		DAGRunID:  "run-1",
 		AttemptID: "attempt-1",
+		Error:     "boom",
 	}
 
 	require.True(t, monitor.notifyCompletion(context.Background(), status))


### PR DESCRIPTION
## Summary
- suppress success-class bot notification batches before they reach Slack, Telegram, or Discord transports
- keep success events in the shared notification state machine so they still clear stale pending wait alerts
- extend monitor and bot tests to verify successful completions are acknowledged silently while urgent notifications still deliver normally

## Why
- successful DAG completion digests were noisy in chat and did not require operator action
- the shared notification monitor was still useful for deduplication and state cleanup, so the change should remove the outward message without breaking delivery semantics for urgent statuses
- the regression coverage needs to pin down that success events no longer open threads, append chat messages, or send direct notifications

## Validation
- `go test ./internal/service/chatbridge ./internal/service/slack ./internal/service/telegram ./internal/service/discord ./internal/cmn/config`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Successful DAG run completions are now properly suppressed and no longer generate chat notifications or digests in Slack and Telegram.
  * Successful runs are still tracked as delivered and seen by the system, preventing duplicate alert notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->