### PR TITLE
fix: repair git sync shallow pulls

### DIFF
--- a/internal/gitsync/git.go
+++ b/internal/gitsync/git.go
@@ -30,6 +30,11 @@ type GitClient struct {
 	mu       sync.Mutex
 }
 
+// shallowRepairDepth asks go-git to deepen a broken shallow checkout far
+// enough to recover missing parent commits. Depth 0 does not repair a stale
+// shallow boundary once the remote-tracking ref already points at the new tip.
+const shallowRepairDepth = 2147483647
+
 // NewGitClient creates a new Git client.
 func NewGitClient(cfg *Config, repoPath string) *GitClient {
 	return &GitClient{
@@ -181,16 +186,6 @@ func (c *GitClient) Pull(ctx context.Context) (*PullResult, error) {
 		return nil, err
 	}
 
-	if err := c.Fetch(ctx); err != nil {
-		return nil, err
-	}
-
-	// Get remote HEAD
-	remoteRef, err := c.repo.Reference(plumbing.NewRemoteReferenceName("origin", c.cfg.Branch), true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get remote reference: %w", err)
-	}
-
 	// Get current HEAD
 	headRef, err := c.repo.Head()
 	if err != nil {
@@ -199,27 +194,65 @@ func (c *GitClient) Pull(ctx context.Context) (*PullResult, error) {
 
 	result := &PullResult{
 		PreviousCommit: headRef.Hash().String(),
-		CurrentCommit:  remoteRef.Hash().String(),
+		CurrentCommit:  headRef.Hash().String(),
 	}
 
-	// Check if already up to date
-	if headRef.Hash() == remoteRef.Hash() {
-		result.AlreadyUpToDate = true
-		return result, nil
+	err = c.pullWorktree(ctx, wt, auth)
+	if err != nil {
+		if err == git.NoErrAlreadyUpToDate {
+			result.AlreadyUpToDate = true
+			return result, nil
+		}
+		if errors.Is(err, plumbing.ErrObjectNotFound) && c.isShallow() {
+			if repairErr := c.repairShallowHistory(ctx, auth); repairErr != nil {
+				return nil, c.wrapAuthError(repairErr, "pull")
+			}
+			err = c.pullWorktree(ctx, wt, auth)
+			if err == git.NoErrAlreadyUpToDate {
+				result.AlreadyUpToDate = true
+				return result, nil
+			}
+		}
+		if err != nil {
+			return nil, c.wrapAuthError(err, "pull")
+		}
 	}
 
-	err = wt.Pull(&git.PullOptions{
+	headRef, err = c.repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+	}
+	result.CurrentCommit = headRef.Hash().String()
+
+	return result, nil
+}
+
+func (c *GitClient) pullWorktree(ctx context.Context, wt *git.Worktree, auth transport.AuthMethod) error {
+	return wt.PullContext(ctx, &git.PullOptions{
 		Auth:          auth,
 		RemoteName:    "origin",
 		ReferenceName: plumbing.NewBranchReferenceName(c.cfg.Branch),
 		SingleBranch:  true,
 		Force:         true,
 	})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
-		return nil, c.wrapAuthError(err, "pull")
-	}
+}
 
-	return result, nil
+func (c *GitClient) isShallow() bool {
+	shallow, err := c.repo.Storer.Shallow()
+	return err == nil && len(shallow) > 0
+}
+
+func (c *GitClient) repairShallowHistory(ctx context.Context, auth transport.AuthMethod) error {
+	err := c.repo.FetchContext(ctx, &git.FetchOptions{
+		Auth:       auth,
+		RemoteName: "origin",
+		Depth:      shallowRepairDepth,
+		Force:      true,
+	})
+	if err != nil && err != git.NoErrAlreadyUpToDate {
+		return err
+	}
+	return nil
 }
 
 // PullResult represents the result of a pull operation.

--- a/internal/gitsync/git_test.go
+++ b/internal/gitsync/git_test.go
@@ -4,11 +4,16 @@
 package gitsync
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -174,4 +179,110 @@ func TestGitClient_CommitStaged_NoChanges(t *testing.T) {
 	hash, err := c2.CommitStaged("empty commit")
 	require.NoError(t, err)
 	require.Equal(t, firstHash, hash)
+}
+
+func TestGitClient_PullShallowRepoMultipleCommitsAhead(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	remotePath := filepath.Join(root, "remote")
+	clonePath := filepath.Join(root, "clone")
+
+	remoteRepo := initGitTestRepo(t, remotePath)
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 0\n", "initial")
+
+	_, err := git.PlainCloneContext(ctx, clonePath, false, &git.CloneOptions{
+		URL:           remotePath,
+		ReferenceName: plumbing.NewBranchReferenceName("main"),
+		SingleBranch:  true,
+		Depth:         1,
+	})
+	require.NoError(t, err)
+
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 1\n", "first remote update")
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 2\n", "second remote update")
+
+	cfg := &Config{Enabled: true, Repository: remotePath, Branch: "main"}
+	client := NewGitClient(cfg, clonePath)
+	require.NoError(t, client.Open())
+
+	result, err := client.Pull(ctx)
+	require.NoError(t, err)
+	require.False(t, result.AlreadyUpToDate)
+	require.NotEqual(t, result.PreviousCommit, result.CurrentCommit)
+
+	content, err := os.ReadFile(filepath.Join(clonePath, "dag.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "value: 2\n", string(content))
+}
+
+func TestGitClient_PullRecoversAfterShallowFetch(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	remotePath := filepath.Join(root, "remote")
+	clonePath := filepath.Join(root, "clone")
+
+	remoteRepo := initGitTestRepo(t, remotePath)
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 0\n", "initial")
+
+	_, err := git.PlainCloneContext(ctx, clonePath, false, &git.CloneOptions{
+		URL:           remotePath,
+		ReferenceName: plumbing.NewBranchReferenceName("main"),
+		SingleBranch:  true,
+		Depth:         1,
+	})
+	require.NoError(t, err)
+
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 1\n", "first remote update")
+	commitGitTestFile(t, remoteRepo, remotePath, "dag.yaml", "value: 2\n", "second remote update")
+
+	cfg := &Config{Enabled: true, Repository: remotePath, Branch: "main"}
+	client := NewGitClient(cfg, clonePath)
+	require.NoError(t, client.Open())
+	require.NoError(t, client.Fetch(ctx))
+
+	result, err := client.Pull(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, result.PreviousCommit, result.CurrentCommit)
+
+	content, err := os.ReadFile(filepath.Join(clonePath, "dag.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "value: 2\n", string(content))
+}
+
+func initGitTestRepo(t *testing.T, path string) *git.Repository {
+	t.Helper()
+
+	repo, err := git.PlainInit(path, false)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewSymbolicReference(
+		plumbing.HEAD,
+		plumbing.NewBranchReferenceName("main"),
+	)))
+
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{path}})
+	require.NoError(t, err)
+
+	return repo
+}
+
+func commitGitTestFile(t *testing.T, repo *git.Repository, repoPath, filePath, content, message string) plumbing.Hash {
+	t.Helper()
+
+	fullPath := filepath.Join(repoPath, filePath)
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add(filePath)
+	require.NoError(t, err)
+
+	hash, err := wt.Commit(message, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	return hash
 }


### PR DESCRIPTION
## Summary

Repair git-sync pull failures for shallow internal repositories when the remote branch advances beyond the available local history.

## Changes

- Remove the extra depth-1 fetch before git-sync pull so go-git can fetch the history it needs in one pull operation.
- Retry shallow pulls after deepening history when an existing internal clone is already missing parent commits.
- Add regression tests for multi-commit shallow pulls and recovery after the old shallow fetch path.

## Root Cause

Dagu cloned and fetched the git-sync repository with depth 1, then performed a separate pull. When the remote branch was more than one commit ahead, go-git could not walk the missing intermediate parent commits and returned object not found.

## Related Issues

Reported by a user; no linked issue.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- go test ./internal/gitsync ./internal/service/frontend/api/v1 -count=1