### PR TITLE
fix: reduce scheduler retry and notification scanning

### DIFF
--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -215,6 +215,13 @@ func (att *Attempt) Write(ctx context.Context, status exec.DAGRunStatus) error {
 		att.cache.Invalidate(att.file)
 	}
 
+	if err := updateRetryCandidateFromStatus(att.file, status); err != nil {
+		logger.Warn(ctx, "Failed to update DAG-run retry candidate", tag.Error(err))
+		if dirtyErr := markRetryCandidatesDirty(att.file); dirtyErr != nil {
+			logger.Warn(ctx, "Failed to mark DAG-run retry candidates dirty", tag.Error(dirtyErr))
+		}
+	}
+
 	nextEventType, _, err := eventstore.EmitPersistedStatusTransitionFromContext(
 		ctx,
 		att.lastEmittedEventType,

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -1,0 +1,299 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+const (
+	retryCandidateDirName       = ".dagrun.retry-candidates"
+	retryCandidateDirtyFileName = ".dagrun.retry-candidates.dirty"
+	retryCandidateExt           = ".json"
+)
+
+type retryCandidateFile struct {
+	RunTimestampUnix int64             `json:"runTimestampUnix"`
+	Status           exec.DAGRunStatus `json:"status"`
+}
+
+func (store *Store) ListRetryCandidates(ctx context.Context, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error) {
+	var candidates []*exec.DAGRunStatus
+
+	roots, err := store.listRoot(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list root directories: %w", err)
+	}
+
+	for _, root := range roots {
+		dayPaths, err := listDayPathsInRange(root, from, exec.TimeInUTC{})
+		if err != nil {
+			return nil, err
+		}
+		for _, dayPath := range dayPaths {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			dayCandidates, err := store.listRetryCandidatesForDay(ctx, dayPath, from)
+			if err != nil {
+				return nil, err
+			}
+			candidates = append(candidates, dayCandidates...)
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CreatedAt > candidates[j].CreatedAt
+	})
+	return candidates, nil
+}
+
+func (store *Store) listRetryCandidatesForDay(ctx context.Context, dayPath string, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error) {
+	candidateDir := filepath.Join(dayPath, retryCandidateDirName)
+	needsRebuild, err := retryCandidatesNeedRebuild(dayPath)
+	if err != nil {
+		return nil, err
+	}
+	if needsRebuild {
+		if err := rebuildRetryCandidatesForDay(ctx, dayPath, store.cache); err != nil {
+			return nil, err
+		}
+	}
+
+	entries, err := os.ReadDir(candidateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read retry candidate directory %s: %w", candidateDir, err)
+	}
+
+	var candidates []*exec.DAGRunStatus
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), retryCandidateExt) {
+			continue
+		}
+		candidatePath := filepath.Join(candidateDir, entry.Name())
+		candidate, err := readRetryCandidateFile(candidatePath)
+		if err != nil {
+			continue
+		}
+		exists, err := retryCandidateRunExists(dayPath, candidate)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			if err := fileutil.Remove(candidatePath); err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("remove stale retry candidate %s: %w", candidatePath, err)
+			}
+			continue
+		}
+		if !from.IsZero() && time.Unix(candidate.RunTimestampUnix, 0).UTC().Before(from.Time) {
+			continue
+		}
+		if !isRetryCandidateStatus(candidate.Status) {
+			continue
+		}
+		status := candidate.Status
+		candidates = append(candidates, &status)
+	}
+	return candidates, nil
+}
+
+func updateRetryCandidateFromStatus(statusFile string, status exec.DAGRunStatus) error {
+	runDir, dayDir, ok := retryCandidateRootPaths(statusFile)
+	if !ok {
+		return nil
+	}
+
+	candidatePath := retryCandidatePath(dayDir, status)
+	if !isRetryCandidateStatus(status) {
+		if err := fileutil.Remove(candidatePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove retry candidate: %w", err)
+		}
+		return nil
+	}
+
+	run, err := NewDAGRun(runDir)
+	if err != nil {
+		return fmt.Errorf("parse retry candidate run directory: %w", err)
+	}
+
+	candidate := retryCandidateFile{
+		RunTimestampUnix: run.timestamp.UTC().Unix(),
+		Status:           retryCandidateStatus(status),
+	}
+	data, err := json.Marshal(candidate)
+	if err != nil {
+		return fmt.Errorf("marshal retry candidate: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(candidatePath), 0750); err != nil {
+		return fmt.Errorf("create retry candidate directory: %w", err)
+	}
+	return fileutil.WriteFileAtomic(candidatePath, data, 0600)
+}
+
+func markRetryCandidatesDirty(statusFile string) error {
+	_, dayDir, ok := retryCandidateRootPaths(statusFile)
+	if !ok {
+		return nil
+	}
+	return fileutil.WriteFileAtomic(filepath.Join(dayDir, retryCandidateDirtyFileName), []byte("dirty\n"), 0600)
+}
+
+func retryCandidateRootPaths(statusFile string) (runDir, dayDir string, ok bool) {
+	if filepath.Base(statusFile) != JSONLStatusFile {
+		return "", "", false
+	}
+	attemptDir := filepath.Dir(statusFile)
+	if !strings.HasPrefix(filepath.Base(attemptDir), AttemptDirPrefix) {
+		return "", "", false
+	}
+	runDir = filepath.Dir(attemptDir)
+	if !strings.HasPrefix(filepath.Base(runDir), DAGRunDirPrefix) {
+		return "", "", false
+	}
+	return runDir, filepath.Dir(runDir), true
+}
+
+func retryCandidatesNeedRebuild(dayPath string) (bool, error) {
+	dirtyFile := filepath.Join(dayPath, retryCandidateDirtyFileName)
+	if _, err := os.Stat(dirtyFile); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("stat retry candidate dirty marker %s: %w", dirtyFile, err)
+	}
+
+	candidateDir := filepath.Join(dayPath, retryCandidateDirName)
+	info, err := os.Stat(candidateDir)
+	if err == nil {
+		return !info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, fmt.Errorf("stat retry candidate directory %s: %w", candidateDir, err)
+}
+
+func rebuildRetryCandidatesForDay(ctx context.Context, dayPath string, cache *fileutil.Cache[*exec.DAGRunStatus]) error {
+	candidateDir := filepath.Join(dayPath, retryCandidateDirName)
+	if err := fileutil.RemoveAll(candidateDir); err != nil {
+		return fmt.Errorf("remove retry candidate directory: %w", err)
+	}
+	if err := os.MkdirAll(candidateDir, 0750); err != nil {
+		return fmt.Errorf("create retry candidate directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(dayPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read day directory %s: %w", dayPath, err)
+	}
+
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), DAGRunDirPrefix) {
+			continue
+		}
+		run, err := NewDAGRun(filepath.Join(dayPath, entry.Name()))
+		if err != nil {
+			continue
+		}
+		attempt, err := run.LatestAttempt(ctx, cache)
+		if err != nil {
+			continue
+		}
+		status, err := attempt.ReadStatus(ctx)
+		if err != nil || status == nil {
+			continue
+		}
+		if err := updateRetryCandidateFromStatus(attempt.file, *status); err != nil {
+			return err
+		}
+	}
+	dirtyFile := filepath.Join(dayPath, retryCandidateDirtyFileName)
+	if err := fileutil.Remove(dirtyFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove retry candidate dirty marker: %w", err)
+	}
+	return nil
+}
+
+func readRetryCandidateFile(path string) (*retryCandidateFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var candidate retryCandidateFile
+	if err := json.Unmarshal(data, &candidate); err != nil {
+		return nil, err
+	}
+	return &candidate, nil
+}
+
+func retryCandidatePath(dayDir string, status exec.DAGRunStatus) string {
+	key := status.Name + "\x00" + status.DAGRunID
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(dayDir, retryCandidateDirName, hex.EncodeToString(sum[:])+retryCandidateExt)
+}
+
+func retryCandidateRunExists(dayPath string, candidate *retryCandidateFile) (bool, error) {
+	runTimestamp := exec.NewUTC(time.Unix(candidate.RunTimestampUnix, 0).UTC())
+	runDir := filepath.Join(dayPath, DAGRunDirPrefix+formatDAGRunTimestamp(runTimestamp)+"_"+candidate.Status.DAGRunID)
+	info, err := os.Stat(runDir)
+	if err == nil {
+		return info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat retry candidate run directory %s: %w", runDir, err)
+}
+
+func isRetryCandidateStatus(status exec.DAGRunStatus) bool {
+	return status.Status == core.Failed &&
+		status.Parent.Zero() &&
+		status.AutoRetryLimit > 0 &&
+		status.ProcGroup != ""
+}
+
+func retryCandidateStatus(status exec.DAGRunStatus) exec.DAGRunStatus {
+	return exec.DAGRunStatus{
+		Root:                 status.Root,
+		Parent:               status.Parent,
+		Name:                 status.Name,
+		DAGRunID:             status.DAGRunID,
+		AttemptID:            status.AttemptID,
+		Status:               status.Status,
+		TriggerType:          status.TriggerType,
+		CreatedAt:            status.CreatedAt,
+		QueuedAt:             status.QueuedAt,
+		ScheduleTime:         status.ScheduleTime,
+		StartedAt:            status.StartedAt,
+		FinishedAt:           status.FinishedAt,
+		AutoRetryCount:       status.AutoRetryCount,
+		AutoRetryLimit:       status.AutoRetryLimit,
+		AutoRetryInterval:    status.AutoRetryInterval,
+		AutoRetryBackoff:     status.AutoRetryBackoff,
+		AutoRetryMaxInterval: status.AutoRetryMaxInterval,
+		ProcGroup:            status.ProcGroup,
+		SuspendFlagName:      status.SuspendFlagName,
+	}
+}

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -96,6 +96,9 @@ func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, d
 		candidatePath := filepath.Join(candidateDir, candidateName)
 		candidate, err := readRetryCandidateFile(candidateDir, candidateName)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			if rebuiltCorruptCandidate {
 				return nil, fmt.Errorf("read retry candidate file %s: %w", candidatePath, err)
 			}

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -63,6 +63,10 @@ func (store *Store) ListRetryCandidates(ctx context.Context, from exec.TimeInUTC
 }
 
 func (store *Store) listRetryCandidatesForDay(ctx context.Context, dayPath string, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error) {
+	return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, false)
+}
+
+func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, dayPath string, from exec.TimeInUTC, rebuiltCorruptCandidate bool) ([]*exec.DAGRunStatus, error) {
 	candidateDir := filepath.Join(dayPath, retryCandidateDirName)
 	needsRebuild, err := retryCandidatesNeedRebuild(dayPath)
 	if err != nil {
@@ -90,7 +94,19 @@ func (store *Store) listRetryCandidatesForDay(ctx context.Context, dayPath strin
 		candidatePath := filepath.Join(candidateDir, entry.Name())
 		candidate, err := readRetryCandidateFile(candidatePath)
 		if err != nil {
-			continue
+			if rebuiltCorruptCandidate {
+				return nil, fmt.Errorf("read retry candidate file %s: %w", candidatePath, err)
+			}
+			if err := fileutil.Remove(candidatePath); err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("remove corrupted retry candidate %s: %w", candidatePath, err)
+			}
+			if err := markRetryCandidatesDirtyForDay(dayPath); err != nil {
+				return nil, err
+			}
+			if err := rebuildRetryCandidatesForDay(ctx, dayPath, store.cache); err != nil {
+				return nil, err
+			}
+			return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, true)
 		}
 		exists, err := retryCandidateRunExists(dayPath, candidate)
 		if err != nil {
@@ -152,6 +168,10 @@ func markRetryCandidatesDirty(statusFile string) error {
 	if !ok {
 		return nil
 	}
+	return markRetryCandidatesDirtyForDay(dayDir)
+}
+
+func markRetryCandidatesDirtyForDay(dayDir string) error {
 	return fileutil.WriteFileAtomic(filepath.Join(dayDir, retryCandidateDirtyFileName), []byte("dirty\n"), 0600)
 }
 

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,8 +92,9 @@ func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, d
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), retryCandidateExt) {
 			continue
 		}
