### PR TITLE
fix: keep history JSON output valid for empty results

### DIFF
--- a/internal/agent/web_tools.go
+++ b/internal/agent/web_tools.go
@@ -336,6 +336,9 @@ func newConfiguredWebToolProvider(cfg WebToolsConfig) (webToolProvider, bool) {
 
 // ResolveWebToolsConfig applies runtime defaults and trimming for web tool config.
 func ResolveWebToolsConfig(cfg WebToolsConfig) WebToolsConfig {
+	if cloned := cloneWebToolsConfig(&cfg); cloned != nil {
+		cfg = *cloned
+	}
 	if cfg.Backend == "" {
 		cfg.Backend = WebToolsBackendTavily
 	}

--- a/internal/agent/web_tools.go
+++ b/internal/agent/web_tools.go
@@ -336,9 +336,7 @@ func newConfiguredWebToolProvider(cfg WebToolsConfig) (webToolProvider, bool) {
 
 // ResolveWebToolsConfig applies runtime defaults and trimming for web tool config.
 func ResolveWebToolsConfig(cfg WebToolsConfig) WebToolsConfig {
-	if cloned := cloneWebToolsConfig(&cfg); cloned != nil {
-		cfg = *cloned
-	}
+	cfg = *cloneWebToolsConfig(&cfg)
 	if cfg.Backend == "" {
 		cfg.Backend = WebToolsBackendTavily
 	}

--- a/internal/agent/web_tools_test.go
+++ b/internal/agent/web_tools_test.go
@@ -369,6 +369,50 @@ func TestResolveWebToolsConfig_CentralizesDefaults(t *testing.T) {
 	assert.Equal(t, MaxFirecrawlSearchLimit, firecrawlCfg.Firecrawl.MaxResults)
 }
 
+func TestResolveWebToolsConfig_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	tavily := &TavilyWebToolsConfig{
+		APIKey:      "  tvly-test  ",
+		BaseURL:     "  https://example.test/  ",
+		MaxResults:  0,
+		SearchDepth: "  basic  ",
+	}
+	cfg := ResolveWebToolsConfig(WebToolsConfig{
+		Enabled: true,
+		Tavily:  tavily,
+	})
+
+	require.NotSame(t, tavily, cfg.Tavily)
+	assert.Equal(t, "  tvly-test  ", tavily.APIKey)
+	assert.Equal(t, "  https://example.test/  ", tavily.BaseURL)
+	assert.Equal(t, 0, tavily.MaxResults)
+	assert.Equal(t, "  basic  ", tavily.SearchDepth)
+	assert.Equal(t, "tvly-test", cfg.Tavily.APIKey)
+	assert.Equal(t, "https://example.test", cfg.Tavily.BaseURL)
+	assert.Equal(t, MaxTavilySearchLimit, cfg.Tavily.MaxResults)
+	assert.Equal(t, DefaultTavilySearchDepth, cfg.Tavily.SearchDepth)
+
+	firecrawl := &FirecrawlWebToolsConfig{
+		APIKey:     "  fc-test  ",
+		BaseURL:    "  https://example.test/  ",
+		MaxResults: 0,
+	}
+	firecrawlCfg := ResolveWebToolsConfig(WebToolsConfig{
+		Enabled:   true,
+		Backend:   WebToolsBackendFirecrawl,
+		Firecrawl: firecrawl,
+	})
+
+	require.NotSame(t, firecrawl, firecrawlCfg.Firecrawl)
+	assert.Equal(t, "  fc-test  ", firecrawl.APIKey)
+	assert.Equal(t, "  https://example.test/  ", firecrawl.BaseURL)
+	assert.Equal(t, 0, firecrawl.MaxResults)
+	assert.Equal(t, "fc-test", firecrawlCfg.Firecrawl.APIKey)
+	assert.Equal(t, "https://example.test", firecrawlCfg.Firecrawl.BaseURL)
+	assert.Equal(t, MaxFirecrawlSearchLimit, firecrawlCfg.Firecrawl.MaxResults)
+}
+
 func TestTruncateForToolOutput_PreservesUTF8(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/history.go
+++ b/internal/cmd/history.go
@@ -109,12 +109,24 @@ func runHistory(ctx *Context, args []string) error {
 
 	// Handle empty results
 	if len(statuses) == 0 {
-		fmt.Println("No DAG runs found matching the specified filters.")
-		return nil
+		return renderEmptyHistory(format)
 	}
 
 	// Render output based on format
 	return renderHistory(format, statuses)
+}
+
+const noHistoryRunsMessage = "No DAG runs found matching the specified filters."
+
+func renderEmptyHistory(format string) error {
+	_, _ = fmt.Fprintln(os.Stderr, noHistoryRunsMessage)
+
+	switch format {
+	case "json", "csv":
+		return renderHistory(format, nil)
+	default:
+		return nil
+	}
 }
 
 // validateFormat checks if the output format is valid.

--- a/internal/cmd/remote_commands.go
+++ b/internal/cmd/remote_commands.go
@@ -306,8 +306,7 @@ func remoteRunHistory(ctx *Context, args []string) error {
 		return err
 	}
 	if len(runs) == 0 {
-		fmt.Println("No DAG runs found matching the specified filters.")
-		return nil
+		return renderEmptyHistory(format)
 	}
 	if len(runs) > limit {
 		runs = runs[:limit]

--- a/internal/intg/history_test.go
+++ b/internal/intg/history_test.go
@@ -4,8 +4,12 @@
 package intg_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -286,6 +290,23 @@ func TestHistoryCommand_EmptyResults(t *testing.T) {
 	})
 }
 
+func TestHistoryCommand_EmptyResultsJSONOutput(t *testing.T) {
+	th := test.SetupCommand(t)
+
+	stdout, stderr := captureOutput(t, func() {
+		th.RunCommand(t, cmd.History(), test.CmdTest{
+			Name: "EmptyJSON",
+			Args: []string{"history", "--run-id=non-existent-run-id", "--format=json"},
+		})
+	})
+
+	var payload []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &payload))
+	assert.Empty(t, payload)
+	assert.NotContains(t, stdout, "No DAG runs found")
+	assert.Contains(t, stderr, "No DAG runs found matching the specified filters.")
+}
+
 func TestHistoryCommand_Labels(t *testing.T) {
 	t.Parallel()
 
@@ -334,6 +355,41 @@ steps:
 	}
 	assert.True(t, names[dag1.Name])
 	assert.False(t, names[dag2.Name])
+}
+
+func captureOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutR, stdoutW, err := os.Pipe()
+	require.NoError(t, err)
+	stderrR, stderrW, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	require.NoError(t, stdoutW.Close())
+	require.NoError(t, stderrW.Close())
+
+	var stdout bytes.Buffer
+	_, err = io.Copy(&stdout, stdoutR)
+	require.NoError(t, err)
+	require.NoError(t, stdoutR.Close())
+
+	var stderr bytes.Buffer
+	_, err = io.Copy(&stderr, stderrR)
+	require.NoError(t, err)
+	require.NoError(t, stderrR.Close())
+
+	return stdout.String(), stderr.String()
 }
 
 func TestHistoryCommand_Limit(t *testing.T) {


### PR DESCRIPTION
## Summary
- route empty history result notices to stderr instead of stdout
- render structured empty results for json and csv output paths
- avoid mutating shared agent web tool provider config while applying defaults, fixing a CI race detected in the Ubuntu shard
- add regression tests for empty json history output and non-mutating web tool config resolution

## Testing
- git diff --check
- go test ./internal/intg -run TestHistoryCommand -count=1
- go test ./internal/cmd -count=1
- go test ./internal/agent -run TestResolveWebToolsConfig_DoesNotMutateInput -count=1
- go test -race ./internal/agent -run 'TestRegisteredTools_FactoriesProduceValidTools|TestResolveWebToolsConfig' -count=1
- go test -race ./internal/agent -count=1

Closes #2092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History command now produces format-aware empty results (JSON/CSV render as empty outputs while other formats show a message).

* **Bug Fixes**
  * Web tools configuration processing no longer mutates the caller's input.

* **Tests**
  * Added tests covering empty JSON history output and ensuring web tools config normalization does not mutate inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->