### PR TITLE
fix(ui): guard api-keys page against undefined config.license

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -45,6 +45,7 @@
             auditLogsDir: '~/.local/share/dagu/logs/admin/audit',
           },
           authMode: 'builtin',
+          setupRequired: false,
           gitSyncEnabled: true,
           agentEnabled: true,
           oidcEnabled: false,
@@ -52,6 +53,17 @@
           terminalEnabled: true,
           updateAvailable: true,
           latestVersion: 'v2.0.0',
+          license: {
+            valid: false,
+            plan: '',
+            expiry: '',
+            features: [],
+            gracePeriod: false,
+            graceEndsAt: '',
+            community: true,
+            source: '',
+            warningCode: '',
+          },
         };
       }
     </script>

--- a/ui/src/pages/api-keys/index.tsx
+++ b/ui/src/pages/api-keys/index.tsx
@@ -21,6 +21,7 @@ import {
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { TOKEN_KEY, useIsAdmin } from '@/contexts/AuthContext';
 import { useConfig } from '@/contexts/ConfigContext';
+import { useLicense } from '@/hooks/useLicense';
 import dayjs from '@/lib/dayjs';
 import ConfirmModal from '@/components/ui/confirm-dialog';
 import {
@@ -52,6 +53,7 @@ function attributionLabel(key: APIKey): string {
 
 export default function APIKeysPage() {
   const config = useConfig();
+  const license = useLicense();
   const isAdmin = useIsAdmin();
   const appBarContext = useContext(AppBarContext);
   const [apiKeys, setApiKeys] = useState<APIKey[]>([]);
@@ -62,7 +64,7 @@ export default function APIKeysPage() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingKey, setEditingKey] = useState<APIKey | null>(null);
   const [deletingKey, setDeletingKey] = useState<APIKey | null>(null);
-  const hasActiveLicense = config.license.valid || config.license.gracePeriod;
+  const hasActiveLicense = license.valid || license.gracePeriod;
   const communityLimitReached =
     !hasActiveLicense && apiKeys.length >= COMMUNITY_API_KEY_LIMIT;
 


### PR DESCRIPTION
## Problem

\`APIKeysPage\` (\`ui/src/pages/api-keys/index.tsx\`) read \`config.license.valid\` directly. The dev \`ui/index.html\` \`getConfig()\` was missing the \`license\` block (and also \`setupRequired\`), so under \`pnpm dev\` the page crashed:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'valid')
    at APIKeysPage (src/pages/api-keys/index.tsx)
\`\`\`

Production (Go template at \`internal/service/frontend/templates/base.gohtml\`) injects \`license\` and \`setupRequired\` correctly, so the crash only manifested in the dev harness.

## Fix

1. **\`ui/index.html\`** — populate \`setupRequired\` and a full \`license\` block in dev \`getConfig()\`, matching the \`Config\` / \`LicenseStatus\` shape declared in \`ui/src/contexts/ConfigContext.tsx\`.
2. **\`ui/src/pages/api-keys/index.tsx\`** — use the existing \`useLicense()\` hook (\`ui/src/hooks/useLicense.ts\`), which already falls back to a safe default when \`config.license\` is missing. Same pattern as the rest of the codebase.

## Audit

Grepped the codebase for similar unsafe \`config.X.Y\` reads:

- \`config.license.X\` — only \`api-keys/index.tsx:65\` (fixed by this PR).
- \`config.permissions.X\` — 15+ sites, all safe (dev \`getConfig()\` populates \`permissions\` fully).
- \`config.paths.X\` — safe (dev \`getConfig()\` populates \`paths\` fully).
- \`config.initialWorkspaces\` — already uses \`?? []\` fallback.

\`tsc --noEmit\` clean.

## Scope

Persistence-layer refactor is unrelated. The backend \`APIKeyStore\` (\`internal/persis/store/apikey.go\`) JSON layout and \`license.ActivationStore\` JSON layout are unchanged across recent PRs (#2220, #2222, #2226). This is purely a frontend dev-harness regression.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [ ] In dev (\`pnpm dev\`): navigate to /api-keys → page renders, no console error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dev-only crash on the API Keys page by guarding against a missing license config and aligning the dev config with production. The page now renders under `pnpm dev`; production was unaffected.

- **Bug Fixes**
  - `ui/index.html`: add `setupRequired` and a full `license` block to `getConfig()` for dev.
  - `ui/src/pages/api-keys/index.tsx`: switch to `useLicense()` and derive `hasActiveLicense` from it to avoid unsafe `config.license` reads.

<sup>Written for commit 7ec88a456b1bf7eceaa581d974408a55f5b66bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2228?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key creation now enforces active license status and community tier restrictions

* **Improvements**
  * License information enhanced with plan details, validity tracking, grace period support, and additional metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->