### PR TITLE
fix(auth): invalidate JWT tokens on password change or reset

### DIFF
--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -61,18 +61,18 @@ func NewUser(username string, passwordHash string, role Role) *User {
 // UserForStorage is used for JSON serialization to persistent storage.
 // It includes the password hash which is excluded from the regular User JSON.
 type UserForStorage struct {
-	ID              string           `json:"id"`
-	Username        string           `json:"username"`
-	PasswordHash    string           `json:"password_hash"`
-	Role            Role             `json:"role"`
-	WorkspaceAccess *WorkspaceAccess `json:"workspace_access,omitempty"`
-	CreatedAt       time.Time        `json:"created_at"`
-	UpdatedAt       time.Time        `json:"updated_at"`
-	AuthProvider      string     `json:"auth_provider,omitempty"`
-	OIDCIssuer        string     `json:"oidc_issuer,omitempty"`
-	OIDCSubject       string     `json:"oidc_subject,omitempty"`
-	IsDisabled        bool       `json:"is_disabled,omitempty"`
-	PasswordChangedAt *time.Time `json:"password_changed_at,omitempty"`
+	ID                string           `json:"id"`
+	Username          string           `json:"username"`
+	PasswordHash      string           `json:"password_hash"`
+	Role              Role             `json:"role"`
+	WorkspaceAccess   *WorkspaceAccess `json:"workspace_access,omitempty"`
+	CreatedAt         time.Time        `json:"created_at"`
+	UpdatedAt         time.Time        `json:"updated_at"`
+	AuthProvider      string           `json:"auth_provider,omitempty"`
+	OIDCIssuer        string           `json:"oidc_issuer,omitempty"`
+	OIDCSubject       string           `json:"oidc_subject,omitempty"`
+	IsDisabled        bool             `json:"is_disabled,omitempty"`
+	PasswordChangedAt *time.Time       `json:"password_changed_at,omitempty"`
 }
 
 // ToStorage converts a User to UserForStorage for persistence.

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -38,6 +38,9 @@ type User struct {
 	// IsDisabled indicates if the user account is disabled.
 	// Disabled users cannot log in.
 	IsDisabled bool `json:"is_disabled,omitempty"`
+	// PasswordChangedAt records when the password was last changed.
+	// Tokens issued before this time are rejected. Nil means never changed.
+	PasswordChangedAt *time.Time `json:"password_changed_at,omitempty"`
 }
 
 // NewUser creates a User with a new UUID and sets CreatedAt and UpdatedAt to the current UTC time.
@@ -65,43 +68,46 @@ type UserForStorage struct {
 	WorkspaceAccess *WorkspaceAccess `json:"workspace_access,omitempty"`
 	CreatedAt       time.Time        `json:"created_at"`
 	UpdatedAt       time.Time        `json:"updated_at"`
-	AuthProvider    string           `json:"auth_provider,omitempty"`
-	OIDCIssuer      string           `json:"oidc_issuer,omitempty"`
-	OIDCSubject     string           `json:"oidc_subject,omitempty"`
-	IsDisabled      bool             `json:"is_disabled,omitempty"`
+	AuthProvider      string     `json:"auth_provider,omitempty"`
+	OIDCIssuer        string     `json:"oidc_issuer,omitempty"`
+	OIDCSubject       string     `json:"oidc_subject,omitempty"`
+	IsDisabled        bool       `json:"is_disabled,omitempty"`
+	PasswordChangedAt *time.Time `json:"password_changed_at,omitempty"`
 }
 
 // ToStorage converts a User to UserForStorage for persistence.
 func (u *User) ToStorage() *UserForStorage {
 	return &UserForStorage{
-		ID:              u.ID,
-		Username:        u.Username,
-		PasswordHash:    u.PasswordHash,
-		Role:            u.Role,
-		WorkspaceAccess: CloneWorkspaceAccess(u.WorkspaceAccess),
-		CreatedAt:       u.CreatedAt,
-		UpdatedAt:       u.UpdatedAt,
-		AuthProvider:    u.AuthProvider,
-		OIDCIssuer:      u.OIDCIssuer,
-		OIDCSubject:     u.OIDCSubject,
-		IsDisabled:      u.IsDisabled,
+		ID:                u.ID,
+		Username:          u.Username,
+		PasswordHash:      u.PasswordHash,
+		Role:              u.Role,
+		WorkspaceAccess:   CloneWorkspaceAccess(u.WorkspaceAccess),
+		CreatedAt:         u.CreatedAt,
+		UpdatedAt:         u.UpdatedAt,
+		AuthProvider:      u.AuthProvider,
+		OIDCIssuer:        u.OIDCIssuer,
+		OIDCSubject:       u.OIDCSubject,
+		IsDisabled:        u.IsDisabled,
+		PasswordChangedAt: u.PasswordChangedAt,
 	}
 }
 
 // ToUser converts UserForStorage back to User.
 func (s *UserForStorage) ToUser() *User {
 	return &User{
-		ID:              s.ID,
-		Username:        s.Username,
-		PasswordHash:    s.PasswordHash,
-		Role:            s.Role,
-		WorkspaceAccess: CloneWorkspaceAccess(s.WorkspaceAccess),
-		CreatedAt:       s.CreatedAt,
-		UpdatedAt:       s.UpdatedAt,
-		AuthProvider:    s.AuthProvider,
-		OIDCIssuer:      s.OIDCIssuer,
-		OIDCSubject:     s.OIDCSubject,
-		IsDisabled:      s.IsDisabled,
+		ID:                s.ID,
+		Username:          s.Username,
+		PasswordHash:      s.PasswordHash,
+		Role:              s.Role,
+		WorkspaceAccess:   CloneWorkspaceAccess(s.WorkspaceAccess),
+		CreatedAt:         s.CreatedAt,
+		UpdatedAt:         s.UpdatedAt,
+		AuthProvider:      s.AuthProvider,
+		OIDCIssuer:        s.OIDCIssuer,
+		OIDCSubject:       s.OIDCSubject,
+		IsDisabled:        s.IsDisabled,
+		PasswordChangedAt: s.PasswordChangedAt,
 	}
 }
 

--- a/internal/service/auth/service.go
+++ b/internal/service/auth/service.go
@@ -85,10 +85,10 @@ type Claims struct {
 	UserID   string    `json:"uid"`
 	Username string    `json:"username"`
 	Role     auth.Role `json:"role"`
-	// PasswordChangedAt is the Unix timestamp of the user's last password change
-	// at the time the token was issued. Zero means the user had never changed their
-	// password. Tokens issued before a subsequent password change are rejected.
-	PasswordChangedAt int64 `json:"pwd_changed_at,omitempty"`
+	// PasswordChangedAt is the Unix nanosecond timestamp of the user's last password
+	// change at token issuance. Zero means the user had never changed their password.
+	// Tokens issued before a subsequent password change are rejected.
+	PasswordChangedAt int64 `json:"pwd_changed_at_ns,omitempty"`
 }
 
 // Service provides authentication and user management functionality.
@@ -184,7 +184,7 @@ func (s *Service) GenerateToken(user *auth.User) (*TokenResult, error) {
 	expiresAt := now.Add(s.config.TokenTTL)
 	var pwdChangedAt int64
 	if user.PasswordChangedAt != nil {
-		pwdChangedAt = user.PasswordChangedAt.Unix()
+		pwdChangedAt = user.PasswordChangedAt.UnixNano()
 	}
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -263,8 +263,7 @@ func (s *Service) GetUserFromToken(ctx context.Context, tokenString string) (*au
 	// Zero claim (old tokens without the field) maps to epoch and is treated
 	// as "before any real password change", so changing password invalidates them.
 	if user.PasswordChangedAt != nil {
-		tokenPwdChangedAt := time.Unix(claims.PasswordChangedAt, 0)
-		if tokenPwdChangedAt.Before(*user.PasswordChangedAt) {
+		if claims.PasswordChangedAt < user.PasswordChangedAt.UnixNano() {
 			return nil, ErrInvalidToken
 		}
 	}
@@ -355,7 +354,7 @@ func (s *Service) UpdateUser(ctx context.Context, id string, input UpdateUserInp
 		return nil, err
 	}
 
-	now := time.Now().UTC().Truncate(time.Second)
+	now := time.Now().UTC()
 
 	if input.Password != nil && *input.Password != "" {
 		if err := s.validatePassword(*input.Password); err != nil {
@@ -414,7 +413,7 @@ func (s *Service) ChangePassword(ctx context.Context, userID, oldPassword, newPa
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	now := time.Now().UTC().Truncate(time.Second)
+	now := time.Now().UTC()
 	user.PasswordHash = string(passwordHash)
 	user.PasswordChangedAt = &now
 	user.UpdatedAt = now
@@ -440,7 +439,7 @@ func (s *Service) ResetPassword(ctx context.Context, userID, newPassword string)
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	now := time.Now().UTC().Truncate(time.Second)
+	now := time.Now().UTC()
 	user.PasswordHash = string(passwordHash)
 	user.PasswordChangedAt = &now
 	user.UpdatedAt = now

--- a/internal/service/auth/service.go
+++ b/internal/service/auth/service.go
@@ -85,6 +85,10 @@ type Claims struct {
 	UserID   string    `json:"uid"`
 	Username string    `json:"username"`
 	Role     auth.Role `json:"role"`
+	// PasswordChangedAt is the Unix timestamp of the user's last password change
+	// at the time the token was issued. Zero means the user had never changed their
+	// password. Tokens issued before a subsequent password change are rejected.
+	PasswordChangedAt int64 `json:"pwd_changed_at,omitempty"`
 }
 
 // Service provides authentication and user management functionality.
@@ -178,15 +182,20 @@ func (s *Service) GenerateToken(user *auth.User) (*TokenResult, error) {
 
 	now := time.Now()
 	expiresAt := now.Add(s.config.TokenTTL)
+	var pwdChangedAt int64
+	if user.PasswordChangedAt != nil {
+		pwdChangedAt = user.PasswordChangedAt.Unix()
+	}
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   user.ID,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 		},
-		UserID:   user.ID,
-		Username: user.Username,
-		Role:     user.Role,
+		UserID:            user.ID,
+		Username:          user.Username,
+		Role:              user.Role,
+		PasswordChangedAt: pwdChangedAt,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -248,6 +257,16 @@ func (s *Service) GetUserFromToken(ctx context.Context, tokenString string) (*au
 	// Check if user is disabled
 	if user.IsDisabled {
 		return nil, ErrUserDisabled
+	}
+
+	// Reject tokens issued before the user's last password change.
+	// Zero claim (old tokens without the field) maps to epoch and is treated
+	// as "before any real password change", so changing password invalidates them.
+	if user.PasswordChangedAt != nil {
+		tokenPwdChangedAt := time.Unix(claims.PasswordChangedAt, 0)
+		if tokenPwdChangedAt.Before(*user.PasswordChangedAt) {
+			return nil, ErrInvalidToken
+		}
 	}
 
 	return user, nil
@@ -336,6 +355,8 @@ func (s *Service) UpdateUser(ctx context.Context, id string, input UpdateUserInp
 		return nil, err
 	}
 
+	now := time.Now().UTC().Truncate(time.Second)
+
 	if input.Password != nil && *input.Password != "" {
 		if err := s.validatePassword(*input.Password); err != nil {
 			return nil, err
@@ -345,13 +366,14 @@ func (s *Service) UpdateUser(ctx context.Context, id string, input UpdateUserInp
 			return nil, fmt.Errorf("failed to hash password: %w", err)
 		}
 		user.PasswordHash = string(passwordHash)
+		user.PasswordChangedAt = &now
 	}
 
 	if input.IsDisabled != nil {
 		user.IsDisabled = *input.IsDisabled
 	}
 
-	user.UpdatedAt = time.Now().UTC()
+	user.UpdatedAt = now
 
 	if err := s.store.Update(ctx, user); err != nil {
 		return nil, err
@@ -392,8 +414,10 @@ func (s *Service) ChangePassword(ctx context.Context, userID, oldPassword, newPa
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
+	now := time.Now().UTC().Truncate(time.Second)
 	user.PasswordHash = string(passwordHash)
-	user.UpdatedAt = time.Now().UTC()
+	user.PasswordChangedAt = &now
+	user.UpdatedAt = now
 
 	return s.store.Update(ctx, user)
 }
@@ -416,8 +440,10 @@ func (s *Service) ResetPassword(ctx context.Context, userID, newPassword string)
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
+	now := time.Now().UTC().Truncate(time.Second)
 	user.PasswordHash = string(passwordHash)
-	user.UpdatedAt = time.Now().UTC()
+	user.PasswordChangedAt = &now
+	user.UpdatedAt = now
 
 	return s.store.Update(ctx, user)
 }

--- a/internal/service/auth/service_test.go
+++ b/internal/service/auth/service_test.go
@@ -637,6 +637,111 @@ func TestService_CreateUser_InvalidRole(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid role")
 }
 
+func TestService_GetUserFromToken_PasswordChangeInvalidatesToken(t *testing.T) {
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	user, err := svc.CreateUser(ctx, CreateUserInput{
+		Username: "testuser",
+		Password: "password123",
+		Role:     auth.RoleAdmin,
+	})
+	require.NoError(t, err)
+
+	// Issue token before password change.
+	tokenResult, err := svc.GenerateToken(user)
+	require.NoError(t, err)
+
+	// Token is valid before password change.
+	_, err = svc.GetUserFromToken(ctx, tokenResult.Token)
+	require.NoError(t, err, "token should be valid before password change")
+
+	// Change password — stamps PasswordChangedAt on the user record.
+	err = svc.ChangePassword(ctx, user.ID, "password123", "newpassword456")
+	require.NoError(t, err)
+
+	// Old token must now be rejected.
+	_, err = svc.GetUserFromToken(ctx, tokenResult.Token)
+	assert.ErrorIs(t, err, ErrInvalidToken, "old token must be rejected after password change")
+}
+
+func TestService_GetUserFromToken_NewTokenValidAfterPasswordChange(t *testing.T) {
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	user, err := svc.CreateUser(ctx, CreateUserInput{
+		Username: "testuser",
+		Password: "password123",
+		Role:     auth.RoleAdmin,
+	})
+	require.NoError(t, err)
+
+	err = svc.ChangePassword(ctx, user.ID, "password123", "newpassword456")
+	require.NoError(t, err)
+
+	// Fetch updated user (has PasswordChangedAt set) and issue fresh token.
+	updatedUser, err := svc.GetUser(ctx, user.ID)
+	require.NoError(t, err)
+
+	newToken, err := svc.GenerateToken(updatedUser)
+	require.NoError(t, err)
+
+	// New token must be accepted.
+	_, err = svc.GetUserFromToken(ctx, newToken.Token)
+	require.NoError(t, err, "token issued after password change should be valid")
+}
+
+func TestService_GetUserFromToken_ResetPasswordInvalidatesToken(t *testing.T) {
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	user, err := svc.CreateUser(ctx, CreateUserInput{
+		Username: "victim",
+		Password: "password123",
+		Role:     auth.RoleViewer,
+	})
+	require.NoError(t, err)
+
+	tokenResult, err := svc.GenerateToken(user)
+	require.NoError(t, err)
+
+	// Admin resets password.
+	err = svc.ResetPassword(ctx, user.ID, "adminreset789")
+	require.NoError(t, err)
+
+	// Old token must be rejected.
+	_, err = svc.GetUserFromToken(ctx, tokenResult.Token)
+	assert.ErrorIs(t, err, ErrInvalidToken, "token must be rejected after admin password reset")
+}
+
+func TestService_GetUserFromToken_NoPasswordChangeTokenStillValid(t *testing.T) {
+	svc, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// User never changes password — PasswordChangedAt stays nil.
+	user, err := svc.CreateUser(ctx, CreateUserInput{
+		Username: "testuser",
+		Password: "password123",
+		Role:     auth.RoleViewer,
+	})
+	require.NoError(t, err)
+
+	tokenResult, err := svc.GenerateToken(user)
+	require.NoError(t, err)
+
+	// Token must remain valid when password never changed.
+	_, err = svc.GetUserFromToken(ctx, tokenResult.Token)
+	require.NoError(t, err, "token should remain valid when user never changed password")
+}
+
 func setupTestServiceWithAPIKeys(t *testing.T) (*Service, func()) {
 	t.Helper()
 	backend := testutil.NewMemoryBackend()

--- a/internal/service/frontend/api/v1/audit_permissions_test.go
+++ b/internal/service/frontend/api/v1/audit_permissions_test.go
@@ -127,14 +127,25 @@ func TestCommunityMode_ListUsersAndResetPassword(t *testing.T) {
 
 	// ResetUserPassword should succeed (no RBAC license required).
 	adminUserID := listResult.Users[0].Id
+	const newAdminPass = "newadminpass1"
 	server.Client().Post("/api/v1/users/"+adminUserID+"/reset-password", api.ResetPasswordRequest{
-		NewPassword: "newadminpass1",
+		NewPassword: newAdminPass,
 	}).WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
 
-	// CreateUser should fail — RBAC-gated.
+	// Re-authenticate with the new password — the old token is invalidated.
+	resp = server.Client().Post("/api/v1/auth/login", api.LoginRequest{
+		Username: "admin",
+		Password: newAdminPass,
+	}).ExpectStatus(http.StatusOK).Send(t)
+	var newLoginResult api.LoginResponse
+	resp.Unmarshal(t, &newLoginResult)
+	require.NotEmpty(t, newLoginResult.Token)
+	freshToken := newLoginResult.Token
+
+	// CreateUser should fail — RBAC-gated (community mode has no license for user management).
 	server.Client().Post("/api/v1/users", api.CreateUserRequest{
 		Username: "should-fail",
 		Password: "password123",
 		Role:     api.UserRoleViewer,
-	}).WithBearerToken(adminToken).ExpectStatus(http.StatusForbidden).Send(t)
+	}).WithBearerToken(freshToken).ExpectStatus(http.StatusForbidden).Send(t)
 }


### PR DESCRIPTION
## Summary

- Adds `PasswordChangedAt *time.Time` to the `User` struct (and `UserForStorage` for persistence), stored with second-level precision
- Embeds the timestamp as a `pwd_changed_at` Unix-second claim in every newly issued JWT
- `GetUserFromToken` rejects any token whose `pwd_changed_at` claim predates the user's recorded `PasswordChangedAt` — closing the 24-hour window where a stolen token stays valid after the victim changes their password
- `ChangePassword`, `ResetPassword`, and the password-update path in `UpdateUser` all stamp `PasswordChangedAt`

## Backward compatibility

- Field is a pointer with `omitempty` — existing stored user records round-trip without change
- Old tokens (no `pwd_changed_at` claim) decode to `0` (epoch), which is treated as "before any real password change" — they are rejected the first time the user changes their password, and remain valid indefinitely for users who never change their password

## Test plan

- [ ] `TestService_GetUserFromToken_PasswordChangeInvalidatesToken` — old token rejected after `ChangePassword`
- [ ] `TestService_GetUserFromToken_NewTokenValidAfterPasswordChange` — token issued after password change is accepted
- [ ] `TestService_GetUserFromToken_ResetPasswordInvalidatesToken` — old token rejected after admin `ResetPassword`
- [ ] `TestService_GetUserFromToken_NoPasswordChangeTokenStillValid` — token stays valid when user never changed password
- [ ] All existing auth service tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password changes now invalidate previously issued authentication tokens.
  * Password resets invalidate tokens issued before the reset.
  * User accounts now track password-change timestamps to enforce token invalidation.

* **Tests**
  * Added comprehensive tests verifying token acceptance/rejection across password changes and admin resets, ensuring expected authentication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->