### PR TITLE
executor: fix nil pointer when sub-DAG not in worker local store

### DIFF
--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -98,9 +98,15 @@ func NewSubDAGExecutor(ctx context.Context, childName string) (*SubDAGExecutor, 
 	}
 
 	// If not found as local DAG, look it up in the database
+	if rCtx.DB == nil {
+		return nil, fmt.Errorf("cannot resolve sub-DAG %q: no local DAG store available (hint: parent DAG was dispatched to a worker without local DAG cache — consider setting worker_selector: local on the parent DAG): %w", childName, exec.ErrDAGNotFound)
+	}
 	dag, err := rCtx.DB.GetDAG(ctx, childName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find DAG %q: %w", childName, err)
+	}
+	if dag == nil {
+		return nil, fmt.Errorf("sub-DAG %q resolved to nil (hint: parent DAG may have been dispatched to a worker without local DAG cache — consider setting worker_selector: local on the parent DAG): %w", childName, exec.ErrDAGNotFound)
 	}
 
 	return newSubDAGExecutor(ctx, rCtx, dag, ""), nil

--- a/internal/runtime/executor/dag_runner_test.go
+++ b/internal/runtime/executor/dag_runner_test.go
@@ -151,6 +151,55 @@ func TestNewSubDAGExecutor_NotFound(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestNewSubDAGExecutor_NilDB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parentDAG := &core.DAG{Name: "parent"}
+
+	// Set up context with nil DB
+	dagCtx := exec1.Context{
+		DAG:        parentDAG,
+		DB:         nil,
+		RootDAGRun: exec1.NewDAGRunRef("parent", "root-123"),
+		DAGRunID:   "parent-456",
+	}
+	ctx = exec1.WithContext(ctx, dagCtx)
+
+	executor, err := NewSubDAGExecutor(ctx, "child-dag")
+	require.Error(t, err)
+	require.Nil(t, executor)
+	assert.ErrorIs(t, err, exec1.ErrDAGNotFound)
+	assert.Contains(t, err.Error(), "worker_selector: local")
+}
+
+func TestNewSubDAGExecutor_NilDAGReturn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	parentDAG := &core.DAG{Name: "parent"}
+
+	mockDB := new(mockDatabase)
+	dagCtx := exec1.Context{
+		DAG:        parentDAG,
+		DB:         mockDB,
+		RootDAGRun: exec1.NewDAGRunRef("parent", "root-123"),
+		DAGRunID:   "parent-456",
+	}
+	ctx = exec1.WithContext(ctx, dagCtx)
+
+	// Mock returns nil DAG with nil error
+	mockDB.On("GetDAG", ctx, "child-dag").Return(nil, nil)
+
+	executor, err := NewSubDAGExecutor(ctx, "child-dag")
+	require.Error(t, err)
+	require.Nil(t, executor)
+	assert.ErrorIs(t, err, exec1.ErrDAGNotFound)
+	assert.Contains(t, err.Error(), "worker_selector: local")
+
+	mockDB.AssertExpectations(t)
+}
+
 func TestExecute_NoRunID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/executor/dag_runner_test.go
+++ b/internal/runtime/executor/dag_runner_test.go
@@ -151,6 +151,11 @@ func TestNewSubDAGExecutor_NotFound(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+// TestNewSubDAGExecutor_NilDB verifies that NewSubDAGExecutor returns a
+// structured error wrapping exec.ErrDAGNotFound when the runtime context
+// has no DAG store (rCtx.DB == nil), instead of panicking with a nil
+// pointer dereference. The error message must include the
+// worker_selector: local remediation hint.
 func TestNewSubDAGExecutor_NilDB(t *testing.T) {
 	t.Parallel()
 
@@ -173,6 +178,10 @@ func TestNewSubDAGExecutor_NilDB(t *testing.T) {
 	assert.Contains(t, err.Error(), "worker_selector: local")
 }
 
+// TestNewSubDAGExecutor_NilDAGReturn verifies that NewSubDAGExecutor
+// returns a structured error wrapping exec.ErrDAGNotFound when the DAG
+// store's GetDAG call resolves to a nil DAG without an explicit error,
+// instead of passing nil down to newSubDAGExecutor and panicking.
 func TestNewSubDAGExecutor_NilDAGReturn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #2257.

When `default_execution_mode: distributed` is set and a parent DAG without `worker_selector` uses `dag.run` to invoke a sub-DAG, the parent gets dispatched to a remote worker. The worker's local DAG store does not contain the parent's sub-DAG definitions, causing `rCtx.DB.GetDAG()` to either be called on a nil DB or to return a nil DAG — both leading to nil pointer dereference in `newSubDAGExecutor` and crashing the worker pod.

## Changes

`internal/runtime/executor/dag_runner.go`:
- Add nil-check on `rCtx.DB` before calling `GetDAG`
- Add nil-check on the returned `dag` value
- Both new error paths wrap `exec.ErrDAGNotFound` and include a remediation hint pointing users to set `worker_selector: local` on the parent DAG

`internal/runtime/executor/dag_runner_test.go`:
- New test `TestNewSubDAGExecutor_NilDB` — asserts structured error when `rCtx.DB == nil`
- New test `TestNewSubDAGExecutor_NilDAGReturn` — asserts structured error when `GetDAG` returns nil dag

## Behaviour Change

Before:
\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
\`\`\`

After:
\`\`\`
cannot resolve sub-DAG "child": no local DAG store available
(hint: parent DAG was dispatched to a worker without local DAG cache
— consider setting worker_selector: local on the parent DAG):
DAG is not found
\`\`\`

## Test Plan

\`\`\`
go test ./internal/runtime/executor/...
ok  github.com/dagucloud/dagu/internal/runtime/executor  0.015s
\`\`\`

Local verification on a multi-cluster K3s setup confirmed the worker pod no longer crashes when an orchestrator DAG is mis-dispatched; the descriptive error appears in worker logs instead.

## Related

See #2257 for the full reproduction scenario and background. Example DAGs demonstrating the pattern are documented in that issue's comments; happy to send a follow-up PR adding them to `examples/embedded/distributed/` if the maintainers prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a nil pointer panic when a parent DAG on a remote worker calls a sub-DAG missing from the worker’s local store. Now returns a clear “DAG not found” error with guidance, preventing worker crashes.

- **Bug Fixes**
  - Add nil checks on `rCtx.DB` and the `GetDAG` result in `NewSubDAGExecutor`.
  - Return errors wrapping `exec.ErrDAGNotFound` with a hint to use `worker_selector: local` on the parent DAG in distributed mode.
  - Add tests for nil DB and nil DAG cases, with doc comments; worker now logs a structured error instead of panicking.

<sup>Written for commit fba216b965e2e2ff81e1a9dc85eb1bca05ba9e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when executing sub-workflows to prevent errors from missing database configurations.
  * Enhanced error messages to provide clearer guidance on required configuration settings for sub-workflow execution.

* **Tests**
  * Added comprehensive test coverage for error handling in sub-workflow executor scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->