### PR TITLE
fix: load .env from env-based working_dir

### DIFF
--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -539,6 +539,7 @@ func (d *DAG) loadDotEnvFiles(ctx context.Context) {
 	}
 }
 
+// dotenvEnvScope builds the variable scope used to resolve dotenv search paths.
 func (d *DAG) dotenvEnvScope() *eval.EnvScope {
 	scope := eval.NewEnvScope(nil, true)
 	if params := keyValuesToMap(d.Params); len(params) > 0 {
@@ -553,6 +554,7 @@ func (d *DAG) dotenvEnvScope() *eval.EnvScope {
 	return scope
 }
 
+// keyValuesToMap converts KEY=value entries into a map for env scope construction.
 func keyValuesToMap(entries []string) map[string]string {
 	if len(entries) == 0 {
 		return nil
@@ -572,6 +574,7 @@ func keyValuesToMap(entries []string) map[string]string {
 	return values
 }
 
+// expandDotEnvPath expands a dotenv-related path without mutating the DAG definition.
 func expandDotEnvPath(path string, scope *eval.EnvScope) string {
 	if scope == nil {
 		return os.ExpandEnv(path)

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -518,8 +518,16 @@ func (d *DAG) loadDotEnvFiles(ctx context.Context) {
 		return
 	}
 
-	relativeTos := []string{d.WorkingDir}
-	if fileDir := filepath.Dir(d.Location); d.Location != "" && fileDir != d.WorkingDir {
+	scope := d.dotenvEnvScope()
+	evalCtx := ctx
+	if evalCtx == nil {
+		evalCtx = context.Background()
+	}
+	evalCtx = eval.WithEnvScope(evalCtx, scope)
+
+	workingDir := expandDotEnvPath(d.WorkingDir, scope)
+	relativeTos := []string{workingDir}
+	if fileDir := filepath.Dir(d.Location); d.Location != "" && fileDir != workingDir {
 		relativeTos = append(relativeTos, fileDir)
 	}
 
@@ -527,8 +535,48 @@ func (d *DAG) loadDotEnvFiles(ctx context.Context) {
 	candidates := deduplicateStrings(append([]string{".env"}, d.Dotenv...))
 
 	for _, filePath := range candidates {
-		d.loadSingleDotEnvFile(ctx, resolver, filePath)
+		d.loadSingleDotEnvFile(evalCtx, resolver, filePath)
 	}
+}
+
+func (d *DAG) dotenvEnvScope() *eval.EnvScope {
+	scope := eval.NewEnvScope(nil, true)
+	if params := keyValuesToMap(d.Params); len(params) > 0 {
+		scope = scope.WithEntries(params, eval.EnvSourceParam)
+	}
+	if len(d.PresolvedBuildEnv) > 0 {
+		scope = scope.WithEntries(d.PresolvedBuildEnv, eval.EnvSourcePresolved)
+	}
+	if envs := keyValuesToMap(d.Env); len(envs) > 0 {
+		scope = scope.WithEntries(envs, eval.EnvSourceDAGEnv)
+	}
+	return scope
+}
+
+func keyValuesToMap(entries []string) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		values[key] = value
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func expandDotEnvPath(path string, scope *eval.EnvScope) string {
+	if scope == nil {
+		return os.ExpandEnv(path)
+	}
+	return scope.Expand(path)
 }
 
 // loadSingleDotEnvFile loads a single dotenv file and appends its variables to d.Env.

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/buildenv"
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
@@ -542,36 +543,16 @@ func (d *DAG) loadDotEnvFiles(ctx context.Context) {
 // dotenvEnvScope builds the variable scope used to resolve dotenv search paths.
 func (d *DAG) dotenvEnvScope() *eval.EnvScope {
 	scope := eval.NewEnvScope(nil, true)
-	if params := keyValuesToMap(d.Params); len(params) > 0 {
+	if params := buildenv.ToMap(d.Params); len(params) > 0 {
 		scope = scope.WithEntries(params, eval.EnvSourceParam)
 	}
 	if len(d.PresolvedBuildEnv) > 0 {
 		scope = scope.WithEntries(d.PresolvedBuildEnv, eval.EnvSourcePresolved)
 	}
-	if envs := keyValuesToMap(d.Env); len(envs) > 0 {
+	if envs := buildenv.ToMap(d.Env); len(envs) > 0 {
 		scope = scope.WithEntries(envs, eval.EnvSourceDAGEnv)
 	}
 	return scope
-}
-
-// keyValuesToMap converts KEY=value entries into a map for env scope construction.
-func keyValuesToMap(entries []string) map[string]string {
-	if len(entries) == 0 {
-		return nil
-	}
-
-	values := make(map[string]string, len(entries))
-	for _, entry := range entries {
-		key, value, ok := strings.Cut(entry, "=")
-		if !ok || key == "" {
-			continue
-		}
-		values[key] = value
-	}
-	if len(values) == 0 {
-		return nil
-	}
-	return values
 }
 
 // expandDotEnvPath expands a dotenv-related path without mutating the DAG definition.

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -3424,6 +3424,7 @@ steps:
 	})
 }
 
+// TestDAGLoadEnv verifies dotenv loading preserves DAG envs and search precedence.
 func TestDAGLoadEnv(t *testing.T) {
 	t.Run("LoadEnvWithDotenvAndEnvVars", func(t *testing.T) {
 		// Create a temp directory with a .env file
@@ -3553,6 +3554,7 @@ steps:
 	})
 }
 
+// envSliceMap converts KEY=value env entries into a map for test assertions.
 func envSliceMap(envs []string) map[string]string {
 	envMap := make(map[string]string)
 	for _, env := range envs {

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -3489,6 +3489,79 @@ steps:
 		}
 		assert.Equal(t, "test_value", envMap["TEST_VAR_LOAD_ENV"])
 	})
+
+	t.Run("LoadEnvFromBaseEnvResolvedWorkingDir", func(t *testing.T) {
+		root := t.TempDir()
+		workDir := filepath.Join(root, "work", "quant-signal")
+		dagDir := filepath.Join(root, "dags")
+		require.NoError(t, os.MkdirAll(workDir, 0750))
+		require.NoError(t, os.MkdirAll(dagDir, 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\n"), 0600))
+
+		baseConfig := filepath.Join(root, "base.yaml")
+		require.NoError(t, os.WriteFile(baseConfig, fmt.Appendf(nil, `
+env:
+  - QUANT_SIGNAL_DIR: %q
+`, workDir), 0600))
+
+		dagFile := filepath.Join(dagDir, "health-check.yaml")
+		require.NoError(t, os.WriteFile(dagFile, []byte(`
+working_dir: ${QUANT_SIGNAL_DIR}
+steps:
+  - command: printenv QUANT_SIGNAL_DIR PYTHON_BIN
+`), 0600))
+
+		dag, err := spec.Load(context.Background(), dagFile, spec.WithBaseConfig(baseConfig))
+		require.NoError(t, err)
+
+		dag.LoadDotEnv(context.Background())
+
+		envMap := envSliceMap(dag.Env)
+		assert.Equal(t, workDir, envMap["QUANT_SIGNAL_DIR"])
+		assert.Equal(t, "/usr/local/bin/python", envMap["PYTHON_BIN"])
+	})
+
+	t.Run("LoadEnvPrefersResolvedWorkingDirOverDAGFileDir", func(t *testing.T) {
+		root := t.TempDir()
+		workDir := filepath.Join(root, "work", "quant-signal")
+		dagDir := filepath.Join(root, "dags")
+		require.NoError(t, os.MkdirAll(workDir, 0750))
+		require.NoError(t, os.MkdirAll(dagDir, 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\n"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dagDir, ".env"), []byte("PYTHON_BIN=/wrong/from-dag-dir\n"), 0600))
+
+		baseConfig := filepath.Join(root, "base.yaml")
+		require.NoError(t, os.WriteFile(baseConfig, fmt.Appendf(nil, `
+env:
+  - QUANT_SIGNAL_DIR: %q
+`, workDir), 0600))
+
+		dagFile := filepath.Join(dagDir, "health-check.yaml")
+		require.NoError(t, os.WriteFile(dagFile, []byte(`
+working_dir: ${QUANT_SIGNAL_DIR}
+steps:
+  - command: printenv QUANT_SIGNAL_DIR PYTHON_BIN
+`), 0600))
+
+		dag, err := spec.Load(context.Background(), dagFile, spec.WithBaseConfig(baseConfig))
+		require.NoError(t, err)
+
+		dag.LoadDotEnv(context.Background())
+
+		envMap := envSliceMap(dag.Env)
+		assert.Equal(t, "/usr/local/bin/python", envMap["PYTHON_BIN"])
+	})
+}
+
+func envSliceMap(envs []string) map[string]string {
+	envMap := make(map[string]string)
+	for _, env := range envs {
+		key, value, found := strings.Cut(env, "=")
+		if found {
+			envMap[key] = value
+		}
+	}
+	return envMap
 }
 
 func TestBuildShell(t *testing.T) {

--- a/internal/intg/cfg_test.go
+++ b/internal/intg/cfg_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/test"
 	"github.com/stretchr/testify/require"
@@ -648,6 +649,52 @@ steps:
 		// The test should fail with the current implementation
 		dag.AssertLatestStatus(t, core.Succeeded)
 	})
+}
+
+func TestDotEnvUsesResolvedWorkingDirFromBaseEnv(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	workDir := filepath.Join(baseDir, "signals")
+	require.NoError(t, os.MkdirAll(workDir, 0750))
+	if resolved, err := filepath.EvalSymlinks(workDir); err == nil {
+		workDir = resolved
+	}
+	workDirForYAML := filepath.ToSlash(workDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\n"), 0600))
+
+	baseConfigPath := filepath.Join(baseDir, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfigPath, []byte(fmt.Sprintf(`env:
+  - QUANT_SIGNAL_DIR: %q
+`, workDirForYAML)), 0600))
+
+	th := test.Setup(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Paths.BaseConfig = baseConfigPath
+	}))
+
+	require.NoError(t, os.MkdirAll(th.Config.Paths.DAGsDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(th.Config.Paths.DAGsDir, ".env"), []byte("PYTHON_BIN=wrong-from-dag-dir\n"), 0600))
+
+	pwdCommand := test.ForOS("pwd", "(Get-Location).Path")
+	dag := th.DAG(t, `dotenv: .env
+working_dir: ${QUANT_SIGNAL_DIR}
+steps:
+  - name: check-env
+    command: |
+`+indentTestScript(test.EnvOutput("QUANT_SIGNAL_DIR", "PYTHON_BIN"), 6)+`
+    output: ENV_RESULT
+  - name: check-pwd
+    command: |
+`+indentTestScript(pwdCommand, 6)+`
+    output: PWD_RESULT
+`)
+
+	dag.Agent().RunSuccess(t)
+
+	outputs := dag.ReadOutputs(t)
+	require.Equal(t, workDirForYAML+"|/usr/local/bin/python", outputs["envResult"])
+	require.Equal(t, canonicalTestPath(workDir), canonicalTestPath(outputs["pwdResult"]))
 }
 
 func TestCallSubDAG(t *testing.T) {

--- a/internal/intg/cfg_test.go
+++ b/internal/intg/cfg_test.go
@@ -665,9 +665,9 @@ func TestDotEnvUsesResolvedWorkingDirFromBaseEnv(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\n"), 0600))
 
 	baseConfigPath := filepath.Join(baseDir, "base.yaml")
-	require.NoError(t, os.WriteFile(baseConfigPath, []byte(fmt.Sprintf(`env:
+	require.NoError(t, os.WriteFile(baseConfigPath, fmt.Appendf(nil, `env:
   - QUANT_SIGNAL_DIR: %q
-`, workDirForYAML)), 0600))
+`, workDirForYAML), 0600))
 
 	th := test.Setup(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Paths.BaseConfig = baseConfigPath


### PR DESCRIPTION
## Summary
- resolve dotenv lookup bases using the same DAG/base env scope that can feed working_dir
- keep runtime working_dir expansion unchanged while making .env discovery match the resolved directory
- add regression coverage for env-based working_dir and DAG-dir fallback masking

Fixes #2135

## Testing
- go test ./internal/core/spec -run TestDAGLoadEnv -count=1
- go test ./internal/core/... -count=1
- git diff --check -- internal/core/dag.go internal/core/spec/builder_test.go


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable .env loading when a working directory is set via variables — resolved working directory is expanded before discovery so its .env takes precedence.
  * Improved path expansion and evaluation during dotenv loading to ensure correct values are applied.

* **Tests**
  * Added tests covering .env loading with resolved working directories and precedence scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2140)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->