### PR TITLE
fix: preserve dag-run artifact paths in index

### DIFF
--- a/internal/persis/filedagrun/dagrun.go
+++ b/internal/persis/filedagrun/dagrun.go
@@ -76,6 +76,7 @@ type DAGRunSummary struct {
 	AutoRetryMaxInterval time.Duration
 	ProcGroup            string
 	SuspendFlagName      string
+	ArchiveDir           string
 }
 
 // DAGRun represents a dag-run with its associated timestamp and run ID.

--- a/internal/persis/filedagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/filedagrun/dagrunindex/dagrunindex.go
@@ -25,7 +25,7 @@ const (
 	// IndexFileName is the name of the DAG run index file.
 	IndexFileName = ".dagrun.index"
 	// IndexVersion is the current index format version.
-	IndexVersion = 6
+	IndexVersion = 7
 	// MinRunsForIndex is the minimum number of runs needed to create an index.
 	MinRunsForIndex = 10
 
@@ -66,6 +66,7 @@ type Entry struct {
 	AutoRetryMaxInterval time.Duration
 	ProcGroup            string
 	SuspendFlagName      string
+	ArchiveDir           string
 }
 
 // TryLoadForDay attempts to load and validate the index for a day directory.
@@ -159,6 +160,7 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 			AutoRetryMaxInterval: status.AutoRetryMaxInterval,
 			ProcGroup:            status.ProcGroup,
 			SuspendFlagName:      status.SuspendFlagName,
+			ArchiveDir:           status.ArchiveDir,
 		})
 	}
 
@@ -278,6 +280,7 @@ func writeIndex(dayDir string, entries []Entry) error {
 			AutoRetryMaxInterval: int64(e.AutoRetryMaxInterval),
 			ProcGroup:            e.ProcGroup,
 			SuspendFlagName:      e.SuspendFlagName,
+			ArchiveDir:           e.ArchiveDir,
 		})
 	}
 
@@ -323,6 +326,7 @@ func protoToEntries(protoEntries []*indexv1.DAGRunIndexEntry) []Entry {
 			AutoRetryMaxInterval: time.Duration(pe.AutoRetryMaxInterval),
 			ProcGroup:            pe.ProcGroup,
 			SuspendFlagName:      pe.SuspendFlagName,
+			ArchiveDir:           pe.ArchiveDir,
 		}
 	}
 	return entries

--- a/internal/persis/filedagrun/dataroot.go
+++ b/internal/persis/filedagrun/dataroot.go
@@ -856,6 +856,7 @@ func summaryFromIndexEntry(ie dagrunindex.Entry) *DAGRunSummary {
 		AutoRetryMaxInterval: ie.AutoRetryMaxInterval,
 		ProcGroup:            ie.ProcGroup,
 		SuspendFlagName:      ie.SuspendFlagName,
+		ArchiveDir:           ie.ArchiveDir,
 	}
 }
 

--- a/internal/persis/filedagrun/store.go
+++ b/internal/persis/filedagrun/store.go
@@ -192,6 +192,7 @@ func (store *Store) resolveStatus(
 			AutoRetryMaxInterval: s.AutoRetryMaxInterval,
 			ProcGroup:            s.ProcGroup,
 			SuspendFlagName:      s.SuspendFlagName,
+			ArchiveDir:           s.ArchiveDir,
 		}
 	}
 

