### PR TITLE
refactor: deepen process termination intent

### DIFF
--- a/internal/agent/bash.go
+++ b/internal/agent/bash.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -184,7 +183,7 @@ func executeWithBash(ctx context.Context, bashPath, command, workDir string) com
 		default:
 		}
 
-		_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+		_ = cmdutil.TerminateProcessGroup(cmd, cmdutil.ForceTermination())
 		<-waitCh
 
 		return commandRunResult{

--- a/internal/cmn/cmdutil/cmd_unix.go
+++ b/internal/cmn/cmdutil/cmd_unix.go
@@ -6,6 +6,7 @@
 package cmdutil
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -24,23 +25,45 @@ func setupCommand(cmd *exec.Cmd) {
 	}
 }
 
-// KillProcessGroup kills the process group on Unix systems
-func KillProcessGroup(cmd *exec.Cmd, sig os.Signal) error {
+// TerminateProcessGroup stops the process group on Unix systems according to
+// the requested lifecycle intent.
+func TerminateProcessGroup(cmd *exec.Cmd, intent TerminationIntent) error {
 	if cmd != nil && cmd.Process != nil {
-		return syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
+		if intent.IsForce() {
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		sig, ok := intent.Signal.(syscall.Signal)
+		if !ok {
+			return fmt.Errorf("unsupported process signal %T", intent.Signal)
+		}
+		return syscall.Kill(-cmd.Process.Pid, sig)
 	}
 	return nil
 }
 
-// KillMultipleProcessGroups kills multiple process groups on Unix systems
-func KillMultipleProcessGroups(cmds map[string]*exec.Cmd, sig os.Signal) error {
+// KillProcessGroup kills the process group on Unix systems.
+//
+// Deprecated: use TerminateProcessGroup with a TerminationIntent.
+func KillProcessGroup(cmd *exec.Cmd, sig os.Signal) error {
+	return TerminateProcessGroup(cmd, TerminationFromSignal(sig))
+}
+
+// TerminateMultipleProcessGroups stops multiple process groups on Unix systems.
+func TerminateMultipleProcessGroups(cmds map[string]*exec.Cmd, intent TerminationIntent) error {
 	var lastErr error
 	for _, cmd := range cmds {
 		if cmd != nil && cmd.Process != nil {
-			if err := syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal)); err != nil {
+			if err := TerminateProcessGroup(cmd, intent); err != nil {
 				lastErr = err
 			}
 		}
 	}
 	return lastErr
+}
+
+// KillMultipleProcessGroups kills multiple process groups on Unix systems.
+//
+// Deprecated: use TerminateMultipleProcessGroups with a TerminationIntent.
+func KillMultipleProcessGroups(cmds map[string]*exec.Cmd, sig os.Signal) error {
+	return TerminateMultipleProcessGroups(cmds, TerminationFromSignal(sig))
 }

--- a/internal/cmn/cmdutil/cmd_windows.go
+++ b/internal/cmn/cmdutil/cmd_windows.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -21,30 +22,48 @@ func SetupCommand(cmd *exec.Cmd) {
 
 // setupCommand configures Windows-specific command attributes
 func setupCommand(cmd *exec.Cmd) {
-	// Windows doesn't support process groups in the same way as Unix
-	// No special configuration needed
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
 }
 
-// KillProcessGroup kills the process and its subprocess tree on Windows systems
-func KillProcessGroup(cmd *exec.Cmd, sig os.Signal) error {
+// TerminateProcessGroup stops the process tree on Windows systems according to
+// the requested lifecycle intent. Windows does not support POSIX signal
+// delivery for arbitrary child process trees, so both graceful and forceful
+// intents use the platform adapter's process-tree termination strategy.
+func TerminateProcessGroup(cmd *exec.Cmd, intent TerminationIntent) error {
 	if cmd != nil && cmd.Process != nil {
-		// Kill the entire process tree to ensure child processes are terminated
 		return killProcessTree(uint32(cmd.Process.Pid))
 	}
 	return nil
 }
 
-// KillMultipleProcessGroups kills multiple processes on Windows systems
-func KillMultipleProcessGroups(cmds map[string]*exec.Cmd, sig os.Signal) error {
+// KillProcessGroup kills the process and its subprocess tree on Windows systems.
+//
+// Deprecated: use TerminateProcessGroup with a TerminationIntent.
+func KillProcessGroup(cmd *exec.Cmd, sig os.Signal) error {
+	return TerminateProcessGroup(cmd, TerminationFromSignal(sig))
+}
+
+// TerminateMultipleProcessGroups stops multiple process trees on Windows systems.
+func TerminateMultipleProcessGroups(cmds map[string]*exec.Cmd, intent TerminationIntent) error {
 	var lastErr error
 	for _, cmd := range cmds {
 		if cmd != nil && cmd.Process != nil {
-			if err := killProcessTree(uint32(cmd.Process.Pid)); err != nil {
+			if err := TerminateProcessGroup(cmd, intent); err != nil {
 				lastErr = err
 			}
 		}
 	}
 	return lastErr
+}
+
+// KillMultipleProcessGroups kills multiple processes on Windows systems.
+//
+// Deprecated: use TerminateMultipleProcessGroups with a TerminationIntent.
+func KillMultipleProcessGroups(cmds map[string]*exec.Cmd, sig os.Signal) error {
+	return TerminateMultipleProcessGroups(cmds, TerminationFromSignal(sig))
 }
 
 // killProcessTree kills a process and its subprocess tree on Windows

--- a/internal/cmn/cmdutil/parent_exit_watcher_unix.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_unix.go
@@ -54,7 +54,7 @@ func StartParentExitWatcher(cmd *exec.Cmd) (func(), error) {
 			select {
 			case <-done:
 			case <-time.After(2 * time.Second):
-				_ = KillProcessGroup(watcher, os.Kill)
+				_ = TerminateProcessGroup(watcher, ForceTermination())
 				select {
 				case <-done:
 				case <-time.After(time.Second):

--- a/internal/cmn/cmdutil/parent_exit_watcher_windows.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_windows.go
@@ -6,7 +6,7 @@ package cmdutil
 import "os/exec"
 
 // StartParentExitWatcher is a no-op on Windows. Windows process cleanup uses
-// job/process-tree handling in the platform-specific command utilities.
+// process-tree handling in the platform-specific lifecycle adapter.
 func StartParentExitWatcher(_ *exec.Cmd) (func(), error) {
 	return func() {}, nil
 }

--- a/internal/cmn/cmdutil/termination.go
+++ b/internal/cmn/cmdutil/termination.go
@@ -39,7 +39,14 @@ func TerminationFromSignal(sig os.Signal) TerminationIntent {
 }
 
 // GracefulTermination creates a graceful stop request for the given signal.
+// Force-class signals are normalized to a forceful intent.
 func GracefulTermination(sig os.Signal) TerminationIntent {
+	if isForceSignal(sig) {
+		return TerminationIntent{
+			Mode:   TerminationModeForce,
+			Signal: sig,
+		}
+	}
 	return TerminationIntent{
 		Mode:   TerminationModeGraceful,
 		Signal: sig,

--- a/internal/cmn/cmdutil/termination.go
+++ b/internal/cmn/cmdutil/termination.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmdutil
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/dagucloud/dagu/internal/cmn/signal"
+)
+
+// TerminationMode describes the lifecycle intent behind a process stop request.
+type TerminationMode string
+
+const (
+	// TerminationModeGraceful asks the platform adapter to stop the process tree
+	// using the least forceful supported mechanism for the requested signal.
+	TerminationModeGraceful TerminationMode = "graceful"
+	// TerminationModeForce asks the platform adapter to terminate the process tree.
+	TerminationModeForce TerminationMode = "force"
+)
+
+// TerminationIntent is the platform-neutral stop request used by process
+// adapters. Signal is retained for POSIX adapters and for user-facing logs, but
+// callers should make decisions from Mode instead of assuming Unix semantics.
+type TerminationIntent struct {
+	Mode   TerminationMode
+	Signal os.Signal
+}
+
+// TerminationFromSignal preserves the legacy signal-based call sites while
+// moving the implementation behind an intent-based seam.
+func TerminationFromSignal(sig os.Signal) TerminationIntent {
+	if isForceSignal(sig) {
+		return ForceTermination()
+	}
+	return GracefulTermination(sig)
+}
+
+// GracefulTermination creates a graceful stop request for the given signal.
+func GracefulTermination(sig os.Signal) TerminationIntent {
+	return TerminationIntent{
+		Mode:   TerminationModeGraceful,
+		Signal: sig,
+	}
+}
+
+// ForceTermination creates a forceful process-tree termination request.
+func ForceTermination() TerminationIntent {
+	return TerminationIntent{
+		Mode:   TerminationModeForce,
+		Signal: os.Kill,
+	}
+}
+
+// WithSignal returns a copy of the intent with a different signal. Force-class
+// signals always force the mode because they cannot be graceful in practice.
+func (i TerminationIntent) WithSignal(sig os.Signal) TerminationIntent {
+	if i.IsForce() {
+		return ForceTermination()
+	}
+	if isForceSignal(sig) {
+		return ForceTermination()
+	}
+	i.Signal = sig
+	if i.Mode == "" {
+		i.Mode = TerminationModeGraceful
+	}
+	return i
+}
+
+// IsForce reports whether this request is a forceful stop.
+func (i TerminationIntent) IsForce() bool {
+	return i.Mode == TerminationModeForce
+}
+
+// IsTermination reports whether this intent should mark a running node aborted.
+func (i TerminationIntent) IsTermination() bool {
+	return i.IsForce() || signal.IsTerminationSignalOS(i.Signal)
+}
+
+// SignalName returns a stable string for logging.
+func (i TerminationIntent) SignalName() string {
+	if i.Signal == nil {
+		return ""
+	}
+	return i.Signal.String()
+}
+
+func isForceSignal(sig os.Signal) bool {
+	sysSig, ok := sig.(syscall.Signal)
+	return ok && sysSig == syscall.SIGKILL
+}

--- a/internal/cmn/cmdutil/termination_test.go
+++ b/internal/cmn/cmdutil/termination_test.go
@@ -47,3 +47,11 @@ func TestForceTerminationIgnoresSignalOverride(t *testing.T) {
 	require.Equal(t, os.Kill, intent.Signal)
 	require.True(t, intent.IsForce())
 }
+
+func TestGracefulTerminationNormalizesForceSignal(t *testing.T) {
+	intent := GracefulTermination(os.Kill)
+
+	require.Equal(t, TerminationModeForce, intent.Mode)
+	require.Equal(t, os.Kill, intent.Signal)
+	require.True(t, intent.IsForce())
+}

--- a/internal/cmn/cmdutil/termination_test.go
+++ b/internal/cmn/cmdutil/termination_test.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmdutil
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminationIntentFromSignal(t *testing.T) {
+	t.Run("Graceful", func(t *testing.T) {
+		intent := TerminationFromSignal(syscall.SIGTERM)
+
+		require.Equal(t, TerminationModeGraceful, intent.Mode)
+		require.Equal(t, os.Signal(syscall.SIGTERM), intent.Signal)
+		require.True(t, intent.IsTermination())
+		require.False(t, intent.IsForce())
+	})
+
+	t.Run("Force", func(t *testing.T) {
+		intent := TerminationFromSignal(os.Kill)
+
+		require.Equal(t, TerminationModeForce, intent.Mode)
+		require.Equal(t, os.Kill, intent.Signal)
+		require.True(t, intent.IsTermination())
+		require.True(t, intent.IsForce())
+	})
+
+	t.Run("NonTerminationSignal", func(t *testing.T) {
+		intent := TerminationFromSignal(syscall.Signal(0))
+
+		require.Equal(t, TerminationModeGraceful, intent.Mode)
+		require.Equal(t, os.Signal(syscall.Signal(0)), intent.Signal)
+		require.False(t, intent.IsTermination())
+		require.False(t, intent.IsForce())
+	})
+}
+
+func TestForceTerminationIgnoresSignalOverride(t *testing.T) {
+	intent := ForceTermination().WithSignal(syscall.SIGTERM)
+
+	require.Equal(t, TerminationModeForce, intent.Mode)
+	require.Equal(t, os.Kill, intent.Signal)
+	require.True(t, intent.IsForce())
+}

--- a/internal/intg/distr/zombie_recovery_test.go
+++ b/internal/intg/distr/zombie_recovery_test.go
@@ -83,7 +83,7 @@ steps:
 	lease := waitForLease(t, f, status.AttemptKey, 5*time.Second)
 	require.Equal(t, "crash-worker", lease.WorkerID)
 
-	require.NoError(t, cmdutil.KillProcessGroup(workerCmd, os.Kill))
+	require.NoError(t, cmdutil.TerminateProcessGroup(workerCmd, cmdutil.ForceTermination()))
 
 	finalStatus := f.waitForStatus(core.Failed, 20*time.Second)
 	assert.Equal(t, core.Failed, finalStatus.Status)
@@ -744,7 +744,7 @@ func startWorkerProcess(t *testing.T, f *testFixture, workerID, labels string) (
 		}
 
 		if cmd.Process != nil {
-			_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+			_ = cmdutil.TerminateProcessGroup(cmd, cmdutil.ForceTermination())
 		}
 		select {
 		case <-done:

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -27,6 +27,7 @@ import (
 
 	agentpkg "github.com/dagucloud/dagu/internal/agent"
 	"github.com/dagucloud/dagu/internal/agentoauth"
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -36,7 +37,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/masking"
 	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/cmn/secrets"
-	"github.com/dagucloud/dagu/internal/cmn/signal"
 	"github.com/dagucloud/dagu/internal/cmn/sock"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/cmn/telemetry"
@@ -1404,7 +1404,7 @@ func (a *Agent) pushStatus(ctx context.Context, status exec.DAGRunStatus) {
 				tag.AttemptID(a.dagRunAttemptID),
 				slog.String("reason", rejectedErr.Reason),
 			)
-			a.signal(context.Background(), syscall.SIGTERM, true)
+			a.stopChildren(context.Background(), syscall.SIGTERM, true)
 		}
 	}
 }
@@ -1431,20 +1431,20 @@ func (a *Agent) watchCancelRequested(ctx context.Context, attempt exec.DAGRunAtt
 			// in shared-nothing mode. If the agent already finished normally,
 			// we don't want to send an unnecessary SIGTERM.
 			if !a.finished.Load() {
-				a.signal(context.Background(), syscall.SIGTERM, true)
+				a.stopChildren(context.Background(), syscall.SIGTERM, true)
 			}
 			return
 		case <-ticker.C:
 			if cancelled, _ := attempt.IsAborting(ctx); cancelled {
-				a.signal(ctx, syscall.SIGTERM, true)
+				a.stopChildren(ctx, syscall.SIGTERM, true)
 			}
 		}
 	}
 }
 
-// Signal sends the signal to the processes running
+// Signal requests that running child processes stop.
 func (a *Agent) Signal(ctx context.Context, sig os.Signal) {
-	a.signal(ctx, sig, false)
+	a.stopChildren(ctx, sig, false)
 }
 
 // wait before read the running status
@@ -1481,7 +1481,7 @@ func (a *Agent) HandleHTTP(ctx context.Context) sock.HTTPHandlerFunc {
 			_, _ = w.Write([]byte("OK"))
 			go func() {
 				logger.Info(ctx, "Stop request received")
-				a.signal(ctx, syscall.SIGTERM, true)
+				a.stopChildren(ctx, syscall.SIGTERM, true)
 			}()
 		default:
 			// Unknown request
@@ -1803,23 +1803,22 @@ func (a *Agent) dryRun(ctx context.Context) error {
 	return lastErr
 }
 
-// signal propagates the received signal to the all running child processes.
-// allowOverride parameters is used to specify if a node can override
-// the signal to send to the process, in case the node is configured
-// to send a custom signal (e.g., SIGSTOP instead of SIGTERM).
-// The reason we need this is to allow the system to kill the child
-// process by sending a SIGKILL to force the process to be shutdown.
-// if processes do not terminate after MaxCleanUp time, it sends KILL signal.
-func (a *Agent) signal(ctx context.Context, sig os.Signal, allowOverride bool) {
-	logger.Info(ctx, "Sending signal to running child processes",
-		tag.Signal(sig.String()),
+// stopChildren requests that all running child processes stop.
+// allowOverride specifies whether a node can override the stop request with
+// its configured signal on platforms that support signal delivery. If processes
+// do not terminate after MaxCleanUp time, it requests forceful termination.
+func (a *Agent) stopChildren(ctx context.Context, sig os.Signal, allowOverride bool) {
+	intent := cmdutil.TerminationFromSignal(sig)
+	logger.Info(ctx, "Stopping running child processes",
+		slog.String("stop-mode", string(intent.Mode)),
+		tag.Signal(intent.SignalName()),
 		slog.Bool("allow-override", allowOverride),
 		slog.Duration("max-cleanup-time", a.dag.MaxCleanUpTime),
 	)
 
-	if !signal.IsTerminationSignalOS(sig) {
-		// For non-termination signals, just send the signal once and return.
-		a.runner.Signal(ctx, a.plan, sig, nil, allowOverride)
+	if !intent.IsTermination() {
+		// For non-termination signals, just forward the request once and return.
+		a.runner.Stop(ctx, a.plan, intent, nil, allowOverride)
 		return
 	}
 
@@ -1828,7 +1827,7 @@ func (a *Agent) signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 
 	done := make(chan bool, 1)
 	go func() {
-		a.runner.Signal(ctx, a.plan, sig, done, allowOverride)
+		a.runner.Stop(ctx, a.plan, intent, done, allowOverride)
 	}()
 
 	resendTicker := time.NewTicker(5 * time.Second)
@@ -1843,15 +1842,20 @@ func (a *Agent) signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 			return
 
 		case <-signalCtx.Done():
-			logger.Info(ctx, "Max cleanup time reached, sending SIGKILL to force termination")
-			a.runner.Signal(ctx, a.plan, syscall.SIGKILL, nil, false)
+			forceIntent := cmdutil.ForceTermination()
+			logger.Info(ctx, "Max cleanup time reached, forcing child process termination",
+				slog.String("stop-mode", string(forceIntent.Mode)),
+				tag.Signal(forceIntent.SignalName()),
+			)
+			a.runner.Stop(ctx, a.plan, forceIntent, nil, false)
 			return
 
 		case <-resendTicker.C:
-			logger.Info(ctx, "Resending signal to processes that haven't terminated",
-				tag.Signal(sig.String()),
+			logger.Info(ctx, "Resending stop request to processes that haven't terminated",
+				slog.String("stop-mode", string(intent.Mode)),
+				tag.Signal(intent.SignalName()),
 			)
-			a.runner.Signal(ctx, a.plan, sig, nil, false)
+			a.runner.Stop(ctx, a.plan, intent, nil, false)
 
 		case <-probeTicker.C:
 			if a.plan != nil && !a.plan.HasActiveNodes() {

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -31,6 +31,7 @@ import (
 var errNoCommandSpecified = fmt.Errorf("no command specified")
 
 var _ executor.Executor = (*commandExecutor)(nil)
+var _ executor.Stopper = (*commandExecutor)(nil)
 var _ executor.ExitCoder = (*commandExecutor)(nil)
 
 type commandExecutor struct {
@@ -105,7 +106,7 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 		cmd := e.cmd
 		e.exitCode = 1
 		e.mu.Unlock()
-		_ = cmdutil.KillProcessGroup(cmd, os.Kill)
+		_ = cmdutil.TerminateProcessGroup(cmd, cmdutil.ForceTermination())
 		_ = cmd.Wait()
 		return fmt.Errorf("failed to start parent exit watcher: %w", err)
 	}
@@ -151,10 +152,14 @@ func (e *commandExecutor) SetStderr(out io.Writer) {
 }
 
 func (e *commandExecutor) Kill(sig os.Signal) error {
+	return e.Stop(cmdutil.TerminationFromSignal(sig))
+}
+
+func (e *commandExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	return cmdutil.KillProcessGroup(e.cmd, sig)
+	return cmdutil.TerminateProcessGroup(e.cmd, intent)
 }
 
 // annotateStderrTail writes the full script to the stderr log with the

--- a/internal/runtime/builtin/command/command_unix_test.go
+++ b/internal/runtime/builtin/command/command_unix_test.go
@@ -50,7 +50,7 @@ func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
 		if helperCmd == nil || helperCmd.Process == nil {
 			return
 		}
-		_ = cmdutil.KillProcessGroup(helperCmd, os.Kill)
+		_ = cmdutil.TerminateProcessGroup(helperCmd, cmdutil.ForceTermination())
 		select {
 		case <-cmdDone:
 		case <-time.After(2 * time.Second):
@@ -72,7 +72,7 @@ func TestCommandExecutor_CleansProcessGroupWhenParentDies(t *testing.T) {
 		}
 	})
 
-	require.NoError(t, cmdutil.KillProcessGroup(cmd, os.Kill))
+	require.NoError(t, cmdutil.TerminateProcessGroup(cmd, cmdutil.ForceTermination()))
 	select {
 	case <-cmdDone:
 	case <-time.After(5 * time.Second):

--- a/internal/runtime/builtin/harness/harness.go
+++ b/internal/runtime/builtin/harness/harness.go
@@ -29,6 +29,7 @@ import (
 )
 
 var _ executor.Executor = (*harnessExecutor)(nil)
+var _ executor.Stopper = (*harnessExecutor)(nil)
 var _ executor.ExitCoder = (*harnessExecutor)(nil)
 var _ executor.PushBackAware = (*harnessExecutor)(nil)
 var _ executor.PushBackPreviousStdoutAware = (*harnessExecutor)(nil)
@@ -75,9 +76,13 @@ func (e *harnessExecutor) SetStderr(out io.Writer) {
 }
 
 func (e *harnessExecutor) Kill(sig os.Signal) error {
+	return e.Stop(cmdutil.TerminationFromSignal(sig))
+}
+
+func (e *harnessExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return cmdutil.KillProcessGroup(e.cmd, sig)
+	return cmdutil.TerminateProcessGroup(e.cmd, intent)
 }
 
 func (e *harnessExecutor) SetPushBackContext(inputs map[string]string, iteration int) {

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -1019,6 +1019,12 @@ func extractOutputValuesFromNodes(nodes []*exec.Node) map[string]any {
 
 // Kill terminates all running sub DAG processes (both local and distributed)
 func (e *SubDAGExecutor) Kill(sig os.Signal) error {
+	return e.Stop(cmdutil.TerminationFromSignal(sig))
+}
+
+// Stop terminates all running sub DAG processes (both local and distributed)
+// according to the requested lifecycle intent.
+func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -1072,17 +1078,19 @@ func (e *SubDAGExecutor) Kill(sig os.Signal) error {
 	// Kill local processes
 	for runID, cmd := range e.cmds {
 		if cmd != nil && cmd.Process != nil {
-			if err := cmdutil.KillProcessGroup(cmd, sig); err != nil {
+			if err := cmdutil.TerminateProcessGroup(cmd, intent); err != nil {
 				errs = append(errs, err)
-				logger.Warn(ctx, "Failed to kill local sub DAG process",
+				logger.Warn(ctx, "Failed to stop local sub DAG process",
 					tag.RunID(runID),
 					tag.DAG(e.DAG.Name),
 					tag.Error(err),
 				)
 			} else {
-				logger.Info(ctx, "Requested kill for local sub DAG process",
+				logger.Info(ctx, "Requested stop for local sub DAG process",
 					tag.RunID(runID),
 					tag.DAG(e.DAG.Name),
+					slog.String("stop-mode", string(intent.Mode)),
+					tag.Signal(intent.SignalName()),
 				)
 			}
 		}

--- a/internal/runtime/executor/executor.go
+++ b/internal/runtime/executor/executor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
@@ -35,6 +36,12 @@ type Executor interface {
 	SetStderr(out io.Writer)
 	Kill(sig os.Signal) error
 	Run(ctx context.Context) error
+}
+
+// Stopper is implemented by executors that can handle lifecycle stop intent
+// directly instead of receiving only a legacy OS signal.
+type Stopper interface {
+	Stop(cmdutil.TerminationIntent) error
 }
 
 // ExecutorFactory is a function type that creates an Executor based on the step configuration.

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,6 +21,7 @@ import (
 
 	"syscall"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/collections"
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -924,6 +926,11 @@ func (n *Node) evaluateCommandArgs(ctx context.Context) error {
 }
 
 func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
+	n.Stop(ctx, cmdutil.TerminationFromSignal(sig), allowOverride)
+}
+
+// Stop requests that the node's executor stop according to lifecycle intent.
+func (n *Node) Stop(ctx context.Context, intent cmdutil.TerminationIntent, allowOverride bool) {
 	n.mu.Lock()
 	status := n.Status()
 	if status != core.NodeRunning {
@@ -931,8 +938,8 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 		return
 	}
 
-	killSignal := n.signalToSend(sig, allowOverride)
-	isTermination := signal.IsTerminationSignalOS(killSignal)
+	stopIntent := n.stopIntentToSend(intent, allowOverride)
+	isTermination := stopIntent.IsTermination()
 	if isTermination {
 		n.SetStatus(core.NodeAborted)
 	}
@@ -947,23 +954,31 @@ func (n *Node) Signal(ctx context.Context, sig os.Signal, allowOverride bool) {
 		return
 	}
 
-	logger.Info(ctx, "Sending signal",
-		tag.Signal(killSignal.String()),
+	logger.Info(ctx, "Requesting step stop",
+		slog.String("stop-mode", string(stopIntent.Mode)),
+		tag.Signal(stopIntent.SignalName()),
 		tag.Step(n.Name()),
 	)
-	if err := cmd.Kill(killSignal); err != nil {
-		logger.Error(ctx, "Failed to send signal",
+	if err := stopExecutor(cmd, stopIntent); err != nil {
+		logger.Error(ctx, "Failed to stop step",
 			tag.Error(err),
 			tag.Step(n.Name()),
 		)
 	}
 }
 
-func (n *Node) signalToSend(sig os.Signal, allowOverride bool) os.Signal {
+func (n *Node) stopIntentToSend(intent cmdutil.TerminationIntent, allowOverride bool) cmdutil.TerminationIntent {
 	if allowOverride && n.SignalOnStop() != "" {
-		return syscall.Signal(signal.GetSignalNum(n.SignalOnStop()))
+		return intent.WithSignal(syscall.Signal(signal.GetSignalNum(n.SignalOnStop())))
 	}
-	return sig
+	return intent
+}
+
+func stopExecutor(cmd executor.Executor, intent cmdutil.TerminationIntent) error {
+	if stopper, ok := cmd.(executor.Stopper); ok {
+		return stopper.Stop(intent)
+	}
+	return cmd.Kill(intent.Signal)
 }
 
 func (n *Node) Cancel() {

--- a/internal/runtime/node_test.go
+++ b/internal/runtime/node_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -37,8 +38,9 @@ var (
 )
 
 type blockingSignalExecutor struct {
-	ready  chan struct{}
-	killed chan os.Signal
+	ready   chan struct{}
+	killed  chan os.Signal
+	stopped chan cmdutil.TerminationIntent
 	// Optional test hooks for controlling Kill ordering.
 	killStarted  chan struct{}
 	killContinue chan struct{}
@@ -83,6 +85,16 @@ func (e *blockingSignalExecutor) Kill(sig os.Signal) error {
 		<-e.killContinue
 	}
 	return nil
+}
+
+func (e *blockingSignalExecutor) Stop(intent cmdutil.TerminationIntent) error {
+	if e.stopped != nil {
+		select {
+		case e.stopped <- intent:
+		default:
+		}
+	}
+	return e.Kill(intent.Signal)
 }
 
 func registerNodeSignalExecutor(t *testing.T) {
@@ -265,6 +277,72 @@ func TestNode(t *testing.T) {
 		}
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "signal: interrupt")
+	})
+	t.Run("SignalUsesStopIntent", func(t *testing.T) {
+		execCh, restore := withNodeSignalExecutorFactory(t, func() *blockingSignalExecutor {
+			exec := newBlockingSignalExecutor()
+			exec.stopped = make(chan cmdutil.TerminationIntent, 1)
+			return exec
+		})
+		defer restore()
+
+		node := setupNode(t, withNodeExecutorType(nodeSignalExecutorType))
+		seen := make(chan *blockingSignalExecutor, 1)
+		go func() {
+			exec := <-execCh
+			seen <- exec
+			<-exec.ready
+			node.Signal(node.Context, syscall.SIGTERM, false)
+		}()
+
+		node.SetStatus(core.NodeRunning)
+
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		err := node.Node.Execute(node.execContext(dagRunID))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signal: terminated")
+
+		exec := <-seen
+		select {
+		case intent := <-exec.stopped:
+			require.Equal(t, cmdutil.TerminationModeGraceful, intent.Mode)
+			require.Equal(t, os.Signal(syscall.SIGTERM), intent.Signal)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for stop intent")
+		}
+	})
+	t.Run("ForceSignalIgnoresSignalOnStopOverride", func(t *testing.T) {
+		execCh, restore := withNodeSignalExecutorFactory(t, func() *blockingSignalExecutor {
+			exec := newBlockingSignalExecutor()
+			exec.stopped = make(chan cmdutil.TerminationIntent, 1)
+			return exec
+		})
+		defer restore()
+
+		node := setupNode(t, withNodeExecutorType(nodeSignalExecutorType), withNodeSignalOnStop("SIGINT"))
+		seen := make(chan *blockingSignalExecutor, 1)
+		go func() {
+			exec := <-execCh
+			seen <- exec
+			<-exec.ready
+			node.Signal(node.Context, syscall.SIGKILL, true)
+		}()
+
+		node.SetStatus(core.NodeRunning)
+
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		err := node.Node.Execute(node.execContext(dagRunID))
+		require.Error(t, err)
+		require.Equal(t, core.NodeAborted.String(), node.State().Status.String())
+
+		exec := <-seen
+		select {
+		case intent := <-exec.stopped:
+			require.Equal(t, cmdutil.TerminationModeForce, intent.Mode)
+			require.Equal(t, os.Kill, intent.Signal)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for stop intent")
+		}
 	})
 	t.Run("CancelUpdatesOnlyRunningOrWaiting", func(t *testing.T) {
 		t.Parallel()

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -16,10 +16,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/signal"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"go.opentelemetry.io/otel"
@@ -850,7 +850,14 @@ func (r *Runner) execNode(ctx context.Context, node *Node, progressCh chan *Node
 func (r *Runner) Signal(
 	ctx context.Context, plan *Plan, sig os.Signal, done chan bool, allowOverride bool,
 ) {
-	isTermination := signal.IsTerminationSignalOS(sig)
+	r.Stop(ctx, plan, cmdutil.TerminationFromSignal(sig), done, allowOverride)
+}
+
+// Stop requests that all active nodes stop according to lifecycle intent.
+func (r *Runner) Stop(
+	ctx context.Context, plan *Plan, intent cmdutil.TerminationIntent, done chan bool, allowOverride bool,
+) {
+	isTermination := intent.IsTermination()
 
 	// Set canceled flag FIRST so execution loops see it immediately.
 	// This prevents a race where the execution loop checks isCanceled()
@@ -869,7 +876,7 @@ func (r *Runner) Signal(
 			)
 			continue
 		}
-		node.Signal(ctx, sig, allowOverride)
+		node.Stop(ctx, intent, allowOverride)
 	}
 
 	if done != nil && isTermination {

--- a/internal/service/frontend/terminal/process_windows.go
+++ b/internal/service/frontend/terminal/process_windows.go
@@ -7,7 +7,6 @@ package terminal
 
 import (
 	"os/exec"
-	"syscall"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 )
@@ -23,5 +22,5 @@ func forceKillProcess(cmd *exec.Cmd) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
-	return cmdutil.KillProcessGroup(cmd, syscall.SIGKILL)
+	return cmdutil.TerminateProcessGroup(cmd, cmdutil.ForceTermination())
 }


### PR DESCRIPTION
## Summary

Refactor process termination around lifecycle intent so runtime code requests graceful or forceful stops without assuming Unix signal semantics.

## Changes

- Add a `cmdutil.TerminationIntent` Module with graceful and force modes plus compatibility wrappers for legacy signal-based callers.
- Route Node, Runner, Agent cleanup, command, harness, sub-DAG, bash, and terminal stop paths through intent-based termination.
- Keep Unix signal delivery and Windows process-tree termination behind platform Adapters.
- Add regression coverage for force intent and `signal_on_stop` override behavior.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (not applicable; internal process lifecycle refactor)
- [x] Changes have been tested locally

## Testing

- `go test ./internal/cmn/cmdutil ./internal/runtime/... ./internal/engine ./internal/agent ./internal/service/frontend/terminal -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-cmdutil.test.exe ./internal/cmn/cmdutil`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-runtime.test.exe ./internal/runtime`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-command.test.exe ./internal/runtime/builtin/command`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-runtime-agent.test.exe ./internal/runtime/agent`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-agent.test.exe ./internal/agent`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dagu-terminal.test.exe ./internal/service/frontend/terminal`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced an intent-based stop model for unified graceful/force termination and updated process-group termination across platforms and components.

* **Tests**
  * Added and expanded tests validating termination intents, stop behavior, and force-vs-graceful shutdown handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->