### PR TITLE
fix: defer failure handler during auto retry

### DIFF
--- a/internal/intg/handler_test.go
+++ b/internal/intg/handler_test.go
@@ -182,6 +182,9 @@ steps:
 		{
 			name: "FailureHandler",
 			dagYAML: `
+retry_policy:
+  limit: 0
+
 handler_on:
   failure:
     run: "true"
@@ -509,6 +512,9 @@ steps:
 		th := test.Setup(t)
 
 		dag := th.DAG(t, `
+retry_policy:
+  limit: 0
+
 handler_on:
   failure:
     run: |

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1432,20 +1432,28 @@ func (a *Agent) newRunner(attempt exec.DAGRunAttempt) *runtime.Runner {
 	ts := time.Now().UTC().Format(dateTimeFormatUTC)
 	runnerLogDir := filepath.Join(a.logDir, "run_"+ts+"_"+a.dagRunAttemptID)
 
+	autoRetryLimit := 0
+	if a.dag.RetryPolicy != nil {
+		autoRetryLimit = a.dag.RetryPolicy.Limit
+	}
+
 	cfg := &runtime.Config{
-		LogDir:          runnerLogDir,
-		MaxActiveSteps:  a.dag.MaxActiveSteps,
-		Timeout:         a.dag.Timeout,
-		Delay:           a.dag.Delay,
-		Dry:             a.dry,
-		DAGRunID:        a.dagRunID,
-		MessagesHandler: attempt, // Attempt implements ChatMessagesHandler
-		OnInit:          a.dag.HandlerOn.Init,
-		OnExit:          a.dag.HandlerOn.Exit,
-		OnSuccess:       a.dag.HandlerOn.Success,
-		OnFailure:       a.dag.HandlerOn.Failure,
-		OnAbort:         a.dag.HandlerOn.Abort,
-		OnWait:          a.dag.HandlerOn.Wait,
+		LogDir:               runnerLogDir,
+		MaxActiveSteps:       a.dag.MaxActiveSteps,
+		Timeout:              a.dag.Timeout,
+		Delay:                a.dag.Delay,
+		Dry:                  a.dry,
+		DAGRunID:             a.dagRunID,
+		MessagesHandler:      attempt, // Attempt implements ChatMessagesHandler
+		OnInit:               a.dag.HandlerOn.Init,
+		OnExit:               a.dag.HandlerOn.Exit,
+		OnSuccess:            a.dag.HandlerOn.Success,
+		OnFailure:            a.dag.HandlerOn.Failure,
+		OnAbort:              a.dag.HandlerOn.Abort,
+		OnWait:               a.dag.HandlerOn.Wait,
+		DAGRunAutoRetryCount: a.currentAutoRetryCount(),
+		DAGRunAutoRetryLimit: autoRetryLimit,
+		DAGRunIsRoot:         a.parentDAGRun.Zero(),
 	}
 
 	return runtime.New(cfg)

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -358,10 +358,12 @@ steps:
 		require.ErrorContains(t, err, "failed to start the unix socket server")
 		require.ErrorContains(t, err, "synthetic bind failure")
 	})
