### PR TITLE
feat: show parallel sub-dag runs in timeline

### DIFF
--- a/ui/src/features/dags/components/visualization/TimelineChart.tsx
+++ b/ui/src/features/dags/components/visualization/TimelineChart.tsx
@@ -323,7 +323,7 @@ function TimelineChart({ status }: Props) {
       timelineEnd: end,
       timeMarkers: markers,
     };
-  }, [status.nodes]);
+  }, [status, subRunsData?.subRuns, timeFormat]);
 
   // Don't render if there are no items
   if (items.length === 0) {

--- a/ui/src/features/dags/components/visualization/TimelineChart.tsx
+++ b/ui/src/features/dags/components/visualization/TimelineChart.tsx
@@ -14,10 +14,20 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { useQuery } from '@/hooks/api';
+import { whenEnabled } from '@/hooks/queryUtils';
 import dayjs from '@/lib/dayjs';
 import { isActiveNodeStatus } from '@/lib/status-utils';
-import { useMemo } from 'react';
-import { components, NodeStatus } from '../../../../api/v1/schema';
+import { useContext, useEffect, useMemo } from 'react';
+import { components, NodeStatus, Status } from '../../../../api/v1/schema';
+import {
+  buildTimelineRows,
+  getSubRunQueryContext,
+  getTimelineSubRuns,
+  hasTimelineSubRuns,
+  TimelineRow,
+} from './timelineItems';
 
 /**
  * Props for the TimelineChart component
@@ -33,7 +43,7 @@ const timeFormat = 'HH:mm:ss';
 /**
  * Get status label for display
  */
-function getStatusLabel(status: NodeStatus): string {
+function getNodeStatusLabel(status: NodeStatus): string {
   switch (status) {
     case NodeStatus.NotStarted:
       return 'Not Started';
@@ -58,6 +68,41 @@ function getStatusLabel(status: NodeStatus): string {
     default:
       return 'Unknown';
   }
+}
+
+/**
+ * Get DAG-run status label for display
+ */
+function getDAGRunStatusLabel(status: Status): string {
+  switch (status) {
+    case Status.NotStarted:
+      return 'Not Started';
+    case Status.Running:
+      return 'Running';
+    case Status.Success:
+      return 'Success';
+    case Status.Failed:
+      return 'Failed';
+    case Status.Aborted:
+      return 'Aborted';
+    case Status.Queued:
+      return 'Queued';
+    case Status.PartialSuccess:
+      return 'Partial Success';
+    case Status.Waiting:
+      return 'Waiting';
+    case Status.Rejected:
+      return 'Rejected';
+    default:
+      return 'Unknown';
+  }
+}
+
+function getStatusLabel(row: TimelineRow): string {
+  if (row.statusSource === 'dagrun') {
+    return getDAGRunStatusLabel(row.status as Status);
+  }
+  return getNodeStatusLabel(row.status as NodeStatus);
 }
 
 /**
@@ -127,60 +172,124 @@ const statusColors: Record<NodeStatus, { bg: string; border: string }> = {
   },
 };
 
+const dagRunStatusColors: Record<Status, { bg: string; border: string }> = {
+  [Status.NotStarted]: {
+    bg: 'var(--status-neutral)',
+    border: 'var(--status-neutral)',
+  },
+  [Status.Running]: {
+    bg: 'var(--status-running)',
+    border: 'var(--status-running)',
+  },
+  [Status.Failed]: {
+    bg: 'var(--status-error)',
+    border: 'var(--status-error)',
+  },
+  [Status.Aborted]: {
+    bg: 'var(--status-aborted)',
+    border: 'var(--status-aborted)',
+  },
+  [Status.Success]: {
+    bg: 'var(--status-success)',
+    border: 'var(--status-success)',
+  },
+  [Status.Queued]: {
+    bg: 'var(--status-neutral)',
+    border: 'var(--status-neutral)',
+  },
+  [Status.PartialSuccess]: {
+    bg: 'var(--status-warning)',
+    border: 'var(--status-warning)',
+  },
+  [Status.Waiting]: {
+    bg: 'var(--status-warning)',
+    border: 'var(--status-warning)',
+  },
+  [Status.Rejected]: {
+    bg: 'var(--status-error)',
+    border: 'var(--status-error)',
+  },
+};
+
 /**
  * Get color for a node status
  */
-function getStatusColor(status: NodeStatus): { bg: string; border: string } {
-  return statusColors[status] || { bg: '#6b7280', border: '#6b7280' };
+function getStatusColor(row: TimelineRow): { bg: string; border: string } {
+  if (row.statusSource === 'dagrun') {
+    return (
+      dagRunStatusColors[row.status as Status] || {
+        bg: '#6b7280',
+        border: '#6b7280',
+      }
+    );
+  }
+
+  return (
+    statusColors[row.status as NodeStatus] || {
+      bg: '#6b7280',
+      border: '#6b7280',
+    }
+  );
 }
 
-type TimelineItem = {
-  name: string;
-  startMs: number;
-  endMs: number;
-  status: NodeStatus;
-  node: components['schemas']['Node'];
-};
+function isActiveTimelineStatus(row: TimelineRow): boolean {
+  if (row.statusSource === 'dagrun') {
+    return row.status === Status.Running || row.status === Status.Queued;
+  }
+  return isActiveNodeStatus(row.status as NodeStatus);
+}
 
 /**
  * TimelineChart component renders a horizontal bar chart showing step execution
  */
 function TimelineChart({ status }: Props) {
+  const appBarContext = useContext(AppBarContext);
+  const remoteNode = appBarContext.selectedRemoteNode || 'local';
+  const shouldFetchSubRuns = hasTimelineSubRuns(status);
+  const queryContext = getSubRunQueryContext(status);
+  const eligibleSubRunIdsKey = useMemo(
+    () =>
+      (status.nodes || [])
+        .flatMap((node) => getTimelineSubRuns(node).map((sr) => sr.dagRunId))
+        .join('|'),
+    [status.nodes]
+  );
+  const { data: subRunsData, mutate: refetchSubRuns } = useQuery(
+    '/dag-runs/{name}/{dagRunId}/sub-dag-runs',
+    whenEnabled(shouldFetchSubRuns, {
+      params: {
+        path: {
+          name: queryContext.rootDagName,
+          dagRunId: queryContext.rootDagRunId,
+        },
+        query: {
+          remoteNode,
+          parentSubDAGRunId: queryContext.parentSubDAGRunId,
+        },
+      },
+    }),
+    {
+      refreshInterval:
+        shouldFetchSubRuns &&
+        (status.status === Status.Running || status.status === Status.Queued)
+          ? 3000
+          : 0,
+    }
+  );
+
+  useEffect(() => {
+    if (!shouldFetchSubRuns) {
+      return;
+    }
+    refetchSubRuns();
+  }, [shouldFetchSubRuns, eligibleSubRunIdsKey, refetchSubRuns]);
+
   const { items, timelineStart, timelineEnd, timeMarkers } = useMemo(() => {
-    const now = Date.now();
-    const validItems: TimelineItem[] = [];
-
-    (status.nodes || []).forEach((node) => {
-      // Skip steps that haven't started
-      if (!node.startedAt || node.startedAt === '-') {
-        return;
-      }
-
-      const startMs = dayjs(node.startedAt).valueOf();
-      let endMs: number;
-
-      // Use current time for active steps
-      if (!node.finishedAt || node.finishedAt === '-') {
-        endMs = now;
-      } else {
-        endMs = dayjs(node.finishedAt).valueOf();
-      }
-
-      // Validate
-      if (isNaN(startMs) || isNaN(endMs)) return;
-      if (endMs < startMs) endMs = startMs + 100;
-
-      validItems.push({
-        name: node.step.name,
-        startMs,
-        endMs,
-        status: node.status,
-        node,
-      });
+    const validItems = buildTimelineRows({
+      dagRun: status,
+      subRunDetails: subRunsData?.subRuns || [],
+      nowMs: Date.now(),
     });
-
-    // Sort by start time
-    validItems.sort((a, b) => a.startMs - b.startMs);
 
     if (validItems.length === 0) {
       return { items: [], timelineStart: 0, timelineEnd: 0, timeMarkers: [] };
@@ -265,25 +374,31 @@ function TimelineChart({ status }: Props) {
           const leftPercent =
             ((item.startMs - timelineStart) / totalRange) * 100;
           const widthPercent = ((item.endMs - item.startMs) / totalRange) * 100;
-          const colors = getStatusColor(item.status);
-          const isActive = isActiveNodeStatus(item.status);
+          const colors = getStatusColor(item);
+          const isActive = isActiveTimelineStatus(item);
 
           return (
             <div
-              key={item.name}
+              key={item.id}
+              data-testid="timeline-row"
+              data-row-id={item.id}
               className={`relative h-8 flex items-center ${
                 idx % 2 === 0 ? 'bg-background' : 'bg-muted/20'
               }`}
             >
               {/* Step name label */}
-              <div className="absolute left-2 z-10 text-xs font-medium text-foreground truncate max-w-[120px]">
-                {item.name}
+              <div
+                className="absolute z-10 text-xs font-medium text-foreground truncate max-w-[120px]"
+                style={{ left: item.depth === 0 ? '0.5rem' : '1.5rem' }}
+              >
+                {item.label}
               </div>
 
               {/* Timeline bar */}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div
+                    data-testid={`timeline-bar-${item.id}`}
                     className={`absolute h-5 rounded cursor-pointer transition-opacity hover:opacity-80 ${
                       isActive ? 'animate-pulse' : ''
                     }`}
@@ -298,16 +413,34 @@ function TimelineChart({ status }: Props) {
                 </TooltipTrigger>
                 <TooltipContent side="top" className="max-w-xs">
                   <div className="space-y-1">
-                    <div className="font-semibold">{item.name}</div>
-                    {item.node.step.description && (
+                    <div className="font-semibold">
+                      {item.kind === 'subdag'
+                        ? `${item.parentStepName} ${item.label}`
+                        : item.label}
+                    </div>
+                    {item.description && (
                       <div className="text-xs text-muted-foreground">
-                        {item.node.step.description}
+                        {item.description}
+                      </div>
+                    )}
+                    {item.dagName && (
+                      <div className="text-xs">DAG: {item.dagName}</div>
+                    )}
+                    {item.dagRunId && (
+                      <div className="text-xs">Run ID: {item.dagRunId}</div>
+                    )}
+                    {item.params && (
+                      <div className="text-xs">Params: {item.params}</div>
+                    )}
+                    {item.parentStepName && (
+                      <div className="text-xs text-muted-foreground">
+                        Parent: {item.parentStepName}
                       </div>
                     )}
                     <div className="text-xs">
                       Status:{' '}
                       <span className="font-medium">
-                        {getStatusLabel(item.status)}
+                        {getStatusLabel(item)}
                       </span>
                     </div>
                     <div className="text-xs">
@@ -320,9 +453,9 @@ function TimelineChart({ status }: Props) {
                       {dayjs(item.startMs).format('HH:mm:ss')} →{' '}
                       {dayjs(item.endMs).format('HH:mm:ss')}
                     </div>
-                    {item.node.error && (
+                    {item.error && (
                       <div className="text-xs text-destructive">
-                        Error: {item.node.error}
+                        Error: {item.error}
                       </div>
                     )}
                   </div>

--- a/ui/src/features/dags/components/visualization/__tests__/TimelineChart.test.tsx
+++ b/ui/src/features/dags/components/visualization/__tests__/TimelineChart.test.tsx
@@ -1,0 +1,421 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  components,
+  NodeStatus,
+  NodeStatusLabel,
+  Status,
+  StatusLabel,
+} from '@/api/v1/schema';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { useQuery } from '@/hooks/api';
+import TimelineChart from '../TimelineChart';
+
+vi.mock('@/hooks/api', () => ({
+  useQuery: vi.fn(),
+}));
+
+type DAGRunDetails = components['schemas']['DAGRunDetails'];
+type Node = components['schemas']['Node'];
+type SubDAGRun = components['schemas']['SubDAGRun'];
+type SubDAGRunDetail = components['schemas']['SubDAGRunDetail'];
+
+const useQueryMock = useQuery as unknown as {
+  mockImplementation: (
+    fn: (path: string, init?: unknown, config?: unknown) => unknown
+  ) => void;
+  mockReturnValue: (value: unknown) => void;
+};
+
+const appBarValue = {
+  title: 'DAGs',
+  setTitle: vi.fn(),
+  remoteNodes: ['local', 'remote-a'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'remote-a',
+  selectRemoteNode: vi.fn(),
+};
+
+function node(overrides: Partial<Node> = {}): Node {
+  const { step: stepOverrides, ...nodeOverrides } = overrides;
+
+  return {
+    stdout: '',
+    stderr: '',
+    startedAt: '2026-01-01T00:00:00Z',
+    finishedAt: '2026-01-01T00:00:10Z',
+    status: NodeStatus.Success,
+    statusLabel: NodeStatusLabel.succeeded,
+    retryCount: 0,
+    doneCount: 1,
+    ...nodeOverrides,
+    step: {
+      name: 'step-a',
+      ...stepOverrides,
+    },
+  };
+}
+
+function dagRun(overrides: Partial<DAGRunDetails> = {}): DAGRunDetails {
+  return {
+    dagRunId: 'root-run',
+    name: 'root-dag',
+    status: Status.Success,
+    statusLabel: StatusLabel.succeeded,
+    autoRetryCount: 0,
+    startedAt: '2026-01-01T00:00:00Z',
+    finishedAt: '2026-01-01T00:01:00Z',
+    artifactsAvailable: false,
+    rootDAGRunName: 'root-dag',
+    rootDAGRunId: 'root-run',
+    log: '',
+    nodes: [node()],
+    ...overrides,
+  };
+}
+
+function subRun(
+  dagRunId: string,
+  overrides: Partial<SubDAGRun> = {}
+): SubDAGRun {
+  return {
+    dagRunId,
+    dagName: 'child-dag',
+    params: `{"ITEM":"${dagRunId}"}`,
+    ...overrides,
+  };
+}
+
+function subRunDetail(
+  dagRunId: string,
+  overrides: Partial<SubDAGRunDetail> = {}
+): SubDAGRunDetail {
+  return {
+    dagRunId,
+    dagName: 'child-dag',
+    params: `{"ITEM":"${dagRunId}"}`,
+    status: Status.Success,
+    statusLabel: StatusLabel.succeeded,
+    startedAt: '2026-01-01T00:00:01Z',
+    finishedAt: '2026-01-01T00:00:05Z',
+    ...overrides,
+  };
+}
+
+function parallelNode(
+  stepName: string,
+  runs: SubDAGRun[],
+  overrides: Partial<Node> = {}
+): Node {
+  return node({
+    step: {
+      name: stepName,
+      call: 'child-dag',
+      parallel: { items: runs.map((run) => run.dagRunId) },
+      ...overrides.step,
+    },
+    subRuns: runs,
+    ...overrides,
+  });
+}
+
+function renderChart(
+  status: DAGRunDetails,
+  appBarOverride: Partial<typeof appBarValue> = {}
+) {
+  return render(
+    <AppBarContext.Provider value={{ ...appBarValue, ...appBarOverride }}>
+      <TimelineChart status={status} />
+    </AppBarContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  class ResizeObserverMock {
+    observe() {
+      return;
+    }
+    unobserve() {
+      return;
+    }
+    disconnect() {
+      return;
+    }
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: ResizeObserverMock,
+  });
+  useQueryMock.mockReturnValue({
+    data: { subRuns: [] },
+    mutate: vi.fn(),
+  });
+});
+
+describe('TimelineChart', () => {
+  it('passes null query init when there are no eligible parallel child rows', () => {
+    const queryCalls: Array<{ path: string; init?: unknown }> = [];
+    useQueryMock.mockImplementation((path, init) => {
+      queryCalls.push({ path, init });
+      return { data: { subRuns: [] }, mutate: vi.fn() } as never;
+    });
+
+    renderChart(dagRun());
+
+    expect(queryCalls).toContainEqual({
+      path: '/dag-runs/{name}/{dagRunId}/sub-dag-runs',
+      init: null,
+    });
+  });
+
+  it('does not render child rows for non-parallel sub-DAG calls', () => {
+    useQueryMock.mockReturnValue({
+      data: { subRuns: [subRunDetail('child-run-1')] },
+      mutate: vi.fn(),
+    });
+
+    renderChart(
+      dagRun({
+        nodes: [
+          node({
+            step: { name: 'call-child', call: 'child-dag' },
+            subRuns: [subRun('child-run-1')],
+          }),
+        ],
+      })
+    );
+
+    expect(screen.getByText('call-child')).toBeInTheDocument();
+    expect(screen.queryByText('#01')).not.toBeInTheDocument();
+  });
+
+  it('does not render child rows for repeat-policy-only sub-DAG runs', () => {
+    useQueryMock.mockReturnValue({
+      data: { subRuns: [subRunDetail('repeat-run-1')] },
+      mutate: vi.fn(),
+    });
+
+    renderChart(
+      dagRun({
+        nodes: [
+          node({
+            step: { name: 'repeat-child', call: 'child-dag' },
+            subRunsRepeated: [subRun('repeat-run-1')],
+          }),
+        ],
+      })
+    );
+
+    expect(screen.getByText('repeat-child')).toBeInTheDocument();
+    expect(screen.queryByText('#01')).not.toBeInTheDocument();
+  });
+
+  it('queries root timeline details with the root DAG name and run ID', () => {
+    const queryCalls: Array<{ path: string; init?: unknown; config?: unknown }> =
+      [];
+    useQueryMock.mockImplementation((path, init, config) => {
+      queryCalls.push({ path, init, config });
+      return { data: { subRuns: [] }, mutate: vi.fn() } as never;
+    });
+
+    renderChart(
+      dagRun({
+        status: Status.Running,
+        nodes: [parallelNode('parallel-call', [subRun('child-run-1')])],
+      })
+    );
+
+    expect(queryCalls[0]).toEqual(
+      expect.objectContaining({
+        path: '/dag-runs/{name}/{dagRunId}/sub-dag-runs',
+        init: {
+          params: {
+            path: {
+              name: 'root-dag',
+              dagRunId: 'root-run',
+            },
+            query: {
+              remoteNode: 'remote-a',
+              parentSubDAGRunId: undefined,
+            },
+          },
+        },
+        config: {
+          refreshInterval: 3000,
+        },
+      })
+    );
+  });
+
+  it('queries nested timeline details with parentSubDAGRunId set to the current sub-DAG run ID', () => {
+    const queryCalls: Array<{ path: string; init?: unknown }> = [];
+    useQueryMock.mockImplementation((path, init) => {
+      queryCalls.push({ path, init });
+      return { data: { subRuns: [] }, mutate: vi.fn() } as never;
+    });
+
+    renderChart(
+      dagRun({
+        name: 'child-dag',
+        dagRunId: 'child-run',
+        rootDAGRunName: 'root-dag',
+        rootDAGRunId: 'root-run',
+        nodes: [parallelNode('nested-parallel', [subRun('grandchild-run')])],
+      })
+    );
+
+    expect(queryCalls[0]?.init).toEqual({
+      params: {
+        path: {
+          name: 'root-dag',
+          dagRunId: 'root-run',
+        },
+        query: {
+          remoteNode: 'remote-a',
+          parentSubDAGRunId: 'child-run',
+        },
+      },
+    });
+  });
+
+  it('renders child rows under a parallel parent with child tooltip details', async () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        subRuns: [
+          subRunDetail('child-run-1', { params: '{"SCOPE":"item1"}' }),
+          subRunDetail('child-run-2', { params: '{"SCOPE":"item2"}' }),
+        ],
+      },
+      mutate: vi.fn(),
+    });
+
+    renderChart(
+      dagRun({
+        nodes: [
+          parallelNode('parallel-call', [
+            subRun('child-run-1'),
+            subRun('child-run-2'),
+          ]),
+        ],
+      })
+    );
+
+    const rows = screen.getAllByTestId('timeline-row');
+    expect(rows.map((row) => row.getAttribute('data-row-id'))).toEqual([
+      'step:parallel-call',
+      'subdag:parallel-call:child-run-1',
+      'subdag:parallel-call:child-run-2',
+    ]);
+    expect(screen.getByText('#01')).toBeInTheDocument();
+    expect(screen.getByText('#02')).toBeInTheDocument();
+
+    await userEvent.hover(
+      screen.getByTestId('timeline-bar-subdag:parallel-call:child-run-1')
+    );
+
+    expect(await screen.findAllByText('DAG: child-dag')).not.toHaveLength(0);
+    expect(screen.getAllByText('Run ID: child-run-1')).not.toHaveLength(0);
+    expect(screen.getAllByText('Params: {"SCOPE":"item1"}')).not.toHaveLength(
+      0
+    );
+  });
+
+  it('filters endpoint details for multiple parallel nodes to matching run IDs', () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        subRuns: [
+          subRunDetail('b-run', { dagName: 'child-b' }),
+          subRunDetail('unrelated-run'),
+          subRunDetail('a-run', { dagName: 'child-a' }),
+        ],
+      },
+      mutate: vi.fn(),
+    });
+
+    renderChart(
+      dagRun({
+        nodes: [
+          parallelNode('parallel-a', [subRun('a-run')], {
+            startedAt: '2026-01-01T00:00:00Z',
+            finishedAt: '2026-01-01T00:00:10Z',
+          }),
+          parallelNode('parallel-b', [subRun('b-run')], {
+            startedAt: '2026-01-01T00:00:20Z',
+            finishedAt: '2026-01-01T00:00:30Z',
+          }),
+        ],
+      })
+    );
+
+    expect(
+      screen
+        .getAllByTestId('timeline-row')
+        .map((row) => row.getAttribute('data-row-id'))
+    ).toEqual([
+      'step:parallel-a',
+      'subdag:parallel-a:a-run',
+      'step:parallel-b',
+      'subdag:parallel-b:b-run',
+    ]);
+    expect(screen.getAllByText('#01')).toHaveLength(2);
+  });
+
+  it('keeps parent errors in the step tooltip', async () => {
+    renderChart(
+      dagRun({
+        nodes: [
+          node({
+            step: { name: 'failing-step' },
+            status: NodeStatus.Failed,
+            statusLabel: NodeStatusLabel.failed,
+            error: 'parent exploded',
+          }),
+        ],
+      })
+    );
+
+    await userEvent.hover(screen.getByTestId('timeline-bar-step:failing-step'));
+
+    expect(await screen.findAllByText('Error: parent exploded')).not.toHaveLength(
+      0
+    );
+  });
+
+  it('displays child DAG-run queued status as Queued, not Skipped', async () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        subRuns: [
+          subRunDetail('queued-run', {
+            status: Status.Queued,
+            statusLabel: StatusLabel.queued,
+          }),
+        ],
+      },
+      mutate: vi.fn(),
+    });
+
+    renderChart(
+      dagRun({
+        nodes: [parallelNode('parallel-call', [subRun('queued-run')])],
+      })
+    );
+
+    await userEvent.hover(
+      screen.getByTestId('timeline-bar-subdag:parallel-call:queued-run')
+    );
+
+    const tooltip = (await screen.findAllByText('Queued'))
+      .map((element) => element.closest('[data-slot="tooltip-content"]'))
+      .find((element): element is HTMLElement => element !== null);
+    expect(tooltip).toBeInTheDocument();
+    expect(
+      within(tooltip as HTMLElement).queryByText('Skipped')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/dags/components/visualization/__tests__/timelineItems.test.ts
+++ b/ui/src/features/dags/components/visualization/__tests__/timelineItems.test.ts
@@ -1,0 +1,324 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import { components, NodeStatus, Status, StatusLabel } from '@/api/v1/schema';
+import {
+  buildTimelineRows,
+  getSubRunQueryContext,
+  hasTimelineSubRuns,
+} from '../timelineItems';
+
+type DAGRunDetails = components['schemas']['DAGRunDetails'];
+type Node = components['schemas']['Node'];
+type SubDAGRun = components['schemas']['SubDAGRun'];
+type SubDAGRunDetail = components['schemas']['SubDAGRunDetail'];
+
+const nowMs = Date.parse('2026-01-01T00:02:00Z');
+
+function node(overrides: Partial<Node> = {}): Node {
+  const { step: stepOverrides, ...nodeOverrides } = overrides;
+
+  return {
+    stdout: '',
+    stderr: '',
+    startedAt: '2026-01-01T00:00:00Z',
+    finishedAt: '2026-01-01T00:00:10Z',
+    status: NodeStatus.Success,
+    statusLabel: 'succeeded' as never,
+    retryCount: 0,
+    doneCount: 1,
+    ...nodeOverrides,
+    step: {
+      name: 'step-a',
+      ...stepOverrides,
+    },
+  };
+}
+
+function dagRun(overrides: Partial<DAGRunDetails> = {}): DAGRunDetails {
+  return {
+    dagRunId: 'root-run',
+    name: 'root-dag',
+    status: Status.Success,
+    statusLabel: StatusLabel.succeeded,
+    autoRetryCount: 0,
+    startedAt: '2026-01-01T00:00:00Z',
+    finishedAt: '2026-01-01T00:01:00Z',
+    artifactsAvailable: false,
+    rootDAGRunName: 'root-dag',
+    rootDAGRunId: 'root-run',
+    log: '',
+    nodes: [node()],
+    ...overrides,
+  };
+}
+
+function subRun(
+  dagRunId: string,
+  overrides: Partial<SubDAGRun> = {}
+): SubDAGRun {
+  return {
+    dagRunId,
+    dagName: 'child-dag',
+    params: `{"ITEM":"${dagRunId}"}`,
+    ...overrides,
+  };
+}
+
+function subRunDetail(
+  dagRunId: string,
+  overrides: Partial<SubDAGRunDetail> = {}
+): SubDAGRunDetail {
+  return {
+    dagRunId,
+    dagName: 'child-dag',
+    params: `{"ITEM":"${dagRunId}"}`,
+    status: Status.Success,
+    statusLabel: StatusLabel.succeeded,
+    startedAt: '2026-01-01T00:00:01Z',
+    finishedAt: '2026-01-01T00:00:05Z',
+    ...overrides,
+  };
+}
+
+describe('timelineItems', () => {
+  it('builds parent-only rows when there are no eligible child rows', () => {
+    const rows = buildTimelineRows({
+      dagRun: dagRun(),
+      subRunDetails: [],
+      nowMs,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: 'step',
+      label: 'step-a',
+      status: NodeStatus.Success,
+      statusSource: 'node',
+      depth: 0,
+    });
+  });
+
+  it('sorts parent rows by start time', () => {
+    const rows = buildTimelineRows({
+      dagRun: dagRun({
+        nodes: [
+          node({
+            step: { name: 'later' },
+            startedAt: '2026-01-01T00:00:20Z',
+            finishedAt: '2026-01-01T00:00:30Z',
+          }),
+          node({
+            step: { name: 'earlier' },
+            startedAt: '2026-01-01T00:00:01Z',
+            finishedAt: '2026-01-01T00:00:03Z',
+          }),
+        ],
+      }),
+      subRunDetails: [],
+      nowMs,
+    });
+
+    expect(rows.map((row) => row.label)).toEqual(['earlier', 'later']);
+  });
+
+  it('does not fetch or build child rows for non-parallel sub-DAG calls', () => {
+    const run = dagRun({
+      nodes: [
+        node({
+          step: { name: 'call-child', call: 'child-dag' },
+          subRuns: [subRun('child-run-1')],
+        }),
+      ],
+    });
+
+    expect(hasTimelineSubRuns(run)).toBe(false);
+    expect(
+      buildTimelineRows({
+        dagRun: run,
+        subRunDetails: [subRunDetail('child-run-1')],
+        nowMs,
+      }).map((row) => row.kind)
+    ).toEqual(['step']);
+  });
+
+  it('does not fetch or build child rows for repeat-policy-only sub-runs', () => {
+    const run = dagRun({
+      nodes: [
+        node({
+          step: { name: 'repeat-child', call: 'child-dag' },
+          subRunsRepeated: [subRun('repeat-run-1')],
+        }),
+      ],
+    });
+
+    expect(hasTimelineSubRuns(run)).toBe(false);
+    expect(
+      buildTimelineRows({
+        dagRun: run,
+        subRunDetails: [subRunDetail('repeat-run-1')],
+        nowMs,
+      }).map((row) => row.kind)
+    ).toEqual(['step']);
+  });
+
+  it('builds parallel child rows only when matching timing details exist', () => {
+    const run = dagRun({
+      nodes: [
+        node({
+          step: {
+            name: 'parallel-call',
+            call: 'child-dag',
+            parallel: { items: ['a', 'b'] },
+          },
+          subRuns: [subRun('child-run-1'), subRun('child-run-2')],
+        }),
+      ],
+    });
+
+    expect(hasTimelineSubRuns(run)).toBe(true);
+
+    const rows = buildTimelineRows({
+      dagRun: run,
+      subRunDetails: [subRunDetail('child-run-2')],
+      nowMs,
+    });
+
+    expect(rows.map((row) => [row.kind, row.label, row.dagRunId])).toEqual([
+      ['step', 'parallel-call', undefined],
+      ['subdag', '#02', 'child-run-2'],
+    ]);
+  });
+
+  it('filters endpoint details to each parallel node sub-run list', () => {
+    const run = dagRun({
+      nodes: [
+        node({
+          step: {
+            name: 'parallel-a',
+            call: 'child-a',
+            parallel: { items: ['a'] },
+          },
+          startedAt: '2026-01-01T00:00:00Z',
+          finishedAt: '2026-01-01T00:00:10Z',
+          subRuns: [subRun('a-run')],
+        }),
+        node({
+          step: {
+            name: 'parallel-b',
+            call: 'child-b',
+            parallel: { items: ['b'] },
+          },
+          startedAt: '2026-01-01T00:00:20Z',
+          finishedAt: '2026-01-01T00:00:30Z',
+          subRuns: [subRun('b-run')],
+        }),
+      ],
+    });
+
+    const rows = buildTimelineRows({
+      dagRun: run,
+      subRunDetails: [
+        subRunDetail('b-run', { dagName: 'child-b' }),
+        subRunDetail('a-run', { dagName: 'child-a' }),
+      ],
+      nowMs,
+    });
+
+    expect(
+      rows.map((row) => ({
+        label: row.label,
+        parentStepName: row.parentStepName,
+        dagRunId: row.dagRunId,
+        dagName: row.dagName,
+      }))
+    ).toEqual([
+      {
+        label: 'parallel-a',
+        parentStepName: undefined,
+        dagRunId: undefined,
+        dagName: undefined,
+      },
+      {
+        label: '#01',
+        parentStepName: 'parallel-a',
+        dagRunId: 'a-run',
+        dagName: 'child-a',
+      },
+      {
+        label: 'parallel-b',
+        parentStepName: undefined,
+        dagRunId: undefined,
+        dagName: undefined,
+      },
+      {
+        label: '#01',
+        parentStepName: 'parallel-b',
+        dagRunId: 'b-run',
+        dagName: 'child-b',
+      },
+    ]);
+  });
+
+  it('ignores unrelated endpoint details', () => {
+    const run = dagRun({
+      nodes: [
+        node({
+          step: {
+            name: 'parallel-call',
+            call: 'child-dag',
+            parallel: { items: ['a'] },
+          },
+          subRuns: [subRun('child-run-1')],
+        }),
+      ],
+    });
+
+    const rows = buildTimelineRows({
+      dagRun: run,
+      subRunDetails: [subRunDetail('other-run')],
+      nowMs,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ label: 'parallel-call' });
+  });
+
+  it('preserves parent node errors on the step row', () => {
+    const rows = buildTimelineRows({
+      dagRun: dagRun({
+        nodes: [node({ error: 'step failed' })],
+      }),
+      subRunDetails: [],
+      nowMs,
+    });
+
+    expect(rows[0]).toMatchObject({ error: 'step failed' });
+  });
+
+  it('returns root query context without parentSubDAGRunId for root DAG-runs', () => {
+    expect(getSubRunQueryContext(dagRun())).toEqual({
+      rootDagName: 'root-dag',
+      rootDagRunId: 'root-run',
+      parentSubDAGRunId: undefined,
+    });
+  });
+
+  it('returns nested query context with the current sub-DAG run ID', () => {
+    expect(
+      getSubRunQueryContext(
+        dagRun({
+          name: 'child-dag',
+          dagRunId: 'child-run',
+          rootDAGRunName: 'root-dag',
+          rootDAGRunId: 'root-run',
+        })
+      )
+    ).toEqual({
+      rootDagName: 'root-dag',
+      rootDagRunId: 'root-run',
+      parentSubDAGRunId: 'child-run',
+    });
+  });
+});

--- a/ui/src/features/dags/components/visualization/__tests__/timelineItems.test.ts
+++ b/ui/src/features/dags/components/visualization/__tests__/timelineItems.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from 'vitest';
-import { components, NodeStatus, Status, StatusLabel } from '@/api/v1/schema';
+import {
+  components,
+  NodeStatus,
+  NodeStatusLabel,
+  Status,
+  StatusLabel,
+} from '@/api/v1/schema';
 import {
   buildTimelineRows,
   getSubRunQueryContext,
@@ -25,7 +31,7 @@ function node(overrides: Partial<Node> = {}): Node {
     startedAt: '2026-01-01T00:00:00Z',
     finishedAt: '2026-01-01T00:00:10Z',
     status: NodeStatus.Success,
-    statusLabel: 'succeeded' as never,
+    statusLabel: NodeStatusLabel.succeeded,
     retryCount: 0,
     doneCount: 1,
     ...nodeOverrides,

--- a/ui/src/features/dags/components/visualization/timelineItems.ts
+++ b/ui/src/features/dags/components/visualization/timelineItems.ts
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import dayjs from '@/lib/dayjs';
+import { components, NodeStatus, Status } from '../../../../api/v1/schema';
+
+type DAGRunDetails = components['schemas']['DAGRunDetails'];
+type Node = components['schemas']['Node'];
+type SubDAGRun = components['schemas']['SubDAGRun'];
+type SubDAGRunDetail = components['schemas']['SubDAGRunDetail'];
+
+export type TimelineRow = {
+  id: string;
+  kind: 'step' | 'subdag';
+  label: string;
+  parentStepName?: string;
+  startMs: number;
+  endMs: number;
+  status: NodeStatus | Status;
+  statusLabel?: string;
+  statusSource: 'node' | 'dagrun';
+  description?: string;
+  error?: string;
+  params?: string;
+  dagRunId?: string;
+  dagName?: string;
+  depth: number;
+};
+
+export type SubRunQueryContext = {
+  rootDagName: string;
+  rootDagRunId: string;
+  parentSubDAGRunId?: string;
+};
+
+export function getTimelineSubRuns(node: Node): SubDAGRun[] {
+  if (!node.step.parallel) return [];
+  return node.subRuns || [];
+}
+
+export function hasTimelineSubRuns(dagRun: DAGRunDetails): boolean {
+  return (dagRun.nodes || []).some(
+    (node) => getTimelineSubRuns(node).length > 0
+  );
+}
+
+export function getSubRunQueryContext(
+  dagRun: DAGRunDetails
+): SubRunQueryContext {
+  const rootDagName = dagRun.rootDAGRunName || dagRun.name;
+  const rootDagRunId = dagRun.rootDAGRunId || dagRun.dagRunId;
+  const parentSubDAGRunId =
+    dagRun.dagRunId !== rootDagRunId ? dagRun.dagRunId : undefined;
+
+  return {
+    rootDagName,
+    rootDagRunId,
+    parentSubDAGRunId,
+  };
+}
+
+export function buildTimelineRows({
+  dagRun,
+  subRunDetails,
+  nowMs,
+}: {
+  dagRun: DAGRunDetails;
+  subRunDetails: SubDAGRunDetail[];
+  nowMs: number;
+}): TimelineRow[] {
+  const parentRows = (dagRun.nodes || [])
+    .map((node) => buildStepRow(node, nowMs))
+    .filter((row): row is TimelineRow & { node: Node } => row !== null)
+    .sort((a, b) => a.startMs - b.startMs);
+
+  const subRunDetailsById = new Map(
+    subRunDetails.map((subRunDetail) => [subRunDetail.dagRunId, subRunDetail])
+  );
+  const rows: TimelineRow[] = [];
+
+  for (const parentRow of parentRows) {
+    const { node, ...row } = parentRow;
+    rows.push(row);
+
+    const subRuns = getTimelineSubRuns(node);
+    subRuns.forEach((subRun, index) => {
+      const detail = subRunDetailsById.get(subRun.dagRunId);
+      if (!detail) {
+        return;
+      }
+
+      const childRow = buildSubDAGRow({
+        parentStepName: node.step.name,
+        subRun,
+        detail,
+        index,
+        nowMs,
+      });
+      if (childRow) {
+        rows.push(childRow);
+      }
+    });
+  }
+
+  return rows;
+}
+
+function buildStepRow(
+  node: Node,
+  nowMs: number
+): (TimelineRow & { node: Node }) | null {
+  if (!node.startedAt || node.startedAt === '-') {
+    return null;
+  }
+
+  const startMs = dayjs(node.startedAt).valueOf();
+  const endMs = parseEndMs(node.finishedAt, nowMs);
+  const normalized = normalizeTiming(startMs, endMs);
+
+  if (!normalized) {
+    return null;
+  }
+
+  return {
+    id: `step:${node.step.name}`,
+    kind: 'step',
+    label: node.step.name,
+    startMs: normalized.startMs,
+    endMs: normalized.endMs,
+    status: node.status,
+    statusLabel: node.statusLabel,
+    statusSource: 'node',
+    description: node.step.description,
+    error: node.error,
+    depth: 0,
+    node,
+  };
+}
+
+function buildSubDAGRow({
+  parentStepName,
+  subRun,
+  detail,
+  index,
+  nowMs,
+}: {
+  parentStepName: string;
+  subRun: SubDAGRun;
+  detail: SubDAGRunDetail;
+  index: number;
+  nowMs: number;
+}): TimelineRow | null {
+  const startMs = dayjs(detail.startedAt).valueOf();
+  const endMs = parseEndMs(detail.finishedAt, nowMs);
+  const normalized = normalizeTiming(startMs, endMs);
+
+  if (!normalized) {
+    return null;
+  }
+
+  return {
+    id: `subdag:${parentStepName}:${detail.dagRunId}`,
+    kind: 'subdag',
+    label: `#${String(index + 1).padStart(2, '0')}`,
+    parentStepName,
+    startMs: normalized.startMs,
+    endMs: normalized.endMs,
+    status: detail.status,
+    statusLabel: detail.statusLabel,
+    statusSource: 'dagrun',
+    params: detail.params ?? subRun.params,
+    dagRunId: detail.dagRunId,
+    dagName: detail.dagName ?? subRun.dagName,
+    depth: 1,
+  };
+}
+
+function parseEndMs(timestamp: string | undefined, nowMs: number): number {
+  if (!timestamp || timestamp === '-') {
+    return nowMs;
+  }
+  return dayjs(timestamp).valueOf();
+}
+
+function normalizeTiming(
+  startMs: number,
+  endMs: number
+): { startMs: number; endMs: number } | null {
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+    return null;
+  }
+
+  if (endMs < startMs) {
+    return { startMs, endMs: startMs + 100 };
+  }
+
+  return { startMs, endMs };
+}

--- a/ui/src/features/dags/components/visualization/timelineItems.ts
+++ b/ui/src/features/dags/components/visualization/timelineItems.ts
@@ -9,6 +9,7 @@ type Node = components['schemas']['Node'];
 type SubDAGRun = components['schemas']['SubDAGRun'];
 type SubDAGRunDetail = components['schemas']['SubDAGRunDetail'];
 
+/** Render-ready timeline row for either a parent step or expanded sub-DAG run. */
 export type TimelineRow = {
   id: string;
   kind: 'step' | 'subdag';
@@ -27,23 +28,27 @@ export type TimelineRow = {
   depth: number;
 };
 
+/** API query context needed to load sub-DAG runs for a root or nested DAG run. */
 export type SubRunQueryContext = {
   rootDagName: string;
   rootDagRunId: string;
   parentSubDAGRunId?: string;
 };
 
+/** Returns sub-runs that should be shown under a parallel parent step. */
 export function getTimelineSubRuns(node: Node): SubDAGRun[] {
   if (!node.step.parallel) return [];
   return node.subRuns || [];
 }
 
+/** Checks whether a DAG run has any parallel sub-runs worth expanding. */
 export function hasTimelineSubRuns(dagRun: DAGRunDetails): boolean {
   return (dagRun.nodes || []).some(
     (node) => getTimelineSubRuns(node).length > 0
   );
 }
 
+/** Builds the root-aware query context for fetching sub-DAG run details. */
 export function getSubRunQueryContext(
   dagRun: DAGRunDetails
 ): SubRunQueryContext {
@@ -59,6 +64,7 @@ export function getSubRunQueryContext(
   };
 }
 
+/** Builds sorted timeline rows from parent nodes and loaded sub-DAG details. */
 export function buildTimelineRows({
   dagRun,
   subRunDetails,


### PR DESCRIPTION
## Summary
- show parallel sub-DAG executions as separate timeline items instead of folding everything into the parent step block
- derive timeline items from DAG-run children so sub-DAG runs keep their own timing/status labels
- add unit coverage for timeline item construction and chart rendering with parallel sub-DAG runs

## Testing
- `pnpm exec vitest run src/features/dags/components/visualization/__tests__/TimelineChart.test.tsx src/features/dags/components/visualization/__tests__/timelineItems.test.ts`

Closes #2048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced timeline visualization with unified status handling for runs and steps, improved coloring and labels.
  * Tooltips enriched with DAG/run metadata, run IDs, parameters, parent step and error details.
  * Better handling and ordering of parallel sub-DAG entries and correct queued vs skipped status display.

* **Tests**
  * Added comprehensive tests covering timeline row construction, sub-DAG query behavior, tooltip content, and rendering order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->