### PR TITLE
fix: align command condition expansion with shell commands

### DIFF
--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -9518,10 +9518,10 @@ components:
       properties:
         condition:
           type: string
-          description: "Expression or check to evaluate"
+          description: "Expression or check to evaluate. When `expected` is omitted, the value runs as a command check using the same variable expansion rules as shell `command` steps."
         expected:
           type: string
-          description: "Expected result of the condition evaluation"
+          description: "Expected result of the condition evaluation. When set, Dagu compares the evaluated string output instead of using command exit status."
         negate:
           type: boolean
           description: "If true, inverts the condition result (run when condition does NOT match)"

--- a/internal/core/capabilities.go
+++ b/internal/core/capabilities.go
@@ -30,8 +30,18 @@ type ExecutorCapabilities struct {
 	LLM bool
 	// Agent indicates whether the executor supports the agent field.
 	Agent bool
-	// GetEvalOptions returns eval options for command argument evaluation.
-	// If nil, default evaluation is used.
+	// GetCommandEvalOptions returns eval options for command field evaluation.
+	// Step command fields disable backtick substitution by default; this hook
+	// lets executors refine the remaining evaluation behavior.
+	GetCommandEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetScriptEvalOptions returns eval options for script field evaluation.
+	// Step script fields disable backtick substitution by default.
+	GetScriptEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetConfigEvalOptions returns eval options for executor config evaluation.
+	// Step config fields disable backtick substitution by default.
+	GetConfigEvalOptions func(ctx context.Context, step Step) []eval.Option
+	// GetEvalOptions is the legacy shared hook for command/script evaluation.
+	// Deprecated: prefer the field-specific hooks above.
 	GetEvalOptions func(ctx context.Context, step Step) []eval.Option
 }
 
@@ -126,12 +136,61 @@ func SupportsAgent(executorType string) bool {
 	return executorCapabilities.Get(executorType).Agent
 }
 
-// EvalOptions returns eval options for this step's executor type.
-// Returns nil if no special eval options are needed.
-func (s Step) EvalOptions(ctx context.Context) []eval.Option {
-	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
-	if caps.GetEvalOptions != nil {
-		return caps.GetEvalOptions(ctx, s)
+func appendEvalOptions(base []eval.Option, extra []eval.Option) []eval.Option {
+	if len(extra) == 0 {
+		return base
 	}
-	return nil
+	opts := make([]eval.Option, 0, len(base)+len(extra))
+	opts = append(opts, base...)
+	opts = append(opts, extra...)
+	return opts
+}
+
+// CommandEvalOptions returns eval options for the step command field.
+// Step command fields disable backtick substitution by default.
+func (s Step) CommandEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	switch {
+	case caps.GetCommandEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetCommandEvalOptions(ctx, s))
+	case caps.GetEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetEvalOptions(ctx, s))
+	default:
+		return base
+	}
+}
+
+// ScriptEvalOptions returns eval options for the step script field.
+// Step script fields disable backtick substitution by default.
+func (s Step) ScriptEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	switch {
+	case caps.GetScriptEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetScriptEvalOptions(ctx, s))
+	case caps.GetCommandEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetCommandEvalOptions(ctx, s))
+	case caps.GetEvalOptions != nil:
+		return appendEvalOptions(base, caps.GetEvalOptions(ctx, s))
+	default:
+		return base
+	}
+}
+
+// ConfigEvalOptions returns eval options for the executor config fields.
+// Step config fields disable backtick substitution by default.
+func (s Step) ConfigEvalOptions(ctx context.Context) []eval.Option {
+	caps := executorCapabilities.Get(s.ExecutorConfig.Type)
+	base := []eval.Option{eval.WithoutSubstitute()}
+	if caps.GetConfigEvalOptions != nil {
+		return appendEvalOptions(base, caps.GetConfigEvalOptions(ctx, s))
+	}
+	return base
+}
+
+// EvalOptions returns eval options for this step's executor type command field.
+// Deprecated: use CommandEvalOptions, ScriptEvalOptions, or ConfigEvalOptions.
+func (s Step) EvalOptions(ctx context.Context) []eval.Option {
+	return s.CommandEvalOptions(ctx)
 }

