### PR TITLE
fix(mail): forward cfg.Attachments to the mailer instead of an empty slice

### DIFF
--- a/internal/runtime/builtin/mail/mail.go
+++ b/internal/runtime/builtin/mail/mail.go
@@ -105,7 +105,7 @@ func (e *mail) Run(ctx context.Context) error {
 		toAddresses,
 		e.cfg.Subject,
 		e.cfg.Message,
-		[]string{},
+		e.cfg.Attachments,
 	)
 	if err != nil {
 		_, _ = e.stderr.Write([]byte("error occurred."))

--- a/internal/runtime/builtin/mail/mail_test.go
+++ b/internal/runtime/builtin/mail/mail_test.go
@@ -208,17 +208,22 @@ func TestMailRunSendsAttachments(t *testing.T) {
 	require.NoError(t, err)
 
 	dataCh := make(chan string, 1)
-	serverDone := make(chan error, 1)
+	// serverErr signals fake-SMTP failures only; a clean run leaves it empty
+	// so the select below can use it as an unambiguous fail-fast case without
+	// racing the happy-path completion.
+	serverErr := make(chan error, 1)
 
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
-			serverDone <- err
+			serverErr <- err
 			return
 		}
 		defer func() { _ = conn.Close() }()
 		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
-		serverDone <- runFakeSMTP(conn, dataCh)
+		if err := runFakeSMTP(conn, dataCh); err != nil {
+			serverErr <- err
+		}
 	}()
 
 	step := core.Step{
@@ -250,11 +255,13 @@ func TestMailRunSendsAttachments(t *testing.T) {
 			"mail step must forward cfg.Attachments to the mailer")
 		assert.Contains(t, data, base64.StdEncoding.EncodeToString(attachBody),
 			"attached file contents must appear (base64) in the message")
+	case err := <-serverErr:
+		// Fail fast with the real server error instead of waiting for the
+		// timeout to elapse and reporting it as "timeout".
+		t.Fatalf("fake SMTP server error before DATA capture: %v", err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for SMTP DATA payload")
 	}
-
-	require.NoError(t, <-serverDone)
 }
 
 // runFakeSMTP implements just enough of RFC 5321 to capture the body of a

--- a/internal/runtime/builtin/mail/mail_test.go
+++ b/internal/runtime/builtin/mail/mail_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMail exercises mail executor construction: NewMail verifies that valid
+// configs (including the attachments field) decode onto mailConfig, and
+// MultipleRecipients covers the supported shapes of the `to` field (string,
+// []string, []any, and the empty-recipient error path).
 func TestMail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/builtin/mail/mail_test.go
