### PR TITLE
fix: preserve dotenv env on retry

### DIFF
--- a/internal/cmd/export_test.go
+++ b/internal/cmd/export_test.go
@@ -1,0 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+var RestoreDAGFromStatusForTest = restoreDAGFromStatus

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -111,6 +111,7 @@ func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
 		return dag, nil
 	}
 
+	loadedEnv := append([]string{}, dag.Env...)
 	buildEnvMap := buildenv.ToMap(dag.Env)
 	for key, value := range dag.PresolvedBuildEnv {
 		if buildEnvMap == nil {
@@ -122,6 +123,7 @@ func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load presolved build env: %w", err)
 	}
+	transportEnv := buildenv.FromMap(presolvedBuildEnv)
 	for key, value := range presolvedBuildEnv {
 		if buildEnvMap == nil {
 			buildEnvMap = make(map[string]string)
@@ -152,7 +154,7 @@ func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
 	// Copy only fields excluded from JSON serialization (json:"-").
 	// All other fields (Queue, WorkerSelector, HandlerOn, Steps, Labels, etc.)
 	// are already correctly stored in dag.json and must be preserved.
-	dag.Env = fresh.Env
+	dag.Env = buildenv.AppendMissing(fresh.Env, loadedEnv, buildenv.FromMap(dag.PresolvedBuildEnv), transportEnv)
 	dag.Params = fresh.Params
 	dag.ParamsJSON = fresh.ParamsJSON
 	dag.SMTP = fresh.SMTP

--- a/internal/cmd/helper_external_test.go
+++ b/internal/cmd/helper_external_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dagucmd "github.com/dagucloud/dagu/internal/cmd"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestoreDAGFromStatusIncludesDotenvFromResolvedWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work", "quant-signal")
+	require.NoError(t, os.MkdirAll(workDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\nPROJECT_DIR=/work/quant-signal\n"), 0o600))
+
+	dag := &core.DAG{
+		Name:               "signal",
+		Location:           filepath.Join(root, "dags", "signal.yaml"),
+		WorkingDir:         "${QUANT_SIGNAL_DIR}",
+		Dotenv:             []string{".env"},
+		PresolvedBuildEnv:  map[string]string{"QUANT_SIGNAL_DIR": workDir},
+		BaseConfigData:     []byte("env:\n  - QUANT_SIGNAL_DIR: ${QUANT_SIGNAL_DIR}\n"),
+		WorkingDirExplicit: true,
+		YamlData: []byte(`
+working_dir: ${QUANT_SIGNAL_DIR}
+steps:
+  - name: run_signals
+    run: ${PYTHON_BIN} ${PROJECT_DIR}/signals/run_signals.py
+`),
+	}
+	status := &exec.DAGRunStatus{}
+
+	restored, err := dagucmd.RestoreDAGFromStatusForTest(context.Background(), dag, status)
+	require.NoError(t, err)
+
+	envMap := envSliceMap(restored.Env)
+	require.Equal(t, workDir, envMap["QUANT_SIGNAL_DIR"])
+	require.Equal(t, "/usr/local/bin/python", envMap["PYTHON_BIN"])
+	require.Equal(t, "/work/quant-signal", envMap["PROJECT_DIR"])
+}
+
+func envSliceMap(envs []string) map[string]string {
+	envMap := make(map[string]string)
+	for _, env := range envs {
+		key, value, ok := strings.Cut(env, "=")
+		if ok {
+			envMap[key] = value
+		}
+	}
+	return envMap
+}

--- a/internal/cmn/buildenv/env.go
+++ b/internal/cmn/buildenv/env.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -93,4 +94,75 @@ func ToMap(env []string) map[string]string {
 		return nil
 	}
 	return entries
+}
+
+// FromMap converts env entries into a deterministic KEY=value slice.
+func FromMap(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	entries := make([]string, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, key+"="+env[key])
+	}
+	return entries
+}
+
+// AppendMissing appends env entries whose keys are absent from base.
+// Duplicate extra keys use the last extra value, matching env slice semantics.
+func AppendMissing(base []string, extras ...[]string) []string {
+	result := append([]string{}, base...)
+	seen := make(map[string]struct{})
+	for _, entry := range result {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+
+	type indexedEntry struct {
+		index int
+		key   string
+		entry string
+	}
+
+	var entries []indexedEntry
+	lastIndex := make(map[string]int)
+	for _, extra := range extras {
+		for _, entry := range extra {
+			key, _, ok := strings.Cut(entry, "=")
+			if !ok || key == "" {
+				continue
+			}
+			index := len(entries)
+			entries = append(entries, indexedEntry{
+				index: index,
+				key:   key,
+				entry: entry,
+			})
+			lastIndex[key] = index
+		}
+	}
+
+	for _, item := range entries {
+		if _, ok := seen[item.key]; ok {
+			continue
+		}
+		if lastIndex[item.key] != item.index {
+			continue
+		}
+		result = append(result, item.entry)
+		seen[item.key] = struct{}{}
+	}
+
+	return result
 }

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dagucloud/dagu/internal/cmn/buildenv"
 	"github.com/dagucloud/dagu/internal/core"
 )
 
@@ -58,9 +59,12 @@ func ResolveEnv(ctx context.Context, dag *core.DAG, params any, opts ResolveEnvO
 		cloned.Env = nil
 	}
 	cloned.LoadDotEnv(ctx)
-	if buildEnv := buildEnvMap(cloned.Env); len(buildEnv) > 0 {
+	loadedEnv := append([]string{}, cloned.Env...)
+	buildEnv := buildEnvMap(loadedEnv)
+	if len(buildEnv) > 0 {
 		loadOpts = append(loadOpts, WithBuildEnv(buildEnv))
 	}
+	presolvedEnv := buildenv.FromMap(dag.PresolvedBuildEnv)
 
 	switch {
 	case len(dag.YamlData) > 0:
@@ -68,17 +72,17 @@ func ResolveEnv(ctx context.Context, dag *core.DAG, params any, opts ResolveEnvO
 		if err != nil {
 			return nil, err
 		}
-		return append([]string{}, fresh.Env...), nil
+		return buildenv.AppendMissing(fresh.Env, loadedEnv, presolvedEnv), nil
 
 	case dag.Location != "":
 		fresh, err := Load(ctx, dag.Location, loadOpts...)
 		if err != nil {
 			return nil, err
 		}
-		return append([]string{}, fresh.Env...), nil
+		return buildenv.AppendMissing(fresh.Env, loadedEnv, presolvedEnv), nil
 
 	default:
-		return append([]string{}, dag.Env...), nil
+		return buildenv.AppendMissing(dag.Env, loadedEnv, presolvedEnv), nil
 	}
 }
 

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEnvIncludesDotenvFromResolvedWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work", "quant-signal")
+	dagDir := filepath.Join(root, "dags")
+	require.NoError(t, os.MkdirAll(workDir, 0o750))
+	require.NoError(t, os.MkdirAll(dagDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env"), []byte("PYTHON_BIN=/usr/local/bin/python\nPROJECT_DIR=/work/quant-signal\n"), 0o600))
+
+	baseConfig := filepath.Join(root, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfig, fmt.Appendf(nil, "env:\n  - QUANT_SIGNAL_DIR: %q\n", workDir), 0o600))
+
+	dagFile := filepath.Join(dagDir, "signal.yaml")
+	require.NoError(t, os.WriteFile(dagFile, []byte(`
+working_dir: ${QUANT_SIGNAL_DIR}
+steps:
+  - name: run_signals
+    run: ${PYTHON_BIN} ${PROJECT_DIR}/signals/run_signals.py
+`), 0o600))
+
+	dag, err := spec.Load(context.Background(), dagFile, spec.WithBaseConfig(baseConfig))
+	require.NoError(t, err)
+
+	dag.Env = nil
+	env, err := spec.ResolveEnv(context.Background(), dag, spec.QuoteRuntimeParams(nil, dag.ParamDefs), spec.ResolveEnvOptions{
+		BaseConfig: baseConfig,
+	})
+	require.NoError(t, err)
+
+	envMap := runtimeEnvSliceMap(env)
+	require.Equal(t, workDir, envMap["QUANT_SIGNAL_DIR"])
+	require.Equal(t, "/usr/local/bin/python", envMap["PYTHON_BIN"])
+	require.Equal(t, "/work/quant-signal", envMap["PROJECT_DIR"])
+}
+
+func runtimeEnvSliceMap(envs []string) map[string]string {
+	envMap := make(map[string]string)
+	for _, env := range envs {
+		key, value, ok := strings.Cut(env, "=")
+		if ok {
+			envMap[key] = value
+		}
+	}
+	return envMap
+}


### PR DESCRIPTION
## Summary

Preserve dotenv-derived environment variables when retrying a DAG from a failed step.

## Changes

- Keep dotenv values loaded from a resolved `working_dir` when retry code rebuilds the DAG from stored YAML
- Preserve pre-resolved base/DAG env values alongside freshly parsed YAML env during retry restoration
- Add regression coverage for API retry env resolution and CLI retry restoration

## Related Issues

Closes #2223

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `go test ./internal/core/spec -run TestResolveEnvIncludesDotenvFromResolvedWorkingDir -count=1 -v`
- `go test -overlay /private/tmp/dagu-ignore-startall-overlay.json ./internal/cmd -run TestRestoreDAGFromStatusIncludesDotenvFromResolvedWorkingDir -count=1 -v`
- `go test ./internal/cmn/buildenv ./internal/core/spec -count=1`
- `go test -overlay /private/tmp/dagu-ignore-startall-overlay.json ./internal/cmd -count=1`
- `make test`
- `GOCACHE=/private/tmp/dagu-gocache GOLANGCI_LINT_CACHE=/private/tmp/dagu-golangci-cache make check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves dotenv-derived env vars when retrying a DAG, so `.env` files from a resolved `working_dir` remain in effect. Fixes inconsistent command expansion on retry.

- **Bug Fixes**
  - Keep dotenv values from resolved `working_dir` when retry rebuilds DAG from stored YAML.
  - Merge envs with new helpers in `internal/cmn/buildenv` (`FromMap`, `AppendMissing`) and apply in `internal/core/spec.ResolveEnv` and `internal/cmd.rebuildDAGFromYAML`.
  - Preserve pre-resolved base/DAG env alongside freshly parsed YAML env during retry.
  - Add regression tests for API and CLI retry paths.

<sup>Written for commit 7daf1ce58e85d2147c3b3e07522020eb313cf22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2225?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variables from `.env` files in DAG working directories are now properly included in resolved runtime environments.
  * Environment variable handling improved to preserve and merge variables rather than replacing them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->