### PR TITLE
fix: prevent duplicate runbook tab activation

### DIFF
--- a/ui/src/pages/__tests__/DocArboristNode.test.tsx
+++ b/ui/src/pages/__tests__/DocArboristNode.test.tsx
@@ -32,10 +32,6 @@ function makeFileNode() {
     submit: vi.fn(),
     reset: vi.fn(),
     edit: vi.fn(),
-    handleClick: vi.fn(() => {
-      select();
-      activate();
-    }),
   };
 }
 
@@ -43,9 +39,15 @@ describe('DocArboristNode', () => {
   it('activates a file once when the filename is clicked', async () => {
     const user = userEvent.setup();
     const node = makeFileNode();
+    const defaultRowClick = vi.fn(() => {
+      node.select();
+      node.activate();
+    });
 
     render(
-      <div onClick={node.handleClick}>
+      // Simulate react-arborist's default row click handler, which also
+      // activates the node if the custom node click bubbles to the row.
+      <div onClick={defaultRowClick}>
         <DocArboristNode
           node={node as never}
           tree={{} as never}

--- a/ui/src/pages/__tests__/DocArboristNode.test.tsx
+++ b/ui/src/pages/__tests__/DocArboristNode.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DocTreeNodeResponseType } from '@/api/v1/schema';
+import DocArboristNode from '../docs/components/DocArboristNode';
+
+function makeFileNode() {
+  const select = vi.fn();
+  const activate = vi.fn();
+  return {
+    id: 'runbooks/deploy',
+    data: {
+      id: 'runbooks/deploy',
+      name: 'deploy',
+      title: 'deploy',
+      type: DocTreeNodeResponseType.file,
+    },
+    isEditing: false,
+    isSelected: false,
+    isOpen: false,
+    willReceiveDrop: false,
+    isDragging: false,
+    select,
+    activate,
+    selectMulti: vi.fn(),
+    selectContiguous: vi.fn(),
+    toggle: vi.fn(),
+    submit: vi.fn(),
+    reset: vi.fn(),
+    edit: vi.fn(),
+    handleClick: vi.fn(() => {
+      select();
+      activate();
+    }),
+  };
+}
+
+describe('DocArboristNode', () => {
+  it('activates a file once when the filename is clicked', async () => {
+    const user = userEvent.setup();
+    const node = makeFileNode();
+
+    render(
+      <div onClick={node.handleClick}>
+        <DocArboristNode
+          node={node as never}
+          tree={{} as never}
+          style={{}}
+          dragHandle={null as never}
+          preview={null as never}
+          onContextAction={vi.fn()}
+          canWrite={false}
+        />
+      </div>
+    );
+
+    await user.click(screen.getByText('deploy'));
+
+    expect(node.activate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/pages/docs/components/DocArboristNode.tsx
+++ b/ui/src/pages/docs/components/DocArboristNode.tsx
@@ -54,6 +54,7 @@ function DocArboristNode({ node, style, dragHandle, onContextAction, canWrite, a
   }, [node.isEditing]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
     if (node.isEditing) return;
     if (e.ctrlKey || e.metaKey) {
       node.selectMulti();


### PR DESCRIPTION
## Summary
- Prevent document tree file clicks from bubbling into react-arborist's default row click handler.
- Add a regression test covering the duplicate activation path.

## Root cause
The custom Runbooks/Documents tree node called `node.activate()` on file clicks, then the same click bubbled to react-arborist's default row handler, which called `node.handleClick()` and activated the node again before React state had updated.

## Validation
- `pnpm test src/pages/docs src/pages/__tests__/DocArboristNode.test.tsx`
- `pnpm typecheck`

Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where clicking on document nodes could inadvertently trigger parent element actions, improving the reliability of document navigation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->