+++ b/internal/runtime/builtin/mail/mail_test.go
@@ -4,14 +4,21 @@
 package mail
 
 import (
+	"bufio"
 	"context"
+	"encoding/base64"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMail(t *testing.T) {
@@ -175,4 +182,135 @@ func TestMail(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestMailRunSendsAttachments is an end-to-end regression test for a bug where
+// the mail step decoded `attachments:` from YAML into cfg.Attachments but then
+// passed []string{} to the mailer, silently dropping every attachment. It
+// stands up an in-process fake SMTP server, drives the mail executor against
+// it, and asserts the captured DATA payload references the attachment.
+func TestMailRunSendsAttachments(t *testing.T) {
+	t.Parallel()
+
+	attachPath := filepath.Join(t.TempDir(), "report.txt")
+	attachBody := []byte("hello-from-dagu-attachment-test")
+	require.NoError(t, os.WriteFile(attachPath, attachBody, 0600))
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
+
+	dataCh := make(chan string, 1)
+	serverDone := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		serverDone <- runFakeSMTP(conn, dataCh)
+	}()
+
+	step := core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Config: map[string]any{
+				"from":        "sender@example.com",
+				"to":          "rcpt@example.com",
+				"subject":     "Attachment regression",
+				"message":     "Body content",
+				"attachments": []string{attachPath},
+			},
+		},
+	}
+
+	ctx := runtime.NewContext(context.Background(), &core.DAG{
+		SMTP: &core.SMTPConfig{Host: host, Port: port},
+	}, "", "")
+
+	exec, err := newMail(ctx, step)
+	require.NoError(t, err)
+	exec.SetStdout(io.Discard)
+	exec.SetStderr(io.Discard)
+
+	require.NoError(t, exec.Run(ctx))
+
+	select {
+	case data := <-dataCh:
+		assert.Contains(t, data, "Content-Disposition: attachment; filename=report.txt",
+			"mail step must forward cfg.Attachments to the mailer")
+		assert.Contains(t, data, base64.StdEncoding.EncodeToString(attachBody),
+			"attached file contents must appear (base64) in the message")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for SMTP DATA payload")
+	}
+
+	require.NoError(t, <-serverDone)
+}
+
+// runFakeSMTP implements just enough of RFC 5321 to capture the body of a
+// single message: greeting → EHLO → MAIL FROM → RCPT TO → DATA → body → QUIT.
+// The DATA payload (excluding the trailing "\r\n.\r\n" terminator) is sent on
+// dataCh.
+func runFakeSMTP(conn net.Conn, dataCh chan<- string) error {
+	r := bufio.NewReader(conn)
+	write := func(s string) error {
+		_, err := conn.Write([]byte(s))
+		return err
+	}
+
+	if err := write("220 fake.dagu.test ready\r\n"); err != nil {
+		return err
+	}
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		cmd := strings.ToUpper(strings.TrimSpace(line))
+		switch {
+		case strings.HasPrefix(cmd, "EHLO"), strings.HasPrefix(cmd, "HELO"):
+			if err := write("250-fake.dagu.test\r\n250 OK\r\n"); err != nil {
+				return err
+			}
+		case strings.HasPrefix(cmd, "MAIL FROM"), strings.HasPrefix(cmd, "RCPT TO"):
+			if err := write("250 OK\r\n"); err != nil {
+				return err
+			}
+		case cmd == "DATA":
+			if err := write("354 End data with <CR><LF>.<CR><LF>\r\n"); err != nil {
+				return err
+			}
+			var body strings.Builder
+			for {
+				dataLine, err := r.ReadString('\n')
+				if err != nil {
+					return err
+				}
+				if dataLine == ".\r\n" {
+					break
+				}
+				body.WriteString(dataLine)
+			}
+			dataCh <- body.String()
+			if err := write("250 OK\r\n"); err != nil {
+				return err
+			}
+		case cmd == "QUIT":
+			_ = write("221 Bye\r\n")
+			return nil
+		case cmd == "":
+			// blank line — ignore
+		default:
+			if err := write("502 unrecognized\r\n"); err != nil {
+				return err
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

The `mail` step decodes `attachments:` from YAML into `cfg.Attachments` but
then hands a hardcoded `[]string{}` to `mailer.Send`, silently dropping every
attachment. The schema, docs, and config field all suggest the feature works;
only the one call site that hands the slice to the mailer ignores it.

## Changes

- `internal/runtime/builtin/mail/mail.go`: pass `e.cfg.Attachments` instead of `[]string{}` to `mailer.Send`.
- `internal/runtime/builtin/mail/mail_test.go`: add `TestMailRunSendsAttachments`, an end-to-end regression test that drives the executor against an in-process fake SMTP server and asserts the captured DATA payload contains `Content-Disposition: attachment; filename=<basename>` and the base64-encoded file body.

The existing `TestMail` only asserts that `cfg.Attachments` decodes correctly from YAML; it never invokes `Run()`, which is why this slipped through. The new test fails against the previous code with a clear diagnostic and passes with the fix.

## Repro (before the fix)

```yaml
smtp:
  host: smtp.example.com
  port: "587"

steps:
  - name: send
    executor:
      type: mail
      config:
        from: a@example.com
        to: b@example.com
        subject: hello
        message: see attached
        attachments:
          - /tmp/report.xlsx
```

This step succeeds and logs "sending email succeed.", but `report.xlsx` is never on the outgoing message.

## Related Issues

(none filed — happy to open one first if maintainers prefer)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed (feature was already documented as working)
- [x] Changes have been tested locally (go test ./internal/runtime/builtin/mail/...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email attachments configured in mail steps are now correctly included and transmitted with outgoing messages.

* **Tests**
  * Added an end-to-end regression test that verifies attachments are sent and their encoded content and filenames appear in outgoing emails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->