### PR TITLE
fix: remove agent step LLM request timeout

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -671,10 +671,7 @@ func (a *API) runOneShotPrompt(ctx context.Context, provider llm.Provider, model
 		{Role: llm.RoleUser, Content: prompt},
 	}
 
-	llmCtx, cancel := context.WithTimeout(ctx, llmRequestTimeout)
-	defer cancel()
-
-	return llm.ChatWithRetry(llmCtx, provider, &llm.ChatRequest{
+	return llm.ChatWithRetry(ctx, provider, &llm.ChatRequest{
 		Model:    model,
 		Messages: messages,
 	}, llm.DefaultLogicalRetryConfig())

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -20,9 +20,6 @@ const (
 	// idlePollingInterval is the interval for polling when no messages are queued.
 	idlePollingInterval = 100 * time.Millisecond
 
-	// llmRequestTimeout is the maximum time allowed for an LLM request.
-	llmRequestTimeout = 5 * time.Minute
-
 	// maxToolCallDepth limits nested tool call chains to prevent infinite recursion.
 	// This can happen if an LLM continuously makes tool calls without producing a final response.
 	maxToolCallDepth = 50
@@ -89,6 +86,10 @@ type LoopConfig struct {
 	// processed (processLLMRequest returned nil). For single-shot callers
 	// like the agent-step executor this is the signal to cancel the loop.
 	OnTurnComplete func()
+	// ReturnTurnErrors makes Go return turn-processing errors instead of
+	// recording them and waiting for another queued message. Interactive
+	// sessions keep this false so a later user message can recover.
+	ReturnTurnErrors bool
 }
 
 // Loop manages a session turn with an LLM including tool execution.
@@ -120,6 +121,7 @@ type Loop struct {
 	registry           SubSessionRegistry
 	webSearch          *llm.WebSearchRequest
 	onTurnComplete     func()
+	returnTurnErrors   bool
 	activeTurn         bool
 	interruptRequested bool
 }
@@ -155,6 +157,7 @@ func NewLoop(config LoopConfig) *Loop {
 		registry:         config.Registry,
 		webSearch:        config.WebSearch,
 		onTurnComplete:   config.OnTurnComplete,
+		returnTurnErrors: config.ReturnTurnErrors,
 	}
 }
 
@@ -258,6 +261,9 @@ func (l *Loop) Go(ctx context.Context) error {
 				}
 				l.logger.Error("failed to process LLM request", "error", err)
 				l.finishActiveTurn()
+				if l.returnTurnErrors {
+					return err
+				}
 				continue
 			}
 			l.finishActiveTurn()
@@ -356,12 +362,10 @@ func (l *Loop) sendRequest(ctx context.Context) (*llm.ChatResponse, error) {
 
 	l.setWorking(true)
 
-	llmCtx, cancel := context.WithTimeout(ctx, llmRequestTimeout)
-	defer cancel()
-	stopHeartbeat := startHeartbeatPump(llmCtx, loopHeartbeatInterval, l.onHeartbeat)
+	stopHeartbeat := startHeartbeatPump(ctx, loopHeartbeatInterval, l.onHeartbeat)
 	defer stopHeartbeat()
 
-	resp, err := llm.ChatWithRetry(llmCtx, provider, req, llm.DefaultLogicalRetryConfig())
+	resp, err := llm.ChatWithRetry(ctx, provider, req, llm.DefaultLogicalRetryConfig())
 	if err != nil {
 		l.recordErrorMessage(ctx, fmt.Sprintf("LLM request failed: %v", err))
 		l.setWorking(false)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1618,8 +1618,21 @@ func TestLoop_OnTurnComplete(t *testing.T) {
 		})
 		loop.QueueUserMessage(llm.Message{Role: llm.RoleUser, Content: "test"})
 
-		err := loop.Go(ctx)
-		assert.ErrorIs(t, err, context.Canceled)
+		done := make(chan error, 1)
+		go func() {
+			done <- loop.Go(ctx)
+		}()
+
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, context.Canceled)
+		case <-timer.C:
+			cancel()
+			t.Fatal("loop.Go did not return in time")
+		}
 	})
 
 	t.Run("loop exits promptly without idle polling", func(t *testing.T) {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1570,6 +1570,58 @@ func TestLoop_OnTurnComplete(t *testing.T) {
 			"provider should have been called at least once")
 	})
 
