### PR TITLE
refactor: preserve persistence file layout

### DIFF
--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -34,73 +34,11 @@ type Collection struct {
 
 var _ persis.Collection = (*Collection)(nil)
 
-// fileRecord is the on-disk JSON envelope for a [persis.Record].
-// Data is kept as json.RawMessage so the file is human-readable when
-// the encoding is JSON.
-type fileRecord struct {
-	ID        string          `json:"id"`
-	Encoding  persis.Encoding `json:"encoding"`
-	Data      json.RawMessage `json:"data"`
-	CreatedAt time.Time       `json:"created_at"`
-	UpdatedAt time.Time       `json:"updated_at"`
-	ExpiresAt *time.Time      `json:"expires_at,omitempty"`
-}
-
-func toFileRecord(r *persis.Record) *fileRecord {
-	var data json.RawMessage
-	if r.Encoding == persis.EncodingJSON {
-		data = json.RawMessage(r.Data)
-	} else {
-		// Non-JSON (e.g. proto/binary) payloads are not valid JSON, so base64-encode
-		// them as a JSON string so the file envelope always marshals cleanly.
-		quoted, _ := json.Marshal(base64.StdEncoding.EncodeToString(r.Data))
-		data = json.RawMessage(quoted)
-	}
-	return &fileRecord{
-		ID:        r.ID,
-		Encoding:  r.Encoding,
-		Data:      data,
-		CreatedAt: r.CreatedAt,
-		UpdatedAt: r.UpdatedAt,
-		ExpiresAt: r.ExpiresAt,
-	}
-}
-
-func (fr *fileRecord) toRecord() *persis.Record {
-	data := []byte(fr.Data)
-	if fr.Encoding != persis.EncodingJSON {
-		// Non-JSON data was stored as a base64 JSON string; decode it.
-		var encoded string
-		if json.Unmarshal(fr.Data, &encoded) == nil {
-			if decoded, err := base64.StdEncoding.DecodeString(encoded); err == nil {
-				data = decoded
-			}
-		}
-	}
-	return &persis.Record{
-		ID:        fr.ID,
-		Encoding:  fr.Encoding,
-		Data:      data,
-		CreatedAt: fr.CreatedAt,
-		UpdatedAt: fr.UpdatedAt,
-		ExpiresAt: fr.ExpiresAt,
-	}
-}
-
 func sameRecord(a, b *persis.Record) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.ID != b.ID || a.Encoding != b.Encoding || !bytes.Equal(a.Data, b.Data) {
-		return false
-	}
-	if !a.CreatedAt.Equal(b.CreatedAt) || !a.UpdatedAt.Equal(b.UpdatedAt) {
-		return false
-	}
-	if a.ExpiresAt == nil || b.ExpiresAt == nil {
-		return a.ExpiresAt == b.ExpiresAt
-	}
-	return a.ExpiresAt.Equal(*b.ExpiresAt)
+	return a.ID == b.ID && a.Encoding == b.Encoding && bytes.Equal(a.Data, b.Data)
 }
 
 // ─── Collection methods ───────────────────────────────────────────────────────
@@ -113,11 +51,11 @@ func (c *Collection) Get(_ context.Context, id string) (*persis.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	fr, err := c.readFile(path)
+	rec, err := c.readFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return fr.toRecord(), nil
+	return rec, nil
 }
 
 func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
@@ -128,7 +66,7 @@ func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
 	if err != nil {
 		return err
 	}
