### PR TITLE
fix: repair stale distributed sub-dag leases

### DIFF
--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -617,12 +617,8 @@ func (s *dagRunManageTestStore) ListStatusesPage(_ context.Context, opts ...exec
 	return s.page, nil
 }
 
-func (s *dagRunManageTestStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+func (s *dagRunManageTestStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error, ...exec.CompareAndSwapStatusOption) (*exec.DAGRunStatus, bool, error) {
 	return nil, false, errors.New("unexpected CompareAndSwapLatestAttemptStatus")
-}
-
-func (s *dagRunManageTestStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
-	return nil, false, errors.New("unexpected CompareAndSwapAttemptStatus")
 }
 
 func (s *dagRunManageTestStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {

--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -621,6 +621,10 @@ func (s *dagRunManageTestStore) CompareAndSwapLatestAttemptStatus(context.Contex
 	return nil, false, errors.New("unexpected CompareAndSwapLatestAttemptStatus")
 }
 
+func (s *dagRunManageTestStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, errors.New("unexpected CompareAndSwapAttemptStatus")
+}
+
 func (s *dagRunManageTestStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	return &dagRunManageTestAttempt{status: s.status, messages: s.messages, messageErr: s.messageErr}, nil
 }

--- a/internal/cmd/enqueue_internal_test.go
+++ b/internal/cmd/enqueue_internal_test.go
@@ -98,11 +98,7 @@ func (s *enqueueTrackingDAGRunStore) ListStatusesPage(context.Context, ...exec.L
 	return exec.DAGRunStatusPage{}, nil
 }
 
-func (s *enqueueTrackingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
-	return nil, false, nil
-}
-
-func (s *enqueueTrackingDAGRunStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+func (s *enqueueTrackingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error, ...exec.CompareAndSwapStatusOption) (*exec.DAGRunStatus, bool, error) {
 	return nil, false, nil
 }
 

--- a/internal/cmd/enqueue_internal_test.go
+++ b/internal/cmd/enqueue_internal_test.go
@@ -102,6 +102,10 @@ func (s *enqueueTrackingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.C
 	return nil, false, nil
 }
 
+func (s *enqueueTrackingDAGRunStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
 func (s *enqueueTrackingDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	return nil, exec.ErrDAGRunIDNotFound
 }

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -176,21 +176,9 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	args := m.Called(ctx, dagRun, expectedAttemptID, expectedStatus, mutate)
-	if args.Get(0) == nil {
-		return nil, args.Bool(1), args.Error(2)
-	}
-	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
-}
-
-func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	args := m.Called(ctx, ref, expectedStatus, mutate)
 	if args.Get(0) == nil {
 		return nil, args.Bool(1), args.Error(2)
 	}

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -184,6 +184,19 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
 }
 
+func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	args := m.Called(ctx, ref, expectedStatus, mutate)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1), args.Error(2)
+	}
+	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
+}
+
 func (m *mockDAGRunStore) FindAttempt(ctx context.Context, dagRun exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	args := m.Called(ctx, dagRun)
 	if args.Get(0) == nil {

--- a/internal/core/exec/dagrun.go
+++ b/internal/core/exec/dagrun.go
@@ -71,14 +71,7 @@ type DAGRunStore interface {
 		expectedAttemptID string,
 		expectedStatus core.Status,
 		mutate func(*DAGRunStatus) error,
-	) (*DAGRunStatus, bool, error)
-	// CompareAndSwapAttemptStatus atomically updates a root or sub-DAG attempt
-	// status when both the latest attempt identity and status still match.
-	CompareAndSwapAttemptStatus(
-		ctx context.Context,
-		attempt DAGRunAttemptRef,
-		expectedStatus core.Status,
-		mutate func(*DAGRunStatus) error,
+		opts ...CompareAndSwapStatusOption,
 	) (*DAGRunStatus, bool, error)
 	// FindAttempt finds the latest attempt for the dag-run.
 	FindAttempt(ctx context.Context, dagRun DAGRunRef) (DAGRunAttempt, error)
@@ -271,14 +264,6 @@ type DAGRunRef struct {
 	ID   string `json:"id,omitempty"`
 }
 
-// DAGRunAttemptRef identifies a concrete root or sub-DAG attempt.
-type DAGRunAttemptRef struct {
-	DAGRun     DAGRunRef
-	Root       DAGRunRef
-	AttemptID  string
-	AttemptKey string
-}
-
 // NewDAGRunRef creates a new reference to dag-run with the given DAG name and run ID.
 // It is used to identify a specific dag-run.
 func NewDAGRunRef(name, runID string) DAGRunRef {
@@ -298,20 +283,41 @@ func (e DAGRunRef) Zero() bool {
 	return e == zeroRef
 }
 
-// IsSubDAG returns true when the attempt is stored under a different root run.
-func (r DAGRunAttemptRef) IsSubDAG() bool {
-	if r.Root.Zero() || r.Root.ID == "" {
-		return false
-	}
-	return r.Root.ID != r.DAGRun.ID || r.Root.Name != r.DAGRun.Name
+// CompareAndSwapStatusOptions configures additional identity guards for
+// CompareAndSwapLatestAttemptStatus.
+type CompareAndSwapStatusOptions struct {
+	RootDAGRun         DAGRunRef
+	ExpectedAttemptKey string
 }
 
-// RootOrDAGRun returns the root reference for locking and lookup.
-func (r DAGRunAttemptRef) RootOrDAGRun() DAGRunRef {
-	if r.Root.Zero() {
-		return r.DAGRun
+// CompareAndSwapStatusOption configures CompareAndSwapLatestAttemptStatus.
+type CompareAndSwapStatusOption func(*CompareAndSwapStatusOptions)
+
+// WithCompareAndSwapRootDAGRun routes CompareAndSwapLatestAttemptStatus
+// through a root dag-run when the target dag-run is stored as a sub-DAG attempt.
+func WithCompareAndSwapRootDAGRun(root DAGRunRef) CompareAndSwapStatusOption {
+	return func(opts *CompareAndSwapStatusOptions) {
+		opts.RootDAGRun = root
 	}
-	return r.Root
+}
+
+// WithCompareAndSwapExpectedAttemptKey requires the current status attempt key
+// to match.
+func WithCompareAndSwapExpectedAttemptKey(attemptKey string) CompareAndSwapStatusOption {
+	return func(opts *CompareAndSwapStatusOptions) {
+		opts.ExpectedAttemptKey = attemptKey
+	}
+}
+
+// NewCompareAndSwapStatusOptions applies CompareAndSwapLatestAttemptStatus options.
+func NewCompareAndSwapStatusOptions(opts ...CompareAndSwapStatusOption) CompareAndSwapStatusOptions {
+	var cfg CompareAndSwapStatusOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
 }
 
 // ParseDAGRunRef parses a string into a DAGRunRef.

--- a/internal/core/exec/dagrun.go
+++ b/internal/core/exec/dagrun.go
@@ -72,6 +72,14 @@ type DAGRunStore interface {
 		expectedStatus core.Status,
 		mutate func(*DAGRunStatus) error,
 	) (*DAGRunStatus, bool, error)
+	// CompareAndSwapAttemptStatus atomically updates a root or sub-DAG attempt
+	// status when both the latest attempt identity and status still match.
+	CompareAndSwapAttemptStatus(
+		ctx context.Context,
+		attempt DAGRunAttemptRef,
+		expectedStatus core.Status,
+		mutate func(*DAGRunStatus) error,
+	) (*DAGRunStatus, bool, error)
 	// FindAttempt finds the latest attempt for the dag-run.
 	FindAttempt(ctx context.Context, dagRun DAGRunRef) (DAGRunAttempt, error)
 	// FindSubAttempt finds a sub dag-run record by dag-run ID.
@@ -263,6 +271,14 @@ type DAGRunRef struct {
 	ID   string `json:"id,omitempty"`
 }
 
+// DAGRunAttemptRef identifies a concrete root or sub-DAG attempt.
+type DAGRunAttemptRef struct {
+	DAGRun     DAGRunRef
+	Root       DAGRunRef
+	AttemptID  string
+	AttemptKey string
+}
+
 // NewDAGRunRef creates a new reference to dag-run with the given DAG name and run ID.
 // It is used to identify a specific dag-run.
 func NewDAGRunRef(name, runID string) DAGRunRef {
@@ -280,6 +296,19 @@ func (e DAGRunRef) String() string {
 // Zero checks if the DAGRunRef is a zero value.
 func (e DAGRunRef) Zero() bool {
 	return e == zeroRef
+}
+
+// IsSubDAG returns true when the attempt is stored under a different root run.
+func (r DAGRunAttemptRef) IsSubDAG() bool {
+	return !r.Root.Zero() && r.Root.ID != "" && r.Root.ID != r.DAGRun.ID
+}
+
+// RootOrDAGRun returns the root reference for locking and lookup.
+func (r DAGRunAttemptRef) RootOrDAGRun() DAGRunRef {
+	if r.Root.Zero() {
+		return r.DAGRun
+	}
+	return r.Root
 }
 
 // ParseDAGRunRef parses a string into a DAGRunRef.

--- a/internal/core/exec/dagrun.go
+++ b/internal/core/exec/dagrun.go
@@ -300,7 +300,10 @@ func (e DAGRunRef) Zero() bool {
 
 // IsSubDAG returns true when the attempt is stored under a different root run.
 func (r DAGRunAttemptRef) IsSubDAG() bool {
-	return !r.Root.Zero() && r.Root.ID != "" && r.Root.ID != r.DAGRun.ID
+	if r.Root.Zero() || r.Root.ID == "" {
+		return false
+	}
+	return r.Root.ID != r.DAGRun.ID || r.Root.Name != r.DAGRun.Name
 }
 
 // RootOrDAGRun returns the root reference for locking and lookup.

--- a/internal/core/exec/dagrun_test.go
+++ b/internal/core/exec/dagrun_test.go
@@ -52,12 +52,3 @@ func TestNewDAGRunAttemptOptions(t *testing.T) {
 	assert.Equal(t, rootDAGRun, opts.RootDAGRun)
 	assert.True(t, opts.Retry)
 }
-
-func TestDAGRunAttemptRefIsSubDAGWhenRootAndRunShareID(t *testing.T) {
-	ref := exec.DAGRunAttemptRef{
-		DAGRun: exec.NewDAGRunRef("child-dag", "shared-run"),
-		Root:   exec.NewDAGRunRef("root-dag", "shared-run"),
-	}
-
-	assert.True(t, ref.IsSubDAG())
-}

--- a/internal/core/exec/dagrun_test.go
+++ b/internal/core/exec/dagrun_test.go
@@ -52,3 +52,12 @@ func TestNewDAGRunAttemptOptions(t *testing.T) {
 	assert.Equal(t, rootDAGRun, opts.RootDAGRun)
 	assert.True(t, opts.Retry)
 }
+
+func TestDAGRunAttemptRefIsSubDAGWhenRootAndRunShareID(t *testing.T) {
+	ref := exec.DAGRunAttemptRef{
+		DAGRun: exec.NewDAGRunRef("child-dag", "shared-run"),
+		Root:   exec.NewDAGRunRef("root-dag", "shared-run"),
+	}
+
+	assert.True(t, ref.IsSubDAG())
+}

--- a/internal/core/exec/enqueue_retry_test.go
+++ b/internal/core/exec/enqueue_retry_test.go
@@ -378,6 +378,15 @@ func (s *stubDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	return s.cloneStatus(), true, nil
 }
 
+func (s *stubDAGRunStore) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	return s.CompareAndSwapLatestAttemptStatus(ctx, ref.DAGRun, ref.AttemptID, expectedStatus, mutate)
+}
+
 func (s *stubDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	return nil, errors.New("unexpected call")
 }

--- a/internal/core/exec/enqueue_retry_test.go
+++ b/internal/core/exec/enqueue_retry_test.go
@@ -342,6 +342,7 @@ func (s *stubDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	s.casCalls++
 	if s.casCalls == 1 && s.firstErr != nil {
@@ -376,15 +377,6 @@ func (s *stubDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	}
 	s.status = updated
 	return s.cloneStatus(), true, nil
-}
-
-func (s *stubDAGRunStore) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	return s.CompareAndSwapLatestAttemptStatus(ctx, ref.DAGRun, ref.AttemptID, expectedStatus, mutate)
 }
 
 func (s *stubDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {

--- a/internal/core/exec/failed_auto_retry_cancel.go
+++ b/internal/core/exec/failed_auto_retry_cancel.go
@@ -70,6 +70,7 @@ type latestAttemptStatusSwapper interface {
 		expectedAttemptID string,
 		expectedStatus core.Status,
 		mutate func(*DAGRunStatus) error,
+		opts ...CompareAndSwapStatusOption,
 	) (*DAGRunStatus, bool, error)
 }
 

--- a/internal/core/exec/failed_auto_retry_cancel_test.go
+++ b/internal/core/exec/failed_auto_retry_cancel_test.go
@@ -29,6 +29,7 @@ func (s *failedAutoRetryCancelStoreStub) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*DAGRunStatus) error,
+	_ ...CompareAndSwapStatusOption,
 ) (*DAGRunStatus, bool, error) {
 	return s.compareAndSwap(ctx, dagRun, expectedAttemptID, expectedStatus, mutate)
 }

--- a/internal/intg/distr/zombie_recovery_test.go
+++ b/internal/intg/distr/zombie_recovery_test.go
@@ -110,6 +110,16 @@ func TestDistributedRun_DelayedAfterAck_DoesNotExecuteAfterStaleCleanup(t *testi
 	})
 }
 
+func TestDistributedSubDAG_StaleLeaseMarkedFailedAndCleansLease(t *testing.T) {
+	t.Run("SharedNothing", func(t *testing.T) {
+		testDistributedSubDAGStaleLeaseMarkedFailedAndCleansLease(t, sharedNothingMode)
+	})
+
+	t.Run("SharedStorage", func(t *testing.T) {
+		testDistributedSubDAGStaleLeaseMarkedFailedAndCleansLease(t, sharedFSMode)
+	})
+}
+
 // TestDistributedRun_HeartbeatRefreshKeepsQuietRunAlive verifies that a
 // long-running quiet step remains RUNNING past the lease threshold because
 // coordinator-owned heartbeat refreshes keep the lease fresh.
@@ -577,6 +587,125 @@ steps:
 	delayedWorker.SetAfterTaskAckHook(nil)
 }
 
+func testDistributedSubDAGStaleLeaseMarkedFailedAndCleansLease(t *testing.T, mode workerMode) {
+	t.Helper()
+
+	opts := []fixtureOption{
+		withWorkerCount(0),
+		withWorkerMaxActiveRuns(1),
+		withStaleThresholds(testStaleHeartbeatThreshold, testStaleLeaseThreshold),
+		withZombieDetectionInterval(testZombieDetectorInterval),
+	}
+	if mode == sharedFSMode {
+		opts = append(opts, withWorkerMode(sharedFSMode))
+	}
+
+	f := newTestFixture(t, `
+name: stale-subdag-parent
+steps:
+  - name: call-child
+    call: stale-subdag-child
+---
+name: stale-subdag-child
+worker_selector:
+  test: "true"
+steps:
+  - name: child-step
+    command: echo "should not execute"
+`, opts...)
+	defer f.cleanup()
+
+	abandonedTask := make(chan *coordinatorv1.Task, 1)
+	abandonOnce := sync.Once{}
+	afterAckHook := func(_ context.Context, task *coordinatorv1.Task) bool {
+		triggered := false
+		abandonOnce.Do(func() {
+			triggered = true
+			abandonedTask <- task
+		})
+		return triggered
+	}
+
+	var crashWorker *worker.Worker
+	switch mode {
+	case sharedFSMode:
+		crashWorker = f.setupSharedFSWorkerWithAfterAckHook("subdag-crash-worker", map[string]string{"test": "true"}, afterAckHook)
+	case sharedNothingMode:
+		crashWorker = f.setupSharedNothingWorkerWithAfterAckHook("subdag-crash-worker", map[string]string{"test": "true"}, "", afterAckHook)
+	default:
+		t.Fatalf("unsupported worker mode: %v", mode)
+	}
+	require.NotNil(t, crashWorker)
+	defer crashWorker.SetAfterTaskAckHook(nil)
+
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(45 * time.Second)
+
+	var task *coordinatorv1.Task
+	select {
+	case task = <-abandonedTask:
+	case <-time.After(distrTestTimeout(15 * time.Second)):
+		t.Fatal("timed out waiting for worker to accept and abandon sub-DAG task")
+	}
+	require.NotNil(t, task)
+	require.Equal(t, "stale-subdag-child", task.Target)
+	require.NotEmpty(t, task.AttemptKey)
+	require.NotEmpty(t, task.AttemptId)
+	require.NotEmpty(t, task.RootDagRunName)
+	require.NotEmpty(t, task.RootDagRunId)
+	require.NotEmpty(t, task.DagRunId)
+
+	rootRef := exec.NewDAGRunRef(task.RootDagRunName, task.RootDagRunId)
+	subRunRef := exec.NewDAGRunRef(task.Target, task.DagRunId)
+	lease := waitForLease(t, f, task.AttemptKey, 5*time.Second)
+	require.Equal(t, subRunRef, lease.DAGRun)
+	require.Equal(t, rootRef, lease.Root)
+	require.Equal(t, task.AttemptId, lease.AttemptID)
+
+	var initialSubStatus exec.DAGRunStatus
+	require.Eventually(t, func() bool {
+		subStatus, err := readSubDAGRunStatus(f, rootRef, subRunRef.ID)
+		if err != nil || subStatus == nil {
+			return false
+		}
+		if subStatus.AttemptKey != task.AttemptKey {
+			return false
+		}
+		initialSubStatus = *subStatus
+		return subStatus.Status == core.Queued ||
+			subStatus.Status == core.NotStarted ||
+			subStatus.Status == core.Running
+	}, distrTestTimeout(5*time.Second), 100*time.Millisecond, "sub-DAG attempt should be persisted before stale lease cleanup")
+	require.Equal(t, rootRef, initialSubStatus.Root)
+
+	finalSubStatus := waitForSubDAGRunStatus(t, f, rootRef, subRunRef.ID, core.Failed, 25*time.Second)
+	expectedReason := exec.DistributedLeaseExpiredReason("subdag-crash-worker")
+	require.Equal(t, task.AttemptKey, finalSubStatus.AttemptKey)
+	require.Equal(t, task.AttemptId, finalSubStatus.AttemptID)
+	require.Equal(t, expectedReason, finalSubStatus.Error)
+	if len(finalSubStatus.Nodes) > 0 {
+		require.Equal(t, core.NodeFailed, finalSubStatus.Nodes[0].Status)
+		require.Equal(t, expectedReason, finalSubStatus.Nodes[0].Error)
+	}
+
+	finalParentStatus := f.waitForStatus(core.Failed, 15*time.Second)
+	require.NotEmpty(t, finalParentStatus.Nodes)
+	require.Equal(t, core.NodeFailed, finalParentStatus.Nodes[0].Status)
+	require.Len(t, finalParentStatus.Nodes[0].SubRuns, 1)
+	require.Equal(t, subRunRef.ID, finalParentStatus.Nodes[0].SubRuns[0].DAGRunID)
+
+	require.Eventually(t, func() bool {
+		_, err := f.coord.DAGRunLeaseStore.Get(f.coord.Context, task.AttemptKey)
+		return errors.Is(err, exec.ErrDAGRunLeaseNotFound)
+	}, 10*time.Second, 100*time.Millisecond, "stale sub-DAG lease should be removed after failure")
+
+	require.Eventually(t, func() bool {
+		_, err := f.coord.ActiveDistributedRunStore.Get(f.coord.Context, task.AttemptKey)
+		return errors.Is(err, exec.ErrActiveRunNotFound)
+	}, 10*time.Second, 100*time.Millisecond, "stale sub-DAG active-run index should be removed after failure")
+}
+
 func startWorkerProcess(t *testing.T, f *testFixture, workerID, labels string) (*osexec.Cmd, *bytes.Buffer) {
 	t.Helper()
 
@@ -642,6 +771,46 @@ func waitForLease(t *testing.T, f *testFixture, attemptKey string, timeout time.
 	}, timeout, 100*time.Millisecond, "lease %s should exist", attemptKey)
 
 	return *lease
+}
+
+func waitForSubDAGRunStatus(
+	t *testing.T,
+	f *testFixture,
+	rootRef exec.DAGRunRef,
+	subRunID string,
+	expected core.Status,
+	timeout time.Duration,
+) exec.DAGRunStatus {
+	t.Helper()
+
+	timeout = distrTestTimeout(timeout)
+	var status *exec.DAGRunStatus
+	var schedulerErr error
+	require.Eventually(t, func() bool {
+		schedulerErr = f.pollSchedulerErr()
+		if schedulerErr != nil {
+			return true
+		}
+		var err error
+		status, err = readSubDAGRunStatus(f, rootRef, subRunID)
+		return err == nil && status != nil && status.Status == expected
+	}, timeout, 100*time.Millisecond, "timeout waiting for sub-DAG %s status %s", subRunID, expected)
+	require.NoError(t, schedulerErr)
+	require.NotNil(t, status)
+
+	return *status
+}
+
+func readSubDAGRunStatus(
+	f *testFixture,
+	rootRef exec.DAGRunRef,
+	subRunID string,
+) (*exec.DAGRunStatus, error) {
+	attempt, err := f.coord.DAGRunStore.FindSubAttempt(f.coord.Context, rootRef, subRunID)
+	if err != nil {
+		return nil, err
+	}
+	return attempt.ReadStatus(f.coord.Context)
 }
 
 func waitForAnyLease(t *testing.T, f *testFixture, timeout time.Duration) exec.DAGRunLease {

--- a/internal/persis/filedagrun/store.go
+++ b/internal/persis/filedagrun/store.go
@@ -237,11 +237,34 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
 ) (*exec.DAGRunStatus, bool, error) {
+	return store.CompareAndSwapAttemptStatus(ctx, exec.DAGRunAttemptRef{
+		DAGRun:    dagRun,
+		AttemptID: expectedAttemptID,
+	}, expectedStatus, mutate)
+}
+
+func (store *Store) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	dagRun := ref.DAGRun
 	if dagRun.ID == "" {
 		return nil, false, ErrDAGRunIDEmpty
 	}
+	rootRef := ref.RootOrDAGRun()
+	if ref.IsSubDAG() && rootRef.Name == "" {
+		return nil, false, fmt.Errorf("missing root dag-run name for sub dag-run %s", dagRun.ID)
+	}
+	if rootRef.Name == "" {
+		rootRef.Name = dagRun.Name
+	}
+	if rootRef.ID == "" {
+		return nil, false, ErrDAGRunIDEmpty
+	}
 
-	root := NewDataRoot(store.baseDir, dagRun.Name)
+	root := NewDataRoot(store.baseDir, rootRef.Name)
 	lockCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -254,9 +277,15 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 		}
 	}()
 
-	run, err := root.FindByDAGRunID(ctx, dagRun.ID)
+	run, err := root.FindByDAGRunID(ctx, rootRef.ID)
 	if err != nil {
 		return nil, false, err
+	}
+	if ref.IsSubDAG() {
+		run, err = run.FindSubDAGRun(ctx, dagRun.ID)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	attempt, err := run.LatestAttempt(ctx, store.cache)
@@ -268,7 +297,13 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 	if err != nil {
 		return nil, false, err
 	}
-	if expectedAttemptID != "" && status.AttemptID != expectedAttemptID {
+	if ref.AttemptID != "" && status.AttemptID != ref.AttemptID {
+		return status, false, nil
+	}
+	if ref.AttemptKey != "" && status.AttemptKey != "" && status.AttemptKey != ref.AttemptKey {
+		return status, false, nil
+	}
+	if status.DAGRunID != "" && status.DAGRunID != dagRun.ID {
 		return status, false, nil
 	}
 	if status.Status != expectedStatus {

--- a/internal/persis/filedagrun/store.go
+++ b/internal/persis/filedagrun/store.go
@@ -236,25 +236,18 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
+	opts ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
-	return store.CompareAndSwapAttemptStatus(ctx, exec.DAGRunAttemptRef{
-		DAGRun:    dagRun,
-		AttemptID: expectedAttemptID,
-	}, expectedStatus, mutate)
-}
-
-func (store *Store) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	dagRun := ref.DAGRun
 	if dagRun.ID == "" {
 		return nil, false, ErrDAGRunIDEmpty
 	}
-	rootRef := ref.RootOrDAGRun()
-	if ref.IsSubDAG() && rootRef.Name == "" {
+	cfg := exec.NewCompareAndSwapStatusOptions(opts...)
+	rootRef := cfg.RootDAGRun
+	if rootRef.Zero() {
+		rootRef = dagRun
+	}
+	isSubDAG := rootRef.ID != "" && (rootRef.ID != dagRun.ID || rootRef.Name != dagRun.Name)
+	if isSubDAG && rootRef.Name == "" {
 		return nil, false, fmt.Errorf("missing root dag-run name for sub dag-run %s", dagRun.ID)
 	}
 	if rootRef.Name == "" {
@@ -281,7 +274,7 @@ func (store *Store) CompareAndSwapAttemptStatus(
 	if err != nil {
 		return nil, false, err
 	}
-	if ref.IsSubDAG() {
+	if isSubDAG {
 		run, err = run.FindSubDAGRun(ctx, dagRun.ID)
 		if err != nil {
 			return nil, false, err
@@ -297,10 +290,10 @@ func (store *Store) CompareAndSwapAttemptStatus(
 	if err != nil {
 		return nil, false, err
 	}
-	if ref.AttemptID != "" && status.AttemptID != ref.AttemptID {
+	if expectedAttemptID != "" && status.AttemptID != expectedAttemptID {
 		return status, false, nil
 	}
-	if ref.AttemptKey != "" && status.AttemptKey != "" && status.AttemptKey != ref.AttemptKey {
+	if cfg.ExpectedAttemptKey != "" && status.AttemptKey != cfg.ExpectedAttemptKey {
 		return status, false, nil
 	}
 	if status.DAGRunID != "" && status.DAGRunID != dagRun.ID {

--- a/internal/persis/filedagrun/store_test.go
+++ b/internal/persis/filedagrun/store_test.go
@@ -376,6 +376,58 @@ func TestJSONDB(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "sub-id", status.DAGRunID)
 	})
+	t.Run("CompareAndSwapAttemptStatusUpdatesSubAttempt", func(t *testing.T) {
+		th := setupTestStore(t)
+
+		ts := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		th.CreateAttempt(t, ts, "parent-id", core.Running)
+
+		rootRef := exec.NewDAGRunRef("test_DAG", "parent-id")
+		subRef := exec.NewDAGRunRef("child", "sub-id")
+		subAttempt, err := th.Store.CreateSubAttempt(th.Context, rootRef, subRef.ID)
+		require.NoError(t, err)
+
+		subDAG := th.DAG(subRef.Name)
+		subAttempt.SetDAG(subDAG.DAG)
+		require.NoError(t, subAttempt.Open(th.Context))
+		statusToWrite := exec.InitialStatus(subDAG.DAG)
+		statusToWrite.DAGRunID = subRef.ID
+		statusToWrite.Root = rootRef
+		statusToWrite.AttemptID = subAttempt.ID()
+		statusToWrite.AttemptKey = exec.GenerateAttemptKey(rootRef.Name, rootRef.ID, subRef.Name, subRef.ID, subAttempt.ID())
+		statusToWrite.Status = core.Running
+		statusToWrite.Nodes = []*exec.Node{{Status: core.NodeRunning}}
+		require.NoError(t, subAttempt.Write(th.Context, statusToWrite))
+		require.NoError(t, subAttempt.Close(th.Context))
+
+		updated, swapped, err := th.Store.CompareAndSwapAttemptStatus(
+			th.Context,
+			exec.DAGRunAttemptRef{
+				DAGRun:     subRef,
+				Root:       rootRef,
+				AttemptID:  subAttempt.ID(),
+				AttemptKey: statusToWrite.AttemptKey,
+			},
+			core.Running,
+			func(status *exec.DAGRunStatus) error {
+				status.Status = core.Failed
+				status.Error = "lease expired"
+				status.Nodes[0].Status = core.NodeFailed
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, swapped)
+		require.Equal(t, core.Failed, updated.Status)
+
+		foundAttempt, err := th.Store.FindSubAttempt(th.Context, rootRef, subRef.ID)
+		require.NoError(t, err)
+		foundStatus, err := foundAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Failed, foundStatus.Status)
+		require.Equal(t, "lease expired", foundStatus.Error)
+		require.Equal(t, core.NodeFailed, foundStatus.Nodes[0].Status)
+	})
 	t.Run("CreateSubAttemptEmptyRootID", func(t *testing.T) {
 		th := setupTestStore(t)
 

--- a/internal/persis/filedagrun/store_test.go
+++ b/internal/persis/filedagrun/store_test.go
@@ -376,14 +376,14 @@ func TestJSONDB(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "sub-id", status.DAGRunID)
 	})
-	t.Run("CompareAndSwapAttemptStatusUpdatesSubAttempt", func(t *testing.T) {
+	t.Run("CompareAndSwapLatestAttemptStatusUpdatesSubAttempt", func(t *testing.T) {
 		th := setupTestStore(t)
 
 		ts := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 		th.CreateAttempt(t, ts, "parent-id", core.Running)
 
 		rootRef := exec.NewDAGRunRef("test_DAG", "parent-id")
-		subRef := exec.NewDAGRunRef("child", "sub-id")
+		subRef := exec.NewDAGRunRef("child", "parent-id")
 		subAttempt, err := th.Store.CreateSubAttempt(th.Context, rootRef, subRef.ID)
 		require.NoError(t, err)
 
@@ -400,14 +400,10 @@ func TestJSONDB(t *testing.T) {
 		require.NoError(t, subAttempt.Write(th.Context, statusToWrite))
 		require.NoError(t, subAttempt.Close(th.Context))
 
-		updated, swapped, err := th.Store.CompareAndSwapAttemptStatus(
+		updated, swapped, err := th.Store.CompareAndSwapLatestAttemptStatus(
 			th.Context,
-			exec.DAGRunAttemptRef{
-				DAGRun:     subRef,
-				Root:       rootRef,
-				AttemptID:  subAttempt.ID(),
-				AttemptKey: statusToWrite.AttemptKey,
-			},
+			subRef,
+			subAttempt.ID(),
 			core.Running,
 			func(status *exec.DAGRunStatus) error {
 				status.Status = core.Failed
@@ -415,6 +411,8 @@ func TestJSONDB(t *testing.T) {
 				status.Nodes[0].Status = core.NodeFailed
 				return nil
 			},
+			exec.WithCompareAndSwapRootDAGRun(rootRef),
+			exec.WithCompareAndSwapExpectedAttemptKey(statusToWrite.AttemptKey),
 		)
 		require.NoError(t, err)
 		require.True(t, swapped)

--- a/internal/runtime/agent/dbclient_test.go
+++ b/internal/runtime/agent/dbclient_test.go
@@ -315,21 +315,9 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	args := m.Called(ctx, dagRun, expectedAttemptID, expectedStatus, mutate)
-	if args.Get(0) == nil {
-		return nil, args.Bool(1), args.Error(2)
-	}
-	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
-}
-
-func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	args := m.Called(ctx, ref, expectedStatus, mutate)
 	if args.Get(0) == nil {
 		return nil, args.Bool(1), args.Error(2)
 	}

--- a/internal/runtime/agent/dbclient_test.go
+++ b/internal/runtime/agent/dbclient_test.go
@@ -323,6 +323,19 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
 }
 
+func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	args := m.Called(ctx, ref, expectedStatus, mutate)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1), args.Error(2)
+	}
+	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
+}
+
 func (m *mockDAGRunStore) FindAttempt(ctx context.Context, dagRun exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	args := m.Called(ctx, dagRun)
 	if args.Get(0) == nil {

--- a/internal/runtime/distributed_stale_run.go
+++ b/internal/runtime/distributed_stale_run.go
@@ -94,19 +94,17 @@ func ConfirmAndRepairStaleDistributedRun(
 	}
 
 	reason := exec.DistributedLeaseExpiredReason(workerID)
-	currentStatus, swapped, err := cfg.DAGRunStore.CompareAndSwapAttemptStatus(
+	currentStatus, swapped, err := cfg.DAGRunStore.CompareAndSwapLatestAttemptStatus(
 		ctx,
-		exec.DAGRunAttemptRef{
-			DAGRun:     status.DAGRun(),
-			Root:       status.Root,
-			AttemptID:  attemptID,
-			AttemptKey: attemptKey,
-		},
+		status.DAGRun(),
+		attemptID,
 		status.Status,
 		func(current *exec.DAGRunStatus) error {
 			markActiveStatusFailed(current, reason, now)
 			return nil
 		},
+		exec.WithCompareAndSwapRootDAGRun(status.Root),
+		exec.WithCompareAndSwapExpectedAttemptKey(attemptKey),
 	)
 	if err != nil {
 		return nil, false, err

--- a/internal/runtime/distributed_stale_run.go
+++ b/internal/runtime/distributed_stale_run.go
@@ -94,10 +94,14 @@ func ConfirmAndRepairStaleDistributedRun(
 	}
 
 	reason := exec.DistributedLeaseExpiredReason(workerID)
-	currentStatus, swapped, err := cfg.DAGRunStore.CompareAndSwapLatestAttemptStatus(
+	currentStatus, swapped, err := cfg.DAGRunStore.CompareAndSwapAttemptStatus(
 		ctx,
-		status.DAGRun(),
-		attemptID,
+		exec.DAGRunAttemptRef{
+			DAGRun:     status.DAGRun(),
+			Root:       status.Root,
+			AttemptID:  attemptID,
+			AttemptKey: attemptKey,
+		},
 		status.Status,
 		func(current *exec.DAGRunStatus) error {
 			markActiveStatusFailed(current, reason, now)

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -987,10 +987,14 @@ func (h *Handler) repairStaleLeaseFailureFromRunHeartbeat(
 
 	reason := staleDistributedLeaseReason(workerID)
 	storeCtx := context.WithoutCancel(ctx)
-	repairedStatus, swapped, err := h.dagRunStore.CompareAndSwapLatestAttemptStatus(
+	repairedStatus, swapped, err := h.dagRunStore.CompareAndSwapAttemptStatus(
 		storeCtx,
-		lease.DAGRun,
-		lease.AttemptID,
+		exec.DAGRunAttemptRef{
+			DAGRun:     lease.DAGRun,
+			Root:       lease.Root,
+			AttemptID:  lease.AttemptID,
+			AttemptKey: lease.AttemptKey,
+		},
 		core.Failed,
 		func(status *exec.DAGRunStatus) error {
 			if !h.canRepairStaleLeaseFailureFromRunHeartbeat(workerID, task, lease, status, reason, observedAt) {
@@ -2675,9 +2679,12 @@ func (h *Handler) markStatusLeaseRunFailed(
 	}
 	h.failDistributedAttemptIfCurrent(
 		ctx,
-		status.DAGRun(),
-		attemptID,
-		attemptKey,
+		exec.DAGRunAttemptRef{
+			DAGRun:     status.DAGRun(),
+			Root:       status.Root,
+			AttemptID:  attemptID,
+			AttemptKey: attemptKey,
+		},
 		reason,
 		status.Status,
 	)
@@ -2709,17 +2716,15 @@ func (h *Handler) resolveAttemptIDForStatus(ctx context.Context, status *exec.DA
 
 func (h *Handler) failDistributedAttemptIfCurrent(
 	ctx context.Context,
-	dagRun exec.DAGRunRef,
-	attemptID string,
-	attemptKey string,
+	ref exec.DAGRunAttemptRef,
 	reason string,
 	expectedStatuses ...core.Status,
 ) {
 	storeCtx := context.WithoutCancel(ctx)
-	if attemptID == "" {
+	if ref.AttemptID == "" {
 		logger.Error(ctx, "Skipping distributed stale-run repair due to missing attempt ID",
-			tag.DAG(dagRun.Name),
-			tag.RunID(dagRun.ID),
+			tag.DAG(ref.DAGRun.Name),
+			tag.RunID(ref.DAGRun.ID),
 		)
 		return
 	}
@@ -2753,35 +2758,34 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 	)
 
 	for _, expectedStatus := range expectedStatuses {
-		status, swapped, err = h.dagRunStore.CompareAndSwapLatestAttemptStatus(
+		status, swapped, err = h.dagRunStore.CompareAndSwapAttemptStatus(
 			storeCtx,
-			dagRun,
-			attemptID,
+			ref,
 			expectedStatus,
 			mutate,
 		)
 		if err != nil {
 			logger.Error(ctx, "Failed to fail stale distributed run",
-				tag.RunID(dagRun.ID),
+				tag.RunID(ref.DAGRun.ID),
 				slog.String("expected_status", expectedStatus.String()),
 				tag.Error(err),
 			)
 			return
 		}
-		if swapped || status == nil || status.AttemptID != attemptID || status.Status == expectedStatus {
+		if swapped || status == nil || status.AttemptID != ref.AttemptID || status.Status == expectedStatus {
 			break
 		}
 	}
 
 	if status == nil {
-		h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
+		h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
 			"Failed to delete orphaned distributed lease",
 			"Failed to delete orphaned active distributed run",
 		)
 		return
 	}
-	if status.AttemptID != attemptID || !status.Status.IsActive() && status.Status != core.NotStarted {
-		h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
+	if status.AttemptID != ref.AttemptID || !status.Status.IsActive() && status.Status != core.NotStarted {
+		h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
 			"Failed to delete superseded distributed lease",
 			"Failed to delete superseded active distributed run",
 		)
@@ -2791,14 +2795,14 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 		return
 	}
 
-	h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
+	h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
 		"Failed to delete stale distributed lease after failure",
 		"Failed to delete active distributed run after failure",
 	)
 
 	logger.Warn(ctx, "Marked stale distributed run as FAILED",
-		tag.DAG(dagRun.Name),
-		tag.RunID(dagRun.ID),
+		tag.DAG(ref.DAGRun.Name),
+		tag.RunID(ref.DAGRun.ID),
 		slog.String("reason", reason),
 	)
 }

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2784,7 +2784,7 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 		)
 		return
 	}
-	if status.AttemptID != ref.AttemptID || !status.Status.IsActive() && status.Status != core.NotStarted {
+	if status.AttemptID != ref.AttemptID || (!status.Status.IsActive() && status.Status != core.NotStarted) {
 		h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
 			"Failed to delete superseded distributed lease",
 			"Failed to delete superseded active distributed run",

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -987,14 +987,10 @@ func (h *Handler) repairStaleLeaseFailureFromRunHeartbeat(
 
 	reason := staleDistributedLeaseReason(workerID)
 	storeCtx := context.WithoutCancel(ctx)
-	repairedStatus, swapped, err := h.dagRunStore.CompareAndSwapAttemptStatus(
+	repairedStatus, swapped, err := h.dagRunStore.CompareAndSwapLatestAttemptStatus(
 		storeCtx,
-		exec.DAGRunAttemptRef{
-			DAGRun:     lease.DAGRun,
-			Root:       lease.Root,
-			AttemptID:  lease.AttemptID,
-			AttemptKey: lease.AttemptKey,
-		},
+		lease.DAGRun,
+		lease.AttemptID,
 		core.Failed,
 		func(status *exec.DAGRunStatus) error {
 			if !h.canRepairStaleLeaseFailureFromRunHeartbeat(workerID, task, lease, status, reason, observedAt) {
@@ -1003,6 +999,8 @@ func (h *Handler) repairStaleLeaseFailureFromRunHeartbeat(
 			restoreStaleLeaseFailure(status, lease, workerID, reason)
 			return nil
 		},
+		exec.WithCompareAndSwapRootDAGRun(lease.Root),
+		exec.WithCompareAndSwapExpectedAttemptKey(lease.AttemptKey),
 	)
 	if err != nil {
 		if errors.Is(err, errRunHeartbeatRepairSkipped) {
@@ -2679,12 +2677,10 @@ func (h *Handler) markStatusLeaseRunFailed(
 	}
 	h.failDistributedAttemptIfCurrent(
 		ctx,
-		exec.DAGRunAttemptRef{
-			DAGRun:     status.DAGRun(),
-			Root:       status.Root,
-			AttemptID:  attemptID,
-			AttemptKey: attemptKey,
-		},
+		status.DAGRun(),
+		status.Root,
+		attemptID,
+		attemptKey,
 		reason,
 		status.Status,
 	)
@@ -2716,15 +2712,18 @@ func (h *Handler) resolveAttemptIDForStatus(ctx context.Context, status *exec.DA
 
 func (h *Handler) failDistributedAttemptIfCurrent(
 	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
+	dagRun exec.DAGRunRef,
+	root exec.DAGRunRef,
+	attemptID string,
+	attemptKey string,
 	reason string,
 	expectedStatuses ...core.Status,
 ) {
 	storeCtx := context.WithoutCancel(ctx)
-	if ref.AttemptID == "" {
+	if attemptID == "" {
 		logger.Error(ctx, "Skipping distributed stale-run repair due to missing attempt ID",
-			tag.DAG(ref.DAGRun.Name),
-			tag.RunID(ref.DAGRun.ID),
+			tag.DAG(dagRun.Name),
+			tag.RunID(dagRun.ID),
 		)
 		return
 	}
@@ -2758,34 +2757,37 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 	)
 
 	for _, expectedStatus := range expectedStatuses {
-		status, swapped, err = h.dagRunStore.CompareAndSwapAttemptStatus(
+		status, swapped, err = h.dagRunStore.CompareAndSwapLatestAttemptStatus(
 			storeCtx,
-			ref,
+			dagRun,
+			attemptID,
 			expectedStatus,
 			mutate,
+			exec.WithCompareAndSwapRootDAGRun(root),
+			exec.WithCompareAndSwapExpectedAttemptKey(attemptKey),
 		)
 		if err != nil {
 			logger.Error(ctx, "Failed to fail stale distributed run",
-				tag.RunID(ref.DAGRun.ID),
+				tag.RunID(dagRun.ID),
 				slog.String("expected_status", expectedStatus.String()),
 				tag.Error(err),
 			)
 			return
 		}
-		if swapped || status == nil || status.AttemptID != ref.AttemptID || status.Status == expectedStatus {
+		if swapped || status == nil || status.AttemptID != attemptID || status.Status == expectedStatus {
 			break
 		}
 	}
 
 	if status == nil {
-		h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
+		h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
 			"Failed to delete orphaned distributed lease",
 			"Failed to delete orphaned active distributed run",
 		)
 		return
 	}
-	if status.AttemptID != ref.AttemptID || (!status.Status.IsActive() && status.Status != core.NotStarted) {
-		h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
+	if status.AttemptID != attemptID || (!status.Status.IsActive() && status.Status != core.NotStarted) {
+		h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
 			"Failed to delete superseded distributed lease",
 			"Failed to delete superseded active distributed run",
 		)
@@ -2795,14 +2797,14 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 		return
 	}
 
-	h.deleteDistributedTracking(ctx, storeCtx, ref.DAGRun, ref.AttemptKey,
+	h.deleteDistributedTracking(ctx, storeCtx, dagRun, attemptKey,
 		"Failed to delete stale distributed lease after failure",
 		"Failed to delete active distributed run after failure",
 	)
 
 	logger.Warn(ctx, "Marked stale distributed run as FAILED",
-		tag.DAG(ref.DAGRun.Name),
-		tag.RunID(ref.DAGRun.ID),
+		tag.DAG(dagRun.Name),
+		tag.RunID(dagRun.ID),
 		slog.String("reason", reason),
 	)
 }

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -168,46 +168,42 @@ func (m *mockDAGRunStore) ListStatusesPage(ctx context.Context, opts ...exec.Lis
 	return exec.DAGRunStatusPage{Items: items}, nil
 }
 func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
-	ctx context.Context,
+	_ context.Context,
 	dagRun exec.DAGRunRef,
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	return m.CompareAndSwapAttemptStatus(ctx, exec.DAGRunAttemptRef{
-		DAGRun:    dagRun,
-		AttemptID: expectedAttemptID,
-	}, expectedStatus, mutate)
-}
-
-func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
-	_ context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
+	opts ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	cfg := exec.NewCompareAndSwapStatusOptions(opts...)
+	root := cfg.RootDAGRun
+	if root.Zero() {
+		root = dagRun
+	}
+	isSubDAG := root.ID != "" && (root.ID != dagRun.ID || root.Name != dagRun.Name)
 
 	var (
 		attempt *mockDAGRunAttempt
 		ok      bool
 	)
-	if ref.IsSubDAG() {
-		key := ref.Root.ID + ":" + ref.DAGRun.ID
+	if isSubDAG {
+		key := root.ID + ":" + dagRun.ID
 		attempt, ok = m.subAttempts[key]
 	} else {
-		attempt, ok = m.attempts[ref.DAGRun.ID]
+		attempt, ok = m.attempts[dagRun.ID]
 	}
 	if !ok || attempt.status == nil {
 		return nil, false, nil
 	}
 
 	current := *attempt.status
-	if ref.AttemptID != "" && current.AttemptID != ref.AttemptID {
+	if expectedAttemptID != "" && current.AttemptID != expectedAttemptID {
 		return &current, false, nil
 	}
-	if ref.AttemptKey != "" && current.AttemptKey != "" && current.AttemptKey != ref.AttemptKey {
+	if cfg.ExpectedAttemptKey != "" && current.AttemptKey != cfg.ExpectedAttemptKey {
 		return &current, false, nil
 	}
 	if current.Status != expectedStatus {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -1974,6 +1974,9 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
 		require.Equal(t, core.NodeFailed, status.Nodes[0].Status)
 		require.Equal(t, staleDistributedLeaseReason("worker-1"), status.Nodes[0].Error)
+
+		_, err = leaseStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
 	})
 
 	t.Run("DetectStaleLeasesKeepsLeasedRunWhenFreshWorkerHeartbeatStillReportsAttempt", func(t *testing.T) {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -168,22 +168,49 @@ func (m *mockDAGRunStore) ListStatusesPage(ctx context.Context, opts ...exec.Lis
 	return exec.DAGRunStatusPage{Items: items}, nil
 }
 func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
-	_ context.Context,
+	ctx context.Context,
 	dagRun exec.DAGRunRef,
 	expectedAttemptID string,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	return m.CompareAndSwapAttemptStatus(ctx, exec.DAGRunAttemptRef{
+		DAGRun:    dagRun,
+		AttemptID: expectedAttemptID,
+	}, expectedStatus, mutate)
+}
+
+func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
+	_ context.Context,
+	ref exec.DAGRunAttemptRef,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
 ) (*exec.DAGRunStatus, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	attempt, ok := m.attempts[dagRun.ID]
+	var (
+		attempt *mockDAGRunAttempt
+		ok      bool
+	)
+	if ref.IsSubDAG() {
+		key := ref.Root.ID + ":" + ref.DAGRun.ID
+		attempt, ok = m.subAttempts[key]
+	} else {
+		attempt, ok = m.attempts[ref.DAGRun.ID]
+	}
 	if !ok || attempt.status == nil {
 		return nil, false, nil
 	}
 
 	current := *attempt.status
-	if current.AttemptID != expectedAttemptID || current.Status != expectedStatus {
+	if ref.AttemptID != "" && current.AttemptID != ref.AttemptID {
+		return &current, false, nil
+	}
+	if ref.AttemptKey != "" && current.AttemptKey != "" && current.AttemptKey != ref.AttemptKey {
+		return &current, false, nil
+	}
+	if current.Status != expectedStatus {
 		return &current, false, nil
 	}
 	if err := mutate(&current); err != nil {
@@ -1885,6 +1912,68 @@ func TestHandler_ZombieDetection(t *testing.T) {
 
 		_, err = leaseStore.Get(ctx, "lease-key-1")
 		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+	})
+
+	t.Run("DetectStaleLeasesFailsSubDAGLeasedRunWhenFreshWorkerHeartbeatDropsAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := filedistributed.NewDAGRunLeaseStore(baseDir)
+		heartbeatStore := filedistributed.NewWorkerHeartbeatStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:             store,
+			DAGRunLeaseStore:        leaseStore,
+			WorkerHeartbeatStore:    heartbeatStore,
+			StaleHeartbeatThreshold: time.Minute,
+			StaleLeaseThreshold:     time.Second,
+		})
+
+		root := exec.NewDAGRunRef("root-dag", "root-run")
+		subRun := exec.NewDAGRunRef("sub-dag", "sub-run")
+		attemptKey := "sub-attempt-key"
+		attemptID := "sub-attempt-id"
+		attempt := store.addSubAttempt(root, subRun.ID, &exec.DAGRunStatus{
+			Name:       subRun.Name,
+			DAGRunID:   subRun.ID,
+			Root:       root,
+			AttemptID:  attemptID,
+			AttemptKey: attemptKey,
+			Status:     core.Running,
+			WorkerID:   "worker-1",
+			Nodes: []*exec.Node{
+				{Status: core.NodeRunning},
+			},
+		})
+
+		staleAt := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      attemptKey,
+			DAGRun:          subRun,
+			Root:            root,
+			AttemptID:       attemptID,
+			QueueName:       subRun.Name,
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: staleAt.UnixMilli(),
+			ClaimedAt:       staleAt.UnixMilli(),
+		}))
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+			Stats: &coordinatorv1.WorkerStats{
+				RunningTasks: []*coordinatorv1.RunningTask{},
+			},
+		}))
+
+		h.detectStaleLeases(ctx)
+
+		status, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		require.Equal(t, core.Failed, status.Status)
+		require.Equal(t, staleDistributedLeaseReason("worker-1"), status.Error)
+		require.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+		require.Equal(t, staleDistributedLeaseReason("worker-1"), status.Nodes[0].Error)
 	})
 
 	t.Run("DetectStaleLeasesKeepsLeasedRunWhenFreshWorkerHeartbeatStillReportsAttempt", func(t *testing.T) {

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -522,11 +522,7 @@ func (blockingDAGRunStore) ListStatusesPage(ctx context.Context, _ ...exec.ListD
 	return exec.DAGRunStatusPage{}, ctx.Err()
 }
 
-func (blockingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
-	panic("not implemented")
-}
-
-func (blockingDAGRunStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+func (blockingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error, ...exec.CompareAndSwapStatusOption) (*exec.DAGRunStatus, bool, error) {
 	panic("not implemented")
 }
 

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -526,6 +526,10 @@ func (blockingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, ex
 	panic("not implemented")
 }
 
+func (blockingDAGRunStore) CompareAndSwapAttemptStatus(context.Context, exec.DAGRunAttemptRef, core.Status, func(*exec.DAGRunStatus) error) (*exec.DAGRunStatus, bool, error) {
+	panic("not implemented")
+}
+
 func (blockingDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	panic("not implemented")
 }

--- a/internal/service/scheduler/retry_scanner_test.go
+++ b/internal/service/scheduler/retry_scanner_test.go
@@ -757,6 +757,15 @@ func (s *retryScannerStore) CompareAndSwapLatestAttemptStatus(
 	return cloneRetryStatus(attempt.status), true, nil
 }
 
+func (s *retryScannerStore) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	mutate func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	return s.CompareAndSwapLatestAttemptStatus(ctx, ref.DAGRun, ref.AttemptID, expectedStatus, mutate)
+}
+
 func (s *retryScannerStore) FindAttempt(_ context.Context, dagRun exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	s.findAttemptCalls++
 	attempt, ok := s.attempts[dagRun.String()]

--- a/internal/service/scheduler/retry_scanner_test.go
+++ b/internal/service/scheduler/retry_scanner_test.go
@@ -741,6 +741,7 @@ func (s *retryScannerStore) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	mutate func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	attempt, ok := s.attempts[dagRun.String()]
 	if !ok {
@@ -755,15 +756,6 @@ func (s *retryScannerStore) CompareAndSwapLatestAttemptStatus(
 	}
 	attempt.status = cloneRetryStatus(current)
 	return cloneRetryStatus(attempt.status), true, nil
-}
-
-func (s *retryScannerStore) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	mutate func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	return s.CompareAndSwapLatestAttemptStatus(ctx, ref.DAGRun, ref.AttemptID, expectedStatus, mutate)
 }
 
 func (s *retryScannerStore) FindAttempt(_ context.Context, dagRun exec.DAGRunRef) (exec.DAGRunAttempt, error) {

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -336,21 +336,9 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	expectedAttemptID string,
 	expectedStatus core.Status,
 	_ func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	args := m.Called(ctx, dagRun, expectedAttemptID, expectedStatus, mock.Anything)
-	if args.Get(0) == nil {
-		return nil, args.Bool(1), args.Error(2)
-	}
-	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
-}
-
-func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
-	ctx context.Context,
-	ref exec.DAGRunAttemptRef,
-	expectedStatus core.Status,
-	_ func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	args := m.Called(ctx, ref, expectedStatus, mock.Anything)
 	if args.Get(0) == nil {
 		return nil, args.Bool(1), args.Error(2)
 	}

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -344,6 +344,19 @@ func (m *mockDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
 }
 
+func (m *mockDAGRunStore) CompareAndSwapAttemptStatus(
+	ctx context.Context,
+	ref exec.DAGRunAttemptRef,
+	expectedStatus core.Status,
+	_ func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	args := m.Called(ctx, ref, expectedStatus, mock.Anything)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1), args.Error(2)
+	}
+	return args.Get(0).(*exec.DAGRunStatus), args.Bool(1), args.Error(2)
+}
+
 func (m *mockDAGRunStore) FindAttempt(ctx context.Context, dagRun exec.DAGRunRef) (exec.DAGRunAttempt, error) {
 	args := m.Called(ctx, dagRun)
 	if args.Get(0) == nil {

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -661,15 +661,7 @@ func (m *mockRemoteDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	_ string,
 	_ core.Status,
 	_ func(*exec.DAGRunStatus) error,
-) (*exec.DAGRunStatus, bool, error) {
-	return nil, false, nil
-}
-
-func (m *mockRemoteDAGRunStore) CompareAndSwapAttemptStatus(
-	_ context.Context,
-	_ exec.DAGRunAttemptRef,
-	_ core.Status,
-	_ func(*exec.DAGRunStatus) error,
+	_ ...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
 	return nil, false, nil
 }

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -665,6 +665,15 @@ func (m *mockRemoteDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	return nil, false, nil
 }
 
+func (m *mockRemoteDAGRunStore) CompareAndSwapAttemptStatus(
+	_ context.Context,
+	_ exec.DAGRunAttemptRef,
+	_ core.Status,
+	_ func(*exec.DAGRunStatus) error,
+) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
 func (m *mockRemoteDAGRunStore) RemoveOldDAGRuns(_ context.Context, _ string, _ int, _ ...exec.RemoveOldDAGRunsOption) ([]string, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- add a hierarchy-aware DAG run attempt reference for root and sub-DAG status mutation
- update stale distributed lease repair to preserve root/sub-DAG identity when failing stale attempts
- add regression coverage for stale distributed sub-DAG leases and file-store sub-attempt CAS

Fixes #2136

## Testing
- go test ./internal/service/coordinator ./internal/persis/filedagrun ./internal/runtime ./internal/service/frontend/api/v1
- go test ./internal/core/exec ./internal/service/scheduler ./internal/service/worker
- go test ./internal/... -run '^$'
- go test ./internal/intg/distr -run 'TestSubDAG|TestCancellation/cancelPropagatesToSubDAGOnWorker'
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic status operations for DAG run attempts to enhance concurrency safety during status transitions and execution reliability across distributed systems
  * Enhanced sub-DAG attempt identification and lifecycle tracking for more accurate state management and recovery
  * Strengthened stale run detection mechanisms with more precise attempt-level comparison logic for robust error handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->