### PR TITLE
fix: clean command process groups on parent death

### DIFF
--- a/internal/cmn/cmdutil/parent_exit_watcher_unix.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_unix.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package cmdutil
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const parentExitWatcherOK = "ok"
+
+// StartParentExitWatcher starts a small watchdog process that kills cmd's
+// process group if this parent process dies before the returned stop function
+// sends a normal-shutdown token.
+func StartParentExitWatcher(cmd *exec.Cmd) (func(), error) {
+	if cmd == nil || cmd.Process == nil {
+		return func() {}, nil
+	}
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	const script = `if IFS= read -r line <&3 && [ "$line" = "` + parentExitWatcherOK + `" ]; then exit 0; fi; kill -KILL -"$1" 2>/dev/null; exit 0`
+	watcher := exec.Command("/bin/sh", "-c", script, "dagu-parent-exit-watcher", strconv.Itoa(cmd.Process.Pid)) //nolint:gosec
+	watcher.ExtraFiles = []*os.File{readPipe}
+	setupCommand(watcher)
+
+	if err := watcher.Start(); err != nil {
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		return nil, err
+	}
+	_ = readPipe.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- watcher.Wait()
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_, _ = writePipe.WriteString(parentExitWatcherOK + "\n")
+			_ = writePipe.Close()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				_ = KillProcessGroup(watcher, os.Kill)
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+				}
+			}
+		})
+	}, nil
+}

--- a/internal/cmn/cmdutil/parent_exit_watcher_windows.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_windows.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmdutil
+
+import "os/exec"
+
+// StartParentExitWatcher is a no-op on Windows. Windows process cleanup uses
+// job/process-tree handling in the platform-specific command utilities.
+func StartParentExitWatcher(_ *exec.Cmd) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -91,7 +91,17 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 		}
 		return err
 	}
+	stopParentExitWatcher, err := cmdutil.StartParentExitWatcher(e.cmd)
+	if err != nil {
+		cmd := e.cmd
+		e.exitCode = 1
+		e.mu.Unlock()
+		_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+		_ = cmd.Wait()
+		return fmt.Errorf("failed to start parent exit watcher: %w", err)
+	}
 	e.mu.Unlock()
