### PR TITLE
fix: load base config during validation

### DIFF
--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -51,12 +51,15 @@ similar to the server-side spec validation.`,
 
 func runValidate(ctx *Context, args []string) error {
 	// Try loading the DAG without evaluation, resolving relative names against DAGsDir
-	dag, err := spec.Load(
-		ctx,
-		args[0],
+	loadOpts := []spec.LoadOption{
 		spec.WithoutEval(),
 		spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
-	)
+	}
+	if ctx.Config.Paths.BaseConfig != "" {
+		loadOpts = append(loadOpts, spec.WithBaseConfig(ctx.Config.Paths.BaseConfig))
+	}
+
+	dag, err := spec.Load(ctx, args[0], loadOpts...)
 
 	if err != nil {
 		// Collect and return a formatted error message

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -4,6 +4,7 @@
 package cmd_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/cmd"
@@ -22,6 +23,38 @@ steps:
 
 		th.RunCommand(t, cmd.Validate(), test.CmdTest{
 			Args:        []string{"validate", dag.Location},
+			ExpectedOut: []string{"DAG spec is valid"},
+		})
+	})
+
+	t.Run("BaseConfigStepTypes", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(th.Config.Paths.BaseConfig, []byte(`
+step_types:
+  greet:
+    type: command
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [message]
+      properties:
+        message:
+          type: string
+    template:
+      exec:
+        command: /bin/echo
+        args:
+          - {$input: message}
+`), 0600))
+
+		dagFile := th.CreateDAGFile(t, "base_config_step_type.yaml", `
+steps:
+  - type: greet
+    with:
+      message: hello
+`)
+
+		th.RunCommand(t, cmd.Validate(), test.CmdTest{
+			Args:        []string{"validate", dagFile},
 			ExpectedOut: []string{"DAG spec is valid"},
 		})
 	})


### PR DESCRIPTION
## Summary
- apply the configured base config when `dagu validate` loads a DAG spec
- keep validation unevaluated while allowing base-config-defined custom `step_types` to resolve
- add regression coverage for validating a DAG that uses a `step_types` entry inherited from base config

## Root cause
`dagu validate` loaded DAG specs with `WithoutEval` and `WithDAGsDir`, but did not pass `WithBaseConfig`. DAGs that use custom step types declared only in base config were therefore validated without the inherited registry and failed with `unknown executor type`.

## Testing
- `go test ./internal/cmd ./cmd -count=1`
- `go test ./internal/core/spec -run "TestCustomStepTypes_BaseConfigRegistry" -count=1`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to correctly handle and validate DAGs using custom step types defined in base configuration files.

* **Tests**
  * Added test coverage for DAG validation with custom step types sourced from base configuration, ensuring step types are properly recognized and validated during the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->