### PR TITLE
refactor: extract process wiring modules

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -18,9 +18,8 @@ import (
 
 	"golang.org/x/term"
 
-	"github.com/dagucloud/dagu/internal/agent"
-	"github.com/dagucloud/dagu/internal/agentoauth"
 	"github.com/dagucloud/dagu/internal/clicontext"
+	cmdprocess "github.com/dagucloud/dagu/internal/cmd/process"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/crypto"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -29,43 +28,24 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logpath"
 	"github.com/dagucloud/dagu/internal/cmn/signalctx"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
-	"github.com/dagucloud/dagu/internal/cmn/telemetry"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/license"
-	"github.com/dagucloud/dagu/internal/persis/fileagentconfig"
-	"github.com/dagucloud/dagu/internal/persis/fileagentmodel"
-	"github.com/dagucloud/dagu/internal/persis/fileagentoauth"
-
-	"github.com/dagucloud/dagu/internal/persis/fileagentsoul"
 	"github.com/dagucloud/dagu/internal/persis/filebaseconfig"
-	"github.com/dagucloud/dagu/internal/persis/filedag"
 	"github.com/dagucloud/dagu/internal/persis/filedagrun"
 	"github.com/dagucloud/dagu/internal/persis/filedistributed"
 	"github.com/dagucloud/dagu/internal/persis/fileeventstore"
-	"github.com/dagucloud/dagu/internal/persis/filegithubdispatch"
-	"github.com/dagucloud/dagu/internal/persis/fileincident"
 	"github.com/dagucloud/dagu/internal/persis/filelicense"
-	"github.com/dagucloud/dagu/internal/persis/filememory"
-	"github.com/dagucloud/dagu/internal/persis/filenotification"
 	"github.com/dagucloud/dagu/internal/persis/fileproc"
 	"github.com/dagucloud/dagu/internal/persis/filequeue"
-	"github.com/dagucloud/dagu/internal/persis/filesecret"
 	"github.com/dagucloud/dagu/internal/persis/fileserviceregistry"
-	"github.com/dagucloud/dagu/internal/persis/filewatermark"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
-	secretpkg "github.com/dagucloud/dagu/internal/secret"
-	"github.com/dagucloud/dagu/internal/service/chatbridge"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
 	"github.com/dagucloud/dagu/internal/service/frontend"
-	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
-	incidentservice "github.com/dagucloud/dagu/internal/service/incident"
-	notificationservice "github.com/dagucloud/dagu/internal/service/notification"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
-	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -586,230 +566,42 @@ func isSharedNothingWorker(cmd *cobra.Command, cfg *config.Config) bool {
 	return len(cfg.Worker.Coordinators) > 0
 }
 
-// NewServer creates and returns a new web UI NewServer.
-// It initializes in-memory caches for DAGs and runstore, and uses them in the client.
+// NewServer creates and returns a new web UI server for this command context.
 func (c *Context) NewServer(rs *resource.Service, opts ...frontend.ServerOption) (*frontend.Server, error) {
-	limits := c.Config.Cache.Limits()
-	dc := fileutil.NewCache[*core.DAG]("dag_definition", limits.DAG.Limit, limits.DAG.TTL)
-	dc.StartEviction(c)
-
-	dr, err := c.dagStore(dagStoreConfig{Cache: dc})
-	if err != nil {
-		return nil, err
-	}
-
-	// Create coordinator client (may be nil if not configured)
-	cc := c.NewCoordinatorClient()
-
-	collector := telemetry.NewCollector(
-		config.Version,
-		dr,
-		c.DAGRunStore,
-		c.QueueStore,
-		c.ServiceRegistry,
-	)
-	collector.SetWorkerHeartbeatStore(c.WorkerHeartbeatStore)
-
-	// Register DAG definition cache for metrics
-	collector.RegisterCache(dc)
-
-	mr := telemetry.NewRegistry(collector)
-
-	if c.LicenseManager != nil {
-		opts = append(opts, frontend.WithLicenseManager(c.LicenseManager))
-	}
-	if c.DAGRunLeaseStore != nil {
-		opts = append(opts, frontend.WithAPIOption(apiv1.WithDAGRunLeaseStore(c.DAGRunLeaseStore)))
-	}
-	if c.WorkerHeartbeatStore != nil {
-		opts = append(opts, frontend.WithAPIOption(apiv1.WithWorkerHeartbeatStore(c.WorkerHeartbeatStore)))
-	}
-	opts = append(opts, frontend.WithAPIOption(apiv1.WithSchedulerStateStore(
-		filewatermark.New(filepath.Join(c.Config.Paths.DataDir, "scheduler")),
-	)))
-
-	return frontend.NewServer(c.Context, c.Config, dr, c.DAGRunStore, c.QueueStore, c.ProcStore, c.DAGRunMgr, cc, c.ServiceRegistry, mr, collector, rs, opts...)
+	return cmdprocess.NewServer(cmdprocess.ServerConfig{
+		Context:              c.Context,
+		Config:               c.Config,
+		DAGRunStore:          c.DAGRunStore,
+		QueueStore:           c.QueueStore,
+		ProcStore:            c.ProcStore,
+		DAGRunManager:        c.DAGRunMgr,
+		ServiceRegistry:      c.ServiceRegistry,
+		DAGRunLeaseStore:     c.DAGRunLeaseStore,
+		WorkerHeartbeatStore: c.WorkerHeartbeatStore,
+		LicenseManager:       c.LicenseManager,
+		ResourceService:      rs,
+	}, opts...)
 }
 
 // NewCoordinatorClient creates a new coordinator client using the global peer configuration.
 // Returns nil when the coordinator is disabled via configuration.
 func (c *Context) NewCoordinatorClient() coordinator.Client {
-	if !c.Config.Coordinator.Enabled {
-		return nil
-	}
-
-	coordinatorCliCfg := coordinator.DefaultConfig()
-	coordinatorCliCfg.CAFile = c.Config.Core.Peer.ClientCaFile
-	coordinatorCliCfg.CertFile = c.Config.Core.Peer.CertFile
-	coordinatorCliCfg.KeyFile = c.Config.Core.Peer.KeyFile
-	coordinatorCliCfg.SkipTLSVerify = c.Config.Core.Peer.SkipTLSVerify
-	coordinatorCliCfg.Insecure = c.Config.Core.Peer.Insecure
-
-	// Use config values for retry if provided
-	if c.Config.Core.Peer.MaxRetries > 0 {
-		coordinatorCliCfg.MaxRetries = c.Config.Core.Peer.MaxRetries
-	}
-	if c.Config.Core.Peer.RetryInterval > 0 {
-		coordinatorCliCfg.RetryInterval = c.Config.Core.Peer.RetryInterval
-	}
-
-	if err := coordinatorCliCfg.Validate(); err != nil {
-		logger.Error(c.Context, "Invalid coordinator client configuration", tag.Error(err))
-		return nil
-	}
-	return coordinator.New(c.ServiceRegistry, coordinatorCliCfg)
+	return cmdprocess.NewCoordinatorClient(c.Context, c.Config, c.ServiceRegistry)
 }
 
-// NewScheduler creates a new NewScheduler instance using the default client.
-// It builds a DAG job manager to handle scheduled executions.
+// NewScheduler creates a scheduler for this command context.
 func (c *Context) NewScheduler() (*scheduler.Scheduler, error) {
-	limits := c.Config.Cache.Limits()
-	cache := fileutil.NewCache[*core.DAG]("dag_definition", limits.DAG.Limit, limits.DAG.TTL)
-	cache.StartEviction(c)
-
-	dr, err := c.dagStore(dagStoreConfig{Cache: cache})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize DAG client: %w", err)
-	}
-
-	coordinatorCli := c.NewCoordinatorClient()
-	m := scheduler.NewEntryReader(c.Config.Paths.DAGsDir, dr)
-	watermarkDir := filepath.Join(c.Config.Paths.DataDir, "scheduler")
-	wmStore := filewatermark.New(watermarkDir)
-
-	statusCache := fileutil.NewCache[*exec.DAGRunStatus]("scheduler_dag_run_status", limits.DAGRun.Limit, limits.DAGRun.TTL)
-	statusCache.StartEviction(c)
-	schedulerRunStore := filedagrun.New(
-		c.Config.Paths.DAGRunsDir,
-		filedagrun.WithArtifactDir(c.Config.Paths.ArtifactDir),
-		filedagrun.WithLatestStatusToday(false),
-		filedagrun.WithLocation(c.Config.Core.Location),
-		filedagrun.WithHistoryFileCache(statusCache),
-	)
-	schedulerRunMgr := runtime.NewManager(schedulerRunStore, c.ProcStore, c.Config)
-
-	sched, err := scheduler.New(c.Config, m, schedulerRunMgr, schedulerRunStore, c.QueueStore, c.ProcStore, c.ServiceRegistry, coordinatorCli, wmStore)
-	if err != nil {
-		return nil, err
-	}
-	if c.EventService != nil {
-		collector, eventErr := fileeventstore.NewCollector(c.Config.Paths.EventStoreDir, c.Config.EventStore.RetentionDays)
-		if eventErr != nil {
-			logger.Warn(c, "Failed to initialize event collector; continuing without collection", tag.Error(eventErr))
-		} else {
-			sched.SetEventCollector(collector)
-		}
-		if notificationMonitor := c.newNotificationMonitor(dr); notificationMonitor != nil {
-			sched.SetNotificationMonitor(notificationMonitor)
-		}
-		if incidentMonitor := c.newIncidentMonitor(); incidentMonitor != nil {
-			sched.SetIncidentMonitor(incidentMonitor)
-		}
-	}
-	sched.SetDAGRunLeaseStore(c.DAGRunLeaseStore)
-	sched.SetDispatchTaskStore(c.DispatchTaskStore)
-	if c.LicenseManager != nil {
-		githubTracker := filegithubdispatch.New(filepath.Join(c.Config.Paths.DataDir, "github-dispatch"))
-		sched.SetGitHubDispatchWorker(scheduler.NewGitHubDispatchWorker(
-			c.Config,
-			dr,
-			schedulerRunStore,
-			c.QueueStore,
-			&schedulerRunMgr,
-			c.LicenseManager,
-			license.NewCloudClient(c.Config.License.CloudURL),
-			githubTracker,
-			logger.FromContext(c.Context),
-		))
-	}
-	return sched, nil
-}
-
-func (c *Context) newNotificationMonitor(dr exec.DAGStore) *chatbridge.NotificationMonitor {
-	encKey, encErr := crypto.ResolveKey(c.Config.Paths.DataDir)
-	if encErr != nil {
-		logger.Warn(c, "Notification settings store is disabled because encrypted storage is not available", tag.Error(encErr))
-		return nil
-	}
-	encryptor, encErr := crypto.NewEncryptor(encKey)
-	if encErr != nil {
-		logger.Warn(c, "Failed to create encryptor for notification settings store", tag.Error(encErr))
-		return nil
-	}
-	store, err := filenotification.New(
-		filepath.Join(c.Config.Paths.DataDir, "notifications", "dags"),
-		filenotification.WithEncryptor(encryptor),
-	)
-	if err != nil {
-		logger.Warn(c, "Failed to create notification settings store", tag.Error(err))
-		return nil
-	}
-	var checker license.Checker
-	if c.LicenseManager != nil {
-		checker = c.LicenseManager.Checker()
-	}
-	notificationSvc := notificationservice.New(
-		store,
-		dr,
-		notificationservice.WithReusableChannelsEnabled(func() bool {
-			return license.HasActiveLicense(checker)
-		}),
-	)
-	stateFile := filepath.Join(c.Config.Paths.DataDir, "notifications", "monitor-state.json")
-	return chatbridge.NewNotificationMonitor(
-		c.EventService,
-		stateFile,
-		notificationSvc,
-		slog.Default(),
-		chatbridge.DefaultNotificationMonitorConfig(),
-	)
-}
-
-func (c *Context) newIncidentMonitor() *chatbridge.NotificationMonitor {
-	encKey, encErr := crypto.ResolveKey(c.Config.Paths.DataDir)
-	if encErr != nil {
-		logger.Warn(c, "Incident settings store is disabled because encrypted storage is not available", tag.Error(encErr))
-		return nil
-	}
-	encryptor, encErr := crypto.NewEncryptor(encKey)
-	if encErr != nil {
-		logger.Warn(c, "Failed to create encryptor for incident settings store", tag.Error(encErr))
-		return nil
-	}
-	store, err := fileincident.New(
-		filepath.Join(c.Config.Paths.DataDir, "incidents"),
-		fileincident.WithEncryptor(encryptor),
-	)
-	if err != nil {
-		logger.Warn(c, "Failed to create incident settings store", tag.Error(err))
-		return nil
-	}
-	var checker license.Checker
-	if c.LicenseManager != nil {
-		checker = c.LicenseManager.Checker()
-	}
-	incidentSvc := incidentservice.New(
-		store,
-		incidentservice.WithIncidentsEnabled(func() bool {
-			return license.HasActiveLicense(checker)
-		}),
-		incidentservice.WithPublicURL(c.Config.Server.PublicURL),
-	)
-	stateFile := filepath.Join(c.Config.Paths.DataDir, "incidents", "monitor-state.json")
-	cfg := chatbridge.DefaultNotificationMonitorConfig()
-	cfg.UrgentWindow = time.Second
-	cfg.SuccessWindow = time.Second
-	cfg.InterestedEventTypes = []eventstore.EventType{
-		eventstore.TypeDAGRunFailed,
-		eventstore.TypeDAGRunSucceeded,
-	}
-	return chatbridge.NewNotificationMonitor(
-		c.EventService,
-		stateFile,
-		incidentSvc,
-		slog.Default(),
-		cfg,
-	)
+	return cmdprocess.NewScheduler(cmdprocess.SchedulerConfig{
+		Context:           c.Context,
+		Config:            c.Config,
+		QueueStore:        c.QueueStore,
+		ProcStore:         c.ProcStore,
+		ServiceRegistry:   c.ServiceRegistry,
+		DispatchTaskStore: c.DispatchTaskStore,
+		DAGRunLeaseStore:  c.DAGRunLeaseStore,
+		EventService:      c.EventService,
+		LicenseManager:    c.LicenseManager,
+	})
 }
 
 // StringParam retrieves a string parameter from the command line flags.
