### PR TITLE
Make graph the default DAG type

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ artifacts:
 steps:
   - id: review_pr
     action: agent.run
-    depends: []
     with:
       task: |
         Review the README.md file in ${REPO_URL}.
@@ -359,7 +358,6 @@ graph LR
 steps:
   - id: step_1
     run: echo "Step 1"
-    depends: []
   - id: step_2
     run: echo "Step 2"
     depends: [step_1]
@@ -374,7 +372,6 @@ tools:
 steps:
   - id: inspect
     run: jq --version
-    depends: []
 
   - id: transform
     run: jq '.items[] | .name' data.json
@@ -483,7 +480,6 @@ handler_on:
 steps:
   - id: review
     action: agent.run
-    depends: []
     with:
       task: Review the README.md file and return concise Markdown findings.
       max_iterations: 10

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ artifacts:
 steps:
   - id: review_pr
     action: agent.run
+    depends: []
     with:
       task: |
         Review the README.md file in ${REPO_URL}.
@@ -146,11 +147,13 @@ steps:
 
   - id: approval
     action: noop
+    depends: [review_pr]
     approval:
       prompt: Review the review.md artifact. Approve to post an issue with the findings, or reject to skip.
 
   - id: post_issue
     run: gh issue create --title "Review Findings" --body-file "${DAG_RUN_ARTIFACTS_DIR}/review.md"
+    depends: [approval]
 ```
 
 This workflow uses the built-in [`agent.run` action](https://docs.dagu.sh/features/agent/step) and assumes a default model is configured in Agent Settings. It reviews a GitHub repository's README file, saves the agent's final output as an artifact, and then prompts for manual [approval](https://docs.dagu.sh/writing-workflows/yaml-specification#approval) before posting an issue with the findings. GitHub CLI (`gh`) is used in the final step to create the issue.
@@ -317,19 +320,9 @@ See the [embedded API documentation](https://docs.dagu.sh/embedding/go-api) and 
 
 ## Workflow Examples
 
-### Sequential execution
-
-```yaml
-type: chain
-steps:
-  - run: echo "Step 1"
-  - run: echo "Step 2"
-```
-
 ### Parallel execution with dependencies
 
 ```yaml
-type: graph
 steps:
   - id: extract
     run: ./extract.sh
@@ -344,6 +337,9 @@ steps:
     depends: [transform_a, transform_b]
 ```
 
+`graph` is the default execution type. Use explicit `depends` to define ordering; steps without dependencies can run in parallel.
+Scalar step shorthand such as `- echo "hello"` is deprecated; use explicit step objects with `run:` instead.
+
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'background': '#18181B', 'primaryTextColor': '#fff', 'lineColor': '#888'}}}%%
 graph LR
@@ -357,6 +353,18 @@ graph LR
     style D fill:#18181B,stroke:#3B82F6,stroke-width:1.6px,color:#fff
 ```
 
