### PR TITLE
refactor: hide proc entry storage identity

### DIFF
--- a/internal/core/exec/proc.go
+++ b/internal/core/exec/proc.go
@@ -73,13 +73,34 @@ func (m ProcMeta) DAGRun() DAGRunRef {
 	return NewDAGRunRef(m.Name, m.DAGRunID)
 }
 
-// ProcEntry represents a single proc heartbeat file on disk.
+// ProcEntry represents a storage-independent proc heartbeat observation.
 type ProcEntry struct {
 	GroupName       string
-	FilePath        string
+	Identity        ProcEntryID
 	Meta            ProcMeta
 	LastHeartbeatAt int64
 	Fresh           bool
+}
+
+// ProcEntryID is an opaque identity returned by ProcStore for exact stale-entry
+// removal. Callers must not interpret it as a filesystem path or record key.
+type ProcEntryID struct {
+	token string
+}
+
+// NewProcEntryID creates an opaque proc entry identity token.
+func NewProcEntryID(token string) ProcEntryID {
+	return ProcEntryID{token: token}
+}
+
+// IsZero reports whether the identity is empty.
+func (id ProcEntryID) IsZero() bool {
+	return id.token == ""
+}
+
+// String returns an opaque display token. Callers must not parse it.
+func (id ProcEntryID) String() string {
+	return id.token
 }
 
 // ProcHeartbeat is a storage-independent observation of a proc heartbeat.

--- a/internal/persis/store/proc.go
+++ b/internal/persis/store/proc.go
@@ -313,13 +313,17 @@ func (s *ProcStore) RemoveIfStale(ctx context.Context, entry exec.ProcEntry) err
 	if entry.GroupName == "" || entry.Fresh {
 		return nil
 	}
-	if procEntryIsLegacyPath(entry.FilePath) {
+	switch procEntryIdentityKind(entry) {
+	case procEntryIdentityLegacy:
 		if s.legacy == nil {
 			return nil
 		}
 		return s.legacy.removeIfStale(ctx, entry)
+	case procEntryIdentityCollection:
+		return s.removeCollectionIfStale(ctx, entry)
+	default:
+		return nil
 	}
-	return s.removeCollectionIfStale(ctx, entry)
 }
 
 // Validate fails if any proc entry cannot be decoded.