@@ -847,106 +639,19 @@ type dagStoreConfig struct {
 
 // dagStore returns a new DAGRepository instance.
 func (c *Context) dagStore(cfg dagStoreConfig) (exec.DAGStore, error) {
-	// Merge configured alternate DAGs directory into search paths if provided
-	searchPaths := append([]string{}, cfg.SearchPaths...)
-	if c.Config != nil && c.Config.Paths.AltDAGsDir != "" {
-		searchPaths = append(searchPaths, c.Config.Paths.AltDAGsDir)
-	}
-
-	store := filedag.New(
-		c.Config.Paths.DAGsDir,
-		filedag.WithFlagsBaseDir(c.Config.Paths.SuspendFlagsDir),
-		filedag.WithSearchPaths(searchPaths),
-		filedag.WithBaseConfig(c.Config.Paths.BaseConfig),
-		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(c.Config.Paths.DAGsDir)),
-		filedag.WithFileCache(cfg.Cache),
-		filedag.WithSkipExamples(c.Config.Core.SkipExamples),
-		filedag.WithSkipDirectoryCreation(cfg.SkipDirectoryCreation),
-	)
-
-	// Initialize the store (creates directory and example DAGs if needed, unless SkipDirectoryCreation is true)
-	if s, ok := store.(*filedag.Storage); ok {
-		if err := s.Initialize(); err != nil {
-			return nil, fmt.Errorf("failed to initialize DAG store: %w", err)
-		}
-	}
-
-	return store, nil
+	return cmdprocess.NewDAGStore(c.Config, cmdprocess.DAGStoreConfig{
+		Cache:                 cfg.Cache,
+		SearchPaths:           cfg.SearchPaths,
+		SkipDirectoryCreation: cfg.SkipDirectoryCreation,
+	})
 }
 
 // agentStoresResult holds the agent stores created by agentStores().
