### PR TITLE
refactor: extract queue dispatch module

### DIFF
--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -1,0 +1,615 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	osexec "os/exec"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/backoff"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/stringutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+)
+
+type queueDispatchDeps struct {
+	queueStore          exec.QueueStore
+	dagRunStore         exec.DAGRunStore
+	procStore           exec.ProcStore
+	dagRunLeaseStore    exec.DAGRunLeaseStore
+	dispatchTaskStore   exec.DispatchTaskStore
+	dagExecutor         *DAGExecutor
+	isSuspended         IsSuspendedFunc
+	backoffConfig       BackoffConfig
+	leaseStaleThreshold time.Duration
+	isClosed            func() bool
+	wakeUp              func()
+}
+
+// queueDispatcher owns queue-item dispatch decisions after a queue has capacity.
+type queueDispatcher struct {
+	queueStore          exec.QueueStore
+	dagRunStore         exec.DAGRunStore
+	procStore           exec.ProcStore
+	dagRunLeaseStore    exec.DAGRunLeaseStore
+	dispatchTaskStore   exec.DispatchTaskStore
+	dagExecutor         *DAGExecutor
+	isSuspended         IsSuspendedFunc
+	backoffConfig       BackoffConfig
+	leaseStaleThreshold time.Duration
+	isClosed            func() bool
+	wakeUp              func()
+}
+
+type queueDispatchBatch struct {
+	items          []exec.QueuedItemData
+	maxConcurrency int
+	aliveCount     int
+}
+
+func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
+	if deps.isSuspended == nil {
+		deps.isSuspended = func(context.Context, string) bool { return false }
+	}
+	if deps.isClosed == nil {
+		deps.isClosed = func() bool { return false }
+	}
+	if deps.wakeUp == nil {
+		deps.wakeUp = func() {}
+	}
+	return &queueDispatcher{
+		queueStore:          deps.queueStore,
+		dagRunStore:         deps.dagRunStore,
+		procStore:           deps.procStore,
+		dagRunLeaseStore:    deps.dagRunLeaseStore,
+		dispatchTaskStore:   deps.dispatchTaskStore,
+		dagExecutor:         deps.dagExecutor,
+		isSuspended:         deps.isSuspended,
+		backoffConfig:       deps.backoffConfig,
+		leaseStaleThreshold: deps.leaseStaleThreshold,
+		isClosed:            deps.isClosed,
+		wakeUp:              deps.wakeUp,
+	}
+}
+
+func (d *queueDispatcher) selectDispatchBatch(
+	ctx context.Context,
+	queueName string,
+	items []exec.QueuedItemData,
+	maxConcurrency int,
+	inflightCount int,
+) (queueDispatchBatch, error) {
+	localAliveCount, err := d.procStore.CountAlive(ctx, queueName)
+	if err != nil {
+		logger.Error(ctx, "Failed to count alive processes", tag.Error(err), tag.Queue(queueName))
+		return queueDispatchBatch{}, fmt.Errorf("count alive processes: %w", err)
+	}
+
+	distributedAliveCount, err := d.countActiveDistributedRuns(ctx, queueName)
+	if err != nil {
+		logger.Error(ctx, "Failed to count distributed leases", tag.Error(err), tag.Queue(queueName))
+		return queueDispatchBatch{}, fmt.Errorf("count distributed leases: %w", err)
+	}
+	outstandingDispatchCount, err := d.countOutstandingDispatchReservations(ctx, queueName)
+	if err != nil {
+		logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
+		return queueDispatchBatch{}, fmt.Errorf("count outstanding distributed dispatch reservations: %w", err)
+	}
+	aliveCount := localAliveCount + distributedAliveCount
+	freeSlots := maxConcurrency - aliveCount - inflightCount - outstandingDispatchCount
+
+	logger.Debug(ctx, "Queue capacity check",
+		tag.MaxConcurrency(maxConcurrency),
+		tag.Alive(aliveCount),
+		slog.Int("outstanding-dispatches", outstandingDispatchCount),
+		tag.Count(freeSlots),
+	)
+
+	if freeSlots <= 0 {
+		logger.Debug(ctx, "Max concurrency reached",
+			tag.MaxConcurrency(maxConcurrency),
+			tag.Alive(aliveCount),
+		)
+		return queueDispatchBatch{}, nil
+	}
+
+	runnableItems, err := d.selectRunnableQueueItems(ctx, items, freeSlots)
+	if err != nil {
+		logger.Error(ctx, "Failed to select runnable queue items", tag.Error(err), tag.Queue(queueName))
+		return queueDispatchBatch{}, fmt.Errorf("select runnable queue items: %w", err)
+	}
+	if len(runnableItems) == 0 {
+		logger.Debug(ctx, "No queue items eligible for a new dispatch attempt")
+		return queueDispatchBatch{}, nil
+	}
+
+	return queueDispatchBatch{
+		items:          runnableItems,
+		maxConcurrency: maxConcurrency,
+		aliveCount:     aliveCount,
+	}, nil
+}
+
+func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.QueuedItemData, queueName string, incInflight, decInflight func()) bool {
+	if d.isClosed() {
+		return false
+	}
+
+	data, err := item.Data()
+	if err != nil {
+		logger.Error(ctx, "Failed to get item data", tag.Error(err))
+		return false
+	}
+
+	runRef := *data
+	runID := runRef.ID
+	ctx = logger.WithValues(ctx, tag.RunID(runID))
+	logger.Debug(ctx, "Processing queue item", tag.Name(runRef.Name))
+
+	running, err := d.procStore.IsRunAlive(ctx, queueName, runRef)
+	if err != nil {
+		logger.Error(ctx, "Failed to check if run is alive", tag.Error(err))
+		return false
+	}
+	if running {
+		logger.Warn(ctx, "DAG run is already running, discarding")
+		return true
+	}
+
+	attempt, err := d.dagRunStore.FindAttempt(ctx, runRef)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			logger.Error(ctx, "DAG run not found, discarding")
+			return true
+		}
+		logger.Error(ctx, "Failed to find run", tag.Error(err))
+		return false
+	}
+
+	if attempt.Hidden() {
+		logger.Info(ctx, "DAG run is hidden, discarding")
+		return true
+	}
+
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		if errors.Is(err, exec.ErrCorruptedStatusFile) {
+			logger.Error(ctx, "Status file is corrupted, marking as invalid", tag.Error(err))
+			return true
+		}
+		logger.Error(ctx, "Failed to read status", tag.Error(err))
+		return false
+	}
+
+	if status.Status != core.Queued {
+		logger.Info(ctx, "Status is not queued, skipping", tag.Status(status.Status.String()))
+		return true
+	}
+
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil {
+		logger.Error(ctx, "Failed to read DAG", tag.Error(err), tag.DAG(runRef.Name))
+		return false
+	}
+
+	if isSchedulerManagedTriggerType(status.TriggerType) && isSuspendedDAG(ctx, d.isSuspended, status, dag) {
+		if err := d.dropSuspendedQueuedRun(ctx, queueName, runRef, attempt.ID(), status); err != nil {
+			logger.Error(ctx, "Failed to drop suspended queued DAG run", tag.Error(err))
+		}
+		return false
+	}
+
+	if schedTime, err := time.Parse(time.RFC3339, status.ScheduleTime); err == nil {
+		if queueAge := time.Since(schedTime); queueAge > queueAgeWarningThreshold {
+			logger.Warn(ctx, "Queued item has been waiting for dispatch",
+				tag.DAG(runRef.Name),
+				slog.Duration("queue_age", queueAge),
+			)
+		}
+	}
+
+	incInflight()
+	defer decInflight()
+
+	if d.dagExecutor.IsDistributed(dag) {
+		return d.dispatchAndWaitForStartup(ctx, queueName, runRef, dag, runID, status)
+	}
+
+	execErrCh := make(chan error, 1)
+	go func() {
+		defer d.wakeUp()
+		if err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType, status.ScheduleTime); err != nil {
+			logger.Error(ctx, "Failed to execute DAG", tag.Error(err))
+			if isPreStartExecutionFailure(err) {
+				select {
+				case execErrCh <- err:
+				default:
+				}
+			}
+		}
+	}()
+
+	return d.waitForStartup(ctx, queueName, runRef, startupWaitState{
+		launchedAt: time.Now(),
+		execErrCh:  execErrCh,
+	})
+}
+
+func (d *queueDispatcher) dropSuspendedQueuedRun(
+	ctx context.Context,
+	queueName string,
+	runRef exec.DAGRunRef,
+	attemptID string,
+	status *exec.DAGRunStatus,
+) error {
+	finishedAt := stringutil.FormatTime(time.Now().UTC())
+	currentStatus, swapped, err := d.dagRunStore.CompareAndSwapLatestAttemptStatus(
+		ctx,
+		runRef,
+		attemptID,
+		core.Queued,
+		func(latest *exec.DAGRunStatus) error {
+			latest.Status = core.Aborted
+			latest.FinishedAt = finishedAt
+			latest.Error = suspendedQueueDropReason
+			latest.WorkerID = ""
+			latest.PID = 0
+			latest.LeaseAt = 0
+			return nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("abort suspended queued DAG run: %w", err)
+	}
+
+	if _, err := d.queueStore.DequeueByDAGRunID(ctx, queueName, runRef); err != nil && !errors.Is(err, exec.ErrQueueItemNotFound) {
+		return fmt.Errorf("dequeue suspended queued DAG run: %w", err)
+	}
+
+	if swapped {
+		logger.Info(ctx, "Dropped queued scheduler-managed run for suspended DAG",
+			tag.Status(core.Aborted.String()),
+			slog.String("trigger_type", status.TriggerType.String()),
+		)
+		return nil
+	}
+
+	logger.Info(ctx, "Removed stale queued scheduler-managed run for suspended DAG",
+		slog.String("trigger_type", status.TriggerType.String()),
+		slog.String("current_status", currentStatusString(currentStatus)),
+	)
+	return nil
+}
+
+func (d *queueDispatcher) dispatchAndWaitForStartup(
+	ctx context.Context,
+	queueName string,
+	runRef exec.DAGRunRef,
+	dag *core.DAG,
+	runID string,
+	dagStatus *exec.DAGRunStatus,
+) bool {
+	policy := backoff.NewExponentialBackoffPolicy(d.backoffConfig.InitialInterval)
+	policy.MaxInterval = d.backoffConfig.MaxInterval
+	policy.MaxRetries = d.backoffConfig.MaxRetries
+	retryCtx := backoff.WithRetryFailureLogLevel(ctx, slog.LevelInfo)
+
+	launchedAt := time.Now()
+	var started bool
+	dispatched := false
+
+	operation := func(ctx context.Context) error {
+		if err := d.checkContextAndQuit(ctx); err != nil {
+			return err
+		}
+
+		if !dispatched {
+			err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY,
+				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime)
+			if err != nil {
+				var staleErr *exec.StaleQueueDispatchError
+				if errors.As(err, &staleErr) {
+					return backoff.PermanentError(err)
+				}
+				if errors.Is(err, backoff.ErrPermanent) {
+					logger.Error(ctx, "Permanent dispatch failure", tag.Error(err))
+					return err
+				}
+				logger.Warn(ctx, "Transient dispatch failure, will retry", tag.Error(err))
+				return err
+			}
+			dispatched = true
+		}
+
+		var err error
+		started, err = d.checkStartupStatus(ctx, queueName, runRef, startupWaitState{
+			launchedAt: launchedAt,
+		})
+		return err
+	}
+
+	if err := backoff.Retry(retryCtx, operation, policy, nil); err != nil {
+		var staleErr *exec.StaleQueueDispatchError
+		if errors.As(err, &staleErr) {
+			logger.Info(ctx, "Discarding stale distributed queue dispatch",
+				tag.DAG(runRef.Name),
+				tag.RunID(runRef.ID),
+				tag.Queue(queueName),
+				tag.Error(staleErr),
+			)
+			return true
+		}
+		logger.Error(ctx, "Failed to dispatch DAG after retries", tag.Error(err))
+	}
+
+	defer d.wakeUp()
+	return started
+}
+
+func (d *queueDispatcher) waitForStartup(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) bool {
+	policy := backoff.NewExponentialBackoffPolicy(d.backoffConfig.InitialInterval)
+	policy.MaxInterval = d.backoffConfig.MaxInterval
+	policy.MaxRetries = d.backoffConfig.MaxRetries
+
+	var started bool
+	operation := func(ctx context.Context) error {
+		var err error
+		started, err = d.checkStartupStatus(ctx, queueName, runRef, waitState)
+		return err
+	}
+
+	if err := backoff.Retry(ctx, operation, policy, nil); err != nil {
+		logger.Error(ctx, "Failed to execute DAG after retries", tag.Error(err))
+	}
+
+	return started
+}
+
+func (d *queueDispatcher) checkStartupStatus(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) (bool, error) {
+	if err := d.checkContextAndQuit(ctx); err != nil {
+		return false, err
+	}
+	if err := readStartupExecutionError(waitState.execErrCh); err != nil {
+		logger.Warn(ctx, "DAG execution failed before startup was observed", tag.Error(err))
+		return false, backoff.PermanentError(err)
+	}
+
+	isAlive, err := d.procStore.IsRunAlive(ctx, queueName, runRef)
+	if err != nil {
+		logger.Warn(ctx, "Failed to check run liveness", tag.Error(err), tag.Queue(queueName), tag.RunID(runRef.ID))
+	} else if isAlive {
+		logger.Info(ctx, "DAG run has started (heartbeat detected)")
+		return true, nil
+	}
+	if d.inStartupGracePeriod(waitState.launchedAt) && d.dagRunLeaseStore == nil {
+		return false, errNotStarted
+	}
+
+	attempt, err := d.dagRunStore.FindAttempt(ctx, runRef)
+	if err != nil {
+		logger.Debug(ctx, "Failed to read attempt, keep checking")
+		return false, err
+	}
+
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if status.Status != core.Queued {
+		logger.Info(ctx, "DAG execution has started or finished", tag.Status(status.Status.String()))
+		return true, nil
+	}
+	started, err := d.hasFreshDistributedLease(ctx, queueName, runRef, attempt, status)
+	if err != nil {
+		logger.Warn(ctx, "Failed to check distributed run lease",
+			tag.Error(err),
+			tag.Queue(queueName),
+			tag.RunID(runRef.ID),
+		)
+	} else if started {
+		logger.Info(ctx, "DAG run has started (distributed lease detected)")
+		return true, nil
+	}
+	if d.inStartupGracePeriod(waitState.launchedAt) {
+		return false, errNotStarted
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return false, errNotStarted
+}
+
+func (d *queueDispatcher) inStartupGracePeriod(launchedAt time.Time) bool {
+	grace := d.backoffConfig.StartupGracePeriod
+	return grace > 0 && time.Since(launchedAt) < grace
+}
+
+func (d *queueDispatcher) selectRunnableQueueItems(
+	ctx context.Context,
+	items []exec.QueuedItemData,
+	freeSlots int,
+) ([]exec.QueuedItemData, error) {
+	if freeSlots <= 0 {
+		return nil, nil
+	}
+
+	runnable := make([]exec.QueuedItemData, 0, min(freeSlots, len(items)))
+	for _, item := range items {
+		if len(runnable) >= freeSlots {
+			break
+		}
+		if d.dispatchTaskStore != nil {
+			runRef, err := item.Data()
+			if err != nil {
+				logger.Error(ctx, "Failed to get item data while selecting runnable queue items", tag.Error(err))
+				continue
+			}
+			reserved, err := d.hasOutstandingDispatchReservation(ctx, *runRef)
+			if err != nil {
+				return nil, err
+			}
+			if reserved {
+				logger.Debug(ctx, "Skipping queue item with outstanding distributed dispatch reservation",
+					tag.RunID(runRef.ID),
+				)
+				continue
+			}
+		}
+		runnable = append(runnable, item)
+	}
+
+	return runnable, nil
+}
+
+func (d *queueDispatcher) hasOutstandingDispatchReservation(ctx context.Context, runRef exec.DAGRunRef) (bool, error) {
+	if d.dispatchTaskStore == nil {
+		return false, nil
+	}
+
+	attempt, err := d.dagRunStore.FindAttempt(ctx, runRef)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if attempt.Hidden() {
+		return false, nil
+	}
+
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		if errors.Is(err, exec.ErrNoStatusData) || errors.Is(err, exec.ErrCorruptedStatusFile) {
+			return false, nil
+		}
+		return false, err
+	}
+	if status == nil || status.Status != core.Queued {
+		return false, nil
+	}
+
+	attemptKey := queueAttemptKey(runRef, attempt, status)
+	if attemptKey == "" {
+		return false, nil
+	}
+	return d.dispatchTaskStore.HasOutstandingAttempt(ctx, attemptKey, d.leaseStaleThresholdOrDefault())
+}
+
+func (d *queueDispatcher) countActiveDistributedRuns(ctx context.Context, queueName string) (int, error) {
+	if d.dagRunLeaseStore == nil {
+		return 0, nil
+	}
+
+	leases, err := d.dagRunLeaseStore.ListByQueue(ctx, queueName)
+	if err != nil {
+		return 0, fmt.Errorf("list distributed leases for queue %q: %w", queueName, err)
+	}
+
+	count := 0
+	staleThreshold := d.leaseStaleThresholdOrDefault()
+	now := time.Now().UTC()
+	for _, lease := range leases {
+		if lease.IsFresh(now, staleThreshold) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (d *queueDispatcher) countOutstandingDispatchReservations(ctx context.Context, queueName string) (int, error) {
+	if d.dispatchTaskStore == nil {
+		return 0, nil
+	}
+	count, err := d.dispatchTaskStore.CountOutstandingByQueue(ctx, queueName, d.leaseStaleThresholdOrDefault())
+	if err != nil {
+		return 0, fmt.Errorf("list outstanding distributed dispatches for queue %q: %w", queueName, err)
+	}
+	return count, nil
+}
+
+func (d *queueDispatcher) hasFreshDistributedLease(
+	ctx context.Context,
+	queueName string,
+	runRef exec.DAGRunRef,
+	attempt exec.DAGRunAttempt,
+	status *exec.DAGRunStatus,
+) (bool, error) {
+	if d.dagRunLeaseStore == nil || status == nil {
+		return false, nil
+	}
+
+	attemptID := status.AttemptID
+	if attemptID == "" && attempt != nil {
+		attemptID = attempt.ID()
+	}
+	attemptKey := queueAttemptKey(runRef, attempt, status)
+	if attemptKey == "" {
+		return false, nil
+	}
+
+	lease, err := d.dagRunLeaseStore.Get(ctx, attemptKey)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunLeaseNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if lease == nil {
+		return false, nil
+	}
+	if lease.DAGRun != runRef {
+		return false, nil
+	}
+	if queueName != "" && lease.QueueName != "" && lease.QueueName != queueName {
+		return false, nil
+	}
+	if attemptID != "" && lease.AttemptID != "" && lease.AttemptID != attemptID {
+		return false, nil
+	}
+
+	return lease.IsFresh(time.Now().UTC(), d.leaseStaleThresholdOrDefault()), nil
+}
+
+func (d *queueDispatcher) leaseStaleThresholdOrDefault() time.Duration {
+	if d.leaseStaleThreshold <= 0 {
+		return exec.DefaultStaleLeaseThreshold
+	}
+	return d.leaseStaleThreshold
+}
+
+func (d *queueDispatcher) checkContextAndQuit(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		logger.Debug(ctx, "Context canceled")
+		return backoff.PermanentError(ctx.Err())
+	default:
+	}
+	if d.isClosed() {
+		logger.Info(ctx, "Processor is closed")
+		return backoff.PermanentError(errProcessorClosed)
+	}
+	return nil
+}
+
+// isPreStartExecutionFailure reports whether an execution error proves the DAG
+// never reached an observable started state. Spawn and dispatch failures should
+// abort the startup wait immediately, while process exit errors should continue
+// to rely on heartbeat/status because the attempt did start.
+func isPreStartExecutionFailure(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var exitErr *osexec.ExitError
+	return !errors.As(err, &exitErr)
+}

--- a/internal/service/scheduler/queue_dispatcher_test.go
+++ b/internal/service/scheduler/queue_dispatcher_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueDispatcher_SelectRunnableQueueItemsSkipsOutstandingReservations(t *testing.T) {
+	f := newQueueFixture(t).withDAG("dispatcher-select-dag", 2).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second)).
+		simulateQueue(2, false)
+
+	f.enqueueRuns(2)
+
+	reservedRef := exec.NewDAGRunRef(f.dag.Name, "run-1")
+	reservedAttempt, err := f.dagRunStore.FindAttempt(f.ctx, reservedRef)
+	require.NoError(t, err)
+	reservedStatus, err := reservedAttempt.ReadStatus(f.ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &coordinatorv1.Task{
+		DagRunId:   reservedRef.ID,
+		Target:     f.dag.Name,
+		QueueName:  f.dag.Name,
+		AttemptId:  reservedAttempt.ID(),
+		AttemptKey: queueAttemptKey(reservedRef, reservedAttempt, reservedStatus),
+	}))
+
+	items, err := f.queueStore.List(f.ctx, f.dag.Name)
+	require.NoError(t, err)
+
+	dispatcher := newQueueDispatcher(queueDispatchDeps{
+		dagRunStore:         f.dagRunStore,
+		dispatchTaskStore:   f.dispatchStore,
+		leaseStaleThreshold: 5 * time.Second,
+	})
+	runnable, err := dispatcher.selectRunnableQueueItems(f.ctx, items, 1)
+	require.NoError(t, err)
+	require.Len(t, runnable, 1)
+
+	selectedRef, err := runnable[0].Data()
+	require.NoError(t, err)
+	assert.Equal(t, "run-2", selectedRef.ID)
+}

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -6,22 +6,15 @@ package scheduler
 import (
 	"context"
 	"errors"
-	"fmt"
-	"log/slog"
-	osexec "os/exec"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/dagucloud/dagu/internal/cmn/backoff"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/stringutil"
-	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 const queueAgeWarningThreshold = 2 * time.Minute
@@ -298,8 +291,23 @@ func (p *QueueProcessor) isClosed() bool {
 	}
 }
 
