### PR TITLE
feat: add git checkout action

### DIFF
--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -200,6 +200,7 @@ Current builtin actions:
 | `mail.send` | Email sending | mail executor config |
 | `archive.create`, `archive.extract`, `archive.list` | Archive operations | archive config |
 | `file.stat`, `file.read`, `file.write`, `file.copy`, `file.move`, `file.delete`, `file.mkdir`, `file.list` | File operations | path/source/destination/content config |
+| `git.checkout` | Git repository checkout | `repository`, `path`, optional `ref`, `depth`, auth config |
 | `wait.duration`, `wait.until`, `wait.file`, `wait.http` | Wait or poll for time, files, or HTTP readiness | `duration`, `until`, `path`, `url`, optional polling config |
 | `s3.upload`, `s3.download`, `s3.list`, `s3.delete` | S3 operations | S3 config |
 | `sftp.upload`, `sftp.download` | SFTP transfers | SFTP config |

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2230,6 +2230,18 @@
         },
         {
           "if": {
+            "properties": { "action": { "const": "git.checkout" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/gitCheckoutActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": { "action": { "enum": ["wait.duration", "wait.until", "wait.file", "wait.http"] } },
             "required": ["action"]
           },
@@ -2530,6 +2542,19 @@
               "with": { "$ref": "#/definitions/fileActionConfig" },
               "config": {
                 "$ref": "#/definitions/fileActionConfig",
+                "deprecated": true,
+                "doNotSuggest": true
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
+          "then": {
+            "properties": {
+              "with": { "$ref": "#/definitions/gitCheckoutActionConfig" },
+              "config": {
+                "$ref": "#/definitions/gitCheckoutActionConfig",
                 "deprecated": true,
                 "doNotSuggest": true
               }
@@ -5881,6 +5906,7 @@
         "docker",
         "container",
         "file",
+        "git",
         "kubernetes",
         "k8s",
         "http",
@@ -5945,6 +5971,7 @@
             "file.read",
             "file.stat",
             "file.write",
+            "git.checkout",
             "harness.run",
             "http.request",
             "jq.filter",
@@ -6470,6 +6497,64 @@
       },
       "description": "Configuration for local file actions."
     },
+    "gitCheckoutActionConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "path"],
+      "not": {
+        "anyOf": [
+          { "required": ["ssh_key_path", "token"] },
+          { "required": ["ssh_key_path", "password"] }
+        ]
+      },
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Git repository URL or local repository path."
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Branch, tag, or commit to checkout. Defaults to the repository default HEAD."
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Destination checkout path. Relative paths resolve from the step working directory."
+        },
+        "depth": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Shallow clone/fetch depth. Zero means full history."
+        },
+        "force": {
+          "type": "boolean",
+          "description": "Force checkout when the existing worktree has local changes. Defaults to false."
+        },
+        "token": {
+          "type": "string",
+          "description": "HTTPS token for repository authentication."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTPS username when using password authentication."
+        },
+        "password": {
+          "type": "string",
+          "description": "HTTPS password for repository authentication."
+        },
+        "ssh_key_path": {
+          "type": "string",
+          "description": "Path to an SSH private key for repository authentication."
+        },
+        "ssh_passphrase": {
+          "type": "string",
+          "description": "Passphrase for ssh_key_path."
+        }
+      },
+      "description": "Configuration for action: git.checkout."
+    },
     "waitActionConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -6741,6 +6826,14 @@
           "then": {
             "properties": {
               "config": { "$ref": "#/definitions/fileActionConfig" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "git" } }, "required": ["type"] },