-type agentStoresResult struct {
-	ConfigStore     agent.ConfigStore
-	ModelStore      agent.ModelStore
-	MemoryStore     agent.MemoryStore
-	SoulStore       agent.SoulStore
-	OAuthManager    *agentoauth.Manager
-	ContextResolver agent.RemoteContextResolver
-	SecretStore     secretpkg.Store
-}
+type agentStoresResult = cmdprocess.AgentStores
 
-// agentStores creates the agent config, model, memory, and soul stores from the config paths.
-// Errors are logged as warnings; nil stores are returned if creation fails.
+// agentStores creates the agent store bundle for this command context.
 func (c *Context) agentStores() agentStoresResult {
-	var result agentStoresResult
-
-	if store, err := filesecret.NewFromDataDir(c.Config.Paths.DataDir); err != nil {
-		logger.Warn(c, "Failed to create secret store", tag.Error(err))
-	} else {
-		result.SecretStore = store
-	}
-
-	acs, err := fileagentconfig.New(c.Config.Paths.DataDir)
-	if err != nil {
-		logger.Warn(c, "Failed to create agent config store", tag.Error(err))
-		return result
-	}
-	if acs == nil {
-		return result
-	}
-	result.ConfigStore = acs
-
-	ams, err := fileagentmodel.New(filepath.Join(c.Config.Paths.DataDir, "agent", "models"))
-	if err != nil {
-		logger.Warn(c, "Failed to create agent model store", tag.Error(err))
-		return result
-	}
-	result.ModelStore = ams
-
-	ms, err := filememory.New(c.Config.Paths.DAGsDir)
-	if err != nil {
-		logger.Warn(c, "Failed to create agent memory store", tag.Error(err))
-		return result
-	}
-	result.MemoryStore = ms
-
-	soulsDir := filepath.Join(c.Config.Paths.DAGsDir, "souls")
-	soulStore, err := fileagentsoul.New(c, soulsDir)
-	if err != nil {
-		logger.Warn(c, "Failed to create agent soul store", tag.Error(err))
-		return result
-	}
-	result.SoulStore = soulStore
-
-	oauthManager, err := fileagentoauth.NewManager(c.Config.Paths.DataDir)
-	if err != nil {
-		logger.Warn(c, "Failed to create agent OAuth store", tag.Error(err))
-	} else {
-		result.OAuthManager = oauthManager
-	}
-
-	// Build context resolver for agent step remote tools.
-	result.ContextResolver = c.buildRemoteContextResolver()
-
-	return result
-}
-
-// buildRemoteContextResolver creates a RemoteContextResolver from the CLI context store.
-func (c *Context) buildRemoteContextResolver() agent.RemoteContextResolver {
-	if c.ContextStore == nil {
-		return nil
-	}
-	return &agent.RemoteContextResolverAdapter{Store: c.ContextStore}
+	return cmdprocess.NewAgentStores(c.Context, c.Config, c.ContextStore)
 }
 
 // OpenLogFile creates and opens a log file for a given dag-run.

