### PR TITLE
feat: add agent session search tool

### DIFF
--- a/internal/agent/delegate.go
+++ b/internal/agent/delegate.go
@@ -325,6 +325,7 @@ func runSingleDelegate(ctx ToolContext, task delegateTask) singleDelegateResult 
 		Hooks:         dc.Hooks,
 		SafeMode:      ctx.SafeMode,
 		User:          dc.User,
+		SessionStore:  dc.SessionStore,
 		OnWorking: func(working bool) {
 			subMgr.SetWorking(working)
 			if !working {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -516,6 +516,9 @@ func (l *Loop) executeTool(ctx context.Context, tc llm.ToolCall) ToolOut {
 		WaitUserResponse: l.waitUserResponse,
 		SafeMode:         safeMode,
 		Role:             user.Role,
+		SessionID:        l.sessionID,
+		User:             user,
+		SessionStore:     l.sessionStore,
 		Delegate:         delegate,
 	}, input)
 

--- a/internal/agent/policy_test.go
+++ b/internal/agent/policy_test.go
@@ -23,6 +23,7 @@ func TestResolveToolPolicy_Defaults(t *testing.T) {
 	assert.True(t, resolved.Tools["think"])
 	assert.True(t, resolved.Tools["navigate"])
 	assert.True(t, resolved.Tools["ask_user"])
+	assert.True(t, resolved.Tools["session_search"])
 	assert.True(t, resolved.Tools["delegate"])
 	assert.Equal(t, BashDefaultBehaviorAllow, resolved.Bash.DefaultBehavior)
 	assert.Equal(t, BashDenyBehaviorAskUser, resolved.Bash.DenyBehavior)

--- a/internal/agent/session_search.go
+++ b/internal/agent/session_search.go
@@ -237,11 +237,11 @@ func sessionSearchIndex(text, queryLower string) int {
 		return -1
 	}
 	lowerText := strings.ToLower(text)
-	matchByteIndex := strings.Index(lowerText, queryLower)
-	if matchByteIndex < 0 {
+	before, _, ok := strings.Cut(lowerText, queryLower)
+	if !ok {
 		return -1
 	}
-	return utf8.RuneCountInString(lowerText[:matchByteIndex])
+	return utf8.RuneCountInString(before)
 }
 
 func sessionSearchSnippetText(text, query string, matchRuneIndex int) string {

--- a/internal/agent/session_search.go
+++ b/internal/agent/session_search.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dagucloud/dagu/internal/llm"
 )
@@ -17,6 +19,7 @@ const (
 	sessionSearchToolName           = "session_search"
 	defaultSessionSearchLimit       = 5
 	maxSessionSearchLimit           = 20
+	sessionSearchScanMultiplier     = 20
 	maxSessionSearchSnippets        = 3
 	sessionSearchSnippetRunesBefore = 80
 	sessionSearchSnippetRunesAfter  = 140
@@ -112,9 +115,10 @@ func sessionSearchRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	}
 
 	limit := normalizeSessionSearchLimit(args.Limit)
+	candidates := prepareSessionSearchCandidates(sessions, limit)
 	results := make([]sessionSearchResult, 0, limit)
 	queryLower := strings.ToLower(query)
-	for _, sess := range sessions {
+	for _, sess := range candidates {
 		if sess == nil || sess.ID == "" || sess.ID == ctx.SessionID {
 			continue
 		}
@@ -145,6 +149,27 @@ func normalizeSessionSearchLimit(limit int) int {
 		return defaultSessionSearchLimit
 	}
 	return min(limit, maxSessionSearchLimit)
+}
+
+func prepareSessionSearchCandidates(sessions []*Session, limit int) []*Session {
+	candidates := append([]*Session(nil), sessions...)
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left := candidates[i]
+		right := candidates[j]
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		return left.UpdatedAt.After(right.UpdatedAt)
+	})
+
+	maxCandidates := limit * sessionSearchScanMultiplier
+	if maxCandidates > 0 && len(candidates) > maxCandidates {
+		return candidates[:maxCandidates]
+	}
+	return candidates
 }
 
 func searchSessionMessages(ctx context.Context, store SessionStore, sess *Session, query, queryLower string) (sessionSearchResult, error) {
@@ -208,17 +233,15 @@ func sessionSearchMessageText(msg Message) string {
 }
 
 func sessionSearchIndex(text, queryLower string) int {
-	queryRuneLen := len([]rune(queryLower))
-	if queryRuneLen == 0 {
+	if queryLower == "" {
 		return -1
 	}
-	runes := []rune(text)
-	for i := 0; i+queryRuneLen <= len(runes); i++ {
-		if strings.ToLower(string(runes[i:i+queryRuneLen])) == queryLower {
-			return i
-		}
+	lowerText := strings.ToLower(text)
+	matchByteIndex := strings.Index(lowerText, queryLower)
+	if matchByteIndex < 0 {
+		return -1
 	}
-	return -1
+	return utf8.RuneCountInString(lowerText[:matchByteIndex])
 }
 
 func sessionSearchSnippetText(text, query string, matchRuneIndex int) string {

--- a/internal/agent/session_search.go
+++ b/internal/agent/session_search.go
@@ -1,0 +1,282 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/llm"
+)
+
+const (
+	sessionSearchToolName           = "session_search"
+	defaultSessionSearchLimit       = 5
+	maxSessionSearchLimit           = 20
+	maxSessionSearchSnippets        = 3
+	sessionSearchSnippetRunesBefore = 80
+	sessionSearchSnippetRunesAfter  = 140
+)
+
+func init() {
+	RegisterTool(ToolRegistration{
+		Name:           sessionSearchToolName,
+		Label:          "Session Search",
+		Description:    "Search past agent session transcripts",
+		DefaultEnabled: true,
+		Factory:        func(_ ToolConfig) *AgentTool { return NewSessionSearchTool() },
+	})
+}
+
+// SessionSearchInput defines the input parameters for the session_search tool.
+type SessionSearchInput struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+type sessionSearchResult struct {
+	session       *Session
+	metadataMatch bool
+	snippets      []sessionSearchSnippet
+}
+
+type sessionSearchSnippet struct {
+	messageType MessageType
+	sequenceID  int64
+	createdAt   time.Time
+	content     string
+}
+
+// NewSessionSearchTool creates a tool for searching persisted agent sessions.
+func NewSessionSearchTool() *AgentTool {
+	return &AgentTool{
+		Tool: llm.Tool{
+			Type: "function",
+			Function: llm.ToolFunction{
+				Name:        sessionSearchToolName,
+				Description: "Search past persisted agent session transcripts for the current user. Use this when the user references earlier conversations or prior task context.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"query": map[string]any{
+							"type":        "string",
+							"description": "Case-insensitive text to search for in prior session titles, DAG names, and transcript messages",
+						},
+						"limit": map[string]any{
+							"type":        "integer",
+							"description": "Maximum number of sessions to return (default 5, max 20)",
+						},
+					},
+					"required": []string{"query"},
+				},
+			},
+		},
+		Run: sessionSearchRun,
+		Audit: &AuditInfo{
+			Action:          "session_search",
+			DetailExtractor: ExtractFields("query", "limit"),
+		},
+	}
+}
+
+func sessionSearchRun(ctx ToolContext, input json.RawMessage) ToolOut {
+	var args SessionSearchInput
+	if err := json.Unmarshal(input, &args); err != nil {
+		return toolError("Failed to parse input: %v", err)
+	}
+
+	query := strings.TrimSpace(args.Query)
+	if query == "" {
+		return toolError("Query is required")
+	}
+	if ctx.SessionStore == nil {
+		return toolError("Session store is not available")
+	}
+	userID := strings.TrimSpace(ctx.User.UserID)
+	if userID == "" {
+		return toolError("User context is required")
+	}
+
+	callCtx := ctx.Context
+	if callCtx == nil {
+		callCtx = context.Background()
+	}
+
+	sessions, err := ctx.SessionStore.ListSessions(callCtx, userID)
+	if err != nil {
+		return toolError("Failed to list sessions: %v", err)
+	}
+
+	limit := normalizeSessionSearchLimit(args.Limit)
+	results := make([]sessionSearchResult, 0, limit)
+	queryLower := strings.ToLower(query)
+	for _, sess := range sessions {
+		if sess == nil || sess.ID == "" || sess.ID == ctx.SessionID {
+			continue
+		}
+
+		result, err := searchSessionMessages(callCtx, ctx.SessionStore, sess, query, queryLower)
+		if err != nil {
+			return toolError("Failed to search session %s: %v", sess.ID, err)
+		}
+		if !result.metadataMatch && len(result.snippets) == 0 {
+			continue
+		}
+
+		results = append(results, result)
+		if len(results) >= limit {
+			break
+		}
+	}
+
+	if len(results) == 0 {
+		return ToolOut{Content: fmt.Sprintf("No matching past sessions found for %q.", query)}
+	}
+
+	return ToolOut{Content: formatSessionSearchResults(query, results)}
+}
+
+func normalizeSessionSearchLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSessionSearchLimit
+	}
+	return min(limit, maxSessionSearchLimit)
+}
+
+func searchSessionMessages(ctx context.Context, store SessionStore, sess *Session, query, queryLower string) (sessionSearchResult, error) {
+	result := sessionSearchResult{
+		session:       sess,
+		metadataMatch: sessionMetadataMatches(sess, queryLower),
+	}
+
+	messages, err := store.GetMessages(ctx, sess.ID)
+	if err != nil {
+		return result, err
+	}
+
+	for _, msg := range messages {
+		text := sessionSearchMessageText(msg)
+		if text == "" {
+			continue
+		}
+		matchRuneIndex := sessionSearchIndex(text, queryLower)
+		if matchRuneIndex < 0 {
+			continue
+		}
+		result.snippets = append(result.snippets, sessionSearchSnippet{
+			messageType: msg.Type,
+			sequenceID:  msg.SequenceID,
+			createdAt:   msg.CreatedAt,
+			content:     sessionSearchSnippetText(text, query, matchRuneIndex),
+		})
+		if len(result.snippets) >= maxSessionSearchSnippets {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func sessionMetadataMatches(sess *Session, queryLower string) bool {
+	fields := []string{sess.ID, sess.Title, sess.DAGName, sess.ParentSessionID, sess.DelegateTask}
+	for _, field := range fields {
+		if strings.Contains(strings.ToLower(field), queryLower) {
+			return true
+		}
+	}
+	return false
+}
+
+func sessionSearchMessageText(msg Message) string {
+	parts := make([]string, 0, 2+len(msg.ToolResults))
+	if msg.Content != "" {
+		parts = append(parts, msg.Content)
+	}
+	if msg.UserPrompt != nil {
+		parts = append(parts, msg.UserPrompt.Question)
+	}
+	for _, result := range msg.ToolResults {
+		if result.Content != "" {
+			parts = append(parts, result.Content)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func sessionSearchIndex(text, queryLower string) int {
+	queryRuneLen := len([]rune(queryLower))
+	if queryRuneLen == 0 {
+		return -1
+	}
+	runes := []rune(text)
+	for i := 0; i+queryRuneLen <= len(runes); i++ {
+		if strings.ToLower(string(runes[i:i+queryRuneLen])) == queryLower {
+			return i
+		}
+	}
+	return -1
+}
+
+func sessionSearchSnippetText(text, query string, matchRuneIndex int) string {
+	queryRunes := len([]rune(query))
+	runes := []rune(text)
+
+	start := max(0, matchRuneIndex-sessionSearchSnippetRunesBefore)
+	end := min(len(runes), matchRuneIndex+queryRunes+sessionSearchSnippetRunesAfter)
+
+	snippet := strings.Join(strings.Fields(string(runes[start:end])), " ")
+	if start > 0 {
+		snippet = "..." + snippet
+	}
+	if end < len(runes) {
+		snippet += "..."
+	}
+	return snippet
+}
+
+func formatSessionSearchResults(query string, results []sessionSearchResult) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "Found %d matching past session(s) for %q:\n", len(results), query)
+	for i, result := range results {
+		sess := result.session
+		fmt.Fprintf(&out, "\n%d. session_id: %s", i+1, sess.ID)
+		if sess.Title != "" {
+			fmt.Fprintf(&out, " | title: %s", sess.Title)
+		}
+		if sess.DAGName != "" {
+			fmt.Fprintf(&out, " | dag: %s", sess.DAGName)
+		}
+		if sess.ParentSessionID != "" {
+			fmt.Fprintf(&out, " | parent: %s", sess.ParentSessionID)
+		}
+		if !sess.UpdatedAt.IsZero() {
+			fmt.Fprintf(&out, " | updated: %s", sess.UpdatedAt.Format(time.RFC3339))
+		}
+		out.WriteByte('\n')
+		if result.metadataMatch && len(result.snippets) == 0 {
+			out.WriteString("   - matched session metadata\n")
+		}
+		for _, snippet := range result.snippets {
+			fmt.Fprintf(&out, "   - %s", sessionSearchMessageType(snippet.messageType))
+			if snippet.sequenceID > 0 {
+				fmt.Fprintf(&out, " seq=%d", snippet.sequenceID)
+			}
+			if !snippet.createdAt.IsZero() {
+				fmt.Fprintf(&out, " at=%s", snippet.createdAt.Format(time.RFC3339))
+			}
+			fmt.Fprintf(&out, ": %s\n", snippet.content)
+		}
+	}
+	return out.String()
+}
+
+func sessionSearchMessageType(messageType MessageType) string {
+	if messageType == "" {
+		return "message"
+	}
+	return string(messageType)
+}

--- a/internal/agent/session_search_test.go
+++ b/internal/agent/session_search_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sessionSearchInput(t *testing.T, query string, limit int) json.RawMessage {
+	t.Helper()
+	input := map[string]any{"query": query}
+	if limit > 0 {
+		input["limit"] = limit
+	}
+	b, err := json.Marshal(input)
+	require.NoError(t, err)
+	return b
+}
+
+func seedSearchSession(t *testing.T, store *mockSessionStore, sess *Session, messages ...Message) {
+	t.Helper()
+	require.NoError(t, store.CreateSession(context.Background(), sess))
+	for i := range messages {
+		require.NoError(t, store.AddMessage(context.Background(), sess.ID, &messages[i]))
+	}
+}
+
+func TestSessionSearchTool_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("searches persisted sessions for current user only", func(t *testing.T) {
+		t.Parallel()
+		store := newMockSessionStore()
+		now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+		seedSearchSession(t, store, &Session{
+			ID:        "past-session",
+			UserID:    "admin",
+			Title:     "Import cleanup",
+			DAGName:   "daily-import",
+			CreatedAt: now.Add(-2 * time.Hour),
+			UpdatedAt: now.Add(-time.Hour),
+		}, Message{
+			Type:       MessageTypeUser,
+			SequenceID: 1,
+			Content:    "Can you debug the import failure?",
+			CreatedAt:  now.Add(-2 * time.Hour),
+		}, Message{
+			Type:       MessageTypeAssistant,
+			SequenceID: 2,
+			Content:    "The fix was to write reports under DAGU_DOCS_DIR.",
+			CreatedAt:  now.Add(-time.Hour),
+		})
+		seedSearchSession(t, store, &Session{
+			ID:        "current-session",
+			UserID:    "admin",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}, Message{
+			Type:       MessageTypeUser,
+			SequenceID: 1,
+			Content:    "DAGU_DOCS_DIR in the current turn should not be returned.",
+			CreatedAt:  now,
+		})
+		seedSearchSession(t, store, &Session{
+			ID:        "other-user-session",
+			UserID:    "other-user",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}, Message{
+			Type:       MessageTypeUser,
+			SequenceID: 1,
+			Content:    "Other user also mentioned DAGU_DOCS_DIR.",
+			CreatedAt:  now,
+		})
+
+		result := NewSessionSearchTool().Run(ToolContext{
+			Context:      context.Background(),
+			SessionID:    "current-session",
+			User:         UserIdentity{UserID: "admin"},
+			SessionStore: store,
+		}, sessionSearchInput(t, "dagu_docs_dir", 5))
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "past-session")
+		assert.Contains(t, result.Content, "daily-import")
+		assert.Contains(t, result.Content, "DAGU_DOCS_DIR")
+		assert.NotContains(t, result.Content, "current-session")
+		assert.NotContains(t, result.Content, "other-user-session")
+		assert.NotContains(t, result.Content, "Other user")
+	})
+
+	t.Run("requires query", func(t *testing.T) {
+		t.Parallel()
+
+		result := NewSessionSearchTool().Run(ToolContext{
+			Context:      context.Background(),
+			User:         UserIdentity{UserID: "admin"},
+			SessionStore: newMockSessionStore(),
+		}, sessionSearchInput(t, "   ", 0))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "Query is required")
+	})
+
+	t.Run("requires session store", func(t *testing.T) {
+		t.Parallel()
+
+		result := NewSessionSearchTool().Run(ToolContext{
+			Context: context.Background(),
+			User:    UserIdentity{UserID: "admin"},
+		}, sessionSearchInput(t, "anything", 0))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "Session store is not available")
+	})
+}

