### PR TITLE
test: add portable integration harness

### DIFF
--- a/internal/intg/proc_liveness_test.go
+++ b/internal/intg/proc_liveness_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/test"
+	"github.com/dagucloud/dagu/internal/test/intgharness"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -34,12 +35,13 @@ func TestProcHeartbeat_StartCommand(t *testing.T) {
 		cfg.Proc.HeartbeatSyncInterval = testProcHeartbeatInterval
 		cfg.Proc.StaleThreshold = testProcStaleThreshold
 	}))
+	h := intgharness.New(t, th.Helper)
 
 	dag := th.DAG(t, `
 name: proc-heartbeat-start
 steps:
   - name: sleep
-    run: sleep 2
+    run: `+h.Commands.Sleep(2*time.Second)+`
 `)
 
 	dagRunID := uuid.Must(uuid.NewV7()).String()
@@ -51,16 +53,13 @@ steps:
 	})
 
 	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
-	require.Eventually(t, func() bool {
-		status, ok := readStatusIfPresent(th, ref)
-		return ok && status.Status == core.Running
-	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
-
-	test.RequireProcHeartbeatAdvance(t, th.Context, th.ProcStore, dag.ProcGroup(), ref, intgTestTimeout(3*time.Second))
+	run := h.Run(ref, dag.ProcGroup())
+	run.RequireRunning(5 * time.Second)
+	run.RequireHeartbeatAdvance(3 * time.Second)
 
 	require.NoError(t, <-errCh)
 
-	status := test.ReadRunStatus(th.Context, t, th.DAGRunStore, ref)
+	status := run.ReadStatus()
 	require.Equal(t, core.Succeeded, status.Status)
 }
 
@@ -72,12 +71,13 @@ func TestProcHeartbeat_RetryCommand(t *testing.T) {
 		cfg.Proc.HeartbeatSyncInterval = testProcHeartbeatInterval
 		cfg.Proc.StaleThreshold = testProcStaleThreshold
 	}))
+	h := intgharness.New(t, th.Helper)
 
 	dag := th.DAG(t, `
 name: proc-heartbeat-retry
 steps:
   - name: sleep
-    run: sleep 2
+    run: `+h.Commands.Sleep(2*time.Second)+`
 `)
 
 	dagRunID := uuid.Must(uuid.NewV7()).String()
@@ -91,16 +91,13 @@ steps:
 	})
 
 	ref := exec.NewDAGRunRef(dag.Name, dagRunID)
-	require.Eventually(t, func() bool {
-		status, ok := readStatusIfPresent(th, ref)
-		return ok && status.Status == core.Running
-	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
-
-	test.RequireProcHeartbeatAdvance(t, th.Context, th.ProcStore, dag.ProcGroup(), ref, intgTestTimeout(3*time.Second))
+	run := h.Run(ref, dag.ProcGroup())
+	run.RequireRunning(5 * time.Second)
+	run.RequireHeartbeatAdvance(3 * time.Second)
 
 	require.NoError(t, <-errCh)
 
-	status := test.ReadRunStatus(th.Context, t, th.DAGRunStore, ref)
+	status := run.ReadStatus()
 	require.Equal(t, core.Succeeded, status.Status)
 }
 
@@ -138,16 +135,4 @@ func createFailedRun(t *testing.T, th test.Command, dag *core.DAG, dagRunID stri
 	require.NoError(t, attempt.Open(th.Context))
 	require.NoError(t, attempt.Write(th.Context, status))
 	require.NoError(t, attempt.Close(th.Context))
-}
-
-func readStatusIfPresent(th test.Command, dagRun exec.DAGRunRef) (*exec.DAGRunStatus, bool) {
-	attempt, err := th.DAGRunStore.FindAttempt(th.Context, dagRun)
-	if err != nil {
-		return nil, false
-	}
-	status, err := attempt.ReadStatus(th.Context)
-	if err != nil {
-		return nil, false
-	}
-	return status, true
 }

--- a/internal/intg/sched_test.go
+++ b/internal/intg/sched_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/test"
+	"github.com/dagucloud/dagu/internal/test/intgharness"
 	"github.com/stretchr/testify/require"
 )
 
