### PR TITLE
fix: stop evaluating step backticks by default

### DIFF
--- a/internal/core/capabilities.go
+++ b/internal/core/capabilities.go
@@ -30,8 +30,18 @@ type ExecutorCapabilities struct {
 	LLM bool
 	// Agent indicates whether the executor supports the agent field.
 	Agent bool
-	// GetEvalOptions returns eval options for command argument evaluation.
-	// If nil, default evaluation is used.
+	// GetCommandEvalOptions returns eval options for command field evaluation.
+	// Step command fields disable backtick substitution by default; this hook
+	// lets executors refine the remaining evaluation behavior.
+	GetCommandEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetScriptEvalOptions returns eval options for script field evaluation.
+	// Step script fields disable backtick substitution by default.
+	GetScriptEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetConfigEvalOptions returns eval options for executor config evaluation.
+	// Step config fields disable backtick substitution by default.
+	GetConfigEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetEvalOptions is the legacy shared hook for command/script evaluation.
+	// Deprecated: prefer the field-specific hooks above.
 	GetEvalOptions func(ctx context.Context, step Step) []eval.Option
 }
 
@@ -126,12 +136,61 @@ func SupportsAgent(executorType string) bool {
 	return executorCapabilities.Get(executorType).Agent
 }
 
-// EvalOptions returns eval options for this step's executor type.
-// Returns nil if no special eval options are needed.
-func (s Step) EvalOptions(ctx context.Context) []eval.Option {
-	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
-	if caps.GetEvalOptions != nil {
-		return caps.GetEvalOptions(ctx, s)
+func appendEvalOptions(base []eval.Option, extra []eval.Option) []eval.Option {
+	if len(extra) == 0 {
+		return base
 	}
-	return nil
+	opts := make([]eval.Option, 0, len(base)+len(extra))
+	opts = append(opts, base...)
+	opts = append(opts, extra...)
+	return opts
+}
+
+// CommandEvalOptions returns eval options for the step command field.
+// Step command fields disable backtick substitution by default.
+func (s Step) CommandEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	switch {
+	case caps.GetCommandEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetCommandEvalOptions(ctx, s))
+	case caps.GetEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetEvalOptions(ctx, s))
+	default:
+		return base
+	}
+}
+
+// ScriptEvalOptions returns eval options for the step script field.
+// Step script fields disable backtick substitution by default.
+func (s Step) ScriptEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	switch {
+	case caps.GetScriptEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetScriptEvalOptions(ctx, s))
+	case caps.GetCommandEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetCommandEvalOptions(ctx, s))
+	case caps.GetEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetEvalOptions(ctx, s))
+	default:
+		return base
+	}
+}
+
+// ConfigEvalOptions returns eval options for the executor config fields.
+// Step config fields disable backtick substitution by default.
+func (s Step) ConfigEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	if caps.GetConfigEvalOptions != nil {
+		return appendEvalOptions(base, caps.GetConfigEvalOptions(ctx, s))
+	}
+	return base
+}
+
+// EvalOptions returns eval options for this step's executor type command field.
+// Deprecated: use CommandEvalOptions, ScriptEvalOptions, or ConfigEvalOptions.
+func (s Step) EvalOptions(ctx context.Context) []eval.Option {
+	return s.CommandEvalOptions(ctx)
 }

--- a/internal/core/capabilities_test.go
+++ b/internal/core/capabilities_test.go
@@ -77,38 +77,82 @@ func TestExecutorCapabilities_ConcurrentAccess(t *testing.T) {
 	assert.True(t, registry.Get("executor-63").Command)
 }
 
