### PR TITLE
fix: show DAG tool preparation status

### DIFF
--- a/internal/tools/prepare.go
+++ b/internal/tools/prepare.go
@@ -6,7 +6,9 @@ package tools
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
+	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/core"
 )
 
@@ -21,10 +23,16 @@ func PrepareDAG(ctx context.Context, dag *core.DAG, installer Installer, opts In
 	if err := ValidateDAGSupported(dag); err != nil {
 		return nil, err
 	}
+	logger.Info(ctx, "Preparing DAG tools", slog.Int("packages", len(dag.Tools.Packages)))
 	manifest, err := installer.Install(ctx, dag.Tools, opts)
 	if err != nil {
 		return nil, fmt.Errorf("prepare DAG tools: %w", err)
 	}
+	commands := 0
+	if manifest != nil {
+		commands = len(manifest.Commands)
+	}
+	logger.Info(ctx, "DAG tools ready", slog.Int("commands", commands))
 	return EnvVars(manifest, basePath), nil
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -4,11 +4,13 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -117,6 +119,45 @@ func TestPrepareDAGInstallsDeclaredTools(t *testing.T) {
 	assert.Same(t, dag.Tools, installer.cfg)
 	assert.Equal(t, InstallOptions{ToolsDir: "/data/tools", WorkDir: "/work"}, installer.opts)
 	assert.Contains(t, envs, "PATH=/data/tools/aqua/envs/linux-amd64/hash/bin"+string(os.PathListSeparator)+"/usr/bin")
+}
+
+func TestPrepareDAGLogsToolPreparationStatus(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	ctx := logger.WithFixedLogger(context.Background(), logger.NewLogger(
+		logger.WithQuiet(),
+		logger.WithFormat("text"),
+		logger.WithWriter(&output),
+	))
+	installer := &fakeInstaller{
+		manifest: &Manifest{
+			RootDir:      "/data/tools/aqua/root",
+			EnvDir:       "/data/tools/aqua/envs/linux-amd64/hash",
+			BinDir:       "/data/tools/aqua/envs/linux-amd64/hash/bin",
+			Config:       "/data/tools/aqua/envs/linux-amd64/hash/aqua.yaml",
+			ManifestFile: "/data/tools/aqua/envs/linux-amd64/hash/manifest.json",
+			Commands: map[string]Command{
+				"jq": {Name: "jq", Package: "jqlang/jq", Version: "jq-1.7.1"},
+			},
+		},
+	}
+	dag := &core.DAG{
+		Name: "tool-dag",
+		Tools: &core.ToolConfig{
+			Provider: "aqua",
+			Packages: []core.ToolPackage{{
+				Package: "jqlang/jq",
+				Version: "jq-1.7.1",
+			}},
+		},
+	}
+
+	_, err := PrepareDAG(ctx, dag, installer, InstallOptions{}, "/usr/bin")
+
+	require.NoError(t, err)
+	assert.Contains(t, output.String(), "Preparing DAG tools")
+	assert.Contains(t, output.String(), "DAG tools ready")
 }
 
 func TestPrepareDAGRejectsUnsupportedExecutor(t *testing.T) {


### PR DESCRIPTION
## Summary

Show CLI-visible status messages while DAG tool preparation is running.

## Changes

- Log when Dagu starts preparing declared DAG tools before installer work begins.
- Log when declared DAG tools are ready after the manifest is resolved.
- Add regression coverage for tool preparation status output through the existing context logger.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- go test ./internal/tools -count=1
- go test ./internal/cmd -count=1
- git diff --check -- internal/tools/prepare.go internal/tools/tools_test.go


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DAG tool preparation now provides enhanced visibility with progress logging, showing the number of tool packages being prepared and confirmation when preparation completes, including the total count of manifest commands generated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->