### PR TITLE
refactor: introduce run state port

### DIFF
--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -52,6 +52,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/builtin/ssh"
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/resourcelimit"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
 
@@ -84,6 +85,9 @@ type Agent struct {
 
 	// dagRunStore is the database to store the run history.
 	dagRunStore exec.DAGRunStore
+
+	// runStateStore opens execution state for this run.
+	runStateStore runstate.Store
 
 	// queueStore is the database to store queued dag-run items.
 	queueStore exec.QueueStore
@@ -188,7 +192,7 @@ type Agent struct {
 	tracer *telemetry.Tracer
 
 	// statusPusher is used to push status updates to a remote coordinator.
-	// When nil, status is written to local filesystem via DAGRunAttempt.
+	// When nil, status is written to local filesystem via the run-state attempt.
 	statusPusher StatusPusher
 
 	// subWorkflowRunnerFactory creates a runner for child workflows.
@@ -209,10 +213,6 @@ type Agent struct {
 	// attemptID is the attempt ID from the coordinator.
 	// When set, the agent creates an attempt with this ID instead of generating a new one.
 	attemptID string
-
-	// preparedAttempt is an exact local attempt prepared before proc acquisition.
-	// When set, the agent must reuse this attempt instead of creating another one.
-	preparedAttempt exec.DAGRunAttempt
 
 	// agentConfigStore is the agent config store for agent step execution.
 	agentConfigStore agentpkg.ConfigStore
@@ -298,7 +298,7 @@ type Options struct {
 	// For local execution, this defaults to "local".
 	WorkerID string
 	// StatusPusher is used to push status updates to a remote coordinator.
-	// When nil, status is written to local filesystem via DAGRunAttempt.
+	// When nil, status is written to local filesystem via the run-state attempt.
 	StatusPusher StatusPusher
 	// SubWorkflowRunnerFactory creates a runner for child workflows.
 	SubWorkflowRunnerFactory SubWorkflowRunnerFactory
@@ -376,6 +376,11 @@ func New(
 	ds exec.DAGStore,
 	opts Options,
 ) *Agent {
+	runStateStore := runstate.NewHistoryStore(opts.DAGRunStore)
+	if opts.PreparedAttempt != nil {
+		runStateStore = runstate.NewHistoryStore(opts.DAGRunStore, runstate.WithPreparedAttempt(opts.PreparedAttempt))
+	}
+
 	a := &Agent{
 		rootDAGRun:                 opts.RootDAGRun,
 		parentDAGRun:               opts.ParentDAGRun,
@@ -390,6 +395,7 @@ func New(
 		dagRunMgr:                  drm,
 		dagStore:                   ds,
 		dagRunStore:                opts.DAGRunStore,
+		runStateStore:              runStateStore,
 		queueStore:                 opts.QueueStore,
 		stateStore:                 opts.StateStore,
 		secretStore:                opts.SecretStore,
@@ -405,7 +411,6 @@ func New(
 		logWriterFactory:           opts.LogWriterFactory,
 		queuedRun:                  opts.QueuedRun,
 		attemptID:                  opts.AttemptID,
-		preparedAttempt:            opts.PreparedAttempt,
 		triggerType:                opts.TriggerType,
 		defaultExecMode:            opts.DefaultExecMode,
 		agentConfigStore:           opts.AgentConfigStore,
@@ -527,7 +532,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 	}
 
-	var attempt exec.DAGRunAttempt
+	var attempt runstate.Attempt
 
 	// Check if the DAG is already running.
 	if err := a.checkIsAlreadyRunning(ctx); err != nil {
@@ -1066,7 +1071,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	// Collect and write step outputs BEFORE finalizing status (per spec)
 	if dagOutputs := a.buildOutputs(ctx, finishedStatus.Status); dagOutputs != nil {
-		if err := attempt.WriteOutputs(ctx, dagOutputs); err != nil {
+		if err := attempt.RecordOutputs(ctx, dagOutputs); err != nil {
 			logger.Error(ctx, "Failed to write outputs", tag.Error(err))
 		}
 	}
@@ -1389,7 +1394,7 @@ func (a *Agent) statusSourceTarget() *exec.DAGRunStatus {
 	return a.retryTarget
 }
 
-func (a *Agent) prepareWorkDir(ctx context.Context, attempt exec.DAGRunAttempt) (func(), error) {
+func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (func(), error) {
 	if attempt == nil {
 		return nil, nil
 	}
@@ -1422,8 +1427,8 @@ func (a *Agent) prepareWorkDir(ctx context.Context, attempt exec.DAGRunAttempt) 
 
 // writeStatus writes the current status to storage.
 // In shared-nothing mode (statusPusher is set), it only pushes to the coordinator.
-// In local mode, it writes to local storage via attempt.Write.
-func (a *Agent) writeStatus(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) {
+// In local mode, it writes to local storage via the run-state attempt.
+func (a *Agent) writeStatus(ctx context.Context, attempt runstate.Attempt, status exec.DAGRunStatus) {
 	if a.statusPusher != nil {
 		a.pushStatus(ctx, status)
 		return
@@ -1451,17 +1456,17 @@ func (a *Agent) pushStatus(ctx context.Context, status exec.DAGRunStatus) {
 	}
 }
 
-func (a *Agent) writeStatusLocally(ctx context.Context, attempt exec.DAGRunAttempt, status exec.DAGRunStatus) {
+func (a *Agent) writeStatusLocally(ctx context.Context, attempt runstate.Attempt, status exec.DAGRunStatus) {
 	if attempt == nil {
 		return
 	}
-	if err := attempt.Write(ctx, status); err != nil {
+	if err := attempt.RecordStatus(ctx, status); err != nil {
 		logger.Error(ctx, "Failed to write status to local storage", tag.Error(err))
 	}
 }
 
 // watchCancelRequested is a goroutine that watches for cancel requests
-func (a *Agent) watchCancelRequested(ctx context.Context, attempt exec.DAGRunAttempt) {
+func (a *Agent) watchCancelRequested(ctx context.Context, attempt runstate.Attempt) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -1477,7 +1482,7 @@ func (a *Agent) watchCancelRequested(ctx context.Context, attempt exec.DAGRunAtt
 			}
 			return
 		case <-ticker.C:
-			if cancelled, _ := attempt.IsAborting(ctx); cancelled {
+			if cancelled, _ := attempt.CancelRequested(ctx); cancelled {
 				a.stopChildren(ctx, syscall.SIGTERM, true)
 			}
 		}
@@ -1565,7 +1570,7 @@ func (a *Agent) setupReporter(ctx context.Context) {
 }
 
 // newRunner creates a runner instance for the dag-run.
-func (a *Agent) newRunner(attempt exec.DAGRunAttempt) *runtime.Runner {
+func (a *Agent) newRunner(attempt runstate.Attempt) *runtime.Runner {
 	// runnerLogDir is the directory to store the log files for each node in the dag-run.
 	const dateTimeFormatUTC = "20060102_150405Z"
 	ts := time.Now().UTC().Format(dateTimeFormatUTC)
@@ -2014,63 +2019,17 @@ func (a *Agent) setupDefaultRetryPlan(ctx context.Context, nodes []*runtime.Node
 	return nil
 }
 
-func (a *Agent) setupDAGRunAttempt(ctx context.Context) (exec.DAGRunAttempt, error) {
-	if a.dagRunStore == nil {
-		logger.Debug(ctx, "Using no-op DAGRunAttempt in shared-nothing mode")
-		return exec.NewNoopDAGRunAttempt(a.noopAttemptID(), a.dag), nil
+func (a *Agent) setupDAGRunAttempt(ctx context.Context) (runstate.Attempt, error) {
+	if a.runStateStore == nil {
+		a.runStateStore = runstate.NewHistoryStore(a.dagRunStore)
 	}
-
-	if a.dag.HistRetentionRuns == 0 {
-		retentionDays := a.dag.HistRetentionDays
-		if _, err := a.dagRunStore.RemoveOldDAGRuns(ctx, a.dag.Name, retentionDays); err != nil {
-			logger.Error(ctx, "DAG runs data cleanup failed", tag.Error(err))
-		}
-	}
-
-	var attempt exec.DAGRunAttempt
-	if a.preparedAttempt != nil {
-		if a.attemptID != "" && a.preparedAttempt.ID() != a.attemptID {
-			return nil, fmt.Errorf(
-				"prepared attempt ID %q does not match requested attempt ID %q",
-				a.preparedAttempt.ID(),
-				a.attemptID,
-			)
-		}
-		a.preparedAttempt.SetDAG(a.dag)
-		attempt = a.preparedAttempt
-	} else {
-		var err error
-		attempt, err = a.dagRunStore.CreateAttempt(ctx, a.dag, time.Now(), a.dagRunID, a.attemptOptions())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if a.dag.HistRetentionRuns > 0 {
-		if _, err := a.dagRunStore.RemoveOldDAGRuns(ctx, a.dag.Name, 0, exec.WithRetentionRuns(a.dag.HistRetentionRuns)); err != nil {
-			logger.Error(ctx, "DAG runs data cleanup failed", tag.Error(err))
-		}
-	}
-
-	return attempt, nil
-}
-
-func (a *Agent) noopAttemptID() string {
-	if a.attemptID != "" {
-		return a.attemptID
-	}
-	return a.dagRunID
-}
-
-func (a *Agent) attemptOptions() exec.NewDAGRunAttemptOptions {
-	opts := exec.NewDAGRunAttemptOptions{
-		Retry:     a.retryTarget != nil || a.queuedRun,
-		AttemptID: a.attemptID,
-	}
-	if a.isSubDAGRun.Load() {
-		opts.RootDAGRun = &a.rootDAGRun
-	}
-	return opts
+	return a.runStateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:        a.dag,
+		RunID:      a.dagRunID,
+		AttemptID:  a.attemptID,
+		Retry:      a.retryTarget != nil || a.queuedRun,
+		RootDAGRun: a.rootDAGRun,
+	})
 }
 
 // setupSocketServer creates a socket server instance.

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -2023,6 +2023,13 @@ func (a *Agent) setupDAGRunAttempt(ctx context.Context) (runstate.Attempt, error
 	if a.runStateStore == nil {
 		a.runStateStore = runstate.NewHistoryStore(a.dagRunStore)
 	}
+	if a.attemptID != "" && a.dagRunAttemptID != "" && a.attemptID != a.dagRunAttemptID {
+		return nil, fmt.Errorf(
+			"prepared attempt ID %q does not match requested attempt ID %q",
+			a.dagRunAttemptID,
+			a.attemptID,
+		)
+	}
 	return a.runStateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
 		DAG:        a.dag,
 		RunID:      a.dagRunID,

--- a/internal/runtime/runstate/dagrun_attempt.go
+++ b/internal/runtime/runstate/dagrun_attempt.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runstate
+
+import (
+	"context"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+func wrapDAGRunAttempt(attempt exec.DAGRunAttempt) Attempt {
+	return dagRunAttempt{attempt: attempt}
+}
+
+type dagRunAttempt struct {
+	attempt exec.DAGRunAttempt
+}
+
+func (a dagRunAttempt) ID() string {
+	return a.attempt.ID()
+}
+
+func (a dagRunAttempt) Open(ctx context.Context) error {
+	return a.attempt.Open(ctx)
+}
+
+func (a dagRunAttempt) RecordStatus(ctx context.Context, status exec.DAGRunStatus) error {
+	return a.attempt.Write(ctx, status)
+}
+
+func (a dagRunAttempt) RecordOutputs(ctx context.Context, outputs *exec.DAGRunOutputs) error {
+	return a.attempt.WriteOutputs(ctx, outputs)
+}
+
+func (a dagRunAttempt) ReadStatus(ctx context.Context) (*exec.DAGRunStatus, error) {
+	return a.attempt.ReadStatus(ctx)
+}
+
+func (a dagRunAttempt) RequestCancel(ctx context.Context) error {
+	return a.attempt.Abort(ctx)
+}
+
+func (a dagRunAttempt) CancelRequested(ctx context.Context) (bool, error) {
+	return a.attempt.IsAborting(ctx)
+}
+
+func (a dagRunAttempt) ReadStepMessages(ctx context.Context, stepName string) ([]exec.LLMMessage, error) {
+	return a.attempt.ReadStepMessages(ctx, stepName)
+}
+
+func (a dagRunAttempt) WriteStepMessages(ctx context.Context, stepName string, messages []exec.LLMMessage) error {
+	return a.attempt.WriteStepMessages(ctx, stepName, messages)
+}
+
+func (a dagRunAttempt) WorkDir() string {
+	return a.attempt.WorkDir()
+}
+
+func (a dagRunAttempt) Close(ctx context.Context) error {
+	return a.attempt.Close(ctx)
+}

--- a/internal/runtime/runstate/history_store.go
+++ b/internal/runtime/runstate/history_store.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runstate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+type historyStoreOption func(*historyStore)
+
+// WithPreparedAttempt reuses an attempt that was opened by Dagu before runtime execution.
+func WithPreparedAttempt(attempt exec.DAGRunAttempt) historyStoreOption {
+	return func(s *historyStore) {
+		s.preparedAttempt = attempt
+	}
+}
+
+// NewHistoryStore uses Dagu's run history store as the runtime run-state store.
+func NewHistoryStore(store exec.DAGRunStore, opts ...historyStoreOption) Store {
+	s := &historyStore{store: store}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+type historyStore struct {
+	store           exec.DAGRunStore
+	preparedAttempt exec.DAGRunAttempt
+}
+
+func (s *historyStore) BeginAttempt(ctx context.Context, req BeginAttemptRequest) (Attempt, error) {
+	if s.store == nil {
+		return wrapDAGRunAttempt(exec.NewNoopDAGRunAttempt(noopAttemptID(req), req.DAG)), nil
+	}
+
+	if req.DAG != nil && req.DAG.HistRetentionRuns == 0 {
+		if _, err := s.store.RemoveOldDAGRuns(ctx, req.DAG.Name, req.DAG.HistRetentionDays); err != nil {
+			logger.Error(ctx, "DAG runs data cleanup failed", tag.Error(err))
+		}
+	}
+
+	var attempt exec.DAGRunAttempt
+	if s.preparedAttempt != nil {
+		if req.AttemptID != "" && s.preparedAttempt.ID() != req.AttemptID {
+			return nil, fmt.Errorf(
+				"prepared attempt ID %q does not match requested attempt ID %q",
+				s.preparedAttempt.ID(),
+				req.AttemptID,
+			)
+		}
+		s.preparedAttempt.SetDAG(req.DAG)
+		attempt = s.preparedAttempt
+	} else {
+		created, err := s.store.CreateAttempt(ctx, req.DAG, time.Now(), req.RunID, dagRunAttemptOptions(req))
+		if err != nil {
+			return nil, err
+		}
+		attempt = created
+	}
+
+	if req.DAG != nil && req.DAG.HistRetentionRuns > 0 {
+		if _, err := s.store.RemoveOldDAGRuns(ctx, req.DAG.Name, 0, exec.WithRetentionRuns(req.DAG.HistRetentionRuns)); err != nil {
+			logger.Error(ctx, "DAG runs data cleanup failed", tag.Error(err))
+		}
+	}
+
+	return wrapDAGRunAttempt(attempt), nil
+}
+
+func (s *historyStore) OpenChildAttempt(ctx context.Context, root exec.DAGRunRef, childRunID string) (Attempt, error) {
+	if s.store == nil {
+		return nil, exec.ErrNoopAttemptNotSupported
+	}
+	attempt, err := s.store.FindSubAttempt(ctx, root, childRunID)
+	if err != nil {
+		return nil, err
+	}
+	return wrapDAGRunAttempt(attempt), nil
+}
+
+func dagRunAttemptOptions(req BeginAttemptRequest) exec.NewDAGRunAttemptOptions {
+	opts := exec.NewDAGRunAttemptOptions{
+		Retry:     req.Retry,
+		AttemptID: req.AttemptID,
+	}
+	if req.RootDAGRun.ID != "" && req.RootDAGRun.ID != req.RunID {
+		opts.RootDAGRun = &req.RootDAGRun
+	}
+	return opts
+}
+
+func noopAttemptID(req BeginAttemptRequest) string {
+	if req.AttemptID != "" {
+		return req.AttemptID
+	}
+	return req.RunID
+}

--- a/internal/runtime/runstate/history_store_test.go
+++ b/internal/runtime/runstate/history_store_test.go
@@ -1,0 +1,348 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runstate_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
+)
+
+func TestHistoryStoreBeginAttemptUsesPreparedAttempt(t *testing.T) {
+	ctx := context.Background()
+	dag := &core.DAG{Name: "parent"}
+	attempt := newRecordingAttempt("attempt-1")
+	store := &recordingDAGRunStore{}
+
+	stateStore := runstate.NewHistoryStore(store, runstate.WithPreparedAttempt(attempt))
+	got, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:       dag,
+		RunID:     "run-1",
+		AttemptID: "attempt-1",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "attempt-1", got.ID())
+	require.Same(t, dag, attempt.dag)
+	require.Zero(t, store.createCalls)
+}
+
+func TestHistoryStoreBeginAttemptRejectsPreparedAttemptIDMismatch(t *testing.T) {
+	ctx := context.Background()
+	attempt := newRecordingAttempt("prepared-attempt")
+	store := &recordingDAGRunStore{}
+
+	stateStore := runstate.NewHistoryStore(store, runstate.WithPreparedAttempt(attempt))
+	got, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:       &core.DAG{Name: "parent"},
+		RunID:     "run-1",
+		AttemptID: "requested-attempt",
+	})
+
+	require.ErrorContains(t, err, "prepared attempt ID")
+	require.Nil(t, got)
+	require.Zero(t, store.createCalls)
+}
+
+func TestHistoryStoreBeginAttemptUsesNoopAttemptWhenStoreMissing(t *testing.T) {
+	ctx := context.Background()
+
+	stateStore := runstate.NewHistoryStore(nil)
+	attempt, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:       &core.DAG{Name: "parent"},
+		RunID:     "run-1",
+		AttemptID: "attempt-1",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "attempt-1", attempt.ID())
+}
+
+func TestHistoryStoreBeginAttemptCreatesAttemptAndAppliesRetention(t *testing.T) {
+	ctx := context.Background()
+	dag := &core.DAG{Name: "parent", HistRetentionRuns: 3}
+	store := &recordingDAGRunStore{
+		createAttempt: newRecordingAttempt("attempt-2"),
+	}
+
+	stateStore := runstate.NewHistoryStore(store)
+	got, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:        dag,
+		RunID:      "run-2",
+		AttemptID:  "attempt-2",
+		Retry:      true,
+		RootDAGRun: exec.NewDAGRunRef("root", "root-run"),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "attempt-2", got.ID())
+	require.Equal(t, 1, store.createCalls)
+	require.Equal(t, "run-2", store.createRunID)
+	require.True(t, store.createOpts.Retry)
+	require.Equal(t, "attempt-2", store.createOpts.AttemptID)
+	require.NotNil(t, store.createOpts.RootDAGRun)
+	require.Equal(t, exec.NewDAGRunRef("root", "root-run"), *store.createOpts.RootDAGRun)
+	require.Len(t, store.removeOldCalls, 1)
+	require.Equal(t, 0, store.removeOldCalls[0].retentionDays)
+	require.NotNil(t, store.removeOldCalls[0].opts.RetentionRuns)
+	require.Equal(t, 3, *store.removeOldCalls[0].opts.RetentionRuns)
+}
+
+func TestHistoryStoreBeginAttemptOmitsRootDAGRunForRootAttempt(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingDAGRunStore{
+		createAttempt: newRecordingAttempt("attempt-1"),
+	}
+
+	stateStore := runstate.NewHistoryStore(store)
+	got, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:        &core.DAG{Name: "parent"},
+		RunID:      "root-run",
+		RootDAGRun: exec.NewDAGRunRef("parent", "root-run"),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "attempt-1", got.ID())
+	require.Nil(t, store.createOpts.RootDAGRun)
+}
+
+func TestHistoryStoreBeginAttemptIgnoresRetentionCleanupFailure(t *testing.T) {
+	ctx := context.Background()
+	dag := &core.DAG{Name: "parent", HistRetentionDays: 7}
+	store := &recordingDAGRunStore{
+		createAttempt: newRecordingAttempt("attempt-1"),
+		removeOldErr:  errors.New("cleanup failed"),
+	}
+
+	stateStore := runstate.NewHistoryStore(store)
+	got, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:   dag,
+		RunID: "run-1",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "attempt-1", got.ID())
+	require.Equal(t, 1, store.createCalls)
+	require.Len(t, store.removeOldCalls, 1)
+	require.Equal(t, 7, store.removeOldCalls[0].retentionDays)
+}
+
+func TestHistoryStoreOpenChildAttemptReturnsAttemptState(t *testing.T) {
+	ctx := context.Background()
+	status := &exec.DAGRunStatus{Name: "child", DAGRunID: "child-run", Status: core.Succeeded}
+	attempt := newRecordingAttempt("child-attempt")
+	attempt.status = status
+	store := &recordingDAGRunStore{
+		subAttempt: attempt,
+	}
+
+	stateStore := runstate.NewHistoryStore(store)
+	child, err := stateStore.OpenChildAttempt(ctx, exec.NewDAGRunRef("root", "root-run"), "child-run")
+	require.NoError(t, err)
+
+	got, err := child.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, status, got)
+
+	require.NoError(t, child.RequestCancel(ctx))
+	require.Equal(t, 1, attempt.abortCalls)
+}
+
+func TestAttemptDelegatesStateOperations(t *testing.T) {
+	ctx := context.Background()
+	attempt := newRecordingAttempt("attempt-1")
+	store := &recordingDAGRunStore{
+		createAttempt: attempt,
+	}
+	stateStore := runstate.NewHistoryStore(store)
+	stateAttempt, err := stateStore.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:   &core.DAG{Name: "parent"},
+		RunID: "run-1",
+	})
+	require.NoError(t, err)
+
+	status := exec.DAGRunStatus{Name: "parent", DAGRunID: "run-1", Status: core.Running}
+	outputs := &exec.DAGRunOutputs{Outputs: map[string]string{"result": "ok"}}
+	messages := []exec.LLMMessage{{Role: exec.RoleAssistant, Content: "done"}}
+
+	require.NoError(t, stateAttempt.Open(ctx))
+	require.NoError(t, stateAttempt.RecordStatus(ctx, status))
+	require.NoError(t, stateAttempt.RecordOutputs(ctx, outputs))
+	require.NoError(t, stateAttempt.WriteStepMessages(ctx, "step-1", messages))
+	gotMessages, err := stateAttempt.ReadStepMessages(ctx, "step-1")
+	require.NoError(t, err)
+	cancelled, err := stateAttempt.CancelRequested(ctx)
+	require.NoError(t, err)
+	require.False(t, cancelled)
+	require.NoError(t, stateAttempt.Close(ctx))
+
+	require.Equal(t, 1, attempt.openCalls)
+	require.Equal(t, status, attempt.writtenStatus)
+	require.Equal(t, outputs, attempt.writtenOutputs)
+	require.Equal(t, messages, gotMessages)
+	require.Equal(t, 1, attempt.closeCalls)
+}
+
+type recordingDAGRunStore struct {
+	createAttempt  exec.DAGRunAttempt
+	subAttempt     exec.DAGRunAttempt
+	createCalls    int
+	createRunID    string
+	createOpts     exec.NewDAGRunAttemptOptions
+	removeOldErr   error
+	removeOldCalls []removeOldCall
+}
+
+type removeOldCall struct {
+	retentionDays int
+	opts          exec.RemoveOldDAGRunsOptions
+}
+
+func (s *recordingDAGRunStore) CreateAttempt(_ context.Context, dag *core.DAG, _ time.Time, dagRunID string, opts exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
+	s.createCalls++
+	s.createRunID = dagRunID
+	s.createOpts = opts
+	if s.createAttempt == nil {
+		return newRecordingAttempt(opts.AttemptID), nil
+	}
+	s.createAttempt.SetDAG(dag)
+	return s.createAttempt, nil
+}
+
+func (s *recordingDAGRunStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
+	return nil
+}
+
+func (s *recordingDAGRunStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *recordingDAGRunStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	return nil, nil
+}
+
+func (s *recordingDAGRunStore) ListStatusesPage(context.Context, ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
+	return exec.DAGRunStatusPage{}, nil
+}
+
+func (s *recordingDAGRunStore) CompareAndSwapLatestAttemptStatus(context.Context, exec.DAGRunRef, string, core.Status, func(*exec.DAGRunStatus) error, ...exec.CompareAndSwapStatusOption) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
+func (s *recordingDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *recordingDAGRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	if s.subAttempt == nil {
+		return nil, exec.ErrDAGRunIDNotFound
+	}
+	return s.subAttempt, nil
+}
+
+func (s *recordingDAGRunStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, nil
+}
+
+func (s *recordingDAGRunStore) RemoveOldDAGRuns(_ context.Context, _ string, retentionDays int, opts ...exec.RemoveOldDAGRunsOption) ([]string, error) {
+	var options exec.RemoveOldDAGRunsOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	s.removeOldCalls = append(s.removeOldCalls, removeOldCall{retentionDays: retentionDays, opts: options})
+	return nil, s.removeOldErr
+}
+
+func (s *recordingDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
+	return nil
+}
+
+func (s *recordingDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
+	return nil
+}
+
+type recordingAttempt struct {
+	id             string
+	dag            *core.DAG
+	status         *exec.DAGRunStatus
+	writtenStatus  exec.DAGRunStatus
+	writtenOutputs *exec.DAGRunOutputs
+	messages       map[string][]exec.LLMMessage
+	openCalls      int
+	closeCalls     int
+	abortCalls     int
+}
+
+func newRecordingAttempt(id string) *recordingAttempt {
+	return &recordingAttempt{id: id, messages: make(map[string][]exec.LLMMessage)}
+}
+
+func (a *recordingAttempt) ID() string { return a.id }
+
+func (a *recordingAttempt) Open(context.Context) error {
+	a.openCalls++
+	return nil
+}
+
+func (a *recordingAttempt) Write(_ context.Context, status exec.DAGRunStatus) error {
+	a.writtenStatus = status
+	return nil
+}
+
+func (a *recordingAttempt) Close(context.Context) error {
+	a.closeCalls++
+	return nil
+}
+
+func (a *recordingAttempt) ReadStatus(context.Context) (*exec.DAGRunStatus, error) {
+	return a.status, nil
+}
+
+func (a *recordingAttempt) ReadDAG(context.Context) (*core.DAG, error) {
+	return a.dag, nil
+}
+
+func (a *recordingAttempt) SetDAG(dag *core.DAG) {
+	a.dag = dag
+}
+
+func (a *recordingAttempt) Abort(context.Context) error {
+	a.abortCalls++
+	return nil
+}
+
+func (a *recordingAttempt) IsAborting(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (a *recordingAttempt) Hide(context.Context) error { return nil }
+
+func (a *recordingAttempt) Hidden() bool { return false }
+
+func (a *recordingAttempt) WriteOutputs(_ context.Context, outputs *exec.DAGRunOutputs) error {
+	a.writtenOutputs = outputs
+	return nil
+}
+
+func (a *recordingAttempt) ReadOutputs(context.Context) (*exec.DAGRunOutputs, error) {
+	return nil, nil
+}
+
+func (a *recordingAttempt) WriteStepMessages(_ context.Context, stepName string, messages []exec.LLMMessage) error {
+	a.messages[stepName] = append([]exec.LLMMessage(nil), messages...)
+	return nil
+}
+
+func (a *recordingAttempt) ReadStepMessages(_ context.Context, stepName string) ([]exec.LLMMessage, error) {
+	return append([]exec.LLMMessage(nil), a.messages[stepName]...), nil
+}
+
+func (a *recordingAttempt) WorkDir() string { return "" }

--- a/internal/runtime/runstate/runstate.go
+++ b/internal/runtime/runstate/runstate.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package runstate defines the execution-state port used by the runtime.
+package runstate
+
+import (
+	"context"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+// Store opens execution state for workflow runs.
+type Store interface {
+	BeginAttempt(ctx context.Context, req BeginAttemptRequest) (Attempt, error)
+	OpenChildAttempt(ctx context.Context, root exec.DAGRunRef, childRunID string) (Attempt, error)
+}
+
+// BeginAttemptRequest describes the workflow run attempt to open for execution.
+type BeginAttemptRequest struct {
+	DAG        *core.DAG
+	RunID      string
+	AttemptID  string
+	Retry      bool
+	RootDAGRun exec.DAGRunRef
+}
+
+// Attempt records and reads state for a single workflow execution attempt.
+type Attempt interface {
+	ID() string
+	Open(ctx context.Context) error
+	RecordStatus(ctx context.Context, status exec.DAGRunStatus) error
+	RecordOutputs(ctx context.Context, outputs *exec.DAGRunOutputs) error
+	ReadStatus(ctx context.Context) (*exec.DAGRunStatus, error)
+	RequestCancel(ctx context.Context) error
+	CancelRequested(ctx context.Context) (bool, error)
+	ReadStepMessages(ctx context.Context, stepName string) ([]exec.LLMMessage, error)
+	WriteStepMessages(ctx context.Context, stepName string, messages []exec.LLMMessage) error
+	WorkDir() string
+	Close(ctx context.Context) error
+}

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime"
 	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
 	"github.com/dagucloud/dagu/internal/workspace"
 )
@@ -193,11 +194,11 @@ func (r *Local) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest)
 		return nil, errStepNameNotSet
 	}
 
-	dagRunStore := r.dagRunStoreFromContext(ctx)
-	if dagRunStore == nil {
+	runStateStore := r.runStateStoreFromContext(ctx)
+	if runStateStore == nil {
 		return nil, errNoRunDatabase
 	}
-	attempt, err := dagRunStore.FindSubAttempt(ctx, req.RootDAGRun, req.RunID)
+	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find child workflow attempt: %w", err)
 	}
@@ -236,15 +237,15 @@ func (r *Local) Cancel(ctx context.Context, req executor.SubWorkflowCancelReques
 		return nil
 	}
 
-	dagRunStore := r.dagRunStoreFromContext(ctx)
-	if dagRunStore == nil || req.RunID == "" || req.RootDAGRun.Zero() {
+	runStateStore := r.runStateStoreFromContext(ctx)
+	if runStateStore == nil || req.RunID == "" || req.RootDAGRun.Zero() {
 		return nil
 	}
-	attempt, err := dagRunStore.FindSubAttempt(ctx, req.RootDAGRun, req.RunID)
+	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
 	if err != nil {
 		return nil
 	}
-	return attempt.Abort(ctx)
+	return attempt.RequestCancel(ctx)
 }
 
 func (r *Local) newAgent(
@@ -351,6 +352,13 @@ func (r *Local) dagRunStoreFromContext(ctx context.Context) exec.DAGRunStore {
 		return rCtx.DAGRunStore
 	}
 	return agentctx.GetDAGRunStore(ctx)
+}
+
+func (r *Local) runStateStoreFromContext(ctx context.Context) runstate.Store {
+	if dagRunStore := r.dagRunStoreFromContext(ctx); dagRunStore != nil {
+		return runstate.NewHistoryStore(dagRunStore)
+	}
+	return nil
 }
 
 func (r *Local) queueStoreFromContext(ctx context.Context) exec.QueueStore {

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -5,6 +5,7 @@ package subflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -243,7 +244,10 @@ func (r *Local) Cancel(ctx context.Context, req executor.SubWorkflowCancelReques
 	}
 	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
 	if err != nil {
-		return nil
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to find child workflow attempt: %w", err)
 	}
 	return attempt.RequestCancel(ctx)
 }

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -5,6 +5,7 @@ package subflow_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -39,8 +40,97 @@ func TestLocalCancelRequestsStoredChildAttemptWhenInactive(t *testing.T) {
 	attempt.AssertExpectations(t)
 }
 
+func TestLocalCancelIgnoresMissingStoredChildAttemptWhenInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := exec.NewDAGRunRef("root", "root-run")
+	store := &localDAGRunStore{}
+	runner := subflow.NewLocal(runtime.Manager{}, nil, subflow.WithLocalDAGRunStore(store))
+
+	err := runner.Cancel(ctx, executor.SubWorkflowCancelRequest{
+		DAG:        &core.DAG{Name: "child"},
+		RootDAGRun: root,
+		RunID:      "child-run",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, root, store.findRoot)
+	require.Equal(t, "child-run", store.findRunID)
+}
+
+func TestLocalCancelReturnsStoredChildAttemptLookupError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := exec.NewDAGRunRef("root", "root-run")
+	findErr := errors.New("store unavailable")
+	store := &localDAGRunStore{findErr: findErr}
+	runner := subflow.NewLocal(runtime.Manager{}, nil, subflow.WithLocalDAGRunStore(store))
+
+	err := runner.Cancel(ctx, executor.SubWorkflowCancelRequest{
+		DAG:        &core.DAG{Name: "child"},
+		RootDAGRun: root,
+		RunID:      "child-run",
+	})
+
+	require.ErrorIs(t, err, findErr)
+	require.ErrorContains(t, err, "failed to find child workflow attempt")
+	require.Equal(t, root, store.findRoot)
+	require.Equal(t, "child-run", store.findRunID)
+}
+
+func TestLocalRetryRejectsMissingRunDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := exec.NewDAGRunRef("root", "root-run")
+	runner := subflow.NewLocal(runtime.Manager{}, nil)
+
+	result, err := runner.Retry(ctx, executor.SubWorkflowRetryRequest{
+		SubWorkflowRequest: executor.SubWorkflowRequest{
+			DAG:        &core.DAG{Name: "child"},
+			RootDAGRun: root,
+			RunID:      "child-run",
+		},
+		StepName: "step-1",
+	})
+
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "child workflow status database is not configured")
+}
+
+func TestLocalRetryReadsStoredChildAttemptStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := exec.NewDAGRunRef("root", "root-run")
+	readErr := errors.New("read status failed")
+	attempt := new(exec.MockDAGRunAttempt)
+	attempt.On("ReadStatus", ctx).Return(nil, readErr).Once()
+	store := &localDAGRunStore{subAttempt: attempt}
+	runner := subflow.NewLocal(runtime.Manager{}, nil, subflow.WithLocalDAGRunStore(store))
+
+	result, err := runner.Retry(ctx, executor.SubWorkflowRetryRequest{
+		SubWorkflowRequest: executor.SubWorkflowRequest{
+			DAG:        &core.DAG{Name: "child"},
+			RootDAGRun: root,
+			RunID:      "child-run",
+		},
+		StepName: "step-1",
+	})
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorContains(t, err, "failed to read child workflow status")
+	require.Equal(t, root, store.findRoot)
+	require.Equal(t, "child-run", store.findRunID)
+	attempt.AssertExpectations(t)
+}
+
 type localDAGRunStore struct {
 	subAttempt exec.DAGRunAttempt
+	findErr    error
 	findRoot   exec.DAGRunRef
 	findRunID  string
 }
@@ -83,6 +173,9 @@ func (s *localDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DA
 func (s *localDAGRunStore) FindSubAttempt(_ context.Context, root exec.DAGRunRef, childRunID string) (exec.DAGRunAttempt, error) {
 	s.findRoot = root
 	s.findRunID = childRunID
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
 	if s.subAttempt == nil {
 		return nil, exec.ErrDAGRunIDNotFound
 	}

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package subflow_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/subflow"
+)
+
+func TestLocalCancelRequestsStoredChildAttemptWhenInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := exec.NewDAGRunRef("root", "root-run")
+	attempt := new(exec.MockDAGRunAttempt)
+	attempt.On("Abort", ctx).Return(nil).Once()
+	store := &localDAGRunStore{subAttempt: attempt}
+	runner := subflow.NewLocal(runtime.Manager{}, nil, subflow.WithLocalDAGRunStore(store))
+
+	err := runner.Cancel(ctx, executor.SubWorkflowCancelRequest{
+		DAG:        &core.DAG{Name: "child"},
+		RootDAGRun: root,
+		RunID:      "child-run",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, root, store.findRoot)
+	require.Equal(t, "child-run", store.findRunID)
+	attempt.AssertExpectations(t)
+}
+
+type localDAGRunStore struct {
+	subAttempt exec.DAGRunAttempt
+	findRoot   exec.DAGRunRef
+	findRunID  string
+}
+
+func (s *localDAGRunStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
+	return nil, nil
+}
+
+func (s *localDAGRunStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
+	return nil
+}
+
+func (s *localDAGRunStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *localDAGRunStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	return nil, nil
+}
+
+func (s *localDAGRunStore) ListStatusesPage(context.Context, ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
+	return exec.DAGRunStatusPage{}, nil
+}
+
+func (s *localDAGRunStore) CompareAndSwapLatestAttemptStatus(
+	context.Context,
+	exec.DAGRunRef,
+	string,
+	core.Status,
+	func(*exec.DAGRunStatus) error,
+	...exec.CompareAndSwapStatusOption,
+) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
+func (s *localDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *localDAGRunStore) FindSubAttempt(_ context.Context, root exec.DAGRunRef, childRunID string) (exec.DAGRunAttempt, error) {
+	s.findRoot = root
+	s.findRunID = childRunID
+	if s.subAttempt == nil {
+		return nil, exec.ErrDAGRunIDNotFound
+	}
+	return s.subAttempt, nil
+}
+
+func (s *localDAGRunStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, nil
+}
+
+func (s *localDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.RemoveOldDAGRunsOption) ([]string, error) {
+	return nil, nil
+}
+
+func (s *localDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
+	return nil
+}
+
+func (s *localDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- introduce internal/runtime/runstate as the runtime-facing execution-state port
- move agent attempt begin/status/output/cancel reads through the run-state port
- move local subflow retry/cancel lookup through the same port while preserving DAGRunStore-backed history behavior

## Testing
- go test ./internal/runtime/runstate ./internal/subflow
- go test ./internal/runtime/agent
- go test -run '^$' ./internal/runtime/... ./internal/subflow
- git diff --check origin/main..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `internal/runtime/runstate`, a runtime-facing port for execution state. Agent and local subflow now use this port for attempts, status, outputs, and cancel checks while preserving `DAGRunStore` history and retention behavior.

- **Refactors**
  - Added `runstate.Store`/`Attempt` and `HistoryStore` over `exec.DAGRunStore` with prepared-attempt reuse, retention cleanup, and no-op attempts for shared-nothing mode.
  - Agent now uses `BeginAttempt`, `RecordStatus`, `RecordOutputs`, and `CancelRequested`; `WithPreparedAttempt` replaces the removed `preparedAttempt`, and mismatched attempt IDs now error out.
  - Local subflow opens child attempts via `OpenChildAttempt` and cancels via `RequestCancel`; it builds a `HistoryStore` from the context store and ignores missing child attempts on cancel.

<sup>Written for commit 3d715a7743d7811c1365ee1bf0e767c2c97a3df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved execution-history and state handling for workflow runs, with more reliable status/output persistence and cancellation detection
  * Updated child-workflow retry/cancel behavior to use the unified run-state layer, increasing robustness and error transparency

* **Tests**
  * Added extensive tests covering execution-state store behavior, attempt lifecycle, retention/cleanup, and local subflow retry/cancel scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->