### PR TITLE
Add Deno-backed external actions

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -6000,8 +6000,8 @@
         },
         {
           "type": "string",
-          "pattern": "^pkg:[^\\s]+@[^\\s]+$",
-          "description": "Packaged action reference resolved from an action registry."
+          "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]+@[^\\s]+$",
+          "description": "GitHub action reference resolved from owner/repo@version."
         },
         {
           "type": "string",
@@ -6697,8 +6697,8 @@
       "properties": {
         "ref": {
           "type": "string",
-          "pattern": "^(source:|pkg:)[^\\s]+@[^\\s]+$",
-          "description": "External action reference. Supported prefixes are source: and pkg:."
+          "pattern": "^(source:[^\\s]+|[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]+)@[^\\s]+$",
+          "description": "External action reference. Use owner/repo@version for GitHub actions or source:target@version for explicit source actions."
         },
         "input": {
           "type": "object",

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2430,6 +2430,20 @@
           }
         },
         {
+          "if": { "properties": { "type": { "const": "action" } }, "required": ["type"] },
+          "then": {
+            "anyOf": [{ "required": ["with"] }, { "required": ["config"] }],
+            "properties": {
+              "with": { "$ref": "#/definitions/actionExecutorConfig" },
+              "config": {
+                "$ref": "#/definitions/actionExecutorConfig",
+                "deprecated": true,
+                "doNotSuggest": true
+              }
+            }
+          }
+        },
+        {
           "if": { "properties": { "type": { "const": "http" } }, "required": ["type"] },
           "then": {
             "properties": {
@@ -5876,6 +5890,7 @@
     "builtinExecutorType": {
       "type": "string",
       "enum": [
+        "action",
         "command",
         "shell",
         "docker",
@@ -5977,6 +5992,16 @@
           "type": "string",
           "pattern": "^redis\\.[A-Za-z][A-Za-z0-9_-]*$",
           "description": "Redis operation action such as redis.get or redis.set."
+        },
+        {
+          "type": "string",
+          "pattern": "^source:[^\\s]+@[^\\s]+$",
+          "description": "Source action reference resolved from a Git or local source target."
+        },
+        {
+          "type": "string",
+          "pattern": "^pkg:[^\\s]+@[^\\s]+$",
+          "description": "Packaged action reference resolved from an action registry."
         },
         {
           "type": "string",
@@ -6665,6 +6690,24 @@
       "description": "Executor-specific configuration. Schema depends on executor type.",
       "additionalProperties": true
     },
+    "actionExecutorConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "pattern": "^(source:|pkg:)[^\\s]+@[^\\s]+$",
+          "description": "External action reference. Supported prefixes are source: and pkg:."
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Action input object."
+        }
+      },
+      "description": "Configuration for external Dagu actions executed by the action executor."
+    },
     "executorObject": {
       "type": "object",
       "required": ["type"],
@@ -6677,6 +6720,15 @@
         }
       },
       "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "action" } }, "required": ["type"] },
+          "then": {
+            "required": ["config"],
+            "properties": {
+              "config": { "$ref": "#/definitions/actionExecutorConfig" }
+            }
+          }
+        },
         {
           "if": { "properties": { "type": { "const": "http" } }, "required": ["type"] },
           "then": {

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -469,10 +469,10 @@ steps:
 `,
 		},
 		{
-			name: "PackageAction",
+			name: "GitHubAction",
 			spec: `
 steps:
-  - action: pkg:dagu-actions/slack.notify@1.2.3
+  - action: acme/dagu-actions-slack@v1
     with:
       channel: "#ops"
       text: hello
@@ -484,11 +484,29 @@ steps:
 steps:
   - type: action
     with:
-      ref: source:github.com/acme/dagu-actions-slack@v1
+      ref: acme/dagu-actions-slack@v1
       input:
         channel: "#ops"
         text: hello
 `,
+		},
+		{
+			name: "RejectPackageActionPrefix",
+			spec: `
+steps:
+  - action: pkg:dagu-actions/slack.notify@1.2.3
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectExplicitPackageActionPrefix",
+			spec: `
+steps:
+  - type: action
+    with:
+      ref: pkg:dagu-actions/slack.notify@1.2.3
+`,
+			wantErr: "did not validate",
 		},
 		{
 			name: "FileActions",

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -459,6 +459,38 @@ steps:
 `,
 		},
 		{
+			name: "SourceAction",
+			spec: `
+steps:
+  - action: source:github.com/acme/dagu-actions-slack@v1
+    with:
+      channel: "#ops"
+      text: hello
+`,
+		},
+		{
+			name: "PackageAction",
+			spec: `
+steps:
+  - action: pkg:dagu-actions/slack.notify@1.2.3
+    with:
+      channel: "#ops"
+      text: hello
+`,
+		},
+		{
+			name: "ExplicitActionExecutor",
+			spec: `
+steps:
+  - type: action
+    with:
+      ref: source:github.com/acme/dagu-actions-slack@v1
+      input:
+        channel: "#ops"
+        text: hello
+`,
+		},
+		{
 			name: "FileActions",
 			spec: `
 steps:

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -71,6 +71,7 @@ var customStepWholeRuntimeExpressionRegexp = regexp.MustCompile("^\\s*(?:`[^`]+`
 var builtinStepTypeNames = map[string]struct{}{
 	"agent":         {},
 	"archive":       {},
+	"action":        {},
 	"chat":          {},
 	"command":       {},
 	"container":     {},

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -176,6 +176,13 @@ func normalizeActionStep(normalized, raw map[string]any, registry *customStepTyp
 	if action == "" {
 		return core.NewValidationError("action", raw["action"], fmt.Errorf("action is required"))
 	}
+	if isRemoteActionReference(action) {
+		with, err := actionWith(raw)
+		if err != nil {
+			return err
+		}
+		return normalizeRemoteAction(normalized, action, with)
+	}
 	if strings.Contains(action, "@") {
 		return core.NewValidationError("action", raw["action"], fmt.Errorf("versioned action references are reserved for the future action registry"))
 	}
@@ -204,6 +211,24 @@ func normalizeActionStep(normalized, raw map[string]any, registry *customStepTyp
 		return normalizeRedisAction(normalized, with, after)
 	}
 	return core.NewValidationError("action", raw["action"], fmt.Errorf("unknown action %q", action))
+}
+
+func isRemoteActionReference(action string) bool {
+	return strings.HasPrefix(action, "source:") || strings.HasPrefix(action, "pkg:")
+}
+
+func normalizeRemoteAction(normalized map[string]any, action string, with map[string]any) error {
+	cfg := map[string]any{
+		"ref":   action,
+		"input": map[string]any{},
+	}
+	if len(with) > 0 {
+		cfg["input"] = with
+	}
+	normalized["type"] = core.ExecutorTypeAction
+	normalized["with"] = cfg
+	delete(normalized, "action")
+	return nil
 }
 
 func actionWith(raw map[string]any) (map[string]any, error) {

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -184,7 +184,7 @@ func normalizeActionStep(normalized, raw map[string]any, registry *customStepTyp
 		return normalizeRemoteAction(normalized, action, with)
 	}
 	if strings.Contains(action, "@") {
-		return core.NewValidationError("action", raw["action"], fmt.Errorf("versioned action references are reserved for the future action registry"))
+		return core.NewValidationError("action", raw["action"], fmt.Errorf("versioned action references must use GitHub owner/repo@version"))
 	}
 
 	if registry != nil {
@@ -214,7 +214,77 @@ func normalizeActionStep(normalized, raw map[string]any, registry *customStepTyp
 }
 
 func isRemoteActionReference(action string) bool {
-	return strings.HasPrefix(action, "source:") || strings.HasPrefix(action, "pkg:")
+	return strings.HasPrefix(action, "source:") || isGitHubActionReference(action)
+}
+
+func isGitHubActionReference(action string) bool {
+	target, version, err := splitActionRef(action)
+	return err == nil && isGitHubActionTarget(target) && isSafeActionVersion(version)
+}
+
+func splitActionRef(action string) (string, string, error) {
+	idx := strings.LastIndex(action, "@")
+	if idx <= 0 || idx == len(action)-1 {
+		return "", "", fmt.Errorf("action ref must be target@version")
+	}
+	return strings.TrimSpace(action[:idx]), strings.TrimSpace(action[idx+1:]), nil
+}
+
+func isGitHubActionTarget(target string) bool {
+	parts := strings.Split(target, "/")
+	if len(parts) != 2 {
+		return false
+	}
+	owner, repo := parts[0], parts[1]
+	if owner == "" || repo == "" || strings.HasPrefix(owner, "-") || strings.HasSuffix(owner, "-") {
+		return false
+	}
+	if len(owner) > 39 || repo == "." || repo == ".." || strings.HasSuffix(repo, ".git") {
+		return false
+	}
+	for _, r := range owner {
+		if !isGitHubOwnerRune(r) {
+			return false
+		}
+	}
+	for _, r := range repo {
+		if !isGitHubRepoRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isGitHubOwnerRune(r rune) bool {
+	return r >= 'A' && r <= 'Z' ||
+		r >= 'a' && r <= 'z' ||
+		r >= '0' && r <= '9' ||
+		r == '-'
+}
+
+func isGitHubRepoRune(r rune) bool {
+	return isGitHubOwnerRune(r) || r == '_' || r == '.'
+}
+
+func isSafeActionVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" ||
+		strings.HasPrefix(version, "-") ||
+		strings.ContainsAny(version, " \t\r\n\\~^:?*[]") ||
+		strings.Contains(version, "..") ||
+		strings.Contains(version, "@{") ||
+		strings.Contains(version, "//") ||
+		strings.HasSuffix(version, "/") ||
+		strings.HasSuffix(version, ".") ||
+		strings.HasSuffix(version, ".lock") {
+		return false
+	}
+	for part := range strings.SplitSeq(version, "/") {
+		if part == "" || strings.HasPrefix(part, ".") || strings.HasSuffix(part, ".lock") {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeRemoteAction(normalized map[string]any, action string, with map[string]any) error {

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -98,6 +98,78 @@ steps:
 	assert.Contains(t, err.Error(), `parallel currently requires action: dag.run`)
 }
 
+func TestStepSchemaV2_SourceAction(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: notify
+    action: source:github.com/acme/dagu-actions-slack@v1
+    with:
+      channel: "#ops"
+      text: done
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "notify", step.ID)
+	assert.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
+	assert.Equal(t, "source:github.com/acme/dagu-actions-slack@v1", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, map[string]any{
+		"channel": "#ops",
+		"text":    "done",
+	}, step.ExecutorConfig.Config["input"])
+}
+
+func TestStepSchemaV2_PackagedAction(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: notify
+    action: pkg:dagu-actions/slack.notify@1.2.3
+    with:
+      channel: "#ops"
+      text: done
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
+	assert.Equal(t, "pkg:dagu-actions/slack.notify@1.2.3", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, map[string]any{
+		"channel": "#ops",
+		"text":    "done",
+	}, step.ExecutorConfig.Config["input"])
+}
+
+func TestStepSchemaV2_ExplicitActionExecutor(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: notify
+    type: action
+    with:
+      ref: source:github.com/acme/dagu-actions-slack@v1
+      input:
+        channel: "#ops"
+        text: done
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
+	assert.Equal(t, "source:github.com/acme/dagu-actions-slack@v1", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, map[string]any{
+		"channel": "#ops",
+		"text":    "done",
+	}, step.ExecutorConfig.Config["input"])
+}
+
 func TestStepSchemaV2_ActionHTTPRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -122,13 +122,13 @@ steps:
 	}, step.ExecutorConfig.Config["input"])
 }
 
-func TestStepSchemaV2_PackagedAction(t *testing.T) {
+func TestStepSchemaV2_GitHubAction(t *testing.T) {
 	t.Parallel()
 
 	dag, err := LoadYAML(context.Background(), []byte(`
 steps:
   - id: notify
-    action: pkg:dagu-actions/slack.notify@1.2.3
+    action: acme/dagu-actions-slack@v1
     with:
       channel: "#ops"
       text: done
@@ -138,11 +138,35 @@ steps:
 
 	step := dag.Steps[0]
 	assert.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
-	assert.Equal(t, "pkg:dagu-actions/slack.notify@1.2.3", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, "acme/dagu-actions-slack@v1", step.ExecutorConfig.Config["ref"])
 	assert.Equal(t, map[string]any{
 		"channel": "#ops",
 		"text":    "done",
 	}, step.ExecutorConfig.Config["input"])
+}
+
+func TestStepSchemaV2_ActionRejectsPackagePrefix(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: notify
+    action: pkg:dagu-actions/slack.notify@1.2.3
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner/repo@version")
+}
+
+func TestStepSchemaV2_ActionRejectsUnsafeGitHubVersion(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: notify
+    action: acme/dagu-actions-slack@-main
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner/repo@version")
 }
 
 func TestStepSchemaV2_ExplicitActionExecutor(t *testing.T) {
@@ -153,7 +177,7 @@ steps:
   - id: notify
     type: action
     with:
-      ref: source:github.com/acme/dagu-actions-slack@v1
+      ref: acme/dagu-actions-slack@v1
       input:
         channel: "#ops"
         text: done
@@ -163,7 +187,7 @@ steps:
 
 	step := dag.Steps[0]
 	assert.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
-	assert.Equal(t, "source:github.com/acme/dagu-actions-slack@v1", step.ExecutorConfig.Config["ref"])
+	assert.Equal(t, "acme/dagu-actions-slack@v1", step.ExecutorConfig.Config["ref"])
 	assert.Equal(t, map[string]any{
 		"channel": "#ops",
 		"text":    "done",

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -401,6 +401,9 @@ const (
 
 	// ExecutorTypeAgent is the executor type for agent steps.
 	ExecutorTypeAgent = "agent"
+
+	// ExecutorTypeAction is the executor type for external Dagu actions.
+	ExecutorTypeAction = "action"
 )
 
 // AgentStepConfig contains the configuration for an agent step.

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -40,6 +40,7 @@ import (
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
 	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
@@ -380,6 +381,10 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 			AgentOAuthManager:          stores.OAuthManager,
 			AgentRemoteContextResolver: stores.ContextResolver,
 			ArtifactDir:                artifactDir,
+			ExtraEnvs: dagutools.ToolDirEnvVars(dagutools.InstallOptions{
+				ToolsDir: e.cfg.Paths.ToolsDir,
+				DataDir:  e.cfg.Paths.DataDir,
+			}),
 		},
 	)
 

--- a/internal/runtime/builtin/action/action.go
+++ b/internal/runtime/builtin/action/action.go
@@ -264,7 +264,7 @@ func readPermissions(rootDir, inputPath string, extra []string) []string {
 	paths := []string{filepath.Clean(rootDir), filepath.Clean(inputPath)}
 	for _, item := range extra {
 		item = strings.TrimSpace(item)
-		if item == "" || filepath.IsAbs(item) {
+		if item == "" {
 			continue
 		}
 		if path, err := safeRelativePath(rootDir, item); err == nil {
@@ -278,7 +278,7 @@ func writePermissions(rootDir, outputDir string, extra []string) []string {
 	paths := []string{filepath.Clean(outputDir)}
 	for _, item := range extra {
 		item = strings.TrimSpace(item)
-		if item == "" || filepath.IsAbs(item) {
+		if item == "" {
 			continue
 		}
 		if path, err := safeRelativePath(rootDir, item); err == nil {

--- a/internal/runtime/builtin/action/action.go
+++ b/internal/runtime/builtin/action/action.go
@@ -228,7 +228,7 @@ func denoRunArgs(rootDir, entrypoint, inputPath, outputDir string, perms permiss
 		"--cached-only",
 		"--no-prompt",
 		"--allow-read=" + strings.Join(readPermissions(rootDir, inputPath, perms.Read), ","),
-		"--allow-write=" + strings.Join(writePermissions(outputDir, perms.Write), ","),
+		"--allow-write=" + strings.Join(writePermissions(rootDir, outputDir, perms.Write), ","),
 	}
 	args = append(args, denoLockArgs(rootDir)...)
 	if len(perms.Net) > 0 {
@@ -274,16 +274,15 @@ func readPermissions(rootDir, inputPath string, extra []string) []string {
 	return dedupeStrings(paths)
 }
 
-func writePermissions(outputDir string, extra []string) []string {
+func writePermissions(rootDir, outputDir string, extra []string) []string {
 	paths := []string{filepath.Clean(outputDir)}
 	for _, item := range extra {
 		item = strings.TrimSpace(item)
 		if item == "" || filepath.IsAbs(item) {
 			continue
 		}
-		path := filepath.Join(outputDir, item)
-		if isPathWithin(outputDir, path) {
-			paths = append(paths, filepath.Clean(path))
+		if path, err := safeRelativePath(rootDir, item); err == nil {
+			paths = append(paths, path)
 		}
 	}
 	return dedupeStrings(paths)

--- a/internal/runtime/builtin/action/action.go
+++ b/internal/runtime/builtin/action/action.go
@@ -1,0 +1,360 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const (
+	executorType = core.ExecutorTypeAction
+
+	envActionInput     = "DAGU_ACTION_INPUT"
+	envActionOutput    = "DAGU_ACTION_OUTPUT"
+	envActionOutputDir = "DAGU_ACTION_OUTPUT_DIR"
+	envActionDir       = "DAGU_ACTION_DIR"
+	envActionRef       = "DAGU_ACTION_REF"
+	envActionRegistry  = "DAGU_ACTION_REGISTRY_DIR"
+)
+
+var _ runtimeexec.Executor = (*Executor)(nil)
+
+type config struct {
+	Ref   string
+	Input map[string]any
+}
+
+type Executor struct {
+	cfg    config
+	stdout io.Writer
+	stderr io.Writer
+
+	mu  sync.Mutex
+	cmd *exec.Cmd
+}
+
+func newAction(_ context.Context, step core.Step) (runtimeexec.Executor, error) {
+	cfg, err := parseConfig(step.ExecutorConfig.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &Executor{
+		cfg:    cfg,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}, nil
+}
+
+func parseConfig(raw map[string]any) (config, error) {
+	if raw == nil {
+		return config{}, fmt.Errorf("action: ref is required")
+	}
+	ref, ok := raw["ref"].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return config{}, fmt.Errorf("action: ref must be a non-empty string")
+	}
+	input := map[string]any{}
+	if rawInput, ok := raw["input"]; ok && rawInput != nil {
+		mapped, ok := rawInput.(map[string]any)
+		if !ok {
+			return config{}, fmt.Errorf("action: input must be an object")
+		}
+		input = mapped
+	}
+	return config{Ref: strings.TrimSpace(ref), Input: input}, nil
+}
+
+func (e *Executor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *Executor) SetStderr(out io.Writer) {
+	e.stderr = out
+}
+
+func (e *Executor) Kill(sig os.Signal) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.cmd == nil || e.cmd.Process == nil {
+		return nil
+	}
+	return e.cmd.Process.Signal(sig)
+}
+
+func (e *Executor) Run(ctx context.Context) error {
+	env := runtime.GetEnv(ctx)
+	envMap := env.UserEnvsMap()
+	bundle, err := resolveBundle(ctx, e.cfg.Ref, resolveOptions{
+		ToolsDir:    envMap[dagutools.EnvToolsDir],
+		WorkDir:     env.WorkingDir,
+		RegistryDir: envMap[envActionRegistry],
+	})
+	if err != nil {
+		return err
+	}
+	m, err := loadManifest(bundle.RootDir)
+	if err != nil {
+		return err
+	}
+	if err := m.validateInput(e.cfg.Input); err != nil {
+		return err
+	}
+	denoPath, err := resolveDeno(ctx, m.Runtime.Deno, envMap, env.WorkingDir)
+	if err != nil {
+		return err
+	}
+
+	runDir, cleanup, err := e.actionRunDir(envMap, env.Step.Name)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	inputPath := filepath.Join(runDir, "input.json")
+	outputPath := filepath.Join(runDir, "output.json")
+	if err := writeJSONFile(inputPath, e.cfg.Input); err != nil {
+		return err
+	}
+
+	entrypoint, err := safeRelativePath(bundle.RootDir, m.Runtime.Entrypoint)
+	if err != nil {
+		return err
+	}
+	if err := e.runDeno(ctx, denoPath, bundle.RootDir, denoInstallArgs(bundle.RootDir, entrypoint), e.stderr, e.stderr, nil); err != nil {
+		return fmt.Errorf("prepare Deno action dependencies: %w", err)
+	}
+	actionEnv := []string{
+		envActionInput + "=" + inputPath,
+		envActionOutput + "=" + outputPath,
+		envActionOutputDir + "=" + runDir,
+		envActionDir + "=" + bundle.RootDir,
+		envActionRef + "=" + bundle.OriginalRef,
+	}
+	if err := e.runDeno(ctx, denoPath, bundle.RootDir, denoRunArgs(bundle.RootDir, entrypoint, inputPath, runDir, m.Permissions), e.stderr, e.stderr, actionEnv); err != nil {
+		return err
+	}
+	return e.writeActionOutput(outputPath)
+}
+
+func (e *Executor) actionRunDir(envMap map[string]string, stepName string) (string, func(), error) {
+	base := strings.TrimSpace(envMap["DAG_RUN_ARTIFACTS_DIR"])
+	if base == "" {
+		dir, err := os.MkdirTemp("", "dagu-action-")
+		if err != nil {
+			return "", func() {}, fmt.Errorf("create action temp dir: %w", err)
+		}
+		return dir, func() { _ = os.RemoveAll(dir) }, nil
+	}
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		return "", func() {}, fmt.Errorf("create action artifacts dir: %w", err)
+	}
+	dir, err := os.MkdirTemp(base, "action-"+safeName(stepName)+"-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create action run dir: %w", err)
+	}
+	return dir, func() {}, nil
+}
+
+func (e *Executor) runDeno(ctx context.Context, denoPath, dir string, args []string, stdout, stderr io.Writer, extraEnv []string) error {
+	cmd := exec.CommandContext(ctx, denoPath, args...) //nolint:gosec
+	cmd.Dir = dir
+	cmd.Env = append(runtime.AllEnvs(ctx), extraEnv...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmdutil.SetupCommand(cmd)
+
+	e.mu.Lock()
+	e.cmd = cmd
+	e.mu.Unlock()
+	err := cmd.Run()
+	e.mu.Lock()
+	if e.cmd == cmd {
+		e.cmd = nil
+	}
+	e.mu.Unlock()
+	return err
+}
+
+func (e *Executor) writeActionOutput(path string) error {
+	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read action output: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil
+	}
+	if !json.Valid(data) {
+		return fmt.Errorf("action output must be JSON")
+	}
+	if _, err := e.stdout.Write(data); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(string(data), "\n") {
+		_, err = io.WriteString(e.stdout, "\n")
+	}
+	return err
+}
+
+func denoInstallArgs(rootDir, entrypoint string) []string {
+	args := []string{"install"}
+	args = append(args, denoLockArgs(rootDir)...)
+	args = append(args, "--entrypoint", entrypoint)
+	return args
+}
+
+func denoRunArgs(rootDir, entrypoint, inputPath, outputDir string, perms permissionManifest) []string {
+	args := []string{
+		"run",
+		"--cached-only",
+		"--no-prompt",
+		"--allow-read=" + strings.Join(readPermissions(rootDir, inputPath, perms.Read), ","),
+		"--allow-write=" + strings.Join(writePermissions(outputDir, perms.Write), ","),
+	}
+	args = append(args, denoLockArgs(rootDir)...)
+	if len(perms.Net) > 0 {
+		args = append(args, "--allow-net="+strings.Join(trimmedStrings(perms.Net), ","))
+	}
+	envPerms := actionEnvPermissions(perms.Env)
+	if len(envPerms) > 0 {
+		args = append(args, "--allow-env="+strings.Join(envPerms, ","))
+	}
+	args = append(args, entrypoint)
+	return args
+}
+
+func denoLockArgs(rootDir string) []string {
+	lockPath := filepath.Join(rootDir, "deno.lock")
+	if info, err := os.Stat(lockPath); err == nil && !info.IsDir() {
+		return []string{"--lock=" + filepath.Clean(lockPath), "--frozen"}
+	}
+	return nil
+}
+
+func actionEnvPermissions(extra []string) []string {
+	return dedupeStrings(append([]string{
+		envActionInput,
+		envActionOutput,
+		envActionOutputDir,
+		envActionDir,
+		envActionRef,
+	}, trimmedStrings(extra)...))
+}
+
+func readPermissions(rootDir, inputPath string, extra []string) []string {
+	paths := []string{filepath.Clean(rootDir), filepath.Clean(inputPath)}
+	for _, item := range extra {
+		item = strings.TrimSpace(item)
+		if item == "" || filepath.IsAbs(item) {
+			continue
+		}
+		if path, err := safeRelativePath(rootDir, item); err == nil {
+			paths = append(paths, path)
+		}
+	}
+	return dedupeStrings(paths)
+}
+
+func writePermissions(outputDir string, extra []string) []string {
+	paths := []string{filepath.Clean(outputDir)}
+	for _, item := range extra {
+		item = strings.TrimSpace(item)
+		if item == "" || filepath.IsAbs(item) {
+			continue
+		}
+		path := filepath.Join(outputDir, item)
+		if isPathWithin(outputDir, path) {
+			paths = append(paths, filepath.Clean(path))
+		}
+	}
+	return dedupeStrings(paths)
+}
+
+func writeJSONFile(path string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal action input: %w", err)
+	}
+	if err := os.WriteFile(filepath.Clean(path), data, 0o600); err != nil {
+		return fmt.Errorf("write action input: %w", err)
+	}
+	return nil
+}
+
+func trimmedStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+var safeNameRegexp = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+
+func safeName(name string) string {
+	name = strings.Trim(safeNameRegexp.ReplaceAllString(name, "-"), "-")
+	if name == "" {
+		return "step"
+	}
+	return name
+}
+
+var configSchema = &jsonschema.Schema{
+	Type:     "object",
+	Required: []string{"ref"},
+	Properties: map[string]*jsonschema.Schema{
+		"ref": {
+			Type:        "string",
+			Description: "External action reference. Supported prefixes are source: and pkg:.",
+		},
+		"input": {
+			Type:        "object",
+			Description: "Action input object produced from the step with field.",
+		},
+	},
+	AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+	runtimeexec.RegisterExecutor(executorType, newAction, validateStep, core.ExecutorCapabilities{})
+}
+
+func validateStep(step core.Step) error {
+	_, err := parseConfig(step.ExecutorConfig.Config)
+	return err
+}

--- a/internal/runtime/builtin/action/action.go
+++ b/internal/runtime/builtin/action/action.go
@@ -31,7 +31,6 @@ const (
 	envActionOutputDir = "DAGU_ACTION_OUTPUT_DIR"
 	envActionDir       = "DAGU_ACTION_DIR"
 	envActionRef       = "DAGU_ACTION_REF"
-	envActionRegistry  = "DAGU_ACTION_REGISTRY_DIR"
 )
 
 var _ runtimeexec.Executor = (*Executor)(nil)
@@ -102,9 +101,8 @@ func (e *Executor) Run(ctx context.Context) error {
 	env := runtime.GetEnv(ctx)
 	envMap := env.UserEnvsMap()
 	bundle, err := resolveBundle(ctx, e.cfg.Ref, resolveOptions{
-		ToolsDir:    envMap[dagutools.EnvToolsDir],
-		WorkDir:     env.WorkingDir,
-		RegistryDir: envMap[envActionRegistry],
+		ToolsDir: envMap[dagutools.EnvToolsDir],
+		WorkDir:  env.WorkingDir,
 	})
 	if err != nil {
 		return err
@@ -338,7 +336,7 @@ var configSchema = &jsonschema.Schema{
 	Properties: map[string]*jsonschema.Schema{
 		"ref": {
 			Type:        "string",
-			Description: "External action reference. Supported prefixes are source: and pkg:.",
+			Description: "External action reference. Use owner/repo@version for GitHub actions or source:target@version for explicit source actions.",
 		},
 		"input": {
 			Type:        "object",

--- a/internal/runtime/builtin/action/action_integration_test.go
+++ b/internal/runtime/builtin/action/action_integration_test.go
@@ -33,7 +33,7 @@ func TestExecutorRunsLocalSourceActionWithRealDenoIntegration(t *testing.T) {
 	actionDir := filepath.Join(workDir, "actions", "echo")
 	writeRealDenoAction(t, actionDir, realDenoVersion())
 
-	dag, err := spec.LoadYAML(context.Background(), []byte(fmt.Sprintf(`
+	dag, err := spec.LoadYAML(context.Background(), fmt.Appendf(nil, `
 name: real-deno-action
 working_dir: %s
 steps:
@@ -41,7 +41,7 @@ steps:
     action: source:actions/echo@local
     with:
       text: hello from dagu action
-`, strconv.Quote(workDir))))
+`, strconv.Quote(workDir)))
 	require.NoError(t, err)
 	require.Len(t, dag.Steps, 1)
 	step := dag.Steps[0]

--- a/internal/runtime/builtin/action/action_integration_test.go
+++ b/internal/runtime/builtin/action/action_integration_test.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorRunsLocalSourceActionWithRealDenoIntegration(t *testing.T) {
+	if os.Getenv("DAGU_ACTION_DENO_INTEGRATION") != "1" {
+		t.Skip("set DAGU_ACTION_DENO_INTEGRATION=1 to run the real Deno/aqua integration test")
+	}
+
+	workDir := t.TempDir()
+	toolsDir := filepath.Join(t.TempDir(), "tools")
+	artifactDir := filepath.Join(t.TempDir(), "artifacts")
+	actionDir := filepath.Join(workDir, "actions", "echo")
+	writeRealDenoAction(t, actionDir, realDenoVersion())
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(fmt.Sprintf(`
+name: real-deno-action
+working_dir: %s
+steps:
+  - name: echo-action
+    action: source:actions/echo@local
+    with:
+      text: hello from dagu action
+`, strconv.Quote(workDir))))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+	step := dag.Steps[0]
+	require.Equal(t, core.ExecutorTypeAction, step.ExecutorConfig.Type)
+	require.Equal(t, "source:actions/echo@local", step.ExecutorConfig.Config["ref"])
+
+	ctx := runtime.NewContext(
+		context.Background(),
+		dag,
+		"run-1",
+		"",
+		runtime.WithWorkDir(workDir),
+		runtime.WithEnvVars(dagutools.EnvToolsDir+"="+toolsDir),
+		runtime.WithArtifactDir(artifactDir),
+	)
+	ctx = runtime.WithEnv(ctx, runtime.NewEnv(ctx, step))
+
+	exec, err := newAction(ctx, step)
+	require.NoError(t, err)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exec.SetStdout(&stdout)
+	exec.SetStderr(&stderr)
+
+	require.NoError(t, exec.Run(ctx))
+
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &output))
+	assert.Equal(t, true, output["ok"])
+	assert.Equal(t, "hello from dagu action", output["text"])
+	assert.Equal(t, "source:actions/echo@local", output["ref"])
+	assert.Equal(t, "echo-action", output["step"])
+	assert.Equal(t, true, output["actionDirReadable"])
+	assert.Contains(t, stderr.String(), "action stdout")
+	assert.NotContains(t, stdout.String(), "action stdout")
+}
+
+func realDenoVersion() string {
+	if version := strings.TrimSpace(os.Getenv("DAGU_ACTION_DENO_VERSION")); version != "" {
+		return version
+	}
+	return "v2.5.2"
+}
+
+func writeRealDenoAction(t *testing.T, dir, denoVersion string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	manifest := `apiVersion: dagu.dev/v1alpha1
+name: real-deno-echo
+runtime:
+  type: deno
+  deno: ` + denoVersion + `
+  entrypoint: mod.ts
+inputs:
+  type: object
+  required: [text]
+  additionalProperties: false
+  properties:
+    text:
+      type: string
+permissions:
+  env: [DAG_RUN_STEP_NAME]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestFileName), []byte(manifest), 0o600))
+	source := `const inputPath = Deno.env.get("DAGU_ACTION_INPUT");
+const outputPath = Deno.env.get("DAGU_ACTION_OUTPUT");
+const actionDir = Deno.env.get("DAGU_ACTION_DIR");
+const actionRef = Deno.env.get("DAGU_ACTION_REF");
+const step = Deno.env.get("DAG_RUN_STEP_NAME");
+
+if (!inputPath || !outputPath || !actionDir || !actionRef || !step) {
+  throw new Error("missing Dagu action environment");
+}
+
+const input = JSON.parse(await Deno.readTextFile(inputPath));
+const actionInfo = await Deno.stat(actionDir);
+
+console.log("action stdout");
+await Deno.writeTextFile(outputPath, JSON.stringify({
+  ok: true,
+  text: input.text,
+  ref: actionRef,
+  step,
+  actionDirReadable: actionInfo.isDirectory,
+}));
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mod.ts"), []byte(source), 0o600))
+}

--- a/internal/runtime/builtin/action/action_test.go
+++ b/internal/runtime/builtin/action/action_test.go
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorRunsLocalSourceActionWithDeclaredDeno(t *testing.T) {
+	if os.Getenv("DAGU_FAKE_DENO") == "1" {
+		fakeDenoProcess()
+		return
+	}
+	t.Parallel()
+
+	actionDir := writeTestAction(t, "source-action", "v2.5.2")
+	manifestPath := writeToolsManifest(t, os.Args[0], "v2.5.2")
+	argsPath := filepath.Join(t.TempDir(), "deno-args.txt")
+	artifactDir := t.TempDir()
+
+	step := core.Step{
+		Name: "notify",
+		ExecutorConfig: core.ExecutorConfig{
+			Type: executorType,
+			Config: map[string]any{
+				"ref": "source:" + actionDir + "@local",
+				"input": map[string]any{
+					"channel": "#ops",
+					"text":    "done",
+				},
+			},
+		},
+	}
+	ctx := runtime.NewContext(
+		context.Background(),
+		&core.DAG{Name: "action-test"},
+		"run-1",
+		"",
+		runtime.WithEnvVars(
+			dagutools.EnvManifest+"="+manifestPath,
+			"DAGU_FAKE_DENO=1",
+			"DAGU_FAKE_DENO_ARGS_FILE="+argsPath,
+			"DAGU_FAKE_DENO_LOG_STDOUT=1",
+		),
+		runtime.WithArtifactDir(artifactDir),
+	)
+
+	exec, err := newAction(ctx, step)
+	require.NoError(t, err)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exec.SetStdout(&stdout)
+	exec.SetStderr(&stderr)
+
+	require.NoError(t, exec.Run(ctx))
+	assert.JSONEq(t, `{"ok":true,"mode":"run"}`, strings.TrimSpace(stdout.String()))
+	assert.Contains(t, stderr.String(), "action log")
+
+	argsData, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	argsLog := string(argsData)
+	assert.Contains(t, argsLog, "install")
+	assert.Contains(t, argsLog, "--entrypoint "+filepath.Join(actionDir, "mod.ts"))
+	assert.Contains(t, argsLog, "run --cached-only --no-prompt")
+	assert.Contains(t, argsLog, "--lock="+filepath.Join(actionDir, "deno.lock"))
+	assert.Contains(t, argsLog, "--frozen")
+	assert.Contains(t, argsLog, "--allow-env=DAGU_ACTION_INPUT,DAGU_ACTION_OUTPUT,DAGU_ACTION_OUTPUT_DIR,DAGU_ACTION_DIR,DAGU_ACTION_REF,SLACK_BOT_TOKEN")
+	assert.Contains(t, argsLog, "--allow-net=slack.com")
+	assert.NotContains(t, argsLog, "--allow-run")
+	assert.NotContains(t, argsLog, "--allow-all")
+}
+
+func TestResolveLocalSourceActionUsesWorkDir(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	actionDir := filepath.Join(workDir, "actions", "notify")
+	writeManifestOnly(t, actionDir, "source-action", "v2.5.2")
+
+	bundle, err := resolveBundle(context.Background(), "source:actions/notify@local", resolveOptions{
+		WorkDir: workDir,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, bundleModeSource, bundle.Mode)
+	assert.Equal(t, actionDir, bundle.RootDir)
+	assert.Equal(t, actionDir, bundle.ResolvedRef)
+	assert.Equal(t, "local", bundle.Version)
+}
+
+func TestResolvePackageActionFromRegistryDir(t *testing.T) {
+	t.Parallel()
+
+	registryDir := t.TempDir()
+	actionDir := filepath.Join(registryDir, "dagu-actions", "slack.notify", "1.2.3")
+	writeManifestOnly(t, actionDir, "pkg-action", "v2.5.2")
+
+	bundle, err := resolveBundle(context.Background(), "pkg:dagu-actions/slack.notify@1.2.3", resolveOptions{
+		RegistryDir: registryDir,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, bundleModePackage, bundle.Mode)
+	assert.Equal(t, actionDir, bundle.RootDir)
+	assert.Equal(t, "dagu-actions/slack.notify", bundle.ResolvedRef)
+	assert.Equal(t, "1.2.3", bundle.Version)
+}
+
+func TestResolvePackageActionDefaultsRegistryUnderToolsDir(t *testing.T) {
+	t.Parallel()
+
+	toolsDir := t.TempDir()
+	actionDir := filepath.Join(toolsDir, "actions", "registry", "dagu-actions", "slack.notify", "1.2.3")
+	writeManifestOnly(t, actionDir, "pkg-action", "v2.5.2")
+
+	bundle, err := resolveBundle(context.Background(), "pkg:dagu-actions/slack.notify@1.2.3", resolveOptions{
+		ToolsDir: toolsDir,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, actionDir, bundle.RootDir)
+}
+
+func TestResolvePackageActionRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveBundle(context.Background(), "pkg:../bad@1.0.0", resolveOptions{
+		RegistryDir: t.TempDir(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid package name")
+}
+
+func TestLoadManifestRejectsEscapingPermissionPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mod.ts"), []byte("export {};\n"), 0o600))
+	manifest := `apiVersion: dagu.dev/v1alpha1
+name: bad-action
+runtime:
+  type: deno
+  deno: v2.5.2
+  entrypoint: mod.ts
+permissions:
+  read: ["../secret"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestFileName), []byte(manifest), 0o600))
+
+	_, err := loadManifest(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid action read permission path")
+}
+
+func writeTestAction(t *testing.T, name, denoVersion string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeManifestOnly(t, dir, name, denoVersion)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mod.ts"), []byte("export {};\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deno.lock"), []byte("{}\n"), 0o600))
+	return dir
+}
+
+func writeManifestOnly(t *testing.T, dir, name, denoVersion string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	manifest := `apiVersion: dagu.dev/v1alpha1
+name: ` + name + `
+runtime:
+  type: deno
+  deno: ` + denoVersion + `
+  entrypoint: mod.ts
+inputs:
+  type: object
+  additionalProperties: true
+permissions:
+  net: [slack.com]
+  env: [SLACK_BOT_TOKEN]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifestFileName), []byte(manifest), 0o600))
+}
+
+func writeToolsManifest(t *testing.T, denoPath, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.json")
+	manifest := dagutools.Manifest{
+		Provider: "aqua",
+		Commands: map[string]dagutools.Command{
+			"deno": {
+				Name:    "deno",
+				Path:    denoPath,
+				Package: denoAquaPackage,
+				Version: version,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, data, 0o600))
+	return manifestPath
+}
+
+func fakeDenoProcess() {
+	argsPath := os.Getenv("DAGU_FAKE_DENO_ARGS_FILE")
+	if argsPath != "" {
+		line := strings.Join(os.Args[1:], " ") + "\n"
+		f, err := os.OpenFile(argsPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err == nil {
+			_, _ = f.WriteString(line)
+			_ = f.Close()
+		}
+	}
+	if len(os.Args) > 1 && os.Args[1] == "run" {
+		if os.Getenv("DAGU_FAKE_DENO_LOG_STDOUT") == "1" {
+			_, _ = os.Stdout.WriteString("action log\n")
+		}
+		output := os.Getenv(envActionOutput)
+		if output != "" {
+			_ = os.WriteFile(output, []byte(`{"ok":true,"mode":"run"}`), 0o600)
+		}
+	}
+	os.Exit(0)
+}

--- a/internal/runtime/builtin/action/action_test.go
+++ b/internal/runtime/builtin/action/action_test.go
@@ -101,47 +101,65 @@ func TestResolveLocalSourceActionUsesWorkDir(t *testing.T) {
 	assert.Equal(t, "local", bundle.Version)
 }
 
-func TestResolvePackageActionFromRegistryDir(t *testing.T) {
+func TestGitHubRepoURLForBareActionRef(t *testing.T) {
 	t.Parallel()
 
-	registryDir := t.TempDir()
-	actionDir := filepath.Join(registryDir, "dagu-actions", "slack.notify", "1.2.3")
-	writeManifestOnly(t, actionDir, "pkg-action", "v2.5.2")
+	repoURL, err := githubRepoURL("acme/dagu-actions-slack")
 
-	bundle, err := resolveBundle(context.Background(), "pkg:dagu-actions/slack.notify@1.2.3", resolveOptions{
-		RegistryDir: registryDir,
-	})
 	require.NoError(t, err)
-
-	assert.Equal(t, bundleModePackage, bundle.Mode)
-	assert.Equal(t, actionDir, bundle.RootDir)
-	assert.Equal(t, "dagu-actions/slack.notify", bundle.ResolvedRef)
-	assert.Equal(t, "1.2.3", bundle.Version)
+	assert.Equal(t, "https://github.com/acme/dagu-actions-slack.git", repoURL)
 }
 
-func TestResolvePackageActionDefaultsRegistryUnderToolsDir(t *testing.T) {
+func TestGitHubRepoURLRejectsInvalidTargets(t *testing.T) {
 	t.Parallel()
 
-	toolsDir := t.TempDir()
-	actionDir := filepath.Join(toolsDir, "actions", "registry", "dagu-actions", "slack.notify", "1.2.3")
-	writeManifestOnly(t, actionDir, "pkg-action", "v2.5.2")
-
-	bundle, err := resolveBundle(context.Background(), "pkg:dagu-actions/slack.notify@1.2.3", resolveOptions{
-		ToolsDir: toolsDir,
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, actionDir, bundle.RootDir)
+	for _, target := range []string{
+		"dagu-actions-slack",
+		"acme/dagu-actions/slack",
+		"acme/../slack",
+		"-acme/slack",
+		"acme-/slack",
+		"acme/slack repo",
+		"github.com/acme/slack",
+	} {
+		t.Run(target, func(t *testing.T) {
+			_, err := githubRepoURL(target)
+			require.Error(t, err)
+		})
+	}
 }
 
-func TestResolvePackageActionRejectsTraversal(t *testing.T) {
+func TestResolvePackagePrefixRejectsTraversal(t *testing.T) {
 	t.Parallel()
 
 	_, err := resolveBundle(context.Background(), "pkg:../bad@1.0.0", resolveOptions{
-		RegistryDir: t.TempDir(),
+		ToolsDir: t.TempDir(),
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid package name")
+	assert.Contains(t, err.Error(), "owner/repo@version")
+}
+
+func TestValidateGitRefRejectsUnsafeRefs(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{
+		"",
+		"-main",
+		"feature/../main",
+		"feature//main",
+		"feature.lock/main",
+		"main.lock",
+		"main with space",
+		"main~1",
+		"main@{1}",
+	} {
+		t.Run(ref, func(t *testing.T) {
+			require.Error(t, validateGitRef(ref))
+		})
+	}
+
+	require.NoError(t, validateGitRef("v1.2.3"))
+	require.NoError(t, validateGitRef("release/v1"))
 }
 
 func TestWritePermissionsResolveExtrasFromActionRoot(t *testing.T) {

--- a/internal/runtime/builtin/action/action_test.go
+++ b/internal/runtime/builtin/action/action_test.go
@@ -150,12 +150,31 @@ func TestWritePermissionsResolveExtrasFromActionRoot(t *testing.T) {
 	rootDir := filepath.Join(t.TempDir(), "action")
 	outputDir := filepath.Join(t.TempDir(), "output")
 
-	got := writePermissions(rootDir, outputDir, []string{"cache/state.json", "../secret", "/tmp/abs"})
+	got := writePermissions(rootDir, outputDir, []string{"cache/state.json", "../secret", "/tmp/abs", `C:\tmp\abs`})
 
 	assert.Equal(t, []string{
 		filepath.Clean(outputDir),
 		filepath.Join(rootDir, "cache", "state.json"),
 	}, got)
+}
+
+func TestValidateRelativePermissionPathRejectsAbsoluteLikePaths(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	for _, path := range []string{
+		"/tmp/abs",
+		`\tmp\abs`,
+		`C:\tmp\abs`,
+		"C:/tmp/abs",
+		"C:tmp",
+		"../secret",
+		"cache/../../secret",
+	} {
+		t.Run(path, func(t *testing.T) {
+			require.Error(t, validateRelativePermissionPath(rootDir, path, "read"))
+		})
+	}
 }
 
 func TestLoadManifestRejectsEscapingPermissionPath(t *testing.T) {

--- a/internal/runtime/builtin/action/action_test.go
+++ b/internal/runtime/builtin/action/action_test.go
@@ -144,6 +144,20 @@ func TestResolvePackageActionRejectsTraversal(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid package name")
 }
 
+func TestWritePermissionsResolveExtrasFromActionRoot(t *testing.T) {
+	t.Parallel()
+
+	rootDir := filepath.Join(t.TempDir(), "action")
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	got := writePermissions(rootDir, outputDir, []string{"cache/state.json", "../secret", "/tmp/abs"})
+
+	assert.Equal(t, []string{
+		filepath.Clean(outputDir),
+		filepath.Join(rootDir, "cache", "state.json"),
+	}, got)
+}
+
 func TestLoadManifestRejectsEscapingPermissionPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/builtin/action/deno.go
+++ b/internal/runtime/builtin/action/deno.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+	daguaqua "github.com/dagucloud/dagu/internal/tools/aqua"
+)
+
+const (
+	runtimeTypeDeno = "deno"
+	denoCommand     = "deno"
+	denoAquaPackage = "denoland/deno"
+)
+
+func resolveDeno(ctx context.Context, version string, env map[string]string, workDir string) (string, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "", fmt.Errorf("deno version is required")
+	}
+	if path, ok := denoFromManifest(env[dagutools.EnvManifest], version); ok {
+		return path, nil
+	}
+	toolsDir := strings.TrimSpace(env[dagutools.EnvToolsDir])
+	if toolsDir == "" {
+		toolsDir = inferToolsDirFromManifest(env[dagutools.EnvManifest])
+	}
+	if toolsDir == "" {
+		return "", fmt.Errorf("%s is required to install Deno runtime", dagutools.EnvToolsDir)
+	}
+	manifest, err := daguaqua.New().Install(ctx, &core.ToolConfig{
+		Provider: "aqua",
+		Packages: []core.ToolPackage{{
+			Package:  denoAquaPackage,
+			Version:  version,
+			Commands: []string{denoCommand},
+		}},
+	}, dagutools.InstallOptions{
+		ToolsDir: toolsDir,
+		WorkDir:  workDir,
+	})
+	if err != nil {
+		return "", err
+	}
+	cmd, ok := manifest.Commands[denoCommand]
+	if !ok || strings.TrimSpace(cmd.Path) == "" {
+		return "", fmt.Errorf("installed Deno runtime did not expose %q", denoCommand)
+	}
+	return cmd.Path, nil
+}
+
+func denoFromManifest(manifestPath, version string) (string, bool) {
+	manifestPath = strings.TrimSpace(manifestPath)
+	if manifestPath == "" {
+		return "", false
+	}
+	manifest, err := dagutools.ReadManifest(manifestPath)
+	if err != nil {
+		return "", false
+	}
+	cmd, ok := manifest.Commands[denoCommand]
+	if !ok || strings.TrimSpace(cmd.Path) == "" {
+		return "", false
+	}
+	if strings.TrimSpace(cmd.Package) != denoAquaPackage || strings.TrimSpace(cmd.Version) != version {
+		return "", false
+	}
+	return cmd.Path, true
+}
+
+func inferToolsDirFromManifest(manifestPath string) string {
+	manifestPath = strings.TrimSpace(manifestPath)
+	if manifestPath == "" {
+		return ""
+	}
+	manifest, err := dagutools.ReadManifest(manifestPath)
+	if err != nil || strings.TrimSpace(manifest.RootDir) == "" {
+		return ""
+	}
+	root := filepath.Clean(manifest.RootDir)
+	if filepath.Base(root) != "root" {
+		return ""
+	}
+	aquaDir := filepath.Dir(root)
+	if filepath.Base(aquaDir) != "aqua" {
+		return ""
+	}
+	return filepath.Dir(aquaDir)
+}

--- a/internal/runtime/builtin/action/manifest.go
+++ b/internal/runtime/builtin/action/manifest.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -140,11 +141,30 @@ func validateNetPermission(host string) error {
 
 func validateRelativePermissionPath(rootDir, path string, kind string) error {
 	path = strings.TrimSpace(path)
-	if path == "" || filepath.IsAbs(path) {
+	if path == "" || isAbsoluteActionPath(path) {
 		return fmt.Errorf("invalid action %s permission path %q", kind, path)
 	}
 	if _, err := safeRelativePath(rootDir, path); err != nil {
 		return fmt.Errorf("invalid action %s permission path %q: %w", kind, path, err)
 	}
 	return nil
+}
+
+func isAbsoluteActionPath(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if filepath.IsAbs(value) {
+		return true
+	}
+	slashPath := strings.ReplaceAll(value, `\`, "/")
+	if path.IsAbs(slashPath) {
+		return true
+	}
+	if len(slashPath) >= 2 && slashPath[1] == ':' {
+		drive := slashPath[0]
+		return ('A' <= drive && drive <= 'Z') || ('a' <= drive && drive <= 'z')
+	}
+	return false
 }

--- a/internal/runtime/builtin/action/manifest.go
+++ b/internal/runtime/builtin/action/manifest.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const manifestFileName = "dagu-action.yaml"
+
+var envNameRegexp = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type manifest struct {
+	APIVersion  string             `yaml:"apiVersion"`
+	Name        string             `yaml:"name"`
+	Runtime     runtimeManifest    `yaml:"runtime"`
+	Inputs      map[string]any     `yaml:"inputs"`
+	Outputs     map[string]any     `yaml:"outputs"`
+	Permissions permissionManifest `yaml:"permissions"`
+}
+
+type runtimeManifest struct {
+	Type       string `yaml:"type"`
+	Deno       string `yaml:"deno"`
+	Entrypoint string `yaml:"entrypoint"`
+}
+
+type permissionManifest struct {
+	Net   []string `yaml:"net"`
+	Env   []string `yaml:"env"`
+	Read  []string `yaml:"read"`
+	Write []string `yaml:"write"`
+}
+
+func loadManifest(rootDir string) (*manifest, error) {
+	path := filepath.Join(rootDir, manifestFileName)
+	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read action manifest: %w", err)
+	}
+	var m manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse action manifest: %w", err)
+	}
+	if err := m.validate(rootDir); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (m *manifest) validate(rootDir string) error {
+	if strings.TrimSpace(m.Name) == "" {
+		return fmt.Errorf("action manifest name is required")
+	}
+	if strings.TrimSpace(m.Runtime.Type) != runtimeTypeDeno {
+		return fmt.Errorf("action runtime type must be %q", runtimeTypeDeno)
+	}
+	if strings.TrimSpace(m.Runtime.Deno) == "" {
+		return fmt.Errorf("action runtime.deno is required")
+	}
+	entrypoint := strings.TrimSpace(m.Runtime.Entrypoint)
+	if entrypoint == "" {
+		return fmt.Errorf("action runtime.entrypoint is required")
+	}
+	entrypointPath, err := safeRelativePath(rootDir, entrypoint)
+	if err != nil {
+		return fmt.Errorf("invalid action runtime.entrypoint: %w", err)
+	}
+	info, err := os.Stat(entrypointPath)
+	if err != nil {
+		return fmt.Errorf("stat action runtime.entrypoint: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("action runtime.entrypoint must be a file")
+	}
+	for _, host := range m.Permissions.Net {
+		if err := validateNetPermission(host); err != nil {
+			return err
+		}
+	}
+	for _, env := range m.Permissions.Env {
+		if !envNameRegexp.MatchString(strings.TrimSpace(env)) {
+			return fmt.Errorf("invalid action env permission %q", env)
+		}
+	}
+	for _, path := range m.Permissions.Read {
+		if err := validateRelativePermissionPath(rootDir, path, "read"); err != nil {
+			return err
+		}
+	}
+	for _, path := range m.Permissions.Write {
+		if err := validateRelativePermissionPath(rootDir, path, "write"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *manifest) validateInput(input map[string]any) error {
+	if len(m.Inputs) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(m.Inputs)
+	if err != nil {
+		return fmt.Errorf("marshal action input schema: %w", err)
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return fmt.Errorf("parse action input schema: %w", err)
+	}
+	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	if err != nil {
+		return fmt.Errorf("resolve action input schema: %w", err)
+	}
+	if err := resolved.Validate(input); err != nil {
+		return fmt.Errorf("action input does not match inputs schema: %w", err)
+	}
+	return nil
+}
+
+func validateNetPermission(host string) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fmt.Errorf("empty action net permission")
+	}
+	if strings.Contains(host, "://") || strings.ContainsAny(host, `/\`) || strings.Contains(host, "*") {
+		return fmt.Errorf("invalid action net permission %q", host)
+	}
+	return nil
+}
+
+func validateRelativePermissionPath(rootDir, path string, kind string) error {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.IsAbs(path) {
+		return fmt.Errorf("invalid action %s permission path %q", kind, path)
+	}
+	if _, err := safeRelativePath(rootDir, path); err != nil {
+		return fmt.Errorf("invalid action %s permission path %q: %w", kind, path, err)
+	}
+	return nil
+}

--- a/internal/runtime/builtin/action/resolver.go
+++ b/internal/runtime/builtin/action/resolver.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
@@ -20,17 +21,19 @@ import (
 
 const (
 	actionPrefixSource = "source:"
-	actionPrefixPkg    = "pkg:"
 
-	bundleModeSource  = "source"
-	bundleModePackage = "package"
+	bundleModeSource = "source"
+)
+
+var (
+	githubOwnerRegexp = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$`)
+	githubRepoRegexp  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 )
 
 type resolveOptions struct {
-	ToolsDir    string
-	CacheDir    string
-	RegistryDir string
-	WorkDir     string
+	ToolsDir string
+	CacheDir string
+	WorkDir  string
 }
 
 type actionBundle struct {
@@ -46,11 +49,33 @@ func resolveBundle(ctx context.Context, ref string, opts resolveOptions) (*actio
 	switch {
 	case strings.HasPrefix(ref, actionPrefixSource):
 		return resolveSourceBundle(ctx, ref, opts)
-	case strings.HasPrefix(ref, actionPrefixPkg):
-		return resolvePackageBundle(ref, opts)
+	case strings.HasPrefix(ref, "pkg:"):
+		return nil, fmt.Errorf("package action references must use GitHub owner/repo@version")
 	default:
-		return nil, fmt.Errorf("action ref must start with %q or %q", actionPrefixSource, actionPrefixPkg)
+		return resolveGitHubBundle(ctx, ref, opts)
 	}
+}
+
+func resolveGitHubBundle(ctx context.Context, ref string, opts resolveOptions) (*actionBundle, error) {
+	target, version, err := splitVersionedRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	repoURL, err := githubRepoURL(target)
+	if err != nil {
+		return nil, err
+	}
+	root, resolved, err := cloneGitSource(ctx, repoURL, version, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &actionBundle{
+		Mode:        bundleModeSource,
+		RootDir:     root,
+		OriginalRef: ref,
+		ResolvedRef: resolved,
+		Version:     version,
+	}, nil
 }
 
 func resolveSourceBundle(ctx context.Context, ref string, opts resolveOptions) (*actionBundle, error) {
@@ -76,48 +101,6 @@ func resolveSourceBundle(ctx context.Context, ref string, opts resolveOptions) (
 		RootDir:     root,
 		OriginalRef: ref,
 		ResolvedRef: resolved,
-		Version:     version,
-	}, nil
-}
-
-func resolvePackageBundle(ref string, opts resolveOptions) (*actionBundle, error) {
-	target, version, err := splitVersionedRef(strings.TrimPrefix(ref, actionPrefixPkg))
-	if err != nil {
-		return nil, err
-	}
-	if dir, ok := localPackageDir(target); ok {
-		return &actionBundle{
-			Mode:        bundleModePackage,
-			RootDir:     dir,
-			OriginalRef: ref,
-			ResolvedRef: dir,
-			Version:     version,
-		}, nil
-	}
-	if err := validatePackageName(target); err != nil {
-		return nil, err
-	}
-	if err := validatePackageVersion(version); err != nil {
-		return nil, err
-	}
-	registryDir := packageRegistryDir(opts)
-	if registryDir == "" {
-		return nil, fmt.Errorf("package action registry dir is required")
-	}
-	root := filepath.Join(registryDir, filepath.FromSlash(target), version)
-	if !isPathWithin(registryDir, root) {
-		return nil, fmt.Errorf("invalid package action path")
-	}
-	if info, err := os.Stat(root); err != nil {
-		return nil, fmt.Errorf("stat package action: %w", err)
-	} else if !info.IsDir() {
-		return nil, fmt.Errorf("package action path must be a directory")
-	}
-	return &actionBundle{
-		Mode:        bundleModePackage,
-		RootDir:     root,
-		OriginalRef: ref,
-		ResolvedRef: target,
 		Version:     version,
 	}, nil
 }
@@ -149,10 +132,6 @@ func localSourceDir(target string, workDir string) (string, bool) {
 	return "", false
 }
 
-func localPackageDir(target string) (string, bool) {
-	return fileURLDir(target)
-}
-
 func fileURLDir(target string) (string, bool) {
 	if !strings.HasPrefix(target, "file://") {
 		return "", false
@@ -165,6 +144,9 @@ func fileURLDir(target string) (string, bool) {
 }
 
 func cloneGitSource(ctx context.Context, target, version string, opts resolveOptions) (string, string, error) {
+	if err := validateGitRef(version); err != nil {
+		return "", "", err
+	}
 	cacheDir := actionCacheDir(opts)
 	if cacheDir == "" {
 		return "", "", fmt.Errorf("action cache dir is required for remote source actions")
@@ -238,6 +220,22 @@ func gitURL(target string) string {
 	return target
 }
 
+func githubRepoURL(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	parts := strings.Split(target, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("GitHub action ref target must be owner/repo")
+	}
+	owner, repo := parts[0], parts[1]
+	if !githubOwnerRegexp.MatchString(owner) || strings.HasSuffix(owner, "-") {
+		return "", fmt.Errorf("invalid GitHub action owner %q", owner)
+	}
+	if !githubRepoRegexp.MatchString(repo) || repo == "." || repo == ".." || strings.HasSuffix(repo, ".git") {
+		return "", fmt.Errorf("invalid GitHub action repository %q", repo)
+	}
+	return "https://github.com/" + owner + "/" + repo + ".git", nil
+}
+
 func actionCacheDir(opts resolveOptions) string {
 	if strings.TrimSpace(opts.CacheDir) != "" {
 		return strings.TrimSpace(opts.CacheDir)
@@ -248,40 +246,9 @@ func actionCacheDir(opts resolveOptions) string {
 	return filepath.Join(strings.TrimSpace(opts.ToolsDir), "actions")
 }
 
-func packageRegistryDir(opts resolveOptions) string {
-	if strings.TrimSpace(opts.RegistryDir) != "" {
-		return strings.TrimSpace(opts.RegistryDir)
-	}
-	if strings.TrimSpace(opts.ToolsDir) == "" {
-		return ""
-	}
-	return filepath.Join(strings.TrimSpace(opts.ToolsDir), "actions", "registry")
-}
-
 func hashRef(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
-}
-
-func validatePackageName(name string) error {
-	name = strings.TrimSpace(name)
-	if name == "" || filepath.IsAbs(name) || strings.Contains(name, "\\") {
-		return fmt.Errorf("invalid package name %q", name)
-	}
-	for part := range strings.SplitSeq(name, "/") {
-		if part == "" || part == "." || part == ".." {
-			return fmt.Errorf("invalid package name %q", name)
-		}
-	}
-	return nil
-}
-
-func validatePackageVersion(version string) error {
-	version = strings.TrimSpace(version)
-	if version == "" || strings.ContainsAny(version, `/\`) || version == "." || version == ".." {
-		return fmt.Errorf("invalid package version %q", version)
-	}
-	return nil
 }
 
 func safeRelativePath(rootDir, relPath string) (string, error) {
@@ -298,6 +265,29 @@ func safeRelativePath(rootDir, relPath string) (string, error) {
 		return "", fmt.Errorf("path escapes action directory")
 	}
 	return filepath.Clean(resolvedPath), nil
+}
+
+func validateGitRef(ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("action git ref is required")
+	}
+	if strings.HasPrefix(ref, "-") ||
+		strings.ContainsAny(ref, " \t\r\n\\~^:?*[]") ||
+		strings.Contains(ref, "..") ||
+		strings.Contains(ref, "@{") ||
+		strings.Contains(ref, "//") ||
+		strings.HasSuffix(ref, "/") ||
+		strings.HasSuffix(ref, ".") ||
+		strings.HasSuffix(ref, ".lock") {
+		return fmt.Errorf("invalid action git ref %q", ref)
+	}
+	for part := range strings.SplitSeq(ref, "/") {
+		if part == "" || strings.HasPrefix(part, ".") || strings.HasSuffix(part, ".lock") {
+			return fmt.Errorf("invalid action git ref %q", ref)
+		}
+	}
+	return nil
 }
 
 func isPathWithin(dir, path string) bool {

--- a/internal/runtime/builtin/action/resolver.go
+++ b/internal/runtime/builtin/action/resolver.go
@@ -1,0 +1,302 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package action
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+)
+
+const (
+	actionPrefixSource = "source:"
+	actionPrefixPkg    = "pkg:"
+
+	bundleModeSource  = "source"
+	bundleModePackage = "package"
+)
+
+type resolveOptions struct {
+	ToolsDir    string
+	CacheDir    string
+	RegistryDir string
+	WorkDir     string
+}
+
+type actionBundle struct {
+	Mode        string
+	RootDir     string
+	OriginalRef string
+	ResolvedRef string
+	Version     string
+}
+
+func resolveBundle(ctx context.Context, ref string, opts resolveOptions) (*actionBundle, error) {
+	ref = strings.TrimSpace(ref)
+	switch {
+	case strings.HasPrefix(ref, actionPrefixSource):
+		return resolveSourceBundle(ctx, ref, opts)
+	case strings.HasPrefix(ref, actionPrefixPkg):
+		return resolvePackageBundle(ref, opts)
+	default:
+		return nil, fmt.Errorf("action ref must start with %q or %q", actionPrefixSource, actionPrefixPkg)
+	}
+}
+
+func resolveSourceBundle(ctx context.Context, ref string, opts resolveOptions) (*actionBundle, error) {
+	target, version, err := splitVersionedRef(strings.TrimPrefix(ref, actionPrefixSource))
+	if err != nil {
+		return nil, err
+	}
+	if dir, ok := localSourceDir(target, opts.WorkDir); ok {
+		return &actionBundle{
+			Mode:        bundleModeSource,
+			RootDir:     dir,
+			OriginalRef: ref,
+			ResolvedRef: dir,
+			Version:     version,
+		}, nil
+	}
+	root, resolved, err := cloneGitSource(ctx, target, version, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &actionBundle{
+		Mode:        bundleModeSource,
+		RootDir:     root,
+		OriginalRef: ref,
+		ResolvedRef: resolved,
+		Version:     version,
+	}, nil
+}
+
+func resolvePackageBundle(ref string, opts resolveOptions) (*actionBundle, error) {
+	target, version, err := splitVersionedRef(strings.TrimPrefix(ref, actionPrefixPkg))
+	if err != nil {
+		return nil, err
+	}
+	if dir, ok := localPackageDir(target); ok {
+		return &actionBundle{
+			Mode:        bundleModePackage,
+			RootDir:     dir,
+			OriginalRef: ref,
+			ResolvedRef: dir,
+			Version:     version,
+		}, nil
+	}
+	if err := validatePackageName(target); err != nil {
+		return nil, err
+	}
+	if err := validatePackageVersion(version); err != nil {
+		return nil, err
+	}
+	registryDir := packageRegistryDir(opts)
+	if registryDir == "" {
+		return nil, fmt.Errorf("package action registry dir is required")
+	}
+	root := filepath.Join(registryDir, filepath.FromSlash(target), version)
+	if !isPathWithin(registryDir, root) {
+		return nil, fmt.Errorf("invalid package action path")
+	}
+	if info, err := os.Stat(root); err != nil {
+		return nil, fmt.Errorf("stat package action: %w", err)
+	} else if !info.IsDir() {
+		return nil, fmt.Errorf("package action path must be a directory")
+	}
+	return &actionBundle{
+		Mode:        bundleModePackage,
+		RootDir:     root,
+		OriginalRef: ref,
+		ResolvedRef: target,
+		Version:     version,
+	}, nil
+}
+
+func splitVersionedRef(ref string) (string, string, error) {
+	ref = strings.TrimSpace(ref)
+	idx := strings.LastIndex(ref, "@")
+	if idx <= 0 || idx == len(ref)-1 {
+		return "", "", fmt.Errorf(`action ref must be "target@version"`)
+	}
+	return strings.TrimSpace(ref[:idx]), strings.TrimSpace(ref[idx+1:]), nil
+}
+
+func localSourceDir(target string, workDir string) (string, bool) {
+	if dir, ok := fileURLDir(target); ok {
+		return dir, true
+	}
+	candidate := target
+	if !filepath.IsAbs(candidate) && strings.TrimSpace(workDir) != "" {
+		candidate = filepath.Join(strings.TrimSpace(workDir), candidate)
+	}
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			return filepath.Clean(candidate), true
+		}
+		return filepath.Clean(abs), true
+	}
+	return "", false
+}
+
+func localPackageDir(target string) (string, bool) {
+	return fileURLDir(target)
+}
+
+func fileURLDir(target string) (string, bool) {
+	if !strings.HasPrefix(target, "file://") {
+		return "", false
+	}
+	u, err := url.Parse(target)
+	if err != nil || u.Path == "" {
+		return "", false
+	}
+	return filepath.Clean(u.Path), true
+}
+
+func cloneGitSource(ctx context.Context, target, version string, opts resolveOptions) (string, string, error) {
+	cacheDir := actionCacheDir(opts)
+	if cacheDir == "" {
+		return "", "", fmt.Errorf("action cache dir is required for remote source actions")
+	}
+	repoURL := gitURL(target)
+	key := hashRef(repoURL + "@" + version)
+	root := filepath.Join(cacheDir, "source", key)
+	if info, err := os.Stat(filepath.Join(root, ".git")); err == nil && info.IsDir() {
+		resolved, err := gitRevParse(ctx, root)
+		return root, resolved, err
+	}
+	if err := os.MkdirAll(filepath.Dir(root), 0o750); err != nil {
+		return "", "", fmt.Errorf("create action source cache: %w", err)
+	}
+	tmp := fmt.Sprintf("%s.%d.tmp", root, os.Getpid())
+	_ = os.RemoveAll(tmp)
+	if err := runGit(ctx, "", "clone", "--depth", "1", "--branch", version, repoURL, tmp); err != nil {
+		_ = os.RemoveAll(tmp)
+		if err := runGit(ctx, "", "clone", repoURL, tmp); err != nil {
+			return "", "", fmt.Errorf("clone action source: %w", err)
+		}
+		if err := runGit(ctx, tmp, "checkout", version); err != nil {
+			_ = os.RemoveAll(tmp)
+			return "", "", fmt.Errorf("checkout action source ref: %w", err)
+		}
+	}
+	if err := os.Rename(tmp, root); err != nil {
+		if info, statErr := os.Stat(filepath.Join(root, ".git")); statErr == nil && info.IsDir() {
+			_ = os.RemoveAll(tmp)
+			resolved, revErr := gitRevParse(ctx, root)
+			return root, resolved, revErr
+		}
+		_ = os.RemoveAll(tmp)
+		return "", "", fmt.Errorf("store action source cache: %w", err)
+	}
+	resolved, err := gitRevParse(ctx, root)
+	return root, resolved, err
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec
+	cmd.Dir = dir
+	cmdutil.SetupCommand(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func gitRevParse(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD") //nolint:gosec
+	cmd.Dir = dir
+	cmdutil.SetupCommand(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitURL(target string) string {
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") || strings.HasPrefix(target, "ssh://") || strings.HasPrefix(target, "git@") {
+		return target
+	}
+	if strings.HasPrefix(target, "github.com/") {
+		return "https://" + target + ".git"
+	}
+	return target
+}
+
+func actionCacheDir(opts resolveOptions) string {
+	if strings.TrimSpace(opts.CacheDir) != "" {
+		return strings.TrimSpace(opts.CacheDir)
+	}
+	if strings.TrimSpace(opts.ToolsDir) == "" {
+		return ""
+	}
+	return filepath.Join(strings.TrimSpace(opts.ToolsDir), "actions")
+}
+
+func packageRegistryDir(opts resolveOptions) string {
+	if strings.TrimSpace(opts.RegistryDir) != "" {
+		return strings.TrimSpace(opts.RegistryDir)
+	}
+	if strings.TrimSpace(opts.ToolsDir) == "" {
+		return ""
+	}
+	return filepath.Join(strings.TrimSpace(opts.ToolsDir), "actions", "registry")
+}
+
+func hashRef(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func validatePackageName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" || filepath.IsAbs(name) || strings.Contains(name, "\\") {
+		return fmt.Errorf("invalid package name %q", name)
+	}
+	for _, part := range strings.Split(name, "/") {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("invalid package name %q", name)
+		}
+	}
+	return nil
+}
+
+func validatePackageVersion(version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" || strings.ContainsAny(version, `/\`) || version == "." || version == ".." {
+		return fmt.Errorf("invalid package version %q", version)
+	}
+	return nil
+}
+
+func safeRelativePath(rootDir, relPath string) (string, error) {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" || filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("path must be relative")
+	}
+	path := filepath.Join(rootDir, relPath)
+	if !isPathWithin(rootDir, path) {
+		return "", fmt.Errorf("path escapes action directory")
+	}
+	return filepath.Clean(path), nil
+}
+
+func isPathWithin(dir, path string) bool {
+	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != "" && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/internal/runtime/builtin/action/resolver.go
+++ b/internal/runtime/builtin/action/resolver.go
@@ -265,7 +265,7 @@ func validatePackageName(name string) error {
 	if name == "" || filepath.IsAbs(name) || strings.Contains(name, "\\") {
 		return fmt.Errorf("invalid package name %q", name)
 	}
-	for _, part := range strings.Split(name, "/") {
+	for part := range strings.SplitSeq(name, "/") {
 		if part == "" || part == "." || part == ".." {
 			return fmt.Errorf("invalid package name %q", name)
 		}

--- a/internal/runtime/builtin/action/resolver.go
+++ b/internal/runtime/builtin/action/resolver.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -285,14 +286,18 @@ func validatePackageVersion(version string) error {
 
 func safeRelativePath(rootDir, relPath string) (string, error) {
 	relPath = strings.TrimSpace(relPath)
-	if relPath == "" || filepath.IsAbs(relPath) {
+	if relPath == "" || isAbsoluteActionPath(relPath) {
 		return "", fmt.Errorf("path must be relative")
 	}
-	path := filepath.Join(rootDir, relPath)
-	if !isPathWithin(rootDir, path) {
+	slashPath := path.Clean(strings.ReplaceAll(relPath, `\`, "/"))
+	if slashPath == "." || slashPath == ".." || strings.HasPrefix(slashPath, "../") {
 		return "", fmt.Errorf("path escapes action directory")
 	}
-	return filepath.Clean(path), nil
+	resolvedPath := filepath.Join(rootDir, filepath.FromSlash(slashPath))
+	if !isPathWithin(rootDir, resolvedPath) {
+		return "", fmt.Errorf("path escapes action directory")
+	}
+	return filepath.Clean(resolvedPath), nil
 }
 
 func isPathWithin(dir, path string) bool {

--- a/internal/runtime/builtin/action/resolver.go
+++ b/internal/runtime/builtin/action/resolver.go
@@ -178,8 +178,10 @@ func cloneGitSource(ctx context.Context, target, version string, opts resolveOpt
 	if err := os.MkdirAll(filepath.Dir(root), 0o750); err != nil {
 		return "", "", fmt.Errorf("create action source cache: %w", err)
 	}
-	tmp := fmt.Sprintf("%s.%d.tmp", root, os.Getpid())
-	_ = os.RemoveAll(tmp)
+	tmp, err := os.MkdirTemp(filepath.Dir(root), filepath.Base(root)+".*.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("create action source temp dir: %w", err)
+	}
 	if err := runGit(ctx, "", "clone", "--depth", "1", "--branch", version, repoURL, tmp); err != nil {
 		_ = os.RemoveAll(tmp)
 		if err := runGit(ctx, "", "clone", repoURL, tmp); err != nil {

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -4,6 +4,7 @@
 package builtin
 
 import (
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/action"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/agentstep"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/archive"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/chat"

--- a/internal/tools/aqua/installer.go
+++ b/internal/tools/aqua/installer.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -232,7 +233,7 @@ func (i *Installer) Install(ctx context.Context, cfg *core.ToolConfig, opts tool
 func readyManifest(paths tools.CacheLayout, platform, hash string) (*tools.Manifest, error) {
 	manifest, err := tools.ReadManifest(paths.ManifestFile)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/tools/aqua/installer_test.go
+++ b/internal/tools/aqua/installer_test.go
@@ -178,6 +178,17 @@ func TestReadyManifestMissesWhenCommandIsMissing(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+func TestReadyManifestMissesWhenManifestFileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	paths := testCacheLayout(t.TempDir())
+
+	got, err := readyManifest(paths, "linux/amd64", "hash")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
 func TestRegistryCacheReadyRequiresValidJSONCache(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/prepare.go
+++ b/internal/tools/prepare.go
@@ -13,7 +13,7 @@ import (
 // PrepareDAG validates, installs, and exposes the tools declared by a DAG.
 func PrepareDAG(ctx context.Context, dag *core.DAG, installer Installer, opts InstallOptions, basePath string) ([]string, error) {
 	if dag == nil || dag.Tools == nil {
-		return nil, nil
+		return ToolDirEnvVars(opts), nil
 	}
 	if installer == nil {
 		return nil, fmt.Errorf("tools installer is required")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -25,6 +25,8 @@ const (
 
 	// EnvManifest points command executors to the resolved Dagu tools manifest.
 	EnvManifest = "DAGU_TOOLS_MANIFEST"
+	// EnvToolsDir points action executors to the worker-local tool cache root.
+	EnvToolsDir = "DAGU_TOOLS_DIR"
 )
 
 // Installer installs and resolves a DAG tool declaration.
@@ -133,7 +135,7 @@ func EnvVars(manifest *Manifest, basePath string) []string {
 	if basePath != "" {
 		pathValue += string(os.PathListSeparator) + basePath
 	}
-	return []string{
+	envs := []string{
 		"AQUA_ROOT_DIR=" + manifest.RootDir,
 		"AQUA_CONFIG=" + manifest.Config,
 		"AQUA_DISABLE_LAZY_INSTALL=true",
@@ -144,6 +146,35 @@ func EnvVars(manifest *Manifest, basePath string) []string {
 		EnvManifest + "=" + manifestFilePath(manifest),
 		"PATH=" + pathValue,
 	}
+	if toolsDir := toolsDirFromManifest(manifest); toolsDir != "" {
+		envs = append(envs, EnvToolsDir+"="+toolsDir)
+	}
+	return envs
+}
+
+// ToolDirEnvVars returns the minimal tool cache environment for executors that
+// install action-scoped runtimes after DAG loading.
+func ToolDirEnvVars(opts InstallOptions) []string {
+	toolsDir := strings.TrimSpace(opts.ToolsDir)
+	if toolsDir == "" && strings.TrimSpace(opts.DataDir) != "" {
+		toolsDir = filepath.Join(strings.TrimSpace(opts.DataDir), "tools")
+	}
+	if toolsDir == "" {
+		return nil
+	}
+	return []string{EnvToolsDir + "=" + toolsDir}
+}
+
+func toolsDirFromManifest(manifest *Manifest) string {
+	root := filepath.Clean(manifest.RootDir)
+	if filepath.Base(root) != "root" {
+		return ""
+	}
+	aquaDir := filepath.Dir(root)
+	if filepath.Base(aquaDir) != "aqua" {
+		return ""
+	}
+	return filepath.Dir(aquaDir)
 }
 
 func sanitizePlatform(platform string) string {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -119,6 +119,17 @@ func TestPrepareDAGInstallsDeclaredTools(t *testing.T) {
 	assert.Contains(t, envs, "PATH=/data/tools/aqua/envs/linux-amd64/hash/bin"+string(os.PathListSeparator)+"/usr/bin")
 }
 
+func TestPrepareDAGExposesToolsDirWithoutDeclaredTools(t *testing.T) {
+	t.Parallel()
+
+	envs, err := PrepareDAG(context.Background(), &core.DAG{Name: "action-dag"}, &fakeInstaller{}, InstallOptions{
+		ToolsDir: "/data/tools",
+	}, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"DAGU_TOOLS_DIR=/data/tools"}, envs)
+}
+
 func TestPrepareDAGRejectsUnsupportedExecutor(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Add a generic external `action` executor backed by Deno so Dagu can run third-party actions without expanding core builtins for every integration.

## Changes
- Add `action` executor support for Deno-based external actions.
- Normalize `action: source:...@...` and `action: pkg:...@...` into the executor config.
- Support explicit `type: action` with `ref` and `input` config.
- Resolve source actions from local paths or git refs, with cached clones.
- Resolve packaged actions from local registry directories or `file://` package dirs.
- Load `dagu-action.yaml`, validate inputs and permissions, and run Deno with constrained read/write/net/env permissions.
- Install the requested Deno version through the existing aqua-backed tools cache.
- Expose `DAGU_TOOLS_DIR` for runs without declared DAG tools.
- Fix aqua first-run manifest handling when `manifest.json` does not exist yet.

## Related Issues
None linked.

## Validation
- [x] `go test ./internal/core ./internal/runtime ./internal/runtime/builtin/... ./internal/engine ./internal/cmd ./internal/service/worker ./internal/tools ./internal/tools/aqua ./internal/cmn/schema`
- [x] `DAGU_ACTION_DENO_INTEGRATION=1 go test -count=1 -run TestExecutorRunsLocalSourceActionWithRealDenoIntegration -v ./internal/runtime/builtin/action`
- [x] `DAGU_AQUA_INTEGRATION=1 go test -count=1 -run TestInstallerInstallIntegration -v ./internal/tools/aqua`
- [x] `go fix -diff ./internal/runtime/builtin/action`

## Checklist
- [x] Code is formatted and modernized for the repo's Go version.
- [x] Unit tests cover source/pkg normalization, package registry resolution, manifest validation, write permission path resolution, and tools-dir env exposure.
- [x] Integration tests verify real Deno execution through aqua when explicitly enabled.
- [ ] Documentation and public examples will be handled separately.
