### PR TITLE
feat: improve agent content navigation

### DIFF
--- a/ui/e2e/distributed-stack.spec.ts
+++ b/ui/e2e/distributed-stack.spec.ts
@@ -8,7 +8,6 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import {
   enqueueRunFromUI,
-  getQueue,
   getStepStdout,
   getWorkers,
   loadStack,
@@ -90,7 +89,9 @@ test('exercises the web UI against the real distributed shared-nothing worker st
     await expect(page.getByText('role=e2e')).toHaveCount(stack.workers.length);
 
     await page.goto(`/dags/${DAG_FILE}`);
-    await expect(page.getByText(DAG_NAME)).toBeVisible();
+    await expect(
+      page.getByRole('heading', { level: 1, name: DAG_NAME, exact: true })
+    ).toBeVisible();
 
     const firstRunId = await enqueueRunFromUI(page, DAG_FILE);
     const activeWorkerId = await waitForWorkerState(
@@ -128,15 +129,19 @@ test('exercises the web UI against the real distributed shared-nothing worker st
 
     await page.goto(`/queues/${stack.queues.shared}`);
     await expect(
-      page.getByText(stack.queues.shared, { exact: true }).first()
+      page.getByRole('link', { name: stack.queues.shared, exact: true })
     ).toBeVisible();
     await expect(page.getByText('Running (1)')).toBeVisible();
     await expect(page.getByText('Queued (1)')).toBeVisible();
-    await expect(page.getByText(DAG_NAME).first()).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: new RegExp(`\\b${escapeRegExp(DAG_NAME)}\\b`, 'i'),
+      })
+    ).toHaveCount(2);
 
     await page.goto('/system-status');
     await page.getByText(activeWorkerId).click();
-    await expect(page.getByText(DAG_NAME)).toBeVisible();
+    await expect(page.getByText(DAG_NAME, { exact: true })).toBeVisible();
 
     await releaseRuns();
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -66,6 +66,7 @@ import WorkflowDesignPage from './pages/design';
 import DocsPage from './pages/docs';
 import EventLogsPage from './pages/event-logs';
 import GitSyncPage from './pages/git-sync';
+import HomePage from './pages/home';
 import IntegrationsPage from './pages/integrations';
 import LicensePage from './pages/license';
 import LoginPage from './pages/login';
@@ -517,6 +518,10 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
                                           element={
                                             <OverviewPage initialTab="cockpit" />
                                           }
+                                        />
+                                        <Route
+                                          path="/home"
+                                          element={<HomePage />}
                                         />
                                         <Route
                                           path="/api-docs"

--- a/ui/src/features/agent/components/AgentChatPanel.tsx
+++ b/ui/src/features/agent/components/AgentChatPanel.tsx
@@ -23,6 +23,7 @@ type AgentChatPanelProps = {
   active?: boolean;
   className?: string;
   defaultSidebarOpen?: boolean;
+  onClose?: () => void;
   placeholder?: string;
   rememberSidebarState?: boolean;
   showDelegatePanels?: boolean;
@@ -56,6 +57,7 @@ export function AgentChatPanel({
   active = true,
   className,
   defaultSidebarOpen = true,
+  onClose,
   placeholder,
   rememberSidebarState = true,
   showDelegatePanels = true,
@@ -68,6 +70,7 @@ export function AgentChatPanel({
       className={className}
       controller={controller}
       defaultSidebarOpen={defaultSidebarOpen}
+      onClose={onClose}
       placeholder={placeholder}
       rememberSidebarState={rememberSidebarState}
       showDelegatePanels={showDelegatePanels}

--- a/ui/src/layouts/ContentNavigation.tsx
+++ b/ui/src/layouts/ContentNavigation.tsx
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Home } from 'lucide-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type BreadcrumbItemData = {
+  label: string;
+  to?: string;
+};
+
+const STATIC_ROUTE_LABELS: Record<string, string> = {
+  '/': 'Overview',
+  '/home': 'Home',
+  '/dashboard': 'Timeline',
+  '/cockpit': 'Cockpit',
+  '/api-docs': 'API Reference',
+  '/integrations': 'Integrations',
+  '/dags': 'DAGs',
+  '/search': 'Search',
+  '/base-config': 'Base Config',
+  '/docs': 'Runbooks',
+  '/queues': 'Queues',
+  '/dag-runs': 'DAG Runs',
+  '/system-status': 'System Status',
+  '/users': 'Users',
+  '/administration': 'Administration',
+  '/remote-nodes': 'Remote Nodes',
+  '/api-keys': 'API Keys',
+  '/webhooks': 'Webhooks',
+  '/terminal': 'Terminal',
+  '/event-logs': 'Events',
+  '/audit-logs': 'Audit Logs',
+  '/license': 'License',
+  '/git-sync': 'Git Sync',
+  '/agent': 'Agent',
+  '/agent-settings': 'Models',
+  '/agent-tools': 'Tools',
+  '/agent-memory': 'Memory',
+  '/agent-souls': 'Souls',
+};
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function humanizePathSegment(segment: string): string {
+  return decodePathSegment(segment)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
+  const normalized = pathname.replace(/\/+$/, '') || '/';
+  const segments = normalized.split('/').filter(Boolean);
+  const items: BreadcrumbItemData[] = [{ label: 'Home', to: '/home' }];
+
+  if (normalized === '/home') {
+    return [{ label: 'Home' }];
+  }
+
+  if (normalized === '/') {
+    return [...items, { label: 'Overview', to: '/' }];
+  }
+
+  if (segments[0] === 'dags') {
+    items.push({ label: 'Workflows' }, { label: 'DAGs', to: '/dags' });
+    if (segments[1]) {
+      items.push({
+        label: decodePathSegment(segments[1]),
+        to: `/dags/${segments[1]}`,
+      });
+    }
+    if (segments[2]) {
+      items.push({ label: humanizePathSegment(segments[2]) });
+    }
+    return items;
+  }
+
+  if (segments[0] === 'dag-runs') {
+    items.push({ label: 'Executions' }, { label: 'DAG Runs', to: '/dag-runs' });
+    if (segments[1]) {
+      items.push({ label: decodePathSegment(segments[1]) });
+    }
+    if (segments[2]) {
+      items.push({ label: decodePathSegment(segments[2]) });
+    }
+    return items;
+  }
+
+  if (segments[0] === 'queues') {
+    items.push({ label: 'Executions' }, { label: 'Queues', to: '/queues' });
+    if (segments[1]) {
+      items.push({ label: decodePathSegment(segments[1]) });
+    }
+    return items;
+  }
+
+  if (segments[0] === 'docs') {
+    items.push({ label: 'Workflows' }, { label: 'Runbooks', to: '/docs' });
+    for (const segment of segments.slice(1)) {
+      items.push({ label: decodePathSegment(segment) });
+    }
+    return items;
+  }
+
+  if (segments[0]?.startsWith('agent')) {
+    items.push(
+      { label: 'Administration', to: '/administration' },
+      { label: 'Agent', to: '/agent' }
+    );
+    if (normalized !== '/agent') {
+      items.push({ label: STATIC_ROUTE_LABELS[normalized] ?? 'Agent' });
+    }
+    return items;
+  }
+
+  if (
+    [
+      'users',
+      'administration',
+      'remote-nodes',
+      'api-keys',
+      'terminal',
+      'license',
+      'git-sync',
+    ].includes(segments[0] ?? '')
+  ) {
+    if (normalized !== '/administration') {
+      items.push({ label: 'Administration', to: '/administration' });
+    }
+    items.push({ label: STATIC_ROUTE_LABELS[normalized] ?? humanizePathSegment(segments[0] ?? '') });
+    return items;
+  }
+
+  if (['system-status', 'event-logs', 'audit-logs'].includes(segments[0] ?? '')) {
+    items.push({ label: 'Monitor' });
+    items.push({ label: STATIC_ROUTE_LABELS[normalized] ?? humanizePathSegment(segments[0] ?? '') });
+    return items;
+  }
+
+  if (['integrations', 'webhooks', 'api-docs'].includes(segments[0] ?? '')) {
+    if (normalized !== '/integrations') {
+      items.push({ label: 'Integrations', to: '/integrations' });
+    }
+    items.push({ label: STATIC_ROUTE_LABELS[normalized] ?? humanizePathSegment(segments[0] ?? '') });
+    return items;
+  }
+
+  const exactLabel = STATIC_ROUTE_LABELS[normalized];
+  if (exactLabel) {
+    items.push({ label: exactLabel, to: normalized });
+    return items;
+  }
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const path = `/${segments.slice(0, index + 1).join('/')}`;
+    items.push({
+      label: STATIC_ROUTE_LABELS[path] ?? humanizePathSegment(segments[index] ?? ''),
+      to: index === segments.length - 1 ? undefined : path,
+    });
+  }
+
+  return items;
+}
+
+export function ContentNavigation({
+  pathname,
+}: {
+  pathname: string;
+}): React.ReactElement {
+  const items = getBreadcrumbItems(pathname);
+
+  return (
+    <div className="hidden min-h-12 items-center gap-3 border-b border-border bg-background/95 px-4 backdrop-blur md:flex">
+      <Button asChild variant="ghost" size="icon-sm" className="shrink-0">
+        <Link to="/home" aria-label="Content home">
+          <Home className="h-4 w-4" />
+        </Link>
+      </Button>
+      <Breadcrumb className="min-w-0">
+        <BreadcrumbList className="min-w-0 flex-nowrap overflow-hidden">
+          {items.map((item, index) => {
+            const isLast = index === items.length - 1;
+            return (
+              <React.Fragment key={`${item.label}-${index}`}>
+                {index > 0 && <BreadcrumbSeparator className="shrink-0" />}
+                <BreadcrumbItem className="min-w-0">
+                  {isLast || !item.to ? (
+                    <BreadcrumbPage
+                      className={cn(
+                        'block truncate',
+                        item.label.length > 28 && 'max-w-[28ch]'
+                      )}
+                    >
+                      {item.label}
+                    </BreadcrumbPage>
+                  ) : (
+                    <Link
+                      to={item.to}
+                      className="block truncate text-muted-foreground hover:text-foreground"
+                    >
+                      {item.label}
+                    </Link>
+                  )}
+                </BreadcrumbItem>
+              </React.Fragment>
+            );
+          })}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/ui/src/layouts/ContentNavigation.tsx
+++ b/ui/src/layouts/ContentNavigation.tsx
@@ -48,6 +48,7 @@ const STATIC_ROUTE_LABELS: Record<string, string> = {
   '/agent-tools': 'Tools',
   '/agent-memory': 'Memory',
   '/agent-souls': 'Souls',
+  '/agent-souls/new': 'New Soul',
 };
 
 function decodePathSegment(segment: string): string {
@@ -121,11 +122,30 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
   if (segments[0]?.startsWith('agent')) {
     items.push(
       { label: 'Administration', to: '/administration' },
-      { label: 'Agent', to: '/agent' }
+      { label: 'Agent', to: normalized === '/agent' ? undefined : '/agent' }
     );
-    if (normalized !== '/agent') {
-      items.push({ label: STATIC_ROUTE_LABELS[normalized] ?? 'Agent' });
+
+    if (normalized === '/agent') {
+      return items;
     }
+
+    const sectionPath = `/${segments[0]}`;
+    items.push({
+      label:
+        STATIC_ROUTE_LABELS[sectionPath] ??
+        humanizePathSegment(segments[0] ?? ''),
+      to: normalized === sectionPath ? undefined : sectionPath,
+    });
+
+    for (let index = 1; index < segments.length; index += 1) {
+      const path = `${sectionPath}/${segments.slice(1, index + 1).join('/')}`;
+      items.push({
+        label:
+          STATIC_ROUTE_LABELS[path] ?? decodePathSegment(segments[index] ?? ''),
+        to: index === segments.length - 1 ? undefined : path,
+      });
+    }
+
     return items;
   }
 

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -4,9 +4,10 @@ import { useConfig } from '@/contexts/ConfigContext';
 import { cn } from '@/lib/utils';
 import { getResponsiveTitleClass } from '@/lib/text-utils';
 import { Menu, Terminal, X } from 'lucide-react';
-import { useAgentChatContext } from '@/features/agent';
+import { AgentChatPanel, useAgentChatContext } from '@/features/agent';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
+import { ContentNavigation } from './ContentNavigation';
 import { mainListItems as MainListItems } from '../menu';
 
 /**
@@ -66,11 +67,57 @@ function getSidebarOverlayColor(foreground: string, alpha: number): string {
 }
 
 // Constants
+const NAV_SIDEBAR_EXPANDED_WIDTH = 240;
+const NAV_SIDEBAR_COLLAPSED_WIDTH = 56;
+const AGENT_SIDEBAR_DEFAULT_WIDTH = 420;
+const AGENT_SIDEBAR_MIN_WIDTH = 320;
+const AGENT_SIDEBAR_MAX_WIDTH = 720;
+const AGENT_SIDEBAR_MIN_CONTENT_WIDTH = 360;
+const AGENT_SIDEBAR_WIDTH_STORAGE_KEY = 'agentSidebarWidth';
+
+type SidebarMode = 'navigation' | 'agent';
 
 type LayoutProps = {
   navbarColor?: string;
   children?: React.ReactElement | React.ReactElement[];
 };
+
+function getAgentSidebarMaxWidth(): number {
+  if (typeof window === 'undefined') {
+    return AGENT_SIDEBAR_MAX_WIDTH;
+  }
+
+  return Math.max(
+    AGENT_SIDEBAR_MIN_WIDTH,
+    Math.min(
+      AGENT_SIDEBAR_MAX_WIDTH,
+      window.innerWidth - AGENT_SIDEBAR_MIN_CONTENT_WIDTH
+    )
+  );
+}
+
+function clampAgentSidebarWidth(width: number): number {
+  return Math.min(
+    getAgentSidebarMaxWidth(),
+    Math.max(AGENT_SIDEBAR_MIN_WIDTH, Math.round(width))
+  );
+}
+
+function getInitialAgentSidebarWidth(): number {
+  try {
+    const saved = localStorage.getItem(AGENT_SIDEBAR_WIDTH_STORAGE_KEY);
+    if (saved) {
+      const parsed = Number(saved);
+      if (Number.isFinite(parsed)) {
+        return clampAgentSidebarWidth(parsed);
+      }
+    }
+  } catch {
+    // Ignore unavailable storage and fall back to the default width.
+  }
+
+  return clampAgentSidebarWidth(AGENT_SIDEBAR_DEFAULT_WIDTH);
+}
 
 /**
  * Render the application's main layout with a responsive sidebar and scrollable content area.
@@ -116,13 +163,63 @@ function Content({ navbarColor, children }: LayoutProps) {
     const saved = localStorage.getItem('sidebarExpanded');
     return saved ? saved === 'true' : true;
   });
+  const [sidebarMode, setSidebarMode] =
+    React.useState<SidebarMode>('navigation');
+  const [agentSidebarWidth, setAgentSidebarWidth] = React.useState(
+    getInitialAgentSidebarWidth
+  );
+  const [isResizingAgentSidebar, setIsResizingAgentSidebar] =
+    React.useState(false);
   // Mobile sidebar state (hidden by default)
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = React.useState(false);
+  const isAgentSidebarOpen = sidebarMode === 'agent' && config.agentEnabled;
 
   // Save sidebar state to localStorage when it changes
   React.useEffect(() => {
     localStorage.setItem('sidebarExpanded', isSidebarExpanded.toString());
   }, [isSidebarExpanded]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(
+        AGENT_SIDEBAR_WIDTH_STORAGE_KEY,
+        agentSidebarWidth.toString()
+      );
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }, [agentSidebarWidth]);
+
+  React.useEffect(() => {
+    if (!config.agentEnabled && sidebarMode === 'agent') {
+      setSidebarMode('navigation');
+    }
+  }, [config.agentEnabled, sidebarMode]);
+
+  React.useEffect(() => {
+    if (!isResizingAgentSidebar) {
+      return undefined;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      setAgentSidebarWidth(clampAgentSidebarWidth(event.clientX));
+    };
+    const handlePointerUp = () => setIsResizingAgentSidebar(false);
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [isResizingAgentSidebar]);
 
   const isDesignWorkspace =
     location.pathname === '/design' || location.pathname.startsWith('/design/');
@@ -140,31 +237,110 @@ function Content({ navbarColor, children }: LayoutProps) {
     setIsSidebarExpanded(!isSidebarExpanded);
   };
 
+  const openAgentSidebar = () => {
+    if (config.agentEnabled) {
+      setSidebarMode('agent');
+    }
+  };
+
+  const closeAgentSidebar = () => {
+    setSidebarMode('navigation');
+  };
+
+  const startAgentSidebarResize = (
+    event: React.PointerEvent<HTMLDivElement>
+  ) => {
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    setIsResizingAgentSidebar(true);
+  };
+
+  const handleAgentSidebarResizeKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    const step = event.shiftKey ? 40 : 16;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setAgentSidebarWidth((width) => clampAgentSidebarWidth(width - step));
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setAgentSidebarWidth((width) => clampAgentSidebarWidth(width + step));
+    }
+  };
+
+  const desktopSidebarWidth = isAgentSidebarOpen
+    ? agentSidebarWidth
+    : isSidebarExpanded
+      ? NAV_SIDEBAR_EXPANDED_WIDTH
+      : NAV_SIDEBAR_COLLAPSED_WIDTH;
+  const desktopSidebarStyle = {
+    ...(isAgentSidebarOpen ? {} : sidebarStyle),
+    width: desktopSidebarWidth,
+    transition: isResizingAgentSidebar
+      ? 'none'
+      : 'width 280ms cubic-bezier(0.4, 0, 0.2, 1)',
+  } as React.CSSProperties;
+
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background">
       {/* Sidebar - Desktop - Developer-tool */}
       <aside
+        data-testid="app-sidebar"
         className={cn(
-          'hidden md:block h-full border-r border-border z-20',
-          isSidebarExpanded ? 'w-[240px]' : 'w-[56px]',
-          !hasCustomColor && 'bg-sidebar text-sidebar-foreground',
-          hasCustomColor && 'custom-sidebar-color'
+          'hidden md:block h-full shrink-0 border-r border-border z-20',
+          isAgentSidebarOpen
+            ? 'bg-card text-foreground'
+            : [
+                !hasCustomColor && 'bg-sidebar text-sidebar-foreground',
+                hasCustomColor && 'custom-sidebar-color',
+              ]
         )}
-        style={{
-          ...sidebarStyle,
-          transition: 'width 280ms cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
+        style={desktopSidebarStyle}
       >
         <div className="flex flex-col h-full">
-          <nav className="flex-1 overflow-y-auto min-h-0 px-2 py-3">
-            <MainListItems
-              isOpen={isSidebarExpanded}
-              onToggle={toggleSidebar}
-              customColor={hasCustomColor}
+          {isAgentSidebarOpen ? (
+            <AgentChatPanel
+              active
+              className="h-full"
+              defaultSidebarOpen={false}
+              onClose={closeAgentSidebar}
+              placeholder="Ask me to create a DAG, run a command..."
             />
-          </nav>
+          ) : (
+            <nav className="flex-1 overflow-y-auto min-h-0 px-2 py-3">
+              <MainListItems
+                isOpen={isSidebarExpanded}
+                onAgentModeToggle={openAgentSidebar}
+                onToggle={toggleSidebar}
+                customColor={hasCustomColor}
+              />
+            </nav>
+          )}
         </div>
       </aside>
+
+      {isAgentSidebarOpen && (
+        <div
+          role="separator"
+          aria-label="Resize agent panel"
+          aria-orientation="vertical"
+          aria-valuemin={AGENT_SIDEBAR_MIN_WIDTH}
+          aria-valuemax={getAgentSidebarMaxWidth()}
+          aria-valuenow={agentSidebarWidth}
+          tabIndex={0}
+          className={cn(
+            'hidden md:flex h-full w-1 shrink-0 cursor-col-resize items-center justify-center z-20',
+            'bg-border/30 transition-colors hover:bg-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            isResizingAgentSidebar && 'bg-primary/60'
+          )}
+          onPointerDown={startAgentSidebarResize}
+          onKeyDown={handleAgentSidebarResizeKeyDown}
+        >
+          <div className="h-8 w-px rounded-full bg-muted-foreground/40" />
+        </div>
+      )}
 
       {/* Main Content Area - Developer-tool */}
       <div className="flex flex-col flex-1 h-full overflow-hidden relative bg-background">
@@ -207,6 +383,7 @@ function Content({ navbarColor, children }: LayoutProps) {
 
         {/* Scrollable Content - More Compact Padding */}
         <main className="flex-1 overflow-auto">
+          <ContentNavigation pathname={location.pathname} />
           <UpdateBanner />
           <LicenseBanner />
           <div className="p-4 md:p-6 w-full h-full">{children}</div>

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { LicenseBanner } from '@/components/LicenseBanner';
 import { UpdateBanner } from '@/components/UpdateBanner';
 import { useConfig } from '@/contexts/ConfigContext';
@@ -393,11 +396,13 @@ function Content({ navbarColor, children }: LayoutProps) {
         </header>
 
         {/* Scrollable Content - More Compact Padding */}
-        <main className="flex-1 overflow-auto">
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <ContentNavigation pathname={location.pathname} />
           <UpdateBanner />
           <LicenseBanner />
-          <div className="p-4 md:p-6 w-full h-full">{children}</div>
+          <div className="min-h-0 flex-1 overflow-auto p-4 md:p-6 w-full">
+            {children}
+          </div>
         </main>
       </div>
 

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -221,6 +221,17 @@ function Content({ navbarColor, children }: LayoutProps) {
     };
   }, [isResizingAgentSidebar]);
 
+  React.useEffect(() => {
+    const handleResize = () => {
+      setAgentSidebarWidth((width) => clampAgentSidebarWidth(width));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   const isDesignWorkspace =
     location.pathname === '/design' || location.pathname.startsWith('/design/');
 

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -1,10 +1,10 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConfigContext, type Config } from '@/contexts/ConfigContext';
 import Layout from '../Layout';
 
@@ -18,10 +18,27 @@ vi.mock('@/components/UpdateBanner', () => ({
 
 vi.mock('@/features/agent', () => ({
   useAgentChatContext: () => ({ toggleChat: vi.fn() }),
+  AgentChatPanel: ({ onClose }: { onClose?: () => void }) => (
+    <div data-testid="agent-sidebar">
+      <button type="button" onClick={onClose}>
+        Close Agent
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../../menu', () => ({
-  mainListItems: () => <div data-testid="sidebar-menu">Sidebar</div>,
+  mainListItems: ({
+    onAgentModeToggle,
+  }: {
+    onAgentModeToggle?: () => void;
+  }) => (
+    <div data-testid="sidebar-menu">
+      <button type="button" onClick={onAgentModeToggle}>
+        Open Agent
+      </button>
+    </div>
+  ),
 }));
 
 const config = {
@@ -43,6 +60,10 @@ function renderLayout(path: string): void {
 }
 
 describe('Layout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('keeps the app sidebar visible on the agent home page', () => {
     renderLayout('/agent');
 
@@ -50,10 +71,62 @@ describe('Layout', () => {
     expect(screen.getByText('Page Content')).toBeVisible();
   });
 
+  it('renders content home navigation and breadcrumbs for detail pages', () => {
+    renderLayout(
+      '/dag-runs/briefing_gmail_fetch_test/019df6cf-0127-7340-bd96-d51bc1453045'
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Content home' })
+    ).toHaveAttribute('href', '/home');
+    expect(screen.getByRole('link', { name: 'DAG Runs' })).toHaveAttribute(
+      'href',
+      '/dag-runs'
+    );
+    expect(screen.getByText('briefing_gmail_fetch_test')).toBeVisible();
+    expect(
+      screen.getByText('019df6cf-0127-7340-bd96-d51bc1453045')
+    ).toBeVisible();
+  });
+
   it('keeps workflow design fullscreen without the app sidebar', () => {
     renderLayout('/design');
 
     expect(screen.queryByTestId('sidebar-menu')).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Content home' })
+    ).not.toBeInTheDocument();
     expect(screen.getByText('Page Content')).toBeVisible();
+  });
+
+  it('switches the desktop sidebar into the agent panel without covering content', () => {
+    renderLayout('/cockpit');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Agent' }));
+
+    expect(screen.queryByTestId('sidebar-menu')).toBeNull();
+    expect(screen.getByTestId('agent-sidebar')).toBeVisible();
+    expect(
+      screen.getByRole('separator', { name: 'Resize agent panel' })
+    ).toBeVisible();
+    expect(screen.getByText('Page Content')).toBeVisible();
+  });
+
+  it('resizes the agent sidebar from the divider', () => {
+    renderLayout('/cockpit');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Agent' }));
+    const sidebar = screen.getByTestId('app-sidebar');
+    const divider = screen.getByRole('separator', {
+      name: 'Resize agent panel',
+    });
+
+    expect(sidebar).toHaveStyle({ width: '420px' });
+
+    fireEvent.pointerDown(divider, { clientX: 420 });
+    fireEvent.pointerMove(document, { clientX: 520 });
+    fireEvent.pointerUp(document);
+
+    expect(sidebar).toHaveStyle({ width: '520px' });
   });
 });

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -62,6 +62,11 @@ function renderLayout(path: string): void {
 describe('Layout', () => {
   beforeEach(() => {
     localStorage.clear();
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
   });
 
   it('keeps the app sidebar visible on the agent home page', () => {
@@ -87,6 +92,20 @@ describe('Layout', () => {
     expect(
       screen.getByText('019df6cf-0127-7340-bd96-d51bc1453045')
     ).toBeVisible();
+  });
+
+  it('preserves nested agent page labels in breadcrumbs', () => {
+    renderLayout('/agent-souls/new');
+
+    expect(screen.getByRole('link', { name: 'Agent' })).toHaveAttribute(
+      'href',
+      '/agent'
+    );
+    expect(screen.getByRole('link', { name: 'Souls' })).toHaveAttribute(
+      'href',
+      '/agent-souls'
+    );
+    expect(screen.getByText('New Soul')).toBeVisible();
   });
 
   it('keeps workflow design fullscreen without the app sidebar', () => {
@@ -128,5 +147,30 @@ describe('Layout', () => {
     fireEvent.pointerUp(document);
 
     expect(sidebar).toHaveStyle({ width: '520px' });
+  });
+
+  it('reclamps the saved agent sidebar width when the viewport narrows', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1200,
+      writable: true,
+    });
+    localStorage.setItem('agentSidebarWidth', '720');
+    renderLayout('/cockpit');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Agent' }));
+    const sidebar = screen.getByTestId('app-sidebar');
+
+    expect(sidebar).toHaveStyle({ width: '720px' });
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 700,
+      writable: true,
+    });
+    fireEvent.resize(window);
+
+    expect(sidebar).toHaveStyle({ width: '340px' });
+    expect(localStorage.getItem('agentSidebarWidth')).toBe('340');
   });
 });

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -54,6 +54,7 @@ type NavItemProps = {
 
 type MainListItemsProps = {
   isOpen?: boolean;
+  onAgentModeToggle?: () => void;
   onNavItemClick?: () => void;
   onToggle?: () => void;
   customColor?: boolean;
@@ -445,7 +446,13 @@ export const mainListItems = React.forwardRef<
   HTMLDivElement,
   MainListItemsProps
 >(function MainListItems(
-  { isOpen = false, onNavItemClick, onToggle, customColor = false },
+  {
+    isOpen = false,
+    onAgentModeToggle,
+    onNavItemClick,
+    onToggle,
+    customColor = false,
+  },
   ref
 ) {
   const config = useConfig();
@@ -463,6 +470,7 @@ export const mainListItems = React.forwardRef<
   const canViewAuditLogs = useCanViewAuditLogs();
   const { preferences, updatePreference } = useUserPreferences();
   const { toggleChat } = useAgentChatContext();
+  const handleAgentClick = onAgentModeToggle ?? toggleChat;
 
   const theme = preferences.theme || 'dark';
   const title = config.title || DEFAULT_TITLE;
@@ -894,7 +902,7 @@ export const mainListItems = React.forwardRef<
         >
           {config.agentEnabled && (
             <SidebarButton
-              onClick={toggleChat}
+              onClick={handleAgentClick}
               icon={<Terminal size={18} />}
               label="Agent"
               isOpen={isOpen}

--- a/ui/src/pages/home/__tests__/index.test.tsx
+++ b/ui/src/pages/home/__tests__/index.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserRole } from '@/api/v1/schema';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { ConfigContext, type Config } from '@/contexts/ConfigContext';
+import { defaultWorkspaceSelection } from '@/lib/workspace';
+
+import HomePage from '..';
+
+const useAuthMock = vi.fn();
+const useIsAdminMock = vi.fn();
+const useCanAccessSystemStatusMock = vi.fn();
+const useCanViewEventLogsMock = vi.fn();
+const useCanManageWebhooksMock = vi.fn();
+const useCanViewAuditLogsMock = vi.fn();
+const useHasFeatureMock = vi.fn();
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
+  useIsAdmin: () => useIsAdminMock(),
+  useCanAccessSystemStatus: () => useCanAccessSystemStatusMock(),
+  useCanViewEventLogs: () => useCanViewEventLogsMock(),
+  useCanManageWebhooks: () => useCanManageWebhooksMock(),
+  useCanViewAuditLogs: () => useCanViewAuditLogsMock(),
+}));
+
+vi.mock('@/hooks/useLicense', () => ({
+  useHasFeature: (feature: string) => useHasFeatureMock(feature),
+}));
+
+const config = {
+  title: 'Dagu',
+  navbarColor: '',
+  authMode: 'builtin',
+  terminalEnabled: true,
+  gitSyncEnabled: true,
+  agentEnabled: true,
+  permissions: {
+    writeDags: true,
+    runDags: true,
+  },
+} as Config;
+
+function renderHome(configOverride: Partial<Config> = {}): void {
+  render(
+    <MemoryRouter>
+      <ConfigContext.Provider value={{ ...config, ...configOverride }}>
+        <AppBarContext.Provider
+          value={{
+            title: '',
+            setTitle: vi.fn(),
+            remoteNodes: ['local'],
+            setRemoteNodes: vi.fn(),
+            selectedRemoteNode: 'local',
+            selectRemoteNode: vi.fn(),
+            workspaces: [],
+            workspaceError: null,
+            workspaceSelection: defaultWorkspaceSelection(),
+            selectWorkspace: vi.fn(),
+            createWorkspace: vi.fn(),
+            deleteWorkspace: vi.fn(),
+          }}
+        >
+          <HomePage />
+        </AppBarContext.Provider>
+      </ConfigContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: { id: '1', username: 'admin', role: UserRole.admin },
+    });
+    useIsAdminMock.mockReturnValue(true);
+    useCanAccessSystemStatusMock.mockReturnValue(true);
+    useCanViewEventLogsMock.mockReturnValue(true);
+    useCanManageWebhooksMock.mockReturnValue(true);
+    useCanViewAuditLogsMock.mockReturnValue(true);
+    useHasFeatureMock.mockReturnValue(true);
+  });
+
+  it('renders grouped navigation cards for the main app areas', () => {
+    renderHome();
+
+    expect(
+      screen.getByRole('heading', { name: 'Home' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Overview/i })).toHaveAttribute(
+      'href',
+      '/'
+    );
+    expect(screen.getByRole('link', { name: /DAG Runs/i })).toHaveAttribute(
+      'href',
+      '/dag-runs'
+    );
+    expect(
+      screen.getByRole('link', { name: /Administration/i })
+    ).toHaveAttribute('href', '/administration');
+  });
+});

--- a/ui/src/pages/home/index.tsx
+++ b/ui/src/pages/home/index.tsx
@@ -1,0 +1,262 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Title from '@/components/ui/title';
+import {
+  useAuth,
+  useCanAccessSystemStatus,
+  useCanManageWebhooks,
+  useCanViewAuditLogs,
+  useCanViewEventLogs,
+  useIsAdmin,
+} from '@/contexts/AuthContext';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { useConfig } from '@/contexts/ConfigContext';
+import { useHasFeature } from '@/hooks/useLicense';
+import { roleAtLeast } from '@/lib/workspaceAccess';
+import { UserRole } from '@/api/v1/schema';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type HomeLink = {
+  to: string;
+  label: string;
+  description: string;
+};
+
+type HomeSection = {
+  title: string;
+  links: HomeLink[];
+};
+
+function SectionLinks({
+  section,
+}: {
+  section: HomeSection;
+}): React.ReactElement {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+        {section.title}
+      </h3>
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {section.links.map((link) => (
+          <Link
+            key={link.to}
+            to={link.to}
+            className="rounded-md border border-border bg-card px-4 py-3 transition-colors hover:border-border-strong hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <span className="block text-sm font-medium text-foreground">
+              {link.label}
+            </span>
+            <span className="mt-1 block text-xs text-muted-foreground">
+              {link.description}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function HomePage(): React.ReactElement {
+  const { setTitle } = React.useContext(AppBarContext);
+  const config = useConfig();
+  const { user } = useAuth();
+  const isAdmin = useIsAdmin();
+  const hasAudit = useHasFeature('audit');
+  const canWrite =
+    config.authMode !== 'builtin'
+      ? config.permissions.writeDags
+      : roleAtLeast(user?.role ?? null, UserRole.developer);
+  const canAccessSystemStatus = useCanAccessSystemStatus();
+  const canManageWebhooks = useCanManageWebhooks();
+  const canViewEventLogs = useCanViewEventLogs();
+  const canViewAuditLogs = useCanViewAuditLogs();
+
+  React.useEffect(() => {
+    setTitle('Home');
+  }, [setTitle]);
+
+  const sections: HomeSection[] = [
+    {
+      title: 'Overview',
+      links: [
+        {
+          to: '/',
+          label: 'Overview',
+          description: 'Review workflow status and recent activity.',
+        },
+        {
+          to: '/dashboard',
+          label: 'Timeline',
+          description: 'Inspect scheduled and historical execution trends.',
+        },
+        {
+          to: '/cockpit',
+          label: 'Cockpit',
+          description: 'Work through active and waiting runs.',
+        },
+      ],
+    },
+    {
+      title: 'Workflows',
+      links: [
+        {
+          to: '/dags',
+          label: 'DAGs',
+          description: 'Browse and open workflow definitions.',
+        },
+        {
+          to: '/search',
+          label: 'Search',
+          description: 'Find workflows and documentation.',
+        },
+        {
+          to: '/docs',
+          label: 'Runbooks',
+          description: 'Read and edit operational docs.',
+        },
+        ...(canWrite
+          ? [
+              {
+                to: '/base-config',
+                label: 'Base Config',
+                description: 'Edit shared workflow defaults.',
+              },
+            ]
+          : []),
+        ...(canWrite && config.gitSyncEnabled
+          ? [
+              {
+                to: '/git-sync',
+                label: 'Git Sync',
+                description: 'Sync workflow files with Git.',
+              },
+            ]
+          : []),
+      ],
+    },
+    {
+      title: 'Executions',
+      links: [
+        {
+          to: '/dag-runs',
+          label: 'DAG Runs',
+          description: 'Review run history and execution state.',
+        },
+        {
+          to: '/queues',
+          label: 'Queues',
+          description: 'Inspect queued workflow work.',
+        },
+      ],
+    },
+    {
+      title: 'Monitor',
+      links: [
+        ...(canAccessSystemStatus
+          ? [
+              {
+                to: '/system-status',
+                label: 'System Status',
+                description: 'Check services, paths, and runtime health.',
+              },
+            ]
+          : []),
+        ...(canViewEventLogs
+          ? [
+              {
+                to: '/event-logs',
+                label: 'Events',
+                description: 'Inspect workflow and system events.',
+              },
+            ]
+          : []),
+        ...(canViewAuditLogs
+          ? [
+              {
+                to: '/audit-logs',
+                label: hasAudit ? 'Audit Logs' : 'Audit Logs (Pro)',
+                description: 'Review administrative activity.',
+              },
+            ]
+          : []),
+      ],
+    },
+    {
+      title: 'Integrations',
+      links: [
+        {
+          to: '/integrations',
+          label: 'Integrations',
+          description: 'Open integration entry points.',
+        },
+        ...(canManageWebhooks
+          ? [
+              {
+                to: '/webhooks',
+                label: 'Webhooks',
+                description: 'Manage webhook endpoints.',
+              },
+            ]
+          : []),
+        {
+          to: '/api-docs',
+          label: 'API Reference',
+          description: 'Browse HTTP API documentation.',
+        },
+      ],
+    },
+    {
+      title: 'Administration',
+      links: isAdmin
+        ? [
+            {
+              to: '/administration',
+              label: 'Administration',
+              description: 'Open access, infrastructure, and agent settings.',
+            },
+            {
+              to: '/remote-nodes',
+              label: 'Remote Nodes',
+              description: 'Configure distributed execution targets.',
+            },
+            ...(config.terminalEnabled
+              ? [
+                  {
+                    to: '/terminal',
+                    label: 'Terminal',
+                    description: 'Open a server-side shell.',
+                  },
+                ]
+              : []),
+            {
+              to: '/license',
+              label: 'License',
+              description: 'Review plan and entitlement status.',
+            },
+            ...(config.agentEnabled
+              ? [
+                  {
+                    to: '/agent',
+                    label: 'Agent',
+                    description: 'Configure models, tools, memory, and souls.',
+                  },
+                ]
+              : []),
+          ]
+        : [],
+    },
+  ].filter((section) => section.links.length > 0);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-5 overflow-auto">
+      <Title>Home</Title>
+
+      {sections.map((section) => (
+        <SectionLinks key={section.title} section={section} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the floating agent modal flow with a desktop sidebar mode that can be toggled from navigation and resized.
- Add a right-content navigation bar with a home shortcut and breadcrumbs for detail pages.
- Add a `/home` navigation hub modeled after the Administration page card layout.

## Validation
- `pnpm --dir ui test src/layouts/__tests__/Layout.test.tsx src/pages/home/__tests__/index.test.tsx src/__tests__/menu.test.tsx`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui exec eslint src/App.tsx src/layouts/Layout.tsx src/layouts/ContentNavigation.tsx src/layouts/__tests__/Layout.test.tsx src/pages/home/index.tsx src/pages/home/__tests__/index.test.tsx src/menu.tsx src/features/agent/components/AgentChatPanel.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New home dashboard with configurable, permission-aware navigation.
  * Dynamic breadcrumb navigation for clearer context.
  * Resizable agent sidebar, integrated agent panel with a close action, and additional UI entry point to toggle agent mode.

* **Tests**
  * Expanded unit and end-to-end tests covering home page, breadcrumbs, agent panel behavior, resizing, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->