### PR TITLE
feat: add worker prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ Dagu exposes Prometheus-compatible metrics:
 - `dagu_dag_runs_currently_running` — Active DAG runs
 - `dagu_dag_runs_queued_total` — Queued runs
 - `dagu_workers_registered` — Registered distributed workers
+- `dagu_worker_info` — Worker heartbeat labels as key/value metadata
 - `dagu_worker_heartbeat_timestamp_seconds` — Last worker heartbeat timestamp
 - `dagu_worker_health_status` — Worker health by heartbeat freshness
 - `dagu_worker_pollers` — Worker poller capacity by state

--- a/README.md
+++ b/README.md
@@ -593,6 +593,12 @@ Dagu exposes Prometheus-compatible metrics:
 - `dagu_dag_run_duration_seconds` — Histogram of run durations
 - `dagu_dag_runs_currently_running` — Active DAG runs
 - `dagu_dag_runs_queued_total` — Queued runs
+- `dagu_workers_registered` — Registered distributed workers
+- `dagu_worker_heartbeat_timestamp_seconds` — Last worker heartbeat timestamp
+- `dagu_worker_health_status` — Worker health by heartbeat freshness
+- `dagu_worker_pollers` — Worker poller capacity by state
+- `dagu_worker_running_tasks` — Running tasks per worker
+- `dagu_worker_oldest_running_task_age_seconds` — Age of the oldest running task per worker
 
 ### Structured Logging
 

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -588,6 +588,7 @@ func (c *Context) NewServer(rs *resource.Service, opts ...frontend.ServerOption)
 		c.QueueStore,
 		c.ServiceRegistry,
 	)
+	collector.SetWorkerHeartbeatStore(c.WorkerHeartbeatStore)
 
 	// Register DAG definition cache for metrics
 	collector.RegisterCache(dc)

