### PR TITLE
feat: add LINE bot integration

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/service/discord"
 	"github.com/dagucloud/dagu/internal/service/frontend"
+	"github.com/dagucloud/dagu/internal/service/line"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	daguslack "github.com/dagucloud/dagu/internal/service/slack"
 	"github.com/dagucloud/dagu/internal/service/telegram"
@@ -196,6 +197,33 @@ func runServer(ctx *Context, _ []string) error {
 					}
 				}()
 				logger.Info(serviceCtx, "Discord bot started")
+			}
+
+		case config.BotProviderLine:
+			lineBot, lineErr := line.New(
+				line.Config{
+					ChannelAccessToken:    ctx.Config.Bots.Line.ChannelAccessToken,
+					ChannelSecret:         ctx.Config.Bots.Line.ChannelSecret,
+					AllowedSourceIDs:      ctx.Config.Bots.Line.AllowedSourceIDs,
+					InterestedEventTypes:  ctx.Config.Bots.Line.InterestedEventTypes,
+					RespondToAll:          ctx.Config.Bots.Line.RespondToAll,
+					SafeMode:              ctx.Config.Bots.SafeMode,
+					EventService:          ctx.EventService,
+					NotificationStateFile: filepath.Join(ctx.Config.Paths.DataDir, "bots", "line", "notifications.json"),
+				},
+				agentAPI,
+				slog.Default(),
+			)
+			if lineErr != nil {
+				logger.Warn(serviceCtx, "Failed to initialize LINE bot", tag.Error(lineErr))
+			} else {
+				server.RegisterRoutes(lineBot.ConfigureRoutes)
+				go func() {
+					if runErr := lineBot.Run(signalCtx); runErr != nil {
+						logger.Error(serviceCtx, "LINE bot failed", tag.Error(runErr))
+					}
+				}()
+				logger.Info(serviceCtx, "LINE bot started")
 			}
 
 		case config.BotProviderNone:

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dagucloud/dagu/internal/service/discord"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
 	"github.com/dagucloud/dagu/internal/service/frontend"
+	"github.com/dagucloud/dagu/internal/service/line"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	daguslack "github.com/dagucloud/dagu/internal/service/slack"
 	"github.com/dagucloud/dagu/internal/service/telegram"