-		candidatePath := filepath.Join(candidateDir, entry.Name())
-		candidate, err := readRetryCandidateFile(candidatePath)
+		candidateName := entry.Name()
+		candidatePath := filepath.Join(candidateDir, candidateName)
+		candidate, err := readRetryCandidateFile(candidateDir, candidateName)
 		if err != nil {
 			if rebuiltCorruptCandidate {
 				return nil, fmt.Errorf("read retry candidate file %s: %w", candidatePath, err)
@@ -256,8 +258,19 @@ func rebuildRetryCandidatesForDay(ctx context.Context, dayPath string, cache *fi
 	return nil
 }
 
-func readRetryCandidateFile(path string) (*retryCandidateFile, error) {
-	data, err := os.ReadFile(path)
+func readRetryCandidateFile(dir, name string) (*retryCandidateFile, error) {
+	if filepath.Base(name) != name || !strings.HasSuffix(name, retryCandidateExt) {
+		return nil, fmt.Errorf("invalid retry candidate file name %q", name)
+	}
+	file, err := os.OpenInRoot(dir, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/persis/file/dagrun/retry_candidates_external_test.go
+++ b/internal/persis/file/dagrun/retry_candidates_external_test.go
@@ -104,6 +104,33 @@ func TestStoreListRetryCandidatesRebuildsDirtyCandidateDirectory(t *testing.T) {
 	require.DirExists(t, candidateDir)
 }
 
+func TestStoreListRetryCandidatesRebuildsCorruptedCandidateFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir)
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+	candidateDir := filepath.Join(baseDir, dag.Name, "dag-runs", "2026", "06", "08", ".dagrun.retry-candidates")
+
+	attempt, _ := writeRetryCandidateStatus(t, ctx, store, dag, now, "failed-run", core.Failed)
+	defer func() { require.NoError(t, attempt.Close(ctx)) }()
+
+	entries, err := os.ReadDir(candidateDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.NoError(t, os.WriteFile(filepath.Join(candidateDir, entries[0].Name()), []byte("{"), 0600))
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "failed-run", candidates[0].DAGRunID)
+}
+
 func TestStoreListRetryCandidatesRemovesCandidateWhenRunIsGone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/dagrun/retry_candidates_external_test.go
+++ b/internal/persis/file/dagrun/retry_candidates_external_test.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type retryCandidateLister interface {
+	ListRetryCandidates(ctx context.Context, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error)
+}
+
+func TestStoreListRetryCandidatesTracksFailedRunWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := dagrun.New(t.TempDir())
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+
+	successAttempt, _ := writeRetryCandidateStatus(t, ctx, store, dag, now, "success-run", core.Succeeded)
+	defer func() { require.NoError(t, successAttempt.Close(ctx)) }()
+	failedAttempt, failedStatus := writeRetryCandidateStatus(t, ctx, store, dag, now.Add(time.Second), "failed-run", core.Failed)
+	defer func() { require.NoError(t, failedAttempt.Close(ctx)) }()
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "failed-run", candidates[0].DAGRunID)
+	assert.Equal(t, core.Failed, candidates[0].Status)
+	assert.Equal(t, 2, candidates[0].AutoRetryLimit)
+	assert.NotEmpty(t, candidates[0].ProcGroup)
+
+	failedStatus.Status = core.Queued
+	failedStatus.QueuedAt = now.Add(2 * time.Second).Format(time.RFC3339)
+	require.NoError(t, failedAttempt.Write(ctx, *failedStatus))
+
+	candidates, err = lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+}
+
+func TestStoreListRetryCandidatesRebuildsMissingCandidateDirectory(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir)
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+
+	attempt, _ := writeRetryCandidateStatus(t, ctx, store, dag, now, "failed-run", core.Failed)
+	defer func() { require.NoError(t, attempt.Close(ctx)) }()
+
+	candidateDir := filepath.Join(baseDir, dag.Name, "dag-runs", "2026", "06", "08", ".dagrun.retry-candidates")
+	require.NoError(t, os.RemoveAll(candidateDir))
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "failed-run", candidates[0].DAGRunID)
+	require.DirExists(t, candidateDir)
+}
+
+func TestStoreListRetryCandidatesRebuildsDirtyCandidateDirectory(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir)
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+	candidateDir := filepath.Join(baseDir, dag.Name, "dag-runs", "2026", "06", "08", ".dagrun.retry-candidates")
+	require.NoError(t, os.MkdirAll(filepath.Dir(candidateDir), 0750))
+	require.NoError(t, os.WriteFile(candidateDir, []byte("not a directory"), 0600))
+
+	attempt, _ := writeRetryCandidateStatus(t, ctx, store, dag, now, "failed-run", core.Failed)
+	defer func() { require.NoError(t, attempt.Close(ctx)) }()
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "failed-run", candidates[0].DAGRunID)
+	require.DirExists(t, candidateDir)
+}
+
+func TestStoreListRetryCandidatesRemovesCandidateWhenRunIsGone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir)
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+	attempt, _ := writeRetryCandidateStatus(t, ctx, store, dag, now, "failed-run", core.Failed)
+	require.NoError(t, attempt.Close(ctx))
+
+	require.NoError(t, store.RemoveDAGRun(ctx, exec.NewDAGRunRef(dag.Name, "failed-run")))
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+}
+
+func TestStoreListRetryCandidatesIgnoresChildAttemptStatusFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir)
+	lister, ok := store.(retryCandidateLister)
+	require.True(t, ok)
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	parentDAG := retryCandidateDAG()
+	parentAttempt, _ := writeRetryCandidateStatus(t, ctx, store, parentDAG, now, "parent-run", core.Running)
+	defer func() { require.NoError(t, parentAttempt.Close(ctx)) }()
+
+	rootRef := exec.NewDAGRunRef(parentDAG.Name, "parent-run")
+	childDAG := retryCandidateDAG()
+	childDAG.Name = "child-retry-dag"
+	childAttempt, err := store.CreateAttempt(ctx, childDAG, now.Add(time.Second), "child-run", exec.NewDAGRunAttemptOptions{
+		RootDAGRun: &rootRef,
+		AttemptID:  "child-attempt",
+	})
+	require.NoError(t, err)
+	require.NoError(t, childAttempt.Open(ctx))
+	defer func() { require.NoError(t, childAttempt.Close(ctx)) }()
+
+	childStatus := exec.InitialStatus(childDAG)
+	childStatus.DAGRunID = "child-run"
+	childStatus.AttemptID = childAttempt.ID()
+	childStatus.Status = core.Failed
+	childStatus.StartedAt = now.Add(time.Second).Format(time.RFC3339)
+	childStatus.FinishedAt = now.Add(2 * time.Second).Format(time.RFC3339)
+	require.NoError(t, childAttempt.Write(ctx, childStatus))
+
+	candidates, err := lister.ListRetryCandidates(ctx, exec.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+
+	childSidecarDir := filepath.Join(
+		baseDir,
+		parentDAG.Name,
+		"dag-runs",
+		"2026",
+		"06",
+		"08",
+		"dag-run_20260608_120000Z_parent-run",
+		"children",
+		".dagrun.retry-candidates",
+	)
+	require.NoDirExists(t, childSidecarDir)
+}
+
+func retryCandidateDAG() *core.DAG {
+	return &core.DAG{
+		Name:     "retry-dag",
+		Location: "/tmp/retry-dag.yaml",
+		RetryPolicy: &core.DAGRetryPolicy{
+			Limit:       2,
+			Interval:    time.Minute,
+			Backoff:     0,
+			MaxInterval: 10 * time.Minute,
+		},
+	}
+}
+
+func writeRetryCandidateStatus(
+	t *testing.T,
+	ctx context.Context,
+	store exec.DAGRunStore,
+	dag *core.DAG,
+	ts time.Time,
+	runID string,
+	status core.Status,
+) (exec.DAGRunAttempt, *exec.DAGRunStatus) {
+	t.Helper()
+
+	attempt, err := store.CreateAttempt(ctx, dag, ts, runID, exec.NewDAGRunAttemptOptions{
+		AttemptID: runID + "-attempt",
+	})
+	require.NoError(t, err)
+	require.NoError(t, attempt.Open(ctx))
+
+	runStatus := exec.InitialStatus(dag)
+	runStatus.DAGRunID = runID
+	runStatus.AttemptID = attempt.ID()
+	runStatus.Status = status
+	runStatus.StartedAt = ts.Format(time.RFC3339)
+	runStatus.FinishedAt = ts.Add(time.Minute).Format(time.RFC3339)
+	require.NoError(t, attempt.Write(ctx, runStatus))
+	return attempt, &runStatus
+}

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -385,6 +385,12 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 	cursor := m.state.SourceCursor
 	m.stateMu.Unlock()
 