--- a/internal/cmd/process/agent_stores.go
+++ b/internal/cmd/process/agent_stores.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/agentoauth"
+	"github.com/dagucloud/dagu/internal/clicontext"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/persis/fileagentconfig"
+	"github.com/dagucloud/dagu/internal/persis/fileagentmodel"
+	"github.com/dagucloud/dagu/internal/persis/fileagentoauth"
+	"github.com/dagucloud/dagu/internal/persis/fileagentsoul"
+	"github.com/dagucloud/dagu/internal/persis/filememory"
+	"github.com/dagucloud/dagu/internal/persis/filesecret"
+	secretpkg "github.com/dagucloud/dagu/internal/secret"
+)
+
+// AgentStores contains the stores and resolvers used by CLI and runtime agent flows.
+type AgentStores struct {
+	ConfigStore     agent.ConfigStore
+	ModelStore      agent.ModelStore
+	MemoryStore     agent.MemoryStore
+	SoulStore       agent.SoulStore
+	OAuthManager    *agentoauth.Manager
+	ContextResolver agent.RemoteContextResolver
+	SecretStore     secretpkg.Store
+}
+
+// NewAgentStores creates the agent store bundle for a command process role.
+func NewAgentStores(ctx context.Context, cfg *config.Config, contextStore *clicontext.Store) AgentStores {
+	var result AgentStores
+
+	if store, err := filesecret.NewFromDataDir(cfg.Paths.DataDir); err != nil {
+		logger.Warn(ctx, "Failed to create secret store", tag.Error(err))
+	} else {
+		result.SecretStore = store
+	}
+
+	agentConfigStore, err := fileagentconfig.New(cfg.Paths.DataDir)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create agent config store", tag.Error(err))
+		return result
+	}
+	if agentConfigStore == nil {
+		return result
+	}
+	result.ConfigStore = agentConfigStore
+
+	agentModelStore, err := fileagentmodel.New(filepath.Join(cfg.Paths.DataDir, "agent", "models"))
+	if err != nil {
+		logger.Warn(ctx, "Failed to create agent model store", tag.Error(err))
+		return result
+	}
+	result.ModelStore = agentModelStore
+
+	memoryStore, err := filememory.New(cfg.Paths.DAGsDir)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create agent memory store", tag.Error(err))
+		return result
+	}
+	result.MemoryStore = memoryStore
+
+	soulsDir := filepath.Join(cfg.Paths.DAGsDir, "souls")
+	soulStore, err := fileagentsoul.New(ctx, soulsDir)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create agent soul store", tag.Error(err))
+		return result
+	}
+	result.SoulStore = soulStore
+
+	oauthManager, err := fileagentoauth.NewManager(cfg.Paths.DataDir)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create agent OAuth store", tag.Error(err))
+	} else {
+		result.OAuthManager = oauthManager
+	}
+
+	if contextStore != nil {
+		result.ContextResolver = &agent.RemoteContextResolverAdapter{Store: contextStore}
+	}
+
+	return result
+}

--- a/internal/cmd/process/coordinator.go
+++ b/internal/cmd/process/coordinator.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+)
+
+// NewCoordinatorClient creates a coordinator client for a command process role.
+func NewCoordinatorClient(ctx context.Context, cfg *config.Config, registry exec.ServiceRegistry) coordinator.Client {
+	if !cfg.Coordinator.Enabled {
+		return nil
+	}
+
+	coordinatorCliCfg := coordinator.DefaultConfig()
+	coordinatorCliCfg.CAFile = cfg.Core.Peer.ClientCaFile
+	coordinatorCliCfg.CertFile = cfg.Core.Peer.CertFile
+	coordinatorCliCfg.KeyFile = cfg.Core.Peer.KeyFile
+	coordinatorCliCfg.SkipTLSVerify = cfg.Core.Peer.SkipTLSVerify
+	coordinatorCliCfg.Insecure = cfg.Core.Peer.Insecure
+
+	if cfg.Core.Peer.MaxRetries > 0 {
+		coordinatorCliCfg.MaxRetries = cfg.Core.Peer.MaxRetries
+	}
+	if cfg.Core.Peer.RetryInterval > 0 {
+		coordinatorCliCfg.RetryInterval = cfg.Core.Peer.RetryInterval
+	}
+
+	if err := coordinatorCliCfg.Validate(); err != nil {
+		logger.Error(ctx, "Invalid coordinator client configuration", tag.Error(err))
+		return nil
+	}
+	return coordinator.New(registry, coordinatorCliCfg)
+}

