### PR TITLE
fix: bound scheduler latest status lookup

### DIFF
--- a/internal/cmn/eval/export_test.go
+++ b/internal/cmn/eval/export_test.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package eval
+
+import "os/exec"
+
+// BuildShellCommandForTest exposes shell command construction to external tests.
+func BuildShellCommandForTest(shell, cmdStr string) *exec.Cmd {
+	return buildShellCommand(shell, cmdStr)
+}

--- a/internal/cmn/eval/options_test.go
+++ b/internal/cmn/eval/options_test.go
@@ -5,8 +5,10 @@ package eval
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,6 +48,11 @@ func TestOptions_WithOSExpansion(t *testing.T) {
 func TestWithoutExpandShell(t *testing.T) {
 	t.Setenv("TEST_VAR", "test_value_for_shell")
 	ctx := context.Background()
+	if runtime.GOOS == "windows" {
+		ctx = config.WithConfig(ctx, &config.Config{
+			Core: config.Core{DefaultShell: "cmd"},
+		})
+	}
 
 	tests := []struct {
 		name  string

--- a/internal/cmn/eval/substitute.go
+++ b/internal/cmn/eval/substitute.go
@@ -36,14 +36,63 @@ func buildShellCommandContext(ctx context.Context, shell, cmdStr string) *exec.C
 		return exec.CommandContext(ctx, "sh", "-c", cmdStr) //nolint:gosec
 	}
 
+	shell, shellArgs := splitShellCommand(shell)
 	switch strings.ToLower(filepath.Base(shell)) {
 	case "powershell.exe", "powershell", "pwsh.exe", "pwsh":
-		return exec.CommandContext(ctx, shell, "-Command", cmdStr) //nolint:gosec
+		return exec.CommandContext(ctx, shell, appendPowerShellCommandArgs(shellArgs, cmdStr)...) //nolint:gosec
 	case "cmd.exe", "cmd":
-		return exec.CommandContext(ctx, shell, "/c", cmdStr) //nolint:gosec
+		return exec.CommandContext(ctx, shell, appendShellCommandArgs(shellArgs, "/c", cmdStr)...) //nolint:gosec
 	default:
-		return exec.CommandContext(ctx, shell, "-c", cmdStr) //nolint:gosec
+		return exec.CommandContext(ctx, shell, appendShellCommandArgs(shellArgs, "-c", cmdStr)...) //nolint:gosec
 	}
+}
+
+func splitShellCommand(shell string) (string, []string) {
+	command, args, err := cmdutil.SplitCommand(shell)
+	if err != nil || command == "" {
+		return shell, nil
+	}
+	return command, args
+}
+
+func appendPowerShellCommandArgs(args []string, cmdStr string) []string {
+	result := append([]string(nil), args...)
+	commandFlagIndex := shellArgIndex(result, "-Command")
+	if commandFlagIndex < 0 {
+		commandFlagIndex = len(result)
+	}
+
+	prefix := append([]string(nil), result[:commandFlagIndex]...)
+	suffix := append([]string(nil), result[commandFlagIndex:]...)
+	if !hasShellArg(result, "-NoProfile") {
+		prefix = append(prefix, "-NoProfile")
+	}
+	if !hasShellArg(result, "-NonInteractive") {
+		prefix = append(prefix, "-NonInteractive")
+	}
+	result = append(prefix, suffix...)
+	return appendShellCommandArgs(result, "-Command", cmdStr)
+}
+
+func appendShellCommandArgs(args []string, flag, cmdStr string) []string {
+	result := append([]string(nil), args...)
+	if !hasShellArg(result, flag) {
+		result = append(result, flag)
+	}
+	return append(result, cmdStr)
+}
+
+func shellArgIndex(args []string, flag string) int {
+	for i, arg := range args {
+		if strings.EqualFold(arg, flag) {
+			return i
+		}
+	}
+	return -1
+}
+
+func hasShellArg(args []string, flag string) bool {
+	return shellArgIndex(args, flag) >= 0
 }
 
 // runCommandWithContext executes cmdStr in a shell using the EnvScope from context,

--- a/internal/cmn/eval/substitute.go
+++ b/internal/cmn/eval/substitute.go
@@ -48,6 +48,10 @@ func buildShellCommandContext(ctx context.Context, shell, cmdStr string) *exec.C
 }
 
 func splitShellCommand(shell string) (string, []string) {
+	if _, err := os.Stat(shell); err == nil {
+		return shell, nil
+	}
+
 	command, args, err := cmdutil.SplitCommand(shell)
 	if err != nil || command == "" {
 		return shell, nil

--- a/internal/cmn/eval/substitute_external_test.go
+++ b/internal/cmn/eval/substitute_external_test.go
@@ -4,23 +4,27 @@
 package eval_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/cmn/eval"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildShellCommandForPowerShellUsesStableInvocation(t *testing.T) {
 	cmd := eval.BuildShellCommandForTest("pwsh", "echo hello")
 
-	assert.Equal(t, "pwsh", cmd.Path)
+	assert.Equal(t, "pwsh", shellBaseNameForTest(cmd.Path))
 	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"}, cmd.Args[1:])
 }
 
 func TestBuildShellCommandParsesConfiguredShellArgs(t *testing.T) {
 	cmd := eval.BuildShellCommandForTest("powershell -ExecutionPolicy Bypass", "echo hello")
 
-	assert.Equal(t, "powershell", cmd.Path)
+	assert.Equal(t, "powershell", shellBaseNameForTest(cmd.Path))
 	assert.Equal(t, []string{
 		"-ExecutionPolicy",
 		"Bypass",
@@ -35,4 +39,22 @@ func TestBuildShellCommandDoesNotDuplicateCommandFlag(t *testing.T) {
 	cmd := eval.BuildShellCommandForTest("pwsh -NoProfile -Command", "echo hello")
 
 	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"}, cmd.Args[1:])
+}
+
+func TestBuildShellCommandKeepsExistingShellPathWithSpaces(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "shell dir")
+	require.NoError(t, os.MkdirAll(dir, 0750))
+	shellPath := filepath.Join(dir, "pwsh")
+	require.NoError(t, os.WriteFile(shellPath, []byte{}, 0600))
+
+	cmd := eval.BuildShellCommandForTest(shellPath, "echo hello")
+
+	assert.Equal(t, shellPath, cmd.Path)
+	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"}, cmd.Args[1:])
+}
+
+func shellBaseNameForTest(path string) string {
+	name := filepath.Base(path)
+	name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	return name
 }

--- a/internal/cmn/eval/substitute_external_test.go
+++ b/internal/cmn/eval/substitute_external_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package eval_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/eval"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildShellCommandForPowerShellUsesStableInvocation(t *testing.T) {
+	cmd := eval.BuildShellCommandForTest("pwsh", "echo hello")
+
+	assert.Equal(t, "pwsh", cmd.Path)
+	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"}, cmd.Args[1:])
+}
+
+func TestBuildShellCommandParsesConfiguredShellArgs(t *testing.T) {
+	cmd := eval.BuildShellCommandForTest("powershell -ExecutionPolicy Bypass", "echo hello")
+
+	assert.Equal(t, "powershell", cmd.Path)
+	assert.Equal(t, []string{
+		"-ExecutionPolicy",
+		"Bypass",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"echo hello",
+	}, cmd.Args[1:])
+}
+
+func TestBuildShellCommandDoesNotDuplicateCommandFlag(t *testing.T) {
+	cmd := eval.BuildShellCommandForTest("pwsh -NoProfile -Command", "echo hello")
+
+	assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"}, cmd.Args[1:])
+}

--- a/internal/cmn/eval/substitute_unix_test.go
+++ b/internal/cmn/eval/substitute_unix_test.go
@@ -50,13 +50,13 @@ func TestBuildShellCommand(t *testing.T) {
 			name:     "PowershellDetectionEvenOnUnix",
 			shell:    "/usr/local/bin/powershell",
 			cmdStr:   "echo hello",
-			wantArgs: []string{"-Command", "echo hello"},
+			wantArgs: []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"},
 		},
 		{
 			name:     "PwshDetection",
 			shell:    "/usr/local/bin/pwsh",
 			cmdStr:   "echo hello",
-			wantArgs: []string{"-Command", "echo hello"},
+			wantArgs: []string{"-NoProfile", "-NonInteractive", "-Command", "echo hello"},
 		},
 	}
 

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1455,7 +1455,7 @@ func buildEnvs(ctx BuildContext, d *dag) ([]string, error) {
 		maps.Copy(ctx.envScope.buildEnv, vars)
 	}
 
-	var envs []string
+	envs := make([]string, 0, len(vars))
 	for k, v := range vars {
 		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -133,7 +133,7 @@ func ResolveEnvWithWarnings(ctx context.Context, dag *core.DAG, params any, opts
 }
 
 func canReuseCurrentEnv(dag *core.DAG, params any) bool {
-	return !hasRuntimeParams(params) && len(dag.Env) > 0 && (dag.EnvEvaluated || !hasDAGSource(dag))
+	return !hasRuntimeParams(params) && ((dag.EnvEvaluated && dag.Env != nil) || (len(dag.Env) > 0 && !hasDAGSource(dag)))
 }
 
 func shouldRecomputeEnv(dag *core.DAG, params any) bool {

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -263,6 +263,19 @@ steps:
 	require.Equal(t, "old-value", runtimeEnvSliceMap(result.Env)["TOKEN"])
 }
 
+func TestResolveEnvWithWarningsReusesEvaluatedEmptySourceEnv(t *testing.T) {
+	dag := &core.DAG{
+		Name:         "evaluated-empty-source-env",
+		Env:          []string{},
+		EnvEvaluated: true,
+		YamlData:     []byte("invalid: ["),
+	}
+
+	result, err := spec.ResolveEnvWithWarnings(context.Background(), dag, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	require.Empty(t, result.Env)
+}
+
 func TestResolveEnvWithWarningsKeepsProgrammaticEnvWithoutSource(t *testing.T) {
 	dag := &core.DAG{
 		Name: "programmatic-env",

--- a/internal/intg/queue/queue_test.go
+++ b/internal/intg/queue/queue_test.go
@@ -528,17 +528,16 @@ steps:
 }
 
 func TestSchedulerCatchupFromPersistedWatermark(t *testing.T) {
-	scheduledTime := stableCurrentMinute(t)
-
 	f := newFixture(t, `
 name: catchup-watermark-test
 schedule: "* * * * *"
-catchup_window: "2m"
+catchup_window: "10m"
 steps:
   - name: echo-step
     run: echo catchup-from-watermark
 `)
 
+	scheduledTime := time.Now().UTC().Truncate(time.Minute)
 	f.seedWatermark(scheduledTime.Add(-time.Minute), scheduledTime.Add(-time.Minute))
 	f.StartScheduler(45 * time.Second)
 	defer f.Stop()
@@ -579,15 +578,4 @@ func retryScanReferenceMidnight(now time.Time) time.Time {
 		return midnight.Add(-24 * time.Hour)
 	}
 	return midnight
-}
-
-func stableCurrentMinute(t *testing.T) time.Time {
-	t.Helper()
-
-	now := time.Now().UTC()
-	if now.Second() >= 50 {
-		return now.Truncate(time.Minute).Add(-time.Minute)
-	}
-
-	return now.Truncate(time.Minute)
 }

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -315,12 +315,15 @@ func (att *Attempt) compactLocked(ctx context.Context) (retErr error) {
 		}()
 	}
 
-	status, err := att.parseLocked(ctx)
+	status, shouldCompact, err := att.statusForCompactionLocked(ctx)
 	if err == io.EOF {
 		return nil // Empty file, nothing to compact
 	}
 	if err != nil {
 		return fmt.Errorf("%w: %s: %v", ErrCompactFailed, att.file, err)
+	}
+	if !shouldCompact {
+		return nil
 	}
 
 	// Create a temporary file in the same directory
@@ -374,6 +377,52 @@ func (att *Attempt) compactLocked(ctx context.Context) (retErr error) {
 
 	success = true
 	return nil
+}
+
+// statusForCompactionLocked reads the current file and reports whether a
+// replacement would change its compacted contents.
+func (att *Attempt) statusForCompactionLocked(ctx context.Context) (*exec.DAGRunStatus, bool, error) {
+	f, err := openStatusFileWithRetry(att.file)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: %w", ErrReadFailed, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var (
+		offset          int64
+		result          *exec.DAGRunStatus
+		validLineCount  int
+		invalidLineSeen bool
+	)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, fmt.Errorf("%w: %w", ErrReadFailed, err)
+		}
+		line, nextOffset, err := readLineFrom(f, offset)
+		if err == io.EOF {
+			if result == nil {
+				return nil, false, err
+			}
+			return result, invalidLineSeen || validLineCount > 1, nil
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("%w: %w", ErrReadFailed, err)
+		}
+
+		offset = nextOffset
+		if len(line) == 0 {
+			continue
+		}
+		status, err := exec.StatusFromJSON(string(line))
+		if err != nil {
+			invalidLineSeen = true
+			continue
+		}
+		result = status
+		validLineCount++
+	}
 }
 
 // safeRename safely replaces the target file with the source file,

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -222,6 +222,10 @@ func (att *Attempt) Write(ctx context.Context, status exec.DAGRunStatus) error {
 		}
 	}
 
