### PR TITLE
refactor: separate runtime run state from history

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -197,7 +197,7 @@ func (e *Engine) RunYAML(ctx context.Context, yaml []byte, opts ...RunOption) (*
 	return &Run{inner: inner}, nil
 }
 
-// Status reads the latest file-backed status for a local DAG run.
+// Status reads the latest status for a local DAG run.
 func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
 	if e == nil || e.inner == nil {
 		return nil, fmt.Errorf("engine is not initialized")
@@ -207,6 +207,14 @@ func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
 		return nil, err
 	}
 	return publicStatus(status), nil
+}
+
+// Outputs reads the collected step outputs for a local DAG run.
+func (e *Engine) Outputs(ctx context.Context, ref RunRef) (map[string]string, error) {
+	if e == nil || e.inner == nil {
+		return nil, fmt.Errorf("engine is not initialized")
+	}
+	return e.inner.Outputs(ctx, internalRunRef(ref))
 }
 
 // Stop requests cancellation for a local DAG run.
@@ -269,6 +277,14 @@ func (r *Run) Status(ctx context.Context) (*Status, error) {
 	}
 	status, err := r.inner.Status(ctx)
 	return publicStatus(status), err
+}
+
+// Outputs reads the collected step outputs for this run.
+func (r *Run) Outputs(ctx context.Context) (map[string]string, error) {
+	if r == nil || r.inner == nil {
+		return nil, fmt.Errorf("run is not initialized")
+	}
+	return r.inner.Outputs(ctx)
 }
 
 // Stop requests cancellation for this run.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -40,6 +40,7 @@
 - Added embedded run output readback so no-file local execution can verify collected outputs through runtime state instead of relying on file-backed dag-run history.
 - Added `internal/node` as the adapter for child workflow runner construction. The adapter owns the distributed/local router composition, while command, worker, engine, and test code still own their concrete stores and remote transport dependencies.
 - When both `RunStateStore` and `DAGRunStore` are configured for embedded execution, `RunStateStore` is now authoritative for status, outputs, and cancel requests because the agent writes to that store.
+- A missing run-state attempt now falls back to DAG-run history in hybrid configurations. Other run-state errors still remain authoritative. This preserves compatibility for runs created before the direct run-state store saw them without hiding real runtime-state failures.
 - Direct run-state embedded execution now preflights duplicate run IDs before returning a run handle. This matches the file-backed path more closely and keeps duplicate errors synchronous.
 - `memstore` validates run IDs at the adapter boundary instead of relying only on engine-level validation.
 - CodeRabbit review fixes kept the missing-store errors explicit when neither runtime nor history storage is configured, and preserved `ProfileStore` when test-helper subworkflows are routed through the centralized factory.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -42,6 +42,7 @@
 - When both `RunStateStore` and `DAGRunStore` are configured for embedded execution, `RunStateStore` is now authoritative for status, outputs, and cancel requests because the agent writes to that store.
 - Direct run-state embedded execution now preflights duplicate run IDs before returning a run handle. This matches the file-backed path more closely and keeps duplicate errors synchronous.
 - `memstore` validates run IDs at the adapter boundary instead of relying only on engine-level validation.
+- CodeRabbit review fixes kept the missing-store errors explicit when neither runtime nor history storage is configured, and preserved `ProfileStore` when test-helper subworkflows are routed through the centralized factory.
 
 ### Verification
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -16,3 +16,35 @@
 ## Verification notes
 
 - The full Go suite must run outside the filesystem sandbox because several existing tests create localhost `httptest` servers. In-sandbox `make test` fails with `bind: operation not permitted`; escalated `make test` passed.
+
+## Plane separation refactor
+
+### Invariant
+
+- Preserve existing Dagu CLI/server/worker behavior and storage formats while allowing local execution to use a runtime `runstate.Store` directly.
+
+### Target Strings
+
+- Notes file: `implementation-notes.md`
+- New package: `internal/runtime/runstate/memstore`
+- No branch, image name, package release name, tag, workflow trigger, or release output is changed.
+
+### Decisions
+
+- Treat the next deep module as execution state, not generic persistence. The runtime-facing seam should expose run attempt behavior, while Dagu history listing, retention, rename, and UI queries stay outside the engine store.
+- Added `OpenAttempt`, `OpenChildAttempt`, `ReadStatus`, and `ReadOutputs` to the runtime run-state port. These are still execution-state operations needed by embedded local execution and retry/cancel flows; broad history operations remain on `DAGRunStore`.
+- Added `internal/runtime/runstate/memstore` as a concrete runtime store for embedded/no-file dag-run state. It keeps root and child attempt state in memory and intentionally omits listing, retention, rename, and UI history behavior.
+- `Agent` now prefers an explicitly supplied `runstate.Store`. The existing prepared-attempt path remains the file-backed local execution path so current Dagu storage formats and proc attempt IDs are preserved.
+- `subflow.Local` now accepts a direct `runstate.Store` and passes it to child workflow agents. When no direct store is provided, it keeps using the current `DAGRunStore`-backed history adapter.
+- Embedded local execution can be configured without `DAGRunStore`; process tracking uses the run ID until the runtime opens its attempt. This keeps duplicate-run protection lightweight but means no-file embedded mode does not provide Dagu history/listing APIs.
+- Added embedded run output readback so no-file local execution can verify collected outputs through runtime state instead of relying on file-backed dag-run history.
+- Added `internal/node` as the adapter for child workflow runner construction. The adapter owns the distributed/local router composition, while command, worker, engine, and test code still own their concrete stores and remote transport dependencies.
+- When both `RunStateStore` and `DAGRunStore` are configured for embedded execution, `RunStateStore` is now authoritative for status, outputs, and cancel requests because the agent writes to that store.
+- Direct run-state embedded execution now preflights duplicate run IDs before returning a run handle. This matches the file-backed path more closely and keeps duplicate errors synchronous.
+- `memstore` validates run IDs at the adapter boundary instead of relying only on engine-level validation.
+
+### Verification
+
+- `go test ./internal/node ./internal/runtime/runstate/... ./internal/runtime/agent ./internal/subflow ./internal/engine ./internal/cmd ./internal/service/worker ./internal/test`
+- `go test .`
+- `git diff --check`

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/dagstate"
 	"github.com/dagucloud/dagu/internal/license"
+	"github.com/dagucloud/dagu/internal/node"
 	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/store"
 	"github.com/dagucloud/dagu/internal/runtime"
@@ -42,7 +43,6 @@ import (
 	"github.com/dagucloud/dagu/internal/service/frontend"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
-	"github.com/dagucloud/dagu/internal/subflow"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -589,34 +589,22 @@ func (c *Context) NewCoordinatorClient() coordinator.Client {
 }
 
 func (c *Context) SubWorkflowRunnerFactory() func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
-	var factory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
-	factory = func(_ context.Context) (runtimeexec.SubWorkflowRunner, error) {
-		dagStore, err := c.dagStore(dagStoreConfig{})
-		if err != nil {
-			return nil, err
-		}
-		dispatcher, err := coordinator.NewRuntimeDispatcher(c.ServiceRegistry, c.Config.Core.Peer)
-		if err != nil {
-			return nil, err
-		}
-		stores := c.agentStores()
-		return subflow.NewRouter(
-			subflow.New(dispatcher, c.Config.DefaultExecMode),
-			subflow.NewLocal(
-				c.DAGRunMgr,
-				dagStore,
-				subflow.WithLocalDAGRunStore(c.DAGRunStore),
-				subflow.WithLocalQueueStore(c.QueueStore),
-				subflow.WithLocalStateStore(c.StateStore),
-				subflow.WithLocalSecretStore(stores.SecretStore),
-				subflow.WithLocalServiceRegistry(c.ServiceRegistry),
-				subflow.WithLocalSubWorkflowRunnerFactory(factory),
-				subflow.WithLocalWorkerID("local"),
-				subflow.WithLocalDAGRunDirs(c.Config.Paths.LogDir, c.Config.Paths.ArtifactDir),
-			),
-		), nil
-	}
-	return factory
+	return node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+		DAGRunMgr: c.DAGRunMgr,
+		DAGStoreFactory: func(context.Context) (exec.DAGStore, error) {
+			return c.dagStore(dagStoreConfig{})
+		},
+		DAGRunStore:       c.DAGRunStore,
+		QueueStore:        c.QueueStore,
+		StateStore:        c.StateStore,
+		AgentStores:       c.agentStores(),
+		ServiceRegistry:   c.ServiceRegistry,
+		PeerConfig:        c.Config.Core.Peer,
+		DefaultExecMode:   c.Config.DefaultExecMode,
+		WorkerID:          "local",
+		DAGRunLogDir:      c.Config.Paths.LogDir,
+		DAGRunArtifactDir: c.Config.Paths.ArtifactDir,
+	})
 }
 
 // NewScheduler creates a scheduler for this command context.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -17,16 +17,18 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	coreexec "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/dagstate"
