### PR TITLE
feat: add agent runbook management tool

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/llm"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -67,14 +68,16 @@ func getAuthenticatedUserIDFromContext(ctx context.Context) (string, bool) {
 
 func userIdentityFromContext(ctx context.Context) UserIdentity {
 	user := UserIdentity{
-		UserID:   defaultUserID,
-		Username: defaultUserID,
-		Role:     defaultUserRole,
+		UserID:          defaultUserID,
+		Username:        defaultUserID,
+		Role:            defaultUserRole,
+		WorkspaceAccess: auth.AllWorkspaceAccess(),
 	}
 	if authUser, ok := auth.UserFromContext(ctx); ok && authUser != nil {
 		user.UserID = authUser.ID
 		user.Username = authUser.Username
 		user.Role = authUser.Role
+		user.WorkspaceAccess = auth.CloneWorkspaceAccess(authUser.WorkspaceAccess)
 	}
 	user.IPAddress, _ = auth.ClientIPFromContext(ctx)
 	return user
@@ -95,6 +98,8 @@ type API struct {
 	environment           EnvironmentInfo
 	hooks                 *Hooks
 	memoryStore           MemoryStore
+	docStore              DocStore
+	workspaceStore        workspacepkg.Store
 	soulStore             SoulStore
 	remoteContextResolver RemoteContextResolver
 	oauthManager          *agentoauth.Manager
@@ -113,6 +118,8 @@ type APIConfig struct {
 	Environment           EnvironmentInfo
 	Hooks                 *Hooks
 	MemoryStore           MemoryStore
+	DocStore              DocStore
+	WorkspaceStore        workspacepkg.Store
 	RemoteContextResolver RemoteContextResolver
 	OAuthManager          *agentoauth.Manager
 	EventService          *eventstore.Service
@@ -160,6 +167,8 @@ func NewAPI(cfg APIConfig) *API {
 		environment:           cfg.Environment,
 		hooks:                 cfg.Hooks,
 		memoryStore:           cfg.MemoryStore,
+		docStore:              cfg.DocStore,
+		workspaceStore:        cfg.WorkspaceStore,
 		remoteContextResolver: cfg.RemoteContextResolver,
 		oauthManager:          cfg.OAuthManager,
 		eventService:          cfg.EventService,
@@ -561,6 +570,8 @@ func (a *API) buildSessionManagerConfig(id string, user UserIdentity, cfg sessio
 		InputCostPer1M:        cfg.inputCostPer1M,
 		OutputCostPer1M:       cfg.outputCostPer1M,
 		MemoryStore:           a.memoryStore,
+		DocStore:              a.docStore,
+		WorkspaceStore:        a.workspaceStore,
 		DAGName:               cfg.dagName,
 		SessionStore:          a.store,
 		Soul:                  cfg.soul,

--- a/internal/agent/runbook_manage.go
+++ b/internal/agent/runbook_manage.go
@@ -1,0 +1,504 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/dagucloud/dagu/internal/llm"
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
+)
+
+const (
+	runbookManageToolName = "runbook_manage"
+	defaultRunbookLimit   = 20
+	maxRunbookLimit       = 100
+)
+
+type runbookManageAction string
+
+const (
+	runbookActionList           runbookManageAction = "list"
+	runbookActionSearch         runbookManageAction = "search"
+	runbookActionGet            runbookManageAction = "get"
+	runbookActionCreate         runbookManageAction = "create"
+	runbookActionUpdate         runbookManageAction = "update"
+	runbookActionPatch          runbookManageAction = "patch"
+	runbookActionEnsureMetadata runbookManageAction = "ensure_metadata"
+)
+
+type runbookManageInput struct {
+	Action      runbookManageAction `json:"action"`
+	ID          string              `json:"id,omitempty"`
+	Query       string              `json:"query,omitempty"`
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Content     string              `json:"content,omitempty"`
+	OldString   string              `json:"old_string,omitempty"`
+	NewString   string              `json:"new_string,omitempty"`
+	Limit       int                 `json:"limit,omitempty"`
+}
+
+type runbookMetadataOutput struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+type runbookSearchOutput struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+}
+
+type runbookGetOutput struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Content     string `json:"content"`
+	Body        string `json:"body"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+type runbookManageDeps struct {
+	docStore       DocStore
+	workspaceStore workspacepkg.Store
+}
+
+func init() {
+	RegisterTool(ToolRegistration{
+		Name:           runbookManageToolName,
+		Label:          "Runbook Manage",
+		Description:    "List, search, read, create, and update Markdown runbooks",
+		DefaultEnabled: true,
+		Factory: func(cfg ToolConfig) *AgentTool {
+			return NewRunbookManageToolWithWorkspaceStore(cfg.DocStore, cfg.WorkspaceStore)
+		},
+	})
+}
+
+// NewRunbookManageTool creates a tool for managing Markdown runbooks stored in the docs store.
+func NewRunbookManageTool(store DocStore) *AgentTool {
+	return NewRunbookManageToolWithWorkspaceStore(store, nil)
+}
+
+// NewRunbookManageToolWithWorkspaceStore creates a runbook tool scoped by known workspaces.
+func NewRunbookManageToolWithWorkspaceStore(store DocStore, workspaceStore workspacepkg.Store) *AgentTool {
+	deps := runbookManageDeps{docStore: store, workspaceStore: workspaceStore}
+	return &AgentTool{
+		Tool: llm.Tool{
+			Type: "function",
+			Function: llm.ToolFunction{
+				Name:        runbookManageToolName,
+				Description: "Manage Markdown runbooks in the Dagu docs store. Use this before complex or operational tasks to discover relevant runbooks, read the selected runbook, and keep runbooks updated when instructions are missing, stale, or wrong. Runbooks use optional YAML frontmatter with title and description.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"action": map[string]any{
+							"type":        "string",
+							"enum":        []string{"list", "search", "get", "create", "update", "patch", "ensure_metadata"},
+							"description": "Operation to perform. Use list/search first, get before acting, patch or ensure_metadata to keep runbooks current. Delete is intentionally unsupported for safety.",
+						},
+						"id": map[string]any{
+							"type":        "string",
+							"description": "Runbook doc ID, relative path without .md, e.g. runbooks/deploy-production",
+						},
+						"query":       map[string]any{"type": "string", "description": "Search query"},
+						"title":       map[string]any{"type": "string", "description": "Runbook title metadata"},
+						"description": map[string]any{"type": "string", "description": "Runbook description metadata"},
+						"content":     map[string]any{"type": "string", "description": "Markdown body or full content for create/update"},
+						"old_string":  map[string]any{"type": "string", "description": "For patch: exact unique text to replace"},
+						"new_string":  map[string]any{"type": "string", "description": "For patch: replacement text"},
+						"limit":       map[string]any{"type": "integer", "description": "Maximum results for list/search (default 20, max 100)"},
+					},
+					"required": []string{"action"},
+				},
+			},
+		},
+		Run: func(ctx ToolContext, input json.RawMessage) ToolOut {
+			return runbookManageRun(ctx, input, deps)
+		},
+		Audit: &AuditInfo{
+			Action:          "runbook_manage",
+			DetailExtractor: ExtractFields("action", "id", "query"),
+		},
+	}
+}
+
+func runbookManageRun(ctx ToolContext, input json.RawMessage, deps runbookManageDeps) ToolOut {
+	store := deps.docStore
+	if store == nil {
+		return toolError("runbook_manage is unavailable: doc store is not configured")
+	}
+	var args runbookManageInput
+	if err := json.Unmarshal(input, &args); err != nil {
+		return toolError("Failed to parse input: %v", err)
+	}
+	if ctx.Context == nil {
+		ctx.Context = defaultToolContext()
+	}
+
+	switch args.Action {
+	case runbookActionList:
+		return runbookList(ctx, deps, args)
+	case runbookActionSearch:
+		return runbookSearch(ctx, deps, args)
+	case runbookActionGet:
+		return runbookGet(ctx, deps, args)
+	case runbookActionCreate:
+		if out, denied := requireRunbookWrite(ctx, deps, args.ID); denied {
+			return out
+		}
+		return runbookCreate(ctx, store, args)
+	case runbookActionUpdate:
+		if out, denied := requireRunbookWrite(ctx, deps, args.ID); denied {
+			return out
+		}
+		return runbookUpdate(ctx, store, args)
+	case runbookActionPatch:
+		if out, denied := requireRunbookWrite(ctx, deps, args.ID); denied {
+			return out
+		}
+		return runbookPatch(ctx, store, args)
+	case runbookActionEnsureMetadata:
+		if out, denied := requireRunbookWrite(ctx, deps, args.ID); denied {
+			return out
+		}
+		return runbookEnsureMetadata(ctx, store, args)
+	default:
+		return toolError("Unknown action: %s. Use list, search, get, create, update, patch, or ensure_metadata.", args.Action)
+	}
+}
+
+func defaultToolContext() context.Context { return context.Background() }
+
+func requireRunbookWrite(ctx ToolContext, deps runbookManageDeps, id string) (ToolOut, bool) {
+	if err := validateRunbookID(id); err != nil {
+		return toolError("invalid runbook id: %v", err), true
+	}
+	role, access, ok := runbookAuthContext(ctx)
+	if ok {
+		workspaceName, err := runbookWorkspaceName(ctx.Context, deps, id)
+		if err != nil {
+			return toolError("Failed to resolve runbook workspace: %v", err), true
+		}
+		effectiveRole, ok := auth.EffectiveRole(role, access, workspaceName)
+		if !ok || !effectiveRole.CanWrite() {
+			return toolError("Permission denied: runbook_manage write actions require write permission for workspace %q", workspaceName), true
+		}
+	}
+	return ToolOut{}, false
+}
+
+func runbookAuthContext(ctx ToolContext) (auth.Role, *auth.WorkspaceAccess, bool) {
+	role := ctx.Role
+	var access *auth.WorkspaceAccess
+	if ctx.User.UserID != "" {
+		role = ctx.User.Role
+		access = ctx.User.WorkspaceAccess
+	}
+	return role, access, role.IsSet()
+}
+
+func runbookKnownWorkspaces(ctx context.Context, deps runbookManageDeps) (map[string]struct{}, error) {
+	if deps.workspaceStore == nil {
+		return nil, nil
+	}
+	workspaces, err := deps.workspaceStore.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspaces: %w", err)
+	}
+	known := make(map[string]struct{}, len(workspaces))
+	for _, ws := range workspaces {
+		known[ws.Name] = struct{}{}
+	}
+	return known, nil
+}
+
+func runbookWorkspaceName(ctx context.Context, deps runbookManageDeps, id string) (string, error) {
+	known, err := runbookKnownWorkspaces(ctx, deps)
+	if err != nil {
+		return "", err
+	}
+	if len(known) == 0 {
+		return "", nil
+	}
+	workspaceName, rest, hasSlash := strings.Cut(id, "/")
+	if workspaceName == "" || !hasSlash || rest == "" {
+		return "", nil
+	}
+	if _, ok := known[workspaceName]; ok {
+		return workspaceName, nil
+	}
+	return "", nil
+}
+
+func runbookVisible(ctx ToolContext, deps runbookManageDeps, id string) (bool, error) {
+	role, access, ok := runbookAuthContext(ctx)
+	if !ok {
+		return true, nil
+	}
+	workspaceName, err := runbookWorkspaceName(ctx.Context, deps, id)
+	if err != nil {
+		return false, err
+	}
+	_, allowed := auth.EffectiveRole(role, access, workspaceName)
+	return allowed, nil
+}
+
+func runbookExcludedPathRoots(ctx ToolContext, deps runbookManageDeps) ([]string, error) {
+	_, access, ok := runbookAuthContext(ctx)
+	if !ok || deps.workspaceStore == nil {
+		return nil, nil
+	}
+	normalized := auth.NormalizeWorkspaceAccess(access)
+	if normalized.All {
+		return nil, nil
+	}
+	known, err := runbookKnownWorkspaces(ctx.Context, deps)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(normalized.Grants))
+	for _, grant := range normalized.Grants {
+		allowed[grant.Workspace] = struct{}{}
+	}
+	roots := make([]string, 0, len(known))
+	for name := range known {
+		if _, ok := allowed[name]; !ok {
+			roots = append(roots, name)
+		}
+	}
+	sort.Strings(roots)
+	return roots, nil
+}
+
+func runbookList(ctx ToolContext, deps runbookManageDeps, args runbookManageInput) ToolOut {
+	limit := normalizeRunbookLimit(args.Limit)
+	excludedRoots, err := runbookExcludedPathRoots(ctx, deps)
+	if err != nil {
+		return toolError("Failed to filter runbook workspaces: %v", err)
+	}
+	result, err := deps.docStore.ListFlat(ctx.Context, ListDocsOptions{PerPage: limit, ExcludePathRoots: excludedRoots})
+	if err != nil {
+		return toolError("Failed to list runbooks: %v", err)
+	}
+	items := result.Items
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	runbooks := make([]runbookMetadataOutput, 0, len(items))
+	for _, item := range items {
+		visible, err := runbookVisible(ctx, deps, item.ID)
+		if err != nil {
+			return toolError("Failed to filter runbook workspaces: %v", err)
+		}
+		if !visible {
+			continue
+		}
+		runbooks = append(runbooks, runbookMetadataOutput{ID: item.ID, Title: item.Title, Description: item.Description, UpdatedAt: formatRunbookTime(item.ModTime)})
+	}
+	return runbookJSON(map[string]any{"runbooks": runbooks})
+}
+
+func runbookSearch(ctx ToolContext, deps runbookManageDeps, args runbookManageInput) ToolOut {
+	if strings.TrimSpace(args.Query) == "" {
+		return toolError("query is required for search")
+	}
+	limit := normalizeRunbookLimit(args.Limit)
+	results, err := deps.docStore.Search(ctx.Context, args.Query)
+	if err != nil {
+		return toolError("Failed to search runbooks: %v", err)
+	}
+	out := make([]runbookSearchOutput, 0, len(results))
+	for _, result := range results {
+		visible, err := runbookVisible(ctx, deps, result.ID)
+		if err != nil {
+			return toolError("Failed to filter runbook workspaces: %v", err)
+		}
+		if !visible {
+			continue
+		}
+		out = append(out, runbookSearchOutput{ID: result.ID, Title: result.Title, Description: result.Description})
+		if len(out) == limit {
+			break
+		}
+	}
+	return runbookJSON(map[string]any{"results": out})
+}
+
+func runbookGet(ctx ToolContext, deps runbookManageDeps, args runbookManageInput) ToolOut {
+	if err := validateRunbookID(args.ID); err != nil {
+		return toolError("invalid runbook id: %v", err)
+	}
+	visible, err := runbookVisible(ctx, deps, args.ID)
+	if err != nil {
+		return toolError("Failed to filter runbook workspace: %v", err)
+	}
+	if !visible {
+		return toolError("Failed to get runbook %q: %v", args.ID, ErrDocNotFound)
+	}
+	doc, err := deps.docStore.Get(ctx.Context, args.ID)
+	if err != nil {
+		return toolError("Failed to get runbook %q: %v", args.ID, err)
+	}
+	return runbookJSON(runbookGetOutput{ID: doc.ID, Title: doc.Title, Description: doc.Description, Content: doc.Content, Body: stripMarkdownFrontmatter(doc.Content), UpdatedAt: doc.UpdatedAt})
+}
+
+func runbookCreate(ctx ToolContext, store DocStore, args runbookManageInput) ToolOut {
+	if err := validateRunbookID(args.ID); err != nil {
+		return toolError("invalid runbook id: %v", err)
+	}
+	content := normalizeRunbookContent(args.Content, args.Title, args.Description)
+	if err := store.Create(ctx.Context, args.ID, content); err != nil {
+		return toolError("Failed to create runbook %q: %v", args.ID, err)
+	}
+	return runbookJSON(map[string]any{"id": args.ID, "updated": true, "action": "created"})
+}
+
+func runbookUpdate(ctx ToolContext, store DocStore, args runbookManageInput) ToolOut {
+	if err := validateRunbookID(args.ID); err != nil {
+		return toolError("invalid runbook id: %v", err)
+	}
+	if args.Content == "" {
+		return toolError("content is required for update")
+	}
+	content := args.Content
+	if args.Title != "" || args.Description != "" {
+		content = normalizeRunbookContent(content, args.Title, args.Description)
+	}
+	if err := store.Update(ctx.Context, args.ID, content); err != nil {
+		return toolError("Failed to update runbook %q: %v", args.ID, err)
+	}
+	return runbookJSON(map[string]any{"id": args.ID, "updated": true, "action": "updated"})
+}
+
+func runbookPatch(ctx ToolContext, store DocStore, args runbookManageInput) ToolOut {
+	if err := validateRunbookID(args.ID); err != nil {
+		return toolError("invalid runbook id: %v", err)
+	}
+	if args.OldString == "" {
+		return toolError("old_string is required for patch")
+	}
+	doc, err := store.Get(ctx.Context, args.ID)
+	if err != nil {
+		return toolError("Failed to get runbook %q: %v", args.ID, err)
+	}
+	count := strings.Count(doc.Content, args.OldString)
+	if count == 0 {
+		return toolError("old_string not found in runbook")
+	}
+	if count > 1 {
+		return toolError("old_string found %d times in runbook; include more context so it is unique", count)
+	}
+	updated := strings.Replace(doc.Content, args.OldString, args.NewString, 1)
+	if err := store.Update(ctx.Context, args.ID, updated); err != nil {
+		return toolError("Failed to patch runbook %q: %v", args.ID, err)
+	}
+	return runbookJSON(map[string]any{"id": args.ID, "updated": true, "action": "patched"})
+}
+
+func runbookEnsureMetadata(ctx ToolContext, store DocStore, args runbookManageInput) ToolOut {
+	if err := validateRunbookID(args.ID); err != nil {
+		return toolError("invalid runbook id: %v", err)
+	}
+	doc, err := store.Get(ctx.Context, args.ID)
+	if err != nil {
+		return toolError("Failed to get runbook %q: %v", args.ID, err)
+	}
+	title := args.Title
+	if title == "" {
+		title = doc.Title
+	}
+	description := args.Description
+	if description == "" {
+		description = doc.Description
+	}
+	updated := upsertRunbookFrontmatter(doc.Content, title, description)
+	if updated == doc.Content {
+		return runbookJSON(map[string]any{"id": args.ID, "updated": false, "action": "ensure_metadata"})
+	}
+	if err := store.Update(ctx.Context, args.ID, updated); err != nil {
+		return toolError("Failed to update runbook metadata %q: %v", args.ID, err)
+	}
+	return runbookJSON(map[string]any{"id": args.ID, "updated": true, "action": "ensure_metadata"})
+}
+
+func validateRunbookID(id string) error {
+	return ValidateDocID(id)
+}
+
+func normalizeRunbookLimit(limit int) int {
+	if limit <= 0 {
+		return defaultRunbookLimit
+	}
+	if limit > maxRunbookLimit {
+		return maxRunbookLimit
+	}
+	return limit
+}
+
+func normalizeRunbookContent(content, title, description string) string {
+	body := stripMarkdownFrontmatter(content)
+	return buildRunbookContent(title, description, body)
+}
+
+func buildRunbookContent(title, description, body string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	if title != "" {
+		b.WriteString("title: ")
+		b.WriteString(sanitizeFrontmatterValue(title))
+		b.WriteString("\n")
+	}
+	b.WriteString("description: ")
+	b.WriteString(sanitizeFrontmatterValue(description))
+	b.WriteString("\n---\n\n")
+	b.WriteString(strings.TrimLeft(body, "\r\n"))
+	return b.String()
+}
+
+func upsertRunbookFrontmatter(content, title, description string) string {
+	body := stripMarkdownFrontmatter(content)
+	return buildRunbookContent(title, description, body)
+}
+
+var markdownFrontmatterRE = regexp.MustCompile(`^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)`)
+
+func stripMarkdownFrontmatter(content string) string {
+	return markdownFrontmatterRE.ReplaceAllString(content, "")
+}
+
+func sanitizeFrontmatterValue(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.TrimSpace(value)
+	if strings.ContainsAny(value, `:#{}[],&*?|-<>=!%@\\"'`) {
+		return fmt.Sprintf("%q", value)
+	}
+	return value
+}
+
+func formatRunbookTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func runbookJSON(v any) ToolOut {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return toolError("Failed to encode runbook_manage output: %v", err)
+	}
+	return ToolOut{Content: string(data)}
+}