--- a/internal/core/capabilities_test.go
+++ b/internal/core/capabilities_test.go
@@ -77,38 +77,82 @@ func TestExecutorCapabilities_ConcurrentAccess(t *testing.T) {
 	assert.True(t, registry.Get("executor-63").Command)
 }
 
+func optionsFromSlice(opts []eval.Option) *eval.Options {
+	out := eval.NewOptions()
+	for _, opt := range opts {
+		opt(out)
+	}
+	return out
+}
+
 func TestStep_EvalOptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("WithGetEvalOptions", func(t *testing.T) {
-		// Register executor with GetEvalOptions callback
-		RegisterExecutorCapabilities("eval-opts-test", ExecutorCapabilities{
+	t.Run("CommandUsesFieldSpecificHook", func(t *testing.T) {
+		RegisterExecutorCapabilities("command-eval-opts-test", ExecutorCapabilities{
 			Command: true,
+			GetCommandEvalOptions: func(_ context.Context, _ Step) []eval.Option {
+				return []eval.Option{eval.WithoutExpandShell()}
+			},
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "command-eval-opts-test"}}
+		opts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+		assert.False(t, opts.ExpandShell)
+	})
+
+	t.Run("ScriptUsesFieldSpecificHook", func(t *testing.T) {
+		RegisterExecutorCapabilities("script-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+			Script:  true,
+			GetScriptEvalOptions: func(_ context.Context, _ Step) []eval.Option {
+				return []eval.Option{eval.WithNoExpansion()}
+			},
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "script-eval-opts-test"}}
+		opts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+		assert.True(t, opts.NoExpansion)
+	})
+
+	t.Run("ConfigDefaultsDisableSubstitute", func(t *testing.T) {
+		RegisterExecutorCapabilities("config-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+		})
+
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "config-eval-opts-test"}}
+		opts := optionsFromSlice(step.ConfigEvalOptions(ctx))
+		assert.False(t, opts.Substitute)
+	})
+
+	t.Run("LegacyEvalHookFallsBackForCommandAndScript", func(t *testing.T) {
+		RegisterExecutorCapabilities("legacy-eval-opts-test", ExecutorCapabilities{
+			Command: true,
+			Script:  true,
 			GetEvalOptions: func(_ context.Context, _ Step) []eval.Option {
 				return []eval.Option{eval.WithoutExpandShell()}
 			},
 		})
 
-		step := Step{ExecutorConfig: ExecutorConfig{Type: "eval-opts-test"}}
-		opts := step.EvalOptions(ctx)
-		assert.Len(t, opts, 1)
+		step := Step{ExecutorConfig: ExecutorConfig{Type: "legacy-eval-opts-test"}}
+		commandOpts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		scriptOpts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		assert.False(t, commandOpts.Substitute)
+		assert.False(t, commandOpts.ExpandShell)
+		assert.False(t, scriptOpts.Substitute)
+		assert.False(t, scriptOpts.ExpandShell)
 	})
 
-	t.Run("WithoutGetEvalOptions", func(t *testing.T) {
-		// Register executor without GetEvalOptions
-		RegisterExecutorCapabilities("no-eval-opts-test", ExecutorCapabilities{
-			Command: true,
-		})
-
-		step := Step{ExecutorConfig: ExecutorConfig{Type: "no-eval-opts-test"}}
-		opts := step.EvalOptions(ctx)
-		assert.Nil(t, opts)
-	})
-
-	t.Run("UnregisteredExecutor", func(t *testing.T) {
+	t.Run("UnregisteredExecutorStillDisablesSubstitute", func(t *testing.T) {
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "unregistered-executor"}}
-		opts := step.EvalOptions(ctx)
-		assert.Nil(t, opts)
+		commandOpts := optionsFromSlice(step.CommandEvalOptions(ctx))
+		scriptOpts := optionsFromSlice(step.ScriptEvalOptions(ctx))
+		configOpts := optionsFromSlice(step.ConfigEvalOptions(ctx))
+		assert.False(t, commandOpts.Substitute)
+		assert.False(t, scriptOpts.Substitute)
+		assert.False(t, configOpts.Substitute)
 	})
 }

--- a/internal/core/capabilities_test.go
+++ b/internal/core/capabilities_test.go
@@ -96,6 +96,7 @@ func TestStep_EvalOptions(t *testing.T) {
 				return []eval.Option{eval.WithoutExpandShell()}
 			},
 		})
