### PR TITLE
fix: preserve literal code fences in template config

### DIFF
--- a/internal/cmn/eval/eval.go
+++ b/internal/cmn/eval/eval.go
@@ -99,8 +99,8 @@ func ExpandReferencesWithSteps(ctx context.Context, input string, dataMap map[st
 // by default — only explicitly provided vars and non-OS scope entries are used.
 // This prevents OS variables like $HOME from being expanded in non-shell executor
 // configs (SSH, Docker, S3, etc.) where they should be preserved for the remote env.
-func Object[T any](ctx context.Context, obj T, vars map[string]string) (T, error) {
-	options := NewOptions()
+func Object[T any](ctx context.Context, obj T, vars map[string]string, opts ...Option) (T, error) {
+	options := buildOptions(opts)
 	options.Variables = append(options.Variables, vars)
 
 	transform := func(ctx context.Context, s string) (string, error) {

--- a/internal/intg/template_test.go
+++ b/internal/intg/template_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTemplateExecutor covers the end-to-end behavior of the template executor,
+// including literal rendering, file output, and data interpolation edge cases.
 func TestTemplateExecutor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/template_test.go
+++ b/internal/intg/template_test.go
@@ -192,6 +192,39 @@ steps:
 		})
 	})
 
+	t.Run("CodeFenceDataPreserved", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - name: render
+    type: template
+    with:
+      data:
+        issue_text: |
+          `+"```yaml"+`
+          env:
+            TEST_FILE: ~/dagu-test.txt
+
+          steps:
+            - command: touch $TEST_FILE
+          `+"```"+`
+    script: |
+      {{ .issue_text }}
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": []test.Contains{
+				test.Contains("```yaml"),
+				test.Contains("touch $TEST_FILE"),
+			},
+		})
+	})
+
 	t.Run("MissingKeyError", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/intg/template_test.go
+++ b/internal/intg/template_test.go
@@ -222,6 +222,7 @@ steps:
 		dag.AssertOutputs(t, map[string]any{
 			"RESULT": []test.Contains{
 				test.Contains("```yaml"),
+				test.Contains("\n```"),
 				test.Contains("touch $TEST_FILE"),
 			},
 		})

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -33,10 +33,15 @@ func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 	return eval.Object(ctx, obj, GetEnv(ctx).UserEnvsMap())
 }
 
+// evalObjectTreatingOmittedParamsAsEmpty evaluates template executor config while
+// preserving literal backticks in template data and resolving omitted named params
+// to empty strings so optional template fields can remain unset.
 func evalObjectTreatingOmittedParamsAsEmpty[T any](ctx context.Context, obj T) (T, error) {
 	return eval.Object(ctx, obj, templateConfigEvalVariables(GetEnv(ctx)), eval.WithoutSubstitute())
 }
 
+// templateConfigEvalVariables clones the user env map and seeds omitted named DAG
+// params with empty strings for template executor config evaluation.
 func templateConfigEvalVariables(env Env) map[string]string {
 	vars := env.UserEnvsMap()
 	if env.DAG == nil || len(env.DAG.ParamDefs) == 0 {
@@ -60,6 +65,8 @@ func templateConfigEvalVariables(env Env) map[string]string {
 	return cloned
 }
 
+// isPositionalParamName reports whether a param name is a positional index rather
+// than a named parameter.
 func isPositionalParamName(name string) bool {
 	_, err := strconv.Atoi(name)
 	return err == nil

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -34,7 +34,7 @@ func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 }
 
 func evalObjectTreatingOmittedParamsAsEmpty[T any](ctx context.Context, obj T) (T, error) {
-	return eval.Object(ctx, obj, templateConfigEvalVariables(GetEnv(ctx)))
+	return eval.Object(ctx, obj, templateConfigEvalVariables(GetEnv(ctx)), eval.WithoutSubstitute())
 }
 
 func templateConfigEvalVariables(env Env) map[string]string {

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -802,14 +802,14 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 			tag.Signal(killSignal.String()),
 			tag.Step(n.Name()),
 		)
+		if signal.IsTerminationSignalOS(killSignal) {
+			n.SetStatus(core.NodeAborted)
+		}
 		if err := n.cmd.Kill(killSignal); err != nil {
 			logger.Error(ctx, "Failed to send signal",
 				tag.Error(err),
 				tag.Step(n.Name()),
 			)
-		}
-		if signal.IsTerminationSignalOS(killSignal) {
-			n.SetStatus(core.NodeAborted)
 		}
 	}
 }

