### PR TITLE
chore: migrate Anthropic model references to current versions

### DIFF
--- a/internal/agent/presets.go
+++ b/internal/agent/presets.go
@@ -17,14 +17,14 @@ var modelPresets = []ModelConfig{
 	// --- Anthropic ---
 	// https://platform.claude.com/docs/en/docs/about-claude/models
 	// https://platform.claude.com/docs/en/docs/about-claude/pricing
+	{Name: "Anthropic Claude Opus 4.8", Provider: "anthropic", Model: "claude-opus-4-8",
+		ContextWindow: 1_000_000, MaxOutputTokens: 128_000,
+		InputCostPer1M: 5, OutputCostPer1M: 25, SupportsThinking: true,
+		Description: "Most capable to date. State-of-the-art long-horizon agentic work, knowledge work, and memory. 1M context."},
 	{Name: "Anthropic Claude Opus 4.7", Provider: "anthropic", Model: "claude-opus-4-7",
 		ContextWindow: 1_000_000, MaxOutputTokens: 128_000,
 		InputCostPer1M: 5, OutputCostPer1M: 25, SupportsThinking: true,
-		Description: "Most capable. Step-change improvement in agentic coding. 1M context."},
-	{Name: "Anthropic Claude Opus 4.6", Provider: "anthropic", Model: "claude-opus-4-6",
-		ContextWindow: 1_000_000, MaxOutputTokens: 128_000,
-		InputCostPer1M: 5, OutputCostPer1M: 25, SupportsThinking: true,
-		Description: "Previous Opus. Strong at complex agents and coding. 1M context."},
+		Description: "Previous Opus. Highly autonomous; strong long-horizon agentic work and coding. 1M context."},
 	{Name: "Anthropic Claude Sonnet 4.6", Provider: "anthropic", Model: "claude-sonnet-4-6",
 		ContextWindow: 1_000_000, MaxOutputTokens: 64_000,
 		InputCostPer1M: 3, OutputCostPer1M: 15, SupportsThinking: true,

--- a/internal/agent/store_test.go
+++ b/internal/agent/store_test.go
@@ -105,7 +105,7 @@ func TestModelConfig_ToLLMConfig(t *testing.T) {
 			ID:               "test-model",
 			Name:             "Test Model",
 			Provider:         "anthropic",
-			Model:            "claude-sonnet-4-5",
+			Model:            "claude-sonnet-4-6",
 			APIKey:           "sk-test-key-123",
 			BaseURL:          "https://custom.api.example.com",
 			ContextWindow:    200000,
@@ -119,7 +119,7 @@ func TestModelConfig_ToLLMConfig(t *testing.T) {
 		llmCfg := mc.ToLLMConfig()
 
 		assert.Equal(t, "anthropic", llmCfg.Provider)
-		assert.Equal(t, "claude-sonnet-4-5", llmCfg.Model)
+		assert.Equal(t, "claude-sonnet-4-6", llmCfg.Model)
 		assert.Equal(t, "sk-test-key-123", llmCfg.APIKey)
 		assert.Equal(t, "https://custom.api.example.com", llmCfg.BaseURL)
 	})

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -74,7 +74,7 @@ type ThinkingConfig struct {
 type ModelEntry struct {
 	// Provider is the LLM provider for this model.
 	Provider string `json:"provider"`
-	// Name is the model name (e.g., gpt-4o, claude-sonnet-4-20250514).
+	// Name is the model name (e.g., gpt-4o, claude-sonnet-4-6).
 	Name string `json:"name"`
 	// Temperature overrides the shared temperature for this model.
 	Temperature *float64 `json:"temperature,omitempty"`
@@ -93,7 +93,7 @@ type LLMConfig struct {
 	// Provider is the LLM provider (openai, anthropic, gemini, openrouter, local).
 	// Used for single model config (backward compatible).
 	Provider string `json:"provider,omitempty"`
-	// Model is the model to use (e.g., gpt-4o, claude-sonnet-4-20250514).
+	// Model is the model to use (e.g., gpt-4o, claude-sonnet-4-6).
 	// Used for single model config (backward compatible).
 	Model string `json:"model,omitempty"`
 	// Models is an array of models for fallback support.

--- a/internal/core/spec/llm_test.go
+++ b/internal/core/spec/llm_test.go
@@ -36,7 +36,7 @@ model:
   - provider: openai
     name: gpt-4
   - provider: anthropic
-    name: claude-sonnet-4-20250514
+    name: claude-sonnet-4-6
 `,
 			wantErr: "",
 		},

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -877,7 +877,7 @@ max_clean_up_time_sec: 30
 
 llm:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   system: "Override system prompt"
 
 steps:
@@ -903,7 +903,7 @@ steps:
 		// LLM overridden
 		require.NotNil(t, dag.LLM)
 		assert.Equal(t, "anthropic", dag.LLM.Provider)
-		assert.Equal(t, "claude-sonnet-4-20250514", dag.LLM.Model)
+		assert.Equal(t, "claude-sonnet-4-6", dag.LLM.Model)
 		assert.Equal(t, "Override system prompt", dag.LLM.System)
 
 		// Env still inherited from base (since not specified in override DAG)

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -284,7 +284,7 @@ type llmConfig struct {
 	Provider string `yaml:"provider,omitempty"`
 	// Model can be a string (single model) or array of model entries (fallback support).
 	// String example: "gpt-4o"
-	// Array example: [{provider: openai, name: gpt-4o}, {provider: anthropic, name: claude-sonnet-4-20250514}]
+	// Array example: [{provider: openai, name: gpt-4o}, {provider: anthropic, name: claude-sonnet-4-6}]
 	Model types.ModelValue `yaml:"model,omitempty"`
 	// System is the default system prompt for sessions.
 	System string `yaml:"system,omitempty"`

--- a/internal/core/spec/types/model_test.go
+++ b/internal/core/spec/types/model_test.go
@@ -31,8 +31,8 @@ func TestModelValue_UnmarshalYAML(t *testing.T) {
 		},
 		{
 			name:       "QuotedModelString",
-			input:      `"claude-sonnet-4-20250514"`,
-			wantString: "claude-sonnet-4-20250514",
+			input:      `"claude-sonnet-4-6"`,
+			wantString: "claude-sonnet-4-6",
 		},
 		{
 			name: "SingleEntryArray",
@@ -49,7 +49,7 @@ func TestModelValue_UnmarshalYAML(t *testing.T) {
 - provider: openai
   name: gpt-4o
 - provider: anthropic
-  name: claude-sonnet-4-20250514
+  name: claude-sonnet-4-6
 `,
 			wantIsArray: true,
 			wantLen:     2,
@@ -317,7 +317,7 @@ model:
   - provider: openai
     name: gpt-4o
   - provider: anthropic
-    name: claude-sonnet-4-20250514
+    name: claude-sonnet-4-6
 `,
 			wantIsArray: true,
 		},

--- a/internal/llm/providers/anthropic/anthropic_test.go
+++ b/internal/llm/providers/anthropic/anthropic_test.go
@@ -23,7 +23,7 @@ func TestBuildRequestBody_WebSearch(t *testing.T) {
 	t.Run("web search disabled - no tool added", func(t *testing.T) {
 		t.Parallel()
 		req := &llm.ChatRequest{
-			Model:    "claude-sonnet-4-20250514",
+			Model:    "claude-sonnet-4-6",
 			Messages: []llm.Message{{Role: llm.RoleUser, Content: "Hello"}},
 		}
 		body, err := provider.buildRequestBody(req, false)
@@ -37,7 +37,7 @@ func TestBuildRequestBody_WebSearch(t *testing.T) {
 	t.Run("web search enabled - tool appended", func(t *testing.T) {
 		t.Parallel()
 		req := &llm.ChatRequest{
-			Model:    "claude-sonnet-4-20250514",
+			Model:    "claude-sonnet-4-6",
 			Messages: []llm.Message{{Role: llm.RoleUser, Content: "Hello"}},
 			WebSearch: &llm.WebSearchRequest{
 				Enabled: true,
@@ -62,7 +62,7 @@ func TestBuildRequestBody_WebSearch(t *testing.T) {
 		t.Parallel()
 		maxUses := 5
 		req := &llm.ChatRequest{
-			Model:    "claude-sonnet-4-20250514",
+			Model:    "claude-sonnet-4-6",
 			Messages: []llm.Message{{Role: llm.RoleUser, Content: "Hello"}},
 			WebSearch: &llm.WebSearchRequest{
 				Enabled:        true,
@@ -97,7 +97,7 @@ func TestBuildRequestBody_WebSearch(t *testing.T) {
 	t.Run("web search alongside function tools", func(t *testing.T) {
 		t.Parallel()
 		req := &llm.ChatRequest{
-			Model:    "claude-sonnet-4-20250514",
+			Model:    "claude-sonnet-4-6",
 			Messages: []llm.Message{{Role: llm.RoleUser, Content: "Hello"}},
 			Tools: []llm.Tool{{
 				Type: "function",
@@ -278,7 +278,7 @@ func TestBuildRequestBody_ThinkingTokens(t *testing.T) {
 			t.Parallel()
 
 			req := &llm.ChatRequest{
-				Model: "claude-sonnet-4-20250514",
+				Model: "claude-sonnet-4-6",
 				Messages: []llm.Message{
 					{Role: llm.RoleUser, Content: "Hello"},
 				},

--- a/internal/persis/store/agentmodel_test.go
+++ b/internal/persis/store/agentmodel_test.go
@@ -37,7 +37,7 @@ func newFileAgentModelStore(t *testing.T, dir string) *store.AgentModelStore {
 }
 
 func sampleModel(id, name string) *agent.ModelConfig {
-	return &agent.ModelConfig{ID: id, Name: name, Provider: "anthropic", Model: "claude-opus-4-7"}
+	return &agent.ModelConfig{ID: id, Name: name, Provider: "anthropic", Model: "claude-opus-4-8"}
 }
 
 func TestAgentModelStore_CreateAndGetByID(t *testing.T) {

--- a/internal/runtime/builtin/chat/executor_test.go
+++ b/internal/runtime/builtin/chat/executor_test.go
@@ -271,7 +271,7 @@ func TestNewChatExecutor(t *testing.T) {
 			Name: "test",
 			LLM: &core.LLMConfig{
 				Provider: "anthropic",
-				Model:    "claude-sonnet-4-20250514",
+				Model:    "claude-sonnet-4-6",
 				System:   "You are a helpful assistant",
 			},
 		}

--- a/internal/service/frontend/api/v1/agent_models_test.go
+++ b/internal/service/frontend/api/v1/agent_models_test.go
@@ -215,7 +215,7 @@ func TestListAgentModels(t *testing.T) {
 			ID: "model-1", Name: "Model 1", Provider: "openai", Model: "gpt-4",
 		})
 		setup.modelStore.addModel(&agent.ModelConfig{
-			ID: "model-2", Name: "Model 2", Provider: "anthropic", Model: "claude-sonnet-4-5",
+			ID: "model-2", Name: "Model 2", Provider: "anthropic", Model: "claude-sonnet-4-6",
 		})
 		setup.configStore.config.DefaultModelID = "model-1"
 


### PR DESCRIPTION
## What

Migrates Anthropic model references in `internal/` to the current per-tier latest models (Opus → `claude-opus-4-8`, Sonnet → `claude-sonnet-4-6`, Haiku unchanged at `claude-haiku-4-5`).

### Changed

| File | Change |
|---|---|
| `internal/agent/presets.go` | Quick-add registry: add **Opus 4.8** (`claude-opus-4-8`) as top entry, shift Opus 4.7 into the previous-generation slot. Sonnet 4.6/4.5 + Haiku 4.5 already current. |
| `internal/core/llm.go`, `internal/core/spec/step.go` | godoc examples `claude-sonnet-4-20250514` → `claude-sonnet-4-6` |
| `internal/core/spec/{loader,llm,types/model}_test.go` | fixtures → `claude-sonnet-4-6` |
| `internal/llm/providers/anthropic/anthropic_test.go` | request fixtures → `claude-sonnet-4-6` |
| `internal/runtime/builtin/chat/executor_test.go` | chat-executor fixture → `claude-sonnet-4-6` |
| `internal/persis/store/agentmodel_test.go` | `claude-opus-4-7` → `claude-opus-4-8` |
| `internal/service/frontend/api/v1/agent_models_test.go` | `claude-sonnet-4-5` → `claude-sonnet-4-6` |
| `internal/agent/store_test.go` | `ToLLMConfig` mapping fixture → `claude-sonnet-4-6` |

### Deliberately left unchanged

- `internal/agent/provider_cache_test.go` (`claude-opus-4`) — provider cache-dedup key; identity incidental
- `internal/agent/store_test.go` slug cases + `slug.go` comment — exercise slug transformation, not model selection
- `internal/agent/store_test.go` `TestValidateModelID` (`claude-opus-4`) — exercises the ID-format validator
- `internal/llm/providers/openrouter/openrouter_test.go` (`anthropic/claude-sonnet-4`) — OpenRouter-namespaced routing ID, not a first-party Anthropic ID
- `ui/src/features/agent/modelProviders.ts` — anthropic placeholder already `claude-sonnet-4-6`

## Why

`claude-sonnet-4-20250514` (Sonnet 4.0) is deprecated (retires 2026-06-15); presets advertised Opus 4.7 as "most capable" while Opus 4.8 is current. No behavioral/API change — these are config/registry strings and test fixtures. No direct Anthropic SDK call sites are in scope, so no thinking/sampling-parameter changes are involved.

## Verification

`go test` passes for every touched package (`internal/agent`, `internal/core/spec`, `internal/core/spec/types`, `internal/llm/providers/anthropic`, `internal/persis/store`, `internal/runtime/builtin/chat`).

## Open questions for review

1. **presets.go Opus window** — kept 2 Opus entries (4.8 + 4.7), dropping the 4.6 quick-add slot. Prefer keeping 4.6 too (3-deep), or adding 4.8 without dropping any?
2. **Incidental fixtures** (cache/slug/validator) left stale. Want zero stale Claude strings instead?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Anthropic model references to current versions across presets, docs, and tests; no behavior change. Presets now surface `claude-opus-4-8` as most capable and use `claude-sonnet-4-6` (Haiku stays `claude-haiku-4-5`).

- **Refactors**
  - `internal/agent/presets.go`: add Opus 4.8 and move Opus 4.7 to previous-gen.
  - Replace `claude-sonnet-4-20250514`/`claude-sonnet-4-5` with `claude-sonnet-4-6` in examples and tests across `internal/core`, `internal/llm`, `internal/runtime`, and frontend API tests.
  - Update Opus fixtures to `claude-opus-4-8` where relevant.
  - Leave incidental cache/slug/ID-validator fixtures and OpenRouter-scoped IDs as-is.

<sup>Written for commit 65e0a201a06a8f2894655948d222e13aac13f838. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2227?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Anthropic Claude model presets: added Opus 4.8, revised Opus 4.7 description, removed Opus 4.6.
* **Tests**
  * Synchronized model identifiers across test fixtures and validation cases to reflect the updated Anthropic models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->