+		t.Cleanup(func() { UnregisterExecutorCapabilities("command-eval-opts-test") })
 
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "command-eval-opts-test"}}
 		opts := optionsFromSlice(step.CommandEvalOptions(ctx))
@@ -111,6 +112,7 @@ func TestStep_EvalOptions(t *testing.T) {
 				return []eval.Option{eval.WithNoExpansion()}
 			},
 		})
+		t.Cleanup(func() { UnregisterExecutorCapabilities("script-eval-opts-test") })
 
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "script-eval-opts-test"}}
 		opts := optionsFromSlice(step.ScriptEvalOptions(ctx))
@@ -122,6 +124,7 @@ func TestStep_EvalOptions(t *testing.T) {
 		RegisterExecutorCapabilities("config-eval-opts-test", ExecutorCapabilities{
 			Command: true,
 		})
+		t.Cleanup(func() { UnregisterExecutorCapabilities("config-eval-opts-test") })
 
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "config-eval-opts-test"}}
 		opts := optionsFromSlice(step.ConfigEvalOptions(ctx))
@@ -136,6 +139,7 @@ func TestStep_EvalOptions(t *testing.T) {
 				return []eval.Option{eval.WithoutExpandShell()}
 			},
 		})
+		t.Cleanup(func() { UnregisterExecutorCapabilities("legacy-eval-opts-test") })
 
 		step := Step{ExecutorConfig: ExecutorConfig{Type: "legacy-eval-opts-test"}}
 		commandOpts := optionsFromSlice(step.CommandEvalOptions(ctx))

--- a/internal/intg/precondition_env_test.go
+++ b/internal/intg/precondition_env_test.go
@@ -5,12 +5,40 @@ package intg_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/test"
 )
+
+func posixHomeRelativeTempPath(t *testing.T, pattern string) (string, string) {
+	t.Helper()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("resolve home dir: %v", err)
+	}
+
+	tempFile, err := os.CreateTemp(homeDir, pattern)
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
+	if err := os.Remove(tempFile.Name()); err != nil {
+		t.Fatalf("remove temp file: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Remove(tempFile.Name())
+	})
+
+	return tempFile.Name(), "~/" + filepath.Base(tempFile.Name())
+}
 
 func powerShellEnvOrLiteral(value string) string {
 	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") && len(value) > 3 {
@@ -127,4 +155,40 @@ steps:
 		"STEP_RESULT": "go",
 		"FINAL":       "ran",
 	})
+}
+
+func TestPreconditionWithHomeRelativeDAGEnvVar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping Unix shell test on Windows")
+	}
+
+	t.Parallel()
+	th := test.Setup(t)
+	absolutePath, homeRelativePath := posixHomeRelativeTempPath(t, ".dagu-precondition-*")
+
+	dag := th.DAG(t, fmt.Sprintf(`
+type: graph
+env:
+  - TEST_FILE: %q
+steps:
+  - name: create
+    command: touch $TEST_FILE
+  - name: check
+    command: echo "ran"
+    output: RESULT
+    depends: create
+    preconditions:
+      - condition: test -f $TEST_FILE
+`, homeRelativePath))
+	agent := dag.Agent()
+	agent.RunSuccess(t)
+
+	dag.AssertOutputs(t, map[string]any{
+		"RESULT": "ran",
+	})
+
+	_, err := os.Stat(absolutePath)
+	if err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
 }

--- a/internal/intg/repeat_test.go
+++ b/internal/intg/repeat_test.go
@@ -161,6 +161,44 @@ func TestRepeatPolicy_WithLimitAndCondition(t *testing.T) {
 	assert.Equal(t, 5, dagRunStatus.Nodes[0].DoneCount, "Step should have stopped at limit of 5")
 }
 