--- a/internal/cmd/process/dag_store.go
+++ b/internal/cmd/process/dag_store.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"fmt"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/filedag"
+	"github.com/dagucloud/dagu/internal/workspace"
+)
+
+// DAGStoreConfig contains process wiring options for creating a DAG store.
+type DAGStoreConfig struct {
+	Cache                 *fileutil.Cache[*core.DAG]
+	SearchPaths           []string
+	SkipDirectoryCreation bool
+}
+
+// NewDAGStore creates the file-backed DAG store used by command process roles.
+func NewDAGStore(cfg *config.Config, storeCfg DAGStoreConfig) (exec.DAGStore, error) {
+	searchPaths := append([]string{}, storeCfg.SearchPaths...)
+	if cfg.Paths.AltDAGsDir != "" {
+		searchPaths = append(searchPaths, cfg.Paths.AltDAGsDir)
+	}
+
+	store := filedag.New(
+		cfg.Paths.DAGsDir,
+		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
+		filedag.WithSearchPaths(searchPaths),
+		filedag.WithBaseConfig(cfg.Paths.BaseConfig),
+		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
+		filedag.WithFileCache(storeCfg.Cache),
+		filedag.WithSkipExamples(cfg.Core.SkipExamples),
+		filedag.WithSkipDirectoryCreation(storeCfg.SkipDirectoryCreation),
+	)
+
+	if s, ok := store.(*filedag.Storage); ok {
+		if err := s.Initialize(); err != nil {
+			return nil, fmt.Errorf("failed to initialize DAG store: %w", err)
+		}
+	}
+
+	return store, nil
+}

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -126,6 +126,8 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 	return sched, nil
 }
 
+// newNotificationMonitor wires optional DAG notification delivery. It returns nil
+// when encrypted settings storage is unavailable so scheduler startup can continue.
 func newNotificationMonitor(
 	ctx context.Context,
 	cfg *config.Config,
@@ -172,6 +174,8 @@ func newNotificationMonitor(
 	)
 }
 
