### PR TITLE
fix: support multiline schema parameter input

### DIFF
--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -41,6 +41,7 @@ import {
 } from './paramSchemaForm';
 import { schemaFormTemplates } from './schemaFormTemplates';
 import { schemaFormWidgets } from './schemaFormWidgets';
+import { autoGrowTextarea } from './textareaAutoGrow';
 
 type ScalarValue = components['schemas']['ParamScalar'];
 type ParamDef = components['schemas']['ParamDef'];
@@ -79,15 +80,6 @@ type Props = {
   ) => Promise<void> | void;
   action?: 'start' | 'enqueue';
 };
-
-const maxTextareaHeight = 150;
-
-function autoGrowTextarea(el: HTMLTextAreaElement) {
-  el.style.height = 'auto';
-  const clamped = Math.min(el.scrollHeight, maxTextareaHeight);
-  el.style.height = `${clamped}px`;
-  el.style.overflowY = el.scrollHeight > maxTextareaHeight ? 'auto' : 'hidden';
-}
 
 function createParamFields(paramDefs: ParamDef[] = []): ParamField[] {
   return paramDefs.map((def, index) => {

--- a/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@rjsf/shadcn', async () => {
     default: React.forwardRef(function MockSchemaForm(
       props: {
         formData?: Record<string, unknown>;
-        uiSchema?: Record<string, unknown>;
+        uiSchema?: Record<string, Record<string, unknown>>;
         onChange?: (event: { formData: Record<string, unknown> }) => void;
       },
       ref: any
@@ -24,9 +24,15 @@ vi.mock('@rjsf/shadcn', async () => {
       React.useImperativeHandle(ref, () => ({
         validateForm: () => true,
       }));
+      const widget = props.uiSchema?.message?.['ui:widget'];
 
       return (
         <div data-testid="schema-form">
+          {widget === 'textarea' ? (
+            <textarea aria-label="message" defaultValue="" />
+          ) : (
+            <input aria-label="message" defaultValue="" />
+          )}
           <button
             type="button"
             onClick={() =>
@@ -110,6 +116,42 @@ describe('StartDAGModal', () => {
         true
       )
     );
+  });
+
+  it('does not submit a schema-backed string param when Shift+Enter is pressed', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <StartDAGModal
+        visible={true}
+        dismissModal={vi.fn()}
+        onSubmit={onSubmit}
+        dag={
+          {
+            name: 'schema-dag',
+            paramSchema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                },
+              },
+            },
+          } as never
+        }
+      />
+    );
+
+    const messageInput = screen.getByLabelText('message');
+    expect(messageInput.tagName).toBe('TEXTAREA');
+    messageInput.focus();
+
+    fireEvent.keyDown(messageInput, {
+      key: 'Enter',
+      shiftKey: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('falls back to typed param fields when paramSchema is absent', () => {

--- a/ui/src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts
+++ b/ui/src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts
@@ -66,6 +66,26 @@ describe('paramSchemaForm helpers', () => {
     expect(uiSchema.backend?.['ui:widget']).toBeUndefined();
   });
 
+  it('uses textarea widgets for free text schema fields', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        date: { type: 'string', format: 'date' },
+        region: {
+          type: 'string',
+          enum: ['us-east-1', 'us-west-2'],
+        },
+      },
+    };
+
+    const uiSchema = buildParamSchemaUiSchema(schema);
+
+    expect(uiSchema.message?.['ui:widget']).toBe('textarea');
+    expect(uiSchema.date).toBeUndefined();
+    expect(uiSchema.region?.['ui:widget']).toBe('radio');
+  });
+
   it('serializes schema-backed form data as a JSON object payload', () => {
     expect(
       stringifyParamSchemaFormData({

--- a/ui/src/features/dags/components/dag-execution/__tests__/schemaFormWidgets.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/schemaFormWidgets.test.tsx
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentType } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { schemaFormWidgets } from '../schemaFormWidgets';
+
+const TextareaWidget = schemaFormWidgets.TextareaWidget as ComponentType<any>;
+
+describe('schemaFormWidgets', () => {
+  it('auto-grows schema textarea widgets on input', () => {
+    render(
+      <TextareaWidget
+        id="root_message"
+        htmlName="message"
+        schema={{ type: 'string' }}
+        value=""
+        required={false}
+        disabled={false}
+        readonly={false}
+        autofocus={false}
+        options={{ emptyValue: undefined, rows: 1 }}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />
+    );
+
+    const textarea = screen.getByRole('textbox');
+    Object.defineProperty(textarea, 'scrollHeight', {
+      configurable: true,
+      value: 180,
+    });
+
+    fireEvent.input(textarea, { target: { value: 'line 1\nline 2' } });
+
+    expect(textarea.style.height).toBe('150px');
+    expect(textarea.style.overflowY).toBe('auto');
+  });
+});

--- a/ui/src/features/dags/components/dag-execution/__tests__/schemaFormWidgets.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/schemaFormWidgets.test.tsx
@@ -9,6 +9,31 @@ import { schemaFormWidgets } from '../schemaFormWidgets';
 const TextareaWidget = schemaFormWidgets.TextareaWidget as ComponentType<any>;
 
 describe('schemaFormWidgets', () => {
+  it('renders schema textarea widgets at one-line height by default', () => {
+    render(
+      <TextareaWidget
+        id="root_message"
+        htmlName="message"
+        schema={{ type: 'string' }}
+        value=""
+        required={false}
+        disabled={false}
+        readonly={false}
+        autofocus={false}
+        options={{ emptyValue: undefined }}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+      />
+    );
+
+    const textarea = screen.getByRole('textbox');
+
+    expect(textarea).toHaveAttribute('rows', '1');
+    expect(textarea).toHaveClass('min-h-9');
+    expect(textarea).not.toHaveClass('min-h-16');
+  });
+
   it('auto-grows schema textarea widgets on input', () => {
     render(
       <TextareaWidget

--- a/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
+++ b/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
@@ -134,6 +134,10 @@ function getChoiceCount(schema: JSONSchema): number {
   return 0;
 }
 
+/**
+ * Treats plain string schemas as multiline user input while leaving formatted
+ * strings and fixed-choice fields to their specialized widgets.
+ */
 function isFreeTextSchema(schema: JSONSchema): boolean {
   if (
     schema.const !== undefined ||

--- a/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
+++ b/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
@@ -47,6 +47,10 @@ export function buildParamSchemaUiSchema(
     const choiceCount = getChoiceCount(propertySchema);
     if (choiceCount > 0 && choiceCount <= radioChoiceLimit) {
       uiSchema[name] = { 'ui:widget': 'radio' };
+      continue;
+    }
+    if (isFreeTextSchema(propertySchema)) {
+      uiSchema[name] = { 'ui:widget': 'textarea' };
     }
   }
 
@@ -128,4 +132,15 @@ function getChoiceCount(schema: JSONSchema): number {
     return schema.oneOf.filter((option) => option.const !== undefined).length;
   }
   return 0;
+}
+
+function isFreeTextSchema(schema: JSONSchema): boolean {
+  if (
+    schema.const !== undefined ||
+    getChoiceCount(schema) > 0 ||
+    typeof schema.format === 'string'
+  ) {
+    return false;
+  }
+  return inferScalarType(schema) === 'string';
 }

--- a/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
+++ b/ui/src/features/dags/components/dag-execution/paramSchemaForm.ts
@@ -9,6 +9,9 @@ export type ParamSchemaUiSchema = Record<string, Record<string, unknown>>;
 
 const radioChoiceLimit = 4;
 
+/**
+ * Builds typed schema form data from the legacy newline-delimited parameter text.
+ */
 export function buildParamSchemaFormData(
   schema: JSONSchema,
   defaultParams?: string
@@ -36,6 +39,9 @@ export function buildParamSchemaFormData(
   return formData;
 }
 
+/**
+ * Chooses compact widgets for schema-backed parameters without losing free-text editing.
+ */
 export function buildParamSchemaUiSchema(
   schema: JSONSchema
 ): ParamSchemaUiSchema {
@@ -57,12 +63,18 @@ export function buildParamSchemaUiSchema(
   return uiSchema;
 }
 
+/**
+ * Serializes schema form data into the parameter payload expected by the start API.
+ */
 export function stringifyParamSchemaFormData(
   formData: ParamSchemaFormData
 ): string {
   return JSON.stringify(formData);
 }
 
+/**
+ * Converts default string parameters to the scalar type declared by the JSON schema.
+ */
 function coerceParamSchemaValue(value: string, schema: JSONSchema): unknown {
   if (value.trim() === '') {
     return value;
@@ -91,6 +103,9 @@ function coerceParamSchemaValue(value: string, schema: JSONSchema): unknown {
   }
 }
 
+/**
+ * Infers the effective scalar type from direct, oneOf, or enum schema declarations.
+ */
 function inferScalarType(schema: JSONSchema): string | undefined {
   if (typeof schema.type === 'string') {
     return schema.type;
@@ -111,6 +126,9 @@ function inferScalarType(schema: JSONSchema): string | undefined {
   return undefined;
 }
 
+/**
+ * Maps a JavaScript scalar value back to the JSON schema type that represents it.
+ */
 function inferTypeFromValue(value: unknown): string | undefined {
   switch (typeof value) {
     case 'string':
@@ -124,6 +142,9 @@ function inferTypeFromValue(value: unknown): string | undefined {
   }
 }
 
+/**
+ * Counts fixed choices represented as enum values or oneOf constants.
+ */
 function getChoiceCount(schema: JSONSchema): number {
   if (Array.isArray(schema.enum)) {
     return schema.enum.length;

--- a/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
+++ b/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
@@ -46,6 +46,8 @@ function SchemaTextareaWidget<
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   React.useLayoutEffect(() => {
+    // RJSF's shadcn textarea widget does not expose a ref, so the wrapper
+    // applies the shared auto-grow behavior to the rendered textarea.
     const textarea = containerRef.current?.querySelector('textarea');
     if (textarea) {
       autoGrowTextarea(textarea);

--- a/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
+++ b/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
@@ -50,6 +50,10 @@ function SchemaTextareaWidget<
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const options = React.useMemo(
+    () => ({ ...props.options, rows: props.options.rows ?? 1 }),
+    [props.options]
+  );
 
   React.useLayoutEffect(() => {
     // RJSF's shadcn textarea widget does not expose a ref, so the wrapper
@@ -69,7 +73,14 @@ function SchemaTextareaWidget<
         }
       }}
     >
-      <TextareaWidget {...props} className={cn('bg-card', props.className)} />
+      <TextareaWidget
+        {...props}
+        options={options}
+        className={cn(
+          'bg-card min-h-9 resize-none overflow-hidden',
+          props.className
+        )}
+      />
     </div>
   );
 }

--- a/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
+++ b/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
@@ -28,6 +28,7 @@ import React from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
+import { autoGrowTextarea } from './textareaAutoGrow';
 
 function SchemaSelectWidget<
   T = any,
@@ -42,8 +43,26 @@ function SchemaTextareaWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useLayoutEffect(() => {
+    const textarea = containerRef.current?.querySelector('textarea');
+    if (textarea) {
+      autoGrowTextarea(textarea);
+    }
+  }, [props.value]);
+
   return (
-    <TextareaWidget {...props} className={cn('bg-card', props.className)} />
+    <div
+      ref={containerRef}
+      onInput={(event) => {
+        if (event.target instanceof HTMLTextAreaElement) {
+          autoGrowTextarea(event.target);
+        }
+      }}
+    >
+      <TextareaWidget {...props} className={cn('bg-card', props.className)} />
+    </div>
   );
 }
 

--- a/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
+++ b/ui/src/features/dags/components/dag-execution/schemaFormWidgets.tsx
@@ -30,6 +30,9 @@ import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { autoGrowTextarea } from './textareaAutoGrow';
 
+/**
+ * Applies Dagu's card background styling to RJSF's shadcn select widget.
+ */
 function SchemaSelectWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -38,6 +41,9 @@ function SchemaSelectWidget<
   return <SelectWidget {...props} className={cn('bg-card', props.className)} />;
 }
 
+/**
+ * Wraps RJSF's shadcn textarea so schema-backed text parameters auto-resize.
+ */
 function SchemaTextareaWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -68,6 +74,9 @@ function SchemaTextareaWidget<
   );
 }
 
+/**
+ * Renders boolean schema fields with the local checkbox component styling.
+ */
 function SchemaCheckboxWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -144,6 +153,9 @@ function SchemaCheckboxWidget<
   );
 }
 
+/**
+ * Renders small fixed-choice schema fields as accessible radio groups.
+ */
 function SchemaRadioWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,

--- a/ui/src/features/dags/components/dag-execution/textareaAutoGrow.ts
+++ b/ui/src/features/dags/components/dag-execution/textareaAutoGrow.ts
@@ -3,6 +3,9 @@
 
 const maxTextareaHeight = 150;
 
+/**
+ * Resizes a textarea to fit its content while preserving a bounded modal layout.
+ */
 export function autoGrowTextarea(el: HTMLTextAreaElement) {
   el.style.height = 'auto';
   const clamped = Math.min(el.scrollHeight, maxTextareaHeight);

--- a/ui/src/features/dags/components/dag-execution/textareaAutoGrow.ts
+++ b/ui/src/features/dags/components/dag-execution/textareaAutoGrow.ts
@@ -1,0 +1,11 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const maxTextareaHeight = 150;
+
+export function autoGrowTextarea(el: HTMLTextAreaElement) {
+  el.style.height = 'auto';
+  const clamped = Math.min(el.scrollHeight, maxTextareaHeight);
+  el.style.height = `${clamped}px`;
+  el.style.overflowY = el.scrollHeight > maxTextareaHeight ? 'auto' : 'hidden';
+}


### PR DESCRIPTION
## Summary
- render schema-backed free text params with textarea widgets so multiline values can be entered
- share textarea auto-grow behavior across typed/raw params and schema-backed textarea widgets
- add regression coverage for Shift+Enter and auto-grow behavior

## Root cause
Schema-backed string params were rendered through the default RJSF single-line input path, so the start modal global Enter handler treated Shift+Enter as a submit action instead of multiline text entry.

## Testing
- `pnpm vitest run src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts src/features/dags/components/dag-execution/__tests__/schemaFormWidgets.test.tsx`
- `pnpm typecheck`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Textarea fields in DAG parameter forms now auto-expand as you type (with a max height).
  * Short fixed-choice parameters now render as radio buttons for quicker selection.
  * Parameter forms now better handle default values and serialization when submitting.

* **Bug Fixes**
  * Pressing Shift+Enter in message inputs no longer submits the form (prevents accidental submits).

* **Tests**
  * Added tests for textarea auto-grow behavior, widget selection, and Shift+Enter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->