### PR TITLE
Add agent DAG management tools and run watches

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -17,8 +17,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func engineTestTimeout(timeout time.Duration) time.Duration {
+	if runtime.GOOS == "windows" {
+		return timeout * 3
+	}
+	return timeout
+}
+
 func TestEngineRunFile(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), engineTestTimeout(20*time.Second))
 	defer cancel()
 
 	home := t.TempDir()
@@ -53,7 +60,7 @@ steps:
 }
 
 func TestEngineRunYAML(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), engineTestTimeout(20*time.Second))
 	defer cancel()
 
 	originalWorkingDir, err := os.Getwd()
@@ -82,7 +89,7 @@ steps:
 }
 
 func TestEngineDistributedRequiresCoordinator(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), engineTestTimeout(20*time.Second))
 	defer cancel()
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: t.TempDir()})

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1168,6 +1168,7 @@ func (a *API) CreateSession(ctx context.Context, user UserIdentity, req ChatRequ
 	if err := mgr.AcceptUserMessage(ctx, provider, model, modelCfg.Model, messageWithContext); err != nil {
 		a.logger.Error("Failed to accept user message", "error", err)
 		a.sessions.Delete(id)
+		a.clearDAGRunWatchesForSession(id)
 		return "", "", ErrFailedToProcessMessage
 	}
 
@@ -1312,6 +1313,7 @@ func (a *API) CompactSessionIfNeeded(ctx context.Context, sessionID string, user
 		},
 	}); err != nil {
 		a.sessions.Delete(newID)
+		a.clearDAGRunWatchesForSession(newID)
 		return "", false, err
 	}
 
@@ -1327,6 +1329,7 @@ func (a *API) CompactSessionIfNeeded(ctx context.Context, sessionID string, user
 	}
 	if err := a.ensureSessionLoop(newMgr, provider, runtimeCfg); err != nil {
 		a.sessions.Delete(newID)
+		a.clearDAGRunWatchesForSession(newID)
 		if a.store != nil {
 			if delErr := a.store.DeleteSession(ctx, newID); delErr != nil && !errors.Is(delErr, ErrSessionNotFound) {
 				a.logger.Warn("Failed to roll back compacted session after loop init error", "session_id", newID, "error", delErr)
@@ -1337,6 +1340,7 @@ func (a *API) CompactSessionIfNeeded(ctx context.Context, sessionID string, user
 
 	_ = mgr.Cancel(ctx)
 	a.sessions.Delete(sessionID)
+	a.clearDAGRunWatchesForSession(sessionID)
 
 	return newID, true, nil
 }
@@ -1652,6 +1656,7 @@ func (a *API) CancelSession(ctx context.Context, sessionID, userID string) error
 		a.logger.Error("Failed to cancel session", "error", err)
 		return ErrFailedToCancel
 	}
+	a.clearDAGRunWatchesForSession(sessionID)
 
 	return nil
 }
@@ -1756,6 +1761,7 @@ func (a *API) cleanupIdleSessions() {
 				a.logger.Warn("Failed to cancel stuck session", "session_id", id, "error", err)
 			} else {
 				a.logger.Warn("Cancelled stuck session", "session_id", id)
+				a.clearDAGRunWatchesForSession(id)
 			}
 		}
 		// Cancelled sessions remain in the map until the next cleanup cycle
@@ -1773,7 +1779,19 @@ func (a *API) cleanupIdleSessions() {
 			}
 		}
 		a.sessions.Delete(id)
+		a.clearDAGRunWatchesForSession(id)
 		a.logger.Debug("Cleaned up idle session", "session_id", id)
+	}
+}
+
+func (a *API) clearDAGRunWatchesForSession(sessionID string) {
+	cleaner, ok := a.dagRunWatcher.(DAGRunWatchCleaner)
+	if !ok {
+		return
+	}
+	removed := cleaner.ClearSession(sessionID)
+	if removed > 0 {
+		a.logger.Debug("Cleared DAG run watches for session", "session_id", sessionID, "count", removed)
 	}
 }
 

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1377,6 +1377,23 @@ func (a *API) prepareSessionRuntime(ctx context.Context, mgr *SessionManager, us
 	return provider, model, modelCfg.Model, nil
 }
 
+func (a *API) prepareInternalSessionRuntime(ctx context.Context, mgr *SessionManager, user UserIdentity) (llm.Provider, string, string, error) {
+	mgr.UpdateUserContext(user)
+
+	model := selectModel("", mgr.GetModel(), a.getDefaultModelID(ctx))
+	provider, modelCfg, err := a.resolveProvider(ctx, model)
+	if err != nil {
+		a.logger.Error("Failed to get LLM provider", "error", err)
+		return nil, "", "", ErrAgentNotConfigured
+	}
+
+	mgr.UpdatePricing(modelCfg.InputCostPer1M, modelCfg.OutputCostPer1M)
+	mgr.UpdateThinkingEffort(modelThinkingEffort(modelCfg))
+	mgr.UpdateLoopProvider(provider, modelCfg.Model)
+	a.persistSessionModel(ctx, mgr, model)
+	return provider, model, modelCfg.Model, nil
+}
+
 // EnqueueChatMessage accepts bot chat input for an existing session. Idle sessions
 // start immediately, while working sessions merge the text into a queued
 // safe-boundary interrupt turn.
@@ -1483,6 +1500,23 @@ func (a *API) FlushQueuedChatMessage(ctx context.Context, sessionID string, user
 	}
 	targetMgr.CompleteQueuedChatFlush()
 	return ChatQueueResult{SessionID: targetSessionID, Rotated: rotated, Started: true}, nil
+}
+
+func (a *API) enqueueInternalAgentMessage(ctx context.Context, sessionID string, user UserIdentity, content string) error {
+	mgr, ok := a.getOrReactivateSession(ctx, sessionID, user)
+	if !ok {
+		return ErrSessionNotFound
+	}
+
+	provider, model, resolvedModel, err := a.prepareInternalSessionRuntime(ctx, mgr, user)
+	if err != nil {
+		return err
+	}
+	if err := mgr.enqueueInternalUserMessage(provider, model, resolvedModel, content); err != nil {
+		a.logger.Error("Failed to enqueue internal agent message", "error", err)
+		return ErrFailedToProcessMessage
+	}
+	return nil
 }
 
 // isValidUUID checks if a string is a valid UUID.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -95,6 +95,9 @@ type API struct {
 	workingDir            string
 	logger                *slog.Logger
 	dagStore              DAGMetadataStore // For resolving DAG file paths
+	dagDefinitionStore    exec.DAGStore    // For dag_def_manage
+	dagRunStore           exec.DAGRunStore // For dag_run_manage
+	dagRunWatcher         DAGRunWatcher    // For dag_run_manage watch actions
 	environment           EnvironmentInfo
 	hooks                 *Hooks
 	memoryStore           MemoryStore
