### PR TITLE
fix: dedupe builtin harness flag aliases

### DIFF
--- a/internal/core/harness.go
+++ b/internal/core/harness.go
@@ -6,6 +6,7 @@ package core
 import (
 	"maps"
 	"sort"
+	"strings"
 )
 
 type HarnessPromptMode string
@@ -67,6 +68,59 @@ func BuiltinHarnessProviderNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// NormalizeBuiltinHarnessFlagKeys clones cfg and canonicalizes builtin harness
+// flag aliases to kebab-case so equivalent keys merge predictably.
+func NormalizeBuiltinHarnessFlagKeys(cfg map[string]any) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+
+	normalized := make(map[string]any, len(cfg))
+	sourceKeys := make(map[string]string, len(cfg))
+	keys := make([]string, 0, len(cfg))
+	for key := range cfg {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		canonical := canonicalBuiltinHarnessFlagKey(key)
+		prevKey, exists := sourceKeys[canonical]
+		if exists && !preferBuiltinHarnessKeyVariant(key, prevKey) {
+			continue
+		}
+		normalized[canonical] = cloneHarnessValue(cfg[key])
+		sourceKeys[canonical] = key
+	}
+
+	return normalized
+}
+
+func canonicalBuiltinHarnessFlagKey(key string) string {
+	if isBuiltinHarnessReservedKey(key) {
+		return key
+	}
+	return strings.ReplaceAll(key, "_", "-")
+}
+
+func isBuiltinHarnessReservedKey(key string) bool {
+	switch key {
+	case "provider", "fallback":
+		return true
+	default:
+		return false
+	}
+}
+
+func preferBuiltinHarnessKeyVariant(candidate, current string) bool {
+	candidateCanonical := !strings.Contains(candidate, "_")
+	currentCanonical := !strings.Contains(current, "_")
+	if candidateCanonical != currentCanonical {
+		return candidateCanonical
+	}
+	return false
 }
 
 func cloneHarnessDefinition(def *HarnessDefinition) *HarnessDefinition {

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -3064,6 +3064,28 @@ steps:
 		assert.Equal(t, "codex", fallback[0]["provider"])
 	})
 
+	t.Run("StepOverridesBuiltinFlagAliasesWithoutDuplicates", func(t *testing.T) {
+		yaml := `
+harness:
+  provider: codex
+  skip_git_repo_check: true
+steps:
+  - name: step1
+    type: harness
+    command: "Fix bugs"
+    with:
+      skip-git-repo-check: false
+`
+		dag, err := spec.LoadYAML(context.Background(), []byte(yaml))
+		require.NoError(t, err)
+		step := dag.Steps[0]
+
+		assert.Equal(t, "codex", step.ExecutorConfig.Config["provider"])
+		assert.Equal(t, false, step.ExecutorConfig.Config["skip-git-repo-check"])
+		_, exists := step.ExecutorConfig.Config["skip_git_repo_check"]
+		assert.False(t, exists)
+	})
+
 	t.Run("StepFallbackReplacesDAGFallback", func(t *testing.T) {
 		yaml := `
 harness:

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -1583,6 +1583,14 @@ func mergeRedisConfig(dagRedis *core.RedisConfig, stepConfig map[string]any) {
 }
 
 func mergeHarnessConfig(dagHarness *core.HarnessConfig, stepConfig map[string]any) map[string]any {
+	effectiveProvider := harnessProviderName(stepConfig)
+	if effectiveProvider == "" && dagHarness != nil {
+		effectiveProvider = harnessProviderName(dagHarness.Config)
+	}
+	if core.IsBuiltinHarnessProvider(effectiveProvider) {
+		stepConfig = core.NormalizeBuiltinHarnessFlagKeys(stepConfig)
+	}
+
 	merged := cloneHarnessSpecMap(stepConfig)
 	if merged == nil {
 		merged = make(map[string]any)
@@ -1592,7 +1600,12 @@ func mergeHarnessConfig(dagHarness *core.HarnessConfig, stepConfig map[string]an
 		return merged
 	}
 
-	for key, value := range dagHarness.Config {
+	dagConfig := dagHarness.Config
+	if core.IsBuiltinHarnessProvider(effectiveProvider) {
+		dagConfig = core.NormalizeBuiltinHarnessFlagKeys(dagConfig)
+	}
+
+	for key, value := range dagConfig {
 		if _, exists := merged[key]; !exists {
 			merged[key] = cloneHarnessSpecValue(value)
 		}
@@ -1605,6 +1618,14 @@ func mergeHarnessConfig(dagHarness *core.HarnessConfig, stepConfig map[string]an
 	}
 
 	return merged
+}
+
+func harnessProviderName(cfg map[string]any) string {
+	if cfg == nil {
+		return ""
+	}
+	provider, _ := cfg["provider"].(string)
+	return strings.TrimSpace(provider)
 }
 
 // isRedisZeroValue checks if a value is a zero value for Redis config merging.

--- a/internal/runtime/builtin/harness/harness.go
+++ b/internal/runtime/builtin/harness/harness.go
@@ -451,6 +451,8 @@ func mergeProviderDefaultConfig(provider Provider, cfg map[string]any) map[strin
 	if len(defaults) == 0 {
 		return merged
 	}
+	defaults = core.NormalizeBuiltinHarnessFlagKeys(defaults)
+	merged = core.NormalizeBuiltinHarnessFlagKeys(merged)
 	withDefaults := cloneConfigMap(defaults)
 	maps.Copy(withDefaults, merged)
 	return withDefaults

--- a/internal/runtime/builtin/harness/harness_test.go
+++ b/internal/runtime/builtin/harness/harness_test.go
@@ -348,7 +348,7 @@ func TestBuildProviderConfigs(t *testing.T) {
 		require.Len(t, configs, 1)
 		assert.Equal(t, map[string]any{
 			"provider":            "codex",
-			"skip_git_repo_check": true,
+			"skip-git-repo-check": true,
 		}, configs[0].flags)
 	})
 
@@ -361,7 +361,20 @@ func TestBuildProviderConfigs(t *testing.T) {
 		require.Len(t, configs, 1)
 		assert.Equal(t, map[string]any{
 			"provider":            "codex",
-			"skip_git_repo_check": false,
+			"skip-git-repo-check": false,
+		}, configs[0].flags)
+	})
+
+	t.Run("builtin_provider_aliases_are_deduped", func(t *testing.T) {
+		configs, err := buildProviderConfigs(map[string]any{
+			"provider":            "codex",
+			"skip-git-repo-check": false,
+		}, nil)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		assert.Equal(t, map[string]any{
+			"provider":            "codex",
+			"skip-git-repo-check": false,
 		}, configs[0].flags)
 	})
 }


### PR DESCRIPTION
## Summary
- normalize built-in harness flag aliases to kebab-case before merging DAG harness defaults, step with config, and provider default flags
- prevent duplicate `--skip-git-repo-check` flags when the same option is provided with mixed snake_case and kebab-case keys
- add regression coverage for DAG harness inheritance and built-in provider config merging

## Root Cause
Built-in harness providers normalize option keys from snake_case to kebab-case only when building CLI args. That let equivalent keys like `skip_git_repo_check` and `skip-git-repo-check` coexist in merged config maps and produce duplicate CLI flags.

## Testing
- `make fmt`
- `go test ./internal/core ./internal/core/spec ./internal/runtime/builtin/harness -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed harness flag alias handling during step configuration overrides to prevent duplicate entries when using underscore and hyphenated versions of the same flag.
  * Improved configuration merging to consistently normalize builtin harness flag keys across default and override layers.

* **Tests**
  * Added test coverage for harness flag alias deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->