### PR TITLE
fix: harden scheduler DAG file reload on Windows

### DIFF
--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -417,7 +417,7 @@ func markConfiguredWorkingDirsExplicit(dag *core.DAG) {
 
 // loadDAGsFromFile loads all DAGs from a multi-document YAML file.
 func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
-	data, err := os.ReadFile(filePath) //nolint:gosec
+	data, err := fileutil.ReadFileWithRetry(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
 	}
@@ -515,7 +515,7 @@ func readBaseDefinitionData(opts BuildOpts) ([]byte, string, error) {
 		return nil, "", nil
 	}
 
-	baseRaw, err := os.ReadFile(opts.Base) //nolint:gosec
+	baseRaw, err := fileutil.ReadFileWithRetry(opts.Base)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, "", nil
@@ -604,7 +604,7 @@ func readWorkspaceBaseDefinitionData(opts BuildOpts, doc map[string]any) ([]byte
 		return nil, nil
 	}
 
-	data, err := os.ReadFile(filepath.Join(opts.WorkspaceBaseConfigDir, workspaceName, workspace.BaseConfigFileName)) //nolint:gosec
+	data, err := fileutil.ReadFileWithRetry(filepath.Join(opts.WorkspaceBaseConfigDir, workspaceName, workspace.BaseConfigFileName))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -1091,7 +1091,7 @@ func (*mergeTransformer) Transformer(
 
 // readYAMLFile reads the contents of the file into a map.
 func readYAMLFile(file string) (cfg map[string]any, err error) {
-	data, err := os.ReadFile(file) //nolint:gosec
+	data, err := fileutil.ReadFileWithRetry(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %v", file, err)
 	}

--- a/internal/service/scheduler/dag_file_source.go
+++ b/internal/service/scheduler/dag_file_source.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
+)
+
+const (
+	dagFileSnapshotAttempts    = 6
+	dagFileSnapshotInitialWait = 10 * time.Millisecond
+	dagFileSnapshotMaxWait     = 100 * time.Millisecond
+)
+
+type dagFileSource struct {
+	dir  string
+	load func(context.Context, string) (*core.DAG, error)
+}
+
+type dagFileSnapshot struct {
+	dag    *core.DAG
+	exists bool
+}
+
+func newDAGFileSource(dir string) *dagFileSource {
+	return &dagFileSource{
+		dir:  dir,
+		load: loadDAGMetadata,
+	}
+}
+
+func loadDAGMetadata(ctx context.Context, filePath string) (*core.DAG, error) {
+	return spec.Load(
+		ctx,
+		filePath,
+		spec.OnlyMetadata(),
+		spec.WithoutEval(),
+		spec.SkipSchemaValidation(),
+	)
+}
+
+func (s *dagFileSource) snapshot(ctx context.Context, fileName string) (dagFileSnapshot, error) {
+	filePath := filepath.Join(s.dir, fileName)
+	wait := dagFileSnapshotInitialWait
+
+	for attempt := 0; ; attempt++ {
+		dag, err := s.load(ctx, filePath)
+		if err == nil {
+			return dagFileSnapshot{dag: dag, exists: true}, nil
+		}
+
+		if !errors.Is(err, os.ErrNotExist) {
+			return dagFileSnapshot{}, err
+		}
+		if attempt >= dagFileSnapshotAttempts {
+			return dagFileSnapshot{exists: false}, nil
+		}
+		if !sleepDAGFileSnapshot(ctx, wait) {
+			return dagFileSnapshot{}, ctx.Err()
+		}
+		wait *= 2
+		if wait > dagFileSnapshotMaxWait {
+			wait = dagFileSnapshotMaxWait
+		}
+	}
+}
+
+func sleepDAGFileSnapshot(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/internal/service/scheduler/dag_file_source.go
+++ b/internal/service/scheduler/dag_file_source.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	// dagFileSnapshotAttempts bounds how long watcher handling waits for
+	// dagFileSnapshotRetries bounds how long watcher handling waits for
 	// atomic replace operations to settle before treating the file as deleted.
-	dagFileSnapshotAttempts = 6
+	dagFileSnapshotRetries = 6
 	// dagFileSnapshotInitialWait keeps the common retry path short for
 	// transient Windows sharing and rename gaps.
 	dagFileSnapshotInitialWait = 10 * time.Millisecond
@@ -70,7 +70,7 @@ func (s *dagFileSource) snapshot(ctx context.Context, fileName string) (dagFileS
 		if !errors.Is(err, os.ErrNotExist) {
 			return dagFileSnapshot{}, err
 		}
-		if attempt >= dagFileSnapshotAttempts {
+		if attempt >= dagFileSnapshotRetries {
 			return dagFileSnapshot{exists: false}, nil
 		}
 		if !sleepDAGFileSnapshot(ctx, wait) {

--- a/internal/service/scheduler/dag_file_source.go
+++ b/internal/service/scheduler/dag_file_source.go
@@ -20,16 +20,19 @@ const (
 	dagFileSnapshotMaxWait     = 100 * time.Millisecond
 )
 
+// dagFileSource resolves watched DAG files into stable metadata snapshots.
 type dagFileSource struct {
 	dir  string
 	load func(context.Context, string) (*core.DAG, error)
 }
 
+// dagFileSnapshot represents the scheduler-visible state of one DAG file.
 type dagFileSnapshot struct {
 	dag    *core.DAG
 	exists bool
 }
 
+// newDAGFileSource creates the production DAG file source for a watched directory.
 func newDAGFileSource(dir string) *dagFileSource {
 	return &dagFileSource{
 		dir:  dir,
@@ -37,6 +40,7 @@ func newDAGFileSource(dir string) *dagFileSource {
 	}
 }
 
+// loadDAGMetadata loads only scheduler metadata from a DAG spec file.
 func loadDAGMetadata(ctx context.Context, filePath string) (*core.DAG, error) {
 	return spec.Load(
 		ctx,
@@ -47,6 +51,7 @@ func loadDAGMetadata(ctx context.Context, filePath string) (*core.DAG, error) {
 	)
 }
 
+// snapshot returns the current stable state of a DAG file for watcher handling.
 func (s *dagFileSource) snapshot(ctx context.Context, fileName string) (dagFileSnapshot, error) {
 	filePath := filepath.Join(s.dir, fileName)
 	wait := dagFileSnapshotInitialWait
@@ -73,6 +78,7 @@ func (s *dagFileSource) snapshot(ctx context.Context, fileName string) (dagFileS
 	}
 }
 
+// sleepDAGFileSnapshot waits between snapshot retries while honoring cancellation.
 func sleepDAGFileSnapshot(ctx context.Context, d time.Duration) bool {
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/internal/service/scheduler/dag_file_source.go
+++ b/internal/service/scheduler/dag_file_source.go
@@ -15,9 +15,14 @@ import (
 )
 
 const (
-	dagFileSnapshotAttempts    = 6
+	// dagFileSnapshotAttempts bounds how long watcher handling waits for
+	// atomic replace operations to settle before treating the file as deleted.
+	dagFileSnapshotAttempts = 6
+	// dagFileSnapshotInitialWait keeps the common retry path short for
+	// transient Windows sharing and rename gaps.
 	dagFileSnapshotInitialWait = 10 * time.Millisecond
-	dagFileSnapshotMaxWait     = 100 * time.Millisecond
+	// dagFileSnapshotMaxWait caps backoff so watcher processing stays responsive.
+	dagFileSnapshotMaxWait = 100 * time.Millisecond
 )
 
 // dagFileSource resolves watched DAG files into stable metadata snapshots.

--- a/internal/service/scheduler/dag_file_source_test.go
+++ b/internal/service/scheduler/dag_file_source_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAGFileSourceSnapshotRetriesTemporaryAbsence(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	source := &dagFileSource{
+		dir: t.TempDir(),
+		load: func(context.Context, string) (*core.DAG, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fmt.Errorf("open dag.yaml: %w", os.ErrNotExist)
+			}
+			return &core.DAG{Name: "replace-test"}, nil
+		},
+	}
+
+	snapshot, err := source.snapshot(context.Background(), "replace-test.yaml")
+
+	require.NoError(t, err)
+	assert.True(t, snapshot.exists)
+	assert.Equal(t, "replace-test", snapshot.dag.Name)
+	assert.Equal(t, 2, attempts)
+}
+
+func TestDAGFileSourceSnapshotReturnsNonAbsenceError(t *testing.T) {
+	t.Parallel()
+
+	loadErr := errors.New("invalid dag")
+	source := &dagFileSource{
+		dir: t.TempDir(),
+		load: func(context.Context, string) (*core.DAG, error) {
+			return nil, loadErr
+		},
+	}
+
+	snapshot, err := source.snapshot(context.Background(), "invalid.yaml")
+
+	require.ErrorIs(t, err, loadErr)
+	assert.False(t, snapshot.exists)
+}

--- a/internal/service/scheduler/dag_file_source_test.go
+++ b/internal/service/scheduler/dag_file_source_test.go
@@ -56,3 +56,25 @@ func TestDAGFileSourceSnapshotReturnsNonAbsenceError(t *testing.T) {
 	require.ErrorIs(t, err, loadErr)
 	assert.False(t, snapshot.exists)
 }
+
+// TestDAGFileSourceSnapshotHonorsContextCancellation verifies retry waits stop on cancellation.
+func TestDAGFileSourceSnapshotHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	source := &dagFileSource{
+		dir: t.TempDir(),
+		load: func(context.Context, string) (*core.DAG, error) {
+			attempts++
+			return nil, os.ErrNotExist
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	snapshot, err := source.snapshot(ctx, "missing.yaml")
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, snapshot.exists)
+	assert.Equal(t, 1, attempts)
+}

--- a/internal/service/scheduler/dag_file_source_test.go
+++ b/internal/service/scheduler/dag_file_source_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDAGFileSourceSnapshotRetriesTemporaryAbsence verifies transient missing files are retried before deletion.
 func TestDAGFileSourceSnapshotRetriesTemporaryAbsence(t *testing.T) {
 	t.Parallel()
 
@@ -38,6 +39,7 @@ func TestDAGFileSourceSnapshotRetriesTemporaryAbsence(t *testing.T) {
 	assert.Equal(t, 2, attempts)
 }
 
+// TestDAGFileSourceSnapshotReturnsNonAbsenceError verifies parse/load errors are not treated as deletion.
 func TestDAGFileSourceSnapshotReturnsNonAbsenceError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -71,6 +71,7 @@ func (er *entryReaderImpl) setEvents(ch chan DAGChangeEvent) {
 	er.events = ch
 }
 
+// Init loads the initial DAG registry and starts watching the target directory.
 func (er *entryReaderImpl) Init(ctx context.Context) error {
 	er.lock.Lock()
 	defer er.lock.Unlock()
@@ -90,6 +91,7 @@ func (er *entryReaderImpl) Init(ctx context.Context) error {
 	return nil
 }
 
+// Start forwards watcher events into registry updates until the reader stops.
 func (er *entryReaderImpl) Start(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -151,6 +153,7 @@ func (er *entryReaderImpl) handleFSEvent(ctx context.Context, event fsnotify.Eve
 	}
 }
 
+// reloadDAGFile reloads a create/write event when the file still snapshots as present.
 func (er *entryReaderImpl) reloadDAGFile(ctx context.Context, fileName, eventName string) {
 	snapshot, err := er.dagFileSource().snapshot(ctx, fileName)
 	if err != nil {
@@ -167,6 +170,7 @@ func (er *entryReaderImpl) reloadDAGFile(ctx context.Context, fileName, eventNam
 	logger.Info(ctx, "DAG added/updated", tag.Name(fileName))
 }
 
+// applyDAGFileSnapshot stores a loaded DAG and emits the matching add/update events.
 func (er *entryReaderImpl) applyDAGFileSnapshot(ctx context.Context, fileName string, dag *core.DAG) {
 	// Determine add vs update by checking registry before updating
 	er.lock.Lock()
@@ -197,6 +201,7 @@ func (er *entryReaderImpl) applyDAGFileSnapshot(ctx context.Context, fileName st
 	})
 }
 
+// removeDAGFile drops a confirmed-absent DAG file from the registry.
 func (er *entryReaderImpl) removeDAGFile(ctx context.Context, fileName string) {
 	// Capture DAG name from registry before deleting
 	er.lock.Lock()
@@ -213,6 +218,7 @@ func (er *entryReaderImpl) removeDAGFile(ctx context.Context, fileName string) {
 	logger.Info(ctx, "DAG removed", tag.Name(fileName))
 }
 
+// dagFileSource returns the snapshot loader used by watcher and initialization paths.
 func (er *entryReaderImpl) dagFileSource() *dagFileSource {
 	if er.dagSource == nil {
 		er.dagSource = newDAGFileSource(er.targetDir)
@@ -233,6 +239,7 @@ func (er *entryReaderImpl) sendEvent(ctx context.Context, event DAGChangeEvent) 
 	}
 }
 
+// Stop closes the watcher and prevents future event sends.
 func (er *entryReaderImpl) Stop() {
 	er.lock.Lock()
 	defer er.lock.Unlock()
@@ -245,6 +252,7 @@ func (er *entryReaderImpl) Stop() {
 	})
 }
 
+// DAGs returns the currently loaded DAG metadata.
 func (er *entryReaderImpl) DAGs() []*core.DAG {
 	er.lock.Lock()
 	defer er.lock.Unlock()
@@ -256,10 +264,12 @@ func (er *entryReaderImpl) DAGs() []*core.DAG {
 	return dags
 }
 
+// DAGStore returns the backing DAG store for full DAG details.
 func (er *entryReaderImpl) DAGStore() exec.DAGStore {
 	return er.dagStore
 }
 
+// initialize loads existing YAML files through the same stable snapshot path as watcher events.
 func (er *entryReaderImpl) initialize(ctx context.Context) error {
 	// Note: This method expects the caller to already hold er.lock
 	logger.Info(ctx, "Loading DAGs", tag.Dir(er.targetDir))

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -136,7 +136,7 @@ func (er *entryReaderImpl) handleFSEvent(ctx context.Context, event fsnotify.Eve
 	}
 
 	if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
-		snapshot, err := er.dagFileSource().snapshot(ctx, fileName)
+		snapshot, err := er.dagSource.snapshot(ctx, fileName)
 		if err != nil {
 			logger.Error(ctx, "DAG load failed",
 				tag.Error(err),
@@ -155,7 +155,7 @@ func (er *entryReaderImpl) handleFSEvent(ctx context.Context, event fsnotify.Eve
 
 // reloadDAGFile reloads a create/write event when the file still snapshots as present.
 func (er *entryReaderImpl) reloadDAGFile(ctx context.Context, fileName, eventName string) {
-	snapshot, err := er.dagFileSource().snapshot(ctx, fileName)
+	snapshot, err := er.dagSource.snapshot(ctx, fileName)
 	if err != nil {
 		logger.Error(ctx, "DAG load failed",
 			tag.Error(err),
@@ -218,14 +218,6 @@ func (er *entryReaderImpl) removeDAGFile(ctx context.Context, fileName string) {
 	logger.Info(ctx, "DAG removed", tag.Name(fileName))
 }
 
-// dagFileSource returns the snapshot loader used by watcher and initialization paths.
-func (er *entryReaderImpl) dagFileSource() *dagFileSource {
-	if er.dagSource == nil {
-		er.dagSource = newDAGFileSource(er.targetDir)
-	}
-	return er.dagSource
-}
-
 // sendEvent sends a DAGChangeEvent on the channel.
 // Returns immediately if the entry reader is shutting down or the context is cancelled.
 func (er *entryReaderImpl) sendEvent(ctx context.Context, event DAGChangeEvent) {
@@ -285,7 +277,7 @@ func (er *entryReaderImpl) initialize(ctx context.Context) error {
 	var dags []string
 	for _, fi := range fis {
 		if fileutil.IsYAMLFile(fi.Name()) {
-			snapshot, err := er.dagFileSource().snapshot(ctx, fi.Name())
+			snapshot, err := er.dagSource.snapshot(ctx, fi.Name())
 			if err != nil {
 				logger.Error(ctx, "DAG load failed",
 					tag.Error(err),

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/service/scheduler/filenotify"
 
 	"github.com/fsnotify/fsnotify"
@@ -48,6 +47,7 @@ type entryReaderImpl struct {
 	registry  map[string]*core.DAG
 	lock      sync.Mutex
 	dagStore  exec.DAGStore
+	dagSource *dagFileSource
 	watcher   filenotify.FileWatcher
 	quit      chan struct{}
 	closeOnce sync.Once
@@ -60,6 +60,7 @@ func NewEntryReader(dir string, dagCli exec.DAGStore) EntryReader {
 		targetDir: dir,
 		registry:  make(map[string]*core.DAG),
 		dagStore:  dagCli,
+		dagSource: newDAGFileSource(dir),
 		quit:      make(chan struct{}),
 	}
 }
@@ -128,67 +129,95 @@ func (er *entryReaderImpl) handleFSEvent(ctx context.Context, event fsnotify.Eve
 	fileName := filepath.Base(event.Name)
 
 	if event.Op&(fsnotify.Create|fsnotify.Write) != 0 {
-		filePath := filepath.Join(er.targetDir, fileName)
-		dag, err := spec.Load(
-			ctx,
-			filePath,
-			spec.OnlyMetadata(),
-			spec.WithoutEval(),
-			spec.SkipSchemaValidation(),
-		)
+		er.reloadDAGFile(ctx, fileName, event.Name)
+		return
+	}
+
+	if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
+		snapshot, err := er.dagFileSource().snapshot(ctx, fileName)
 		if err != nil {
 			logger.Error(ctx, "DAG load failed",
 				tag.Error(err),
 				tag.File(event.Name))
 			return
 		}
-
-		// Determine add vs update by checking registry before updating
-		er.lock.Lock()
-		oldDAG, existed := er.registry[fileName]
-		var oldDAGName string
-		if existed && oldDAG.Name != dag.Name {
-			oldDAGName = oldDAG.Name
-		}
-		er.registry[fileName] = dag
-		er.lock.Unlock()
-
-		// If the DAG name changed, emit delete for the old name first
-		if oldDAGName != "" {
-			er.sendEvent(ctx, DAGChangeEvent{
-				Type:    DAGChangeDeleted,
-				DAGName: oldDAGName,
-			})
+		if snapshot.exists {
+			er.applyDAGFileSnapshot(ctx, fileName, snapshot.dag)
+			logger.Info(ctx, "DAG added/updated", tag.Name(fileName))
+			return
 		}
 
-		changeType := DAGChangeAdded
-		if existed && oldDAGName == "" {
-			changeType = DAGChangeUpdated
-		}
-		er.sendEvent(ctx, DAGChangeEvent{
-			Type:    changeType,
-			DAG:     dag,
-			DAGName: dag.Name,
-		})
-		logger.Info(ctx, "DAG added/updated", tag.Name(fileName))
+		er.removeDAGFile(ctx, fileName)
+	}
+}
+
+func (er *entryReaderImpl) reloadDAGFile(ctx context.Context, fileName, eventName string) {
+	snapshot, err := er.dagFileSource().snapshot(ctx, fileName)
+	if err != nil {
+		logger.Error(ctx, "DAG load failed",
+			tag.Error(err),
+			tag.File(eventName))
+		return
+	}
+	if !snapshot.exists {
 		return
 	}
 
-	if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
-		// Capture DAG name from registry before deleting
-		er.lock.Lock()
-		dag, existed := er.registry[fileName]
-		delete(er.registry, fileName)
-		er.lock.Unlock()
+	er.applyDAGFileSnapshot(ctx, fileName, snapshot.dag)
+	logger.Info(ctx, "DAG added/updated", tag.Name(fileName))
+}
 
-		if existed && dag != nil {
-			er.sendEvent(ctx, DAGChangeEvent{
-				Type:    DAGChangeDeleted,
-				DAGName: dag.Name,
-			})
-		}
-		logger.Info(ctx, "DAG removed", tag.Name(fileName))
+func (er *entryReaderImpl) applyDAGFileSnapshot(ctx context.Context, fileName string, dag *core.DAG) {
+	// Determine add vs update by checking registry before updating
+	er.lock.Lock()
+	oldDAG, existed := er.registry[fileName]
+	var oldDAGName string
+	if existed && oldDAG.Name != dag.Name {
+		oldDAGName = oldDAG.Name
 	}
+	er.registry[fileName] = dag
+	er.lock.Unlock()
+
+	// If the DAG name changed, emit delete for the old name first
+	if oldDAGName != "" {
+		er.sendEvent(ctx, DAGChangeEvent{
+			Type:    DAGChangeDeleted,
+			DAGName: oldDAGName,
+		})
+	}
+
+	changeType := DAGChangeAdded
+	if existed && oldDAGName == "" {
+		changeType = DAGChangeUpdated
+	}
+	er.sendEvent(ctx, DAGChangeEvent{
+		Type:    changeType,
+		DAG:     dag,
+		DAGName: dag.Name,
+	})
+}
+
+func (er *entryReaderImpl) removeDAGFile(ctx context.Context, fileName string) {
+	// Capture DAG name from registry before deleting
+	er.lock.Lock()
+	dag, existed := er.registry[fileName]
+	delete(er.registry, fileName)
+	er.lock.Unlock()
+
+	if existed && dag != nil {
+		er.sendEvent(ctx, DAGChangeEvent{
+			Type:    DAGChangeDeleted,
+			DAGName: dag.Name,
+		})
+	}
+	logger.Info(ctx, "DAG removed", tag.Name(fileName))
+}
+
+func (er *entryReaderImpl) dagFileSource() *dagFileSource {
+	if er.dagSource == nil {
+		er.dagSource = newDAGFileSource(er.targetDir)
+	}
+	return er.dagSource
 }
 
 // sendEvent sends a DAGChangeEvent on the channel.
@@ -246,20 +275,17 @@ func (er *entryReaderImpl) initialize(ctx context.Context) error {
 	var dags []string
 	for _, fi := range fis {
 		if fileutil.IsYAMLFile(fi.Name()) {
-			dag, err := spec.Load(
-				ctx,
-				filepath.Join(er.targetDir, fi.Name()),
-				spec.OnlyMetadata(),
-				spec.WithoutEval(),
-				spec.SkipSchemaValidation(),
-			)
+			snapshot, err := er.dagFileSource().snapshot(ctx, fi.Name())
 			if err != nil {
 				logger.Error(ctx, "DAG load failed",
 					tag.Error(err),
 					tag.Name(fi.Name()))
 				continue
 			}
-			er.registry[fi.Name()] = dag
+			if !snapshot.exists {
+				continue
+			}
+			er.registry[fi.Name()] = snapshot.dag
 			dags = append(dags, fi.Name())
 		}
 	}

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -223,6 +223,43 @@ func TestHandleFSEvent_RemoveDeletesDAG(t *testing.T) {
 	}
 }
 
+func TestHandleFSEvent_RemoveReloadsDAGWhenFileStillExists(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	events := make(chan DAGChangeEvent, 10)
+
+	er := &entryReaderImpl{
+		targetDir: tmpDir,
+		registry:  make(map[string]*core.DAG),
+		quit:      make(chan struct{}),
+		events:    events,
+	}
+
+	er.registry["replace-test.yaml"] = &core.DAG{Name: "replace-test"}
+	writeDAGFile(t, tmpDir, "replace-test.yaml", "replace-test")
+
+	er.handleFSEvent(context.Background(), fsnotify.Event{
+		Name: filepath.Join(tmpDir, "replace-test.yaml"),
+		Op:   fsnotify.Remove,
+	})
+
+	er.lock.Lock()
+	dag, ok := er.registry["replace-test.yaml"]
+	er.lock.Unlock()
+	require.True(t, ok, "DAG should stay in registry when the source file still exists")
+	assert.Equal(t, "replace-test", dag.Name)
+
+	select {
+	case event := <-events:
+		assert.Equal(t, DAGChangeUpdated, event.Type)
+		assert.Equal(t, "replace-test", event.DAGName)
+		assert.NotNil(t, event.DAG)
+	case <-time.After(time.Second):
+		t.Fatal("expected DAGChangeUpdated event")
+	}
+}
+
 func TestHandleFSEvent_NameChangeEmitsDeleteThenAdd(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSendEvent_UnblocksOnQuit verifies shutdown unblocks a pending event send.
 func TestSendEvent_UnblocksOnQuit(t *testing.T) {
 	t.Parallel()
 
@@ -48,6 +49,7 @@ func TestSendEvent_UnblocksOnQuit(t *testing.T) {
 	}
 }
 
+// TestSendEvent_UnblocksOnContextCancel verifies context cancellation unblocks a pending event send.
 func TestSendEvent_UnblocksOnContextCancel(t *testing.T) {
 	t.Parallel()
 
@@ -81,6 +83,7 @@ func TestSendEvent_UnblocksOnContextCancel(t *testing.T) {
 	}
 }
 
+// TestSendEvent_NilChannelReturnsImmediately verifies missing event wiring cannot block shutdown.
 func TestSendEvent_NilChannelReturnsImmediately(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +109,7 @@ func TestSendEvent_NilChannelReturnsImmediately(t *testing.T) {
 	}
 }
 
+// writeDAGFile writes a minimal DAG fixture and returns its path.
 func writeDAGFile(t *testing.T, dir, fileName, dagName string) string {
 	t.Helper()
 	content := "name: " + dagName + "\nsteps:\n  - name: step1\n    command: echo hello\n"
@@ -114,6 +118,7 @@ func writeDAGFile(t *testing.T, dir, fileName, dagName string) string {
 	return path
 }
 
+// TestHandleFSEvent_CreateAddsDAG verifies create events load DAG metadata and emit an add event.
 func TestHandleFSEvent_CreateAddsDAG(t *testing.T) {
 	t.Parallel()
 
@@ -152,6 +157,7 @@ func TestHandleFSEvent_CreateAddsDAG(t *testing.T) {
 	}
 }
 
+// TestHandleFSEvent_WriteUpdatesDAG verifies write events update existing registry entries.
 func TestHandleFSEvent_WriteUpdatesDAG(t *testing.T) {
 	t.Parallel()
 
@@ -186,6 +192,7 @@ func TestHandleFSEvent_WriteUpdatesDAG(t *testing.T) {
 	}
 }
 
+// TestHandleFSEvent_RemoveDeletesDAG verifies remove events delete confirmed-absent DAG files.
 func TestHandleFSEvent_RemoveDeletesDAG(t *testing.T) {
 	t.Parallel()
 
@@ -223,6 +230,7 @@ func TestHandleFSEvent_RemoveDeletesDAG(t *testing.T) {
 	}
 }
 
+// TestHandleFSEvent_RemoveReloadsDAGWhenFileStillExists verifies remove events reload files that still exist after replacement.
 func TestHandleFSEvent_RemoveReloadsDAGWhenFileStillExists(t *testing.T) {
 	t.Parallel()
 
@@ -260,6 +268,7 @@ func TestHandleFSEvent_RemoveReloadsDAGWhenFileStillExists(t *testing.T) {
 	}
 }
 
+// TestHandleFSEvent_NameChangeEmitsDeleteThenAdd verifies renamed DAG metadata emits delete before add.
 func TestHandleFSEvent_NameChangeEmitsDeleteThenAdd(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -118,19 +118,24 @@ func writeDAGFile(t *testing.T, dir, fileName, dagName string) string {
 	return path
 }
 
+// newTestEntryReader creates an entry reader wired like the production constructor.
+func newTestEntryReader(dir string, events chan DAGChangeEvent) *entryReaderImpl {
+	return &entryReaderImpl{
+		targetDir: dir,
+		registry:  make(map[string]*core.DAG),
+		dagSource: newDAGFileSource(dir),
+		quit:      make(chan struct{}),
+		events:    events,
+	}
+}
+
 // TestHandleFSEvent_CreateAddsDAG verifies create events load DAG metadata and emit an add event.
 func TestHandleFSEvent_CreateAddsDAG(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	events := make(chan DAGChangeEvent, 10)
-
-	er := &entryReaderImpl{
-		targetDir: tmpDir,
-		registry:  make(map[string]*core.DAG),
-		quit:      make(chan struct{}),
-		events:    events,
-	}
+	er := newTestEntryReader(tmpDir, events)
 
 	writeDAGFile(t, tmpDir, "create-test.yaml", "create-test")
 
@@ -163,13 +168,7 @@ func TestHandleFSEvent_WriteUpdatesDAG(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	events := make(chan DAGChangeEvent, 10)
-
-	er := &entryReaderImpl{
-		targetDir: tmpDir,
-		registry:  make(map[string]*core.DAG),
-		quit:      make(chan struct{}),
-		events:    events,
-	}
+	er := newTestEntryReader(tmpDir, events)
 
 	// Pre-populate registry with existing DAG
 	er.registry["update-test.yaml"] = &core.DAG{Name: "update-test"}
@@ -198,13 +197,7 @@ func TestHandleFSEvent_RemoveDeletesDAG(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	events := make(chan DAGChangeEvent, 10)
-
-	er := &entryReaderImpl{
-		targetDir: tmpDir,
-		registry:  make(map[string]*core.DAG),
-		quit:      make(chan struct{}),
-		events:    events,
-	}
+	er := newTestEntryReader(tmpDir, events)
 
 	// Pre-populate registry
 	er.registry["remove-test.yaml"] = &core.DAG{Name: "remove-test"}
@@ -236,13 +229,7 @@ func TestHandleFSEvent_RemoveReloadsDAGWhenFileStillExists(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	events := make(chan DAGChangeEvent, 10)
-
-	er := &entryReaderImpl{
-		targetDir: tmpDir,
-		registry:  make(map[string]*core.DAG),
-		quit:      make(chan struct{}),
-		events:    events,
-	}
+	er := newTestEntryReader(tmpDir, events)
 
 	er.registry["replace-test.yaml"] = &core.DAG{Name: "replace-test"}
 	writeDAGFile(t, tmpDir, "replace-test.yaml", "replace-test")
@@ -274,13 +261,7 @@ func TestHandleFSEvent_NameChangeEmitsDeleteThenAdd(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	events := make(chan DAGChangeEvent, 10)
-
-	er := &entryReaderImpl{
-		targetDir: tmpDir,
-		registry:  make(map[string]*core.DAG),
-		quit:      make(chan struct{}),
-		events:    events,
-	}
+	er := newTestEntryReader(tmpDir, events)
 
 	// Pre-populate registry with old name
 	er.registry["rename-test.yaml"] = &core.DAG{Name: "old-name"}


### PR DESCRIPTION
## Summary

Harden scheduler DAG file reload handling for Windows watcher behavior.

## Changes

- Add a scheduler DAG file snapshot module so watched remove and rename events reload a DAG when the file still exists.
- Route scheduler initial load and watcher reloads through the snapshot path.
- Use retry-aware file reads for DAG specs and base config files to tolerate transient Windows sharing violations.
- Add regression coverage for atomic replacement-shaped remove events and snapshot retry behavior.

## Related Issues

Not applicable.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `go test ./internal/service/scheduler ./internal/core/spec -count=1`
- `go test ./internal/intg -run TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient file loading for base configs and DAG/YAML files with retry/backoff; snapshot loading now honors context cancellation.

* **Refactor**
  * Centralized snapshot-based DAG loading and streamlined reload/remove flow to ensure correct add/update/delete events (including name-change delete handling).

* **Tests**
  * Added tests for retry behavior, context-cancellation, event send/unblock semantics, and DAG lifecycle (create/write/remove/replace) scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->