+func TestRepeatPolicy_CommandConditionWithHomeRelativeDAGEnvVar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping Unix shell test on Windows")
+	}
+
+	repeatPolicyParallel(t)
+	th := test.Setup(t)
+	_, homeRelativePath := posixHomeRelativeTempPath(t, ".dagu-repeat-*")
+
+	dag := th.DAG(t, fmt.Sprintf(`env:
+  - TEST_FILE: %q
+steps:
+  - command: touch $TEST_FILE
+    repeat_policy:
+      repeat: while
+      condition: test ! -f $TEST_FILE
+      interval_sec: 0
+      limit: 2
+`, homeRelativePath))
+	agent := dag.Agent()
+
+	ctx, cancel := context.WithTimeout(agent.Context, repeatPolicyTimeout(10*time.Second))
+	defer cancel()
+
+	err := agent.Run(ctx)
+	require.NoError(t, err, "DAG should complete successfully")
+
+	dag.AssertLatestStatus(t, core.Succeeded)
+
+	dagRunStatus, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, dagRunStatus)
+
+	require.Len(t, dagRunStatus.Nodes, 1)
+	assert.Equal(t, core.NodeSucceeded, dagRunStatus.Nodes[0].Status)
+	assert.Equal(t, 1, dagRunStatus.Nodes[0].DoneCount, "Step should stop after the first run once the file exists")
+}
+
 func TestRepeatPolicy_WithLimitReachedBeforeCondition(t *testing.T) {
 	repeatPolicyParallel(t)
 	th := test.Setup(t)

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -419,7 +419,11 @@ func init() {
 		MultipleCommands: true,
 		Script:           true,
 		Shell:            true,
-		GetEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+		GetCommandEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
+			env := runtime.GetEnv(ctx)
+			return runtime.CommandEvalOptions(env.Shell(ctx))
+		},
+		GetScriptEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			env := runtime.GetEnv(ctx)
 			return runtime.CommandEvalOptions(env.Shell(ctx))
 		},

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -421,35 +421,10 @@ func init() {
 		Shell:            true,
 		GetEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			env := runtime.GetEnv(ctx)
-			return commandEvalOptions(env.Shell(ctx))
+			return runtime.CommandEvalOptions(env.Shell(ctx))
 		},
 	}
 	executor.RegisterExecutor("", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("shell", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("command", NewCommand, validateCommandStep, caps)
-}
-
-// commandEvalOptions returns eval options based on the shell type.
-//
-// Shell classification:
-//   - Unix-like (sh, bash, zsh, ksh, ash, dash) and nix-shell: these expand
-//     ${VAR} natively, so Dagu disables its own env expansion to avoid
-//     double-expanding values.
-//   - fish: intentionally excluded from IsUnixLikeShell (it lacks -e flag
-//     support and uses $VAR but not ${VAR}), so Dagu performs ${VAR} expansion.
-//   - Non-Unix (PowerShell, cmd.exe): do not understand ${VAR} syntax at all,
-//     so Dagu must expand variables on their behalf (ExpandEnv stays enabled).
-//   - direct / empty: no shell is involved; Dagu expands OS variables itself.
-func commandEvalOptions(shell []string) []eval.Option {
-	if len(shell) == 0 || shell[0] == "direct" {
-		return []eval.Option{eval.WithOSExpansion()}
-	}
-
-	opts := []eval.Option{eval.WithoutDollarEscape()}
-
-	if cmdutil.IsUnixLikeShell(shell[0]) || cmdutil.IsNixShell(shell[0]) {
-		opts = append(opts, eval.WithoutExpandEnv())
-	}
-
-	return opts
 }

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -421,14 +421,20 @@ func init() {
 		Shell:            true,
 		GetCommandEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			env := runtime.GetEnv(ctx)
-			return runtime.CommandEvalOptions(env.Shell(ctx))
+			return commandEvalOptions(env.Shell(ctx))
 		},
 		GetScriptEvalOptions: func(ctx context.Context, step core.Step) []eval.Option {
 			env := runtime.GetEnv(ctx)
-			return runtime.CommandEvalOptions(env.Shell(ctx))
+			return commandEvalOptions(env.Shell(ctx))
 		},
 	}
 	executor.RegisterExecutor("", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("shell", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("command", NewCommand, validateCommandStep, caps)
+}
+
+// commandEvalOptions keeps the command executor aligned with the shape of the
+// main branch while delegating the shared policy to runtime.
+func commandEvalOptions(shell []string) []eval.Option {
+	return runtime.CommandEvalOptions(shell)
 }

--- a/internal/runtime/condition.go
+++ b/internal/runtime/condition.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"slices"
 
-	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 )
@@ -105,7 +104,7 @@ func matchCondition(ctx context.Context, c *core.Condition) error {
 }
 
 func evalCommand(ctx context.Context, shell []string, c *core.Condition) error {
-	commandToRun, err := EvalString(ctx, c.Condition, eval.OnlyReplaceVars())
+	commandToRun, err := EvalString(ctx, c.Condition, CommandEvalOptions(shell)...)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate command: %w", err)
 	}

