### PR TITLE
fix(dag): propagate runtime params in distributed queue dispatch

### DIFF
--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -156,6 +156,9 @@ func (e *DAGExecutor) ExecuteDAG(
 			executor.WithPreviousStatus(previousStatus),
 			executor.WithBaseConfig(executor.ResolveBaseConfig(dag.BaseConfigData, e.baseConfigPath)),
 		}
+		if previousStatus != nil && previousStatus.Params != "" {
+			taskOpts = append(taskOpts, executor.WithTaskParams(previousStatus.Params))
+		}
 		if dag.SourceFile != "" {
 			taskOpts = append(taskOpts, executor.WithSourceFile(dag.SourceFile))
 		}


### PR DESCRIPTION
## Problem

When `DAGU_DEFAULT_EXECUTION_MODE=distributed`, DAG parameters (e.g., `content_hash`) passed via the enqueue API were silently lost. The DAG would run on workers with no runtime params, causing failures for DAGs that require them.

## Root Cause

In `DAGExecutor.ExecuteDAG()`, the distributed execution path (when `shouldUseDistributedExecution(dag)` is true) built task options with `WithWorkerSelector`, `WithPreviousStatus`, and `WithBaseConfig` — but never called `WithTaskParams()`. This meant `task.Params` was empty when dispatched to the coordinator.

Meanwhile, the local execution path correctly extracted params from `previousStatus.ParamsList` via `spec.QuoteRuntimeParams()` and injected them into the subprocess env.

## Fix

Added a `WithTaskParams(previousStatus.Params)` call in the distributed branch of `ExecuteDAG()`, before `CreateTask()`. This mirrors how the API's `dispatchStartToCoordinator` correctly passes params, ensuring the worker's `loadDAG()` receives them via `spec.WithParams(task.Params)`.

## Tests

All related tests pass: `internal/service/scheduler`, `internal/service/worker`, `internal/dispatch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped DAG runtime params in distributed queue dispatch. We now append `executor.WithTaskParams(previousStatus.Params)` to task options before `CreateTask()`, so workers receive params (e.g., content_hash) when `DAGU_DEFAULT_EXECUTION_MODE=distributed`.

<sup>Written for commit dfe32db17d9882ffc7c8d51096de58e71afa72ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task parameter propagation in distributed execution scenarios, ensuring parameters are correctly preserved and passed through execution workflows when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->