### PR TITLE
fix: require DAG write permission for inline specs

### DIFF
--- a/internal/service/frontend/api/v1/apikeys_test.go
+++ b/internal/service/frontend/api/v1/apikeys_test.go
@@ -93,6 +93,20 @@ func newCreateAPIKeyRequest(name string, role api.UserRole) api.CreateAPIKeyRequ
 	}
 }
 
+func createAPIKeyForRole(t *testing.T, server test.Server, adminToken, name string, role api.UserRole) string {
+	t.Helper()
+
+	resp := server.Client().Post("/api/v1/api-keys", newCreateAPIKeyRequest(name, role)).
+		WithBearerToken(adminToken).
+		ExpectStatus(http.StatusCreated).
+		Send(t)
+
+	var result api.CreateAPIKeyResponse
+	resp.Unmarshal(t, &result)
+	require.NotEmpty(t, result.Key)
+	return result.Key
+}
+
 // TestAPIKeys_ListEmpty tests listing API keys when none exist
 func TestAPIKeys_ListEmpty(t *testing.T) {
 	t.Parallel()

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -201,6 +201,14 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 	}
 	defer cleanup()
 
+	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireDAGWriteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
+		return nil, err
+	}
+
 	if err := a.ensureDAGRunIDUnique(ctx, dag, dagRunId); err != nil {
 		return nil, err
 	}
@@ -209,14 +217,6 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 		if err := a.checkSingletonRunning(ctx, dag); err != nil {
 			return nil, err
 		}
-	}
-
-	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
-	if err != nil {
-		return nil, err
-	}
-	if err := a.requireExecuteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
-		return nil, err
 	}
 
 	if err := a.startDAGRun(ctx, dag, params, dagRunId, valueOf(request.Body.Name), labels); err != nil {
@@ -283,6 +283,14 @@ func (a *API) EnqueueDAGRunFromSpec(ctx context.Context, request api.EnqueueDAGR
 	}
 	defer cleanup()
 
+	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireDAGWriteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
+		return nil, err
+	}
+
 	if request.Body.Queue != nil && *request.Body.Queue != "" {
 		dag.Queue = *request.Body.Queue
 	}
@@ -302,14 +310,6 @@ func (a *API) EnqueueDAGRunFromSpec(ctx context.Context, request api.EnqueueDAGR
 		if err := a.checkSingletonQueued(ctx, dag); err != nil {
 			return nil, err
 		}
-	}
-
-	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
-	if err != nil {
-		return nil, err
-	}
-	if err := a.requireExecuteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
-		return nil, err
 	}
 
 	if err := persistInlineEnqueueLabels(dag, labels); err != nil {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -172,6 +172,14 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 		}
 	}
 
+	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireDAGWriteForWorkspace(ctx, submittedSpecRuntimeWorkspaceName(request.Body.Spec, labels)); err != nil {
+		return nil, err
+	}
+
 	// Determine dagRunId upfront (used for unique temp dir path)
 	var dagRunId, params string
 	var singleton bool
@@ -201,10 +209,6 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 	}
 	defer cleanup()
 
-	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
-	if err != nil {
-		return nil, err
-	}
 	if err := a.requireDAGWriteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
 		return nil, err
 	}
@@ -256,6 +260,14 @@ func (a *API) EnqueueDAGRunFromSpec(ctx context.Context, request api.EnqueueDAGR
 		}
 	}
 
+	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.requireDAGWriteForWorkspace(ctx, submittedSpecRuntimeWorkspaceName(request.Body.Spec, labels)); err != nil {
+		return nil, err
+	}
+
 	var dagRunId, params string
 	var singleton bool
 	if request.Body.DagRunId != nil {
@@ -283,10 +295,6 @@ func (a *API) EnqueueDAGRunFromSpec(ctx context.Context, request api.EnqueueDAGR
 	}
 	defer cleanup()
 
-	labels, err := extractLabelsParam(request.Body.Labels, request.Body.Tags)
-	if err != nil {
-		return nil, err
-	}
 	if err := a.requireDAGWriteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
 		return nil, err
 	}
@@ -419,6 +427,34 @@ func extractInlineEnqueueLabelStrings(data []byte) ([]string, error) {
 		return parsed.Labels.Values(), nil
 	}
 	return parsed.DeprecatedTags.Values(), nil
