### PR TITLE
fix: tolerate extra agent tool fields

### DIFF
--- a/internal/agent/ask_user.go
+++ b/internal/agent/ask_user.go
@@ -25,10 +25,10 @@ func init() {
 // AskUserToolInput is the input schema for the ask_user tool.
 type AskUserToolInput struct {
 	Question            string   `json:"question"`
-	Options             []string `json:"options"`
-	AllowFreeText       bool     `json:"allow_free_text"`
-	FreeTextPlaceholder string   `json:"free_text_placeholder,omitempty"`
-	MultiSelect         bool     `json:"multi_select"`
+	Options             []string `json:"options" lenient:"true"`
+	AllowFreeText       bool     `json:"allow_free_text" lenient:"true"`
+	FreeTextPlaceholder string   `json:"free_text_placeholder,omitempty" lenient:"true"`
+	MultiSelect         bool     `json:"multi_select" lenient:"true"`
 }
 
 const askUserDescription = "Ask the user a question and wait for their response. " +

--- a/internal/agent/ask_user.go
+++ b/internal/agent/ask_user.go
@@ -84,7 +84,7 @@ func NewAskUserTool() *AgentTool {
 
 func askUserRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	var args AskUserToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 

--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -52,7 +52,7 @@ type commandRunResult struct {
 // BashToolInput defines the input parameters for the bash tool.
 type BashToolInput struct {
 	Command string `json:"command"`
-	Timeout int    `json:"timeout,omitempty"`
+	Timeout int    `json:"timeout,omitempty" lenient:"true"`
 }
 
 // NewBashTool creates a new bash tool for shell command execution.

--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -89,7 +89,7 @@ func NewBashTool() *AgentTool {
 
 func bashRun(toolCtx ToolContext, input json.RawMessage) ToolOut {
 	var args BashToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	if args.Command == "" {

--- a/internal/agent/dag_def_manage.go
+++ b/internal/agent/dag_def_manage.go
@@ -90,7 +90,7 @@ func dagDefManageRun(toolCtx ToolContext, input json.RawMessage, store exec.DAGS
 		return toolError("%s is unavailable: DAG store is not configured", dagDefManageToolName)
 	}
 	var args dagDefManageInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	if toolCtx.Context == nil {

--- a/internal/agent/dag_def_manage.go
+++ b/internal/agent/dag_def_manage.go
@@ -32,16 +32,16 @@ func init() {
 
 type dagDefManageInput struct {
 	Action  string   `json:"action"`
-	DAGName string   `json:"dagName,omitempty"`
-	Spec    string   `json:"spec,omitempty"`
-	Path    string   `json:"path,omitempty"`
-	Query   string   `json:"query,omitempty"`
-	Labels  []string `json:"labels,omitempty"`
-	Limit   int      `json:"limit,omitempty"`
-	Page    int      `json:"page,omitempty"`
-	Sort    string   `json:"sort,omitempty"`
-	Order   string   `json:"order,omitempty"`
-	Full    bool     `json:"full,omitempty"`
+	DAGName string   `json:"dagName,omitempty" lenient:"true"`
+	Spec    string   `json:"spec,omitempty" lenient:"true"`
+	Path    string   `json:"path,omitempty" lenient:"true"`
+	Query   string   `json:"query,omitempty" lenient:"true"`
+	Labels  []string `json:"labels,omitempty" lenient:"true"`
+	Limit   int      `json:"limit,omitempty" lenient:"true"`
+	Page    int      `json:"page,omitempty" lenient:"true"`
+	Sort    string   `json:"sort,omitempty" lenient:"true"`
+	Order   string   `json:"order,omitempty" lenient:"true"`
+	Full    bool     `json:"full,omitempty" lenient:"true"`
 }
 
 // NewDAGDefManageTool creates an agent tool for read-only DAG definition inspection.

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -35,26 +35,26 @@ func init() {
 
 type dagRunManageInput struct {
 	Action      string   `json:"action"`
-	DAGName     string   `json:"dagName,omitempty"`
-	DAGRunID    string   `json:"dagRunId,omitempty"`
-	SubDAGRunID string   `json:"subDAGRunId,omitempty"`
-	WatchID     string   `json:"watchId,omitempty"`
-	StepName    string   `json:"stepName,omitempty"`
-	Stream      string   `json:"stream,omitempty"`
-	Status      []string `json:"status,omitempty"`
-	Labels      []string `json:"labels,omitempty"`
-	NotifyOn    []string `json:"notifyOn,omitempty"`
-	Last        string   `json:"last,omitempty"`
-	From        string   `json:"from,omitempty"`
-	To          string   `json:"to,omitempty"`
-	Limit       int      `json:"limit,omitempty"`
-	Cursor      string   `json:"cursor,omitempty"`
-	Head        int      `json:"head,omitempty"`
-	Tail        int      `json:"tail,omitempty"`
-	Offset      int      `json:"offset,omitempty"`
-	Encoding    string   `json:"encoding,omitempty"`
+	DAGName     string   `json:"dagName,omitempty" lenient:"true"`
+	DAGRunID    string   `json:"dagRunId,omitempty" lenient:"true"`
+	SubDAGRunID string   `json:"subDAGRunId,omitempty" lenient:"true"`
+	WatchID     string   `json:"watchId,omitempty" lenient:"true"`
+	StepName    string   `json:"stepName,omitempty" lenient:"true"`
+	Stream      string   `json:"stream,omitempty" lenient:"true"`
+	Status      []string `json:"status,omitempty" lenient:"true"`
+	Labels      []string `json:"labels,omitempty" lenient:"true"`
+	NotifyOn    []string `json:"notifyOn,omitempty" lenient:"true"`
+	Last        string   `json:"last,omitempty" lenient:"true"`
+	From        string   `json:"from,omitempty" lenient:"true"`
+	To          string   `json:"to,omitempty" lenient:"true"`
+	Limit       int      `json:"limit,omitempty" lenient:"true"`
+	Cursor      string   `json:"cursor,omitempty" lenient:"true"`
+	Head        int      `json:"head,omitempty" lenient:"true"`
+	Tail        int      `json:"tail,omitempty" lenient:"true"`
+	Offset      int      `json:"offset,omitempty" lenient:"true"`
+	Encoding    string   `json:"encoding,omitempty" lenient:"true"`
 	// DiagnoseOnFailure defaults to true for watch notifications.
-	DiagnoseOnFailure *bool `json:"diagnoseOnFailure,omitempty"`
+	DiagnoseOnFailure *bool `json:"diagnoseOnFailure,omitempty" lenient:"true"`
 }
 
 type dagRunManageLogRef struct {

--- a/internal/agent/dag_run_manage.go
+++ b/internal/agent/dag_run_manage.go
@@ -140,7 +140,7 @@ func NewDAGRunManageTool(store exec.DAGRunStore, watchers ...DAGRunWatcher) *Age
 
 func dagRunManageRun(toolCtx ToolContext, input json.RawMessage, store exec.DAGRunStore, watcher DAGRunWatcher) ToolOut {
 	var args dagRunManageInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	if toolCtx.Context == nil {

--- a/internal/agent/delegate.go
+++ b/internal/agent/delegate.go
@@ -107,7 +107,7 @@ func delegateRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	}
 
 	var args delegateInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Invalid input: %v", err)
 	}
 

--- a/internal/agent/navigate.go
+++ b/internal/agent/navigate.go
@@ -69,7 +69,7 @@ func NewNavigateTool() *AgentTool {
 
 func navigateRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	var args NavigateToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 

--- a/internal/agent/output.go
+++ b/internal/agent/output.go
@@ -42,7 +42,7 @@ func outputRunFunc(w io.Writer) ToolFunc {
 		var params struct {
 			Content string `json:"content"`
 		}
-		if err := json.Unmarshal(input, &params); err != nil {
+		if err := decodeToolInput(input, &params); err != nil {
 			return toolError("failed to parse output parameters: %v", err)
 		}
 		if params.Content == "" {

--- a/internal/agent/patch.go
+++ b/internal/agent/patch.go
@@ -117,7 +117,7 @@ func patchRun(ctx ToolContext, input json.RawMessage, dagsDir string) ToolOut {
 	}
 
 	var args PatchToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	var rawFields map[string]json.RawMessage
@@ -133,49 +133,31 @@ func patchRun(ctx ToolContext, input json.RawMessage, dagsDir string) ToolOut {
 
 	switch args.Operation {
 	case PatchOpCreate:
-		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string", "anchor"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		if err := validateRequiredFields(args.Operation, rawFields, "content"); err != nil {
 			return toolError("%s", err.Error())
 		}
 		return patchCreate(ctx.Context, path, args.Content, dagsDir)
 	case PatchOpReplace:
-		if err := validateNoFields(args.Operation, rawFields, "content", "anchor"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		if err := validateRequiredFields(args.Operation, rawFields, "old_string", "new_string"); err != nil {
 			return toolError("%s", err.Error())
 		}
 		return patchReplace(ctx.Context, path, args.OldString, args.NewString, dagsDir)
 	case PatchOpAppend:
-		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string", "anchor"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		if err := validateRequiredFields(args.Operation, rawFields, "content"); err != nil {
 			return toolError("%s", err.Error())
 		}
 		return patchAppend(ctx.Context, path, args.Content, dagsDir)
 	case PatchOpInsertBefore:
-		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		if err := validateRequiredFields(args.Operation, rawFields, "anchor", "content"); err != nil {
 			return toolError("%s", err.Error())
 		}
 		return patchInsert(ctx.Context, path, args.Anchor, args.Content, false, dagsDir)
 	case PatchOpInsertAfter:
-		if err := validateNoFields(args.Operation, rawFields, "old_string", "new_string"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		if err := validateRequiredFields(args.Operation, rawFields, "anchor", "content"); err != nil {
 			return toolError("%s", err.Error())
 		}
 		return patchInsert(ctx.Context, path, args.Anchor, args.Content, true, dagsDir)
 	case PatchOpDelete:
-		if err := validateNoFields(args.Operation, rawFields, "content", "old_string", "new_string", "anchor"); err != nil {
-			return toolError("%s", err.Error())
-		}
 		return patchDelete(path)
 	default:
 		return toolError("Unknown operation: %s. Use 'create', 'replace', 'append', 'insert_before', 'insert_after', or 'delete'.", args.Operation)
@@ -316,15 +298,6 @@ func patchDelete(path string) ToolOut {
 	return ToolOut{Content: fmt.Sprintf("Deleted %s", path)}
 }
 
-func validateNoFields(operation PatchOperation, rawFields map[string]json.RawMessage, fields ...string) error {
-	for _, field := range fields {
-		if _, ok := rawFields[field]; ok {
-			return fmt.Errorf("%s is not allowed for %s operation", field, operation)
-		}
-	}
-	return nil
-}
-
 func validateRequiredFields(operation PatchOperation, rawFields map[string]json.RawMessage, fields ...string) error {
 	for _, field := range fields {
 		raw, ok := rawFields[field]
@@ -332,9 +305,10 @@ func validateRequiredFields(operation PatchOperation, rawFields map[string]json.
 			return fmt.Errorf("%s is required for %s operation", field, operation)
 		}
 		var value string
-		if err := json.Unmarshal(raw, &value); err == nil &&
-			strings.TrimSpace(value) == "" &&
-			!requiredFieldAllowsEmptyString(operation, field) {
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return fmt.Errorf("%s must be a string for %s operation", field, operation)
+		}
+		if strings.TrimSpace(value) == "" && !requiredFieldAllowsEmptyString(operation, field) {
 			return fmt.Errorf("%s is required for %s operation", field, operation)
 		}
 	}

--- a/internal/agent/patch.go
+++ b/internal/agent/patch.go
@@ -49,10 +49,10 @@ const (
 type PatchToolInput struct {
 	Path      string         `json:"path"`
 	Operation PatchOperation `json:"operation"`
-	Content   string         `json:"content,omitempty"`    // For create, append, and insert operations
-	OldString string         `json:"old_string,omitempty"` // For replace operation
-	NewString string         `json:"new_string,omitempty"` // For replace operation
-	Anchor    string         `json:"anchor,omitempty"`     // For insert operations
+	Content   string         `json:"content,omitempty" lenient:"true"`    // For create, append, and insert operations
+	OldString string         `json:"old_string,omitempty" lenient:"true"` // For replace operation
+	NewString string         `json:"new_string,omitempty" lenient:"true"` // For replace operation
+	Anchor    string         `json:"anchor,omitempty" lenient:"true"`     // For insert operations
 }
 
 // NewPatchTool creates a new patch tool for file editing.

--- a/internal/agent/patch_test.go
+++ b/internal/agent/patch_test.go
@@ -91,7 +91,7 @@ func TestPatchTool_Create(t *testing.T) {
 		assert.Equal(t, "new content", string(content))
 	})
 
-	t.Run("rejects unused operation-specific fields even when empty", func(t *testing.T) {
+	t.Run("ignores unused operation-specific fields", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "new.txt")
@@ -104,25 +104,23 @@ func TestPatchTool_Create(t *testing.T) {
 			"anchor", "",
 		))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "old_string is not allowed")
-		_, err := os.Stat(filePath)
-		assert.True(t, os.IsNotExist(err))
+		assert.False(t, result.IsError)
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(content))
 	})
 
-	t.Run("rejects meaningful operation-specific fields", func(t *testing.T) {
+	t.Run("rejects malformed required content", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "new.txt")
-		result := tool.Run(ToolContext{}, patchInput(
+		result := tool.Run(ToolContext{}, json.RawMessage(fmt.Sprintf(
+			`{"path":%q,"operation":"create","content":{"wrong":"shape"},"old_string":"","anchor":""}`,
 			filePath,
-			"create",
-			"content", "hello world",
-			"old_string", "old",
-		))
+		)))
 
 		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "old_string is not allowed")
+		assert.Contains(t, result.Content, "content must be a string")
 		_, err := os.Stat(filePath)
 		assert.True(t, os.IsNotExist(err))
 	})
@@ -249,7 +247,7 @@ func TestPatchTool_Replace(t *testing.T) {
 		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
 	})
 
-	t.Run("rejects ambiguous content field", func(t *testing.T) {
+	t.Run("ignores irrelevant content field", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "test.txt")
@@ -257,14 +255,13 @@ func TestPatchTool_Replace(t *testing.T) {
 
 		result := tool.Run(ToolContext{}, patchInput(filePath, "replace", "old_string", "world", "new_string", "universe", "content", "extra"))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "content is not allowed")
+		assert.False(t, result.IsError)
 		content, err := os.ReadFile(filePath)
 		require.NoError(t, err)
-		assert.Equal(t, "hello world", string(content))
+		assert.Equal(t, "hello universe", string(content))
 	})
 
-	t.Run("rejects unused fields with null values", func(t *testing.T) {
+	t.Run("ignores irrelevant fields with null values", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "test.txt")
@@ -275,14 +272,13 @@ func TestPatchTool_Replace(t *testing.T) {
 			filePath,
 		)))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "content is not allowed")
+		assert.False(t, result.IsError)
 		content, err := os.ReadFile(filePath)
 		require.NoError(t, err)
-		assert.Equal(t, "hello world", string(content))
+		assert.Equal(t, "hello universe", string(content))
 	})
 
-	t.Run("rejects unused fields with empty string values", func(t *testing.T) {
+	t.Run("ignores irrelevant fields with empty string values", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "test.txt")
@@ -297,11 +293,27 @@ func TestPatchTool_Replace(t *testing.T) {
 			"anchor", "",
 		))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "content is not allowed")
+		assert.False(t, result.IsError)
 		content, err := os.ReadFile(filePath)
 		require.NoError(t, err)
-		assert.Equal(t, "hello world", string(content))
+		assert.Equal(t, "hello universe", string(content))
+	})
+
+	t.Run("ignores malformed irrelevant fields", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("hello world"), 0o600))
+
+		result := tool.Run(ToolContext{}, json.RawMessage(fmt.Sprintf(
+			`{"path":%q,"operation":"replace","old_string":"world","new_string":"universe","content":{"unused":true},"anchor":["unused"]}`,
+			filePath,
+		)))
+
+		assert.False(t, result.IsError)
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, "hello universe", string(content))
 	})
 }
 
@@ -449,7 +461,7 @@ func TestPatchTool_Insert(t *testing.T) {
 		assert.Equal(t, "one\n", string(content))
 	})
 
-	t.Run("rejects unused replace fields even when empty", func(t *testing.T) {
+	t.Run("ignores unused replace fields", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "test.txt")
@@ -464,11 +476,10 @@ func TestPatchTool_Insert(t *testing.T) {
 			"new_string", "",
 		))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "old_string is not allowed")
+		assert.False(t, result.IsError)
 		content, err := os.ReadFile(filePath)
 		require.NoError(t, err)
-		assert.Equal(t, "one\n", string(content))
+		assert.Equal(t, "one\ntwo\n", string(content))
 	})
 }
 
