### PR TITLE
refactor: move coordinator transport behind runtime ports

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -586,6 +586,12 @@ func (c *Context) NewCoordinatorClient() coordinator.Client {
 	return cmdprocess.NewCoordinatorClient(c.Context, c.Config, c.ServiceRegistry)
 }
 
+func (c *Context) RuntimeDispatcherFactory() func(context.Context) (runtime.Dispatcher, error) {
+	return func(_ context.Context) (runtime.Dispatcher, error) {
+		return coordinator.NewRuntimeDispatcher(c.ServiceRegistry, c.Config.Core.Peer)
+	}
+}
+
 // NewScheduler creates a scheduler for this command context.
 func (c *Context) NewScheduler() (*scheduler.Scheduler, error) {
 	return cmdprocess.NewScheduler(cmdprocess.SchedulerConfig{

--- a/internal/cmd/dry.go
+++ b/internal/cmd/dry.go
@@ -88,6 +88,7 @@ func runDry(ctx *Context, args []string) error {
 			StateStore:                 ctx.StateStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
+			DispatcherFactory:          ctx.RuntimeDispatcherFactory(),
 			RootDAGRun:                 exec.NewDAGRunRef(dag.Name, dagRunID),
 			PeerConfig:                 ctx.Config.Core.Peer,
 			DefaultExecMode:            ctx.Config.DefaultExecMode,

--- a/internal/cmd/progress_remote.go
+++ b/internal/cmd/progress_remote.go
@@ -13,8 +13,6 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/output"
-	"github.com/dagucloud/dagu/internal/proto/convert"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"golang.org/x/term"
 )
 
@@ -98,19 +96,14 @@ func (p *RemoteProgressDisplay) animationLoop() {
 }
 
 // Update updates the display with new status from coordinator.
-func (p *RemoteProgressDisplay) Update(protoStatus *coordinatorv1.DAGRunStatusProto) {
-	if protoStatus == nil {
+func (p *RemoteProgressDisplay) Update(status *exec.DAGRunStatus) {
+	if status == nil {
 		return
 	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Convert proto to execution status
-	status, err := convert.ProtoToDAGRunStatus(protoStatus)
-	if err != nil || status == nil {
-		return
-	}
 	p.lastStatus = status
 
 	// Capture worker ID if available and update header

--- a/internal/cmd/restart.go
+++ b/internal/cmd/restart.go
@@ -179,6 +179,7 @@ func executeDAGWithRunID(ctx *Context, cli runtime.Manager, dag *core.DAG, dagRu
 			StateStore:                 ctx.StateStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
+			DispatcherFactory:          ctx.RuntimeDispatcherFactory(),
 			RootDAGRun:                 exec.NewDAGRunRef(dag.Name, dagRunID),
 			PeerConfig:                 ctx.Config.Core.Peer,
 			DefaultExecMode:            ctx.Config.DefaultExecMode,

--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -588,6 +588,7 @@ func executeRetry(ctx *Context, dag *core.DAG, status *exec.DAGRunStatus, rootRu
 			StateStore:                 ctx.StateStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
+			DispatcherFactory:          ctx.RuntimeDispatcherFactory(),
 			RootDAGRun:                 rootRun,
 			PeerConfig:                 ctx.Config.Core.Peer,
 			TriggerType:                triggerType,

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -22,12 +22,10 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/dispatch"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/workspace"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -530,6 +528,7 @@ func executeDAGRun(ctx *Context, d *core.DAG, parent exec.DAGRunRef, dagRunID st
 			StateStore:                 ctx.StateStore,
 			SecretStore:                as.SecretStore,
 			ServiceRegistry:            ctx.ServiceRegistry,
+			DispatcherFactory:          ctx.RuntimeDispatcherFactory(),
 			RootDAGRun:                 root,
 			PeerConfig:                 ctx.Config.Core.Peer,
 			TriggerType:                triggerType,
@@ -593,7 +592,7 @@ func dispatchToCoordinatorAndWait(ctx *Context, d *core.DAG, dagRunID string, sc
 	task := executor.CreateTask(
 		d.Name,
 		string(d.YamlData),
-		coordinatorv1.Operation_OPERATION_START,
+		exec.DispatchOperationStart,
 		dagRunID,
 		taskOpts...,
 	)
@@ -643,8 +642,7 @@ func handleDistributedCancellation(ctx context.Context, dag *core.DAG, dagRunID 
 				continue
 			}
 			progress.Update(resp.Status)
-			dagStatus, convErr := convert.ProtoToDAGRunStatus(resp.Status)
-			if convErr == nil && dagStatus != nil && !dagStatus.Status.IsActive() {
+			if !resp.Status.Status.IsActive() {
 				return originalErr
 			}
 		}
@@ -697,19 +695,14 @@ func waitForDAGCompletionWithProgress(ctx *Context, d *core.DAG, dagRunID string
 				progress.Update(resp.Status)
 			}
 
-			// Check status
-			dagStatus, convErr := convert.ProtoToDAGRunStatus(resp.Status)
-			if convErr != nil || dagStatus == nil {
-				continue
-			}
+			dagStatus := resp.Status
 			if !dagStatus.Status.IsActive() {
 				if dagStatus.Status.IsSuccess() {
 					logger.Info(ctx, "DAG completed successfully", tag.RunID(dagRunID))
 					return nil
 				}
-				// Include error details from response if available
-				if resp.Error != "" {
-					return fmt.Errorf("DAG run failed with status %s: %s", dagStatus.Status, resp.Error)
+				if dagStatus.Error != "" {
+					return fmt.Errorf("DAG run failed with status %s: %s", dagStatus.Status, dagStatus.Error)
 				}
 				return fmt.Errorf("DAG run failed with status: %s", dagStatus.Status)
 			}

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 var _ exec.DAGStore = (*mockDAGStore)(nil)
@@ -543,12 +542,12 @@ func TestCollector_Collect_WithWorkerHeartbeatMetrics(t *testing.T) {
 					"pool":   "gpu",
 					"region": "ap-northeast-1",
 				},
-				Stats: &coordinatorv1.WorkerStats{
+				Stats: &exec.WorkerStats{
 					TotalPollers: 4,
 					BusyPollers:  2,
-					RunningTasks: []*coordinatorv1.RunningTask{
-						{DagRunId: "run-1", DagName: "dag-1", StartedAt: now.Add(-2 * time.Minute).Unix()},
-						{DagRunId: "run-2", DagName: "dag-2", StartedAt: now.Add(-30 * time.Second).Unix()},
+					RunningTasks: []*exec.RunningTask{
+						{DAGRunID: "run-1", DAGName: "dag-1", StartedAt: now.Add(-2 * time.Minute).Unix()},
+						{DAGRunID: "run-2", DAGName: "dag-2", StartedAt: now.Add(-30 * time.Second).Unix()},
 					},
 				},
 				LastHeartbeatAt: now.Add(-2 * time.Second).UnixMilli(),

--- a/internal/core/exec/context.go
+++ b/internal/core/exec/context.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/dagstate"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 // Context contains the execution metadata for a dag-run.
@@ -179,26 +178,6 @@ func (r *RunStatus) MarshalJSON() ([]byte, error) {
 		Status:             r.Status.String(),
 		PendingStepRetries: r.PendingStepRetries,
 	}, "", "  ")
-}
-
-// Dispatcher defines the interface for coordinator operations
-type Dispatcher interface {
-	// Dispatch sends a task to the coordinator
-	Dispatch(ctx context.Context, task *coordinatorv1.Task) error
-
-	// Cleanup cleans up any resources used by the coordinator client
-	Cleanup(ctx context.Context) error
-
-	// GetDAGRunStatus retrieves the status of a DAG run from the coordinator.
-	// Used by parent DAGs to poll status of remote sub-DAGs.
-	// For sub-DAG queries, provide rootRef to look up the status under the root DAG run.
-	// Returns (nil, nil) if the DAG run is not found.
-	GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error)
-
-	// RequestCancel requests cancellation of a DAG run through the coordinator.
-	// Used in shared-nothing mode for sub-DAG cancellation where the parent
-	// worker cannot directly access the sub-DAG's attempt.
-	RequestCancel(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) error
 }
 
 // contextOptions holds optional configuration for NewContext.

--- a/internal/core/exec/dispatch.go
+++ b/internal/core/exec/dispatch.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec
+
+import (
+	"context"
+	"fmt"
+)
+
+// DispatchOperation identifies the operation requested for a distributed DAG run.
+type DispatchOperation int32
+
+const (
+	DispatchOperationUnspecified DispatchOperation = iota
+	DispatchOperationStart
+	DispatchOperationRetry
+)
+
+func (o DispatchOperation) String() string {
+	switch o {
+	case DispatchOperationStart:
+		return "start"
+	case DispatchOperationRetry:
+		return "retry"
+	case DispatchOperationUnspecified:
+		return "unspecified"
+	default:
+		return fmt.Sprintf("DispatchOperation(%d)", o)
+	}
+}
+
+// DispatchTask describes a DAG run request for a distributed executor.
+type DispatchTask struct {
+	RootDAGRunName string
+	RootDAGRunID   string
+
+	ParentDAGRunName string
+	ParentDAGRunID   string
+
+	Operation  DispatchOperation
+	DAGRunID   string
+	Target     string
+	Definition string
+	AttemptID  string
+	AttemptKey string
+	Step       string
+	Params     string
+	QueueName  string
+	WorkerID   string
+
+	PreviousStatus *DAGRunStatus
+
+	BaseConfig   string
+	Labels       string
+	ScheduleTime string
+	SourceFile   string
+
+	WorkerSelector map[string]string
+	AgentSnapshot  []byte
+
+	ExternalStepRetry bool
+
+	WorkspaceBundleDigest      string
+	WorkspaceBundleSize        int64
+	WorkspaceBundleDAGPath     string
+	WorkspaceBundleOriginalRef string
+	WorkspaceBundleResolvedRef string
+
+	Owner      CoordinatorEndpoint
+	ClaimToken string
+}
+
+// DAGRunStatusResult is a distributed status lookup result.
+type DAGRunStatusResult struct {
+	Found  bool
+	Status *DAGRunStatus
+}
+
+// Dispatcher defines distributed DAG run operations.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, task *DispatchTask) error
+	Cleanup(ctx context.Context) error
+	GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) (*DAGRunStatusResult, error)
+	RequestCancel(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) error
+}

--- a/internal/core/exec/dispatch_test.go
+++ b/internal/core/exec/dispatch_test.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDispatchOperationStringUsesDomainNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		op   exec.DispatchOperation
+		want string
+	}{
+		{name: "unspecified", op: exec.DispatchOperationUnspecified, want: "unspecified"},
+		{name: "start", op: exec.DispatchOperationStart, want: "start"},
+		{name: "retry", op: exec.DispatchOperationRetry, want: "retry"},
+		{name: "unknown", op: exec.DispatchOperation(99), want: "DispatchOperation(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.op.String())
+		})
+	}
+}

--- a/internal/core/exec/distributed.go
+++ b/internal/core/exec/distributed.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 var (
@@ -59,7 +58,7 @@ type DispatchTaskClaim struct {
 // ClaimedDispatchTask is a shared pending task that has been claimed by a
 // specific worker poller and must be acknowledged before execution begins.
 type ClaimedDispatchTask struct {
-	Task       *coordinatorv1.Task
+	Task       *DispatchTask
 	ClaimToken string
 	ClaimedAt  time.Time
 	WorkerID   string
@@ -69,9 +68,10 @@ type ClaimedDispatchTask struct {
 
 // DispatchTaskStore manages the shared distributed dispatch queue.
 type DispatchTaskStore interface {
-	Enqueue(ctx context.Context, task *coordinatorv1.Task) error
+	Enqueue(ctx context.Context, task *DispatchTask) error
 	ClaimNext(ctx context.Context, claim DispatchTaskClaim) (*ClaimedDispatchTask, error)
 	GetClaim(ctx context.Context, claimToken string) (*ClaimedDispatchTask, error)
+	ReleaseClaim(ctx context.Context, claimToken string) error
 	DeleteClaim(ctx context.Context, claimToken string) error
 	CountOutstandingByQueue(ctx context.Context, queueName string, claimTimeout time.Duration) (int, error)
 	HasOutstandingAttempt(ctx context.Context, attemptKey string, claimTimeout time.Duration) (bool, error)
@@ -79,10 +79,29 @@ type DispatchTaskStore interface {
 
 // WorkerHeartbeatRecord is the shared presence record for a worker.
 type WorkerHeartbeatRecord struct {
-	WorkerID        string                     `json:"workerId"`
-	Labels          map[string]string          `json:"labels,omitempty"`
-	Stats           *coordinatorv1.WorkerStats `json:"stats,omitempty"`
-	LastHeartbeatAt int64                      `json:"lastHeartbeatAt"`
+	WorkerID        string            `json:"workerId"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	Stats           *WorkerStats      `json:"stats,omitempty"`
+	LastHeartbeatAt int64             `json:"lastHeartbeatAt"`
+}
+
+// WorkerStats describes worker poller capacity and running distributed tasks.
+type WorkerStats struct {
+	TotalPollers int32          `json:"totalPollers,omitempty"`
+	BusyPollers  int32          `json:"busyPollers,omitempty"`
+	RunningTasks []*RunningTask `json:"runningTasks,omitempty"`
+}
+
+// RunningTask describes one task currently executing on a worker.
+type RunningTask struct {
+	DAGRunID         string `json:"dagRunId,omitempty"`
+	DAGName          string `json:"dagName,omitempty"`
+	StartedAt        int64  `json:"startedAt,omitempty"`
+	RootDAGRunName   string `json:"rootDagRunName,omitempty"`
+	RootDAGRunID     string `json:"rootDagRunId,omitempty"`
+	ParentDAGRunName string `json:"parentDagRunName,omitempty"`
+	ParentDAGRunID   string `json:"parentDagRunId,omitempty"`
+	AttemptKey       string `json:"attemptKey,omitempty"`
 }
 
 // LastHeartbeatTime returns the last heartbeat as a time.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -202,6 +202,12 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 	return coordinator.New(registry, cfg), nil
 }
 
+func (e *Engine) runtimeDispatcherFactory() func(context.Context) (runtime.Dispatcher, error) {
+	return func(_ context.Context) (runtime.Dispatcher, error) {
+		return coordinator.NewRuntimeDispatcher(e.serviceRegistry, e.cfg.Core.Peer)
+	}
+}
+
 func runStatusToPublic(status *coreexec.DAGRunStatus) (*Status, error) {
 	if status == nil {
 		return nil, nil

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -25,12 +25,10 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	coreexec "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/workspace"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 func (e *Engine) RunFile(ctx context.Context, path string, opts RunOptions) (*Run, error) {
@@ -100,18 +98,14 @@ func (r *Run) Wait(ctx context.Context) (*Status, error) {
 
 func (r *Run) Status(ctx context.Context) (*Status, error) {
 	if r.mode == ExecutionModeDistributed {
-		resp, err := r.coordinator.GetDAGRunStatus(ctx, r.ref.Name, r.ref.ID, nil)
+		result, err := r.coordinator.GetDAGRunStatus(ctx, r.ref.Name, r.ref.ID, nil)
 		if err != nil {
 			return nil, err
 		}
-		if resp == nil || resp.Status == nil {
+		if result == nil || !result.Found || result.Status == nil {
 			return nil, nil
 		}
-		status, err := convert.ProtoToDAGRunStatus(resp.Status)
-		if err != nil {
-			return nil, err
-		}
-		return runStatusToPublic(status)
+		return runStatusToPublic(result.Status)
 	}
 	if r.agent != nil {
 		select {
@@ -361,6 +355,7 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 			StateStore:                 e.stateStore,
 			SecretStore:                stores.SecretStore,
 			ServiceRegistry:            e.serviceRegistry,
+			DispatcherFactory:          e.runtimeDispatcherFactory(),
 			RootDAGRun:                 root,
 			PeerConfig:                 e.cfg.Core.Peer,
 			TriggerType:                core.TriggerTypeManual,
@@ -440,7 +435,7 @@ func (e *Engine) runDistributed(ctx context.Context, dag *core.DAG, runID string
 	task := runtimeexec.CreateTask(
 		dag.Name,
 		string(dag.YamlData),
-		coordinatorv1.Operation_OPERATION_START,
+		coreexec.DispatchOperationStart,
 		runID,
 		taskOpts...,
 	)

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/procutil"
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 // CommandError wraps a command execution error with captured output.
@@ -300,7 +299,7 @@ func (b *SubCmdBuilder) QueueDispatchRetry(dag *core.DAG, dagRunID string, stepN
 }
 
 // QueueDispatchTaskRetry creates a retry command spec for a worker-consumed queued run.
-func (b *SubCmdBuilder) QueueDispatchTaskRetry(task *coordinatorv1.Task, envHints []string, dagName string) CmdSpec {
+func (b *SubCmdBuilder) QueueDispatchTaskRetry(task *exec1.DispatchTask, envHints []string, dagName string) CmdSpec {
 	spec := b.TaskRetry(task, envHints, dagName)
 	spec.Env = append(spec.Env, exec1.EnvKeyQueueDispatchRetry+"=1")
 	return spec
@@ -309,26 +308,26 @@ func (b *SubCmdBuilder) QueueDispatchTaskRetry(task *coordinatorv1.Task, envHint
 // TaskStart creates a start command spec for coordinator tasks.
 // envHints optionally provides resolved DAG/base-config env entries for
 // rebuild-time env values in the child process.
-func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task, envHints []string, dagName string) CmdSpec {
+func (b *SubCmdBuilder) TaskStart(task *exec1.DispatchTask, envHints []string, dagName string) CmdSpec {
 	args := []string{"start", "-q"}
 	env := b.parentEnv()
 
 	// Add hierarchy flags for sub DAGs
-	if task.RootDagRunId != "" {
-		args = append(args, fmt.Sprintf("--root=%s:%s", task.RootDagRunName, task.RootDagRunId))
+	if task.RootDAGRunID != "" {
+		args = append(args, fmt.Sprintf("--root=%s:%s", task.RootDAGRunName, task.RootDAGRunID))
 	}
-	if task.ParentDagRunId != "" {
-		args = append(args, fmt.Sprintf("--parent=%s:%s", task.ParentDagRunName, task.ParentDagRunId))
+	if task.ParentDAGRunID != "" {
+		args = append(args, fmt.Sprintf("--parent=%s:%s", task.ParentDAGRunName, task.ParentDAGRunID))
 	}
 
-	args = append(args, fmt.Sprintf("--run-id=%s", task.DagRunId))
-	if task.AttemptId != "" {
-		args = append(args, fmt.Sprintf("--attempt-id=%s", task.AttemptId))
+	args = append(args, fmt.Sprintf("--run-id=%s", task.DAGRunID))
+	if task.AttemptID != "" {
+		args = append(args, fmt.Sprintf("--attempt-id=%s", task.AttemptID))
 	}
 
 	// Override derived name since temp files lack 'name:' field
 	if dagName == "" {
-		dagName = task.RootDagRunName
+		dagName = task.RootDAGRunName
 	}
 	if dagName == "" {
 		dagName = dagNameHint(task.Target)
@@ -338,8 +337,8 @@ func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task, envHints []string, d
 	}
 
 	// Worker ID prevents re-dispatch to coordinator
-	if task.WorkerId != "" {
-		args = append(args, fmt.Sprintf("--worker-id=%s", task.WorkerId))
+	if task.WorkerID != "" {
+		args = append(args, fmt.Sprintf("--worker-id=%s", task.WorkerID))
 	}
 
 	if task.Labels != "" {
@@ -375,11 +374,11 @@ func (b *SubCmdBuilder) TaskStart(task *coordinatorv1.Task, envHints []string, d
 // TaskRetry creates a retry command spec for coordinator tasks.
 // envHints optionally provides resolved DAG/base-config env entries for
 // rebuild-time env values in the child process.
-func (b *SubCmdBuilder) TaskRetry(task *coordinatorv1.Task, envHints []string, dagName string) CmdSpec {
-	args := []string{"retry", fmt.Sprintf("--run-id=%s", task.DagRunId), "-q"}
+func (b *SubCmdBuilder) TaskRetry(task *exec1.DispatchTask, envHints []string, dagName string) CmdSpec {
+	args := []string{"retry", fmt.Sprintf("--run-id=%s", task.DAGRunID), "-q"}
 	env := b.parentEnv()
-	if task.AttemptId != "" {
-		args = append(args, fmt.Sprintf("--attempt-id=%s", task.AttemptId))
+	if task.AttemptID != "" {
+		args = append(args, fmt.Sprintf("--attempt-id=%s", task.AttemptID))
 	}
 
 	if task.Step != "" {
@@ -387,15 +386,15 @@ func (b *SubCmdBuilder) TaskRetry(task *coordinatorv1.Task, envHints []string, d
 	}
 
 	// Pass worker ID for tracking which worker executes this DAG run
-	if task.WorkerId != "" {
-		args = append(args, fmt.Sprintf("--worker-id=%s", task.WorkerId))
+	if task.WorkerID != "" {
+		args = append(args, fmt.Sprintf("--worker-id=%s", task.WorkerID))
 	}
 
 	if b.configFile != "" {
 		args = append(args, "--config", b.configFile)
 	}
 	if dagName == "" {
-		dagName = task.RootDagRunName
+		dagName = task.RootDAGRunName
 	}
 	if dagName == "" {
 		dagName = dagNameHint(task.Target)

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dagucloud/dagu/internal/launcher"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/test"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 func TestNewSubCmdBuilder(t *testing.T) {
@@ -719,9 +718,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("BasicTaskStart", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:  "task-run-id",
-			AttemptId: "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:  "task-run-id",
+			AttemptID: "attempt-1",
 			Target:    "/path/to/task.yaml",
 		}
 		spec := builder.TaskStart(task, nil, "")
@@ -738,13 +737,13 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithHierarchy", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:         "child-run-id",
+		task := &exec.DispatchTask{
+			DAGRunID:         "child-run-id",
 			Target:           "/path/to/child.yaml",
-			RootDagRunId:     "root-id",
-			RootDagRunName:   "root-dag",
-			ParentDagRunId:   "parent-id",
-			ParentDagRunName: "parent-dag",
+			RootDAGRunID:     "root-id",
+			RootDAGRunName:   "root-dag",
+			ParentDAGRunID:   "parent-id",
+			ParentDAGRunName: "parent-dag",
 		}
 		spec := builder.TaskStart(task, nil, "")
 
@@ -756,11 +755,11 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithExplicitDagName", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "child-run-id",
+		task := &exec.DispatchTask{
+			DAGRunID:       "child-run-id",
 			Target:         "/tmp/worker-child.yaml",
-			RootDagRunId:   "root-id",
-			RootDagRunName: "root-dag",
+			RootDAGRunID:   "root-id",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskStart(task, nil, "child-dag")
 
@@ -772,9 +771,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithParams", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:  "task-run-id",
-			AttemptId: "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:  "task-run-id",
+			AttemptID: "attempt-1",
 			Target:    "/path/to/task.yaml",
 			Params:    "env=production",
 		}
@@ -786,11 +785,11 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithRootOnly", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "task-run-id",
+		task := &exec.DispatchTask{
+			DAGRunID:       "task-run-id",
 			Target:         "/path/to/task.yaml",
-			RootDagRunId:   "root-id",
-			RootDagRunName: "root-dag",
+			RootDAGRunID:   "root-id",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskStart(task, nil, "")
 
@@ -803,11 +802,11 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithParentOnly", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:         "task-run-id",
+		task := &exec.DispatchTask{
+			DAGRunID:         "task-run-id",
 			Target:           "/path/to/task.yaml",
-			ParentDagRunId:   "parent-id",
-			ParentDagRunName: "parent-dag",
+			ParentDAGRunID:   "parent-id",
+			ParentDAGRunName: "parent-dag",
 		}
 		spec := builder.TaskStart(task, nil, "")
 
@@ -820,9 +819,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithLabels", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:  "task-run-id",
-			AttemptId: "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:  "task-run-id",
+			AttemptID: "attempt-1",
 			Target:    "/path/to/task.yaml",
 			Labels:    "env=prod,team=backend",
 		}
@@ -833,9 +832,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithScheduleTime", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:     "task-run-id",
-			AttemptId:    "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:     "task-run-id",
+			AttemptID:    "attempt-1",
 			Target:       "/path/to/task.yaml",
 			ScheduleTime: "2026-03-13T10:00:00Z",
 		}
@@ -846,9 +845,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithSourceFile", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:   "task-run-id",
-			AttemptId:  "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:   "task-run-id",
+			AttemptID:  "attempt-1",
 			Target:     "/path/to/task.yaml",
 			SourceFile: "/dags/original.yaml",
 		}
@@ -859,9 +858,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithExternalStepRetry", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:          "task-run-id",
-			AttemptId:         "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:          "task-run-id",
+			AttemptID:         "attempt-1",
 			Target:            "/path/to/task.yaml",
 			ExternalStepRetry: true,
 		}
@@ -872,9 +871,9 @@ func TestTaskStart(t *testing.T) {
 
 	t.Run("TaskStartWithoutLabels", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:  "task-run-id",
-			AttemptId: "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:  "task-run-id",
+			AttemptID: "attempt-1",
 			Target:    "/path/to/task.yaml",
 		}
 		spec := builder.TaskStart(task, nil, "")
@@ -892,9 +891,9 @@ func TestTaskStart(t *testing.T) {
 			},
 		}
 		builderNoFile := launcher.NewSubCmdBuilder(cfgNoFile)
-		task := &coordinatorv1.Task{
-			DagRunId:  "task-run-id",
-			AttemptId: "attempt-1",
+		task := &exec.DispatchTask{
+			DAGRunID:  "task-run-id",
+			AttemptID: "attempt-1",
 			Target:    "/path/to/task.yaml",
 		}
 		spec := builderNoFile.TaskStart(task, nil, "")
@@ -915,11 +914,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("BasicTaskRetry", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "retry-run-id",
-			AttemptId:      "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:       "retry-run-id",
+			AttemptID:      "attempt-2",
 			Target:         "/path/to/task.yaml",
-			RootDagRunName: "root-dag",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskRetry(task, nil, "")
 
@@ -934,9 +933,9 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("TaskRetryWithStep", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:  "retry-run-id",
-			AttemptId: "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:  "retry-run-id",
+			AttemptID: "attempt-2",
 			Target:    "/path/to/task.yaml",
 			Step:      "failed-step",
 		}
@@ -947,11 +946,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("TaskRetryWithExplicitDagName", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "retry-run-id",
-			AttemptId:      "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:       "retry-run-id",
+			AttemptID:      "attempt-2",
 			Target:         "/tmp/worker-child.yaml",
-			RootDagRunName: "root-dag",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskRetry(task, nil, "child-dag")
 
@@ -961,11 +960,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("TaskRetryWithExternalStepRetry", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:          "retry-run-id",
-			AttemptId:         "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:          "retry-run-id",
+			AttemptID:         "attempt-2",
 			Target:            "/path/to/task.yaml",
-			RootDagRunName:    "root-dag",
+			RootDAGRunName:    "root-dag",
 			ExternalStepRetry: true,
 		}
 		spec := builder.TaskRetry(task, nil, "")
@@ -975,11 +974,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("TaskRetryDoesNotMarkQueueDispatch", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "retry-run-id",
-			AttemptId:      "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:       "retry-run-id",
+			AttemptID:      "attempt-2",
 			Target:         "/path/to/task.yaml",
-			RootDagRunName: "root-dag",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskRetry(task, nil, "")
 
@@ -988,11 +987,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("TaskRetryStripsInheritedQueueDispatchMarker", func(t *testing.T) {
 		t.Setenv(exec.EnvKeyQueueDispatchRetry, "1")
-		task := &coordinatorv1.Task{
-			DagRunId:       "retry-run-id",
-			AttemptId:      "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:       "retry-run-id",
+			AttemptID:      "attempt-2",
 			Target:         "/path/to/task.yaml",
-			RootDagRunName: "root-dag",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.TaskRetry(task, nil, "")
 
@@ -1001,11 +1000,11 @@ func TestTaskRetry(t *testing.T) {
 
 	t.Run("QueueDispatchTaskRetryMarksQueueDispatch", func(t *testing.T) {
 		t.Parallel()
-		task := &coordinatorv1.Task{
-			DagRunId:       "retry-run-id",
-			AttemptId:      "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:       "retry-run-id",
+			AttemptID:      "attempt-2",
 			Target:         "/path/to/task.yaml",
-			RootDagRunName: "root-dag",
+			RootDAGRunName: "root-dag",
 		}
 		spec := builder.QueueDispatchTaskRetry(task, nil, "")
 
@@ -1020,9 +1019,9 @@ func TestTaskRetry(t *testing.T) {
 			},
 		}
 		builderNoFile := launcher.NewSubCmdBuilder(cfgNoFile)
-		task := &coordinatorv1.Task{
-			DagRunId:  "retry-run-id",
-			AttemptId: "attempt-2",
+		task := &exec.DispatchTask{
+			DAGRunID:  "retry-run-id",
+			AttemptID: "attempt-2",
 			Target:    "/path/to/task.yaml",
 		}
 		spec := builderNoFile.TaskRetry(task, nil, "")

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
+	"maps"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,11 +15,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 const (
@@ -49,7 +47,7 @@ type DispatchTaskStore struct {
 
 type dispatchTaskPayload struct {
 	Version      int                      `json:"version"`
-	Task         *coordinatorv1.Task      `json:"task"`
+	Task         *exec.DispatchTask       `json:"task"`
 	TaskFileName string                   `json:"taskFileName"`
 	EnqueuedAt   int64                    `json:"enqueuedAt"`
 	ClaimToken   string                   `json:"claimToken,omitempty"`
@@ -79,7 +77,7 @@ func NewDispatchTaskStore(col persis.Collection, opts ...DispatchTaskStoreOption
 	return s
 }
 
-func (s *DispatchTaskStore) Enqueue(ctx context.Context, task *coordinatorv1.Task) error {
+func (s *DispatchTaskStore) Enqueue(ctx context.Context, task *exec.DispatchTask) error {
 	if task == nil {
 		return fmt.Errorf("task is required")
 	}
@@ -189,6 +187,27 @@ func (s *DispatchTaskStore) GetClaim(ctx context.Context, claimToken string) (*e
 	}, nil
 }
 
+func (s *DispatchTaskStore) ReleaseClaim(ctx context.Context, claimToken string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rec, err := s.col.Get(ctx, claimDispatchRecordID(claimToken))
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return exec.ErrDispatchTaskNotFound
+		}
+		return err
+	}
+	payload, err := dispatchTaskPayloadFromRecord(rec)
+	if err != nil {
+		return err
+	}
+	if payload.Task == nil || payload.ClaimToken == "" || payload.ClaimToken != claimToken || payload.ClaimedAt == 0 {
+		return exec.ErrDispatchTaskNotFound
+	}
+	return s.releaseClaimRecord(ctx, rec, payload, time.Now().UTC())
+}
+
 func (s *DispatchTaskStore) DeleteClaim(ctx context.Context, claimToken string) error {
 	if err := s.col.Delete(ctx, claimDispatchRecordID(claimToken)); err != nil && !errors.Is(err, persis.ErrNotFound) {
 		return err
@@ -276,26 +295,7 @@ func (s *DispatchTaskStore) recycleExpiredClaims(ctx context.Context) error {
 			continue
 		}
 
-		payload.EnqueuedAt = now.UnixMilli()
-		payload.ClaimToken = ""
-		payload.ClaimedAt = 0
-		payload.WorkerID = ""
-		payload.PollerID = ""
-		payload.Owner = exec.CoordinatorEndpoint{}
-		payload.Task = clearDispatchTaskClaim(payload.Task)
-
-		pendingID, err := pendingDispatchRecordID(payload.TaskFileName)
-		if err != nil {
-			return err
-		}
-		pendingRec, err := s.newDispatchRecord(pendingID, payload, now, now)
-		if err != nil {
-			return err
-		}
-		if err := s.col.Put(ctx, pendingRec); err != nil {
-			return err
-		}
-		if err := s.col.CompareAndDelete(ctx, rec); err != nil {
+		if err := s.releaseClaimRecord(ctx, rec, payload, now); err != nil {
 			if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
 				continue
 			}
@@ -305,6 +305,35 @@ func (s *DispatchTaskStore) recycleExpiredClaims(ctx context.Context) error {
 	return nil
 }
 
+func (s *DispatchTaskStore) releaseClaimRecord(ctx context.Context, rec *persis.Record, payload dispatchTaskPayload, now time.Time) error {
+	releasedAt := now
+	enqueuedAt := now.UnixMilli()
+	if payload.ClaimedAt >= enqueuedAt {
+		enqueuedAt = payload.ClaimedAt + 1
+		releasedAt = time.UnixMilli(enqueuedAt).UTC()
+	}
+	payload.EnqueuedAt = enqueuedAt
+	payload.ClaimToken = ""
+	payload.ClaimedAt = 0
+	payload.WorkerID = ""
+	payload.PollerID = ""
+	payload.Owner = exec.CoordinatorEndpoint{}
+	payload.Task = clearDispatchTaskClaim(payload.Task)
+
+	pendingID, err := pendingDispatchRecordID(payload.TaskFileName)
+	if err != nil {
+		return err
+	}
+	pendingRec, err := s.newDispatchRecord(pendingID, payload, releasedAt, releasedAt)
+	if err != nil {
+		return err
+	}
+	if err := s.col.Put(ctx, pendingRec); err != nil {
+		return err
+	}
+	return s.col.CompareAndDelete(ctx, rec)
+}
+
 func (s *DispatchTaskStore) removePendingRecordsWithActiveClaims(ctx context.Context) error {
 	claimRecs, err := s.listDispatchRecords(ctx, dispatchClaimsPrefix)
 	if err != nil {
@@ -312,7 +341,7 @@ func (s *DispatchTaskStore) removePendingRecordsWithActiveClaims(ctx context.Con
 	}
 
 	now := time.Now().UTC()
-	activeTaskFiles := make(map[string]struct{}, len(claimRecs))
+	activeTaskFiles := make(map[string]time.Time, len(claimRecs))
 	for _, rec := range claimRecs {
 		payload, err := dispatchTaskPayloadFromRecord(rec)
 		if err != nil {
@@ -325,7 +354,9 @@ func (s *DispatchTaskStore) removePendingRecordsWithActiveClaims(ctx context.Con
 		if now.Sub(claimedAt) >= s.reservationTTL {
 			continue
 		}
-		activeTaskFiles[payload.TaskFileName] = struct{}{}
+		if prev, ok := activeTaskFiles[payload.TaskFileName]; !ok || claimedAt.After(prev) {
+			activeTaskFiles[payload.TaskFileName] = claimedAt
+		}
 	}
 	if len(activeTaskFiles) == 0 {
 		return nil
@@ -340,7 +371,12 @@ func (s *DispatchTaskStore) removePendingRecordsWithActiveClaims(ctx context.Con
 		if err != nil {
 			return err
 		}
-		if _, ok := activeTaskFiles[payload.TaskFileName]; !ok {
+		claimedAt, ok := activeTaskFiles[payload.TaskFileName]
+		if !ok {
+			continue
+		}
+		enqueuedAt := dispatchRecordTimestamp(payload.EnqueuedAt, rec.CreatedAt)
+		if enqueuedAt.After(claimedAt) {
 			continue
 		}
 		if err := s.col.CompareAndDelete(ctx, rec); err != nil {
@@ -485,42 +521,34 @@ func dispatchRecordTimestamp(unixMillis int64, fallback time.Time) time.Time {
 	return time.Now().UTC()
 }
 
-func cloneDispatchTask(task *coordinatorv1.Task) *coordinatorv1.Task {
+func cloneDispatchTask(task *exec.DispatchTask) *exec.DispatchTask {
 	if task == nil {
 		return nil
 	}
-	cloned, ok := proto.Clone(task).(*coordinatorv1.Task)
-	if !ok {
-		return nil
-	}
-	return cloned
+	cloned := *task
+	cloned.WorkerSelector = maps.Clone(task.WorkerSelector)
+	cloned.AgentSnapshot = append([]byte(nil), task.AgentSnapshot...)
+	return &cloned
 }
 
-func applyDispatchTaskClaim(task *coordinatorv1.Task, owner exec.CoordinatorEndpoint, claimToken string) (*coordinatorv1.Task, error) {
+func applyDispatchTaskClaim(task *exec.DispatchTask, owner exec.CoordinatorEndpoint, claimToken string) (*exec.DispatchTask, error) {
 	task = cloneDispatchTask(task)
 	if task == nil {
 		return nil, nil
 	}
-	if owner.Port < 0 || owner.Port > math.MaxInt32 {
-		return nil, fmt.Errorf("owner coordinator port out of range: %d", owner.Port)
-	}
-	task.OwnerCoordinatorId = owner.ID
-	task.OwnerCoordinatorHost = owner.Host
-	task.OwnerCoordinatorPort = int32(owner.Port)
+	task.Owner = owner
 	task.ClaimToken = claimToken
 	return task, nil
 }
 
-func clearDispatchTaskClaim(task *coordinatorv1.Task) *coordinatorv1.Task {
+func clearDispatchTaskClaim(task *exec.DispatchTask) *exec.DispatchTask {
 	task = cloneDispatchTask(task)
 	if task == nil {
 		return nil
 	}
-	task.OwnerCoordinatorId = ""
-	task.OwnerCoordinatorHost = ""
-	task.OwnerCoordinatorPort = 0
+	task.Owner = exec.CoordinatorEndpoint{}
 	task.ClaimToken = ""
-	task.WorkerId = ""
+	task.WorkerID = ""
 	return task
 }
 

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,6 +25,8 @@ import (
 const (
 	dispatchTaskStoreVersion      = 1
 	defaultDispatchReservationTTL = exec.DefaultStaleLeaseThreshold
+	minDispatchCleanupInterval    = 100 * time.Millisecond
+	maxDispatchCleanupInterval    = time.Second
 
 	dispatchPendingPrefix = "pending/"
 	dispatchClaimsPrefix  = "claims/"
@@ -39,8 +42,9 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 // file collection rooted at the distributed directory uses the existing
 // on-disk layout directly.
 type DispatchTaskStore struct {
-	col            persis.Collection
-	reservationTTL time.Duration
+	col                      persis.Collection
+	reservationTTL           time.Duration
+	lastReservationCleanupAt time.Time
 	// mu serializes the in-process recycle+scan+claim sequence;
 	// per-record CompareAndDelete provides cross-process safety.
 	mu sync.Mutex
@@ -92,6 +96,20 @@ var legacyDispatchTaskJSONFields = map[string]string{
 	"claim_token":                   "ClaimToken",
 }
 
+var legacyDispatchTaskJSONMarkers = func() [][]byte {
+	markers := make([][]byte, 0, len(legacyDispatchTaskJSONFields)+4)
+	for legacyKey := range legacyDispatchTaskJSONFields {
+		markers = append(markers, []byte(`"`+legacyKey+`"`))
+	}
+	markers = append(markers,
+		[]byte(`"previous_status"`),
+		[]byte(`"owner_coordinator_id"`),
+		[]byte(`"owner_coordinator_host"`),
+		[]byte(`"owner_coordinator_port"`),
+	)
+	return markers
+}()
+
 // WithDispatchReservationTTL sets how long pending and claimed dispatch
 // records can remain outstanding before cleanup recycles or removes them.
 func WithDispatchReservationTTL(ttl time.Duration) DispatchTaskStoreOption {
@@ -140,15 +158,36 @@ func (s *DispatchTaskStore) ClaimNext(ctx context.Context, claim exec.DispatchTa
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.recycleExpiredReservations(ctx); err != nil {
-		return nil, err
-	}
-
-	recs, err := s.listDispatchRecords(ctx, dispatchPendingPrefix)
+	cleaned, err := s.maybeRecycleExpiredReservations(ctx)
 	if err != nil {
 		return nil, err
 	}
-	for _, rec := range recs {
+
+	claimed, err := s.claimNextPending(ctx, claim)
+	if err != nil || claimed != nil || cleaned {
+		return claimed, err
+	}
+
+	if err := s.recycleExpiredReservations(ctx); err != nil {
+		return nil, err
+	}
+	s.lastReservationCleanupAt = time.Now().UTC()
+	return s.claimNextPending(ctx, claim)
+}
+
+func (s *DispatchTaskStore) claimNextPending(ctx context.Context, claim exec.DispatchTaskClaim) (*exec.ClaimedDispatchTask, error) {
+	ids, err := s.listDispatchRecordIDs(ctx, dispatchPendingPrefix)
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		rec, err := s.col.Get(ctx, id)
+		if err != nil {
+			if errors.Is(err, persis.ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("list record %q: %w", id, err)
+		}
 		payload, err := dispatchTaskPayloadFromRecord(rec)
 		if err != nil {
 			return nil, err
@@ -195,6 +234,19 @@ func (s *DispatchTaskStore) ClaimNext(ctx context.Context, claim exec.DispatchTa
 		}, nil
 	}
 	return nil, nil
+}
+
+func (s *DispatchTaskStore) maybeRecycleExpiredReservations(ctx context.Context) (bool, error) {
+	now := time.Now().UTC()
+	if !s.lastReservationCleanupAt.IsZero() &&
+		now.Sub(s.lastReservationCleanupAt) < dispatchCleanupInterval(s.reservationTTL) {
+		return false, nil
+	}
+	if err := s.recycleExpiredReservations(ctx); err != nil {
+		return false, err
+	}
+	s.lastReservationCleanupAt = now
+	return true, nil
 }
 
 func (s *DispatchTaskStore) GetClaim(ctx context.Context, claimToken string) (*exec.ClaimedDispatchTask, error) {
@@ -489,6 +541,27 @@ func (s *DispatchTaskStore) listDispatchRecords(ctx context.Context, prefix stri
 	return recs, nil
 }
 
+func (s *DispatchTaskStore) listDispatchRecordIDs(ctx context.Context, prefix string) ([]string, error) {
+	if idCol, ok := s.col.(strictRecordIDsCollection); ok {
+		ids, err := idCol.RecordIDs(ctx, prefix)
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(ids)
+		return ids, nil
+	}
+
+	recs, err := s.listDispatchRecords(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		ids = append(ids, rec.ID)
+	}
+	return ids, nil
+}
+
 func (s *DispatchTaskStore) putDispatchRecord(ctx context.Context, id string, payload dispatchTaskPayload, createdAt, updatedAt time.Time) error {
 	rec, err := s.newDispatchRecord(id, payload, createdAt, updatedAt)
 	if err != nil {
@@ -515,6 +588,9 @@ func dispatchTaskPayloadFromRecord(rec *persis.Record) (dispatchTaskPayload, err
 	if err := persis.Decode(rec, &payload); err != nil {
 		return dispatchTaskPayload{}, fmt.Errorf("dispatch task store: decode %q: %w", rec.ID, err)
 	}
+	if !hasLegacyDispatchTaskJSON(rec.Data) {
+		return payload, nil
+	}
 	task, err := legacyDispatchTaskFromRecord(rec.Data)
 	if err != nil {
 		return dispatchTaskPayload{}, fmt.Errorf("dispatch task store: decode legacy task %q: %w", rec.ID, err)
@@ -523,6 +599,15 @@ func dispatchTaskPayloadFromRecord(rec *persis.Record) (dispatchTaskPayload, err
 		payload.Task = task
 	}
 	return payload, nil
+}
+
+func hasLegacyDispatchTaskJSON(data []byte) bool {
+	for _, marker := range legacyDispatchTaskJSONMarkers {
+		if bytes.Contains(data, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func legacyDispatchTaskFromRecord(data []byte) (*exec.DispatchTask, error) {
@@ -648,6 +733,17 @@ func normalizeDispatchReservationTTL(ttl time.Duration) time.Duration {
 		return defaultDispatchReservationTTL
 	}
 	return ttl
+}
+
+func dispatchCleanupInterval(ttl time.Duration) time.Duration {
+	interval := normalizeDispatchReservationTTL(ttl) / 10
+	if interval < minDispatchCleanupInterval {
+		return minDispatchCleanupInterval
+	}
+	if interval > maxDispatchCleanupInterval {
+		return maxDispatchCleanupInterval
+	}
+	return interval
 }
 
 func dispatchRecordTimestamp(unixMillis int64, fallback time.Time) time.Time {

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -55,6 +56,40 @@ type dispatchTaskPayload struct {
 	WorkerID     string                   `json:"workerId,omitempty"`
 	PollerID     string                   `json:"pollerId,omitempty"`
 	Owner        exec.CoordinatorEndpoint `json:"owner,omitzero"`
+}
+
+type legacyDAGRunStatusProto struct {
+	JSONData string `json:"json_data,omitempty"`
+}
+
+var legacyDispatchTaskJSONFields = map[string]string{
+	"root_dag_run_name":             "RootDAGRunName",
+	"root_dag_run_id":               "RootDAGRunID",
+	"parent_dag_run_name":           "ParentDAGRunName",
+	"parent_dag_run_id":             "ParentDAGRunID",
+	"operation":                     "Operation",
+	"dag_run_id":                    "DAGRunID",
+	"target":                        "Target",
+	"definition":                    "Definition",
+	"worker_id":                     "WorkerID",
+	"attempt_id":                    "AttemptID",
+	"attempt_key":                   "AttemptKey",
+	"step":                          "Step",
+	"params":                        "Params",
+	"queue_name":                    "QueueName",
+	"base_config":                   "BaseConfig",
+	"labels":                        "Labels",
+	"schedule_time":                 "ScheduleTime",
+	"source_file":                   "SourceFile",
+	"worker_selector":               "WorkerSelector",
+	"agent_snapshot":                "AgentSnapshot",
+	"external_step_retry":           "ExternalStepRetry",
+	"workspace_bundle_digest":       "WorkspaceBundleDigest",
+	"workspace_bundle_size":         "WorkspaceBundleSize",
+	"workspace_bundle_dag_path":     "WorkspaceBundleDAGPath",
+	"workspace_bundle_original_ref": "WorkspaceBundleOriginalRef",
+	"workspace_bundle_resolved_ref": "WorkspaceBundleResolvedRef",
+	"claim_token":                   "ClaimToken",
 }
 
 // WithDispatchReservationTTL sets how long pending and claimed dispatch
@@ -480,7 +515,111 @@ func dispatchTaskPayloadFromRecord(rec *persis.Record) (dispatchTaskPayload, err
 	if err := persis.Decode(rec, &payload); err != nil {
 		return dispatchTaskPayload{}, fmt.Errorf("dispatch task store: decode %q: %w", rec.ID, err)
 	}
+	task, err := legacyDispatchTaskFromRecord(rec.Data)
+	if err != nil {
+		return dispatchTaskPayload{}, fmt.Errorf("dispatch task store: decode legacy task %q: %w", rec.ID, err)
+	}
+	if task != nil {
+		payload.Task = task
+	}
 	return payload, nil
+}
+
+func legacyDispatchTaskFromRecord(data []byte) (*exec.DispatchTask, error) {
+	var raw struct {
+		Task map[string]json.RawMessage `json:"task"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	if len(raw.Task) == 0 {
+		return nil, nil
+	}
+
+	current := make(map[string]json.RawMessage, len(raw.Task))
+	var hasLegacyKeys bool
+	for legacyKey, currentKey := range legacyDispatchTaskJSONFields {
+		value, ok := raw.Task[legacyKey]
+		if !ok {
+			continue
+		}
+		hasLegacyKeys = true
+		current[currentKey] = value
+	}
+	if statusData, ok := raw.Task["previous_status"]; ok {
+		hasLegacyKeys = true
+		previousStatus, err := legacyPreviousStatusJSON(statusData)
+		if err != nil {
+			return nil, err
+		}
+		if len(previousStatus) > 0 {
+			current["PreviousStatus"] = previousStatus
+		}
+	}
+	owner, ok, err := legacyOwnerJSON(raw.Task)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		hasLegacyKeys = true
+		current["Owner"] = owner
+	}
+	if !hasLegacyKeys {
+		return nil, nil
+	}
+
+	encoded, err := json.Marshal(current)
+	if err != nil {
+		return nil, err
+	}
+	var task exec.DispatchTask
+	if err := json.Unmarshal(encoded, &task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+func legacyPreviousStatusJSON(data json.RawMessage) (json.RawMessage, error) {
+	var status legacyDAGRunStatusProto
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("decode previous status wrapper: %w", err)
+	}
+	if status.JSONData == "" {
+		return nil, nil
+	}
+	var decoded exec.DAGRunStatus
+	if err := json.Unmarshal([]byte(status.JSONData), &decoded); err != nil {
+		return nil, fmt.Errorf("decode previous status: %w", err)
+	}
+	return json.RawMessage(status.JSONData), nil
+}
+
+func legacyOwnerJSON(fields map[string]json.RawMessage) (json.RawMessage, bool, error) {
+	var owner exec.CoordinatorEndpoint
+	var ok bool
+	if err := decodeLegacyOwnerField(fields, "owner_coordinator_id", &owner.ID, &ok); err != nil {
+		return nil, false, err
+	}
+	if err := decodeLegacyOwnerField(fields, "owner_coordinator_host", &owner.Host, &ok); err != nil {
+		return nil, false, err
+	}
+	if err := decodeLegacyOwnerField(fields, "owner_coordinator_port", &owner.Port, &ok); err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	data, err := json.Marshal(owner)
+	return data, true, err
+}
+
+func decodeLegacyOwnerField[T any](fields map[string]json.RawMessage, key string, dst *T, ok *bool) error {
+	value, exists := fields[key]
+	if !exists {
+		return nil
+	}
+	*ok = true
+	return json.Unmarshal(value, dst)
 }
 
 func pendingDispatchRecordID(fileName string) (string, error) {

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -393,6 +393,98 @@ func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	assert.ErrorIs(t, err, exec.ErrDispatchTaskNotFound)
 }
 
+func TestDispatchTaskStore_ClaimsLegacyProtoJSONTaskRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	s := store.NewDispatchTaskStore(file.NewCollection(dir))
+
+	statusData, err := json.Marshal(exec.DAGRunStatus{
+		Name:     "dag-legacy",
+		DAGRunID: "run-legacy",
+		Status:   core.Running,
+	})
+	require.NoError(t, err)
+
+	fileName := "task_00000000000000000001_legacy.json"
+	writeJSONFile(t, filepath.Join(dir, "pending", fileName), map[string]any{
+		"version":      1,
+		"taskFileName": fileName,
+		"enqueuedAt":   time.Now().UTC().UnixMilli(),
+		"task": map[string]any{
+			"root_dag_run_name":             "root-dag",
+			"root_dag_run_id":               "root-run",
+			"parent_dag_run_name":           "parent-dag",
+			"parent_dag_run_id":             "parent-run",
+			"operation":                     int32(exec.DispatchOperationRetry),
+			"dag_run_id":                    "run-legacy",
+			"target":                        "dag-legacy",
+			"definition":                    "steps:\n  - run: echo legacy\n",
+			"worker_id":                     "worker-old",
+			"attempt_id":                    "attempt-legacy",
+			"attempt_key":                   "attempt-key-legacy",
+			"step":                          "step-a",
+			"params":                        "PARAM=value",
+			"queue_name":                    "queue-legacy",
+			"base_config":                   "env:\n  - BASE=1\n",
+			"labels":                        "team=ops",
+			"schedule_time":                 "2026-05-31T00:00:00Z",
+			"source_file":                   "/dags/legacy.yaml",
+			"worker_selector":               map[string]string{"type": "gpu"},
+			"agent_snapshot":                []byte{1, 2, 3},
+			"external_step_retry":           true,
+			"workspace_bundle_digest":       "sha256:legacy",
+			"workspace_bundle_size":         42,
+			"workspace_bundle_dag_path":     "legacy.yaml",
+			"workspace_bundle_original_ref": "main",
+			"workspace_bundle_resolved_ref": "abc123",
+			"owner_coordinator_id":          "coord-old",
+			"owner_coordinator_host":        "old.example.test",
+			"owner_coordinator_port":        int32(8090),
+			"claim_token":                   "claim-old",
+			"previous_status":               map[string]any{"json_data": string(statusData)},
+		},
+	})
+
+	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID: "worker-1",
+		PollerID: "poller-1",
+		Labels:   map[string]string{"type": "gpu"},
+		Owner:    exec.CoordinatorEndpoint{ID: "coord-new", Host: "new.example.test", Port: 9090},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.NotNil(t, claimed.Task)
+
+	assert.Equal(t, "root-dag", claimed.Task.RootDAGRunName)
+	assert.Equal(t, "root-run", claimed.Task.RootDAGRunID)
+	assert.Equal(t, "parent-dag", claimed.Task.ParentDAGRunName)
+	assert.Equal(t, "parent-run", claimed.Task.ParentDAGRunID)
+	assert.Equal(t, exec.DispatchOperationRetry, claimed.Task.Operation)
+	assert.Equal(t, "run-legacy", claimed.Task.DAGRunID)
+	assert.Equal(t, "dag-legacy", claimed.Task.Target)
+	assert.Equal(t, "attempt-legacy", claimed.Task.AttemptID)
+	assert.Equal(t, "attempt-key-legacy", claimed.Task.AttemptKey)
+	assert.Equal(t, "step-a", claimed.Task.Step)
+	assert.Equal(t, "PARAM=value", claimed.Task.Params)
+	assert.Equal(t, "queue-legacy", claimed.Task.QueueName)
+	assert.Equal(t, "team=ops", claimed.Task.Labels)
+	assert.Equal(t, map[string]string{"type": "gpu"}, claimed.Task.WorkerSelector)
+	assert.Equal(t, []byte{1, 2, 3}, claimed.Task.AgentSnapshot)
+	assert.Equal(t, "sha256:legacy", claimed.Task.WorkspaceBundleDigest)
+	assert.Equal(t, int64(42), claimed.Task.WorkspaceBundleSize)
+	assert.Equal(t, "legacy.yaml", claimed.Task.WorkspaceBundleDAGPath)
+	assert.Equal(t, "main", claimed.Task.WorkspaceBundleOriginalRef)
+	assert.Equal(t, "abc123", claimed.Task.WorkspaceBundleResolvedRef)
+	assert.Equal(t, exec.CoordinatorEndpoint{ID: "coord-new", Host: "new.example.test", Port: 9090}, claimed.Task.Owner)
+	assert.NotEmpty(t, claimed.Task.ClaimToken)
+	require.NotNil(t, claimed.Task.PreviousStatus)
+	assert.Equal(t, "dag-legacy", claimed.Task.PreviousStatus.Name)
+	assert.Equal(t, "run-legacy", claimed.Task.PreviousStatus.DAGRunID)
+	assert.Equal(t, core.Running, claimed.Task.PreviousStatus.Status)
+}
+
 func TestDispatchTaskStore_ReleaseClaimReturnsTaskToPending(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/store"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 func TestDAGRunLeaseStore_UpsertTouchListAndDelete(t *testing.T) {
@@ -331,17 +330,17 @@ func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	claimTimeout := 3 * time.Second
 	s := store.NewDispatchTaskStore(col, store.WithDispatchReservationTTL(claimTimeout))
 
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:       "run-a",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-a",
 		Target:         "dag-a",
-		AttemptId:      "attempt-a",
+		AttemptID:      "attempt-a",
 		AttemptKey:     "attempt-key-a",
 		WorkerSelector: map[string]string{"type": "gpu"},
 	}))
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:       "run-b",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-b",
 		Target:         "dag-b",
-		AttemptId:      "attempt-b",
+		AttemptID:      "attempt-b",
 		AttemptKey:     "attempt-key-b",
 		WorkerSelector: map[string]string{"type": "cpu"},
 	}))
@@ -354,8 +353,8 @@ func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
-	assert.Equal(t, "run-b", claimed.Task.DagRunId)
-	assert.Equal(t, "coord-a", claimed.Task.OwnerCoordinatorId)
+	assert.Equal(t, "run-b", claimed.Task.DAGRunID)
+	assert.Equal(t, "coord-a", claimed.Task.Owner.ID)
 	assert.NotEmpty(t, claimed.Task.ClaimToken)
 
 	secondClaim, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
@@ -375,7 +374,7 @@ func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, gpuClaim)
-	assert.Equal(t, "run-a", gpuClaim.Task.DagRunId)
+	assert.Equal(t, "run-a", gpuClaim.Task.DAGRunID)
 
 	ageClaimedDispatchRecord(t, col, claimed.ClaimToken, 10*time.Second, 10*time.Second)
 
@@ -387,11 +386,53 @@ func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, reclaimed)
-	assert.Equal(t, "run-b", reclaimed.Task.DagRunId)
-	assert.Equal(t, "coord-b", reclaimed.Task.OwnerCoordinatorId)
+	assert.Equal(t, "run-b", reclaimed.Task.DAGRunID)
+	assert.Equal(t, "coord-b", reclaimed.Task.Owner.ID)
 
 	_, err = s.GetClaim(ctx, claimed.ClaimToken)
 	assert.ErrorIs(t, err, exec.ErrDispatchTaskNotFound)
+}
+
+func TestDispatchTaskStore_ReleaseClaimReturnsTaskToPending(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := store.NewDispatchTaskStore(testutil.NewMemoryBackend().Collection("dispatch_tasks"))
+
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-release",
+		Target:         "dag-release",
+		AttemptID:      "attempt-release",
+		AttemptKey:     "attempt-key-release",
+		WorkerSelector: map[string]string{"type": "cpu"},
+	}))
+
+	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID: "worker-1",
+		PollerID: "poller-1",
+		Labels:   map[string]string{"type": "cpu"},
+		Owner:    exec.CoordinatorEndpoint{ID: "coord-a"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.NotEmpty(t, claimed.ClaimToken)
+
+	require.NoError(t, s.ReleaseClaim(ctx, claimed.ClaimToken))
+
+	_, err = s.GetClaim(ctx, claimed.ClaimToken)
+	assert.ErrorIs(t, err, exec.ErrDispatchTaskNotFound)
+
+	reclaimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID: "worker-2",
+		PollerID: "poller-2",
+		Labels:   map[string]string{"type": "cpu"},
+		Owner:    exec.CoordinatorEndpoint{ID: "coord-b"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, reclaimed)
+	assert.Equal(t, "run-release", reclaimed.Task.DAGRunID)
+	assert.Equal(t, "coord-b", reclaimed.Task.Owner.ID)
+	assert.NotEqual(t, claimed.ClaimToken, reclaimed.ClaimToken)
 }
 
 func TestDispatchTaskStore_RemovesPendingDuplicateWhenActiveClaimExists(t *testing.T) {
@@ -401,11 +442,11 @@ func TestDispatchTaskStore_RemovesPendingDuplicateWhenActiveClaimExists(t *testi
 	col := testutil.NewMemoryBackend().Collection("dispatch_tasks")
 	s := store.NewDispatchTaskStore(col)
 
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:   "run-duplicate",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:   "run-duplicate",
 		Target:     "dag-duplicate",
 		QueueName:  "queue-a",
-		AttemptId:  "attempt-duplicate",
+		AttemptID:  "attempt-duplicate",
 		AttemptKey: "attempt-key-duplicate",
 	}))
 	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
