### PR TITLE
fix: prevent false zombie repair for live local runs

### DIFF
--- a/internal/cmn/procutil/process.go
+++ b/internal/cmn/procutil/process.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package procutil
+
+// IsAlive reports whether pid currently refers to a live OS process.
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return isAlive(pid)
+}

--- a/internal/cmn/procutil/process.go
+++ b/internal/cmn/procutil/process.go
@@ -3,10 +3,43 @@
 
 package procutil
 
+import "github.com/shirou/gopsutil/v4/process"
+
+const maxPIDInt32 = 1<<31 - 1
+
 // IsAlive reports whether pid currently refers to a live OS process.
 func IsAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
 	return isAlive(pid)
+}
+
+// StartTime returns the process creation time as Unix milliseconds.
+func StartTime(pid int) (int64, bool) {
+	if pid <= 0 || pid > maxPIDInt32 {
+		return 0, false
+	}
+	proc, err := process.NewProcess(int32(pid)) //nolint:gosec // pid is bounded by maxPIDInt32
+	if err != nil {
+		return 0, false
+	}
+	startedAt, err := proc.CreateTime()
+	if err != nil || startedAt <= 0 {
+		return 0, false
+	}
+	return startedAt, true
+}
+
+// MatchesStartTime reports whether pid still refers to the process that
+// started at expectedStartedAt. actualStartedAt is set when lookup succeeds.
+func MatchesStartTime(pid int, expectedStartedAt int64) (matched bool, actualStartedAt int64, ok bool) {
+	if expectedStartedAt <= 0 {
+		return false, 0, false
+	}
+	actualStartedAt, ok = StartTime(pid)
+	if !ok {
+		return false, 0, false
+	}
+	return actualStartedAt == expectedStartedAt, actualStartedAt, true
 }

--- a/internal/cmn/procutil/process.go
+++ b/internal/cmn/procutil/process.go
@@ -3,8 +3,6 @@
 
 package procutil
 
-import "github.com/shirou/gopsutil/v4/process"
-
 const maxPIDInt32 = 1<<31 - 1
 
 // IsAlive reports whether pid currently refers to a live OS process.
@@ -20,15 +18,7 @@ func StartTime(pid int) (int64, bool) {
 	if pid <= 0 || pid > maxPIDInt32 {
 		return 0, false
 	}
-	proc, err := process.NewProcess(int32(pid)) //nolint:gosec // pid is bounded by maxPIDInt32
-	if err != nil {
-		return 0, false
-	}
-	startedAt, err := proc.CreateTime()
-	if err != nil || startedAt <= 0 {
-		return 0, false
-	}
-	return startedAt, true
+	return startTime(pid)
 }
 
 // MatchesStartTime reports whether pid still refers to the process that

--- a/internal/cmn/procutil/process.go
+++ b/internal/cmn/procutil/process.go
@@ -3,8 +3,6 @@
 
 package procutil
 