@@ -115,6 +118,9 @@ type APIConfig struct {
 	Logger                *slog.Logger
 	SessionStore          SessionStore
 	DAGStore              DAGMetadataStore // For resolving DAG file paths
+	DAGDefinitionStore    exec.DAGStore    // For dag_def_manage
+	DAGRunStore           exec.DAGRunStore // For dag_run_manage
+	DAGRunWatcher         DAGRunWatcher    // Optional override for dag_run_manage watch actions
 	Environment           EnvironmentInfo
 	Hooks                 *Hooks
 	MemoryStore           MemoryStore
@@ -154,8 +160,14 @@ func NewAPI(cfg APIConfig) *API {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	dagDefinitionStore := cfg.DAGDefinitionStore
+	if dagDefinitionStore == nil {
+		if store, ok := cfg.DAGStore.(exec.DAGStore); ok {
+			dagDefinitionStore = store
+		}
+	}
 
-	return &API{
+	api := &API{
 		configStore:           cfg.ConfigStore,
 		modelStore:            cfg.ModelStore,
 		soulStore:             cfg.SoulStore,
@@ -164,6 +176,9 @@ func NewAPI(cfg APIConfig) *API {
 		logger:                logger,
 		store:                 cfg.SessionStore,
 		dagStore:              cfg.DAGStore,
+		dagDefinitionStore:    dagDefinitionStore,
+		dagRunStore:           cfg.DAGRunStore,
+		dagRunWatcher:         cfg.DAGRunWatcher,
 		environment:           cfg.Environment,
 		hooks:                 cfg.Hooks,
 		memoryStore:           cfg.MemoryStore,
@@ -173,6 +188,10 @@ func NewAPI(cfg APIConfig) *API {
 		oauthManager:          cfg.OAuthManager,
 		eventService:          cfg.EventService,
 	}
+	if api.dagRunWatcher == nil && api.dagRunStore != nil {
+		api.dagRunWatcher = newDAGRunWatchRegistry(api.dagRunStore, api.notifyDAGRunWatch, api.logger)
+	}
+	return api
 }
 
 // RegisterRoutes registers the agent SSE stream route on the given router.
@@ -572,6 +591,9 @@ func (a *API) buildSessionManagerConfig(id string, user UserIdentity, cfg sessio
 		MemoryStore:           a.memoryStore,
 		DocStore:              a.docStore,
 		WorkspaceStore:        a.workspaceStore,
+		DAGDefinitionStore:    a.dagDefinitionStore,
+		DAGRunStore:           a.dagRunStore,
+		DAGRunWatcher:         a.dagRunWatcher,
 		DAGName:               cfg.dagName,
 		SessionStore:          a.store,
 		Soul:                  cfg.soul,

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -94,8 +94,7 @@ type API struct {
 	providers             *ProviderCache
 	workingDir            string
 	logger                *slog.Logger
-	dagStore              DAGMetadataStore // For resolving DAG file paths
-	dagDefinitionStore    exec.DAGStore    // For dag_def_manage
+	dagStore              exec.DAGStore    // For resolving DAG file paths and dag_def_manage
 	dagRunStore           exec.DAGRunStore // For dag_run_manage
 	dagRunWatcher         DAGRunWatcher    // For dag_run_manage watch actions
 	environment           EnvironmentInfo
@@ -117,8 +116,7 @@ type APIConfig struct {
 	WorkingDir            string
 	Logger                *slog.Logger
 	SessionStore          SessionStore
-	DAGStore              DAGMetadataStore // For resolving DAG file paths
-	DAGDefinitionStore    exec.DAGStore    // For dag_def_manage
+	DAGStore              exec.DAGStore    // For resolving DAG file paths and dag_def_manage
 	DAGRunStore           exec.DAGRunStore // For dag_run_manage
 	DAGRunWatcher         DAGRunWatcher    // Optional override for dag_run_manage watch actions
 	Environment           EnvironmentInfo
@@ -160,13 +158,6 @@ func NewAPI(cfg APIConfig) *API {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	dagDefinitionStore := cfg.DAGDefinitionStore
-	if dagDefinitionStore == nil {
-		if store, ok := cfg.DAGStore.(exec.DAGStore); ok {
-			dagDefinitionStore = store
-		}
-	}
-
 	api := &API{
 		configStore:           cfg.ConfigStore,
 		modelStore:            cfg.ModelStore,
@@ -176,7 +167,6 @@ func NewAPI(cfg APIConfig) *API {
 		logger:                logger,
 		store:                 cfg.SessionStore,
 		dagStore:              cfg.DAGStore,
-		dagDefinitionStore:    dagDefinitionStore,
 		dagRunStore:           cfg.DAGRunStore,
 		dagRunWatcher:         cfg.DAGRunWatcher,
 		environment:           cfg.Environment,
@@ -591,7 +581,7 @@ func (a *API) buildSessionManagerConfig(id string, user UserIdentity, cfg sessio
 		MemoryStore:           a.memoryStore,
 		DocStore:              a.docStore,
 		WorkspaceStore:        a.workspaceStore,
-		DAGDefinitionStore:    a.dagDefinitionStore,
+		DAGStore:              a.dagStore,
 		DAGRunStore:           a.dagRunStore,
 		DAGRunWatcher:         a.dagRunWatcher,
 		DAGName:               cfg.dagName,

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/llm"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
@@ -1438,6 +1440,64 @@ func TestAPI_FlushQueuedChatMessage_RestoresQueuedTextOnSpillFailure(t *testing.
 	assert.True(t, mgr.HasQueuedChatInput())
 	require.Len(t, mgr.queuedChatMessages, 1)
 	assert.Equal(t, raw, mgr.queuedChatMessages[0])
+}
+
+func TestAPI_NotifyDAGRunWatch_QueuesInternalAgentTurn(t *testing.T) {
+	t.Parallel()
+
+	model := testModelConfig("watch-model")
+	api, _ := testAPIWithModels(t, model)
+
+	reqCh := make(chan *llm.ChatRequest, 1)
+	api.providers.Set(model.ToLLMConfig(), newCapturingProvider(reqCh, simpleStopResponse("I checked the watched run.")))
+
+	user := UserIdentity{UserID: "user-1", Username: "user", Role: auth.RoleAdmin}
+	sessionID, err := api.CreateEmptySession(context.Background(), user, "youtube_summary_jp", false)
+	require.NoError(t, err)
+
+	watchReq := DAGRunWatchRequest{
+		SessionID: sessionID,
+		User:      user,
+		DAGName:   "youtube_summary_jp",
+		DAGRunID:  "run-1",
+	}
+	watchInfo := DAGRunWatchInfo{
+		WatchID:  "watch-1",
+		DAGName:  "youtube_summary_jp",
+		DAGRunID: "run-1",
+		Status:   core.Succeeded.String(),
+	}
+	status := &exec.DAGRunStatus{
+		Name:     "youtube_summary_jp",
+		DAGRunID: "run-1",
+		Status:   core.Succeeded,
+	}
+
+	require.NoError(t, api.notifyDAGRunWatch(context.Background(), watchReq, watchInfo, status))
+
+	llmReq := waitForRequest(t, reqCh, time.Second)
+	require.NotEmpty(t, llmReq.Messages)
+	internalMsg := llmReq.Messages[len(llmReq.Messages)-1]
+	assert.Equal(t, llm.RoleUser, internalMsg.Role)
+	assert.Contains(t, internalMsg.Content, "A watched DAG run finished.")
+	assert.Contains(t, internalMsg.Content, "DAG: youtube_summary_jp")
+	assert.Contains(t, internalMsg.Content, "Status: succeeded")
+	assert.NotContains(t, internalMsg.Content, "Use `dag_run_manage`")
+
+	require.Eventually(t, func() bool {
+		detail, err := api.GetSessionDetail(context.Background(), sessionID, user.UserID)
+		if err != nil || detail == nil {
+			return false
+		}
+		return len(detail.Messages) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	detail, err := api.GetSessionDetail(context.Background(), sessionID, user.UserID)
+	require.NoError(t, err)
+	require.Len(t, detail.Messages, 1)
+	assert.Equal(t, MessageTypeAssistant, detail.Messages[0].Type)
+	assert.Equal(t, "I checked the watched run.", detail.Messages[0].Content)
+	assert.NotContains(t, detail.Messages[0].Content, "Watch ID")
 }
 
 func TestAPI_MaterializeChatInput_PrunesToNewestTenFiles(t *testing.T) {

--- a/internal/agent/contextkeys.go
+++ b/internal/agent/contextkeys.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/dagucloud/dagu/internal/agentoauth"
+	"github.com/dagucloud/dagu/internal/core/exec"
 )
 
 // Context keys for agent stores.
@@ -19,6 +20,8 @@ type memoryStoreKey struct{}
 type soulStoreKey struct{}
 type remoteContextResolverKey struct{}
 type oauthManagerKey struct{}
+type dagStoreKey struct{}
+type dagRunStoreKey struct{}
 
 // WithConfigStore injects a ConfigStore into the context.
 func WithConfigStore(ctx context.Context, s ConfigStore) context.Context {
@@ -89,4 +92,28 @@ func WithOAuthManager(ctx context.Context, m *agentoauth.Manager) context.Contex
 func GetOAuthManager(ctx context.Context) *agentoauth.Manager {
 	m, _ := ctx.Value(oauthManagerKey{}).(*agentoauth.Manager)
 	return m
+}
+
+// WithDAGStore injects a DAG store into the context.
+func WithDAGStore(ctx context.Context, s exec.DAGStore) context.Context {
+	return context.WithValue(ctx, dagStoreKey{}, s)
+}
+
+// GetDAGStore retrieves a DAG store from the context.
+// Returns nil if no DAG store is set.
+func GetDAGStore(ctx context.Context) exec.DAGStore {
+	s, _ := ctx.Value(dagStoreKey{}).(exec.DAGStore)
+	return s
+}
+
+// WithDAGRunStore injects a DAG run store into the context.
+func WithDAGRunStore(ctx context.Context, s exec.DAGRunStore) context.Context {
+	return context.WithValue(ctx, dagRunStoreKey{}, s)
+}
+
+// GetDAGRunStore retrieves a DAG run store from the context.
+// Returns nil if no DAG run store is set.
+func GetDAGRunStore(ctx context.Context) exec.DAGRunStore {
+	s, _ := ctx.Value(dagRunStoreKey{}).(exec.DAGRunStore)
+	return s
 }

--- a/internal/agent/dag_def_manage.go
+++ b/internal/agent/dag_def_manage.go
@@ -157,6 +157,9 @@ func dagDefManageList(ctx context.Context, store exec.DAGStore, args dagDefManag
 	}
 	items := make([]dagDefManageDAGSummary, 0, len(result.Items))
 	for _, dag := range result.Items {
+		if dag == nil {
+			continue
+		}
 		items = append(items, summarizeDAGDefinition(dag, store.IsSuspended(ctx, dag.Name)))
 	}
 	nextCursor := ""

--- a/internal/agent/dag_def_manage.go
+++ b/internal/agent/dag_def_manage.go
@@ -1,0 +1,304 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	agentschema "github.com/dagucloud/dagu/internal/agent/schema"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	corespec "github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/llm"
+)
+
+const dagDefManageToolName = "dag_def_manage"
+
+func init() {
+	RegisterTool(ToolRegistration{
+		Name:           dagDefManageToolName,
+		Label:          "DAG Definition Manage",
+		Description:    "List, inspect, validate, and navigate DAG definitions",
+		DefaultEnabled: true,
+		Factory: func(cfg ToolConfig) *AgentTool {
+			return NewDAGDefManageTool(cfg.DAGStore)
+		},
+	})
+}
+
+type dagDefManageInput struct {
+	Action  string              `json:"action"`
+	DAGName string              `json:"dagName,omitempty"`
+	Spec    string              `json:"spec,omitempty"`
+	Path    string              `json:"path,omitempty"`
+	Query   string              `json:"query,omitempty"`
+	Labels  dagManageStringList `json:"labels,omitempty"`
+	Limit   int                 `json:"limit,omitempty"`
+	Cursor  string              `json:"cursor,omitempty"`
+	Page    int                 `json:"page,omitempty"`
+	Sort    string              `json:"sort,omitempty"`
+	Order   string              `json:"order,omitempty"`
+	Full    bool                `json:"full,omitempty"`
+}
+
+type dagDefManageDAGSummary struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Group       string   `json:"group,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Location    string   `json:"location,omitempty"`
+	SourceFile  string   `json:"sourceFile,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	StepCount   int      `json:"stepCount"`
+	Steps       []string `json:"steps,omitempty"`
+	Suspended   bool     `json:"suspended,omitempty"`
+}
+
+// NewDAGDefManageTool creates an agent tool for read-only DAG definition inspection.
+func NewDAGDefManageTool(store exec.DAGStore) *AgentTool {
+	return &AgentTool{
+		Tool: llm.Tool{
+			Type: "function",
+			Function: llm.ToolFunction{
+				Name:        dagDefManageToolName,
+				Description: "Inspect and validate DAG definitions. Use list to discover DAGs, get to read the exact YAML and step summary, validate before or after changes, and schema to inspect valid DAG YAML fields.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"action": map[string]any{
+							"type":        "string",
+							"enum":        []string{"list", "get", "validate", "schema"},
+							"description": "Operation to perform.",
+						},
+						"dagName": map[string]any{"type": "string", "description": "DAG name or file name for get/validate."},
+						"spec":    map[string]any{"type": "string", "description": "Raw DAG YAML spec for validate."},
+						"path":    map[string]any{"type": "string", "description": "DAG schema path for schema action, e.g. steps, params, schedule."},
+						"query":   map[string]any{"type": "string", "description": "Optional name filter for list."},
+						"labels":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional labels filter for list."},
+						"limit":   map[string]any{"type": "integer", "description": "Maximum items for list (default 50, max 200)."},
+						"cursor":  map[string]any{"type": "string", "description": "Opaque cursor returned by list."},
+						"page":    map[string]any{"type": "integer", "description": "Optional page number for list when no cursor is available."},
+						"sort":    map[string]any{"type": "string", "description": "Optional list sort field, e.g. name, updated_at, created_at, nextRun."},
+						"order":   map[string]any{"type": "string", "description": "Optional sort order: asc or desc."},
+						"full":    map[string]any{"type": "boolean", "description": "For schema, include full descriptions instead of compact output."},
+					},
+					"required": []string{"action"},
+				},
+			},
+		},
+		Run: func(ctx ToolContext, input json.RawMessage) ToolOut {
+			return dagDefManageRun(ctx, input, store)
+		},
+		Audit: &AuditInfo{
+			Action:          dagDefManageToolName,
+			DetailExtractor: ExtractFields("action", "dagName", "query", "path"),
+		},
+	}
+}
+
+func dagDefManageRun(toolCtx ToolContext, input json.RawMessage, store exec.DAGStore) ToolOut {
+	if store == nil {
+		return toolError("%s is unavailable: DAG store is not configured", dagDefManageToolName)
+	}
+	var args dagDefManageInput
+	if err := json.Unmarshal(input, &args); err != nil {
+		return toolError("Failed to parse input: %v", err)
+	}
+	if toolCtx.Context == nil {
+		toolCtx.Context = context.Background()
+	}
+
+	switch strings.TrimSpace(args.Action) {
+	case "list":
+		return dagDefManageList(toolCtx.Context, store, args)
+	case "get":
+		return dagDefManageGet(toolCtx.Context, store, args)
+	case "validate":
+		return dagDefManageValidate(toolCtx.Context, store, args)
+	case "schema":
+		return dagDefManageSchema(args)
+	default:
+		return toolError("Unknown action: %s. Use list, get, validate, or schema.", args.Action)
+	}
+}
+
+func dagDefManageList(ctx context.Context, store exec.DAGStore, args dagDefManageInput) ToolOut {
+	limit := clampAgentLimit(args.Limit, 50, 200)
+	page, err := decodeDAGDefCursor(args.Cursor)
+	if err != nil {
+		return toolError("%v", err)
+	}
+	if page == 0 {
+		page = args.Page
+	}
+	if page <= 0 {
+		page = 1
+	}
+	nameFilter := args.Query
+	if nameFilter == "" {
+		nameFilter = args.DAGName
+	}
+	paginator := exec.NewPaginator(page, limit)
+	result, warnings, err := store.List(ctx, exec.ListDAGsOptions{
+		Paginator: &paginator,
+		Name:      nameFilter,
+		Labels:    []string(args.Labels),
+		Sort:      args.Sort,
+		Order:     args.Order,
+	})
+	if err != nil {
+		return toolError("Failed to list DAG definitions: %v", err)
+	}
+	items := make([]dagDefManageDAGSummary, 0, len(result.Items))
+	for _, dag := range result.Items {
+		items = append(items, summarizeDAGDefinition(dag, store.IsSuspended(ctx, dag.Name)))
+	}
+	nextCursor := ""
+	if result.HasNextPage {
+		nextCursor = encodeDAGDefCursor(result.NextPage)
+	}
+	return dagManageJSON(map[string]any{
+		"action":      "list",
+		"items":       items,
+		"limit":       limit,
+		"cursor":      args.Cursor,
+		"nextCursor":  nextCursor,
+		"hasMore":     nextCursor != "",
+		"currentPage": result.CurrentPage,
+		"totalPages":  result.TotalPages,
+		"totalCount":  result.TotalCount,
+		"warnings":    warnings,
+	})
+}
+
+func dagDefManageGet(ctx context.Context, store exec.DAGStore, args dagDefManageInput) ToolOut {
+	if args.DAGName == "" {
+		return toolError("dagName is required")
+	}
+	dag, err := store.GetDetails(ctx, args.DAGName, corespec.WithoutEval())
+	if err != nil {
+		return toolError("Failed to get DAG details: %v", err)
+	}
+	raw, err := store.GetSpec(ctx, args.DAGName)
+	if err != nil {
+		return toolError("Failed to get DAG spec: %v", err)
+	}
+	summary := summarizeDAGDefinition(dag, store.IsSuspended(ctx, args.DAGName))
+	return dagManageJSON(map[string]any{
+		"action":      "get",
+		"name":        summary.Name,
+		"description": summary.Description,
+		"group":       summary.Group,
+		"type":        summary.Type,
+		"location":    summary.Location,
+		"sourceFile":  summary.SourceFile,
+		"labels":      summary.Labels,
+		"stepCount":   summary.StepCount,
+		"steps":       summary.Steps,
+		"suspended":   summary.Suspended,
+		"spec":        raw,
+	})
+}
+
+func dagDefManageValidate(ctx context.Context, store exec.DAGStore, args dagDefManageInput) ToolOut {
+	raw := args.Spec
+	var err error
+	if raw == "" {
+		if args.DAGName == "" {
+			return toolError("spec or dagName is required for validate")
+		}
+		raw, err = store.GetSpec(ctx, args.DAGName)
+		if err != nil {
+			return toolError("Failed to get DAG spec: %v", err)
+		}
+	}
+	dag, err := store.LoadSpec(ctx, []byte(raw), corespec.WithoutEval())
+	if err != nil {
+		return dagManageJSON(map[string]any{
+			"action": "validate",
+			"valid":  false,
+			"errors": dagDefValidationErrors(err),
+		})
+	}
+	return dagManageJSON(map[string]any{
+		"action":    "validate",
+		"valid":     true,
+		"dag":       summarizeDAGDefinition(dag, false),
+		"stepCount": len(dag.Steps),
+	})
+}
+
+func dagDefManageSchema(args dagDefManageInput) ToolOut {
+	var (
+		out string
+		err error
+	)
+	if args.Full {
+		out, err = agentschema.DefaultRegistry.NavigateFull("dag", args.Path)
+	} else {
+		out, err = agentschema.DefaultRegistry.Navigate("dag", args.Path)
+	}
+	if err != nil {
+		return toolError("Failed to navigate DAG schema: %v", err)
+	}
+	return dagManageJSON(map[string]any{
+		"action": "schema",
+		"path":   args.Path,
+		"schema": out,
+	})
+}
+
+func summarizeDAGDefinition(dag *core.DAG, suspended bool) dagDefManageDAGSummary {
+	if dag == nil {
+		return dagDefManageDAGSummary{}
+	}
+	steps := make([]string, 0, len(dag.Steps))
+	for _, step := range dag.Steps {
+		steps = append(steps, step.Name)
+	}
+	return dagDefManageDAGSummary{
+		Name:        dag.Name,
+		Description: dag.Description,
+		Group:       dag.Group,
+		Type:        dag.Type,
+		Location:    dag.Location,
+		SourceFile:  dag.SourceFile,
+		Labels:      dag.Labels.Strings(),
+		StepCount:   len(dag.Steps),
+		Steps:       steps,
+		Suspended:   suspended,
+	}
+}
+
+func dagDefValidationErrors(err error) []string {
+	var errList core.ErrorList
+	if errors.As(err, &errList) {
+		return errList.ToStringList()
+	}
+	return []string{err.Error()}
+}
+
+func encodeDAGDefCursor(page int) string {
+	return fmt.Sprintf("page:%d", page)
+}
+
+func decodeDAGDefCursor(cursor string) (int, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return 0, nil
+	}
+	page, ok := strings.CutPrefix(cursor, "page:")
+	if !ok {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	n, err := strconv.Atoi(page)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	return n, nil
+}

--- a/internal/agent/dag_def_manage.go
+++ b/internal/agent/dag_def_manage.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"strconv"
 	"strings"
 
 	agentschema "github.com/dagucloud/dagu/internal/agent/schema"
@@ -33,31 +31,17 @@ func init() {
 }
 
 type dagDefManageInput struct {
-	Action  string              `json:"action"`
-	DAGName string              `json:"dagName,omitempty"`
-	Spec    string              `json:"spec,omitempty"`
-	Path    string              `json:"path,omitempty"`
-	Query   string              `json:"query,omitempty"`
-	Labels  dagManageStringList `json:"labels,omitempty"`
-	Limit   int                 `json:"limit,omitempty"`
-	Cursor  string              `json:"cursor,omitempty"`
-	Page    int                 `json:"page,omitempty"`
-	Sort    string              `json:"sort,omitempty"`
-	Order   string              `json:"order,omitempty"`
-	Full    bool                `json:"full,omitempty"`
-}
-
-type dagDefManageDAGSummary struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Group       string   `json:"group,omitempty"`
-	Type        string   `json:"type,omitempty"`
-	Location    string   `json:"location,omitempty"`
-	SourceFile  string   `json:"sourceFile,omitempty"`
-	Labels      []string `json:"labels,omitempty"`
-	StepCount   int      `json:"stepCount"`
-	Steps       []string `json:"steps,omitempty"`
-	Suspended   bool     `json:"suspended,omitempty"`
+	Action  string   `json:"action"`
+	DAGName string   `json:"dagName,omitempty"`
+	Spec    string   `json:"spec,omitempty"`
+	Path    string   `json:"path,omitempty"`
+	Query   string   `json:"query,omitempty"`
+	Labels  []string `json:"labels,omitempty"`
+	Limit   int      `json:"limit,omitempty"`
+	Page    int      `json:"page,omitempty"`
+	Sort    string   `json:"sort,omitempty"`
+	Order   string   `json:"order,omitempty"`
+	Full    bool     `json:"full,omitempty"`
 }
 
 // NewDAGDefManageTool creates an agent tool for read-only DAG definition inspection.
@@ -82,7 +66,6 @@ func NewDAGDefManageTool(store exec.DAGStore) *AgentTool {
 						"query":   map[string]any{"type": "string", "description": "Optional name filter for list."},
 						"labels":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional labels filter for list."},
 						"limit":   map[string]any{"type": "integer", "description": "Maximum items for list (default 50, max 200)."},
-						"cursor":  map[string]any{"type": "string", "description": "Opaque cursor returned by list."},
 						"page":    map[string]any{"type": "integer", "description": "Optional page number for list when no cursor is available."},
 						"sort":    map[string]any{"type": "string", "description": "Optional list sort field, e.g. name, updated_at, created_at, nextRun."},
 						"order":   map[string]any{"type": "string", "description": "Optional sort order: asc or desc."},
@@ -130,13 +113,7 @@ func dagDefManageRun(toolCtx ToolContext, input json.RawMessage, store exec.DAGS
 
 func dagDefManageList(ctx context.Context, store exec.DAGStore, args dagDefManageInput) ToolOut {
 	limit := clampAgentLimit(args.Limit, 50, 200)
-	page, err := decodeDAGDefCursor(args.Cursor)
-	if err != nil {
-		return toolError("%v", err)
-	}
-	if page == 0 {
-		page = args.Page
-	}
+	page := args.Page
 	if page <= 0 {
 		page = 1
 	}
@@ -148,32 +125,27 @@ func dagDefManageList(ctx context.Context, store exec.DAGStore, args dagDefManag
 	result, warnings, err := store.List(ctx, exec.ListDAGsOptions{
 		Paginator: &paginator,
 		Name:      nameFilter,
-		Labels:    []string(args.Labels),
+		Labels:    args.Labels,
 		Sort:      args.Sort,
 		Order:     args.Order,
 	})
 	if err != nil {
 		return toolError("Failed to list DAG definitions: %v", err)
 	}
-	items := make([]dagDefManageDAGSummary, 0, len(result.Items))
+	items := make([]map[string]any, 0, len(result.Items))
 	for _, dag := range result.Items {
 		if dag == nil {
 			continue
 		}
-		items = append(items, summarizeDAGDefinition(dag, store.IsSuspended(ctx, dag.Name)))
-	}
-	nextCursor := ""
-	if result.HasNextPage {
-		nextCursor = encodeDAGDefCursor(result.NextPage)
+		items = append(items, dagDefManageSummary(dag, store.IsSuspended(ctx, dag.Name)))
 	}
 	return dagManageJSON(map[string]any{
 		"action":      "list",
 		"items":       items,
 		"limit":       limit,
-		"cursor":      args.Cursor,
-		"nextCursor":  nextCursor,
-		"hasMore":     nextCursor != "",
+		"hasMore":     result.HasNextPage,
 		"currentPage": result.CurrentPage,
+		"nextPage":    result.NextPage,
 		"totalPages":  result.TotalPages,
 		"totalCount":  result.TotalCount,
 		"warnings":    warnings,
@@ -192,20 +164,12 @@ func dagDefManageGet(ctx context.Context, store exec.DAGStore, args dagDefManage
 	if err != nil {
 		return toolError("Failed to get DAG spec: %v", err)
 	}
-	summary := summarizeDAGDefinition(dag, store.IsSuspended(ctx, args.DAGName))
+	summary := dagDefManageSummary(dag, store.IsSuspended(ctx, args.DAGName))
 	return dagManageJSON(map[string]any{
-		"action":      "get",
-		"name":        summary.Name,
-		"description": summary.Description,
-		"group":       summary.Group,
-		"type":        summary.Type,
-		"location":    summary.Location,
-		"sourceFile":  summary.SourceFile,
-		"labels":      summary.Labels,
-		"stepCount":   summary.StepCount,
-		"steps":       summary.Steps,
-		"suspended":   summary.Suspended,
-		"spec":        raw,
+		"action":  "get",
+		"summary": summary,
+		"dag":     dag,
+		"spec":    raw,
 	})
 }
 
@@ -232,7 +196,8 @@ func dagDefManageValidate(ctx context.Context, store exec.DAGStore, args dagDefM
 	return dagManageJSON(map[string]any{
 		"action":    "validate",
 		"valid":     true,
-		"dag":       summarizeDAGDefinition(dag, false),
+		"dag":       dag,
+		"summary":   dagDefManageSummary(dag, false),
 		"stepCount": len(dag.Steps),
 	})
 }
@@ -257,26 +222,39 @@ func dagDefManageSchema(args dagDefManageInput) ToolOut {
 	})
 }
 
-func summarizeDAGDefinition(dag *core.DAG, suspended bool) dagDefManageDAGSummary {
+func dagDefManageSummary(dag *core.DAG, suspended bool) map[string]any {
 	if dag == nil {
-		return dagDefManageDAGSummary{}
+		return map[string]any{}
 	}
 	steps := make([]string, 0, len(dag.Steps))
 	for _, step := range dag.Steps {
 		steps = append(steps, step.Name)
 	}
-	return dagDefManageDAGSummary{
-		Name:        dag.Name,
-		Description: dag.Description,
-		Group:       dag.Group,
-		Type:        dag.Type,
-		Location:    dag.Location,
-		SourceFile:  dag.SourceFile,
-		Labels:      dag.Labels.Strings(),
-		StepCount:   len(dag.Steps),
-		Steps:       steps,
-		Suspended:   suspended,
+	out := map[string]any{
+		"name":      dag.Name,
+		"stepCount": len(dag.Steps),
 	}
+	for key, value := range map[string]string{
+		"description": dag.Description,
+		"group":       dag.Group,
+		"type":        dag.Type,
+		"location":    dag.Location,
+		"sourceFile":  dag.SourceFile,
+	} {
+		if value != "" {
+			out[key] = value
+		}
+	}
+	if labels := dag.Labels.Strings(); len(labels) > 0 {
+		out["labels"] = labels
+	}
+	if len(steps) > 0 {
+		out["steps"] = steps
+	}
+	if suspended {
+		out["suspended"] = true
+	}
+	return out
 }
 
 func dagDefValidationErrors(err error) []string {
@@ -285,23 +263,4 @@ func dagDefValidationErrors(err error) []string {
 		return errList.ToStringList()
 	}
 	return []string{err.Error()}
-}
-
-func encodeDAGDefCursor(page int) string {
-	return fmt.Sprintf("page:%d", page)
-}
-
-func decodeDAGDefCursor(cursor string) (int, error) {
-	if strings.TrimSpace(cursor) == "" {
-		return 0, nil
-	}
-	page, ok := strings.CutPrefix(cursor, "page:")
-	if !ok {
-		return 0, fmt.Errorf("invalid cursor")
-	}
-	n, err := strconv.Atoi(page)
-	if err != nil || n <= 0 {
-		return 0, fmt.Errorf("invalid cursor")
-	}
-	return n, nil
 }

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -191,6 +191,7 @@ func TestDAGRunManageMessagesFallbackToStatusOnReadError(t *testing.T) {
 		"dagRunId": "run-1",
 	})
 	require.False(t, out.IsError, out.Content)
+	got = map[string]any{}
 	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
 	messages = got["messages"].([]any)
 	require.Len(t, messages, 1)

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -130,6 +130,73 @@ func TestDAGRunManageReadStepLogAndMessages(t *testing.T) {
 	assert.Equal(t, "assistant", messages[0].(map[string]any)["role"])
 }
 
+func TestDAGRunManageReadStepLogRequiresStepStream(t *testing.T) {
+	logFile := writeTempLog(t, "scheduler\n")
+	tool := NewDAGRunManageTool(&dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Log:      logFile,
+			Nodes: []*exec.Node{{
+				Step:   core.Step{Name: "agent-step"},
+				Status: core.NodeFailed,
+				Stderr: logFile,
+			}},
+		},
+	})
+
+	out := runJSONTool(t, tool, map[string]any{
+		"action":   "read_log",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+		"stepName": "agent-step",
+	})
+
+	require.True(t, out.IsError)
+	assert.Contains(t, out.Content, "stream is required when stepName is set")
+}
+
+func TestDAGRunManageMessagesFallbackToStatusOnReadError(t *testing.T) {
+	fallback := []exec.LLMMessage{{Role: exec.RoleAssistant, Content: "fallback from status"}}
+	tool := NewDAGRunManageTool(&dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Failed,
+			Nodes: []*exec.Node{{
+				Step:         core.Step{Name: "agent-step", ExecutorConfig: core.ExecutorConfig{Type: "agent"}},
+				Status:       core.NodeFailed,
+				ChatMessages: fallback,
+			}},
+		},
+		messageErr: errors.New("messages file missing"),
+	})
+
+	out := runJSONTool(t, tool, map[string]any{
+		"action":   "read_messages",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+		"stepName": "agent-step",
+	})
+	require.False(t, out.IsError, out.Content)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
+	messages := got["messages"].([]any)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "fallback from status", messages[0].(map[string]any)["content"])
+
+	out = runJSONTool(t, tool, map[string]any{
+		"action":   "diagnose",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+	})
+	require.False(t, out.IsError, out.Content)
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
+	messages = got["messages"].([]any)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "fallback from status", messages[0].(map[string]any)["content"])
+}
+
 func TestDAGRunManageListRejectsConflictingTimeFilters(t *testing.T) {
 	tool := NewDAGRunManageTool(&dagRunManageTestStore{})
 
@@ -490,10 +557,11 @@ func writeTempLog(t *testing.T, content string) string {
 }
 
 type dagRunManageTestStore struct {
-	page     exec.DAGRunStatusPage
-	status   *exec.DAGRunStatus
-	messages []exec.LLMMessage
-	listOpts exec.ListDAGRunStatusesOptions
+	page       exec.DAGRunStatusPage
+	status     *exec.DAGRunStatus
+	messages   []exec.LLMMessage
+	messageErr error
+	listOpts   exec.ListDAGRunStatusesOptions
 }
 
 type dagRunManageFakeWatcher struct {
@@ -550,11 +618,11 @@ func (s *dagRunManageTestStore) CompareAndSwapLatestAttemptStatus(context.Contex
 }
 
 func (s *dagRunManageTestStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
-	return &dagRunManageTestAttempt{status: s.status, messages: s.messages}, nil
+	return &dagRunManageTestAttempt{status: s.status, messages: s.messages, messageErr: s.messageErr}, nil
 }
 
 func (s *dagRunManageTestStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
-	return &dagRunManageTestAttempt{status: s.status, messages: s.messages}, nil
+	return &dagRunManageTestAttempt{status: s.status, messages: s.messages, messageErr: s.messageErr}, nil
 }
 
 func (s *dagRunManageTestStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
@@ -574,8 +642,9 @@ func (s *dagRunManageTestStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ..
 }
 
 type dagRunManageTestAttempt struct {
-	status   *exec.DAGRunStatus
-	messages []exec.LLMMessage
+	status     *exec.DAGRunStatus
+	messages   []exec.LLMMessage
+	messageErr error
 }
 
 func (a *dagRunManageTestAttempt) ID() string {
@@ -609,6 +678,9 @@ func (a *dagRunManageTestAttempt) WriteStepMessages(context.Context, string, []e
 	return nil
 }
 func (a *dagRunManageTestAttempt) ReadStepMessages(context.Context, string) ([]exec.LLMMessage, error) {
+	if a.messageErr != nil {
+		return nil, a.messageErr
+	}
 	return a.messages, nil
 }
 func (a *dagRunManageTestAttempt) WorkDir() string { return "" }

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -351,11 +351,14 @@ func TestDAGRunWatchRegistryNotifiesTerminalRun(t *testing.T) {
 	require.NotNil(t, notifiedStatus)
 	assert.Equal(t, core.Failed, notifiedStatus.Status)
 
-	message := formatDAGRunWatchNotification(notifiedReq, notifiedInfo, notifiedStatus)
-	assert.Contains(t, message, "DAG run finished: build/run-1")
+	message := formatDAGRunWatchAgentEvent(notifiedReq, notifiedInfo, notifiedStatus)
+	assert.Contains(t, message, "A watched DAG run finished.")
+	assert.Contains(t, message, "DAG: build")
+	assert.Contains(t, message, "Run ID: run-1")
 	assert.Contains(t, message, "Status: failed")
 	assert.Contains(t, message, "Primary failed step: test")
 	assert.Contains(t, message, "dag_run_manage")
+	assert.Contains(t, message, "Do not quote it verbatim.")
 }
 
 func TestDAGRunWatchRegistryDeduplicatesActiveRun(t *testing.T) {

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -75,7 +75,8 @@ func TestDAGRunManageListUsesCursorAndReturnsLogRefs(t *testing.T) {
 	assert.Equal(t, "agent-step", node["stepName"])
 	assert.Equal(t, "agent", node["executorType"])
 
-	logRefs := node["logRefs"].(map[string]any)
+	stepRefs := item["stepLogRefs"].(map[string]any)
+	logRefs := stepRefs["agent-step"].(map[string]any)
 	assert.Equal(t, "stdout", logRefs["stdout"].(map[string]any)["stream"])
 	assert.Equal(t, "stderr", logRefs["stderr"].(map[string]any)["stream"])
 }
@@ -159,7 +160,7 @@ func TestDAGRunManageDiagnoseCollectsFailedStepContext(t *testing.T) {
 	var got map[string]any
 	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
 	assert.Equal(t, "failed", got["status"])
-	assert.Equal(t, "agent-step", got["primaryFailedStep"].(map[string]any)["stepName"])
+	assert.Equal(t, "agent-step", got["primaryFailedStepName"])
 
 	logs := got["logs"].(map[string]any)
 	assert.Contains(t, logs["scheduler"].(map[string]any)["content"], "panic: boom")
@@ -398,7 +399,7 @@ func TestDAGDefManageListGetValidateAndSchema(t *testing.T) {
 	var getGot map[string]any
 	require.NoError(t, json.Unmarshal([]byte(getOut.Content), &getGot))
 	assert.Contains(t, getGot["spec"], "go test")
-	assert.EqualValues(t, 1, getGot["stepCount"])
+	assert.EqualValues(t, 1, getGot["summary"].(map[string]any)["stepCount"])
 
 	validateOut := runJSONTool(t, tool, map[string]any{
 		"action": "validate",

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -130,6 +130,19 @@ func TestDAGRunManageReadStepLogAndMessages(t *testing.T) {
 	assert.Equal(t, "assistant", messages[0].(map[string]any)["role"])
 }
 
+func TestDAGRunManageListRejectsConflictingTimeFilters(t *testing.T) {
+	tool := NewDAGRunManageTool(&dagRunManageTestStore{})
+
+	out := runJSONTool(t, tool, map[string]any{
+		"action": "list",
+		"last":   "1h",
+		"from":   "2026-05-07",
+	})
+
+	require.True(t, out.IsError)
+	assert.Contains(t, out.Content, "cannot use --last with --from or --to")
+}
+
 func TestDAGRunManageDiagnoseCollectsFailedStepContext(t *testing.T) {
 	logFile := writeTempLog(t, "ok\npanic: boom\n")
 	store := &dagRunManageTestStore{
@@ -334,6 +347,46 @@ func TestDAGRunWatchRegistryClearSessionRemovesActiveWatches(t *testing.T) {
 		WatchID:   info.WatchID,
 	})
 	require.Error(t, err)
+}
+
+func TestDAGRunWatchRegistryCompleteDoesNotCancelNotifyContextBeforeNotify(t *testing.T) {
+	status := &exec.DAGRunStatus{
+		Name:     "build",
+		DAGRunID: "run-1",
+		Status:   core.Succeeded,
+	}
+	parentCtx, cancelWatch := context.WithCancel(context.Background())
+	notifyCtx, cancelNotify := context.WithTimeout(parentCtx, time.Second)
+	defer cancelNotify()
+
+	registry := newDAGRunWatchRegistry(
+		&dagRunManageTestStore{status: status},
+		func(ctx context.Context, _ DAGRunWatchRequest, _ DAGRunWatchInfo, _ *exec.DAGRunStatus) error {
+			assert.NoError(t, ctx.Err())
+			return nil
+		},
+		slog.Default(),
+	)
+	watchID := "watch-1"
+	registry.watches[watchID] = &dagRunWatchEntry{
+		req: DAGRunWatchRequest{
+			SessionID: "session-1",
+			DAGName:   "build",
+			DAGRunID:  "run-1",
+			NotifyOn:  []string{"terminal"},
+		},
+		info: DAGRunWatchInfo{
+			WatchID:  watchID,
+			DAGName:  "build",
+			DAGRunID: "run-1",
+			State:    DAGRunWatchStateRunning,
+		},
+		cancel: cancelWatch,
+	}
+
+	_, err := registry.complete(notifyCtx, watchID, status)
+	require.NoError(t, err)
+	assert.ErrorIs(t, parentCtx.Err(), context.Canceled)
 }
 
 func TestDAGRunWatchRegistryExpiresStuckRun(t *testing.T) {

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -1,0 +1,588 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	corespec "github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAGRunManageListUsesCursorAndReturnsLogRefs(t *testing.T) {
+	store := &dagRunManageTestStore{
+		page: exec.DAGRunStatusPage{
+			Items: []*exec.DAGRunStatus{{
+				Name:       "build",
+				DAGRunID:   "run-1",
+				AttemptID:  "attempt-1",
+				Status:     core.Failed,
+				StartedAt:  "2026-05-07T00:00:00Z",
+				FinishedAt: "2026-05-07T00:01:00Z",
+				Log:        "/tmp/build-run-1.log",
+				Nodes: []*exec.Node{{
+					Step:   core.Step{Name: "agent-step", ExecutorConfig: core.ExecutorConfig{Type: "agent"}},
+					Status: core.NodeFailed,
+					Stdout: "/tmp/agent-step.out",
+					Stderr: "/tmp/agent-step.err",
+				}},
+			}},
+			NextCursor: "next-cursor",
+		},
+	}
+	tool := NewDAGRunManageTool(store)
+
+	out := runJSONTool(t, tool, map[string]any{
+		"action":  "list",
+		"dagName": "build",
+		"status":  []string{"failed"},
+		"limit":   1,
+		"cursor":  "cursor-1",
+	})
+	require.False(t, out.IsError, out.Content)
+
+	assert.Equal(t, "build", store.listOpts.ExactName)
+	assert.Equal(t, "cursor-1", store.listOpts.Cursor)
+	assert.Equal(t, 1, store.listOpts.Limit)
+	require.Len(t, store.listOpts.Statuses, 1)
+	assert.Equal(t, core.Failed, store.listOpts.Statuses[0])
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
+	assert.Equal(t, "list", got["action"])
+	assert.Equal(t, true, got["hasMore"])
+	assert.Equal(t, "next-cursor", got["nextCursor"])
+
+	items := got["items"].([]any)
+	require.Len(t, items, 1)
+	item := items[0].(map[string]any)
+	assert.Equal(t, "build", item["dagName"])
+	assert.Equal(t, "run-1", item["dagRunId"])
+	assert.Equal(t, "failed", item["status"])
+
+	nodes := item["nodes"].([]any)
+	node := nodes[0].(map[string]any)
+	assert.Equal(t, "agent-step", node["stepName"])
+	assert.Equal(t, "agent", node["executorType"])
+
+	logRefs := node["logRefs"].(map[string]any)
+	assert.Equal(t, "stdout", logRefs["stdout"].(map[string]any)["stream"])
+	assert.Equal(t, "stderr", logRefs["stderr"].(map[string]any)["stream"])
+}
+
+func TestDAGRunManageReadStepLogAndMessages(t *testing.T) {
+	logFile := writeTempLog(t, "line 1\nline 2\nline 3\n")
+	store := &dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Failed,
+			Nodes: []*exec.Node{{
+				Step:   core.Step{Name: "agent-step", ExecutorConfig: core.ExecutorConfig{Type: "agent"}},
+				Status: core.NodeFailed,
+				Stderr: logFile,
+			}},
+		},
+		messages: []exec.LLMMessage{{
+			Role:    exec.RoleAssistant,
+			Content: "I found the failing command",
+		}},
+	}
+	tool := NewDAGRunManageTool(store)
+
+	logOut := runJSONTool(t, tool, map[string]any{
+		"action":   "read_log",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+		"stepName": "agent-step",
+		"stream":   "stderr",
+		"tail":     2,
+	})
+	require.False(t, logOut.IsError, logOut.Content)
+	var logGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(logOut.Content), &logGot))
+	assert.Equal(t, "line 2\nline 3", logGot["content"])
+	assert.EqualValues(t, 2, logGot["lineCount"])
+	assert.EqualValues(t, 3, logGot["totalLines"])
+
+	msgOut := runJSONTool(t, tool, map[string]any{
+		"action":   "read_messages",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+		"stepName": "agent-step",
+	})
+	require.False(t, msgOut.IsError, msgOut.Content)
+	var msgGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(msgOut.Content), &msgGot))
+	messages := msgGot["messages"].([]any)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "assistant", messages[0].(map[string]any)["role"])
+}
+
+func TestDAGRunManageDiagnoseCollectsFailedStepContext(t *testing.T) {
+	logFile := writeTempLog(t, "ok\npanic: boom\n")
+	store := &dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Failed,
+			Log:      logFile,
+			Nodes: []*exec.Node{{
+				Step:   core.Step{Name: "agent-step", ExecutorConfig: core.ExecutorConfig{Type: "agent"}},
+				Status: core.NodeFailed,
+				Error:  "exit status 1",
+				Stderr: logFile,
+			}},
+		},
+		messages: []exec.LLMMessage{{Role: exec.RoleAssistant, Content: "tool failed"}},
+	}
+	tool := NewDAGRunManageTool(store)
+
+	out := runJSONTool(t, tool, map[string]any{
+		"action":   "diagnose",
+		"dagName":  "build",
+		"dagRunId": "run-1",
+		"tail":     5,
+	})
+	require.False(t, out.IsError, out.Content)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
+	assert.Equal(t, "failed", got["status"])
+	assert.Equal(t, "agent-step", got["primaryFailedStep"].(map[string]any)["stepName"])
+
+	logs := got["logs"].(map[string]any)
+	assert.Contains(t, logs["scheduler"].(map[string]any)["content"], "panic: boom")
+	assert.Contains(t, logs["stderr"].(map[string]any)["content"], "panic: boom")
+
+	messages := got["messages"].([]any)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "assistant", messages[0].(map[string]any)["role"])
+}
+
+func TestDAGRunManageWatchActions(t *testing.T) {
+	watcher := &dagRunManageFakeWatcher{
+		info: DAGRunWatchInfo{
+			WatchID:  "watch-1",
+			DAGName:  "build",
+			DAGRunID: "run-1",
+			State:    DAGRunWatchStateRunning,
+			Status:   core.Running.String(),
+		},
+	}
+	tool := NewDAGRunManageTool(nil, watcher)
+	toolCtx := ToolContext{
+		Context:   context.Background(),
+		SessionID: "session-1",
+		User:      UserIdentity{UserID: "user-1", Username: "dev"},
+	}
+
+	watchOut := runJSONToolWithContext(t, tool, toolCtx, map[string]any{
+		"action":            "watch",
+		"dagName":           "build",
+		"dagRunId":          "run-1",
+		"notifyOn":          []string{"terminal"},
+		"diagnoseOnFailure": false,
+	})
+	require.False(t, watchOut.IsError, watchOut.Content)
+	assert.Equal(t, "session-1", watcher.watchReq.SessionID)
+	assert.Equal(t, "user-1", watcher.watchReq.User.UserID)
+	assert.Equal(t, "build", watcher.watchReq.DAGName)
+	assert.Equal(t, "run-1", watcher.watchReq.DAGRunID)
+	assert.Equal(t, []string{"terminal"}, watcher.watchReq.NotifyOn)
+	assert.False(t, watcher.watchReq.DiagnoseOnFailure)
+
+	var watchGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(watchOut.Content), &watchGot))
+	assert.Equal(t, "watch", watchGot["action"])
+	assert.Equal(t, "watch-1", watchGot["watchId"])
+
+	statusOut := runJSONToolWithContext(t, tool, toolCtx, map[string]any{
+		"action":  "watch_status",
+		"watchId": "watch-1",
+	})
+	require.False(t, statusOut.IsError, statusOut.Content)
+	assert.Equal(t, "watch-1", watcher.statusReq.WatchID)
+	assert.Equal(t, "session-1", watcher.statusReq.SessionID)
+
+	cancelOut := runJSONToolWithContext(t, tool, toolCtx, map[string]any{
+		"action":  "cancel_watch",
+		"watchId": "watch-1",
+	})
+	require.False(t, cancelOut.IsError, cancelOut.Content)
+	assert.Equal(t, "watch-1", watcher.cancelReq.WatchID)
+	assert.Equal(t, "session-1", watcher.cancelReq.SessionID)
+}
+
+func TestDAGRunWatchRegistryNotifiesTerminalRun(t *testing.T) {
+	status := &exec.DAGRunStatus{
+		Name:     "build",
+		DAGRunID: "run-1",
+		Status:   core.Failed,
+		Error:    "workflow failed",
+		Nodes: []*exec.Node{{
+			Step:   core.Step{Name: "test"},
+			Status: core.NodeFailed,
+			Error:  "exit status 1",
+		}},
+	}
+	store := &dagRunManageTestStore{status: status}
+	var notifiedReq DAGRunWatchRequest
+	var notifiedInfo DAGRunWatchInfo
+	var notifiedStatus *exec.DAGRunStatus
+	registry := newDAGRunWatchRegistry(
+		store,
+		func(_ context.Context, req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) error {
+			notifiedReq = req
+			notifiedInfo = info
+			notifiedStatus = status
+			return nil
+		},
+		slog.Default(),
+		withDAGRunWatchPollInterval(time.Millisecond),
+	)
+
+	info, err := registry.Watch(context.Background(), DAGRunWatchRequest{
+		SessionID:         "session-1",
+		User:              UserIdentity{UserID: "user-1"},
+		DAGName:           "build",
+		DAGRunID:          "run-1",
+		DiagnoseOnFailure: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, DAGRunWatchStateCompleted, info.State)
+	assert.Equal(t, core.Failed.String(), info.Status)
+	assert.True(t, info.Notified)
+	assert.Equal(t, "session-1", notifiedReq.SessionID)
+	assert.Equal(t, info.WatchID, notifiedInfo.WatchID)
+	require.NotNil(t, notifiedStatus)
+	assert.Equal(t, core.Failed, notifiedStatus.Status)
+
+	message := formatDAGRunWatchNotification(notifiedReq, notifiedInfo, notifiedStatus)
+	assert.Contains(t, message, "DAG run finished: build/run-1")
+	assert.Contains(t, message, "Status: failed")
+	assert.Contains(t, message, "Primary failed step: test")
+	assert.Contains(t, message, "dag_run_manage")
+}
+
+func TestDAGRunWatchRegistryDeduplicatesActiveRun(t *testing.T) {
+	store := &dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Running,
+		},
+	}
+	registry := newDAGRunWatchRegistry(store, nil, slog.Default(), withDAGRunWatchPollInterval(time.Hour))
+	req := DAGRunWatchRequest{
+		SessionID: "session-1",
+		User:      UserIdentity{UserID: "user-1"},
+		DAGName:   "build",
+		DAGRunID:  "run-1",
+	}
+
+	first, err := registry.Watch(context.Background(), req)
+	require.NoError(t, err)
+	second, err := registry.Watch(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.WatchID, second.WatchID)
+	assert.Equal(t, DAGRunWatchStateRunning, second.State)
+
+	canceled, err := registry.Cancel(context.Background(), DAGRunWatchCancelRequest{
+		SessionID: "session-1",
+		WatchID:   first.WatchID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, DAGRunWatchStateCanceled, canceled.State)
+}
+
+func TestDAGRunWatchRegistryExpiresStuckRun(t *testing.T) {
+	store := &dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Running,
+		},
+	}
+	registry := newDAGRunWatchRegistry(
+		store,
+		nil,
+		slog.Default(),
+		withDAGRunWatchPollInterval(time.Millisecond),
+		withDAGRunWatchMaxDuration(time.Nanosecond),
+	)
+
+	info, err := registry.Watch(context.Background(), DAGRunWatchRequest{
+		SessionID: "session-1",
+		User:      UserIdentity{UserID: "user-1"},
+		DAGName:   "build",
+		DAGRunID:  "run-1",
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		current, err := registry.Status(context.Background(), DAGRunWatchStatusRequest{
+			SessionID: "session-1",
+			WatchID:   info.WatchID,
+		})
+		return err == nil && current.State == DAGRunWatchStateExpired
+	}, 100*time.Millisecond, time.Millisecond)
+}
+
+func TestDAGDefManageListGetValidateAndSchema(t *testing.T) {
+	store := &dagDefManageTestStore{
+		dags: []*core.DAG{{
+			Name:        "build",
+			Description: "Build workflow",
+			Location:    "/dags/build.yaml",
+			Labels:      core.NewLabels([]string{"team:platform"}),
+			Steps:       []core.Step{{Name: "test", ExecutorConfig: core.ExecutorConfig{Type: "command"}}},
+		}},
+		specs: map[string]string{
+			"build": "steps:\n  - name: test\n    command: go test ./...\n",
+		},
+	}
+	tool := NewDAGDefManageTool(store)
+
+	listOut := runJSONTool(t, tool, map[string]any{"action": "list", "limit": 1})
+	require.False(t, listOut.IsError, listOut.Content)
+	assert.Equal(t, 1, store.listParams.Paginator.Limit())
+
+	var listGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(listOut.Content), &listGot))
+	items := listGot["items"].([]any)
+	require.Len(t, items, 1)
+	assert.Equal(t, "build", items[0].(map[string]any)["name"])
+
+	getOut := runJSONTool(t, tool, map[string]any{"action": "get", "dagName": "build"})
+	require.False(t, getOut.IsError, getOut.Content)
+	var getGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(getOut.Content), &getGot))
+	assert.Contains(t, getGot["spec"], "go test")
+	assert.EqualValues(t, 1, getGot["stepCount"])
+
+	validateOut := runJSONTool(t, tool, map[string]any{
+		"action": "validate",
+		"spec":   "steps:\n  - name: ok\n    command: echo ok\n",
+	})
+	require.False(t, validateOut.IsError, validateOut.Content)
+	var validateGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(validateOut.Content), &validateGot))
+	assert.Equal(t, true, validateGot["valid"])
+
+	schemaOut := runJSONTool(t, tool, map[string]any{"action": "schema", "path": "steps"})
+	require.False(t, schemaOut.IsError, schemaOut.Content)
+	var schemaGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(schemaOut.Content), &schemaGot))
+	assert.Contains(t, schemaGot["schema"], "steps")
+}
+
+func runJSONTool(t *testing.T, tool *AgentTool, input map[string]any) ToolOut {
+	t.Helper()
+	return runJSONToolWithContext(t, tool, ToolContext{Context: context.Background()}, input)
+}
+
+func runJSONToolWithContext(t *testing.T, tool *AgentTool, toolCtx ToolContext, input map[string]any) ToolOut {
+	t.Helper()
+	raw, err := json.Marshal(input)
+	require.NoError(t, err)
+	return tool.Run(toolCtx, raw)
+}
+
+func writeTempLog(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/step.log"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+type dagRunManageTestStore struct {
+	page     exec.DAGRunStatusPage
+	status   *exec.DAGRunStatus
+	messages []exec.LLMMessage
+	listOpts exec.ListDAGRunStatusesOptions
+}
+
+type dagRunManageFakeWatcher struct {
+	info      DAGRunWatchInfo
+	watchReq  DAGRunWatchRequest
+	statusReq DAGRunWatchStatusRequest
+	cancelReq DAGRunWatchCancelRequest
+}
+
+func (w *dagRunManageFakeWatcher) Watch(_ context.Context, req DAGRunWatchRequest) (DAGRunWatchInfo, error) {
+	w.watchReq = req
+	return w.info, nil
+}
+
+func (w *dagRunManageFakeWatcher) Status(_ context.Context, req DAGRunWatchStatusRequest) (DAGRunWatchInfo, error) {
+	w.statusReq = req
+	return w.info, nil
+}
+
+func (w *dagRunManageFakeWatcher) Cancel(_ context.Context, req DAGRunWatchCancelRequest) (DAGRunWatchInfo, error) {
+	w.cancelReq = req
+	info := w.info
+	info.State = DAGRunWatchStateCanceled
+	return info, nil
+}
+
+func (s *dagRunManageTestStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
+	return nil, errors.New("unexpected CreateAttempt")
+}
+
+func (s *dagRunManageTestStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
+	return nil
+}
+
+func (s *dagRunManageTestStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
+	return nil, errors.New("unexpected LatestAttempt")
+}
+
+func (s *dagRunManageTestStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	return nil, errors.New("unexpected ListStatuses")
+}
+
+func (s *dagRunManageTestStore) ListStatusesPage(_ context.Context, opts ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
+	var parsed exec.ListDAGRunStatusesOptions
+	for _, opt := range opts {
+		opt(&parsed)
+	}
+	s.listOpts = parsed
+	return s.page, nil
+}
+
+func (s *dagRunManageTestStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, errors.New("unexpected CompareAndSwapLatestAttemptStatus")
+}
+
+func (s *dagRunManageTestStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
+	return &dagRunManageTestAttempt{status: s.status, messages: s.messages}, nil
+}
+
+func (s *dagRunManageTestStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return &dagRunManageTestAttempt{status: s.status, messages: s.messages}, nil
+}
+
+func (s *dagRunManageTestStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, errors.New("unexpected CreateSubAttempt")
+}
+
+func (s *dagRunManageTestStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.RemoveOldDAGRunsOption) ([]string, error) {
+	return nil, errors.New("unexpected RemoveOldDAGRuns")
+}
+
+func (s *dagRunManageTestStore) RenameDAGRuns(context.Context, string, string) error {
+	return errors.New("unexpected RenameDAGRuns")
+}
+
+func (s *dagRunManageTestStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
+	return errors.New("unexpected RemoveDAGRun")
+}
+
+type dagRunManageTestAttempt struct {
+	status   *exec.DAGRunStatus
+	messages []exec.LLMMessage
+}
+
+func (a *dagRunManageTestAttempt) ID() string {
+	if a.status == nil {
+		return ""
+	}
+	return a.status.AttemptID
+}
+func (a *dagRunManageTestAttempt) Open(context.Context) error                     { return nil }
+func (a *dagRunManageTestAttempt) Write(context.Context, exec.DAGRunStatus) error { return nil }
+func (a *dagRunManageTestAttempt) Close(context.Context) error                    { return nil }
+func (a *dagRunManageTestAttempt) ReadStatus(context.Context) (*exec.DAGRunStatus, error) {
+	if a.status == nil {
+		return nil, exec.ErrNoStatusData
+	}
+	return a.status, nil
+}
+func (a *dagRunManageTestAttempt) ReadDAG(context.Context) (*core.DAG, error) { return nil, nil }
+func (a *dagRunManageTestAttempt) SetDAG(*core.DAG)                           {}
+func (a *dagRunManageTestAttempt) Abort(context.Context) error                { return nil }
+func (a *dagRunManageTestAttempt) IsAborting(context.Context) (bool, error)   { return false, nil }
+func (a *dagRunManageTestAttempt) Hide(context.Context) error                 { return nil }
+func (a *dagRunManageTestAttempt) Hidden() bool                               { return false }
+func (a *dagRunManageTestAttempt) WriteOutputs(context.Context, *exec.DAGRunOutputs) error {
+	return nil
+}
+func (a *dagRunManageTestAttempt) ReadOutputs(context.Context) (*exec.DAGRunOutputs, error) {
+	return nil, nil
+}
+func (a *dagRunManageTestAttempt) WriteStepMessages(context.Context, string, []exec.LLMMessage) error {
+	return nil
+}
+func (a *dagRunManageTestAttempt) ReadStepMessages(context.Context, string) ([]exec.LLMMessage, error) {
+	return a.messages, nil
+}
+func (a *dagRunManageTestAttempt) WorkDir() string { return "" }
+
+type dagDefManageTestStore struct {
+	dags       []*core.DAG
+	specs      map[string]string
+	listParams exec.ListDAGsOptions
+}
+
+func (s *dagDefManageTestStore) Create(context.Context, string, []byte) error { return nil }
+func (s *dagDefManageTestStore) Delete(context.Context, string) error         { return nil }
+func (s *dagDefManageTestStore) List(_ context.Context, params exec.ListDAGsOptions) (exec.PaginatedResult[*core.DAG], []string, error) {
+	s.listParams = params
+	pg := exec.DefaultPaginator()
+	if params.Paginator != nil {
+		pg = *params.Paginator
+	}
+	return exec.NewPaginatedResult(s.dags, len(s.dags), pg), nil, nil
+}
+func (s *dagDefManageTestStore) GetMetadata(context.Context, string) (*core.DAG, error) {
+	if len(s.dags) == 0 {
+		return nil, exec.ErrDAGNotFound
+	}
+	return s.dags[0], nil
+}
+func (s *dagDefManageTestStore) GetDetails(context.Context, string, ...corespec.LoadOption) (*core.DAG, error) {
+	if len(s.dags) == 0 {
+		return nil, exec.ErrDAGNotFound
+	}
+	return s.dags[0], nil
+}
+func (s *dagDefManageTestStore) Grep(context.Context, string) ([]*exec.GrepDAGsResult, []string, error) {
+	return nil, nil, nil
+}
+func (s *dagDefManageTestStore) SearchCursor(context.Context, exec.SearchDAGsOptions) (*exec.CursorResult[exec.SearchDAGResult], []string, error) {
+	return nil, nil, nil
+}
+func (s *dagDefManageTestStore) SearchMatches(context.Context, string, exec.SearchDAGMatchesOptions) (*exec.CursorResult[*exec.Match], error) {
+	return nil, nil
+}
+func (s *dagDefManageTestStore) Rename(context.Context, string, string) error { return nil }
+func (s *dagDefManageTestStore) GetSpec(_ context.Context, fileName string) (string, error) {
+	raw, ok := s.specs[fileName]
+	if !ok {
+		return "", exec.ErrDAGNotFound
+	}
+	return raw, nil
+}
+func (s *dagDefManageTestStore) UpdateSpec(context.Context, string, []byte) error { return nil }
+func (s *dagDefManageTestStore) LoadSpec(ctx context.Context, raw []byte, opts ...corespec.LoadOption) (*core.DAG, error) {
+	return corespec.LoadYAML(ctx, raw, opts...)
+}
+func (s *dagDefManageTestStore) LabelList(context.Context) ([]string, []string, error) {
+	return nil, nil, nil
+}
+func (s *dagDefManageTestStore) ToggleSuspend(context.Context, string, bool) error { return nil }
+func (s *dagDefManageTestStore) IsSuspended(context.Context, string) bool          { return false }

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -179,9 +179,9 @@ func TestDAGRunManageMessagesFallbackToStatusOnReadError(t *testing.T) {
 		"stepName": "agent-step",
 	})
 	require.False(t, out.IsError, out.Content)