+func (p *QueueProcessor) newQueueDispatcher() *queueDispatcher {
+	return newQueueDispatcher(queueDispatchDeps{
+		queueStore:          p.queueStore,
+		dagRunStore:         p.dagRunStore,
+		procStore:           p.procStore,
+		dagRunLeaseStore:    p.dagRunLeaseStore,
+		dispatchTaskStore:   p.dispatchTaskStore,
+		dagExecutor:         p.dagExecutor,
+		isSuspended:         p.isSuspended,
+		backoffConfig:       p.backoffConfig,
+		leaseStaleThreshold: p.leaseStaleThreshold,
+		isClosed:            p.isClosed,
+		wakeUp:              p.wakeUp,
+	})
+}
+
 // ProcessQueueItems processes items in the specified queue.
-// It returns true if there are more items to process in the queue.
 func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string) {
 	if p.isClosed() {
 		return
@@ -325,61 +333,24 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 	}
 
 	defer p.wakeUp()
-
-	localAliveCount, err := p.procStore.CountAlive(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count alive processes", tag.Error(err), tag.Queue(queueName))
-		return
-	}
-
-	distributedAliveCount, err := p.countActiveDistributedRuns(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count distributed leases", tag.Error(err), tag.Queue(queueName))
-		return
-	}
-	outstandingDispatchCount, err := p.countOutstandingDispatchReservations(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
-		return
-	}
-	aliveCount := localAliveCount + distributedAliveCount
+	dispatcher := p.newQueueDispatcher()
 
 	maxConcurrency := q.getMaxConcurrency()
-	inflightCount := q.getInflight()
-	freeSlots := maxConcurrency - aliveCount - inflightCount - outstandingDispatchCount
-
-	logger.Debug(ctx, "Queue capacity check",
-		tag.MaxConcurrency(maxConcurrency),
-		tag.Alive(aliveCount),
-		slog.Int("outstanding-dispatches", outstandingDispatchCount),
-		tag.Count(freeSlots),
-	)
-
-	if freeSlots <= 0 {
-		logger.Debug(ctx, "Max concurrency reached",
-			tag.MaxConcurrency(maxConcurrency),
-			tag.Alive(aliveCount),
-		)
-		return
-	}
-
-	runnableItems, err := p.selectRunnableQueueItems(ctx, items, freeSlots)
+	batch, err := dispatcher.selectDispatchBatch(ctx, queueName, items, maxConcurrency, q.getInflight())
 	if err != nil {
-		logger.Error(ctx, "Failed to select runnable queue items", tag.Error(err), tag.Queue(queueName))
 		return
 	}
-	if len(runnableItems) == 0 {
-		logger.Debug(ctx, "No queue items eligible for a new dispatch attempt")
+	if len(batch.items) == 0 {
 		return
 	}
 	logger.Info(ctx, "Processing batch of items",
-		tag.Count(len(runnableItems)),
-		tag.MaxConcurrency(maxConcurrency),
-		tag.Alive(aliveCount),
+		tag.Count(len(batch.items)),
+		tag.MaxConcurrency(batch.maxConcurrency),
+		tag.Alive(batch.aliveCount),
 	)
 
 	var wg sync.WaitGroup
-	for _, item := range runnableItems {
+	for _, item := range batch.items {
 		wg.Add(1)
 		go func(queuedItem exec.QueuedItemData) {
 			defer wg.Done()
@@ -388,7 +359,7 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 					logger.Error(ctx, "Queue item processing panicked", tag.Error(panicToError(r)))
 				}
 			}()
-			if !p.processDAG(ctx, queuedItem, queueName, q.incInflight, q.decInflight) {
+			if !dispatcher.dispatchQueuedItem(ctx, queuedItem, queueName, q.incInflight, q.decInflight) {
 				return
 			}
 			data, err := queuedItem.Data()
@@ -407,238 +378,11 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 	wg.Wait()
 }
 
-func (p *QueueProcessor) processDAG(ctx context.Context, item exec.QueuedItemData, queueName string, incInflight, decInflight func()) bool {
-	if p.isClosed() {
-		return false
-	}
-
-	data, err := item.Data()
-	if err != nil {
-		logger.Error(ctx, "Failed to get item data", tag.Error(err))
-		return false
-	}
-
-	runRef := *data
-	runID := runRef.ID
-	ctx = logger.WithValues(ctx, tag.RunID(runID))
-	logger.Debug(ctx, "Processing queue item", tag.Name(runRef.Name))
-
-	running, err := p.procStore.IsRunAlive(ctx, queueName, runRef)
-	if err != nil {
-		logger.Error(ctx, "Failed to check if run is alive", tag.Error(err))
-		return false
-	}
-	if running {
-		logger.Warn(ctx, "DAG run is already running, discarding")
-		return true
-	}
-
-	attempt, err := p.dagRunStore.FindAttempt(ctx, runRef)
-	if err != nil {
-		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
-			logger.Error(ctx, "DAG run not found, discarding")
-			return true
-		}
-		logger.Error(ctx, "Failed to find run", tag.Error(err))
-		return false
-	}
-
-	if attempt.Hidden() {
-		logger.Info(ctx, "DAG run is hidden, discarding")
-		return true
-	}
-
-	status, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		if errors.Is(err, exec.ErrCorruptedStatusFile) {
-			logger.Error(ctx, "Status file is corrupted, marking as invalid", tag.Error(err))
-			return true
-		}
-		logger.Error(ctx, "Failed to read status", tag.Error(err))
-		return false
-	}
-
-	if status.Status != core.Queued {
-		logger.Info(ctx, "Status is not queued, skipping", tag.Status(status.Status.String()))
-		return true
-	}
-
-	dag, err := attempt.ReadDAG(ctx)
-	if err != nil {
-		logger.Error(ctx, "Failed to read DAG", tag.Error(err), tag.DAG(runRef.Name))
-		return false
-	}
-
-	if isSchedulerManagedTriggerType(status.TriggerType) && isSuspendedDAG(ctx, p.isSuspended, status, dag) {
-		if err := p.dropSuspendedQueuedRun(ctx, queueName, runRef, attempt.ID(), status); err != nil {
-			logger.Error(ctx, "Failed to drop suspended queued DAG run", tag.Error(err))
-		}
-		return false
-	}
-
-	// Log a warning if the item has been queued for too long.
-	if schedTime, err := time.Parse(time.RFC3339, status.ScheduleTime); err == nil {
-		if queueAge := time.Since(schedTime); queueAge > queueAgeWarningThreshold {
-			logger.Warn(ctx, "Queued item has been waiting for dispatch",
-				tag.DAG(runRef.Name),
-				slog.Duration("queue_age", queueAge),
-			)
-		}
-	}
-
-	incInflight()
-	defer decInflight()
-
-	// For distributed execution, dispatch synchronously inside the retry loop
-	// so transient "no available workers" errors are retried with backoff.
-	if p.dagExecutor.IsDistributed(dag) {
-		return p.dispatchAndWaitForStartup(ctx, queueName, runRef, dag, runID, status)
-	}
-
-	// For local execution, launch in a goroutine and poll for startup.
-	execErrCh := make(chan error, 1)
-	go func() {
-		defer p.wakeUp()
-		if err := p.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType, status.ScheduleTime); err != nil {
-			logger.Error(ctx, "Failed to execute DAG", tag.Error(err))
-			if isPreStartExecutionFailure(err) {
-				select {
-				case execErrCh <- err:
-				default:
-				}
-			}
-		}
-	}()
-
-	return p.waitForStartup(ctx, queueName, runRef, startupWaitState{
-		launchedAt: time.Now(),
-		execErrCh:  execErrCh,
-	})
-}
-
-func (p *QueueProcessor) dropSuspendedQueuedRun(
-	ctx context.Context,
-	queueName string,
-	runRef exec.DAGRunRef,
-	attemptID string,
-	status *exec.DAGRunStatus,
-) error {
-	finishedAt := stringutil.FormatTime(time.Now().UTC())
-	currentStatus, swapped, err := p.dagRunStore.CompareAndSwapLatestAttemptStatus(
-		ctx,
-		runRef,
-		attemptID,
-		core.Queued,
-		func(latest *exec.DAGRunStatus) error {
-			latest.Status = core.Aborted
-			latest.FinishedAt = finishedAt
-			latest.Error = suspendedQueueDropReason
-			latest.WorkerID = ""
-			latest.PID = 0
-			latest.LeaseAt = 0
-			return nil
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("abort suspended queued DAG run: %w", err)
-	}
-
-	if _, err := p.queueStore.DequeueByDAGRunID(ctx, queueName, runRef); err != nil && !errors.Is(err, exec.ErrQueueItemNotFound) {
-		return fmt.Errorf("dequeue suspended queued DAG run: %w", err)
-	}
-
-	if swapped {
-		logger.Info(ctx, "Dropped queued scheduler-managed run for suspended DAG",
-			tag.Status(core.Aborted.String()),
-			slog.String("trigger_type", status.TriggerType.String()),
-		)
-		return nil
-	}
-
-	logger.Info(ctx, "Removed stale queued scheduler-managed run for suspended DAG",
-		slog.String("trigger_type", status.TriggerType.String()),
-		slog.String("current_status", currentStatusString(currentStatus)),
-	)
-	return nil
-}
-
 func currentStatusString(status *exec.DAGRunStatus) string {
 	if status == nil {
 		return "unknown"
 	}
 	return status.Status.String()
-}
-
-// dispatchAndWaitForStartup handles distributed DAG execution by retrying
-// dispatch within the backoff loop. This ensures transient "no available workers"
-// errors are retried rather than immediately failing.
-func (p *QueueProcessor) dispatchAndWaitForStartup(
-	ctx context.Context,
-	queueName string,
-	runRef exec.DAGRunRef,
-	dag *core.DAG,
-	runID string,
-	dagStatus *exec.DAGRunStatus,
-) bool {
-	policy := backoff.NewExponentialBackoffPolicy(p.backoffConfig.InitialInterval)
-	policy.MaxInterval = p.backoffConfig.MaxInterval
-	policy.MaxRetries = p.backoffConfig.MaxRetries
-	retryCtx := backoff.WithRetryFailureLogLevel(ctx, slog.LevelInfo)
-
-	launchedAt := time.Now()
-	var started bool
-	dispatched := false
-
-	operation := func(ctx context.Context) error {
-		if err := p.checkContextAndQuit(ctx); err != nil {
-			return err
-		}
-
-		// If not yet dispatched (or last dispatch was a transient failure), try dispatch.
-		if !dispatched {
-			err := p.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY,
-				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime)
-			if err != nil {
-				var staleErr *exec.StaleQueueDispatchError
-				if errors.As(err, &staleErr) {
-					return backoff.PermanentError(err)
-				}
-				// Permanent dispatch error (e.g. selector mismatch): stop retrying.
-				if errors.Is(err, backoff.ErrPermanent) {
-					logger.Error(ctx, "Permanent dispatch failure", tag.Error(err))
-					return err
-				}
-				// Transient dispatch error (e.g. no available workers): retry.
-				logger.Warn(ctx, "Transient dispatch failure, will retry", tag.Error(err))
-				return err
-			}
-			dispatched = true
-		}
-
-		// Dispatch succeeded, now poll for startup.
-		var err error
-		started, err = p.checkStartupStatus(ctx, queueName, runRef, startupWaitState{
-			launchedAt: launchedAt,
-		})
-		return err
-	}
-
-	if err := backoff.Retry(retryCtx, operation, policy, nil); err != nil {
-		var staleErr *exec.StaleQueueDispatchError
-		if errors.As(err, &staleErr) {
-			logger.Info(ctx, "Discarding stale distributed queue dispatch",
-				tag.DAG(runRef.Name),
-				tag.RunID(runRef.ID),
-				tag.Queue(queueName),
-				tag.Error(staleErr),
-			)
-			return true
-		}
-		logger.Error(ctx, "Failed to dispatch DAG after retries", tag.Error(err))
-	}
-
-	defer p.wakeUp()
-	return started
 }
 
 func (p *QueueProcessor) wakeUp() {
@@ -670,88 +414,6 @@ func (p *QueueProcessor) removeInactiveQueues(activeQueues map[string]struct{}) 
 	}
 }
 
