### PR TITLE
fix: preserve workspace label when creating DAGs

### DIFF
--- a/ui/src/components/DAGNameInputModal.tsx
+++ b/ui/src/components/DAGNameInputModal.tsx
@@ -122,10 +122,10 @@ export function DAGNameInputModal({
             <DialogTitle>{modalContent.title}</DialogTitle>
             <DialogDescription>
               {modalContent.description}
-              <div className="mt-1 font-mono text-xs bg-muted p-1 rounded">
-                Pattern: {DAG_NAME_PATTERN_STRING}
-              </div>
             </DialogDescription>
+            <div className="mt-1 font-mono text-xs bg-muted p-1 rounded text-muted-foreground">
+              Pattern: {DAG_NAME_PATTERN_STRING}
+            </div>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-4 items-center gap-4">

--- a/ui/src/features/dags/components/common/CreateDAGButton.tsx
+++ b/ui/src/features/dags/components/common/CreateDAGButton.tsx
@@ -10,6 +10,11 @@ import React from 'react';
 import { DAGNameInputModal } from '../../../../components/DAGNameInputModal';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { useClient } from '../../../../hooks/api';
+import { defaultDAGSpec } from '../../../../lib/dagSpec';
+import {
+  sanitizeWorkspaceSelection,
+  WorkspaceKind,
+} from '../../../../lib/workspace';
 
 /**
  * CreateDAGButton displays a button that opens a prompt to create a new DAG
@@ -22,6 +27,9 @@ function CreateDAGButton() {
   const [error, setError] = React.useState<string | null>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
+  const workspaceSelection = sanitizeWorkspaceSelection(
+    appBarContext.workspaceSelection
+  );
 
   if (!canWrite) {
     return null;
@@ -45,6 +53,11 @@ function CreateDAGButton() {
         },
         body: {
           name,
+          spec:
+            workspaceSelection.kind === WorkspaceKind.workspace &&
+            workspaceSelection.workspace
+              ? defaultDAGSpec(workspaceSelection.workspace)
+              : undefined,
         },
       });
 

--- a/ui/src/features/dags/components/common/__tests__/CreateDAGButton.test.tsx
+++ b/ui/src/features/dags/components/common/__tests__/CreateDAGButton.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { WorkspaceKind } from '@/lib/workspace';
+import CreateDAGButton from '../CreateDAGButton';
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useCanWrite: () => true,
+}));
+
+vi.mock('@/hooks/api', () => ({
+  useClient: () => ({
+    POST: postMock,
+  }),
+}));
+
+describe('CreateDAGButton', () => {
+  it('creates new DAGs with the selected workspace label', async () => {
+    postMock.mockResolvedValueOnce({
+      error: { message: 'stop before redirect' },
+    });
+
+    render(
+      <AppBarContext.Provider
+        value={{
+          title: '',
+          setTitle: vi.fn(),
+          remoteNodes: ['local'],
+          setRemoteNodes: vi.fn(),
+          selectedRemoteNode: 'local',
+          selectRemoteNode: vi.fn(),
+          workspaces: [{ id: 'workspace-1', name: 'ops' }],
+          workspaceSelection: {
+            kind: WorkspaceKind.workspace,
+            workspace: 'ops',
+          },
+          selectWorkspace: vi.fn(),
+        }}
+      >
+        <CreateDAGButton />
+      </AppBarContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create new DAG' }));
+    fireEvent.change(screen.getByLabelText('DAG Name'), {
+      target: { value: 'header-new-dag' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+
+    expect(postMock).toHaveBeenCalledWith('/dags', {
+      params: {
+        query: {
+          remoteNode: 'local',
+        },
+      },
+      body: {
+        name: 'header-new-dag',
+        spec: expect.stringContaining('workspace=ops'),
+      },
+    });
+  });
+});

--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -15,6 +15,7 @@ import { Textarea } from '@/components/ui/textarea';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -472,6 +473,9 @@ function StartDAGModal({
           <DialogTitle>
             {forceEnqueue ? 'Enqueue the DAG' : 'Start the DAG'}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Configure the DAG run before submitting it.
+          </DialogDescription>
         </DialogHeader>
 
         {(paramsReadOnly || runIdReadOnly) && (

--- a/ui/src/pages/agent-settings/ModelFormModal.tsx
+++ b/ui/src/pages/agent-settings/ModelFormModal.tsx
@@ -16,6 +16,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -246,6 +247,9 @@ export function ModelFormModal({
       <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Model' : 'Add Model'}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Configure the model settings used by the agent.
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-3 py-3">


### PR DESCRIPTION
## Summary
- Add the selected workspace label to DAGs created from the Workflows header New button.
- Add a regression test for the selected-workspace create payload.
- Fix dialog accessibility/DOM warnings uncovered while validating the create flow.

## Root cause
The header create path posted only the DAG name, unlike the empty-state create path that initialized the spec with the selected workspace label. New DAGs created from the header were therefore treated as default-workspace DAGs and failed the selected-workspace check.

## Tests
- `pnpm vitest run src/features/dags/components/common/__tests__/CreateDAGButton.test.tsx`
- `pnpm vitest run src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx`
- `pnpm vitest run src/pages/agent-settings/__tests__/ModelFormModal.test.tsx`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace-aware default specifications are now automatically included when creating DAGs
* **Accessibility**
  * Improved screen reader support for DAG execution and model configuration modals
* **UI Updates**
  * Refined DAG name input modal layout for better organization
* **Tests**
  * Added comprehensive test coverage for DAG creation with workspace configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->