+}
+
+func submittedSpecRuntimeWorkspaceName(specContent string, labels string) string {
+	if workspaceName := workspaceNameFromLabelString(labels); workspaceName != "" {
+		return workspaceName
+	}
+	return workspaceNameFromSubmittedSpec(specContent)
+}
+
+func workspaceNameFromSubmittedSpec(specContent string) string {
+	var parsed struct {
+		Labels         spectypes.LabelsValue `yaml:"labels"`
+		DeprecatedTags spectypes.LabelsValue `yaml:"tags"`
+	}
+	if err := yaml.NewDecoder(strings.NewReader(specContent)).Decode(&parsed); err != nil {
+		return ""
+	}
+	if workspaceName := workspaceNameFromLabelsValue(parsed.Labels); workspaceName != "" {
+		return workspaceName
+	}
+	return workspaceNameFromLabelsValue(parsed.DeprecatedTags)
+}
+
+func workspaceNameFromLabelsValue(labels spectypes.LabelsValue) string {
+	if labels.IsZero() {
+		return ""
+	}
+	return workspaceNameFromLabelString(strings.Join(labels.Values(), ","))
 }
 
 func getInlineEnqueueMapValue(ms yaml.MapSlice, key string) (any, bool) {

--- a/internal/service/frontend/api/v1/dagruns_edit_retry.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry.go
@@ -43,16 +43,17 @@ type editRetryOptions struct {
 }
 
 type editRetryPlan struct {
-	sourceAttempt  exec.DAGRunAttempt
-	sourceDAGRunID string
-	sourceStatus   *exec.DAGRunStatus
-	editedDAG      *core.DAG
-	newDAGRunID    string
-	params         string
-	skippedSteps   []string
-	runnableSteps  []string
-	ineligible     []editRetryIneligibleStep
-	warnings       []string
+	sourceAttempt   exec.DAGRunAttempt
+	sourceDAGRunID  string
+	sourceStatus    *exec.DAGRunStatus
+	editedDAG       *core.DAG
+	targetWorkspace string
+	newDAGRunID     string
+	params          string
+	skippedSteps    []string
+	runnableSteps   []string
+	ineligible      []editRetryIneligibleStep
+	warnings        []string
 }
 
 type editRetryIneligibleStep struct {
@@ -67,6 +68,10 @@ func (a *API) PreviewEditRetryDAGRun(ctx context.Context, request api.PreviewEdi
 
 	opts, err := previewEditRetryOptions(request.Body)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := a.requireEditRetryPrePlanPermissions(ctx, request.Name, request.DagRunId, opts.specContent); err != nil {
 		return nil, err
 	}
 
@@ -125,6 +130,10 @@ func (a *API) EditRetryDAGRun(ctx context.Context, request api.EditRetryDAGRunRe
 		return nil, err
 	}
 
+	if err := a.requireEditRetryPrePlanPermissions(ctx, request.Name, request.DagRunId, opts.specContent); err != nil {
+		return nil, err
+	}
+
 	plan, validationErrors, err := a.buildEditRetryPlan(ctx, request.Name, request.DagRunId, opts)
 	if err != nil {
 		return nil, err
@@ -178,7 +187,28 @@ func (a *API) requireEditRetryPermissions(ctx context.Context, plan *editRetryPl
 	if err := a.requireDAGRunStatusExecute(ctx, plan.sourceStatus); err != nil {
 		return err
 	}
-	return a.requireDAGWriteForWorkspace(ctx, dagWorkspaceName(plan.editedDAG))
+	return a.requireDAGWriteForWorkspace(ctx, plan.targetWorkspace)
+}
+
+func (a *API) requireEditRetryPrePlanPermissions(ctx context.Context, dagName string, dagRunID string, specContent string) error {
+	attempt, _, err := a.resolveAttemptForDAGRun(ctx, dagName, dagRunID)
+	if err != nil {
+		return err
+	}
+	sourceWorkspace, err := workspaceNameForAttempt(ctx, attempt)
+	if err != nil {
+		return err
+	}
+	if err := a.requireExecuteForWorkspace(ctx, sourceWorkspace); err != nil {
+		return err
+	}
+	if err := a.requireDAGWriteForWorkspace(ctx, sourceWorkspace); err != nil {
+		return err
+	}
+	if strings.TrimSpace(specContent) == "" {
+		return nil
+	}
+	return a.requireDAGWriteForWorkspace(ctx, submittedSpecRuntimeWorkspaceName(specContent, ""))
 }
 
 func editRetryRuntimeParams(status *exec.DAGRunStatus, preservedParams string) string {
@@ -273,11 +303,12 @@ func (a *API) buildEditRetryPlan(
 	}
 	if len(validationErrors) > 0 {
 		return &editRetryPlan{
-			sourceAttempt:  attempt,
-			sourceDAGRunID: sourceDAGRunID,
-			sourceStatus:   status,
-			editedDAG:      &core.DAG{Name: dagName},
-			newDAGRunID:    opts.newDAGRunID,
+			sourceAttempt:   attempt,
+			sourceDAGRunID:  sourceDAGRunID,
+			sourceStatus:    status,
+			editedDAG:       &core.DAG{Name: dagName},
+			targetWorkspace: statusWorkspaceName(status),
+			newDAGRunID:     opts.newDAGRunID,
 		}, validationErrors, nil
 	}
 
@@ -293,12 +324,13 @@ func (a *API) buildEditRetryPlan(
 	}
 	if editedDAG == nil {
 		return &editRetryPlan{
-			sourceAttempt:  attempt,
-			sourceDAGRunID: sourceDAGRunID,
-			sourceStatus:   status,
-			editedDAG:      &core.DAG{Name: editRetryFallbackDAGName(dagName, opts.nameOverride)},
-			newDAGRunID:    opts.newDAGRunID,
-			params:         params,
+			sourceAttempt:   attempt,
+			sourceDAGRunID:  sourceDAGRunID,
+			sourceStatus:    status,
+			editedDAG:       &core.DAG{Name: editRetryFallbackDAGName(dagName, opts.nameOverride)},
+			targetWorkspace: submittedSpecRuntimeWorkspaceName(opts.specContent, ""),
+			newDAGRunID:     opts.newDAGRunID,
+			params:          params,
 		}, validationErrors, nil
 	}
 
@@ -307,16 +339,17 @@ func (a *API) buildEditRetryPlan(
 
 	warnings := editRetryWarnings(stepPlan.skippedSteps, stepPlan.ineligible, stepPlan.reusableSourceSteps)
 	return &editRetryPlan{
-		sourceAttempt:  attempt,
-		sourceDAGRunID: sourceDAGRunID,
-		sourceStatus:   status,
-		editedDAG:      editedDAG,
-		newDAGRunID:    opts.newDAGRunID,
-		params:         params,
-		skippedSteps:   stepPlan.skippedSteps,
-		runnableSteps:  stepPlan.runnableSteps,
-		ineligible:     stepPlan.ineligible,
-		warnings:       warnings,
+		sourceAttempt:   attempt,
+		sourceDAGRunID:  sourceDAGRunID,
+		sourceStatus:    status,
+		editedDAG:       editedDAG,
+		targetWorkspace: dagWorkspaceName(editedDAG),
+		newDAGRunID:     opts.newDAGRunID,
+		params:          params,
+		skippedSteps:    stepPlan.skippedSteps,
+		runnableSteps:   stepPlan.runnableSteps,
+		ineligible:      stepPlan.ineligible,
+		warnings:        warnings,
 	}, validationErrors, nil
 }
 

--- a/internal/service/frontend/api/v1/dagruns_edit_retry.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry.go
@@ -75,10 +75,7 @@ func (a *API) PreviewEditRetryDAGRun(ctx context.Context, request api.PreviewEdi
 		return nil, err
 	}
 	if plan != nil {
-		if err := a.requireDAGRunStatusExecute(ctx, plan.sourceStatus); err != nil {
-			return nil, err
-		}
-		if err := a.requireExecuteForWorkspace(ctx, dagWorkspaceName(plan.editedDAG)); err != nil {
+		if err := a.requireEditRetryPermissions(ctx, plan); err != nil {
 			return nil, err
 		}
 	}
@@ -132,16 +129,13 @@ func (a *API) EditRetryDAGRun(ctx context.Context, request api.EditRetryDAGRunRe
 	if err != nil {
 		return nil, err
 	}
+	if plan != nil {
+		if err := a.requireEditRetryPermissions(ctx, plan); err != nil {
+			return nil, err
+		}
+	}
 	if len(validationErrors) > 0 {
 		return nil, badEditRetryRequest(strings.Join(validationErrors, "; "))
-	}
-	if plan != nil {
-		if err := a.requireDAGRunStatusExecute(ctx, plan.sourceStatus); err != nil {
-			return nil, err
-		}
-		if err := a.requireExecuteForWorkspace(ctx, dagWorkspaceName(plan.editedDAG)); err != nil {
-			return nil, err
-		}
 	}
 
 	if plan.newDAGRunID == "" {
@@ -178,6 +172,13 @@ func nonNilEditRetryStrings(values []string) []string {
 		return []string{}
 	}
 	return values
+}
+
+func (a *API) requireEditRetryPermissions(ctx context.Context, plan *editRetryPlan) error {
+	if err := a.requireDAGRunStatusExecute(ctx, plan.sourceStatus); err != nil {
+		return err
+	}
+	return a.requireDAGWriteForWorkspace(ctx, dagWorkspaceName(plan.editedDAG))
 }
 
 func editRetryRuntimeParams(status *exec.DAGRunStatus, preservedParams string) string {

--- a/internal/service/frontend/api/v1/dagruns_edit_retry_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry_internal_test.go
@@ -345,7 +345,8 @@ func setupEditRetryAPI(t *testing.T, tmpDir string, yamlContent string) (*API, *
 			},
 			Server: config.Server{
 				Permissions: map[config.Permission]bool{
-					config.PermissionRunDAGs: true,
+					config.PermissionRunDAGs:   true,
+					config.PermissionWriteDAGs: true,
 				},
 			},
 		},

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -420,6 +420,16 @@ steps:
 		WithBearerToken(operatorKey).
 		Send(t)
 	require.Equal(t, http.StatusForbidden, enqueueResp.Response.StatusCode())
+
+	invalidInlineSpec := ":"
+	invalidInlineDAGName := "operator_invalid_inline_spec_denied"
+	invalidResp := server.Client().Post("/api/v1/dag-runs", api.ExecuteDAGRunFromSpecJSONRequestBody{
+		Spec: invalidInlineSpec,
+		Name: &invalidInlineDAGName,
+	}).
+		WithBearerToken(operatorKey).
+		Send(t)
+	require.Equal(t, http.StatusForbidden, invalidResp.Response.StatusCode())
 }
 
 func TestOperatorCannotSubmitEditedRetrySpec(t *testing.T) {
@@ -447,6 +457,17 @@ steps:
 	var startBody api.ExecuteDAG200JSONResponse
 	startResp.Unmarshal(t, &startBody)
 	require.NotEmpty(t, startBody.DagRunId)
+	waitForDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Succeeded || status.Status == core.Failed
+	})
+
+	server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/retry", dagName, startBody.DagRunId),
+		api.RetryDAGRunJSONRequestBody{},
+	).
+		WithBearerToken(operatorKey).
+		ExpectStatus(http.StatusOK).
+		Send(t)
 	waitForDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
 		return status.Status == core.Succeeded || status.Status == core.Failed
 	})

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -373,6 +373,111 @@ func TestGetDAGRunSpecInlineEnqueueWithLabelsPatchesSpec(t *testing.T) {
 	require.Contains(t, specBody.Spec, "team=backend")
 }
 
+func TestOperatorCannotSubmitInlineDAGSpec(t *testing.T) {
+	server := setupBuiltinAuthServer(t)
+	adminToken := getAdminToken(t, server)
+	operatorKey := createAPIKeyForRole(t, server, adminToken, "operator-inline-spec", api.UserRoleOperator)
+
+	storedDAGSpec := fmt.Sprintf(`
+steps:
+  - %s
+`, test.ShellQuote("exit 0"))
+	storedDAGName := "operator_existing_dag"
+	server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: storedDAGName,
+		Spec: &storedDAGSpec,
+	}).
+		WithBearerToken(adminToken).
+		ExpectStatus(http.StatusCreated).
+		Send(t)
+
+	startResp := server.Client().Post("/api/v1/dags/"+storedDAGName+"/start", api.ExecuteDAGJSONRequestBody{}).
+		WithBearerToken(operatorKey).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+
+	inlineDAGSpec := fmt.Sprintf(`
+steps:
+  - %s
+`, test.ShellQuote("echo inline denied"))
+	inlineDAGName := "operator_inline_spec_denied"
+	executeResp := server.Client().Post("/api/v1/dag-runs", api.ExecuteDAGRunFromSpecJSONRequestBody{
+		Spec: inlineDAGSpec,
+		Name: &inlineDAGName,
+	}).
+		WithBearerToken(operatorKey).
+		Send(t)
+	require.Equal(t, http.StatusForbidden, executeResp.Response.StatusCode())
+
+	inlineEnqueueDAGName := "operator_inline_enqueue_denied"
+	enqueueResp := server.Client().Post("/api/v1/dag-runs/enqueue", api.EnqueueDAGRunFromSpecJSONRequestBody{
+		Spec: inlineDAGSpec,
+		Name: &inlineEnqueueDAGName,
+	}).
+		WithBearerToken(operatorKey).
+		Send(t)
+	require.Equal(t, http.StatusForbidden, enqueueResp.Response.StatusCode())
+}
+
+func TestOperatorCannotSubmitEditedRetrySpec(t *testing.T) {
+	server := setupBuiltinAuthServer(t)
+	adminToken := getAdminToken(t, server)
+	operatorKey := createAPIKeyForRole(t, server, adminToken, "operator-edit-retry", api.UserRoleOperator)
+
+	dagSpec := fmt.Sprintf(`
+steps:
+  - %s
+`, test.ShellQuote("exit 0"))
+	dagName := "operator_edit_retry_source"
+	server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &dagSpec,
+	}).
+		WithBearerToken(adminToken).
+		ExpectStatus(http.StatusCreated).
+		Send(t)
+
+	startResp := server.Client().Post("/api/v1/dags/"+dagName+"/start", api.ExecuteDAGJSONRequestBody{}).
+		WithBearerToken(adminToken).
+		ExpectStatus(http.StatusOK).
+		Send(t)
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+	waitForDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Succeeded || status.Status == core.Failed
+	})
+
+	editedSpec := fmt.Sprintf(`
+steps:
+  - %s
+`, test.ShellQuote("echo edited retry denied"))
+	previewResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/edit-retry/preview", dagName, startBody.DagRunId),
+		api.PreviewEditRetryDAGRunJSONRequestBody{
+			Spec: editedSpec,
+		},
+	).
+		WithBearerToken(operatorKey).
+		Send(t)
+	require.Equal(t, http.StatusForbidden, previewResp.Response.StatusCode())
+
+	editRetryRunID := "operator-edit-retry-denied"
+	editResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/edit-retry", dagName, startBody.DagRunId),
+		api.EditRetryDAGRunJSONRequestBody{
+			DagRunId: &editRetryRunID,
+			Spec:     editedSpec,
+		},
+	).
+		WithBearerToken(operatorKey).
+		Send(t)
+	require.Equal(t, http.StatusForbidden, editResp.Response.StatusCode())
+}
+
 func TestGetDAGRunSpecFileEnqueueWithLabelsDoesNotPatchSpec(t *testing.T) {
 	server := test.SetupServer(t)
 


### PR DESCRIPTION
## Summary

Require DAG write permission for submitted DAG specs while preserving stored-DAG execution for operator credentials.

## Changes

- Preauthorize inline execute/enqueue requests from request labels or submitted spec metadata before materializing the inline DAG.
- Preauthorize edit-retry requests before building the retry plan, including both the source run workspace and edited spec target workspace.
- Keep source-run execute permission for normal retry paths and add regression coverage for operator API keys.

## Related Issues

Addresses GHSA-3cmh-rvhh-32pq.

## Acknowledgements

Thanks to Yaohui Wang (@YHalo-wyh) for responsibly reporting GHSA-3cmh-rvhh-32pq.

## Testing

- go test ./internal/service/frontend/api/v1 -run "TestOperatorCannotSubmit(InlineDAGSpec|EditedRetrySpec)" -count=1
- go test ./internal/service/frontend/api/v1 -count=1
- CI run 26802150562: all checks passed

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally