### PR TITLE
fix: align precondition env with step execution

### DIFF
--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -129,7 +129,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.Len(t, status.Nodes, 2)
@@ -226,7 +226,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -42,6 +42,20 @@ func executionStatusTimeout() time.Duration {
 	}
 }
 
+func artifactExecutionStatusTimeout() time.Duration {
+	switch {
+	case runtime.GOOS == "windows" && raceEnabled():
+		return 60 * time.Second
+	case runtime.GOOS == "windows":
+		// Shared-nothing artifact persistence has to archive worker output and
+		// stream it back to the coordinator, which is materially slower on the
+		// GitHub-hosted Windows runners than ordinary distributed execution.
+		return 45 * time.Second
+	default:
+		return 20 * time.Second
+	}
+}
+
 func artifactStepShellYAML() string {
 	if runtime.GOOS == "windows" {
 		return "    shell: powershell\n"
@@ -115,7 +129,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.Len(t, status.Nodes, 2)
@@ -239,7 +253,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Failed, executionStatusTimeout())
+		status := f.waitForStatus(core.Failed, artifactExecutionStatusTimeout())
 
 		require.Equal(t, core.Failed, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -266,7 +280,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -296,7 +310,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
 
 		require.Equal(t, core.Succeeded, status.Status)
 		require.NotEmpty(t, status.ArchiveDir)
@@ -323,7 +337,7 @@ steps:
 		f.waitForQueued()
 		f.startScheduler(30 * time.Second)
 
-		status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+		status := f.waitForStatus(core.Succeeded, artifactExecutionStatusTimeout())
 		require.Equal(t, core.Succeeded, status.Status)
 
 		stream, err := f.coordinatorClient.StreamArtifacts(f.coord.Context)

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -434,44 +434,12 @@ func (r *Runner) runNodeExecution(ctx context.Context, plan *Plan, node *Node, p
 	}
 
 	ctx = spanCtx
+	ctx = r.setupNodeExecutionEnv(ctx, node)
 
 	// Check preconditions
 	logger.Debug(ctx, "Checking preconditions")
 	if !meetsPreconditions(ctx, node, progressCh) {
 		return
-	}
-
-	ctx = node.SetupEnv(ctx)
-
-	// Inject push-back inputs as environment variables for any step being
-	// re-executed within the rewound scope.
-	if node.State().ApprovalIteration > 0 {
-		state := node.State()
-		env := GetEnv(ctx)
-		approval := node.Step().Approval
-		var allowedInputs []string
-		if approval != nil {
-			allowedInputs = approval.Input
-		}
-		filteredInputs := exec.FilterPushBackInputs(allowedInputs, state.PushBackInputs)
-		for k, v := range filteredInputs {
-			env = env.WithEnvVars(k, v)
-		}
-		if approval != nil && len(filteredInputs) != len(state.PushBackInputs) {
-			for k := range state.PushBackInputs {
-				if _, ok := filteredInputs[k]; ok {
-					continue
-				}
-				logger.Warn(ctx, "Ignoring unexpected push-back input", slog.String("input", k))
-			}
-		}
-		payload, err := marshalPushBackPayload(allowedInputs, state)
-		if err != nil {
-			logger.Warn(ctx, "Failed to marshal push-back payload", tag.Error(err))
-		} else if payload != "" {
-			env = env.WithEnvVars(exec.EnvKeyDAGPushBack, payload)
-		}
-		ctx = WithEnv(ctx, env)
 	}
 
 	// Setup chat messages from dependencies before execution
@@ -547,6 +515,45 @@ ExecRepeat: // repeat execution
 	if progressCh != nil {
 		progressCh <- node
 	}
+}
+
+func (r *Runner) setupNodeExecutionEnv(ctx context.Context, node *Node) context.Context {
+	ctx = node.SetupEnv(ctx)
+
+	if node.State().ApprovalIteration == 0 {
+		return ctx
+	}
+
+	state := node.State()
+	env := GetEnv(ctx)
+	approval := node.Step().Approval
+	var allowedInputs []string
+	if approval != nil {
+		allowedInputs = approval.Input
+	}
+
+	filteredInputs := exec.FilterPushBackInputs(allowedInputs, state.PushBackInputs)
+	for k, v := range filteredInputs {
+		env = env.WithEnvVars(k, v)
+	}
+
+	if approval != nil && len(filteredInputs) != len(state.PushBackInputs) {
+		for k := range state.PushBackInputs {
+			if _, ok := filteredInputs[k]; ok {
+				continue
+			}
+			logger.Warn(ctx, "Ignoring unexpected push-back input", slog.String("input", k))
+		}
+	}
+
+	payload, err := marshalPushBackPayload(allowedInputs, state)
+	if err != nil {
+		logger.Warn(ctx, "Failed to marshal push-back payload", tag.Error(err))
+	} else if payload != "" {
+		env = env.WithEnvVars(exec.EnvKeyDAGPushBack, payload)
+	}
+
+	return WithEnv(ctx, env)
 }
 
 func (r *Runner) setLastError(err error) {

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -517,6 +517,9 @@ ExecRepeat: // repeat execution
 	}
 }
 
