### PR TITLE
fix: sort suspended DAGs after live next runs

### DIFF
--- a/internal/persis/filedag/store.go
+++ b/internal/persis/filedag/store.go
@@ -499,6 +499,10 @@ func (store *Storage) List(ctx context.Context, opts exec.ListDAGsOptions) (exec
 		// Pre-calculate next run times to avoid recalculating on each comparison
 		nextRunTimes := make(map[*core.DAG]time.Time, len(allDags))
 		for _, dag := range allDags {
+			if store.IsSuspended(ctx, dag.FileName()) {
+				nextRunTimes[dag] = time.Time{}
+				continue
+			}
 			nextRunTimes[dag] = projectNextRun(dag, now)
 		}
 

--- a/internal/persis/filedag/store.go
+++ b/internal/persis/filedag/store.go
@@ -143,6 +143,22 @@ func (store *Storage) useIndexedMetadata() bool {
 	return true
 }
 
+func (store *Storage) readSuspendFlags(ctx context.Context) dagindex.SuspendFlags {
+	flags := make(dagindex.SuspendFlags)
+	flagEntries, err := os.ReadDir(store.flagsBaseDir)
+	if err != nil {
+		// Flags directory may not exist yet (e.g., new installations).
+		logger.Debug(ctx, "Could not read flags directory", tag.Dir(store.flagsBaseDir))
+		return flags
+	}
+	for _, fe := range flagEntries {
+		if !fe.IsDir() {
+			flags[fe.Name()] = struct{}{}
+		}
+	}
+	return flags
+}
+
 func (store *Storage) defaultLoadOptions(opts ...spec.LoadOption) []spec.LoadOption {
 	loadOpts := make([]spec.LoadOption, 0, len(opts)+1)
 	if store.baseConfigPath != "" {
@@ -371,18 +387,7 @@ func (store *Storage) loadOrRebuildIndex(ctx context.Context) []*indexv1.DAGInde
 	}
 
 	// Build suspend flags set.
-	flags := make(dagindex.SuspendFlags)
-	flagEntries, err := os.ReadDir(store.flagsBaseDir)
-	if err != nil {
-		// Flags directory may not exist yet (e.g., new installations).
-		logger.Debug(ctx, "Could not read flags directory", tag.Dir(store.flagsBaseDir))
-	} else {
-		for _, fe := range flagEntries {
-			if !fe.IsDir() {
-				flags[fe.Name()] = struct{}{}
-			}
-		}
-	}
+	flags := store.readSuspendFlags(ctx)
 
 	indexPath := filepath.Join(store.baseDir, dagindex.IndexFileName)
 
@@ -497,9 +502,10 @@ func (store *Storage) List(ctx context.Context, opts exec.ListDAGsOptions) (exec
 			}
 		}
 		// Pre-calculate next run times to avoid recalculating on each comparison
+		suspendFlags := store.readSuspendFlags(ctx)
 		nextRunTimes := make(map[*core.DAG]time.Time, len(allDags))
 		for _, dag := range allDags {
-			if store.IsSuspended(ctx, dag.FileName()) {
+			if _, suspended := suspendFlags[fileName(dag.FileName())]; suspended {
 				nextRunTimes[dag] = time.Time{}
 				continue
 			}

--- a/internal/persis/filedag/store_test.go
+++ b/internal/persis/filedag/store_test.go
@@ -1483,6 +1483,42 @@ func TestListWithNextRunSorting(t *testing.T) {
 	assert.Equal(t, "no-schedule", result.Items[2].Name)
 }
 
+func TestListWithNextRunSortingPutsSuspendedDAGsLast(t *testing.T) {
+	tmpDir := fileutil.MustTempDir("test-list-nextrun-suspended")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	store := New(tmpDir, WithSkipExamples(true))
+	ctx := context.Background()
+
+	createDAG := func(name, schedule string) {
+		content := fmt.Sprintf(`name: %s
+schedule: "%s"
+steps:
+  - name: step1
+    command: echo "test"`, name, schedule)
+		require.NoError(t, store.Create(ctx, name, []byte(content)))
+	}
+
+	createDAG("suspended-sooner", "0 2 * * *")
+	createDAG("live-later", "0 3 * * *")
+	require.NoError(t, store.ToggleSuspend(ctx, "suspended-sooner", true))
+
+	fixedTime := time.Date(2024, 1, 15, 1, 30, 0, 0, time.UTC)
+
+	result, _, err := store.List(ctx, exec.ListDAGsOptions{
+		Sort:  "nextRun",
+		Order: "asc",
+		Time:  &fixedTime,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 2)
+
+	assert.Equal(t, "live-later", result.Items[0].Name)
+	assert.Equal(t, "suspended-sooner", result.Items[1].Name)
+}
+
 func TestConcurrentList(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := New(tmpDir, WithSkipExamples(true))


### PR DESCRIPTION
## Summary
- Treat suspended DAG definitions as having no runnable next run when sorting by `nextRun`
- Add a regression test covering a suspended earlier schedule versus a live later schedule

## Root cause
Suspended DAGs still received projected next-run timestamps during server-side DAG listing, so the workflows page could place non-live DAGs ahead of live scheduled DAGs when sorting by next run.

## Tests
- `go test ./internal/persis/filedag -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Next-run sorting now correctly places suspended DAGs at the end of listings instead of treating them as active with projected run times.

* **Tests**
  * Added a test that verifies suspended DAGs are ordered after active DAGs when sorting by next-run time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->