+	if err := updateLatestAttemptPointer(ctx, att.file); err != nil {
+		logger.Warn(ctx, "Failed to update DAG-run latest attempt pointer", tag.Error(err))
+	}
+
 	nextEventType, _, err := eventstore.EmitPersistedStatusTransitionFromContext(
 		ctx,
 		att.lastEmittedEventType,

--- a/internal/persis/file/dagrun/attempt_external_test.go
+++ b/internal/persis/file/dagrun/attempt_external_test.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun_test
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttemptCloseKeepsSingleStatusFile(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir, dagrun.WithLatestStatusToday(false))
+	dag := &core.DAG{Name: "single-status-close"}
+	startedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	attempt, err := store.CreateAttempt(ctx, dag, startedAt, "run-1", exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, attempt.Open(ctx))
+	require.NoError(t, attempt.Write(ctx, exec.DAGRunStatus{
+		Name:      dag.Name,
+		DAGRunID:  "run-1",
+		AttemptID: attempt.ID(),
+		Status:    core.Queued,
+		QueuedAt:  exec.FormatTime(startedAt),
+	}))
+
+	statusFile := findOnlyStatusFile(t, baseDir)
+	beforeClose, err := os.Stat(statusFile)
+	require.NoError(t, err)
+
+	require.NoError(t, attempt.Close(ctx))
+
+	afterClose, err := os.Stat(statusFile)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(beforeClose, afterClose), "single-entry close should not replace status file")
+
+	status, err := attempt.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, core.Queued, status.Status)
+}
+
+func findOnlyStatusFile(t *testing.T, root string) string {
+	t.Helper()
+
+	var matches []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || d.Name() != dagrun.JSONLStatusFile {
+			return nil
+		}
+		matches = append(matches, path)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, matches, 1, fmt.Sprintf("status files under %s", root))
+	return matches[0]
+}

