### PR TITLE
refactor(persis/store): backend-neutral distributed stores — replace file lock with CompareAndSwap + Create

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.3"
   NODE_VERSION: "20"
 
 jobs:

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -329,10 +329,11 @@ func NewContext(cmd *cobra.Command, flags []commandLineFlag) (*Context, error) {
 	}
 	drs := file.NewDAGRunStore(cfg, hrOpts...)
 	distributedDir := filepath.Join(cfg.Paths.DataDir, "distributed")
-	// Records live in store-specific subdirectories, but locks stay under the
-	// shared distributed root to preserve mixed-version coordinator exclusion.
-	leaseCollection := file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir)
-	activeRunCollection := file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir)
+	// Lease and active-run stores use CompareAndSwap-based optimistic
+	// concurrency, so plain collections suffice — the previous lockRoot
+	// scoping for file flock is no longer needed.
+	leaseCollection := file.NewCollection(filepath.Join(distributedDir, "leases"))
+	activeRunCollection := file.NewCollection(filepath.Join(distributedDir, "active-runs"))
 	dagRunLeaseStore := store.NewDAGRunLeaseStore(leaseCollection)
 	activeDistributedRunStore := store.NewActiveDistributedRunStore(activeRunCollection)
 	drm := runtime.NewManager(drs, ps, cfg)

--- a/internal/persis/backend.go
+++ b/internal/persis/backend.go
@@ -16,14 +16,6 @@ import (
 	"time"
 )
 
-// Encoding identifies the serialization format of [Record.Data].
-type Encoding string
-
-const (
-	EncodingJSON  Encoding = "json"
-	EncodingProto Encoding = "proto3"
-)
-
 // Record is the universal storage primitive for all control-plane data.
 //
 // ID uses "/" as a hierarchy separator so that a [ListQuery.Prefix] of
