### PR TITLE
refactor: preserve released file layout across control-plane stores; align CAS identity

### DIFF
--- a/internal/cmd/process/frontend_store_factories.go
+++ b/internal/cmd/process/frontend_store_factories.go
@@ -80,12 +80,12 @@ func newBuiltinAuthService(ctx context.Context, cfg *config.Config) (*frontend.B
 		return nil, false, fmt.Errorf("failed to resolve token secret: %w", err)
 	}
 
-	userStore, err := store.NewUserStore(file.NewCollection(cfg.Paths.UsersDir))
+	userStore, err := store.NewUserStore(file.NewCollection(cfg.Paths.UsersDir, file.WithIndentedJSON()))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create user store: %w", err)
 	}
 
-	apiKeyStore, err := store.NewAPIKeyStore(file.NewCollection(cfg.Paths.APIKeysDir))
+	apiKeyStore, err := store.NewAPIKeyStore(file.NewCollection(cfg.Paths.APIKeysDir, file.WithIndentedJSON()))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create API key store: %w", err)
 	}
@@ -100,7 +100,7 @@ func newBuiltinAuthService(ctx context.Context, cfg *config.Config) (*frontend.B
 			logger.Warn(ctx, "Failed to create encryptor for webhook store", tag.Error(encErr))
 		}
 	}
-	webhookStore, err := store.NewWebhookStore(file.NewCollection(cfg.Paths.WebhooksDir), webhookEncryptor)
+	webhookStore, err := store.NewWebhookStore(file.NewCollection(cfg.Paths.WebhooksDir, file.WithIndentedJSON()), webhookEncryptor)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create webhook store: %w", err)
 	}

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
@@ -58,11 +59,9 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 
 	coordinatorClient := NewCoordinatorClient(ctx, cfg.Config, cfg.ServiceRegistry)
 	entryReader := scheduler.NewEntryReader(cfg.Config.Paths.DAGsDir, dagStore)
-	wmBackend, wmErr := file.New(cfg.Config.Paths.DataDir)
-	if wmErr != nil {
-		return nil, fmt.Errorf("failed to open file backend for watermark: %w", wmErr)
-	}
-	watermarkStore := schedulerstore.NewWatermarkStore(wmBackend.Collection("scheduler"))
+	watermarkStore := schedulerstore.NewWatermarkStore(
+		file.NewCollection(filepath.Join(cfg.Config.Paths.DataDir, "scheduler"), file.WithIndentedJSON()),
+	)
 
 	statusCache := fileutil.NewCache[*exec.DAGRunStatus]("scheduler_dag_run_status", limits.DAGRun.Limit, limits.DAGRun.TTL)
 	statusCache.StartEviction(ctx)