--- a/internal/persis/file/dagrun/export_test.go
+++ b/internal/persis/file/dagrun/export_test.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun
+
+import "context"
+
+// UpdateLatestAttemptPointerForTest exposes latest-attempt pointer updates to external tests.
+func UpdateLatestAttemptPointerForTest(ctx context.Context, statusFile string) error {
+	return updateLatestAttemptPointer(ctx, statusFile)
+}
+
+// LatestAttemptPointerPathForTest exposes latest-attempt pointer paths to external tests.
+func LatestAttemptPointerPathForTest(dagRunsDir string) string {
+	return latestAttemptPointerPath(dagRunsDir)
+}

--- a/internal/persis/file/dagrun/latest_attempt.go
+++ b/internal/persis/file/dagrun/latest_attempt.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dagucloud/dagu/internal/cmn/dirlock"
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/core/exec"
+)
+
+const latestAttemptFileName = ".dagrun.latest"
+
+var errLatestAttemptPointerInvalid = errors.New("latest attempt pointer invalid")
+
+type latestAttemptPointer struct {
+	StatusFile string `json:"statusFile"`
+}
+
+type attemptStatusFileInfo struct {
+	dagRunsDir         string
+	statusFile         string
+	relativeStatusFile string
+	runDir             string
+	runDirName         string
+	attemptDirName     string
+}
+
+func updateLatestAttemptPointer(_ context.Context, statusFile string) error {
+	candidate, ok := parseAttemptStatusFileInfo(statusFile)
+	if !ok {
+		return nil
+	}
+
+	lock := dirlock.New(candidate.dagRunsDir, nil)
+	if err := lock.TryLock(); err != nil {
+		if errors.Is(err, dirlock.ErrLockConflict) {
+			return nil
+		}
+		return err
+	}
+	unlock := true
+	defer func() {
+		if unlock {
+			_ = lock.Unlock()
+		}
+	}()
+
+	current, err := latestAttemptInfoFromPointer(candidate.dagRunsDir)
+	if err == nil && !attemptStatusFileInfoLess(current, candidate) {
+		if unlockErr := lock.Unlock(); unlockErr != nil {
+			return unlockErr
+		}
+		unlock = false
+		return nil
+	}
+
+	ptr := latestAttemptPointer{StatusFile: candidate.relativeStatusFile}
+	data, err := json.Marshal(ptr)
+	if err != nil {
+		return err
+	}
+	if err := fileutil.WriteFileAtomic(latestAttemptPointerPath(candidate.dagRunsDir), data, 0600); err != nil {
+		return err
+	}
+	if unlockErr := lock.Unlock(); unlockErr != nil {
+		return unlockErr
+	}
+	unlock = false
+	return nil
+}
+
+func (dr DataRoot) latestAttemptFromPointer(ctx context.Context, cache *fileutil.Cache[*exec.DAGRunStatus], cutoff exec.TimeInUTC) (*Attempt, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	info, err := latestAttemptInfoFromPointer(dr.dagRunsDir)
+	if err != nil {
+		return nil, err
+	}
+	run, err := newDAGRun(info.runDir, dr.artifactDir)
+	if err != nil {
+		return nil, err
+	}
+	if !cutoff.IsZero() && run.timestamp.Before(cutoff.Time) {
+		return nil, errLatestAttemptPointerInvalid
+	}
+	attempt, err := NewAttempt(info.statusFile, cache)
+	if err != nil {
+		return nil, err
+	}
+	if attempt.Hidden() || !attempt.Exists() {
+		return nil, errLatestAttemptPointerInvalid
+	}
+	return attempt, nil
+}
+
+func latestAttemptInfoFromPointer(dagRunsDir string) (attemptStatusFileInfo, error) {
+	data, err := os.ReadFile(latestAttemptPointerPath(dagRunsDir)) //nolint:gosec // path is derived from the DAG-run root.
+	if err != nil {
+		return attemptStatusFileInfo{}, err
+	}
+
+	var ptr latestAttemptPointer
+	if err := json.Unmarshal(data, &ptr); err != nil {
+		return attemptStatusFileInfo{}, fmt.Errorf("%w: %v", errLatestAttemptPointerInvalid, err)
+	}
+	if ptr.StatusFile == "" || !filepath.IsLocal(ptr.StatusFile) {
+		return attemptStatusFileInfo{}, errLatestAttemptPointerInvalid
+	}
+
+	statusFile := filepath.Join(dagRunsDir, filepath.Clean(ptr.StatusFile))
+	info, ok := parseAttemptStatusFileInfo(statusFile)
+	if !ok || info.dagRunsDir != filepath.Clean(dagRunsDir) {
+		return attemptStatusFileInfo{}, errLatestAttemptPointerInvalid
+	}
+	if _, err := os.Stat(info.statusFile); err != nil {
+		return attemptStatusFileInfo{}, err
+	}
+	return info, nil
+}
+
+func parseAttemptStatusFileInfo(statusFile string) (attemptStatusFileInfo, bool) {
+	cleanStatusFile := filepath.Clean(statusFile)
+	if filepath.Base(cleanStatusFile) != JSONLStatusFile {
+		return attemptStatusFileInfo{}, false
+	}
+
+	attemptDir := filepath.Dir(cleanStatusFile)
+	attemptDirName := filepath.Base(attemptDir)
+	if !reAttemptDir.MatchString(attemptDirName) {
+		return attemptStatusFileInfo{}, false
+	}
+
+	runDir := filepath.Dir(attemptDir)
+	runDirName := filepath.Base(runDir)
+	if !reDAGRunDir.MatchString(runDirName) {
+		return attemptStatusFileInfo{}, false
+	}
+
+	dayDir := filepath.Dir(runDir)
+	monthDir := filepath.Dir(dayDir)
+	yearDir := filepath.Dir(monthDir)
+	if !reDay.MatchString(filepath.Base(dayDir)) ||
+		!reMonth.MatchString(filepath.Base(monthDir)) ||
+		!reYear.MatchString(filepath.Base(yearDir)) {
+		return attemptStatusFileInfo{}, false
+	}
+
+	dagRunsDir := filepath.Dir(yearDir)
+	relativeStatusFile, err := filepath.Rel(dagRunsDir, cleanStatusFile)
+	if err != nil || !filepath.IsLocal(relativeStatusFile) {
+		return attemptStatusFileInfo{}, false
+	}
+
+	return attemptStatusFileInfo{
+		dagRunsDir:         filepath.Clean(dagRunsDir),
+		statusFile:         cleanStatusFile,
+		relativeStatusFile: filepath.Clean(relativeStatusFile),
+		runDir:             runDir,
+		runDirName:         runDirName,
+		attemptDirName:     attemptDirName,
+	}, true
+}
+
+func attemptStatusFileInfoLess(a, b attemptStatusFileInfo) bool {
+	if a.runDirName != b.runDirName {
+		return a.runDirName < b.runDirName
+	}
+	return a.attemptDirName < b.attemptDirName
+}
+
+func latestAttemptPointerPath(dagRunsDir string) string {
+	return filepath.Join(dagRunsDir, latestAttemptFileName)
+}