--- a/internal/cmn/telemetry/collector.go
+++ b/internal/cmn/telemetry/collector.go
@@ -6,6 +6,9 @@ package telemetry
 import (
 	"context"
 	"runtime"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,22 +34,24 @@ var (
 var _ prometheus.Collector = (*Collector)(nil)
 
 type Collector struct {
-	startTime       time.Time
-	version         string
-	dagStore        exec.DAGStore
-	dagRunStore     exec.DAGRunStore
-	queueStore      exec.QueueStore
-	serviceRegistry exec.ServiceRegistry
-	caches          []fileutil.CacheMetrics
+	startTime            time.Time
+	version              string
+	dagStore             exec.DAGStore
+	dagRunStore          exec.DAGRunStore
+	queueStore           exec.QueueStore
+	serviceRegistry      exec.ServiceRegistry
+	workerHeartbeatStore exec.WorkerHeartbeatStore
+	caches               []fileutil.CacheMetrics
 
 	// Metric descriptors (aggregate - backward compatible)
-	infoDesc             *prometheus.Desc
-	uptimeDesc           *prometheus.Desc
-	dagRunsCurrentlyDesc *prometheus.Desc
-	dagRunsQueuedDesc    *prometheus.Desc
-	dagRunsTotalDesc     *prometheus.Desc
-	dagsTotalDesc        *prometheus.Desc
-	schedulerRunningDesc *prometheus.Desc
+	infoDesc              *prometheus.Desc
+	uptimeDesc            *prometheus.Desc
+	dagRunsCurrentlyDesc  *prometheus.Desc
+	dagRunsQueuedDesc     *prometheus.Desc
+	dagRunsTotalDesc      *prometheus.Desc
+	dagsTotalDesc         *prometheus.Desc
+	schedulerRunningDesc  *prometheus.Desc
+	workersRegisteredDesc *prometheus.Desc
 
 	// Metric descriptors (per-DAG)
 	dagRunsCurrentlyByDAGDesc *prometheus.Desc
@@ -120,6 +125,12 @@ func NewCollector(
 			nil,
 			nil,
 		),
+		workersRegisteredDesc: prometheus.NewDesc(
+			"dagu_workers_registered",
+			"Number of workers registered via heartbeat",
+			nil,
+			nil,
+		),
 
 		// Per-DAG metric descriptors
 		dagRunsCurrentlyByDAGDesc: prometheus.NewDesc(
@@ -163,6 +174,13 @@ func NewCollector(
 	}
 }
 
+// SetWorkerHeartbeatStore sets the worker heartbeat store used for worker metrics.
+func (c *Collector) SetWorkerHeartbeatStore(store exec.WorkerHeartbeatStore) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.workerHeartbeatStore = store
+}
+
 // RegisterCache adds a cache to be monitored for metrics
 func (c *Collector) RegisterCache(cache fileutil.CacheMetrics) {
 	c.mu.Lock()
@@ -180,6 +198,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dagRunsTotalDesc
 	ch <- c.dagsTotalDesc
 	ch <- c.schedulerRunningDesc
+	ch <- c.workersRegisteredDesc
 
 	// Per-DAG metrics
 	ch <- c.dagRunsCurrentlyByDAGDesc
@@ -243,6 +262,8 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue,
 		schedulerRunning,
 	)
+
+	c.collectWorkerMetrics(ctx, ch)
 
 	// Collect cache metrics
 	c.collectCacheMetrics(ch)
@@ -426,6 +447,277 @@ func (c *Collector) collectQueueMetrics(ctx context.Context, ch chan<- prometheu
 			dagName,
 		)
 	}
+}
+
+func (c *Collector) collectWorkerMetrics(ctx context.Context, ch chan<- prometheus.Metric) {
+	if c.workerHeartbeatStore == nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.workersRegisteredDesc,
+			prometheus.GaugeValue,
+			0,
+		)
+		return
+	}
+
+	records, err := c.workerHeartbeatStore.List(ctx)
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.workersRegisteredDesc,
+			prometheus.GaugeValue,
+			0,
+		)
+		return
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].WorkerID < records[j].WorkerID
+	})
+
+	ch <- prometheus.MustNewConstMetric(
+		c.workersRegisteredDesc,
+		prometheus.GaugeValue,
+		float64(len(records)),
+	)
+
+	labelSpecs := workerMetricLabelSpecs(records)
+	now := time.Now().UTC()
+
+	for _, record := range records {
+		c.collectWorkerRecordMetrics(ch, record, labelSpecs, now)
+	}
+}
+
+func (c *Collector) collectWorkerRecordMetrics(
+	ch chan<- prometheus.Metric,
+	record exec.WorkerHeartbeatRecord,
+	labelSpecs []workerMetricLabelSpec,
+	now time.Time,
+) {
+	baseLabels := append([]string{"worker_id"}, workerMetricLabelNames(labelSpecs)...)
+	baseValues := append([]string{record.WorkerID}, workerMetricLabelValues(record, labelSpecs)...)
+
+	lastHeartbeat := record.LastHeartbeatTime()
+	lastHeartbeatSeconds := float64(0)
+	if !lastHeartbeat.IsZero() {
+		lastHeartbeatSeconds = float64(record.LastHeartbeatAt) / 1000
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			"dagu_worker_heartbeat_timestamp_seconds",
+			"Unix timestamp of the worker's last heartbeat",
+			baseLabels,
+			nil,
+		),
+		prometheus.GaugeValue,
+		lastHeartbeatSeconds,
+		baseValues...,
+	)
+
+	health := workerHealthStatus(now.Sub(lastHeartbeat))
+	for _, status := range []string{"healthy", "warning", "unhealthy"} {
+		value := float64(0)
+		if status == health {
+			value = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"dagu_worker_health_status",
+				"Worker health status as a one-hot gauge",
+				append([]string{"worker_id", "status"}, workerMetricLabelNames(labelSpecs)...),
+				nil,
+			),
+			prometheus.GaugeValue,
+			value,
+			append([]string{record.WorkerID, status}, workerMetricLabelValues(record, labelSpecs)...)...,
+		)
+	}
+
+	stats := workerStats(record, now)
+	idlePollers := stats.totalPollers - stats.busyPollers
+	if idlePollers < 0 {
+		idlePollers = 0
+	}
+	for _, item := range []struct {
+		state string
+		value float64
+	}{
+		{state: "total", value: stats.totalPollers},
+		{state: "busy", value: stats.busyPollers},
+		{state: "idle", value: idlePollers},
+	} {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"dagu_worker_pollers",
+				"Number of worker pollers by state",
+				append([]string{"worker_id", "state"}, workerMetricLabelNames(labelSpecs)...),
+				nil,
+			),
+			prometheus.GaugeValue,
+			item.value,
+			append([]string{record.WorkerID, item.state}, workerMetricLabelValues(record, labelSpecs)...)...,
+		)
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			"dagu_worker_running_tasks",
+			"Number of tasks currently running on the worker",
+			baseLabels,
+			nil,
+		),
+		prometheus.GaugeValue,
+		stats.runningTasks,
+		baseValues...,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(
+			"dagu_worker_oldest_running_task_age_seconds",
+			"Age of the oldest task currently running on the worker",
+			baseLabels,
+			nil,
+		),
+		prometheus.GaugeValue,
+		stats.oldestRunningTaskAge,
+		baseValues...,
+	)
+}
+
+type workerStatsSnapshot struct {
+	totalPollers         float64
+	busyPollers          float64
+	runningTasks         float64
+	oldestRunningTaskAge float64
+}
+
+type workerMetricLabelSpec struct {
+	source string
+	name   string
+}
+
+func workerMetricLabelSpecs(records []exec.WorkerHeartbeatRecord) []workerMetricLabelSpec {
+	keys := make(map[string]struct{})
+	for _, record := range records {
+		for key := range record.Labels {
+			keys[key] = struct{}{}
+		}
+	}
+
+	sources := make([]string, 0, len(keys))
+	for key := range keys {
+		sources = append(sources, key)
+	}
+	sort.Strings(sources)
+
+	reserved := map[string]struct{}{
+		"worker_id": {},
+		"state":     {},
+		"status":    {},
+	}
+	used := make(map[string]struct{}, len(sources))
+	specs := make([]workerMetricLabelSpec, 0, len(sources))
+	for _, source := range sources {
+		name := sanitizePrometheusLabelName(source)
+		if _, ok := reserved[name]; ok {
+			name = "worker_label_" + name
+		}
+		baseName := name
+		for suffix := 2; ; suffix++ {
+			if _, ok := used[name]; !ok {
+				break
+			}
+			name = baseName + "_" + strconv.Itoa(suffix)
+		}
+		used[name] = struct{}{}
+		specs = append(specs, workerMetricLabelSpec{source: source, name: name})
+	}
+	return specs
+}
+
+func workerMetricLabelNames(specs []workerMetricLabelSpec) []string {
+	names := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		names = append(names, spec.name)
+	}
+	return names
+}
+
+func workerMetricLabelValues(record exec.WorkerHeartbeatRecord, specs []workerMetricLabelSpec) []string {
+	values := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		values = append(values, record.Labels[spec.source])
+	}
+	return values
+}
+
+func sanitizePrometheusLabelName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+
+	result := strings.Trim(b.String(), "_")
+	if result == "" {
+		result = "worker_label"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		result = "worker_label_" + result
+	}
+	if strings.HasPrefix(result, "__") {
+		result = "worker_label_" + strings.TrimLeft(result, "_")
+	}
+	return result
+}
+
+func workerHealthStatus(sinceLastHeartbeat time.Duration) string {
+	const (
+		healthyThreshold = 5 * time.Second
+		warningThreshold = 15 * time.Second
+	)
+
+	switch {
+	case sinceLastHeartbeat < healthyThreshold:
+		return "healthy"
+	case sinceLastHeartbeat < warningThreshold:
+		return "warning"
+	default:
+		return "unhealthy"
+	}
+}
+
+func workerStats(record exec.WorkerHeartbeatRecord, now time.Time) workerStatsSnapshot {
+	if record.Stats == nil {
+		return workerStatsSnapshot{}
+	}
+
+	stats := workerStatsSnapshot{
+		totalPollers: float64(record.Stats.TotalPollers),
+		busyPollers:  float64(record.Stats.BusyPollers),
+		runningTasks: float64(len(record.Stats.RunningTasks)),
+	}
+
+	for _, task := range record.Stats.RunningTasks {
+		if task == nil || task.StartedAt <= 0 {
+			continue
+		}
+		age := now.Sub(time.Unix(task.StartedAt, 0)).Seconds()
+		if age > stats.oldestRunningTaskAge {
+			stats.oldestRunningTaskAge = age
+		}
+	}
+	return stats
 }
 
 // isCompletedStatus returns true if the status represents a terminal state

