### PR TITLE
fix: default empty DAG type to graph

### DIFF
--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -606,7 +606,7 @@ func (d *DAG) initializeDefaults() {
 	)
 
 	if d.Type == "" {
-		d.Type = TypeChain
+		d.Type = TypeGraph
 	}
 	if d.LogOutput == "" {
 		d.LogOutput = LogOutputSeparate

--- a/internal/core/dag_test.go
+++ b/internal/core/dag_test.go
@@ -768,7 +768,7 @@ func TestDAG_InitializeDefaults(t *testing.T) {
 		dag := &core.DAG{}
 		core.InitializeDefaults(dag)
 
-		assert.Equal(t, core.TypeChain, dag.Type)
+		assert.Equal(t, core.TypeGraph, dag.Type)
 		assert.Equal(t, 30, dag.HistRetentionDays)
 		assert.Equal(t, 0, dag.HistRetentionRuns)
 		assert.Equal(t, 5*time.Second, dag.MaxCleanUpTime)


### PR DESCRIPTION
## Summary
- Align `core.InitializeDefaults` with the schema v2 default DAG type.
- Default an empty `DAG.Type` to `graph` instead of `chain`.
- Update the corresponding default expectation in the core test.

## Why
The YAML builder already defaults omitted DAG `type` to `graph`, and the `DAG.Type` field comment says the default is graph. This keeps low-level defaults consistent with that behavior.

## Validation
- Not run locally; this PR will be validated by GitHub CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default type behavior for DAGs when initialized without an explicit type specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->