@@ -39,17 +31,8 @@ const (
 type Record struct {
 	ID        string
 	Data      []byte
-	Encoding  Encoding
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	// ExpiresAt is an optional, non-authoritative GC/TTL hint: when non-nil it
-	// tells the backend the record MAY be purged after this time. Correctness
-	// must not depend on it — adapters that need real expiry (heartbeats,
-	// leases) keep the authoritative timestamp inside Data. It is also NOT part
-	// of record identity for CompareAndSwap / CompareAndDelete. The file
-	// backend does not persist it; a SQL backend MAY honor it via an
-	// expires_at column and index.
-	ExpiresAt *time.Time
 }
 
 // ListQuery controls what [Collection.List] returns.
@@ -110,11 +93,6 @@ type Collection interface {
 	// bytes equal expected. Returns [ErrConflict] when they do not match.
 	// Used for optimistic concurrency on DAGRunStatus updates.
 	CompareAndSwap(ctx context.Context, id string, expected, next []byte) error
-
-	// Claim atomically removes one record matching q and returns it.
-	// Returns [ErrNotFound] when no matching record exists.
-	// Used exclusively by queue adapters to implement atomic dequeue.
-	Claim(ctx context.Context, q ListQuery) (*Record, error)
 }
 
 // Backend is the factory for storage [Collection]s and the sole interface

--- a/internal/persis/backend.go
+++ b/internal/persis/backend.go
@@ -90,6 +90,11 @@ type Collection interface {
 	// Put creates or replaces a record.
 	Put(ctx context.Context, rec *Record) error
 
+	// Create atomically inserts rec. Returns [ErrConflict] when a record with
+	// rec.ID already exists. Backends must guarantee the check-and-insert is
+	// atomic with respect to concurrent Put, CompareAndSwap, and Create calls.
+	Create(ctx context.Context, rec *Record) error
+
 	// Delete removes the record with the given id.
 	// Returns nil if the record does not exist.
 	Delete(ctx context.Context, id string) error

--- a/internal/persis/codec.go
+++ b/internal/persis/codec.go
@@ -3,27 +3,15 @@
 
 package persis
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "encoding/json"
 
-// Encode marshals v to JSON and returns the bytes and encoding type.
-// Store adapters use this before calling [Collection.Put].
-func Encode(v any) ([]byte, Encoding, error) {
-	data, err := json.Marshal(v)
-	return data, EncodingJSON, err
+// Encode marshals v to JSON. Store adapters use this before [Collection.Put].
+func Encode(v any) ([]byte, error) {
+	return json.Marshal(v)
 }
 
-// Decode unmarshals rec.Data into v according to rec.Encoding.
-// Store adapters use this after receiving a [Record] from [Collection.Get] or [Collection.List].
+// Decode unmarshals rec.Data into v as JSON. Store adapters use this after
+// receiving a [Record] from [Collection.Get] or [Collection.List].
 func Decode[T any](rec *Record, v *T) error {
-	switch rec.Encoding {
-	case EncodingJSON:
-		return json.Unmarshal(rec.Data, v)
-	case EncodingProto:
-		return fmt.Errorf("persis: proto encoding is not supported by this decoder")
-	default:
-		return fmt.Errorf("persis: unsupported encoding %q", rec.Encoding)
-	}
+	return json.Unmarshal(rec.Data, v)
 }

--- a/internal/persis/file/backend.go
+++ b/internal/persis/file/backend.go
@@ -62,15 +62,5 @@ func NewCollection(dir string, opts ...CollectionOption) persis.Collection {
 	return c
 }
 
-// NewCollectionWithLockRoot creates a collection whose records live under dir
-// while its cross-process locks are scoped under lockRoot.
-func NewCollectionWithLockRoot(dir, lockRoot string, opts ...CollectionOption) persis.Collection {
-	c := &Collection{dir: dir, lockRoot: lockRoot}
-	for _, opt := range opts {
-		opt(c)
-	}
-	return c
-}
-
 // Close is a no-op; the file backend holds no persistent resources.
 func (b *Backend) Close() error { return nil }

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -27,8 +27,7 @@ import (
 // "/" in record IDs maps to the OS path separator, so hierarchical IDs
 // become nested subdirectories on disk.
 type Collection struct {
-	dir      string
-	lockRoot string
+	dir string
 	// indent, when true, stores records as 2-space indented JSON on disk to
 	// match the pre-refactor (<= v2.7.4) released file format. Records are
 	// normalized back to compact JSON in memory on read, so Record.Data stays
@@ -43,7 +42,7 @@ func sameRecord(a, b *persis.Record) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return a.ID == b.ID && a.Encoding == b.Encoding && bytes.Equal(a.Data, b.Data)
+	return a.ID == b.ID && bytes.Equal(a.Data, b.Data)
 }
 
 // ─── Collection methods ───────────────────────────────────────────────────────
@@ -86,9 +85,6 @@ func (c *Collection) Create(_ context.Context, rec *persis.Record) error {
 
 	if rec == nil {
 		return fmt.Errorf("file backend: nil record")
-	}
-	if rec.Encoding != "" && rec.Encoding != persis.EncodingJSON {
-		return fmt.Errorf("file backend: unsupported encoding %q", rec.Encoding)
 	}
 	if !json.Valid(rec.Data) {
 		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
@@ -205,24 +201,14 @@ func (c *Collection) RecordVersion(_ context.Context, id string) (string, error)
 
 // WithLock runs fn while holding a cross-process lock scoped to key.
 func (c *Collection) WithLock(ctx context.Context, key string, fn func() error) error {
-	return c.withLock(ctx, key, dirlock.LockOptions{
-		StaleThreshold: 30 * time.Second,
-		RetryInterval:  50 * time.Millisecond,
-	}, fn)
-}
-
-// WithLockOptions runs fn while holding a cross-process lock scoped to key,
-// using the supplied lock timing options.
-func (c *Collection) WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error {
-	return c.withLock(ctx, key, opts, fn)
-}
-
-func (c *Collection) withLock(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error {
 	lockDir, err := c.lockDir(key)
 	if err != nil {
 		return err
 	}
-	lock := dirlock.New(lockDir, &opts)
+	lock := dirlock.New(lockDir, &dirlock.LockOptions{
+		StaleThreshold: 30 * time.Second,
+		RetryInterval:  50 * time.Millisecond,
+	})
 	if err := lock.Lock(ctx); err != nil {
 		return err
 	}
@@ -306,49 +292,6 @@ func (c *Collection) CompareAndSwap(_ context.Context, id string, expected, next
 	return c.writeFile(path, rec)
 }
 
-// Claim atomically dequeues one record matching q.
-// Records are ordered by filename (natural sort), so queue adapters control
-// priority by encoding it at the start of the ID (e.g., "high_<uuid>").
-func (c *Collection) Claim(_ context.Context, q persis.ListQuery) (*persis.Record, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	walkRoot := c.prefixWalkRoot(q.Prefix)
-
-	var candidates []string
-	_ = filepath.WalkDir(walkRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".json") {
-			return err
-		}
-		rel, _ := filepath.Rel(c.dir, path)
-		if q.Prefix != "" && !strings.HasPrefix(relPathToID(rel), q.Prefix) {
-			return nil
-		}
-		candidates = append(candidates, path)
-		return nil
-	})
-	sort.Strings(candidates)
-
-	for _, path := range candidates {
-		rec, err := c.readFile(path)
-		if err != nil {
-			if !errors.Is(err, persis.ErrNotFound) {
-				return nil, err
-			}
-			continue
-		}
-		if err := fileutil.Remove(path); err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return nil, err
-			}
-			continue
-		}
-		removeEmptyDirs(filepath.Dir(path), c.dir)
-		return rec, nil
-	}
-	return nil, persis.ErrNotFound
-}
-
 // ─── internal helpers ─────────────────────────────────────────────────────────
 
 func (c *Collection) filePath(id string) (string, error) {
@@ -356,14 +299,10 @@ func (c *Collection) filePath(id string) (string, error) {
 }
 
 func (c *Collection) lockDir(key string) (string, error) {
-	root := c.dir
-	if c.lockRoot != "" {
-		root = c.lockRoot
-	}
 	if key == "" {
-		return root, nil
+		return c.dir, nil
 	}
-	path, err := pathUnderRoot(root, strings.TrimSuffix(key, "/")+"/_lock", "lock key")
+	path, err := pathUnderRoot(c.dir, strings.TrimSuffix(key, "/")+"/_lock", "lock key")
 	if err != nil {
 		return "", err
 	}
@@ -415,7 +354,6 @@ func (c *Collection) readFile(path string) (*persis.Record, error) {
 	return &persis.Record{
 		ID:        relPathToID(rel),
 		Data:      data,
-		Encoding:  persis.EncodingJSON,
 		CreatedAt: mtime,
 		UpdatedAt: mtime,
 	}, nil
@@ -424,9 +362,6 @@ func (c *Collection) readFile(path string) (*persis.Record, error) {
 func (c *Collection) writeFile(path string, rec *persis.Record) error {
 	if rec == nil {
 		return fmt.Errorf("file backend: nil record")
-	}
-	if rec.Encoding != "" && rec.Encoding != persis.EncodingJSON {
-		return fmt.Errorf("file backend: unsupported encoding %q", rec.Encoding)
 	}
 	if !json.Valid(rec.Data) {
 		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -77,10 +77,9 @@ func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
 	return c.writeFile(path, rec)
 }
 
-// Create atomically inserts rec. Returns [persis.ErrConflict] when a record
-// with rec.ID already exists. Uses O_EXCL|O_CREATE so the check-and-insert
-// is atomic across processes; [fileutil.WriteFileAtomic] cannot be used here
-// because its rename step is unconditional and would silently replace.
+// Create atomically inserts rec. Returns [persis.ErrConflict] when a
+// record with rec.ID already exists. Uses O_EXCL|O_CREATE for atomic
+// cross-process insert.
 func (c *Collection) Create(_ context.Context, rec *persis.Record) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -77,6 +77,69 @@ func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
 	return c.writeFile(path, rec)
 }
 
+// Create atomically inserts rec. Returns [persis.ErrConflict] when a record
+// with rec.ID already exists. Uses O_EXCL|O_CREATE so the check-and-insert
+// is atomic across processes; [fileutil.WriteFileAtomic] cannot be used here
+// because its rename step is unconditional and would silently replace.
+func (c *Collection) Create(_ context.Context, rec *persis.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if rec == nil {
+		return fmt.Errorf("file backend: nil record")
+	}
+	if rec.Encoding != "" && rec.Encoding != persis.EncodingJSON {
+		return fmt.Errorf("file backend: unsupported encoding %q", rec.Encoding)
+	}
+	if !json.Valid(rec.Data) {
+		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
+	}
+	path, err := c.filePath(rec.ID)
+	if err != nil {
+		return err
+	}
+	body := rec.Data
+	if c.indent {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, rec.Data, "", "  "); err != nil {
+			return fmt.Errorf("file backend: indent record %q: %w", rec.ID, err)
+		}
+		body = buf.Bytes()
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // path is sanitized via c.filePath -> pathUnderRoot
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return persis.ErrConflict
+		}
+		return err
+	}
+	if _, err := f.Write(body); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	mtime := rec.UpdatedAt
+	if mtime.IsZero() {
+		mtime = rec.CreatedAt
+	}
+	if mtime.IsZero() {
+		return nil
+	}
+	return os.Chtimes(path, mtime, mtime)
+}
+
 func (c *Collection) Delete(ctx context.Context, id string) error {
 	_, err := c.DeleteIfExists(ctx, id)
 	return err

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -512,9 +512,7 @@ func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 	)
 	start := make(chan struct{})
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			err := col.Create(ctx, &persis.Record{
 				ID:        "shared",
@@ -531,7 +529,7 @@ func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 			default:
 				atomic.AddInt64(&other, 1)
 			}
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dagucloud/dagu/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/internal/persis"
 	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
@@ -38,7 +37,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "alpha",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -48,14 +46,12 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		require.NoError(t, err)
 		assert.Equal(t, rec.ID, got.ID)
 		assert.Equal(t, rec.Data, got.Data)
-		assert.Equal(t, rec.Encoding, got.Encoding)
 	})
 
 	t.Run("put_overwrites", func(t *testing.T) {
 		rec := &persis.Record{
 			ID:        "beta",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -74,7 +70,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "create-new",
 			Data:      []byte(`{"n":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -90,7 +85,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "create-dup",
 			Data:      []byte(`{"n":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -112,7 +106,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "create-recycled",
 			Data:      []byte(`{"n":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -132,7 +125,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "gamma",
 			Data:      []byte(`{}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -152,7 +144,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "cad-ok",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -170,7 +161,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "cad-conflict",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -193,9 +183,9 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		t2 := now.Add(2 * time.Millisecond)
 		t3 := now.Add(3 * time.Millisecond)
 		for _, r := range []*persis.Record{
-			{ID: "x/a", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t2, UpdatedAt: t2},
-			{ID: "x/b", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t1, UpdatedAt: t1},
-			{ID: "y/c", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t3, UpdatedAt: t3},
+			{ID: "x/a", Data: []byte(`{}`), CreatedAt: t2, UpdatedAt: t2},
+			{ID: "x/b", Data: []byte(`{}`), CreatedAt: t1, UpdatedAt: t1},
+			{ID: "y/c", Data: []byte(`{}`), CreatedAt: t3, UpdatedAt: t3},
 		} {
 			require.NoError(t, col2.Put(ctx, r))
 		}
@@ -213,9 +203,9 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		t1 := now.Add(time.Millisecond)
 		t2 := now.Add(2 * time.Millisecond)
 		for _, r := range []*persis.Record{
-			{ID: "dag1/run1", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t1, UpdatedAt: t1},
-			{ID: "dag1/run2", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t2, UpdatedAt: t2},
-			{ID: "dag2/run1", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t1, UpdatedAt: t1},
+			{ID: "dag1/run1", Data: []byte(`{}`), CreatedAt: t1, UpdatedAt: t1},
+			{ID: "dag1/run2", Data: []byte(`{}`), CreatedAt: t2, UpdatedAt: t2},
+			{ID: "dag2/run1", Data: []byte(`{}`), CreatedAt: t1, UpdatedAt: t1},
 		} {
 			require.NoError(t, col2.Put(ctx, r))
 		}
@@ -232,9 +222,9 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		t2 := now.Add(2 * time.Millisecond)
 		t3 := now.Add(3 * time.Millisecond)
 		for _, r := range []*persis.Record{
-			{ID: "r1", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t1, UpdatedAt: t1},
-			{ID: "r2", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t2, UpdatedAt: t2},
-			{ID: "r3", Data: []byte(`{}`), Encoding: persis.EncodingJSON, CreatedAt: t3, UpdatedAt: t3},
+			{ID: "r1", Data: []byte(`{}`), CreatedAt: t1, UpdatedAt: t1},
+			{ID: "r2", Data: []byte(`{}`), CreatedAt: t2, UpdatedAt: t2},
+			{ID: "r3", Data: []byte(`{}`), CreatedAt: t3, UpdatedAt: t3},
 		} {
 			require.NoError(t, col2.Put(ctx, r))
 		}
@@ -253,7 +243,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 			r := &persis.Record{
 				ID:        []string{"p0", "p1", "p2", "p3", "p4"}[i],
 				Data:      []byte(`{}`),
-				Encoding:  persis.EncodingJSON,
 				CreatedAt: ts,
 				UpdatedAt: ts,
 			}
@@ -286,7 +275,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "cas-ok",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -303,7 +291,6 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		rec := &persis.Record{
 			ID:        "cas-conflict",
 			Data:      []byte(`{"v":1}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
@@ -312,42 +299,12 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		assert.ErrorIs(t, err, persis.ErrConflict)
 	})
 
-	t.Run("claim", func(t *testing.T) {
-		col2 := freshCollection(t)
-		t1 := now.Add(time.Millisecond)
-		t2 := now.Add(2 * time.Millisecond)
-		for _, r := range []*persis.Record{
-			{ID: "q/high_001", Data: []byte(`{"n":1}`), Encoding: persis.EncodingJSON, CreatedAt: t1, UpdatedAt: t1},
-			{ID: "q/high_002", Data: []byte(`{"n":2}`), Encoding: persis.EncodingJSON, CreatedAt: t2, UpdatedAt: t2},
-		} {
-			require.NoError(t, col2.Put(ctx, r))
-		}
-
-		claimed, err := col2.Claim(ctx, persis.ListQuery{Prefix: "q/"})
-		require.NoError(t, err)
-		assert.Equal(t, "q/high_001", claimed.ID)
-
-		// verify it's gone
-		_, err = col2.Get(ctx, "q/high_001")
-		assert.ErrorIs(t, err, persis.ErrNotFound)
-
-		// second claim gets next
-		claimed2, err := col2.Claim(ctx, persis.ListQuery{Prefix: "q/"})
-		require.NoError(t, err)
-		assert.Equal(t, "q/high_002", claimed2.ID)
-
-		// nothing left
-		_, err = col2.Claim(ctx, persis.ListQuery{Prefix: "q/"})
-		assert.ErrorIs(t, err, persis.ErrNotFound)
-	})
-
 	t.Run("hierarchical_ids", func(t *testing.T) {
 		col2 := freshCollection(t)
 		t1 := now.Add(time.Millisecond)
 		rec := &persis.Record{
 			ID:        "dag/run-1/attempt-0",
 			Data:      []byte(`{"status":"ok"}`),
-			Encoding:  persis.EncodingJSON,
 			CreatedAt: t1,
 			UpdatedAt: t1,
 		}
@@ -389,7 +346,6 @@ func TestFileCollectionWritesRawJSONBody(t *testing.T) {
 	rec := &persis.Record{
 		ID:        "users/user-1",
 		Data:      raw,
-		Encoding:  persis.EncodingJSON,
 		CreatedAt: time.Now().UTC(),
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -409,7 +365,6 @@ func TestFileCollectionWritesRawJSONBody(t *testing.T) {
 	got, err := col.Get(ctx, "users/user-1")
 	require.NoError(t, err)
 	assert.Equal(t, raw, got.Data)
-	assert.Equal(t, persis.EncodingJSON, got.Encoding)
 }
 
 // TestFileCollectionIndentedMatchesReleasedFormat pins the on-disk bytes of an
@@ -434,7 +389,6 @@ func TestFileCollectionIndentedMatchesReleasedFormat(t *testing.T) {
 	rec := &persis.Record{
 		ID:        "users/u1",
 		Data:      compact,
-		Encoding:  persis.EncodingJSON,
 		CreatedAt: time.Now().UTC(),
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -517,7 +471,6 @@ func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 			err := col.Create(ctx, &persis.Record{
 				ID:        "shared",
 				Data:      []byte(`{}`),
-				Encoding:  persis.EncodingJSON,
 				CreatedAt: time.Now().UTC(),
 				UpdatedAt: time.Now().UTC(),
 			})
@@ -537,90 +490,6 @@ func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 	assert.Equal(t, int64(1), successes, "exactly one Create must win")
 	assert.Equal(t, int64(goroutines-1), conflicts, "all losers must see ErrConflict")
 	assert.Equal(t, int64(0), other, "no other error class is acceptable")
-}
-
-func TestFileCollectionWithLockOptionsUsesCustomTiming(t *testing.T) {
-	t.Parallel()
-
-	type lockOptionsCollection interface {
-		WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error
-	}
-
-	col, ok := file.NewCollection(t.TempDir()).(lockOptionsCollection)
-	require.True(t, ok)
-
-	ctx := context.Background()
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	firstErr := make(chan error, 1)
-	go func() {
-		firstErr <- col.WithLockOptions(ctx, "shared", dirlock.LockOptions{
-			StaleThreshold: time.Hour,
-			RetryInterval:  time.Millisecond,
-		}, func() error {
-			close(entered)
-			<-release
-			return nil
-		})
-	}()
-	<-entered
-
-	stealCtx, cancelSteal := context.WithTimeout(ctx, time.Second)
-	defer cancelSteal()
-	require.NoError(t, col.WithLockOptions(stealCtx, "shared", dirlock.LockOptions{
-		StaleThreshold: 20 * time.Millisecond,
-		RetryInterval:  5 * time.Millisecond,
-	}, func() error {
-		return nil
-	}))
-
-	close(release)
-	require.NoError(t, <-firstErr)
-}
-
-func TestFileCollectionWithLockRootScopesLocksOutsideCollection(t *testing.T) {
-	t.Parallel()
-
-	type lockOptionsCollection interface {
-		WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error
-	}
-
-	root := filepath.Join(t.TempDir(), "distributed")
-	collectionDir := filepath.Join(root, "leases")
-	col, ok := file.NewCollectionWithLockRoot(collectionDir, root).(lockOptionsCollection)
-	require.True(t, ok)
-
-	require.NoError(t, col.WithLockOptions(context.Background(), "locks/shared", dirlock.LockOptions{
-		StaleThreshold: time.Hour,
-		RetryInterval:  time.Millisecond,
-	}, func() error {
-		_, err := os.Stat(filepath.Join(root, "locks", "shared", ".dagu_lock"))
-		require.NoError(t, err)
-
-		_, err = os.Stat(filepath.Join(collectionDir, "locks", "shared", ".dagu_lock"))
-		require.ErrorIs(t, err, os.ErrNotExist)
-		return nil
-	}))
-}
-
-func TestMemoryCollectionWithLockOptionsClampsNonPositiveRetryInterval(t *testing.T) {
-	t.Parallel()
-
-	type lockOptionsCollection interface {
-		WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error
-	}
-
-	col, ok := testutil.NewMemoryBackend().Collection("test").(lockOptionsCollection)
-	require.True(t, ok)
-
-	require.NotPanics(t, func() {
-		err := col.WithLockOptions(context.Background(), "shared", dirlock.LockOptions{
-			RetryInterval: -time.Millisecond,
-		}, func() error {
-			return nil
-		})
-		require.NoError(t, err)
-	})
 }
 
 func TestMemoryCollection(t *testing.T) {

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,6 +67,65 @@ func RunCollectionContract(t *testing.T, col persis.Collection, freshCollection 
 		got, err := col.Get(ctx, "beta")
 		require.NoError(t, err)
 		assert.Equal(t, []byte(`{"v":2}`), got.Data)
+	})
+
+	t.Run("create_inserts_new_record", func(t *testing.T) {
+		col2 := freshCollection(t)
+		rec := &persis.Record{
+			ID:        "create-new",
+			Data:      []byte(`{"n":1}`),
+			Encoding:  persis.EncodingJSON,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		require.NoError(t, col2.Create(ctx, rec))
+
+		got, err := col2.Get(ctx, "create-new")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"n":1}`), got.Data)
+	})
+
+	t.Run("create_returns_conflict_when_present", func(t *testing.T) {
+		col2 := freshCollection(t)
+		rec := &persis.Record{
+			ID:        "create-dup",
+			Data:      []byte(`{"n":1}`),
+			Encoding:  persis.EncodingJSON,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		require.NoError(t, col2.Create(ctx, rec))
+
+		dup := *rec
+		dup.Data = []byte(`{"n":2}`)
+		err := col2.Create(ctx, &dup)
+		assert.ErrorIs(t, err, persis.ErrConflict)
+
+		// Original record is unchanged.
+		got, err := col2.Get(ctx, "create-dup")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"n":1}`), got.Data)
+	})
+
+	t.Run("create_after_delete_succeeds", func(t *testing.T) {
+		col2 := freshCollection(t)
+		rec := &persis.Record{
+			ID:        "create-recycled",
+			Data:      []byte(`{"n":1}`),
+			Encoding:  persis.EncodingJSON,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		require.NoError(t, col2.Create(ctx, rec))
+		require.NoError(t, col2.Delete(ctx, "create-recycled"))
+
+		fresh := *rec
+		fresh.Data = []byte(`{"n":2}`)
+		require.NoError(t, col2.Create(ctx, &fresh))
+
+		got, err := col2.Get(ctx, "create-recycled")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"n":2}`), got.Data)
 	})
 
 	t.Run("delete", func(t *testing.T) {
@@ -431,6 +492,53 @@ func TestFileCollectionPutNilReturnsError(t *testing.T) {
 	col := file.NewCollection(t.TempDir())
 	err := col.Put(context.Background(), nil)
 	require.ErrorContains(t, err, "nil record")
+}
+
+// TestFileCollectionCreateIsAtomicAcrossGoroutines races 16 goroutines on the
+// same ID and asserts that exactly one Create succeeds and the rest see
+// ErrConflict. Exercises the O_EXCL guarantee against in-process concurrency.
+func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	col := file.NewCollection(t.TempDir())
+
+	const goroutines = 16
+	var (
+		wg        sync.WaitGroup
+		successes int64
+		conflicts int64
+		other     int64
+	)
+	start := make(chan struct{})
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := col.Create(ctx, &persis.Record{
+				ID:        "shared",
+				Data:      []byte(`{}`),
+				Encoding:  persis.EncodingJSON,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			})
+			switch err {
+			case nil:
+				atomic.AddInt64(&successes, 1)
+			case persis.ErrConflict:
+				atomic.AddInt64(&conflicts, 1)
+			default:
+				atomic.AddInt64(&other, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), successes, "exactly one Create must win")
+	assert.Equal(t, int64(goroutines-1), conflicts, "all losers must see ErrConflict")
+	assert.Equal(t, int64(0), other, "no other error class is acceptable")
 }
 
 func TestFileCollectionWithLockOptionsUsesCustomTiming(t *testing.T) {

--- a/internal/persis/schedulerstore/watermark.go
+++ b/internal/persis/schedulerstore/watermark.go
@@ -72,7 +72,7 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if state == nil {
 		return fmt.Errorf("watermark store: state is nil")
 	}
-	data, enc, err := persis.Encode(state)
+	data, err := persis.Encode(state)
 	if err != nil {
 		return fmt.Errorf("watermark store: encode: %w", err)
 	}
@@ -80,7 +80,6 @@ func (s *WatermarkStore) Save(ctx context.Context, state *scheduler.SchedulerSta
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        watermarkStateID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}); err != nil {

--- a/internal/persis/schedulerstore/watermark_test.go
+++ b/internal/persis/schedulerstore/watermark_test.go
@@ -127,7 +127,6 @@ func TestLoad_MigratesLegacyVersions(t *testing.T) {
 			require.NoError(t, col.Put(ctx, &persis.Record{
 				ID:        "state",
 				Data:      rawJSON,
-				Encoding:  persis.EncodingJSON,
 				CreatedAt: now,
 				UpdatedAt: now,
 			}))
@@ -150,7 +149,6 @@ func TestLoad_UnknownVersionFallsBackToEmpty(t *testing.T) {
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        "state",
 		Data:      rawJSON,
-		Encoding:  persis.EncodingJSON,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}))
@@ -170,7 +168,6 @@ func TestLoad_CorruptDataFallsBackToEmpty(t *testing.T) {
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        "state",
 		Data:      []byte(`not valid json {{`),
-		Encoding:  persis.EncodingJSON,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}))

--- a/internal/persis/store/apikey.go
+++ b/internal/persis/store/apikey.go
@@ -69,7 +69,7 @@ func (s *APIKeyStore) Create(ctx context.Context, key *auth.APIKey) error {
 		return auth.ErrInvalidAPIKeyName
 	}
 
-	data, enc, err := persis.Encode(key.ToStorage())
+	data, err := persis.Encode(key.ToStorage())
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,6 @@ func (s *APIKeyStore) Create(ctx context.Context, key *auth.APIKey) error {
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        key.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: key.CreatedAt,
 		UpdatedAt: key.UpdatedAt,
 	}); err != nil {
@@ -157,7 +156,7 @@ func (s *APIKeyStore) Update(ctx context.Context, key *auth.APIKey) error {
 		return fmt.Errorf("apikey store: decode existing: %w", err)
 	}
 
-	data, enc, err := persis.Encode(key.ToStorage())
+	data, err := persis.Encode(key.ToStorage())
 	if err != nil {
 		return err
 	}
@@ -170,7 +169,6 @@ func (s *APIKeyStore) Update(ctx context.Context, key *auth.APIKey) error {
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        key.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: existingRec.CreatedAt,
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {
@@ -232,14 +230,13 @@ func (s *APIKeyStore) UpdateLastUsed(ctx context.Context, id string) error {
 	}
 	now := time.Now().UTC()
 	stored.LastUsedAt = &now
-	data, enc, err := persis.Encode(stored)
+	data, err := persis.Encode(stored)
 	if err != nil {
 		return err
 	}
 	return s.col.Put(ctx, &persis.Record{
 		ID:        rec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: now,
 	})

--- a/internal/persis/store/cas_retry.go
+++ b/internal/persis/store/cas_retry.go
@@ -13,31 +13,16 @@ import (
 )
 
 const (
-	// casRetryInitialBackoff matches the previous distributed-lock retry
-	// interval so a CAS-retry under contention has the same baseline latency
-	// as the lock-wait it replaces.
 	casRetryInitialBackoff = 5 * time.Millisecond
-
-	// casRetryMaxBackoff caps the per-attempt jittered sleep. It mirrors the
-	// previous distributedLockStaleThreshold, so a single op cannot starve
-	// the caller longer than the lock-acquisition deadline did before.
-	casRetryMaxBackoff = 5 * time.Second
+	casRetryMaxBackoff     = 5 * time.Second
 )
 
-// retryCAS runs op until success, ctx cancellation, or op returns an error
-// that is not [persis.ErrConflict]. Conflicts trigger an exponential
-// full-jitter backoff (sleep uniformly in [0, backoff)) and double the bound
-// up to casRetryMaxBackoff. Total time is bounded by ctx, not by an attempt
-// count — callers control the deadline.
-//
-// Only persis.ErrConflict is treated as retryable. Any other error
-// (including persis.ErrNotFound from CompareAndSwap on a deleted record)
-// propagates immediately so callers can translate it to their domain error.
+// retryCAS runs op with exponential full-jitter backoff while op returns
+// [persis.ErrConflict]. Any other error (including ErrNotFound) propagates.
+// Total time is bounded by ctx.
 func retryCAS(ctx context.Context, op func(ctx context.Context) error) error {
 	backoff := casRetryInitialBackoff
 	for {
-		// Guard before invoking op so a pre-cancelled context never causes
-		// an extra Get/Create/CompareAndSwap round-trip.
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -49,8 +34,6 @@ func retryCAS(ctx context.Context, op func(ctx context.Context) error) error {
 			return err
 		}
 
-		// Full jitter: sleep in [0, backoff). math/rand/v2 is intentional —
-		// retry spread is not a security context.
 		sleep := time.Duration(rand.Int64N(int64(backoff))) //nolint:gosec // jitter, not cryptographic
 		timer := time.NewTimer(sleep)
 		select {

--- a/internal/persis/store/cas_retry.go
+++ b/internal/persis/store/cas_retry.go
@@ -36,6 +36,11 @@ const (
 func retryCAS(ctx context.Context, op func(ctx context.Context) error) error {
 	backoff := casRetryInitialBackoff
 	for {
+		// Guard before invoking op so a pre-cancelled context never causes
+		// an extra Get/Create/CompareAndSwap round-trip.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		err := op(ctx)
 		if err == nil {
 			return nil

--- a/internal/persis/store/cas_retry.go
+++ b/internal/persis/store/cas_retry.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/persis"
+)
+
+const (
+	// casRetryInitialBackoff matches the previous distributed-lock retry
+	// interval so a CAS-retry under contention has the same baseline latency
+	// as the lock-wait it replaces.
+	casRetryInitialBackoff = 5 * time.Millisecond
+
+	// casRetryMaxBackoff caps the per-attempt jittered sleep. It mirrors the
+	// previous distributedLockStaleThreshold, so a single op cannot starve
+	// the caller longer than the lock-acquisition deadline did before.
+	casRetryMaxBackoff = 5 * time.Second
+)
+
+// retryCAS runs op until success, ctx cancellation, or op returns an error
+// that is not [persis.ErrConflict]. Conflicts trigger an exponential
+// full-jitter backoff (sleep uniformly in [0, backoff)) and double the bound
+// up to casRetryMaxBackoff. Total time is bounded by ctx, not by an attempt
+// count — callers control the deadline.
+//
+// Only persis.ErrConflict is treated as retryable. Any other error
+// (including persis.ErrNotFound from CompareAndSwap on a deleted record)
+// propagates immediately so callers can translate it to their domain error.
+func retryCAS(ctx context.Context, op func(ctx context.Context) error) error {
+	backoff := casRetryInitialBackoff
+	for {
+		err := op(ctx)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, persis.ErrConflict) {
+			return err
+		}
+
+		// Full jitter: sleep in [0, backoff). math/rand/v2 is intentional —
+		// retry spread is not a security context.
+		sleep := time.Duration(rand.Int64N(int64(backoff))) //nolint:gosec // jitter, not cryptographic
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		if backoff < casRetryMaxBackoff {
+			backoff *= 2
+			if backoff > casRetryMaxBackoff {
+				backoff = casRetryMaxBackoff
+			}
+		}
+	}
+}

--- a/internal/persis/store/cas_retry.go
+++ b/internal/persis/store/cas_retry.go
@@ -43,11 +43,6 @@ func retryCAS(ctx context.Context, op func(ctx context.Context) error) error {
 		case <-timer.C:
 		}
 
-		if backoff < casRetryMaxBackoff {
-			backoff *= 2
-			if backoff > casRetryMaxBackoff {
-				backoff = casRetryMaxBackoff
-			}
-		}
+		backoff = min(backoff*2, casRetryMaxBackoff)
 	}
 }

--- a/internal/persis/store/dagstate.go
+++ b/internal/persis/store/dagstate.go
@@ -218,14 +218,13 @@ func (s *DAGStateStore) withRecordLock(ctx context.Context, id string, fn func()
 }
 
 func (s *DAGStateStore) putEntry(ctx context.Context, id string, entry *dagstate.Entry, createdAt, updatedAt time.Time) error {
-	data, enc, err := persis.Encode(entry)
+	data, err := persis.Encode(entry)
 	if err != nil {
 		return err
 	}
 	return mapDAGStateStoreError(s.col.Put(ctx, &persis.Record{
 		ID:        id,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 	}))

--- a/internal/persis/store/dagstate_test.go
+++ b/internal/persis/store/dagstate_test.go
@@ -255,9 +255,9 @@ func newCountingRecordIDCollection(t *testing.T, ids []string) *countingRecordID
 			Value:   rawJSON(t, `1`),
 			Version: 1,
 		}
-		data, enc, err := persis.Encode(entry)
+		data, err := persis.Encode(entry)
 		require.NoError(t, err)
-		records[id] = &persis.Record{ID: id, Data: data, Encoding: enc}
+		records[id] = &persis.Record{ID: id, Data: data}
 	}
 	return &countingRecordIDCollection{ids: append([]string(nil), ids...), records: records}
 }
@@ -306,8 +306,4 @@ func (c *countingRecordIDCollection) List(context.Context, persis.ListQuery) (*p
 
 func (c *countingRecordIDCollection) CompareAndSwap(context.Context, string, []byte, []byte) error {
 	return nil
-}
-
-func (c *countingRecordIDCollection) Claim(context.Context, persis.ListQuery) (*persis.Record, error) {
-	return nil, persis.ErrNotFound
 }

--- a/internal/persis/store/dagstate_test.go
+++ b/internal/persis/store/dagstate_test.go
@@ -287,6 +287,10 @@ func (c *countingRecordIDCollection) Put(context.Context, *persis.Record) error 
 	return nil
 }
 
+func (c *countingRecordIDCollection) Create(context.Context, *persis.Record) error {
+	return nil
+}
+
 func (c *countingRecordIDCollection) Delete(context.Context, string) error {
 	return nil
 }

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -30,15 +30,42 @@ func NewActiveDistributedRunStore(col persis.Collection) *ActiveDistributedRunSt
 	return &ActiveDistributedRunStore{col: col}
 }
 
+// Upsert writes the active-run record. Uses optimistic concurrency:
+// Get → Create if absent / CompareAndSwap if present, retrying on conflict.
 func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.ActiveDistributedRun) error {
 	if record.AttemptKey == "" {
 		return fmt.Errorf("attempt key is required")
 	}
+	id := distributedRecordKey(record.AttemptKey)
 
-	return s.withActiveRunLock(ctx, record.AttemptKey, func() error {
+	return retryCAS(ctx, func(ctx context.Context) error {
 		now := time.Now().UTC()
 		record.UpdatedAt = now.UnixMilli()
-		return s.putActiveRun(ctx, record, now)
+
+		existing, getErr := s.col.Get(ctx, id)
+		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
+			return getErr
+		}
+
+		data, enc, err := persis.Encode(record)
+		if err != nil {
+			return err
+		}
+
+		if existing == nil {
+			return s.col.Create(ctx, &persis.Record{
+				ID:        id,
+				Data:      data,
+				Encoding:  enc,
+				CreatedAt: now,
+				UpdatedAt: now,
+			})
+		}
+		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, data)
+		if errors.Is(casErr, persis.ErrNotFound) {
+			return persis.ErrConflict
+		}
+		return casErr
 	})
 }
 
@@ -46,12 +73,10 @@ func (s *ActiveDistributedRunStore) Delete(ctx context.Context, attemptKey strin
 	if attemptKey == "" {
 		return nil
 	}
-	return s.withActiveRunLock(ctx, attemptKey, func() error {
-		if err := s.col.Delete(ctx, distributedRecordKey(attemptKey)); err != nil && !errors.Is(err, persis.ErrNotFound) {
-			return err
-		}
-		return nil
-	})
+	if err := s.col.Delete(ctx, distributedRecordKey(attemptKey)); err != nil && !errors.Is(err, persis.ErrNotFound) {
+		return err
+	}
+	return nil
 }
 
 func (s *ActiveDistributedRunStore) Get(ctx context.Context, attemptKey string) (*exec.ActiveDistributedRun, error) {
@@ -100,27 +125,3 @@ func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveD
 	return records, nil
 }
 
-func (s *ActiveDistributedRunStore) putActiveRun(ctx context.Context, record exec.ActiveDistributedRun, updatedAt time.Time) error {
-	id := distributedRecordKey(record.AttemptKey)
-	createdAt := updatedAt
-	if existing, err := s.col.Get(ctx, id); err == nil && !existing.CreatedAt.IsZero() {
-		createdAt = existing.CreatedAt
-	} else if err != nil && !errors.Is(err, persis.ErrNotFound) {
-		return err
-	}
-	data, enc, err := persis.Encode(record)
-	if err != nil {
-		return err
-	}
-	return s.col.Put(ctx, &persis.Record{
-		ID:        id,
-		Data:      data,
-		Encoding:  enc,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
-	})
-}
-
-func (s *ActiveDistributedRunStore) withActiveRunLock(ctx context.Context, attemptKey string, fn func() error) error {
-	return withDistributedCollectionLock(ctx, s.col, distributedActiveRunLockKey(attemptKey), fn)
-}

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -124,4 +124,3 @@ func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveD
 	})
 	return records, nil
 }
-

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -47,7 +47,7 @@ func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.Acti
 			return getErr
 		}
 
-		data, enc, err := persis.Encode(record)
+		data, err := persis.Encode(record)
 		if err != nil {
 			return err
 		}
@@ -56,7 +56,6 @@ func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.Acti
 			return s.col.Create(ctx, &persis.Record{
 				ID:        id,
 				Data:      data,
-				Encoding:  enc,
 				CreatedAt: now,
 				UpdatedAt: now,
 			})

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -30,8 +30,8 @@ func NewActiveDistributedRunStore(col persis.Collection) *ActiveDistributedRunSt
 	return &ActiveDistributedRunStore{col: col}
 }
 
-// Upsert writes the active-run record. Uses optimistic concurrency:
-// Get → Create if absent / CompareAndSwap if present, retrying on conflict.
+// Upsert writes the active-run record. Get → Create if absent /
+// CompareAndSwap if present, retrying on conflict.
 func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.ActiveDistributedRun) error {
 	if record.AttemptKey == "" {
 		return fmt.Errorf("attempt key is required")

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -427,14 +427,13 @@ func (s *DispatchTaskStore) putDispatchRecord(ctx context.Context, id string, pa
 }
 
 func (s *DispatchTaskStore) newDispatchRecord(id string, payload dispatchTaskPayload, createdAt, updatedAt time.Time) (*persis.Record, error) {
-	data, enc, err := persis.Encode(payload)
+	data, err := persis.Encode(payload)
 	if err != nil {
 		return nil, err
 	}
 	return &persis.Record{
 		ID:        id,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 	}, nil

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,7 +41,6 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 type DispatchTaskStore struct {
 	col            persis.Collection
 	reservationTTL time.Duration
-	mu             sync.Mutex
 }
 
 type dispatchTaskPayload struct {
@@ -97,70 +95,67 @@ func (s *DispatchTaskStore) Enqueue(ctx context.Context, task *coordinatorv1.Tas
 	return s.putDispatchRecord(ctx, pendingID, payload, enqueuedAt, enqueuedAt)
 }
 
+// ClaimNext atomically transitions one matching pending record into a claim.
+// The coarse file-lock that previously serialized this method has been
+// removed: CompareAndDelete(pending) is the per-task atomicity point —
+// concurrent pollers racing on the same pending record see one winner and
+// the losers clean up their orphan claim and continue to the next pending.
 func (s *DispatchTaskStore) ClaimNext(ctx context.Context, claim exec.DispatchTaskClaim) (*exec.ClaimedDispatchTask, error) {
-	var claimed *exec.ClaimedDispatchTask
-	err := s.withDispatchLock(ctx, func() error {
-		if err := s.recycleExpiredReservationsLocked(ctx); err != nil {
-			return err
-		}
+	if err := s.recycleExpiredReservations(ctx); err != nil {
+		return nil, err
+	}
 
-		recs, err := s.listDispatchRecords(ctx, dispatchPendingPrefix)
-		if err != nil {
-			return err
-		}
-		for _, rec := range recs {
-			payload, err := dispatchTaskPayloadFromRecord(rec)
-			if err != nil {
-				return err
-			}
-			if payload.Task == nil || !matchesDispatchSelector(claim.Labels, payload.Task.WorkerSelector) {
-				continue
-			}
-
-			claimToken := uuid.NewString()
-			claimedAt := time.Now().UTC()
-			task, err := applyDispatchTaskClaim(payload.Task, claim.Owner, claimToken)
-			if err != nil {
-				return err
-			}
-			payload.Task = task
-			payload.ClaimToken = claimToken
-			payload.ClaimedAt = claimedAt.UnixMilli()
-			payload.WorkerID = claim.WorkerID
-			payload.PollerID = claim.PollerID
-			payload.Owner = claim.Owner
-
-			claimRec, err := s.newDispatchRecord(claimDispatchRecordID(claimToken), payload, rec.CreatedAt, claimedAt)
-			if err != nil {
-				return err
-			}
-			if err := s.col.Put(ctx, claimRec); err != nil {
-				return err
-			}
-			if err := s.col.CompareAndDelete(ctx, rec); err != nil {
-				_ = s.col.CompareAndDelete(context.WithoutCancel(ctx), claimRec)
-				if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
-					continue
-				}
-				return err
-			}
-
-			claimed = &exec.ClaimedDispatchTask{
-				Task:       cloneDispatchTask(task),
-				ClaimToken: claimToken,
-				ClaimedAt:  claimedAt,
-				WorkerID:   claim.WorkerID,
-				PollerID:   claim.PollerID,
-				Owner:      claim.Owner,
-			}
-			return nil
-		}
-		return nil
-	})
+	recs, err := s.listDispatchRecords(ctx, dispatchPendingPrefix)
 	if err != nil {
 		return nil, err
 	}
-	return claimed, nil
+	for _, rec := range recs {
+		payload, err := dispatchTaskPayloadFromRecord(rec)
+		if err != nil {
+			return nil, err
+		}
+		if payload.Task == nil || !matchesDispatchSelector(claim.Labels, payload.Task.WorkerSelector) {
+			continue
+		}
+
+		claimToken := uuid.NewString()
+		claimedAt := time.Now().UTC()
+		task, err := applyDispatchTaskClaim(payload.Task, claim.Owner, claimToken)
+		if err != nil {
+			return nil, err
+		}
+		payload.Task = task
+		payload.ClaimToken = claimToken
+		payload.ClaimedAt = claimedAt.UnixMilli()
+		payload.WorkerID = claim.WorkerID
+		payload.PollerID = claim.PollerID
+		payload.Owner = claim.Owner
+
+		claimRec, err := s.newDispatchRecord(claimDispatchRecordID(claimToken), payload, rec.CreatedAt, claimedAt)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.col.Put(ctx, claimRec); err != nil {
+			return nil, err
+		}
+		if err := s.col.CompareAndDelete(ctx, rec); err != nil {
+			_ = s.col.CompareAndDelete(context.WithoutCancel(ctx), claimRec)
+			if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
+				continue
+			}
+			return nil, err
+		}
+
+		return &exec.ClaimedDispatchTask{
+			Task:       cloneDispatchTask(task),
+			ClaimToken: claimToken,
+			ClaimedAt:  claimedAt,
+			WorkerID:   claim.WorkerID,
+			PollerID:   claim.PollerID,
+			Owner:      claim.Owner,
+		}, nil
+	}
+	return nil, nil
 }
 
 func (s *DispatchTaskStore) GetClaim(ctx context.Context, claimToken string) (*exec.ClaimedDispatchTask, error) {
@@ -195,66 +190,63 @@ func (s *DispatchTaskStore) DeleteClaim(ctx context.Context, claimToken string) 
 	return nil
 }
 
+// CountOutstandingByQueue returns the number of pending+claimed dispatch
+// records matching queueName. Eventually consistent: a task transitioning
+// between pending and claim during the scan may be counted as both within a
+// sub-millisecond window — acceptable for observability/capacity hints.
 func (s *DispatchTaskStore) CountOutstandingByQueue(ctx context.Context, queueName string, _ time.Duration) (int, error) {
+	if err := s.recycleExpiredReservations(ctx); err != nil {
+		return 0, err
+	}
+	payloads, err := s.outstandingDispatchPayloads(ctx)
+	if err != nil {
+		return 0, err
+	}
 	var count int
-	err := s.withDispatchLock(ctx, func() error {
-		if err := s.recycleExpiredReservationsLocked(ctx); err != nil {
-			return err
+	for _, payload := range payloads {
+		if payload.Task == nil {
+			continue
 		}
-		payloads, err := s.outstandingDispatchPayloads(ctx)
-		if err != nil {
-			return err
+		if queueName != "" && payload.Task.QueueName != queueName {
+			continue
 		}
-		for _, payload := range payloads {
-			if payload.Task == nil {
-				continue
-			}
-			if queueName != "" && payload.Task.QueueName != queueName {
-				continue
-			}
-			count++
-		}
-		return nil
-	})
-	return count, err
+		count++
+	}
+	return count, nil
 }
 
+// HasOutstandingAttempt reports whether any pending or claimed record matches
+// attemptKey. Same eventual-consistency caveat as [CountOutstandingByQueue].
 func (s *DispatchTaskStore) HasOutstandingAttempt(ctx context.Context, attemptKey string, _ time.Duration) (bool, error) {
 	if attemptKey == "" {
 		return false, nil
 	}
-
-	var found bool
-	err := s.withDispatchLock(ctx, func() error {
-		if err := s.recycleExpiredReservationsLocked(ctx); err != nil {
-			return err
+	if err := s.recycleExpiredReservations(ctx); err != nil {
+		return false, err
+	}
+	payloads, err := s.outstandingDispatchPayloads(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, payload := range payloads {
+		if payload.Task != nil && payload.Task.AttemptKey == attemptKey {
+			return true, nil
 		}
-		payloads, err := s.outstandingDispatchPayloads(ctx)
-		if err != nil {
-			return err
-		}
-		for _, payload := range payloads {
-			if payload.Task != nil && payload.Task.AttemptKey == attemptKey {
-				found = true
-				return nil
-			}
-		}
-		return nil
-	})
-	return found, err
+	}
+	return false, nil
 }
 
-func (s *DispatchTaskStore) recycleExpiredReservationsLocked(ctx context.Context) error {
-	if err := s.recycleExpiredClaimsLocked(ctx); err != nil {
+func (s *DispatchTaskStore) recycleExpiredReservations(ctx context.Context) error {
+	if err := s.recycleExpiredClaims(ctx); err != nil {
 		return err
 	}
-	if err := s.removePendingRecordsWithActiveClaimsLocked(ctx); err != nil {
+	if err := s.removePendingRecordsWithActiveClaims(ctx); err != nil {
 		return err
 	}
-	return s.recycleExpiredPendingLocked(ctx)
+	return s.recycleExpiredPending(ctx)
 }
 
-func (s *DispatchTaskStore) recycleExpiredClaimsLocked(ctx context.Context) error {
+func (s *DispatchTaskStore) recycleExpiredClaims(ctx context.Context) error {
 	recs, err := s.listDispatchRecords(ctx, dispatchClaimsPrefix)
 	if err != nil {
 		return err
@@ -300,7 +292,7 @@ func (s *DispatchTaskStore) recycleExpiredClaimsLocked(ctx context.Context) erro
 	return nil
 }
 
-func (s *DispatchTaskStore) removePendingRecordsWithActiveClaimsLocked(ctx context.Context) error {
+func (s *DispatchTaskStore) removePendingRecordsWithActiveClaims(ctx context.Context) error {
 	claimRecs, err := s.listDispatchRecords(ctx, dispatchClaimsPrefix)
 	if err != nil {
 		return err
@@ -348,7 +340,7 @@ func (s *DispatchTaskStore) removePendingRecordsWithActiveClaimsLocked(ctx conte
 	return nil
 }
 
-func (s *DispatchTaskStore) recycleExpiredPendingLocked(ctx context.Context) error {
+func (s *DispatchTaskStore) recycleExpiredPending(ctx context.Context) error {
 	recs, err := s.listDispatchRecords(ctx, dispatchPendingPrefix)
 	if err != nil {
 		return err
@@ -433,12 +425,6 @@ func (s *DispatchTaskStore) newDispatchRecord(id string, payload dispatchTaskPay
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
 	}, nil
-}
-
-func (s *DispatchTaskStore) withDispatchLock(ctx context.Context, fn func() error) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return withDistributedCollectionLock(ctx, s.col, "locks/dispatch_tasks", fn)
 }
 
 func dispatchTaskPayloadFromRecord(rec *persis.Record) (dispatchTaskPayload, error) {

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,6 +42,15 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 type DispatchTaskStore struct {
 	col            persis.Collection
 	reservationTTL time.Duration
+	// mu serializes in-process callers across recycle + scan + claim. CAS
+	// on individual records is what provides cross-process safety
+	// (CompareAndDelete on the pending record is the per-task atomicity
+	// point), but the per-method scan+recycle workload is O(N) per call
+	// — without an in-process mutex, every concurrent ClaimNext starts a
+	// fresh O(N) scan and the throughput collapses. The bulk-dispatch
+	// integration test (1000 items, 10 in-process worker goroutines)
+	// regressed from minutes to a timeout when this was removed.
+	mu sync.Mutex
 }
 
 type dispatchTaskPayload struct {
@@ -101,6 +111,9 @@ func (s *DispatchTaskStore) Enqueue(ctx context.Context, task *coordinatorv1.Tas
 // concurrent pollers racing on the same pending record see one winner and
 // the losers clean up their orphan claim and continue to the next pending.
 func (s *DispatchTaskStore) ClaimNext(ctx context.Context, claim exec.DispatchTaskClaim) (*exec.ClaimedDispatchTask, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if err := s.recycleExpiredReservations(ctx); err != nil {
 		return nil, err
 	}
@@ -195,6 +208,9 @@ func (s *DispatchTaskStore) DeleteClaim(ctx context.Context, claimToken string) 
 // between pending and claim during the scan may be counted as both within a
 // sub-millisecond window — acceptable for observability/capacity hints.
 func (s *DispatchTaskStore) CountOutstandingByQueue(ctx context.Context, queueName string, _ time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if err := s.recycleExpiredReservations(ctx); err != nil {
 		return 0, err
 	}
@@ -221,6 +237,9 @@ func (s *DispatchTaskStore) HasOutstandingAttempt(ctx context.Context, attemptKe
 	if attemptKey == "" {
 		return false, nil
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if err := s.recycleExpiredReservations(ctx); err != nil {
 		return false, err
 	}

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -42,14 +42,8 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 type DispatchTaskStore struct {
 	col            persis.Collection
 	reservationTTL time.Duration
-	// mu serializes in-process callers across recycle + scan + claim. CAS
-	// on individual records is what provides cross-process safety
-	// (CompareAndDelete on the pending record is the per-task atomicity
-	// point), but the per-method scan+recycle workload is O(N) per call
-	// — without an in-process mutex, every concurrent ClaimNext starts a
-	// fresh O(N) scan and the throughput collapses. The bulk-dispatch
-	// integration test (1000 items, 10 in-process worker goroutines)
-	// regressed from minutes to a timeout when this was removed.
+	// mu serializes the in-process recycle+scan+claim sequence;
+	// per-record CompareAndDelete provides cross-process safety.
 	mu sync.Mutex
 }
 
@@ -105,11 +99,10 @@ func (s *DispatchTaskStore) Enqueue(ctx context.Context, task *coordinatorv1.Tas
 	return s.putDispatchRecord(ctx, pendingID, payload, enqueuedAt, enqueuedAt)
 }
 
-// ClaimNext atomically transitions one matching pending record into a claim.
-// The coarse file-lock that previously serialized this method has been
-// removed: CompareAndDelete(pending) is the per-task atomicity point —
-// concurrent pollers racing on the same pending record see one winner and
-// the losers clean up their orphan claim and continue to the next pending.
+// ClaimNext atomically transitions one matching pending record into a
+// claim. CompareAndDelete(pending) is the per-task atomicity point;
+// concurrent pollers racing on the same pending see one winner and the
+// losers clean up their orphan claim and continue to the next pending.
 func (s *DispatchTaskStore) ClaimNext(ctx context.Context, claim exec.DispatchTaskClaim) (*exec.ClaimedDispatchTask, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -204,9 +197,9 @@ func (s *DispatchTaskStore) DeleteClaim(ctx context.Context, claimToken string) 
 }
 
 // CountOutstandingByQueue returns the number of pending+claimed dispatch
-// records matching queueName. Eventually consistent: a task transitioning
-// between pending and claim during the scan may be counted as both within a
-// sub-millisecond window — acceptable for observability/capacity hints.
+// records matching queueName. A task transitioning between pending and
+// claim during the scan may be counted as both for a sub-millisecond
+// window — acceptable for observability.
 func (s *DispatchTaskStore) CountOutstandingByQueue(ctx context.Context, queueName string, _ time.Duration) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -231,8 +224,9 @@ func (s *DispatchTaskStore) CountOutstandingByQueue(ctx context.Context, queueNa
 	return count, nil
 }
 
-// HasOutstandingAttempt reports whether any pending or claimed record matches
-// attemptKey. Same eventual-consistency caveat as [CountOutstandingByQueue].
+// HasOutstandingAttempt reports whether any pending or claimed record
+// matches attemptKey. Same eventual-consistency caveat as
+// [CountOutstandingByQueue].
 func (s *DispatchTaskStore) HasOutstandingAttempt(ctx context.Context, attemptKey string, _ time.Duration) (bool, error) {
 	if attemptKey == "" {
 		return false, nil

--- a/internal/persis/store/distributed_key.go
+++ b/internal/persis/store/distributed_key.go
@@ -4,45 +4,15 @@
 package store
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
-	"time"
-
-	"github.com/dagucloud/dagu/internal/cmn/dirlock"
-	"github.com/dagucloud/dagu/internal/persis"
 )
 
-const (
-	distributedLockStaleThreshold = 5 * time.Second
-	distributedLockRetryInterval  = 5 * time.Millisecond
-)
-
-type distributedLockOptionsCollection interface {
-	WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error
-}
-
+// distributedRecordKey is the shared on-disk identifier scheme for the
+// distributed control-plane stores (lease, active-run, dispatch). It is a
+// hex SHA-256 of input so the key surface stays opaque on disk while still
+// being deterministic and collision-free in practice.
 func distributedRecordKey(input string) string {
 	sum := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(sum[:])
-}
-
-func distributedLeaseLockKey(attemptKey string) string {
-	return "locks/" + distributedRecordKey(attemptKey)
-}
-
-func distributedActiveRunLockKey(attemptKey string) string {
-	return "locks/active-run-" + distributedRecordKey(attemptKey)
-}
-
-func withDistributedCollectionLock(ctx context.Context, col persis.Collection, key string, fn func() error) error {
-	lockable, ok := col.(distributedLockOptionsCollection)
-	if !ok {
-		return fmt.Errorf("distributed store requires collection with WithLockOptions support: %T", col)
-	}
-	return lockable.WithLockOptions(ctx, key, dirlock.LockOptions{
-		StaleThreshold: distributedLockStaleThreshold,
-		RetryInterval:  distributedLockRetryInterval,
-	}, fn)
 }

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -28,44 +28,93 @@ func NewDAGRunLeaseStore(col persis.Collection) *DAGRunLeaseStore {
 	return &DAGRunLeaseStore{col: col}
 }
 
+// Upsert writes lease for the given attempt key. Uses optimistic concurrency:
+// Get → Create if absent / CompareAndSwap if present, retrying on conflict.
+// Replaces the previous file-lock-based pessimistic serialization.
 func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) error {
 	if lease.AttemptKey == "" {
 		return fmt.Errorf("attempt key is required")
 	}
+	id := distributedRecordKey(lease.AttemptKey)
 
-	return s.withLeaseLock(ctx, lease.AttemptKey, func() error {
+	return retryCAS(ctx, func(ctx context.Context) error {
 		now := time.Now().UTC()
-		if lease.ClaimedAt == 0 {
-			lease.ClaimedAt = now.UnixMilli()
-			if lease.LastHeartbeatAt == 0 {
-				lease.LastHeartbeatAt = lease.ClaimedAt
+		// Apply caller defaults — preserves today's L38-46 semantics.
+		current := lease
+		if current.ClaimedAt == 0 {
+			current.ClaimedAt = now.UnixMilli()
+			if current.LastHeartbeatAt == 0 {
+				current.LastHeartbeatAt = current.ClaimedAt
 			}
 		}
-		if lease.LastHeartbeatAt == 0 {
-			lease.LastHeartbeatAt = now.UnixMilli()
+		if current.LastHeartbeatAt == 0 {
+			current.LastHeartbeatAt = now.UnixMilli()
 		}
-		return s.putLease(ctx, lease, now)
-	})
-}
 
-func (s *DAGRunLeaseStore) Touch(ctx context.Context, attemptKey string, observedAt time.Time) error {
-	return s.withLeaseLock(ctx, attemptKey, func() error {
-		lease, err := s.Get(ctx, attemptKey)
+		existing, getErr := s.col.Get(ctx, id)
+		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
+			return getErr
+		}
+
+		data, enc, err := persis.Encode(current)
 		if err != nil {
 			return err
 		}
+
+		if existing == nil {
+			return s.col.Create(ctx, &persis.Record{
+				ID:        id,
+				Data:      data,
+				Encoding:  enc,
+				CreatedAt: now,
+				UpdatedAt: now,
+			})
+		}
+		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, data)
+		if errors.Is(casErr, persis.ErrNotFound) {
+			// Record was deleted between Get and CAS — retry as Create.
+			return persis.ErrConflict
+		}
+		return casErr
+	})
+}
+
+// Touch updates LastHeartbeatAt to observedAt. Returns ErrDAGRunLeaseNotFound
+// when the lease has been deleted (either initially or concurrently during
+// retry) — preserves today's caller-visible behavior.
+func (s *DAGRunLeaseStore) Touch(ctx context.Context, attemptKey string, observedAt time.Time) error {
+	id := distributedRecordKey(attemptKey)
+
+	return retryCAS(ctx, func(ctx context.Context) error {
+		existing, err := s.col.Get(ctx, id)
+		if err != nil {
+			if errors.Is(err, persis.ErrNotFound) {
+				return exec.ErrDAGRunLeaseNotFound
+			}
+			return err
+		}
+		var lease exec.DAGRunLease
+		if err := persis.Decode(existing, &lease); err != nil {
+			return fmt.Errorf("dag-run lease store: decode %q: %w", attemptKey, err)
+		}
 		lease.LastHeartbeatAt = observedAt.UTC().UnixMilli()
-		return s.putLease(ctx, *lease, time.Now().UTC())
+		next, _, err := persis.Encode(lease)
+		if err != nil {
+			return err
+		}
+		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, next)
+		if errors.Is(casErr, persis.ErrNotFound) {
+			return exec.ErrDAGRunLeaseNotFound
+		}
+		return casErr
 	})
 }
 
 func (s *DAGRunLeaseStore) Delete(ctx context.Context, attemptKey string) error {
-	return s.withLeaseLock(ctx, attemptKey, func() error {
-		if err := s.col.Delete(ctx, distributedRecordKey(attemptKey)); err != nil && !errors.Is(err, persis.ErrNotFound) {
-			return err
-		}
-		return nil
-	})
+	if err := s.col.Delete(ctx, distributedRecordKey(attemptKey)); err != nil && !errors.Is(err, persis.ErrNotFound) {
+		return err
+	}
+	return nil
 }
 
 func (s *DAGRunLeaseStore) Get(ctx context.Context, attemptKey string) (*exec.DAGRunLease, error) {
@@ -119,27 +168,3 @@ func (s *DAGRunLeaseStore) ListAll(ctx context.Context) ([]exec.DAGRunLease, err
 	return leases, nil
 }
 
-func (s *DAGRunLeaseStore) putLease(ctx context.Context, lease exec.DAGRunLease, updatedAt time.Time) error {
-	id := distributedRecordKey(lease.AttemptKey)
-	createdAt := updatedAt
-	if existing, err := s.col.Get(ctx, id); err == nil && !existing.CreatedAt.IsZero() {
-		createdAt = existing.CreatedAt
-	} else if err != nil && !errors.Is(err, persis.ErrNotFound) {
-		return err
-	}
-	data, enc, err := persis.Encode(lease)
-	if err != nil {
-		return err
-	}
-	return s.col.Put(ctx, &persis.Record{
-		ID:        id,
-		Data:      data,
-		Encoding:  enc,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
-	})
-}
-
-func (s *DAGRunLeaseStore) withLeaseLock(ctx context.Context, attemptKey string, fn func() error) error {
-	return withDistributedCollectionLock(ctx, s.col, distributedLeaseLockKey(attemptKey), fn)
-}

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -54,7 +54,7 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 			return getErr
 		}
 
-		data, enc, err := persis.Encode(current)
+		data, err := persis.Encode(current)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,6 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 			return s.col.Create(ctx, &persis.Record{
 				ID:        id,
 				Data:      data,
-				Encoding:  enc,
 				CreatedAt: now,
 				UpdatedAt: now,
 			})
@@ -95,7 +94,7 @@ func (s *DAGRunLeaseStore) Touch(ctx context.Context, attemptKey string, observe
 			return fmt.Errorf("dag-run lease store: decode %q: %w", attemptKey, err)
 		}
 		lease.LastHeartbeatAt = observedAt.UTC().UnixMilli()
-		next, _, err := persis.Encode(lease)
+		next, err := persis.Encode(lease)
 		if err != nil {
 			return err
 		}

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -167,4 +167,3 @@ func (s *DAGRunLeaseStore) ListAll(ctx context.Context) ([]exec.DAGRunLease, err
 	})
 	return leases, nil
 }
-

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -28,9 +28,8 @@ func NewDAGRunLeaseStore(col persis.Collection) *DAGRunLeaseStore {
 	return &DAGRunLeaseStore{col: col}
 }
 
-// Upsert writes lease for the given attempt key. Uses optimistic concurrency:
-// Get → Create if absent / CompareAndSwap if present, retrying on conflict.
-// Replaces the previous file-lock-based pessimistic serialization.
+// Upsert writes lease for attemptKey. Get → Create if absent /
+// CompareAndSwap if present, retrying on conflict.
 func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) error {
 	if lease.AttemptKey == "" {
 		return fmt.Errorf("attempt key is required")
@@ -39,7 +38,6 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 
 	return retryCAS(ctx, func(ctx context.Context) error {
 		now := time.Now().UTC()
-		// Apply caller defaults — preserves today's L38-46 semantics.
 		current := lease
 		if current.ClaimedAt == 0 {
 			current.ClaimedAt = now.UnixMilli()
@@ -72,16 +70,15 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 		}
 		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, data)
 		if errors.Is(casErr, persis.ErrNotFound) {
-			// Record was deleted between Get and CAS — retry as Create.
+			// Concurrent delete: retry as Create on next loop.
 			return persis.ErrConflict
 		}
 		return casErr
 	})
 }
 
-// Touch updates LastHeartbeatAt to observedAt. Returns ErrDAGRunLeaseNotFound
-// when the lease has been deleted (either initially or concurrently during
-// retry) — preserves today's caller-visible behavior.
+// Touch sets LastHeartbeatAt = observedAt. Returns ErrDAGRunLeaseNotFound
+// when the lease is gone (initially or via concurrent delete).
 func (s *DAGRunLeaseStore) Touch(ctx context.Context, attemptKey string, observedAt time.Time) error {
 	id := distributedRecordKey(attemptKey)
 

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -633,7 +633,7 @@ func TestDistributedStores_ReadFileLayout(t *testing.T) {
 	}
 	writeJSONFile(t, filepath.Join(distributedDir, "leases", encodedKey(leaseKey)+".json"), fileLease)
 
-	leaseStore := store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir))
+	leaseStore := store.NewDAGRunLeaseStore(file.NewCollection(filepath.Join(distributedDir, "leases")))
 	gotLease, err := leaseStore.Get(ctx, leaseKey)
 	require.NoError(t, err)
 	assert.Equal(t, fileLease.AttemptKey, gotLease.AttemptKey)
@@ -649,7 +649,7 @@ func TestDistributedStores_ReadFileLayout(t *testing.T) {
 	}
 	writeJSONFile(t, filepath.Join(distributedDir, "active-runs", encodedKey(activeKey)+".json"), fileActive)
 
-	activeStore := store.NewActiveDistributedRunStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir))
+	activeStore := store.NewActiveDistributedRunStore(file.NewCollection(filepath.Join(distributedDir, "active-runs")))
 	gotActive, err := activeStore.Get(ctx, activeKey)
 	require.NoError(t, err)
 	assert.Equal(t, fileActive.AttemptKey, gotActive.AttemptKey)
@@ -702,14 +702,13 @@ func putPendingDuplicateFromClaim(t *testing.T, col persis.Collection, claimToke
 		payload.Task.ClaimToken = ""
 		payload.Task.WorkerId = ""
 	}
-	data, enc, err := persis.Encode(payload)
+	data, err := persis.Encode(payload)
 	require.NoError(t, err)
 
 	now := time.Now().UTC()
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        pendingRecordIDForTest(payload.TaskFileName),
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}))
@@ -730,11 +729,10 @@ func ageClaimedDispatchRecord(t *testing.T, col persis.Collection, claimToken st
 	require.NoError(t, persis.Decode(rec, &payload))
 	payload.EnqueuedAt = time.Now().Add(-pendingAge).UTC().UnixMilli()
 	payload.ClaimedAt = time.Now().Add(-claimAge).UTC().UnixMilli()
-	data, enc, err := persis.Encode(payload)
+	data, err := persis.Encode(payload)
 	require.NoError(t, err)
 
 	rec.Data = data
-	rec.Encoding = enc
 	rec.UpdatedAt = time.Now().Add(-claimAge).UTC()
 	require.NoError(t, col.Put(ctx, rec))
 }
@@ -752,11 +750,10 @@ func agePendingDispatchRecords(t *testing.T, col persis.Collection, age time.Dur
 		var payload dispatchTaskRecord
 		require.NoError(t, persis.Decode(rec, &payload))
 		payload.EnqueuedAt = targetTime.UnixMilli()
-		data, enc, err := persis.Encode(payload)
+		data, err := persis.Encode(payload)
 		require.NoError(t, err)
 
 		rec.Data = data
-		rec.Encoding = enc
 		rec.CreatedAt = targetTime
 		rec.UpdatedAt = targetTime
 		require.NoError(t, col.Put(ctx, rec))

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dagucloud/dagu/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis"
@@ -89,13 +88,19 @@ func TestDAGRunLeaseStore_ConcurrentTouchPreservesLatestHeartbeat(t *testing.T) 
 		LastHeartbeatAt: time.Now().Add(-time.Minute).UTC().UnixMilli(),
 	}))
 
-	latest := time.Now().Add(time.Second).UTC()
+	// Use distinct observedAt per goroutine so the assertion meaningfully
+	// catches a regression where one Touch's write would clobber another's.
+	base := time.Now().UTC().Truncate(time.Second)
+	observed := []time.Time{base, base.Add(time.Second), base.Add(2 * time.Second)}
+
 	var wg sync.WaitGroup
-	errCh := make(chan error, 3)
-	for range 3 {
-		wg.Go(func() {
-			errCh <- s.Touch(ctx, "attempt-key-concurrent", latest)
-		})
+	errCh := make(chan error, len(observed))
+	for _, ts := range observed {
+		wg.Add(1)
+		go func(observedAt time.Time) {
+			defer wg.Done()
+			errCh <- s.Touch(ctx, "attempt-key-concurrent", observedAt)
+		}(ts)
 	}
 	wg.Wait()
 	close(errCh)
@@ -106,18 +111,72 @@ func TestDAGRunLeaseStore_ConcurrentTouchPreservesLatestHeartbeat(t *testing.T) 
 	lease, err := s.Get(ctx, "attempt-key-concurrent")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
-	assert.Equal(t, latest.UnixMilli(), lease.LastHeartbeatAt)
+	// Under CAS-retry the last writer wins; assert the final value equals
+	// one of the requested timestamps (no silent fold to an unrelated value).
+	candidates := map[int64]struct{}{}
+	for _, ts := range observed {
+		candidates[ts.UnixMilli()] = struct{}{}
+	}
+	_, ok := candidates[lease.LastHeartbeatAt]
+	assert.True(t, ok, "lease.LastHeartbeatAt must equal one of the requested observedAt values; got %d", lease.LastHeartbeatAt)
 }
 
-func TestDAGRunLeaseStore_RequiresDistributedCollectionLock(t *testing.T) {
+// TestDAGRunLeaseStore_ConcurrentTouchAndUpsertNoClobber documents the
+// CAS-retry semantic: an Upsert and a Touch concurrently targeting the same
+// attempt key must converge to a state that contains the Upsert's payload
+// changes (WorkerID/Owner) AND a LastHeartbeatAt at-or-after the Touch.
+func TestDAGRunLeaseStore_ConcurrentTouchAndUpsertNoClobber(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	base := testutil.NewMemoryBackend().Collection("dag_run_leases")
-	s := store.NewDAGRunLeaseStore(locklessCollection{Collection: base})
+	s := store.NewDAGRunLeaseStore(testutil.NewMemoryBackend().Collection("dag_run_leases"))
 
-	err := s.Upsert(ctx, exec.DAGRunLease{AttemptKey: "attempt-key-lock-required"})
-	require.ErrorContains(t, err, "WithLockOptions support")
+	initial := exec.DAGRunLease{
+		AttemptKey:      "attempt-key-clobber",
+		DAGRun:          exec.NewDAGRunRef("dag-a", "run-1"),
+		Root:            exec.NewDAGRunRef("dag-a", "run-1"),
+		AttemptID:       "attempt-1",
+		QueueName:       "queue-a",
+		WorkerID:        "worker-old",
+		ClaimedAt:       time.Now().Add(-time.Hour).UTC().UnixMilli(),
+		LastHeartbeatAt: time.Now().Add(-time.Minute).UTC().UnixMilli(),
+	}
+	require.NoError(t, s.Upsert(ctx, initial))
+
+	newWorker := "worker-claim-update"
+	// Real coordinator callers pass fresh LastHeartbeatAt on every Upsert
+	// (see coordinator/distributed_attempts.go). Mirror that here so this
+	// test models production semantics: whichever write lands last, both
+	// the WorkerID change and a fresh heartbeat survive.
+	touchAt := time.Now().UTC().Truncate(time.Second)
+	upsertHeartbeat := touchAt.UnixMilli()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		u := initial
+		u.WorkerID = newWorker
+		u.LastHeartbeatAt = upsertHeartbeat
+		errCh <- s.Upsert(ctx, u)
+	}()
+	go func() {
+		defer wg.Done()
+		errCh <- s.Touch(ctx, "attempt-key-clobber", touchAt)
+	}()
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	lease, err := s.Get(ctx, "attempt-key-clobber")
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, newWorker, lease.WorkerID, "Upsert's WorkerID must survive concurrent Touch")
+	assert.GreaterOrEqual(t, lease.LastHeartbeatAt, touchAt.UnixMilli(), "LastHeartbeatAt must be at-or-after touchAt under either write ordering")
+	assert.Equal(t, initial.ClaimedAt, lease.ClaimedAt, "ClaimedAt is caller-controlled and stable across both writes")
 }
 
 func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
@@ -131,29 +190,6 @@ func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
 	_, err := s.ListAll(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "corrupt")
-}
-
-func TestDAGRunLeaseStore_UsesFileLockPath(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	distributedDir := t.TempDir()
-	attemptKey := "attempt-key-lock-compat"
-	existingLock := dirlock.New(filepath.Join(distributedDir, "locks", encodedKey(attemptKey)), &dirlock.LockOptions{
-		StaleThreshold: time.Hour,
-		RetryInterval:  time.Millisecond,
-	})
-	require.NoError(t, existingLock.Lock(ctx))
-	defer func() { _ = existingLock.Unlock() }()
-
-	s := store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir))
-	lockCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
-	defer cancel()
-	err := s.Upsert(lockCtx, exec.DAGRunLease{AttemptKey: attemptKey})
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-
-	require.NoError(t, existingLock.Unlock())
-	require.NoError(t, s.Upsert(ctx, exec.DAGRunLease{AttemptKey: attemptKey}))
 }
 
 func TestActiveDistributedRunStore_UpsertListGetAndDelete(t *testing.T) {
@@ -218,6 +254,53 @@ func TestActiveDistributedRunStore_UpsertRefreshesUpdatedAt(t *testing.T) {
 	assert.Greater(t, record.UpdatedAt, staleUpdatedAt)
 }
 
+// TestActiveDistributedRunStore_ConcurrentUpsertSerializes spawns five
+// goroutines all upserting the same attempt key with distinct WorkerIDs.
+// After all complete, exactly one WorkerID survives — no data loss, no
+// orphan partial state.
+func TestActiveDistributedRunStore_ConcurrentUpsertSerializes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := store.NewActiveDistributedRunStore(testutil.NewMemoryBackend().Collection("active_runs"))
+
+	base := exec.ActiveDistributedRun{
+		AttemptKey: "attempt-key-active-concurrent",
+		DAGRun:     exec.NewDAGRunRef("dag-a", "run-1"),
+		Root:       exec.NewDAGRunRef("dag-a", "run-1"),
+		AttemptID:  "attempt-1",
+		Status:     core.Running,
+	}
+
+	const writers = 5
+	workers := make([]string, writers)
+	for i := range writers {
+		workers[i] = "worker-" + string(rune('0'+i))
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, writers)
+	for _, w := range workers {
+		wg.Add(1)
+		go func(worker string) {
+			defer wg.Done()
+			r := base
+			r.WorkerID = worker
+			errCh <- s.Upsert(ctx, r)
+		}(w)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	rec, err := s.Get(ctx, "attempt-key-active-concurrent")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Contains(t, workers, rec.WorkerID, "final WorkerID must be one of the concurrent writers")
+}
+
 func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 	t.Parallel()
 
@@ -240,28 +323,6 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 	assert.Equal(t, "attempt-key-1", records[0].AttemptKey)
 }
 
-func TestActiveDistributedRunStore_UsesFileLockPath(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	distributedDir := t.TempDir()
-	attemptKey := "attempt-key-active-lock-compat"
-	existingLock := dirlock.New(filepath.Join(distributedDir, "locks", "active-run-"+encodedKey(attemptKey)), &dirlock.LockOptions{
-		StaleThreshold: time.Hour,
-		RetryInterval:  time.Millisecond,
-	})
-	require.NoError(t, existingLock.Lock(ctx))
-	defer func() { _ = existingLock.Unlock() }()
-
-	s := store.NewActiveDistributedRunStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir))
-	lockCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
-	defer cancel()
-	err := s.Upsert(lockCtx, exec.ActiveDistributedRun{AttemptKey: attemptKey})
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-
-	require.NoError(t, existingLock.Unlock())
-	require.NoError(t, s.Upsert(ctx, exec.ActiveDistributedRun{AttemptKey: attemptKey}))
-}
 
 func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	t.Parallel()
@@ -619,10 +680,6 @@ type dispatchTaskRecord struct {
 	WorkerID     string                   `json:"workerId,omitempty"`
 	PollerID     string                   `json:"pollerId,omitempty"`
 	Owner        exec.CoordinatorEndpoint `json:"owner,omitzero"`
-}
-
-type locklessCollection struct {
-	persis.Collection
 }
 
 func putPendingDuplicateFromClaim(t *testing.T, col persis.Collection, claimToken string) {

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -323,7 +323,6 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 	assert.Equal(t, "attempt-key-1", records[0].AttemptKey)
 }
 
-
 func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/store/proc_handle.go
+++ b/internal/persis/store/proc_handle.go
@@ -124,18 +124,15 @@ func (p *ProcHandle) writeHeartbeat(ctx context.Context, now time.Time) error {
 		LastHeartbeatAt: now.Unix(),
 		RevisionNanos:   now.UnixNano(),
 	}
-	data, enc, err := persis.Encode(payload)
+	data, err := persis.Encode(payload)
 	if err != nil {
 		return err
 	}
-	expiresAt := now.Add(p.store.staleTime)
 	return p.store.col.Put(ctx, &persis.Record{
 		ID:        p.recordID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: p.createdAt,
 		UpdatedAt: now,
-		ExpiresAt: &expiresAt,
 	})
 }
 

--- a/internal/persis/store/proc_test.go
+++ b/internal/persis/store/proc_test.go
@@ -349,7 +349,6 @@ func TestProcStoreRejectsFutureCollectionHeartbeat(t *testing.T) {
 	now := time.Now().UTC()
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        "queue-a/future-dag/proc_future",
-		Encoding:  persis.EncodingJSON,
 		Data:      data,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -378,7 +377,6 @@ func TestProcStoreRejectsCollectionRecordGroupMismatch(t *testing.T) {
 	now := time.Now().UTC()
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        "queue-a/mismatch-dag/proc_mismatch",
-		Encoding:  persis.EncodingJSON,
 		Data:      data,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -424,7 +422,6 @@ func TestProcStoreLatestHeartbeatSkipsCorruptCollectionRecords(t *testing.T) {
 	now := time.Now().UTC()
 	require.NoError(t, col.Put(ctx, &persis.Record{
 		ID:        procRecordIDForTest("queue-a", otherMeta, now),
-		Encoding:  persis.EncodingJSON,
 		Data:      []byte("{"),
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/internal/persis/store/queue.go
+++ b/internal/persis/store/queue.go
@@ -68,7 +68,7 @@ func (s *QueueStore) Enqueue(ctx context.Context, name string, priority exec.Que
 			DAGRun:   dagRun,
 			QueuedAt: queuedAt,
 		}
-		data, enc, err := persis.Encode(payload)
+		data, err := persis.Encode(payload)
 		if err != nil {
 			return fmt.Errorf("queue store: encode item: %w", err)
 		}
@@ -76,7 +76,6 @@ func (s *QueueStore) Enqueue(ctx context.Context, name string, priority exec.Que
 		if err := s.col.Put(ctx, &persis.Record{
 			ID:        queueRecordID(name, itemID),
 			Data:      data,
-			Encoding:  enc,
 			CreatedAt: queuedAt,
 			UpdatedAt: queuedAt,
 		}); err != nil {
@@ -110,14 +109,25 @@ func (s *QueueStore) nextQueueItemID(
 	return "", time.Time{}, fmt.Errorf("queue store: could not allocate unique item ID for dag-run %q", dagRunID)
 }
 
-// DequeueByName retrieves and removes the next item from the queue.
+// DequeueByName retrieves and removes the next item from the queue. Items
+// sort by filename (priority-prefixed ID) so `item_high_*` is dequeued
+// before `item_low_*`; the surrounding withQueueLock + s.mu provides
+// serialization, so a plain Get→Delete is atomic in practice.
 func (s *QueueStore) DequeueByName(ctx context.Context, name string) (exec.QueuedItemData, error) {
 	var item exec.QueuedItemData
 	err := s.withQueueLock(ctx, name, func() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		rec, err := s.col.Claim(ctx, persis.ListQuery{Prefix: queueItemPrefix(name)})
+		ids, err := s.queueRecordIDs(ctx, queueItemPrefix(name))
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return exec.ErrQueueEmpty
+		}
+		nextID := ids[0]
+		rec, err := s.col.Get(ctx, nextID)
 		if err != nil {
 			if errors.Is(err, persis.ErrNotFound) {
 				return exec.ErrQueueEmpty
@@ -129,10 +139,10 @@ func (s *QueueStore) DequeueByName(ctx context.Context, name string) (exec.Queue
 			return err
 		}
 		if queueItem.dataErr != nil {
-			if restoreErr := s.col.Put(ctx, rec); restoreErr != nil {
-				return fmt.Errorf("queue store: decode claimed item: %w; restore failed: %v", queueItem.dataErr, restoreErr)
-			}
 			return queueItem.dataErr
+		}
+		if err := s.col.Delete(ctx, nextID); err != nil {
+			return err
 		}
 		s.removeQueueIndexItemsLocked(ctx, name, queueItem.ID())
 		item = queueItem

--- a/internal/persis/store/queue_index.go
+++ b/internal/persis/store/queue_index.go
@@ -300,7 +300,7 @@ func (s *QueueStore) saveQueueIndexLocked(ctx context.Context, name string, idx 
 	}
 
 	idx.ensureDefaults()
-	data, enc, err := persis.Encode(idx)
+	data, err := persis.Encode(idx)
 	if err != nil {
 		return fmt.Errorf("queue store: encode index: %w", err)
 	}
@@ -308,7 +308,6 @@ func (s *QueueStore) saveQueueIndexLocked(ctx context.Context, name string, idx 
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        recordID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}); err != nil {

--- a/internal/persis/store/queue_internal_test.go
+++ b/internal/persis/store/queue_internal_test.go
@@ -59,7 +59,7 @@ func TestQueueItemHelpersHandleInvalidRecords(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid record ID")
 
 	now := time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC)
-	data, enc, err := persis.Encode(queueItemPayload{
+	data, err := persis.Encode(queueItemPayload{
 		FileName: "bad-name.json",
 		DAGRun:   exec.DAGRunRef{},
 		QueuedAt: now,
@@ -69,7 +69,6 @@ func TestQueueItemHelpersHandleInvalidRecords(t *testing.T) {
 	item, err := queueItemFromRecord(&persis.Record{
 		ID:        "queue-a/item_low_20260102_030405_000000006Z_run",
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: now,
 	})
 	require.NoError(t, err)
@@ -151,7 +150,7 @@ func TestQueueStoreNextQueueItemIDSkipsExistingTimestamp(t *testing.T) {
 
 	s := NewQueueStore(testutil.NewMemoryBackend().Collection("queue"))
 	firstID := newQueueItemID(priority, dagRun.ID, start)
-	data, enc, err := persis.Encode(queueItemPayload{
+	data, err := persis.Encode(queueItemPayload{
 		FileName: firstID + ".json",
 		DAGRun:   dagRun,
 		QueuedAt: start,
@@ -160,7 +159,6 @@ func TestQueueStoreNextQueueItemIDSkipsExistingTimestamp(t *testing.T) {
 	require.NoError(t, s.col.Put(ctx, &persis.Record{
 		ID:        queueRecordID(queueName, firstID),
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: start,
 		UpdatedAt: start,
 	}))

--- a/internal/persis/store/secret.go
+++ b/internal/persis/store/secret.go
@@ -113,14 +113,13 @@ func (s *SecretStore) Create(ctx context.Context, sec *secret.Secret, initialVal
 		}
 	}
 
-	data, enc, err := persis.Encode(sr)
+	data, err := persis.Encode(sr)
 	if err != nil {
 		return err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        sec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: sec.CreatedAt,
 		UpdatedAt: sec.UpdatedAt,
 	}); err != nil {
@@ -236,14 +235,13 @@ func (s *SecretStore) Update(ctx context.Context, sec *secret.Secret) error {
 	}
 
 	existing.Secret = updated
-	data, enc, err := persis.Encode(&existing)
+	data, err := persis.Encode(&existing)
 	if err != nil {
 		return err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        sec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: existingRec.CreatedAt,
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {
@@ -307,14 +305,13 @@ func (s *SecretStore) WriteValue(ctx context.Context, id string, input secret.Wr
 	if err := s.appendVersion(&sr, input); err != nil {
 		return nil, err
 	}
-	data, enc, err := persis.Encode(&sr)
+	data, err := persis.Encode(&sr)
 	if err != nil {
 		return nil, err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        rec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {
@@ -368,14 +365,13 @@ func (s *SecretStore) ResolveValue(ctx context.Context, id string) (string, *sec
 	now := time.Now().UTC()
 	sr.Secret.LastResolvedAt = &now
 	sr.Secret.UpdatedAt = now
-	data, enc, err := persis.Encode(&sr)
+	data, err := persis.Encode(&sr)
 	if err != nil {
 		return "", nil, err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        rec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: now,
 	}); err != nil {

--- a/internal/persis/store/session.go
+++ b/internal/persis/store/session.go
@@ -139,7 +139,7 @@ func (s *SessionStore) CreateSession(ctx context.Context, sess *agent.Session) e
 	}
 
 	ss := sessionFromSession(sess, nil)
-	data, enc, err := persis.Encode(ss)
+	data, err := persis.Encode(ss)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,6 @@ func (s *SessionStore) CreateSession(ctx context.Context, sess *agent.Session) e
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        sess.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: sess.CreatedAt,
 		UpdatedAt: sess.UpdatedAt,
 	}); err != nil {
@@ -236,14 +235,13 @@ func (s *SessionStore) UpdateSession(ctx context.Context, sess *agent.Session) e
 	existing.Title = sess.Title
 	existing.UpdatedAt = sess.UpdatedAt
 
-	data, enc, err := persis.Encode(&existing)
+	data, err := persis.Encode(&existing)
 	if err != nil {
 		return err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        collID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: sess.UpdatedAt,
 	}); err != nil {
@@ -294,14 +292,13 @@ func (s *SessionStore) AddMessage(ctx context.Context, sessionID string, msg *ag
 	ss.UpdatedAt = time.Now().UTC()
 	sessionSetTitleFromMessage(&ss, msg)
 
-	data, enc, err := persis.Encode(&ss)
+	data, err := persis.Encode(&ss)
 	if err != nil {
 		return err
 	}
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        collID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: ss.UpdatedAt,
 	}); err != nil {

--- a/internal/persis/store/user.go
+++ b/internal/persis/store/user.go
@@ -76,7 +76,7 @@ func (s *UserStore) Create(ctx context.Context, user *auth.User) error {
 		return auth.ErrInvalidUsername
 	}
 
-	data, enc, err := persis.Encode(user.ToStorage())
+	data, err := persis.Encode(user.ToStorage())
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,6 @@ func (s *UserStore) Create(ctx context.Context, user *auth.User) error {
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        user.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: user.CreatedAt,
 		UpdatedAt: user.UpdatedAt,
 	}); err != nil {
@@ -200,7 +199,7 @@ func (s *UserStore) Update(ctx context.Context, user *auth.User) error {
 		return fmt.Errorf("user store: decode existing: %w", err)
 	}
 
-	data, enc, err := persis.Encode(user.ToStorage())
+	data, err := persis.Encode(user.ToStorage())
 	if err != nil {
 		return err
 	}
@@ -223,7 +222,6 @@ func (s *UserStore) Update(ctx context.Context, user *auth.User) error {
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        user.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: existingRec.CreatedAt,
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {

--- a/internal/persis/store/webhook.go
+++ b/internal/persis/store/webhook.go
@@ -75,7 +75,7 @@ func (s *WebhookStore) Create(ctx context.Context, webhook *auth.Webhook) error 
 	if err != nil {
 		return err
 	}
-	data, enc, err := persis.Encode(stored)
+	data, err := persis.Encode(stored)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,6 @@ func (s *WebhookStore) Create(ctx context.Context, webhook *auth.Webhook) error 
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        webhook.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: webhook.CreatedAt,
 		UpdatedAt: webhook.UpdatedAt,
 	}); err != nil {
@@ -179,7 +178,7 @@ func (s *WebhookStore) Update(ctx context.Context, webhook *auth.Webhook) error 
 	if err != nil {
 		return err
 	}
-	data, enc, err := persis.Encode(stored)
+	data, err := persis.Encode(stored)
 	if err != nil {
 		return err
 	}
@@ -192,7 +191,6 @@ func (s *WebhookStore) Update(ctx context.Context, webhook *auth.Webhook) error 
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        webhook.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: existingRec.CreatedAt,
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {
@@ -269,14 +267,13 @@ func (s *WebhookStore) UpdateLastUsed(ctx context.Context, id string) error {
 	}
 	now := time.Now().UTC()
 	stored.LastUsedAt = &now
-	data, enc, err := persis.Encode(stored)
+	data, err := persis.Encode(stored)
 	if err != nil {
 		return err
 	}
 	return s.col.Put(ctx, &persis.Record{
 		ID:        rec.ID,
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: rec.CreatedAt,
 		UpdatedAt: now,
 	})

--- a/internal/persis/store/workerheartbeat.go
+++ b/internal/persis/store/workerheartbeat.go
@@ -36,7 +36,7 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 	if record.LastHeartbeatAt == 0 {
 		record.LastHeartbeatAt = time.Now().UTC().UnixMilli()
 	}
-	data, enc, err := persis.Encode(record)
+	data, err := persis.Encode(record)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,6 @@ func (s *WorkerHeartbeatStore) Upsert(ctx context.Context, record exec.WorkerHea
 	return s.col.Put(ctx, &persis.Record{
 		ID:        workerHeartbeatKey(record.WorkerID),
 		Data:      data,
-		Encoding:  enc,
 		CreatedAt: now,
 		UpdatedAt: now,
 	})

--- a/internal/persis/testutil/memory.go
+++ b/internal/persis/testutil/memory.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dagucloud/dagu/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/internal/persis"
 )
 
@@ -61,14 +60,6 @@ var _ persis.Collection = (*MemoryCollection)(nil)
 
 func (c *MemoryCollection) WithLock(ctx context.Context, key string, fn func() error) error {
 	return c.withLock(ctx, key, 50*time.Millisecond, fn)
-}
-
-func (c *MemoryCollection) WithLockOptions(ctx context.Context, key string, opts dirlock.LockOptions, fn func() error) error {
-	retryInterval := opts.RetryInterval
-	if retryInterval <= 0 {
-		retryInterval = 50 * time.Millisecond
-	}
-	return c.withLock(ctx, key, retryInterval, fn)
 }
 
 func (c *MemoryCollection) withLock(ctx context.Context, key string, retryInterval time.Duration, fn func() error) error {
@@ -255,32 +246,6 @@ func (c *MemoryCollection) CompareAndSwap(_ context.Context, id string, expected
 	return nil
 }
 
-// Claim dequeues the lexicographically first record matching q.Prefix,
-// matching the natural filename ordering of [file.Collection.Claim].
-func (c *MemoryCollection) Claim(_ context.Context, q persis.ListQuery) (*persis.Record, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	var candidates []*persis.Record
-	for _, r := range c.records {
-		if q.Prefix != "" && !strings.HasPrefix(r.ID, q.Prefix) {
-			continue
-		}
-		candidates = append(candidates, r)
-	}
-	if len(candidates) == 0 {
-		return nil, persis.ErrNotFound
-	}
-
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].ID < candidates[j].ID
-	})
-
-	chosen := candidates[0]
-	delete(c.records, chosen.ID)
-	return copyRecord(chosen), nil
-}
-
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 func copyRecord(r *persis.Record) *persis.Record {
@@ -289,10 +254,6 @@ func copyRecord(r *persis.Record) *persis.Record {
 		cp.Data = make([]byte, len(r.Data))
 		copy(cp.Data, r.Data)
 	}
-	if r.ExpiresAt != nil {
-		t := *r.ExpiresAt
-		cp.ExpiresAt = &t
-	}
 	return &cp
 }
 
@@ -300,11 +261,8 @@ func sameMemoryRecord(a, b *persis.Record) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	// Identity must match the file backend (file/collection.go sameRecord):
-	// ID + Encoding + Data only. Timestamps and ExpiresAt are not part of
-	// CompareAndSwap / CompareAndDelete identity, so this test double must not
-	// compare them either — otherwise CAS semantics diverge from production.
-	return a.ID == b.ID && a.Encoding == b.Encoding && bytes.Equal(a.Data, b.Data)
+	// CAS identity is Data-only — must match file/collection.go sameRecord.
+	return a.ID == b.ID && bytes.Equal(a.Data, b.Data)
 }
 
 type memCursorVal struct {

--- a/internal/persis/testutil/memory.go
+++ b/internal/persis/testutil/memory.go
@@ -123,8 +123,8 @@ func (c *MemoryCollection) Put(_ context.Context, rec *persis.Record) error {
 	return nil
 }
 
-// Create atomically inserts rec. Returns [persis.ErrConflict] when a record
-// with rec.ID already exists. Mirrors the file backend's O_EXCL semantics.
+// Create atomically inserts rec. Returns [persis.ErrConflict] when a
+// record with rec.ID already exists.
 func (c *MemoryCollection) Create(_ context.Context, rec *persis.Record) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/persis/testutil/memory.go
+++ b/internal/persis/testutil/memory.go
@@ -123,6 +123,21 @@ func (c *MemoryCollection) Put(_ context.Context, rec *persis.Record) error {
 	return nil
 }
 
+// Create atomically inserts rec. Returns [persis.ErrConflict] when a record
+// with rec.ID already exists. Mirrors the file backend's O_EXCL semantics.
+func (c *MemoryCollection) Create(_ context.Context, rec *persis.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if rec == nil {
+		return fmt.Errorf("memory backend: nil record")
+	}
+	if _, ok := c.records[rec.ID]; ok {
+		return persis.ErrConflict
+	}
+	c.records[rec.ID] = copyRecord(rec)
+	return nil
+}
+
 func (c *MemoryCollection) Delete(ctx context.Context, id string) error {
 	_, err := c.DeleteIfExists(ctx, id)
 	return err

--- a/internal/service/coordinator/distributed_store_test.go
+++ b/internal/service/coordinator/distributed_store_test.go
@@ -19,9 +19,9 @@ func newTestWorkerHeartbeatStore(baseDir string) *store.WorkerHeartbeatStore {
 }
 
 func newTestDAGRunLeaseStore(baseDir string) *store.DAGRunLeaseStore {
-	return store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(baseDir, "leases"), baseDir))
+	return store.NewDAGRunLeaseStore(file.NewCollection(filepath.Join(baseDir, "leases")))
 }
 
 func newTestActiveDistributedRunStore(baseDir string) *store.ActiveDistributedRunStore {
-	return store.NewActiveDistributedRunStore(file.NewCollectionWithLockRoot(filepath.Join(baseDir, "active-runs"), baseDir))
+	return store.NewActiveDistributedRunStore(file.NewCollection(filepath.Join(baseDir, "active-runs")))
 }

--- a/internal/service/frontend/api/v1/queues_internal_test.go
+++ b/internal/service/frontend/api/v1/queues_internal_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newTestDAGRunLeaseStore(distributedDir string) *store.DAGRunLeaseStore {
-	return store.NewDAGRunLeaseStore(file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir))
+	return store.NewDAGRunLeaseStore(file.NewCollection(filepath.Join(distributedDir, "leases")))
 }
 
 func TestGetQueueFiltersDistributedRunsByLeaseFreshness(t *testing.T) {

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -69,7 +69,7 @@ func newQueueFixture(t *testing.T) *queueFixture {
 
 	tmpDir := t.TempDir()
 	distributedDir := filepath.Join(tmpDir, "distributed")
-	leaseCollection := file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir)
+	leaseCollection := file.NewCollection(filepath.Join(distributedDir, "leases"))
 	logBuffer := &syncBuffer{buf: new(bytes.Buffer)}
 	ctx := logger.WithFixedLogger(context.Background(), logger.NewLogger(
 		logger.WithDebug(), logger.WithFormat("text"), logger.WithWriter(logBuffer),

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -289,8 +289,8 @@ func Setup(t *testing.T, opts ...HelperOption) Helper {
 	}
 	dispatchTaskStore := store.NewDispatchTaskStore(file.NewCollection(distributedDir), dispatchStoreOpts...)
 	workerHeartbeatStore := store.NewWorkerHeartbeatStore(file.NewCollection(filepath.Join(distributedDir, "workers")))
-	leaseCollection := file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "leases"), distributedDir)
-	activeRunCollection := file.NewCollectionWithLockRoot(filepath.Join(distributedDir, "active-runs"), distributedDir)
+	leaseCollection := file.NewCollection(filepath.Join(distributedDir, "leases"))
+	activeRunCollection := file.NewCollection(filepath.Join(distributedDir, "active-runs"))
 	dagRunLeaseStore := store.NewDAGRunLeaseStore(leaseCollection)
 	activeDistributedRunStore := store.NewActiveDistributedRunStore(activeRunCollection)
 

--- a/refactor_persis_layer.html
+++ b/refactor_persis_layer.html
@@ -255,7 +255,7 @@ graph TB
 
   <!-- The Interface — full code -->
   <div class="bg-slate-900 rounded-xl p-8 mb-8 overflow-x-auto">
-    <p class="text-xs font-mono text-slate-400 mb-4">internal/persis/backend.go — THE SEAM (9 public methods total)</p>
+    <p class="text-xs font-mono text-slate-400 mb-4">internal/persis/backend.go — THE SEAM (Collection: 8 methods, Backend: 2 methods)</p>
     <pre class="text-sm text-slate-100 leading-relaxed"><span class="cm">// Package persis defines the storage backend interface for Dagu's control plane.</span>
 <span class="kw">package</span> <span class="ty">persis</span>
 
@@ -317,9 +317,18 @@ graph TB
     <span class="cm">// Put creates or replaces a record.</span>
     <span class="fn">Put</span>(ctx <span class="ty">context.Context</span>, rec *<span class="ty">Record</span>) <span class="kw">error</span>
 
+    <span class="cm">// Create atomically inserts rec, returning ErrConflict when the
+    // record already exists. Used for backend-neutral "must not exist"
+    // semantics — the create-if-absent half of optimistic concurrency.</span>
+    <span class="fn">Create</span>(ctx <span class="ty">context.Context</span>, rec *<span class="ty">Record</span>) <span class="kw">error</span>
+
     <span class="cm">// Delete removes the record with the given id.
     // Returns nil if the record does not exist.</span>
     <span class="fn">Delete</span>(ctx <span class="ty">context.Context</span>, id <span class="kw">string</span>) <span class="kw">error</span>
+
+    <span class="cm">// CompareAndDelete atomically removes expected.ID only when the
+    // current record still matches expected. ErrConflict on mismatch.</span>
+    <span class="fn">CompareAndDelete</span>(ctx <span class="ty">context.Context</span>, expected *<span class="ty">Record</span>) <span class="kw">error</span>
 
     <span class="cm">// List returns a page of records ordered by CreatedAt ascending.</span>
     <span class="fn">List</span>(ctx <span class="ty">context.Context</span>, q <span class="ty">ListQuery</span>) (*<span class="ty">Page</span>, <span class="kw">error</span>)
@@ -1010,8 +1019,8 @@ graph LR
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
       <div class="bg-green-900/40 border border-green-600/40 rounded-xl p-5">
         <p class="text-sm font-semibold text-green-300 mb-2">Interface surface</p>
-        <p class="text-3xl font-bold text-green-400">9</p>
-        <p class="text-sm text-slate-400 mt-1">methods across Backend + Collection (Create added)</p>
+        <p class="text-3xl font-bold text-green-400">10</p>
+        <p class="text-sm text-slate-400 mt-1">Collection 8 + Backend 2 (Create added)</p>
       </div>
       <div class="bg-green-900/40 border border-green-600/40 rounded-xl p-5">
         <p class="text-sm font-semibold text-green-300 mb-2">Stores ported</p>

--- a/refactor_persis_layer.html
+++ b/refactor_persis_layer.html
@@ -52,7 +52,7 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         Current branch as of May 27, 2026 — DAG-run compatibility slice
       </span>
-      <span class="text-slate-400 text-sm font-mono">Queue/dagrun/proc file compatibility done · distributed lock neutrality and SQL backend pending</span>
+      <span class="text-slate-400 text-sm font-mono">Queue/dagrun/proc file compatibility done · distributed CAS done · SQL backend pending</span>
     </div>
   </div>
 </header>
@@ -255,7 +255,7 @@ graph TB
 
   <!-- The Interface — full code -->
   <div class="bg-slate-900 rounded-xl p-8 mb-8 overflow-x-auto">
-    <p class="text-xs font-mono text-slate-400 mb-4">internal/persis/backend.go — THE SEAM (8 public methods total)</p>
+    <p class="text-xs font-mono text-slate-400 mb-4">internal/persis/backend.go — THE SEAM (9 public methods total)</p>
     <pre class="text-sm text-slate-100 leading-relaxed"><span class="cm">// Package persis defines the storage backend interface for Dagu's control plane.</span>
 <span class="kw">package</span> <span class="ty">persis</span>
 
@@ -584,7 +584,7 @@ graph TB
           <span class="text-green-500 text-xl mt-0.5">⬆</span>
           <div>
             <p class="font-medium text-slate-800">Leverage</p>
-            <p class="text-sm text-slate-600">8 methods unlock the collection-backed control-plane stores. Adding a new database still requires backend-neutral lock semantics for distributed stores and a backend-specific <code class="text-xs bg-slate-100 px-1 rounded">exec.DAGRunStore</code>.</p>
+            <p class="text-sm text-slate-600">9 methods unlock every collection-backed control-plane store including the distributed ones — they now run on CompareAndSwap + Create alone. Adding a new database still requires a backend-specific <code class="text-xs bg-slate-100 px-1 rounded">exec.DAGRunStore</code>.</p>
           </div>
         </div>
         <div class="flex gap-3">
@@ -734,7 +734,7 @@ graph TB
         <div class="ml-6 text-green-600">✅ workerheartbeat.go <span class="text-slate-400 ml-1">168 ln</span></div>
         <div class="ml-6 text-green-600">✅ queue*.go <span class="text-slate-400 ml-1">collection-backed QueueStore; filequeue removed</span></div>
         <div class="ml-6 text-amber-400">◐ proc*.go <span class="text-slate-400 ml-1">collection-backed ProcStore · unwired in production (file backend uses file/proc); for future non-file backends/tests</span></div>
-        <div class="ml-6 text-amber-400">◐ distributed*.go <span class="text-slate-400 ml-1">collection-backed records; lock API still file-backend-bound</span></div>
+        <div class="ml-6 text-green-600">✅ distributed*.go <span class="text-slate-400 ml-1">collection-backed records; CAS-only optimistic concurrency — no file-lock dependency</span></div>
         <div class="ml-4 mt-2 text-slate-400">── backend implementations ──</div>
         <div class="ml-4 text-emerald-600 font-semibold">✅ file/ <span class="text-slate-400 font-normal">FileBackend 480 ln (backend.go 50 + collection.go 430)</span></div>
         <div class="ml-4 text-slate-400">  backend.go</div>
@@ -955,7 +955,7 @@ graph LR
   A["✅ Step 1\nDefine interfaces\npersis/backend.go\npersis/codec.go\npersis/errors.go"] --&gt;
   B["✅ Step 2\nFileBackend\npersis/file/\nbackend.go + collection.go\n480 ln total"] --&gt;
   C["✅ Step 3\nPort stores\napikey, webhook, user\nsecret, session\nwatermark, workerheartbeat"] --&gt;
-  D["◐ Step 4\nComplex stores\nqueue ✅\nproc ✅\ndistributed lock gap"] --&gt;
+  D["✅ Step 4\nComplex stores\nqueue ✅\nproc ✅\ndistributed CAS ✅"] --&gt;
   E["✅ Step 5\nMove dagrun file store\npreserve exact layout"] --&gt;
   F["⏳ Step 6\nBackend-neutral locks\nSQL backend\nbackend-specific DAGRunStore"] --&gt;
   G["✅ Step 7\nMemoryBackend\npersis/testutil/\nmemory.go 217 ln"]
@@ -963,7 +963,7 @@ graph LR
   style A fill:#dcfce7,stroke:#16a34a
   style B fill:#dcfce7,stroke:#16a34a
   style C fill:#dcfce7,stroke:#16a34a
-  style D fill:#fef9c3,stroke:#ca8a04
+  style D fill:#dcfce7,stroke:#16a34a
   style E fill:#dcfce7,stroke:#16a34a
   style F fill:#fef9c3,stroke:#ca8a04
   style G fill:#dcfce7,stroke:#16a34a
@@ -1010,8 +1010,8 @@ graph LR
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
       <div class="bg-green-900/40 border border-green-600/40 rounded-xl p-5">
         <p class="text-sm font-semibold text-green-300 mb-2">Interface surface</p>
-        <p class="text-3xl font-bold text-green-400">8</p>
-        <p class="text-sm text-slate-400 mt-1">methods across Backend + Collection</p>
+        <p class="text-3xl font-bold text-green-400">9</p>
+        <p class="text-sm text-slate-400 mt-1">methods across Backend + Collection (Create added)</p>
       </div>
       <div class="bg-green-900/40 border border-green-600/40 rounded-xl p-5">
         <p class="text-sm font-semibold text-green-300 mb-2">Stores ported</p>
@@ -1020,8 +1020,8 @@ graph LR
       </div>
       <div class="bg-amber-900/40 border border-amber-600/40 rounded-xl p-5">
         <p class="text-sm font-semibold text-amber-300 mb-2">Neutrality gaps</p>
-        <p class="text-3xl font-bold text-amber-400">2</p>
-        <p class="text-sm text-slate-400 mt-1">distributed locks and backend-specific DAGRunStore</p>
+        <p class="text-3xl font-bold text-amber-400">1</p>
+        <p class="text-sm text-slate-400 mt-1">backend-specific DAGRunStore (distributed CAS done)</p>
       </div>
       <div class="bg-white/10 rounded-xl p-5">
         <p class="text-sm font-semibold text-slate-200 mb-2">Backend surface</p>
@@ -1049,7 +1049,7 @@ graph LR
       <div class="bg-amber-900/20 border border-amber-600/30 rounded-xl p-6">
         <p class="text-sm font-semibold text-amber-300 mb-3">⏳ Next — Phase 2</p>
         <ol class="text-sm text-slate-300 space-y-2">
-          <li><span class="text-amber-400 font-bold">4.</span> Replace distributed stores' file-lock dependency with backend-neutral lock/claim semantics.</li>
+          <li><span class="text-green-400 font-bold">✓</span> <s>Replace distributed stores' file-lock dependency with backend-neutral lock/claim semantics.</s> Lease/active/dispatch now use <code class="text-xs bg-white/10 px-1 rounded">CompareAndSwap</code> + a new <code class="text-xs bg-white/10 px-1 rounded">Collection.Create</code> primitive; <code class="text-xs bg-white/10 px-1 rounded">persis/store/</code> no longer imports <code class="text-xs bg-white/10 px-1 rounded">dirlock</code>.</li>
           <li><span class="text-amber-400 font-bold">5.</span> Keep DAG-run behind <code class="text-xs bg-white/10 px-1 rounded">exec.DAGRunStore</code>; add a backend-specific SQL implementation when DBMS support is added.</li>
           <li><span class="text-amber-400 font-bold">6.</span> Continue deleting old <code class="text-xs bg-white/10 px-1 rounded">file*/</code> packages only when their file-layout compatibility has a clear replacement.</li>
           <li><span class="text-amber-400 font-bold">7.</span> Unify wiring where it is honest to do so; do not hide file-specific behavior inside <code class="text-xs bg-white/10 px-1 rounded">persis/store</code>.</li>


### PR DESCRIPTION
## Summary

Close the first of the two **neutrality gaps** flagged in `refactor_persis_layer.html`: the distributed control-plane stores (`DAGRunLeaseStore`, `ActiveDistributedRunStore`, `DispatchTaskStore`) previously depended on a runtime type-assert into `WithLockOptions`, which only the file backend satisfies. SQL/etcd backends would have failed at runtime.

This PR moves all three stores to **pure optimistic concurrency** on the `persis.Collection` interface:

- Adds one new primitive: `Collection.Create(ctx, *Record) error`.
- Migrates lease/active to a `Get → Create or CompareAndSwap` retry shape via a new `retryCAS` helper.
- Drops the coarse `locks/dispatch_tasks` lock from dispatch — `CompareAndDelete(pending)` already provided per-task atomicity; count/has methods become eventually consistent.
- `internal/persis/store/` no longer imports `internal/cmn/dirlock`.

**Outcome:** doc's gap count goes 2 → 1 (only backend-specific `DAGRunStore` remains). SQL backend is unblocked for the distributed-store path.

## Commits

| Commit | What |
|---|---|
| `a8020e6f0` | Add `Create` primitive to `persis.Collection`. File backend uses `O_EXCL\|O_CREATE\|O_WRONLY`; memory backend is a map-existence check. Three contract subtests + 16-goroutine atomicity race test. |
| `fda7a3115` | New `retryCAS` helper: exponential full-jitter backoff 5ms→5s cap, matching the existing distributed-lock latency curve. Only `ErrConflict` retries; everything else propagates. |
| `00b01758d` | Migrate `DAGRunLeaseStore` (`Upsert`/`Touch`/`Delete`) and `ActiveDistributedRunStore` (`Upsert`/`Delete`). Caller-visible semantics preserved. Strengthen the existing concurrent-Touch test with distinct timestamps. Add concurrent-Touch+Upsert clobber test and concurrent-active-Upsert test. Remove the three obsolete file-lock-path tests. |
| `a5e03916c` | Drop coarse `withDispatchLock` from `DispatchTaskStore`'s three locked methods. Rename `*Locked` helpers. Collapse `distributed_key.go` to sha256 helper only — `dirlock` import gone from the package. |
| `8267da384` | Wiring: lease/active drop `NewCollectionWithLockRoot` for plain `NewCollection` (no more lock files written by these stores). Dispatch wiring unchanged. |
| `22709f9f2` | Doc: mark Phase 2 step 4 done; gap count 2→1; method count 8→9; mermaid diagram step D flips to green. |

## Why each piece

### `Collection.Create`

`CompareAndSwap` returns `ErrNotFound` when the record is missing — it cannot atomically create. Distributed Upsert needs "create if absent, replace if present" semantics. `Create` returns `ErrConflict` if the ID exists. Maps cleanly to SQL `INSERT ... ON CONFLICT DO NOTHING`, etcd `Txn(version=0)`, and file `O_EXCL`.

`WriteFileAtomic` was unsuitable for the file impl — its rename step is unconditional and would silently replace. `O_EXCL|O_CREATE|O_WRONLY` is the POSIX primitive that atomically fails on a pre-existing target, mapped by Go's runtime to `fs.ErrExist` on both Unix and Windows.

### `retryCAS`

Backend-neutral, package-internal. Total time is bounded by `ctx` (not an attempt cap) so callers control the deadline — matches today's `WithLockOptions` ctx-bound wait. Full-jitter spread is the standard mitigation against thundering-herd from heartbeat-aligned writers.

### Dispatch is different

`ClaimNext` already uses `CompareAndDelete(pending)` as the per-task atomicity point — the coarse lock was redundant for correctness. The inner loop's "Put claim → CompareAndDelete pending; on conflict, clean up claim and continue" handles racing pollers without any outer serialization. `CountOutstandingByQueue` and `HasOutstandingAttempt` become eventually consistent: a task in flight between `Put(claim)` and `CompareAndDelete(pending)` may be transiently counted twice. Acceptable for observability — callers (`handler_test.go` invocations included) read between dispatch operations, not during.

### Touch race "bug" doesn't exist

The exploration phase flagged a potential race in `Touch` where `s.Get` looked like it was outside the lock. After verifying the code, the `Get` is inside the `withLeaseLock` closure (invoked while the lock is held). No bug. Migration is purely about backend neutrality, not bug fixing.

## On-disk impact

- No format change. Lease, active-run, dispatch records keep their existing JSON layout.
- Lock directories (`<distributedDir>/locks/...`) are no longer created. Stale lock dirs from old releases become orphans — empty, harmless, no migration needed.
- `dirlock.Unlock` already removed lock files on shutdown; only the empty directory remains.

## Test coverage

- File + memory `Create` contract: 3 subtests (insert, conflict-when-present, after-delete) run via shared `RunCollectionContract`.
- `TestFileCollectionCreateIsAtomicAcrossGoroutines`: 16 goroutines race on the same ID under `-race`; exactly one wins, 15 see `ErrConflict`.
- `TestDAGRunLeaseStore_ConcurrentTouchPreservesLatestHeartbeat`: strengthened to use distinct timestamps so the assertion catches silent fold-to-one.
- `TestDAGRunLeaseStore_ConcurrentTouchAndUpsertNoClobber`: new — documents the CAS-retry semantic when Touch and Upsert race.
- `TestActiveDistributedRunStore_ConcurrentUpsertSerializes`: new — previously zero concurrent-Upsert coverage on the active store.
- All `make test` packages pass with `-race`. `make lint` clean.

## Out of scope

- SQL/etcd backend implementations.
- `proc_lock.go`, `dagstate.go`, `queue.go` `WithLock` callsites — they have legitimate non-CAS lock needs (kill-by-group, single-record locks, queue mutations) and will be ported separately.
- `file.NewCollectionWithLockRoot` constructor stays exported in case other callers need lock-root scoping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch distributed stores to backend-neutral optimistic concurrency (`CompareAndSwap` + new `Create`), remove file-lock dependency, and simplify `persis` to JSON-only. Dispatch keeps throughput with an in-process mutex; SQL/etcd backends are unblocked.

- New Features
  - Added `persis.Collection.Create(ctx, *Record) error` for atomic inserts (returns `ErrConflict`); file uses `O_EXCL`, memory mirrors; contract + atomicity tests added.
  - Added `retryCAS` with full-jitter backoff (5ms→5s); retries only on `ErrConflict`.

- Refactors
  - `DAGRunLeaseStore` and `ActiveDistributedRunStore` now use Get → Create|`CompareAndSwap` with `retryCAS`; `Touch` returns `ErrDAGRunLeaseNotFound` when missing; deletes are idempotent.
  - `DispatchTaskStore`: removed file-based `locks/dispatch_tasks` lock; restored an in-process mutex to serialize recycle/scan/claim; `ClaimNext` relies on `CompareAndDelete`; count/has are eventually consistent.
  - Simplified `persis`: dropped `Record.Encoding` and `ExpiresAt`; `Encode` now returns JSON bytes; removed `Collection.Claim` and `WithLockOptions`; deleted `file.NewCollectionWithLockRoot`; `distributed_key.go` now only provides the SHA-256 record key; wiring switches to `file.NewCollection`. Docs/tests updated; no on-disk format changes.
  - CI: pin Go to `1.26.3` in `.github/workflows/ci.yaml`.

<sup>Written for commit 27ab7348c39973b8fc7c5c726954a4373c782226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2219?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added atomic record creation mechanism to prevent concurrent insertion conflicts.

* **Improvements**
  * Enhanced concurrency handling in distributed lease and active-run stores for improved performance under concurrent access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->