### PR TITLE
fix(cmd): preserve spaced dash params

### DIFF
--- a/internal/cmd/params_validation.go
+++ b/internal/cmd/params_validation.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
 )
 
 func validateStartArgumentSeparator(ctx *Context, args []string) error {
@@ -26,7 +27,7 @@ func buildStartValidationInput(ctx *Context, args []string) (core.StartParamInpu
 		if argsLenAtDash >= len(args) {
 			return core.StartParamInput{}, nil
 		}
-		return core.StartParamInput{DashArgs: args[argsLenAtDash:]}, nil
+		return core.StartParamInput{DashArgs: spec.QuoteRuntimeParams(args[argsLenAtDash:], nil)}, nil
 	}
 
 	raw, err := ctx.Command.Flags().GetString("params")

--- a/internal/cmd/params_validation.go
+++ b/internal/cmd/params_validation.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/dagucloud/dagu/internal/core"
-	"github.com/dagucloud/dagu/internal/core/spec"
 )
 
 func validateStartArgumentSeparator(ctx *Context, args []string) error {
@@ -27,7 +26,7 @@ func buildStartValidationInput(ctx *Context, args []string) (core.StartParamInpu
 		if argsLenAtDash >= len(args) {
 			return core.StartParamInput{}, nil
 		}
-		return core.StartParamInput{DashArgs: spec.QuoteRuntimeParams(args[argsLenAtDash:], nil)}, nil
+		return core.StartParamInput{DashArgs: quoteStartDashArgs(args[argsLenAtDash:])}, nil
 	}
 
 	raw, err := ctx.Command.Flags().GetString("params")

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -340,7 +340,9 @@ func loadDAGWithParams(ctx *Context, args []string, isSubDAGRun bool) (*core.DAG
 	var params string
 
 	if ctx.Command.ArgsLenAtDash() != -1 && len(args) > 0 {
-		loadOpts = append(loadOpts, spec.WithParams(args[ctx.Command.ArgsLenAtDash():]))
+		dashArgs := args[ctx.Command.ArgsLenAtDash():]
+		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(dashArgs, nil)))
+		params = strings.Join(dashArgs, " ")
 	} else {
 		params, err = ctx.Command.Flags().GetString("params")
 		if err != nil {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -341,7 +341,7 @@ func loadDAGWithParams(ctx *Context, args []string, isSubDAGRun bool) (*core.DAG
 
 	if ctx.Command.ArgsLenAtDash() != -1 && len(args) > 0 {
 		dashArgs := args[ctx.Command.ArgsLenAtDash():]
-		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(dashArgs, nil)))
+		loadOpts = append(loadOpts, spec.WithParams(quoteStartDashArgs(dashArgs)))
 		params = strings.Join(dashArgs, " ")
 	} else {
 		params, err = ctx.Command.Flags().GetString("params")

--- a/internal/cmd/start_params.go
+++ b/internal/cmd/start_params.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/cmn/stringutil"
+	"github.com/dagucloud/dagu/internal/core/spec"
+)
+
+func quoteStartDashArgs(args []string) []string {
+	if isSingleJSONDashArg(args) {
+		return args
+	}
+	return spec.QuoteRuntimeParams(args, nil)
+}
+
+func isSingleJSONDashArg(args []string) bool {
+	if len(args) != 1 {
+		return false
+	}
+
+	input := strings.TrimSpace(stringutil.RemoveQuotes(args[0]))
+	if input == "" {
+		return false
+	}
+
+	isObject := strings.HasPrefix(input, "{") && strings.HasSuffix(input, "}")
+	isArray := strings.HasPrefix(input, "[") && strings.HasSuffix(input, "]")
+	if !isObject && !isArray {
+		return false
+	}
+	return json.Valid([]byte(input))
+}

--- a/internal/cmd/start_test.go
+++ b/internal/cmd/start_test.go
@@ -36,6 +36,11 @@ steps:
   - name: "1"
     run: "echo \"params is $1 and $2\""
 `)
+	dagStartWithSingleParam := th.DAG(t, `params: "p1"
+steps:
+  - name: "1"
+    run: "echo \"params is $1\""
+`)
 
 	dagStartWithDAGRunID := th.DAG(t, `steps:
   - name: "1"
@@ -62,6 +67,11 @@ steps:
 			Name:        "StartDAGWithParamsAfterDash",
 			Args:        []string{"start", dagStartWithParams.Location, "--", "p5", "p6"},
 			ExpectedOut: []string{`params="[1=p5 2=p6`},
+		},
+		{
+			Name:        "StartDAGWithSpacedParamAfterDash",
+			Args:        []string{"start", dagStartWithSingleParam.Location, "--", "Something here"},
+			ExpectedOut: []string{`params="[1=Something here]"`},
 		},
 		{
 			Name:        "StartDAGWithRequestID",

--- a/internal/cmd/start_test.go
+++ b/internal/cmd/start_test.go
@@ -214,6 +214,14 @@ steps:
 			Args: []string{"start", dagFile, "--", `{"KEY":"value"}`},
 		})
 		require.NoError(t, err)
+
+		dag, err := spec.Load(th.Context, dagFile)
+		require.NoError(t, err)
+
+		status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag)
+		require.NoError(t, err)
+		require.Equal(t, core.Succeeded, status.Status)
+		require.Contains(t, status.Params, "KEY=value")
 	})
 
 	t.Run("AllowsNamedPairsWhenNoParamsDeclared", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Allows for params after "--" to contain space char.

## Changes

- Arg parsing
- Tests

## Related Issues

Closes https://github.com/dagucloud/dagu/issues/2275

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves spaces in params passed after `--` in `dagu start`, and lets a single JSON arg pass through unchanged. Prevents splitting values like "Something here" and keeps JSON objects/arrays valid.

- **Bug Fixes**
  - Use `quoteStartDashArgs` when building `DashArgs` and `spec.WithParams` to quote spaced values but skip quoting for a single JSON arg.
  - Set the `params` string from joined dash args for correct display.
  - Add tests for spaced param after `--` and for a single JSON param after `--`.

<sup>Written for commit 4c08842e2730ed790a37f57eeacff3ca31ff6a63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of runtime parameters passed after the `--` separator. Arguments containing spaces are now correctly preserved as single values and properly mapped to their target parameters.

* **Tests**
  * Added test coverage for validating correct parsing of spaced parameters passed after the `--` separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->