### PR TITLE
fix: preserve child subdag state on parent retry

### DIFF
--- a/internal/intg/subdag_test.go
+++ b/internal/intg/subdag_test.go
@@ -711,6 +711,95 @@ steps:
 		require.Equal(t, dagRunID, sub2Status.Root.ID)
 	})
 
+	t.Run("ParentRetryDoesNotRerunSucceededSubDAGSteps", func(t *testing.T) {
+		th := test.SetupCommand(t)
+
+		runDir := t.TempDir()
+		successCounter := filepath.Join(runDir, "already-succeeded-count")
+		failOnceMarker := filepath.Join(runDir, "fail-once-marker")
+
+		incrementSuccessCounter := test.ForOS(
+			fmt.Sprintf(`
+count=0
+if [ -f %s ]; then
+  count=$(cat %s)
+fi
+count=$((count + 1))
+printf '%%s' "$count" > %s
+`, test.PosixQuote(test.ShellPath(successCounter)), test.PosixQuote(test.ShellPath(successCounter)), test.PosixQuote(test.ShellPath(successCounter))),
+			fmt.Sprintf(`
+$count = 0
+if (Test-Path %s) {
+  $raw = (Get-Content -Raw -Path %s).Trim()
+  if ($raw) { $count = [int]$raw }
+}
+$count = $count + 1
+Set-Content -Path %s -Value $count -NoNewline
+`, test.PowerShellQuote(successCounter), test.PowerShellQuote(successCounter), test.PowerShellQuote(successCounter)),
+		)
+		failOnce := test.ForOS(
+			fmt.Sprintf(`
+if [ ! -f %s ]; then
+  touch %s
+  exit 1
+fi
+echo ok
+`, test.PosixQuote(test.ShellPath(failOnceMarker)), test.PosixQuote(test.ShellPath(failOnceMarker))),
+			fmt.Sprintf(`
+if (-not (Test-Path %s)) {
+  New-Item -ItemType File %s | Out-Null
+  exit 1
+}
+"ok"
+`, test.PowerShellQuote(failOnceMarker), test.PowerShellQuote(failOnceMarker)),
+		)
+
+		th.CreateDAGFile(t, "parent_retry_child_state.yaml", `
+steps:
+  - name: call-child
+    action: dag.run
+    with:
+      dag: child_retry_state
+`)
+
+		th.CreateDAGFile(t, "child_retry_state.yaml", fmt.Sprintf(`
+steps:
+  - name: already-succeeded
+    run: |
+%s
+
+  - name: fail-once
+    run: |
+%s
+    depends: already-succeeded
+`, indentCommandBlock(incrementSuccessCounter, 6), indentCommandBlock(failOnce, 6)))
+
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		err := th.RunCommandWithError(t, cmd.Start(), test.CmdTest{
+			Args: []string{"start", "--run-id", dagRunID, "parent_retry_child_state"},
+		})
+		require.Error(t, err)
+
+		counter, err := os.ReadFile(successCounter)
+		require.NoError(t, err)
+		require.Equal(t, "1", strings.TrimSpace(string(counter)))
+
+		th.RunCommand(t, cmd.Retry(), test.CmdTest{
+			Args: []string{"retry", "--run-id", dagRunID, "parent_retry_child_state"},
+		})
+
+		counter, err = os.ReadFile(successCounter)
+		require.NoError(t, err)
+		require.Equal(t, "1", strings.TrimSpace(string(counter)), "parent retry should not rerun child steps that already succeeded")
+
+		ref := exec.NewDAGRunRef("parent_retry_child_state", dagRunID)
+		parentAttempt, err := th.DAGRunStore.FindAttempt(context.Background(), ref)
+		require.NoError(t, err)
+		parentStatus, err := parentAttempt.ReadStatus(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, core.Succeeded, parentStatus.Status)
+	})
+
 	t.Run("RetryPolicyWithOutputCapture", func(t *testing.T) {
 		th := test.SetupCommand(t)
 

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -179,15 +179,26 @@ func (r *Local) Run(ctx context.Context, req executor.SubWorkflowRequest) (*exec
 		return nil, err
 	}
 
+	retryTarget, err := r.existingChildRetryTarget(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
 	dag, cleanup, err := loadInProcessDAG(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
 
-	child, err := r.newAgent(ctx, req, dag, rtagent.Options{
+	opts := rtagent.Options{
 		TriggerType: core.TriggerTypeSubDAG,
-	})
+	}
+	if retryTarget != nil {
+		opts.RetryTarget = retryTarget
+		opts.TriggerType = inProcessRetryTriggerType(retryTarget)
+	}
+
+	child, err := r.newAgent(ctx, req, dag, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -231,6 +242,31 @@ func (r *Local) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest)
 		return nil, err
 	}
 	return r.runAgent(ctx, req.RunID, child)
+}
+
+func (r *Local) existingChildRetryTarget(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+) (*exec.DAGRunStatus, error) {
+	runStateStore := r.runStateStoreFromContext(ctx)
+	if runStateStore == nil {
+		return nil, nil
+	}
+	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find child workflow attempt: %w", err)
+	}
+	retryTarget, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read child workflow status: %w", err)
+	}
+	if retryTarget == nil {
+		return nil, fmt.Errorf("failed to read child workflow status: status data is nil")
+	}
+	return retryTarget, nil
 }
 
 // Cancel requests cancellation for a running in-process child workflow.

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -136,6 +136,18 @@ func (r *Runner) Run(ctx context.Context, req executor.SubWorkflowRequest) (*exe
 		tag.DAG(req.DAG.Name),
 	)
 