+### Sequential execution
+
+```yaml
+steps:
+  - id: step_1
+    run: echo "Step 1"
+    depends: []
+  - id: step_2
+    run: echo "Step 2"
+    depends: [step_1]
+```
+
 ### Reproducible external tools
 
 ```yaml
@@ -364,11 +372,13 @@ tools:
   - jqlang/jq@jq-1.7.1
 
 steps:
-  - name: inspect
+  - id: inspect
     run: jq --version
+    depends: []
 
-  - name: transform
+  - id: transform
     run: jq '.items[] | .name' data.json
+    depends: [inspect]
 ```
 
 Dagu installs declared portable CLIs before the DAG run, exposes them on `PATH` for host command steps, and caches them on each worker. You do not need to install a separate tool manager; Dagu remains a single binary. See the [Tools documentation](https://docs.dagu.sh/writing-workflows/tools) for package syntax, immutable refs, distributed worker behavior, sub-DAG scoping, and current limitations.
@@ -471,20 +481,23 @@ handler_on:
 
 ```yaml
 steps:
-  - name: review
+  - id: review
     action: agent.run
+    depends: []
     with:
       task: Review the README.md file and return concise Markdown findings.
       max_iterations: 10
     stdout: ${DAG_RUN_ARTIFACTS_DIR}/review.md
 
-  - name: approval
+  - id: approval
     action: noop
+    depends: [review]
     approval:
       prompt: Review the review.md artifact. Approve to post an issue with the findings, or reject to skip.
 
-  - name: post_issue
+  - id: post_issue
     run: gh issue create --title "Review Findings" --body-file "${DAG_RUN_ARTIFACTS_DIR}/review.md"
+    depends: [approval]
 ```
 
 For more examples, see the [Examples documentation](https://docs.dagu.sh/writing-workflows/examples).

--- a/README.md
+++ b/README.md
@@ -336,9 +336,6 @@ steps:
     depends: [transform_a, transform_b]
 ```
 
-`graph` is the default execution type. Use explicit `depends` to define ordering; steps without dependencies can run in parallel.
-Scalar step shorthand such as `- echo "hello"` is deprecated; use explicit step objects with `run:` instead.
-
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'background': '#18181B', 'primaryTextColor': '#fff', 'lineColor': '#888'}}}%%
 graph LR

--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -46,13 +46,17 @@ steps:
 
 The root `type:` controls how the workflow executes:
 
-- `chain` runs steps in order. This is the default.
 - `graph` runs steps according to `depends:` and can run independent steps in
   parallel.
+- `graph` is the default when `type:` is omitted.
+- `chain` runs steps in order.
 - `agent` is reserved for agent-oriented execution.
 
 Do not confuse root `type:` with legacy step-level `type:`. Step-level
 `type:` is deprecated; use `action:` for named executors.
+
+Do not use scalar step shorthand such as `- echo hello`. It is deprecated;
+write explicit step objects with `run:` instead.
 
 ## Mental Model
 
@@ -367,9 +371,11 @@ steps:
   - id: version
     run: git rev-parse --short HEAD
     output: VERSION
+    depends: []
 
   - id: publish
     run: echo "Publishing ${VERSION}"
+    depends: [version]
 ```
 
 Object-form `output:` publishes structured step output:

--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -371,7 +371,6 @@ steps:
   - id: version
     run: git rev-parse --short HEAD
     output: VERSION
-    depends: []
 
   - id: publish
     run: echo "Publishing ${VERSION}"

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -165,7 +165,7 @@ Do not route large payloads through `output:` variables; use `output:` for small
 
 Omit the root `name:` field—Dagu uses the filename as the DAG name by default.
 
-Always use `type: graph` with explicit `depends` on every step. This makes execution order clear and deterministic. Steps with no dependencies use `depends: []`. Never use `type: chain` or omit `type`—implicit sequential ordering hides the real dependency structure.
+Use the default graph execution model with explicit `depends` on every step. This makes execution order clear and deterministic. Steps with no dependencies use `depends: []`. Do not use `type: chain` unless sequential chain semantics are specifically required.
 
 Example:
 ```yaml

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -169,7 +169,6 @@ Use the default graph execution model with explicit `depends` on every step. Thi
 
 Example:
 ```yaml
-type: graph
 steps:
   - id: fetch_data
     run: curl -o data.json https://api.example.com/data

--- a/internal/agent/system_prompt.txt
+++ b/internal/agent/system_prompt.txt
@@ -165,14 +165,13 @@ Do not route large payloads through `output:` variables; use `output:` for small
 
 Omit the root `name:` field—Dagu uses the filename as the DAG name by default.
 
-Use the default graph execution model with explicit `depends` on every step. This makes execution order clear and deterministic. Steps with no dependencies use `depends: []`. Do not use `type: chain` unless sequential chain semantics are specifically required.
+Use the default graph execution model with explicit `depends` whenever one step must wait for another. Omit `depends` on root steps with no dependencies. Do not use `type: chain` unless sequential chain semantics are specifically required.
 
 Example:
 ```yaml
 steps:
   - id: fetch_data
     run: curl -o data.json https://api.example.com/data
-    depends: []
   - id: process
     run: python process.py
     depends:

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -380,8 +380,8 @@
     "type": {
       "type": "string",
       "enum": ["graph", "chain", "agent"],
-      "default": "chain",
-      "description": "Execution type for steps. 'chain' (default) executes steps sequentially in the order they are defined, with each step automatically depending on the previous one. 'graph' uses dependency-based execution where steps run based on their 'depends' field. 'agent' is reserved for future agent-based execution."
+      "default": "graph",
+      "description": "Execution type for steps. 'graph' (default) uses dependency-based execution where steps run based on their 'depends' field. 'chain' executes steps sequentially in the order they are defined, with each step automatically depending on the previous one. 'agent' is reserved for future agent-based execution."
     },
     "env": {
       "oneOf": [

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -1367,6 +1367,7 @@ func TestNestedArrayParallelSyntax(t *testing.T) {
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - run: echo "step 1"
   - 
@@ -1408,6 +1409,7 @@ steps:
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - name: setup
     run: echo "setup"
@@ -1442,8 +1444,8 @@ steps:
 	t.Run("ParallelStepsWithExplicitDependenciesShouldError", func(t *testing.T) {
 		t.Parallel()
 
-		// Default type is chain, so explicit depends is not allowed
 		data := []byte(`
+type: chain
 steps:
   - name: step1
     run: echo "1"
@@ -1509,6 +1511,7 @@ steps:
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - 
     - run: echo "parallel 1"
@@ -1531,6 +1534,7 @@ steps:
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - 
     - run: echo "parallel 1"
@@ -1773,6 +1777,7 @@ steps:
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - run: echo "setup"
   - run: echo "test"
@@ -1867,6 +1872,7 @@ steps:
 		t.Parallel()
 
 		data := []byte(`
+type: chain
 steps:
   - id: step_a
     run: echo a

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -45,8 +45,8 @@ type dag struct {
 	// Description is the description of the DAG.
 	Description string `yaml:"description,omitempty"`
 	// Type is the execution type for steps (graph, chain, or agent).
-	// Default is "chain" which executes steps in the order they are defined.
-	// "graph" uses dependency-based parallel execution.
+	// Default is "graph" which uses dependency-based parallel execution.
+	// "chain" executes steps in the order they are defined.
 	// "agent" is reserved for future agent-based execution.
 	Type string `yaml:"type,omitempty"`
 	// Shell is the default shell to use for all steps in this DAG.
@@ -741,7 +741,7 @@ func applyHistoryRetentionOverride(effective *core.DAG, authoredDays, authoredRu
 func buildType(_ BuildContext, d *dag) (string, error) {
 	t := strings.TrimSpace(d.Type)
 	if t == "" {
-		return core.TypeChain, nil
+		return core.TypeGraph, nil
 	}
 	switch t {
 	case core.TypeGraph, core.TypeChain:

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -385,14 +385,14 @@ func TestBuildType(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "EmptyDefaultsToChain",
+			name:     "EmptyDefaultsToGraph",
 			input:    "",
-			expected: core.TypeChain,
+			expected: core.TypeGraph,
 		},
 		{
-			name:     "WhitespaceDefaultsToChain",
+			name:     "WhitespaceDefaultsToGraph",
 			input:    "  ",
-			expected: core.TypeChain,
+			expected: core.TypeGraph,
 		},
 		{
 			name:     "GraphType",
@@ -3213,16 +3213,14 @@ func TestChainTypeDependsValidation(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "DefaultTypeWithDependsShouldError",
+			name: "DefaultTypeWithDependsShouldWork",
 			dag: &dag{
-				// Default type is chain, so depends should not be allowed
 				Steps: []any{
 					map[string]any{"name": "step1", "command": "echo 1"},
 					map[string]any{"name": "step2", "command": "echo 2", "depends": []string{"step1"}},
 				},
 			},
-			expectErr:   true,
-			errContains: "depends field is not allowed for DAGs with type 'chain'",
+			expectErr: false,
 		},
 		{
 			name: "ChainTypeNestedParallelWithDependsShouldError",
@@ -3381,9 +3379,8 @@ func TestRouterNotAllowedInChainType(t *testing.T) {
 			errContains: "router steps require type 'graph'",
 		},
 		{
-			name: "DefaultTypeWithRouterShouldError",
+			name: "DefaultTypeWithRouterShouldWork",
 			dag: &dag{
-				// Default type is chain, so router should not be allowed
 				Steps: []any{
 					map[string]any{
 						"name":  "router",
@@ -3396,8 +3393,7 @@ func TestRouterNotAllowedInChainType(t *testing.T) {
 					map[string]any{"name": "step_a", "command": "echo A"},
 				},
 			},
-			expectErr:   true,
-			errContains: "router steps require type 'graph'",
+			expectErr: false,
 		},
 		{
 			name: "GraphTypeWithRouterShouldWork",

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -1315,7 +1315,7 @@ steps:
 		assert.False(t, dag.WorkingDirExplicit)
 	})
 
-	t.Run("WithoutBaseConfigStillDefaultsTypeToChain", func(t *testing.T) {
+	t.Run("WithoutBaseConfigDefaultsTypeToGraph", func(t *testing.T) {
 		t.Parallel()
 
 		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
@@ -1326,9 +1326,9 @@ steps:
     run: echo two
 `), spec.BuildOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, core.TypeChain, dag.Type)
+		assert.Equal(t, core.TypeGraph, dag.Type)
 		require.Len(t, dag.Steps, 2)
-		assert.Equal(t, []string{"step1"}, dag.Steps[1].Depends)
+		assert.Empty(t, dag.Steps[1].Depends)
 	})
 }
 
