### PR TITLE
fix: restore mermaid graph interactions

### DIFF
--- a/ui/src/components/ui/__tests__/mermaid.test.tsx
+++ b/ui/src/components/ui/__tests__/mermaid.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Mermaid from '../mermaid';
 
 type RenderResult = {
@@ -38,6 +38,7 @@ describe('Mermaid', () => {
   }
 
   beforeEach(() => {
+    vi.useRealTimers();
     pendingRenders = [];
     mermaidRenderMock.mockReset();
     mermaidRenderMock.mockImplementation(
@@ -46,6 +47,10 @@ describe('Mermaid', () => {
           pendingRenders.push({ def, resolve, reject });
         })
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('ignores stale render results after a newer definition renders', async () => {
@@ -104,5 +109,105 @@ describe('Mermaid', () => {
     });
 
     expect(screen.queryByText('Fallback graph')).not.toBeInTheDocument();
+  });
+
+  it('resolves Mermaid 11.15 prefixed node ids before firing graph callbacks', async () => {
+    vi.useFakeTimers();
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    const onRightClick = vi.fn();
+    const firstNodeId = 'node_66_69_72_73_74';
+    const secondNodeId = 'node_73_65_63_6f_6e_64';
+    const thirdNodeId = 'node_74_68_69_72_64';
+
+    const { container } = render(
+      <Mermaid
+        def="graph TD; A-->B;"
+        nodeIds={[firstNodeId, secondNodeId, thirdNodeId]}
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
+        onRightClick={onRightClick}
+        scale={1}
+      />
+    );
+
+    await act(async () => {
+      pendingRenderAt(0).resolve({
+        svg: `
+          <svg>
+            <g class="node" id="mermaid-random-flowchart-${firstNodeId}-0"></g>
+            <g class="node" id="mermaid-random-flowchart-${secondNodeId}-1"></g>
+            <g class="node" id="mermaid-random-flowchart-${thirdNodeId}-2"></g>
+          </svg>
+        `,
+      });
+    });
+
+    const nodes = container.querySelectorAll('.node');
+    expect(nodes).toHaveLength(3);
+
+    fireEvent.click(nodes.item(0));
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    fireEvent.dblClick(nodes.item(1));
+    fireEvent.contextMenu(nodes.item(2));
+
+    expect(onClick).toHaveBeenCalledWith(firstNodeId);
+    expect(onDoubleClick).toHaveBeenCalledWith(secondNodeId);
+    expect(onRightClick).toHaveBeenCalledWith(thirdNodeId);
+  });
+
+  it('keeps legacy Mermaid node ids working', async () => {
+    const onRightClick = vi.fn();
+    const nodeId = 'node_6c_65_67_61_63_79';
+
+    const { container } = render(
+      <Mermaid
+        def="graph TD; A-->B;"
+        nodeIds={[nodeId]}
+        onRightClick={onRightClick}
+        scale={1}
+      />
+    );
+
+    await act(async () => {
+      pendingRenderAt(0).resolve({
+        svg: `<svg><g class="node" id="flowchart-${nodeId}-0"></g></svg>`,
+      });
+    });
+
+    const node = container.querySelector('.node');
+    expect(node).not.toBeNull();
+    fireEvent.contextMenu(node!);
+
+    expect(onRightClick).toHaveBeenCalledWith(nodeId);
+  });
+
+  it('prefers the longest known node id when ids share a prefix', async () => {
+    const onRightClick = vi.fn();
+    const shortNodeId = 'node_61';
+    const longNodeId = 'node_61_62';
+
+    const { container } = render(
+      <Mermaid
+        def="graph TD; A-->B;"
+        nodeIds={[shortNodeId, longNodeId]}
+        onRightClick={onRightClick}
+        scale={1}
+      />
+    );
+
+    await act(async () => {
+      pendingRenderAt(0).resolve({
+        svg: `<svg><g class="node" id="mermaid-random-flowchart-${longNodeId}-0"></g></svg>`,
+      });
+    });
+
+    const node = container.querySelector('.node');
+    expect(node).not.toBeNull();
+    fireEvent.contextMenu(node!);
+
+    expect(onRightClick).toHaveBeenCalledWith(longNodeId);
   });
 });

--- a/ui/src/components/ui/__tests__/mermaid.test.tsx
+++ b/ui/src/components/ui/__tests__/mermaid.test.tsx
@@ -210,4 +210,31 @@ describe('Mermaid', () => {
 
     expect(onRightClick).toHaveBeenCalledWith(longNodeId);
   });
+
+  it('does not match a known node id inside a longer rendered node id', async () => {
+    const onRightClick = vi.fn();
+    const knownNodeId = 'node_61';
+
+    const { container } = render(
+      <Mermaid
+        def="graph TD; A-->B;"
+        nodeIds={[knownNodeId]}
+        onRightClick={onRightClick}
+        scale={1}
+      />
+    );
+
+    await act(async () => {
+      pendingRenderAt(0).resolve({
+        svg: '<svg><g class="node" id="mermaid-random-flowchart-node_61_62-0"></g></svg>',
+      });
+    });
+
+    const node = container.querySelector<HTMLElement>('.node');
+    expect(node).not.toBeNull();
+    expect(node!.style.cursor).toBe('');
+    fireEvent.contextMenu(node!);
+
+    expect(onRightClick).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/components/ui/mermaid.tsx
+++ b/ui/src/components/ui/mermaid.tsx
@@ -91,12 +91,29 @@ function normalizeNodeIds(nodeIds?: readonly string[]): string[] {
     .sort((a, b) => b.length - a.length);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchesRenderedNodeId(renderedId: string, nodeId: string): boolean {
+  if (renderedId === nodeId) {
+    return true;
+  }
+
+  // Dagu node ids use underscores internally, so only non-id characters can
+  // delimit the node id inside Mermaid's generated SVG element id.
+  const escapedNodeId = escapeRegExp(nodeId);
+  return new RegExp(
+    `(^|[^A-Za-z0-9_])${escapedNodeId}($|[^A-Za-z0-9_])`
+  ).test(renderedId);
+}
+
 function resolveRenderedNodeId(
   renderedId: string,
   knownNodeIds: readonly string[]
 ): string | null {
   for (const nodeId of knownNodeIds) {
-    if (renderedId === nodeId || renderedId.includes(nodeId)) {
+    if (matchesRenderedNodeId(renderedId, nodeId)) {
       return nodeId;
     }
   }

--- a/ui/src/components/ui/mermaid.tsx
+++ b/ui/src/components/ui/mermaid.tsx
@@ -5,6 +5,7 @@ type Props = {
   def: string;
   style?: CSSProperties;
   scale: number;
+  nodeIds?: readonly string[];
   onClick?: (id: string) => void;
   onDoubleClick?: (id: string) => void;
   onRightClick?: (id: string) => void;
@@ -81,6 +82,63 @@ function initializeMermaid(): void {
   });
 }
 
+function normalizeNodeIds(nodeIds?: readonly string[]): string[] {
+  if (!nodeIds?.length) {
+    return [];
+  }
+  return [...new Set(nodeIds)]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+}
+
+function resolveRenderedNodeId(
+  renderedId: string,
+  knownNodeIds: readonly string[]
+): string | null {
+  for (const nodeId of knownNodeIds) {
+    if (renderedId === nodeId || renderedId.includes(nodeId)) {
+      return nodeId;
+    }
+  }
+
+  // Backward compatibility for older callers that do not pass known ids.
+  // Older Mermaid versions rendered ids as "flowchart-${nodeId}-${index}".
+  if (knownNodeIds.length === 0) {
+    return renderedId.split('-')[1] || null;
+  }
+
+  return null;
+}
+
+function findRenderedNodeElement(
+  target: EventTarget | null,
+  container: HTMLDivElement | null
+): Element | null {
+  if (!(target instanceof Element) || !container) {
+    return null;
+  }
+  const nodeElement = target.closest('.node');
+  return nodeElement && container.contains(nodeElement) ? nodeElement : null;
+}
+
+function applyNodeInteractionStyles(
+  container: HTMLDivElement,
+  knownNodeIds: readonly string[],
+  hasNodeInteractions: boolean
+): void {
+  container.querySelectorAll('.node').forEach((node) => {
+    const nodeElement = node as HTMLElement;
+    const nodeId = resolveRenderedNodeId(node.id, knownNodeIds);
+    if (hasNodeInteractions && nodeId) {
+      nodeElement.style.cursor = 'pointer';
+      nodeElement.style.userSelect = 'none';
+    } else {
+      nodeElement.style.removeProperty('cursor');
+      nodeElement.style.removeProperty('user-select');
+    }
+  });
+}
+
 // Initialize on load
 initializeMermaid();
 
@@ -88,6 +146,7 @@ function Mermaid({
   def,
   style = {},
   scale,
+  nodeIds,
   onClick,
   onDoubleClick,
   onRightClick,
@@ -98,6 +157,10 @@ function Mermaid({
   const scrollContainerRef = React.useRef<HTMLDivElement>(null); // Ref for the outer scrollable div
   const scrollPosRef = React.useRef({ top: 0, left: 0 }); // Ref to store scroll position
   const handlersRef = React.useRef({ onClick, onDoubleClick, onRightClick });
+  const knownNodeIds = React.useMemo(() => normalizeNodeIds(nodeIds), [nodeIds]);
+  const knownNodeIdsRef = React.useRef(knownNodeIds);
+  const hasNodeInteractions = Boolean(onClick || onDoubleClick || onRightClick);
+  const hasNodeInteractionsRef = React.useRef(hasNodeInteractions);
   const renderGenerationRef = React.useRef(0);
   const clickTimeoutsRef = React.useRef<
     Map<string, ReturnType<typeof setTimeout>>
@@ -133,6 +196,84 @@ function Mermaid({
     handlersRef.current = { onClick, onDoubleClick, onRightClick };
   }, [onClick, onDoubleClick, onRightClick]);
 
+  React.useEffect(() => {
+    knownNodeIdsRef.current = knownNodeIds;
+  }, [knownNodeIds]);
+
+  React.useEffect(() => {
+    hasNodeInteractionsRef.current = hasNodeInteractions;
+  }, [hasNodeInteractions]);
+
+  const resolveEventNodeId = React.useCallback(
+    (target: EventTarget | null): string | null => {
+      const nodeElement = findRenderedNodeElement(target, mermaidRef.current);
+      if (!nodeElement) {
+        return null;
+      }
+      return resolveRenderedNodeId(nodeElement.id, knownNodeIdsRef.current);
+    },
+    []
+  );
+
+  const clearPendingClick = React.useCallback((nodeId: string) => {
+    const existingTimeout = clickTimeoutsRef.current.get(nodeId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      clickTimeoutsRef.current.delete(nodeId);
+    }
+  }, []);
+
+  const handleNodeClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!handlersRef.current.onClick) {
+        return;
+      }
+      const nodeId = resolveEventNodeId(event.target);
+      if (!nodeId) {
+        return;
+      }
+      clearPendingClick(nodeId);
+      const timeout = setTimeout(() => {
+        clickTimeoutsRef.current.delete(nodeId);
+        handlersRef.current.onClick?.(nodeId);
+      }, 250);
+      clickTimeoutsRef.current.set(nodeId, timeout);
+    },
+    [clearPendingClick, resolveEventNodeId]
+  );
+
+  const handleNodeDoubleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!handlersRef.current.onDoubleClick) {
+        return;
+      }
+      const nodeId = resolveEventNodeId(event.target);
+      if (!nodeId) {
+        return;
+      }
+      event.stopPropagation();
+      clearPendingClick(nodeId);
+      handlersRef.current.onDoubleClick(nodeId);
+    },
+    [clearPendingClick, resolveEventNodeId]
+  );
+
+  const handleNodeRightClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!handlersRef.current.onRightClick) {
+        return;
+      }
+      const nodeId = resolveEventNodeId(event.target);
+      if (!nodeId) {
+        return;
+      }
+      event.preventDefault();
+      clearPendingClick(nodeId);
+      handlersRef.current.onRightClick(nodeId);
+    },
+    [clearPendingClick, resolveEventNodeId]
+  );
+
   const render = async () => {
     const renderGeneration = ++renderGenerationRef.current;
     if (!mermaidRef.current) {
@@ -163,6 +304,11 @@ function Mermaid({
 
       mermaidRef.current.innerHTML = svg;
       onRender?.(mermaidRef.current);
+      applyNodeInteractionStyles(
+        mermaidRef.current,
+        knownNodeIdsRef.current,
+        hasNodeInteractionsRef.current
+      );
 
       // Apply scale transform immediately after SVG is rendered
       const svgEl = mermaidRef.current.querySelector('svg');
@@ -189,74 +335,6 @@ function Mermaid({
       if (scrollContainerRef.current) {
         scrollContainerRef.current.scrollTop = scrollPosRef.current.top;
         scrollContainerRef.current.scrollLeft = scrollPosRef.current.left;
-      }
-
-      // Attach custom event handlers if provided
-      if ((onClick || onDoubleClick || onRightClick) && mermaidRef.current) {
-        // Clear existing timeouts before setting up new handlers
-        clickTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout));
-        clickTimeoutsRef.current.clear();
-
-        // Find all nodes in the SVG (typically these are <g> elements with class="node")
-        const nodeElements = mermaidRef.current.querySelectorAll('.node');
-
-        nodeElements.forEach((node) => {
-          // Extract the node ID from the element
-          // The ID is typically in the format "flowchart-nodeId-number"
-          const nodeId = node.id.split('-')[1];
-
-          if (nodeId) {
-            // Attach single-click event listener if provided
-            if (onClick) {
-              node.addEventListener('click', () => {
-                // Clear any existing timeout for this node
-                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                if (existingTimeout) {
-                  clearTimeout(existingTimeout);
-                }
-                // Set timeout to allow double-click to cancel
-                const timeout = setTimeout(() => {
-                  clickTimeoutsRef.current.delete(nodeId);
-                  handlersRef.current.onClick?.(nodeId);
-                }, 250);
-                clickTimeoutsRef.current.set(nodeId, timeout);
-              });
-            }
-
-            // Attach double-click event listener if provided
-            if (onDoubleClick) {
-              node.addEventListener('dblclick', (event) => {
-                event.stopPropagation();
-                // Cancel pending single-click action
-                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                if (existingTimeout) {
-                  clearTimeout(existingTimeout);
-                  clickTimeoutsRef.current.delete(nodeId);
-                }
-                handlersRef.current.onDoubleClick?.(nodeId);
-              });
-            }
-
-            // Attach right-click (contextmenu) event listener if provided
-            if (onRightClick) {
-              node.addEventListener('contextmenu', (event) => {
-                event.preventDefault(); // Prevent default context menu
-                // Also cancel pending single-click
-                const existingTimeout = clickTimeoutsRef.current.get(nodeId);
-                if (existingTimeout) {
-                  clearTimeout(existingTimeout);
-                  clickTimeoutsRef.current.delete(nodeId);
-                }
-                handlersRef.current.onRightClick?.(nodeId);
-              });
-            }
-
-            // Add pointer cursor and disable text selection
-            const nodeElement = node as HTMLElement;
-            nodeElement.style.cursor = 'pointer';
-            nodeElement.style.userSelect = 'none';
-          }
-        });
       }
 
       // Bind standard Mermaid event handlers
@@ -297,6 +375,17 @@ function Mermaid({
   }, [def, onRender]); // Re-render when the definition or SVG post-processing changes
 
   React.useEffect(() => {
+    if (!mermaidRef.current) {
+      return;
+    }
+    applyNodeInteractionStyles(
+      mermaidRef.current,
+      knownNodeIds,
+      hasNodeInteractions
+    );
+  }, [knownNodeIds, hasNodeInteractions]);
+
+  React.useEffect(() => {
     // Apply scale transformation when scale prop changes
     if (mermaidRef.current) {
       const svg = mermaidRef.current.querySelector('svg');
@@ -335,6 +424,9 @@ function Mermaid({
     <div ref={scrollContainerRef} style={dStyle}>
       <div
         className="mermaid no-text-select"
+        onClick={handleNodeClick}
+        onContextMenu={handleNodeRightClick}
+        onDoubleClick={handleNodeDoubleClick}
         ref={mermaidRef} // Keep ref for mermaid rendering target
         style={{
           ...mStyle,
@@ -349,10 +441,4 @@ function Mermaid({
   );
 }
 
-export default React.memo(Mermaid, (prev, next) => {
-  return (
-    prev.def === next.def &&
-    prev.scale === next.scale &&
-    prev.onRender === next.onRender
-  );
-});
+export default Mermaid;

--- a/ui/src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts
+++ b/ui/src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { JSONSchema } from '@/lib/schema-utils';
+import type { ParamSchemaFormData } from '../paramSchemaForm';
 import {
   buildParamSchemaFormData,
   buildParamSchemaUiSchema,

--- a/ui/src/features/dags/components/visualization/Graph.tsx
+++ b/ui/src/features/dags/components/visualization/Graph.tsx
@@ -212,6 +212,13 @@ function Graph({
     };
   }, [width, isExpandedView, height, isDarkMode]);
 
+  const mermaidNodeIds = React.useMemo(() => {
+    return (steps ?? []).map((stepOrNode) => {
+      const step = isRuntimeNode(stepOrNode) ? stepOrNode.step : stepOrNode;
+      return toMermaidNodeId(step.name);
+    });
+  }, [steps]);
+
   const graph = React.useMemo(() => {
     if (!steps || steps.length === 0) return '';
 
@@ -484,6 +491,7 @@ function Graph({
           style={mermaidStyle}
           def={graph}
           scale={scale}
+          nodeIds={mermaidNodeIds}
           onClick={selectOnClick ? onClickNode : undefined}
           onDoubleClick={onDoubleClickNode ?? onClickNode}
           onRightClick={onRightClickNode}


### PR DESCRIPTION
## Summary
- restore Mermaid graph click, double-click, and right-click handling by resolving rendered SVG nodes against known Dagu node ids
- pass generated graph node ids into the shared Mermaid wrapper and add regression coverage for Mermaid 11.15, legacy ids, and shared-prefix collisions
- fix a missing schema form test type import that broke UI typecheck on latest main

## Testing
- pnpm vitest run src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts src/components/ui/__tests__/mermaid.test.tsx src/features/dags/components/visualization/__tests__/Graph.test.tsx src/features/dags/components/__tests__/DAGStatus.test.tsx
- pnpm typecheck
- pnpm exec eslint --ext .ts,.tsx src/components/ui/mermaid.tsx src/components/ui/__tests__/mermaid.test.tsx src/features/dags/components/visualization/Graph.tsx src/features/dags/components/dag-execution/__tests__/paramSchemaForm.test.ts
- pnpm build (passes with existing asset-size warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a nodeIds prop to control which Mermaid nodes are interactive; graph rendering now provides explicit node IDs.

* **Improvements**
  * Refactored node event handling for more reliable click/double-click/right-click behavior and timing.
  * Better backward compatibility with varied Mermaid node ID formats and improved interaction styling/cursor feedback.

* **Tests**
  * Added comprehensive tests for node ID resolution, event handling, and timer/cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->