+func optionsFromSlice(opts []eval.Option) *eval.Options {
+	out := eval.NewOptions()
+	for _, opt := range opts {
+		opt(out)
+	}
+	return out
+}
+
 func TestStep_EvalOptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("WithGetEvalOptions", func(t *testing.T) {
-		// Register executor with GetEvalOptions callback
-		RegisterExecutorCapabilities("eval-opts-test", ExecutorCapabilities{
+	t.Run("CommandUsesFieldSpecificHook", func(t *testing.T) {
+		RegisterExecutorCapabilities("command-eval-opts-test", ExecutorCapabilities{
 			Command: true,
+			GetCommandEvalOptions: func(_ context.Context, _ Step) []eval.Option {
+				return []eval.Option{eval.WithoutExpandShell()}
+			},
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "command-eval-opts-test"}}
+		opts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+		assert.False(t, opts.ExpandShell)
+	})
+
+	t.Run("ScriptUsesFieldSpecificHook", func(t *testing.T) {
+		RegisterExecutorCapabilities("script-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+			Script:  true,
+			GetScriptEvalOptions: func(_ context.Context, _ Step) []eval.Option {
+				return []eval.Option{eval.WithNoExpansion()}
+			},
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "script-eval-opts-test"}}
+		opts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+		assert.True(t, opts.NoExpansion)
+	})
+
+	t.Run("ConfigDefaultsDisableSubstitute", func(t *testing.T) {
+		RegisterExecutorCapabilities("config-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "config-eval-opts-test"}}
+		opts := optionsFromSlice(step.ConfigEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+	})
+
+	t.Run("LegacyEvalHookFallsBackForCommandAndScript", func(t *testing.T) {
+		RegisterExecutorCapabilities("legacy-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+			Script:  true,
 			GetEvalOptions: func(_ context.Context, _ Step) []eval.Option {
 				return []eval.Option{eval.WithoutExpandShell()}
 			},
 		})
 
-		step := Step{ExecutorConfig: ExecutorConfig{Type: "eval-opts-test"}}
-		opts := step.EvalOptions(ctx)
-		assert.Len(t, opts, 1)
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "legacy-eval-opts-test"}}
+		commandOpts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		scriptOpts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		assert.False(t, commandOpts.Substitute)
+		assert.False(t, commandOpts.ExpandShell)
+		assert.False(t, scriptOpts.Substitute)
+		assert.False(t, scriptOpts.ExpandShell)
 	})
 
-	t.Run("WithoutGetEvalOptions", func(t *testing.T) {
-		// Register executor without GetEvalOptions
-		RegisterExecutorCapabilities("no-eval-opts-test", ExecutorCapabilities{
-			Command: true,
-		})
-
-		step := Step{ExecutorConfig: ExecutorConfig{Type: "no-eval-opts-test"}}
-		opts := step.EvalOptions(ctx)
-		assert.Nil(t, opts)
-	})
-
-	t.Run("UnregisteredExecutor", func(t *testing.T) {
+	t.Run("UnregisteredExecutorStillDisablesSubstitute", func(t *testing.T) {
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "unregistered-executor"}}
-		opts := step.EvalOptions(ctx)
-		assert.Nil(t, opts)
+		commandOpts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		scriptOpts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		configOpts := optionsFromSlice(step.ConfigEvalOptions(ctx))
+		assert.False(t, commandOpts.Substitute)
+		assert.False(t, scriptOpts.Substitute)
+		assert.False(t, configOpts.Substitute)
 	})
 }

--- a/internal/runtime/builtin/agentstep/executor.go
+++ b/internal/runtime/builtin/agentstep/executor.go
@@ -189,7 +189,7 @@ func (e *Executor) Run(ctx context.Context) error {
 	// Evaluate variable substitution in messages.
 	var userMessages []llm.Message
 	for _, msg := range e.step.Messages {
-		content, evalErr := runtime.EvalString(ctx, msg.Content)
+		content, evalErr := runtime.EvalStepString(ctx, msg.Content)
 		if evalErr != nil {
 			return fmt.Errorf("failed to evaluate message content: %w", evalErr)
 		}

--- a/internal/runtime/builtin/chat/executor.go
+++ b/internal/runtime/builtin/chat/executor.go
@@ -272,7 +272,7 @@ func normalizeEnvVarExpr(expr string) string {
 func evalMessages(ctx context.Context, msgs []exec.LLMMessage) ([]exec.LLMMessage, error) {
 	result := make([]exec.LLMMessage, len(msgs))
 	for i, msg := range msgs {
-		content, err := runtime.EvalString(ctx, msg.Content)
+		content, err := runtime.EvalStepString(ctx, msg.Content)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate message content: %w", err)
 		}
@@ -448,7 +448,7 @@ func (e *Executor) createProviderForModel(ctx context.Context, model core.ModelE
 	var apiKey string
 	if apiKeyEnvVar != "" {
 		apiKeyExpr := normalizeEnvVarExpr(apiKeyEnvVar)
-		apiKey, err = runtime.EvalString(ctx, apiKeyExpr)
+		apiKey, err = runtime.EvalStepString(ctx, apiKeyExpr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate API key: %w", err)
 		}
@@ -457,7 +457,7 @@ func (e *Executor) createProviderForModel(ctx context.Context, model core.ModelE
 	// Evaluate base URL if specified
 	baseURL := cfg.BaseURL
 	if baseURL != "" {
-		baseURL, err = runtime.EvalString(ctx, baseURL)
+		baseURL, err = runtime.EvalStepString(ctx, baseURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate baseURL: %w", err)
 		}

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -419,7 +419,11 @@ func init() {
 		MultipleCommands: true,
 		Script:           true,
 		Shell:            true,
-		GetEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+		GetCommandEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+			env := runtime.GetEnv(ctx)
+			return commandEvalOptions(env.Shell(ctx))
+		},
+		GetScriptEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			env := runtime.GetEnv(ctx)
 			return commandEvalOptions(env.Shell(ctx))
 		},

--- a/internal/runtime/builtin/command/eval_options_test.go
+++ b/internal/runtime/builtin/command/eval_options_test.go
@@ -22,7 +22,7 @@ func getEvalOptions(t *testing.T, step core.Step) *eval.Options {
 	ctx = runtime.WithEnv(ctx, env)
 
 	opts := eval.NewOptions()
-	for _, opt := range step.EvalOptions(ctx) {
+	for _, opt := range step.CommandEvalOptions(ctx) {
 		opt(opts)
 	}
 
@@ -124,6 +124,7 @@ func TestCommandExecutor_GetEvalOptions(t *testing.T) {
 			require.Equal(t, tt.wantExpandEnv, opts.ExpandEnv)
 			require.Equal(t, tt.wantExpandOS, opts.ExpandOS)
 			require.Equal(t, tt.wantEscape, opts.EscapeDollar)
+			require.False(t, opts.Substitute)
 		})
 	}
 }

--- a/internal/runtime/builtin/docker/eval_options_test.go
+++ b/internal/runtime/builtin/docker/eval_options_test.go
@@ -15,7 +15,7 @@ import (
 
 func getEscapeDollar(ctx context.Context, step core.Step) bool {
 	opts := eval.NewOptions()
-	for _, opt := range step.EvalOptions(ctx) {
+	for _, opt := range step.CommandEvalOptions(ctx) {
 		opt(opts)
 	}
 	return opts.EscapeDollar

--- a/internal/runtime/builtin/docker/executor.go
+++ b/internal/runtime/builtin/docker/executor.go
@@ -446,24 +446,24 @@ func EvalContainerFields(ctx context.Context, ct core.Container) (core.Container
 	var err error
 
 	// Evaluate exec field (for exec-into-existing-container mode)
-	if ct.Exec, err = runtime.EvalString(ctx, ct.Exec); err != nil {
+	if ct.Exec, err = runtime.EvalStepString(ctx, ct.Exec); err != nil {
 		return ct, fmt.Errorf("failed to evaluate exec: %w", err)
 	}
 
 	// Evaluate string fields
-	if ct.Image, err = runtime.EvalString(ctx, ct.Image); err != nil {
+	if ct.Image, err = runtime.EvalStepString(ctx, ct.Image); err != nil {
 		return ct, fmt.Errorf("failed to evaluate image: %w", err)
 	}
-	if ct.Name, err = runtime.EvalString(ctx, ct.Name); err != nil {
+	if ct.Name, err = runtime.EvalStepString(ctx, ct.Name); err != nil {
 		return ct, fmt.Errorf("failed to evaluate name: %w", err)
 	}
-	if ct.User, err = runtime.EvalString(ctx, ct.User); err != nil {
+	if ct.User, err = runtime.EvalStepString(ctx, ct.User); err != nil {
 		return ct, fmt.Errorf("failed to evaluate user: %w", err)
 	}
-	if ct.WorkingDir, err = runtime.EvalString(ctx, ct.WorkingDir); err != nil {
+	if ct.WorkingDir, err = runtime.EvalStepString(ctx, ct.WorkingDir); err != nil {
 		return ct, fmt.Errorf("failed to evaluate workingDir: %w", err)
 	}
-	if ct.Network, err = runtime.EvalString(ctx, ct.Network); err != nil {
+	if ct.Network, err = runtime.EvalStepString(ctx, ct.Network); err != nil {
 		return ct, fmt.Errorf("failed to evaluate network: %w", err)
 	}
 
@@ -487,14 +487,14 @@ func EvalContainerFields(ctx context.Context, ct core.Container) (core.Container
 	return ct, nil
 }
 
-// evalStringSlice evaluates each string in a slice using runtime.EvalString.
+// evalStringSlice evaluates each string in a slice as a step-owned field.
 func evalStringSlice(ctx context.Context, ss []string) ([]string, error) {
 	if len(ss) == 0 {
 		return ss, nil
 	}
 	result := make([]string, len(ss))
 	for i, s := range ss {
-		evaluated, err := runtime.EvalString(ctx, s)
+		evaluated, err := runtime.EvalStepString(ctx, s)
 		if err != nil {
 			return nil, err
 		}
@@ -533,7 +533,7 @@ func init() {
 		Command:          true,
 		MultipleCommands: true,
 		Container:        true,
-		GetEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+		GetCommandEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			if hasShellConfigured(ctx, step) {
 				return []eval.Option{eval.WithoutDollarEscape()}
 			}

--- a/internal/runtime/builtin/jq/jq.go
+++ b/internal/runtime/builtin/jq/jq.go
@@ -49,7 +49,7 @@ func newJQ(ctx context.Context, step core.Step) (executor.Executor, error) {
 		return nil, fmt.Errorf("jq: config.input and script are mutually exclusive; provide one, not both")
 	case jqCfg.Input != "":
 		// Evaluate the input path to resolve step references like ${step.stdout}
-		inputPath, err := runtime.EvalString(ctx, jqCfg.Input)
+		inputPath, err := runtime.EvalStepString(ctx, jqCfg.Input)
 		if err != nil {
 			return nil, fmt.Errorf("jq: failed to evaluate config.input: %w", err)
 		}

--- a/internal/runtime/builtin/ssh/ssh.go
+++ b/internal/runtime/builtin/ssh/ssh.go
@@ -242,7 +242,15 @@ func init() {
 		MultipleCommands: true,
 		Script:           true,
 		Shell:            true,
-		GetEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+		GetCommandEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+			if hasShellConfigured(ctx, step) {
+				// Shell is configured, shell features (expansion, pipes, etc.) are supported
+				return []eval.Option{eval.WithoutDollarEscape()}
+			}
+			// No shell configured - skip shell expansion for remote execution
+			return []eval.Option{eval.WithoutExpandShell()}
+		},
+		GetScriptEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			if hasShellConfigured(ctx, step) {
 				// Shell is configured, shell features (expansion, pipes, etc.) are supported
 				return []eval.Option{eval.WithoutDollarEscape()}

--- a/internal/runtime/builtin/ssh/ssh_test.go
+++ b/internal/runtime/builtin/ssh/ssh_test.go
@@ -277,11 +277,12 @@ func TestSSHExecutor_GetEvalOptions(t *testing.T) {
 				ctx = WithSSHClient(ctx, &Client{Shell: tt.dagShell})
 			}
 
-			opts := tt.step.EvalOptions(ctx)
+			opts := tt.step.CommandEvalOptions(ctx)
 			evalOpts := eval.NewOptions()
 			for _, opt := range opts {
 				opt(evalOpts)
 			}
+			require.False(t, evalOpts.Substitute, "expected step fields to disable backtick substitution")
 
 			if tt.expectSkipShell {
 				require.False(t, evalOpts.ExpandShell, "expected WithoutExpandShell option")

--- a/internal/runtime/builtin/template/template.go
+++ b/internal/runtime/builtin/template/template.go
@@ -151,7 +151,7 @@ func buildFuncMap() template.FuncMap {
 func init() {
 	executor.RegisterExecutor("template", newTemplate, validateTemplate, core.ExecutorCapabilities{
 		Script: true,
-		GetEvalOptions: func(_ context.Context, _ core.Step) []eval.Option {
+		GetScriptEvalOptions: func(_ context.Context, _ core.Step) []eval.Option {
 			return []eval.Option{eval.WithNoExpansion()}
 		},
 	})

--- a/internal/runtime/data.go
+++ b/internal/runtime/data.go
@@ -261,17 +261,15 @@ func (d *Data) Setup(ctx context.Context, logFile string, startedAt time.Time) e
 	}
 	d.inner.State.StartedAt = startedAt
 
-	env := GetEnv(ctx)
-
 	// Evaluate the stdout field
-	stdout, err := env.EvalString(ctx, d.inner.Step.Stdout, eval.WithoutDollarEscape())
+	stdout, err := EvalStepString(ctx, d.inner.Step.Stdout, eval.WithoutDollarEscape())
 	if err != nil {
 		return fmt.Errorf("failed to evaluate stdout field: %w", err)
 	}
 	d.inner.Step.Stdout = stdout
 
 	// Evaluate the stderr field
-	stderr, err := env.EvalString(ctx, d.inner.Step.Stderr, eval.WithoutDollarEscape())
+	stderr, err := EvalStepString(ctx, d.inner.Step.Stderr, eval.WithoutDollarEscape())
 	if err != nil {
 		return fmt.Errorf("failed to evaluate stderr field: %w", err)
 	}

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -21,6 +21,16 @@ func EvalString(ctx context.Context, s string, opts ...eval.Option) (string, err
 	return GetEnv(ctx).EvalString(ctx, s, opts...)
 }
 
+// EvalStepString evaluates a step-owned string field while preserving literal
+// backticks. Step fields are treated as data or downstream program input unless
+// they are explicit condition expressions evaluated elsewhere.
+func EvalStepString(ctx context.Context, s string, opts ...eval.Option) (string, error) {
+	options := make([]eval.Option, 0, len(opts)+1)
+	options = append(options, eval.WithoutSubstitute())
+	options = append(options, opts...)
+	return EvalString(ctx, s, options...)
+}
+
 // EvalBool evaluates the given value with the variables within the execution context
 // and parses it as a boolean.
 func EvalBool(ctx context.Context, value any) (bool, error) {
@@ -31,13 +41,6 @@ func EvalBool(ctx context.Context, value any) (bool, error) {
 // with the variables within the execution context.
 func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 	return eval.Object(ctx, obj, GetEnv(ctx).UserEnvsMap())
-}
-
-// evalObjectTreatingOmittedParamsAsEmpty evaluates template executor config while
-// preserving literal backticks in template data and resolving omitted named params
-// to empty strings so optional template fields can remain unset.
-func evalObjectTreatingOmittedParamsAsEmpty[T any](ctx context.Context, obj T) (T, error) {
-	return eval.Object(ctx, obj, templateConfigEvalVariables(GetEnv(ctx)), eval.WithoutSubstitute())
 }
 
 // templateConfigEvalVariables clones the user env map and seeds omitted named DAG

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -650,7 +650,7 @@ func (n *Node) setupExecutor(ctx context.Context) (executor.Executor, error) {
 	if child := n.Step().SubDAG; child != nil {
 		copy := *child
 		if n.Step().Parallel == nil {
-			dagName, err := EvalString(ctx, child.Name)
+			dagName, err := EvalStepString(ctx, child.Name)
 			if err != nil {
 				return nil, fmt.Errorf("failed to eval sub DAG name: %w", err)
 			}
@@ -661,7 +661,7 @@ func (n *Node) setupExecutor(ctx context.Context) (executor.Executor, error) {
 
 	// Evaluate script if set
 	if script := n.Step().Script; script != "" {
-		opts := n.Step().EvalOptions(ctx)
+		opts := n.Step().ScriptEvalOptions(ctx)
 		if n.Step().ExecutorConfig.IsCommand() {
 			opts = append(opts, eval.OnlyReplaceVars())
 		}
@@ -701,9 +701,9 @@ func (n *Node) setupExecutor(ctx context.Context) (executor.Executor, error) {
 
 func evalExecutorConfig(ctx context.Context, step core.Step) (map[string]any, error) {
 	if step.ExecutorConfig.Type == "template" {
-		return evalObjectTreatingOmittedParamsAsEmpty(ctx, step.ExecutorConfig.Config)
+		return eval.Object(ctx, step.ExecutorConfig.Config, templateConfigEvalVariables(GetEnv(ctx)), step.ConfigEvalOptions(ctx)...)
 	}
-	return EvalObject(ctx, step.ExecutorConfig.Config)
+	return eval.Object(ctx, step.ExecutorConfig.Config, GetEnv(ctx).UserEnvsMap(), step.ConfigEvalOptions(ctx)...)
 }
 
 func (n *Node) configureSubDAGExecutor(cmd executor.Executor, subRuns []SubDAGRun) error {
@@ -747,7 +747,7 @@ func (n *Node) evaluateCommandArgs(ctx context.Context) error {
 	}
 
 	// Get eval options from executor capabilities
-	evalOptions := n.Step().EvalOptions(ctx)
+	evalOptions := n.Step().CommandEvalOptions(ctx)
 
 	step := n.Step()
 
@@ -974,7 +974,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 
 	// Single sub DAG execution (non-parallel)
 	if parallel == nil {
-		params, err := EvalString(ctx, subDAG.Params)
+		params, err := EvalStepString(ctx, subDAG.Params)
 		if err != nil {
 			return nil, fmt.Errorf("failed to eval sub dag params: %w", err)
 		}
@@ -996,7 +996,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 
 	// Handle variable reference
 	if parallel.Variable != "" {
-		value, err := EvalString(ctx, parallel.Variable)
+		value, err := EvalStepString(ctx, parallel.Variable)
 		if err != nil {
 			return nil, fmt.Errorf("failed to eval parallel variable %q: %w", parallel.Variable, err)
 		}
@@ -1013,7 +1013,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 		// Handle static items
 		for _, item := range parallel.Items {
 			if item.Value != "" {
-				value, err := EvalString(ctx, item.Value)
+				value, err := EvalStepString(ctx, item.Value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to eval parallel item value %q: %w", item.Value, err)
 				}
@@ -1022,7 +1022,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 				// evaluate each value in Params
 				m := make(collections.DeterministicMap)
 				for key, value := range item.Params {
-					evaluatedValue, err := EvalString(ctx, value)
+					evaluatedValue, err := EvalStepString(ctx, value)
 					if err != nil {
 						return nil, fmt.Errorf("failed to eval parallel item param %q: %w", key, err)
 					}
@@ -1067,7 +1067,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 			"ITEM": param,
 		}
 
-		dagName, err := EvalString(ctx, subDAG.Name, eval.WithVariables(variables))
+		dagName, err := EvalStepString(ctx, subDAG.Name, eval.WithVariables(variables))
 		if err != nil {
 			return nil, fmt.Errorf("failed to eval sub dag name: %w", err)
 		}
@@ -1076,7 +1076,7 @@ func (n *Node) BuildSubDAGRuns(ctx context.Context, subDAG *core.SubDAG) ([]SubD
 		finalParams := param
 		if subDAG.Params != "" {
 			params := subDAG.Params
-			evaluatedStepParams, err := EvalString(ctx, params, eval.WithVariables(variables))
+			evaluatedStepParams, err := EvalStepString(ctx, params, eval.WithVariables(variables))
 			if err != nil {
 				return nil, fmt.Errorf("failed to eval step params: %w", err)
 			}

--- a/internal/runtime/node_internal_test.go
+++ b/internal/runtime/node_internal_test.go
@@ -88,3 +88,93 @@ func TestEvalExecutorConfig_TemplatePreservesLiteralCodeFencesInData(t *testing.
 	require.True(t, ok)
 	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", data["issue_text"])
 }
+
+// TestEvalExecutorConfig_DefaultPreservesLiteralCodeFencesInData verifies that
+// non-template executor config is also treated as step data and should not
+// execute backticks while resolving variable references.
+func TestEvalExecutorConfig_DefaultPreservesLiteralCodeFencesInData(t *testing.T) {
+	t.Parallel()
+
+	ctx := exec.NewContext(
+		context.Background(),
+		&core.DAG{Name: "test-dag"},
+		"",
+		"",
+	)
+	env := NewEnv(ctx, core.Step{Name: "analyze"})
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"PROMPT_TEXT": "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```",
+	}, eval.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	result, err := evalExecutorConfig(ctx, core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "harness",
+			Config: map[string]any{
+				"provider": "codex",
+				"note":     "${PROMPT_TEXT}",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", result["note"])
+}
+
+// TestSetupExecutor_HarnessCommandPreservesLiteralCodeFences verifies that
+// command-backed prompt executors resolve ${VAR} placeholders without treating
+// the resulting prompt text as shell command substitution input.
+func TestSetupExecutor_HarnessCommandPreservesLiteralCodeFences(t *testing.T) {
+	t.Parallel()
+
+	step := core.Step{
+		Name: "analyze",
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   "harness",
+			Config: map[string]any{"provider": "codex"},
+		},
+		Commands: []core.CommandEntry{{
+			CmdWithArgs: "${ANALYZE_PROMPT}",
+		}},
+	}
+	ctx := NewContextForTest(context.Background(), &core.DAG{Name: "test-dag"}, "run-1", "test.log")
+	env := NewEnv(ctx, step)
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"ANALYZE_PROMPT": "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```",
+	}, eval.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	node := NewNode(step, NodeState{})
+	_, err := node.setupExecutor(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", node.Step().Commands[0].CmdWithArgs)
+}
+
+// TestSetupExecutor_HarnessScriptPreservesLiteralCodeFences verifies that
+// script-backed prompt content is preserved literally until the target executor
+// consumes it.
+func TestSetupExecutor_HarnessScriptPreservesLiteralCodeFences(t *testing.T) {
+	t.Parallel()
+
+	step := core.Step{
+		Name: "analyze",
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   "harness",
+			Config: map[string]any{"provider": "codex"},
+		},
+		Commands: []core.CommandEntry{{
+			CmdWithArgs: "Summarize the issue",
+		}},
+		Script: "${ANALYZE_SCRIPT}",
+	}
+	ctx := NewContextForTest(context.Background(), &core.DAG{Name: "test-dag"}, "run-1", "test.log")
+	env := NewEnv(ctx, step)
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"ANALYZE_SCRIPT": "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```",
+	}, eval.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	node := NewNode(step, NodeState{})
+	_, err := node.setupExecutor(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", node.Step().Script)
+}


### PR DESCRIPTION
## Summary

Stop evaluating backtick command substitution in step-owned fields by default.

## What Changed

- add field-aware evaluator hooks for executor capabilities so command, script, and config fields can declare their own evaluation policy
- disable backtick substitution by default for step command, script, config, sub-DAG, parallel, and other step-owned text fields while preserving condition evaluation behavior
- update affected runtime call sites and executor eval-option wiring to use the new step-field contract
- add regression coverage for harness prompt/script paths and generic executor config with literal fenced content

## Why

Step-owned text was being routed through the generic evaluator pipeline, which treats backticks as command substitution. That made prompts, templates, config strings, and other non-shell step fields brittle: a rendered value containing fenced Markdown or YAML could be executed accidentally during step setup instead of being passed through literally.

## Validation

- `go test ./internal/core ./internal/runtime ./internal/runtime/builtin/command ./internal/runtime/builtin/docker ./internal/runtime/builtin/ssh -run 'Test(Step_EvalOptions|EvalExecutorConfig_DefaultPreservesLiteralCodeFencesInData|SetupExecutor_Harness(Command|Script)PreservesLiteralCodeFences|CommandExecutor_GetEvalOptions|DockerExecutor_GetEvalOptions|SSHExecutor_GetEvalOptions)' -count=1`
- `go test ./internal/core/... ./internal/runtime/... -count=1`
- `go test ./... -run ^ -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal evaluation consistency across command, script, and configuration steps to ensure more appropriate variable substitution and character escaping behavior in different execution contexts.

* **Bug Fixes**
  * Enhanced preservation of literal code content and backticks during step execution across various executor types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->