### PR TITLE
feat: add security headers middleware

### DIFF
--- a/internal/intg/webhook_test.go
+++ b/internal/intg/webhook_test.go
@@ -254,5 +254,5 @@ func waitForWebhookRunStatus(
 		}
 
 		return status.Status == expected
-	}, intgTestTimeout(30*time.Second), 200*time.Millisecond)
+	}, test.SubprocessRunTimeout(30*time.Second), 200*time.Millisecond)
 }

--- a/internal/service/frontend/securityheaders.go
+++ b/internal/service/frontend/securityheaders.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import "net/http"
+
+// securityHeadersMiddleware adds defensive HTTP response headers to every response.
+// Pass tlsEnabled=true to also emit Strict-Transport-Security (HSTS).
+func securityHeadersMiddleware(tlsEnabled bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("X-Frame-Options", "DENY")
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			h.Set("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=()")
+			// Disable the legacy XSS auditor; modern browsers removed it and it
+			// caused false-positive page blocking. CSP is the correct mitigation.
+			h.Set("X-XSS-Protection", "0")
+			if tlsEnabled {
+				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/service/frontend/securityheaders_test.go
+++ b/internal/service/frontend/securityheaders_test.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	t.Parallel()
+
+	noop := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name       string
+		tlsEnabled bool
+		wantHSTS   bool
+	}{
+		{name: "without TLS", tlsEnabled: false, wantHSTS: false},
+		{name: "with TLS", tlsEnabled: true, wantHSTS: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := securityHeadersMiddleware(tt.tlsEnabled)(noop)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			h := rec.Result().Header
+			assert.Equal(t, "DENY", h.Get("X-Frame-Options"))
+			assert.Equal(t, "nosniff", h.Get("X-Content-Type-Options"))
+			assert.Equal(t, "strict-origin-when-cross-origin", h.Get("Referrer-Policy"))
+			assert.Equal(t, "geolocation=(), camera=(), microphone=(), payment=()", h.Get("Permissions-Policy"))
+			assert.Equal(t, "0", h.Get("X-XSS-Protection"))
+
+			hsts := h.Get("Strict-Transport-Security")
+			if tt.wantHSTS {
+				assert.Equal(t, "max-age=31536000; includeSubDomains", hsts)
+			} else {
+				assert.Empty(t, hsts)
+			}
+		})
+	}
+}
+
+func TestSecurityHeadersMiddlewarePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	handler := securityHeadersMiddleware(false)(inner)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/dags", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusTeapot, rec.Code)
+}

--- a/internal/service/frontend/securityheaders_test.go
+++ b/internal/service/frontend/securityheaders_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestSecurityHeadersMiddleware verifies that all security headers are present
+// on every response and that HSTS is emitted only when TLS is enabled.
 func TestSecurityHeadersMiddleware(t *testing.T) {
 	t.Parallel()
 
@@ -54,6 +56,8 @@ func TestSecurityHeadersMiddleware(t *testing.T) {
 	}
 }
 
+// TestSecurityHeadersMiddlewarePassesThrough confirms that the middleware calls
+// the next handler and preserves its status code.
 func TestSecurityHeadersMiddlewarePassesThrough(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1062,6 +1062,7 @@ func (srv *Server) Serve(ctx context.Context) error {
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))
+	r.Use(securityHeadersMiddleware(srv.config.Server.TLS != nil))
 	r.Use(middleware.RedirectSlashes)
 
 	if err := srv.setupRoutes(ctx, r); err != nil {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1054,6 +1054,7 @@ func (srv *Server) Serve(ctx context.Context) error {
 		r.Use(logMiddleware)
 	}
 	r.Use(middleware.Recoverer)
+	r.Use(securityHeadersMiddleware(srv.config.Server.TLS != nil))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
@@ -1062,7 +1063,6 @@ func (srv *Server) Serve(ctx context.Context) error {
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))
-	r.Use(securityHeadersMiddleware(srv.config.Server.TLS != nil))
 	r.Use(middleware.RedirectSlashes)
 
 	if err := srv.setupRoutes(ctx, r); err != nil {

--- a/internal/test/reschedule_inline_helpers.go
+++ b/internal/test/reschedule_inline_helpers.go
@@ -22,11 +22,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func rescheduleEventuallyTimeout(base time.Duration) time.Duration {
+// SubprocessRunTimeout returns a timeout appropriate for waiting on the result
+// of a subprocess-executed DAG run. On Windows, process creation is
+// significantly slower so a larger multiplier is used.
+func SubprocessRunTimeout(base time.Duration) time.Duration {
 	if runtime.GOOS == "windows" {
 		return base * 20
 	}
 	return base
+}
+
+func rescheduleEventuallyTimeout(base time.Duration) time.Duration {
+	return SubprocessRunTimeout(base)
 }
 
 func CreateInlineDAGRunForReschedule(t *testing.T, server Server, dagName string, enqueue bool) (string, string) {


### PR DESCRIPTION
## Summary

- Add `securityHeadersMiddleware` in `internal/service/frontend/securityheaders.go`
- Wire middleware into chi router in `server.go` after CORS, before RedirectSlashes
- Emit HSTS only when TLS is configured (`srv.config.Server.TLS != nil`)

### Headers added to every response

| Header | Value | Protection |
|--------|-------|------------|
| `X-Frame-Options` | `DENY` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME-type confusion attacks |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage |
| `Permissions-Policy` | `geolocation=(), camera=(), microphone=(), payment=()` | Unused browser feature access |
| `X-XSS-Protection` | `0` | Disables the broken legacy XSS auditor (CSP is the modern replacement) |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HTTPS enforcement (TLS-only) |

## Test plan

- [ ] `go test ./internal/service/frontend/ -run TestSecurityHeaders` passes
- [ ] `TestSecurityHeadersMiddleware/without_TLS` — no HSTS header emitted
- [ ] `TestSecurityHeadersMiddleware/with_TLS` — HSTS header emitted
- [ ] `TestSecurityHeadersMiddlewarePassesThrough` — downstream handler still called, status code preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security headers to all HTTP responses, including protections against clickjacking, MIME-type sniffing, and XSS attacks
  * Strict-Transport-Security header automatically enabled when HTTPS is configured

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->