### PR TITLE
feat: add data convert and pick actions

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2206,6 +2206,30 @@
         },
         {
           "if": {
+            "properties": { "action": { "const": "data.convert" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/dataConvertActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "action": { "const": "data.pick" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/dataPickActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": { "action": { "enum": ["wait.duration", "wait.until", "wait.file", "wait.http"] } },
             "required": ["action"]
           },
@@ -5907,6 +5931,8 @@
             "chat.completion",
             "container.run",
             "dag.run",
+            "data.convert",
+            "data.pick",
             "docker.run",
             "duckdb.import",
             "duckdb.query",
@@ -6165,6 +6191,114 @@
         }
       },
       "description": "Configuration for action: jq.filter."
+    },
+    "dataConvertActionConfig": {
+      "type": "object",
+      "required": ["from", "to"],
+      "oneOf": [
+        { "required": ["data"] },
+        { "required": ["input"] }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "enum": ["json", "yaml", "csv", "tsv", "text"],
+          "description": "Input format."
+        },
+        "to": {
+          "type": "string",
+          "enum": ["json", "yaml", "csv", "tsv", "text"],
+          "description": "Output format."
+        },
+        "data": {
+          "description": "Inline data to convert."
+        },
+        "input": {
+          "type": "string",
+          "description": "File path to read input from."
+        },
+        "has_header": {
+          "type": "boolean",
+          "description": "Whether CSV or TSV input has a header row. Defaults to true."
+        },
+        "headers": {
+          "type": "boolean",
+          "description": "Include a header row for CSV or TSV output. Defaults to true."
+        },
+        "delimiter": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1,
+          "description": "Single-character delimiter override for CSV or TSV input and output."
+        },
+        "columns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Column names for headerless CSV/TSV input or CSV/TSV output ordering."
+        }
+      },
+      "description": "Configuration for action: data.convert."
+    },
+    "dataPickActionConfig": {
+      "type": "object",
+      "required": ["from", "select"],
+      "oneOf": [
+        { "required": ["data"] },
+        { "required": ["input"] }
+      ],
+      "not": {
+        "required": ["raw", "to"]
+      },
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "enum": ["json", "yaml", "csv", "tsv", "text"],
+          "description": "Input format."
+        },
+        "to": {
+          "type": "string",
+          "enum": ["json", "yaml", "csv", "tsv", "text"],
+          "description": "Output format. Defaults to json when raw is false."
+        },
+        "select": {
+          "type": "string",
+          "minLength": 1,
+          "description": "jq-style path to select."
+        },
+        "raw": {
+          "type": "boolean",
+          "description": "Write selected scalar values without JSON/YAML encoding."
+        },
+        "data": {
+          "description": "Inline data to read."
+        },
+        "input": {
+          "type": "string",
+          "description": "File path to read input from."
+        },
+        "has_header": {
+          "type": "boolean",
+          "description": "Whether CSV or TSV input has a header row. Defaults to true."
+        },
+        "headers": {
+          "type": "boolean",
+          "description": "Include a header row for CSV or TSV output. Defaults to true."
+        },
+        "delimiter": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1,
+          "description": "Single-character delimiter override for CSV or TSV input and output."
+        },
+        "columns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Column names for headerless CSV/TSV input or CSV/TSV output ordering."
+        }
+      },
+      "description": "Configuration for action: data.pick."
     },
     "routerRouteActionConfig": {
       "type": "object",

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -495,6 +495,34 @@ steps:
 `,
 		},
 		{
+			name: "DataConvertAction",
+			spec: `
+steps:
+  - action: data.convert
+    with:
+      from: csv
+      to: json
+      data: |
+        name,age
+        Alice,30
+`,
+		},
+		{
+			name: "DataPickAction",
+			spec: `
+steps:
+  - action: data.pick
+    with:
+      from: yaml
+      select: .spec.containers[0].image
+      raw: true
+      data:
+        spec:
+          containers:
+            - image: nginx:1.27
+`,
+		},
+		{
 			name: "LegacyFileTypeConfig",
 			spec: `
 steps:
@@ -684,6 +712,31 @@ steps:
     with:
       path: out/data.txt
       unexpected: true
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectDataConvertUnknownConfig",
+			spec: `
+steps:
+  - action: data.convert
+    with:
+      from: csv
+      to: json
+      data: "name\nAlice\n"
+      unexpected: true
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectDataPickMissingSelect",
+			spec: `
+steps:
+  - action: data.pick
+    with:
+      from: yaml
+      data:
+        name: Alice
 `,
 			wantErr: "did not validate",
 		},

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -53,6 +53,8 @@ func TestMain(m *testing.M) {
 	core.RegisterExecutorCapabilities("archive", core.ExecutorCapabilities{Command: true})
 	// file: supports command only
 	core.RegisterExecutorCapabilities("file", core.ExecutorCapabilities{Command: true})
+	// data: supports operation commands only
+	core.RegisterExecutorCapabilities("data", core.ExecutorCapabilities{Command: true})
 	// wait: supports command only
 	core.RegisterExecutorCapabilities("wait", core.ExecutorCapabilities{Command: true})
 	// dag/subworkflow/parallel: support SubDAG and WorkerSelector

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -75,6 +75,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"command":       {},
 	"container":     {},
 	"dag":           {},
+	"data":          {},
 	"docker":        {},
 	"duckdb":        {},
 	"file":          {},

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -46,6 +46,8 @@ var builtinActionNormalizers = map[string]actionNormalizer{
 	"chat.completion": normalizeChatAction,
 	"container.run":   optionalCommandAction("container", "command"),
 	"dag.run":         normalizeDagRunAction,
+	"data.convert":    operationAction("data", "convert"),
+	"data.pick":       operationAction("data", "pick"),
 	"docker.run":      optionalCommandAction("docker", "command"),
 	"duckdb.query":    commandAction("duckdb", "query"),
 	"duckdb.import":   importAction("duckdb"),

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -181,6 +181,62 @@ steps:
 	assert.Contains(t, err.Error(), `jq.filter does not allow both with.data and with.input`)
 }
 
+func TestStepSchemaV2_ActionDataConvert(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: convert_users
+    action: data.convert
+    with:
+      from: csv
+      to: json
+      data: |
+        name,age
+        Alice,30
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "data", step.ExecutorConfig.Type)
+	require.Len(t, step.Commands, 1)
+	assert.Equal(t, "convert", step.Commands[0].Command)
+	require.NotNil(t, step.ExecutorConfig.Config)
+	assert.Equal(t, "csv", step.ExecutorConfig.Config["from"])
+	assert.Equal(t, "json", step.ExecutorConfig.Config["to"])
+	assert.Contains(t, step.ExecutorConfig.Config, "data")
+}
+
+func TestStepSchemaV2_ActionDataPick(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: pick_image
+    action: data.pick
+    with:
+      from: yaml
+      select: .spec.containers[0].image
+      raw: true
+      data:
+        spec:
+          containers:
+            - image: nginx:1.27
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "data", step.ExecutorConfig.Type)
+	require.Len(t, step.Commands, 1)
+	assert.Equal(t, "pick", step.Commands[0].Command)
+	require.NotNil(t, step.ExecutorConfig.Config)
+	assert.Equal(t, "yaml", step.ExecutorConfig.Config["from"])
+	assert.Equal(t, ".spec.containers[0].image", step.ExecutorConfig.Config["select"])
+	assert.Equal(t, true, step.ExecutorConfig.Config["raw"])
+}
+
 func TestStepSchemaV2_ActionSQLQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/data_test.go
+++ b/internal/intg/data_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/test"
+)
+
+func TestDataConvertAction(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `type: graph
+steps:
+  - id: users
+    action: data.convert
+    with:
+      from: csv
+      to: json
+      data: |
+        name,age
+        Alice,30
+        Bob,25
+    output: USERS_JSON
+
+  - id: first_name
+    depends: [users]
+    action: data.pick
+    with:
+      from: json
+      select: '.[0].name'
+      data: ${USERS_JSON}
+      raw: true
+    output: FIRST_NAME
+`)
+	agent := dag.Agent()
+
+	agent.RunSuccess(t)
+
+	dag.AssertLatestStatus(t, core.Succeeded)
+	dag.AssertOutputs(t, map[string]any{
+		"FIRST_NAME": "Alice",
+	})
+}

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/chat"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/command"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/dag"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/data"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/file"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/harness"

--- a/internal/runtime/builtin/data/config.go
+++ b/internal/runtime/builtin/data/config.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package data
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+type config struct {
+	From      string   `mapstructure:"from"`
+	To        string   `mapstructure:"to"`
+	Input     string   `mapstructure:"input"`
+	Data      any      `mapstructure:"data"`
+	Select    string   `mapstructure:"select"`
+	Raw       bool     `mapstructure:"raw"`
+	HasHeader *bool    `mapstructure:"has_header"`
+	Headers   *bool    `mapstructure:"headers"`
+	Delimiter string   `mapstructure:"delimiter"`
+	Columns   []string `mapstructure:"columns"`
+
+	hasData bool
+}
+
+func decodeConfig(raw map[string]any, cfg *config) error {
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	_, cfg.hasData = raw["data"]
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      true,
+		TagName:          "mapstructure",
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(raw)
+}
+
+func validateConfig(operation string, cfg config) error {
+	if strings.TrimSpace(cfg.From) == "" {
+		return fmt.Errorf("%w: from is required", errConfig)
+	}
+	if !isSupportedFormat(cfg.From) {
+		return fmt.Errorf("%w: unsupported from format %q", errConfig, cfg.From)
+	}
+	if cfg.hasData && strings.TrimSpace(cfg.Input) != "" {
+		return fmt.Errorf("%w: data and input are mutually exclusive", errConfig)
+	}
+	if !cfg.hasData && strings.TrimSpace(cfg.Input) == "" {
+		return fmt.Errorf("%w: either data or input is required", errConfig)
+	}
+	if cfg.Delimiter != "" && len([]rune(cfg.Delimiter)) != 1 {
+		return fmt.Errorf("%w: delimiter must be a single character", errConfig)
+	}
+
+	switch operation {
+	case opConvert:
+		if strings.TrimSpace(cfg.To) == "" {
+			return fmt.Errorf("%w: to is required", errConfig)
+		}
+		if !isSupportedFormat(cfg.To) {
+			return fmt.Errorf("%w: unsupported to format %q", errConfig, cfg.To)
+		}
+	case opPick:
+		if strings.TrimSpace(cfg.Select) == "" {
+			return fmt.Errorf("%w: select is required", errConfig)
+		}
+		if cfg.Raw && strings.TrimSpace(cfg.To) != "" {
+			return fmt.Errorf("%w: raw and to are mutually exclusive", errConfig)
+		}
+		if strings.TrimSpace(cfg.To) != "" && !isSupportedFormat(cfg.To) {
+			return fmt.Errorf("%w: unsupported to format %q", errConfig, cfg.To)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported operation %q", errConfig, operation)
+	}
+	return nil
+}
+
+func isSupportedFormat(format string) bool {
+	switch strings.ToLower(format) {
+	case formatJSON, formatYAML, formatCSV, formatTSV, formatText:
+		return true
+	default:
+		return false
+	}
+}
+
+var configSchema = &jsonschema.Schema{
+	Type:                 "object",
+	AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+	OneOf: []*jsonschema.Schema{
+		{Required: []string{"data"}},
+		{Required: []string{"input"}},
+	},
+	Properties: map[string]*jsonschema.Schema{
+		"from":       {Type: "string", Enum: []any{formatJSON, formatYAML, formatCSV, formatTSV, formatText}, Description: "Input format."},
+		"to":         {Type: "string", Enum: []any{formatJSON, formatYAML, formatCSV, formatTSV, formatText}, Description: "Output format."},
+		"input":      {Type: "string", Description: "File path to read input from. Mutually exclusive with data."},
+		"data":       {Description: "Inline data to convert. Mutually exclusive with input."},
+		"select":     {Type: "string", Description: "jq-style path to select for action: data.pick."},
+		"raw":        {Type: "boolean", Description: "Write selected scalar values without JSON/YAML encoding for action: data.pick."},
+		"has_header": {Type: "boolean", Description: "Whether CSV or TSV input has a header row. Defaults to true."},
+		"headers":    {Type: "boolean", Description: "Include a header row for CSV or TSV output. Defaults to true."},
+		"delimiter":  {Type: "string", Description: "Single-character delimiter override for CSV or TSV input and output."},
+		"columns":    {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Column names for headerless CSV/TSV input or CSV/TSV output ordering."},
+	},
+	Required: []string{"from"},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+}

--- a/internal/runtime/builtin/data/data.go
+++ b/internal/runtime/builtin/data/data.go
@@ -1,0 +1,540 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package data
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/cmn/eval"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	executorType = "data"
+
+	opConvert = "convert"
+	opPick    = "pick"
+
+	formatJSON = "json"
+	formatYAML = "yaml"
+	formatCSV  = "csv"
+	formatTSV  = "tsv"
+	formatText = "text"
+)
+
+var (
+	errConfig      = errors.New("data: configuration error")
+	errUnsupported = errors.New("data: unsupported operation")
+)
+
+var _ executor.Executor = (*executorImpl)(nil)
+
+type executorImpl struct {
+	mu      sync.Mutex
+	stdout  io.Writer
+	stderr  io.Writer
+	cfg     config
+	op      string
+	workDir string
+}
+
+func init() {
+	executor.RegisterExecutor(executorType, newExecutor, validateStep, core.ExecutorCapabilities{Command: true})
+}
+
+func newExecutor(ctx context.Context, step core.Step) (executor.Executor, error) {
+	var cfg config
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return nil, err
+	}
+
+	op := stepOperation(step)
+	if err := validateConfig(op, cfg); err != nil {
+		return nil, err
+	}
+
+	env := runtime.GetEnv(ctx)
+	return &executorImpl{
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+		cfg:     cfg,
+		op:      op,
+		workDir: env.WorkingDir,
+	}, nil
+}
+
+func validateStep(step core.Step) error {
+	if step.ExecutorConfig.Type != executorType {
+		return nil
+	}
+	var cfg config
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return err
+	}
+	return validateConfig(stepOperation(step), cfg)
+}
+
+func stepOperation(step core.Step) string {
+	if len(step.Commands) == 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(step.Commands[0].Command))
+}
+
+func (e *executorImpl) SetStdout(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stdout = out
+}
+
+func (e *executorImpl) SetStderr(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stderr = out
+}
+
+func (*executorImpl) Kill(_ os.Signal) error { return nil }
+
+func (e *executorImpl) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	switch e.op {
+	case opConvert:
+		return e.runConvert(ctx)
+	case opPick:
+		return e.runPick(ctx)
+	default:
+		return fmt.Errorf("%w: %q", errUnsupported, e.op)
+	}
+}
+
+func (e *executorImpl) runConvert(ctx context.Context) error {
+	value, err := e.readValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	parsed, err := parseValue(e.cfg, value)
+	if err != nil {
+		return err
+	}
+
+	return writeValue(e.stdout, e.cfg, parsed)
+}
+
+func (e *executorImpl) runPick(ctx context.Context) error {
+	value, err := e.readValue(ctx)
+	if err != nil {
+		return err
+	}
+
+	parsed, err := parseValue(e.cfg, value)
+	if err != nil {
+		return err
+	}
+
+	selected, ok := eval.ResolveDataPath(ctx, "data.pick", parsed, e.cfg.Select)
+	if !ok {
+		return fmt.Errorf("data pick: failed to resolve select path %q", e.cfg.Select)
+	}
+
+	if e.cfg.Raw {
+		return writeRawValue(e.stdout, selected)
+	}
+
+	outCfg := e.cfg
+	if strings.TrimSpace(outCfg.To) == "" {
+		outCfg.To = formatJSON
+	}
+	return writeValue(e.stdout, outCfg, selected)
+}
+
+func (e *executorImpl) readValue(ctx context.Context) (any, error) {
+	if e.cfg.hasData {
+		return e.cfg.Data, nil
+	}
+
+	inputPath, err := runtime.EvalStepString(ctx, e.cfg.Input)
+	if err != nil {
+		return nil, fmt.Errorf("data: failed to evaluate input path: %w", err)
+	}
+	if !filepath.IsAbs(inputPath) {
+		inputPath = filepath.Join(e.workDir, inputPath)
+	}
+	inputPath = filepath.Clean(inputPath)
+
+	data, err := os.ReadFile(inputPath) //nolint:gosec // input path is workflow-controlled local file input.
+	if err != nil {
+		return nil, fmt.Errorf("data: reading input file %q: %w", inputPath, err)
+	}
+	return string(data), nil
+}
+
+func parseValue(cfg config, value any) (any, error) {
+	format := strings.ToLower(cfg.From)
+	switch format {
+	case formatJSON:
+		return parseJSON(value)
+	case formatYAML:
+		return parseYAML(value)
+	case formatCSV, formatTSV:
+		raw, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("data: %s input must be a string or input file", format)
+		}
+		return parseDelimited(raw, cfg)
+	case formatText:
+		return stringifyText(value), nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported from format %q", errConfig, cfg.From)
+	}
+}
+
+func parseJSON(value any) (any, error) {
+	raw, ok := value.(string)
+	if !ok {
+		return value, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, fmt.Errorf("data: failed to decode JSON: %w", err)
+	}
+	return decoded, nil
+}
+
+func parseYAML(value any) (any, error) {
+	raw, ok := value.(string)
+	if !ok {
+		return value, nil
+	}
+	var decoded any
+	if err := yaml.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, fmt.Errorf("data: failed to decode YAML: %w", err)
+	}
+	return normalizeYAMLValue(decoded), nil
+}
+
+func parseDelimited(raw string, cfg config) (any, error) {
+	reader := csv.NewReader(strings.NewReader(raw))
+	reader.Comma = delimiterFor(cfg)
+	reader.LazyQuotes = true
+	reader.TrimLeadingSpace = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("data: failed to decode %s: %w", cfg.From, err)
+	}
+	if len(records) == 0 {
+		return []any{}, nil
+	}
+
+	hasHeader := true
+	if cfg.HasHeader != nil {
+		hasHeader = *cfg.HasHeader
+	}
+
+	var columns []string
+	var rows [][]string
+	switch {
+	case hasHeader:
+		columns = records[0]
+		rows = records[1:]
+	case len(cfg.Columns) > 0:
+		columns = cfg.Columns
+		rows = records
+	default:
+		result := make([]any, len(records))
+		for i, record := range records {
+			row := make([]any, len(record))
+			for j, field := range record {
+				row[j] = field
+			}
+			result[i] = row
+		}
+		return result, nil
+	}
+
+	result := make([]any, len(rows))
+	for i, record := range rows {
+		row := make(map[string]any, len(columns))
+		for colIdx, column := range columns {
+			value := ""
+			if colIdx < len(record) {
+				value = record[colIdx]
+			}
+			row[column] = value
+		}
+		result[i] = row
+	}
+	return result, nil
+}
+
+func writeValue(w io.Writer, cfg config, value any) error {
+	switch strings.ToLower(cfg.To) {
+	case formatJSON:
+		data, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return fmt.Errorf("data: failed to encode JSON: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	case formatYAML:
+		data, err := yaml.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("data: failed to encode YAML: %w", err)
+		}
+		_, err = w.Write(data)
+		return err
+	case formatCSV, formatTSV:
+		return writeDelimited(w, cfg, value)
+	case formatText:
+		_, err := fmt.Fprint(w, stringifyText(value))
+		return err
+	default:
+		return fmt.Errorf("%w: unsupported to format %q", errConfig, cfg.To)
+	}
+}
+
+func writeDelimited(w io.Writer, cfg config, value any) error {
+	writer := csv.NewWriter(w)
+	writer.Comma = delimiterFor(config{To: cfg.To, Delimiter: cfg.Delimiter})
+
+	rows, columns, err := tabularRows(value, cfg.Columns)
+	if err != nil {
+		return err
+	}
+
+	headers := true
+	if cfg.Headers != nil {
+		headers = *cfg.Headers
+	}
+	if headers && len(columns) > 0 {
+		if err := writer.Write(columns); err != nil {
+			return err
+		}
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func tabularRows(value any, preferredColumns []string) ([][]string, []string, error) {
+	items, ok := asSlice(value)
+	if !ok {
+		return nil, nil, fmt.Errorf("data: %s output requires an array input", formatCSV)
+	}
+	if len(items) == 0 {
+		return nil, preferredColumns, nil
+	}
+
+	if _, ok := asMap(items[0]); ok {
+		columns := preferredColumns
+		if len(columns) == 0 {
+			columns = collectColumns(items)
+		}
+		rows := make([][]string, 0, len(items))
+		for _, item := range items {
+			rowMap, ok := asMap(item)
+			if !ok {
+				return nil, nil, fmt.Errorf("data: cannot mix object and array rows in delimited output")
+			}
+			row := make([]string, len(columns))
+			for i, column := range columns {
+				row[i] = cellString(rowMap[column])
+			}
+			rows = append(rows, row)
+		}
+		return rows, columns, nil
+	}
+
+	rows := make([][]string, 0, len(items))
+	for _, item := range items {
+		fields, ok := asSlice(item)
+		if !ok {
+			return nil, nil, fmt.Errorf("data: delimited output rows must be objects or arrays")
+		}
+		row := make([]string, len(fields))
+		for i, field := range fields {
+			row[i] = cellString(field)
+		}
+		rows = append(rows, row)
+	}
+	return rows, preferredColumns, nil
+}
+
+func collectColumns(items []any) []string {
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		rowMap, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		for key := range rowMap {
+			seen[key] = struct{}{}
+		}
+	}
+	columns := make([]string, 0, len(seen))
+	for key := range seen {
+		columns = append(columns, key)
+	}
+	sort.Strings(columns)
+	return columns
+}
+
+func asMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case map[any]any:
+		result := make(map[string]any, len(typed))
+		for key, val := range typed {
+			result[fmt.Sprint(key)] = val
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func asSlice(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []map[string]any:
+		result := make([]any, len(typed))
+		for i, val := range typed {
+			result[i] = val
+		}
+		return result, true
+	case [][]any:
+		result := make([]any, len(typed))
+		for i, val := range typed {
+			result[i] = val
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func delimiterFor(cfg config) rune {
+	if cfg.Delimiter != "" {
+		return []rune(cfg.Delimiter)[0]
+	}
+	switch strings.ToLower(firstNonEmpty(cfg.From, cfg.To)) {
+	case formatTSV:
+		return '\t'
+	default:
+		return ','
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringifyText(value any) string {
+	if value == nil {
+		return ""
+	}
+	if str, ok := value.(string); ok {
+		return str
+	}
+	data, err := json.Marshal(value)
+	if err == nil {
+		return string(data)
+	}
+	return fmt.Sprint(value)
+}
+
+func cellString(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case map[string]any, []any:
+		data, err := json.Marshal(typed)
+		if err == nil {
+			return string(data)
+		}
+	}
+	return fmt.Sprint(value)
+}
+
+func writeRawValue(w io.Writer, value any) error {
+	switch typed := value.(type) {
+	case nil:
+		_, err := fmt.Fprintln(w)
+		return err
+	case string:
+		_, err := fmt.Fprintln(w, typed)
+		return err
+	case bool:
+		_, err := fmt.Fprintln(w, typed)
+		return err
+	case float64, float32, int, int64, int32, uint, uint64, uint32:
+		_, err := fmt.Fprintln(w, typed)
+		return err
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Errorf("data pick: failed to encode raw value: %w", err)
+		}
+		_, err = fmt.Fprintln(w, string(data))
+		return err
+	}
+}
+
+func normalizeYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, val := range typed {
+			result[key] = normalizeYAMLValue(val)
+		}
+		return result
+	case map[any]any:
+		result := make(map[string]any, len(typed))
+		for key, val := range typed {
+			result[fmt.Sprint(key)] = normalizeYAMLValue(val)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for i, val := range typed {
+			result[i] = normalizeYAMLValue(val)
+		}
+		return result
+	default:
+		return typed
+	}
+}

--- a/internal/runtime/builtin/data/data_test.go
+++ b/internal/runtime/builtin/data/data_test.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package data
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertCSVToJSON(t *testing.T) {
+	t.Parallel()
+
+	out := runDataConvert(t, map[string]any{
+		"from": "csv",
+		"to":   "json",
+		"data": "name,age\nAlice,30\nBob,25\n",
+	})
+
+	assert.JSONEq(t, `[
+		{"name":"Alice","age":"30"},
+		{"name":"Bob","age":"25"}
+	]`, out.String())
+}
+
+func TestConvertYAMLToCSV(t *testing.T) {
+	t.Parallel()
+
+	out := runDataConvert(t, map[string]any{
+		"from":    "yaml",
+		"to":      "csv",
+		"columns": []any{"name", "age"},
+		"data": `
+- name: Alice
+  age: 30
+- name: Bob
+  age: 25
+`,
+	})
+
+	assert.Equal(t, "name,age\nAlice,30\nBob,25\n", out.String())
+}
+
+func TestConvertJSONToCSVWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	out := runDataConvert(t, map[string]any{
+		"from":    "json",
+		"to":      "csv",
+		"headers": false,
+		"columns": []any{"name", "age"},
+		"data":    `[{"name":"Alice","age":30}]`,
+	})
+
+	assert.Equal(t, "Alice,30\n", out.String())
+}
+
+func TestPickYAMLScalarRaw(t *testing.T) {
+	t.Parallel()
+
+	out := runDataPick(t, map[string]any{
+		"from":   "yaml",
+		"select": ".spec.containers[0].image",
+		"raw":    true,
+		"data": `
+spec:
+  containers:
+    - image: nginx:1.27
+`,
+	})
+
+	assert.Equal(t, "nginx:1.27\n", out.String())
+}
+
+func TestPickCSVRowAsJSON(t *testing.T) {
+	t.Parallel()
+
+	out := runDataPick(t, map[string]any{
+		"from":   "csv",
+		"select": ".[1]",
+		"data":   "name,age\nAlice,30\nBob,25\n",
+	})
+
+	assert.JSONEq(t, `{"name":"Bob","age":"25"}`, out.String())
+}
+
+func TestConvertInputFile(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "users.csv"), []byte("name\nAlice\n"), 0o600))
+
+	step := dataStep(opConvert, map[string]any{
+		"from":  "csv",
+		"to":    "json",
+		"input": "users.csv",
+	})
+	ctx := dataContext(workDir, step)
+
+	exec, err := newExecutor(ctx, step)
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	exec.SetStdout(out)
+	require.NoError(t, exec.Run(ctx))
+	assert.JSONEq(t, `[{"name":"Alice"}]`, out.String())
+}
+
+func TestConvertRejectsDataAndInput(t *testing.T) {
+	t.Parallel()
+
+	step := dataStep(opConvert, map[string]any{
+		"from":  "csv",
+		"to":    "json",
+		"data":  "name\nAlice\n",
+		"input": "users.csv",
+	})
+
+	_, err := newExecutor(context.Background(), step)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data and input are mutually exclusive")
+}
+
+func TestConvertConfigSchemaRejectsMissingDataAndInput(t *testing.T) {
+	t.Parallel()
+
+	err := core.ValidateExecutorConfig(executorType, map[string]any{
+		"from": "csv",
+		"to":   "json",
+	})
+	require.Error(t, err)
+}
+
+func runDataConvert(t *testing.T, cfg map[string]any) *bytes.Buffer {
+	t.Helper()
+
+	exec, err := newExecutor(context.Background(), dataStep(opConvert, cfg))
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	exec.SetStdout(out)
+	require.NoError(t, exec.Run(context.Background()))
+	return out
+}
+
+func runDataPick(t *testing.T, cfg map[string]any) *bytes.Buffer {
+	t.Helper()
+
+	exec, err := newExecutor(context.Background(), dataStep(opPick, cfg))
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	exec.SetStdout(out)
+	require.NoError(t, exec.Run(context.Background()))
+	return out
+}
+
+func dataStep(op string, cfg map[string]any) core.Step {
+	return core.Step{
+		Name:     "convert",
+		Commands: []core.CommandEntry{{Command: op}},
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   executorType,
+			Config: cfg,
+		},
+	}
+}
+
+func dataContext(workDir string, step core.Step) context.Context {
+	dag := &core.DAG{
+		Name:               "data-test",
+		WorkingDir:         workDir,
+		WorkingDirExplicit: true,
+	}
+	ctx := runtime.NewContext(context.Background(), dag, "run-1", "")
+	return runtime.WithEnv(ctx, runtime.NewEnv(ctx, step))
+}


### PR DESCRIPTION
## Summary

Add built-in data actions for converting structured text and selecting values from structured payloads.

## Changes

- Add `data.convert` and `data.pick` action normalization and executor registration.
- Support JSON, YAML, CSV, TSV, and text parsing/encoding with inline data or file input.
- Wire data action config into DAG JSON schema validation.
- Add unit, schema, spec, and integration coverage for conversion and selection behavior.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Changes have been tested locally

## Validation

- `go test ./internal/runtime/builtin/data ./internal/core/spec ./internal/cmn/schema -count=1`
- `go test ./internal/intg -run TestDataConvertAction -count=1`
- `make check`
- `git diff --check && git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new built-in data processing actions: `data.convert` and `data.pick`
  * `data.convert` enables transformation between multiple data formats (JSON, YAML, CSV, TSV, text)
  * `data.pick` allows selecting specific values from parsed data structures
  * Both actions support inline data or external file inputs
  * Configurable delimiter, headers, and column handling for tabular formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->