### PR TITLE
fix: isolate parent exit watcher environment

### DIFF
--- a/internal/cmn/cmdutil/parent_exit_watcher_unix.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_unix.go
@@ -31,6 +31,8 @@ func StartParentExitWatcher(cmd *exec.Cmd) (func(), error) {
 	const script = `if IFS= read -r line <&3 && [ "$line" = "` + parentExitWatcherOK + `" ]; then exit 0; fi; kill -KILL -"$1" 2>/dev/null; exit 0`
 	watcher := exec.Command("/bin/sh", "-c", script, "dagu-parent-exit-watcher", strconv.Itoa(cmd.Process.Pid)) //nolint:gosec
 	watcher.ExtraFiles = []*os.File{readPipe}
+	// Keep shell control variables from changing the watcher's blocking read.
+	watcher.Env = []string{"PATH=/usr/bin:/bin"}
 	setupCommand(watcher)
 
 	if err := watcher.Start(); err != nil {

--- a/internal/cmn/cmdutil/parent_exit_watcher_unix_external_test.go
+++ b/internal/cmn/cmdutil/parent_exit_watcher_unix_external_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+
+package cmdutil_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/stretchr/testify/require"
+)
+
+const parentExitWatcherHelperEnv = "DAGU_PARENT_EXIT_WATCHER_HELPER"
+
+func TestParentExitWatcherIgnoresInheritedShellTimeout(t *testing.T) {
+	t.Setenv("TMOUT", "1")
+
+	cmd := exec.Command("/bin/sh", "-c", "sleep 2") //nolint:gosec
+	cmd.Env = []string{"PATH=/usr/bin:/bin"}
+
+	startedAt := time.Now()
+	proc, err := cmdutil.StartManagedProcess(cmd)
+	require.NoError(t, err)
+	defer func() { _ = proc.Release() }()
+
+	require.NoError(t, proc.Wait())
+	require.GreaterOrEqual(t, time.Since(startedAt), 2*time.Second)
+}
+
+func TestParentExitWatcherTerminatesChildWhenParentExits(t *testing.T) {
+	executable, err := os.Executable()
+	require.NoError(t, err)
+
+	helper := exec.Command(executable, "-test.run=^TestParentExitWatcherHelper$") //nolint:gosec
+	helper.Env = append(os.Environ(), parentExitWatcherHelperEnv+"=1")
+
+	stdout, err := helper.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, helper.Start())
+
+	scanner := bufio.NewScanner(stdout)
+	require.True(t, scanner.Scan(), "helper did not print child pid")
+	childPID, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	require.NoError(t, err)
+
+	require.NoError(t, helper.Wait())
+	require.Eventually(t, func() bool {
+		return !processExists(childPID)
+	}, 3*time.Second, 50*time.Millisecond)
+}
+
+func TestParentExitWatcherHelper(t *testing.T) {
+	if os.Getenv(parentExitWatcherHelperEnv) != "1" {
+		t.Skip("helper only")
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30") //nolint:gosec
+	cmd.Env = []string{"PATH=/usr/bin:/bin"}
+	proc, err := cmdutil.StartManagedProcess(cmd)
+	require.NoError(t, err)
+
+	fmt.Println(proc.PID())
+	os.Exit(0)
+}
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return !errors.Is(err, syscall.ESRCH)
+}


### PR DESCRIPTION
## Summary
- isolate the Unix parent-exit watcher from inherited shell control variables
- prevent exported `TMOUT` from timing out the watcher's blocking `read` and killing healthy workflow steps
- add regression coverage for both inherited `TMOUT` and real parent-exit cleanup behavior

## Related Issues
- Closes #2253

## Checklist
- [x] Code style follows existing patterns
- [x] Self-review completed
- [x] Tests added or updated where needed
- [x] Documentation updated or not required
- [x] Local validation completed

## Testing
- `go test ./internal/cmn/cmdutil -run 'TestParentExitWatcher(IgnoresInheritedShellTimeout|TerminatesChildWhenParentExits)$' -count=1`
- `go test ./internal/cmn/cmdutil -count=1`
- `make test TEST_TARGET=./internal/cmn/cmdutil`
- `git diff --check`
- patched CLI repro: `TMOUT=3` with a `sleep 5` DAG completed successfully instead of dying at 3 seconds


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the Unix parent-exit watcher from inherited shell control variables to prevent `TMOUT` from aborting its blocking read and killing healthy steps. Adds regression tests for `TMOUT` inheritance and parent-exit cleanup. Closes #2253.

- **Bug Fixes**
  - Set a minimal env for the watcher (`Env = ["PATH=/usr/bin:/bin"]`) so shell vars like `TMOUT` don’t affect its blocking read.
  - Added external tests verifying the watcher ignores inherited `TMOUT` and still terminates the child when the parent exits.

<sup>Written for commit 162c532a2d0c062bfb9a45ddbc8f6f582768072c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parent exit watcher stability on Unix systems by preventing shell environment variables from interfering with the watcher process.

* **Tests**
  * Added test coverage for parent exit watcher behavior on Unix platforms, including shell timeout handling and child process termination scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dagucloud/dagu/pull/2256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->