### PR TITLE
refactor: extract DAG-run intake module

### DIFF
--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -4,17 +4,14 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 	"github.com/spf13/cobra"
 )
 
@@ -96,68 +93,29 @@ func enqueueDAGRun(ctx *Context, dag *core.DAG, dagRunID string, triggerType cor
 		return fmt.Errorf("queues are disabled in configuration")
 	}
 
-	logFile, err := ctx.GenLogFileName(dag, dagRunID)
-	if err != nil {
-		return fmt.Errorf("failed to generate log file name: %w", err)
-	}
-
 	dagRun := exec.NewDAGRunRef(dag.Name, dagRunID)
 
-	if _, err = ctx.DAGRunStore.FindAttempt(ctx, dagRun); err == nil {
+	if _, err := ctx.DAGRunStore.FindAttempt(ctx, dagRun); err == nil {
 		return fmt.Errorf("DAG %q with ID %q already exists", dag.Name, dagRunID)
 	}
-	artifactDir, err := ctx.GenArtifactDir(dag, dagRunID)
+
+	queued, err := intake.EnqueueRun(ctx.Context, intake.QueueRequest{
+		DAGRunStore:             ctx.DAGRunStore,
+		QueueStore:              ctx.QueueStore,
+		DAG:                     dag,
+		DAGRunID:                dagRunID,
+		LogBaseDir:              ctx.Config.Paths.LogDir,
+		ArtifactBaseDir:         ctx.Config.Paths.ArtifactDir,
+		TriggerType:             triggerType,
+		ScheduleTime:            scheduleTime,
+		ProceedOnStatusCloseErr: true,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to generate artifact directory: %w", err)
+		return err
 	}
-
-	att, err := ctx.DAGRunStore.CreateAttempt(ctx.Context, dag, time.Now(), dagRunID, exec.NewDAGRunAttemptOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create run: %w", err)
-	}
-
-	opts := []transform.StatusOption{
-		transform.WithLogFilePath(logFile),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithAttemptID(att.ID()),
-		transform.WithPreconditions(dag.Preconditions),
-		transform.WithQueuedAt(stringutil.FormatTime(time.Now())),
-		transform.WithHierarchyRefs(
-			exec.NewDAGRunRef(dag.Name, dagRunID),
-			exec.DAGRunRef{},
-		),
-		transform.WithTriggerType(triggerType),
-	}
-
-	if scheduleTime != "" {
-		opts = append(opts, transform.WithScheduleTime(scheduleTime))
-	}
-
-	dagStatus := transform.NewStatusBuilder(dag).Create(dagRunID, core.Queued, 0, time.Time{}, opts...)
-
-	if err := att.Open(ctx.Context); err != nil {
-		return fmt.Errorf("failed to open run: %w", err)
-	}
-
-	if err := att.Write(ctx.Context, dagStatus); err != nil {
-		_ = att.Close(ctx.Context)
-		return fmt.Errorf("failed to save status: %w", err)
-	}
-
-	closeErr := att.Close(ctx.Context)
-	if closeErr != nil {
+	if queued.StatusCloseErr != nil {
 		logger.Warn(ctx.Context, "Failed to close queued status before enqueue",
-			tag.Error(closeErr))
-	}
-
-	if err := ctx.QueueStore.Enqueue(ctx.Context, dag.ProcGroup(), exec.QueuePriorityLow, dagRun); err != nil {
-		if closeErr != nil {
-			return errors.Join(
-				fmt.Errorf("failed to close run: %w", closeErr),
-				fmt.Errorf("failed to enqueue dag-run: %w", err),
-			)
-		}
-		return fmt.Errorf("failed to enqueue dag-run: %w", err)
+			tag.Error(queued.StatusCloseErr))
 	}
 
 	logger.Info(ctx.Context, "Enqueued dag-run",

--- a/internal/cmd/local_execution.go
+++ b/internal/cmd/local_execution.go
@@ -5,150 +5,13 @@ package cmd
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 )
-
-var errLocalExecutionAlreadyExists = errors.New("local execution already exists")
-
-type localExecutionPreparation struct {
-	Attempt exec.DAGRunAttempt
-	Proc    exec.ProcHandle
-}
-
-func prepareLocalExecution(
-	ctx *Context,
-	dag *core.DAG,
-	dagRunID string,
-	root exec.DAGRunRef,
-	parent exec.DAGRunRef,
-	triggerType core.TriggerType,
-	scheduleTime string,
-	buildAttempt func(context.Context) (exec.DAGRunAttempt, error),
-) (*localExecutionPreparation, error) {
-	if dag == nil {
-		return nil, fmt.Errorf("dag is required")
-	}
-	if dagRunID == "" {
-		return nil, fmt.Errorf("dag-run ID is required")
-	}
-	if buildAttempt == nil {
-		return nil, fmt.Errorf("attempt builder is required")
-	}
-	if root.Zero() {
-		root = exec.NewDAGRunRef(dag.Name, dagRunID)
-	}
-
-	if err := ctx.ProcStore.Lock(ctx, dag.ProcGroup()); err != nil {
-		return nil, fmt.Errorf("failed to lock process group: %w", err)
-	}
-	defer ctx.ProcStore.Unlock(ctx, dag.ProcGroup())
-
-	attempt, err := buildAttempt(ctx.Context)
-	if err != nil {
-		if errors.Is(err, exec.ErrDAGRunAlreadyExists) {
-			return nil, fmt.Errorf("%w: dag-run ID %s already exists for DAG %s", errLocalExecutionAlreadyExists, dagRunID, dag.Name)
-		}
-		return nil, fmt.Errorf("failed to prepare execution attempt: %w", err)
-	}
-	if attempt == nil {
-		return nil, fmt.Errorf("attempt builder returned nil attempt")
-	}
-	attempt.SetDAG(dag)
-
-	proc, err := ctx.ProcStore.Acquire(ctx, dag.ProcGroup(), exec.ProcMeta{
-		StartedAt:    time.Now().Unix(),
-		Name:         dag.Name,
-		DAGRunID:     dagRunID,
-		AttemptID:    attempt.ID(),
-		RootName:     root.Name,
-		RootDAGRunID: root.ID,
-	})
-	if err != nil {
-		_ = recordPreparedAttemptFailure(ctx, attempt, dag, dagRunID, root, parent, triggerType, scheduleTime, err)
-		return nil, fmt.Errorf("%w: %w", errProcAcquisitionFailed, err)
-	}
-
-	return &localExecutionPreparation{
-		Attempt: attempt,
-		Proc:    proc,
-	}, nil
-}
-
-func recordPreparedAttemptFailure(
-	ctx *Context,
-	attempt exec.DAGRunAttempt,
-	dag *core.DAG,
-	dagRunID string,
-	root exec.DAGRunRef,
-	parent exec.DAGRunRef,
-	triggerType core.TriggerType,
-	scheduleTime string,
-	runErr error,
-) error {
-	if attempt == nil {
-		return fmt.Errorf("attempt is required")
-	}
-	if dag == nil {
-		return fmt.Errorf("dag is required")
-	}
-	if dagRunID == "" {
-		return fmt.Errorf("dag-run ID is required")
-	}
-	if root.Zero() {
-		root = exec.NewDAGRunRef(dag.Name, dagRunID)
-	}
-
-	logPath, logPathErr := ctx.GenLogFileName(dag, dagRunID)
-	if logPathErr != nil {
-		logger.Warn(ctx, "Failed to generate log file path for prepared local execution failure",
-			tag.Error(logPathErr),
-			tag.DAG(dag.Name),
-			tag.RunID(dagRunID),
-		)
-	}
-	artifactDir, artifactDirErr := ctx.GenArtifactDir(dag, dagRunID)
-	if artifactDirErr != nil {
-		logger.Warn(ctx, "Failed to generate artifact directory for prepared local execution failure",
-			tag.Error(artifactDirErr),
-			tag.DAG(dag.Name),
-			tag.RunID(dagRunID),
-		)
-	}
-	opts := []transform.StatusOption{
-		transform.WithAttemptID(attempt.ID()),
-		transform.WithHierarchyRefs(root, parent),
-		transform.WithLogFilePath(logPath),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithFinishedAt(time.Now()),
-		transform.WithError(runErr.Error()),
-		transform.WithWorkerID("local"),
-		transform.WithTriggerType(triggerType),
-	}
-	if scheduleTime != "" {
-		opts = append(opts, transform.WithScheduleTime(scheduleTime))
-	}
-	status := transform.NewStatusBuilder(dag).Create(dagRunID, core.Failed, 0, time.Now(), opts...)
-
-	if err := attempt.Open(ctx.Context); err != nil {
-		return fmt.Errorf("failed to open attempt for failure recording: %w", err)
-	}
-	defer func() {
-		_ = attempt.Close(ctx.Context)
-	}()
-
-	if err := attempt.Write(ctx.Context, status); err != nil {
-		return fmt.Errorf("failed to write failed status: %w", err)
-	}
-	return nil
-}
 
 func withPreparedLocalExecution(
 	ctx *Context,
@@ -161,16 +24,18 @@ func withPreparedLocalExecution(
 	buildAttempt func(context.Context) (exec.DAGRunAttempt, error),
 	run func(exec.DAGRunAttempt) error,
 ) error {
-	prepared, err := prepareLocalExecution(
-		ctx,
-		dag,
-		dagRunID,
-		root,
-		parent,
-		triggerType,
-		scheduleTime,
-		buildAttempt,
-	)
+	prepared, err := intake.PrepareLocalExecution(ctx.Context, intake.LocalRequest{
+		ProcStore:       ctx.ProcStore,
+		DAG:             dag,
+		DAGRunID:        dagRunID,
+		Root:            root,
+		Parent:          parent,
+		TriggerType:     triggerType,
+		ScheduleTime:    scheduleTime,
+		LogBaseDir:      ctx.Config.Paths.LogDir,
+		ArtifactBaseDir: ctx.Config.Paths.ArtifactDir,
+		BuildAttempt:    buildAttempt,
+	})
 	if err != nil {
 		logger.Debug(ctx, "Failed to prepare local execution", tag.Error(err))
 		return err

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -224,8 +224,6 @@ func runStart(ctx *Context, args []string) error {
 	return tryExecuteDAG(ctx, dag, dagRunID, root, workerID, attemptID, triggerType, scheduleTime)
 }
 
-var errProcAcquisitionFailed = errors.New("failed to acquire process handle")
-
 // tryExecuteDAG acquires a process handle and executes the DAG.
 func tryExecuteDAG(ctx *Context, dag *core.DAG, dagRunID string, root exec.DAGRunRef, workerID, attemptID string, triggerType core.TriggerType, scheduleTime string) error {
 	// Check for dispatch to coordinator for distributed execution.

--- a/internal/dagrun/intake/local.go
+++ b/internal/dagrun/intake/local.go
@@ -1,0 +1,173 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/logpath"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
+)
+
+var (
+	ErrLocalExecutionAlreadyExists = errors.New("local execution already exists")
+	ErrProcAcquisitionFailed       = errors.New("failed to acquire process handle")
+)
+
+// LocalAttemptBuilder creates or resolves the attempt that a local execution
+// will own.
+type LocalAttemptBuilder func(context.Context) (exec.DAGRunAttempt, error)
+
+// LocalRequest describes local DAG-run intake before execution starts.
+type LocalRequest struct {
+	ProcStore exec.ProcStore
+	DAG       *core.DAG
+	DAGRunID  string
+
+	Root        exec.DAGRunRef
+	Parent      exec.DAGRunRef
+	TriggerType core.TriggerType
+
+	ScheduleTime string
+
+	LogBaseDir      string
+	ArtifactBaseDir string
+
+	BuildAttempt LocalAttemptBuilder
+}
+
+// LocalPreparation is the successfully prepared local execution ownership.
+type LocalPreparation struct {
+	Attempt exec.DAGRunAttempt
+	Proc    exec.ProcHandle
+}
+
+// PrepareLocalExecution creates or resolves the execution attempt, acquires the
+// local process heartbeat, and records a failed status if heartbeat acquisition
+// fails after an attempt was prepared.
+func PrepareLocalExecution(ctx context.Context, req LocalRequest) (*LocalPreparation, error) {
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+	if req.Root.Zero() {
+		req.Root = exec.NewDAGRunRef(req.DAG.Name, req.DAGRunID)
+	}
+
+	if err := req.ProcStore.Lock(ctx, req.DAG.ProcGroup()); err != nil {
+		return nil, fmt.Errorf("failed to lock process group: %w", err)
+	}
+	defer req.ProcStore.Unlock(ctx, req.DAG.ProcGroup())
+
+	attempt, err := req.BuildAttempt(ctx)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunAlreadyExists) {
+			return nil, fmt.Errorf("%w: dag-run ID %s already exists for DAG %s", ErrLocalExecutionAlreadyExists, req.DAGRunID, req.DAG.Name)
+		}
+		return nil, fmt.Errorf("failed to prepare execution attempt: %w", err)
+	}
+	if attempt == nil {
+		return nil, fmt.Errorf("attempt builder returned nil attempt")
+	}
+	attempt.SetDAG(req.DAG)
+
+	proc, err := req.ProcStore.Acquire(ctx, req.DAG.ProcGroup(), exec.ProcMeta{
+		StartedAt:    time.Now().Unix(),
+		Name:         req.DAG.Name,
+		DAGRunID:     req.DAGRunID,
+		AttemptID:    attempt.ID(),
+		RootName:     req.Root.Name,
+		RootDAGRunID: req.Root.ID,
+	})
+	if err != nil {
+		_ = recordPreparedAttemptFailure(ctx, req, attempt, err)
+		return nil, fmt.Errorf("%w: %w", ErrProcAcquisitionFailed, err)
+	}
+
+	return &LocalPreparation{
+		Attempt: attempt,
+		Proc:    proc,
+	}, nil
+}
+
+func (r LocalRequest) validate() error {
+	if r.ProcStore == nil {
+		return fmt.Errorf("proc store is required")
+	}
+	if r.DAG == nil {
+		return fmt.Errorf("dag is required")
+	}
+	if r.DAGRunID == "" {
+		return fmt.Errorf("dag-run ID is required")
+	}
+	if r.BuildAttempt == nil {
+		return fmt.Errorf("attempt builder is required")
+	}
+	return nil
+}
+
+func recordPreparedAttemptFailure(
+	ctx context.Context,
+	req LocalRequest,
+	attempt exec.DAGRunAttempt,
+	runErr error,
+) error {
+	logFile, logErr := logpath.Generate(ctx, req.LogBaseDir, req.DAG.LogDir, req.DAG.Name, req.DAGRunID)
+	if logErr != nil {
+		logger.Warn(ctx, "Failed to generate log file path for prepared local execution failure",
+			tag.Error(logErr),
+			tag.DAG(req.DAG.Name),
+			tag.RunID(req.DAGRunID),
+		)
+	}
+
+	archiveDir, archiveErr := localArtifactDir(ctx, req)
+	if archiveErr != nil {
+		logger.Warn(ctx, "Failed to generate artifact directory for prepared local execution failure",
+			tag.Error(archiveErr),
+			tag.DAG(req.DAG.Name),
+			tag.RunID(req.DAGRunID),
+		)
+	}
+
+	opts := []transform.StatusOption{
+		transform.WithAttemptID(attempt.ID()),
+		transform.WithHierarchyRefs(req.Root, req.Parent),
+		transform.WithLogFilePath(logFile),
+		transform.WithArchiveDir(archiveDir),
+		transform.WithFinishedAt(time.Now()),
+		transform.WithError(runErr.Error()),
+		transform.WithWorkerID("local"),
+		transform.WithTriggerType(req.TriggerType),
+	}
+	if req.ScheduleTime != "" {
+		opts = append(opts, transform.WithScheduleTime(req.ScheduleTime))
+	}
+	status := transform.NewStatusBuilder(req.DAG).Create(req.DAGRunID, core.Failed, 0, time.Now(), opts...)
+
+	if err := attempt.Open(ctx); err != nil {
+		return fmt.Errorf("failed to open attempt for failure recording: %w", err)
+	}
+	defer func() {
+		_ = attempt.Close(ctx)
+	}()
+
+	if err := attempt.Write(ctx, status); err != nil {
+		return fmt.Errorf("failed to write failed status: %w", err)
+	}
+	return nil
+}
+
+func localArtifactDir(ctx context.Context, req LocalRequest) (string, error) {
+	if !req.DAG.ArtifactsEnabled() {
+		return "", nil
+	}
+	return logpath.GenerateDir(ctx, req.ArtifactBaseDir, req.DAG.Artifacts.Dir, req.DAG.Name, req.DAGRunID)
+}

--- a/internal/dagrun/intake/local.go
+++ b/internal/dagrun/intake/local.go
@@ -87,7 +87,12 @@ func PrepareLocalExecution(ctx context.Context, req LocalRequest) (*LocalPrepara
 		RootDAGRunID: req.Root.ID,
 	})
 	if err != nil {
-		_ = recordPreparedAttemptFailure(ctx, req, attempt, err)
+		if recErr := recordPreparedAttemptFailure(ctx, req, attempt, err); recErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("%w: %w", ErrProcAcquisitionFailed, err),
+				fmt.Errorf("failed to record prepared local execution failure: %w", recErr),
+			)
+		}
 		return nil, fmt.Errorf("%w: %w", ErrProcAcquisitionFailed, err)
 	}
 