-	return c.writeFile(path, toFileRecord(rec))
+	return c.writeFile(path, rec)
 }
 
 func (c *Collection) Delete(ctx context.Context, id string) error {
@@ -146,11 +84,11 @@ func (c *Collection) CompareAndDelete(_ context.Context, expected *persis.Record
 	if err != nil {
 		return err
 	}
-	fr, err := c.readFile(path)
+	rec, err := c.readFile(path)
 	if err != nil {
 		return err
 	}
-	if !sameRecord(fr.toRecord(), expected) {
+	if !sameRecord(rec, expected) {
 		return persis.ErrConflict
 	}
 	if err := fileutil.Remove(path); err != nil {
@@ -286,20 +224,16 @@ func (c *Collection) CompareAndSwap(_ context.Context, id string, expected, next
 	if err != nil {
 		return err
 	}
-	fr, err := c.readFile(path)
+	rec, err := c.readFile(path)
 	if err != nil {
 		return err
 	}
-	// Compare decoded Record.Data bytes, not the raw envelope bytes, so CAS
-	// works correctly regardless of whether data was base64-wrapped on disk.
-	rec := fr.toRecord()
 	if !bytes.Equal(rec.Data, expected) {
 		return persis.ErrConflict
 	}
 	rec.Data = next
-	updated := toFileRecord(rec)
-	updated.UpdatedAt = time.Now().UTC()
-	return c.writeFile(path, updated)
+	rec.UpdatedAt = time.Now().UTC()
+	return c.writeFile(path, rec)
 }
 
 // Claim atomically dequeues one record matching q.
@@ -326,7 +260,7 @@ func (c *Collection) Claim(_ context.Context, q persis.ListQuery) (*persis.Recor
 	sort.Strings(candidates)
 
 	for _, path := range candidates {
-		fr, err := c.readFile(path)
+		rec, err := c.readFile(path)
 		if err != nil {
 			if !errors.Is(err, persis.ErrNotFound) {
 				return nil, err
@@ -340,7 +274,7 @@ func (c *Collection) Claim(_ context.Context, q persis.ListQuery) (*persis.Recor
 			continue
 		}
 		removeEmptyDirs(filepath.Dir(path), c.dir)
-		return fr.toRecord(), nil
+		return rec, nil
 	}
 	return nil, persis.ErrNotFound
 }
@@ -376,7 +310,7 @@ func pathUnderRoot(root, id, kind string) (string, error) {
 	return full, nil
 }
 
-func (c *Collection) readFile(path string) (*fileRecord, error) {
+func (c *Collection) readFile(path string) (*persis.Record, error) {
 	raw, err := fileutil.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -384,40 +318,52 @@ func (c *Collection) readFile(path string) (*fileRecord, error) {
 		}
 		return nil, err
 	}
-	var fr fileRecord
-	if err := json.Unmarshal(raw, &fr); err != nil {
-		return nil, fmt.Errorf("file backend: corrupt record at %q: %w", path, err)
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("file backend: corrupt record at %q: invalid JSON", path)
 	}
-	// Legacy format: flat JSON without the "encoding" envelope field.
-	// Wrap the raw bytes as the Data payload so old files are readable
-	// by the new adapters. The file is rewritten in new format on next Put.
-	if fr.Encoding == "" {
-		rel, _ := filepath.Rel(c.dir, path)
-		info, _ := os.Stat(path)
-		mtime := time.Now().UTC()
-		if info != nil {
-			mtime = info.ModTime().UTC()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, persis.ErrNotFound
 		}
-		fr = fileRecord{
-			ID:        relPathToID(rel),
-			Encoding:  persis.EncodingJSON,
-			Data:      json.RawMessage(raw),
-			CreatedAt: mtime,
-			UpdatedAt: mtime,
-		}
+		return nil, err
 	}
-	return &fr, nil
+	rel, _ := filepath.Rel(c.dir, path)
+	mtime := info.ModTime().UTC()
+	return &persis.Record{
+		ID:        relPathToID(rel),
+		Data:      raw,
+		Encoding:  persis.EncodingJSON,
+		CreatedAt: mtime,
+		UpdatedAt: mtime,
+	}, nil
 }
 
-func (c *Collection) writeFile(path string, fr *fileRecord) error {
-	data, err := json.Marshal(fr)
-	if err != nil {
-		return err
+func (c *Collection) writeFile(path string, rec *persis.Record) error {
+	if rec == nil {
+		return fmt.Errorf("file backend: nil record")
+	}
+	if rec.Encoding != "" && rec.Encoding != persis.EncodingJSON {
+		return fmt.Errorf("file backend: unsupported encoding %q", rec.Encoding)
+	}
+	if !json.Valid(rec.Data) {
+		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	return fileutil.WriteFileAtomic(path, data, 0o600)
+	if err := fileutil.WriteFileAtomic(path, rec.Data, 0o600); err != nil {
+		return err
+	}
+	mtime := rec.UpdatedAt
+	if mtime.IsZero() {
+		mtime = rec.CreatedAt
+	}
+	if mtime.IsZero() {
+		return nil
+	}
+	return os.Chtimes(path, mtime, mtime)
 }
 
 func (c *Collection) collectIDs(prefix string) ([]string, error) {
@@ -457,11 +403,10 @@ func (c *Collection) collect(prefix string, since, until *time.Time) ([]*persis.
 		if prefix != "" && !strings.HasPrefix(id, prefix) {
 			return nil
 		}
-		fr, err := c.readFile(path)
+		r, err := c.readFile(path)
 		if err != nil {
 			return nil // skip corrupt records
 		}
-		r := fr.toRecord()
 		if since != nil && r.CreatedAt.Before(*since) {
 			return nil
 		}

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -62,6 +62,9 @@ func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if rec == nil {
+		return fmt.Errorf("file backend: nil record")
+	}
 	path, err := c.filePath(rec.ID)
 	if err != nil {
 		return err

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -5,6 +5,7 @@ package file_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -315,6 +316,39 @@ func TestFileCollection(t *testing.T) {
 	}
 
 	RunCollectionContract(t, b.Collection("test"), freshCollection)
+}
+
+func TestFileCollectionWritesRawJSONBody(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	col := file.NewCollection(root)
+	raw := []byte(`{"id":"user-1","name":"admin"}`)
+	rec := &persis.Record{
+		ID:        "users/user-1",
+		Data:      raw,
+		Encoding:  persis.EncodingJSON,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	require.NoError(t, col.Put(ctx, rec))
+
+	path := filepath.Join(root, "users", "user-1.json")
+	gotRaw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, raw, gotRaw)
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(gotRaw, &body))
+	assert.NotContains(t, body, "encoding")
+	assert.NotContains(t, body, "data")
+
+	got, err := col.Get(ctx, "users/user-1")
+	require.NoError(t, err)
+	assert.Equal(t, raw, got.Data)
+	assert.Equal(t, persis.EncodingJSON, got.Encoding)
 }
 
 func TestFileCollectionWithLockOptionsUsesCustomTiming(t *testing.T) {

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -351,6 +351,14 @@ func TestFileCollectionWritesRawJSONBody(t *testing.T) {
 	assert.Equal(t, persis.EncodingJSON, got.Encoding)
 }
 
+func TestFileCollectionPutNilReturnsError(t *testing.T) {
+	t.Parallel()
+
+	col := file.NewCollection(t.TempDir())
+	err := col.Put(context.Background(), nil)
+	require.ErrorContains(t, err, "nil record")
+}
+
 func TestFileCollectionWithLockOptionsUsesCustomTiming(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/schedulerstore/watermark.go
+++ b/internal/persis/schedulerstore/watermark.go
@@ -5,6 +5,7 @@ package schedulerstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -72,7 +73,7 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if state == nil {
 		return fmt.Errorf("watermark store: state is nil")
 	}
-	data, enc, err := persis.Encode(state)
+	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("watermark store: encode: %w", err)
 	}
@@ -80,7 +81,7 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        watermarkStateID,
 		Data:      data,
-		Encoding:  enc,
+		Encoding:  persis.EncodingJSON,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}); err != nil {

--- a/internal/persis/schedulerstore/watermark_test.go
+++ b/internal/persis/schedulerstore/watermark_test.go
@@ -5,7 +5,10 @@ package schedulerstore_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagucloud/dagu/internal/persis"
+	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/schedulerstore"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
@@ -58,6 +62,31 @@ func TestWatermarkSaveAndLoad(t *testing.T) {
 	assert.Equal(t, now, got.LastTick)
 	assert.Contains(t, got.DAGs, "my-dag")
 	assert.Equal(t, now, got.DAGs["my-dag"].LastScheduledTime)
+}
+
+func TestWatermarkSaveFileLayoutCompatibility(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	backend, err := file.New(root)
+	require.NoError(t, err)
+	s := schedulerstore.NewWatermarkStore(backend.Collection("scheduler"))
+	state := &scheduler.SchedulerState{
+		Version: scheduler.SchedulerStateVersion,
+		DAGs: map[string]scheduler.DAGWatermark{
+			"my-dag": {},
+		},
+	}
+
+	require.NoError(t, s.Save(ctx, state))
+
+	raw, err := os.ReadFile(filepath.Join(root, "scheduler", "state.json"))
+	require.NoError(t, err)
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.NotContains(t, body, "encoding")
+	assert.NotContains(t, body, "data")
+	assert.Contains(t, body, "version")
+	assert.Contains(t, body, "dags")
 }
 
 func TestWatermarkSave_Overwrite(t *testing.T) {

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -19,8 +19,8 @@ import (
 var _ exec.ActiveDistributedRunStore = (*ActiveDistributedRunStore)(nil)
 
 // ActiveDistributedRunStore implements [exec.ActiveDistributedRunStore] on top
-// of a [persis.Collection]. Record IDs intentionally match the legacy
-// file-backed distributed store SHA-256 key.
+// of a [persis.Collection]. Record IDs intentionally match the file-backed
+// distributed store SHA-256 key.
 type ActiveDistributedRunStore struct {
 	col persis.Collection
 }

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -37,8 +37,8 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 
 // DispatchTaskStore implements [exec.DispatchTaskStore] on top of a
 // [persis.Collection]. Record IDs use "pending/" and "claims/" prefixes so a
-// file collection rooted at the legacy distributed directory reads the old
-// on-disk layout without migration.
+// file collection rooted at the distributed directory uses the existing
+// on-disk layout directly.
 type DispatchTaskStore struct {
 	col            persis.Collection
 	reservationTTL time.Duration

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -17,8 +17,8 @@ import (
 var _ exec.DAGRunLeaseStore = (*DAGRunLeaseStore)(nil)
 
 // DAGRunLeaseStore implements [exec.DAGRunLeaseStore] on top of a
-// [persis.Collection]. Record IDs intentionally use the same SHA-256 key as the
-// old file-backed distributed store, so existing lease files remain readable.
+// [persis.Collection]. Record IDs use the file-backed distributed store
+// SHA-256 key.
 type DAGRunLeaseStore struct {
 	col persis.Collection
 }

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -125,7 +125,7 @@ func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
 
 	ctx := context.Background()
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, legacyHash("corrupt-lease")+".json"), []byte("{"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, encodedKey("corrupt-lease")+".json"), []byte("{"), 0o600))
 
 	s := store.NewDAGRunLeaseStore(file.NewCollection(dir))
 	_, err := s.ListAll(ctx)
@@ -133,18 +133,18 @@ func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
 	assert.Contains(t, err.Error(), "corrupt")
 }
 
-func TestDAGRunLeaseStore_UsesLegacyLockPath(t *testing.T) {
+func TestDAGRunLeaseStore_UsesFileLockPath(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	distributedDir := t.TempDir()
 	attemptKey := "attempt-key-lock-compat"
-	legacyLock := dirlock.New(filepath.Join(distributedDir, "locks", legacyHash(attemptKey)), &dirlock.LockOptions{
+	existingLock := dirlock.New(filepath.Join(distributedDir, "locks", encodedKey(attemptKey)), &dirlock.LockOptions{
 		StaleThreshold: time.Hour,
 		RetryInterval:  time.Millisecond,
 	})
-	require.NoError(t, legacyLock.Lock(ctx))
-	defer func() { _ = legacyLock.Unlock() }()
+	require.NoError(t, existingLock.Lock(ctx))
+	defer func() { _ = existingLock.Unlock() }()
 
 	s := store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir))
 	lockCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
@@ -152,7 +152,7 @@ func TestDAGRunLeaseStore_UsesLegacyLockPath(t *testing.T) {
 	err := s.Upsert(lockCtx, exec.DAGRunLease{AttemptKey: attemptKey})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	require.NoError(t, legacyLock.Unlock())
+	require.NoError(t, existingLock.Unlock())
 	require.NoError(t, s.Upsert(ctx, exec.DAGRunLease{AttemptKey: attemptKey}))
 }
 
@@ -232,7 +232,7 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 		WorkerID:   "worker-1",
 		Status:     core.Running,
 	}))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, legacyHash("corrupt-active")+".json"), []byte("{"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, encodedKey("corrupt-active")+".json"), []byte("{"), 0o600))
 
 	records, err := s.ListAll(ctx)
 	require.NoError(t, err)
@@ -240,18 +240,18 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 	assert.Equal(t, "attempt-key-1", records[0].AttemptKey)
 }
 
-func TestActiveDistributedRunStore_UsesLegacyLockPath(t *testing.T) {
+func TestActiveDistributedRunStore_UsesFileLockPath(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	distributedDir := t.TempDir()
 	attemptKey := "attempt-key-active-lock-compat"
-	legacyLock := dirlock.New(filepath.Join(distributedDir, "locks", "active-run-"+legacyHash(attemptKey)), &dirlock.LockOptions{
+	existingLock := dirlock.New(filepath.Join(distributedDir, "locks", "active-run-"+encodedKey(attemptKey)), &dirlock.LockOptions{
 		StaleThreshold: time.Hour,
 		RetryInterval:  time.Millisecond,
 	})
-	require.NoError(t, legacyLock.Lock(ctx))
-	defer func() { _ = legacyLock.Unlock() }()
+	require.NoError(t, existingLock.Lock(ctx))
+	defer func() { _ = existingLock.Unlock() }()
 
 	s := store.NewActiveDistributedRunStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir))
 	lockCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
@@ -259,7 +259,7 @@ func TestActiveDistributedRunStore_UsesLegacyLockPath(t *testing.T) {
 	err := s.Upsert(lockCtx, exec.ActiveDistributedRun{AttemptKey: attemptKey})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	require.NoError(t, legacyLock.Unlock())
+	require.NoError(t, existingLock.Unlock())
 	require.NoError(t, s.Upsert(ctx, exec.ActiveDistributedRun{AttemptKey: attemptKey}))
 }
 
@@ -553,15 +553,15 @@ func TestDispatchTaskStore_UsesStoreReservationTTLForCleanup(t *testing.T) {
 	assert.Equal(t, "run-shared-ttl", claimed.Task.DagRunId)
 }
 
-func TestDistributedStores_ReadLegacyFileLayout(t *testing.T) {
+func TestDistributedStores_ReadFileLayout(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	distributedDir := t.TempDir()
-	leaseKey := "attempt-key-legacy-lease"
-	activeKey := "attempt-key-legacy-active"
+	leaseKey := "attempt-key-file-lease"
+	activeKey := "attempt-key-file-active"
 
-	legacyLease := exec.DAGRunLease{
+	fileLease := exec.DAGRunLease{
 		AttemptKey:      leaseKey,
 		DAGRun:          exec.NewDAGRunRef("dag-a", "run-1"),
 		Root:            exec.NewDAGRunRef("dag-a", "run-1"),
@@ -571,14 +571,14 @@ func TestDistributedStores_ReadLegacyFileLayout(t *testing.T) {
 		ClaimedAt:       time.Now().UTC().UnixMilli(),
 		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
 	}
-	writeLegacyJSON(t, filepath.Join(distributedDir, "leases", legacyHash(leaseKey)+".json"), legacyLease)
+	writeJSONFile(t, filepath.Join(distributedDir, "leases", encodedKey(leaseKey)+".json"), fileLease)
 
 	leaseStore := store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir))
 	gotLease, err := leaseStore.Get(ctx, leaseKey)
 	require.NoError(t, err)
-	assert.Equal(t, legacyLease.AttemptKey, gotLease.AttemptKey)
+	assert.Equal(t, fileLease.AttemptKey, gotLease.AttemptKey)
 
-	legacyActive := exec.ActiveDistributedRun{
+	fileActive := exec.ActiveDistributedRun{
 		AttemptKey: activeKey,
 		DAGRun:     exec.NewDAGRunRef("dag-a", "run-1"),
 		Root:       exec.NewDAGRunRef("dag-a", "run-1"),
@@ -587,26 +587,26 @@ func TestDistributedStores_ReadLegacyFileLayout(t *testing.T) {
 		Status:     core.Running,
 		UpdatedAt:  time.Now().UTC().UnixMilli(),
 	}
-	writeLegacyJSON(t, filepath.Join(distributedDir, "active-runs", legacyHash(activeKey)+".json"), legacyActive)
+	writeJSONFile(t, filepath.Join(distributedDir, "active-runs", encodedKey(activeKey)+".json"), fileActive)
 
 	activeStore := store.NewActiveDistributedRunStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir))
 	gotActive, err := activeStore.Get(ctx, activeKey)
 	require.NoError(t, err)
-	assert.Equal(t, legacyActive.AttemptKey, gotActive.AttemptKey)
+	assert.Equal(t, fileActive.AttemptKey, gotActive.AttemptKey)
 
-	legacyTask := dispatchTaskRecord{
+	fileTask := dispatchTaskRecord{
 		Version:      1,
-		Task:         &coordinatorv1.Task{DagRunId: "run-legacy", Target: "dag-legacy", AttemptKey: "attempt-key-legacy-task"},
-		TaskFileName: "task_00000000000000000001_legacy.json",
+		Task:         &coordinatorv1.Task{DagRunId: "run-file", Target: "dag-file", AttemptKey: "attempt-key-file-task"},
+		TaskFileName: "task_00000000000000000001_file.json",
 		EnqueuedAt:   time.Now().UTC().UnixMilli(),
 	}
-	writeLegacyJSON(t, filepath.Join(distributedDir, "pending", legacyTask.TaskFileName), legacyTask)
+	writeJSONFile(t, filepath.Join(distributedDir, "pending", fileTask.TaskFileName), fileTask)
 
 	dispatchStore := store.NewDispatchTaskStore(file.NewCollection(distributedDir))
 	claimed, err := dispatchStore.ClaimNext(ctx, exec.DispatchTaskClaim{WorkerID: "worker-1"})
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
-	assert.Equal(t, "run-legacy", claimed.Task.DagRunId)
+	assert.Equal(t, "run-file", claimed.Task.DagRunId)
 }
 
 type dispatchTaskRecord struct {
@@ -629,7 +629,7 @@ func putPendingDuplicateFromClaim(t *testing.T, col persis.Collection, claimToke
 	t.Helper()
 
 	ctx := context.Background()
-	claimRec, err := col.Get(ctx, "claims/claim_"+legacyHash(claimToken))
+	claimRec, err := col.Get(ctx, "claims/claim_"+encodedKey(claimToken))
 	require.NoError(t, err)
 
 	var payload dispatchTaskRecord
@@ -667,7 +667,7 @@ func ageClaimedDispatchRecord(t *testing.T, col persis.Collection, claimToken st
 	t.Helper()
 
 	ctx := context.Background()
-	rec, err := col.Get(ctx, "claims/claim_"+legacyHash(claimToken))
+	rec, err := col.Get(ctx, "claims/claim_"+encodedKey(claimToken))
 	require.NoError(t, err)
 
 	var payload dispatchTaskRecord
@@ -707,7 +707,7 @@ func agePendingDispatchRecords(t *testing.T, col persis.Collection, age time.Dur
 	}
 }
 
-func writeLegacyJSON(t *testing.T, path string, value any) {
+func writeJSONFile(t *testing.T, path string, value any) {
 	t.Helper()
 
 	data, err := json.Marshal(value)
@@ -716,7 +716,7 @@ func writeLegacyJSON(t *testing.T, path string, value any) {
 	require.NoError(t, os.WriteFile(path, data, 0o600))
 }
 
-func legacyHash(input string) string {
+func encodedKey(input string) string {
 	sum := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/persis/store/queue.go
+++ b/internal/persis/store/queue.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	queueCursorVersion = 1
-	queueDateTimeUTC   = "20060102_150405"
-	queuePollInterval  = 2 * time.Second
+	queueCursorVersion       = 1
+	queueDateTimeUTC         = "20060102_150405"
+	queueItemIDMaxCollisions = 1000
+	queuePollInterval        = 2 * time.Second
 )
 
 var _ exec.QueueStore = (*QueueStore)(nil)
@@ -54,26 +55,30 @@ func (s *QueueStore) Enqueue(ctx context.Context, name string, priority exec.Que
 	}
 
 	now := time.Now().UTC()
-	itemID := newQueueItemID(priority, dagRun.ID, now)
-	payload := queueItemPayload{
-		FileName: itemID + ".json",
-		DAGRun:   dagRun,
-		QueuedAt: now,
-	}
-	data, enc, err := persis.Encode(payload)
-	if err != nil {
-		return fmt.Errorf("queue store: encode item: %w", err)
-	}
 	return s.withQueueLock(ctx, name, func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
+
+		itemID, queuedAt, err := s.nextQueueItemID(ctx, name, priority, dagRun.ID, now)
+		if err != nil {
+			return err
+		}
+		payload := queueItemPayload{
+			FileName: itemID + ".json",
+			DAGRun:   dagRun,
+			QueuedAt: queuedAt,
+		}
+		data, enc, err := persis.Encode(payload)
+		if err != nil {
+			return fmt.Errorf("queue store: encode item: %w", err)
+		}
 
 		if err := s.col.Put(ctx, &persis.Record{
 			ID:        queueRecordID(name, itemID),
 			Data:      data,
 			Encoding:  enc,
-			CreatedAt: now,
-			UpdatedAt: now,
+			CreatedAt: queuedAt,
+			UpdatedAt: queuedAt,
 		}); err != nil {
 			return err
 		}
@@ -81,6 +86,28 @@ func (s *QueueStore) Enqueue(ctx context.Context, name string, priority exec.Que
 		s.addQueueIndexItemLocked(ctx, name, priority, itemID)
 		return nil
 	})
+}
+
+func (s *QueueStore) nextQueueItemID(
+	ctx context.Context,
+	name string,
+	priority exec.QueuePriority,
+	dagRunID string,
+	start time.Time,
+) (string, time.Time, error) {
+	start = start.UTC()
+	for attempt := range queueItemIDMaxCollisions {
+		queuedAt := start.Add(time.Duration(attempt) * time.Nanosecond)
+		itemID := newQueueItemID(priority, dagRunID, queuedAt)
+		_, err := s.col.Get(ctx, queueRecordID(name, itemID))
+		if errors.Is(err, persis.ErrNotFound) {
+			return itemID, queuedAt, nil
+		}
+		if err != nil {
+			return "", time.Time{}, err
+		}
+	}
+	return "", time.Time{}, fmt.Errorf("queue store: could not allocate unique item ID for dag-run %q", dagRunID)
 }
 
 // DequeueByName retrieves and removes the next item from the queue.

--- a/internal/persis/store/queue_index.go
+++ b/internal/persis/store/queue_index.go
@@ -55,6 +55,8 @@ func (idx *queueReadIndex) ensureDefaults() {
 	if idx.Low == nil {
 		idx.Low = []string{}
 	}
+	idx.High = normalizeQueueIndexEntries(idx.High)
+	idx.Low = normalizeQueueIndexEntries(idx.Low)
 }
 
 func (idx *queueReadIndex) total() int {
@@ -77,12 +79,13 @@ func (idx *queueReadIndex) append(priority exec.QueuePriority, itemID string) bo
 	if itemID == "" || idx.findItemOffset(itemID) >= 0 {
 		return false
 	}
+	entry := queueIndexEntryName(itemID)
 	switch priority {
 	case exec.QueuePriorityHigh:
-		idx.High = append(idx.High, itemID)
+		idx.High = append(idx.High, entry)
 		sort.Strings(idx.High)
 	case exec.QueuePriorityLow:
-		idx.Low = append(idx.Low, itemID)
+		idx.Low = append(idx.Low, entry)
 		sort.Strings(idx.Low)
 	default:
 		return false
@@ -111,11 +114,11 @@ func (idx *queueReadIndex) itemIDAt(offset int) (string, bool) {
 		return "", false
 	}
 	if offset < len(idx.High) {
-		return idx.High[offset], true
+		return queueIndexItemID(idx.High[offset]), true
 	}
 	offset -= len(idx.High)
 	if offset < len(idx.Low) {
-		return idx.Low[offset], true
+		return queueIndexItemID(idx.Low[offset]), true
 	}
 	return "", false
 }
@@ -162,13 +165,14 @@ func (idx *queueReadIndex) slice(start, limit int) []string {
 }
 
 func (idx *queueReadIndex) findItemOffset(itemID string) int {
+	itemID = normalizeQueueItemID(itemID)
 	for pos, current := range idx.High {
-		if current == itemID {
+		if queueIndexItemID(current) == itemID {
 			return pos
 		}
 	}
 	for pos, current := range idx.Low {
-		if current == itemID {
+		if queueIndexItemID(current) == itemID {
 			return len(idx.High) + pos
 		}
 	}
@@ -176,8 +180,9 @@ func (idx *queueReadIndex) findItemOffset(itemID string) int {
 }
 
 func removeQueueItemID(target *[]string, itemID string) bool {
+	itemID = normalizeQueueItemID(itemID)
 	for i, current := range *target {
-		if current != itemID {
+		if queueIndexItemID(current) != itemID {
 			continue
 		}
 		copy((*target)[i:], (*target)[i+1:])
@@ -187,11 +192,45 @@ func removeQueueItemID(target *[]string, itemID string) bool {
 	return false
 }
 
+func normalizeQueueIndexEntries(entries []string) []string {
+	if len(entries) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		fileName := queueIndexEntryName(entry)
+		if fileName == "" {
+			continue
+		}
+		if _, ok := seen[fileName]; ok {
+			continue
+		}
+		seen[fileName] = struct{}{}
+		out = append(out, fileName)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func queueIndexEntryName(itemID string) string {
+	itemID = normalizeQueueItemID(itemID)
+	if itemID == "" {
+		return ""
+	}
+	return itemID + ".json"
+}
+
+func queueIndexItemID(entry string) string {
+	return normalizeQueueItemID(entry)
+}
+
 func queueIndexRecordID(name string) string {
-	return queuePrefix(name) + "_queue_index"
+	return queuePrefix(name) + ".queue-index"
 }
 
 func queuePriorityFromItemID(itemID string) exec.QueuePriority {
+	itemID = normalizeQueueItemID(itemID)
 	if strings.HasPrefix(itemID, "item_high_") {
 		return exec.QueuePriorityHigh
 	}
@@ -239,17 +278,8 @@ func (s *QueueStore) rebuildQueueIndexLocked(ctx context.Context, name string) (
 		if !ok || itemID == "" {
 			continue
 		}
-		switch queuePriorityFromItemID(itemID) {
-		case exec.QueuePriorityHigh:
-			idx.High = append(idx.High, itemID)
-		case exec.QueuePriorityLow:
-			idx.Low = append(idx.Low, itemID)
-		default:
-			continue
-		}
+		idx.append(queuePriorityFromItemID(itemID), itemID)
 	}
-	sort.Strings(idx.High)
-	sort.Strings(idx.Low)
 	idx.touch()
 
 	if err := s.saveQueueIndexLocked(ctx, name, idx); err != nil {

--- a/internal/persis/store/queue_internal_test.go
+++ b/internal/persis/store/queue_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis"
+	"github.com/dagucloud/dagu/internal/persis/testutil"
 )
 
 func TestQueueCursorHelpersRejectInvalidState(t *testing.T) {
@@ -137,4 +138,37 @@ func TestPollingQueueWatcherUsesDefaultInterval(t *testing.T) {
 
 	watcher := newPollingQueueWatcher(0, nil)
 	assert.Equal(t, queuePollInterval, watcher.interval)
+}
+
+func TestQueueStoreNextQueueItemIDSkipsExistingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	queueName := "main"
+	dagRun := exec.NewDAGRunRef("dag", "run-same")
+	priority := exec.QueuePriorityLow
+	start := time.Date(2026, 1, 1, 0, 0, 0, 1, time.UTC)
+
+	s := NewQueueStore(testutil.NewMemoryBackend().Collection("queue"))
+	firstID := newQueueItemID(priority, dagRun.ID, start)
+	data, enc, err := persis.Encode(queueItemPayload{
+		FileName: firstID + ".json",
+		DAGRun:   dagRun,
+		QueuedAt: start,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.col.Put(ctx, &persis.Record{
+		ID:        queueRecordID(queueName, firstID),
+		Data:      data,
+		Encoding:  enc,
+		CreatedAt: start,
+		UpdatedAt: start,
+	}))
+
+	gotID, gotQueuedAt, err := s.nextQueueItemID(ctx, queueName, priority, dagRun.ID, start)
+	require.NoError(t, err)
+
+	wantQueuedAt := start.Add(time.Nanosecond)
+	assert.Equal(t, newQueueItemID(priority, dagRun.ID, wantQueuedAt), gotID)
+	assert.Equal(t, wantQueuedAt, gotQueuedAt)
 }

--- a/internal/persis/store/queue_item.go
+++ b/internal/persis/store/queue_item.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis"
 )
@@ -196,12 +194,11 @@ func newQueueItemID(priority exec.QueuePriority, dagRunID string, t time.Time) s
 		label = "high"
 	}
 	t = t.UTC()
-	return fmt.Sprintf("item_%s_%s_%09dZ_%s_%s",
+	return fmt.Sprintf("item_%s_%s_%09dZ_%s",
 		label,
 		t.Format(queueDateTimeUTC),
 		t.Nanosecond(),
 		dagRunID,
-		uuid.NewString(),
 	)
 }
 

--- a/internal/persis/store/queue_test.go
+++ b/internal/persis/store/queue_test.go
@@ -5,9 +5,11 @@ package store_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -140,6 +142,47 @@ func TestQueueStore_ListCursorDecodesOnlyPageItems(t *testing.T) {
 	require.Len(t, secondPage.Items, 1)
 	_, err = secondPage.Items[0].Data()
 	require.ErrorContains(t, err, "invalid dag-run")
+}
+
+func TestQueueStore_FileLayoutCompatibility(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := store.NewQueueStore(file.NewCollection(root))
+
+	require.NoError(t, s.Enqueue(ctx, "main", exec.QueuePriorityLow, queueRef("dag", "run-file-layout")))
+
+	queueDir := filepath.Join(root, "main")
+	entries, err := os.ReadDir(queueDir)
+	require.NoError(t, err)
+
+	var itemFile string
+	itemNamePattern := regexp.MustCompile(`^item_low_\d{8}_\d{6}_\d{9}Z_run-file-layout\.json$`)
+	for _, entry := range entries {
+		if itemNamePattern.MatchString(entry.Name()) {
+			itemFile = entry.Name()
+		}
+	}
+	require.NotEmpty(t, itemFile, "queue item file should keep the existing file name")
+	assert.FileExists(t, filepath.Join(queueDir, ".queue-index.json"))
+	assert.NoFileExists(t, filepath.Join(queueDir, "_queue_index.json"))
+
+	itemRaw, err := os.ReadFile(filepath.Join(queueDir, itemFile))
+	require.NoError(t, err)
+	var itemBody map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(itemRaw, &itemBody))
+	assert.NotContains(t, itemBody, "encoding")
+	assert.NotContains(t, itemBody, "data")
+	assert.JSONEq(t, `"`+itemFile+`"`, string(itemBody["fileName"]))
+
+	indexRaw, err := os.ReadFile(filepath.Join(queueDir, ".queue-index.json"))
+	require.NoError(t, err)
+	var indexBody struct {
+		Low []string `json:"low"`
+	}
+	require.NoError(t, json.Unmarshal(indexRaw, &indexBody))
+	assert.Equal(t, []string{itemFile}, indexBody.Low)
 }
 
 func TestQueueStore_DequeueByDAGRunIDAndDeleteByItemIDs(t *testing.T) {
@@ -352,15 +395,15 @@ func TestQueueStore_ConcurrentDequeueIsExclusive(t *testing.T) {
 	assert.Equal(t, int32(1), claimed.Load())
 }
 
-func TestQueueStore_ReadsLegacyFileQueueItems(t *testing.T) {
+func TestQueueStore_ReadsFileQueueItems(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	root := t.TempDir()
-	queueName := "legacy-q"
-	itemFile := "item_high_20260101_000000_000000001Z_run-legacy.json"
+	queueName := "file-q"
+	itemFile := "item_high_20260101_000000_000000001Z_run-file.json"
 	queuedAt := time.Date(2026, 1, 1, 0, 0, 0, 1, time.UTC)
-	raw := `{"fileName":"` + itemFile + `","dagRun":{"name":"legacy-dag","id":"run-legacy"},"queuedAt":"` + queuedAt.Format(time.RFC3339Nano) + `"}`
+	raw := `{"fileName":"` + itemFile + `","dagRun":{"name":"file-dag","id":"run-file"},"queuedAt":"` + queuedAt.Format(time.RFC3339Nano) + `"}`
 
 	itemPath := filepath.Join(root, queueName, itemFile)
 	require.NoError(t, os.MkdirAll(filepath.Dir(itemPath), 0o750))
@@ -371,8 +414,8 @@ func TestQueueStore_ReadsLegacyFileQueueItems(t *testing.T) {
 	items, err := s.List(ctx, queueName)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
-	assert.Equal(t, "item_high_20260101_000000_000000001Z_run-legacy", items[0].ID())
-	assert.Equal(t, queueRef("legacy-dag", "run-legacy"), requireQueuedRef(t, items[0]))
+	assert.Equal(t, "item_high_20260101_000000_000000001Z_run-file", items[0].ID())
+	assert.Equal(t, queueRef("file-dag", "run-file"), requireQueuedRef(t, items[0]))
 
 	claimed, err := s.DequeueByName(ctx, queueName)
 	require.NoError(t, err)

--- a/internal/persis/store/workerheartbeat.go
+++ b/internal/persis/store/workerheartbeat.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -34,9 +33,6 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 	if record.WorkerID == "" {
 		return fmt.Errorf("worker heartbeat store: workerID is required")
 	}
-	if strings.ContainsAny(record.WorkerID, `/\`) || strings.Contains(record.WorkerID, "..") {
-		return fmt.Errorf("worker heartbeat store: workerID %q contains unsafe characters", record.WorkerID)
-	}
 	if record.LastHeartbeatAt == 0 {
 		record.LastHeartbeatAt = time.Now().UTC().UnixMilli()
 	}
@@ -46,7 +42,7 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 	}
 	now := time.Now().UTC()
 	if err := s.col.Put(ctx, &persis.Record{
-		ID:        record.WorkerID,
+		ID:        workerHeartbeatKey(record.WorkerID),
 		Data:      data,
 		Encoding:  enc,
 		CreatedAt: now,
@@ -54,43 +50,20 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 	}); err != nil {
 		return err
 	}
-	// Remove any legacy SHA-256-keyed record so the worker only appears once in List.
-	_ = s.col.Delete(ctx, workerHeartbeatLegacyKey(record.WorkerID))
 	return nil
 }
 
-// workerHeartbeatLegacyKey returns the SHA-256-encoded key used by the
-// pre-refactor file-backed worker heartbeat store for backward compatibility.
-func workerHeartbeatLegacyKey(workerID string) string {
+func workerHeartbeatKey(workerID string) string {
 	sum := sha256.Sum256([]byte(workerID))
 	return hex.EncodeToString(sum[:])
 }
 
 // Get retrieves the heartbeat record for a specific worker.
-// When both a new-format (plain workerID) and a legacy (SHA-256-keyed) record
-// coexist during migration, the fresher record wins.
 func (s *WorkerHeartbeatStore) Get(ctx context.Context, workerID string) (*exec.WorkerHeartbeatRecord, error) {
 	if workerID == "" {
 		return nil, exec.ErrWorkerHeartbeatNotFound
 	}
-	newR, newErr := s.getByCollectionID(ctx, workerID)
-	legacyR, _ := s.getByCollectionID(ctx, workerHeartbeatLegacyKey(workerID))
-	switch {
-	case newR != nil && legacyR != nil:
-		if legacyR.LastHeartbeatTime().After(newR.LastHeartbeatTime()) {
-			return legacyR, nil
-		}
-		return newR, nil
-	case newR != nil:
-		return newR, nil
-	case legacyR != nil:
-		return legacyR, nil
-	default:
-		if newErr != nil {
-			return nil, newErr
-		}
-		return nil, exec.ErrWorkerHeartbeatNotFound
-	}
+	return s.getByCollectionID(ctx, workerHeartbeatKey(workerID))
 }
 
 func (s *WorkerHeartbeatStore) getByCollectionID(ctx context.Context, collectionID string) (*exec.WorkerHeartbeatRecord, error) {

--- a/internal/persis/store/workerheartbeat.go
+++ b/internal/persis/store/workerheartbeat.go
@@ -41,16 +41,13 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 		return err
 	}
 	now := time.Now().UTC()
-	if err := s.col.Put(ctx, &persis.Record{
+	return s.col.Put(ctx, &persis.Record{
 		ID:        workerHeartbeatKey(record.WorkerID),
 		Data:      data,
 		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func workerHeartbeatKey(workerID string) string {

--- a/internal/persis/store/workerheartbeat_test.go
+++ b/internal/persis/store/workerheartbeat_test.go
@@ -5,6 +5,11 @@ package store_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/store"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
 )
@@ -30,6 +36,11 @@ func newRecord(workerID string) exec.WorkerHeartbeatRecord {
 	}
 }
 
+func encodedWorkerHeartbeatKey(workerID string) string {
+	sum := sha256.Sum256([]byte(workerID))
+	return hex.EncodeToString(sum[:])
+}
+
 func TestWorkerHeartbeatUpsertAndGet(t *testing.T) {
 	ctx := context.Background()
 	s := newWorkerHeartbeatStore(t)
@@ -41,6 +52,35 @@ func TestWorkerHeartbeatUpsertAndGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "worker-1", got.WorkerID)
 	assert.Equal(t, "test", got.Labels["env"])
+}
+
+func TestWorkerHeartbeatFileLayout(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	s := store.NewWorkerHeartbeatStore(file.NewCollection(filepath.Join(root, "workers")))
+	rec := exec.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		Labels:          map[string]string{"env": "test"},
+		LastHeartbeatAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli(),
+	}
+
+	require.NoError(t, s.Upsert(ctx, rec))
+
+	path := filepath.Join(root, "workers", encodedWorkerHeartbeatKey("worker-1")+".json")
+	assert.FileExists(t, path)
+	assert.NoFileExists(t, filepath.Join(root, "workers", "worker-1.json"))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.NotContains(t, body, "encoding")
+	assert.NotContains(t, body, "data")
+
+	var saved exec.WorkerHeartbeatRecord
+	require.NoError(t, json.Unmarshal(raw, &saved))
+	assert.Equal(t, rec.WorkerID, saved.WorkerID)
+	assert.Equal(t, rec.LastHeartbeatAt, saved.LastHeartbeatAt)
 }
 
 func TestWorkerHeartbeatUpsert_Overwrite(t *testing.T) {

--- a/ui/e2e/helpers/e2e.ts
+++ b/ui/e2e/helpers/e2e.ts
@@ -284,12 +284,8 @@ export async function waitForSchedulerDAGRegistered(
           const raw = await fs.readFile(schedulerStatePath, 'utf8');
           const parsed = JSON.parse(raw) as {
             dags?: Record<string, unknown>;
-            data?: { dags?: Record<string, unknown> };
           };
-          // Support both legacy flat format and the persis-envelope format
-          // ({"id","encoding","data":{...state...},...}) used by the new store.
-          const state = parsed.data ?? parsed;
-          return Boolean(state.dags?.[dagName]);
+          return Boolean(parsed.dags?.[dagName]);
         } catch {
           return false;
         }


### PR DESCRIPTION
## Summary
- keep file-backed collections writing raw JSON payloads instead of collection record envelopes
- restore existing queue item/index filenames and worker heartbeat SHA-keyed filenames
- remove the scheduler-state envelope fallback from e2e helpers and add file-layout regression coverage

## Testing
- go test ./internal/persis/file ./internal/persis/store ./internal/persis/schedulerstore -count=1
- go test ./internal/persis/... -count=1
- go test ./internal/service/scheduler ./internal/service/coordinator ./internal/service/worker -count=1
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the on-disk persistence layout by writing raw JSON files and restoring existing filenames for queues and worker heartbeats. Also hardens edge cases and prevents queue item ID collisions.

- **Refactors**
  - `internal/persis/file`: Collections read/write raw JSON bodies (no envelope). Validate JSON, reject nil records, disallow non-JSON encodings, keep IDs, and set file mtime from record timestamps.
  - Scheduler watermark: Save `state.json` as flat JSON via `json.MarshalIndent`; set encoding to JSON. Updated e2e helper to read the flat shape.
  - Queue store: Restore item filenames and index layout.
    - Item files: `item_<priority>_<YYYYMMDD>_<HHMMSS>_<nanos>Z_<dagRunId>.json` (no UUID).
    - Index file: `.queue-index.json`; entries are item file names and are normalized/deduped.
  - Worker heartbeat: Always use SHA-256 key filenames for records; `Get`/`Upsert` read/write the hashed key only.
  - Distributed stores: Keep SHA-based keys and lock paths so files/locks are read directly without migration.
  - Tests: Add regression coverage for file layout compatibility and behaviors across collections, queue, scheduler watermark, worker heartbeat, and distributed stores.

- **Bug Fixes**
  - File backend: Error on nil record, invalid JSON body, or unsupported encoding.
  - Queue: Avoid item ID collisions by probing nanoseconds when allocating IDs; use the actual queued timestamp for record times. Index entries are normalized and deduped to prevent corruption.

<sup>Written for commit 171cd1eb9b3bf7c9dd045425203e6c64cb1c653f. Summary will update on new commits. <a href="https://cubic.dev/pr/dagucloud/dagu/pull/2217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified persistence storage by writing records as raw JSON and removing older file format handling.
  * Standardized record key naming and queue index storage for more consistent file layout.
  * Updated queue item ID allocation and worker heartbeat storage to use deterministic hashed keys.

* **Bug Fixes**
  * Improved conflict handling and record updates for persisted data.
  * Queue entries now avoid filename collisions more reliably.

* **Tests**
  * Added coverage for raw JSON file output and compatibility with the updated persistence layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->