--- a/internal/runtime/condition_test.go
+++ b/internal/runtime/condition_test.go
@@ -6,6 +6,9 @@ package runtime_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/cmn/eval"
@@ -205,6 +208,32 @@ func TestEvalConditions_NilShell(t *testing.T) {
 	// the condition should run as a direct command
 	err := runtime.EvalConditions(ctx, nil, []*core.Condition{
 		{Condition: "true"},
+	})
+	require.NoError(t, err)
+}
+
+func TestEvalConditions_CommandFormExpandsHomeRelativeScopeVars(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipping Unix shell test on Windows")
+	}
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tempFile, err := os.CreateTemp(homeDir, ".dagu-condition-*")
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+	t.Cleanup(func() {
+		_ = os.Remove(tempFile.Name())
+	})
+
+	ctx := newTestContext()
+	env := runtime.GetEnv(ctx)
+	env.Scope = env.Scope.WithEntry("TEST_FILE", "~/"+filepath.Base(tempFile.Name()), eval.EnvSourceDAGEnv)
+	ctx = runtime.WithEnv(ctx, env)
+
+	err = runtime.EvalConditions(ctx, []string{"sh"}, []*core.Condition{
+		{Condition: "test -f $TEST_FILE"},
 	})
 	require.NoError(t, err)
 }

--- a/internal/runtime/eval_options.go
+++ b/internal/runtime/eval_options.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/cmn/eval"
+)
+
+// CommandEvalOptions returns eval options for shell-backed command strings.
+//
+// Shell classification:
+//   - Unix-like (sh, bash, zsh, ksh, ash, dash) and nix-shell: these expand
+//     ${VAR} natively, so Dagu disables its own env expansion to avoid
+//     double-expanding values.
+//   - fish: intentionally excluded from IsUnixLikeShell (it lacks -e flag
+//     support and uses $VAR but not ${VAR}), so Dagu performs ${VAR} expansion.
+//   - Non-Unix (PowerShell, cmd.exe): do not understand ${VAR} syntax at all,
+//     so Dagu must expand variables on their behalf (ExpandEnv stays enabled).
+//   - direct / empty: no shell is involved; Dagu expands OS variables itself.
+func CommandEvalOptions(shell []string) []eval.Option {
+	if len(shell) == 0 || shell[0] == "direct" {
+		return []eval.Option{eval.WithOSExpansion()}
+	}
+
+	opts := []eval.Option{eval.WithoutDollarEscape()}
+
+	if cmdutil.IsUnixLikeShell(shell[0]) || cmdutil.IsNixShell(shell[0]) {
+		opts = append(opts, eval.WithoutExpandEnv())
+	}
+
+	return opts
+}


### PR DESCRIPTION
## Summary

- align command-form condition evaluation with shell `command` expansion semantics
- share runtime command eval options between the command executor and condition execution paths
- add regression coverage for home-relative DAG env vars in preconditions and repeat-policy conditions

## Root Cause

Command-form conditions were evaluated with `eval.OnlyReplaceVars()`, which deferred scoped variables to the shell. That diverged from shell `command:` steps, where Dagu expands the command text before execution. Values like `~/...` therefore worked in shell commands but failed in conditions because tilde expansion does not happen after shell parameter expansion.

## Testing

- `go test ./internal/runtime -run "TestEvalConditions|TestRunner_DAGPreconditions|TestRunner_RepeatPolicy" -count=1`
- `go test ./internal/intg -run "TestPreconditionWithDAGEnvVars|TestDAGLevelPreconditionWithEnvVars|TestPreconditionWithHomeRelativeDAGEnvVar|TestRepeatPolicy" -count=1`
- `go test ./internal/runtime/builtin/command -run TestCommandExecutor_GetEvalOptions -count=1`

Closes #2057


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAPI schema documentation for condition execution semantics, clarifying behavior when the `expected` parameter is omitted versus specified.

* **Tests**
  * Added integration tests for condition evaluation with environment variable expansion and repeat policy.
  * Enhanced unit tests with improved capability registration lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->