--- a/internal/cmd/process/server.go
+++ b/internal/cmd/process/server.go
@@ -5,7 +5,7 @@ package process
 
 import (
 	"context"
-	"fmt"
+	"path/filepath"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -74,12 +74,10 @@ func NewServer(cfg ServerConfig, opts ...frontend.ServerOption) (*frontend.Serve
 	if cfg.WorkerHeartbeatStore != nil {
 		opts = append(opts, frontend.WithAPIOption(apiv1.WithWorkerHeartbeatStore(cfg.WorkerHeartbeatStore)))
 	}
-	wmBackend, wmErr := file.New(cfg.Config.Paths.DataDir)
-	if wmErr != nil {
-		return nil, fmt.Errorf("failed to open file backend for watermark: %w", wmErr)
-	}
 	opts = append(opts, frontend.WithAPIOption(apiv1.WithSchedulerStateStore(
-		schedulerstore.NewWatermarkStore(wmBackend.Collection("scheduler")),
+		schedulerstore.NewWatermarkStore(
+			file.NewCollection(filepath.Join(cfg.Config.Paths.DataDir, "scheduler"), file.WithIndentedJSON()),
+		),
 	)))
 
 	return frontend.NewServer(

--- a/internal/persis/backend.go
+++ b/internal/persis/backend.go
@@ -42,8 +42,13 @@ type Record struct {
 	Encoding  Encoding
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	// ExpiresAt, when non-nil, signals the backend that this record may be
-	// purged after this time. Used for heartbeat / lease / TTL records.
+	// ExpiresAt is an optional, non-authoritative GC/TTL hint: when non-nil it
+	// tells the backend the record MAY be purged after this time. Correctness
+	// must not depend on it — adapters that need real expiry (heartbeats,
+	// leases) keep the authoritative timestamp inside Data. It is also NOT part
+	// of record identity for CompareAndSwap / CompareAndDelete. The file
+	// backend does not persist it; a SQL backend MAY honor it via an
+	// expires_at column and index.
 	ExpiresAt *time.Time
 }
 

--- a/internal/persis/file/agent_stores.go
+++ b/internal/persis/file/agent_stores.go
@@ -179,9 +179,9 @@ func NewSecretStore(ctx context.Context, cfg *config.Config) secret.Store {
 		logger.Warn(ctx, "Failed to resolve encryption key for secret store", tag.Error(encErr))
 	} else if enc, encErr := crypto.NewEncryptor(encKey); encErr != nil {
 		logger.Warn(ctx, "Failed to create encryptor for secret store", tag.Error(encErr))
-	} else if backend, backendErr := New(cfg.Paths.DataDir); backendErr != nil {
-		logger.Warn(ctx, "Failed to open file backend for secret store", tag.Error(backendErr))
-	} else if secretStore, storeErr := store.NewSecretStore(backend.Collection("secrets"), enc); storeErr != nil {
+	} else if secretStore, storeErr := store.NewSecretStore(
+		NewCollection(filepath.Join(cfg.Paths.DataDir, "secrets"), WithIndentedJSON()), enc,
+	); storeErr != nil {
 		logger.Warn(ctx, "Failed to create secret store", tag.Error(storeErr))
 	} else {
 		return secretStore

--- a/internal/persis/file/backend.go
+++ b/internal/persis/file/backend.go
@@ -39,17 +39,37 @@ func (b *Backend) Collection(name string) persis.Collection {
 	return v.(*Collection)
 }
 
+// CollectionOption configures a file-backed [Collection].
+type CollectionOption func(*Collection)
+
+// WithIndentedJSON stores records as 2-space indented JSON on disk, matching
+// the pre-refactor (<= v2.7.4) released format for human-readable stores such
+// as users, API keys, secrets, and webhooks. Records are normalized back to
+// compact JSON in memory on read, so callers see canonical Record.Data
+// regardless of on-disk indentation.
+func WithIndentedJSON() CollectionOption {
+	return func(c *Collection) { c.indent = true }
+}
+
 // NewCollection creates a [persis.Collection] backed by the given directory.
 // Unlike [New]+[Collection], this skips the root MkdirAll — the directory
 // is created lazily on the first write.
-func NewCollection(dir string) persis.Collection {
-	return &Collection{dir: dir}
+func NewCollection(dir string, opts ...CollectionOption) persis.Collection {
+	c := &Collection{dir: dir}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // NewCollectionWithLockRoot creates a collection whose records live under dir
 // while its cross-process locks are scoped under lockRoot.
-func NewCollectionWithLockRoot(dir, lockRoot string) persis.Collection {
-	return &Collection{dir: dir, lockRoot: lockRoot}
+func NewCollectionWithLockRoot(dir, lockRoot string, opts ...CollectionOption) persis.Collection {
+	c := &Collection{dir: dir, lockRoot: lockRoot}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // Close is a no-op; the file backend holds no persistent resources.

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -343,12 +343,12 @@ func (c *Collection) readFile(path string) (*persis.Record, error) {
 	if c.indent {
 		// Normalize indented on-disk JSON back to compact so the in-memory
 		// Record.Data is canonical (matches the memory backend and keeps
-		// CompareAndSwap/CompareAndDelete byte comparisons stable). json.Valid
-		// above guarantees Compact succeeds.
+		// CompareAndSwap/CompareAndDelete byte comparisons stable). The
+		// json.Valid check above makes json.Compact infallible here, so we
+		// drop its error rather than fall back to non-canonical raw bytes.
 		var buf bytes.Buffer
-		if err := json.Compact(&buf, raw); err == nil {
-			data = buf.Bytes()
-		}
+		_ = json.Compact(&buf, raw)
+		data = buf.Bytes()
 	}
 	return &persis.Record{
 		ID:        relPathToID(rel),

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -29,7 +29,12 @@ import (
 type Collection struct {
 	dir      string
 	lockRoot string
-	mu       sync.RWMutex
+	// indent, when true, stores records as 2-space indented JSON on disk to
+	// match the pre-refactor (<= v2.7.4) released file format. Records are
+	// normalized back to compact JSON in memory on read, so Record.Data stays
+	// canonical regardless of on-disk whitespace.
+	indent bool
+	mu     sync.RWMutex
 }
 
 var _ persis.Collection = (*Collection)(nil)
@@ -334,9 +339,20 @@ func (c *Collection) readFile(path string) (*persis.Record, error) {
 	}
 	rel, _ := filepath.Rel(c.dir, path)
 	mtime := info.ModTime().UTC()
+	data := raw
+	if c.indent {
+		// Normalize indented on-disk JSON back to compact so the in-memory
+		// Record.Data is canonical (matches the memory backend and keeps
+		// CompareAndSwap/CompareAndDelete byte comparisons stable). json.Valid
+		// above guarantees Compact succeeds.
+		var buf bytes.Buffer
+		if err := json.Compact(&buf, raw); err == nil {
+			data = buf.Bytes()
+		}
+	}
 	return &persis.Record{
 		ID:        relPathToID(rel),
-		Data:      raw,
+		Data:      data,
 		Encoding:  persis.EncodingJSON,
 		CreatedAt: mtime,
 		UpdatedAt: mtime,
@@ -353,10 +369,21 @@ func (c *Collection) writeFile(path string, rec *persis.Record) error {
 	if !json.Valid(rec.Data) {
 		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
 	}
+	body := rec.Data
+	if c.indent {
+		// Match the pre-refactor on-disk format. json.Indent over compact
+		// json.Marshal output is byte-identical to json.MarshalIndent of the
+		// same value, so existing released files stay format-compatible.
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, rec.Data, "", "  "); err != nil {
+			return fmt.Errorf("file backend: indent record %q: %w", rec.ID, err)
+		}
+		body = buf.Bytes()
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	if err := fileutil.WriteFileAtomic(path, rec.Data, 0o600); err != nil {
+	if err := fileutil.WriteFileAtomic(path, body, 0o600); err != nil {
 		return err
 	}
 	mtime := rec.UpdatedAt

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -351,6 +351,80 @@ func TestFileCollectionWritesRawJSONBody(t *testing.T) {
 	assert.Equal(t, persis.EncodingJSON, got.Encoding)
 }
 
+// TestFileCollectionIndentedMatchesReleasedFormat pins the on-disk bytes of an
+// indented collection to json.MarshalIndent(v, "", "  ") — the exact format the
+// pre-refactor (<= v2.7.4) file stores wrote — so upgrades need no migration.
+func TestFileCollectionIndentedMatchesReleasedFormat(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	col := file.NewCollection(root, file.WithIndentedJSON())
+
+	type sample struct {
+		ID   string   `json:"id"`
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	v := sample{ID: "u1", Name: "admin", Tags: []string{"a", "b"}}
+
+	compact, err := json.Marshal(v)
+	require.NoError(t, err)
+	rec := &persis.Record{
+		ID:        "users/u1",
+		Data:      compact,
+		Encoding:  persis.EncodingJSON,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, col.Put(ctx, rec))
+
+	// On-disk bytes must equal the released json.MarshalIndent output.
+	onDisk, err := os.ReadFile(filepath.Join(root, "users", "u1.json"))
+	require.NoError(t, err)
+	wantIndented, err := json.MarshalIndent(v, "", "  ")
+	require.NoError(t, err)
+	assert.Equal(t, wantIndented, onDisk)
+
+	// Get normalizes back to canonical compact Data.
+	got, err := col.Get(ctx, "users/u1")
+	require.NoError(t, err)
+	assert.Equal(t, compact, got.Data)
+}
+
+// TestFileCollectionIndentedReadsLegacyIndentedFile verifies a file written by
+// an older release (indented, no envelope) is read back as canonical compact
+// Data without any migration step.
+func TestFileCollectionIndentedReadsLegacyIndentedFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	col := file.NewCollection(root, file.WithIndentedJSON())
+
+	compact := []byte(`{"id":"k1","name":"ci"}`)
+	legacy, err := json.MarshalIndent(json.RawMessage(compact), "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "api_keys"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "api_keys", "k1.json"), legacy, 0o600))
+
+	got, err := col.Get(ctx, "api_keys/k1")
+	require.NoError(t, err)
+	assert.Equal(t, compact, got.Data)
+}
+
+// TestFileCollectionIndentedContract runs the full Collection contract against
+// an indented collection, proving CompareAndSwap, CompareAndDelete, List, and
+// Claim all stay correct when records are indented on disk.
+func TestFileCollectionIndentedContract(t *testing.T) {
+	t.Parallel()
+
+	freshCollection := func(t *testing.T) persis.Collection {
+		return file.NewCollection(t.TempDir(), file.WithIndentedJSON())
+	}
+	RunCollectionContract(t, file.NewCollection(t.TempDir(), file.WithIndentedJSON()), freshCollection)
+}
+
 func TestFileCollectionPutNilReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/store_guard_test.go
+++ b/internal/persis/file/store_guard_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package file_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/persis/file"
+	"github.com/dagucloud/dagu/internal/persis/file/proc"
+	"github.com/dagucloud/dagu/internal/persis/filesession"
+	"github.com/dagucloud/dagu/internal/persis/store"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileBackendUsesFileSpecificStores locks the invariant that the file
+// backend wires proc and agent-session through the layout-preserving,
+// file-specific implementations — never the backend-neutral collection
+// adapters in internal/persis/store.
+//
+// The collection-backed store.ProcStore (JSON records) and store.SessionStore
+// (flat "{sessionID}.json") are NOT layout-compatible with the released
+// file-backend layouts (binary ".proc" files; nested "{userID}/{sessionID}.json").
+// Swapping the wiring to those would silently break upgrades, so guard it here.
+//
+// NewProcStore returns a concrete *proc.Store, so the compiler already prevents
+// a proc swap; this test documents that and additionally guards the session
+// boundary, whose constructor returns the agent.SessionStore interface and so
+// would accept a store.SessionStore swap without a compile error.
+func TestFileBackendUsesFileSpecificStores(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	cfg.Paths.ProcDir = t.TempDir()
+	cfg.Paths.SessionsDir = t.TempDir()
+
+	t.Run("proc store is file-backed", func(t *testing.T) {
+		t.Parallel()
+
+		ps := file.NewProcStore(cfg)
+		require.IsType(t, &proc.Store{}, ps,
+			"file backend must use the binary .proc store, not a collection adapter")
+
+		var asCollectionStore any = ps
+		_, isCollectionBacked := asCollectionStore.(*store.ProcStore)
+		require.False(t, isCollectionBacked,
+			"file backend proc store must not be the collection-backed store.ProcStore")
+	})
+
+	t.Run("agent session store is file-backed", func(t *testing.T) {
+		t.Parallel()
+
+		ss, err := file.NewAgentSessionStore(cfg)
+		require.NoError(t, err)
+		require.IsType(t, &filesession.Store{}, ss,
+			"file backend must use the nested filesession store, not a collection adapter")
+
+		_, isCollectionBacked := ss.(*store.SessionStore)
+		require.False(t, isCollectionBacked,
+			"file backend agent session store must not be the collection-backed store.SessionStore")
+	})
+}

--- a/internal/persis/schedulerstore/watermark.go
+++ b/internal/persis/schedulerstore/watermark.go
@@ -5,7 +5,6 @@ package schedulerstore
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -73,7 +72,7 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if state == nil {
 		return fmt.Errorf("watermark store: state is nil")
 	}
-	data, err := json.MarshalIndent(state, "", "  ")
+	data, enc, err := persis.Encode(state)
 	if err != nil {
 		return fmt.Errorf("watermark store: encode: %w", err)
 	}
@@ -81,7 +80,7 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        watermarkStateID,
 		Data:      data,
-		Encoding:  persis.EncodingJSON,
+		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}); err != nil {

--- a/internal/persis/schedulerstore/watermark_test.go
+++ b/internal/persis/schedulerstore/watermark_test.go
@@ -67,9 +67,8 @@ func TestWatermarkSaveAndLoad(t *testing.T) {
 func TestWatermarkSaveFileLayoutCompatibility(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
-	backend, err := file.New(root)
-	require.NoError(t, err)
-	s := schedulerstore.NewWatermarkStore(backend.Collection("scheduler"))
+	col := file.NewCollection(filepath.Join(root, "scheduler"), file.WithIndentedJSON())
+	s := schedulerstore.NewWatermarkStore(col)
 	state := &scheduler.SchedulerState{
 		Version: scheduler.SchedulerStateVersion,
 		DAGs: map[string]scheduler.DAGWatermark{

--- a/internal/persis/store/proc.go
+++ b/internal/persis/store/proc.go
@@ -53,6 +53,15 @@ func WithProcHeartbeatSyncInterval(_ time.Duration) ProcStoreOption {
 }
 
 // ProcStore implements [exec.ProcStore] on top of a [persis.Collection].
+//
+// This is the backend-neutral proc store, intended for non-file backends
+// (SQL/etcd) and tests. It serializes each entry as a JSON record and derives
+// liveness from the entry's heartbeat timestamp plus the record's UpdatedAt.
+//
+// It is NOT layout-compatible with the file backend's proc store
+// ([github.com/dagucloud/dagu/internal/persis/file/proc]), which writes the
+// released binary ".proc" files. The file backend must use file.NewProcStore;
+// do not point this store at a file backend's ProcDir. See [NewProcStore].
 type ProcStore struct {
 	col               persis.Collection
 	staleTime         time.Duration
@@ -64,6 +73,11 @@ type ProcStore struct {
 }
 
 // NewProcStore creates a ProcStore backed by col.
+//
+// For non-file backends and tests only. The file backend uses
+// file.NewProcStore (binary ".proc" layout); this collection-backed store
+// writes JSON records and is not compatible with that on-disk layout, so it
+// must not be wired over a file backend's ProcDir without a migration.
 func NewProcStore(col persis.Collection, opts ...ProcStoreOption) *ProcStore {
 	s := &ProcStore{
 		col:               col,

--- a/internal/persis/store/proc_handle.go
+++ b/internal/persis/store/proc_handle.go
@@ -122,6 +122,7 @@ func (p *ProcHandle) writeHeartbeat(ctx context.Context, now time.Time) error {
 		GroupName:       p.groupName,
 		Meta:            p.meta,
 		LastHeartbeatAt: now.Unix(),
+		RevisionNanos:   now.UnixNano(),
 	}
 	data, enc, err := persis.Encode(payload)
 	if err != nil {
@@ -143,4 +144,10 @@ type procPayload struct {
 	GroupName       string        `json:"groupName"`
 	Meta            exec.ProcMeta `json:"meta"`
 	LastHeartbeatAt int64         `json:"lastHeartbeatAt"`
+	// RevisionNanos is a monotonic per-write nonce (now.UnixNano()) included
+	// so every heartbeat changes Data. The Collection contract makes
+	// CompareAndSwap / CompareAndDelete identity Data-only (see persis.Record),
+	// so an in-Data nonce is what lets stale-removal detect a concurrent
+	// refresh without depending on backend-specific timestamp semantics.
+	RevisionNanos int64 `json:"revisionNanos,omitempty"`
 }

--- a/internal/persis/store/proc_test.go
+++ b/internal/persis/store/proc_test.go
@@ -198,9 +198,19 @@ func TestProcStoreRemoveIfStaleKeepsRefreshedCollectionRecord(t *testing.T) {
 		return true
 	}, time.Second, 10*time.Millisecond)
 
+	// Simulate a concurrent heartbeat by bumping the in-Data revision nonce.
+	// The Collection CAS contract is Data-only (matches the file backend), so
+	// only a Data change is observable to CompareAndDelete; touching just
+	// UpdatedAt would not be — and would not protect the record in production.
 	col.refresh = func(expected *persis.Record) {
 		rec, err := base.Get(ctx, expected.ID)
 		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(rec.Data, &payload))
+		payload["revisionNanos"] = time.Now().UnixNano()
+		newData, err := json.Marshal(payload)
+		require.NoError(t, err)
+		rec.Data = newData
 		rec.UpdatedAt = time.Now().UTC()
 		require.NoError(t, base.Put(ctx, rec))
 	}

--- a/internal/persis/store/session.go
+++ b/internal/persis/store/session.go
@@ -24,6 +24,15 @@ const sessionMaxTitleLength = 50
 // SessionStore implements [agent.SessionStore].
 // Three in-memory indices (byUser, byParent, updatedAt) are rebuilt from
 // the collection on startup and kept in sync under mu.
+//
+// This is the backend-neutral session store, intended for non-file backends
+// (SQL/etcd) and tests. It keys records by flat session ID ("{sessionID}").
+//
+// It is NOT layout-compatible with the file backend's agent session store
+// ([github.com/dagucloud/dagu/internal/persis/filesession]), which nests
+// files as "{userID}/{sessionID}.json". The file backend must use
+// file.NewAgentSessionStore; do not point this store at a file backend's
+// SessionsDir. See [NewSessionStore].
 type SessionStore struct {
 	col        persis.Collection
 	maxPerUser int
@@ -73,6 +82,12 @@ func WithMaxPerUser(n int) SessionOption {
 }
 
 // NewSessionStore creates a SessionStore backed by col.
+//
+// For non-file backends and tests only. The file backend uses
+// file.NewAgentSessionStore (nested "{userID}/{sessionID}.json" layout); this
+// collection-backed store keys records by flat session ID and is not
+// compatible with that on-disk layout, so it must not be wired over a file
+// backend's SessionsDir without a migration.
 func NewSessionStore(col persis.Collection, opts ...SessionOption) (*SessionStore, error) {
 	s := &SessionStore{
 		col:          col,

--- a/internal/persis/testutil/memory.go
+++ b/internal/persis/testutil/memory.go
@@ -285,16 +285,11 @@ func sameMemoryRecord(a, b *persis.Record) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.ID != b.ID || a.Encoding != b.Encoding || !bytes.Equal(a.Data, b.Data) {
-		return false
-	}
-	if !a.CreatedAt.Equal(b.CreatedAt) || !a.UpdatedAt.Equal(b.UpdatedAt) {
-		return false
-	}
-	if a.ExpiresAt == nil || b.ExpiresAt == nil {
-		return a.ExpiresAt == b.ExpiresAt
-	}
-	return a.ExpiresAt.Equal(*b.ExpiresAt)
+	// Identity must match the file backend (file/collection.go sameRecord):
+	// ID + Encoding + Data only. Timestamps and ExpiresAt are not part of
+	// CompareAndSwap / CompareAndDelete identity, so this test double must not
+	// compare them either — otherwise CAS semantics diverge from production.
+	return a.ID == b.ID && a.Encoding == b.Encoding && bytes.Equal(a.Data, b.Data)
 }
 
 type memCursorVal struct {

--- a/refactor_persis_layer.html
+++ b/refactor_persis_layer.html
@@ -35,9 +35,11 @@
     <p class="text-blue-400 text-xs font-mono tracking-widest uppercase mb-3">Architecture Review · Persistence Layer</p>
     <h1 class="text-4xl font-bold mb-4 tracking-tight">Dagu Persistence Layer Refactoring</h1>
     <p class="text-slate-300 text-lg max-w-3xl">
-      Deep Module redesign: consolidate 30 file-store implementations behind a single pluggable
-      <strong class="text-white">Backend</strong> interface — enabling PostgreSQL, etcd, or Cassandra support
-      without touching any domain code.
+      Deep Module redesign: introduce a single pluggable
+      <strong class="text-white">Backend</strong> interface so control-plane stores share one file-I/O implementation.
+      Boundary established and the first wave of stores ported; ~17 still run behind their original leaf packages
+      (incremental, ongoing), while DAG-run and proc stay file-specific by design. The seam makes future
+      PostgreSQL/etcd backends possible without rewriting every store.
     </p>
     <div class="mt-8 flex flex-wrap gap-3 text-sm">
       <span class="bg-slate-800 text-slate-300 px-3 py-1 rounded-full">Control-plane stores → Backend interface</span>
@@ -268,7 +270,7 @@ graph TB
 
 <span class="kw">const</span> (
     <span class="ty">EncodingJSON</span>  <span class="ty">Encoding</span> = <span class="st">"json"</span>
-    <span class="ty">EncodingProto</span> <span class="ty">Encoding</span> = <span class="st">"proto3"</span>
+    <span class="ty">EncodingProto</span> <span class="ty">Encoding</span> = <span class="st">"proto3"</span> <span class="cm">// reserved; not yet supported</span>
 )
 
 <span class="cm">// Record is the universal storage primitive for all control-plane data.
@@ -280,7 +282,7 @@ graph TB
     // Example: "mydag/run-abc/attempt-0"</span>
     ID        <span class="kw">string</span>
 
-    Data      []<span class="kw">byte</span>    <span class="cm">// opaque serialized payload (JSON or proto3)</span>
+    Data      []<span class="kw">byte</span>    <span class="cm">// opaque serialized payload (JSON only; proto3 reserved, not yet supported)</span>
     Encoding  <span class="ty">Encoding</span> <span class="cm">// describes Data's format</span>
 
     CreatedAt <span class="ty">time.Time</span>
@@ -649,8 +651,8 @@ graph TB
           A thin <code class="text-xs bg-slate-100 px-1 rounded">persis/codec.go</code> with two generic helpers:
         </p>
         <div class="bg-slate-900 rounded-lg p-4 mt-3 overflow-x-auto">
-          <pre class="text-xs text-slate-300"><span class="cm">// Encode marshals v into a Record Data+Encoding pair.</span>
-<span class="kw">func</span> <span class="fn">Encode</span>[T <span class="kw">any</span>](v T) (<span class="ty">Record</span>, <span class="kw">error</span>)
+          <pre class="text-xs text-slate-300"><span class="cm">// Encode marshals v to JSON, returning the bytes and encoding.</span>
+<span class="kw">func</span> <span class="fn">Encode</span>(v <span class="kw">any</span>) ([]<span class="kw">byte</span>, <span class="ty">Encoding</span>, <span class="kw">error</span>)
 
 <span class="cm">// Decode unmarshals rec.Data into *v using rec.Encoding.</span>
 <span class="kw">func</span> <span class="fn">Decode</span>[T <span class="kw">any</span>](rec *<span class="ty">Record</span>, v *T) <span class="kw">error</span></pre>
@@ -660,7 +662,7 @@ graph TB
       <div>
         <h3 class="font-semibold text-slate-900 mb-3">Benefits</h3>
         <ul class="text-sm text-slate-600 space-y-2">
-          <li class="flex gap-2"><span class="text-amber-500">→</span> One place to switch JSON → proto3 globally</li>
+          <li class="flex gap-2"><span class="text-amber-500">→</span> One place to change encoding later (currently JSON-only; file backend rejects non-JSON)</li>
           <li class="flex gap-2"><span class="text-amber-500">→</span> One place to add a version field for future migrations</li>
           <li class="flex gap-2"><span class="text-amber-500">→</span> Store adapters become 2-line encode/decode calls</li>
           <li class="flex gap-2"><span class="text-amber-500">→</span> Codec is tested in isolation, independently of backend</li>
@@ -719,19 +721,19 @@ graph TB
       <div class="font-mono text-xs text-slate-600 leading-relaxed">
         <div class="text-slate-400">internal/persis/</div>
         <div class="ml-4 text-purple-600 font-semibold">backend.go <span class="text-slate-400 font-normal">← Backend, Collection, Record</span></div>
-        <div class="ml-4 text-purple-600 font-semibold">codec.go <span class="text-slate-400 font-normal">← Encode[T], Decode[T]</span></div>
+        <div class="ml-4 text-purple-600 font-semibold">codec.go <span class="text-slate-400 font-normal">← Encode, Decode[T]</span></div>
         <div class="ml-4 text-purple-600 font-semibold">errors.go <span class="text-slate-400 font-normal">← ErrNotFound, ErrConflict</span></div>
         <div class="ml-4 mt-2 text-slate-400">── adapters (thin, pure Go) ──</div>
         <div class="ml-4 text-green-600">store/ <span class="text-slate-400 ml-1 font-normal">── ported adapters (persis/store/) ──</span></div>
         <div class="ml-6 text-green-600">✅ apikey.go <span class="text-slate-400 ml-1">254 ln</span></div>
         <div class="ml-6 text-green-600">✅ secret.go <span class="text-slate-400 ml-1">453 ln</span></div>
-        <div class="ml-6 text-green-600">✅ session.go <span class="text-slate-400 ml-1">528 ln</span></div>
+        <div class="ml-6 text-amber-400">◐ session.go <span class="text-slate-400 ml-1">528 ln · ported, unwired; awaits non-file backend (prod uses filesession)</span></div>
         <div class="ml-6 text-green-600">✅ user.go <span class="text-slate-400 ml-1">303 ln</span></div>
         <div class="ml-6 text-green-600">✅ webhook.go <span class="text-slate-400 ml-1">319 ln</span></div>
-        <div class="ml-6 text-green-600">✅ watermark.go <span class="text-slate-400 ml-1">122 ln</span></div>
+        <div class="ml-6 text-green-600">✅ watermark.go <span class="text-slate-400 ml-1">122 ln · lives in persis/schedulerstore/, not store/</span></div>
         <div class="ml-6 text-green-600">✅ workerheartbeat.go <span class="text-slate-400 ml-1">168 ln</span></div>
         <div class="ml-6 text-green-600">✅ queue*.go <span class="text-slate-400 ml-1">collection-backed QueueStore; filequeue removed</span></div>
-        <div class="ml-6 text-green-600">✅ proc*.go <span class="text-slate-400 ml-1">collection-backed ProcStore for non-file backends/tests; no file sidecar adapter</span></div>
+        <div class="ml-6 text-amber-400">◐ proc*.go <span class="text-slate-400 ml-1">collection-backed ProcStore · unwired in production (file backend uses file/proc); for future non-file backends/tests</span></div>
         <div class="ml-6 text-amber-400">◐ distributed*.go <span class="text-slate-400 ml-1">collection-backed records; lock API still file-backend-bound</span></div>
         <div class="ml-4 mt-2 text-slate-400">── backend implementations ──</div>
         <div class="ml-4 text-emerald-600 font-semibold">✅ file/ <span class="text-slate-400 font-normal">FileBackend 480 ln (backend.go 50 + collection.go 430)</span></div>
@@ -747,6 +749,7 @@ graph TB
         <div class="ml-4 mt-2 text-slate-500">legacy/ <span class="text-slate-400">unchanged</span></div>
         <div class="ml-4 text-green-600">✅ testutil/ <span class="text-slate-400">memory.go 217 ln — in-memory Backend for unit tests</span></div>
         <div class="ml-4 text-slate-500">filedag/ <span class="text-slate-400 font-normal">← untouched leaf implementation; composition roots use file.NewDAGStore, app/engine code receives exec.DAGStore</span></div>
+        <div class="ml-4 text-amber-400">◐ file*/ <span class="text-slate-400 font-normal">← ~17 leaf packages still in use (agent*, audit, eventstore, notification, session, serviceregistry, baseconfig, …), each wrapped by a file/ boundary; ported incrementally, not yet behind Backend</span></div>
       </div>
     </div>
   </div>
@@ -1032,7 +1035,7 @@ graph LR
         <p class="text-sm font-semibold text-green-300 mb-3">✅ Done / preserved</p>
         <ol class="text-sm text-slate-300 space-y-2">
           <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/backend.go</code> — Backend, Collection, Record, ListQuery, Page</li>
-          <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/codec.go</code> — Encode[T], Decode[T]</li>
+          <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/codec.go</code> — Encode(v any) ([]byte, Encoding, error), Decode[T]</li>
           <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/errors.go</code> — ErrNotFound, ErrConflict</li>
           <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/file/</code> — FileBackend + FileCollection (480 ln)</li>
           <li><span class="text-green-400 font-bold">✓</span> <code class="text-xs bg-white/10 px-1 rounded">persis/testutil/memory.go</code> — MemoryBackend (217 ln)</li>


### PR DESCRIPTION
## Summary

Preserve the released (`<= v2.7.4`) on-disk file layout for control-plane stores while continuing the persistence Backend refactor. Aligns CAS identity between the memory test double and the file backend, fixes a heartbeat invisibility that the identity change exposes, locks the file boundary against accidental adapter swaps, and corrects overclaims in the refactor design doc.

Builds on #2217 (release-layout preservation).

## Commits

| Commit | What |
|---|---|
| `41786071d` | Add opt-in `file.WithIndentedJSON()` collection option. Write path uses `json.Indent` over compact Encode output (byte-identical to released `json.MarshalIndent`); read path normalizes to canonical compact `Record.Data` so CAS stays stable. Wire users / API keys / webhooks / secrets. |
| `3df60410c` | Guard test: the file backend must resolve `proc → file/proc` (binary `.proc`) and `agent session → filesession` (nested `{userID}/{sessionID}.json`). Compiler already guards proc; session needs a runtime test because `NewAgentSessionStore` returns the `agent.SessionStore` interface. |
| `3bcc8621f` | Dial back overclaim in `refactor_persis_layer.html`: first wave of stores ported, ~17 still leaf, DAG-run/proc file-specific by design, proto3 reserved-not-implemented, `Encode(any) ([]byte, Encoding, error)`. |
| `0832778af` | Watermark drops adapter-side `json.MarshalIndent`, routes through `WithIndentedJSON`. Single owner of indentation = backend. |
| `e8ec89465` | `sameMemoryRecord` now ID+Encoding+Data only, matching `file/collection.go sameRecord`. Documents `Record.ExpiresAt` as non-authoritative GC/TTL hint, not part of CAS identity. Adds `RevisionNanos` nonce in `procPayload` so every heartbeat changes `Data` (required under Data-only CAS for `RemoveIfStale` to detect concurrent refresh). |
| `efe83b382` | Drop a dead silent-fallback branch in the indented read path (`json.Valid` upstream guarantees `json.Compact` succeeds). |

## On-disk format

**No migration needed.** `json.Indent` over compact `json.Marshal` output is byte-identical to `json.MarshalIndent` of the same value (pinned by `TestFileCollectionIndentedMatchesReleasedFormat`). Existing indented files round-trip via `TestFileCollectionIndentedReadsLegacyIndentedFile`. The full Collection contract runs against the indented backend in `TestFileCollectionIndentedContract`.

## Correctness fix surfaced by the identity change

Before this PR the memory test double compared timestamps; the file backend did not. Adapters using `CompareAndDelete` could pass in tests while behaving differently in production. After alignment, `ProcStore.RemoveIfStale` would race against concurrent heartbeats that touched only `UpdatedAt`. Fix: add a monotonic `RevisionNanos` nonce inside `procPayload` so every heartbeat mutates `Data`. The `exec.ProcEntry.LastHeartbeatAt` seconds contract is unchanged.

## Test coverage

- `internal/persis/file` — three new tests: byte-pin against `MarshalIndent`, legacy-file read, full Collection contract under indent.
- `internal/persis/file/store_guard_test.go` — locks file backend to file-specific stores; would fail if `NewAgentSessionStore` were silently swapped to the collection adapter.
- `internal/persis/store/proc_test.go` — updated to model a real heartbeat (Data change), not a timestamp touch.

## Out of scope (intentional)

- `store.ProcStore` and `store.SessionStore` remain unwired in production — they target future non-file backends and tests. The file backend keeps using `file/proc` and `filesession` (binary `.proc` / nested layout). The guard test pins this.
- ~17 leaf `file*` packages (agent skill, audit, eventstore, …) still live behind their original packages. Incremental.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the released (<= v2.7.4) on-disk layout for control‑plane file stores by adding an indented JSON mode and wiring it for human-readable stores. Aligns CAS identity across backends and fixes a heartbeat race exposed by the alignment.

- **Refactors**
  - Added `file.WithIndentedJSON()` to write 2-space indented JSON; reads normalize to compact JSON to keep `Record.Data` canonical.
  - Wired `users`, `api keys`, `webhooks`, `secrets`, and `scheduler` watermark to `file.NewCollection(..., file.WithIndentedJSON())`.
  - Moved indentation ownership from adapters to the file backend; `schedulerstore.WatermarkStore` now uses `persis.Encode`.
  - Guarded the file boundary: proc uses `file/proc` (binary `.proc`), agent sessions use `filesession` (nested `{userID}/{sessionID}.json`); prevents accidental swaps to collection adapters.
  - Updated docs: corrected codec signature, noted proto3 is reserved, and clarified which stores remain file-specific/unwired.
  - No migration needed; indented bytes match released `json.MarshalIndent`, and reads compact in-memory.

- **Bug Fixes**
  - Unified CAS identity: memory backend now matches file backend (ID + Encoding + Data only). `persis.Record.ExpiresAt` documented as a non-authoritative TTL hint.
  - Fixed proc heartbeat invisibility under Data-only CAS by adding `procPayload.RevisionNanos` so each heartbeat mutates `Data`.
  - Removed a dead fallback in the indented read path (compact is guaranteed after `json.Valid`).

<sup>Written for commit efe83b38280965fd540a50d623f52403e39073ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2218?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal persistence layer with improved JSON file format compatibility and backward compatibility support.
  * Optimized store initialization patterns for enhanced system reliability and maintainability.
  * Expanded test coverage for file storage format handling and data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->