### PR TITLE
refactor: stage DAG spec compiler

### DIFF
--- a/internal/core/exec/queue_abort_test.go
+++ b/internal/core/exec/queue_abort_test.go
@@ -31,7 +31,7 @@ func TestAbortQueuedDAGRun_PreservesPreviousVisibleAttempt(t *testing.T) {
 
 	require.NoError(t, exec.AbortQueuedDAGRun(ctx, store, runRef))
 
-	attempt, err := store.LatestAttempt(ctx, dag.Name)
+	attempt, err := store.FindAttempt(ctx, runRef)
 	require.NoError(t, err)
 	status, err := attempt.ReadStatus(ctx)
 	require.NoError(t, err)

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -737,7 +737,7 @@ func (s *dagBuildState) buildActionGraph() {
 	if handlerOn, err := buildHandlers(s.ctx, s.spec, s.result); err != nil {
 		s.errs = append(s.errs, core.NewValidationError("handlers", nil, err))
 	} else {
-		s.result.HandlerOn = handlerOn
+		s.result.HandlerOn = composeHandlerOn(s.result.HandlerOn, handlerOn)
 	}
 
 	if steps, err := buildSteps(s.ctx, s.spec, s.result); err != nil {
@@ -2909,6 +2909,28 @@ func buildDotenv(_ BuildContext, d *dag) ([]string, error) {
 		return []string{".env"}, nil
 	}
 	return d.Dotenv.Values(), nil
+}
+
+func composeHandlerOn(inherited, current core.HandlerOn) core.HandlerOn {
+	if current.Init != nil {
+		inherited.Init = current.Init
+	}
+	if current.Exit != nil {
+		inherited.Exit = current.Exit
+	}
+	if current.Success != nil {
+		inherited.Success = current.Success
+	}
+	if current.Failure != nil {
+		inherited.Failure = current.Failure
+	}
+	if current.Abort != nil {
+		inherited.Abort = current.Abort
+	}
+	if current.Wait != nil {
+		inherited.Wait = current.Wait
+	}
+	return inherited
 }
 
 func buildHandlers(ctx BuildContext, d *dag, result *core.DAG) (core.HandlerOn, error) {

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -511,23 +511,34 @@ type transform struct {
 	transformer Transformer[BuildContext, *dag]
 }
 
-// metadataTransformers are always run (for listing, scheduling, etc.)
-var metadataTransformers = []transform{
+type transformStage []transform
+
+// Metadata stages are always run (for listing, scheduling, etc.).
+var metadataIdentityStage = transformStage{
 	{"name", newTransformer("Name", buildName)},
 	{"group", newTransformer("Group", buildGroup)},
 	{"description", newTransformer("Description", buildDescription)},
 	{"type", newTransformer("Type", buildType)},
 	{"labels", newTransformer("Labels", buildLabels)},
-	// params must run BEFORE env so that env: values can reference ${param_name}
+}
+
+// Params must run before env so that env: values can reference ${param_name}.
+var metadataParamsEnvStage = transformStage{
 	{"params", newTransformer("Params", buildParams)},
 	{"default_params", newTransformer("DefaultParams", buildDefaultParams)},
 	{"param_defs", newTransformer("ParamDefs", buildParamDefs)},
 	{"param_schema", newTransformer("ParamSchema", buildParamSchema)},
 	{"params_json", newTransformer("ParamsJSON", buildParamsJSON)},
 	{"env", newTransformer("Env", buildEnvs)},
+}
+
+var metadataScheduleStage = transformStage{
 	{"schedule", newTransformer("Schedule", buildSchedule)},
 	{"stop_schedule", newTransformer("StopSchedule", buildStopSchedule)},
 	{"restart_schedule", newTransformer("RestartSchedule", buildRestartSchedule)},
+}
+
+var metadataExecutionPlacementStage = transformStage{
 	{"worker_selector", &workerSelectorTransformer{}},
 	{"timeout", newTransformer("Timeout", buildTimeout)},
 	{"delay", newTransformer("Delay", buildDelay)},
@@ -542,18 +553,34 @@ var metadataTransformers = []transform{
 	{"overlap_policy", newTransformer("OverlapPolicy", buildOverlapPolicy)},
 }
 
-// fullTransformers are only run when building the full DAG (not metadata-only)
-var fullTransformers = []transform{
+var metadataTransformStages = []transformStage{
+	metadataIdentityStage,
+	metadataParamsEnvStage,
+	metadataScheduleStage,
+	metadataExecutionPlacementStage,
+}
+
+// Full stages are only run when building the full DAG (not metadata-only).
+var fullRunOutputStage = transformStage{
 	{"log_dir", newTransformer("LogDir", buildLogDir)},
 	{"artifacts", newTransformer("Artifacts", buildArtifacts)},
 	{"log_output", newTransformer("LogOutput", buildLogOutput)},
+}
+
+var fullInteractionStage = transformStage{
 	{"mail_on", newTransformer("MailOn", buildMailOn)},
 	{"run_config", newTransformer("RunConfig", buildRunConfig)},
 	{"resources", newTransformer("Resources", buildResources)},
 	{"webhook", newTransformer("Webhook", buildWebhookConfig)},
+}
+
+var fullRetentionStage = transformStage{
 	{"hist_retention_days", newTransformer("HistRetentionDays", buildHistRetentionDays)},
 	{"hist_retention_runs", newTransformer("HistRetentionRuns", buildHistRetentionRuns)},
 	{"max_clean_up_time_sec", newTransformer("MaxCleanUpTime", buildMaxCleanUpTime)},
+}
+
+var fullExecutionDefaultsStage = transformStage{
 	{"shell", newTransformer("Shell", buildShell)},
 	{"shell_args", newTransformer("ShellArgs", buildShellArgs)},
 	{"working_dir", newTransformer("WorkingDir", buildWorkingDir)},
@@ -569,6 +596,9 @@ var fullTransformers = []transform{
 	{"secrets", newTransformer("Secrets", buildSecrets)},
 	{"tools", newTransformer("Tools", buildTools)},
 	{"dotenv", newTransformer("Dotenv", buildDotenv)},
+}
+
+var fullNotificationStage = transformStage{
 	{"smtp", newTransformer("SMTP", buildSMTPConfig)},
 	{"error_mail", newTransformer("ErrorMail", buildErrMailConfig)},
 	{"info_mail", newTransformer("InfoMail", buildInfoMailConfig)},
@@ -577,27 +607,38 @@ var fullTransformers = []transform{
 	{"otel", newTransformer("OTel", buildOTel)},
 }
 
+var fullTransformStages = []transformStage{
+	fullRunOutputStage,
+	fullInteractionStage,
+	fullRetentionStage,
+	fullExecutionDefaultsStage,
+	fullNotificationStage,
+}
+
 // runTransformers executes all transformers in the pipeline
 func runTransformers(ctx BuildContext, spec *dag, result *core.DAG) core.ErrorList {
 	var errs core.ErrorList
 	out := reflect.ValueOf(result).Elem()
 
-	// Always run metadata transformers
-	for _, t := range metadataTransformers {
-		if err := t.transformer.Transform(ctx, spec, out); err != nil {
-			errs = append(errs, wrapTransformError(t.name, err))
-		}
-	}
+	errs = append(errs, runTransformerStages(ctx, spec, out, metadataTransformStages)...)
 
 	// Run full transformers only when not in metadata-only mode
 	if !ctx.opts.Has(BuildFlagOnlyMetadata) {
-		for _, t := range fullTransformers {
+		errs = append(errs, runTransformerStages(ctx, spec, out, fullTransformStages)...)
+	}
+
+	return errs
+}
+
+func runTransformerStages(ctx BuildContext, spec *dag, out reflect.Value, stages []transformStage) core.ErrorList {
+	var errs core.ErrorList
+	for _, stage := range stages {
+		for _, t := range stage {
 			if err := t.transformer.Transform(ctx, spec, out); err != nil {
 				errs = append(errs, wrapTransformError(t.name, err))
 			}
 		}
 	}
-
 	return errs
 }
 
@@ -610,119 +651,153 @@ func wrapTransformError(name string, err error) error {
 	return core.NewValidationError(name, nil, err)
 }
 
-// build transforms the dag specification into a core.DAG.
-func (d *dag) build(ctx BuildContext) (*core.DAG, error) {
-	// Initialize with only Location (set from context, not spec)
+type dagBuildState struct {
+	ctx       BuildContext
+	spec      *dag
+	result    *core.DAG
+	effective *core.DAG
+	errs      core.ErrorList
+}
+
+func newDAGBuildState(ctx BuildContext, spec *dag) *dagBuildState {
 	result := &core.DAG{
 		Location: ctx.file,
 	}
-	var errs core.ErrorList
-	if err := validateHistoryRetentionConfig(d); err != nil {
-		errs = append(errs, err)
+	return &dagBuildState{
+		ctx:       ctx,
+		spec:      spec,
+		result:    result,
+		effective: result,
 	}
+}
 
-	// Initialize shared envScope state for thread-safe env var handling.
-	// Start with OS environment as base layer.
+func (s *dagBuildState) validateSpecShape() {
+	if err := validateHistoryRetentionConfig(s.spec); err != nil {
+		s.errs = append(s.errs, err)
+	}
+}
+
+func (s *dagBuildState) prepareParamEnvStage() {
 	baseScope := eval.NewEnvScope(nil, true)
 
-	// Pre-populate with build env from options (for retry with dotenv).
-	// This allows YAML to reference env vars that were loaded from .env files
-	// before the rebuild.
-	buildEnv := make(map[string]string, len(ctx.opts.BuildEnv))
-	maps.Copy(buildEnv, ctx.opts.BuildEnv)
+	buildEnv := make(map[string]string, len(s.ctx.opts.BuildEnv))
+	maps.Copy(buildEnv, s.ctx.opts.BuildEnv)
 	if len(buildEnv) > 0 {
 		baseScope = baseScope.WithEntries(buildEnv, eval.EnvSourceDotEnv)
 	}
 
-	ctx.envScope = &envScopeState{
+	s.ctx.envScope = &envScopeState{
 		scope:    baseScope,
 		buildEnv: buildEnv,
 	}
-	ctx.paramsState = &paramsState{}
+	s.ctx.paramsState = &paramsState{}
+}
 
-	// Run the transformer pipeline
-	errs = append(errs, runTransformers(ctx, d, result)...)
+func (s *dagBuildState) runFieldStages() {
+	s.errs = append(s.errs, runTransformers(s.ctx, s.spec, s.result)...)
+}
 
-	buildResult := result
-	if ctx.baseDAG != nil {
-		merged, err := composeBuildDAGContext(ctx.baseDAG, result, d)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to compose inherited DAG context: %w", err))
-		} else {
-			buildResult = merged
-		}
+func (s *dagBuildState) composeInheritedContext() {
+	if s.ctx.baseDAG == nil {
+		return
 	}
 
-	// Add deprecation warning for max_active_runs on local queues.
+	merged, err := composeBuildDAGContext(s.ctx.baseDAG, s.result, s.spec)
+	if err != nil {
+		s.errs = append(s.errs, fmt.Errorf("failed to compose inherited DAG context: %w", err))
+		return
+	}
+	s.effective = merged
+}
+
+func (s *dagBuildState) collectWarnings() {
 	// Both max_active_runs > 1 (concurrency) and max_active_runs < 0 (queue bypass) are deprecated.
-	if result.Queue == "" && (result.MaxActiveRuns > 1 || result.MaxActiveRuns < 0) {
-		result.BuildWarnings = append(result.BuildWarnings, fmt.Sprintf(
+	if s.result.Queue == "" && (s.result.MaxActiveRuns > 1 || s.result.MaxActiveRuns < 0) {
+		s.result.BuildWarnings = append(s.result.BuildWarnings, fmt.Sprintf(
 			"max_active_runs=%d is deprecated for local queues and will be ignored. "+
 				"Use a global queue with 'queue:' field for concurrency control.",
-			result.MaxActiveRuns,
+			s.result.MaxActiveRuns,
 		))
 	}
 
-	// Collect schedule warnings (misleading step values like */33).
-	for _, sched := range result.Schedule {
-		result.BuildWarnings = append(result.BuildWarnings, sched.Warnings...)
+	for _, sched := range s.result.Schedule {
+		s.result.BuildWarnings = append(s.result.BuildWarnings, sched.Warnings...)
 	}
-	for _, sched := range result.StopSchedule {
-		result.BuildWarnings = append(result.BuildWarnings, sched.Warnings...)
+	for _, sched := range s.result.StopSchedule {
+		s.result.BuildWarnings = append(s.result.BuildWarnings, sched.Warnings...)
 	}
-	for _, sched := range result.RestartSchedule {
-		result.BuildWarnings = append(result.BuildWarnings, sched.Warnings...)
+	for _, sched := range s.result.RestartSchedule {
+		s.result.BuildWarnings = append(s.result.BuildWarnings, sched.Warnings...)
+	}
+}
+
+func (s *dagBuildState) buildActionGraph() {
+	if s.ctx.opts.Has(BuildFlagOnlyMetadata) {
+		return
 	}
 
-	// Build handlers and steps directly (they need access to partially built result)
-	if !ctx.opts.Has(BuildFlagOnlyMetadata) {
-		if handlerOn, err := buildHandlers(ctx, d, buildResult); err != nil {
-			errs = append(errs, core.NewValidationError("handlers", nil, err))
-		} else {
-			result.HandlerOn = handlerOn
-		}
-
-		if steps, err := buildSteps(ctx, d, buildResult); err != nil {
-			errs = append(errs, core.NewValidationError("steps", nil, err))
-		} else {
-			result.Steps = steps
-		}
+	if handlerOn, err := buildHandlers(s.ctx, s.spec, s.effective); err != nil {
+		s.errs = append(s.errs, core.NewValidationError("handlers", nil, err))
+	} else {
+		s.result.HandlerOn = handlerOn
 	}
 
-	// Validate steps
-	if err := core.ValidateSteps(result); err != nil {
-		errs = append(errs, err)
+	if steps, err := buildSteps(s.ctx, s.spec, s.effective); err != nil {
+		s.errs = append(s.errs, core.NewValidationError("steps", nil, err))
+	} else {
+		s.result.Steps = steps
+	}
+}
+
+func (s *dagBuildState) validateResult() {
+	if err := core.ValidateSteps(s.result); err != nil {
+		s.errs = append(s.errs, err)
 	}
 
-	// Validate workerSelector compatibility with approval steps
-	if len(result.WorkerSelector) > 0 && result.HasApprovalSteps() {
-		errs = append(errs, core.NewValidationError(
+	if len(s.result.WorkerSelector) > 0 && s.result.HasApprovalSteps() {
+		s.errs = append(s.errs, core.NewValidationError(
 			"worker_selector",
-			result.WorkerSelector,
+			s.result.WorkerSelector,
 			fmt.Errorf("DAG with approval steps cannot be dispatched to workers"),
 		))
 	}
 
-	// Validate name
-	if result.Name != "" {
-		if err := core.ValidateDAGName(result.Name); err != nil {
-			errs = append(errs, core.NewValidationError("name", result.Name, err))
+	if s.result.Name != "" {
+		if err := core.ValidateDAGName(s.result.Name); err != nil {
+			s.errs = append(s.errs, core.NewValidationError("name", s.result.Name, err))
 		}
 	}
+}
 
-	if len(ctx.envScope.buildEnv) > 0 {
-		result.PresolvedBuildEnv = maps.Clone(ctx.envScope.buildEnv)
+func (s *dagBuildState) capturePresolvedBuildEnv() {
+	if len(s.ctx.envScope.buildEnv) > 0 {
+		s.result.PresolvedBuildEnv = maps.Clone(s.ctx.envScope.buildEnv)
 	}
+}
 
-	if len(errs) > 0 {
-		if ctx.opts.Has(BuildFlagAllowBuildErrors) {
-			result.BuildErrors = errs
+func (s *dagBuildState) finish() (*core.DAG, error) {
+	if len(s.errs) > 0 {
+		if s.ctx.opts.Has(BuildFlagAllowBuildErrors) {
+			s.result.BuildErrors = s.errs
 		} else {
-			return nil, fmt.Errorf("failed to build DAG: %w", errs)
+			return nil, fmt.Errorf("failed to build DAG: %w", s.errs)
 		}
 	}
+	return s.result, nil
+}
 
-	return result, nil
+// build transforms the dag specification into a core.DAG.
+func (d *dag) build(ctx BuildContext) (*core.DAG, error) {
+	state := newDAGBuildState(ctx, d)
+	state.validateSpecShape()
+	state.prepareParamEnvStage()
+	state.runFieldStages()
+	state.composeInheritedContext()
+	state.collectWarnings()
+	state.buildActionGraph()
+	state.validateResult()
+	state.capturePresolvedBuildEnv()
+	return state.finish()
 }
 
 func composeBuildDAGContext(base, current *core.DAG, currentSpec *dag) (*core.DAG, error) {

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -652,11 +652,10 @@ func wrapTransformError(name string, err error) error {
 }
 
 type dagBuildState struct {
-	ctx       BuildContext
-	spec      *dag
-	result    *core.DAG
-	effective *core.DAG
-	errs      core.ErrorList
+	ctx    BuildContext
+	spec   *dag
+	result *core.DAG
+	errs   core.ErrorList
 }
 
 func newDAGBuildState(ctx BuildContext, spec *dag) *dagBuildState {
@@ -664,10 +663,9 @@ func newDAGBuildState(ctx BuildContext, spec *dag) *dagBuildState {
 		Location: ctx.file,
 	}
 	return &dagBuildState{
-		ctx:       ctx,
-		spec:      spec,
-		result:    result,
-		effective: result,
+		ctx:    ctx,
+		spec:   spec,
+		result: result,
 	}
 }
 
@@ -707,7 +705,7 @@ func (s *dagBuildState) composeInheritedContext() {
 		s.errs = append(s.errs, fmt.Errorf("failed to compose inherited DAG context: %w", err))
 		return
 	}
-	s.effective = merged
+	s.result = merged
 }
 
 func (s *dagBuildState) collectWarnings() {
@@ -736,13 +734,13 @@ func (s *dagBuildState) buildActionGraph() {
 		return
 	}
 
-	if handlerOn, err := buildHandlers(s.ctx, s.spec, s.effective); err != nil {
+	if handlerOn, err := buildHandlers(s.ctx, s.spec, s.result); err != nil {
 		s.errs = append(s.errs, core.NewValidationError("handlers", nil, err))
 	} else {
 		s.result.HandlerOn = handlerOn
 	}
 
-	if steps, err := buildSteps(s.ctx, s.spec, s.effective); err != nil {
+	if steps, err := buildSteps(s.ctx, s.spec, s.result); err != nil {
 		s.errs = append(s.errs, core.NewValidationError("steps", nil, err))
 	} else {
 		s.result.Steps = steps

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -709,6 +709,8 @@ func (s *dagBuildState) composeInheritedContext() {
 }
 
 func (s *dagBuildState) collectWarnings() {
+	s.result.BuildWarnings = nil
+
 	// Both max_active_runs > 1 (concurrency) and max_active_runs < 0 (queue bypass) are deprecated.
 	if s.result.Queue == "" && (s.result.MaxActiveRuns > 1 || s.result.MaxActiveRuns < 0) {
 		s.result.BuildWarnings = append(s.result.BuildWarnings, fmt.Sprintf(

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -737,13 +737,18 @@ func (s *dagBuildState) buildActionGraph() {
 	if handlerOn, err := buildHandlers(s.ctx, s.spec, s.result); err != nil {
 		s.errs = append(s.errs, core.NewValidationError("handlers", nil, err))
 	} else {
-		s.result.HandlerOn = composeHandlerOn(s.result.HandlerOn, handlerOn)
+		composed, err := composeHandlerOn(s.result.HandlerOn, handlerOn)
+		if err != nil {
+			s.errs = append(s.errs, core.NewValidationError("handlers", nil, err))
+		} else {
+			s.result.HandlerOn = composed
+		}
 	}
 
 	if steps, err := buildSteps(s.ctx, s.spec, s.result); err != nil {
 		s.errs = append(s.errs, core.NewValidationError("steps", nil, err))
 	} else {
-		s.result.Steps = steps
+		s.result.Steps = composeSteps(s.result.Steps, steps)
 	}
 }
 
@@ -2911,26 +2916,43 @@ func buildDotenv(_ BuildContext, d *dag) ([]string, error) {
 	return d.Dotenv.Values(), nil
 }
 
-func composeHandlerOn(inherited, current core.HandlerOn) core.HandlerOn {
-	if current.Init != nil {
-		inherited.Init = current.Init
+func composeSteps(inherited, current []core.Step) []core.Step {
+	if current == nil {
+		return inherited
 	}
-	if current.Exit != nil {
-		inherited.Exit = current.Exit
+	return current
+}
+
+func composeHandlerOn(inherited, current core.HandlerOn) (core.HandlerOn, error) {
+	dest := &core.DAG{
+		HandlerOn: cloneHandlerOn(inherited),
 	}
-	if current.Success != nil {
-		inherited.Success = current.Success
+	src := &core.DAG{
+		HandlerOn: current,
 	}
-	if current.Failure != nil {
-		inherited.Failure = current.Failure
+	if err := merge(dest, src); err != nil {
+		return inherited, err
 	}
-	if current.Abort != nil {
-		inherited.Abort = current.Abort
+	return dest.HandlerOn, nil
+}
+
+func cloneHandlerOn(handlerOn core.HandlerOn) core.HandlerOn {
+	return core.HandlerOn{
+		Init:    cloneStepPointer(handlerOn.Init),
+		Failure: cloneStepPointer(handlerOn.Failure),
+		Success: cloneStepPointer(handlerOn.Success),
+		Abort:   cloneStepPointer(handlerOn.Abort),
+		Exit:    cloneStepPointer(handlerOn.Exit),
+		Wait:    cloneStepPointer(handlerOn.Wait),
 	}
-	if current.Wait != nil {
-		inherited.Wait = current.Wait
+}
+
+func cloneStepPointer(step *core.Step) *core.Step {
+	if step == nil {
+		return nil
 	}
-	return inherited
+	cloned := *step
+	return &cloned
 }
 
 func buildHandlers(ctx BuildContext, d *dag, result *core.DAG) (core.HandlerOn, error) {

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -552,7 +552,7 @@ func processDAGDocument(
 		return nil, err
 	}
 
-	docCtx, dest, err := prepareDocumentContext(ctx, baseDef, spec)
+	docCtx, _, err := prepareDocumentContext(ctx, baseDef, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -565,21 +565,18 @@ func processDAGDocument(
 	if err != nil {
 		return nil, err
 	}
-	if err := merge(dest, dag); err != nil {
-		return nil, err
-	}
 	if len(baseRaw) > 0 {
-		dest.BaseConfigData = baseRaw
+		dag.BaseConfigData = baseRaw
 	}
-	applyHistoryRetentionOverride(dest, spec.HistRetentionDays != nil, spec.HistRetentionRuns != nil)
+	applyHistoryRetentionOverride(dag, spec.HistRetentionDays != nil, spec.HistRetentionRuns != nil)
 
-	dest.Location = filePath
-	dest.SourceFile = filePath
-	dest.YamlData, err = documentYAML(ctx.index, doc, fullData)
+	dag.Location = filePath
+	dag.SourceFile = filePath
+	dag.YamlData, err = documentYAML(ctx.index, doc, fullData)
 	if err != nil {
 		return nil, err
 	}
-	return dest, nil
+	return dag, nil
 }
 
 // loadEffectiveBaseDefinition returns the base definition that applies to a document.

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -2422,6 +2422,52 @@ steps:
 		require.Equal(t, 600*time.Second, dag.Steps[0].Timeout)
 	})
 
+	t.Run("BaseConfigStepsInheritedWhenChildOmitsSteps", func(t *testing.T) {
+		t.Parallel()
+
+		base := createTempYAMLFile(t, `
+steps:
+  - name: base-step
+    run: echo "base"
+`)
+		child := createTempYAMLFile(t, `
+description: child DAG
+`)
+		dag, err := spec.Load(context.Background(), child, spec.WithBaseConfig(base))
+		require.NoError(t, err)
+		require.Len(t, dag.Steps, 1)
+		require.Equal(t, "base-step", dag.Steps[0].Name)
+		require.Equal(t, "echo \"base\"", dag.Steps[0].Commands[0].CmdWithArgs)
+	})
+
+	t.Run("BaseConfigHandlerPartialOverrideKeepsInheritedFields", func(t *testing.T) {
+		t.Parallel()
+
+		base := createTempYAMLFile(t, `
+handler_on:
+  failure:
+    run: echo "base failure"
+    timeout_sec: 300
+    env:
+      - BASE_ONLY: base
+`)
+		child := createTempYAMLFile(t, `
+handler_on:
+  failure:
+    run: echo "child failure"
+
+steps:
+  - name: step1
+    run: echo "test"
+`)
+		dag, err := spec.Load(context.Background(), child, spec.WithBaseConfig(base))
+		require.NoError(t, err)
+		require.NotNil(t, dag.HandlerOn.Failure)
+		require.Equal(t, "echo \"child failure\"", dag.HandlerOn.Failure.Commands[0].CmdWithArgs)
+		require.Equal(t, 300*time.Second, dag.HandlerOn.Failure.Timeout)
+		require.Contains(t, dag.HandlerOn.Failure.Env, "BASE_ONLY=base")
+	})
+
 	t.Run("BaseConfigDefaultsAllowExplicitClears", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -2468,6 +2468,23 @@ steps:
 		require.Contains(t, dag.HandlerOn.Failure.Env, "BASE_ONLY=base")
 	})
 
+	t.Run("BaseConfigScheduleWarningsCollectedOnce", func(t *testing.T) {
+		t.Parallel()
+
+		base := createTempYAMLFile(t, `
+schedule: "*/33 * * * *"
+`)
+		child := createTempYAMLFile(t, `
+steps:
+  - name: step1
+    run: echo "test"
+`)
+		dag, err := spec.Load(context.Background(), child, spec.WithBaseConfig(base))
+		require.NoError(t, err)
+		require.Len(t, dag.BuildWarnings, 1)
+		require.Contains(t, dag.BuildWarnings[0], "not every 33 minutes")
+	})
+
 	t.Run("BaseConfigDefaultsAllowExplicitClears", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -410,19 +410,29 @@ type stepTransform struct {
 	transformer Transformer[StepBuildContext, *step]
 }
 
-// stepTransformers defines the ordered sequence of step transformers
-var stepTransformers = []stepTransform{
+type stepTransformStage []stepTransform
+
+var stepIdentityStage = stepTransformStage{
 	{"name", newStepTransformer("Name", buildStepName)},
 	{"id", newStepTransformer("ID", buildStepID)},
 	{"description", newStepTransformer("Description", buildStepDescription)},
+}
+
+var stepScriptStage = stepTransformStage{
 	{"shell_packages", newStepTransformer("ShellPackages", buildStepShellPackages)},
 	{"script", newStepTransformer("Script", buildStepScript)},
+}
+
+var stepLogOutputStage = stepTransformStage{
 	{"stdout", newStepTransformer("Stdout", buildStepStdout)},
 	{"stdout.artifact", newStepTransformer("StdoutArtifact", buildStepStdoutArtifact)},
 	{"stdout.outputs", newStepTransformer("StdoutOutputs", buildStepStdoutOutputs)},
 	{"stderr", newStepTransformer("Stderr", buildStepStderr)},
 	{"stderr.artifact", newStepTransformer("StderrArtifact", buildStepStderrArtifact)},
 	{"log_output", newStepTransformer("LogOutput", buildStepLogOutput)},
+}
+
+var stepExecutionPlacementStage = stepTransformStage{
 	{"mail_on_error", newStepTransformer("MailOnError", buildStepMailOnError)},
 	{"worker_selector", newStepTransformer("WorkerSelector", buildStepWorkerSelector)},
 	{"working_dir", newStepTransformer("Dir", buildStepWorkingDir)},
@@ -435,11 +445,26 @@ var stepTransformers = []stepTransform{
 	{"retry_policy", newStepTransformer("RetryPolicy", buildStepRetryPolicy)},
 	{"repeat_policy", newStepTransformer("RepeatPolicy", buildStepRepeatPolicy)},
 	{"signal_on_stop", newStepTransformer("SignalOnStop", buildStepSignalOnStop)},
+}
+
+var stepStructuredOutputStage = stepTransformStage{
 	{"output", newStepTransformer("Output", buildStepOutput)},
 	{"structured_output", newStepTransformer("StructuredOutput", buildStepStructuredOutput)},
 	{"output_schema", newStepTransformer("OutputSchema", buildStepOutputSchema)},
+}
+
+var stepEnvConditionStage = stepTransformStage{
 	{"env", newStepTransformer("Env", buildStepEnvs)},
 	{"preconditions", newStepTransformer("Preconditions", buildStepPreconditions)},
+}
+
+var stepTransformStages = []stepTransformStage{
+	stepIdentityStage,
+	stepScriptStage,
+	stepLogOutputStage,
+	stepExecutionPlacementStage,
+	stepStructuredOutputStage,
+	stepEnvConditionStage,
 }
 
 // runStepTransformers executes all step transformers
@@ -447,12 +472,110 @@ func runStepTransformers(ctx StepBuildContext, spec *step, result *core.Step) co
 	var errs core.ErrorList
 	out := reflect.ValueOf(result).Elem()
 
-	for _, t := range stepTransformers {
-		if err := t.transformer.Transform(ctx, spec, out); err != nil {
-			errs = append(errs, wrapTransformError(t.name, err))
+	for _, stage := range stepTransformStages {
+		for _, t := range stage {
+			if err := t.transformer.Transform(ctx, spec, out); err != nil {
+				errs = append(errs, wrapTransformError(t.name, err))
+			}
 		}
 	}
 
+	return errs
+}
+
+type stepActionBuilder struct {
+	name                     string
+	build                    func(StepBuildContext, *step, *core.Step) error
+	stopOnStepTypeValidation bool
+}
+
+type stepActionStage []stepActionBuilder
+
+var stepExecutionTargetStage = stepActionStage{
+	{"container", buildStepContainer, false},
+	{"parallel", buildStepParallel, false},
+	{"subDAG", buildStepSubDAG, false},
+	{"executor", buildStepExecutor, true},
+}
+
+var stepInteractionActionStage = stepActionStage{
+	// LLM must be after executor so we know if type supports LLM.
+	{"llm", buildStepLLM, false},
+	{"messages", func(_ StepBuildContext, s *step, result *core.Step) error {
+		return buildStepMessages(s, result)
+	}, false},
+	{"agent", buildStepAgent, false},
+	{"router", buildStepRouter, false},
+	{"approval", buildStepApproval, false},
+}
+
+var stepCommandActionStage = stepActionStage{
+	{"command", buildStepCommand, false},
+	{"params", buildStepParamsField, false},
+}
+
+var stepActionStages = []stepActionStage{
+	stepExecutionTargetStage,
+	stepInteractionActionStage,
+	stepCommandActionStage,
+}
+
+func runStepActionStages(ctx StepBuildContext, spec *step, result *core.Step) (core.ErrorList, bool) {
+	var errs core.ErrorList
+	for _, stage := range stepActionStages {
+		for _, builder := range stage {
+			if err := builder.build(ctx, spec, result); err != nil {
+				errs = append(errs, wrapTransformError(builder.name, err))
+				if builder.stopOnStepTypeValidation && isStepTypeValidationError(err) {
+					return errs, true
+				}
+			}
+		}
+	}
+	return errs, false
+}
+
+type stepValidation struct {
+	name     string
+	validate func(*core.Step) error
+}
+
+type stepValidationStage []stepValidation
+
+var stepCommandValidationStage = stepValidationStage{
+	{"command", validateCommand},
+	{"command", validateMultipleCommands},
+	{"script", validateScript},
+	{"shell", validateShell},
+}
+
+var stepExecutionValidationStage = stepValidationStage{
+	{"container", validateContainer},
+	{"dag", validateSubDAG},
+	{"worker_selector", validateWorkerSelector},
+}
+
+var stepInteractionValidationStage = stepValidationStage{
+	{"llm", validateLLM},
+	{"messages", validateMessages},
+	{"agent", validateAgent},
+}
+
+var stepValidationStages = []stepValidationStage{
+	stepCommandValidationStage,
+	stepExecutionValidationStage,
+	stepInteractionValidationStage,
+}
+
+func runStepValidationStages(result *core.Step) core.ErrorList {
+	var errs core.ErrorList
+	for _, stage := range stepValidationStages {
+		for _, validation := range stage {
+			if err := validation.validate(result); err != nil {
+				errs = append(errs, wrapTransformError(validation.name, err))
+			}
+		}
+	}
 	return errs
 }
 
@@ -469,77 +592,15 @@ func (s *step) build(ctx StepBuildContext) (*core.Step, error) {
 	// Run the transformer pipeline
 	errs := runStepTransformers(ctx, s, result)
 
-	// Action-defining transformations
-	if err := buildStepContainer(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("container", err))
-	}
-	if err := buildStepParallel(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("parallel", err))
-	}
-	if err := buildStepSubDAG(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("subDAG", err))
-	}
-	if err := buildStepExecutor(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("executor", err))
-		if isStepTypeValidationError(err) {
-			return nil, errs
-		}
-	}
-	// LLM must be after executor so we know if type supports LLM
-	if err := buildStepLLM(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("llm", err))
-	}
-	if err := buildStepMessages(s, result); err != nil {
-		errs = append(errs, wrapTransformError("messages", err))
-	}
-	if err := buildStepAgent(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("agent", err))
-	}
-	if err := buildStepRouter(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("router", err))
-	}
-	if err := buildStepApproval(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("approval", err))
-	}
-	if err := buildStepCommand(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("command", err))
-	}
-	if err := buildStepParamsField(ctx, s, result); err != nil {
-		errs = append(errs, wrapTransformError("params", err))
+	actionErrs, stop := runStepActionStages(ctx, s, result)
+	errs = append(errs, actionErrs...)
+	if stop {
+		return nil, errs
 	}
 
 	// Final validators run after the executor type is determined
 	// Capabilities-based validators handle all execution type conflicts
-	if err := validateCommand(result); err != nil {
-		errs = append(errs, wrapTransformError("command", err))
-	}
-	if err := validateMultipleCommands(result); err != nil {
-		errs = append(errs, wrapTransformError("command", err))
-	}
-	if err := validateScript(result); err != nil {
-		errs = append(errs, wrapTransformError("script", err))
-	}
-	if err := validateShell(result); err != nil {
-		errs = append(errs, wrapTransformError("shell", err))
-	}
-	if err := validateContainer(result); err != nil {
-		errs = append(errs, wrapTransformError("container", err))
-	}
-	if err := validateSubDAG(result); err != nil {
-		errs = append(errs, wrapTransformError("dag", err))
-	}
-	if err := validateWorkerSelector(result); err != nil {
-		errs = append(errs, wrapTransformError("worker_selector", err))
-	}
-	if err := validateLLM(result); err != nil {
-		errs = append(errs, wrapTransformError("llm", err))
-	}
-	if err := validateMessages(result); err != nil {
-		errs = append(errs, wrapTransformError("messages", err))
-	}
-	if err := validateAgent(result); err != nil {
-		errs = append(errs, wrapTransformError("agent", err))
-	}
+	errs = append(errs, runStepValidationStages(result)...)
 
 	// Validate executor config against registered schema
 	// Only validate when config has actual values (not just initialized as empty map)


### PR DESCRIPTION
## Summary

Refactor the DAG spec compiler internals into explicit stages while preserving the public `spec.Load` interface and existing base-config inheritance behavior.

## Changes

- Split DAG field compilation into named metadata, params/env/defaults, execution placement, full-output/interaction/retention, action graph, and validation stages.
- Split step compilation into staged transformer, action expansion, and validation phases.
- Preserve inherited base DAG fields, handlers, steps, and warnings during staged action graph construction.
- Add regression tests for base-config step inheritance, partial handler overrides, and inherited warning deduplication.
- Stabilize the queued-abort preservation test by asserting through the run-specific lookup path.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `go test ./internal/core/spec`
- `go test ./internal/core/exec -run 'TestAbortQueuedDAGRun' -count=20`
- `go test ./internal/intg -run 'Test(BaseDAGSpecialEnvVarsInHandler|SkipBaseHandlers)' -count=1`
- `go test ./internal/core/...`
- `go test ./internal/cmd ./internal/service/scheduler ./internal/service/frontend/api/v1`
- `make lint`
- `git diff --check -- internal/core/spec/dag.go internal/core/spec/loader_test.go internal/core/exec/queue_abort_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal build processes for DAG and step configurations into structured transformer stages.

* **Tests**
  * Enhanced test coverage for base-config inheritance in child DAGs.
  * Corrected queue abort test to verify behavior for specific run attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->