### PR TITLE
fix: allow multiple history status filters

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -367,7 +367,7 @@ var (
 
 	historyStatusFlag = commandLineFlag{
 		name:  "status",
-		usage: "Filter by execution status (running, succeeded, failed, aborted, queued, waiting, rejected, not_started, partially_succeeded)",
+		usage: "Filter by execution status; accepts a single value or comma-separated values (running, succeeded, failed, aborted, queued, waiting, rejected, not_started, partially_succeeded)",
 	}
 
 	historyRunIDFlag = commandLineFlag{

--- a/internal/cmd/history.go
+++ b/internal/cmd/history.go
@@ -34,7 +34,8 @@ Date/Time Filtering:
                     Note: --last cannot be combined with --from or --to
 
 Status Filtering:
-  --status          Filter by execution status (running, succeeded, failed, aborted, skipped, waiting, none)
+  --status          Filter by execution status. Accepts a single status or comma-separated statuses
+                    (running, succeeded, failed, aborted, queued, waiting, rejected, not_started, partially_succeeded)
 
 Other Filters:
   --labels          Filter by DAG labels (comma-separated, AND logic)
@@ -55,6 +56,7 @@ Examples:
   dagu history --from 2026-01-01              # Runs since date
   dagu history --last 7d                      # Last 7 days
   dagu history --status failed                # Only failed runs
+  dagu history --status running,queued        # Running or queued runs
   dagu history --format json                  # JSON output
   dagu history --labels "prod,critical"       # Filter by labels (AND logic)
   dagu history --limit 50                     # Limit to 50 results
@@ -260,12 +262,12 @@ func buildStatusOption(ctx *Context) (exec.ListDAGRunStatusesOption, error) {
 		return nil, nil
 	}
 
-	status, err := parseStatus(statusStr)
+	statuses, err := parseStatuses(statusStr)
 	if err != nil {
 		return nil, err
 	}
 
-	return exec.WithStatuses([]core.Status{status}), nil
+	return exec.WithStatuses(statuses), nil
 }
 
 // buildRunIDOption constructs run ID filtering option.
@@ -412,6 +414,27 @@ func parseStatus(s string) (core.Status, error) {
 	}
 
 	return core.NotStarted, fmt.Errorf("invalid status '%s'. Valid values: running, succeeded, failed, aborted, queued, waiting, rejected, not_started, partially_succeeded", s)
+}
+
+// parseStatuses converts a comma-separated status string to core.Status values.
+func parseStatuses(s string) ([]core.Status, error) {
+	parts := strings.Split(s, ",")
+	statuses := make([]core.Status, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		status, err := parseStatus(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, status)
+	}
+	if len(statuses) == 0 {
+		return nil, fmt.Errorf("invalid status '%s'. Valid values: running, succeeded, failed, aborted, queued, waiting, rejected, not_started, partially_succeeded", s)
+	}
+	return statuses, nil
 }
 
 // parseLabels splits comma-separated labels and trims whitespace.

--- a/internal/cmd/history_test.go
+++ b/internal/cmd/history_test.go
@@ -308,6 +308,59 @@ func TestParseStatus(t *testing.T) {
 	}
 }
 
