### PR TITLE
fix: support underscored docs and md URLs

### DIFF
--- a/internal/agent/doc.go
+++ b/internal/agent/doc.go
@@ -123,8 +123,8 @@ type DocStore interface {
 }
 
 // validDocIDRegexp matches a valid doc ID: segments separated by slashes.
-// Each segment starts with alphanumeric and can contain alphanumeric, underscore, dot, hyphen, or space.
-var validDocIDRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_. -]*(/[a-zA-Z0-9][a-zA-Z0-9_. -]*)*$`)
+// Each segment starts with alphanumeric or underscore and can contain alphanumeric, underscore, dot, hyphen, or space.
+var validDocIDRegexp = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_. -]*(/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*$`)
 
 // maxDocIDLength is the maximum allowed length for a doc ID.
 const maxDocIDLength = 256
@@ -138,7 +138,7 @@ func ValidateDocID(id string) error {
 		return fmt.Errorf("%w: exceeds maximum length of %d", ErrInvalidDocID, maxDocIDLength)
 	}
 	if !validDocIDRegexp.MatchString(id) {
-		return fmt.Errorf("%w: must match pattern [a-zA-Z0-9][a-zA-Z0-9_. -]*(/[a-zA-Z0-9][a-zA-Z0-9_. -]*)*", ErrInvalidDocID)
+		return fmt.Errorf("%w: must match pattern [a-zA-Z0-9_][a-zA-Z0-9_. -]*(/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*", ErrInvalidDocID)
 	}
 	return nil
 }

