### PR TITLE
fix: avoid recursive lock cleanup on old windows

### DIFF
--- a/internal/cmn/dirlock/dirlock.go
+++ b/internal/cmn/dirlock/dirlock.go
@@ -94,6 +94,8 @@ type dirLock struct {
 
 var _ DirLock = (*dirLock)(nil)
 
+const lockOwnerFileName = "owner"
+
 // New creates a new directory lock instance
 func New(directory string, opts *LockOptions) DirLock {
 	// Set default options if not provided
@@ -126,7 +128,7 @@ func (l *dirLock) Heartbeat(_ context.Context) error {
 	}
 
 	// Verify we still own the lock by checking the fence token
-	tokenPath := filepath.Join(l.lockPath, "owner")
+	tokenPath := filepath.Join(l.lockPath, lockOwnerFileName)
 	data, err := os.ReadFile(tokenPath) //nolint:gosec // path is constructed from lock directory, not user input
 	if err != nil {
 		l.isHeld = false
@@ -161,11 +163,11 @@ func (l *dirLock) TryLock() error {
 		// Lock exists, check if it's stale
 		if l.isStaleInfo(info) {
 			// This is detection-based, not prevention-based: two contenders may
-			// both observe a stale lock and one RemoveAll can race with the
+			// both observe a stale lock and one cleanup can race with the
 			// other's new lock creation. The fence token lets us detect ownership
 			// loss on the next Heartbeat/IsHeldByMe check and self-fence safely.
 			// Remove stale lock
-			if err := os.RemoveAll(l.lockPath); err != nil && !os.IsNotExist(err) {
+			if err := removeLockDir(l.lockPath); err != nil && !os.IsNotExist(err) {
 				if isRetryableLockStateError(err) {
 					return ErrLockConflict
 				}
@@ -202,9 +204,9 @@ func (l *dirLock) TryLock() error {
 		hostname = "unknown-host"
 	}
 	token := newFenceToken(hostname)
-	tokenPath := filepath.Join(l.lockPath, "owner")
+	tokenPath := filepath.Join(l.lockPath, lockOwnerFileName)
 	if err := os.WriteFile(tokenPath, []byte(token), 0600); err != nil {
-		_ = os.RemoveAll(l.lockPath)
+		_ = removeLockDir(l.lockPath)
 		return fmt.Errorf("failed to write lock token: %w", err)
 	}
 	l.fenceToken = token
@@ -264,7 +266,7 @@ func (l *dirLock) Unlock() error {
 	}
 
 	// Verify we still own the lock before removing
-	tokenPath := filepath.Join(l.lockPath, "owner")
+	tokenPath := filepath.Join(l.lockPath, lockOwnerFileName)
 	data, err := os.ReadFile(tokenPath) //nolint:gosec // path is constructed from lock directory, not user input
 	if err != nil {
 		l.isHeld = false
@@ -277,7 +279,7 @@ func (l *dirLock) Unlock() error {
 	}
 
 	// We still own the lock — safe to remove.
-	if err := os.RemoveAll(l.lockPath); err != nil && !os.IsNotExist(err) {
+	if err := removeLockDir(l.lockPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove lock directory: %w", err)
 	}
 
@@ -305,7 +307,7 @@ func (l *dirLock) IsHeldByMe() bool {
 	}
 
 	// Verify the fence token still matches
-	tokenPath := filepath.Join(l.lockPath, "owner")
+	tokenPath := filepath.Join(l.lockPath, lockOwnerFileName)
 	data, err := os.ReadFile(tokenPath) //nolint:gosec // path is constructed from lock directory, not user input
 	if err != nil || string(data) != l.fenceToken {
 		l.isHeld = false
@@ -338,8 +340,23 @@ func (l *dirLock) Info() (*LockInfo, error) {
 // ForceUnlock forcibly removes a lock (administrative operation)
 func ForceUnlock(directory string) error {
 	lockPath := filepath.Join(directory, ".dagu_lock")
-	if err := os.RemoveAll(lockPath); err != nil && !os.IsNotExist(err) {
+	if err := removeLockDir(lockPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to force unlock: %w", err)
+	}
+	return nil
+}
+
+func removeLockDir(lockPath string) error {
+	// The scheduler lock directory is intentionally shallow: Dagu creates only
+	// the owner token file inside it. Avoid os.RemoveAll here because recent Go
+	// releases use recursive open-at cleanup paths that are not reliable on old
+	// Windows versions such as Windows Server 2012 R2.
+	ownerPath := filepath.Join(lockPath, lockOwnerFileName)
+	if err := os.Remove(ownerPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/cmn/dirlock/dirlock_test.go
+++ b/internal/cmn/dirlock/dirlock_test.go
@@ -301,6 +301,38 @@ func TestStaleDetection(t *testing.T) {
 	})
 }
 
+func TestRemoveLockDir(t *testing.T) {
+	t.Run("WithOwnerFile", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, ".dagu_lock")
+		require.NoError(t, os.Mkdir(lockPath, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(lockPath, lockOwnerFileName), []byte("token"), 0600))
+
+		require.NoError(t, removeLockDir(lockPath))
+
+		_, err := os.Stat(lockPath)
+		require.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("EmptyLockDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, ".dagu_lock")
+		require.NoError(t, os.Mkdir(lockPath, 0700))
+
+		require.NoError(t, removeLockDir(lockPath))
+
+		_, err := os.Stat(lockPath)
+		require.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("MissingLockDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, ".dagu_lock")
+
+		require.NoError(t, removeLockDir(lockPath))
+	})
+}
+
 func TestForceUnlock(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/intg/queue/fixture_test.go
+++ b/internal/intg/queue/fixture_test.go
@@ -278,6 +278,21 @@ func (f *fixture) WaitForAllStatuses(expected core.Status, timeout time.Duration
 	return f
 }
 
+func (f *fixture) WaitForAllStopped(timeout time.Duration) *fixture {
+	f.t.Helper()
+	timeout = queueTestTimeout(timeout)
+	require.Eventually(f.t, func() bool {
+		for _, runID := range f.runIDs {
+			alive, err := f.th.ProcStore.IsRunAlive(f.th.Context, f.queue, exec.NewDAGRunRef(f.dag.Name, runID))
+			if err != nil || alive {
+				return false
+			}
+		}
+		return true
+	}, timeout, 50*time.Millisecond, "timed out waiting for queued runs to stop")
+	return f
+}
+
 // Stop stops the scheduler.
 func (f *fixture) Stop() {
 	if f.cancel != nil {

--- a/internal/intg/queue/queue_test.go
+++ b/internal/intg/queue/queue_test.go
@@ -6,10 +6,8 @@ package queue_test
 import (
 	"fmt"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -61,16 +59,15 @@ steps:
 }
 
 func TestGlobalConcurrency(t *testing.T) {
-	sleepDuration := time.Second
+	startedDir := t.TempDir()
+	releaseFile := filepath.Join(t.TempDir(), "release")
 	maxDiff := 2 * time.Second
 	switch {
 	case runtime.GOOS == "windows" && raceEnabled():
-		sleepDuration = 12 * time.Second
 		maxDiff = 10 * time.Second
 	case runtime.GOOS == "windows":
 		// StartedAt is second-granularity in persisted queue statuses, so give
 		// Windows enough overlap budget to avoid false negatives from rounding.
-		sleepDuration = 6 * time.Second
 		maxDiff = 5 * time.Second
 	}
 
@@ -79,42 +76,63 @@ name: sleep-dag
 queue: global-queue
 steps:
   - name: sleep
-    %s
-`, directSleepStepYAML(t, sleepDuration)), WithQueue("global-queue"), WithGlobalQueue("global-queue", 3)).
+    command: |
+%s
+`, indentQueueTestScript(markQueueRunStartedAndWaitCommand(startedDir, releaseFile), 6)), WithQueue("global-queue"), WithGlobalQueue("global-queue", 3)).
 		Enqueue(3).StartScheduler(30 * time.Second)
+	released := false
+	stopped := false
+	defer func() {
+		if !released {
+			_ = os.WriteFile(releaseFile, []byte("release"), 0600)
+		}
+		if !stopped {
+			f.Stop()
+		}
+	}()
 
 	f.WaitDrain(35 * time.Second)
-	f.WaitForAllStatuses(core.Succeeded, 20*time.Second)
-	f.Stop()
+	waitForStartedQueueRuns(t, startedDir, 3, 20*time.Second)
 	f.AssertConcurrent(maxDiff)
+
+	require.NoError(t, os.WriteFile(releaseFile, []byte("release"), 0600))
+	released = true
+	f.WaitForAllStatuses(core.Succeeded, 20*time.Second)
+	f.WaitForAllStopped(10 * time.Second)
+	f.Stop()
+	stopped = true
 }
 
-func directSleepStepYAML(t *testing.T, d time.Duration) string {
-	t.Helper()
-
-	if runtime.GOOS == "windows" {
-		commandPath, err := osexec.LookPath("ping")
-		require.NoError(t, err)
-
-		seconds := max(int((d+time.Second-1)/time.Second), 1)
-
-		return fmt.Sprintf(
-			"exec:\n      command: %s\n      args: [%s, %s, %s]",
-			strconv.Quote(commandPath),
-			strconv.Quote("-n"),
-			strconv.Quote(strconv.Itoa(seconds+1)),
-			strconv.Quote("127.0.0.1"),
-		)
-	}
-
-	commandPath, err := osexec.LookPath("sleep")
-	require.NoError(t, err)
-
-	return fmt.Sprintf(
-		"exec:\n      command: %s\n      args: [%s]",
-		strconv.Quote(commandPath),
-		strconv.Quote(strconv.FormatFloat(d.Seconds(), 'f', -1, 64)),
+func markQueueRunStartedAndWaitCommand(startedDir, releaseFile string) string {
+	return test.ForOS(
+		fmt.Sprintf(`mkdir -p %s
+: > %s/"started-$$"
+while [ ! -f %s ]; do
+  sleep 0.05
+done`, test.PosixQuote(startedDir), test.PosixQuote(startedDir), test.PosixQuote(releaseFile)),
+		fmt.Sprintf(`New-Item -ItemType Directory -Path %s -Force | Out-Null
+New-Item -ItemType File -Path (Join-Path %s ("started-" + [guid]::NewGuid().ToString())) -Force | Out-Null
+while (-not (Test-Path %s)) {
+  Start-Sleep -Milliseconds 50
+}`, test.PowerShellQuote(startedDir), test.PowerShellQuote(startedDir), test.PowerShellQuote(releaseFile)),
 	)
+}
+
+func indentQueueTestScript(script string, spaces int) string {
+	indent := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimRight(script, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = indent + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func waitForStartedQueueRuns(t *testing.T, startedDir string, want int, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		entries, err := os.ReadDir(startedDir)
+		return err == nil && len(entries) >= want
+	}, queueTestTimeout(timeout), 50*time.Millisecond)
 }
 
 func TestLocalQueueFIFOProcessing(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace scheduler dirlock cleanup with shallow owner-file removal instead of recursive RemoveAll
- reuse the lock owner filename consistently across acquire, heartbeat, unlock, and force unlock
- add regression coverage for expected lock directory cleanup cases

## Testing
- go test ./internal/cmn/dirlock -count=1
- go test ./internal/service/scheduler -count=1
- git diff --check

Refs #2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved lock cleanup operations to handle edge cases more robustly.

* **Tests**
  * Added comprehensive test coverage for lock directory cleanup across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->