@@ -431,15 +472,44 @@ func TestDispatchTaskStore_RemovesPendingDuplicateWhenActiveClaimExists(t *testi
 	assert.Empty(t, page.Records)
 }
 
+func TestDispatchTaskStore_KeepsNewerPendingDuplicateDuringActiveClaimCleanup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	col := testutil.NewMemoryBackend().Collection("dispatch_tasks")
+	s := store.NewDispatchTaskStore(col)
+
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:   "run-newer-pending",
+		Target:     "dag-newer-pending",
+		QueueName:  "queue-a",
+		AttemptID:  "attempt-newer-pending",
+		AttemptKey: "attempt-key-newer-pending",
+	}))
+	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID: "worker-1",
+		PollerID: "poller-1",
+		Owner:    exec.CoordinatorEndpoint{ID: "coord-a"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	putNewerPendingDuplicateFromClaim(t, col, claimed.ClaimToken)
+
+	count, err := s.CountOutstandingByQueue(ctx, "queue-a", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
 func TestDispatchTaskStore_ConcurrentClaimIsExclusive(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	s := store.NewDispatchTaskStore(testutil.NewMemoryBackend().Collection("dispatch_tasks"))
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:       "run-exclusive",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-exclusive",
 		Target:         "dag-exclusive",
-		AttemptId:      "attempt-exclusive",
+		AttemptID:      "attempt-exclusive",
 		AttemptKey:     "attempt-key-exclusive",
 		WorkerSelector: map[string]string{"type": "cpu"},
 	}))
