### PR TITLE
refactor: move local subworkflows behind runner

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -594,7 +594,10 @@ func (c *Context) SubWorkflowRunnerFactory() func(context.Context) (runtimeexec.
 		if err != nil {
 			return nil, err
 		}
-		return subflow.New(dispatcher, c.Config.DefaultExecMode), nil
+		return subflow.NewRouter(
+			subflow.New(dispatcher, c.Config.DefaultExecMode),
+			subflow.NewLocalCLI(),
+		), nil
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -210,7 +210,10 @@ func (e *Engine) subWorkflowRunnerFactory() func(context.Context) (runtimeexec.S
 		if err != nil {
 			return nil, err
 		}
-		return subflow.New(dispatcher, configExecutionMode(e.defaultMode)), nil
+		return subflow.NewRouter(
+			subflow.New(dispatcher, configExecutionMode(e.defaultMode)),
+			subflow.NewLocalCLI(),
+		), nil
 	}
 }
 

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -187,7 +187,7 @@ type Agent struct {
 	// When nil, status is written to local filesystem via DAGRunAttempt.
 	statusPusher StatusPusher
 
-	// subWorkflowRunnerFactory creates a runner for distributed child workflows.
+	// subWorkflowRunnerFactory creates a runner for child workflows.
 	subWorkflowRunnerFactory SubWorkflowRunnerFactory
 
 	// logWriterFactory is used to create log writers for step output.
@@ -259,7 +259,7 @@ func defaultSocketServerFactory(addr string, handlerFunc sock.HTTPHandlerFunc) (
 // ArtifactFinalizer uploads or persists artifacts before the final terminal status is written.
 type ArtifactFinalizer = runtime.ArtifactFinalizer
 
-// SubWorkflowRunnerFactory creates a runner for distributed child workflows.
+// SubWorkflowRunnerFactory creates a runner for child workflows.
 type SubWorkflowRunnerFactory func(ctx context.Context) (runtimeexec.SubWorkflowRunner, error)
 
 // Options is the configuration for the Agent.
@@ -288,7 +288,7 @@ type Options struct {
 	// StatusPusher is used to push status updates to a remote coordinator.
 	// When nil, status is written to local filesystem via DAGRunAttempt.
 	StatusPusher StatusPusher
-	// SubWorkflowRunnerFactory creates a runner for distributed child workflows.
+	// SubWorkflowRunnerFactory creates a runner for child workflows.
 	SubWorkflowRunnerFactory SubWorkflowRunnerFactory
 	// LogWriterFactory is used to create log writers for step output.
 	// When nil, logs are written to local filesystem.

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -7,32 +7,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
 	"maps"
 	"os"
-	osexec "os/exec"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
-	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
-	"github.com/dagucloud/dagu/internal/cmn/telemetry"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
-	dagutools "github.com/dagucloud/dagu/internal/tools"
 )
 
 var (
-	errSubDAGCancelled  = errors.New("sub DAG execution cancelled")
-	errDAGRunIDNotSet   = errors.New("DAG run ID is not set")
-	errRootDAGRunNotSet = errors.New("root DAG run ID is not set")
+	errSubDAGCancelled       = errors.New("sub DAG execution cancelled")
+	errDAGRunIDNotSet        = errors.New("DAG run ID is not set")
+	errRootDAGRunNotSet      = errors.New("root DAG run ID is not set")
+	errSubWorkflowRunnerNone = errors.New("sub-workflow runner is not configured")
 )
 
 // SubDAGExecutor is a helper for executing sub DAGs.
@@ -55,12 +48,9 @@ type SubDAGExecutor struct {
 	// workspaceSeed carries immutable action source content for action sub-DAGs.
 	workspaceSeed *WorkspaceSeed
 
-	// Process tracking for ALL executions
-	mu                 sync.Mutex
-	processes          map[string]*cmdutil.ManagedProcess // runID -> local process
-	distributedRuns    map[string]bool                    // runID -> true for distributed runs
-	distributedCancels map[string]context.CancelFunc      // runID -> cancel active runner wait
-	dagCtx             exec.Context                       // for DB access when cancelling distributed runs
+	mu         sync.Mutex
+	activeRuns map[string]context.CancelFunc // runID -> cancel active runner wait
+	dagCtx     exec.Context
 
 	// killed should be closed when Kill is called
 	killed     chan struct{}
@@ -128,86 +118,13 @@ func NewSubDAGExecutorForDAG(ctx context.Context, dag *core.DAG) (*SubDAGExecuto
 func newSubDAGExecutor(ctx context.Context, rCtx exec.Context, dag *core.DAG, tempFile string) *SubDAGExecutor {
 	subWorkflowRunner, _ := SubWorkflowRunnerFromContext(ctx)
 	return &SubDAGExecutor{
-		DAG:                dag,
-		tempFile:           tempFile,
-		subWorkflowRunner:  subWorkflowRunner,
-		processes:          make(map[string]*cmdutil.ManagedProcess),
-		distributedRuns:    make(map[string]bool),
-		distributedCancels: make(map[string]context.CancelFunc),
-		dagCtx:             rCtx,
-		killed:             make(chan struct{}),
+		DAG:               dag,
+		tempFile:          tempFile,
+		subWorkflowRunner: subWorkflowRunner,
+		activeRuns:        make(map[string]context.CancelFunc),
+		dagCtx:            rCtx,
+		killed:            make(chan struct{}),
 	}
-}
-
-// buildCommand builds the command to execute the sub DAG.
-func (e *SubDAGExecutor) buildCommand(ctx context.Context, runParams RunParams, workDir string) (*osexec.Cmd, error) {
-	if runParams.RunID == "" {
-		return nil, errDAGRunIDNotSet
-	}
-
-	rCtx := exec.GetContext(ctx)
-	if rCtx.RootDAGRun.Zero() {
-		return nil, errRootDAGRunNotSet
-	}
-
-	args := []string{
-		"start",
-		fmt.Sprintf("--root=%s", rCtx.RootDAGRun.String()),
-		fmt.Sprintf("--parent=%s", rCtx.DAGRunRef().String()),
-		fmt.Sprintf("--run-id=%s", runParams.RunID),
-		"--trigger-type=subdag",
-	}
-	if workDir != "" {
-		args = append(args, fmt.Sprintf("--default-working-dir=%s", workDir))
-	}
-
-	target := e.DAG.Location
-	if e.workspaceSeed != nil && workDir != "" {
-		target = filepath.Join(workDir, filepath.FromSlash(e.workspaceSeed.Descriptor.DAGPath))
-	}
-
-	if runParams.Params != "" {
-		cmd, err := e.newLocalCLICommand(ctx, workDir, args, target, "--", runParams.Params)
-		if err != nil {
-			return nil, err
-		}
-		return e.injectTraceContext(ctx, cmd), nil
-	}
-
-	cmd, err := e.newLocalCLICommand(ctx, workDir, args, target)
-	if err != nil {
-		return nil, err
-	}
-	return e.injectTraceContext(ctx, cmd), nil
-}
-
-func (e *SubDAGExecutor) buildRetryCommand(
-	ctx context.Context,
-	runParams RunParams,
-	stepName string,
-	workDir string,
-) (*osexec.Cmd, error) {
-	if runParams.RunID == "" {
-		return nil, errDAGRunIDNotSet
-	}
-
-	rCtx := exec.GetContext(ctx)
-	if rCtx.RootDAGRun.Zero() {
-		return nil, errRootDAGRunNotSet
-	}
-
-	args := []string{
-		"retry",
-		fmt.Sprintf("--run-id=%s", runParams.RunID),
-		fmt.Sprintf("--root=%s", rCtx.RootDAGRun.String()),
-	}
-	if workDir != "" {
-		args = append(args, fmt.Sprintf("--default-working-dir=%s", workDir))
-	}
-	if stepName != "" {
-		args = append(args, fmt.Sprintf("--step=%s", stepName))
-	}
-	return e.newLocalCLICommand(ctx, workDir, args, e.DAG.Location)
 }
 
 func (e *SubDAGExecutor) SetExternalStepRetry(enabled bool) {
@@ -249,111 +166,6 @@ func cloneWorkerSelector(selector map[string]string) map[string]string {
 	return clone
 }
 
-func (e *SubDAGExecutor) newLocalCLICommand(
-	ctx context.Context,
-	workDir string,
-	args []string,
-	target string,
-	trailingArgs ...string,
-) (*osexec.Cmd, error) {
-	executable, err := executablePath(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find executable path: %w", err)
-	}
-
-	fullArgs := append([]string{}, args...)
-	if configFile := config.ConfigFileUsed(ctx); configFile != "" {
-		fullArgs = append(fullArgs, "--config", configFile)
-	}
-	fullArgs = append(fullArgs, target)
-	fullArgs = append(fullArgs, trailingArgs...)
-
-	cmd := osexec.CommandContext(ctx, executable, fullArgs...) // nolint:gosec
-	cmd.Dir = workDir
-
-	rCtx := exec.GetContext(ctx)
-	cmd.Env = localCLIEnv(rCtx)
-	if e.externalStepRetry {
-		cmd.Env = append(cmd.Env, exec.EnvKeyExternalStepRetry+"=1")
-	}
-
-	cmdutil.SetupCommand(cmd)
-	return cmd, nil
-}
-
-func (e *SubDAGExecutor) injectTraceContext(ctx context.Context, cmd *osexec.Cmd) *osexec.Cmd {
-	logCtx := logger.WithValues(ctx, tag.DAG(e.DAG.Name))
-	traceEnvVars := extractTraceContext(ctx)
-	if len(traceEnvVars) > 0 {
-		cmd.Env = append(cmd.Env, traceEnvVars...)
-		logger.Debug(logCtx, "Injecting trace context into sub DAG",
-			slog.Any("trace-env-vars", traceEnvVars),
-		)
-	} else {
-		logger.Debug(logCtx, "No trace context to inject into sub DAG")
-	}
-	return cmd
-}
-
-func localCLIEnv(rCtx exec.Context) []string {
-	env := baseEnvForLocalCLI(rCtx)
-	return append(env, inheritedEnvForLocalCLI(rCtx.AllEnvs())...)
-}
-
-func baseEnvForLocalCLI(rCtx exec.Context) []string {
-	if rCtx.BaseEnv != nil {
-		env := rCtx.BaseEnv.AsSlice()
-		if len(env) > 0 {
-			return env
-		}
-	}
-	return os.Environ()
-}
-
-func inheritedEnvForLocalCLI(envs []string) []string {
-	if !hasDAGToolsEnv(envs) {
-		return envs
-	}
-	filtered := make([]string, 0, len(envs))
-	for _, env := range envs {
-		key, _, ok := strings.Cut(env, "=")
-		if ok && isDAGToolsEnvKey(key) {
-			continue
-		}
-		filtered = append(filtered, env)
-	}
-	return filtered
-}
-
-func hasDAGToolsEnv(envs []string) bool {
-	for _, env := range envs {
-		key, _, ok := strings.Cut(env, "=")
-		if ok && strings.EqualFold(key, dagutools.EnvManifest) {
-			return true
-		}
-	}
-	return false
-}
-
-func isDAGToolsEnvKey(key string) bool {
-	for _, candidate := range []string{
-		"PATH",
-		"AQUA_ROOT_DIR",
-		"AQUA_CONFIG",
-		"AQUA_DISABLE_LAZY_INSTALL",
-		"AQUA_CHECKSUM",
-		"AQUA_REQUIRE_CHECKSUM",
-		"AQUA_ENFORCE_CHECKSUM",
-		"AQUA_ENFORCE_REQUIRE_CHECKSUM",
-		dagutools.EnvManifest,
-	} {
-		if strings.EqualFold(key, candidate) {
-			return true
-		}
-	}
-	return false
-}
-
 // Cleanup removes any temporary files created for local DAGs.
 // This should be called after the sub DAG execution is complete.
 func (e *SubDAGExecutor) Cleanup(ctx context.Context) error {
@@ -378,34 +190,23 @@ func (e *SubDAGExecutor) Execute(ctx context.Context, runParams RunParams, workD
 	ctx = logger.WithValues(ctx, tag.SubDAG(e.DAG.Name), tag.SubRunID(runParams.RunID))
 
 	req := e.subWorkflowRequest(ctx, runParams, workDir)
-	if e.shouldRunWithSubWorkflowRunner(ctx, req) {
-		logger.Info(ctx, "Executing sub DAG via injected sub-workflow runner")
-
-		runCtx, cancel := context.WithCancel(ctx)
-		e.trackDistributedRun(runParams.RunID, cancel)
-		defer e.clearDistributedCancel(runParams.RunID)
-
-		if err := e.cancellationErr(ctx); err != nil {
-			return nil, err
-		}
-		return e.subWorkflowRunner.Run(runCtx, req)
-	}
-
-	if e.workspaceSeed != nil {
-		var cleanup func()
-		var err error
-		workDir, cleanup, err = e.materializeLocalWorkspace(runParams)
-		if err != nil {
-			return nil, err
-		}
-		defer cleanup()
-	}
-
-	cmd, err := e.buildCommand(ctx, runParams, workDir)
-	if err != nil {
+	if err := validateSubWorkflowRequest(req); err != nil {
 		return nil, err
 	}
-	return e.runLocalCommand(ctx, runParams.RunID, cmd)
+	if !e.shouldRunWithSubWorkflowRunner(ctx, req) {
+		return nil, errSubWorkflowRunnerNone
+	}
+
+	logger.Info(ctx, "Executing sub DAG via injected sub-workflow runner")
+
+	runCtx, cancel := context.WithCancel(ctx)
+	e.trackRun(runParams.RunID, cancel)
+	defer e.clearRun(runParams.RunID)
+
+	if err := e.cancellationErr(ctx); err != nil {
+		return nil, err
+	}
+	return e.subWorkflowRunner.Run(runCtx, req)
 }
 
 // Retry executes a parent-managed step retry for a previously started sub DAG.
@@ -413,27 +214,36 @@ func (e *SubDAGExecutor) Retry(ctx context.Context, runParams RunParams, stepNam
 	ctx = logger.WithValues(ctx, tag.SubDAG(e.DAG.Name), tag.SubRunID(runParams.RunID))
 
 	req := e.subWorkflowRequest(ctx, runParams, workDir)
-	if e.shouldRunWithSubWorkflowRunner(ctx, req) {
-		logger.Info(ctx, "Retrying sub DAG via injected sub-workflow runner", tag.Step(stepName))
-
-		runCtx, cancel := context.WithCancel(ctx)
-		e.trackDistributedRun(runParams.RunID, cancel)
-		defer e.clearDistributedCancel(runParams.RunID)
-
-		if err := e.cancellationErr(ctx); err != nil {
-			return nil, err
-		}
-		return e.subWorkflowRunner.Retry(runCtx, SubWorkflowRetryRequest{
-			SubWorkflowRequest: req,
-			StepName:           stepName,
-		})
-	}
-
-	cmd, err := e.buildRetryCommand(ctx, runParams, stepName, workDir)
-	if err != nil {
+	if err := validateSubWorkflowRequest(req); err != nil {
 		return nil, err
 	}
-	return e.runLocalCommand(ctx, runParams.RunID, cmd)
+	if !e.shouldRunWithSubWorkflowRunner(ctx, req) {
+		return nil, errSubWorkflowRunnerNone
+	}
+
+	logger.Info(ctx, "Retrying sub DAG via injected sub-workflow runner", tag.Step(stepName))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	e.trackRun(runParams.RunID, cancel)
+	defer e.clearRun(runParams.RunID)
+
+	if err := e.cancellationErr(ctx); err != nil {
+		return nil, err
+	}
+	return e.subWorkflowRunner.Retry(runCtx, SubWorkflowRetryRequest{
+		SubWorkflowRequest: req,
+		StepName:           stepName,
+	})
+}
+
+func validateSubWorkflowRequest(req SubWorkflowRequest) error {
+	if req.RunID == "" {
+		return errDAGRunIDNotSet
+	}
+	if req.RootDAGRun.Zero() {
+		return errRootDAGRunNotSet
+	}
+	return nil
 }
 
 func (e *SubDAGExecutor) subWorkflowRequest(ctx context.Context, runParams RunParams, workDir string) SubWorkflowRequest {
@@ -462,108 +272,24 @@ func (e *SubDAGExecutor) subWorkflowRequest(ctx context.Context, runParams RunPa
 	return req
 }
 
-func (e *SubDAGExecutor) trackDistributedRun(runID string, cancel context.CancelFunc) {
+func (e *SubDAGExecutor) trackRun(runID string, cancel context.CancelFunc) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.distributedRuns == nil {
-		e.distributedRuns = make(map[string]bool)
+	if e.activeRuns == nil {
+		e.activeRuns = make(map[string]context.CancelFunc)
 	}
-	if e.distributedCancels == nil {
-		e.distributedCancels = make(map[string]context.CancelFunc)
-	}
-	e.distributedRuns[runID] = true
-	e.distributedCancels[runID] = cancel
+	e.activeRuns[runID] = cancel
 }
 
-func (e *SubDAGExecutor) clearDistributedCancel(runID string) {
+func (e *SubDAGExecutor) clearRun(runID string) {
 	e.mu.Lock()
-	cancel := e.distributedCancels[runID]
-	delete(e.distributedCancels, runID)
-	delete(e.distributedRuns, runID)
+	cancel := e.activeRuns[runID]
+	delete(e.activeRuns, runID)
 	e.mu.Unlock()
 
 	if cancel != nil {
 		cancel()
 	}
-}
-
-func (e *SubDAGExecutor) runLocalCommand(ctx context.Context, runID string, cmd *osexec.Cmd) (*exec.RunStatus, error) {
-	// Discard subprocess output (logging is handled internally by the sub-DAG)
-	cmd.Stdout = io.Discard
-	stderrTail := NewTailWriter(io.Discard, 4096)
-	cmd.Stderr = stderrTail
-
-	// Ensure we clear command reference when done
-	defer func() {
-		e.mu.Lock()
-		delete(e.processes, runID)
-		e.mu.Unlock()
-	}()
-
-	logger.Info(ctx, "Executing sub DAG locally")
-
-	process, err := cmdutil.StartManagedProcess(cmd)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start sub dag-run: %w", err)
-	}
-	defer func() { _ = process.Release() }()
-
-	e.mu.Lock()
-	e.processes[runID] = process
-	e.mu.Unlock()
-
-	waitErr := process.Wait()
-	if waitErr != nil {
-		logger.Error(ctx, "Sub DAG execution returned error", tag.Error(waitErr))
-	}
-
-	// Check for cancellation before retrieving results
-	select {
-	case <-e.killed:
-		return nil, errSubDAGCancelled
-	case <-ctx.Done():
-		return nil, errors.Join(errSubDAGCancelled, ctx.Err())
-	default:
-	}
-
-	rCtx := exec.GetContext(ctx)
-	result, resultErr := rCtx.DB.GetSubDAGRunStatus(ctx, runID, rCtx.RootDAGRun)
-	if resultErr != nil {
-		errMsg := fmt.Sprintf("sub dag-run %q failed and wrote no status", runID)
-		if waitErr != nil {
-			errMsg += fmt.Sprintf(" (process: %v)", waitErr)
-		}
-		if tail := strings.TrimSpace(stderrTail.Tail()); tail != "" {
-			errMsg += fmt.Sprintf("; stderr: %s", tail)
-		}
-		return nil, fmt.Errorf("%s: %w", errMsg, resultErr)
-	}
-
-	if result.Status.IsSuccess() {
-		logger.Info(ctx, "Sub DAG completed successfully")
-		return result, nil
-	}
-
-	return result, waitErr
-}
-
-func (e *SubDAGExecutor) materializeLocalWorkspace(runParams RunParams) (string, func(), error) {
-	if e.workspaceSeed == nil {
-		return "", func() {}, nil
-	}
-	tmp, err := os.MkdirTemp("", "dagu-action-workspace-*")
-	if err != nil {
-		return "", nil, fmt.Errorf("create local action workspace: %w", err)
-	}
-	cleanup := func() {
-		_ = fileutil.RemoveAll(tmp)
-	}
-	dest := filepath.Join(tmp, "workspace")
-	if err := workspacebundle.Extract(e.workspaceSeed.Archive, dest, e.workspaceSeed.Descriptor, workspacebundle.DefaultLimits()); err != nil {
-		cleanup()
-		return "", nil, fmt.Errorf("materialize action workspace for run %q: %w", runParams.RunID, err)
-	}
-	return dest, cleanup, nil
 }
 
 func (e *SubDAGExecutor) cancellationErr(ctx context.Context) error {
@@ -578,36 +304,24 @@ func (e *SubDAGExecutor) cancellationErr(ctx context.Context) error {
 	return nil
 }
 
-// Kill terminates all running sub DAG processes (both local and distributed)
+// Kill cancels all running sub DAG executions.
 func (e *SubDAGExecutor) Kill(sig os.Signal) error {
 	return e.Stop(cmdutil.TerminationFromSignal(sig))
 }
 
-// Stop terminates all running sub DAG processes (both local and distributed)
-// according to the requested lifecycle intent.
+// Stop cancels all running sub DAG executions according to the requested lifecycle intent.
 func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
-	type distributedRun struct {
+	type activeRun struct {
 		runID  string
 		cancel context.CancelFunc
 	}
-	type localProcess struct {
-		runID   string
-		process *cmdutil.ManagedProcess
-	}
 
 	e.mu.Lock()
-	distributedRuns := make([]distributedRun, 0, len(e.distributedRuns))
-	for runID := range e.distributedRuns {
-		distributedRuns = append(distributedRuns, distributedRun{
+	activeRuns := make([]activeRun, 0, len(e.activeRuns))
+	for runID, cancel := range e.activeRuns {
+		activeRuns = append(activeRuns, activeRun{
 			runID:  runID,
-			cancel: e.distributedCancels[runID],
-		})
-	}
-	processes := make([]localProcess, 0, len(e.processes))
-	for runID, process := range e.processes {
-		processes = append(processes, localProcess{
-			runID:   runID,
-			process: process,
+			cancel: cancel,
 		})
 	}
 	e.mu.Unlock()
@@ -616,71 +330,45 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Cancel distributed runs
-	for _, run := range distributedRuns {
-		if run.cancel != nil {
-			run.cancel()
-		}
+	for _, run := range activeRuns {
 		if e.subWorkflowRunner != nil {
 			if err := e.subWorkflowRunner.Cancel(ctx, SubWorkflowCancelRequest{
 				DAG:        e.DAG,
 				RootDAGRun: e.dagCtx.RootDAGRun,
 				RunID:      run.runID,
+				Intent:     intent,
 			}); err != nil {
 				errs = append(errs, err)
-				logger.Warn(ctx, "Failed to request distributed sub DAG cancellation",
+				logger.Warn(ctx, "Failed to request sub DAG cancellation",
 					tag.RunID(run.runID),
 					tag.DAG(e.DAG.Name),
 					tag.Error(err),
 				)
 			} else {
-				logger.Info(ctx, "Requested distributed sub DAG cancellation",
+				logger.Info(ctx, "Requested sub DAG cancellation",
 					tag.RunID(run.runID),
 					tag.DAG(e.DAG.Name),
 				)
 			}
-			continue
-		}
-
-		if e.dagCtx.DB != nil {
+		} else if e.dagCtx.DB != nil {
 			if err := e.dagCtx.DB.RequestChildCancel(ctx, run.runID, e.dagCtx.RootDAGRun); err != nil {
-				if errors.Is(err, exec.ErrDAGRunIDNotFound) {
-					continue
+				if !errors.Is(err, exec.ErrDAGRunIDNotFound) {
+					errs = append(errs, err)
+					logger.Warn(ctx, "Failed to request child cancel via local DB",
+						tag.RunID(run.runID),
+						tag.DAG(e.DAG.Name),
+						tag.Error(err),
+					)
 				}
-				errs = append(errs, err)
-				logger.Warn(ctx, "Failed to request child cancel via local DB",
-					tag.RunID(run.runID),
-					tag.DAG(e.DAG.Name),
-					tag.Error(err),
-				)
 			} else {
-				logger.Info(ctx, "Requested distributed sub DAG cancellation via local DB",
+				logger.Info(ctx, "Requested sub DAG cancellation via local DB",
 					tag.RunID(run.runID),
 					tag.DAG(e.DAG.Name),
 				)
 			}
 		}
-	}
-
-	// Kill local processes
-	for _, local := range processes {
-		if local.process == nil {
-			continue
-		}
-		if _, err := local.process.Stop(cmdutil.StopRequest{Intent: intent}); err != nil {
-			errs = append(errs, err)
-			logger.Warn(ctx, "Failed to stop local sub DAG process",
-				tag.RunID(local.runID),
-				tag.DAG(e.DAG.Name),
-				tag.Error(err),
-			)
-		} else {
-			logger.Info(ctx, "Requested stop for local sub DAG process",
-				tag.RunID(local.runID),
-				tag.DAG(e.DAG.Name),
-				slog.String("stop-mode", string(intent.Mode)),
-				tag.Signal(intent.SignalName()),
-			)
+		if run.cancel != nil {
+			run.cancel()
 		}
 	}
 
@@ -689,25 +377,4 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	})
 
 	return errors.Join(errs...)
-}
-
-// executablePath returns the path to the dagu executable.
-func executablePath(ctx context.Context) (string, error) {
-	if cfg := config.GetConfig(ctx); cfg != nil && cfg.Paths.Executable != "" {
-		return cfg.Paths.Executable, nil
-	}
-	if path := os.Getenv("DAGU_EXECUTABLE"); path != "" {
-		return path, nil
-	}
-	executable, err := os.Executable()
-	if err != nil {
-		return "", fmt.Errorf("failed to get executable path: %w", err)
-	}
-	return executable, nil
-}
-
-// extractTraceContext extracts OpenTelemetry trace context from the current context
-// and returns it as environment variables for child processes.
-func extractTraceContext(ctx context.Context) []string {
-	return telemetry.InjectTraceContext(ctx)
 }

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -311,6 +311,10 @@ func (e *SubDAGExecutor) Kill(sig os.Signal) error {
 
 // Stop cancels all running sub DAG executions according to the requested lifecycle intent.
 func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
+	e.cancelOnce.Do(func() {
+		close(e.killed)
+	})
+
 	type activeRun struct {
 		runID  string
 		cancel context.CancelFunc
@@ -371,10 +375,6 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 			run.cancel()
 		}
 	}
-
-	e.cancelOnce.Do(func() {
-		close(e.killed)
-	})
 
 	return errors.Join(errs...)
 }

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	errSubDAGCancelled       = errors.New("sub DAG execution cancelled")
-	errDAGRunIDNotSet        = errors.New("DAG run ID is not set")
-	errRootDAGRunNotSet      = errors.New("root DAG run ID is not set")
-	errSubWorkflowRunnerNone = errors.New("sub-workflow runner is not configured")
+	errSubDAGCancelled     = errors.New("sub DAG execution cancelled")
+	errDAGRunIDNotSet      = errors.New("DAG run ID is not set")
+	errRootDAGRunNotSet    = errors.New("root DAG run ID is not set")
+	errNoSubWorkflowRunner = errors.New("no sub-workflow runner accepted request")
 )
 
 // SubDAGExecutor is a helper for executing sub DAGs.
@@ -194,7 +194,7 @@ func (e *SubDAGExecutor) Execute(ctx context.Context, runParams RunParams, workD
 		return nil, err
 	}
 	if !e.shouldRunWithSubWorkflowRunner(ctx, req) {
-		return nil, errSubWorkflowRunnerNone
+		return nil, errNoSubWorkflowRunner
 	}
 
 	logger.Info(ctx, "Executing sub DAG via injected sub-workflow runner")
@@ -218,7 +218,7 @@ func (e *SubDAGExecutor) Retry(ctx context.Context, runParams RunParams, stepNam
 		return nil, err
 	}
 	if !e.shouldRunWithSubWorkflowRunner(ctx, req) {
-		return nil, errSubWorkflowRunnerNone
+		return nil, errNoSubWorkflowRunner
 	}
 
 	logger.Info(ctx, "Retrying sub DAG via injected sub-workflow runner", tag.Step(stepName))
@@ -336,7 +336,7 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 				DAG:        e.DAG,
 				RootDAGRun: e.dagCtx.RootDAGRun,
 				RunID:      run.runID,
-				Intent:     intent,
+				Intent:     subWorkflowCancelIntent(intent),
 			}); err != nil {
 				errs = append(errs, err)
 				logger.Warn(ctx, "Failed to request sub DAG cancellation",
@@ -377,4 +377,18 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 	})
 
 	return errors.Join(errs...)
+}
+
+func subWorkflowCancelIntent(intent cmdutil.TerminationIntent) SubWorkflowCancelIntent {
+	if intent.Mode == "" {
+		intent = cmdutil.TerminationFromSignal(intent.Signal)
+	}
+	mode := SubWorkflowCancelModeGraceful
+	if intent.IsForce() {
+		mode = SubWorkflowCancelModeForce
+	}
+	return SubWorkflowCancelIntent{
+		Mode:   mode,
+		Signal: intent.Signal,
+	}
 }

--- a/internal/runtime/executor/dag_runner_test.go
+++ b/internal/runtime/executor/dag_runner_test.go
@@ -6,32 +6,15 @@ package executor
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
-	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
-	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	exec1 "github.com/dagucloud/dagu/internal/core/exec"
-	dagutools "github.com/dagucloud/dagu/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func envSliceToMap(envs []string) map[string]string {
-	result := make(map[string]string, len(envs))
-	for _, env := range envs {
-		key, value, ok := strings.Cut(env, "=")
-		if ok {
-			result[key] = value
-		}
-	}
-	return result
-}
 
 func TestNewSubDAGExecutor_LocalDAG(t *testing.T) {
 	t.Parallel()
@@ -168,107 +151,7 @@ func TestNewSubDAGExecutor_NotFound(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
-func TestBuildCommand(t *testing.T) {
-	t.Parallel()
-
-	// Create a context with environment
-	ctx := context.Background()
-
-	// Set up the DAG context
-	mockDB := new(mockDatabase)
-	baseEnv := config.NewBaseEnv(nil)
-	dagCtx := exec1.Context{
-		DAG:        &core.DAG{Name: "parent"},
-		DB:         mockDB,
-		RootDAGRun: exec1.NewDAGRunRef("parent", "root-123"),
-		DAGRunID:   "parent-456",
-		BaseEnv:    &baseEnv,
-	}
-	ctx = exec1.WithContext(ctx, dagCtx)
-
-	// Create executor
-	executor := &SubDAGExecutor{
-		DAG: &core.DAG{
-			Name:     "test-child",
-			Location: "/path/to/test.yaml",
-		},
-		killed: make(chan struct{}),
-	}
-
-	// Build command
-	runParams := RunParams{
-		RunID:  "child-789",
-		Params: "param1=value1 param2=value2",
-	}
-
-	cmd, err := executor.buildCommand(ctx, runParams, "/work/dir")
-	require.NoError(t, err)
-	require.NotNil(t, cmd)
-
-	// Verify command properties
-	assert.Equal(t, "/work/dir", cmd.Dir)
-
-	// Verify args
-	args := cmd.Args
-	assert.Contains(t, args, "start")
-	assert.Contains(t, args, "--root=parent:root-123")
-	assert.Contains(t, args, "--parent=parent:parent-456")
-	assert.Contains(t, args, "--run-id=child-789")
-	assert.Contains(t, args, "/path/to/test.yaml")
-	assert.Contains(t, args, "--")
-	assert.Contains(t, args, "param1=value1 param2=value2")
-}
-
-func TestBuildCommandDoesNotInheritParentDAGToolsEnv(t *testing.T) {
-	t.Parallel()
-
-	baseEnv := config.NewBaseEnv([]string{"PATH=/usr/bin"})
-	parentDAG := &core.DAG{
-		Name: "parent",
-		Tools: &core.ToolConfig{
-			Provider: "aqua",
-			Packages: []core.ToolPackage{{
-				Package: "jqlang/jq",
-				Version: "jq-1.7.1",
-			}},
-		},
-	}
-	ctx := config.WithConfig(context.Background(), &config.Config{
-		Core: config.Core{BaseEnv: baseEnv},
-	})
-	ctx = exec1.NewContext(
-		ctx,
-		parentDAG,
-		"parent-456",
-		"",
-		exec1.WithRootDAGRun(exec1.NewDAGRunRef("parent", "root-123")),
-		exec1.WithEnvVars(
-			dagutools.EnvManifest+"=/tmp/parent-tools/manifest.json",
-			"PATH=/tmp/parent-tools/bin:/usr/bin",
-			"AQUA_ROOT_DIR=/tmp/parent-tools/root",
-			"PARENT_ENV=ok",
-		),
-	)
-
-	executor := &SubDAGExecutor{
-		DAG: &core.DAG{
-			Name:     "test-child",
-			Location: "/path/to/test.yaml",
-		},
-		killed: make(chan struct{}),
-	}
-
-	cmd, err := executor.buildCommand(ctx, RunParams{RunID: "child-789"}, "/work/dir")
-	require.NoError(t, err)
-
-	env := envSliceToMap(cmd.Env)
-	assert.Equal(t, "/usr/bin", env["PATH"])
-	assert.Equal(t, "ok", env["PARENT_ENV"])
-	assert.NotContains(t, env, dagutools.EnvManifest)
-	assert.NotContains(t, env, "AQUA_ROOT_DIR")
-}
-
-func TestBuildCommand_NoRunID(t *testing.T) {
+func TestExecute_NoRunID(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -293,13 +176,13 @@ func TestBuildCommand_NoRunID(t *testing.T) {
 		RunID: "", // Empty RunID
 	}
 
-	cmd, err := executor.buildCommand(ctx, runParams, "/work/dir")
+	result, err := executor.Execute(ctx, runParams, "/work/dir")
 	assert.Error(t, err)
-	assert.Nil(t, cmd)
+	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "DAG run ID is not set")
 }
 
-func TestBuildCommand_NoRootDAGRun(t *testing.T) {
+func TestExecute_NoRootDAGRun(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -320,45 +203,10 @@ func TestBuildCommand_NoRootDAGRun(t *testing.T) {
 
 	runParams := RunParams{RunID: "child-789"}
 
-	cmd, err := executor.buildCommand(ctx, runParams, "/work/dir")
+	result, err := executor.Execute(ctx, runParams, "/work/dir")
 	assert.Error(t, err)
-	assert.Nil(t, cmd)
+	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "root DAG run ID is not set")
-}
-
-func TestBuildRetryCommand(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-
-	mockDB := new(mockDatabase)
-	dagCtx := exec1.Context{
-		DAG:        &core.DAG{Name: "parent"},
-		DB:         mockDB,
-		RootDAGRun: exec1.NewDAGRunRef("parent", "root-123"),
-		DAGRunID:   "parent-456",
-	}
-	ctx = exec1.WithContext(ctx, dagCtx)
-
-	executor := &SubDAGExecutor{
-		DAG: &core.DAG{
-			Name:     "test-child",
-			Location: "/path/to/test.yaml",
-		},
-		killed: make(chan struct{}),
-	}
-
-	cmd, err := executor.buildRetryCommand(ctx, RunParams{RunID: "child-789"}, "flaky", "/work/dir")
-	require.NoError(t, err)
-	require.NotNil(t, cmd)
-
-	assert.Equal(t, "/work/dir", cmd.Dir)
-	assert.Contains(t, cmd.Args, "retry")
-	assert.Contains(t, cmd.Args, "--run-id=child-789")
-	assert.Contains(t, cmd.Args, "--root=parent:root-123")
-	assert.Contains(t, cmd.Args, "--default-working-dir=/work/dir")
-	assert.Contains(t, cmd.Args, "--step=flaky")
-	assert.Contains(t, cmd.Args, "/path/to/test.yaml")
 }
 
 func TestExecute_UsesInjectedSubWorkflowRunner(t *testing.T) {
@@ -388,8 +236,7 @@ func TestExecute_UsesInjectedSubWorkflowRunner(t *testing.T) {
 		},
 		subWorkflowRunner: runner,
 		externalStepRetry: true,
-		distributedRuns:   make(map[string]bool),
-		processes:         make(map[string]*cmdutil.ManagedProcess),
+		activeRuns:        make(map[string]context.CancelFunc),
 		dagCtx:            dagCtx,
 		killed:            make(chan struct{}),
 	}
@@ -407,8 +254,7 @@ func TestExecute_UsesInjectedSubWorkflowRunner(t *testing.T) {
 	assert.Equal(t, exec1.NewDAGRunRef("parent", "parent-456"), req.ParentDAGRun)
 	assert.Equal(t, map[string]string{"role": "worker"}, req.WorkerSelector)
 	assert.True(t, req.ExternalStepRetry)
-	assert.NotContains(t, executor.distributedRuns, "child-789")
-	assert.NotContains(t, executor.distributedCancels, "child-789")
+	assert.NotContains(t, executor.activeRuns, "child-789")
 }
 
 func TestRetry_Distributed(t *testing.T) {
@@ -438,8 +284,7 @@ func TestRetry_Distributed(t *testing.T) {
 		},
 		subWorkflowRunner: runner,
 		externalStepRetry: true,
-		distributedRuns:   make(map[string]bool),
-		processes:         make(map[string]*cmdutil.ManagedProcess),
+		activeRuns:        make(map[string]context.CancelFunc),
 		dagCtx:            dagCtx,
 		killed:            make(chan struct{}),
 	}
@@ -454,8 +299,7 @@ func TestRetry_Distributed(t *testing.T) {
 	assert.Equal(t, "flaky", req.StepName)
 	assert.Equal(t, "child-789", req.RunID)
 	assert.True(t, req.ExternalStepRetry)
-	assert.NotContains(t, executor.distributedRuns, "child-789")
-	assert.NotContains(t, executor.distributedCancels, "child-789")
+	assert.NotContains(t, executor.activeRuns, "child-789")
 
 	require.NoError(t, executor.Kill(os.Interrupt))
 	assert.Equal(t, 0, runner.cancelCalled)
@@ -480,8 +324,7 @@ func TestSubDAGExecutor_ExecuteDoesNotDispatchAfterPreRunKill(t *testing.T) {
 			WorkerSelector: map[string]string{"role": "worker"},
 		},
 		subWorkflowRunner: runner,
-		distributedRuns:   make(map[string]bool),
-		processes:         make(map[string]*cmdutil.ManagedProcess),
+		activeRuns:        make(map[string]context.CancelFunc),
 		dagCtx:            dagCtx,
 		killed:            make(chan struct{}),
 	}
@@ -492,11 +335,10 @@ func TestSubDAGExecutor_ExecuteDoesNotDispatchAfterPreRunKill(t *testing.T) {
 	require.ErrorIs(t, err, errSubDAGCancelled)
 	require.Nil(t, result)
 	assert.Empty(t, runner.runRequests)
-	assert.NotContains(t, executor.distributedRuns, "child-789")
-	assert.NotContains(t, executor.distributedCancels, "child-789")
+	assert.NotContains(t, executor.activeRuns, "child-789")
 }
 
-func TestBuildRetryCommand_NoRootDAGRun(t *testing.T) {
+func TestRetry_NoRootDAGRun(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -514,9 +356,9 @@ func TestBuildRetryCommand_NoRootDAGRun(t *testing.T) {
 		killed: make(chan struct{}),
 	}
 
-	cmd, err := executor.buildRetryCommand(ctx, RunParams{RunID: "child-789"}, "flaky", "/work/dir")
+	result, err := executor.Retry(ctx, RunParams{RunID: "child-789"}, "flaky", "/work/dir")
 	assert.Error(t, err)
-	assert.Nil(t, cmd)
+	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "root DAG run ID is not set")
 }
 
@@ -564,172 +406,64 @@ func TestCleanup_NonExistentFile(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestExecutablePath(t *testing.T) {
-	t.Run("UsesConfigExecutableBeforeEnv", func(t *testing.T) {
-		ctx := config.WithConfig(context.Background(), &config.Config{
-			Paths: config.PathsConfig{Executable: "/configured/path/to/dagu"},
-		})
-		_ = os.Setenv("DAGU_EXECUTABLE", "/env/path/to/dagu")
-		defer func() { _ = os.Unsetenv("DAGU_EXECUTABLE") }()
-
-		path, err := executablePath(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, "/configured/path/to/dagu", path)
-	})
-
-	t.Run("FallsBackToEnv", func(t *testing.T) {
-		testPath := "/custom/path/to/dagu"
-		_ = os.Setenv("DAGU_EXECUTABLE", testPath)
-		defer func() { _ = os.Unsetenv("DAGU_EXECUTABLE") }()
-
-		path, err := executablePath(context.Background())
-		assert.NoError(t, err)
-		assert.Equal(t, testPath, path)
-	})
-
-	t.Run("FallsBackToCurrentExecutable", func(t *testing.T) {
-		_ = os.Unsetenv("DAGU_EXECUTABLE")
-		path, err := executablePath(context.Background())
-		assert.NoError(t, err)
-		assert.NotEmpty(t, path)
-	})
-}
-
-func TestSubDAGExecutor_Kill_MixedProcesses(t *testing.T) {
+func TestSubDAGExecutor_Kill_ActiveRunner(t *testing.T) {
 	t.Parallel()
 
-	// Create a mock database
-	mockDB := new(mockDatabase)
-
-	// Create a DAG context
 	dagCtx := exec1.Context{
-		DB:         mockDB,
 		RootDAGRun: exec1.NewDAGRunRef("root-dag", "root-run-id"),
 		DAGRunID:   "parent-run-id",
 	}
-
-	// Create a sub DAG
 	subDAG := &core.DAG{
 		Name: "sub-dag",
 	}
+	runner := &mockSubWorkflowRunner{shouldRun: true}
+	cancelCalled := false
 
-	// Create child executor with both local and distributed processes
 	executor := &SubDAGExecutor{
-		DAG:    subDAG,
-		dagCtx: dagCtx,
-		processes: map[string]*cmdutil.ManagedProcess{
-			"local-run-1": cmdutil.NewManagedProcess(&exec.Cmd{Process: &os.Process{Pid: 999999999}}),
-			"local-run-2": cmdutil.NewManagedProcess(&exec.Cmd{Process: &os.Process{Pid: 999999998}}),
-		},
-		distributedRuns: map[string]bool{
-			"distributed-run-1": true,
-			"distributed-run-2": true,
+		DAG:               subDAG,
+		dagCtx:            dagCtx,
+		subWorkflowRunner: runner,
+		activeRuns: map[string]context.CancelFunc{
+			"child-run": func() { cancelCalled = true },
 		},
 		killed: make(chan struct{}),
 	}
 
-	// Set up expectations for RequestChildCancel
-	mockDB.On("RequestChildCancel", mock.Anything, "distributed-run-1", dagCtx.RootDAGRun).Return(nil)
-	mockDB.On("RequestChildCancel", mock.Anything, "distributed-run-2", dagCtx.RootDAGRun).Return(nil)
-
-	// Call Kill
 	err := executor.Kill(os.Interrupt)
 
-	// Windows killProcessTree returns nil for nonexistent fake PIDs; Unix returns an error.
-	if runtime.GOOS == "windows" {
-		assert.NoError(t, err)
-	} else {
-		assert.Error(t, err)
-	}
-
-	// Verify RequestChildCancel was called for both distributed runs
-	mockDB.AssertExpectations(t)
-}
-
-func TestSubDAGExecutor_Kill_OnlyDistributed(t *testing.T) {
-	t.Parallel()
-
-	// Create a mock database
-	mockDB := new(mockDatabase)
-
-	// Create a DAG context
-	dagCtx := exec1.Context{
-		DB:         mockDB,
-		RootDAGRun: exec1.NewDAGRunRef("root-dag", "root-run-id"),
-		DAGRunID:   "parent-run-id",
-	}
-
-	// Create a sub DAG
-	subDAG := &core.DAG{
-		Name: "sub-dag",
-	}
-
-	// Create child executor with only distributed processes
-	executor := &SubDAGExecutor{
-		DAG:       subDAG,
-		dagCtx:    dagCtx,
-		processes: make(map[string]*cmdutil.ManagedProcess),
-		distributedRuns: map[string]bool{
-			"distributed-run-1": true,
-			"distributed-run-2": true,
-		},
-		killed: make(chan struct{}),
-	}
-
-	// Set up expectations for RequestChildCancel
-	mockDB.On("RequestChildCancel", mock.Anything, "distributed-run-1", dagCtx.RootDAGRun).Return(nil)
-	mockDB.On("RequestChildCancel", mock.Anything, "distributed-run-2", dagCtx.RootDAGRun).Return(nil)
-
-	// Call Kill
-	err := executor.Kill(os.Interrupt)
-
-	// Verify no error
 	assert.NoError(t, err)
-
-	// Verify RequestChildCancel was called for both distributed runs
-	mockDB.AssertExpectations(t)
+	assert.True(t, cancelCalled)
+	assert.Equal(t, 1, runner.cancelCalled)
 }
 
-func TestSubDAGExecutor_Kill_OnlyLocal(t *testing.T) {
+func TestSubDAGExecutor_Kill_FallbackDB(t *testing.T) {
 	t.Parallel()
 
-	// Create a mock database
 	mockDB := new(mockDatabase)
-
-	// Create a DAG context
 	dagCtx := exec1.Context{
 		DB:         mockDB,
 		RootDAGRun: exec1.NewDAGRunRef("root-dag", "root-run-id"),
 		DAGRunID:   "parent-run-id",
 	}
-
-	// Create a sub DAG
 	subDAG := &core.DAG{
 		Name: "sub-dag",
 	}
 
-	// Create child executor with only local processes
 	executor := &SubDAGExecutor{
 		DAG:    subDAG,
 		dagCtx: dagCtx,
-		processes: map[string]*cmdutil.ManagedProcess{
-			"local-run-1": cmdutil.NewManagedProcess(&exec.Cmd{Process: &os.Process{Pid: 999999999}}),
+		activeRuns: map[string]context.CancelFunc{
+			"child-run": func() {},
 		},
-		distributedRuns: make(map[string]bool),
-		killed:          make(chan struct{}),
+		killed: make(chan struct{}),
 	}
 
-	// Call Kill
+	mockDB.On("RequestChildCancel", mock.Anything, "child-run", dagCtx.RootDAGRun).Return(nil)
+
 	err := executor.Kill(os.Interrupt)
 
-	if runtime.GOOS == "windows" {
-		assert.NoError(t, err)
-	} else {
-		assert.Error(t, err)
-	}
-
-	// Verify RequestChildCancel was NOT called
-	mockDB.AssertNotCalled(t, "RequestChildCancel")
+	assert.NoError(t, err)
+	mockDB.AssertExpectations(t)
 }
 
 func TestSubDAGExecutor_Kill_Empty(t *testing.T) {
@@ -750,13 +484,11 @@ func TestSubDAGExecutor_Kill_Empty(t *testing.T) {
 		Name: "sub-dag",
 	}
 
-	// Create child executor with no processes
 	executor := &SubDAGExecutor{
-		DAG:             subDAG,
-		dagCtx:          dagCtx,
-		processes:       make(map[string]*cmdutil.ManagedProcess),
-		distributedRuns: make(map[string]bool),
-		killed:          make(chan struct{}),
+		DAG:        subDAG,
+		dagCtx:     dagCtx,
+		activeRuns: make(map[string]context.CancelFunc),
+		killed:     make(chan struct{}),
 	}
 
 	// Call Kill

--- a/internal/runtime/executor/subworkflow.go
+++ b/internal/runtime/executor/subworkflow.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"context"
 
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
@@ -44,6 +45,7 @@ type SubWorkflowCancelRequest struct {
 	DAG        *core.DAG
 	RootDAGRun exec.DAGRunRef
 	RunID      string
+	Intent     cmdutil.TerminationIntent
 }
 
 // SubWorkflowWorkspace carries an immutable child workflow workspace.

--- a/internal/runtime/executor/subworkflow.go
+++ b/internal/runtime/executor/subworkflow.go
@@ -44,8 +44,10 @@ type SubWorkflowRetryRequest struct {
 type SubWorkflowCancelMode string
 
 const (
+	// SubWorkflowCancelModeGraceful requests a graceful stop of the child workflow.
 	SubWorkflowCancelModeGraceful SubWorkflowCancelMode = "graceful"
-	SubWorkflowCancelModeForce    SubWorkflowCancelMode = "force"
+	// SubWorkflowCancelModeForce requests a forced stop of the child workflow.
+	SubWorkflowCancelModeForce SubWorkflowCancelMode = "force"
 )
 
 // SubWorkflowCancelIntent carries runtime-owned cancellation intent.

--- a/internal/runtime/executor/subworkflow.go
+++ b/internal/runtime/executor/subworkflow.go
@@ -5,8 +5,8 @@ package executor
 
 import (
 	"context"
+	"os"
 
-	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
@@ -40,12 +40,26 @@ type SubWorkflowRetryRequest struct {
 	StepName string
 }
 
+// SubWorkflowCancelMode describes how a child workflow should be stopped.
+type SubWorkflowCancelMode string
+
+const (
+	SubWorkflowCancelModeGraceful SubWorkflowCancelMode = "graceful"
+	SubWorkflowCancelModeForce    SubWorkflowCancelMode = "force"
+)
+
+// SubWorkflowCancelIntent carries runtime-owned cancellation intent.
+type SubWorkflowCancelIntent struct {
+	Mode   SubWorkflowCancelMode
+	Signal os.Signal
+}
+
 // SubWorkflowCancelRequest describes a child workflow cancellation.
 type SubWorkflowCancelRequest struct {
 	DAG        *core.DAG
 	RootDAGRun exec.DAGRunRef
 	RunID      string
-	Intent     cmdutil.TerminationIntent
+	Intent     SubWorkflowCancelIntent
 }
 
 // SubWorkflowWorkspace carries an immutable child workflow workspace.

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -613,7 +613,10 @@ func (h *remoteTaskHandler) executeDAGRun(
 			if err != nil {
 				return nil, err
 			}
-			return subflow.New(dispatcher, h.config.DefaultExecMode), nil
+			return subflow.NewRouter(
+				subflow.New(dispatcher, h.config.DefaultExecMode),
+				subflow.NewLocalCLI(),
+			), nil
 		},
 		RootDAGRun:        root,
 		PeerConfig:        h.peerConfig,

--- a/internal/subflow/local_cli.go
+++ b/internal/subflow/local_cli.go
@@ -133,6 +133,9 @@ func validateLocalRequest(req executor.SubWorkflowRequest) error {
 	if req.DAG == nil {
 		return errMissingChildDAG
 	}
+	if strings.TrimSpace(req.DAG.Location) == "" {
+		return errMissingDAGPath
+	}
 	if req.RunID == "" {
 		return errRunIDNotSet
 	}
@@ -274,6 +277,16 @@ func (r *LocalCLI) runCommand(
 }
 
 func materializeLocalWorkspace(req executor.SubWorkflowRequest) (string, string, func(), error) {
+	if req.Workspace == nil {
+		return "", "", nil, fmt.Errorf("missing workspace for run %q", req.RunID)
+	}
+	desc := req.Workspace.Descriptor
+	dagPath, err := workspacebundle.NormalizeRelativePath(desc.DAGPath)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("invalid workspace DAG path for run %q: %w", req.RunID, err)
+	}
+	desc.DAGPath = dagPath
+
 	tmp, err := os.MkdirTemp("", "dagu-action-workspace-*")
 	if err != nil {
 		return "", "", nil, fmt.Errorf("create local action workspace: %w", err)
@@ -282,11 +295,15 @@ func materializeLocalWorkspace(req executor.SubWorkflowRequest) (string, string,
 		_ = fileutil.RemoveAll(tmp)
 	}
 	dest := filepath.Join(tmp, "workspace")
-	if err := workspacebundle.Extract(req.Workspace.Archive, dest, req.Workspace.Descriptor, workspacebundle.DefaultLimits()); err != nil {
+	if err := workspacebundle.Extract(req.Workspace.Archive, dest, desc, workspacebundle.DefaultLimits()); err != nil {
 		cleanup()
 		return "", "", nil, fmt.Errorf("materialize action workspace for run %q: %w", req.RunID, err)
 	}
-	target := filepath.Join(dest, filepath.FromSlash(req.Workspace.Descriptor.DAGPath))
+	target := filepath.Join(dest, filepath.FromSlash(dagPath))
+	if !workspacebundle.IsPathWithin(dest, target) {
+		cleanup()
+		return "", "", nil, fmt.Errorf("workspace DAG path escapes workspace for run %q", req.RunID)
+	}
 	return dest, target, cleanup, nil
 }
 

--- a/internal/subflow/local_cli.go
+++ b/internal/subflow/local_cli.go
@@ -1,0 +1,366 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package subflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/cmn/telemetry"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+)
+
+var errNoRunDatabase = errors.New("child workflow status database is not configured")
+
+// LocalCLI executes child workflows through the Dagu CLI subprocess contract.
+type LocalCLI struct {
+	mu        sync.Mutex
+	processes map[string]*cmdutil.ManagedProcess
+}
+
+var _ executor.SubWorkflowRunner = (*LocalCLI)(nil)
+
+// NewLocalCLI creates a subprocess-backed local child workflow runner.
+func NewLocalCLI() *LocalCLI {
+	return &LocalCLI{
+		processes: make(map[string]*cmdutil.ManagedProcess),
+	}
+}
+
+// ShouldRun reports whether req can use the local CLI path.
+func (r *LocalCLI) ShouldRun(_ context.Context, req executor.SubWorkflowRequest) bool {
+	return validateLocalRequest(req) == nil
+}
+
+// Run starts a child workflow through the local CLI and returns its stored result.
+func (r *LocalCLI) Run(ctx context.Context, req executor.SubWorkflowRequest) (*exec.RunStatus, error) {
+	if err := validateLocalRequest(req); err != nil {
+		return nil, err
+	}
+
+	workDir := req.WorkDir
+	target := req.DAG.Location
+	if req.Workspace != nil {
+		var cleanup func()
+		var err error
+		workDir, target, cleanup, err = materializeLocalWorkspace(req)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanup()
+	}
+
+	cmd, err := r.buildStartCommand(ctx, req, workDir, target)
+	if err != nil {
+		return nil, err
+	}
+	return r.runCommand(ctx, req, cmd)
+}
+
+// Retry retries a child workflow step through the local CLI.
+func (r *LocalCLI) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest) (*exec.RunStatus, error) {
+	if err := validateLocalRequest(req.SubWorkflowRequest); err != nil {
+		return nil, err
+	}
+	cmd, err := r.buildRetryCommand(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return r.runCommand(ctx, req.SubWorkflowRequest, cmd)
+}
+
+// Cancel stops a running local CLI child process.
+func (r *LocalCLI) Cancel(ctx context.Context, req executor.SubWorkflowCancelRequest) error {
+	r.mu.Lock()
+	process := r.processes[req.RunID]
+	r.mu.Unlock()
+
+	if process != nil {
+		_, err := process.Stop(cmdutil.StopRequest{
+			Intent: req.Intent,
+			Reason: cmdutil.StopReasonCancel,
+		})
+		return err
+	}
+
+	rCtx := exec.GetContext(ctx)
+	if rCtx.DB == nil {
+		return nil
+	}
+	if err := rCtx.DB.RequestChildCancel(ctx, req.RunID, req.RootDAGRun); err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func validateLocalRequest(req executor.SubWorkflowRequest) error {
+	if req.DAG == nil {
+		return errMissingChildDAG
+	}
+	if req.RunID == "" {
+		return errRunIDNotSet
+	}
+	if req.RootDAGRun.Zero() {
+		return errRootRunNotSet
+	}
+	return nil
+}
+
+func (r *LocalCLI) buildStartCommand(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+	workDir string,
+	target string,
+) (*osexec.Cmd, error) {
+	args := []string{
+		"start",
+		fmt.Sprintf("--root=%s", req.RootDAGRun.String()),
+		fmt.Sprintf("--parent=%s", req.ParentDAGRun.String()),
+		fmt.Sprintf("--run-id=%s", req.RunID),
+		"--trigger-type=subdag",
+	}
+	if workDir != "" {
+		args = append(args, fmt.Sprintf("--default-working-dir=%s", workDir))
+	}
+	if req.Params != "" {
+		return r.newCommand(ctx, req, workDir, args, target, "--", req.Params)
+	}
+	return r.newCommand(ctx, req, workDir, args, target)
+}
+
+func (r *LocalCLI) buildRetryCommand(
+	ctx context.Context,
+	req executor.SubWorkflowRetryRequest,
+) (*osexec.Cmd, error) {
+	args := []string{
+		"retry",
+		fmt.Sprintf("--run-id=%s", req.RunID),
+		fmt.Sprintf("--root=%s", req.RootDAGRun.String()),
+	}
+	if req.WorkDir != "" {
+		args = append(args, fmt.Sprintf("--default-working-dir=%s", req.WorkDir))
+	}
+	if req.StepName != "" {
+		args = append(args, fmt.Sprintf("--step=%s", req.StepName))
+	}
+	return r.newCommand(ctx, req.SubWorkflowRequest, req.WorkDir, args, req.DAG.Location)
+}
+
+func (r *LocalCLI) newCommand(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+	workDir string,
+	args []string,
+	target string,
+	trailingArgs ...string,
+) (*osexec.Cmd, error) {
+	executable, err := executablePath(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find executable path: %w", err)
+	}
+
+	fullArgs := append([]string{}, args...)
+	if configFile := config.ConfigFileUsed(ctx); configFile != "" {
+		fullArgs = append(fullArgs, "--config", configFile)
+	}
+	fullArgs = append(fullArgs, target)
+	fullArgs = append(fullArgs, trailingArgs...)
+
+	cmd := osexec.CommandContext(ctx, executable, fullArgs...) // nolint:gosec
+	cmd.Dir = workDir
+
+	rCtx := exec.GetContext(ctx)
+	cmd.Env = localCLIEnv(rCtx)
+	if req.ExternalStepRetry {
+		cmd.Env = append(cmd.Env, exec.EnvKeyExternalStepRetry+"=1")
+	}
+
+	cmdutil.SetupCommand(cmd)
+	return injectTraceContext(ctx, req.DAG, cmd), nil
+}
+
+func (r *LocalCLI) runCommand(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+	cmd *osexec.Cmd,
+) (*exec.RunStatus, error) {
+	cmd.Stdout = io.Discard
+	stderrTail := executor.NewTailWriter(io.Discard, 4096)
+	cmd.Stderr = stderrTail
+
+	logger.Info(ctx, "Executing child workflow through local CLI")
+
+	process, err := cmdutil.StartManagedProcess(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start child workflow: %w", err)
+	}
+	defer func() { _ = process.Release() }()
+
+	r.mu.Lock()
+	r.processes[req.RunID] = process
+	r.mu.Unlock()
+	defer func() {
+		r.mu.Lock()
+		delete(r.processes, req.RunID)
+		r.mu.Unlock()
+	}()
+
+	waitErr := process.Wait()
+	if waitErr != nil {
+		logger.Error(ctx, "Child workflow execution returned error", tag.Error(waitErr))
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Join(errChildCancelled, err)
+	}
+
+	rCtx := exec.GetContext(ctx)
+	if rCtx.DB == nil {
+		return nil, errNoRunDatabase
+	}
+	result, resultErr := rCtx.DB.GetSubDAGRunStatus(ctx, req.RunID, req.RootDAGRun)
+	if resultErr != nil {
+		errMsg := fmt.Sprintf("child workflow run %q failed and wrote no status", req.RunID)
+		if waitErr != nil {
+			errMsg += fmt.Sprintf(" (process: %v)", waitErr)
+		}
+		if tail := strings.TrimSpace(stderrTail.Tail()); tail != "" {
+			errMsg += fmt.Sprintf("; stderr: %s", tail)
+		}
+		return nil, fmt.Errorf("%s: %w", errMsg, resultErr)
+	}
+
+	if result.Status.IsSuccess() {
+		logger.Info(ctx, "Child workflow completed successfully")
+		return result, nil
+	}
+	return result, waitErr
+}
+
+func materializeLocalWorkspace(req executor.SubWorkflowRequest) (string, string, func(), error) {
+	tmp, err := os.MkdirTemp("", "dagu-action-workspace-*")
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create local action workspace: %w", err)
+	}
+	cleanup := func() {
+		_ = fileutil.RemoveAll(tmp)
+	}
+	dest := filepath.Join(tmp, "workspace")
+	if err := workspacebundle.Extract(req.Workspace.Archive, dest, req.Workspace.Descriptor, workspacebundle.DefaultLimits()); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("materialize action workspace for run %q: %w", req.RunID, err)
+	}
+	target := filepath.Join(dest, filepath.FromSlash(req.Workspace.Descriptor.DAGPath))
+	return dest, target, cleanup, nil
+}
+
+func localCLIEnv(rCtx exec.Context) []string {
+	env := baseEnvForLocalCLI(rCtx)
+	return append(env, inheritedEnvForLocalCLI(rCtx.AllEnvs())...)
+}
+
+func baseEnvForLocalCLI(rCtx exec.Context) []string {
+	if rCtx.BaseEnv != nil {
+		env := rCtx.BaseEnv.AsSlice()
+		if len(env) > 0 {
+			return env
+		}
+	}
+	return os.Environ()
+}
+
+func inheritedEnvForLocalCLI(envs []string) []string {
+	if !hasDAGToolsEnv(envs) {
+		return envs
+	}
+	filtered := make([]string, 0, len(envs))
+	for _, env := range envs {
+		key, _, ok := strings.Cut(env, "=")
+		if ok && isDAGToolsEnvKey(key) {
+			continue
+		}
+		filtered = append(filtered, env)
+	}
+	return filtered
+}
+
+func hasDAGToolsEnv(envs []string) bool {
+	for _, env := range envs {
+		key, _, ok := strings.Cut(env, "=")
+		if ok && strings.EqualFold(key, dagutools.EnvManifest) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDAGToolsEnvKey(key string) bool {
+	for _, candidate := range []string{
+		"PATH",
+		"AQUA_ROOT_DIR",
+		"AQUA_CONFIG",
+		"AQUA_DISABLE_LAZY_INSTALL",
+		"AQUA_CHECKSUM",
+		"AQUA_REQUIRE_CHECKSUM",
+		"AQUA_ENFORCE_CHECKSUM",
+		"AQUA_ENFORCE_REQUIRE_CHECKSUM",
+		dagutools.EnvManifest,
+	} {
+		if strings.EqualFold(key, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func executablePath(ctx context.Context) (string, error) {
+	if cfg := config.GetConfig(ctx); cfg != nil && cfg.Paths.Executable != "" {
+		return cfg.Paths.Executable, nil
+	}
+	if path := os.Getenv("DAGU_EXECUTABLE"); path != "" {
+		return path, nil
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+	return executable, nil
+}
+
+func injectTraceContext(ctx context.Context, dag *core.DAG, cmd *osexec.Cmd) *osexec.Cmd {
+	logCtx := ctx
+	if dag != nil {
+		logCtx = logger.WithValues(ctx, tag.DAG(dag.Name))
+	}
+	traceEnvVars := telemetry.InjectTraceContext(ctx)
+	if len(traceEnvVars) > 0 {
+		cmd.Env = append(cmd.Env, traceEnvVars...)
+		logger.Debug(logCtx, "Injecting trace context into child workflow",
+			slog.Any("trace-env-vars", traceEnvVars),
+		)
+	} else {
+		logger.Debug(logCtx, "No trace context to inject into child workflow")
+	}
+	return cmd
+}

--- a/internal/subflow/local_cli.go
+++ b/internal/subflow/local_cli.go
@@ -31,6 +31,7 @@ import (
 var errNoRunDatabase = errors.New("child workflow status database is not configured")
 
 // LocalCLI executes child workflows through the Dagu CLI subprocess contract.
+// It is intended as the final router fallback after policy-specific runners.
 type LocalCLI struct {
 	mu        sync.Mutex
 	processes map[string]*cmdutil.ManagedProcess
@@ -95,7 +96,7 @@ func (r *LocalCLI) Cancel(ctx context.Context, req executor.SubWorkflowCancelReq
 
 	if process != nil {
 		_, err := process.Stop(cmdutil.StopRequest{
-			Intent: req.Intent,
+			Intent: localStopIntent(req.Intent),
 			Reason: cmdutil.StopReasonCancel,
 		})
 		return err
@@ -112,6 +113,20 @@ func (r *LocalCLI) Cancel(ctx context.Context, req executor.SubWorkflowCancelReq
 		return err
 	}
 	return nil
+}
+
+func localStopIntent(intent executor.SubWorkflowCancelIntent) cmdutil.TerminationIntent {
+	if intent.Mode == "" {
+		return cmdutil.TerminationFromSignal(intent.Signal)
+	}
+	mode := cmdutil.TerminationModeGraceful
+	if intent.Mode == executor.SubWorkflowCancelModeForce {
+		mode = cmdutil.TerminationModeForce
+	}
+	return cmdutil.TerminationIntent{
+		Mode:   mode,
+		Signal: intent.Signal,
+	}
 }
 
 func validateLocalRequest(req executor.SubWorkflowRequest) error {

--- a/internal/subflow/router.go
+++ b/internal/subflow/router.go
@@ -66,6 +66,7 @@ func (r *Router) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest
 }
 
 // Cancel routes cancellation to the runner that owns req.RunID.
+// Unknown ownership falls back to best-effort cancellation across all runners.
 func (r *Router) Cancel(ctx context.Context, req executor.SubWorkflowCancelRequest) error {
 	r.mu.Lock()
 	runner := r.selected[req.RunID]

--- a/internal/subflow/router.go
+++ b/internal/subflow/router.go
@@ -1,0 +1,129 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package subflow
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+)
+
+var errNoMatchingRunner = errors.New("no child workflow runner matched request")
+
+// Router selects the first child workflow runner that accepts a request.
+type Router struct {
+	runners []executor.SubWorkflowRunner
+
+	mu       sync.Mutex
+	selected map[string]executor.SubWorkflowRunner
+}
+
+var _ executor.SubWorkflowRunner = (*Router)(nil)
+
+// NewRouter creates a child workflow runner that tries runners in order.
+func NewRouter(runners ...executor.SubWorkflowRunner) *Router {
+	filtered := make([]executor.SubWorkflowRunner, 0, len(runners))
+	for _, runner := range runners {
+		if runner != nil {
+			filtered = append(filtered, runner)
+		}
+	}
+	return &Router{
+		runners:  filtered,
+		selected: make(map[string]executor.SubWorkflowRunner),
+	}
+}
+
+// ShouldRun reports whether any runner accepts req.
+func (r *Router) ShouldRun(ctx context.Context, req executor.SubWorkflowRequest) bool {
+	return r.selectRunner(ctx, req) != nil
+}
+
+// Run executes req with the first matching runner.
+func (r *Router) Run(ctx context.Context, req executor.SubWorkflowRequest) (*exec.RunStatus, error) {
+	runner := r.selectRunner(ctx, req)
+	if runner == nil {
+		return nil, errNoMatchingRunner
+	}
+	r.remember(req.RunID, runner)
+	defer r.forget(req.RunID)
+	return runner.Run(ctx, req)
+}
+
+// Retry retries req with the first matching runner.
+func (r *Router) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest) (*exec.RunStatus, error) {
+	runner := r.selectRunner(ctx, req.SubWorkflowRequest)
+	if runner == nil {
+		return nil, errNoMatchingRunner
+	}
+	r.remember(req.RunID, runner)
+	defer r.forget(req.RunID)
+	return runner.Retry(ctx, req)
+}
+
+// Cancel routes cancellation to the runner that owns req.RunID.
+func (r *Router) Cancel(ctx context.Context, req executor.SubWorkflowCancelRequest) error {
+	r.mu.Lock()
+	runner := r.selected[req.RunID]
+	r.mu.Unlock()
+	if runner != nil {
+		return runner.Cancel(ctx, req)
+	}
+
+	var errs []error
+	for _, candidate := range r.runners {
+		if err := candidate.Cancel(ctx, req); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Cleanup releases resources held by child runners.
+func (r *Router) Cleanup(ctx context.Context) error {
+	var errs []error
+	for _, runner := range r.runners {
+		cleaner, ok := runner.(interface{ Cleanup(context.Context) error })
+		if !ok {
+			continue
+		}
+		if err := cleaner.Cleanup(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (r *Router) selectRunner(ctx context.Context, req executor.SubWorkflowRequest) executor.SubWorkflowRunner {
+	if r == nil {
+		return nil
+	}
+	for _, runner := range r.runners {
+		if runner.ShouldRun(ctx, req) {
+			return runner
+		}
+	}
+	return nil
+}
+
+func (r *Router) remember(runID string, runner executor.SubWorkflowRunner) {
+	if runID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.selected[runID] = runner
+}
+
+func (r *Router) forget(runID string) {
+	if runID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.selected, runID)
+}

--- a/internal/subflow/router_test.go
+++ b/internal/subflow/router_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package subflow_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/subflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouterPrefersFirstMatchingRunner(t *testing.T) {
+	t.Parallel()
+
+	distributed := &stubRunner{
+		shouldRun: true,
+		result: &exec.RunStatus{
+			Name:     "child",
+			DAGRunID: "child-run",
+			Status:   core.Succeeded,
+		},
+	}
+	local := &stubRunner{
+		shouldRun: true,
+		result: &exec.RunStatus{
+			Name:     "child",
+			DAGRunID: "child-run",
+			Status:   core.Failed,
+		},
+	}
+	router := subflow.NewRouter(distributed, local)
+
+	req := validSubWorkflowRequest()
+	got, err := router.Run(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, core.Succeeded, got.Status)
+	assert.Equal(t, 1, distributed.runCount)
+	assert.Equal(t, 0, local.runCount)
+}
+
+func TestRouterFallsBackToLocalRunner(t *testing.T) {
+	t.Parallel()
+
+	distributed := &stubRunner{shouldRun: false}
+	local := &stubRunner{
+		shouldRun: true,
+		result: &exec.RunStatus{
+			Name:     "child",
+			DAGRunID: "child-run",
+			Status:   core.Succeeded,
+		},
+	}
+	router := subflow.NewRouter(distributed, local)
+
+	req := validSubWorkflowRequest()
+	got, err := router.Run(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, core.Succeeded, got.Status)
+	assert.Equal(t, 0, distributed.runCount)
+	assert.Equal(t, 1, local.runCount)
+}
+
+func TestLocalCLIShouldRunValidLocalRequest(t *testing.T) {
+	t.Parallel()
+
+	runner := subflow.NewLocalCLI()
+
+	assert.True(t, runner.ShouldRun(context.Background(), validSubWorkflowRequest()))
+}
+
+func validSubWorkflowRequest() executor.SubWorkflowRequest {
+	return executor.SubWorkflowRequest{
+		DAG: &core.DAG{
+			Name:     "child",
+			Location: "/tmp/child.yaml",
+		},
+		RootDAGRun:   exec.NewDAGRunRef("root", "root-run"),
+		ParentDAGRun: exec.NewDAGRunRef("parent", "parent-run"),
+		RunID:        "child-run",
+	}
+}
+
+type stubRunner struct {
+	shouldRun bool
+	result    *exec.RunStatus
+	runCount  int
+}
+
+func (r *stubRunner) ShouldRun(context.Context, executor.SubWorkflowRequest) bool {
+	return r.shouldRun
+}
+
+func (r *stubRunner) Run(context.Context, executor.SubWorkflowRequest) (*exec.RunStatus, error) {
+	r.runCount++
+	return r.result, nil
+}
+
+func (r *stubRunner) Retry(context.Context, executor.SubWorkflowRetryRequest) (*exec.RunStatus, error) {
+	return r.result, nil
+}
+
+func (r *stubRunner) Cancel(context.Context, executor.SubWorkflowCancelRequest) error {
+	return nil
+}

--- a/internal/subflow/router_test.go
+++ b/internal/subflow/router_test.go
@@ -68,12 +68,71 @@ func TestRouterFallsBackToLocalRunner(t *testing.T) {
 	assert.Equal(t, 1, local.runCount)
 }
 
+func TestRouterCancelRoutesToSelectedRunner(t *testing.T) {
+	t.Parallel()
+
+	distributed := newBlockingRunner(true)
+	local := &stubRunner{shouldRun: true}
+	router := subflow.NewRouter(distributed, local)
+
+	req := validSubWorkflowRequest()
+	done := make(chan error, 1)
+	go func() {
+		_, err := router.Run(context.Background(), req)
+		done <- err
+	}()
+
+	<-distributed.started
+	err := router.Cancel(context.Background(), executor.SubWorkflowCancelRequest{
+		DAG:        req.DAG,
+		RootDAGRun: req.RootDAGRun,
+		RunID:      req.RunID,
+	})
+	require.NoError(t, err)
+
+	close(distributed.release)
+	require.NoError(t, <-done)
+
+	assert.Equal(t, 1, distributed.cancelCount)
+	assert.Equal(t, 0, local.cancelCount)
+}
+
+func TestRouterCancelFallsBackToAllRunnersWhenOwnerUnknown(t *testing.T) {
+	t.Parallel()
+
+	distributed := &stubRunner{shouldRun: true}
+	local := &stubRunner{shouldRun: true}
+	router := subflow.NewRouter(distributed, local)
+
+	req := validSubWorkflowRequest()
+	err := router.Cancel(context.Background(), executor.SubWorkflowCancelRequest{
+		DAG:        req.DAG,
+		RootDAGRun: req.RootDAGRun,
+		RunID:      req.RunID,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, distributed.cancelCount)
+	assert.Equal(t, 1, local.cancelCount)
+}
+
 func TestLocalCLIShouldRunValidLocalRequest(t *testing.T) {
 	t.Parallel()
 
 	runner := subflow.NewLocalCLI()
 
 	assert.True(t, runner.ShouldRun(context.Background(), validSubWorkflowRequest()))
+}
+
+func TestLocalCLIIsFallbackRunnerForValidRequests(t *testing.T) {
+	t.Parallel()
+
+	req := validSubWorkflowRequest()
+	req.WorkerSelector = map[string]string{"gpu": "true"}
+
+	runner := subflow.NewLocalCLI()
+
+	assert.True(t, runner.ShouldRun(context.Background(), req))
 }
 
 func validSubWorkflowRequest() executor.SubWorkflowRequest {
@@ -89,9 +148,10 @@ func validSubWorkflowRequest() executor.SubWorkflowRequest {
 }
 
 type stubRunner struct {
-	shouldRun bool
-	result    *exec.RunStatus
-	runCount  int
+	shouldRun   bool
+	result      *exec.RunStatus
+	runCount    int
+	cancelCount int
 }
 
 func (r *stubRunner) ShouldRun(context.Context, executor.SubWorkflowRequest) bool {
@@ -108,5 +168,44 @@ func (r *stubRunner) Retry(context.Context, executor.SubWorkflowRetryRequest) (*
 }
 
 func (r *stubRunner) Cancel(context.Context, executor.SubWorkflowCancelRequest) error {
+	r.cancelCount++
+	return nil
+}
+
+type blockingRunner struct {
+	shouldRun   bool
+	started     chan struct{}
+	release     chan struct{}
+	cancelCount int
+}
+
+func newBlockingRunner(shouldRun bool) *blockingRunner {
+	return &blockingRunner{
+		shouldRun: shouldRun,
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (r *blockingRunner) ShouldRun(context.Context, executor.SubWorkflowRequest) bool {
+	return r.shouldRun
+}
+
+func (r *blockingRunner) Run(context.Context, executor.SubWorkflowRequest) (*exec.RunStatus, error) {
+	close(r.started)
+	<-r.release
+	return &exec.RunStatus{
+		Name:     "child",
+		DAGRunID: "child-run",
+		Status:   core.Succeeded,
+	}, nil
+}
+
+func (r *blockingRunner) Retry(context.Context, executor.SubWorkflowRetryRequest) (*exec.RunStatus, error) {
+	return nil, nil
+}
+
+func (r *blockingRunner) Cancel(context.Context, executor.SubWorkflowCancelRequest) error {
+	r.cancelCount++
 	return nil
 }

--- a/internal/subflow/router_test.go
+++ b/internal/subflow/router_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/internal/subflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,18 @@ func TestLocalCLIShouldRunValidLocalRequest(t *testing.T) {
 	assert.True(t, runner.ShouldRun(context.Background(), validSubWorkflowRequest()))
 }
 
+func TestLocalCLIRejectsMissingDAGLocation(t *testing.T) {
+	t.Parallel()
+
+	req := validSubWorkflowRequest()
+	req.DAG.Location = ""
+	runner := subflow.NewLocalCLI()
+
+	assert.False(t, runner.ShouldRun(context.Background(), req))
+	_, err := runner.Run(context.Background(), req)
+	require.ErrorContains(t, err, "child workflow DAG location is required")
+}
+
 func TestLocalCLIIsFallbackRunnerForValidRequests(t *testing.T) {
 	t.Parallel()
 
@@ -133,6 +146,22 @@ func TestLocalCLIIsFallbackRunnerForValidRequests(t *testing.T) {
 	runner := subflow.NewLocalCLI()
 
 	assert.True(t, runner.ShouldRun(context.Background(), req))
+}
+
+func TestLocalCLIRunRejectsInvalidWorkspaceDAGPath(t *testing.T) {
+	t.Parallel()
+
+	req := validSubWorkflowRequest()
+	req.Workspace = &executor.SubWorkflowWorkspace{
+		Descriptor: workspacebundle.Descriptor{
+			DAGPath: "../child.yaml",
+		},
+		Archive: []byte("invalid archive"),
+	}
+	runner := subflow.NewLocalCLI()
+
+	_, err := runner.Run(context.Background(), req)
+	require.ErrorContains(t, err, "invalid workspace DAG path")
 }
 
 func validSubWorkflowRequest() executor.SubWorkflowRequest {

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -1,8 +1,8 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package subflow adapts Dagu's coordinator-backed child workflow execution to the
-// runtime executor's child workflow interface.
+// Package subflow adapts Dagu child workflow execution to the runtime executor's
+// child workflow interface.
 package subflow
 
 import (

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -30,6 +30,7 @@ var (
 	errRootRunNotSet   = errors.New("root DAG run ID is not set")
 	errNoDispatcher    = errors.New("no dispatcher configured for child workflow execution")
 	errMissingChildDAG = errors.New("child workflow DAG is required")
+	errMissingDAGPath  = errors.New("child workflow DAG location is required")
 	errStepNameNotSet  = errors.New("retry step name is not set")
 	errChildCancelled  = errors.New("sub DAG execution cancelled")
 )

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -792,7 +792,10 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 			if err != nil {
 				return nil, err
 			}
-			return subflow.New(dispatcher, d.Config.DefaultExecMode), nil
+			return subflow.NewRouter(
+				subflow.New(dispatcher, d.Config.DefaultExecMode),
+				subflow.NewLocalCLI(),
+			), nil
 		}
 	}
 


### PR DESCRIPTION
## Summary
- move local CLI child workflow execution out of runtime/executor into internal/subflow
- add a subworkflow router that prefers coordinator-backed execution and falls back to local CLI execution
- tighten cancellation ownership and boundary types with router fallback coverage

## Testing
- go test ./internal/subflow ./internal/runtime/executor -count=1
- go test -race ./internal/subflow ./internal/runtime/executor -count=1
- go test ./internal/runtime/... -count=1
- go test ./internal/engine ./internal/cmd ./internal/service/worker -count=1
- go test ./internal/intg -run 'TestInlineSubDAG|TestExternalSubDAG|TestCallSubDAG|TestInlineParams_LocalSubDAGRuntimeCoercion|TestSubDAGParamsReferencedInChildEnv|TestWorkingDir' -count=1
- go test ./internal/intg/distr -run 'TestSubDAG|TestParams_DistributedSubDAG|TestBaseConfig_SubDAGPropagation|TestCancellation_SubDAG|TestCustomStepTypes_SubDAGBaseConfigPropagation' -count=1
- make test
- make lint
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved local sub-workflow execution behind a router and `LocalCLI` runner, removing process management from the executor. Added strict request and workspace validation with cleaner cancellation mapping for safer child runs.

- **Refactors**
  - Added `internal/subflow` router that selects the first runner that accepts a request.
  - Implemented `subflow.NewLocalCLI()`; `internal/runtime/executor` no longer spawns/tracks OS processes.
  - Forwarded cancellation intent (graceful/force) and signals to runners; executor tracks only context cancels.
  - Moved action workspace materialization and trace-context injection into `LocalCLI`.
  - Updated factories to use `subflow.NewRouter(subflow.New(...), subflow.NewLocalCLI())` across context, engine, worker, and tests.

- **Bug Fixes**
  - Hardened `LocalCLI` with validation for DAG location and workspace DAG path (normalized and bounds-checked to prevent traversal).
  - Improved cancellation fallback: if no local process is found, request child cancel via DB; error when run DB is missing.

<sup>Written for commit e1a2b56b9bcb559ba8b999e4ffffbf1cfcbc786c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local CLI execution as an alternative for running child workflows.
* **Improvements**
  * Introduced structured cancellation semantics (graceful vs force with signal support).
  * Smarter routing to pick the appropriate sub-workflow execution mode per request.
  * Simplified active-run tracking for more reliable stop/kill behavior.
* **Tests**
  * Updated and added tests covering routing, local-run fallback, execution errors, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->