@@ -197,82 +198,24 @@ func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {
 	ctx, cancel := context.WithCancel(th.Context)
 	defer cancel()
 
-	errCh := make(chan error, 1)
-	go func() { errCh <- sc.Start(ctx) }()
-
-	var schedulerErr error
-	var schedulerStopped bool
-	pollSchedulerErr := func() error {
-		if schedulerStopped {
-			return schedulerErr
-		}
-		select {
-		case err := <-errCh:
-			schedulerStopped = true
-			if err == nil {
-				err = errors.New("scheduler exited unexpectedly before test completed")
-			}
-			schedulerErr = err
-		default:
-		}
-		return schedulerErr
-	}
-
-	schedulerHasSchedule := func(expression string) bool {
-		for _, loaded := range th.EntryReader.DAGs() {
-			if loaded.Name != dagName || len(loaded.Schedule) != 1 {
-				continue
-			}
-			return loaded.Schedule[0].Expression == expression
-		}
-		return false
-	}
-
-	require.Eventually(t, func() bool {
-		if err := pollSchedulerErr(); err != nil {
-			return true
-		}
-		return sc.IsRunning() && schedulerHasSchedule("0 10 * * *")
-	}, intgTestTimeout(2*time.Second), 50*time.Millisecond)
-	require.NoError(t, schedulerErr)
+	h := intgharness.New(t, th.Helper)
+	probe := h.StartScheduler(ctx, sc, th.EntryReader)
+	probe.RequireRunningWithSchedule(dagName, "0 10 * * *", 2*time.Second)
 
 	writeSpec("5 10 * * *")
 
-	require.Eventually(t, func() bool {
-		if err := pollSchedulerErr(); err != nil {
-			return true
-		}
-		return schedulerHasSchedule("5 10 * * *")
-	}, intgTestTimeout(5*time.Second), 50*time.Millisecond)
-	require.NoError(t, schedulerErr)
+	probe.RequireLoadedSchedule(dagName, "5 10 * * *", 5*time.Second)
 
 	require.NoError(t, os.Remove(suspendFlag))
 
-	require.Eventually(t, func() bool {
-		if err := pollSchedulerErr(); err != nil {
-			return true
-		}
+	probe.RequireEventually("expected edited schedule to dispatch", 35*time.Second, func() bool {
 		return dispatchCount.Load() > 0
-	}, intgTestTimeout(35*time.Second), 50*time.Millisecond)
-	require.NoError(t, schedulerErr)
+	})
 	require.Equal(t, int32(1), dispatchCount.Load(), "edited schedules should dispatch exactly once")
 	lastDispatchMu.Lock()
 	require.Equal(t, core.TriggerTypeScheduler, lastDispatchType)
 	require.Equal(t, newSlot, lastDispatchTime)
 	lastDispatchMu.Unlock()
 
-	sc.Stop(context.Background())
-	cancel()
-
-	if !schedulerStopped {
-		select {
-		case err := <-errCh:
-			require.True(t,
-				err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
-				"unexpected scheduler shutdown error: %v", err,
-			)
-		case <-time.After(intgTestTimeout(5 * time.Second)):
-			t.Fatal("scheduler did not stop within 5 seconds")
-		}
-	}
+	probe.Stop(context.Background(), cancel, 5*time.Second)
 }