+// newIncidentMonitor wires optional incident notifications. It returns nil when
+// encrypted settings storage is unavailable so scheduler startup can continue.
 func newIncidentMonitor(
 	ctx context.Context,
 	cfg *config.Config,

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -1,0 +1,225 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/crypto"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/license"
+	"github.com/dagucloud/dagu/internal/persis/filedagrun"
+	"github.com/dagucloud/dagu/internal/persis/fileeventstore"
+	"github.com/dagucloud/dagu/internal/persis/filegithubdispatch"
+	"github.com/dagucloud/dagu/internal/persis/fileincident"
+	"github.com/dagucloud/dagu/internal/persis/filenotification"
+	"github.com/dagucloud/dagu/internal/persis/filewatermark"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+	incidentservice "github.com/dagucloud/dagu/internal/service/incident"
+	notificationservice "github.com/dagucloud/dagu/internal/service/notification"
+	"github.com/dagucloud/dagu/internal/service/scheduler"
+)
+
+// SchedulerConfig contains the wiring needed to construct the scheduler process role.
+type SchedulerConfig struct {
+	Context           context.Context
+	Config            *config.Config
+	QueueStore        exec.QueueStore
+	ProcStore         exec.ProcStore
+	ServiceRegistry   exec.ServiceRegistry
+	DispatchTaskStore exec.DispatchTaskStore
+	DAGRunLeaseStore  exec.DAGRunLeaseStore
+	EventService      *eventstore.Service
+	LicenseManager    *license.Manager
+}
+
+// NewScheduler creates the scheduler and its process-local stores, monitors, and workers.
+func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
+	ctx := cfg.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	limits := cfg.Config.Cache.Limits()
+	dagCache := fileutil.NewCache[*core.DAG]("dag_definition", limits.DAG.Limit, limits.DAG.TTL)
+	dagCache.StartEviction(ctx)
+
+	dagStore, err := NewDAGStore(cfg.Config, DAGStoreConfig{Cache: dagCache})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize DAG client: %w", err)
+	}
+
+	coordinatorClient := NewCoordinatorClient(ctx, cfg.Config, cfg.ServiceRegistry)
+	entryReader := scheduler.NewEntryReader(cfg.Config.Paths.DAGsDir, dagStore)
+	watermarkStore := filewatermark.New(filepath.Join(cfg.Config.Paths.DataDir, "scheduler"))
+
+	statusCache := fileutil.NewCache[*exec.DAGRunStatus]("scheduler_dag_run_status", limits.DAGRun.Limit, limits.DAGRun.TTL)
+	statusCache.StartEviction(ctx)
+	schedulerRunStore := filedagrun.New(
+		cfg.Config.Paths.DAGRunsDir,
+		filedagrun.WithArtifactDir(cfg.Config.Paths.ArtifactDir),
+		filedagrun.WithLatestStatusToday(false),
+		filedagrun.WithLocation(cfg.Config.Core.Location),
+		filedagrun.WithHistoryFileCache(statusCache),
+	)
+	schedulerRunManager := runtime.NewManager(schedulerRunStore, cfg.ProcStore, cfg.Config)
+
+	sched, err := scheduler.New(
+		cfg.Config,
+		entryReader,
+		schedulerRunManager,
+		schedulerRunStore,
+		cfg.QueueStore,
+		cfg.ProcStore,
+		cfg.ServiceRegistry,
+		coordinatorClient,
+		watermarkStore,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.EventService != nil {
+		collector, eventErr := fileeventstore.NewCollector(cfg.Config.Paths.EventStoreDir, cfg.Config.EventStore.RetentionDays)
+		if eventErr != nil {
+			logger.Warn(ctx, "Failed to initialize event collector; continuing without collection", tag.Error(eventErr))
+		} else {
+			sched.SetEventCollector(collector)
+		}
+		if notificationMonitor := newNotificationMonitor(ctx, cfg.Config, dagStore, cfg.LicenseManager, cfg.EventService); notificationMonitor != nil {
+			sched.SetNotificationMonitor(notificationMonitor)
+		}
+		if incidentMonitor := newIncidentMonitor(ctx, cfg.Config, cfg.LicenseManager, cfg.EventService); incidentMonitor != nil {
+			sched.SetIncidentMonitor(incidentMonitor)
+		}
+	}
+
+	sched.SetDAGRunLeaseStore(cfg.DAGRunLeaseStore)
+	sched.SetDispatchTaskStore(cfg.DispatchTaskStore)
+	if cfg.LicenseManager != nil {
+		githubTracker := filegithubdispatch.New(filepath.Join(cfg.Config.Paths.DataDir, "github-dispatch"))
+		sched.SetGitHubDispatchWorker(scheduler.NewGitHubDispatchWorker(
+			cfg.Config,
+			dagStore,
+			schedulerRunStore,
+			cfg.QueueStore,
+			&schedulerRunManager,
+			cfg.LicenseManager,
+			license.NewCloudClient(cfg.Config.License.CloudURL),
+			githubTracker,
+			logger.FromContext(ctx),
+		))
+	}
+
+	return sched, nil
+}
+
+func newNotificationMonitor(
+	ctx context.Context,
+	cfg *config.Config,
+	dagStore exec.DAGStore,
+	licenseManager *license.Manager,
+	eventService *eventstore.Service,
+) *chatbridge.NotificationMonitor {
+	encKey, encErr := crypto.ResolveKey(cfg.Paths.DataDir)
+	if encErr != nil {
+		logger.Warn(ctx, "Notification settings store is disabled because encrypted storage is not available", tag.Error(encErr))
+		return nil
+	}
+	encryptor, encErr := crypto.NewEncryptor(encKey)
+	if encErr != nil {
+		logger.Warn(ctx, "Failed to create encryptor for notification settings store", tag.Error(encErr))
+		return nil
+	}
+	store, err := filenotification.New(
+		filepath.Join(cfg.Paths.DataDir, "notifications", "dags"),
+		filenotification.WithEncryptor(encryptor),
+	)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create notification settings store", tag.Error(err))
+		return nil
+	}
+	var checker license.Checker
+	if licenseManager != nil {
+		checker = licenseManager.Checker()
+	}
+	notificationService := notificationservice.New(
+		store,
+		dagStore,
+		notificationservice.WithReusableChannelsEnabled(func() bool {
+			return license.HasActiveLicense(checker)
+		}),
+	)
+	stateFile := filepath.Join(cfg.Paths.DataDir, "notifications", "monitor-state.json")
+	return chatbridge.NewNotificationMonitor(
+		eventService,
+		stateFile,
+		notificationService,
+		slog.Default(),
+		chatbridge.DefaultNotificationMonitorConfig(),
+	)
+}
+
+func newIncidentMonitor(
+	ctx context.Context,
+	cfg *config.Config,
+	licenseManager *license.Manager,
+	eventService *eventstore.Service,
+) *chatbridge.NotificationMonitor {
+	encKey, encErr := crypto.ResolveKey(cfg.Paths.DataDir)
+	if encErr != nil {
+		logger.Warn(ctx, "Incident settings store is disabled because encrypted storage is not available", tag.Error(encErr))
+		return nil
+	}
+	encryptor, encErr := crypto.NewEncryptor(encKey)
+	if encErr != nil {
+		logger.Warn(ctx, "Failed to create encryptor for incident settings store", tag.Error(encErr))
+		return nil
+	}
+	store, err := fileincident.New(
+		filepath.Join(cfg.Paths.DataDir, "incidents"),
+		fileincident.WithEncryptor(encryptor),
+	)
+	if err != nil {
+		logger.Warn(ctx, "Failed to create incident settings store", tag.Error(err))
+		return nil
+	}
+	var checker license.Checker
+	if licenseManager != nil {
+		checker = licenseManager.Checker()
+	}
+	incidentService := incidentservice.New(
+		store,
+		incidentservice.WithIncidentsEnabled(func() bool {
+			return license.HasActiveLicense(checker)
+		}),
+		incidentservice.WithPublicURL(cfg.Server.PublicURL),
+	)
+	stateFile := filepath.Join(cfg.Paths.DataDir, "incidents", "monitor-state.json")
+	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
+	monitorConfig.UrgentWindow = time.Second
+	monitorConfig.SuccessWindow = time.Second
+	monitorConfig.InterestedEventTypes = []eventstore.EventType{
+		eventstore.TypeDAGRunFailed,
+		eventstore.TypeDAGRunSucceeded,
+	}
+	return chatbridge.NewNotificationMonitor(
+		eventService,
+		stateFile,
+		incidentService,
+		slog.Default(),
+		monitorConfig,
+	)
+}

