### PR TITLE
feat: add workspace base config

### DIFF
--- a/api/v1/api.gen.go
+++ b/api/v1/api.gen.go
@@ -305,6 +305,7 @@ const (
 
 // Defines values for SyncItemKind.
 const (
+	SyncItemKindConfig SyncItemKind = "config"
 	SyncItemKindDag    SyncItemKind = "dag"
 	SyncItemKindDoc    SyncItemKind = "doc"
 	SyncItemKindMemory SyncItemKind = "memory"
@@ -4889,6 +4890,24 @@ type UpdateBaseConfigParams struct {
 	RemoteNode *RemoteNode `form:"remoteNode,omitempty" json:"remoteNode,omitempty"`
 }
 
+// GetWorkspaceBaseConfigParams defines parameters for GetWorkspaceBaseConfig.
+type GetWorkspaceBaseConfigParams struct {
+	// RemoteNode name of the remote node
+	RemoteNode *RemoteNode `form:"remoteNode,omitempty" json:"remoteNode,omitempty"`
+}
+
+// UpdateWorkspaceBaseConfigJSONBody defines parameters for UpdateWorkspaceBaseConfig.
+type UpdateWorkspaceBaseConfigJSONBody struct {
+	// Spec The workspace base configuration in YAML format
+	Spec string `json:"spec"`
+}
+
+// UpdateWorkspaceBaseConfigParams defines parameters for UpdateWorkspaceBaseConfig.
+type UpdateWorkspaceBaseConfigParams struct {
+	// RemoteNode name of the remote node
+	RemoteNode *RemoteNode `form:"remoteNode,omitempty" json:"remoteNode,omitempty"`
+}
+
 // SyncCleanupParams defines parameters for SyncCleanup.
 type SyncCleanupParams struct {
 	// RemoteNode name of the remote node
@@ -5209,6 +5228,9 @@ type UpdateAgentSoulJSONRequestBody = UpdateSoulRequest
 
 // UpdateBaseConfigJSONRequestBody defines body for UpdateBaseConfig for application/json ContentType.
 type UpdateBaseConfigJSONRequestBody UpdateBaseConfigJSONBody
+
+// UpdateWorkspaceBaseConfigJSONRequestBody defines body for UpdateWorkspaceBaseConfig for application/json ContentType.
+type UpdateWorkspaceBaseConfigJSONRequestBody UpdateWorkspaceBaseConfigJSONBody
 
 // UpdateSyncConfigJSONRequestBody defines body for UpdateSyncConfig for application/json ContentType.
 type UpdateSyncConfigJSONRequestBody = SyncConfigUpdateRequest
@@ -6034,6 +6056,12 @@ type ServerInterface interface {
 	// Update base configuration
 	// (PUT /settings/base-config)
 	UpdateBaseConfig(w http.ResponseWriter, r *http.Request, params UpdateBaseConfigParams)
+	// Get workspace base configuration
+	// (GET /settings/workspaces/{workspaceName}/base-config)
+	GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams)
+	// Update workspace base configuration
+	// (PUT /settings/workspaces/{workspaceName}/base-config)
+	UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams)
 	// Cleanup missing sync items
 	// (POST /sync/cleanup)
 	SyncCleanup(w http.ResponseWriter, r *http.Request, params SyncCleanupParams)
@@ -6970,6 +6998,18 @@ func (_ Unimplemented) GetBaseConfig(w http.ResponseWriter, r *http.Request, par
 // Update base configuration
 // (PUT /settings/base-config)
 func (_ Unimplemented) UpdateBaseConfig(w http.ResponseWriter, r *http.Request, params UpdateBaseConfigParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get workspace base configuration
+// (GET /settings/workspaces/{workspaceName}/base-config)
+func (_ Unimplemented) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update workspace base configuration
+// (PUT /settings/workspaces/{workspaceName}/base-config)
+func (_ Unimplemented) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -14353,6 +14393,94 @@ func (siw *ServerInterfaceWrapper) UpdateBaseConfig(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r)
 }
 
+// GetWorkspaceBaseConfig operation middleware
+func (siw *ServerInterfaceWrapper) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "workspaceName" -------------
+	var workspaceName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "workspaceName", chi.URLParam(r, "workspaceName"), &workspaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "workspaceName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiTokenScopes, []string{})
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetWorkspaceBaseConfigParams
+
+	// ------------- Optional query parameter "remoteNode" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "remoteNode", r.URL.Query(), &params.RemoteNode)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "remoteNode", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetWorkspaceBaseConfig(w, r, workspaceName, params)
+	}))
+
+	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
+		handler = siw.HandlerMiddlewares[i](handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateWorkspaceBaseConfig operation middleware
+func (siw *ServerInterfaceWrapper) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "workspaceName" -------------
+	var workspaceName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "workspaceName", chi.URLParam(r, "workspaceName"), &workspaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "workspaceName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, ApiTokenScopes, []string{})
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params UpdateWorkspaceBaseConfigParams
+
+	// ------------- Optional query parameter "remoteNode" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "remoteNode", r.URL.Query(), &params.RemoteNode)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "remoteNode", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateWorkspaceBaseConfig(w, r, workspaceName, params)
+	}))
+
+	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
+		handler = siw.HandlerMiddlewares[i](handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // SyncCleanup operation middleware
 func (siw *ServerInterfaceWrapper) SyncCleanup(w http.ResponseWriter, r *http.Request) {
 
@@ -15991,6 +16119,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/settings/base-config", wrapper.UpdateBaseConfig)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/settings/workspaces/{workspaceName}/base-config", wrapper.GetWorkspaceBaseConfig)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/settings/workspaces/{workspaceName}/base-config", wrapper.UpdateWorkspaceBaseConfig)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/sync/cleanup", wrapper.SyncCleanup)
@@ -22530,6 +22664,148 @@ func (response UpdateBaseConfigdefaultJSONResponse) VisitUpdateBaseConfigRespons
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
+type GetWorkspaceBaseConfigRequestObject struct {
+	WorkspaceName string `json:"workspaceName"`
+	Params        GetWorkspaceBaseConfigParams
+}
+
+type GetWorkspaceBaseConfigResponseObject interface {
+	VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error
+}
+
+type GetWorkspaceBaseConfig200JSONResponse struct {
+	// Errors List of validation errors in the configuration
+	Errors []string `json:"errors"`
+
+	// Spec The workspace base configuration in YAML format
+	Spec string `json:"spec"`
+}
+
+func (response GetWorkspaceBaseConfig200JSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkspaceBaseConfig400JSONResponse Error
+
+func (response GetWorkspaceBaseConfig400JSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkspaceBaseConfig401JSONResponse Error
+
+func (response GetWorkspaceBaseConfig401JSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkspaceBaseConfig403JSONResponse Error
+
+func (response GetWorkspaceBaseConfig403JSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkspaceBaseConfig404JSONResponse Error
+
+func (response GetWorkspaceBaseConfig404JSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetWorkspaceBaseConfigdefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response GetWorkspaceBaseConfigdefaultJSONResponse) VisitGetWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type UpdateWorkspaceBaseConfigRequestObject struct {
+	WorkspaceName string `json:"workspaceName"`
+	Params        UpdateWorkspaceBaseConfigParams
+	Body          *UpdateWorkspaceBaseConfigJSONRequestBody
+}
+
+type UpdateWorkspaceBaseConfigResponseObject interface {
+	VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error
+}
+
+type UpdateWorkspaceBaseConfig200JSONResponse struct {
+	// Errors List of validation warnings
+	Errors []string `json:"errors"`
+}
+
+func (response UpdateWorkspaceBaseConfig200JSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkspaceBaseConfig400JSONResponse Error
+
+func (response UpdateWorkspaceBaseConfig400JSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkspaceBaseConfig401JSONResponse Error
+
+func (response UpdateWorkspaceBaseConfig401JSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkspaceBaseConfig403JSONResponse Error
+
+func (response UpdateWorkspaceBaseConfig403JSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkspaceBaseConfig404JSONResponse Error
+
+func (response UpdateWorkspaceBaseConfig404JSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateWorkspaceBaseConfigdefaultJSONResponse struct {
+	Body       Error
+	StatusCode int
+}
+
+func (response UpdateWorkspaceBaseConfigdefaultJSONResponse) VisitUpdateWorkspaceBaseConfigResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
 type SyncCleanupRequestObject struct {
 	Params SyncCleanupParams
 }
@@ -24208,6 +24484,12 @@ type StrictServerInterface interface {
 	// Update base configuration
 	// (PUT /settings/base-config)
 	UpdateBaseConfig(ctx context.Context, request UpdateBaseConfigRequestObject) (UpdateBaseConfigResponseObject, error)
+	// Get workspace base configuration
+	// (GET /settings/workspaces/{workspaceName}/base-config)
+	GetWorkspaceBaseConfig(ctx context.Context, request GetWorkspaceBaseConfigRequestObject) (GetWorkspaceBaseConfigResponseObject, error)
+	// Update workspace base configuration
+	// (PUT /settings/workspaces/{workspaceName}/base-config)
+	UpdateWorkspaceBaseConfig(ctx context.Context, request UpdateWorkspaceBaseConfigRequestObject) (UpdateWorkspaceBaseConfigResponseObject, error)
 	// Cleanup missing sync items
 	// (POST /sync/cleanup)
 	SyncCleanup(ctx context.Context, request SyncCleanupRequestObject) (SyncCleanupResponseObject, error)
@@ -28473,6 +28755,67 @@ func (sh *strictHandler) UpdateBaseConfig(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// GetWorkspaceBaseConfig operation middleware
+func (sh *strictHandler) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams) {
+	var request GetWorkspaceBaseConfigRequestObject
+
+	request.WorkspaceName = workspaceName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetWorkspaceBaseConfig(ctx, request.(GetWorkspaceBaseConfigRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetWorkspaceBaseConfig")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetWorkspaceBaseConfigResponseObject); ok {
+		if err := validResponse.VisitGetWorkspaceBaseConfigResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateWorkspaceBaseConfig operation middleware
+func (sh *strictHandler) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams) {
+	var request UpdateWorkspaceBaseConfigRequestObject
+
+	request.WorkspaceName = workspaceName
+	request.Params = params
+
+	var body UpdateWorkspaceBaseConfigJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateWorkspaceBaseConfig(ctx, request.(UpdateWorkspaceBaseConfigRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateWorkspaceBaseConfig")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateWorkspaceBaseConfigResponseObject); ok {
+		if err := validResponse.VisitUpdateWorkspaceBaseConfigResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // SyncCleanup operation middleware
 func (sh *strictHandler) SyncCleanup(w http.ResponseWriter, r *http.Request, params SyncCleanupParams) {
 	var request SyncCleanupRequestObject
@@ -29601,344 +29944,346 @@ var swaggerSpec = []string{
 	"kVBF7OejFwIF7TYr7b7A+YBnflxXDi/3ZJyJYCOy2kzQ1gK6OJHSR8XjuwSVMSjPXZ8eD+MIdk0Nos1W",
 	"YXNAEKPbfJ06EeyDKw9Zbb2GKS3Hy5OmlArsKMDCfTL9gM/nafXHPPUpzMgDVORuyrbWv4sTh4twTPDf",
 	"kdg7XXZkXpLbn6VCApsMD8PqCVS/MmlvT8rhCYmZd5BlUxrRsaBcqN42U7O1Ag2KvNgBBveO7XmjpS01",
-	"p27p5c54wnNBY8v7uOHHaLaUizEJKdzZsWxYNeYCA1BIUSCSBiDNySweV7YR2XE1K7ha7hejIq3X+PaQ",
-	"wj5KmbZtgSvKZn1NIV/FHw+yJJXQJc3OXE8ArWI/ZPneVhFTI3XrceE4wdJts27x3IDgftOXpov3HdcU",
-	"O2cWPrf/YnPj08bL6JjLKh26MtQj78r8/ZdAKJ0Zjt/wurzzuJwIfw3qJ56kApSeBMRkQJaGf3ebifRc",
-	"z6cTq1CO6NurnlvU/A6Ltl4B7kf5gN26pZTkS0VW+9udzY6zLOQdxG5WwdJ6qTGp72gTrxgnZSGOAJA0",
-	"ozE25nczhIP9lxAmxWi2RBJPeCV93wkMfhxO/GFAVJFEMr/pEcA8P/nI4/b+XGfxYtuXFgtvz1lppLu3",
-	"yybWrDaONr//AX63Skffldzt3rgj3O5204Aaj0n0I+eK1G6RuClJDVopgHjsMT5aPqWStcy16vmY6oWg",
-	"YsElDCPXYUJ919veW52/0RKZQUje9tfnMYqmnNc99bWVlCBeeNQD3rGi6RGcEokLWGj67gB22Wfk/buj",
-	"OFz4KNRTGHcC87QmMteYIxVP50luHIOBWqk6PsisyYzmCxYTrWsmcjQJRASCq5sZk6qndGH3Y12yDCu4",
-	"xQKxD/xzQgtOcVzgd1d7ZN/Hc5MCfoKA0/W62ARFiiCqYAdp7yk5Y5v/QNx/WZo/0EW8R16zcuEK1dm2",
-	"LAweCSKY1Zple+R1pStaAFZpVlTK3A/hu5/xw5//jgvHyhroT5FXp6fH5PvHEFM6k3oJCqtiejtVFb0B",
-	"DmKx9hKkwRa/pN3/FCPCvPyhRWFDffsI36lav/XAd45rKYis6dw3DsKUE0MioA6ZuzQXFVNB6gIXgByx",
-	"KCGP9vPHLUKeOpVX7IrYGpCl93UZ8vEDMYcsdhzmvXVXV8riwKf2xKD7IUapnf0DBXrPKS/ACGv55Ojo",
-	"dSSJtCeR5CCROYJdJjJHhjOHzefJuCWIT9oujwPilU6AHGyyy8xlo5iuHqig/Ee0Nseo4MRTxO47jWaA",
-	"vJIXDVFk1h9zZ3UDY9PhUExreARIiBYVgMJfsNlSyjMQ+TO81UOFPSN6qc6W1TouZyshWHEV2AkNX4IY",
-	"4x60pC8qJZGvAc0AOXvlyLBUIp8m0JZGF13GgaZLLnMFF/Ksv4yIbcYWgFF4nbahM4JpG18Uv0lHkR5x",
-	"6RGw08VBY3rUAwgen8PzB3CinVJeqIwW7GHcul3Xfe/aFJsDLwlmQQeUpV3jUQrBedoc2lgVFFiG9++O",
-	"6lpFs02wYqFiV5X8ZlBi7JysU3sL7TGFHOPspvV1sTEDby5DYDJ7wxGIK13/YQtbNh6ldJy0yoZDjAmS",
-	"94JfnoY3606W0mWwUo1gLnZJV+uCTZ4++cv//e7Pf3ry5G9/GwW5h+Ez+8eHP7JN0mCFL5H940OjM5HS",
-	"vrfVifGGXYT5hpNGWbs/P348/rxgF86DGbTg0Nj7nO6lLAZRzd4rVr4z732eTi5keQYwjvteG+r79KfW",
-	"61FDmV3vBRPahZyNjlzaPyQILtAfudRFf0jpPm0UiUgVwyHxvgyGNXD9dbbhE1kNjEvJqsBMP/MF1N8r",
-	"QF9xp3wkOlQW43KNYOlP69c/w9mKuCejvv3Jve1CrAa2+TUY37fYZgtrWft1RsJFGMZofkt2VhZC4uGg",
-	"RS7r8T/gbEaia9tZeFjtrefxoiqarq0g4N8ByZF/7r8+IvNSCr2CpKYbmB8wzNZMSZF7hqIJ1/xHFomU",
-	"i8Uiz3rA8S38009c5PLCxhn11MgYhAAR60o/k0ofs/LJ63jRz54SFyCBsZbzqTxjQg2PCEXNVuj2mPd0",
-	"nVGGCpTHghN6Wco11BOQayYo9//YzWTOLifTyYKZZu3vNinRuusm08mvlEc1KlWt17LU6nTJxVnTjhsW",
-	"JbVPn8/nstThyAp5AT67nFeryXSy5IvlZDq5hP+PwyV0MbF1LQZPztuXYnBx9zdbqAHeAHCYABso/db7",
-	"APdna6Cbq9dNSC8uIgFtISXgTNuxcB/254f3BgtIjI+Wx/mDnjQaLAqmiyVaLFR5yy+sDpzm3Zf5b9Vz",
-	"D3nuYKei6sa22l4aWsocrO4p2Vk1QA4eNtXQv3w/qIXenlbpX03y+1gyGDUgRP+NDkfFLqvvES67H8zp",
-	"OHnX3W8mHfn77s6s4oXmwlyqJc+zEPDTPjISnOfZcMWYVo8W1MzB/dZ3r9H3UZ7GXEX08N5YoFFs0eIF",
-	"CJSvr7E3wBdhZZcWsA1V2km47dcmzXCm+wcqBHO7DS7qwJkF/cEidXsJySVcmY8JJtjO5FYNMUhl+Wpo",
-	"66L4dulBWoKIcKtZBogBLVcWuAOz7NbmB0j3V3uIAPiUzI3abp/XCjvMaUUFXTBzG5jaf5dPwd797N37",
-	"AwjZaxV+plXONSmk63BKcnbOCrMWqQ+nNpxE2jcCEBRRbKbknLML83XJKFavDHGBzQzQ2koRp8x3h8of",
-	"tDuZTrCRqBwx66XaNbqG97yw2FBmnVR0w8cHquDWD2BAYJMxWvgJTcxGzsaLEbUksC9FRIm1TvsqNkzk",
-	"gPQdWiGNKvjJLjz+QUX+abmiRlE0/8OHsbW1I3sGvDc2dwiltrkzlqRkCyYg2AjLxNnh7iCdMoXEC6N6",
-	"GCn0GM08hWuqnzimnUJVVLU0epoUGZtaqB/Fsqpkxeb/F9XNnGl/SIThaxbstbOvtYOgrXR3dtg10T1T",
-	"7GyaACu5hZfdwUkK6S7kWL6se4Y76hkxG09s/SexDyxw630BwO6MbmMbtu//sEkIu8MDcrGUrtmwu0R6",
-	"/zCwAODZLblqM4i6srHNNcQV8RDm3TMeuGrcDrx6vf/M01SvwhJBx6rXp/YBVDxPxWK8V1tsL4Rk2PXa",
-	"YpeBSI9LNueXMYyVUmnyV5ItaUkzwDvwnkdD2wBsa6fZrm+SqHU3diZBINVVy+PVhS/CSU4D34LnPksC",
-	"2+grAT04bLFRabW+zqGfs2kCMALwiIBjWkAsq1EB9j6Iw3n4w2tbd9BVeADpDXMy0to0NiVcO2O1QgS1",
-	"kme2pcZnbjAWZIxdcoVVcnBoWCjCYa4GY/ggVnYUUJy/PGc5EnnjoJoSqLJH/GnlSsdDzTo/qGcFN5xm",
-	"DoKqyGGAnflieqvdLtOvbxPCRz4IGz9iv3Ot1yuKwKCKyBm8ufdB9Mri5jE8+uRtDXsLmfK89WWbov3g",
-	"BmgxeVihU7dJdNGDq7suxUKWXC9XMQFxyXJLwO4tIITzJ1cS2Z4VAr2JN+od9zhMbnDxa6ETQe6ytWv5",
-	"QlBt+HjJqLlYY5xUGu0FX4sfgq+wiTCeYMlwNXw/Uf8ty0qmvfzpWVkqbHPwBSxqXXC1ez51V3eMFA97",
-	"8JLcqpJXFeWBJ7g92QFWeN6lh26sCQz5nBY899Rm6ciKSHih4aqrIbVKjOCzMqVPFzetnMD4x+rjXqK3",
-	"9fEGB7dUclyirppppBZ2n1DMw527H2p5MOSefe6/QYbVW2zLXfHmH4y9N7anMHCD9O33TGO8abjn6niL",
-	"8X8eIZfnbLWWGkryn7ENJB35QBdzzlIfmAeWCdDmDw8ILUpG8w1qGGr6QQCOmB27j/r8/vHfiMO8gKbN",
-	"5ck1PyWUCHZB3r8/PDAM6eWKOcsB03RNN64k5PiYt/1yxnVJyw2iddk22iijZlJUkZ+e//Dq7dsfPx3v",
-	"//Po7f5BNAYuvceDjA9R5dvs8PCVyt8I4tVFroK7NlxqrofST+ViUYxSlDW86ZfDBcNB5P8VAuukbQHr",
-	"VteOkfSZtwW+zk+yPIsZ4WN1F3NuFn8GAHoX+F0nd6NSm2NZxEtSvakhefGVUD2qEcSpOoujVi0ZLfRy",
-	"XOo3zutV+MX2l143x8gdd8aKnhDVId/l5Ee22UW1a015aTMTIBqdKqM31cB87UHUW2d0lFeMlnrGqB4X",
-	"c2dZC7SbpfuUlCxjHC5ChovRjJGcellX6+xBwIdNTNboxMDCsJtRx1dYKDSWqiY1LZLEh2VrRZcE28pk",
-	"ZPap5Cm4rFtaaPU/bbBCa9m6e9ci7jSnvmrxQEcbL/SyFfyIsyFYx0uK1saLLDSQ4yg2UJmitBUuKuF+",
-	"jaqJ0PpYgzhOB1a6sDf2rlRRcVCjHnLD54QJ8IzBoWEhazDt24Uxjk/AcCNJdhkf9jg1DMlrUP3yrdrp",
-	"p6ii5R7rFmzAEtXOpQPhcHtGtfwPo1aQRUmFdmCnawvyCw4hLgg7Z+WGePcYfgbJycSOVdV1Sv1rrk3U",
-	"q+pW0a0Cje9FbutFn0mUK+KDIDIq3HRAQ3b9xsO2cTA9S1NXf7DjhkIJaLlx091mc6HRl6apwU2mkKZv",
-	"R9i7wdheBCq9sMttJVhQ7MWvSwQj/YoRstsHDbRJ2g0IhtA747ZMad1+6k0fff+p4yZsq2N40HbSO9S4",
-	"OlvzHoAHk1MQRtbqiEjwhnwNl7gIXVoyuDvQopAXCHDQG3Xisewn//Ov/d3/pru/Pt7926fdj//+b5OE",
-	"sG4uQLfaf+icGYlMdb36Y1uQU8uYc1X7eiLBB81SVcn1BlKJfOicD42bMVqy8oXrVq7pLwBaD8MFqQMv",
-	"1KNYar1uxLe5sq34toueC1/+DOGac+mixChmj+NqTf4pNSWv6Irm1BzNZWG/U08fPVpwvaxme5lcPdpI",
-	"relylXc1z/3jw059e0OAKym4lnBmHtBFZdMa96CyaMYsqdhBvDw+2v3T3uO+AeR0UWWFrHL416NZIWeP",
-	"VpSLR0eHz56/OXm+h2PTXBtBNDFdTqYTh8zydPJk7/HeYwgKXTNB13zydPIn+AmhLGFnHkE0+iOF9Qjg",
-	"p0XMTmTkiCLuNa/eO+8ARC7AnX9NF1zAnWfPhwNwCVdMaATCvE9cd81stYSJon7lUR2mCXaKgbeP6WLc",
-	"e6zEVz8aQkeuhqX47vHjVqAhXZtzGqb06H8VMisy2hAbdiZfC9DPHQo7xlVkuY958Dv0eTr5/vGTGxuW",
-	"zSDtDuGNbGBXM8sHFlvltnt/L5iztTP7TpANjhokJlKompY0JEr/awIPsHB8tDY4xkYoa1JqNIPw+Awq",
-	"oAHCW6k8ukuXoLGhcFevRdEfUc4ypX+Q+ebGFhkTaJZUO8PL56ZEt6H0Lcq/ORLrrlIf6dtXfMQC0Pvj",
-	"26e4QwGOAH/T+aJ89ufHf7r9nmFHQFOqL/D3icmRbpr8GeHyz9P2KfboN/uvw/xz8kR7Z83OjvFd5E4d",
-	"jmfZHq9gWZAUGZEEL5m+MTEwfGCFXR3mt3tuhX2h12MM9+a1f+TLcdH3j7+//Z7djA0fYfnwe8RCL5m+",
-	"Jv88yqjIMAspcZjCc+Uq31kUCDAuABxko/vIEQqf/655pwko0HfkwVoUjni/sc0XO3lgI67NOUuMIYnz",
-	"zQkomdSjM2jZCMIaYpsl/eIHzn3RVL+7a351qME0y9j6D6ujfjkx8U07tvKjITyuJ6yQp/IeeVXNVhzt",
-	"+uWDuvCWlVvY+7qUq7XuSitkpvx3KrDeK1Yew8ybQmNIbt25nuFdiN8E15cRXN8/uYO1RlIk7HJtiA/K",
-	"TNv4KyrUBbtnYsyKhlqCoQxJCbA13z1jGzV4q6dF4SB41B5559yskLzmfacR6zRg+0Cwwa3xKnbRcMxF",
-	"ls35yN0kvjTL3MGJG9mlO6XU50lDc0BMIWE6YkxbmiG8FmGgDF1C8EixQZhM3qheGTUsA6lMbufoCrv4",
-	"soZhO4Q0Lzz7I5uCvyTrff/4b3cwa7pirRDhL8721vRsmT7O8+F59Oi3M7ax1mZb3yxyNJ3LM7Amu3ZH",
-	"HkxYDs4Lg+3UZvwsbuj6PpK2bGHrcBL5H5n0v7+bWd+98StG8Ehj/QQ/7Ve5HOnMNuTwYCRpv2T6Fuj6",
-	"ppW1vrOpZph74fD4xjB3xDAvmR7iljXVsRoMiD9U8wsXczmSXUIA0utyzM1rlDF41Ls2hAzyKw4y93v3",
-	"Taf83cuJP6wW24Qi7tFiqxyrh/SbVDzOEBO65EyRlRFwLkNgzgvNSpKVXLOS0z3yGgGCwAAFFGCuvgmz",
-	"i2n6SC6uHRDYTlCHIc02duyG/hey3DiIcYRqosUUjNpTktPFQ6jLP3k6+aViABhvwzXdpy5QlUYBANMD",
-	"qBA0JdG6eQo5dL1tDyzFkVycaFrqU74aZSI/kovnIh/7ttuiI77iemTzb+dzxfQta2iOdMYY0zok/AcQ",
-	"wy9kOeN5zgTZrdNNVm3evHNj26gAz852BSIMZJaTX3r5KFtSsWC76wAiNW6T2y8KeYHhnY0dQR7VkmBL",
-	"5gVeEnkhiG8z4oUXC3ZcP74VQ12jky+kWJ1g6Zr+mGUcoV2/nNhyN/OqKL6YnuVE/QWjZ34fH345tjcc",
-	"d1FKsfABhZ647lP8C3JAGN0P5V88nddcqJchExZywUUP6wVLoSy+LaYNeMhYKnLf0dRjA1Dynz+dWtwp",
-	"KUhdEbGlS0D3t8OG0PYX4j7bd48VoomaU3PenVG647usZJBhSAt1DyjapiJNnv7rY0jfIR1aQFiREznT",
-	"lIua0nroHLOuetVl3sn+DxJmik3k7IlZx2wtlvf4+NYIrIG/GvPAhHk+Ierqt2wUawtysjK6rSkyUkxX",
-	"657QWpunUmeioLIGu2CTs7E8VkGgqT3yFoDWfMkyyL8VEhFT8Vq6R95FhCqA+a1WLOeGJUCMd69qJzDc",
-	"e5jhAgO7t7IZ9oyG+NhfgXL0p7sIkdHV2ttMzJfgcyI7AbU+vL+HiPUROgak4TbHeT6ni92yEr3RKyVn",
-	"56AbFQF8la2HZwt5+7ouaHIxUmC2IV578tXnunYWhPHZ3sqCoWWmhTE3/wOq2SlfsRelXG3z/qkc9baF",
-	"IrJViEZ/YUY/2nhRf/KsKpUtsXmjAYo+Kzttt/K7bnc3YTyyj7Y3S4XtH+y/dOg5O5lcreiuYma0muUP",
-	"6xMD3gaEG6jeDTUyl/Sckf2jIweZwHLbUE/xV8MbVyj9Gpm8R44ZmP4VKufWJWpXA0Vs98i2K5qYDciM",
-	"vrncpiXNCodjumC9x1lwdNUBTHd1gr2mhVE+GSTkKQkWLG5PtTr1PKxUepfnx0smWMmzVsnaVEiZo5bg",
-	"sPAnxJjkZVclFQtlFhvkTFpD8rkyzB6gmez8c//10UN3TJRa1dD/ex/EB3G6BLBLi8yXS6YggNVqU9A2",
-	"2/U5Kqb9OS+Y5eTKLCjLyc+mz58BH5iWykIDWpRNln8Qiq94QUusPP2zORXVI/f45ym8DZBDFQJyOsAr",
-	"r54WGyMd4AtE8m0edM/xAyRncwadrFn2pbTWu4BlPDzweAyWJP5uFshiPTvkRClYAzgRURNrFLZeHRff",
-	"SpaZ9EMBJUTDfcMWJzWEsWYZjAYy7hM1SmDpY8jFfksiqIxA/ubKfvL2TQ/4ruJiUTDtKm1aYQCQRB0N",
-	"eU7ggDCEfm7zfUssbT238JYW2pIRZSYLM+bKq7EWpIzsBLCWD+MlHg1ZdotFd3iWC1vALzk/bQvE920h",
-	"FJHvFCQ3Q4iAuNz4BSrNBtdDnYyPvaVUVx5MoBZ8XyCa1O2sObKa59OdOKj3tyBeWCbHNCH+8b07TB1G",
-	"gK9uw4KDEc5DLgouUAjFD9rwZvaIiV8qVrFhm8x1j1/bkSIcofzu/Tm8ZqXiSteomjD+/pMY5/jtJLZV",
-	"F+qD+IIXBZmxr/00RpKohQpsd77FyeyZrTWDc1aWPGcBndlpeHxR28dNH/fIlva8N3wVkY6ydBMND3lI",
-	"Ey14pr+d9l/ytHe0F9pXnbD9w535wwRcn/IrmbOHUwDItuv9JcPZRh3+9ny53on/m5GBn7+0SfaHja1W",
-	"9LUbZi3I5B/QjPvNNvc7tM3ZEps1HrDTmEZJlUe/OVnamxl2zMoVFRgWULKVPG/cL0qWyRKVd1DalJIZ",
-	"h9ss3D6opnvkwJXg9DVDp0Nxt5jxg4R1y2AMB/svtxMLz6TISqbZ6LS16KnfyGF7fCenLQwio8Jc1mas",
-	"OYLv724EXwZUaRSH2UQzGirwMeN39DB+wXS2ZMomWzF3sEZibQKOtR3tkfeKkQeFub3rB4RiWIXXdbQk",
-	"pT3q4cFKKgvur2vtwt7tak+XUbAAlzoWu4O0fFAXVrtPLHYTmXMxPT8oQTd8oKUKQTWbGqP295x8d8N3",
-	"7+432zk1tsM6cj7Ei/3n2iNaaj6nmR7G5ICIa/s22KuILpmrilwPIcFH+76fe8hJI/In7PDfMaMc8fNb",
-	"Vhhdd6cl69cY3X7AVjgJGAtPugM28oNBk6osN/eZpVBXdFTZIeNrcNKjXF4IV8wsylIH9gWjJ+IVvsVZ",
-	"1had4ir3fZO1vm7OOqZ6uS1TyUwzvat0yeiqSTe+LsKMCwoxGu1YjDT5wg64Hl3tTxjNM/xx94CrtVTc",
-	"lXtotaM1zZYro3mYlgbjez7fOX/CBO+zkmnJG5Dp/KBvkEHXJTvn7GLwyLPvkRXT1NzU0KnCLrUjD1du",
-	"JsLDw0fhsR3FH45tr3YW2uUadRy6jbsvJ+J95zi7tjfMcDnzDqL4McjaBmDvRsXgxEb5aOsD6BpCAi/l",
-	"V3RN+3YB2s7u4Eil6aS8El2ynOtdIxo2YwIFBLtoOiioIKYFaz/I2RxiyKWwFfNtVX3w1FR6XWkbc6tY",
-	"YauPn/H1Gq5wbK26pofnOdfmvre55yR9Q378N/1OcGeiIdI5lZ0Zx+4B7CMpK0h46a2Qu02gAG5/NFzg",
-	"uav1ZwgiCBkI6CQSNtCue4wRA4YUTgwZRAB7zc9ES7Ki5ZmnmQ6JYZoznHeyUpbiyDktOZ0VDMhrfMnH",
-	"uJf7eU3sfc7uvcHKY1+NB9tGNuSxosC5TX+98GUZMcbmgionm7hQmtEc6j75+MM6/HUvHmGAO+ypYYtd",
-	"w4i4rb9M14L2R21jUK2extj1TkKDfkErkS1Z3uDce2hrqxryHUd5vWMmvHDEj5t/2MAtlT5d6IIawsLo",
-	"MeR2dyyZa0kZmOlcKUVzwoDosIdPtBaB1f2+HTs3eOz8bgVpfNneMSWL88ChEl2t6Eql6hpbhjCrY0sb",
-	"w41gVSlwzc35JcvJjM1lyaxg4WKx3WnHBSv4gs8KljiCjx2f1cmNCk9lM5TaT+gPZxdIZ2fd2OTG2Fql",
-	"aBlVicKhpj+35gM04d6cuvZi5Vrba1BWAmKD+5UQM10X82jPAKPhmOnbuW+pZ7TOuva1sJZeqlabtQzW",
-	"esv+4h15sg0ELnbKw6uoLHNbEr82K4gcwoT2xtZENlONFtnGGuORwb2RYndWyOzMaA/utSRfXf3MtzTT",
-	"OumbdOFWsMsznoGDqWytGNhlZXlnavfXUlKTjI3yuKqWUMhF0kDiHOawLJ4eC7kY63U7kouv07x4Snkx",
-	"5r1XjI5qz2GZjQA+w+i0j7eLOXD/nOBHhqruuZnSu8GN3GhxxLU94YVcbOO5A54Umpcd1gQHXi9/Nv13",
-	"95RJhzlAs0v9aF1Q3iKAQVebp7XfoZfta+Aj72C7DT6yRs9Rh5p9d89MvqYIyjGNrSjwBuvMqJksrC5o",
-	"0XPCPNI6A4uEESvuWwqAOSdv3xBUSsjFkpUMaoIASEH9LlxgIOtfnDNQdcF8+/74+Pm7T8/2T54DyCBd",
-	"seIZVYzMNu66DTGbWaW0XCEy9LwONXvosrcqVveX0bWuoMgPdozEqnqi0d7atf0dRqMNW+bc5IfUydrp",
-	"58irQRE1FTnagHub8/HukcN5g7Dqy9+s0vWeCem+D3DuBGGrtd74lpHW9r5FkEbO8O4+dKJethc+JTOj",
-	"zKuiJwf0CMwFhJJ5ydSy5dshS660hFl4sYhG95JVWB5XK2JeYXkQCx8tmmdH8s2g1mtQE+ZCfcPum1t3",
-	"3FSKWVC9A7p4wYvI1H+ClE1IT6ypEqksgBJ0KhCEcsIhVPIFdysGR2LgToDwZaQ9R6e0QNuhEnStllLH",
-	"vAufIzfyP56PZdDfsbXhwu1q3nQTfzFAuHaO4h2cOK+cuOwcO3eSIvnMZu2SHcvUzaTHh/fx/POywJ08",
-	"NknJCkLEmb/K0XeFgIYZVVDVLvQq+YMvcqb9YfxDN3fsHB44ye0W3SarbGwMQGDijx+eoJI6XIop1iCE",
-	"LHq4HTnDPKq9+bD3aCAhe5QHaaTl6v6pnpvuhfFK3OY8fINXXDycG+6+mhwa/t06M9A6kho4CYkb4bUx",
-	"Ob6K5KS4P/XULiKk6A8hL4x3od6zyDwgVlmiBv0V3Ou67u3rR5KC++nRb05Ufn5E10Ye9lzy9vEFyLAw",
-	"UtLFk3JBfqIc1EVMoZr67H/wRBkhi8DM6ypUqJpO0BqimSrCxDkvpQBbpA+8Mh2paqbMeSSsL7PDxXaQ",
-	"lpM1W3+dzpoTd4LdWp12XCfTTwATfauVyMIe0wHn5jmxtPiFQKFhCBwBpjrETYBfUeohSSuy4krZ6/Vd",
-	"izDgxHssw+yuE0ou/DICU96AxBrr5/XeXUG4yPk5zytq7eBcjPH5GoL4av2+tSj5CnzEY6YDqWnfvMn3",
-	"WmOpAyo86kCM325GCFzRx9z0LG8pG5r+5j+MgBjPfd882V+7J/vueHjFlKILNs7BfXT0mmQQuIpfWbP9",
-	"xo4VHpmmaxclOhAhXA9eElLs+tf6fMOGM167sf0e7hG3dF4+W1Lt1qm3aFKwbepLZ5J+RUp07eBtLKBl",
-	"zhvTp9eVWu7OaHaWtgEcV8rwoXlphBlg7N2fi/9Ft3Xy6l+DtZouAeoXsI3VHjl1v0IgOxTfoMLeIGkB",
-	"IKR8UZU0kapRqeUPNDv7ZjAYoGC3UHdoMWh2OWAyMMTLcqTM+2c1mDobQdt2MPXyx2NaIwk36febVIzE",
-	"jVdq6SRRaFwAuehFBESbcL0kc8ZyEG43IitLBtbtpKB8B8+vbCulBDNO7Fz+FzPNIt5D8+Sb7BqgM1ym",
-	"O5RcYYcDcgs3916aOr8JnZgqBqGut2HOtItuRArV2TISbwBFiJXVg2qwuub1zAi7XtPF+3VOdeAhOXFY",
-	"zH9U0dFyjPpt6KMiM2+7cN20Qfj59kMBvkRA1F0DqHwFIuE1FVgMrwLGskf+gyDqp4Y7v4qYkD0FcV/I",
-	"MmM2ck7LtdE3HKa9ZX8MoaciY4V5Okesy1LKGsXVKSdKm/vYmoncfV+wc1YQWmm5oppndXJkU6KcsnLF",
-	"BdW/W8ig+0Vwfrnrrb2uRa6a7W5Ri1XzlS+K1MUbBrNEURBVzRDuoRKK7HCRFVWON6A11p7y/KEeRg6y",
-	"PQLhvmtaMqFPqpnbSyi94yO3XJ6AmQF0BJFAVAdt1cMgO2Zsq6rQ3JK2YMrmnKqHUUOg7/i+HpCJ4HBc",
-	"tsbkDw/ckg6snhEFsdVrRU07GUIclnROepY3VeGzs7+3Wu6zddRXs3eW4selnLtRIhDzYC64a/+rCIoi",
-	"9zzL5SXTTZGCIX0oioz8ubbke/Sbqsnw86AzYivMdTvyVJxBi7K+DmFTh+EGs2vgxuMSgaXasf+a6mXN",
-	"/arB903l+O7kwB8YqP0k2LmvFq29yVw3KQRuCsx9azlw38Hdt5UEDVjwm5UF36Dmv0HNI5PdgRi4OST6",
-	"Pkng2uiIg69bGuQJFPIvJQ++AeR/g+seBsi/E7FyS/j5IQMOYul3pM39htMfKXTWcSD2r0nmfEP3/3rQ",
-	"/W9RWlwz32HkzeMbwN01khe2vRYF23W/DCTf0iPuOj3iVuXGLaRIbHN9ub8yZdubyxdk2G8ZFb/HjIrb",
-	"Y/tePIXQahnBU6icN6851F3rfOlVIO4rfsIVj2eAQrjnDow4mEMaJ8Nu5c1BOpxY2mj29oVvEyc1wd53",
-	"x6Yb6rtKkJNwDW9cKNwe7EMdeRiw0z3AgqgF0/2NkB4jmAIcV58Jo6XDSrhre8Y3hIpvCBXj3MpfLUoF",
-	"aQuzWxfGN4VoMdbW81XnrX9FYBX3yTJ0X5KGv1mRbhVk447F1m1icGxlarrfIu0q5iZYiC8uCr5hg3wT",
-	"PSOxQe5S9NwKdEhnGtfCEmmIpnsOJzJCPv0+tZGvEsLkK7tlDcKY3L34uGHIk4QJ7CvCQfmdG8vWDjPi",
-	"d2cu+4bP8ofAZ/nKRH4So6UtJG8FtGWLg+Cm8Fy2cYJsBfLyOxfMdv1/b1L5G/LM/Uae+eo06Aj6zN1r",
-	"zTeNVNNn4EO0mob0u9eANSMtfBYrxItAu0pf3tr/DULnG4TO/YXQ2U7WjcEyaZYMsqgCTl0jc15oBoVx",
-	"ZxsstkhFTgo6Y0U33uSIK32w/3J7yXRMF6MEzTErx766nbD7SZZnak0zFhFhL2AJAMPDLUICymPQlj7U",
-	"Nq4r2cnkakV3FTMj1Cx/WJtf4U1QvuEWtn90VBcEtp/vkdeVRmpil1lRKX7OcFd/NpTy899R6LLynJUe",
-	"AOXV6ekx+f7xY8LnZCb1EgoKK6ZTqCWeAgYmuy5ZZqbgBHWLQf1zQgtO0RT2M7b989/JKjUP+8YeGbt+",
-	"iVkA52y5YazIzfmlZKnJbPP0g9glP5vmfn5KTsxvtFgv6YxpnsHQZ5u6TulORhXb5UIxobjm5+whfs0u",
-	"9btKuAYMjbFLHVSChCOTr9geThTWgNGy4KzEV90LylzLGS3JnJcK1EqqMgtnJcuclUELsqq78N8VVOm9",
-	"DyKxXGbOjeXyQtSRPhPVyogi+6edWXCOpVcW5g6DJDvhqIl5Df96mBgXfJUYGFVZMC78y7QYG9ONg2qo",
-	"SKVgrrRRiaJiVy8ZL52kN4LWZTmaiY8B6DnYfwmVYzvAPNMJnD89A8LnhIlMVkKzslkS3R3dwTg6lXXb",
-	"Pa7pggvqvJC9hrT6zQieiGFRO/pGo9cCF7mP6fxFEUR+2oM0ONzNwT4dVYoTnXS+2q+jreCosAzaPL+x",
-	"kTfsAkOjr367uDFFWtgilgM0by8qiTDwRsHoSGE/I86BD2nBf2WujmKrQqaPhHe+ClBp4eiasbksGcnM",
-	"6lnfQn9UOczqarr9kxtYzObqvIEK2nNXtrrY4EQQtew6U7mPNxBHAfdPAiDv1aV0g8OhKwWcev/IqmHD",
-	"Wr6RLZXgv1TMKUmQ4UKzUqrOHSDmxN8vioP9l0dO7btNy0OgjN9q/B1XGubTmyD+NZ8f9T0tRT+K0RLt",
-	"V1H6OWalEZGAm1oVxS7gLOA3jnRMp0PkcwJfXOlm2KKczubgWEAfJFZExXXEX+40O6nNhtgUQfEItxwc",
-	"ucWZhXVpyOqUtva8V0uz27mNklYyVRU60hNuGrHPyYpqHK7px63tONBIaOgdtHOo2WoQNdINyWt9vyNF",
-	"z65qXLnzbKnbppsrXKPDAwLsB1c5CfbSR8EpKua/k4PglC5+v8eANXOkqM1psmnn7z/sGwphlmMJs86k",
-	"sGal4kojPPKGZOgI2fsgPghnw6KksHdO27P5HlndAvR6ZTujwujaa1oa7bzYmH8plk8/CLyUWrm6ohtC",
-	"C2XU+KyocmZfs9SMEJyzihfa2k5MX7taFqykQpNC0pyLBdo9mtTuJn6w//LaWb03filK3HLA1KSlYesg",
-	"XMqsplxx8ODby1/nbIhfn7pprTdXF32UK+Pq9pcRV0ePYzpsIelQ61YHLXwdKThfVozweb1JXGFHZEdI",
-	"28/DeolnUhaMds0k2PpWJ+Y/6ungiXv/5JljPyt2VDoxuCHQfpvzgoGnFte7YJpFldsVNaMtNqRkK5vi",
-	"2zwAEasQ9majjO7SSb+Axq9rLxnlYn1hJxU7DL9PsG0Q2EBwHfI7hdS+z6H8sByECsIu7YFlDR5ti9s4",
-	"EOxe9OvOhT5WcPPOoK/7KOmm7zkLpmFt3TEMYRCWX64prnOuZfmKCz3GLP78/2PvW5fbuLEGXwWl3arY",
-	"85GUnDj5ElflB2PZimYt22spm8yOsg7YfUhi1A1wADRljkvvvoUDoC/sC5sURbZl/klkCQ0cAOeGc82N",
-	"3os13PAkrH1Xds6PlIgSDdZYO6N66u1xqQVXcBIydVMltCOjl7kWaGuW7u4dRSKg0WmjowKH5PyOVFp9",
-	"LG2VYC+z1VPwjVuu6nyqlY8rdwrrKSCGztUMeAgVEvf3KegpyPSAmSLZ6JWCtnDc+XXyh/kYX65Z8oKI",
-	"ZxKmwNEhiyeYsb5WUvl4ZasVz119fpJ1mNkWHd487UQzUy25K17Zr3bCL4nHVpXqb6BXe2TMEW3Dka3h",
-	"UywyjWXKnUgWnlJdIRDOJAsJVmk1omDOVEIj9h+PKG1XN7O0Mhz5s8mB9BgJMIsJypEHrdZemqgvF/3Y",
-	"woPQ0OQDn+dBElGZRTnXYFw9Ze5B+9lC/6x7UfE2Om08Jgw/A13T3yKnR5eD3urwHPi/E0gazFqZ0zxN",
-	"wvDPvaVnIOUhoWGoCENvsbOBJzZtP6XHEn6/shCkOL5zsbMNc1NIJ2+bLU5pgJOYg5QsTM1P5nTSszKS",
-	"YOJvb1lf85wIgYuid+Pa0ykSR3MTsPPTFIQ0E4WN8VXqPfvO4yo4pJ79icFVtLbf/YkKtvexNqq2dtSd",
-	"u+EKAf0+l/QoyIwq5VHJYx/j5O+X7942qLUpQi9tOD13N5vtPmZRtOhILinKWCdd+0oBjh2MaaRKbobz",
-	"MUHvAxbLBq6JJTBM6xx7VZpGEmi4SLswCulv/4mPNXx+8hNmjUUs0FWmLU/czQeO/oe7u32YFVNMbYef",
-	"lXz7PPyCwiYcI8nn7QrpvcsIzE+7sSc1I1iKyyQWITztnoBz8mBZ4LTW3CR423+NQMulnaDdIEu/WPFG",
-	"+oAz78OOuRWPCNyms5YDnODW1RUxIionD1YHN+WmPaRiPGZjsCWczN52ftqOIBtLDOcrr1SXoqXtTBe7",
-	"KSj8gBaL7frhnG2WZZ7NtQyxqw2NGzk4H7XNr4X3rXc0SyqI4EKEbMzuRwVpw/69EMJWEgJrcc6He26M",
-	"d7t3rD8ofS5t8fHRlEXmLBK5nZzRVOptGTJwMkWYzqcXFtP+chRWsmnYgjtfqqq4BWuGt20ezBn3NWfc",
-	"x/iAWNxsezhYHA4WhwewOCzbGTBJ0R1xOhiDSlR380x46Jj/5tYIpMC+WvBgC5KpVymWeljowwY0W9O7",
-	"ORAM3HliOCGLQST6aQ/3I3MtXcZJFOWkm48+sfGh5hK5CH1pDhee+re/ncczITXlmoxgSudMSPXib3+7",
-	"5n1ybo0obj2DFPApAEgzw3yXDXPBjCeQbgFL3uGQEQ1uJtI8f22puucnP2YBrC5u1cL+l0emv4gSJIiY",
-	"uX4MhY0FZ1pIg3AB5QFENhol4YMckAgLUHx6UvKNq5TyjXeoPJkmMeV9xvt6Cv1IiFlWy4vjlp72XIXi",
-	"cCYY1+m5sjiGkFEN0cKqC9+enNj2m0YoJlI6tqwTVRVLmykOlwZlDsrDQXn46pSH3pFjIRUPZfqJxUlM",
-	"FASCh3gehnTx0gyIGTMrcEEv5w1ksZ3i6MWPPzw/OekdxYzbfz9LoWZcwwRkSUXwYP25J+1mZ67wrAyb",
-	"PcEQBYnll2GurJThYk87qPb8uDVgruyV18Lk/p6eSSMiWpm2nhg86HH3cSU55Q3tCAseTKXgIlHRAiVy",
-	"yjnc/bSOzFNazPo0iuo1uiuQMeNWqYsiL/ej7FjTqDMvbrKqA1UxQJdazGxGmYvd+kLN3O0zNndiDbvM",
-	"h/6bW51hdmCUXhPjShsdUh18QC41UxtVuOqE1oyvczHBDY8iwbUUEVazTkORfS0eSdRUJFHoNMUcORXi",
-	"XWkQCIkvGS3wzYRPKTCfCZ5O1mBKRyAVE/xSUw1fplU9O+hl5Mc/+CePFkSBrnb91sV5+7l34fc90N6V",
-	"mExcsqpKEROvD9rR3C2MpkLcNOV7fXA5XgYF3PBiUfhqgTUgpzCHyOBdj8SU04n5QUhCw5hxIni0GNSn",
-	"hf3u4OpadpiDyyeF7ad9w1tRugjXdTeNGN4lpv7G4dPMVgQGN6YiYcxD7NThHHq6vzQkjeWbDtejYDHe",
-	"FV/p5kluNdFBTYxAJxBtey8lt53swVe6rd+rzu+AupWoewa6Ld62KS+Wn6qCX35YtsP68VrcAO9d89sp",
-	"C6bmRWaYp1F3bg0fDWBALrWQQJgmCoJEQrQYXPPV7LfC2GgB7gpdPNs2XdjtNVWsSMnD2RvLDH4HD28P",
-	"RPEx3Vkycb6RVpTSoIQcT2MaHKdsof4dYJXxojj49WL4ktBET9EmYRAd+FjIALARDv7Ol9qQQlPN+MQW",
-	"w1AQSNBYtS73xYX5wFBazLT23gpvq1+e+ZozRWYSsDas42aGZD9SHn40m+qR2ymLgJifPyLx0uiWLrCE",
-	"jML6S4HemGL9eWVEa86i0w8T+ETjWWSpPD0T8485jWycvrlJcwdHL3ID0IdcONiPYoSHXvdtcTQWNC1c",
-	"MT5P7AwVk9uLucfcbgKkqLX4lLnB9GJzHSC2bVLejiqBtGcrcO+pKcSyHVhIwtyvELguKzvfb1HMrZQo",
-	"eBque4ZKZjMhzZ0JbiHilvq7I1j8qRXY/IaCJWSKjqIGsXJqB6hMlgDXPt5y2VGe6WaW1/eRrRtpsNnD",
-	"1669Zx7eDU7iLqrTj+sD0da/9+31bYNkgTdT7CteT7D+kZVWqfHwLFNy6qq/5jiPVQgJfKKBjhbugbVC",
-	"O2SauONXRItr7lQ6spFGZ3d1UOcO6twDMGEDyiVieJtXMBKEpcKDZncQEtsTEpbHbUNGSPAMvF5OnLkR",
-	"3hCX5/N1csJGZogo9ANHEIgY1DX3+JeL6ysa78wSVVJkwxf+h3SHRZlgyfiRKYkb8Cd31Bki7IlVVVFi",
-	"xh0OvOlL4U0ZvRWti8rT25psahMOhdpIC95kx63Hmqw7gdR6E7bIpq7MUo+MQ632IeCuV/Cjg69tNdVp",
-	"hz1r0pvGoIjVr0YhvamhaNLxfgKswe1LVyIsG5l2bIzGHl1q2+9OnFK32VnnzdMWHw5E2IIIXTyRhzh9",
-	"+S0FFC0Toggae+mg9AlFkMSYkUONkNMSgCgtk0AnEv1144hqrHA/IMMoyptzICSJAmlzeUZS3CoYVDfR",
-	"NIDsrLdC70H6c9ZkYHiLVXpKGGYJNMRCNRLqemua8VWtGnPxe2v1ahyW2jSGTM0iumhs1WgW/esF+WVh",
-	"88fMP8mTkElF5gorhyibPMWX20C6Vs9AgymZSJHMcLpYs9jNF1GFTtisMoL52yatGPFgSq0Y3W9xxTX7",
-	"MQ7Ia0Pmixm8IFQFP49FFBosxiaT9o847Qts1fgzh1tQ2v214x0bG1NORGBosUlB8hUPUp7QJR6IwGWQ",
-	"5cIoDXdpG+vjJzDqN4pEG358K5kGMgMZM6Vc07vKCBwR7LhJzPa1hHQna2kI9+nUF4NSho9WdaRtkeLk",
-	"rszH/uy3uNQu8nv8hveYtNMutMhTU5kavf5xbCNy+yOqbWO2Gh8vjlIkTiLNZhHk1RIeHuOTQEKghWTg",
-	"m4ZjthNJqXRALq0JQxEJQSKxnLf/yrWLwGFvhe5j3DjBtBWsAK9dWBlV+bD20EGF6dohxDOhgQeLtXmH",
-	"C58WwS94Cl86AzkVgd0RbmdP74xlIOqlGg5wd5nPk4zpIt9gSTMakTFlUSJBPe1gpHYFbRTpookKRdCU",
-	"S+DJj24uH1Mc36miX8M4selE4YJVRNXUkTIHhSnrIlB1LbjNBI0dFlegJnbGuGvZ2cZDvfOONn7h/WTS",
-	"tMP6ehGzIikhlRB+BvMoMvdanXJwQNxmxN0q525i1zlySEsoHsjBFpNvoIWZV7CqY7LzfaH8NN8o4ra0",
-	"Nrd3eZcHoikRzfbVrfSsH1DTepD3mgs9PhBwvlBimyeTCFaWxrYFrtWx7/OXCrmcSrggWjizB8o924yU",
-	"5v6OlMMUmbA58B5mi2fKZcJDwDJV5oFk1gkJ1SK2FsC1OYaryL1XjvHSJYpUH9YjZyPpBXxpbKRwSZYu",
-	"9sBTClAUGMxObEJXVE7AibrumoUsjlXTVwPDW9G23zYZh8xX5dWWNBAD+Zdt4z6oa9e/ax9UZfv5tNP8",
-	"3lv6r+BFaZf7Wj292FB/Z0bZCyNg+MSeZFZYqktU4E6mwVdhMB8rt/UjMVntow2Aa0kj9h+zIBZ8i8SE",
-	"mF8yUCQ2mr+PhxizSIMkgZHHktEBubDhEKuiId4wpV+Zqd+I+/fBX/ZbIkijhYP9hvGQPIHBZNAjIZ18",
-	"xNJ9URR/TIy0qBOu5qujJoJYua71bqbrDmTCB2NszoXLD3D5gYRAyNAWoKuCwzkeN4LDV1OsmdqXY7zH",
-	"7DLhttlDzfy2rOKGC1CtIZ7p+gXcgM1XUIDaY/0KbsDmKyQKZP305q+bzx2LEKKmC8YBq2ZfQWpvxORS",
-	"U6mvWLuWf2/E5BUP2472LOANi5le54P3dMI4spOLltLyjZi8G48VrLXMy0Qqw28fUvqlbLCNq7zEjncn",
-	"CGk0FjKGkAR4KPkUjFl6G/nS9wjZs13EVulimJBd+buHX/m1kCMWhsBJn0j/Po2XJaAUEXQusqFRxuc0",
-	"CPyb1yGmQCM9Xak/2GEVvU6xfBidJASTs2SVYfxX/PYSK48dPSDV2XWaSK5NQ4z1nNhTCG7c1v0ZKb9R",
-	"f95qoTTE7rwjFgBXcEwDzeaNgeOvPgWueRkl7ityAwtfEIlNOITk779f+QDWYYNuNnSrvbHz3Es721qx",
-	"uhtYVLVMyXaKmpZRSn7r//HHH38s/efpym4wZoE9NIP5NGNyUVnKcgxUJ9IOa9+eaRZRvqEFxN07lo5L",
-	"MX/n0S/mLg3SZsBYpXlnTP2cq2Q8ZgFDW39qYuyU4cOTaJHaV7GREFYzEl/mD7vx528B+5AXkqaxfHGc",
-	"cKZ9xYNhY00/um2+0hHLoedC2fHuLmbsrbB3BCkeCJn+mIs0nzNKgM/JnMoDIRW8/v7OCqWdohRFKwkq",
-	"Bi1Zi2D391LEoKeQqL6BmWo2ioC4r1E2u5YUWPjZKEYpzagq5ejCrbsS+TV80seziLKlI3Qp+uYUya+v",
-	"3rwnIZ0kH42iZpcfJSwK84rbNf8f5Oof71/lBk5oMoFrnv7i8xykudefr4+eDZ49H5xcH/Vwno8h1fDz",
-	"9dG3J98+75886588u3r27YuTkxcnJ//3+qg3ER/zX3777Projjy7xiUz2JKZZjF89GX9zcOSKMYD8IoU",
-	"9iIogrn0TR7gpT9998PJyfKKzkakPqa1uT/6ksZvk3hkNPtxdd1u87MqgtIwWR6shmHf18Jn+/Z+1ELT",
-	"iFzhf3kKoAeHMG4b/NbAVZikEqTCiB9roVkBxmjhdN0aOOznrsj3Mgj4x8/2+5+vj5x2YvDl2+c/fbdi",
-	"NJI94tb3K0bSEWakmrH/XbHPhj2Wd6Wqj9T/+nnpWtMC1unN/15Z3popj3LFNcvf55cu//XZdUX3lDL/",
-	"zFhYyrcYJ4a/+N4inauGfAaalMHO8fKM6Tp+LmbA6YwNPJQrq89ys3X7eH43Az58f545i1z5v9HCpXYZ",
-	"vuproVcx9Xd28b8rbDJwL62GhiGz/Wre5/Qb69pZqcZcTaG0mf3acLoUC6WrTqdGPUCOuVo7sM3MMYkL",
-	"+0F5yjRKtuvJjvxQDchvCoib9vgzpzHcofZgZ/Dducx3xUHHNuJ8nDV5H9HgJhITmz7H+KTaM/O/7Qb2",
-	"qaA33aMF7762mw5wKrTE0UKrNXt/FiHcQBScTOkiE3NIlsc4d+stES8GTc2jrpd1bDDY0ivjX0WlYvx7",
-	"ZWQrXs52PXo4ZcHR4UJfnJ/D/aUbzmy7//U6Q+4gsMSdYXd7GBgm6xE+bzleKun+b4deq8ngODWaNRKD",
-	"4Nhd7pbK0BZvnNEJGLXOkUBDPx4c0bNZnhBmrRktfU2BhkQLM7EtHUBZ5Cp2zOi/E/B+FAkqiUEROtZO",
-	"2cNkVhVQzv0iaJhfNDDrc9zrw8ab4EJmxdbeuvQL70d7BKQdulZL7+kENhJBO7WmBv7gO0jtjsAyHaUt",
-	"mUtE2z4XYQstyw7GhHPXBGgk9NTZxjDp3HX1FhIq6Ssjku5qRNk6bXOu88eye39pnR5UgCq7/cKFt0m9",
-	"xtvsW09smJ+1Js86d0978natzqDOFnrAROp2SNaEYB+yw/5qMqjf0hhKYbKVfaMxOr6IjzVIvszojj/L",
-	"9PzPw7t26ZXt6cB+sxU6cI1078Uan1d7pjxiFVIXd8C4XlJuVOc0qdfIjr4SiQwgTAvX7aiQUKrBV6Uv",
-	"0nbI1TaXMTcZGS1sIFvpxdcZpDnZI6vbdfZgHR4Yxao1EqxK4luDf9hv9okKD5UJt6Hc3ScyFjLhdsce",
-	"sf7SoivssTOy32Xi0a3I/WMNSvcDwTkEFoL6TsNKY8Ytjpwz7fLzlnh6TG/Q6Owj0gKMUvMaVKmKIeQf",
-	"RC8zMB4L56/bYBPpZaOIuR2Xo7J3UXBlYcmp4/nrakA/mx+FhTVX54qggaE/ogrzGthkqm/B/Nd2Iy0k",
-	"7WT5U5EY0cj/dUYnUJtGNTx7DdjzeV+ZVEMPps0AcoambaRU1YX2nw7P0F9u+9aTJ4GIY9pXYADWED7N",
-	"SvniSD2lmkzpHMjwzZucddJ+XldCzjXFv19ygL2jnHGv1XhnPnzQjLLhmV3LIE8j6ebQtwJjd/5yTZdP",
-	"H7Ad6/Jt4TOIl/d+2oTKEvfIl+XFtDFYj6EQxdlsBo5zCA5Z8pm5K+zZjQ7vWvZBJxdu3XU5SKGAbu9+",
-	"Dqy98BDiTrwdK/GD0QVyOwXue32TKVW75yxr1VfdjA0hYuyAF+VWa3Zal3gR3klKA/u1oh2arGesb/li",
-	"VjDCNmWR69WoXFzRfXUpETxmXeqL1VV89vtaukoNWuyTSXSSXKuy4uuodNs6SlrcsJ4gN9VOHnFZq0fA",
-	"NbqtWqSs42vTL/Zbr2sTrtVa05BzFoA6DoSQIeNUC7mSidmw94osXeuInzClMawpN2cax6w2aoFyBvpl",
-	"Nlma49vNkIoSpI8g3vQMdOE6Hd6syEJOsUuCtemr4ylTWGNpZSY4jmMBjWz+oJEkdm6STrYpKn1wE/zq",
-	"YNlqyOmpayVJxNhtAq3nErRkME/runx3EvfIs2mdRAx9Q8rqVg3Ppke77cmwfGRfNiZ7DCJYScdf00os",
-	"TlNhtsYhc8k59+WPl36qjnPHJTgfCW/MLnJNzqgTziHaHKEwPhjnSFd+ckVZpAIawdNNkekKZ+w4JuWB",
-	"fCRotHSTq3BIa8Yn6phOHOgrs898lvLwnOBHxe7HuVKpWf2ZSvwYmo9tQ+rOokcOxkbsKJ/DV1B/qOKi",
-	"u5Y3V4GghVeMRf420UgG8++F8XairSL9Q8UcFbB+L0FHLenOghtWXvNe7QkHut976fHWpF8Wg8fmXI9n",
-	"UsxZiLS5SrFKRumv+yMa3KQoaSYifiKvgKWpXBDZXXAsX9OKi7xhygrOYaKn71MIuyo/q8FtkyFSODl1",
-	"oKpOlO2rQOq8Zml1yBYUdfzZ/3ge3h1HYmIrxdRlFPiqUEg0WphH7zuDUCSQEJqbolGZqPwKLQnrlCkX",
-	"oFbC1zcI31YNPMMCX8gqtBbTD7NDumcSYkU+g98cCdONe2Q/kNkeK0Klt1EpQSKHissUV5eThsVzFaHm",
-	"3Z7QyJENzkLGkbi9N9ngAo+QYrZoq6o/oUY5mN0R1pjadx7bgSnsscS+QYC1+MEmEvjYd4usD+p/6UY0",
-	"cZRE+er8M4pOewm2Kwb57cMbNBsmeiok+4+1QAbtdV+/+uNgNw+QqNt4Pnt6ya8CahUHTFuYHtjf18r+",
-	"PArdlwO6/fRtYwLD5JLK/jvavjTccNfowCtK3gbYVj8CfWrnQQK4cD0ROmf4y+BEEPfELEpQNDTOLNyO",
-	"bazwldLpTsKXLmy7jy72GrwEnRKrZRG+9UgLphBD7EJJVtUzyIU7X7y6ePfhH4M4xAoubS0MkMrBC7vo",
-	"A1jtli4N1yFBBBQjBVIXZrQ4iLW9izVzKx6jHN56vKj0UDXaoN08sbtx1zKO8tCWeHSFYm1lPztoTU/t",
-	"w+Hs9jxGFsbVnlp3SmIOcs7g9kAL3fHVNpNApcaWd9GWGHS553NLJ+228P1BnbQe4dfV1irFhKvbUCEm",
-	"Dq+ur9aN2lo+1epWLhfX9fu7a6tqOR6NJfKWyvOdDs/W17lOh2dbIOmSoQgLcIixz1etthNlvQ43TE8Z",
-	"ntlM4HZqHyYJHlS/rqt+p8OzforT91YAlzS/jUnG63uPml62p3Kmx9RorMgRpFv5QIMdUDnXpsCV+ue2",
-	"qDCn4z0iQvwCdOEcqR704QO/KOnDa7KMKq1YhBD1ZxIU6NWxhVMqw0CEEDpLt/vOG3JsE4U1ggfRjvve",
-	"Ld7lsME8oG0CBgvHcyCXTsQLFu+knT3efLKaLGgU5RsMppH59vN1g2kv7KKdJ4f2hHCggC5FzMYev9rG",
-	"7WW15DncLmH3RtkndsJu+6AtjAjeBskn20P1AgT19GY9op0oMv91er1/2pXXe7m+bocMSa6w/9peb2RI",
-	"x5/x/23r+fNtMKK8F/zejKj0qLX3VReu53a7/WB6u2yhLcAhEOXrC0TxXRAaqXF13XtuGQ3jk20QXN5C",
-	"8sUQ3EMZijZVLk72o1wUKukflIsDJ9tLDu0aeoUSyfqPd7sKfkqezEAqwWnENAP1dN2H/CWu/7DlDN/T",
-	"SbtxINOhyyHGuYKCT3ztY8MzeyQ38mlDlcH95DKZc8YjbmOHsLhwMEN0xwyhHHVsZoXI5shT6eLp+hYI",
-	"g0LdNUAY6PZkebBL15OW+fvB4vCoLQ54xV+IwUFZOm6rFxx/Nv9rb23IFlnftnBvFtOi2C5upmX7QLzW",
-	"goFgl209zOLnpwd1/uEpt/t2iRqibduTMacFYEvGNaPK9kqXJ7sV1IWmjAdyP5D7zpMpaml9DRPk2lI4",
-	"Z3DcNbU/lNlw7SfBjjnNwU544DR7NxO2fw1oIVpYCX1wmw2iLda8tiviPA3WwCtcp/O18RDMNhY1e24H",
-	"i1p3LGraYVgj0o+ogr61d7cqsGzGY6OvgruP/GN48SYngkNflBvPBwvrjMS8WvX+hSroQKXlmTSQaWa/",
-	"xqNV5aPw2I4ixm7dDiXMtgVcrunJNMSqwhSedjegUlKM3FYzCCpaFfszL543s0dObLX0il4JeTXgn3bu",
-	"nt/Vn+lwMfoXBLoKzX4prfk10XYN/nZNkS4jxsa5IY10/X8stoMiIxgLCUTROeOTTQjerrlNmt9Mry6S",
-	"+4PTXjXJbVdT35iD3VLJEVPas6ulPd6LsXQjl+XA67rL65wq35bdoYKz4MFxEAHlyay+ZqAv3ms0+Jgp",
-	"rA4IXEsGioyliImZBktjQ7l61oIHL90C3VFcxkJOhNbA6yk/HUIMtZPzU7WWnhKDUnRS4R25tPdF/IBV",
-	"jDEDNZu0DQdxh55V3ysxji6lUhtIPWohNtmTzrc84UEBadsr477byRnTdu5l4ig3UTJI2+22JhmIjW0b",
-	"CxLENx/rLioYda32mpZQoYW61vLGnYVwi5f+ANX9UugstPuyZW6AdnWKS8fkZlu8S1mQ9QX3R94Q3yw8",
-	"sUR32gEf2ZsVnhKRh0iYCcW0kIseiQQ2PGTqpof1vzL5atTq1JEXiDhmVc2BFzywDsNfELaOonMOxAfE",
-	"5qLg9/77WrHvBuxZ6Hsw1xP554hUfgd7eSe8pJwL7WAgT2aJmho8pqMIwh5JuJa2twqeaa9kIHq6M4u8",
-	"OatOu/rTcv6t1CHHi5wKtZ4qvykvauA7Fw6OTpgtaqnyJfJPT5RpfWA8S8f6S1RaIsIDf2rNny4KCNcd",
-	"PtXFQJ8cfbZiAPj348/mf+fh3XEWm7eCD7jnbTX1kycTpomMyX85XYP8FzEs/elabMFuyTAHw3S3m7x0",
-	"ZbQqfz6EYSuhMQNJnmDVuRnVU6yzIRJN4JMGrvJR+cVUJ3t2u8p0Khkkggq6fG1+7aUpzIETNrZbnVLl",
-	"7iAWIRu7dVRGuSMhzLu6key3wgB3+vywvKLp7YGCfa+8BSEILIMZQTFk9KDZgHm/eIpdg6Gx8biVtccM",
-	"JCPQtwDcUYjhT463zUEaDqCwP10BjkojkDnLU7Pyo2NaD2gf8IfWWE7P3FK9PeorJ5Qz0BaPXfG5TchF",
-	"BVSG9QrAqR3ghUgwpXyC+oAhlTlIrYgWSFCOZLzrvqQkVPbhozL0qPDSTn0goe3JOHekxN3ygYCqevBR",
-	"GS4h98bUNBbSyZ0WNj400wHXcuEWdHp8zvyBvfcDwccRC3QG0IAYmoEQqdCqdampkEpDc//CLZctfq8R",
-	"wMerYu9Zncx8gV1QKDOP4IHQLeJvRtWGZutpeqhFzAIaRQsiwaBv9limgRTKS05DBGqhNMS9KvPZirfx",
-	"hZg/4MvYez4f/QvZXGX5few57HZexYguvbKRjcPtuT2XytAoDrelo9fC4RTRYqWtLZv/zy/k9W1Oqhtv",
-	"b4Rkj2xym/nG3vVqMHqV8xX1ihB02hK6K/za8LvNuPUsGUVMTRs7m8ZM2yfMLFFTyKU8ZgzQPWpWv2Le",
-	"2/UOZsv1MNQd2x7DEz6ASiK9kkk5fOrO2+nAK5Z4hUOlCipu4BruWvs0itZiFeXwDHJ+qgbk3OoT56Ei",
-	"TBERM63N+81jj/Ok+reakMs+7uroDLe1YRR1NTgjg7DTpOxxpPtRjh7S1K9/OjxTjYjchMGvwVac8s8L",
-	"lRk5pIjzIu6M6SYxZ+96G3i4ZzzAgmTdR4IoKt5UlSJShxLmCZmoVl4QMQdpOFMa1Ga/JYwHURKiV9n+",
-	"QoyRgzlkrHSCXNplu4wgFsTGJOvcIXxhcbDKn38dXmhQuh8IziGw09dxjStQRuplmRRMcGQh/uM50wuv",
-	"IufK+7XgIWbqlxkIHQ+bdmAaoFeoR24kMWdMJPKhLiGK2QEJcmCKthwlUSBb1HlMe88aLoHfrFHQ8Tdc",
-	"4wGvExcwK7XJvbY7fvw5S6+FHLEwBE76RH4Jedges3KIav/dtq6hGU1oEIikdZtYO4HBn6OHrERoFthT",
-	"JUK7dD1ZmL/7SoSdaJBFnsBgMuiRW6A3ZEaVuhUy7BHmR4kInh7Id2dlDFPbQB/pC83V3a9qmPKDCmaS",
-	"ir3jz+Z/bcsYtmAvpBj3vhCJVBCN6+obOraznor0G4LcslghEnd9FNzXTEDoey9cl7mqnRn+8Ga6HJ5X",
-	"Qzyrqwv6lnpILqOFeUQwuVZ9wS3TxcluZWmhWOBBRH3VtGQe8J4OsLVGhWK7ooAffv+NIozbEhrr9gu5",
-	"PzE9VC2+tZXiHRPyoWvsgZuEBz27KVm6tYZ9jJ1D+/451xRDiU1xU7bnvyBaOK1+TqMEWrJAnM1c6Hu/",
-	"cMc4IQLogduXi211PI+HkOA1dtdMcDAMHLQuR/XLDKSGTd3CaCrEzbomcP+ZDwL1zrMBOfUVonokppxO",
-	"zA9CugsSPFpU28h/93B01WXiAGxrZU/PtYtm5tvssD1OpL8qosXx5zGL4C2N4a7BnybZZALS4Mjp8IzA",
-	"JwgSdMPMGfVrDcjV1NYMjBOlyZRiAJz7Y87Jds0pDwlwLJUwIMOiky6EGfBQEWGTcPznhhFhc68X13wE",
-	"VGJs6Q1YfOuRwq9mUaLIrxfDl4iW5geLldf8ml9hvIBlryMRLgiz9AOh9waaDVDrW/791S+/vnv3vz6+",
-	"H/7jzbvhKQE+Z1LwGLi+5nMqmdkCRs74D9NdKvKXP5axkLdUhh+nQEOQ6q9eGhlxzT0o7m+Y/ODAWYLh",
-	"11fD01cfLvMwkBSEa/5aSKLoGPSih5/9ZY5VSPYfPNW/3AJmtxzmIIkDCsKBPRMDvEy4GQD83wkkLjnD",
-	"zAU8nAnGNZGOUbA4hpBRDdHC9vbXU7jmIZ30zRTnp4Prcukhh0GOxtbmAafDs9cOTdtUWm+MSfwljyxj",
-	"IQtIlkNFJ36/ceNDOkk+3k4/DgaDb7JGUiHiFrmdQg3CukgEUG7B4iIDH+poLygLdizcX2MTtdL+EOM9",
-	"HIpNONWJBJ/WZt/Y5Bs1pd9+/8PP18nJyXfBFD7hD/DNJhvDBZcOD/HCwBhoAhxj2g3O1u73j/4pnST9",
-	"Sw9uYcvwicazCHdtoT559u13z7//4b9//ImOghDG6/4b8U9rkAaU/+cm/edJ/yfaHw/7r//8/MPzu/9Z",
-	"EbD+QDqyo4qcdnz38HKuMWvVsQNtqbYrfjPDsXem//7GqaNBCEk/LVIhZOqoQ4Lu5X5z7ActY7MlI0cO",
-	"SC45mjBMlwaazWEvGrYnbF+9yOzHKL2ZxN6Zwm3QLseP92qi8CTgBVwuaDakkw8JPw+7Z72AIJFML45e",
-	"/PPPQvCMJeN63a1BTRTyZkX8DIaYFcy3hI5Eog1GaclGiQHSzeNDeDJ9KxBChoxTLeRGT4sz0L87GDv7",
-	"sLDwrXpYDHNMlsh0YO/o+12whJfZPRAFcs4CIAmnc8oiwxZ2itxnwEGywGJ27ijKb50KFCtEgSkNcQ6T",
-	"1YwGkEfmimdqNqzL+IQgtn6qZnvq5jXikzV/8Ck3yn6Zj5GqCnFKT6W77VpTEPcUKZVbvx5p0kHd6N66",
-	"A6n/tsoTUR10c5tDskocLXKa48/pz6UgnKp4mQYcrkiIy829VlZc756crCIMJ0OaXVeBepspidU1mFZe",
-	"Wa9aGDjFovvXcbIv/lCIA9njVZ+Bzm65FIiwLEJ8NEJVKEFnL/yhIhQ2k0h7w7hC88DdYlxnZJFvZNdC",
-	"FhWfhAZediVugJv3ocHCEVUsGCZ66n5hcM3o/h7nl17ndJKQ4ftzYocc9Y4SGR29OPpsN3X34vj481Qo",
-	"fXdMZ+x4/uyod+Qt1Ig309S14PTPIywsgr9ePoZfhdIEIwSEta67Ne/ydJVNNNV6dtQ7Ap7E5hTcP83/",
-	"7Dn8mZ7Q8qbeeS5gqybhqxNbifLQ6j/mH+bdHMKYceZrTzoOEJpJyxbYpUldGpaZacqUFpJhSVGqKS4T",
-	"iQmmp50Oz9CAnr7QiwuZv1UtdomPHCKWNiI4Myu5raT7Qk+Fucj0Et0K7q1Unv+9FDHoKSSqbxCZajaK",
-	"gMRmT0FpLZw6AyWbPhuz+rwKl5CbPDNdoIciN7v7d3nmJe9S7pCeRGLCeM+cvkh0z1nnrdUhBq6fZrNT",
-	"QyHludE9nH1QmPzlh99Oe1loR+W0Pk2nBPP7c3IDi7qpM2NIHsQZ69/Aomo6Z+5N3Tj2jJ1l12N3erQ5",
-	"6Zb5N8unGjJtTq4FYGZoxRQvgWtJIzSuppPQCGvblKd2xqCiLSi3Cn5VBanPLZxKwZ0zZZlSXEZoSgY8",
-	"qNrxOcH+l0utqlZvH5ssluc7FUGCN1t5yTm6F0HVtqx+QLgIYS00sSlzffOdOrr78+7/BwAA//9u8RWY",
-	"CjMEAA==",
+	"p27p5c54wnNBY8v7uOHHaLaUizEJKdzZsTCs2uN32KRgQAwpCoTUAMg5mcUDzDYiO65mBVfL/WJUyPUa",
+	"3x7S3Edp1bYt8EnZ9K8pJK74c0KWpBK6pNmZ6wkwVuyHLN/bKnRqpJI9Li4nWLpt1i2eJBBcdPrydfHi",
+	"45pi58zi6PbfcG582ngrHXNrpUN3h3rkXeG//xIIpTPD8Rte13kelxzh70P9xJPUhNKTgOAMSNfw724z",
+	"kZ57+nRiNcsRfXsddIvi32H11ivg/igfuVu3lBKBqRBrf82zaXKWhbyn2M0qWFovNSb1ZW3iNeSkLMQR",
+	"AKRmNNjG/G6GcLD/EuKlGM2WSOIJ96TvOwHGj8OJPwyIKpJR5jc9gpznJx953N6f6yxebPvSYuHtOSuN",
+	"dPcG2sSa1VbS5vc/wO9W++i7m7vdG3eW291uWlLjwYl+5FyR2j8StympQXMFEI89z0fLp1TWlrlfPR9T",
+	"xhB0LbiNYQg7TKjvntt7vfNXWyIziM3b/h49RuOU87qnvraSEsQLj3rAO1Y0PYJTInETC23gHeQu+4y8",
+	"f3cUxw0fBX8K406An9ZE5hpzpOLpPMmNY8BQK1UHCpk1mdF8wWKidc1EjraBiEBwBTRjUvWULux+rEuW",
+	"YSm3WET2gX9OaMEpjgsc8GqP7PvAblLATxB5ul4Xm6BaEYQX7CDtPSVnbPMfWABAluYP9BXvkdesXLiK",
+	"dbYti4dHglBmtWbZHnld6YoWAFqaFZUyF0X47mf88Oe/48Kxskb8U+TV6ekx+f4xBJfOpF6CwqqY3k5V",
+	"RbeAw1qs3QVp1MUv6QA4xdAwL39oUdiY3z7Cd6rWbz04nuNaCkJsOveNgzD3xJAIqEPmUs1FxVSQw8AF",
+	"QEgsSkio/fxxi9inTgkWuyK2GGTpnV6GfPxAzCGLHYcJcN3VlbI48Dk+MQx/CFZqpwFBpd5zyguwxlo+",
+	"OTp6Hckm7ckoOUikkGCXiRSS4RRi83kygAkClbZL6IDApRMgB5v1MnNpKaarByqoAxIt0jEqSvEUQfxO",
+	"o6kgr+RFQxSZ9cckWt0A23SAFNMaJwEyo0UF6PAXbLaU8gxE/gyv91Bqz4heqrNltY7L2UoIVlwFf0LD",
+	"lyDGuEcv6QtPSSRuQDNAzl45MiyVSKwJtKXR1ZdxoOnay1zBhTzrrydim7GVYBRep20MjWDaBhrFb9JR",
+	"yEdcekTudAHRmCf1AKLI5/D8AZxop5QXKqMFexg3c9cF4LvGxebAS4Lp0AFladd4lEJwnjaZNlYOBZbh",
+	"/bujumjRbBOsWKjYVSW/GbgYOyfr3d5Ce0xByDgDan1dbMzA280QoczecAQCTNd/2AqXjUcpHSetsuEQ",
+	"Y4LkveCXp+HNupOudBmsVCOqi13S1bpgk6dP/vJ/v/vzn548+dvfRmHvYRzN/vHhj2yTNFjhS2T/+NDo",
+	"TKS07211YrxhF2Hi4aRR3+7Pjx+PPy/YhXNlBi04WPY+73spi0F4s/eKle/Me5+nkwtZngGe477Xhvo+",
+	"/an1etRQZtd7wYR2sWejQ5j2DwmiDPSHMHVhIFK6TxtOIlLOcEi8L4NhDVx/nW34RFYD41KyKjDlz3wB",
+	"hfgK0FfcKR8JE5XFuKQjWPrT+vXPcLYiAMqob39yb7tYq4Ftfg3G9y222eJb1g6ekbgRhjGa35KdlcWS",
+	"eDhokct6HBE4m5Ew23YWHl9763m8qIqmjyuI/HeIcuSf+6+PyLyUQq8gu+kG5gcMszVTUuSeobDCNf+R",
+	"RULmYkHJsx6UfIsD9RMXubywAUc9xTIGsUDEutLPpNLHrHzyOl79s6fWBUhgLOp8Ks+YUMMjQlGzFcw9",
+	"JkBdZ5ShAuVB4YRelnINhQXkmgnK/T92M5mzy8l0smCmWfu7zU60frvJdPIr5VGNSlXrtSy1Ol1ycda0",
+	"44bVSe3T5/O5LHU4skJegM8u59VqMp0s+WI5mU4u4f/jAApdcGxdlMGT8/Y1GVwA/s1WbIA3ACUmAAlK",
+	"v/U+AADaGvHm6gUU0ouLkEBbSAk403Ys7of9+eG9AQUS48Pmcf6gJ41GjYLpYq0Wi1ne8gurA6d590EA",
+	"WPXcY587/KmourGttpfGmDIHq3tKdlYNtIOHTTX0L98PaqG3p1X6V5P8PpYMRg0IYYCjw1Gxy+p7xM3u",
+	"R3U6Tt5195vZR/6+uzOreKG5MJdqyfMsRP60j4wE53k2XDqm1aNFN3O4v/Xda/R9lKfBVxFGvDcoaBRb",
+	"tHgBIubra+wN8EVY4qWFcEOVdhJu+7VJM5zp/oEKUd1ug4s6uGZBf7BI3V5CcglX5mOCCbYzuVVDDFJZ",
+	"vhrauijQXXqQliAi3GqWAYJBy5VF8MB0u7X5AfL+1R5CAT4lc6O22+e1wg5zWlFBF8zcBqb23+VTsHc/",
+	"e/f+AGL3WhWgaZVzTQrpOpySnJ2zwqxF6sOpDSeR9o0ADUUUmyk55+zCfF0yimUsQ4BgMwO0tlIELPPd",
+	"ofIH7U6mE2wkKkfMeql2sa7hPS8sSJRZJxXd8PGBKrj1A2AQ2GSMFn5CE7ORs/GqRC0J7GsSUWKt076c",
+	"DRM5QH6HVkijCn6yC49/UJF/Wq6oURTN//BhbG3tyJ4B741NIkKpbe6MJSnZggkINsJ6cXa4O0inTCHx",
+	"wqgeRio+RlNQ4ZrqJ475p1AeVS2NniZFxqYW80exrCpZsfn/RXUzZ9ofEmH4mkV97exr7SBoK92dHXZN",
+	"dM8UO5sm0kpucWZ3cJJCugs51jHrnuGOekbMxhNb/0nsAwvcel8Awjuj29iG7fs/bBLC7vCAXCylazbs",
+	"LpHnP4wwAMB2S67aDKKubGxzDXFFPJZ594wHrhq3A69e7z/zNNWrsERgsur1qX0AFc9TsRjv1RbbCyEZ",
+	"dr222GUg0uOSzfllDGylVJr8lWRLWtIMgA+859HQNiDc2mm2C50kit6NnUkQSHXVOnl1BYxwktPAt+C5",
+	"z5LANvpKQA8OZGxUfq0veOjnbJoAsAA8IuCYFhDLalSAvQ/icB7+8NoWIHSlHkB6w5yMtDaNTQnXzlit",
+	"EEqt5JltqfGZG4xFG2OXXGG5HBwaVoxw4KvBGD6IlR0FVOkvz1mORN44qKYEyu0Rf1q5GvJQvM4P6lnB",
+	"DaeZg6AqchhgZ76Y52q3y/Tr24TwkQ/Cxo/Y71zr9YoiQqgicgZv7n0QvbK4eQyPPnlbw95Cpjxvfdmm",
+	"aD+4AVpMHlbo1G0SXfTg6q5LsZAl18tVTEBcstwSsHsLCOH8yZVEtmeFQG/ijcLHPQ6TG1z8WuhEILxs",
+	"EVu+EFQbPl4yai7WGCeVhn3B1+KH4CtsIownWDJcDd9P1H/LspJpL396VpYK2xx8AYtaV17tnk/d1R0j",
+	"xcMevCS3quRVRXngCW5PdoAVnnfpoRtrAkM+pwXPPbVZOrIiEl5ouOpqbK0SI/isTOnTxU0rJzD+sfq4",
+	"l+htfbzBwS2VHJeoq2YaqYXdJxTzcOfuh1oeDLlnn/tvkGEZF9tyV7z5B2Pvje0pDNwgffs90xhvGu65",
+	"Ot5i/J+HyuU5W62lhtr8Z2wDSUc+0MWcs9QH5oFlArT5wwNCi5LRfIMahpp+EAAoZsfuoz6/f/w34sAv",
+	"oGlzeXLNTwklgl2Q9+8PDwxDerliznIAN13TjasNOT7mbb+ccV3ScoOwXbaNNtyomRRV5KfnP7x6+/bH",
+	"T8f7/zx6u38QjYFL7/Eg40NU+TY7PHyl8jeCeJmRqwCwDdec66H0U7lYFKMUZQ1v+uVwwXAQ+X+FwDpp",
+	"W8AC1rVjJH3mbQG085Msz2JG+FgBxpybxZ8Bkt4FftfJ3ajU5lgW8dpUb2psXnwlVI9qKHGqzuLwVUtG",
+	"C70clwOO83oVfrH9pdfNMXLHnbGiJ0R1yHc5+ZFtdlHtWlNe2swEiEanyuhNNUJfexD11hkd5RWjpZ4x",
+	"qsfF3FnWAu1m6T4lJcsYh4uQ4WI0YySnXtZlO3ug8GETk8U6MbAw7GbU8RVWDI2lqklNiyTxYf1a0SXB",
+	"tjIZmX0qeQou65YWWv1PG6zQWrbu3rWIO82pr1o80NHGC71sBT/ibAgW9JKitfEiCw3kOIoNlKgobamL",
+	"Srhfo2oitD7WII7TgZUu7I29K1VUHN2oh9zwOWECPGNwaFjsGsz/dmGM4xMw3EiSXcaHPU4NQ/IaVL98",
+	"q3b6Kapouce6lRuwVrVz6UA43J5RLf/DqBVkUVKhHerp2qL9gkOIC8LOWbkh3j2Gn0FyMrFjVXXBUv+a",
+	"axP1qrpVdKtA43uR23rRZxLlivggiIwKNx3QkF2/8bBtHEzP0tRlIOy4oWICWm7cdLfZXGj0pWlqcJMp",
+	"pOnbEfZuMLYXwUwv7HJbCRZUffHrEgFLv2KE7PZBA22SdgOCIfTOuC1TWrefetNH33/quAnb6hgetJ30",
+	"DjWuzta8ByjC5BSEkbU6IiS8IV/DJS5Cl5YM7g60KOQFAhz0Rp14UPvJ//xrf/e/6e6vj3f/9mn347//",
+	"2yQhrJsL0C37HzpnRkJUXa8Q2Rbk1DLmXNW+nkjwQbNUVXK9gVQiHzrnQ+NmjJasfOG6lWv6C6DXw3BB",
+	"6sAL9SiWWq8b8W2ufiu+7aLnwpc/Q7jmXLooMYrZ47hak39KTckruqI5NUdzWdjv1NNHjxZcL6vZXiZX",
+	"jzZSa7pc5V3Nc//4sFPo3hDgSgquJZyZB3RR2bTGPSgxmjFLKnYQL4+Pdv+097hvADldVFkhqxz+9WhW",
+	"yNmjFeXi0dHhs+dvTp7v4dg010YQTUyXk+nEQbQ8nTzZe7z3GIJC10zQNZ88nfwJfkJMS9iZRxCN/khh",
+	"YQL4aRGzExk5ooh7zav3zjsAkQtw51/TBRdw59nz4QBcwhUTGoEw7xPXXTNbLWGiqF95VIdpgp1i4O1j",
+	"uhj3Hivx1Y+G0JGrYSm+e/y4FWhI1+achik9+l+FzIqMNsSGncnXAvRzh8KOcRVZ7mMe/A59nk6+f/zk",
+	"xoZlM0i7Q3gjGyDWzPKBxVa57d7fC+Zs7cy+E2SDowaJiRSqpiUNidL/msADrCAfLRKOsRHKmpQazSBO",
+	"PoNSaAD1ViqP7tIlaGwo3NVrUfRHlLNM6R9kvrmxRcYEmiXVzvDyuSnRbSh9i/JvjsS6q9RH+vYVH7EA",
+	"9P749inuUIAjwN90viif/fnxn26/Z9gR0JTqC/x9YnKkmyZ/Rrj887R9ij36zf7rMP+cPNHeWbOzY3wX",
+	"uVOH41m2xytYFiRFRiTBS6ZvTAwMH1hhV4f57Z5bYV/o9RjDvXntH/lyXPT94+9vv2c3Y8NHWEf8HrHQ",
+	"S6avyT+PMioyzEJKHKbwXLkSeBYFAowLgAvZ6D5yhMLnv2veaQIK9B15sBaFI95vbPPFTh7YiGtzzhJj",
+	"SOJ8cwJKJvXoDFo2grCG2GZJv/iBc1801e/uml8dfDDNMrb+w+qoX05MfNOOrfxoCI/rCSvkqbxHXlWz",
+	"FUe7fvmgrsBl5Rb2vi7laq270gqZKf+dCqz3ipXHMPOm0BiSW3euZ3gX4jfB9WUE1/dP7mCtkRQJu1wb",
+	"4oN60zb+igp1we6ZGLOioZZgKENSAmzNd8/YRg3e6mlROAgetUfeOTcrJK9532nEOg3YPhBscGu8il00",
+	"HHORZXM+cjeJL80yd3DiRnbpTin1edLQHBBTSJiOGNOWZgivRRgoQ5cQPFJsECaTN8pYRg3LQCqT2zm6",
+	"wi6+rGHYDiHNC8/+yKbgL8l63z/+2x3Mmq5YK0T4i7O9NT1bpo/zfHgePfrtjG2stdkWOoscTefyDKzJ",
+	"rt2RBxPWhfPCYDu1GT+LG7q+j6QtW9g6nET+Ryb97+9m1ndv/IoRPNJYP8FP+1UuRzqzDTk8GEnaL5m+",
+	"Bbq+aWWt72yqGeZeODy+McwdMcxLpoe4ZU11rAYD4g/V/MLFXI5klxCA9Locc/MaZQwe9a4NIYP8ioPM",
+	"/d590yl/93LiD6vFNqGIe7TYKsfqIf0mFY8zxIQuOVNkZQScyxCY80KzkmQl16zkdI+8RoAgMEABBZir",
+	"b8LsYpo+kotrBwS2E9RhSLONHbuh/4UsNw5iHKGaaDEFo/aU5HTxEAr0T55OfqkYAMbbcE33qQtUpVEA",
+	"wPQAKgRNSbRunkIOXW/bA0txJBcnmpb6lK9GmciP5OK5yMe+7bboiK+4Htn82/lcMX3LGpojnTHGtA4J",
+	"/wHE8AtZznieM0F263STVZs379zYNirAs7NdgQgDmeXkl14+ypZULNjuOoBIjdvk9otCXmB4Z2NHkEe1",
+	"JNiSeYGXRF4I4tuMeOHFgh3Xj2/FUNfo5AspVidYuqY/ZhlHaNcvJ7bczbwqii+mZzlRf8Homd/Hh1+O",
+	"7Q3HXZRSLHxAoSeu+xT/ghwQRvdD+RdP5zUX6mXIhIVccNHDesFSKItvi2kDHjKWitx3NPXYAJT850+n",
+	"FndKClJXRGzpEtD97bAhtP2FuM/23WOFaKLm1Jx3Z5Tu+C4rGWQY0kLdA4q2qUiTp//6GNJ3SIcWEFbk",
+	"RM405aKmtB46x6yrXnWZd7L/g4SZYhM5e2LWMVuL5T0+vjUCa+CvxjwwYZ5PiLr6LRvF2oKcrIxua4qM",
+	"FNPVuie01uap1JkoqKzBLtjkbCyPVRBoao+8BaA1X7IM8m+FRMRUvJbukXcRoQpgfqsVy7lhCRDj3ava",
+	"CQz3Hma4wMDurWyGPaMhPvZXoBz96S5CZHS19jYT8yX4nMhOQK0P7+8hYn2EjgFpuM1xns/pYresRG/0",
+	"SsnZOehGRQBfZevh2ULevq4LmlyMFJhtiNeefPW5rp0FYXy2t7JgaJlpYczN/4BqdspX7EUpV9u8fypH",
+	"vW2hiGwVotFfmNGPNl7UnzyrSmVLbN5ogKLPyk7brfyu291NGI/so+3NUmH7B/svHXrOTiZXK7qrmBmt",
+	"ZvnD+sSAtwHhBqp3Q43MJT1nZP/oyEEmsNw21FP81fDGFUq/RibvkWMGpn+Fyrl1idrVQBHbPbLtiiZm",
+	"AzKjby63aUmzwuGYLljvcRYcXXUA012dYK9pYZRPBgl5SoIFi9tTrU49DyuV3uX58ZIJVvKsVbI2FVLm",
+	"qCU4LPwJMSZ52VVJxUKZxQY5k9aQfK4MswdoJjv/3H999NAdE6VWNfT/3gfxQZwuAezSIvPlkikIYLXa",
+	"FLTNdn2Oiml/zgtmObkyC8py8rPp82fAB6alstCAFmWT5R+E4ite0BIrT/9sTkX1yD3+eQpvA+RQhYCc",
+	"DvDKq6fFxkgH+AKRfJsH3XP8AMnZnEEna5Z9Ka31LmAZDw88HoMlib+bBbJYzw45UQrWAE5E1MQaha1X",
+	"x8W3kmUm/VBACdFw37DFSQ1hrFkGo4GM+0SNElj6GHKx35IIKiOQv7myn7x90wO+q7hYFEy7SptWGAAk",
+	"UUdDnhM4IAyhn9t83xJLW88tvKWFtmREmcnCjLnyaqwFKSM7Aazlw3iJR0OW3WLRHZ7lwhbwS85P2wLx",
+	"fVsIReQ7BcnNECIgLjd+gUqzwfVQJ+NjbynVlQcTqAXfF4gmdTtrjqzm+XQnDur9LYgXlskxTYh/fO8O",
+	"U4cR4KvbsOBghPOQi4ILFELxgza8mT1i4peKVWzYJnPd49d2pAhHKL97fw6vWam40jWqJoy//yTGOX47",
+	"iW3VhfogvuBFQWbsaz+NkSRqoQLbnW9xMntma83gnJUlz1lAZ3YaHl/U9nHTxz2ypT3vDV9FpKMs3UTD",
+	"Qx7SRAue6W+n/Zc87R3thfZVJ2z/cGf+MAHXp/xK5uzhFACy7Xp/yXC2UYe/PV+ud+L/ZmTg5y9tkv1h",
+	"Y6sVfe2GWQsy+Qc0436zzf0ObXO2xGaNB+w0plFS5dFvTpb2ZoYds3JFBYYFlGwlzxv3i5JlskTlHZQ2",
+	"pWTG4TYLtw+q6R45cCU4fc3Q6VDcLWb8IGHdMhjDwf7L7cTCMymykmk2Om0teuo3ctge38lpC4PIqDCX",
+	"tRlrjuD7uxvBlwFVGsVhNtGMhgp8zPgdPYxfMJ0tmbLJVswdrJFYm4BjbUd75L1i5EFhbu/6AaEYVuF1",
+	"HS1JaY96eLCSyoL761q7sHe72tNlFCzApY7F7iAtH9SF1e4Ti91E5lxMzw9K0A0faKlCUM2mxqj9PSff",
+	"3fDdu/vNdk6N7bCOnA/xYv+59oiWms9ppocxOSDi2r4N9iqiS+aqItdDSPDRvu/nHnLSiPwJO/x3zChH",
+	"/PyWFUbX3WnJ+jVGtx+wFU4CxsKT7oCN/GDQpCrLzX1mKdQVHVV2yPganPQolxfCFTOLstSBfcHoiXiF",
+	"b3GWtUWnuMp932Str5uzjqlebstUMtNM7ypdMrpq0o2vizDjgkKMRjsWI02+sAOuR1f7E0bzDH/cPeBq",
+	"LRV35R5a7WhNs+XKaB6mpcH4ns93zp8wwfusZFryBmQ6P+gbZNB1yc45uxg88ux7ZMU0NTc1dKqwS+3I",
+	"w5WbifDw8FF4bEfxh2Pbq52FdrlGHYdu4+7LiXjfOc6u7Q0zXM68gyh+DLK2Adi7UTE4sVE+2voAuoaQ",
+	"wEv5FV3Tvl2AtrM7OFJpOimvRJcs53rXiIbNmEABwS6aDgoqiGnB2g9yNocYcilsxXxbVR88NZVeV9rG",
+	"3CpW2OrjZ3y9hiscW6uu6eF5zrW5723uOUnfkB//Tb8T3JloiHROZWfGsXsA+0jKChJeeivkbhMogNsf",
+	"DRd47mr9GYIIQgYCOomEDbTrHmPEgCGFE0MGEcBe8zPRkqxoeeZppkNimOYM552slKU4ck5LTmcFA/Ia",
+	"X/Ix7uV+XhN7n7N7b7Dy2FfjwbaRDXmsKHBu018vfFlGjLG5oMrJJi6UZjSHuk8+/rAOf92LRxjgDntq",
+	"2GLXMCJu6y/TtaD9UdsYVKunMXa9k9CgX9BKZEuWNzj3HtraqoZ8x1Fe75gJLxzx4+YfNnBLpU8XuqCG",
+	"sDB6DLndHUvmWlIGZjpXStGcMCA67OETrUVgdb9vx84NHju/W0EaX7Z3TMniPHCoRFcrulKpusaWIczq",
+	"2NLGcCNYVQpcc3N+yXIyY3NZMitYuFhsd9pxwQq+4LOCJY7gY8dndXKjwlPZDKX2E/rD2QXS2Vk3Nrkx",
+	"tlYpWkZVonCo6c+t+QBNuDenrr1Yudb2GpSVgNjgfiXETNfFPNozwGg4Zvp27lvqGa2zrn0trKWXqtVm",
+	"LYO13rK/eEeebAOBi53y8Coqy9yWxK/NCiKHMKG9sTWRzVSjRbaxxnhkcG+k2J0VMjsz2oN7LclXVz/z",
+	"Lc20TvomXbgV7PKMZ+BgKlsrBnZZWd6Z2v21lNQkY6M8rqolFHKRNJA4hzksi6fHQi7Get2O5OLrNC+e",
+	"Ul6Mee8Vo6Pac1hmI4DPMDrt4+1iDtw/J/iRoap7bqb0bnAjN1occW1PeCEX23jugCeF5mWHNcGB18uf",
+	"Tf/dPWXSYQ7Q7FI/WheUtwhg0NXmae136GX7GvjIO9hug4+s0XPUoWbf3TOTrymCckxjKwq8wTozaiYL",
+	"qwta9Jwwj7TOwCJhxIr7lgJgzsnbNwSVEnKxZCWDmiAAUlC/CxcYyPoX5wxUXTDfvj8+fv7u07P9k+cA",
+	"MkhXrHhGFSOzjbtuQ8xmViktV4gMPa9DzR667K2K1f1ldK0rKPKDHSOxqp5otLd2bX+H0WjDljk3+SF1",
+	"snb6OfJqUERNRY424N7mfLx75HDeIKz68jerdL1nQrrvA5w7QdhqrTe+ZaS1vW8RpJEzvLsPnaiX7YVP",
+	"ycwo86royQE9AnMBoWReMrVs+XbIkistYRZeLKLRvWQVlsfViphXWB7EwkeL5tmRfDOo9RrUhLlQ37D7",
+	"5tYdN5ViFlTvgC5e8CIy9Z8gZRPSE2uqRCoLoASdCgShnHAIlXzB3YrBkRi4EyB8GWnP0Skt0HaoBF2r",
+	"pdQx78LnyI38j+djGfR3bG24cLuaN93EXwwQrp2jeAcnzisnLjvHzp2kSD6zWbtkxzJ1M+nx4X08/7ws",
+	"cCePTVKyghBx5q9y9F0hoGFGFVS1C71K/uCLnGl/GP/QzR07hwdOcrtFt8kqGxsDEJj444cnqKQOl2KK",
+	"NQghix5uR84wj2pvPuw9GkjIHuVBGmm5un+q56Z7YbwStzkP3+AVFw/nhruvJoeGf7fODLSOpAZOQuJG",
+	"eG1Mjq8iOSnuTz21iwgp+kPIC+NdqPcsMg+IVZaoQX8F97que/v6kaTgfnr0mxOVnx/RtZGHPZe8fXwB",
+	"MiyMlHTxpFyQnygHdRFTqKY++x88UUbIIjDzugoVqqYTtIZopoowcc5LKcAW6QOvTEeqmilzHgnry+xw",
+	"sR2k5WTN1l+ns+bEnWC3Vqcd18n0E8BE32olsrDHdMC5eU4sLX4hUGgYAkeAqQ5xE+BXlHpI0oqsuFL2",
+	"en3XIgw48R7LMLvrhJILv4zAlDcgscb6eb13VxAucn7O84paOzgXY3y+hiC+Wr9vLUq+Ah/xmOlAato3",
+	"b/K91ljqgAqPOhDjt5sRAlf0MTc9y1vKhqa/+Q8jIMZz3zdP9tfuyb47Hl4xpeiCjXNwHx29JhkEruJX",
+	"1my/sWOFR6bp2kWJDkQI14OXhBS7/rU+37DhjNdubL+He8QtnZfPllS7deotmhRsm/rSmaRfkRJdO3gb",
+	"C2iZ88b06XWllrszmp2lbQDHlTJ8aF4aYQYYe/fn4n/RbZ28+tdgraZLgPoFbGO1R07drxDIDsU3qLA3",
+	"SFoACClfVCVNpGpUavkDzc6+GQwGKNgt1B1aDJpdDpgMDPGyHCnz/lkNps5G0LYdTL388ZjWSMJN+v0m",
+	"FSNx45VaOkkUGhdALnoRAdEmXC/JnLEchNuNyMqSgXU7KSjfwfMr20opwYwTO5f/xUyziPfQPPkmuwbo",
+	"DJfpDiVX2OGA3MLNvZemzm9CJ6aKQajrbZgz7aIbkUJ1tozEG0ARYmX1oBqsrnk9M8Ku13Txfp1THXhI",
+	"ThwW8x9VdLQco34b+qjIzNsuXDdtEH6+/VCALxEQddcAKl+BSHhNBRbDq4Cx7JH/IIj6qeHOryImZE9B",
+	"3BeyzJiNnNNybfQNh2lv2R9D6KnIWGGezhHrspSyRnF1yonS5j62ZiJ33xfsnBWEVlquqOZZnRzZlCin",
+	"rFxxQfXvFjLofhGcX+56a69rkatmu1vUYtV85YsidfGGwSxRFERVM4R7qIQiO1xkRZXjDWiNtac8f6iH",
+	"kYNsj0C475qWTOiTaub2Ekrv+MgtlydgZgAdQSQQ1UFb9TDIjhnbqio0t6QtmLI5p+ph1BDoO76vB2Qi",
+	"OByXrTH5wwO3pAOrZ0RBbPVaUdNOhhCHJZ2TnuVNVfjs7O+tlvtsHfXV7J2l+HEp526UCMQ8mAvu2v8q",
+	"gqLIPc9yecl0U6RgSB+KIiN/ri35Hv2majL8POiM2Apz3Y48FWfQoqyvQ9jUYbjB7Bq48bhEYKl27L+m",
+	"ellzv2rwfVM5vjs58AcGaj8Jdu6rRWtvMtdNCoGbAnPfWg7cd3D3bSVBAxb8ZmXBN6j5b1DzyGR3IAZu",
+	"Dom+TxK4Njri4OuWBnkChfxLyYNvAPnf4LqHAfLvRKzcEn5+yICDWPodaXO/4fRHCp11HIj9a5I539D9",
+	"vx50/1uUFtfMdxh58/gGcHeN5IVtr0XBdt0vA8m39Ii7To+4VblxCykS21xf7q9M2fbm8gUZ9ltGxe8x",
+	"o+L22L4XTyG0WkbwFCrnzWsOddc6X3oViPuKn3DF4xmgEO65AyMO5pDGybBbeXOQDieWNpq9feHbxElN",
+	"sPfdsemG+q4S5CRcwxsXCrcH+1BHHgbsdA+wIGrBdH8jpMcIpgDH1WfCaOmwEu7anvENoeIbQsU4t/JX",
+	"i1JB2sLs1oXxTSFajLX1fNV5618RWMV9sgzdl6Thb1akWwXZuGOxdZsYHFuZmu63SLuKuQkW4ouLgm/Y",
+	"IN9Ez0hskLsUPbcCHdKZxrWwRBqi6Z7DiYyQT79PbeSrhDD5ym5ZgzAmdy8+bhjyJGEC+4pwUH7nxrK1",
+	"w4z43ZnLvuGz/CHwWb4ykZ/EaGkLyVsBbdniILgpPJdtnCBbgbz8zgWzXf/fm1T+hjxzv5FnvjoNOoI+",
+	"c/da800j1fQZ+BCtpiH97jVgzUgLn8UK8SLQrtKXt/Z/g9D5BqFzfyF0tpN1Y7BMmiWDLKqAU9fInBea",
+	"QWHc2QaLLVKRk4LOWNGNNzniSh/sv9xeMh3TxShBc8zKsa9uJ+x+kuWZWtOMRUTYC1gCwPBwi5CA8hi0",
+	"pQ+1jetKdjK5WtFdxcwINcsf1uZXeBOUb7iF7R8d1QWB7ed75HWlkZrYZVZUip8z3NWfDaX8/HcUuqw8",
+	"Z6UHQHl1enpMvn/8mPA5mUm9hILCiukUaomngIHJrkuWmSk4Qd1iUP+c0IJTNIX9jG3//HeySs3DvrFH",
+	"xq5fYhbAOVtuGCtyc34pWWoy2zz9IHbJz6a5n5+SE/MbLdZLOmOaZzD02aauU7qTUcV2uVBMKK75OXuI",
+	"X7NL/a4SrgFDY+xSB5Ug4cjkK7aHE4U1YLQsOCvxVfeCMtdyRksy56UCtZKqzMJZyTJnZdCCrOou/HcF",
+	"VXrvg0gsl5lzY7m8EHWkz0S1MqLI/mlnFpxj6ZWFucMgyU44amJew78eJsYFXyUGRlUWjAv/Mi3GxnTj",
+	"oBoqUimYK21UoqjY1UvGSyfpjaB1WY5m4mMAeg72X0Ll2A4wz3QC50/PgPA5YSKTldCsbJZEd0d3MI5O",
+	"Zd12j2u64II6L2SvIa1+M4InYljUjr7R6LXARe5jOn9RBJGf9iANDndzsE9HleJEJ52v9utoKzgqLIM2",
+	"z29s5A27wNDoq98ubkyRFraI5QDN24tKIgy8UTA6UtjPiHPgQ1rwX5mro9iqkOkj4Z2vAlRaOLpmbC5L",
+	"RjKzeta30B9VDrO6mm7/5AYWs7k6b6CC9tyVrS42OBFELbvOVO7jDcRRwP2TAMh7dSnd4HDoSgGn3j+y",
+	"atiwlm9kSyX4LxVzShJkuNCslKpzB4g58feL4mD/5ZFT+27T8hAo47caf8eVhvn0Joh/zedHfU9L0Y9i",
+	"tET7VZR+jllpRCTgplZFsQs4C/iNIx3T6RD5nMAXV7oZtiinszk4FtAHiRVRcR3xlzvNTmqzITZFUDzC",
+	"LQdHbnFmYV0asjqlrT3v1dLsdm6jpJVMVYWO9ISbRuxzsqIah2v6cWs7DjQSGnoH7RxqthpEjXRD8lrf",
+	"70jRs6saV+48W+q26eYK1+jwgAD7wVVOgr30UXCKivnv5CA4pYvf7zFgzRwpanOabNr5+w/7hkKY5VjC",
+	"rDMprFmpuNIIj7whGTpC9j6ID8LZsCgp7J3T9my+R1a3AL1e2c6oMLr2mpZGOy825l+K5dMPAi+lVq6u",
+	"6IbQQhk1PiuqnNnXLDUjBOes4oW2thPT166WBSup0KSQNOdigXaPJrW7iR/sv7x2Vu+NX4oStxwwNWlp",
+	"2DoIlzKrKVccPPj28tc5G+LXp25a683VRR/lyri6/WXE1dHjmA5bSDrUutVBC19HCs6XFSN8Xm8SV9gR",
+	"2RHS9vOwXuKZlAWjXTMJtr7VifmPejp44t4/eebYz4odlU4Mbgi03+a8YOCpxfUumGZR5XZFzWiLDSnZ",
+	"yqb4Ng9AxCqEvdkoo7t00i+g8evaS0a5WF/YScUOw+8TbBsENhBch/xOIbXvcyg/LAehgrBLe2BZg0fb",
+	"4jYOBLsX/bpzoY8V3Lwz6Os+Srrpe86CaVhbdwxDGITll2uK65xrWb7iQo8xi/9/7H3rchs31uCroLRb",
+	"FXs+kpITJ1/iqvxgLFvRrGV7LWWT2VHWAbsPSYy6AQ6Apsxx6d23cAD0hewbKYpsy/yTyBIaOADODef6",
+	"Kjd6L9Zww5Ow9t2qc36kRJRosMbaGdVTb49LLbiCk5CpmzKhHRm9zLVAW7N0d+8oEgGNTmsdFTgk53ek",
+	"0upjaasEe5mtnoJv3HJl51OufFy5U1hPATF0rmbAQyiRuL9PQU9BpgfMFMlGNwrawnHn18kf5mN8uWbJ",
+	"CyKeSZgCR4csnmDG+lpJ5ePGViueu/r8JOswsy06vHnaiWamWnJXvLJf7YRfEo8tK9VfQ6/2yJgj2poj",
+	"W8OnWGQay5Q7kSw8pbpEIJxJFhKs0mpEwZyphEbsPx5R2q5uZmllOPJnkwPpMRJgFhOUIw9arr3UUV8u",
+	"+rGFB6GmyQc+z4MkojKLcq7AuGrK3IP2s4X+Wfei4m102nhMGH4GuqK/RU6PXg16q8Jz4P9OIKkxa2VO",
+	"8zQJwz/3lp6BlIeEhqEiDL3Fzgae2LT9lB5X8PuVhSDF8Z2LnW2Ym0I6eVtvcUoDnMQcpGRhan4yp5Oe",
+	"lZEEE397y/qa50QIXBS9G1eeTpE46puAnZ+mIKSZKGyMr1Lv2XceV8Eh9exPDK6itf3uT1SwvY+1VrW1",
+	"o+7cDZcI6Pe5pEdBZlQpj0oe+xgnf79897ZGrU0RemnD6bm72Wz3MYuiRUfyiqKMddK1rxTg2MGYRmrF",
+	"zXA+Juh9wGLZwDWxBIZpnWOvStNIAg0XaRdGIf3tP/Gxhs9PfsKssYgFusy05Ym7/sDR/3B3tw+zYoqp",
+	"7fCzlG+fh19Q2IRjJPm8XSG9dxmB+Wk39qR6BEtxmcQihKfdE3BOHiwLnNaamwRv+68QaLm0E7QbZOkX",
+	"DW+kDzjzPuyYW/GIwG0662qAE9y6uiJGROXkQXNwU27aQyrGYzYGW8LJ7G3np+0IsrbEcL7ySnkpWtrO",
+	"dLGbgsIPaLHYrh/O2WZZ5tlcyxDbbGjcyMH5qG1+LbxvvaNZUkIEFyJkY3Y/Kkgb9u+FELaSEFiJcz7c",
+	"c2O8271j/UHpc2mLj4+mLDJnkcjt5IymUm/LkIGTKcJ0Pr2wmPaXo7AVm4YtuPOlqopbsGZ42+bBnHFf",
+	"c8Z9jA+IxfW2h4PF4WBxeACLw7KdAZMU3RGngzGoRHU3z4SHjvlvbo1ACuyrBQ+2IJl6pWKph4U+bECz",
+	"Nb2bA8HAnSeGE7IYRKKf9nA/MtfSZZxEUU66+egTGx9qLpGL0JfmcOGpf/vbeTwTUlOuyQimdM6EVC/+",
+	"9rdr3ifn1oji1jNIAZ8CgDQzzHfZMBfMeALpFrDkHQ4Z0eBmIs3z15aqe37yYxbA6uJWLex/eWT6iyhB",
+	"goiZ68dQ2FhwpoU0CBdQHkBko1ESPsgBibAAxacnJd+4SinfeIfKk2kSU95nvK+n0I+EmGW1vDhu6WnP",
+	"VSgOZ4JxnZ4ri2MIGdUQLay68O3JiW2/aYRiIqVjyzpRZbG0meJwaVDmoDwclIevTnnoHTkWUvJQpp9Y",
+	"nMREQSB4iOdhSBcvzYCYMbMCF/Ry3kAW2ymOXvz4w/OTk95RzLj997MUasY1TECuqAgerD/3pN3szBWe",
+	"lWGzJxiiILH8MsyVlTJc7GkH1Z4ftwbMlb3ySpjc39MzqUVEK9PWE4MHPe4+riSnvKEdYcGDqRRcJCpa",
+	"oEROOYe7n9aReUqLWZ9GUbVGdwUyZtwqdVHk5X6UHWsadebFTVZ1oCwG6FKLmc0oc7FbX6iZu33G5k6s",
+	"YZf50H9zqzPMDozSa2JcaaNDqoMPyKVmaqMKl53QmvF1Lia45lEkuJYiwmrWaSiyr8UjiZqKJAqdppgj",
+	"p0K8Kw0CIfElowW+mfApBeYzwdPJakzpCKRigl9qquHLtKpnB72M/PgH/+TRgijQ5a7fqjhvP/cu/L4H",
+	"2rsSk4lLVlUpYuL1QTuau4XRVIibunyvDy7Hy6CAG14sCl8usAbkFOYQGbzrkZhyOjE/CEloGDNOBI8W",
+	"g+q0sN8dXF3LDnNw+aSw/bRveCtWLsJ13U0jhneJqb9x+DSzFYHBjSlJGPMQO3U4h57uLzVJY/mmw9Uo",
+	"WIx3xVe6eZJbTXRQESPQCUTb3kvJbSd78K3c1u9l53dA3VLUPQPdFm/blBfLT1XCLz8s22H9eC1ugPeu",
+	"+e2UBVPzIjPM06g7t4aPBjAgl1pIIEwTBUEiIVoMrnkz+y0xNlqAu0IXz7ZNF3Z7dRUrUvJw9sZVBr+D",
+	"h7cHoviY7iyZON9IK0qpUUKOpzENjlO2UP0OsMp4URz8ejF8SWiip2iTMIgOfCxkANgIB3/nS21Ioalm",
+	"fGKLYSgIJGisWpf74sJ8YCgtZlp7b4W31S/PfM2ZIjMJWBvWcTNDsh8pDz+aTfXI7ZRFQMzPH5F4aXRL",
+	"F1hCRmH9pUBvTLH+vDKiNWfR6YcJfKLxLLJUnp6J+cecRjZO39ykuYOjF7kB6EMuHOxHMcJDr/q2OBoL",
+	"mhauGJ8ndoaSye3F3GNuNwFS1Fp8ytxgerG5DhDbNilvR5VA2rMVuPfUFGLZDiwkYe5XCFyXlZ3vtyjm",
+	"GiUKnobrnqGS2UxIc2eCW4i4pf7uCBZ/agU2v6FgCZmio6hGrJzaASqTJcC1j7dcdpRnupnl9X1k60Ya",
+	"bPbwtWvvmYd3g5O4i+r04/pAtNXvfXt92yBZ4PUU+4pXE6x/ZKVVajw8y5ScuuqvOc5jFUICn2igo4V7",
+	"YDVoh0wTd/yKaHHNnUpHNtLo7K4O6txBnXsAJmxAuUQMb/MKRoKwVHjQ7A5CYntCwvK4bcgICZ6BV8uJ",
+	"MzfCG+LyfL5KTtjIDBGFfuAIAhGDuuYe/3JxfUXjnVmiTIps+ML/kO6wKBMsGT8yJXED/uSOOkOEPbGq",
+	"MkrMuMOBN30pvCmjt6J1UXl6W5NNbcKhUBtpwZvsuPVYk3UnkEpvwhbZ1JVZ6pFxqGYfAu66gR8dfG3N",
+	"VKcd9qxJbxqDIppfjUJ6U0PRpOP9BFiD25euRFg2Mu3YGI09utS23504pW6zs86bpy0+HIiwBRG6eCIP",
+	"cfryWwooWiZEEdT20kHpE4ogiTEjhxohpyUAUVomgU4k+uvGEdVY4X5AhlGUN+dASBIF0ubyjKS4VTAo",
+	"b6JpANlZb4Xeg/TnrMjA8Bar9JQwzBJoiIVqJFT11jTjy1o15uL31urVOFxp0xgyNYvoorZVo1n0rxfk",
+	"l4XNHzP/JE9CJhWZK6wcomzyFF9uA+laPQMNpmQiRTLD6WLNYjdfRBU6YbPKCOZvm7RixINZacXofosr",
+	"rtmPcUBeGzJfzOAFoSr4eSyi0GAxNpm0f8RpX2Crxp853ILS7q8d79hYm3IiAkOLdQqSr3iQ8oQu8UAE",
+	"LoMsF0ZpuEvbWB8/gVG/USTa8ONbyTSQGciYKeWa3pVG4Ihgx01itq8lpDtZS0O4T6e+GJQyfLSsI22L",
+	"FCd3ZT72Z7/FpXaR3+M3vMeknXahRZ6aVqnR6x/HNiK3P6LaNmar8PHiKEXiJNJsFkFeLeHhMT4JJARa",
+	"SAa+aThmO5GUSgfk0powFJEQJBLLefuvXLsIHPZW6D7GjRNMW8EK8NqFlVGVD2sPHVSYrh1CPBMaeLBY",
+	"m3e48GkR/IKn8KUzkFMR2B3hdvb0zlgGolqq4QB3l/k8yZgu8g2WNKMRGVMWJRLU0w5GapfQRpEu6qhQ",
+	"BHW5BJ786ObyMcXxnSr6FYwTm04ULlhFVE0dKXNQmLIuAlXVgttMUNthsQE1sTPGXcvONh7qnXe08Qvv",
+	"J5OmHdZXi5iGpIRUQvgZzKPI3Gt5ysEBcesRd6ucu45d58ghLaF4IAdbTL6GFmZewSqPyc73hfLTfKOI",
+	"29La3N7lXR6IZoVotq9upWf9gJrWg7zXXOjxgYDzhRLbPJlE0Fga2xa4Vse+z18q5HIq4YJo4cweKPds",
+	"M1Ka+ztSDlNkwubAe5gtnimXCQ8By1SZB5JZJyRUi9haANfmGK4i9145xkuXKFJ+WI+cjaQX8KWxkcIl",
+	"WbrYA08pQFFgMDuxCV1ROQEn6rprFrI4Vk5fNQyvoW2/bTIOma/Kqy1pIAbyL9vGfVDVrn/XPqjS9vNp",
+	"p/m9t/Rv4EVpl/tKPb3YUH9nRtkLI2D4xJ5kVliqS1TgTqbGV2EwHyu39SMxafbRBsC1pBH7j1kQC75F",
+	"YkLMLxkoEhvN38dDjFmkQZLAyGPJ6IBc2HCIpmiIN0zpV2bqN+L+ffCX/ZYI0mjhYL9hPCRPYDAZ9EhI",
+	"Jx+xdF8UxR8TIy2qhKv56qiOIBrXtd7NdN2BTPhgjM25cPkBLj+QEAgZ2gJ0ZXA4x+NGcPhqihVT+3KM",
+	"95hdJtw2e6iY35ZV3HABqjXEM129gBuw+QoKUHusXsEN2HyFRIGsnt78dfO5YxFCVHfBOKBp9gZSeyMm",
+	"l5pKfcXatfx7IyaveNh2tGcBb1jM9DofvKcTxpGdXLSUlm/E5N14rGCtZV4mUhl++5DSL2WDbVzlK+x4",
+	"d4KQRmMhYwhJgIeST8GYpbeRL32PkD3bRWyVLoYJ2ZW/e/iVXws5YmEInPSJ9O/TeFkCShFB5yIbamV8",
+	"ToPAv3kdYgo00tNG/cEOK+l1iuXD6CQhmJwlywzjv+K3l1h57OgBqc6uU0dybRpirOfEnkJw47buz0j5",
+	"jfrzVgulIXbnHbEAuIJjGmg2rw0cf/UpcM3LKHFfkRtY+IJIbMIhJH///coHsA5rdLOhW+2Nnede2tnW",
+	"itXdwKKsZUq2U9S0jFLyW/+PP/74Y+k/Txu7wZgF9tAM5tOMyUVpKcsxUJ1IO6x9e6ZZRPmGFhB371g6",
+	"LsX8nUe/mLs0SJsBY5XmnTH1c66S8ZgFDG39qYmxU4YPT6JFam9iIyE0MxJf5g+78edvAfuQF5KmsXxx",
+	"nHCmfcWDYW1NP7ptvtIRy6HnQtnx7i5m7K2wdwQpHgiZ/piLNJ8zSoDPyZzKAyEVvP7+zgqlnaIURUsJ",
+	"KgYtWYtg9/dSxKCnkKi+gZlqNoqAuK9RNruWFFj42ShGKc2oMuXowq3biPwaPunjWUTZ0hG6FH1ziuTX",
+	"V2/ek5BOko9GUbPLjxIWhXnF7Zr/D3L1j/evcgMnNJnANU9/8XkO0tzrz9dHzwbPng9Oro96OM/HkGr4",
+	"+fro25Nvn/dPnvVPnl09+/bFycmLk5P/e33Um4iP+S+/fXZ9dEeeXeOSGWzJTLMYPvqy/uZhSRTjAXhF",
+	"CnsRFMFc+iYP8NKfvvvh5GR5RWcjUh/T2twffUnjt0k8Mpr9uLxut/lZFUGpmSwPVs2w7yvhs317P2qh",
+	"aUSu8L88BdCDQxi3DX4r4CpMUgpSYcSPldA0gDFaOF23Ag77uSvyvQwC/vGz/f7n6yOnnRh8+fb5T981",
+	"jEayR9z6vmEkHWFGqhn73yX7rNnj6q5U+ZH6Xz9fuda0gHV687+XlrdmyqNccc3V7/NLr/712XVJ95RV",
+	"/pmxsJRvMU4Mf/G9RTpXDfkMNFkFO8fLM6br+LmYAaczNvBQNlaf5Wbr9vH8bgZ8+P48cxa58n+jhUvt",
+	"MnzV10IvY+rv7OJ/V9hk4F5aDQ1DZvvVvM/pN9a106jGXE1hZTP7teF0KRZKl51OhXqAHLNZO7DNzDGJ",
+	"C/tBeco0SrbryY78UA3IbwqIm/b4M6cx3KH2YGfw3bnMd8VBxzbifJw1eR/R4CYSE5s+x/ik3DPzv+0G",
+	"9qmg192jBe++tpsOcCq0xNFCqzV7fxYh3EAUnEzpIhNzSJbHOHfrLREvBk3No66XdWww2NJbxb+SSsX4",
+	"99LIVryc7Xr0cMqCo8OFvjg/h/tLN5zZdv/rdYbcQWCJO8Pu9jAwTNYjfN5yvFTS/d8OvZrJ4Dg1mtUS",
+	"g+DYXe6WytAWb5zRCRi1zpFATT8eHNGzWZ4QZq0ZLX1NgYZECzOxLR1AWeQqdszovxPwfhQJKolBETrW",
+	"TtnDZFYVUM79ImiYX9Qw63Pc68PGm+BCZsXW3rr0C+9HewSkHbpWS+/pBDYSQTu1pgb+4DtI7Y7AMh2l",
+	"LZlLRNs+F2ELLcsOxoRz1wRoJPTU2cYw6dx19RYSSukrI5LuakTZOm1zrvPHsnt/aZUeVIAqu/3ChbdJ",
+	"vcbb7FtPbJiftSLPOndPe/J2NWdQZws9YCJ1OySrQ7AP2WF/NRnUb2kMK2GypX2jMTq+iI8VSL7M6I4/",
+	"y/T8z8O7dumV7enAfrMVOnCNdO/FGp+Xe6Y8YhVSF3fAuF5SblTnNKnXyI6+EokMIEwL1+2okFCqwZel",
+	"L9J2yNU2lzE3GRktbCDbyouvM0hzskdWt+vswSo8MIpVayRoSuJbg3/Yb/aJCg+VCbeh3N0nMhYy4XbH",
+	"HrH+0qIr7LEzst9l4tGtyP1jDUr3A8E5BBaC6k7DSmPGLY6cM+3y85Z4ekxv0OjsI9ICjFLzGtRKFUPI",
+	"P4heZmA8Fs5ftcE60stGEXM7Lkdl76LgysKSU8fz11WDfjY/CgtrNueKoIGhP6IK8xrYZKpvwfzXdiMt",
+	"JO1k+VORGNHI/3VGJ1CZRjU8ew3Y83lfmVRDD6bNAHKGpm2kVFWF9p8Oz9BfbvvWkyeBiGPaV2AA1hA+",
+	"zUr54kg9pZpM6RzI8M2bnHXSfl5VQs41xb9fcoC9o5xxr9V4Zz580Iyy4ZldyyBPLenm0LcEY3f+ck2X",
+	"Tx+wHevybeEziJf3ftqEyhXukS/Li2ljsB5DIYqz2Qwc5xAcsuQzc1fYsxsd3pXsg04u3LrrcpBCAd3e",
+	"/RxYe+EhxJ14O1biB6ML5HYK3Pf6JlOqds9Z1qqvuhkbQsTYAS/KrVbvtF7hRXgnKQ3s14p2aLKesb7l",
+	"i2lghG3KIlerUbm4ovvqUiJ4zLrUF6ur+Oz3tXSVCrTYJ5PoJLmWZcVXUem2dZS0uGE1QW6qnTzislaP",
+	"gGt0W7VIWcfXpl/st17XJlyrtaYh5ywAdRwIIUPGqRaykYnZsPeSLF3riJ8wpTGsKTdnGsesNmqBcgb6",
+	"ZTZZmuPbzZCKFUgfQbzpGejCdTq8achCTrFLgrXpq+MpU1hjqTETHMexgEY2f9BIEjs3SSfbFJU+uAl+",
+	"dbBsNeT01LWSJGLsNoHWcwlaMpindV2+O4l75Nm0SiKGviFleauGZ9Oj3fZkWD6yLxuTPQYRrKTjr6kR",
+	"i9NUmK1xyFxyzn3546WfquPccQnOR8Ibs4tckzPqhHOINkcojA/GOdKVn1xRFqmARvB0U2S6whk7jkl5",
+	"IB8JGi3dZBMOac34RB3TiQO9MfvMZykPzwl+VOx+nCuVmtWfKcWPofnYNqTuLHrkYKzFjtVz+ArqD5Vc",
+	"dNfy5koQtPCKscjfJhrJYP69MN5OtFWkf6iYowLW7yXoqCXdWXDD0mveqz3hQPd7Lz3emvRXxeCxOdfj",
+	"mRRzFiJtNilWySj9dX9Eg5sUJc1ExE/kFbA0lQsiuwuO5WtacZE3TFnBOUz09H0KYVflZzm4bTJECien",
+	"DlTVibJ9JUid1yytDtmCoo4/+x/Pw7vjSExspZiqjAJfFQqJRgvz6H1nEIoEEkJzUzRaJSq/QkvCOmXK",
+	"Bait4OsbhG+rBp5hgS9kFVqL6YfZId0zCbEkn8FvjoTpxj2yH8hsjxWh0tsolSCRQ8VliqvKScPiuYpQ",
+	"825PaOTIBmch40jc3ptscIFHSDFbtFVVn1CtHMzuCGtM7TuP7cAU9lhi3yDAWvxgEwl87LtFVgf1v3Qj",
+	"6jhKonx1/hlFp70E2xWD/PbhDZoNEz0Vkv3HWiCD9rqvX/1xsJsHSNStPZ89veSbgGrigGkL0wP7+1rZ",
+	"n0eh+3JAt5++bUxgmFxS2n9H25eGG+4aHXhFydsA2+pHoE/tPEgAF64nQucMfxmcCOKemMUKFDWNMwu3",
+	"YxsrfKV0upPwpQvb7qOLvQYvQafEalmEbz3SginEELtQkqZ6Brlw54tXF+8+/GMQh1jBpa2FAVI5eGEX",
+	"fQCr3dKl4TokiIBipEDqwowWB7G2d7FmbsVjlMNbjxelHqpaG7SbJ3Y37lrGUR7aEo+uUKyt7GcHremp",
+	"fTic3Z7HyMLY7Kl1pyTmIOcMbg+00B1fbT0JlGpseRftCoNe7fnc0km7LXx/UCetR/h1tbVSMeHqNpSI",
+	"icOr66t1o7aWT5W6lcvFdf3+7tqqWo5HY4m8pfJ8p8Oz9XWu0+HZFkh6xVCEBTjE2OerltuJsl6HG6an",
+	"DM9sJnA7tQ+TBA+qX9dVv9PhWT/F6XsrgEua38Yk4/W9R00v21M502OqNVbkCNKtfKDBDqica1Ngo/65",
+	"LSrM6XiPiBC/AF04R6oHffjAL1b04TVZRplWLEKI+jMJCnRzbOGUyjAQIYTO0u2+84Yc20RhjeBBtOO+",
+	"d4t3OWwwD2ibgMHC8RzIpRPxgsU7aWePN580kwWNonyDwTQy336+bjDthV208+TQnhAOFNCliNnY41fb",
+	"uL2sljyH2yXs3ij7xE7YbR+0hRHB2yD5ZHuoXoCgmt6sR7QTRea/Tq/3T7vyei/X1+2QIckV9l/b640M",
+	"6fgz/r9tPX++DUaU94LfmxGtPGrtfVWF67ndbj+Y3i5baAtwCET5+gJRfBeEWmpsrnvPLaNhfLINgstb",
+	"SL4YgnsoQ9GmysXJfpSLQiX9g3Jx4GR7yaFdQ69QIln/8W5XwU/JkxlIJTiNmGagnq77kL/E9R+2nOF7",
+	"Omk3DmQ6dDnEOFdQ8ImvfWx4Zo/kRj6tqTK4n1wmc854xG3sEBYXDmaI7pghlKOOzawQ2Rx5Kl08Xd8C",
+	"YVCouwYIA92eLA926WrSMn8/WBwetcUBr/gLMTgoS8dt9YLjz+Z/7a0N2SLr2xbuzWJaFNvFzbRsH4jX",
+	"WjAQ7LKth1n8/PSgzj885XbfLlFBtG17Mua0AGzJuGZU2V7p8mS3grrQlPFA7gdy33kyRSWtr2GCXFsK",
+	"5wyOu6b2hzIbrv0k2DGnOdgJD5xm72bC9q8BLUQLK6EPbrNBtMWa13ZFnKfGGniF63S+Nh6C2caiZs/t",
+	"YFHrjkVNOwyrRfoRVdC39u5WBZbNeGz0VXD3kX8ML97kRHDoi3Lj+WBhnZGYl6vev1AFHai0PJMGMs3s",
+	"13i0avUoPLajiLFbt0MJs20Bl2t6Mg2xKjGFp90NqJQUI7fVDIKSVsX+zIvnzeyRE1stvaRXQl4N+Ked",
+	"u+d39Wc6XIz+BYEuQ7NfVtb8mmi7An+7pkivIsbGuSG1dP1/LLaDIiMYCwlE0Tnjk00I3q65TZrfTK8u",
+	"kvuD0145yW1XU9+Yg91SyRFT2rOrpT3ei7F0I5flwOu6y+ucKt+W3RUUnFvf4E8df05/tn2X19V90s/7",
+	"KhAzCFsqQxSxmmhRnKRUGUrbEdZxyJJgpsLOttzo7yvRstIj3Iu+9XvN6jvnhbe5ppiPnQ+ec5WMxyxg",
+	"2OgTZMyUYoKrnVlQspvvrMG2jjQ21jjX46bNKuitZBraM1sLyhfBbx9Ww9063zvoum2Y+kHrPXD7zhrN",
+	"12f4qHMveHAcREB5Mquu0+0bZtAoInj8fEKAa8lAkbEUMTHTYDsaWK1Yu+DBS7dAd4yFYyEnQmvg1Rwo",
+	"HUIM1yHnp2otrTUGpeikJCLp0t4c8QOaGHQGajZpG07mDj2reL3CtrpUvshA6lELscmedL7NIA8KSNv+",
+	"Eeg7DJ4xbedeJo7VxqUGabvdSjADsbZVekF++Ya/3UUFo7pWXtMSKrRQWFveuPPKb/HSH6CidgqdhXZf",
+	"8QMboF2V2tQxCdoW71IWZOMv+yMf/FIvPLEtjq30AqFlb1Z4SkQeImEmFNNCLnokEthknKmbHtbczeSr",
+	"Ue/T4LlAxDHTg1KZa4P0fkHYOorOORAfEJuLgt/HzFaKfTdgz0Lfg7meyD9HpPI72Msr5SXlRku2MJAn",
+	"s0RNDR7TUQRhjyRcS9vPEM+0t2IufLozrd6cVafDa9MWWq3UIceLnAq1niq/KS+q4TsXDo5OuAorqfIl",
+	"8k9PlGlPDjxLx/pXqHSFCA/8qTV/uiggXHf4VBeD63P02YoB4N+PP5v/nYd3x1k+TAMfcM/bcuonTyZM",
+	"ExmT/3K6BvkvYlj607XYgt2SYQ6G6W63YMCV0ar8+RCG7TvHDCR5gpWeZ1RPsbadSDSBTxq4ymfCFi3E",
+	"9ux2VV1gxSARlNDla/NrL01hDpywsd3qlCp3B7EI2ditozLKHQlh3tW1ZL8VBrjT54flFXVvDxTse+Ut",
+	"CEFgGcwIimlaB80GzPvFU+waDI2Nx62sPWYgGYG+BeCOQgx/crxtDhKtx9gTugBHqRHInOWpWfnRMa0H",
+	"tA/4Q6stYW1uqdoe9ZUTyhloi8eu4PMm5KICKsNqBeDUDvBCJJhSPkF9wJDKHKROPbKOZHwgx4qSUNr7",
+	"msrQo8JLO/WBhLYn49yREnfLBwIq63tNZbiE3BtT01hIJ3da2PjQTAdcy4Vb0OnxOfNHjwiJZsaIBToD",
+	"aEAMzUCIVGjVutRUSKWhuX/hllctfq8RwMerYu9Zncx8gV1QKDOP4IHQLeJvRtWGZqtpeqhFzAIaRQsi",
+	"waBv9limgRTKS05DBGqhNMS9MvNZw9v4Qswf8GXsPZ+P/oVsrnL1few57HZexYguvVUjG4fbc3supcFa",
+	"HG5Xjl4Lh1NEi0ZbWzb/n1/I69ucVDfe3gjJHtnkNmv8eNerwegm5yvqFSFoZJxd4teG323GrWfJKGKq",
+	"xtFqydY+YWaJmkKuzEjGAN2jpvkV896udzBbroeh7tj2GJ7wAVQS6UYm5fCpO2+nA69Y4hUOlUqouIZr",
+	"uGvt0yhai1WshmeQ81M1IOdWnzgPFWGKiJhpbd5vHnucJ9W/1YRc9nGXR2e4rQ2jqKvBGRmEnSZljyPd",
+	"j3L0kKZ+/dPhmapF5DoMfg22yqt/XqjMyCFFnBdxZ0zXiTl719vAwz3jARYB7j4SRFHxpsoUkSqUME/I",
+	"RLXygog5SMOZ0qA2+y1hPIiSEL3K9hdijBzMIWOpE+TSLttlBLEg1hY2yh3CFxYHq/z5V+GFBqX7geAc",
+	"Ajt9Fde4AmWkXpbHwQRHFuI/njO98CpyrqR2Cx5ipn6ZgdDxsGkHpgG6QT1yI4k5YyKRD3UJUcwOSJAD",
+	"U7TlKIkC2aK2Oolc4JHhEvjNGkXUf8M1HvA6cQGzUpt6R3bHjz9j6rWQIxaGwEmfyC+h9pHHrByi2n+3",
+	"rSVuRhMaBCLheq364QZ/jh6y+rdZYE/Vv+3S1WRh/u6rf3eiKS15AoPJoEdugd6QGVXqVsiwR5gfJSJ4",
+	"eiDfnZUOT20DfaQvNFd3v5J4yg9KmEkq9o4/m/+1LR3egr2QYtz7QiRSQTSuqinu2M56KtJvCHLLAuFI",
+	"3NVRcF8zAaHvvXBd5qp2ZvjDm+lyeF4F8TRX9PZtrJFcRgvziGByrZreW6aLk93K0kKB7oOI+qppyTzg",
+	"PR1gO7sSxbahaDZ+/40ijNtSHuv26Ls/MT1U/eu1leIdE3In6nx8PcWwu8tNDnp2VbJ0aw37GLv19/1z",
+	"ri6GUoHOsT3/BdHCafVzGiXQkgXibOZC3/uFO8YJEUAP3L5cbM3xPB5CgtfYXTPBwTBw0Loc1S8zkAo2",
+	"dQujqRA365rA/Wc+CNQ7zwbk1Fdl7ZGYcjoxPwjpLkjwaFFuI//dw9FVl4kDsK2VPT3XLpqZb7PD9jiR",
+	"/qqIFsefxyyyVWdr/GmSTSYgDY6cDs8IfIIgQTfMnFG/1oBcTW2RxDhRmkwpBsC5P+acbNec8pAAx1IJ",
+	"AzIsOulCmAEPFRE2Ccd/bhgRNtR9cc1HQCXGlt6AxbceKfxqFiWK/HoxfIloaX6wWHnNr/kVxgtY9joS",
+	"4YIwSz8Qem+g2QC1vuXfX/3y67t3/+vj++E/3rwbnhLgcyYFj4Hraz6nkpktYOSM/zDdpSJ/+WMZC3lL",
+	"ZfhxCjQEqf7qpZER19yD4v6GyQ8OnCUYfn01PH314TIPA0lBuOavhSSKjkEvevjZX+ZYhWT/wVP9yy1g",
+	"dsthDpI4oCAc2DMxwMuEmwHA/51A4pIzzFzAw5lgXBPpGAWLYwgZ1RAtMHjPjLrmIZ30zRTnp4Pr1dJD",
+	"DoMcja3NA06HZ68dmh6tWadyJSbxlzyyjIUsIFkOFZ34/caND+kk+Xg7/TgYDL7JmreGiFvkdgoVCOsi",
+	"EUC5BYuLDHyoo72gLNixcH9HDVU7i/tDjPdwKDbhVCcSfFqbfWOTb9SUfvv9Dz9fJycn3wVT+IQ/wDeb",
+	"bAwXXDo8xAsDY6AJcIxpNzhbud8/+qd0kvQvPbiFLcMnGs8i3LWF+uTZt989//6H//7xJzoKQhiv+2/E",
+	"P61BGlD+n5v0nyf9n2h/POy//vPzD8/v/mdJwPoD6ciOKnLa8d3Dy7narFXHDrSl2q74zQzH3pn++xun",
+	"jgYhJP20SIWQqaMOCbqX+82xH7SMzZaMHDkgueRowjBdGmg2h71o2J6wffUisx+j9GYSe2cKt0G7HD/e",
+	"q4nCk4AXcLmg2ZBOPiT8POye9QKCRDK9OHrxzz8LwTOWjKt1txo1UcibhvgZDDErmG8JHYlEG4zSko0S",
+	"A6Sbx4fwZPpWIIQMGadayI2eFq4zgY2q6OjDwsLX9LAY5pgskenA3tH3u2AJL7N7IArknAVAEk7nlEWG",
+	"LewUuc+Ag2SBxezcUay+dUpQrBAFpjTEOUy23TZyyFzyTM2GdRmfEMTWT9VsT928Rnyy5g8+5UbZL/Mx",
+	"UmUhTumpdDHTYAnEPUVK5davRpqsDLiLmdqvR2gHUv9tmSeiPOjmNodkpTha5DS5vj4rQThl8TI1OFzX",
+	"6WHNrLj79tUpCcPJkGbXVaDeZkpieQ2mxivrlQuDfMujTl/Hyb74QyEOZI9XvdQHZikQYVmE+GiE2p4r",
+	"Xbvwh4pQ2Ewi7Q3jCg27d4txnZFFvnl0C1lUfBIaeNmVuAFu3ocGC0dUsWCY6Kn7hcE1o/t7nF96ndNJ",
+	"Qobvz4kdctQ7SmR09OLos93U3Yvj489TofTdMZ2x4/mzo96Rt1Aj3kxT14LTP4+wsAj+evkYfhVKE4wQ",
+	"ENa67ta8y9NVNtFU69lR7wh4EptTcP80/7Pn8Gd6Qsubeue5gK2ahK9ObN/PQ6v/mH+Yd3MIY8aZrz3p",
+	"OEBoJl21wC5N6tKwzExTprSQDEuKUk1xmUhMMD3tdHiGBvT0hV5cyPytbLFLfOQQsbQRwZlZyW0l3Rd6",
+	"KsxFppfoVnBvpdX530sRg55CovoGkalmowhIbPYUrKyFU2egZNNnY5rPq3AJuckz0wV6KHKzu3+vzrzk",
+	"Xcod0pNITBjvmdMXie4567y1OsTA9dNsdmooZHVudA9nHxQmf/nht9NeFtpROq1P01mB+f05uYFF1dSZ",
+	"MSQP4oz1b2BRNp0z96ZuHHvGzrLrsTs92px0y/ybq6caMm1OrgVgZmjJFC+Ba0kjNK6mk9AIa9usTu2M",
+	"QUVbUG4V/KoMUp9bOJWCO2fKMqW4jNCUDHhQtuNzgj3nlxplNW8fG5uvzncqggRvtvSSc3QvgrJtWf2A",
+	"cBHCWmhiU+b65jt1dPfn3f8PAAD//zlxlIuHPgQA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1/api.gen.go
+++ b/api/v1/api.gen.go
@@ -6058,10 +6058,10 @@ type ServerInterface interface {
 	UpdateBaseConfig(w http.ResponseWriter, r *http.Request, params UpdateBaseConfigParams)
 	// Get workspace base configuration
 	// (GET /settings/workspaces/{workspaceName}/base-config)
-	GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams)
+	GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params GetWorkspaceBaseConfigParams)
 	// Update workspace base configuration
 	// (PUT /settings/workspaces/{workspaceName}/base-config)
-	UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams)
+	UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params UpdateWorkspaceBaseConfigParams)
 	// Cleanup missing sync items
 	// (POST /sync/cleanup)
 	SyncCleanup(w http.ResponseWriter, r *http.Request, params SyncCleanupParams)
@@ -7003,13 +7003,13 @@ func (_ Unimplemented) UpdateBaseConfig(w http.ResponseWriter, r *http.Request, 
 
 // Get workspace base configuration
 // (GET /settings/workspaces/{workspaceName}/base-config)
-func (_ Unimplemented) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams) {
+func (_ Unimplemented) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params GetWorkspaceBaseConfigParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Update workspace base configuration
 // (PUT /settings/workspaces/{workspaceName}/base-config)
-func (_ Unimplemented) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams) {
+func (_ Unimplemented) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params UpdateWorkspaceBaseConfigParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -14399,7 +14399,7 @@ func (siw *ServerInterfaceWrapper) GetWorkspaceBaseConfig(w http.ResponseWriter,
 	var err error
 
 	// ------------- Path parameter "workspaceName" -------------
-	var workspaceName string
+	var workspaceName WorkspaceName
 
 	err = runtime.BindStyledParameterWithOptions("simple", "workspaceName", chi.URLParam(r, "workspaceName"), &workspaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -14443,7 +14443,7 @@ func (siw *ServerInterfaceWrapper) UpdateWorkspaceBaseConfig(w http.ResponseWrit
 	var err error
 
 	// ------------- Path parameter "workspaceName" -------------
-	var workspaceName string
+	var workspaceName WorkspaceName
 
 	err = runtime.BindStyledParameterWithOptions("simple", "workspaceName", chi.URLParam(r, "workspaceName"), &workspaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -22665,7 +22665,7 @@ func (response UpdateBaseConfigdefaultJSONResponse) VisitUpdateBaseConfigRespons
 }
 
 type GetWorkspaceBaseConfigRequestObject struct {
-	WorkspaceName string `json:"workspaceName"`
+	WorkspaceName WorkspaceName `json:"workspaceName"`
 	Params        GetWorkspaceBaseConfigParams
 }
 
@@ -22737,7 +22737,7 @@ func (response GetWorkspaceBaseConfigdefaultJSONResponse) VisitGetWorkspaceBaseC
 }
 
 type UpdateWorkspaceBaseConfigRequestObject struct {
-	WorkspaceName string `json:"workspaceName"`
+	WorkspaceName WorkspaceName `json:"workspaceName"`
 	Params        UpdateWorkspaceBaseConfigParams
 	Body          *UpdateWorkspaceBaseConfigJSONRequestBody
 }
@@ -28756,7 +28756,7 @@ func (sh *strictHandler) UpdateBaseConfig(w http.ResponseWriter, r *http.Request
 }
 
 // GetWorkspaceBaseConfig operation middleware
-func (sh *strictHandler) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params GetWorkspaceBaseConfigParams) {
+func (sh *strictHandler) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params GetWorkspaceBaseConfigParams) {
 	var request GetWorkspaceBaseConfigRequestObject
 
 	request.WorkspaceName = workspaceName
@@ -28783,7 +28783,7 @@ func (sh *strictHandler) GetWorkspaceBaseConfig(w http.ResponseWriter, r *http.R
 }
 
 // UpdateWorkspaceBaseConfig operation middleware
-func (sh *strictHandler) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName string, params UpdateWorkspaceBaseConfigParams) {
+func (sh *strictHandler) UpdateWorkspaceBaseConfig(w http.ResponseWriter, r *http.Request, workspaceName WorkspaceName, params UpdateWorkspaceBaseConfigParams) {
 	var request UpdateWorkspaceBaseConfigRequestObject
 
 	request.WorkspaceName = workspaceName
@@ -30115,33 +30115,33 @@ var swaggerSpec = []string{
 	"2RHS9vOwXuKZlAWjXTMJtr7VifmPejp44t4/eebYz4odlU4Mbgi03+a8YOCpxfUumGZR5XZFzWiLDSnZ",
 	"yqb4Ng9AxCqEvdkoo7t00i+g8evaS0a5WF/YScUOw+8TbBsENhBch/xOIbXvcyg/LAehgrBLe2BZg0fb",
 	"4jYOBLsX/bpzoY8V3Lwz6Os+Srrpe86CaVhbdwxDGITll2uK65xrWb7iQo8xi/9/7H3rchs31uCroLRb",
-	"FXs+kpITJ1/iqvxgLFvRrGV7LWWT2VHWAbsPSYy6AQ6Apsxx6d23cAD0hewbKYpsy/yTyBIaOADODef6",
+	"FXs+kpITJ1/iqvxgLFvRrBV7LWWd2VHWAbsPSYy6AQ6Apsxx6d23cAD0hewbKYpsy/yTyBIaOADODef6",
 	"Kjd6L9Zww5Ow9t2qc36kRJRosMbaGdVTb49LLbiCk5CpmzKhHRm9zLVAW7N0d+8oEgGNTmsdFTgk53ek",
-	"0upjaasEe5mtnoJv3HJl51OufFy5U1hPATF0rmbAQyiRuL9PQU9BpgfMFMlGNwrawnHn18kf5mN8uWbJ",
-	"CyKeSZgCR4csnmDG+lpJ5ePGViueu/r8JOswsy06vHnaiWamWnJXvLJf7YRfEo8tK9VfQ6/2yJgj2poj",
-	"W8OnWGQay5Q7kSw8pbpEIJxJFhKs0mpEwZyphEbsPx5R2q5uZmllOPJnkwPpMRJgFhOUIw9arr3UUV8u",
-	"+rGFB6GmyQc+z4MkojKLcq7AuGrK3IP2s4X+Wfei4m102nhMGH4GuqK/RU6PXg16q8Jz4P9OIKkxa2VO",
-	"8zQJwz/3lp6BlIeEhqEiDL3Fzgae2LT9lB5X8PuVhSDF8Z2LnW2Ym0I6eVtvcUoDnMQcpGRhan4yp5Oe",
-	"lZEEE397y/qa50QIXBS9G1eeTpE46puAnZ+mIKSZKGyMr1Lv2XceV8Eh9exPDK6itf3uT1SwvY+1VrW1",
-	"o+7cDZcI6Pe5pEdBZlQpj0oe+xgnf79897ZGrU0RemnD6bm72Wz3MYuiRUfyiqKMddK1rxTg2MGYRmrF",
-	"zXA+Juh9wGLZwDWxBIZpnWOvStNIAg0XaRdGIf3tP/Gxhs9PfsKssYgFusy05Ym7/sDR/3B3tw+zYoqp",
-	"7fCzlG+fh19Q2IRjJPm8XSG9dxmB+Wk39qR6BEtxmcQihKfdE3BOHiwLnNaamwRv+68QaLm0E7QbZOkX",
-	"DW+kDzjzPuyYW/GIwG0662qAE9y6uiJGROXkQXNwU27aQyrGYzYGW8LJ7G3np+0IsrbEcL7ySnkpWtrO",
-	"dLGbgsIPaLHYrh/O2WZZ5tlcyxDbbGjcyMH5qG1+LbxvvaNZUkIEFyJkY3Y/Kkgb9u+FELaSEFiJcz7c",
-	"c2O8271j/UHpc2mLj4+mLDJnkcjt5IymUm/LkIGTKcJ0Pr2wmPaXo7AVm4YtuPOlqopbsGZ42+bBnHFf",
-	"c8Z9jA+IxfW2h4PF4WBxeACLw7KdAZMU3RGngzGoRHU3z4SHjvlvbo1ACuyrBQ+2IJl6pWKph4U+bECz",
-	"Nb2bA8HAnSeGE7IYRKKf9nA/MtfSZZxEUU66+egTGx9qLpGL0JfmcOGpf/vbeTwTUlOuyQimdM6EVC/+",
-	"9rdr3ifn1oji1jNIAZ8CgDQzzHfZMBfMeALpFrDkHQ4Z0eBmIs3z15aqe37yYxbA6uJWLex/eWT6iyhB",
-	"goiZ68dQ2FhwpoU0CBdQHkBko1ESPsgBibAAxacnJd+4SinfeIfKk2kSU95nvK+n0I+EmGW1vDhu6WnP",
-	"VSgOZ4JxnZ4ri2MIGdUQLay68O3JiW2/aYRiIqVjyzpRZbG0meJwaVDmoDwclIevTnnoHTkWUvJQpp9Y",
-	"nMREQSB4iOdhSBcvzYCYMbMCF/Ry3kAW2ymOXvz4w/OTk95RzLj997MUasY1TECuqAgerD/3pN3szBWe",
-	"lWGzJxiiILH8MsyVlTJc7GkH1Z4ftwbMlb3ySpjc39MzqUVEK9PWE4MHPe4+riSnvKEdYcGDqRRcJCpa",
-	"oEROOYe7n9aReUqLWZ9GUbVGdwUyZtwqdVHk5X6UHWsadebFTVZ1oCwG6FKLmc0oc7FbX6iZu33G5k6s",
-	"YZf50H9zqzPMDozSa2JcaaNDqoMPyKVmaqMKl53QmvF1Lia45lEkuJYiwmrWaSiyr8UjiZqKJAqdppgj",
-	"p0K8Kw0CIfElowW+mfApBeYzwdPJakzpCKRigl9qquHLtKpnB72M/PgH/+TRgijQ5a7fqjhvP/cu/L4H",
-	"2rsSk4lLVlUpYuL1QTuau4XRVIibunyvDy7Hy6CAG14sCl8usAbkFOYQGbzrkZhyOjE/CEloGDNOBI8W",
-	"g+q0sN8dXF3LDnNw+aSw/bRveCtWLsJ13U0jhneJqb9x+DSzFYHBjSlJGPMQO3U4h57uLzVJY/mmw9Uo",
-	"WIx3xVe6eZJbTXRQESPQCUTb3kvJbSd78K3c1u9l53dA3VLUPQPdFm/blBfLT1XCLz8s22H9eC1ugPeu",
+	"0upjaasEe5mtnoJv3HJl51OufFy5U1hPATF0rmbAQyiRuB+moKcg0wNmimSjGwVt4bjz6+QP8zG+XLPk",
+	"BRHPJEyBo0MWTzBjfa2k8nFjqxXPXX1+knWY2RYd3jztRDNTLbkrXtmvdsIviceWleqvoVd7ZMwRbc2R",
+	"reFTLDKNZcqdSBaeUl0iEM4kCwlWaTWiYM5UQiP2H48obVc3s7QyHPmzyYH0GAkwiwnKkQct117qqC8X",
+	"/djCg1DT5AOf50ESUZlFOVdgXDVl7kH72UL/rHtR8TY6bTwmDD8DXdHfIqdHrwa9VeE58H8nkNSYtTKn",
+	"eZqE4Z97S89AykNCw1ARht5iZwNPbNp+So8r+P3KQpDi+M7FzjbMTSGd/FZvcUoDnMQcpGRhan4yp5Oe",
+	"lZEEE397y/qa50QIXBS9HVeeTpE46puAnZ+mIKSZKGyMr1Lv2XceV8Eh9exPDK6itf3uT1SwvY+1VrW1",
+	"o+7cDZcI6He5pEdBZlQpj0oe+xgnf798+1uNWpsi9NKG03N3s9nuYxZFi47kFUUZ66RrXynAsYMxjdSK",
+	"m+F8TND7gMWygWtiCQzTOsdelaaRBBou0i6MQvrbf+JjDZ+f/IRZYxELdJlpyxN3/YGj/+Hubh9mxRRT",
+	"2+FnKd8+D7+gsAnHSPJ5u0J67zIC89Nu7En1CJbiMolFCE+7J+CcPFgWOK01Nwne9l8h0HJpJ2g3yNIv",
+	"Gt5I73Hmfdgxt+IRgdt01tUAJ7h1dUWMiMrJg+bgpty0h1SMx2wMtoST2dvOT9sRZG2J4XzllfJStLSd",
+	"6WI3BYUf0GKxXT+cs82yzLO5liG22dC4kYPzUdv8WnjfekezpIQILkTIxux+VJA27N8LIWwlIbAS53y4",
+	"58Z4t3vH+oPS59IWHx9NWWTOIpHbyRlNpd6WIQMnU4TpfHphMe0vR2ErNg1bcOdLVRW3YM3wts2DOeO+",
+	"5oz7GB8Qi+ttDweLw8Hi8AAWh2U7AyYpuiNOB2NQiepungkPHfPf3BqBFNhXCx5sQTL1SsVSDwt92IBm",
+	"a3o3B4KBO08MJ2QxiEQ/7eF+ZK6lyziJopx089EnNj7UXCIXoS/N4cJT//a383gmpKZckxFM6ZwJqV78",
+	"7W/XvE/OrRHFrWeQAj4FAGlmmO+yYS6Y8QTSLWDJOxwyosHNRJrnry1V9/zkxyyA1cWtWtj/8sj0F1GC",
+	"BBEz14+hsLHgTAtpEC6gPIDIRqMkfJADEmEBik9PSr5xlVK+8Q6VJ9MkprzPeF9PoR8JMctqeXHc0tOe",
+	"q1AczgTjOj1XFscQMqohWlh14duTE9t+0wjFRErHlnWiymJpM8Xh0qDMQXk4KA9fnfLQO3IspOShTD+x",
+	"OImJgkDwEM/DkC5emgExY2YFLujlvIEstlMcvfjxh+cnJ72jmHH772cp1IxrmIBcURE8WH/uSbvZmSs8",
+	"K8NmTzBEQWL5ZZgrK2W42NMOqj0/bg2YK3vllTC5v6dnUouIVqatJwYPetx9XElOeUM7woIHUym4SFS0",
+	"QImccg53P60j85QWsz6NomqN7gpkzLhV6qLIy/0oO9Y06syLm6zqQFkM0KUWM5tR5mK3vlAzd/uMzZ1Y",
+	"wy7zof/mVmeYHRil18S40kaHVAcfkEvN1EYVLjuhNePrXExwzaNIcC1FhNWs01BkX4tHEjUVSRQ6TTFH",
+	"ToV4VxoEQuJLRgt8M+FTCsxngqeT1ZjSEUjFBL/UVMOXaVXPDnoZ+fEP/smjBVGgy12/VXHefu5d+H0P",
+	"tHclJhOXrKpSxMTrg3Y0dwujqRA3dfle712Ol0EBN7xYFL5cYA3IKcwhMnjXIzHldGJ+EJLQMGacCB4t",
+	"BtVpYR8cXF3LDnNw+aSw/bRv+E2sXITruptGDO8SU3/n8GlmKwKDG1OSMOYhdupwDj3dX2qSxvJNh6tR",
+	"sBjviq908yS3muigIkagE4i2vZeS20724Fu5rQ9l53dA3VLUPQPdFm/blBfLT1XCL98v22H9eC1ugPeu",
 	"+e2UBVPzIjPM06g7t4aPBjAgl1pIIEwTBUEiIVoMrnkz+y0xNlqAu0IXz7ZNF3Z7dRUrUvJw9sZVBr+D",
 	"h7cHoviY7iyZON9IK0qpUUKOpzENjlO2UP0OsMp4URz8ejF8SWiip2iTMIgOfCxkANgIB3/nS21Ioalm",
 	"fGKLYSgIJGisWpf74sJ8YCgtZlp7b4W31S/PfM2ZIjMJWBvWcTNDsh8pDz+aTfXI7ZRFQMzPH5F4aXRL",
@@ -30150,7 +30150,7 @@ var swaggerSpec = []string{
 	"GiUKnobrnqGS2UxIc2eCW4i4pf7uCBZ/agU2v6FgCZmio6hGrJzaASqTJcC1j7dcdpRnupnl9X1k60Ya",
 	"bPbwtWvvmYd3g5O4i+r04/pAtNXvfXt92yBZ4PUU+4pXE6x/ZKVVajw8y5ScuuqvOc5jFUICn2igo4V7",
 	"YDVoh0wTd/yKaHHNnUpHNtLo7K4O6txBnXsAJmxAuUQMb/MKRoKwVHjQ7A5CYntCwvK4bcgICZ6BV8uJ",
-	"MzfCG+LyfL5KTtjIDBGFfuAIAhGDuuYe/3JxfUXjnVmiTIps+ML/kO6wKBMsGT8yJXED/uSOOkOEPbGq",
+	"MzfCG+LyfL5KTtjIDBGFfuAIAhGDuuYe/3JxfUXjnVmiTIps+MJ/n+6wKBMsGT8yJXED/uSOOkOEPbGq",
 	"MkrMuMOBN30pvCmjt6J1UXl6W5NNbcKhUBtpwZvsuPVYk3UnkEpvwhbZ1JVZ6pFxqGYfAu66gR8dfG3N",
 	"VKcd9qxJbxqDIppfjUJ6U0PRpOP9BFiD25euRFg2Mu3YGI09utS23504pW6zs86bpy0+HIiwBRG6eCIP",
 	"cfryWwooWiZEEdT20kHpE4ogiTEjhxohpyUAUVomgU4k+uvGEdVY4X5AhlGUN+dASBIF0ubyjKS4VTAo",
@@ -30159,131 +30159,131 @@ var swaggerSpec = []string{
 	"rtmPcUBeGzJfzOAFoSr4eSyi0GAxNpm0f8RpX2Crxp853ILS7q8d79hYm3IiAkOLdQqSr3iQ8oQu8UAE",
 	"LoMsF0ZpuEvbWB8/gVG/USTa8ONbyTSQGciYKeWa3pVG4Ihgx01itq8lpDtZS0O4T6e+GJQyfLSsI22L",
 	"FCd3ZT72Z7/FpXaR3+M3vMeknXahRZ6aVqnR6x/HNiK3P6LaNmar8PHiKEXiJNJsFkFeLeHhMT4JJARa",
-	"SAa+aThmO5GUSgfk0powFJEQJBLLefuvXLsIHPZW6D7GjRNMW8EK8NqFlVGVD2sPHVSYrh1CPBMaeLBY",
-	"m3e48GkR/IKn8KUzkFMR2B3hdvb0zlgGolqq4QB3l/k8yZgu8g2WNKMRGVMWJRLU0w5GapfQRpEu6qhQ",
-	"BHW5BJ786ObyMcXxnSr6FYwTm04ULlhFVE0dKXNQmLIuAlXVgttMUNthsQE1sTPGXcvONh7qnXe08Qvv",
-	"J5OmHdZXi5iGpIRUQvgZzKPI3Gt5ysEBcesRd6ucu45d58ghLaF4IAdbTL6GFmZewSqPyc73hfLTfKOI",
-	"29La3N7lXR6IZoVotq9upWf9gJrWg7zXXOjxgYDzhRLbPJlE0Fga2xa4Vse+z18q5HIq4YJo4cweKPds",
-	"M1Ka+ztSDlNkwubAe5gtnimXCQ8By1SZB5JZJyRUi9haANfmGK4i9145xkuXKFJ+WI+cjaQX8KWxkcIl",
-	"WbrYA08pQFFgMDuxCV1ROQEn6rprFrI4Vk5fNQyvoW2/bTIOma/Kqy1pIAbyL9vGfVDVrn/XPqjS9vNp",
-	"p/m9t/Rv4EVpl/tKPb3YUH9nRtkLI2D4xJ5kVliqS1TgTqbGV2EwHyu39SMxafbRBsC1pBH7j1kQC75F",
-	"YkLMLxkoEhvN38dDjFmkQZLAyGPJ6IBc2HCIpmiIN0zpV2bqN+L+ffCX/ZYI0mjhYL9hPCRPYDAZ9EhI",
-	"Jx+xdF8UxR8TIy2qhKv56qiOIBrXtd7NdN2BTPhgjM25cPkBLj+QEAgZ2gJ0ZXA4x+NGcPhqihVT+3KM",
-	"95hdJtw2e6iY35ZV3HABqjXEM129gBuw+QoKUHusXsEN2HyFRIGsnt78dfO5YxFCVHfBOKBp9gZSeyMm",
-	"l5pKfcXatfx7IyaveNh2tGcBb1jM9DofvKcTxpGdXLSUlm/E5N14rGCtZV4mUhl++5DSL2WDbVzlK+x4",
-	"d4KQRmMhYwhJgIeST8GYpbeRL32PkD3bRWyVLoYJ2ZW/e/iVXws5YmEInPSJ9O/TeFkCShFB5yIbamV8",
-	"ToPAv3kdYgo00tNG/cEOK+l1iuXD6CQhmJwlywzjv+K3l1h57OgBqc6uU0dybRpirOfEnkJw47buz0j5",
-	"jfrzVgulIXbnHbEAuIJjGmg2rw0cf/UpcM3LKHFfkRtY+IJIbMIhJH///coHsA5rdLOhW+2Nnede2tnW",
-	"itXdwKKsZUq2U9S0jFLyW/+PP/74Y+k/Txu7wZgF9tAM5tOMyUVpKcsxUJ1IO6x9e6ZZRPmGFhB371g6",
+	"SAa+aThmO5GUSgfk0powFJEQJBLLefuvXLsIHPab0H2MGyeYtoIV4LULK6MqH9YeOqgwXTuEeCY08GCx",
+	"Nu9w4dMi+AVP4UtnIKcisDvC7ezpnbEMRLVUwwHuLvN5kjFd5BssaUYjMqYsSiSopx2M1C6hjSJd1FGh",
+	"COpyCTz50c3lY4rjO1X0KxgnNp0oXLCKqJo6UuagMGVdBKqqBbeZoLbDYgNqYmeMu5adbTzUO+9o4xfe",
+	"TyZNO6yvFjENSQmphPAzmEeRudfylIMD4tYj7lY5dx27zpFDWkLxQA62mHwNLcy8glUek53vC+Wn+UYR",
+	"t6W1ub3LuzwQzQrRbF/dSs/6ATWtB3mvudDjAwHnCyW2eTKJoLE0ti1wrY59n79UyOVUwgXRwpk9UO7Z",
+	"ZqQ093ekHKbIhM2B9zBbPFMuEx4ClqkyDySzTkioFrG1AK7NMVxF7r1yjJcuUaT8sB45G0kv4EtjI4VL",
+	"snSxB55SgKLAYHZiE7qicgJO1HXXLGRxrJy+ahheQ9t+22QcMl+VV1vSQAzkX7aN+6CqXf+ufVCl7efT",
+	"TvN7b+nfwIvSLveVenqxof7OjLIXRsDwiT3JrLBUl6jAnUyNr8JgPlZu60di0uyjDYBrSSP2H7MgFnyL",
+	"xISYXzJQJDaav4+HGLNIgySBkceS0QG5sOEQTdEQb5jSr8zUb8T9++Av+y0RpNHCwX7DeEiewGAy6JGQ",
+	"Tj5i6b4oij8mRlpUCVfz1VEdQTSua72b6boDmfDBGJtz4fIDXH4gIRAytAXoyuBwjseN4PDVFCum9uUY",
+	"7zG7TLht9lAxvy2ruOECVGuIZ7p6ATdg8xUUoPZYvYIbsPkKiQJZPb356+ZzxyKEqO6CcUDT7A2k9kZM",
+	"LjWV+oq1a/n3Rkxe8bDtaM8C3rCY6XU+eEcnjCM7uWgpLd+IydvxWMFay7xMpDL89iGlX8oG27jKV9jx",
+	"7gQhjcZCxhCSAA8ln4IxS28jX/oeIXu2i9gqXQwTsit/9/ArvxZyxMIQOOkT6d+n8bIElCKCzkU21Mr4",
+	"nAaBf/M6xBRopKeN+oMdVtLrFMuH0UlCMDlLlhnGf8VvL7Hy2NEDUp1dp47k2jTEWM+JPYXgxm3dn5Hy",
+	"G/XnrRZKQ+zOO2IBcAXHNNBsXhs4/upT4JqXUeK+Ijew8AWR2IRDSP7+4coHsA5rdLOhW+2Nnede2tnW",
+	"itXdwKKsZUq2U9S0jFLye/+PP/74Y+k/Txu7wZgF9tAM5tOMyUVpKcsxUJ1IO6x9e6ZZRPmGFhB371g6",
 	"LsX8nUe/mLs0SJsBY5XmnTH1c66S8ZgFDG39qYmxU4YPT6JFam9iIyE0MxJf5g+78edvAfuQF5KmsXxx",
-	"nHCmfcWDYW1NP7ptvtIRy6HnQtnx7i5m7K2wdwQpHgiZ/piLNJ8zSoDPyZzKAyEVvP7+zgqlnaIURUsJ",
-	"KgYtWYtg9/dSxKCnkKi+gZlqNoqAuK9RNruWFFj42ShGKc2oMuXowq3biPwaPunjWUTZ0hG6FH1ziuTX",
-	"V2/ek5BOko9GUbPLjxIWhXnF7Zr/D3L1j/evcgMnNJnANU9/8XkO0tzrz9dHzwbPng9Oro96OM/HkGr4",
-	"+fro25Nvn/dPnvVPnl09+/bFycmLk5P/e33Um4iP+S+/fXZ9dEeeXeOSGWzJTLMYPvqy/uZhSRTjAXhF",
-	"CnsRFMFc+iYP8NKfvvvh5GR5RWcjUh/T2twffUnjt0k8Mpr9uLxut/lZFUGpmSwPVs2w7yvhs317P2qh",
-	"aUSu8L88BdCDQxi3DX4r4CpMUgpSYcSPldA0gDFaOF23Ag77uSvyvQwC/vGz/f7n6yOnnRh8+fb5T981",
-	"jEayR9z6vmEkHWFGqhn73yX7rNnj6q5U+ZH6Xz9fuda0gHV687+XlrdmyqNccc3V7/NLr/712XVJ95RV",
-	"/pmxsJRvMU4Mf/G9RTpXDfkMNFkFO8fLM6br+LmYAaczNvBQNlaf5Wbr9vH8bgZ8+P48cxa58n+jhUvt",
-	"MnzV10IvY+rv7OJ/V9hk4F5aDQ1DZvvVvM/pN9a106jGXE1hZTP7teF0KRZKl51OhXqAHLNZO7DNzDGJ",
-	"C/tBeco0SrbryY78UA3IbwqIm/b4M6cx3KH2YGfw3bnMd8VBxzbifJw1eR/R4CYSE5s+x/ik3DPzv+0G",
-	"9qmg192jBe++tpsOcCq0xNFCqzV7fxYh3EAUnEzpIhNzSJbHOHfrLREvBk3No66XdWww2NJbxb+SSsX4",
-	"99LIVryc7Xr0cMqCo8OFvjg/h/tLN5zZdv/rdYbcQWCJO8Pu9jAwTNYjfN5yvFTS/d8OvZrJ4Dg1mtUS",
-	"g+DYXe6WytAWb5zRCRi1zpFATT8eHNGzWZ4QZq0ZLX1NgYZECzOxLR1AWeQqdszovxPwfhQJKolBETrW",
-	"TtnDZFYVUM79ImiYX9Qw63Pc68PGm+BCZsXW3rr0C+9HewSkHbpWS+/pBDYSQTu1pgb+4DtI7Y7AMh2l",
-	"LZlLRNs+F2ELLcsOxoRz1wRoJPTU2cYw6dx19RYSSukrI5LuakTZOm1zrvPHsnt/aZUeVIAqu/3ChbdJ",
-	"vcbb7FtPbJiftSLPOndPe/J2NWdQZws9YCJ1OySrQ7AP2WF/NRnUb2kMK2GypX2jMTq+iI8VSL7M6I4/",
-	"y/T8z8O7dumV7enAfrMVOnCNdO/FGp+Xe6Y8YhVSF3fAuF5SblTnNKnXyI6+EokMIEwL1+2okFCqwZel",
-	"L9J2yNU2lzE3GRktbCDbyouvM0hzskdWt+vswSo8MIpVayRoSuJbg3/Yb/aJCg+VCbeh3N0nMhYy4XbH",
-	"HrH+0qIr7LEzst9l4tGtyP1jDUr3A8E5BBaC6k7DSmPGLY6cM+3y85Z4ekxv0OjsI9ICjFLzGtRKFUPI",
-	"P4heZmA8Fs5ftcE60stGEXM7Lkdl76LgysKSU8fz11WDfjY/CgtrNueKoIGhP6IK8xrYZKpvwfzXdiMt",
-	"JO1k+VORGNHI/3VGJ1CZRjU8ew3Y83lfmVRDD6bNAHKGpm2kVFWF9p8Oz9BfbvvWkyeBiGPaV2AA1hA+",
-	"zUr54kg9pZpM6RzI8M2bnHXSfl5VQs41xb9fcoC9o5xxr9V4Zz580Iyy4ZldyyBPLenm0LcEY3f+ck2X",
-	"Tx+wHevybeEziJf3ftqEyhXukS/Li2ljsB5DIYqz2Qwc5xAcsuQzc1fYsxsd3pXsg04u3LrrcpBCAd3e",
-	"/RxYe+EhxJ14O1biB6ML5HYK3Pf6JlOqds9Z1qqvuhkbQsTYAS/KrVbvtF7hRXgnKQ3s14p2aLKesb7l",
-	"i2lghG3KIlerUbm4ovvqUiJ4zLrUF6ur+Oz3tXSVCrTYJ5PoJLmWZcVXUem2dZS0uGE1QW6qnTzislaP",
-	"gGt0W7VIWcfXpl/st17XJlyrtaYh5ywAdRwIIUPGqRaykYnZsPeSLF3riJ8wpTGsKTdnGsesNmqBcgb6",
-	"ZTZZmuPbzZCKFUgfQbzpGejCdTq8achCTrFLgrXpq+MpU1hjqTETHMexgEY2f9BIEjs3SSfbFJU+uAl+",
-	"dbBsNeT01LWSJGLsNoHWcwlaMpindV2+O4l75Nm0SiKGviFleauGZ9Oj3fZkWD6yLxuTPQYRrKTjr6kR",
-	"i9NUmK1xyFxyzn3546WfquPccQnOR8Ibs4tckzPqhHOINkcojA/GOdKVn1xRFqmARvB0U2S6whk7jkl5",
-	"IB8JGi3dZBMOac34RB3TiQO9MfvMZykPzwl+VOx+nCuVmtWfKcWPofnYNqTuLHrkYKzFjtVz+ArqD5Vc",
-	"dNfy5koQtPCKscjfJhrJYP69MN5OtFWkf6iYowLW7yXoqCXdWXDD0mveqz3hQPd7Lz3emvRXxeCxOdfj",
-	"mRRzFiJtNilWySj9dX9Eg5sUJc1ExE/kFbA0lQsiuwuO5WtacZE3TFnBOUz09H0KYVflZzm4bTJECien",
-	"DlTVibJ9JUid1yytDtmCoo4/+x/Pw7vjSExspZiqjAJfFQqJRgvz6H1nEIoEEkJzUzRaJSq/QkvCOmXK",
-	"Bait4OsbhG+rBp5hgS9kFVqL6YfZId0zCbEkn8FvjoTpxj2yH8hsjxWh0tsolSCRQ8VliqvKScPiuYpQ",
-	"825PaOTIBmch40jc3ptscIFHSDFbtFVVn1CtHMzuCGtM7TuP7cAU9lhi3yDAWvxgEwl87LtFVgf1v3Qj",
-	"6jhKonx1/hlFp70E2xWD/PbhDZoNEz0Vkv3HWiCD9rqvX/1xsJsHSNStPZ89veSbgGrigGkL0wP7+1rZ",
-	"n0eh+3JAt5++bUxgmFxS2n9H25eGG+4aHXhFydsA2+pHoE/tPEgAF64nQucMfxmcCOKemMUKFDWNMwu3",
-	"YxsrfKV0upPwpQvb7qOLvQYvQafEalmEbz3SginEELtQkqZ6Brlw54tXF+8+/GMQh1jBpa2FAVI5eGEX",
-	"fQCr3dKl4TokiIBipEDqwowWB7G2d7FmbsVjlMNbjxelHqpaG7SbJ3Y37lrGUR7aEo+uUKyt7GcHremp",
-	"fTic3Z7HyMLY7Kl1pyTmIOcMbg+00B1fbT0JlGpseRftCoNe7fnc0km7LXx/UCetR/h1tbVSMeHqNpSI",
-	"icOr66t1o7aWT5W6lcvFdf3+7tqqWo5HY4m8pfJ8p8Oz9XWu0+HZFkh6xVCEBTjE2OerltuJsl6HG6an",
-	"DM9sJnA7tQ+TBA+qX9dVv9PhWT/F6XsrgEua38Yk4/W9R00v21M502OqNVbkCNKtfKDBDqica1Ngo/65",
-	"LSrM6XiPiBC/AF04R6oHffjAL1b04TVZRplWLEKI+jMJCnRzbOGUyjAQIYTO0u2+84Yc20RhjeBBtOO+",
-	"d4t3OWwwD2ibgMHC8RzIpRPxgsU7aWePN580kwWNonyDwTQy336+bjDthV208+TQnhAOFNCliNnY41fb",
-	"uL2sljyH2yXs3ij7xE7YbR+0hRHB2yD5ZHuoXoCgmt6sR7QTRea/Tq/3T7vyei/X1+2QIckV9l/b640M",
-	"6fgz/r9tPX++DUaU94LfmxGtPGrtfVWF67ndbj+Y3i5baAtwCET5+gJRfBeEWmpsrnvPLaNhfLINgstb",
-	"SL4YgnsoQ9GmysXJfpSLQiX9g3Jx4GR7yaFdQ69QIln/8W5XwU/JkxlIJTiNmGagnq77kL/E9R+2nOF7",
-	"Omk3DmQ6dDnEOFdQ8ImvfWx4Zo/kRj6tqTK4n1wmc854xG3sEBYXDmaI7pghlKOOzawQ2Rx5Kl08Xd8C",
-	"YVCouwYIA92eLA926WrSMn8/WBwetcUBr/gLMTgoS8dt9YLjz+Z/7a0N2SLr2xbuzWJaFNvFzbRsH4jX",
-	"WjAQ7LKth1n8/PSgzj885XbfLlFBtG17Mua0AGzJuGZU2V7p8mS3grrQlPFA7gdy33kyRSWtr2GCXFsK",
-	"5wyOu6b2hzIbrv0k2DGnOdgJD5xm72bC9q8BLUQLK6EPbrNBtMWa13ZFnKfGGniF63S+Nh6C2caiZs/t",
-	"YFHrjkVNOwyrRfoRVdC39u5WBZbNeGz0VXD3kX8ML97kRHDoi3Lj+WBhnZGYl6vev1AFHai0PJMGMs3s",
-	"13i0avUoPLajiLFbt0MJs20Bl2t6Mg2xKjGFp90NqJQUI7fVDIKSVsX+zIvnzeyRE1stvaRXQl4N+Ked",
-	"u+d39Wc6XIz+BYEuQ7NfVtb8mmi7An+7pkivIsbGuSG1dP1/LLaDIiMYCwlE0Tnjk00I3q65TZrfTK8u",
-	"kvuD0145yW1XU9+Yg91SyRFT2rOrpT3ei7F0I5flwOu6y+ucKt+W3RUUnFvf4E8df05/tn2X19V90s/7",
-	"KhAzCFsqQxSxmmhRnKRUGUrbEdZxyJJgpsLOttzo7yvRstIj3Iu+9XvN6jvnhbe5ppiPnQ+ec5WMxyxg",
-	"2OgTZMyUYoKrnVlQspvvrMG2jjQ21jjX46bNKuitZBraM1sLyhfBbx9Ww9063zvoum2Y+kHrPXD7zhrN",
-	"12f4qHMveHAcREB5Mquu0+0bZtAoInj8fEKAa8lAkbEUMTHTYDsaWK1Yu+DBS7dAd4yFYyEnQmvg1Rwo",
-	"HUIM1yHnp2otrTUGpeikJCLp0t4c8QOaGHQGajZpG07mDj2reL3CtrpUvshA6lELscmedL7NIA8KSNv+",
-	"Eeg7DJ4xbedeJo7VxqUGabvdSjADsbZVekF++Ya/3UUFo7pWXtMSKrRQWFveuPPKb/HSH6CidgqdhXZf",
-	"8QMboF2V2tQxCdoW71IWZOMv+yMf/FIvPLEtjq30AqFlb1Z4SkQeImEmFNNCLnokEthknKmbHtbczeSr",
-	"Ue/T4LlAxDHTg1KZa4P0fkHYOorOORAfEJuLgt/HzFaKfTdgz0Lfg7meyD9HpPI72Msr5SXlRku2MJAn",
-	"s0RNDR7TUQRhjyRcS9vPEM+0t2IufLozrd6cVafDa9MWWq3UIceLnAq1niq/KS+q4TsXDo5OuAorqfIl",
-	"8k9PlGlPDjxLx/pXqHSFCA/8qTV/uiggXHf4VBeD63P02YoB4N+PP5v/nYd3x1k+TAMfcM/bcuonTyZM",
-	"ExmT/3K6BvkvYlj607XYgt2SYQ6G6W63YMCV0ar8+RCG7TvHDCR5gpWeZ1RPsbadSDSBTxq4ymfCFi3E",
-	"9ux2VV1gxSARlNDla/NrL01hDpywsd3qlCp3B7EI2ditozLKHQlh3tW1ZL8VBrjT54flFXVvDxTse+Ut",
-	"CEFgGcwIimlaB80GzPvFU+waDI2Nx62sPWYgGYG+BeCOQgx/crxtDhKtx9gTugBHqRHInOWpWfnRMa0H",
-	"tA/4Q6stYW1uqdoe9ZUTyhloi8eu4PMm5KICKsNqBeDUDvBCJJhSPkF9wJDKHKROPbKOZHwgx4qSUNr7",
-	"msrQo8JLO/WBhLYn49yREnfLBwIq63tNZbiE3BtT01hIJ3da2PjQTAdcy4Vb0OnxOfNHjwiJZsaIBToD",
-	"aEAMzUCIVGjVutRUSKWhuX/hllctfq8RwMerYu9Zncx8gV1QKDOP4IHQLeJvRtWGZqtpeqhFzAIaRQsi",
-	"waBv9limgRTKS05DBGqhNMS9MvNZw9v4Qswf8GXsPZ+P/oVsrnL1few57HZexYguvVUjG4fbc3supcFa",
-	"HG5Xjl4Lh1NEi0ZbWzb/n1/I69ucVDfe3gjJHtnkNmv8eNerwegm5yvqFSFoZJxd4teG323GrWfJKGKq",
-	"xtFqydY+YWaJmkKuzEjGAN2jpvkV896udzBbroeh7tj2GJ7wAVQS6UYm5fCpO2+nA69Y4hUOlUqouIZr",
-	"uGvt0yhai1WshmeQ81M1IOdWnzgPFWGKiJhpbd5vHnucJ9W/1YRc9nGXR2e4rQ2jqKvBGRmEnSZljyPd",
-	"j3L0kKZ+/dPhmapF5DoMfg22yqt/XqjMyCFFnBdxZ0zXiTl719vAwz3jARYB7j4SRFHxpsoUkSqUME/I",
-	"RLXygog5SMOZ0qA2+y1hPIiSEL3K9hdijBzMIWOpE+TSLttlBLEg1hY2yh3CFxYHq/z5V+GFBqX7geAc",
-	"Ajt9Fde4AmWkXpbHwQRHFuI/njO98CpyrqR2Cx5ipn6ZgdDxsGkHpgG6QT1yI4k5YyKRD3UJUcwOSJAD",
-	"U7TlKIkC2aK2Oolc4JHhEvjNGkXUf8M1HvA6cQGzUpt6R3bHjz9j6rWQIxaGwEmfyC+h9pHHrByi2n+3",
-	"rSVuRhMaBCLheq364QZ/jh6y+rdZYE/Vv+3S1WRh/u6rf3eiKS15AoPJoEdugd6QGVXqVsiwR5gfJSJ4",
-	"eiDfnZUOT20DfaQvNFd3v5J4yg9KmEkq9o4/m/+1LR3egr2QYtz7QiRSQTSuqinu2M56KtJvCHLLAuFI",
-	"3NVRcF8zAaHvvXBd5qp2ZvjDm+lyeF4F8TRX9PZtrJFcRgvziGByrZreW6aLk93K0kKB7oOI+qppyTzg",
-	"PR1gO7sSxbahaDZ+/40ijNtSHuv26Ls/MT1U/eu1leIdE3In6nx8PcWwu8tNDnp2VbJ0aw37GLv19/1z",
-	"ri6GUoHOsT3/BdHCafVzGiXQkgXibOZC3/uFO8YJEUAP3L5cbM3xPB5CgtfYXTPBwTBw0Loc1S8zkAo2",
-	"dQujqRA365rA/Wc+CNQ7zwbk1Fdl7ZGYcjoxPwjpLkjwaFFuI//dw9FVl4kDsK2VPT3XLpqZb7PD9jiR",
-	"/qqIFsefxyyyVWdr/GmSTSYgDY6cDs8IfIIgQTfMnFG/1oBcTW2RxDhRmkwpBsC5P+acbNec8pAAx1IJ",
-	"AzIsOulCmAEPFRE2Ccd/bhgRNtR9cc1HQCXGlt6AxbceKfxqFiWK/HoxfIloaX6wWHnNr/kVxgtY9joS",
-	"4YIwSz8Qem+g2QC1vuXfX/3y67t3/+vj++E/3rwbnhLgcyYFj4Hraz6nkpktYOSM/zDdpSJ/+WMZC3lL",
-	"ZfhxCjQEqf7qpZER19yD4v6GyQ8OnCUYfn01PH314TIPA0lBuOavhSSKjkEvevjZX+ZYhWT/wVP9yy1g",
-	"dsthDpI4oCAc2DMxwMuEmwHA/51A4pIzzFzAw5lgXBPpGAWLYwgZ1RAtMHjPjLrmIZ30zRTnp4Pr1dJD",
-	"DoMcja3NA06HZ68dmh6tWadyJSbxlzyyjIUsIFkOFZ34/caND+kk+Xg7/TgYDL7JmreGiFvkdgoVCOsi",
-	"EUC5BYuLDHyoo72gLNixcH9HDVU7i/tDjPdwKDbhVCcSfFqbfWOTb9SUfvv9Dz9fJycn3wVT+IQ/wDeb",
-	"bAwXXDo8xAsDY6AJcIxpNzhbud8/+qd0kvQvPbiFLcMnGs8i3LWF+uTZt989//6H//7xJzoKQhiv+2/E",
-	"P61BGlD+n5v0nyf9n2h/POy//vPzD8/v/mdJwPoD6ciOKnLa8d3Dy7narFXHDrSl2q74zQzH3pn++xun",
-	"jgYhJP20SIWQqaMOCbqX+82xH7SMzZaMHDkgueRowjBdGmg2h71o2J6wffUisx+j9GYSe2cKt0G7HD/e",
-	"q4nCk4AXcLmg2ZBOPiT8POye9QKCRDK9OHrxzz8LwTOWjKt1txo1UcibhvgZDDErmG8JHYlEG4zSko0S",
-	"A6Sbx4fwZPpWIIQMGadayI2eFq4zgY2q6OjDwsLX9LAY5pgskenA3tH3u2AJL7N7IArknAVAEk7nlEWG",
-	"LewUuc+Ag2SBxezcUay+dUpQrBAFpjTEOUy23TZyyFzyTM2GdRmfEMTWT9VsT928Rnyy5g8+5UbZL/Mx",
-	"UmUhTumpdDHTYAnEPUVK5davRpqsDLiLmdqvR2gHUv9tmSeiPOjmNodkpTha5DS5vj4rQThl8TI1OFzX",
-	"6WHNrLj79tUpCcPJkGbXVaDeZkpieQ2mxivrlQuDfMujTl/Hyb74QyEOZI9XvdQHZikQYVmE+GiE2p4r",
-	"Xbvwh4pQ2Ewi7Q3jCg27d4txnZFFvnl0C1lUfBIaeNmVuAFu3ocGC0dUsWCY6Kn7hcE1o/t7nF96ndNJ",
-	"Qobvz4kdctQ7SmR09OLos93U3Yvj489TofTdMZ2x4/mzo96Rt1Aj3kxT14LTP4+wsAj+evkYfhVKE4wQ",
-	"ENa67ta8y9NVNtFU69lR7wh4EptTcP80/7Pn8Gd6Qsubeue5gK2ahK9ObN/PQ6v/mH+Yd3MIY8aZrz3p",
-	"OEBoJl21wC5N6tKwzExTprSQDEuKUk1xmUhMMD3tdHiGBvT0hV5cyPytbLFLfOQQsbQRwZlZyW0l3Rd6",
-	"KsxFppfoVnBvpdX530sRg55CovoGkalmowhIbPYUrKyFU2egZNNnY5rPq3AJuckz0wV6KHKzu3+vzrzk",
-	"Xcod0pNITBjvmdMXie4567y1OsTA9dNsdmooZHVudA9nHxQmf/nht9NeFtpROq1P01mB+f05uYFF1dSZ",
-	"MSQP4oz1b2BRNp0z96ZuHHvGzrLrsTs92px0y/ybq6caMm1OrgVgZmjJFC+Ba0kjNK6mk9AIa9usTu2M",
-	"QUVbUG4V/KoMUp9bOJWCO2fKMqW4jNCUDHhQtuNzgj3nlxplNW8fG5uvzncqggRvtvSSc3QvgrJtWf2A",
-	"cBHCWmhiU+b65jt1dPfn3f8PAAD//zlxlIuHPgQA",
+	"nHCmfcWDYW1NP7ptvtIRy6HnQtnx7i5m7Ddh7whSPBAy/TEXaT5nlACfkzmVB0IqeP39nRVKO0UpipYS",
+	"VAxashbB7u+kiEFPIVF9AzPVbBQBcV+jbHYtKbDws1GMUppRZcrRhVu3Efk1fNLHs4iypSN0KfrmFMmv",
+	"r968IyGdJB+NomaXHyUsCvOK2zX/H+TqH+9e5QZOaDKBa57+4vMcpLnXn6+Png2ePR+cXB/1cJ6PIdXw",
+	"8/XRtyffPu+fPOufPLt69u2Lk5MXJyf/9/qoNxEf819+++z66I48u8YlM9iSmWYxfPRl/c3DkijGA/CK",
+	"FPYiKIK59E0e4KU/fffDycnyis5GpD6mtbk/+pLGvyXxyGj24/K63eZnVQSlZrI8WDXDvq+Ez/bt/aiF",
+	"phG5wv/yFEAPDmHcNvitgKswSSlIhRE/VkLTAMZo4XTdCjjs567I9zII+MfP9vufr4+cdmLw5dvnP33X",
+	"MBrJHnHr+4aRdIQZqWbsf5fss2aPq7tS5Ufqf/185VrTAtbpzX8oLW/NlEe54pqr3+eXXv3rs+uS7imr",
+	"/DNjYSnfYpwY/uJ7i3SuGvIZaLIKdo6XZ0zX8XMxA05nbOChbKw+y83W7eP57Qz48N155ixy5f9GC5fa",
+	"Zfiqr4VextTf2sX/rrDJwL20GhqGzPareZfTb6xrp1GNuZrCymb2a8PpUiyULjudCvUAOWazdmCbmWMS",
+	"F/aD8pRplGzXkx35oRqQ3xUQN+3xZ05juEPtwc7gu3OZ74qDjm3E+Thr8j6iwU0kJjZ9jvFJuWfmf9sN",
+	"7FNBr7tHC959bTcd4FRoiaOFVmv2/ixCuIEoOJnSRSbmkCyPce7WWyJeDJqaR10v69hgsKW3in8llYrx",
+	"76WRrXg52/Xo4ZQFR4cLfXF+DveXbjiz7f7X6wy5g8ASd4bd7WFgmKxH+LzleKmk+78dejWTwXFqNKsl",
+	"BsGxu9wtlaEt3jijEzBqnSOBmn48OKJnszwhzFozWvqaAg2JFmZiWzqAsshV7JjRfyfg/SgSVBKDInSs",
+	"nbKHyawqoJz7RdAwv6hh1ue414eNN8GFzIqtvXXpF96P9ghIO3Stlt7RCWwkgnZqTQ38wXeQ2h2BZTpK",
+	"WzKXiLZ9LsIWWpYdjAnnrgnQSOips41h0rnr6i0klNJXRiTd1YiyddrmXOePZff+0io9qABVdvuFC2+T",
+	"eo232bee2DA/a0Wede6e9uTtas6gzhZ6wETqdkhWh2Dvs8P+ajKof6MxrITJlvaNxuj4Ij5WIPkyozv+",
+	"LNPzPw/v2qVXtqcD+81W6MA10r0Xa3xe7pnyiFVIXdwB43pJuVGd06ReIzv6SiQygDAtXLejQkKpBl+W",
+	"vkjbIVfbXMbcZGS0sIFsKy++ziDNyR5Z3a6zB6vwwChWrZGgKYlvDf5hv9knKjxUJtyGcnefyFjIhNsd",
+	"e8T6S4uusMfOyH6XiUe3IvePNSjdDwTnEFgIqjsNK40ZtzhyzrTLz1vi6TG9QaOzj0gLMErNa1ArVQwh",
+	"/yB6mYHxWDh/1QbrSC8bRcztuByVvYuCKwtLTh3PX1cN+tn8KCys2ZwrggaG/ogqzGtgk6m+BfNf2420",
+	"kLST5U9FYkQj/9cZnUBlGtXw7DVgz+d9ZVINPZg2A8gZmraRUlUV2n86PEN/ue1bT54EIo5pX4EBWEP4",
+	"NCvliyP1lGoypXMgwzdvctZJ+3lVCTnXFP9+yQH2jnLGvVbjnfnwQTPKhmd2LYM8taSbQ98SjN35yzVd",
+	"Pn3AdqzLt4XPIF7e+2kTKle4R74sL6aNwXoMhSjOZjNwnENwyJLPzF1hz250eFeyDzq5cOuuy0EKBXR7",
+	"93Ng7YWHEHfi7ViJH4wukNspcN/rm0yp2j1nWau+6mZsCBFjB7wot1q903qFF+GdpDSwXyvaocl6xvqW",
+	"L6aBEbYpi1ytRuXiiu6rS4ngMetSX6yu4rPf19JVKtBin0yik+RalhVfRaXb1lHS4obVBLmpdvKIy1o9",
+	"Aq7RbdUiZR1fm36x33pdm3Ct1pqGnLMA1HEghAwZp1rIRiZmw95LsnStI37ClMawptycaRyz2qgFyhno",
+	"l9lkaY5vN0MqViB9BPGmZ6AL1+nwpiELOcUuCdamr46nTGGNpcZMcBzHAhrZ/EEjSezcJJ1sU1R67yb4",
+	"1cGy1ZDTU9dKkoix2wRazyVoyWCe1nX57iTukWfTKokY+oaU5a0ank2PdtuTYfnIvmxM9hhEsJKOv6ZG",
+	"LE5TYbbGIXPJOfflj5d+qo5zxyU4HwlvzC5yTc6oE84h2hyhMD4Y50hXfnJFWaQCGsHTTZHpCmfsOCbl",
+	"gXwkaLR0k004pDXjE3VMJw70xuwzn6U8PCf4UbH7ca5UalZ/phQ/huZj25C6s+iRg7EWO1bP4SuoP1Ry",
+	"0V3LmytB0MIrxiJ/m2gkg/n3wng70VaR/qFijgpYv5ego5Z0Z8ENS695r/aEA93vvfR4a9JfFYPH5lyP",
+	"Z1LMWYi02aRYJaP01/0RDW5SlDQTET+RV8DSVC6I7C44lq9pxUXeMGUF5zDR03cphF2Vn+XgtskQKZyc",
+	"OlBVJ8r2lSB1XrO0OmQLijr+7H88D++OIzGxlWKqMgp8VSgkGi3Mo/etQSgSSAjNTdFolaj8Ci0J65Qp",
+	"F6C2gq9vEL6tGniGBb6QVWgtph9mh3TPJMSSfAa/ORKmG/fIfiCzPVaESm+jVIJEDhWXKa4qJw2L5ypC",
+	"zbs9oZEjG5yFjCNxe2+ywQUeIcVs0VZVfUK1cjC7I6wxte88tgNT2GOJfYMAa/GDTSTwse8WWR3U/9KN",
+	"qOMoifLV+WcUnfYSbFcM8vv7N2g2TPRUSPYfa4EM2uu+fvXHwW4eIFG39nz29JJvAqqJA6YtTA/s72tl",
+	"fx6F7ssB3X76tjGBYXJJaf8dbV8abrhrdOAVJW8DbKsfgT618yABXLieCJ0z/GVwIoh7YhYrUNQ0zizc",
+	"jm2s8JXS6U7Cly5su48u9hq8BJ0Sq2URvvVIC6YQQ+xCSZrqGeTCnS9eXbx9/49BHGIFl7YWBkjl4IVd",
+	"9AGsdkuXhuuQIAKKkQKpCzNaHMTa3sWauRWPUQ5vPV6UeqhqbdBuntjduGsZR3loSzy6QrG2sp8dtKan",
+	"9uFwdnseIwtjs6fWnZKYg5wzuD3QQnd8tfUkUKqx5V20Kwx6tedzSyfttvD9QZ20HuHX1dZKxYSr21Ai",
+	"Jg6vrq/WjdpaPlXqVi4X1/X7u2urajkejSXylsrznQ7P1te5TodnWyDpFUMRFuAQY5+vWm4nynodbpie",
+	"MjyzmcDt1D5MEjyofl1X/U6HZ/0Up++tAC5pfhuTjNf3HjW9bE/lTI+p1liRI0i38oEGO6Byrk2Bjfrn",
+	"tqgwp+M9IkL8AnThHKke9OEDv1jRh9dkGWVasQgh6s8kKNDNsYVTKsNAhBA6S7f7zhtybBOFNYIH0Y77",
+	"zi3e5bDBPKBtAgYLx3Mgl07ECxbvpJ093nzSTBY0ivINBtPIfPv5usG0F3bRzpNDe0I4UECXImZjj19t",
+	"4/ayWvIcbpewe6PsEztht33QFkYEb4Pkk+2hegGCanqzHtFOFJn/Or3eP+3K671cX7dDhiRX2H9trzcy",
+	"pOPP+P+29fz5NhhR3gt+b0a08qi191UVrud2u/1gertsoS3AIRDl6wtE8V0Qaqmxue49t4yG8ck2CC5v",
+	"IfliCO6hDEWbKhcn+1EuCpX0D8rFgZPtJYd2Db1CiWT9x7tdBT8lT2YgleA0YpqBerruQ/4S13/Ycobv",
+	"6KTdOJDp0OUQ41xBwSe+9rHhmT2SG/m0psrgfnKZzDnjEbexQ1hcOJghumOGUI46NrNCZHPkqXTxdH0L",
+	"hEGh7hogDHR7sjzYpatJy/z9YHF41BYHvOIvxOCgLB231QuOP5v/tbc2ZIusb1u4N4tpUWwXN9OyfSBe",
+	"a8FAsMu2Hmbx89ODOv/wlNt9u0QF0bbtyZjTArAl45pRZXuly5PdCupCU8YDuR/IfefJFJW0voYJcm0p",
+	"nDM47praH8psuPaTYMec5mAnPHCavZsJ278GtBAtrIQ+uM0G0RZrXtsVcZ4aa+AVrtP52ngIZhuLmj23",
+	"g0WtOxY17TCsFulHVEHf2rtbFVg247HRV8HdR/4xvHiTE8GhL8qN54OFdUZiXq56/0IVdKDS8kwayDSz",
+	"X+PRqtWj8NiOIsZu3Q4lzLYFXK7pyTTEqsQUnnY3oFJSjNxWMwhKWhX7My+eN7NHTmy19JJeCXk14J92",
+	"7p7f1Z/pcDH6FwS6DM1+WVnza6LtCvztmiK9ihgb54bU0vX/sdgOioxgLCQQReeMTzYheLvmNml+M726",
+	"SO4PTnvlJLddTX1jDnZLJUdMac+ulvZ4L8bSjVyWA6/rLq9zqnxbdldQcG59gz91/Dn92fZdXlf3ST/v",
+	"q0DMIGypDFHEaqJFcZJSZShtR1jHIUuCmQo72zgj7kNhlrs1ezs/Yg0sPd696GIfalbfOZ+8zTXMfOw8",
+	"8pyrZDxmAcMmoCBjphQTXO3MupLdfGeNuXWksbE2uh6nbVZPbyXT0J4RW1C+eF78sJrx1nniQUduw/AP",
+	"2vJBEnTW2L6+MEBdfcGD4yACypNZdX1v32iDRhHB4+cTAlxLBoqMpYiJmQbb2MBqpdsFD166BbpjZBwL",
+	"ORFaA6/mQOkQYrgOOT9Va2m0MShFJyWRTJf25ogf0MSgM1CzSdtwMnfoWaXsFbbVpbJHBlKPWohN9qTz",
+	"7Ql5UEDa9o9H35nwjGk79zJxrDY8NUjb7RaEGYi1LdYL8ss3Cu4uKhi1tvKallChhTLb8sadN3+Ll/4A",
+	"lbhT6Cy0+4o72ADtqtSmjknQtniXsiAbt9kf+aCZeuGJ7XRshRgILXuzwlMi8hAJM6GYFnLRI5HA5uRM",
+	"3fSwVm8mX416nwbdBSKOmR6Uylwb3PcLwtZRdM6B+IDYXBT8Pta2Uuy7AXsW+h7M9UT+OSKV38FeXikv",
+	"KTdasoWBPJklamrwmI4iCHsk4VraPoh4pr0VU+LTnWn15qw6HZabtt5qpQ45XuRUqPVU+U15UQ3fuXBw",
+	"dMLFWEmVL5F/eqJMe3ngWTrWv0KlK0R44E+t+dNFAeG6w6e6GJSfo89WDAD/fvzZ/O88vDvO8mga+IB7",
+	"3pZTP3kyYZrImPyX0zXIfxHD0p+uxRbslgxzMEx3u4UGroxW5c+HMGz7OWYgyROsED2jeoo18USiCXzS",
+	"wFU+g7ZoPbZnt6uqBCsGiaCELl+bX3tpCnPghI3tVqdUuTuIRcjGbh2VUe5ICPOuriX7rTDAnT4/LK+o",
+	"e3ugYN8rb0EIAstgRlBM7zpoNmDeL55i12BobDxuZe0xA8kI9C0AdxRi+JPjbXOQaD3GXtIFOEqNQOYs",
+	"T83Kj45pPaB9wB9abelrc0vV9qivnFDOQFs8doWiNyEXFVAZVisAp3aAFyLBlPIJ6gOGVOYgdeqtdSTj",
+	"gzxWlITSntlUhh4VXtqpDyS0PRnnjpS4Wz4QUFm/bCrDJeTemJrGQjq508LGh2Y64Fou3IJOj8+ZP3pE",
+	"SDQzRizQGUADYmgGQqRCq9alpkIqDc39C7e8avF7jQA+XhV7z+pk5gvsgkKZeQQPhG4RfzOqNjRbTdND",
+	"LWIW0ChaEAkGfbPHMg2kUF5yGiJQC6Uh7pWZzxrexhdi/oAvY+/5fPQvZHOVq+9jz2G38ypGdOmtGtk4",
+	"3J7bcykN1uJwu3L0WjicIlo02tqy+f/8Ql7f5qS68fZGSPbIJrdZG8i7Xg1GNzlfUa8IQSPj7BK/Nvxu",
+	"M249S0YRUzWOVku29gkzS9QUcuVJMgboHjXNr5h3dr2D2XI9DHXHtsfwhPegkkg3MimHT915Ox14xRKv",
+	"cKhUQsU1XMNda59G0VqsYjU8g5yfqgE5t/rEeagIU0TETGvzfvPY4zyp/q0m5LKPuzw6w21tGEVdDc7I",
+	"IOw0KXsc6X6Uo4c09eufDs9ULSLXYfBrsNVh/fNCZUYOKeK8iDtjuk7M2bveBh7uGQ+weHD3kSCKijdV",
+	"pohUoYR5QiaqlRdEzEEazpQGtdlvCeNBlIToVba/EGPkYA4ZS50gl3bZLiOIBbG2IFLuEL6wOFjlz78K",
+	"LzQo3Q8E5xDY6au4xhUoI/WyPA4mOLIQ//Gc6YVXkXOluFvwEDP1ywyEjodNOzAN0A3qkRtJzBkTiXyo",
+	"S4hidkCCHJiiLUdJFMgWNdlJ5AKPDJfAb9Yovv47rvGA14kLmJXa1EmyO378GVOvhRyxMARO+kR+CTWT",
+	"PGblENX+u20NcjOa0CAQCddr1R03+HP0kFXDzQJ7qhpul64mC/N3XzW8E81syRMYTAY9cgv0hsyoUrdC",
+	"hj3C/CgRwdMD+e6s5HhqG+gjfaG5uvsVyFN+UMJMUrF3/Nn8r23J8RbshRTj3hcikQqicVUtcsd21lOR",
+	"fkeQWxYWR+KujoL7mgkIfe+F6zJXtTPDH95Ml8PzKoinuRK4b3+N5DJamEcEk2vVAt8yXZzsVpYWCnsf",
+	"RNRXTUvmAe/pANvglSi2DcW28ftvFGHclvJYt7ff/Ynpoepmr60U75iQO1Hn4+spot1dbnLQs6uSpVtr",
+	"2MfY5b/vn3N1MZQKdI7t+S+IFk6rn9MogZYsEGczF/rOL9wxTogAeuD25WJrjufxEBK8xu6aCQ6GgYPW",
+	"5ah+mYFUsKlbGE2FuFnXBO4/80Gg3nk2IKe+mmuPxJTTiflBSHdBgkeLchv5Bw9HV10mDsC2Vvb0XLto",
+	"Zr7NDtvjRPqrIlocfx6zyFarrfGnSTaZgDQ4cjo8I/AJggTdMHNG/VoDcjW1BRTjRGkypRgA5/6Yc7Jd",
+	"c8pDAhxLJQzIsOikC2EGPFRE2CQc/7lhRNiI98U1HwGVGFt6AxbfeqTwq1mUKPLrxfAloqX5wWLlNb/m",
+	"VxgvYNnrSIQLwiz9QOi9gWYD1PqWP7z65de3b//Xx3fDf7x5OzwlwOdMCh4D19d8TiUzW8DIGf9huktF",
+	"/vLHMhbylsrw4xRoCFL91UsjI665B8X9DZMfHDhLMPz6anj66v1lHgaSgnDNXwtJFB2DXvTws7/MsQrJ",
+	"/oOn+pdbwOyWwxwkcUBBOLBnYoCXCTcDgP87gcQlZ5i5gIczwbgm0jEKFscQMqohWmDwnhl1zUM66Zsp",
+	"zk8H16ulhxwGORpbmwecDs9eOzQ9WrNO5UpM4i95ZBkLWUCyHCo68fuNGx/SSfLxdvpxMBh8kzV9DRG3",
+	"yO0UKhDWRSKAcgsWFxn4UEd7QVmwY+H+ahser+wPMd7DodiEU51I8Glt9o1NvlFT+u33P/x8nZycfBdM",
+	"4RP+AN9ssjFccOnwEC8MjIEmwDGm3eBs5X7/6J/SSdK/9OAWtgyfaDyLcNcW6pNn3373/Psf/vvHn+go",
+	"CGG87r8R/7QGaUD5f27Sf570f6L98bD/+s/PPzy/+58lAesPpCM7qshpx3cPL+dqs1YdO9CWarviNzMc",
+	"e2f67++cOhqEkPTTIhVCpo46JOhe7jfHftAyNlsycuSA5JKjCcN0aaDZHPaiYXvC9tWLzH6M0ptJ7J0p",
+	"3Abtcvx4ryYKTwJewOWCZkM6eZ/w87B71gsIEsn04ujFP/8sBM9YMq7W3WrURCFvGuJnMMSsYL4ldCQS",
+	"bTBKSzZKDJBuHh/Ck+lbgRAyZJxqITd6WriOBjaqoqMPCwtf08NimGOyRKYDe0ff74IlvMzugSiQcxYA",
+	"STidUxYZtrBT5D4DDpIFFrNzR7H61ilBsUIUmNIQ5zDZdunIIXPJMzUb1mV8QhBbP1WzPXXzGvHJmj/4",
+	"lBtlv8zHSJWFOKWn0sVMgyUQ9xQplVu/GmmyMuAuZmq/HqEdSP3fyjwR5UE3tzkkK8XRIqfJ9QNaCcIp",
+	"i5epweG6LhBrZsXdt+dOSRhOhjS7rgL1W6YkltdgaryyXrkwyLdK6vR1nOyLPxTiQPZ41Us9YpYCEZZF",
+	"iI9GqO3H0rULf6gIhc0k0t4wrtDoe7cY1xlZ5JtOt5BFxSehgZddiRvg5n1osHBEFQuGiZ66XxhcM7q/",
+	"x/ml1zmdJGT47pzYIUe9o0RGRy+OPttN3b04Pv48FUrfHdMZO54/O+odeQs14s00dS04/fMIC4vgr5eP",
+	"4VehNMEIAWGt627NuzxdZRNNtZ4d9Y6AJ7E5BfdP8z97Dn+mJ7S8qbeeC9iqSfjqxLb/PLT6j/mHeTeH",
+	"MGac+dqTjgOEZtJVC+zSpC4Ny8w0ZUoLybCkKNUUl4nEBNPTTodnaEBPX+jFhczfyha7xEcOEUsbEZyZ",
+	"ldxW0n2hp8JcZHqJbgX3Vlqd/50UMegpJKpvEJlqNoqAxGZPwcpaOHUGSjZ9Nqb5vAqXkJs8M12ghyI3",
+	"u/v36sxL3qXcIT2JxITxnjl9keies85bq0MMXD/NZqeGQlbnRvdw9kFh8pfvfz/tZaEdpdP6NJ0VmN+d",
+	"kxtYVE2dGUPyIM5Y/wYWZdM5c2/qxrFn7Cy7HrvTo81Jt8y/uXqqIdPm5FoAZoaWTPESuJY0QuNqOgmN",
+	"sLbN6tTOGFS0BeVWwa/KIPW5hVMpuHOmLFOKywhNyYAHZTs+J9irfqlRVvP2sSH66nynIkjwZksvOUf3",
+	"IijbltUPCBchrIUmNmWub75TR3d/3v3/AAAA//+Q3ZCavz4EAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -5138,6 +5138,141 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /settings/workspaces/{workspaceName}/base-config:
+    get:
+      summary: "Get workspace base configuration"
+      description: "Returns the workspace-scoped base DAG configuration YAML. Requires access to the workspace."
+      operationId: "getWorkspaceBaseConfig"
+      tags:
+        - "settings"
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/RemoteNode"
+      responses:
+        "200":
+          description: "Workspace base configuration"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  spec:
+                    type: string
+                    description: "The workspace base configuration in YAML format"
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                    description: "List of validation errors in the configuration"
+                required:
+                  - spec
+                  - errors
+        "400":
+          description: "Invalid workspace"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: "Not authenticated"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Workspace not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: "Unexpected error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    put:
+      summary: "Update workspace base configuration"
+      description: "Updates the workspace-scoped base DAG configuration YAML. Validates before saving. Requires write access to the workspace."
+      operationId: "updateWorkspaceBaseConfig"
+      tags:
+        - "settings"
+      parameters:
+        - name: workspaceName
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/RemoteNode"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                spec:
+                  type: string
+                  description: "The workspace base configuration in YAML format"
+              required:
+                - spec
+      responses:
+        "200":
+          description: "Workspace base configuration updated successfully"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+                    description: "List of validation warnings"
+                required:
+                  - errors
+        "400":
+          description: "Invalid configuration"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: "Not authenticated"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: "Workspace not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: "Unexpected error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /settings/agent:
     get:
       summary: "Get agent configuration"
@@ -10229,6 +10364,7 @@ components:
       description: "Type of sync item"
       enum:
         - dag
+        - config
         - memory
         - skill
         - soul

--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -5150,7 +5150,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: "#/components/schemas/WorkspaceName"
         - $ref: "#/components/parameters/RemoteNode"
       responses:
         "200":
@@ -5213,7 +5213,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: "#/components/schemas/WorkspaceName"
         - $ref: "#/components/parameters/RemoteNode"
       requestBody:
         required: true

--- a/internal/agentsnapshot/dispatch.go
+++ b/internal/agentsnapshot/dispatch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/fileagentmodel"
 	"github.com/dagucloud/dagu/internal/persis/fileagentsoul"
 	"github.com/dagucloud/dagu/internal/persis/filememory"
+	"github.com/dagucloud/dagu/internal/workspace"
 )
 
 // BuildFromPaths builds a worker snapshot from fresh filesystem-backed stores.
@@ -28,7 +29,10 @@ func BuildFromPaths(
 	var resolve agent.DAGResolver
 	if dagStore != nil {
 		resolve = func(ctx context.Context, name string) (*core.DAG, error) {
-			loadOpts := []spec.LoadOption{spec.WithBaseConfig(paths.BaseConfig)}
+			loadOpts := []spec.LoadOption{
+				spec.WithBaseConfig(paths.BaseConfig),
+				spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(paths.DAGsDir)),
+			}
 			return dagStore.GetDetails(ctx, name, loadOpts...)
 		}
 	}

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -58,6 +58,7 @@ import (
 	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -745,6 +746,7 @@ func (c *Context) dagStore(cfg dagStoreConfig) (exec.DAGStore, error) {
 		filedag.WithFlagsBaseDir(c.Config.Paths.SuspendFlagsDir),
 		filedag.WithSearchPaths(searchPaths),
 		filedag.WithBaseConfig(c.Config.Paths.BaseConfig),
+		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(c.Config.Paths.DAGsDir)),
 		filedag.WithFileCache(cfg.Cache),
 		filedag.WithSkipExamples(c.Config.Core.SkipExamples),
 		filedag.WithSkipDirectoryCreation(cfg.SkipDirectoryCreation),

--- a/internal/cmd/dry.go
+++ b/internal/cmd/dry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -111,6 +112,7 @@ func runDry(ctx *Context, args []string) error {
 func loadDAGForDryRun(ctx *Context, args []string) (*core.DAG, error) {
 	loadOpts := []spec.LoadOption{
 		spec.WithBaseConfig(ctx.Config.Paths.BaseConfig),
+		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(ctx.Config.Paths.DAGsDir)),
 		spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
 	}
 

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/agent"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/spf13/cobra"
 )
@@ -300,6 +301,7 @@ func loadDAGWithParams(ctx *Context, args []string, isSubDAGRun bool) (*core.DAG
 
 	loadOpts := []spec.LoadOption{
 		spec.WithBaseConfig(ctx.Config.Paths.BaseConfig),
+		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(ctx.Config.Paths.DAGsDir)),
 		spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
 	}
 

--- a/internal/cmd/stop.go
+++ b/internal/cmd/stop.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +76,11 @@ func runStop(ctx *Context, args []string) error {
 		}
 		dag = d
 	} else {
-		d, err := spec.Load(ctx, args[0], spec.WithBaseConfig(ctx.Config.Paths.BaseConfig))
+		d, err := spec.Load(ctx, args[0],
+			spec.WithBaseConfig(ctx.Config.Paths.BaseConfig),
+			spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(ctx.Config.Paths.DAGsDir)),
+			spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)
 		}

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -670,5 +670,5 @@ func newSyncService(ctx *Context) (gitsync.Service, error) {
 	if !syncCfg.Enabled {
 		return nil, fmt.Errorf("git sync is not enabled, set gitSync.enabled=true in your config")
 	}
-	return gitsync.NewService(syncCfg, ctx.Config.Paths.DAGsDir, ctx.Config.Paths.DataDir), nil
+	return gitsync.NewService(syncCfg, ctx.Config.Paths.DAGsDir, ctx.Config.Paths.DataDir, ctx.Config.Paths.BaseConfig), nil
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,7 @@ func runValidate(ctx *Context, args []string) error {
 	loadOpts := []spec.LoadOption{
 		spec.WithoutEval(),
 		spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
+		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(ctx.Config.Paths.DAGsDir)),
 	}
 	if ctx.Config.Paths.BaseConfig != "" {
 		loadOpts = append(loadOpts, spec.WithBaseConfig(ctx.Config.Paths.BaseConfig))

--- a/internal/core/spec/builder.go
+++ b/internal/core/spec/builder.go
@@ -103,6 +103,8 @@ type BuildOpts struct {
 	// BaseConfigContent is the raw base config YAML content.
 	// When set, this takes precedence over Base file path.
 	BaseConfigContent []byte
+	// WorkspaceBaseConfigDir contains per-workspace base configs at <workspace>/base.yaml.
+	WorkspaceBaseConfigDir string
 	// Parameters specifies the Parameters to the DAG.
 	// Parameters are used to override the default Parameters in the DAG.
 	Parameters string

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -417,9 +417,25 @@ func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *d
 		return nil, err
 	}
 
+	fileBaseDef, fileBaseRaw := baseDef, baseRaw
+	if len(docs) > 0 {
+		fileBaseDef, fileBaseRaw, err = loadEffectiveBaseDefinition(ctx.opts, docs[0].data, baseDef, baseRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process document %d: %w", docs[0].index, err)
+		}
+	}
+
 	dags := make([]*core.DAG, 0, len(docs))
 	for _, doc := range docs {
-		dag, err := processDAGDocument(buildDocumentContext(ctx, doc.index), doc.data, baseDef, baseRaw, filePath, data)
+		docBaseDef, docBaseRaw := fileBaseDef, fileBaseRaw
+		if doc.index == 0 || workspaceNameFromDocument(doc.data) != "" {
+			docBaseDef, docBaseRaw, err = loadEffectiveBaseDefinition(ctx.opts, doc.data, baseDef, baseRaw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process document %d: %w", doc.index, err)
+			}
+		}
+
+		dag, err := processDAGDocument(buildDocumentContext(ctx, doc.index), doc.data, docBaseDef, docBaseRaw, filePath, data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process document %d: %w", doc.index, err)
 		}
@@ -512,23 +528,18 @@ func processDAGDocument(
 	filePath string,
 	fullData []byte,
 ) (*core.DAG, error) {
-	effectiveBaseDef, effectiveBaseRaw, err := loadEffectiveBaseDefinition(ctx.opts, doc, baseDef, baseRaw)
-	if err != nil {
-		return nil, err
-	}
-
 	spec, err := decode(doc)
 	if err != nil {
 		return nil, err
 	}
 
-	docCtx, dest, err := prepareDocumentContext(ctx, effectiveBaseDef, spec)
+	docCtx, dest, err := prepareDocumentContext(ctx, baseDef, spec)
 	if err != nil {
 		return nil, err
 	}
 
-	if shouldInheritType(doc, effectiveBaseDef, spec) {
-		spec.Type = effectiveBaseDef.Type
+	if shouldInheritType(doc, baseDef, spec) {
+		spec.Type = baseDef.Type
 	}
 
 	dag, err := spec.build(docCtx)
@@ -538,8 +549,8 @@ func processDAGDocument(
 	if err := merge(dest, dag); err != nil {
 		return nil, err
 	}
-	if len(effectiveBaseRaw) > 0 {
-		dest.BaseConfigData = effectiveBaseRaw
+	if len(baseRaw) > 0 {
+		dest.BaseConfigData = baseRaw
 	}
 	applyHistoryRetentionOverride(dest, spec.HistRetentionDays != nil, spec.HistRetentionRuns != nil)
 
@@ -656,7 +667,10 @@ func mergeBaseDefinitionData(baseRaw, overrideRaw []byte) (*dag, []byte, error) 
 		return nil, nil, fmt.Errorf("failed to unmarshal workspace base config: %w", err)
 	}
 
-	mergedMap := mergeDefinitionMaps(baseMap, overrideMap)
+	mergedMap, err := mergeDefinitionMaps(baseMap, overrideMap)
+	if err != nil {
+		return nil, nil, err
+	}
 	def, err := decode(mergedMap)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode merged base config: %w", err)
@@ -669,22 +683,56 @@ func mergeBaseDefinitionData(baseRaw, overrideRaw []byte) (*dag, []byte, error) 
 	return def, mergedRaw, nil
 }
 
-func mergeDefinitionMaps(base, override map[string]any) map[string]any {
+func mergeDefinitionMaps(base, override map[string]any) (map[string]any, error) {
 	merged := cloneMap(base)
 	if merged == nil {
 		merged = make(map[string]any, len(override))
 	}
 	for key, overrideValue := range override {
 		baseValue, ok := merged[key]
+		if key == "env" {
+			mergedEnv, err := mergeBaseEnvRaw(baseValue, overrideValue)
+			if err != nil {
+				return nil, err
+			}
+			merged[key] = mergedEnv
+			continue
+		}
+
 		baseMap, baseIsMap := baseValue.(map[string]any)
 		overrideMap, overrideIsMap := overrideValue.(map[string]any)
 		if ok && baseIsMap && overrideIsMap {
-			merged[key] = mergeDefinitionMaps(baseMap, overrideMap)
+			mergedNested, err := mergeDefinitionMaps(baseMap, overrideMap)
+			if err != nil {
+				return nil, err
+			}
+			merged[key] = mergedNested
 			continue
 		}
 		merged[key] = cloneAny(overrideValue)
 	}
-	return merged
+	return merged, nil
+}
+
+func mergeBaseEnvRaw(base, override any) (any, error) {
+	switch {
+	case base == nil:
+		return cloneAny(override), nil
+	case override == nil:
+		return cloneAny(base), nil
+	}
+
+	baseEnv, err := decodeViaYAML[types.EnvValue](base)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base config env: %w", err)
+	}
+	overrideEnv, err := decodeViaYAML[types.EnvValue](override)
+	if err != nil {
+		return nil, fmt.Errorf("invalid workspace base config env: %w", err)
+	}
+
+	combined := overrideEnv.Prepend(baseEnv)
+	return envValueToRaw(combined), nil
 }
 
 // buildDocumentContext applies per-document overrides for multi-DAG files.

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec/types"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/goccy/go-yaml"
@@ -32,15 +33,16 @@ var (
 
 // LoadOptions contains options for loading a DAG.
 type LoadOptions struct {
-	name              string   // Name of the DAG.
-	baseConfig        string   // Path to the base core.DAG configuration file.
-	baseConfigContent []byte   // Raw base config YAML content (used when file is unavailable, e.g., distributed mode).
-	params            string   // Parameters to override default parameters in the DAG.
-	paramsList        []string // List of parameters to override default parameters in the DAG.
-	flags             BuildFlag
-	dagsDir           string            // Directory containing the core.DAG files.
-	defaultWorkingDir string            // Default working directory for DAGs without explicit workingDir.
-	buildEnv          map[string]string // Pre-populated env vars for build (used for retry with dotenv).
+	name                   string   // Name of the DAG.
+	baseConfig             string   // Path to the base core.DAG configuration file.
+	baseConfigContent      []byte   // Raw base config YAML content (used when file is unavailable, e.g., distributed mode).
+	workspaceBaseConfigDir string   // Directory containing workspace base configs (<workspace>/base.yaml).
+	params                 string   // Parameters to override default parameters in the DAG.
+	paramsList             []string // List of parameters to override default parameters in the DAG.
+	flags                  BuildFlag
+	dagsDir                string            // Directory containing the core.DAG files.
+	defaultWorkingDir      string            // Default working directory for DAGs without explicit workingDir.
+	buildEnv               map[string]string // Pre-populated env vars for build (used for retry with dotenv).
 }
 
 // LoadOption is a function type for setting LoadOptions.
@@ -59,6 +61,14 @@ func WithBaseConfig(baseDAG string) LoadOption {
 func WithBaseConfigContent(content []byte) LoadOption {
 	return func(o *LoadOptions) {
 		o.baseConfigContent = content
+	}
+}
+
+// WithWorkspaceBaseConfigDir sets the directory containing workspace base configs.
+// Named workspace DAGs inherit <dir>/<workspace>/base.yaml after the global base config.
+func WithWorkspaceBaseConfigDir(dir string) LoadOption {
+	return func(o *LoadOptions) {
+		o.workspaceBaseConfigDir = dir
 	}
 }
 
@@ -184,15 +194,16 @@ func Load(ctx context.Context, nameOrPath string, opts ...LoadOption) (*core.DAG
 	buildContext := BuildContext{
 		ctx: ctx,
 		opts: BuildOpts{
-			Base:              options.baseConfig,
-			BaseConfigContent: options.baseConfigContent,
-			Parameters:        options.params,
-			ParametersList:    options.paramsList,
-			Name:              options.name,
-			DAGsDir:           options.dagsDir,
-			DefaultWorkingDir: options.defaultWorkingDir,
-			Flags:             options.flags,
-			BuildEnv:          options.buildEnv,
+			Base:                   options.baseConfig,
+			BaseConfigContent:      options.baseConfigContent,
+			WorkspaceBaseConfigDir: options.workspaceBaseConfigDir,
+			Parameters:             options.params,
+			ParametersList:         options.paramsList,
+			Name:                   options.name,
+			DAGsDir:                options.dagsDir,
+			DefaultWorkingDir:      options.defaultWorkingDir,
+			Flags:                  options.flags,
+			BuildEnv:               options.buildEnv,
 		},
 	}
 	return loadDAG(buildContext, nameOrPath)
@@ -205,15 +216,16 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*core.DAG, 
 		opt(&options)
 	}
 	return LoadYAMLWithOpts(ctx, data, BuildOpts{
-		Base:              options.baseConfig,
-		BaseConfigContent: options.baseConfigContent,
-		Parameters:        options.params,
-		ParametersList:    options.paramsList,
-		Name:              options.name,
-		DAGsDir:           options.dagsDir,
-		DefaultWorkingDir: options.defaultWorkingDir,
-		Flags:             options.flags,
-		BuildEnv:          options.buildEnv,
+		Base:                   options.baseConfig,
+		BaseConfigContent:      options.baseConfigContent,
+		WorkspaceBaseConfigDir: options.workspaceBaseConfigDir,
+		Parameters:             options.params,
+		ParametersList:         options.paramsList,
+		Name:                   options.name,
+		DAGsDir:                options.dagsDir,
+		DefaultWorkingDir:      options.defaultWorkingDir,
+		Flags:                  options.flags,
+		BuildEnv:               options.buildEnv,
 	})
 }
 
@@ -224,7 +236,7 @@ func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.D
 		return loadYAMLFailure(opts, err)
 	}
 
-	dags, err := loadDAGsFromData(BuildContext{ctx: ctx, opts: opts}, data, "", baseDef)
+	dags, err := loadDAGsFromData(BuildContext{ctx: ctx, opts: opts}, data, "", baseDef, baseRaw)
 	if err != nil {
 		return loadYAMLFailure(opts, err)
 	}
@@ -235,9 +247,6 @@ func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.D
 	}
 
 	mainDAG.YamlData = data
-	if len(baseRaw) > 0 {
-		mainDAG.BaseConfigData = baseRaw
-	}
 
 	return mainDAG, nil
 }
@@ -310,7 +319,7 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 		return loadDAGFailure(ctx, filePath, err)
 	}
 
-	dags, err := loadDAGsFromFile(ctx, filePath, baseDef)
+	dags, err := loadDAGsFromFile(ctx, filePath, baseDef, baseRaw)
 	if err != nil {
 		return loadDAGFailure(ctx, filePath, err)
 	}
@@ -318,10 +327,6 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 	mainDAG, err := assembleLoadedDAGs(dags, fmt.Errorf("no DAGs found in file %q", filePath))
 	if err != nil {
 		return loadDAGFailure(ctx, filePath, err)
-	}
-
-	if len(baseRaw) > 0 {
-		mainDAG.BaseConfigData = baseRaw
 	}
 
 	core.InitializeDefaults(mainDAG)
@@ -392,12 +397,12 @@ func applyWorkingDirFallback(dag *core.DAG, filePath string) error {
 }
 
 // loadDAGsFromFile loads all DAGs from a multi-document YAML file.
-func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag) ([]*core.DAG, error) {
+func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
 	data, err := os.ReadFile(filePath) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
 	}
-	return loadDAGsFromData(ctx, data, filePath, baseDef)
+	return loadDAGsFromData(ctx, data, filePath, baseDef, baseRaw)
 }
 
 type dagDocument struct {
@@ -406,7 +411,7 @@ type dagDocument struct {
 }
 
 // loadDAGsFromData builds DAGs from every non-empty YAML document in the input.
-func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *dag) ([]*core.DAG, error) {
+func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
 	docs, err := decodeDocuments(data)
 	if err != nil {
 		return nil, err
@@ -414,7 +419,7 @@ func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *d
 
 	dags := make([]*core.DAG, 0, len(docs))
 	for _, doc := range docs {
-		dag, err := processDAGDocument(buildDocumentContext(ctx, doc.index), doc.data, baseDef, filePath, data)
+		dag, err := processDAGDocument(buildDocumentContext(ctx, doc.index), doc.data, baseDef, baseRaw, filePath, data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process document %d: %w", doc.index, err)
 		}
@@ -503,21 +508,27 @@ func processDAGDocument(
 	ctx BuildContext,
 	doc map[string]any,
 	baseDef *dag,
+	baseRaw []byte,
 	filePath string,
 	fullData []byte,
 ) (*core.DAG, error) {
+	effectiveBaseDef, effectiveBaseRaw, err := loadEffectiveBaseDefinition(ctx.opts, doc, baseDef, baseRaw)
+	if err != nil {
+		return nil, err
+	}
+
 	spec, err := decode(doc)
 	if err != nil {
 		return nil, err
 	}
 
-	docCtx, dest, err := prepareDocumentContext(ctx, baseDef, spec)
+	docCtx, dest, err := prepareDocumentContext(ctx, effectiveBaseDef, spec)
 	if err != nil {
 		return nil, err
 	}
 
-	if shouldInheritType(doc, baseDef, spec) {
-		spec.Type = baseDef.Type
+	if shouldInheritType(doc, effectiveBaseDef, spec) {
+		spec.Type = effectiveBaseDef.Type
 	}
 
 	dag, err := spec.build(docCtx)
@@ -526,6 +537,9 @@ func processDAGDocument(
 	}
 	if err := merge(dest, dag); err != nil {
 		return nil, err
+	}
+	if len(effectiveBaseRaw) > 0 {
+		dest.BaseConfigData = effectiveBaseRaw
 	}
 	applyHistoryRetentionOverride(dest, spec.HistRetentionDays != nil, spec.HistRetentionRuns != nil)
 
@@ -536,6 +550,141 @@ func processDAGDocument(
 		return nil, err
 	}
 	return dest, nil
+}
+
+// loadEffectiveBaseDefinition returns the base definition that applies to a document.
+// Embedded base configs are already effective for distributed workers, so local
+// workspace config files are only considered when loading from filesystem state.
+func loadEffectiveBaseDefinition(opts BuildOpts, doc map[string]any, baseDef *dag, baseRaw []byte) (*dag, []byte, error) {
+	workspaceRaw, err := readWorkspaceBaseDefinitionData(opts, doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(workspaceRaw) == 0 {
+		return baseDef, baseRaw, nil
+	}
+	return mergeBaseDefinitionData(baseRaw, workspaceRaw)
+}
+
+// readWorkspaceBaseDefinitionData returns raw per-workspace base config data for a named workspace DAG.
+func readWorkspaceBaseDefinitionData(opts BuildOpts, doc map[string]any) ([]byte, error) {
+	if opts.Has(BuildFlagOnlyMetadata) || opts.WorkspaceBaseConfigDir == "" || len(opts.BaseConfigContent) > 0 {
+		return nil, nil
+	}
+
+	workspaceName := workspaceNameFromDocument(doc)
+	if workspaceName == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(opts.WorkspaceBaseConfigDir, workspaceName, workspace.BaseConfigFileName)) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read workspace base config %q: %w", workspaceName, err)
+	}
+	return data, nil
+}
+
+func workspaceNameFromDocument(doc map[string]any) string {
+	for _, key := range []string{"labels", "tags"} {
+		labels, ok := labelsValueFromRaw(doc[key])
+		if !ok {
+			continue
+		}
+
+		var workspaceName string
+		for _, entry := range labels.Entries() {
+			labelKey := strings.ToLower(strings.TrimSpace(entry.Key()))
+			if labelKey != "workspace" {
+				continue
+			}
+
+			value := strings.TrimSpace(entry.Value())
+			if err := workspace.ValidateName(value); err != nil {
+				return ""
+			}
+			if workspaceName != "" && !strings.EqualFold(workspaceName, value) {
+				return ""
+			}
+			workspaceName = value
+		}
+		if workspaceName != "" {
+			return workspaceName
+		}
+	}
+	return ""
+}
+
+func labelsValueFromRaw(raw any) (types.LabelsValue, bool) {
+	if raw == nil {
+		return types.LabelsValue{}, false
+	}
+
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return types.LabelsValue{}, false
+	}
+
+	var labels types.LabelsValue
+	if err := yaml.Unmarshal(data, &labels); err != nil {
+		return types.LabelsValue{}, false
+	}
+	if labels.IsZero() {
+		return types.LabelsValue{}, false
+	}
+	return labels, true
+}
+
+func mergeBaseDefinitionData(baseRaw, overrideRaw []byte) (*dag, []byte, error) {
+	if len(baseRaw) == 0 {
+		def, err := decodeDefinitionData(overrideRaw, "workspace base config")
+		return def, overrideRaw, err
+	}
+	if len(overrideRaw) == 0 {
+		def, err := decodeDefinitionData(baseRaw, "base config")
+		return def, baseRaw, err
+	}
+
+	baseMap, err := unmarshalData(baseRaw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal base config: %w", err)
+	}
+	overrideMap, err := unmarshalData(overrideRaw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal workspace base config: %w", err)
+	}
+
+	mergedMap := mergeDefinitionMaps(baseMap, overrideMap)
+	def, err := decode(mergedMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode merged base config: %w", err)
+	}
+
+	mergedRaw, err := yaml.Marshal(mergedMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal merged base config: %w", err)
+	}
+	return def, mergedRaw, nil
+}
+
+func mergeDefinitionMaps(base, override map[string]any) map[string]any {
+	merged := cloneMap(base)
+	if merged == nil {
+		merged = make(map[string]any, len(override))
+	}
+	for key, overrideValue := range override {
+		baseValue, ok := merged[key]
+		baseMap, baseIsMap := baseValue.(map[string]any)
+		overrideMap, overrideIsMap := overrideValue.(map[string]any)
+		if ok && baseIsMap && overrideIsMap {
+			merged[key] = mergeDefinitionMaps(baseMap, overrideMap)
+			continue
+		}
+		merged[key] = cloneAny(overrideValue)
+	}
+	return merged
 }
 
 // buildDocumentContext applies per-document overrides for multi-DAG files.

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -722,6 +722,91 @@ steps:
 		assert.Contains(t, dag.Env, "SOURCE=embedded")
 	})
 
+	t.Run("WithWorkspaceBaseConfigDir_MergesNamedWorkspaceConfig", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		globalBase := filepath.Join(root, "base.yaml")
+		require.NoError(t, os.WriteFile(globalBase, []byte(`
+env:
+  GLOBAL_ONLY: "global"
+  SHARED: "global"
+log_dir: "/global/logs"
+hist_retention_days: 30
+`), 0600))
+
+		workspaceConfigDir := filepath.Join(root, "workspaces")
+		require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(workspaceConfigDir, "ops", "base.yaml"), []byte(`
+env:
+  WORKSPACE_ONLY: "ops"
+  SHARED: "workspace"
+log_dir: "/workspace/logs"
+max_active_steps: 7
+`), 0600))
+
+		childDAG := createTempYAMLFile(t, `
+labels:
+  - workspace=ops
+env:
+  DAG_ONLY: "dag"
+steps:
+  - name: "step1"
+    command: echo "step1"
+`)
+
+		dag, err := spec.Load(context.Background(), childDAG,
+			spec.WithBaseConfig(globalBase),
+			spec.WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		)
+		require.NoError(t, err)
+
+		assert.Contains(t, dag.Env, "GLOBAL_ONLY=global")
+		assert.Contains(t, dag.Env, "WORKSPACE_ONLY=ops")
+		assert.Contains(t, dag.Env, "DAG_ONLY=dag")
+		assert.Contains(t, dag.Env, "SHARED=workspace")
+		assert.Equal(t, "/workspace/logs", dag.LogDir)
+		assert.Equal(t, 30, dag.HistRetentionDays)
+		assert.Equal(t, 7, dag.MaxActiveSteps)
+		assert.Contains(t, string(dag.BaseConfigData), "WORKSPACE_ONLY")
+	})
+
+	t.Run("WithWorkspaceBaseConfigDir_IgnoresDefaultWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		globalBase := filepath.Join(root, "base.yaml")
+		require.NoError(t, os.WriteFile(globalBase, []byte(`
+env:
+  GLOBAL_ONLY: "global"
+log_dir: "/global/logs"
+`), 0600))
+
+		workspaceConfigDir := filepath.Join(root, "workspaces")
+		require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "default"), 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(workspaceConfigDir, "default", "base.yaml"), []byte(`
+env:
+  SHOULD_NOT_APPLY: "default"
+log_dir: "/default/logs"
+`), 0600))
+
+		childDAG := createTempYAMLFile(t, `
+steps:
+  - name: "step1"
+    command: echo "step1"
+`)
+
+		dag, err := spec.Load(context.Background(), childDAG,
+			spec.WithBaseConfig(globalBase),
+			spec.WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		)
+		require.NoError(t, err)
+
+		assert.Contains(t, dag.Env, "GLOBAL_ONLY=global")
+		assert.NotContains(t, dag.Env, "SHOULD_NOT_APPLY=default")
+		assert.Equal(t, "/global/logs", dag.LogDir)
+	})
+
 	t.Run("OverrideBaseConfig", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/harness"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -771,6 +772,44 @@ steps:
 		assert.Contains(t, string(dag.BaseConfigData), "WORKSPACE_ONLY")
 	})
 
+	t.Run("WithWorkspaceBaseConfigDir_MergesListSyntaxEnv", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		globalBase := filepath.Join(root, "base.yaml")
+		require.NoError(t, os.WriteFile(globalBase, []byte(`
+env:
+  - GLOBAL_ONLY=global
+  - SHARED=global
+`), 0600))
+
+		workspaceConfigDir := filepath.Join(root, "workspaces")
+		require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(workspaceConfigDir, "ops", "base.yaml"), []byte(`
+env:
+  - WORKSPACE_ONLY=ops
+  - SHARED=workspace
+`), 0600))
+
+		childDAG := createTempYAMLFile(t, `
+labels:
+  - workspace=ops
+steps:
+  - name: "step1"
+    command: echo "step1"
+`)
+
+		dag, err := spec.Load(context.Background(), childDAG,
+			spec.WithBaseConfig(globalBase),
+			spec.WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		)
+		require.NoError(t, err)
+
+		assert.Contains(t, dag.Env, "GLOBAL_ONLY=global")
+		assert.Contains(t, dag.Env, "WORKSPACE_ONLY=ops")
+		assert.Contains(t, dag.Env, "SHARED=workspace")
+	})
+
 	t.Run("WithWorkspaceBaseConfigDir_IgnoresDefaultWorkspace", func(t *testing.T) {
 		t.Parallel()
 
@@ -1413,6 +1452,57 @@ steps:
 	assert.Equal(t, dagFile, childDAG.SourceFile)
 	assert.Contains(t, string(childDAG.YamlData), "name: child-task")
 	assert.NotContains(t, string(childDAG.YamlData), "call: child-task")
+}
+
+func TestLoad_MultiDocumentFilePropagatesWorkspaceBaseConfig(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	globalBase := filepath.Join(root, "base.yaml")
+	require.NoError(t, os.WriteFile(globalBase, []byte(`
+env:
+  GLOBAL_ONLY: "global"
+  SHARED: "global"
+`), 0600))
+
+	workspaceConfigDir := workspace.BaseConfigDir(root)
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+	require.NoError(t, os.WriteFile(workspace.BaseConfigPath(root, "ops"), []byte(`
+env:
+  WORKSPACE_ONLY: "ops"
+  SHARED: "workspace"
+`), 0600))
+
+	dagFile := filepath.Join(root, "parent.yaml")
+	require.NoError(t, os.WriteFile(dagFile, []byte(`
+labels:
+  - workspace=ops
+steps:
+  - name: call-child
+    call: child-task
+
+---
+name: child-task
+steps:
+  - name: work
+    command: echo "child"
+`), 0600))
+
+	dag, err := spec.Load(context.Background(), dagFile,
+		spec.WithBaseConfig(globalBase),
+		spec.WithWorkspaceBaseConfigDir(workspaceConfigDir),
+	)
+	require.NoError(t, err)
+
+	childDAG, ok := dag.LocalDAGs["child-task"]
+	require.True(t, ok)
+
+	assert.Contains(t, dag.Env, "WORKSPACE_ONLY=ops")
+	assert.Contains(t, dag.Env, "SHARED=workspace")
+	assert.Contains(t, childDAG.Env, "GLOBAL_ONLY=global")
+	assert.Contains(t, childDAG.Env, "WORKSPACE_ONLY=ops")
+	assert.Contains(t, childDAG.Env, "SHARED=workspace")
+	assert.Contains(t, string(childDAG.BaseConfigData), "WORKSPACE_ONLY")
 }
 
 func TestLoadYAMLWithOpts_TypeInheritanceInMultiDocumentYAML(t *testing.T) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/fileserviceregistry"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/spf13/viper"
 )
 
@@ -193,6 +194,7 @@ func newDAGStore(cfg *config.Config, searchPaths []string, skipDirectoryCreation
 		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
 		filedag.WithSearchPaths(searchPaths),
 		filedag.WithBaseConfig(cfg.Paths.BaseConfig),
+		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
 		filedag.WithSkipExamples(cfg.Core.SkipExamples),
 		filedag.WithSkipDirectoryCreation(skipDirectoryCreation),
 	)

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -38,6 +38,7 @@ import (
 	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
@@ -256,6 +257,7 @@ func (e *Engine) loadYAML(ctx context.Context, data []byte, opts RunOptions) (*c
 func (e *Engine) loadOptions(opts RunOptions) []spec.LoadOption {
 	loadOpts := []spec.LoadOption{
 		spec.WithBaseConfig(e.cfg.Paths.BaseConfig),
+		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(e.cfg.Paths.DAGsDir)),
 		spec.WithDAGsDir(e.cfg.Paths.DAGsDir),
 	}
 	if opts.Name != "" {

--- a/internal/gitsync/service.go
+++ b/internal/gitsync/service.go
@@ -521,7 +521,7 @@ func (s *serviceImpl) scanConfigFiles(state *State) {
 		if !entry.IsDir() || workspace.ValidateName(entry.Name()) != nil {
 			continue
 		}
-		itemID := path.Join(workspace.BaseConfigDirName, entry.Name(), strings.TrimSuffix(workspace.BaseConfigFileName, ".yaml"))
+		itemID := path.Join(workspace.BaseConfigDirName, entry.Name(), workspace.BaseConfigStem())
 		s.scanConfigFile(state, itemID, workspace.BaseConfigPath(s.dagsDir, entry.Name()), DAGKindConfig)
 	}
 }

--- a/internal/gitsync/service.go
+++ b/internal/gitsync/service.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dagucloud/dagu/internal/workspace"
 )
 
 // Service defines the interface for Git sync operations.
@@ -154,6 +156,7 @@ func fileExtensionForID(id string) string {
 type serviceImpl struct {
 	cfg          *Config
 	dagsDir      string
+	baseConfig   string
 	dataDir      string
 	stateManager *StateManager
 	gitClient    *GitClient
@@ -163,11 +166,16 @@ type serviceImpl struct {
 }
 
 // NewService creates a new Git sync service.
-func NewService(cfg *Config, dagsDir, dataDir string) Service {
+func NewService(cfg *Config, dagsDir, dataDir string, baseConfigPath ...string) Service {
 	repoPath := filepath.Join(dataDir, "gitsync", "repo")
+	baseConfig := ""
+	if len(baseConfigPath) > 0 {
+		baseConfig = baseConfigPath[0]
+	}
 	return &serviceImpl{
 		cfg:          cfg,
 		dagsDir:      dagsDir,
+		baseConfig:   baseConfig,
 		dataDir:      dataDir,
 		stateManager: NewStateManager(dataDir),
 		gitClient:    NewGitClient(cfg, repoPath),
@@ -453,6 +461,9 @@ func (s *serviceImpl) scanLocalDAGs(state *State) error {
 		}
 
 		dagID := strings.TrimSuffix(entry.Name(), ext)
+		if isConfigFile(dagID) {
+			continue
+		}
 
 		// Skip if already tracked
 		if _, exists := state.DAGs[dagID]; exists {
@@ -491,7 +502,54 @@ func (s *serviceImpl) scanLocalDAGs(state *State) error {
 	// Scan docs directory for .md files
 	s.scanDocFiles(state)
 
+	// Scan global and workspace base config files
+	s.scanConfigFiles(state)
+
 	return nil
+}
+
+// scanConfigFiles scans global and workspace base config files and adds them as untracked.
+func (s *serviceImpl) scanConfigFiles(state *State) {
+	s.scanConfigFile(state, baseConfigID, s.resolveBaseConfigPath(), DAGKindConfig)
+
+	workspaceConfigDir := workspace.BaseConfigDir(s.dagsDir)
+	entries, err := os.ReadDir(workspaceConfigDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || workspace.ValidateName(entry.Name()) != nil {
+			continue
+		}
+		itemID := path.Join(workspace.BaseConfigDirName, entry.Name(), strings.TrimSuffix(workspace.BaseConfigFileName, ".yaml"))
+		s.scanConfigFile(state, itemID, workspace.BaseConfigPath(s.dagsDir, entry.Name()), DAGKindConfig)
+	}
+}
+
+func (s *serviceImpl) scanConfigFile(state *State, itemID, filePath string, kind DAGKind) {
+	if filePath == "" {
+		return
+	}
+	if _, exists := state.DAGs[itemID]; exists {
+		return
+	}
+
+	content, err := os.ReadFile(filePath) //nolint:gosec // path configured by server
+	if err != nil {
+		return
+	}
+
+	now := time.Now()
+	ds := &DAGState{
+		Status:     StatusUntracked,
+		Kind:       kind,
+		LocalHash:  ComputeContentHash(content),
+		ModifiedAt: &now,
+	}
+	if fi, err := os.Stat(filePath); err == nil {
+		updateStatCache(ds, fi)
+	}
+	state.DAGs[itemID] = ds
 }
 
 // scanMemoryFiles scans the memory directory for .md files and adds them as untracked.
@@ -1428,6 +1486,12 @@ func (s *serviceImpl) Move(ctx context.Context, oldID, newID, message string, fo
 			Message: fmt.Sprintf("cannot move across kinds: source is %s, destination is %s", oldKind, newKind),
 		}
 	}
+	if oldKind == DAGKindConfig {
+		return &ValidationError{
+			Field:   "itemId",
+			Message: "config items cannot be moved",
+		}
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1987,6 +2051,12 @@ func (s *serviceImpl) dagIDToFilePath(dagID string) string {
 		dagID = decoded
 	}
 	dagID = normalizeDAGIDSeparators(dagID)
+	if dagID == baseConfigID {
+		return s.resolveBaseConfigPath()
+	}
+	if workspaceName, ok := workspaceBaseConfigNameFromID(dagID); ok {
+		return workspace.BaseConfigPath(s.dagsDir, workspaceName)
+	}
 	ext := fileExtensionForID(dagID)
 	return filepath.Join(s.dagsDir, filepath.FromSlash(dagID+ext))
 }
@@ -2015,6 +2085,13 @@ func decodeDAGID(dagID string) (string, error) {
 		}
 	}
 	return decoded, nil
+}
+
+func (s *serviceImpl) resolveBaseConfigPath() string {
+	if s.baseConfig != "" {
+		return s.baseConfig
+	}
+	return filepath.Join(s.dagsDir, workspace.BaseConfigFileName)
 }
 
 func normalizeDAGID(dagID string) (string, error) {
@@ -2096,6 +2173,12 @@ func (s *serviceImpl) safeDAGIDToFilePath(dagID string) (string, error) {
 	normalized, err := normalizeDAGID(dagID)
 	if err != nil {
 		return "", err
+	}
+	if normalized == baseConfigID {
+		return s.resolveBaseConfigPath(), nil
+	}
+	if workspaceName, ok := workspaceBaseConfigNameFromID(normalized); ok {
+		return safeJoinWithinBase(s.dagsDir, filepath.FromSlash(path.Join(workspace.BaseConfigDirName, workspaceName, workspace.BaseConfigFileName)))
 	}
 	ext := fileExtensionForID(normalized)
 	return safeJoinWithinBase(s.dagsDir, filepath.FromSlash(normalized+ext))

--- a/internal/gitsync/service_test.go
+++ b/internal/gitsync/service_test.go
@@ -76,6 +76,31 @@ func TestService_PathHelpers(t *testing.T) {
 	require.Equal(t, "subdir/my_dag.yaml", repoPath)
 }
 
+func TestKindForDAGID_ConfigFiles(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, DAGKindConfig, KindForDAGID("base"))
+	assert.Equal(t, DAGKindConfig, KindForDAGID("workspaces/ops/base"))
+	assert.Equal(t, DAGKindDAG, KindForDAGID("workspaces/default/base"))
+	assert.Equal(t, DAGKindDAG, KindForDAGID("workspaces/ops/other"))
+}
+
+func TestDagIDPathHelpers_ConfigFiles(t *testing.T) {
+	s := &serviceImpl{
+		dagsDir:    "/dags",
+		baseConfig: filepath.Join("/config", "base.yaml"),
+		cfg:        &Config{Path: "subdir"},
+	}
+
+	assert.Equal(t, filepath.Join("/config", "base.yaml"), s.dagIDToFilePath("base"))
+	assert.Equal(t,
+		filepath.Join("/dags", "workspaces", "ops", "base.yaml"),
+		s.dagIDToFilePath("workspaces/ops/base"),
+	)
+	assert.Equal(t, "subdir/base.yaml", s.dagIDToRepoPath("base"))
+	assert.Equal(t, "subdir/workspaces/ops/base.yaml", s.dagIDToRepoPath("workspaces/ops/base"))
+}
+
 func TestIsMemoryFile(t *testing.T) {
 	t.Parallel()
 
@@ -162,6 +187,29 @@ func TestScanMemoryFiles(t *testing.T) {
 	assert.Contains(t, state.DAGs, dagID)
 	assert.Equal(t, StatusUntracked, state.DAGs[dagID].Status)
 	assert.Equal(t, DAGKindMemory, state.DAGs[dagID].Kind)
+}
+
+func TestScanLocalDAGs_ConfigFiles(t *testing.T) {
+	rootDir := t.TempDir()
+	dagsDir := filepath.Join(rootDir, "dags")
+	baseConfig := filepath.Join(rootDir, "base.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Join(dagsDir, "workspaces", "ops"), 0750))
+	require.NoError(t, os.WriteFile(baseConfig, []byte("env:\n  GLOBAL: 1\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dagsDir, "workspaces", "ops", "base.yaml"), []byte("env:\n  OPS: 1\n"), 0600))
+
+	s := &serviceImpl{
+		dagsDir:    dagsDir,
+		baseConfig: baseConfig,
+		cfg:        &Config{},
+	}
+	state := &State{DAGs: make(map[string]*DAGState)}
+
+	require.NoError(t, s.scanLocalDAGs(state))
+
+	require.Contains(t, state.DAGs, "base")
+	assert.Equal(t, DAGKindConfig, state.DAGs["base"].Kind)
+	require.Contains(t, state.DAGs, "workspaces/ops/base")
+	assert.Equal(t, DAGKindConfig, state.DAGs["workspaces/ops/base"].Kind)
 }
 
 func TestScanLocalDAGs_IgnoresNonMemoryMd(t *testing.T) {

--- a/internal/gitsync/service_test.go
+++ b/internal/gitsync/service_test.go
@@ -81,6 +81,8 @@ func TestKindForDAGID_ConfigFiles(t *testing.T) {
 
 	assert.Equal(t, DAGKindConfig, KindForDAGID("base"))
 	assert.Equal(t, DAGKindConfig, KindForDAGID("workspaces/ops/base"))
+	// TestKindForDAGID_ConfigFiles expects KindForDAGID to reject reserved
+	// workspace names through workspace.ValidateName and fall back to DAG files.
 	assert.Equal(t, DAGKindDAG, KindForDAGID("workspaces/default/base"))
 	assert.Equal(t, DAGKindDAG, KindForDAGID("workspaces/ops/other"))
 }

--- a/internal/gitsync/state.go
+++ b/internal/gitsync/state.go
@@ -103,7 +103,7 @@ func workspaceBaseConfigNameFromID(id string) (string, bool) {
 	if len(parts) != 3 {
 		return "", false
 	}
-	if parts[0] != workspace.BaseConfigDirName || parts[2] != strings.TrimSuffix(workspace.BaseConfigFileName, ".yaml") {
+	if parts[0] != workspace.BaseConfigDirName || parts[2] != workspace.BaseConfigStem() {
 		return "", false
 	}
 	if err := workspace.ValidateName(parts[1]); err != nil {

--- a/internal/gitsync/state.go
+++ b/internal/gitsync/state.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dagucloud/dagu/internal/workspace"
 )
 
 // SyncStatus represents the synchronization status of a DAG.
@@ -40,6 +42,7 @@ const (
 	agentSkillsDir = "skills"
 	agentSoulsDir  = "souls"
 	agentDocsDir   = "docs"
+	baseConfigID   = "base"
 )
 
 // DAGKind represents the type of tracked item in git sync.
@@ -60,11 +63,17 @@ const (
 
 	// DAGKindDoc indicates a document file under docs/.
 	DAGKindDoc DAGKind = "doc"
+
+	// DAGKindConfig indicates a global or workspace base config file.
+	DAGKindConfig DAGKind = "config"
 )
 
 // KindForDAGID returns the DAG kind derived from a DAG ID.
 func KindForDAGID(id string) DAGKind {
 	id = normalizeDAGIDSeparators(id)
+	if isConfigFile(id) {
+		return DAGKindConfig
+	}
 	if strings.HasPrefix(id, agentMemoryDir+"/") {
 		return DAGKindMemory
 	}
@@ -78,6 +87,29 @@ func KindForDAGID(id string) DAGKind {
 		return DAGKindDoc
 	}
 	return DAGKindDAG
+}
+
+func isConfigFile(id string) bool {
+	id = normalizeDAGIDSeparators(id)
+	if id == baseConfigID {
+		return true
+	}
+	_, ok := workspaceBaseConfigNameFromID(id)
+	return ok
+}
+
+func workspaceBaseConfigNameFromID(id string) (string, bool) {
+	parts := strings.Split(normalizeDAGIDSeparators(id), "/")
+	if len(parts) != 3 {
+		return "", false
+	}
+	if parts[0] != workspace.BaseConfigDirName || parts[2] != strings.TrimSuffix(workspace.BaseConfigFileName, ".yaml") {
+		return "", false
+	}
+	if err := workspace.ValidateName(parts[1]); err != nil {
+		return "", false
+	}
+	return parts[1], true
 }
 
 func normalizeDAGIDSeparators(id string) string {

--- a/internal/persis/filedag/store.go
+++ b/internal/persis/filedag/store.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/persis/filedag/dagindex"
 	"github.com/dagucloud/dagu/internal/persis/filedag/grep"
+	"github.com/dagucloud/dagu/internal/workspace"
 	indexv1 "github.com/dagucloud/dagu/proto/index/v1"
 )
 
@@ -37,12 +38,13 @@ type Option func(*Options)
 
 // Options contains configuration options for the DAG repository
 type Options struct {
-	FlagsBaseDir          string                     // Base directory for flag store
-	FileCache             *fileutil.Cache[*core.DAG] // Optional cache for DAG objects
-	SearchPaths           []string                   // Additional search paths for DAG files
-	BaseConfigPath        string                     // Optional base config file applied when loading DAGs
-	SkipExamples          bool                       // Skip creating example DAGs
-	SkipDirectoryCreation bool                       // Skip creating base directory (for worker mode)
+	FlagsBaseDir           string                     // Base directory for flag store
+	FileCache              *fileutil.Cache[*core.DAG] // Optional cache for DAG objects
+	SearchPaths            []string                   // Additional search paths for DAG files
+	BaseConfigPath         string                     // Optional base config file applied when loading DAGs
+	WorkspaceBaseConfigDir string                     // Optional directory containing workspace base configs
+	SkipExamples           bool                       // Skip creating example DAGs
+	SkipDirectoryCreation  bool                       // Skip creating base directory (for worker mode)
 }
 
 // WithFileCache returns a DAGRepositoryOption that sets the file cache for DAG objects
@@ -71,6 +73,14 @@ func WithSearchPaths(paths []string) Option {
 func WithBaseConfig(path string) Option {
 	return func(o *Options) {
 		o.BaseConfigPath = path
+	}
+}
+
+// WithWorkspaceBaseConfigDir returns a DAGRepositoryOption that sets the directory
+// containing per-workspace base configs.
+func WithWorkspaceBaseConfigDir(dir string) Option {
+	return func(o *Options) {
+		o.WorkspaceBaseConfigDir = dir
 	}
 }
 
@@ -110,29 +120,31 @@ func New(baseDir string, opts ...Option) exec.DAGStore {
 	}
 
 	return &Storage{
-		baseDir:               baseDir,
-		flagsBaseDir:          options.FlagsBaseDir,
-		fileCache:             options.FileCache,
-		searchPaths:           searchPaths,
-		baseConfigPath:        options.BaseConfigPath,
-		baseConfigState:       describeBaseConfigState(options.BaseConfigPath),
-		skipExamples:          options.SkipExamples,
-		skipDirectoryCreation: options.SkipDirectoryCreation,
+		baseDir:                baseDir,
+		flagsBaseDir:           options.FlagsBaseDir,
+		fileCache:              options.FileCache,
+		searchPaths:            searchPaths,
+		baseConfigPath:         options.BaseConfigPath,
+		workspaceBaseConfigDir: options.WorkspaceBaseConfigDir,
+		baseConfigState:        describeBaseConfigStateSet(options.BaseConfigPath, options.WorkspaceBaseConfigDir),
+		skipExamples:           options.SkipExamples,
+		skipDirectoryCreation:  options.SkipDirectoryCreation,
 	}
 }
 
 // Storage implements the DAGRepository interface using the local filesystem
 type Storage struct {
-	baseDir               string                     // Base directory for DAG storage
-	flagsBaseDir          string                     // Base directory for flag store
-	fileCache             *fileutil.Cache[*core.DAG] // Optional cache for DAG objects
-	searchPaths           []string                   // Additional search paths for DAG files
-	baseConfigPath        string                     // Optional base config file applied when loading DAGs
-	baseConfigState       string                     // Last observed base config file state for cache/index invalidation
-	skipExamples          bool                       // Skip creating example DAGs
-	skipDirectoryCreation bool                       // Skip creating base directory (for worker mode)
-	baseConfigMu          sync.Mutex                 // Protects base config state refresh and invalidation
-	indexMu               sync.Mutex                 // Protects index load/rebuild/invalidate
+	baseDir                string                     // Base directory for DAG storage
+	flagsBaseDir           string                     // Base directory for flag store
+	fileCache              *fileutil.Cache[*core.DAG] // Optional cache for DAG objects
+	searchPaths            []string                   // Additional search paths for DAG files
+	baseConfigPath         string                     // Optional base config file applied when loading DAGs
+	workspaceBaseConfigDir string                     // Optional directory containing workspace base configs
+	baseConfigState        string                     // Last observed base config state for cache/index invalidation
+	skipExamples           bool                       // Skip creating example DAGs
+	skipDirectoryCreation  bool                       // Skip creating base directory (for worker mode)
+	baseConfigMu           sync.Mutex                 // Protects base config state refresh and invalidation
+	indexMu                sync.Mutex                 // Protects index load/rebuild/invalidate
 }
 
 func (store *Storage) useCachedLoads() bool {
@@ -164,16 +176,19 @@ func (store *Storage) defaultLoadOptions(opts ...spec.LoadOption) []spec.LoadOpt
 	if store.baseConfigPath != "" {
 		loadOpts = append(loadOpts, spec.WithBaseConfig(store.baseConfigPath))
 	}
+	if store.workspaceBaseConfigDir != "" {
+		loadOpts = append(loadOpts, spec.WithWorkspaceBaseConfigDir(store.workspaceBaseConfigDir))
+	}
 	loadOpts = append(loadOpts, opts...)
 	return loadOpts
 }
 
 func (store *Storage) refreshBaseConfigState() {
-	if store.baseConfigPath == "" {
+	if store.baseConfigPath == "" && store.workspaceBaseConfigDir == "" {
 		return
 	}
 
-	state := describeBaseConfigState(store.baseConfigPath)
+	state := describeBaseConfigStateSet(store.baseConfigPath, store.workspaceBaseConfigDir)
 
 	store.baseConfigMu.Lock()
 	defer store.baseConfigMu.Unlock()
@@ -187,6 +202,17 @@ func (store *Storage) refreshBaseConfigState() {
 	}
 	store.invalidateIndex()
 	store.baseConfigState = state
+}
+
+func describeBaseConfigStateSet(basePath, workspaceDir string) string {
+	parts := make([]string, 0, 2)
+	if basePath != "" {
+		parts = append(parts, "global="+describeBaseConfigState(basePath))
+	}
+	if workspaceDir != "" {
+		parts = append(parts, "workspaces="+describeWorkspaceBaseConfigState(workspaceDir))
+	}
+	return strings.Join(parts, "|")
 }
 
 func describeBaseConfigState(path string) string {
@@ -203,6 +229,40 @@ func describeBaseConfigState(path string) string {
 	}
 
 	return fmt.Sprintf("%d:%d", fi.Size(), fi.ModTime().UnixNano())
+}
+
+func describeWorkspaceBaseConfigState(dir string) string {
+	if dir == "" {
+		return ""
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "missing"
+		}
+		return "error:" + err.Error()
+	}
+
+	states := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		configPath := filepath.Join(dir, entry.Name(), workspace.BaseConfigFileName)
+		fi, err := os.Stat(configPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			states = append(states, entry.Name()+":error:"+err.Error())
+			continue
+		}
+		states = append(states, fmt.Sprintf("%s:%d:%d", entry.Name(), fi.Size(), fi.ModTime().UnixNano()))
+	}
+	sort.Strings(states)
+	return strings.Join(states, ",")
 }
 
 // Initialize ensures the storage is ready and creates example DAGs if needed

--- a/internal/persis/filedag/store_test.go
+++ b/internal/persis/filedag/store_test.go
@@ -822,6 +822,48 @@ steps:
 	require.Equal(t, []string{"build"}, dag.Steps[1].Depends)
 }
 
+func TestLoadSpecWithWorkspaceBaseConfig(t *testing.T) {
+	rootDir := t.TempDir()
+	dagDir := filepath.Join(rootDir, "dags")
+	workspaceConfigDir := filepath.Join(rootDir, "workspaces")
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+
+	baseConfig := filepath.Join(rootDir, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfig, []byte(`
+env:
+  GLOBAL_ONLY: "1"
+  SHARED: "global"
+log_dir: "/global/logs"
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(workspaceConfigDir, "ops", "base.yaml"), []byte(`
+env:
+  WORKSPACE_ONLY: "1"
+  SHARED: "workspace"
+log_dir: "/workspace/logs"
+`), 0600))
+
+	store := New(
+		dagDir,
+		WithBaseConfig(baseConfig),
+		WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		WithSkipExamples(true),
+	)
+	ctx := context.Background()
+
+	dag, err := store.LoadSpec(ctx, []byte(`name: workspace-config-dag
+labels:
+  - workspace=ops
+steps:
+  - name: step1
+    command: echo "hello"
+`))
+	require.NoError(t, err)
+	assert.Contains(t, dag.Env, "GLOBAL_ONLY=1")
+	assert.Contains(t, dag.Env, "WORKSPACE_ONLY=1")
+	assert.Contains(t, dag.Env, "SHARED=workspace")
+	assert.Equal(t, "/workspace/logs", dag.LogDir)
+}
+
 func TestGetMetadataRefreshesCacheWhenBaseConfigChanges(t *testing.T) {
 	rootDir := t.TempDir()
 	dagDir := filepath.Join(rootDir, "dags")
@@ -858,6 +900,49 @@ steps:
 	require.Equal(t, 1, cache.Size())
 }
 
+func TestGetMetadataRefreshesCacheWhenWorkspaceBaseConfigChanges(t *testing.T) {
+	rootDir := t.TempDir()
+	dagDir := filepath.Join(rootDir, "dags")
+	workspaceConfigDir := filepath.Join(rootDir, "workspaces")
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+	require.NoError(t, os.MkdirAll(dagDir, 0750))
+
+	baseConfig := filepath.Join(rootDir, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfig, []byte("type: graph\n"), 0600))
+	workspaceBaseConfig := filepath.Join(workspaceConfigDir, "ops", "base.yaml")
+	require.NoError(t, os.WriteFile(workspaceBaseConfig, []byte("max_active_steps: 1\n"), 0600))
+
+	cache := fileutil.NewCache[*core.DAG]("dag_definition", 16, time.Hour)
+	store := New(
+		dagDir,
+		WithBaseConfig(baseConfig),
+		WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		WithFileCache(cache),
+		WithSkipExamples(true),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dagDir, "workspace-cache-refresh.yaml"), []byte(`name: workspace-cache-refresh
+labels:
+  - workspace=ops
+steps:
+  - name: step1
+    command: echo "hello"
+`), 0600))
+
+	dag, err := store.GetMetadata(ctx, "workspace-cache-refresh")
+	require.NoError(t, err)
+	require.Equal(t, 1, cache.Size())
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(workspaceBaseConfig, []byte("max_active_steps: 2\n"), 0600))
+
+	reloaded, err := store.GetMetadata(ctx, "workspace-cache-refresh")
+	require.NoError(t, err)
+	require.NotSame(t, dag, reloaded)
+	require.Equal(t, 1, cache.Size())
+}
+
 func TestListRebuildsIndexWhenBaseConfigChanges(t *testing.T) {
 	rootDir := t.TempDir()
 	dagDir := filepath.Join(rootDir, "dags")
@@ -888,6 +973,56 @@ steps:
 
 	time.Sleep(10 * time.Millisecond)
 	require.NoError(t, os.WriteFile(baseConfig, []byte("type: chain\n"), 0600))
+
+	result, errList, err = store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, errList)
+	require.Len(t, result.Items, 1)
+
+	indexInfoAfter, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	require.True(t, indexInfoAfter.ModTime().After(indexInfoBefore.ModTime()))
+}
+
+func TestListRebuildsIndexWhenWorkspaceBaseConfigChanges(t *testing.T) {
+	rootDir := t.TempDir()
+	dagDir := filepath.Join(rootDir, "dags")
+	workspaceConfigDir := filepath.Join(rootDir, "workspaces")
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceConfigDir, "ops"), 0750))
+	require.NoError(t, os.MkdirAll(dagDir, 0750))
+
+	baseConfig := filepath.Join(rootDir, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfig, []byte("type: graph\n"), 0600))
+	workspaceBaseConfig := filepath.Join(workspaceConfigDir, "ops", "base.yaml")
+	require.NoError(t, os.WriteFile(workspaceBaseConfig, []byte("max_active_steps: 1\n"), 0600))
+
+	store := New(
+		dagDir,
+		WithBaseConfig(baseConfig),
+		WithWorkspaceBaseConfigDir(workspaceConfigDir),
+		WithSkipExamples(true),
+	)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dagDir, "workspace-index-refresh.yaml"), []byte(`name: workspace-index-refresh
+labels:
+  - workspace=ops
+steps:
+  - name: step1
+    command: echo "hello"
+`), 0600))
+
+	result, errList, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, errList)
+	require.Len(t, result.Items, 1)
+
+	indexPath := filepath.Join(dagDir, dagindex.IndexFileName)
+	indexInfoBefore, err := os.Stat(indexPath)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(workspaceBaseConfig, []byte("max_active_steps: 2\n"), 0600))
 
 	result, errList, err = store.List(ctx, exec.ListDAGsOptions{})
 	require.NoError(t, err)

--- a/internal/service/frontend/api/v1/base_config.go
+++ b/internal/service/frontend/api/v1/base_config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/dagucloud/dagu/api/v1"
@@ -14,7 +15,9 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/persis/filebaseconfig"
 	"github.com/dagucloud/dagu/internal/service/audit"
+	"github.com/dagucloud/dagu/internal/workspace"
 )
 
 var (
@@ -36,6 +39,20 @@ var (
 	ErrFailedToSaveBaseConfig = &Error{
 		Code:       api.ErrorCodeInternalError,
 		Message:    "Failed to save base configuration",
+		HTTPStatus: http.StatusInternalServerError,
+	}
+
+	// ErrFailedToLoadWorkspaceBaseConfig is returned when reading workspace config fails.
+	ErrFailedToLoadWorkspaceBaseConfig = &Error{
+		Code:       api.ErrorCodeInternalError,
+		Message:    "Failed to load workspace base configuration",
+		HTTPStatus: http.StatusInternalServerError,
+	}
+
+	// ErrFailedToSaveWorkspaceBaseConfig is returned when writing workspace config fails.
+	ErrFailedToSaveWorkspaceBaseConfig = &Error{
+		Code:       api.ErrorCodeInternalError,
+		Message:    "Failed to save workspace base configuration",
 		HTTPStatus: http.StatusInternalServerError,
 	}
 )
@@ -99,11 +116,141 @@ func (a *API) UpdateBaseConfig(ctx context.Context, request api.UpdateBaseConfig
 	}, nil
 }
 
+// GetWorkspaceBaseConfig returns the workspace-scoped base DAG configuration YAML.
+func (a *API) GetWorkspaceBaseConfig(
+	ctx context.Context,
+	request api.GetWorkspaceBaseConfigRequestObject,
+) (api.GetWorkspaceBaseConfigResponseObject, error) {
+	workspaceName, err := a.resolveWorkspaceBaseConfigTarget(ctx, request.WorkspaceName)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireWorkspaceVisible(ctx, workspaceName); err != nil {
+		return nil, err
+	}
+
+	yamlSpec, err := readWorkspaceBaseConfigSpec(a.config.Paths.DAGsDir, workspaceName)
+	if err != nil {
+		logger.Error(ctx, "Failed to load workspace base config", tag.Name(workspaceName), tag.Error(err))
+		return nil, ErrFailedToLoadWorkspaceBaseConfig
+	}
+
+	errs := validateBaseConfig(ctx, yamlSpec)
+	if errs == nil {
+		errs = []string{}
+	}
+
+	return api.GetWorkspaceBaseConfig200JSONResponse{
+		Spec:   yamlSpec,
+		Errors: errs,
+	}, nil
+}
+
+// UpdateWorkspaceBaseConfig validates and saves a workspace-scoped base DAG configuration YAML.
+func (a *API) UpdateWorkspaceBaseConfig(
+	ctx context.Context,
+	request api.UpdateWorkspaceBaseConfigRequestObject,
+) (api.UpdateWorkspaceBaseConfigResponseObject, error) {
+	workspaceName, err := a.resolveWorkspaceBaseConfigTarget(ctx, request.WorkspaceName)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireWorkspaceConfigWrite(ctx, workspaceName); err != nil {
+		return nil, err
+	}
+	if request.Body == nil {
+		return nil, ErrInvalidRequestBody
+	}
+
+	if errs := validateBaseConfig(ctx, request.Body.Spec); len(errs) > 0 {
+		return nil, &Error{
+			Code:       api.ErrorCodeBadRequest,
+			Message:    strings.Join(errs, "; "),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	store, err := workspaceBaseConfigStore(a.config.Paths.DAGsDir, workspaceName)
+	if err != nil {
+		logger.Error(ctx, "Failed to initialize workspace base config store", tag.Name(workspaceName), tag.Error(err))
+		return nil, ErrFailedToSaveWorkspaceBaseConfig
+	}
+	if err := store.UpdateSpec(ctx, []byte(request.Body.Spec)); err != nil {
+		logger.Error(ctx, "Failed to save workspace base config", tag.Name(workspaceName), tag.Error(err))
+		return nil, ErrFailedToSaveWorkspaceBaseConfig
+	}
+
+	a.logAudit(ctx, audit.CategoryWorkspace, "workspace_base_config_update", map[string]string{
+		"workspace": workspaceName,
+	})
+
+	return api.UpdateWorkspaceBaseConfig200JSONResponse{
+		Errors: []string{},
+	}, nil
+}
+
 func (a *API) requireBaseConfigManagement() error {
 	if a.baseConfigStore == nil {
 		return ErrBaseConfigNotAvailable
 	}
 	return nil
+}
+
+func (a *API) resolveWorkspaceBaseConfigTarget(ctx context.Context, name string) (string, error) {
+	if err := a.requireBaseConfigManagement(); err != nil {
+		return "", err
+	}
+	if a.workspaceStore == nil {
+		return "", workspaceStoreUnavailable()
+	}
+	workspaceName, err := validateWorkspaceParam(name)
+	if err != nil {
+		return "", err
+	}
+	if workspaceName == "" {
+		return "", badWorkspaceError("workspace name is required")
+	}
+
+	ws, err := a.workspaceStore.GetByName(ctx, workspaceName)
+	if err != nil {
+		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
+			return "", workspaceResourceNotFound()
+		}
+		return "", err
+	}
+	return ws.Name, nil
+}
+
+func (a *API) requireWorkspaceConfigWrite(ctx context.Context, workspaceName string) error {
+	role, ok, err := a.effectiveRoleForWorkspace(ctx, workspaceName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return workspaceResourceNotFound()
+	}
+	if !role.CanWrite() {
+		return errInsufficientPermissions
+	}
+	return nil
+}
+
+func readWorkspaceBaseConfigSpec(dagsDir, workspaceName string) (string, error) {
+	data, err := os.ReadFile(workspace.BaseConfigPath(dagsDir, workspaceName)) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+func workspaceBaseConfigStore(dagsDir, workspaceName string) (*filebaseconfig.Store, error) {
+	return filebaseconfig.New(
+		workspace.BaseConfigPath(dagsDir, workspaceName),
+		filebaseconfig.WithSkipDefault(true),
+	)
 }
 
 // validateBaseConfig parses the YAML spec and returns any validation errors.

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -41,6 +41,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/service/audit"
+	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/parser"
@@ -4256,6 +4257,7 @@ func (a *API) loadCurrentRescheduleDAG(ctx context.Context, sourceFile, nameOver
 
 	loadOpts := []spec.LoadOption{
 		spec.WithBaseConfig(a.config.Paths.BaseConfig),
+		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(a.config.Paths.DAGsDir)),
 		spec.WithDAGsDir(a.config.Paths.DAGsDir),
 	}
 	if nameOverride != "" {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/logpath"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -40,6 +41,7 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/filedagrun"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -448,7 +450,7 @@ func deleteInlineEnqueueMapValue(ms *yaml.MapSlice, key string) {
 	}
 }
 
-func (a *API) loadInlineDAG(ctx context.Context, specContent string, name *string, dagRunID string) (*core.DAG, func(), error) {
+func (a *API) loadInlineDAG(ctx context.Context, specContent string, name *string, dagRunID string, extraLoadOpts ...spec.LoadOption) (*core.DAG, func(), error) {
 	nameHint := "inline"
 	if name != nil && *name != "" {
 		if err := core.ValidateDAGName(*name); err != nil {
@@ -460,9 +462,12 @@ func (a *API) loadInlineDAG(ctx context.Context, specContent string, name *strin
 		}
 		nameHint = *name
 	} else {
+		validateOpts := append([]spec.LoadOption{
+			spec.WithoutEval(),
+		}, extraLoadOpts...)
 		dag, err := spec.LoadYAML(
 			ctx, []byte(specContent),
-			spec.WithoutEval(),
+			validateOpts...,
 		)
 		if err != nil {
 			return nil, func() {}, &Error{
@@ -494,7 +499,7 @@ func (a *API) loadInlineDAG(ctx context.Context, specContent string, name *strin
 		return nil, func() {}, fmt.Errorf("failed to write spec to temp file: %w", err)
 	}
 
-	loadOpts := []spec.LoadOption{}
+	loadOpts := append([]spec.LoadOption{}, extraLoadOpts...)
 	if name != nil && *name != "" {
 		loadOpts = append(loadOpts, spec.WithName(*name))
 	}
@@ -3028,7 +3033,19 @@ func (a *API) rescheduleDAGRun(ctx context.Context, dagName, dagRunID string, op
 		if nameOverride != "" {
 			inlineName = nameOverride
 		}
-		dag, cleanup, err = a.loadInlineDAG(ctx, string(snapshotDAG.YamlData), &inlineName, newDagRunID)
+		snapshotLoadOpts := []spec.LoadOption{
+			spec.WithDAGsDir(a.config.Paths.DAGsDir),
+		}
+		if len(snapshotDAG.BaseConfigData) > 0 {
+			snapshotLoadOpts = append(snapshotLoadOpts, spec.WithBaseConfigContent(snapshotDAG.BaseConfigData))
+		} else {
+			snapshotLoadOpts = append(snapshotLoadOpts,
+				spec.WithBaseConfig(a.config.Paths.BaseConfig),
+				spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(a.config.Paths.DAGsDir)),
+			)
+		}
+
+		dag, cleanup, err = a.loadInlineDAG(ctx, string(snapshotDAG.YamlData), &inlineName, newDagRunID, snapshotLoadOpts...)
 		if err != nil {
 			return rescheduleDAGRunResult{}, fmt.Errorf("failed to prepare reschedule snapshot: %w", err)
 		}
@@ -3048,8 +3065,14 @@ func (a *API) rescheduleDAGRun(ctx context.Context, dagName, dagRunID string, op
 	if opts.useCurrentDAGFile {
 		paramsToUse = currentFileParams
 	}
-	if err := a.enqueueDAGRun(ctx, dag, paramsToUse, newDagRunID, "", core.TriggerTypeManual, ""); err != nil {
-		return rescheduleDAGRunResult{}, fmt.Errorf("failed to enqueue dag-run: %w", err)
+	var enqueueErr error
+	if opts.useCurrentDAGFile {
+		enqueueErr = a.enqueueDAGRun(ctx, dag, paramsToUse, newDagRunID, "", core.TriggerTypeManual, "")
+	} else {
+		enqueueErr = a.enqueuePreparedDAGRun(ctx, dag, paramsToUse, newDagRunID, core.TriggerTypeManual)
+	}
+	if enqueueErr != nil {
+		return rescheduleDAGRunResult{}, fmt.Errorf("failed to enqueue dag-run: %w", enqueueErr)
 	}
 
 	queued := false
@@ -3072,6 +3095,113 @@ func (a *API) rescheduleDAGRun(ctx context.Context, dagName, dagRunID string, op
 		newDagRunID: newDagRunID,
 		queued:      queued,
 	}, nil
+}
+
+func (a *API) enqueuePreparedDAGRun(
+	ctx context.Context,
+	dag *core.DAG,
+	params string,
+	dagRunID string,
+	triggerType core.TriggerType,
+) error {
+	resolvedDAG, err := spec.ResolveRuntimeParams(ctx, dag, params, spec.ResolveRuntimeParamsOptions{
+		BaseConfig: a.config.Paths.BaseConfig,
+	})
+	if err != nil {
+		return &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Code:       api.ErrorCodeBadRequest,
+			Message:    err.Error(),
+		}
+	}
+	dag = resolvedDAG
+
+	if err := buildErrorsToAPIError(dag.BuildErrors); err != nil {
+		return err
+	}
+	if err := core.ValidateStartParams(dag.DefaultParams, core.StartParamInput{
+		RawParams: params,
+	}); err != nil {
+		return &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Code:       api.ErrorCodeBadRequest,
+			Message:    err.Error(),
+		}
+	}
+
+	queuedDAG := dag.Clone()
+	queuedDAG.Location = ""
+
+	now := time.Now()
+	attempt, err := a.dagRunStore.CreateAttempt(ctx, queuedDAG, now, dagRunID, exec.NewDAGRunAttemptOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create queued dag-run attempt: %w", err)
+	}
+
+	logFile, err := logpath.Generate(ctx, a.config.Paths.LogDir, queuedDAG.LogDir, queuedDAG.Name, dagRunID)
+	if err != nil {
+		return fmt.Errorf("failed to generate queued dag-run log file: %w", err)
+	}
+	artifactDir, err := artifactDirForQueuedDAGRun(ctx, a.config.Paths.ArtifactDir, queuedDAG, dagRunID)
+	if err != nil {
+		return err
+	}
+
+	statusOpts := []transform.StatusOption{
+		transform.WithLogFilePath(logFile),
+		transform.WithArchiveDir(artifactDir),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithQueuedAt(stringutil.FormatTime(now)),
+		transform.WithPreconditions(queuedDAG.Preconditions),
+		transform.WithHierarchyRefs(
+			exec.NewDAGRunRef(queuedDAG.Name, dagRunID),
+			exec.DAGRunRef{},
+		),
+		transform.WithTriggerType(triggerType),
+	}
+	status := transform.NewStatusBuilder(queuedDAG).Create(dagRunID, core.Queued, 0, time.Time{}, statusOpts...)
+
+	if err := attempt.Open(ctx); err != nil {
+		return fmt.Errorf("failed to open queued dag-run attempt: %w", err)
+	}
+	if err := attempt.Write(ctx, status); err != nil {
+		_ = attempt.Close(ctx)
+		return fmt.Errorf("failed to save queued dag-run status: %w", err)
+	}
+	closeErr := attempt.Close(ctx)
+	if closeErr != nil {
+		logger.Warn(ctx, "Failed to close queued dag-run status before enqueue",
+			tag.Error(closeErr))
+	}
+
+	dagRun := exec.NewDAGRunRef(queuedDAG.Name, dagRunID)
+	if err := a.queueStore.Enqueue(ctx, queuedDAG.ProcGroup(), exec.QueuePriorityLow, dagRun); err != nil {
+		if closeErr != nil {
+			return errors.Join(
+				fmt.Errorf("failed to close queued dag-run attempt: %w", closeErr),
+				fmt.Errorf("failed to enqueue dag-run: %w", err),
+			)
+		}
+		return fmt.Errorf("failed to enqueue dag-run: %w", err)
+	}
+
+	return nil
+}
+
+func artifactDirForQueuedDAGRun(ctx context.Context, baseDir string, dag *core.DAG, dagRunID string) (string, error) {
+	if dag == nil || !dag.ArtifactsEnabled() {
+		return "", nil
+	}
+
+	dagArtifactDir := ""
+	if dag.Artifacts != nil {
+		dagArtifactDir = dag.Artifacts.Dir
+	}
+	artifactDir, err := logpath.GenerateDir(ctx, baseDir, dagArtifactDir, dag.Name, dagRunID)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate queued dag-run artifact directory: %w", err)
+	}
+	return artifactDir, nil
 }
 
 // GetSubDAGRuns returns timing and status information for all sub DAG runs.

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -907,6 +907,65 @@ func TestRescheduleDAGRunFromInlineEnqueueUsesPersistedSnapshot(t *testing.T) {
 	test.AssertInlineRescheduledRunParams(t, server, "inline_reschedule_enqueue", rescheduledRunID)
 }
 
+func TestRescheduleDAGRunUsesPersistedBaseConfigSnapshot(t *testing.T) {
+	dagName := "reschedule_base_snapshot"
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Queues.Enabled = true
+		cfg.Queues.Config = []config.QueueConfig{
+			{Name: dagName, MaxActiveRuns: 1},
+		}
+	}))
+
+	require.NoError(t, os.WriteFile(server.Config.Paths.BaseConfig, []byte(`
+env:
+  BASE_FROM_SNAPSHOT: old
+`), 0600))
+
+	dagSpec := `steps:
+  - name: main
+    command: echo "$BASE_FROM_SNAPSHOT"`
+
+	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &dagSpec,
+	}).ExpectStatus(http.StatusCreated).Send(t)
+
+	startResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dags/%s/start", dagName),
+		api.ExecuteDAGJSONRequestBody{},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+
+	waitForDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Succeeded
+	})
+
+	_, originalDAG := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, startBody.DagRunId)
+	require.Contains(t, string(originalDAG.BaseConfigData), "BASE_FROM_SNAPSHOT: old")
+
+	require.NoError(t, os.WriteFile(server.Config.Paths.BaseConfig, []byte(`
+env:
+  BASE_FROM_SNAPSHOT: new
+`), 0600))
+
+	rescheduleResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/reschedule", dagName, startBody.DagRunId),
+		api.RescheduleDAGRunJSONRequestBody{},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var rescheduleBody api.RescheduleDAGRun200JSONResponse
+	rescheduleResp.Unmarshal(t, &rescheduleBody)
+	require.NotEmpty(t, rescheduleBody.DagRunId)
+	require.True(t, rescheduleBody.Queued)
+
+	_, rescheduledDAG := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, rescheduleBody.DagRunId)
+	assert.Contains(t, string(rescheduledDAG.BaseConfigData), "BASE_FROM_SNAPSHOT: old")
+	assert.NotContains(t, string(rescheduledDAG.BaseConfigData), "BASE_FROM_SNAPSHOT: new")
+}
+
 func TestRescheduleDAGRunCanUseCurrentDAGFile(t *testing.T) {
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Queues.Enabled = true

--- a/internal/service/frontend/api/v1/sync.go
+++ b/internal/service/frontend/api/v1/sync.go
@@ -710,6 +710,8 @@ func toAPISyncItemKind(itemID string, kind gitsync.DAGKind) api.SyncItemKind {
 		return api.SyncItemKindSoul
 	case gitsync.DAGKindDoc:
 		return api.SyncItemKindDoc
+	case gitsync.DAGKindConfig:
+		return api.SyncItemKindConfig
 	case gitsync.DAGKindDAG:
 		return api.SyncItemKindDag
 	default:
@@ -723,7 +725,7 @@ func syncItemFilePath(itemID string, kind gitsync.DAGKind) string {
 	switch kind {
 	case gitsync.DAGKindMemory, gitsync.DAGKindSkill, gitsync.DAGKindSoul, gitsync.DAGKindDoc:
 		ext = ".md"
-	case gitsync.DAGKindDAG:
+	case gitsync.DAGKindDAG, gitsync.DAGKindConfig:
 		// default .yaml extension
 	}
 	return itemID + ext

--- a/internal/service/frontend/api/v1/sync_test.go
+++ b/internal/service/frontend/api/v1/sync_test.go
@@ -767,18 +767,28 @@ func TestToAPISyncItems_IncludesKindAndPath(t *testing.T) {
 			Status:     gitsync.StatusUntracked,
 			ModifiedAt: &now, // No Kind set: should fallback by DAG ID
 		},
+		"base": {
+			Status:     gitsync.StatusModified,
+			Kind:       gitsync.DAGKindConfig,
+			ModifiedAt: &now,
+		},
 	}
 
 	apiItems := toAPISyncItems(states)
-	require.Len(t, apiItems, 2)
+	require.Len(t, apiItems, 3)
 
 	assert.Equal(t, "alpha", apiItems[0].ItemId)
 	assert.Equal(t, apigen.SyncItemKindDag, apiItems[0].Kind)
 	assert.Equal(t, "alpha.yaml", apiItems[0].FilePath)
 	assert.Equal(t, "alpha.yaml", apiItems[0].DisplayName)
 
-	assert.Equal(t, "memory/MEMORY", apiItems[1].ItemId)
-	assert.Equal(t, apigen.SyncItemKindMemory, apiItems[1].Kind)
-	assert.Equal(t, "memory/MEMORY.md", apiItems[1].FilePath)
-	assert.Equal(t, "memory/MEMORY.md", apiItems[1].DisplayName)
+	assert.Equal(t, "base", apiItems[1].ItemId)
+	assert.Equal(t, apigen.SyncItemKindConfig, apiItems[1].Kind)
+	assert.Equal(t, "base.yaml", apiItems[1].FilePath)
+	assert.Equal(t, "base.yaml", apiItems[1].DisplayName)
+
+	assert.Equal(t, "memory/MEMORY", apiItems[2].ItemId)
+	assert.Equal(t, apigen.SyncItemKindMemory, apiItems[2].Kind)
+	assert.Equal(t, "memory/MEMORY.md", apiItems[2].FilePath)
+	assert.Equal(t, "memory/MEMORY.md", apiItems[2].DisplayName)
 }

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -731,7 +731,7 @@ func initSyncService(ctx context.Context, cfg *config.Config) gitsync.Service {
 	}
 
 	syncCfg := gitsync.NewConfigFromGlobal(cfg.GitSync)
-	svc := gitsync.NewService(syncCfg, cfg.Paths.DAGsDir, cfg.Paths.DataDir)
+	svc := gitsync.NewService(syncCfg, cfg.Paths.DAGsDir, cfg.Paths.DataDir, cfg.Paths.BaseConfig)
 
 	if syncCfg.AutoSync.Enabled {
 		if err := svc.Start(ctx); err != nil {

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -39,6 +39,7 @@ import (
 	runtimepkg "github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
 	"github.com/dagucloud/dagu/internal/service/frontend"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -281,6 +282,7 @@ func Setup(t *testing.T, opts ...HelperOption) Helper {
 		cfg.Paths.DAGsDir,
 		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
 		filedag.WithBaseConfig(cfg.Paths.BaseConfig),
+		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
 		filedag.WithSkipExamples(true),
 	)
 	runStore := filedagrun.New(
@@ -565,6 +567,7 @@ func (h Helper) DAG(t *testing.T, yamlContent string) DAG {
 	if h.Config.Paths.BaseConfig != "" {
 		loadOpts = append(loadOpts, spec.WithBaseConfig(h.Config.Paths.BaseConfig))
 	}
+	loadOpts = append(loadOpts, spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(h.Config.Paths.DAGsDir)))
 	dag, err := spec.Load(h.Context, testFile, loadOpts...)
 	require.NoError(t, err, "failed to load test DAG")
 

--- a/internal/test/scheduler.go
+++ b/internal/test/scheduler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,6 +64,7 @@ func SetupScheduler(t *testing.T, opts ...HelperOption) *Scheduler {
 		helper.Config.Paths.DAGsDir,
 		filedag.WithFlagsBaseDir(helper.Config.Paths.SuspendFlagsDir),
 		filedag.WithBaseConfig(helper.Config.Paths.BaseConfig),
+		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(helper.Config.Paths.DAGsDir)),
 		filedag.WithSkipExamples(true),
 	)
 	drs := filedagrun.New(

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -5,6 +5,7 @@ package workspace
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -13,6 +14,29 @@ import (
 )
 
 var workspaceNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+const (
+	// BaseConfigDirName is the directory below DAGsDir that stores workspace-scoped config.
+	BaseConfigDirName = "workspaces"
+	// BaseConfigFileName is the file name for a workspace-scoped base config.
+	BaseConfigFileName = "base.yaml"
+)
+
+// BaseConfigDir returns the root directory for workspace-scoped base configs.
+func BaseConfigDir(dagsDir string) string {
+	if strings.TrimSpace(dagsDir) == "" {
+		return ""
+	}
+	return filepath.Join(dagsDir, BaseConfigDirName)
+}
+
+// BaseConfigPath returns the workspace-scoped base config path for name.
+func BaseConfigPath(dagsDir, name string) string {
+	if strings.TrimSpace(dagsDir) == "" || strings.TrimSpace(name) == "" {
+		return ""
+	}
+	return filepath.Join(BaseConfigDir(dagsDir), name, BaseConfigFileName)
+}
 
 // Workspace is the domain model for a cockpit workspace.
 type Workspace struct {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -35,7 +35,15 @@ func BaseConfigPath(dagsDir, name string) string {
 	if strings.TrimSpace(dagsDir) == "" || strings.TrimSpace(name) == "" {
 		return ""
 	}
+	if err := ValidateName(name); err != nil {
+		return ""
+	}
 	return filepath.Join(BaseConfigDir(dagsDir), name, BaseConfigFileName)
+}
+
+// BaseConfigStem returns the sync item name for a base config file without extension.
+func BaseConfigStem() string {
+	return strings.TrimSuffix(BaseConfigFileName, filepath.Ext(BaseConfigFileName))
 }
 
 // Workspace is the domain model for a cockpit workspace.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package workspace
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseConfigPathValidatesWorkspaceName(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	assert.Equal(t,
+		filepath.Join(root, BaseConfigDirName, "ops", BaseConfigFileName),
+		BaseConfigPath(root, "ops"),
+	)
+
+	assert.Empty(t, BaseConfigPath(root, "../ops"))
+	assert.Empty(t, BaseConfigPath(root, "default"))
+	assert.Empty(t, BaseConfigPath(root, "all"))
+	assert.Empty(t, BaseConfigPath(root, ""))
+}

--- a/ui/src/api/v1/schema.ts
+++ b/ui/src/api/v1/schema.ts
@@ -2188,6 +2188,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/settings/workspaces/{workspaceName}/base-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get workspace base configuration
+         * @description Returns the workspace-scoped base DAG configuration YAML. Requires access to the workspace.
+         */
+        get: operations["getWorkspaceBaseConfig"];
+        /**
+         * Update workspace base configuration
+         * @description Updates the workspace-scoped base DAG configuration YAML. Validates before saving. Requires write access to the workspace.
+         */
+        put: operations["updateWorkspaceBaseConfig"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/settings/agent": {
         parameters: {
             query?: never;
@@ -11401,6 +11425,161 @@ export interface operations {
             };
         };
     };
+    getWorkspaceBaseConfig: {
+        parameters: {
+            query?: {
+                /** @description name of the remote node */
+                remoteNode?: components["parameters"]["RemoteNode"];
+            };
+            header?: never;
+            path: {
+                workspaceName: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Workspace base configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The workspace base configuration in YAML format */
+                        spec: string;
+                        /** @description List of validation errors in the configuration */
+                        errors: string[];
+                    };
+                };
+            };
+            /** @description Invalid workspace */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient permissions */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unexpected error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    updateWorkspaceBaseConfig: {
+        parameters: {
+            query?: {
+                /** @description name of the remote node */
+                remoteNode?: components["parameters"]["RemoteNode"];
+            };
+            header?: never;
+            path: {
+                workspaceName: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The workspace base configuration in YAML format */
+                    spec: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Workspace base configuration updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description List of validation warnings */
+                        errors: string[];
+                    };
+                };
+            };
+            /** @description Invalid configuration */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Insufficient permissions */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unexpected error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getAgentConfig: {
         parameters: {
             query?: {
@@ -14330,6 +14509,7 @@ export enum SyncSummary {
 }
 export enum SyncItemKind {
     dag = "dag",
+    config = "config",
     memory = "memory",
     skill = "skill",
     soul = "soul",

--- a/ui/src/api/v1/schema.ts
+++ b/ui/src/api/v1/schema.ts
@@ -11433,7 +11433,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                workspaceName: string;
+                workspaceName: components["schemas"]["WorkspaceName"];
             };
             cookie?: never;
         };
@@ -11508,7 +11508,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                workspaceName: string;
+                workspaceName: components["schemas"]["WorkspaceName"];
             };
             cookie?: never;
         };

--- a/ui/src/pages/base-config/index.tsx
+++ b/ui/src/pages/base-config/index.tsx
@@ -1,31 +1,45 @@
-import { RotateCcw, Save } from 'lucide-react';
+import { Globe2, RotateCcw, Save, SquareStack } from 'lucide-react';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { useErrorModal } from '@/components/ui/error-modal';
 import { useSimpleToast } from '@/components/ui/simple-toast';
+import { Tab, Tabs } from '@/components/ui/tabs';
+import { useCanWriteForWorkspace } from '@/contexts/AuthContext';
+import DAGEditorWithDocs from '@/features/dags/components/dag-editor/DAGEditorWithDocs';
+import { useClient, useQuery } from '@/hooks/api';
+import { whenEnabled } from '@/hooks/queryUtils';
+import { workspaceNameForSelection } from '@/lib/workspace';
 import { AppBarContext } from '../../contexts/AppBarContext';
 import { useConfig } from '../../contexts/ConfigContext';
-import DAGEditorWithDocs from '../../features/dags/components/dag-editor/DAGEditorWithDocs';
-import { useClient, useQuery } from '../../hooks/api';
+
+type ConfigScope = 'global' | 'workspace';
 
 function BaseConfigPage(): React.ReactNode {
   const appBarContext = React.useContext(AppBarContext);
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
+  const workspaceSelection = appBarContext.workspaceSelection;
+  const selectedWorkspace = workspaceNameForSelection(workspaceSelection);
+  const hasWorkspaceConfig = !!selectedWorkspace;
   const client = useClient();
   const config = useConfig();
+  const canWriteWorkspace = useCanWriteForWorkspace(selectedWorkspace);
   const { showError } = useErrorModal();
   const { showToast } = useSimpleToast();
 
-  const editable = !!config.permissions.writeDags;
-  const [currentValue, setCurrentValue] = React.useState<string | null>(null);
-  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);
+  const [activeScope, setActiveScope] = React.useState<ConfigScope>('global');
+  const [globalValue, setGlobalValue] = React.useState<string | null>(null);
+  const [workspaceValue, setWorkspaceValue] = React.useState<string | null>(
+    null
+  );
+  const [globalDirty, setGlobalDirty] = React.useState(false);
+  const [workspaceDirty, setWorkspaceDirty] = React.useState(false);
   const saveHandlerRef = useRef<(() => Promise<void>) | null>(null);
 
   useEffect(() => {
     appBarContext.setTitle('Base Config');
   }, [appBarContext]);
 
-  const { data, mutate } = useQuery(
+  const { data: globalData, mutate: mutateGlobal } = useQuery(
     '/settings/base-config',
     {
       params: {
@@ -38,44 +52,116 @@ function BaseConfigPage(): React.ReactNode {
     }
   );
 
-  // Initialize editor value from fetched data
-  useEffect(() => {
-    if (data?.spec !== undefined && currentValue === null) {
-      setCurrentValue(data.spec);
+  const { data: workspaceData, mutate: mutateWorkspace } = useQuery(
+    '/settings/workspaces/{workspaceName}/base-config',
+    whenEnabled(hasWorkspaceConfig, {
+      params: {
+        path: { workspaceName: selectedWorkspace },
+        query: { remoteNode },
+      },
+    }),
+    {
+      revalidateOnFocus: true,
+      revalidateOnMount: true,
     }
-  }, [data, currentValue]);
+  );
 
-  const handleChange = useCallback((newValue?: string) => {
-    setCurrentValue(newValue || '');
-    setHasUnsavedChanges(true);
-  }, []);
+  useEffect(() => {
+    if (globalData?.spec !== undefined && globalValue === null) {
+      setGlobalValue(globalData.spec);
+    }
+  }, [globalData, globalValue]);
+
+  useEffect(() => {
+    if (workspaceData?.spec !== undefined && workspaceValue === null) {
+      setWorkspaceValue(workspaceData.spec);
+    }
+  }, [workspaceData, workspaceValue]);
+
+  useEffect(() => {
+    if (!hasWorkspaceConfig && activeScope === 'workspace') {
+      setActiveScope('global');
+    }
+  }, [activeScope, hasWorkspaceConfig]);
+
+  useEffect(() => {
+    setWorkspaceValue(null);
+    setWorkspaceDirty(false);
+  }, [selectedWorkspace, remoteNode]);
+
+  const globalEditable = !!config.permissions.writeDags;
+  const workspaceEditable =
+    !!config.permissions.writeDags && hasWorkspaceConfig && canWriteWorkspace;
+  const editable =
+    activeScope === 'workspace' ? workspaceEditable : globalEditable;
+  const currentValue =
+    activeScope === 'workspace' ? workspaceValue : globalValue;
+  const currentSpec =
+    activeScope === 'workspace' ? workspaceData?.spec : globalData?.spec;
+  const hasUnsavedChanges =
+    activeScope === 'workspace' ? workspaceDirty : globalDirty;
+  const modelUri =
+    activeScope === 'workspace'
+      ? `inmemory://dagu/base-config.workspace.${selectedWorkspace}.yaml`
+      : 'inmemory://dagu/base-config.global.yaml';
+  const activeLabel =
+    activeScope === 'workspace' ? `${selectedWorkspace} Workspace` : 'Global';
+
+  const handleChange = useCallback(
+    (newValue?: string) => {
+      if (activeScope === 'workspace') {
+        setWorkspaceValue(newValue || '');
+        setWorkspaceDirty(true);
+        return;
+      }
+      setGlobalValue(newValue || '');
+      setGlobalDirty(true);
+    },
+    [activeScope]
+  );
 
   const handleRevert = useCallback(() => {
-    setCurrentValue(null);
-    setHasUnsavedChanges(false);
-    mutate();
-  }, [mutate]);
+    if (activeScope === 'workspace') {
+      setWorkspaceValue(null);
+      setWorkspaceDirty(false);
+      mutateWorkspace();
+      return;
+    }
+    setGlobalValue(null);
+    setGlobalDirty(false);
+    mutateGlobal();
+  }, [activeScope, mutateGlobal, mutateWorkspace]);
 
   const handleSave = useCallback(async () => {
     if (currentValue === null) {
       return;
     }
 
-    const { data: responseData, error } = await client.PUT(
-      '/settings/base-config',
-      {
-        params: {
-          query: { remoteNode },
-        },
-        body: {
-          spec: currentValue,
-        },
-      }
-    );
+    const request =
+      activeScope === 'workspace'
+        ? client.PUT('/settings/workspaces/{workspaceName}/base-config', {
+            params: {
+              path: { workspaceName: selectedWorkspace },
+              query: { remoteNode },
+            },
+            body: {
+              spec: currentValue,
+            },
+          })
+        : client.PUT('/settings/base-config', {
+            params: {
+              query: { remoteNode },
+            },
+            body: {
+              spec: currentValue,
+            },
+          });
+
+    const { data: responseData, error } = await request;
 
     if (error) {
       showError(
-        error.message || 'Failed to save base configuration',
+        error.message || `Failed to save ${activeLabel.toLowerCase()} config`,
         'Please check the YAML syntax and try again.'
       );
       return;
@@ -86,16 +172,31 @@ function BaseConfigPage(): React.ReactNode {
       return;
     }
 
-    setHasUnsavedChanges(false);
-    mutate();
-    showToast('Base configuration saved successfully');
-  }, [currentValue, remoteNode, client, showError, showToast, mutate]);
+    if (activeScope === 'workspace') {
+      setWorkspaceDirty(false);
+      mutateWorkspace();
+    } else {
+      setGlobalDirty(false);
+      mutateGlobal();
+    }
+    showToast(`${activeLabel} base config saved successfully`);
+  }, [
+    activeScope,
+    activeLabel,
+    currentValue,
+    selectedWorkspace,
+    remoteNode,
+    client,
+    showError,
+    showToast,
+    mutateGlobal,
+    mutateWorkspace,
+  ]);
 
   useEffect(() => {
     saveHandlerRef.current = handleSave;
   }, [handleSave]);
 
-  // Ctrl+S / Cmd+S keyboard shortcut
   useEffect(() => {
     if (!editable) {
       return;
@@ -119,18 +220,45 @@ function BaseConfigPage(): React.ReactNode {
       <div>
         <h1 className="text-lg font-semibold">Base Configuration</h1>
         <p className="text-sm text-muted-foreground">
-          Global defaults inherited by all DAG definitions
+          {activeScope === 'workspace'
+            ? `${selectedWorkspace} overrides layered on top of global defaults`
+            : 'Global defaults inherited by all DAG definitions'}
         </p>
       </div>
 
+      {hasWorkspaceConfig ? (
+        <Tabs role="tablist" aria-label="Base config scope" className="shrink-0">
+          <Tab
+            role="tab"
+            aria-selected={activeScope === 'global'}
+            isActive={activeScope === 'global'}
+            onClick={() => setActiveScope('global')}
+            className="gap-2 cursor-pointer"
+          >
+            <Globe2 className="h-4 w-4" />
+            Global
+          </Tab>
+          <Tab
+            role="tab"
+            aria-selected={activeScope === 'workspace'}
+            isActive={activeScope === 'workspace'}
+            onClick={() => setActiveScope('workspace')}
+            className="gap-2 cursor-pointer"
+          >
+            <SquareStack className="h-4 w-4" />
+            Workspace
+          </Tab>
+        </Tabs>
+      ) : null}
+
       <DAGEditorWithDocs
         value={
-          editable ? (currentValue ?? data?.spec ?? '') : (data?.spec ?? '')
+          editable ? (currentValue ?? currentSpec ?? '') : (currentSpec ?? '')
         }
         readOnly={!editable}
         onChange={editable ? handleChange : undefined}
         className="min-h-[400px]"
-        modelUri="inmemory://dagu/base-config.yaml"
+        modelUri={modelUri}
         headerActions={
           editable ? (
             <>

--- a/ui/src/pages/base-config/index.tsx
+++ b/ui/src/pages/base-config/index.tsx
@@ -89,6 +89,11 @@ function BaseConfigPage(): React.ReactNode {
     setWorkspaceDirty(false);
   }, [selectedWorkspace, remoteNode]);
 
+  useEffect(() => {
+    setGlobalValue(null);
+    setGlobalDirty(false);
+  }, [remoteNode]);
+
   const globalEditable = !!config.permissions.writeDags;
   const workspaceEditable =
     !!config.permissions.writeDags && hasWorkspaceConfig && canWriteWorkspace;

--- a/ui/src/pages/git-sync/MoveDialog.tsx
+++ b/ui/src/pages/git-sync/MoveDialog.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { SyncStatus } from '@/api/v1/schema';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';

--- a/ui/src/pages/git-sync/MoveDialog.tsx
+++ b/ui/src/pages/git-sync/MoveDialog.tsx
@@ -14,7 +14,7 @@ import { Label } from '@/components/ui/label';
 import { ArrowRightLeft, RefreshCw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-type ItemKind = 'dag' | 'memory' | 'skill' | 'soul' | 'doc';
+type ItemKind = 'dag' | 'config' | 'memory' | 'skill' | 'soul' | 'doc';
 
 interface MoveDialogProps {
   open: boolean;
@@ -27,6 +27,7 @@ interface MoveDialogProps {
 }
 
 function deriveKind(id: string): ItemKind {
+  if (id === 'base' || /^workspaces\/[^/]+\/base$/.test(id)) return 'config';
   if (id.startsWith('memory/')) return 'memory';
   if (id.startsWith('skills/')) return 'skill';
   if (id.startsWith('souls/')) return 'soul';
@@ -64,6 +65,10 @@ export function MoveDialog({
     }
     if (newItemId.trim() === itemId) {
       setValidationError('New item ID must be different from the current one');
+      return false;
+    }
+    if (itemKind === 'config') {
+      setValidationError('Config items cannot be moved');
       return false;
     }
     const newKind = deriveKind(newItemId.trim());

--- a/ui/src/pages/git-sync/RowActionMenu.tsx
+++ b/ui/src/pages/git-sync/RowActionMenu.tsx
@@ -10,6 +10,7 @@ import { MoreHorizontal, EyeOff, Trash2, ArrowRightLeft } from 'lucide-react';
 
 interface RowActionMenuProps {
   itemId: string;
+  kind: 'dag' | 'config' | 'memory' | 'skill' | 'soul' | 'doc';
   status: SyncStatus;
   pushEnabled: boolean;
   canWrite: boolean;
@@ -44,6 +45,7 @@ const canMove: Record<SyncStatus, boolean> = {
 
 export function RowActionMenu({
   itemId,
+  kind,
   status,
   pushEnabled,
   canWrite,
@@ -55,7 +57,7 @@ export function RowActionMenu({
 
   const showForget = canForget[status];
   const showDelete = canDelete[status];
-  const showMove = canMove[status];
+  const showMove = kind !== 'config' && canMove[status];
 
   if (!showForget && !showDelete && !showMove) return null;
 

--- a/ui/src/pages/git-sync/index.tsx
+++ b/ui/src/pages/git-sync/index.tsx
@@ -67,8 +67,8 @@ type SyncConfigResponse = components['schemas']['SyncConfigResponse'];
 type SyncItemDiffResponse = components['schemas']['SyncItemDiffResponse'];
 type SyncItem = components['schemas']['SyncItem'];
 type StatusFilter = 'all' | 'modified' | 'untracked' | 'conflict' | 'missing';
-type TypeFilter = 'dag' | 'memory' | 'skill' | 'soul' | 'doc';
-type UISyncKind = 'dag' | 'memory' | 'skill' | 'soul' | 'doc';
+type TypeFilter = 'dag' | 'config' | 'memory' | 'skill' | 'soul' | 'doc';
+type UISyncKind = 'dag' | 'config' | 'memory' | 'skill' | 'soul' | 'doc';
 type SyncRow = { itemId: string; item: SyncItem; kind: UISyncKind };
 
 const statusFilters: StatusFilter[] = [
@@ -78,7 +78,14 @@ const statusFilters: StatusFilter[] = [
   'conflict',
   'missing',
 ];
-const typeFilters: TypeFilter[] = ['dag', 'memory', 'skill', 'soul', 'doc'];
+const typeFilters: TypeFilter[] = [
+  'dag',
+  'config',
+  'memory',
+  'skill',
+  'soul',
+  'doc',
+];
 
 function parseStatusFilter(value: string | null): StatusFilter {
   if (
@@ -96,6 +103,7 @@ function parseStatusFilter(value: string | null): StatusFilter {
 function parseTypeFilter(value: string | null): TypeFilter {
   if (
     value === 'dag' ||
+    value === 'config' ||
     value === 'memory' ||
     value === 'skill' ||
     value === 'soul' ||
@@ -107,6 +115,7 @@ function parseTypeFilter(value: string | null): TypeFilter {
 }
 
 function normalizeSyncItemKind(kind: SyncItemKind): UISyncKind {
+  if (kind === SyncItemKind.config) return 'config';
   if (kind === SyncItemKind.memory) return 'memory';
   if (kind === SyncItemKind.skill) return 'skill';
   if (kind === SyncItemKind.soul) return 'soul';
@@ -503,6 +512,7 @@ export default function GitSyncPage() {
   const typeCounts = useMemo(() => {
     const counts: Record<TypeFilter, number> = {
       dag: 0,
+      config: 0,
       memory: 0,
       skill: 0,
       soul: 0,
@@ -587,6 +597,7 @@ export default function GitSyncPage() {
 
   const selectedCounts = useMemo(() => {
     let dag = 0;
+    let config = 0;
     let memory = 0;
     let skill = 0;
     let soul = 0;
@@ -594,7 +605,8 @@ export default function GitSyncPage() {
     for (const dagID of selectedDags) {
       const row = rowByID.get(dagID);
       if (!row) continue;
-      if (row.kind === 'memory') memory += 1;
+      if (row.kind === 'config') config += 1;
+      else if (row.kind === 'memory') memory += 1;
       else if (row.kind === 'skill') skill += 1;
       else if (row.kind === 'soul') soul += 1;
       else if (row.kind === 'doc') doc += 1;
@@ -602,17 +614,19 @@ export default function GitSyncPage() {
     }
     return {
       dag,
+      config,
       memory,
       skill,
       soul,
       doc,
-      total: dag + memory + skill + soul + doc,
+      total: dag + config + memory + skill + soul + doc,
     };
   }, [selectedDags, rowByID]);
 
   const emptyStateMessage = useMemo(() => {
     const typeLabelMap: Record<string, string> = {
       dag: 'DAG',
+      config: 'config',
       memory: 'memory',
       skill: 'skill',
       soul: 'soul',
@@ -783,6 +797,7 @@ export default function GitSyncPage() {
                 (
                   {
                     dag: 'DAGs',
+                    config: 'Config',
                     memory: 'Memory',
                     skill: 'Skills',
                     soul: 'Souls',
@@ -806,6 +821,9 @@ export default function GitSyncPage() {
         {selectedCounts.total > 0 && (
           <span className="text-xs text-muted-foreground">
             Selected: {selectedCounts.dag} DAGs
+            {selectedCounts.config > 0
+              ? `, ${selectedCounts.config} config`
+              : ''}
             {selectedCounts.memory > 0
               ? `, ${selectedCounts.memory} memory`
               : ''}
@@ -869,7 +887,7 @@ export default function GitSyncPage() {
                   />
                 )}
               </TableHead>
-              <TableHead>DAG</TableHead>
+              <TableHead>Item</TableHead>
               <TableHead className="w-24">Status</TableHead>
               <TableHead className="w-28">Synced</TableHead>
               <TableHead className="w-28"></TableHead>
@@ -997,6 +1015,7 @@ export default function GitSyncPage() {
                         )}
                       <RowActionMenu
                         itemId={itemId}
+                        kind={kind}
                         status={item.status}
                         pushEnabled={!!config?.pushEnabled}
                         canWrite={canWrite}


### PR DESCRIPTION
## Summary
- add workspace-scoped base config layered after the global base config
- expose workspace base config editing in the Web UI when a named workspace is selected
- include global and workspace base config files in git sync

## Details
- global base config remains the shared default for all DAGs
- named workspace DAGs can inherit an additional workspace config from `workspaces/<workspace>/base.yaml`
- default/all workspace selections do not get workspace config editing

## Validation
- `go test ./internal/core/spec ./internal/persis/filedag ./internal/gitsync ./internal/service/frontend/api/v1 ./internal/cmd ./internal/engine ./internal/service/frontend ./internal/test ./internal/workspace -count=1`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace-scoped base configuration management via new API endpoints for retrieving and updating workspace-specific DAG configurations
  * Introduced workspace base config as a distinct sync item kind alongside DAGs and other item types
  
* **User Interface**
  * Base config editor now supports switching between Global and Workspace configuration scopes with dedicated management per scope
  * Git sync interface updated to recognize and handle configuration items separately from DAGs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->