@@ -501,19 +571,19 @@ func TestDispatchTaskStore_CountOutstandingByQueueAndAttempt(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewDispatchTaskStore(testutil.NewMemoryBackend().Collection("dispatch_tasks"))
 
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:       "run-a",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-a",
 		Target:         "dag-a",
 		QueueName:      "queue-a",
-		AttemptId:      "attempt-a",
+		AttemptID:      "attempt-a",
 		AttemptKey:     "attempt-key-a",
 		WorkerSelector: map[string]string{"type": "queue-a"},
 	}))
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:       "run-b",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:       "run-b",
 		Target:         "dag-b",
 		QueueName:      "queue-b",
-		AttemptId:      "attempt-b",
+		AttemptID:      "attempt-b",
 		AttemptKey:     "attempt-key-b",
 		WorkerSelector: map[string]string{"type": "queue-b"},
 	}))
@@ -557,11 +627,11 @@ func TestDispatchTaskStore_StalePendingReservationsExpire(t *testing.T) {
 	col := testutil.NewMemoryBackend().Collection("dispatch_tasks")
 	s := store.NewDispatchTaskStore(col, store.WithDispatchReservationTTL(500*time.Millisecond))
 
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:   "run-stale",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:   "run-stale",
 		Target:     "dag-stale",
 		QueueName:  "queue-a",
-		AttemptId:  "attempt-stale",
+		AttemptID:  "attempt-stale",
 		AttemptKey: "attempt-key-stale",
 	}))
 	agePendingDispatchRecords(t, col, 2*time.Second)
