### PR TITLE
fix(config): whitelist XDG_STATE_HOME (#2056)

### DIFF
--- a/internal/cmn/config/env_test.go
+++ b/internal/cmn/config/env_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestLoadBaseEnv(t *testing.T) {
 	windowsExpected := runtime.GOOS == "windows"
+	unixExpected := runtime.GOOS != "windows"
 
 	testCases := []struct {
 		name     string
@@ -21,6 +22,12 @@ func TestLoadBaseEnv(t *testing.T) {
 	}{
 		{"TEST_VAR_BASE_ENV", false},
 		{"DAGU_TEST_BASE_ENV", true},
+
+		// XDG base-dir variables should pass through on Unix/macOS only.
+		{"XDG_CONFIG_HOME", unixExpected},
+		{"XDG_DATA_HOME", unixExpected},
+		{"XDG_CACHE_HOME", unixExpected},
+		{"XDG_STATE_HOME", unixExpected},
 
 		// Windows-specific user profile and install roots should only pass
 		// through on Windows builds.

--- a/internal/cmn/config/env_unix.go
+++ b/internal/cmn/config/env_unix.go
@@ -36,6 +36,7 @@ func init() {
 		"XDG_CONFIG_HOME", // User config (usually ~/.config)
 		"XDG_DATA_HOME",   // User data (usually ~/.local/share)
 		"XDG_CACHE_HOME",  // User cache (usually ~/.cache)
+		"XDG_STATE_HOME",  // User state (usually ~/.local/state)
 
 		// Docker daemon connection (used by Docker SDK's client.FromEnv)
 		"DOCKER_HOST",        // Docker daemon address


### PR DESCRIPTION
## Summary
- add `XDG_STATE_HOME` to the default Unix base env allow list
- extend the base env regression test to cover the XDG variables explicitly

## Why
The Unix allow list already forwards the XDG config, data, and cache directories by default, but it omitted `XDG_STATE_HOME`. That broke tools that rely on the standard XDG state location during step execution.

## Testing
- `make lint`
- `go test ./internal/cmn/config -count=1`

Closes #2056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced XDG base-directory support on Unix/macOS platforms with recognition of the state directory configuration variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