--- a/internal/runtime/node_internal_test.go
+++ b/internal/runtime/node_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/stretchr/testify/require"
@@ -48,4 +49,36 @@ func TestEvalExecutorConfig_TemplateTreatsOmittedOptionalParamsAsEmpty(t *testin
 	require.True(t, ok)
 	require.Equal(t, "tom", data["name"])
 	require.Equal(t, "", data["favorite_color"])
+}
+
+func TestEvalExecutorConfig_TemplatePreservesLiteralCodeFencesInData(t *testing.T) {
+	t.Parallel()
+
+	ctx := exec.NewContext(
+		context.Background(),
+		&core.DAG{Name: "test-dag"},
+		"",
+		"",
+	)
+	env := NewEnv(ctx, core.Step{Name: "render"})
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"ISSUE_TEXT": "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```",
+	}, eval.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	result, err := evalExecutorConfig(ctx, core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "template",
+			Config: map[string]any{
+				"data": map[string]any{
+					"issue_text": "${ISSUE_TEXT}",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", data["issue_text"])
 }

--- a/internal/runtime/node_internal_test.go
+++ b/internal/runtime/node_internal_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestEvalExecutorConfig_TemplateTreatsOmittedOptionalParamsAsEmpty verifies
+// that optional named params are coerced to empty strings for template config
+// evaluation instead of being left as unresolved placeholders.
 func TestEvalExecutorConfig_TemplateTreatsOmittedOptionalParamsAsEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -51,6 +54,9 @@ func TestEvalExecutorConfig_TemplateTreatsOmittedOptionalParamsAsEmpty(t *testin
 	require.Equal(t, "", data["favorite_color"])
 }
 
+// TestEvalExecutorConfig_TemplatePreservesLiteralCodeFencesInData verifies that
+// template config data can carry fenced content without backtick substitution
+// executing it during evaluator setup.
 func TestEvalExecutorConfig_TemplatePreservesLiteralCodeFencesInData(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/node_test.go
+++ b/internal/runtime/node_test.go
@@ -226,12 +226,21 @@ func TestNode(t *testing.T) {
 
 		go node.Signal(node.Context, syscall.Signal(0), true) // allow override signal
 
-		<-exec.killStarted
+		select {
+		case <-exec.killStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for Kill to start")
+		}
 		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
 
 		close(exec.killContinue)
 
-		err := <-errCh
+		var err error
+		select {
+		case err = <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for Execute to return")
+		}
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "signal: interrupt")
 	})

--- a/internal/runtime/node_test.go
+++ b/internal/runtime/node_test.go
@@ -39,8 +39,11 @@ var (
 type blockingSignalExecutor struct {
 	ready  chan struct{}
 	killed chan os.Signal
-	stdout io.Writer
-	stderr io.Writer
+	// Optional test hooks for controlling Kill ordering.
+	killStarted  chan struct{}
+	killContinue chan struct{}
+	stdout       io.Writer
+	stderr       io.Writer
 }
 
 func newBlockingSignalExecutor() *blockingSignalExecutor {
@@ -69,6 +72,15 @@ func (e *blockingSignalExecutor) Kill(sig os.Signal) error {
 	select {
 	case e.killed <- sig:
 	default:
+	}
+	if e.killStarted != nil {
+		select {
+		case e.killStarted <- struct{}{}:
+		default:
+		}
+	}
+	if e.killContinue != nil {
+		<-e.killContinue
 	}
 	return nil
 }
@@ -105,6 +117,29 @@ func withNodeSignalExecutor(t *testing.T) (<-chan *blockingSignalExecutor, func(
 	prev := nodeSignalExecutorFactory
 	nodeSignalExecutorFactory = func() *blockingSignalExecutor {
 		exec := newBlockingSignalExecutor()
+		execCh <- exec
+		return exec
+	}
+	nodeSignalExecutorFactoryMu.Unlock()
+
+	return execCh, func() {
+		nodeSignalExecutorFactoryMu.Lock()
+		nodeSignalExecutorFactory = prev
+		nodeSignalExecutorFactoryMu.Unlock()
+	}
+}
+
+func withNodeSignalExecutorFactory(t *testing.T, factory func() *blockingSignalExecutor) (<-chan *blockingSignalExecutor, func()) {
+	t.Helper()
+
+	registerNodeSignalExecutor(t)
+
+	execCh := make(chan *blockingSignalExecutor, 1)
+
+	nodeSignalExecutorFactoryMu.Lock()
+	prev := nodeSignalExecutorFactory
+	nodeSignalExecutorFactory = func() *blockingSignalExecutor {
+		exec := factory()
 		execCh <- exec
 		return exec
 	}
@@ -167,6 +202,38 @@ func TestNode(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "signal: interrupt")
 		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
+	})
+	t.Run("SignalMarksAbortedBeforeKillReturns", func(t *testing.T) {
+		execCh, restore := withNodeSignalExecutorFactory(t, func() *blockingSignalExecutor {
+			exec := newBlockingSignalExecutor()
+			exec.killStarted = make(chan struct{}, 1)
+			exec.killContinue = make(chan struct{})
+			return exec
+		})
+		defer restore()
+
+		node := setupNode(t, withNodeExecutorType(nodeSignalExecutorType), withNodeSignalOnStop("SIGINT"))
+		node.SetStatus(core.NodeRunning)
+
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- node.Node.Execute(node.execContext(dagRunID))
+		}()
+
+		exec := <-execCh
+		<-exec.ready
+
+		go node.Signal(node.Context, syscall.Signal(0), true) // allow override signal
+
+		<-exec.killStarted
+		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
+
+		close(exec.killContinue)
+
+		err := <-errCh
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signal: interrupt")
 	})
 	t.Run("CancelUpdatesOnlyRunningOrWaiting", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

Preserve literal fenced template data in `type: template` executor config.

## What Changed

- allow object evaluation to accept evaluator options at the call site
- disable backtick substitution when evaluating template `with:` data while keeping variable expansion and omitted optional param handling
- add runtime and end-to-end regressions for literal fenced content in template data

## Why

Template step config evaluation was treating backticks inside `with.data` as command substitution before the template executor ran. When a prior step injected fenced YAML or Markdown into template data, executor setup tried to run that content as shell commands and failed before rendering.

## Validation

- `go test ./internal/runtime -run 'TestEvalExecutorConfig_Template' -count=1`
- `go test ./internal/intg -run 'TestTemplateExecutor' -count=1`
- `go test ./... -run '^$' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template rendering preserves Markdown fenced code blocks and literal content during interpolation.
  * Improved shutdown handling so interrupted tasks are marked aborted earlier and report interrupt errors promptly.

* **Tests**
  * Added integration and unit tests verifying fenced code blocks remain intact for substituted multi-line values.

* **Refactor**
  * Evaluation API now accepts optional evaluation options to control substitution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->