+// setupNodeExecutionEnv prepares the runtime-managed step env before
+// preconditions and command execution so both paths evaluate against the same
+// context.
 func (r *Runner) setupNodeExecutionEnv(ctx context.Context, node *Node) context.Context {
 	ctx = node.SetupEnv(ctx)
 

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -834,6 +834,11 @@ func TestRunner(t *testing.T) {
 	})
 	t.Run("PreconditionUsesSameRuntimeManagedStepEnvAsCommand", func(t *testing.T) {
 		t.Parallel()
+
+		if windowsShellTest() {
+			t.Skip("Skipping Unix-specific env assertion on Windows")
+		}
+
 		r := setupRunner(t)
 
 		plan := r.newPlan(t,
@@ -3788,6 +3793,8 @@ func TestPushBackInputsExposeJSONHistoryEnvForRewoundStep(t *testing.T) {
 	assert.Equal(t, "2026-04-26T06:20:00Z", second["at"])
 }
 
+// TestPushBackPreconditionUsesSameEnvAsCommand verifies that rewound steps
+// evaluate preconditions with the same push-back env seen by the step command.
 func TestPushBackPreconditionUsesSameEnvAsCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -832,6 +832,25 @@ func TestRunner(t *testing.T) {
 		result.assertNodeStatus(t, "2", core.NodeSucceeded)
 		result.assertNodeStatus(t, "3", core.NodeSucceeded)
 	})
+	t.Run("PreconditionUsesSameRuntimeManagedStepEnvAsCommand", func(t *testing.T) {
+		t.Parallel()
+		r := setupRunner(t)
+
+		plan := r.newPlan(t,
+			newStep("1",
+				withCommand(`printf '%s' "$DAG_RUN_STEP_STDOUT_FILE"`),
+				withOutput("RESULT"),
+				withPrecondition(&core.Condition{
+					Condition: `test -n "$DAG_RUN_STEP_STDOUT_FILE"`,
+				}),
+			),
+		)
+
+		result := plan.assertRun(t, core.Succeeded)
+
+		result.assertNodeStatus(t, "1", core.NodeSucceeded)
+		assert.Equal(t, result.nodeByName(t, "1").GetStdout(), result.nodeByName(t, "1").OutputVariablesMap()["RESULT"])
+	})
 	t.Run("PreconditionWithCommandNotMet", func(t *testing.T) {
 		r := setupRunner(t)
 
@@ -3767,6 +3786,36 @@ func TestPushBackInputsExposeJSONHistoryEnvForRewoundStep(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "reviewer-b", second["by"])
 	assert.Equal(t, "2026-04-26T06:20:00Z", second["at"])
+}
+
+func TestPushBackPreconditionUsesSameEnvAsCommand(t *testing.T) {
+	t.Parallel()
+
+	if windowsShellTest() {
+		t.Skip("Skipping Unix-specific env assertion on Windows")
+	}
+
+	r := setupRunner(t)
+	step := newStep("prepare",
+		withScript(`printf '%s' "$FEEDBACK"`),
+		withPrecondition(&core.Condition{
+			Condition: `test -n "$FEEDBACK"`,
+		}),
+	)
+
+	plan := r.newPlan(t, step)
+	node := plan.GetNodeByName("prepare")
+	require.NotNil(t, node)
+
+	node.SetApprovalIteration(1)
+	node.SetPushBackInputs(map[string]string{"FEEDBACK": "rerun from review"})
+
+	result := plan.assertRun(t, core.Succeeded)
+	result.assertNodeStatus(t, "prepare", core.NodeSucceeded)
+
+	output, err := os.ReadFile(result.nodeByName(t, "prepare").GetStdout())
+	require.NoError(t, err)
+	assert.Equal(t, "rerun from review", strings.TrimSpace(string(output)))
 }
 
 func TestWaitStep(t *testing.T) {


### PR DESCRIPTION
## Summary
- move runtime step env setup ahead of precondition evaluation
- reuse the same setup path for push-back env injection so preconditions see the same inputs as the step command
- add regressions for runtime-managed step env and push-back env parity

## Testing
- go test ./internal/runtime -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Precondition checks now consistently observe the same runtime-managed environment variables and injected push-back inputs as the commands they guard, preventing mismatches and unexpected failures.

* **Refactor**
  * Consolidated environment setup to ensure consistent behavior across normal and rewound (push-back) executions.

* **Tests**
  * Added tests verifying preconditions access the correct environment during step and push-back runs.
  * Increased artifact execution test timeouts for platform and persistence variability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->