@@ -1441,7 +1441,7 @@ steps:
 	assert.Equal(t, "child-task", childDAG.Name)
 	require.Len(t, childDAG.Steps, 1)
 	assert.Equal(t, "work", childDAG.Steps[0].Name)
-	assert.Equal(t, core.TypeChain, childDAG.Type)
+	assert.Equal(t, core.TypeGraph, childDAG.Type)
 }
 
 func TestLoad_MultiDocumentFilePreservesDocumentProvenance(t *testing.T) {

--- a/internal/core/spec/step_v2_cleanup_test.go
+++ b/internal/core/spec/step_v2_cleanup_test.go
@@ -43,6 +43,19 @@ handler_on:
 	}, warnings)
 }
 
+func TestDeprecatedSyntaxWarningsStringStepShorthand(t *testing.T) {
+	t.Parallel()
+
+	warnings := DeprecatedSyntaxWarnings([]byte(`
+steps:
+  - echo shorthand
+`))
+
+	require.Equal(t, []string{
+		"Deprecated DAG syntax: steps[0] string shorthand is deprecated; use run",
+	}, warnings)
+}
+
 func TestBuiltinActionNamesMatchDAGSchema(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/cfg_test.go
+++ b/internal/intg/cfg_test.go
@@ -28,6 +28,7 @@ func TestDAGExecution(t *testing.T) {
   - run: echo 1
     output: NO_NAME_STEP_OUT
   - run: echo ${NO_NAME_STEP_OUT}=1
+    depends: cmd_1
     output: NO_NAME_STEP_OUT2
 `)
 		agent := dag.Agent()
@@ -281,6 +282,7 @@ steps:
   - run: |
 `+indentTestScript(out2Command, 6)+`
     output: OUT2
+    depends: cmd_1
     preconditions:
       - condition: "$OUT1"
         expected: "re:^abc.*def$"
@@ -302,6 +304,7 @@ steps:
     output: CONFIG
 
   - run: echo "Starting server at ${CONFIG.host}:${CONFIG.port}"
+    depends: cmd_1
     output: OUT1
 `)
 		agent := dag.Agent()
@@ -323,11 +326,13 @@ steps:
   - run: echo foo
     stdout: "${DATA_DIR}_${PROCESS_DATE}"
   - run: cat ${DATA_DIR}_${PROCESS_DATE}
+    depends: cmd_1
     output: OUT1
     preconditions:
       - condition: "${DATA_DIR}_${PROCESS_DATE}"
         expected: "re:[0-9]{8}_[0-9]{6}"
   - run: rm ${DATA_DIR}_${PROCESS_DATE}
+    depends: cmd_2
 `, dataPrefix))
 		agent := dag.Agent()
 		agent.RunSuccess(t)
@@ -473,6 +478,7 @@ steps:
     output: CONFIG
 
   - name: start_server
+    depends: cmd_1
     run: echo "Starting server at ${CONFIG.host}:${CONFIG.port}"
     output: OUT1
 `)
