### PR TITLE
fix: stabilize queued retry dispatch

### DIFF
--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -175,7 +175,7 @@ func runRetry(ctx *Context, args []string) error {
 			status.ScheduleTime,
 			func(execCtx context.Context) (exec.DAGRunAttempt, error) {
 				if queueDispatchRetry {
-					queuedAttempt, queuedStatus, err := queueDispatchRetryTarget(execCtx, ctx.DAGRunStore, ref, rootRun)
+					queuedAttempt, queuedStatus, err := queueDispatchRetryTarget(execCtx, ctx.DAGRunStore, ref, rootRun, attempt.ID())
 					if err != nil {
 						return nil, err
 					}
@@ -290,7 +290,7 @@ func ensureQueueDispatchRetryTarget(
 	ref exec.DAGRunRef,
 	rootRun exec.DAGRunRef,
 ) error {
-	_, err := queueDispatchRetryAttempt(ctx, dagRunStore, ref, rootRun)
+	_, err := queueDispatchRetryAttempt(ctx, dagRunStore, ref, rootRun, "")
 	return err
 }
 
@@ -299,8 +299,9 @@ func queueDispatchRetryAttempt(
 	dagRunStore exec.DAGRunStore,
 	ref exec.DAGRunRef,
 	rootRun exec.DAGRunRef,
+	expectedAttemptID string,
 ) (exec.DAGRunAttempt, error) {
-	attempt, _, err := queueDispatchRetryTarget(ctx, dagRunStore, ref, rootRun)
+	attempt, _, err := queueDispatchRetryTarget(ctx, dagRunStore, ref, rootRun, expectedAttemptID)
 	return attempt, err
 }
 
@@ -309,6 +310,7 @@ func queueDispatchRetryTarget(
 	dagRunStore exec.DAGRunStore,
 	ref exec.DAGRunRef,
 	rootRun exec.DAGRunRef,
+	expectedAttemptID string,
 ) (exec.DAGRunAttempt, *exec.DAGRunStatus, error) {
 	if dagRunStore == nil {
 		return nil, nil, nil
@@ -318,6 +320,9 @@ func queueDispatchRetryTarget(
 	err = normalizeQueueDispatchRetryLookupError(err)
 	if err != nil {
 		return nil, nil, err
+	}
+	if expectedAttemptID != "" && attempt.ID() != expectedAttemptID {
+		return nil, nil, newQueueDispatchNotQueuedError(nil)
 	}
 
 	status, err := attempt.ReadStatus(ctx)

--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -175,8 +175,12 @@ func runRetry(ctx *Context, args []string) error {
 			status.ScheduleTime,
 			func(execCtx context.Context) (exec.DAGRunAttempt, error) {
 				if queueDispatchRetry {
-					if err := ensureQueueDispatchRetryTarget(execCtx, ctx.DAGRunStore, ref, rootRun); err != nil {
+					queuedAttempt, queuedStatus, err := queueDispatchRetryTarget(execCtx, ctx.DAGRunStore, ref, rootRun)
+					if err != nil {
 						return nil, err
+					}
+					if shouldUseQueuedDispatchAttempt(queuedStatus) {
+						return queuedAttempt, nil
 					}
 				}
 				opts := exec.NewDAGRunAttemptOptions{Retry: true}
@@ -286,26 +290,50 @@ func ensureQueueDispatchRetryTarget(
 	ref exec.DAGRunRef,
 	rootRun exec.DAGRunRef,
 ) error {
+	_, err := queueDispatchRetryAttempt(ctx, dagRunStore, ref, rootRun)
+	return err
+}
+
+func queueDispatchRetryAttempt(
+	ctx context.Context,
+	dagRunStore exec.DAGRunStore,
+	ref exec.DAGRunRef,
+	rootRun exec.DAGRunRef,
+) (exec.DAGRunAttempt, error) {
+	attempt, _, err := queueDispatchRetryTarget(ctx, dagRunStore, ref, rootRun)
+	return attempt, err
+}
+
+func queueDispatchRetryTarget(
+	ctx context.Context,
+	dagRunStore exec.DAGRunStore,
+	ref exec.DAGRunRef,
+	rootRun exec.DAGRunRef,
+) (exec.DAGRunAttempt, *exec.DAGRunStatus, error) {
 	if dagRunStore == nil {
-		return nil
+		return nil, nil, nil
 	}
 
 	attempt, err := findRetryAttempt(ctx, dagRunStore, ref, rootRun)
 	err = normalizeQueueDispatchRetryLookupError(err)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	status, err := attempt.ReadStatus(ctx)
 	err = normalizeQueueDispatchRetryLookupError(err)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if status == nil || status.Status != core.Queued {
-		return newQueueDispatchNotQueuedError(status)
+		return nil, nil, newQueueDispatchNotQueuedError(status)
 	}
 
-	return nil
+	return attempt, status, nil
+}
+
+func shouldUseQueuedDispatchAttempt(status *exec.DAGRunStatus) bool {
+	return status != nil && status.TriggerType != core.TriggerTypeRetry
 }
 
 func normalizeQueueDispatchRetryLookupError(err error) error {

--- a/internal/cmd/retry_test.go
+++ b/internal/cmd/retry_test.go
@@ -196,6 +196,87 @@ steps:
 		require.Contains(t, err.Error(), "dag-run is not queued")
 	})
 
+	t.Run("QueueDispatchRetryUsesQueuedAttempt", func(t *testing.T) {
+		th := test.SetupCommand(t)
+		t.Setenv(exec.EnvKeyQueueDispatchRetry, "1")
+
+		dagFile := th.DAG(t, `name: queue-dispatch-existing-attempt
+steps:
+  - name: "1"
+    run: echo queued dispatch
+`)
+
+		runID := "queue-dispatch-run"
+		attempt, err := th.DAGRunStore.CreateAttempt(th.Context, dagFile.DAG, time.Now(), runID, exec.NewDAGRunAttemptOptions{})
+		require.NoError(t, err)
+		logPath := filepath.Join(th.Config.Paths.LogDir, "queue-dispatch-test.log")
+		require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o750))
+
+		status := transform.NewStatusBuilder(dagFile.DAG).Create(
+			runID,
+			core.Queued,
+			0,
+			time.Time{},
+			transform.WithAttemptID(attempt.ID()),
+			transform.WithTriggerType(core.TriggerTypeWebhook),
+			transform.WithQueuedAt(stringutil.FormatTime(time.Now())),
+			transform.WithLogFilePath(logPath),
+		)
+		writeStatus(t, th.Context, attempt, status)
+
+		args := []string{"retry", fmt.Sprintf("--run-id=%s", runID), dagFile.Location}
+		th.RunCommand(t, cmd.Retry(), test.CmdTest{Args: args})
+
+		latestAttempt, err := th.DAGRunStore.FindAttempt(th.Context, exec.NewDAGRunRef(dagFile.Name, runID))
+		require.NoError(t, err)
+		require.Equal(t, attempt.ID(), latestAttempt.ID())
+
+		latestStatus, err := latestAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Succeeded, latestStatus.Status)
+	})
+
+	t.Run("QueueDispatchRetryTriggerCreatesNewAttempt", func(t *testing.T) {
+		th := test.SetupCommand(t)
+		t.Setenv(exec.EnvKeyQueueDispatchRetry, "1")
+
+		dagFile := th.DAG(t, `name: queue-dispatch-retry-attempt
+steps:
+  - name: "1"
+    run: echo queued retry dispatch
+`)
+
+		runID := "queue-dispatch-retry-run"
+		attempt, err := th.DAGRunStore.CreateAttempt(th.Context, dagFile.DAG, time.Now(), runID, exec.NewDAGRunAttemptOptions{})
+		require.NoError(t, err)
+		logPath := filepath.Join(th.Config.Paths.LogDir, "queue-dispatch-retry-test.log")
+		require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o750))
+
+		status := transform.NewStatusBuilder(dagFile.DAG).Create(
+			runID,
+			core.Queued,
+			0,
+			time.Time{},
+			transform.WithAttemptID(attempt.ID()),
+			transform.WithTriggerType(core.TriggerTypeRetry),
+			transform.WithQueuedAt(stringutil.FormatTime(time.Now())),
+			transform.WithLogFilePath(logPath),
+		)
+		writeStatus(t, th.Context, attempt, status)
+
+		args := []string{"retry", fmt.Sprintf("--run-id=%s", runID), dagFile.Location}
+		th.RunCommand(t, cmd.Retry(), test.CmdTest{Args: args})
+
+		latestAttempt, err := th.DAGRunStore.FindAttempt(th.Context, exec.NewDAGRunRef(dagFile.Name, runID))
+		require.NoError(t, err)
+		require.NotEqual(t, attempt.ID(), latestAttempt.ID())
+
+		latestStatus, err := latestAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Succeeded, latestStatus.Status)
+		require.Equal(t, core.TriggerTypeRetry, latestStatus.TriggerType)
+	})
+
 	t.Run("RetryAllowsRootFlagPointingAtSameRun", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cmd/retry_test.go
+++ b/internal/cmd/retry_test.go
@@ -234,6 +234,7 @@ steps:
 		latestStatus, err := latestAttempt.ReadStatus(th.Context)
 		require.NoError(t, err)
 		require.Equal(t, core.Succeeded, latestStatus.Status)
+		require.Equal(t, core.TriggerTypeWebhook, latestStatus.TriggerType)
 	})
 
 	t.Run("QueueDispatchRetryTriggerCreatesNewAttempt", func(t *testing.T) {

--- a/internal/core/exec/queued_status.go
+++ b/internal/core/exec/queued_status.go
@@ -13,11 +13,11 @@ func IsQueuedCatchup(status *DAGRunStatus) bool {
 }
 
 // PreservedQueueTriggerType returns the trigger type that must be preserved
-// when consuming a queued item. Only catchup is preserved for now; all other
-// queued execution paths keep their existing behavior.
+// when consuming a queued item. Queued retry records still execute as retries;
+// initial queued runs keep the trigger that originally enqueued them.
 func PreservedQueueTriggerType(status *DAGRunStatus) core.TriggerType {
-	if IsQueuedCatchup(status) {
-		return core.TriggerTypeCatchUp
+	if status == nil || status.Status != core.Queued || status.TriggerType == core.TriggerTypeRetry {
+		return core.TriggerTypeUnknown
 	}
-	return core.TriggerTypeUnknown
+	return status.TriggerType
 }

--- a/internal/core/exec/queued_status_test.go
+++ b/internal/core/exec/queued_status_test.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreservedQueueTriggerType(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, core.TriggerTypeWebhook, exec.PreservedQueueTriggerType(&exec.DAGRunStatus{
+		Status:      core.Queued,
+		TriggerType: core.TriggerTypeWebhook,
+	}))
+	require.Equal(t, core.TriggerTypeCatchUp, exec.PreservedQueueTriggerType(&exec.DAGRunStatus{
+		Status:      core.Queued,
+		TriggerType: core.TriggerTypeCatchUp,
+	}))
+	require.Equal(t, core.TriggerTypeUnknown, exec.PreservedQueueTriggerType(&exec.DAGRunStatus{
+		Status:      core.Queued,
+		TriggerType: core.TriggerTypeRetry,
+	}))
+	require.Equal(t, core.TriggerTypeUnknown, exec.PreservedQueueTriggerType(&exec.DAGRunStatus{
+		Status:      core.Succeeded,
+		TriggerType: core.TriggerTypeWebhook,
+	}))
+}

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -735,9 +735,8 @@ func TestNotificationMonitor_SuccessEventsCanBeDeliveredByOptInTransport(t *test
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(calls) == 1
+		return len(calls) == 1 && monitor.IsDelivered("dest-1", status)
 	}, time.Second, 10*time.Millisecond)
-	assert.True(t, monitor.IsDelivered("dest-1", status))
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -224,9 +224,14 @@ func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.Queu
 	}
 
 	execErrCh := make(chan error, 1)
+	execDoneCh := make(chan struct{})
+	var execDoneErr error
 	go func() {
 		defer d.wakeUp()
-		if err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType, status.ScheduleTime); err != nil {
+		err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType, status.ScheduleTime)
+		execDoneErr = err
+		close(execDoneCh)
+		if err != nil {
 			logger.Error(ctx, "Failed to execute DAG", tag.Error(err))
 			if isPreStartExecutionFailure(err) {
 				select {
@@ -240,6 +245,14 @@ func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.Queu
 	return d.waitForStartup(ctx, queueName, runRef, startupWaitState{
 		launchedAt: time.Now(),
 		execErrCh:  execErrCh,
+		execDone: func() (bool, error) {
+			select {
+			case <-execDoneCh:
+				return true, execDoneErr
+			default:
+				return false, nil
+			}
+		},
 	})
 }
 
@@ -359,6 +372,9 @@ func (d *queueDispatcher) waitForStartup(ctx context.Context, queueName string, 
 	policy := backoff.NewExponentialBackoffPolicy(d.backoffConfig.InitialInterval)
 	policy.MaxInterval = d.backoffConfig.MaxInterval
 	policy.MaxRetries = d.backoffConfig.MaxRetries
+	if waitState.execDone != nil {
+		policy.MaxRetries = 0
+	}
 
 	var started bool
 	operation := func(ctx context.Context) error {
@@ -390,7 +406,8 @@ func (d *queueDispatcher) checkStartupStatus(ctx context.Context, queueName stri
 		logger.Info(ctx, "DAG run has started (heartbeat detected)")
 		return true, nil
 	}
-	if d.inStartupGracePeriod(waitState.launchedAt) && d.dagRunLeaseStore == nil {
+	execDone, execDoneErr := waitState.executionDone()
+	if d.inStartupGracePeriod(waitState.launchedAt) && d.dagRunLeaseStore == nil && !execDone {
 		return false, errNotStarted
 	}
 
@@ -408,6 +425,12 @@ func (d *queueDispatcher) checkStartupStatus(ctx context.Context, queueName stri
 	if status.Status != core.Queued {
 		logger.Info(ctx, "DAG execution has started or finished", tag.Status(status.Status.String()))
 		return true, nil
+	}
+	if execDone {
+		if execDoneErr != nil {
+			return false, backoff.PermanentError(execDoneErr)
+		}
+		return false, backoff.PermanentError(errExecutionExitedBeforeStartup)
 	}
 	started, err := d.hasFreshDistributedLease(ctx, queueName, runRef, attempt, status)
 	if err != nil {

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -377,9 +377,16 @@ func (d *queueDispatcher) waitForStartup(ctx context.Context, queueName string, 
 	}
 
 	var started bool
+	var startupObservationErrors int
 	operation := func(ctx context.Context) error {
 		var err error
 		started, err = d.checkStartupStatus(ctx, queueName, runRef, waitState)
+		if shouldBoundLocalStartupError(waitState, err) {
+			startupObservationErrors++
+			if d.backoffConfig.MaxRetries > 0 && startupObservationErrors > d.backoffConfig.MaxRetries {
+				return backoff.PermanentError(err)
+			}
+		}
 		return err
 	}
 
@@ -388,6 +395,13 @@ func (d *queueDispatcher) waitForStartup(ctx context.Context, queueName string, 
 	}
 
 	return started
+}
+
+func shouldBoundLocalStartupError(waitState startupWaitState, err error) bool {
+	return waitState.execDone != nil &&
+		err != nil &&
+		!errors.Is(err, errNotStarted) &&
+		!errors.Is(err, backoff.ErrPermanent)
 }
 
 func (d *queueDispatcher) checkStartupStatus(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) (bool, error) {

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -21,8 +21,9 @@ const queueAgeWarningThreshold = 2 * time.Minute
 const queueProcessMinInterval = 3 * time.Second
 
 var (
-	errProcessorClosed = errors.New("processor closed")
-	errNotStarted      = errors.New("execution not started")
+	errProcessorClosed              = errors.New("processor closed")
+	errNotStarted                   = errors.New("execution not started")
+	errExecutionExitedBeforeStartup = errors.New("execution exited before startup")
 )
 
 const suspendedQueueDropReason = "dag schedule suspended before dispatch"
@@ -53,6 +54,14 @@ func DefaultBackoffConfig() BackoffConfig {
 type startupWaitState struct {
 	launchedAt time.Time
 	execErrCh  <-chan error
+	execDone   func() (bool, error)
+}
+
+func (s startupWaitState) executionDone() (bool, error) {
+	if s.execDone == nil {
+		return false, nil
+	}
+	return s.execDone()
 }
 
 // QueueProcessor is responsible for processing queued DAG runs.
@@ -415,6 +424,9 @@ func (p *QueueProcessor) removeInactiveQueues(activeQueues map[string]struct{}) 
 }
 
 func readStartupExecutionError(execErrCh <-chan error) error {
+	if execErrCh == nil {
+		return nil
+	}
 	select {
 	case err := <-execErrCh:
 		return err

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -156,6 +156,36 @@ func TestQueueDispatcher_WaitForStartupKeepsLocalLaunchInFlightUntilDone(t *test
 	procStore.AssertExpectations(t)
 }
 
+func TestQueueDispatcher_WaitForStartupBoundsLocalObservationErrors(t *testing.T) {
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	runRef := exec.NewDAGRunRef("test-dag", "run-1")
+	storeErr := errors.New("status store unavailable")
+
+	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(false, nil).Twice()
+	dagRunStore.On("FindAttempt", mock.Anything, runRef).Return(nil, storeErr).Twice()
+
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
+		InitialInterval:    time.Millisecond,
+		MaxInterval:        time.Millisecond,
+		MaxRetries:         1,
+		StartupGracePeriod: 0,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	started := dispatcher.waitForStartup(ctx, "test-queue", runRef, startupWaitState{
+		launchedAt: time.Now().Add(-time.Second),
+		execDone: func() (bool, error) {
+			return false, nil
+		},
+	})
+
+	require.False(t, started)
+	dagRunStore.AssertExpectations(t)
+	procStore.AssertExpectations(t)
+}
+
 func TestQueueDispatcher_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -119,6 +119,43 @@ func TestQueueDispatcher_CheckStartupStatus_PreStartExecutionErrorIsPermanent(t 
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
+func TestQueueDispatcher_WaitForStartupKeepsLocalLaunchInFlightUntilDone(t *testing.T) {
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	runRef := exec.NewDAGRunRef("test-dag", "run-1")
+	attempt := &exec.MockDAGRunAttempt{
+		Status: &exec.DAGRunStatus{Status: core.Queued},
+	}
+	var checks atomic.Int32
+
+	procStore.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(false, nil)
+	dagRunStore.On("FindAttempt", mock.Anything, runRef).Return(attempt, nil)
+
+	dispatcher := newStartupTestDispatcher(dagRunStore, procStore, BackoffConfig{
+		InitialInterval:    time.Millisecond,
+		MaxInterval:        time.Millisecond,
+		MaxRetries:         1,
+		StartupGracePeriod: 0,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := dispatcher.waitForStartup(ctx, "test-queue", runRef, startupWaitState{
+		launchedAt: time.Now().Add(-time.Second),
+		execDone: func() (bool, error) {
+			if checks.Add(1) >= 3 {
+				cancel()
+			}
+			return false, nil
+		},
+	})
+
+	require.False(t, started)
+	require.GreaterOrEqual(t, checks.Load(), int32(3))
+	dagRunStore.AssertExpectations(t)
+	procStore.AssertExpectations(t)
+}
+
 func TestQueueDispatcher_CheckStartupStatus_AfterGraceFallsBackToStatus(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- keep queue-dispatched initial runs on their queued attempt while preserving fresh attempts for queued retries
- avoid duplicate local queue dispatch while a launched child process is still starting
- fix notification delivery test race by waiting for delivery state

## Testing
- make lint
- go test ./internal/service/scheduler -run TestQueueDispatcher -count=1
- go test ./internal/service/chatbridge -run TestNotificationMonitor_SuccessEventsCanBeDeliveredByOptInTransport -count=100
- go test ./internal/cmd -run TestRetryCommand -count=1
- go test -race ./internal/intg/... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue dispatch retry to intelligently reuse existing queued attempts based on their status
  * Enhanced scheduler startup logic to reliably coordinate execution completion

* **Tests**
  * Added test coverage for queue dispatch retry behavior with different trigger types
  * Added test for scheduler startup coordination with execution completion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->