-// waitForStartup waits for the DAG execution to start using exponential backoff.
-func (p *QueueProcessor) waitForStartup(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) bool {
-	policy := backoff.NewExponentialBackoffPolicy(p.backoffConfig.InitialInterval)
-	policy.MaxInterval = p.backoffConfig.MaxInterval
-	policy.MaxRetries = p.backoffConfig.MaxRetries
-
-	var started bool
-	operation := func(ctx context.Context) error {
-		var err error
-		started, err = p.checkStartupStatus(ctx, queueName, runRef, waitState)
-		return err
-	}
-
-	if err := backoff.Retry(ctx, operation, policy, nil); err != nil {
-		logger.Error(ctx, "Failed to execute DAG after retries", tag.Error(err))
-	}
-
-	return started
-}
-
-// checkStartupStatus checks if the DAG execution has started.
-func (p *QueueProcessor) checkStartupStatus(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) (bool, error) {
-	if err := p.checkContextAndQuit(ctx); err != nil {
-		return false, err
-	}
-	if err := readStartupExecutionError(waitState.execErrCh); err != nil {
-		logger.Warn(ctx, "DAG execution failed before startup was observed", tag.Error(err))
-		return false, backoff.PermanentError(err)
-	}
-
-	isAlive, err := p.procStore.IsRunAlive(ctx, queueName, runRef)
-	if err != nil {
-		logger.Warn(ctx, "Failed to check run liveness", tag.Error(err), tag.Queue(queueName), tag.RunID(runRef.ID))
-	} else if isAlive {
-		logger.Info(ctx, "DAG run has started (heartbeat detected)")
-		return true, nil
-	}
-	if p.inStartupGracePeriod(waitState.launchedAt) && p.dagRunLeaseStore == nil {
-		return false, errNotStarted
-	}
-
-	attempt, err := p.dagRunStore.FindAttempt(ctx, runRef)
-	if err != nil {
-		logger.Debug(ctx, "Failed to read attempt, keep checking")
-		return false, err
-	}
-
-	status, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if status.Status != core.Queued {
-		logger.Info(ctx, "DAG execution has started or finished", tag.Status(status.Status.String()))
-		return true, nil
-	}
-	started, err := p.hasFreshDistributedLease(ctx, queueName, runRef, attempt, status)
-	if err != nil {
-		logger.Warn(ctx, "Failed to check distributed run lease",
-			tag.Error(err),
-			tag.Queue(queueName),
-			tag.RunID(runRef.ID),
-		)
-	} else if started {
-		logger.Info(ctx, "DAG run has started (distributed lease detected)")
-		return true, nil
-	}
-	if p.inStartupGracePeriod(waitState.launchedAt) {
-		return false, errNotStarted
-	}
-	if err != nil {
-		return false, err
-	}
-
-	return false, errNotStarted
-}
-
-func (p *QueueProcessor) inStartupGracePeriod(launchedAt time.Time) bool {
-	grace := p.backoffConfig.StartupGracePeriod
-	return grace > 0 && time.Since(launchedAt) < grace
-}
-
 func readStartupExecutionError(execErrCh <-chan error) error {
 	select {
 	case err := <-execErrCh:
@@ -759,168 +421,6 @@ func readStartupExecutionError(execErrCh <-chan error) error {
 	default:
 		return nil
 	}
-}
-
-func (p *QueueProcessor) selectRunnableQueueItems(
-	ctx context.Context,
-	items []exec.QueuedItemData,
-	freeSlots int,
-) ([]exec.QueuedItemData, error) {
-	if freeSlots <= 0 {
-		return nil, nil
-	}
-
-	runnable := make([]exec.QueuedItemData, 0, min(freeSlots, len(items)))
-	for _, item := range items {
-		if len(runnable) >= freeSlots {
-			break
-		}
-		if p.dispatchTaskStore != nil {
-			runRef, err := item.Data()
-			if err != nil {
-				logger.Error(ctx, "Failed to get item data while selecting runnable queue items", tag.Error(err))
-				continue
-			}
-			reserved, err := p.hasOutstandingDispatchReservation(ctx, *runRef)
-			if err != nil {
-				return nil, err
-			}
-			if reserved {
-				logger.Debug(ctx, "Skipping queue item with outstanding distributed dispatch reservation",
-					tag.RunID(runRef.ID),
-				)
-				continue
-			}
-		}
-		runnable = append(runnable, item)
-	}
-
-	return runnable, nil
-}
-
-// isPreStartExecutionFailure reports whether an execution error proves the DAG
-// never reached an observable started state. Spawn and dispatch failures should
-// abort the startup wait immediately, while process exit errors should continue
-// to rely on heartbeat/status because the attempt did start.
-func isPreStartExecutionFailure(err error) bool {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	var exitErr *osexec.ExitError
-	return !errors.As(err, &exitErr)
-}
-
-// countActiveDistributedRuns counts distributed runs (non-empty WorkerID) that
-// belong to the given queue/proc-group and have a fresh lease. These runs are
-// invisible to the local procStore but must count against queue concurrency.
-func (p *QueueProcessor) countActiveDistributedRuns(ctx context.Context, queueName string) (int, error) {
-	if p.dagRunLeaseStore == nil {
-		return 0, nil
-	}
-
-	leases, err := p.dagRunLeaseStore.ListByQueue(ctx, queueName)
-	if err != nil {
-		return 0, fmt.Errorf("list distributed leases for queue %q: %w", queueName, err)
-	}
-
-	count := 0
-	staleThreshold := p.leaseStaleThresholdOrDefault()
-	now := time.Now().UTC()
-	for _, lease := range leases {
-		if lease.IsFresh(now, staleThreshold) {
-			count++
-		}
-	}
-	return count, nil
-}
-
-func (p *QueueProcessor) countOutstandingDispatchReservations(ctx context.Context, queueName string) (int, error) {
-	if p.dispatchTaskStore == nil {
-		return 0, nil
-	}
-	count, err := p.dispatchTaskStore.CountOutstandingByQueue(ctx, queueName, p.leaseStaleThresholdOrDefault())
-	if err != nil {
-		return 0, fmt.Errorf("list outstanding distributed dispatches for queue %q: %w", queueName, err)
-	}
-	return count, nil
-}
-
-func (p *QueueProcessor) hasOutstandingDispatchReservation(ctx context.Context, runRef exec.DAGRunRef) (bool, error) {
-	if p.dispatchTaskStore == nil {
-		return false, nil
-	}
-
-	attempt, err := p.dagRunStore.FindAttempt(ctx, runRef)
-	if err != nil {
-		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	if attempt.Hidden() {
-		return false, nil
-	}
-
-	status, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		if errors.Is(err, exec.ErrNoStatusData) || errors.Is(err, exec.ErrCorruptedStatusFile) {
-			return false, nil
-		}
-		return false, err
-	}
-	if status == nil || status.Status != core.Queued {
-		return false, nil
-	}
-
-	attemptKey := queueAttemptKey(runRef, attempt, status)
-	if attemptKey == "" {
-		return false, nil
-	}
-	return p.dispatchTaskStore.HasOutstandingAttempt(ctx, attemptKey, p.leaseStaleThresholdOrDefault())
-}
-
-func (p *QueueProcessor) hasFreshDistributedLease(
-	ctx context.Context,
-	queueName string,
-	runRef exec.DAGRunRef,
-	attempt exec.DAGRunAttempt,
-	status *exec.DAGRunStatus,
-) (bool, error) {
-	if p.dagRunLeaseStore == nil || status == nil {
-		return false, nil
-	}
-
-	attemptID := status.AttemptID
-	if attemptID == "" && attempt != nil {
-		attemptID = attempt.ID()
-	}
-	attemptKey := queueAttemptKey(runRef, attempt, status)
-	if attemptKey == "" {
-		return false, nil
-	}
-
-	lease, err := p.dagRunLeaseStore.Get(ctx, attemptKey)
-	if err != nil {
-		if errors.Is(err, exec.ErrDAGRunLeaseNotFound) {
-			return false, nil
-		}
-		return false, err
-	}
-	if lease == nil {
-		return false, nil
-	}
-	if lease.DAGRun != runRef {
-		return false, nil
-	}
-	if queueName != "" && lease.QueueName != "" && lease.QueueName != queueName {
-		return false, nil
-	}
-	if attemptID != "" && lease.AttemptID != "" && lease.AttemptID != attemptID {
-		return false, nil
-	}
-
-	return lease.IsFresh(time.Now().UTC(), p.leaseStaleThresholdOrDefault()), nil
 }
 
 func queueAttemptKey(runRef exec.DAGRunRef, attempt exec.DAGRunAttempt, status *exec.DAGRunStatus) string {
@@ -946,18 +446,4 @@ func (p *QueueProcessor) leaseStaleThresholdOrDefault() time.Duration {
 		return exec.DefaultStaleLeaseThreshold
 	}
 	return p.leaseStaleThreshold
-}
-
-// checkContextAndQuit returns a permanent error if context is done or processor is closed.
-func (p *QueueProcessor) checkContextAndQuit(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		logger.Debug(ctx, "Context canceled")
-		return backoff.PermanentError(ctx.Err())
-	case <-p.quit:
-		logger.Info(ctx, "Processor is closed")
-		return backoff.PermanentError(errProcessorClosed)
-	default:
-		return nil
-	}
 }

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -20,13 +20,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newStartupTestProcessor(dagRunStore exec.DAGRunStore, procStore exec.ProcStore, cfg BackoffConfig) *QueueProcessor {
-	return &QueueProcessor{
+func newStartupTestDispatcher(dagRunStore exec.DAGRunStore, procStore exec.ProcStore, cfg BackoffConfig) *queueDispatcher {
+	return newQueueDispatcher(queueDispatchDeps{
 		dagRunStore:   dagRunStore,
 		procStore:     procStore,
-		quit:          make(chan struct{}),
 		backoffConfig: cfg,
-	}
+	})
 }
 
 type mockLeaseStore struct {
@@ -54,18 +53,18 @@ func (m *mockLeaseStore) ListByQueue(ctx context.Context, queueName string) ([]e
 
 func (m *mockLeaseStore) ListAll(context.Context) ([]exec.DAGRunLease, error) { return nil, nil }
 
-func TestQueueProcessor_CheckStartupStatus_WithinGraceSkipsAttemptLookup(t *testing.T) {
+func TestQueueDispatcher_CheckStartupStatus_WithinGraceSkipsAttemptLookup(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 
 	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(false, nil).Once()
 
-	p := newStartupTestProcessor(dagRunStore, procStore, BackoffConfig{
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
 		StartupGracePeriod: time.Second,
 	})
 
-	started, err := p.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
+	started, err := dispatcher.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
 		launchedAt: time.Now(),
 		execErrCh:  make(chan error, 1),
 	})
@@ -76,18 +75,18 @@ func TestQueueProcessor_CheckStartupStatus_WithinGraceSkipsAttemptLookup(t *test
 	procStore.AssertExpectations(t)
 }
 
-func TestQueueProcessor_CheckStartupStatus_HeartbeatSkipsAttemptLookup(t *testing.T) {
+func TestQueueDispatcher_CheckStartupStatus_HeartbeatSkipsAttemptLookup(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 
 	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(true, nil).Once()
 
-	p := newStartupTestProcessor(dagRunStore, procStore, BackoffConfig{
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
 		StartupGracePeriod: time.Second,
 	})
 
-	started, err := p.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
+	started, err := dispatcher.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
 		launchedAt: time.Now(),
 		execErrCh:  make(chan error, 1),
 	})
@@ -98,18 +97,18 @@ func TestQueueProcessor_CheckStartupStatus_HeartbeatSkipsAttemptLookup(t *testin
 	procStore.AssertExpectations(t)
 }
 
-func TestQueueProcessor_CheckStartupStatus_PreStartExecutionErrorIsPermanent(t *testing.T) {
+func TestQueueDispatcher_CheckStartupStatus_PreStartExecutionErrorIsPermanent(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 	execErrCh := make(chan error, 1)
 	execErrCh <- errors.New("dispatch failed")
 
-	p := newStartupTestProcessor(dagRunStore, procStore, BackoffConfig{
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
 		StartupGracePeriod: time.Second,
 	})
 
-	started, err := p.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
+	started, err := dispatcher.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
 		launchedAt: time.Now(),
 		execErrCh:  execErrCh,
 	})
@@ -120,7 +119,7 @@ func TestQueueProcessor_CheckStartupStatus_PreStartExecutionErrorIsPermanent(t *
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestQueueProcessor_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testing.T) {
+func TestQueueDispatcher_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testing.T) {
 	testCases := []struct {
 		name      string
 		status    core.Status
@@ -145,11 +144,11 @@ func TestQueueProcessor_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testin
 			procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(false, nil).Once()
 			dagRunStore.On("FindAttempt", mock.Anything, runRef).Return(attempt, nil).Once()
 
-			p := newStartupTestProcessor(dagRunStore, procStore, BackoffConfig{
+			dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
 				StartupGracePeriod: 50 * time.Millisecond,
 			})
 
-			started, err := p.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
+			started, err := dispatcher.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
 				launchedAt: time.Now().Add(-time.Second),
 				execErrCh:  make(chan error, 1),
 			})
@@ -167,7 +166,7 @@ func TestQueueProcessor_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testin
 	}
 }
 
-func TestQueueProcessor_CheckStartupStatus_AfterGracePropagatesLeaseLookupError(t *testing.T) {
+func TestQueueDispatcher_CheckStartupStatus_AfterGracePropagatesLeaseLookupError(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 	leaseStore := &mockLeaseStore{
@@ -186,12 +185,12 @@ func TestQueueProcessor_CheckStartupStatus_AfterGracePropagatesLeaseLookupError(
 	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(false, nil).Once()
 	dagRunStore.On("FindAttempt", mock.Anything, runRef).Return(attempt, nil).Once()
 
-	p := newStartupTestProcessor(dagRunStore, procStore, BackoffConfig{
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
 		StartupGracePeriod: 50 * time.Millisecond,
 	})
-	p.dagRunLeaseStore = leaseStore
+	dispatcher.dagRunLeaseStore = leaseStore
 
-	started, err := p.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
+	started, err := dispatcher.checkStartupStatus(context.Background(), "test-queue", runRef, startupWaitState{
 		launchedAt: time.Now().Add(-time.Second),
 		execErrCh:  make(chan error, 1),
 	})
@@ -248,7 +247,7 @@ func (m *mockDispatcher) RequestCancel(_ context.Context, _, _ string, _ *exec.D
 	return nil
 }
 
-func TestDispatchAndWaitForStartup_TransientRetryThenSuccess(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_TransientRetryThenSuccess(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
@@ -270,27 +269,25 @@ func TestDispatchAndWaitForStartup_TransientRetryThenSuccess(t *testing.T) {
 	// After dispatch succeeds, the process should become alive.
 	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(true, nil).Once()
 
-	p := &QueueProcessor{
+	dispatcher := newQueueDispatcher(queueDispatchDeps{
 		dagRunStore: dagRunStore,
 		procStore:   procStore,
 		dagExecutor: dagExec,
-		quit:        make(chan struct{}),
-		wakeUpCh:    make(chan struct{}, 1),
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
 			MaxRetries:         5,
 			StartupGracePeriod: 10 * time.Millisecond,
 		},
-	}
+	})
 
-	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
 	require.True(t, started)
 	require.GreaterOrEqual(t, disp.callCount.Load(), int32(3))
 	procStore.AssertExpectations(t)
 }
 
-func TestDispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 
@@ -307,27 +304,25 @@ func TestDispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded(t *testing.T) {
 	status := &exec.DAGRunStatus{Status: core.Queued, TriggerType: core.TriggerTypeScheduler}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 
-	p := &QueueProcessor{
+	dispatcher := newQueueDispatcher(queueDispatchDeps{
 		dagRunStore: dagRunStore,
 		procStore:   procStore,
 		dagExecutor: dagExec,
-		quit:        make(chan struct{}),
-		wakeUpCh:    make(chan struct{}, 1),
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
 			MaxRetries:         5,
 			StartupGracePeriod: 10 * time.Millisecond,
 		},
-	}
+	})
 
-	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
 	require.True(t, started)
 	require.Equal(t, int32(1), disp.callCount.Load())
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestDispatchAndWaitForStartup_RawStaleQueueDispatchStopsRetry(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_RawStaleQueueDispatchStopsRetry(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 
@@ -342,27 +337,25 @@ func TestDispatchAndWaitForStartup_RawStaleQueueDispatchStopsRetry(t *testing.T)
 	status := &exec.DAGRunStatus{Status: core.Queued, TriggerType: core.TriggerTypeScheduler}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 
-	p := &QueueProcessor{
+	dispatcher := newQueueDispatcher(queueDispatchDeps{
 		dagRunStore: dagRunStore,
 		procStore:   procStore,
 		dagExecutor: dagExec,
-		quit:        make(chan struct{}),
-		wakeUpCh:    make(chan struct{}, 1),
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
 			MaxRetries:         5,
 			StartupGracePeriod: 10 * time.Millisecond,
 		},
-	}
+	})
 
-	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
 	require.True(t, started)
 	require.Equal(t, int32(1), disp.callCount.Load())
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestDispatchAndWaitForStartup_PermanentErrorStopsRetry(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_PermanentErrorStopsRetry(t *testing.T) {
 	dagRunStore := &mockDAGRunStore{}
 	procStore := &mockProcStore{}
 
@@ -378,21 +371,19 @@ func TestDispatchAndWaitForStartup_PermanentErrorStopsRetry(t *testing.T) {
 	status := &exec.DAGRunStatus{Status: core.Queued, TriggerType: core.TriggerTypeScheduler}
 	runRef := exec.NewDAGRunRef("test-dag", "run-1")
 
-	p := &QueueProcessor{
+	dispatcher := newQueueDispatcher(queueDispatchDeps{
 		dagRunStore: dagRunStore,
 		procStore:   procStore,
 		dagExecutor: dagExec,
-		quit:        make(chan struct{}),
-		wakeUpCh:    make(chan struct{}, 1),
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
 			MaxRetries:         5,
 			StartupGracePeriod: 10 * time.Millisecond,
 		},
-	}
+	})
 
-	started := p.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
 	require.False(t, started)
 	// Should have been called exactly once (permanent error stops retries).
 	require.Equal(t, int32(1), disp.callCount.Load())

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -363,7 +363,7 @@ func TestQueueProcessor_SelectRunnableQueueItemsSkipsOutstandingReservations(t *
 	items, err := f.queueStore.List(f.ctx, "distributed-select-dag")
 	require.NoError(t, err)
 
-	runnable, err := f.processor.selectRunnableQueueItems(f.ctx, items, 1)
+	runnable, err := f.processor.newQueueDispatcher().selectRunnableQueueItems(f.ctx, items, 1)
 	require.NoError(t, err)
 	require.Len(t, runnable, 1)
 
@@ -394,14 +394,14 @@ func TestQueueProcessor_StaleOutstandingDispatchReservationsExpire(t *testing.T)
 	}))
 	agePendingDispatchReservationFiles(t, f.distributedDir, 2*time.Second)
 
-	count, err := f.processor.countOutstandingDispatchReservations(f.ctx, f.dag.Name)
+	count, err := f.processor.newQueueDispatcher().countOutstandingDispatchReservations(f.ctx, f.dag.Name)
 	require.NoError(t, err)
 	assert.Zero(t, count)
 
 	items, err := f.queueStore.List(f.ctx, f.dag.Name)
 	require.NoError(t, err)
 
-	runnable, err := f.processor.selectRunnableQueueItems(f.ctx, items, 1)
+	runnable, err := f.processor.newQueueDispatcher().selectRunnableQueueItems(f.ctx, items, 1)
 	require.NoError(t, err)
 	require.Len(t, runnable, 1)
 
@@ -466,23 +466,21 @@ func TestQueueProcessor_SuspendedManualQueuedRunStillDispatches(t *testing.T) {
 	procStore.On("IsRunAlive", mock.Anything, dagName, runRef).Return(true, nil).Once()
 	dispatcher := &mockDispatcher{}
 
-	processor := &QueueProcessor{
+	queueDispatcher := newQueueDispatcher(queueDispatchDeps{
 		queueStore:  f.queueStore,
 		dagRunStore: f.dagRunStore,
 		procStore:   procStore,
 		dagExecutor: NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil),
 		isSuspended: func(_ context.Context, name string) bool { return name == dagName },
-		quit:        make(chan struct{}),
-		wakeUpCh:    make(chan struct{}, 1),
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
 			MaxRetries:         2,
 			StartupGracePeriod: time.Second,
 		},
-	}
+	})
 
-	dispatched := processor.processDAG(f.ctx, items[0], dagName, func() {}, func() {})
+	dispatched := queueDispatcher.dispatchQueuedItem(f.ctx, items[0], dagName, func() {}, func() {})
 	require.True(t, dispatched)
 	assert.Equal(t, int32(1), dispatcher.callCount.Load())
 
@@ -568,7 +566,7 @@ func TestQueueProcessor_CheckStartupStatusTreatsRunningStatusAsStarted(t *testin
 	require.NoError(t, run.Write(f.ctx, status))
 	require.NoError(t, run.Close(f.ctx))
 
-	started, err := f.processor.checkStartupStatus(
+	started, err := f.processor.newQueueDispatcher().checkStartupStatus(
 		f.ctx,
 		f.dag.Name,
 		exec.NewDAGRunRef(f.dag.Name, "running-startup-run"),
@@ -603,7 +601,7 @@ func TestQueueProcessor_CheckStartupStatusTreatsFreshDistributedLeaseAsStarted(t
 		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
 	}))
 
-	started, err := f.processor.checkStartupStatus(
+	started, err := f.processor.newQueueDispatcher().checkStartupStatus(
 		f.ctx,
 		f.dag.Name,
 		exec.NewDAGRunRef(f.dag.Name, "lease-startup-run"),


### PR DESCRIPTION
## Summary

Refactors scheduler queue dispatching into a deeper module boundary so queue polling and dispatch/startup policy are no longer concentrated in `QueueProcessor`.

## Changes

- Extracted queue dispatch capacity, reservation, startup, and dispatch decisions into `queueDispatcher`.
- Kept `QueueProcessor` focused on queue polling, queue bookkeeping, batch handoff, and dequeue-after-success.
- Moved dispatch/startup tests to the dispatcher boundary and added direct dispatcher coverage for outstanding reservations.

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `go test ./internal/service/scheduler ./internal/service/coordinator ./internal/service/worker -count=1`