### PR TITLE
fix: resolve scheduler no-eval env before subprocess launch

### DIFF
--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -119,6 +119,8 @@ type DAG struct {
 	// Note: This field is evaluated at build time and may contain secrets.
 	// It is excluded from JSON serialization to prevent secret leakage.
 	Env []string `json:"-"`
+	// EnvEvaluated reports whether Env is safe to reuse as resolved build env.
+	EnvEvaluated bool `json:"-"`
 	// PresolvedBuildEnv stores resolved DAG/base-config env entries needed to
 	// rebuild the DAG from persisted YAML during retry/restart paths.
 	// It is serialized with dag.json because direct retry/restart cannot rely on

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -775,9 +775,16 @@ func (s *dagBuildState) validateResult() {
 }
 
 func (s *dagBuildState) capturePresolvedBuildEnv() {
+	if s.ctx.opts.Has(BuildFlagNoEval) {
+		return
+	}
 	if len(s.ctx.envScope.buildEnv) > 0 {
 		s.result.PresolvedBuildEnv = maps.Clone(s.ctx.envScope.buildEnv)
 	}
+}
+
+func (s *dagBuildState) markEnvEvaluated() {
+	s.result.EnvEvaluated = !s.ctx.opts.Has(BuildFlagNoEval)
 }
 
 func (s *dagBuildState) finish() (*core.DAG, error) {
@@ -798,6 +805,7 @@ func (d *dag) build(ctx BuildContext) (*core.DAG, error) {
 	state.prepareParamEnvStage()
 	state.runFieldStages()
 	state.composeInheritedContext()
+	state.markEnvEvaluated()
 	state.collectWarnings()
 	state.buildActionGraph()
 	state.validateResult()

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -60,7 +60,7 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 	if dag == nil {
 		return ResolveEnvResult{}, nil
 	}
-	if !hasRuntimeParams(params) && len(dag.Env) > 0 {
+	if canReuseCurrentEnv(dag, params) {
 		return ResolveEnvResult{Env: append([]string{}, dag.Env...)}, nil
 	}
 
@@ -76,9 +76,9 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 	cloned := dag.Clone()
 	cloned.BuildWarnings = append([]string(nil), cloned.BuildWarnings...)
 	cloned.Params = runtimeParams
-	if hasRuntimeParams(params) {
-		// Recompute DAG/base-config env entries for the new runtime params instead
-		// of short-circuiting to whatever happened to be on the current snapshot.
+	if shouldRecomputeEnv(dag, params) {
+		// Recompute DAG/base-config env entries when params or raw source-backed
+		// metadata can affect build-time env resolution.
 		cloned.Env = nil
 	} else {
 		cloned.Env = append([]string(nil), cloned.Env...)
@@ -120,6 +120,18 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 			BuildWarnings: buildWarnings,
 		}, nil
 	}
+}
+
+func canReuseCurrentEnv(dag *core.DAG, params any) bool {
+	return !hasRuntimeParams(params) && len(dag.Env) > 0 && (dag.EnvEvaluated || !hasDAGSource(dag))
+}
+
+func shouldRecomputeEnv(dag *core.DAG, params any) bool {
+	return hasRuntimeParams(params) || (hasDAGSource(dag) && !dag.EnvEvaluated)
+}
+
+func hasDAGSource(dag *core.DAG) bool {
+	return len(dag.YamlData) > 0 || dag.Location != ""
 }
 
 func resolveRuntimeParamsForEnv(ctx context.Context, dag *core.DAG, loadOpts []LoadOption) ([]string, error) {

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -114,6 +114,16 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 			BuildWarnings: buildWarnings,
 		}, nil
 
+	case dag.SourceFile != "":
+		fresh, err := Load(ctx, dag.SourceFile, loadOpts...)
+		if err != nil {
+			return ResolveEnvResult{}, err
+		}
+		return ResolveEnvResult{
+			Env:           buildenv.AppendMissing(fresh.Env, loadedEnv, presolvedEnv),
+			BuildWarnings: buildWarnings,
+		}, nil
+
 	default:
 		return ResolveEnvResult{
 			Env:           buildenv.AppendMissing(dag.Env, loadedEnv, presolvedEnv),
@@ -131,7 +141,7 @@ func shouldRecomputeEnv(dag *core.DAG, params any) bool {
 }
 
 func hasDAGSource(dag *core.DAG) bool {
-	return len(dag.YamlData) > 0 || dag.Location != ""
+	return len(dag.YamlData) > 0 || dag.Location != "" || dag.SourceFile != ""
 }
 
 func resolveRuntimeParamsForEnv(ctx context.Context, dag *core.DAG, loadOpts []LoadOption) ([]string, error) {
@@ -144,6 +154,12 @@ func resolveRuntimeParamsForEnv(ctx context.Context, dag *core.DAG, loadOpts []L
 		return append([]string(nil), fresh.Params...), nil
 	case dag.Location != "":
 		fresh, err := Load(ctx, dag.Location, loadOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return append([]string(nil), fresh.Params...), nil
+	case dag.SourceFile != "":
+		fresh, err := Load(ctx, dag.SourceFile, loadOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -155,6 +156,86 @@ steps:
 		require.Len(t, dag.BuildWarnings, 1)
 		require.Empty(t, dag.BuildWarnings[:cap(dag.BuildWarnings)][1])
 	})
+}
+
+func TestResolveEnvWithWarningsReloadsNoEvalMetadataEnvFromSource(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ISSUE_2268_TOKEN", "secret123")
+
+	dagPath := filepath.Join(t.TempDir(), "issue2268.yaml")
+	require.NoError(t, os.WriteFile(dagPath, []byte(`
+name: issue2268
+schedule:
+  - "*/5 * * * *"
+env:
+  - TOKEN: ${ISSUE_2268_TOKEN}
+steps:
+  - name: check
+    run: echo "$TOKEN"
+`), 0o600))
+
+	metadata, err := spec.Load(
+		ctx,
+		dagPath,
+		spec.OnlyMetadata(),
+		spec.WithoutEval(),
+		spec.SkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(metadata.Env)["TOKEN"])
+
+	result, err := spec.ResolveEnvWithWarnings(ctx, metadata, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "secret123", runtimeEnvSliceMap(result.Env)["TOKEN"])
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(metadata.Env)["TOKEN"])
+}
+
+func TestLoadWithoutEvalDoesNotCaptureRawEnvAsPresolvedBuildEnv(t *testing.T) {
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: raw-metadata-env
+env:
+  - TOKEN: ${ISSUE_2268_TOKEN}
+steps:
+  - name: check
+    run: echo "$TOKEN"
+`), spec.OnlyMetadata(), spec.WithoutEval())
+	require.NoError(t, err)
+
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(dag.Env)["TOKEN"])
+	require.Empty(t, dag.PresolvedBuildEnv)
+}
+
+func TestResolveEnvWithWarningsReusesEvaluatedSourceEnv(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ISSUE_2268_TOKEN", "old-value")
+
+	dag, err := spec.LoadYAML(ctx, []byte(`
+name: evaluated-source-env
+env:
+  - TOKEN: ${ISSUE_2268_TOKEN}
+steps:
+  - name: check
+    run: echo "$TOKEN"
+`))
+	require.NoError(t, err)
+	require.Equal(t, "old-value", runtimeEnvSliceMap(dag.Env)["TOKEN"])
+
+	t.Setenv("ISSUE_2268_TOKEN", "new-value")
+
+	result, err := spec.ResolveEnvWithWarnings(ctx, dag, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "old-value", runtimeEnvSliceMap(result.Env)["TOKEN"])
+}
+
+func TestResolveEnvWithWarningsKeepsProgrammaticEnvWithoutSource(t *testing.T) {
+	dag := &core.DAG{
+		Name: "programmatic-env",
+		Env:  []string{"TOKEN=${ISSUE_2268_TOKEN}"},
+	}
+
+	result, err := spec.ResolveEnvWithWarnings(context.Background(), dag, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(result.Env)["TOKEN"])
 }
 
 func runtimeEnvSliceMap(envs []string) map[string]string {

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -190,6 +190,42 @@ steps:
 	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(metadata.Env)["TOKEN"])
 }
 
+func TestResolveEnvWithWarningsReloadsNoEvalMetadataEnvFromSourceFile(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ISSUE_2268_TOKEN", "secret123")
+
+	dagPath := filepath.Join(t.TempDir(), "issue2268.yaml")
+	require.NoError(t, os.WriteFile(dagPath, []byte(`
+name: issue2268
+schedule:
+  - "*/5 * * * *"
+env:
+  - TOKEN: ${ISSUE_2268_TOKEN}
+steps:
+  - name: check
+    run: echo "$TOKEN"
+`), 0o600))
+
+	metadata, err := spec.Load(
+		ctx,
+		dagPath,
+		spec.OnlyMetadata(),
+		spec.WithoutEval(),
+		spec.SkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, metadata.SourceFile)
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(metadata.Env)["TOKEN"])
+
+	metadata.Location = ""
+	metadata.YamlData = nil
+
+	result, err := spec.ResolveEnvWithWarnings(ctx, metadata, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "secret123", runtimeEnvSliceMap(result.Env)["TOKEN"])
+	require.Equal(t, "${ISSUE_2268_TOKEN}", runtimeEnvSliceMap(metadata.Env)["TOKEN"])
+}
+
 func TestLoadWithoutEvalDoesNotCaptureRawEnvAsPresolvedBuildEnv(t *testing.T) {
 	dag, err := spec.LoadYAML(context.Background(), []byte(`
 name: raw-metadata-env


### PR DESCRIPTION
## Summary
- add in-memory env provenance so no-eval scheduler metadata is not treated as resolved
- stop persisting raw no-eval env as presolved build env
- reload source-backed raw env before subprocess launch while preserving evaluated/source and programmatic no-source behavior

Closes #2268

## Root cause
Scheduler metadata loads use OnlyMetadata with WithoutEval, leaving env values such as ${MY_SECRET} raw in dag.Env. The subprocess preparation path treated any non-empty dag.Env as already resolved and serialized it as presolved build env, causing child DAG loads to reuse the raw literal instead of expanding the OS environment.

## Testing
- go test ./internal/core/... ./internal/service/scheduler ./internal/cmd ./internal/launcher ./internal/service/worker -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix scheduler to resolve no-eval env vars before launching subprocesses and handle source-file-only metadata correctly. Prevents `${VAR}` literals from leaking into child DAG loads and recomputes env from source when needed.

- **Bug Fixes**
  - Track env provenance via `DAG.EnvEvaluated` to know when `Env` is safe to reuse.
  - Skip capturing `PresolvedBuildEnv` when building with `WithoutEval`.
  - Update `ResolveEnvWithWarnings` to reload from `SourceFile`, recompute when params change or raw source-backed metadata exists, and reuse only when `EnvEvaluated` or no source is present.
  - Extend runtime param resolution to support `SourceFile`.
  - Add tests for source-file-only reload, evaluated-source reuse, programmatic env without source, and no-eval metadata.

<sup>Written for commit dd880c7e9c1f59126da22efe6513112e932d392b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized environment variable caching to reduce unnecessary recomputation during builds by properly tracking when resolved environments can be safely reused.

* **Tests**
  * Added comprehensive test coverage for environment variable resolution and caching behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->