+	destinations := m.transport.NotificationDestinations()
+	if len(destinationSet(destinations)) == 0 {
+		m.advanceSourceCursorToHead(ctx)
+		return
+	}
+
 	events, nextCursor, err := m.eventService.ReadDAGRunEvents(ctx, cursor)
 	if err != nil {
 		m.logger.Debug("Failed to read DAG-run events", slog.String("error", err.Error()))
@@ -423,6 +429,27 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 	for _, item := range queued {
 		m.enqueueBatch(item.destination, item.event)
 	}
+}
+
+func (m *NotificationMonitor) advanceSourceCursorToHead(ctx context.Context) {
+	cursor, err := m.eventService.DAGRunHeadCursor(ctx)
+	if err != nil {
+		m.logger.Debug("Failed to advance DAG-run notification cursor", slog.String("error", err.Error()))
+		return
+	}
+
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+
+	if !m.state.Bootstrapped {
+		return
+	}
+
+	m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
+		cursorChanged := !candidate.SourceCursor.Equal(cursor)
+		candidate.SourceCursor = cursor.Normalize()
+		return cursorChanged
+	})
 }
 
 func (m *NotificationMonitor) syncPendingDestinations(ctx context.Context) {

--- a/internal/service/chatbridge/monitor_external_test.go
+++ b/internal/service/chatbridge/monitor_external_test.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chatbridge_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/internal/service/eventstore"
+	"github.com/dagucloud/dagu/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type monitorEventStore struct {
+	mu        sync.Mutex
+	events    []*eventstore.Event
+	headCalls int
+	readCalls int
+}
+
+var _ eventstore.Store = (*monitorEventStore)(nil)
+var _ eventstore.NotificationReader = (*monitorEventStore)(nil)
+
+func (s *monitorEventStore) Emit(_ context.Context, event *eventstore.Event) error {
+	if event == nil {
+		return nil
+	}
+	event.Normalize()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *monitorEventStore) Query(context.Context, eventstore.QueryFilter) (*eventstore.QueryResult, error) {
+	return &eventstore.QueryResult{}, nil
+}
+
+func (s *monitorEventStore) NotificationHeadCursor(context.Context) (eventstore.NotificationCursor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.headCalls++
+	return s.currentCursorLocked(), nil
+}
+
+func (s *monitorEventStore) ReadNotificationEvents(_ context.Context, cursor eventstore.NotificationCursor) ([]*eventstore.Event, eventstore.NotificationCursor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readCalls++
+
+	index := int(cursor.Normalize().CommittedOffsets["events"])
+	if index < 0 || index > len(s.events) {
+		index = 0
+	}
+	return append([]*eventstore.Event(nil), s.events[index:]...), s.currentCursorLocked(), nil
+}
+
+func (s *monitorEventStore) currentCursorLocked() eventstore.NotificationCursor {
+	return eventstore.NotificationCursor{
+		CommittedOffsets: map[string]int64{"events": int64(len(s.events))},
+	}
+}
+
+func (s *monitorEventStore) stats() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.headCalls, s.readCalls
+}
+
+type mutableNotificationTransport struct {
+	mu           sync.Mutex
+	destinations []string
+	delivered    []string
+}
+
+func (t *mutableNotificationTransport) NotificationDestinations() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.destinations...)
+}
+
+func (t *mutableNotificationTransport) FlushNotificationBatch(_ context.Context, _ string, batch chatbridge.NotificationBatch, _ bool) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, event := range batch.Events {
+		if event.Status != nil {
+			t.delivered = append(t.delivered, event.Status.Name)
+		}
+	}
+	return true
+}
+
+func (t *mutableNotificationTransport) setDestinations(destinations []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.destinations = append([]string(nil), destinations...)
+}
+
+func (t *mutableNotificationTransport) deliveredNames() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.delivered...)
+}
+
+func TestNotificationMonitorWithoutDestinationsAdvancesCursorWithoutReadingEvents(t *testing.T) {
+	t.Parallel()
+
+	store := &monitorEventStore{}
+	service := eventstore.New(store)
+	transport := &mutableNotificationTransport{}
+
+	cfg := chatbridge.DefaultNotificationMonitorConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	cfg.UrgentWindow = 5 * time.Millisecond
+	cfg.SuccessWindow = 5 * time.Millisecond
+
+	monitor := chatbridge.NewNotificationMonitor(
+		service,
+		filepath.Join(t.TempDir(), "state.json"),
+		transport,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg,
+	)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	require.Eventually(t, func() bool {
+		headCalls, _ := store.stats()
+		return headCalls > 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, store.Emit(context.Background(), newMonitorDAGRunEvent("old-run")))
+
+	require.Eventually(t, func() bool {
+		headCalls, readCalls := store.stats()
+		return headCalls > 1 && readCalls == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestNotificationMonitorDeliversOnlyFutureEventsAfterDestinationIsAdded(t *testing.T) {
+	t.Parallel()
+
+	store := &monitorEventStore{}
+	service := eventstore.New(store)
+	transport := &mutableNotificationTransport{}
+
+	cfg := chatbridge.DefaultNotificationMonitorConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	cfg.UrgentWindow = 5 * time.Millisecond
+	cfg.SuccessWindow = 5 * time.Millisecond
+
+	monitor := chatbridge.NewNotificationMonitor(
+		service,
+		filepath.Join(t.TempDir(), "state.json"),
+		transport,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg,
+	)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	require.Eventually(t, func() bool {
+		headCalls, _ := store.stats()
+		return headCalls > 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, store.Emit(context.Background(), newMonitorDAGRunEvent("old-run")))
+	require.Eventually(t, func() bool {
+		headCalls, readCalls := store.stats()
+		return headCalls > 1 && readCalls == 0
+	}, time.Second, 10*time.Millisecond)
+
+	transport.setDestinations([]string{"dest-1"})
+	require.NoError(t, store.Emit(context.Background(), newMonitorDAGRunEvent("new-run")))
+
+	require.Eventually(t, func() bool {
+		names := transport.deliveredNames()
+		return len(names) == 1 && names[0] == "new-run"
+	}, time.Second, 10*time.Millisecond)
+
+	require.Never(t, func() bool {
+		for _, name := range transport.deliveredNames() {
+			if name == "old-run" {
+				return true
+			}
+		}
+		return false
+	}, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func newMonitorDAGRunEvent(name string) *eventstore.Event {
+	return eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceScheduler},
+		eventstore.TypeDAGRunFailed,
+		&exec.DAGRunStatus{
+			Name:      name,
+			Status:    core.Failed,
+			DAGRunID:  name + "-run",
+			AttemptID: name + "-attempt",
+		},
+		nil,
+	)
+}

--- a/internal/service/chatbridge/monitor_external_test.go
+++ b/internal/service/chatbridge/monitor_external_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -191,12 +192,7 @@ func TestNotificationMonitorDeliversOnlyFutureEventsAfterDestinationIsAdded(t *t
 	}, time.Second, 10*time.Millisecond)
 
 	require.Never(t, func() bool {
-		for _, name := range transport.deliveredNames() {
-			if name == "old-run" {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(transport.deliveredNames(), "old-run")
 	}, 50*time.Millisecond, 5*time.Millisecond)
 }
 

--- a/internal/service/chatbridge/monitor_external_test.go
+++ b/internal/service/chatbridge/monitor_external_test.go
@@ -193,7 +193,7 @@ func TestNotificationMonitorDeliversOnlyFutureEventsAfterDestinationIsAdded(t *t
 
 	require.Never(t, func() bool {
 		return slices.Contains(transport.deliveredNames(), "old-run")
-	}, 50*time.Millisecond, 5*time.Millisecond)
+	}, 300*time.Millisecond, 10*time.Millisecond)
 }
 
 func newMonitorDAGRunEvent(name string) *eventstore.Event {

--- a/internal/service/scheduler/export_test.go
+++ b/internal/service/scheduler/export_test.go
@@ -4,6 +4,8 @@
 package scheduler
 
 import (
+	"context"
+
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime"
@@ -39,4 +41,8 @@ func NewWithHooksForTest(
 		schedulerHooks{onLockWait: hooks.OnLockWait},
 		schedulerOptions{},
 	)
+}
+
+func (s *RetryScanner) ScanForTest(ctx context.Context) error {
+	return s.scan(ctx)
 }

--- a/internal/service/scheduler/retry_scanner.go
+++ b/internal/service/scheduler/retry_scanner.go
@@ -31,6 +31,10 @@ type dagRetryMetadata struct {
 	maxInterval time.Duration
 }
 
+type retryCandidateLister interface {
+	ListRetryCandidates(ctx context.Context, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error)
+}
+
 // RetryScanner periodically discovers failed latest attempts and enqueues
 // DAG-level retries once their backoff has elapsed.
 type RetryScanner struct {
@@ -112,6 +116,9 @@ func (s *RetryScanner) scan(ctx context.Context) error {
 }
 
 func (s *RetryScanner) listFailedRuns(ctx context.Context, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error) {
+	if lister, ok := s.dagRunStore.(retryCandidateLister); ok {
+		return lister.ListRetryCandidates(ctx, from)
+	}
 	return s.dagRunStore.ListStatuses(ctx,
 		exec.WithStatuses([]core.Status{core.Failed}),
 		exec.WithFrom(from),

--- a/internal/service/scheduler/retry_scanner_external_test.go
+++ b/internal/service/scheduler/retry_scanner_external_test.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/service/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type retryCandidateDAGRunStore struct {
+	exec.DAGRunStore
+
+	candidateCalls int
+	candidateFrom  exec.TimeInUTC
+	listCalls      int
+	listOptions    exec.ListDAGRunStatusesOptions
+}
+
+func (s *retryCandidateDAGRunStore) ListRetryCandidates(_ context.Context, from exec.TimeInUTC) ([]*exec.DAGRunStatus, error) {
+	s.candidateCalls++
+	s.candidateFrom = from
+	return nil, nil
+}
+
+func (s *retryCandidateDAGRunStore) ListStatuses(_ context.Context, opts ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	s.listCalls++
+	for _, opt := range opts {
+		opt(&s.listOptions)
+	}
+	return nil, nil
+}
+
+type fallbackRetryDAGRunStore struct {
+	exec.DAGRunStore
+
+	listCalls   int
+	listOptions exec.ListDAGRunStatusesOptions
+}
+
+func (s *fallbackRetryDAGRunStore) ListStatuses(_ context.Context, opts ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	s.listCalls++
+	for _, opt := range opts {
+		opt(&s.listOptions)
+	}
+	return nil, nil
+}
+
+func TestRetryScannerUsesRetryCandidateListerWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	store := &retryCandidateDAGRunStore{}
+	scanner, err := scheduler.NewRetryScanner(
+		store,
+		nil,
+		nil,
+		time.Hour,
+		func() time.Time { return now },
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, scanner.ScanForTest(context.Background()))
+
+	assert.Equal(t, 1, store.candidateCalls)
+	assert.Equal(t, now.Add(-time.Hour), store.candidateFrom.Time)
+	assert.Equal(t, 0, store.listCalls)
+}
+
+func TestRetryScannerFallsBackToStatusListingWithoutCandidateLister(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	store := &fallbackRetryDAGRunStore{}
+	scanner, err := scheduler.NewRetryScanner(
+		store,
+		nil,
+		nil,
+		time.Hour,
+		func() time.Time { return now },
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, scanner.ScanForTest(context.Background()))
+
+	assert.Equal(t, 1, store.listCalls)
+	assert.Equal(t, now.Add(-time.Hour), store.listOptions.From.Time)
+	assert.Equal(t, []core.Status{core.Failed}, store.listOptions.Statuses)
+	assert.True(t, store.listOptions.Unlimited)
+}


### PR DESCRIPTION
## Summary

- Skip DAG-run notification event reads when no notification destinations are configured by advancing the monitor cursor to the current event head.
- Add file-backed retry-candidate sidecars so the scheduler retry scanner no longer performs broad failed-status history scans in normal operation.
- Keep the retry-candidate sidecar self-healing from durable status files, including missing/dirty sidecars and stale candidates after run deletion.

## Root Cause

The scheduler-related growth came from two independent history-reading paths: the notification monitor read DAG-run events even when there were no destinations to notify, and the retry scanner used generic failed-status listing across current-day run history. Both paths scaled with accumulated history rather than actionable work.

## Testing

- `go test ./internal/persis/file/dagrun -run 'TestStoreListRetryCandidates(RebuildsDirtyCandidateDirectory|RemovesCandidateWhenRunIsGone|IgnoresChildAttemptStatusFiles)' -count=1`
- `go test ./internal/persis/file/dagrun -count=1`
- `go test ./internal/persis/file/dagrun ./internal/persis/file/eventstore ./internal/service/chatbridge ./internal/service/scheduler ./internal/service/healthcheck -count=1`
- `go test ./internal/core/exec ./internal/runtime/... -count=1`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce memory and I/O by removing broad history scans in scheduler retries and notification monitoring. Skip event reads when no destinations are set and use file-backed retry-candidate sidecars for targeted retry scans.

- **Bug Fixes**
  - Notifications: `NotificationMonitor` advances the source cursor to head when `NotificationDestinations()` is empty, avoiding DAG-run event reads and only delivering future events once destinations are set.
  - Scheduler retries: introduce `.dagrun.retry-candidates` sidecars updated on status writes; `RetryScanner` uses `ListRetryCandidates` when available (falls back to `ListStatuses` otherwise) to avoid wide failed-status scans.
  - Self-healing and hardening: confine retry-candidate file reads to the sidecar directory; rebuild sidecars when missing, dirty, or corrupted; remove stale candidates when runs are deleted and tolerate cleanup races; ignore child attempt status files.

<sup>Written for commit aacbf2ec3ed0b477f41853fe249e9d64b05aecce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent tracking of failed DAG run candidates to improve retry reliability and recovery operations.
  * Optimized notification delivery to skip event processing when notification destinations are not configured, reducing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->