### PR TITLE
fix: pre-filter retry scanner DAG runs at index level (#2261)

### DIFF
--- a/internal/persis/file/dagrun/pagination.go
+++ b/internal/persis/file/dagrun/pagination.go
@@ -250,7 +250,7 @@ func (it *dagRunStatusIterator) loadDay(ctx context.Context, dayPath string) ([]
 		return nil, fmt.Errorf("read day directory %s: %w", dayPath, err)
 	}
 
-	runs, err := loadDayRuns(dayPath, entries)
+	runs, err := loadDayRuns(dayPath, entries, it.statusesFilter, it.hasStatusFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -352,11 +352,16 @@ func listDayPathsInRange(root DataRoot, from, to exec.TimeInUTC) ([]string, erro
 	return dayPaths, nil
 }
 
-func loadDayRuns(dayPath string, dayEntries []os.DirEntry) ([]*DAGRun, error) {
+func loadDayRuns(dayPath string, dayEntries []os.DirEntry, statusesFilter map[core.Status]struct{}, hasStatusFilter bool) ([]*DAGRun, error) {
 	indexEntries, _, indexErr := dagrunindex.TryLoadForDay(dayPath, dayEntries)
 	if indexErr == nil && indexEntries != nil && len(indexEntries) == countDAGRunDirs(dayEntries) {
 		runs := make([]*DAGRun, 0, len(indexEntries))
 		for _, indexEntry := range indexEntries {
+			if hasStatusFilter {
+				if _, ok := statusesFilter[indexEntry.Status]; !ok {
+					continue
+				}
+			}
 			run, err := NewDAGRun(filepath.Join(dayPath, indexEntry.DagRunDir))
 			if err != nil {
 				continue


### PR DESCRIPTION
## Summary

Single fix for the memory leak reported in #546, root-caused in #2261.

The file-based DAG run store's `loadDayRuns` function creates `DAGRun` objects for ALL runs in a day before `resolveStatus` filters them by status. The day index already contains the status — use it for pre-filtering.

## Changes

**`internal/persis/file/dagrun/pagination.go`** — Pass the status filter to `loadDayRuns`. When the day index is present and a status filter is active, check each index entry's `Status` before calling `NewDAGRun`. Skip entries whose known status doesn't match the filter.

This avoids creating 12,960+ `DAGRun` + `DAGRunStatus` objects per retry-scanner scan for installations with many historical runs (9 DAGs × every minute = 12,960 runs/day in a 24h window).

## Design Decision: No periodic `FreeOSMemory()`

We considered adding a periodic `debug.FreeOSMemory()` call to the scheduler's cronLoop to return accumulated heap to the OS. **Rejected** — two reasons:

1. **The pre-filter eliminates the root cause.** With ~0 allocations per scan (instead of ~12MB), the heap doesn't grow in the first place. No wound to bandage.
2. **FreeOSMemory() adds runtime overhead.** It triggers a full stop-the-world GC + madvise syscall every 5 minutes, introducing scheduling jitter. Unnecessary once the allocation rate is fixed.

No new imports, no runtime penalty.

Closes #2261
Related: #546