--- a/internal/dagrun/intake/local_test.go
+++ b/internal/dagrun/intake/local_test.go
@@ -76,6 +76,34 @@ func TestPrepareLocalExecutionRecordsFailedStatusWhenProcAcquireFails(t *testing
 	assert.True(t, procStore.unlocked)
 }
 
+func TestPrepareLocalExecutionReturnsFailureRecordingErrorWhenRecordFails(t *testing.T) {
+	t.Parallel()
+
+	recordErr := errors.New("status write failed")
+	attempt := &queueAttempt{id: "attempt-1", writeErr: recordErr}
+	procStore := &localProcStore{
+		handle:     &localProcHandle{},
+		acquireErr: errors.New("already running"),
+	}
+	dag := newLocalDAG()
+
+	_, err := PrepareLocalExecution(context.Background(), LocalRequest{
+		ProcStore:   procStore,
+		DAG:         dag,
+		DAGRunID:    "run-1",
+		TriggerType: core.TriggerTypeManual,
+		BuildAttempt: func(context.Context) (exec.DAGRunAttempt, error) {
+			return attempt, nil
+		},
+	})
+
+	require.ErrorIs(t, err, ErrProcAcquisitionFailed)
+	assert.ErrorIs(t, err, recordErr)
+	assert.Contains(t, err.Error(), "already running")
+	assert.Contains(t, err.Error(), "failed to record prepared local execution failure")
+	assert.True(t, procStore.unlocked)
+}
+
 func newLocalDAG() *core.DAG {
 	dag := &core.DAG{
 		Name:   "test-dag",

--- a/internal/dagrun/intake/local_test.go
+++ b/internal/dagrun/intake/local_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intake
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareLocalExecutionAcquiresProcWithPreparedAttempt(t *testing.T) {
+	t.Parallel()
+
+	attempt := &queueAttempt{id: "attempt-1"}
+	procStore := &localProcStore{handle: &localProcHandle{}}
+	dag := newLocalDAG()
+	root := exec.NewDAGRunRef("root-dag", "root-run")
+
+	prepared, err := PrepareLocalExecution(context.Background(), LocalRequest{
+		ProcStore:   procStore,
+		DAG:         dag,
+		DAGRunID:    "run-1",
+		Root:        root,
+		TriggerType: core.TriggerTypeManual,
+		BuildAttempt: func(context.Context) (exec.DAGRunAttempt, error) {
+			return attempt, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	assert.Same(t, attempt, prepared.Attempt)
+	assert.Same(t, dag, attempt.dag)
+	assert.True(t, procStore.locked)
+	assert.True(t, procStore.unlocked)
+	assert.Equal(t, dag.ProcGroup(), procStore.groupName)
+	assert.Equal(t, "run-1", procStore.meta.DAGRunID)
+	assert.Equal(t, "attempt-1", procStore.meta.AttemptID)
+	assert.Equal(t, root.Name, procStore.meta.RootName)
+	assert.Equal(t, root.ID, procStore.meta.RootDAGRunID)
+}
+
+func TestPrepareLocalExecutionRecordsFailedStatusWhenProcAcquireFails(t *testing.T) {
+	t.Parallel()
+
+	attempt := &queueAttempt{id: "attempt-1"}
+	procStore := &localProcStore{
+		handle:     &localProcHandle{},
+		acquireErr: errors.New("already running"),
+	}
+	dag := newLocalDAG()
+
+	_, err := PrepareLocalExecution(context.Background(), LocalRequest{
+		ProcStore:   procStore,
+		DAG:         dag,
+		DAGRunID:    "run-1",
+		TriggerType: core.TriggerTypeManual,
+		BuildAttempt: func(context.Context) (exec.DAGRunAttempt, error) {
+			return attempt, nil
+		},
+	})
+
+	require.ErrorIs(t, err, ErrProcAcquisitionFailed)
+	require.NotNil(t, attempt.status)
+	assert.Equal(t, core.Failed, attempt.status.Status)
+	assert.Equal(t, "attempt-1", attempt.status.AttemptID)
+	assert.Equal(t, "local", attempt.status.WorkerID)
+	assert.Contains(t, attempt.status.Error, "already running")
+	assert.True(t, attempt.closed)
+	assert.True(t, procStore.unlocked)
+}
+
+func newLocalDAG() *core.DAG {
+	dag := &core.DAG{
+		Name:   "test-dag",
+		LogDir: "logs",
+	}
+	core.InitializeDefaults(dag)
+	return dag
+}
+
+type localProcStore struct {
+	handle     exec.ProcHandle
+	acquireErr error
+	locked     bool
+	unlocked   bool
+	groupName  string
+	meta       exec.ProcMeta
+}
+
+func (s *localProcStore) Lock(_ context.Context, groupName string) error {
+	s.locked = true
+	s.groupName = groupName
+	return nil
+}
+
+func (s *localProcStore) Unlock(context.Context, string) {
+	s.unlocked = true
+}
+
+func (s *localProcStore) Acquire(_ context.Context, groupName string, meta exec.ProcMeta) (exec.ProcHandle, error) {
+	s.groupName = groupName
+	s.meta = meta
+	if s.acquireErr != nil {
+		return nil, s.acquireErr
+	}
+	return s.handle, nil
+}
+
+func (s *localProcStore) CountAlive(context.Context, string) (int, error) { return 0, nil }
+func (s *localProcStore) CountAliveByDAGName(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+func (s *localProcStore) IsRunAlive(context.Context, string, exec.DAGRunRef) (bool, error) {
+	return false, nil
+}
+func (s *localProcStore) IsAttemptAlive(context.Context, string, exec.DAGRunRef, string) (bool, error) {
+	return false, nil
+}
+func (s *localProcStore) ListAlive(context.Context, string) ([]exec.DAGRunRef, error) {
+	return nil, nil
+}
+func (s *localProcStore) ListAllAlive(context.Context) (map[string][]exec.DAGRunRef, error) {
+	return nil, nil
+}
+func (s *localProcStore) ListEntries(context.Context, string) ([]exec.ProcEntry, error) {
+	return nil, nil
+}
+func (s *localProcStore) LatestFreshEntryByDAGName(context.Context, string, string) (*exec.ProcEntry, error) {
+	return nil, nil
+}
+func (s *localProcStore) ListAllEntries(context.Context) ([]exec.ProcEntry, error) {
+	return nil, nil
+}
+func (s *localProcStore) RemoveIfStale(context.Context, exec.ProcEntry) error { return nil }
+
+type localProcHandle struct {
+	meta exec.ProcMeta
+}
+
+func (h *localProcHandle) Stop(context.Context) error { return nil }
+func (h *localProcHandle) GetMeta() exec.ProcMeta     { return h.meta }

--- a/internal/dagrun/intake/queue.go
+++ b/internal/dagrun/intake/queue.go
@@ -1,0 +1,220 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/logpath"
+	"github.com/dagucloud/dagu/internal/cmn/stringutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/transform"
+)
+
+// QueueRequest describes a DAG-run intake operation that persists a queued
+// attempt before publishing the queue item.
+type QueueRequest struct {
+	DAGRunStore exec.DAGRunStore
+	QueueStore  exec.QueueStore
+	DAG         *core.DAG
+	DAGRunID    string
+
+	QueueName string
+
+	LogBaseDir      string
+	ArtifactBaseDir string
+
+	Root         exec.DAGRunRef
+	Parent       exec.DAGRunRef
+	TriggerType  core.TriggerType
+	ScheduleTime string
+
+	AttemptOptions exec.NewDAGRunAttemptOptions
+
+	// ProceedOnStatusCloseErr preserves legacy CLI enqueue behavior: publish
+	// the queue item after best-effort close so readers can see the queued status.
+	ProceedOnStatusCloseErr bool
+
+	Now func() time.Time
+}
+
+// QueuedRun is the result of successful DAG-run queue intake.
+type QueuedRun struct {
+	DAGRun      exec.DAGRunRef
+	Attempt     exec.DAGRunAttempt
+	Status      exec.DAGRunStatus
+	QueueName   string
+	LogFile     string
+	ArtifactDir string
+	// StatusCloseErr is set only when ProceedOnStatusCloseErr allowed intake
+	// to continue after the status attempt close failed.
+	StatusCloseErr error
+}
+
+// EnqueueRun creates a queued DAG-run attempt, writes the queued status, closes
+// the attempt, then publishes the queue item. If any post-create step fails, the
+// created attempt is rolled back.
+func EnqueueRun(ctx context.Context, req QueueRequest) (*QueuedRun, error) {
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+
+	now := req.now()
+	dagRun := exec.NewDAGRunRef(req.DAG.Name, req.DAGRunID)
+	queueName := req.queueName()
+
+	logFile, err := logpath.Generate(ctx, req.LogBaseDir, req.DAG.LogDir, req.DAG.Name, req.DAGRunID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate log file name: %w", err)
+	}
+
+	artifactDir, err := artifactDir(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	attempt, err := req.DAGRunStore.CreateAttempt(ctx, req.DAG, now, req.DAGRunID, req.AttemptOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create queued DAG run: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if rmErr := req.DAGRunStore.RemoveDAGRun(context.WithoutCancel(ctx), dagRun); rmErr != nil {
+			logger.Error(ctx, "Failed to rollback queued DAG run",
+				tag.DAG(req.DAG.Name),
+				tag.RunID(req.DAGRunID),
+				tag.Error(rmErr),
+			)
+		}
+	}()
+
+	status := queuedStatus(req, dagRun, attempt.ID(), logFile, artifactDir, now)
+	statusCloseErr, err := writeQueuedStatus(ctx, attempt, status, req.ProceedOnStatusCloseErr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := req.QueueStore.Enqueue(ctx, queueName, exec.QueuePriorityLow, dagRun); err != nil {
+		return nil, joinCloseAndEnqueue(
+			wrapCloseErr(statusCloseErr),
+			fmt.Errorf("failed to enqueue DAG run: %w", err),
+		)
+	}
+	committed = true
+
+	return &QueuedRun{
+		DAGRun:         dagRun,
+		Attempt:        attempt,
+		Status:         status,
+		QueueName:      queueName,
+		LogFile:        logFile,
+		ArtifactDir:    artifactDir,
+		StatusCloseErr: statusCloseErr,
+	}, nil
+}
+
+func (r QueueRequest) validate() error {
+	if r.DAGRunStore == nil {
+		return fmt.Errorf("dag-run store is required")
+	}
+	if r.QueueStore == nil {
+		return fmt.Errorf("queue store is required")
+	}
+	if r.DAG == nil {
+		return fmt.Errorf("dag is required")
+	}
+	if r.DAGRunID == "" {
+		return fmt.Errorf("dag-run ID is required")
+	}
+	return nil
+}
+
+func (r QueueRequest) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
+}
+
+func (r QueueRequest) queueName() string {
+	if r.QueueName != "" {
+		return r.QueueName
+	}
+	return r.DAG.ProcGroup()
+}
+
+func artifactDir(ctx context.Context, req QueueRequest) (string, error) {
+	if !req.DAG.ArtifactsEnabled() {
+		return "", nil
+	}
+
+	dir, err := logpath.GenerateDir(ctx, req.ArtifactBaseDir, req.DAG.Artifacts.Dir, req.DAG.Name, req.DAGRunID)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate artifact directory: %w", err)
+	}
+	return dir, nil
+}
+
+func queuedStatus(req QueueRequest, dagRun exec.DAGRunRef, attemptID, logFile, archiveDir string, now time.Time) exec.DAGRunStatus {
+	root := req.Root
+	if root.Zero() {
+		root = dagRun
+	}
+
+	opts := []transform.StatusOption{
+		transform.WithLogFilePath(logFile),
+		transform.WithArchiveDir(archiveDir),
+		transform.WithAttemptID(attemptID),
+		transform.WithPreconditions(req.DAG.Preconditions),
+		transform.WithQueuedAt(stringutil.FormatTime(now)),
+		transform.WithHierarchyRefs(root, req.Parent),
+		transform.WithTriggerType(req.TriggerType),
+	}
+	if req.ScheduleTime != "" {
+		opts = append(opts, transform.WithScheduleTime(req.ScheduleTime))
+	}
+
+	return transform.NewStatusBuilder(req.DAG).Create(req.DAGRunID, core.Queued, 0, time.Time{}, opts...)
+}
+
+func writeQueuedStatus(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus, proceedOnCloseErr bool) (error, error) {
+	if err := attempt.Open(ctx); err != nil {
+		return nil, fmt.Errorf("failed to open queued DAG run: %w", err)
+	}
+	if err := attempt.Write(ctx, status); err != nil {
+		_ = attempt.Close(ctx)
+		return nil, fmt.Errorf("failed to save queued DAG run status: %w", err)
+	}
+	if err := attempt.Close(ctx); err != nil {
+		if proceedOnCloseErr {
+			return err, nil
+		}
+		return nil, fmt.Errorf("failed to close queued DAG run: %w", err)
+	}
+	return nil, nil
+}
+
+func wrapCloseErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("failed to close queued DAG run: %w", err)
+}
+
+func joinCloseAndEnqueue(closeErr, enqueueErr error) error {
+	if closeErr == nil {
+		return enqueueErr
+	}
+	return errors.Join(closeErr, enqueueErr)
+}

--- a/internal/dagrun/intake/queue.go
+++ b/internal/dagrun/intake/queue.go
@@ -100,14 +100,14 @@ func EnqueueRun(ctx context.Context, req QueueRequest) (*QueuedRun, error) {
 	}()
 
 	status := queuedStatus(req, dagRun, attempt.ID(), logFile, artifactDir, now)
-	statusCloseErr, err := writeQueuedStatus(ctx, attempt, status, req.ProceedOnStatusCloseErr)
+	writeResult, err := writeQueuedStatus(ctx, attempt, status, req.ProceedOnStatusCloseErr)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := req.QueueStore.Enqueue(ctx, queueName, exec.QueuePriorityLow, dagRun); err != nil {
 		return nil, joinCloseAndEnqueue(
-			wrapCloseErr(statusCloseErr),
+			wrapCloseErr(writeResult.closeErr),
 			fmt.Errorf("failed to enqueue DAG run: %w", err),
 		)
 	}
@@ -120,7 +120,7 @@ func EnqueueRun(ctx context.Context, req QueueRequest) (*QueuedRun, error) {
 		QueueName:      queueName,
 		LogFile:        logFile,
 		ArtifactDir:    artifactDir,
-		StatusCloseErr: statusCloseErr,
+		StatusCloseErr: writeResult.closeErr,
 	}, nil
 }
 
@@ -188,21 +188,28 @@ func queuedStatus(req QueueRequest, dagRun exec.DAGRunRef, attemptID, logFile, a
 	return transform.NewStatusBuilder(req.DAG).Create(req.DAGRunID, core.Queued, 0, time.Time{}, opts...)
 }
 
-func writeQueuedStatus(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus, proceedOnCloseErr bool) (error, error) {
+// queuedStatusWriteResult captures non-fatal status write side effects.
+type queuedStatusWriteResult struct {
+	// closeErr is set when closing the status attempt failed but the request
+	// allowed queue publication to continue.
+	closeErr error
+}
+
+func writeQueuedStatus(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus, proceedOnCloseErr bool) (queuedStatusWriteResult, error) {
 	if err := attempt.Open(ctx); err != nil {
-		return nil, fmt.Errorf("failed to open queued DAG run: %w", err)
+		return queuedStatusWriteResult{}, fmt.Errorf("failed to open queued DAG run: %w", err)
 	}
 	if err := attempt.Write(ctx, status); err != nil {
 		_ = attempt.Close(ctx)
-		return nil, fmt.Errorf("failed to save queued DAG run status: %w", err)
+		return queuedStatusWriteResult{}, fmt.Errorf("failed to save queued DAG run status: %w", err)
 	}
 	if err := attempt.Close(ctx); err != nil {
 		if proceedOnCloseErr {
-			return err, nil
+			return queuedStatusWriteResult{closeErr: err}, nil
 		}
-		return nil, fmt.Errorf("failed to close queued DAG run: %w", err)
+		return queuedStatusWriteResult{}, fmt.Errorf("failed to close queued DAG run: %w", err)
 	}
-	return nil, nil
+	return queuedStatusWriteResult{}, nil
 }
 
 func wrapCloseErr(err error) error {

--- a/internal/dagrun/intake/queue_test.go
+++ b/internal/dagrun/intake/queue_test.go
@@ -1,0 +1,286 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intake
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnqueueRunWritesQueuedStatusBeforeQueuePublish(t *testing.T) {
+	t.Parallel()
+
+	f := newQueueFixture(t)
+
+	queued, err := EnqueueRun(f.ctx, QueueRequest{
+		DAGRunStore:     f.runStore,
+		QueueStore:      f.queueStore,
+		DAG:             f.dag,
+		DAGRunID:        "run-1",
+		LogBaseDir:      f.logDir,
+		ArtifactBaseDir: f.artifactDir,
+		TriggerType:     core.TriggerTypeManual,
+		Now:             fixedQueueNow,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, queued)
+	assert.True(t, f.queueStore.enqueued)
+	assert.Equal(t, exec.QueuePriorityLow, f.queueStore.priority)
+	require.NotNil(t, f.attempt.status)
+	assert.Equal(t, core.Queued, f.attempt.status.Status)
+	assert.Equal(t, "attempt-1", f.attempt.status.AttemptID)
+	assert.Equal(t, "2026-05-19T01:02:03Z", f.attempt.status.QueuedAt)
+	assert.Equal(t, core.TriggerTypeManual, f.attempt.status.TriggerType)
+	assert.Equal(t, f.attempt.status.Log, queued.LogFile)
+	assert.Equal(t, f.attempt.status.ArchiveDir, queued.ArtifactDir)
+}
+
+func TestEnqueueRunRollsBackCreatedAttemptWhenQueuePublishFails(t *testing.T) {
+	t.Parallel()
+
+	f := newQueueFixture(t)
+	f.queueStore.err = errors.New("queue offline")
+
+	_, err := EnqueueRun(f.ctx, QueueRequest{
+		DAGRunStore:     f.runStore,
+		QueueStore:      f.queueStore,
+		DAG:             f.dag,
+		DAGRunID:        "run-1",
+		LogBaseDir:      f.logDir,
+		ArtifactBaseDir: f.artifactDir,
+		Now:             fixedQueueNow,
+	})
+
+	require.Error(t, err)
+	assert.True(t, f.runStore.removed)
+	assert.Equal(t, exec.NewDAGRunRef("test-dag", "run-1"), f.runStore.removedRef)
+}
+
+func TestEnqueueRunCanProceedWhenAttemptCloseFails(t *testing.T) {
+	t.Parallel()
+
+	f := newQueueFixture(t)
+	f.attempt.closeErr = errors.New("sync failed")
+
+	queued, err := EnqueueRun(f.ctx, QueueRequest{
+		DAGRunStore:             f.runStore,
+		QueueStore:              f.queueStore,
+		DAG:                     f.dag,
+		DAGRunID:                "run-1",
+		LogBaseDir:              f.logDir,
+		ArtifactBaseDir:         f.artifactDir,
+		ProceedOnStatusCloseErr: true,
+		Now:                     fixedQueueNow,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, queued)
+	assert.True(t, f.queueStore.enqueued)
+	assert.True(t, f.attempt.closed)
+	assert.False(t, f.runStore.removed)
+}
+
+func fixedQueueNow() time.Time {
+	return time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+}
+
+type queueFixture struct {
+	ctx         context.Context
+	logDir      string
+	artifactDir string
+	dag         *core.DAG
+	attempt     *queueAttempt
+	runStore    *queueRunStore
+	queueStore  *queueStore
+}
+
+func newQueueFixture(t *testing.T) queueFixture {
+	t.Helper()
+
+	tmp := t.TempDir()
+	attempt := &queueAttempt{id: "attempt-1"}
+	dag := &core.DAG{
+		Name:   "test-dag",
+		LogDir: "logs",
+		Artifacts: &core.ArtifactsConfig{
+			Enabled: true,
+			Dir:     "artifacts",
+		},
+	}
+	core.InitializeDefaults(dag)
+
+	return queueFixture{
+		ctx:         context.Background(),
+		logDir:      filepath.Join(tmp, "logs"),
+		artifactDir: filepath.Join(tmp, "artifacts"),
+		dag:         dag,
+		attempt:     attempt,
+		runStore:    &queueRunStore{attempt: attempt},
+		queueStore:  &queueStore{attempt: attempt},
+	}
+}
+
+type queueRunStore struct {
+	attempt    *queueAttempt
+	removed    bool
+	removedRef exec.DAGRunRef
+}
+
+func (s *queueRunStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
+	return s.attempt, nil
+}
+
+func (s *queueRunStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
+	return nil
+}
+
+func (s *queueRunStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *queueRunStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	return nil, nil
+}
+
+func (s *queueRunStore) ListStatusesPage(context.Context, ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
+	return exec.DAGRunStatusPage{}, nil
+}
+
+func (s *queueRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error, ...exec.CompareAndSwapStatusOption) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
+func (s *queueRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *queueRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *queueRunStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *queueRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.RemoveOldDAGRunsOption) ([]string, error) {
+	return nil, nil
+}
+
+func (s *queueRunStore) RenameDAGRuns(context.Context, string, string) error {
+	return nil
+}
+
+func (s *queueRunStore) RemoveDAGRun(_ context.Context, ref exec.DAGRunRef, _ ...exec.RemoveDAGRunOption) error {
+	s.removed = true
+	s.removedRef = ref
+	return nil
+}
+
+type queueAttempt struct {
+	id       string
+	dag      *core.DAG
+	open     bool
+	closed   bool
+	closeErr error
+	status   *exec.DAGRunStatus
+}
+
+func (a *queueAttempt) ID() string { return a.id }
+
+func (a *queueAttempt) Open(context.Context) error {
+	a.open = true
+	a.closed = false
+	return nil
+}
+
+func (a *queueAttempt) Write(_ context.Context, status exec.DAGRunStatus) error {
+	if !a.open {
+		return errors.New("attempt is not open")
+	}
+	a.status = &status
+	return nil
+}
+
+func (a *queueAttempt) Close(context.Context) error {
+	a.open = false
+	a.closed = true
+	return a.closeErr
+}
+
+func (a *queueAttempt) ReadStatus(context.Context) (*exec.DAGRunStatus, error) { return a.status, nil }
+func (a *queueAttempt) ReadDAG(context.Context) (*core.DAG, error)             { return a.dag, nil }
+func (a *queueAttempt) SetDAG(dag *core.DAG)                                   { a.dag = dag }
+func (a *queueAttempt) Abort(context.Context) error                            { return nil }
+func (a *queueAttempt) IsAborting(context.Context) (bool, error)               { return false, nil }
+func (a *queueAttempt) Hide(context.Context) error                             { return nil }
+func (a *queueAttempt) Hidden() bool                                           { return false }
+func (a *queueAttempt) WriteOutputs(context.Context, *exec.DAGRunOutputs) error {
+	return nil
+}
+func (a *queueAttempt) ReadOutputs(context.Context) (*exec.DAGRunOutputs, error) {
+	return nil, nil
+}
+func (a *queueAttempt) WriteStepMessages(context.Context, string, []exec.LLMMessage) error {
+	return nil
+}
+func (a *queueAttempt) ReadStepMessages(context.Context, string) ([]exec.LLMMessage, error) {
+	return nil, nil
+}
+func (a *queueAttempt) WorkDir() string { return "" }
+
+type queueStore struct {
+	attempt  *queueAttempt
+	enqueued bool
+	priority exec.QueuePriority
+	err      error
+}
+
+func (s *queueStore) Enqueue(_ context.Context, _ string, priority exec.QueuePriority, _ exec.DAGRunRef) error {
+	if s.err != nil {
+		return s.err
+	}
+	if !s.attempt.closed {
+		return errors.New("status attempt was not closed before queue enqueue")
+	}
+	if s.attempt.status == nil || s.attempt.status.Status != core.Queued {
+		return errors.New("queued status was not written before queue enqueue")
+	}
+	s.enqueued = true
+	s.priority = priority
+	return nil
+}
+
+func (s *queueStore) DequeueByName(context.Context, string) (exec.QueuedItemData, error) {
+	return nil, exec.ErrQueueEmpty
+}
+func (s *queueStore) DequeueByDAGRunID(context.Context, string, exec.DAGRunRef) ([]exec.QueuedItemData, error) {
+	return nil, exec.ErrQueueItemNotFound
+}
+func (s *queueStore) DeleteByItemIDs(context.Context, string, []string) (int, error) {
+	return 0, nil
+}
+func (s *queueStore) Len(context.Context, string) (int, error) { return 0, nil }
+func (s *queueStore) List(context.Context, string) ([]exec.QueuedItemData, error) {
+	return nil, nil
+}
+func (s *queueStore) ListCursor(context.Context, string, string, int) (exec.CursorResult[exec.QueuedItemData], error) {
+	return exec.CursorResult[exec.QueuedItemData]{}, nil
+}
+func (s *queueStore) All(context.Context) ([]exec.QueuedItemData, error) { return nil, nil }
+func (s *queueStore) ListByDAGName(context.Context, string, string) ([]exec.QueuedItemData, error) {
+	return nil, nil
+}
+func (s *queueStore) QueueList(context.Context) ([]string, error) { return nil, nil }
+func (s *queueStore) QueueWatcher(context.Context) exec.QueueWatcher {
+	return nil
+}

--- a/internal/dagrun/intake/queue_test.go
+++ b/internal/dagrun/intake/queue_test.go
@@ -88,6 +88,7 @@ func TestEnqueueRunCanProceedWhenAttemptCloseFails(t *testing.T) {
 	assert.True(t, f.queueStore.enqueued)
 	assert.True(t, f.attempt.closed)
 	assert.False(t, f.runStore.removed)
+	assert.ErrorIs(t, queued.StatusCloseErr, f.attempt.closeErr)
 }
 
 func fixedQueueNow() time.Time {
@@ -191,6 +192,8 @@ type queueAttempt struct {
 	dag      *core.DAG
 	open     bool
 	closed   bool
+	openErr  error
+	writeErr error
 	closeErr error
 	status   *exec.DAGRunStatus
 }
@@ -198,6 +201,9 @@ type queueAttempt struct {
 func (a *queueAttempt) ID() string { return a.id }
 
 func (a *queueAttempt) Open(context.Context) error {
+	if a.openErr != nil {
+		return a.openErr
+	}
 	a.open = true
 	a.closed = false
 	return nil
@@ -206,6 +212,9 @@ func (a *queueAttempt) Open(context.Context) error {
 func (a *queueAttempt) Write(_ context.Context, status exec.DAGRunStatus) error {
 	if !a.open {
 		return errors.New("attempt is not open")
+	}
+	if a.writeErr != nil {
+		return a.writeErr
 	}
 	a.status = &status
 	return nil

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -14,19 +14,16 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/logpath"
-	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
 )
 
 const dagEnqueueQueueConfigKey = "queue"
@@ -168,68 +165,19 @@ func (e *enqueueExecutor) enqueueOne(ctx context.Context, runParams executor.Run
 		return enqueueRunOutput{}, fmt.Errorf("failed to check existing DAG run: %w", err)
 	}
 
-	logFile, err := logpath.Generate(ctx, rCtx.DAGRunLogDir, dagCopy.LogDir, dagCopy.Name, runParams.RunID)
+	_, err = intake.EnqueueRun(ctx, intake.QueueRequest{
+		DAGRunStore:     rCtx.DAGRunStore,
+		QueueStore:      rCtx.QueueStore,
+		DAG:             dagCopy,
+		DAGRunID:        runParams.RunID,
+		QueueName:       queueName,
+		LogBaseDir:      rCtx.DAGRunLogDir,
+		ArtifactBaseDir: rCtx.DAGRunArtifactDir,
+		TriggerType:     core.TriggerTypeSubDAG,
+	})
 	if err != nil {
-		return enqueueRunOutput{}, fmt.Errorf("failed to generate log file name: %w", err)
-	}
-
-	artifactDir := ""
-	if dagCopy.ArtifactsEnabled() {
-		artifactDir, err = logpath.GenerateDir(ctx, rCtx.DAGRunArtifactDir, dagCopy.Artifacts.Dir, dagCopy.Name, runParams.RunID)
-		if err != nil {
-			return enqueueRunOutput{}, fmt.Errorf("failed to generate artifact directory: %w", err)
-		}
-	}
-
-	attempt, err := rCtx.DAGRunStore.CreateAttempt(ctx, dagCopy, time.Now(), runParams.RunID, exec1.NewDAGRunAttemptOptions{})
-	if err != nil {
-		return enqueueRunOutput{}, fmt.Errorf("failed to create queued DAG run: %w", err)
-	}
-
-	committed := false
-	defer func() {
-		if committed {
-			return
-		}
-		if rmErr := rCtx.DAGRunStore.RemoveDAGRun(ctx, dagRun); rmErr != nil {
-			logger.Error(ctx, "Failed to rollback queued DAG run",
-				tag.DAG(dagCopy.Name),
-				tag.RunID(runParams.RunID),
-				tag.Error(rmErr),
-			)
-		}
-	}()
-
-	queuedAt := stringutil.FormatTime(time.Now())
-	status := transform.NewStatusBuilder(dagCopy).Create(
-		runParams.RunID,
-		core.Queued,
-		0,
-		time.Time{},
-		transform.WithLogFilePath(logFile),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithAttemptID(attempt.ID()),
-		transform.WithPreconditions(dagCopy.Preconditions),
-		transform.WithQueuedAt(queuedAt),
-		transform.WithHierarchyRefs(dagRun, exec1.DAGRunRef{}),
-		transform.WithTriggerType(core.TriggerTypeSubDAG),
-	)
-
-	if err := attempt.Open(ctx); err != nil {
-		return enqueueRunOutput{}, fmt.Errorf("failed to open queued DAG run: %w", err)
-	}
-	if err := attempt.Write(ctx, status); err != nil {
-		_ = attempt.Close(ctx)
-		return enqueueRunOutput{}, fmt.Errorf("failed to save queued DAG run status: %w", err)
-	}
-	if err := attempt.Close(ctx); err != nil {
-		return enqueueRunOutput{}, fmt.Errorf("failed to close queued DAG run: %w", err)
-	}
-
-	if err := rCtx.QueueStore.Enqueue(ctx, queueName, exec1.QueuePriorityLow, dagRun); err != nil {
 		return enqueueRunOutput{}, fmt.Errorf("failed to enqueue DAG run: %w", err)
 	}
-	committed = true
 
 	logger.Info(ctx, "Enqueued sub DAG run",
 		tag.DAG(dagCopy.Name),

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -32,16 +32,15 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/logpath"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	spectypes "github.com/dagucloud/dagu/internal/core/spec/types"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 	"github.com/dagucloud/dagu/internal/persis/filedagrun"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	"github.com/dagucloud/dagu/internal/workspace"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -3132,76 +3131,25 @@ func (a *API) enqueuePreparedDAGRun(
 	queuedDAG := dag.Clone()
 	queuedDAG.Location = ""
 
-	now := time.Now()
-	attempt, err := a.dagRunStore.CreateAttempt(ctx, queuedDAG, now, dagRunID, exec.NewDAGRunAttemptOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create queued dag-run attempt: %w", err)
-	}
-
-	logFile, err := logpath.Generate(ctx, a.config.Paths.LogDir, queuedDAG.LogDir, queuedDAG.Name, dagRunID)
-	if err != nil {
-		return fmt.Errorf("failed to generate queued dag-run log file: %w", err)
-	}
-	artifactDir, err := artifactDirForQueuedDAGRun(ctx, a.config.Paths.ArtifactDir, queuedDAG, dagRunID)
+	queued, err := intake.EnqueueRun(ctx, intake.QueueRequest{
+		DAGRunStore:             a.dagRunStore,
+		QueueStore:              a.queueStore,
+		DAG:                     queuedDAG,
+		DAGRunID:                dagRunID,
+		LogBaseDir:              a.config.Paths.LogDir,
+		ArtifactBaseDir:         a.config.Paths.ArtifactDir,
+		TriggerType:             triggerType,
+		ProceedOnStatusCloseErr: true,
+	})
 	if err != nil {
 		return err
 	}
-
-	statusOpts := []transform.StatusOption{
-		transform.WithLogFilePath(logFile),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithAttemptID(attempt.ID()),
-		transform.WithQueuedAt(stringutil.FormatTime(now)),
-		transform.WithPreconditions(queuedDAG.Preconditions),
-		transform.WithHierarchyRefs(
-			exec.NewDAGRunRef(queuedDAG.Name, dagRunID),
-			exec.DAGRunRef{},
-		),
-		transform.WithTriggerType(triggerType),
-	}
-	status := transform.NewStatusBuilder(queuedDAG).Create(dagRunID, core.Queued, 0, time.Time{}, statusOpts...)
-
-	if err := attempt.Open(ctx); err != nil {
-		return fmt.Errorf("failed to open queued dag-run attempt: %w", err)
-	}
-	if err := attempt.Write(ctx, status); err != nil {
-		_ = attempt.Close(ctx)
-		return fmt.Errorf("failed to save queued dag-run status: %w", err)
-	}
-	closeErr := attempt.Close(ctx)
-	if closeErr != nil {
+	if queued.StatusCloseErr != nil {
 		logger.Warn(ctx, "Failed to close queued dag-run status before enqueue",
-			tag.Error(closeErr))
-	}
-
-	dagRun := exec.NewDAGRunRef(queuedDAG.Name, dagRunID)
-	if err := a.queueStore.Enqueue(ctx, queuedDAG.ProcGroup(), exec.QueuePriorityLow, dagRun); err != nil {
-		if closeErr != nil {
-			return errors.Join(
-				fmt.Errorf("failed to close queued dag-run attempt: %w", closeErr),
-				fmt.Errorf("failed to enqueue dag-run: %w", err),
-			)
-		}
-		return fmt.Errorf("failed to enqueue dag-run: %w", err)
+			tag.Error(queued.StatusCloseErr))
 	}
 
 	return nil
-}
-
-func artifactDirForQueuedDAGRun(ctx context.Context, baseDir string, dag *core.DAG, dagRunID string) (string, error) {
-	if dag == nil || !dag.ArtifactsEnabled() {
-		return "", nil
-	}
-
-	dagArtifactDir := ""
-	if dag.Artifacts != nil {
-		dagArtifactDir = dag.Artifacts.Dir
-	}
-	artifactDir, err := logpath.GenerateDir(ctx, baseDir, dagArtifactDir, dag.Name, dagRunID)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate queued dag-run artifact directory: %w", err)
-	}
-	return artifactDir, nil
 }
 
 // GetSubDAGRuns returns timing and status information for all sub DAG runs.

--- a/internal/service/scheduler/enqueue.go
+++ b/internal/service/scheduler/enqueue.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/logpath"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 )
 
 // EnqueueCatchupRun enqueues a catchup run for a DAG.
@@ -66,72 +65,19 @@ func EnqueueCatchupRun(
 	dagCopy := fullDAG.Clone()
 	dagCopy.Location = ""
 
-	logFile, err := logpath.Generate(ctx, baseLogDir, dagCopy.LogDir, dagCopy.Name, runID)
+	_, err = intake.EnqueueRun(ctx, intake.QueueRequest{
+		DAGRunStore:     dagRunStore,
+		QueueStore:      queueStore,
+		DAG:             dagCopy,
+		DAGRunID:        runID,
+		LogBaseDir:      baseLogDir,
+		ArtifactBaseDir: baseArtifactDir,
+		TriggerType:     triggerType,
+		ScheduleTime:    stringutil.FormatTime(scheduleTime),
+	})
 	if err != nil {
-		return fmt.Errorf("failed to generate catchup log file name: %w", err)
-	}
-	artifactDir := ""
-	if dagCopy.ArtifactsEnabled() {
-		dagArtifactDir := dagCopy.Artifacts.Dir
-		artifactDir, err = logpath.GenerateDir(ctx, baseArtifactDir, dagArtifactDir, dagCopy.Name, runID)
-		if err != nil {
-			return fmt.Errorf("failed to generate catchup artifact directory: %w", err)
-		}
-	}
-
-	att, err := dagRunStore.CreateAttempt(ctx, dagCopy, time.Now(), runID, exec.NewDAGRunAttemptOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create catchup attempt: %w", err)
-	}
-
-	// Rollback the attempt on any failure after creation. Without this,
-	// an orphaned attempt would block all future retries for this run ID
-	// because FindAttempt would find it and skip.
-	committed := false
-	defer func() {
-		if committed {
-			return
-		}
-		if rmErr := dagRunStore.RemoveDAGRun(ctx, dagRun); rmErr != nil {
-			logger.Error(ctx, "Failed to rollback catchup attempt",
-				tag.DAG(dag.Name),
-				tag.RunID(runID),
-				tag.Error(rmErr),
-			)
-		}
-	}()
-
-	opts := []transform.StatusOption{
-		transform.WithLogFilePath(logFile),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithAttemptID(att.ID()),
-		transform.WithPreconditions(dagCopy.Preconditions),
-		transform.WithQueuedAt(stringutil.FormatTime(time.Now())),
-		transform.WithHierarchyRefs(dagRun, exec.DAGRunRef{}),
-		transform.WithTriggerType(triggerType),
-		transform.WithScheduleTime(stringutil.FormatTime(scheduleTime)),
-	}
-
-	dagStatus := transform.NewStatusBuilder(dagCopy).Create(runID, core.Queued, 0, time.Time{}, opts...)
-
-	if err := att.Open(ctx); err != nil {
-		return fmt.Errorf("failed to open catchup attempt: %w", err)
-	}
-
-	if err := att.Write(ctx, dagStatus); err != nil {
-		_ = att.Close(ctx)
-		return fmt.Errorf("failed to write catchup status: %w", err)
-	}
-
-	if err := att.Close(ctx); err != nil {
-		return fmt.Errorf("failed to close catchup attempt: %w", err)
-	}
-
-	if err := queueStore.Enqueue(ctx, dagCopy.ProcGroup(), exec.QueuePriorityLow, dagRun); err != nil {
 		return fmt.Errorf("failed to enqueue catchup run: %w", err)
 	}
-
-	committed = true
 
 	logger.Info(ctx, "Catchup run enqueued",
 		tag.DAG(dag.Name),

--- a/internal/service/scheduler/enqueue_webhook.go
+++ b/internal/service/scheduler/enqueue_webhook.go
@@ -11,11 +11,9 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/logpath"
-	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/runtime/transform"
+	"github.com/dagucloud/dagu/internal/dagrun/intake"
 )
 
 // EnqueueWebhookRun enqueues a webhook-triggered run while preserving the same
@@ -55,63 +53,19 @@ func EnqueueWebhookRun(
 	dagCopy := fullDAG.Clone()
 	dagCopy.Location = ""
 
-	logFile, err := logpath.Generate(ctx, baseLogDir, dagCopy.LogDir, dagCopy.Name, runID)
+	_, err = intake.EnqueueRun(ctx, intake.QueueRequest{
+		DAGRunStore:     dagRunStore,
+		QueueStore:      queueStore,
+		DAG:             dagCopy,
+		DAGRunID:        runID,
+		LogBaseDir:      baseLogDir,
+		ArtifactBaseDir: baseArtifactDir,
+		TriggerType:     core.TriggerTypeWebhook,
+		Now:             func() time.Time { return now },
+	})
 	if err != nil {
-		return fmt.Errorf("failed to generate webhook log file name: %w", err)
-	}
-	artifactDir := ""
-	if dagCopy.ArtifactsEnabled() {
-		artifactDir, err = logpath.GenerateDir(ctx, baseArtifactDir, dagCopy.Artifacts.Dir, dagCopy.Name, runID)
-		if err != nil {
-			return fmt.Errorf("failed to generate webhook artifact directory: %w", err)
-		}
-	}
-
-	att, err := dagRunStore.CreateAttempt(ctx, dagCopy, now, runID, exec.NewDAGRunAttemptOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create webhook attempt: %w", err)
-	}
-
-	committed := false
-	defer func() {
-		if committed {
-			return
-		}
-		if rmErr := dagRunStore.RemoveDAGRun(ctx, dagRun); rmErr != nil {
-			logger.Error(ctx, "Failed to rollback webhook attempt",
-				tag.DAG(dag.Name),
-				tag.RunID(runID),
-				tag.Error(rmErr),
-			)
-		}
-	}()
-
-	opts := []transform.StatusOption{
-		transform.WithLogFilePath(logFile),
-		transform.WithArchiveDir(artifactDir),
-		transform.WithAttemptID(att.ID()),
-		transform.WithPreconditions(dagCopy.Preconditions),
-		transform.WithQueuedAt(stringutil.FormatTime(now)),
-		transform.WithHierarchyRefs(dagRun, exec.DAGRunRef{}),
-		transform.WithTriggerType(core.TriggerTypeWebhook),
-	}
-	dagStatus := transform.NewStatusBuilder(dagCopy).Create(runID, core.Queued, 0, time.Time{}, opts...)
-
-	if err := att.Open(ctx); err != nil {
-		return fmt.Errorf("failed to open webhook attempt: %w", err)
-	}
-	if err := att.Write(ctx, dagStatus); err != nil {
-		_ = att.Close(ctx)
-		return fmt.Errorf("failed to write webhook status: %w", err)
-	}
-	if err := att.Close(ctx); err != nil {
-		return fmt.Errorf("failed to close webhook attempt: %w", err)
-	}
-	if err := queueStore.Enqueue(ctx, dagCopy.ProcGroup(), exec.QueuePriorityLow, dagRun); err != nil {
 		return fmt.Errorf("failed to enqueue webhook run: %w", err)
 	}
-
-	committed = true
 
 	logger.Info(ctx, "Webhook run enqueued",
 		tag.DAG(dag.Name),


### PR DESCRIPTION
## Summary
- add internal/dagrun/intake to centralize queued DAG-run and local execution intake
- migrate CLI, scheduler, sub-DAG executor, and frontend API queue/local setup through the module
- add focused intake tests for queued status, rollback, priority, and local proc acquisition failure behavior

## Testing
- go test ./internal/dagrun/intake ./internal/cmd ./internal/service/scheduler ./internal/runtime/builtin/dag ./internal/service/frontend/api/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized DAG run enqueueing into a single intake flow for more consistent and reliable queue behavior.
  * Centralized local execution preparation and proc acquisition to simplify setup and error handling.
* **Tests**
  * Added unit tests covering enqueue and local-prep failure and rollback scenarios to improve resilience and correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->