### PR TITLE
fix: tolerate unsupported unix socket transport

### DIFF
--- a/internal/cmn/sock/server.go
+++ b/internal/cmn/sock/server.go
@@ -56,6 +56,7 @@ func (srv *Server) Serve(ctx context.Context, listen chan error) error {
 	_ = os.Remove(srv.addr)
 	listener, err := net.Listen("unix", srv.addr)
 	if err != nil {
+		err = wrapListenError(err)
 		if listen != nil {
 			listen <- err
 		}

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -63,6 +63,8 @@ func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
 	require.Equal(t, idleTimeout, httpServer.IdleTimeout)
 }
 
+// TestWrapListenErrorMarksUnsupportedTransport verifies capability failures are
+// exposed through ErrUnsupported.
 func TestWrapListenErrorMarksUnsupportedTransport(t *testing.T) {
 	t.Parallel()
 
@@ -71,6 +73,8 @@ func TestWrapListenErrorMarksUnsupportedTransport(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnsupported)
 }
 
+// TestWrapListenErrorPreservesOtherErrors verifies bind/path errors keep their
+// original classification.
 func TestWrapListenErrorPreservesOtherErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/sock/server_internal_test.go
+++ b/internal/cmn/sock/server_internal_test.go
@@ -6,6 +6,7 @@ package sock
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -60,4 +61,22 @@ func TestNewHTTPServerConfiguresTimeouts(t *testing.T) {
 	httpServer := srv.newHTTPServer(context.Background())
 	require.Equal(t, defaultTimeout, httpServer.ReadHeaderTimeout)
 	require.Equal(t, idleTimeout, httpServer.IdleTimeout)
+}
+
+func TestWrapListenErrorMarksUnsupportedTransport(t *testing.T) {
+	t.Parallel()
+
+	err := wrapListenError(unsupportedListenErrorForTest())
+
+	require.ErrorIs(t, err, ErrUnsupported)
+}
+
+func TestWrapListenErrorPreservesOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	original := errors.New("bind permission denied")
+	err := wrapListenError(original)
+
+	require.ErrorIs(t, err, original)
+	require.NotErrorIs(t, err, ErrUnsupported)
 }

--- a/internal/cmn/sock/unsupported.go
+++ b/internal/cmn/sock/unsupported.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sock
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnsupported indicates the platform/runtime cannot provide Unix sockets.
+var ErrUnsupported = errors.New("unix socket transport unsupported")
+
+func wrapListenError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isUnsupportedListenError(err) {
+		return fmt.Errorf("%w: %w", ErrUnsupported, err)
+	}
+	return err
+}

--- a/internal/cmn/sock/unsupported.go
+++ b/internal/cmn/sock/unsupported.go
@@ -11,6 +11,7 @@ import (
 // ErrUnsupported indicates the platform/runtime cannot provide Unix sockets.
 var ErrUnsupported = errors.New("unix socket transport unsupported")
 
+// wrapListenError marks only transport capability failures as unsupported.
 func wrapListenError(err error) error {
 	if err == nil {
 		return nil

--- a/internal/cmn/sock/unsupported_test_unix.go
+++ b/internal/cmn/sock/unsupported_test_unix.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package sock
+
+import (
+	"net"
+	"syscall"
+)
+
+func unsupportedListenErrorForTest() error {
+	return &net.OpError{
+		Op:  "listen",
+		Net: "unix",
+		Err: syscall.EAFNOSUPPORT,
+	}
+}

--- a/internal/cmn/sock/unsupported_test_unix.go
+++ b/internal/cmn/sock/unsupported_test_unix.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 )
 
+// unsupportedListenErrorForTest returns a Unix unsupported-listen error.
 func unsupportedListenErrorForTest() error {
 	return &net.OpError{
 		Op:  "listen",

--- a/internal/cmn/sock/unsupported_test_windows.go
+++ b/internal/cmn/sock/unsupported_test_windows.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// unsupportedListenErrorForTest returns a Windows unsupported-listen error.
 func unsupportedListenErrorForTest() error {
 	return &net.OpError{
 		Op:  "listen",

--- a/internal/cmn/sock/unsupported_test_windows.go
+++ b/internal/cmn/sock/unsupported_test_windows.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package sock
+
+import (
+	"net"
+
+	"golang.org/x/sys/windows"
+)
+
+func unsupportedListenErrorForTest() error {
+	return &net.OpError{
+		Op:  "listen",
+		Net: "unix",
+		Err: windows.WSAEAFNOSUPPORT,
+	}
+}

--- a/internal/cmn/sock/unsupported_unix.go
+++ b/internal/cmn/sock/unsupported_unix.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 )
 
+// isUnsupportedListenError reports whether AF_UNIX is unavailable.
 func isUnsupportedListenError(err error) bool {
 	return errors.Is(err, syscall.EAFNOSUPPORT) ||
 		errors.Is(err, syscall.EPROTONOSUPPORT)

--- a/internal/cmn/sock/unsupported_unix.go
+++ b/internal/cmn/sock/unsupported_unix.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package sock
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isUnsupportedListenError(err error) bool {
+	return errors.Is(err, syscall.EAFNOSUPPORT) ||
+		errors.Is(err, syscall.EPROTONOSUPPORT)
+}

--- a/internal/cmn/sock/unsupported_windows.go
+++ b/internal/cmn/sock/unsupported_windows.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package sock
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isUnsupportedListenError(err error) bool {
+	return errors.Is(err, windows.WSAEAFNOSUPPORT) ||
+		errors.Is(err, windows.WSAEPROTONOSUPPORT)
+}

--- a/internal/cmn/sock/unsupported_windows.go
+++ b/internal/cmn/sock/unsupported_windows.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// isUnsupportedListenError reports whether AF_UNIX is unavailable.
 func isUnsupportedListenError(err error) bool {
 	return errors.Is(err, windows.WSAEAFNOSUPPORT) ||
 		errors.Is(err, windows.WSAEPROTONOSUPPORT)

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -94,7 +94,9 @@ type Agent struct {
 
 	// socketServer is the unix socket server to handle HTTP requests.
 	// It listens to the requests from the local client (e.g., frontend server).
-	socketServer *sock.Server
+	socketServer SocketServer
+	// socketServerFactory creates the local status/control transport.
+	socketServerFactory SocketServerFactory
 
 	// logDir is the directory to store the log files for each node in the DAG.
 	logDir string
@@ -214,6 +216,19 @@ type StatusPusher interface {
 	Push(ctx context.Context, status exec.DAGRunStatus) error
 }
 
+// SocketServer handles local status/control requests for a running DAG.
+type SocketServer interface {
+	Serve(ctx context.Context, listen chan error) error
+	Shutdown(ctx context.Context) error
+}
+
+// SocketServerFactory creates a local status/control transport.
+type SocketServerFactory func(addr string, handlerFunc sock.HTTPHandlerFunc) (SocketServer, error)
+
+func defaultSocketServerFactory(addr string, handlerFunc sock.HTTPHandlerFunc) (SocketServer, error) {
+	return sock.NewServer(addr, handlerFunc)
+}
+
 // ArtifactFinalizer uploads or persists artifacts before the final terminal status is written.
 type ArtifactFinalizer interface {
 	Finalize(ctx context.Context, attemptID, dir string) error
@@ -290,6 +305,9 @@ type Options struct {
 	ArtifactDir string
 	// ArtifactFinalizer persists artifacts before the final terminal status is written.
 	ArtifactFinalizer ArtifactFinalizer
+	// SocketServerFactory creates the local status/control transport.
+	// When nil, the default Unix socket transport is used.
+	SocketServerFactory SocketServerFactory
 }
 
 // New creates a new Agent.
@@ -335,6 +353,10 @@ func New(
 		agentOAuthManager:          opts.AgentOAuthManager,
 		agentRemoteContextResolver: opts.AgentRemoteContextResolver,
 		scheduleTime:               opts.ScheduleTime,
+		socketServerFactory:        opts.SocketServerFactory,
+	}
+	if a.socketServerFactory == nil {
+		a.socketServerFactory = defaultSocketServerFactory
 	}
 
 	// Initialize progress display if enabled
@@ -731,21 +753,31 @@ func (a *Agent) Run(ctx context.Context) error {
 	go execWithRecovery(ctx, func() {
 		err := a.socketServer.Serve(ctx, listenerErrCh)
 		if err != nil && !errors.Is(err, sock.ErrServerRequestedShutdown) {
+			if errors.Is(err, sock.ErrUnsupported) {
+				return
+			}
 			logger.Error(ctx, "Failed to start socket frontend", tag.Error(err))
 		}
 	})
 
-	// Stop the socket server when the dag-run is finished.
-	defer func() {
-		if err := a.socketServer.Shutdown(ctx); err != nil {
-			logger.Error(ctx, "Failed to shutdown socket frontend", tag.Error(err))
-		}
-	}()
-
 	// It returns error if it failed to start the unix socket server.
 	if err := <-listenerErrCh; err != nil {
-		initErr = fmt.Errorf("failed to start the unix socket server: %w", err)
-		return initErr
+		if errors.Is(err, sock.ErrUnsupported) {
+			logger.Warn(ctx,
+				"Unix socket transport unavailable; continuing without live status/control socket",
+				tag.Error(err),
+			)
+		} else {
+			initErr = fmt.Errorf("failed to start the unix socket server: %w", err)
+			return initErr
+		}
+	} else {
+		// Stop the socket server when the dag-run is finished.
+		defer func() {
+			if err := a.socketServer.Shutdown(ctx); err != nil {
+				logger.Error(ctx, "Failed to shutdown socket frontend", tag.Error(err))
+			}
+		}()
 	}
 
 	// Start progress display if enabled
@@ -1819,7 +1851,7 @@ func (a *Agent) attemptOptions() exec.NewDAGRunAttemptOptions {
 
 // setupSocketServer creates a socket server instance.
 func (a *Agent) setupSocketServer(ctx context.Context) error {
-	socketServer, err := sock.NewServer(a.socketAddr(), a.HandleHTTP(ctx))
+	socketServer, err := a.socketServerFactory(a.socketAddr(), a.HandleHTTP(ctx))
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -225,6 +225,7 @@ type SocketServer interface {
 // SocketServerFactory creates a local status/control transport.
 type SocketServerFactory func(addr string, handlerFunc sock.HTTPHandlerFunc) (SocketServer, error)
 
+// defaultSocketServerFactory creates the production Unix socket server.
 func defaultSocketServerFactory(addr string, handlerFunc sock.HTTPHandlerFunc) (SocketServer, error) {
 	return sock.NewServer(addr, handlerFunc)
 }

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -5,6 +5,7 @@ package agent_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/cmn/sock"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
@@ -284,6 +286,74 @@ steps:
 		require.NoError(t, readErr)
 		require.Equal(t, core.Failed, latest.Status)
 		require.NotEmpty(t, latest.FinishedAt)
+	})
+	t.Run("UnsupportedSocketTransportContinuesRun", func(t *testing.T) {
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - "exit 0"
+`)
+		dagAgent := dag.Agent(test.WithAgentOptions(agent.Options{
+			SocketServerFactory: fakeSocketServerFactory(
+				fmt.Errorf("%w: synthetic unsupported transport", sock.ErrUnsupported),
+			),
+		}))
+
+		dagAgent.RunSuccess(t)
+		dag.AssertLatestStatus(t, core.Succeeded)
+	})
+	t.Run("UnsupportedSocketTransportCanStopWithAbortFlag", func(t *testing.T) {
+		th := test.Setup(t)
+		runDir := t.TempDir()
+		startedFile := filepath.Join(runDir, "started")
+		releaseFile := filepath.Join(runDir, "release")
+		dagRunID := "test-dag-run-no-socket-stop"
+		t.Cleanup(func() {
+			_ = os.WriteFile(releaseFile, []byte("cleanup"), 0600)
+		})
+		dag := th.DAG(t, fmt.Sprintf(`steps:
+  - command: %q
+`, signalFileThenWaitScript(startedFile, releaseFile, 50*time.Millisecond)))
+		dagAgent := dag.Agent(
+			test.WithDAGRunID(dagRunID),
+			test.WithAgentOptions(agent.Options{
+				SocketServerFactory: fakeSocketServerFactory(
+					fmt.Errorf("%w: synthetic unsupported transport", sock.ErrUnsupported),
+				),
+			}),
+		)
+		runErr := make(chan error, 1)
+		go func() {
+			runErr <- dagAgent.Run(th.Context)
+		}()
+
+		waitForTestFile(t, startedFile, 2*time.Minute)
+		require.Eventually(t, func() bool {
+			status, err := th.DAGRunMgr.GetCurrentStatus(th.Context, dag.DAG, dagRunID)
+			return err == nil && status != nil && status.Status == core.Running
+		}, 10*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, th.DAGRunMgr.Stop(th.Context, dag.DAG, dagRunID))
+
+		select {
+		case err := <-runErr:
+			require.NoError(t, err)
+		case <-time.After(30 * time.Second):
+			require.FailNow(t, "timed out waiting for DAG run to stop via abort flag")
+		}
+		dag.AssertLatestStatus(t, core.Aborted)
+	})
+	t.Run("SocketStartupFailureRemainsFatal", func(t *testing.T) {
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - "exit 0"
+`)
+		dagAgent := dag.Agent(test.WithAgentOptions(agent.Options{
+			SocketServerFactory: fakeSocketServerFactory(errors.New("synthetic bind failure")),
+		}))
+
+		err := dagAgent.Run(th.Context)
+		require.ErrorContains(t, err, "failed to start the unix socket server")
+		require.ErrorContains(t, err, "synthetic bind failure")
 	})
 	t.Run("FailureHandlerRunsInline", func(t *testing.T) {
 		th := test.Setup(t)
@@ -781,6 +851,27 @@ type mockResponseWriter struct {
 	status int
 	body   string
 	header *http.Header
+}
+
+type fakeSocketServer struct {
+	serveErr error
+}
+
+func fakeSocketServerFactory(serveErr error) agent.SocketServerFactory {
+	return func(string, sock.HTTPHandlerFunc) (agent.SocketServer, error) {
+		return &fakeSocketServer{serveErr: serveErr}, nil
+	}
+}
+
+func (s *fakeSocketServer) Serve(_ context.Context, listen chan error) error {
+	if listen != nil {
+		listen <- s.serveErr
+	}
+	return s.serveErr
+}
+
+func (*fakeSocketServer) Shutdown(context.Context) error {
+	return nil
 }
 
 func (h *mockResponseWriter) Header() http.Header {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -857,12 +857,14 @@ type fakeSocketServer struct {
 	serveErr error
 }
 
+// fakeSocketServerFactory returns a socket factory with deterministic serve behavior.
 func fakeSocketServerFactory(serveErr error) agent.SocketServerFactory {
 	return func(string, sock.HTTPHandlerFunc) (agent.SocketServer, error) {
 		return &fakeSocketServer{serveErr: serveErr}, nil
 	}
 }
 
+// Serve reports the configured startup result through the listen channel.
 func (s *fakeSocketServer) Serve(_ context.Context, listen chan error) error {
 	if listen != nil {
 		listen <- s.serveErr
@@ -870,6 +872,7 @@ func (s *fakeSocketServer) Serve(_ context.Context, listen chan error) error {
 	return s.serveErr
 }
 
+// Shutdown is a no-op for the fake socket server.
 func (*fakeSocketServer) Shutdown(context.Context) error {
 	return nil
 }

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -214,6 +214,9 @@ func (m *Manager) IsRunning(ctx context.Context, dag *core.DAG, dagRunID string)
 	if st != nil && st.DAGRunID == dagRunID && st.Status == core.Running {
 		return true
 	}
+	if m.procStore == nil {
+		return false
+	}
 
 	runRef := exec.NewDAGRunRef(dag.Name, dagRunID)
 	if alive, err := m.procStore.IsRunAlive(ctx, dag.ProcGroup(), runRef); err == nil && alive {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -207,11 +207,24 @@ func (m *Manager) GenDAGRunID(_ context.Context) (string, error) {
 	return id.String(), nil
 }
 
-// IsRunning checks if a dag-run is currently running by querying its status.
-// Returns true if the status can be retrieved without error, indicating the DAG is running.
+// IsRunning checks if a dag-run is currently running. It prefers the live socket
+// status and falls back to a fresh proc heartbeat plus persisted running status.
 func (m *Manager) IsRunning(ctx context.Context, dag *core.DAG, dagRunID string) bool {
 	st, _ := m.currentStatus(ctx, dag, dagRunID)
-	return st != nil && st.DAGRunID == dagRunID && st.Status == core.Running
+	if st != nil && st.DAGRunID == dagRunID && st.Status == core.Running {
+		return true
+	}
+
+	runRef := exec.NewDAGRunRef(dag.Name, dagRunID)
+	if alive, err := m.procStore.IsRunAlive(ctx, dag.ProcGroup(), runRef); err == nil && alive {
+		st, err := m.getPersistedOrCurrentStatus(ctx, dag, dagRunID)
+		if err != nil {
+			return false
+		}
+		return st.DAGRunID == dagRunID && st.Status == core.Running
+	}
+
+	return false
 }
 
 // GetCurrentStatus retrieves the current status of a dag-run by its run ID.

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -462,6 +462,63 @@ steps:
 		require.Empty(t, latest.Error)
 		require.Equal(t, core.NodeRunning, latest.Nodes[0].Status)
 	})
+	t.Run("IsRunningFallsBackToFreshProcWithoutSocket", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    command: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		attemptID := "attempt-no-socket"
+
+		att, err := th.DAGRunStore.CreateAttempt(ctx, dag.DAG, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{
+			AttemptID: attemptID,
+		})
+		require.NoError(t, err)
+		require.NoError(t, att.Open(ctx))
+		runningStatus := testNewStatus(dag.DAG, dagRunID, core.Running, core.NodeRunning)
+		runningStatus.AttemptID = attemptID
+		require.NoError(t, att.Write(ctx, runningStatus))
+		require.NoError(t, att.Close(ctx))
+
+		proc, err := th.ProcStore.Acquire(ctx, dag.ProcGroup(), exec.ProcMeta{
+			StartedAt:    time.Now().Unix(),
+			Name:         dag.Name,
+			DAGRunID:     dagRunID,
+			AttemptID:    attemptID,
+			RootName:     dag.Name,
+			RootDAGRunID: dagRunID,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = proc.Stop(ctx)
+		})
+
+		require.True(t, th.DAGRunMgr.IsRunning(ctx, dag.DAG, dagRunID))
+	})
+	t.Run("IsRunningIgnoresProcWithoutReadableRunningStatus", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    command: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+
+		proc, err := th.ProcStore.Acquire(ctx, dag.ProcGroup(), exec.ProcMeta{
+			StartedAt:    time.Now().Unix(),
+			Name:         dag.Name,
+			DAGRunID:     dagRunID,
+			AttemptID:    "attempt-without-status",
+			RootName:     dag.Name,
+			RootDAGRunID: dagRunID,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = proc.Stop(ctx)
+		})
+
+		require.False(t, th.DAGRunMgr.IsRunning(ctx, dag.DAG, dagRunID))
+	})
 }
 
 func testNewStatus(dag *core.DAG, dagRunID string, dagStatus core.Status, nodeStatus core.NodeStatus) exec.DAGRunStatus {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -519,6 +519,15 @@ steps:
 
 		require.False(t, th.DAGRunMgr.IsRunning(ctx, dag.DAG, dagRunID))
 	})
+	t.Run("IsRunningWithoutProcStoreReturnsFalse", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    command: "exit 0"
+`)
+		mgr := runtime.NewManager(nil, nil, th.Config)
+
+		require.False(t, mgr.IsRunning(th.Context, dag.DAG, uuid.Must(uuid.NewV7()).String()))
+	})
 }
 
 func testNewStatus(dag *core.DAG, dagRunID string, dagStatus core.Status, nodeStatus core.NodeStatus) exec.DAGRunStatus {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dagucloud/dagu/internal/test"
 )
 
+// TestManager exercises DAG run manager status and control behavior.
 func TestManager(t *testing.T) {
 	th := test.Setup(t, test.WithBuiltExecutable())
 
@@ -530,11 +531,13 @@ steps:
 	})
 }
 
+// testNewStatus builds a minimal persisted DAG run status for manager tests.
 func testNewStatus(dag *core.DAG, dagRunID string, dagStatus core.Status, nodeStatus core.NodeStatus) exec.DAGRunStatus {
 	nodes := []runtime.NodeData{{State: runtime.NodeState{Status: nodeStatus}}}
 	return transform.NewStatusBuilder(dag).Create(dagRunID, dagStatus, 0, time.Now(), transform.WithNodes(nodes))
 }
 
+// startStatusSocketServer serves a fixed status over the DAG run socket.
 func startStatusSocketServer(t *testing.T, ctx context.Context, dag *core.DAG, dagRunID string, status exec.DAGRunStatus) func() {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Continue local DAG runs when the OS/runtime cannot provide the Unix socket transport.
- Keep non-unsupported socket startup failures fatal.
- Fall back to proc heartbeat plus persisted running status when live socket status is unavailable.

## Tests
- make test TEST_TARGET="./internal/cmn/sock ./internal/runtime ./internal/runtime/agent"
- GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-sock.test.exe ./internal/cmn/sock && GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-runtime.test.exe ./internal/runtime && GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-agent.test.exe ./internal/runtime/agent

Closes #2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent treats Unix-socket transport as optional; service continues with a warning if unsupported.
* **Improvements**
  * Socket server is pluggable via a configurable factory for flexible startup/shutdown.
  * Run-status detection tightened to confirm process liveness before reporting running state.
* **Bug Fixes**
  * Listen errors for unsupported transports are now classified so unsupported cases are handled non‑fatally.
* **Tests**
  * Added tests covering unsupported socket handling, socket startup outcomes, and run-status scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->