--- a/internal/persis/file/dagrun/latest_attempt.go
+++ b/internal/persis/file/dagrun/latest_attempt.go
@@ -33,7 +33,7 @@ type attemptStatusFileInfo struct {
 	attemptDirName     string
 }
 
-func updateLatestAttemptPointer(_ context.Context, statusFile string) error {
+func updateLatestAttemptPointer(ctx context.Context, statusFile string) error {
 	candidate, ok := parseAttemptStatusFileInfo(statusFile)
 	if !ok {
 		return nil
@@ -53,6 +53,10 @@ func updateLatestAttemptPointer(_ context.Context, statusFile string) error {
 		}
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	current, err := latestAttemptInfoFromPointer(candidate.dagRunsDir)
 	if err == nil && !attemptStatusFileInfoLess(current, candidate) {
 		if unlockErr := lock.Unlock(); unlockErr != nil {
@@ -65,6 +69,9 @@ func updateLatestAttemptPointer(_ context.Context, statusFile string) error {
 	ptr := latestAttemptPointer{StatusFile: candidate.relativeStatusFile}
 	data, err := json.Marshal(ptr)
 	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := fileutil.WriteFileAtomic(latestAttemptPointerPath(candidate.dagRunsDir), data, 0600); err != nil {

--- a/internal/persis/file/dagrun/latest_attempt_external_test.go
+++ b/internal/persis/file/dagrun/latest_attempt_external_test.go
@@ -46,6 +46,29 @@ func TestStoreLatestAttemptUsesPersistedLatestPointer(t *testing.T) {
 	require.Equal(t, core.Succeeded, status.Status)
 }
 
+func TestUpdateLatestAttemptPointerHonorsCanceledContext(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	dagName := "latest-pointer-canceled"
+	startedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	statusFile := createStatuslessRunDir(t, baseDir, dagName, startedAt, "run-1")
+	require.NoError(t, os.WriteFile(statusFile, []byte("{}\n"), 0600))
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err := dagrun.UpdateLatestAttemptPointerForTest(canceledCtx, statusFile)
+	require.ErrorIs(t, err, context.Canceled)
+
+	dagRunsDir := filepath.Join(baseDir, dagName, "dag-runs")
+	pointerFile := dagrun.LatestAttemptPointerPathForTest(dagRunsDir)
+	_, err = os.Stat(pointerFile)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	require.NoError(t, dagrun.UpdateLatestAttemptPointerForTest(ctx, statusFile))
+	_, err = os.Stat(pointerFile)
+	require.NoError(t, err)
+}
+
 func BenchmarkStoreLatestAttemptWithPersistedLatestPointer(b *testing.B) {
 	ctx := context.Background()
 	baseDir := b.TempDir()
@@ -82,7 +105,7 @@ func BenchmarkStoreLatestAttemptWithPersistedLatestPointer(b *testing.B) {
 	}
 }
 
-func createStatuslessRunDir(t testing.TB, baseDir, dagName string, ts time.Time, runID string) {
+func createStatuslessRunDir(t testing.TB, baseDir, dagName string, ts time.Time, runID string) string {
 	t.Helper()
 
 	runDir := filepath.Join(
@@ -96,4 +119,5 @@ func createStatuslessRunDir(t testing.TB, baseDir, dagName string, ts time.Time,
 		fmt.Sprintf("attempt_%s_%06d", ts.UTC().Format("20060102_150405_000Z"), 1),
 	)
 	require.NoError(t, os.MkdirAll(runDir, 0750))
+	return filepath.Join(runDir, dagrun.JSONLStatusFile)
 }

--- a/internal/persis/file/dagrun/latest_attempt_external_test.go
+++ b/internal/persis/file/dagrun/latest_attempt_external_test.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreLatestAttemptUsesPersistedLatestPointer(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir, dagrun.WithLatestStatusToday(false))
+	dag := &core.DAG{Name: "latest-pointer"}
+	startedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	attempt, err := store.CreateAttempt(ctx, dag, startedAt, "run-1", exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, attempt.Open(ctx))
+	require.NoError(t, attempt.Write(ctx, exec.DAGRunStatus{
+		Name:      dag.Name,
+		DAGRunID:  "run-1",
+		AttemptID: attempt.ID(),
+		Status:    core.Succeeded,
+		StartedAt: startedAt.Format(time.RFC3339),
+	}))
+	require.NoError(t, attempt.Close(ctx))
+
+	createStatuslessRunDir(t, baseDir, dag.Name, startedAt.Add(time.Hour), "run-2")
+
+	latest, err := store.LatestAttempt(ctx, dag.Name)
+	require.NoError(t, err)
+	status, err := latest.ReadStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "run-1", status.DAGRunID)
+	require.Equal(t, core.Succeeded, status.Status)
+}
+
+func BenchmarkStoreLatestAttemptWithPersistedLatestPointer(b *testing.B) {
+	ctx := context.Background()
+	baseDir := b.TempDir()
+	store := dagrun.New(baseDir, dagrun.WithLatestStatusToday(false))
+	dag := &core.DAG{Name: "latest-pointer-bench"}
+	startedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	attempt, err := store.CreateAttempt(ctx, dag, startedAt, "run-1", exec.NewDAGRunAttemptOptions{})
+	require.NoError(b, err)
+	require.NoError(b, attempt.Open(ctx))
+	require.NoError(b, attempt.Write(ctx, exec.DAGRunStatus{
+		Name:      dag.Name,
+		DAGRunID:  "run-1",
+		AttemptID: attempt.ID(),
+		Status:    core.Succeeded,
+		StartedAt: startedAt.Format(time.RFC3339),
+	}))
+	require.NoError(b, attempt.Close(ctx))
+
+	for i := range 4000 {
+		createStatuslessRunDir(b, baseDir, dag.Name, startedAt.Add(time.Duration(i+1)*time.Second), fmt.Sprintf("run-%d", i+2))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		latest, err := store.LatestAttempt(ctx, dag.Name)
+		require.NoError(b, err)
+		status, err := latest.ReadStatus(ctx)
+		require.NoError(b, err)
+		if status.DAGRunID != "run-1" {
+			b.Fatalf("unexpected dag-run ID %q", status.DAGRunID)
+		}
+	}
+}
+
+func createStatuslessRunDir(t testing.TB, baseDir, dagName string, ts time.Time, runID string) {
+	t.Helper()
+
+	runDir := filepath.Join(
+		baseDir,
+		dagName,
+		"dag-runs",
+		ts.Format("2006"),
+		ts.Format("01"),
+		ts.Format("02"),
+		fmt.Sprintf("dag-run_%s_%s", ts.UTC().Format("20060102_150405Z"), runID),
+		fmt.Sprintf("attempt_%s_%06d", ts.UTC().Format("20060102_150405_000Z"), 1),
+	)
+	require.NoError(t, os.MkdirAll(runDir, 0750))
+}

--- a/internal/persis/file/dagrun/store.go
+++ b/internal/persis/file/dagrun/store.go
@@ -451,13 +451,27 @@ func (store *Store) LatestAttempt(ctx context.Context, dagName string) (exec.DAG
 		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, store.location)
 		startOfDayInUTC := exec.NewUTC(startOfDay)
 
+		if attempt, err := root.latestAttemptFromPointer(ctx, store.cache, startOfDayInUTC); err == nil {
+			return attempt, nil
+		}
+
 		// Get the latest execution data after the start of the day.
 		exec, err := root.LatestAfter(ctx, startOfDayInUTC)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get latest after: %w", err)
 		}
 
-		return exec.LatestAttempt(ctx, store.cache)
+		attempt, err := exec.LatestAttempt(ctx, store.cache)
+		if err == nil {
+			if markerErr := updateLatestAttemptPointer(ctx, attempt.file); markerErr != nil {
+				logger.Debug(ctx, "Failed to refresh DAG-run latest attempt pointer", tag.Error(markerErr))
+			}
+		}
+		return attempt, err
+	}
+
+	if attempt, err := root.latestAttemptFromPointer(ctx, store.cache, exec.TimeInUTC{}); err == nil {
+		return attempt, nil
 	}
 
 	// Get the latest execution data.
@@ -465,7 +479,13 @@ func (store *Store) LatestAttempt(ctx context.Context, dagName string) (exec.DAG
 	if len(latest) == 0 {
 		return nil, exec.ErrNoStatusData
 	}
-	return latest[0].LatestAttempt(ctx, store.cache)
+	attempt, err := latest[0].LatestAttempt(ctx, store.cache)
+	if err == nil {
+		if markerErr := updateLatestAttemptPointer(ctx, attempt.file); markerErr != nil {
+			logger.Debug(ctx, "Failed to refresh DAG-run latest attempt pointer", tag.Error(markerErr))
+		}
+	}
+	return attempt, err
 }
 
 // FindAttempt finds a history record by dag-run ID.

--- a/internal/service/chatbridge/monitor_external_test.go
+++ b/internal/service/chatbridge/monitor_external_test.go
@@ -22,10 +22,11 @@ import (
 )
 
 type monitorEventStore struct {
-	mu        sync.Mutex
-	events    []*eventstore.Event
-	headCalls int
-	readCalls int
+	mu             sync.Mutex
+	events         []*eventstore.Event
+	headCalls      int
+	readCalls      int
+	lastHeadOffset int64
 }
 
 var _ eventstore.Store = (*monitorEventStore)(nil)
@@ -51,6 +52,7 @@ func (s *monitorEventStore) NotificationHeadCursor(context.Context) (eventstore.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.headCalls++
+	s.lastHeadOffset = int64(len(s.events))
 	return s.currentCursorLocked(), nil
 }
 
@@ -76,6 +78,12 @@ func (s *monitorEventStore) stats() (int, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.headCalls, s.readCalls
+}
+
+func (s *monitorEventStore) lastHead() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastHeadOffset
 }
 
 type mutableNotificationTransport struct {
@@ -144,8 +152,8 @@ func TestNotificationMonitorWithoutDestinationsAdvancesCursorWithoutReadingEvent
 	require.NoError(t, store.Emit(context.Background(), newMonitorDAGRunEvent("old-run")))
 
 	require.Eventually(t, func() bool {
-		headCalls, readCalls := store.stats()
-		return headCalls > 1 && readCalls == 0
+		_, readCalls := store.stats()
+		return store.lastHead() >= 1 && readCalls == 0
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -179,8 +187,8 @@ func TestNotificationMonitorDeliversOnlyFutureEventsAfterDestinationIsAdded(t *t
 
 	require.NoError(t, store.Emit(context.Background(), newMonitorDAGRunEvent("old-run")))
 	require.Eventually(t, func() bool {
-		headCalls, readCalls := store.stats()
-		return headCalls > 1 && readCalls == 0
+		_, readCalls := store.stats()
+		return store.lastHead() >= 1 && readCalls == 0
 	}, time.Second, 10*time.Millisecond)
 
 	transport.setDestinations([]string{"dest-1"})


### PR DESCRIPTION
## Summary
- add a validated latest-attempt pointer for file-backed DAG run history so scheduler status checks avoid rescanning growing run directories
- reuse evaluated empty DAG env data during subprocess dispatch to avoid unnecessary YAML reloads
- add regression coverage and a benchmark for latest-attempt lookup with a large run directory

## Root cause
The scheduler asks for latest DAG status while planning scheduled runs. On the file backend, latest-attempt lookup could fall back to walking and sorting the current day run directory, so frequent schedules accumulated file traversal, I/O, and cache pressure as data/dag-runs grew.

## Validation
- core, file persistence, runtime, and scheduler Go tests passed locally
- latest-attempt benchmark passed locally
- binary build passed locally

Fixes #546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the scheduler’s latest-status lookup on the file backend by persisting a validated pointer to the latest attempt, avoiding rescans of large run directories. Also stabilized shell command substitution and scheduler timing tests, skipped no-op status rewrites, reused evaluated empty DAG envs, and hardened notification monitor assertions. Fixes #546.

- **Bug Fixes**
  - Persist and validate a `.dagrun.latest` pointer in `dagrun`; update it on attempt writes; respect context cancellation.
  - Store reads the pointer first; falls back to scan and refreshes the pointer; honors the “today” cutoff.
  - Stabilized eval substitution: parse configured shell args, preserve resolved shell paths (incl. spaces), add PowerShell `-NoProfile`/`-NonInteractive`, avoid duplicate `-Command`.
  - Reuse evaluated empty source envs in `ResolveEnvWithWarnings`; minor env slice preallocation.
  - Skip no-op status compaction to avoid replacing unchanged status files.
  - Stabilize chatbridge notification monitor tests by asserting on head cursor offset to avoid flaky reads.
  - Stabilize scheduler catchup watermark integration timing to avoid minute-boundary flakiness.

<sup>Written for commit 10c925460734e5d555973525be4a254c6ace469d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent latest-attempt pointer for DAG runs to speed and stabilize latest-run resolution.

* **Bug Fixes**
  * Smarter environment reuse to avoid re-evaluating already-evaluated environments.
  * More robust DAG-run status writes and compaction with safer pointer updates and fallbacks.

* **Tests**
  * Expanded tests and benchmarks covering latest-attempt pointer behavior, environment reuse, shell invocation handling, and run-status persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->