@@ -166,6 +167,7 @@ func runStartAll(ctx *Context, _ []string) error {
 	var tgBot *telegram.Bot
 	var slackBot *daguslack.Bot
 	var discordBot *discord.Bot
+	var lineBot *line.Bot
 	if agentAPI != nil {
 		switch ctx.Config.Bots.Provider {
 		case config.BotProviderTelegram:
@@ -228,6 +230,28 @@ func runStartAll(ctx *Context, _ []string) error {
 				logger.Info(serviceCtx, "Discord bot initialized")
 			}
 
+		case config.BotProviderLine:
+			lineBot, err = line.New(
+				line.Config{
+					ChannelAccessToken:    ctx.Config.Bots.Line.ChannelAccessToken,
+					ChannelSecret:         ctx.Config.Bots.Line.ChannelSecret,
+					AllowedSourceIDs:      ctx.Config.Bots.Line.AllowedSourceIDs,
+					InterestedEventTypes:  ctx.Config.Bots.Line.InterestedEventTypes,
+					RespondToAll:          ctx.Config.Bots.Line.RespondToAll,
+					SafeMode:              ctx.Config.Bots.SafeMode,
+					EventService:          ctx.EventService,
+					NotificationStateFile: filepath.Join(ctx.Config.Paths.DataDir, "bots", "line", "notifications.json"),
+				},
+				agentAPI,
+				slog.Default(),
+			)
+			if err != nil {
+				logger.Warn(serviceCtx, "Failed to initialize LINE bot", tag.Error(err))
+			} else {
+				server.RegisterRoutes(lineBot.ConfigureRoutes)
+				logger.Info(serviceCtx, "LINE bot initialized")
+			}
+
 		case config.BotProviderNone:
 			// No bot configured
 		}
@@ -251,6 +275,9 @@ func runStartAll(ctx *Context, _ []string) error {
 		serviceCount++
 	}
 	if discordBot != nil {
+		serviceCount++
+	}
+	if lineBot != nil {
 		serviceCount++
 	}
 	errCh := make(chan error, serviceCount)
@@ -309,6 +336,18 @@ func runStartAll(ctx *Context, _ []string) error {
 			if err := discordBot.Run(signalCtx); err != nil {
 				select {
 				case errCh <- fmt.Errorf("discord bot failed: %w", err):
+				default:
+				}
+			}
+		})
+	}
+
+	// Start LINE bot background work
+	if lineBot != nil {
+		wg.Go(func() {
+			if err := lineBot.Run(signalCtx); err != nil {
+				select {
+				case errCh <- fmt.Errorf("line bot failed: %w", err):
 				default:
 				}
 			}

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -44,6 +44,7 @@ const (
 	BotProviderTelegram BotProvider = "telegram"
 	BotProviderSlack    BotProvider = "slack"
 	BotProviderDiscord  BotProvider = "discord"
+	BotProviderLine     BotProvider = "line"
 )
 
 var DefaultBotInterestedEventTypes = []string{
@@ -63,6 +64,7 @@ type BotsConfig struct {
 	Telegram TelegramBotConfig
 	Slack    SlackBotConfig
 	Discord  DiscordBotConfig
+	Line     LineBotConfig
 }
 
 // TelegramBotConfig holds the Telegram-specific bot configuration.
@@ -87,6 +89,15 @@ type DiscordBotConfig struct {
 	AllowedChannelIDs    []string
 	InterestedEventTypes []string
 	RespondToAll         bool // respond to all channel messages, not just @mentions
+}
+
+// LineBotConfig holds the LINE-specific bot configuration.
+type LineBotConfig struct {
+	ChannelAccessToken   string
+	ChannelSecret        string
+	AllowedSourceIDs     []string
+	InterestedEventTypes []string
+	RespondToAll         bool // respond to all group/room messages, not just mentions
 }
 
 // GitSyncConfig holds the configuration for Git sync functionality.
@@ -631,6 +642,9 @@ func (c *Config) validateBots() error {
 		return err
 	}
 	if err := validateInterestedEventTypes("bots.discord.interested_event_types", c.Bots.Discord.InterestedEventTypes); err != nil {
+		return err
+	}
+	if err := validateInterestedEventTypes("bots.line.interested_event_types", c.Bots.Line.InterestedEventTypes); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -467,6 +467,7 @@ type BotsDef struct {
 	Telegram *TelegramBotDef `mapstructure:"telegram"`
 	Slack    *SlackBotDef    `mapstructure:"slack"`
 	Discord  *DiscordBotDef  `mapstructure:"discord"`
+	Line     *LineBotDef     `mapstructure:"line"`
 }
 
 // TelegramBotDef configures the Telegram bot.
@@ -489,6 +490,15 @@ type SlackBotDef struct {
 type DiscordBotDef struct {
 	Token                string   `mapstructure:"token"`
 	AllowedChannelIDs    []string `mapstructure:"allowed_channel_ids"`
+	InterestedEventTypes []string `mapstructure:"interested_event_types"`
+	RespondToAll         *bool    `mapstructure:"respond_to_all"` // Default: true
+}
+
+// LineBotDef configures the LINE bot.
+type LineBotDef struct {
+	ChannelAccessToken   string   `mapstructure:"channel_access_token"`
+	ChannelSecret        string   `mapstructure:"channel_secret"`
+	AllowedSourceIDs     []string `mapstructure:"allowed_source_ids"`
 	InterestedEventTypes []string `mapstructure:"interested_event_types"`
 	RespondToAll         *bool    `mapstructure:"respond_to_all"` // Default: true
 }

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -1199,8 +1199,10 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 	cfg.Bots.Telegram.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Slack.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Discord.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
+	cfg.Bots.Line.InterestedEventTypes = append([]string(nil), DefaultBotInterestedEventTypes...)
 	cfg.Bots.Slack.RespondToAll = true
 	cfg.Bots.Discord.RespondToAll = true
+	cfg.Bots.Line.RespondToAll = true
 
 	botsDef := def.Bots
 	if botsDef == nil {
@@ -1300,6 +1302,49 @@ func (l *ConfigLoader) loadBotsConfig(cfg *Config, def Definition) {
 			cfg.Bots.Discord.RespondToAll = *botsDef.Discord.RespondToAll
 		}
 	}
+
+	// Check env var override for LINE credentials
+	if token := l.v.GetString("bots.line.channel_access_token"); token != "" {
+		cfg.Bots.Line.ChannelAccessToken = token
+	}
+	if secret := l.v.GetString("bots.line.channel_secret"); secret != "" {
+		cfg.Bots.Line.ChannelSecret = secret
+	}
+	if _, ok := os.LookupEnv(strings.ToUpper(AppSlug) + "_BOTS_LINE_ALLOWED_SOURCE_IDS"); ok {
+		cfg.Bots.Line.AllowedSourceIDs = parseStringList(l.v.Get("bots.line.allowed_source_ids"))
+	}
+	if raw, ok := lookupInterestedEventTypesEnv("BOTS_LINE_INTERESTED_EVENT_TYPES"); ok {
+		cfg.Bots.Line.InterestedEventTypes = parseInterestedEventTypes(raw)
+	}
+	if _, ok := os.LookupEnv(strings.ToUpper(AppSlug) + "_BOTS_LINE_RESPOND_TO_ALL"); ok {
+		cfg.Bots.Line.RespondToAll = l.v.GetBool("bots.line.respond_to_all")
+	}
+
+	if botsDef.Line != nil {
+		if cfg.Bots.Line.ChannelAccessToken == "" {
+			cfg.Bots.Line.ChannelAccessToken = botsDef.Line.ChannelAccessToken
+		}
+		if cfg.Bots.Line.ChannelSecret == "" {
+			cfg.Bots.Line.ChannelSecret = botsDef.Line.ChannelSecret
+		}
+		if len(botsDef.Line.AllowedSourceIDs) > 0 &&
+			!hasEnv("BOTS_LINE_ALLOWED_SOURCE_IDS") {
+			cfg.Bots.Line.AllowedSourceIDs = botsDef.Line.AllowedSourceIDs
+		}
+		if botsDef.Line.InterestedEventTypes != nil &&
+			!hasInterestedEventTypesEnv("BOTS_LINE_INTERESTED_EVENT_TYPES") {
+			cfg.Bots.Line.InterestedEventTypes = parseInterestedEventTypesSlice(botsDef.Line.InterestedEventTypes)
+		}
+		if botsDef.Line.RespondToAll != nil &&
+			!hasEnv("BOTS_LINE_RESPOND_TO_ALL") {
+			cfg.Bots.Line.RespondToAll = *botsDef.Line.RespondToAll
+		}
+	}
+}
+
+func hasEnv(name string) bool {
+	_, ok := os.LookupEnv(strings.ToUpper(AppSlug) + "_" + name)
+	return ok
 }
 
 func parseInterestedEventTypes(raw string) []string {
@@ -1836,6 +1881,11 @@ var envBindings = []envBinding{
 	{key: "bots.discord.allowed_channel_ids", env: "BOTS_DISCORD_ALLOWED_CHANNEL_IDS"},
 	{key: "bots.discord.interested_event_types", env: "BOTS_DISCORD_INTERESTED_EVENT_TYPES"},
 	{key: "bots.discord.respond_to_all", env: "BOTS_DISCORD_RESPOND_TO_ALL"},
+	{key: "bots.line.channel_access_token", env: "BOTS_LINE_CHANNEL_ACCESS_TOKEN"},
+	{key: "bots.line.channel_secret", env: "BOTS_LINE_CHANNEL_SECRET"},
+	{key: "bots.line.allowed_source_ids", env: "BOTS_LINE_ALLOWED_SOURCE_IDS"},
+	{key: "bots.line.interested_event_types", env: "BOTS_LINE_INTERESTED_EVENT_TYPES"},
+	{key: "bots.line.respond_to_all", env: "BOTS_LINE_RESPOND_TO_ALL"},
 
 	// License
 	{key: "license.key", env: "LICENSE_KEY"},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -358,6 +358,10 @@ func TestLoad_Env(t *testing.T) {
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
 				RespondToAll:         true,
 			},
+			Line: LineBotConfig{
+				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
+			},
 		},
 		DefaultExecMode: ExecutionModeLocal,
 		Warnings:        nil,
@@ -799,6 +803,10 @@ scheduler:
 				RespondToAll:         true,
 			},
 			Discord: DiscordBotConfig{
+				InterestedEventTypes: DefaultBotInterestedEventTypes,
+				RespondToAll:         true,
+			},
+			Line: LineBotConfig{
 				InterestedEventTypes: DefaultBotInterestedEventTypes,
 				RespondToAll:         true,
 			},
@@ -1313,6 +1321,36 @@ bots:
 
 		assert.Equal(t, []string{"dag.run.running", "dag.run.queued"}, cfg.Bots.Discord.InterestedEventTypes)
 	})
+
+	t.Run("line env overrides config", func(t *testing.T) {
+		cfg := loadWithEnv(t, `
+bots:
+  line:
+    interested_event_types:
+      - dag.run.failed
+      - dag.run.succeeded
+`, map[string]string{
+			"DAGU_BOTS_LINE_INTERESTED_EVENT_TYPES": "dag.run.running,dag.run.queued",
+		})
+
+		assert.Equal(t, []string{"dag.run.running", "dag.run.queued"}, cfg.Bots.Line.InterestedEventTypes)
+	})
+
+	t.Run("line env overrides config for source ids and respond mode", func(t *testing.T) {
+		cfg := loadWithEnv(t, `
+bots:
+  line:
+    allowed_source_ids:
+      - Ufrom-yaml
+    respond_to_all: true
+`, map[string]string{
+			"DAGU_BOTS_LINE_ALLOWED_SOURCE_IDS": "Ufrom-env,Cfrom-env",
+			"DAGU_BOTS_LINE_RESPOND_TO_ALL":     "false",
+		})
+
+		assert.Equal(t, []string{"Ufrom-env", "Cfrom-env"}, cfg.Bots.Line.AllowedSourceIDs)
+		assert.False(t, cfg.Bots.Line.RespondToAll)
+	})
 }
 
 func TestLoad_DiscordBotEnvOnlyConfig(t *testing.T) {
@@ -1328,6 +1366,23 @@ func TestLoad_DiscordBotEnvOnlyConfig(t *testing.T) {
 	assert.Equal(t, []string{"chan-1", "chan-2"}, cfg.Bots.Discord.AllowedChannelIDs)
 	assert.False(t, cfg.Bots.Discord.RespondToAll)
 	assert.Equal(t, DefaultBotInterestedEventTypes, cfg.Bots.Discord.InterestedEventTypes)
+}
+
+func TestLoad_LineBotEnvOnlyConfig(t *testing.T) {
+	cfg := loadWithEnv(t, "# empty", map[string]string{
+		"DAGU_BOTS_PROVIDER":                  "line",
+		"DAGU_BOTS_LINE_CHANNEL_ACCESS_TOKEN": "line-channel-token",
+		"DAGU_BOTS_LINE_CHANNEL_SECRET":       "line-channel-secret",
+		"DAGU_BOTS_LINE_ALLOWED_SOURCE_IDS":   "U123,C456",
+		"DAGU_BOTS_LINE_RESPOND_TO_ALL":       "false",
+	})
+
+	assert.Equal(t, BotProviderLine, cfg.Bots.Provider)
+	assert.Equal(t, "line-channel-token", cfg.Bots.Line.ChannelAccessToken)
+	assert.Equal(t, "line-channel-secret", cfg.Bots.Line.ChannelSecret)
+	assert.Equal(t, []string{"U123", "C456"}, cfg.Bots.Line.AllowedSourceIDs)
+	assert.False(t, cfg.Bots.Line.RespondToAll)
+	assert.Equal(t, DefaultBotInterestedEventTypes, cfg.Bots.Line.InterestedEventTypes)
 }
 
 func TestLoad_Monitoring(t *testing.T) {

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -1176,13 +1176,13 @@
     },
     "BotsDef": {
       "type": "object",
-      "description": "Bot integration configuration for Telegram or Slack.",
+      "description": "Bot integration configuration for Telegram, Slack, Discord, or LINE.",
       "additionalProperties": false,
       "properties": {
         "provider": {
           "type": "string",
           "description": "Bot provider to run. Empty or omitted disables bot integrations.",
-          "enum": ["", "telegram", "slack"],
+          "enum": ["", "telegram", "slack", "discord", "line"],
           "default": ""
         },
         "safe_mode": {
@@ -1195,6 +1195,12 @@
         },
         "slack": {
           "$ref": "#/definitions/SlackBotDef"
+        },
+        "discord": {
+          "$ref": "#/definitions/DiscordBotDef"
+        },
+        "line": {
+          "$ref": "#/definitions/LineBotDef"
         }
       },
       "allOf": [
@@ -1253,6 +1259,74 @@
                     "minLength": 1
                   },
                   "allowed_channel_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["provider"],
+            "properties": {
+              "provider": {
+                "const": "discord"
+              }
+            }
+          },
+          "then": {
+            "required": ["discord"],
+            "properties": {
+              "discord": {
+                "required": ["token", "allowed_channel_ids"],
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "allowed_channel_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["provider"],
+            "properties": {
+              "provider": {
+                "const": "line"
+              }
+            }
+          },
+          "then": {
+            "required": ["line"],
+            "properties": {
+              "line": {
+                "required": ["channel_access_token", "channel_secret", "allowed_source_ids"],
+                "properties": {
+                  "channel_access_token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "channel_secret": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "allowed_source_ids": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
@@ -1340,6 +1414,88 @@
         "respond_to_all": {
           "type": "boolean",
           "description": "Respond to all messages in allowed channels, not just direct mentions. Default: true.",
+          "default": true
+        }
+      }
+    },
+    "DiscordBotDef": {
+      "type": "object",
+      "description": "Discord bot settings.",
+      "additionalProperties": false,
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "Discord bot token."
+        },
+        "allowed_channel_ids": {
+          "type": "array",
+          "description": "Discord channel IDs the bot is allowed to operate in. Required and must be non-empty when provider is 'discord'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "interested_event_types": {
+          "type": "array",
+          "description": "DAG-run lifecycle event types that the bot tracks for notification delivery. Defaults to waiting, succeeded, failed, aborted, and rejected. Succeeded events are used to suppress stale pending alerts and do not send a chat message.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "dag.run.queued",
+              "dag.run.running",
+              "dag.run.waiting",
+              "dag.run.succeeded",
+              "dag.run.failed",
+              "dag.run.aborted",
+              "dag.run.rejected"
+            ]
+          }
+        },
+        "respond_to_all": {
+          "type": "boolean",
+          "description": "Respond to all messages in allowed channels, not just direct mentions. Default: true.",
+          "default": true
+        }
+      }
+    },
+    "LineBotDef": {
+      "type": "object",
+      "description": "LINE bot settings.",
+      "additionalProperties": false,
+      "properties": {
+        "channel_access_token": {
+          "type": "string",
+          "description": "LINE Messaging API channel access token."
+        },
+        "channel_secret": {
+          "type": "string",
+          "description": "LINE Messaging API channel secret used to verify webhook signatures."
+        },
+        "allowed_source_ids": {
+          "type": "array",
+          "description": "LINE user, group, or room IDs the bot is allowed to operate in. Required and must be non-empty when provider is 'line'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "interested_event_types": {
+          "type": "array",
+          "description": "DAG-run lifecycle event types that the bot tracks for notification delivery. Defaults to waiting, succeeded, failed, aborted, and rejected. Succeeded events are used to suppress stale pending alerts and do not send a chat message.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "dag.run.queued",
+              "dag.run.running",
+              "dag.run.waiting",
+              "dag.run.succeeded",
+              "dag.run.failed",
+              "dag.run.aborted",
+              "dag.run.rejected"
+            ]
+          }
+        },
+        "respond_to_all": {
+          "type": "boolean",
+          "description": "Respond to all messages in allowed LINE groups and rooms, not just messages that mention the bot. One-on-one chats always respond. Default: true.",
           "default": true
         }
       }

--- a/internal/cmn/schema/config_schema_test.go
+++ b/internal/cmn/schema/config_schema_test.go
@@ -77,10 +77,33 @@ bots:
 `,
 		},
 		{
-			name: "RejectInvalidProvider",
+			name: "ValidLineBotConfig",
+			spec: `
+bots:
+  provider: line
+  line:
+    channel_access_token: line-channel-token
+    channel_secret: line-channel-secret
+    allowed_source_ids: [U12345, C67890]
+    respond_to_all: false
+`,
+		},
+		{
+			name: "ValidDiscordBotConfig",
 			spec: `
 bots:
   provider: discord
+  discord:
+    token: discord-token
+    allowed_channel_ids: [C12345]
+    respond_to_all: true
+`,
+		},
+		{
+			name: "RejectInvalidProvider",
+			spec: `
+bots:
+  provider: unknown
 `,
 			wantErr: "bots",
 		},
@@ -101,6 +124,17 @@ bots:
   provider: slack
   slack:
     allowed_channel_ids: [C12345]
+`,
+			wantErr: "bots",
+		},
+		{
+			name: "RejectLineWithoutChannelSecret",
+			spec: `
+bots:
+  provider: line
+  line:
+    channel_access_token: line-channel-token
+    allowed_source_ids: [U12345]
 `,
 			wantErr: "bots",
 		},

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -108,6 +108,9 @@ type shutdownActions struct {
 	closeAudit             func() error
 }
 
