### PR TITLE
fix: stop auth-expired UI request loops

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -37,6 +37,7 @@ import Layout from './layouts/Layout';
 import fetchJson from './lib/fetchJson';
 import { fetchWithTimeout, shouldRetryQueryError } from './lib/requestTimeout';
 import { useClient } from './hooks/api';
+import { addAuthSessionListener, getAuthToken } from './lib/authSession';
 import {
   getStoredWorkspaceSelection,
   persistWorkspaceSelection,
@@ -257,7 +258,12 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
   );
   const [workspaceSelection, setWorkspaceSelection] =
     React.useState<WorkspaceSelection>(() => getStoredWorkspaceSelection());
+  const [authToken, setAuthToken] = React.useState<string | null>(() =>
+    getAuthToken()
+  );
   const selectedWorkspaceName = workspaceNameForSelection(workspaceSelection);
+  const canFetchAuthenticatedResources =
+    config.authMode !== 'builtin' || authToken !== null;
   const handleSelectWorkspace = React.useCallback(
     (selection: WorkspaceSelection) => {
       const sanitized = sanitizeWorkspaceSelection(selection);
@@ -296,6 +302,13 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
   );
 
   const fetchWorkspaces = React.useCallback(async () => {
+    if (!canFetchAuthenticatedResources) {
+      setWorkspaceError(null);
+      applyWorkspaces(initialWorkspacesRef.current ?? []);
+      setWorkspacesLoaded(true);
+      return;
+    }
+
     const requestSeq = workspaceFetchSeqRef.current + 1;
     workspaceFetchSeqRef.current = requestSeq;
     setWorkspaceError(null);
@@ -325,7 +338,12 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
         setWorkspacesLoaded(true);
       }
     }
-  }, [applyWorkspaces, client, selectedRemoteNode]);
+  }, [
+    applyWorkspaces,
+    canFetchAuthenticatedResources,
+    client,
+    selectedRemoteNode,
+  ]);
 
   const handleCreateWorkspace = React.useCallback(
     async (name: string) => {
@@ -399,9 +417,13 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
   // Fetch remote node names from the API on mount so the dropdown
   // includes store-sourced nodes (not just config-sourced ones from the template).
   React.useEffect(() => {
+    if (!canFetchAuthenticatedResources) {
+      return;
+    }
+
     const fetchRemoteNodeNames = async () => {
       try {
-        const token = localStorage.getItem('dagu_auth_token');
+        const token = getAuthToken();
         const headers: Record<string, string> = { Accept: 'application/json' };
         if (token) {
           headers['Authorization'] = `Bearer ${token}`;
@@ -425,7 +447,13 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
       }
     };
     fetchRemoteNodeNames();
-  }, [config.apiURL]);
+  }, [canFetchAuthenticatedResources, config.apiURL]);
+
+  React.useEffect(() => {
+    return addAuthSessionListener((change) => {
+      setAuthToken(change.token);
+    });
+  }, []);
 
   React.useEffect(() => {
     if (!remoteNodes.includes(selectedRemoteNode)) {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,10 +1,27 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from 'react';
+import { mutate as globalMutate } from 'swr';
 import { AppBarContext } from './AppBarContext';
 import { useConfig } from './ConfigContext';
 import { components, UserRole } from '@/api/v1/schema';
+import { sseManager } from '@/hooks/SSEManager';
+import {
+  TOKEN_KEY,
+  addAuthSessionListener,
+  clearAuthSession,
+  getAuthExpiresAt,
+  getAuthToken,
+  setAuthSession,
+} from '@/lib/authSession';
 import {
   effectiveWorkspaceRole,
   roleAtLeast,
@@ -17,6 +34,7 @@ type User = components['schemas']['User'];
 
 type SetupResult = {
   token: string;
+  expiresAt?: string;
   user: User;
 };
 
@@ -35,24 +53,31 @@ type AuthContextType = {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-export const TOKEN_KEY = 'dagu_auth_token';
+export { TOKEN_KEY };
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const config = useConfig();
   const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(() => localStorage.getItem(TOKEN_KEY));
+  const [token, setToken] = useState<string | null>(() => getAuthToken());
   const [isLoading, setIsLoading] = useState(true);
   const [setupRequired, setSetupRequired] = useState(config.setupRequired);
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(TOKEN_KEY);
+  const clearLocalSession = useCallback(() => {
     setToken(null);
     setUser(null);
+    sseManager.disposeAll();
+    void globalMutate(() => true, undefined, { revalidate: false });
   }, []);
 
+  const logout = useCallback(() => {
+    clearAuthSession('logout');
+    clearLocalSession();
+  }, [clearLocalSession]);
+
   const refreshUser = useCallback(async () => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedToken = getAuthToken();
     if (!storedToken) {
+      clearLocalSession();
       setIsLoading(false);
       return;
     }
@@ -69,14 +94,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(data.user);
         setToken(storedToken);
       } else {
-        logout();
+        clearAuthSession('unauthorized');
+        clearLocalSession();
       }
     } catch {
       logout();
     } finally {
       setIsLoading(false);
     }
-  }, [config.apiURL, logout]);
+  }, [clearLocalSession, config.apiURL, logout]);
 
   const login = useCallback(async (username: string, password: string) => {
     const response = await fetch(`${config.apiURL}/auth/login`, {
@@ -93,35 +119,72 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     const data = await response.json();
-    localStorage.setItem(TOKEN_KEY, data.token);
+    setAuthSession(data.token, data.expiresAt, 'login');
     setToken(data.token);
     setUser(data.user);
   }, [config.apiURL]);
 
-  const setup = useCallback(async (username: string, password: string): Promise<SetupResult> => {
-    const response = await fetch(`${config.apiURL}/auth/setup`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    });
+  const setup = useCallback(
+    async (username: string, password: string): Promise<SetupResult> => {
+      const response = await fetch(`${config.apiURL}/auth/setup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
 
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({}));
-      const err = new Error(data.message || 'Setup failed');
-      (err as any).status = response.status;
-      throw err;
-    }
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const err = new Error(data.message || 'Setup failed');
+        (err as any).status = response.status;
+        throw err;
+      }
 
-    const data = await response.json();
-    return { token: data.token, user: data.user };
-  }, [config.apiURL]);
+      const data = await response.json();
+      return { token: data.token, expiresAt: data.expiresAt, user: data.user };
+    },
+    [config.apiURL]
+  );
 
   const completeSetup = useCallback((result: SetupResult) => {
-    localStorage.setItem(TOKEN_KEY, result.token);
+    setAuthSession(result.token, result.expiresAt, 'setup');
     setToken(result.token);
     setUser(result.user);
     setSetupRequired(false);
   }, []);
+
+  useEffect(() => {
+    return addAuthSessionListener((change) => {
+      if (change.token) {
+        setToken(change.token);
+        if (change.reason === 'oidc') {
+          setIsLoading(true);
+          void refreshUser();
+        }
+        return;
+      }
+      clearLocalSession();
+      setIsLoading(false);
+    });
+  }, [clearLocalSession, refreshUser]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+    const expiresAt = getAuthExpiresAt();
+    if (!expiresAt) {
+      return;
+    }
+    const delay = Date.parse(expiresAt) - Date.now();
+    if (delay <= 0) {
+      clearAuthSession('expired');
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      clearAuthSession('expired');
+    }, delay);
+    return () => window.clearTimeout(timeout);
+  }, [token]);
 
   useEffect(() => {
     if (config.authMode === 'builtin') {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -93,16 +93,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const data = await response.json();
         setUser(data.user);
         setToken(storedToken);
-      } else {
+      } else if (response.status === 401 || response.status === 403) {
         clearAuthSession('unauthorized');
         clearLocalSession();
+      } else {
+        console.warn(
+          'Failed to refresh authenticated user',
+          response.status,
+          response.statusText
+        );
       }
-    } catch {
-      logout();
+    } catch (error) {
+      console.warn('Failed to refresh authenticated user', error);
     } finally {
       setIsLoading(false);
     }
-  }, [clearLocalSession, config.apiURL, logout]);
+  }, [clearLocalSession, config.apiURL]);
 
   const login = useCallback(async (username: string, password: string) => {
     const response = await fetch(`${config.apiURL}/auth/login`, {
@@ -126,11 +132,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const setup = useCallback(
     async (username: string, password: string): Promise<SetupResult> => {
-      const response = await fetch(`${config.apiURL}/auth/setup`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-      });
+      const response = await fetch(
+        `${config.apiURL}/auth/setup?remoteNode=local`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password }),
+        }
+      );
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
@@ -156,10 +165,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return addAuthSessionListener((change) => {
       if (change.token) {
         setToken(change.token);
-        if (change.reason === 'oidc') {
-          setIsLoading(true);
-          void refreshUser();
-        }
+        setIsLoading(true);
+        void refreshUser();
         return;
       }
       clearLocalSession();

--- a/ui/src/hooks/SSEManager.ts
+++ b/ui/src/hooks/SSEManager.ts
@@ -1,7 +1,12 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { getAuthHeaders, getAuthToken } from '@/lib/authHeaders';
+import { getAuthHeaders } from '@/lib/authHeaders';
+import {
+  getAuthToken,
+  handleAuthResponse,
+  isBuiltinAuthMode,
+} from '@/lib/authSession';
 
 const MAX_RETRY_DELAY_MS = 16000;
 const CONNECT_TIMEOUT_MS = 15000;
@@ -401,6 +406,16 @@ export class SSEManager {
       return;
     }
 
+    if (isBuiltinAuthMode() && !getAuthToken()) {
+      this.updateState(conn, {
+        isConnected: false,
+        isConnecting: false,
+        shouldUseFallback: false,
+        error: new Error('Authentication required'),
+      });
+      return;
+    }
+
     if (conn.eventSource) {
       conn.eventSource.close();
       conn.eventSource = null;
@@ -606,6 +621,7 @@ export class SSEManager {
           }),
         }
       );
+      handleAuthResponse(response);
 
       const isStaleMutation = () =>
         conn.sessionId !== mutationSessionId ||
@@ -735,6 +751,12 @@ export class SSEManager {
     }
 
     this.connections.delete(conn.key);
+  }
+
+  disposeAll(): void {
+    for (const conn of Array.from(this.connections.values())) {
+      this.disposeConnection(conn);
+    }
   }
 }
 

--- a/ui/src/hooks/SSEManager.ts
+++ b/ui/src/hooks/SSEManager.ts
@@ -3,6 +3,7 @@
 
 import { getAuthHeaders } from '@/lib/authHeaders';
 import {
+  addAuthSessionListener,
   getAuthToken,
   handleAuthResponse,
   isBuiltinAuthMode,
@@ -13,6 +14,7 @@ const CONNECT_TIMEOUT_MS = 15000;
 const MUTATION_DEBOUNCE_MS = 200;
 const DRAINING_GRACE_PERIOD_MS = 2000;
 const FALLBACK_AFTER_RETRIES = 5;
+const AUTHENTICATION_REQUIRED_MESSAGE = 'Authentication required';
 
 export interface SSEConnectionState {
   isConnected: boolean;
@@ -182,22 +184,18 @@ function buildStreamUrl(
   remoteNode: string,
   topics: string[],
   lastEventId: string
-): string {
+): URL {
   const url = new URL(`${apiURL}/events/stream`, window.location.origin);
   for (const topic of [...topics].sort()) {
     url.searchParams.append('topic', topic);
   }
   url.searchParams.set('remoteNode', remoteNode);
 
-  const token = getAuthToken();
-  if (token) {
-    url.searchParams.set('token', token);
-  }
   if (lastEventId) {
     url.searchParams.set('lastEventId', lastEventId);
   }
 
-  return url.toString();
+  return url;
 }
 
 function buildMutationUrl(apiURL: string, remoteNode: string): string {
@@ -227,6 +225,20 @@ function calculateRetryDelay(retryCount: number): number {
 
 export class SSEManager {
   private connections = new Map<string, ManagedConnection>();
+
+  constructor() {
+    addAuthSessionListener((change) => {
+      if (!change.token) {
+        return;
+      }
+
+      for (const conn of Array.from(this.connections.values())) {
+        if (conn.state.error?.message === AUTHENTICATION_REQUIRED_MESSAGE) {
+          this.ensureConnected(conn);
+        }
+      }
+    });
+  }
 
   subscribe(
     endpoint: string,
@@ -406,12 +418,13 @@ export class SSEManager {
       return;
     }
 
-    if (isBuiltinAuthMode() && !getAuthToken()) {
+    const token = getAuthToken();
+    if (isBuiltinAuthMode() && !token) {
       this.updateState(conn, {
         isConnected: false,
         isConnecting: false,
         shouldUseFallback: false,
-        error: new Error('Authentication required'),
+        error: new Error(AUTHENTICATION_REQUIRED_MESSAGE),
       });
       return;
     }
@@ -431,7 +444,10 @@ export class SSEManager {
       Array.from(conn.topics.keys()),
       conn.lastEventId
     );
-    const eventSource = new EventSource(url);
+    if (token) {
+      url.searchParams.set('token', token);
+    }
+    const eventSource = new EventSource(url.toString());
     conn.eventSource = eventSource;
     conn.sessionId = null;
     conn.serverTopics.clear();

--- a/ui/src/hooks/__tests__/SSEManager.test.ts
+++ b/ui/src/hooks/__tests__/SSEManager.test.ts
@@ -104,6 +104,7 @@ describe('SSEManager', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    localStorage.clear();
   });
 
   it('keeps a fresh topic pending until the server acknowledges the subscription', async () => {
@@ -385,5 +386,37 @@ describe('SSEManager', () => {
 
     unsubscribeSecondary();
     unsubscribePrimary();
+  });
+
+  it('does not open a builtin-auth stream when the local token is expired', () => {
+    vi.stubGlobal('getConfig', () => ({ authMode: 'builtin' }));
+    localStorage.setItem('dagu_auth_token', 'expired-token');
+    localStorage.setItem(
+      'dagu_auth_token_expires_at',
+      new Date(Date.now() - 1000).toISOString()
+    );
+
+    const manager = new SSEManager();
+    const states: SSEConnectionState[] = [];
+
+    const unsubscribe = manager.subscribeTopic(
+      'dag:test.yaml',
+      'local',
+      '/api/v1',
+      {
+        onData: () => undefined,
+        onStateChange: (state) => states.push(snapshotState(state)),
+      }
+    );
+
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(localStorage.getItem('dagu_auth_token')).toBeNull();
+    expect(lastState(states)).toMatchObject({
+      isConnected: false,
+      isConnecting: false,
+      shouldUseFallback: false,
+    });
+
+    unsubscribe();
   });
 });

--- a/ui/src/hooks/__tests__/SSEManager.test.ts
+++ b/ui/src/hooks/__tests__/SSEManager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SSEConnectionState } from '../SSEManager';
 import { endpointToTopic, SSEManager } from '../SSEManager';
+import { setAuthSession } from '../../lib/authSession';
 
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -416,6 +417,33 @@ describe('SSEManager', () => {
       isConnecting: false,
       shouldUseFallback: false,
     });
+
+    unsubscribe();
+  });
+
+  it('retries builtin-auth streams when a token becomes available', () => {
+    vi.stubGlobal('getConfig', () => ({ authMode: 'builtin' }));
+
+    const manager = new SSEManager();
+    const states: SSEConnectionState[] = [];
+
+    const unsubscribe = manager.subscribeTopic(
+      'dag:test.yaml',
+      'local',
+      '/api/v1',
+      {
+        onData: () => undefined,
+        onStateChange: (state) => states.push(snapshotState(state)),
+      }
+    );
+
+    expect(MockEventSource.instances).toHaveLength(0);
+    expect(lastState(states)?.error?.message).toBe('Authentication required');
+
+    setAuthSession('fresh-token', new Date(Date.now() + 60_000).toISOString());
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.url).toContain('token=fresh-token');
 
     unsubscribe();
   });

--- a/ui/src/hooks/api.ts
+++ b/ui/src/hooks/api.ts
@@ -5,15 +5,20 @@ import {
   createInfiniteHook,
 } from 'swr-openapi';
 import type { paths } from '../api/v1/schema';
+import { getAuthToken, handleAuthResponse } from '../lib/authSession';
 import { fetchWithTimeout } from '../lib/requestTimeout';
 
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const token = localStorage.getItem('dagu_auth_token');
+    const token = getAuthToken();
     if (token) {
       request.headers.set('Authorization', `Bearer ${token}`);
     }
     return request;
+  },
+  async onResponse({ response }) {
+    handleAuthResponse(response);
+    return response;
   },
 };
 

--- a/ui/src/lib/__tests__/authSession.test.ts
+++ b/ui/src/lib/__tests__/authSession.test.ts
@@ -3,10 +3,23 @@ import {
   AUTH_SESSION_CHANGED_EVENT,
   AUTH_TOKEN_EXPIRES_AT_KEY,
   TOKEN_KEY,
+  addAuthSessionListener,
+  clearAuthSession,
   getAuthToken,
   handleAuthResponse,
   setAuthSession,
 } from '../authSession';
+
+function base64URL(value: string): string {
+  return btoa(value)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function createJWT(payload: Record<string, unknown>): string {
+  return `header.${base64URL(JSON.stringify(payload))}.signature`;
+}
 
 describe('authSession', () => {
   beforeEach(() => {
@@ -64,5 +77,70 @@ describe('authSession', () => {
     handleAuthResponse(new Response(null, { status: 401 }));
 
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('decodes the JWT exp claim when an explicit expiry is omitted', () => {
+    const expiresAtSeconds = Math.floor((Date.now() + 60_000) / 1000);
+    const token = createJWT({ exp: expiresAtSeconds });
+
+    setAuthSession(token);
+
+    expect(localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY)).toBe(
+      new Date(expiresAtSeconds * 1000).toISOString()
+    );
+  });
+
+  it('keeps tokens on 401 responses for non-builtin auth modes', () => {
+    vi.stubGlobal('getConfig', () => ({ authMode: 'oidc' }));
+    setAuthSession('token-1', new Date(Date.now() + 60_000).toISOString());
+
+    handleAuthResponse(new Response(null, { status: 401 }));
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe('token-1');
+  });
+
+  it('removes auth session listeners after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = addAuthSessionListener(listener);
+
+    setAuthSession('token-1', new Date(Date.now() + 60_000).toISOString());
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    listener.mockClear();
+    unsubscribe();
+    setAuthSession('token-2', new Date(Date.now() + 60_000).toISOString());
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed JWT expiry payloads', () => {
+    const tokens = [
+      'not-a-jwt',
+      'header..signature',
+      'header.%%%%.signature',
+      createJWT({ sub: 'user-1' }),
+    ];
+
+    for (const token of tokens) {
+      localStorage.clear();
+
+      setAuthSession(token);
+
+      expect(localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY)).toBeNull();
+    }
+  });
+
+  it('notifies explicit logout even when storage is already clear', () => {
+    const listener = vi.fn();
+    const unsubscribe = addAuthSessionListener(listener);
+
+    clearAuthSession('logout');
+
+    expect(listener).toHaveBeenCalledWith({
+      token: null,
+      expiresAt: null,
+      reason: 'logout',
+    });
+    unsubscribe();
   });
 });

--- a/ui/src/lib/__tests__/authSession.test.ts
+++ b/ui/src/lib/__tests__/authSession.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_SESSION_CHANGED_EVENT,
+  AUTH_TOKEN_EXPIRES_AT_KEY,
+  TOKEN_KEY,
+  getAuthToken,
+  handleAuthResponse,
+  setAuthSession,
+} from '../authSession';
+
+describe('authSession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('getConfig', () => ({ authMode: 'builtin' }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('clears the stored token when an authenticated request returns 401', () => {
+    const events: Array<{ token: string | null; reason?: string }> = [];
+    window.addEventListener(AUTH_SESSION_CHANGED_EVENT, (event) => {
+      events.push((event as CustomEvent).detail);
+    });
+
+    setAuthSession('token-1', new Date(Date.now() + 60_000).toISOString());
+
+    handleAuthResponse(new Response(null, { status: 401 }));
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY)).toBeNull();
+    expect(events[events.length - 1]).toMatchObject({
+      token: null,
+      reason: 'unauthorized',
+    });
+  });
+
+  it('expires a locally stale token before it can be reused', () => {
+    const events: Array<{ token: string | null; reason?: string }> = [];
+    window.addEventListener(AUTH_SESSION_CHANGED_EVENT, (event) => {
+      events.push((event as CustomEvent).detail);
+    });
+
+    localStorage.setItem(TOKEN_KEY, 'expired-token');
+    localStorage.setItem(
+      AUTH_TOKEN_EXPIRES_AT_KEY,
+      new Date(Date.now() - 1000).toISOString()
+    );
+
+    expect(getAuthToken()).toBeNull();
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(events[events.length - 1]).toMatchObject({
+      token: null,
+      reason: 'expired',
+    });
+  });
+
+  it('ignores login failures when there is no active token to invalidate', () => {
+    const listener = vi.fn();
+    window.addEventListener(AUTH_SESSION_CHANGED_EVENT, listener);
+
+    handleAuthResponse(new Response(null, { status: 401 }));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/authHeaders.ts
+++ b/ui/src/lib/authHeaders.ts
@@ -1,8 +1,6 @@
-const TOKEN_KEY = 'dagu_auth_token';
+import { getAuthToken } from './authSession';
 
-export function getAuthToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
-}
+export { getAuthToken };
 
 export function getAuthHeaders(
   additionalHeaders?: Record<string, string>

--- a/ui/src/lib/authSession.ts
+++ b/ui/src/lib/authSession.ts
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export const TOKEN_KEY = 'dagu_auth_token';
+export const AUTH_TOKEN_EXPIRES_AT_KEY = 'dagu_auth_token_expires_at';
+export const AUTH_SESSION_CHANGED_EVENT = 'dagu:auth-session-changed';
+
+declare const getConfig: undefined | (() => { authMode?: string });
+
+type AuthSessionReason =
+  | 'login'
+  | 'logout'
+  | 'setup'
+  | 'oidc'
+  | 'expired'
+  | 'unauthorized';
+
+export type AuthSessionChange = {
+  token: string | null;
+  expiresAt: string | null;
+  reason: AuthSessionReason;
+};
+
+function dispatchSessionChange(change: AuthSessionChange): void {
+  window.dispatchEvent(
+    new CustomEvent<AuthSessionChange>(AUTH_SESSION_CHANGED_EVENT, {
+      detail: change,
+    })
+  );
+}
+
+function readRuntimeAuthMode(): string | undefined {
+  try {
+    if (typeof getConfig === 'function') {
+      return getConfig().authMode;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+export function isBuiltinAuthMode(): boolean {
+  return readRuntimeAuthMode() === 'builtin';
+}
+
+function parseExpiresAt(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function base64URLDecode(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    '='
+  );
+  return globalThis.atob(padded);
+}
+
+function decodeJWTExpiresAt(token: string): string | null {
+  const [, payload] = token.split('.');
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(base64URLDecode(payload)) as { exp?: unknown };
+    if (typeof parsed.exp !== 'number') {
+      return null;
+    }
+    return new Date(parsed.exp * 1000).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+export function setAuthSession(
+  token: string,
+  expiresAt?: string | null,
+  reason: AuthSessionReason = 'login'
+): void {
+  const resolvedExpiresAt = expiresAt ?? decodeJWTExpiresAt(token);
+  localStorage.setItem(TOKEN_KEY, token);
+  if (resolvedExpiresAt) {
+    localStorage.setItem(AUTH_TOKEN_EXPIRES_AT_KEY, resolvedExpiresAt);
+  } else {
+    localStorage.removeItem(AUTH_TOKEN_EXPIRES_AT_KEY);
+  }
+  dispatchSessionChange({
+    token,
+    expiresAt: resolvedExpiresAt,
+    reason,
+  });
+}
+
+export function clearAuthSession(
+  reason: AuthSessionReason = 'logout'
+): void {
+  const hadToken = localStorage.getItem(TOKEN_KEY) !== null;
+  const hadExpiresAt = localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY) !== null;
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(AUTH_TOKEN_EXPIRES_AT_KEY);
+  if (hadToken || hadExpiresAt) {
+    dispatchSessionChange({ token: null, expiresAt: null, reason });
+  }
+}
+
+export function getAuthExpiresAt(): string | null {
+  return localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY);
+}
+
+export function isAuthSessionExpired(now: number = Date.now()): boolean {
+  const expiresAt = parseExpiresAt(getAuthExpiresAt());
+  return expiresAt !== null && expiresAt <= now;
+}
+
+export function getAuthToken(): string | null {
+  const token = localStorage.getItem(TOKEN_KEY);
+  if (!token) {
+    return null;
+  }
+  if (isAuthSessionExpired()) {
+    clearAuthSession('expired');
+    return null;
+  }
+  return token;
+}
+
+export function handleAuthResponse(response: Response): void {
+  if (response.status !== 401 || !isBuiltinAuthMode()) {
+    return;
+  }
+  if (localStorage.getItem(TOKEN_KEY)) {
+    clearAuthSession('unauthorized');
+  }
+}
+
+export function addAuthSessionListener(
+  listener: (change: AuthSessionChange) => void
+): () => void {
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<AuthSessionChange>).detail);
+  };
+  window.addEventListener(AUTH_SESSION_CHANGED_EVENT, handler);
+  return () => window.removeEventListener(AUTH_SESSION_CHANGED_EVENT, handler);
+}

--- a/ui/src/lib/authSession.ts
+++ b/ui/src/lib/authSession.ts
@@ -62,8 +62,9 @@ function base64URLDecode(value: string): string {
 }
 
 function decodeJWTExpiresAt(token: string): string | null {
-  const [, payload] = token.split('.');
-  if (!payload) {
+  const parts = token.split('.');
+  const payload = parts[1];
+  if (parts.length !== 3 || !payload || payload.trim() === '') {
     return null;
   }
 
@@ -104,7 +105,7 @@ export function clearAuthSession(
   const hadExpiresAt = localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY) !== null;
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(AUTH_TOKEN_EXPIRES_AT_KEY);
-  if (hadToken || hadExpiresAt) {
+  if (reason === 'logout' || hadToken || hadExpiresAt) {
     dispatchSessionChange({ token: null, expiresAt: null, reason });
   }
 }
@@ -113,7 +114,7 @@ export function getAuthExpiresAt(): string | null {
   return localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY);
 }
 
-export function isAuthSessionExpired(now: number = Date.now()): boolean {
+export function isAuthSessionExpired(now: number): boolean {
   const expiresAt = parseExpiresAt(getAuthExpiresAt());
   return expiresAt !== null && expiresAt <= now;
 }
@@ -123,7 +124,10 @@ export function getAuthToken(): string | null {
   if (!token) {
     return null;
   }
-  if (isAuthSessionExpired()) {
+  // localStorage is intentionally lock-free across tabs. If TOKEN_KEY changes
+  // between getAuthToken, isAuthSessionExpired, and clearAuthSession, the server
+  // still rejects stale credentials and handleAuthResponse clears the session.
+  if (isAuthSessionExpired(Date.now())) {
     clearAuthSession('expired');
     return null;
   }

--- a/ui/src/lib/fetchJson.ts
+++ b/ui/src/lib/fetchJson.ts
@@ -1,5 +1,6 @@
 declare const getConfig: () => { apiURL: string };
 
+import { getAuthToken } from './authSession';
 import { fetchWithTimeout } from './requestTimeout';
 
 /**
@@ -14,7 +15,7 @@ export default async function fetchJson<JSON = unknown>(
     Accept: 'application/json',
   };
 
-  const token = localStorage.getItem('dagu_auth_token');
+  const token = getAuthToken();
   if (token) {
     (headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
   }
@@ -23,7 +24,7 @@ export default async function fetchJson<JSON = unknown>(
     ...init,
     headers,
   });
-  const data = await response.json();
+  const data = await response.json().catch(() => undefined);
 
   if (response.ok) {
     return data;
@@ -32,7 +33,7 @@ export default async function fetchJson<JSON = unknown>(
   throw new FetchError({
     message: data?.message || response.statusText,
     response,
-    data,
+    data: data ?? { message: response.statusText },
   });
 }
 

--- a/ui/src/lib/fetchJson.ts
+++ b/ui/src/lib/fetchJson.ts
@@ -24,7 +24,13 @@ export default async function fetchJson<JSON = unknown>(
     ...init,
     headers,
   });
-  const data = await response.json().catch(() => undefined);
+  const contentType = response.headers.get('content-type') ?? '';
+  const data = contentType.includes('application/json')
+    ? await response.json().catch((error) => {
+        console.warn('Failed to parse response JSON', error);
+        return undefined;
+      })
+    : undefined;
 
   if (response.ok) {
     return data;

--- a/ui/src/lib/requestTimeout.ts
+++ b/ui/src/lib/requestTimeout.ts
@@ -40,6 +40,14 @@ function resolveMethod(input: RequestInfo | URL, init?: RequestInit): string {
   return 'GET';
 }
 
+function getErrorResponse(error: unknown): Response | undefined {
+  if (typeof Response === 'undefined' || !error || typeof error !== 'object') {
+    return undefined;
+  }
+  const response = (error as { response?: unknown }).response;
+  return response instanceof Response ? response : undefined;
+}
+
 export function getDefaultTimeoutMs(
   input: RequestInfo | URL,
   init?: RequestInit
@@ -116,6 +124,10 @@ export async function fetchWithTimeout(
     handleAuthResponse(response);
     return response;
   } catch (error) {
+    const response = getErrorResponse(error);
+    if (response) {
+      handleAuthResponse(response);
+    }
     if (controller.signal.aborted) {
       const reason = controller.signal.reason;
       if (reason instanceof RequestTimeoutError) {

--- a/ui/src/lib/requestTimeout.ts
+++ b/ui/src/lib/requestTimeout.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { handleAuthResponse } from './authSession';
+
 const READ_METHODS = new Set(['GET', 'HEAD']);
 
 export const DEFAULT_READ_TIMEOUT_MS = 10_000;
@@ -107,10 +109,12 @@ export async function fetchWithTimeout(
   }, timeoutMs);
 
   try {
-    return await fetch(input, {
+    const response = await fetch(input, {
       ...init,
       signal: controller.signal,
     });
+    handleAuthResponse(response);
+    return response;
   } catch (error) {
     if (controller.signal.aborted) {
       const reason = controller.signal.reason;
@@ -169,5 +173,6 @@ export function isAbortLikeError(error: unknown): boolean {
 }
 
 export function shouldRetryQueryError(error: unknown): boolean {
-  return !isAbortLikeError(error);
+  const status = getErrorResponseStatus(error);
+  return !isAbortLikeError(error) && status !== 401;
 }

--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import { useAuth, TOKEN_KEY } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/AuthContext';
 import { useConfig } from '@/contexts/ConfigContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { setAuthSession } from '@/lib/authSession';
 import { AlertCircle, LogIn, KeyRound, CheckCircle } from 'lucide-react';
 
 export default function LoginPage() {
@@ -30,7 +31,7 @@ export default function LoginPage() {
 
     // Handle OIDC callback token - store in localStorage and navigate to home
     if (tokenParam) {
-      localStorage.setItem(TOKEN_KEY, tokenParam);
+      setAuthSession(tokenParam, null, 'oidc');
       // Navigate to home immediately - AuthProvider will validate token on next page load
       navigate(from, { replace: true });
       return;


### PR DESCRIPTION
## Summary
- clear expired builtin-auth sessions before attaching tokens to API/SSE requests
- invalidate local UI state, SSE connections, and SWR cache after builtin-auth 401 responses
- avoid authenticated app-shell fetches on the login page when there is no builtin session

## Testing
- pnpm --dir ui typecheck
- pnpm --dir ui test

Closes #2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tab/window auth sync and scheduled token-expiration cleanup
  * SSE connections now respond to auth state and auto-reconnect when a token becomes available
  * UI falls back to initial workspaces and skips remote-node name loading when auth-required resources are unavailable

* **Bug Fixes**
  * Improved expired-token handling, logout cleanup, and API auth response handling
  * Prevented retries on 401 and avoided creating SSE streams without valid auth

* **Tests**
  * Expanded auth session and SSE tests covering expiry, logout, and reconnection scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2144)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->