### PR TITLE
fix: recover scheduler tick panics

### DIFF
--- a/internal/intg/distr/lifecycle_test.go
+++ b/internal/intg/distr/lifecycle_test.go
@@ -165,6 +165,7 @@ steps:
 
 		rootRef := exec.NewDAGRunRef(f.dagWrapper.Name, runID)
 		var subRunID string
+		subDAGCancelTimeout := distrTestTimeout(30 * time.Second)
 		require.Eventually(t, func() bool {
 			attempt, err := f.dagWrapper.DAGRunStore.FindAttempt(ctx, rootRef)
 			if err != nil {
@@ -183,12 +184,12 @@ steps:
 				return subRunID != ""
 			}
 			return false
-		}, 30*time.Second, 100*time.Millisecond, "expected parent DAG to start sub DAG before cancellation")
+		}, subDAGCancelTimeout, 100*time.Millisecond, "expected parent DAG to start sub DAG before cancellation")
 
 		require.Eventually(t, func() bool {
 			status, err := f.dagWrapper.DAGRunMgr.FindSubDAGRunStatus(ctx, rootRef, subRunID)
 			return err == nil && status != nil && status.Status == core.Running
-		}, 30*time.Second, 100*time.Millisecond, "expected sub DAG to reach running state before cancellation")
+		}, subDAGCancelTimeout, 100*time.Millisecond, "expected sub DAG to reach running state before cancellation")
 
 		require.NoError(t, f.stop(runID))
 
@@ -197,14 +198,14 @@ steps:
 		select {
 		case err := <-errCh:
 			require.NoError(t, err)
-		case <-time.After(30 * time.Second):
-			t.Fatal("timed out waiting for parent DAG cancellation")
+		case <-time.After(subDAGCancelTimeout):
+			require.FailNow(t, "timed out waiting for parent DAG cancellation")
 		}
 
 		require.Eventually(t, func() bool {
 			subStatus, err := f.dagWrapper.DAGRunMgr.FindSubDAGRunStatus(ctx, rootRef, subRunID)
 			return err == nil && subStatus != nil && subStatus.Status == core.Aborted
-		}, 30*time.Second, 100*time.Millisecond, "expected sub DAG to become aborted after parent cancellation")
+		}, subDAGCancelTimeout, 100*time.Millisecond, "expected sub DAG to become aborted after parent cancellation")
 	})
 }
 

--- a/internal/intg/distr/lifecycle_test.go
+++ b/internal/intg/distr/lifecycle_test.go
@@ -353,7 +353,7 @@ steps:
 			}
 			parallelNode := st.Nodes[0]
 			return parallelNode.Status == core.NodeRunning
-		}, 5*time.Second, 100*time.Millisecond)
+		}, distrTestTimeout(5*time.Second), 100*time.Millisecond)
 
 		require.Eventually(t, func() bool {
 			workerInfo, err := f.coordinatorClient.GetWorkers(f.coord.Context)
@@ -363,7 +363,7 @@ steps:
 				runningTasks += len(w.RunningTasks)
 			}
 			return runningTasks > 0
-		}, 5*time.Second, 100*time.Millisecond)
+		}, distrTestTimeout(5*time.Second), 100*time.Millisecond)
 
 		agent.Signal(f.coord.Context, os.Signal(syscall.SIGINT))
 

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,13 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+func coordinatorTestTimeout(timeout time.Duration) time.Duration {
+	if runtime.GOOS == "windows" {
+		return timeout * 5
+	}
+	return timeout
+}
 
 // mockDAGRunStore is a test implementation of execution.DAGRunStore
 type mockDAGRunStore struct {
@@ -2189,10 +2197,11 @@ func TestHandler_ZombieDetection(t *testing.T) {
 			reportDone <- nil
 		}()
 
+		statusReportTimeout := coordinatorTestTimeout(time.Second)
 		select {
 		case <-writeStarted:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for status report to reach write")
+		case <-time.After(statusReportTimeout):
+			require.FailNow(t, "timed out waiting for status report to reach write")
 		}
 
 		detectDone := make(chan struct{})
@@ -2203,7 +2212,7 @@ func TestHandler_ZombieDetection(t *testing.T) {
 
 		select {
 		case <-detectDone:
-			t.Fatal("stale-lease repair completed while status report held the run mutex")
+			require.FailNow(t, "stale-lease repair completed while status report held the run mutex")
 		case <-time.After(50 * time.Millisecond):
 		}
 
@@ -2211,13 +2220,13 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		select {
 		case err := <-reportDone:
 			require.NoError(t, err)
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for status report")
+		case <-time.After(statusReportTimeout):
+			require.FailNow(t, "timed out waiting for status report")
 		}
 		select {
 		case <-detectDone:
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for stale-lease repair")
+		case <-time.After(statusReportTimeout):
+			require.FailNow(t, "timed out waiting for stale-lease repair")
 		}
 
 		status, err := attempt.ReadStatus(ctx)

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -724,7 +724,7 @@ func (s *Scheduler) cronLoop(ctx context.Context, sig chan os.Signal) {
 	defer s.running.Store(false)
 
 	for s.waitForTick(ctx, sig, timer) {
-		s.runTick(ctx, tickTime)
+		s.runTickSafely(ctx, tickTime)
 		tickTime = s.NextTick(tickTime)
 		timer.Reset(tickTime.Sub(s.clock()))
 	}
@@ -743,6 +743,18 @@ func (s *Scheduler) waitForTick(ctx context.Context, sig chan os.Signal, timer *
 		_ = timer.Stop()
 		return true
 	}
+}
+
+func (s *Scheduler) runTickSafely(ctx context.Context, tickTime time.Time) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(ctx, "Scheduler tick panicked",
+				slog.Time("tick_time", tickTime),
+				tag.Error(panicToError(r)),
+			)
+		}
+	}()
+	s.runTick(ctx, tickTime)
 }
 
 func (s *Scheduler) runTick(ctx context.Context, tickTime time.Time) {

--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -37,3 +37,83 @@ func TestWaitForTickSignalStopsScheduler(t *testing.T) {
 		t.Fatal("expected scheduler quit channel to close on signal")
 	}
 }