+	t.Run("can return LLM errors for one-shot callers", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &mockLLMProvider{
+			chatFunc: func(_ context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+				return nil, fmt.Errorf("API error")
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		loop := NewLoop(LoopConfig{
+			Provider:         provider,
+			Model:            "test",
+			ReturnTurnErrors: true,
+		})
+		loop.QueueUserMessage(llm.Message{Role: llm.RoleUser, Content: "fail"})
+
+		err := loop.Go(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "LLM request failed")
+		assert.Contains(t, err.Error(), "API error")
+	})
+
+	t.Run("does not add request deadline", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &mockLLMProvider{
+			chatFunc: func(ctx context.Context, _ *llm.ChatRequest) (*llm.ChatResponse, error) {
+				_, hasDeadline := ctx.Deadline()
+				assert.False(t, hasDeadline)
+				return &llm.ChatResponse{Content: "done", FinishReason: "stop"}, nil
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		loop := NewLoop(LoopConfig{
+			Provider: provider,
+			Model:    "test",
+			OnTurnComplete: func() {
+				cancel()
+			},
+		})
+		loop.QueueUserMessage(llm.Message{Role: llm.RoleUser, Content: "test"})
+
+		err := loop.Go(ctx)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
 	t.Run("loop exits promptly without idle polling", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/agent/provider_cache.go
+++ b/internal/agent/provider_cache.go
@@ -135,8 +135,7 @@ func CreateLLMProvider(agentCfg LLMConfig, deps ProviderDeps) (llm.Provider, err
 		return nil, fmt.Errorf("invalid LLM provider: %w", err)
 	}
 
-	cfg := llm.DefaultConfig()
-	cfg.Timeout = llmRequestTimeout
+	cfg := llm.Config{DisableRequestTimeout: true}
 	cfg.APIKey = cmp.Or(agentCfg.APIKey, cfg.APIKey)
 	cfg.BaseURL = cmp.Or(agentCfg.BaseURL, cfg.BaseURL)
 	if providerType == llm.ProviderOpenAICodex && deps.OAuthManager != nil {

--- a/internal/agent/provider_cache.go
+++ b/internal/agent/provider_cache.go
@@ -4,7 +4,6 @@
 package agent
 
 import (
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -136,8 +135,8 @@ func CreateLLMProvider(agentCfg LLMConfig, deps ProviderDeps) (llm.Provider, err
 	}
 
 	cfg := llm.Config{DisableRequestTimeout: true}
-	cfg.APIKey = cmp.Or(agentCfg.APIKey, cfg.APIKey)
-	cfg.BaseURL = cmp.Or(agentCfg.BaseURL, cfg.BaseURL)
+	cfg.APIKey = agentCfg.APIKey
+	cfg.BaseURL = agentCfg.BaseURL
 	if providerType == llm.ProviderOpenAICodex && deps.OAuthManager != nil {
 		cfg.OAuthCredentialProvider = deps.OAuthManager.CredentialProvider(agentoauth.ProviderOpenAICodex)
 	}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -147,7 +147,9 @@ func NewProvider(providerType ProviderType, cfg Config) (Provider, error) {
 	}
 
 	// Apply defaults
-	if cfg.Timeout == 0 {
+	if cfg.DisableRequestTimeout {
+		cfg.Timeout = 0
+	} else if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultConfig().Timeout
 	}
 	if cfg.MaxRetries == 0 {

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -152,3 +152,25 @@ func TestNewProvider(t *testing.T) {
 		assert.ErrorIs(t, err, ErrInvalidProvider)
 	})
 }
+
+func TestNewProvider_DisableRequestTimeout(t *testing.T) {
+	orig := registry
+	defer func() { registry = orig }()
+	registry = make(map[ProviderType]ProviderFactory)
+
+	testType := ProviderType("test-no-timeout")
+	var captured Config
+	RegisterProvider(testType, func(cfg Config) (Provider, error) {
+		captured = cfg
+		return &mockProvider{name: "test-no-timeout"}, nil
+	})
+
+	_, err := NewProvider(testType, Config{DisableRequestTimeout: true})
+	require.NoError(t, err)
+
+	assert.Zero(t, captured.Timeout)
+	assert.Equal(t, DefaultConfig().MaxRetries, captured.MaxRetries)
+	assert.Equal(t, DefaultConfig().InitialInterval, captured.InitialInterval)
+	assert.Equal(t, DefaultConfig().MaxInterval, captured.MaxInterval)
+	assert.Equal(t, DefaultConfig().Multiplier, captured.Multiplier)
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -159,8 +159,11 @@ type Config struct {
 	// OAuthCredentialProvider resolves dynamic bearer credentials on demand.
 	OAuthCredentialProvider OAuthCredentialProvider
 	// Timeout is the maximum time to wait for a response.
-	// Default is 60 seconds if not specified.
+	// Default is 60 seconds if not specified unless DisableRequestTimeout is true.
 	Timeout time.Duration
+	// DisableRequestTimeout leaves the underlying request client without a
+	// response timeout. Callers must cancel through the request context.
+	DisableRequestTimeout bool
 
 	// Retry configuration
 	// MaxRetries is the maximum number of retry attempts for transient errors.

--- a/internal/runtime/builtin/agentstep/executor.go
+++ b/internal/runtime/builtin/agentstep/executor.go
@@ -227,15 +227,16 @@ func (e *Executor) Run(ctx context.Context) error {
 	webSearch := resolveWebSearch(stepCfg, agentCfg)
 
 	loop := agent.NewLoop(agent.LoopConfig{
-		Provider:     provider,
-		Model:        modelCfg.Model,
-		Tools:        tools,
-		History:      contextToLLMHistory(e.contextMessages),
-		SystemPrompt: systemPrompt,
-		SafeMode:     safeMode,
-		Hooks:        hooks,
-		Logger:       slog.Default(),
-		WebSearch:    webSearch,
+		Provider:         provider,
+		Model:            modelCfg.Model,
+		Tools:            tools,
+		History:          contextToLLMHistory(e.contextMessages),
+		SystemPrompt:     systemPrompt,
+		SafeMode:         safeMode,
+		Hooks:            hooks,
+		Logger:           slog.Default(),
+		WebSearch:        webSearch,
+		ReturnTurnErrors: true,
 		RecordMessage: func(_ context.Context, msg agent.Message) {
 			logMessage(stderr, msg)
 			converted := convertMessage(msg, modelCfg)


### PR DESCRIPTION
## Summary

- Remove the separate hardcoded LLM request timeout from agent loop execution and one-shot agent prompts.
- Let Dagu step/DAG timeout and explicit cancellation control agent step duration.
- Keep `agent.run` failure propagation so LLM/provider failures fail the workflow step instead of leaving it running.

## Root Cause

The shared agent loop used a fixed LLM request deadline and recorded turn errors without returning them. That combination made `agent.run` unreliable: a provider failure could be logged while the workflow step stayed in `running`, and a later cancellation could be treated as normal completion.

## Validation

- `go test ./internal/agent ./internal/llm ./internal/runtime/builtin/agentstep`
- `go test ./internal/runtime -run TestRunner_ChatMessagesHandler`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced error handling for agent workflow steps with more responsive error reporting from LLM operations.

* **Chores**
  * Optimized internal request timeout configuration for LLM provider integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2154)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->