--- a/internal/agent/doc.go
+++ b/internal/agent/doc.go
@@ -124,7 +124,9 @@ type DocStore interface {
 
 // validDocIDRegexp matches a valid doc ID: segments separated by slashes.
 // Each segment starts with alphanumeric or underscore and can contain alphanumeric, underscore, dot, hyphen, or space.
-var validDocIDRegexp = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_. -]*(/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*$`)
+const validDocIDPattern = `^[a-zA-Z0-9_][a-zA-Z0-9_. -]*(/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*$`
+
+var validDocIDRegexp = regexp.MustCompile(validDocIDPattern)
 
 // maxDocIDLength is the maximum allowed length for a doc ID.
 const maxDocIDLength = 256
@@ -138,7 +140,7 @@ func ValidateDocID(id string) error {
 		return fmt.Errorf("%w: exceeds maximum length of %d", ErrInvalidDocID, maxDocIDLength)
 	}
 	if !validDocIDRegexp.MatchString(id) {
-		return fmt.Errorf("%w: must match pattern [a-zA-Z0-9_][a-zA-Z0-9_. -]*(/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*", ErrInvalidDocID)
+		return fmt.Errorf("%w: must match pattern %s", ErrInvalidDocID, validDocIDPattern)
 	}
 	return nil
 }

--- a/internal/persis/filedoc/store_test.go
+++ b/internal/persis/filedoc/store_test.go
@@ -358,10 +358,12 @@ func TestValidateDocID(t *testing.T) {
 	assert.NoError(t, agent.ValidateDocID("simple"))
 	assert.NoError(t, agent.ValidateDocID("with-hyphen"))
 	assert.NoError(t, agent.ValidateDocID("with_underscore"))
+	assert.NoError(t, agent.ValidateDocID("_leading-underscore"))
 	assert.NoError(t, agent.ValidateDocID("with space"))
 	assert.NoError(t, agent.ValidateDocID("with.dot"))
 	assert.NoError(t, agent.ValidateDocID("MixedCase"))
 	assert.NoError(t, agent.ValidateDocID("nested/path/doc"))
+	assert.NoError(t, agent.ValidateDocID("nested/_partial"))
 	assert.NoError(t, agent.ValidateDocID("123"))
 
 	// Invalid IDs.
@@ -415,6 +417,35 @@ func TestBuildTreeSkipsNonConformingFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.TotalCount)
 	assert.Equal(t, "good-doc", result.Items[0].ID)
+}
+
+func TestListTreeIncludesLeadingUnderscoreDocs(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(store.baseDir, "guides"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(store.baseDir, "_index.md"), []byte("top"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(store.baseDir, "guides", "_partial.md"), []byte("nested"), 0600))
+
+	result, err := store.List(ctx, defaultListOpts(1, 50))
+	require.NoError(t, err)
+	require.Len(t, result.Items, 2)
+	assert.Equal(t, "guides", result.Items[0].ID)
+	require.Len(t, result.Items[0].Children, 1)
+	assert.Equal(t, "guides/_partial", result.Items[0].Children[0].ID)
+	assert.Equal(t, "_index", result.Items[1].ID)
+}
+
+func TestGetLeadingUnderscoreDoc(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(store.baseDir, "_index.md"), []byte("content"), 0600))
+
+	doc, err := store.Get(ctx, "_index")
+	require.NoError(t, err)
+	assert.Equal(t, "_index", doc.ID)
+	assert.Equal(t, "content", doc.Content)
 }
 
 func TestSearchSkipsNonConformingFiles(t *testing.T) {

--- a/ui/src/pages/docs/index.tsx
+++ b/ui/src/pages/docs/index.tsx
@@ -45,6 +45,7 @@ import { CreateDocModal } from './components/CreateDocModal';
 import DocTabEditorPanel from './components/DocTabEditorPanel';
 import DocTreeSidebar from './components/DocTreeSidebar';
 import { RenameDocModal } from './components/RenameDocModal';
+import { normalizeDocPathFromURL } from './lib/doc-url';
 import type { ContextAction } from './components/DocArboristNode';
 
 function titleFromPath(docPath: string): string {
@@ -232,7 +233,7 @@ function DocsContent() {
         searchParams.get('workspace') ?? ''
       );
       const docWorkspace = queryWorkspace || null;
-      const decodedPath = decodeURIComponent(docPath);
+      const decodedPath = normalizeDocPathFromURL(decodeURIComponent(docPath));
       openDoc(decodedPath, titleFromPath(decodedPath), docWorkspace);
     }
   }, [location.pathname, location.search, openDoc, selectedWorkspace]);

--- a/ui/src/pages/docs/lib/__tests__/doc-url.test.ts
+++ b/ui/src/pages/docs/lib/__tests__/doc-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeDocPathFromURL } from '../doc-url';
+
+describe('normalizeDocPathFromURL', () => {
+  it('strips a markdown extension from URL paths', () => {
+    expect(normalizeDocPathFromURL('runbooks/deploy.md')).toBe(
+      'runbooks/deploy'
+    );
+  });
+
+  it('keeps leading-underscore names visible after stripping the extension', () => {
+    expect(normalizeDocPathFromURL('_index.md')).toBe('_index');
+    expect(normalizeDocPathFromURL('guides/_partial.md')).toBe(
+      'guides/_partial'
+    );
+  });
+
+  it('does not strip md text from non-markdown suffixes', () => {
+    expect(normalizeDocPathFromURL('notes.md.backup')).toBe('notes.md.backup');
+  });
+});

--- a/ui/src/pages/docs/lib/__tests__/doc-url.test.ts
+++ b/ui/src/pages/docs/lib/__tests__/doc-url.test.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { describe, expect, it } from 'vitest';
 import { normalizeDocPathFromURL } from '../doc-url';
 
@@ -5,6 +8,9 @@ describe('normalizeDocPathFromURL', () => {
   it('strips a markdown extension from URL paths', () => {
     expect(normalizeDocPathFromURL('runbooks/deploy.md')).toBe(
       'runbooks/deploy'
+    );
+    expect(normalizeDocPathFromURL('runbooks/DEPLOY.MD')).toBe(
+      'runbooks/DEPLOY'
     );
   });
 

--- a/ui/src/pages/docs/lib/__tests__/doc-validation.test.ts
+++ b/ui/src/pages/docs/lib/__tests__/doc-validation.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { validateDocPath } from '../doc-validation';
+
+describe('validateDocPath', () => {
+  it('accepts document path segments that start with underscores', () => {
+    expect(validateDocPath('_index')).toEqual({ isValid: true });
+    expect(validateDocPath('guides/_partial')).toEqual({ isValid: true });
+  });
+
+  it('continues to reject hidden dot files', () => {
+    expect(validateDocPath('.hidden').isValid).toBe(false);
+  });
+});

--- a/ui/src/pages/docs/lib/__tests__/doc-validation.test.ts
+++ b/ui/src/pages/docs/lib/__tests__/doc-validation.test.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { describe, expect, it } from 'vitest';
 import { validateDocPath } from '../doc-validation';
 

--- a/ui/src/pages/docs/lib/doc-url.ts
+++ b/ui/src/pages/docs/lib/doc-url.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 export function normalizeDocPathFromURL(path: string): string {
   return path.replace(/\.md$/i, '');
 }

--- a/ui/src/pages/docs/lib/doc-url.ts
+++ b/ui/src/pages/docs/lib/doc-url.ts
@@ -1,0 +1,3 @@
+export function normalizeDocPathFromURL(path: string): string {
+  return path.replace(/\.md$/i, '');
+}

--- a/ui/src/pages/docs/lib/doc-validation.ts
+++ b/ui/src/pages/docs/lib/doc-validation.ts
@@ -1,6 +1,10 @@
-export const DOC_PATH_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_. -]*(\/[a-zA-Z0-9][a-zA-Z0-9_. -]*)*$/;
+export const DOC_PATH_PATTERN =
+  /^[a-zA-Z0-9_][a-zA-Z0-9_. -]*(\/[a-zA-Z0-9_][a-zA-Z0-9_. -]*)*$/;
 
-export function validateDocPath(path: string): { isValid: boolean; error?: string } {
+export function validateDocPath(path: string): {
+  isValid: boolean;
+  error?: string;
+} {
   const trimmed = path.trim();
   if (!trimmed) {
     return { isValid: false, error: 'Path is required' };
@@ -11,7 +15,8 @@ export function validateDocPath(path: string): { isValid: boolean; error?: strin
   if (!DOC_PATH_PATTERN.test(trimmed)) {
     return {
       isValid: false,
-      error: 'Invalid path. Use letters, numbers, underscores, dots, hyphens, and spaces. Use / for directories.',
+      error:
+        'Invalid path. Use letters, numbers, underscores, dots, hyphens, and spaces. Use / for directories.',
     };
   }
   return { isValid: true };


### PR DESCRIPTION
## Summary
- allow document path segments that start with `_` so existing `_index.md`-style docs are listed and readable
- normalize docs page URLs that end in `.md` before opening the document tab
- add regression coverage for underscored docs, docs URL normalization, and docs path validation

## Root cause
Document ID validation required every path segment to start with an alphanumeric character, so `_`-prefixed Markdown files were treated as non-conforming and skipped or rejected. The docs page also used the raw route path as the document ID, so `/docs/foo.md` attempted to load `foo.md` instead of the stored `foo` document.

## Testing
- `go test ./internal/agent ./internal/persis/filedoc ./internal/service/frontend/api/v1`
- `pnpm test src/pages/docs/lib/__tests__/doc-url.test.ts src/pages/docs/lib/__tests__/doc-validation.test.ts`
- `pnpm typecheck`
- `make test TEST_TARGET="./internal/agent ./internal/persis/filedoc ./internal/service/frontend/api/v1"`
- `pnpm test`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents can now have IDs and path segments starting with underscores (e.g., `_index`, `guides/_partial`).
  * Document URLs are automatically normalized by stripping `.md` extensions when syncing tabs.

* **Tests**
  * Added comprehensive tests for underscore-prefixed document operations including creation, retrieval, and tree listing.
  * Added validation tests for document path format rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->