--- a/internal/cmn/telemetry/collector.go
+++ b/internal/cmn/telemetry/collector.go
@@ -42,6 +42,7 @@ type Collector struct {
 	serviceRegistry      exec.ServiceRegistry
 	workerHeartbeatStore exec.WorkerHeartbeatStore
 	caches               []fileutil.CacheMetrics
+	now                  func() time.Time
 
 	// Metric descriptors (aggregate - backward compatible)
 	infoDesc              *prometheus.Desc
@@ -81,6 +82,7 @@ func NewCollector(
 		dagRunStore:     dagRunStore,
 		queueStore:      queueStore,
 		serviceRegistry: serviceRegistry,
+		now:             func() time.Time { return time.Now().UTC() },
 
 		// Initialize metric descriptors
 		infoDesc: prometheus.NewDesc(
@@ -480,7 +482,7 @@ func (c *Collector) collectWorkerMetrics(ctx context.Context, ch chan<- promethe
 	)
 
 	labelSpecs := workerMetricLabelSpecs(records)
-	now := time.Now().UTC()
+	now := c.now()
 
 	for _, record := range records {
 		c.collectWorkerRecordMetrics(ch, record, labelSpecs, now)

--- a/internal/cmn/telemetry/collector.go
+++ b/internal/cmn/telemetry/collector.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"runtime"
 	"sort"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -53,6 +51,7 @@ type Collector struct {
 	dagsTotalDesc         *prometheus.Desc
 	schedulerRunningDesc  *prometheus.Desc
 	workersRegisteredDesc *prometheus.Desc
+	workerInfoDesc        *prometheus.Desc
 
 	// Metric descriptors (per-DAG)
 	dagRunsCurrentlyByDAGDesc *prometheus.Desc
@@ -60,6 +59,13 @@ type Collector struct {
 	dagRunsTotalByDAGDesc     *prometheus.Desc
 	dagRunDurationDesc        *prometheus.Desc
 	queueWaitTimeDesc         *prometheus.Desc
+
+	// Metric descriptors (per-worker)
+	workerHeartbeatTimestampDesc   *prometheus.Desc
+	workerHealthStatusDesc         *prometheus.Desc
+	workerPollersDesc              *prometheus.Desc
+	workerRunningTasksDesc         *prometheus.Desc
+	workerOldestRunningTaskAgeDesc *prometheus.Desc
 
 	// Cache metrics
 	cacheEntriesDesc *prometheus.Desc
@@ -133,6 +139,12 @@ func NewCollector(
 			nil,
 			nil,
 		),
+		workerInfoDesc: prometheus.NewDesc(
+			"dagu_worker_info",
+			"Worker label reported by heartbeat as key/value metadata",
+			[]string{"worker_id", "label_name", "label_value"},
+			nil,
+		),
 
 		// Per-DAG metric descriptors
 		dagRunsCurrentlyByDAGDesc: prometheus.NewDesc(
@@ -163,6 +175,38 @@ func NewCollector(
 			"dagu_queue_wait_seconds",
 			"Time spent waiting in queue before execution starts",
 			[]string{"dag"},
+			nil,
+		),
+
+		// Per-worker metric descriptors
+		workerHeartbeatTimestampDesc: prometheus.NewDesc(
+			"dagu_worker_heartbeat_timestamp_seconds",
+			"Unix timestamp of the worker's last heartbeat",
+			[]string{"worker_id"},
+			nil,
+		),
+		workerHealthStatusDesc: prometheus.NewDesc(
+			"dagu_worker_health_status",
+			"Worker health status as a one-hot gauge",
+			[]string{"worker_id", "status"},
+			nil,
+		),
+		workerPollersDesc: prometheus.NewDesc(
+			"dagu_worker_pollers",
+			"Number of worker pollers by state",
+			[]string{"worker_id", "state"},
+			nil,
+		),
+		workerRunningTasksDesc: prometheus.NewDesc(
+			"dagu_worker_running_tasks",
+			"Number of tasks currently running on the worker",
+			[]string{"worker_id"},
+			nil,
+		),
+		workerOldestRunningTaskAgeDesc: prometheus.NewDesc(
+			"dagu_worker_oldest_running_task_age_seconds",
+			"Age of the oldest task currently running on the worker",
+			[]string{"worker_id"},
 			nil,
 		),
 
@@ -201,6 +245,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dagsTotalDesc
 	ch <- c.schedulerRunningDesc
 	ch <- c.workersRegisteredDesc
+	ch <- c.workerInfoDesc
 
 	// Per-DAG metrics
 	ch <- c.dagRunsCurrentlyByDAGDesc
@@ -208,6 +253,13 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dagRunsTotalByDAGDesc
 	ch <- c.dagRunDurationDesc
 	ch <- c.queueWaitTimeDesc
+
+	// Per-worker metrics
+	ch <- c.workerHeartbeatTimestampDesc
+	ch <- c.workerHealthStatusDesc
+	ch <- c.workerPollersDesc
+	ch <- c.workerRunningTasksDesc
+	ch <- c.workerOldestRunningTaskAgeDesc
 
 	// Cache metrics
 	ch <- c.cacheEntriesDesc
@@ -481,22 +533,19 @@ func (c *Collector) collectWorkerMetrics(ctx context.Context, ch chan<- promethe
 		float64(len(records)),
 	)
 
-	labelSpecs := workerMetricLabelSpecs(records)
 	now := c.now()
 
 	for _, record := range records {
-		c.collectWorkerRecordMetrics(ch, record, labelSpecs, now)
+		c.collectWorkerRecordMetrics(ch, record, now)
 	}
 }
 
 func (c *Collector) collectWorkerRecordMetrics(
 	ch chan<- prometheus.Metric,
 	record exec.WorkerHeartbeatRecord,
-	labelSpecs []workerMetricLabelSpec,
 	now time.Time,
 ) {
-	baseLabels := append([]string{"worker_id"}, workerMetricLabelNames(labelSpecs)...)
-	baseValues := append([]string{record.WorkerID}, workerMetricLabelValues(record, labelSpecs)...)
+	c.collectWorkerInfoMetrics(ch, record)
 
 	lastHeartbeat := record.LastHeartbeatTime()
 	lastHeartbeatSeconds := float64(0)
@@ -505,15 +554,10 @@ func (c *Collector) collectWorkerRecordMetrics(
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			"dagu_worker_heartbeat_timestamp_seconds",
-			"Unix timestamp of the worker's last heartbeat",
-			baseLabels,
-			nil,
-		),
+		c.workerHeartbeatTimestampDesc,
 		prometheus.GaugeValue,
 		lastHeartbeatSeconds,
-		baseValues...,
+		record.WorkerID,
 	)
 
 	health := workerHealthStatus(now.Sub(lastHeartbeat))
@@ -523,15 +567,11 @@ func (c *Collector) collectWorkerRecordMetrics(
 			value = 1
 		}
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				"dagu_worker_health_status",
-				"Worker health status as a one-hot gauge",
-				append([]string{"worker_id", "status"}, workerMetricLabelNames(labelSpecs)...),
-				nil,
-			),
+			c.workerHealthStatusDesc,
 			prometheus.GaugeValue,
 			value,
-			append([]string{record.WorkerID, status}, workerMetricLabelValues(record, labelSpecs)...)...,
+			record.WorkerID,
+			status,
 		)
 	}
 
@@ -549,41 +589,46 @@ func (c *Collector) collectWorkerRecordMetrics(
 		{state: "idle", value: idlePollers},
 	} {
 		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(
-				"dagu_worker_pollers",
-				"Number of worker pollers by state",
-				append([]string{"worker_id", "state"}, workerMetricLabelNames(labelSpecs)...),
-				nil,
-			),
+			c.workerPollersDesc,
 			prometheus.GaugeValue,
 			item.value,
-			append([]string{record.WorkerID, item.state}, workerMetricLabelValues(record, labelSpecs)...)...,
+			record.WorkerID,
+			item.state,
 		)
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			"dagu_worker_running_tasks",
-			"Number of tasks currently running on the worker",
-			baseLabels,
-			nil,
-		),
+		c.workerRunningTasksDesc,
 		prometheus.GaugeValue,
 		stats.runningTasks,
-		baseValues...,
+		record.WorkerID,
 	)
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			"dagu_worker_oldest_running_task_age_seconds",
-			"Age of the oldest task currently running on the worker",
-			baseLabels,
-			nil,
-		),
+		c.workerOldestRunningTaskAgeDesc,
 		prometheus.GaugeValue,
 		stats.oldestRunningTaskAge,