+	defer stopParentExitWatcher()
 
 	// Wait for the command to finish or the context to be cancelled.
 	// This ensures timeout is enforced even if cmd.Wait() blocks due to

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -10,14 +10,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
-	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
-	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/runtime"
@@ -395,100 +392,6 @@ func TestCommandExecutor_Kill(t *testing.T) {
 	executor = &commandExecutor{cmd: &exec.Cmd{}}
 	err = executor.Kill(os.Interrupt)
 	assert.NoError(t, err)
-}
-
-func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
-	if goruntime.GOOS == "windows" {
-		t.Skip("Skipping Unix-specific test on Windows")
-	}
-	if os.Getenv("DAGU_COMMAND_PARENT_DEATH_HELPER") == "1" {
-		runCommandParentDeathHelper(t)
-		return
-	}
-
-	tmpDir := t.TempDir()
-	pidFile := filepath.Join(tmpDir, "script.pid")
-	readyFile := filepath.Join(tmpDir, "helper.ready")
-
-	cmd := exec.Command(os.Args[0], "-test.run=TestCommandExecutor_CleansProcessGroupWhenParentDies")
-	cmd.Env = append(os.Environ(),
-		"DAGU_COMMAND_PARENT_DEATH_HELPER=1",
-		"DAGU_COMMAND_PARENT_DEATH_DIR="+tmpDir,
-	)
-	cmdutil.SetupCommand(cmd)
-
-	require.NoError(t, cmd.Start())
-	t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmdutil.KillProcessGroup(cmd, os.Kill)
-		}
-	})
-
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(readyFile)
-		return err == nil
-	}, 5*time.Second, 25*time.Millisecond, "helper did not start command script")
-
-	pidData, err := os.ReadFile(pidFile)
-	require.NoError(t, err)
-	scriptPID, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = syscall.Kill(-scriptPID, syscall.SIGKILL)
-	})
-
-	require.NoError(t, cmdutil.KillProcessGroup(cmd, os.Kill))
-	_ = cmd.Wait()
-
-	require.Eventually(t, func() bool {
-		return !processGroupAlive(scriptPID)
-	}, 2*time.Second, 25*time.Millisecond, "script process group should die with its parent")
-}
-
-func runCommandParentDeathHelper(t *testing.T) {
-	t.Helper()
-
-	tmpDir := os.Getenv("DAGU_COMMAND_PARENT_DEATH_DIR")
-	require.NotEmpty(t, tmpDir)
-	pidFile := filepath.Join(tmpDir, "script.pid")
-	readyFile := filepath.Join(tmpDir, "helper.ready")
-
-	step := core.Step{
-		Name: "parent-death",
-		Dir:  tmpDir,
-		Script: "echo $$ > " + pidFile + "\n" +
-			"while true; do sleep 1; done\n",
-	}
-
-	ctx := setupTestContext(t, nil, step)
-	env := runtime.GetEnv(ctx)
-	env.WorkingDir = tmpDir
-	ctx = runtime.WithEnv(ctx, env)
-
-	commandExec, err := NewCommand(ctx, step)
-	require.NoError(t, err)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- commandExec.Run(ctx)
-	}()
-
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(pidFile)
-		return err == nil
-	}, 5*time.Second, 25*time.Millisecond, "command script did not start")
-	require.NoError(t, os.WriteFile(readyFile, []byte("ok"), 0600))
-
-	select {
-	case err := <-errCh:
-		require.NoError(t, err)
-	case <-time.After(30 * time.Second):
-		t.Fatal("helper was not killed by parent test")
-	}
-}
-
-func processGroupAlive(pid int) bool {
-	err := syscall.Kill(-pid, 0)
-	return err == nil || err == syscall.EPERM
 }
 
 func TestCommandConfig_NewCmd(t *testing.T) {

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -10,11 +10,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/runtime"
@@ -392,6 +395,100 @@ func TestCommandExecutor_Kill(t *testing.T) {
 	executor = &commandExecutor{cmd: &exec.Cmd{}}
 	err = executor.Kill(os.Interrupt)
 	assert.NoError(t, err)
+}
+
+func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("Skipping Unix-specific test on Windows")
+	}
+	if os.Getenv("DAGU_COMMAND_PARENT_DEATH_HELPER") == "1" {
+		runCommandParentDeathHelper(t)
+		return
+	}
+
+	tmpDir := t.TempDir()
+	pidFile := filepath.Join(tmpDir, "script.pid")
+	readyFile := filepath.Join(tmpDir, "helper.ready")
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCommandExecutor_CleansProcessGroupWhenParentDies")
+	cmd.Env = append(os.Environ(),
+		"DAGU_COMMAND_PARENT_DEATH_HELPER=1",
+		"DAGU_COMMAND_PARENT_DEATH_DIR="+tmpDir,
+	)
+	cmdutil.SetupCommand(cmd)
+
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, "helper did not start command script")
+
+	pidData, err := os.ReadFile(pidFile)
+	require.NoError(t, err)
+	scriptPID, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = syscall.Kill(-scriptPID, syscall.SIGKILL)
+	})
+
+	require.NoError(t, cmdutil.KillProcessGroup(cmd, os.Kill))
+	_ = cmd.Wait()
+
+	require.Eventually(t, func() bool {
+		return !processGroupAlive(scriptPID)
+	}, 2*time.Second, 25*time.Millisecond, "script process group should die with its parent")
+}
+
+func runCommandParentDeathHelper(t *testing.T) {
+	t.Helper()
+
+	tmpDir := os.Getenv("DAGU_COMMAND_PARENT_DEATH_DIR")
+	require.NotEmpty(t, tmpDir)
+	pidFile := filepath.Join(tmpDir, "script.pid")
+	readyFile := filepath.Join(tmpDir, "helper.ready")
+
+	step := core.Step{
+		Name: "parent-death",
+		Dir:  tmpDir,
+		Script: "echo $$ > " + pidFile + "\n" +
+			"while true; do sleep 1; done\n",
+	}
+
+	ctx := setupTestContext(t, nil, step)
+	env := runtime.GetEnv(ctx)
+	env.WorkingDir = tmpDir
+	ctx = runtime.WithEnv(ctx, env)
+
+	commandExec, err := NewCommand(ctx, step)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- commandExec.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pidFile)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, "command script did not start")
+	require.NoError(t, os.WriteFile(readyFile, []byte("ok"), 0600))
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("helper was not killed by parent test")
+	}
+}
+
+func processGroupAlive(pid int) bool {
+	err := syscall.Kill(-pid, 0)
+	return err == nil || err == syscall.EPERM
 }
 
 func TestCommandConfig_NewCmd(t *testing.T) {

--- a/internal/runtime/builtin/command/command_unix_test.go
+++ b/internal/runtime/builtin/command/command_unix_test.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,7 +122,7 @@ func runCommandParentDeathHelper(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			require.Contains(t, err.Error(), "killed")
+			require.Truef(t, isSIGKILLExitError(err), "expected SIGKILL exit error, got %v", err)
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("helper was not killed by parent test")
@@ -131,4 +132,13 @@ func runCommandParentDeathHelper(t *testing.T) {
 func processGroupAlive(pid int) bool {
 	err := syscall.Kill(-pid, 0)
 	return err == nil || err == syscall.EPERM
+}
+
+func isSIGKILLExitError(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && status.Signal() == syscall.SIGKILL
 }

--- a/internal/runtime/builtin/command/command_unix_test.go
+++ b/internal/runtime/builtin/command/command_unix_test.go
@@ -120,7 +120,9 @@ func runCommandParentDeathHelper(t *testing.T) {
 
 	select {
 	case err := <-errCh:
-		require.NoError(t, err)
+		if err != nil {
+			require.Contains(t, err.Error(), "killed")
+		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("helper was not killed by parent test")
 	}

--- a/internal/runtime/builtin/command/command_unix_test.go
+++ b/internal/runtime/builtin/command/command_unix_test.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
+	if os.Getenv("DAGU_COMMAND_PARENT_DEATH_HELPER") == "1" {
+		runCommandParentDeathHelper(t)
+		return
+	}
+
+	tmpDir := t.TempDir()
+	pidFile := filepath.Join(tmpDir, "script.pid")
+	readyFile := filepath.Join(tmpDir, "helper.ready")
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCommandExecutor_CleansProcessGroupWhenParentDies")
+	cmd.Env = append(os.Environ(),
+		"DAGU_COMMAND_PARENT_DEATH_HELPER=1",
+		"DAGU_COMMAND_PARENT_DEATH_DIR="+tmpDir,
+	)
+	cmdutil.SetupCommand(cmd)
+
+	require.NoError(t, cmd.Start())
+	cmdDone := make(chan error, 1)
+	go func() {
+		cmdDone <- cmd.Wait()
+	}()
+
+	helperCmd := cmd
+	t.Cleanup(func() {
+		if helperCmd == nil || helperCmd.Process == nil {
+			return
+		}
+		_ = cmdutil.KillProcessGroup(helperCmd, os.Kill)
+		select {
+		case <-cmdDone:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, "helper did not start command script")
+
+	pidData, err := os.ReadFile(pidFile)
+	require.NoError(t, err)
+	scriptPID, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if scriptPID > 0 && processGroupAlive(scriptPID) {
+			_ = syscall.Kill(-scriptPID, syscall.SIGKILL)
+		}
+	})
+
+	require.NoError(t, cmdutil.KillProcessGroup(cmd, os.Kill))
+	select {
+	case <-cmdDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("helper did not exit after SIGKILL")
+	}
+	helperCmd = nil
+
+	require.Eventually(t, func() bool {
+		return !processGroupAlive(scriptPID)
+	}, 2*time.Second, 25*time.Millisecond, "script process group should die with its parent")
+	scriptPID = 0
+}
+
+func runCommandParentDeathHelper(t *testing.T) {
+	t.Helper()
+
+	tmpDir := os.Getenv("DAGU_COMMAND_PARENT_DEATH_DIR")
+	require.NotEmpty(t, tmpDir)
+	pidFile := filepath.Join(tmpDir, "script.pid")
+	readyFile := filepath.Join(tmpDir, "helper.ready")
+
+	step := core.Step{
+		Name: "parent-death",
+		Dir:  tmpDir,
+		Script: "echo $$ > " + pidFile + "\n" +
+			"while true; do sleep 1; done\n",
+	}
+
+	ctx := setupTestContext(t, nil, step)
+	env := runtime.GetEnv(ctx)
+	env.WorkingDir = tmpDir
+	ctx = runtime.WithEnv(ctx, env)
+
+	commandExec, err := NewCommand(ctx, step)
+	require.NoError(t, err)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- commandExec.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pidFile)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond, "command script did not start")
+	require.NoError(t, os.WriteFile(readyFile, []byte("ok"), 0600))
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("helper was not killed by parent test")
+	}
+}
+
+func processGroupAlive(pid int) bool {
+	err := syscall.Kill(-pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/runtime/builtin/command/command_unix_test.go
+++ b/internal/runtime/builtin/command/command_unix_test.go
@@ -31,7 +31,7 @@ func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
 	pidFile := filepath.Join(tmpDir, "script.pid")
 	readyFile := filepath.Join(tmpDir, "helper.ready")
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestCommandExecutor_CleansProcessGroupWhenParentDies")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCommandExecutor_CleansProcessGroupWhenParentDies$")
 	cmd.Env = append(os.Environ(),
 		"DAGU_COMMAND_PARENT_DEATH_HELPER=1",
 		"DAGU_COMMAND_PARENT_DEATH_DIR="+tmpDir,

--- a/internal/service/scheduler/github_dispatch_test.go
+++ b/internal/service/scheduler/github_dispatch_test.go
@@ -284,7 +284,7 @@ func TestGitHubDispatchWorker_StartRunsLoopsUntilContextCanceled(t *testing.T) {
 
 	env := newDispatchTestEnv(t, "github-loop")
 	tracker := filegithubdispatch.New(filepath.Join(t.TempDir(), "tracker"))
-	client := &loopDispatchClient{}
+	client := &loopDispatchClient{pulled: make(chan struct{})}
 	licenses := newStubDispatchLicenseManager()
 	worker := NewGitHubDispatchWorker(
 		env.cfg,
@@ -302,12 +302,24 @@ func TestGitHubDispatchWorker_StartRunsLoopsUntilContextCanceled(t *testing.T) {
 	worker.reportGap = time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(10 * time.Millisecond)
-		cancel()
+		defer close(done)
+		worker.Start(ctx)
 	}()
 
-	worker.Start(ctx)
+	select {
+	case <-client.pulled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("github dispatch worker did not pull")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("github dispatch worker did not stop")
+	}
 	assert.Greater(t, client.pullCalls, 0)
 }
 
@@ -470,10 +482,17 @@ func (s *stubDispatchClient) FinishGitHubDispatch(_ context.Context, jobID strin
 type loopDispatchClient struct {
 	stubDispatchClient
 	pullCalls int
+	pulled    chan struct{}
+	once      sync.Once
 }
 
 func (l *loopDispatchClient) PullGitHubDispatch(context.Context, license.PullGitHubDispatchRequest) (*license.GitHubDispatchJob, error) {
 	l.pullCalls++
+	if l.pulled != nil {
+		l.once.Do(func() {
+			close(l.pulled)
+		})
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary
- add a Unix parent-exit watcher for command executor child process groups
- stop the watcher on normal command completion and keep Windows on existing process-tree cleanup
- add a regression test that hard-kills a parent test process and verifies the script process group exits

## Testing
- go test ./internal/runtime/builtin/command -count=1
- go test ./internal/cmn/cmdutil -count=1
- go test ./internal/intg/distr -run TestDistributedRun_WorkerCrash_MarkedFailed -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent-exit watcher added on Unix (Windows remains a no-op).
* **Bug Fixes**
  * Command execution now starts the parent-exit watcher and ensures child process groups are terminated if watcher startup fails or when needed.
* **Tests**
  * Added Unix-only test validating process-group cleanup when a parent dies.
  * Made dispatch worker test deterministic to reliably verify pull-and-stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->