### PR TITLE
fix: improve mobile dag run detail layout

### DIFF
--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -429,75 +429,82 @@ function DAGStatus({
       )}
     >
       {/* Status Detail Tabs */}
-      <Tabs className={cn('whitespace-nowrap', fillHeight && 'shrink-0')}>
-        <Tab
-          isActive={activeTab === 'status'}
-          onClick={() => setActiveTab('status')}
-          className="flex items-center gap-2 cursor-pointer"
-        >
-          <ActivitySquare className="h-4 w-4" />
-          Status
-        </Tab>
-        {hasWaitingSteps && (
-          <Tab
-            isActive={activeTab === 'approval'}
-            onClick={() => setActiveTab('approval')}
-            className="flex items-center gap-2 cursor-pointer"
-          >
-            <ShieldCheck className="h-4 w-4" />
-            Approval
-            <span className="bg-warning/15 text-warning text-xs font-medium px-1.5 py-0.5 rounded-full">
-              {waitingStepCount}
-            </span>
-          </Tab>
+      <div
+        className={cn(
+          'w-full min-w-0 overflow-x-auto',
+          fillHeight && 'shrink-0'
         )}
-        {showTimeline && (
+      >
+        <Tabs className="w-max min-w-full whitespace-nowrap">
           <Tab
-            isActive={activeTab === 'timeline'}
-            onClick={() => setActiveTab('timeline')}
-            className="flex items-center gap-2 cursor-pointer"
+            isActive={activeTab === 'status'}
+            onClick={() => setActiveTab('status')}
+            className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
           >
-            <GanttChart className="h-4 w-4" />
-            Timeline
+            <ActivitySquare className="h-4 w-4" />
+            Status
           </Tab>
-        )}
-        <Tab
-          isActive={activeTab === 'outputs'}
-          onClick={() => setActiveTab('outputs')}
-          className="flex items-center gap-2 cursor-pointer"
-        >
-          <Package className="h-4 w-4" />
-          Outputs
-        </Tab>
-        {hasArtifacts && (
+          {hasWaitingSteps && (
+            <Tab
+              isActive={activeTab === 'approval'}
+              onClick={() => setActiveTab('approval')}
+              className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
+            >
+              <ShieldCheck className="h-4 w-4" />
+              Approval
+              <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-medium text-warning">
+                {waitingStepCount}
+              </span>
+            </Tab>
+          )}
+          {showTimeline && (
+            <Tab
+              isActive={activeTab === 'timeline'}
+              onClick={() => setActiveTab('timeline')}
+              className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
+            >
+              <GanttChart className="h-4 w-4" />
+              Timeline
+            </Tab>
+          )}
           <Tab
-            isActive={activeTab === 'artifacts'}
-            onClick={() => setActiveTab('artifacts')}
-            className="flex items-center gap-2 cursor-pointer"
+            isActive={activeTab === 'outputs'}
+            onClick={() => setActiveTab('outputs')}
+            className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
           >
-            <Archive className="h-4 w-4" />
-            Artifacts
+            <Package className="h-4 w-4" />
+            Outputs
           </Tab>
-        )}
-        {hasChatSteps && (
+          {hasArtifacts && (
+            <Tab
+              isActive={activeTab === 'artifacts'}
+              onClick={() => setActiveTab('artifacts')}
+              className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
+            >
+              <Archive className="h-4 w-4" />
+              Artifacts
+            </Tab>
+          )}
+          {hasChatSteps && (
+            <Tab
+              isActive={activeTab === 'chat'}
+              onClick={() => setActiveTab('chat')}
+              className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
+            >
+              <MessageSquare className="h-4 w-4" />
+              Chat
+            </Tab>
+          )}
           <Tab
-            isActive={activeTab === 'chat'}
-            onClick={() => setActiveTab('chat')}
-            className="flex items-center gap-2 cursor-pointer"
+            isActive={activeTab === 'spec'}
+            onClick={() => setActiveTab('spec')}
+            className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
           >
-            <MessageSquare className="h-4 w-4" />
-            Chat
+            <FileCode className="h-4 w-4" />
+            Spec
           </Tab>
-        )}
-        <Tab
-          isActive={activeTab === 'spec'}
-          onClick={() => setActiveTab('spec')}
-          className="flex items-center gap-2 cursor-pointer"
-        >
-          <FileCode className="h-4 w-4" />
-          Spec
-        </Tab>
-      </Tabs>
+        </Tabs>
+      </div>
 
       {/* Status Tab Content */}
       {activeTab === 'status' && (
@@ -559,7 +566,7 @@ function DAGStatus({
           <DAGContext.Consumer>
             {(props) => (
               <>
-                <div className="grid grid-cols-1 gap-6">
+                <div className="grid min-w-0 grid-cols-1 gap-6">
                   {/* Status Overview */}
                   <div className="bg-surface border border-border rounded-lg p-4">
                     <DAGStatusOverview

--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -133,7 +133,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
         onRunStarted,
       }}
     >
-      <div className="w-full flex flex-col">
+      <div className="flex w-full min-w-0 flex-col">
         {/* Only render the header if skipHeader is not true */}
         {!skipHeader && (
           <DAGHeader
@@ -146,7 +146,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
             navigateToStatusTab={navigateToStatusTab}
           />
         )}
-        <div className="flex flex-col lg:flex-row justify-between items-center gap-3 lg:gap-0 mb-4 mt-3">
+        <div className="mb-4 mt-3 flex min-w-0 flex-col items-center justify-between gap-3 lg:flex-row lg:gap-0">
           {/* Desktop Tabs (lg and up) */}
           <div className="hidden lg:block flex-1 min-w-0">
             <Tabs className="whitespace-nowrap">
@@ -290,8 +290,8 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
           </div>
 
           {/* Mobile/Tablet Tabs (sm to lg) */}
-          <div className="lg:hidden w-full overflow-x-auto">
-            <div className="flex space-x-1 w-full">
+          <div className="w-full min-w-0 overflow-x-auto lg:hidden">
+            <div className="flex min-w-max space-x-1">
               {isModal ? (
                 <ModalLinkTab
                   label=""

--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { Tabs } from '@/components/ui/tabs';
 import {
   AlertTriangle,

--- a/ui/src/features/dags/components/dag-details/DAGHeader.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGHeader.tsx
@@ -161,9 +161,9 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
     dagRunToDisplay.dagRunId === dagRunToDisplay.rootDAGRunId;
 
   return (
-    <div className="bg-card rounded-2xl p-6 border border-border shadow-sm">
+    <div className="min-w-0 rounded-xl border border-border bg-card p-4 shadow-sm sm:rounded-2xl sm:p-6">
       {/* Header with title and actions */}
-      <div className="flex items-start justify-between gap-6 mb-4">
+      <div className="mb-4 flex min-w-0 flex-col items-stretch gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
         <div className="flex-1 min-w-0">
           {/* Breadcrumb navigation */}
           {dagRunToDisplay && (
@@ -201,8 +201,8 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
             </nav>
           )}
 
-          <div className="flex items-center gap-2 min-w-0">
-            <h1 className="text-2xl font-bold text-foreground truncate">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="min-w-0 break-words text-2xl font-bold text-foreground sm:truncate">
               {dagRunToDisplay?.name || dag.name}
             </h1>
             {filePath && (
@@ -222,7 +222,7 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
         </div>
 
         {showActions && (
-          <div className="flex flex-shrink-0 flex-wrap items-center justify-end gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 sm:flex-shrink-0 sm:justify-end">
             <DAGActions
               status={dagRunToDisplay}
               dag={dag}
@@ -239,7 +239,7 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
       {dagRunToDisplay &&
         dagRunToDisplay.status !== undefined &&
         dagRunToDisplay.status !== null && (
-          <div className="flex flex-wrap items-center gap-2 text-sm">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm">
             <StatusChip status={dagRunToDisplay.status} size="md">
               {dagRunToDisplay.statusLabel || ''}
             </StatusChip>
@@ -261,11 +261,13 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
               <span>Refresh</span>
             </button>
 
-            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            <span className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
               <Calendar className="h-3 w-3" />
-              {dagRunToDisplay?.startedAt
-                ? dayjs(dagRunToDisplay.startedAt).format('MMM D, HH:mm:ss')
-                : '--'}
+              <span className="truncate">
+                {dagRunToDisplay?.startedAt
+                  ? dayjs(dagRunToDisplay.startedAt).format('MMM D, HH:mm:ss')
+                  : '--'}
+              </span>
             </span>
 
             <span className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -279,11 +281,13 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
             {dagRunToDisplay.workerId && (
               <span className="flex items-center gap-1 text-xs text-muted-foreground">
                 <Server className="h-3 w-3" />
-                <span className="font-mono">{dagRunToDisplay.workerId}</span>
+                <span className="min-w-0 truncate font-mono">
+                  {dagRunToDisplay.workerId}
+                </span>
               </span>
             )}
 
-            <code className="text-xs font-mono text-muted-foreground">
+            <code className="max-w-full break-all text-xs font-mono text-muted-foreground sm:max-w-xs sm:truncate">
               {dagRunToDisplay.rootDAGRunId}
             </code>
           </div>

--- a/ui/src/features/dags/components/dag-details/DAGStatusOverview.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGStatusOverview.tsx
@@ -238,19 +238,22 @@ function DAGStatusOverview({
   }
 
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-2">
       {/* Parameters - Only show when present */}
       {status.params && (
-        <div className="flex items-center gap-1.5 text-xs font-mono">
+        <div className="flex min-w-0 items-center gap-1.5 text-xs font-mono">
           <Terminal className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-          <span className="text-foreground truncate" title={status.params}>
+          <span
+            className="min-w-0 truncate text-foreground"
+            title={status.params}
+          >
             {status.params}
           </span>
         </div>
       )}
 
       {/* Timing & Metadata - Compact grid */}
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs">
         {status.scheduleTime && (
           <span>
             <span className="text-muted-foreground">Scheduled </span>
@@ -291,7 +294,7 @@ function DAGStatusOverview({
       </div>
 
       {/* Metadata row */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs">
         {status.triggerType && (
           <span>
             <span className="text-muted-foreground">Trigger </span>
@@ -319,10 +322,10 @@ function DAGStatusOverview({
         {status.dagRunId && (
           <button
             onClick={copyRunId}
-            className="inline-flex items-center gap-1 font-mono text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            className="inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 font-mono text-muted-foreground transition-colors hover:text-foreground"
             title={`Click to copy: ${status.dagRunId}`}
           >
-            <span>{truncateId(status.dagRunId)}</span>
+            <span className="truncate">{truncateId(status.dagRunId)}</span>
             {copied ? (
               <Check className="h-3 w-3 text-success" />
             ) : (

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -334,7 +334,7 @@ function DAGDetails() {
             setData: setRootDAGRunData,
           }}
         >
-          <div className="max-w-7xl flex flex-col">
+          <div className="flex w-full min-w-0 max-w-7xl flex-col">
             {dagData?.dag && dagMatchesWorkspace && (
               <>
                 <DAGHeader


### PR DESCRIPTION
## Summary
- prevent DAG run detail content from forcing document-level horizontal overflow on mobile
- constrain the run header, metadata, and status tabs with shrink-safe wrappers and local horizontal scrolling
- keep long run IDs, params, worker IDs, and tab labels from widening the page

## Changes
- add shrink-safe page and detail wrappers with `min-w-0`
- make the DAG run header wrap/truncate long values on small screens
- move the status tab overflow into a local horizontal scroller
- add the standard GPL/SPDX header to `DAGDetailsContent.tsx`

## Related Issues
- N/A

## Checklist
- [x] Code style follows existing patterns
- [x] Self-review completed
- [x] Tests added or updated where needed
- [x] Documentation updated or not required
- [x] Local validation completed

## Testing
- `pnpm typecheck`
- `pnpm vitest run src/features/dags/components/__tests__/DAGStatus.test.tsx src/features/dags/components/dag-details/__tests__/DAGStatusOverview.test.tsx`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Enhanced layout responsiveness across DAG detail pages
  * Improved text overflow handling and truncation for long content
  * Better horizontal scrolling behavior on mobile and tablet devices
  * Refined spacing and alignment in tabs and status displays

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->