### PR TITLE
fix(compose): keep DAG mounts writable

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -14,3 +14,5 @@ Run examples from the repository root:
 ```bash
 docker compose -f deploy/docker/compose.minimal.yaml up -d
 ```
+
+The Compose stacks mount `deploy/docker/dags/` read-write so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.

--- a/deploy/docker/compose.minimal.yaml
+++ b/deploy/docker/compose.minimal.yaml
@@ -36,10 +36,10 @@ services:
       # - PUID=1000 # optional. default is 1000
       # - PGID=1000 # optional. default is 1000
 
-    # Dev-friendly mounts (persistent data + read-only DAGs)
+    # Dev-friendly mounts (persistent data + writable DAGs)
     volumes:
       - dagu-data:/var/lib/dagu
-      - ./dags:/var/lib/dagu/dags:ro
+      - ./dags:/var/lib/dagu/dags
       # For Docker in Docker (DinD) support, mount the host Docker socket:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/deploy/docker/compose.prod.yaml
+++ b/deploy/docker/compose.prod.yaml
@@ -48,7 +48,7 @@ services:
       - "50055:50055"
     volumes:
       - dagu-data:/var/lib/dagu
-      - ./dags:/var/lib/dagu/dags:ro
+      - ./dags:/var/lib/dagu/dags
     networks: [dagu-net]
 
   # Dagu scheduler service (reads DAGs and enqueues runs)
@@ -69,7 +69,7 @@ services:
       - "8090:8090" # Scheduler health
     volumes:
       - dagu-data:/var/lib/dagu
-      - ./dags:/var/lib/dagu/dags:ro
+      - ./dags:/var/lib/dagu/dags
     networks: [dagu-net]
 
   # Dagu web UI / API server
@@ -97,7 +97,7 @@ services:
       - "8080:8080"
     volumes:
       - dagu-data:/var/lib/dagu
-      - ./dags:/var/lib/dagu/dags:ro
+      - ./dags:/var/lib/dagu/dags
     networks: [dagu-net]
 
   # Dagu worker (polls coordinator and executes tasks)
@@ -116,7 +116,7 @@ services:
     volumes:
       - dagu-data:/var/lib/dagu
       # Workers typically don't need DAG definitions, but sharing is harmless
-      - ./dags:/var/lib/dagu/dags:ro
+      - ./dags:/var/lib/dagu/dags
     networks: [dagu-net]
 
   # Grafana: visualize Prometheus metrics

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -110,6 +110,26 @@ func TestDockerComposeEntrypointOverridesPreserveTini(t *testing.T) {
 	require.Contains(t, content, `entrypoint: ["/usr/local/bin/tini", "-g", "--"]`, "compose.minimal.yaml must keep tini as PID 1 when overriding the image entrypoint")
 }
 
+func TestDockerComposeDAGMountsStayWritable(t *testing.T) {
+	t.Parallel()
+
+	files := []string{
+		"deploy/docker/compose.minimal.yaml",
+		"deploy/docker/compose.prod.yaml",
+	}
+
+	root := repoRoot(t)
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+
+			content := readFile(t, filepath.Join(root, file))
+			require.NotContains(t, content, "./dags:/var/lib/dagu/dags:ro", "%s must keep the DAG directory writable for first-run seeding and DAG edits", file)
+			require.Contains(t, content, "./dags:/var/lib/dagu/dags", "%s must mount the local DAG directory", file)
+		})
+	}
+}
+
 func repoRoot(t *testing.T) string {
 	t.Helper()
 

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -113,19 +113,20 @@ func TestDockerComposeEntrypointOverridesPreserveTini(t *testing.T) {
 func TestDockerComposeDAGMountsStayWritable(t *testing.T) {
 	t.Parallel()
 
-	files := []string{
-		"deploy/docker/compose.minimal.yaml",
-		"deploy/docker/compose.prod.yaml",
+	expectedMountCounts := map[string]int{
+		"deploy/docker/compose.minimal.yaml": 1,
+		"deploy/docker/compose.prod.yaml":    4,
 	}
 
 	root := repoRoot(t)
-	for _, file := range files {
+	for file, expectedCount := range expectedMountCounts {
 		t.Run(file, func(t *testing.T) {
 			t.Parallel()
 
 			content := readFile(t, filepath.Join(root, file))
 			require.NotContains(t, content, "./dags:/var/lib/dagu/dags:ro", "%s must keep the DAG directory writable for first-run seeding and DAG edits", file)
 			require.Contains(t, content, "./dags:/var/lib/dagu/dags", "%s must mount the local DAG directory", file)
+			require.Equal(t, expectedCount, strings.Count(content, "./dags:/var/lib/dagu/dags"), "%s must keep DAG mounts on all expected services", file)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- keep Docker Compose DAG bind mounts writable so Dagu can seed first-run examples and save DAG edits
- document when to opt into read-only DAG sources
- add packaging regression coverage for Compose DAG mount writability

## Testing
- go test ./internal/packaging -count=1
- docker compose -f deploy/docker/compose.minimal.yaml config
- docker compose -f deploy/docker/compose.prod.yaml config
- live Docker Compose smoke with a local image: verified Tini as PID 1, writable DAG mount, seeded examples/souls, HTTP 200, no read-only filesystem errors, and no zombie processes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Docker Compose DAG mounts writable so Dagu can seed first-run examples and persist DAG edits.

- Bug Fixes
  - Removed :ro from ./dags mounts in deploy/docker/compose.minimal.yaml and deploy/docker/compose.prod.yaml.
  - Documented when to opt into read-only DAG sources in deploy/docker/README.md.
  - Added regression test that forbids :ro and verifies expected mount counts (1 in minimal, 4 in prod) across services.

<sup>Written for commit 65e631b49e075b3c9157b753a3ed1b816b298ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Docker deployment documentation to clarify DAG file mounting and persistence behavior.

* **Configuration Changes**
  * Updated Docker Compose configurations to mount DAG directories as writable by default, enabling persistent DAG edits across container restarts.

* **Tests**
  * Added automated verification tests for DAG mount persistence in Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->