### PR TITLE
feat: add dag enqueue action

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Dagu includes built-in actions that run within the Dagu process (or worker). Loc
 | [`template.render`](https://docs.dagu.sh/step-types/template) | Text generation with template rendering |
 | [`router.route`](https://docs.dagu.sh/step-types/router) | Conditional step routing based on values and patterns |
 | [`dag.run`](https://docs.dagu.sh/writing-workflows/control-flow) | Invoke another DAG as a sub-workflow with params and dependencies |
+| [`dag.enqueue`](https://docs.dagu.sh/writing-workflows/control-flow) | Queue another DAG asynchronously and continue after enqueue |
 | [`harness.run`](https://docs.dagu.sh/step-types/harness) | Run coding agent CLIs such as Claude Code, Codex, Copilot, OpenCode, and Pi |
 | [`agent.run`](https://docs.dagu.sh/features/agent/step) | Built-in agent action with tool use |
 

--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -191,6 +191,7 @@ Current builtin actions:
 | `redis.<operation>` | Redis operations | Redis config; operation comes from the action suffix |
 | `jq.filter` | jq transforms | `filter`, plus `data` or `input` |
 | `dag.run` | Child DAG execution | `dag`, optional `params` |
+| `dag.enqueue` | Asynchronous child DAG enqueue | `dag`, optional `params`, optional `queue` |
 | `router.route` | Conditional routing | `value`, `routes` |
 | `chat.completion` | LLM chat completion | `prompt` or `messages`, model config |
 | `agent.run` | Agent step execution | `task`, `prompt`, or `messages`, agent config |
@@ -229,6 +230,8 @@ for an in-memory DuckDB database.
 
 ### Child DAG
 
+Use `dag.run` when the parent workflow must wait for the child DAG result:
+
 ```yaml
 steps:
   - id: process_account
@@ -240,7 +243,24 @@ steps:
         REGION: us-east-1
 ```
 
-`parallel:` currently requires `action: dag.run`:
+Use `dag.enqueue` when the parent only needs to create a queued child DAG run
+and continue:
+
+```yaml
+steps:
+  - id: queue_account_report
+    action: dag.enqueue
+    with:
+      dag: workflows/account-report
+      params:
+        ACCOUNT_ID: acct_123
+      queue: background
+```
+
+`dag.enqueue` accepts the same `with.dag` and `with.params` inputs as
+`dag.run`, plus `with.queue` to override the queued child run's queue.
+
+`parallel:` currently requires `action: dag.run` or `action: dag.enqueue`:
 
 ```yaml
 steps:

--- a/internal/cmd/dry.go
+++ b/internal/cmd/dry.go
@@ -84,6 +84,7 @@ func runDry(ctx *Context, args []string) error {
 		agent.Options{
 			Dry:                        true,
 			DAGRunStore:                ctx.DAGRunStore,
+			QueueStore:                 ctx.QueueStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
 			RootDAGRun:                 exec.NewDAGRunRef(dag.Name, dagRunID),
@@ -95,6 +96,8 @@ func runDry(ctx *Context, args []string) error {
 			AgentSoulStore:             as.SoulStore,
 			AgentOAuthManager:          as.OAuthManager,
 			AgentRemoteContextResolver: as.ContextResolver,
+			DAGRunLogDir:               ctx.Config.Paths.LogDir,
+			DAGRunArtifactDir:          ctx.Config.Paths.ArtifactDir,
 		},
 	)
 

--- a/internal/cmd/restart.go
+++ b/internal/cmd/restart.go
@@ -175,6 +175,7 @@ func executeDAGWithRunID(ctx *Context, cli runtime.Manager, dag *core.DAG, dagRu
 			ExtraEnvs:                  extraEnvs,
 			PreparedAttempt:            preparedAttempt,
 			DAGRunStore:                ctx.DAGRunStore,
+			QueueStore:                 ctx.QueueStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
 			RootDAGRun:                 exec.NewDAGRunRef(dag.Name, dagRunID),
@@ -188,6 +189,8 @@ func executeDAGWithRunID(ctx *Context, cli runtime.Manager, dag *core.DAG, dagRu
 			AgentRemoteContextResolver: as.ContextResolver,
 			ScheduleTime:               scheduleTime,
 			ArtifactDir:                artifactDir,
+			DAGRunLogDir:               ctx.Config.Paths.LogDir,
+			DAGRunArtifactDir:          ctx.Config.Paths.ArtifactDir,
 		})
 
 	listenSignals(ctx, agentInstance)

--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -435,6 +435,7 @@ func executeRetry(ctx *Context, dag *core.DAG, status *exec.DAGRunStatus, rootRu
 			AttemptID:                  attemptID,
 			PreparedAttempt:            preparedAttempt,
 			DAGRunStore:                ctx.DAGRunStore,
+			QueueStore:                 ctx.QueueStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
 			RootDAGRun:                 rootRun,
@@ -448,6 +449,8 @@ func executeRetry(ctx *Context, dag *core.DAG, status *exec.DAGRunStatus, rootRu
 			AgentOAuthManager:          as.OAuthManager,
 			AgentRemoteContextResolver: as.ContextResolver,
 			ArtifactDir:                artifactDir,
+			DAGRunLogDir:               ctx.Config.Paths.LogDir,
+			DAGRunArtifactDir:          ctx.Config.Paths.ArtifactDir,
 		},
 	)
 

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -527,6 +527,7 @@ func executeDAGRun(ctx *Context, d *core.DAG, parent exec.DAGRunRef, dagRunID st
 			QueuedRun:                  queuedRun,
 			PreparedAttempt:            preparedAttempt,
 			DAGRunStore:                ctx.DAGRunStore,
+			QueueStore:                 ctx.QueueStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
 			RootDAGRun:                 root,
@@ -541,6 +542,8 @@ func executeDAGRun(ctx *Context, d *core.DAG, parent exec.DAGRunRef, dagRunID st
 			AgentRemoteContextResolver: as.ContextResolver,
 			ScheduleTime:               scheduleTime,
 			ArtifactDir:                artifactDir,
+			DAGRunLogDir:               ctx.Config.Paths.LogDir,
+			DAGRunArtifactDir:          ctx.Config.Paths.ArtifactDir,
 		},
 	)
 

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -1941,7 +1941,7 @@
               "description": "Parallel execution configuration with concurrency control"
             }
           ],
-          "description": "Configuration for parallel execution of child DAGs. Currently only valid with action: dag.run. Allows processing multiple items concurrently using the same workflow definition."
+          "description": "Configuration for parallel execution of child DAGs. Currently only valid with action: dag.run or dag.enqueue. Allows processing multiple items concurrently using the same workflow definition."
         },
         "worker_selector": {
           "oneOf": [
@@ -2119,6 +2119,18 @@
             "required": ["with"],
             "properties": {
               "with": { "$ref": "#/definitions/dagRunActionConfig" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "action": { "const": "dag.enqueue" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/dagEnqueueActionConfig" }
             }
           }
         },
@@ -5928,6 +5940,7 @@
         "shell",
         "docker",
         "container",
+        "dag_enqueue",
         "file",
         "git",
         "kubernetes",
@@ -5982,6 +5995,7 @@
             "artifact.write",
             "chat.completion",
             "container.run",
+            "dag.enqueue",
             "dag.run",
             "data.convert",
             "data.pick",
@@ -6113,6 +6127,38 @@
         }
       },
       "description": "Configuration for action: dag.run."
+    },
+    "dagEnqueueActionConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dag"],
+      "properties": {
+        "dag": {
+          "type": "string",
+          "description": "Child DAG name or path."
+        },
+        "params": {
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  { "type": "string" },
+                  { "type": "object", "additionalProperties": true }
+                ]
+              }
+            },
+            { "type": "object", "additionalProperties": true }
+          ],
+          "description": "Parameters passed to the queued child DAG."
+        },
+        "queue": {
+          "type": "string",
+          "description": "Optional queue name override for the queued child DAG run."
+        }
+      },
+      "description": "Configuration for action: dag.enqueue."
     },
     "httpRequestActionConfig": {
       "allOf": [

--- a/internal/core/exec/context.go
+++ b/internal/core/exec/context.go
@@ -29,6 +29,10 @@ type Context struct {
 	BaseEnv            *config.BaseEnv
 	EnvScope           *eval.EnvScope // Unified environment scope - THE single source for all env vars
 	CoordinatorCli     Dispatcher
+	DAGRunStore        DAGRunStore
+	QueueStore         QueueStore
+	DAGRunLogDir       string
+	DAGRunArtifactDir  string
 	Shell              string               // Default shell for this DAG (from DAG.Shell)
 	LogEncodingCharset string               // Character encoding for log files (e.g., "utf-8", "shift_jis", "euc-jp")
 	LogWriterFactory   LogWriterFactory     // For remote log streaming (nil = use local files)
@@ -202,6 +206,10 @@ type contextOptions struct {
 	logEncodingCharset string
 	logWriterFactory   LogWriterFactory
 	defaultExecMode    config.ExecutionMode
+	dagRunStore        DAGRunStore
+	queueStore         QueueStore
+	dagRunLogDir       string
+	dagRunArtifactDir  string
 	workDir            string
 	artifactDir        string
 }
@@ -273,6 +281,34 @@ func WithDefaultExecMode(mode config.ExecutionMode) ContextOption {
 	}
 }
 
+// WithDAGRunStore sets the dag-run store for executors that persist DAG runs.
+func WithDAGRunStore(store DAGRunStore) ContextOption {
+	return func(o *contextOptions) {
+		o.dagRunStore = store
+	}
+}
+
+// WithQueueStore sets the queue store for executors that enqueue DAG runs.
+func WithQueueStore(store QueueStore) ContextOption {
+	return func(o *contextOptions) {
+		o.queueStore = store
+	}
+}
+
+// WithDAGRunLogDir sets the base log directory for newly persisted DAG runs.
+func WithDAGRunLogDir(dir string) ContextOption {
+	return func(o *contextOptions) {
+		o.dagRunLogDir = dir
+	}
+}
+
+// WithDAGRunArtifactDir sets the base artifact directory for newly persisted DAG runs.
+func WithDAGRunArtifactDir(dir string) ContextOption {
+	return func(o *contextOptions) {
+		o.dagRunArtifactDir = dir
+	}
+}
+
 // WithWorkDir sets the per-DAG-run working directory path.
 func WithWorkDir(dir string) ContextOption {
 	return func(o *contextOptions) {
@@ -340,6 +376,10 @@ func NewContext(
 		DAGRunID:           dagRunID,
 		BaseEnv:            config.GetBaseEnv(ctx),
 		CoordinatorCli:     options.coordinator,
+		DAGRunStore:        options.dagRunStore,
+		QueueStore:         options.queueStore,
+		DAGRunLogDir:       options.dagRunLogDir,
+		DAGRunArtifactDir:  options.dagRunArtifactDir,
 		Shell:              dag.Shell,
 		LogEncodingCharset: options.logEncodingCharset,
 		LogWriterFactory:   options.logWriterFactory,

--- a/internal/core/parallel_test.go
+++ b/internal/core/parallel_test.go
@@ -133,7 +133,7 @@ steps:
     parallel: ${ITEMS}
 `,
 			wantErr:    true,
-			wantErrMsg: "parallel currently requires action: dag.run",
+			wantErrMsg: "parallel currently requires action: dag.run or dag.enqueue",
 		},
 		{
 			name: "ErrorParallelWithoutCommandOrRun",

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -61,8 +61,8 @@ func TestMain(m *testing.M) {
 	core.RegisterExecutorCapabilities("wait", core.ExecutorCapabilities{Command: true})
 	// git: supports command only
 	core.RegisterExecutorCapabilities("git", core.ExecutorCapabilities{Command: true})
-	// dag/subworkflow/parallel: support SubDAG and WorkerSelector
-	for _, t := range []string{"dag", "subworkflow", "parallel"} {
+	// dag/subworkflow/parallel/dag_enqueue: support SubDAG and WorkerSelector
+	for _, t := range []string{"dag", "subworkflow", "parallel", core.ExecutorTypeDAGEnqueue} {
 		core.RegisterExecutorCapabilities(t, core.ExecutorCapabilities{
 			SubDAG: true, WorkerSelector: true,
 		})

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -77,6 +77,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"container":     {},
 	"dag":           {},
 	"data":          {},
+	"dag_enqueue":   {},
 	"docker":        {},
 	"duckdb":        {},
 	"file":          {},

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -48,6 +48,7 @@ var builtinActionNormalizers = map[string]actionNormalizer{
 	"archive.list":    operationAction("archive", "list"),
 	"chat.completion": normalizeChatAction,
 	"container.run":   optionalCommandAction("container", "command"),
+	"dag.enqueue":     normalizeDagEnqueueAction,
 	"dag.run":         normalizeDagRunAction,
 	"data.convert":    operationAction("data", "convert"),
 	"data.pick":       operationAction("data", "pick"),
@@ -291,6 +292,34 @@ func normalizeDagRunAction(normalized map[string]any, with map[string]any) error
 		normalized["params"] = cloneAny(params)
 	}
 	delete(normalized, "with")
+	delete(normalized, "action")
+	return nil
+}
+
+func normalizeDagEnqueueAction(normalized map[string]any, with map[string]any) error {
+	dagName, err := requireActionStringField(with, "dag")
+	if err != nil {
+		return err
+	}
+	for key := range with {
+		if key != "dag" && key != "params" && key != "queue" {
+			return core.NewValidationError("with", with, fmt.Errorf("dag.enqueue does not support with.%s", key))
+		}
+	}
+	normalized["type"] = core.ExecutorTypeDAGEnqueue
+	normalized["call"] = dagName
+	if params, ok := with["params"]; ok {
+		normalized["params"] = cloneAny(params)
+	}
+	config := make(map[string]any)
+	if queue, ok := with["queue"]; ok {
+		config["queue"] = cloneAny(queue)
+	}
+	if len(config) > 0 {
+		normalized["with"] = config
+	} else {
+		delete(normalized, "with")
+	}
 	delete(normalized, "action")
 	return nil
 }

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -82,6 +82,68 @@ steps:
 	assert.Equal(t, "a", step.Parallel.Items[0].Params["id"])
 }
 
+func TestStepSchemaV2_ActionDagEnqueue(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: enqueue_child
+    action: dag.enqueue
+    with:
+      dag: account_workflow
+      params:
+        account_id: "42"
+      queue: background
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, core.ExecutorTypeDAGEnqueue, step.ExecutorConfig.Type)
+	require.NotNil(t, step.SubDAG)
+	assert.Equal(t, "account_workflow", step.SubDAG.Name)
+	assert.Contains(t, step.SubDAG.Params, `account_id="42"`)
+	assert.Equal(t, "background", step.ExecutorConfig.Config["queue"])
+}
+
+func TestStepSchemaV2_ActionDagEnqueueParallel(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: enqueue_fanout
+    parallel:
+      items:
+        - id: a
+          region: us
+        - id: b
+          region: eu
+      max_concurrent: 2
+    action: dag.enqueue
+    with:
+      dag: account_workflow
+      params:
+        account_id: ${ITEM.id}
+        region: ${ITEM.region}
+      queue: background
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, core.ExecutorTypeDAGEnqueue, step.ExecutorConfig.Type)
+	require.NotNil(t, step.SubDAG)
+	assert.Equal(t, "account_workflow", step.SubDAG.Name)
+	assert.Contains(t, step.SubDAG.Params, `${ITEM.id}`)
+	assert.Contains(t, step.SubDAG.Params, `${ITEM.region}`)
+	assert.Equal(t, "background", step.ExecutorConfig.Config["queue"])
+	require.NotNil(t, step.Parallel)
+	assert.Equal(t, 2, step.Parallel.MaxConcurrent)
+	require.Len(t, step.Parallel.Items, 2)
+	assert.Equal(t, "a", step.Parallel.Items[0].Params["id"])
+	assert.Equal(t, "eu", step.Parallel.Items[1].Params["region"])
+}
+
 func TestStepSchemaV2_ActionParallelRejectsNonDAG(t *testing.T) {
 	t.Parallel()
 
@@ -95,7 +157,7 @@ steps:
       url: https://example.com
 `))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `parallel currently requires action: dag.run`)
+	assert.Contains(t, err.Error(), `parallel currently requires action: dag.run or dag.enqueue`)
 }
 
 func TestStepSchemaV2_ActionHTTPRequest(t *testing.T) {

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -393,6 +393,9 @@ const (
 	// ExecutorTypeDAG is the executor type for a sub DAG.
 	ExecutorTypeDAG = "dag"
 
+	// ExecutorTypeDAGEnqueue is the executor type for asynchronously queueing a sub DAG.
+	ExecutorTypeDAGEnqueue = "dag_enqueue"
+
 	// ExecutorTypeParallel is the executor type for parallel steps.
 	ExecutorTypeParallel = "parallel"
 

--- a/internal/core/validator.go
+++ b/internal/core/validator.go
@@ -267,7 +267,7 @@ func validateParallelConfig(step Step) ErrorList {
 	var errs ErrorList
 
 	if step.SubDAG == nil {
-		errs = append(errs, NewValidationError("parallel", step.Parallel, fmt.Errorf("parallel currently requires action: dag.run")))
+		errs = append(errs, NewValidationError("parallel", step.Parallel, fmt.Errorf("parallel currently requires action: dag.run or dag.enqueue")))
 	}
 
 	if step.Parallel.MaxConcurrent <= 0 {

--- a/internal/core/validator_test.go
+++ b/internal/core/validator_test.go
@@ -375,7 +375,7 @@ func TestValidateSteps(t *testing.T) {
 		}
 		err := ValidateSteps(dag)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "parallel currently requires action: dag.run")
+		assert.Contains(t, err.Error(), "parallel currently requires action: dag.run or dag.enqueue")
 	})
 
 	t.Run("parallel config with max_concurrent 0 fails", func(t *testing.T) {

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -75,6 +75,9 @@ type Agent struct {
 	// dagRunStore is the database to store the run history.
 	dagRunStore exec.DAGRunStore
 
+	// queueStore is the database to store queued dag-run items.
+	queueStore exec.QueueStore
+
 	// secretStore resolves workspace-local team-managed secret references.
 	secretStore secretpkg.Store
 
@@ -110,6 +113,12 @@ type Agent struct {
 
 	// artifactDir is the per-run artifact directory when artifact storage is enabled.
 	artifactDir string
+
+	// dagRunLogDir is the base log directory for newly persisted child DAG runs.
+	dagRunLogDir string
+
+	// dagRunArtifactDir is the base artifact directory for newly persisted child DAG runs.
+	dagRunArtifactDir string
 
 	// artifactFinalizer persists artifacts before the final terminal status is written.
 	artifactFinalizer ArtifactFinalizer
@@ -281,6 +290,8 @@ type Options struct {
 	PreparedAttempt exec.DAGRunAttempt
 	// DAGRunStore is the store for dag-run data. Nil in shared-nothing mode.
 	DAGRunStore exec.DAGRunStore
+	// QueueStore is the store for queued dag-run items. Nil when queues are unavailable.
+	QueueStore exec.QueueStore
 	// SecretStore resolves workspace-local team-managed secret references.
 	SecretStore secretpkg.Store
 	// ServiceRegistry is the registry for service discovery.
@@ -310,6 +321,10 @@ type Options struct {
 	ScheduleTime string
 	// ArtifactDir is the per-run artifact directory when artifact storage is enabled.
 	ArtifactDir string
+	// DAGRunLogDir is the base log directory used for child DAG runs created by executors.
+	DAGRunLogDir string
+	// DAGRunArtifactDir is the base artifact directory used for child DAG runs created by executors.
+	DAGRunArtifactDir string
 	// ArtifactFinalizer persists artifacts before the final terminal status is written.
 	ArtifactFinalizer ArtifactFinalizer
 	// SocketServerFactory creates the local status/control transport.
@@ -341,6 +356,7 @@ func New(
 		dagRunMgr:                  drm,
 		dagStore:                   ds,
 		dagRunStore:                opts.DAGRunStore,
+		queueStore:                 opts.QueueStore,
 		secretStore:                opts.SecretStore,
 		registry:                   opts.ServiceRegistry,
 		extraEnvs:                  append([]string{}, opts.ExtraEnvs...),
@@ -361,6 +377,8 @@ func New(
 		agentOAuthManager:          opts.AgentOAuthManager,
 		agentRemoteContextResolver: opts.AgentRemoteContextResolver,
 		scheduleTime:               opts.ScheduleTime,
+		dagRunLogDir:               opts.DAGRunLogDir,
+		dagRunArtifactDir:          opts.DAGRunArtifactDir,
 		socketServerFactory:        opts.SocketServerFactory,
 	}
 	if a.socketServerFactory == nil {
@@ -536,6 +554,18 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 	if a.artifactDir != "" {
 		contextOpts = append(contextOpts, runtime.WithArtifactDir(a.artifactDir))
+	}
+	if a.dagRunStore != nil {
+		contextOpts = append(contextOpts, runtime.WithDAGRunStore(a.dagRunStore))
+	}
+	if a.queueStore != nil {
+		contextOpts = append(contextOpts, runtime.WithQueueStore(a.queueStore))
+	}
+	if a.dagRunLogDir != "" {
+		contextOpts = append(contextOpts, runtime.WithDAGRunLogDir(a.dagRunLogDir))
+	}
+	if a.dagRunArtifactDir != "" {
+		contextOpts = append(contextOpts, runtime.WithDAGRunArtifactDir(a.dagRunArtifactDir))
 	}
 	if a.logWriterFactory != nil {
 		contextOpts = append(contextOpts, runtime.WithLogWriterFactory(a.logWriterFactory))
@@ -1671,6 +1701,18 @@ func (a *Agent) dryRun(ctx context.Context) error {
 	}
 	if a.artifactDir != "" {
 		contextOpts = append(contextOpts, runtime.WithArtifactDir(a.artifactDir))
+	}
+	if a.dagRunStore != nil {
+		contextOpts = append(contextOpts, runtime.WithDAGRunStore(a.dagRunStore))
+	}
+	if a.queueStore != nil {
+		contextOpts = append(contextOpts, runtime.WithQueueStore(a.queueStore))
+	}
+	if a.dagRunLogDir != "" {
+		contextOpts = append(contextOpts, runtime.WithDAGRunLogDir(a.dagRunLogDir))
+	}
+	if a.dagRunArtifactDir != "" {
+		contextOpts = append(contextOpts, runtime.WithDAGRunArtifactDir(a.dagRunArtifactDir))
 	}
 	dagCtx := runtime.NewContext(ctx, a.dag, a.dagRunID, a.logFile, contextOpts...)
 	lastErr := a.runner.Run(dagCtx, a.plan, progressCh)

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -1232,9 +1232,11 @@ steps:
 		return err == nil && childStatus.Status == core.Succeeded
 	}, subDAGVisibleTimeout(), 100*time.Millisecond)
 
-	length, err := th.QueueStore.Len(th.Context, "background")
-	require.NoError(t, err)
-	require.Zero(t, length)
+	require.Eventually(t, func() bool {
+		processor.ProcessQueueItems(th.Context, "background")
+		length, err := th.QueueStore.Len(th.Context, "background")
+		return err == nil && length == 0
+	}, subDAGVisibleTimeout(), 100*time.Millisecond)
 }
 
 func subDAGVisibleTimeout() time.Duration {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -16,13 +16,16 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/crypto"
 	"github.com/dagucloud/dagu/internal/cmn/sock"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis/filesecret"
+	runtimepkg "github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	"github.com/dagucloud/dagu/internal/service/scheduler"
 	"github.com/dagucloud/dagu/internal/test"
 
 	"github.com/stretchr/testify/require"
@@ -1101,6 +1104,137 @@ steps:
 
 	require.NoError(t, os.WriteFile(releaseFile, []byte("done"), 0600))
 	require.NoError(t, <-runErr)
+}
+
+func TestAgent_DAGEnqueueQueuesChildWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+	releaseFile := filepath.Join(t.TempDir(), "release-child")
+	t.Cleanup(func() {
+		_ = os.WriteFile(releaseFile, []byte("done"), 0600)
+	})
+
+	th.CreateDAGFile(t, th.Config.Paths.DAGsDir, "child-enqueued", fmt.Appendf(nil, `
+params:
+  - TARGET: default
+  - OTHER: keep
+steps:
+  - name: wait
+    run: %q
+`, waitForFileScript(releaseFile, 100*time.Millisecond)))
+
+	parent := th.DAG(t, `
+type: graph
+steps:
+  - name: enqueue-child
+    action: dag.enqueue
+    with:
+      dag: child-enqueued
+      params:
+        TARGET: async
+      queue: background
+`)
+
+	a := parent.Agent()
+	a.RunSuccess(t)
+
+	status := a.Status(parent.Context)
+	require.Len(t, status.Nodes, 1)
+	require.Len(t, status.Nodes[0].SubRuns, 1)
+	subRun := status.Nodes[0].SubRuns[0]
+	require.Equal(t, "child-enqueued", subRun.DAGName)
+	require.Contains(t, subRun.Params, `TARGET="async"`)
+
+	items, err := th.QueueStore.List(th.Context, "background")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	ref, err := items[0].Data()
+	require.NoError(t, err)
+	require.Equal(t, exec.NewDAGRunRef("child-enqueued", subRun.DAGRunID), *ref)
+
+	attempt, err := th.DAGRunStore.FindAttempt(th.Context, *ref)
+	require.NoError(t, err)
+	childStatus, err := attempt.ReadStatus(th.Context)
+	require.NoError(t, err)
+	require.Equal(t, core.Queued, childStatus.Status)
+	require.Equal(t, core.TriggerTypeSubDAG, childStatus.TriggerType)
+	require.Equal(t, []string{"TARGET=async", "OTHER=keep"}, childStatus.ParamsList)
+	require.Equal(t, *ref, childStatus.Root)
+	require.True(t, childStatus.Parent.Zero())
+}
+
+func TestAgent_DAGEnqueueQueuedChildRunsFromQueue(t *testing.T) {
+	t.Parallel()
+
+	outputFile := filepath.Join(t.TempDir(), "child-output")
+	th := test.Setup(t,
+		test.WithBuiltExecutable(),
+		test.WithConfigMutator(func(cfg *config.Config) {
+			cfg.Queues.Enabled = true
+			cfg.Queues.Config = append(cfg.Queues.Config, config.QueueConfig{
+				Name:          "background",
+				MaxActiveRuns: 1,
+			})
+		}),
+	)
+
+	th.CreateDAGFile(t, th.Config.Paths.DAGsDir, "child-queue-exec", fmt.Appendf(nil, `
+steps:
+  - name: write-output
+    run: %q
+`, writeFileCommand(outputFile, "done")))
+
+	parent := th.DAG(t, `
+type: graph
+steps:
+  - name: enqueue-child
+    action: dag.enqueue
+    with:
+      dag: child-queue-exec
+      queue: background
+`)
+
+	a := parent.Agent()
+	a.RunSuccess(t)
+
+	status := a.Status(parent.Context)
+	require.Len(t, status.Nodes, 1)
+	require.Len(t, status.Nodes[0].SubRuns, 1)
+	subRun := status.Nodes[0].SubRuns[0]
+	ref := exec.NewDAGRunRef("child-queue-exec", subRun.DAGRunID)
+
+	dagExecutor := scheduler.NewDAGExecutor(
+		nil,
+		runtimepkg.NewSubCmdBuilder(th.Config),
+		th.Config.DefaultExecMode,
+		th.Config.Paths.BaseConfig,
+		nil,
+	)
+	processor := scheduler.NewQueueProcessor(
+		th.QueueStore,
+		th.DAGRunStore,
+		th.ProcStore,
+		dagExecutor,
+		th.Config.Queues,
+		scheduler.WithBackoffConfig(scheduler.BackoffConfig{
+			InitialInterval: 100 * time.Millisecond,
+			MaxInterval:     250 * time.Millisecond,
+			MaxRetries:      20,
+		}),
+	)
+	processor.ProcessQueueItems(th.Context, "background")
+
+	waitForTestFile(t, outputFile, subDAGVisibleTimeout())
+	require.Eventually(t, func() bool {
+		childStatus, err := th.DAGRunMgr.GetSavedStatus(th.Context, ref)
+		return err == nil && childStatus.Status == core.Succeeded
+	}, subDAGVisibleTimeout(), 100*time.Millisecond)
+
+	length, err := th.QueueStore.Len(th.Context, "background")
+	require.NoError(t, err)
+	require.Zero(t, length)
 }
 
 func subDAGVisibleTimeout() time.Duration {

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -1,0 +1,360 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dag
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/logpath"
+	"github.com/dagucloud/dagu/internal/cmn/stringutil"
+	"github.com/dagucloud/dagu/internal/core"
+	exec1 "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
+)
+
+const dagEnqueueQueueConfigKey = "queue"
+
+var _ executor.DAGExecutor = (*enqueueExecutor)(nil)
+var _ executor.ParallelExecutor = (*enqueueExecutor)(nil)
+var _ executor.SubRunProvider = (*enqueueExecutor)(nil)
+
+type enqueueExecutor struct {
+	step core.Step
+
+	lock          sync.Mutex
+	stdout        io.Writer
+	stderr        io.Writer
+	runParams     executor.RunParams
+	runParamsList []executor.RunParams
+	subRuns       []exec1.SubDAGRun
+}
+
+type enqueueRunOutput struct {
+	Name          string `json:"name"`
+	DAGRunID      string `json:"dagRunId"`
+	Params        string `json:"params,omitempty"`
+	Queue         string `json:"queue"`
+	Status        string `json:"status"`
+	AlreadyExists bool   `json:"alreadyExists,omitempty"`
+}
+
+type enqueueRunsOutput struct {
+	Summary struct {
+		Total  int `json:"total"`
+		Queued int `json:"queued"`
+	} `json:"summary"`
+	Runs []enqueueRunOutput `json:"runs"`
+}
+
+func newEnqueueExecutor(_ context.Context, step core.Step) (executor.Executor, error) {
+	if step.SubDAG == nil {
+		return nil, fmt.Errorf("sub DAG configuration is missing")
+	}
+
+	if rawQueue, ok := step.ExecutorConfig.Config[dagEnqueueQueueConfigKey]; ok {
+		queue, ok := rawQueue.(string)
+		if !ok {
+			return nil, fmt.Errorf("dag.enqueue with.queue must be a string")
+		}
+		step.ExecutorConfig.Config[dagEnqueueQueueConfigKey] = strings.TrimSpace(queue)
+	}
+
+	return &enqueueExecutor{step: step}, nil
+}
+
+func (e *enqueueExecutor) Run(ctx context.Context) error {
+	paramsList, parallel := e.paramsSnapshot()
+	if len(paramsList) == 0 {
+		return fmt.Errorf("no sub DAG runs to enqueue")
+	}
+
+	outputs := make([]enqueueRunOutput, 0, len(paramsList))
+	subRuns := make([]exec1.SubDAGRun, 0, len(paramsList))
+	for _, params := range paramsList {
+		output, err := e.enqueueOne(ctx, params)
+		if err != nil {
+			return err
+		}
+		outputs = append(outputs, output)
+		subRuns = append(subRuns, exec1.SubDAGRun{
+			DAGRunID: output.DAGRunID,
+			Params:   output.Params,
+			DAGName:  output.Name,
+		})
+	}
+
+	e.lock.Lock()
+	e.subRuns = subRuns
+	e.lock.Unlock()
+
+	return e.writeOutput(outputs, parallel)
+}
+
+func (e *enqueueExecutor) enqueueOne(ctx context.Context, runParams executor.RunParams) (enqueueRunOutput, error) {
+	if runParams.RunID == "" {
+		return enqueueRunOutput{}, fmt.Errorf("DAG run ID is not set")
+	}
+
+	rCtx := runtime.GetDAGContext(ctx)
+	if rCtx.DAGRunStore == nil {
+		return enqueueRunOutput{}, fmt.Errorf("dag.enqueue requires a DAG run store")
+	}
+	if rCtx.QueueStore == nil {
+		return enqueueRunOutput{}, fmt.Errorf("dag.enqueue requires a queue store")
+	}
+	if !config.GetConfig(ctx).Queues.Enabled {
+		return enqueueRunOutput{}, fmt.Errorf("queues are disabled in configuration")
+	}
+
+	target := runParams.DAGName
+	if target == "" && e.step.SubDAG != nil {
+		target = e.step.SubDAG.Name
+	}
+	if target == "" {
+		return enqueueRunOutput{}, fmt.Errorf("sub DAG name is not set")
+	}
+
+	child, err := executor.NewSubDAGExecutor(ctx, target)
+	if err != nil {
+		return enqueueRunOutput{}, err
+	}
+	defer func() {
+		if err := child.Cleanup(context.WithoutCancel(ctx)); err != nil {
+			logger.Error(ctx, "Failed to cleanup sub DAG executor", tag.Error(err))
+		}
+	}()
+
+	if len(e.step.WorkerSelector) > 0 && child.DAG.HasApprovalSteps() {
+		return enqueueRunOutput{}, fmt.Errorf("%w: %s", ErrApprovalStepsWithWorker, target)
+	}
+
+	dagCopy, err := spec.ResolveRuntimeParams(ctx, child.DAG, runParams.Params, spec.ResolveRuntimeParamsOptions{
+		BaseConfig: config.GetConfig(ctx).Paths.BaseConfig,
+	})
+	if err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to resolve sub DAG params: %w", err)
+	}
+	dagCopy = dagCopy.Clone()
+	dagCopy.Location = ""
+	if len(e.step.WorkerSelector) > 0 {
+		dagCopy.WorkerSelector = maps.Clone(e.step.WorkerSelector)
+	}
+
+	queueName := dagCopy.ProcGroup()
+	if queueOverride := e.queueOverride(); queueOverride != "" {
+		dagCopy.Queue = queueOverride
+		queueName = queueOverride
+	}
+
+	dagRun := exec1.NewDAGRunRef(dagCopy.Name, runParams.RunID)
+	if existing, err := rCtx.DAGRunStore.FindAttempt(ctx, dagRun); err == nil {
+		return e.outputFromExisting(ctx, existing, dagCopy.Name, runParams, queueName), nil
+	} else if !errors.Is(err, exec1.ErrDAGRunIDNotFound) {
+		return enqueueRunOutput{}, fmt.Errorf("failed to check existing DAG run: %w", err)
+	}
+
+	logFile, err := logpath.Generate(ctx, rCtx.DAGRunLogDir, dagCopy.LogDir, dagCopy.Name, runParams.RunID)
+	if err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to generate log file name: %w", err)
+	}
+
+	artifactDir := ""
+	if dagCopy.ArtifactsEnabled() {
+		artifactDir, err = logpath.GenerateDir(ctx, rCtx.DAGRunArtifactDir, dagCopy.Artifacts.Dir, dagCopy.Name, runParams.RunID)
+		if err != nil {
+			return enqueueRunOutput{}, fmt.Errorf("failed to generate artifact directory: %w", err)
+		}
+	}
+
+	attempt, err := rCtx.DAGRunStore.CreateAttempt(ctx, dagCopy, time.Now(), runParams.RunID, exec1.NewDAGRunAttemptOptions{})
+	if err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to create queued DAG run: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if rmErr := rCtx.DAGRunStore.RemoveDAGRun(ctx, dagRun); rmErr != nil {
+			logger.Error(ctx, "Failed to rollback queued DAG run",
+				tag.DAG(dagCopy.Name),
+				tag.RunID(runParams.RunID),
+				tag.Error(rmErr),
+			)
+		}
+	}()
+
+	queuedAt := stringutil.FormatTime(time.Now())
+	status := transform.NewStatusBuilder(dagCopy).Create(
+		runParams.RunID,
+		core.Queued,
+		0,
+		time.Time{},
+		transform.WithLogFilePath(logFile),
+		transform.WithArchiveDir(artifactDir),
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithPreconditions(dagCopy.Preconditions),
+		transform.WithQueuedAt(queuedAt),
+		transform.WithHierarchyRefs(dagRun, exec1.DAGRunRef{}),
+		transform.WithTriggerType(core.TriggerTypeSubDAG),
+	)
+
+	if err := attempt.Open(ctx); err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to open queued DAG run: %w", err)
+	}
+	if err := attempt.Write(ctx, status); err != nil {
+		_ = attempt.Close(ctx)
+		return enqueueRunOutput{}, fmt.Errorf("failed to save queued DAG run status: %w", err)
+	}
+	if err := attempt.Close(ctx); err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to close queued DAG run: %w", err)
+	}
+
+	if err := rCtx.QueueStore.Enqueue(ctx, queueName, exec1.QueuePriorityLow, dagRun); err != nil {
+		return enqueueRunOutput{}, fmt.Errorf("failed to enqueue DAG run: %w", err)
+	}
+	committed = true
+
+	logger.Info(ctx, "Enqueued sub DAG run",
+		tag.DAG(dagCopy.Name),
+		tag.RunID(runParams.RunID),
+		tag.Queue(queueName),
+		slog.Any("params", dagCopy.Params),
+	)
+
+	return enqueueRunOutput{
+		Name:     dagCopy.Name,
+		DAGRunID: runParams.RunID,
+		Params:   runParams.Params,
+		Queue:    queueName,
+		Status:   core.Queued.String(),
+	}, nil
+}
+
+func (e *enqueueExecutor) outputFromExisting(ctx context.Context, attempt exec1.DAGRunAttempt, dagName string, params executor.RunParams, queueName string) enqueueRunOutput {
+	statusText := core.Queued.String()
+	if status, err := attempt.ReadStatus(ctx); err == nil && status != nil {
+		statusText = status.Status.String()
+	}
+	return enqueueRunOutput{
+		Name:          dagName,
+		DAGRunID:      params.RunID,
+		Params:        params.Params,
+		Queue:         queueName,
+		Status:        statusText,
+		AlreadyExists: true,
+	}
+}
+
+func (e *enqueueExecutor) queueOverride() string {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	queue, _ := e.step.ExecutorConfig.Config[dagEnqueueQueueConfigKey].(string)
+	return strings.TrimSpace(queue)
+}
+
+func (e *enqueueExecutor) writeOutput(outputs []enqueueRunOutput, parallel bool) error {
+	if e.stdout == nil {
+		return nil
+	}
+
+	var payload any
+	if !parallel && len(outputs) == 1 {
+		payload = outputs[0]
+	} else {
+		summary := enqueueRunsOutput{Runs: outputs}
+		summary.Summary.Total = len(outputs)
+		for _, output := range outputs {
+			if output.Status == core.Queued.String() && !output.AlreadyExists {
+				summary.Summary.Queued++
+			}
+		}
+		payload = summary
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal enqueue output: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := e.stdout.Write(data); err != nil {
+		return fmt.Errorf("failed to write enqueue output: %w", err)
+	}
+	return nil
+}
+
+func (e *enqueueExecutor) paramsSnapshot() ([]executor.RunParams, bool) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if len(e.runParamsList) > 0 {
+		return append([]executor.RunParams(nil), e.runParamsList...), true
+	}
+	if e.runParams.RunID != "" {
+		return []executor.RunParams{e.runParams}, false
+	}
+	return nil, false
+}
+
+func (e *enqueueExecutor) SetParams(params executor.RunParams) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.runParams = params
+	e.runParamsList = nil
+}
+
+func (e *enqueueExecutor) SetParamsList(paramsList []executor.RunParams) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.runParams = executor.RunParams{}
+	e.runParamsList = append([]executor.RunParams(nil), paramsList...)
+}
+
+func (e *enqueueExecutor) GetSubRuns() []exec1.SubDAGRun {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	return append([]exec1.SubDAGRun(nil), e.subRuns...)
+}
+
+func (e *enqueueExecutor) SetStdout(out io.Writer) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.stdout = out
+}
+
+func (e *enqueueExecutor) SetStderr(out io.Writer) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.stderr = out
+}
+
+func (e *enqueueExecutor) Kill(os.Signal) error {
+	return nil
+}
+
+func init() {
+	caps := core.ExecutorCapabilities{
+		SubDAG:         true,
+		WorkerSelector: true,
+	}
+	executor.RegisterExecutor(core.ExecutorTypeDAGEnqueue, newEnqueueExecutor, nil, caps)
+}

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -69,11 +69,9 @@ func newEnqueueExecutor(_ context.Context, step core.Step) (executor.Executor, e
 	}
 
 	if rawQueue, ok := step.ExecutorConfig.Config[dagEnqueueQueueConfigKey]; ok {
-		queue, ok := rawQueue.(string)
-		if !ok {
+		if _, ok := rawQueue.(string); !ok {
 			return nil, fmt.Errorf("dag.enqueue with.queue must be a string")
 		}
-		step.ExecutorConfig.Config[dagEnqueueQueueConfigKey] = strings.TrimSpace(queue)
 	}
 
 	return &enqueueExecutor{step: step}, nil

--- a/internal/runtime/context.go
+++ b/internal/runtime/context.go
@@ -47,6 +47,14 @@ var (
 	WithLogWriterFactory = exec.WithLogWriterFactory
 	// WithDefaultExecMode sets the server-level default execution mode.
 	WithDefaultExecMode = exec.WithDefaultExecMode
+	// WithDAGRunStore sets the dag-run store.
+	WithDAGRunStore = exec.WithDAGRunStore
+	// WithQueueStore sets the queue store.
+	WithQueueStore = exec.WithQueueStore
+	// WithDAGRunLogDir sets the base log directory for newly persisted DAG runs.
+	WithDAGRunLogDir = exec.WithDAGRunLogDir
+	// WithDAGRunArtifactDir sets the base artifact directory for newly persisted DAG runs.
+	WithDAGRunArtifactDir = exec.WithDAGRunArtifactDir
 	// WithWorkDir sets the per-DAG-run working directory path.
 	WithWorkDir = exec.WithWorkDir
 	// WithArtifactDir sets the per-DAG-run artifact directory path.

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1255,7 +1255,7 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 		return nil, err
 	}
 	rootRef := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, rootRef, request.SubDAGRunId)
+	mutationRef, dagStatus, err := a.getReferencedDAGRunStatusWithRef(ctx, rootRef, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.ApproveSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1265,7 +1265,7 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 	if err := a.requireDAGRunStatusExecute(ctx, dagStatus); err != nil {
 		return nil, err
 	}
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, rootRef, request.SubDAGRunId)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, rootRef, request.SubDAGRunId, dagStatus.Name)
 	if err != nil {
 		return &api.ApproveSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1301,7 +1301,7 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 
 	applyApproval(ctx, dagStatus.Nodes[stepIdx], request.Body)
 
-	if err := a.updateDAGRunStatus(ctx, rootRef, *dagStatus); err != nil {
+	if err := a.updateDAGRunStatus(ctx, mutationRef, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating sub DAG-run status: %w", err)
 	}
 
@@ -1486,7 +1486,7 @@ func (a *API) RejectSubDAGRunStep(ctx context.Context, request api.RejectSubDAGR
 		return nil, err
 	}
 	rootRef := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, rootRef, request.SubDAGRunId)
+	mutationRef, dagStatus, err := a.getReferencedDAGRunStatusWithRef(ctx, rootRef, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.RejectSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1496,7 +1496,7 @@ func (a *API) RejectSubDAGRunStep(ctx context.Context, request api.RejectSubDAGR
 	if err := a.requireDAGRunStatusExecute(ctx, dagStatus); err != nil {
 		return nil, err
 	}
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, rootRef, request.SubDAGRunId)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, rootRef, request.SubDAGRunId, dagStatus.Name)
 	if err != nil {
 		return &api.RejectSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1529,7 +1529,7 @@ func (a *API) RejectSubDAGRunStep(ctx context.Context, request api.RejectSubDAGR
 	}
 	applyRejection(ctx, dagStatus.Nodes[stepIdx], dagStatus, reason)
 
-	if err := a.updateDAGRunStatus(ctx, rootRef, *dagStatus); err != nil {
+	if err := a.updateDAGRunStatus(ctx, mutationRef, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating sub DAG-run status: %w", err)
 	}
 
@@ -1655,7 +1655,7 @@ func (a *API) PushBackSubDAGRunStep(ctx context.Context, request api.PushBackSub
 		return nil, err
 	}
 	rootRef := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, rootRef, request.SubDAGRunId)
+	mutationRef, dagStatus, err := a.getReferencedDAGRunStatusWithRef(ctx, rootRef, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.PushBackSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1665,7 +1665,7 @@ func (a *API) PushBackSubDAGRunStep(ctx context.Context, request api.PushBackSub
 	if err := a.requireDAGRunStatusExecute(ctx, dagStatus); err != nil {
 		return nil, err
 	}
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, rootRef, request.SubDAGRunId)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, rootRef, request.SubDAGRunId, dagStatus.Name)
 	if err != nil {
 		return &api.PushBackSubDAGRunStep404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1721,7 +1721,7 @@ func (a *API) PushBackSubDAGRunStep(ctx context.Context, request api.PushBackSub
 		}, nil
 	}
 
-	if err := a.updateDAGRunStatus(ctx, rootRef, *dagStatus); err != nil {
+	if err := a.updateDAGRunStatus(ctx, mutationRef, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating sub DAG-run status: %w", err)
 	}
 
@@ -1729,7 +1729,7 @@ func (a *API) PushBackSubDAGRunStep(ctx context.Context, request api.PushBackSub
 		logger.Error(ctx, "Failed to resume sub DAG after push-back, rolling back", tag.Error(err))
 		var original exec.DAGRunStatus
 		if unmarshalErr := json.Unmarshal(snapshot, &original); unmarshalErr == nil {
-			if rollbackErr := a.updateDAGRunStatus(ctx, rootRef, original); rollbackErr != nil {
+			if rollbackErr := a.updateDAGRunStatus(ctx, mutationRef, original); rollbackErr != nil {
 				logger.Error(ctx, "Failed to rollback push-back state", tag.Error(rollbackErr))
 			}
 		}
@@ -2351,7 +2351,7 @@ func (a *API) UpdateSubDAGRunStepStatus(ctx context.Context, request api.UpdateS
 		return nil, err
 	}
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, root, request.SubDAGRunId)
+	mutationRef, dagStatus, err := a.getReferencedDAGRunStatusWithRef(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.UpdateSubDAGRunStepStatus404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2379,7 +2379,7 @@ func (a *API) UpdateSubDAGRunStepStatus(ctx context.Context, request api.UpdateS
 	dagStatus.Nodes[stepIdx].Status = nodeStatusMapping[request.Body.Status]
 	dagStatus.Status = deriveManualDAGRunStatus(dagStatus.Nodes, dagStatus.Status)
 
-	if err := a.updateDAGRunStatus(ctx, root, *dagStatus); err != nil {
+	if err := a.updateDAGRunStatus(ctx, mutationRef, *dagStatus); err != nil {
 		return nil, fmt.Errorf("error updating status: %w", err)
 	}
 
@@ -3290,9 +3290,14 @@ func (a *API) getSubDAGRunDetail(ctx context.Context, parentRef exec.DAGRunRef, 
 }
 
 func (a *API) getReferencedDAGRunStatus(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, dagName string) (*exec.DAGRunStatus, error) {
+	_, status, err := a.getReferencedDAGRunStatusWithRef(ctx, parentRef, subRunID, dagName)
+	return status, err
+}
+
+func (a *API) getReferencedDAGRunStatusWithRef(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, dagName string) (exec.DAGRunRef, *exec.DAGRunStatus, error) {
 	status, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, parentRef, subRunID)
 	if err == nil {
-		return status, nil
+		return parentRef, status, nil
 	}
 	subErr := err
 
@@ -3302,14 +3307,15 @@ func (a *API) getReferencedDAGRunStatus(ctx context.Context, parentRef exec.DAGR
 		}
 	}
 	if strings.TrimSpace(dagName) == "" {
-		return nil, subErr
+		return exec.DAGRunRef{}, nil, subErr
 	}
 
-	status, err = a.dagRunMgr.GetSavedStatus(ctx, exec.NewDAGRunRef(dagName, subRunID))
+	ref := exec.NewDAGRunRef(dagName, subRunID)
+	status, err = a.dagRunMgr.GetSavedStatus(ctx, ref)
 	if err != nil {
-		return nil, subErr
+		return exec.DAGRunRef{}, nil, subErr
 	}
-	return status, nil
+	return ref, status, nil
 }
 
 func (a *API) getReferencedDAGRunAttempt(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, dagName string) (exec.DAGRunAttempt, error) {
@@ -3474,7 +3480,7 @@ func (a *API) resumeDAGRun(ctx context.Context, ref exec.DAGRunRef, dagRunID str
 }
 
 func (a *API) resumeSubDAGRun(ctx context.Context, rootRef exec.DAGRunRef, subDAGRunID string) error {
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, rootRef, subDAGRunID)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, rootRef, subDAGRunID, "")
 	if err != nil {
 		return fmt.Errorf("find sub-attempt: %w", err)
 	}

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1373,7 +1373,7 @@ func (a *API) GetDAGRunStepMessages(ctx context.Context, request api.GetDAGRunSt
 
 func (a *API) GetSubDAGRunStepMessages(ctx context.Context, request api.GetSubDAGRunStepMessagesRequestObject) (api.GetSubDAGRunStepMessagesResponseObject, error) {
 	rootRef := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, rootRef, request.SubDAGRunId)
+	dagStatus, err := a.getReferencedDAGRunStatus(ctx, rootRef, request.SubDAGRunId, "")
 	if err != nil {
 		return api.GetSubDAGRunStepMessages404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -1392,7 +1392,7 @@ func (a *API) GetSubDAGRunStepMessages(ctx context.Context, request api.GetSubDA
 		}, nil
 	}
 
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, rootRef, request.SubDAGRunId)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, rootRef, request.SubDAGRunId, "")
 	if err != nil {
 		return api.GetSubDAGRunStepMessages404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2025,7 +2025,7 @@ func (a *API) GetSubDAGRunDetails(ctx context.Context, request api.GetSubDAGRunD
 		dagRunID:    request.DagRunId,
 		subDAGRunID: request.SubDAGRunId,
 	}, func(readCtx context.Context) (*exec.DAGRunStatus, error) {
-		return a.dagRunMgr.FindSubDAGRunStatus(readCtx, root, request.SubDAGRunId)
+		return a.getReferencedDAGRunStatus(readCtx, root, request.SubDAGRunId, "")
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -2056,7 +2056,7 @@ func (a *API) GetSubDAGRunDetails(ctx context.Context, request api.GetSubDAGRunD
 // GetSubDAGRunSpec returns the YAML spec used for a specific sub-DAG run.
 func (a *API) GetSubDAGRunSpec(ctx context.Context, request api.GetSubDAGRunSpecRequestObject) (api.GetSubDAGRunSpecResponseObject, error) {
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, root, request.SubDAGRunId)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.GetSubDAGRunSpec404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2096,7 +2096,7 @@ func (a *API) getSpecFromAttempt(ctx context.Context, attempt exec.DAGRunAttempt
 
 func (a *API) GetSubDAGRunLog(ctx context.Context, request api.GetSubDAGRunLogRequestObject) (api.GetSubDAGRunLogResponseObject, error) {
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, root, request.SubDAGRunId)
+	dagStatus, err := a.getReferencedDAGRunStatus(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.GetSubDAGRunLog404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2130,7 +2130,7 @@ func (a *API) GetSubDAGRunLog(ctx context.Context, request api.GetSubDAGRunLogRe
 
 func (a *API) DownloadSubDAGRunLog(ctx context.Context, request api.DownloadSubDAGRunLogRequestObject) (api.DownloadSubDAGRunLogResponseObject, error) {
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, root, request.SubDAGRunId)
+	dagStatus, err := a.getReferencedDAGRunStatus(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.DownloadSubDAGRunLog404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2258,7 +2258,7 @@ func (a *API) DownloadSubDAGRunArtifact(ctx context.Context, request api.Downloa
 
 func (a *API) GetSubDAGRunStepLog(ctx context.Context, request api.GetSubDAGRunStepLogRequestObject) (api.GetSubDAGRunStepLogResponseObject, error) {
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, root, request.SubDAGRunId)
+	dagStatus, err := a.getReferencedDAGRunStatus(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.GetSubDAGRunStepLog404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -2302,7 +2302,7 @@ func (a *API) GetSubDAGRunStepLog(ctx context.Context, request api.GetSubDAGRunS
 
 func (a *API) DownloadSubDAGRunStepLog(ctx context.Context, request api.DownloadSubDAGRunStepLogRequestObject) (api.DownloadSubDAGRunStepLogResponseObject, error) {
 	root := exec.NewDAGRunRef(request.Name, request.DagRunId)
-	dagStatus, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, root, request.SubDAGRunId)
+	dagStatus, err := a.getReferencedDAGRunStatus(ctx, root, request.SubDAGRunId, "")
 	if err != nil {
 		return &api.DownloadSubDAGRunStepLog404JSONResponse{
 			Code:    api.ErrorCodeNotFound,
@@ -3213,14 +3213,18 @@ func (a *API) GetSubDAGRuns(ctx context.Context, request api.GetSubDAGRunsReques
 
 	var dagStatus *exec.DAGRunStatus
 	var err error
+	detailParentRef := rootRef
 
 	if parentSubDAGRunId != nil && *parentSubDAGRunId != "" {
-		dagStatus, err = a.dagRunMgr.FindSubDAGRunStatus(ctx, rootRef, *parentSubDAGRunId)
+		dagStatus, err = a.getReferencedDAGRunStatus(ctx, rootRef, *parentSubDAGRunId, "")
 		if err != nil {
 			return &api.GetSubDAGRuns404JSONResponse{
 				Code:    api.ErrorCodeNotFound,
 				Message: fmt.Sprintf("sub dag-run ID %s not found for root DAG %s/%s", *parentSubDAGRunId, request.Name, request.DagRunId),
 			}, nil
+		}
+		if dagStatus.Parent.Zero() && !dagStatus.Root.Zero() && dagStatus.Root == dagStatus.DAGRun() {
+			detailParentRef = dagStatus.Root
 		}
 	} else {
 		dagStatus, err = a.dagRunMgr.GetSavedStatus(ctx, rootRef)
@@ -3242,13 +3246,13 @@ func (a *API) GetSubDAGRuns(ctx context.Context, request api.GetSubDAGRunsReques
 		}
 
 		for _, subRun := range node.SubRuns {
-			if detail, err := a.getSubDAGRunDetail(ctx, rootRef, subRun.DAGRunID, subRun.Params, subRun.DAGName); err == nil {
+			if detail, err := a.getSubDAGRunDetail(ctx, detailParentRef, subRun.DAGRunID, subRun.Params, subRun.DAGName); err == nil {
 				subRuns = append(subRuns, detail)
 			}
 		}
 
 		for _, subRun := range node.SubRunsRepeated {
-			if detail, err := a.getSubDAGRunDetail(ctx, rootRef, subRun.DAGRunID, subRun.Params, subRun.DAGName); err == nil {
+			if detail, err := a.getSubDAGRunDetail(ctx, detailParentRef, subRun.DAGRunID, subRun.Params, subRun.DAGName); err == nil {
 				subRuns = append(subRuns, detail)
 			}
 		}
@@ -3261,8 +3265,7 @@ func (a *API) GetSubDAGRuns(ctx context.Context, request api.GetSubDAGRunsReques
 
 // getSubDAGRunDetail fetches timing and status info for a single sub DAG run
 func (a *API) getSubDAGRunDetail(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, params string, dagName string) (api.SubDAGRunDetail, error) {
-	// Use FindSubDAGRunStatus to properly fetch sub DAG run from parent's storage
-	status, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, parentRef, subRunID)
+	status, err := a.getReferencedDAGRunStatus(ctx, parentRef, subRunID, dagName)
 	if err != nil {
 		return api.SubDAGRunDetail{}, err
 	}
@@ -3284,6 +3287,80 @@ func (a *API) getSubDAGRunDetail(ctx context.Context, parentRef exec.DAGRunRef, 
 	}
 
 	return detail, nil
+}
+
+func (a *API) getReferencedDAGRunStatus(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, dagName string) (*exec.DAGRunStatus, error) {
+	status, err := a.dagRunMgr.FindSubDAGRunStatus(ctx, parentRef, subRunID)
+	if err == nil {
+		return status, nil
+	}
+	subErr := err
+
+	if strings.TrimSpace(dagName) == "" {
+		if resolved, ok := a.findReferencedDAGName(ctx, parentRef, subRunID); ok {
+			dagName = resolved
+		}
+	}
+	if strings.TrimSpace(dagName) == "" {
+		return nil, subErr
+	}
+
+	status, err = a.dagRunMgr.GetSavedStatus(ctx, exec.NewDAGRunRef(dagName, subRunID))
+	if err != nil {
+		return nil, subErr
+	}
+	return status, nil
+}
+
+func (a *API) getReferencedDAGRunAttempt(ctx context.Context, parentRef exec.DAGRunRef, subRunID string, dagName string) (exec.DAGRunAttempt, error) {
+	attempt, err := a.dagRunStore.FindSubAttempt(ctx, parentRef, subRunID)
+	if err == nil {
+		return attempt, nil
+	}
+	subErr := err
+
+	if strings.TrimSpace(dagName) == "" {
+		if resolved, ok := a.findReferencedDAGName(ctx, parentRef, subRunID); ok {
+			dagName = resolved
+		}
+	}
+	if strings.TrimSpace(dagName) == "" {
+		return nil, subErr
+	}
+
+	attempt, err = a.dagRunStore.FindAttempt(ctx, exec.NewDAGRunRef(dagName, subRunID))
+	if err != nil {
+		return nil, subErr
+	}
+	return attempt, nil
+}
+
+func (a *API) findReferencedDAGName(ctx context.Context, parentRef exec.DAGRunRef, subRunID string) (string, bool) {
+	status, err := a.dagRunMgr.GetSavedStatus(ctx, parentRef)
+	if err != nil || status == nil {
+		return "", false
+	}
+	for _, node := range status.Nodes {
+		if node == nil {
+			continue
+		}
+		if dagName, ok := findDAGNameInSubRuns(node.SubRuns, subRunID); ok {
+			return dagName, true
+		}
+		if dagName, ok := findDAGNameInSubRuns(node.SubRunsRepeated, subRunID); ok {
+			return dagName, true
+		}
+	}
+	return "", false
+}
+
+func findDAGNameInSubRuns(subRuns []exec.SubDAGRun, subRunID string) (string, bool) {
+	for _, subRun := range subRuns {
+		if subRun.DAGRunID == subRunID && strings.TrimSpace(subRun.DAGName) != "" {
+			return subRun.DAGName, true
+		}
+	}
+	return "", false
 }
 
 func (a *API) waitForManualStepMutationReady(
@@ -3731,7 +3808,7 @@ func (a *API) GetSubDAGRunDetailsData(ctx context.Context, identifier string) (a
 		dagRunID:    parts[1],
 		subDAGRunID: parts[2],
 	}, func(readCtx context.Context) (*exec.DAGRunStatus, error) {
-		return a.dagRunMgr.FindSubDAGRunStatus(readCtx, root, parts[2])
+		return a.getReferencedDAGRunStatus(readCtx, root, parts[2], "")
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
@@ -3930,7 +4007,7 @@ func (a *API) getDAGRunArtifactStatus(ctx context.Context, dagName, dagRunID str
 }
 
 func (a *API) getSubDAGRunArtifactStatus(ctx context.Context, dagName, dagRunID, subDAGRunID string) (*exec.DAGRunStatus, error) {
-	attempt, err := a.dagRunStore.FindSubAttempt(ctx, exec.NewDAGRunRef(dagName, dagRunID), subDAGRunID)
+	attempt, err := a.getReferencedDAGRunAttempt(ctx, exec.NewDAGRunRef(dagName, dagRunID), subDAGRunID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1118,6 +1118,50 @@ steps:
 	require.Equal(t, core.TriggerTypeRetry, status.TriggerType)
 }
 
+func TestGetSubDAGRunsIncludesTopLevelDagEnqueueRun(t *testing.T) {
+	server := test.SetupServer(t)
+
+	parent := server.DAG(t, `
+name: dag_enqueue_parent
+steps:
+  - name: enqueue-child
+    run: echo queued
+`)
+	child := server.DAG(t, `
+name: dag_enqueue_child
+steps:
+  - name: child
+    run: echo child
+`)
+
+	parentRunID := "parent-run"
+	childRunID := "child-run"
+	seedLatestDAGRunStatus(t, server, parent.DAG, parentRunID, core.Succeeded, seedDAGRunStatusOptions{
+		subRuns: map[string][]exec.SubDAGRun{
+			"enqueue-child": {{
+				DAGRunID: childRunID,
+				DAGName:  child.Name,
+				Params:   "TARGET=async",
+			}},
+		},
+	})
+	seedLatestDAGRunStatus(t, server, child.DAG, childRunID, core.Queued, seedDAGRunStatusOptions{})
+
+	resp := server.Client().Get(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/sub-dag-runs", parent.Name, parentRunID),
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var body api.GetSubDAGRuns200JSONResponse
+	resp.Unmarshal(t, &body)
+	require.Len(t, body.SubRuns, 1)
+	require.Equal(t, childRunID, body.SubRuns[0].DagRunId)
+	require.Equal(t, api.Status(core.Queued), body.SubRuns[0].Status)
+	require.NotNil(t, body.SubRuns[0].DagName)
+	require.Equal(t, child.Name, *body.SubRuns[0].DagName)
+	require.NotNil(t, body.SubRuns[0].Params)
+	require.Equal(t, "TARGET=async", *body.SubRuns[0].Params)
+}
+
 func TestRetryDAGRunStartsLocalRetrySubprocess(t *testing.T) {
 	server := test.SetupServer(t)
 
@@ -1384,6 +1428,7 @@ type seedDAGRunStatusOptions struct {
 	parentRef      exec.DAGRunRef
 	paramsList     []string
 	nodeStatuses   map[string]core.NodeStatus
+	subRuns        map[string][]exec.SubDAGRun
 }
 
 func seedLatestDAGRunStatus(
@@ -1438,6 +1483,18 @@ func seedLatestDAGRunStatus(
 				continue
 			}
 			node.Status = nodeStatus
+			found = true
+			break
+		}
+		require.Truef(t, found, "seeded DAG-run status step %q not found", stepName)
+	}
+	for stepName, subRuns := range opts.subRuns {
+		found := false
+		for _, node := range dagRunStatus.Nodes {
+			if node.Step.Name != stepName {
+				continue
+			}
+			node.SubRuns = append([]exec.SubDAGRun(nil), subRuns...)
 			found = true
 			break
 		}

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1162,6 +1162,116 @@ steps:
 	require.Equal(t, "TARGET=async", *body.SubRuns[0].Params)
 }
 
+func TestUpdateSubDAGRunStepStatusHandlesTopLevelDagEnqueueRun(t *testing.T) {
+	server := test.SetupServer(t)
+
+	parent := &core.DAG{
+		Name: "dag_enqueue_status_parent",
+		Steps: []core.Step{
+			{Name: "enqueue-child"},
+		},
+	}
+	child := &core.DAG{
+		Name: "dag_enqueue_status_child",
+		Steps: []core.Step{
+			{Name: "child"},
+		},
+	}
+	parentRunID := "status-parent-run"
+	childRunID := "status-child-run"
+	seedLatestDAGRunStatus(t, server, parent, parentRunID, core.Succeeded, seedDAGRunStatusOptions{
+		subRuns: map[string][]exec.SubDAGRun{
+			"enqueue-child": {{
+				DAGRunID: childRunID,
+				DAGName:  child.Name,
+			}},
+		},
+	})
+	seedLatestDAGRunStatus(t, server, child, childRunID, core.Succeeded, seedDAGRunStatusOptions{})
+
+	server.Client().Patch(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/sub-dag-runs/%s/steps/%s/status", parent.Name, parentRunID, childRunID, "child"),
+		api.UpdateSubDAGRunStepStatusJSONRequestBody{Status: api.NodeStatusFailed},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	status := waitForStoredDAGRunStatus(
+		t,
+		server,
+		child.Name,
+		childRunID,
+		5*time.Second,
+		func(status *exec.DAGRunStatus) bool {
+			return status.Status == core.Failed &&
+				hasNodeWithStatus(status, "child", core.NodeFailed)
+		},
+	)
+	require.Equal(t, core.Failed, status.Status)
+
+	_, err := server.DAGRunStore.FindSubAttempt(server.Context, exec.NewDAGRunRef(parent.Name, parentRunID), childRunID)
+	require.Error(t, err)
+}
+
+func TestRejectSubDAGRunStepHandlesTopLevelDagEnqueueRun(t *testing.T) {
+	server := test.SetupServer(t)
+
+	parent := &core.DAG{
+		Name: "dag_enqueue_reject_parent",
+		Steps: []core.Step{
+			{Name: "enqueue-child"},
+		},
+	}
+	child := &core.DAG{
+		Name: "dag_enqueue_reject_child",
+		Steps: []core.Step{
+			{
+				Name: "wait-step",
+				Approval: &core.ApprovalConfig{
+					Prompt: "Please approve",
+				},
+			},
+		},
+	}
+	parentRunID := "reject-parent-run"
+	childRunID := "reject-child-run"
+	seedLatestDAGRunStatus(t, server, parent, parentRunID, core.Succeeded, seedDAGRunStatusOptions{
+		subRuns: map[string][]exec.SubDAGRun{
+			"enqueue-child": {{
+				DAGRunID: childRunID,
+				DAGName:  child.Name,
+			}},
+		},
+	})
+	seedLatestDAGRunStatus(t, server, child, childRunID, core.Waiting, seedDAGRunStatusOptions{
+		nodeStatuses: map[string]core.NodeStatus{
+			"wait-step": core.NodeWaiting,
+		},
+	})
+
+	reason := "queued child rejected"
+	resp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/sub-dag-runs/%s/steps/%s/reject", parent.Name, parentRunID, childRunID, "wait-step"),
+		api.RejectStepRequest{Reason: &reason},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var body api.RejectSubDAGRunStep200JSONResponse
+	resp.Unmarshal(t, &body)
+	require.Equal(t, api.DAGRunId(childRunID), body.DagRunId)
+	require.Equal(t, "wait-step", body.StepName)
+
+	status := waitForStoredDAGRunStatus(
+		t,
+		server,
+		child.Name,
+		childRunID,
+		5*time.Second,
+		func(status *exec.DAGRunStatus) bool {
+			return status.Status == core.Rejected &&
+				hasNodeWithStatus(status, "wait-step", core.NodeRejected)
+		},
+	)
+	require.Equal(t, reason, status.Nodes[0].RejectionReason)
+}
+
 func TestRetryDAGRunStartsLocalRetrySubprocess(t *testing.T) {
 	server := test.SetupServer(t)
 

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -781,10 +781,13 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 	root := exec1.NewDAGRunRef(d.Name, dagRunID)
 
 	helper.opts.DAGRunStore = d.DAGRunStore
+	helper.opts.QueueStore = d.QueueStore
 	helper.opts.ServiceRegistry = d.ServiceRegistry
 	helper.opts.RootDAGRun = root
 	helper.opts.PeerConfig = d.Config.Core.Peer
 	helper.opts.DefaultExecMode = d.Config.DefaultExecMode
+	helper.opts.DAGRunLogDir = d.Config.Paths.LogDir
+	helper.opts.DAGRunArtifactDir = d.Config.Paths.ArtifactDir
 
 	helper.Agent = agent.New(
 		dagRunID,


### PR DESCRIPTION
## Summary

Add asynchronous child DAG enqueue support with `action: dag.enqueue`.

## Changes

- Add `dag.enqueue` action normalization and `dag_enqueue` executor support.
- Persist queued child DAG runs with sub-DAG trigger metadata, resolved params, logs, artifacts, and queue selection.
- Wire queue and DAG-run stores into runtime execution context for executors that create queued runs.
- Update sub-DAG API lookup paths so asynchronously queued child DAG runs remain visible from parent DAG run details.
- Add parser, schema, runtime, queue-processing, and API coverage for enqueue behavior.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Changes have been tested locally

## Validation

- `go test -count=1 ./internal/core ./internal/core/spec ./internal/service/frontend/api/v1 ./internal/cmd ./internal/service/scheduler ./internal/runtime/agent ./internal/runtime/builtin/dag`
- `make bin`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dag.enqueue` action to enqueue child DAG runs asynchronously with optional queue configuration and parameter overrides.
  * Enhanced support for parallel execution of enqueued child DAG runs.

* **Improvements**
  * Improved sub-DAG run resolution and tracking in API endpoints for better visibility across parent and child DAG runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->