### PR TITLE
feat: add log step type

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -1975,8 +1975,12 @@
           }
         },
         {
-          "if": { "properties": { "type": { "const": "log" } } },
+          "if": {
+            "properties": { "type": { "const": "log" } },
+            "required": ["type"]
+          },
           "then": {
+            "anyOf": [{ "required": ["with"] }, { "required": ["config"] }],
             "properties": {
               "with": { "$ref": "#/definitions/logExecutorConfig" },
               "config": {
@@ -5367,8 +5371,12 @@
           }
         },
         {
-          "if": { "properties": { "type": { "const": "log" } } },
+          "if": {
+            "properties": { "type": { "const": "log" } },
+            "required": ["type"]
+          },
           "then": {
+            "required": ["config"],
             "properties": {
               "config": { "$ref": "#/definitions/logExecutorConfig" }
             }

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -1975,6 +1975,19 @@
           }
         },
         {
+          "if": { "properties": { "type": { "const": "log" } } },
+          "then": {
+            "properties": {
+              "with": { "$ref": "#/definitions/logExecutorConfig" },
+              "config": {
+                "$ref": "#/definitions/logExecutorConfig",
+                "deprecated": true,
+                "doNotSuggest": true
+              }
+            }
+          }
+        },
+        {
           "if": { "properties": { "type": { "const": "postgres" } } },
           "then": {
             "properties": {
@@ -2633,6 +2646,18 @@
         }
       },
       "description": "Configuration options for HTTP executor requests."
+    },
+    "logExecutorConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["message"],
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Message to write to stdout. Supports Dagu variable substitution such as ${VAR}."
+        }
+      },
+      "description": "Configuration for log steps. Writes message to stdout without running a shell command."
     },
     "sshExecutorConfig": {
       "type": "object",
@@ -5186,6 +5211,7 @@
         "parallel",
         "archive",
         "chat",
+        "log",
         "postgres",
         "sqlite",
         "redis",
@@ -5337,6 +5363,14 @@
           "then": {
             "properties": {
               "config": { "$ref": "#/definitions/archiveExecutorConfig" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "log" } } },
+          "then": {
+            "properties": {
+              "config": { "$ref": "#/definitions/logExecutorConfig" }
             }
           }
         },

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -672,6 +672,120 @@ steps:
 	}
 }
 
