### PR TITLE
fix(auth): move OIDC token from query param to hash fragment

### DIFF
--- a/internal/service/frontend/auth/oidc.go
+++ b/internal/service/frontend/auth/oidc.go
@@ -33,12 +33,10 @@ const (
 	oidcProviderInitialInterval = 500 * time.Millisecond // initial backoff interval
 	oidcProviderMaxInterval     = 5 * time.Second        // maximum backoff interval
 	stateCookieExpiry           = 120                    // seconds for transient state/nonce/originalURL cookies
-	defaultTokenExpirySecs      = 60                     // fallback when ID token expiry is invalid or already passed
 )
 
 // Cookie names centralised to avoid copy-paste strings.
 const (
-	cookieOIDCToken   = "oidcToken"
 	cookieState       = "state"
 	cookieNonce       = "nonce"
 	cookieOriginalURL = "originalURL"
@@ -377,15 +375,14 @@ func BuiltinOIDCCallbackHandler(cfg *BuiltinOIDCConfig) http.HandlerFunc {
 		// Clear OIDC cookies
 		clearOIDCStateCookies(w, r)
 
-		// Redirect to login page with token in URL for frontend to store in localStorage
-		// This is secure because:
-		// 1. It's a one-time redirect (not a shareable link)
-		// 2. Frontend stores the token and navigates away with replace:true (React Router)
-		// 3. Token won't appear in browser history after navigation completes
-		redirectURL := strings.TrimSuffix(cfg.LoginBasePath, "/") + "/login?token=" + url.QueryEscape(tokenResult.Token)
+		// Redirect to login page with token in the URL hash fragment.
+		// Hash fragments are never sent to the server, so the JWT does not appear
+		// in server access logs, reverse-proxy logs, or Referer headers.
+		redirectURL := strings.TrimSuffix(cfg.LoginBasePath, "/") + "/login"
 		if isNewUser {
-			redirectURL += "&welcome=true"
+			redirectURL += "?welcome=true"
 		}
+		redirectURL += "#token=" + url.QueryEscape(tokenResult.Token)
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 	}
 }

--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -23,9 +23,11 @@ export default function LoginPage() {
 
   const from = (location.state as { from?: Location })?.from?.pathname || '/';
 
-  // Handle OIDC callback token and messages from URL params
+  // Handle OIDC callback: token from hash fragment, error/welcome from query params
   useEffect(() => {
-    const tokenParam = searchParams.get('token');
+    // Token is in the hash fragment so it never appears in server access logs
+    const hashParams = new URLSearchParams(location.hash.slice(1));
+    const tokenParam = hashParams.get('token');
     const errorParam = searchParams.get('error');
     const welcomeParam = searchParams.get('welcome');
 
@@ -43,7 +45,7 @@ export default function LoginPage() {
     if (welcomeParam === 'true') {
       setWelcomeMessage('Welcome! Your account has been created.');
     }
-  }, [searchParams, navigate, from]);
+  }, [searchParams, location.hash, navigate, from]);
 
   // Redirect to setup page if initial admin account hasn't been created.
   // Wait for auth state to settle (isLoading=false) to avoid acting on


### PR DESCRIPTION
## Summary

- OIDC callback previously redirected to `/login?token=<jwt>` — the full JWT appeared in server access logs, reverse-proxy logs, and `Referer` headers sent to any external resources loaded on the login page
- Changed to `/login#token=<jwt>` (hash fragment) — browsers never send the fragment to the server, so it is invisible to all logging infrastructure
- New user flow: `/login?welcome=true#token=<jwt>` — `welcome` flag stays as query param (not sensitive), token stays in hash
- Frontend reads token from `location.hash` via `new URLSearchParams(location.hash.slice(1))` instead of `useSearchParams`; `error`/`welcome` params unchanged
- Removed two unused constants (`cookieOIDCToken`, `defaultTokenExpirySecs`) from `oidc.go`

## Test plan

- [ ] OIDC login flow completes and lands on home page
- [ ] Server access logs show `/login` or `/login?welcome=true` — no JWT visible
- [ ] New user welcome message still displays
- [ ] Error messages from OIDC provider still display on login page
- [ ] Existing unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privacy in OIDC login authentication by improving how authentication tokens are transmitted during the login callback process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->