+// RouteRegistrar registers additional HTTP routes on the frontend server.
+type RouteRegistrar func(context.Context, chi.Router, string)
+
 // Server represents the HTTP server for the frontend application.
 type Server struct {
 	apiV1               *apiv1.API
@@ -136,6 +139,7 @@ type Server struct {
 	remoteNodeResolver  *remotenode.Resolver
 	upgradeStore        upgrade.CacheStore
 	agentAPICallback    func(*agent.API)
+	routeRegistrars     []RouteRegistrar
 }
 
 // ServerOption is a functional option for configuring the Server.
@@ -183,6 +187,14 @@ func WithAPIOption(opt apiv1.APIOption) ServerOption {
 		if opt != nil {
 			s.tunnelAPIOpts = append(s.tunnelAPIOpts, opt)
 		}
+	}
+}
+
+// RegisterRoutes appends a route registrar that is applied before API routes
+// are mounted.
+func (srv *Server) RegisterRoutes(fn RouteRegistrar) {
+	if fn != nil {
+		srv.routeRegistrars = append(srv.routeRegistrars, fn)
 	}
 }
 
@@ -1059,6 +1071,8 @@ func (srv *Server) Serve(ctx context.Context) error {
 		return err
 	}
 
+	srv.setupRegisteredRoutes(ctx, r, apiV1BasePath)
+
 	if err := srv.setupAPIRoutes(ctx, r, apiV1BasePath); err != nil {
 		return err
 	}
@@ -1282,6 +1296,12 @@ func (srv *Server) setupAPIRoutes(ctx context.Context, r *chi.Mux, apiV1BasePath
 		}
 	})
 	return setupErr
