### PR TITLE
fix: refresh structured output examples

### DIFF
--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -48,21 +48,24 @@ steps:
 	{
 		ID:          2,
 		Name:        "output-passing",
-		Description: "Capture step output and pass between steps",
+		Description: "Use publish-only object-form output between steps",
 		Content: `type: graph
 steps:
-  - name: get-version
-    command: echo "2.5.0"
-    output: VERSION
-  - name: get-metadata
-    command: echo '{"build":"abc123","env":"staging"}'
+  - id: publish_version
     output:
-      name: BUILD_ID
-      key: build
-    depends: [get-version]
-  - name: deploy
-    command: echo "deploying v${VERSION} build ${BUILD_ID}"
-    depends: [get-version, get-metadata]
+      version: "2.5.0"
+  - id: publish_metadata
+    output:
+      build: abc123
+      env: staging
+  - id: publish_release
+    output:
+      version_label: "v${publish_version.output.version}"
+      target_env: "${publish_metadata.output.env}"
+    depends: [publish_version, publish_metadata]
+  - id: deploy
+    command: echo "deploying ${publish_release.output.version_label} build ${publish_metadata.output.build} to ${publish_release.output.target_env}"
+    depends: [publish_release]
 `,
 	},
 	{
@@ -187,20 +190,31 @@ steps:
 	{
 		ID:          7,
 		Name:        "http-requests",
-		Description: "Make HTTP requests and use responses",
+		Description: "Make HTTP requests and parse JSON response fields",
 		Content: `type: graph
 defaults:
   retry_policy:
     limit: 2
     interval_sec: 5
 steps:
-  - name: get-todo
+  - id: get_todo
     type: http
     command: "GET https://jsonplaceholder.typicode.com/todos/1"
-    output: TODO
-  - name: show-result
-    command: echo "Received - ${TODO}"
-    depends: [get-todo]
+    output:
+      # decode + select act as a lightweight contract check.
+      # malformed JSON or a missing selected field fails the step,
+      # so the normal retry_policy can retry it.
+      title:
+        from: stdout
+        decode: json
+        select: .title
+      completed:
+        from: stdout
+        decode: json
+        select: .completed
+  - id: show_result
+    command: 'echo "Todo: ${get_todo.output.title} (completed=${get_todo.output.completed})"'
+    depends: [get_todo]
 `,
 	},
 	{
@@ -277,19 +291,19 @@ defaults:
     limit: 2
     interval_sec: 5
 steps:
-  - name: check-status
-    command: "echo success"
-    output: STATUS
-  - name: route
+  - id: check_status
+    output:
+      status: success
+  - id: route
     type: router
-    value: ${STATUS}
+    value: ${check_status.output.status}
     routes:
-      success: [on-success]
-      "re:.*": [on-failure]
-    depends: [check-status]
-  - name: on-success
+      success: [on_success]
+      "re:.*": [on_failure]
+    depends: [check_status]
+  - id: on_success
     command: echo "status was success"
-  - name: on-failure
+  - id: on_failure
     command: echo "status was something else"
 `,
 	},
@@ -302,8 +316,8 @@ artifacts:
   enabled: true
 steps:
   - id: build
-    command: echo "v1.2.3"
-    output: VERSION
+    output:
+      version: "v1.2.3"
   - id: draft_release_notes
     depends: [build]
     type: agent
@@ -312,7 +326,7 @@ steps:
     messages:
       - role: user
         content: |
-          Draft release notes for version ${VERSION}.
+          Draft release notes for version ${build.output.version}.
 
           Current draft path: ${DAG_RUN_ARTIFACTS_DIR}/release-notes.md
 
@@ -328,7 +342,7 @@ steps:
       rewind_to: draft_release_notes
   - id: deploy
     depends: [draft_release_notes]
-    command: echo "deploying ${VERSION} with reviewed release notes"
+    command: echo "deploying ${build.output.version} with reviewed release notes"
 `,
 	},
 	{
@@ -416,19 +430,19 @@ step_types:
       command: echo {{ json .input.channel }} release {{ json .input.version }} - {{ json .input.summary }}
 steps:
   - id: build
-    command: echo "v1.2.3"
-    output: VERSION
+    output:
+      version: "v1.2.3"
   - id: announce_changelog
     type: announce_release
     with:
       channel: changelog
-      version: ${VERSION}
+      version: ${build.output.version}
     depends: [build]
   - id: announce_email
     type: announce_release
     with:
       channel: email
-      version: ${VERSION}
+      version: ${build.output.version}
       summary: Sent to subscribers
     depends: [build]
 `,
@@ -449,15 +463,15 @@ params:
     default: STG
 steps:
   - id: build
-    command: echo "v1.2.3"
-    output: VERSION
+    output:
+      version: "v1.2.3"
   - id: render_config
     type: template
     with:
       output: ${DAG_RUN_ARTIFACTS_DIR}/deploy.env
       data:
         env: ${ENV}
-        version: ${VERSION}
+        version: ${build.output.version}
     script: |
       APP_ENV={{ .env }}
       APP_VERSION={{ .version }}
@@ -482,13 +496,13 @@ harness:
   bare: true
 steps:
   - id: gather_issue
-    command: echo "scheduler retries the same task after it already succeeded"
-    output: ISSUE
+    output:
+      issue: "scheduler retries the same task after it already succeeded"
   - id: build_prompt
     type: template
     with:
       data:
-        issue: ${ISSUE}
+        issue: ${gather_issue.output.issue}
     script: |
       Review this workflow issue and suggest a fix:
       
@@ -507,7 +521,7 @@ steps:
     with:
       output: ${DAG_RUN_ARTIFACTS_DIR}/harness-report.md
       data:
-        issue: ${ISSUE}
+        issue: ${gather_issue.output.issue}
         analysis: ${ANALYSIS}
     script: |
       # Harness Review
@@ -539,13 +553,13 @@ harnesses:
       model: --model
 steps:
   - id: gather_task
-    command: echo "Summarize the deployment checklist for the next engineer"
-    output: TASK
+    output:
+      task: "Summarize the deployment checklist for the next engineer"
   - id: build_prompt
     type: template
     with:
       data:
-        task: ${TASK}
+        task: ${gather_task.output.task}
     script: |
       {{ .task }}
       

--- a/internal/persis/filedistributed/helpers.go
+++ b/internal/persis/filedistributed/helpers.go
@@ -60,6 +60,11 @@ func sortedFiles(dir string) ([]string, error) {
 		if entry.IsDir() {
 			continue
 		}
+		// Store directories may temporarily contain atomic-write staging files
+		// such as "*.json.tmp.*". Only finalized JSON records should be listed.
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
 		files = append(files, filepath.Join(dir, entry.Name()))
 	}
 	sort.Strings(files)

--- a/internal/persis/filedistributed/helpers_test.go
+++ b/internal/persis/filedistributed/helpers_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package filedistributed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortedFiles_IgnoresAtomicWriteTempFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	finalFile := filepath.Join(dir, "worker.json")
+	require.NoError(t, os.WriteFile(finalFile, []byte(`{"worker_id":"worker-1"}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "worker.json.tmp.1234"), []byte(`{"worker_id":"partial"`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore"), 0600))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0750))
+
+	files, err := sortedFiles(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{finalFile}, files)
+}

--- a/skills/dagu/SKILL.md
+++ b/skills/dagu/SKILL.md
@@ -15,18 +15,24 @@ Load only the reference file that matches the task.
 - Prefer `dagu schema ...` and `dagu validate ...` over guessing field names or shapes.
 - Prefer `type: template` when generating text files, prompts, or artifacts instead of assembling them with shell `echo` or heredocs.
 - Prefer `DAG_RUN_ARTIFACTS_DIR` for file outputs when possible, as it provides a preview in the UI and automatically cleans up when the DAG run gets deleted.
-- Prefer `output:` for capturing stdout content into variables if the content is reasonably small and doesn't require complex parsing.
+- Prefer string-form `output: VAR_NAME` for capturing small stdout values into flat variables.
+- Prefer object-form `output:` when downstream steps need structured values via `${step_id.output.*}`.
 - Prefer temporary file in artifacts dir for larger outputs or when downstream steps need file paths.
 
 ## High-Signal Rules
 
-- `output:` captures trimmed stdout content into a variable. `${step_id.stdout}` is a log file path, not stdout content.
+- `output:` has two modes:
+  - string form captures trimmed stdout into a flat variable such as `${VERSION}`
+  - object form publishes structured step-scoped output for `${step_id.output.*}` access
+- `${step_id.stdout}` is a log file path, not stdout content.
 - `env:` should use list-of-maps when values depend on earlier env vars.
 - `params:` values arrive as strings. The `params:` field supports JSON schema-like types and validation, check for schema to see how to specify types and validation rules.
 - Do not assume `bash` for `script:` steps. If a script depends on a specific interpreter, add a shebang such as `#!/bin/sh` or `#!/usr/bin/env bash` only after checking that shell exists on the target host or container. Otherwise keep the script portable or set `shell:` explicitly.
 - `parallel:` requires `call:` to a sub-DAG.
 - Sub-DAGs do not inherit parent env vars; pass what you need via `params:`.
 - For arbitrary text inside shell steps, prefer `printenv VAR_NAME` or `type: template` over `${VAR}` interpolation.
+- Object-form `output:` is step-scoped only today. Only string-form `output: VAR_NAME` is collected into final DAG `outputs.json`.
+- Object-form `output:` with `decode: json` or `decode: yaml` can act as lightweight runtime validation. Malformed data or an unresolved `select:` path fails the step, so normal `retry_policy` applies.
 - Use `dagu schema dag` to check the full list of available fields and their shapes.
 - Use `dagu example` to see different DAG patterns and how to express them in YAML.
 
@@ -62,6 +68,30 @@ steps:
       Your favorite color is {{ .favorite_color }}.
       {{- end }}
     stdout: ${DAG_RUN_ARTIFACTS_DIR}/greeting.txt
+```
+
+## Example of Object-Form Output
+
+```yaml
+steps:
+  - id: inspect_build
+    command: echo '{"version":"v1.2.3","artifact":{"url":"https://example.test/app.tgz"}}'
+    output:
+      # decode + select act as a lightweight contract check:
+      # malformed JSON or a missing selected field fails the step.
+      version:
+        from: stdout
+        decode: json
+        select: .version
+      artifact:
+        from: stdout
+        decode: json
+        select: .artifact
+
+  - id: publish
+    output:
+      versionLabel: "ver - ${inspect_build.output.version}"
+      artifactUrl: "${inspect_build.output.artifact.url}"
 ```
 
 ## Reference Guide

--- a/skills/dagu/SKILL.md
+++ b/skills/dagu/SKILL.md
@@ -89,6 +89,7 @@ steps:
         select: .artifact
 
   - id: publish
+    depends: [inspect_build]
     output:
       versionLabel: "ver - ${inspect_build.output.version}"
       artifactUrl: "${inspect_build.output.artifact.url}"

--- a/skills/dagu/references/codingagent.md
+++ b/skills/dagu/references/codingagent.md
@@ -291,6 +291,6 @@ steps:
 3. **Timeouts** — Set `timeout_sec:` (300-600s+) on agent steps. Agent CLIs can run for minutes.
 4. **Retry on transient failures** — Add `retry_policy: { limit: 3, interval_sec: 30 }` to handle rate limits and network errors.
 5. **Working directory** — Use `working_dir:` on the step. The CLI operates relative to this directory.
-6. **Output capture** — Use `output: VAR_NAME` for variable interpolation; use `${step_id.stdout}` for file-path-based access.
+6. **Output capture** — Use string-form `output: VAR_NAME` for flat variable interpolation, object-form `output:` for structured `${step_id.output.*}` access, and `${step_id.stdout}` when a downstream step needs the stdout log file path.
 7. **Exit codes** — 0 = success, 1 = CLI error, 124 = step timed out. Last 1KB of stderr is included in the error message on failure.
 8. **Fallback behavior** — If the primary harness config fails and the context is still active, fallback entries are tried in order. Failed-attempt stdout is discarded; stderr remains visible in logs.

--- a/skills/dagu/references/steptypes.md
+++ b/skills/dagu/references/steptypes.md
@@ -84,7 +84,7 @@ Uses step `call:` and `params:` fields. Sub-DAGs do not inherit parent env vars.
 Notes:
 
 - Pass values explicitly via `params:` when the child needs parent env vars or derived values.
-- Child step `output:` variables are not propagated back into the parent DAG output map. Use shared files or another explicit handoff if the parent needs results.
+- Child string-form `output:` variables are not propagated back into the parent DAG output map. Use files, explicit params, or another handoff if the parent needs results.
 
 ## parallel
 
@@ -237,7 +237,7 @@ Behavior:
 - `data` — Object exposed to the template as `.`
 - `output` — File path for rendered output; if omitted, rendered text is written to stdout
 
-Important: step `output:` and `with.output` are different. Step `output:` captures stdout into a Dagu variable. `with.output` writes the rendered result directly to a file.
+Important: step `output:` and `with.output` are different. String-form step `output:` captures stdout into a Dagu variable, object-form step `output:` publishes structured `${step_id.output.*}` values, and `with.output` writes the rendered result directly to a file.
 
 Use `template` when you need to generate text files such as Markdown, config files, SQL, JSON, or prompts. It is usually safer and simpler than building files with `echo`, heredocs, or shell string interpolation.
 


### PR DESCRIPTION
## Summary
- refresh the built-in DAG examples to use publish-only object-form `output:` for synthetic values instead of shelling out with `echo`
- add a real JSON parsing example that shows `decode: json` and `select:` as a lightweight runtime contract for step output
- update the bundled Dagu skill references to explain string-form vs object-form output and the failure behavior for malformed decoded output

## Why
- examples should model the current structured output feature directly instead of preserving old shell-based workarounds for fixed values
- the bundled skill is user-facing guidance, so it needs to describe the actual two-mode `output:` behavior and the retry-relevant failure semantics
- a concrete built-in example makes it easier for users to discover that `decode: json` plus `select:` can validate command output structure at runtime

## Validation
- `go test ./internal/cmd -run TestExampleCommand -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified two output modes: string-form for flat variables and object-form for structured, step-scoped outputs (with decode/select); emphasized stdout is a log file path; added examples for JSON/YAML field extraction and validation.
  * Updated example DAGs and routing examples to use structured output references and explicit success/failure routing.
* **Bug Fix**
  * Ignore temporary/atomic-write files when listing persisted JSON files.
* **Tests**
  * Added unit test verifying temp files are excluded from persisted file lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->