@@ -716,6 +722,7 @@ func TestCallSubDAG(t *testing.T) {
       params: "SUB_P1=foo"
     output: OUT1
   - run: echo "${OUT1.outputs.OUT}"
+    depends: dag_1
     output: OUT2
 ---
 name: sub
@@ -756,6 +763,7 @@ steps:
       params: "PARAM=123"
     output: SUB_OUTPUT
   - run: echo "${SUB_OUTPUT.outputs.OUTPUT}"
+    depends: dag_1
     output: OUT1
 ---
 name: nested_child
@@ -768,6 +776,7 @@ steps:
       params: "PARAM=${PARAM}"
     output: GRAND_SUB_OUTPUT
   - run: echo "${GRAND_SUB_OUTPUT.outputs.OUTPUT}"
+    depends: dag_1
     output: OUTPUT
 `
 	dag := th.DAG(t, dagContent)

--- a/internal/intg/ct_test.go
+++ b/internal/intg/ct_test.go
@@ -129,9 +129,12 @@ container:
 steps:
   - run: sh -c "echo 'Hello from step 1' > /data/test.txt"
   - run: cat /data/test.txt
+    depends: container_1
     output: BIND_MOUNT_OUT1
   - run: sh -c "echo 'Hello from step 3' >> /data/test.txt"
+    depends: container_2
   - run: cat /data/test.txt
+    depends: container_3
     output: BIND_MOUNT_OUT2
 `, testImage, tempDir)
 			},
