### PR TITLE
test: cover distributed queued runtime params

### DIFF
--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -443,8 +443,16 @@ func (f *testFixture) startSchedulerWithOptions(
 
 func (f *testFixture) enqueue() error {
 	f.t.Helper()
+	return f.enqueueWithParams("")
+}
+
+func (f *testFixture) enqueueWithParams(params string) error {
+	f.t.Helper()
 	subCmdBuilder := launcher.NewSubCmdBuilder(f.coord.Config)
-	enqueueSpec := subCmdBuilder.Enqueue(f.dagWrapper.DAG, launcher.EnqueueOptions{Quiet: true})
+	enqueueSpec := subCmdBuilder.Enqueue(f.dagWrapper.DAG, launcher.EnqueueOptions{
+		Quiet:  true,
+		Params: params,
+	})
 	return launcher.Run(f.coord.Context, enqueueSpec)
 }
 

--- a/internal/intg/distr/params_test.go
+++ b/internal/intg/distr/params_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
@@ -116,6 +117,42 @@ steps:
 	subStatus := readDistributedSubAttemptStatus(t, f, rootRef, subRunID)
 	require.NotEqual(t, core.Succeeded, subStatus.Status)
 	require.True(t, statusErrorsContain(subStatus.Errors(), "count"), "expected child status errors to mention count")
+}
+
+func TestParams_DistributedQueuedRunRuntimeParams(t *testing.T) {
+	f := newTestFixture(t, `
+name: queued-runtime-params
+worker_selector:
+  test: "true"
+params:
+  - name: content_hash
+    type: string
+    required: true
+steps:
+  - name: shell-value
+    run: echo "content_hash=$content_hash"
+    output: SHELL_VALUE
+  - name: params-json
+    run: printenv DAGU_PARAMS_JSON
+    output: PARAMS_JSON
+`)
+	defer f.cleanup()
+
+	require.NoError(t, f.enqueueWithParams("content_hash=sha256:abc123"))
+	f.waitForQueued()
+
+	queuedStatus, err := f.latestStatus()
+	require.NoError(t, err)
+	require.Equal(t, core.Queued, queuedStatus.Status)
+	require.Equal(t, []string{"content_hash=sha256:abc123"}, queuedStatus.ParamsList)
+
+	f.startScheduler(30 * time.Second)
+	status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+
+	require.Equal(t, []string{"content_hash=sha256:abc123"}, status.ParamsList)
+	require.Len(t, status.Nodes, 2)
+	assert.Equal(t, "content_hash=sha256:abc123", nodeOutputValue(t, status.Nodes[0], "SHELL_VALUE"))
+	assert.JSONEq(t, `{"content_hash":"sha256:abc123"}`, nodeOutputValue(t, status.Nodes[1], "PARAMS_JSON"))
 }
 
 func readDistributedSubAttemptStatus(t *testing.T, f *testFixture, rootRef exec1.DAGRunRef, subRunID string) *exec1.DAGRunStatus {

--- a/internal/service/scheduler/dag_executor_test.go
+++ b/internal/service/scheduler/dag_executor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
+	exec1 "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
@@ -105,4 +106,55 @@ steps:
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to dispatch task")
 	})
+}
+
+func TestDAGExecutor_DistributedRetryPassesQueuedParams(t *testing.T) {
+	dispatcher := &capturingDispatcher{}
+	dagExecutor := scheduler.NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil)
+
+	dag := &core.DAG{
+		Name:           "queued-param-dag",
+		YamlData:       []byte("name: queued-param-dag\n"),
+		WorkerSelector: map[string]string{"type": "test-worker"},
+	}
+	previousStatus := &exec1.DAGRunStatus{
+		Status:     core.Queued,
+		Params:     "content_hash=sha256:abc123",
+		ParamsList: []string{"content_hash=sha256:abc123"},
+	}
+
+	err := dagExecutor.ExecuteDAG(
+		context.Background(),
+		dag,
+		coordinatorv1.Operation_OPERATION_RETRY,
+		"queued-param-run",
+		previousStatus,
+		core.TriggerTypeManual,
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, dispatcher.task)
+	require.Equal(t, "content_hash=sha256:abc123", dispatcher.task.Params)
+	require.NotNil(t, dispatcher.task.PreviousStatus)
+}
+
+type capturingDispatcher struct {
+	task *coordinatorv1.Task
+}
+
+func (d *capturingDispatcher) Dispatch(_ context.Context, task *coordinatorv1.Task) error {
+	d.task = task
+	return nil
+}
+
+func (d *capturingDispatcher) Cleanup(context.Context) error {
+	return nil
+}
+
+func (d *capturingDispatcher) GetDAGRunStatus(context.Context, string, string, *exec1.DAGRunRef) (*coordinatorv1.GetDAGRunStatusResponse, error) {
+	return nil, nil
+}
+
+func (d *capturingDispatcher) RequestCancel(context.Context, string, string, *exec1.DAGRunRef) error {
+	return nil
 }


### PR DESCRIPTION
## Summary
- add scheduler unit coverage that distributed queue dispatch includes queued runtime params in coordinator tasks
- add shared-nothing integration coverage for queued root DAG runtime params reaching worker execution
- extend the distributed integration fixture with a params-aware enqueue helper

## Testing
- go test ./internal/service/scheduler -run TestDAGExecutor_DistributedRetryPassesQueuedParams -count=1
- go test ./internal/service/scheduler -run TestDAGExecutor -count=1
- go test ./internal/intg/distr -run TestParams -count=1
- go test ./internal/intg/distr -run 'TestExecution_QueueLifecycle/queueItemRemovedAfterSuccess' -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify queued runtime params propagate end-to-end in distributed runs, including retries. Adds a params-aware enqueue helper and asserts params flow into coordinator tasks, DAGRun status, and worker outputs.

<sup>Written for commit 5b7a51d383b2c86e56ddc4e35a8a275f2fd88cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for distributed DAG execution, including parameterized queue operations and runtime parameter handling in queued runs.
  * Added distributed retry test to verify parameters are correctly preserved through retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->