@@ -590,11 +660,11 @@ func TestDispatchTaskStore_UsesStoreReservationTTLForCleanup(t *testing.T) {
 	col := testutil.NewMemoryBackend().Collection("dispatch_tasks")
 	s := store.NewDispatchTaskStore(col, store.WithDispatchReservationTTL(5*time.Second))
 
-	require.NoError(t, s.Enqueue(ctx, &coordinatorv1.Task{
-		DagRunId:   "run-shared-ttl",
+	require.NoError(t, s.Enqueue(ctx, &exec.DispatchTask{
+		DAGRunID:   "run-shared-ttl",
 		Target:     "dag-shared-ttl",
 		QueueName:  "queue-a",
-		AttemptId:  "attempt-shared-ttl",
+		AttemptID:  "attempt-shared-ttl",
 		AttemptKey: "attempt-key-shared-ttl",
 	}))
 	agePendingDispatchRecords(t, col, 2*time.Second)
@@ -610,7 +680,7 @@ func TestDispatchTaskStore_UsesStoreReservationTTLForCleanup(t *testing.T) {
 	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{WorkerID: "worker-1"})
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
-	assert.Equal(t, "run-shared-ttl", claimed.Task.DagRunId)
+	assert.Equal(t, "run-shared-ttl", claimed.Task.DAGRunID)
 }
 
 func TestDistributedStores_ReadFileLayout(t *testing.T) {
@@ -656,7 +726,7 @@ func TestDistributedStores_ReadFileLayout(t *testing.T) {
 
 	fileTask := dispatchTaskRecord{
 		Version:      1,
-		Task:         &coordinatorv1.Task{DagRunId: "run-file", Target: "dag-file", AttemptKey: "attempt-key-file-task"},
+		Task:         &exec.DispatchTask{DAGRunID: "run-file", Target: "dag-file", AttemptKey: "attempt-key-file-task"},
 		TaskFileName: "task_00000000000000000001_file.json",
 		EnqueuedAt:   time.Now().UTC().UnixMilli(),
 	}
@@ -666,12 +736,12 @@ func TestDistributedStores_ReadFileLayout(t *testing.T) {
 	claimed, err := dispatchStore.ClaimNext(ctx, exec.DispatchTaskClaim{WorkerID: "worker-1"})
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
-	assert.Equal(t, "run-file", claimed.Task.DagRunId)
+	assert.Equal(t, "run-file", claimed.Task.DAGRunID)
 }
 
 type dispatchTaskRecord struct {
 	Version      int                      `json:"version"`
-	Task         *coordinatorv1.Task      `json:"task"`
+	Task         *exec.DispatchTask       `json:"task"`
 	TaskFileName string                   `json:"taskFileName"`
 	EnqueuedAt   int64                    `json:"enqueuedAt"`
 	ClaimToken   string                   `json:"claimToken,omitempty"`
@@ -696,11 +766,41 @@ func putPendingDuplicateFromClaim(t *testing.T, col persis.Collection, claimToke
 	payload.PollerID = ""
 	payload.Owner = exec.CoordinatorEndpoint{}
 	if payload.Task != nil {
-		payload.Task.OwnerCoordinatorId = ""
-		payload.Task.OwnerCoordinatorHost = ""
-		payload.Task.OwnerCoordinatorPort = 0
+		payload.Task.Owner = exec.CoordinatorEndpoint{}
 		payload.Task.ClaimToken = ""
-		payload.Task.WorkerId = ""
+		payload.Task.WorkerID = ""
+	}
+	data, err := persis.Encode(payload)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, col.Put(ctx, &persis.Record{
+		ID:        pendingRecordIDForTest(payload.TaskFileName),
+		Data:      data,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+}
+
+func putNewerPendingDuplicateFromClaim(t *testing.T, col persis.Collection, claimToken string) {
+	t.Helper()
+
+	ctx := context.Background()
+	claimRec, err := col.Get(ctx, "claims/claim_"+encodedKey(claimToken))
+	require.NoError(t, err)
+
+	var payload dispatchTaskRecord
+	require.NoError(t, persis.Decode(claimRec, &payload))
+	payload.EnqueuedAt = time.Now().Add(time.Second).UTC().UnixMilli()
+	payload.ClaimToken = ""
+	payload.ClaimedAt = 0
+	payload.WorkerID = ""
+	payload.PollerID = ""
+	payload.Owner = exec.CoordinatorEndpoint{}
+	if payload.Task != nil {
+		payload.Task.Owner = exec.CoordinatorEndpoint{}
+		payload.Task.ClaimToken = ""
+		payload.Task.WorkerID = ""
 	}
 	data, err := persis.Encode(payload)
 	require.NoError(t, err)

--- a/internal/proto/convert/dispatch.go
+++ b/internal/proto/convert/dispatch.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package convert
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+)
+
+const maxCoordinatorPort = 65535
+
+// DispatchTaskToProto converts a dispatch task to the coordinator wire shape.
+func DispatchTaskToProto(task *exec.DispatchTask) (*coordinatorv1.Task, error) {
+	if task == nil {
+		return nil, nil
+	}
+	if task.Owner.Port < 0 || task.Owner.Port > maxCoordinatorPort {
+		return nil, fmt.Errorf("owner coordinator port out of range: %d", task.Owner.Port)
+	}
+
+	protoTask := &coordinatorv1.Task{
+		RootDagRunName:             task.RootDAGRunName,
+		RootDagRunId:               task.RootDAGRunID,
+		ParentDagRunName:           task.ParentDAGRunName,
+		ParentDagRunId:             task.ParentDAGRunID,
+		Operation:                  coordinatorv1.Operation(task.Operation),
+		DagRunId:                   task.DAGRunID,
+		Target:                     task.Target,
+		Definition:                 task.Definition,
+		WorkerId:                   task.WorkerID,
+		AttemptId:                  task.AttemptID,
+		AttemptKey:                 task.AttemptKey,
+		Step:                       task.Step,
+		Params:                     task.Params,
+		QueueName:                  task.QueueName,
+		BaseConfig:                 task.BaseConfig,
+		Labels:                     task.Labels,
+		ScheduleTime:               task.ScheduleTime,
+		SourceFile:                 task.SourceFile,
+		WorkerSelector:             maps.Clone(task.WorkerSelector),
+		AgentSnapshot:              append([]byte(nil), task.AgentSnapshot...),
+		ExternalStepRetry:          task.ExternalStepRetry,
+		WorkspaceBundleDigest:      task.WorkspaceBundleDigest,
+		WorkspaceBundleSize:        task.WorkspaceBundleSize,
+		WorkspaceBundleDagPath:     task.WorkspaceBundleDAGPath,
+		WorkspaceBundleOriginalRef: task.WorkspaceBundleOriginalRef,
+		WorkspaceBundleResolvedRef: task.WorkspaceBundleResolvedRef,
+		OwnerCoordinatorId:         task.Owner.ID,
+		OwnerCoordinatorHost:       task.Owner.Host,
+		OwnerCoordinatorPort:       int32(task.Owner.Port), //nolint:gosec // Port is range-checked above before narrowing to proto int32.
+		ClaimToken:                 task.ClaimToken,
+	}
+	if task.PreviousStatus != nil {
+		protoStatus, err := DAGRunStatusToProto(task.PreviousStatus)
+		if err != nil {
+			return nil, fmt.Errorf("convert previous status to proto: %w", err)
+		}
+		protoTask.PreviousStatus = protoStatus
+	}
+	return protoTask, nil
+}
+
+// ProtoToDispatchTask converts a coordinator wire task to a dispatch task.
+func ProtoToDispatchTask(task *coordinatorv1.Task) (*exec.DispatchTask, error) {
+	if task == nil {
+		return nil, nil
+	}
+	if task.OwnerCoordinatorPort < 0 || task.OwnerCoordinatorPort > maxCoordinatorPort {
+		return nil, fmt.Errorf("owner coordinator port out of range: %d", task.OwnerCoordinatorPort)
+	}
+
+	dispatchTask := &exec.DispatchTask{
+		RootDAGRunName:             task.RootDagRunName,
+		RootDAGRunID:               task.RootDagRunId,
+		ParentDAGRunName:           task.ParentDagRunName,
+		ParentDAGRunID:             task.ParentDagRunId,
+		Operation:                  exec.DispatchOperation(task.Operation),
+		DAGRunID:                   task.DagRunId,
+		Target:                     task.Target,
+		Definition:                 task.Definition,
+		WorkerID:                   task.WorkerId,
+		AttemptID:                  task.AttemptId,
+		AttemptKey:                 task.AttemptKey,
+		Step:                       task.Step,
+		Params:                     task.Params,
+		QueueName:                  task.QueueName,
+		BaseConfig:                 task.BaseConfig,
+		Labels:                     task.Labels,
+		ScheduleTime:               task.ScheduleTime,
+		SourceFile:                 task.SourceFile,
+		WorkerSelector:             maps.Clone(task.WorkerSelector),
+		AgentSnapshot:              append([]byte(nil), task.AgentSnapshot...),
+		ExternalStepRetry:          task.ExternalStepRetry,
+		WorkspaceBundleDigest:      task.WorkspaceBundleDigest,
+		WorkspaceBundleSize:        task.WorkspaceBundleSize,
+		WorkspaceBundleDAGPath:     task.WorkspaceBundleDagPath,
+		WorkspaceBundleOriginalRef: task.WorkspaceBundleOriginalRef,
+		WorkspaceBundleResolvedRef: task.WorkspaceBundleResolvedRef,
+		Owner: exec.CoordinatorEndpoint{
+			ID:   task.OwnerCoordinatorId,
+			Host: task.OwnerCoordinatorHost,
+			Port: int(task.OwnerCoordinatorPort),
+		},
+		ClaimToken: task.ClaimToken,
+	}
+	if task.PreviousStatus != nil {
+		status, err := ProtoToDAGRunStatus(task.PreviousStatus)
+		if err != nil {
+			return nil, fmt.Errorf("convert previous status from proto: %w", err)
+		}
+		dispatchTask.PreviousStatus = status
+	}
+	return dispatchTask, nil
+}
+
+// WorkerStatsToProto converts worker stats to the coordinator wire shape.
+func WorkerStatsToProto(stats *exec.WorkerStats) *coordinatorv1.WorkerStats {
+	if stats == nil {
+		return nil
+	}
+	runningTasks := make([]*coordinatorv1.RunningTask, 0, len(stats.RunningTasks))
+	for _, task := range stats.RunningTasks {
+		runningTasks = append(runningTasks, RunningTaskToProto(task))
+	}
+	return &coordinatorv1.WorkerStats{
+		TotalPollers: stats.TotalPollers,
+		BusyPollers:  stats.BusyPollers,
+		RunningTasks: runningTasks,
+	}
+}
+
+// ProtoToWorkerStats converts coordinator worker stats to the domain shape.
+func ProtoToWorkerStats(stats *coordinatorv1.WorkerStats) *exec.WorkerStats {
+	if stats == nil {
+		return nil
+	}
+	runningTasks := make([]*exec.RunningTask, 0, len(stats.RunningTasks))
+	for _, task := range stats.RunningTasks {
+		runningTasks = append(runningTasks, ProtoToRunningTask(task))
+	}
+	return &exec.WorkerStats{
+		TotalPollers: stats.TotalPollers,
+		BusyPollers:  stats.BusyPollers,
+		RunningTasks: runningTasks,
+	}
+}
+
+// RunningTaskToProto converts a running task to the coordinator wire shape.
+func RunningTaskToProto(task *exec.RunningTask) *coordinatorv1.RunningTask {
+	if task == nil {
+		return nil
+	}
+	return &coordinatorv1.RunningTask{
+		DagRunId:         task.DAGRunID,
+		DagName:          task.DAGName,
+		StartedAt:        task.StartedAt,
+		RootDagRunName:   task.RootDAGRunName,
+		RootDagRunId:     task.RootDAGRunID,
+		ParentDagRunName: task.ParentDAGRunName,
+		ParentDagRunId:   task.ParentDAGRunID,
+		AttemptKey:       task.AttemptKey,
+	}
+}
+
+// ProtoToRunningTask converts a coordinator running task to the domain shape.
+func ProtoToRunningTask(task *coordinatorv1.RunningTask) *exec.RunningTask {
+	if task == nil {
+		return nil
+	}
+	return &exec.RunningTask{
+		DAGRunID:         task.DagRunId,
+		DAGName:          task.DagName,
+		StartedAt:        task.StartedAt,
+		RootDAGRunName:   task.RootDagRunName,
+		RootDAGRunID:     task.RootDagRunId,
+		ParentDAGRunName: task.ParentDagRunName,
+		ParentDAGRunID:   task.ParentDagRunId,
+		AttemptKey:       task.AttemptKey,
+	}
+}

--- a/internal/proto/convert/dispatch_test.go
+++ b/internal/proto/convert/dispatch_test.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/proto/convert"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDispatchTaskToProtoClonesWorkerSelector(t *testing.T) {
+	t.Parallel()
+
+	task := &exec.DispatchTask{
+		WorkerSelector: map[string]string{"host": "server-a"},
+	}
+
+	protoTask, err := convert.DispatchTaskToProto(task)
+	require.NoError(t, err)
+	require.NotNil(t, protoTask)
+
+	task.WorkerSelector["host"] = "server-b"
+	task.WorkerSelector["zone"] = "zone-1"
+
+	assert.Equal(t, map[string]string{"host": "server-a"}, protoTask.WorkerSelector)
+}
+
+func TestDispatchTaskToProtoValidatesOwnerPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{name: "zero", port: 0},
+		{name: "max", port: 65535},
+		{name: "negative", port: -1, wantErr: true},
+		{name: "too_large", port: 65536, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := convert.DispatchTaskToProto(&exec.DispatchTask{
+				Owner: exec.CoordinatorEndpoint{Port: tt.port},
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "owner coordinator port out of range")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestProtoToDispatchTaskClonesWorkerSelector(t *testing.T) {
+	t.Parallel()
+
+	protoTask := &coordinatorv1.Task{
+		WorkerSelector: map[string]string{"host": "server-a"},
+	}
+
+	task, err := convert.ProtoToDispatchTask(protoTask)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+
+	protoTask.WorkerSelector["host"] = "server-b"
+	protoTask.WorkerSelector["zone"] = "zone-1"
+
+	assert.Equal(t, map[string]string{"host": "server-a"}, task.WorkerSelector)
+}
+
+func TestProtoToDispatchTaskValidatesOwnerPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		port    int32
+		wantErr bool
+	}{
+		{name: "zero", port: 0},
+		{name: "max", port: 65535},
+		{name: "negative", port: -1, wantErr: true},
+		{name: "too_large", port: 65536, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := convert.ProtoToDispatchTask(&coordinatorv1.Task{
+				OwnerCoordinatorPort: tt.port,
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "owner coordinator port out of range")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -49,11 +49,9 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	"github.com/dagucloud/dagu/internal/runtime/builtin/s3"
 	"github.com/dagucloud/dagu/internal/runtime/builtin/ssh"
-	"github.com/dagucloud/dagu/internal/runtime/remote"
 	"github.com/dagucloud/dagu/internal/runtime/resourcelimit"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
-	"github.com/dagucloud/dagu/internal/service/coordinator"
 
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin"
 )
@@ -188,6 +186,9 @@ type Agent struct {
 	// When nil, status is written to local filesystem via DAGRunAttempt.
 	statusPusher StatusPusher
 
+	// dispatcherFactory creates a dispatcher for distributed child DAG execution.
+	dispatcherFactory DispatcherFactory
+
 	// logWriterFactory is used to create log writers for step output.
 	// When nil, logs are written to local filesystem.
 	logWriterFactory exec.LogWriterFactory
@@ -237,10 +238,8 @@ type Agent struct {
 	evaluatedS3            *core.S3Config
 }
 
-// StatusPusher is an interface for pushing status updates remotely.
-type StatusPusher interface {
-	Push(ctx context.Context, status exec.DAGRunStatus) error
-}
+// StatusPusher reports DAG run status outside the current execution process.
+type StatusPusher = runtime.StatusPusher
 
 // SocketServer handles local status/control requests for a running DAG.
 type SocketServer interface {
@@ -257,9 +256,10 @@ func defaultSocketServerFactory(addr string, handlerFunc sock.HTTPHandlerFunc) (
 }
 
 // ArtifactFinalizer uploads or persists artifacts before the final terminal status is written.
-type ArtifactFinalizer interface {
-	Finalize(ctx context.Context, attemptID, dir string) error
-}
+type ArtifactFinalizer = runtime.ArtifactFinalizer
+
+// DispatcherFactory creates a dispatcher for distributed child DAG execution.
+type DispatcherFactory func(ctx context.Context) (runtime.Dispatcher, error)
 
 // Options is the configuration for the Agent.
 type Options struct {
@@ -287,6 +287,8 @@ type Options struct {
 	// StatusPusher is used to push status updates to a remote coordinator.
 	// When nil, status is written to local filesystem via DAGRunAttempt.
 	StatusPusher StatusPusher
+	// DispatcherFactory creates dispatchers for distributed child DAG execution.
+	DispatcherFactory DispatcherFactory
 	// LogWriterFactory is used to create log writers for step output.
 	// When nil, logs are written to local filesystem.
 	LogWriterFactory exec.LogWriterFactory
@@ -380,6 +382,7 @@ func New(
 		peerConfig:                 opts.PeerConfig,
 		workerID:                   opts.WorkerID,
 		statusPusher:               opts.StatusPusher,
+		dispatcherFactory:          opts.DispatcherFactory,
 		logWriterFactory:           opts.LogWriterFactory,
 		queuedRun:                  opts.QueuedRun,
 		attemptID:                  opts.AttemptID,
@@ -550,14 +553,16 @@ func (a *Agent) Run(ctx context.Context) error {
 	// Create a new environment for the dag-run.
 	dbClient := newDBClient(a.dagRunStore, a.dagStore)
 
-	// Initialize coordinator client factory for distributed execution
-	coordinatorCli := a.createCoordinatorClient(ctx)
+	dispatcher, err := a.createDispatcher(ctx)
+	if err != nil {
+		return err
+	}
 
 	contextOpts := []runtime.ContextOption{
 		runtime.WithDatabase(dbClient),
 		runtime.WithRootDAGRun(a.rootDAGRun),
 		runtime.WithParams(a.dag.Params),
-		runtime.WithCoordinator(coordinatorCli),
+		runtime.WithCoordinator(dispatcher),
 		runtime.WithSecrets(secretEnvs),
 		runtime.WithDefaultExecMode(a.defaultExecMode),
 	}
@@ -964,10 +969,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	<-progressDone
 	progressDrained = true
 
-	if coordinatorCli != nil {
-		// Cleanup the coordinator client resources if it was created.
-		if err := coordinatorCli.Cleanup(ctx); err != nil {
-			logger.Warn(ctx, "Failed to cleanup coordinator client", tag.Error(err))
+	if dispatcher != nil {
+		if err := dispatcher.Cleanup(ctx); err != nil {
+			logger.Warn(ctx, "Failed to cleanup dispatcher", tag.Error(err))
 		}
 	}
 
@@ -1040,7 +1044,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	// Stream scheduler log to coordinator if using remote logging (shared-nothing mode)
 	if a.logWriterFactory != nil {
-		if streamer, ok := a.logWriterFactory.(*remote.LogStreamer); ok {
+		if streamer, ok := a.logWriterFactory.(runtime.SchedulerLogStreamer); ok {
 			if err := streamer.StreamSchedulerLog(ctx, a.logFile); err != nil {
 				logger.Warn(ctx, "Failed to stream scheduler log", tag.Error(err))
 			}
@@ -1399,11 +1403,11 @@ func (a *Agent) pushStatus(ctx context.Context, status exec.DAGRunStatus) {
 	}
 	if err := a.statusPusher.Push(pushCtx, status); err != nil {
 		logger.Error(ctx, "Failed to push status to coordinator", tag.Error(err))
-		var rejectedErr *remote.AttemptRejectedError
+		var rejectedErr runtime.AttemptRejected
 		if errors.As(err, &rejectedErr) && !a.finished.Load() {
 			logger.Warn(ctx, "Coordinator rejected the worker attempt; stopping execution",
 				tag.AttemptID(a.dagRunAttemptID),
-				slog.String("reason", rejectedErr.Reason),
+				slog.String("reason", rejectedErr.AttemptRejectedReason()),
 			)
 			a.stopChildren(context.Background(), syscall.SIGTERM, true)
 		}
@@ -1430,7 +1434,7 @@ func (a *Agent) watchCancelRequested(ctx context.Context, attempt exec.DAGRunAtt
 			// Only signal if the agent hasn't finished yet.
 			// This handles cancellation from the worker (via heartbeat CancelledRuns)
 			// in shared-nothing mode. If the agent already finished normally,
-			// we don't want to send an unnecessary SIGTERM.
+			// sending an extra SIGTERM is unnecessary.
 			if !a.finished.Load() {
 				a.stopChildren(context.Background(), syscall.SIGTERM, true)
 			}
@@ -1557,25 +1561,15 @@ func (a *Agent) newRunner(attempt exec.DAGRunAttempt) *runtime.Runner {
 	return runtime.New(cfg)
 }
 
-// createCoordinatorClient creates a coordinator client factory for distributed execution
-func (a *Agent) createCoordinatorClient(ctx context.Context) runtime.Dispatcher {
-	if a.registry == nil {
-		logger.Debug(ctx, "Service monitor is not configured; skipping coordinator client creation")
-		return nil
+func (a *Agent) createDispatcher(ctx context.Context) (runtime.Dispatcher, error) {
+	if a.dispatcherFactory == nil {
+		if a.registry != nil {
+			logger.Debug(ctx, "Dispatcher factory is not configured; running in local-only mode")
+		}
+		return nil, nil
 	}
 
-	// Create and configure factory
-	coordinatorCliCfg := coordinator.DefaultConfig()
-	coordinatorCliCfg.MaxRetries = 50
-
-	// Configure the coordinator client based on the global configuration
-	coordinatorCliCfg.CAFile = a.peerConfig.ClientCaFile
-	coordinatorCliCfg.CertFile = a.peerConfig.CertFile
-	coordinatorCliCfg.KeyFile = a.peerConfig.KeyFile
-	coordinatorCliCfg.SkipTLSVerify = a.peerConfig.SkipTLSVerify
-	coordinatorCliCfg.Insecure = a.peerConfig.Insecure
-
-	return coordinator.New(a.registry, coordinatorCliCfg)
+	return a.dispatcherFactory(ctx)
 }
 
 // resolveSecrets resolves all secrets defined in the DAG and returns them as

--- a/internal/runtime/distributed_stale_run.go
+++ b/internal/runtime/distributed_stale_run.go
@@ -160,7 +160,7 @@ func workerHeartbeatReportsAttempt(record *exec.WorkerHeartbeatRecord, status *e
 		if task.AttemptKey != "" && task.AttemptKey == attemptKey {
 			return true
 		}
-		if task.AttemptKey == "" && task.DagRunId == status.DAGRunID && task.DagName == status.Name {
+		if task.AttemptKey == "" && task.DAGRunID == status.DAGRunID && task.DAGName == status.Name {
 			return true
 		}
 	}

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -27,10 +27,8 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/telemetry"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	dagutools "github.com/dagucloud/dagu/internal/tools"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 var (
@@ -373,8 +371,8 @@ func isDAGToolsEnvKey(key string) bool {
 	return false
 }
 
-// BuildCoordinatorTask creates a coordinator task for distributed execution
-func (e *SubDAGExecutor) BuildCoordinatorTask(ctx context.Context, runParams RunParams) (*coordinatorv1.Task, error) {
+// BuildCoordinatorTask creates a dispatch task for distributed execution.
+func (e *SubDAGExecutor) BuildCoordinatorTask(ctx context.Context, runParams RunParams) (*exec.DispatchTask, error) {
 	rCtx := exec.GetContext(ctx)
 
 	if runParams.RunID == "" {
@@ -394,7 +392,7 @@ func (e *SubDAGExecutor) BuildCoordinatorTask(ctx context.Context, runParams Run
 	task := CreateTask(
 		e.DAG.Name,
 		string(e.DAG.YamlData),
-		coordinatorv1.Operation_OPERATION_START,
+		exec.DispatchOperationStart,
 		runParams.RunID,
 		taskOpts...,
 	)
@@ -415,7 +413,7 @@ func (e *SubDAGExecutor) buildCoordinatorRetryTask(
 	runParams RunParams,
 	stepName string,
 	previousStatus *exec.DAGRunStatus,
-) (*coordinatorv1.Task, error) {
+) (*exec.DispatchTask, error) {
 	rCtx := exec.GetContext(ctx)
 	if runParams.RunID == "" {
 		return nil, errDAGRunIDNotSet
@@ -436,7 +434,7 @@ func (e *SubDAGExecutor) buildCoordinatorRetryTask(
 	task := CreateTask(
 		e.DAG.Name,
 		string(e.DAG.YamlData),
-		coordinatorv1.Operation_OPERATION_RETRY,
+		exec.DispatchOperationRetry,
 		runParams.RunID,
 		taskOpts...,
 	)
@@ -691,7 +689,7 @@ func (e *SubDAGExecutor) dispatchToCoordinator(ctx context.Context, runParams Ru
 	}
 
 	taskCtx := logger.WithValues(ctx,
-		tag.RunID(task.DagRunId),
+		tag.RunID(task.DAGRunID),
 		tag.Target(task.Target),
 	)
 	logger.Info(taskCtx, "Dispatching task to coordinator",
@@ -727,7 +725,7 @@ func (e *SubDAGExecutor) dispatchRetryToCoordinator(ctx context.Context, runPara
 	}
 
 	taskCtx := logger.WithValues(ctx,
-		tag.RunID(task.DagRunId),
+		tag.RunID(task.DAGRunID),
 		tag.Target(task.Target),
 		tag.Step(stepName),
 	)
@@ -944,22 +942,20 @@ func (e *SubDAGExecutor) getFullStatusFromCoordinator(
 	rootDAGRun exec.DAGRunRef,
 ) (*exec.DAGRunStatus, error) {
 	rootRef := &rootDAGRun
-	resp, err := e.coordinatorCli.GetDAGRunStatus(ctx, e.DAG.Name, dagRunID, rootRef)
+	result, err := e.coordinatorCli.GetDAGRunStatus(ctx, e.DAG.Name, dagRunID, rootRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DAG run status from coordinator: %w", err)
 	}
-	if resp == nil {
+	if result == nil {
 		return nil, fmt.Errorf("no response from coordinator")
 	}
-	if !resp.Found {
+	if !result.Found {
 		return nil, fmt.Errorf("DAG run not found in coordinator")
 	}
-
-	dagRunStatus, convErr := convert.ProtoToDAGRunStatus(resp.Status)
-	if convErr != nil {
-		return nil, fmt.Errorf("failed to convert status: %w", convErr)
+	if result.Status == nil {
+		return nil, fmt.Errorf("coordinator returned empty DAG run status")
 	}
-	return dagRunStatus, nil
+	return result.Status, nil
 }
 
 // extractOutputsFromNodes extracts output variables from nodes.

--- a/internal/runtime/executor/dag_runner_test.go
+++ b/internal/runtime/executor/dag_runner_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	dagutools "github.com/dagucloud/dagu/internal/tools"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -407,7 +405,7 @@ func TestBuildCoordinatorTask_ExternalStepRetry(t *testing.T) {
 	task, err := executor.BuildCoordinatorTask(ctx, RunParams{RunID: "child-789", Params: "ITEM=1"})
 	require.NoError(t, err)
 
-	assert.Equal(t, coordinatorv1.Operation_OPERATION_START, task.Operation)
+	assert.Equal(t, exec1.DispatchOperationStart, task.Operation)
 	assert.True(t, task.ExternalStepRetry)
 	assert.Equal(t, "ITEM=1", task.Params)
 }
@@ -446,7 +444,7 @@ func TestRetry_Distributed(t *testing.T) {
 	}
 
 	dispatcher := &mockDispatcher{
-		getStatusResponses: []*coordinatorv1.GetDAGRunStatusResponse{
+		getStatusResponses: []*exec1.DAGRunStatusResult{
 			mustStatusResponse(t, previousStatus),
 			mustStatusResponse(t, completedStatus),
 		},
@@ -473,7 +471,7 @@ func TestRetry_Distributed(t *testing.T) {
 
 	require.Len(t, dispatcher.dispatches, 1)
 	task := dispatcher.dispatches[0]
-	assert.Equal(t, coordinatorv1.Operation_OPERATION_RETRY, task.Operation)
+	assert.Equal(t, exec1.DispatchOperationRetry, task.Operation)
 	assert.Equal(t, "flaky", task.Step)
 	assert.True(t, task.ExternalStepRetry)
 	require.NotNil(t, task.PreviousStatus)
@@ -798,13 +796,13 @@ type mockDatabase struct {
 }
 
 type mockDispatcher struct {
-	dispatches          []*coordinatorv1.Task
-	getStatusResponses  []*coordinatorv1.GetDAGRunStatusResponse
+	dispatches          []*exec1.DispatchTask
+	getStatusResponses  []*exec1.DAGRunStatusResult
 	getStatusErr        error
 	requestCancelCalled int
 }
 
-func (m *mockDispatcher) Dispatch(_ context.Context, task *coordinatorv1.Task) error {
+func (m *mockDispatcher) Dispatch(_ context.Context, task *exec1.DispatchTask) error {
 	m.dispatches = append(m.dispatches, task)
 	return nil
 }
@@ -816,12 +814,12 @@ func (m *mockDispatcher) GetDAGRunStatus(
 	_ string,
 	_ string,
 	_ *exec1.DAGRunRef,
-) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+) (*exec1.DAGRunStatusResult, error) {
 	if m.getStatusErr != nil {
 		return nil, m.getStatusErr
 	}
 	if len(m.getStatusResponses) == 0 {
-		return &coordinatorv1.GetDAGRunStatusResponse{Found: false}, nil
+		return &exec1.DAGRunStatusResult{Found: false}, nil
 	}
 	resp := m.getStatusResponses[0]
 	m.getStatusResponses = m.getStatusResponses[1:]
@@ -861,12 +859,10 @@ func (m *mockDatabase) RequestChildCancel(ctx context.Context, dagRunID string, 
 	return args.Error(0)
 }
 
-func mustStatusResponse(t *testing.T, status *exec1.DAGRunStatus) *coordinatorv1.GetDAGRunStatusResponse {
+func mustStatusResponse(t *testing.T, status *exec1.DAGRunStatus) *exec1.DAGRunStatusResult {
 	t.Helper()
-	protoStatus, err := convert.DAGRunStatusToProto(status)
-	require.NoError(t, err)
-	return &coordinatorv1.GetDAGRunStatusResponse{
+	return &exec1.DAGRunStatusResult{
 		Found:  true,
-		Status: protoStatus,
+		Status: status,
 	}
 }

--- a/internal/runtime/executor/task.go
+++ b/internal/runtime/executor/task.go
@@ -9,26 +9,24 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
-// CreateTask creates a coordinator task from this DAG for distributed execution.
+// CreateTask creates a dispatch task from this DAG for distributed execution.
 // It constructs a task with the given operation and run ID, setting the DAG's name
 // as both the root DAG and target, and includes the DAG's YAML definition.
 func CreateTask(
 	dagName string,
 	yamlDefinition string,
-	op coordinatorv1.Operation,
+	op exec.DispatchOperation,
 	runID string,
 	opts ...TaskOption,
-) *coordinatorv1.Task {
-	task := &coordinatorv1.Task{
-		RootDagRunName: dagName,
-		RootDagRunId:   runID,
+) *exec.DispatchTask {
+	task := &exec.DispatchTask{
+		RootDAGRunName: dagName,
+		RootDAGRunID:   runID,
 		Operation:      op,
-		DagRunId:       runID,
+		DAGRunID:       runID,
 		Target:         dagName,
 		Definition:     yamlDefinition,
 	}
@@ -40,62 +38,62 @@ func CreateTask(
 	return task
 }
 
-// TaskOption is a function that modifies a coordinatorv1.Task.
-type TaskOption func(*coordinatorv1.Task)
+// TaskOption is a function that modifies a dispatch task.
+type TaskOption func(*exec.DispatchTask)
 
 // WithRootDagRun sets the root DAG run name and ID in the task.
 func WithRootDagRun(ref exec.DAGRunRef) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		if ref.Name == "" || ref.ID == "" {
 			return // No root DAG run reference provided
 		}
-		task.RootDagRunName = ref.Name
-		task.RootDagRunId = ref.ID
+		task.RootDAGRunName = ref.Name
+		task.RootDAGRunID = ref.ID
 	}
 }
 
 // WithParentDagRun sets the parent DAG run name and ID in the task.
 func WithParentDagRun(ref exec.DAGRunRef) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		if ref.Name == "" || ref.ID == "" {
 			return // No parent DAG run reference provided
 		}
-		task.ParentDagRunName = ref.Name
-		task.ParentDagRunId = ref.ID
+		task.ParentDAGRunName = ref.Name
+		task.ParentDAGRunID = ref.ID
 	}
 }
 
 // WithTaskParams sets the parameters for the task.
 func WithTaskParams(params string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.Params = params
 	}
 }
 
 // WithSourceFile sets the original DAG source file path for provenance-aware flows.
 func WithSourceFile(sourceFile string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.SourceFile = sourceFile
 	}
 }
 
 // WithWorkerSelector sets the worker selector labels for the task.
 func WithWorkerSelector(selector map[string]string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.WorkerSelector = selector
 	}
 }
 
 // WithStep sets the step name for retry operations.
 func WithStep(step string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.Step = step
 	}
 }
 
 // WithLabels sets additional labels (comma-separated) for the task.
 func WithLabels(labels string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.Labels = labels
 	}
 }
@@ -108,7 +106,7 @@ func WithTags(tags string) TaskOption {
 
 // WithScheduleTime sets the RFC 3339 timestamp of when the task was scheduled.
 func WithScheduleTime(scheduleTime string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.ScheduleTime = scheduleTime
 	}
 }
@@ -116,14 +114,14 @@ func WithScheduleTime(scheduleTime string) TaskOption {
 // WithBaseConfig sets the base config YAML content on the task.
 // This allows workers to apply base config without needing local base config files.
 func WithBaseConfig(content string) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.BaseConfig = content
 	}
 }
 
 // WithAgentSnapshot sets the opaque worker agent snapshot on the task.
 func WithAgentSnapshot(snapshot []byte) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		if len(snapshot) == 0 {
 			task.AgentSnapshot = nil
 			return
@@ -132,11 +130,12 @@ func WithAgentSnapshot(snapshot []byte) TaskOption {
 	}
 }
 
+// WithWorkspaceBundle sets workspace bundle metadata for shared-nothing dispatch.
 func WithWorkspaceBundle(desc workspacebundle.Descriptor) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.WorkspaceBundleDigest = desc.Digest
 		task.WorkspaceBundleSize = desc.Size
-		task.WorkspaceBundleDagPath = desc.DAGPath
+		task.WorkspaceBundleDAGPath = desc.DAGPath
 		task.WorkspaceBundleOriginalRef = desc.OriginalRef
 		task.WorkspaceBundleResolvedRef = desc.ResolvedRef
 	}
@@ -144,7 +143,7 @@ func WithWorkspaceBundle(desc workspacebundle.Descriptor) TaskOption {
 
 // WithExternalStepRetry enables parent-managed step retries for the dispatched task.
 func WithExternalStepRetry(enabled bool) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		task.ExternalStepRetry = enabled
 	}
 }
@@ -171,17 +170,12 @@ func ResolveBaseConfig(baseConfigData []byte, fallbackPath string) string {
 // WithPreviousStatus sets the previous status for retry operations in shared-nothing mode.
 // When set, workers can retry without needing local DAGRunStore access.
 func WithPreviousStatus(status *exec.DAGRunStatus) TaskOption {
-	return func(task *coordinatorv1.Task) {
+	return func(task *exec.DispatchTask) {
 		if status != nil {
 			if task.QueueName == "" && status.ProcGroup != "" {
 				task.QueueName = status.ProcGroup
 			}
-			protoStatus, err := convert.DAGRunStatusToProto(status)
-			if err != nil {
-				slog.Error("failed to convert previous status to proto", "error", err)
-				return
-			}
-			task.PreviousStatus = protoStatus
+			task.PreviousStatus = status
 		}
 	}
 }

--- a/internal/runtime/executor/task_test.go
+++ b/internal/runtime/executor/task_test.go
@@ -8,11 +8,8 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDAG_CreateTask(t *testing.T) {
@@ -38,24 +35,24 @@ steps:
 		task := executor.CreateTask(
 			dagName,
 			yamlDefinition,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			runID,
 			executor.WithTaskParams(params),
 			executor.WithWorkerSelector(selector),
 		)
 
 		assert.NotNil(t, task)
-		assert.Equal(t, "test-dag", task.RootDagRunName)
-		assert.Equal(t, runID, task.RootDagRunId)
-		assert.Equal(t, coordinatorv1.Operation_OPERATION_START, task.Operation)
-		assert.Equal(t, runID, task.DagRunId)
+		assert.Equal(t, "test-dag", task.RootDAGRunName)
+		assert.Equal(t, runID, task.RootDAGRunID)
+		assert.Equal(t, exec.DispatchOperationStart, task.Operation)
+		assert.Equal(t, runID, task.DAGRunID)
 		assert.Equal(t, "test-dag", task.Target)
 		assert.Equal(t, params, task.Params)
 		assert.Equal(t, selector, task.WorkerSelector)
 		assert.Equal(t, yamlDefinition, task.Definition)
 		// Parent fields should be empty when no options provided
-		assert.Empty(t, task.ParentDagRunName)
-		assert.Empty(t, task.ParentDagRunId)
+		assert.Empty(t, task.ParentDAGRunName)
+		assert.Empty(t, task.ParentDAGRunID)
 	})
 
 	t.Run("WithRootDagRunOption", func(t *testing.T) {
@@ -73,14 +70,14 @@ steps:
 		task := executor.CreateTask(
 			dag.Name,
 			string(dag.YamlData),
-			coordinatorv1.Operation_OPERATION_RETRY,
+			exec.DispatchOperationRetry,
 			"child-run-456",
 			executor.WithRootDagRun(rootRef),
 		)
 
-		assert.Equal(t, "root-dag", task.RootDagRunName)
-		assert.Equal(t, "root-run-123", task.RootDagRunId)
-		assert.Equal(t, "child-run-456", task.DagRunId)
+		assert.Equal(t, "root-dag", task.RootDAGRunName)
+		assert.Equal(t, "root-run-123", task.RootDAGRunID)
+		assert.Equal(t, "child-run-456", task.DAGRunID)
 		assert.Equal(t, "sub-dag", task.Target)
 	})
 
@@ -95,15 +92,15 @@ steps:
 		task := executor.CreateTask(
 			"sub-dag",
 			`name: sub-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"child-run-456",
 			executor.WithParentDagRun(parentRef),
 		)
 
-		assert.Equal(t, "parent-dag", task.ParentDagRunName)
-		assert.Equal(t, "parent-run-789", task.ParentDagRunId)
-		assert.Equal(t, "sub-dag", task.RootDagRunName)
-		assert.Equal(t, "child-run-456", task.RootDagRunId)
+		assert.Equal(t, "parent-dag", task.ParentDAGRunName)
+		assert.Equal(t, "parent-run-789", task.ParentDAGRunID)
+		assert.Equal(t, "sub-dag", task.RootDAGRunName)
+		assert.Equal(t, "child-run-456", task.RootDAGRunID)
 	})
 
 	t.Run("WithMultipleOptions", func(t *testing.T) {
@@ -121,7 +118,7 @@ steps:
 		task := executor.CreateTask(
 			"grandsub-dag",
 			`name: grandsub-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"grandchild-run-789",
 			executor.WithTaskParams("nested=true"),
 			executor.WithWorkerSelector(map[string]string{"env": "prod"}),
@@ -129,11 +126,11 @@ steps:
 			executor.WithParentDagRun(parentRef),
 		)
 
-		assert.Equal(t, "root-dag", task.RootDagRunName)
-		assert.Equal(t, "root-run-123", task.RootDagRunId)
-		assert.Equal(t, "parent-dag", task.ParentDagRunName)
-		assert.Equal(t, "parent-run-456", task.ParentDagRunId)
-		assert.Equal(t, "grandchild-run-789", task.DagRunId)
+		assert.Equal(t, "root-dag", task.RootDAGRunName)
+		assert.Equal(t, "root-run-123", task.RootDAGRunID)
+		assert.Equal(t, "parent-dag", task.ParentDAGRunName)
+		assert.Equal(t, "parent-run-456", task.ParentDAGRunID)
+		assert.Equal(t, "grandchild-run-789", task.DAGRunID)
 		assert.Equal(t, "grandsub-dag", task.Target)
 		assert.Equal(t, "nested=true", task.Params)
 		assert.Equal(t, map[string]string{"env": "prod"}, task.WorkerSelector)
@@ -145,7 +142,7 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 		)
 
@@ -162,18 +159,18 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 			executor.WithRootDagRun(emptyRootRef),
 			executor.WithParentDagRun(emptyParentRef),
 		)
 
 		// Should use DAG name and runID as root values
-		assert.Equal(t, "test-dag", task.RootDagRunName)
-		assert.Equal(t, "run-123", task.RootDagRunId)
+		assert.Equal(t, "test-dag", task.RootDAGRunName)
+		assert.Equal(t, "run-123", task.RootDAGRunID)
 		// Parent fields should remain empty
-		assert.Empty(t, task.ParentDagRunName)
-		assert.Empty(t, task.ParentDagRunId)
+		assert.Empty(t, task.ParentDAGRunName)
+		assert.Empty(t, task.ParentDAGRunID)
 	})
 
 	t.Run("PartiallyEmptyRefs", func(t *testing.T) {
@@ -186,17 +183,17 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 			executor.WithRootDagRun(partialRootRef),
 			executor.WithParentDagRun(partialParentRef),
 		)
 
 		// Partial refs should not modify the task
-		assert.Equal(t, "test-dag", task.RootDagRunName)
-		assert.Equal(t, "run-123", task.RootDagRunId)
-		assert.Empty(t, task.ParentDagRunName)
-		assert.Empty(t, task.ParentDagRunId)
+		assert.Equal(t, "test-dag", task.RootDAGRunName)
+		assert.Equal(t, "run-123", task.RootDAGRunID)
+		assert.Empty(t, task.ParentDAGRunName)
+		assert.Empty(t, task.ParentDAGRunID)
 	})
 
 	t.Run("CustomTaskOption", func(t *testing.T) {
@@ -204,7 +201,7 @@ steps:
 
 		// Create a custom task option
 		withStep := func(step string) executor.TaskOption {
-			return func(task *coordinatorv1.Task) {
+			return func(task *exec.DispatchTask) {
 				task.Step = step
 			}
 		}
@@ -212,13 +209,13 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_RETRY,
+			exec.DispatchOperationRetry,
 			"run-123",
 			withStep("step-2"),
 		)
 
 		assert.Equal(t, "step-2", task.Step)
-		assert.Equal(t, coordinatorv1.Operation_OPERATION_RETRY, task.Operation)
+		assert.Equal(t, exec.DispatchOperationRetry, task.Operation)
 	})
 
 	t.Run("WithLabelsOption", func(t *testing.T) {
@@ -227,7 +224,7 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 			executor.WithLabels("env=prod,region=us-east-1"),
 		)
@@ -241,7 +238,7 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 			executor.WithScheduleTime("2026-03-13T10:00:00Z"),
 		)
@@ -255,7 +252,7 @@ steps:
 		task := executor.CreateTask(
 			"test-dag",
 			`name: test-dag`,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"run-123",
 			executor.WithExternalStepRetry(true),
 		)
@@ -266,10 +263,10 @@ steps:
 	t.Run("AllOperationTypes", func(t *testing.T) {
 		t.Parallel()
 
-		operations := []coordinatorv1.Operation{
-			coordinatorv1.Operation_OPERATION_UNSPECIFIED,
-			coordinatorv1.Operation_OPERATION_START,
-			coordinatorv1.Operation_OPERATION_RETRY,
+		operations := []exec.DispatchOperation{
+			exec.DispatchOperationUnspecified,
+			exec.DispatchOperationStart,
+			exec.DispatchOperationRetry,
 		}
 
 		for _, op := range operations {
@@ -290,31 +287,31 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithRootDagRun", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		ref := exec.DAGRunRef{Name: "root", ID: "123"}
 
 		executor.WithRootDagRun(ref)(task)
 
-		assert.Equal(t, "root", task.RootDagRunName)
-		assert.Equal(t, "123", task.RootDagRunId)
+		assert.Equal(t, "root", task.RootDAGRunName)
+		assert.Equal(t, "123", task.RootDAGRunID)
 	})
 
 	t.Run("WithParentDagRun", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		ref := exec.DAGRunRef{Name: "parent", ID: "456"}
 
 		executor.WithParentDagRun(ref)(task)
 
-		assert.Equal(t, "parent", task.ParentDagRunName)
-		assert.Equal(t, "456", task.ParentDagRunId)
+		assert.Equal(t, "parent", task.ParentDAGRunName)
+		assert.Equal(t, "456", task.ParentDAGRunID)
 	})
 
 	t.Run("WithTaskParams", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithTaskParams("key1=value1 key2=value2")(task)
 
@@ -324,7 +321,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithWorkerSelector", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		selector := map[string]string{
 			"gpu":    "true",
 			"region": "us-west-2",
@@ -338,7 +335,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithStep", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithStep("step-name")(task)
 
@@ -348,7 +345,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithLabels", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithLabels("env=prod,team=backend")(task)
 
@@ -358,7 +355,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithLabelsEmpty", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithLabels("")(task)
 
@@ -368,7 +365,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithTags", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithTags("env=prod,team=backend")(task)
 
@@ -378,7 +375,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithTagsEmpty", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		executor.WithTags("")(task)
 
@@ -388,7 +385,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithPreviousStatus", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		status := &exec.DAGRunStatus{
 			Name:      "test-dag",
 			DAGRunID:  "run-123",
@@ -402,22 +399,14 @@ func TestTaskOption_Functions(t *testing.T) {
 
 		executor.WithPreviousStatus(status)(task)
 
-		assert.NotNil(t, task.PreviousStatus)
-		// Verify via JSON conversion
-		s, convErr := convert.ProtoToDAGRunStatus(task.PreviousStatus)
-		require.NoError(t, convErr)
-		assert.NotNil(t, s)
-		assert.Equal(t, "test-dag", s.Name)
-		assert.Equal(t, "run-123", s.DAGRunID)
-		assert.Equal(t, core.Running, s.Status)
-		assert.Len(t, s.Nodes, 2)
+		assert.Same(t, status, task.PreviousStatus)
 		assert.Equal(t, "shared-queue", task.QueueName)
 	})
 
 	t.Run("WithPreviousStatusNil", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 
 		// Should not panic with nil status
 		executor.WithPreviousStatus(nil)(task)
@@ -428,7 +417,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithExternalStepRetry", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		executor.WithExternalStepRetry(true)(task)
 
 		assert.True(t, task.ExternalStepRetry)
@@ -437,7 +426,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithSourceFile", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		executor.WithSourceFile("/dags/test-dag.yaml")(task)
 
 		assert.Equal(t, "/dags/test-dag.yaml", task.SourceFile)
@@ -446,7 +435,7 @@ func TestTaskOption_Functions(t *testing.T) {
 	t.Run("WithAgentSnapshot", func(t *testing.T) {
 		t.Parallel()
 
-		task := &coordinatorv1.Task{}
+		task := &exec.DispatchTask{}
 		snapshot := []byte("agent-snapshot")
 		want := append([]byte(nil), snapshot...)
 		executor.WithAgentSnapshot(snapshot)(task)

--- a/internal/runtime/reporter.go
+++ b/internal/runtime/reporter.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+// StatusPusher reports DAG run status outside the current execution process.
+type StatusPusher interface {
+	Push(ctx context.Context, status exec.DAGRunStatus) error
+}
+
+// AttemptRejected marks a status push failure caused by a non-authoritative attempt.
+type AttemptRejected interface {
+	error
+	AttemptRejectedReason() string
+}
+
+// SchedulerLogStreamer streams a completed scheduler log.
+type SchedulerLogStreamer interface {
+	exec.LogWriterFactory
+	NewSchedulerLogWriter(ctx context.Context, localFile *os.File) io.WriteCloser
+	StreamSchedulerLog(ctx context.Context, logFilePath string) error
+}
+
+// ArtifactFinalizer persists artifacts before terminal status is reported.
+type ArtifactFinalizer interface {
+	Finalize(ctx context.Context, attemptID, dir string) error
+}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"google.golang.org/grpc"
@@ -39,9 +40,6 @@ import (
 // service registry and gRPC.
 type Client interface {
 	exec.Dispatcher
-
-	// Dispatch sends a task to the coordinator
-	Dispatch(ctx context.Context, task *coordinatorv1.Task) error
 
 	// Poll retrieves a task from the coordinator.
 	Poll(ctx context.Context, policy backoff.RetryPolicy, req *coordinatorv1.PollRequest) (*coordinatorv1.Task, error)
@@ -167,11 +165,19 @@ func New(registry exec.ServiceRegistry, config *Config) Client {
 	}
 }
 
-// Dispatch sends a task to the coordinator
-func (cli *clientImpl) Dispatch(ctx context.Context, task *coordinatorv1.Task) error {
+// Dispatch sends a task to the coordinator.
+func (cli *clientImpl) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
+	if task == nil {
+		return fmt.Errorf("dispatch task is nil")
+	}
+	protoTask, err := convert.DispatchTaskToProto(task)
+	if err != nil {
+		return err
+	}
+
 	logger.Info(ctx, "Client dispatching task",
 		slog.String("operation", task.Operation.String()),
-		tag.RunID(task.DagRunId),
+		tag.RunID(task.DAGRunID),
 		tag.Target(task.Target),
 	)
 
@@ -195,7 +201,7 @@ func (cli *clientImpl) Dispatch(ctx context.Context, task *coordinatorv1.Task) e
 
 		return cli.attemptCall(ctx, members, func(ctx context.Context, member exec.HostInfo, client *client) error {
 			// Create request
-			req := &coordinatorv1.DispatchRequest{Task: task}
+			req := &coordinatorv1.DispatchRequest{Task: protoTask}
 
 			// Apply request timeout
 			dispatchCtx, cancel := context.WithTimeout(ctx, cli.config.RequestTimeout)
@@ -204,7 +210,7 @@ func (cli *clientImpl) Dispatch(ctx context.Context, task *coordinatorv1.Task) e
 			// Try to dispatch
 			if _, err := client.client.Dispatch(dispatchCtx, req); err != nil {
 				logger.Warn(ctx, "Failed to dispatch task to coordinator",
-					tag.RunID(task.DagRunId),
+					tag.RunID(task.DAGRunID),
 					tag.Target(task.Target),
 					slog.Any("worker-selector", task.WorkerSelector),
 					slog.String("coordinator-id", member.ID),
@@ -226,7 +232,7 @@ func (cli *clientImpl) Dispatch(ctx context.Context, task *coordinatorv1.Task) e
 			}
 
 			logger.Info(ctx, "Task dispatched successfully",
-				tag.RunID(task.DagRunId),
+				tag.RunID(task.DAGRunID),
 				tag.Target(task.Target),
 				slog.Any("worker-selector", task.WorkerSelector),
 				slog.String("coordinator-id", member.ID),
@@ -951,8 +957,8 @@ func openStreamWithFailover[T any](
 	return zero, fmt.Errorf("failed to create %s stream: %w", streamType, lastErr)
 }
 
-// GetDAGRunStatus retrieves the status of a DAG run from the coordinator
-func (cli *clientImpl) GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+// GetDAGRunStatus retrieves the status of a DAG run from the coordinator.
+func (cli *clientImpl) GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
 	members, err := cli.getCoordinatorMembers(ctx)
 	if err != nil {
 		return nil, err
@@ -978,7 +984,22 @@ func (cli *clientImpl) GetDAGRunStatus(ctx context.Context, dagName, dagRunID st
 		}
 		return nil
 	})
-	return resp, err
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("coordinator returned empty DAG run status response")
+	}
+
+	result := &exec.DAGRunStatusResult{Found: resp.Found}
+	if resp.Status != nil {
+		status, convErr := convert.ProtoToDAGRunStatus(resp.Status)
+		if convErr != nil {
+			return nil, fmt.Errorf("convert coordinator status: %w", convErr)
+		}
+		result.Status = status
+	}
+	return result, nil
 }
 
 // RequestCancel requests cancellation of a DAG run through the coordinator

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -81,8 +81,8 @@ func TestClientDispatch(t *testing.T) {
 
 		client := coordinator.New(monitor, config)
 
-		task := &coordinatorv1.Task{
-			DagRunId: "test-dag-run",
+		task := &exec.DispatchTask{
+			DAGRunID: "test-dag-run",
 			Target:   "test.yaml",
 		}
 
@@ -106,8 +106,8 @@ func TestClientDispatch(t *testing.T) {
 
 		client := coordinator.New(monitor, config)
 
-		task := &coordinatorv1.Task{
-			DagRunId: "test-dag-run",
+		task := &exec.DispatchTask{
+			DAGRunID: "test-dag-run",
 			Target:   "test.yaml",
 		}
 
@@ -148,8 +148,8 @@ func TestClientDispatch(t *testing.T) {
 
 		client := coordinator.New(monitor, config)
 
-		err := client.Dispatch(context.Background(), &coordinatorv1.Task{
-			DagRunId: "run-123",
+		err := client.Dispatch(context.Background(), &exec.DispatchTask{
+			DAGRunID: "run-123",
 			Target:   "test-dag",
 		})
 		require.Error(t, err)
@@ -1159,7 +1159,7 @@ func TestClientMetrics(t *testing.T) {
 	assert.True(t, metrics.IsConnected)
 	assert.Equal(t, 0, metrics.ConsecutiveFails)
 
-	task := &coordinatorv1.Task{DagRunId: "test"}
+	task := &exec.DispatchTask{DAGRunID: "test"}
 
 	// Attempt dispatch - should fail
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -1198,7 +1198,7 @@ func TestClientCleanup(t *testing.T) {
 	client := coordinator.New(monitor, config)
 
 	// Make a call to establish connection
-	task := &coordinatorv1.Task{DagRunId: "test"}
+	task := &exec.DispatchTask{DAGRunID: "test"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -1225,8 +1225,8 @@ func TestClientDispatch_NoCoordinators(t *testing.T) {
 	monitor := &mockServiceMonitor{}
 	client := coordinator.New(monitor, config)
 
-	task := &coordinatorv1.Task{
-		DagRunId: "test-dag-run",
+	task := &exec.DispatchTask{
+		DAGRunID: "test-dag-run",
 		Target:   "test.yaml",
 	}
 

--- a/internal/service/coordinator/export_test.go
+++ b/internal/service/coordinator/export_test.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator
+
+import "github.com/dagucloud/dagu/internal/core/exec"
+
+// RuntimeDispatcherConfigForTest exposes the coordinator client config for
+// external package tests.
+func RuntimeDispatcherConfigForTest(dispatcher exec.Dispatcher) (*Config, bool) {
+	client, ok := dispatcher.(*clientImpl)
+	if !ok {
+		return nil, false
+	}
+	return client.config, true
+}

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -308,8 +308,16 @@ func (h *Handler) Poll(ctx context.Context, req *coordinatorv1.PollRequest) (*co
 			return nil, status.Error(codes.Internal, "failed to claim task: "+err.Error())
 		}
 		if claimed != nil && claimed.Task != nil {
-			claimed.Task.WorkerId = req.WorkerId
-			return &coordinatorv1.PollResponse{Task: claimed.Task}, nil
+			claimed.Task.WorkerID = req.WorkerId
+			task, err := convert.DispatchTaskToProto(claimed.Task)
+			if err != nil {
+				releaseCtx := context.WithoutCancel(ctx)
+				if releaseErr := h.dispatchTaskStore.ReleaseClaim(releaseCtx, claimed.ClaimToken); releaseErr != nil && !errors.Is(releaseErr, exec.ErrDispatchTaskNotFound) {
+					return nil, status.Error(codes.Internal, fmt.Sprintf("failed to encode claimed task: %v; failed to release task claim: %v", err, releaseErr))
+				}
+				return nil, status.Error(codes.Internal, "failed to encode claimed task: "+err.Error())
+			}
+			return &coordinatorv1.PollResponse{Task: task}, nil
 		}
 
 		select {
@@ -380,7 +388,12 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	if err != nil {
 		return nil, status.Error(prepareAttemptErrorCode(err), "failed to prepare attempt: "+err.Error())
 	}
-	if err := h.dispatchTaskStore.Enqueue(ctx, req.Task); err != nil {
+	dispatchTask, err := convert.ProtoToDispatchTask(req.Task)
+	if err != nil {
+		h.markPreparedAttemptDispatchFailed(ctx, req.Task, prepared, err)
+		return nil, status.Error(codes.Internal, "failed to encode task: "+err.Error())
+	}
+	if err := h.dispatchTaskStore.Enqueue(ctx, dispatchTask); err != nil {
 		h.markPreparedAttemptDispatchFailed(ctx, req.Task, prepared, err)
 		return nil, status.Error(codes.Internal, "failed to enqueue task: "+err.Error())
 	}
@@ -845,7 +858,7 @@ func (h *Handler) GetWorkers(_ context.Context, _ *coordinatorv1.GetWorkersReque
 		if hb.Stats != nil {
 			workerInfo.TotalPollers = hb.Stats.TotalPollers
 			workerInfo.BusyPollers = hb.Stats.BusyPollers
-			workerInfo.RunningTasks = hb.Stats.RunningTasks
+			workerInfo.RunningTasks = convert.WorkerStatsToProto(hb.Stats).RunningTasks
 		}
 
 		workers = append(workers, workerInfo)
@@ -890,7 +903,7 @@ func (h *Handler) Heartbeat(ctx context.Context, req *coordinatorv1.HeartbeatReq
 		if err := h.workerHeartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        req.WorkerId,
 			Labels:          req.Labels,
-			Stats:           req.Stats,
+			Stats:           convert.ProtoToWorkerStats(req.Stats),
 			LastHeartbeatAt: receivedAt.UnixMilli(),
 		}); err != nil {
 			return nil, status.Error(codes.Internal, "failed to persist worker heartbeat: "+err.Error())
@@ -942,7 +955,11 @@ func (h *Handler) AckTaskClaim(ctx context.Context, req *coordinatorv1.AckTaskCl
 		return &coordinatorv1.AckTaskClaimResponse{Accepted: false, Error: "worker_id is required"}, nil
 	}
 
-	if err := h.distributedAttempts().recordTaskClaim(ctx, claimed.Task, workerID); err != nil {
+	task, err := convert.DispatchTaskToProto(claimed.Task)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to encode claimed task: "+err.Error())
+	}
+	if err := h.distributedAttempts().recordTaskClaim(ctx, task, workerID); err != nil {
 		return nil, status.Error(codes.Internal, "failed to create run lease: "+err.Error())
 	}
 	if err := h.dispatchTaskStore.DeleteClaim(ctx, req.ClaimToken); err != nil {

--- a/internal/service/coordinator/handler_external_test.go
+++ b/internal/service/coordinator/handler_external_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	coord "github.com/dagucloud/dagu/internal/service/coordinator"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerPollReleasesClaimWhenTaskEncodingFails(t *testing.T) {
+	t.Parallel()
+
+	store := &claimReleaseStore{
+		claimed: &exec.ClaimedDispatchTask{
+			Task: &exec.DispatchTask{
+				DAGRunID: "run-invalid-port",
+				Target:   "dag-invalid-port",
+				Owner:    exec.CoordinatorEndpoint{Port: -1},
+			},
+			ClaimToken: "claim-invalid-port",
+		},
+	}
+	handler := coord.NewHandler(coord.HandlerConfig{
+		DispatchTaskStore: store,
+		Owner:             exec.CoordinatorEndpoint{ID: "coord-a", Host: "127.0.0.1", Port: 1234},
+	})
+
+	resp, err := handler.Poll(context.Background(), &coordinatorv1.PollRequest{
+		WorkerId: "worker-1",
+		PollerId: "poller-1",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to encode claimed task")
+	assert.Equal(t, "claim-invalid-port", store.releasedToken)
+}
+
+type claimReleaseStore struct {
+	claimed       *exec.ClaimedDispatchTask
+	releasedToken string
+}
+
+func (s *claimReleaseStore) Enqueue(context.Context, *exec.DispatchTask) error {
+	return nil
+}
+
+func (s *claimReleaseStore) ClaimNext(context.Context, exec.DispatchTaskClaim) (*exec.ClaimedDispatchTask, error) {
+	claimed := s.claimed
+	s.claimed = nil
+	return claimed, nil
+}
+
+func (s *claimReleaseStore) GetClaim(context.Context, string) (*exec.ClaimedDispatchTask, error) {
+	return nil, exec.ErrDispatchTaskNotFound
+}
+
+func (s *claimReleaseStore) ReleaseClaim(_ context.Context, claimToken string) error {
+	s.releasedToken = claimToken
+	return nil
+}
+
+func (s *claimReleaseStore) DeleteClaim(context.Context, string) error {
+	return nil
+}
+
+func (s *claimReleaseStore) CountOutstandingByQueue(context.Context, string, time.Duration) (int, error) {
+	return 0, nil
+}
+
+func (s *claimReleaseStore) HasOutstandingAttempt(context.Context, string, time.Duration) (bool, error) {
+	return false, nil
+}

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -908,7 +908,7 @@ type failingDispatchTaskStore struct {
 	enqueueErr error
 }
 
-func (s *failingDispatchTaskStore) Enqueue(context.Context, *coordinatorv1.Task) error {
+func (s *failingDispatchTaskStore) Enqueue(context.Context, *exec.DispatchTask) error {
 	return s.enqueueErr
 }
 
@@ -918,6 +918,10 @@ func (s *failingDispatchTaskStore) ClaimNext(context.Context, exec.DispatchTaskC
 
 func (s *failingDispatchTaskStore) GetClaim(context.Context, string) (*exec.ClaimedDispatchTask, error) {
 	return nil, exec.ErrDispatchTaskNotFound
+}
+
+func (s *failingDispatchTaskStore) ReleaseClaim(context.Context, string) error {
+	return nil
 }
 
 func (s *failingDispatchTaskStore) DeleteClaim(context.Context, string) error {
@@ -2284,8 +2288,8 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        "worker-1",
 			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-			Stats: &coordinatorv1.WorkerStats{
-				RunningTasks: []*coordinatorv1.RunningTask{},
+			Stats: &exec.WorkerStats{
+				RunningTasks: []*exec.RunningTask{},
 			},
 		}))
 
@@ -2346,13 +2350,13 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        "worker-1",
 			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-			Stats: &coordinatorv1.WorkerStats{
-				RunningTasks: []*coordinatorv1.RunningTask{
+			Stats: &exec.WorkerStats{
+				RunningTasks: []*exec.RunningTask{
 					{
-						DagRunId:       "run-lease",
-						DagName:        "lease-dag",
-						RootDagRunId:   "run-lease",
-						RootDagRunName: "lease-dag",
+						DAGRunID:       "run-lease",
+						DAGName:        "lease-dag",
+						RootDAGRunID:   "run-lease",
+						RootDAGRunName: "lease-dag",
 						AttemptKey:     attemptKey,
 					},
 				},
@@ -2406,13 +2410,13 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        "worker-1",
 			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-			Stats: &coordinatorv1.WorkerStats{
-				RunningTasks: []*coordinatorv1.RunningTask{
+			Stats: &exec.WorkerStats{
+				RunningTasks: []*exec.RunningTask{
 					{
-						DagRunId:       "run-lease",
-						DagName:        "lease-dag",
-						RootDagRunId:   "run-lease",
-						RootDagRunName: "lease-dag",
+						DAGRunID:       "run-lease",
+						DAGName:        "lease-dag",
+						RootDAGRunID:   "run-lease",
+						RootDAGRunName: "lease-dag",
 						AttemptKey:     attemptKey,
 					},
 				},
@@ -2476,8 +2480,8 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        "worker-1",
 			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-			Stats: &coordinatorv1.WorkerStats{
-				RunningTasks: []*coordinatorv1.RunningTask{},
+			Stats: &exec.WorkerStats{
+				RunningTasks: []*exec.RunningTask{},
 			},
 		}))
 
@@ -2571,13 +2575,13 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
 			WorkerID:        "worker-1",
 			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-			Stats: &coordinatorv1.WorkerStats{
-				RunningTasks: []*coordinatorv1.RunningTask{
+			Stats: &exec.WorkerStats{
+				RunningTasks: []*exec.RunningTask{
 					{
-						DagRunId:       "run-lease",
-						DagName:        "lease-dag",
-						RootDagRunId:   "run-lease",
-						RootDagRunName: "lease-dag",
+						DAGRunID:       "run-lease",
+						DAGName:        "lease-dag",
+						RootDAGRunID:   "run-lease",
+						RootDAGRunName: "lease-dag",
 						AttemptKey:     attemptKey,
 					},
 				},
@@ -3515,14 +3519,14 @@ func TestHandler_ReportStatus(t *testing.T) {
 		})
 		ctx := context.Background()
 
-		task := &coordinatorv1.Task{
-			DagRunId:       "run-123",
+		task := &exec.DispatchTask{
+			DAGRunID:       "run-123",
 			Target:         "test-dag",
-			AttemptId:      "attempt-1",
+			AttemptID:      "attempt-1",
 			AttemptKey:     "attempt-key-1",
 			QueueName:      "queue-a",
-			RootDagRunName: "test-dag",
-			RootDagRunId:   "run-123",
+			RootDAGRunName: "test-dag",
+			RootDAGRunID:   "run-123",
 		}
 		require.NoError(t, dispatchStore.Enqueue(ctx, task))
 
@@ -3574,10 +3578,10 @@ func TestHandler_ReportStatus(t *testing.T) {
 		})
 		ctx := context.Background()
 
-		task := &coordinatorv1.Task{
-			DagRunId:   "run-123",
+		task := &exec.DispatchTask{
+			DAGRunID:   "run-123",
 			Target:     "test-dag",
-			AttemptId:  "attempt-1",
+			AttemptID:  "attempt-1",
 			AttemptKey: "attempt-key-1",
 			QueueName:  "queue-a",
 		}

--- a/internal/service/coordinator/runtime_dispatcher.go
+++ b/internal/service/coordinator/runtime_dispatcher.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator
+
+import (
+	"fmt"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+// NewRuntimeDispatcher creates a coordinator-backed dispatcher for runtime DAG execution.
+func NewRuntimeDispatcher(registry exec.ServiceRegistry, peerConfig config.Peer) (exec.Dispatcher, error) {
+	if registry == nil {
+		return nil, nil
+	}
+
+	cfg := DefaultConfig()
+	cfg.MaxRetries = 50
+	cfg.CAFile = peerConfig.ClientCaFile
+	cfg.CertFile = peerConfig.CertFile
+	cfg.KeyFile = peerConfig.KeyFile
+	cfg.SkipTLSVerify = peerConfig.SkipTLSVerify
+	cfg.Insecure = peerConfig.Insecure
+	if peerConfig.MaxRetries > 0 {
+		cfg.MaxRetries = peerConfig.MaxRetries
+	}
+	if peerConfig.RetryInterval > 0 {
+		cfg.RetryInterval = peerConfig.RetryInterval
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validate runtime dispatcher config: %w", err)
+	}
+	return New(registry, cfg), nil
+}

--- a/internal/service/coordinator/runtime_dispatcher_test.go
+++ b/internal/service/coordinator/runtime_dispatcher_test.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	coord "github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRuntimeDispatcherValidatesPeerConfig(t *testing.T) {
+	t.Parallel()
+
+	registry, err := coord.NewStaticRegistry([]string{"127.0.0.1:50055"})
+	require.NoError(t, err)
+
+	dispatcher, err := coord.NewRuntimeDispatcher(registry, config.Peer{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coord.ErrMissingTLSConfig))
+	assert.Nil(t, dispatcher)
+}
+
+func TestNewRuntimeDispatcherAllowsMissingRegistry(t *testing.T) {
+	t.Parallel()
+
+	dispatcher, err := coord.NewRuntimeDispatcher(nil, config.Peer{})
+	require.NoError(t, err)
+	assert.Nil(t, dispatcher)
+}
+
+func TestNewRuntimeDispatcherForwardsPeerRetryConfig(t *testing.T) {
+	t.Parallel()
+
+	registry, err := coord.NewStaticRegistry([]string{"127.0.0.1:50055"})
+	require.NoError(t, err)
+
+	dispatcher, err := coord.NewRuntimeDispatcher(registry, config.Peer{
+		Insecure:      true,
+		MaxRetries:    7,
+		RetryInterval: 3 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dispatcher)
+
+	cfg, ok := coord.RuntimeDispatcherConfigForTest(dispatcher)
+	require.True(t, ok)
+	assert.Equal(t, 7, cfg.MaxRetries)
+	assert.Equal(t, 3*time.Second, cfg.RetryInterval)
+}

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -45,7 +45,6 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	"github.com/dagucloud/dagu/internal/workspace"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/parser"
 )
@@ -2627,7 +2626,7 @@ func (a *API) retryDAGRun(ctx context.Context, dagName, dagRunID, retryDagRunID,
 		task := executor.CreateTask(
 			dag.Name,
 			string(dag.YamlData),
-			coordinatorv1.Operation_OPERATION_RETRY,
+			exec.DispatchOperationRetry,
 			retryDagRunID,
 			opts...,
 		)

--- a/internal/service/frontend/api/v1/dagruns_edit_retry.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/service/audit"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 type editRetryOptions struct {
@@ -802,7 +801,7 @@ func (a *API) dispatchEditRetry(ctx context.Context, dag *core.DAG, status *exec
 	task := executor.CreateTask(
 		dag.Name,
 		string(dag.YamlData),
-		coordinatorv1.Operation_OPERATION_RETRY,
+		exec.DispatchOperationRetry,
 		status.DAGRunID,
 		opts...,
 	)

--- a/internal/service/frontend/api/v1/dagruns_edit_retry_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry_internal_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
-	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -172,11 +170,10 @@ func TestEditRetryDAGRun_DispatchesSeededRetryWithSkippedOutputs(t *testing.T) {
 
 	require.Len(t, recorder.dispatched, 1)
 	task := recorder.dispatched[0]
-	require.Equal(t, coordinatorv1.Operation_OPERATION_RETRY, task.Operation)
-	require.Equal(t, "edit-run", task.DagRunId)
+	require.Equal(t, exec.DispatchOperationRetry, task.Operation)
+	require.Equal(t, "edit-run", task.DAGRunID)
 	require.NotNil(t, task.PreviousStatus)
-	previousStatus, err := convert.ProtoToDAGRunStatus(task.PreviousStatus)
-	require.NoError(t, err)
+	previousStatus := task.PreviousStatus
 	require.Equal(t, core.Queued, previousStatus.Status)
 	require.True(t, previousStatus.Nodes[0].SkippedByRetry)
 }
@@ -272,8 +269,8 @@ func TestEditRetryDAGRun_ExplicitEmptySkipStepsRunsAllSteps(t *testing.T) {
 	require.Contains(t, string(raw), `"skippedSteps":[]`)
 
 	require.Len(t, recorder.dispatched, 1)
-	previousStatus, err := convert.ProtoToDAGRunStatus(recorder.dispatched[0].PreviousStatus)
-	require.NoError(t, err)
+	previousStatus := recorder.dispatched[0].PreviousStatus
+	require.NotNil(t, previousStatus)
 	require.Len(t, previousStatus.Nodes, 3)
 	require.Equal(t, core.NodeNotStarted, previousStatus.Nodes[0].Status)
 	require.False(t, previousStatus.Nodes[0].SkippedByRetry)

--- a/internal/service/frontend/api/v1/dagruns_retry_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_retry_internal_test.go
@@ -19,19 +19,18 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/require"
 )
 
 type retryCoordinatorRecorder struct {
 	stubCoordinatorClient
-	dispatched  []*coordinatorv1.Task
+	dispatched  []*exec.DispatchTask
 	dispatchErr error
 }
 
 var _ coordinator.Client = (*retryCoordinatorRecorder)(nil)
 
-func (c *retryCoordinatorRecorder) Dispatch(_ context.Context, task *coordinatorv1.Task) error {
+func (c *retryCoordinatorRecorder) Dispatch(_ context.Context, task *exec.DispatchTask) error {
 	c.dispatched = append(c.dispatched, task)
 	return c.dispatchErr
 }
@@ -108,9 +107,9 @@ steps:
 
 	require.Len(t, coordinatorCli.dispatched, 1)
 	task := coordinatorCli.dispatched[0]
-	require.Equal(t, coordinatorv1.Operation_OPERATION_RETRY, task.Operation)
+	require.Equal(t, exec.DispatchOperationRetry, task.Operation)
 	require.Equal(t, dag.Name, task.Target)
-	require.Equal(t, "distributed-run", task.DagRunId)
+	require.Equal(t, "distributed-run", task.DAGRunID)
 	require.Equal(t, dag.WorkerSelector, task.WorkerSelector)
 	require.NotNil(t, task.PreviousStatus)
 }
@@ -207,5 +206,5 @@ steps:
 	require.True(t, ok)
 
 	require.Len(t, coordinatorCli.dispatched, 1)
-	require.Equal(t, "latest-run", coordinatorCli.dispatched[0].DagRunId)
+	require.Equal(t, "latest-run", coordinatorCli.dispatched[0].DAGRunID)
 }

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 const defaultHistoryLimit = 30
@@ -1428,7 +1427,7 @@ func (a *API) dispatchStartToCoordinator(ctx context.Context, dag *core.DAG, dag
 	task := executor.CreateTask(
 		dag.Name,
 		string(dag.YamlData),
-		coordinatorv1.Operation_OPERATION_START,
+		exec.DispatchOperationStart,
 		dagRunID,
 		taskOpts...,
 	)

--- a/internal/service/frontend/api/v1/metrics_test.go
+++ b/internal/service/frontend/api/v1/metrics_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/test"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,11 +70,11 @@ func TestMetrics_ExportsWorkerMetrics(t *testing.T) {
 			"pool":   "gpu",
 			"region": "ap-northeast-1",
 		},
-		Stats: &coordinatorv1.WorkerStats{
+		Stats: &exec.WorkerStats{
 			TotalPollers: 4,
 			BusyPollers:  2,
-			RunningTasks: []*coordinatorv1.RunningTask{
-				{DagRunId: "run-1", DagName: "dag-1", StartedAt: time.Now().Add(-time.Minute).Unix()},
+			RunningTasks: []*exec.RunningTask{
+				{DAGRunID: "run-1", DAGName: "dag-1", StartedAt: time.Now().Add(-time.Minute).Unix()},
 			},
 		},
 		LastHeartbeatAt: time.Now().UnixMilli(),

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/test"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -256,8 +255,8 @@ steps:
 	require.NoError(t, server.WorkerHeartbeatStore.Upsert(server.Context, exec.WorkerHeartbeatRecord{
 		WorkerID:        status.WorkerID,
 		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-		Stats: &coordinatorv1.WorkerStats{
-			RunningTasks: []*coordinatorv1.RunningTask{},
+		Stats: &exec.WorkerStats{
+			RunningTasks: []*exec.RunningTask{},
 		},
 	}))
 
@@ -326,8 +325,8 @@ steps:
 	require.NoError(t, server.WorkerHeartbeatStore.Upsert(server.Context, exec.WorkerHeartbeatRecord{
 		WorkerID:        "worker-1",
 		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
-		Stats: &coordinatorv1.WorkerStats{
-			RunningTasks: []*coordinatorv1.RunningTask{},
+		Stats: &exec.WorkerStats{
+			RunningTasks: []*exec.RunningTask{},
 		},
 	}))
 

--- a/internal/service/frontend/api/v1/workers_internal_test.go
+++ b/internal/service/frontend/api/v1/workers_internal_test.go
@@ -25,7 +25,7 @@ type stubCoordinatorClient struct {
 	err     error
 }
 
-func (s *stubCoordinatorClient) Dispatch(context.Context, *coordinatorv1.Task) error {
+func (s *stubCoordinatorClient) Dispatch(context.Context, *exec.DispatchTask) error {
 	return nil
 }
 
@@ -33,7 +33,7 @@ func (s *stubCoordinatorClient) Cleanup(context.Context) error {
 	return nil
 }
 
-func (s *stubCoordinatorClient) GetDAGRunStatus(context.Context, string, string, *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+func (s *stubCoordinatorClient) GetDAGRunStatus(context.Context, string, string, *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
 	return nil, nil
 }
 

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dagucloud/dagu/internal/dispatch"
 	"github.com/dagucloud/dagu/internal/launcher"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 // DAGExecutor handles both local and distributed DAG execution.
@@ -96,13 +95,13 @@ func NewDAGExecutor(
 func (e *DAGExecutor) HandleJob(
 	ctx context.Context,
 	dag *core.DAG,
-	operation coordinatorv1.Operation,
+	operation exec.DispatchOperation,
 	runID string,
 	triggerType core.TriggerType,
 	scheduleTime time.Time,
 ) error {
 	// For distributed execution with START operation, enqueue for persistence
-	if e.shouldUseDistributedExecution(dag) && operation == coordinatorv1.Operation_OPERATION_START {
+	if e.shouldUseDistributedExecution(dag) && operation == exec.DispatchOperationStart {
 		ctx = logger.WithValues(ctx,
 			tag.DAG(dag.Name),
 			tag.RunID(runID),
@@ -143,12 +142,16 @@ func (e *DAGExecutor) HandleJob(
 func (e *DAGExecutor) ExecuteDAG(
 	ctx context.Context,
 	dag *core.DAG,
-	operation coordinatorv1.Operation,
+	operation exec.DispatchOperation,
 	runID string,
 	previousStatus *exec.DAGRunStatus,
 	triggerType core.TriggerType,
 	scheduleTime string,
 ) error {
+	if err := validateDispatchOperation(operation); err != nil {
+		return err
+	}
+
 	if e.shouldUseDistributedExecution(dag) {
 		// Distributed execution: dispatch to coordinator
 		taskOpts := []executor.TaskOption{
@@ -192,10 +195,10 @@ func (e *DAGExecutor) ExecuteDAG(
 	}
 
 	switch operation {
-	case coordinatorv1.Operation_OPERATION_UNSPECIFIED:
+	case exec.DispatchOperationUnspecified:
 		return fmt.Errorf("operation not specified")
 
-	case coordinatorv1.Operation_OPERATION_START:
+	case exec.DispatchOperationStart:
 		spec := e.subCmdBuilder.Start(dag, launcher.StartOptions{
 			DAGRunID:     runID,
 			Quiet:        true,
@@ -204,12 +207,23 @@ func (e *DAGExecutor) ExecuteDAG(
 		})
 		return launcher.Start(ctx, spec)
 
-	case coordinatorv1.Operation_OPERATION_RETRY:
+	case exec.DispatchOperationRetry:
 		spec := e.subCmdBuilder.QueueDispatchRetry(dag, runID, "")
 		return launcher.Run(ctx, spec)
 
 	default:
-		return fmt.Errorf("unsupported operation: %v", operation)
+		return fmt.Errorf("unknown operation: %s", operation)
+	}
+}
+
+func validateDispatchOperation(operation exec.DispatchOperation) error {
+	switch operation {
+	case exec.DispatchOperationStart, exec.DispatchOperationRetry:
+		return nil
+	case exec.DispatchOperationUnspecified:
+		return fmt.Errorf("operation not specified")
+	default:
+		return fmt.Errorf("unknown operation: %s", operation)
 	}
 }
 
@@ -233,10 +247,10 @@ func (e *DAGExecutor) IsDistributed(dag *core.DAG) bool {
 // 1. Select an appropriate worker based on the task's workerSelector
 // 2. Forward the task to the selected worker
 // 3. Track the execution status
-func (e *DAGExecutor) dispatchToCoordinator(ctx context.Context, task *coordinatorv1.Task) error {
+func (e *DAGExecutor) dispatchToCoordinator(ctx context.Context, task *exec.DispatchTask) error {
 	ctx = logger.WithValues(ctx,
 		tag.Target(task.Target),
-		tag.RunID(task.DagRunId),
+		tag.RunID(task.DAGRunID),
 	)
 
 	if err := e.coordinatorCli.Dispatch(ctx, task); err != nil {

--- a/internal/service/scheduler/dag_executor_test.go
+++ b/internal/service/scheduler/dag_executor_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
 	"github.com/dagucloud/dagu/internal/test"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +47,7 @@ steps:
 		err := dagExecutor.HandleJob(
 			context.Background(),
 			dag,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"handle-job-test-123",
 			core.TriggerTypeScheduler,
 			time.Time{},
@@ -62,7 +62,7 @@ steps:
 		err := dagExecutor.ExecuteDAG(
 			context.Background(),
 			dag,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"execute-dag-test-456",
 			nil,
 			core.TriggerTypeScheduler,
@@ -71,6 +71,34 @@ steps:
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to dispatch task")
+	})
+
+	t.Run("ExecuteDAG_Distributed_RejectsInvalidOperation", func(t *testing.T) {
+		dag := loadDAGWithWorkerSelector(t)
+
+		err := dagExecutor.ExecuteDAG(
+			context.Background(),
+			dag,
+			exec.DispatchOperationUnspecified,
+			"execute-dag-invalid-operation",
+			nil,
+			core.TriggerTypeScheduler,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "operation not specified")
+
+		err = dagExecutor.ExecuteDAG(
+			context.Background(),
+			dag,
+			exec.DispatchOperation(99),
+			"execute-dag-unknown-operation",
+			nil,
+			core.TriggerTypeScheduler,
+			"",
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown operation")
 	})
 
 	t.Run("HandleJob_Local_ExecutesDirectly", func(t *testing.T) {
@@ -82,7 +110,7 @@ steps:
 		err = localExecutor.HandleJob(
 			context.Background(),
 			dag,
-			coordinatorv1.Operation_OPERATION_START,
+			exec.DispatchOperationStart,
 			"handle-job-local-789",
 			core.TriggerTypeScheduler,
 			time.Time{},
@@ -96,7 +124,7 @@ steps:
 		err := dagExecutor.HandleJob(
 			context.Background(),
 			dag,
-			coordinatorv1.Operation_OPERATION_RETRY,
+			exec.DispatchOperationRetry,
 			"handle-job-retry-999",
 			core.TriggerTypeScheduler,
 			time.Time{},

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -17,7 +17,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 type queueDispatchDeps struct {
@@ -228,7 +227,7 @@ func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.Queu
 	var execDoneErr error
 	go func() {
 		defer d.wakeUp()
-		err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY, runID, status, status.TriggerType, status.ScheduleTime)
+		err := d.dagExecutor.ExecuteDAG(ctx, dag, exec.DispatchOperationRetry, runID, status, status.TriggerType, status.ScheduleTime)
 		execDoneErr = err
 		close(execDoneCh)
 		if err != nil {
@@ -326,7 +325,7 @@ func (d *queueDispatcher) dispatchAndWaitForStartup(
 		}
 
 		if !dispatched {
-			err := d.dagExecutor.ExecuteDAG(ctx, dag, coordinatorv1.Operation_OPERATION_RETRY,
+			err := d.dagExecutor.ExecuteDAG(ctx, dag, exec.DispatchOperationRetry,
 				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime)
 			if err != nil {
 				var staleErr *exec.StaleQueueDispatchError

--- a/internal/service/scheduler/queue_dispatcher_test.go
+++ b/internal/service/scheduler/queue_dispatcher_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,11 +43,11 @@ func TestQueueDispatcher_SelectRunnableQueueItemsSkipsOutstandingReservations(t 
 	reservedStatus, err := reservedAttempt.ReadStatus(f.ctx)
 	require.NoError(t, err)
 
-	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &coordinatorv1.Task{
-		DagRunId:   reservedRef.ID,
+	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &exec.DispatchTask{
+		DAGRunID:   reservedRef.ID,
 		Target:     f.dag.Name,
 		QueueName:  f.dag.Name,
-		AttemptId:  reservedAttempt.ID(),
+		AttemptID:  reservedAttempt.ID(),
 		AttemptKey: queueAttemptKey(reservedRef, reservedAttempt, reservedStatus),
 	}))
 

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -296,7 +295,7 @@ type mockDispatcher struct {
 	errFunc   func(callNum int32) error
 }
 
-func (m *mockDispatcher) Dispatch(_ context.Context, _ *coordinatorv1.Task) error {
+func (m *mockDispatcher) Dispatch(_ context.Context, _ *exec.DispatchTask) error {
 	n := m.callCount.Add(1)
 	if m.errFunc != nil {
 		return m.errFunc(n)
@@ -306,7 +305,7 @@ func (m *mockDispatcher) Dispatch(_ context.Context, _ *coordinatorv1.Task) erro
 
 func (m *mockDispatcher) Cleanup(_ context.Context) error { return nil }
 
-func (m *mockDispatcher) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+func (m *mockDispatcher) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
 	return nil, nil
 }
 

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
 	"github.com/dagucloud/dagu/internal/persis/file/proc"
 	"github.com/dagucloud/dagu/internal/persis/store"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -339,11 +338,11 @@ func TestQueueProcessor_CountsOutstandingDispatchReservationsAgainstQueueConcurr
 	status, err := attempt.ReadStatus(f.ctx)
 	require.NoError(t, err)
 
-	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &coordinatorv1.Task{
-		DagRunId:   runRef.ID,
+	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &exec.DispatchTask{
+		DAGRunID:   runRef.ID,
 		Target:     f.dag.Name,
 		QueueName:  f.dag.Name,
-		AttemptId:  attempt.ID(),
+		AttemptID:  attempt.ID(),
 		AttemptKey: queueAttemptKey(runRef, attempt, status),
 	}))
 
@@ -368,11 +367,11 @@ func TestQueueProcessor_SelectRunnableQueueItemsSkipsOutstandingReservations(t *
 	reservedStatus, err := reservedAttempt.ReadStatus(f.ctx)
 	require.NoError(t, err)
 
-	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &coordinatorv1.Task{
-		DagRunId:   reservedRef.ID,
+	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &exec.DispatchTask{
+		DAGRunID:   reservedRef.ID,
 		Target:     f.dag.Name,
 		QueueName:  f.dag.Name,
-		AttemptId:  reservedAttempt.ID(),
+		AttemptID:  reservedAttempt.ID(),
 		AttemptKey: queueAttemptKey(reservedRef, reservedAttempt, reservedStatus),
 	}))
 
@@ -401,11 +400,11 @@ func TestQueueProcessor_StaleOutstandingDispatchReservationsExpire(t *testing.T)
 	status, err := attempt.ReadStatus(f.ctx)
 	require.NoError(t, err)
 
-	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &coordinatorv1.Task{
-		DagRunId:   runRef.ID,
+	require.NoError(t, f.dispatchStore.Enqueue(f.ctx, &exec.DispatchTask{
+		DAGRunID:   runRef.ID,
 		Target:     f.dag.Name,
 		QueueName:  f.dag.Name,
-		AttemptId:  attempt.ID(),
+		AttemptID:  attempt.ID(),
 		AttemptKey: queueAttemptKey(runRef, attempt, status),
 	}))
 	agePendingDispatchReservationFiles(t, f.distributedDir, 2*time.Second)
@@ -516,7 +515,7 @@ type mockDispatchTaskStore struct {
 	hasOutstandingAttemptFunc   func(context.Context, string, time.Duration) (bool, error)
 }
 
-func (m *mockDispatchTaskStore) Enqueue(context.Context, *coordinatorv1.Task) error {
+func (m *mockDispatchTaskStore) Enqueue(context.Context, *exec.DispatchTask) error {
 	return nil
 }
 
@@ -526,6 +525,10 @@ func (m *mockDispatchTaskStore) ClaimNext(context.Context, exec.DispatchTaskClai
 
 func (m *mockDispatchTaskStore) GetClaim(context.Context, string) (*exec.ClaimedDispatchTask, error) {
 	return nil, exec.ErrDispatchTaskNotFound
+}
+
+func (m *mockDispatchTaskStore) ReleaseClaim(context.Context, string) error {
+	return nil
 }
 
 func (m *mockDispatchTaskStore) DeleteClaim(context.Context, string) error {

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/launcher"
 	"github.com/dagucloud/dagu/internal/runtime"
-	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
 
 // Clock is a function that returns the current time.
@@ -206,7 +205,7 @@ func newScheduler(
 		Dispatch: func(ctx context.Context, dag *core.DAG, runID string, triggerType core.TriggerType, scheduleTime time.Time) error {
 			return dagExecutor.HandleJob(
 				ctx, dag,
-				coordinatorv1.Operation_OPERATION_START,
+				exec.DispatchOperationStart,
 				runID, triggerType, scheduleTime,
 			)
 		},

--- a/internal/service/worker/coordreport/artifact_uploader.go
+++ b/internal/service/worker/coordreport/artifact_uploader.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport
 
 import (
 	"context"
@@ -13,9 +13,12 @@ import (
 	"sync"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
+
+var _ runtime.ArtifactFinalizer = (*ArtifactUploader)(nil)
 
 // ArtifactUploader uploads DAG run artifacts to the coordinator in shared-nothing mode.
 type ArtifactUploader struct {

--- a/internal/service/worker/coordreport/artifact_uploader_test.go
+++ b/internal/service/worker/coordreport/artifact_uploader_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,7 +117,7 @@ func TestArtifactUploaderUploadDirIncludesEmptyFiles(t *testing.T) {
 		},
 	}
 
-	uploader := NewArtifactUploader(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
+	uploader := coordreport.NewArtifactUploader(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
 	err := uploader.UploadDir(context.Background(), dir)
 	require.NoError(t, err)
 
@@ -137,7 +138,7 @@ func TestArtifactUploaderUploadDirUsesSingleAttemptIDSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "artifact.txt"), []byte("hello"), 0o600))
 
-	var uploader *ArtifactUploader
+	var uploader *coordreport.ArtifactUploader
 	var once sync.Once
 
 	stream := &mockStreamArtifactsClient{
@@ -156,7 +157,7 @@ func TestArtifactUploaderUploadDirUsesSingleAttemptIDSnapshot(t *testing.T) {
 		},
 	}
 
-	uploader = NewArtifactUploader(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
+	uploader = coordreport.NewArtifactUploader(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
 	err := uploader.UploadDir(context.Background(), dir)
 	require.NoError(t, err)
 

--- a/internal/service/worker/coordreport/export_test.go
+++ b/internal/service/worker/coordreport/export_test.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordreport
+
+import (
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+)
+
+// LogBufferSize exposes the step log buffer threshold to black-box tests.
+const LogBufferSize = logBufferSize
+
+// MaxChunkSize exposes the stream chunk limit to black-box tests.
+const MaxChunkSize = maxChunkSize
+
+// StepLogWriter exposes the concrete step writer type to black-box tests.
+type StepLogWriter = stepLogWriter
+
+// StatusPusherSnapshot captures status pusher construction state for tests.
+type StatusPusherSnapshot struct {
+	WorkerID string
+	Client   coordinator.Client
+}
+
+// SnapshotStatusPusher captures status pusher construction state.
+func SnapshotStatusPusher(p *StatusPusher) StatusPusherSnapshot {
+	return StatusPusherSnapshot{
+		WorkerID: p.workerID,
+		Client:   p.client,
+	}
+}
+
+// LogStreamerSnapshot captures log streamer construction state for tests.
+type LogStreamerSnapshot struct {
+	WorkerID  string
+	DAGRunID  string
+	DAGName   string
+	AttemptID string
+	RootRef   exec.DAGRunRef
+}
+
+// SnapshotLogStreamer captures log streamer construction state.
+func SnapshotLogStreamer(s *LogStreamer) LogStreamerSnapshot {
+	return LogStreamerSnapshot{
+		WorkerID:  s.workerID,
+		DAGRunID:  s.dagRunID,
+		DAGName:   s.dagName,
+		AttemptID: s.getAttemptID(),
+		RootRef:   s.rootRef,
+	}
+}
+
+// LogStreamerAttemptID returns the current attempt ID.
+func LogStreamerAttemptID(s *LogStreamer) string {
+	return s.getAttemptID()
+}
+
+// StepLogWriterSnapshot captures mutable step writer state for tests.
+type StepLogWriterSnapshot struct {
+	StepName         string
+	StreamType       int
+	Streamer         *LogStreamer
+	Closed           bool
+	StreamInitFailed bool
+	BufferLen        int
+	Sequence         uint64
+	HasStream        bool
+}
+
+// SnapshotStepLogWriter captures step writer state under its lock.
+func SnapshotStepLogWriter(w *StepLogWriter) StepLogWriterSnapshot {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return snapshotStepLogWriterLocked(w)
+}
+
+func snapshotStepLogWriterLocked(w *StepLogWriter) StepLogWriterSnapshot {
+	return StepLogWriterSnapshot{
+		StepName:         w.stepName,
+		StreamType:       w.streamType,
+		Streamer:         w.streamer,
+		Closed:           w.closed,
+		StreamInitFailed: w.streamInitFailed,
+		BufferLen:        len(w.buffer),
+		Sequence:         w.sequence,
+		HasStream:        w.stream != nil,
+	}
+}
+
+// StepLogWriterFlushResult captures a flush and the resulting writer state.
+type StepLogWriterFlushResult struct {
+	Err             error
+	InitialSequence uint64
+	FinalSequence   uint64
+	BufferLen       int
+	HasStream       bool
+	StreamFailed    bool
+}
+
+// FlushStepLogWriterWithBuffer sets the writer buffer and flushes it under the writer lock.
+func FlushStepLogWriterWithBuffer(w *StepLogWriter, data []byte) StepLogWriterFlushResult {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	initialSequence := w.sequence
+	w.buffer = data
+	err := w.flush()
+
+	return StepLogWriterFlushResult{
+		Err:             err,
+		InitialSequence: initialSequence,
+		FinalSequence:   w.sequence,
+		BufferLen:       len(w.buffer),
+		HasStream:       w.stream != nil,
+		StreamFailed:    w.streamInitFailed,
+	}
+}
+
+// ToProtoStreamType exposes stream type conversion to black-box tests.
+func ToProtoStreamType(streamType int) coordinatorv1.LogStreamType {
+	return toProtoStreamType(streamType)
+}

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
@@ -28,6 +29,7 @@ const (
 )
 
 var _ exec.LogWriterFactory = (*LogStreamer)(nil)
+var _ runtime.SchedulerLogStreamer = (*LogStreamer)(nil)
 
 // LogStreamer streams logs to coordinator via gRPC
 type LogStreamer struct {
@@ -112,7 +114,6 @@ func (s *LogStreamer) NewSchedulerLogWriter(ctx context.Context, localFile *os.F
 }
 
 // StreamSchedulerLog reads the local scheduler.log file and streams it to the coordinator.
-// This should be called after DAG execution completes.
 func (s *LogStreamer) StreamSchedulerLog(ctx context.Context, logFilePath string) error {
 	// Read the scheduler.log file
 	// #nosec G304 - logFilePath is a controlled internal path from createAgentEnv
@@ -500,6 +501,6 @@ func (w *schedulerLogWriter) Close() error {
 		_, _ = w.stream.CloseAndRecv() // Ignore error - best effort
 	}
 
-	// Note: localFile is NOT closed here - caller owns it
+	// The caller owns localFile.
 	return nil
 }

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,7 +124,7 @@ func TestToProtoStreamType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, toProtoStreamType(tt.input))
+			assert.Equal(t, tt.expected, coordreport.ToProtoStreamType(tt.input))
 		})
 	}
 }
@@ -133,14 +134,15 @@ func TestNewLogStreamer(t *testing.T) {
 	client := &logStreamerMockClient{}
 	rootRef := exec.DAGRunRef{Name: "root-dag", ID: "root-id"}
 
-	streamer := NewLogStreamer(client, "worker-1", "run-123", "test-dag", "attempt-1", rootRef)
+	streamer := coordreport.NewLogStreamer(client, "worker-1", "run-123", "test-dag", "attempt-1", rootRef)
 
 	require.NotNil(t, streamer)
-	assert.Equal(t, "worker-1", streamer.workerID)
-	assert.Equal(t, "run-123", streamer.dagRunID)
-	assert.Equal(t, "test-dag", streamer.dagName)
-	assert.Equal(t, "attempt-1", streamer.attemptID)
-	assert.Equal(t, rootRef, streamer.rootRef)
+	snapshot := coordreport.SnapshotLogStreamer(streamer)
+	assert.Equal(t, "worker-1", snapshot.WorkerID)
+	assert.Equal(t, "run-123", snapshot.DAGRunID)
+	assert.Equal(t, "test-dag", snapshot.DAGName)
+	assert.Equal(t, "attempt-1", snapshot.AttemptID)
+	assert.Equal(t, rootRef, snapshot.RootRef)
 }
 
 func TestLogStreamer_FinalChunksIncludeOwnerCoordinatorID(t *testing.T) {
@@ -153,7 +155,7 @@ func TestLogStreamer_FinalChunksIncludeOwnerCoordinatorID(t *testing.T) {
 		},
 	}
 	owner := exec.HostInfo{ID: "coord-1", Host: "127.0.0.1", Port: 4321}
-	streamer := NewLogStreamer(stepClient, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{}, owner)
+	streamer := coordreport.NewLogStreamer(stepClient, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{}, owner)
 
 	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 	_, err := stepWriter.Write([]byte("hello"))
@@ -170,7 +172,7 @@ func TestLogStreamer_FinalChunksIncludeOwnerCoordinatorID(t *testing.T) {
 			return schedulerStream, nil
 		},
 	}
-	schedulerStreamer := NewLogStreamer(schedulerClient, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{}, owner)
+	schedulerStreamer := coordreport.NewLogStreamer(schedulerClient, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{}, owner)
 	localFile, err := os.CreateTemp(t.TempDir(), "scheduler-*.log")
 	require.NoError(t, err)
 	defer func() { _ = localFile.Close() }()
@@ -187,23 +189,23 @@ func TestLogStreamer_FinalChunksIncludeOwnerCoordinatorID(t *testing.T) {
 
 func TestSetAttemptID(t *testing.T) {
 	t.Parallel()
-	streamer := NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "initial", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "initial", exec.DAGRunRef{})
 
-	assert.Equal(t, "initial", streamer.getAttemptID())
+	assert.Equal(t, "initial", coordreport.LogStreamerAttemptID(streamer))
 
 	streamer.SetAttemptID("updated")
-	assert.Equal(t, "updated", streamer.getAttemptID())
+	assert.Equal(t, "updated", coordreport.LogStreamerAttemptID(streamer))
 }
 
 func TestGetAttemptID(t *testing.T) {
 	t.Parallel()
-	streamer := NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "test-attempt", exec.DAGRunRef{})
-	assert.Equal(t, "test-attempt", streamer.getAttemptID())
+	streamer := coordreport.NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "test-attempt", exec.DAGRunRef{})
+	assert.Equal(t, "test-attempt", coordreport.LogStreamerAttemptID(streamer))
 }
 
 func TestSetAttemptID_Concurrent(t *testing.T) {
 	t.Parallel()
-	streamer := NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "initial", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(&logStreamerMockClient{}, "w", "r", "d", "initial", exec.DAGRunRef{})
 
 	var wg sync.WaitGroup
 	const goroutines = 100
@@ -220,13 +222,13 @@ func TestSetAttemptID_Concurrent(t *testing.T) {
 	// Concurrent readers
 	for range goroutines {
 		wg.Go(func() {
-			_ = streamer.getAttemptID() // Should not panic
+			_ = coordreport.LogStreamerAttemptID(streamer) // Should not panic
 		})
 	}
 
 	wg.Wait()
 	// Final value should be one of the written values
-	final := streamer.getAttemptID()
+	final := coordreport.LogStreamerAttemptID(streamer)
 	assert.NotEmpty(t, final)
 }
 
@@ -238,18 +240,19 @@ func TestNewStepWriter(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "worker-1", "run-123", "test-dag", "attempt-1", exec.DAGRunRef{})
 
 	writer := streamer.NewStepWriter(context.Background(), "step1", exec.StreamTypeStdout)
 
 	require.NotNil(t, writer)
-	stepWriter, ok := writer.(*stepLogWriter)
+	stepWriter, ok := writer.(*coordreport.StepLogWriter)
 	require.True(t, ok)
-	assert.Equal(t, "step1", stepWriter.stepName)
-	assert.Equal(t, exec.StreamTypeStdout, stepWriter.streamType)
-	assert.Equal(t, streamer, stepWriter.streamer)
-	assert.False(t, stepWriter.closed)
-	assert.False(t, stepWriter.streamInitFailed)
+	snapshot := coordreport.SnapshotStepLogWriter(stepWriter)
+	assert.Equal(t, "step1", snapshot.StepName)
+	assert.Equal(t, exec.StreamTypeStdout, snapshot.StreamType)
+	assert.Equal(t, streamer, snapshot.Streamer)
+	assert.False(t, snapshot.Closed)
+	assert.False(t, snapshot.StreamInitFailed)
 }
 
 func TestWrite_SmallData(t *testing.T) {
@@ -260,7 +263,7 @@ func TestWrite_SmallData(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write small data (< 32KB)
@@ -281,11 +284,11 @@ func TestWrite_ExactThreshold(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
-	// Write exactly logBufferSize (32KB) - should trigger flush
-	data := make([]byte, logBufferSize)
+	// Write exactly the buffer threshold to trigger flush.
+	data := make([]byte, coordreport.LogBufferSize)
 	for i := range data {
 		data[i] = byte('A' + i%26)
 	}
@@ -309,7 +312,7 @@ func TestWrite_LargeData(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write data larger than buffer (64KB)
@@ -335,7 +338,7 @@ func TestWrite_MultipleSmallWrites(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Multiple small writes that accumulate to >= threshold
@@ -364,7 +367,7 @@ func TestWrite_AfterClose(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Close the writer
@@ -387,11 +390,11 @@ func TestWrite_FlushError_Continues(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write enough to trigger flush (which will fail)
-	data := make([]byte, logBufferSize)
+	data := make([]byte, coordreport.LogBufferSize)
 	n, err := writer.Write(data)
 
 	// Write should succeed even though flush failed (best-effort)
@@ -409,19 +412,17 @@ func TestWrite_FlushError_ClearsBuffer(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
-	stepWriter := writer.(*stepLogWriter)
+	stepWriter := writer.(*coordreport.StepLogWriter)
 
 	// Write enough to trigger flush
-	data := make([]byte, logBufferSize)
+	data := make([]byte, coordreport.LogBufferSize)
 	_, _ = writer.Write(data)
 
 	// Buffer should be cleared to prevent memory growth
-	stepWriter.mu.Lock()
-	bufLen := len(stepWriter.buffer)
-	stepWriter.mu.Unlock()
-	assert.Equal(t, 0, bufLen)
+	snapshot := coordreport.SnapshotStepLogWriter(stepWriter)
+	assert.Equal(t, 0, snapshot.BufferLen)
 }
 
 func TestFlush_EmptyBuffer(t *testing.T) {
@@ -432,15 +433,12 @@ func TestFlush_EmptyBuffer(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	// Flush with empty buffer
-	stepWriter.mu.Lock()
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, nil)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	assert.Empty(t, mockStream.getSentChunks())
 }
 
@@ -454,17 +452,14 @@ func TestFlush_StreamInitSuccess(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("test data")
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("test data"))
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	assert.True(t, streamInitCalled)
-	assert.NotNil(t, stepWriter.stream)
+	assert.True(t, result.HasStream)
 }
 
 func TestFlush_StreamInitFailure(t *testing.T) {
@@ -475,19 +470,14 @@ func TestFlush_StreamInitFailure(t *testing.T) {
 			return nil, initErr
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("test data")
-	err := stepWriter.flush()
-	streamInitFailed := stepWriter.streamInitFailed
-	bufLen := len(stepWriter.buffer)
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("test data"))
 
-	assert.Equal(t, initErr, err)
-	assert.True(t, streamInitFailed, "streamInitFailed should be set")
-	assert.Equal(t, 0, bufLen, "buffer should be cleared")
+	assert.Equal(t, initErr, result.Err)
+	assert.True(t, result.StreamFailed, "streamInitFailed should be set")
+	assert.Equal(t, 0, result.BufferLen, "buffer should be cleared")
 }
 
 func TestFlush_AfterInitFailure(t *testing.T) {
@@ -499,24 +489,17 @@ func TestFlush_AfterInitFailure(t *testing.T) {
 			return nil, errors.New("init failed")
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	// First flush - triggers init failure
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("data1")
-	_ = stepWriter.flush()
-	stepWriter.mu.Unlock()
+	// First flush triggers init failure.
+	_ = coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("data1"))
 
-	// Second flush - should silently return (no retry)
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("data2")
-	err := stepWriter.flush()
-	bufLen := len(stepWriter.buffer)
-	stepWriter.mu.Unlock()
+	// Second flush silently returns without retrying.
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("data2"))
 
-	require.NoError(t, err, "should silently succeed after init failure")
-	assert.Equal(t, 0, bufLen, "buffer should be cleared")
+	require.NoError(t, result.Err, "should silently succeed after init failure")
+	assert.Equal(t, 0, result.BufferLen, "buffer should be cleared")
 	assert.Equal(t, 1, callCount, "should not retry stream init")
 }
 
@@ -528,18 +511,13 @@ func TestFlush_SendSuccess(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("test data")
-	initialSeq := stepWriter.sequence
-	err := stepWriter.flush()
-	finalSeq := stepWriter.sequence
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("test data"))
 
-	require.NoError(t, err)
-	assert.Equal(t, initialSeq+1, finalSeq, "sequence should increment after success")
+	require.NoError(t, result.Err)
+	assert.Equal(t, result.InitialSequence+1, result.FinalSequence, "sequence should increment after success")
 }
 
 func TestFlush_SendFailure(t *testing.T) {
@@ -552,18 +530,13 @@ func TestFlush_SendFailure(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = []byte("test data")
-	initialSeq := stepWriter.sequence
-	err := stepWriter.flush()
-	finalSeq := stepWriter.sequence
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, []byte("test data"))
 
-	assert.Error(t, err)
-	assert.Equal(t, initialSeq, finalSeq, "sequence should NOT increment on failure")
+	assert.Error(t, result.Err)
+	assert.Equal(t, result.InitialSequence, result.FinalSequence, "sequence should NOT increment on failure")
 }
 
 func TestFlush_SingleChunk(t *testing.T) {
@@ -574,8 +547,8 @@ func TestFlush_SingleChunk(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	// Buffer < 3MB - single chunk
 	data := make([]byte, 1*1024*1024) // 1MB
@@ -583,12 +556,9 @@ func TestFlush_SingleChunk(t *testing.T) {
 		data[i] = byte('A')
 	}
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 1)
 	assert.Len(t, chunks[0].Data, 1*1024*1024)
@@ -602,24 +572,21 @@ func TestFlush_ExactMaxChunkSize(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
-	// Buffer == maxChunkSize (3MB) - single chunk
-	data := make([]byte, maxChunkSize)
+	// A max-size buffer stays in a single chunk.
+	data := make([]byte, coordreport.MaxChunkSize)
 	for i := range data {
 		data[i] = byte('B')
 	}
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 1)
-	assert.Len(t, chunks[0].Data, maxChunkSize)
+	assert.Len(t, chunks[0].Data, coordreport.MaxChunkSize)
 }
 
 func TestFlush_TwoChunks(t *testing.T) {
@@ -630,8 +597,8 @@ func TestFlush_TwoChunks(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	// 4MB buffer - should split into 3MB + 1MB
 	data := make([]byte, 4*1024*1024)
@@ -639,16 +606,13 @@ func TestFlush_TwoChunks(t *testing.T) {
 		data[i] = byte('C')
 	}
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 2)
-	assert.Len(t, chunks[0].Data, maxChunkSize) // 3MB
-	assert.Len(t, chunks[1].Data, 1*1024*1024)  // 1MB
+	assert.Len(t, chunks[0].Data, coordreport.MaxChunkSize) // 3MB
+	assert.Len(t, chunks[1].Data, 1*1024*1024)              // 1MB
 }
 
 func TestFlush_MultipleChunks(t *testing.T) {
@@ -659,8 +623,8 @@ func TestFlush_MultipleChunks(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	// 10MB buffer - should split into 3MB + 3MB + 3MB + 1MB = 4 chunks
 	data := make([]byte, 10*1024*1024)
@@ -668,17 +632,14 @@ func TestFlush_MultipleChunks(t *testing.T) {
 		data[i] = byte('D')
 	}
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 4)
-	assert.Len(t, chunks[0].Data, maxChunkSize)
-	assert.Len(t, chunks[1].Data, maxChunkSize)
-	assert.Len(t, chunks[2].Data, maxChunkSize)
+	assert.Len(t, chunks[0].Data, coordreport.MaxChunkSize)
+	assert.Len(t, chunks[1].Data, coordreport.MaxChunkSize)
+	assert.Len(t, chunks[2].Data, coordreport.MaxChunkSize)
 	assert.Len(t, chunks[3].Data, 1*1024*1024)
 }
 
@@ -690,18 +651,15 @@ func TestFlush_ChunkSequences(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	// 6MB buffer - 2 chunks
 	data := make([]byte, 6*1024*1024)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 2)
 	assert.Equal(t, uint64(1), chunks[0].Sequence)
@@ -724,24 +682,19 @@ func TestFlush_PartialFailure(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	// 6MB buffer - would be 2 chunks, but second fails
 	data := make([]byte, 6*1024*1024)
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	initialSeq := stepWriter.sequence
-	err := stepWriter.flush()
-	finalSeq := stepWriter.sequence
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	assert.Error(t, err)
+	assert.Error(t, result.Err)
 	// Only first chunk sent and sequence incremented
 	chunks := mockStream.getSentChunks()
 	require.Len(t, chunks, 1)
-	assert.Equal(t, initialSeq+1, finalSeq, "only first chunk's sequence incremented")
+	assert.Equal(t, result.InitialSequence+1, result.FinalSequence, "only first chunk's sequence incremented")
 }
 
 func TestFlush_DataCopied(t *testing.T) {
@@ -752,17 +705,14 @@ func TestFlush_DataCopied(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	data := []byte("original data")
 
-	stepWriter.mu.Lock()
-	stepWriter.buffer = data
-	err := stepWriter.flush()
-	stepWriter.mu.Unlock()
+	result := coordreport.FlushStepLogWriterWithBuffer(stepWriter, data)
 
-	require.NoError(t, err)
+	require.NoError(t, result.Err)
 
 	// Modify original data after send
 	data[0] = 'X'
@@ -781,7 +731,7 @@ func TestClose_NoData(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	err := writer.Close()
@@ -799,7 +749,7 @@ func TestClose_WithUnflushedData(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write small data (not flushed)
@@ -823,7 +773,7 @@ func TestClose_Idempotent(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write and close
@@ -849,11 +799,11 @@ func TestClose_FinalChunkSequence(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write enough to flush, then close
-	data := make([]byte, logBufferSize)
+	data := make([]byte, coordreport.LogBufferSize)
 	_, _ = writer.Write(data)
 	_, _ = writer.Write([]byte("more data"))
 	err := writer.Close()
@@ -878,8 +828,8 @@ func TestClose_FinalSendSuccess(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
-	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*stepLogWriter)
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	stepWriter := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
 
 	_, _ = stepWriter.Write([]byte("data"))
 	err := stepWriter.Close()
@@ -887,10 +837,8 @@ func TestClose_FinalSendSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Final sequence should be 2 (data=1, final=2)
-	stepWriter.mu.Lock()
-	finalSeq := stepWriter.sequence
-	stepWriter.mu.Unlock()
-	assert.Equal(t, uint64(2), finalSeq)
+	snapshot := coordreport.SnapshotStepLogWriter(stepWriter)
+	assert.Equal(t, uint64(2), snapshot.Sequence)
 }
 
 func TestClose_FinalSendFailure(t *testing.T) {
@@ -909,7 +857,7 @@ func TestClose_FinalSendFailure(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	_, _ = writer.Write([]byte("data"))
@@ -929,7 +877,7 @@ func TestClose_CloseAndRecvError(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	_, _ = writer.Write([]byte("data"))
@@ -955,7 +903,7 @@ func TestClose_MultipleErrors(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	_, _ = writer.Write([]byte("data"))
@@ -974,11 +922,11 @@ func TestClose_NoStream(t *testing.T) {
 			return nil, errors.New("init failed")
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write triggers init failure
-	data := make([]byte, logBufferSize)
+	data := make([]byte, coordreport.LogBufferSize)
 	_, _ = writer.Write(data)
 
 	// Close should handle nil stream gracefully
@@ -1005,7 +953,7 @@ func TestClose_FlushErrorThenSendSuccess(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	_, _ = writer.Write([]byte("data"))
@@ -1024,7 +972,7 @@ func TestConcurrentWrites(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	var wg sync.WaitGroup
@@ -1052,7 +1000,7 @@ func TestConcurrentWriteAndClose(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	var wg sync.WaitGroup
@@ -1087,7 +1035,7 @@ func TestConcurrentSetAttemptID(t *testing.T) {
 			return &mockStreamLogsClient{}, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "initial", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "initial", exec.DAGRunRef{})
 
 	var wg sync.WaitGroup
 
@@ -1104,7 +1052,7 @@ func TestConcurrentSetAttemptID(t *testing.T) {
 	for range 10 {
 		wg.Go(func() {
 			writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
-			_, _ = writer.Write(make([]byte, logBufferSize)) // Triggers flush which reads attemptID
+			_, _ = writer.Write(make([]byte, coordreport.LogBufferSize)) // Triggers flush which reads attemptID
 			_ = writer.Close()
 		})
 	}
@@ -1121,7 +1069,7 @@ func TestLogStreamer_FullLifecycle(t *testing.T) {
 		},
 	}
 	rootRef := exec.DAGRunRef{Name: "root", ID: "root-123"}
-	streamer := NewLogStreamer(client, "worker-1", "run-456", "test-dag", "attempt-789", rootRef)
+	streamer := coordreport.NewLogStreamer(client, "worker-1", "run-456", "test-dag", "attempt-789", rootRef)
 
 	writer := streamer.NewStepWriter(context.Background(), "step1", exec.StreamTypeStdout)
 
@@ -1169,7 +1117,7 @@ func TestLogStreamer_MultipleSteps(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 
 	// Create multiple step writers
 	writer1 := streamer.NewStepWriter(context.Background(), "step1", exec.StreamTypeStdout)
@@ -1199,7 +1147,7 @@ func TestLogStreamer_StdoutAndStderr(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 
 	stdout := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 	stderr := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStderr)
@@ -1234,7 +1182,7 @@ func TestLogStreamer_LargeOutput(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Write 12MB of data
@@ -1260,9 +1208,9 @@ func TestLogStreamer_LargeOutput(t *testing.T) {
 	}
 	assert.Equal(t, len(data), totalBytes)
 
-	// Verify no chunk exceeds maxChunkSize
+	// Verify no chunk exceeds the stream chunk limit.
 	for _, chunk := range chunks {
-		assert.LessOrEqual(t, len(chunk.Data), maxChunkSize)
+		assert.LessOrEqual(t, len(chunk.Data), coordreport.MaxChunkSize)
 	}
 }
 
@@ -1274,11 +1222,11 @@ func TestLogStreamer_AttemptIDUpdatedDuringStream(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "initial-attempt", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "initial-attempt", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// First write with initial attempt ID
-	data := make([]byte, logBufferSize)
+	data := make([]byte, coordreport.LogBufferSize)
 	_, _ = writer.Write(data)
 
 	// Update attempt ID mid-stream
@@ -1309,12 +1257,12 @@ func TestLogStreamer_SequenceContinuity(t *testing.T) {
 			return mockStream, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
 
 	// Multiple flushes
 	for range 5 {
-		data := make([]byte, logBufferSize)
+		data := make([]byte, coordreport.LogBufferSize)
 		_, _ = writer.Write(data)
 	}
 	_ = writer.Close()
@@ -1336,7 +1284,7 @@ func TestLogStreamer_RaceDetector(t *testing.T) {
 			return &mockStreamLogsClient{}, nil
 		},
 	}
-	streamer := NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
 
 	var wg sync.WaitGroup
 	var ops int64

--- a/internal/service/worker/coordreport/status_pusher.go
+++ b/internal/service/worker/coordreport/status_pusher.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport
 
 import (
 	"context"
@@ -9,9 +9,12 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 )
+
+var _ runtime.StatusPusher = (*StatusPusher)(nil)
 
 // StatusPusher sends status updates to coordinator via gRPC
 type StatusPusher struct {
@@ -31,6 +34,14 @@ func (e *AttemptRejectedError) Error() string {
 		return "status rejected"
 	}
 	return fmt.Sprintf("status rejected: %s", e.Reason)
+}
+
+// AttemptRejectedReason returns the coordinator rejection reason.
+func (e *AttemptRejectedError) AttemptRejectedReason() string {
+	if e == nil {
+		return ""
+	}
+	return e.Reason
 }
 
 // NewStatusPusher creates a new StatusPusher

--- a/internal/service/worker/coordreport/status_pusher_test.go
+++ b/internal/service/worker/coordreport/status_pusher_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package remote
+package coordreport_test
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func (m *mockCoordinatorClient) ReportStatus(ctx context.Context, req *coordinat
 }
 
 // Stub methods for interface compliance - panic if called unexpectedly
-func (m *mockCoordinatorClient) Dispatch(_ context.Context, _ *coordinatorv1.Task) error {
+func (m *mockCoordinatorClient) Dispatch(_ context.Context, _ *exec.DispatchTask) error {
 	panic("Dispatch not implemented in mock")
 }
 
@@ -93,7 +94,7 @@ func (m *mockCoordinatorClient) Cleanup(_ context.Context) error {
 	return nil
 }
 
-func (m *mockCoordinatorClient) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+func (m *mockCoordinatorClient) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
 	panic("GetDAGRunStatus not implemented in mock")
 }
 
@@ -105,11 +106,12 @@ func TestNewStatusPusher(t *testing.T) {
 	t.Parallel()
 
 	client := &mockCoordinatorClient{}
-	pusher := NewStatusPusher(client, "worker-123")
+	pusher := coordreport.NewStatusPusher(client, "worker-123")
 
 	require.NotNil(t, pusher)
-	assert.Equal(t, "worker-123", pusher.workerID)
-	assert.Equal(t, client, pusher.client)
+	snapshot := coordreport.SnapshotStatusPusher(pusher)
+	assert.Equal(t, "worker-123", snapshot.WorkerID)
+	assert.Equal(t, client, snapshot.Client)
 }
 
 func TestPush(t *testing.T) {
@@ -126,7 +128,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		status := exec.DAGRunStatus{
 			Name:     "test-dag",
 			DAGRunID: "run-123",
@@ -159,7 +161,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		status := exec.DAGRunStatus{Name: "test-dag", DAGRunID: "run-123"}
 
 		err := pusher.Push(context.Background(), status)
@@ -167,7 +169,7 @@ func TestPush(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "status rejected")
 		assert.Contains(t, err.Error(), "duplicate status")
-		var rejectedErr *AttemptRejectedError
+		var rejectedErr *coordreport.AttemptRejectedError
 		require.ErrorAs(t, err, &rejectedErr)
 		assert.Equal(t, "duplicate status", rejectedErr.Reason)
 	})
@@ -181,12 +183,12 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		err := pusher.Push(context.Background(), exec.DAGRunStatus{})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "status rejected")
-		var rejectedErr *AttemptRejectedError
+		var rejectedErr *coordreport.AttemptRejectedError
 		require.ErrorAs(t, err, &rejectedErr)
 		assert.Empty(t, rejectedErr.Reason)
 	})
@@ -200,7 +202,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		err := pusher.Push(context.Background(), exec.DAGRunStatus{})
 
 		require.Error(t, err)
@@ -216,7 +218,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		err := pusher.Push(context.Background(), exec.DAGRunStatus{})
 
 		require.Error(t, err)
@@ -236,7 +238,7 @@ func TestPush(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		err := pusher.Push(ctx, exec.DAGRunStatus{})
 
 		require.Error(t, err)
@@ -274,7 +276,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1")
+		pusher := coordreport.NewStatusPusher(client, "worker-1")
 		err := pusher.Push(context.Background(), status)
 
 		require.NoError(t, err)
@@ -304,7 +306,7 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := NewStatusPusher(client, "worker-1", exec.HostInfo{ID: "coord-1", Host: "127.0.0.1", Port: 4321})
+		pusher := coordreport.NewStatusPusher(client, "worker-1", exec.HostInfo{ID: "coord-1", Host: "127.0.0.1", Port: 4321})
 		err := pusher.Push(context.Background(), exec.DAGRunStatus{Name: "test-dag", DAGRunID: "run-owner"})
 
 		require.NoError(t, err)

--- a/internal/service/worker/handler.go
+++ b/internal/service/worker/handler.go
@@ -161,6 +161,10 @@ func (e *taskHandler) sharedVolumeActionWorkDir(ctx context.Context, task *coord
 
 func (e *taskHandler) buildCommandSpec(ctx context.Context, task *coordinatorv1.Task, originalTarget string) (launcher.CmdSpec, error) {
 	dagName := dagNameHint(originalTarget)
+	dispatchTask, err := convert.ProtoToDispatchTask(task)
+	if err != nil {
+		return launcher.CmdSpec{}, fmt.Errorf("convert coordinator task: %w", err)
+	}
 
 	switch task.Operation {
 	case coordinatorv1.Operation_OPERATION_START:
@@ -168,7 +172,7 @@ func (e *taskHandler) buildCommandSpec(ctx context.Context, task *coordinatorv1.
 		if err != nil {
 			return launcher.CmdSpec{}, err
 		}
-		spec := e.subCmdBuilder.TaskStart(task, hints.env, dagName)
+		spec := e.subCmdBuilder.TaskStart(dispatchTask, hints.env, dagName)
 		return withDefaultWorkingDir(spec, hints.defaultWorkingDir), nil
 
 	case coordinatorv1.Operation_OPERATION_RETRY:
@@ -177,10 +181,10 @@ func (e *taskHandler) buildCommandSpec(ctx context.Context, task *coordinatorv1.
 			return launcher.CmdSpec{}, err
 		}
 		if isQueueDispatchTask(task) {
-			spec := e.subCmdBuilder.QueueDispatchTaskRetry(task, hints.env, dagName)
+			spec := e.subCmdBuilder.QueueDispatchTaskRetry(dispatchTask, hints.env, dagName)
 			return withDefaultWorkingDir(spec, hints.defaultWorkingDir), nil
 		}
-		spec := e.subCmdBuilder.TaskRetry(task, hints.env, dagName)
+		spec := e.subCmdBuilder.TaskRetry(dispatchTask, hints.env, dagName)
 		return withDefaultWorkingDir(spec, hints.defaultWorkingDir), nil
 
 	case coordinatorv1.Operation_OPERATION_UNSPECIFIED:

--- a/internal/service/worker/handler_test.go
+++ b/internal/service/worker/handler_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/launcher"
-	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/test"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/google/uuid"
@@ -51,6 +51,32 @@ func workerStatusOutputValue(t *testing.T, status *exec.DAGRunStatus, key string
 
 	t.Fatalf("output %q not found in DAG-run status", key)
 	return ""
+}
+
+func workerHandlerTask(
+	t *testing.T,
+	dagName string,
+	definition string,
+	operation coordinatorv1.Operation,
+	runID string,
+	previousStatus *exec.DAGRunStatus,
+) *coordinatorv1.Task {
+	t.Helper()
+
+	task := &coordinatorv1.Task{
+		Operation:      operation,
+		DagRunId:       runID,
+		Target:         dagName,
+		Definition:     definition,
+		RootDagRunName: dagName,
+		RootDagRunId:   runID,
+	}
+	if previousStatus != nil {
+		protoStatus, err := convert.DAGRunStatusToProto(previousStatus)
+		require.NoError(t, err)
+		task.PreviousStatus = protoStatus
+	}
+	return task
 }
 
 func TestTaskHandler(t *testing.T) {
@@ -228,11 +254,13 @@ steps:
 `, test.EnvOutput("EXPORTED_SECRET", "WORKER_TASK_START_ENV"))
 		dag := th.DAG(t, dagContent)
 		runID := uuid.Must(uuid.NewV7()).String()
-		task := runtimeexec.CreateTask(
+		task := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
@@ -260,11 +288,13 @@ steps:
 		runID := uuid.Must(uuid.NewV7()).String()
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
 
-		startTask := runtimeexec.CreateTask(
+		startTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 		err := handler.Handle(th.Context, startTask)
 		require.NoError(t, err)
@@ -275,12 +305,13 @@ steps:
 		require.NoError(t, err)
 		require.Equal(t, "from-host|", workerStatusOutputValue(t, initialStatus, "RESULT"))
 
-		retryTask := runtimeexec.CreateTask(
+		retryTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_RETRY,
 			runID,
-			runtimeexec.WithPreviousStatus(initialStatus),
+			initialStatus,
 		)
 		err = handler.Handle(th.Context, retryTask)
 		require.NoError(t, err)
@@ -307,11 +338,13 @@ steps:
 `, test.EnvOutput("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT", "WORKER_TASK_HOST_ONLY_ENV"))
 		dag := th.DAG(t, dagContent)
 		runID := uuid.Must(uuid.NewV7()).String()
-		task := runtimeexec.CreateTask(
+		task := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
@@ -339,11 +372,13 @@ steps:
 		runID := uuid.Must(uuid.NewV7()).String()
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
 
-		startTask := runtimeexec.CreateTask(
+		startTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 		err := handler.Handle(th.Context, startTask)
 		require.NoError(t, err)
@@ -354,12 +389,13 @@ steps:
 		require.NoError(t, err)
 		require.Equal(t, "10.43.0.1|443|", workerStatusOutputValue(t, initialStatus, "RESULT"))
 
-		retryTask := runtimeexec.CreateTask(
+		retryTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_RETRY,
 			runID,
-			runtimeexec.WithPreviousStatus(initialStatus),
+			initialStatus,
 		)
 		err = handler.Handle(th.Context, retryTask)
 		require.NoError(t, err)
@@ -389,11 +425,13 @@ steps:
 `, test.EnvOutput("WORKER_TASK_EXACT_ENV", "WORKER_TASK_PREFIX_TOKEN", "WORKER_TASK_HOST_ONLY_ENV"))
 		dag := th.DAG(t, dagContent)
 		runID := uuid.Must(uuid.NewV7()).String()
-		task := runtimeexec.CreateTask(
+		task := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
@@ -424,11 +462,13 @@ steps:
 		runID := uuid.Must(uuid.NewV7()).String()
 		handler := NewTaskHandlerWithDAGRunStore(th.Config, th.DAGRunStore)
 
-		startTask := runtimeexec.CreateTask(
+		startTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_START,
 			runID,
+			nil,
 		)
 		err := handler.Handle(th.Context, startTask)
 		require.NoError(t, err)
@@ -439,12 +479,13 @@ steps:
 		require.NoError(t, err)
 		require.Equal(t, "exact-value|prefix-value|", workerStatusOutputValue(t, initialStatus, "RESULT"))
 
-		retryTask := runtimeexec.CreateTask(
+		retryTask := workerHandlerTask(
+			t,
 			dag.Name,
 			dagContent,
 			coordinatorv1.Operation_OPERATION_RETRY,
 			runID,
-			runtimeexec.WithPreviousStatus(initialStatus),
+			initialStatus,
 		)
 		err = handler.Handle(th.Context, retryTask)
 		require.NoError(t, err)

--- a/internal/service/worker/poller_test.go
+++ b/internal/service/worker/poller_test.go
@@ -378,7 +378,7 @@ var _ coordinator.Client = (*mockCoordinatorCli)(nil)
 // mockCoordinatorCli is a mock implementation of coordinator.Client
 type mockCoordinatorCli struct {
 	PollFunc         func(ctx context.Context, policy backoff.RetryPolicy, req *coordinatorv1.PollRequest) (*coordinatorv1.Task, error)
-	DispatchFunc     func(ctx context.Context, task *coordinatorv1.Task) error
+	DispatchFunc     func(ctx context.Context, task *exec.DispatchTask) error
 	MetricsFunc      func() coordinator.Metrics
 	CleanupFunc      func(ctx context.Context) error
 	HeartbeatFunc    func(ctx context.Context, req *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
@@ -410,7 +410,7 @@ func (m *mockCoordinatorCli) Poll(ctx context.Context, policy backoff.RetryPolic
 	return nil, nil
 }
 
-func (m *mockCoordinatorCli) Dispatch(ctx context.Context, task *coordinatorv1.Task) error {
+func (m *mockCoordinatorCli) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
 	m.mu.Lock()
 	dispatchFunc := m.DispatchFunc
 	m.mu.Unlock()
@@ -504,8 +504,8 @@ func (m *mockCoordinatorCli) StreamArtifactsTo(ctx context.Context, _ exec.HostI
 	return m.StreamArtifacts(ctx)
 }
 
-func (m *mockCoordinatorCli) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
-	return &coordinatorv1.GetDAGRunStatusResponse{Found: false}, nil
+func (m *mockCoordinatorCli) GetDAGRunStatus(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
+	return &exec.DAGRunStatusResult{Found: false}, nil
 }
 
 func (m *mockCoordinatorCli) RequestCancel(_ context.Context, _, _ string, _ *exec.DAGRunRef) error {

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -28,9 +28,9 @@ import (
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime"
 	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
-	"github.com/dagucloud/dagu/internal/runtime/remote"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	dagutools "github.com/dagucloud/dagu/internal/tools"
 	daguaqua "github.com/dagucloud/dagu/internal/tools/aqua"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -199,7 +199,7 @@ func (h *remoteTaskHandler) handleRetry(ctx context.Context, task *coordinatorv1
 }
 
 func (h *remoteTaskHandler) reportTaskLoadFailure(ctx context.Context, task *coordinatorv1.Task, root, parent exec.DAGRunRef, owner exec.HostInfo, loadErr error) {
-	statusPusher := remote.NewStatusPusher(h.coordinatorClient, h.workerID, owner)
+	statusPusher := coordreport.NewStatusPusher(h.coordinatorClient, h.workerID, owner)
 	finishedAt := stringutil.FormatTime(time.Now())
 	logger.Warn(ctx, "Failed to load DAG on worker",
 		tag.Target(task.Target),
@@ -232,7 +232,7 @@ func (h *remoteTaskHandler) reportTaskInitFailure(
 	task *coordinatorv1.Task,
 	root exec.DAGRunRef,
 	parent exec.DAGRunRef,
-	statusPusher *remote.StatusPusher,
+	statusPusher runtime.StatusPusher,
 	initErr error,
 ) {
 	if statusPusher == nil || initErr == nil {
@@ -316,13 +316,13 @@ func taskExtraEnvs(task *coordinatorv1.Task) []string {
 }
 
 // createRemoteHandlers creates the remote status, log, and artifact transport handlers.
-func (h *remoteTaskHandler) createRemoteHandlers(dagRunID, dagName string, root exec.DAGRunRef, owner ...exec.HostInfo) (*remote.StatusPusher, *remote.LogStreamer, *remote.ArtifactUploader) {
+func (h *remoteTaskHandler) createRemoteHandlers(dagRunID, dagName string, root exec.DAGRunRef, owner ...exec.HostInfo) (runtime.StatusPusher, runtime.SchedulerLogStreamer, runtime.ArtifactFinalizer) {
 	var target exec.HostInfo
 	if len(owner) > 0 {
 		target = owner[0]
 	}
-	statusPusher := remote.NewStatusPusher(h.coordinatorClient, h.workerID, target)
-	logStreamer := remote.NewLogStreamer(
+	statusPusher := coordreport.NewStatusPusher(h.coordinatorClient, h.workerID, target)
+	logStreamer := coordreport.NewLogStreamer(
 		h.coordinatorClient,
 		h.workerID,
 		dagRunID,
@@ -331,7 +331,7 @@ func (h *remoteTaskHandler) createRemoteHandlers(dagRunID, dagName string, root 
 		root,
 		target,
 	)
-	artifactUploader := remote.NewArtifactUploader(
+	artifactUploader := coordreport.NewArtifactUploader(
 		h.coordinatorClient,
 		h.workerID,
 		dagRunID,
@@ -401,10 +401,8 @@ func (h *remoteTaskHandler) loadDAG(ctx context.Context, task *coordinatorv1.Tas
 		}
 	}
 
-	// Prepare load options
-	// Note: DAGsDir is intentionally NOT included because:
-	// 1. Remote handlers always receive DAG definitions from the coordinator
-	// 2. Shared-nothing workers should not access local DAG directories
+	// Remote tasks load the DAG definition received from the coordinator.
+	// Local DAG directories are outside the shared-nothing task boundary.
 	loadOpts := []spec.LoadOption{
 		spec.WithName(task.Target), // Use original DAG name, not temp file path
 	}
@@ -536,9 +534,9 @@ func (h *remoteTaskHandler) executeDAGRun(
 	scheduleTime string,
 	root exec.DAGRunRef,
 	parent exec.DAGRunRef,
-	statusPusher *remote.StatusPusher,
-	logStreamer *remote.LogStreamer,
-	artifactUploader *remote.ArtifactUploader,
+	statusPusher runtime.StatusPusher,
+	logStreamer runtime.SchedulerLogStreamer,
+	artifactUploader runtime.ArtifactFinalizer,
 	queuedRun bool,
 	retry *retryConfig,
 	agentSnapshot []byte,
@@ -597,17 +595,20 @@ func (h *remoteTaskHandler) executeDAGRun(
 
 	// Build agent options
 	opts := rtagent.Options{
-		ParentDAGRun:      parent,
-		WorkerID:          h.workerID,
-		StatusPusher:      statusPusher,
-		LogWriterFactory:  logStreamer,
-		ExtraEnvs:         extraEnvs,
-		QueuedRun:         queuedRun,
-		AttemptID:         attemptID,
-		DAGRunStore:       h.dagRunStore,
-		StateStore:        h.stateStore,
-		SecretStore:       agentStores.SecretStore,
-		ServiceRegistry:   h.serviceRegistry,
+		ParentDAGRun:     parent,
+		WorkerID:         h.workerID,
+		StatusPusher:     statusPusher,
+		LogWriterFactory: logStreamer,
+		ExtraEnvs:        extraEnvs,
+		QueuedRun:        queuedRun,
+		AttemptID:        attemptID,
+		DAGRunStore:      h.dagRunStore,
+		StateStore:       h.stateStore,
+		SecretStore:      agentStores.SecretStore,
+		ServiceRegistry:  h.serviceRegistry,
+		DispatcherFactory: func(_ context.Context) (runtime.Dispatcher, error) {
+			return coordinator.NewRuntimeDispatcher(h.serviceRegistry, h.peerConfig)
+		},
 		RootDAGRun:        root,
 		PeerConfig:        h.peerConfig,
 		DefaultExecMode:   h.config.DefaultExecMode,

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/store"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
 	"github.com/dagucloud/dagu/internal/proto/convert"
-	"github.com/dagucloud/dagu/internal/runtime/remote"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	"github.com/dagucloud/dagu/internal/test"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
@@ -309,8 +309,8 @@ type mockRemoteCoordinatorClient struct {
 	StreamLogsToFunc      func(ctx context.Context, owner exec.HostInfo) (coordinatorv1.CoordinatorService_StreamLogsClient, error)
 	StreamArtifactsFunc   func(ctx context.Context) (coordinatorv1.CoordinatorService_StreamArtifactsClient, error)
 	StreamArtifactsToFunc func(ctx context.Context, owner exec.HostInfo) (coordinatorv1.CoordinatorService_StreamArtifactsClient, error)
-	GetDAGRunStatusFunc   func(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error)
-	DispatchFunc          func(ctx context.Context, task *coordinatorv1.Task) error
+	GetDAGRunStatusFunc   func(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*exec.DAGRunStatusResult, error)
+	DispatchFunc          func(ctx context.Context, task *exec.DispatchTask) error
 	PollFunc              func(ctx context.Context, policy backoff.RetryPolicy, req *coordinatorv1.PollRequest) (*coordinatorv1.Task, error)
 	HeartbeatFunc         func(ctx context.Context, req *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
 	GetWorkersFunc        func(ctx context.Context) ([]*coordinatorv1.WorkerInfo, error)
@@ -330,8 +330,8 @@ func newMockRemoteCoordinatorClient() *mockRemoteCoordinatorClient {
 		StreamArtifactsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamArtifactsClient, error) {
 			return newMockStreamArtifactsClient(), nil
 		},
-		GetDAGRunStatusFunc: func(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
-			return &coordinatorv1.GetDAGRunStatusResponse{Found: false}, nil
+		GetDAGRunStatusFunc: func(_ context.Context, _, _ string, _ *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
+			return &exec.DAGRunStatusResult{Found: false}, nil
 		},
 		MetricsFunc: func() coordinator.Metrics {
 			return coordinator.Metrics{IsConnected: true}
@@ -395,14 +395,14 @@ func (m *mockRemoteCoordinatorClient) StreamArtifactsTo(ctx context.Context, own
 	return m.StreamArtifacts(ctx)
 }
 
-func (m *mockRemoteCoordinatorClient) GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+func (m *mockRemoteCoordinatorClient) GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
 	if m.GetDAGRunStatusFunc != nil {
 		return m.GetDAGRunStatusFunc(ctx, dagName, dagRunID, rootRef)
 	}
-	return &coordinatorv1.GetDAGRunStatusResponse{Found: false}, nil
+	return &exec.DAGRunStatusResult{Found: false}, nil
 }
 
-func (m *mockRemoteCoordinatorClient) Dispatch(ctx context.Context, task *coordinatorv1.Task) error {
+func (m *mockRemoteCoordinatorClient) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
 	if m.DispatchFunc != nil {
 		return m.DispatchFunc(ctx, task)
 	}
@@ -1281,6 +1281,7 @@ steps:
 			dagStore:          th.DAGStore,
 			dagRunMgr:         th.DAGRunMgr,
 			serviceRegistry:   th.ServiceRegistry,
+			peerConfig:        config.Peer{Insecure: true},
 			config:            th.Config,
 		}
 
@@ -1402,6 +1403,7 @@ steps:
 		dagStore:          th.DAGStore,
 		dagRunMgr:         th.DAGRunMgr,
 		serviceRegistry:   th.ServiceRegistry,
+		peerConfig:        config.Peer{Insecure: true},
 		config:            th.Config,
 	}
 
@@ -1934,15 +1936,16 @@ steps:
 		dagStore:          th.DAGStore,
 		dagRunMgr:         th.DAGRunMgr,
 		serviceRegistry:   th.ServiceRegistry,
+		peerConfig:        config.Peer{Insecure: true},
 		config:            th.Config,
 	}
 
 	// For a top-level run, root ID should match the dagRunID
 	dagRunID := "run-success-1"
 	root := exec.DAGRunRef{Name: dag.Name, ID: dagRunID}
-	statusPusher := remote.NewStatusPusher(client, "integration-test-worker")
-	logStreamer := remote.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
-	artifactUploader := remote.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	statusPusher := coordreport.NewStatusPusher(client, "integration-test-worker")
+	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
 	// Call executeDAGRun - this should succeed and log completion
 	// For top-level runs, pass empty parent and ensure root matches dagRunID
@@ -1973,14 +1976,15 @@ func TestExecuteDAGRun_FailedExecutionStillUploadsArtifacts(t *testing.T) {
 		dagStore:          th.DAGStore,
 		dagRunMgr:         th.DAGRunMgr,
 		serviceRegistry:   th.ServiceRegistry,
+		peerConfig:        config.Peer{Insecure: true},
 		config:            th.Config,
 	}
 
 	dagRunID := "run-failure-artifacts-1"
 	root := exec.DAGRunRef{Name: dag.Name, ID: dagRunID}
-	statusPusher := remote.NewStatusPusher(client, "integration-test-worker")
-	logStreamer := remote.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
-	artifactUploader := remote.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	statusPusher := coordreport.NewStatusPusher(client, "integration-test-worker")
+	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
 	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil)
 	require.Error(t, err)
@@ -2037,14 +2041,15 @@ func TestExecuteDAGRun_ArtifactUploadFailureMarksRunFailed(t *testing.T) {
 		dagStore:          th.DAGStore,
 		dagRunMgr:         th.DAGRunMgr,
 		serviceRegistry:   th.ServiceRegistry,
+		peerConfig:        config.Peer{Insecure: true},
 		config:            th.Config,
 	}
 
 	dagRunID := "run-upload-failure-1"
 	root := exec.DAGRunRef{Name: dag.Name, ID: dagRunID}
-	statusPusher := remote.NewStatusPusher(client, "integration-test-worker")
-	logStreamer := remote.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
-	artifactUploader := remote.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	statusPusher := coordreport.NewStatusPusher(client, "integration-test-worker")
+	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
 	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil)
 	require.Error(t, err)
@@ -2093,14 +2098,15 @@ func TestExecuteDAGRun_FailedExecutionWithArtifactUploadFailurePreservesFailedSt
 		dagStore:          th.DAGStore,
 		dagRunMgr:         th.DAGRunMgr,
 		serviceRegistry:   th.ServiceRegistry,
+		peerConfig:        config.Peer{Insecure: true},
 		config:            th.Config,
 	}
 
 	dagRunID := "run-failure-upload-failure-1"
 	root := exec.DAGRunRef{Name: dag.Name, ID: dagRunID}
-	statusPusher := remote.NewStatusPusher(client, "integration-test-worker")
-	logStreamer := remote.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
-	artifactUploader := remote.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	statusPusher := coordreport.NewStatusPusher(client, "integration-test-worker")
+	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
+	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
 	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil)
 	require.Error(t, err)

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dagucloud/dagu/internal/persis/store"
 	runtimepkg "github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/frontend"
 	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
@@ -783,6 +784,11 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 	helper.opts.DefaultExecMode = d.Config.DefaultExecMode
 	helper.opts.DAGRunLogDir = d.Config.Paths.LogDir
 	helper.opts.DAGRunArtifactDir = d.Config.Paths.ArtifactDir
+	if helper.opts.DispatcherFactory == nil {
+		helper.opts.DispatcherFactory = func(_ context.Context) (runtimepkg.Dispatcher, error) {
+			return coordinator.NewRuntimeDispatcher(d.ServiceRegistry, d.Config.Core.Peer)
+		}
+	}
 
 	helper.Agent = agent.New(
 		dagRunID,


### PR DESCRIPTION
## Summary
- move coordinator dispatch/reporting transport details out of runtime-facing packages and behind domain ports
- add proto-free dispatch task/status contracts in core/exec and convert to coordinator proto at Dagu adapter boundaries
- move worker remote reporting adapters under service/worker/coordreport while preserving distributed sub-DAG behavior

## Testing
- go test -count=1 ./internal/core/exec ./internal/proto/convert
- go test -count=1 ./internal/runtime/executor ./internal/service/coordinator ./internal/service/worker ./internal/service/scheduler
- go test -count=1 ./internal/intg/distr
- make lint
- make test
- go list -deps ./internal/runtime/... | rg "proto/coordinator/v1|internal/service/coordinator"
- rg -n "coordinator/v1|coordinatorv1|internal/service/coordinator" internal/runtime internal/core/exec internal/launcher -S
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves coordinator transport behind runtime ports and switches the runtime to domain dispatch/status/worker types. Adds a TLS‑validated, coordinator‑backed runtime dispatcher injected via a DispatcherFactory; keeps the runtime proto‑free and preserves distributed sub‑DAG behavior.

- **New Features**
  - Added domain dispatch types `exec.DispatchTask` and `exec.DispatchOperation`, with converters in `internal/proto/convert/dispatch`; used by coordinator client/handler with validation.
  - Introduced runtime ports: `runtime.StatusPusher`, `runtime.SchedulerLogStreamer`, `runtime.ArtifactFinalizer` (with `AttemptRejected`); implemented in service/worker/coordreport.
  - Provided coordinator‑backed runtime dispatcher via `coordinator.NewRuntimeDispatcher` (validates TLS/retry); wired through a `DispatcherFactory` in CLI, engine, and tests.
  - Added docs: “Distributed Runtime Ports,” linked from README.

- **Refactors**
  - Removed coordinator proto usage across runtime/engine/CLI/scheduler/launcher/worker; progress UI now consumes `exec.DAGRunStatus`.
  - `DispatchTaskStore` now persists `exec.DispatchTask`; releases claims on encode failure; adaptive cleanup interval reduces contention; can read legacy dispatch records.
  - Consolidated worker remote reporting under service/worker/coordreport; updated scheduler/queue to new operation enums.
  - Updated launcher/worker command specs to accept `exec.DispatchTask`; telemetry now uses `exec.WorkerStats`/`exec.RunningTask`.

<sup>Written for commit 9001832e5c515e10dbdbd1c72d14976bb8da60a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Decoupled distributed execution dispatching from coordinator protobuf types by introducing internal dispatch abstractions and task representations across the executor, coordinator client, and runtime agent layers.
  * Consolidated distributed task and worker status reporting logic into a unified "coordreport" package with cleaner interface boundaries.
  * Improved dependency injection patterns for runtime dispatcher configuration and status/artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->