### PR TITLE
fix: harden mermaid graph rendering

### DIFF
--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -40,6 +40,16 @@ func notificationMonitorEventuallyTimeout(base time.Duration) time.Duration {
 	return base
 }
 
+func requireNotificationMonitorShutdown(t *testing.T, name string, done <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(notificationMonitorEventuallyTimeout(2 * time.Second)):
+		t.Fatalf("timed out waiting for %s shutdown", name)
+	}
+}
+
 func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvents(t *testing.T) {
 	t.Parallel()
 
@@ -233,16 +243,8 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 	defer func() {
 		cancel1()
 		cancel2()
-		select {
-		case <-done1:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for monitor-1 shutdown")
-		}
-		select {
-		case <-done2:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for monitor-2 shutdown")
-		}
+		requireNotificationMonitorShutdown(t, "monitor-1", done1)
+		requireNotificationMonitorShutdown(t, "monitor-2", done2)
 	}()
 
 	require.Eventually(t, func() bool {
@@ -299,11 +301,7 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 	switch firstOwner {
 	case "monitor-1":
 		cancel1()
-		select {
-		case <-done1:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for monitor-1 shutdown")
-		}
+		requireNotificationMonitorShutdown(t, "monitor-1", done1)
 		require.Eventually(t, func() bool {
 			monitor2.stateMu.Lock()
 			bootstrapped := monitor2.state.Bootstrapped
@@ -312,11 +310,7 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 		}, notificationMonitorEventuallyTimeout(2*time.Second), 10*time.Millisecond)
 	case "monitor-2":
 		cancel2()
-		select {
-		case <-done2:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for monitor-2 shutdown")
-		}
+		requireNotificationMonitorShutdown(t, "monitor-2", done2)
 		require.Eventually(t, func() bool {
 			monitor1.stateMu.Lock()
 			bootstrapped := monitor1.state.Bootstrapped
@@ -738,11 +732,7 @@ func TestNotificationMonitor_LockTheftSelfFencesActiveOwner(t *testing.T) {
 	}()
 	defer func() {
 		cancel()
-		select {
-		case <-done:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for monitor shutdown")
-		}
+		requireNotificationMonitorShutdown(t, "monitor", done)
 	}()
 
 	require.Eventually(t, func() bool {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1100,7 +1100,12 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 }
 
 func cacheControlForAsset(assetPath string) string {
-	if strings.HasSuffix(strings.ToLower(path.Base(assetPath)), ".js") {
+	base := path.Base(assetPath)
+	lowerBase := strings.ToLower(base)
+	if strings.HasSuffix(lowerBase, ".bundle.js") && !strings.EqualFold(base, "bundle.js") {
+		return "max-age=31536000, immutable"
+	}
+	if strings.HasSuffix(lowerBase, ".js") {
 		return "no-cache, no-store, must-revalidate"
 	}
 	return "max-age=86400"

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1078,7 +1078,7 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 	}
 
 	r.Get(assetsPath, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "max-age=86400")
+		w.Header().Set("Cache-Control", cacheControlForAsset(r.URL.Path))
 
 		// Serve schemas from shared package instead of embedded assets
 		if strings.HasSuffix(r.URL.Path, "dag.schema.json") {
@@ -1097,6 +1097,13 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 		}
 		fileServer.ServeHTTP(w, r)
 	})
+}
+
+func cacheControlForAsset(assetPath string) string {
+	if strings.HasSuffix(strings.ToLower(path.Base(assetPath)), ".js") {
+		return "no-cache, no-store, must-revalidate"
+	}
+	return "max-age=86400"
 }
 
 func (srv *Server) setupOIDCRoutes(r *chi.Mux, basePath string) {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -170,34 +170,16 @@ func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *t
 	}
 }
 
-func TestAssetRoutesDoNotCacheJavaScript(t *testing.T) {
+func TestCacheControlForAssetDisablesJavaScriptCaching(t *testing.T) {
 	t.Parallel()
 
-	r := chi.NewRouter()
-	srv := &Server{}
-	srv.setupAssetRoutes(r, "")
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/assets/bundle.js", nil)
-
-	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, "no-cache, no-store, must-revalidate", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/bundle.js"))
 }
 
-func TestAssetRoutesCacheNonJavaScriptAssets(t *testing.T) {
+func TestCacheControlForAssetCachesNonJavaScriptAssets(t *testing.T) {
 	t.Parallel()
 
-	r := chi.NewRouter()
-	srv := &Server{}
-	srv.setupAssetRoutes(r, "")
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/assets/favicon.ico", nil)
-
-	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, "max-age=86400", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "max-age=86400", cacheControlForAsset("/assets/favicon.ico"))
 }
 
 func TestInitBuiltinAuthService_AutoProvision(t *testing.T) {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -174,6 +174,17 @@ func TestCacheControlForAssetDisablesJavaScriptCaching(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/bundle.js"))
+	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/legacy.js"))
+}
+
+func TestCacheControlForAssetCachesContentHashedJavaScriptChunks(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		"max-age=31536000, immutable",
+		cacheControlForAsset("/assets/vendors.a1b2c3d4e5f6a1b2.bundle.js"),
+	)
 }
 
 func TestCacheControlForAssetCachesNonJavaScriptAssets(t *testing.T) {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -170,6 +170,36 @@ func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *t
 	}
 }
 
+func TestAssetRoutesDoNotCacheJavaScript(t *testing.T) {
+	t.Parallel()
+
+	r := chi.NewRouter()
+	srv := &Server{}
+	srv.setupAssetRoutes(r, "")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/assets/bundle.js", nil)
+
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, "no-cache, no-store, must-revalidate", rec.Header().Get("Cache-Control"))
+}
+
+func TestAssetRoutesCacheNonJavaScriptAssets(t *testing.T) {
+	t.Parallel()
+
+	r := chi.NewRouter()
+	srv := &Server{}
+	srv.setupAssetRoutes(r, "")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/assets/favicon.ico", nil)
+
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, "max-age=86400", rec.Header().Get("Cache-Control"))
+}
+
 func TestInitBuiltinAuthService_AutoProvision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/templates.go
+++ b/internal/service/frontend/templates.go
@@ -55,17 +55,12 @@ func formatAssetVersion(version string, bundle []byte) string {
 
 func currentAssetVersion() string {
 	assetVersionOnce.Do(func() {
-		switch config.Version {
-		case "", "0.0.0", "dev":
-			data, err := assetsFS.ReadFile("assets/bundle.js")
-			if err != nil {
-				assetVersion = config.Version
-				return
-			}
-			assetVersion = formatAssetVersion(config.Version, data)
-		default:
+		data, err := assetsFS.ReadFile("assets/bundle.js")
+		if err != nil {
 			assetVersion = config.Version
+			return
 		}
+		assetVersion = formatAssetVersion(config.Version, data)
 	})
 	return assetVersion
 }

--- a/internal/service/frontend/templates_test.go
+++ b/internal/service/frontend/templates_test.go
@@ -70,7 +70,7 @@ func TestFormatAssetVersionSupportsEmptyVersion(t *testing.T) {
 	assert.Equal(t, want, formatAssetVersion("", bundle))
 }
 
-func TestCurrentAssetVersionUsesReleaseVersionWhenSet(t *testing.T) {
+func TestCurrentAssetVersionUsesReleaseVersionAndBundleHashWhenSet(t *testing.T) {
 	originalVersion := config.Version
 	t.Cleanup(func() {
 		config.Version = originalVersion
@@ -80,7 +80,13 @@ func TestCurrentAssetVersionUsesReleaseVersionWhenSet(t *testing.T) {
 	config.Version = "1.2.3"
 	resetAssetVersionCache()
 
-	assert.Equal(t, "1.2.3", currentAssetVersion())
+	data, err := assetsFS.ReadFile("assets/bundle.js")
+	if err != nil {
+		assert.Equal(t, "1.2.3", currentAssetVersion())
+		return
+	}
+
+	assert.Equal(t, formatAssetVersion("1.2.3", data), currentAssetVersion())
 }
 
 func TestDefaultFunctionsExposeInitialWorkspacesJSON(t *testing.T) {

--- a/ui/src/__tests__/webpack.prod.test.ts
+++ b/ui/src/__tests__/webpack.prod.test.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/ui/src/__tests__/webpack.prod.test.ts
+++ b/ui/src/__tests__/webpack.prod.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webpackProdConfigSource = readFileSync(
+  resolve(__dirname, '../../webpack.prod.js'),
+  'utf8'
+);
+
+describe('webpack production assets', () => {
+  it('uses stable entry and content-hashed lazy chunk filenames', () => {
+    expect(webpackProdConfigSource).toContain("filename: 'bundle.js'");
+    expect(webpackProdConfigSource).toContain(
+      "chunkFilename: '[name].[contenthash:16].bundle.js'"
+    );
+    expect(webpackProdConfigSource).not.toContain('bundle.js?v=0.0.0');
+  });
+});

--- a/ui/src/components/ui/__tests__/mermaid.test.tsx
+++ b/ui/src/components/ui/__tests__/mermaid.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Mermaid from '../mermaid';
+
+type RenderResult = {
+  svg: string;
+  bindFunctions?: (element: Element) => void;
+};
+
+type PendingRender = {
+  def: string;
+  resolve: (value: RenderResult) => void;
+  reject: (error: unknown) => void;
+};
+
+const mermaidRenderMock = vi.hoisted(() => vi.fn());
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: mermaidRenderMock,
+  },
+}));
+
+describe('Mermaid', () => {
+  let pendingRenders: PendingRender[];
+
+  function pendingRenderAt(index: number): PendingRender {
+    const pendingRender = pendingRenders[index];
+    if (!pendingRender) {
+      throw new Error(`Missing pending render at index ${index}`);
+    }
+    return pendingRender;
+  }
+
+  beforeEach(() => {
+    pendingRenders = [];
+    mermaidRenderMock.mockReset();
+    mermaidRenderMock.mockImplementation(
+      (_id: string, def: string) =>
+        new Promise<RenderResult>((resolve, reject) => {
+          pendingRenders.push({ def, resolve, reject });
+        })
+    );
+  });
+
+  it('ignores stale render results after a newer definition renders', async () => {
+    const { container, rerender } = render(
+      <Mermaid def="graph TD; A-->B;" scale={1} />
+    );
+
+    await waitFor(() => expect(pendingRenders).toHaveLength(1));
+    rerender(<Mermaid def="graph TD; C-->D;" scale={1} />);
+    await waitFor(() => expect(pendingRenders).toHaveLength(2));
+
+    await act(async () => {
+      pendingRenderAt(1).resolve({ svg: '<svg data-def="newer"></svg>' });
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('svg[data-def="newer"]')).not.toBeNull();
+    });
+
+    await act(async () => {
+      pendingRenderAt(0).resolve({ svg: '<svg data-def="stale"></svg>' });
+    });
+
+    expect(container.querySelector('svg[data-def="newer"]')).not.toBeNull();
+    expect(container.querySelector('svg[data-def="stale"]')).toBeNull();
+  });
+
+  it('ignores stale render errors after a newer definition renders', async () => {
+    const { rerender } = render(
+      <Mermaid
+        def="graph TD; A-->B;"
+        fallback={<div>Fallback graph</div>}
+        scale={1}
+      />
+    );
+
+    await waitFor(() => expect(pendingRenders).toHaveLength(1));
+    rerender(
+      <Mermaid
+        def="graph TD; C-->D;"
+        fallback={<div>Fallback graph</div>}
+        scale={1}
+      />
+    );
+    await waitFor(() => expect(pendingRenders).toHaveLength(2));
+
+    await act(async () => {
+      pendingRenderAt(1).resolve({ svg: '<svg data-def="newer"></svg>' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Fallback graph')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      pendingRenderAt(0).reject(new Error('stale failure'));
+    });
+
+    expect(screen.queryByText('Fallback graph')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/mermaid.tsx
+++ b/ui/src/components/ui/mermaid.tsx
@@ -96,6 +96,7 @@ function Mermaid({
   const scrollContainerRef = React.useRef<HTMLDivElement>(null); // Ref for the outer scrollable div
   const scrollPosRef = React.useRef({ top: 0, left: 0 }); // Ref to store scroll position
   const handlersRef = React.useRef({ onClick, onDoubleClick, onRightClick });
+  const renderGenerationRef = React.useRef(0);
   const clickTimeoutsRef = React.useRef<
     Map<string, ReturnType<typeof setTimeout>>
   >(new Map()); // Persistent timeout storage
@@ -131,6 +132,7 @@ function Mermaid({
   }, [onClick, onDoubleClick, onRightClick]);
 
   const render = async () => {
+    const renderGeneration = ++renderGenerationRef.current;
     if (!mermaidRef.current) {
       return;
     }
@@ -150,113 +152,128 @@ function Mermaid({
       // Generate SVG
       const { svg, bindFunctions } = await mermaid.render(uniqueId, def);
 
-      if (mermaidRef.current) {
-        mermaidRef.current.innerHTML = svg;
-
-        // Apply scale transform immediately after SVG is rendered
-        const svgEl = mermaidRef.current.querySelector('svg');
-        if (svgEl) {
-          svgEl.style.overflow = 'visible';
-          svgEl.style.transform = `scale(${scale})`;
-          svgEl.style.transformOrigin = 'top left';
-
-          // Adjust the SVG's wrapper div to account for the scale
-          // This ensures the horizontal scrollbar properly reflects the scaled size
-          const parent = svgEl.parentElement;
-          if (parent && scale !== 1) {
-            const bbox = svgEl.getBBox();
-            parent.style.width = `${bbox.width * scale}px`;
-            parent.style.height = `${bbox.height * scale}px`;
-          } else if (parent && scale === 1) {
-            // Reset to auto when scale is 1
-            parent.style.width = 'auto';
-            parent.style.height = 'auto';
-          }
-        }
-
-        // Restore scroll position *after* SVG is rendered
-        if (scrollContainerRef.current) {
-          scrollContainerRef.current.scrollTop = scrollPosRef.current.top;
-          scrollContainerRef.current.scrollLeft = scrollPosRef.current.left;
-        }
-
-        // Attach custom event handlers if provided
-        if ((onClick || onDoubleClick || onRightClick) && mermaidRef.current) {
-          // Clear existing timeouts before setting up new handlers
-          clickTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
-          clickTimeoutsRef.current.clear();
-
-          // Find all nodes in the SVG (typically these are <g> elements with class="node")
-          const nodeElements = mermaidRef.current.querySelectorAll('.node');
-
-          nodeElements.forEach((node) => {
-            // Extract the node ID from the element
-            // The ID is typically in the format "flowchart-nodeId-number"
-            const nodeId = node.id.split('-')[1];
-
-            if (nodeId) {
-              // Attach single-click event listener if provided
-              if (onClick) {
-                node.addEventListener('click', () => {
-                  // Clear any existing timeout for this node
-                  const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                  if (existingTimeout) {
-                    clearTimeout(existingTimeout);
-                  }
-                  // Set timeout to allow double-click to cancel
-                  const timeout = setTimeout(() => {
-                    clickTimeoutsRef.current.delete(nodeId);
-                    handlersRef.current.onClick?.(nodeId);
-                  }, 250);
-                  clickTimeoutsRef.current.set(nodeId, timeout);
-                });
-              }
-
-              // Attach double-click event listener if provided
-              if (onDoubleClick) {
-                node.addEventListener('dblclick', (event) => {
-                  event.stopPropagation();
-                  // Cancel pending single-click action
-                  const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                  if (existingTimeout) {
-                    clearTimeout(existingTimeout);
-                    clickTimeoutsRef.current.delete(nodeId);
-                  }
-                  handlersRef.current.onDoubleClick?.(nodeId);
-                });
-              }
-
-              // Attach right-click (contextmenu) event listener if provided
-              if (onRightClick) {
-                node.addEventListener('contextmenu', (event) => {
-                  event.preventDefault(); // Prevent default context menu
-                  // Also cancel pending single-click
-                  const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                  if (existingTimeout) {
-                    clearTimeout(existingTimeout);
-                    clickTimeoutsRef.current.delete(nodeId);
-                  }
-                  handlersRef.current.onRightClick?.(nodeId);
-                });
-              }
-
-              // Add pointer cursor and disable text selection
-              const nodeElement = node as HTMLElement;
-              nodeElement.style.cursor = 'pointer';
-              nodeElement.style.userSelect = 'none';
-            }
-          });
-        }
-
-        // Bind standard Mermaid event handlers
-        // This is still needed for other functionality
-        setTimeout(() => {
-          if (mermaidRef.current && bindFunctions) {
-            bindFunctions(mermaidRef.current);
-          }
-        }, 100); // Reduced timeout slightly
+      if (
+        renderGeneration !== renderGenerationRef.current ||
+        !mermaidRef.current
+      ) {
+        return;
       }
+
+      mermaidRef.current.innerHTML = svg;
+
+      // Apply scale transform immediately after SVG is rendered
+      const svgEl = mermaidRef.current.querySelector('svg');
+      if (svgEl) {
+        svgEl.style.overflow = 'visible';
+        svgEl.style.transform = `scale(${scale})`;
+        svgEl.style.transformOrigin = 'top left';
+
+        // Adjust the SVG's wrapper div to account for the scale
+        // This ensures the horizontal scrollbar properly reflects the scaled size
+        const parent = svgEl.parentElement;
+        if (parent && scale !== 1) {
+          const bbox = svgEl.getBBox();
+          parent.style.width = `${bbox.width * scale}px`;
+          parent.style.height = `${bbox.height * scale}px`;
+        } else if (parent && scale === 1) {
+          // Reset to auto when scale is 1
+          parent.style.width = 'auto';
+          parent.style.height = 'auto';
+        }
+      }
+
+      // Restore scroll position *after* SVG is rendered
+      if (scrollContainerRef.current) {
+        scrollContainerRef.current.scrollTop = scrollPosRef.current.top;
+        scrollContainerRef.current.scrollLeft = scrollPosRef.current.left;
+      }
+
+      // Attach custom event handlers if provided
+      if ((onClick || onDoubleClick || onRightClick) && mermaidRef.current) {
+        // Clear existing timeouts before setting up new handlers
+        clickTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
+        clickTimeoutsRef.current.clear();
+
+        // Find all nodes in the SVG (typically these are <g> elements with class="node")
+        const nodeElements = mermaidRef.current.querySelectorAll('.node');
+
+        nodeElements.forEach((node) => {
+          // Extract the node ID from the element
+          // The ID is typically in the format "flowchart-nodeId-number"
+          const nodeId = node.id.split('-')[1];
+
+          if (nodeId) {
+            // Attach single-click event listener if provided
+            if (onClick) {
+              node.addEventListener('click', () => {
+                // Clear any existing timeout for this node
+                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
+                if (existingTimeout) {
+                  clearTimeout(existingTimeout);
+                }
+                // Set timeout to allow double-click to cancel
+                const timeout = setTimeout(() => {
+                  clickTimeoutsRef.current.delete(nodeId);
+                  handlersRef.current.onClick?.(nodeId);
+                }, 250);
+                clickTimeoutsRef.current.set(nodeId, timeout);
+              });
+            }
+
+            // Attach double-click event listener if provided
+            if (onDoubleClick) {
+              node.addEventListener('dblclick', (event) => {
+                event.stopPropagation();
+                // Cancel pending single-click action
+                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
+                if (existingTimeout) {
+                  clearTimeout(existingTimeout);
+                  clickTimeoutsRef.current.delete(nodeId);
+                }
+                handlersRef.current.onDoubleClick?.(nodeId);
+              });
+            }
+
+            // Attach right-click (contextmenu) event listener if provided
+            if (onRightClick) {
+              node.addEventListener('contextmenu', (event) => {
+                event.preventDefault(); // Prevent default context menu
+                // Also cancel pending single-click
+                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
+                if (existingTimeout) {
+                  clearTimeout(existingTimeout);
+                  clickTimeoutsRef.current.delete(nodeId);
+                }
+                handlersRef.current.onRightClick?.(nodeId);
+              });
+            }
+
+            // Add pointer cursor and disable text selection
+            const nodeElement = node as HTMLElement;
+            nodeElement.style.cursor = 'pointer';
+            nodeElement.style.userSelect = 'none';
+          }
+        });
+      }
+
+      // Bind standard Mermaid event handlers
+      // This is still needed for other functionality
+      setTimeout(() => {
+        if (
+          renderGeneration === renderGenerationRef.current &&
+          mermaidRef.current &&
+          bindFunctions
+        ) {
+          bindFunctions(mermaidRef.current);
+        }
+      }, 100); // Reduced timeout slightly
     } catch (error: unknown) {
+      if (
+        renderGeneration !== renderGenerationRef.current ||
+        !mermaidRef.current
+      ) {
+        return;
+      }
       console.error('Mermaid render error:', error);
       setRenderError(String(error));
       if (mermaidRef.current) {

--- a/ui/src/components/ui/mermaid.tsx
+++ b/ui/src/components/ui/mermaid.tsx
@@ -8,6 +8,7 @@ type Props = {
   onClick?: (id: string) => void;
   onDoubleClick?: (id: string) => void;
   onRightClick?: (id: string) => void;
+  fallback?: React.ReactNode;
 };
 
 // Helper function to get computed CSS variable value with fallback
@@ -89,6 +90,7 @@ function Mermaid({
   onClick,
   onDoubleClick,
   onRightClick,
+  fallback,
 }: Props) {
   const mermaidRef = React.useRef<HTMLDivElement>(null); // Ref for the inner div holding the SVG
   const scrollContainerRef = React.useRef<HTMLDivElement>(null); // Ref for the outer scrollable div
@@ -100,6 +102,7 @@ function Mermaid({
   const [uniqueId] = React.useState(
     () => `mermaid-${Math.random().toString(36).substr(2, 9)}`
   );
+  const [renderError, setRenderError] = React.useState<string | null>(null);
 
   // Extract background-related styles for the scroll container
   const { background, backgroundSize, backgroundColor, ...contentStyle } =
@@ -137,6 +140,7 @@ function Mermaid({
     }
 
     try {
+      setRenderError(null);
       // Reinitialize Mermaid to pick up current theme
       initializeMermaid();
 
@@ -254,12 +258,9 @@ function Mermaid({
       }
     } catch (error: unknown) {
       console.error('Mermaid render error:', error);
+      setRenderError(String(error));
       if (mermaidRef.current) {
-        mermaidRef.current.innerHTML = `
-          <div style="color: red; padding: 10px; white-space: pre-wrap;">
-            Error rendering diagram: ${String(error)}
-          </div>
-        `;
+        mermaidRef.current.innerHTML = '';
       }
     }
   };
@@ -317,11 +318,13 @@ function Mermaid({
         ref={mermaidRef} // Keep ref for mermaid rendering target
         style={{
           ...mStyle,
+          display: renderError ? 'none' : mStyle.display,
           // Remove overflow from inner div, let outer div handle it
           // overflow: 'auto',
           // maxHeight: '80vh', // Max height is now on the outer div
         }}
       />
+      {renderError && fallback}
     </div>
   );
 }

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/api/v1/schema';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { useClient } from '@/hooks/api';
+import { toMermaidNodeId } from '@/lib/utils';
 import { DAGContext } from '../../contexts/DAGContext';
 import DAGStatus from '../DAGStatus';
 
@@ -54,10 +55,16 @@ vi.mock('../visualization', () => ({
   }) => (
     <div>
       <div>Graph status: {steps?.[0]?.status}</div>
-      <button type="button" onClick={() => onClickNode?.('step')}>
+      <button
+        type="button"
+        onClick={() => onClickNode?.(toMermaidNodeId('step'))}
+      >
         Open step details
       </button>
-      <button type="button" onClick={() => onRightClickNode?.('step')}>
+      <button
+        type="button"
+        onClick={() => onRightClickNode?.(toMermaidNodeId('step'))}
+      >
         Open status modal
       </button>
     </div>

--- a/ui/src/features/dags/components/visualization/Graph.tsx
+++ b/ui/src/features/dags/components/visualization/Graph.tsx
@@ -204,10 +204,13 @@ function Graph({
       const id = toMermaidNodeId(step.name);
       const c = graphStatusMap[status] || '';
 
-      // Check if this is a sub dagRun node (has a call property)
-      const subDAGName = step.call;
+      const subRuns = [
+        ...(node?.subRuns ?? []),
+        ...(node?.subRunsRepeated ?? []),
+      ];
+      const subDAGName = step.call || subRuns[0]?.dagName;
       // Check if this is a sub dagRun node (has a 'run' property)
-      const isSubDAGRun = !!step.call;
+      const isSubDAGRun = !!subDAGName;
       const hasParallelExecutions = !!step.parallel;
       // Check if this is a router step
       const isRouterStep =
@@ -217,12 +220,12 @@ function Graph({
       // Escape any special characters in the label to prevent Mermaid parsing errors
       let label = step.id || step.name;
       if (isSubDAGRun && subDAGName) {
-        if (hasParallelExecutions && node?.subRuns) {
+        if (hasParallelExecutions && subRuns.length > 0) {
           // Show parallel execution count in the label - avoid brackets in stadium nodes
-          label = `${step.name} → ${subDAGName} x${node.subRuns.length}`;
+          label = `${step.name} -> ${subDAGName} x${subRuns.length}`;
         } else {
           // Single sub DAG run
-          label = `${step.name} → ${subDAGName}`;
+          label = `${step.name} -> ${subDAGName}`;
         }
       }
 
@@ -458,6 +461,15 @@ function Graph({
           onClick={selectOnClick ? onClickNode : undefined}
           onDoubleClick={onDoubleClickNode ?? onClickNode}
           onRightClick={onRightClickNode}
+          fallback={
+            <GraphFallback
+              steps={steps}
+              selectOnClick={selectOnClick}
+              onClickNode={onClickNode}
+              onDoubleClickNode={onDoubleClickNode ?? onClickNode}
+              onRightClickNode={onRightClickNode}
+            />
+          }
         />
       </div>
 
@@ -489,6 +501,256 @@ function Graph({
       )}
     </div>
   );
+}
+
+function isRuntimeNode(
+  stepOrNode: components['schemas']['Step'] | components['schemas']['Node']
+): stepOrNode is components['schemas']['Node'] {
+  return 'step' in stepOrNode;
+}
+
+function getStepLabel(
+  step: components['schemas']['Step'],
+  node?: components['schemas']['Node']
+): string {
+  const subRuns = [...(node?.subRuns ?? []), ...(node?.subRunsRepeated ?? [])];
+  const subDAGName = step.call || subRuns[0]?.dagName;
+  const hasParallelExecutions = !!step.parallel;
+
+  if (!subDAGName) {
+    return step.id || step.name;
+  }
+  if (hasParallelExecutions && subRuns.length > 0) {
+    return `${step.name} -> ${subDAGName} x${subRuns.length}`;
+  }
+  return `${step.name} -> ${subDAGName}`;
+}
+
+type FallbackNode = {
+  id: string;
+  name: string;
+  label: string;
+  depends: string[];
+  status: NodeStatus;
+};
+
+type GraphFallbackProps = {
+  steps?: Steps;
+  selectOnClick: boolean;
+  onClickNode?: onClickNode;
+  onDoubleClickNode?: onClickNode;
+  onRightClickNode?: onRightClickNode;
+};
+
+function GraphFallback({
+  steps,
+  selectOnClick,
+  onClickNode,
+  onDoubleClickNode,
+  onRightClickNode,
+}: GraphFallbackProps): React.JSX.Element | null {
+  const clickTimeoutsRef = React.useRef<
+    Map<string, ReturnType<typeof setTimeout>>
+  >(new Map());
+
+  React.useEffect(() => {
+    return () => {
+      clickTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
+      clickTimeoutsRef.current.clear();
+    };
+  }, []);
+
+  const nodes = React.useMemo<FallbackNode[]>(() => {
+    return (steps ?? []).map((stepOrNode) => {
+      const node = isRuntimeNode(stepOrNode) ? stepOrNode : undefined;
+      const step = isRuntimeNode(stepOrNode) ? stepOrNode.step : stepOrNode;
+      return {
+        id: toMermaidNodeId(step.name),
+        name: step.name,
+        label: getStepLabel(step, node),
+        depends: step.depends ?? [],
+        status: node?.status ?? NodeStatus.NotStarted,
+      };
+    });
+  }, [steps]);
+
+  const handleClick = React.useCallback(
+    (id: string) => {
+      if (!selectOnClick || !onClickNode) {
+        return;
+      }
+      const existingTimeout = clickTimeoutsRef.current.get(id);
+      if (existingTimeout) {
+        clearTimeout(existingTimeout);
+      }
+      const timeout = setTimeout(() => {
+        clickTimeoutsRef.current.delete(id);
+        onClickNode(id);
+      }, 250);
+      clickTimeoutsRef.current.set(id, timeout);
+    },
+    [onClickNode, selectOnClick]
+  );
+
+  const handleDoubleClick = React.useCallback(
+    (id: string) => {
+      const existingTimeout = clickTimeoutsRef.current.get(id);
+      if (existingTimeout) {
+        clearTimeout(existingTimeout);
+        clickTimeoutsRef.current.delete(id);
+      }
+      onDoubleClickNode?.(id);
+    },
+    [onDoubleClickNode]
+  );
+
+  const handleRightClick = React.useCallback(
+    (event: React.MouseEvent, id: string) => {
+      if (!onRightClickNode) {
+        return;
+      }
+      event.preventDefault();
+      const existingTimeout = clickTimeoutsRef.current.get(id);
+      if (existingTimeout) {
+        clearTimeout(existingTimeout);
+        clickTimeoutsRef.current.delete(id);
+      }
+      onRightClickNode(id);
+    },
+    [onRightClickNode]
+  );
+
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  const hasInteraction =
+    (selectOnClick && !!onClickNode) ||
+    !!onDoubleClickNode ||
+    !!onRightClickNode;
+
+  return (
+    <div
+      aria-label="Workflow graph"
+      className="min-w-full p-6 pr-24"
+      data-testid="graph-fallback"
+      role="list"
+    >
+      <div className="flex flex-wrap items-start gap-3">
+        {nodes.map((node) => (
+          <div key={node.id} role="listitem">
+            {hasInteraction ? (
+              <button
+                aria-label={`Inspect ${node.name}`}
+                className={fallbackNodeClassName(node.status, true)}
+                onClick={() => handleClick(node.id)}
+                onContextMenu={(event) => handleRightClick(event, node.id)}
+                onDoubleClick={() => handleDoubleClick(node.id)}
+                title={node.name}
+                type="button"
+              >
+                <FallbackNodeContent node={node} />
+              </button>
+            ) : (
+              <div
+                className={fallbackNodeClassName(node.status, false)}
+                title={node.name}
+              >
+                <FallbackNodeContent node={node} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FallbackNodeContent({ node }: { node: FallbackNode }) {
+  const visibleDepends = node.depends.slice(0, 2);
+  const hiddenDepends = node.depends.length - visibleDepends.length;
+
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className={cn(
+          'h-2.5 w-2.5 flex-shrink-0 rounded-full',
+          fallbackStatusDotClassName(node.status)
+        )}
+      />
+      <span className="min-w-0 flex-1 truncate font-medium">{node.label}</span>
+      {visibleDepends.length > 0 && (
+        <span className="flex min-w-0 max-w-full flex-wrap gap-1">
+          {visibleDepends.map((dep) => (
+            <span
+              className="max-w-28 truncate rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              key={dep}
+              title={dep}
+            >
+              {dep}
+            </span>
+          ))}
+          {hiddenDepends > 0 && (
+            <span className="rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              +{hiddenDepends}
+            </span>
+          )}
+        </span>
+      )}
+    </>
+  );
+}
+
+function fallbackNodeClassName(
+  status: NodeStatus,
+  interactive: boolean
+): string {
+  return cn(
+    'flex min-h-12 w-72 max-w-72 items-center gap-2 rounded-md border bg-card px-3 py-2 text-left text-sm shadow-sm',
+    fallbackStatusBorderClassName(status),
+    interactive &&
+      'cursor-pointer transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary'
+  );
+}
+
+function fallbackStatusBorderClassName(status: NodeStatus): string {
+  switch (status) {
+    case NodeStatus.Success:
+    case NodeStatus.Running:
+      return 'border-l-4 border-l-success';
+    case NodeStatus.Retrying:
+    case NodeStatus.Waiting:
+    case NodeStatus.PartialSuccess:
+      return 'border-l-4 border-l-warning';
+    case NodeStatus.Failed:
+    case NodeStatus.Rejected:
+      return 'border-l-4 border-l-destructive';
+    case NodeStatus.Aborted:
+      return 'border-l-4 border-l-primary';
+    default:
+      return 'border-l-4 border-l-muted-foreground/60';
+  }
+}
+
+function fallbackStatusDotClassName(status: NodeStatus): string {
+  switch (status) {
+    case NodeStatus.Success:
+      return 'bg-success';
+    case NodeStatus.Running:
+      return 'bg-success animate-pulse';
+    case NodeStatus.Retrying:
+    case NodeStatus.Waiting:
+    case NodeStatus.PartialSuccess:
+      return 'bg-warning';
+    case NodeStatus.Failed:
+    case NodeStatus.Rejected:
+      return 'bg-destructive';
+    case NodeStatus.Aborted:
+      return 'bg-primary';
+    default:
+      return 'bg-muted-foreground/60';
+  }
 }
 
 /**

--- a/ui/src/features/dags/components/visualization/Graph.tsx
+++ b/ui/src/features/dags/components/visualization/Graph.tsx
@@ -679,12 +679,14 @@ function FallbackNodeContent({ node }: { node: FallbackNode }) {
           fallbackStatusDotClassName(node.status)
         )}
       />
-      <span className="min-w-0 flex-1 truncate font-medium">{node.label}</span>
+      <span className="min-w-0 flex-1 whitespace-normal break-words font-medium">
+        {node.label}
+      </span>
       {visibleDepends.length > 0 && (
         <span className="flex min-w-0 max-w-full flex-wrap gap-1">
           {visibleDepends.map((dep) => (
             <span
-              className="max-w-28 truncate rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              className="max-w-28 whitespace-normal break-words rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
               key={dep}
               title={dep}
             >
@@ -692,7 +694,7 @@ function FallbackNodeContent({ node }: { node: FallbackNode }) {
             </span>
           ))}
           {hiddenDepends > 0 && (
-            <span className="rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            <span className="whitespace-normal break-words rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground">
               +{hiddenDepends}
             </span>
           )}

--- a/ui/src/features/dags/components/visualization/__tests__/Graph.test.tsx
+++ b/ui/src/features/dags/components/visualization/__tests__/Graph.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { components, NodeStatus, NodeStatusLabel } from '@/api/v1/schema';
+import { toMermaidNodeId } from '@/lib/utils';
+import Graph from '../Graph';
+
+const mermaidRenderMock = vi.hoisted(() => vi.fn());
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: mermaidRenderMock,
+  },
+}));
+
+vi.mock('@/contexts/UserPreference', () => ({
+  useUserPreferences: () => ({ preferences: { theme: 'light' } }),
+}));
+
+function node(
+  name: string,
+  status: NodeStatus,
+  depends?: string[]
+): components['schemas']['Node'] {
+  return {
+    step: { name, depends },
+    stdout: '',
+    stderr: '',
+    startedAt: '',
+    finishedAt: '',
+    status,
+    statusLabel: NodeStatusLabel.not_started,
+    retryCount: 0,
+    doneCount: 0,
+  };
+}
+
+describe('Graph', () => {
+  it('renders an interactive fallback when Mermaid rendering fails', async () => {
+    mermaidRenderMock.mockRejectedValueOnce(new TypeError('render exploded'));
+    const onClickNode = vi.fn();
+
+    render(
+      <Graph
+        type="status"
+        steps={[
+          node('extract (source)', NodeStatus.Success),
+          node('load:warehouse', NodeStatus.NotStarted, ['extract (source)']),
+        ]}
+        onClickNode={onClickNode}
+        selectOnClick
+      />
+    );
+
+    const fallback = await screen.findByTestId('graph-fallback');
+    expect(fallback).toHaveTextContent('extract (source)');
+    expect(fallback).toHaveTextContent('load:warehouse');
+    expect(
+      screen.queryByText(/Error rendering diagram/i)
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /inspect extract \(source\)/i })
+    );
+
+    await waitFor(() => {
+      expect(onClickNode).toHaveBeenCalledWith(
+        toMermaidNodeId('extract (source)')
+      );
+    });
+  });
+});

--- a/ui/src/lib/__tests__/utils.test.ts
+++ b/ui/src/lib/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ describe('toMermaidNodeId', () => {
     expect(toMermaidNodeId('extract (source)')).toBe(
       'node_65_78_74_72_61_63_74_20_28_73_6f_75_72_63_65_29'
     );
+    expect(toMermaidNodeId('a🚀')).toBe('node_61_1f680');
     expect(toMermaidNodeId('')).toBe('node_empty');
   });
 

--- a/ui/src/lib/__tests__/utils.test.ts
+++ b/ui/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import { toMermaidNodeId } from '../utils';
+
+describe('toMermaidNodeId', () => {
+  it('always returns a prefixed Mermaid-safe ID', () => {
+    expect(toMermaidNodeId('end')).toBe('node_65_6e_64');
+    expect(toMermaidNodeId('extract (source)')).toBe(
+      'node_65_78_74_72_61_63_74_20_28_73_6f_75_72_63_65_29'
+    );
+    expect(toMermaidNodeId('')).toBe('node_empty');
+  });
+
+  it('does not collide raw encoded-looking names with names that need encoding', () => {
+    expect(toMermaidNodeId('a-b')).not.toBe(toMermaidNodeId('au2d_b'));
+  });
+});

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -30,15 +30,14 @@ export function parseLabelParts(label: string): {
 export const parseTagParts = parseLabelParts;
 
 /**
- * Converts a step name to a valid Mermaid node ID by encoding
- * all non-ASCII-alphanumeric characters (including emojis, CJK characters,
- * and other Unicode) that could break Mermaid syntax.
- * Each character is encoded as its hex code point delimited by underscores
- * (e.g., 'ス' → 'u30b9_') to produce deterministic, collision-free IDs.
+ * Converts a step name to a deterministic Mermaid node ID by encoding every
+ * code point and adding a safe prefix. This avoids reserved Mermaid words,
+ * syntax-sensitive leading characters, and collisions between raw and encoded
+ * step names.
  */
 export function toMermaidNodeId(stepName: string): string {
-  return stepName.replace(
-    /[^a-zA-Z0-9_]/gu,
-    (ch) => `u${ch.codePointAt(0)!.toString(16)}_`
-  );
+  const encoded = Array.from(stepName)
+    .map((ch) => ch.codePointAt(0)!.toString(16))
+    .join('_');
+  return `node_${encoded || 'empty'}`;
 }

--- a/ui/webpack.prod.js
+++ b/ui/webpack.prod.js
@@ -49,7 +49,8 @@ module.exports = merge(common, {
     }),
   ],
   output: {
-    filename: 'bundle.js?v=0.0.0', // Add version query to prevent caching issues
+    filename: 'bundle.js',
+    chunkFilename: '[name].[contenthash:16].bundle.js',
     path: path.resolve(__dirname, 'dist'),
     publicPath: 'auto',
     clean: true,


### PR DESCRIPTION
## Summary
- prevent stale frontend JS chunks from breaking Mermaid after upgrades by hashing lazy chunks and disabling JS asset caching
- render an interactive fallback graph when Mermaid throws instead of showing a raw render error
- harden Mermaid node IDs and sub-DAG labels against syntax and reserved-word edge cases

## Testing
- pnpm vitest run src/lib/__tests__/utils.test.ts src/features/dags/components/visualization/__tests__/Graph.test.tsx src/__tests__/webpack.prod.test.ts
- pnpm typecheck
- pnpm build
- go test ./internal/service/frontend -count=1

Closes #2121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fallback UI for diagram rendering failures, displaying workflow steps when visualization encounters errors.

* **Bug Fixes**
  * Improved asset caching strategy: JavaScript bundles now use stricter no-cache headers while other assets benefit from longer cache periods.

* **Improvements**
  * Enhanced asset versioning system with content-hash based caching for better performance and reliability.
  * Improved diagram node ID generation for more stable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->