### PR TITLE
fix: suppress pending auto-retry notifications

### DIFF
--- a/internal/agent/dag_manage_test.go
+++ b/internal/agent/dag_manage_test.go
@@ -361,6 +361,55 @@ func TestDAGRunWatchRegistryNotifiesTerminalRun(t *testing.T) {
 	assert.Contains(t, message, "Do not quote it verbatim.")
 }
 
+func TestDAGRunWatchRegistryDefersFailedRunWithAutoRetryRemaining(t *testing.T) {
+	status := &exec.DAGRunStatus{
+		Name:           "build",
+		DAGRunID:       "run-1",
+		AttemptID:      "attempt-1",
+		Status:         core.Failed,
+		Error:          "workflow failed",
+		AutoRetryCount: 0,
+		AutoRetryLimit: 2,
+	}
+	store := &dagRunManageTestStore{status: status}
+	notifyCount := 0
+	registry := newDAGRunWatchRegistry(
+		store,
+		func(_ context.Context, _ DAGRunWatchRequest, _ DAGRunWatchInfo, _ *exec.DAGRunStatus) error {
+			notifyCount++
+			return nil
+		},
+		slog.Default(),
+		withDAGRunWatchPollInterval(time.Hour),
+	)
+	defer registry.ClearSession("session-1")
+
+	info, err := registry.Watch(context.Background(), DAGRunWatchRequest{
+		SessionID: "session-1",
+		User:      UserIdentity{UserID: "user-1"},
+		DAGName:   "build",
+		DAGRunID:  "run-1",
+		NotifyOn:  []string{"failure"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, DAGRunWatchStateRunning, info.State)
+	assert.Equal(t, core.Failed.String(), info.Status)
+	assert.False(t, info.Notified)
+	assert.Equal(t, 0, notifyCount)
+
+	status.AutoRetryCount = status.AutoRetryLimit
+	current, err := registry.Status(context.Background(), DAGRunWatchStatusRequest{
+		SessionID: "session-1",
+		WatchID:   info.WatchID,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, DAGRunWatchStateCompleted, current.State)
+	assert.True(t, current.Notified)
+	assert.Equal(t, 1, notifyCount)
+}
+
 func TestDAGRunWatchRegistryDeduplicatesActiveRun(t *testing.T) {
 	store := &dagRunManageTestStore{
 		status: &exec.DAGRunStatus{

--- a/internal/agent/dag_run_watch.go
+++ b/internal/agent/dag_run_watch.go
@@ -602,6 +602,9 @@ func isDAGRunWatchTerminal(status *exec.DAGRunStatus) bool {
 	if status == nil {
 		return false
 	}
+	if exec.CanCancelFailedAutoRetryPendingRun(status) {
+		return false
+	}
 	return status.Status != core.NotStarted && !status.Status.IsActive()
 }
 

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -1174,7 +1174,6 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 			if pending, ok := destState.Pending[event.Key]; ok {
 				if shouldSuppressNotificationEvent(pending) {
 					delete(destState.Pending, event.Key)
-					changed = true
 				} else {
 					queued = append(queued, queuedNotification{
 						destination: destination,
@@ -1194,7 +1193,6 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 					continue
 				}
 				delete(destState.Pending, pendingKey)
-				changed = true
 			}
 
 			destState.Pending[event.Key] = NotificationEvent{

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -251,7 +251,7 @@ func (m *NotificationMonitor) initializeSession(ctx context.Context) {
 	}
 
 	m.ensureBootstrapped(ctx)
-	m.requeuePending(destinations)
+	m.requeuePending(ctx, destinations)
 }
 
 func (m *NotificationMonitor) loadPersistedState(ctx context.Context) {
@@ -433,7 +433,7 @@ func (m *NotificationMonitor) syncPendingDestinations(ctx context.Context) {
 		m.discardPendingDestinations(removed)
 	}
 
-	m.requeuePending(destinations)
+	m.requeuePending(ctx, destinations)
 }
 
 func (m *NotificationMonitor) enqueueEvents(ctx context.Context, destinations []string, events []NotificationEvent) bool {
@@ -472,7 +472,7 @@ func (m *NotificationMonitor) enqueueEvents(ctx context.Context, destinations []
 	return accepted
 }
 
-func (m *NotificationMonitor) requeuePending(destinations []string) {
+func (m *NotificationMonitor) requeuePending(ctx context.Context, destinations []string) {
 	if len(destinations) == 0 {
 		return
 	}
@@ -488,12 +488,34 @@ func (m *NotificationMonitor) requeuePending(destinations []string) {
 	var queued []queuedNotification
 
 	m.stateMu.Lock()
+	persisted := m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
+		changed := false
+		for destination, destState := range candidate.Destinations {
+			if _, ok := allowed[destination]; !ok || destState == nil {
+				continue
+			}
+			for key, event := range destState.Pending {
+				if shouldSuppressNotificationEvent(event) {
+					delete(destState.Pending, key)
+					changed = true
+				}
+			}
+		}
+		return changed
+	})
+	if !persisted {
+		m.stateMu.Unlock()
+		return
+	}
 	for destination, destState := range m.state.Destinations {
 		if _, ok := allowed[destination]; !ok || destState == nil {
 			continue
 		}
 		for _, event := range destState.Pending {
 			if event.Status == nil || event.Key == "" {
+				continue
+			}
+			if shouldSuppressNotificationEvent(event) {
 				continue
 			}
 			queued = append(queued, queuedNotification{
@@ -1140,16 +1162,27 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 			if event.Status == nil || event.Key == "" {
 				continue
 			}
+			if shouldSuppressNotificationEvent(event) {
+				if removePendingNotificationsForRun(destState, NotificationRunKey(event.Status)) {
+					changed = true
+				}
+				continue
+			}
 			if _, ok := destState.Delivered[event.Key]; ok {
 				continue
 			}
 			if pending, ok := destState.Pending[event.Key]; ok {
-				queued = append(queued, queuedNotification{
-					destination: destination,
-					event:       pending,
-				})
-				accepted = true
-				continue
+				if shouldSuppressNotificationEvent(pending) {
+					delete(destState.Pending, event.Key)
+					changed = true
+				} else {
+					queued = append(queued, queuedNotification{
+						destination: destination,
+						event:       pending,
+					})
+					accepted = true
+					continue
+				}
 			}
 
 			runKey := NotificationRunKey(event.Status)
@@ -1161,10 +1194,12 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 					continue
 				}
 				delete(destState.Pending, pendingKey)
+				changed = true
 			}
 
 			destState.Pending[event.Key] = NotificationEvent{
 				Key:        event.Key,
+				Type:       event.Type,
 				Status:     cloneNotificationStatus(event.Status),
 				ObservedAt: event.ObservedAt,
 			}
@@ -1178,4 +1213,19 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 	}
 
 	return queued, changed, accepted
+}
+
+func removePendingNotificationsForRun(destState *notificationDestinationState, runKey string) bool {
+	if destState == nil || runKey == "" {
+		return false
+	}
+	changed := false
+	for pendingKey, pending := range destState.Pending {
+		if pending.Status == nil || NotificationRunKey(pending.Status) != runKey {
+			continue
+		}
+		delete(destState.Pending, pendingKey)
+		changed = true
+	}
+	return changed
 }

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -193,6 +193,96 @@ func TestNotificationMonitor_ShutdownDrainRetriesInFlightBatchWithoutLLM(t *test
 	assert.True(t, monitor.IsDelivered("dest-1", status))
 }
 
+func TestNotificationMonitor_NotifyCompletionSkipsFailedRunWithAutoRetryRemaining(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(_ context.Context, _ string, _ NotificationBatch, _ bool) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			calls++
+			return true
+		},
+	}
+
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.UrgentWindow = 10 * time.Millisecond
+	cfg.PollInterval = time.Hour
+	cfg.SeenEvictInterval = time.Hour
+
+	monitor := NewNotificationMonitor(nil, "", transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	status := &exec.DAGRunStatus{
+		Name:           "briefing",
+		Status:         core.Failed,
+		DAGRunID:       "run-1",
+		AttemptID:      "attempt-1",
+		Error:          "boom",
+		AutoRetryCount: 0,
+		AutoRetryLimit: 2,
+	}
+	require.False(t, monitor.NotifyCompletion(status))
+
+	require.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls > 0 || monitor.IsDelivered("dest-1", status)
+	}, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestNotificationMonitor_RequeuePendingDropsFailedRunWithAutoRetryRemaining(t *testing.T) {
+	t.Parallel()
+
+	transport := &fakeNotificationTransport{destinations: []string{"dest-1"}}
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.UrgentWindow = 10 * time.Millisecond
+	cfg.PollInterval = time.Hour
+	cfg.SeenEvictInterval = time.Hour
+
+	monitor := NewNotificationMonitor(nil, "", transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	status := &exec.DAGRunStatus{
+		Name:           "briefing",
+		Status:         core.Failed,
+		DAGRunID:       "run-1",
+		AttemptID:      "attempt-1",
+		Error:          "boom",
+		AutoRetryCount: 0,
+		AutoRetryLimit: 2,
+	}
+	event := testNotificationEvent(status)
+	monitor.state = newNotificationMonitorState()
+	monitor.state.Bootstrapped = true
+	monitor.state.Destinations["dest-1"] = &notificationDestinationState{
+		Pending: map[string]NotificationEvent{
+			event.Key: event,
+		},
+		Delivered: make(map[string]time.Time),
+	}
+
+	monitor.requeuePending(context.Background(), []string{"dest-1"})
+
+	monitor.stateMu.Lock()
+	assert.Empty(t, monitor.state.Destinations["dest-1"].Pending)
+	monitor.stateMu.Unlock()
+	require.Never(t, func() bool {
+		return len(monitor.currentBatcher().TakeReady()) > 0
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	status.AutoRetryCount = status.AutoRetryLimit
+	require.True(t, monitor.NotifyCompletion(status))
+
+	ready := waitForReadyBatch(t, monitor.currentBatcher())
+	require.Len(t, ready.Batch.Events, 1)
+	assert.Equal(t, status.AutoRetryLimit, ready.Batch.Events[0].Status.AutoRetryCount)
+}
+
 func TestNotificationMonitor_BootstrapFailureDoesNotReplayFromZeroCursor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -175,6 +175,9 @@ func (b *NotificationBatcher) Enqueue(destination string, event NotificationEven
 	if destination == "" || event.Status == nil || event.Key == "" {
 		return false
 	}
+	if shouldSuppressNotificationEvent(event) {
+		return false
+	}
 
 	eventType := event.Type
 	if eventType == "" {
@@ -416,6 +419,10 @@ func NotificationClassForEvent(eventType eventstore.EventType, status core.Statu
 			return NotificationClassUnknown, false
 		}
 	}
+}
+
+func shouldSuppressNotificationEvent(event NotificationEvent) bool {
+	return exec.CanCancelFailedAutoRetryPendingRun(event.Status)
 }
 
 // NotificationSeenKey is used by monitors to suppress repeated polling of the same status.

--- a/internal/service/chatbridge/notifications_test.go
+++ b/internal/service/chatbridge/notifications_test.go
@@ -79,6 +79,28 @@ func TestNotificationBatcher_DuplicateStatusDoesNotDuplicateBatch(t *testing.T) 
 	assert.Equal(t, core.Failed, ready.Batch.Events[0].Status.Status)
 }
 
+func TestNotificationBatcher_SkipsFailedRunWithAutoRetryRemaining(t *testing.T) {
+	t.Parallel()
+
+	batcher := NewNotificationBatcher(10*time.Millisecond, 20*time.Millisecond)
+	defer batcher.Stop()
+
+	status := &exec.DAGRunStatus{
+		Name:           "briefing",
+		DAGRunID:       "run-1",
+		AttemptID:      "a1",
+		Status:         core.Failed,
+		Error:          "boom",
+		AutoRetryCount: 0,
+		AutoRetryLimit: 2,
+	}
+
+	assert.False(t, batcher.Enqueue("dest-1", testNotificationEvent(status)))
+	require.Never(t, func() bool {
+		return len(batcher.TakeReady()) > 0
+	}, 50*time.Millisecond, 5*time.Millisecond)
+}
+
 func TestNotificationBatcher_RunningEventsUseInformationalClass(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- suppress agent-side DAG run failure notifications while DAG-level auto retry budget remains
- keep agent watches active until the failed run is truly terminal
- drop stale pending chatbridge notifications for failures that are still awaiting auto retry

## Changes
- treat failed root DAG runs with remaining auto retry budget as non-terminal for `dag_run_manage` watches
- skip chatbridge notification batching for the same pending-auto-retry failed states
- remove stale pending notification events for pending-auto-retry runs before requeueing
- add regression tests for watch notifications, batch suppression, and pending notification cleanup

## Related Issues
N/A

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Validation
- `go test ./internal/agent ./internal/service/chatbridge`
- `go test -race ./internal/agent ./internal/service/chatbridge`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failure notifications for runs with remaining automatic retries are deferred; notifications only send once retries are exhausted or canceled.

* **Improvements**
  * Requeueing and delivery logic now respects suppression rules and context, avoiding re-enqueue of suppressed pending items and skipping suppressed events.

* **Tests**
  * Added unit tests validating deferred notification, suppressed enqueueing, and correct requeue/drop behavior for retrying failed runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->