### PR TITLE
feat: add headless release artifact

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -38,6 +38,7 @@ jobs:
   goreleaser:
     needs: validate-inputs
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
   # Build release binaries
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,45 @@ builds:
       - goos: windows
         goarch: arm
         goarm: "7"
+  - id: dagu-headless
+    dir: ./cmd
+    binary: dagu
+    flags:
+      - -tags=headless
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - "amd64"
+      - "386"
+      - "arm"
+      - "arm64"
+      - "ppc64le"
+      - "s390x"
+    goarm:
+      - "6"
+      - "7"
+    ignore:
+      # Go does not support windows/arm.
+      - goos: windows
+        goarch: arm
+        goarm: "6"
+      - goos: windows
+        goarch: arm
+        goarm: "7"
+
+archives:
+  - id: dagu
+    ids:
+      - dagu
+    name_template: "dagu_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}"
+  - id: dagu-headless
+    ids:
+      - dagu-headless
+    name_template: "dagu-headless_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}"
 
 release:
   mode: keep-existing
@@ -53,6 +92,8 @@ changelog:
 
 brews:
   - skip_upload: auto
+    ids:
+      - dagu
     repository:
       owner: dagu-org
       name: homebrew-brew
@@ -71,6 +112,8 @@ brews:
 
   # Deprecated brew tap:
   - skip_upload: auto
+    ids:
+      - dagu
     repository:
       owner: yohamta
       name: homebrew-tap

--- a/internal/service/frontend/assets_default_test.go
+++ b/internal/service/frontend/assets_default_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !headless
+
+package frontend_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/service/frontend"
+)
+
+func TestEmbeddedWebUIAvailableInDefaultBuild(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, frontend.WebUIEmbeddedForTest())
+
+	srv := frontend.NewRouteTestServerForTest(&config.Config{})
+	r := chi.NewMux()
+
+	require.NoError(t, frontend.SetupRoutesForTest(context.Background(), srv, r))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/bundle.js", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/service/frontend/assets_default_test.go
+++ b/internal/service/frontend/assets_default_test.go
@@ -30,7 +30,7 @@ func TestEmbeddedWebUIAvailableInDefaultBuild(t *testing.T) {
 	require.NoError(t, frontend.SetupRoutesForTest(context.Background(), srv, r))
 
 	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/bundle.js", nil))
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/service/frontend/assets_embed.go
+++ b/internal/service/frontend/assets_embed.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !headless
+
+package frontend
+
+import "embed"
+
+//go:embed templates/* assets/*
+var assetsFS embed.FS
+
+const webUIEmbedded = true

--- a/internal/service/frontend/assets_headless.go
+++ b/internal/service/frontend/assets_headless.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build headless
+
+package frontend
+
+import "embed"
+
+var assetsFS embed.FS
+
+const webUIEmbedded = false

--- a/internal/service/frontend/assets_headless_test.go
+++ b/internal/service/frontend/assets_headless_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build headless
+
+package frontend_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/service/frontend"
+)
+
+func TestEmbeddedWebUIUnavailableInHeadlessBuild(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, frontend.WebUIEmbeddedForTest())
+
+	srv := frontend.NewRouteTestServerForTest(&config.Config{})
+	r := chi.NewMux()
+
+	require.NoError(t, frontend.SetupRoutesForTest(context.Background(), srv, r))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/bundle.js", nil))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/service/frontend/export_test.go
+++ b/internal/service/frontend/export_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+)
+
+func WebUIEmbeddedForTest() bool {
+	return webUIEmbedded
+}
+
+func NewRouteTestServerForTest(cfg *config.Config) *Server {
+	return &Server{
+		config: cfg,
+		funcsConfig: funcsConfig{
+			BasePath: cfg.Server.BasePath,
+		},
+	}
+}
+
+func SetupRoutesForTest(ctx context.Context, srv *Server, r *chi.Mux) error {
+	return srv.setupRoutes(ctx, r)
+}

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1036,7 +1036,7 @@ func ensureLeadingSlash(p string) string {
 }
 
 func (srv *Server) setupRoutes(ctx context.Context, r *chi.Mux) error {
-	if srv.config.Server.Headless {
+	if !srv.webUIEnabled() {
 		logger.Info(ctx, "Headless mode enabled: UI is disabled, but API remains active")
 		return nil
 	}

--- a/internal/service/frontend/templates.go
+++ b/internal/service/frontend/templates.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -27,9 +26,6 @@ import (
 	"github.com/dagucloud/dagu/internal/service/frontend/api/pathutil"
 	workspacepkg "github.com/dagucloud/dagu/internal/workspace"
 )
-
-//go:embed templates/* assets/*
-var assetsFS embed.FS
 
 const (
 	templatePath     = "templates/"
@@ -65,8 +61,12 @@ func currentAssetVersion() string {
 	return assetVersion
 }
 
+func (srv *Server) webUIEnabled() bool {
+	return webUIEmbedded && !srv.config.Server.Headless
+}
+
 func (srv *Server) useTemplate(ctx context.Context, layout, name string) func(http.ResponseWriter, any) {
-	if srv.config.Server.Headless {
+	if !srv.webUIEnabled() {
 		return func(w http.ResponseWriter, _ any) {
 			http.Error(w, "Web UI is disabled in headless mode", http.StatusForbidden)
 		}


### PR DESCRIPTION
## Summary
- add a headless build tag that excludes embedded frontend assets while keeping API/headless server behavior available
- publish `dagu-headless` release archives alongside the normal UI-enabled `dagu` archives
- keep Homebrew formulas pinned to the normal `dagu` archive

## Changes
- split embedded frontend assets behind default and `headless` build-tag files
- gate Web UI routes and template rendering through `webUIEnabled()` so `server.headless` and headless builds behave consistently
- add build-specific frontend route tests for default and headless binaries
- add a `dagu-headless` GoReleaser build and archive while restricting Homebrew formulas to the normal `dagu` archive

## Related Issues
- N/A

## Checklist
- [x] Code style follows existing patterns
- [x] Self-review completed
- [x] Tests added or updated where needed
- [x] Documentation updated or not required
- [x] Local validation completed

## Testing
- `go test ./internal/service/frontend -count=1`
- `go test -tags=headless ./internal/service/frontend -count=1`
- `go build -o /private/tmp/dagu-default ./cmd`
- `go build -tags=headless -o /private/tmp/dagu-headless ./cmd`
- `git diff --cached --check`
- not run: `goreleaser check` (GoReleaser is not installed locally)