-		baseValues...,
+		record.WorkerID,
 	)
+}
+
+func (c *Collector) collectWorkerInfoMetrics(ch chan<- prometheus.Metric, record exec.WorkerHeartbeatRecord) {
+	keys := make([]string, 0, len(record.Labels))
+	for key := range record.Labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		ch <- prometheus.MustNewConstMetric(
+			c.workerInfoDesc,
+			prometheus.GaugeValue,
+			1,
+			record.WorkerID,
+			key,
+			record.Labels[key],
+		)
+	}
 }
 
 type workerStatsSnapshot struct {
@@ -591,96 +636,6 @@ type workerStatsSnapshot struct {
 	busyPollers          float64
 	runningTasks         float64
 	oldestRunningTaskAge float64
-}
-
-type workerMetricLabelSpec struct {
-	source string
-	name   string
-}
-
-func workerMetricLabelSpecs(records []exec.WorkerHeartbeatRecord) []workerMetricLabelSpec {
-	keys := make(map[string]struct{})
-	for _, record := range records {
-		for key := range record.Labels {
-			keys[key] = struct{}{}
-		}
-	}
-
-	sources := make([]string, 0, len(keys))
-	for key := range keys {
-		sources = append(sources, key)
-	}
-	sort.Strings(sources)
-
-	reserved := map[string]struct{}{
-		"worker_id": {},
-		"state":     {},
-		"status":    {},
-	}
-	used := make(map[string]struct{}, len(sources))
-	specs := make([]workerMetricLabelSpec, 0, len(sources))
-	for _, source := range sources {
-		name := sanitizePrometheusLabelName(source)
-		if _, ok := reserved[name]; ok {
-			name = "worker_label_" + name
-		}
-		baseName := name
-		for suffix := 2; ; suffix++ {
-			if _, ok := used[name]; !ok {
-				break
-			}
-			name = baseName + "_" + strconv.Itoa(suffix)
-		}
-		used[name] = struct{}{}
-		specs = append(specs, workerMetricLabelSpec{source: source, name: name})
-	}
-	return specs
-}
-
-func workerMetricLabelNames(specs []workerMetricLabelSpec) []string {
-	names := make([]string, 0, len(specs))
-	for _, spec := range specs {
-		names = append(names, spec.name)
-	}
-	return names
-}
-
-func workerMetricLabelValues(record exec.WorkerHeartbeatRecord, specs []workerMetricLabelSpec) []string {
-	values := make([]string, 0, len(specs))
-	for _, spec := range specs {
-		values = append(values, record.Labels[spec.source])
-	}
-	return values
-}
-
-func sanitizePrometheusLabelName(name string) string {
-	var b strings.Builder
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z':
-			b.WriteRune(r)
-		case r >= 'A' && r <= 'Z':
-			b.WriteRune(r)
-		case r >= '0' && r <= '9':
-			b.WriteRune(r)
-		case r == '_':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('_')
-		}
-	}
-
-	result := strings.Trim(b.String(), "_")
-	if result == "" {
-		result = "worker_label"
-	}
-	if result[0] >= '0' && result[0] <= '9' {
-		result = "worker_label_" + result
-	}
-	if strings.HasPrefix(result, "__") {
-		result = "worker_label_" + strings.TrimLeft(result, "_")
-	}
-	return result
 }
 
 func workerHealthStatus(sinceLastHeartbeat time.Duration) string {

--- a/internal/cmn/telemetry/collector.go
+++ b/internal/cmn/telemetry/collector.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -515,6 +517,7 @@ func (c *Collector) collectWorkerMetrics(ctx context.Context, ch chan<- promethe
 
 	records, err := c.workerHeartbeatStore.List(ctx)
 	if err != nil {
+		logger.Warn(ctx, "Failed to list worker heartbeats for metrics", tag.Error(err))
 		ch <- prometheus.MustNewConstMetric(
 			c.workersRegisteredDesc,
 			prometheus.GaugeValue,
@@ -548,10 +551,7 @@ func (c *Collector) collectWorkerRecordMetrics(
 	c.collectWorkerInfoMetrics(ch, record)
 
 	lastHeartbeat := record.LastHeartbeatTime()
-	lastHeartbeatSeconds := float64(0)
-	if !lastHeartbeat.IsZero() {
-		lastHeartbeatSeconds = float64(record.LastHeartbeatAt) / 1000
-	}
+	lastHeartbeatSeconds := float64(record.LastHeartbeatAt) / 1000
 
 	ch <- prometheus.MustNewConstMetric(
 		c.workerHeartbeatTimestampDesc,

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -533,6 +533,7 @@ func TestCollector_Collect_WithWorkerHeartbeatMetrics(t *testing.T) {
 
 	now := time.Now().UTC()
 	collector := NewCollector("1.0.0", dagStore, dagRunStore, queueStore, nil)
+	collector.now = func() time.Time { return now }
 	collector.SetWorkerHeartbeatStore(&mockWorkerHeartbeatStore{
 		records: []exec.WorkerHeartbeatRecord{
 			{
@@ -624,6 +625,7 @@ func TestCollector_Collect_WithWorkerLabelKeySanitization(t *testing.T) {
 
 	now := time.Now().UTC()
 	collector := NewCollector("1.0.0", dagStore, dagRunStore, queueStore, nil)
+	collector.now = func() time.Time { return now }
 	collector.SetWorkerHeartbeatStore(&mockWorkerHeartbeatStore{
 		records: []exec.WorkerHeartbeatRecord{
 			{

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -14,9 +14,11 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 var _ exec.DAGStore = (*mockDAGStore)(nil)
@@ -316,6 +318,32 @@ func (m *mockServiceRegistry) UpdateStatus(ctx context.Context, serviceName exec
 	return args.Error(0)
 }
 
+type mockWorkerHeartbeatStore struct {
+	records []exec.WorkerHeartbeatRecord
+	err     error
+}
+
+var _ exec.WorkerHeartbeatStore = (*mockWorkerHeartbeatStore)(nil)
+
+func (m *mockWorkerHeartbeatStore) Upsert(context.Context, exec.WorkerHeartbeatRecord) error {
+	panic("unimplemented")
+}
+
+func (m *mockWorkerHeartbeatStore) Get(context.Context, string) (*exec.WorkerHeartbeatRecord, error) {
+	panic("unimplemented")
+}
+
+func (m *mockWorkerHeartbeatStore) List(context.Context) ([]exec.WorkerHeartbeatRecord, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.records, nil
+}
+
+func (m *mockWorkerHeartbeatStore) DeleteStale(context.Context, time.Time) (int, error) {
+	panic("unimplemented")
+}
+
 // Tests
 
 func TestNewCollector(t *testing.T) {
@@ -352,8 +380,8 @@ func TestCollector_Describe(t *testing.T) {
 		count++
 	}
 
-	// 7 aggregate + 5 per-DAG + 1 cache metrics
-	assert.Equal(t, 13, count)
+	// 8 aggregate + 5 per-DAG + 1 cache metrics
+	assert.Equal(t, 14, count)
 }
 
 func TestCollector_Collect_BasicMetrics(t *testing.T) {
@@ -488,6 +516,147 @@ func TestCollector_Collect_WithDAGRuns(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCollector_Collect_WithWorkerHeartbeatMetrics(t *testing.T) {
+	dagStore := &mockDAGStore{}
+	dagRunStore := &mockDAGRunStore{}
+	queueStore := &mockQueueStore{}
+
+	dagStore.On("List", mock.Anything, mock.Anything).Return(
+		exec.PaginatedResult[*core.DAG]{},
+		[]string{},
+		nil,
+	)
+	dagRunStore.On("ListStatuses", mock.Anything, mock.Anything).Return([]*exec.DAGRunStatus{}, nil)
+	queueStore.On("All", mock.Anything).Return([]exec.QueuedItemData{}, nil)
+
+	now := time.Now().UTC()
+	collector := NewCollector("1.0.0", dagStore, dagRunStore, queueStore, nil)
+	collector.SetWorkerHeartbeatStore(&mockWorkerHeartbeatStore{
+		records: []exec.WorkerHeartbeatRecord{
+			{
+				WorkerID: "worker-a",
+				Labels: map[string]string{
+					"pool":   "gpu",
+					"region": "ap-northeast-1",
+				},
+				Stats: &coordinatorv1.WorkerStats{
+					TotalPollers: 4,
+					BusyPollers:  2,
+					RunningTasks: []*coordinatorv1.RunningTask{
+						{DagRunId: "run-1", DagName: "dag-1", StartedAt: now.Add(-2 * time.Minute).Unix()},
+						{DagRunId: "run-2", DagName: "dag-2", StartedAt: now.Add(-30 * time.Second).Unix()},
+					},
+				},
+				LastHeartbeatAt: now.Add(-2 * time.Second).UnixMilli(),
+			},
+		},
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+	metricMap := metricFamilyMap(metrics)
+
+	assertGaugeValue(t, metricMap["dagu_workers_registered"], nil, 1)
+	assertGaugeValue(t, metricMap["dagu_worker_heartbeat_timestamp_seconds"], map[string]string{
+		"worker_id": "worker-a",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, float64(now.Add(-2*time.Second).UnixMilli())/1000)
+	assertGaugeValue(t, metricMap["dagu_worker_health_status"], map[string]string{
+		"worker_id": "worker-a",
+		"status":    "healthy",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 1)
+	assertGaugeValue(t, metricMap["dagu_worker_health_status"], map[string]string{
+		"worker_id": "worker-a",
+		"status":    "warning",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 0)
+	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
+		"worker_id": "worker-a",
+		"state":     "total",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 4)
+	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
+		"worker_id": "worker-a",
+		"state":     "busy",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 2)
+	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
+		"worker_id": "worker-a",
+		"state":     "idle",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 2)
+	assertGaugeValue(t, metricMap["dagu_worker_running_tasks"], map[string]string{
+		"worker_id": "worker-a",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 2)
+	assertGaugeAtLeast(t, metricMap["dagu_worker_oldest_running_task_age_seconds"], map[string]string{
+		"worker_id": "worker-a",
+		"pool":      "gpu",
+		"region":    "ap-northeast-1",
+	}, 119)
+}
+
+func TestCollector_Collect_WithWorkerLabelKeySanitization(t *testing.T) {
+	dagStore := &mockDAGStore{}
+	dagRunStore := &mockDAGRunStore{}
+	queueStore := &mockQueueStore{}
+
+	dagStore.On("List", mock.Anything, mock.Anything).Return(
+		exec.PaginatedResult[*core.DAG]{},
+		[]string{},
+		nil,
+	)
+	dagRunStore.On("ListStatuses", mock.Anything, mock.Anything).Return([]*exec.DAGRunStatus{}, nil)
+	queueStore.On("All", mock.Anything).Return([]exec.QueuedItemData{}, nil)
+
+	now := time.Now().UTC()
+	collector := NewCollector("1.0.0", dagStore, dagRunStore, queueStore, nil)
+	collector.SetWorkerHeartbeatStore(&mockWorkerHeartbeatStore{
+		records: []exec.WorkerHeartbeatRecord{
+			{
+				WorkerID: "worker-a",
+				Labels: map[string]string{
+					"pool-name": "gpu",
+					"status":    "spot",
+					"9zone":     "a",
+					"a-b":       "one",
+					"a b":       "two",
+					"a_b":       "three",
+				},
+				LastHeartbeatAt: now.UnixMilli(),
+			},
+		},
+	})
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+	metricMap := metricFamilyMap(metrics)
+
+	assertGaugeValue(t, metricMap["dagu_worker_running_tasks"], map[string]string{
+		"worker_id":           "worker-a",
+		"pool_name":           "gpu",
+		"worker_label_status": "spot",
+		"worker_label_9zone":  "a",
+		"a_b":                 "two",
+		"a_b_2":               "one",
+		"a_b_3":               "three",
+	}, 0)
 }
 
 func TestCollector_Collect_WithErrors(t *testing.T) {
@@ -651,4 +820,54 @@ func TestCollector_SchedulerStatus(t *testing.T) {
 		}
 		assert.True(t, schedulerRunningFound, "scheduler_running metric not found")
 	})
+}
+
+func metricFamilyMap(metrics []*dto.MetricFamily) map[string]*dto.MetricFamily {
+	result := make(map[string]*dto.MetricFamily, len(metrics))
+	for _, metric := range metrics {
+		result[metric.GetName()] = metric
+	}
+	return result
+}
+
+func assertGaugeValue(t *testing.T, family *dto.MetricFamily, labels map[string]string, expected float64) {
+	t.Helper()
+	metric := findMetric(t, family, labels)
+	require.NotNil(t, metric.Gauge)
+	assert.InDelta(t, expected, metric.Gauge.GetValue(), 0.001)
+}
+
+func assertGaugeAtLeast(t *testing.T, family *dto.MetricFamily, labels map[string]string, expectedMin float64) {
+	t.Helper()
+	metric := findMetric(t, family, labels)
+	require.NotNil(t, metric.Gauge)
+	assert.GreaterOrEqual(t, metric.Gauge.GetValue(), expectedMin)
+}
+
+func findMetric(t *testing.T, family *dto.MetricFamily, labels map[string]string) *dto.Metric {
+	t.Helper()
+	require.NotNil(t, family)
+	for _, metric := range family.GetMetric() {
+		if metricLabelsMatch(metric, labels) {
+			return metric
+		}
+	}
+	require.Failf(t, "metric not found", "metric %s with labels %v not found", family.GetName(), labels)
+	return nil
+}
+
+func metricLabelsMatch(metric *dto.Metric, expected map[string]string) bool {
+	actual := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		actual[label.GetName()] = label.GetValue()
+	}
+	if len(actual) != len(expected) {
+		return false
+	}
+	for name, value := range expected {
+		if actual[name] != value {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -371,7 +371,7 @@ func TestCollector_Describe(t *testing.T) {
 		nil,
 	)
 
-	ch := make(chan *prometheus.Desc, 20)
+	ch := make(chan *prometheus.Desc, 24)
 	collector.Describe(ch)
 	close(ch)
 
@@ -380,8 +380,8 @@ func TestCollector_Describe(t *testing.T) {
 		count++
 	}
 
-	// 8 aggregate + 5 per-DAG + 1 cache metrics
-	assert.Equal(t, 14, count)
+	// 9 aggregate/info + 5 per-DAG + 5 per-worker + 1 cache metrics
+	assert.Equal(t, 20, count)
 }
 
 func TestCollector_Collect_BasicMetrics(t *testing.T) {
@@ -563,54 +563,48 @@ func TestCollector_Collect_WithWorkerHeartbeatMetrics(t *testing.T) {
 	metricMap := metricFamilyMap(metrics)
 
 	assertGaugeValue(t, metricMap["dagu_workers_registered"], nil, 1)
+	assertGaugeValue(t, metricMap["dagu_worker_info"], map[string]string{
+		"worker_id":   "worker-a",
+		"label_name":  "pool",
+		"label_value": "gpu",
+	}, 1)
+	assertGaugeValue(t, metricMap["dagu_worker_info"], map[string]string{
+		"worker_id":   "worker-a",
+		"label_name":  "region",
+		"label_value": "ap-northeast-1",
+	}, 1)
 	assertGaugeValue(t, metricMap["dagu_worker_heartbeat_timestamp_seconds"], map[string]string{
 		"worker_id": "worker-a",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, float64(now.Add(-2*time.Second).UnixMilli())/1000)
 	assertGaugeValue(t, metricMap["dagu_worker_health_status"], map[string]string{
 		"worker_id": "worker-a",
 		"status":    "healthy",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 1)
 	assertGaugeValue(t, metricMap["dagu_worker_health_status"], map[string]string{
 		"worker_id": "worker-a",
 		"status":    "warning",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 0)
 	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
 		"worker_id": "worker-a",
 		"state":     "total",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 4)
 	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
 		"worker_id": "worker-a",
 		"state":     "busy",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 2)
 	assertGaugeValue(t, metricMap["dagu_worker_pollers"], map[string]string{
 		"worker_id": "worker-a",
 		"state":     "idle",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 2)
 	assertGaugeValue(t, metricMap["dagu_worker_running_tasks"], map[string]string{
 		"worker_id": "worker-a",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 2)
 	assertGaugeAtLeast(t, metricMap["dagu_worker_oldest_running_task_age_seconds"], map[string]string{
 		"worker_id": "worker-a",
-		"pool":      "gpu",
-		"region":    "ap-northeast-1",
 	}, 119)
 }
 
-func TestCollector_Collect_WithWorkerLabelKeySanitization(t *testing.T) {
+func TestCollector_Collect_WithWorkerInfoLabels(t *testing.T) {
 	dagStore := &mockDAGStore{}
 	dagRunStore := &mockDAGRunStore{}
 	queueStore := &mockQueueStore{}
@@ -650,14 +644,22 @@ func TestCollector_Collect_WithWorkerLabelKeySanitization(t *testing.T) {
 	require.NoError(t, err)
 	metricMap := metricFamilyMap(metrics)
 
+	for name, value := range map[string]string{
+		"pool-name": "gpu",
+		"status":    "spot",
+		"9zone":     "a",
+		"a-b":       "one",
+		"a b":       "two",
+		"a_b":       "three",
+	} {
+		assertGaugeValue(t, metricMap["dagu_worker_info"], map[string]string{
+			"worker_id":   "worker-a",
+			"label_name":  name,
+			"label_value": value,
+		}, 1)
+	}
 	assertGaugeValue(t, metricMap["dagu_worker_running_tasks"], map[string]string{
-		"worker_id":           "worker-a",
-		"pool_name":           "gpu",
-		"worker_label_status": "spot",
-		"worker_label_9zone":  "a",
-		"a_b":                 "two",
-		"a_b_2":               "one",
-		"a_b_3":               "three",
+		"worker_id": "worker-a",
 	}, 0)
 }
 

--- a/internal/service/frontend/api/v1/metrics_test.go
+++ b/internal/service/frontend/api/v1/metrics_test.go
@@ -4,11 +4,15 @@
 package api_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/test"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,6 +58,35 @@ func TestMetrics_PrivateMode_WithBasicAuth(t *testing.T) {
 		ExpectStatus(http.StatusOK).Send(t)
 	require.Contains(t, resp.Response.Header().Get("Content-Type"), "text/plain")
 	require.NotEmpty(t, resp.Body)
+}
+
+func TestMetrics_ExportsWorkerMetrics(t *testing.T) {
+	t.Parallel()
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Server.Metrics = config.MetricsAccessPublic
+	}))
+	require.NoError(t, server.WorkerHeartbeatStore.Upsert(context.Background(), exec.WorkerHeartbeatRecord{
+		WorkerID: "worker-a",
+		Labels: map[string]string{
+			"pool":   "gpu",
+			"region": "ap-northeast-1",
+		},
+		Stats: &coordinatorv1.WorkerStats{
+			TotalPollers: 4,
+			BusyPollers:  2,
+			RunningTasks: []*coordinatorv1.RunningTask{
+				{DagRunId: "run-1", DagName: "dag-1", StartedAt: time.Now().Add(-time.Minute).Unix()},
+			},
+		},
+		LastHeartbeatAt: time.Now().UnixMilli(),
+	}))
+
+	resp := server.Client().Get("/api/v1/metrics").ExpectStatus(http.StatusOK).Send(t)
+	require.Contains(t, resp.Body, "dagu_workers_registered")
+	require.Contains(t, resp.Body, "dagu_worker_running_tasks")
+	require.Contains(t, resp.Body, `worker_id="worker-a"`)
+	require.Contains(t, resp.Body, `pool="gpu"`)
+	require.Contains(t, resp.Body, `region="ap-northeast-1"`)
 }
 
 func TestMetrics_DefaultsToPrivate(t *testing.T) {

--- a/internal/service/frontend/api/v1/metrics_test.go
+++ b/internal/service/frontend/api/v1/metrics_test.go
@@ -83,10 +83,13 @@ func TestMetrics_ExportsWorkerMetrics(t *testing.T) {
 
 	resp := server.Client().Get("/api/v1/metrics").ExpectStatus(http.StatusOK).Send(t)
 	require.Contains(t, resp.Body, "dagu_workers_registered")
+	require.Contains(t, resp.Body, "dagu_worker_info")
 	require.Contains(t, resp.Body, "dagu_worker_running_tasks")
 	require.Contains(t, resp.Body, `worker_id="worker-a"`)
-	require.Contains(t, resp.Body, `pool="gpu"`)
-	require.Contains(t, resp.Body, `region="ap-northeast-1"`)
+	require.Contains(t, resp.Body, `label_name="pool"`)
+	require.Contains(t, resp.Body, `label_value="gpu"`)
+	require.Contains(t, resp.Body, `label_name="region"`)
+	require.Contains(t, resp.Body, `label_value="ap-northeast-1"`)
 }
 
 func TestMetrics_DefaultsToPrivate(t *testing.T) {

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -86,6 +86,7 @@ func (srv *Server) newFrontendServer(listener net.Listener) (*frontend.Server, e
 		srv.QueueStore,
 		srv.ServiceRegistry,
 	)
+	collector.SetWorkerHeartbeatStore(srv.WorkerHeartbeatStore)
 	mr := telemetry.NewRegistry(collector)
 
 	// Pass the pre-bound listener to the server to avoid port race conditions


### PR DESCRIPTION
## Summary
- add Prometheus worker metrics from distributed worker heartbeat records
- export worker labels on worker metrics with Prometheus-safe label names
- wire the worker heartbeat store into the server metrics collector and cover it with collector/API tests

## Validation
- go test ./internal/cmn/telemetry ./internal/cmd ./internal/test ./internal/service/frontend ./internal/service/frontend/api/v1
- make check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six Prometheus worker metrics: workers registered, heartbeat timestamp, health status, pollers by state, running tasks, and oldest running task age.

* **Documentation**
  * Updated Observability docs to list the new worker metrics.

* **Tests**
  * Added tests to validate worker metric export, label sanitization, and collector behavior for worker heartbeat metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->