+	"github.com/dagucloud/dagu/internal/node"
 	"github.com/dagucloud/dagu/internal/runtime"
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
-	"github.com/dagucloud/dagu/internal/subflow"
 	"github.com/spf13/viper"
 )
 
 type Engine struct {
 	cfg             *config.Config
 	dagRunStore     coreexec.DAGRunStore
+	runStateStore   runstate.Store
 	stateStore      dagstate.Store
 	procStore       coreexec.ProcStore
 	serviceRegistry coreexec.ServiceRegistry
@@ -79,6 +81,7 @@ func New(ctx context.Context, opts Options) (*Engine, error) {
 	return &Engine{
 		cfg:             cfg,
 		dagRunStore:     persistence.DAGRunStore,
+		runStateStore:   persistence.RunStateStore,
 		stateStore:      persistence.StateStore,
 		procStore:       persistence.ProcStore,
 		serviceRegistry: persistence.ServiceRegistry,
@@ -205,28 +208,20 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 }
 
 func (e *Engine) subWorkflowRunnerFactory(stores AgentStores) func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
-	var factory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
-	factory = func(_ context.Context) (runtimeexec.SubWorkflowRunner, error) {
-		dispatcher, err := coordinator.NewRuntimeDispatcher(e.serviceRegistry, e.cfg.Core.Peer)
-		if err != nil {
-			return nil, err
-		}
-		return subflow.NewRouter(
-			subflow.New(dispatcher, configExecutionMode(e.defaultMode)),
-			subflow.NewLocal(
-				e.dagRunMgr,
-				e.dagStore,
-				subflow.WithLocalDAGRunStore(e.dagRunStore),
-				subflow.WithLocalStateStore(e.stateStore),
-				subflow.WithLocalSecretStore(stores.SecretStore),
-				subflow.WithLocalServiceRegistry(e.serviceRegistry),
-				subflow.WithLocalSubWorkflowRunnerFactory(factory),
-				subflow.WithLocalWorkerID("local"),
-				subflow.WithLocalDAGRunDirs(e.cfg.Paths.LogDir, e.cfg.Paths.ArtifactDir),
-			),
-		), nil
-	}
-	return factory
+	return node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+		DAGRunMgr:         e.dagRunMgr,
+		DAGStore:          e.dagStore,
+		DAGRunStore:       e.dagRunStore,
+		RunStateStore:     e.runStateStore,
+		StateStore:        e.stateStore,
+		AgentStores:       stores,
+		ServiceRegistry:   e.serviceRegistry,
+		PeerConfig:        e.cfg.Core.Peer,
+		DefaultExecMode:   configExecutionMode(e.defaultMode),
+		WorkerID:          "local",
+		DAGRunLogDir:      e.cfg.Paths.LogDir,
+		DAGRunArtifactDir: e.cfg.Paths.ArtifactDir,
+	})
 }
 
 func runStatusToPublic(status *coreexec.DAGRunStatus) (*Status, error) {

--- a/internal/engine/persistence.go
+++ b/internal/engine/persistence.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/dagstate"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
 )
 
 // PersistenceFactory wires backend-specific stores after configuration is loaded.