--- a/internal/cmd/process/server.go
+++ b/internal/cmd/process/server.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/telemetry"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/license"
+	"github.com/dagucloud/dagu/internal/persis/filewatermark"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/service/frontend"
+	apiv1 "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
+	"github.com/dagucloud/dagu/internal/service/resource"
+)
+
+// ServerConfig contains the wiring needed to construct the frontend process role.
+type ServerConfig struct {
+	Context              context.Context
+	Config               *config.Config
+	DAGRunStore          exec.DAGRunStore
+	QueueStore           exec.QueueStore
+	ProcStore            exec.ProcStore
+	DAGRunManager        runtime.Manager
+	ServiceRegistry      exec.ServiceRegistry
+	DAGRunLeaseStore     exec.DAGRunLeaseStore
+	WorkerHeartbeatStore exec.WorkerHeartbeatStore
+	LicenseManager       *license.Manager
+	ResourceService      *resource.Service
+}
+
+// NewServer creates the frontend server and process-local telemetry wiring.
+func NewServer(cfg ServerConfig, opts ...frontend.ServerOption) (*frontend.Server, error) {
+	ctx := cfg.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	limits := cfg.Config.Cache.Limits()
+	dagCache := fileutil.NewCache[*core.DAG]("dag_definition", limits.DAG.Limit, limits.DAG.TTL)
+	dagCache.StartEviction(ctx)
+
+	dagStore, err := NewDAGStore(cfg.Config, DAGStoreConfig{Cache: dagCache})
+	if err != nil {
+		return nil, err
+	}
+
+	coordinatorClient := NewCoordinatorClient(ctx, cfg.Config, cfg.ServiceRegistry)
+	collector := telemetry.NewCollector(
+		config.Version,
+		dagStore,
+		cfg.DAGRunStore,
+		cfg.QueueStore,
+		cfg.ServiceRegistry,
+	)
+	collector.SetWorkerHeartbeatStore(cfg.WorkerHeartbeatStore)
+	collector.RegisterCache(dagCache)
+
+	metricsRegistry := telemetry.NewRegistry(collector)
+
+	if cfg.LicenseManager != nil {
+		opts = append(opts, frontend.WithLicenseManager(cfg.LicenseManager))
+	}
+	if cfg.DAGRunLeaseStore != nil {
+		opts = append(opts, frontend.WithAPIOption(apiv1.WithDAGRunLeaseStore(cfg.DAGRunLeaseStore)))
+	}
+	if cfg.WorkerHeartbeatStore != nil {
+		opts = append(opts, frontend.WithAPIOption(apiv1.WithWorkerHeartbeatStore(cfg.WorkerHeartbeatStore)))
+	}
+	opts = append(opts, frontend.WithAPIOption(apiv1.WithSchedulerStateStore(
+		filewatermark.New(filepath.Join(cfg.Config.Paths.DataDir, "scheduler")),
+	)))
+
+	return frontend.NewServer(
+		ctx,
+		cfg.Config,
+		dagStore,
+		cfg.DAGRunStore,
+		cfg.QueueStore,
+		cfg.ProcStore,
+		cfg.DAGRunManager,
+		coordinatorClient,
+		cfg.ServiceRegistry,
+		metricsRegistry,
+		collector,
+		cfg.ResourceService,
+		opts...,
+	)
+}

--- a/internal/cmd/process/worker.go
+++ b/internal/cmd/process/worker.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+)
+
+// BuildWorkerCoordinatorClientConfig creates coordinator client config from application config.
+// It returns nil config when no static coordinators are configured, so the worker can use service discovery.
+func BuildWorkerCoordinatorClientConfig(cfg *config.Config) (*coordinator.Config, bool, error) {
+	if len(cfg.Worker.Coordinators) == 0 {
+		return nil, false, nil
+	}
+
+	coordCliCfg := coordinator.DefaultConfig()
+	coordCliCfg.CAFile = cfg.Core.Peer.ClientCaFile
+	coordCliCfg.CertFile = cfg.Core.Peer.CertFile
+	coordCliCfg.KeyFile = cfg.Core.Peer.KeyFile
+	coordCliCfg.SkipTLSVerify = cfg.Core.Peer.SkipTLSVerify
+	coordCliCfg.Insecure = cfg.Core.Peer.Insecure
+
+	if err := coordCliCfg.Validate(); err != nil {
+		return nil, false, fmt.Errorf("invalid coordinator client configuration: %w", err)
+	}
+
+	return coordCliCfg, true, nil
+}
+
+// NewWorkerCoordinatorClient creates the worker coordinator client and reports
+// whether the worker should use the shared-nothing remote task handler.
+func NewWorkerCoordinatorClient(
+	ctx context.Context,
+	cfg *config.Config,
+	registry exec.ServiceRegistry,
+) (coordinator.Client, bool, error) {
+	coordCliCfg, useRemoteHandler, err := BuildWorkerCoordinatorClientConfig(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if coordCliCfg == nil {
+		return NewCoordinatorClient(ctx, cfg, registry), false, nil
+	}
+
+	staticRegistry, err := coordinator.NewStaticRegistry(cfg.Worker.Coordinators)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create static registry: %w", err)
+	}
+	logger.Info(ctx, "Using static coordinator discovery",
+		slog.Any("coordinators", cfg.Worker.Coordinators))
+
+	return coordinator.New(staticRegistry, coordCliCfg), useRemoteHandler, nil
+}