+
+func TestRunTickSafelyRecoversTickPanic(t *testing.T) {
+	t.Parallel()
+
+	sc := &Scheduler{}
+
+	require.NotPanics(t, func() {
+		sc.runTickSafely(context.Background(), time.Now())
+	})
+}
+
+func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
+	t.Parallel()
+
+	sc := &Scheduler{
+		quit: make(chan any),
+		clock: func() time.Time {
+			return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		},
+	}
+	sig := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	panicCh := make(chan any, 1)
+
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		sc.cronLoop(context.Background(), sig)
+	}()
+
+	defer func() {
+		select {
+		case <-sc.quit:
+		default:
+			close(sc.quit)
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cronLoop did not stop")
+		}
+	}()
+
+	requireCronLoopRunning(t, sc, done, panicCh)
+
+	select {
+	case r := <-panicCh:
+		t.Fatalf("cronLoop panic escaped: %v", r)
+	case <-done:
+		t.Fatal("cronLoop exited after tick panic")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func requireCronLoopRunning(t *testing.T, sc *Scheduler, done <-chan struct{}, panicCh <-chan any) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case r := <-panicCh:
+			t.Fatalf("cronLoop panic escaped: %v", r)
+		case <-done:
+			t.Fatal("cronLoop exited before reporting running")
+		case <-deadline:
+			t.Fatal("cronLoop did not report running")
+		case <-ticker.C:
+			if sc.IsRunning() {
+				return
+			}
+		}
+	}
+}

--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -34,7 +34,7 @@ func TestWaitForTickSignalStopsScheduler(t *testing.T) {
 	select {
 	case <-sc.quit:
 	default:
-		t.Fatal("expected scheduler quit channel to close on signal")
+		require.FailNow(t, "expected scheduler quit channel to close on signal")
 	}
 }
 
@@ -80,7 +80,7 @@ func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(time.Second):
-			t.Fatal("cronLoop did not stop")
+			require.FailNow(t, "cronLoop did not stop")
 		}
 	}()
 
@@ -88,9 +88,9 @@ func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 
 	select {
 	case r := <-panicCh:
-		t.Fatalf("cronLoop panic escaped: %v", r)
+		require.Failf(t, "cronLoop panic escaped", "%v", r)
 	case <-done:
-		t.Fatal("cronLoop exited after tick panic")
+		require.FailNow(t, "cronLoop exited after tick panic")
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -105,11 +105,11 @@ func requireCronLoopRunning(t *testing.T, sc *Scheduler, done <-chan struct{}, p
 	for {
 		select {
 		case r := <-panicCh:
-			t.Fatalf("cronLoop panic escaped: %v", r)
+			require.Failf(t, "cronLoop panic escaped", "%v", r)
 		case <-done:
-			t.Fatal("cronLoop exited before reporting running")
+			require.FailNow(t, "cronLoop exited before reporting running")
 		case <-deadline:
-			t.Fatal("cronLoop did not report running")
+			require.FailNow(t, "cronLoop did not report running")
 		case <-ticker.C:
 			if sc.IsRunning() {
 				return


### PR DESCRIPTION
## Summary

Recover scheduler tick panics so the scheduler loop stays alive instead of exiting.

## Changes

- Add a safe scheduler tick wrapper that recovers and logs tick panics with tick time.
- Route cron loop tick execution through the recovery wrapper.
- Add scheduler regression tests for tick panic recovery and cron loop continuity.
- Use `require` assertions in scheduler tick tests.
- Scale Windows-sensitive distributed/coordinator test waits using the existing test timeout pattern.

## Related Issues

N/A

## Testing

- `go test ./internal/service/scheduler -run 'TestRunTickSafelyRecoversTickPanic|TestCronLoopRecoversTickPanicAndKeepsRunning|TestWaitForTickSignalStopsScheduler' -count=1`
- `make test TEST_TARGET=./internal/service/scheduler`
- `go test ./internal/service/coordinator -count=1`
- `go test ./internal/intg/distr -run 'TestCancellation_SubDAG/cancelPropagatesToSubDAGOnWorker' -count=1`
- `go test ./internal/intg/distr -count=1`
- `make lint`

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally
