### PR TITLE
fix: harden agent patch tool

### DIFF
--- a/internal/agent/patch.go
+++ b/internal/agent/patch.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/llm"
@@ -36,18 +37,22 @@ const (
 type PatchOperation string
 
 const (
-	PatchOpCreate  PatchOperation = "create"
-	PatchOpReplace PatchOperation = "replace"
-	PatchOpDelete  PatchOperation = "delete"
+	PatchOpCreate       PatchOperation = "create"
+	PatchOpReplace      PatchOperation = "replace"
+	PatchOpAppend       PatchOperation = "append"
+	PatchOpInsertBefore PatchOperation = "insert_before"
+	PatchOpInsertAfter  PatchOperation = "insert_after"
+	PatchOpDelete       PatchOperation = "delete"
 )
 
 // PatchToolInput is the input schema for the patch tool.
 type PatchToolInput struct {
 	Path      string         `json:"path"`
 	Operation PatchOperation `json:"operation"`
-	Content   string         `json:"content,omitempty"`    // For create operation
+	Content   string         `json:"content,omitempty"`    // For create, append, and insert operations
 	OldString string         `json:"old_string,omitempty"` // For replace operation
 	NewString string         `json:"new_string,omitempty"` // For replace operation
+	Anchor    string         `json:"anchor,omitempty"`     // For insert operations
 }
 
 // NewPatchTool creates a new patch tool for file editing.
@@ -58,7 +63,7 @@ func NewPatchTool(dagsDir string) *AgentTool {
 			Type: "function",
 			Function: llm.ToolFunction{
 				Name:        "patch",
-				Description: "Create, edit, or delete files. Use 'create' to write new files, 'replace' to edit existing files by replacing text, or 'delete' to remove files.",
+				Description: "Create, edit, or delete files. Use 'create' to write a full file, 'replace' only to replace an exact unique old_string, 'append' to add content at EOF, 'insert_before'/'insert_after' to add content around an exact unique anchor, or 'delete' to remove a file. Do not use replace to express an append.",
 				Parameters: map[string]any{
 					"type": "object",
 					"properties": map[string]any{
@@ -68,20 +73,24 @@ func NewPatchTool(dagsDir string) *AgentTool {
 						},
 						"operation": map[string]any{
 							"type":        "string",
-							"enum":        []string{"create", "replace", "delete"},
-							"description": "The operation to perform: 'create' (write new file), 'replace' (edit by replacing text), or 'delete' (remove file)",
+							"enum":        []string{"create", "replace", "append", "insert_before", "insert_after", "delete"},
+							"description": "The operation to perform: 'create' writes full file content, 'replace' replaces exact unique old_string with new_string, 'append' adds content at EOF, 'insert_before'/'insert_after' insert content around exact unique anchor, and 'delete' removes a file",
 						},
 						"content": map[string]any{
 							"type":        "string",
-							"description": "For 'create': the full content to write to the file",
+							"description": "For 'create': the full content to write. For 'append' and insert operations: the content to add",
 						},
 						"old_string": map[string]any{
 							"type":        "string",
-							"description": "For 'replace': the exact text to find and replace (must be unique in the file)",
+							"description": "For 'replace': the exact unique text to find and replace. Must be copied exactly from a prior read result",
 						},
 						"new_string": map[string]any{
 							"type":        "string",
-							"description": "For 'replace': the text to replace old_string with",
+							"description": "For 'replace': the text to replace old_string with. To append content, use append or insert_after instead",
+						},
+						"anchor": map[string]any{
+							"type":        "string",
+							"description": "For 'insert_before' and 'insert_after': the exact unique text that must remain in the file",
 						},
 					},
 					"required": []string{"path", "operation"},
@@ -107,6 +116,10 @@ func patchRun(ctx ToolContext, input json.RawMessage, dagsDir string) ToolOut {
 	if err := json.Unmarshal(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(input, &rawFields); err != nil {
+		return toolError("Failed to parse input: %v", err)
+	}
 
 	if args.Path == "" {
 		return toolError("Path is required")
@@ -116,22 +129,52 @@ func patchRun(ctx ToolContext, input json.RawMessage, dagsDir string) ToolOut {
 
 	switch args.Operation {
 	case PatchOpCreate:
+		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string", "anchor"); err != nil {
+			return toolError("%s", err.Error())
+		}
 		return patchCreate(ctx.Context, path, args.Content, dagsDir)
 	case PatchOpReplace:
+		if err := validateNoFields(args.Operation, rawFields, "content", "anchor"); err != nil {
+			return toolError("%s", err.Error())
+		}
 		return patchReplace(ctx.Context, path, args.OldString, args.NewString, dagsDir)
+	case PatchOpAppend:
+		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string", "anchor"); err != nil {
+			return toolError("%s", err.Error())
+		}
+		return patchAppend(ctx.Context, path, args.Content, dagsDir)
+	case PatchOpInsertBefore:
+		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string"); err != nil {
+			return toolError("%s", err.Error())
+		}
+		return patchInsert(ctx.Context, path, args.Anchor, args.Content, false, dagsDir)
+	case PatchOpInsertAfter:
+		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string"); err != nil {
+			return toolError("%s", err.Error())
+		}
+		return patchInsert(ctx.Context, path, args.Anchor, args.Content, true, dagsDir)
 	case PatchOpDelete:
+		if err := validateNoFields(args.Operation, rawFields, "content", "old_string", "new_string", "anchor"); err != nil {
+			return toolError("%s", err.Error())
+		}
 		return patchDelete(path)
 	default:
-		return toolError("Unknown operation: %s. Use 'create', 'replace', or 'delete'.", args.Operation)
+		return toolError("Unknown operation: %s. Use 'create', 'replace', 'append', 'insert_before', 'insert_after', or 'delete'.", args.Operation)
 	}
 }
 
 func patchCreate(ctx context.Context, path, content, dagsDir string) ToolOut {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return toolError("Path is a directory: %s", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return toolError("Failed to stat path: %v", err)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), dirPermission); err != nil {
 		return toolError("Failed to create directory: %v", err)
 	}
 
-	if err := os.WriteFile(path, []byte(content), filePermission); err != nil {
+	if err := fileutil.WriteFileAtomic(path, []byte(content), filePermission); err != nil {
 		return toolError("Failed to write file: %v", err)
 	}
 
@@ -147,15 +190,11 @@ func patchReplace(ctx context.Context, path, oldString, newString, dagsDir strin
 		return toolError("old_string is required for replace operation")
 	}
 
-	content, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return toolError("File not found: %s. Use 'create' operation to create new files.", path)
-		}
-		return toolError("Failed to read file: %v", err)
+	contentStr, mode, out := readExistingRegularFile(path)
+	if out.IsError {
+		return out
 	}
 
-	contentStr := string(content)
 	count := strings.Count(contentStr, oldString)
 
 	if count == 0 {
@@ -166,7 +205,7 @@ func patchReplace(ctx context.Context, path, oldString, newString, dagsDir strin
 	}
 
 	newContent := strings.Replace(contentStr, oldString, newString, 1)
-	if err := os.WriteFile(path, []byte(newContent), filePermission); err != nil {
+	if err := fileutil.WriteFileAtomic(path, []byte(newContent), mode); err != nil {
 		return toolError("Failed to write file: %v", err)
 	}
 
@@ -177,7 +216,77 @@ func patchReplace(ctx context.Context, path, oldString, newString, dagsDir strin
 	return ToolOut{Content: msg}
 }
 
+func patchAppend(ctx context.Context, path, content, dagsDir string) ToolOut {
+	if content == "" {
+		return toolError("content is required for append operation")
+	}
+
+	contentStr, mode, out := readExistingRegularFile(path)
+	if out.IsError {
+		return out
+	}
+
+	newContent := contentStr
+	if newContent != "" && !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+	newContent += content
+
+	if err := fileutil.WriteFileAtomic(path, []byte(newContent), mode); err != nil {
+		return toolError("Failed to write file: %v", err)
+	}
+
+	msg := fmt.Sprintf("Appended %d lines to %s", countLines(content), path)
+	if errs := validateIfDAGFile(ctx, path, dagsDir); len(errs) > 0 {
+		msg += "\n\nDAG Validation Errors:\n- " + strings.Join(errs, "\n- ")
+	}
+	return ToolOut{Content: msg}
+}
+
+func patchInsert(ctx context.Context, path, anchor, content string, after bool, dagsDir string) ToolOut {
+	if anchor == "" {
+		return toolError("anchor is required for insert operation")
+	}
+	if content == "" {
+		return toolError("content is required for insert operation")
+	}
+
+	contentStr, mode, out := readExistingRegularFile(path)
+	if out.IsError {
+		return out
+	}
+
+	count := strings.Count(contentStr, anchor)
+	if count == 0 {
+		return toolError("anchor not found in file. Make sure to include exact text including whitespace and indentation.")
+	}
+	if count > 1 {
+		return toolError("anchor found %d times in file. It must be unique. Include more context to make it unique.", count)
+	}
+
+	replacement := content + anchor
+	opName := "Inserted before"
+	if after {
+		replacement = anchor + content
+		opName = "Inserted after"
+	}
+	newContent := strings.Replace(contentStr, anchor, replacement, 1)
+
+	if err := fileutil.WriteFileAtomic(path, []byte(newContent), mode); err != nil {
+		return toolError("Failed to write file: %v", err)
+	}
+
+	msg := fmt.Sprintf("%s anchor: %d lines in %s", opName, countLines(content), path)
+	if errs := validateIfDAGFile(ctx, path, dagsDir); len(errs) > 0 {
+		msg += "\n\nDAG Validation Errors:\n- " + strings.Join(errs, "\n- ")
+	}
+	return ToolOut{Content: msg}
+}
+
 func patchDelete(path string) ToolOut {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return toolError("Path is a directory: %s", path)
+	}
 	err := os.Remove(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -186,6 +295,34 @@ func patchDelete(path string) ToolOut {
 		return toolError("Failed to delete file: %v", err)
 	}
 	return ToolOut{Content: fmt.Sprintf("Deleted %s", path)}
+}
+
+func validateNoFields(operation PatchOperation, rawFields map[string]json.RawMessage, fields ...string) error {
+	for _, field := range fields {
+		if _, ok := rawFields[field]; ok {
+			return fmt.Errorf("%s is not allowed for %s operation", field, operation)
+		}
+	}
+	return nil
+}
+
+func readExistingRegularFile(path string) (string, os.FileMode, ToolOut) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", 0, toolError("File not found: %s. Use 'create' operation to create new files.", path)
+		}
+		return "", 0, toolError("Failed to stat file: %v", err)
+	}
+	if info.IsDir() {
+		return "", 0, toolError("Path is a directory: %s", path)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, toolError("Failed to read file: %v", err)
+	}
+	return string(content), info.Mode().Perm(), ToolOut{}
 }
 
 func countLines(s string) int {

--- a/internal/agent/patch.go
+++ b/internal/agent/patch.go
@@ -299,7 +299,7 @@ func patchDelete(path string) ToolOut {
 
 func validateNoFields(operation PatchOperation, rawFields map[string]json.RawMessage, fields ...string) error {
 	for _, field := range fields {
-		if _, ok := rawFields[field]; ok {
+		if raw, ok := rawFields[field]; ok && strings.TrimSpace(string(raw)) != "null" {
 			return fmt.Errorf("%s is not allowed for %s operation", field, operation)
 		}
 	}

--- a/internal/agent/patch_test.go
+++ b/internal/agent/patch_test.go
@@ -148,6 +148,266 @@ func TestPatchTool_Replace(t *testing.T) {
 		assert.True(t, result.IsError)
 		assert.Contains(t, result.Content, "required")
 	})
+
+	t.Run("preserves existing file mode", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "mode.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o640))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "replace", "old_string", "world", "new_string", "universe"))
+
+		assert.False(t, result.IsError, result.Content)
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	})
+
+	t.Run("rejects ambiguous content field", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "replace", "old_string", "world", "new_string", "universe", "content", "extra"))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "content is not allowed")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(content))
+	})
+}
+
+func TestPatchTool_Append(t *testing.T) {
+	t.Parallel()
+	tool := NewPatchTool("")
+
+	t.Run("appends to end of file without deleting existing content", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "memory.md")
+		require.NoError(t, os.WriteFile(filePath, []byte("- existing\n"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "append", "content", "- new\n"))
+
+		assert.False(t, result.IsError, result.Content)
+		assert.Contains(t, result.Content, "Appended")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "- existing\n- new\n", string(content))
+	})
+
+	t.Run("adds newline before appending when file has no trailing newline", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "memory.md")
+		require.NoError(t, os.WriteFile(filePath, []byte("- existing"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "append", "content", "- new\n"))
+
+		assert.False(t, result.IsError, result.Content)
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "- existing\n- new\n", string(content))
+	})
+
+	t.Run("preserves existing file mode", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "mode.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("one\n"), 0o640))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "append", "content", "two\n"))
+
+		assert.False(t, result.IsError, result.Content)
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	})
+
+	t.Run("rejects empty append content without writing", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("one\n"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "append", "content", ""))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "content is required")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "one\n", string(content))
+	})
+}
+
+func TestPatchTool_Insert(t *testing.T) {
+	t.Parallel()
+	tool := NewPatchTool("")
+
+	t.Run("insert_after keeps anchor and inserts content after it", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "memory.md")
+		initial := "- YouTube動画の要約は `youtube_summary_jp` DAGを使用する\n- 日本語で要約を取得する\n"
+		require.NoError(t, os.WriteFile(filePath, []byte(initial), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(
+			filePath,
+			"insert_after",
+			"anchor", "- 日本語で要約を取得する\n",
+			"content", "- ユーザーを「きみ」と呼ばない\n",
+		))
+
+		assert.False(t, result.IsError, result.Content)
+		assert.Contains(t, result.Content, "Inserted")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, initial+"- ユーザーを「きみ」と呼ばない\n", string(content))
+	})
+
+	t.Run("insert_before keeps anchor and inserts content before it", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "memory.md")
+		initial := "- first\n- third\n"
+		require.NoError(t, os.WriteFile(filePath, []byte(initial), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(
+			filePath,
+			"insert_before",
+			"anchor", "- third\n",
+			"content", "- second\n",
+		))
+
+		assert.False(t, result.IsError, result.Content)
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "- first\n- second\n- third\n", string(content))
+	})
+
+	t.Run("preserves existing file mode", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "mode.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("one\nthree\n"), 0o640))
+
+		result := tool.Run(ToolContext{}, patchInput(
+			filePath,
+			"insert_after",
+			"anchor", "one\n",
+			"content", "two\n",
+		))
+
+		assert.False(t, result.IsError, result.Content)
+		info, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	})
+
+	t.Run("rejects empty insert content without writing", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("one\n"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "insert_after", "anchor", "one\n", "content", ""))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "content is required")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "one\n", string(content))
+	})
+}
+
+func TestPatchTool_FailedEditsDoNotWrite(t *testing.T) {
+	t.Parallel()
+	tool := NewPatchTool("")
+
+	tests := []struct {
+		name     string
+		initial  string
+		input    json.RawMessage
+		contains string
+	}{
+		{
+			name:     "insert_after missing anchor",
+			initial:  "alpha\n",
+			input:    nil,
+			contains: "anchor not found",
+		},
+		{
+			name:     "insert_before duplicate anchor",
+			initial:  "same\nsame\n",
+			input:    nil,
+			contains: "2 times",
+		},
+		{
+			name:     "insert_after empty anchor",
+			initial:  "alpha\n",
+			input:    nil,
+			contains: "anchor is required",
+		},
+		{
+			name:     "replace missing old string",
+			initial:  "alpha\n",
+			input:    nil,
+			contains: "not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filePath := filepath.Join(t.TempDir(), "test.txt")
+			require.NoError(t, os.WriteFile(filePath, []byte(tc.initial), 0o600))
+
+			input := tc.input
+			if input == nil {
+				switch tc.name {
+				case "insert_after missing anchor":
+					input = patchInput(filePath, "insert_after", "anchor", "missing\n", "content", "new\n")
+				case "insert_before duplicate anchor":
+					input = patchInput(filePath, "insert_before", "anchor", "same\n", "content", "new\n")
+				case "insert_after empty anchor":
+					input = patchInput(filePath, "insert_after", "anchor", "", "content", "new\n")
+				case "replace missing old string":
+					input = patchInput(filePath, "replace", "old_string", "missing\n", "new_string", "new\n")
+				}
+			}
+
+			result := tool.Run(ToolContext{}, input)
+
+			assert.True(t, result.IsError)
+			assert.Contains(t, result.Content, tc.contains)
+			content, err := os.ReadFile(filePath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.initial, string(content))
+		})
+	}
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "missing.txt")
+		result := tool.Run(ToolContext{}, patchInput(filePath, "append", "content", "new\n"))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "File not found")
+	})
+
+	t.Run("directory path returns error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		result := tool.Run(ToolContext{}, patchInput(dir, "append", "content", "new\n"))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "is a directory")
+	})
 }
 
 func TestPatchTool_Delete(t *testing.T) {
@@ -176,6 +436,21 @@ func TestPatchTool_Delete(t *testing.T) {
 
 		assert.True(t, result.IsError)
 		assert.Contains(t, result.Content, "not found")
+	})
+
+	t.Run("rejects forbidden field even when empty", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "delete-me.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o600))
+
+		result := tool.Run(ToolContext{}, patchInput(filePath, "delete", "content", ""))
+
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Content, "content is not allowed")
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "content", string(content))
 	})
 }
 

