### PR TITLE
fix: support old powershell in generated scripts

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -30,19 +30,19 @@ func TestEngineRunFile(t *testing.T) {
 
 	home := t.TempDir()
 	dagFile := filepath.Join(home, "embedded-file.yaml")
-	checkParamCommand := `test "$FOO" = "bar"`
-	checkParamShell := ""
-	if runtime.GOOS == "windows" {
-		checkParamCommand = `if ($env:FOO -ne "bar") { exit 1 }`
-		checkParamShell = `
-    shell: powershell`
-	}
+	testBinary, err := os.Executable()
+	require.NoError(t, err, "Executable()")
 	writeDAG(t, dagFile, fmt.Sprintf(`
 name: embedded-file
 steps:
   - name: check-param
-    command: %q%s
-`, checkParamCommand, checkParamShell))
+    exec:
+      command: %q
+      args:
+        - -test.run=TestEngineRunFileParamHelper
+    env:
+      DAGU_ENGINE_PARAM_HELPER: "1"
+`, testBinary))
 
 	engine, err := dagu.New(ctx, dagu.Options{HomeDir: home})
 	require.NoError(t, err, "New()")
@@ -57,6 +57,13 @@ steps:
 	require.Equal(t, "succeeded", status.Status)
 	require.Equal(t, "embedded-file", status.Name)
 	require.NotEmpty(t, status.RunID)
+}
+
+func TestEngineRunFileParamHelper(t *testing.T) {
+	if os.Getenv("DAGU_ENGINE_PARAM_HELPER") != "1" {
+		return
+	}
+	require.Equal(t, "bar", os.Getenv("FOO"))
 }
 
 func TestEngineRunYAML(t *testing.T) {

--- a/internal/runtime/builtin/command/command_script.go
+++ b/internal/runtime/builtin/command/command_script.go
@@ -71,12 +71,10 @@ func hasShebang(script string) bool {
 
 var powerShellPreambleStatements = []string{
 	"$ErrorActionPreference = 'Stop'",
-	"$PSNativeCommandUseErrorActionPreference = $true",
-	"$utf8NoBom = [System.Text.UTF8Encoding]::new($false)",
+	"$utf8NoBom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false",
 	"[Console]::InputEncoding = $utf8NoBom",
 	"[Console]::OutputEncoding = $utf8NoBom",
 	"$OutputEncoding = $utf8NoBom",
-	"$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'",
 }
 
 func powerShellPreamble() string {
@@ -106,7 +104,9 @@ func scriptLineOffset(scriptFile string) int {
 }
 
 // preprocessScript returns the script content adjusted for the shell indicated by ext.
-// For ".ps1" it prepends PowerShell directives that make cmdlet errors and non-zero exit codes stop execution; for other extensions it returns the original script.
+// For ".ps1" it prepends PowerShell directives that make cmdlet errors stop
+// execution and normalize UTF-8 console/pipeline encoding; for other extensions
+// it returns the original script.
 func preprocessScript(script, ext string) string {
 	switch ext {
 	case ".ps1":

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -47,6 +47,16 @@ func expectedPowerShellScriptArgs(shell, script string) []string {
 	return []string{shell, "-ExecutionPolicy", "Bypass", "-NoProfile", "-NonInteractive", "-File", script}
 }
 
+func TestPowerShellPreambleUsesLegacyCompatibleSyntax(t *testing.T) {
+	preamble := powerShellPreamble()
+
+	assert.NotContains(t, preamble, "::new(")
+	assert.NotContains(t, preamble, "PSNativeCommandUseErrorActionPreference")
+	assert.NotContains(t, preamble, "PSDefaultParameterValues")
+	assert.NotContains(t, preamble, "Out-File:Encoding")
+	assert.Contains(t, preamble, "New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false")
+}
+
 func TestDirectShell(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Ref: https://github.com/dagucloud/dagu/issues/2116


## Summary
- replace generated PowerShell static constructor syntax with `New-Object` for old Windows PowerShell compatibility
- remove optional modern PowerShell native-command and default-parameter preamble settings from generated scripts
- add regression coverage that rejects modern PowerShell-only preamble constructs

## Root Cause
- Windows Server 2012 R2 ships Windows PowerShell 4.0, where `[Type]::new()` is not available.
- Dagu generated child DAG `.ps1` scripts with `[System.Text.UTF8Encoding]::new(...)`, so sub-DAG command scripts could fail before the user script executed.

## Testing
- `go test ./internal/runtime/builtin/command -count=1`
- `go test ./internal/intg -run 'TestInlineSubDAG/(TwoLevelNesting|ThreeLevelNesting|ThreeLevelNestingWithOutputPassing)|TestExternalSubDAG/(BasicOutputCapture|RetrySubDAGRun)' -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UTF-8 encoding compatibility in PowerShell command execution for improved support of legacy systems.

* **Tests**
  * Added validation test for PowerShell encoding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->