--- a/internal/agent/runbook_manage_test.go
+++ b/internal/agent/runbook_manage_test.go
@@ -76,8 +76,8 @@ func (s *mockRunbookDocStore) Get(_ context.Context, id string) (*Doc, error) {
 	if !ok {
 		return nil, ErrDocNotFound
 	}
-	copy := *doc
-	return &copy, nil
+	docCopy := *doc
+	return &docCopy, nil
 }
 
 func (s *mockRunbookDocStore) Create(_ context.Context, id, content string) error {
@@ -287,7 +287,7 @@ func TestRunbookManageTool_AvailabilityAndInputErrors(t *testing.T) {
 	assert.True(t, out.IsError)
 	assert.Contains(t, out.Content, "Failed to parse")
 
-	out = tool.Run(ToolContext{}, runbookInput(t, map[string]any{"action": "list"}))
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "list"}))
 	assert.False(t, out.IsError, out.Content)
 
 	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "bogus"}))

--- a/internal/agent/runbook_manage_test.go
+++ b/internal/agent/runbook_manage_test.go
@@ -30,6 +30,7 @@ type mockRunbookDocStore struct {
 	updateErr              error
 	searchErr              error
 	ignoreExcludePathRoots bool
+	listContextNil         bool
 }
 
 func newMockRunbookDocStore() *mockRunbookDocStore {
@@ -40,7 +41,8 @@ func (s *mockRunbookDocStore) List(context.Context, ListDocsOptions) (*exec.Pagi
 	return nil, nil
 }
 
-func (s *mockRunbookDocStore) ListFlat(_ context.Context, opts ListDocsOptions) (*exec.PaginatedResult[DocMetadata], error) {
+func (s *mockRunbookDocStore) ListFlat(ctx context.Context, opts ListDocsOptions) (*exec.PaginatedResult[DocMetadata], error) {
+	s.listContextNil = ctx == nil
 	if s.listErr != nil {
 		return nil, s.listErr
 	}
@@ -293,6 +295,16 @@ func TestRunbookManageTool_AvailabilityAndInputErrors(t *testing.T) {
 	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "bogus"}))
 	assert.True(t, out.IsError)
 	assert.Contains(t, out.Content, "Unknown action")
+}
+
+func TestRunbookManageTool_DefaultContextFallback(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+
+	out := tool.Run(ToolContext{}, runbookInput(t, map[string]any{"action": "list"}))
+	assert.False(t, out.IsError, out.Content)
+	assert.False(t, store.listContextNil)
 }
 
 func TestRunbookManageTool_ListAndSearchErrors(t *testing.T) {

--- a/internal/agent/runbook_manage_test.go
+++ b/internal/agent/runbook_manage_test.go
@@ -1,0 +1,594 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errRunbookForced = errors.New("forced runbook error")
+
+type mockRunbookDocStore struct {
+	docs                   map[string]*Doc
+	listErr                error
+	getErr                 error
+	createErr              error
+	updateErr              error
+	searchErr              error
+	ignoreExcludePathRoots bool
+}
+
+func newMockRunbookDocStore() *mockRunbookDocStore {
+	return &mockRunbookDocStore{docs: map[string]*Doc{}}
+}
+
+func (s *mockRunbookDocStore) List(context.Context, ListDocsOptions) (*exec.PaginatedResult[*DocTreeNode], error) {
+	return nil, nil
+}
+
+func (s *mockRunbookDocStore) ListFlat(_ context.Context, opts ListDocsOptions) (*exec.PaginatedResult[DocMetadata], error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	items := make([]DocMetadata, 0, len(s.docs))
+	for id, doc := range s.docs {
+		if opts.PathPrefix != "" && !strings.HasPrefix(id, opts.PathPrefix) {
+			continue
+		}
+		if !s.ignoreExcludePathRoots && runbookTestRootExcluded(id, opts.ExcludePathRoots) {
+			continue
+		}
+		items = append(items, DocMetadata{
+			ID:          id,
+			Title:       doc.Title,
+			Description: doc.Description,
+			ModTime:     time.Unix(1700000000, 0),
+		})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
+	return &exec.PaginatedResult[DocMetadata]{Items: items, TotalCount: len(items)}, nil
+}
+
+func runbookTestRootExcluded(id string, roots []string) bool {
+	root, _, _ := strings.Cut(id, "/")
+	for _, excluded := range roots {
+		if root == excluded {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *mockRunbookDocStore) Get(_ context.Context, id string) (*Doc, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	doc, ok := s.docs[id]
+	if !ok {
+		return nil, ErrDocNotFound
+	}
+	copy := *doc
+	return &copy, nil
+}
+
+func (s *mockRunbookDocStore) Create(_ context.Context, id, content string) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	if _, ok := s.docs[id]; ok {
+		return ErrDocAlreadyExists
+	}
+	s.docs[id] = docFromContent(id, content)
+	return nil
+}
+
+func (s *mockRunbookDocStore) Update(_ context.Context, id, content string) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	if _, ok := s.docs[id]; !ok {
+		return ErrDocNotFound
+	}
+	s.docs[id] = docFromContent(id, content)
+	return nil
+}
+
+func (s *mockRunbookDocStore) Delete(_ context.Context, id string) error {
+	if _, ok := s.docs[id]; !ok {
+		return ErrDocNotFound
+	}
+	delete(s.docs, id)
+	return nil
+}
+
+func (s *mockRunbookDocStore) DeleteBatch(context.Context, []string) ([]string, []DeleteError, error) {
+	return nil, nil, nil
+}
+
+func (s *mockRunbookDocStore) Rename(context.Context, string, string) error { return nil }
+
+func (s *mockRunbookDocStore) Search(_ context.Context, query string) ([]*DocSearchResult, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	var results []*DocSearchResult
+	q := strings.ToLower(query)
+	for id, doc := range s.docs {
+		if strings.Contains(strings.ToLower(id), q) || strings.Contains(strings.ToLower(doc.Title), q) || strings.Contains(strings.ToLower(doc.Description), q) || strings.Contains(strings.ToLower(doc.Content), q) {
+			results = append(results, &DocSearchResult{ID: id, Title: doc.Title, Description: doc.Description})
+		}
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].ID < results[j].ID })
+	return results, nil
+}
+
+func (s *mockRunbookDocStore) SearchCursor(context.Context, SearchDocsOptions) (*exec.CursorResult[DocSearchResult], error) {
+	return nil, nil
+}
+
+func (s *mockRunbookDocStore) SearchMatches(context.Context, string, SearchDocMatchesOptions) (*exec.CursorResult[*exec.Match], error) {
+	return nil, nil
+}
+
+type mockRunbookWorkspaceStore struct {
+	workspaces []*workspacepkg.Workspace
+	err        error
+}
+
+func (s *mockRunbookWorkspaceStore) Create(context.Context, *workspacepkg.Workspace) error {
+	return nil
+}
+func (s *mockRunbookWorkspaceStore) GetByID(context.Context, string) (*workspacepkg.Workspace, error) {
+	return nil, workspacepkg.ErrWorkspaceNotFound
+}
+func (s *mockRunbookWorkspaceStore) GetByName(context.Context, string) (*workspacepkg.Workspace, error) {
+	return nil, workspacepkg.ErrWorkspaceNotFound
+}
+func (s *mockRunbookWorkspaceStore) List(context.Context) ([]*workspacepkg.Workspace, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.workspaces, nil
+}
+func (s *mockRunbookWorkspaceStore) Update(context.Context, *workspacepkg.Workspace) error {
+	return nil
+}
+func (s *mockRunbookWorkspaceStore) Delete(context.Context, string) error { return nil }
+
+func docFromContent(id, content string) *Doc {
+	title := id
+	description := ""
+	if strings.HasPrefix(content, "---\n") {
+		parts := strings.SplitN(strings.TrimPrefix(content, "---\n"), "\n---\n", 2)
+		if len(parts) == 2 {
+			for _, line := range strings.Split(parts[0], "\n") {
+				if v, ok := strings.CutPrefix(line, "title: "); ok {
+					title = strings.Trim(v, `"`)
+				}
+				if v, ok := strings.CutPrefix(line, "description: "); ok {
+					description = strings.Trim(v, `"`)
+				}
+			}
+		}
+	}
+	return &Doc{ID: id, Title: title, Description: description, Content: content}
+}
+
+func runbookInput(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}
+
+func decodeRunbookOutput(t *testing.T, out ToolOut) map[string]any {
+	t.Helper()
+	require.False(t, out.IsError, out.Content)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &decoded))
+	return decoded
+}
+
+func TestRunbookManageTool_ListSearchGet(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	store.docs["runbooks/deploy"] = &Doc{ID: "runbooks/deploy", Title: "Deploy", Description: "Deploy production safely", Content: "# Deploy\n"}
+	store.docs["notes/other"] = &Doc{ID: "notes/other", Title: "Other", Content: "# Other\n"}
+	tool := NewRunbookManageTool(store)
+
+	list := decodeRunbookOutput(t, tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "list", "limit": 10})))
+	runbooks := list["runbooks"].([]any)
+	require.Len(t, runbooks, 2)
+	assert.Equal(t, "runbooks/deploy", runbooks[1].(map[string]any)["id"])
+	assert.Equal(t, "Deploy production safely", runbooks[1].(map[string]any)["description"])
+	assert.NotContains(t, runbooks[1].(map[string]any), "content")
+
+	search := decodeRunbookOutput(t, tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "search", "query": "production"})))
+	results := search["results"].([]any)
+	require.Len(t, results, 1)
+	assert.Equal(t, "runbooks/deploy", results[0].(map[string]any)["id"])
+
+	get := decodeRunbookOutput(t, tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "get", "id": "runbooks/deploy"})))
+	assert.Equal(t, "Deploy", get["title"])
+	assert.Equal(t, "# Deploy\n", get["body"])
+}
+
+func TestRunbookManageTool_CreatePatchEnsureMetadata(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+	ctx := ToolContext{Context: context.Background(), Role: auth.RoleAdmin}
+
+	create := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":      "create",
+		"id":          "runbooks/restart-api",
+		"title":       "Restart API",
+		"description": "Restart the API and verify health",
+		"content":     "# Restart API\n\nRun the restart command.\n",
+	})))
+	assert.Equal(t, true, create["updated"])
+	require.Contains(t, store.docs, "runbooks/restart-api")
+	assert.Contains(t, store.docs["runbooks/restart-api"].Content, "title: Restart API")
+	assert.Contains(t, store.docs["runbooks/restart-api"].Content, "description: Restart the API and verify health")
+
+	patch := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":     "patch",
+		"id":         "runbooks/restart-api",
+		"old_string": "Run the restart command.",
+		"new_string": "Run the restart command, then check /healthz.",
+	})))
+	assert.Equal(t, true, patch["updated"])
+	assert.Contains(t, store.docs["runbooks/restart-api"].Content, "check /healthz")
+
+	store.docs["runbooks/plain"] = &Doc{ID: "runbooks/plain", Title: "plain", Content: "# Plain\n"}
+	ensure := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":      "ensure_metadata",
+		"id":          "runbooks/plain",
+		"title":       "Plain",
+		"description": "Plain runbook",
+	})))
+	assert.Equal(t, true, ensure["updated"])
+	assert.Contains(t, store.docs["runbooks/plain"].Content, "title: Plain")
+	assert.Contains(t, store.docs["runbooks/plain"].Content, "# Plain")
+}
+
+func TestRunbookManageTool_WritePermissionAndInvalidID(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+
+	out := tool.Run(ToolContext{Context: context.Background(), Role: auth.RoleViewer}, runbookInput(t, map[string]any{"action": "create", "id": "runbooks/new", "content": "# New"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "write permission")
+
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "get", "id": "../secrets"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+}
+
+func TestRunbookManageTool_AvailabilityAndInputErrors(t *testing.T) {
+	t.Parallel()
+	tool := NewRunbookManageTool(nil)
+	out := tool.Run(ToolContext{}, runbookInput(t, map[string]any{"action": "list"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "unavailable")
+
+	tool = NewRunbookManageTool(newMockRunbookDocStore())
+	out = tool.Run(ToolContext{}, json.RawMessage(`{invalid`))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to parse")
+
+	out = tool.Run(ToolContext{}, runbookInput(t, map[string]any{"action": "list"}))
+	assert.False(t, out.IsError, out.Content)
+
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "bogus"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Unknown action")
+}
+
+func TestRunbookManageTool_ListAndSearchErrors(t *testing.T) {
+	t.Parallel()
+
+	storeWithMany := newMockRunbookDocStore()
+	storeWithMany.docs["runbooks/a"] = &Doc{ID: "runbooks/a", Title: "A", Content: "# A"}
+	storeWithMany.docs["runbooks/b"] = &Doc{ID: "runbooks/b", Title: "B", Content: "# B"}
+	tool := NewRunbookManageTool(storeWithMany)
+	list := decodeRunbookOutput(t, tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "list", "limit": 1})))
+	require.Len(t, list["runbooks"].([]any), 1)
+
+	search := decodeRunbookOutput(t, tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "search", "query": "runbooks", "limit": 1})))
+	require.Len(t, search["results"].([]any), 1)
+
+	tool = NewRunbookManageTool(&mockRunbookDocStore{docs: map[string]*Doc{}, listErr: errRunbookForced})
+	out := tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "list"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to list")
+
+	store := newMockRunbookDocStore()
+	tool = NewRunbookManageToolWithWorkspaceStore(store, &mockRunbookWorkspaceStore{err: errRunbookForced})
+	out = tool.Run(ToolContext{
+		Context: context.Background(),
+		User: UserIdentity{
+			UserID:          "u1",
+			Role:            auth.RoleViewer,
+			WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{{Workspace: "ops", Role: auth.RoleViewer}}},
+		},
+	}, runbookInput(t, map[string]any{"action": "list"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to filter")
+
+	tool = NewRunbookManageTool(store)
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "search"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "query is required")
+
+	store.searchErr = errRunbookForced
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "search", "query": "deploy"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to search")
+}
+
+func TestRunbookManageTool_GetErrors(t *testing.T) {
+	t.Parallel()
+
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+	out := tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "get", "id": "runbooks/missing"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "doc not found")
+
+	store.getErr = errRunbookForced
+	out = tool.Run(ToolContext{Context: context.Background()}, runbookInput(t, map[string]any{"action": "get", "id": "runbooks/forced"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "forced runbook error")
+
+	tool = NewRunbookManageToolWithWorkspaceStore(store, &mockRunbookWorkspaceStore{err: errRunbookForced})
+	out = tool.Run(ToolContext{Context: context.Background(), Role: auth.RoleViewer}, runbookInput(t, map[string]any{"action": "get", "id": "ops/runbooks/restart"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to filter")
+}
+
+func TestRunbookManageTool_EnforcesVisibleWorkspacesForAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	store.docs["ops/runbooks/restart"] = &Doc{ID: "ops/runbooks/restart", Title: "Restart", Description: "visible", Content: "# Restart\n"}
+	store.docs["prod/runbooks/deploy"] = &Doc{ID: "prod/runbooks/deploy", Title: "Deploy", Description: "hidden production", Content: "# Deploy\n"}
+	store.docs["runbooks/general"] = &Doc{ID: "runbooks/general", Title: "General", Description: "unscoped", Content: "# General\n"}
+	tool := NewRunbookManageToolWithWorkspaceStore(store, &mockRunbookWorkspaceStore{workspaces: []*workspacepkg.Workspace{{Name: "ops"}, {Name: "prod"}}})
+	ctx := ToolContext{
+		Context: context.Background(),
+		User: UserIdentity{
+			UserID:          "u1",
+			Role:            auth.RoleViewer,
+			WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{{Workspace: "ops", Role: auth.RoleViewer}}},
+		},
+	}
+
+	list := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{"action": "list", "limit": 10})))
+	runbooks := list["runbooks"].([]any)
+	require.Len(t, runbooks, 2)
+	ids := []string{runbooks[0].(map[string]any)["id"].(string), runbooks[1].(map[string]any)["id"].(string)}
+	assert.Contains(t, ids, "ops/runbooks/restart")
+	assert.Contains(t, ids, "runbooks/general")
+	assert.NotContains(t, ids, "prod/runbooks/deploy")
+
+	search := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{"action": "search", "query": "hidden", "limit": 10})))
+	results := search["results"].([]any)
+	require.Empty(t, results)
+
+	out := tool.Run(ctx, runbookInput(t, map[string]any{"action": "get", "id": "prod/runbooks/deploy"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "not found")
+
+	store.ignoreExcludePathRoots = true
+	list = decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{"action": "list", "limit": 10})))
+	runbooks = list["runbooks"].([]any)
+	require.Len(t, runbooks, 2)
+	ids = []string{runbooks[0].(map[string]any)["id"].(string), runbooks[1].(map[string]any)["id"].(string)}
+	assert.NotContains(t, ids, "prod/runbooks/deploy")
+}
+
+func TestRunbookManageTool_EnforcesWorkspaceWriteRole(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	store.docs["ops/runbooks/restart"] = &Doc{ID: "ops/runbooks/restart", Title: "Restart", Content: "# Restart\n"}
+	tool := NewRunbookManageToolWithWorkspaceStore(store, &mockRunbookWorkspaceStore{workspaces: []*workspacepkg.Workspace{{Name: "ops"}}})
+
+	viewerCtx := ToolContext{Context: context.Background(), User: UserIdentity{UserID: "u1", Role: auth.RoleViewer, WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{{Workspace: "ops", Role: auth.RoleViewer}}}}}
+	out := tool.Run(viewerCtx, runbookInput(t, map[string]any{"action": "patch", "id": "ops/runbooks/restart", "old_string": "Restart", "new_string": "Restart API"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "write permission")
+
+	managerCtx := ToolContext{Context: context.Background(), User: UserIdentity{UserID: "u1", Role: auth.RoleViewer, WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{{Workspace: "ops", Role: auth.RoleManager}}}}}
+	out = tool.Run(managerCtx, runbookInput(t, map[string]any{"action": "patch", "id": "ops/runbooks/restart", "old_string": "Restart", "new_string": "Restart API"}))
+	require.False(t, out.IsError, out.Content)
+}
+
+func TestRunbookManageTool_CreateUpdatePatchErrors(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+	ctx := ToolContext{Context: context.Background(), Role: auth.RoleAdmin}
+
+	out := tool.Run(ctx, runbookInput(t, map[string]any{"action": "create", "id": "../bad", "content": "# Bad"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+
+	_, ok := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{"action": "create", "id": "runbooks/existing", "content": "# Existing"})))["updated"].(bool)
+	assert.True(t, ok)
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "create", "id": "runbooks/existing", "content": "# Existing"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "already exists")
+
+	store.createErr = errRunbookForced
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "create", "id": "runbooks/create-error", "content": "# Error"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "forced runbook error")
+	store.createErr = nil
+
+	update := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{"action": "update", "id": "runbooks/existing", "content": "# Updated\n"})))
+	assert.Equal(t, true, update["updated"])
+	assert.Equal(t, "# Updated\n", store.docs["runbooks/existing"].Content)
+
+	update = decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":      "update",
+		"id":          "runbooks/existing",
+		"title":       "Updated",
+		"description": "Updated desc",
+		"content":     "# Body\n",
+	})))
+	assert.Equal(t, true, update["updated"])
+	assert.Contains(t, store.docs["runbooks/existing"].Content, "title: Updated")
+	assert.Contains(t, store.docs["runbooks/existing"].Content, "# Body")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "update", "id": "../bad", "content": "# Bad"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "update", "id": "runbooks/missing", "content": "# Missing"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "doc not found")
+
+	store.updateErr = errRunbookForced
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "update", "id": "runbooks/existing", "content": "# Forced"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "forced runbook error")
+	store.updateErr = nil
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "patch", "id": "runbooks/existing"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "old_string is required")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "patch", "id": "runbooks/missing", "old_string": "x", "new_string": "y"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "doc not found")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "patch", "id": "runbooks/existing", "old_string": "absent", "new_string": "present"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "not found")
+
+	store.docs["runbooks/repeated"] = &Doc{ID: "runbooks/repeated", Title: "Repeated", Content: "same same"}
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "patch", "id": "runbooks/repeated", "old_string": "same", "new_string": "different"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "found 2 times")
+
+	store.updateErr = errRunbookForced
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "patch", "id": "runbooks/existing", "old_string": "Body", "new_string": "Forced"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "forced runbook error")
+
+	out = runbookCreate(ctx, store, runbookManageInput{ID: "../bad", Content: "# Bad"})
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+}
+
+func TestRunbookManageTool_EnsureMetadataErrorsAndNoop(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	tool := NewRunbookManageTool(store)
+	ctx := ToolContext{Context: context.Background(), Role: auth.RoleAdmin}
+
+	out := tool.Run(ctx, runbookInput(t, map[string]any{"action": "ensure_metadata", "id": "../bad"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "ensure_metadata", "id": "runbooks/missing"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "doc not found")
+
+	content := "---\ntitle: Plain\ndescription: Plain runbook\n---\n\n# Plain\n"
+	store.docs["runbooks/plain"] = docFromContent("runbooks/plain", content)
+	noop := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":      "ensure_metadata",
+		"id":          "runbooks/plain",
+		"title":       "Plain",
+		"description": "Plain runbook",
+	})))
+	assert.Equal(t, false, noop["updated"])
+
+	store.updateErr = errRunbookForced
+	out = tool.Run(ctx, runbookInput(t, map[string]any{
+		"action":      "ensure_metadata",
+		"id":          "runbooks/plain",
+		"title":       "Different",
+		"description": "Plain runbook",
+	}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "forced runbook error")
+
+	store.updateErr = nil
+	store.docs["runbooks/fallback"] = &Doc{ID: "runbooks/fallback", Title: "Fallback", Description: "Fallback desc", Content: "# Fallback\n"}
+	updated := decodeRunbookOutput(t, tool.Run(ctx, runbookInput(t, map[string]any{
+		"action": "ensure_metadata",
+		"id":     "runbooks/fallback",
+	})))
+	assert.Equal(t, true, updated["updated"])
+	assert.Contains(t, store.docs["runbooks/fallback"].Content, "title: Fallback")
+
+	out = runbookEnsureMetadata(ctx, store, runbookManageInput{ID: "../bad"})
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "invalid")
+}
+
+func TestRunbookManageHelpers(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, defaultRunbookLimit, normalizeRunbookLimit(0))
+	assert.Equal(t, maxRunbookLimit, normalizeRunbookLimit(maxRunbookLimit+1))
+	assert.Equal(t, 7, normalizeRunbookLimit(7))
+
+	assert.Empty(t, formatRunbookTime(time.Time{}))
+	assert.NotEmpty(t, formatRunbookTime(time.Unix(1700000000, 0)))
+
+	assert.Equal(t, "plain", sanitizeFrontmatterValue(" plain "))
+	assert.Equal(t, `"needs: quoting"`, sanitizeFrontmatterValue("needs: quoting"))
+
+	out := runbookJSON(func() {})
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Failed to encode")
+
+	deps := runbookManageDeps{
+		workspaceStore: &mockRunbookWorkspaceStore{workspaces: []*workspacepkg.Workspace{{Name: "ops"}}},
+	}
+	workspaceName, err := runbookWorkspaceName(context.Background(), deps, "ops")
+	require.NoError(t, err)
+	assert.Empty(t, workspaceName)
+
+	workspaceName, err = runbookWorkspaceName(context.Background(), deps, "other/runbook")
+	require.NoError(t, err)
+	assert.Empty(t, workspaceName)
+
+	roots, err := runbookExcludedPathRoots(ToolContext{Context: context.Background()}, deps)
+	require.NoError(t, err)
+	assert.Nil(t, roots)
+}
+
+func TestRunbookManageTool_RejectsDeleteAndUpdateWithoutContent(t *testing.T) {
+	t.Parallel()
+	store := newMockRunbookDocStore()
+	store.docs["runbooks/plain"] = &Doc{ID: "runbooks/plain", Title: "Plain", Content: "# Plain\n"}
+	tool := NewRunbookManageTool(store)
+	ctx := ToolContext{Context: context.Background(), Role: auth.RoleAdmin}
+
+	out := tool.Run(ctx, runbookInput(t, map[string]any{"action": "delete", "id": "runbooks/plain"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "Unknown action")
+
+	out = tool.Run(ctx, runbookInput(t, map[string]any{"action": "update", "id": "runbooks/plain", "title": "Renamed"}))
+	assert.True(t, out.IsError)
+	assert.Contains(t, out.Content, "content is required")
+	assert.Equal(t, "# Plain\n", store.docs["runbooks/plain"].Content)
+}

--- a/internal/agent/runbook_manage_test.go
+++ b/internal/agent/runbook_manage_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -64,12 +65,7 @@ func (s *mockRunbookDocStore) ListFlat(_ context.Context, opts ListDocsOptions) 
 
 func runbookTestRootExcluded(id string, roots []string) bool {
 	root, _, _ := strings.Cut(id, "/")
-	for _, excluded := range roots {
-		if root == excluded {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(roots, root)
 }
 
 func (s *mockRunbookDocStore) Get(_ context.Context, id string) (*Doc, error) {
@@ -171,10 +167,10 @@ func (s *mockRunbookWorkspaceStore) Delete(context.Context, string) error { retu
 func docFromContent(id, content string) *Doc {
 	title := id
 	description := ""
-	if strings.HasPrefix(content, "---\n") {
-		parts := strings.SplitN(strings.TrimPrefix(content, "---\n"), "\n---\n", 2)
+	if after, ok := strings.CutPrefix(content, "---\n"); ok {
+		parts := strings.SplitN(after, "\n---\n", 2)
 		if len(parts) == 2 {
-			for _, line := range strings.Split(parts[0], "\n") {
+			for line := range strings.SplitSeq(parts[0], "\n") {
 				if v, ok := strings.CutPrefix(line, "title: "); ok {
 					title = strings.Trim(v, `"`)
 				}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/llm"
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
 )
 
@@ -55,6 +56,8 @@ type SessionManager struct {
 	thinkingEffort        llm.ThinkingEffort
 	totalCost             float64
 	memoryStore           MemoryStore
+	docStore              DocStore
+	workspaceStore        workspacepkg.Store
 	dagName               string
 	sessionStore          SessionStore
 	parentSessionID       string
@@ -100,6 +103,8 @@ type SessionManagerConfig struct {
 	OutputCostPer1M float64
 	ThinkingEffort  llm.ThinkingEffort
 	MemoryStore     MemoryStore
+	DocStore        DocStore
+	WorkspaceStore  workspacepkg.Store
 	DAGName         string
 	SessionStore    SessionStore
 	// ParentSessionID links this session to its parent (non-empty = sub-session).
@@ -191,6 +196,8 @@ func NewSessionManager(cfg SessionManagerConfig) *SessionManager {
 		thinkingEffort:        cfg.ThinkingEffort,
 		totalCost:             totalCost,
 		memoryStore:           cfg.MemoryStore,
+		docStore:              cfg.DocStore,
+		workspaceStore:        cfg.WorkspaceStore,
 		dagName:               cfg.DAGName,
 		sessionStore:          cfg.SessionStore,
 		parentSessionID:       cfg.ParentSessionID,
@@ -820,6 +827,8 @@ func (sm *SessionManager) createLoop(provider llm.Provider, model string, histor
 		History:  history,
 		Tools: CreateTools(ToolConfig{
 			DAGsDir:               sm.environment.DAGsDir,
+			DocStore:              sm.docStore,
+			WorkspaceStore:        sm.workspaceStore,
 			RemoteContextResolver: sm.remoteContextResolver,
 		}),
 		RecordMessage: sm.createRecordMessageFunc(),

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -16,8 +16,9 @@ Write memories as declarative facts, not instructions to yourself. 'User prefers
 
 When the user references something from a past conversation or you suspect relevant cross-session context exists, use session_search to recall it before asking them to repeat themselves.
 
-When approaching a complex task, check if there's any available runbook. After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a runbook so you can refer it next time.
-When using a runbook and finding it outdated, incomplete, or wrong, patch it immediately — don't wait to be asked. Runbooks that aren't maintained become liabilities.
+When approaching a complex or operational task, use `runbook_manage` with `search` or `list` to check for relevant runbooks before acting. If a relevant runbook exists, use `runbook_manage` with `get` to read it first.
+After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a runbook with `runbook_manage` so you can refer it next time.
+When using a runbook and finding it outdated, incomplete, or wrong, patch it immediately with `runbook_manage` — don't wait to be asked. Runbooks that aren't maintained become liabilities. Do not delete runbooks without explicit user confirmation.
 
 # Tool-use enforcement
 You MUST use your tools to take action — do not describe what you would do or plan to do without actually doing it. When you say you will perform an action (e.g. 'I will run the tests', 'Let me check the file', 'I will create the project'), you MUST immediately make the corresponding tool call in the same response. Never end your turn with a promise of future action — execute it now.
@@ -232,19 +233,20 @@ Actively report your progress during multi-step work so the user is not left wai
 - `session_search`: Search past persisted session transcripts for previous conversations and task context.
 - `navigate`: Open a UI page (/dags/<name>, /dag-runs/<name>/<id>, /docs, /docs/<doc-id>).
 - `delegate`: Spawn a sub-agent for a focused sub-task. The sub-agent works independently with the same tools and returns a summary. Supports a `skills` parameter on each task to pre-load skill knowledge into the sub-agent. You can delegate multiple tasks simultaneously.
+- `runbook_manage`: List/search/get/create/update/patch Markdown runbooks in the docs store. Use it before complex tasks and to keep runbooks current.
 - `search_skills`: Discover available skills by keyword or label. Returns summaries without loading full knowledge.
 </tools>
 
 <docs>
 When a user message begins with [Doc: id | title] document markers, these reference markdown
-documents stored under {{.DocsDir}}/. To access a referenced document:
-1. Validate the id: reject any id containing "..", leading "/", or backslashes
-2. Reconstruct the file path: {{.DocsDir}}/<id>.md
-3. Use `read` to load the content
-4. Use `patch` to modify the content if needed
+documents stored under {{.DocsDir}}/. To access or maintain referenced documents and runbooks:
+1. Use `runbook_manage` with action `get` and the referenced id to load content and metadata.
+2. Use `runbook_manage` with action `patch`, `update`, or `ensure_metadata` to modify runbooks when needed.
+3. Prefer `runbook_manage` over reconstructing file paths. Only fall back to `read`/`patch` on {{.DocsDir}}/<id>.md if the runbook tool is unavailable.
+4. Do not delete runbooks without explicit user confirmation.
 
 The id is the relative path without the .md extension (e.g., "runbooks/deployment"
-maps to {{.DocsDir}}/runbooks/deployment.md).
+maps to {{.DocsDir}}/runbooks/deployment.md). Runbooks may include YAML frontmatter with only `title` and `description` metadata.
 </docs>
 
 <workflows>

--- a/internal/agent/tool_registry.go
+++ b/internal/agent/tool_registry.go
@@ -3,7 +3,11 @@
 
 package agent
 
-import "slices"
+import (
+	"slices"
+
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
+)
 
 // ToolRegistration contains metadata and a factory for a single tool.
 // Each tool registers itself via init() so the registry is the single source of truth.
@@ -24,6 +28,11 @@ type ToolRegistration struct {
 type ToolConfig struct {
 	// DAGsDir is the directory containing DAG definition files.
 	DAGsDir string
+	// DocStore provides access to Markdown docs/runbooks for runbook_manage.
+	// Nil means runbook_manage reports unavailable when called.
+	DocStore DocStore
+	// WorkspaceStore provides workspace names for workspace-scoped tools.
+	WorkspaceStore workspacepkg.Store
 	// RemoteContextResolver provides access to remote CLI contexts for remote_agent tools.
 	// Nil means remote context tools are not available.
 	RemoteContextResolver RemoteContextResolver

--- a/internal/agent/tool_registry_test.go
+++ b/internal/agent/tool_registry_test.go
@@ -30,6 +30,7 @@ func TestRegisteredTools_ContainsAllExpected(t *testing.T) {
 		"navigate", "ask_user",
 		"session_search",
 		"delegate",
+		"runbook_manage",
 		"remote_agent", "list_contexts",
 	}
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -328,6 +328,9 @@ type UserIdentity struct {
 	IPAddress string
 	// Role is the authenticated user's role.
 	Role auth.Role
+	// WorkspaceAccess restricts the user's access to selected workspaces.
+	// Nil is treated as all-workspaces for backward compatibility.
+	WorkspaceAccess *auth.WorkspaceAccess
 }
 
 // SubSessionRegistry manages sub-session lifecycle for delegate tools.

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -83,6 +83,7 @@ import (
 	"github.com/dagucloud/dagu/internal/service/resource"
 	"github.com/dagucloud/dagu/internal/tunnel"
 	"github.com/dagucloud/dagu/internal/upgrade"
+	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 )
 
 const (
@@ -383,7 +384,7 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 
 	var agentAPI *agent.API
 	if agentConfigStore != nil {
-		agentAPI, err = initAgentAPI(ctx, agentConfigStore, agentModelStore, agentSoulStore, agentOAuthManager, &cfg.Paths, referencesDir, cfg.Server.Session.MaxPerUser, dr, auditSvc, auditEnabled, eventSvc, memoryStore, newRemoteNodeAdapter(remoteNodeResolver))
+		agentAPI, err = initAgentAPI(ctx, agentConfigStore, agentModelStore, agentSoulStore, agentOAuthManager, &cfg.Paths, referencesDir, cfg.Server.Session.MaxPerUser, dr, auditSvc, auditEnabled, eventSvc, memoryStore, docStore, wsStore, newRemoteNodeAdapter(remoteNodeResolver))
 		if err != nil {
 			logger.Warn(ctx, "Failed to initialize agent API", tag.Error(err))
 		}
@@ -753,7 +754,7 @@ func initSyncService(ctx context.Context, cfg *config.Config) gitsync.Service {
 
 // initAgentAPI creates and returns an agent API.
 // The API uses the config store to check enabled status and resolve providers via the model store.
-func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore agent.ModelStore, soulStore agent.SoulStore, oauthManager *agentoauth.Manager, paths *config.PathsConfig, referencesDir string, sessionMaxPerUser int, dagStore exec.DAGStore, auditSvc *audit.Service, auditEnabled func() bool, eventSvc *eventstore.Service, memoryStore agent.MemoryStore, remoteResolver agent.RemoteContextResolver) (*agent.API, error) {
+func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore agent.ModelStore, soulStore agent.SoulStore, oauthManager *agentoauth.Manager, paths *config.PathsConfig, referencesDir string, sessionMaxPerUser int, dagStore exec.DAGStore, auditSvc *audit.Service, auditEnabled func() bool, eventSvc *eventstore.Service, memoryStore agent.MemoryStore, docStore agent.DocStore, workspaceStore workspacepkg.Store, remoteResolver agent.RemoteContextResolver) (*agent.API, error) {
 	sessStore, err := filesession.New(paths.SessionsDir, filesession.WithMaxPerUser(sessionMaxPerUser))
 	if err != nil {
 		logger.Warn(ctx, "Failed to create session store, persistence disabled", tag.Error(err))
@@ -776,6 +777,8 @@ func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore 
 		Hooks:                 hooks,
 		EventService:          eventSvc,
 		MemoryStore:           memoryStore,
+		DocStore:              docStore,
+		WorkspaceStore:        workspaceStore,
 		OAuthManager:          oauthManager,
 		RemoteContextResolver: remoteResolver,
 		Environment: agent.EnvironmentInfo{


### PR DESCRIPTION
## Summary
- add an agent `runbook_manage` tool for listing, searching, reading, creating, updating, patching, and ensuring metadata on Markdown runbooks
- wire the docs and workspace stores through agent API/session/tool construction
- update the built-in agent prompt to prefer runbook management for complex and operational workflows
- add runbook management coverage for permissions, workspace filtering, update safety, and error paths

## Validation
- `go test ./internal/agent -run 'TestRunbookManage|TestRegisteredTools' -count=1`
- `go test ./internal/service/frontend/...`
- `go test ./internal/agent -coverprofile=/tmp/dagu-agent-runbook.cover`
- `runbook_manage.go` statement coverage: 97.3% (220/226)

## Notes
- `go test ./...` was run locally before this push and reached the end, but existing Docker-backed `internal/intg` tests failed while waiting on test containers unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runbook management capabilities enabling users to create, search, list, retrieve, update, and patch Markdown documentation.
  * Updated agent system prompts to automatically check and leverage existing runbooks for complex operational tasks.
  * Added workspace-scoped access control for runbook resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->