+          "then": {
+            "properties": {
+              "config": { "$ref": "#/definitions/gitCheckoutActionConfig" }
             }
           }
         },

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -57,6 +57,8 @@ func TestMain(m *testing.M) {
 	core.RegisterExecutorCapabilities("data", core.ExecutorCapabilities{Command: true})
 	// wait: supports command only
 	core.RegisterExecutorCapabilities("wait", core.ExecutorCapabilities{Command: true})
+	// git: supports command only
+	core.RegisterExecutorCapabilities("git", core.ExecutorCapabilities{Command: true})
 	// dag/subworkflow/parallel: support SubDAG and WorkerSelector
 	for _, t := range []string{"dag", "subworkflow", "parallel"} {
 		core.RegisterExecutorCapabilities(t, core.ExecutorCapabilities{

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -80,6 +80,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"duckdb":        {},
 	"file":          {},
 	"gha":           {},
+	"git":           {},
 	"github-action": {},
 	"github_action": {},
 	"harness":       {},

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -60,6 +60,7 @@ var builtinActionNormalizers = map[string]actionNormalizer{
 	"file.read":       operationAction("file", "read"),
 	"file.stat":       operationAction("file", "stat"),
 	"file.write":      operationAction("file", "write"),
+	"git.checkout":    operationAction("git", "checkout"),
 	"harness.run":     normalizeHarnessRunAction,
 	"http.request":    normalizeHTTPRequestAction,
 	"jq.filter":       normalizeJQFilterAction,

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -142,6 +142,32 @@ steps:
 	assert.Equal(t, "alpine:3.20", step.ExecutorConfig.Config["image"])
 }
 
+func TestStepSchemaV2_ActionGitCheckout(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: checkout
+    action: git.checkout
+    with:
+      repository: https://example.com/acme/app.git
+      ref: main
+      path: ./workspace/app
+      depth: 1
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "git", step.ExecutorConfig.Type)
+	require.Len(t, step.Commands, 1)
+	assert.Equal(t, "checkout", step.Commands[0].Command)
+	assert.Equal(t, "https://example.com/acme/app.git", step.ExecutorConfig.Config["repository"])
+	assert.Equal(t, "main", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, "./workspace/app", step.ExecutorConfig.Config["path"])
+	assert.Equal(t, uint64(1), step.ExecutorConfig.Config["depth"])
+}
+
 func TestStepSchemaV2_ActionJQFilterData(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/data"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/file"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/git"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/harness"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/http"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/jq"

--- a/internal/runtime/builtin/git/config.go
+++ b/internal/runtime/builtin/git/config.go
@@ -57,6 +57,9 @@ func validateConfig(operation string, cfg config) error {
 	if cfg.SSHKeyPath != "" && (cfg.Token != "" || cfg.Password != "") {
 		return fmt.Errorf("git: ssh_key_path cannot be combined with token or password")
 	}
+	if cfg.Token != "" && (cfg.Username != "" || cfg.Password != "") {
+		return fmt.Errorf("git: token cannot be combined with username/password")
+	}
 	return nil
 }
 

--- a/internal/runtime/builtin/git/config.go
+++ b/internal/runtime/builtin/git/config.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package git
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+type config struct {
+	Repository    string `mapstructure:"repository"`
+	Ref           string `mapstructure:"ref"`
+	Path          string `mapstructure:"path"`
+	Depth         int    `mapstructure:"depth"`
+	Force         bool   `mapstructure:"force"`
+	Token         string `mapstructure:"token"`
+	Username      string `mapstructure:"username"`
+	Password      string `mapstructure:"password"`
+	SSHKeyPath    string `mapstructure:"ssh_key_path"`
+	SSHPassphrase string `mapstructure:"ssh_passphrase"`
+}
+
+func decodeConfig(raw map[string]any, cfg *config) error {
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      true,
+		TagName:          "mapstructure",
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(raw)
+}
+
+func validateConfig(operation string, cfg config) error {
+	if operation != opCheckout {
+		return fmt.Errorf("git: unsupported operation %q", operation)
+	}
+	if strings.TrimSpace(cfg.Repository) == "" {
+		return fmt.Errorf("git: repository is required")
+	}
+	if strings.TrimSpace(cfg.Path) == "" {
+		return fmt.Errorf("git: path is required")
+	}
+	if cfg.Depth < 0 {
+		return fmt.Errorf("git: depth must be >= 0")
+	}
+	if cfg.SSHKeyPath != "" && (cfg.Token != "" || cfg.Password != "") {
+		return fmt.Errorf("git: ssh_key_path cannot be combined with token or password")
+	}
+	return nil
+}
+
+var configSchema = &jsonschema.Schema{
+	Type:                 "object",
+	AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+	Properties: map[string]*jsonschema.Schema{
+		"repository":     {Type: "string", Description: "Git repository URL or local repository path for action: git.checkout."},
+		"ref":            {Type: "string", Description: "Branch, tag, or commit to checkout. Defaults to the repository default HEAD."},
+		"path":           {Type: "string", Description: "Destination checkout path. Relative paths resolve from the step working directory."},
+		"depth":          {Type: "integer", Minimum: new(float64(0)), Description: "Shallow clone/fetch depth. Zero means full history."},
+		"force":          {Type: "boolean", Description: "Force checkout when the existing worktree has local changes. Defaults to false."},
+		"token":          {Type: "string", Description: "HTTPS token for repository authentication."},
+		"username":       {Type: "string", Description: "HTTPS username when using password authentication."},
+		"password":       {Type: "string", Description: "HTTPS password for repository authentication."},
+		"ssh_key_path":   {Type: "string", Description: "Path to an SSH private key for repository authentication."},
+		"ssh_passphrase": {Type: "string", Description: "Passphrase for ssh_key_path."},
+	},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+}

--- a/internal/runtime/builtin/git/git.go
+++ b/internal/runtime/builtin/git/git.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	executorType = "git"
+	remoteName   = "origin"
 
 	opCheckout = "checkout"
 )
@@ -193,7 +194,7 @@ func (e *executorImpl) runCheckout(ctx context.Context) error {
 			return err
 		}
 	}
-	commit, err := e.checkoutRef(repo)
+	commit, err := e.checkoutRef(ctx, repo, auth)
 	if err != nil {
 		return err
 	}
@@ -227,11 +228,12 @@ func (e *executorImpl) clone(ctx context.Context, target string, auth transport.
 func (e *executorImpl) fetch(ctx context.Context, repo *gogit.Repository, auth transport.AuthMethod) error {
 	err := repo.FetchContext(ctx, &gogit.FetchOptions{
 		Auth:       auth,
-		RemoteName: "origin",
+		RemoteName: remoteName,
 		Depth:      e.cfg.Depth,
 		Force:      true,
 		RefSpecs: []gogitconfig.RefSpec{
-			"+refs/heads/*:refs/remotes/origin/*",
+			"+HEAD:refs/remotes/" + remoteName + "/HEAD",
+			"+refs/heads/*:refs/remotes/" + remoteName + "/*",
 			"+refs/tags/*:refs/tags/*",
 		},
 	})
@@ -241,9 +243,13 @@ func (e *executorImpl) fetch(ctx context.Context, repo *gogit.Repository, auth t
 	return nil
 }
 
-func (e *executorImpl) checkoutRef(repo *gogit.Repository) (string, error) {
+func (e *executorImpl) checkoutRef(ctx context.Context, repo *gogit.Repository, auth transport.AuthMethod) (string, error) {
 	ref := strings.TrimSpace(e.cfg.Ref)
 	if ref == "" {
+		hash, name, ok := remoteDefaultHead(ctx, repo, auth)
+		if ok {
+			return e.checkoutHash(repo, hash, name)
+		}
 		return currentHead(repo)
 	}
 
@@ -251,6 +257,10 @@ func (e *executorImpl) checkoutRef(repo *gogit.Repository) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return e.checkoutHash(repo, hash, ref)
+}
+
+func (e *executorImpl) checkoutHash(repo *gogit.Repository, hash plumbing.Hash, ref string) (string, error) {
 	wt, err := repo.Worktree()
 	if err != nil {
 		return "", fmt.Errorf("git checkout: worktree: %w", err)
@@ -259,6 +269,32 @@ func (e *executorImpl) checkoutRef(repo *gogit.Repository) (string, error) {
 		return "", fmt.Errorf("git checkout: checkout %q: %w", ref, err)
 	}
 	return hash.String(), nil
+}
+
+func remoteDefaultHead(ctx context.Context, repo *gogit.Repository, auth transport.AuthMethod) (plumbing.Hash, string, bool) {
+	revisions := []plumbing.Revision{
+		plumbing.Revision(plumbing.NewRemoteHEADReferenceName(remoteName)),
+		plumbing.Revision(remoteName + "/HEAD"),
+	}
+	for _, revision := range revisions {
+		hash, err := repo.ResolveRevision(revision)
+		if err == nil && hash != nil {
+			return *hash, string(revision), true
+		}
+	}
+
+	remote, err := repo.Remote(remoteName)
+	if err == nil {
+		refs, err := remote.ListContext(ctx, &gogit.ListOptions{Auth: auth})
+		if err == nil {
+			for _, ref := range refs {
+				if ref.Name() == plumbing.HEAD && !ref.Hash().IsZero() {
+					return ref.Hash(), string(plumbing.HEAD), true
+				}
+			}
+		}
+	}
+	return plumbing.ZeroHash, "", false
 }
 
 func resolveRef(repo *gogit.Repository, ref string) (plumbing.Hash, error) {

--- a/internal/runtime/builtin/git/git.go
+++ b/internal/runtime/builtin/git/git.go
@@ -1,0 +1,359 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+)
+
+const (
+	executorType = "git"
+
+	opCheckout = "checkout"
+)
+
+var (
+	_ executor.Executor  = (*executorImpl)(nil)
+	_ executor.ExitCoder = (*executorImpl)(nil)
+)
+
+type executorImpl struct {
+	mu       sync.Mutex
+	stdout   io.Writer
+	stderr   io.Writer
+	cancel   context.CancelFunc
+	kill     context.Context
+	cfg      config
+	op       string
+	workDir  string
+	exitCode int
+}
+
+type checkoutResult struct {
+	Operation string `json:"operation"`
+	Path      string `json:"path"`
+	Ref       string `json:"ref,omitempty"`
+	Commit    string `json:"commit"`
+	Cloned    bool   `json:"cloned"`
+	Changed   bool   `json:"changed"`
+}
+
+func init() {
+	executor.RegisterExecutor(executorType, newExecutor, validateStep, core.ExecutorCapabilities{Command: true})
+}
+
+func newExecutor(ctx context.Context, step core.Step) (executor.Executor, error) {
+	cfg := config{}
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return nil, err
+	}
+	op := stepOperation(step)
+	if err := validateConfig(op, cfg); err != nil {
+		return nil, err
+	}
+
+	kill, cancel := context.WithCancel(ctx)
+	env := runtime.GetEnv(ctx)
+	return &executorImpl{
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+		cancel:  cancel,
+		kill:    kill,
+		cfg:     cfg,
+		op:      op,
+		workDir: env.WorkingDir,
+	}, nil
+}
+
+func validateStep(step core.Step) error {
+	if step.ExecutorConfig.Type != executorType {
+		return nil
+	}
+	cfg := config{}
+	if err := decodeConfig(step.ExecutorConfig.Config, &cfg); err != nil {
+		return err
+	}
+	return validateConfig(stepOperation(step), cfg)
+}
+
+func stepOperation(step core.Step) string {
+	if len(step.Commands) == 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(step.Commands[0].Command))
+}
+
+func (e *executorImpl) SetStdout(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stdout = out
+}
+
+func (e *executorImpl) SetStderr(out io.Writer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stderr = out
+}
+
+func (e *executorImpl) Kill(_ os.Signal) error {
+	e.mu.Lock()
+	cancel := e.cancel
+	e.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+func (e *executorImpl) ExitCode() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exitCode
+}
+
+func (e *executorImpl) Run(ctx context.Context) error {
+	ctx, stop := e.runContext(ctx)
+	defer stop()
+
+	var err error
+	switch e.op {
+	case opCheckout:
+		err = e.runCheckout(ctx)
+	default:
+		err = fmt.Errorf("git: unsupported operation %q", e.op)
+	}
+
+	e.mu.Lock()
+	if err != nil {
+		e.exitCode = 1
+	} else {
+		e.exitCode = 0
+	}
+	e.mu.Unlock()
+	return err
+}
+
+func (e *executorImpl) runContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	go func() {
+		select {
+		case <-e.kill.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+func (e *executorImpl) runCheckout(ctx context.Context) error {
+	target := e.resolvePath(e.cfg.Path)
+	auth, err := e.auth()
+	if err != nil {
+		return err
+	}
+
+	cloned := false
+	repo, err := gogit.PlainOpen(target)
+	if err != nil {
+		if !errors.Is(err, gogit.ErrRepositoryNotExists) {
+			return fmt.Errorf("git checkout: open repository: %w", err)
+		}
+		if err := ensureCloneTarget(target); err != nil {
+			return err
+		}
+		repo, err = e.clone(ctx, target, auth)
+		if err != nil {
+			return err
+		}
+		cloned = true
+	}
+
+	before := headHash(repo)
+	if !cloned {
+		if err := e.fetch(ctx, repo, auth); err != nil {
+			return err
+		}
+	}
+	commit, err := e.checkoutRef(repo)
+	if err != nil {
+		return err
+	}
+
+	result := checkoutResult{
+		Operation: opCheckout,
+		Path:      target,
+		Ref:       strings.TrimSpace(e.cfg.Ref),
+		Commit:    commit,
+		Cloned:    cloned,
+		Changed:   cloned || before != commit,
+	}
+	return e.writeJSON(result)
+}
+
+func (e *executorImpl) clone(ctx context.Context, target string, auth transport.AuthMethod) (*gogit.Repository, error) {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return nil, fmt.Errorf("git checkout: create parent directory: %w", err)
+	}
+	repo, err := gogit.PlainCloneContext(ctx, target, false, &gogit.CloneOptions{
+		URL:   strings.TrimSpace(e.cfg.Repository),
+		Auth:  auth,
+		Depth: e.cfg.Depth,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("git checkout: clone failed: %w", err)
+	}
+	return repo, nil
+}
+
+func (e *executorImpl) fetch(ctx context.Context, repo *gogit.Repository, auth transport.AuthMethod) error {
+	err := repo.FetchContext(ctx, &gogit.FetchOptions{
+		Auth:       auth,
+		RemoteName: "origin",
+		Depth:      e.cfg.Depth,
+		Force:      true,
+		RefSpecs: []gogitconfig.RefSpec{
+			"+refs/heads/*:refs/remotes/origin/*",
+			"+refs/tags/*:refs/tags/*",
+		},
+	})
+	if err != nil && !errors.Is(err, gogit.NoErrAlreadyUpToDate) {
+		return fmt.Errorf("git checkout: fetch failed: %w", err)
+	}
+	return nil
+}
+
+func (e *executorImpl) checkoutRef(repo *gogit.Repository) (string, error) {
+	ref := strings.TrimSpace(e.cfg.Ref)
+	if ref == "" {
+		return currentHead(repo)
+	}
+
+	hash, err := resolveRef(repo, ref)
+	if err != nil {
+		return "", err
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("git checkout: worktree: %w", err)
+	}
+	if err := wt.Checkout(&gogit.CheckoutOptions{Hash: hash, Force: e.cfg.Force}); err != nil {
+		return "", fmt.Errorf("git checkout: checkout %q: %w", ref, err)
+	}
+	return hash.String(), nil
+}
+
+func resolveRef(repo *gogit.Repository, ref string) (plumbing.Hash, error) {
+	if plumbing.IsHash(ref) {
+		hash := plumbing.NewHash(ref)
+		if _, err := repo.CommitObject(hash); err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("git checkout: resolve %q: %w", ref, err)
+		}
+		return hash, nil
+	}
+
+	revisions := []plumbing.Revision{
+		plumbing.Revision(ref),
+		plumbing.Revision("refs/heads/" + ref),
+		plumbing.Revision("refs/remotes/origin/" + ref),
+		plumbing.Revision("refs/tags/" + ref),
+	}
+	for _, revision := range revisions {
+		hash, err := repo.ResolveRevision(revision)
+		if err == nil && hash != nil {
+			return *hash, nil
+		}
+	}
+	return plumbing.ZeroHash, fmt.Errorf("git checkout: ref %q not found", ref)
+}
+
+func currentHead(repo *gogit.Repository) (string, error) {
+	ref, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("git checkout: head: %w", err)
+	}
+	return ref.Hash().String(), nil
+}
+
+func headHash(repo *gogit.Repository) string {
+	ref, err := repo.Head()
+	if err != nil {
+		return ""
+	}
+	return ref.Hash().String()
+}
+
+func ensureCloneTarget(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("git checkout: stat target: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("git checkout: target path exists and is not a directory")
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("git checkout: read target directory: %w", err)
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("git checkout: target directory is not a git repository and is not empty")
+	}
+	return nil
+}
+
+func (e *executorImpl) auth() (transport.AuthMethod, error) {
+	if e.cfg.SSHKeyPath != "" {
+		auth, err := gitssh.NewPublicKeysFromFile("git", e.resolvePath(e.cfg.SSHKeyPath), e.cfg.SSHPassphrase)
+		if err != nil {
+			return nil, fmt.Errorf("git checkout: load ssh key: %w", err)
+		}
+		return auth, nil
+	}
+	if e.cfg.Token != "" {
+		return &githttp.BasicAuth{Username: "git", Password: e.cfg.Token}, nil
+	}
+	if e.cfg.Password != "" {
+		username := e.cfg.Username
+		if username == "" {
+			username = "git"
+		}
+		return &githttp.BasicAuth{Username: username, Password: e.cfg.Password}, nil
+	}
+	return nil, nil
+}
+
+func (e *executorImpl) resolvePath(path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) || e.workDir == "" {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(e.workDir, path))
+}
+
+func (e *executorImpl) writeJSON(value any) error {
+	e.mu.Lock()
+	out := e.stdout
+	e.mu.Unlock()
+	return json.NewEncoder(out).Encode(value)
+}

--- a/internal/runtime/builtin/git/git_test.go
+++ b/internal/runtime/builtin/git/git_test.go
@@ -98,6 +98,7 @@ func TestGitCheckoutUpdatesExistingRepositoryWithoutRef(t *testing.T) {
 
 	first, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
 		"repository": source,
+		"ref":        "",
 		"path":       "repo",
 	}))
 	require.NoError(t, err)
@@ -114,6 +115,7 @@ func TestGitCheckoutUpdatesExistingRepositoryWithoutRef(t *testing.T) {
 	secondCommit := commitFile(t, source, "version.txt", "two\n")
 	second, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
 		"repository": source,
+		"ref":        "",
 		"path":       "repo",
 	}))
 	require.NoError(t, err)

