### PR TITLE
fix: keep agent modal inside viewport

### DIFF
--- a/ui/src/features/agent/hooks/__tests__/useResizableDraggable.test.ts
+++ b/ui/src/features/agent/hooks/__tests__/useResizableDraggable.test.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useResizableDraggable } from '../useResizableDraggable';
+
+const originalInnerWidth = window.innerWidth;
+const originalInnerHeight = window.innerHeight;
+
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  });
+}
+
+afterEach(() => {
+  localStorage.clear();
+  setViewport(originalInnerWidth, originalInnerHeight);
+});
+
+describe('useResizableDraggable', () => {
+  it('keeps stored modal bounds inside the current viewport', () => {
+    setViewport(700, 520);
+    localStorage.setItem(
+      'agent-chat-modal-bounds',
+      JSON.stringify({
+        right: 620,
+        bottom: 240,
+        width: 560,
+        height: 540,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useResizableDraggable({
+        storageKey: 'agent-chat-modal-bounds',
+        defaultWidth: 560,
+      })
+    );
+
+    expect(result.current.bounds).toMatchObject({
+      right: 140,
+      bottom: 100,
+      width: 560,
+      height: 420,
+    });
+  });
+
+  it('re-clamps open modal bounds when browser zoom changes the viewport', () => {
+    setViewport(1100, 760);
+    localStorage.setItem(
+      'agent-chat-modal-bounds',
+      JSON.stringify({
+        right: 500,
+        bottom: 260,
+        width: 560,
+        height: 540,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useResizableDraggable({
+        storageKey: 'agent-chat-modal-bounds',
+        defaultWidth: 560,
+      })
+    );
+
+    setViewport(700, 520);
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current.bounds).toMatchObject({
+      right: 140,
+      bottom: 100,
+      width: 560,
+      height: 420,
+    });
+  });
+});

--- a/ui/src/features/agent/hooks/useResizableDraggable.ts
+++ b/ui/src/features/agent/hooks/useResizableDraggable.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { useState, useCallback, useEffect, useRef } from 'react';
 
 interface Bounds {
@@ -17,6 +20,9 @@ interface UseResizableDraggableOptions {
   storageKey?: string;
 }
 
+const VIEWPORT_HORIZONTAL_PADDING = 32;
+const VIEWPORT_VERTICAL_PADDING = 100;
+
 type ResizeDirection =
   | 'top'
   | 'right'
@@ -27,7 +33,52 @@ type ResizeDirection =
   | 'bottomLeft'
   | 'bottomRight';
 
-export function useResizableDraggable(options: UseResizableDraggableOptions = {}) {
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
+}
+
+function clampBounds(
+  bounds: Bounds,
+  minWidth: number,
+  minHeight: number
+): Bounds {
+  if (typeof window === 'undefined') {
+    return bounds;
+  }
+
+  const maxWidth = Math.max(1, window.innerWidth - VIEWPORT_HORIZONTAL_PADDING);
+  const maxHeight = Math.max(1, window.innerHeight - VIEWPORT_VERTICAL_PADDING);
+  const width = clamp(bounds.width, Math.min(minWidth, maxWidth), maxWidth);
+  const height = clamp(
+    bounds.height,
+    Math.min(minHeight, maxHeight),
+    maxHeight
+  );
+
+  return {
+    right: clamp(bounds.right, 0, Math.max(0, window.innerWidth - width)),
+    bottom: clamp(bounds.bottom, 0, Math.max(0, window.innerHeight - height)),
+    width,
+    height,
+  };
+}
+
+function areBoundsEqual(a: Bounds, b: Bounds): boolean {
+  return (
+    a.right === b.right &&
+    a.bottom === b.bottom &&
+    a.width === b.width &&
+    a.height === b.height
+  );
+}
+
+export function useResizableDraggable(
+  options: UseResizableDraggableOptions = {}
+) {
   const {
     defaultWidth = 440,
     defaultHeight = 540,
@@ -39,27 +90,35 @@ export function useResizableDraggable(options: UseResizableDraggableOptions = {}
   } = options;
 
   const [bounds, setBounds] = useState<Bounds>(() => {
+    const defaultBounds = {
+      right: defaultRight,
+      bottom: defaultBottom,
+      width: defaultWidth,
+      height: defaultHeight,
+    };
+
     if (typeof window === 'undefined') {
-      return { right: defaultRight, bottom: defaultBottom, width: defaultWidth, height: defaultHeight };
+      return defaultBounds;
     }
     try {
       const stored = storageKey ? localStorage.getItem(storageKey) : null;
       if (stored) {
         const parsed = JSON.parse(stored);
-        // Validate bounds are within viewport
-        const maxWidth = window.innerWidth - 32;
-        const maxHeight = window.innerHeight - 100;
-        return {
-          right: Math.max(0, Math.min(parsed.right ?? defaultRight, window.innerWidth - minWidth)),
-          bottom: Math.max(0, Math.min(parsed.bottom ?? defaultBottom, window.innerHeight - minHeight)),
-          width: Math.max(minWidth, Math.min(parsed.width ?? defaultWidth, maxWidth)),
-          height: Math.max(minHeight, Math.min(parsed.height ?? defaultHeight, maxHeight)),
-        };
+        return clampBounds(
+          {
+            right: finiteNumber(parsed.right, defaultRight),
+            bottom: finiteNumber(parsed.bottom, defaultBottom),
+            width: finiteNumber(parsed.width, defaultWidth),
+            height: finiteNumber(parsed.height, defaultHeight),
+          },
+          minWidth,
+          minHeight
+        );
       }
     } catch {
       // Ignore parse errors
     }
-    return { right: defaultRight, bottom: defaultBottom, width: defaultWidth, height: defaultHeight };
+    return clampBounds(defaultBounds, minWidth, minHeight);
   });
 
   const boundsRef = useRef(bounds);
@@ -81,14 +140,17 @@ export function useResizableDraggable(options: UseResizableDraggableOptions = {}
     startBounds: bounds,
   });
 
-  const saveBounds = useCallback((b: Bounds) => {
-    if (!storageKey) return;
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(b));
-    } catch {
-      // Ignore storage errors
-    }
-  }, [storageKey]);
+  const saveBounds = useCallback(
+    (b: Bounds) => {
+      if (!storageKey) return;
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(b));
+      } catch {
+        // Ignore storage errors
+      }
+    },
+    [storageKey]
+  );
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
@@ -97,16 +159,42 @@ export function useResizableDraggable(options: UseResizableDraggableOptions = {}
 
       const deltaX = e.clientX - state.startX;
       const deltaY = e.clientY - state.startY;
-      const maxWidth = window.innerWidth - 32;
-      const maxHeight = window.innerHeight - 100;
+      const maxWidth = Math.max(
+        1,
+        window.innerWidth - VIEWPORT_HORIZONTAL_PADDING
+      );
+      const maxHeight = Math.max(
+        1,
+        window.innerHeight - VIEWPORT_VERTICAL_PADDING
+      );
 
       if (state.isDragging) {
         // Dragging: move position (invert delta because we use right/bottom)
-        setBounds((prev) => ({
-          ...prev,
-          right: Math.max(0, Math.min(state.startBounds.right - deltaX, window.innerWidth - prev.width)),
-          bottom: Math.max(0, Math.min(state.startBounds.bottom - deltaY, window.innerHeight - prev.height)),
-        }));
+        setBounds((prev) =>
+          clampBounds(
+            {
+              ...state.startBounds,
+              width: prev.width,
+              height: prev.height,
+              right: Math.max(
+                0,
+                Math.min(
+                  state.startBounds.right - deltaX,
+                  window.innerWidth - prev.width
+                )
+              ),
+              bottom: Math.max(
+                0,
+                Math.min(
+                  state.startBounds.bottom - deltaY,
+                  window.innerHeight - prev.height
+                )
+              ),
+            },
+            minWidth,
+            minHeight
+          )
+        );
       } else if (state.isResizing && state.resizeDirection) {
         // Resizing: adjust size and possibly position
         const dir = state.resizeDirection;
@@ -118,33 +206,57 @@ export function useResizableDraggable(options: UseResizableDraggableOptions = {}
         // Handle horizontal resize
         if (dir.includes('Left') || dir === 'left') {
           // Left edge: increase width, keep right anchor
-          newWidth = Math.max(minWidth, Math.min(state.startBounds.width - deltaX, maxWidth));
+          newWidth = Math.max(
+            minWidth,
+            Math.min(state.startBounds.width - deltaX, maxWidth)
+          );
         }
         if (dir.includes('Right') || dir === 'right') {
           // Right edge: increase width by moving right anchor
-          newWidth = Math.max(minWidth, Math.min(state.startBounds.width + deltaX, maxWidth));
+          newWidth = Math.max(
+            minWidth,
+            Math.min(state.startBounds.width + deltaX, maxWidth)
+          );
           newRight = Math.max(0, state.startBounds.right - deltaX);
         }
 
         // Handle vertical resize
         if (dir.includes('top') || dir === 'top') {
           // Top edge: increase height, keep bottom anchor
-          newHeight = Math.max(minHeight, Math.min(state.startBounds.height - deltaY, maxHeight));
+          newHeight = Math.max(
+            minHeight,
+            Math.min(state.startBounds.height - deltaY, maxHeight)
+          );
         }
         if (dir.includes('bottom') || dir === 'bottom') {
           // Bottom edge: increase height by moving bottom anchor
-          newHeight = Math.max(minHeight, Math.min(state.startBounds.height + deltaY, maxHeight));
+          newHeight = Math.max(
+            minHeight,
+            Math.min(state.startBounds.height + deltaY, maxHeight)
+          );
           newBottom = Math.max(0, state.startBounds.bottom - deltaY);
         }
 
-        setBounds({ right: newRight, bottom: newBottom, width: newWidth, height: newHeight });
+        setBounds(
+          clampBounds(
+            {
+              right: newRight,
+              bottom: newBottom,
+              width: newWidth,
+              height: newHeight,
+            },
+            minWidth,
+            minHeight
+          )
+        );
       }
     },
     [minWidth, minHeight]
   );
 
   const handleMouseUp = useCallback(() => {
-    const wasActive = dragStateRef.current.isDragging || dragStateRef.current.isResizing;
+    const wasActive =
+      dragStateRef.current.isDragging || dragStateRef.current.isResizing;
     dragStateRef.current.isDragging = false;
     dragStateRef.current.isResizing = false;
     dragStateRef.current.resizeDirection = null;
@@ -164,19 +276,38 @@ export function useResizableDraggable(options: UseResizableDraggableOptions = {}
     };
   }, [handleMouseMove, handleMouseUp]);
 
-  const startDrag = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    dragStateRef.current = {
-      isDragging: true,
-      isResizing: false,
-      resizeDirection: null,
-      startX: e.clientX,
-      startY: e.clientY,
-      startBounds: { ...bounds },
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setBounds((prev) => {
+        const next = clampBounds(prev, minWidth, minHeight);
+        return areBoundsEqual(prev, next) ? prev : next;
+      });
     };
-    document.body.style.cursor = 'move';
-    document.body.style.userSelect = 'none';
-  }, [bounds]);
+
+    window.addEventListener('resize', handleWindowResize);
+    window.addEventListener('orientationchange', handleWindowResize);
+    return () => {
+      window.removeEventListener('resize', handleWindowResize);
+      window.removeEventListener('orientationchange', handleWindowResize);
+    };
+  }, [minWidth, minHeight]);
+
+  const startDrag = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragStateRef.current = {
+        isDragging: true,
+        isResizing: false,
+        resizeDirection: null,
+        startX: e.clientX,
+        startY: e.clientY,
+        startBounds: { ...bounds },
+      };
+      document.body.style.cursor = 'move';
+      document.body.style.userSelect = 'none';
+    },
+    [bounds]
+  );
 
   const startResize = useCallback(
     (direction: ResizeDirection) => (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- clamp restored and live-resized agent modal bounds against the actual viewport size
- re-clamp draggable windows on resize and orientation changes so browser zoom keeps controls reachable
- add regression tests for stale stored bounds and viewport shrink behavior

## Root cause
Saved `right` and `bottom` offsets were clamped against the minimum modal size instead of the clamped actual modal size. A browser zoom or viewport shrink could therefore leave the fixed-position modal with a negative top or left offset, and already-open modals were not re-clamped on resize.

## Testing
- `pnpm vitest run src/features/agent/hooks/__tests__/useResizableDraggable.test.ts src/features/agent/components/__tests__/AgentChatModal.test.tsx`
- `pnpm typecheck`
- `pnpm exec eslint --ext .ts,.tsx src/features/agent/hooks/useResizableDraggable.ts src/features/agent/hooks/__tests__/useResizableDraggable.test.ts`
- `pnpm test`
- `pnpm build`
- Playwright browser geometry check at `1100x760`, then `900x520`, with mocked API responses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Draggable and resizable elements now remain within the visible viewport
  * Elements automatically adjust position when the window is resized or orientation changes
  * Improved persistence of element positions

* **Tests**
  * Added test coverage for draggable and resizable functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->