--- a/internal/persis/filedagrun/store_test.go
+++ b/internal/persis/filedagrun/store_test.go
@@ -995,6 +995,49 @@ func TestListStatuses_WithAllHistoryBypassesDefaultTodayWindow(t *testing.T) {
 }
 
 func TestListStatusesPage(t *testing.T) {
+	t.Run("IndexPathPreservesArchiveDir", func(t *testing.T) {
+		th := setupTestStore(t)
+
+		base := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+		dag := th.DAG("artifact-dag")
+		artifactDir := filepath.Join(th.TmpDir, "artifacts", "artifact-dag", "artifact-run")
+
+		attempt, err := th.Store.CreateAttempt(th.Context, dag.DAG, base, "artifact-run", exec.NewDAGRunAttemptOptions{})
+		require.NoError(t, err)
+		require.NoError(t, attempt.Open(th.Context))
+		defer func() {
+			require.NoError(t, attempt.Close(th.Context))
+		}()
+
+		status := exec.InitialStatus(dag.DAG)
+		status.DAGRunID = "artifact-run"
+		status.Status = core.Succeeded
+		status.ArchiveDir = artifactDir
+		require.NoError(t, attempt.Write(th.Context, status))
+
+		for i := range 9 {
+			th.CreateAttemptWithDAG(t, base.Add(time.Duration(i+1)*time.Second), fmt.Sprintf("filler-run-%d", i), core.Succeeded, dag.DAG)
+		}
+
+		_, err = th.Store.ListStatusesPage(
+			th.Context,
+			exec.WithAllHistory(),
+			exec.WithDAGRunID("artifact-run"),
+			exec.WithLimit(20),
+		)
+		require.NoError(t, err)
+
+		page, err := th.Store.ListStatusesPage(
+			th.Context,
+			exec.WithAllHistory(),
+			exec.WithDAGRunID("artifact-run"),
+			exec.WithLimit(20),
+		)
+		require.NoError(t, err)
+		require.Len(t, page.Items, 1)
+		assert.Equal(t, artifactDir, page.Items[0].ArchiveDir)
+	})
+
 	t.Run("ForwardPaginationHasDeterministicOrderWithoutDuplicates", func(t *testing.T) {
 		th := setupTestStore(t)
 

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/telemetry"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/frontend"
+	"github.com/dagucloud/dagu/internal/service/frontend/api/pathutil"
 	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
 	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/require"
@@ -58,31 +59,24 @@ func SetupServer(t *testing.T, opts ...HelperOption) Server {
 
 	srv := Server{Helper: helper}
 
-	// Use error channel to detect server startup failures
-	errChan := make(chan error, 1)
-	go srv.runServer(t, listener, errChan)
-
-	// Wait for the server to start or fail
-	select {
-	case err := <-errChan:
-		if err != nil {
-			_ = listener.Close() // Clean up listener on failure
-			t.Fatalf("server failed to start: %v", err)
-		}
-		// Server started successfully, wait for it to be ready
-		waitForServerStart(t, fmt.Sprintf("localhost:%d", port))
-	case <-time.After(10 * time.Second):
+	server, err := srv.newFrontendServer(listener)
+	if err != nil {
 		_ = listener.Close()
-		t.Fatal("server failed to start within timeout")
+		t.Fatalf("server failed to initialize: %v", err)
 	}
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(srv.Context)
+	}()
+
+	waitForServerStart(t, srv.healthURL(), serveErr)
 
 	return srv
 }
 
-// runServer starts the HTTP server with the provided listener
-func (srv *Server) runServer(t *testing.T, listener net.Listener, errChan chan<- error) {
-	t.Helper()
-
+// newFrontendServer constructs the HTTP server with the provided listener.
+func (srv *Server) newFrontendServer(listener net.Listener) (*frontend.Server, error) {
 	cc := coordinator.New(srv.ServiceRegistry, coordinator.DefaultConfig())
 
 	collector := telemetry.NewCollector(
@@ -107,15 +101,19 @@ func (srv *Server) runServer(t *testing.T, listener net.Listener, errChan chan<-
 		serverOpts...,
 	)
 	if err != nil {
-		errChan <- fmt.Errorf("failed to create server: %w", err)
-		return
+		return nil, fmt.Errorf("failed to create server: %w", err)
 	}
-	close(errChan) // Signal that server created successfully
-	err = server.Serve(srv.Context)
-	if err != nil {
-		// Log but don't fail - context cancellation is expected
-		t.Logf("server.Serve returned: %v", err)
-	}
+
+	return server, nil
+}
+
+func (srv *Server) healthURL() string {
+	healthPath := pathutil.BuildMountedAPIEndpointPath(
+		srv.Config.Server.BasePath,
+		srv.Config.Server.APIBasePath,
+		"health",
+	)
+	return fmt.Sprintf("http://%s:%d%s", srv.Config.Server.Host, srv.Config.Server.Port, healthPath)
 }
 
 // Client returns an HTTP client for the server
@@ -300,23 +298,40 @@ func (r *Response) Unmarshal(t *testing.T, v any) {
 	require.NoError(t, err, "failed to unmarshal response body")
 }
 
-// waitForServerStart polls the server until it responds or times out
-func waitForServerStart(t *testing.T, addr string) {
+// waitForServerStart polls the health endpoint until the server is ready.
+func waitForServerStart(t *testing.T, url string, serveErr <-chan error) {
 	t.Helper()
 
-	const (
-		maxRetries = 10
-		retryDelay = 100 * time.Millisecond
-	)
+	const retryDelay = 100 * time.Millisecond
 
-	for range maxRetries {
-		conn, err := net.Dial("tcp", addr)
-		if err == nil {
-			_ = conn.Close()
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(10 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-serveErr:
+			if err != nil {
+				t.Fatalf("server failed before health endpoint became ready: %v", err)
+			}
+			t.Fatal("server stopped before health endpoint became ready")
+		default:
+		}
+
+		resp, err := client.Get(url)
+		switch {
+		case err == nil && resp != nil && resp.StatusCode == http.StatusOK:
+			_ = resp.Body.Close()
 			return
+		case resp != nil:
+			statusCode := resp.StatusCode
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("unexpected status %d", statusCode)
+		default:
+			lastErr = err
 		}
 		time.Sleep(retryDelay)
 	}
 
-	t.Fatalf("server failed to start within %v", maxRetries*retryDelay)
+	t.Fatalf("server health endpoint did not become ready within 10s: %v", lastErr)
 }

--- a/proto/index/v1/index.pb.go
+++ b/proto/index/v1/index.pb.go
@@ -293,6 +293,7 @@ type DAGRunIndexEntry struct {
 	AutoRetryMaxInterval int64                  `protobuf:"varint,25,opt,name=auto_retry_max_interval,json=autoRetryMaxInterval,proto3" json:"auto_retry_max_interval,omitempty"` // Duration in nanoseconds
 	ProcGroup            string                 `protobuf:"bytes,26,opt,name=proc_group,json=procGroup,proto3" json:"proc_group,omitempty"`
 	SuspendFlagName      string                 `protobuf:"bytes,27,opt,name=suspend_flag_name,json=suspendFlagName,proto3" json:"suspend_flag_name,omitempty"`
+	ArchiveDir           string                 `protobuf:"bytes,28,opt,name=archive_dir,json=archiveDir,proto3" json:"archive_dir,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -516,6 +517,13 @@ func (x *DAGRunIndexEntry) GetSuspendFlagName() string {
 	return ""
 }
 
+func (x *DAGRunIndexEntry) GetArchiveDir() string {
+	if x != nil {
+		return x.ArchiveDir
+	}
+	return ""
+}
+
 var File_proto_index_v1_index_proto protoreflect.FileDescriptor
 
 const file_proto_index_v1_index_proto_rawDesc = "" +
@@ -541,7 +549,7 @@ const file_proto_index_v1_index_proto_rawDesc = "" +
 	"\vDAGRunIndex\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\"\n" +
 	"\rbuilt_at_unix\x18\x02 \x01(\x03R\vbuiltAtUnix\x124\n" +
-	"\aentries\x18\x03 \x03(\v2\x1a.index.v1.DAGRunIndexEntryR\aentries\"\xf4\a\n" +
+	"\aentries\x18\x03 \x03(\v2\x1a.index.v1.DAGRunIndexEntryR\aentries\"\x95\b\n" +
 	"\x10DAGRunIndexEntry\x12\x1e\n" +
 	"\vdag_run_dir\x18\x01 \x01(\tR\tdagRunDir\x12\x1c\n" +
 	"\n" +
@@ -576,7 +584,9 @@ const file_proto_index_v1_index_proto_rawDesc = "" +
 	"\x17auto_retry_max_interval\x18\x19 \x01(\x03R\x14autoRetryMaxInterval\x12\x1d\n" +
 	"\n" +
 	"proc_group\x18\x1a \x01(\tR\tprocGroup\x12*\n" +
-	"\x11suspend_flag_name\x18\x1b \x01(\tR\x0fsuspendFlagNameB2Z0github.com/dagucloud/dagu/proto/index/v1;indexv1b\x06proto3"
+	"\x11suspend_flag_name\x18\x1b \x01(\tR\x0fsuspendFlagName\x12\x1f\n" +
+	"\varchive_dir\x18\x1c \x01(\tR\n" +
+	"archiveDirB2Z0github.com/dagucloud/dagu/proto/index/v1;indexv1b\x06proto3"
 
 var (
 	file_proto_index_v1_index_proto_rawDescOnce sync.Once

--- a/proto/index/v1/index.proto
+++ b/proto/index/v1/index.proto
@@ -65,4 +65,5 @@ message DAGRunIndexEntry {
   int64 auto_retry_max_interval = 25;  // Duration in nanoseconds
   string proc_group = 26;
   string suspend_flag_name = 27;
+  string archive_dir = 28;
 }


### PR DESCRIPTION
## Summary
- preserve DAG-run artifact archive paths in the day index used by paginated run listings
- restore `ArchiveDir` when list responses are built from indexed summaries
- add regression coverage for index-backed list results so artifact availability remains visible in Cockpit

## Root cause
The DAG-run day index omitted `ArchiveDir`, so once enough runs existed for `.dagrun.index` to be used, `/dag-runs` list responses reconstructed statuses without the artifact directory. Detail and artifact endpoints still read `status.jsonl`, but Cockpit cards use the list response and saw `artifactsAvailable: false`.

## Tests
- `go test -count=1 ./internal/persis/filedagrun/... ./internal/service/frontend/api/v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * DAG runs now track and preserve archive directory information throughout persistence and retrieval operations.

* **Tests**
  * Added test coverage ensuring archive directory is preserved when listing DAG runs with history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->