-	t.Run("FailureHandlerRunsInline", func(t *testing.T) {
+	t.Run("FailureHandlerRunsInlineWithoutDAGAutoRetry", func(t *testing.T) {
 		th := test.Setup(t)
 		marker := filepath.Join(t.TempDir(), "failure-marker")
-		dag := th.DAG(t, fmt.Sprintf(`handler_on:
+		dag := th.DAG(t, fmt.Sprintf(`retry_policy:
+  limit: 0
+handler_on:
   failure:
     run: %q
 steps:
@@ -380,6 +382,28 @@ steps:
 		data, err := os.ReadFile(marker)
 		require.NoError(t, err)
 		require.Equal(t, "failed", string(data))
+	})
+	t.Run("FailureHandlerSkipsRootDAGPendingAutoRetry", func(t *testing.T) {
+		th := test.Setup(t)
+		marker := filepath.Join(t.TempDir(), "failure-marker")
+		dag := th.DAG(t, fmt.Sprintf(`retry_policy:
+  limit: 1
+handler_on:
+  failure:
+    run: %q
+steps:
+  - %q
+`, writeFileCommand(marker, "failed"), "exit 1"))
+		dagAgent := dag.Agent()
+		dagAgent.RunError(t)
+
+		status := dagAgent.Status(th.Context)
+		require.Equal(t, core.Failed, status.Status)
+		require.NotNil(t, status.OnFailure)
+		require.Equal(t, core.NodeNotStarted, status.OnFailure.Status)
+
+		_, err := os.Stat(marker)
+		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 	t.Run("FinishWithTimeout", func(t *testing.T) {
 		th := test.Setup(t)
@@ -1043,7 +1067,7 @@ steps:
 func TestAgent_SubDAGRunVisibleWhileRunning(t *testing.T) {
 	t.Parallel()
 
-	th := test.Setup(t)
+	th := test.Setup(t, test.WithBuiltExecutable())
 	releaseFile := filepath.Join(t.TempDir(), "release-child")
 	t.Cleanup(func() {
 		_ = os.WriteFile(releaseFile, []byte("done"), 0600)

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -59,6 +59,10 @@ type Runner struct {
 	onWait          *core.Step
 	forcedStatus    *core.Status
 
+	dagRunAutoRetryCount int
+	dagRunAutoRetryLimit int
+	dagRunIsRoot         bool
+
 	canceled  int32
 	mu        sync.RWMutex
 	pause     time.Duration
@@ -80,21 +84,24 @@ type Runner struct {
 
 func New(cfg *Config) *Runner {
 	return &Runner{
-		logDir:          cfg.LogDir,
-		maxActiveRuns:   cfg.MaxActiveSteps,
-		timeout:         cfg.Timeout,
-		delay:           cfg.Delay,
-		dry:             cfg.Dry,
-		onInit:          cfg.OnInit,
-		onExit:          cfg.OnExit,
-		onSuccess:       cfg.OnSuccess,
-		onFailure:       cfg.OnFailure,
-		onAbort:         cfg.OnAbort,
-		dagRunID:        cfg.DAGRunID,
-		messagesHandler: cfg.MessagesHandler,
-		pause:           time.Millisecond * 100,
-		onWait:          cfg.OnWait,
-		forcedStatus:    cfg.ForcedStatus,
+		logDir:               cfg.LogDir,
+		maxActiveRuns:        cfg.MaxActiveSteps,
+		timeout:              cfg.Timeout,
+		delay:                cfg.Delay,
+		dry:                  cfg.Dry,
+		onInit:               cfg.OnInit,
+		onExit:               cfg.OnExit,
+		onSuccess:            cfg.OnSuccess,
+		onFailure:            cfg.OnFailure,
+		onAbort:              cfg.OnAbort,
+		dagRunID:             cfg.DAGRunID,
+		messagesHandler:      cfg.MessagesHandler,
+		pause:                time.Millisecond * 100,
+		onWait:               cfg.OnWait,
+		forcedStatus:         cfg.ForcedStatus,
+		dagRunAutoRetryCount: cfg.DAGRunAutoRetryCount,
+		dagRunAutoRetryLimit: cfg.DAGRunAutoRetryLimit,
+		dagRunIsRoot:         cfg.DAGRunIsRoot,
 	}
 }
 
@@ -113,6 +120,10 @@ type Config struct {
 	MessagesHandler ChatMessagesHandler
 	OnWait          *core.Step
 	ForcedStatus    *core.Status
+
+	DAGRunAutoRetryCount int
+	DAGRunAutoRetryLimit int
+	DAGRunIsRoot         bool
 }
 
 // Run runs the plan of steps.
@@ -284,7 +295,8 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	r.metrics.totalExecutionTime = time.Since(r.metrics.startTime)
 
 	var eventHandlers []core.HandlerType
-	switch r.Status(ctx, plan) {
+	finalStatus := r.Status(ctx, plan)
+	switch finalStatus {
 	case core.Succeeded:
 		eventHandlers = append(eventHandlers, core.HandlerOnSuccess)
 
@@ -294,7 +306,14 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 		eventHandlers = append(eventHandlers, core.HandlerOnSuccess)
 
 	case core.Failed:
-		eventHandlers = append(eventHandlers, core.HandlerOnFailure)
+		if r.shouldRunFailureHandler(finalStatus) {
+			eventHandlers = append(eventHandlers, core.HandlerOnFailure)
+		} else {
+			logger.Info(ctx, "Skipping failure handler while DAG auto-retry is pending",
+				slog.Int("autoRetryCount", r.dagRunAutoRetryCount),
+				slog.Int("autoRetryLimit", r.dagRunAutoRetryLimit),
+			)
+		}
 
 	case core.Aborted:
 		eventHandlers = append(eventHandlers, core.HandlerOnAbort)
@@ -338,7 +357,7 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	case core.NotStarted, core.Running:
 		// These states should not occur at this point
 		logger.Warn(ctx, "Unexpected final status",
-			tag.Status(r.Status(ctx, plan).String()),
+			tag.Status(finalStatus.String()),
 		)
 	}
 
@@ -368,6 +387,19 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	)
 
 	return r.lastError
+}
+
+func (r *Runner) shouldRunFailureHandler(status core.Status) bool {
+	if status != core.Failed {
+		return true
+	}
+	if !r.dagRunIsRoot {
+		return true
+	}
+	if r.dagRunAutoRetryLimit <= 0 {
+		return true
+	}
+	return r.dagRunAutoRetryCount >= r.dagRunAutoRetryLimit
 }
 
 func (r *Runner) processCompletedNode(ctx context.Context, plan *Plan, node *Node, readyCh chan *Node) {

--- a/internal/runtime/runner_helper_test.go
+++ b/internal/runtime/runner_helper_test.go
@@ -173,6 +173,14 @@ func withForcedStatus(status core.Status) runnerOption {
 	}
 }
 
+func withDAGAutoRetry(count, limit int, isRoot bool) runnerOption {
+	return func(cfg *runtime.Config) {
+		cfg.DAGRunAutoRetryCount = count
+		cfg.DAGRunAutoRetryLimit = limit
+		cfg.DAGRunIsRoot = isRoot
+	}
+}
+
 func newHandlerStep(_ *testing.T, name, id, command string) core.Step {
 	return core.Step{
 		Name:     name,

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -934,6 +934,65 @@ func TestRunner(t *testing.T) {
 		result.assertNodeStatus(t, "1", core.NodeFailed)
 		result.assertNodeStatus(t, "onFailure", core.NodeSucceeded)
 	})
+	t.Run("OnFailureHandlerSkippedWhileRootDAGAutoRetryPending", func(t *testing.T) {
+		r := setupRunner(t,
+			withDAGAutoRetry(0, 2, true),
+			withOnFailure(successStep("onFailure")),
+			withOnExit(successStep("onExit")),
+		)
+
+		plan := r.newPlan(t, failStep("1"))
+
+		result := plan.assertRun(t, core.Failed)
+
+		result.assertNodeStatus(t, "1", core.NodeFailed)
+		result.assertNodeStatus(t, "onFailure", core.NodeNotStarted)
+		result.assertNodeStatus(t, "onExit", core.NodeSucceeded)
+	})
+	t.Run("OnFailureHandlerRunsWhenRootDAGAutoRetryExhausted", func(t *testing.T) {
+		r := setupRunner(t,
+			withDAGAutoRetry(2, 2, true),
+			withOnFailure(successStep("onFailure")),
+			withOnExit(successStep("onExit")),
+		)
+
+		plan := r.newPlan(t, failStep("1"))
+
+		result := plan.assertRun(t, core.Failed)
+
+		result.assertNodeStatus(t, "1", core.NodeFailed)
+		result.assertNodeStatus(t, "onFailure", core.NodeSucceeded)
+		result.assertNodeStatus(t, "onExit", core.NodeSucceeded)
+	})
+	t.Run("OnFailureHandlerRunsForChildDAGFailure", func(t *testing.T) {
+		r := setupRunner(t,
+			withDAGAutoRetry(0, 2, false),
+			withOnFailure(successStep("onFailure")),
+		)
+
+		plan := r.newPlan(t, failStep("1"))
+
+		result := plan.assertRun(t, core.Failed)
+
+		result.assertNodeStatus(t, "1", core.NodeFailed)
+		result.assertNodeStatus(t, "onFailure", core.NodeSucceeded)
+	})
+	t.Run("OnFailureHandlerRunsForRejectedRootDAGWithAutoRetryPending", func(t *testing.T) {
+		r := setupRunner(t,
+			withForcedStatus(core.Rejected),
+			withDAGAutoRetry(0, 2, true),
+			withOnFailure(successStep("onFailure")),
+			withOnExit(successStep("onExit")),
+		)
+
+		plan := r.newPlan(t, successStep("1"))
+
+		result := plan.assertRun(t, core.Rejected)
+
+		result.assertNodeStatus(t, "1", core.NodeSucceeded)
+		result.assertNodeStatus(t, "onFailure", core.NodeSucceeded)
+		result.assertNodeStatus(t, "onExit", core.NodeSucceeded)
+	})
 	t.Run("CancelOnSignal", func(t *testing.T) {
 		r := setupRunner(t)
 


### PR DESCRIPTION
## Summary
- skip root DAG failure lifecycle handlers while DAG-level auto retry budget remains
- keep exit handlers and rejected-run failure handlers on their existing paths
- avoid stale local sub-DAG tests by building the current binary for subprocess execution

## Changes
- pass DAG auto-retry count, limit, and root-run metadata from the agent to the runner
- suppress `handler_on.failure` only for failed root attempts that still have auto retries remaining
- add regression coverage for pending retry, retry exhaustion, child DAG failure, and rejected runs
- update agent lifecycle tests for pending auto-retry behavior

## Related Issues
N/A

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Validation
- `go test ./internal/runtime ./internal/runtime/agent ./internal/agent ./internal/service/chatbridge -count=1`
- `go test ./internal/service/scheduler -count=1`
- `go test ./internal/runtime/agent -run TestAgent_SubDAGRunVisibleWhileRunning -count=1`
- `git diff --check`
- `make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced DAG auto-retry metadata tracking including retry count, limit, and root execution status.

* **Bug Fixes**
  * Fixed failure handler behavior to correctly skip execution when a root DAG has pending auto-retry attempts, ensuring proper sequencing of retry and failure handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->