@@ -281,6 +284,7 @@ steps:
     output: WORK_DIR_VOL_OUT1
   - run: sh -c "echo 'New content' > /workspace/new.txt"
   - run: cat /workspace/new.txt
+    depends: container_2
     output: WORK_DIR_VOL_OUT2
   - run: ls -la /workspace/
     output: WORK_DIR_VOL_OUT3

--- a/internal/intg/ct_test.go
+++ b/internal/intg/ct_test.go
@@ -249,8 +249,10 @@ container:
 steps:
   - run: sh -c "echo 'Data in named volume' > /data/volume.txt"
   - run: cat /data/volume.txt
+    depends: container_1
     output: NAMED_VOL_OUT1
   - run: ls -la /data/
+    depends: container_1
     output: NAMED_VOL_OUT2
 `, testImage)
 			},

--- a/internal/intg/env_test.go
+++ b/internal/intg/env_test.go
@@ -115,6 +115,7 @@ steps:
     run: |
 `+indentTestScript(writeCommand, 6)+`
   - name: read-from-workdir
+    depends: write-to-workdir
     run: |
 `+indentTestScript(readCommand, 6)+`
     output: WORKDIR_OUTPUT
@@ -153,6 +154,7 @@ steps:
     run: |
 `+indentTestScript(writeCommand, 6)+`
   - name: read-from-workdir
+    depends: write-to-workdir
     run: |
 `+indentTestScript(readCommand, 6)+`
     output: WORKDIR_OUTPUT

--- a/internal/intg/parallel_test.go
+++ b/internal/intg/parallel_test.go
@@ -922,11 +922,13 @@ func TestParallelExecution_OutputsArray(t *testing.T) {
     output: RESULTS
   - run: |
       echo "First output: ${RESULTS.outputs[0].TASK_OUTPUT}"
+    depends: parallel_1
     output: FIRST_OUTPUT
   - run: |
       echo "Output 0: ${RESULTS.outputs[0].TASK_OUTPUT}"
       echo "Output 1: ${RESULTS.outputs[1].TASK_OUTPUT}"
       echo "Output 2: ${RESULTS.outputs[2].TASK_OUTPUT}"
+    depends: parallel_1
     output: ALL_OUTPUTS
 ` + parallelChildWithOutputDAG()
 
@@ -1069,6 +1071,7 @@ func TestParallelExecution_ObjectItemProperties(t *testing.T) {
       params:
         - REGION: ${ITEM.region}
         - BUCKET: ${ITEM.bucket}
+    depends: cmd_1
     parallel:
       items: ${CONFIGS}
       max_concurrent: 2
@@ -1177,6 +1180,7 @@ steps:
       dag: process-file
       params:
         - ITEM: ${ITEM}
+    depends: cmd_1
     parallel: ${FILES}
     output: RESULTS
 `, discoverCommand))
@@ -1367,6 +1371,7 @@ func TestIssue1274_ParallelJSONSingleItem(t *testing.T) {
       dag: issue-1274-worker
       params:
         aJson: ${ITEM}
+    depends: cmd_1
     parallel:
       items: ${jsonList}
       max_concurrent: 1
@@ -1421,6 +1426,7 @@ func TestIssue1274_ParallelJSONMultipleItems(t *testing.T) {
       dag: issue-1274-worker-multi
       params:
         aJson: ${ITEM}
+    depends: script_1
     parallel:
       items: ${jsonList}
       max_concurrent: 1
@@ -1543,6 +1549,7 @@ func TestIssue1658_ParallelCallExpandedParamsSplitting(t *testing.T) {
     with:
       dag: child-params-split
       params: "NAME=${ITEM.name} ${ITEM.extra}"
+    depends: cmd_1
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1576,6 +1583,7 @@ steps:
     with:
       dag: child-multi-expand
       params: "NAME=${ITEM.name} ${ITEM.extra}"
+    depends: cmd_1
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1620,6 +1628,7 @@ steps:
     with:
       dag: child-named-spaces
       params: "LABEL=${ITEM.label} ID=${ITEM.id}"
+    depends: cmd_1
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1652,6 +1661,7 @@ steps:
     with:
       dag: child-positional-single
       params: "${ITEM.tag}"
+    depends: cmd_1
     parallel:
       items: ${ITEMS}
     output: RESULTS

--- a/internal/intg/subdag_test.go
+++ b/internal/intg/subdag_test.go
@@ -77,6 +77,7 @@ steps:
     output: SUB_RESULT
 
   - run: echo "Child said ${SUB_RESULT.outputs.GREETING}"
+    depends: run-local-child
 
 ---
 
@@ -88,6 +89,7 @@ steps:
     output: GREETING
 
   - run: echo "Greeting was ${GREETING}"
+    depends: cmd_1
 `)
 
 		agent := testDAG.Agent()