--- a/internal/agent/patch_test.go
+++ b/internal/agent/patch_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -35,6 +36,13 @@ func patchInput(path, operation string, extra ...string) json.RawMessage {
 		base.WriteString(fmt.Sprintf(`, %q: %q`, extra[i], extra[i+1]))
 	}
 	return json.RawMessage(base.String() + "}")
+}
+
+func skipIfWindowsFileMode(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions are not applicable on Windows")
+	}
 }
 
 func TestPatchTool_Create(t *testing.T) {
@@ -151,6 +159,7 @@ func TestPatchTool_Replace(t *testing.T) {
 
 	t.Run("preserves existing file mode", func(t *testing.T) {
 		t.Parallel()
+		skipIfWindowsFileMode(t)
 
 		filePath := filepath.Join(t.TempDir(), "mode.txt")
 		require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o640))
@@ -231,6 +240,7 @@ func TestPatchTool_Append(t *testing.T) {
 
 	t.Run("preserves existing file mode", func(t *testing.T) {
 		t.Parallel()
+		skipIfWindowsFileMode(t)
 
 		filePath := filepath.Join(t.TempDir(), "mode.txt")
 		require.NoError(t, os.WriteFile(filePath, []byte("one\n"), 0o640))
@@ -306,6 +316,7 @@ func TestPatchTool_Insert(t *testing.T) {
 
 	t.Run("preserves existing file mode", func(t *testing.T) {
 		t.Parallel()
+		skipIfWindowsFileMode(t)
 
 		filePath := filepath.Join(t.TempDir(), "mode.txt")
 		require.NoError(t, os.WriteFile(filePath, []byte("one\nthree\n"), 0o640))

--- a/internal/agent/patch_test.go
+++ b/internal/agent/patch_test.go
@@ -177,6 +177,23 @@ func TestPatchTool_Replace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "hello world", string(content))
 	})
+
+	t.Run("allows forbidden fields with null values", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o600))
+
+		result := tool.Run(ToolContext{}, json.RawMessage(fmt.Sprintf(
+			`{"path":%q,"operation":"replace","old_string":"world","new_string":"universe","content":null,"anchor":null}`,
+			filePath,
+		)))
+
+		assert.False(t, result.IsError, result.Content)
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "hello universe", string(content))
+	})
 }
 
 func TestPatchTool_Append(t *testing.T) {

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -228,7 +228,7 @@ Actively report your progress during multi-step work so the user is not left wai
 <tools>
 - `bash`: Run shell commands (120s timeout). It uses system `bash` when available and a built-in shell interpreter otherwise, so do not assume Unix-only helper binaries are installed. Use it for Dagu CLI commands and other installed CLIs.
 - `read`: Read file contents. Use before editing any file.
-- `patch`: Create or edit files using unified diff format.
+- `patch`: Create/edit/delete files with JSON operations: `create`, `replace`, `append`, `insert_before`, `insert_after`, `delete`. Use `append` or `insert_after` for additions; do not use `replace` to simulate an append.
 - `think`: Reason through complex multi-step tasks before acting.
 - `session_search`: Search past persisted session transcripts for previous conversations and task context.
 - `navigate`: Open a UI page (/dags/<name>, /dag-runs/<name>/<id>, /docs, /docs/<doc-id>).
@@ -292,7 +292,7 @@ Formats: table (default), json
 
 ### Working with Documents
 1. Check if the document exists: read({{.DocsDir}}/<id>.md)
-2. Create or update: patch(path, operation: create|replace, ...)
+2. Create or update: patch(path, operation: create|replace|append|insert_before|insert_after, ...)
 3. Navigate the user to the document: navigate("/docs/<doc-id>")
 </workflows>
 
@@ -327,7 +327,7 @@ Paths:
 
 Rules:
 - MEMORY.md is loaded into context automatically; keep under 200 lines
-- Use `read` and `patch` to manage memory files
+- Use `read` and `patch` to manage memory files. For adding a memory bullet, use `append` or `insert_after`; do not replace an existing bullet unless the user asked to change that exact fact.
 - Organize by topic, not chronologically
 - If DAG context is available, save memory to Per-DAG by default (not Global)
 - After creating or updating a DAG, if anything should be remembered, create/update that DAG's memory file

--- a/ui/src/features/agent/components/ChatMessages.tsx
+++ b/ui/src/features/agent/components/ChatMessages.tsx
@@ -61,6 +61,18 @@ export function ChatMessages({
     return ids;
   }, [messages]);
 
+  const toolResultsByCallId = useMemo(() => {
+    const results = new Map<string, NonNullable<Message['tool_results']>[number]>();
+    for (const msg of messages) {
+      if (msg.tool_results) {
+        for (const tr of msg.tool_results) {
+          if (tr.tool_call_id) results.set(tr.tool_call_id, tr);
+        }
+      }
+    }
+    return results;
+  }, [messages]);
+
   if (messages.length === 0 && !pendingUserMessage) {
     return (
       <div className="flex-1 flex items-center justify-center text-muted-foreground p-4 bg-popover">
@@ -91,6 +103,7 @@ export function ChatMessages({
           delegateStatuses={delegateStatuses}
           onOpenDelegate={onOpenDelegate}
           completedToolCallIds={completedToolCallIds}
+          toolResultsByCallId={toolResultsByCallId}
         />
       ))}
       {pendingUserMessage && (
@@ -116,9 +129,20 @@ interface MessageItemProps {
   delegateStatuses?: Record<string, DelegateInfo>;
   onOpenDelegate?: (id: string) => void;
   completedToolCallIds?: Set<string>;
+  toolResultsByCallId?: Map<string, NonNullable<Message['tool_results']>[number]>;
 }
 
-function MessageItem({ message, messages, messageIndex, onPromptRespond, answeredPrompts, delegateStatuses, onOpenDelegate, completedToolCallIds }: MessageItemProps): React.ReactNode {
+function MessageItem({
+  message,
+  messages,
+  messageIndex,
+  onPromptRespond,
+  answeredPrompts,
+  delegateStatuses,
+  onOpenDelegate,
+  completedToolCallIds,
+  toolResultsByCallId,
+}: MessageItemProps): React.ReactNode {
   const delegateIdsForToolCalls = useMemo(() => {
     const map = new Map<string, string[]>();
     if (message.type !== 'assistant' || !message.tool_calls) return map;
@@ -153,6 +177,7 @@ function MessageItem({ message, messages, messageIndex, onPromptRespond, answere
           onOpenDelegate={onOpenDelegate}
           completedToolCallIds={completedToolCallIds}
           delegateIdsForToolCalls={delegateIdsForToolCalls}
+          toolResultsByCallId={toolResultsByCallId}
         />
       );
     case 'error':

--- a/ui/src/features/agent/components/JsonPatchViewer.tsx
+++ b/ui/src/features/agent/components/JsonPatchViewer.tsx
@@ -1,12 +1,28 @@
 import { useMemo } from 'react';
 import { useUserPreferences } from '@/contexts/UserPreference';
+import { cn } from '@/lib/utils';
 import { type JsonPatch, type DiffLine, computeDiffLines } from '../utils/diffUtils';
 
 interface JsonPatchViewerProps {
   patch: JsonPatch;
+  status?: PatchViewStatus;
 }
 
-export function JsonPatchViewer({ patch }: JsonPatchViewerProps): React.ReactNode {
+export type PatchViewStatus = 'proposed' | 'applied' | 'failed';
+
+const STATUS_LABELS: Record<PatchViewStatus, string> = {
+  proposed: 'Proposed patch',
+  applied: 'Patch applied',
+  failed: 'Patch failed',
+};
+
+const STATUS_CLASSES: Record<PatchViewStatus, string> = {
+  proposed: 'text-muted-foreground',
+  applied: 'text-green-600 dark:text-green-400',
+  failed: 'text-red-600 dark:text-red-400',
+};
+
+export function JsonPatchViewer({ patch, status = 'proposed' }: JsonPatchViewerProps): React.ReactNode {
   const { preferences } = useUserPreferences();
   const isDark = preferences.theme === 'dark';
 
@@ -26,12 +42,16 @@ export function JsonPatchViewer({ patch }: JsonPatchViewerProps): React.ReactNod
   }, [diffLines]);
 
   return (
-    <div className="rounded border border-border overflow-hidden text-xs font-mono">
+    <div className={cn(
+      'rounded border overflow-hidden text-xs font-mono',
+      status === 'failed' ? 'border-red-500/40' : 'border-border'
+    )}>
       {/* Header */}
       <div className="flex items-center gap-2 px-2 py-1 bg-muted border-b border-border text-muted-foreground">
         {patch.path && (
           <span className="truncate">{patch.path.split('/').pop()}</span>
         )}
+        <span className={cn('ml-auto', STATUS_CLASSES[status])}>{STATUS_LABELS[status]}</span>
         <span className="text-green-600 dark:text-green-400">+{stats.additions}</span>
         <span className="text-red-600 dark:text-red-400">-{stats.deletions}</span>
       </div>

--- a/ui/src/features/agent/components/ToolViewers/PatchToolViewer.tsx
+++ b/ui/src/features/agent/components/ToolViewers/PatchToolViewer.tsx
@@ -23,6 +23,11 @@ const STATUS_CLASSES: Record<PatchViewStatus, string> = {
   failed: 'text-red-600 dark:text-red-400',
 };
 
+function splitPatchPreviewLines(value: string): string[] {
+  const lines = value.split('\n');
+  return lines[lines.length - 1] === '' ? lines.slice(0, -1) : lines;
+}
+
 export function PatchToolViewer({ args, toolName, toolResult }: ToolViewerProps): React.ReactNode {
   const { preferences } = useUserPreferences();
   const isDark = preferences.theme === 'dark';
@@ -36,8 +41,8 @@ export function PatchToolViewer({ args, toolName, toolResult }: ToolViewerProps)
 
   // Append and insert operations - show added content without implying an applied diff
   if ((operation === 'append' || operation === 'insert_before' || operation === 'insert_after') && content !== undefined) {
-    const lines = content.split('\n');
-    const anchorLines = anchor ? anchor.split('\n') : [];
+    const lines = splitPatchPreviewLines(content);
+    const anchorLines = anchor ? splitPatchPreviewLines(anchor) : [];
     const filename = path?.split('/').pop() || path;
 
     return (
@@ -68,7 +73,7 @@ export function PatchToolViewer({ args, toolName, toolResult }: ToolViewerProps)
 
   // Create operation - show file creation with content preview (all additions)
   if (operation === 'create' && content !== undefined) {
-    const lines = content.split('\n');
+    const lines = splitPatchPreviewLines(content);
     const filename = path?.split('/').pop() || path;
 
     return (

--- a/ui/src/features/agent/components/ToolViewers/PatchToolViewer.tsx
+++ b/ui/src/features/agent/components/ToolViewers/PatchToolViewer.tsx
@@ -1,18 +1,69 @@
 import { FilePlus, FileX } from 'lucide-react';
 import { useUserPreferences } from '@/contexts/UserPreference';
+import { cn } from '@/lib/utils';
 import type { PatchToolInput } from '../../types';
-import { JsonPatchViewer } from '../JsonPatchViewer';
+import { JsonPatchViewer, type PatchViewStatus } from '../JsonPatchViewer';
 import { DefaultToolViewer } from './DefaultToolViewer';
 import type { ToolViewerProps } from './index';
 
-export function PatchToolViewer({ args, toolName }: ToolViewerProps): React.ReactNode {
+function patchStatus(toolResult: ToolViewerProps['toolResult']): PatchViewStatus {
+  if (!toolResult) return 'proposed';
+  return toolResult.is_error ? 'failed' : 'applied';
+}
+
+const STATUS_LABELS: Record<PatchViewStatus, string> = {
+  proposed: 'Proposed patch',
+  applied: 'Patch applied',
+  failed: 'Patch failed',
+};
+
+const STATUS_CLASSES: Record<PatchViewStatus, string> = {
+  proposed: 'text-muted-foreground',
+  applied: 'text-green-600 dark:text-green-400',
+  failed: 'text-red-600 dark:text-red-400',
+};
+
+export function PatchToolViewer({ args, toolName, toolResult }: ToolViewerProps): React.ReactNode {
   const { preferences } = useUserPreferences();
   const isDark = preferences.theme === 'dark';
-  const { path, operation, content, old_string, new_string } = args as unknown as PatchToolInput;
+  const { path, operation, content, old_string, new_string, anchor } = args as unknown as PatchToolInput;
+  const status = patchStatus(toolResult);
 
   // Replace operation with old_string and new_string - use existing JsonPatchViewer
   if (old_string !== undefined && new_string !== undefined) {
-    return <JsonPatchViewer patch={{ path, old_string, new_string }} />;
+    return <JsonPatchViewer patch={{ path, old_string, new_string }} status={status} />;
+  }
+
+  // Append and insert operations - show added content without implying an applied diff
+  if ((operation === 'append' || operation === 'insert_before' || operation === 'insert_after') && content !== undefined) {
+    const lines = content.split('\n');
+    const anchorLines = anchor ? anchor.split('\n') : [];
+    const filename = path?.split('/').pop() || path;
+
+    return (
+      <div className={cn(
+        'rounded border overflow-hidden text-xs font-mono',
+        status === 'failed' ? 'border-red-500/40' : 'border-border'
+      )}>
+        <div className="flex items-center gap-2 px-2 py-1 bg-muted border-b border-border text-muted-foreground">
+          <FilePlus className="h-3 w-3 text-green-600 dark:text-green-400" />
+          <span className="truncate" title={path}>{filename}</span>
+          <span className={cn('ml-auto', STATUS_CLASSES[status])}>{STATUS_LABELS[status]}</span>
+          <span className="text-green-600 dark:text-green-400">+{lines.length}</span>
+        </div>
+        <div className="max-h-[300px] overflow-auto">
+          {operation === 'insert_after' && anchorLines.map((line, idx) => (
+            <DiffPreviewLine key={`anchor-before-${idx}`} line={line} type="context" isDark={isDark} />
+          ))}
+          {lines.map((line, idx) => (
+            <DiffPreviewLine key={`content-${idx}`} line={line} type="addition" isDark={isDark} />
+          ))}
+          {operation === 'insert_before' && anchorLines.map((line, idx) => (
+            <DiffPreviewLine key={`anchor-after-${idx}`} line={line} type="context" isDark={isDark} />
+          ))}
+        </div>
+      </div>
+    );
   }
 
   // Create operation - show file creation with content preview (all additions)
@@ -21,10 +72,14 @@ export function PatchToolViewer({ args, toolName }: ToolViewerProps): React.Reac
     const filename = path?.split('/').pop() || path;
 
     return (
-      <div className="rounded border border-border overflow-hidden text-xs font-mono">
+      <div className={cn(
+        'rounded border overflow-hidden text-xs font-mono',
+        status === 'failed' ? 'border-red-500/40' : 'border-border'
+      )}>
         <div className="flex items-center gap-2 px-2 py-1 bg-muted border-b border-border text-muted-foreground">
           <FilePlus className="h-3 w-3 text-green-600 dark:text-green-400" />
           <span className="truncate" title={path}>{filename}</span>
+          <span className={cn('ml-auto', STATUS_CLASSES[status])}>{STATUS_LABELS[status]}</span>
           <span className="text-green-600 dark:text-green-400">+{lines.length}</span>
         </div>
         <div className="max-h-[300px] overflow-auto">
@@ -53,6 +108,7 @@ export function PatchToolViewer({ args, toolName }: ToolViewerProps): React.Reac
       <div className="flex items-center gap-2 px-2 py-1 text-xs font-mono text-green-600 dark:text-green-400">
         <FilePlus className="h-3 w-3" />
         <span className="truncate" title={path}>{filename}</span>
+        <span className={cn('ml-auto', STATUS_CLASSES[status])}>{STATUS_LABELS[status]}</span>
       </div>
     );
   }
@@ -63,10 +119,35 @@ export function PatchToolViewer({ args, toolName }: ToolViewerProps): React.Reac
       <div className="flex items-center gap-2 px-2 py-1 text-xs font-mono text-red-600 dark:text-red-400">
         <FileX className="h-3 w-3" />
         <span className="truncate" title={path}>{path}</span>
+        <span className={cn('ml-auto', STATUS_CLASSES[status])}>{STATUS_LABELS[status]}</span>
       </div>
     );
   }
 
   // Fallback for unknown patch formats
   return <DefaultToolViewer args={args} toolName={toolName} />;
+}
+
+function DiffPreviewLine({
+  line,
+  type,
+  isDark,
+}: {
+  line: string;
+  type: 'addition' | 'context';
+  isDark: boolean;
+}): React.ReactNode {
+  const isAddition = type === 'addition';
+  return (
+    <div
+      className="px-2 py-0.5 whitespace-pre"
+      style={{
+        backgroundColor: isAddition ? (isDark ? 'rgba(34,197,94,0.1)' : '#d1fae5') : 'transparent',
+        color: isAddition ? (isDark ? '#4ade80' : '#14532d') : 'inherit',
+      }}
+    >
+      <span className="select-none mr-1">{isAddition ? '+' : ' '}</span>
+      {line}
+    </div>
+  );
 }

--- a/ui/src/features/agent/components/ToolViewers/index.tsx
+++ b/ui/src/features/agent/components/ToolViewers/index.tsx
@@ -5,10 +5,12 @@ import { ThinkToolViewer } from './ThinkToolViewer';
 import { NavigateToolViewer } from './NavigateToolViewer';
 import { AskUserToolViewer } from './AskUserToolViewer';
 import { DefaultToolViewer } from './DefaultToolViewer';
+import type { ToolResult } from '../../types';
 
 export interface ToolViewerProps {
   toolName: string;
   args: Record<string, unknown>;
+  toolResult?: ToolResult;
 }
 
 const toolViewerRegistry: Record<string, React.FC<ToolViewerProps>> = {
@@ -20,9 +22,9 @@ const toolViewerRegistry: Record<string, React.FC<ToolViewerProps>> = {
   ask_user: AskUserToolViewer,
 };
 
-export function ToolContentViewer({ toolName, args }: ToolViewerProps): React.ReactNode {
+export function ToolContentViewer({ toolName, args, toolResult }: ToolViewerProps): React.ReactNode {
   const Viewer = toolViewerRegistry[toolName] || DefaultToolViewer;
-  return <Viewer args={args} toolName={toolName} />;
+  return <Viewer args={args} toolName={toolName} toolResult={toolResult} />;
 }
 
 export { BashToolViewer } from './BashToolViewer';

--- a/ui/src/features/agent/components/__tests__/ChatMessages.test.tsx
+++ b/ui/src/features/agent/components/__tests__/ChatMessages.test.tsx
@@ -89,6 +89,21 @@ describe('ChatMessages patch tool status', () => {
     expect(screen.queryByText('Patch applied')).not.toBeInTheDocument();
   });
 
+  it('does not count a trailing newline as an extra append preview line', () => {
+    renderMessages([
+      patchMessage('msg-1', 'call-1', {
+        path: '/tmp/MEMORY.md',
+        operation: 'append',
+        content: '- new preference\n',
+      }),
+    ]);
+    openPatch();
+
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.queryByText('+2')).not.toBeInTheDocument();
+    expect(screen.getByText('- new preference')).toBeInTheDocument();
+  });
+
   it('marks a matching failed tool result on the patch preview', () => {
     renderMessages([
       patchMessage('msg-1', 'call-1', replaceArgs),

--- a/ui/src/features/agent/components/__tests__/ChatMessages.test.tsx
+++ b/ui/src/features/agent/components/__tests__/ChatMessages.test.tsx
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { UserPreferencesProvider } from '@/contexts/UserPreference';
+import { ChatMessages } from '../ChatMessages';
+import type { Message } from '../../types';
+
+function renderMessages(messages: Message[]) {
+  return render(
+    <UserPreferencesProvider>
+      <ChatMessages
+        messages={messages}
+        pendingUserMessage={null}
+        isWorking={false}
+      />
+    </UserPreferencesProvider>
+  );
+}
+
+function patchMessage(id: string, callId: string, args: Record<string, unknown>): Message {
+  return {
+    id,
+    session_id: 'session-1',
+    type: 'assistant',
+    sequence_id: Number(id.replace(/\D/g, '')) || 1,
+    content: '',
+    tool_calls: [
+      {
+        id: callId,
+        type: 'function',
+        function: {
+          name: 'patch',
+          arguments: JSON.stringify(args),
+        },
+      },
+    ],
+    created_at: '2026-05-07T00:00:00Z',
+  };
+}
+
+function toolResultMessage(id: string, callId: string, isError: boolean): Message {
+  return {
+    id,
+    session_id: 'session-1',
+    type: 'user',
+    sequence_id: Number(id.replace(/\D/g, '')) || 1,
+    content: '',
+    tool_results: [
+      {
+        tool_call_id: callId,
+        content: isError
+          ? 'old_string not found in file. Make sure to include exact text including whitespace and indentation.'
+          : 'Replaced 1 lines with 2 lines in /tmp/MEMORY.md',
+        is_error: isError,
+      },
+    ],
+    created_at: '2026-05-07T00:00:01Z',
+  };
+}
+
+const replaceArgs = {
+  path: '/tmp/MEMORY.md',
+  operation: 'replace',
+  old_string: 'line one\n',
+  new_string: 'line one\nline two\n',
+};
+
+function openPatch(index = 0) {
+  fireEvent.click(screen.getAllByRole('button', { name: /patch/i })[index]!);
+}
+
+describe('ChatMessages patch tool status', () => {
+  it('keeps patch tool calls collapsed by default', () => {
+    renderMessages([patchMessage('msg-1', 'call-1', replaceArgs)]);
+
+    expect(screen.getByRole('button', { name: /patch\[\+\]/i })).toBeInTheDocument();
+    expect(screen.queryByText('Proposed patch')).not.toBeInTheDocument();
+  });
+
+  it('labels a patch call without a result as proposed', () => {
+    renderMessages([patchMessage('msg-1', 'call-1', replaceArgs)]);
+    openPatch();
+
+    expect(screen.getByText('Proposed patch')).toBeInTheDocument();
+    expect(screen.queryByText('Patch failed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Patch applied')).not.toBeInTheDocument();
+  });
+
+  it('marks a matching failed tool result on the patch preview', () => {
+    renderMessages([
+      patchMessage('msg-1', 'call-1', replaceArgs),
+      toolResultMessage('msg-2', 'call-1', true),
+    ]);
+    openPatch();
+
+    expect(screen.getByText('Patch failed')).toBeInTheDocument();
+    expect(screen.queryByText('Proposed patch')).not.toBeInTheDocument();
+  });
+
+  it('marks a matching successful tool result on the patch preview', () => {
+    renderMessages([
+      patchMessage('msg-1', 'call-1', replaceArgs),
+      toolResultMessage('msg-2', 'call-1', false),
+    ]);
+    openPatch();
+
+    expect(screen.getByText('Patch applied')).toBeInTheDocument();
+    expect(screen.queryByText('Proposed patch')).not.toBeInTheDocument();
+  });
+
+  it('keeps a failed first patch visibly failed when a later patch succeeds', () => {
+    renderMessages([
+      patchMessage('msg-1', 'call-1', replaceArgs),
+      toolResultMessage('msg-2', 'call-1', true),
+      patchMessage('msg-3', 'call-2', {
+        path: '/tmp/MEMORY.md',
+        operation: 'replace',
+        old_string: 'line two\n',
+        new_string: 'line three\n',
+      }),
+      toolResultMessage('msg-4', 'call-2', false),
+    ]);
+    openPatch(0);
+    openPatch(1);
+
+    expect(screen.getByText('Patch failed')).toBeInTheDocument();
+    expect(screen.getByText('Patch applied')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/agent/components/messages/AssistantMessage.tsx
+++ b/ui/src/features/agent/components/messages/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { DelegateInfo, TokenUsage, ToolCall } from '../../types';
+import { DelegateInfo, TokenUsage, ToolCall, ToolResult } from '../../types';
 import { formatCost } from '../../utils/formatCost';
 import { ToolCallList } from './ToolCallBadge';
 import { SubAgentChips } from './SubAgentChips';
@@ -12,6 +12,7 @@ export function AssistantMessage({
   onOpenDelegate,
   completedToolCallIds,
   delegateIdsForToolCalls,
+  toolResultsByCallId,
 }: {
   content: string;
   toolCalls?: ToolCall[];
@@ -21,6 +22,7 @@ export function AssistantMessage({
   onOpenDelegate?: (id: string) => void;
   completedToolCallIds?: Set<string>;
   delegateIdsForToolCalls?: Map<string, string[]>;
+  toolResultsByCallId?: Map<string, ToolResult>;
 }): React.ReactNode {
   const delegateCalls = toolCalls?.filter((tc) => tc.function.name === 'delegate') ?? [];
   const otherCalls = toolCalls?.filter((tc) => tc.function.name !== 'delegate') ?? [];
@@ -33,7 +35,7 @@ export function AssistantMessage({
         </p>
       )}
       {otherCalls.length > 0 && (
-        <ToolCallList toolCalls={otherCalls} className="pl-4" />
+        <ToolCallList toolCalls={otherCalls} className="pl-4" toolResultsByCallId={toolResultsByCallId} />
       )}
       {delegateCalls.map((tc) => (
         <SubAgentChips

--- a/ui/src/features/agent/components/messages/ToolCallBadge.tsx
+++ b/ui/src/features/agent/components/messages/ToolCallBadge.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { ToolCall } from '../../types';
+import { ToolCall, ToolResult } from '../../types';
 import { ToolContentViewer } from '../ToolViewers';
 
 function parseToolArguments(jsonString: string): Record<string, unknown> {
@@ -12,8 +12,14 @@ function parseToolArguments(jsonString: string): Record<string, unknown> {
   }
 }
 
-export function ToolCallBadge({ toolCall }: { toolCall: ToolCall }): React.ReactNode {
-  const [expanded, setExpanded] = useState(true);
+export function ToolCallBadge({
+  toolCall,
+  toolResult,
+}: {
+  toolCall: ToolCall;
+  toolResult?: ToolResult;
+}): React.ReactNode {
+  const [expanded, setExpanded] = useState(false);
   const args = useMemo(() => parseToolArguments(toolCall.function.arguments), [toolCall.function.arguments]);
 
   return (
@@ -28,18 +34,26 @@ export function ToolCallBadge({ toolCall }: { toolCall: ToolCall }): React.React
       </button>
       {expanded && (
         <div className="px-2 py-1.5 border-t border-border bg-card dark:bg-surface">
-          <ToolContentViewer toolName={toolCall.function.name} args={args} />
+          <ToolContentViewer toolName={toolCall.function.name} args={args} toolResult={toolResult} />
         </div>
       )}
     </div>
   );
 }
 
-export function ToolCallList({ toolCalls, className }: { toolCalls: ToolCall[]; className?: string }): React.ReactNode {
+export function ToolCallList({
+  toolCalls,
+  className,
+  toolResultsByCallId,
+}: {
+  toolCalls: ToolCall[];
+  className?: string;
+  toolResultsByCallId?: Map<string, ToolResult>;
+}): React.ReactNode {
   return (
     <div className={cn('space-y-1', className)}>
       {toolCalls.map((tc) => (
-        <ToolCallBadge key={tc.id} toolCall={tc} />
+        <ToolCallBadge key={tc.id} toolCall={tc} toolResult={toolResultsByCallId?.get(tc.id)} />
       ))}
     </div>
   );

--- a/ui/src/features/agent/types.ts
+++ b/ui/src/features/agent/types.ts
@@ -168,10 +168,11 @@ export interface ReadToolInput {
 
 export interface PatchToolInput {
   path: string;
-  operation?: 'create' | 'replace' | 'delete';
+  operation?: 'create' | 'replace' | 'append' | 'insert_before' | 'insert_after' | 'delete';
   content?: string;
   old_string?: string;
   new_string?: string;
+  anchor?: string;
 }
 
 export interface ThinkToolInput {

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -77,6 +77,7 @@ const AGENT_SIDEBAR_MIN_WIDTH = 320;
 const AGENT_SIDEBAR_MAX_WIDTH = 720;
 const AGENT_SIDEBAR_MIN_CONTENT_WIDTH = 360;
 const AGENT_SIDEBAR_WIDTH_STORAGE_KEY = 'agentSidebarWidth';
+const SIDEBAR_MODE_STORAGE_KEY = 'sidebarMode';
 
 type SidebarMode = 'navigation' | 'agent';
 
@@ -120,6 +121,23 @@ function getInitialAgentSidebarWidth(): number {
   }
 
   return clampAgentSidebarWidth(AGENT_SIDEBAR_DEFAULT_WIDTH);
+}
+
+function isSidebarMode(value: string | null): value is SidebarMode {
+  return value === 'navigation' || value === 'agent';
+}
+
+function getInitialSidebarMode(): SidebarMode {
+  try {
+    const saved = localStorage.getItem(SIDEBAR_MODE_STORAGE_KEY);
+    if (isSidebarMode(saved)) {
+      return saved;
+    }
+  } catch {
+    // Ignore unavailable storage and fall back to navigation.
+  }
+
+  return 'navigation';
 }
 
 /**
@@ -167,7 +185,7 @@ function Content({ navbarColor, children }: LayoutProps) {
     return saved ? saved === 'true' : true;
   });
   const [sidebarMode, setSidebarMode] =
-    React.useState<SidebarMode>('navigation');
+    React.useState<SidebarMode>(getInitialSidebarMode);
   const [agentSidebarWidth, setAgentSidebarWidth] = React.useState(
     getInitialAgentSidebarWidth
   );
@@ -181,6 +199,14 @@ function Content({ navbarColor, children }: LayoutProps) {
   React.useEffect(() => {
     localStorage.setItem('sidebarExpanded', isSidebarExpanded.toString());
   }, [isSidebarExpanded]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_MODE_STORAGE_KEY, sidebarMode);
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }, [sidebarMode]);
 
   React.useEffect(() => {
     try {

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -47,10 +47,10 @@ const config = {
   agentEnabled: true,
 } as Config;
 
-function renderLayout(path: string): void {
-  render(
+function renderLayout(path: string, configOverride?: Partial<Config>) {
+  return render(
     <MemoryRouter initialEntries={[path]}>
-      <ConfigContext.Provider value={config}>
+      <ConfigContext.Provider value={{ ...config, ...configOverride }}>
         <Layout>
           <div>Page Content</div>
         </Layout>
@@ -125,10 +125,46 @@ describe('Layout', () => {
 
     expect(screen.queryByTestId('sidebar-menu')).toBeNull();
     expect(screen.getByTestId('agent-sidebar')).toBeVisible();
+    expect(localStorage.getItem('sidebarMode')).toBe('agent');
     expect(
       screen.getByRole('separator', { name: 'Resize agent panel' })
     ).toBeVisible();
     expect(screen.getByText('Page Content')).toBeVisible();
+  });
+
+  it('restores the agent sidebar mode after a reload', () => {
+    localStorage.setItem('sidebarMode', 'agent');
+
+    renderLayout('/cockpit');
+
+    expect(screen.queryByTestId('sidebar-menu')).toBeNull();
+    expect(screen.getByTestId('agent-sidebar')).toBeVisible();
+  });
+
+  it('persists navigation mode when the agent panel is closed', () => {
+    localStorage.setItem('sidebarMode', 'agent');
+    renderLayout('/cockpit');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close Agent' }));
+
+    expect(screen.getByTestId('sidebar-menu')).toBeVisible();
+    expect(localStorage.getItem('sidebarMode')).toBe('navigation');
+  });
+
+  it('falls back to navigation for invalid or unavailable agent mode', () => {
+    localStorage.setItem('sidebarMode', 'unknown');
+    const { unmount } = renderLayout('/cockpit');
+
+    expect(screen.getByTestId('sidebar-menu')).toBeVisible();
+    expect(screen.queryByTestId('agent-sidebar')).toBeNull();
+
+    unmount();
+    localStorage.setItem('sidebarMode', 'agent');
+    renderLayout('/cockpit', { agentEnabled: false });
+
+    expect(screen.getByTestId('sidebar-menu')).toBeVisible();
+    expect(screen.queryByTestId('agent-sidebar')).toBeNull();
+    expect(localStorage.getItem('sidebarMode')).toBe('navigation');
   });
 
   it('resizes the agent sidebar from the divider', () => {


### PR DESCRIPTION
## Summary
- add explicit append and insert operations to the agent patch tool
- make patch writes atomic and preserve existing file modes for edits
- update agent prompt/tool guidance so append is not modeled as replace
- show patch previews as proposed/applied/failed and keep tool calls collapsed by default

## Tests
- go test ./internal/agent
- pnpm vitest run src/features/agent/components/__tests__ src/features/agent/hooks/__tests__
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended patch operations with `append`, `insert_before`, and `insert_after` modes for more flexible file editing.
  * Added visual status indicators ("Proposed," "Applied," "Failed") to patch previews for better workflow visibility.
  * Enhanced patch preview display with line-count indicators and contextual anchors for insert operations.

* **Improvements**
  * Patch operations now preserve existing file permissions during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->