-	var got map[string]any
-	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
-	messages := got["messages"].([]any)
+	var readMessagesGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &readMessagesGot))
+	messages := readMessagesGot["messages"].([]any)
 	require.Len(t, messages, 1)
 	assert.Equal(t, "fallback from status", messages[0].(map[string]any)["content"])
 
@@ -191,11 +191,11 @@ func TestDAGRunManageMessagesFallbackToStatusOnReadError(t *testing.T) {
 		"dagRunId": "run-1",
 	})
 	require.False(t, out.IsError, out.Content)
-	got = map[string]any{}
-	require.NoError(t, json.Unmarshal([]byte(out.Content), &got))
-	messages = got["messages"].([]any)
-	require.Len(t, messages, 1)
-	assert.Equal(t, "fallback from status", messages[0].(map[string]any)["content"])
+	var diagnoseGot map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.Content), &diagnoseGot))
+	diagnoseMessages := diagnoseGot["messages"].([]any)
+	require.Len(t, diagnoseMessages, 1)
+	assert.Equal(t, "fallback from status", diagnoseMessages[0].(map[string]any)["content"])
 }
 
 func TestDAGRunManageListRejectsConflictingTimeFilters(t *testing.T) {

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -308,6 +308,33 @@ func TestDAGRunWatchRegistryDeduplicatesActiveRun(t *testing.T) {
 	assert.Equal(t, DAGRunWatchStateCanceled, canceled.State)
 }
 
+func TestDAGRunWatchRegistryClearSessionRemovesActiveWatches(t *testing.T) {
+	store := &dagRunManageTestStore{
+		status: &exec.DAGRunStatus{
+			Name:     "build",
+			DAGRunID: "run-1",
+			Status:   core.Running,
+		},
+	}
+	registry := newDAGRunWatchRegistry(store, nil, slog.Default(), withDAGRunWatchPollInterval(time.Hour))
+	info, err := registry.Watch(context.Background(), DAGRunWatchRequest{
+		SessionID: "session-1",
+		User:      UserIdentity{UserID: "user-1"},
+		DAGName:   "build",
+		DAGRunID:  "run-1",
+	})
+	require.NoError(t, err)
+
+	removed := registry.ClearSession("session-1")
+	assert.Equal(t, 1, removed)
+
+	_, err = registry.Status(context.Background(), DAGRunWatchStatusRequest{
+		SessionID: "session-1",
+		WatchID:   info.WatchID,
+	})
+	require.Error(t, err)
+}
+
 func TestDAGRunWatchRegistryExpiresStuckRun(t *testing.T) {
 	store := &dagRunManageTestStore{
 		status: &exec.DAGRunStatus{

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -34,25 +34,25 @@ func init() {
 }
 
 type dagRunManageInput struct {
-	Action      string              `json:"action"`
-	DAGName     string              `json:"dagName,omitempty"`
-	DAGRunID    string              `json:"dagRunId,omitempty"`
-	SubDAGRunID string              `json:"subDAGRunId,omitempty"`
-	WatchID     string              `json:"watchId,omitempty"`
-	StepName    string              `json:"stepName,omitempty"`
-	Stream      string              `json:"stream,omitempty"`
-	Status      dagManageStringList `json:"status,omitempty"`
-	Labels      dagManageStringList `json:"labels,omitempty"`
-	NotifyOn    dagManageStringList `json:"notifyOn,omitempty"`
-	Last        string              `json:"last,omitempty"`
-	From        string              `json:"from,omitempty"`
-	To          string              `json:"to,omitempty"`
-	Limit       int                 `json:"limit,omitempty"`
-	Cursor      string              `json:"cursor,omitempty"`
-	Head        int                 `json:"head,omitempty"`
-	Tail        int                 `json:"tail,omitempty"`
-	Offset      int                 `json:"offset,omitempty"`
-	Encoding    string              `json:"encoding,omitempty"`
+	Action      string   `json:"action"`
+	DAGName     string   `json:"dagName,omitempty"`
+	DAGRunID    string   `json:"dagRunId,omitempty"`
+	SubDAGRunID string   `json:"subDAGRunId,omitempty"`
+	WatchID     string   `json:"watchId,omitempty"`
+	StepName    string   `json:"stepName,omitempty"`
+	Stream      string   `json:"stream,omitempty"`
+	Status      []string `json:"status,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	NotifyOn    []string `json:"notifyOn,omitempty"`
+	Last        string   `json:"last,omitempty"`
+	From        string   `json:"from,omitempty"`
+	To          string   `json:"to,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+	Cursor      string   `json:"cursor,omitempty"`
+	Head        int      `json:"head,omitempty"`
+	Tail        int      `json:"tail,omitempty"`
+	Offset      int      `json:"offset,omitempty"`
+	Encoding    string   `json:"encoding,omitempty"`
 	// DiagnoseOnFailure defaults to true for watch notifications.
 	DiagnoseOnFailure *bool `json:"diagnoseOnFailure,omitempty"`
 }
@@ -64,47 +64,6 @@ type dagRunManageLogRef struct {
 	SubDAGRunID string `json:"subDAGRunId,omitempty"`
 	StepName    string `json:"stepName,omitempty"`
 	Stream      string `json:"stream"`
-}
-
-type dagRunManageRunSummary struct {
-	DAGName      string                        `json:"dagName"`
-	DAGRunID     string                        `json:"dagRunId"`
-	SubDAGRunID  string                        `json:"subDAGRunId,omitempty"`
-	AttemptID    string                        `json:"attemptId,omitempty"`
-	AttemptKey   string                        `json:"attemptKey,omitempty"`
-	Status       string                        `json:"status"`
-	TriggerType  string                        `json:"triggerType,omitempty"`
-	WorkerID     string                        `json:"workerId,omitempty"`
-	PID          exec.PID                      `json:"pid,omitempty"`
-	StartedAt    string                        `json:"startedAt,omitempty"`
-	FinishedAt   string                        `json:"finishedAt,omitempty"`
-	QueuedAt     string                        `json:"queuedAt,omitempty"`
-	ScheduleTime string                        `json:"scheduleTime,omitempty"`
-	Error        string                        `json:"error,omitempty"`
-	Params       string                        `json:"params,omitempty"`
-	ParamsList   []string                      `json:"paramsList,omitempty"`
-	Labels       []string                      `json:"labels,omitempty"`
-	LogRefs      map[string]dagRunManageLogRef `json:"logRefs,omitempty"`
-	Nodes        []dagRunManageNodeSummary     `json:"nodes,omitempty"`
-	Root         *dagRunManageRef              `json:"root,omitempty"`
-	Parent       *dagRunManageRef              `json:"parent,omitempty"`
-}
-
-type dagRunManageRef struct {
-	DAGName  string `json:"dagName"`
-	DAGRunID string `json:"dagRunId"`
-}
-
-type dagRunManageNodeSummary struct {
-	StepName     string                        `json:"stepName"`
-	Status       string                        `json:"status"`
-	ExecutorType string                        `json:"executorType,omitempty"`
-	StartedAt    string                        `json:"startedAt,omitempty"`
-	FinishedAt   string                        `json:"finishedAt,omitempty"`
-	RetryCount   int                           `json:"retryCount,omitempty"`
-	Error        string                        `json:"error,omitempty"`
-	LogRefs      map[string]dagRunManageLogRef `json:"logRefs,omitempty"`
-	SubRuns      []exec.SubDAGRun              `json:"subRuns,omitempty"`
 }
 
 type dagRunManageLogOutput struct {
@@ -120,31 +79,6 @@ type dagRunManageLogOutput struct {
 	TotalLines  int    `json:"totalLines"`
 	HasMore     bool   `json:"hasMore"`
 	IsEstimate  bool   `json:"isEstimate"`
-}
-
-type dagManageStringList []string
-
-func (l *dagManageStringList) UnmarshalJSON(data []byte) error {
-	raw := strings.TrimSpace(string(data))
-	if raw == "" || raw == "null" {
-		*l = nil
-		return nil
-	}
-	var single string
-	if err := json.Unmarshal(data, &single); err == nil {
-		if single == "" {
-			*l = nil
-			return nil
-		}
-		*l = splitDAGManageList(single)
-		return nil
-	}
-	var values []string
-	if err := json.Unmarshal(data, &values); err != nil {
-		return err
-	}
-	*l = values
-	return nil
 }
 
 // NewDAGRunManageTool creates an agent tool for DAG run inspection and watches.
@@ -264,7 +198,7 @@ func dagRunManageWatch(toolCtx ToolContext, watcher DAGRunWatcher, args dagRunMa
 		DAGName:           args.DAGName,
 		DAGRunID:          args.DAGRunID,
 		SubDAGRunID:       args.SubDAGRunID,
-		NotifyOn:          []string(args.NotifyOn),
+		NotifyOn:          args.NotifyOn,
 		DiagnoseOnFailure: diagnoseOnFailure,
 	})
 	if err != nil {
@@ -341,10 +275,10 @@ func dagRunManageList(ctx context.Context, store exec.DAGRunStore, args dagRunMa
 		opts = append(opts, exec.WithCursor(args.Cursor))
 	}
 	if len(args.Labels) > 0 {
-		opts = append(opts, exec.WithLabels([]string(args.Labels)))
+		opts = append(opts, exec.WithLabels(args.Labels))
 	}
 	if len(args.Status) > 0 {
-		statuses, err := parseDAGRunStatuses([]string(args.Status))
+		statuses, err := parseDAGRunStatuses(args.Status)
 		if err != nil {
 			return toolError("%v", err)
 		}
@@ -376,9 +310,12 @@ func dagRunManageList(ctx context.Context, store exec.DAGRunStore, args dagRunMa
 	if err != nil {
 		return toolError("Failed to list DAG runs: %v", err)
 	}
-	items := make([]dagRunManageRunSummary, 0, len(page.Items))
+	items := make([]map[string]any, 0, len(page.Items))
 	for _, status := range page.Items {
-		items = append(items, summarizeDAGRunStatus(status, ""))
+		if status == nil {
+			continue
+		}
+		items = append(items, dagRunManageStatusPayload(status, "", false))
 	}
 	return dagManageJSON(map[string]any{
 		"action":     "list",
@@ -391,18 +328,18 @@ func dagRunManageList(ctx context.Context, store exec.DAGRunStore, args dagRunMa
 }
 
 func dagRunManageGet(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
-	status, _, out, ok := dagRunManageFindStatus(ctx, store, args)
+	status, _, out, ok := dagRunManageReadStatusForTool(ctx, store, args)
 	if !ok {
 		return out
 	}
 	return dagManageJSON(map[string]any{
 		"action": "get",
-		"run":    summarizeDAGRunStatus(status, args.SubDAGRunID),
+		"run":    dagRunManageStatusPayload(status, args.SubDAGRunID, true),
 	})
 }
 
 func dagRunManageReadLog(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
-	status, _, out, ok := dagRunManageFindStatus(ctx, store, args)
+	status, _, out, ok := dagRunManageReadStatusForTool(ctx, store, args)
 	if !ok {
 		return out
 	}
@@ -429,7 +366,7 @@ func dagRunManageReadLog(ctx context.Context, store exec.DAGRunStore, args dagRu
 }
 
 func dagRunManageReadMessages(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
-	status, attempt, out, ok := dagRunManageFindStatus(ctx, store, args)
+	status, attempt, out, ok := dagRunManageReadStatusForTool(ctx, store, args)
 	if !ok {
 		return out
 	}
@@ -457,7 +394,7 @@ func dagRunManageReadMessages(ctx context.Context, store exec.DAGRunStore, args 
 }
 
 func dagRunManageDiagnose(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
-	status, attempt, out, ok := dagRunManageFindStatus(ctx, store, args)
+	status, attempt, out, ok := dagRunManageReadStatusForTool(ctx, store, args)
 	if !ok {
 		return out
 	}
@@ -495,10 +432,11 @@ func dagRunManageDiagnose(ctx context.Context, store exec.DAGRunStore, args dagR
 		}
 	}
 
-	var primarySummary *dagRunManageNodeSummary
+	primaryName := ""
+	primaryStatus := ""
 	if primary != nil {
-		summary := summarizeDAGRunNode(status.Name, status.DAGRunID, args.SubDAGRunID, primary)
-		primarySummary = &summary
+		primaryName = primary.Step.Name
+		primaryStatus = primary.Status.String()
 	}
 
 	errs := make([]string, 0)
@@ -507,93 +445,176 @@ func dagRunManageDiagnose(ctx context.Context, store exec.DAGRunStore, args dagR
 	}
 
 	return dagManageJSON(map[string]any{
-		"action":            "diagnose",
-		"dagName":           status.Name,
-		"dagRunId":          status.DAGRunID,
-		"subDAGRunId":       args.SubDAGRunID,
-		"status":            status.Status.String(),
-		"error":             status.Error,
-		"errors":            errs,
-		"primaryFailedStep": primarySummary,
-		"logs":              logs,
-		"messages":          messages,
-		"messageCount":      len(messages),
+		"action":                  "diagnose",
+		"dagName":                 status.Name,
+		"dagRunId":                status.DAGRunID,
+		"subDAGRunId":             args.SubDAGRunID,
+		"status":                  status.Status.String(),
+		"error":                   status.Error,
+		"errors":                  errs,
+		"primaryFailedStep":       primary,
+		"primaryFailedStepName":   primaryName,
+		"primaryFailedStepStatus": primaryStatus,
+		"logs":                    logs,
+		"messages":                messages,
+		"messageCount":            len(messages),
 	})
 }
 
-func dagRunManageFindStatus(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) (*exec.DAGRunStatus, exec.DAGRunAttempt, ToolOut, bool) {
+func dagRunManageReadStatusForTool(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) (*exec.DAGRunStatus, exec.DAGRunAttempt, ToolOut, bool) {
 	if args.DAGName == "" {
 		return nil, nil, toolError("dagName is required"), false
 	}
 	if args.DAGRunID == "" {
 		return nil, nil, toolError("dagRunId is required"), false
 	}
-	root := exec.NewDAGRunRef(args.DAGName, args.DAGRunID)
-	var (
-		attempt exec.DAGRunAttempt
-		err     error
-	)
-	if args.SubDAGRunID != "" {
-		attempt, err = store.FindSubAttempt(ctx, root, args.SubDAGRunID)
-	} else {
-		attempt, err = store.FindAttempt(ctx, root)
-	}
+	status, attempt, err := readDAGRunStatus(ctx, store, args.DAGName, args.DAGRunID, args.SubDAGRunID)
 	if err != nil {
-		return nil, nil, toolError("Failed to find DAG run: %v", err), false
-	}
-	status, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		return nil, nil, toolError("Failed to read DAG run status: %v", err), false
+		return nil, nil, toolError("%v", err), false
 	}
 	return status, attempt, ToolOut{}, true
 }
 
-func summarizeDAGRunStatus(status *exec.DAGRunStatus, subDAGRunID string) dagRunManageRunSummary {
+func readDAGRunStatus(ctx context.Context, store exec.DAGRunStore, dagName, dagRunID, subDAGRunID string) (*exec.DAGRunStatus, exec.DAGRunAttempt, error) {
+	if store == nil {
+		return nil, nil, errors.New("dag-run store is not configured")
+	}
+	root := exec.NewDAGRunRef(dagName, dagRunID)
+	var (
+		attempt exec.DAGRunAttempt
+		err     error
+	)
+	if subDAGRunID != "" {
+		attempt, err = store.FindSubAttempt(ctx, root, subDAGRunID)
+	} else {
+		attempt, err = store.FindAttempt(ctx, root)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find DAG run: %w", err)
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read DAG run status: %w", err)
+	}
+	return status, attempt, nil
+}
+
+func dagRunManageStatusPayload(status *exec.DAGRunStatus, subDAGRunID string, includeRun bool) map[string]any {
 	if status == nil {
-		return dagRunManageRunSummary{}
+		return map[string]any{}
 	}
-	nodes := make([]dagRunManageNodeSummary, 0, len(status.Nodes))
-	for _, node := range status.Nodes {
-		nodes = append(nodes, summarizeDAGRunNode(status.Name, status.DAGRunID, subDAGRunID, node))
+	out := map[string]any{
+		"dagName":  status.Name,
+		"dagRunId": status.DAGRunID,
+		"status":   status.Status.String(),
 	}
-	out := dagRunManageRunSummary{
-		DAGName:      status.Name,
-		DAGRunID:     status.DAGRunID,
-		SubDAGRunID:  subDAGRunID,
-		AttemptID:    status.AttemptID,
-		AttemptKey:   status.AttemptKey,
-		Status:       status.Status.String(),
-		TriggerType:  status.TriggerType.String(),
-		WorkerID:     status.WorkerID,
-		PID:          status.PID,
-		StartedAt:    status.StartedAt,
-		FinishedAt:   status.FinishedAt,
-		QueuedAt:     status.QueuedAt,
-		ScheduleTime: status.ScheduleTime,
-		Error:        status.Error,
-		Params:       status.Params,
-		ParamsList:   status.ParamsList,
-		Labels:       status.Labels,
-		Nodes:        nodes,
-	}
-	if status.Log != "" {
-		out.LogRefs = map[string]dagRunManageLogRef{
-			"scheduler": newDAGRunManageLogRef(status.Name, status.DAGRunID, subDAGRunID, "", "scheduler"),
+	for key, value := range map[string]string{
+		"subDAGRunId":  subDAGRunID,
+		"attemptId":    status.AttemptID,
+		"attemptKey":   status.AttemptKey,
+		"workerId":     status.WorkerID,
+		"startedAt":    status.StartedAt,
+		"finishedAt":   status.FinishedAt,
+		"queuedAt":     status.QueuedAt,
+		"scheduleTime": status.ScheduleTime,
+		"error":        status.Error,
+		"params":       status.Params,
+	} {
+		if value != "" {
+			out[key] = value
 		}
 	}
+	if len(status.ParamsList) > 0 {
+		out["paramsList"] = status.ParamsList
+	}
+	if len(status.Labels) > 0 {
+		out["labels"] = status.Labels
+	}
+	if status.TriggerType != core.TriggerTypeUnknown {
+		out["triggerType"] = status.TriggerType.String()
+	}
+	if nodes := dagRunManageNodePayloads(status.Name, status.DAGRunID, subDAGRunID, status); len(nodes) > 0 {
+		out["nodes"] = nodes
+	}
+	if refs := dagRunManageLogRefs(status.Name, status.DAGRunID, subDAGRunID, status); len(refs) > 0 {
+		out["logRefs"] = refs
+	}
+	if refs := dagRunManageStepLogRefs(status.Name, status.DAGRunID, subDAGRunID, status); len(refs) > 0 {
+		out["stepLogRefs"] = refs
+	}
 	if !status.Root.Zero() {
-		out.Root = &dagRunManageRef{DAGName: status.Root.Name, DAGRunID: status.Root.ID}
+		out["root"] = status.Root
 	}
 	if !status.Parent.Zero() {
-		out.Parent = &dagRunManageRef{DAGName: status.Parent.Name, DAGRunID: status.Parent.ID}
+		out["parent"] = status.Parent
+	}
+	if includeRun {
+		out["run"] = status
 	}
 	return out
 }
 
-func summarizeDAGRunNode(dagName, dagRunID, subDAGRunID string, node *exec.Node) dagRunManageNodeSummary {
-	if node == nil {
-		return dagRunManageNodeSummary{}
+func dagRunManageLogRefs(dagName, dagRunID, subDAGRunID string, status *exec.DAGRunStatus) map[string]dagRunManageLogRef {
+	if status.Log != "" {
+		return map[string]dagRunManageLogRef{
+			"scheduler": newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, "", "scheduler"),
+		}
 	}
+	return nil
+}
+
+func dagRunManageNodePayloads(dagName, dagRunID, subDAGRunID string, status *exec.DAGRunStatus) []map[string]any {
+	nodes := make([]map[string]any, 0, len(status.Nodes))
+	for _, node := range status.Nodes {
+		if node == nil {
+			continue
+		}
+		item := map[string]any{
+			"stepName": node.Step.Name,
+			"status":   node.Status.String(),
+		}
+		for key, value := range map[string]string{
+			"executorType": node.Step.ExecutorConfig.Type,
+			"startedAt":    node.StartedAt,
+			"finishedAt":   node.FinishedAt,
+			"error":        node.Error,
+		} {
+			if value != "" {
+				item[key] = value
+			}
+		}
+		if node.RetryCount > 0 {
+			item["retryCount"] = node.RetryCount
+		}
+		if len(node.SubRuns) > 0 {
+			item["subRuns"] = node.SubRuns
+		}
+		if refs := dagRunManageNodeLogRefs(dagName, dagRunID, subDAGRunID, node); len(refs) > 0 {
+			item["logRefs"] = refs
+		}
+		nodes = append(nodes, item)
+	}
+	return nodes
+}
+
+func dagRunManageStepLogRefs(dagName, dagRunID, subDAGRunID string, status *exec.DAGRunStatus) map[string]map[string]dagRunManageLogRef {
+	refs := map[string]map[string]dagRunManageLogRef{}
+	for _, node := range status.Nodes {
+		if node == nil || node.Step.Name == "" {
+			continue
+		}
+		nodeRefs := dagRunManageNodeLogRefs(dagName, dagRunID, subDAGRunID, node)
+		if len(nodeRefs) > 0 {
+			refs[node.Step.Name] = nodeRefs
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+func dagRunManageNodeLogRefs(dagName, dagRunID, subDAGRunID string, node *exec.Node) map[string]dagRunManageLogRef {
 	refs := map[string]dagRunManageLogRef{}
 	if node.Stdout != "" {
 		refs["stdout"] = newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, node.Step.Name, "stdout")
@@ -602,19 +623,9 @@ func summarizeDAGRunNode(dagName, dagRunID, subDAGRunID string, node *exec.Node)
 		refs["stderr"] = newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, node.Step.Name, "stderr")
 	}
 	if len(refs) == 0 {
-		refs = nil
+		return nil
 	}
-	return dagRunManageNodeSummary{
-		StepName:     node.Step.Name,
-		Status:       node.Status.String(),
-		ExecutorType: node.Step.ExecutorConfig.Type,
-		StartedAt:    node.StartedAt,
-		FinishedAt:   node.FinishedAt,
-		RetryCount:   node.RetryCount,
-		Error:        node.Error,
-		LogRefs:      refs,
-		SubRuns:      node.SubRuns,
-	}
+	return refs
 }
 
 func newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, stepName, stream string) dagRunManageLogRef {
@@ -827,20 +838,6 @@ func clampAgentLimit(value, defaultValue, maxValue int) int {
 		return maxValue
 	}
 	return value
-}
-
-func splitDAGManageList(value string) []string {
-	fields := strings.FieldsFunc(value, func(r rune) bool {
-		return r == ',' || r == ' '
-	})
-	out := make([]string, 0, len(fields))
-	for _, field := range fields {
-		field = strings.TrimSpace(field)
-		if field != "" {
-			out = append(out, field)
-		}
-	}
-	return out
 }
 
 func dagManageJSON(v any) ToolOut {

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -1,0 +1,852 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/llm"
+)
+
+const dagRunManageToolName = "dag_run_manage"
+
+func init() {
+	RegisterTool(ToolRegistration{
+		Name:           dagRunManageToolName,
+		Label:          "DAG Run Manage",
+		Description:    "Inspect DAG run history, status, logs, and LLM step messages",
+		DefaultEnabled: true,
+		Factory: func(cfg ToolConfig) *AgentTool {
+			return NewDAGRunManageTool(cfg.DAGRunStore, cfg.DAGRunWatcher)
+		},
+	})
+}
+
+type dagRunManageInput struct {
+	Action      string              `json:"action"`
+	DAGName     string              `json:"dagName,omitempty"`
+	DAGRunID    string              `json:"dagRunId,omitempty"`
+	SubDAGRunID string              `json:"subDAGRunId,omitempty"`
+	WatchID     string              `json:"watchId,omitempty"`
+	StepName    string              `json:"stepName,omitempty"`
+	Stream      string              `json:"stream,omitempty"`
+	Status      dagManageStringList `json:"status,omitempty"`
+	Labels      dagManageStringList `json:"labels,omitempty"`
+	NotifyOn    dagManageStringList `json:"notifyOn,omitempty"`
+	Last        string              `json:"last,omitempty"`
+	From        string              `json:"from,omitempty"`
+	To          string              `json:"to,omitempty"`
+	Limit       int                 `json:"limit,omitempty"`
+	Cursor      string              `json:"cursor,omitempty"`
+	Head        int                 `json:"head,omitempty"`
+	Tail        int                 `json:"tail,omitempty"`
+	Offset      int                 `json:"offset,omitempty"`
+	Encoding    string              `json:"encoding,omitempty"`
+	// DiagnoseOnFailure defaults to true for watch notifications.
+	DiagnoseOnFailure *bool `json:"diagnoseOnFailure,omitempty"`
+}
+
+type dagRunManageLogRef struct {
+	Action      string `json:"action"`
+	DAGName     string `json:"dagName"`
+	DAGRunID    string `json:"dagRunId"`
+	SubDAGRunID string `json:"subDAGRunId,omitempty"`
+	StepName    string `json:"stepName,omitempty"`
+	Stream      string `json:"stream"`
+}
+
+type dagRunManageRunSummary struct {
+	DAGName      string                        `json:"dagName"`
+	DAGRunID     string                        `json:"dagRunId"`
+	SubDAGRunID  string                        `json:"subDAGRunId,omitempty"`
+	AttemptID    string                        `json:"attemptId,omitempty"`
+	AttemptKey   string                        `json:"attemptKey,omitempty"`
+	Status       string                        `json:"status"`
+	TriggerType  string                        `json:"triggerType,omitempty"`
+	WorkerID     string                        `json:"workerId,omitempty"`
+	PID          exec.PID                      `json:"pid,omitempty"`
+	StartedAt    string                        `json:"startedAt,omitempty"`
+	FinishedAt   string                        `json:"finishedAt,omitempty"`
+	QueuedAt     string                        `json:"queuedAt,omitempty"`
+	ScheduleTime string                        `json:"scheduleTime,omitempty"`
+	Error        string                        `json:"error,omitempty"`
+	Params       string                        `json:"params,omitempty"`
+	ParamsList   []string                      `json:"paramsList,omitempty"`
+	Labels       []string                      `json:"labels,omitempty"`
+	LogRefs      map[string]dagRunManageLogRef `json:"logRefs,omitempty"`
+	Nodes        []dagRunManageNodeSummary     `json:"nodes,omitempty"`
+	Root         *dagRunManageRef              `json:"root,omitempty"`
+	Parent       *dagRunManageRef              `json:"parent,omitempty"`
+}
+
+type dagRunManageRef struct {
+	DAGName  string `json:"dagName"`
+	DAGRunID string `json:"dagRunId"`
+}
+
+type dagRunManageNodeSummary struct {
+	StepName     string                        `json:"stepName"`
+	Status       string                        `json:"status"`
+	ExecutorType string                        `json:"executorType,omitempty"`
+	StartedAt    string                        `json:"startedAt,omitempty"`
+	FinishedAt   string                        `json:"finishedAt,omitempty"`
+	RetryCount   int                           `json:"retryCount,omitempty"`
+	Error        string                        `json:"error,omitempty"`
+	LogRefs      map[string]dagRunManageLogRef `json:"logRefs,omitempty"`
+	SubRuns      []exec.SubDAGRun              `json:"subRuns,omitempty"`
+}
+
+type dagRunManageLogOutput struct {
+	Action      string `json:"action"`
+	DAGName     string `json:"dagName"`
+	DAGRunID    string `json:"dagRunId"`
+	SubDAGRunID string `json:"subDAGRunId,omitempty"`
+	StepName    string `json:"stepName,omitempty"`
+	Stream      string `json:"stream"`
+	Path        string `json:"path,omitempty"`
+	Content     string `json:"content"`
+	LineCount   int    `json:"lineCount"`
+	TotalLines  int    `json:"totalLines"`
+	HasMore     bool   `json:"hasMore"`
+	IsEstimate  bool   `json:"isEstimate"`
+}
+
+type dagManageStringList []string
+
+func (l *dagManageStringList) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw == "null" {
+		*l = nil
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		if single == "" {
+			*l = nil
+			return nil
+		}
+		*l = splitDAGManageList(single)
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+	*l = values
+	return nil
+}
+
+// NewDAGRunManageTool creates an agent tool for DAG run inspection and watches.
+func NewDAGRunManageTool(store exec.DAGRunStore, watchers ...DAGRunWatcher) *AgentTool {
+	var watcher DAGRunWatcher
+	if len(watchers) > 0 {
+		watcher = watchers[0]
+	}
+	return &AgentTool{
+		Tool: llm.Tool{
+			Type: "function",
+			Function: llm.ToolFunction{
+				Name:        dagRunManageToolName,
+				Description: "Inspect DAG run history, detailed run state, scheduler/step logs, LLM messages, and session-local run watches. Use list to find runs, get to obtain step log refs, read_log/read_messages to drill into a step, diagnose to collect likely failure context, and watch after enqueueing instead of polling.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"action": map[string]any{
+							"type":        "string",
+							"enum":        []string{"list", "get", "read_log", "read_messages", "diagnose", "watch", "watch_status", "cancel_watch"},
+							"description": "Operation to perform.",
+						},
+						"dagName":     map[string]any{"type": "string", "description": "DAG name. Required for get/read_log/read_messages/diagnose/watch; optional exact filter for list."},
+						"dagRunId":    map[string]any{"type": "string", "description": "DAG run ID. Required for get/read_log/read_messages/diagnose/watch."},
+						"subDAGRunId": map[string]any{"type": "string", "description": "Optional sub-DAG run ID under dagName/dagRunId."},
+						"watchId":     map[string]any{"type": "string", "description": "Watch ID returned by watch. Use for watch_status or cancel_watch."},
+						"stepName":    map[string]any{"type": "string", "description": "Step name for step logs or LLM messages."},
+						"stream":      map[string]any{"type": "string", "enum": []string{"scheduler", "stdout", "stderr"}, "description": "Log stream to read. Use scheduler for run log; stdout/stderr for step logs."},
+						"status":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional status filter for list, e.g. failed, running, succeeded."},
+						"labels":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional labels filter for list."},
+						"notifyOn":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional watch notification filter. Defaults to terminal; also supports failure or success."},
+						"diagnoseOnFailure": map[string]any{
+							"type":        "boolean",
+							"description": "For watch notifications, include compact failed-step context when the run ends unsuccessfully. Defaults to true.",
+						},
+						"last":     map[string]any{"type": "string", "description": "Optional relative list window, e.g. 30m, 24h, 7d, 2w."},
+						"from":     map[string]any{"type": "string", "description": "Optional RFC3339 or YYYY-MM-DD list start time."},
+						"to":       map[string]any{"type": "string", "description": "Optional RFC3339 or YYYY-MM-DD list end time."},
+						"limit":    map[string]any{"type": "integer", "description": "Maximum items for list (default 20, max 100)."},
+						"cursor":   map[string]any{"type": "string", "description": "Opaque cursor returned by list."},
+						"head":     map[string]any{"type": "integer", "description": "Read first N log lines."},
+						"tail":     map[string]any{"type": "integer", "description": "Read last N log lines (default 500 for read_log/diagnose)."},
+						"offset":   map[string]any{"type": "integer", "description": "1-based log line offset."},
+						"encoding": map[string]any{"type": "string", "description": "Optional log file character encoding."},
+					},
+					"required": []string{"action"},
+				},
+			},
+		},
+		Run: func(ctx ToolContext, input json.RawMessage) ToolOut {
+			return dagRunManageRun(ctx, input, store, watcher)
+		},
+		Audit: &AuditInfo{
+			Action:          dagRunManageToolName,
+			DetailExtractor: ExtractFields("action", "dagName", "dagRunId", "subDAGRunId", "watchId", "stepName", "stream"),
+		},
+	}
+}
+
+func dagRunManageRun(toolCtx ToolContext, input json.RawMessage, store exec.DAGRunStore, watcher DAGRunWatcher) ToolOut {
+	var args dagRunManageInput
+	if err := json.Unmarshal(input, &args); err != nil {
+		return toolError("Failed to parse input: %v", err)
+	}
+	if toolCtx.Context == nil {
+		toolCtx.Context = context.Background()
+	}
+
+	switch strings.TrimSpace(args.Action) {
+	case "list":
+		if store == nil {
+			return toolError("%s is unavailable: dag-run store is not configured", dagRunManageToolName)
+		}
+		return dagRunManageList(toolCtx.Context, store, args)
+	case "get":
+		if store == nil {
+			return toolError("%s is unavailable: dag-run store is not configured", dagRunManageToolName)
+		}
+		return dagRunManageGet(toolCtx.Context, store, args)
+	case "read_log":
+		if store == nil {
+			return toolError("%s is unavailable: dag-run store is not configured", dagRunManageToolName)
+		}
+		return dagRunManageReadLog(toolCtx.Context, store, args)
+	case "read_messages":
+		if store == nil {
+			return toolError("%s is unavailable: dag-run store is not configured", dagRunManageToolName)
+		}
+		return dagRunManageReadMessages(toolCtx.Context, store, args)
+	case "diagnose":
+		if store == nil {
+			return toolError("%s is unavailable: dag-run store is not configured", dagRunManageToolName)
+		}
+		return dagRunManageDiagnose(toolCtx.Context, store, args)
+	case "watch":
+		return dagRunManageWatch(toolCtx, watcher, args)
+	case "watch_status":
+		return dagRunManageWatchStatus(toolCtx, watcher, args)
+	case "cancel_watch":
+		return dagRunManageCancelWatch(toolCtx, watcher, args)
+	default:
+		return toolError("Unknown action: %s. Use list, get, read_log, read_messages, diagnose, watch, watch_status, or cancel_watch.", args.Action)
+	}
+}
+
+func dagRunManageWatch(toolCtx ToolContext, watcher DAGRunWatcher, args dagRunManageInput) ToolOut {
+	if watcher == nil {
+		return toolError("%s watch is unavailable: dag-run watcher is not configured", dagRunManageToolName)
+	}
+	diagnoseOnFailure := true
+	if args.DiagnoseOnFailure != nil {
+		diagnoseOnFailure = *args.DiagnoseOnFailure
+	}
+	info, err := watcher.Watch(toolCtx.Context, DAGRunWatchRequest{
+		SessionID:         toolCtx.SessionID,
+		User:              toolCtx.User,
+		DAGName:           args.DAGName,
+		DAGRunID:          args.DAGRunID,
+		SubDAGRunID:       args.SubDAGRunID,
+		NotifyOn:          []string(args.NotifyOn),
+		DiagnoseOnFailure: diagnoseOnFailure,
+	})
+	if err != nil {
+		return toolError("Failed to watch DAG run: %v", err)
+	}
+	return dagManageJSON(map[string]any{
+		"action":  "watch",
+		"watch":   info,
+		"watchId": info.WatchID,
+		"state":   info.State,
+		"status":  info.Status,
+	})
+}
+
+func dagRunManageWatchStatus(toolCtx ToolContext, watcher DAGRunWatcher, args dagRunManageInput) ToolOut {
+	if watcher == nil {
+		return toolError("%s watch is unavailable: dag-run watcher is not configured", dagRunManageToolName)
+	}
+	info, err := watcher.Status(toolCtx.Context, DAGRunWatchStatusRequest{
+		SessionID:   toolCtx.SessionID,
+		WatchID:     args.WatchID,
+		DAGName:     args.DAGName,
+		DAGRunID:    args.DAGRunID,
+		SubDAGRunID: args.SubDAGRunID,
+	})
+	if err != nil {
+		return toolError("Failed to read DAG run watch: %v", err)
+	}
+	return dagManageJSON(map[string]any{
+		"action":  "watch_status",
+		"watch":   info,
+		"watchId": info.WatchID,
+		"state":   info.State,
+		"status":  info.Status,
+	})
+}
+
+func dagRunManageCancelWatch(toolCtx ToolContext, watcher DAGRunWatcher, args dagRunManageInput) ToolOut {
+	if watcher == nil {
+		return toolError("%s watch is unavailable: dag-run watcher is not configured", dagRunManageToolName)
+	}
+	info, err := watcher.Cancel(toolCtx.Context, DAGRunWatchCancelRequest{
+		SessionID:   toolCtx.SessionID,
+		WatchID:     args.WatchID,
+		DAGName:     args.DAGName,
+		DAGRunID:    args.DAGRunID,
+		SubDAGRunID: args.SubDAGRunID,
+	})
+	if err != nil {
+		return toolError("Failed to cancel DAG run watch: %v", err)
+	}
+	return dagManageJSON(map[string]any{
+		"action":  "cancel_watch",
+		"watch":   info,
+		"watchId": info.WatchID,
+		"state":   info.State,
+		"status":  info.Status,
+	})
+}
+
+func dagRunManageList(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
+	limit := clampAgentLimit(args.Limit, 20, 100)
+	opts := []exec.ListDAGRunStatusesOption{
+		exec.WithLimit(limit),
+		exec.WithAllHistory(),
+	}
+	if args.DAGName != "" {
+		opts = append(opts, exec.WithExactName(args.DAGName))
+	}
+	if args.DAGRunID != "" {
+		opts = append(opts, exec.WithDAGRunID(args.DAGRunID))
+	}
+	if args.Cursor != "" {
+		opts = append(opts, exec.WithCursor(args.Cursor))
+	}
+	if len(args.Labels) > 0 {
+		opts = append(opts, exec.WithLabels([]string(args.Labels)))
+	}
+	if len(args.Status) > 0 {
+		statuses, err := parseDAGRunStatuses([]string(args.Status))
+		if err != nil {
+			return toolError("%v", err)
+		}
+		opts = append(opts, exec.WithStatuses(statuses))
+	}
+	if args.Last != "" {
+		from, err := parseDAGManageRelativeTime(args.Last, time.Now())
+		if err != nil {
+			return toolError("%v", err)
+		}
+		opts = append(opts, exec.WithFrom(exec.NewUTC(from)))
+	}
+	if args.From != "" {
+		from, err := parseDAGManageAbsoluteTime(args.From, false)
+		if err != nil {
+			return toolError("invalid from time: %v", err)
+		}
+		opts = append(opts, exec.WithFrom(exec.NewUTC(from)))
+	}
+	if args.To != "" {
+		to, err := parseDAGManageAbsoluteTime(args.To, true)
+		if err != nil {
+			return toolError("invalid to time: %v", err)
+		}
+		opts = append(opts, exec.WithTo(exec.NewUTC(to)))
+	}
+
+	page, err := store.ListStatusesPage(ctx, opts...)
+	if err != nil {
+		return toolError("Failed to list DAG runs: %v", err)
+	}
+	items := make([]dagRunManageRunSummary, 0, len(page.Items))
+	for _, status := range page.Items {
+		items = append(items, summarizeDAGRunStatus(status, ""))
+	}
+	return dagManageJSON(map[string]any{
+		"action":     "list",
+		"items":      items,
+		"limit":      limit,
+		"cursor":     args.Cursor,
+		"nextCursor": page.NextCursor,
+		"hasMore":    page.NextCursor != "",
+	})
+}
+
+func dagRunManageGet(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
+	status, _, out, ok := dagRunManageFindStatus(ctx, store, args)
+	if !ok {
+		return out
+	}
+	return dagManageJSON(map[string]any{
+		"action": "get",
+		"run":    summarizeDAGRunStatus(status, args.SubDAGRunID),
+	})
+}
+
+func dagRunManageReadLog(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
+	status, _, out, ok := dagRunManageFindStatus(ctx, store, args)
+	if !ok {
+		return out
+	}
+	stream := normalizeDAGRunLogStream(args.Stream)
+	if stream == "" {
+		return toolError("stream is required and must be one of: scheduler, stdout, stderr")
+	}
+	logPath, err := selectDAGRunManageLogPath(status, args.StepName, stream)
+	if err != nil {
+		return toolError("%v", err)
+	}
+	read, err := readDAGManageLogFile(logPath, args)
+	if err != nil {
+		return toolError("Failed to read %s log: %v", stream, err)
+	}
+	read.Action = "read_log"
+	read.DAGName = args.DAGName
+	read.DAGRunID = args.DAGRunID
+	read.SubDAGRunID = args.SubDAGRunID
+	read.StepName = args.StepName
+	read.Stream = stream
+	read.Path = logPath
+	return dagManageJSON(read)
+}
+
+func dagRunManageReadMessages(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
+	status, attempt, out, ok := dagRunManageFindStatus(ctx, store, args)
+	if !ok {
+		return out
+	}
+	if strings.TrimSpace(args.StepName) == "" {
+		return toolError("stepName is required for read_messages")
+	}
+	messages, err := attempt.ReadStepMessages(ctx, args.StepName)
+	if err != nil {
+		return toolError("Failed to read step messages: %v", err)
+	}
+	if len(messages) == 0 {
+		if node, err := status.NodeByName(args.StepName); err == nil {
+			messages = node.ChatMessages
+		}
+	}
+	return dagManageJSON(map[string]any{
+		"action":      "read_messages",
+		"dagName":     args.DAGName,
+		"dagRunId":    args.DAGRunID,
+		"subDAGRunId": args.SubDAGRunID,
+		"stepName":    args.StepName,
+		"messages":    messages,
+		"count":       len(messages),
+	})
+}
+
+func dagRunManageDiagnose(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) ToolOut {
+	status, attempt, out, ok := dagRunManageFindStatus(ctx, store, args)
+	if !ok {
+		return out
+	}
+	var primary *exec.Node
+	if args.StepName != "" {
+		node, err := status.NodeByName(args.StepName)
+		if err != nil {
+			return toolError("%v", err)
+		}
+		primary = node
+	} else {
+		primary = firstFailedDAGRunNode(status)
+	}
+
+	logArgs := args
+	if logArgs.Tail == 0 && logArgs.Head == 0 && logArgs.Offset == 0 && logArgs.Limit == 0 {
+		logArgs.Tail = 500
+	}
+	logs := map[string]any{}
+	if status.Log != "" {
+		logs["scheduler"] = readDAGManageLogForDiagnose(status.Log, logArgs)
+	}
+	var messages []exec.LLMMessage
+	if primary != nil {
+		if primary.Stdout != "" {
+			logs["stdout"] = readDAGManageLogForDiagnose(primary.Stdout, logArgs)
+		}
+		if primary.Stderr != "" {
+			logs["stderr"] = readDAGManageLogForDiagnose(primary.Stderr, logArgs)
+		}
+		var err error
+		messages, err = attempt.ReadStepMessages(ctx, primary.Step.Name)
+		if err == nil && len(messages) == 0 {
+			messages = primary.ChatMessages
+		}
+	}
+
+	var primarySummary *dagRunManageNodeSummary
+	if primary != nil {
+		summary := summarizeDAGRunNode(status.Name, status.DAGRunID, args.SubDAGRunID, primary)
+		primarySummary = &summary
+	}
+
+	errs := make([]string, 0)
+	for _, err := range status.Errors() {
+		errs = append(errs, err.Error())
+	}
+
+	return dagManageJSON(map[string]any{
+		"action":            "diagnose",
+		"dagName":           status.Name,
+		"dagRunId":          status.DAGRunID,
+		"subDAGRunId":       args.SubDAGRunID,
+		"status":            status.Status.String(),
+		"error":             status.Error,
+		"errors":            errs,
+		"primaryFailedStep": primarySummary,
+		"logs":              logs,
+		"messages":          messages,
+		"messageCount":      len(messages),
+	})
+}
+
+func dagRunManageFindStatus(ctx context.Context, store exec.DAGRunStore, args dagRunManageInput) (*exec.DAGRunStatus, exec.DAGRunAttempt, ToolOut, bool) {
+	if args.DAGName == "" {
+		return nil, nil, toolError("dagName is required"), false
+	}
+	if args.DAGRunID == "" {
+		return nil, nil, toolError("dagRunId is required"), false
+	}
+	root := exec.NewDAGRunRef(args.DAGName, args.DAGRunID)
+	var (
+		attempt exec.DAGRunAttempt
+		err     error
+	)
+	if args.SubDAGRunID != "" {
+		attempt, err = store.FindSubAttempt(ctx, root, args.SubDAGRunID)
+	} else {
+		attempt, err = store.FindAttempt(ctx, root)
+	}
+	if err != nil {
+		return nil, nil, toolError("Failed to find DAG run: %v", err), false
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, nil, toolError("Failed to read DAG run status: %v", err), false
+	}
+	return status, attempt, ToolOut{}, true
+}
+
+func summarizeDAGRunStatus(status *exec.DAGRunStatus, subDAGRunID string) dagRunManageRunSummary {
+	if status == nil {
+		return dagRunManageRunSummary{}
+	}
+	nodes := make([]dagRunManageNodeSummary, 0, len(status.Nodes))
+	for _, node := range status.Nodes {
+		nodes = append(nodes, summarizeDAGRunNode(status.Name, status.DAGRunID, subDAGRunID, node))
+	}
+	out := dagRunManageRunSummary{
+		DAGName:      status.Name,
+		DAGRunID:     status.DAGRunID,
+		SubDAGRunID:  subDAGRunID,
+		AttemptID:    status.AttemptID,
+		AttemptKey:   status.AttemptKey,
+		Status:       status.Status.String(),
+		TriggerType:  status.TriggerType.String(),
+		WorkerID:     status.WorkerID,
+		PID:          status.PID,
+		StartedAt:    status.StartedAt,
+		FinishedAt:   status.FinishedAt,
+		QueuedAt:     status.QueuedAt,
+		ScheduleTime: status.ScheduleTime,
+		Error:        status.Error,
+		Params:       status.Params,
+		ParamsList:   status.ParamsList,
+		Labels:       status.Labels,
+		Nodes:        nodes,
+	}
+	if status.Log != "" {
+		out.LogRefs = map[string]dagRunManageLogRef{
+			"scheduler": newDAGRunManageLogRef(status.Name, status.DAGRunID, subDAGRunID, "", "scheduler"),
+		}
+	}
+	if !status.Root.Zero() {
+		out.Root = &dagRunManageRef{DAGName: status.Root.Name, DAGRunID: status.Root.ID}
+	}
+	if !status.Parent.Zero() {
+		out.Parent = &dagRunManageRef{DAGName: status.Parent.Name, DAGRunID: status.Parent.ID}
+	}
+	return out
+}
+
+func summarizeDAGRunNode(dagName, dagRunID, subDAGRunID string, node *exec.Node) dagRunManageNodeSummary {
+	if node == nil {
+		return dagRunManageNodeSummary{}
+	}
+	refs := map[string]dagRunManageLogRef{}
+	if node.Stdout != "" {
+		refs["stdout"] = newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, node.Step.Name, "stdout")
+	}
+	if node.Stderr != "" {
+		refs["stderr"] = newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, node.Step.Name, "stderr")
+	}
+	if len(refs) == 0 {
+		refs = nil
+	}
+	return dagRunManageNodeSummary{
+		StepName:     node.Step.Name,
+		Status:       node.Status.String(),
+		ExecutorType: node.Step.ExecutorConfig.Type,
+		StartedAt:    node.StartedAt,
+		FinishedAt:   node.FinishedAt,
+		RetryCount:   node.RetryCount,
+		Error:        node.Error,
+		LogRefs:      refs,
+		SubRuns:      node.SubRuns,
+	}
+}
+
+func newDAGRunManageLogRef(dagName, dagRunID, subDAGRunID, stepName, stream string) dagRunManageLogRef {
+	return dagRunManageLogRef{
+		Action:      "read_log",
+		DAGName:     dagName,
+		DAGRunID:    dagRunID,
+		SubDAGRunID: subDAGRunID,
+		StepName:    stepName,
+		Stream:      stream,
+	}
+}
+
+func selectDAGRunManageLogPath(status *exec.DAGRunStatus, stepName, stream string) (string, error) {
+	if stream == "scheduler" {
+		if status.Log == "" {
+			return "", fmt.Errorf("scheduler log path is empty")
+		}
+		return status.Log, nil
+	}
+	if stepName == "" {
+		return "", fmt.Errorf("stepName is required for %s logs", stream)
+	}
+	node, err := status.NodeByName(stepName)
+	if err != nil {
+		return "", err
+	}
+	switch stream {
+	case "stdout":
+		if node.Stdout == "" {
+			return "", fmt.Errorf("stdout log path is empty for step %s", stepName)
+		}
+		return node.Stdout, nil
+	case "stderr":
+		if node.Stderr == "" {
+			return "", fmt.Errorf("stderr log path is empty for step %s", stepName)
+		}
+		return node.Stderr, nil
+	default:
+		return "", fmt.Errorf("unknown log stream: %s", stream)
+	}
+}
+
+func readDAGManageLogFile(path string, args dagRunManageInput) (dagRunManageLogOutput, error) {
+	options := buildDAGManageLogOptions(args)
+	content, lineCount, totalLines, hasMore, isEstimate, err := fileutil.ReadLogContent(path, options)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return dagRunManageLogOutput{}, fmt.Errorf("log file not found: %s", path)
+		}
+		return dagRunManageLogOutput{}, err
+	}
+	return dagRunManageLogOutput{
+		Content:    content,
+		LineCount:  lineCount,
+		TotalLines: totalLines,
+		HasMore:    hasMore,
+		IsEstimate: isEstimate,
+	}, nil
+}
+
+func buildDAGManageLogOptions(args dagRunManageInput) fileutil.LogReadOptions {
+	tail := args.Tail
+	if tail == 0 && args.Head == 0 && args.Offset == 0 && args.Limit == 0 {
+		tail = 500
+	}
+	return fileutil.LogReadOptions{
+		Head:     args.Head,
+		Tail:     tail,
+		Offset:   args.Offset,
+		Limit:    args.Limit,
+		Encoding: args.Encoding,
+	}
+}
+
+func readDAGManageLogForDiagnose(path string, args dagRunManageInput) map[string]any {
+	read, err := readDAGManageLogFile(path, args)
+	if err != nil {
+		return map[string]any{
+			"path":  path,
+			"error": err.Error(),
+		}
+	}
+	return map[string]any{
+		"path":       path,
+		"content":    read.Content,
+		"lineCount":  read.LineCount,
+		"totalLines": read.TotalLines,
+		"hasMore":    read.HasMore,
+		"isEstimate": read.IsEstimate,
+	}
+}
+
+func firstFailedDAGRunNode(status *exec.DAGRunStatus) *exec.Node {
+	if status == nil {
+		return nil
+	}
+	for _, node := range status.Nodes {
+		if node == nil {
+			continue
+		}
+		switch node.Status {
+		case core.NodeFailed, core.NodeAborted, core.NodeRejected:
+			return node
+		}
+	}
+	return nil
+}
+
+func normalizeDAGRunLogStream(stream string) string {
+	switch strings.ToLower(strings.TrimSpace(stream)) {
+	case "", "scheduler":
+		return "scheduler"
+	case "stdout", "out":
+		return "stdout"
+	case "stderr", "err":
+		return "stderr"
+	default:
+		return ""
+	}
+}
+
+func parseDAGRunStatuses(values []string) ([]core.Status, error) {
+	statuses := make([]core.Status, 0, len(values))
+	for _, value := range values {
+		status, ok := parseDAGRunStatus(value)
+		if !ok {
+			return nil, fmt.Errorf("unknown status %q", value)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
+func parseDAGRunStatus(value string) (core.Status, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "not_started", "notstarted":
+		return core.NotStarted, true
+	case "running":
+		return core.Running, true
+	case "failed", "failure", "error":
+		return core.Failed, true
+	case "aborted", "cancelled", "canceled":
+		return core.Aborted, true
+	case "succeeded", "success":
+		return core.Succeeded, true
+	case "queued":
+		return core.Queued, true
+	case "partially_succeeded", "partial_success":
+		return core.PartiallySucceeded, true
+	case "waiting":
+		return core.Waiting, true
+	case "rejected":
+		return core.Rejected, true
+	default:
+		return core.NotStarted, false
+	}
+}
+
+func parseDAGManageRelativeTime(value string, now time.Time) (time.Time, error) {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return time.Time{}, fmt.Errorf("relative time is empty")
+	}
+	unit := value[len(value)-1]
+	rawNumber := strings.TrimSpace(value[:len(value)-1])
+	n, err := strconv.Atoi(rawNumber)
+	if err != nil || n <= 0 {
+		return time.Time{}, fmt.Errorf("invalid relative time %q", value)
+	}
+	var d time.Duration
+	switch unit {
+	case 'm':
+		d = time.Duration(n) * time.Minute
+	case 'h':
+		d = time.Duration(n) * time.Hour
+	case 'd':
+		d = time.Duration(n) * 24 * time.Hour
+	case 'w':
+		d = time.Duration(n) * 7 * 24 * time.Hour
+	default:
+		return time.Time{}, fmt.Errorf("invalid relative time unit %q in %q", string(unit), value)
+	}
+	return now.Add(-d), nil
+}
+
+func parseDAGManageAbsoluteTime(value string, endOfDay bool) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("time is empty")
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	t, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if endOfDay {
+		t = t.Add(24*time.Hour - time.Nanosecond)
+	}
+	return t, nil
+}
+
+func clampAgentLimit(value, defaultValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func splitDAGManageList(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ' '
+	})
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func dagManageJSON(v any) ToolOut {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return toolError("Failed to encode DAG management output: %v", err)
+	}
+	return ToolOut{Content: string(data)}
+}

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -284,6 +284,9 @@ func dagRunManageList(ctx context.Context, store exec.DAGRunStore, args dagRunMa
 		}
 		opts = append(opts, exec.WithStatuses(statuses))
 	}
+	if args.Last != "" && (args.From != "" || args.To != "") {
+		return toolError("cannot use --last with --from or --to (conflicting time range specifications)")
+	}
 	if args.Last != "" {
 		from, err := parseDAGManageRelativeTime(args.Last, time.Now())
 		if err != nil {

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -346,9 +346,15 @@ func dagRunManageReadLog(ctx context.Context, store exec.DAGRunStore, args dagRu
 	if !ok {
 		return out
 	}
+	if args.StepName != "" && strings.TrimSpace(args.Stream) == "" {
+		return toolError("stream is required when stepName is set; use stdout or stderr")
+	}
 	stream := normalizeDAGRunLogStream(args.Stream)
 	if stream == "" {
 		return toolError("stream is required and must be one of: scheduler, stdout, stderr")
+	}
+	if args.StepName != "" && stream == "scheduler" {
+		return toolError("scheduler logs do not use stepName; omit stepName or use stdout/stderr")
 	}
 	logPath, err := selectDAGRunManageLogPath(status, args.StepName, stream)
 	if err != nil {
@@ -376,14 +382,9 @@ func dagRunManageReadMessages(ctx context.Context, store exec.DAGRunStore, args 
 	if strings.TrimSpace(args.StepName) == "" {
 		return toolError("stepName is required for read_messages")
 	}
-	messages, err := attempt.ReadStepMessages(ctx, args.StepName)
+	messages, err := dagRunManageStepMessages(ctx, status, attempt, args.StepName)
 	if err != nil {
 		return toolError("Failed to read step messages: %v", err)
-	}
-	if len(messages) == 0 {
-		if node, err := status.NodeByName(args.StepName); err == nil {
-			messages = node.ChatMessages
-		}
 	}
 	return dagManageJSON(map[string]any{
 		"action":      "read_messages",
@@ -428,11 +429,7 @@ func dagRunManageDiagnose(ctx context.Context, store exec.DAGRunStore, args dagR
 		if primary.Stderr != "" {
 			logs["stderr"] = readDAGManageLogForDiagnose(primary.Stderr, logArgs)
 		}
-		var err error
-		messages, err = attempt.ReadStepMessages(ctx, primary.Step.Name)
-		if err == nil && len(messages) == 0 {
-			messages = primary.ChatMessages
-		}
+		messages, _ = dagRunManageStepMessages(ctx, status, attempt, primary.Step.Name)
 	}
 
 	primaryName := ""
@@ -500,6 +497,20 @@ func readDAGRunStatus(ctx context.Context, store exec.DAGRunStore, dagName, dagR
 		return nil, nil, fmt.Errorf("failed to read DAG run status: %w", err)
 	}
 	return status, attempt, nil
+}
+
+func dagRunManageStepMessages(ctx context.Context, status *exec.DAGRunStatus, attempt exec.DAGRunAttempt, stepName string) ([]exec.LLMMessage, error) {
+	messages, readErr := attempt.ReadStepMessages(ctx, stepName)
+	if readErr == nil && len(messages) > 0 {
+		return messages, nil
+	}
+	if node, err := status.NodeByName(stepName); err == nil && len(node.ChatMessages) > 0 {
+		return node.ChatMessages, nil
+	}
+	if readErr != nil {
+		return nil, readErr
+	}
+	return messages, nil
 }
 
 func dagRunManageStatusPayload(status *exec.DAGRunStatus, subDAGRunID string, includeRun bool) map[string]any {

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -355,9 +355,7 @@ func (r *dagRunWatchRegistry) complete(ctx context.Context, watchID string, stat
 	entry.info.LastCheckedAt = now
 	entry.info.CompletedAt = &now
 	entry.info.LastError = ""
-	if entry.cancel != nil {
-		entry.cancel()
-	}
+	cancel := entry.cancel
 	shouldNotify := r.notify != nil && dagRunWatchShouldNotify(entry.req, status) && !entry.info.Notified && !entry.notifying
 	if shouldNotify {
 		entry.notifying = true
@@ -367,6 +365,9 @@ func (r *dagRunWatchRegistry) complete(ctx context.Context, watchID string, stat
 	r.mu.Unlock()
 
 	if !shouldNotify {
+		if cancel != nil {
+			cancel()
+		}
 		return info, nil
 	}
 	if err := r.notify(ctx, req, info, status); err != nil {
@@ -377,6 +378,9 @@ func (r *dagRunWatchRegistry) complete(ctx context.Context, watchID string, stat
 			info = entry.info
 		}
 		r.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
 		return info, err
 	}
 
@@ -387,6 +391,9 @@ func (r *dagRunWatchRegistry) complete(ctx context.Context, watchID string, stat
 		info = entry.info
 	}
 	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	return info, nil
 }
 

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -85,7 +85,7 @@ type DAGRunWatchInfo struct {
 	Notified      bool             `json:"notified"`
 	CreatedAt     time.Time        `json:"createdAt"`
 	CompletedAt   *time.Time       `json:"completedAt,omitempty"`
-	LastCheckedAt time.Time        `json:"lastCheckedAt,omitempty"`
+	LastCheckedAt time.Time        `json:"lastCheckedAt"`
 	LastError     string           `json:"lastError,omitempty"`
 }
 

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -1,0 +1,632 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/llm"
+	"github.com/google/uuid"
+)
+
+const (
+	defaultDAGRunWatchPollInterval  = 5 * time.Second
+	defaultDAGRunWatchRetention     = 24 * time.Hour
+	defaultDAGRunWatchMaxDuration   = 7 * 24 * time.Hour
+	defaultDAGRunWatchMaxTotal      = 1024
+	defaultDAGRunWatchMaxPerSession = 64
+)
+
+// DAGRunWatchState is the lifecycle state of an agent-side DAG run watch.
+type DAGRunWatchState string
+
+const (
+	DAGRunWatchStateRunning   DAGRunWatchState = "running"
+	DAGRunWatchStateCompleted DAGRunWatchState = "completed"
+	DAGRunWatchStateCanceled  DAGRunWatchState = "canceled"
+	DAGRunWatchStateExpired   DAGRunWatchState = "expired"
+)
+
+// DAGRunWatcher registers lightweight, session-local watches for DAG runs.
+// Watch registrations are intentionally in-memory; delivered notifications are
+// persisted as normal session messages by the API layer.
+type DAGRunWatcher interface {
+	Watch(ctx context.Context, req DAGRunWatchRequest) (DAGRunWatchInfo, error)
+	Status(ctx context.Context, req DAGRunWatchStatusRequest) (DAGRunWatchInfo, error)
+	Cancel(ctx context.Context, req DAGRunWatchCancelRequest) (DAGRunWatchInfo, error)
+}
+
+// DAGRunWatchRequest describes a new run watch.
+type DAGRunWatchRequest struct {
+	SessionID         string
+	User              UserIdentity
+	DAGName           string
+	DAGRunID          string
+	SubDAGRunID       string
+	NotifyOn          []string
+	DiagnoseOnFailure bool
+}
+
+// DAGRunWatchStatusRequest identifies an existing watch.
+type DAGRunWatchStatusRequest struct {
+	SessionID   string
+	WatchID     string
+	DAGName     string
+	DAGRunID    string
+	SubDAGRunID string
+}
+
+// DAGRunWatchCancelRequest identifies a watch to cancel.
+type DAGRunWatchCancelRequest struct {
+	SessionID   string
+	WatchID     string
+	DAGName     string
+	DAGRunID    string
+	SubDAGRunID string
+}
+
+// DAGRunWatchInfo is returned to tools and stored by the registry.
+type DAGRunWatchInfo struct {
+	WatchID       string           `json:"watchId"`
+	DAGName       string           `json:"dagName"`
+	DAGRunID      string           `json:"dagRunId"`
+	SubDAGRunID   string           `json:"subDAGRunId,omitempty"`
+	State         DAGRunWatchState `json:"state"`
+	Status        string           `json:"status,omitempty"`
+	Notified      bool             `json:"notified"`
+	CreatedAt     time.Time        `json:"createdAt"`
+	CompletedAt   *time.Time       `json:"completedAt,omitempty"`
+	LastCheckedAt time.Time        `json:"lastCheckedAt,omitempty"`
+	LastError     string           `json:"lastError,omitempty"`
+}
+
+type dagRunWatchNotifyFunc func(context.Context, DAGRunWatchRequest, DAGRunWatchInfo, *exec.DAGRunStatus) error
+
+type dagRunWatchRegistry struct {
+	store         exec.DAGRunStore
+	notify        dagRunWatchNotifyFunc
+	logger        *slog.Logger
+	pollInterval  time.Duration
+	retention     time.Duration
+	maxDuration   time.Duration
+	maxTotal      int
+	maxPerSession int
+
+	mu      sync.Mutex
+	watches map[string]*dagRunWatchEntry
+	byRun   map[string]string
+}
+
+type dagRunWatchEntry struct {
+	req       DAGRunWatchRequest
+	info      DAGRunWatchInfo
+	cancel    context.CancelFunc
+	notifying bool
+}
+
+type dagRunWatchRegistryOption func(*dagRunWatchRegistry)
+
+func withDAGRunWatchPollInterval(interval time.Duration) dagRunWatchRegistryOption {
+	return func(r *dagRunWatchRegistry) {
+		r.pollInterval = interval
+	}
+}
+
+func withDAGRunWatchMaxDuration(maxDuration time.Duration) dagRunWatchRegistryOption {
+	return func(r *dagRunWatchRegistry) {
+		r.maxDuration = maxDuration
+	}
+}
+
+func newDAGRunWatchRegistry(store exec.DAGRunStore, notify dagRunWatchNotifyFunc, logger *slog.Logger, opts ...dagRunWatchRegistryOption) *dagRunWatchRegistry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	r := &dagRunWatchRegistry{
+		store:         store,
+		notify:        notify,
+		logger:        logger,
+		pollInterval:  defaultDAGRunWatchPollInterval,
+		retention:     defaultDAGRunWatchRetention,
+		maxDuration:   defaultDAGRunWatchMaxDuration,
+		maxTotal:      defaultDAGRunWatchMaxTotal,
+		maxPerSession: defaultDAGRunWatchMaxPerSession,
+		watches:       map[string]*dagRunWatchEntry{},
+		byRun:         map[string]string{},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	if r.pollInterval <= 0 {
+		r.pollInterval = defaultDAGRunWatchPollInterval
+	}
+	if r.retention <= 0 {
+		r.retention = defaultDAGRunWatchRetention
+	}
+	if r.maxDuration <= 0 {
+		r.maxDuration = defaultDAGRunWatchMaxDuration
+	}
+	return r
+}
+
+func (r *dagRunWatchRegistry) Watch(ctx context.Context, req DAGRunWatchRequest) (DAGRunWatchInfo, error) {
+	if r == nil || r.store == nil {
+		return DAGRunWatchInfo{}, errors.New("dag-run watcher is not configured")
+	}
+	req = normalizeDAGRunWatchRequest(req)
+	if err := validateDAGRunWatchRequest(req); err != nil {
+		return DAGRunWatchInfo{}, err
+	}
+
+	key := dagRunWatchKey(req.SessionID, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+	r.mu.Lock()
+	r.pruneLocked(time.Now())
+	if watchID := r.byRun[key]; watchID != "" {
+		info := r.watches[watchID].info
+		r.mu.Unlock()
+		return info, nil
+	}
+	if r.maxTotal > 0 && r.runningWatchCountLocked("") >= r.maxTotal {
+		r.mu.Unlock()
+		return DAGRunWatchInfo{}, fmt.Errorf("too many active DAG run watches: limit is %d", r.maxTotal)
+	}
+	if r.maxPerSession > 0 && r.runningWatchCountLocked(req.SessionID) >= r.maxPerSession {
+		r.mu.Unlock()
+		return DAGRunWatchInfo{}, fmt.Errorf("too many active DAG run watches for this session: limit is %d", r.maxPerSession)
+	}
+	r.mu.Unlock()
+
+	status, err := r.readStatus(ctx, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+	if err != nil {
+		return DAGRunWatchInfo{}, err
+	}
+
+	now := time.Now()
+	watchCtx, cancel := context.WithCancel(context.Background())
+	state := DAGRunWatchStateRunning
+	if isDAGRunWatchTerminal(status) {
+		state = DAGRunWatchStateCompleted
+	}
+	info := DAGRunWatchInfo{
+		WatchID:       uuid.NewString(),
+		DAGName:       req.DAGName,
+		DAGRunID:      req.DAGRunID,
+		SubDAGRunID:   req.SubDAGRunID,
+		State:         state,
+		Status:        status.Status.String(),
+		CreatedAt:     now,
+		LastCheckedAt: now,
+	}
+	entry := &dagRunWatchEntry{req: req, info: info, cancel: cancel}
+
+	r.mu.Lock()
+	if watchID := r.byRun[key]; watchID != "" {
+		cancel()
+		info := r.watches[watchID].info
+		r.mu.Unlock()
+		return info, nil
+	}
+	r.watches[info.WatchID] = entry
+	r.byRun[key] = info.WatchID
+	r.mu.Unlock()
+
+	if isDAGRunWatchTerminal(status) {
+		cancel()
+		return r.complete(ctx, info.WatchID, status)
+	}
+
+	go r.poll(watchCtx, info.WatchID)
+	return info, nil
+}
+
+func (r *dagRunWatchRegistry) Status(ctx context.Context, req DAGRunWatchStatusRequest) (DAGRunWatchInfo, error) {
+	if r == nil || r.store == nil {
+		return DAGRunWatchInfo{}, errors.New("dag-run watcher is not configured")
+	}
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	if req.SessionID == "" {
+		return DAGRunWatchInfo{}, errors.New("sessionId is required")
+	}
+	watchID, entry, err := r.findWatch(req.SessionID, req.WatchID, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+	if err != nil {
+		return DAGRunWatchInfo{}, err
+	}
+	if entry.info.State != DAGRunWatchStateRunning {
+		return entry.info, nil
+	}
+	if info, expired := r.expireIfOverdue(watchID, time.Now()); expired {
+		return info, nil
+	}
+
+	status, readErr := r.readStatus(ctx, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID)
+	if readErr != nil {
+		return r.markWatchError(watchID, readErr.Error()), nil
+	}
+	if isDAGRunWatchTerminal(status) {
+		return r.complete(ctx, watchID, status)
+	}
+	return r.updateWatchStatus(watchID, status), nil
+}
+
+func (r *dagRunWatchRegistry) Cancel(_ context.Context, req DAGRunWatchCancelRequest) (DAGRunWatchInfo, error) {
+	if r == nil {
+		return DAGRunWatchInfo{}, errors.New("dag-run watcher is not configured")
+	}
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	if req.SessionID == "" {
+		return DAGRunWatchInfo{}, errors.New("sessionId is required")
+	}
+	watchID, _, err := r.findWatch(req.SessionID, req.WatchID, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+	if err != nil {
+		return DAGRunWatchInfo{}, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.watches[watchID]
+	if entry == nil {
+		return DAGRunWatchInfo{}, errors.New("watch not found")
+	}
+	if entry.info.State != DAGRunWatchStateRunning {
+		return entry.info, nil
+	}
+	if entry.cancel != nil {
+		entry.cancel()
+	}
+	now := time.Now()
+	entry.info.State = DAGRunWatchStateCanceled
+	entry.info.CompletedAt = &now
+	delete(r.byRun, dagRunWatchKey(entry.req.SessionID, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID))
+	return entry.info, nil
+}
+
+func (r *dagRunWatchRegistry) poll(ctx context.Context, watchID string) {
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		r.mu.Lock()
+		entry := r.watches[watchID]
+		if entry == nil || entry.info.State != DAGRunWatchStateRunning {
+			r.mu.Unlock()
+			return
+		}
+		req := entry.req
+		r.mu.Unlock()
+		if _, expired := r.expireIfOverdue(watchID, time.Now()); expired {
+			return
+		}
+
+		status, err := r.readStatus(context.Background(), req.DAGName, req.DAGRunID, req.SubDAGRunID)
+		if err != nil {
+			r.markWatchError(watchID, err.Error())
+			r.logger.Debug("failed to refresh DAG run watch", "watch_id", watchID, "dag", req.DAGName, "run_id", req.DAGRunID, "error", err)
+			continue
+		}
+		if isDAGRunWatchTerminal(status) {
+			if _, err := r.complete(context.Background(), watchID, status); err != nil {
+				r.logger.Warn("failed to notify DAG run watch", "watch_id", watchID, "dag", req.DAGName, "run_id", req.DAGRunID, "error", err)
+			}
+			return
+		}
+		r.updateWatchStatus(watchID, status)
+	}
+}
+
+func (r *dagRunWatchRegistry) complete(ctx context.Context, watchID string, status *exec.DAGRunStatus) (DAGRunWatchInfo, error) {
+	now := time.Now()
+	r.mu.Lock()
+	entry := r.watches[watchID]
+	if entry == nil {
+		r.mu.Unlock()
+		return DAGRunWatchInfo{}, errors.New("watch not found")
+	}
+	if entry.info.State == DAGRunWatchStateCanceled {
+		info := entry.info
+		r.mu.Unlock()
+		return info, nil
+	}
+	entry.info.State = DAGRunWatchStateCompleted
+	entry.info.Status = status.Status.String()
+	entry.info.LastCheckedAt = now
+	entry.info.CompletedAt = &now
+	entry.info.LastError = ""
+	if entry.cancel != nil {
+		entry.cancel()
+	}
+	shouldNotify := r.notify != nil && dagRunWatchShouldNotify(entry.req, status) && !entry.info.Notified && !entry.notifying
+	if shouldNotify {
+		entry.notifying = true
+	}
+	req := entry.req
+	info := entry.info
+	r.mu.Unlock()
+
+	if !shouldNotify {
+		return info, nil
+	}
+	if err := r.notify(ctx, req, info, status); err != nil {
+		r.mu.Lock()
+		if entry := r.watches[watchID]; entry != nil {
+			entry.info.LastError = "notification failed: " + err.Error()
+			entry.notifying = false
+			info = entry.info
+		}
+		r.mu.Unlock()
+		return info, err
+	}
+
+	r.mu.Lock()
+	if entry := r.watches[watchID]; entry != nil {
+		entry.info.Notified = true
+		entry.notifying = false
+		info = entry.info
+	}
+	r.mu.Unlock()
+	return info, nil
+}
+
+func (r *dagRunWatchRegistry) findWatch(sessionID, watchID, dagName, dagRunID, subDAGRunID string) (string, *dagRunWatchEntry, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	watchID = strings.TrimSpace(watchID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if watchID == "" {
+		dagName = strings.TrimSpace(dagName)
+		dagRunID = strings.TrimSpace(dagRunID)
+		subDAGRunID = strings.TrimSpace(subDAGRunID)
+		if dagName == "" || dagRunID == "" {
+			return "", nil, errors.New("watchId or dagName/dagRunId is required")
+		}
+		watchID = r.byRun[dagRunWatchKey(sessionID, dagName, dagRunID, subDAGRunID)]
+	}
+	entry := r.watches[watchID]
+	if entry == nil || entry.req.SessionID != sessionID {
+		return "", nil, errors.New("watch not found")
+	}
+	copied := *entry
+	return watchID, &copied, nil
+}
+
+func (r *dagRunWatchRegistry) readStatus(ctx context.Context, dagName, dagRunID, subDAGRunID string) (*exec.DAGRunStatus, error) {
+	if r.store == nil {
+		return nil, errors.New("dag-run store is not configured")
+	}
+	root := exec.NewDAGRunRef(dagName, dagRunID)
+	var (
+		attempt exec.DAGRunAttempt
+		err     error
+	)
+	if subDAGRunID != "" {
+		attempt, err = r.store.FindSubAttempt(ctx, root, subDAGRunID)
+	} else {
+		attempt, err = r.store.FindAttempt(ctx, root)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find DAG run: %w", err)
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read DAG run status: %w", err)
+	}
+	return status, nil
+}
+
+func (r *dagRunWatchRegistry) updateWatchStatus(watchID string, status *exec.DAGRunStatus) DAGRunWatchInfo {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.watches[watchID]
+	if entry == nil {
+		return DAGRunWatchInfo{}
+	}
+	entry.info.Status = status.Status.String()
+	entry.info.LastCheckedAt = time.Now()
+	entry.info.LastError = ""
+	return entry.info
+}
+
+func (r *dagRunWatchRegistry) markWatchError(watchID, message string) DAGRunWatchInfo {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.watches[watchID]
+	if entry == nil {
+		return DAGRunWatchInfo{}
+	}
+	entry.info.LastCheckedAt = time.Now()
+	entry.info.LastError = message
+	return entry.info
+}
+
+func (r *dagRunWatchRegistry) expireIfOverdue(watchID string, now time.Time) (DAGRunWatchInfo, bool) {
+	if r.maxDuration <= 0 {
+		return DAGRunWatchInfo{}, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry := r.watches[watchID]
+	if entry == nil || entry.info.State != DAGRunWatchStateRunning {
+		if entry == nil {
+			return DAGRunWatchInfo{}, false
+		}
+		return entry.info, false
+	}
+	if now.Sub(entry.info.CreatedAt) <= r.maxDuration {
+		return entry.info, false
+	}
+	if entry.cancel != nil {
+		entry.cancel()
+	}
+	entry.info.State = DAGRunWatchStateExpired
+	entry.info.CompletedAt = &now
+	entry.info.LastCheckedAt = now
+	entry.info.LastError = fmt.Sprintf("watch expired after %s", r.maxDuration)
+	delete(r.byRun, dagRunWatchKey(entry.req.SessionID, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID))
+	return entry.info, true
+}
+
+func (r *dagRunWatchRegistry) pruneLocked(now time.Time) {
+	if r.retention <= 0 {
+		return
+	}
+	for watchID, entry := range r.watches {
+		if entry == nil || entry.info.CompletedAt == nil {
+			continue
+		}
+		if now.Sub(*entry.info.CompletedAt) <= r.retention {
+			continue
+		}
+		if entry.cancel != nil {
+			entry.cancel()
+		}
+		delete(r.watches, watchID)
+		delete(r.byRun, dagRunWatchKey(entry.req.SessionID, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID))
+	}
+}
+
+func (r *dagRunWatchRegistry) runningWatchCountLocked(sessionID string) int {
+	count := 0
+	for _, entry := range r.watches {
+		if entry == nil || entry.info.State != DAGRunWatchStateRunning {
+			continue
+		}
+		if sessionID != "" && entry.req.SessionID != sessionID {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func normalizeDAGRunWatchRequest(req DAGRunWatchRequest) DAGRunWatchRequest {
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	req.DAGName = strings.TrimSpace(req.DAGName)
+	req.DAGRunID = strings.TrimSpace(req.DAGRunID)
+	req.SubDAGRunID = strings.TrimSpace(req.SubDAGRunID)
+	req.NotifyOn = normalizeDAGRunWatchNotifyOn(req.NotifyOn)
+	return req
+}
+
+func validateDAGRunWatchRequest(req DAGRunWatchRequest) error {
+	if req.SessionID == "" {
+		return errors.New("sessionId is required")
+	}
+	if req.DAGName == "" {
+		return errors.New("dagName is required")
+	}
+	if req.DAGRunID == "" {
+		return errors.New("dagRunId is required")
+	}
+	return nil
+}
+
+func normalizeDAGRunWatchNotifyOn(values []string) []string {
+	if len(values) == 0 {
+		return []string{"terminal"}
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		switch value {
+		case "", "terminal", "complete", "completion", "finished", "finish":
+			out = append(out, "terminal")
+		case "failure", "failed", "error":
+			out = append(out, "failure")
+		case "success", "succeeded":
+			out = append(out, "success")
+		}
+	}
+	if len(out) == 0 {
+		return []string{"terminal"}
+	}
+	return out
+}
+
+func dagRunWatchShouldNotify(req DAGRunWatchRequest, status *exec.DAGRunStatus) bool {
+	if status == nil {
+		return false
+	}
+	for _, value := range normalizeDAGRunWatchNotifyOn(req.NotifyOn) {
+		switch value {
+		case "terminal":
+			return true
+		case "failure":
+			if !status.Status.IsSuccess() {
+				return true
+			}
+		case "success":
+			if status.Status.IsSuccess() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isDAGRunWatchTerminal(status *exec.DAGRunStatus) bool {
+	if status == nil {
+		return false
+	}
+	return status.Status != core.NotStarted && !status.Status.IsActive()
+}
+
+func dagRunWatchKey(sessionID, dagName, dagRunID, subDAGRunID string) string {
+	return strings.Join([]string{sessionID, dagName, dagRunID, subDAGRunID}, "\x00")
+}
+
+func formatDAGRunWatchNotification(req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) string {
+	target := req.DAGName + "/" + req.DAGRunID
+	if req.SubDAGRunID != "" {
+		target += " (subDAGRunId: " + req.SubDAGRunID + ")"
+	}
+	statusText := info.Status
+	if statusText == "" && status != nil {
+		statusText = status.Status.String()
+	}
+	lines := []string{
+		"DAG run finished: " + target,
+		"Status: " + statusText,
+		"Watch ID: " + info.WatchID,
+	}
+	if status != nil && status.Error != "" {
+		lines = append(lines, "Error: "+status.Error)
+	}
+	if req.DiagnoseOnFailure && status != nil && !status.Status.IsSuccess() {
+		if node := firstFailedDAGRunNode(status); node != nil {
+			stepLine := fmt.Sprintf("Primary failed step: %s (%s)", node.Step.Name, node.Status.String())
+			lines = append(lines, stepLine)
+			if node.Error != "" {
+				lines = append(lines, "Step error: "+node.Error)
+			}
+		}
+	}
+	lines = append(lines, "Use `dag_run_manage` with action `get`, `diagnose`, `read_log`, or `read_messages` for details.")
+	return strings.Join(lines, "\n")
+}
+
+func (a *API) notifyDAGRunWatch(ctx context.Context, req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) error {
+	content := formatDAGRunWatchNotification(req, info, status)
+	llmMsg := llm.Message{Role: llm.RoleAssistant, Content: content}
+	_, err := a.AppendExternalMessage(ctx, req.SessionID, req.User, Message{
+		Type:      MessageTypeAssistant,
+		Content:   content,
+		CreatedAt: time.Now(),
+		LLMData:   &llmMsg,
+	})
+	return err
+}

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -22,6 +22,7 @@ const (
 	defaultDAGRunWatchPollInterval  = 5 * time.Second
 	defaultDAGRunWatchRetention     = 24 * time.Hour
 	defaultDAGRunWatchMaxDuration   = 7 * 24 * time.Hour
+	defaultDAGRunWatchPollTimeout   = 30 * time.Second
 	defaultDAGRunWatchMaxTotal      = 1024
 	defaultDAGRunWatchMaxPerSession = 64
 )
@@ -43,6 +44,10 @@ type DAGRunWatcher interface {
 	Watch(ctx context.Context, req DAGRunWatchRequest) (DAGRunWatchInfo, error)
 	Status(ctx context.Context, req DAGRunWatchStatusRequest) (DAGRunWatchInfo, error)
 	Cancel(ctx context.Context, req DAGRunWatchCancelRequest) (DAGRunWatchInfo, error)
+}
+
+type DAGRunWatchCleaner interface {
+	ClearSession(sessionID string) int
 }
 
 // DAGRunWatchRequest describes a new run watch.
@@ -312,16 +317,20 @@ func (r *dagRunWatchRegistry) poll(ctx context.Context, watchID string) {
 			return
 		}
 
-		status, err := r.readStatus(context.Background(), req.DAGName, req.DAGRunID, req.SubDAGRunID)
+		statusCtx, cancelStatus := context.WithTimeout(ctx, r.pollTimeout())
+		status, err := r.readStatus(statusCtx, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+		cancelStatus()
 		if err != nil {
 			r.markWatchError(watchID, err.Error())
 			r.logger.Debug("failed to refresh DAG run watch", "watch_id", watchID, "dag", req.DAGName, "run_id", req.DAGRunID, "error", err)
 			continue
 		}
 		if isDAGRunWatchTerminal(status) {
-			if _, err := r.complete(context.Background(), watchID, status); err != nil {
+			notifyCtx, cancelNotify := context.WithTimeout(ctx, r.pollTimeout())
+			if _, err := r.complete(notifyCtx, watchID, status); err != nil {
 				r.logger.Warn("failed to notify DAG run watch", "watch_id", watchID, "dag", req.DAGName, "run_id", req.DAGRunID, "error", err)
 			}
+			cancelNotify()
 			return
 		}
 		r.updateWatchStatus(watchID, status)
@@ -453,6 +462,28 @@ func (r *dagRunWatchRegistry) markWatchError(watchID, message string) DAGRunWatc
 	return entry.info
 }
 
+func (r *dagRunWatchRegistry) ClearSession(sessionID string) int {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	removed := 0
+	for watchID, entry := range r.watches {
+		if entry == nil || entry.req.SessionID != sessionID {
+			continue
+		}
+		if entry.cancel != nil {
+			entry.cancel()
+		}
+		delete(r.watches, watchID)
+		delete(r.byRun, dagRunWatchKey(entry.req.SessionID, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID))
+		removed++
+	}
+	return removed
+}
+
 func (r *dagRunWatchRegistry) expireIfOverdue(watchID string, now time.Time) (DAGRunWatchInfo, bool) {
 	if r.maxDuration <= 0 {
 		return DAGRunWatchInfo{}, false
@@ -511,6 +542,13 @@ func (r *dagRunWatchRegistry) runningWatchCountLocked(sessionID string) int {
 		count++
 	}
 	return count
+}
+
+func (r *dagRunWatchRegistry) pollTimeout() time.Duration {
+	if r.pollInterval > defaultDAGRunWatchPollTimeout {
+		return r.pollInterval
+	}
+	return defaultDAGRunWatchPollTimeout
 }
 
 func normalizeDAGRunWatchRequest(req DAGRunWatchRequest) DAGRunWatchRequest {

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/llm"
 	"github.com/google/uuid"
 )
 
@@ -610,44 +609,42 @@ func dagRunWatchKey(sessionID, dagName, dagRunID, subDAGRunID string) string {
 	return strings.Join([]string{sessionID, dagName, dagRunID, subDAGRunID}, "\x00")
 }
 
-func formatDAGRunWatchNotification(req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) string {
-	target := req.DAGName + "/" + req.DAGRunID
-	if req.SubDAGRunID != "" {
-		target += " (subDAGRunId: " + req.SubDAGRunID + ")"
-	}
+func formatDAGRunWatchAgentEvent(req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) string {
 	statusText := info.Status
 	if statusText == "" && status != nil {
 		statusText = status.Status.String()
 	}
+
 	lines := []string{
-		"DAG run finished: " + target,
+		"A watched DAG run finished.",
+		"",
+		"DAG: " + req.DAGName,
+		"Run ID: " + req.DAGRunID,
 		"Status: " + statusText,
 		"Watch ID: " + info.WatchID,
+	}
+	if req.SubDAGRunID != "" {
+		lines = append(lines, "Sub DAG Run ID: "+req.SubDAGRunID)
 	}
 	if status != nil && status.Error != "" {
 		lines = append(lines, "Error: "+status.Error)
 	}
 	if req.DiagnoseOnFailure && status != nil && !status.Status.IsSuccess() {
 		if node := firstFailedDAGRunNode(status); node != nil {
-			stepLine := fmt.Sprintf("Primary failed step: %s (%s)", node.Step.Name, node.Status.String())
-			lines = append(lines, stepLine)
+			lines = append(lines, fmt.Sprintf("Primary failed step: %s (%s)", node.Step.Name, node.Status.String()))
 			if node.Error != "" {
 				lines = append(lines, "Step error: "+node.Error)
 			}
 		}
 	}
-	lines = append(lines, "Use `dag_run_manage` with action `get`, `diagnose`, `read_log`, or `read_messages` for details.")
+	lines = append(lines,
+		"",
+		"This is an internal background event, not a user message. Do not quote it verbatim.",
+		"Continue the user's task. Use dag_run_manage get, diagnose, read_log, or read_messages only when details are needed.",
+	)
 	return strings.Join(lines, "\n")
 }
 
 func (a *API) notifyDAGRunWatch(ctx context.Context, req DAGRunWatchRequest, info DAGRunWatchInfo, status *exec.DAGRunStatus) error {
-	content := formatDAGRunWatchNotification(req, info, status)
-	llmMsg := llm.Message{Role: llm.RoleAssistant, Content: content}
-	_, err := a.AppendExternalMessage(ctx, req.SessionID, req.User, Message{
-		Type:      MessageTypeAssistant,
-		Content:   content,
-		CreatedAt: time.Now(),
-		LLMData:   &llmMsg,
-	})
-	return err
+	return a.enqueueInternalAgentMessage(ctx, req.SessionID, req.User, formatDAGRunWatchAgentEvent(req, info, status))
 }

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -190,7 +190,7 @@ func (r *dagRunWatchRegistry) Watch(ctx context.Context, req DAGRunWatchRequest)
 	}
 	r.mu.Unlock()
 
-	status, err := r.readStatus(ctx, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+	status, _, err := readDAGRunStatus(ctx, r.store, req.DAGName, req.DAGRunID, req.SubDAGRunID)
 	if err != nil {
 		return DAGRunWatchInfo{}, err
 	}
@@ -252,7 +252,7 @@ func (r *dagRunWatchRegistry) Status(ctx context.Context, req DAGRunWatchStatusR
 		return info, nil
 	}
 
-	status, readErr := r.readStatus(ctx, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID)
+	status, _, readErr := readDAGRunStatus(ctx, r.store, entry.req.DAGName, entry.req.DAGRunID, entry.req.SubDAGRunID)
 	if readErr != nil {
 		return r.markWatchError(watchID, readErr.Error()), nil
 	}
@@ -318,7 +318,7 @@ func (r *dagRunWatchRegistry) poll(ctx context.Context, watchID string) {
 		}
 
 		statusCtx, cancelStatus := context.WithTimeout(ctx, r.pollTimeout())
-		status, err := r.readStatus(statusCtx, req.DAGName, req.DAGRunID, req.SubDAGRunID)
+		status, _, err := readDAGRunStatus(statusCtx, r.store, req.DAGName, req.DAGRunID, req.SubDAGRunID)
 		cancelStatus()
 		if err != nil {
 			r.markWatchError(watchID, err.Error())
@@ -411,30 +411,6 @@ func (r *dagRunWatchRegistry) findWatch(sessionID, watchID, dagName, dagRunID, s
 	}
 	copied := *entry
 	return watchID, &copied, nil
-}
-
-func (r *dagRunWatchRegistry) readStatus(ctx context.Context, dagName, dagRunID, subDAGRunID string) (*exec.DAGRunStatus, error) {
-	if r.store == nil {
-		return nil, errors.New("dag-run store is not configured")
-	}
-	root := exec.NewDAGRunRef(dagName, dagRunID)
-	var (
-		attempt exec.DAGRunAttempt
-		err     error
-	)
-	if subDAGRunID != "" {
-		attempt, err = r.store.FindSubAttempt(ctx, root, subDAGRunID)
-	} else {
-		attempt, err = r.store.FindAttempt(ctx, root)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to find DAG run: %w", err)
-	}
-	status, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read DAG run status: %w", err)
-	}
-	return status, nil
 }
 
 func (r *dagRunWatchRegistry) updateWatchStatus(watchID string, status *exec.DAGRunStatus) DAGRunWatchInfo {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/llm"
 	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
@@ -58,6 +59,9 @@ type SessionManager struct {
 	memoryStore           MemoryStore
 	docStore              DocStore
 	workspaceStore        workspacepkg.Store
+	dagDefinitionStore    exec.DAGStore
+	dagRunStore           exec.DAGRunStore
+	dagRunWatcher         DAGRunWatcher
 	dagName               string
 	sessionStore          SessionStore
 	parentSessionID       string
@@ -105,8 +109,14 @@ type SessionManagerConfig struct {
 	MemoryStore     MemoryStore
 	DocStore        DocStore
 	WorkspaceStore  workspacepkg.Store
-	DAGName         string
-	SessionStore    SessionStore
+	// DAGDefinitionStore provides DAG definitions for dag_def_manage.
+	DAGDefinitionStore exec.DAGStore
+	// DAGRunStore provides DAG run history for dag_run_manage.
+	DAGRunStore exec.DAGRunStore
+	// DAGRunWatcher provides session-local run watches for dag_run_manage.
+	DAGRunWatcher DAGRunWatcher
+	DAGName       string
+	SessionStore  SessionStore
 	// ParentSessionID links this session to its parent (non-empty = sub-session).
 	ParentSessionID string
 	// DelegateTask is the task description given to the sub-agent.
@@ -198,6 +208,9 @@ func NewSessionManager(cfg SessionManagerConfig) *SessionManager {
 		memoryStore:           cfg.MemoryStore,
 		docStore:              cfg.DocStore,
 		workspaceStore:        cfg.WorkspaceStore,
+		dagDefinitionStore:    cfg.DAGDefinitionStore,
+		dagRunStore:           cfg.DAGRunStore,
+		dagRunWatcher:         cfg.DAGRunWatcher,
 		dagName:               cfg.DAGName,
 		sessionStore:          cfg.SessionStore,
 		parentSessionID:       cfg.ParentSessionID,
@@ -827,6 +840,9 @@ func (sm *SessionManager) createLoop(provider llm.Provider, model string, histor
 		History:  history,
 		Tools: CreateTools(ToolConfig{
 			DAGsDir:               sm.environment.DAGsDir,
+			DAGStore:              sm.dagDefinitionStore,
+			DAGRunStore:           sm.dagRunStore,
+			DAGRunWatcher:         sm.dagRunWatcher,
 			DocStore:              sm.docStore,
 			WorkspaceStore:        sm.workspaceStore,
 			RemoteContextResolver: sm.remoteContextResolver,

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -614,6 +614,31 @@ func (sm *SessionManager) enqueueImmediateUserMessage(ctx context.Context, conte
 	return nil
 }
 
+func (sm *SessionManager) enqueueInternalUserMessage(provider llm.Provider, modelID string, resolvedModel string, content string) error {
+	if provider == nil {
+		return errors.New("LLM provider is required")
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return errors.New("message is required")
+	}
+	if err := sm.ensureLoop(provider, modelID, resolvedModel); err != nil {
+		return err
+	}
+
+	llmMsg := llm.Message{Role: llm.RoleUser, Content: content}
+	sm.mu.Lock()
+	sm.bumpLastActivityLocked(time.Now())
+	loop := sm.loop
+	sm.mu.Unlock()
+	if loop == nil {
+		return errors.New("session loop not initialized")
+	}
+	sm.SetWorking(true)
+	loop.QueueUserMessage(llmMsg)
+	return nil
+}
+
 // EnqueueChatMessage accepts bot text for a session. When the agent is already
 // working, the text is merged into a single queued follow-up and marked as a
 // safe-boundary interrupt instead of immediately entering LLM history.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -59,7 +59,7 @@ type SessionManager struct {
 	memoryStore           MemoryStore
 	docStore              DocStore
 	workspaceStore        workspacepkg.Store
-	dagDefinitionStore    exec.DAGStore
+	dagStore              exec.DAGStore
 	dagRunStore           exec.DAGRunStore
 	dagRunWatcher         DAGRunWatcher
 	dagName               string
@@ -109,8 +109,8 @@ type SessionManagerConfig struct {
 	MemoryStore     MemoryStore
 	DocStore        DocStore
 	WorkspaceStore  workspacepkg.Store
-	// DAGDefinitionStore provides DAG definitions for dag_def_manage.
-	DAGDefinitionStore exec.DAGStore
+	// DAGStore provides DAG metadata and definitions for DAG management tools.
+	DAGStore exec.DAGStore
 	// DAGRunStore provides DAG run history for dag_run_manage.
 	DAGRunStore exec.DAGRunStore
 	// DAGRunWatcher provides session-local run watches for dag_run_manage.
@@ -208,7 +208,7 @@ func NewSessionManager(cfg SessionManagerConfig) *SessionManager {
 		memoryStore:           cfg.MemoryStore,
 		docStore:              cfg.DocStore,
 		workspaceStore:        cfg.WorkspaceStore,
-		dagDefinitionStore:    cfg.DAGDefinitionStore,
+		dagStore:              cfg.DAGStore,
 		dagRunStore:           cfg.DAGRunStore,
 		dagRunWatcher:         cfg.DAGRunWatcher,
 		dagName:               cfg.DAGName,
@@ -840,7 +840,7 @@ func (sm *SessionManager) createLoop(provider llm.Provider, model string, histor
 		History:  history,
 		Tools: CreateTools(ToolConfig{
 			DAGsDir:               sm.environment.DAGsDir,
-			DAGStore:              sm.dagDefinitionStore,
+			DAGStore:              sm.dagStore,
 			DAGRunStore:           sm.dagRunStore,
 			DAGRunWatcher:         sm.dagRunWatcher,
 			DocStore:              sm.docStore,

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -6,8 +6,6 @@ package agent
 import (
 	"context"
 	"errors"
-
-	"github.com/dagucloud/dagu/internal/core"
 )
 
 // Sentinel errors for session store operations.
@@ -64,11 +62,6 @@ type MemoryStore interface {
 
 	// DeleteDAGMemory removes a DAG-specific MEMORY.md file.
 	DeleteDAGMemory(ctx context.Context, dagName string) error
-}
-
-// DAGMetadataStore resolves DAG metadata used by the agent API.
-type DAGMetadataStore interface {
-	GetMetadata(ctx context.Context, fileName string) (*core.DAG, error)
 }
 
 // SessionStore defines the interface for session persistence.

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -234,6 +234,8 @@ Actively report your progress during multi-step work so the user is not left wai
 - `navigate`: Open a UI page (/dags/<name>, /dag-runs/<name>/<id>, /docs, /docs/<doc-id>).
 - `delegate`: Spawn a sub-agent for a focused sub-task. The sub-agent works independently with the same tools and returns a summary. Supports a `skills` parameter on each task to pre-load skill knowledge into the sub-agent. You can delegate multiple tasks simultaneously.
 - `runbook_manage`: List/search/get/create/update/patch Markdown runbooks in the docs store. Use it before complex tasks and to keep runbooks current.
+- `dag_def_manage`: List/get/validate DAG definitions and inspect DAG YAML schema. Prefer it over shelling out for DAG definition inspection when available.
+- `dag_run_manage`: List/get DAG runs, watch an enqueued run, read scheduler/step logs, read chat/agent step messages, and diagnose failures. Prefer it over shelling out for run history and logs when available.
 - `search_skills`: Discover available skills by keyword or label. Returns summaries without loading full knowledge.
 </tools>
 
@@ -251,38 +253,40 @@ maps to {{.DocsDir}}/runbooks/deployment.md). Runbooks may include YAML frontmat
 
 <workflows>
 ### Creating a New DAG
-1. Use `dagu schema dag` to confirm available fields.
+1. Use `dag_def_manage` with action `schema` to confirm available fields, or `dagu schema dag` via bash if the tool is unavailable.
 2. Verify configuration requirements (secrets/env/services) are available.
    - If anything required is missing: stop and guide user to configure it.
 3. Create the DAG YAML with `patch` in: {{.DAGsDir}}
-4. Validate with `bash`: `dagu validate <dag.yaml>`
+4. Validate with `dag_def_manage` action `validate` or with `bash`: `dagu validate <dag.yaml>`
 5. Navigate to the new DAG page: `/dags/<dag-name>`
 
 ### Updating an Existing DAG
-1. `read` the file first.
+1. Use `dag_def_manage` action `get` or `read` the file first.
 2. Modify with `patch` (keep edits minimal and focused).
-3. Validate with `dagu validate`.
+3. Validate with `dag_def_manage` action `validate` or `dagu validate`.
 4. Navigate to `/dags/<dag-name>/spec` or `/dags/<dag-name>`.
 
 ### Executing a DAG
 1. Only run when user explicitly requests execution.
 2. Default to queue-based execution: `dagu enqueue <dag-name>` (capture the run-id). Use `dagu start` only if the user explicitly asks for immediate local execution instead of queueing.
 3. Do not check running jobs, queued jobs, or call `dagu status` / `dagu history` before enqueueing unless the user explicitly asks for that check or requests singleton behavior.
-4. Verify the enqueued run with `dagu status <dag-name> --run-id=<run-id>` or `dagu history <dag-name> --run-id=<run-id>`
-5. On failure: `read` the log file, identify root cause, propose fix.
-6. Navigate to run: `/dag-runs/<dag-name>/<run-id>`
+4. Verify the enqueued run with `dag_run_manage` action `get` or with `dagu status <dag-name> --run-id=<run-id>` / `dagu history <dag-name> --run-id=<run-id>`.
+5. If the run is still active after verification, register `dag_run_manage` action `watch` for the run instead of repeatedly polling. Continue helping the user with other work; the watch will post a session message when the run reaches a terminal state.
+6. On failure: use `dag_run_manage` action `diagnose`, then read specific log refs/messages as needed and identify root cause.
+7. Navigate to run: `/dag-runs/<dag-name>/<run-id>`
 
 ### Debugging a Failed Run
-1. Status: `dagu status <dag-name> --run-id=<run-id>`
-2. `read` the log file. Look for: exit code, missing deps, config errors, permissions.
+1. Use `dag_run_manage` action `diagnose` for the run.
+2. Use `dag_run_manage` action `read_log` and `read_messages` to drill into the specific failed step. Look for: exit code, missing deps, config errors, permissions.
 3. Propose a minimal fix and apply with `patch`.
 4. If re-running needed: ask user, then run and re-check.
 
 ### Viewing DAG Run History
-Use `dagu history` to view past executions—essential for debugging and monitoring.
+Use `dag_run_manage` action `list` to view past executions—essential for debugging and monitoring. Fall back to `dagu history` if the tool is unavailable.
 Examples:
-- `dagu history my-dag --last 7d --status failed` - Recent failures
-- `dagu history --format json --limit 50` - Programmatic access
+- `dag_run_manage({"action":"list","dagName":"my-dag","last":"7d","status":["failed"]})` - Recent failures
+- `dag_run_manage({"action":"list","limit":50})` - Programmatic access
+- `dag_run_manage({"action":"watch","dagName":"my-dag","dagRunId":"run-id"})` - Notify this session once the run finishes
 Filters: --status, --labels, --from/--to, --last, --run-id, --limit
 Formats: table (default), json
 

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -271,7 +271,7 @@ maps to {{.DocsDir}}/runbooks/deployment.md). Runbooks may include YAML frontmat
 2. Default to queue-based execution: `dagu enqueue <dag-name>` (capture the run-id). Use `dagu start` only if the user explicitly asks for immediate local execution instead of queueing.
 3. Do not check running jobs, queued jobs, or call `dagu status` / `dagu history` before enqueueing unless the user explicitly asks for that check or requests singleton behavior.
 4. Verify the enqueued run with `dag_run_manage` action `get` or with `dagu status <dag-name> --run-id=<run-id>` / `dagu history <dag-name> --run-id=<run-id>`.
-5. If the run is still active after verification, register `dag_run_manage` action `watch` for the run instead of repeatedly polling. Continue helping the user with other work; the watch will post a session message when the run reaches a terminal state.
+5. If the run is still active after verification, register `dag_run_manage` action `watch` for the run instead of repeatedly polling. Continue helping the user with other work; the watch will wake this session with an internal background event when the run reaches a terminal state. Do not quote that event verbatim; use `dag_run_manage` for details if needed, then continue the user's task.
 6. On failure: use `dag_run_manage` action `diagnose`, then read specific log refs/messages as needed and identify root cause.
 7. Navigate to run: `/dag-runs/<dag-name>/<run-id>`
 
@@ -286,7 +286,7 @@ Use `dag_run_manage` action `list` to view past executions—essential for debug
 Examples:
 - `dag_run_manage({"action":"list","dagName":"my-dag","last":"7d","status":["failed"]})` - Recent failures
 - `dag_run_manage({"action":"list","limit":50})` - Programmatic access
-- `dag_run_manage({"action":"watch","dagName":"my-dag","dagRunId":"run-id"})` - Notify this session once the run finishes
+- `dag_run_manage({"action":"watch","dagName":"my-dag","dagRunId":"run-id"})` - Wake this session once the run finishes
 Filters: --status, --labels, --from/--to, --last, --run-id, --limit
 Formats: table (default), json
 

--- a/internal/agent/tool_registry.go
+++ b/internal/agent/tool_registry.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"slices"
 
+	"github.com/dagucloud/dagu/internal/core/exec"
 	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 )
 
@@ -28,6 +29,15 @@ type ToolRegistration struct {
 type ToolConfig struct {
 	// DAGsDir is the directory containing DAG definition files.
 	DAGsDir string
+	// DAGStore provides access to DAG definitions for dag_def_manage.
+	// Nil means dag_def_manage reports unavailable when called.
+	DAGStore exec.DAGStore
+	// DAGRunStore provides access to DAG run history for dag_run_manage.
+	// Nil means dag_run_manage reports unavailable when called.
+	DAGRunStore exec.DAGRunStore
+	// DAGRunWatcher provides session-local run watch registrations for dag_run_manage.
+	// Nil means dag_run_manage watch actions report unavailable when called.
+	DAGRunWatcher DAGRunWatcher
 	// DocStore provides access to Markdown docs/runbooks for runbook_manage.
 	// Nil means runbook_manage reports unavailable when called.
 	DocStore DocStore

--- a/internal/agent/tool_registry_test.go
+++ b/internal/agent/tool_registry_test.go
@@ -31,6 +31,8 @@ func TestRegisteredTools_ContainsAllExpected(t *testing.T) {
 		"session_search",
 		"delegate",
 		"runbook_manage",
+		"dag_def_manage",
+		"dag_run_manage",
 		"remote_agent", "list_contexts",
 	}
 

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -254,7 +254,6 @@ func (c *Context) newAgentAPI() (*agent.API, error) {
 		WorkingDir:            c.Config.Paths.DAGsDir,
 		SessionStore:          sessStore,
 		DAGStore:              dagStore,
-		DAGDefinitionStore:    dagStore,
 		DAGRunStore:           c.DAGRunStore,
 		Hooks:                 hooks,
 		MemoryStore:           stores.MemoryStore,

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -254,6 +254,8 @@ func (c *Context) newAgentAPI() (*agent.API, error) {
 		WorkingDir:            c.Config.Paths.DAGsDir,
 		SessionStore:          sessStore,
 		DAGStore:              dagStore,
+		DAGDefinitionStore:    dagStore,
+		DAGRunStore:           c.DAGRunStore,
 		Hooks:                 hooks,
 		MemoryStore:           stores.MemoryStore,
 		OAuthManager:          stores.OAuthManager,

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/harness"
@@ -342,6 +344,12 @@ schedule: "1"`,
 
 func TestBuildEnv(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
+	if runtime.GOOS == "windows" {
+		ctx = config.WithConfig(ctx, &config.Config{
+			Core: config.Core{DefaultShell: "cmd"},
+		})
+	}
 
 	type testCase struct {
 		name     string
@@ -398,7 +406,7 @@ steps:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			dag, err := spec.LoadYAML(context.Background(), []byte(tc.yaml))
+			dag, err := spec.LoadYAML(ctx, []byte(tc.yaml))
 			require.NoError(t, err)
 			th := DAG{t: t, DAG: dag}
 			for key, val := range tc.expected {

--- a/internal/core/spec/dparams_test.go
+++ b/internal/core/spec/dparams_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +172,12 @@ params:
 
 func TestInlineParamDefs_EvalResolvesDuringNormalBuild(t *testing.T) {
 	t.Setenv("WORK_DIR", "/tmp/work")
+	ctx := context.Background()
+	if runtime.GOOS == "windows" {
+		ctx = config.WithConfig(ctx, &config.Config{
+			Core: config.Core{DefaultShell: "cmd"},
+		})
+	}
 
 	yaml := []byte(`
 name: eval-params
@@ -181,10 +188,10 @@ params:
     eval: "$base_dir/output"
   - name: parallelism
     type: integer
-    eval: "` + "`printf 7`" + `"
+    eval: "` + "`echo 7`" + `"
 `)
 
-	dag, err := LoadYAML(context.Background(), yaml)
+	dag, err := LoadYAML(ctx, yaml)
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"base_dir=/tmp/work/pipeline",

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -532,6 +532,12 @@ func (a *Agent) Run(ctx context.Context) error {
 	if a.agentRemoteContextResolver != nil {
 		ctx = agentpkg.WithRemoteContextResolver(ctx, a.agentRemoteContextResolver)
 	}
+	if a.dagStore != nil {
+		ctx = agentpkg.WithDAGStore(ctx, a.dagStore)
+	}
+	if a.dagRunStore != nil {
+		ctx = agentpkg.WithDAGRunStore(ctx, a.dagRunStore)
+	}
 
 	// Add structured logging context
 	logFields := []slog.Attr{

--- a/internal/runtime/builtin/agentstep/executor.go
+++ b/internal/runtime/builtin/agentstep/executor.go
@@ -309,6 +309,12 @@ func buildTools(ctx context.Context, dagCtx exec.Context, stepCfg *core.AgentSte
 			allTools["list_contexts"] = t
 		}
 	}
+	if dagStore := agent.GetDAGStore(ctx); dagStore != nil {
+		allTools["dag_def_manage"] = agent.NewDAGDefManageTool(dagStore)
+	}
+	if dagRunStore := agent.GetDAGRunStore(ctx); dagRunStore != nil {
+		allTools["dag_run_manage"] = agent.NewDAGRunManageTool(dagRunStore)
+	}
 
 	// Remove tools disabled by global policy (output is step-only, always kept).
 	for name := range allTools {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -774,7 +774,6 @@ func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore 
 		Logger:                slog.Default(),
 		SessionStore:          sessStore,
 		DAGStore:              dagStore,
-		DAGDefinitionStore:    dagStore,
 		DAGRunStore:           dagRunStore,
 		Hooks:                 hooks,
 		EventService:          eventSvc,

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -384,7 +384,7 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 
 	var agentAPI *agent.API
 	if agentConfigStore != nil {
-		agentAPI, err = initAgentAPI(ctx, agentConfigStore, agentModelStore, agentSoulStore, agentOAuthManager, &cfg.Paths, referencesDir, cfg.Server.Session.MaxPerUser, dr, auditSvc, auditEnabled, eventSvc, memoryStore, docStore, wsStore, newRemoteNodeAdapter(remoteNodeResolver))
+		agentAPI, err = initAgentAPI(ctx, agentConfigStore, agentModelStore, agentSoulStore, agentOAuthManager, &cfg.Paths, referencesDir, cfg.Server.Session.MaxPerUser, dr, drs, auditSvc, auditEnabled, eventSvc, memoryStore, docStore, wsStore, newRemoteNodeAdapter(remoteNodeResolver))
 		if err != nil {
 			logger.Warn(ctx, "Failed to initialize agent API", tag.Error(err))
 		}
@@ -754,7 +754,7 @@ func initSyncService(ctx context.Context, cfg *config.Config) gitsync.Service {
 
 // initAgentAPI creates and returns an agent API.
 // The API uses the config store to check enabled status and resolve providers via the model store.
-func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore agent.ModelStore, soulStore agent.SoulStore, oauthManager *agentoauth.Manager, paths *config.PathsConfig, referencesDir string, sessionMaxPerUser int, dagStore exec.DAGStore, auditSvc *audit.Service, auditEnabled func() bool, eventSvc *eventstore.Service, memoryStore agent.MemoryStore, docStore agent.DocStore, workspaceStore workspacepkg.Store, remoteResolver agent.RemoteContextResolver) (*agent.API, error) {
+func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore agent.ModelStore, soulStore agent.SoulStore, oauthManager *agentoauth.Manager, paths *config.PathsConfig, referencesDir string, sessionMaxPerUser int, dagStore exec.DAGStore, dagRunStore exec.DAGRunStore, auditSvc *audit.Service, auditEnabled func() bool, eventSvc *eventstore.Service, memoryStore agent.MemoryStore, docStore agent.DocStore, workspaceStore workspacepkg.Store, remoteResolver agent.RemoteContextResolver) (*agent.API, error) {
 	sessStore, err := filesession.New(paths.SessionsDir, filesession.WithMaxPerUser(sessionMaxPerUser))
 	if err != nil {
 		logger.Warn(ctx, "Failed to create session store, persistence disabled", tag.Error(err))
@@ -774,6 +774,8 @@ func initAgentAPI(ctx context.Context, store *fileagentconfig.Store, modelStore 
 		Logger:                slog.Default(),
 		SessionStore:          sessStore,
 		DAGStore:              dagStore,
+		DAGDefinitionStore:    dagStore,
+		DAGRunStore:           dagRunStore,
 		Hooks:                 hooks,
 		EventService:          eventSvc,
 		MemoryStore:           memoryStore,

--- a/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
+++ b/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
@@ -1,7 +1,10 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { components, NodeStatus } from '@/api/v1/schema';
 import { isActiveNodeStatus } from '@/lib/status-utils';
 import { Loader2 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { StepMessagesTable } from './StepMessagesTable';
 
 type DAGRunDetails = components['schemas']['DAGRunDetails'];
@@ -45,13 +48,21 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
   const [selectedStep, setSelectedStep] = useState<string | undefined>(
     defaultStep
   );
+  const [userSelectedStep, setUserSelectedStep] = useState(false);
+  const previousRunId = useRef(dagRun.dagRunId);
 
   // Update selectedStep when defaultStep changes (e.g., when nodes arrive or runs switch)
   useEffect(() => {
-    if (defaultStep) {
+    if (previousRunId.current !== dagRun.dagRunId) {
+      previousRunId.current = dagRun.dagRunId;
+      setUserSelectedStep(false);
+      setSelectedStep(defaultStep);
+      return;
+    }
+    if (defaultStep && !userSelectedStep) {
       setSelectedStep(defaultStep);
     }
-  }, [defaultStep]);
+  }, [dagRun.dagRunId, defaultStep, userSelectedStep]);
 
   // Get selected node info
   const selectedNode = historySteps.find((n) => n.step.name === selectedStep);
@@ -81,7 +92,10 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
         <select
           id="chat-step-select"
           value={selectedStep || ''}
-          onChange={(e) => setSelectedStep(e.target.value)}
+          onChange={(e) => {
+            setUserSelectedStep(true);
+            setSelectedStep(e.target.value);
+          }}
           className="h-6 px-2 text-xs border rounded bg-card focus:outline-none"
         >
           {historySteps.map((node) => (

--- a/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
+++ b/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
@@ -11,11 +11,13 @@ interface ChatHistoryTabProps {
 }
 
 export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
-  // Find all chat steps (steps with type: 'chat' in executorConfig)
-  const chatSteps = useMemo(() => {
+  // Find all LLM-backed steps that persist message history.
+  const historySteps = useMemo(() => {
     return (
       dagRun.nodes?.filter(
-        (node) => node.step.executorConfig?.type === 'chat'
+        (node) =>
+          node.step.executorConfig?.type === 'chat' ||
+          node.step.executorConfig?.type === 'agent'
       ) || []
     );
   }, [dagRun.nodes]);
@@ -27,7 +29,7 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
       NodeStatus.Failed,
       NodeStatus.Aborted,
     ];
-    const finishedSteps = chatSteps.filter((n) =>
+    const finishedSteps = historySteps.filter((n) =>
       finishedStatuses.includes(n.status as NodeStatus)
     );
 
@@ -36,9 +38,9 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
       return finishedSteps[finishedSteps.length - 1]?.step.name;
     }
 
-    // Fallback to first chat step if none finished
-    return chatSteps[0]?.step.name;
-  }, [chatSteps]);
+    // Fallback to first history step if none finished
+    return historySteps[0]?.step.name;
+  }, [historySteps]);
 
   const [selectedStep, setSelectedStep] = useState<string | undefined>(
     defaultStep
@@ -52,7 +54,7 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
   }, [defaultStep]);
 
   // Get selected node info
-  const selectedNode = chatSteps.find((n) => n.step.name === selectedStep);
+  const selectedNode = historySteps.find((n) => n.step.name === selectedStep);
   const isSelectedActive = isActiveNodeStatus(selectedNode?.status);
 
   // Determine if this is a sub-DAG run
@@ -61,10 +63,10 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
     dagRun.rootDAGRunName &&
     dagRun.rootDAGRunId !== dagRun.dagRunId;
 
-  if (chatSteps.length === 0) {
+  if (historySteps.length === 0) {
     return (
       <div className="text-xs text-muted-foreground p-2">
-        No chat steps in this DAG run
+        No chat or agent steps in this DAG run
       </div>
     );
   }
@@ -82,7 +84,7 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
           onChange={(e) => setSelectedStep(e.target.value)}
           className="h-6 px-2 text-xs border rounded bg-card focus:outline-none"
         >
-          {chatSteps.map((node) => (
+          {historySteps.map((node) => (
             <option key={node.step.name} value={node.step.name}>
               {node.step.name} ({node.statusLabel})
             </option>

--- a/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
+++ b/ui/src/features/dags/components/chat-history/ChatHistoryTab.tsx
@@ -25,7 +25,7 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
     );
   }, [dagRun.nodes]);
 
-  // Determine default selected step: last finished chat step
+  // Determine default selected step: last finished chat/agent step
   const defaultStep = useMemo(() => {
     const finishedStatuses = [
       NodeStatus.Success,
@@ -64,8 +64,21 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
     }
   }, [dagRun.dagRunId, defaultStep, userSelectedStep]);
 
+  const selectedStepExists = useMemo(() => {
+    return historySteps.some((n) => n.step.name === selectedStep);
+  }, [historySteps, selectedStep]);
+
+  useEffect(() => {
+    if (selectedStep && !selectedStepExists) {
+      setUserSelectedStep(false);
+      setSelectedStep(defaultStep);
+    }
+  }, [defaultStep, selectedStep, selectedStepExists]);
+
+  const resolvedStep = selectedStepExists ? selectedStep : defaultStep;
+
   // Get selected node info
-  const selectedNode = historySteps.find((n) => n.step.name === selectedStep);
+  const selectedNode = historySteps.find((n) => n.step.name === resolvedStep);
   const isSelectedActive = isActiveNodeStatus(selectedNode?.status);
 
   // Determine if this is a sub-DAG run
@@ -91,7 +104,7 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
         </label>
         <select
           id="chat-step-select"
-          value={selectedStep || ''}
+          value={resolvedStep || ''}
           onChange={(e) => {
             setUserSelectedStep(true);
             setSelectedStep(e.target.value);
@@ -110,11 +123,11 @@ export function ChatHistoryTab({ dagRun }: ChatHistoryTabProps) {
       </div>
 
       {/* Messages table - only for selected step */}
-      {selectedStep && (
+      {resolvedStep && (
         <StepMessagesTable
           dagName={dagRun.name}
           dagRunId={dagRun.dagRunId}
-          stepName={selectedStep}
+          stepName={resolvedStep}
           isActive={isSelectedActive}
           subDAGRunId={isSubDAGRun ? dagRun.dagRunId : undefined}
           rootDagName={isSubDAGRun ? dagRun.rootDAGRunName : undefined}


### PR DESCRIPTION
## Summary
- add built-in agent tools for DAG definition and DAG run inspection
- add session-local DAG run watch support to avoid repeated agent polling after enqueue
- surface agent step chat history in the UI and update the agent prompt to prefer the new tools

## Validation
- go test ./internal/agent ./internal/runtime/builtin/agentstep ./internal/runtime/agent ./internal/cmd ./internal/service/frontend ./internal/service/frontend/api/v1
- pnpm --dir ui typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DAG definition tools (list/get/validate/schema) and DAG run inspection (list/get/read_log/read_messages/diagnose); session-scoped run watches (watch/status/cancel) with assistant notifications; tools auto-enabled when stores/watchers present; chat history now includes agent/chat steps.

* **Bug Fixes**
  * Session lifecycle now clears associated DAG run watches on failures/cancellations/cleanup.

* **Tests**
  * Extensive tests for DAG tools, watches, diagnostics; Windows test timeout adjustments.

* **Documentation**
  * Updated in-chat guidance to use the new DAG tools and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->