### PR TITLE
feat: add artifact actions

### DIFF
--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -126,6 +126,7 @@ func buildActionsPrompt(env EnvironmentInfo, access *auth.WorkspaceAccess) strin
 	b.WriteString(formatNames(spec.BuiltinActionNames()))
 	b.WriteString(". Use top-level `run:` for plain shell commands and scripts.\n")
 	b.WriteString("- For local file operations in authored DAGs, prefer built-in `file.*` actions over `run:` commands such as `cat`, `cp`, `mv`, `rm`, or `mkdir`; this keeps DAGs portable across hosts and shells.\n")
+	b.WriteString("- For DAG-run artifacts in authored DAGs, prefer built-in `artifact.write`, `artifact.read`, and `artifact.list` over `run:` commands that write to `DAG_RUN_ARTIFACTS_DIR`; this makes reports, JSON snapshots, Markdown summaries, and other run outputs explicit in YAML.\n")
 
 	sources := baseConfigCustomActionSources(env, access)
 	if len(sources) == 0 {

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -153,8 +153,9 @@ Validate with `dagu validate` before claiming a DAG is correct.
 
 Use `dagu schema` via bash when unsure about YAML fields.
 
-Use the appropriate action (`http.request`, `s3.*`, `postgres.query`, `file.*`, etc.) instead of shelling out.
+Use the appropriate action (`http.request`, `s3.*`, `postgres.query`, `artifact.*`, `file.*`, etc.) instead of shelling out.
 For local filesystem work in authored DAGs, use `file.stat`, `file.read`, `file.write`, `file.copy`, `file.move`, `file.delete`, `file.mkdir`, or `file.list` instead of shell commands such as `cat`, `cp`, `mv`, `rm`, or `mkdir` unless the user specifically needs shell behavior.
+For DAG-run outputs such as reports, JSON snapshots, Markdown summaries, and handoff files, use `artifact.write`, `artifact.read`, or `artifact.list` instead of shell commands that write to `DAG_RUN_ARTIFACTS_DIR` unless the user specifically needs shell behavior.
 
 Omit the root `name:` field—Dagu uses the filename as the DAG name by default.
 
@@ -316,7 +317,7 @@ Formats: table (default), json
 5. Navigate the user to the document: navigate("/docs/<doc-id>")
 
 ### Best Practices
-- Use `$DAGU_ARTIFACT_DIR` to store artifacts (intermediate files and results) to enhance debuggability.
+- Use `artifact.write`, `artifact.read`, and `artifact.list` for DAG-run artifacts (reports, JSON snapshots, Markdown summaries, intermediate files) so outputs are explicit and visible in the Artifacts tab.
 - Utilize the `log.write` action to improve clarity for users.
 - For agent and chat LLM steps, select cost-effective models. Ensure that the selected models are currently available.
 - Verify each step by checking the available options for commands that depend on external commands to ensure the steps work as expected. Do not guess.

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -76,8 +76,12 @@ func TestGenerateSystemPrompt(t *testing.T) {
 		assert.Contains(t, result, "`harness.run`")
 		assert.Contains(t, result, "`redis.<operation>`")
 		assert.Contains(t, result, "`file.write`")
+		assert.Contains(t, result, "`artifact.write`")
+		assert.Contains(t, result, "`artifact.read`")
+		assert.Contains(t, result, "`artifact.list`")
 		assert.Contains(t, result, "Use top-level `run:` for plain shell commands and scripts")
 		assert.Contains(t, result, "prefer built-in `file.*` actions over `run:` commands")
+		assert.Contains(t, result, "prefer built-in `artifact.write`, `artifact.read`, and `artifact.list`")
 		assert.Contains(t, result, "Base config custom actions")
 		assert.Contains(t, result, "Current DAG-local custom actions: inspect `actions:`")
 		assert.Contains(t, result, "Legacy DAG-local `step_types:` definitions")
@@ -289,15 +293,17 @@ func TestGenerateSystemPrompt(t *testing.T) {
 		assert.Contains(t, result, "`runbook_manage` action `delete`")
 	})
 
-	t.Run("authoring guidance prefers file actions for file operations", func(t *testing.T) {
+	t.Run("authoring guidance prefers explicit actions for file and artifact operations", func(t *testing.T) {
 		t.Parallel()
 		env := EnvironmentInfo{DAGsDir: "/dags"}
 
 		result := GenerateSystemPrompt(SystemPromptParams{Env: env, Role: auth.RoleDeveloper})
 
-		assert.Contains(t, result, "Use the appropriate action (`http.request`, `s3.*`, `postgres.query`, `file.*`, etc.) instead of shelling out.")
+		assert.Contains(t, result, "Use the appropriate action (`http.request`, `s3.*`, `postgres.query`, `artifact.*`, `file.*`, etc.) instead of shelling out.")
 		assert.Contains(t, result, "use `file.stat`, `file.read`, `file.write`, `file.copy`, `file.move`, `file.delete`, `file.mkdir`, or `file.list`")
 		assert.Contains(t, result, "instead of shell commands such as `cat`, `cp`, `mv`, `rm`, or `mkdir`")
+		assert.Contains(t, result, "For DAG-run outputs such as reports, JSON snapshots, Markdown summaries, and handoff files, use `artifact.write`, `artifact.read`, or `artifact.list`")
+		assert.Contains(t, result, "Use `artifact.write`, `artifact.read`, and `artifact.list` for DAG-run artifacts")
 		assert.Contains(t, result, "Use `run:` only when the step is actually shell logic or an installed CLI invocation.")
 	})
 }

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2194,6 +2194,29 @@
         },
         {
           "if": {
+            "properties": { "action": { "enum": ["artifact.write", "artifact.read"] } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/artifactActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "action": { "const": "artifact.list" } },
+            "required": ["action"]
+          },
+          "then": {
+            "properties": {
+              "with": { "$ref": "#/definitions/artifactActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": { "action": { "enum": ["file.stat", "file.read", "file.write", "file.copy", "file.move", "file.delete", "file.mkdir", "file.list"] } },
             "required": ["action"]
           },
@@ -5928,6 +5951,9 @@
             "archive.create",
             "archive.extract",
             "archive.list",
+            "artifact.list",
+            "artifact.read",
+            "artifact.write",
             "chat.completion",
             "container.run",
             "dag.run",
@@ -6527,6 +6553,56 @@
         }
       },
       "description": "Configuration for wait actions."
+    },
+    "artifactActionConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Relative artifact path. Must stay within the DAG-run artifact directory."
+        },
+        "content": {
+          "type": "string",
+          "description": "Content to write for artifact.write."
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^(0o|0O)?[0-7]{3,4}$",
+          "description": "Octal file mode such as 0600 or 0644."
+        },
+        "format": {
+          "type": "string",
+          "enum": ["raw", "json"],
+          "description": "Output format for artifact.read. Defaults to raw."
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Glob pattern for artifact.list, matched against slash-separated artifact paths."
+        },
+        "overwrite": {
+          "type": "boolean",
+          "description": "Overwrite an existing artifact. Defaults to false."
+        },
+        "atomic": {
+          "type": "boolean",
+          "description": "Use atomic replacement for overwriting artifact.write destinations. Defaults to true."
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Recurse into nested directories for artifact.list."
+        },
+        "include_dirs": {
+          "type": "boolean",
+          "description": "Include directories in artifact.list output."
+        },
+        "max_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum bytes to read for artifact.read. Zero means no limit."
+        }
+      },
+      "description": "Configuration for DAG-run artifact actions."
     },
     "customActions": {
       "type": "object",

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -523,6 +523,25 @@ steps:
 `,
 		},
 		{
+			name: "ArtifactActions",
+			spec: `
+steps:
+  - action: artifact.write
+    with:
+      path: reports/summary.md
+      content: hello
+  - action: artifact.read
+    with:
+      path: reports/summary.md
+  - action: artifact.list
+    with:
+      path: reports
+      recursive: true
+      pattern: "**/*.md"
+  - action: artifact.list
+`,
+		},
+		{
 			name: "LegacyFileTypeConfig",
 			spec: `
 steps:

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -888,7 +888,16 @@ func buildLogDir(_ BuildContext, d *dag) (string, error) {
 }
 
 func buildArtifacts(_ BuildContext, d *dag) (*core.ArtifactsConfig, error) {
-	autoEnable := dagReferencesRunArtifactsDir(d)
+	usesArtifactAction := dagUsesBuiltinArtifactAction(d)
+	autoEnable := dagReferencesRunArtifactsDir(d) || usesArtifactAction
+
+	if usesArtifactAction && d.Artifacts != nil && d.Artifacts.Enabled != nil && !*d.Artifacts.Enabled {
+		return nil, core.NewValidationError(
+			"artifacts.enabled",
+			*d.Artifacts.Enabled,
+			fmt.Errorf("artifact actions require artifacts.enabled to be true"),
+		)
+	}
 
 	if d.Artifacts == nil {
 		if autoEnable {
@@ -915,6 +924,10 @@ func buildArtifacts(_ BuildContext, d *dag) (*core.ArtifactsConfig, error) {
 
 func dagReferencesRunArtifactsDir(d *dag) bool {
 	return valueReferencesRunArtifactsDir(reflect.ValueOf(d))
+}
+
+func dagUsesBuiltinArtifactAction(d *dag) bool {
+	return valueUsesBuiltinArtifactAction(reflect.ValueOf(d))
 }
 
 func referencesArtifactsEnvVar(s string) bool {
@@ -983,6 +996,103 @@ func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 	}
 
 	return false
+}
+
+func valueUsesBuiltinArtifactAction(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
+	}
+
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return false
+		}
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		return false
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			value := iter.Value()
+			if key.Kind() == reflect.String && key.String() == "action" {
+				if action, ok := reflectString(value); ok && strings.HasPrefix(action, "artifact.") {
+					return true
+				}
+			}
+			if valueUsesBuiltinArtifactAction(key) || valueUsesBuiltinArtifactAction(value) {
+				return true
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := range v.Len() {
+			if valueUsesBuiltinArtifactAction(v.Index(i)) {
+				return true
+			}
+		}
+	case reflect.Struct:
+		t := v.Type()
+		for i := range v.NumField() {
+			fieldInfo := t.Field(i)
+			if fieldInfo.PkgPath != "" {
+				continue
+			}
+			field := v.Field(i)
+			if fieldInfo.Name == "Action" {
+				if action, ok := reflectString(field); ok && strings.HasPrefix(action, "artifact.") {
+					return true
+				}
+			}
+			if valueUsesBuiltinArtifactAction(field) {
+				return true
+			}
+		}
+	case reflect.Invalid,
+		reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Pointer,
+		reflect.UnsafePointer:
+		return false
+	default:
+		return false
+	}
+	return false
+}
+
+func reflectString(v reflect.Value) (string, bool) {
+	if !v.IsValid() {
+		return "", false
+	}
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return "", false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.String {
+		return "", false
+	}
+	return strings.TrimSpace(v.String()), true
 }
 
 func buildLogOutput(_ BuildContext, d *dag) (core.LogOutputMode, error) {

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -2728,6 +2728,18 @@ steps:
 			expected: &core.ArtifactsConfig{Enabled: true},
 		},
 		{
+			name: "AutoEnableWhenArtifactActionIsUsed",
+			yaml: `
+steps:
+  - name: write
+    action: artifact.write
+    with:
+      path: out.txt
+      content: artifact
+`,
+			expected: &core.ArtifactsConfig{Enabled: true},
+		},
+		{
 			name: "LiteralMentionWithoutEnvReferenceDoesNotAutoEnable",
 			yaml: `
 steps:
@@ -2764,6 +2776,28 @@ steps:
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestBuildArtifactsRejectsDisabledArtifactsForArtifactAction(t *testing.T) {
+	t.Parallel()
+
+	var d dag
+	err := yaml.Unmarshal([]byte(`
+artifacts:
+  enabled: false
+steps:
+  - name: write
+    action: artifact.write
+    with:
+      path: out.txt
+      content: artifact
+`), &d)
+	require.NoError(t, err)
+
+	result, err := buildArtifacts(testBuildContext(), &d)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "artifact actions require artifacts.enabled to be true")
 }
 
 func TestBuildApprovalStepsValidation(t *testing.T) {

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -51,6 +51,8 @@ func TestMain(m *testing.M) {
 	}
 	// archive: supports command only
 	core.RegisterExecutorCapabilities("archive", core.ExecutorCapabilities{Command: true})
+	// artifact: supports command only
+	core.RegisterExecutorCapabilities("artifact", core.ExecutorCapabilities{Command: true})
 	// file: supports command only
 	core.RegisterExecutorCapabilities("file", core.ExecutorCapabilities{Command: true})
 	// data: supports operation commands only

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -70,6 +70,7 @@ var customStepWholeRuntimeExpressionRegexp = regexp.MustCompile("^\\s*(?:`[^`]+`
 
 var builtinStepTypeNames = map[string]struct{}{
 	"agent":         {},
+	"artifact":      {},
 	"archive":       {},
 	"chat":          {},
 	"command":       {},

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -40,6 +40,9 @@ type actionNormalizer func(normalized map[string]any, with map[string]any) error
 
 var builtinActionNormalizers = map[string]actionNormalizer{
 	"agent.run":       normalizeAgentAction,
+	"artifact.list":   operationAction("artifact", "list"),
+	"artifact.read":   operationAction("artifact", "read"),
+	"artifact.write":  operationAction("artifact", "write"),
 	"archive.create":  operationAction("archive", "create"),
 	"archive.extract": operationAction("archive", "extract"),
 	"archive.list":    operationAction("archive", "list"),

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -474,6 +474,73 @@ steps:
 	}
 }
 
+func TestStepSchemaV2_ActionArtifactOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		action string
+		op     string
+		with   string
+	}{
+		{
+			action: "artifact.write",
+			op:     "write",
+			with: `path: reports/summary.md
+      content: hello`,
+		},
+		{
+			action: "artifact.read",
+			op:     "read",
+			with:   "path: reports/summary.md",
+		},
+		{
+			action: "artifact.list",
+			op:     "list",
+			with:   "path: reports",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			t.Parallel()
+
+			dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: artifact_step
+    action: `+tt.action+`
+    with:
+      `+tt.with+`
+`))
+			require.NoError(t, err)
+			require.Len(t, dag.Steps, 1)
+
+			step := dag.Steps[0]
+			assert.Equal(t, "artifact", step.ExecutorConfig.Type)
+			require.Len(t, step.Commands, 1)
+			assert.Equal(t, tt.op, step.Commands[0].Command)
+			assert.NotEmpty(t, step.ExecutorConfig.Config)
+		})
+	}
+}
+
+func TestStepSchemaV2_ActionArtifactListAllowsOmittedWith(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: list_artifacts
+    action: artifact.list
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "artifact", step.ExecutorConfig.Type)
+	require.Len(t, step.Commands, 1)
+	assert.Equal(t, "list", step.Commands[0].Command)
+	assert.Empty(t, step.ExecutorConfig.Config)
+}
+
 func TestStepSchemaV2_ActionHarnessStdin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/one_off_schedule_test.go
+++ b/internal/intg/one_off_schedule_test.go
@@ -201,7 +201,7 @@ steps:
 		}
 		statuses := th.DAGRunMgr.ListRecentStatus(th.Context, dag.Name, 5)
 		return len(statuses) > 0 && statuses[0].Status == core.Succeeded
-	}, 10*time.Second, 100*time.Millisecond)
+	}, intgTestTimeout(30*time.Second), 100*time.Millisecond)
 	require.NoError(t, schedulerErr)
 
 	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag)
@@ -220,7 +220,7 @@ steps:
 				err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
 				"unexpected scheduler shutdown error: %v", err,
 			)
-		case <-time.After(5 * time.Second):
+		case <-time.After(intgTestTimeout(5 * time.Second)):
 			t.Fatal("scheduler did not stop within 5 seconds")
 		}
 	}

--- a/internal/persis/fileproc/store_test.go
+++ b/internal/persis/fileproc/store_test.go
@@ -110,31 +110,27 @@ func TestStore_IsRunAlive(t *testing.T) {
 	})
 
 	t.Run("StaleProcess", func(t *testing.T) {
-		// Create a store with very short stale time for testing
-		shortStore := &Store{
-			baseDir:   baseDir,
-			staleTime: time.Millisecond * 100,
-		}
+		shortStore := New(baseDir, WithStaleThreshold(100*time.Millisecond))
 
 		dagRun := exec.DAGRunRef{
 			Name: "test-dag-stale",
 			ID:   "run-stale",
 		}
+		meta := testProcMetaFromRun(dagRun)
+		staleAt := time.Now().Add(-10 * time.Second)
+		path := procFilePath(filepath.Join(baseDir, "stale-queue"), exec.NewUTC(staleAt), meta)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0750))
 
-		// Create a process
-		// Use different group name vs dag name
-		proc, err := shortStore.Acquire(ctx, "stale-queue", testProcMetaFromRun(dagRun))
+		fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 		require.NoError(t, err)
+		require.NoError(t, writeProcFile(fd, staleAt.Unix(), meta))
+		require.NoError(t, fd.Sync())
+		require.NoError(t, fd.Close())
+		require.NoError(t, os.Chtimes(path, staleAt, staleAt))
 
-		// Stop the heartbeat immediately
-		err = proc.Stop(ctx)
+		alive, err := shortStore.IsRunAlive(ctx, "stale-queue", dagRun)
 		require.NoError(t, err)
-
-		// Check if the run is alive (should become false when stale)
-		require.Eventually(t, func() bool {
-			alive, err := shortStore.IsRunAlive(ctx, "stale-queue", dagRun)
-			return err == nil && !alive
-		}, 200*time.Millisecond, 10*time.Millisecond, "expected process to become stale")
+		require.False(t, alive)
 	})
 }
 

--- a/internal/runtime/builtin/artifact/artifact.go
+++ b/internal/runtime/builtin/artifact/artifact.go
@@ -1,0 +1,625 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package artifact
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+)
+
+const (
+	executorType = "artifact"
+
+	opWrite = "write"
+	opRead  = "read"
+	opList  = "list"
+)
+
+var (
+	errConfig      = errors.New("artifact: configuration error")
+	errUnsupported = errors.New("artifact: unsupported operation")
+)
+
+var (
+	_ executor.Executor  = (*executorImpl)(nil)
+	_ executor.ExitCoder = (*executorImpl)(nil)
+)
+
+type executorImpl struct {
+	mu          sync.Mutex
+	stdout      io.Writer
+	stderr      io.Writer
+	cfg         config
+	op          string
+	artifactDir string
+	exitCode    int
+}
+
+type artifactPath struct {
+	rel string
+	abs string
+}
+
+type pathInfo struct {
+	Path      string    `json:"path"`
+	Type      string    `json:"type"`
+	Size      int64     `json:"size"`
+	Mode      string    `json:"mode"`
+	ModTime   time.Time `json:"modTime"`
+	IsDir     bool      `json:"isDir"`
+	IsRegular bool      `json:"isRegular"`
+	IsSymlink bool      `json:"isSymlink"`
+}
+
+type opResult struct {
+	Operation string     `json:"operation"`
+	Path      string     `json:"path,omitempty"`
+	Exists    *bool      `json:"exists,omitempty"`
+	Type      string     `json:"type,omitempty"`
+	Size      int64      `json:"size,omitempty"`
+	Mode      string     `json:"mode,omitempty"`
+	ModTime   *time.Time `json:"modTime,omitempty"`
+	Files     int64      `json:"files,omitempty"`
+	Bytes     int64      `json:"bytes,omitempty"`
+	Created   *bool      `json:"created,omitempty"`
+	Content   string     `json:"content,omitempty"`
+	Entries   []pathInfo `json:"entries,omitempty"`
+}
+
+func init() {
+	executor.RegisterExecutor(executorType, newExecutor, validateStep, core.ExecutorCapabilities{Command: true})
+}
+
+func newExecutor(ctx context.Context, step core.Step) (executor.Executor, error) {
+	cfg := defaultConfig()
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return nil, err
+	}
+
+	op := stepOperation(step)
+	if err := validateConfig(op, cfg); err != nil {
+		return nil, err
+	}
+
+	artifactDir, err := artifactDirFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &executorImpl{
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+		cfg:         cfg,
+		op:          op,
+		artifactDir: artifactDir,
+	}, nil
+}
+
+func validateStep(step core.Step) error {
+	if step.ExecutorConfig.Type != executorType {
+		return nil
+	}
+	cfg := defaultConfig()
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return err
+	}
+	return validateConfig(stepOperation(step), cfg)
+}
+
+func stepOperation(step core.Step) string {
+	if len(step.Commands) == 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(step.Commands[0].Command))
+}
+
+func artifactDirFromContext(ctx context.Context) (string, error) {
+	env := runtime.GetEnv(ctx)
+	if env.Scope == nil {
+		return "", fmt.Errorf("%w: %s is not set; enable artifacts for this DAG", errConfig, exec.EnvKeyDAGRunArtifactsDir)
+	}
+	artifactDir, ok := env.Scope.Get(exec.EnvKeyDAGRunArtifactsDir)
+	if !ok || strings.TrimSpace(artifactDir) == "" {
+		return "", fmt.Errorf("%w: %s is not set; enable artifacts for this DAG", errConfig, exec.EnvKeyDAGRunArtifactsDir)
+	}
+	return artifactDir, nil
+}
+
+func (e *executorImpl) SetStdout(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stdout = out
+}
+
+func (e *executorImpl) SetStderr(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stderr = out
+}
+
+func (*executorImpl) Kill(_ os.Signal) error { return nil }
+
+func (e *executorImpl) ExitCode() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exitCode
+}
+
+func (e *executorImpl) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		e.setExitCode(1)
+		return err
+	}
+
+	var err error
+	switch e.op {
+	case opWrite:
+		err = e.runWrite()
+	case opRead:
+		err = e.runRead()
+	case opList:
+		err = e.runList()
+	default:
+		err = fmt.Errorf("%w: %q", errUnsupported, e.op)
+	}
+
+	if err != nil {
+		e.setExitCode(1)
+		return err
+	}
+	e.setExitCode(0)
+	return nil
+}
+
+func (e *executorImpl) setExitCode(code int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.exitCode = code
+}
+
+func (e *executorImpl) runWrite() error {
+	target, err := e.resolveWritablePath(e.cfg.Path)
+	if err != nil {
+		return err
+	}
+
+	mode := os.FileMode(0o600)
+	if e.cfg.Mode != "" {
+		mode, err = parseFileMode(e.cfg.Mode)
+		if err != nil {
+			return err
+		}
+	}
+
+	existed, err := pathExists(target.abs)
+	if err != nil {
+		return err
+	}
+	if err := e.ensureWritableTargetInsideRoot(target.abs); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target.abs), 0o750); err != nil {
+		return fmt.Errorf("artifact write %s: create parent directories: %w", target.rel, err)
+	}
+	if err := e.ensureWritableTargetInsideRoot(target.abs); err != nil {
+		return err
+	}
+
+	data := []byte(e.cfg.Content)
+	if !e.cfg.Overwrite {
+		handle, err := os.OpenFile(target.abs, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) //nolint:gosec // artifact path is constrained to the DAG-run artifact directory.
+		if err != nil {
+			return fmt.Errorf("artifact write %s: %w", target.rel, err)
+		}
+		if _, err := handle.Write(data); err != nil {
+			_ = handle.Close()
+			return fmt.Errorf("artifact write %s: %w", target.rel, err)
+		}
+		if err := handle.Close(); err != nil {
+			return fmt.Errorf("artifact write %s: %w", target.rel, err)
+		}
+		created := true
+		return e.writeJSON(opResult{Operation: opWrite, Path: target.rel, Bytes: int64(len(data)), Created: &created})
+	}
+
+	if err := fileutil.WriteFileAtomic(target.abs, data, mode); err != nil {
+		return fmt.Errorf("artifact write %s: %w", target.rel, err)
+	}
+
+	created := !existed
+	return e.writeJSON(opResult{Operation: opWrite, Path: target.rel, Bytes: int64(len(data)), Created: &created})
+}
+
+func (e *executorImpl) runRead() error {
+	target, err := e.resolveExistingPath(e.cfg.Path, false)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target.abs)
+	if err != nil {
+		return fmt.Errorf("artifact read %s: %w", target.rel, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("artifact read %s: cannot read a directory", target.rel)
+	}
+	if e.cfg.MaxBytes > 0 && info.Size() > e.cfg.MaxBytes {
+		return fmt.Errorf("artifact read %s: file size %d exceeds max_bytes %d", target.rel, info.Size(), e.cfg.MaxBytes)
+	}
+
+	if e.cfg.Format == "json" {
+		data, err := os.ReadFile(target.abs) //nolint:gosec // artifact path is constrained to the DAG-run artifact directory.
+		if err != nil {
+			return fmt.Errorf("artifact read %s: %w", target.rel, err)
+		}
+		result := infoResult(opRead, target.rel, info)
+		result.Content = string(data)
+		result.Bytes = int64(len(data))
+		return e.writeJSON(result)
+	}
+
+	handle, err := os.Open(target.abs) //nolint:gosec // artifact path is constrained to the DAG-run artifact directory.
+	if err != nil {
+		return fmt.Errorf("artifact read %s: %w", target.rel, err)
+	}
+	defer func() { _ = handle.Close() }()
+	_, err = io.Copy(e.stdout, handle)
+	return err
+}
+
+func (e *executorImpl) runList() error {
+	target, err := e.resolveExistingPath(e.cfg.Path, true)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(target.abs)
+	if err != nil {
+		return fmt.Errorf("artifact list %s: %w", target.rel, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("artifact list %s: path must be a directory", target.rel)
+	}
+
+	root, err := e.prepareRoot()
+	if err != nil {
+		return err
+	}
+	entries, err := e.listEntries(root, target.abs)
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return e.writeJSON(opResult{Operation: opList, Path: target.rel, Entries: entries, Files: countFiles(entries)})
+}
+
+func (e *executorImpl) listEntries(root, current string) ([]pathInfo, error) {
+	var entries []pathInfo
+	addEntry := func(path string, info fs.FileInfo) error {
+		if samePath(path, current) {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return nil
+		}
+		if info.IsDir() && !e.cfg.IncludeDirs {
+			return nil
+		}
+		if !matchesPattern(e.cfg.Pattern, rel) {
+			return nil
+		}
+		entries = append(entries, newPathInfo(rel, info))
+		return nil
+	}
+
+	if e.cfg.Recursive {
+		err := filepath.WalkDir(current, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			return addEntry(path, info)
+		})
+		return entries, err
+	}
+
+	children, err := os.ReadDir(current)
+	if err != nil {
+		return nil, err
+	}
+	for _, child := range children {
+		info, err := child.Info()
+		if err != nil {
+			return nil, err
+		}
+		if err := addEntry(filepath.Join(current, child.Name()), info); err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
+}
+
+func (e *executorImpl) resolveWritablePath(raw string) (artifactPath, error) {
+	rel, err := cleanArtifactPath(raw, false)
+	if err != nil {
+		return artifactPath{}, err
+	}
+	root, err := e.prepareRoot()
+	if err != nil {
+		return artifactPath{}, err
+	}
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := e.ensurePathInsideRoot(root, abs); err != nil {
+		return artifactPath{}, err
+	}
+	return artifactPath{rel: rel, abs: abs}, nil
+}
+
+func (e *executorImpl) resolveExistingPath(raw string, allowRoot bool) (artifactPath, error) {
+	rel, err := cleanArtifactPath(raw, allowRoot)
+	if err != nil {
+		return artifactPath{}, err
+	}
+	root, err := e.prepareRoot()
+	if err != nil {
+		return artifactPath{}, err
+	}
+	abs := root
+	if rel != "." {
+		abs = filepath.Join(root, filepath.FromSlash(rel))
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return artifactPath{}, err
+	}
+	resolved = filepath.Clean(resolved)
+	if !pathInsideOrSame(root, resolved) {
+		return artifactPath{}, fmt.Errorf("%w: path %q escapes artifact directory", errConfig, rel)
+	}
+	return artifactPath{rel: rel, abs: resolved}, nil
+}
+
+func (e *executorImpl) prepareRoot() (string, error) {
+	rootRaw := strings.TrimSpace(e.artifactDir)
+	if rootRaw == "" {
+		return "", fmt.Errorf("%w: %s is not set", errConfig, exec.EnvKeyDAGRunArtifactsDir)
+	}
+	root, err := filepath.Abs(rootRaw)
+	if err != nil {
+		return "", fmt.Errorf("artifact: resolve artifact directory: %w", err)
+	}
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		return "", fmt.Errorf("artifact: create artifact directory: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("artifact: resolve artifact directory: %w", err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func cleanArtifactPath(raw string, allowRoot bool) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if allowRoot {
+			return ".", nil
+		}
+		return "", fmt.Errorf("%w: path must not be empty", errConfig)
+	}
+	normalized := strings.ReplaceAll(raw, "\\", "/")
+	if strings.HasPrefix(normalized, "/") ||
+		strings.HasPrefix(normalized, "~/") ||
+		normalized == "~" ||
+		filepath.IsAbs(raw) ||
+		hasWindowsDrive(raw) ||
+		hasWindowsDrive(normalized) {
+		return "", fmt.Errorf("%w: artifact path must be relative", errConfig)
+	}
+	if slices.Contains(strings.Split(normalized, "/"), "..") {
+		return "", fmt.Errorf("%w: artifact path must not contain ..", errConfig)
+	}
+
+	clean := path.Clean(normalized)
+	if clean == "." {
+		if allowRoot {
+			return ".", nil
+		}
+		return "", fmt.Errorf("%w: artifact path must name a file", errConfig)
+	}
+	if strings.HasPrefix(clean, "/") {
+		return "", fmt.Errorf("%w: artifact path must be relative", errConfig)
+	}
+	return clean, nil
+}
+
+func (e *executorImpl) ensureWritableTargetInsideRoot(target string) error {
+	root, err := e.prepareRoot()
+	if err != nil {
+		return err
+	}
+	if err := e.ensurePathInsideRoot(root, filepath.Dir(target)); err != nil {
+		return err
+	}
+	if exists, err := pathExists(target); err != nil {
+		return err
+	} else if exists {
+		resolved, err := filepath.EvalSymlinks(target)
+		if err != nil {
+			return err
+		}
+		if !pathInsideOrSame(root, resolved) {
+			return fmt.Errorf("%w: path %q escapes artifact directory", errConfig, target)
+		}
+	}
+	return nil
+}
+
+func (e *executorImpl) ensurePathInsideRoot(root, target string) error {
+	existing, err := nearestExistingPath(target)
+	if err != nil {
+		return err
+	}
+	resolved, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return err
+	}
+	if !pathInsideOrSame(root, resolved) {
+		return fmt.Errorf("%w: path %q escapes artifact directory", errConfig, target)
+	}
+	return nil
+}
+
+func nearestExistingPath(target string) (string, error) {
+	current := filepath.Clean(target)
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			return current, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		next := filepath.Dir(current)
+		if next == current {
+			return "", fmt.Errorf("%w: no existing parent for path %q", errConfig, target)
+		}
+		current = next
+	}
+}
+
+func pathExists(path string) (bool, error) {
+	if _, err := os.Lstat(path); err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+func pathInsideOrSame(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if samePath(parent, child) {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func samePath(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if goruntime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func hasWindowsDrive(value string) bool {
+	if len(value) < 2 || value[1] != ':' {
+		return false
+	}
+	ch := value[0]
+	return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+}
+
+func infoResult(operation, rel string, info fs.FileInfo) opResult {
+	modTime := info.ModTime()
+	exists := true
+	return opResult{
+		Operation: operation,
+		Path:      rel,
+		Exists:    &exists,
+		Type:      fileType(info),
+		Size:      info.Size(),
+		Mode:      info.Mode().String(),
+		ModTime:   &modTime,
+	}
+}
+
+func newPathInfo(rel string, info fs.FileInfo) pathInfo {
+	return pathInfo{
+		Path:      rel,
+		Type:      fileType(info),
+		Size:      info.Size(),
+		Mode:      info.Mode().String(),
+		ModTime:   info.ModTime(),
+		IsDir:     info.IsDir(),
+		IsRegular: info.Mode().IsRegular(),
+		IsSymlink: info.Mode()&os.ModeSymlink != 0,
+	}
+}
+
+func fileType(info fs.FileInfo) string {
+	mode := info.Mode()
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case info.IsDir():
+		return "directory"
+	case mode.IsRegular():
+		return "file"
+	default:
+		return "other"
+	}
+}
+
+func matchesPattern(pattern, value string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return true
+	}
+	ok, err := doublestar.Match(pattern, filepath.ToSlash(value))
+	return err == nil && ok
+}
+
+func countFiles(entries []pathInfo) int64 {
+	var count int64
+	for _, entry := range entries {
+		if entry.Type == "file" {
+			count++
+		}
+	}
+	return count
+}
+
+func (e *executorImpl) writeJSON(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = e.stdout.Write(data)
+	return err
+}

--- a/internal/runtime/builtin/artifact/artifact_test.go
+++ b/internal/runtime/builtin/artifact/artifact_test.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package artifact
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactExecutorWriteReadAndList(t *testing.T) {
+	t.Parallel()
+
+	artifactDir := t.TempDir()
+
+	writeOut := runArtifactAction(t, artifactDir, opWrite, map[string]any{
+		"path":    "reports/summary.md",
+		"content": "# Summary\nok\n",
+	})
+
+	var writeResult map[string]any
+	require.NoError(t, json.Unmarshal(writeOut.Bytes(), &writeResult))
+	assert.Equal(t, opWrite, writeResult["operation"])
+	assert.Equal(t, "reports/summary.md", writeResult["path"])
+	assert.Equal(t, float64(len("# Summary\nok\n")), writeResult["bytes"])
+	assertFileContent(t, filepath.Join(artifactDir, "reports", "summary.md"), "# Summary\nok\n")
+
+	readOut := runArtifactAction(t, artifactDir, opRead, map[string]any{
+		"path": "reports/summary.md",
+	})
+	assert.Equal(t, "# Summary\nok\n", readOut.String())
+
+	listOut := runArtifactAction(t, artifactDir, opList, map[string]any{
+		"path":      ".",
+		"recursive": true,
+	})
+
+	var listResult struct {
+		Operation string `json:"operation"`
+		Path      string `json:"path"`
+		Entries   []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+		} `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(listOut.Bytes(), &listResult))
+	assert.Equal(t, opList, listResult.Operation)
+	assert.Equal(t, ".", listResult.Path)
+	require.Len(t, listResult.Entries, 1)
+	assert.Equal(t, "reports/summary.md", listResult.Entries[0].Path)
+	assert.Equal(t, "file", listResult.Entries[0].Type)
+}
+
+func TestArtifactExecutorRejectsEscapingPaths(t *testing.T) {
+	t.Parallel()
+
+	artifactDir := t.TempDir()
+
+	for _, path := range []string{"../outside.txt", "nested/../outside.txt", "/tmp/outside.txt", `..\outside.txt`, `\tmp\outside.txt`} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			exec, err := newArtifactExecutorForTest(t, artifactDir, opWrite, map[string]any{
+				"path":    path,
+				"content": "blocked",
+			})
+			require.NoError(t, err)
+			require.Error(t, exec.Run(context.Background()))
+		})
+	}
+}
+
+func TestArtifactExecutorRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	artifactDir := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(artifactDir, "link")))
+
+	exec, err := newArtifactExecutorForTest(t, artifactDir, opWrite, map[string]any{
+		"path":    "link/out.txt",
+		"content": "blocked",
+	})
+	require.NoError(t, err)
+	require.Error(t, exec.Run(context.Background()))
+	assert.NoFileExists(t, filepath.Join(outsideDir, "out.txt"))
+}
+
+func TestArtifactExecutorRejectsNonAtomicOverwrite(t *testing.T) {
+	t.Parallel()
+
+	artifactDir := t.TempDir()
+
+	_, err := newArtifactExecutorForTest(t, artifactDir, opWrite, map[string]any{
+		"path":      "out.txt",
+		"content":   "blocked",
+		"overwrite": true,
+		"atomic":    false,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overwrite requires atomic writes")
+}
+
+func TestArtifactExecutorRequiresArtifactDir(t *testing.T) {
+	t.Parallel()
+
+	step := artifactStep(opWrite, map[string]any{
+		"path":    "out.txt",
+		"content": "hello",
+	})
+	dag := &core.DAG{Name: "artifact-test"}
+	ctx := runtime.NewContext(context.Background(), dag, "run-1", "")
+	ctx = runtime.WithEnv(ctx, runtime.NewEnv(ctx, step))
+
+	_, err := newExecutor(ctx, step)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DAG_RUN_ARTIFACTS_DIR")
+}
+
+func runArtifactAction(t *testing.T, artifactDir, op string, cfg map[string]any) *bytes.Buffer {
+	t.Helper()
+
+	exec, err := newArtifactExecutorForTest(t, artifactDir, op, cfg)
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	exec.SetStdout(out)
+	require.NoError(t, exec.Run(context.Background()))
+	return out
+}
+
+func newArtifactExecutorForTest(t *testing.T, artifactDir, op string, cfg map[string]any) (*executorImpl, error) {
+	t.Helper()
+
+	step := artifactStep(op, cfg)
+	dag := &core.DAG{Name: "artifact-test"}
+	ctx := runtime.NewContext(context.Background(), dag, "run-1", "", runtime.WithArtifactDir(artifactDir))
+	ctx = runtime.WithEnv(ctx, runtime.NewEnv(ctx, step))
+
+	exec, err := newExecutor(ctx, step)
+	if err != nil {
+		return nil, err
+	}
+	artifactExec, ok := exec.(*executorImpl)
+	require.True(t, ok)
+	return artifactExec, nil
+}
+
+func artifactStep(op string, cfg map[string]any) core.Step {
+	return core.Step{
+		Name:     "artifact-step",
+		Commands: []core.CommandEntry{{Command: op}},
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   executorType,
+			Config: cfg,
+		},
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(content))
+}

--- a/internal/runtime/builtin/artifact/config.go
+++ b/internal/runtime/builtin/artifact/config.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package artifact
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+type config struct {
+	Path        string `mapstructure:"path"`
+	Content     string `mapstructure:"content"`
+	Mode        string `mapstructure:"mode"`
+	Format      string `mapstructure:"format"`
+	Pattern     string `mapstructure:"pattern"`
+	Overwrite   bool   `mapstructure:"overwrite"`
+	Atomic      bool   `mapstructure:"atomic"`
+	Recursive   bool   `mapstructure:"recursive"`
+	IncludeDirs bool   `mapstructure:"include_dirs"`
+	MaxBytes    int64  `mapstructure:"max_bytes"`
+
+	hasContent bool
+}
+
+func defaultConfig() config {
+	return config{
+		Atomic: true,
+	}
+}
+
+func decodeConfig(raw map[string]any, cfg *config) error {
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	_, cfg.hasContent = raw["content"]
+	if value, exists := raw["content"]; exists {
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("%w: content must be a string", errConfig)
+		}
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      true,
+		TagName:          "mapstructure",
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(raw)
+}
+
+func validateConfig(operation string, cfg config) error {
+	switch operation {
+	case opRead:
+		if strings.TrimSpace(cfg.Path) == "" {
+			return fmt.Errorf("%w: path is required for read", errConfig)
+		}
+	case opWrite:
+		if strings.TrimSpace(cfg.Path) == "" {
+			return fmt.Errorf("%w: path is required for write", errConfig)
+		}
+		if !cfg.hasContent {
+			return fmt.Errorf("%w: content is required for write", errConfig)
+		}
+		if cfg.Overwrite && !cfg.Atomic {
+			return fmt.Errorf("%w: overwrite requires atomic writes", errConfig)
+		}
+	case opList:
+	default:
+		return fmt.Errorf("%w: unsupported operation %q", errConfig, operation)
+	}
+
+	switch cfg.Format {
+	case "", "raw", "json":
+	default:
+		return fmt.Errorf("%w: format must be raw or json", errConfig)
+	}
+	if cfg.MaxBytes < 0 {
+		return fmt.Errorf("%w: max_bytes must be >= 0", errConfig)
+	}
+	if cfg.Pattern != "" && !doublestar.ValidatePattern(cfg.Pattern) {
+		return fmt.Errorf("%w: invalid glob pattern %q", errConfig, cfg.Pattern)
+	}
+	if cfg.Mode != "" {
+		if _, err := parseFileMode(cfg.Mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseFileMode(raw string) (os.FileMode, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "0o")
+	raw = strings.TrimPrefix(raw, "0O")
+	if raw == "" {
+		return 0, fmt.Errorf("%w: mode must not be empty", errConfig)
+	}
+	parsed, err := strconv.ParseUint(raw, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid mode %q", errConfig, raw)
+	}
+	return os.FileMode(parsed), nil
+}
+
+var configSchema = &jsonschema.Schema{
+	Type:                 "object",
+	AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+	Properties: map[string]*jsonschema.Schema{
+		"path":         {Type: "string", Description: "Relative artifact path. Must stay within the DAG-run artifact directory."},
+		"content":      {Type: "string", Description: "Content to write for action: artifact.write."},
+		"mode":         {Type: "string", Pattern: "^(0o|0O)?[0-7]{3,4}$", Description: "Octal file mode such as 0600 or 0644."},
+		"format":       {Type: "string", Enum: []any{"raw", "json"}, Description: "Output format for artifact.read. Defaults to raw."},
+		"pattern":      {Type: "string", Description: "Glob pattern for artifact.list, matched against slash-separated artifact paths."},
+		"overwrite":    {Type: "boolean", Description: "Overwrite an existing artifact. Defaults to false."},
+		"atomic":       {Type: "boolean", Description: "Use atomic replacement for overwriting artifact.write destinations. Defaults to true."},
+		"recursive":    {Type: "boolean", Description: "Recurse into nested directories for artifact.list."},
+		"include_dirs": {Type: "boolean", Description: "Include directories in artifact.list output."},
+		"max_bytes":    {Type: "integer", Minimum: new(float64), Description: "Maximum bytes to read for artifact.read. Zero means no limit."},
+	},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+}

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -6,6 +6,7 @@ package builtin
 import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/agentstep"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/archive"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/artifact"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/chat"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/command"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/dag"

--- a/internal/service/worker/worker.go
+++ b/internal/service/worker/worker.go
@@ -61,6 +61,11 @@ type runningTaskState struct {
 
 var errTaskClaimRejectedBeforeExecution = errors.New("task claim rejected before execution")
 
+const (
+	ownerRunHeartbeatCallTimeout = 10 * time.Second
+	ownerHeartbeatTimeout        = exec.DefaultStaleLeaseThreshold
+)
+
 // SetHandler sets a custom task executor for testing or custom execution logic
 func (w *Worker) SetHandler(executor TaskHandler) {
 	w.handler = executor
@@ -373,7 +378,7 @@ func (w *Worker) validateClaimedTask(ctx context.Context, owner exec.HostInfo, t
 		return false, nil
 	}
 
-	callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	callCtx, cancel := context.WithTimeout(ctx, ownerRunHeartbeatCallTimeout)
 	resp, err := w.coordinatorCli.RunHeartbeatTo(callCtx, owner, &coordinatorv1.RunHeartbeatRequest{
 		WorkerId:           w.id,
 		OwnerCoordinatorId: owner.ID,
@@ -491,7 +496,7 @@ func (w *Worker) sendOwnerRunHeartbeats(ctx context.Context) {
 	w.pollersMu.Unlock()
 
 	for _, group := range groups {
-		callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		callCtx, cancel := context.WithTimeout(ctx, ownerRunHeartbeatCallTimeout)
 		resp, err := w.coordinatorCli.RunHeartbeatTo(callCtx, group.owner, &coordinatorv1.RunHeartbeatRequest{
 			WorkerId:           w.id,
 			OwnerCoordinatorId: group.owner.ID,
@@ -526,8 +531,6 @@ func (w *Worker) markOwnerHeartbeatSuccess(tasks []*coordinatorv1.RunningTask, o
 }
 
 func (w *Worker) cancelTasksForOwnerTimeout(ctx context.Context, owner exec.HostInfo, tasks []*coordinatorv1.RunningTask, lastSeen map[string]time.Time) {
-	const ownerHeartbeatTimeout = 15 * time.Second
-
 	now := time.Now().UTC()
 	var timedOut []*coordinatorv1.CancelledRun
 	for _, task := range tasks {


### PR DESCRIPTION
## Summary
Add DAG-run artifact actions so workflows can write, read, and list run artifacts without shelling out to `DAG_RUN_ARTIFACTS_DIR`.

## Changes
- Add `artifact.write`, `artifact.read`, and `artifact.list` action normalization and executor registration.
- Add a built-in artifact executor with relative path enforcement, symlink escape checks, optional JSON read output, glob filtering, and overwrite controls.
- Auto-enable DAG artifacts when artifact actions are used.
- Wire artifact action config into DAG JSON schema validation.
- Update agent authoring guidance to prefer explicit artifact actions for run outputs.

## Validation
- `go test ./internal/agent ./internal/cmn/schema ./internal/core/spec ./internal/runtime/builtin ./internal/runtime/builtin/artifact`

## Checklist
- [x] Artifact write/read/list behavior is covered by tests.
- [x] DAG JSON schema accepts artifact actions and config.
- [x] Local focused validation completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in artifact actions: artifact.write, artifact.read, and artifact.list for DAG-run artifact management (write/read/list, patterns, recursion, max_bytes, atomic writes).

* **Behavior**
  * DAGs using artifact actions will enable artifact storage automatically; explicit configuration is validated to prevent contradictory settings.

* **Documentation**
  * Updated guidance to prefer native artifact actions over shell commands for DAG-run artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->