### PR TITLE
fix: recompute env variables before launching scheduled DAGs

### DIFF
--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -14,7 +14,8 @@ import (
 // ResolveEnvOptions controls how a DAG is reloaded to recover resolved env
 // values for subprocess launchers.
 type ResolveEnvOptions struct {
-	BaseConfig string
+	BaseConfig   string
+	RecomputeEnv bool
 }
 
 // QuoteRuntimeParams quotes persisted params so values containing spaces survive
@@ -42,17 +43,19 @@ func ResolveEnv(ctx context.Context, dag *core.DAG, params any, opts ResolveEnvO
 	if dag == nil {
 		return nil, nil
 	}
-	if !hasRuntimeParams(params) && len(dag.Env) > 0 {
+	if !opts.RecomputeEnv && !hasRuntimeParams(params) && len(dag.Env) > 0 {
 		return append([]string{}, dag.Env...), nil
 	}
 
-	loadOpts, err := runtimeParamLoadOptions(dag, params, ResolveRuntimeParamsOptions(opts))
+	loadOpts, err := runtimeParamLoadOptions(dag, params, ResolveRuntimeParamsOptions{
+		BaseConfig: opts.BaseConfig,
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	cloned := dag.Clone()
-	if hasRuntimeParams(params) {
+	if hasRuntimeParams(params) || opts.RecomputeEnv {
 		// Recompute DAG/base-config env entries for the new runtime params instead
 		// of short-circuiting to whatever happened to be on the current snapshot.
 		cloned.Env = nil

--- a/internal/core/spec/runtime_env_test.go
+++ b/internal/core/spec/runtime_env_test.go
@@ -50,3 +50,29 @@ steps:
 	assert.Contains(t, env, "SOURCE=from-snapshot")
 	assert.NotContains(t, env, "SOURCE=from-disk")
 }
+
+func TestResolveEnv_RecomputeEnvEvaluatesMetadataEnv(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+name: runtime-env-metadata
+env:
+  - FIRST: "` + "`printf first`" + `"
+  - SECOND: "${FIRST}/second"
+steps:
+  - name: print
+    run: echo ok
+`)
+
+	dag, err := LoadYAML(context.Background(), data, WithoutEval())
+	require.NoError(t, err)
+	assert.Contains(t, dag.Env, "FIRST=`printf first`")
+	assert.Contains(t, dag.Env, "SECOND=${FIRST}/second")
+
+	env, err := ResolveEnv(context.Background(), dag, nil, ResolveEnvOptions{
+		RecomputeEnv: true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, env, "FIRST=first")
+	assert.Contains(t, env, "SECOND=first/second")
+}

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -277,7 +277,8 @@ func (e *DAGExecutor) prepareDAGForSubprocess(ctx context.Context, dag *core.DAG
 	}
 
 	env, err := spec.ResolveEnv(ctx, dag, params, spec.ResolveEnvOptions{
-		BaseConfig: e.baseConfigPath,
+		BaseConfig:   e.baseConfigPath,
+		RecomputeEnv: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fixes a bug where scheduled DAGs skip env evaluation on launch, causing backticks to output as literal strings.

```yaml
env:
  - TODAY: "`date +%Y-%m-%d`"
  - DATA: "data/${TODAY}"
```

Directly invoking `dagu start ...` works as expected - `${DATA}` evaluates to the date stamp.

But scheduled runs incorrectly evaluate `${DATA}` to the string: `` data/`date +%Y-%m-%d` ``.

## Changes

- Add `RecomputeEnv` flag to `ResolveEnvOptions` so callers can opt for re-evaluation.
- Scheduler passes `RecomputeEnv: true` when preparing a DAG for subprocess launch, ensuring env is fresh at execution time.
- Deliberately does not evaluate during metadata scan.
- Add test covering backtick evaluation plus chained env variable resolution.

## Related Issues

n/a

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variables in DAG execution are now properly re-evaluated during subprocess preparation, ensuring dynamic values and expressions are correctly resolved instead of potentially using cached values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->