--- a/internal/agent/session_search_test.go
+++ b/internal/agent/session_search_test.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -120,4 +121,93 @@ func TestSessionSearchTool_Run(t *testing.T) {
 		assert.True(t, result.IsError)
 		assert.Contains(t, result.Content, "Session store is not available")
 	})
+
+	t.Run("returns empty result message", func(t *testing.T) {
+		t.Parallel()
+		store := newMockSessionStore()
+		now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+		seedSearchSession(t, store, &Session{
+			ID:        "past-session",
+			UserID:    "admin",
+			Title:     "Unrelated task",
+			CreatedAt: now.Add(-time.Hour),
+			UpdatedAt: now.Add(-time.Hour),
+		}, Message{
+			Type:       MessageTypeUser,
+			SequenceID: 1,
+			Content:    "This transcript does not contain the target phrase.",
+			CreatedAt:  now.Add(-time.Hour),
+		})
+
+		result := NewSessionSearchTool().Run(ToolContext{
+			Context:      context.Background(),
+			User:         UserIdentity{UserID: "admin"},
+			SessionStore: store,
+		}, sessionSearchInput(t, "missing needle", 0))
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, `No matching past sessions found for "missing needle".`)
+	})
+
+	t.Run("returns metadata-only matches", func(t *testing.T) {
+		t.Parallel()
+		store := newMockSessionStore()
+		now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+		seedSearchSession(t, store, &Session{
+			ID:        "metadata-session",
+			UserID:    "admin",
+			Title:     "Release notes",
+			DAGName:   "publish-docs",
+			CreatedAt: now.Add(-2 * time.Hour),
+			UpdatedAt: now.Add(-time.Hour),
+		}, Message{
+			Type:       MessageTypeAssistant,
+			SequenceID: 1,
+			Content:    "This transcript should not be shown because only metadata matched.",
+			CreatedAt:  now.Add(-time.Hour),
+		})
+
+		result := NewSessionSearchTool().Run(ToolContext{
+			Context:      context.Background(),
+			User:         UserIdentity{UserID: "admin"},
+			SessionStore: store,
+		}, sessionSearchInput(t, "release", 5))
+
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Content, "metadata-session")
+		assert.Contains(t, result.Content, "Release notes")
+		assert.Contains(t, result.Content, "matched session metadata")
+		assert.NotContains(t, result.Content, "This transcript should not be shown")
+	})
+}
+
+func TestSessionSearchLimitHelpers(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, defaultSessionSearchLimit, normalizeSessionSearchLimit(0))
+	assert.Equal(t, defaultSessionSearchLimit, normalizeSessionSearchLimit(-1))
+	assert.Equal(t, 3, normalizeSessionSearchLimit(3))
+	assert.Equal(t, maxSessionSearchLimit, normalizeSessionSearchLimit(maxSessionSearchLimit+1))
+}
+
+func TestPrepareSessionSearchCandidates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	total := maxSessionSearchLimit*sessionSearchScanMultiplier + 5
+	sessions := make([]*Session, 0, total)
+	for i := 0; i < total; i++ {
+		sessions = append(sessions, &Session{
+			ID:        fmt.Sprintf("session-%03d", i),
+			UserID:    "admin",
+			UpdatedAt: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	candidates := prepareSessionSearchCandidates(sessions, maxSessionSearchLimit)
+
+	assert.Len(t, candidates, maxSessionSearchLimit*sessionSearchScanMultiplier)
+	assert.Equal(t, "session-404", candidates[0].ID)
+	assert.Equal(t, "session-005", candidates[len(candidates)-1].ID)
+	assert.Equal(t, "session-000", sessions[0].ID)
 }

--- a/internal/agent/session_search_test.go
+++ b/internal/agent/session_search_test.go
@@ -196,7 +196,7 @@ func TestPrepareSessionSearchCandidates(t *testing.T) {
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	total := maxSessionSearchLimit*sessionSearchScanMultiplier + 5
 	sessions := make([]*Session, 0, total)
-	for i := 0; i < total; i++ {
+	for i := range total {
 		sessions = append(sessions, &Session{
 			ID:        fmt.Sprintf("session-%03d", i),
 			UserID:    "admin",

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -4,7 +4,7 @@
 </identity>
 {{else}}
 <identity>
-You are Dagu Agent, an intelligent assistant specialized in workflow automation and DAG management. ou are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
+You are Dagu Agent, an intelligent assistant specialized in workflow automation and DAG management. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 You operate inside the Dagu Web UI and help users create, review, debug, and manage DAG workflows safely and correctly.
 
 Dagu Docs: https://docs.dagu.sh
@@ -17,7 +17,7 @@ Write memories as declarative facts, not instructions to yourself. 'User prefers
 When the user references something from a past conversation or you suspect relevant cross-session context exists, use session_search to recall it before asking them to repeat themselves.
 
 When approaching a complex task, check if there's any available runbook. After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a runbook so you can refer it next time.
-When using a runbook and finding it outdated, incomplete, or wrong, patch it immediately — don't wait to be asked. Runbook that aren't maintained become liabilities.
+When using a runbook and finding it outdated, incomplete, or wrong, patch it immediately — don't wait to be asked. Runbooks that aren't maintained become liabilities.
 
 # Tool-use enforcement
 You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it. When you say you will perform an action (e.g. 'I will run the tests', 'Let me check the file', 'I will create the project'), you MUST immediately make the corresponding tool call in the same response. Never end your turn with a promise of future action — execute it now.

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -229,6 +229,7 @@ Actively report your progress during multi-step work so the user is not left wai
 - `read`: Read file contents. Use before editing any file.
 - `patch`: Create or edit files using unified diff format.
 - `think`: Reason through complex multi-step tasks before acting.
+- `session_search`: Search past persisted session transcripts for previous conversations and task context.
 - `navigate`: Open a UI page (/dags/<name>, /dag-runs/<name>/<id>, /docs, /docs/<doc-id>).
 - `delegate`: Spawn a sub-agent for a focused sub-task. The sub-agent works independently with the same tools and returns a summary. Supports a `skills` parameter on each task to pre-load skill knowledge into the sub-agent. You can delegate multiple tasks simultaneously.
 - `search_skills`: Discover available skills by keyword or label. Returns summaries without loading full knowledge.

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -4,16 +4,58 @@
 </identity>
 {{else}}
 <identity>
-You are Dagu Assistant, an AI assistant specialized in workflow automation and DAG management for Dagu.
+You are Dagu Agent, an intelligent assistant specialized in workflow automation and DAG management. ou are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 You operate inside the Dagu Web UI and help users create, review, debug, and manage DAG workflows safely and correctly.
+
+Dagu Docs: https://docs.dagu.sh
+
+You have persistent memory across sessions. Save durable facts using the memory tool: user preferences, environment details, tool quirks, and stable conventions. Memory is injected into every turn, so keep it compact and focused on facts that will still matter later.
+Prioritize what reduces future user steering — the most valuable memory is one that prevents the user from having to correct or remind you again. User preferences and recurring corrections matter more than procedural task details.
+Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO state to memory; use session_search to recall those from past transcripts. If you've discovered a new way to do something, solved a problem that could be necessary later, save it as a skill with the skill tool.
+Write memories as declarative facts, not instructions to yourself. 'User prefers concise responses' ✓ — 'Always respond concisely' ✗. 'Project uses pytest with xdist' ✓ — 'Run tests with pytest -n 4' ✗. Imperative phrasing gets re-read as a directive in later sessions and can cause repeated work or override the user's current request. Procedures and workflows belong in workflow definition and runbooks, not memory.
+
+When the user references something from a past conversation or you suspect relevant cross-session context exists, use session_search to recall it before asking them to repeat themselves.
+
+When approaching a complex task, check if there's any available runbook. After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a runbook so you can refer it next time.
+When using a runbook and finding it outdated, incomplete, or wrong, patch it immediately — don't wait to be asked. Runbook that aren't maintained become liabilities.
+
+# Tool-use enforcement
+You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it. When you say you will perform an action (e.g. 'I will run the tests', 'Let me check the file', 'I will create the project'), you MUST immediately make the corresponding tool call in the same response. Never end your turn with a promise of future action — execute it now.
+Keep working until the task is actually complete. Do not stop with a summary of what you plan to do next time. If you have tools available that can accomplish the task, use them instead of telling the user what you would do.
+Every response should either (a) contain tool calls that make progress, or (b) deliver a final result to the user. Responses that only describe intentions without acting are not acceptable.
 </identity>
 {{end}}
 
+# Execution discipline
+<tool_persistence>
+- Use tools whenever they improve correctness, completeness, or grounding.
+- Do not stop early when another tool call would materially improve the result.
+- If a tool returns empty or partial results, retry with a different query or strategy before giving up.
+- Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.
+</tool_persistence>
+
+<verification>
+Before finalizing your response:
+- Correctness: does the output satisfy every stated requirement?
+- Grounding: are factual claims backed by tool outputs or provided context?
+- Formatting: does the output match the requested format or schema?
+- Safety: if the next step has side effects (file writes, commands, API calls), confirm scope before executing.
+- DAG validity: ensure the DAG actually works by running test DAG and verify commands availability and results without guessing that it works.
+</verification>
+
+<missing_context>
+- If required context is missing, do NOT guess or hallucinate an answer.
+- Use the appropriate lookup tool when missing information is retrievable (search_files, web_search, read_file, etc.).
+- Ask a clarifying question only when the information cannot be retrieved by tools.
+- If you must proceed with incomplete information, label assumptions explicitly.
+</missing_context>
+
 <environment>
 - DAGs Directory: {{.DAGsDir}}
-- Docs Directory: {{.DocsDir}}
+- Runbook Directory: {{.DocsDir}}
 - Logs Directory: {{.LogDir}}
 - Data Directory: {{.DataDir}}
+- Session Store Directory: {{.SessionsDir}}
 - Config File: {{.ConfigFile}}
 - Base Config: {{.BaseConfigFile}} (global defaults inherited by all DAGs)
 - Working Directory: {{.WorkingDir}}

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -217,6 +217,15 @@ func TestGenerateSystemPrompt(t *testing.T) {
 		assert.Contains(t, result, "Do not stay silent until the final answer")
 		assert.Contains(t, result, "what you did, what you found, and what you will do next")
 	})
+
+	t.Run("documents session search tool", func(t *testing.T) {
+		t.Parallel()
+		env := EnvironmentInfo{DAGsDir: "/dags"}
+
+		result := GenerateSystemPrompt(SystemPromptParams{Env: env, Role: auth.RoleDeveloper})
+
+		assert.Contains(t, result, "`session_search`: Search past persisted session transcripts")
+	})
 }
 
 func TestFallbackPrompt(t *testing.T) {

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -19,6 +19,7 @@ func TestGenerateSystemPrompt(t *testing.T) {
 			DAGsDir:        "/dags",
 			DocsDir:        "/dags/docs",
 			LogDir:         "/logs",
+			SessionsDir:    "/data/agent/sessions",
 			WorkingDir:     "/work",
 			BaseConfigFile: "/config/base.yaml",
 		}
@@ -28,6 +29,7 @@ func TestGenerateSystemPrompt(t *testing.T) {
 		assert.NotEmpty(t, result)
 		assert.Contains(t, result, "/dags")
 		assert.Contains(t, result, "/dags/docs")
+		assert.Contains(t, result, "Session Store Directory: /data/agent/sessions")
 		assert.Contains(t, result, "/config/base.yaml")
 		assert.Contains(t, result, "Authenticated role: developer")
 	})

--- a/internal/agent/tool_registry_test.go
+++ b/internal/agent/tool_registry_test.go
@@ -28,6 +28,7 @@ func TestRegisteredTools_ContainsAllExpected(t *testing.T) {
 	expected := []string{
 		"bash", "read", "patch", "think",
 		"navigate", "ask_user",
+		"session_search",
 		"delegate",
 		"remote_agent", "list_contexts",
 	}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -436,6 +436,8 @@ type EnvironmentInfo struct {
 	LogDir string
 	// DataDir is the directory for data storage.
 	DataDir string
+	// SessionsDir is the directory for persisted agent sessions.
+	SessionsDir string
 	// ConfigFile is the path to the configuration file.
 	ConfigFile string
 	// WorkingDir is the current working directory.

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -387,6 +387,12 @@ type ToolContext struct {
 	// Role is the authenticated role of the current user.
 	// Empty means role checks should be skipped (e.g., auth-disabled compatibility).
 	Role auth.Role
+	// SessionID is the current agent session ID.
+	SessionID string
+	// User is the authenticated user for this tool call.
+	User UserIdentity
+	// SessionStore provides read access to persisted agent sessions.
+	SessionStore SessionStore
 	// Delegate provides sub-agent spawning capability. Nil when not available.
 	Delegate *DelegateContext
 }

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -783,6 +783,7 @@ func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore 
 			DocsDir:        paths.DocsDir,
 			LogDir:         paths.LogDir,
 			DataDir:        paths.DataDir,
+			SessionsDir:    paths.SessionsDir,
 			ConfigFile:     paths.ConfigFileUsed,
 			WorkingDir:     paths.DAGsDir,
 			BaseConfigFile: paths.BaseConfig,


### PR DESCRIPTION
## Summary
- expose the agent session store directory in the system prompt environment block
- add a default-enabled `session_search` tool for searching the current user's persisted agent transcripts
- pass session, user, and session store context into tool execution and delegate sub-agent loops

## Root cause
The system prompt instructed agents to use `session_search` for past transcripts, but the tool did not exist in the registry. Agents could see persisted session storage context only as a path, not as an available typed tool.

## Testing
- `go test ./internal/agent ./internal/service/frontend ./internal/service/frontend/api/v1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session search functionality, enabling users to search and retrieve relevant content from their past agent session conversations.

* **Improvements**
  * Enhanced session persistence and context propagation to better support session tracking and user identity in tool execution.
  * Updated agent identity branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->