@@ -588,7 +599,7 @@ func TestPatchTool_Delete(t *testing.T) {
 		assert.Contains(t, result.Content, "not found")
 	})
 
-	t.Run("rejects unused fields even when empty", func(t *testing.T) {
+	t.Run("ignores unused fields", func(t *testing.T) {
 		t.Parallel()
 
 		filePath := filepath.Join(t.TempDir(), "delete-me.txt")
@@ -603,26 +614,9 @@ func TestPatchTool_Delete(t *testing.T) {
 			"anchor", "",
 		))
 
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "content is not allowed")
-		content, err := os.ReadFile(filePath)
-		require.NoError(t, err)
-		assert.Equal(t, "content", string(content))
-	})
-
-	t.Run("rejects meaningful forbidden field", func(t *testing.T) {
-		t.Parallel()
-
-		filePath := filepath.Join(t.TempDir(), "delete-me.txt")
-		require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o600))
-
-		result := tool.Run(ToolContext{}, patchInput(filePath, "delete", "content", "extra"))
-
-		assert.True(t, result.IsError)
-		assert.Contains(t, result.Content, "content is not allowed")
-		content, err := os.ReadFile(filePath)
-		require.NoError(t, err)
-		assert.Equal(t, "content", string(content))
+		assert.False(t, result.IsError)
+		_, err := os.Stat(filePath)
+		assert.True(t, os.IsNotExist(err))
 	})
 }
 