@@ -281,6 +283,7 @@ steps:
     action: dag.run
     with:
       dag: production-dag
+    depends: check-env
     preconditions:
       - condition: "${ENV_TYPE}"
         expected: "production"
@@ -289,6 +292,7 @@ steps:
     action: dag.run
     with:
       dag: development-dag
+    depends: check-env
     preconditions:
       - condition: "${ENV_TYPE}"
         expected: "development"
@@ -299,6 +303,7 @@ name: production-dag
 steps:
   - run: echo "Deploying to production"
   - run: echo "Verifying production deployment"
+    depends: cmd_1
 
 ---
 
@@ -306,6 +311,7 @@ name: development-dag
 steps:
   - run: echo "Building for development"
   - run: echo "Running development tests"
+    depends: cmd_1
 `)
 
 		agent := testDAG.Agent()
@@ -341,6 +347,7 @@ steps:
     with:
       dag: processor-dag
       params: "INPUT_DATA=${GEN_OUTPUT.outputs.DATA}"
+    depends: generate-data
 
 ---
 
@@ -360,6 +367,7 @@ steps:
 
   - run: |
       echo "Validated: ${RESULT}"
+    depends: cmd_1
 `)
 
 		agent := testDAG.Agent()

--- a/internal/persis/filebaseconfig/default_base_config.go
+++ b/internal/persis/filebaseconfig/default_base_config.go
@@ -17,9 +17,9 @@ const defaultBaseConfig = `# Base DAG Configuration
 # -- Active Defaults --
 
 # Execution model. Keep the default explicit so new base.yaml files are self-describing.
-# "chain" runs steps sequentially in definition order.
 # "graph" runs steps in parallel based on dependency resolution.
-type: chain
+# "chain" runs steps sequentially in definition order.
+type: graph
 
 # Behavior when a new run is triggered while one is already active.
 # "skip" = discard the new run. "all" = queue all runs. "latest" = keep only the most recent.

--- a/internal/persis/filebaseconfig/store_test.go
+++ b/internal/persis/filebaseconfig/store_test.go
@@ -127,7 +127,7 @@ func TestInitialize(t *testing.T) {
 		data, err := os.ReadFile(filePath)
 		require.NoError(t, err)
 		assert.Contains(t, string(data), "Base DAG Configuration")
-		assert.Contains(t, string(data), "type: chain")
+		assert.Contains(t, string(data), "type: graph")
 		assert.Contains(t, string(data), "catchup_window")
 		assert.Contains(t, string(data), "hist_retention_days")
 		assert.Contains(t, string(data), "\nretry_policy:\n  limit: 3\n  interval_sec: 5\n")


### PR DESCRIPTION
## Summary
- Make omitted DAG `type` load as `graph` and update generated base config defaults to `type: graph`.
- Update schema, README examples, and built-in agent guidance to use graph-default workflows with explicit dependencies.
- Add coverage for scalar step shorthand deprecation warnings and update chain-specific tests to set `type: chain` explicitly.

## Validation
- `go test ./internal/core/spec ./internal/persis/filebaseconfig ./internal/persis/filedag ./internal/agent`
- `jq empty internal/cmn/schema/dag.schema.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow examples to show explicit step objects with `id` and `depends` fields for clearer dependency declaration
  * Clarified that parallel execution is now the default behavior; sequential execution requires explicit configuration
  * Deprecated scalar step shorthand syntax in favor of structured step objects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->