+func TestParseStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []core.Status
+		wantErr  bool
+	}{
+		{
+			name:     "comma-separated statuses",
+			input:    "running,queued",
+			expected: []core.Status{core.Running, core.Queued},
+		},
+		{
+			name:     "trims spaces",
+			input:    " running, succeeded ",
+			expected: []core.Status{core.Running, core.Succeeded},
+		},
+		{
+			name:     "ignores empty entries",
+			input:    "running,,queued,",
+			expected: []core.Status{core.Running, core.Queued},
+		},
+		{
+			name:    "rejects empty list",
+			input:   ",,",
+			wantErr: true,
+		},
+		{
+			name:    "rejects mixed invalid status",
+			input:   "running,unknown",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseStatuses(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid status")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestParseLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/remote_client.go
+++ b/internal/cmd/remote_client.go
@@ -159,25 +159,23 @@ func (c *remoteClient) enqueueDAG(ctx context.Context, fileName string, body api
 }
 
 func (c *remoteClient) listDAGRuns(ctx context.Context, query remoteHistoryQuery) ([]api.DAGRunSummary, error) {
-	params := map[string]string{}
+	params := url.Values{}
 	if query.From != nil {
-		params["fromDate"] = fmt.Sprintf("%d", *query.From)
+		params.Set("fromDate", fmt.Sprintf("%d", *query.From))
 	}
 	if query.To != nil {
-		params["toDate"] = fmt.Sprintf("%d", *query.To)
+		params.Set("toDate", fmt.Sprintf("%d", *query.To))
 	}
 	if len(query.Statuses) > 0 {
-		values := make([]string, 0, len(query.Statuses))
 		for _, status := range query.Statuses {
-			values = append(values, fmt.Sprintf("%d", status))
+			params.Add("status", fmt.Sprintf("%d", status))
 		}
-		params["status"] = strings.Join(values, ",")
 	}
 	if query.RunID != "" {
-		params["dagRunId"] = query.RunID
+		params.Set("dagRunId", query.RunID)
 	}
 	if len(query.Labels) > 0 {
-		params["labels"] = strings.Join(query.Labels, ",")
+		params.Set("labels", strings.Join(query.Labels, ","))
 	}
 
 	var out struct {
@@ -187,7 +185,7 @@ func (c *remoteClient) listDAGRuns(ctx context.Context, query remoteHistoryQuery
 	if query.Name != "" {
 		path = "/dag-runs/" + url.PathEscape(query.Name)
 	}
-	if err := c.do(ctx, http.MethodGet, path, nil, &out, params); err != nil {
+	if err := c.doWithQueryValues(ctx, http.MethodGet, path, nil, &out, params); err != nil {
 		return nil, err
 	}
 	return out.DagRuns, nil
@@ -245,15 +243,19 @@ func dagRunPath(name, dagRunID string) string {
 }
 
 func (c *remoteClient) do(ctx context.Context, method, path string, body any, out any, query map[string]string) error {
+	values := url.Values{}
+	for key, value := range query {
+		if value != "" {
+			values.Set(key, value)
+		}
+	}
+	return c.doWithQueryValues(ctx, method, path, body, out, values)
+}
+
+func (c *remoteClient) doWithQueryValues(ctx context.Context, method, path string, body any, out any, query url.Values) error {
 	fullURL := c.baseURL + path
 	if len(query) > 0 {
-		values := url.Values{}
-		for key, value := range query {
-			if value != "" {
-				values.Set(key, value)
-			}
-		}
-		if encoded := values.Encode(); encoded != "" {
+		if encoded := query.Encode(); encoded != "" {
 			fullURL += "?" + encoded
 		}
 	}

--- a/internal/cmd/remote_client.go
+++ b/internal/cmd/remote_client.go
@@ -46,12 +46,12 @@ func (e *remoteError) NotFound() bool {
 }
 
 type remoteHistoryQuery struct {
-	Name   string
-	From   *int64
-	To     *int64
-	Status *int
-	RunID  string
-	Labels []string
+	Name     string
+	From     *int64
+	To       *int64
+	Statuses []int
+	RunID    string
+	Labels   []string
 }
 
 func newRemoteClient(ctx *clicontext.Context) (*remoteClient, error) {
@@ -166,8 +166,12 @@ func (c *remoteClient) listDAGRuns(ctx context.Context, query remoteHistoryQuery
 	if query.To != nil {
 		params["toDate"] = fmt.Sprintf("%d", *query.To)
 	}
-	if query.Status != nil {
-		params["status"] = fmt.Sprintf("%d", *query.Status)
+	if len(query.Statuses) > 0 {
+		values := make([]string, 0, len(query.Statuses))
+		for _, status := range query.Statuses {
+			values = append(values, fmt.Sprintf("%d", status))
+		}
+		params["status"] = strings.Join(values, ",")
 	}
 	if query.RunID != "" {
 		params["dagRunId"] = query.RunID

--- a/internal/cmd/remote_commands.go
+++ b/internal/cmd/remote_commands.go
@@ -483,11 +483,11 @@ func buildRemoteHistoryQuery(ctx *Context, args []string) (remoteHistoryQuery, i
 	}
 	statusValue, _ := ctx.StringParam("status")
 	if statusValue != "" {
-		s, err := remoteStatusValue(statusValue)
+		statuses, err := remoteStatusValues(statusValue)
 		if err != nil {
 			return query, 0, err
 		}
-		query.Status = &s
+		query.Statuses = statuses
 	}
 	runID, _ := ctx.StringParam("run-id")
 	query.RunID = runID
@@ -511,24 +511,35 @@ func buildRemoteHistoryQuery(ctx *Context, args []string) (remoteHistoryQuery, i
 }
 
 func remoteStatusValue(s string) (int, error) {
-	switch s {
-	case "running":
-		return int(core.Running), nil
-	case "succeeded":
-		return int(core.Succeeded), nil
-	case "failed":
-		return int(core.Failed), nil
-	case "aborted":
-		return int(core.Aborted), nil
-	case "queued":
-		return int(core.Queued), nil
-	case "waiting":
-		return int(core.Waiting), nil
-	case "none":
+	if strings.EqualFold(strings.TrimSpace(s), "none") {
 		return 0, fmt.Errorf("status %q is not supported in remote history", s)
-	default:
-		return 0, fmt.Errorf("invalid status %q", s)
 	}
+
+	status, err := parseStatus(s)
+	if err != nil {
+		return 0, err
+	}
+	return int(status), nil
+}
+
+func remoteStatusValues(s string) ([]int, error) {
+	parts := strings.Split(s, ",")
+	statuses := make([]int, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		status, err := remoteStatusValue(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, status)
+	}
+	if len(statuses) == 0 {
+		return nil, fmt.Errorf("invalid status %q", s)
+	}
+	return statuses, nil
 }
 
 func waitForRemoteStop(ctx *Context, name, dagRunID string) error {

--- a/internal/cmd/remote_commands_test.go
+++ b/internal/cmd/remote_commands_test.go
@@ -88,6 +88,21 @@ func TestBuildRemoteHistoryQueryRejectsMalformedLimit(t *testing.T) {
 	assert.Contains(t, err.Error(), "greater than 0")
 }
 
+func TestBuildRemoteHistoryQueryParsesMultipleStatuses(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "history"}
+	initFlags(command, historyFlags...)
+	require.NoError(t, command.Flags().Set("status", "running,queued"))
+
+	ctx := &Context{Command: command}
+	query, limit, err := buildRemoteHistoryQuery(ctx, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, limit)
+	assert.Equal(t, []int{int(core.Running), int(core.Queued)}, query.Statuses)
+}
+
 func TestWaitForRemoteStopHonorsContextCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/remote_commands_test.go
+++ b/internal/cmd/remote_commands_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -101,6 +102,29 @@ func TestBuildRemoteHistoryQueryParsesMultipleStatuses(t *testing.T) {
 
 	assert.Equal(t, 100, limit)
 	assert.Equal(t, []int{int(core.Running), int(core.Queued)}, query.Statuses)
+}
+
+func TestRemoteClientListDAGRunsUsesRepeatedStatusParams(t *testing.T) {
+	t.Parallel()
+
+	statusValues := make(chan []string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		statusValues <- append([]string(nil), r.URL.Query()["status"]...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"dagRuns":[]}`))
+	}))
+	defer server.Close()
+
+	client := &remoteClient{
+		baseURL: server.URL,
+		client:  server.Client(),
+	}
+
+	_, err := client.listDAGRuns(context.Background(), remoteHistoryQuery{
+		Statuses: []int{int(core.Running), int(core.Queued)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "5"}, <-statusValues)
 }
 
 func TestWaitForRemoteStopHonorsContextCancellation(t *testing.T) {

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -1747,74 +1747,96 @@ func TestRunner_DryRunWithHandlers(t *testing.T) {
 }
 
 func TestRunner_ConcurrentExecution(t *testing.T) {
-	steps := func() []core.Step {
-		sleep := test.Sleep(300 * time.Millisecond)
+	sequentialGuardScript := func(name, lockDir string) string {
+		if windowsShellTest() {
+			return fmt.Sprintf(`
+				$lockDir = %s
+				if (-not (New-Item -ItemType Directory -Path $lockDir -ErrorAction SilentlyContinue)) {
+					Write-Error "sequential step %s overlapped another active step"
+					exit 1
+				}
+				try {
+					%s
+				} finally {
+					Remove-Item -LiteralPath $lockDir -Force
+				}
+			`, test.PowerShellQuote(shellTestPath(lockDir)), name, test.Sleep(platformTestDuration(300*time.Millisecond, 600*time.Millisecond)))
+		}
+
+		return fmt.Sprintf(`
+			lock_dir=%s
+			if ! mkdir "$lock_dir"; then
+				echo "sequential step %s overlapped another active step" >&2
+				exit 1
+			fi
+			trap 'rmdir "$lock_dir"' EXIT
+			%s
+		`, test.PosixQuote(lockDir), name, test.Sleep(300*time.Millisecond))
+	}
+
+	concurrentBarrierScript := func(name, readyDir string, readyCount int, timeout time.Duration) string {
+		if windowsShellTest() {
+			return fmt.Sprintf(`
+				$readyDir = %s
+				New-Item -ItemType Directory -Path $readyDir -Force | Out-Null
+				New-Item -ItemType File -Path (Join-Path $readyDir %s) -Force | Out-Null
+				$deadline = (Get-Date).AddSeconds(%d)
+				while (@(Get-ChildItem -LiteralPath $readyDir -File).Count -lt %d) {
+					if ((Get-Date) -ge $deadline) {
+						Write-Error "concurrent step %s did not observe all active steps"
+						exit 1
+					}
+					Start-Sleep -Milliseconds 50
+				}
+			`, test.PowerShellQuote(shellTestPath(readyDir)), test.PowerShellQuote(name), int(timeout/time.Second), readyCount, name)
+		}
+
+		return fmt.Sprintf(`
+			ready_dir=%s
+			mkdir -p "$ready_dir"
+			: > "$ready_dir/%s"
+			deadline=$(( $(date +%%s) + %d ))
+			while true; do
+				ready_count=$(find "$ready_dir" -type f | wc -l | tr -d '[:space:]')
+				if [ "$ready_count" -ge %d ]; then
+					break
+				fi
+				if [ "$(date +%%s)" -ge "$deadline" ]; then
+					echo "concurrent step %s did not observe all active steps" >&2
+					exit 1
+				fi
+				sleep 0.05
+			done
+		`, test.PosixQuote(readyDir), name, int(timeout/time.Second), readyCount, name)
+	}
+
+	steps := func(script func(string) string) []core.Step {
 		return []core.Step{
-			newStep("1", withScript(sleep)),
-			newStep("2", withScript(sleep)),
-			newStep("3", withScript(sleep)),
+			newStep("1", withScript(script("1"))),
+			newStep("2", withScript(script("2"))),
+			newStep("3", withScript(script("3"))),
 		}
 	}
 
-	type nodeInterval struct {
-		name     string
-		started  time.Time
-		finished time.Time
-	}
-	intervals := func(result runResult) []nodeInterval {
-		names := []string{"1", "2", "3"}
-		ret := make([]nodeInterval, 0, len(names))
-		for _, name := range names {
-			state := result.nodeByName(t, name).State()
-			require.False(t, state.StartedAt.IsZero(), "step %s should record a start time", name)
-			require.False(t, state.FinishedAt.IsZero(), "step %s should record a finish time", name)
-			require.False(t, state.FinishedAt.Before(state.StartedAt), "step %s should finish after it starts", name)
-			ret = append(ret, nodeInterval{
-				name:     name,
-				started:  state.StartedAt,
-				finished: state.FinishedAt,
-			})
-		}
-		return ret
-	}
-	overlaps := func(a, b nodeInterval) bool {
-		return a.started.Before(b.finished) && b.started.Before(a.finished)
-	}
-
+	lockDir := filepath.Join(t.TempDir(), "active-step")
 	sequential := setupRunner(t, withMaxActiveRuns(1))
-	planSequential := sequential.newPlan(t, steps()...)
+	planSequential := sequential.newPlan(t, steps(func(name string) string {
+		return sequentialGuardScript(name, lockDir)
+	})...)
 	resultSequential := planSequential.assertRun(t, core.Succeeded)
 	resultSequential.assertNodeStatus(t, "1", core.NodeSucceeded)
 	resultSequential.assertNodeStatus(t, "2", core.NodeSucceeded)
 	resultSequential.assertNodeStatus(t, "3", core.NodeSucceeded)
-	sequentialIntervals := intervals(resultSequential)
-	for i := range sequentialIntervals {
-		for j := i + 1; j < len(sequentialIntervals); j++ {
-			assert.False(t, overlaps(sequentialIntervals[i], sequentialIntervals[j]),
-				"sequential steps %s and %s should not overlap",
-				sequentialIntervals[i].name, sequentialIntervals[j].name)
-		}
-	}
 
+	readyDir := filepath.Join(t.TempDir(), "ready")
 	concurrent := setupRunner(t, withMaxActiveRuns(3))
-	planConcurrent := concurrent.newPlan(t, steps()...)
+	planConcurrent := concurrent.newPlan(t, steps(func(name string) string {
+		return concurrentBarrierScript(name, readyDir, 3, platformTestDuration(10*time.Second, 30*time.Second))
+	})...)
 	resultConcurrent := planConcurrent.assertRun(t, core.Succeeded)
 	resultConcurrent.assertNodeStatus(t, "1", core.NodeSucceeded)
 	resultConcurrent.assertNodeStatus(t, "2", core.NodeSucceeded)
 	resultConcurrent.assertNodeStatus(t, "3", core.NodeSucceeded)
-	concurrentIntervals := intervals(resultConcurrent)
-	firstFinishedAt := concurrentIntervals[0].finished
-	for _, interval := range concurrentIntervals[1:] {
-		if interval.finished.Before(firstFinishedAt) {
-			firstFinishedAt = interval.finished
-		}
-	}
-
-	for _, interval := range concurrentIntervals {
-		assert.False(t, interval.started.After(firstFinishedAt),
-			"concurrent step %s should start before the first concurrent step finishes",
-			interval.name)
-	}
 }
 
 func TestRunner_ErrorHandling(t *testing.T) {

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -1748,33 +1748,73 @@ func TestRunner_DryRunWithHandlers(t *testing.T) {
 
 func TestRunner_ConcurrentExecution(t *testing.T) {
 	steps := func() []core.Step {
+		sleep := test.Sleep(300 * time.Millisecond)
 		return []core.Step{
-			newStep("1", withScript("sleep 0.3")),
-			newStep("2", withScript("sleep 0.3")),
-			newStep("3", withScript("sleep 0.3")),
+			newStep("1", withScript(sleep)),
+			newStep("2", withScript(sleep)),
+			newStep("3", withScript(sleep)),
 		}
+	}
+
+	type nodeInterval struct {
+		name     string
+		started  time.Time
+		finished time.Time
+	}
+	intervals := func(result runResult) []nodeInterval {
+		names := []string{"1", "2", "3"}
+		ret := make([]nodeInterval, 0, len(names))
+		for _, name := range names {
+			state := result.nodeByName(t, name).State()
+			require.False(t, state.StartedAt.IsZero(), "step %s should record a start time", name)
+			require.False(t, state.FinishedAt.IsZero(), "step %s should record a finish time", name)
+			require.False(t, state.FinishedAt.Before(state.StartedAt), "step %s should finish after it starts", name)
+			ret = append(ret, nodeInterval{
+				name:     name,
+				started:  state.StartedAt,
+				finished: state.FinishedAt,
+			})
+		}
+		return ret
+	}
+	overlaps := func(a, b nodeInterval) bool {
+		return a.started.Before(b.finished) && b.started.Before(a.finished)
 	}
 
 	sequential := setupRunner(t, withMaxActiveRuns(1))
 	planSequential := sequential.newPlan(t, steps()...)
-	startSequential := time.Now()
 	resultSequential := planSequential.assertRun(t, core.Succeeded)
-	elapsedSequential := time.Since(startSequential)
 	resultSequential.assertNodeStatus(t, "1", core.NodeSucceeded)
 	resultSequential.assertNodeStatus(t, "2", core.NodeSucceeded)
 	resultSequential.assertNodeStatus(t, "3", core.NodeSucceeded)
+	sequentialIntervals := intervals(resultSequential)
+	for i := range sequentialIntervals {
+		for j := i + 1; j < len(sequentialIntervals); j++ {
+			assert.False(t, overlaps(sequentialIntervals[i], sequentialIntervals[j]),
+				"sequential steps %s and %s should not overlap",
+				sequentialIntervals[i].name, sequentialIntervals[j].name)
+		}
+	}
 
 	concurrent := setupRunner(t, withMaxActiveRuns(3))
 	planConcurrent := concurrent.newPlan(t, steps()...)
-	startConcurrent := time.Now()
 	resultConcurrent := planConcurrent.assertRun(t, core.Succeeded)
-	elapsedConcurrent := time.Since(startConcurrent)
 	resultConcurrent.assertNodeStatus(t, "1", core.NodeSucceeded)
 	resultConcurrent.assertNodeStatus(t, "2", core.NodeSucceeded)
 	resultConcurrent.assertNodeStatus(t, "3", core.NodeSucceeded)
+	concurrentIntervals := intervals(resultConcurrent)
+	firstFinishedAt := concurrentIntervals[0].finished
+	for _, interval := range concurrentIntervals[1:] {
+		if interval.finished.Before(firstFinishedAt) {
+			firstFinishedAt = interval.finished
+		}
+	}
 
-	assert.Greater(t, elapsedSequential, elapsedConcurrent)
-	assert.Greater(t, elapsedSequential-elapsedConcurrent, 200*time.Millisecond)
+	for _, interval := range concurrentIntervals {
+		assert.False(t, interval.started.After(firstFinishedAt),
+			"concurrent step %s should start before the first concurrent step finishes",
+			interval.name)
+	}
 }
 
 func TestRunner_ErrorHandling(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow `dagu history --status` to accept comma-separated status filters
- propagate multiple status values through remote history queries
- update CLI help and add parser/query coverage

## Testing
- `go test ./internal/cmd/...`
- `go test ./internal/intg -run TestHistoryCommand -count=1`
- `go test ./internal/persis/filedagrun/...`

Closes #2083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The history command’s --status flag now accepts multiple comma-separated statuses for both local and remote queries; remote requests send repeated status parameters.

* **Bug Fixes**
  * Validation tightened: empty, whitespace-only, or invalid statuses are rejected with clear errors; certain unsupported values are rejected for remote queries.

* **Tests**
  * Added tests for multi-status parsing and remote query parameter handling; updated concurrency test to use filesystem-based coordination for robust scheduling checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->