--- a/internal/test/intgharness/commands.go
+++ b/internal/test/intgharness/commands.go
@@ -37,6 +37,9 @@ func commandsForShell(shell shellKind) Commands {
 
 // Sleep returns a shell snippet that waits for d.
 func (c Commands) Sleep(d time.Duration) string {
+	if d <= 0 {
+		d = time.Millisecond
+	}
 	if c.shell == powerShell {
 		millis := d.Milliseconds()
 		if millis <= 0 {

--- a/internal/test/intgharness/commands.go
+++ b/internal/test/intgharness/commands.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"time"
+
+	testutil "github.com/dagucloud/dagu/internal/test"
+)
+
+type shellKind int
+
+const (
+	posixShell shellKind = iota
+	powerShell
+)
+
+// Commands builds portable command snippets for integration DAG fixtures.
+type Commands struct {
+	shell shellKind
+}
+
+func defaultCommands() Commands {
+	if runtime.GOOS == "windows" {
+		return commandsForShell(powerShell)
+	}
+	return commandsForShell(posixShell)
+}
+
+func commandsForShell(shell shellKind) Commands {
+	return Commands{shell: shell}
+}
+
+// Sleep returns a shell snippet that waits for d.
+func (c Commands) Sleep(d time.Duration) string {
+	if c.shell == powerShell {
+		millis := d.Milliseconds()
+		if millis <= 0 {
+			millis = 1
+		}
+		return fmt.Sprintf("Start-Sleep -Milliseconds %d", millis)
+	}
+	return fmt.Sprintf("sleep %s", strconv.FormatFloat(d.Seconds(), 'f', -1, 64))
+}
+
+// WriteFile returns a shell snippet that writes content to path.
+func (c Commands) WriteFile(path, content string) string {
+	if c.shell == powerShell {
+		return fmt.Sprintf("Set-Content -Path %s -Value %s -NoNewline", testutil.PowerShellQuote(path), testutil.PowerShellQuote(content))
+	}
+	return fmt.Sprintf("printf '%%s' %s > %s", testutil.PosixQuote(content), testutil.PosixQuote(path))
+}
+
+// WaitForFile returns a shell snippet that blocks until path exists.
+func (c Commands) WaitForFile(path string) string {
+	if c.shell == powerShell {
+		return fmt.Sprintf("while (-not (Test-Path %s)) {\n  Start-Sleep -Milliseconds 50\n}", testutil.PowerShellQuote(path))
+	}
+	return fmt.Sprintf("while [ ! -f %s ]; do\n  sleep 0.05\ndone", testutil.PosixQuote(path))
+}
+
+// BlockUntil is an alias for WaitForFile in long-running integration steps.
+func (c Commands) BlockUntil(path string) string {
+	return c.WaitForFile(path)
+}

--- a/internal/test/intgharness/commands_test.go
+++ b/internal/test/intgharness/commands_test.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandsSleepUsesShellSyntax(t *testing.T) {
+	require.Equal(t, "sleep 1.5", commandsForShell(posixShell).Sleep(1500*time.Millisecond))
+	require.Equal(t, "Start-Sleep -Milliseconds 1500", commandsForShell(powerShell).Sleep(1500*time.Millisecond))
+}
+
+func TestCommandsWriteFileUsesShellSyntax(t *testing.T) {
+	require.Equal(t, "printf '%s' 'started' > '/tmp/marker'", commandsForShell(posixShell).WriteFile("/tmp/marker", "started"))
+	require.Equal(t, "Set-Content -Path 'C:/tmp/marker' -Value 'started' -NoNewline", commandsForShell(powerShell).WriteFile("C:/tmp/marker", "started"))
+}
+
+func TestCommandsWaitForFileUsesShellSyntax(t *testing.T) {
+	require.Equal(t, "while [ ! -f '/tmp/marker' ]; do\n  sleep 0.05\ndone", commandsForShell(posixShell).WaitForFile("/tmp/marker"))
+	require.Equal(t, "while (-not (Test-Path 'C:/tmp/marker')) {\n  Start-Sleep -Milliseconds 50\n}", commandsForShell(powerShell).WaitForFile("C:/tmp/marker"))
+}

--- a/internal/test/intgharness/commands_test.go
+++ b/internal/test/intgharness/commands_test.go
@@ -15,6 +15,11 @@ func TestCommandsSleepUsesShellSyntax(t *testing.T) {
 	require.Equal(t, "Start-Sleep -Milliseconds 1500", commandsForShell(powerShell).Sleep(1500*time.Millisecond))
 }
 
+func TestCommandsSleepClampsNonPositiveDurations(t *testing.T) {
+	require.Equal(t, "sleep 0.001", commandsForShell(posixShell).Sleep(0))
+	require.Equal(t, "Start-Sleep -Milliseconds 1", commandsForShell(powerShell).Sleep(-time.Second))
+}
+
 func TestCommandsWriteFileUsesShellSyntax(t *testing.T) {
 	require.Equal(t, "printf '%s' 'started' > '/tmp/marker'", commandsForShell(posixShell).WriteFile("/tmp/marker", "started"))
 	require.Equal(t, "Set-Content -Path 'C:/tmp/marker' -Value 'started' -NoNewline", commandsForShell(powerShell).WriteFile("C:/tmp/marker", "started"))

--- a/internal/test/intgharness/harness.go
+++ b/internal/test/intgharness/harness.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"testing"
+	"time"
+
+	testutil "github.com/dagucloud/dagu/internal/test"
+)
+
+// Harness provides semantic integration-test helpers with platform details hidden behind adapters.
+type Harness struct {
+	t      *testing.T
+	Helper testutil.Helper
+
+	Commands Commands
+	Wait     Waiter
+}
+
+// New creates a portable integration harness around an existing test helper.
+func New(t *testing.T, helper testutil.Helper) Harness {
+	t.Helper()
+
+	return Harness{
+		t:        t,
+		Helper:   helper,
+		Commands: defaultCommands(),
+		Wait:     Waiter{t: t},
+	}
+}
+
+// Timeout scales timeout for the current test platform.
+func (h Harness) Timeout(timeout time.Duration) time.Duration {
+	return h.Wait.Timeout(timeout)
+}

--- a/internal/test/intgharness/race_disabled.go
+++ b/internal/test/intgharness/race_disabled.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !race
+
+package intgharness
+
+func raceEnabled() bool {
+	return false
+}

--- a/internal/test/intgharness/race_enabled.go
+++ b/internal/test/intgharness/race_enabled.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build race
+
+package intgharness
+
+func raceEnabled() bool {
+	return true
+}

--- a/internal/test/intgharness/run.go
+++ b/internal/test/intgharness/run.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	testutil "github.com/dagucloud/dagu/internal/test"
+)
+
+// RunProbe observes a DAG-run through the same stores used by production code.
+type RunProbe struct {
+	h         Harness
+	ref       exec.DAGRunRef
+	procGroup string
+}
+
+// Run returns a semantic probe for a DAG-run.
+func (h Harness) Run(ref exec.DAGRunRef, procGroup string) RunProbe {
+	return RunProbe{
+		h:         h,
+		ref:       ref,
+		procGroup: procGroup,
+	}
+}
+
+// RequireRunning waits until the run reaches running status.
+func (r RunProbe) RequireRunning(timeout time.Duration) {
+	r.RequireStatus(core.Running, timeout)
+}
+
+// RequireStatus waits until the run reaches status.
+func (r RunProbe) RequireStatus(status core.Status, timeout time.Duration) {
+	r.h.t.Helper()
+
+	r.h.Wait.EventuallyEvery(fmt.Sprintf("expected %s to reach status %s", r.ref.String(), status), timeout, defaultPollInterval, func() bool {
+		current, ok := r.readStatusIfPresent()
+		return ok && current.Status == status
+	})
+}
+
+// RequireHeartbeatAdvance waits until the run's proc heartbeat advances.
+func (r RunProbe) RequireHeartbeatAdvance(timeout time.Duration) {
+	r.h.t.Helper()
+
+	testutil.RequireProcHeartbeatAdvance(
+		r.h.t,
+		r.h.Helper.Context,
+		r.h.Helper.ProcStore,
+		r.procGroup,
+		r.ref,
+		r.h.Timeout(timeout),
+	)
+}
+
+// ReadStatus loads the persisted run status.
+func (r RunProbe) ReadStatus() *exec.DAGRunStatus {
+	r.h.t.Helper()
+	return testutil.ReadRunStatus(r.h.Helper.Context, r.h.t, r.h.Helper.DAGRunStore, r.ref)
+}
+
+func (r RunProbe) readStatusIfPresent() (*exec.DAGRunStatus, bool) {
+	attempt, err := r.h.Helper.DAGRunStore.FindAttempt(r.h.Helper.Context, r.ref)
+	if err != nil {
+		return nil, false
+	}
+	status, err := attempt.ReadStatus(r.h.Helper.Context)
+	if err != nil {
+		return nil, false
+	}
+	return status, true
+}

--- a/internal/test/intgharness/scheduler.go
+++ b/internal/test/intgharness/scheduler.go
@@ -74,10 +74,14 @@ func (p *SchedulerProbe) RequireEventually(label string, timeout time.Duration, 
 // HasLoadedSchedule reports whether the scheduler entry reader has dagName with expression.
 func (p *SchedulerProbe) HasLoadedSchedule(dagName, expression string) bool {
 	for _, loaded := range p.entryReader.DAGs() {
-		if loaded.Name != dagName || len(loaded.Schedule) != 1 {
+		if loaded.Name != dagName {
 			continue
 		}
-		return loaded.Schedule[0].Expression == expression
+		for _, schedule := range loaded.Schedule {
+			if schedule.Expression == expression {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -86,9 +90,20 @@ func (p *SchedulerProbe) HasLoadedSchedule(dagName, expression string) bool {
 func (p *SchedulerProbe) Stop(ctx context.Context, cancel context.CancelFunc, timeout time.Duration) {
 	p.h.t.Helper()
 
-	p.scheduler.Stop(ctx)
+	stopDone := make(chan struct{})
+	go func() {
+		p.scheduler.Stop(ctx)
+		close(stopDone)
+	}()
+
 	if cancel != nil {
 		cancel()
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(p.h.Timeout(timeout)):
+		p.h.t.Fatal("scheduler stop did not return within timeout")
 	}
 
 	if p.stopped {

--- a/internal/test/intgharness/scheduler.go
+++ b/internal/test/intgharness/scheduler.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/service/scheduler"
+	"github.com/stretchr/testify/require"
+)
+
+// SchedulerProbe observes a scheduler instance without leaking polling mechanics into tests.
+type SchedulerProbe struct {
+	h           Harness
+	scheduler   *scheduler.Scheduler
+	entryReader scheduler.EntryReader
+	errCh       chan error
+	err         error
+	stopped     bool
+}
+
+// StartScheduler starts scheduler and returns a probe for semantic assertions.
+func (h Harness) StartScheduler(ctx context.Context, schedulerInstance *scheduler.Scheduler, entryReader scheduler.EntryReader) *SchedulerProbe {
+	h.t.Helper()
+
+	probe := &SchedulerProbe{
+		h:           h,
+		scheduler:   schedulerInstance,
+		entryReader: entryReader,
+		errCh:       make(chan error, 1),
+	}
+	go func() {
+		probe.errCh <- schedulerInstance.Start(ctx)
+	}()
+	return probe
+}
+
+// RequireRunningWithSchedule waits until scheduler is running and has loaded dagName with expression.
+func (p *SchedulerProbe) RequireRunningWithSchedule(dagName, expression string, timeout time.Duration) {
+	p.h.t.Helper()
+
+	p.requireEventuallyNoSchedulerError(
+		fmt.Sprintf("expected scheduler to run with schedule %q for DAG %q", expression, dagName),
+		timeout,
+		func() bool {
+			return p.scheduler.IsRunning() && p.HasLoadedSchedule(dagName, expression)
+		},
+	)
+}
+
+// RequireLoadedSchedule waits until dagName has expression in the entry reader.
+func (p *SchedulerProbe) RequireLoadedSchedule(dagName, expression string, timeout time.Duration) {
+	p.h.t.Helper()
+
+	p.requireEventuallyNoSchedulerError(
+		fmt.Sprintf("expected scheduler to load schedule %q for DAG %q", expression, dagName),
+		timeout,
+		func() bool {
+			return p.HasLoadedSchedule(dagName, expression)
+		},
+	)
+}
+
+// RequireEventually waits until condition is true while failing early if scheduler exits.
+func (p *SchedulerProbe) RequireEventually(label string, timeout time.Duration, condition func() bool) {
+	p.h.t.Helper()
+	p.requireEventuallyNoSchedulerError(label, timeout, condition)
+}
+
+// HasLoadedSchedule reports whether the scheduler entry reader has dagName with expression.
+func (p *SchedulerProbe) HasLoadedSchedule(dagName, expression string) bool {
+	for _, loaded := range p.entryReader.DAGs() {
+		if loaded.Name != dagName || len(loaded.Schedule) != 1 {
+			continue
+		}
+		return loaded.Schedule[0].Expression == expression
+	}
+	return false
+}
+
+// Stop stops scheduler and waits for its goroutine to exit.
+func (p *SchedulerProbe) Stop(ctx context.Context, cancel context.CancelFunc, timeout time.Duration) {
+	p.h.t.Helper()
+
+	p.scheduler.Stop(ctx)
+	if cancel != nil {
+		cancel()
+	}
+
+	if p.stopped {
+		require.True(p.h.t, acceptableSchedulerStopErr(p.err), "unexpected scheduler shutdown error: %v", p.err)
+		return
+	}
+
+	select {
+	case err := <-p.errCh:
+		p.stopped = true
+		p.err = err
+		require.True(p.h.t, acceptableSchedulerStopErr(err), "unexpected scheduler shutdown error: %v", err)
+	case <-time.After(p.h.Timeout(timeout)):
+		p.h.t.Fatal("scheduler did not stop within timeout")
+	}
+}
+
+func (p *SchedulerProbe) requireEventuallyNoSchedulerError(label string, timeout time.Duration, condition func() bool) {
+	p.h.Wait.EventuallyEvery(label, timeout, defaultPollInterval, func() bool {
+		if err := p.pollErr(); err != nil {
+			return true
+		}
+		return condition()
+	})
+	require.NoError(p.h.t, p.err)
+}
+
+func (p *SchedulerProbe) pollErr() error {
+	if p.stopped {
+		return p.err
+	}
+
+	select {
+	case err := <-p.errCh:
+		p.stopped = true
+		if err == nil {
+			err = errors.New("scheduler exited unexpectedly before test completed")
+		}
+		p.err = err
+	default:
+	}
+	return p.err
+}
+
+func acceptableSchedulerStopErr(err error) bool {
+	return err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/internal/test/intgharness/scheduler_test.go
+++ b/internal/test/intgharness/scheduler_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerProbeHasLoadedScheduleMatchesAnySchedule(t *testing.T) {
+	probe := SchedulerProbe{
+		entryReader: staticEntryReader{
+			dags: []*core.DAG{
+				{
+					Name: "scheduled",
+					Schedule: []core.Schedule{
+						{Expression: "0 10 * * *"},
+						{Expression: "5 10 * * *"},
+					},
+				},
+			},
+		},
+	}
+
+	require.True(t, probe.HasLoadedSchedule("scheduled", "5 10 * * *"))
+	require.False(t, probe.HasLoadedSchedule("scheduled", "15 10 * * *"))
+	require.False(t, probe.HasLoadedSchedule("other", "5 10 * * *"))
+}
+
+type staticEntryReader struct {
+	dags []*core.DAG
+}
+
+func (s staticEntryReader) Init(context.Context) error {
+	return nil
+}
+
+func (s staticEntryReader) Start(context.Context) {}
+
+func (s staticEntryReader) Stop() {}
+
+func (s staticEntryReader) DAGs() []*core.DAG {
+	return s.dags
+}
+
+func (s staticEntryReader) DAGStore() exec.DAGStore {
+	return nil
+}

--- a/internal/test/intgharness/wait.go
+++ b/internal/test/intgharness/wait.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const defaultPollInterval = 50 * time.Millisecond
+
+// Waiter centralizes integration-test timeout scaling and polling.
+type Waiter struct {
+	t *testing.T
+}
+
+// Timeout scales timeout for Windows and race builds.
+func (w Waiter) Timeout(timeout time.Duration) time.Duration {
+	return scaleTimeout(timeout)
+}
+
+func scaleTimeout(timeout time.Duration) time.Duration {
+	switch {
+	case runtime.GOOS == "windows" && raceEnabled():
+		return timeout * 4
+	case runtime.GOOS == "windows" || raceEnabled():
+		return timeout * 2
+	default:
+		return timeout
+	}
+}
+
+// Eventually waits until condition is satisfied.
+func (w Waiter) Eventually(label string, timeout time.Duration, condition func() bool) {
+	w.EventuallyEvery(label, timeout, defaultPollInterval, condition)
+}
+
+// EventuallyEvery waits until condition is satisfied using interval.
+func (w Waiter) EventuallyEvery(label string, timeout, interval time.Duration, condition func() bool) {
+	w.t.Helper()
+	require.Eventually(w.t, condition, scaleTimeout(timeout), interval, label)
+}
+
+// FileExists waits until path exists.
+func (w Waiter) FileExists(path string, timeout time.Duration) {
+	w.Eventually("expected file to exist: "+path, timeout, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	})
+}

--- a/internal/test/intgharness/wait_test.go
+++ b/internal/test/intgharness/wait_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intgharness
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScaleTimeoutAppliesPlatformAndRaceMultiplier(t *testing.T) {
+	base := 2 * time.Second
+
+	switch {
+	case runtime.GOOS == "windows" && raceEnabled():
+		require.Equal(t, 8*time.Second, scaleTimeout(base))
+	case runtime.GOOS == "windows" || raceEnabled():
+		require.Equal(t, 4*time.Second, scaleTimeout(base))
+	default:
+		require.Equal(t, base, scaleTimeout(base))
+	}
+}


### PR DESCRIPTION
## Summary
- add a portable integration harness for command snippets, timeout scaling, scheduler probes, and DAG-run probes
- migrate proc heartbeat integration tests to semantic run probes and portable sleep commands
- migrate the suspended schedule edit regression test to scheduler probe assertions

## Testing
- go test ./internal/test/... -count=1
- go test ./internal/intg -run 'TestProcHeartbeat|TestScheduleEditWhileSuspended' -count=1
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration tests to use a new semantic test harness with improved run state and scheduler assertion helpers.
  * Added portable shell command generation utilities for cross-platform integration test fixtures.
  * Enhanced timeout handling with platform-aware scaling for Windows and race-enabled builds.

* **Chores**
  * Streamlined integration test infrastructure for improved maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->