-const maxPIDInt32 = 1<<31 - 1
-
 // IsAlive reports whether pid currently refers to a live OS process.
 func IsAlive(pid int) bool {
 	if pid <= 0 {
@@ -15,7 +13,7 @@ func IsAlive(pid int) bool {
 
 // StartTime returns the process creation time as Unix milliseconds.
 func StartTime(pid int) (int64, bool) {
-	if pid <= 0 || pid > maxPIDInt32 {
+	if pid <= 0 || !canLookupStartTime(pid) {
 		return 0, false
 	}
 	return startTime(pid)

--- a/internal/cmn/procutil/process_test.go
+++ b/internal/cmn/procutil/process_test.go
@@ -17,3 +17,20 @@ func TestIsAlive(t *testing.T) {
 	require.False(t, IsAlive(-1))
 	require.True(t, IsAlive(os.Getpid()))
 }
+
+func TestStartTime(t *testing.T) {
+	t.Parallel()
+
+	startedAt, ok := StartTime(os.Getpid())
+	require.True(t, ok)
+	require.Positive(t, startedAt)
+
+	matched, actualStartedAt, ok := MatchesStartTime(os.Getpid(), startedAt)
+	require.True(t, ok)
+	require.True(t, matched)
+	require.Equal(t, startedAt, actualStartedAt)
+
+	matched, _, ok = MatchesStartTime(os.Getpid(), startedAt+1)
+	require.True(t, ok)
+	require.False(t, matched)
+}

--- a/internal/cmn/procutil/process_test.go
+++ b/internal/cmn/procutil/process_test.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package procutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAlive(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsAlive(0))
+	require.False(t, IsAlive(-1))
+	require.True(t, IsAlive(os.Getpid()))
+}

--- a/internal/cmn/procutil/process_unix.go
+++ b/internal/cmn/procutil/process_unix.go
@@ -8,9 +8,23 @@ package procutil
 import (
 	"errors"
 	"syscall"
+
+	"github.com/shirou/gopsutil/v4/process"
 )
 
 func isAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func startTime(pid int) (int64, bool) {
+	proc, err := process.NewProcess(int32(pid)) //nolint:gosec // pid is bounded by StartTime.
+	if err != nil {
+		return 0, false
+	}
+	startedAt, err := proc.CreateTime()
+	if err != nil || startedAt <= 0 {
+		return 0, false
+	}
+	return startedAt, true
 }

--- a/internal/cmn/procutil/process_unix.go
+++ b/internal/cmn/procutil/process_unix.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package procutil
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/cmn/procutil/process_unix.go
+++ b/internal/cmn/procutil/process_unix.go
@@ -12,9 +12,15 @@ import (
 	"github.com/shirou/gopsutil/v4/process"
 )
 
+const maxPIDInt32 = 1<<31 - 1
+
 func isAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func canLookupStartTime(pid int) bool {
+	return pid > 0 && pid <= maxPIDInt32
 }
 
 func startTime(pid int) (int64, bool) {

--- a/internal/cmn/procutil/process_unix_test.go
+++ b/internal/cmn/procutil/process_unix_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package procutil
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanLookupStartTimeRejectsPIDsAboveInt32(t *testing.T) {
+	t.Parallel()
+
+	if strconv.IntSize < 64 {
+		t.Skip("requires an int that can represent a PID above int32")
+	}
+
+	one := int64(1)
+	require.False(t, canLookupStartTime(int(one<<31)))
+}

--- a/internal/cmn/procutil/process_windows.go
+++ b/internal/cmn/procutil/process_windows.go
@@ -5,7 +5,11 @@
 
 package procutil
 
-import "golang.org/x/sys/windows"
+import (
+	"time"
+
+	"golang.org/x/sys/windows"
+)
 
 const windowsStillActiveExitCode = 259
 
@@ -21,4 +25,26 @@ func isAlive(pid int) bool {
 		return true
 	}
 	return exitCode == windowsStillActiveExitCode
+}
+
+func startTime(pid int) (int64, bool) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return 0, false
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck
+
+	var creationTime windows.Filetime
+	var exitTime windows.Filetime
+	var kernelTime windows.Filetime
+	var userTime windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return 0, false
+	}
+
+	startedAt := creationTime.Nanoseconds() / int64(time.Millisecond)
+	if startedAt <= 0 {
+		return 0, false
+	}
+	return startedAt, true
 }

--- a/internal/cmn/procutil/process_windows.go
+++ b/internal/cmn/procutil/process_windows.go
@@ -12,8 +12,12 @@ import (
 )
 
 const windowsStillActiveExitCode = 259
+const maxPIDUint32 = 1<<32 - 1
 
 func isAlive(pid int) bool {
+	if !canUseWindowsPID(pid) {
+		return false
+	}
 	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return err == windows.ERROR_ACCESS_DENIED
@@ -25,6 +29,14 @@ func isAlive(pid int) bool {
 		return true
 	}
 	return exitCode == windowsStillActiveExitCode
+}
+
+func canLookupStartTime(pid int) bool {
+	return canUseWindowsPID(pid)
+}
+
+func canUseWindowsPID(pid int) bool {
+	return pid > 0 && uint64(pid) <= maxPIDUint32
 }
 
 func startTime(pid int) (int64, bool) {

--- a/internal/cmn/procutil/process_windows.go
+++ b/internal/cmn/procutil/process_windows.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package procutil
+
+import "golang.org/x/sys/windows"
+
+const windowsStillActiveExitCode = 259
+
+func isAlive(pid int) bool {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return err == windows.ERROR_ACCESS_DENIED
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return true
+	}
+	return exitCode == windowsStillActiveExitCode
+}

--- a/internal/cmn/procutil/process_windows_test.go
+++ b/internal/cmn/procutil/process_windows_test.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package procutil
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanLookupStartTimeAcceptsWindowsUint32PIDs(t *testing.T) {
+	t.Parallel()
+
+	if strconv.IntSize < 64 {
+		t.Skip("requires an int that can represent Windows uint32 PIDs above int32")
+	}
+
+	one := int64(1)
+	require.True(t, canLookupStartTime(int(one<<31)))
+	require.True(t, canLookupStartTime(int((one<<32)-1)))
+	require.False(t, canLookupStartTime(int(one<<32)))
+}

--- a/internal/core/exec/queue_abort.go
+++ b/internal/core/exec/queue_abort.go
@@ -54,6 +54,7 @@ func AbortQueuedDAGRun(ctx context.Context, dagRunStore DAGRunStore, dagRun DAGR
 			latest.FinishedAt = finishedAt
 			latest.WorkerID = ""
 			latest.PID = 0
+			latest.PIDStartedAt = 0
 			latest.LeaseAt = 0
 			return nil
 		},

--- a/internal/core/exec/runstatus.go
+++ b/internal/core/exec/runstatus.go
@@ -84,6 +84,7 @@ type DAGRunStatus struct {
 	TriggerType    core.TriggerType `json:"triggerType,omitempty"`
 	WorkerID       string           `json:"workerId,omitempty"`
 	PID            PID              `json:"pid,omitempty"`
+	PIDStartedAt   int64            `json:"pidStartedAt,omitempty"`
 	Nodes          []*Node          `json:"nodes,omitempty"`
 	OnInit         *Node            `json:"onInit,omitempty"`
 	OnExit         *Node            `json:"onExit,omitempty"`

--- a/internal/persis/fileproc/handle.go
+++ b/internal/persis/fileproc/handle.go
@@ -34,6 +34,7 @@ type ProcHandle struct {
 	cancel            context.CancelFunc
 	mu                sync.Mutex
 	wg                sync.WaitGroup
+	syncWG            sync.WaitGroup
 	syncing           atomic.Bool
 	meta              exec.ProcMeta
 	heartbeatInterval time.Duration
@@ -139,6 +140,7 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 		}()
 
 		defer func() {
+			p.syncWG.Wait()
 			_ = fd.Close()
 			// On Windows, another process (e.g., the scheduler) may hold a
 			// transient read handle on the proc file, causing os.Remove to fail
@@ -185,6 +187,7 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 					}
 					logger.Warn(ctx, "Heartbeat file deleted externally, recreating",
 						tag.File(p.fileName))
+					p.syncWG.Wait()
 					_ = fd.Close()
 					newFd, err := p.recreateFile(heartbeatUnix)
 					if err != nil {
@@ -209,7 +212,9 @@ func (p *ProcHandle) requestSync(ctx context.Context, fd *os.File) {
 	if !p.syncing.CompareAndSwap(false, true) {
 		return
 	}
+	p.syncWG.Add(1)
 	go func() {
+		defer p.syncWG.Done()
 		defer p.syncing.Store(false)
 		if err := p.syncFile(fd); err != nil {
 			logger.Debug(ctx, "Failed to sync heartbeat file",

--- a/internal/persis/fileproc/handle.go
+++ b/internal/persis/fileproc/handle.go
@@ -34,9 +34,11 @@ type ProcHandle struct {
 	cancel            context.CancelFunc
 	mu                sync.Mutex
 	wg                sync.WaitGroup
+	syncing           atomic.Bool
 	meta              exec.ProcMeta
 	heartbeatInterval time.Duration
 	syncInterval      time.Duration
+	syncFile          func(*os.File) error
 }
 
 // GetMeta implements models.ProcHandle.
@@ -59,6 +61,7 @@ func NewProcHandler(file string, meta exec.ProcMeta, heartbeatInterval, syncInte
 		meta:              meta,
 		heartbeatInterval: heartbeatInterval,
 		syncInterval:      syncInterval,
+		syncFile:          (*os.File).Sync,
 	}
 }
 
@@ -169,7 +172,6 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 		for {
 			select {
 			case <-hbCtx.Done():
-				_ = fd.Sync()
 				return
 			case <-ticker.C:
 				heartbeatUnix := time.Now().Unix()
@@ -195,12 +197,26 @@ func (p *ProcHandle) startHeartbeat(ctx context.Context) error {
 				}
 
 			case <-flush.C:
-				_ = fd.Sync()
+				p.requestSync(ctx, fd)
 			}
 		}
 	}()
 
 	return nil
+}
+
+func (p *ProcHandle) requestSync(ctx context.Context, fd *os.File) {
+	if !p.syncing.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer p.syncing.Store(false)
+		if err := p.syncFile(fd); err != nil {
+			logger.Debug(ctx, "Failed to sync heartbeat file",
+				tag.File(p.fileName),
+				tag.Error(err))
+		}
+	}()
 }
 
 // recreateFile creates a new heartbeat file after the original was deleted externally.

--- a/internal/persis/fileproc/handle.go
+++ b/internal/persis/fileproc/handle.go
@@ -212,16 +212,14 @@ func (p *ProcHandle) requestSync(ctx context.Context, fd *os.File) {
 	if !p.syncing.CompareAndSwap(false, true) {
 		return
 	}
-	p.syncWG.Add(1)
-	go func() {
-		defer p.syncWG.Done()
+	p.syncWG.Go(func() {
 		defer p.syncing.Store(false)
 		if err := p.syncFile(fd); err != nil {
 			logger.Debug(ctx, "Failed to sync heartbeat file",
 				tag.File(p.fileName),
 				tag.Error(err))
 		}
-	}()
+	})
 }
 
 // recreateFile creates a new heartbeat file after the original was deleted externally.

--- a/internal/persis/fileproc/handle_test.go
+++ b/internal/persis/fileproc/handle_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -136,6 +137,52 @@ func TestProcHandle_StartPublishesInitializedFile(t *testing.T) {
 	entry, err := readProcEntry(fileName, meta.Name, time.Minute, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, meta, entry.Meta)
+}
+
+func TestProcHandle_HeartbeatContinuesWhileSyncBlocked(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	meta := testProcMetaFromRun(exec.NewDAGRunRef("test_proc", "run-1"))
+	fileName := procFilePath(tmpDir, exec.NewUTC(time.Now()), meta)
+	proc := NewProcHandler(fileName, meta, 20*time.Millisecond, time.Millisecond)
+
+	syncStarted := make(chan struct{})
+	releaseSync := make(chan struct{})
+	var closeStarted sync.Once
+	proc.syncFile = func(*os.File) error {
+		closeStarted.Do(func() {
+			close(syncStarted)
+		})
+		<-releaseSync
+		return nil
+	}
+
+	require.NoError(t, proc.startHeartbeat(ctx))
+	t.Cleanup(func() {
+		close(releaseSync)
+		_ = proc.Stop(ctx)
+	})
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-syncStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	initialInfo, err := os.Stat(fileName)
+	require.NoError(t, err)
+	initialModTime := initialInfo.ModTime()
+
+	require.Eventually(t, func() bool {
+		info, statErr := os.Stat(fileName)
+		return statErr == nil && info.ModTime().After(initialModTime)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestProcHandle_OpenInitializedProcFileRecreatesMissingParentDir(t *testing.T) {

--- a/internal/persis/fileproc/handle_test.go
+++ b/internal/persis/fileproc/handle_test.go
@@ -185,6 +185,67 @@ func TestProcHandle_HeartbeatContinuesWhileSyncBlocked(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestProcHandle_StopWaitsForInFlightSync(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	meta := testProcMetaFromRun(exec.NewDAGRunRef("test_proc", "run-1"))
+	fileName := procFilePath(tmpDir, exec.NewUTC(time.Now()), meta)
+	proc := NewProcHandler(fileName, meta, 20*time.Millisecond, time.Millisecond)
+
+	syncStarted := make(chan struct{})
+	releaseSync := make(chan struct{})
+	var closeRelease sync.Once
+	release := func() {
+		closeRelease.Do(func() {
+			close(releaseSync)
+		})
+	}
+	proc.syncFile = func(*os.File) error {
+		close(syncStarted)
+		<-releaseSync
+		return nil
+	}
+
+	require.NoError(t, proc.startHeartbeat(ctx))
+	t.Cleanup(func() {
+		release()
+		_ = proc.Stop(ctx)
+	})
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-syncStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- proc.Stop(ctx)
+	}()
+
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+		t.Fatal("Stop returned before the in-flight sync finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	_, err := os.Stat(fileName)
+	require.NoError(t, err, "heartbeat file should not be removed while sync is still in-flight")
+
+	release()
+	require.NoError(t, <-stopDone)
+
+	_, err = os.Stat(fileName)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestProcHandle_OpenInitializedProcFileRecreatesMissingParentDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/fileproc/handle_test.go
+++ b/internal/persis/fileproc/handle_test.go
@@ -197,6 +197,7 @@ func TestProcHandle_StopWaitsForInFlightSync(t *testing.T) {
 
 	syncStarted := make(chan struct{})
 	releaseSync := make(chan struct{})
+	var closeStarted sync.Once
 	var closeRelease sync.Once
 	release := func() {
 		closeRelease.Do(func() {
@@ -204,7 +205,9 @@ func TestProcHandle_StopWaitsForInFlightSync(t *testing.T) {
 		})
 	}
 	proc.syncFile = func(*os.File) error {
-		close(syncStarted)
+		closeStarted.Do(func() {
+			close(syncStarted)
+		})
 		<-releaseSync
 		return nil
 	}

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/cmn/mailer"
 	"github.com/dagucloud/dagu/internal/cmn/masking"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/cmn/secrets"
 	"github.com/dagucloud/dagu/internal/cmn/signal"
 	"github.com/dagucloud/dagu/internal/cmn/sock"
@@ -53,6 +54,11 @@ import (
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin"
+)
+
+var (
+	currentPIDStartedAtOnce  sync.Once
+	currentPIDStartedAtValue int64
 )
 
 // Agent is responsible for running the DAG and handling communication
@@ -1237,6 +1243,7 @@ func (a *Agent) Status(ctx context.Context) exec.DAGRunStatus {
 			transform.WithArchiveDir(a.artifactDir),
 			transform.WithTriggerType(a.triggerType),
 			transform.WithAutoRetryCount(a.currentAutoRetryCount()),
+			transform.WithPIDStartedAt(currentPIDStartedAt()),
 		}
 		if source != nil {
 			statusOpts = append(statusOpts,
@@ -1279,6 +1286,7 @@ func (a *Agent) Status(ctx context.Context) exec.DAGRunStatus {
 		transform.WithWorkerID(a.workerID),
 		transform.WithTriggerType(a.triggerType),
 		transform.WithAutoRetryCount(a.currentAutoRetryCount()),
+		transform.WithPIDStartedAt(currentPIDStartedAt()),
 	}
 
 	// If the current execution is based on a persisted target, copy timing data
@@ -1306,6 +1314,16 @@ func (a *Agent) Status(ctx context.Context) exec.DAGRunStatus {
 			opts...,
 		)
 	return status
+}
+
+func currentPIDStartedAt() int64 {
+	currentPIDStartedAtOnce.Do(func() {
+		startedAt, ok := procutil.StartTime(os.Getpid())
+		if ok {
+			currentPIDStartedAtValue = startedAt
+		}
+	})
+	return currentPIDStartedAtValue
 }
 
 func (a *Agent) currentAutoRetryCount() int {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -463,13 +463,25 @@ func (m *Manager) repairStaleLocalRunIfDead(
 		return st, nil
 	}
 
-	if st.PID > 0 && procutil.IsAlive(int(st.PID)) {
-		logger.Debug(ctx, "Skipping stale local run repair because local process is still alive despite stale proc heartbeat",
-			tag.RunID(st.DAGRunID),
-			tag.AttemptID(st.AttemptID),
-			tag.PID(int(st.PID)),
-		)
-		return st, nil
+	if st.PID > 0 && st.PIDStartedAt > 0 {
+		matched, actualStartedAt, ok := procutil.MatchesStartTime(int(st.PID), st.PIDStartedAt)
+		if matched {
+			logger.Debug(ctx, "Skipping stale local run repair because local process identity is still alive despite stale proc heartbeat",
+				tag.RunID(st.DAGRunID),
+				tag.AttemptID(st.AttemptID),
+				tag.PID(int(st.PID)),
+			)
+			return st, nil
+		}
+		if ok {
+			logger.Debug(ctx, "Not skipping stale local run repair because PID start time does not match persisted run status",
+				tag.RunID(st.DAGRunID),
+				tag.AttemptID(st.AttemptID),
+				tag.PID(int(st.PID)),
+				slog.Int64("expected-pid-started-at", st.PIDStartedAt),
+				slog.Int64("actual-pid-started-at", actualStartedAt),
+			)
+		}
 	}
 
 	repaired, _, err := RepairStaleLocalRun(ctx, attempt, dag)

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/cmn/sock"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
@@ -421,10 +422,9 @@ func (m *Manager) GetLatestStatus(ctx context.Context, dag *core.DAG) (exec.DAGR
 }
 
 // repairStaleLocalRunIfDead repairs a persisted local Running status only when
-// the run has no matching fresh proc heartbeat. "Dead" here means the proc
-// store cannot find any non-stale heartbeat file for the local run; it is not
-// an OS-level PID liveness check. Distributed runs are excluded because local
-// proc heartbeats are not authoritative for remote workers.
+// the run has no matching fresh proc heartbeat and its recorded local process
+// is no longer alive. Distributed runs are excluded because local proc
+// heartbeats are not authoritative for remote workers.
 func (m *Manager) repairStaleLocalRunIfDead(
 	ctx context.Context,
 	attempt exec.DAGRunAttempt,
@@ -459,6 +459,15 @@ func (m *Manager) repairStaleLocalRunIfDead(
 		logger.Debug(ctx, "Skipping stale local run repair because DAG run still has a fresh proc heartbeat",
 			tag.RunID(st.DAGRunID),
 			tag.AttemptID(st.AttemptID),
+		)
+		return st, nil
+	}
+
+	if st.PID > 0 && procutil.IsAlive(int(st.PID)) {
+		logger.Debug(ctx, "Skipping stale local run repair because local process is still alive despite stale proc heartbeat",
+			tag.RunID(st.DAGRunID),
+			tag.AttemptID(st.AttemptID),
+			tag.PID(int(st.PID)),
 		)
 		return st, nil
 	}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/cmn/sock"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -270,6 +271,9 @@ steps:
 		runningStatus.AttemptKey = exec.GenerateAttemptKey(dag.Name, dagRunID, dag.Name, dagRunID, runningStatus.AttemptID)
 		runningStatus.WorkerID = "local"
 		runningStatus.PID = exec.PID(os.Getpid())
+		pidStartedAt, ok := procutil.StartTime(os.Getpid())
+		require.True(t, ok)
+		runningStatus.PIDStartedAt = pidStartedAt
 		staleAt := time.Now().Add(-3 * time.Second)
 		runningStatus.StartedAt = staleAt.UTC().Format(time.RFC3339)
 		runningStatus.CreatedAt = staleAt.UnixMilli()

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -238,6 +239,42 @@ steps:
 		defer func() {
 			_ = proc.Stop(ctx)
 		}()
+
+		latest, err := th.DAGRunMgr.GetLatestStatus(ctx, dag.DAG)
+		require.NoError(t, err)
+		require.Equal(t, core.Running, latest.Status)
+		require.Equal(t, core.NodeRunning, latest.Nodes[0].Status)
+		require.Empty(t, latest.Error)
+
+		persisted, err := att.ReadStatus(ctx)
+		require.NoError(t, err)
+		require.Equal(t, core.Running, persisted.Status)
+		require.Equal(t, core.NodeRunning, persisted.Nodes[0].Status)
+	})
+	t.Run("GetLatestStatusKeepsRunAliveWithStaleHeartbeatAndAlivePID", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		now := time.Now()
+		ctx := th.Context
+
+		att, err := th.DAGRunStore.CreateAttempt(ctx, dag.DAG, now, dagRunID, exec.NewDAGRunAttemptOptions{})
+		require.NoError(t, err)
+		require.NoError(t, att.Open(ctx))
+
+		runningStatus := testNewStatus(dag.DAG, dagRunID, core.Running, core.NodeRunning)
+		runningStatus.AttemptID = att.ID()
+		runningStatus.AttemptKey = exec.GenerateAttemptKey(dag.Name, dagRunID, dag.Name, dagRunID, runningStatus.AttemptID)
+		runningStatus.WorkerID = "local"
+		runningStatus.PID = exec.PID(os.Getpid())
+		staleAt := time.Now().Add(-3 * time.Second)
+		runningStatus.StartedAt = staleAt.UTC().Format(time.RFC3339)
+		runningStatus.CreatedAt = staleAt.UnixMilli()
+		require.NoError(t, att.Write(ctx, runningStatus))
+		require.NoError(t, att.Close(ctx))
 
 		latest, err := th.DAGRunMgr.GetLatestStatus(ctx, dag.DAG)
 		require.NoError(t, err)

--- a/internal/runtime/subcmd.go
+++ b/internal/runtime/subcmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/buildenv"
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -499,23 +500,45 @@ func effectiveLabels(labels, tags string) string {
 	return tags
 }
 
+// StartResult describes an asynchronously started subprocess.
+type StartResult struct {
+	PID          int
+	PIDStartedAt int64
+	Done         <-chan error
+}
+
 // Start executes the command without waiting for it to complete.
 func Start(ctx context.Context, spec CmdSpec) error {
+	_, err := StartProcess(ctx, spec)
+	return err
+}
+
+// StartProcess executes the command without waiting for it to complete and
+// returns the started process identity plus an eventual completion signal.
+func StartProcess(ctx context.Context, spec CmdSpec) (*StartResult, error) {
 	cmd, cleanup, err := newCommand(ctx, spec, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := cmd.Start(); err != nil {
 		cleanupTransport(cleanup)
-		return fmt.Errorf("failed to start command: %w", err)
+		return nil, fmt.Errorf("failed to start command: %w", err)
 	}
 
+	pid := cmd.Process.Pid
+	startedAt, _ := procutil.StartTime(pid)
+	done := make(chan error, 1)
 	go execWithRecovery(ctx, func() {
-		_ = cmd.Wait()
-		cleanupTransport(cleanup)
+		defer close(done)
+		defer cleanupTransport(cleanup)
+		done <- cmd.Wait()
 	})
 
-	return nil
+	return &StartResult{
+		PID:          pid,
+		PIDStartedAt: startedAt,
+		Done:         done,
+	}, nil
 }
 
 // newCommand creates an exec.Cmd from the spec with proper configuration.

--- a/internal/runtime/subcmd_test.go
+++ b/internal/runtime/subcmd_test.go
@@ -4,6 +4,7 @@
 package runtime_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1038,4 +1039,34 @@ func TestCmdSpec(t *testing.T) {
 		assert.Equal(t, os.Stdout, spec.Stdout)
 		assert.Equal(t, os.Stderr, spec.Stderr)
 	})
+}
+
+func TestStartProcessReportsPIDAndCompletion(t *testing.T) {
+	t.Parallel()
+
+	env := append(os.Environ(), "DAGU_RUNTIME_STARTPROCESS_HELPER=1")
+	result, err := runtime.StartProcess(context.Background(), runtime.CmdSpec{
+		Executable: os.Args[0],
+		Args:       []string{"-test.run=TestStartProcessHelperProcess"},
+		Env:        env,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Positive(t, result.PID)
+	require.NotNil(t, result.Done)
+
+	select {
+	case err, ok := <-result.Done:
+		require.True(t, ok)
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("start process helper did not exit")
+	}
+}
+
+func TestStartProcessHelperProcess(_ *testing.T) {
+	if os.Getenv("DAGU_RUNTIME_STARTPROCESS_HELPER") != "1" {
+		return
+	}
+	os.Exit(0)
 }

--- a/internal/runtime/subcmd_test.go
+++ b/internal/runtime/subcmd_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1044,12 +1045,7 @@ func TestCmdSpec(t *testing.T) {
 func TestStartProcessReportsPIDAndCompletion(t *testing.T) {
 	t.Parallel()
 
-	env := append(os.Environ(), "DAGU_RUNTIME_STARTPROCESS_HELPER=1")
-	result, err := runtime.StartProcess(context.Background(), runtime.CmdSpec{
-		Executable: os.Args[0],
-		Args:       []string{"-test.run=TestStartProcessHelperProcess"},
-		Env:        env,
-	})
+	result, err := runtime.StartProcess(context.Background(), exitingCommandSpec())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Positive(t, result.PID)
@@ -1064,9 +1060,15 @@ func TestStartProcessReportsPIDAndCompletion(t *testing.T) {
 	}
 }
 
-func TestStartProcessHelperProcess(_ *testing.T) {
-	if os.Getenv("DAGU_RUNTIME_STARTPROCESS_HELPER") != "1" {
-		return
+func exitingCommandSpec() runtime.CmdSpec {
+	if goruntime.GOOS == "windows" {
+		return runtime.CmdSpec{
+			Executable: "cmd.exe",
+			Args:       []string{"/c", "exit", "0"},
+		}
 	}
-	os.Exit(0)
+	return runtime.CmdSpec{
+		Executable: "/bin/sh",
+		Args:       []string{"-c", "exit 0"},
+	}
 }

--- a/internal/runtime/transform/status.go
+++ b/internal/runtime/transform/status.go
@@ -181,6 +181,13 @@ func WithWorkerID(workerID string) StatusOption {
 	}
 }
 
+// WithPIDStartedAt returns a StatusOption that sets the OS process start time.
+func WithPIDStartedAt(startedAt int64) StatusOption {
+	return func(s *exec.DAGRunStatus) {
+		s.PIDStartedAt = startedAt
+	}
+}
+
 // WithTriggerType returns a StatusOption that sets the trigger type
 func WithTriggerType(triggerType core.TriggerType) StatusOption {
 	return func(s *exec.DAGRunStatus) {

--- a/internal/runtime/transform/status_test.go
+++ b/internal/runtime/transform/status_test.go
@@ -148,6 +148,7 @@ func TestStatusBuilderWithOptions(t *testing.T) {
 		transform.WithQueuedAt("2024-01-01 12:00:00"),
 		transform.WithCreatedAt(1234567890),
 		transform.WithWorkerID("worker-abc"),
+		transform.WithPIDStartedAt(9876543210),
 	)
 
 	assert.Equal(t, stringutil.FormatTime(finishedAt), result.FinishedAt)
@@ -165,6 +166,7 @@ func TestStatusBuilderWithOptions(t *testing.T) {
 	assert.Equal(t, "2024-01-01 12:00:00", result.QueuedAt)
 	assert.Equal(t, int64(1234567890), result.CreatedAt)
 	assert.Equal(t, "worker-abc", result.WorkerID)
+	assert.Equal(t, int64(9876543210), result.PIDStartedAt)
 }
 
 func TestStatusBuilderPopulatesPendingStepRetriesFromNodes(t *testing.T) {

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2604,6 +2604,7 @@ func finalizeNotStartedCancellation(ctx context.Context, attempt exec.DAGRunAtte
 	status.Error = context.Canceled.Error()
 	status.WorkerID = ""
 	status.PID = 0
+	status.PIDStartedAt = 0
 	status.LeaseAt = 0
 
 	if err := attempt.Open(ctx); err != nil {

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1287,24 +1287,57 @@ type startDAGRunOptions struct {
 }
 
 // waitForDAGStatusChange waits until the DAG status transitions from NotStarted.
-// Returns true if the status changed, false if timeout or context cancelled.
-func (a *API) waitForDAGStatusChange(ctx context.Context, dag *core.DAG, dagRunID string, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	pollInterval := 100 * time.Millisecond
+// It returns false with nil error when the wait times out normally.
+func (a *API) waitForDAGStatusChange(ctx context.Context, dag *core.DAG, dagRunID string, timeout time.Duration) (bool, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		select {
 		case <-ctx.Done():
-			return false
+			return false, ctx.Err()
 		default:
-			status, _ := a.dagRunMgr.GetCurrentStatus(ctx, dag, dagRunID)
-			if status != nil && status.Status != core.NotStarted {
-				return true
-			}
-			time.Sleep(pollInterval)
+		}
+
+		status, _ := a.dagRunMgr.GetCurrentStatus(ctx, dag, dagRunID)
+		if status != nil && status.Status != core.NotStarted {
+			return true, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+			return false, nil
+		case <-ticker.C:
 		}
 	}
-	return false
+}
+
+func dagStartWaitContextError(err error) *Error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return &Error{
+			HTTPStatus: statusClientClosedRequest,
+			Code:       api.ErrorCodeInternalError,
+			Message:    "DAG start request canceled",
+		}
+	case errors.Is(err, context.DeadlineExceeded):
+		return &Error{
+			HTTPStatus: http.StatusGatewayTimeout,
+			Code:       api.ErrorCodeTimeout,
+			Message:    "DAG start request timed out",
+		}
+	default:
+		return &Error{
+			HTTPStatus: http.StatusInternalServerError,
+			Code:       api.ErrorCodeInternalError,
+			Message:    err.Error(),
+		}
+	}
 }
 
 func (a *API) waitForLocalDAGStart(
@@ -1314,7 +1347,11 @@ func (a *API) waitForLocalDAGStart(
 	started *runtime.StartResult,
 	timeout time.Duration,
 ) error {
-	if a.waitForDAGStatusChange(ctx, dag, dagRunID, timeout) {
+	statusChanged, err := a.waitForDAGStatusChange(ctx, dag, dagRunID, timeout)
+	if err != nil {
+		return dagStartWaitContextError(err)
+	}
+	if statusChanged {
 		return nil
 	}
 
@@ -1399,7 +1436,11 @@ func (a *API) dispatchStartToCoordinator(ctx context.Context, dag *core.DAG, dag
 		return fmt.Errorf("error dispatching to coordinator: %w", err)
 	}
 
-	if !a.waitForDAGStatusChange(ctx, dag, dagRunID, timeout) {
+	statusChanged, err := a.waitForDAGStatusChange(ctx, dag, dagRunID, timeout)
+	if err != nil {
+		return dagStartWaitContextError(err)
+	}
+	if !statusChanged {
 		return &Error{
 			HTTPStatus: http.StatusInternalServerError,
 			Code:       api.ErrorCodeInternalError,
@@ -1657,7 +1698,11 @@ func (a *API) enqueueDAGRun(ctx context.Context, dag *core.DAG, params, dagRunID
 		return fmt.Errorf("error enqueuing DAG: %w", err)
 	}
 
-	if !a.waitForDAGStatusChange(ctx, dag, dagRunID, 3*time.Second) {
+	statusChanged, err := a.waitForDAGStatusChange(ctx, dag, dagRunID, 3*time.Second)
+	if err != nil {
+		return dagStartWaitContextError(err)
+	}
+	if !statusChanged {
 		return &Error{
 			HTTPStatus: http.StatusInternalServerError,
 			Code:       api.ErrorCodeInternalError,

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
@@ -1306,6 +1307,63 @@ func (a *API) waitForDAGStatusChange(ctx context.Context, dag *core.DAG, dagRunI
 	return false
 }
 
+func (a *API) waitForLocalDAGStart(
+	ctx context.Context,
+	dag *core.DAG,
+	dagRunID string,
+	started *runtime.StartResult,
+	timeout time.Duration,
+) error {
+	if a.waitForDAGStatusChange(ctx, dag, dagRunID, timeout) {
+		return nil
+	}
+
+	if started != nil {
+		select {
+		case err, ok := <-started.Done:
+			msg := "DAG start process exited before publishing status"
+			if ok && err != nil {
+				msg = fmt.Sprintf("%s: %v", msg, err)
+			}
+			return &Error{
+				HTTPStatus: http.StatusInternalServerError,
+				Code:       api.ErrorCodeInternalError,
+				Message:    msg,
+			}
+		default:
+		}
+
+		if localStartProcessStillRunning(started) {
+			logger.Warn(ctx, "Returning successful async start response because local starter process is still alive after status wait timeout",
+				tag.RunID(dagRunID),
+				tag.PID(started.PID),
+				slog.Int64("pid-started-at", started.PIDStartedAt),
+				tag.Timeout(timeout),
+			)
+			return nil
+		}
+	}
+
+	return &Error{
+		HTTPStatus: http.StatusInternalServerError,
+		Code:       api.ErrorCodeInternalError,
+		Message:    "DAG did not start",
+	}
+}
+
+func localStartProcessStillRunning(started *runtime.StartResult) bool {
+	if started == nil || started.PID <= 0 {
+		return false
+	}
+	if started.PIDStartedAt > 0 {
+		matched, _, ok := procutil.MatchesStartTime(started.PID, started.PIDStartedAt)
+		if ok {
+			return matched
+		}
+	}
+	return procutil.IsAlive(started.PID)
+}
+
 // dispatchStartToCoordinator dispatches a DAG start operation to the coordinator
 // and waits for the DAG status to change from NotStarted within the given timeout.
 func (a *API) dispatchStartToCoordinator(ctx context.Context, dag *core.DAG, dagRunID string, timeout time.Duration, params, labels string) error {
@@ -1426,7 +1484,8 @@ func (a *API) startPreparedDAGRunWithOptions(
 		Labels:       opts.labels,
 	})
 
-	if err := runtime.Start(ctx, spec); err != nil {
+	started, err := runtime.StartProcess(ctx, spec)
+	if err != nil {
 		return fmt.Errorf("error starting DAG: %w", err)
 	}
 
@@ -1435,15 +1494,7 @@ func (a *API) startPreparedDAGRunWithOptions(
 		timeout = 20 * time.Second
 	}
 
-	if !a.waitForDAGStatusChange(ctx, dag, opts.dagRunID, timeout) {
-		return &Error{
-			HTTPStatus: http.StatusInternalServerError,
-			Code:       api.ErrorCodeInternalError,
-			Message:    "DAG did not start",
-		}
-	}
-
-	return nil
+	return a.waitForLocalDAGStart(ctx, dag, opts.dagRunID, started, timeout)
 }
 
 func writeInlineRescheduleSpec(name, dagRunID string, data []byte) (string, error) {

--- a/internal/service/frontend/api/v1/dags_start_internal_test.go
+++ b/internal/service/frontend/api/v1/dags_start_internal_test.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	openapiv1 "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/persis/filedagrun"
+	"github.com/dagucloud/dagu/internal/persis/fileproc"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForLocalDAGStartReturnsNilWhenStarterProcessStillAlive(t *testing.T) {
+	t.Parallel()
+
+	api := newLocalStartTestAPI(t)
+	done := make(chan error)
+	started := currentProcessStartResult(t, done)
+
+	err := api.waitForLocalDAGStart(context.Background(), &core.DAG{Name: "pending"}, "run-1", started, time.Nanosecond)
+	require.NoError(t, err)
+}
+
+func TestWaitForLocalDAGStartReturnsErrorWhenStarterExitedWithoutStatus(t *testing.T) {
+	t.Parallel()
+
+	api := newLocalStartTestAPI(t)
+	done := make(chan error, 1)
+	done <- errors.New("exit status 1")
+	close(done)
+
+	err := api.waitForLocalDAGStart(context.Background(), &core.DAG{Name: "pending"}, "run-1", &runtime.StartResult{
+		PID:  1,
+		Done: done,
+	}, time.Nanosecond)
+	require.Error(t, err)
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusInternalServerError, apiErr.HTTPStatus)
+	require.Equal(t, openapiv1.ErrorCodeInternalError, apiErr.Code)
+	require.Contains(t, apiErr.Message, "DAG start process exited before publishing status")
+	require.Contains(t, apiErr.Message, "exit status 1")
+}
+
+func newLocalStartTestAPI(t *testing.T) *API {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	dagRunStore := filedagrun.New(filepath.Join(tmpDir, "dag-runs"))
+	procStore := fileproc.New(filepath.Join(tmpDir, "proc"))
+	return &API{
+		dagRunMgr: runtime.NewManager(dagRunStore, procStore, &config.Config{}),
+	}
+}
+
+func currentProcessStartResult(t *testing.T, done <-chan error) *runtime.StartResult {
+	t.Helper()
+
+	pid := os.Getpid()
+	startedAt, _ := procutil.StartTime(pid)
+	return &runtime.StartResult{
+		PID:          pid,
+		PIDStartedAt: startedAt,
+		Done:         done,
+	}
+}

--- a/internal/service/frontend/api/v1/dags_start_internal_test.go
+++ b/internal/service/frontend/api/v1/dags_start_internal_test.go
@@ -33,6 +33,26 @@ func TestWaitForLocalDAGStartReturnsNilWhenStarterProcessStillAlive(t *testing.T
 	require.NoError(t, err)
 }
 
+func TestWaitForLocalDAGStartReturnsCanceledWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	api := newLocalStartTestAPI(t)
+	done := make(chan error)
+	started := currentProcessStartResult(t, done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := api.waitForLocalDAGStart(ctx, &core.DAG{Name: "pending"}, "run-1", started, time.Second)
+	require.Error(t, err)
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, statusClientClosedRequest, apiErr.HTTPStatus)
+	require.Equal(t, openapiv1.ErrorCodeInternalError, apiErr.Code)
+	require.Equal(t, "DAG start request canceled", apiErr.Message)
+}
+
 func TestWaitForLocalDAGStartReturnsErrorWhenStarterExitedWithoutStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -262,6 +262,7 @@ func (d *queueDispatcher) dropSuspendedQueuedRun(
 			latest.Error = suspendedQueueDropReason
 			latest.WorkerID = ""
 			latest.PID = 0
+			latest.PIDStartedAt = 0
 			latest.LeaseAt = 0
 			return nil
 		},

--- a/internal/service/scheduler/queue_dispatcher_test.go
+++ b/internal/service/scheduler/queue_dispatcher_test.go
@@ -5,7 +5,6 @@ package scheduler
 
 import (
 	"testing"
-	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -16,7 +15,7 @@ import (
 
 func TestQueueDispatcher_SelectRunnableQueueItemsSkipsOutstandingReservations(t *testing.T) {
 	f := newQueueFixture(t).withDAG("dispatcher-select-dag", 2).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second)).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold)).
 		simulateQueue(2, false)
 
 	f.enqueueRuns(2)
@@ -41,7 +40,7 @@ func TestQueueDispatcher_SelectRunnableQueueItemsSkipsOutstandingReservations(t 
 	dispatcher := newQueueDispatcher(queueDispatchDeps{
 		dagRunStore:         f.dagRunStore,
 		dispatchTaskStore:   f.dispatchStore,
-		leaseStaleThreshold: 5 * time.Second,
+		leaseStaleThreshold: freshDistributedTestThreshold,
 	})
 	runnable, err := dispatcher.selectRunnableQueueItems(f.ctx, items, 1)
 	require.NoError(t, err)

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const freshDistributedTestThreshold = time.Hour
+
 type syncBuffer struct {
 	buf  *bytes.Buffer
 	lock sync.Mutex
@@ -237,7 +239,7 @@ func TestQueueProcessor_ConcurrencyLimit(t *testing.T) {
 
 func TestQueueProcessor_CountsFreshDistributedRunsAgainstQueueConcurrency(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-conc-dag", 1).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second)).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold)).
 		simulateQueue(1, false)
 
 	runningAttempt, err := f.dagRunStore.CreateAttempt(f.ctx, f.dag, time.Now(), "running-run", exec.NewDAGRunAttemptOptions{})
@@ -312,7 +314,7 @@ func TestQueueProcessor_ProcessQueueItems_FailsClosedOnOutstandingDispatchCountE
 
 func TestQueueProcessor_CountsOutstandingDispatchReservationsAgainstQueueConcurrency(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-dispatch-reservation-dag", 1).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second)).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold)).
 		simulateQueue(1, false)
 
 	f.enqueueRuns(1)
@@ -341,7 +343,7 @@ func TestQueueProcessor_CountsOutstandingDispatchReservationsAgainstQueueConcurr
 
 func TestQueueProcessor_SelectRunnableQueueItemsSkipsOutstandingReservations(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-select-dag", 2).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second)).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold)).
 		simulateQueue(2, false)
 
 	f.enqueueRuns(2)
@@ -554,7 +556,7 @@ func agePendingDispatchReservationFiles(t *testing.T, distributedDir string, age
 
 func TestQueueProcessor_CheckStartupStatusTreatsRunningStatusAsStarted(t *testing.T) {
 	f := newQueueFixture(t).withDAG("startup-running-dag", 1).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second))
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold))
 
 	run, err := f.dagRunStore.CreateAttempt(f.ctx, f.dag, time.Now(), "running-startup-run", exec.NewDAGRunAttemptOptions{})
 	require.NoError(t, err)
@@ -578,7 +580,7 @@ func TestQueueProcessor_CheckStartupStatusTreatsRunningStatusAsStarted(t *testin
 
 func TestQueueProcessor_CheckStartupStatusTreatsFreshDistributedLeaseAsStarted(t *testing.T) {
 	f := newQueueFixture(t).withDAG("startup-lease-dag", 1).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(5*time.Second))
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold))
 
 	run, err := f.dagRunStore.CreateAttempt(f.ctx, f.dag, time.Now(), "lease-startup-run", exec.NewDAGRunAttemptOptions{})
 	require.NoError(t, err)

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime"
@@ -241,6 +242,14 @@ func (z *ZombieDetector) checkAndCleanZombie(ctx context.Context, entry exec.Pro
 		if err := z.procStore.RemoveIfStale(ctx, entry); err != nil {
 			return fmt.Errorf("remove remote stale proc: %w", err)
 		}
+		return nil
+	}
+
+	if status.PID > 0 && procutil.IsAlive(int(status.PID)) {
+		logger.Warn(ctx, "Skipping zombie repair because local process is still alive despite stale proc heartbeat",
+			tag.PID(int(status.PID)),
+			slog.Int("stale_count", count),
+		)
 		return nil
 	}
 

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -245,12 +245,22 @@ func (z *ZombieDetector) checkAndCleanZombie(ctx context.Context, entry exec.Pro
 		return nil
 	}
 
-	if status.PID > 0 && procutil.IsAlive(int(status.PID)) {
-		logger.Warn(ctx, "Skipping zombie repair because local process is still alive despite stale proc heartbeat",
-			tag.PID(int(status.PID)),
-			slog.Int("stale_count", count),
-		)
-		return nil
+	if status.PID > 0 && status.PIDStartedAt > 0 {
+		matched, actualStartedAt, ok := procutil.MatchesStartTime(int(status.PID), status.PIDStartedAt)
+		if matched {
+			logger.Warn(ctx, "Skipping zombie repair because local process identity is still alive despite stale proc heartbeat",
+				tag.PID(int(status.PID)),
+				slog.Int("stale_count", count),
+			)
+			return nil
+		}
+		if ok {
+			logger.Debug(ctx, "Not skipping zombie repair because PID start time does not match persisted run status",
+				tag.PID(int(status.PID)),
+				slog.Int64("expected-pid-started-at", status.PIDStartedAt),
+				slog.Int64("actual-pid-started-at", actualStartedAt),
+			)
+		}
 	}
 
 	dag, err := attempt.ReadDAG(ctx)

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/stretchr/testify/assert"
@@ -127,14 +128,17 @@ func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithAliveLocalPIDSkipsRep
 		},
 	}
 	entry := testRootProcEntry(dag.ProcGroup(), dag.Name, "run-1", "attempt-1", false)
+	pidStartedAt, ok := procutil.StartTime(os.Getpid())
+	require.True(t, ok)
 	status := &exec.DAGRunStatus{
-		Name:      dag.Name,
-		DAGRunID:  "run-1",
-		AttemptID: "attempt-1",
-		Status:    core.Running,
-		WorkerID:  "local",
-		PID:       exec.PID(os.Getpid()),
-		Nodes:     exec.NewNodesFromSteps(dag.Steps),
+		Name:         dag.Name,
+		DAGRunID:     "run-1",
+		AttemptID:    "attempt-1",
+		Status:       core.Running,
+		WorkerID:     "local",
+		PID:          exec.PID(os.Getpid()),
+		PIDStartedAt: pidStartedAt,
+		Nodes:        exec.NewNodesFromSteps(dag.Steps),
 	}
 	status.Nodes[0].Status = core.NodeRunning
 	attempt := &exec.MockDAGRunAttempt{}

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -5,6 +5,7 @@ package scheduler
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -109,6 +110,47 @@ func TestZombieDetectorDetectAndCleanZombies_StaleEntryRepairsMatchingAttempt(t 
 	procStore.AssertExpectations(t)
 	dagRunStore.AssertExpectations(t)
 	attempt.AssertExpectations(t)
+}
+
+func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithAliveLocalPIDSkipsRepair(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	detector := NewZombieDetector(dagRunStore, procStore, time.Second, 1)
+
+	dag := &core.DAG{
+		Name: "test-dag",
+		Steps: []core.Step{
+			{Name: "step1"},
+		},
+	}
+	entry := testRootProcEntry(dag.ProcGroup(), dag.Name, "run-1", "attempt-1", false)
+	status := &exec.DAGRunStatus{
+		Name:      dag.Name,
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    core.Running,
+		WorkerID:  "local",
+		PID:       exec.PID(os.Getpid()),
+		Nodes:     exec.NewNodesFromSteps(dag.Steps),
+	}
+	status.Nodes[0].Status = core.NodeRunning
+	attempt := &exec.MockDAGRunAttempt{}
+
+	procStore.On("ListAllEntries", ctx).Return([]exec.ProcEntry{entry}, nil).Once()
+	dagRunStore.On("FindAttempt", mock.Anything, exec.NewDAGRunRef(dag.Name, "run-1")).Return(attempt, nil).Once()
+	attempt.On("ReadStatus", mock.Anything).Return(status, nil).Once()
+
+	detector.detectAndCleanZombies(ctx)
+
+	procStore.AssertExpectations(t)
+	dagRunStore.AssertExpectations(t)
+	attempt.AssertExpectations(t)
+	attempt.AssertNotCalled(t, "ReadDAG", mock.Anything)
+	attempt.AssertNotCalled(t, "Write", mock.Anything, mock.Anything)
+	procStore.AssertNotCalled(t, "RemoveIfStale", mock.Anything, mock.Anything)
 }
 
 func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithFreshSiblingRemovesOnlyStale(t *testing.T) {


### PR DESCRIPTION
## Summary

The false zombie detection in #2189 was local-execution specific: the fileproc heartbeat goroutine wrote heartbeat timestamps and then synchronously fsync'd the proc file. A slow or blocked fsync could stall future heartbeat writes without producing heartbeat write errors, leaving the scheduler with a stale proc entry while the child process was still alive.

## Changes

- Decouple fileproc heartbeat writes from proc file syncs so a slow sync cannot block timestamp updates.
- Add process liveness checks before repairing stale local runs from the scheduler or runtime manager.
- Keep distributed-run stale repair on its lease/worker-heartbeat path and add regression coverage for the local false-positive case.

## Validation

- make test TEST_TARGET="./internal/cmn/procutil ./internal/persis/fileproc ./internal/service/scheduler ./internal/runtime ./internal/intg ./internal/intg/queue ./internal/intg/distr"
- go test ./internal/cmn/procutil ./internal/persis/fileproc ./internal/service/scheduler ./internal/runtime -count=1
- GOOS=windows GOARCH=amd64 go test -c ./internal/cmn/procutil -o /tmp/procutil-windows.test.exe
- GOOS=linux GOARCH=amd64 go test -c ./internal/cmn/procutil -o /tmp/procutil-linux.test
- make lint

Closes #2189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist PID start timestamps with run status; agents cache and reuse this value.
  * Add process liveness/start-time helpers and an async process-start flow that returns PID, start time, and completion notifier.
  * Frontend now treats local DAG starts as successful if the starter process is still running.

* **Bug Fixes**
  * Heartbeat file syncing is non-blocking; shutdown waits for in-flight syncs.
  * Stale-run/zombie repair skips when persisted PID start time matches; PID start time cleared on aborts.

* **Tests**
  * Added tests for process helpers, async starts, heartbeat sync behavior, and zombie-skip logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->