### PR TITLE
fix: require DAG definition for enqueue

### DIFF
--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Enqueue returns the cobra command for queueing a DAG-run.
 func Enqueue() *cobra.Command {
 	return NewCommand(
 		&cobra.Command{

--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -29,6 +29,7 @@ Examples:
 	dagu enqueue --run-id=run_id my_dag -- P1=foo P2=bar
 	dagu enqueue --name my_custom_name my_dag.yaml -- P1=foo P2=bar
 `,
+			Args: cobra.MinimumNArgs(1),
 		}, enqueueFlags, runEnqueue,
 	)
 }

--- a/internal/cmd/enqueue_test.go
+++ b/internal/cmd/enqueue_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmd"
 	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnqueueCommand(t *testing.T) {
@@ -57,4 +58,16 @@ steps:
 			th.RunCommand(t, cmd.Enqueue(), tc)
 		})
 	}
+}
+
+func TestEnqueueCommand_RequiresDAGDefinition(t *testing.T) {
+	t.Parallel()
+
+	th := test.SetupCommand(t)
+
+	err := th.RunCommandWithError(t, cmd.Enqueue(), test.CmdTest{
+		Args: []string{"enqueue"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires at least 1 arg")
 }


### PR DESCRIPTION
## Summary
- require a DAG definition argument before running `dagu enqueue`
- return Cobra's normal missing-argument error instead of panicking in DAG loading
- add a regression test for invoking `enqueue` without a DAG file

## Testing
- go test ./internal/cmd -count=1

Closes #2082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The enqueue command now enforces stricter input validation, requiring users to provide a DAG definition argument at command invocation to prevent invalid command usage.

* **Tests**
  * Added test coverage to verify the enqueue command properly validates and enforces that required arguments are supplied before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->