@@ -22,6 +23,7 @@ type PersistenceFactory func(context.Context, *config.Config) (Persistence, erro
 type Persistence struct {
 	DAGStore             exec.DAGStore
 	DAGRunStore          exec.DAGRunStore
+	RunStateStore        runstate.Store
 	ProcStore            exec.ProcStore
 	StateStore           dagstate.Store
 	ServiceRegistry      exec.ServiceRegistry
@@ -61,6 +63,9 @@ func buildPersistence(ctx context.Context, cfg *config.Config, opts Options) (Pe
 	if opts.DAGRunStore != nil {
 		p.DAGRunStore = opts.DAGRunStore
 	}
+	if opts.RunStateStore != nil {
+		p.RunStateStore = opts.RunStateStore
+	}
 	if err := validatePersistence(ctx, p); err != nil {
 		return Persistence{}, err
 	}
@@ -73,6 +78,9 @@ func overridePersistence(base, override Persistence) Persistence {
 	}
 	if override.DAGRunStore != nil {
 		base.DAGRunStore = override.DAGRunStore
+	}
+	if override.RunStateStore != nil {
+		base.RunStateStore = override.RunStateStore
 	}
 	if override.ProcStore != nil {
 		base.ProcStore = override.ProcStore
@@ -100,8 +108,8 @@ func validatePersistence(ctx context.Context, p Persistence) error {
 	if p.DAGStore == nil {
 		errs = append(errs, errors.New("DAG store is not configured"))
 	}
-	if p.DAGRunStore == nil {
-		errs = append(errs, errors.New("DAG-run store is not configured"))
+	if p.DAGRunStore == nil && p.RunStateStore == nil {
+		errs = append(errs, errors.New("DAG-run store or run-state store is not configured"))
 	}
 	if p.ProcStore == nil {
 		errs = append(errs, errors.New("proc store is not configured"))

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -54,17 +54,53 @@ func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
 	if ref.Name == "" || ref.ID == "" {
 		return nil, fmt.Errorf("run name and ID are required")
 	}
-	status, err := e.dagRunMgr.GetSavedStatus(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+	runRef := coreexec.NewDAGRunRef(ref.Name, ref.ID)
+	var (
+		status *coreexec.DAGRunStatus
+		err    error
+	)
+	if e.runStateStore != nil {
+		status, err = e.readRunStateStatus(ctx, runRef)
+	} else if e.dagRunStore != nil {
+		status, err = e.dagRunMgr.GetSavedStatus(ctx, runRef)
+	} else {
+		err = fmt.Errorf("run-state store is not configured")
+	}
 	if err != nil {
 		return nil, err
 	}
 	return runStatusToPublic(status)
 }
 
+func (e *Engine) Outputs(ctx context.Context, ref RunRef) (map[string]string, error) {
+	ctx = e.context(ctx)
+	if ref.Name == "" || ref.ID == "" {
+		return nil, fmt.Errorf("run name and ID are required")
+	}
+	outputs, err := e.readOutputs(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+	if err != nil {
+		return nil, err
+	}
+	if outputs == nil {
+		return nil, nil
+	}
+	return cloneStringMap(outputs.Outputs), nil
+}
+
 func (e *Engine) Stop(ctx context.Context, ref RunRef) error {
 	ctx = e.context(ctx)
 	if ref.Name == "" || ref.ID == "" {
 		return fmt.Errorf("run name and ID are required")
+	}
+	if e.runStateStore != nil {
+		attempt, err := e.runStateStore.OpenAttempt(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+		if err != nil {
+			return err
+		}
+		return attempt.RequestCancel(ctx)
+	}
+	if e.dagRunStore == nil {
+		return fmt.Errorf("DAG-run store is not configured")
 	}
 	attempt, err := e.dagRunStore.FindAttempt(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
 	if err != nil {
@@ -118,6 +154,10 @@ func (r *Run) Status(ctx context.Context) (*Status, error) {
 	return r.engine.Status(ctx, r.ref)
 }
 
+func (r *Run) Outputs(ctx context.Context) (map[string]string, error) {
+	return r.engine.Outputs(ctx, r.ref)
+}
+
 func (r *Run) Stop(ctx context.Context) error {
 	if r.mode == ExecutionModeDistributed {
 		if r.cancel != nil {
@@ -136,6 +176,36 @@ func (r *Run) Stop(ctx context.Context) error {
 		r.cancel()
 	}
 	return r.engine.Stop(ctx, r.ref)
+}
+
+func (e *Engine) readRunStateStatus(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunStatus, error) {
+	attempt, err := e.runStateStore.OpenAttempt(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+func (e *Engine) readOutputs(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunOutputs, error) {
+	if e.runStateStore != nil {
+		attempt, err := e.runStateStore.OpenAttempt(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		return attempt.ReadOutputs(ctx)
+	}
+	if e.dagRunStore != nil {
+		attempt, err := e.dagRunStore.FindAttempt(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		return attempt.ReadOutputs(ctx)
+	}
+	return nil, fmt.Errorf("run-state store is not configured")
 }
 
 func (r *Run) waitLocal(ctx context.Context) (*Status, error) {
@@ -351,6 +421,7 @@ func (e *Engine) runLocal(ctx context.Context, dag *core.DAG, runID string, opts
 			Dry:                        opts.DryRun,
 			WorkerID:                   "local",
 			PreparedAttempt:            preparedAttempt(prepared),
+			RunStateStore:              e.runStateStore,
 			DAGRunStore:                e.dagRunStore,
 			StateStore:                 e.stateStore,
 			SecretStore:                stores.SecretStore,
@@ -498,24 +569,38 @@ func (e *Engine) prepareLocal(ctx context.Context, dag *core.DAG, runID string, 
 	}
 	defer e.procStore.Unlock(ctx, dag.ProcGroup())
 
-	attempt, err := e.dagRunStore.CreateAttempt(ctx, dag, time.Now(), runID, coreexec.NewDAGRunAttemptOptions{})
-	if err != nil {
-		if errors.Is(err, coreexec.ErrDAGRunAlreadyExists) {
-			return nil, fmt.Errorf("dag-run ID %s already exists for DAG %s: %w", runID, dag.Name, err)
+	var attempt coreexec.DAGRunAttempt
+	attemptID := runID
+	if e.dagRunStore != nil {
+		created, err := e.dagRunStore.CreateAttempt(ctx, dag, time.Now(), runID, coreexec.NewDAGRunAttemptOptions{})
+		if err != nil {
+			if errors.Is(err, coreexec.ErrDAGRunAlreadyExists) {
+				return nil, fmt.Errorf("dag-run ID %s already exists for DAG %s: %w", runID, dag.Name, err)
+			}
+			return nil, fmt.Errorf("create DAG run attempt: %w", err)
 		}
-		return nil, fmt.Errorf("create DAG run attempt: %w", err)
+		created.SetDAG(dag)
+		attempt = created
+		attemptID = created.ID()
+	} else if e.runStateStore != nil {
+		if _, err := e.runStateStore.OpenAttempt(ctx, root); err == nil {
+			return nil, fmt.Errorf("%w: %s", coreexec.ErrDAGRunAlreadyExists, runID)
+		} else if !errors.Is(err, coreexec.ErrDAGRunIDNotFound) {
+			return nil, fmt.Errorf("check existing run-state attempt: %w", err)
+		}
 	}
-	attempt.SetDAG(dag)
 	proc, err := e.procStore.Acquire(ctx, dag.ProcGroup(), coreexec.ProcMeta{
 		StartedAt:    time.Now().Unix(),
 		Name:         dag.Name,
 		DAGRunID:     runID,
-		AttemptID:    attempt.ID(),
+		AttemptID:    attemptID,
 		RootName:     root.Name,
 		RootDAGRunID: root.ID,
 	})
 	if err != nil {
-		_ = e.recordPreparedFailure(ctx, attempt, dag, runID, root, err)
+		if attempt != nil {
+			_ = e.recordPreparedFailure(ctx, attempt, dag, runID, root, err)
+		}
 		return nil, fmt.Errorf("acquire process handle: %w", err)
 	}
 	return &localPreparation{attempt: attempt, proc: proc}, nil

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -54,18 +54,7 @@ func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
 	if ref.Name == "" || ref.ID == "" {
 		return nil, fmt.Errorf("run name and ID are required")
 	}
-	runRef := coreexec.NewDAGRunRef(ref.Name, ref.ID)
-	var (
-		status *coreexec.DAGRunStatus
-		err    error
-	)
-	if e.runStateStore != nil {
-		status, err = e.readRunStateStatus(ctx, runRef)
-	} else if e.dagRunStore != nil {
-		status, err = e.dagRunMgr.GetSavedStatus(ctx, runRef)
-	} else {
-		err = fmt.Errorf("neither run-state store nor DAG-run store is configured")
-	}
+	status, err := e.readStatus(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -92,17 +81,40 @@ func (e *Engine) Stop(ctx context.Context, ref RunRef) error {
 	if ref.Name == "" || ref.ID == "" {
 		return fmt.Errorf("run name and ID are required")
 	}
+	runRef := coreexec.NewDAGRunRef(ref.Name, ref.ID)
 	if e.runStateStore != nil {
-		attempt, err := e.runStateStore.OpenAttempt(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
-		if err != nil {
+		attempt, err := e.runStateStore.OpenAttempt(ctx, runRef)
+		if err == nil {
+			return attempt.RequestCancel(ctx)
+		}
+		if !e.shouldFallbackToDAGRunStore(err) {
 			return err
 		}
-		return attempt.RequestCancel(ctx)
 	}
 	if e.dagRunStore == nil {
 		return fmt.Errorf("DAG-run store is not configured")
 	}
-	attempt, err := e.dagRunStore.FindAttempt(ctx, coreexec.NewDAGRunRef(ref.Name, ref.ID))
+	return e.stopDAGRunStore(ctx, ref.ID, runRef)
+}
+
+func (e *Engine) readStatus(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunStatus, error) {
+	if e.runStateStore != nil {
+		status, err := e.readRunStateStatus(ctx, ref)
+		if err == nil {
+			return status, nil
+		}
+		if !e.shouldFallbackToDAGRunStore(err) {
+			return nil, err
+		}
+	}
+	if e.dagRunStore != nil {
+		return e.dagRunMgr.GetSavedStatus(ctx, ref)
+	}
+	return nil, fmt.Errorf("neither run-state store nor DAG-run store is configured")
+}
+
+func (e *Engine) stopDAGRunStore(ctx context.Context, dagRunID string, ref coreexec.DAGRunRef) error {
+	attempt, err := e.dagRunStore.FindAttempt(ctx, ref)
 	if err != nil {
 		return err
 	}
@@ -110,7 +122,7 @@ func (e *Engine) Stop(ctx context.Context, ref RunRef) error {
 	if err != nil {
 		return err
 	}
-	return e.dagRunMgr.Stop(ctx, dag, ref.ID)
+	return e.dagRunMgr.Stop(ctx, dag, dagRunID)
 }
 
 func (r *Run) Ref() RunRef {
@@ -192,20 +204,38 @@ func (e *Engine) readRunStateStatus(ctx context.Context, ref coreexec.DAGRunRef)
 
 func (e *Engine) readOutputs(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunOutputs, error) {
 	if e.runStateStore != nil {
-		attempt, err := e.runStateStore.OpenAttempt(ctx, ref)
-		if err != nil {
+		outputs, err := e.readRunStateOutputs(ctx, ref)
+		if err == nil {
+			return outputs, nil
+		}
+		if !e.shouldFallbackToDAGRunStore(err) {
 			return nil, err
 		}
-		return attempt.ReadOutputs(ctx)
 	}
 	if e.dagRunStore != nil {
-		attempt, err := e.dagRunStore.FindAttempt(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		return attempt.ReadOutputs(ctx)
+		return e.readDAGRunOutputs(ctx, ref)
 	}
 	return nil, fmt.Errorf("neither run-state store nor DAG-run store is configured")
+}
+
+func (e *Engine) readRunStateOutputs(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunOutputs, error) {
+	attempt, err := e.runStateStore.OpenAttempt(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return attempt.ReadOutputs(ctx)
+}
+
+func (e *Engine) readDAGRunOutputs(ctx context.Context, ref coreexec.DAGRunRef) (*coreexec.DAGRunOutputs, error) {
+	attempt, err := e.dagRunStore.FindAttempt(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return attempt.ReadOutputs(ctx)
+}
+
+func (e *Engine) shouldFallbackToDAGRunStore(err error) bool {
+	return e.dagRunStore != nil && errors.Is(err, coreexec.ErrDAGRunIDNotFound)
 }
 
 func (r *Run) waitLocal(ctx context.Context) (*Status, error) {

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -64,7 +64,7 @@ func (e *Engine) Status(ctx context.Context, ref RunRef) (*Status, error) {
 	} else if e.dagRunStore != nil {
 		status, err = e.dagRunMgr.GetSavedStatus(ctx, runRef)
 	} else {
-		err = fmt.Errorf("run-state store is not configured")
+		err = fmt.Errorf("neither run-state store nor DAG-run store is configured")
 	}
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func (e *Engine) readOutputs(ctx context.Context, ref coreexec.DAGRunRef) (*core
 		}
 		return attempt.ReadOutputs(ctx)
 	}
-	return nil, fmt.Errorf("run-state store is not configured")
+	return nil, fmt.Errorf("neither run-state store nor DAG-run store is configured")
 }
 
 func (r *Run) waitLocal(ctx context.Context) (*Status, error) {

--- a/internal/engine/runstate_test.go
+++ b/internal/engine/runstate_test.go
@@ -1,0 +1,156 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/engine"
+	"github.com/dagucloud/dagu/internal/persis/file"
+	"github.com/dagucloud/dagu/internal/persis/store"
+	"github.com/dagucloud/dagu/internal/persis/testutil"
+	"github.com/dagucloud/dagu/internal/runtime/runstate/memstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunYAMLUsesRunStateStoreWithoutDAGRunStore(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	runStateStore := memstore.New()
+	eng, err := engine.New(ctx, engine.Options{
+		HomeDir:            t.TempDir(),
+		PersistenceFactory: memoryPersistenceFactory(runStateStore),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, eng.Close(context.Background()))
+	})
+
+	run, err := eng.RunYAML(ctx, []byte(`
+name: embedded-memory-state
+steps:
+  - name: produce
+    command: echo memory-state
+    output: RESULT
+`), engine.RunOptions{RunID: "memory-run"})
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-memory-state", status.Name)
+
+	outputs, err := run.Outputs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"result": "memory-state"}, outputs)
+
+	opened, err := runStateStore.OpenAttempt(ctx, coreexec.NewDAGRunRef("embedded-memory-state", "memory-run"))
+	require.NoError(t, err)
+	persisted, err := opened.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", persisted.Status.String())
+}
+
+func TestRunYAMLUsesRunStateStoreWhenDAGRunStoreAlsoConfigured(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	runStateStore := memstore.New()
+	eng, err := engine.New(ctx, engine.Options{
+		HomeDir:            t.TempDir(),
+		PersistenceFactory: hybridPersistenceFactory(runStateStore),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, eng.Close(context.Background()))
+	})
+
+	run, err := eng.RunYAML(ctx, []byte(`
+name: embedded-hybrid-state
+steps:
+  - name: produce
+    command: echo hybrid-state
+    output: RESULT
+`), engine.RunOptions{RunID: "hybrid-run"})
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-hybrid-state", status.Name)
+
+	outputs, err := run.Outputs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"result": "hybrid-state"}, outputs)
+}
+
+func TestRunYAMLRejectsDuplicateRunIDWithoutDAGRunStore(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	runStateStore := memstore.New()
+	eng, err := engine.New(ctx, engine.Options{
+		HomeDir:            t.TempDir(),
+		PersistenceFactory: memoryPersistenceFactory(runStateStore),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, eng.Close(context.Background()))
+	})
+
+	dagYAML := []byte(`
+name: embedded-duplicate-state
+steps:
+  - name: done
+    command: echo done
+`)
+	run, err := eng.RunYAML(ctx, dagYAML, engine.RunOptions{RunID: "duplicate-run"})
+	require.NoError(t, err)
+	_, err = run.Wait(ctx)
+	require.NoError(t, err)
+
+	secondRun, err := eng.RunYAML(ctx, dagYAML, engine.RunOptions{RunID: "duplicate-run"})
+	require.ErrorIs(t, err, coreexec.ErrDAGRunAlreadyExists)
+	require.Nil(t, secondRun)
+}
+
+func memoryPersistenceFactory(runStateStore *memstore.Store) engine.PersistenceFactory {
+	return func(ctx context.Context, cfg *config.Config) (engine.Persistence, error) {
+		backend := testutil.NewMemoryBackend()
+		dagStore, err := file.NewDAGStore(cfg, file.WithDAGSkipExamples(true))
+		if err != nil {
+			return engine.Persistence{}, err
+		}
+		return engine.Persistence{
+			DAGStore:        dagStore,
+			RunStateStore:   runStateStore,
+			ProcStore:       store.NewProcStore(backend.Collection("proc")),
+			StateStore:      store.NewDAGStateStore(backend.Collection("dag_state")),
+			ServiceRegistry: file.NewServiceRegistry(cfg),
+			DAGStoreFactory: func(_ context.Context, cfg *config.Config, opts engine.DAGStoreFactoryOptions) (coreexec.DAGStore, error) {
+				fileOpts := []file.DAGStoreOption{file.WithDAGSkipExamples(true)}
+				if len(opts.SearchPaths) > 0 {
+					fileOpts = append(fileOpts, file.WithDAGSearchPaths(opts.SearchPaths))
+				}
+				return file.NewDAGStore(cfg, fileOpts...)
+			},
+		}, nil
+	}
+}
+
+func hybridPersistenceFactory(runStateStore *memstore.Store) engine.PersistenceFactory {
+	return func(ctx context.Context, cfg *config.Config) (engine.Persistence, error) {
+		persistence, err := memoryPersistenceFactory(runStateStore)(ctx, cfg)
+		if err != nil {
+			return engine.Persistence{}, err
+		}
+		persistence.DAGRunStore = file.NewDAGRunStore(cfg, file.WithDAGRunLatestStatusToday(false))
+		return persistence, nil
+	}
+}

--- a/internal/engine/runstate_test.go
+++ b/internal/engine/runstate_test.go
@@ -90,6 +90,60 @@ steps:
 	require.Equal(t, map[string]string{"result": "hybrid-state"}, outputs)
 }
 
+func TestStatusAndOutputsFallBackToDAGRunStoreWhenRunStateMissing(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	homeDir := t.TempDir()
+	historyEngine, err := engine.New(ctx, engine.Options{
+		HomeDir:            homeDir,
+		PersistenceFactory: dagRunPersistenceFactory(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, historyEngine.Close(context.Background()))
+	})
+
+	run, err := historyEngine.RunYAML(ctx, []byte(`
+name: embedded-history-state
+steps:
+  - name: produce
+    command: echo history-state
+    output: RESULT
+`), engine.RunOptions{RunID: "history-run"})
+	require.NoError(t, err)
+
+	status, err := run.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-history-state", status.Name)
+
+	ref := run.Ref()
+	runStateStore := memstore.New()
+	hybridEngine, err := engine.New(ctx, engine.Options{
+		HomeDir:            homeDir,
+		PersistenceFactory: hybridPersistenceFactory(runStateStore),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, hybridEngine.Close(context.Background()))
+	})
+
+	_, err = runStateStore.OpenAttempt(ctx, coreexec.NewDAGRunRef("embedded-history-state", "history-run"))
+	require.ErrorIs(t, err, coreexec.ErrDAGRunIDNotFound)
+
+	status, err = hybridEngine.Status(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, "succeeded", status.Status)
+	require.Equal(t, "embedded-history-state", status.Name)
+
+	outputs, err := hybridEngine.Outputs(ctx, ref)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"result": "history-state"}, outputs)
+
+	require.NoError(t, hybridEngine.Stop(ctx, ref))
+}
+
 func TestRunYAMLRejectsDuplicateRunIDWithoutDAGRunStore(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -127,9 +181,8 @@ func memoryPersistenceFactory(runStateStore *memstore.Store) engine.PersistenceF
 		if err != nil {
 			return engine.Persistence{}, err
 		}
-		return engine.Persistence{
+		persistence := engine.Persistence{
 			DAGStore:        dagStore,
-			RunStateStore:   runStateStore,
 			ProcStore:       store.NewProcStore(backend.Collection("proc")),
 			StateStore:      store.NewDAGStateStore(backend.Collection("dag_state")),
 			ServiceRegistry: file.NewServiceRegistry(cfg),
@@ -140,7 +193,22 @@ func memoryPersistenceFactory(runStateStore *memstore.Store) engine.PersistenceF
 				}
 				return file.NewDAGStore(cfg, fileOpts...)
 			},
-		}, nil
+		}
+		if runStateStore != nil {
+			persistence.RunStateStore = runStateStore
+		}
+		return persistence, nil
+	}
+}
+
+func dagRunPersistenceFactory() engine.PersistenceFactory {
+	return func(ctx context.Context, cfg *config.Config) (engine.Persistence, error) {
+		persistence, err := memoryPersistenceFactory(nil)(ctx, cfg)
+		if err != nil {
+			return engine.Persistence{}, err
+		}
+		persistence.DAGRunStore = file.NewDAGRunStore(cfg, file.WithDAGRunLatestStatusToday(false))
+		return persistence, nil
 	}
 }
 

--- a/internal/engine/runstate_test.go
+++ b/internal/engine/runstate_test.go
@@ -121,7 +121,7 @@ steps:
 }
 
 func memoryPersistenceFactory(runStateStore *memstore.Store) engine.PersistenceFactory {
-	return func(ctx context.Context, cfg *config.Config) (engine.Persistence, error) {
+	return func(_ context.Context, cfg *config.Config) (engine.Persistence, error) {
 		backend := testutil.NewMemoryBackend()
 		dagStore, err := file.NewDAGStore(cfg, file.WithDAGSkipExamples(true))
 		if err != nil {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	coreexec "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/worker"
 )
@@ -35,6 +36,7 @@ type Options struct {
 
 	Persistence        Persistence
 	PersistenceFactory PersistenceFactory
+	RunStateStore      runstate.Store
 	DAGRunStore        coreexec.DAGRunStore
 	DefaultMode        ExecutionMode
 	Distributed        *DistributedOptions

--- a/internal/node/subworkflow.go
+++ b/internal/node/subworkflow.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package node wires runtime node adapters.
+package node
+
+import (
+	"context"
+
+	agentpkg "github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/dagstate"
+	"github.com/dagucloud/dagu/internal/runtime"
+	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	"github.com/dagucloud/dagu/internal/subflow"
+)
+
+// DAGStoreFactory creates the DAG definition store used by local child workflows.
+type DAGStoreFactory func(context.Context) (exec.DAGStore, error)
+
+// SubWorkflowRunnerConfig contains dependencies for child workflow execution.
+type SubWorkflowRunnerConfig struct {
+	DAGRunMgr         runtime.Manager
+	DAGStore          exec.DAGStore
+	DAGStoreFactory   DAGStoreFactory
+	DAGRunStore       exec.DAGRunStore
+	RunStateStore     runstate.Store
+	QueueStore        exec.QueueStore
+	StateStore        dagstate.Store
+	AgentStores       agentpkg.RuntimeStores
+	ServiceRegistry   exec.ServiceRegistry
+	PeerConfig        config.Peer
+	DefaultExecMode   config.ExecutionMode
+	StatusPusher      runtime.StatusPusher
+	LogWriterFactory  exec.LogWriterFactory
+	ArtifactFinalizer runtime.ArtifactFinalizer
+	WorkerID          string
+	DAGRunLogDir      string
+	DAGRunArtifactDir string
+}
+
+// NewSubWorkflowRunnerFactory creates recursive child workflow runners.
+func NewSubWorkflowRunnerFactory(cfg SubWorkflowRunnerConfig) func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
+	var factory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
+	factory = func(ctx context.Context) (runtimeexec.SubWorkflowRunner, error) {
+		dagStore, err := subWorkflowDAGStore(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		dispatcher, err := coordinator.NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
+		if err != nil {
+			return nil, err
+		}
+		return subflow.NewRouter(
+			subflow.New(dispatcher, cfg.DefaultExecMode),
+			subflow.NewLocal(
+				cfg.DAGRunMgr,
+				dagStore,
+				subflow.WithLocalDAGRunStore(cfg.DAGRunStore),
+				subflow.WithLocalRunStateStore(cfg.RunStateStore),
+				subflow.WithLocalQueueStore(cfg.QueueStore),
+				subflow.WithLocalStateStore(cfg.StateStore),
+				subflow.WithLocalSecretStore(cfg.AgentStores.SecretStore),
+				subflow.WithLocalProfileStore(cfg.AgentStores.ProfileStore),
+				subflow.WithLocalServiceRegistry(cfg.ServiceRegistry),
+				subflow.WithLocalStatusPusher(cfg.StatusPusher),
+				subflow.WithLocalLogWriterFactory(cfg.LogWriterFactory),
+				subflow.WithLocalArtifactFinalizer(cfg.ArtifactFinalizer),
+				subflow.WithLocalSubWorkflowRunnerFactory(factory),
+				subflow.WithLocalWorkerID(cfg.WorkerID),
+				subflow.WithLocalDAGRunDirs(cfg.DAGRunLogDir, cfg.DAGRunArtifactDir),
+			),
+		), nil
+	}
+	return factory
+}
+
+func subWorkflowDAGStore(ctx context.Context, cfg SubWorkflowRunnerConfig) (exec.DAGStore, error) {
+	if cfg.DAGStoreFactory != nil {
+		return cfg.DAGStoreFactory(ctx)
+	}
+	return cfg.DAGStore, nil
+}

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -316,6 +316,8 @@ type Options struct {
 	// PreparedAttempt is an exact attempt that was created or reopened before proc acquisition.
 	// This is used for local execution so the proc heartbeat can include the final attempt ID.
 	PreparedAttempt exec.DAGRunAttempt
+	// RunStateStore records execution state for this DAG run.
+	RunStateStore runstate.Store
 	// DAGRunStore is the store for dag-run data. Nil in shared-nothing mode.
 	DAGRunStore exec.DAGRunStore
 	// QueueStore is the store for queued dag-run items. Nil when queues are unavailable.
@@ -376,9 +378,11 @@ func New(
 	ds exec.DAGStore,
 	opts Options,
 ) *Agent {
-	runStateStore := runstate.NewHistoryStore(opts.DAGRunStore)
-	if opts.PreparedAttempt != nil {
+	runStateStore := opts.RunStateStore
+	if runStateStore == nil && opts.PreparedAttempt != nil {
 		runStateStore = runstate.NewHistoryStore(opts.DAGRunStore, runstate.WithPreparedAttempt(opts.PreparedAttempt))
+	} else if runStateStore == nil {
+		runStateStore = runstate.NewHistoryStore(opts.DAGRunStore)
 	}
 
 	a := &Agent{

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -215,7 +215,7 @@ func (m *Manager) IsRunning(ctx context.Context, dag *core.DAG, dagRunID string)
 	if st != nil && st.DAGRunID == dagRunID && st.Status == core.Running {
 		return true
 	}
-	if m.procStore == nil {
+	if m.procStore == nil || m.dagRunStore == nil {
 		return false
 	}
 

--- a/internal/runtime/runstate/dagrun_attempt.go
+++ b/internal/runtime/runstate/dagrun_attempt.go
@@ -37,6 +37,10 @@ func (a dagRunAttempt) ReadStatus(ctx context.Context) (*exec.DAGRunStatus, erro
 	return a.attempt.ReadStatus(ctx)
 }
 
+func (a dagRunAttempt) ReadOutputs(ctx context.Context) (*exec.DAGRunOutputs, error) {
+	return a.attempt.ReadOutputs(ctx)
+}
+
 func (a dagRunAttempt) RequestCancel(ctx context.Context) error {
 	return a.attempt.Abort(ctx)
 }

--- a/internal/runtime/runstate/history_store.go
+++ b/internal/runtime/runstate/history_store.go
@@ -75,6 +75,17 @@ func (s *historyStore) BeginAttempt(ctx context.Context, req BeginAttemptRequest
 	return wrapDAGRunAttempt(attempt), nil
 }
 
+func (s *historyStore) OpenAttempt(ctx context.Context, ref exec.DAGRunRef) (Attempt, error) {
+	if s.store == nil {
+		return nil, exec.ErrNoopAttemptNotSupported
+	}
+	attempt, err := s.store.FindAttempt(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return wrapDAGRunAttempt(attempt), nil
+}
+
 func (s *historyStore) OpenChildAttempt(ctx context.Context, root exec.DAGRunRef, childRunID string) (Attempt, error) {
 	if s.store == nil {
 		return nil, exec.ErrNoopAttemptNotSupported

--- a/internal/runtime/runstate/memstore/memstore_test.go
+++ b/internal/runtime/runstate/memstore/memstore_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package memstore_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
+	"github.com/dagucloud/dagu/internal/runtime/runstate/memstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreRecordsRootAndChildAttempts(t *testing.T) {
+	ctx := context.Background()
+	store := memstore.New()
+	rootRef := exec.NewDAGRunRef("root", "root-run")
+
+	root, err := store.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:   &core.DAG{Name: "root"},
+		RunID: rootRef.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "root-run", root.ID())
+
+	require.NoError(t, root.Open(ctx))
+	require.NoError(t, root.RecordStatus(ctx, exec.DAGRunStatus{
+		Name:      rootRef.Name,
+		DAGRunID:  rootRef.ID,
+		AttemptID: root.ID(),
+		Status:    core.Running,
+	}))
+	require.NoError(t, root.RecordOutputs(ctx, &exec.DAGRunOutputs{
+		Outputs: map[string]string{"result": "root-value"},
+	}))
+	require.NoError(t, root.WriteStepMessages(ctx, "ask", []exec.LLMMessage{{Role: "assistant", Content: "done"}}))
+
+	openedRoot, err := store.OpenAttempt(ctx, rootRef)
+	require.NoError(t, err)
+	rootStatus, err := openedRoot.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, core.Running, rootStatus.Status)
+	rootOutputs, err := openedRoot.ReadOutputs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"result": "root-value"}, rootOutputs.Outputs)
+	messages, err := openedRoot.ReadStepMessages(ctx, "ask")
+	require.NoError(t, err)
+	require.Equal(t, []exec.LLMMessage{{Role: "assistant", Content: "done"}}, messages)
+
+	child, err := store.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:        &core.DAG{Name: "child"},
+		RunID:      "child-run",
+		RootDAGRun: rootRef,
+	})
+	require.NoError(t, err)
+	require.NoError(t, child.RecordStatus(ctx, exec.DAGRunStatus{
+		Name:      "child",
+		DAGRunID:  "child-run",
+		AttemptID: child.ID(),
+		Status:    core.Succeeded,
+	}))
+	require.NoError(t, child.RequestCancel(ctx))
+
+	openedChild, err := store.OpenChildAttempt(ctx, rootRef, "child-run")
+	require.NoError(t, err)
+	childStatus, err := openedChild.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, core.Succeeded, childStatus.Status)
+	cancelled, err := openedChild.CancelRequested(ctx)
+	require.NoError(t, err)
+	require.True(t, cancelled)
+}
+
+func TestStoreRejectsInvalidRunID(t *testing.T) {
+	ctx := context.Background()
+	store := memstore.New()
+
+	_, err := store.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:   &core.DAG{Name: "invalid-run-id"},
+		RunID: "not valid",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dag-run ID")
+
+	_, err = store.BeginAttempt(ctx, runstate.BeginAttemptRequest{
+		DAG:   &core.DAG{Name: "too-long-run-id"},
+		RunID: strings.Repeat("a", 65),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dag-run ID")
+}

--- a/internal/runtime/runstate/memstore/store.go
+++ b/internal/runtime/runstate/memstore/store.go
@@ -1,0 +1,316 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package memstore provides an in-memory runtime run-state store.
+package memstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"sync"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime/runstate"
+)
+
+// Store records run attempts in memory.
+type Store struct {
+	mu sync.RWMutex
+
+	attempts map[attemptKey]*attemptState
+	latest   map[exec.DAGRunRef]attemptKey
+	children map[childKey]attemptKey
+	counters map[exec.DAGRunRef]int
+}
+
+var _ runstate.Store = (*Store)(nil)
+
+// New creates an empty in-memory run-state store.
+func New() *Store {
+	return &Store{
+		attempts: make(map[attemptKey]*attemptState),
+		latest:   make(map[exec.DAGRunRef]attemptKey),
+		children: make(map[childKey]attemptKey),
+		counters: make(map[exec.DAGRunRef]int),
+	}
+}
+
+// BeginAttempt opens a new attempt for a DAG run.
+func (s *Store) BeginAttempt(_ context.Context, req runstate.BeginAttemptRequest) (runstate.Attempt, error) {
+	if req.DAG == nil {
+		return nil, fmt.Errorf("DAG is required")
+	}
+	if req.DAG.Name == "" {
+		return nil, fmt.Errorf("DAG name is required")
+	}
+	if req.RunID == "" {
+		return nil, fmt.Errorf("dag-run ID is required")
+	}
+	if err := exec.ValidateDAGRunID(req.RunID); err != nil {
+		return nil, err
+	}
+
+	ref := exec.NewDAGRunRef(req.DAG.Name, req.RunID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.latest[ref]; exists && !req.Retry {
+		return nil, fmt.Errorf("%w: %s", exec.ErrDAGRunAlreadyExists, req.RunID)
+	}
+
+	s.counters[ref]++
+	attemptID := req.AttemptID
+	if attemptID == "" {
+		attemptID = generatedAttemptID(req.RunID, s.counters[ref])
+	}
+	key := attemptKey{ref: ref, id: attemptID}
+	state := &attemptState{
+		messages: make(map[string][]exec.LLMMessage),
+	}
+	s.attempts[key] = state
+	s.latest[ref] = key
+	if req.RootDAGRun.ID != "" && req.RootDAGRun.ID != req.RunID {
+		s.children[childKey{root: req.RootDAGRun, runID: req.RunID}] = key
+	}
+
+	return attempt{store: s, key: key}, nil
+}
+
+// OpenAttempt opens the latest attempt for a DAG run.
+func (s *Store) OpenAttempt(_ context.Context, ref exec.DAGRunRef) (runstate.Attempt, error) {
+	s.mu.RLock()
+	key, ok := s.latest[ref]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", exec.ErrDAGRunIDNotFound, ref.String())
+	}
+	return attempt{store: s, key: key}, nil
+}
+
+// OpenChildAttempt opens the latest child attempt under a root DAG run.
+func (s *Store) OpenChildAttempt(_ context.Context, root exec.DAGRunRef, childRunID string) (runstate.Attempt, error) {
+	s.mu.RLock()
+	key, ok := s.children[childKey{root: root, runID: childRunID}]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s:%s", exec.ErrDAGRunIDNotFound, root.String(), childRunID)
+	}
+	return attempt{store: s, key: key}, nil
+}
+
+type attemptKey struct {
+	ref exec.DAGRunRef
+	id  string
+}
+
+type childKey struct {
+	root  exec.DAGRunRef
+	runID string
+}
+
+type attemptState struct {
+	status    *exec.DAGRunStatus
+	outputs   *exec.DAGRunOutputs
+	messages  map[string][]exec.LLMMessage
+	cancelled bool
+	workDir   string
+}
+
+type attempt struct {
+	store *Store
+	key   attemptKey
+}
+
+var _ runstate.Attempt = attempt{}
+
+func (a attempt) ID() string {
+	return a.key.id
+}
+
+func (a attempt) Open(_ context.Context) error {
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	_, err := a.stateLocked()
+	return err
+}
+
+func (a attempt) RecordStatus(_ context.Context, status exec.DAGRunStatus) error {
+	cloned, err := cloneStatus(status)
+	if err != nil {
+		return err
+	}
+
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	state, err := a.stateLocked()
+	if err != nil {
+		return err
+	}
+	state.status = cloned
+	return nil
+}
+
+func (a attempt) RecordOutputs(_ context.Context, outputs *exec.DAGRunOutputs) error {
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	state, err := a.stateLocked()
+	if err != nil {
+		return err
+	}
+	state.outputs = cloneOutputs(outputs)
+	return nil
+}
+
+func (a attempt) ReadStatus(_ context.Context) (*exec.DAGRunStatus, error) {
+	a.store.mu.RLock()
+	defer a.store.mu.RUnlock()
+	state, err := a.stateRLocked()
+	if err != nil {
+		return nil, err
+	}
+	if state.status == nil {
+		return nil, exec.ErrNoStatusData
+	}
+	return cloneStatusValue(state.status)
+}
+
+func (a attempt) ReadOutputs(_ context.Context) (*exec.DAGRunOutputs, error) {
+	a.store.mu.RLock()
+	defer a.store.mu.RUnlock()
+	state, err := a.stateRLocked()
+	if err != nil {
+		return nil, err
+	}
+	return cloneOutputs(state.outputs), nil
+}
+
+func (a attempt) RequestCancel(_ context.Context) error {
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	state, err := a.stateLocked()
+	if err != nil {
+		return err
+	}
+	state.cancelled = true
+	return nil
+}
+
+func (a attempt) CancelRequested(_ context.Context) (bool, error) {
+	a.store.mu.RLock()
+	defer a.store.mu.RUnlock()
+	state, err := a.stateRLocked()
+	if err != nil {
+		return false, err
+	}
+	return state.cancelled, nil
+}
+
+func (a attempt) ReadStepMessages(_ context.Context, stepName string) ([]exec.LLMMessage, error) {
+	a.store.mu.RLock()
+	defer a.store.mu.RUnlock()
+	state, err := a.stateRLocked()
+	if err != nil {
+		return nil, err
+	}
+	return cloneMessages(state.messages[stepName]), nil
+}
+
+func (a attempt) WriteStepMessages(_ context.Context, stepName string, messages []exec.LLMMessage) error {
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	state, err := a.stateLocked()
+	if err != nil {
+		return err
+	}
+	state.messages[stepName] = cloneMessages(messages)
+	return nil
+}
+
+func (a attempt) WorkDir() string {
+	a.store.mu.RLock()
+	defer a.store.mu.RUnlock()
+	state, err := a.stateRLocked()
+	if err != nil {
+		return ""
+	}
+	return state.workDir
+}
+
+func (a attempt) Close(_ context.Context) error {
+	a.store.mu.Lock()
+	defer a.store.mu.Unlock()
+	_, err := a.stateLocked()
+	return err
+}
+
+func (a attempt) stateLocked() (*attemptState, error) {
+	state, ok := a.store.attempts[a.key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", exec.ErrDAGRunIDNotFound, a.key.ref.String())
+	}
+	return state, nil
+}
+
+func (a attempt) stateRLocked() (*attemptState, error) {
+	state, ok := a.store.attempts[a.key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", exec.ErrDAGRunIDNotFound, a.key.ref.String())
+	}
+	return state, nil
+}
+
+func generatedAttemptID(runID string, count int) string {
+	if count <= 1 {
+		return runID
+	}
+	return runID + "-" + strconv.Itoa(count)
+}
+
+func cloneStatus(status exec.DAGRunStatus) (*exec.DAGRunStatus, error) {
+	return cloneStatusValue(&status)
+}
+
+func cloneStatusValue(status *exec.DAGRunStatus) (*exec.DAGRunStatus, error) {
+	if status == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(status)
+	if err != nil {
+		return nil, fmt.Errorf("clone status: %w", err)
+	}
+	var cloned exec.DAGRunStatus
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, fmt.Errorf("clone status: %w", err)
+	}
+	return &cloned, nil
+}
+
+func cloneOutputs(outputs *exec.DAGRunOutputs) *exec.DAGRunOutputs {
+	if outputs == nil {
+		return nil
+	}
+	return &exec.DAGRunOutputs{
+		Metadata: outputs.Metadata,
+		Outputs:  maps.Clone(outputs.Outputs),
+	}
+}
+
+func cloneMessages(messages []exec.LLMMessage) []exec.LLMMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := slices.Clone(messages)
+	for i := range out {
+		out[i].ToolCalls = slices.Clone(out[i].ToolCalls)
+		if out[i].Metadata != nil {
+			metadata := *out[i].Metadata
+			out[i].Metadata = &metadata
+		}
+	}
+	return out
+}

--- a/internal/runtime/runstate/runstate.go
+++ b/internal/runtime/runstate/runstate.go
@@ -14,6 +14,7 @@ import (
 // Store opens execution state for workflow runs.
 type Store interface {
 	BeginAttempt(ctx context.Context, req BeginAttemptRequest) (Attempt, error)
+	OpenAttempt(ctx context.Context, ref exec.DAGRunRef) (Attempt, error)
 	OpenChildAttempt(ctx context.Context, root exec.DAGRunRef, childRunID string) (Attempt, error)
 }
 
@@ -33,6 +34,7 @@ type Attempt interface {
 	RecordStatus(ctx context.Context, status exec.DAGRunStatus) error
 	RecordOutputs(ctx context.Context, outputs *exec.DAGRunOutputs) error
 	ReadStatus(ctx context.Context) (*exec.DAGRunStatus, error)
+	ReadOutputs(ctx context.Context) (*exec.DAGRunOutputs, error)
 	RequestCancel(ctx context.Context) error
 	CancelRequested(ctx context.Context) (bool, error)
 	ReadStepMessages(ctx context.Context, stepName string) ([]exec.LLMMessage, error)

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -25,14 +25,13 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/dagstate"
+	"github.com/dagucloud/dagu/internal/node"
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime"
 	rtagent "github.com/dagucloud/dagu/internal/runtime/agent"
-	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
-	"github.com/dagucloud/dagu/internal/subflow"
 	dagutools "github.com/dagucloud/dagu/internal/tools"
 	daguaqua "github.com/dagucloud/dagu/internal/tools/aqua"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -608,31 +607,22 @@ func (h *remoteTaskHandler) executeDAGRun(
 	}
 	extraEnvs = append(extraEnvs, toolEnvs...)
 
-	var subWorkflowRunnerFactory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
-	subWorkflowRunnerFactory = func(_ context.Context) (runtimeexec.SubWorkflowRunner, error) {
-		dispatcher, err := coordinator.NewRuntimeDispatcher(h.serviceRegistry, h.peerConfig)
-		if err != nil {
-			return nil, err
-		}
-		return subflow.NewRouter(
-			subflow.New(dispatcher, h.config.DefaultExecMode),
-			subflow.NewLocal(
-				h.dagRunMgr,
-				h.dagStore,
-				subflow.WithLocalDAGRunStore(h.dagRunStore),
-				subflow.WithLocalStateStore(h.stateStore),
-				subflow.WithLocalSecretStore(agentStores.SecretStore),
-				subflow.WithLocalProfileStore(agentStores.ProfileStore),
-				subflow.WithLocalServiceRegistry(h.serviceRegistry),
-				subflow.WithLocalStatusPusher(statusPusher),
-				subflow.WithLocalLogWriterFactory(logStreamer),
-				subflow.WithLocalArtifactFinalizer(artifactUploader),
-				subflow.WithLocalSubWorkflowRunnerFactory(subWorkflowRunnerFactory),
-				subflow.WithLocalWorkerID(h.workerID),
-				subflow.WithLocalDAGRunDirs(h.config.Paths.LogDir, h.config.Paths.ArtifactDir),
-			),
-		), nil
-	}
+	subWorkflowRunnerFactory := node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+		DAGRunMgr:         h.dagRunMgr,
+		DAGStore:          h.dagStore,
+		DAGRunStore:       h.dagRunStore,
+		StateStore:        h.stateStore,
+		AgentStores:       agentStores,
+		ServiceRegistry:   h.serviceRegistry,
+		PeerConfig:        h.peerConfig,
+		DefaultExecMode:   h.config.DefaultExecMode,
+		StatusPusher:      statusPusher,
+		LogWriterFactory:  logStreamer,
+		ArtifactFinalizer: artifactUploader,
+		WorkerID:          h.workerID,
+		DAGRunLogDir:      h.config.Paths.LogDir,
+		DAGRunArtifactDir: h.config.Paths.ArtifactDir,
+	})
 
 	// Build agent options
 	opts := rtagent.Options{

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -31,6 +31,7 @@ type Local struct {
 	dagRunMgr                runtime.Manager
 	dagStore                 exec.DAGStore
 	dagRunStore              exec.DAGRunStore
+	runStateStore            runstate.Store
 	queueStore               exec.QueueStore
 	stateStore               dagstate.Store
 	secretStore              secretpkg.Store
@@ -57,6 +58,13 @@ type LocalOption func(*Local)
 func WithLocalDAGRunStore(store exec.DAGRunStore) LocalOption {
 	return func(r *Local) {
 		r.dagRunStore = store
+	}
+}
+
+// WithLocalRunStateStore sets the run-state store used by child workflow agents.
+func WithLocalRunStateStore(store runstate.Store) LocalOption {
+	return func(r *Local) {
+		r.runStateStore = store
 	}
 }
 
@@ -286,6 +294,7 @@ func (r *Local) newAgent(
 	opts.StatusPusher = r.statusPusher
 	opts.SubWorkflowRunnerFactory = r.subWorkflowRunnerFactory
 	opts.LogWriterFactory = r.logWriterFactory
+	opts.RunStateStore = r.runStateStoreFromContext(ctx)
 	opts.DAGRunStore = r.dagRunStoreFromContext(ctx)
 	opts.QueueStore = r.queueStoreFromContext(ctx)
 	opts.StateStore = r.stateStoreFromContext(ctx)
@@ -359,6 +368,9 @@ func (r *Local) dagRunStoreFromContext(ctx context.Context) exec.DAGRunStore {
 }
 
 func (r *Local) runStateStoreFromContext(ctx context.Context) runstate.Store {
+	if r.runStateStore != nil {
+		return r.runStateStore
+	}
 	if dagRunStore := r.dagRunStoreFromContext(ctx); dagRunStore != nil {
 		return runstate.NewHistoryStore(dagRunStore)
 	}

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	agentstore "github.com/dagucloud/dagu/internal/agent"
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -32,14 +33,12 @@ import (
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/dagstate"
 	"github.com/dagucloud/dagu/internal/launcher"
+	"github.com/dagucloud/dagu/internal/node"
 	"github.com/dagucloud/dagu/internal/persis/file"
 	"github.com/dagucloud/dagu/internal/persis/store"
 	runtimepkg "github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/agent"
-	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
-	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/frontend"
-	"github.com/dagucloud/dagu/internal/subflow"
 	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -787,29 +786,22 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 	helper.opts.DAGRunLogDir = d.Config.Paths.LogDir
 	helper.opts.DAGRunArtifactDir = d.Config.Paths.ArtifactDir
 	if helper.opts.SubWorkflowRunnerFactory == nil {
-		var subWorkflowRunnerFactory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
-		subWorkflowRunnerFactory = func(_ context.Context) (runtimeexec.SubWorkflowRunner, error) {
-			dispatcher, err := coordinator.NewRuntimeDispatcher(d.ServiceRegistry, d.Config.Core.Peer)
-			if err != nil {
-				return nil, err
-			}
-			return subflow.NewRouter(
-				subflow.New(dispatcher, d.Config.DefaultExecMode),
-				subflow.NewLocal(
-					d.DAGRunMgr,
-					d.DAGStore,
-					subflow.WithLocalDAGRunStore(d.DAGRunStore),
-					subflow.WithLocalQueueStore(d.QueueStore),
-					subflow.WithLocalStateStore(d.StateStore),
-					subflow.WithLocalSecretStore(helper.opts.SecretStore),
-					subflow.WithLocalServiceRegistry(d.ServiceRegistry),
-					subflow.WithLocalSubWorkflowRunnerFactory(subWorkflowRunnerFactory),
-					subflow.WithLocalWorkerID("local"),
-					subflow.WithLocalDAGRunDirs(d.Config.Paths.LogDir, d.Config.Paths.ArtifactDir),
-				),
-			), nil
-		}
-		helper.opts.SubWorkflowRunnerFactory = subWorkflowRunnerFactory
+		helper.opts.SubWorkflowRunnerFactory = node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+			DAGRunMgr:   d.DAGRunMgr,
+			DAGStore:    d.DAGStore,
+			DAGRunStore: d.DAGRunStore,
+			QueueStore:  d.QueueStore,
+			StateStore:  d.StateStore,
+			AgentStores: agentstore.RuntimeStores{
+				SecretStore: helper.opts.SecretStore,
+			},
+			ServiceRegistry:   d.ServiceRegistry,
+			PeerConfig:        d.Config.Core.Peer,
+			DefaultExecMode:   d.Config.DefaultExecMode,
+			WorkerID:          "local",
+			DAGRunLogDir:      d.Config.Paths.LogDir,
+			DAGRunArtifactDir: d.Config.Paths.ArtifactDir,
+		})
 	}
 
 	helper.Agent = agent.New(

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -793,7 +793,8 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 			QueueStore:  d.QueueStore,
 			StateStore:  d.StateStore,
 			AgentStores: agentstore.RuntimeStores{
-				SecretStore: helper.opts.SecretStore,
+				SecretStore:  helper.opts.SecretStore,
+				ProfileStore: helper.opts.ProfileStore,
 			},
 			ServiceRegistry:   d.ServiceRegistry,
 			PeerConfig:        d.Config.Core.Peer,


### PR DESCRIPTION
## Summary
- add a runtime run-state store port with in-memory implementation for embedded local execution
- wire direct run-state storage through agent, subflow, and embedded engine paths
- centralize child workflow runner construction in the node adapter

## Testing
- go test ./internal/runtime/runstate/memstore ./internal/engine
- go test ./internal/node ./internal/runtime/runstate/... ./internal/runtime/agent ./internal/subflow ./internal/engine ./internal/cmd ./internal/service/worker ./internal/test
- go test .
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated live runtime state from historical storage and added in-memory `internal/runtime/runstate/memstore` for embedded/local runs. In hybrid setups, status, outputs, and cancel prefer `runstate.Store` and fall back to `DAGRunStore` when the run-state attempt is missing.

- New Features
  - In-memory `runstate` store (`internal/runtime/runstate/memstore`) with root/child attempts, outputs, cancel, step messages, and run ID validation.
  - New `Engine.Outputs` and `Run.Outputs`; `runstate.Store` adds `OpenAttempt` and `Attempt.ReadOutputs` for direct readback.

- Refactors
  - Engine/Agent/Subflow prefer `runstate.Store`; hybrid fallback to `DAGRunStore` for Status/Outputs/Stop on `ErrDAGRunIDNotFound`, with explicit errors if neither store is configured.
  - Centralized child runner factory in `internal/node`; CLI, engine, worker, and tests now use it (preserves `ProfileStore` wiring).
  - Persistence accepts either `RunStateStore` or `DAGRunStore`; no-file local runs preflight duplicate run IDs.
  - Tests cover memory-only and hybrid runs, including engine and `memstore` behavior.

<sup>Written for commit 207a9e0b9267eb5ace8500e357847eaedcd2699d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve step outputs for runs from both direct and embedded execution handles.

* **Improvements**
  * Local/embedded run execution now supports an independent runtime run-state store and clearer status handling, improving cancel/stop behavior and duplicate-run protection.
  * Subworkflow execution wiring simplified for local runs.

* **Tests**
  * Added tests covering run-state persistence, output readback, and duplicate-run detection.

* **Documentation**
  * Added implementation notes describing runtime/history separation and in-memory run-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->