### PR TITLE
docs: add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Dagu
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Create a DAG with '...'
+2. Run the workflow with '...'
+3. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+What actually happened, including any error messages or logs.
+
+## Environment
+
+- Dagu version: [e.g. 1.12.0]
+- OS: [e.g. Ubuntu 24.04, macOS 15, Windows 11]
+- Go version: [e.g. 1.22]
+- Installation method: [binary / Docker / Homebrew / go install]
+
+## DAG configuration
+
+If applicable, paste the relevant DAG YAML (redact any sensitive information):
+
+```yaml
+
+```
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest an idea for Dagu
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+
+A clear and concise description of what the problem is. Ex. "I'm frustrated when..."
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you have considered.
+
+## Use case
+
+Describe the use case that motivates this feature request.
+
+## Additional context
+
+Add any other context, screenshots, or DAG examples about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+Brief description of the changes in this PR.
+
+## Changes
+
+- List the changes made
+- One item per line
+
+## Related Issues
+
+Closes #issue_number (if applicable)
+
+## Checklist
+
+- [ ] Code follows the project style guidelines
+- [ ] Self-review of the code has been performed
+- [ ] Tests have been added or updated as needed
+- [ ] Documentation has been updated as needed
+- [ ] Changes have been tested locally


### PR DESCRIPTION
## Summary

Add GitHub issue templates (bug report, feature request) and a pull request template to improve contributor onboarding.

## Changes

- Add `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report with environment details, DAG config, and reproduction steps
- Add `.github/ISSUE_TEMPLATE/feature_request.md` — feature request with use case and alternatives sections
- Add `.github/pull_request_template.md` — PR checklist aligned with CONTRIBUTING.md guidelines

## Motivation

Dagu has 3,300+ stars but lacked standard GitHub community health files. These templates:

- Guide bug reporters to include OS, Dagu version, Go version, installation method, and DAG YAML
- Guide feature requesters through structured use-case descriptions
- Remind PR authors of the checklist from CONTRIBUTING.md
- Reduce back-and-forth on issues by collecting key information upfront

## Related

No open issues for this, but follows community health best practices for open-source projects.

## Checklist

- [x] Templates follow GitHub-flavored Markdown conventions
- [x] Bug report template includes environment section matching Dagu's supported platforms
- [x] PR template references existing CONTRIBUTING.md guidelines
- [x] No existing conflicting PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized templates for bug reports, feature requests, and pull requests to provide clear guidelines for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->