+	if previousStatus, found, err := r.existingStatus(ctx, req); err != nil {
+		return nil, fmt.Errorf("failed to load child workflow status before start: %w", err)
+	} else if found {
+		if err := r.dispatchRetryWithStatus(ctx, req, "", previousStatus); err != nil {
+			logger.Error(dispatchCtx, "Distributed child workflow retry dispatch failed", tag.Error(err))
+			return nil, fmt.Errorf("distributed retry failed: %w", err)
+		}
+
+		logger.Info(dispatchCtx, "Distributed child workflow retry dispatched; awaiting completion")
+		return r.waitCompletion(ctx, req)
+	}
+
 	if err := r.dispatchStart(ctx, req); err != nil {
 		logger.Error(dispatchCtx, "Distributed child workflow dispatch failed", tag.Error(err))
 		return nil, fmt.Errorf("distributed execution failed: %w", err)
@@ -237,8 +249,16 @@ func (r *Runner) dispatchRetry(ctx context.Context, req executor.SubWorkflowRetr
 	if err != nil {
 		return fmt.Errorf("failed to load child workflow status for retry: %w", err)
 	}
+	return r.dispatchRetryWithStatus(ctx, req.SubWorkflowRequest, req.StepName, previousStatus)
+}
 
-	task, err := r.buildRetryTask(ctx, req, previousStatus)
+func (r *Runner) dispatchRetryWithStatus(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+	stepName string,
+	previousStatus *exec.DAGRunStatus,
+) error {
+	task, err := r.buildRetryTask(ctx, req, stepName, previousStatus)
 	if err != nil {
 		return fmt.Errorf("failed to build retry coordinator task: %w", err)
 	}
@@ -246,7 +266,7 @@ func (r *Runner) dispatchRetry(ctx context.Context, req executor.SubWorkflowRetr
 	taskCtx := logger.WithValues(ctx,
 		tag.RunID(task.DAGRunID),
 		tag.Target(task.Target),
-		tag.Step(req.StepName),
+		tag.Step(stepName),
 	)
 	logger.Info(taskCtx, "Dispatching child workflow retry task",
 		slog.Any("worker-selector", task.WorkerSelector),
@@ -274,15 +294,15 @@ func (r *Runner) buildStartTask(ctx context.Context, req executor.SubWorkflowReq
 
 func (r *Runner) buildRetryTask(
 	ctx context.Context,
-	req executor.SubWorkflowRetryRequest,
+	req executor.SubWorkflowRequest,
+	stepName string,
 	previousStatus *exec.DAGRunStatus,
 ) (*exec.DispatchTask, error) {
-	opts, err := r.taskOptions(
-		ctx,
-		req.SubWorkflowRequest,
-		executor.WithStep(req.StepName),
-		executor.WithPreviousStatus(previousStatus),
-	)
+	extra := []executor.TaskOption{executor.WithPreviousStatus(previousStatus)}
+	if stepName != "" {
+		extra = append(extra, executor.WithStep(stepName))
+	}
+	opts, err := r.taskOptions(ctx, req, extra...)
 	if err != nil {
 		return nil, err
 	}
@@ -293,6 +313,26 @@ func (r *Runner) buildRetryTask(
 		req.RunID,
 		opts...,
 	), nil
+}
+
+func (r *Runner) existingStatus(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+) (*exec.DAGRunStatus, bool, error) {
+	result, err := r.dispatcher.GetDAGRunStatus(ctx, req.DAG.Name, req.RunID, &req.RootDAGRun)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get DAG run status from coordinator: %w", err)
+	}
+	if result == nil {
+		return nil, false, fmt.Errorf("no response from coordinator")
+	}
+	if !result.Found {
+		return nil, false, nil
+	}
+	if result.Status == nil {
+		return nil, false, fmt.Errorf("coordinator returned empty DAG run status")
+	}
+	return result.Status, true, nil
 }
 
 func (r *Runner) taskOptions(

--- a/internal/subflow/runner_test.go
+++ b/internal/subflow/runner_test.go
@@ -128,6 +128,7 @@ func TestRunnerRunDispatchesWorkflowRequest(t *testing.T) {
 
 	dispatcher := &mockDispatcher{
 		statuses: []*exec.DAGRunStatusResult{
+			{Found: false},
 			{
 				Found: true,
 				Status: &exec.DAGRunStatus{
@@ -186,6 +187,61 @@ func TestRunnerRunDispatchesWorkflowRequest(t *testing.T) {
 	assert.Equal(t, core.Succeeded, result.Status)
 	assert.Equal(t, "ok", result.Outputs["RESULT"])
 	assert.Equal(t, true, result.OutputValues["typed"])
+}
+
+func TestRunnerRunDispatchesRetryWhenChildRunExists(t *testing.T) {
+	t.Parallel()
+
+	previous := &exec.DAGRunStatus{
+		Name:      "child",
+		DAGRunID:  "child-1",
+		ProcGroup: "queue-a",
+		Status:    core.Failed,
+		Nodes: []*exec.Node{
+			{
+				Step:   core.Step{Name: "already-done"},
+				Status: core.NodeSucceeded,
+			},
+			{
+				Step:   core.Step{Name: "flaky"},
+				Status: core.NodeFailed,
+			},
+		},
+	}
+	dispatcher := &mockDispatcher{
+		statuses: []*exec.DAGRunStatusResult{
+			{Found: true, Status: previous},
+			{
+				Found: true,
+				Status: &exec.DAGRunStatus{
+					Name:     "child",
+					DAGRunID: "child-1",
+					Status:   core.Succeeded,
+				},
+			},
+		},
+	}
+	runner := newFastRunner(dispatcher)
+
+	result, err := runner.Run(context.Background(), runtimeexec.SubWorkflowRequest{
+		DAG: &core.DAG{
+			Name:     "child",
+			YamlData: []byte("name: child"),
+		},
+		RootDAGRun:   exec.NewDAGRunRef("parent", "root-1"),
+		ParentDAGRun: exec.NewDAGRunRef("parent", "parent-1"),
+		RunID:        "child-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, dispatcher.dispatches, 1)
+	task := dispatcher.dispatches[0]
+	assert.Equal(t, exec.DispatchOperationRetry, task.Operation)
+	assert.Empty(t, task.Step)
+	assert.Equal(t, previous, task.PreviousStatus)
+	assert.Equal(t, "queue-a", task.QueueName)
+	assert.Equal(t, core.Succeeded, result.Status)
 }
 
 func TestRunnerRetryDispatchesPreviousStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve deterministic child sub-DAG state when a parent retry re-enters an existing child run
- make distributed child execution dispatch a retry task with previous status when the child run already exists
- add regression coverage for parent retry not rerunning succeeded child steps

## Root Cause
PR #2248 moved local sub-DAG execution in process, but the parent retry path only reused the deterministic child run ID. It did not load the existing child status as the child retry target, so the child planner treated the retry as a fresh run and re-executed already-succeeded child steps. The distributed runner had the same start-vs-retry gap when a child status already existed.

## Testing
- git diff --check
- go test ./internal/subflow -count=1
- go test ./internal/service/worker ./internal/service/coordinator -count=1
- go test ./internal/intg -run TestExternalSubDAG -count=1
- go test ./internal/intg/distr -run TestSubDAG -count=1
- go test ./internal/cmd ./internal/runtime ./internal/runtime/agent ./internal/runtime/executor -count=1

Closes #2279

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves child sub-DAG state on parent retry so already-succeeded child steps are not re-run. Applies to both in-process and distributed subflow execution.

- **Bug Fixes**
  - Local sub-DAG: when a child run already exists, load its previous status and set it as the retry target (with the correct trigger type).
  - Distributed sub-DAG: check the coordinator for an existing child status; if found, dispatch a retry task with that status instead of a fresh start.
  - Added regression tests to ensure parent retry does not rerun succeeded child steps and to validate retry dispatch behavior.

<sup>Written for commit fb14fe02c04ead8edadb88190dc979e4d4d7c197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Parent DAG retries now correctly skip re-execution of previously succeeded child DAG steps, preventing duplicate work
  * Improved handling of existing child workflow runs to ensure proper retry dispatch
  * Enhanced retry efficiency for complex multi-level workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->