--- a/internal/agent/policy.go
+++ b/internal/agent/policy.go
@@ -151,7 +151,7 @@ type BashPolicyDecision struct {
 // ExtractBashCommand extracts the bash command string from tool input.
 func ExtractBashCommand(input json.RawMessage) (string, error) {
 	var args BashToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return "", fmt.Errorf("failed to parse bash input: %w", err)
 	}
 	return strings.TrimSpace(args.Command), nil

--- a/internal/agent/read.go
+++ b/internal/agent/read.go
@@ -30,8 +30,8 @@ const (
 // ReadToolInput defines the input parameters for the read tool.
 type ReadToolInput struct {
 	Path   string `json:"path"`
-	Offset int    `json:"offset,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
+	Offset int    `json:"offset,omitempty" lenient:"true"`
+	Limit  int    `json:"limit,omitempty" lenient:"true"`
 }
 
 // NewReadTool creates a new read tool for file reading.

--- a/internal/agent/read.go
+++ b/internal/agent/read.go
@@ -72,7 +72,7 @@ func NewReadTool() *AgentTool {
 
 func readRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	var args ReadToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 

--- a/internal/agent/remote_agent.go
+++ b/internal/agent/remote_agent.go
@@ -153,7 +153,7 @@ func makeRemoteAgentRun(resolver RemoteContextResolver) ToolFunc {
 		}
 
 		var args remoteAgentInput
-		if err := json.Unmarshal(input, &args); err != nil {
+		if err := decodeToolInput(input, &args); err != nil {
 			return toolError("Failed to parse input: %v", err)
 		}
 

--- a/internal/agent/remote_list.go
+++ b/internal/agent/remote_list.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 type listContextsInput struct {
-	NameFilter string `json:"name_filter,omitempty"`
+	NameFilter string `json:"name_filter,omitempty" lenient:"true"`
 }
 
 func NewListContextsTool(resolver RemoteContextResolver) *AgentTool {

--- a/internal/agent/remote_list.go
+++ b/internal/agent/remote_list.go
@@ -63,7 +63,7 @@ func makeListContextsRun(resolver RemoteContextResolver) ToolFunc {
 		}
 
 		var args listContextsInput
-		if err := json.Unmarshal(input, &args); err != nil {
+		if err := decodeToolInput(input, &args); err != nil {
 			return toolError("Failed to parse input: %v", err)
 		}
 

--- a/internal/agent/runbook_manage.go
+++ b/internal/agent/runbook_manage.go
@@ -39,15 +39,15 @@ const (
 
 type runbookManageInput struct {
 	Action      runbookManageAction `json:"action"`
-	ID          string              `json:"id,omitempty"`
-	NewID       string              `json:"new_id,omitempty"`
-	Query       string              `json:"query,omitempty"`
-	Title       string              `json:"title,omitempty"`
-	Description string              `json:"description,omitempty"`
-	Content     string              `json:"content,omitempty"`
-	OldString   string              `json:"old_string,omitempty"`
-	NewString   string              `json:"new_string,omitempty"`
-	Limit       int                 `json:"limit,omitempty"`
+	ID          string              `json:"id,omitempty" lenient:"true"`
+	NewID       string              `json:"new_id,omitempty" lenient:"true"`
+	Query       string              `json:"query,omitempty" lenient:"true"`
+	Title       string              `json:"title,omitempty" lenient:"true"`
+	Description string              `json:"description,omitempty" lenient:"true"`
+	Content     string              `json:"content,omitempty" lenient:"true"`
+	OldString   string              `json:"old_string,omitempty" lenient:"true"`
+	NewString   string              `json:"new_string,omitempty" lenient:"true"`
+	Limit       int                 `json:"limit,omitempty" lenient:"true"`
 }
 
 type runbookMetadataOutput struct {

--- a/internal/agent/runbook_manage.go
+++ b/internal/agent/runbook_manage.go
@@ -147,7 +147,7 @@ func runbookManageRun(ctx ToolContext, input json.RawMessage, deps runbookManage
 		return toolError("runbook_manage is unavailable: doc store is not configured")
 	}
 	var args runbookManageInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	if ctx.Context == nil {

--- a/internal/agent/session_search.go
+++ b/internal/agent/session_search.go
@@ -38,7 +38,7 @@ func init() {
 // SessionSearchInput defines the input parameters for the session_search tool.
 type SessionSearchInput struct {
 	Query string `json:"query"`
-	Limit int    `json:"limit,omitempty"`
+	Limit int    `json:"limit,omitempty" lenient:"true"`
 }
 
 type sessionSearchResult struct {

--- a/internal/agent/session_search.go
+++ b/internal/agent/session_search.go
@@ -88,7 +88,7 @@ func NewSessionSearchTool() *AgentTool {
 
 func sessionSearchRun(ctx ToolContext, input json.RawMessage) ToolOut {
 	var args SessionSearchInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -232,14 +232,14 @@ Actively report your progress during multi-step work so the user is not left wai
 <tools>
 - `bash`: Run shell commands (120s timeout). It uses system `bash` when available and a built-in shell interpreter otherwise, so do not assume Unix-only helper binaries are installed. Use it for Dagu CLI commands and other installed CLIs.
 - `read`: Read file contents. Use before editing any file.
-- `patch`: Create/edit/delete files with strict JSON operations. Use exactly one shape:
+- `patch`: Create/edit/delete files with JSON operations. Prefer exactly one shape:
   - create: `{"path":"...","operation":"create","content":"full file content"}`
   - replace: `{"path":"...","operation":"replace","old_string":"exact unique existing text","new_string":"replacement text"}`
   - append: `{"path":"...","operation":"append","content":"content to add"}`
   - insert_before: `{"path":"...","operation":"insert_before","anchor":"exact unique existing text","content":"content to insert"}`
   - insert_after: `{"path":"...","operation":"insert_after","anchor":"exact unique existing text","content":"content to insert"}`
   - delete: `{"path":"...","operation":"delete"}`
-  Do not include unused fields, even as empty strings or null. Use `append` or `insert_after` for additions; do not use `replace` to simulate an append.
+  Prefer omitting unused fields; the tool ignores fields that are irrelevant to the selected operation. Use `append` or `insert_after` for additions; do not use `replace` to simulate an append.
   Do not use `patch` to move, rename, delete, or maintain documents under {{.DocsDir}} when `runbook_manage` is available; use `runbook_manage` for docs-store operations.
 - `think`: Reason through complex multi-step tasks before acting.
 - `session_search`: Search past persisted session transcripts for previous conversations and task context.

--- a/internal/agent/tool_registry_test.go
+++ b/internal/agent/tool_registry_test.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,6 +111,50 @@ func TestRegisteredTools_FactoriesProduceValidTools(t *testing.T) {
 			assert.NotEmpty(t, tool.Function.Description)
 			assert.NotNil(t, tool.Run)
 		})
+	}
+}
+
+func TestRegisteredTools_SchemasDoNotRejectExtraFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := ToolConfig{
+		DAGsDir:               "/tmp/test-dags",
+		RemoteContextResolver: &testRemoteContextResolver{},
+		WebTools: &WebToolsConfig{
+			Enabled: true,
+			Backend: WebToolsBackendTavily,
+			Tavily:  &TavilyWebToolsConfig{APIKey: "tvly-test"},
+		},
+	}
+
+	for _, reg := range RegisteredTools() {
+		t.Run(reg.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tool := reg.Factory(cfg)
+			require.NotNil(t, tool)
+			assertNoAdditionalPropertiesFalse(t, tool.Function.Parameters, tool.Function.Name)
+		})
+	}
+}
+
+func assertNoAdditionalPropertiesFalse(t *testing.T, node any, path string) {
+	t.Helper()
+
+	switch typed := node.(type) {
+	case map[string]any:
+		if value, ok := typed["additionalProperties"]; ok {
+			assert.NotEqual(t, false, value, "%s must not reject extra fields", path)
+		}
+		for key, value := range typed {
+			assertNoAdditionalPropertiesFalse(t, value, path+"."+key)
+		}
+	case []any:
+		for i, value := range typed {
+			assertNoAdditionalPropertiesFalse(t, value, fmt.Sprintf("%s[%d]", path, i))
+		}
+	case []string:
+		return
 	}
 }
 

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -60,11 +60,10 @@ func isRootedPath(path string) bool {
 	return path[0] == '/' || path[0] == '\\'
 }
 
-// decodeToolInput decodes tool-call arguments leniently. Models sometimes send
-// optional fields that are irrelevant to the selected action, or include stale
-// fields from another operation. Unknown fields and malformed optional fields
-// should not block the tool; action-specific validation below each tool decides
-// which fields are actually required.
+// decodeToolInput decodes tool-call arguments while preserving compatibility
+// with loose model output. Unknown fields are ignored. Known fields are decoded
+// normally unless tagged with `lenient:"true"`, which lets action-specific
+// validation ignore irrelevant or optional malformed fields.
 func decodeToolInput(input json.RawMessage, dest any) error {
 	if strings.TrimSpace(string(input)) == "" {
 		input = json.RawMessage(`{}`)
@@ -103,7 +102,12 @@ func decodeToolInput(input json.RawMessage, dest any) error {
 		if !field.CanSet() {
 			continue
 		}
-		_ = json.Unmarshal(raw, field.Addr().Interface())
+		if err := json.Unmarshal(raw, field.Addr().Interface()); err != nil {
+			if fieldType.Tag.Get("lenient") == "true" {
+				continue
+			}
+			return fmt.Errorf("field %q: %w", name, err)
+		}
 	}
 
 	return nil

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -4,8 +4,11 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"reflect"
+	"strings"
 )
 
 // CreateTools returns all registered agent tools, constructed with the given config.
@@ -55,4 +58,68 @@ func isRootedPath(path string) bool {
 		return false
 	}
 	return path[0] == '/' || path[0] == '\\'
+}
+
+// decodeToolInput decodes tool-call arguments leniently. Models sometimes send
+// optional fields that are irrelevant to the selected action, or include stale
+// fields from another operation. Unknown fields and malformed optional fields
+// should not block the tool; action-specific validation below each tool decides
+// which fields are actually required.
+func decodeToolInput(input json.RawMessage, dest any) error {
+	if strings.TrimSpace(string(input)) == "" {
+		input = json.RawMessage(`{}`)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(input, &fields); err != nil {
+		return err
+	}
+
+	value := reflect.ValueOf(dest)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+
+	value = value.Elem()
+	if value.Kind() != reflect.Struct {
+		return json.Unmarshal(input, dest)
+	}
+
+	typ := value.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		fieldType := typ.Field(i)
+		if fieldType.PkgPath != "" {
+			continue
+		}
+		name := jsonFieldName(fieldType)
+		if name == "" {
+			continue
+		}
+		raw, ok := fields[name]
+		if !ok {
+			continue
+		}
+		field := value.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		_ = json.Unmarshal(raw, field.Addr().Interface())
+	}
+
+	return nil
+}
+
+func jsonFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return ""
+	}
+	if tag == "" {
+		return field.Name
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" {
+		return field.Name
+	}
+	return name
 }

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -74,7 +74,7 @@ func TestDecodeToolInput(t *testing.T) {
 
 		var got struct {
 			Action string `json:"action"`
-			Limit  int    `json:"limit,omitempty"`
+			Limit  int    `json:"limit,omitempty" lenient:"true"`
 		}
 
 		err := decodeToolInput(json.RawMessage(`{
@@ -88,7 +88,7 @@ func TestDecodeToolInput(t *testing.T) {
 		assert.Zero(t, got.Limit)
 	})
 
-	t.Run("keeps malformed required fields at zero value for normal validation", func(t *testing.T) {
+	t.Run("rejects malformed known fields unless marked lenient", func(t *testing.T) {
 		t.Parallel()
 
 		var got struct {
@@ -97,7 +97,8 @@ func TestDecodeToolInput(t *testing.T) {
 
 		err := decodeToolInput(json.RawMessage(`{"path": 123, "extra": "ignored"}`), &got)
 
-		require.NoError(t, err)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `field "path"`)
 		assert.Empty(t, got.Path)
 	})
 

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -63,6 +64,54 @@ func TestGetToolByName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeToolInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ignores unknown and malformed optional fields", func(t *testing.T) {
+		t.Parallel()
+
+		var got struct {
+			Action string `json:"action"`
+			Limit  int    `json:"limit,omitempty"`
+		}
+
+		err := decodeToolInput(json.RawMessage(`{
+			"action": "list",
+			"limit": "not-an-integer",
+			"extra": {"any": ["shape", 1, true]}
+		}`), &got)
+
+		require.NoError(t, err)
+		assert.Equal(t, "list", got.Action)
+		assert.Zero(t, got.Limit)
+	})
+
+	t.Run("keeps malformed required fields at zero value for normal validation", func(t *testing.T) {
+		t.Parallel()
+
+		var got struct {
+			Path string `json:"path"`
+		}
+
+		err := decodeToolInput(json.RawMessage(`{"path": 123, "extra": "ignored"}`), &got)
+
+		require.NoError(t, err)
+		assert.Empty(t, got.Path)
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		var got struct {
+			Action string `json:"action"`
+		}
+
+		err := decodeToolInput(json.RawMessage(`{"action":`), &got)
+
+		require.Error(t, err)
+	})
 }
 
 func TestToolError(t *testing.T) {

--- a/internal/agent/web_tools.go
+++ b/internal/agent/web_tools.go
@@ -464,7 +464,7 @@ func validateWebProviderBaseURL(rawURL string) (string, error) {
 
 func webSearchRun(toolCtx ToolContext, input json.RawMessage, provider webToolProvider) ToolOut {
 	var args WebSearchToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	query := strings.TrimSpace(args.Query)
@@ -488,7 +488,7 @@ func webSearchRun(toolCtx ToolContext, input json.RawMessage, provider webToolPr
 
 func webExtractRun(toolCtx ToolContext, input json.RawMessage, provider webToolProvider) ToolOut {
 	var args WebExtractToolInput
-	if err := json.Unmarshal(input, &args); err != nil {
+	if err := decodeToolInput(input, &args); err != nil {
 		return toolError("Failed to parse input: %v", err)
 	}
 	if len(args.URLs) == 0 {

--- a/internal/agent/web_tools.go
+++ b/internal/agent/web_tools.go
@@ -75,7 +75,7 @@ func init() {
 // WebSearchToolInput defines the input parameters for web_search.
 type WebSearchToolInput struct {
 	Query string `json:"query"`
-	Limit int    `json:"limit,omitempty"`
+	Limit int    `json:"limit,omitempty" lenient:"true"`
 }
 
 // WebExtractToolInput defines the input parameters for web_extract.


### PR DESCRIPTION
## Summary
- make built-in AI-agent tool argument decoding tolerant of unknown and irrelevant fields
- stop rejecting patch calls that include stale operation-specific fields, while preserving required-field and safety validation
- update the agent prompt and regression tests so all registered tool schemas remain extra-field compatible

## Testing
- go test ./internal/agent -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tool input parsing now gracefully handles extra or unused fields instead of rejecting them, making tools more flexible and forgiving of API variations.

* **Improvements**
  * Patch tool now ignores unused operation-specific properties in JSON input rather than failing validation, simplifying successful patch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->