+func TestDAGSchemaLogStepRequiresMessage(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchema(t)
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "CanonicalWith",
+			spec: `
+steps:
+  - type: log
+    with:
+      message: hello
+`,
+		},
+		{
+			name: "LegacyConfigAlias",
+			spec: `
+steps:
+  - type: log
+    config:
+      message: hello
+`,
+		},
+		{
+			name: "RejectMissingWithOrConfig",
+			spec: `
+steps:
+  - type: log
+`,
+			wantErr: "steps",
+		},
+		{
+			name: "RejectMissingMessage",
+			spec: `
+steps:
+  - type: log
+    with: {}
+`,
+			wantErr: "steps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := mustParseYAMLDocument(t, tt.spec)
+			err := resolved.Validate(doc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestDAGSchemaLogExecutorObjectRequiresMessage(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchemaDefinition(t, "executorObject")
+
+	tests := []struct {
+		name    string
+		value   map[string]any
+		wantErr string
+	}{
+		{
+			name: "Valid",
+			value: map[string]any{
+				"type": "log",
+				"config": map[string]any{
+					"message": "hello",
+				},
+			},
+		},
+		{
+			name: "RejectMissingConfig",
+			value: map[string]any{
+				"type": "log",
+			},
+			wantErr: "config",
+		},
+		{
+			name: "RejectMissingMessage",
+			value: map[string]any{
+				"type":   "log",
+				"config": map[string]any{},
+			},
+			wantErr: "message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := resolved.Validate(tt.value)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestDAGSchemaSSHExecutorPort(t *testing.T) {
 	t.Parallel()
 
@@ -1235,16 +1349,16 @@ func mustResolveDAGSchema(t *testing.T) *jsonschema.Resolved {
 func mustResolveDAGSchemaDefinition(t *testing.T, name string) *jsonschema.Resolved {
 	t.Helper()
 
-	var root struct {
-		Definitions map[string]json.RawMessage `json:"definitions"`
-	}
+	var root jsonschema.Schema
 	require.NoError(t, json.Unmarshal(DAGSchemaJSON, &root))
 
-	definition, ok := root.Definitions[name]
+	_, ok := root.Definitions[name]
 	require.True(t, ok, "schema definition %q should exist", name)
 
-	var schema jsonschema.Schema
-	require.NoError(t, json.Unmarshal(definition, &schema))
+	schema := jsonschema.Schema{
+		Ref:         "#/definitions/" + name,
+		Definitions: root.Definitions,
+	}
 
 	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{})
 	require.NoError(t, err)

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -55,6 +55,8 @@ func TestMain(m *testing.M) {
 	}
 	// mail: no command support
 	core.RegisterExecutorCapabilities("mail", core.ExecutorCapabilities{})
+	// log: no command support
+	core.RegisterExecutorCapabilities("log", core.ExecutorCapabilities{})
 	// chat: LLM executor
 	core.RegisterExecutorCapabilities("chat", core.ExecutorCapabilities{LLM: true})
 

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -227,6 +227,23 @@ func TestBuildStepScript(t *testing.T) {
 	}
 }
 
+func TestLoadYAMLLogStep(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - name: announce
+    type: log
+    with:
+      message: "Deploying ${ENVIRONMENT}"
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+	assert.Equal(t, "announce", dag.Steps[0].Name)
+	assert.Equal(t, "log", dag.Steps[0].ExecutorConfig.Type)
+	assert.Equal(t, "Deploying ${ENVIRONMENT}", dag.Steps[0].ExecutorConfig.Config["message"])
+}
+
 func TestBuildStepStdout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -70,6 +70,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"jq":            {},
 	"k8s":           {},
 	"kubernetes":    {},
+	"log":           {},
 	"mail":          {},
 	"noop":          {},
 	"parallel":      {},

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/http"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/jq"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/kubernetes"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/log"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/mail"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/noop"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/redis"

--- a/internal/runtime/builtin/log/log.go
+++ b/internal/runtime/builtin/log/log.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const executorType = "log"
+
+var _ executor.Executor = (*logExecutor)(nil)
+
+type logExecutor struct {
+	stdout  io.Writer
+	message string
+}
+
+func newLog(_ context.Context, step core.Step) (executor.Executor, error) {
+	message, err := parseMessage(step.ExecutorConfig.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &logExecutor{
+		stdout:  os.Stdout,
+		message: message,
+	}, nil
+}
+
+func parseMessage(config map[string]any) (string, error) {
+	if config == nil {
+		return "", fmt.Errorf("log: message is required")
+	}
+	raw, ok := config["message"]
+	if !ok {
+		return "", fmt.Errorf("log: message is required")
+	}
+	message, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("log: message must be a string")
+	}
+	return message, nil
+}
+
+func (e *logExecutor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (*logExecutor) SetStderr(_ io.Writer) {}
+
+func (*logExecutor) Kill(_ os.Signal) error { return nil }
+
+func (e *logExecutor) Run(_ context.Context) error {
+	if _, err := io.WriteString(e.stdout, e.message); err != nil {
+		return err
+	}
+	if strings.HasSuffix(e.message, "\n") {
+		return nil
+	}
+	_, err := io.WriteString(e.stdout, "\n")
+	return err
+}
+
+func validateLogStep(step core.Step) error {
+	_, err := parseMessage(step.ExecutorConfig.Config)
+	return err
+}
+
+var configSchema = &jsonschema.Schema{
+	Type:                 "object",
+	Required:             []string{"message"},
+	AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+	Properties: map[string]*jsonschema.Schema{
+		"message": {
+			Type:        "string",
+			Description: "Message to write to stdout. Supports Dagu variable substitution.",
+		},
+	},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+	executor.RegisterExecutor(executorType, newLog, validateLogStep, core.ExecutorCapabilities{})
+}

--- a/internal/runtime/builtin/log/log.go
+++ b/internal/runtime/builtin/log/log.go
@@ -58,12 +58,18 @@ func (*logExecutor) SetStderr(_ io.Writer) {}
 
 func (*logExecutor) Kill(_ os.Signal) error { return nil }
 
-func (e *logExecutor) Run(_ context.Context) error {
+func (e *logExecutor) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if _, err := io.WriteString(e.stdout, e.message); err != nil {
 		return err
 	}
 	if strings.HasSuffix(e.message, "\n") {
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	_, err := io.WriteString(e.stdout, "\n")
 	return err

--- a/internal/runtime/builtin/log/log_test.go
+++ b/internal/runtime/builtin/log/log_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package log
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorRunWritesMessageToStdout(t *testing.T) {
+	t.Parallel()
+
+	exec, err := newLog(context.Background(), core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "log",
+			Config: map[string]any{
+				"message": "Deploying ${ENVIRONMENT}",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout strings.Builder
+	exec.SetStdout(&stdout)
+
+	require.NoError(t, exec.Run(context.Background()))
+	require.Equal(t, "Deploying ${ENVIRONMENT}\n", stdout.String())
+}
+
+func TestExecutorRunDoesNotDuplicateTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	exec, err := newLog(context.Background(), core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "log",
+			Config: map[string]any{
+				"message": "line one\nline two\n",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout strings.Builder
+	exec.SetStdout(&stdout)
+
+	require.NoError(t, exec.Run(context.Background()))
+	require.Equal(t, "line one\nline two\n", stdout.String())
+}
+
+func TestNewLogRequiresMessage(t *testing.T) {
+	t.Parallel()
+
+	_, err := newLog(context.Background(), core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   "log",
+			Config: map[string]any{},
+		},
+	})
+	require.ErrorContains(t, err, "message is required")
+}

--- a/internal/runtime/builtin/log/log_test.go
+++ b/internal/runtime/builtin/log/log_test.go
@@ -5,6 +5,7 @@ package log
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -50,6 +51,30 @@ func TestExecutorRunDoesNotDuplicateTrailingNewline(t *testing.T) {
 
 	require.NoError(t, exec.Run(context.Background()))
 	require.Equal(t, "line one\nline two\n", stdout.String())
+}
+
+func TestExecutorRunStopsWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	exec, err := newLog(context.Background(), core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "log",
+			Config: map[string]any{
+				"message": "Deploying ${ENVIRONMENT}",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout strings.Builder
+	exec.SetStdout(&stdout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = exec.Run(ctx)
+	require.True(t, errors.Is(err, context.Canceled))
+	require.Empty(t, stdout.String())
 }
 
 func TestNewLogRequiresMessage(t *testing.T) {

--- a/internal/runtime/node_internal_test.go
+++ b/internal/runtime/node_internal_test.go
@@ -5,11 +5,13 @@ package runtime
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -118,6 +120,35 @@ func TestEvalExecutorConfig_DefaultPreservesLiteralCodeFencesInData(t *testing.T
 	})
 	require.NoError(t, err)
 	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", result["note"])
+}
+
+func TestSetupExecutor_LogMessageExpandsVariables(t *testing.T) {
+	t.Parallel()
+
+	step := core.Step{
+		Name: "announce",
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "log",
+			Config: map[string]any{
+				"message": "Deploying ${ENVIRONMENT}",
+			},
+		},
+	}
+	ctx := NewContextForTest(context.Background(), &core.DAG{Name: "test-dag"}, "run-1", "test.log")
+	env := NewEnv(ctx, step)
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"ENVIRONMENT": "production",
+	}, eval.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	node := NewNode(step, NodeState{})
+	cmd, err := node.setupExecutor(ctx)
+	require.NoError(t, err)
+
+	var stdout strings.Builder
+	cmd.SetStdout(&stdout)
+	require.NoError(t, cmd.Run(ctx))
+	require.Equal(t, "Deploying production\n", stdout.String())
 }
 
 // TestSetupExecutor_HarnessCommandPreservesLiteralCodeFences verifies that

--- a/ui/src/features/dags/components/dag-details/DAGStepTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGStepTableRow.tsx
@@ -11,7 +11,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { isHarnessStep } from '@/lib/harness-step';
-import { getExecutorCommand } from '@/lib/executor-utils';
+import { getExecutorCommand, getLogStepMessage } from '@/lib/executor-utils';
 import {
   ArrowRight,
   Code,
@@ -25,6 +25,7 @@ import { components } from '../../../../api/v1/schema';
 import { Badge } from '@/components/ui/badge';
 import { TableCell, TableRow } from '@/components/ui/table';
 import HarnessStepSummary from './HarnessStepSummary';
+import { LogStepMessage } from './LogStepMessage';
 
 /**
  * Props for the DAGStepTableRow component
@@ -41,6 +42,7 @@ type Props = {
  */
 function DAGStepTableRow({ step, index }: Props) {
   const subDagName = step.call;
+  const logMessage = getLogStepMessage(step);
   // Format preconditions as a list
   const preconditions = step.preconditions?.map((c, index) => (
     <div
@@ -120,6 +122,8 @@ function DAGStepTableRow({ step, index }: Props) {
         <div className="space-y-1.5">
           {isHarnessStep(step) ? (
             <HarnessStepSummary step={step} />
+          ) : logMessage !== null ? (
+            <LogStepMessage message={logMessage} compact />
           ) : step.commands && step.commands.length > 0 ? (
             <CommandDisplay
               commands={step.commands}

--- a/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
+++ b/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { MessageSquare } from 'lucide-react';
+
+type LogStepMessageProps = {
+  message: string;
+  className?: string;
+  compact?: boolean;
+};
+
+const singleLineLimit = 72;
+
+function formatSingleLine(message: string): string {
+  return message.length === 0 ? '(empty message)' : message;
+}
+
+function truncateSingleLine(message: string): {
+  text: string;
+  isTruncated: boolean;
+} {
+  const display = formatSingleLine(message);
+  if (display.length <= singleLineLimit) {
+    return { text: display, isTruncated: false };
+  }
+  return {
+    text: `${display.slice(0, singleLineLimit - 3)}...`,
+    isTruncated: true,
+  };
+}
+
+export function LogStepMessage({
+  message,
+  className,
+  compact = false,
+}: LogStepMessageProps) {
+  const isMultiline = message.includes('\n');
+  const singleLine = truncateSingleLine(message);
+
+  const messageBody = isMultiline ? (
+    <pre className="max-h-28 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground">
+      {message || '(empty message)'}
+    </pre>
+  ) : (
+    <span
+      className="block truncate font-mono text-xs leading-5 text-foreground"
+      title={singleLine.isTruncated ? message : undefined}
+    >
+      {singleLine.text}
+    </span>
+  );
+
+  const content = (
+    <div
+      className={cn(
+        'inline-flex min-w-0 max-w-full items-start gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1.5',
+        compact ? 'max-w-[260px]' : 'w-full',
+        className
+      )}
+      aria-label={`Log message: ${formatSingleLine(message)}`}
+    >
+      <MessageSquare className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary" />
+      <div className="min-w-0 flex-1">{messageBody}</div>
+    </div>
+  );
+
+  if (!isMultiline && !singleLine.isTruncated) {
+    return content;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent className="max-w-[520px]">
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs">
+          {message || '(empty message)'}
+        </pre>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
+++ b/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
@@ -7,7 +7,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { MessageSquare } from 'lucide-react';
 
 type LogStepMessageProps = {
   message: string;
@@ -59,14 +58,13 @@ export function LogStepMessage({
   const content = (
     <div
       className={cn(
-        'inline-flex min-w-0 max-w-full items-start gap-1.5 rounded-md border border-border bg-muted/40 px-2 py-1.5',
-        compact ? 'max-w-[260px]' : 'w-full',
+        'min-w-0 rounded-md border border-border bg-muted/40 px-2 py-1.5',
+        compact ? 'w-[320px] max-w-full' : 'w-full',
         className
       )}
       aria-label={`Log message: ${formatSingleLine(message)}`}
     >
-      <MessageSquare className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary" />
-      <div className="min-w-0 flex-1">{messageBody}</div>
+      {messageBody}
     </div>
   );
 

--- a/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
+++ b/ui/src/features/dags/components/dag-details/LogStepMessage.tsx
@@ -15,6 +15,7 @@ type LogStepMessageProps = {
 };
 
 const singleLineLimit = 72;
+const ariaLabelLimit = 120;
 
 function formatSingleLine(message: string): string {
   return message.length === 0 ? '(empty message)' : message;
@@ -34,6 +35,14 @@ function truncateSingleLine(message: string): {
   };
 }
 
+function truncateAriaLabel(message: string): string {
+  const display = formatSingleLine(message).replace(/\s+/g, ' ');
+  if (display.length <= ariaLabelLimit) {
+    return display;
+  }
+  return `${display.slice(0, ariaLabelLimit - 3)}...`;
+}
+
 export function LogStepMessage({
   message,
   className,
@@ -41,6 +50,7 @@ export function LogStepMessage({
 }: LogStepMessageProps) {
   const isMultiline = message.includes('\n');
   const singleLine = truncateSingleLine(message);
+  const ariaLabel = truncateAriaLabel(message);
 
   const messageBody = isMultiline ? (
     <pre className="max-h-28 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground">
@@ -62,7 +72,7 @@ export function LogStepMessage({
         compact ? 'w-[320px] max-w-full' : 'w-full',
         className
       )}
-      aria-label={`Log message: ${formatSingleLine(message)}`}
+      aria-label={`Log message: ${ariaLabel}`}
     >
       {messageBody}
     </div>

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -197,7 +197,7 @@ function NodeStatusTableRow({
         },
         path: {
           name: dagRun.rootDAGRunName,
-          dagRunId: dagRun.rootDAGRunId || '',
+          dagRunId: dagRun.rootDAGRunId,
           subDAGRunId: dagRun.dagRunId,
           stepName: node.step.name,
         },
@@ -218,7 +218,7 @@ function NodeStatusTableRow({
           stream: Stream.stdout,
         },
         path: {
-          name: dagRun?.name || name,
+          name: dagRun.name,
           dagRunId: dagRunId || '',
           stepName: node.step.name,
         },
@@ -233,10 +233,13 @@ function NodeStatusTableRow({
   const logOutputContent = isSubDAGRun
     ? subDAGLogQuery.data?.content
     : dagRunLogQuery.data?.content;
+  const logQueryError = isSubDAGRun
+    ? subDAGLogQuery.error
+    : dagRunLogQuery.error;
   const logStepDisplayMessage =
     typeof logOutputContent === 'string'
       ? formatLogStepOutput(logOutputContent)
-      : shouldFetchLogStepOutput
+      : shouldFetchLogStepOutput && !logQueryError
         ? 'Loading log output...'
         : logMessage;
 

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/tooltip';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { useClient } from '@/hooks/api';
-import { getExecutorCommand } from '@/lib/executor-utils';
+import { getExecutorCommand, getLogStepMessage } from '@/lib/executor-utils';
 import { isHarnessStep } from '@/lib/harness-step';
 import { isActiveNodeStatus } from '@/lib/status-utils';
 import dayjs from '@/lib/dayjs';
@@ -47,10 +47,11 @@ import {
 } from '../../../../api/v1/schema';
 import StyledTableRow from '@/components/ui/styled-table-row';
 import { DAGContext } from '../../contexts/DAGContext';
-import { NodeStatusChip } from '../common';
+import NodeStatusChip from '../common/NodeStatusChip';
 import { InlineLogViewer } from '../common/InlineLogViewer';
 import StatusUpdateModal from '../dag-execution/StatusUpdateModal';
 import HarnessStepSummary from './HarnessStepSummary';
+import { LogStepMessage } from './LogStepMessage';
 import { SubDAGRunsList } from './SubDAGRunsList';
 import PushBackHistory from '../common/PushBackHistory';
 
@@ -170,6 +171,7 @@ function NodeStatusTableRow({
   const isActiveNode = isActiveNodeStatus(node.status);
   const activeDotClass =
     node.status === NodeStatus.Retrying ? 'bg-warning' : 'bg-success';
+  const logMessage = getLogStepMessage(node.step);
 
   // Update duration every second for active tasks.
   useEffect(() => {
@@ -527,6 +529,8 @@ function NodeStatusTableRow({
             <div className="space-y-1.5">
               {isHarnessStep(node.step) ? (
                 <HarnessStepSummary step={node.step} />
+              ) : logMessage !== null ? (
+                <LogStepMessage message={logMessage} compact />
               ) : node.step.commands && node.step.commands.length > 0 ? (
                 <CommandDisplay
                   commands={node.step.commands}
@@ -944,7 +948,9 @@ function NodeStatusTableRow({
       {/* Command section */}
       <div className="mb-3">
         <div className="text-xs font-medium text-foreground/90 mb-1">
-          {isHarnessStep(node.step)
+          {logMessage !== null
+            ? 'Message:'
+            : isHarnessStep(node.step)
             ? 'Execution:'
             : node.step.commands && node.step.commands.length > 1
               ? 'Commands:'
@@ -953,6 +959,8 @@ function NodeStatusTableRow({
         <div className="space-y-1.5">
           {isHarnessStep(node.step) ? (
             <HarnessStepSummary step={node.step} />
+          ) : logMessage !== null ? (
+            <LogStepMessage message={logMessage} />
           ) : node.step.commands && node.step.commands.length > 0 ? (
             <div className="space-y-1.5">
               {node.step.commands.map((entry, idx) => {

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -14,8 +14,13 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { AppBarContext } from '@/contexts/AppBarContext';
-import { useClient } from '@/hooks/api';
-import { getExecutorCommand, getLogStepMessage } from '@/lib/executor-utils';
+import { useClient, useQuery } from '@/hooks/api';
+import { whenEnabled } from '@/hooks/queryUtils';
+import {
+  formatLogStepOutput,
+  getExecutorCommand,
+  getLogStepMessage,
+} from '@/lib/executor-utils';
 import { isHarnessStep } from '@/lib/harness-step';
 import { isActiveNodeStatus } from '@/lib/status-utils';
 import dayjs from '@/lib/dayjs';
@@ -172,6 +177,68 @@ function NodeStatusTableRow({
   const activeDotClass =
     node.status === NodeStatus.Retrying ? 'bg-warning' : 'bg-success';
   const logMessage = getLogStepMessage(node.step);
+  const hasStdout = !!node.stdout;
+  const hasStderr = !!node.stderr;
+  const hasLogs = hasStdout || hasStderr;
+  const isSubDAGRun =
+    !!dagRun.rootDAGRunId &&
+    !!dagRun.rootDAGRunName &&
+    dagRun.rootDAGRunId !== dagRun.dagRunId;
+  const shouldFetchLogStepOutput =
+    logMessage !== null && hasStdout && !!dagRunId;
+
+  const subDAGLogQuery = useQuery(
+    '/dag-runs/{name}/{dagRunId}/sub-dag-runs/{subDAGRunId}/steps/{stepName}/log',
+    whenEnabled(shouldFetchLogStepOutput && isSubDAGRun, {
+      params: {
+        query: {
+          remoteNode,
+          stream: Stream.stdout,
+        },
+        path: {
+          name: dagRun.rootDAGRunName,
+          dagRunId: dagRun.rootDAGRunId || '',
+          subDAGRunId: dagRun.dagRunId,
+          stepName: node.step.name,
+        },
+      },
+    }),
+    {
+      refreshInterval: isActiveNode ? 2000 : 0,
+      revalidateOnFocus: false,
+    }
+  );
+
+  const dagRunLogQuery = useQuery(
+    '/dag-runs/{name}/{dagRunId}/steps/{stepName}/log',
+    whenEnabled(shouldFetchLogStepOutput && !isSubDAGRun, {
+      params: {
+        query: {
+          remoteNode,
+          stream: Stream.stdout,
+        },
+        path: {
+          name: dagRun?.name || name,
+          dagRunId: dagRunId || '',
+          stepName: node.step.name,
+        },
+      },
+    }),
+    {
+      refreshInterval: isActiveNode ? 2000 : 0,
+      revalidateOnFocus: false,
+    }
+  );
+
+  const logOutputContent = isSubDAGRun
+    ? subDAGLogQuery.data?.content
+    : dagRunLogQuery.data?.content;
+  const logStepDisplayMessage =
+    typeof logOutputContent === 'string'
+      ? formatLogStepOutput(logOutputContent)
+      : shouldFetchLogStepOutput
+        ? 'Loading log output...'
+        : logMessage;
 
   // Update duration every second for active tasks.
   useEffect(() => {
@@ -337,11 +404,6 @@ function NodeStatusTableRow({
     status: NodeStatus
   ) => {
     // Check if this is a sub DAG-run
-    const isSubDAGRun =
-      dagRun.rootDAGRunId &&
-      dagRun.rootDAGRunName &&
-      dagRun.rootDAGRunId !== dagRun.dagRunId;
-
     // Define path parameters
     const pathParams = {
       name: isSubDAGRun ? dagRun.rootDAGRunName : dagName,
@@ -379,11 +441,6 @@ function NodeStatusTableRow({
     dagContext.refresh();
     setShowStatusModal(false);
   };
-
-  // Determine if logs are available
-  const hasStdout = !!node.stdout;
-  const hasStderr = !!node.stderr;
-  const hasLogs = hasStdout || hasStderr;
 
   // Determine which stream to show based on active tab
   const currentStream: components['schemas']['Stream'] =
@@ -529,8 +586,8 @@ function NodeStatusTableRow({
             <div className="space-y-1.5">
               {isHarnessStep(node.step) ? (
                 <HarnessStepSummary step={node.step} />
-              ) : logMessage !== null ? (
-                <LogStepMessage message={logMessage} compact />
+              ) : logStepDisplayMessage !== null ? (
+                <LogStepMessage message={logStepDisplayMessage} compact />
               ) : node.step.commands && node.step.commands.length > 0 ? (
                 <CommandDisplay
                   commands={node.step.commands}
@@ -951,16 +1008,16 @@ function NodeStatusTableRow({
           {logMessage !== null
             ? 'Message:'
             : isHarnessStep(node.step)
-            ? 'Execution:'
-            : node.step.commands && node.step.commands.length > 1
-              ? 'Commands:'
-              : 'Command:'}
+              ? 'Execution:'
+              : node.step.commands && node.step.commands.length > 1
+                ? 'Commands:'
+                : 'Command:'}
         </div>
         <div className="space-y-1.5">
           {isHarnessStep(node.step) ? (
             <HarnessStepSummary step={node.step} />
-          ) : logMessage !== null ? (
-            <LogStepMessage message={logMessage} />
+          ) : logStepDisplayMessage !== null ? (
+            <LogStepMessage message={logStepDisplayMessage} />
           ) : node.step.commands && node.step.commands.length > 0 ? (
             <div className="space-y-1.5">
               {node.step.commands.map((entry, idx) => {

--- a/ui/src/features/dags/components/dag-details/SubDAGRunsList.tsx
+++ b/ui/src/features/dags/components/dag-details/SubDAGRunsList.tsx
@@ -5,7 +5,8 @@ import { whenEnabled } from '@/hooks/queryUtils';
 import dayjs from '@/lib/dayjs';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useContext, useEffect, useMemo, useState } from 'react';
-import { STATUS_DISPLAY_LABELS, StatusDot } from '../common';
+import { StatusDot } from '../common/StatusDot';
+import { STATUS_DISPLAY_LABELS } from '../common/statusLabels';
 
 type SubDAGRun = components['schemas']['SubDAGRun'];
 type SubDAGRunDetail = components['schemas']['SubDAGRunDetail'];

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGStepTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGStepTableRow.test.tsx
@@ -8,6 +8,30 @@ import type { components } from '@/api/v1/schema';
 import DAGStepTableRow from '../DAGStepTableRow';
 
 describe('DAGStepTableRow', () => {
+  it('shows log step messages in the execution column', () => {
+    const step = {
+      name: 'announce',
+      executorConfig: {
+        type: 'log',
+        config: {
+          message: 'Deploying ${ENVIRONMENT}',
+        },
+      },
+    } as components['schemas']['Step'];
+
+    render(
+      <table>
+        <tbody>
+          <DAGStepTableRow step={step} index={0} />
+        </tbody>
+      </table>
+    );
+
+    expect(
+      screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
+    ).toBeInTheDocument();
+  });
+
   it('shows the script badge for harness steps', () => {
     const step = {
       name: 'review',

--- a/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
@@ -54,10 +54,15 @@ const mockedUseQuery = vi.mocked(
   useQuery as unknown as (path: unknown, init: unknown) => unknown
 );
 
+const stepLogPath = '/dag-runs/{name}/{dagRunId}/steps/{stepName}/log';
+
 describe('NodeStatusTableRow', () => {
   beforeEach(() => {
-    mockedUseQuery.mockImplementation((_, init) => ({
-      data: init ? { content: 'Deploying production\n' } : undefined,
+    mockedUseQuery.mockImplementation((path, init) => ({
+      data:
+        path === stepLogPath && init
+          ? { content: 'Deploying production\n' }
+          : undefined,
       isLoading: false,
       error: undefined,
       isValidating: false,
@@ -114,11 +119,72 @@ describe('NodeStatusTableRow', () => {
 
     const message = screen.getByLabelText('Log message: Deploying production');
     expect(message).toBeInTheDocument();
-    expect(message).toHaveClass('w-[320px]');
     expect(message.querySelector('svg')).not.toBeInTheDocument();
     expect(
       screen.queryByText('Deploying ${ENVIRONMENT}')
     ).not.toBeInTheDocument();
     expect(screen.getByText('stdout')).toBeInTheDocument();
+  });
+
+  it('falls back to the configured log message when stdout cannot be loaded', () => {
+    mockedUseQuery.mockImplementation((path, init) => ({
+      data: undefined,
+      isLoading: false,
+      error:
+        path === stepLogPath && init ? new Error('log not found') : undefined,
+      isValidating: false,
+      mutate: vi.fn(),
+    }));
+
+    const node = {
+      step: {
+        name: 'announce',
+        executorConfig: {
+          type: 'log',
+          config: {
+            message: 'Deploying ${ENVIRONMENT}',
+          },
+        },
+      },
+      status: NodeStatus.Success,
+      statusLabel: NodeStatusLabel.succeeded,
+      stdout: '/tmp/announce.out',
+      stderr: '',
+      startedAt: '',
+      finishedAt: '',
+      retryCount: 0,
+      doneCount: 1,
+    } as components['schemas']['Node'];
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGContext.Provider
+            value={{
+              refresh: vi.fn(),
+              name: 'example',
+              fileName: 'example.yaml',
+            }}
+          >
+            <table>
+              <tbody>
+                <NodeStatusTableRow
+                  rownum={1}
+                  node={node}
+                  name="example.yaml"
+                  dagRun={dagRun}
+                  view="desktop"
+                />
+              </tbody>
+            </table>
+          </DAGContext.Provider>
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Loading log output...')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { components } from '@/api/v1/schema';
+import {
+  NodeStatus,
+  NodeStatusLabel,
+  Status,
+  StatusLabel,
+} from '@/api/v1/schema';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { DAGContext } from '../../../contexts/DAGContext';
+import NodeStatusTableRow from '../NodeStatusTableRow';
+
+vi.mock('@/hooks/api', () => ({
+  useClient: () => ({
+    PATCH: vi.fn(),
+    POST: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/ui/error-modal', () => ({
+  useErrorModal: () => ({
+    showError: vi.fn(),
+  }),
+}));
+
+const appBarValue = {
+  title: 'DAGs',
+  setTitle: vi.fn(),
+  remoteNodes: ['local'],
+  setRemoteNodes: vi.fn(),
+  selectedRemoteNode: 'local',
+  selectRemoteNode: vi.fn(),
+};
+
+const dagRun = {
+  name: 'example',
+  dagRunId: 'run-1',
+  status: Status.Success,
+  statusLabel: StatusLabel.succeeded,
+  startedAt: '',
+  finishedAt: '',
+  autoRetryCount: 0,
+} as components['schemas']['DAGRunDetails'];
+
+describe('NodeStatusTableRow', () => {
+  it('shows log step messages in the status table without opening step logs', () => {
+    const node = {
+      step: {
+        name: 'announce',
+        executorConfig: {
+          type: 'log',
+          config: {
+            message: 'Deploying ${ENVIRONMENT}',
+          },
+        },
+      },
+      status: NodeStatus.Success,
+      statusLabel: NodeStatusLabel.succeeded,
+      stdout: '/tmp/announce.out',
+      stderr: '',
+      startedAt: '',
+      finishedAt: '',
+      retryCount: 0,
+      doneCount: 1,
+    } as components['schemas']['Node'];
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGContext.Provider
+            value={{
+              refresh: vi.fn(),
+              name: 'example',
+              fileName: 'example.yaml',
+            }}
+          >
+            <table>
+              <tbody>
+                <NodeStatusTableRow
+                  rownum={1}
+                  node={node}
+                  name="example.yaml"
+                  dagRun={dagRun}
+                  view="desktop"
+                />
+              </tbody>
+            </table>
+          </DAGContext.Provider>
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
+    ).toBeInTheDocument();
+    expect(screen.getByText('stdout')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { components } from '@/api/v1/schema';
 import {
   NodeStatus,
@@ -13,6 +13,7 @@ import {
   StatusLabel,
 } from '@/api/v1/schema';
 import { AppBarContext } from '@/contexts/AppBarContext';
+import { useQuery } from '@/hooks/api';
 import { DAGContext } from '../../../contexts/DAGContext';
 import NodeStatusTableRow from '../NodeStatusTableRow';
 
@@ -21,6 +22,7 @@ vi.mock('@/hooks/api', () => ({
     PATCH: vi.fn(),
     POST: vi.fn(),
   }),
+  useQuery: vi.fn(),
 }));
 
 vi.mock('@/components/ui/error-modal', () => ({
@@ -48,7 +50,21 @@ const dagRun = {
   autoRetryCount: 0,
 } as components['schemas']['DAGRunDetails'];
 
+const mockedUseQuery = vi.mocked(
+  useQuery as unknown as (path: unknown, init: unknown) => unknown
+);
+
 describe('NodeStatusTableRow', () => {
+  beforeEach(() => {
+    mockedUseQuery.mockImplementation((_, init) => ({
+      data: init ? { content: 'Deploying production\n' } : undefined,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: vi.fn(),
+    }));
+  });
+
   it('shows log step messages in the status table without opening step logs', () => {
     const node = {
       step: {
@@ -96,9 +112,13 @@ describe('NodeStatusTableRow', () => {
       </MemoryRouter>
     );
 
+    const message = screen.getByLabelText('Log message: Deploying production');
+    expect(message).toBeInTheDocument();
+    expect(message).toHaveClass('w-[320px]');
+    expect(message.querySelector('svg')).not.toBeInTheDocument();
     expect(
-      screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
-    ).toBeInTheDocument();
+      screen.queryByText('Deploying ${ENVIRONMENT}')
+    ).not.toBeInTheDocument();
     expect(screen.getByText('stdout')).toBeInTheDocument();
   });
 });

--- a/ui/src/features/dags/components/step-details/StepDetails.tsx
+++ b/ui/src/features/dags/components/step-details/StepDetails.tsx
@@ -4,7 +4,9 @@
 import { components } from '@/api/v1/schema';
 import { Badge } from '@/components/ui/badge';
 import BorderedBox from '@/components/ui/bordered-box';
+import { getLogMessageFromConfig } from '@/lib/executor-utils';
 import React from 'react';
+import { LogStepMessage } from '../dag-details/LogStepMessage';
 
 type Step = components['schemas']['Step'];
 
@@ -161,10 +163,40 @@ function renderStepFieldValue(name: string, value: unknown): React.ReactNode {
   }
 
   if (isPlainObject(value)) {
+    if (name === 'executorConfig') {
+      return <ExecutorConfigField value={value} />;
+    }
     return <ObjectFieldCard value={value} />;
   }
 
   return <div className="text-sm text-foreground">{String(value)}</div>;
+}
+
+function ExecutorConfigField({ value }: { value: Record<string, unknown> }) {
+  const type = typeof value.type === 'string' ? value.type : '';
+  const config = isPlainObject(value.config) ? value.config : undefined;
+  const logMessage = type === 'log' ? getLogMessageFromConfig(config) : null;
+
+  if (logMessage === null) {
+    return <ObjectFieldCard value={value} />;
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-background p-3">
+      <div className="min-w-0">
+        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
+          Type
+        </div>
+        <Badge variant="outline">log</Badge>
+      </div>
+      <div className="min-w-0">
+        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
+          Message
+        </div>
+        <LogStepMessage message={logMessage} />
+      </div>
+    </div>
+  );
 }
 
 function ObjectFieldCard({ value }: { value: unknown }) {

--- a/ui/src/features/dags/components/step-details/__tests__/StepDetails.test.tsx
+++ b/ui/src/features/dags/components/step-details/__tests__/StepDetails.test.tsx
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import type { components } from '@/api/v1/schema';
+import { StepDetails } from '../StepDetails';
+
+describe('StepDetails', () => {
+  it('renders log executor messages as a first-class message field', () => {
+    const step = {
+      name: 'announce',
+      executorConfig: {
+        type: 'log',
+        config: {
+          message: 'Deploying ${ENVIRONMENT}',
+        },
+      },
+    } as components['schemas']['Step'];
+
+    render(<StepDetails step={step} />);
+
+    expect(screen.getByText('Executor')).toBeInTheDocument();
+    expect(screen.getByText('Message')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/src/lib/__tests__/executor-utils.test.ts
+++ b/ui/src/lib/__tests__/executor-utils.test.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { components } from '@/api/v1/schema';
+import { describe, expect, it } from 'vitest';
+import { getLogStepMessage } from '../executor-utils';
+
+describe('getLogStepMessage', () => {
+  it('returns the configured log message for log steps', () => {
+    const step = {
+      name: 'announce',
+      executorConfig: {
+        type: 'log',
+        config: {
+          message: 'Deploying ${ENVIRONMENT}',
+        },
+      },
+    } as components['schemas']['Step'];
+
+    expect(getLogStepMessage(step)).toBe('Deploying ${ENVIRONMENT}');
+  });
+
+  it('ignores non-log steps', () => {
+    const step = {
+      name: 'run',
+      executorConfig: {
+        type: 'command',
+        config: {},
+      },
+    } as components['schemas']['Step'];
+
+    expect(getLogStepMessage(step)).toBeNull();
+  });
+});

--- a/ui/src/lib/__tests__/executor-utils.test.ts
+++ b/ui/src/lib/__tests__/executor-utils.test.ts
@@ -3,7 +3,7 @@
 
 import type { components } from '@/api/v1/schema';
 import { describe, expect, it } from 'vitest';
-import { getLogStepMessage } from '../executor-utils';
+import { formatLogStepOutput, getLogStepMessage } from '../executor-utils';
 
 describe('getLogStepMessage', () => {
   it('returns the configured log message for log steps', () => {
@@ -30,5 +30,20 @@ describe('getLogStepMessage', () => {
     } as components['schemas']['Step'];
 
     expect(getLogStepMessage(step)).toBeNull();
+  });
+});
+
+describe('formatLogStepOutput', () => {
+  it('formats stdout content for inline log step display', () => {
+    expect(formatLogStepOutput('Deploying production\n')).toBe(
+      'Deploying production'
+    );
+    expect(formatLogStepOutput('one\r\ntwo\r\n')).toBe('one\ntwo');
+  });
+
+  it('removes ANSI escape codes from stdout content', () => {
+    expect(
+      formatLogStepOutput('\u001b[32mDeploying production\u001b[0m\n')
+    ).toBe('Deploying production');
   });
 });

--- a/ui/src/lib/executor-utils.ts
+++ b/ui/src/lib/executor-utils.ts
@@ -72,3 +72,16 @@ export function getLogMessageFromConfig(
   const message = config?.message;
   return typeof message === 'string' ? message : null;
 }
+
+const ANSI_CODES_REGEX = [
+  '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+  '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
+].join('|');
+
+export function formatLogStepOutput(content: string): string {
+  return content
+    .replace(new RegExp(ANSI_CODES_REGEX, 'g'), '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n+$/, '');
+}

--- a/ui/src/lib/executor-utils.ts
+++ b/ui/src/lib/executor-utils.ts
@@ -54,3 +54,21 @@ export function getExecutorCommand(
       return null;
   }
 }
+
+export function getLogStepMessage(
+  step: components['schemas']['Step']
+): string | null {
+  if (step.executorConfig?.type !== 'log') {
+    return null;
+  }
+
+  const config = step.executorConfig.config as Record<string, unknown>;
+  return getLogMessageFromConfig(config);
+}
+
+export function getLogMessageFromConfig(
+  config?: Record<string, unknown>
+): string | null {
+  const message = config?.message;
+  return typeof message === 'string' ? message : null;
+}

--- a/ui/src/lib/executor-utils.ts
+++ b/ui/src/lib/executor-utils.ts
@@ -77,10 +77,11 @@ const ANSI_CODES_REGEX = [
   '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
   '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
 ].join('|');
+const ANSI_CODES_RE = new RegExp(ANSI_CODES_REGEX, 'g');
 
 export function formatLogStepOutput(content: string): string {
   return content
-    .replace(new RegExp(ANSI_CODES_REGEX, 'g'), '')
+    .replace(ANSI_CODES_RE, '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .replace(/\n+$/, '');


### PR DESCRIPTION
## Summary
- add a built-in `log` step type that writes its resolved message to stdout
- register and validate `log` in the DAG spec/schema/runtime
- show log step output directly in the run status UI after execution, and show configured log messages in definition/details views

## Testing
- `go test ./internal/runtime/builtin ./internal/runtime/builtin/log ./internal/core/spec ./internal/runtime ./internal/cmn/schema -count=1`
- `pnpm exec vitest run src/lib/__tests__/executor-utils.test.ts src/features/dags/components/dag-details/__tests__/DAGStepTableRow.test.tsx src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx src/features/dags/components/step-details/__tests__/StepDetails.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "log" executor type allowing steps to emit configured messages.
  * UI: displays log messages in step tables, step details, and node status with truncation, tooltips, and remote log viewing.
  * Variable expansion for log messages and log output formatting/sanitization utilities.

* **Tests**
  * Schema and unit tests added/updated to validate log executor/config behavior and runtime output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->