--- a/internal/persis/store/proc_entry.go
+++ b/internal/persis/store/proc_entry.go
@@ -94,7 +94,7 @@ func (s *ProcStore) entryFromRecord(rec *persis.Record, now time.Time) (exec.Pro
 	}
 	return exec.ProcEntry{
 		GroupName:       groupName,
-		FilePath:        rec.ID,
+		Identity:        collectionProcEntryID(rec.ID),
 		Meta:            payload.Meta,
 		LastHeartbeatAt: payload.LastHeartbeatAt,
 		Fresh:           fresh,
@@ -102,7 +102,11 @@ func (s *ProcStore) entryFromRecord(rec *persis.Record, now time.Time) (exec.Pro
 }
 
 func (s *ProcStore) removeCollectionIfStale(ctx context.Context, entry exec.ProcEntry) error {
-	currentRec, err := s.col.Get(ctx, entry.FilePath)
+	recordID, ok := procEntryIdentityValue(entry, procEntryIdentityCollection)
+	if !ok {
+		return nil
+	}
+	currentRec, err := s.col.Get(ctx, recordID)
 	if errors.Is(err, persis.ErrNotFound) {
 		return nil
 	}
@@ -126,7 +130,7 @@ func (s *ProcStore) removeCollectionIfStale(ctx context.Context, entry exec.Proc
 	if err := persis.Decode(currentRec, &payload); err == nil && payload.LegacyPath != "" {
 		_ = removeLegacyProcFile(payload.LegacyPath)
 	}
-	logger.Info(ctx, "Removed stale proc record", tag.Name(entry.FilePath))
+	logger.Info(ctx, "Removed stale proc record", tag.Name(recordID))
 	return nil
 }
 
@@ -157,7 +161,7 @@ func dedupeAndSortProcEntries(entries []exec.ProcEntry) []exec.ProcEntry {
 	for _, entry := range entries {
 		key := entry.AttemptKey()
 		if key == "" || strings.Count(key, "|") < 4 {
-			key = entry.GroupName + "|" + entry.FilePath
+			key = entry.GroupName + "|" + procEntrySortKey(entry)
 		}
 		existing, ok := byKey[key]
 		if !ok || procEntryPreferred(entry, existing) {
@@ -176,15 +180,15 @@ func procEntryPreferred(candidate, existing exec.ProcEntry) bool {
 	if candidate.Fresh != existing.Fresh {
 		return candidate.Fresh
 	}
-	candidateLegacy := procEntryIsLegacyPath(candidate.FilePath)
-	existingLegacy := procEntryIsLegacyPath(existing.FilePath)
+	candidateLegacy := procEntryIdentityKind(candidate) == procEntryIdentityLegacy
+	existingLegacy := procEntryIdentityKind(existing) == procEntryIdentityLegacy
 	if candidateLegacy != existingLegacy {
 		return !candidateLegacy
 	}
 	if candidate.LastHeartbeatAt != existing.LastHeartbeatAt {
 		return candidate.LastHeartbeatAt > existing.LastHeartbeatAt
 	}
-	return candidate.FilePath < existing.FilePath
+	return procEntrySortKey(candidate) < procEntrySortKey(existing)
 }
 
 func sortProcEntries(entries []exec.ProcEntry) {
@@ -202,13 +206,13 @@ func sortProcEntries(entries []exec.ProcEntry) {
 		if left.LastHeartbeatAt != right.LastHeartbeatAt {
 			return left.LastHeartbeatAt < right.LastHeartbeatAt
 		}
-		return left.FilePath < right.FilePath
+		return procEntrySortKey(left) < procEntrySortKey(right)
 	})
 }
 
 func sameProcEntry(a, b exec.ProcEntry) bool {
 	return a.GroupName == b.GroupName &&
-		a.FilePath == b.FilePath &&
+		a.Identity == b.Identity &&
 		a.LastHeartbeatAt == b.LastHeartbeatAt &&
 		a.Meta == b.Meta
 }

--- a/internal/persis/store/proc_identity.go
+++ b/internal/persis/store/proc_identity.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+const (
+	procEntryIdentityCollection = "collection"
+	procEntryIdentityLegacy     = "legacy"
+)
+
+func collectionProcEntryID(recordID string) exec.ProcEntryID {
+	return procEntryID(procEntryIdentityCollection, recordID)
+}
+
+func legacyProcEntryID(path string) exec.ProcEntryID {
+	return procEntryID(procEntryIdentityLegacy, path)
+}
+
+func procEntryID(kind, value string) exec.ProcEntryID {
+	if kind == "" || value == "" {
+		return exec.ProcEntryID{}
+	}
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(value))
+	return exec.NewProcEntryID(kind + ":" + encoded)
+}
+
+func procEntryIdentityValue(entry exec.ProcEntry, expectedKind string) (string, bool) {
+	kind, value, ok := splitProcEntryID(entry.Identity)
+	if !ok || kind != expectedKind {
+		return "", false
+	}
+	return value, true
+}
+
+func procEntryIdentityKind(entry exec.ProcEntry) string {
+	kind, _, ok := splitProcEntryID(entry.Identity)
+	if !ok {
+		return ""
+	}
+	return kind
+}
+
+func splitProcEntryID(id exec.ProcEntryID) (kind, value string, ok bool) {
+	if id.IsZero() {
+		return "", "", false
+	}
+	raw := id.String()
+	kind, encoded, found := strings.Cut(raw, ":")
+	if !found || kind == "" || encoded == "" {
+		return "", "", false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) == 0 {
+		return "", "", false
+	}
+	return kind, string(decoded), true
+}
+
+func procEntrySortKey(entry exec.ProcEntry) string {
+	if !entry.Identity.IsZero() {
+		return entry.Identity.String()
+	}
+	return entry.GroupName + "|" + entry.Meta.Root().String() + "|" + entry.Meta.Name + "|" + entry.Meta.DAGRunID + "|" + entry.Meta.AttemptID
+}

--- a/internal/persis/store/proc_identity_test.go
+++ b/internal/persis/store/proc_identity_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+func TestProcEntryIdentityRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		id    exec.ProcEntryID
+		kind  string
+		value string
+	}{
+		{
+			name:  "collection",
+			id:    collectionProcEntryID("queue-a/proc-dag/run-1"),
+			kind:  procEntryIdentityCollection,
+			value: "queue-a/proc-dag/run-1",
+		},
+		{
+			name:  "legacy windows path",
+			id:    legacyProcEntryID(`C:\Users\runneradmin\AppData\Local\Temp\dagu proc\queue-a\proc_123.proc`),
+			kind:  procEntryIdentityLegacy,
+			value: `C:\Users\runneradmin\AppData\Local\Temp\dagu proc\queue-a\proc_123.proc`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry := exec.ProcEntry{Identity: tc.id}
+			assert.Equal(t, tc.kind, procEntryIdentityKind(entry))
+
+			value, ok := procEntryIdentityValue(entry, tc.kind)
+			require.True(t, ok)
+			assert.Equal(t, tc.value, value)
+
+			_, ok = procEntryIdentityValue(entry, "other")
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestProcEntryIdentityRejectsMalformedTokens(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		id   exec.ProcEntryID
+	}{
+		{name: "zero", id: exec.ProcEntryID{}},
+		{name: "missing separator", id: exec.NewProcEntryID("plain-file.proc")},
+		{name: "empty kind", id: exec.NewProcEntryID(":cmVjb3Jk")},
+		{name: "empty value", id: exec.NewProcEntryID("collection:")},
+		{name: "bad encoding", id: exec.NewProcEntryID("collection:not base64")},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry := exec.ProcEntry{Identity: tc.id}
+			assert.Empty(t, procEntryIdentityKind(entry))
+
+			value, ok := procEntryIdentityValue(entry, procEntryIdentityCollection)
+			assert.False(t, ok)
+			assert.Empty(t, value)
+		})
+	}
+}

--- a/internal/persis/store/proc_legacy.go
+++ b/internal/persis/store/proc_legacy.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -122,10 +121,6 @@ func procRecordName(meta exec.ProcMeta, t time.Time) string {
 
 func (l *legacyProcStore) filePath(groupName string, meta exec.ProcMeta, t time.Time) string {
 	return filepath.Join(l.root, groupName, meta.Name, procRecordName(meta, t)+procFileExt)
-}
-
-func procEntryIsLegacyPath(path string) bool {
-	return strings.HasSuffix(path, procFileExt)
 }
 
 func (l *legacyProcStore) write(path string, heartbeatUnix int64, meta exec.ProcMeta) error {
@@ -300,7 +295,11 @@ func (l *legacyProcStore) entriesFromFiles(groupName string, files []string) ([]
 }
 
 func (l *legacyProcStore) removeIfStale(ctx context.Context, entry exec.ProcEntry) error {
-	current, err := readLegacyProcEntry(entry.FilePath, entry.GroupName, l.staleTime, time.Now().UTC())
+	path, ok := procEntryIdentityValue(entry, procEntryIdentityLegacy)
+	if !ok {
+		return nil
+	}
+	current, err := readLegacyProcEntry(path, entry.GroupName, l.staleTime, time.Now().UTC())
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
@@ -310,10 +309,10 @@ func (l *legacyProcStore) removeIfStale(ctx context.Context, entry exec.ProcEntr
 	if current.Fresh || !sameProcEntry(current, entry) {
 		return nil
 	}
-	if err := l.remove(entry.FilePath); err != nil {
+	if err := l.remove(path); err != nil {
 		return err
 	}
-	logger.Info(ctx, "Removed stale legacy proc file", tag.File(entry.FilePath))
+	logger.Info(ctx, "Removed stale legacy proc file", tag.File(path))
 	return nil
 }
 
@@ -362,7 +361,7 @@ func readLegacyProcEntryObserved(path, groupName string, staleTime time.Duration
 	}
 	entry := exec.ProcEntry{
 		GroupName:       groupName,
-		FilePath:        path,
+		Identity:        legacyProcEntryID(path),
 		Meta:            meta,
 		LastHeartbeatAt: lastHeartbeatAt,
 		Fresh:           fresh,

--- a/internal/persis/store/proc_test.go
+++ b/internal/persis/store/proc_test.go
@@ -258,12 +258,24 @@ func TestProcStoreRemoveIfStaleIgnoresEntryWithoutStoreIdentity(t *testing.T) {
 		return true
 	}, time.Second, 10*time.Millisecond)
 
-	stale.Identity = exec.ProcEntryID{}
-	require.NoError(t, s.RemoveIfStale(ctx, stale))
+	for _, tc := range []struct {
+		name     string
+		identity exec.ProcEntryID
+	}{
+		{name: "zero", identity: exec.ProcEntryID{}},
+		{name: "missing separator", identity: exec.NewProcEntryID("plain-file.proc")},
+		{name: "bad encoding", identity: exec.NewProcEntryID("collection:not base64")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := stale
+			entry.Identity = tc.identity
+			require.NoError(t, s.RemoveIfStale(ctx, entry))
 
-	entries, err := s.ListEntries(ctx, "queue-a")
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
+			entries, err := s.ListEntries(ctx, "queue-a")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+		})
+	}
 }
 
 func TestProcStoreLatestFreshEntryByDAGName(t *testing.T) {

--- a/internal/persis/store/proc_test.go
+++ b/internal/persis/store/proc_test.go
@@ -61,7 +61,7 @@ func TestProcStoreAcquireStop(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.True(t, entries[0].Fresh)
 	assert.Equal(t, ref, entries[0].DAGRun())
-	assert.NotEmpty(t, entries[0].FilePath)
+	assert.False(t, entries[0].Identity.IsZero())
 
 	require.NoError(t, proc.Stop(ctx))
 
@@ -220,16 +220,50 @@ func TestProcStoreRemoveIfStaleKeepsRefreshedCollectionRecord(t *testing.T) {
 		return true
 	}, time.Second, 10*time.Millisecond)
 
-	col.refresh = func() {
-		rec, err := base.Get(ctx, stale.FilePath)
+	col.refresh = func(expected *persis.Record) {
+		rec, err := base.Get(ctx, expected.ID)
 		require.NoError(t, err)
 		rec.UpdatedAt = time.Now().UTC()
 		require.NoError(t, base.Put(ctx, rec))
 	}
 
 	require.NoError(t, s.RemoveIfStale(ctx, stale))
-	_, err = base.Get(ctx, stale.FilePath)
+	entries, err := s.ListEntries(ctx, "queue-a")
 	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestProcStoreRemoveIfStaleIgnoresEntryWithoutStoreIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newProcStore(t,
+		store.WithProcStaleThreshold(20*time.Millisecond),
+		store.WithProcHeartbeatInterval(time.Hour),
+	)
+	ref := exec.NewDAGRunRef("stale-no-identity-dag", "run-1")
+
+	proc, err := s.Acquire(ctx, "queue-a", procMeta(ref))
+	require.NoError(t, err)
+	defer func() { _ = proc.Stop(ctx) }()
+
+	var stale exec.ProcEntry
+	require.Eventually(t, func() bool {
+		entries, err := s.ListEntries(ctx, "queue-a")
+		require.NoError(t, err)
+		if len(entries) != 1 || entries[0].Fresh {
+			return false
+		}
+		stale = entries[0]
+		return true
+	}, time.Second, 10*time.Millisecond)
+
+	stale.Identity = exec.ProcEntryID{}
+	require.NoError(t, s.RemoveIfStale(ctx, stale))
+
+	entries, err := s.ListEntries(ctx, "queue-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
 }
 
 func TestProcStoreLatestFreshEntryByDAGName(t *testing.T) {
@@ -556,7 +590,8 @@ func TestProcStoreReadsAndRemovesLegacyProcFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	assert.False(t, entries[0].Fresh)
-	assert.Equal(t, legacyFile, entries[0].FilePath)
+	assert.False(t, entries[0].Identity.IsZero())
+	assert.NotEqual(t, legacyFile, entries[0].Identity.String())
 
 	require.NoError(t, s.RemoveIfStale(ctx, entries[0]))
 
@@ -673,13 +708,13 @@ func (c listErrorCollection) RecordIDs(context.Context, string) ([]string, error
 type refreshBeforeCompareDeleteCollection struct {
 	persis.Collection
 	once    sync.Once
-	refresh func()
+	refresh func(*persis.Record)
 }
 
 func (c *refreshBeforeCompareDeleteCollection) CompareAndDelete(ctx context.Context, expected *persis.Record) error {
 	c.once.Do(func() {
 		if c.refresh != nil {
-			c.refresh()
+			c.refresh(expected)
 		}
 	})
 	return c.Collection.CompareAndDelete(ctx, expected)

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -193,7 +193,6 @@ func TestZombieDetectorDetectAndCleanZombies_SubDAGUsesRootScopedLookup(t *testi
 	}
 	entry := exec.ProcEntry{
 		GroupName: dag.ProcGroup(),
-		FilePath:  "/tmp/stale-sub.proc",
 		Meta: exec.ProcMeta{
 			StartedAt:    time.Now().Add(-time.Minute).Unix(),
 			Name:         dag.Name,
@@ -316,7 +315,6 @@ func TestZombieDetectorDetectAndCleanZombies_StaleEntryWithCorruptedStatusIsRemo
 func testRootProcEntry(groupName, dagName, dagRunID, attemptID string, fresh bool) exec.ProcEntry {
 	return exec.ProcEntry{
 		GroupName: groupName,
-		FilePath:  "/tmp/" + dagRunID + "_" + attemptID + ".proc",
 		Meta: exec.ProcMeta{
 			StartedAt:    time.Now().Add(-time.Minute).Unix(),
 			Name:         dagName,


### PR DESCRIPTION
## Summary
- replace storage-path-shaped proc entries with opaque proc entry identities
- route stale proc cleanup through collection and legacy identity adapters
- update proc and zombie detector tests to avoid path-coupled assertions

## Testing
- go test ./internal/persis/store -run 'TestProcStoreRemoveIfStale' -count=1
- go test ./internal/core/exec ./internal/persis/store ./internal/service/scheduler ./internal/intg -run 'TestProcHeartbeat|TestZombieDetector|TestProcStore' -count=1
- go test ./internal/intg/queue ./internal/intg/distr -run 'ProcHeartbeat|StaleProc|StaleLocal|StaleProcFile' -count=1
- go test ./internal/core/exec ./internal/persis/store ./internal/service/scheduler -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched process-entry identification to an opaque identity model for more robust, storage-independent tracking.
* **Bug Fixes**
  * Improved stale-entry detection and removal to avoid accidental deletions when identity is missing or malformed.
* **Tests**
  * Expanded and updated tests to validate identity handling, stale-removal behavior, and zombie detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->