### PR TITLE
fix: avoid recursive dag-run cleanup on old windows

### DIFF
--- a/internal/cmn/fileutil/retry.go
+++ b/internal/cmn/fileutil/retry.go
@@ -57,6 +57,7 @@ func RemoveAllWithRetry(path string) error {
 	return removeAllWithRetry(path, info)
 }
 
+// removeAllWithRetry recursively removes path's children before removing path.
 func removeAllWithRetry(path string, info os.FileInfo) error {
 	if !info.IsDir() {
 		if err := RemoveWithRetry(path); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/cmn/fileutil/retry.go
+++ b/internal/cmn/fileutil/retry.go
@@ -6,6 +6,7 @@ package fileutil
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -37,6 +38,63 @@ func RemoveWithRetry(path string) error {
 	return retryWindowsFileOp(func() error {
 		return os.Remove(path)
 	})
+}
+
+// RemoveAllWithRetry removes a tree without using os.RemoveAll's recursive
+// open-at path, which fails on older Windows versions with openfdat errors.
+func RemoveAllWithRetry(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return removeAllWithRetry(path, info)
+}
+
+func removeAllWithRetry(path string, info os.FileInfo) error {
+	if !info.IsDir() {
+		if err := RemoveWithRetry(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+
+	var firstErr error
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		firstErr = err
+	}
+
+	for _, entry := range entries {
+		childPath := filepath.Join(path, entry.Name())
+		childInfo, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := removeAllWithRetry(childPath, childInfo); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if err := RemoveWithRetry(path); err != nil && !errors.Is(err, os.ErrNotExist) && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 // RenameWithRetry retries transient Windows sharing violations while renaming a file.

--- a/internal/cmn/fileutil/retry.go
+++ b/internal/cmn/fileutil/retry.go
@@ -114,6 +114,7 @@ func ReplaceFileWithRetry(source, target string) error {
 	})
 }
 
+// retryWindowsFileOp retries transient Windows file operation failures.
 func retryWindowsFileOp(op func() error) error {
 	err := op()
 	if err == nil || !isTransientWindowsFileError(err) {
@@ -136,6 +137,7 @@ func retryWindowsFileOp(op func() error) error {
 	return err
 }
 
+// isTransientWindowsFileError reports whether err is a retryable Windows file error.
 func isTransientWindowsFileError(err error) bool {
 	if runtime.GOOS != "windows" || err == nil {
 		return false

--- a/internal/cmn/fileutil/retry_test.go
+++ b/internal/cmn/fileutil/retry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestReplaceFileWithRetry verifies replacing existing and missing target files.
 func TestReplaceFileWithRetry(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +50,7 @@ func TestReplaceFileWithRetry(t *testing.T) {
 	})
 }
 
+// TestRemoveAllWithRetry verifies recursive removal and symlink handling.
 func TestRemoveAllWithRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/fileutil/retry_test.go
+++ b/internal/cmn/fileutil/retry_test.go
@@ -6,6 +6,7 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,5 +46,54 @@ func TestReplaceFileWithRetry(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []byte("new"), data)
 		require.NoFileExists(t, source)
+	})
+}
+
+func TestRemoveAllWithRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes nested directory tree", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		nested := filepath.Join(target, "a", "b")
+		require.NoError(t, os.MkdirAll(nested, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(target, "root.txt"), []byte("root"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(nested, "leaf.txt"), []byte("leaf"), 0o600))
+
+		require.NoError(t, RemoveAllWithRetry(target))
+
+		require.NoDirExists(t, target)
+	})
+
+	t.Run("missing path is success", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, RemoveAllWithRetry(filepath.Join(t.TempDir(), "missing")))
+	})
+
+	t.Run("removes symlink without following target", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		external := filepath.Join(dir, "external")
+		require.NoError(t, os.MkdirAll(external, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(external, "keep.txt"), []byte("keep"), 0o600))
+
+		target := filepath.Join(dir, "target")
+		require.NoError(t, os.MkdirAll(target, 0o750))
+		link := filepath.Join(target, "external-link")
+		if err := os.Symlink(external, link); err != nil {
+			if runtime.GOOS == "windows" {
+				t.Skipf("creating symlinks requires privilege on Windows: %v", err)
+			}
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, RemoveAllWithRetry(target))
+
+		require.NoDirExists(t, target)
+		require.FileExists(t, filepath.Join(external, "keep.txt"))
 	})
 }