+}
+
+func (srv *Server) setupRegisteredRoutes(ctx context.Context, r chi.Router, apiV1BasePath string) {
+	for _, register := range srv.routeRegistrars {
+		register(ctx, r, apiV1BasePath)
+	}
 }
 
 func (srv *Server) setupTerminalRoute(ctx context.Context, r *chi.Mux, apiV1BasePath string) {

--- a/internal/service/line/bot.go
+++ b/internal/service/line/bot.go
@@ -1,0 +1,780 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package line provides a LINE Messaging API bot service that bridges LINE
+// chats with the Dagu AI agent.
+package line
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+)
+
+const maxLineTextLen = 5000
+const maxLineWebhookBodyBytes = 1 << 20
+const defaultIncomingBatchDelay = 750 * time.Millisecond
+const processedWebhookEventTTL = 24 * time.Hour
+const maxProcessedWebhookEvents = 10000
+
+// AgentService is the subset of the agent API that the LINE bot requires.
+type AgentService = chatbridge.AgentService
+
+// Config holds configuration for the LINE bot.
+type Config struct {
+	ChannelAccessToken    string
+	ChannelSecret         string
+	AllowedSourceIDs      []string
+	InterestedEventTypes  []string
+	SafeMode              bool
+	RespondToAll          bool
+	EventService          *eventstore.Service
+	NotificationStateFile string
+}
+
+type chatState struct {
+	chatbridge.State
+
+	promptMu              sync.Mutex
+	pendingPromptOptions  map[string]string
+	pendingPromptFreeText bool
+}
+
+// Bot forwards LINE webhook events to the Dagu agent API.
+type Bot struct {
+	cfg                   Config
+	agentAPI              AgentService
+	client                lineClientAPI
+	chats                 sync.Map // sourceID (string) -> *chatState
+	allowedSources        map[string]struct{}
+	processedEventMu      sync.Mutex
+	processedEvents       map[string]time.Time
+	eventService          *eventstore.Service
+	notificationStateFile string
+	logger                *slog.Logger
+	incomingDelay         time.Duration
+	incomingAfterFunc     func(time.Duration, func())
+}
+
+// New creates a new LINE bot instance.
+func New(cfg Config, agentAPI AgentService, logger *slog.Logger) (*Bot, error) {
+	if cfg.ChannelAccessToken == "" {
+		return nil, fmt.Errorf("line channel access token is required (set DAGU_BOTS_LINE_CHANNEL_ACCESS_TOKEN)")
+	}
+	if cfg.ChannelSecret == "" {
+		return nil, fmt.Errorf("line channel secret is required (set DAGU_BOTS_LINE_CHANNEL_SECRET)")
+	}
+	if len(cfg.AllowedSourceIDs) == 0 {
+		return nil, fmt.Errorf("at least one allowed source ID is required (set DAGU_BOTS_LINE_ALLOWED_SOURCE_IDS)")
+	}
+
+	allowed := make(map[string]struct{}, len(cfg.AllowedSourceIDs))
+	for _, id := range cfg.AllowedSourceIDs {
+		allowed[id] = struct{}{}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Bot{
+		cfg:                   cfg,
+		agentAPI:              agentAPI,
+		client:                newHTTPLineClient(cfg.ChannelAccessToken),
+		allowedSources:        allowed,
+		processedEvents:       make(map[string]time.Time),
+		eventService:          cfg.EventService,
+		notificationStateFile: cfg.NotificationStateFile,
+		logger:                logger,
+		incomingDelay:         defaultIncomingBatchDelay,
+		incomingAfterFunc:     func(delay time.Duration, f func()) { time.AfterFunc(delay, f) },
+	}, nil
+}
+
+// ConfigureRoutes registers the public LINE webhook route on the Dagu server.
+func (b *Bot) ConfigureRoutes(ctx context.Context, r chi.Router, apiV1BasePath string) {
+	webhookPath := path.Join(apiV1BasePath, "bots/line/webhook")
+	r.Post(webhookPath, b.ServeHTTP)
+	b.logger.InfoContext(ctx, "LINE webhook route configured", slog.String("path", webhookPath))
+}
+
+// Run starts background LINE bot work and blocks until the context is cancelled.
+func (b *Bot) Run(ctx context.Context) error {
+	b.logger.Info("LINE bot started",
+		slog.Int("allowed_sources", len(b.allowedSources)),
+		slog.Bool("respond_to_all", b.cfg.RespondToAll),
+	)
+
+	if b.eventService != nil {
+		monitor := NewDAGRunMonitor(b.eventService, b.notificationStateFile, b.agentAPI, b, b.logger)
+		go monitor.Run(ctx)
+	} else {
+		b.logger.Warn("Event store is not configured; DAG run notifications are disabled")
+	}
+
+	<-ctx.Done()
+	b.logger.Info("LINE bot stopped")
+	return nil
+}
+
+func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxLineWebhookBodyBytes))
+	if err != nil {
+		http.Error(w, "invalid webhook body", http.StatusBadRequest)
+		return
+	}
+
+	signature := r.Header.Get("x-line-signature")
+	if !verifySignature(b.cfg.ChannelSecret, body, signature) {
+		http.Error(w, "invalid LINE signature", http.StatusUnauthorized)
+		return
+	}
+
+	var payload webhookRequest
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid webhook json", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	for _, event := range payload.Events {
+		b.handleWebhookEvent(r.Context(), event)
+	}
+}
+
+func verifySignature(channelSecret string, body []byte, signature string) bool {
+	if channelSecret == "" || signature == "" {
+		return false
+	}
+	got, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(channelSecret))
+	_, _ = mac.Write(body)
+	return hmac.Equal(got, mac.Sum(nil))
+}
+
+func (b *Bot) handleWebhookEvent(ctx context.Context, event webhookEvent) {
+	if !b.claimWebhookEvent(event) {
+		b.logger.Info("Skipped duplicate LINE webhook event",
+			slog.String("webhook_event_id", event.WebhookEventID),
+			slog.Bool("is_redelivery", event.DeliveryContext.IsRedelivery),
+		)
+		return
+	}
+	if event.Type != "message" || event.Message.Type != "text" {
+		return
+	}
+	sourceID := event.Source.ID()
+	if sourceID == "" {
+		return
+	}
+	if !b.isSourceAllowed(sourceID) {
+		b.logger.Warn("Rejected LINE webhook from unauthorized source",
+			slog.String("source_id", sourceID),
+			slog.String("source_type", event.Source.Type),
+		)
+		if event.ReplyToken != "" {
+			b.replyText(ctx, event.ReplyToken, "This bot is not authorized for this chat.")
+		}
+		return
+	}
+
+	text := strings.TrimSpace(event.Message.Text)
+	if text == "" {
+		return
+	}
+
+	cs := b.getOrCreateChat(sourceID)
+	pendingPrompt := cs.PendingPromptID()
+	mentioned := event.Message.SelfMentioned()
+	if event.Source.Type != "user" && !b.cfg.RespondToAll && !mentioned && pendingPrompt == "" {
+		return
+	}
+	if mentioned {
+		text = stripSelfMention(text, event.Message.Mention)
+		if text == "" {
+			return
+		}
+	}
+
+	if pendingPrompt != "" {
+		b.submitPromptResponse(ctx, cs, sourceID, pendingPrompt, text)
+		return
+	}
+
+	if fields := strings.Fields(text); len(fields) > 0 {
+		cmd := strings.TrimPrefix(strings.ToLower(fields[0]), "/")
+		switch cmd {
+		case "new", "cancel", "start":
+			b.clearPendingMessages(cs)
+			b.handleTextCommand(ctx, cs, sourceID, cmd)
+			return
+		}
+	}
+
+	b.enqueueIncomingMessage(ctx, cs, sourceID, text)
+}
+
+func (b *Bot) handleTextCommand(ctx context.Context, cs *chatState, sourceID, cmd string) {
+	switch cmd {
+	case "new":
+		b.resetChat(cs)
+		b.sendText(ctx, sourceID, "Session cleared. Send a message to start a new conversation.")
+	case "cancel":
+		sid, ownerUID := cs.ActiveSession()
+		if sid == "" {
+			b.sendText(ctx, sourceID, "No active session.")
+			return
+		}
+		if err := b.agentAPI.CancelSession(ctx, sid, ownerUID); err != nil {
+			b.sendText(ctx, sourceID, "Failed to cancel session: "+err.Error())
+			return
+		}
+		b.sendText(ctx, sourceID, "Session cancelled.")
+	case "start":
+		b.sendText(ctx, sourceID, "Welcome to Dagu AI Agent! Send any message to start chatting.\n\nCommands:\n/new - Start a new session\n/cancel - Cancel current session")
+	}
+}
+
+func (b *Bot) enqueueIncomingMessage(ctx context.Context, cs *chatState, sourceID, text string) {
+	if text == "" {
+		return
+	}
+
+	gen := cs.EnqueuePendingMessage(text)
+	delay := b.incomingDelay
+	if delay <= 0 {
+		delay = defaultIncomingBatchDelay
+	}
+	afterFunc := b.incomingAfterFunc
+	if afterFunc == nil {
+		afterFunc = func(delay time.Duration, f func()) { time.AfterFunc(delay, f) }
+	}
+	afterFunc(delay, func() {
+		b.flushIncomingMessages(ctx, cs, sourceID, gen)
+	})
+}
+
+func (b *Bot) flushIncomingMessages(ctx context.Context, cs *chatState, sourceID string, gen uint64) {
+	text, ok := cs.TakePendingMessages(gen, "\n\n")
+	if !ok {
+		return
+	}
+
+	user := b.userIdentity(sourceID)
+	if cs.SessionID() == "" {
+		b.createSession(ctx, cs, sourceID, user, text)
+		return
+	}
+
+	b.sendMessage(ctx, cs, sourceID, user, text)
+}
+
+func (b *Bot) createSession(ctx context.Context, cs *chatState, sourceID string, user agent.UserIdentity, text string) {
+	req := agent.ChatRequest{
+		Message:  text,
+		SafeMode: b.cfg.SafeMode,
+	}
+
+	sessionID, _, err := b.agentAPI.CreateSession(ctx, user, req)
+	if err != nil {
+		b.logger.Error("Failed to create LINE session", slog.String("error", err.Error()))
+		b.sendText(ctx, sourceID, "Failed to start session: "+err.Error())
+		return
+	}
+
+	b.setActiveSession(cs, sessionID, user.UserID)
+	b.startSubscription(ctx, cs, sourceID, user.UserID, sessionID)
+}
+
+func (b *Bot) sendMessage(ctx context.Context, cs *chatState, sourceID string, user agent.UserIdentity, text string) {
+	req := agent.ChatRequest{
+		Message:  text,
+		SafeMode: b.cfg.SafeMode,
+	}
+
+	result, err := chatbridge.EnqueueMessage(ctx, b.agentAPI, &cs.State, user, req)
+	if err != nil {
+		b.logger.Error("Failed to enqueue LINE message", slog.String("error", err.Error()))
+		b.sendText(ctx, sourceID, "Failed to send message: "+err.Error())
+		return
+	}
+	if result.Missing {
+		b.logger.Warn("Session missing during LINE send, recreating chat",
+			slog.String("session", result.SessionID),
+			slog.String("user", user.UserID),
+		)
+		b.resetChat(cs)
+		b.createSession(ctx, cs, sourceID, user, text)
+		return
+	}
+	sid := result.SessionID
+	if sid == "" {
+		sid = cs.SessionID()
+	}
+	if sid != "" {
+		b.ensureSubscription(ctx, cs, sourceID, user.UserID, sid)
+	}
+}
+
+func (b *Bot) submitPromptResponse(ctx context.Context, cs *chatState, sourceID, promptID, text string) {
+	sid, ownerUserID := cs.ActiveSession()
+	resp, ok := cs.responseForPrompt(promptID, text)
+	cs.ClearPendingPrompt()
+	if !ok {
+		b.sendText(ctx, sourceID, "Please choose one of the listed options.")
+		return
+	}
+	if sid == "" {
+		return
+	}
+
+	if err := b.agentAPI.SubmitUserResponse(ctx, sid, ownerUserID, resp); err != nil {
+		b.sendText(ctx, sourceID, "Failed to submit response: "+err.Error())
+	}
+}
+
+func (b *Bot) ensureSubscription(ctx context.Context, cs *chatState, sourceID, userID, sessionID string) {
+	subCtx, cancel := context.WithCancel(ctx)
+	cleanup, started := cs.PrepareSubscription(sessionID, cancel, false)
+	if !started {
+		if cleanup != nil {
+			cleanup()
+		}
+		return
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+
+	go b.subscribeLoop(subCtx, cs, sourceID, userID, sessionID)
+}
+
+func (b *Bot) startSubscription(ctx context.Context, cs *chatState, sourceID, userID, sessionID string) {
+	subCtx, cancel := context.WithCancel(ctx)
+	cleanup, _ := cs.PrepareSubscription(sessionID, cancel, true)
+	if cleanup != nil {
+		cleanup()
+	}
+
+	go b.subscribeLoop(subCtx, cs, sourceID, userID, sessionID)
+}
+
+func (b *Bot) subscribeLoop(ctx context.Context, cs *chatState, sourceID, userID, sessionID string) {
+	user := agent.UserIdentity{
+		UserID:   userID,
+		Username: "line",
+		Role:     auth.RoleAdmin,
+	}
+
+	snapshot, next, err := b.agentAPI.SubscribeSession(ctx, sessionID, user)
+	if err != nil {
+		b.logger.Warn("Failed to subscribe to LINE session",
+			slog.String("session", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	b.processStreamResponse(ctx, cs, sourceID, snapshot)
+	for {
+		resp, ok := next()
+		if !ok {
+			cs.ClearSessionIfActive(sessionID)
+			return
+		}
+		b.processStreamResponse(ctx, cs, sourceID, resp)
+	}
+}
+
+func (b *Bot) processStreamResponse(ctx context.Context, cs *chatState, sourceID string, resp agent.StreamResponse) {
+	var shouldFlushQueued bool
+	chatbridge.ProcessStreamResponse(&cs.State, resp, chatbridge.StreamHandlers{
+		OnSessionState: func(state agent.SessionState) {
+			if !state.Working && state.HasQueuedUserInput {
+				shouldFlushQueued = true
+			}
+		},
+		OnAssistant: func(msg agent.Message) {
+			b.sendLongText(ctx, sourceID, msg.Content)
+		},
+		OnError: func(msg agent.Message) {
+			b.sendText(ctx, sourceID, "Error: "+msg.Content)
+		},
+		OnPrompt: func(prompt *agent.UserPrompt) {
+			b.sendPrompt(ctx, cs, sourceID, prompt)
+		},
+	})
+	if shouldFlushQueued {
+		_, ownerUserID := cs.ActiveSession()
+		if ownerUserID == "" {
+			return
+		}
+		user := agent.UserIdentity{
+			UserID:   ownerUserID,
+			Username: "line",
+			Role:     auth.RoleAdmin,
+		}
+		result, err := chatbridge.FlushQueuedMessage(ctx, b.agentAPI, &cs.State, user)
+		if err != nil {
+			b.logger.Warn("Failed to flush queued LINE message",
+				slog.String("session", result.SessionID),
+				slog.String("user", user.UserID),
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+		if result.Missing {
+			b.logger.Warn("Session missing during queued LINE flush",
+				slog.String("session", result.SessionID),
+				slog.String("user", user.UserID),
+			)
+			b.resetChat(cs)
+			return
+		}
+		if result.SessionID != "" {
+			b.ensureSubscription(ctx, cs, sourceID, user.UserID, result.SessionID)
+		}
+	}
+}
+
+func (b *Bot) sendPrompt(ctx context.Context, cs *chatState, sourceID string, prompt *agent.UserPrompt) {
+	cs.setPrompt(prompt)
+	text := prompt.Question
+	if prompt.Command != "" {
+		text += "\n\nCommand: " + prompt.Command
+	}
+	if len(prompt.Options) > 0 {
+		lines := make([]string, 0, len(prompt.Options)+1)
+		lines = append(lines, "Options:")
+		for _, opt := range prompt.Options {
+			label := opt.Label
+			if opt.Description != "" {
+				label += " - " + opt.Description
+			}
+			lines = append(lines, fmt.Sprintf("- %s: %s", opt.ID, label))
+		}
+		text += "\n\n" + strings.Join(lines, "\n")
+	}
+	if prompt.AllowFreeText {
+		text += "\n\nYou can also reply with text."
+	}
+	b.sendLongText(ctx, sourceID, text)
+}
+
+func (b *Bot) sendLongText(ctx context.Context, sourceID, text string) {
+	chunks := splitMessage(text, maxLineTextLen)
+	for _, chunk := range chunks {
+		b.sendText(ctx, sourceID, chunk)
+	}
+}
+
+func (b *Bot) sendText(ctx context.Context, sourceID, text string) {
+	if err := b.client.PushText(ctx, sourceID, text); err != nil {
+		b.logger.Warn("Failed to send LINE message",
+			slog.String("source_id", sourceID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func (b *Bot) replyText(ctx context.Context, replyToken, text string) {
+	if err := b.client.ReplyText(ctx, replyToken, text); err != nil {
+		b.logger.Warn("Failed to reply to LINE webhook",
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func (b *Bot) isSourceAllowed(sourceID string) bool {
+	_, ok := b.allowedSources[sourceID]
+	return ok
+}
+
+func (b *Bot) getOrCreateChat(sourceID string) *chatState {
+	val, _ := b.chats.LoadOrStore(sourceID, &chatState{})
+	return val.(*chatState)
+}
+
+func (b *Bot) getOrCreateNotificationChat(sourceID string) *chatState {
+	return b.getOrCreateChat(sourceID)
+}
+
+func (b *Bot) resetChat(cs *chatState) {
+	if cancel := cs.Reset(); cancel != nil {
+		cancel()
+	}
+	cs.clearPrompt()
+}
+
+func (b *Bot) userIdentity(sourceID string) agent.UserIdentity {
+	return agent.UserIdentity{
+		UserID:   "line:" + sourceID,
+		Username: "line",
+		Role:     auth.RoleAdmin,
+	}
+}
+
+func (b *Bot) setActiveSession(cs *chatState, sessionID, ownerUserID string) {
+	cs.SetActiveSession(sessionID, ownerUserID)
+}
+
+func (b *Bot) markDelivered(cs *chatState, seq int64) {
+	cs.MarkDelivered(seq)
+}
+
+func (b *Bot) clearPendingMessages(cs *chatState) {
+	cs.ClearPendingMessages()
+}
+
+func (b *Bot) subscriptionActive(cs *chatState, sessionID string) bool {
+	return cs.SubscriptionActive(sessionID)
+}
+
+func (b *Bot) claimWebhookEvent(event webhookEvent) bool {
+	eventID := event.WebhookEventID
+	if eventID == "" {
+		return true
+	}
+
+	now := time.Now()
+	b.processedEventMu.Lock()
+	defer b.processedEventMu.Unlock()
+
+	if b.processedEvents == nil {
+		b.processedEvents = make(map[string]time.Time)
+	}
+	if _, ok := b.processedEvents[eventID]; ok {
+		return false
+	}
+	b.processedEvents[eventID] = now
+	if len(b.processedEvents) > maxProcessedWebhookEvents {
+		b.pruneProcessedWebhookEventsLocked(now)
+	}
+	return true
+}
+
+func (b *Bot) pruneProcessedWebhookEventsLocked(now time.Time) {
+	cutoff := now.Add(-processedWebhookEventTTL)
+	for eventID, processedAt := range b.processedEvents {
+		if processedAt.Before(cutoff) {
+			delete(b.processedEvents, eventID)
+		}
+	}
+	for eventID := range b.processedEvents {
+		if len(b.processedEvents) <= maxProcessedWebhookEvents {
+			return
+		}
+		delete(b.processedEvents, eventID)
+	}
+}
+
+func (cs *chatState) setPrompt(prompt *agent.UserPrompt) {
+	cs.SetPendingPrompt(prompt.PromptID)
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+	cs.pendingPromptFreeText = prompt.AllowFreeText
+	cs.pendingPromptOptions = make(map[string]string, len(prompt.Options)*2)
+	for _, opt := range prompt.Options {
+		cs.pendingPromptOptions[strings.ToLower(strings.TrimSpace(opt.ID))] = opt.ID
+		cs.pendingPromptOptions[strings.ToLower(strings.TrimSpace(opt.Label))] = opt.ID
+	}
+}
+
+func (cs *chatState) responseForPrompt(promptID, text string) (agent.UserPromptResponse, bool) {
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if optionID, ok := cs.pendingPromptOptions[normalized]; ok {
+		return agent.UserPromptResponse{
+			PromptID:          promptID,
+			SelectedOptionIDs: []string{optionID},
+		}, true
+	}
+	if cs.pendingPromptFreeText || len(cs.pendingPromptOptions) == 0 {
+		return agent.UserPromptResponse{
+			PromptID:         promptID,
+			FreeTextResponse: text,
+		}, true
+	}
+	return agent.UserPromptResponse{}, false
+}
+
+func (cs *chatState) clearPrompt() {
+	cs.promptMu.Lock()
+	defer cs.promptMu.Unlock()
+	cs.pendingPromptOptions = nil
+	cs.pendingPromptFreeText = false
+}
+
+func splitMessage(text string, maxLen int) []string {
+	if maxLen <= 0 || len(text) <= maxLen {
+		return []string{text}
+	}
+
+	runes := []rune(text)
+	var chunks []string
+	for len(runes) > 0 {
+		if len(string(runes)) <= maxLen {
+			chunks = append(chunks, string(runes))
+			break
+		}
+
+		cut := maxRunesWithinBytes(runes, maxLen)
+		if cut == 0 {
+			cut = 1
+		}
+		if idx := lastRuneSequenceIndex(runes[:cut], '\n', '\n'); idx > cut/2 {
+			cut = idx + 2
+		} else if idx := lastRuneSequenceIndex(runes[:cut], '\n'); idx > cut/2 {
+			cut = idx + 1
+		}
+
+		chunks = append(chunks, string(runes[:cut]))
+		runes = runes[cut:]
+	}
+
+	return chunks
+}
+
+func maxRunesWithinBytes(runes []rune, maxLen int) int {
+	var size int
+	for i, r := range runes {
+		next := utf8.RuneLen(r)
+		if next < 0 {
+			next = len(string(r))
+		}
+		if size+next > maxLen {
+			return i
+		}
+		size += next
+	}
+	return len(runes)
+}
+
+func lastRuneSequenceIndex(runes []rune, seq ...rune) int {
+	if len(seq) == 0 || len(seq) > len(runes) {
+		return -1
+	}
+	for i := len(runes) - len(seq); i >= 0; i-- {
+		match := true
+		for j, r := range seq {
+			if runes[i+j] != r {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+type webhookRequest struct {
+	Destination string         `json:"destination"`
+	Events      []webhookEvent `json:"events"`
+}
+
+type webhookEvent struct {
+	Type            string          `json:"type"`
+	ReplyToken      string          `json:"replyToken"`
+	WebhookEventID  string          `json:"webhookEventId"`
+	DeliveryContext deliveryContext `json:"deliveryContext"`
+	Source          eventSource     `json:"source"`
+	Message         eventMessage    `json:"message"`
+}
+
+type deliveryContext struct {
+	IsRedelivery bool `json:"isRedelivery"`
+}
+
+type eventSource struct {
+	Type    string `json:"type"`
+	UserID  string `json:"userId"`
+	GroupID string `json:"groupId"`
+	RoomID  string `json:"roomId"`
+}
+
+func (s eventSource) ID() string {
+	switch s.Type {
+	case "user":
+		return s.UserID
+	case "group":
+		return s.GroupID
+	case "room":
+		return s.RoomID
+	default:
+		return ""
+	}
+}
+
+type eventMessage struct {
+	Type    string       `json:"type"`
+	ID      string       `json:"id"`
+	Text    string       `json:"text"`
+	Mention *lineMention `json:"mention"`
+}
+
+func (m eventMessage) SelfMentioned() bool {
+	if m.Mention == nil {
+		return false
+	}
+	for _, mentionee := range m.Mention.Mentionees {
+		if mentionee.IsSelf {
+			return true
+		}
+	}
+	return false
+}
+
+type lineMention struct {
+	Mentionees []lineMentionee `json:"mentionees"`
+}
+
+type lineMentionee struct {
+	Index  int  `json:"index"`
+	Length int  `json:"length"`
+	IsSelf bool `json:"isSelf"`
+}
+
+func stripSelfMention(text string, mention *lineMention) string {
+	if mention == nil {
+		return strings.TrimSpace(text)
+	}
+	for _, mentionee := range mention.Mentionees {
+		if !mentionee.IsSelf || mentionee.Index != 0 || mentionee.Length <= 0 {
+			continue
+		}
+		runes := []rune(text)
+		if mentionee.Length >= len(runes) {
+			return ""
+		}
+		return strings.TrimSpace(string(runes[mentionee.Length:]))
+	}
+	return strings.TrimSpace(text)
+}

--- a/internal/service/line/bot_test.go
+++ b/internal/service/line/bot_test.go
@@ -1,0 +1,311 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package line
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifySignatureUsesExactRawBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"destination":"U8e742f61d673b39c7fff3cecb7536ef0","events":[]}`)
+	signature := testLineSignature("line-channel-secret", body)
+
+	assert.True(t, verifySignature("line-channel-secret", body, signature))
+	assert.False(t, verifySignature("line-channel-secret", []byte("{\n  \"destination\": \"U8e742f61d673b39c7fff3cecb7536ef0\",\n  \"events\": []\n}"), signature))
+}
+
+func TestServeHTTPRejectsInvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	service := newFakeLineAgentService()
+	bot := newTestLineBot(service, &fakeLineClient{}, []string{"Uallowed"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bots/line/webhook", strings.NewReader(`{"destination":"Ubot","events":[]}`))
+	req.Header.Set("x-line-signature", "invalid")
+	rec := httptest.NewRecorder()
+
+	bot.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Empty(t, service.createMessages)
+}
+
+func TestServeHTTPHandlesConsoleVerificationWithoutEvents(t *testing.T) {
+	t.Parallel()
+
+	service := newFakeLineAgentService()
+	client := &fakeLineClient{}
+	bot := newTestLineBot(service, client, []string{"Uallowed"})
+	body := `{"destination":"Ubot","events":[]}`
+
+	rec := performSignedLineWebhook(t, bot, body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, service.createMessages)
+	assert.Empty(t, client.pushes)
+	assert.Empty(t, client.replies)
+}
+
+func TestServeHTTPForwardsAllowedTextMessageToAgent(t *testing.T) {
+	t.Parallel()
+
+	service := newFakeLineAgentService()
+	service.assistantContent = "assistant response"
+	client := &fakeLineClient{}
+	bot := newTestLineBot(service, client, []string{"Uallowed"})
+	body := `{
+  "destination": "Ubot",
+  "events": [{
+    "type": "message",
+    "replyToken": "reply-token",
+    "source": {"type": "user", "userId": "Uallowed"},
+    "message": {"type": "text", "id": "msg-1", "text": "hello"}
+  }]
+}`
+
+	rec := performSignedLineWebhook(t, bot, body)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		service.mu.Lock()
+		defer service.mu.Unlock()
+		assert.Equal(c, []string{"hello"}, service.createMessages)
+		require.Len(c, service.createUsers, 1)
+		assert.Equal(c, "line:Uallowed", service.createUsers[0].UserID)
+	}, time.Second, 10*time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		require.Len(c, client.pushes, 1)
+		assert.Equal(c, lineText{to: "Uallowed", text: "assistant response"}, client.pushes[0])
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestServeHTTPSkipsDuplicateWebhookEventID(t *testing.T) {
+	t.Parallel()
+
+	service := newFakeLineAgentService()
+	client := &fakeLineClient{}
+	bot := newTestLineBot(service, client, []string{"Uallowed"})
+	body := `{
+  "destination": "Ubot",
+  "events": [{
+    "type": "message",
+    "replyToken": "reply-token",
+    "webhookEventId": "01JLINEEVENT000000000000000",
+    "deliveryContext": {"isRedelivery": false},
+    "source": {"type": "user", "userId": "Uallowed"},
+    "message": {"type": "text", "id": "msg-1", "text": "hello"}
+  }]
+}`
+
+	rec := performSignedLineWebhook(t, bot, body)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rec = performSignedLineWebhook(t, bot, body)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		service.mu.Lock()
+		defer service.mu.Unlock()
+		assert.Equal(c, []string{"hello"}, service.createMessages)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestSplitMessagePreservesUTF8(t *testing.T) {
+	t.Parallel()
+
+	text := strings.Repeat("日", 5) + strings.Repeat("🙂", 5) + "tail"
+	chunks := splitMessage(text, 10)
+
+	require.Greater(t, len(chunks), 1)
+	assert.Equal(t, text, strings.Join(chunks, ""))
+	for _, chunk := range chunks {
+		assert.True(t, utf8.ValidString(chunk))
+		assert.LessOrEqual(t, len(chunk), 10)
+	}
+}
+
+func TestSplitMessagePrefersParagraphBoundary(t *testing.T) {
+	t.Parallel()
+
+	chunks := splitMessage("aaaaaaaa\n\nbbbbbbbb", 12)
+
+	require.Len(t, chunks, 2)
+	assert.Equal(t, "aaaaaaaa\n\n", chunks[0])
+	assert.Equal(t, "bbbbbbbb", chunks[1])
+}
+
+func newTestLineBot(service *fakeLineAgentService, client *fakeLineClient, allowed []string) *Bot {
+	allowedSources := make(map[string]struct{}, len(allowed))
+	for _, id := range allowed {
+		allowedSources[id] = struct{}{}
+	}
+	return &Bot{
+		cfg: Config{
+			ChannelAccessToken: "line-channel-token",
+			ChannelSecret:      "line-channel-secret",
+			SafeMode:           true,
+			RespondToAll:       true,
+		},
+		agentAPI:          service,
+		client:            client,
+		allowedSources:    allowedSources,
+		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		incomingDelay:     time.Millisecond,
+		incomingAfterFunc: func(_ time.Duration, f func()) { f() },
+	}
+}
+
+func performSignedLineWebhook(t *testing.T, bot *Bot, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bots/line/webhook", strings.NewReader(body))
+	req.Header.Set("x-line-signature", testLineSignature("line-channel-secret", []byte(body)))
+	rec := httptest.NewRecorder()
+	bot.ServeHTTP(rec, req)
+	return rec
+}
+
+func testLineSignature(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+type lineText struct {
+	to   string
+	text string
+}
+
+type fakeLineClient struct {
+	mu      sync.Mutex
+	pushes  []lineText
+	replies []lineText
+}
+
+func (c *fakeLineClient) PushText(_ context.Context, to, text string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pushes = append(c.pushes, lineText{to: to, text: text})
+	return nil
+}
+
+func (c *fakeLineClient) ReplyText(_ context.Context, replyToken, text string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.replies = append(c.replies, lineText{to: replyToken, text: text})
+	return nil
+}
+
+type fakeLineAgentService struct {
+	mu               sync.Mutex
+	nextSessionID    int
+	createMessages   []string
+	createUsers      []agent.UserIdentity
+	sendMessages     []string
+	cancelErr        error
+	submitResponses  []agent.UserPromptResponse
+	assistantContent string
+}
+
+func newFakeLineAgentService() *fakeLineAgentService {
+	return &fakeLineAgentService{}
+}
+
+func (s *fakeLineAgentService) CreateSession(_ context.Context, user agent.UserIdentity, req agent.ChatRequest) (string, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSessionID++
+	s.createMessages = append(s.createMessages, req.Message)
+	s.createUsers = append(s.createUsers, user)
+	return fmt.Sprintf("session-%d", s.nextSessionID), "", nil
+}
+
+func (s *fakeLineAgentService) CreateEmptySession(context.Context, agent.UserIdentity, string, bool) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSessionID++
+	return fmt.Sprintf("session-%d", s.nextSessionID), nil
+}
+
+func (s *fakeLineAgentService) SendMessage(_ context.Context, _ string, _ agent.UserIdentity, req agent.ChatRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendMessages = append(s.sendMessages, req.Message)
+	return nil
+}
+
+func (s *fakeLineAgentService) EnqueueChatMessage(_ context.Context, sessionID string, _ agent.UserIdentity, req agent.ChatRequest) (agent.ChatQueueResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendMessages = append(s.sendMessages, req.Message)
+	return agent.ChatQueueResult{SessionID: sessionID, Started: true}, nil
+}
+
+func (s *fakeLineAgentService) FlushQueuedChatMessage(_ context.Context, sessionID string, _ agent.UserIdentity) (agent.ChatQueueResult, error) {
+	return agent.ChatQueueResult{SessionID: sessionID, Started: true}, nil
+}
+
+func (s *fakeLineAgentService) CancelSession(context.Context, string, string) error {
+	return s.cancelErr
+}
+
+func (s *fakeLineAgentService) SubmitUserResponse(_ context.Context, _ string, _ string, resp agent.UserPromptResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.submitResponses = append(s.submitResponses, resp)
+	return nil
+}
+
+func (s *fakeLineAgentService) GenerateAssistantMessage(context.Context, string, agent.UserIdentity, string, string) (agent.Message, error) {
+	return agent.Message{Type: agent.MessageTypeAssistant, Content: s.assistantContent}, nil
+}
+
+func (s *fakeLineAgentService) AppendExternalMessage(_ context.Context, sessionID string, _ agent.UserIdentity, msg agent.Message) (agent.Message, error) {
+	msg.SessionID = sessionID
+	msg.SequenceID = 1
+	return msg, nil
+}
+
+func (s *fakeLineAgentService) CompactSessionIfNeeded(_ context.Context, sessionID string, _ agent.UserIdentity) (string, bool, error) {
+	return sessionID, false, nil
+}
+
+func (s *fakeLineAgentService) GetSessionDetail(context.Context, string, string) (*agent.StreamResponse, error) {
+	return &agent.StreamResponse{}, nil
+}
+
+func (s *fakeLineAgentService) SubscribeSession(context.Context, string, agent.UserIdentity) (agent.StreamResponse, func() (agent.StreamResponse, bool), error) {
+	s.mu.Lock()
+	content := s.assistantContent
+	s.mu.Unlock()
+	snapshot := agent.StreamResponse{}
+	if content != "" {
+		snapshot.Messages = []agent.Message{{
+			Type:       agent.MessageTypeAssistant,
+			SequenceID: 1,
+			Content:    content,
+			CreatedAt:  time.Now(),
+		}}
+	}
+	return snapshot, func() (agent.StreamResponse, bool) { return agent.StreamResponse{}, false }, nil
+}

--- a/internal/service/line/client.go
+++ b/internal/service/line/client.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package line
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultLineAPIBaseURL = "https://api.line.me"
+
+type lineClientAPI interface {
+	PushText(ctx context.Context, to, text string) error
+	ReplyText(ctx context.Context, replyToken, text string) error
+}
+
+type httpLineClient struct {
+	channelAccessToken string
+	httpClient         *http.Client
+	baseURL            string
+}
+
+func newHTTPLineClient(channelAccessToken string) *httpLineClient {
+	return &httpLineClient{
+		channelAccessToken: channelAccessToken,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		baseURL: defaultLineAPIBaseURL,
+	}
+}
+
+func (c *httpLineClient) PushText(ctx context.Context, to, text string) error {
+	body := linePushRequest{
+		To: to,
+		Messages: []lineOutboundMessage{{
+			Type: "text",
+			Text: text,
+		}},
+	}
+	return c.postJSON(ctx, "/v2/bot/message/push", body)
+}
+
+func (c *httpLineClient) ReplyText(ctx context.Context, replyToken, text string) error {
+	body := lineReplyRequest{
+		ReplyToken: replyToken,
+		Messages: []lineOutboundMessage{{
+			Type: "text",
+			Text: text,
+		}},
+	}
+	return c.postJSON(ctx, "/v2/bot/message/reply", body)
+}
+
+func (c *httpLineClient) postJSON(ctx context.Context, endpoint string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal LINE request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(c.baseURL, "/")+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create LINE request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.channelAccessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send LINE request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if len(respBody) == 0 {
+		return fmt.Errorf("LINE API returned status %d", resp.StatusCode)
+	}
+	return fmt.Errorf("LINE API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+}
+
+type linePushRequest struct {
+	To       string                `json:"to"`
+	Messages []lineOutboundMessage `json:"messages"`
+}
+
+type lineReplyRequest struct {
+	ReplyToken string                `json:"replyToken"`
+	Messages   []lineOutboundMessage `json:"messages"`
+}
+
+type lineOutboundMessage struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}

--- a/internal/service/line/monitor.go
+++ b/internal/service/line/monitor.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package line
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+)
+
+// DAGRunMonitor watches for DAG run completions and sends notifications via LINE.
+type DAGRunMonitor struct {
+	core     *chatbridge.NotificationMonitor
+	agentAPI AgentService
+	bot      *Bot
+	logger   *slog.Logger
+}
+
+// NewDAGRunMonitor creates a new monitor instance.
+func NewDAGRunMonitor(eventService *eventstore.Service, stateFile string, agentAPI AgentService, bot *Bot, logger *slog.Logger) *DAGRunMonitor {
+	return newDAGRunMonitorWithWindows(
+		eventService,
+		stateFile,
+		agentAPI,
+		bot,
+		logger,
+		chatbridge.DefaultUrgentNotificationWindow,
+		chatbridge.DefaultSuccessNotificationWindow,
+	)
+}
+
+func newDAGRunMonitorWithWindows(
+	eventService *eventstore.Service,
+	stateFile string,
+	agentAPI AgentService,
+	bot *Bot,
+	logger *slog.Logger,
+	urgentWindow, successWindow time.Duration,
+) *DAGRunMonitor {
+	monitor := &DAGRunMonitor{
+		agentAPI: agentAPI,
+		bot:      bot,
+		logger:   logger,
+	}
+	cfg := chatbridge.DefaultNotificationMonitorConfig()
+	cfg.UrgentWindow = urgentWindow
+	cfg.SuccessWindow = successWindow
+	cfg.InterestedEventTypes = lineInterestedEventTypes(bot.cfg.InterestedEventTypes)
+	monitor.core = chatbridge.NewNotificationMonitor(eventService, stateFile, monitor, logger, cfg)
+	return monitor
+}
+
+func lineInterestedEventTypes(values []string) []eventstore.EventType {
+	if values == nil {
+		return nil
+	}
+	result := make([]eventstore.EventType, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		result = append(result, eventstore.EventType(value))
+	}
+	return result
+}
+
+// Run starts the monitor loop.
+func (m *DAGRunMonitor) Run(ctx context.Context) {
+	m.core.Run(ctx)
+}
+
+// NotificationDestinations returns the configured LINE source IDs.
+func (m *DAGRunMonitor) NotificationDestinations() []string {
+	destinations := make([]string, 0, len(m.bot.allowedSources))
+	for sourceID := range m.bot.allowedSources {
+		destinations = append(destinations, sourceID)
+	}
+	return destinations
+}
+
+// FlushNotificationBatch delivers a single notification batch to LINE.
+func (m *DAGRunMonitor) FlushNotificationBatch(ctx context.Context, sourceID string, batch chatbridge.NotificationBatch, allowLLM bool) bool {
+	return m.flushSource(ctx, sourceID, batch, allowLLM)
+}
+
+func (m *DAGRunMonitor) flushSource(ctx context.Context, sourceID string, batch chatbridge.NotificationBatch, allowLLM bool) bool {
+	user := m.bot.userIdentity(sourceID)
+	cs := m.bot.getOrCreateNotificationChat(sourceID)
+	sessionID := m.currentSessionID(cs)
+	msg := m.buildNotificationMessage(ctx, sessionID, user, batch, allowLLM)
+	sessionID, stored, ok := m.appendNotification(ctx, cs, sessionID, user, chatbridge.NotificationBatchDAGName(batch), msg)
+	if !ok {
+		return false
+	}
+	if m.bot.subscriptionActive(cs, sessionID) {
+		return true
+	}
+
+	m.bot.sendLongText(ctx, sourceID, msg.Content)
+	m.bot.markDelivered(cs, stored.SequenceID)
+	return true
+}
+
+func (m *DAGRunMonitor) currentSessionID(cs *chatState) string {
+	return cs.SessionID()
+}
+
+func (m *DAGRunMonitor) appendNotification(ctx context.Context, cs *chatState, sessionID string, user agent.UserIdentity, dagName string, msg agent.Message) (string, agent.Message, bool) {
+	newSessionID, stored, err := chatbridge.AppendNotification(ctx, m.agentAPI, &cs.State, user, dagName, m.bot.cfg.SafeMode, msg)
+	if err != nil {
+		m.logger.Warn("Failed to append notification message",
+			slog.String("session", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return "", agent.Message{}, false
+	}
+	return newSessionID, stored, true
+}
+
+func (m *DAGRunMonitor) buildNotificationMessage(ctx context.Context, sessionID string, user agent.UserIdentity, batch chatbridge.NotificationBatch, allowLLM bool) agent.Message {
+	service := m.agentAPI
+	if !allowLLM {
+		service = nil
+	}
+
+	msg, err := chatbridge.GenerateNotificationMessage(ctx, service, sessionID, user, batch)
+	if err != nil && len(batch.Events) > 0 && batch.Events[0].Status != nil {
+		m.logger.Warn("Failed to generate AI notification, using deterministic fallback",
+			slog.String("dag", batch.Events[0].Status.Name),
+			slog.String("status", batch.Events[0].Status.Status.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+	return msg
+}


### PR DESCRIPTION
## Summary

Add LINE Messaging API support to Workflow Operator so Dagu can bridge authorized LINE chats into the built-in agent and send DAG-run notifications back to LINE sources.

## Changes

- Add the `line` bot provider configuration, environment bindings, schema validation, and loader tests.
- Register the LINE webhook route from the frontend server and start the LINE bot from `dagu server` and `dagu start-all`.
- Add a LINE Messaging API client, signed webhook handling, allowed source filtering, prompt responses, duplicate webhook event suppression, UTF-8 safe long-message splitting, and DAG-run notification delivery.
- Preserve existing Discord, Slack, and Telegram behavior with focused regression coverage.

## Related Issues

No linked issue.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- go test ./internal/service/discord ./internal/service/slack ./internal/service/telegram ./internal/service/chatbridge ./internal/service/line ./internal/cmn/config ./internal/cmn/schema ./internal/service/frontend ./internal/cmd -count=1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LINE bot integration enabling two-way messaging through webhooks
  * Integrated LINE notifications for DAG run completions and status events
  * Added extensible route registration system for bot providers

* **Documentation**
  * Extended configuration schema to support LINE bot with channel access tokens, secrets, allowed source IDs, and event filtering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->