--- a/internal/runtime/builtin/git/git_test.go
+++ b/internal/runtime/builtin/git/git_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package git
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCheckoutClonesRepositoryToRelativePath(t *testing.T) {
+	t.Parallel()
+
+	source := t.TempDir()
+	commit := createTestRepository(t, source, "hello.txt", "hello\n")
+	workDir := t.TempDir()
+
+	exec, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
+		"repository": source,
+		"ref":        commit,
+		"path":       "workspace/repo",
+		"depth":      1,
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	exec.SetStdout(&stdout)
+	require.NoError(t, exec.Run(context.Background()))
+
+	require.FileExists(t, filepath.Join(workDir, "workspace/repo/hello.txt"))
+	assert.Equal(t, "hello\n", readFile(t, filepath.Join(workDir, "workspace/repo/hello.txt")))
+
+	var result checkoutResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.Equal(t, opCheckout, result.Operation)
+	assert.Equal(t, filepath.Join(workDir, "workspace/repo"), result.Path)
+	assert.Equal(t, commit, result.Commit)
+	assert.Equal(t, commit, result.Ref)
+	assert.True(t, result.Cloned)
+	assert.True(t, result.Changed)
+}
+
+func TestGitCheckoutUpdatesExistingRepository(t *testing.T) {
+	t.Parallel()
+
+	source := t.TempDir()
+	firstCommit := createTestRepository(t, source, "version.txt", "one\n")
+	secondCommit := commitFile(t, source, "version.txt", "two\n")
+	workDir := t.TempDir()
+
+	first, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
+		"repository": source,
+		"ref":        firstCommit,
+		"path":       "repo",
+	}))
+	require.NoError(t, err)
+	require.NoError(t, first.Run(context.Background()))
+	assert.Equal(t, "one\n", readFile(t, filepath.Join(workDir, "repo/version.txt")))
+
+	second, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
+		"repository": source,
+		"ref":        secondCommit,
+		"path":       "repo",
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	second.SetStdout(&stdout)
+	require.NoError(t, second.Run(context.Background()))
+
+	assert.Equal(t, "two\n", readFile(t, filepath.Join(workDir, "repo/version.txt")))
+
+	var result checkoutResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.False(t, result.Cloned)
+	assert.True(t, result.Changed)
+	assert.Equal(t, secondCommit, result.Commit)
+}
+
+func checkoutStep(config map[string]any) core.Step {
+	return core.Step{
+		Name: "checkout",
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   executorType,
+			Config: config,
+		},
+		Commands: []core.CommandEntry{{Command: opCheckout}},
+	}
+}
+
+func testContext(workDir string) context.Context {
+	ctx := context.Background()
+	return runtime.WithEnv(ctx, runtime.Env{WorkingDir: workDir})
+}
+
+func createTestRepository(t *testing.T, path, name, content string) string {
+	t.Helper()
+	_, err := gogit.PlainInit(path, false)
+	require.NoError(t, err)
+	return commitFile(t, path, name, content)
+}
+
+func commitFile(t *testing.T, repoPath, name, content string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0o600))
+
+	repo, err := gogit.PlainOpen(repoPath)
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add(name)
+	require.NoError(t, err)
+	hash, err := wt.Commit("update "+name, &gogit.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Dagu Test",
+			Email: "dagu-test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	return hash.String()
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/runtime/builtin/git/git_test.go
+++ b/internal/runtime/builtin/git/git_test.go
@@ -89,6 +89,61 @@ func TestGitCheckoutUpdatesExistingRepository(t *testing.T) {
 	assert.Equal(t, secondCommit, result.Commit)
 }
 
+func TestGitCheckoutUpdatesExistingRepositoryWithoutRef(t *testing.T) {
+	t.Parallel()
+
+	source := t.TempDir()
+	firstCommit := createTestRepository(t, source, "version.txt", "one\n")
+	workDir := t.TempDir()
+
+	first, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
+		"repository": source,
+		"path":       "repo",
+	}))
+	require.NoError(t, err)
+
+	var firstStdout bytes.Buffer
+	first.SetStdout(&firstStdout)
+	require.NoError(t, first.Run(context.Background()))
+	assert.Equal(t, "one\n", readFile(t, filepath.Join(workDir, "repo/version.txt")))
+
+	var firstResult checkoutResult
+	require.NoError(t, json.Unmarshal(firstStdout.Bytes(), &firstResult))
+	assert.Equal(t, firstCommit, firstResult.Commit)
+
+	secondCommit := commitFile(t, source, "version.txt", "two\n")
+	second, err := newExecutor(testContext(workDir), checkoutStep(map[string]any{
+		"repository": source,
+		"path":       "repo",
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	second.SetStdout(&stdout)
+	require.NoError(t, second.Run(context.Background()))
+
+	assert.Equal(t, "two\n", readFile(t, filepath.Join(workDir, "repo/version.txt")))
+
+	var result checkoutResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.False(t, result.Cloned)
+	assert.True(t, result.Changed)
+	assert.Equal(t, secondCommit, result.Commit)
+}
+
+func TestGitCheckoutRejectsMixedHTTPSAuth(t *testing.T) {
+	t.Parallel()
+
+	_, err := newExecutor(testContext(t.TempDir()), checkoutStep(map[string]any{
+		"repository": "https://example.com/repo.git",
+		"path":       "repo",
+		"token":      "token",
+		"username":   "user",
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token cannot be combined with username/password")
+}
+
 func checkoutStep(config map[string]any) core.Step {
 	return core.Step{
 		Name: "checkout",


### PR DESCRIPTION
## Summary
- add a builtin git.checkout action for cloning and updating repositories during DAG runs
- wire git.checkout into action normalization, schema validation, and builtin registration
- document the new action in README_SCHEMA.md

## Changes
- add a git checkout executor with clone/fetch, auth, ref resolution, and JSON result output
- add schema and spec support for `action: git.checkout` and legacy `type: git` usage
- reject conflicting HTTPS auth modes during validation
- update no-ref checkouts to advance to the fetched remote default HEAD
- add tests for cloning, updating explicit refs, updating without `ref`, auth validation, schema normalization, and registration

## Related Issues
N/A

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Validation
- `go test ./internal/cmn/schema ./internal/core/spec ./internal/runtime/builtin/... -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a git.checkout step to clone/checkout repositories with repository, path, optional ref, depth and force controls; supports legacy git executor alias.
  * Supports HTTPS (token or username/password) and SSH (key + passphrase) authentication.
  * Emits structured checkout results (commit/ref/cloned/changed).

* **Documentation**
  * Workflow/schema reference updated to document the new git.checkout action.

* **Tests**
  * Added unit tests covering cloning, updates, empty-ref behavior, and auth validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