--- a/internal/cmd/process/worker.go
+++ b/internal/cmd/process/worker.go
@@ -27,6 +27,12 @@ func BuildWorkerCoordinatorClientConfig(cfg *config.Config) (*coordinator.Config
 	coordCliCfg.KeyFile = cfg.Core.Peer.KeyFile
 	coordCliCfg.SkipTLSVerify = cfg.Core.Peer.SkipTLSVerify
 	coordCliCfg.Insecure = cfg.Core.Peer.Insecure
+	if cfg.Core.Peer.MaxRetries > 0 {
+		coordCliCfg.MaxRetries = cfg.Core.Peer.MaxRetries
+	}
+	if cfg.Core.Peer.RetryInterval > 0 {
+		coordCliCfg.RetryInterval = cfg.Core.Peer.RetryInterval
+	}
 
 	if err := coordCliCfg.Validate(); err != nil {
 		return nil, false, fmt.Errorf("invalid coordinator client configuration: %w", err)

--- a/internal/cmd/worker.go
+++ b/internal/cmd/worker.go
@@ -8,7 +8,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/dagucloud/dagu/internal/cmn/config"
+	cmdprocess "github.com/dagucloud/dagu/internal/cmd/process"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
@@ -137,46 +137,8 @@ func runWorker(ctx *Context, _ []string) error {
 	return nil
 }
 
-// BuildCoordinatorClientConfig creates coordinator client config from application config.
-// Returns nil config if no static coordinators configured (use service registry instead).
-// This is a pure function that can be unit tested without network I/O.
-func BuildCoordinatorClientConfig(cfg *config.Config) (*coordinator.Config, bool, error) {
-	if len(cfg.Worker.Coordinators) == 0 {
-		return nil, false, nil // Use service registry discovery
-	}
-
-	coordCliCfg := coordinator.DefaultConfig()
-	coordCliCfg.CAFile = cfg.Core.Peer.ClientCaFile
-	coordCliCfg.CertFile = cfg.Core.Peer.CertFile
-	coordCliCfg.KeyFile = cfg.Core.Peer.KeyFile
-	coordCliCfg.SkipTLSVerify = cfg.Core.Peer.SkipTLSVerify
-	coordCliCfg.Insecure = cfg.Core.Peer.Insecure
-
-	if err := coordCliCfg.Validate(); err != nil {
-		return nil, false, fmt.Errorf("invalid coordinator client configuration: %w", err)
-	}
-
-	return coordCliCfg, true, nil
-}
-
 // createCoordinatorClient creates the appropriate coordinator client based on configuration.
 // Returns the client, whether to use remote handler, and any error.
 func createCoordinatorClient(ctx *Context) (coordinator.Client, bool, error) {
-	coordCliCfg, useRemoteHandler, err := BuildCoordinatorClientConfig(ctx.Config)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if coordCliCfg == nil {
-		return ctx.NewCoordinatorClient(), false, nil
-	}
-
-	staticRegistry, err := coordinator.NewStaticRegistry(ctx.Config.Worker.Coordinators)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to create static registry: %w", err)
-	}
-	logger.Info(ctx, "Using static coordinator discovery",
-		slog.Any("coordinators", ctx.Config.Worker.Coordinators))
-
-	return coordinator.New(staticRegistry, coordCliCfg), useRemoteHandler, nil
+	return cmdprocess.NewWorkerCoordinatorClient(ctx.Context, ctx.Config, ctx.ServiceRegistry)
 }

--- a/internal/cmd/worker_test.go
+++ b/internal/cmd/worker_test.go
@@ -5,6 +5,7 @@ package cmd_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmd"
 	cmdprocess "github.com/dagucloud/dagu/internal/cmd/process"
@@ -106,6 +107,29 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 		require.NotNil(t, result)
 		assert.True(t, useRemote)
 		assert.True(t, result.Insecure)
+	})
+
+	t.Run("StaticCoordinatorsPreservePeerRetryConfig", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Config{
+			Worker: config.Worker{
+				Coordinators: []string{"localhost:50055"},
+			},
+			Core: config.Core{
+				Peer: config.Peer{
+					Insecure:      true,
+					MaxRetries:    7,
+					RetryInterval: 3 * time.Second,
+				},
+			},
+		}
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
+		assert.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, useRemote)
+		assert.Equal(t, 7, result.MaxRetries)
+		assert.Equal(t, 3*time.Second, result.RetryInterval)
 	})
 
 	t.Run("TLSValidationFailure", func(t *testing.T) {

--- a/internal/cmd/worker_test.go
+++ b/internal/cmd/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/cmd"
+	cmdprocess "github.com/dagucloud/dagu/internal/cmd/process"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				Coordinators: []string{},
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 		assert.False(t, useRemote)
@@ -81,7 +82,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				Coordinators: nil,
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 		assert.False(t, useRemote)
@@ -100,7 +101,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				},
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, useRemote)
@@ -121,7 +122,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := cmd.BuildCoordinatorClientConfig(cfg)
+		_, _, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid coordinator client configuration")
 	})
@@ -142,7 +143,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				},
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, useRemote)
@@ -167,7 +168,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				},
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, useRemote)
@@ -187,7 +188,7 @@ func TestBuildCoordinatorClientConfig(t *testing.T) {
 				},
 			},
 		}
-		result, useRemote, err := cmd.BuildCoordinatorClientConfig(cfg)
+		result, useRemote, err := cmdprocess.BuildWorkerCoordinatorClientConfig(cfg)
 		assert.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, useRemote)

--- a/internal/intg/embed/embed_test.go
+++ b/internal/intg/embed/embed_test.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	osexec "os/exec"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -22,6 +24,15 @@ func embeddedTimeout(timeout time.Duration) time.Duration {
 		return timeout * 3
 	}
 	return timeout
+}
+
+func embeddedDirectCommandYAML(t *testing.T, commandName string) string {
+	t.Helper()
+
+	commandPath, err := osexec.LookPath(commandName)
+	require.NoError(t, err)
+
+	return fmt.Sprintf("exec:\n      command: %s", strconv.Quote(commandPath))
 }
 
 func TestEmbeddedLocalRunYAML(t *testing.T) {
@@ -39,9 +50,9 @@ name: embedded-intg-local
 type: graph
 steps:
   - name: first
-    run: echo first
+    `+embeddedDirectCommandYAML(t, "whoami")+`
   - name: second
-    run: echo second
+    `+embeddedDirectCommandYAML(t, "whoami")+`
     depends: [first]
 `))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- extract command process wiring into `internal/cmd/process` modules for server, scheduler, worker, DAG store, coordinator, and agent stores
- keep `cmd.Context` as a thin adapter around role-specific process wiring
- move worker static coordinator/shared-nothing client selection behind process wiring

## Testing
- `make lint`
- `make test TEST_TARGET=./internal/cmd/...`
- `go test ./internal/cmd/... -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated initialization and wiring for server, coordinator, scheduler, worker, and data/store components into a centralized internal module, improving startup consistency and reliability.
  * Streamlined optional feature activation (event collection, notifications, incident monitors, license-gated features) for more predictable behavior.

* **Tests**
  * Updated tests to exercise and validate the new centralized helpers and runtime wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->