--- a/internal/persis/filedagrun/dagrun.go
+++ b/internal/persis/filedagrun/dagrun.go
@@ -250,7 +250,7 @@ func (dr DAGRun) Remove(ctx context.Context) error {
 			tag.Error(err),
 			tag.RunID(dr.dagRunID))
 	}
-	return os.RemoveAll(dr.baseDir)
+	return fileutil.RemoveAllWithRetry(dr.baseDir)
 }
 
 // removeLogFiles removes all log files associated with the dag-run and its sub dag-runs.
@@ -305,7 +305,7 @@ func (dr DAGRun) removeLogFiles(ctx context.Context) error {
 		if file == "" {
 			continue
 		}
-		if err := os.Remove(file); err != nil {
+		if err := fileutil.RemoveWithRetry(file); err != nil {
 			logger.Error(ctx, "Failed to remove log file",
 				tag.Error(err),
 				tag.RunID(dr.dagRunID),
@@ -322,7 +322,7 @@ func (dr DAGRun) removeLogFiles(ctx context.Context) error {
 			)
 			continue
 		}
-		if err := os.RemoveAll(validDir); err != nil {
+		if err := fileutil.RemoveAllWithRetry(validDir); err != nil {
 			logger.Error(ctx, "Failed to remove artifact directory",
 				tag.Error(err),
 				tag.RunID(dr.dagRunID),
@@ -334,7 +334,7 @@ func (dr DAGRun) removeLogFiles(ctx context.Context) error {
 
 	// Remove parent dirs if they are empty.
 	for p := range parentDirs {
-		_ = os.Remove(p)
+		_ = fileutil.RemoveWithRetry(p)
 	}
 
 	return nil

--- a/internal/persis/filedagrun/dataroot.go
+++ b/internal/persis/filedagrun/dataroot.go
@@ -286,7 +286,7 @@ func (dr DataRoot) IsEmpty() bool {
 // Remove completely removes the dag-runs directory and all its contents.
 // This operation cannot be undone.
 func (dr DataRoot) Remove() error {
-	if err := os.RemoveAll(dr.dagRunsDir); err != nil {
+	if err := fileutil.RemoveAllWithRetry(dr.dagRunsDir); err != nil {
 		return fmt.Errorf("failed to remove directory %s: %w", dr.dagRunsDir, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- add a retrying depth-first directory removal helper that avoids Go's recursive open-at cleanup path
- use it when deleting DAG-run archive trees, artifact directories, and DAG-run data roots
- add regression coverage for nested tree removal, missing-path idempotency, and symlink safety

## Root cause
`DELETE /api/v1/dag-runs/{name}/{dagRunId}` reaches `DAGRun.Remove`, which used `os.RemoveAll` for the run archive directory. On Windows Server 2012 R2 with recent Go builds, recursive `os.RemoveAll` can fail in the stdlib `openfdat` path with `The parameter is incorrect`, causing Dagu to return a 500 while deleting completed executions.

## Testing
- go test ./internal/cmn/fileutil -count=1
- go test ./internal/persis/filedagrun -count=1
- go test ./internal/service/frontend/api/v1 -run TestDeleteDAGRun -count=1
- GOOS=windows GOARCH=amd64 go test -c ./internal/cmn/fileutil -o /tmp/dagu-fileutil.test.exe
- GOOS=windows GOARCH=amd64 go test -c ./internal/persis/filedagrun -o /tmp/dagu-filedagrun.test.exe
- git diff --check

Closes #2137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new exported removal API that performs retrying directory deletions.

* **Bug Fixes**
  * Improved reliability of directory and file removals with retrying deletion to handle transient filesystem errors.
  * Deletion treats already-missing targets as success and removes symlinks without following their targets, improving artifact cleanup robustness.

* **Tests**
  * Added tests covering recursive removal, missing-path handling, and symlink removal behavior.

* **Documentation**
  * Updated file-level comments clarifying retry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2141)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->