### PR TITLE
fix: preserve retry params for dotenv resolution

### DIFF
--- a/internal/cmd/export_test.go
+++ b/internal/cmd/export_test.go
@@ -3,4 +3,13 @@
 
 package cmd
 
-var RestoreDAGFromStatusForTest = restoreDAGFromStatus
+import (
+	"context"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+func RestoreDAGFromStatusForTest(ctx context.Context, dag *core.DAG, status *exec.DAGRunStatus) (*core.DAG, error) {
+	return restoreDAGFromStatus(ctx, dag, status)
+}

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -81,9 +81,10 @@ func parseScheduleTimeParam(ctx *Context) (string, error) {
 // It restores params from the status, loads dotenv, and rebuilds fields excluded
 // from JSON serialization (env, params JSON, registryAuths, etc.).
 func restoreDAGFromStatus(ctx context.Context, dag *core.DAG, status *exec.DAGRunStatus) (*core.DAG, error) {
-	dag.Params = spec.QuoteRuntimeParams(status.ParamsList, dag.ParamDefs)
+	runtimeParams := append([]string(nil), status.ParamsList...)
+	dag.Params = runtimeParams
 	dagwarning.LoadDotEnv(ctx, dag)
-	restored, err := rebuildDAGFromYAML(ctx, dag)
+	restored, err := rebuildDAGFromYAML(ctx, dag, spec.QuoteRuntimeParams(runtimeParams, dag.ParamDefs))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func applyPersistedRunWorkingDir(dag *core.DAG, status *exec.DAGRunStatus) {
 // only copies JSON-excluded fields (Env, Params, ParamsJSON, SMTP, SSH, S3,
 // Redis, Harness, Harnesses, Kubernetes, RegistryAuths, WorkingDirExplicit)
 // from the rebuilt DAG.
-func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
+func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG, paramsOverride ...[]string) (*core.DAG, error) {
 	if len(dag.YamlData) == 0 {
 		return dag, nil
 	}
@@ -132,8 +133,12 @@ func rebuildDAGFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
 		buildEnvMap[key] = value
 	}
 
+	params := dag.Params
+	if len(paramsOverride) > 0 {
+		params = paramsOverride[0]
+	}
 	loadOpts := []spec.LoadOption{
-		spec.WithParams(dag.Params),
+		spec.WithParams(params),
 		spec.SkipSchemaValidation(),
 	}
 	if len(buildEnvMap) > 0 {

--- a/internal/cmd/retry_params_external_test.go
+++ b/internal/cmd/retry_params_external_test.go
@@ -59,8 +59,8 @@ steps:
 func envValue(env []string, key string) string {
 	prefix := key + "="
 	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix)
+		if after, ok := strings.CutPrefix(entry, prefix); ok {
+			return after
 		}
 	}
 	return ""

--- a/internal/cmd/retry_params_external_test.go
+++ b/internal/cmd/retry_params_external_test.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmdpkg "github.com/dagucloud/dagu/internal/cmd"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestoreDAGFromStatusLoadsDotenvWithPersistedParamsList(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "zscores")
+	require.NoError(t, os.MkdirAll(workDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env.foo"), []byte("TARGET_TABLE=foo\n"), 0o600))
+
+	yamlData := []byte(`
+name: calculate_zscores
+working_dir: zscores
+params:
+  - name: COL
+    type: string
+    required: true
+dotenv:
+  - ".env.${COL}"
+steps:
+  - name: assert_variables_defined
+    run: echo "${TARGET_TABLE}"
+`)
+	dag := &core.DAG{
+		Name:       "calculate_zscores",
+		Location:   filepath.Join(root, "calculate_zscores.yaml"),
+		WorkingDir: workDir,
+		Dotenv:     []string{".env.${COL}"},
+		YamlData:   yamlData,
+		ParamDefs: []core.ParamDef{
+			{Name: "COL", Type: core.ParamDefTypeString, Required: true},
+		},
+	}
+	status := &exec.DAGRunStatus{ParamsList: []string{"COL=foo"}}
+
+	restored, err := cmdpkg.RestoreDAGFromStatusForTest(context.Background(), dag, status)
+	require.NoError(t, err)
+
+	require.Contains(t, restored.Params, "COL=foo")
+	require.Equal(t, "foo", envValue(restored.Env, "TARGET_TABLE"))
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}

--- a/internal/core/spec/dparams_runtime.go
+++ b/internal/core/spec/dparams_runtime.go
@@ -56,7 +56,7 @@ func runtimeParamLoadOptions(dag *core.DAG, params any, opts ResolveRuntimeParam
 	case string:
 		loadOpts = append(loadOpts, WithParams(value))
 	case []string:
-		loadOpts = append(loadOpts, WithParams(value))
+		loadOpts = append(loadOpts, WithParams(QuoteRuntimeParams(value, dag.ParamDefs)))
 	default:
 		return nil, fmt.Errorf("invalid runtime params type %T", params)
 	}

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -68,9 +68,14 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 	if err != nil {
 		return ResolveEnvResult{}, err
 	}
+	runtimeParams, err := resolveRuntimeParamsForEnv(ctx, dag, loadOpts)
+	if err != nil {
+		return ResolveEnvResult{}, err
+	}
 
 	cloned := dag.Clone()
 	cloned.BuildWarnings = append([]string(nil), cloned.BuildWarnings...)
+	cloned.Params = runtimeParams
 	if hasRuntimeParams(params) {
 		// Recompute DAG/base-config env entries for the new runtime params instead
 		// of short-circuiting to whatever happened to be on the current snapshot.
@@ -114,6 +119,25 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 			Env:           buildenv.AppendMissing(dag.Env, loadedEnv, presolvedEnv),
 			BuildWarnings: buildWarnings,
 		}, nil
+	}
+}
+
+func resolveRuntimeParamsForEnv(ctx context.Context, dag *core.DAG, loadOpts []LoadOption) ([]string, error) {
+	switch {
+	case len(dag.YamlData) > 0:
+		fresh, err := LoadYAML(ctx, dag.YamlData, loadOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return append([]string(nil), fresh.Params...), nil
+	case dag.Location != "":
+		fresh, err := Load(ctx, dag.Location, loadOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return append([]string(nil), fresh.Params...), nil
+	default:
+		return append([]string(nil), dag.Params...), nil
 	}
 }
 

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -72,6 +72,40 @@ steps:
 	require.Contains(t, result.BuildWarnings[0], "failed to load .env file")
 }
 
+func TestResolveEnvWithWarningsLoadsDotenvWithRuntimeParams(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "zscores")
+	require.NoError(t, os.MkdirAll(workDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env.foo"), []byte("TARGET_TABLE=foo\n"), 0o600))
+
+	yamlData := fmt.Appendf(nil, `
+name: calculate_zscores
+working_dir: %q
+params:
+  - name: COL
+    type: string
+    required: true
+dotenv:
+  - ".env.${COL}"
+steps:
+  - name: assert_variables_defined
+    run: echo "${TARGET_TABLE}"
+`, workDir)
+	dag, err := spec.LoadYAML(context.Background(), yamlData, spec.WithParams("COL=foo"))
+	require.NoError(t, err)
+	dag.LoadDotEnv(context.Background())
+	require.Equal(t, "foo", runtimeEnvSliceMap(dag.Env)["TARGET_TABLE"])
+
+	persisted := dag.Clone()
+	persisted.Env = nil
+	persisted.Params = nil
+	result, err := spec.ResolveEnvWithWarnings(context.Background(), persisted, []string{"COL=foo"}, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "foo", runtimeEnvSliceMap(result.Env)["TARGET_TABLE"])
+}
+
 func TestResolveEnvWithWarningsDoesNotMutateDAGBackingSlices(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/runtime_params_external_test.go
+++ b/internal/core/spec/runtime_params_external_test.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRuntimeParamsListPreservesValueWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	yamlData := []byte(`
+name: runtime-params
+params:
+  - topic: ""
+steps:
+  - name: test
+    run: echo "$topic"
+`)
+	dag, err := spec.LoadYAML(context.Background(), yamlData, spec.WithoutEval())
+	require.NoError(t, err)
+	dag.YamlData = yamlData
+
+	resolved, err := spec.ResolveRuntimeParams(context.Background(), dag, []string{"topic=hello world"}, spec.ResolveRuntimeParamsOptions{})
+	require.NoError(t, err)
+	require.Contains(t, resolved.Params, "topic=hello world")
+}

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -3055,9 +3055,9 @@ func (a *API) rescheduleDAGRun(ctx context.Context, dagName, dagRunID string, op
 			}
 		}
 	}
-	currentFileParams := status.Params
+	currentFileParams := preservedSnapshotParams
 	if currentFileParams == "" {
-		currentFileParams = preservedSnapshotParams
+		currentFileParams = status.Params
 	}
 
 	newDagRunID := strings.TrimSpace(opts.newDagRunID)

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -567,19 +567,21 @@ func (a *API) loadInlineDAG(ctx context.Context, specContent string, name *strin
 }
 
 func restoreDAGRunSnapshot(ctx context.Context, dag *core.DAG, status *exec.DAGRunStatus) (*core.DAG, string, error) {
-	quotedParams := spec.QuoteRuntimeParams(status.ParamsList, dag.ParamDefs)
-	dag.Params = quotedParams
+	runtimeParams := append([]string(nil), status.ParamsList...)
+	dag.Params = runtimeParams
 	dagwarning.LoadDotEnv(ctx, dag)
 
-	restored, err := rebuildDAGRunSnapshotFromYAML(ctx, dag)
+	quotedParams := spec.QuoteRuntimeParams(runtimeParams, dag.ParamDefs)
+	restored, err := rebuildDAGRunSnapshotFromYAML(ctx, dag, quotedParams)
 	if err != nil {
 		return nil, "", err
 	}
 
-	return restored, strings.Join(quotedParams, " "), nil
+	preservedParams := strings.Join(quotedParams, " ")
+	return restored, preservedParams, nil
 }
 
-func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG) (*core.DAG, error) {
+func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG, paramsOverride ...[]string) (*core.DAG, error) {
 	if len(dag.YamlData) == 0 {
 		return dag, nil
 	}
@@ -603,8 +605,12 @@ func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG) (*core.DA
 		buildEnvMap[key] = value
 	}
 
+	params := dag.Params
+	if len(paramsOverride) > 0 {
+		params = paramsOverride[0]
+	}
 	loadOpts := []spec.LoadOption{
-		spec.WithParams(dag.Params),
+		spec.WithParams(params),
 		spec.SkipSchemaValidation(),
 	}
 	if len(buildEnvMap) > 0 {
@@ -3512,7 +3518,7 @@ func (a *API) prepareRetryDAGForSubprocess(ctx context.Context, dag *core.DAG, s
 		return dag, nil
 	}
 
-	result, err := spec.ResolveEnvWithWarnings(ctx, dag, spec.QuoteRuntimeParams(status.ParamsList, dag.ParamDefs), spec.ResolveEnvOptions{
+	result, err := spec.ResolveEnvWithWarnings(ctx, dag, status.ParamsList, spec.ResolveEnvOptions{
 		BaseConfig: a.config.Paths.BaseConfig,
 	})
 	if err != nil {

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1105,18 +1105,23 @@ func TestRescheduleDAGRunCanUseCurrentDAGFile(t *testing.T) {
 
 	dagName := "reschedule_use_current_file"
 	initialSpec := `queue: reschedule_use_current_file
+params:
+  - name: MESSAGE
+    type: string
+    required: true
 steps:
   - name: main
-    run: echo stored snapshot`
+    run: echo "${MESSAGE} stored snapshot"`
 
 	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
 		Name: dagName,
 		Spec: &initialSpec,
 	}).ExpectStatus(http.StatusCreated).Send(t)
 
+	startParams := `MESSAGE="hello world"`
 	startResp := server.Client().Post(
 		fmt.Sprintf("/api/v1/dags/%s/start", dagName),
-		api.ExecuteDAGJSONRequestBody{},
+		api.ExecuteDAGJSONRequestBody{Params: &startParams},
 	).ExpectStatus(http.StatusOK).Send(t)
 
 	var startBody api.ExecuteDAG200JSONResponse
@@ -1136,9 +1141,13 @@ steps:
 	}, dagRunEventuallyTimeout(10*time.Second), 200*time.Millisecond)
 
 	currentSpec := `queue: reschedule_use_current_file
+params:
+  - name: MESSAGE
+    type: string
+    required: true
 steps:
   - name: main
-    run: echo current file`
+    run: echo "${MESSAGE} current file"`
 	dagPath := filepath.Join(server.Config.Paths.DAGsDir, dagName+".yaml")
 	assertRescheduleSpecSourceFlag(t, server, dagName, startBody.DagRunId, true)
 	originalAttempt, originalDAG := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, startBody.DagRunId)
@@ -1160,12 +1169,13 @@ steps:
 	test.ProcessQueuedInlineRun(t, server, dagName)
 
 	_, dag := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, body.DagRunId)
-	require.Contains(t, string(dag.YamlData), "echo current file")
+	require.Contains(t, string(dag.YamlData), "current file")
 	require.Equal(t, dagPath, dag.SourceFile)
 
-	waitForStoredDAGRunStatus(t, server, dagName, body.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+	rescheduledStatus := waitForStoredDAGRunStatus(t, server, dagName, body.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
 		return status.Status == core.Succeeded
 	})
+	require.Contains(t, rescheduledStatus.ParamsList, "MESSAGE=hello world")
 }
 
 func TestRescheduleDAGRunRequiresQueuesEnabled(t *testing.T) {

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -209,7 +209,7 @@ func (e *DAGExecutor) executeDAG(
 		if profileName != "" {
 			taskOpts = append(taskOpts, executor.WithProfileName(profileName))
 		}
-		if previousStatus != nil && previousStatus.Params != "" {
+		if previousStatus != nil && len(previousStatus.ParamsList) == 0 && previousStatus.Params != "" {
 			taskOpts = append(taskOpts, executor.WithTaskParams(previousStatus.Params))
 		}
 		if dag.SourceFile != "" {

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -240,7 +240,7 @@ func (e *DAGExecutor) executeDAG(
 	// Local execution
 	var params any
 	if previousStatus != nil {
-		params = spec.QuoteRuntimeParams(previousStatus.ParamsList, dag.ParamDefs)
+		params = previousStatus.ParamsList
 	}
 	dag, err := e.prepareDAGForSubprocess(ctx, dag, params)
 	if err != nil {

--- a/internal/service/scheduler/dag_executor_test.go
+++ b/internal/service/scheduler/dag_executor_test.go
@@ -135,7 +135,7 @@ steps:
 	})
 }
 
-func TestDAGExecutor_DistributedRetryPassesQueuedParams(t *testing.T) {
+func TestDAGExecutor_DistributedRetryUsesPreviousStatusParamsList(t *testing.T) {
 	dispatcher := &capturingDispatcher{}
 	dagExecutor := scheduler.NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil)
 
@@ -146,8 +146,8 @@ func TestDAGExecutor_DistributedRetryPassesQueuedParams(t *testing.T) {
 	}
 	previousStatus := &exec.DAGRunStatus{
 		Status:     core.Queued,
-		Params:     "content_hash=sha256:abc123",
-		ParamsList: []string{"content_hash=sha256:abc123"},
+		Params:     "content_hash=sha256:abc123 message=hello world",
+		ParamsList: []string{"content_hash=sha256:abc123", "message=hello world"},
 	}
 
 	err := dagExecutor.ExecuteDAG(
@@ -155,6 +155,36 @@ func TestDAGExecutor_DistributedRetryPassesQueuedParams(t *testing.T) {
 		dag,
 		exec.DispatchOperationRetry,
 		"queued-param-run",
+		previousStatus,
+		core.TriggerTypeManual,
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, dispatcher.task)
+	require.Empty(t, dispatcher.task.Params)
+	require.NotNil(t, dispatcher.task.PreviousStatus)
+	require.Equal(t, previousStatus.ParamsList, dispatcher.task.PreviousStatus.ParamsList)
+}
+
+func TestDAGExecutor_DistributedRetryPassesLegacyQueuedParams(t *testing.T) {
+	dispatcher := &capturingDispatcher{}
+	dagExecutor := scheduler.NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil)
+
+	dag := &core.DAG{
+		Name:           "legacy-queued-param-dag",
+		YamlData:       []byte("name: legacy-queued-param-dag\n"),
+		WorkerSelector: map[string]string{"type": "test-worker"},
+	}
+	previousStatus := &exec.DAGRunStatus{
+		Status: core.Queued,
+		Params: "content_hash=sha256:abc123",
+	}
+
+	err := dagExecutor.ExecuteDAG(
+		context.Background(),
+		dag,
+		exec.DispatchOperationRetry,
+		"legacy-queued-param-run",
 		previousStatus,
 		core.TriggerTypeManual,
 		"",

--- a/internal/service/worker/export_test.go
+++ b/internal/service/worker/export_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
@@ -64,4 +66,13 @@ func ReportTaskInitFailureStatusForTest(ctx context.Context, task *coordinatorv1
 		return nil, errors.New("init failure status was not reported")
 	}
 	return pusher.status, nil
+}
+
+// LoadRemoteTaskDAGForTest loads the DAG definition for a remote task.
+func LoadRemoteTaskDAGForTest(ctx context.Context, cfg *config.Config, task *coordinatorv1.Task) (*core.DAG, func(), error) {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	handler := &remoteTaskHandler{config: cfg}
+	return handler.loadDAG(ctx, task)
 }

--- a/internal/service/worker/handler.go
+++ b/internal/service/worker/handler.go
@@ -227,10 +227,12 @@ func (e *taskHandler) subprocessHints(ctx context.Context, task *coordinatorv1.T
 	}
 	dag.SourceFile = task.SourceFile
 
-	params, err := retryParams(task, dag)
+	var params any
+	retryParams, err := previousStatusParams(task)
 	if err != nil {
 		return nil, err
 	}
+	params = retryParams
 	if task.Operation == coordinatorv1.Operation_OPERATION_START {
 		params = task.Params
 	}
@@ -304,7 +306,7 @@ func dagNameHint(target string) string {
 	return base
 }
 
-func retryParams(task *coordinatorv1.Task, dag *core.DAG) (any, error) {
+func previousStatusParams(task *coordinatorv1.Task) ([]string, error) {
 	if task.Operation != coordinatorv1.Operation_OPERATION_RETRY || task.PreviousStatus == nil {
 		return nil, nil
 	}
@@ -314,7 +316,7 @@ func retryParams(task *coordinatorv1.Task, dag *core.DAG) (any, error) {
 		return nil, fmt.Errorf("failed to decode previous task status: %w", err)
 	}
 
-	return spec.QuoteRuntimeParams(status.ParamsList, dag.ParamDefs), nil
+	return append([]string(nil), status.ParamsList...), nil
 }
 
 func isQueueDispatchTask(task *coordinatorv1.Task) bool {

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -432,6 +432,7 @@ func (h *remoteTaskHandler) loadDAG(ctx context.Context, task *coordinatorv1.Tas
 	if task.Params != "" {
 		loadOpts = append(loadOpts, spec.WithParams(task.Params))
 	} else if params, err := previousStatusParams(task); err != nil {
+		cleanupFunc()
 		return nil, nil, err
 	} else if len(params) > 0 {
 		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(params, nil)))
@@ -473,6 +474,7 @@ func (h *remoteTaskHandler) loadActionWorkspaceDAG(ctx context.Context, task *co
 	if task.Params != "" {
 		loadOpts = append(loadOpts, spec.WithParams(task.Params))
 	} else if params, err := previousStatusParams(task); err != nil {
+		cleanupFunc()
 		return nil, nil, err
 	} else if len(params) > 0 {
 		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(params, nil)))

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -431,6 +431,10 @@ func (h *remoteTaskHandler) loadDAG(ctx context.Context, task *coordinatorv1.Tas
 	// Pass task params to the DAG (e.g., from parallel execution items)
 	if task.Params != "" {
 		loadOpts = append(loadOpts, spec.WithParams(task.Params))
+	} else if params, err := previousStatusParams(task); err != nil {
+		return nil, nil, err
+	} else if len(params) > 0 {
+		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(params, nil)))
 	}
 
 	dag, err := spec.Load(ctx, tempFile, loadOpts...)
@@ -468,6 +472,10 @@ func (h *remoteTaskHandler) loadActionWorkspaceDAG(ctx context.Context, task *co
 	}
 	if task.Params != "" {
 		loadOpts = append(loadOpts, spec.WithParams(task.Params))
+	} else if params, err := previousStatusParams(task); err != nil {
+		return nil, nil, err
+	} else if len(params) > 0 {
+		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(params, nil)))
 	}
 
 	dag, err := spec.Load(ctx, workspace.dagFile, loadOpts...)

--- a/internal/service/worker/remote_retry_params_external_test.go
+++ b/internal/service/worker/remote_retry_params_external_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/proto/convert"
+	"github.com/dagucloud/dagu/internal/service/worker"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteRetryLoadDAGUsesPreviousStatusParamsList(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "zscores")
+	require.NoError(t, os.MkdirAll(workDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".env.foo"), []byte("TARGET_TABLE=foo\n"), 0o600))
+
+	definition := fmt.Sprintf(`
+name: calculate_zscores
+working_dir: %q
+params:
+  - name: COL
+    type: string
+    required: true
+  - name: MESSAGE
+    type: string
+    required: true
+dotenv:
+  - ".env.${COL}"
+steps:
+  - name: assert_variables_defined
+    run: echo "${TARGET_TABLE}"
+`, workDir)
+	previousStatus, err := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+		Name:       "calculate_zscores",
+		DAGRunID:   "run-1",
+		ParamsList: []string{"COL=foo", "MESSAGE=hello world"},
+	})
+	require.NoError(t, err)
+
+	task := &coordinatorv1.Task{
+		Operation:      coordinatorv1.Operation_OPERATION_RETRY,
+		Target:         "calculate_zscores",
+		Definition:     definition,
+		DagRunId:       "run-1",
+		PreviousStatus: previousStatus,
+	}
+	dag, cleanup, err := worker.LoadRemoteTaskDAGForTest(context.Background(), &config.Config{}, task)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	require.Contains(t, dag.Params, "COL=foo")
+	require.Contains(t, dag.Params, "MESSAGE=hello world")
+	dag.LoadDotEnv(context.Background())
+	require.Equal(t, "foo", workerTestEnvValue(dag.Env, "TARGET_TABLE"))
+}
+
+func workerTestEnvValue(env []string, key string) string {
+	for _, entry := range env {
+		k, value, ok := strings.Cut(entry, "=")
+		if ok && k == key {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/service/worker/remote_retry_params_external_test.go
+++ b/internal/service/worker/remote_retry_params_external_test.go
@@ -69,6 +69,35 @@ steps:
 	require.Equal(t, "foo", workerTestEnvValue(dag.Env, "TARGET_TABLE"))
 }
 
+func TestRemoteRetryLoadDAGCleansTempFileWhenPreviousStatusInvalid(t *testing.T) {
+	target := "cleanup-retry-params"
+	pattern := filepath.Join(os.TempDir(), "dagu", "worker-dags", target+"-*.yaml")
+	before, err := filepath.Glob(pattern)
+	require.NoError(t, err)
+
+	task := &coordinatorv1.Task{
+		Operation: coordinatorv1.Operation_OPERATION_RETRY,
+		Target:    target,
+		Definition: `
+name: cleanup-retry-params
+steps:
+  - name: noop
+    run: echo noop
+`,
+		DagRunId:       "run-1",
+		PreviousStatus: &coordinatorv1.DAGRunStatusProto{JsonData: "{"},
+	}
+
+	dag, cleanup, err := worker.LoadRemoteTaskDAGForTest(context.Background(), &config.Config{}, task)
+	require.Error(t, err)
+	require.Nil(t, dag)
+	require.Nil(t, cleanup)
+
+	after, err := filepath.Glob(pattern)
+	require.NoError(t, err)
+	require.ElementsMatch(t, before, after)
+}
+
 func workerTestEnvValue(env []string, key string) string {
 	for _, entry := range env {
 		k, value, ok := strings.Cut(entry, "=")


### PR DESCRIPTION
## Summary

Preserves raw retry `ParamsList` through retry restoration so dotenv paths such as `.env.${COL}` resolve with logical values and parameter values containing spaces survive retries.

## Changes

- Use raw `ParamsList` for dotenv loading and quote runtime params only at parser/reload boundaries.
- Rehydrate retry params consistently in CLI, API reschedule/subprocess, scheduler, and distributed worker paths.
- Add regression coverage for dotenv parameter expansion, values with spaces, reschedule, distributed retry, and worker cleanup on invalid previous status.

## Related Issues

Fixes #2265

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Root Cause

Retry restored `status.ParamsList` through quoted parser tokens before dotenv loading. That changed `COL=foo` into `COL="foo"` for dotenv path expansion, so `.env.${COL}` became `.env."foo"` and missed `.env.foo`. Some retry paths also relied on task params only and did not rehydrate params from embedded previous status.

## Testing

- `go test ./internal/cmd ./internal/core/spec ./internal/service/frontend/api/v1 ./internal/service/scheduler ./internal/service/worker -count=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves raw retry params during dotenv resolution so .env.${COL} resolves correctly and values with spaces aren’t split. Extends this to reschedule and distributed retry paths to keep ParamsList intact across CLI, API/subprocess, scheduler, and remote worker. Fixes #2265.

- **Bug Fixes**
  - Load dotenv using the unquoted previous ParamsList; quote only when re-parsing to keep space-containing values intact.
  - Recompute runtime params before env resolution and apply them to DAG cloning so `.env` expansion is accurate.
  - Standardize retry param restoration across reschedule and distributed paths: reschedule prefers snapshot-preserved params and persists ParamsList; distributed retry passes PreviousStatus.ParamsList to workers with a legacy Params fallback.

<sup>Written for commit 61ceaf65501d94ba4fbbf1f7407adfed310a2875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved preservation and restoration of runtime parameters when retrying DAG runs.
  * Fixed handling of parameterized dotenv file paths during retry operations.
  * Enhanced support for parameter values containing special characters (spaces) during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
