### PR TITLE
fix: track temp files via registry file instead of subshell-local array

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -19,12 +19,15 @@ ERROR='\033[38;2;196;62;62m'
 MUTED='\033[38;2;120;128;142m'
 NC='\033[0m'
 
-TMPFILES=()
+TMPFILE_REGISTRY="$(mktemp)"
 cleanup_tmpfiles() {
     local f
-    for f in "${TMPFILES[@]:-}"; do
-        rm -rf "$f" 2>/dev/null || true
-    done
+    if [[ -f "$TMPFILE_REGISTRY" ]]; then
+        while IFS= read -r f; do
+            rm -rf "$f" 2>/dev/null || true
+        done <"$TMPFILE_REGISTRY"
+        rm -f "$TMPFILE_REGISTRY" 2>/dev/null || true
+    fi
 }
 trap cleanup_tmpfiles EXIT
 
@@ -36,7 +39,7 @@ mktempdir() {
     else
         d="$(mktemp -d)"
     fi
-    TMPFILES+=("$d")
+    printf '%s\n' "$d" >>"$TMPFILE_REGISTRY"
     printf '%s\n' "$d"
 }
 


### PR DESCRIPTION
## Problem

`mktempdir()` is called inside command substitution `$(mktempdir)` throughout the installer script (lines 362, 492, 1328, 1438, 1642, 1669, 1783, 1852, 2169). Command substitution creates a subshell, so `TMPFILES+=("$d")` only modifies the subshell's copy of the array. The parent shell's `TMPFILES` remains empty, and `cleanup_tmpfiles()` never removes any temp directories.

This was originally reported in #1868 and temporarily fixed, but the rollback in commit 62ebc8b reintroduced the issue (noted in #2001).

## Fix

Replace the `TMPFILES` bash array with a `TMPFILE_REGISTRY` temp file:

- **`mktempdir()`**: appends the new directory path to the registry file (`>>"$TMPFILE_REGISTRY"`) — works across subshell boundaries since it's a file, not a shell variable
- **`cleanup_tmpfiles()`**: reads the registry file line-by-line and removes each entry, then removes the registry file itself

The registry file is created once at script start via `mktemp` and cleaned up in the EXIT trap.

Fixes #2001


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installer's temporary file management system for improved reliability during the installation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->