### PR TITLE
fix: clean up upgrade version output spacing

### DIFF
--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -138,7 +138,7 @@ func runUpgrade(ctx *Context, _ []string) error {
 
 	if !skipConfirm {
 		fmt.Printf("Current version: %s\n", result.CurrentVersion)
-		fmt.Printf("Target version:  %s\n\n", result.TargetVersion)
+		fmt.Printf("Target version: %s\n\n", result.TargetVersion)
 		fmt.Println("The following changes will be made:")
 		fmt.Printf("  - Download: %s (%s)\n", result.AssetName, upgrade.FormatBytes(result.AssetSize))
 		fmt.Println("  - Verify:   SHA256 checksum")

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -148,7 +148,7 @@ func FormatResult(r *Result) string {
 	}
 
 	fmt.Fprintf(&sb, "Current version: %s\n", formatVersion(r.CurrentVersion))
-	fmt.Fprintf(&sb, "Target version:  %s\n", r.TargetVersion)
+	fmt.Fprintf(&sb, "Target version: %s\n", r.TargetVersion)
 
 	if !r.UpgradeNeeded && !r.WasUpgraded {
 		sb.WriteString("\nAlready running the latest version.\n")
@@ -182,7 +182,7 @@ func FormatCheckResult(r *Result) string {
 	if r.SpecificVersionRequest {
 		label = "Target version"
 	}
-	fmt.Fprintf(&sb, "%s:  %s\n", label, r.TargetVersion)
+	fmt.Fprintf(&sb, "%s: %s\n", label, r.TargetVersion)
 
 	if r.UpgradeNeeded {
 		sb.WriteString("\nAn update is available. Run 'dagu upgrade' to update.\n")

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1096,6 +1096,9 @@ func TestFormatResult(t *testing.T) {
 		if !strings.Contains(output, "v1.30.3") {
 			t.Error("FormatResult() should contain target version")
 		}
+		if strings.Contains(output, "Target version:  ") {
+			t.Error("FormatResult() should not add extra spacing before target version")
+		}
 	})
 
 	t.Run("already latest", func(t *testing.T) {
@@ -1161,6 +1164,9 @@ func TestFormatCheckResult(t *testing.T) {
 		if !strings.Contains(output, "v1.30.3") {
 			t.Error("FormatCheckResult() should contain latest version")
 		}
+		if strings.Contains(output, "Latest version:  ") {
+			t.Error("FormatCheckResult() should not add extra spacing before latest version")
+		}
 		if !strings.Contains(output, "update is available") {
 			t.Error("FormatCheckResult() should indicate update available")
 		}
@@ -1190,6 +1196,9 @@ func TestFormatCheckResult(t *testing.T) {
 		output := FormatCheckResult(result)
 		if !strings.Contains(output, "Target version") {
 			t.Error("FormatCheckResult() should show 'Target version' when specific version requested")
+		}
+		if strings.Contains(output, "Target version:  ") {
+			t.Error("FormatCheckResult() should not add extra spacing before target version")
 		}
 		if strings.Contains(output, "Latest version") {
 			t.Error("FormatCheckResult() should not show 'Latest version' when specific version requested")


### PR DESCRIPTION
## Summary
- remove the extra padding before upgrade target/latest version values
- keep interactive upgrade confirmation output consistent with formatted upgrade summaries
- add regression coverage for version summary spacing

## Testing
- go test ./internal/upgrade ./internal/cmd -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Improved formatting of upgrade confirmation prompts by adjusting spacing in console output for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->