### PR TITLE
fix: add durable dispatch admission

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -344,7 +344,10 @@ func NewContext(cmd *cobra.Command, flags []commandLineFlag) (*Context, error) {
 	qs := store.NewQueueStore(file.NewCollection(cfg.Paths.QueueDir))
 	stateStore := store.NewDAGStateStore(file.NewCollection(cfg.Paths.DAGStateDir))
 	sm := file.NewServiceRegistry(cfg)
-	dispatchTaskStore := store.NewDispatchTaskStore(file.NewCollection(distributedDir))
+	dispatchTaskStore := store.NewDispatchTaskStore(
+		file.NewCollection(distributedDir),
+		store.WithDispatchAdmissionLiveness(dagRunLeaseStore, activeDistributedRunStore),
+	)
 	workerHeartbeatStore := store.NewWorkerHeartbeatStore(file.NewCollection(filepath.Join(distributedDir, "workers")))
 	dagStore, err := cmdprocess.NewDAGStore(cfg, cmdprocess.DAGStoreConfig{})
 	if err != nil {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -615,7 +615,7 @@ func dispatchToCoordinatorAndWait(ctx *Context, d *core.DAG, dagRunID string, sc
 		taskOpts...,
 	)
 
-	if err := coordinatorCli.Dispatch(signalAwareCtx, task); err != nil {
+	if err := coordinatorCli.Dispatch(signalAwareCtx, exec.DispatchRequest{Task: task}); err != nil {
 		return fmt.Errorf("failed to dispatch task: %w", err)
 	}
 

--- a/internal/core/exec/dispatch.go
+++ b/internal/core/exec/dispatch.go
@@ -78,9 +78,15 @@ type DAGRunStatusResult struct {
 	Status *DAGRunStatus
 }
 
+// DispatchRequest describes a distributed dispatch call.
+type DispatchRequest struct {
+	Task                      *DispatchTask
+	AdmissionReservationToken string
+}
+
 // Dispatcher defines distributed DAG run operations.
 type Dispatcher interface {
-	Dispatch(ctx context.Context, task *DispatchTask) error
+	Dispatch(ctx context.Context, req DispatchRequest) error
 	Cleanup(ctx context.Context) error
 	GetDAGRunStatus(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) (*DAGRunStatusResult, error)
 	RequestCancel(ctx context.Context, dagName, dagRunID string, rootRef *DAGRunRef) error

--- a/internal/core/exec/distributed.go
+++ b/internal/core/exec/distributed.go
@@ -93,7 +93,6 @@ type DispatchAdmissionDecision struct {
 	Reserved         bool
 	Reason           DispatchAdmissionRejectReason
 	ReservationToken string
-	PendingRecordID  string
 }
 
 // DispatchAdmissionBindRequest describes a coordinator bind for a reservation.

--- a/internal/core/exec/distributed.go
+++ b/internal/core/exec/distributed.go
@@ -13,10 +13,13 @@ import (
 )
 
 var (
-	ErrDispatchTaskNotFound    = errors.New("dispatch task claim not found")
-	ErrDAGRunLeaseNotFound     = errors.New("dag-run lease not found")
-	ErrActiveRunNotFound       = errors.New("active distributed run not found")
-	ErrWorkerHeartbeatNotFound = errors.New("worker heartbeat not found")
+	ErrDispatchTaskNotFound                   = errors.New("dispatch task claim not found")
+	ErrDispatchAdmissionNotFound              = errors.New("dispatch admission not found")
+	ErrDispatchAdmissionConflict              = errors.New("dispatch admission conflict")
+	ErrDispatchAdmissionLivenessNotConfigured = errors.New("dispatch admission liveness not configured")
+	ErrDAGRunLeaseNotFound                    = errors.New("dag-run lease not found")
+	ErrActiveRunNotFound                      = errors.New("active distributed run not found")
+	ErrWorkerHeartbeatNotFound                = errors.New("worker heartbeat not found")
 )
 
 // CoordinatorEndpoint identifies a coordinator instance that owns a
@@ -64,6 +67,48 @@ type ClaimedDispatchTask struct {
 	WorkerID   string
 	PollerID   string
 	Owner      CoordinatorEndpoint
+}
+
+// DispatchAdmissionRequest describes a queue admission reservation request.
+type DispatchAdmissionRequest struct {
+	QueueName             string
+	MaxConcurrency        int
+	NonAdmissionOccupancy int
+	AttemptKey            string
+	AttemptID             string
+	DAGRun                DAGRunRef
+	StaleThreshold        time.Duration
+}
+
+// DispatchAdmissionRejectReason identifies why a reservation was not granted.
+type DispatchAdmissionRejectReason string
+
+const (
+	DispatchAdmissionRejectedDuplicate  DispatchAdmissionRejectReason = "duplicate"
+	DispatchAdmissionRejectedNoCapacity DispatchAdmissionRejectReason = "no_capacity"
+)
+
+// DispatchAdmissionDecision is the durable queue admission result.
+type DispatchAdmissionDecision struct {
+	Reserved         bool
+	Reason           DispatchAdmissionRejectReason
+	ReservationToken string
+	PendingRecordID  string
+}
+
+// DispatchAdmissionBindRequest describes a coordinator bind for a reservation.
+type DispatchAdmissionBindRequest struct {
+	ReservationToken string
+	Task             *DispatchTask
+}
+
+// DispatchAdmissionStore reserves queue capacity and binds reservations to tasks.
+type DispatchAdmissionStore interface {
+	ReserveAdmission(ctx context.Context, req DispatchAdmissionRequest) (*DispatchAdmissionDecision, error)
+	BindAdmission(ctx context.Context, req DispatchAdmissionBindRequest) error
+	ReleaseAdmissionToken(ctx context.Context, reservationToken string) error
+	FinalizeAdmissionAttempt(ctx context.Context, attemptKey string) error
+	CleanupAdmissions(ctx context.Context, staleThreshold time.Duration) error
 }
 
 // DispatchTaskStore manages the shared distributed dispatch queue.

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -544,7 +544,7 @@ func (e *Engine) runDistributed(ctx context.Context, dag *core.DAG, runID string
 	if len(dag.Params) > 0 {
 		task.Params = strings.Join(dag.Params, " ")
 	}
-	if err := client.Dispatch(ctx, task); err != nil {
+	if err := client.Dispatch(ctx, coreexec.DispatchRequest{Task: task}); err != nil {
 		_ = client.Cleanup(ctx)
 		return nil, fmt.Errorf("dispatch DAG run: %w", err)
 	}

--- a/internal/persis/store/distributed_admission.go
+++ b/internal/persis/store/distributed_admission.go
@@ -126,17 +126,23 @@ func (s *DispatchTaskStore) ReserveAdmission(
 	for {
 		slots, err := s.listDispatchAdmissionSlots(ctx, req.QueueName)
 		if err != nil {
-			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
+				return nil, errors.Join(err, cleanupErr)
+			}
 			return nil, err
 		}
 		legacyOccupancy, err := s.dispatchLegacyAdmissionOccupancy(ctx, req.QueueName, staleThreshold)
 		if err != nil {
-			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
+				return nil, errors.Join(err, cleanupErr)
+			}
 			return nil, err
 		}
 		occupied = req.NonAdmissionOccupancy + len(slots) + legacyOccupancy
 		if occupied >= req.MaxConcurrency {
-			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			if err := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); err != nil {
+				return nil, err
+			}
 			return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedNoCapacity}, nil
 		}
 
@@ -157,14 +163,18 @@ func (s *DispatchTaskStore) ReserveAdmission(
 			}
 			slotRec, err := newDispatchAdmissionRecord(slotID, slotPayload, now, now)
 			if err != nil {
-				_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+				if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				return nil, err
 			}
 			if err := s.col.Create(ctx, slotRec); err != nil {
 				if errors.Is(err, persis.ErrConflict) {
 					continue
 				}
-				_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+				if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				return nil, err
 			}
 
@@ -176,13 +186,17 @@ func (s *DispatchTaskStore) ReserveAdmission(
 				CreatedAt:        now.UnixMilli(),
 			}, now, now)
 			if err != nil {
-				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
-				_ = s.col.Delete(context.WithoutCancel(ctx), slotID)
+				attemptPayload.SlotID = slotID
+				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				return nil, err
 			}
 			if err := s.col.Create(ctx, tokenRec); err != nil {
-				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
-				_ = s.col.Delete(context.WithoutCancel(ctx), slotID)
+				attemptPayload.SlotID = slotID
+				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				return nil, err
 			}
 
@@ -190,11 +204,16 @@ func (s *DispatchTaskStore) ReserveAdmission(
 			attemptPayload.UpdatedAt = time.Now().UTC().UnixMilli()
 			nextAttemptRec, err := newDispatchAdmissionRecord(attemptID, attemptPayload, attemptRec.CreatedAt, time.Now().UTC())
 			if err != nil {
-				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				return nil, err
 			}
 			if err := s.col.CompareAndSwap(ctx, attemptID, attemptRec.Data, nextAttemptRec.Data); err != nil {
-				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				if cleanupErr != nil {
+					return nil, errors.Join(err, cleanupErr)
+				}
 				if errors.Is(err, persis.ErrConflict) || errors.Is(err, persis.ErrNotFound) {
 					return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedDuplicate}, nil
 				}
@@ -249,7 +268,9 @@ func (s *DispatchTaskStore) BindAdmission(ctx context.Context, req exec.Dispatch
 				return err
 			}
 			if !evidence {
-				s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID)
+				if err := s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID); err != nil {
+					return err
+				}
 				return exec.ErrDispatchAdmissionNotFound
 			}
 		}
@@ -315,8 +336,7 @@ func (s *DispatchTaskStore) ReleaseAdmissionToken(ctx context.Context, reservati
 			return exec.ErrDispatchAdmissionConflict
 		}
 	}
-	s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID)
-	return nil
+	return s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID)
 }
 
 func (s *DispatchTaskStore) FinalizeAdmissionAttempt(ctx context.Context, attemptKey string) error {
@@ -335,8 +355,7 @@ func (s *DispatchTaskStore) FinalizeAdmissionAttempt(ctx context.Context, attemp
 	if err != nil {
 		return err
 	}
-	s.deleteAdmissionReservationRecords(ctx, payload, attemptID)
-	return nil
+	return s.deleteAdmissionReservationRecords(ctx, payload, attemptID)
 }
 
 func (s *DispatchTaskStore) CleanupAdmissions(ctx context.Context, staleThreshold time.Duration) error {
@@ -366,7 +385,9 @@ func (s *DispatchTaskStore) CleanupAdmissions(ctx context.Context, staleThreshol
 		if evidence {
 			continue
 		}
-		s.deleteAdmissionReservationRecords(ctx, payload, rec.ID)
+		if err := s.deleteAdmissionReservationRecords(ctx, payload, rec.ID); err != nil {
+			return err
+		}
 	}
 	return s.cleanupOrphanAdmissionSlots(ctx, staleThreshold, now)
 }
@@ -599,7 +620,9 @@ func (s *DispatchTaskStore) createAdmissionPendingRecord(
 		return nil
 	}
 	if s.index != nil {
+		s.mu.Lock()
 		s.index.addPending(rec, payload)
+		s.mu.Unlock()
 	}
 	return nil
 }
@@ -734,7 +757,9 @@ func (s *DispatchTaskStore) cleanupOrphanAdmissionSlots(
 		attemptRec, err := s.col.Get(ctx, dispatchAdmissionAttemptRecordID(slot.AttemptKey))
 		if err != nil {
 			if errors.Is(err, persis.ErrNotFound) {
-				_ = s.col.Delete(ctx, rec.ID)
+				if err := s.deleteAdmissionRecordIfPresent(ctx, rec.ID); err != nil {
+					return err
+				}
 				continue
 			}
 			return err
@@ -746,7 +771,9 @@ func (s *DispatchTaskStore) cleanupOrphanAdmissionSlots(
 		if attempt.SlotID == rec.ID && attempt.ReservationToken == slot.ReservationToken {
 			continue
 		}
-		_ = s.col.Delete(ctx, rec.ID)
+		if err := s.deleteAdmissionRecordIfPresent(ctx, rec.ID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -755,16 +782,30 @@ func (s *DispatchTaskStore) deleteAdmissionReservationRecords(
 	ctx context.Context,
 	attempt dispatchAdmissionAttemptPayload,
 	attemptRecordID string,
-) {
+) error {
 	if attempt.SlotID != "" {
-		_ = s.col.Delete(ctx, attempt.SlotID)
+		if err := s.deleteAdmissionRecordIfPresent(ctx, attempt.SlotID); err != nil {
+			return err
+		}
 	}
 	if attempt.ReservationToken != "" {
-		_ = s.col.Delete(ctx, dispatchAdmissionTokenRecordID(attempt.ReservationToken))
+		if err := s.deleteAdmissionRecordIfPresent(ctx, dispatchAdmissionTokenRecordID(attempt.ReservationToken)); err != nil {
+			return err
+		}
 	}
 	if attemptRecordID != "" {
-		_ = s.col.Delete(ctx, attemptRecordID)
+		if err := s.deleteAdmissionRecordIfPresent(ctx, attemptRecordID); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func (s *DispatchTaskStore) deleteAdmissionRecordIfPresent(ctx context.Context, recordID string) error {
+	if err := s.col.Delete(ctx, recordID); err != nil && !errors.Is(err, persis.ErrNotFound) {
+		return err
+	}
+	return nil
 }
 
 func dispatchAdmissionAttemptPayloadFromRecord(rec *persis.Record) (dispatchAdmissionAttemptPayload, error) {

--- a/internal/persis/store/distributed_admission.go
+++ b/internal/persis/store/distributed_admission.go
@@ -1,0 +1,837 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis"
+)
+
+const (
+	dispatchAdmissionStoreVersion = 1
+
+	dispatchAdmissionAttemptsPrefix = "admissions/attempts/"
+	dispatchAdmissionSlotsPrefix    = "admissions/slots/"
+	dispatchAdmissionTokensPrefix   = "admissions/tokens/"
+)
+
+type dispatchAdmissionState string
+
+const (
+	dispatchAdmissionReserved dispatchAdmissionState = "reserved"
+	dispatchAdmissionBinding  dispatchAdmissionState = "binding"
+	dispatchAdmissionBound    dispatchAdmissionState = "bound"
+)
+
+type dispatchAdmissionAttemptPayload struct {
+	Version          int                    `json:"version"`
+	QueueName        string                 `json:"queueName"`
+	AttemptKey       string                 `json:"attemptKey"`
+	AttemptID        string                 `json:"attemptId"`
+	DAGRun           exec.DAGRunRef         `json:"dagRun"`
+	State            dispatchAdmissionState `json:"state"`
+	ReservationToken string                 `json:"reservationToken"`
+	SlotID           string                 `json:"slotId,omitempty"`
+	PendingRecordID  string                 `json:"pendingRecordId"`
+	PendingFileName  string                 `json:"pendingFileName"`
+	TaskFingerprint  string                 `json:"taskFingerprint,omitempty"`
+	CreatedAt        int64                  `json:"createdAt"`
+	UpdatedAt        int64                  `json:"updatedAt"`
+	BindStartedAt    int64                  `json:"bindStartedAt,omitempty"`
+	BoundAt          int64                  `json:"boundAt,omitempty"`
+}
+
+type dispatchAdmissionSlotPayload struct {
+	Version          int            `json:"version"`
+	QueueName        string         `json:"queueName"`
+	AttemptKey       string         `json:"attemptKey"`
+	AttemptID        string         `json:"attemptId"`
+	DAGRun           exec.DAGRunRef `json:"dagRun"`
+	ReservationToken string         `json:"reservationToken"`
+	CreatedAt        int64          `json:"createdAt"`
+}
+
+type dispatchAdmissionTokenPayload struct {
+	Version          int    `json:"version"`
+	ReservationToken string `json:"reservationToken"`
+	AttemptRecordID  string `json:"attemptRecordId"`
+	AttemptKey       string `json:"attemptKey"`
+	CreatedAt        int64  `json:"createdAt"`
+}
+
+func (s *DispatchTaskStore) ReserveAdmission(
+	ctx context.Context,
+	req exec.DispatchAdmissionRequest,
+) (*exec.DispatchAdmissionDecision, error) {
+	if err := s.validateAdmissionRequest(req); err != nil {
+		return nil, err
+	}
+
+	staleThreshold := normalizeDispatchReservationTTL(req.StaleThreshold)
+	if err := s.CleanupAdmissions(ctx, staleThreshold); err != nil {
+		return nil, err
+	}
+
+	occupied, err := s.dispatchAdmissionOccupancy(ctx, req.QueueName, req.NonAdmissionOccupancy, staleThreshold)
+	if err != nil {
+		return nil, err
+	}
+	if occupied >= req.MaxConcurrency {
+		return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedNoCapacity}, nil
+	}
+
+	now := time.Now().UTC()
+	token := uuid.NewString()
+	pendingFileName := deterministicAdmissionPendingFileName(req.QueueName, req.AttemptKey, token, now)
+	pendingID, err := pendingDispatchRecordID(pendingFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	attemptID := dispatchAdmissionAttemptRecordID(req.AttemptKey)
+	attemptPayload := dispatchAdmissionAttemptPayload{
+		Version:          dispatchAdmissionStoreVersion,
+		QueueName:        req.QueueName,
+		AttemptKey:       req.AttemptKey,
+		AttemptID:        req.AttemptID,
+		DAGRun:           req.DAGRun,
+		State:            dispatchAdmissionReserved,
+		ReservationToken: token,
+		PendingRecordID:  pendingID,
+		PendingFileName:  pendingFileName,
+		CreatedAt:        now.UnixMilli(),
+		UpdatedAt:        now.UnixMilli(),
+	}
+	attemptRec, err := newDispatchAdmissionRecord(attemptID, attemptPayload, now, now)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.col.Create(ctx, attemptRec); err != nil {
+		if errors.Is(err, persis.ErrConflict) {
+			return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedDuplicate}, nil
+		}
+		return nil, err
+	}
+
+	for {
+		slots, err := s.listDispatchAdmissionSlots(ctx, req.QueueName)
+		if err != nil {
+			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			return nil, err
+		}
+		legacyOccupancy, err := s.dispatchLegacyAdmissionOccupancy(ctx, req.QueueName, staleThreshold)
+		if err != nil {
+			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			return nil, err
+		}
+		occupied = req.NonAdmissionOccupancy + len(slots) + legacyOccupancy
+		if occupied >= req.MaxConcurrency {
+			_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+			return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedNoCapacity}, nil
+		}
+
+		for slotNo := 0; slotNo < req.MaxConcurrency; slotNo++ {
+			slotID := dispatchAdmissionSlotRecordID(req.QueueName, slotNo)
+			if _, ok := slots[slotID]; ok {
+				continue
+			}
+
+			slotPayload := dispatchAdmissionSlotPayload{
+				Version:          dispatchAdmissionStoreVersion,
+				QueueName:        req.QueueName,
+				AttemptKey:       req.AttemptKey,
+				AttemptID:        req.AttemptID,
+				DAGRun:           req.DAGRun,
+				ReservationToken: token,
+				CreatedAt:        now.UnixMilli(),
+			}
+			slotRec, err := newDispatchAdmissionRecord(slotID, slotPayload, now, now)
+			if err != nil {
+				_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+				return nil, err
+			}
+			if err := s.col.Create(ctx, slotRec); err != nil {
+				if errors.Is(err, persis.ErrConflict) {
+					continue
+				}
+				_ = s.col.Delete(context.WithoutCancel(ctx), attemptID)
+				return nil, err
+			}
+
+			tokenRec, err := newDispatchAdmissionRecord(dispatchAdmissionTokenRecordID(token), dispatchAdmissionTokenPayload{
+				Version:          dispatchAdmissionStoreVersion,
+				ReservationToken: token,
+				AttemptRecordID:  attemptID,
+				AttemptKey:       req.AttemptKey,
+				CreatedAt:        now.UnixMilli(),
+			}, now, now)
+			if err != nil {
+				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				_ = s.col.Delete(context.WithoutCancel(ctx), slotID)
+				return nil, err
+			}
+			if err := s.col.Create(ctx, tokenRec); err != nil {
+				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				_ = s.col.Delete(context.WithoutCancel(ctx), slotID)
+				return nil, err
+			}
+
+			attemptPayload.SlotID = slotID
+			attemptPayload.UpdatedAt = time.Now().UTC().UnixMilli()
+			nextAttemptRec, err := newDispatchAdmissionRecord(attemptID, attemptPayload, attemptRec.CreatedAt, time.Now().UTC())
+			if err != nil {
+				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				return nil, err
+			}
+			if err := s.col.CompareAndSwap(ctx, attemptID, attemptRec.Data, nextAttemptRec.Data); err != nil {
+				s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				if errors.Is(err, persis.ErrConflict) || errors.Is(err, persis.ErrNotFound) {
+					return &exec.DispatchAdmissionDecision{Reason: exec.DispatchAdmissionRejectedDuplicate}, nil
+				}
+				return nil, err
+			}
+
+			return &exec.DispatchAdmissionDecision{
+				Reserved:         true,
+				ReservationToken: token,
+				PendingRecordID:  pendingID,
+			}, nil
+		}
+	}
+}
+
+func (s *DispatchTaskStore) BindAdmission(ctx context.Context, req exec.DispatchAdmissionBindRequest) error {
+	if err := s.validateAdmissionConfigured(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.ReservationToken) == "" {
+		return fmt.Errorf("reservation token is required")
+	}
+	if req.Task == nil {
+		return fmt.Errorf("dispatch task is required")
+	}
+
+	taskFingerprint, err := dispatchAdmissionTaskFingerprint(req.Task)
+	if err != nil {
+		return err
+	}
+
+	return retryCAS(ctx, func(ctx context.Context) error {
+		attemptRec, attemptPayload, err := s.loadAdmissionAttemptByToken(ctx, req.ReservationToken)
+		if err != nil {
+			return err
+		}
+		if attemptPayload.ReservationToken != req.ReservationToken {
+			return exec.ErrDispatchAdmissionConflict
+		}
+		if attemptPayload.QueueName != req.Task.QueueName ||
+			attemptPayload.AttemptKey != req.Task.AttemptKey ||
+			attemptPayload.AttemptID != "" && req.Task.AttemptID != "" && attemptPayload.AttemptID != req.Task.AttemptID {
+			return exec.ErrDispatchAdmissionConflict
+		}
+		if err := s.verifyAdmissionSlot(ctx, attemptPayload); err != nil {
+			return err
+		}
+		if attemptPayload.State == dispatchAdmissionReserved &&
+			dispatchAdmissionAttemptExpired(attemptRec, attemptPayload, s.reservationTTL) {
+			evidence, err := s.dispatchAdmissionHasExecutionEvidence(ctx, attemptPayload, s.reservationTTL)
+			if err != nil {
+				return err
+			}
+			if !evidence {
+				s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID)
+				return exec.ErrDispatchAdmissionNotFound
+			}
+		}
+
+		switch attemptPayload.State {
+		case dispatchAdmissionBound:
+			if attemptPayload.TaskFingerprint != taskFingerprint {
+				return exec.ErrDispatchAdmissionConflict
+			}
+			return nil
+		case dispatchAdmissionBinding:
+			if attemptPayload.TaskFingerprint != taskFingerprint {
+				return exec.ErrDispatchAdmissionConflict
+			}
+			evidence, err := s.dispatchAdmissionHasExecutionEvidence(ctx, attemptPayload, s.reservationTTL)
+			if err != nil {
+				return err
+			}
+			if evidence {
+				return s.markAdmissionAttemptBound(ctx, attemptRec, attemptPayload)
+			}
+		case dispatchAdmissionReserved:
+			now := time.Now().UTC()
+			nextPayload := attemptPayload
+			nextPayload.State = dispatchAdmissionBinding
+			nextPayload.TaskFingerprint = taskFingerprint
+			nextPayload.BindStartedAt = now.UnixMilli()
+			nextPayload.UpdatedAt = now.UnixMilli()
+			nextData, err := persis.Encode(nextPayload)
+			if err != nil {
+				return err
+			}
+			if err := s.col.CompareAndSwap(ctx, attemptRec.ID, attemptRec.Data, nextData); err != nil {
+				return err
+			}
+			attemptRec.Data = nextData
+			attemptPayload = nextPayload
+		default:
+			return exec.ErrDispatchAdmissionConflict
+		}
+
+		if err := s.createAdmissionPendingRecord(ctx, attemptPayload, req.Task, taskFingerprint); err != nil {
+			return err
+		}
+		return s.markAdmissionAttemptBound(ctx, attemptRec, attemptPayload)
+	})
+}
+
+func (s *DispatchTaskStore) ReleaseAdmissionToken(ctx context.Context, reservationToken string) error {
+	if err := s.validateAdmissionConfigured(); err != nil {
+		return err
+	}
+	attemptRec, attemptPayload, err := s.loadAdmissionAttemptByToken(ctx, reservationToken)
+	if err != nil {
+		return err
+	}
+	if attemptPayload.State != dispatchAdmissionReserved {
+		evidence, err := s.dispatchAdmissionHasExecutionEvidence(ctx, attemptPayload, s.reservationTTL)
+		if err != nil {
+			return err
+		}
+		if evidence {
+			return exec.ErrDispatchAdmissionConflict
+		}
+	}
+	s.deleteAdmissionReservationRecords(ctx, attemptPayload, attemptRec.ID)
+	return nil
+}
+
+func (s *DispatchTaskStore) FinalizeAdmissionAttempt(ctx context.Context, attemptKey string) error {
+	if attemptKey == "" {
+		return nil
+	}
+	attemptID := dispatchAdmissionAttemptRecordID(attemptKey)
+	rec, err := s.col.Get(ctx, attemptID)
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	payload, err := dispatchAdmissionAttemptPayloadFromRecord(rec)
+	if err != nil {
+		return err
+	}
+	s.deleteAdmissionReservationRecords(ctx, payload, attemptID)
+	return nil
+}
+
+func (s *DispatchTaskStore) CleanupAdmissions(ctx context.Context, staleThreshold time.Duration) error {
+	if err := s.validateAdmissionConfigured(); err != nil {
+		return err
+	}
+	staleThreshold = normalizeDispatchReservationTTL(staleThreshold)
+	now := time.Now().UTC()
+
+	recs, err := listAllStrict(ctx, s.col, persis.ListQuery{Prefix: dispatchAdmissionAttemptsPrefix})
+	if err != nil {
+		return err
+	}
+	for _, rec := range recs {
+		payload, err := dispatchAdmissionAttemptPayloadFromRecord(rec)
+		if err != nil {
+			return err
+		}
+		updatedAt := dispatchRecordTimestamp(payload.UpdatedAt, rec.UpdatedAt)
+		if now.Sub(updatedAt) < staleThreshold {
+			continue
+		}
+		evidence, err := s.dispatchAdmissionHasExecutionEvidence(ctx, payload, staleThreshold)
+		if err != nil {
+			return err
+		}
+		if evidence {
+			continue
+		}
+		s.deleteAdmissionReservationRecords(ctx, payload, rec.ID)
+	}
+	return s.cleanupOrphanAdmissionSlots(ctx, staleThreshold, now)
+}
+
+func (s *DispatchTaskStore) validateAdmissionRequest(req exec.DispatchAdmissionRequest) error {
+	if err := s.validateAdmissionConfigured(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.QueueName) == "" {
+		return fmt.Errorf("queue name is required")
+	}
+	if req.MaxConcurrency <= 0 {
+		return fmt.Errorf("max concurrency must be positive")
+	}
+	if req.NonAdmissionOccupancy < 0 {
+		return fmt.Errorf("non-admission occupancy must be non-negative")
+	}
+	if strings.TrimSpace(req.AttemptKey) == "" {
+		return fmt.Errorf("attempt key is required")
+	}
+	if strings.TrimSpace(req.AttemptID) == "" {
+		return fmt.Errorf("attempt ID is required")
+	}
+	if req.DAGRun.Zero() {
+		return fmt.Errorf("DAG run is required")
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) validateAdmissionConfigured() error {
+	if s.admissionLeaseStore == nil || s.admissionActiveRunStore == nil {
+		return exec.ErrDispatchAdmissionLivenessNotConfigured
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) dispatchAdmissionOccupancy(
+	ctx context.Context,
+	queueName string,
+	nonAdmissionOccupancy int,
+	staleThreshold time.Duration,
+) (int, error) {
+	slots, err := s.listDispatchAdmissionSlots(ctx, queueName)
+	if err != nil {
+		return 0, err
+	}
+	legacy, err := s.dispatchLegacyAdmissionOccupancy(ctx, queueName, staleThreshold)
+	if err != nil {
+		return 0, err
+	}
+	return nonAdmissionOccupancy + len(slots) + legacy, nil
+}
+
+func (s *DispatchTaskStore) dispatchLegacyAdmissionOccupancy(
+	ctx context.Context,
+	queueName string,
+	staleThreshold time.Duration,
+) (int, error) {
+	seen := make(map[string]struct{})
+	if err := s.addLegacyDispatchRecords(ctx, seen, queueName, dispatchPendingPrefix, staleThreshold); err != nil {
+		return 0, err
+	}
+	if err := s.addLegacyDispatchRecords(ctx, seen, queueName, dispatchClaimsPrefix, staleThreshold); err != nil {
+		return 0, err
+	}
+
+	leases, err := s.admissionLeaseStore.ListByQueue(ctx, queueName)
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	for _, lease := range leases {
+		if lease.AttemptKey == "" || !lease.IsFresh(now, staleThreshold) {
+			continue
+		}
+		if s.admissionAttemptExists(ctx, lease.AttemptKey) {
+			continue
+		}
+		seen[dispatchLegacyOccupancyKey("lease", lease.AttemptKey)] = struct{}{}
+	}
+	return len(seen), nil
+}
+
+func (s *DispatchTaskStore) addLegacyDispatchRecords(
+	ctx context.Context,
+	seen map[string]struct{},
+	queueName string,
+	prefix string,
+	staleThreshold time.Duration,
+) error {
+	recs, err := s.listDispatchRecords(ctx, prefix)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, rec := range recs {
+		payload, err := dispatchTaskPayloadFromRecord(rec)
+		if err != nil {
+			return err
+		}
+		if payload.Task == nil || payload.Task.QueueName != queueName {
+			continue
+		}
+		if payload.AdmissionReservationToken != "" {
+			continue
+		}
+		recordAt := dispatchRecordTimestamp(payload.EnqueuedAt, rec.CreatedAt)
+		if prefix == dispatchClaimsPrefix {
+			recordAt = dispatchRecordTimestamp(payload.ClaimedAt, rec.UpdatedAt)
+		}
+		if now.Sub(recordAt) >= staleThreshold {
+			continue
+		}
+		key := payload.Task.AttemptKey
+		if key == "" {
+			key = rec.ID
+		}
+		seen[dispatchLegacyOccupancyKey("dispatch", key)] = struct{}{}
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) admissionAttemptExists(ctx context.Context, attemptKey string) bool {
+	if attemptKey == "" {
+		return false
+	}
+	_, err := s.col.Get(ctx, dispatchAdmissionAttemptRecordID(attemptKey))
+	return err == nil
+}
+
+func (s *DispatchTaskStore) loadAdmissionAttemptByToken(
+	ctx context.Context,
+	token string,
+) (*persis.Record, dispatchAdmissionAttemptPayload, error) {
+	tokenRec, err := s.col.Get(ctx, dispatchAdmissionTokenRecordID(token))
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return nil, dispatchAdmissionAttemptPayload{}, exec.ErrDispatchAdmissionNotFound
+		}
+		return nil, dispatchAdmissionAttemptPayload{}, err
+	}
+	var tokenPayload dispatchAdmissionTokenPayload
+	if err := persis.Decode(tokenRec, &tokenPayload); err != nil {
+		return nil, dispatchAdmissionAttemptPayload{}, fmt.Errorf("dispatch admission token: decode %q: %w", tokenRec.ID, err)
+	}
+	if tokenPayload.ReservationToken != token || tokenPayload.AttemptRecordID == "" {
+		return nil, dispatchAdmissionAttemptPayload{}, exec.ErrDispatchAdmissionConflict
+	}
+
+	attemptRec, err := s.col.Get(ctx, tokenPayload.AttemptRecordID)
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return nil, dispatchAdmissionAttemptPayload{}, exec.ErrDispatchAdmissionNotFound
+		}
+		return nil, dispatchAdmissionAttemptPayload{}, err
+	}
+	attemptPayload, err := dispatchAdmissionAttemptPayloadFromRecord(attemptRec)
+	if err != nil {
+		return nil, dispatchAdmissionAttemptPayload{}, err
+	}
+	return attemptRec, attemptPayload, nil
+}
+
+func (s *DispatchTaskStore) verifyAdmissionSlot(ctx context.Context, attempt dispatchAdmissionAttemptPayload) error {
+	if attempt.SlotID == "" {
+		return exec.ErrDispatchAdmissionConflict
+	}
+	slotRec, err := s.col.Get(ctx, attempt.SlotID)
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return exec.ErrDispatchAdmissionNotFound
+		}
+		return err
+	}
+	var slot dispatchAdmissionSlotPayload
+	if err := persis.Decode(slotRec, &slot); err != nil {
+		return fmt.Errorf("dispatch admission slot: decode %q: %w", attempt.SlotID, err)
+	}
+	if slot.QueueName != attempt.QueueName ||
+		slot.AttemptKey != attempt.AttemptKey ||
+		slot.ReservationToken != attempt.ReservationToken {
+		return exec.ErrDispatchAdmissionConflict
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) createAdmissionPendingRecord(
+	ctx context.Context,
+	attempt dispatchAdmissionAttemptPayload,
+	task *exec.DispatchTask,
+	taskFingerprint string,
+) error {
+	now := time.Now().UTC()
+	payload := dispatchTaskPayload{
+		Version:                   dispatchTaskStoreVersion,
+		Task:                      cloneDispatchTask(task),
+		TaskFileName:              attempt.PendingFileName,
+		EnqueuedAt:                now.UnixMilli(),
+		AdmissionReservationToken: attempt.ReservationToken,
+	}
+	rec, err := s.newDispatchRecord(attempt.PendingRecordID, payload, now, now)
+	if err != nil {
+		return err
+	}
+	if err := s.col.Create(ctx, rec); err != nil {
+		if !errors.Is(err, persis.ErrConflict) {
+			return err
+		}
+		existing, getErr := s.col.Get(ctx, attempt.PendingRecordID)
+		if getErr != nil {
+			if errors.Is(getErr, persis.ErrNotFound) {
+				return persis.ErrConflict
+			}
+			return getErr
+		}
+		existingPayload, err := dispatchTaskPayloadFromRecord(existing)
+		if err != nil {
+			return err
+		}
+		if existingPayload.AdmissionReservationToken != attempt.ReservationToken {
+			return exec.ErrDispatchAdmissionConflict
+		}
+		existingFingerprint, err := dispatchAdmissionTaskFingerprint(existingPayload.Task)
+		if err != nil {
+			return err
+		}
+		if existingFingerprint != taskFingerprint {
+			return exec.ErrDispatchAdmissionConflict
+		}
+		return nil
+	}
+	if s.index != nil {
+		s.index.addPending(rec, payload)
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) markAdmissionAttemptBound(
+	ctx context.Context,
+	rec *persis.Record,
+	payload dispatchAdmissionAttemptPayload,
+) error {
+	if payload.State == dispatchAdmissionBound {
+		return nil
+	}
+	now := time.Now().UTC()
+	nextPayload := payload
+	nextPayload.State = dispatchAdmissionBound
+	nextPayload.BoundAt = now.UnixMilli()
+	nextPayload.UpdatedAt = now.UnixMilli()
+	nextData, err := persis.Encode(nextPayload)
+	if err != nil {
+		return err
+	}
+	if err := s.col.CompareAndSwap(ctx, rec.ID, rec.Data, nextData); err != nil {
+		return err
+	}
+	rec.Data = nextData
+	return nil
+}
+
+func (s *DispatchTaskStore) dispatchAdmissionHasExecutionEvidence(
+	ctx context.Context,
+	attempt dispatchAdmissionAttemptPayload,
+	staleThreshold time.Duration,
+) (bool, error) {
+	if attempt.PendingRecordID != "" {
+		if _, err := s.col.Get(ctx, attempt.PendingRecordID); err == nil {
+			return true, nil
+		} else if !errors.Is(err, persis.ErrNotFound) {
+			return false, err
+		}
+	}
+
+	hasClaim, err := s.dispatchAdmissionHasClaim(ctx, attempt)
+	if err != nil || hasClaim {
+		return hasClaim, err
+	}
+
+	lease, err := s.admissionLeaseStore.Get(ctx, attempt.AttemptKey)
+	switch {
+	case err == nil:
+		if lease.IsFresh(time.Now().UTC(), staleThreshold) {
+			return true, nil
+		}
+	case errors.Is(err, exec.ErrDAGRunLeaseNotFound):
+	default:
+		return false, err
+	}
+
+	_, err = s.admissionActiveRunStore.Get(ctx, attempt.AttemptKey)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, exec.ErrActiveRunNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (s *DispatchTaskStore) dispatchAdmissionHasClaim(
+	ctx context.Context,
+	attempt dispatchAdmissionAttemptPayload,
+) (bool, error) {
+	recs, err := s.listDispatchRecords(ctx, dispatchClaimsPrefix)
+	if err != nil {
+		return false, err
+	}
+	for _, rec := range recs {
+		payload, err := dispatchTaskPayloadFromRecord(rec)
+		if err != nil {
+			return false, err
+		}
+		if payload.AdmissionReservationToken == attempt.ReservationToken {
+			return true, nil
+		}
+		if payload.Task != nil && payload.Task.AttemptKey != "" && payload.Task.AttemptKey == attempt.AttemptKey {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *DispatchTaskStore) listDispatchAdmissionSlots(
+	ctx context.Context,
+	queueName string,
+) (map[string]dispatchAdmissionSlotPayload, error) {
+	recs, err := listAllStrict(ctx, s.col, persis.ListQuery{Prefix: dispatchAdmissionSlotQueuePrefix(queueName)})
+	if err != nil {
+		return nil, err
+	}
+	slots := make(map[string]dispatchAdmissionSlotPayload, len(recs))
+	for _, rec := range recs {
+		var payload dispatchAdmissionSlotPayload
+		if err := persis.Decode(rec, &payload); err != nil {
+			return nil, fmt.Errorf("dispatch admission slot: decode %q: %w", rec.ID, err)
+		}
+		if payload.QueueName != queueName || payload.ReservationToken == "" {
+			continue
+		}
+		slots[rec.ID] = payload
+	}
+	return slots, nil
+}
+
+func (s *DispatchTaskStore) cleanupOrphanAdmissionSlots(
+	ctx context.Context,
+	staleThreshold time.Duration,
+	now time.Time,
+) error {
+	recs, err := listAllStrict(ctx, s.col, persis.ListQuery{Prefix: dispatchAdmissionSlotsPrefix})
+	if err != nil {
+		return err
+	}
+	for _, rec := range recs {
+		var slot dispatchAdmissionSlotPayload
+		if err := persis.Decode(rec, &slot); err != nil {
+			return fmt.Errorf("dispatch admission slot: decode %q: %w", rec.ID, err)
+		}
+		createdAt := dispatchRecordTimestamp(slot.CreatedAt, rec.CreatedAt)
+		if now.Sub(createdAt) < staleThreshold {
+			continue
+		}
+		attemptRec, err := s.col.Get(ctx, dispatchAdmissionAttemptRecordID(slot.AttemptKey))
+		if err != nil {
+			if errors.Is(err, persis.ErrNotFound) {
+				_ = s.col.Delete(ctx, rec.ID)
+				continue
+			}
+			return err
+		}
+		attempt, err := dispatchAdmissionAttemptPayloadFromRecord(attemptRec)
+		if err != nil {
+			return err
+		}
+		if attempt.SlotID == rec.ID && attempt.ReservationToken == slot.ReservationToken {
+			continue
+		}
+		_ = s.col.Delete(ctx, rec.ID)
+	}
+	return nil
+}
+
+func (s *DispatchTaskStore) deleteAdmissionReservationRecords(
+	ctx context.Context,
+	attempt dispatchAdmissionAttemptPayload,
+	attemptRecordID string,
+) {
+	if attempt.SlotID != "" {
+		_ = s.col.Delete(ctx, attempt.SlotID)
+	}
+	if attempt.ReservationToken != "" {
+		_ = s.col.Delete(ctx, dispatchAdmissionTokenRecordID(attempt.ReservationToken))
+	}
+	if attemptRecordID != "" {
+		_ = s.col.Delete(ctx, attemptRecordID)
+	}
+}
+
+func dispatchAdmissionAttemptPayloadFromRecord(rec *persis.Record) (dispatchAdmissionAttemptPayload, error) {
+	var payload dispatchAdmissionAttemptPayload
+	if err := persis.Decode(rec, &payload); err != nil {
+		return dispatchAdmissionAttemptPayload{}, fmt.Errorf("dispatch admission attempt: decode %q: %w", rec.ID, err)
+	}
+	return payload, nil
+}
+
+func newDispatchAdmissionRecord(id string, payload any, createdAt, updatedAt time.Time) (*persis.Record, error) {
+	data, err := persis.Encode(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &persis.Record{
+		ID:        id,
+		Data:      data,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, nil
+}
+
+func dispatchAdmissionAttemptRecordID(attemptKey string) string {
+	return dispatchAdmissionAttemptsPrefix + distributedRecordKey(attemptKey)
+}
+
+func dispatchAdmissionSlotQueuePrefix(queueName string) string {
+	return dispatchAdmissionSlotsPrefix + distributedRecordKey(queueName) + "/"
+}
+
+func dispatchAdmissionSlotRecordID(queueName string, slotNo int) string {
+	return dispatchAdmissionSlotQueuePrefix(queueName) + fmt.Sprintf("slot_%06d", slotNo)
+}
+
+func dispatchAdmissionTokenRecordID(token string) string {
+	return dispatchAdmissionTokensPrefix + distributedRecordKey(token)
+}
+
+func deterministicAdmissionPendingFileName(queueName, attemptKey, token string, createdAt time.Time) string {
+	input := strings.Join([]string{queueName, attemptKey, token}, "\x00")
+	return fmt.Sprintf("task_%020d_%s.json", createdAt.UnixMilli(), distributedRecordKey(input))
+}
+
+func dispatchLegacyOccupancyKey(kind, key string) string {
+	return kind + "\x00" + key
+}
+
+func dispatchAdmissionTaskFingerprint(task *exec.DispatchTask) (string, error) {
+	if task == nil {
+		return "", fmt.Errorf("dispatch task is required")
+	}
+	stable := cloneDispatchTask(task)
+	stable.Owner = exec.CoordinatorEndpoint{}
+	stable.ClaimToken = ""
+	data, err := json.Marshal(stable)
+	if err != nil {
+		return "", err
+	}
+	return distributedRecordKey(string(data)), nil
+}
+
+func dispatchAdmissionAttemptExpired(
+	rec *persis.Record,
+	payload dispatchAdmissionAttemptPayload,
+	ttl time.Duration,
+) bool {
+	updatedAt := dispatchRecordTimestamp(payload.UpdatedAt, rec.UpdatedAt)
+	return time.Since(updatedAt) >= normalizeDispatchReservationTTL(ttl)
+}

--- a/internal/persis/store/distributed_admission.go
+++ b/internal/persis/store/distributed_admission.go
@@ -126,17 +126,13 @@ func (s *DispatchTaskStore) ReserveAdmission(
 	for {
 		slots, err := s.listDispatchAdmissionSlots(ctx, req.QueueName)
 		if err != nil {
-			if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
-				return nil, errors.Join(err, cleanupErr)
-			}
-			return nil, err
+			cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID)
+			return nil, joinAdmissionCleanupError(err, cleanupErr)
 		}
 		legacyOccupancy, err := s.dispatchLegacyAdmissionOccupancy(ctx, req.QueueName, staleThreshold)
 		if err != nil {
-			if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
-				return nil, errors.Join(err, cleanupErr)
-			}
-			return nil, err
+			cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID)
+			return nil, joinAdmissionCleanupError(err, cleanupErr)
 		}
 		occupied = req.NonAdmissionOccupancy + len(slots) + legacyOccupancy
 		if occupied >= req.MaxConcurrency {
@@ -163,20 +159,17 @@ func (s *DispatchTaskStore) ReserveAdmission(
 			}
 			slotRec, err := newDispatchAdmissionRecord(slotID, slotPayload, now, now)
 			if err != nil {
-				if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
-					return nil, errors.Join(err, cleanupErr)
-				}
-				return nil, err
+				cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID)
+				return nil, joinAdmissionCleanupError(err, cleanupErr)
 			}
 			if err := s.col.Create(ctx, slotRec); err != nil {
 				if errors.Is(err, persis.ErrConflict) {
 					continue
 				}
-				if cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID); cleanupErr != nil {
-					return nil, errors.Join(err, cleanupErr)
-				}
-				return nil, err
+				cleanupErr := s.deleteAdmissionRecordIfPresent(context.WithoutCancel(ctx), attemptID)
+				return nil, joinAdmissionCleanupError(err, cleanupErr)
 			}
+			attemptPayload.SlotID = slotID
 
 			tokenRec, err := newDispatchAdmissionRecord(dispatchAdmissionTokenRecordID(token), dispatchAdmissionTokenPayload{
 				Version:          dispatchAdmissionStoreVersion,
@@ -186,28 +179,20 @@ func (s *DispatchTaskStore) ReserveAdmission(
 				CreatedAt:        now.UnixMilli(),
 			}, now, now)
 			if err != nil {
-				attemptPayload.SlotID = slotID
-				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
-					return nil, errors.Join(err, cleanupErr)
-				}
-				return nil, err
+				cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				return nil, joinAdmissionCleanupError(err, cleanupErr)
 			}
 			if err := s.col.Create(ctx, tokenRec); err != nil {
-				attemptPayload.SlotID = slotID
-				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
-					return nil, errors.Join(err, cleanupErr)
-				}
-				return nil, err
+				cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				return nil, joinAdmissionCleanupError(err, cleanupErr)
 			}
 
-			attemptPayload.SlotID = slotID
-			attemptPayload.UpdatedAt = time.Now().UTC().UnixMilli()
-			nextAttemptRec, err := newDispatchAdmissionRecord(attemptID, attemptPayload, attemptRec.CreatedAt, time.Now().UTC())
+			updatedAt := time.Now().UTC()
+			attemptPayload.UpdatedAt = updatedAt.UnixMilli()
+			nextAttemptRec, err := newDispatchAdmissionRecord(attemptID, attemptPayload, attemptRec.CreatedAt, updatedAt)
 			if err != nil {
-				if cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID); cleanupErr != nil {
-					return nil, errors.Join(err, cleanupErr)
-				}
-				return nil, err
+				cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
+				return nil, joinAdmissionCleanupError(err, cleanupErr)
 			}
 			if err := s.col.CompareAndSwap(ctx, attemptID, attemptRec.Data, nextAttemptRec.Data); err != nil {
 				cleanupErr := s.deleteAdmissionReservationRecords(context.WithoutCancel(ctx), attemptPayload, attemptID)
@@ -223,7 +208,6 @@ func (s *DispatchTaskStore) ReserveAdmission(
 			return &exec.DispatchAdmissionDecision{
 				Reserved:         true,
 				ReservationToken: token,
-				PendingRecordID:  pendingID,
 			}, nil
 		}
 	}
@@ -806,6 +790,13 @@ func (s *DispatchTaskStore) deleteAdmissionRecordIfPresent(ctx context.Context, 
 		return err
 	}
 	return nil
+}
+
+func joinAdmissionCleanupError(err, cleanupErr error) error {
+	if cleanupErr != nil {
+		return errors.Join(err, cleanupErr)
+	}
+	return err
 }
 
 func dispatchAdmissionAttemptPayloadFromRecord(rec *persis.Record) (dispatchAdmissionAttemptPayload, error) {

--- a/internal/persis/store/distributed_admission_test.go
+++ b/internal/persis/store/distributed_admission_test.go
@@ -1,0 +1,334 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/store"
+	"github.com/dagucloud/dagu/internal/persis/testutil"
+)
+
+func TestDispatchAdmissionStore_ReserveAdmissionRejectsDuplicateAcrossStores(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	first, second := stores.first, stores.second
+	req := dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 2)
+
+	results := reserveAdmissionConcurrently(ctx, req, first, second)
+
+	require.Len(t, results, 2)
+	assert.Equal(t, 1, countReservedDecisions(results))
+	assert.Equal(t, 1, countRejectReason(results, exec.DispatchAdmissionRejectedDuplicate))
+}
+
+func TestDispatchAdmissionStore_ReserveAdmissionHonorsQueueCapacityAcrossStores(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	first, second := stores.first, stores.second
+
+	results := make([]admissionReserveResult, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		results[0] = reserveAdmission(ctx, first, dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1))
+	}()
+	go func() {
+		defer wg.Done()
+		results[1] = reserveAdmission(ctx, second, dispatchAdmissionRequest("queue-a", "attempt-key-b", "attempt-b", 1))
+	}()
+	wg.Wait()
+
+	assert.Equal(t, 1, countReservedDecisions(results))
+	assert.Equal(t, 1, countRejectReason(results, exec.DispatchAdmissionRejectedNoCapacity))
+}
+
+func TestDispatchAdmissionStore_ReserveAdmissionCountsOldHighSlotsAfterConcurrencyDecrease(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+
+	for i, attempt := range []string{"a", "b", "c"} {
+		result := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-"+attempt, "attempt-"+attempt, 3))
+		require.NoError(t, result.err)
+		require.True(t, result.decision.Reserved, "initial reservation %d should fit", i)
+	}
+
+	result := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-d", "attempt-d", 2))
+	require.NoError(t, result.err)
+	require.False(t, result.decision.Reserved)
+	assert.Equal(t, exec.DispatchAdmissionRejectedNoCapacity, result.decision.Reason)
+}
+
+func TestDispatchAdmissionStore_ReserveAdmissionCountsNonAdmissionOccupancy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+	req := dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1)
+	req.NonAdmissionOccupancy = 1
+
+	result := reserveAdmission(ctx, s, req)
+
+	require.NoError(t, result.err)
+	require.False(t, result.decision.Reserved)
+	assert.Equal(t, exec.DispatchAdmissionRejectedNoCapacity, result.decision.Reason)
+}
+
+func TestDispatchAdmissionStore_ReserveAdmissionCountsLegacyPendingClaimAndLease(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+	leaseStore := stores.leaseStore
+	require.NoError(t, s.Enqueue(ctx, dispatchAdmissionTask("queue-a", "legacy-pending-attempt", "legacy-pending")))
+	require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+		AttemptKey:      "legacy-lease-attempt",
+		DAGRun:          exec.NewDAGRunRef("dag-a", "run-legacy"),
+		Root:            exec.NewDAGRunRef("dag-a", "run-legacy"),
+		AttemptID:       "legacy-lease",
+		QueueName:       "queue-a",
+		WorkerID:        "worker-a",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	result := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-new", "attempt-new", 2))
+
+	require.NoError(t, result.err)
+	require.False(t, result.decision.Reserved)
+	assert.Equal(t, exec.DispatchAdmissionRejectedNoCapacity, result.decision.Reason)
+}
+
+func TestDispatchAdmissionStore_BindAdmissionIsIdempotentForSameToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+	req := dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1)
+	result := reserveAdmission(ctx, s, req)
+	require.NoError(t, result.err)
+	require.True(t, result.decision.Reserved)
+
+	task := dispatchAdmissionTask("queue-a", req.AttemptKey, req.AttemptID)
+	require.NoError(t, s.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: result.decision.ReservationToken,
+		Task:             task,
+	}))
+
+	claimed, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID:     "worker-a",
+		PollerID:     "poller-a",
+		ClaimTimeout: time.Minute,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	require.NoError(t, s.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: result.decision.ReservationToken,
+		Task:             task,
+	}))
+	require.NoError(t, s.DeleteClaim(ctx, claimed.ClaimToken))
+	require.NoError(t, s.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: result.decision.ReservationToken,
+		Task:             task,
+	}))
+
+	claimedAgain, err := s.ClaimNext(ctx, exec.DispatchTaskClaim{
+		WorkerID:     "worker-a",
+		PollerID:     "poller-a",
+		ClaimTimeout: time.Minute,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, claimedAgain)
+}
+
+func TestDispatchAdmissionStore_BindAdmissionRequiresMatchingSlotAndToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+	req := dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1)
+	result := reserveAdmission(ctx, s, req)
+	require.NoError(t, result.err)
+	require.True(t, result.decision.Reserved)
+	require.NoError(t, s.FinalizeAdmissionAttempt(ctx, req.AttemptKey))
+
+	err := s.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: result.decision.ReservationToken,
+		Task:             dispatchAdmissionTask("queue-a", req.AttemptKey, req.AttemptID),
+	})
+
+	require.Error(t, err)
+}
+
+func TestDispatchAdmissionStore_BindAdmissionRejectsExpiredReservation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := testutil.NewMemoryBackend()
+	dispatchCol := backend.Collection("dispatch_tasks")
+	leaseStore := store.NewDAGRunLeaseStore(backend.Collection("dag_run_leases"))
+	activeStore := store.NewActiveDistributedRunStore(backend.Collection("active_runs"))
+	s := store.NewDispatchTaskStore(
+		dispatchCol,
+		store.WithDispatchAdmissionLiveness(leaseStore, activeStore),
+		store.WithDispatchReservationTTL(25*time.Millisecond),
+	)
+	req := dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1)
+	req.StaleThreshold = 25 * time.Millisecond
+	result := reserveAdmission(ctx, s, req)
+	require.NoError(t, result.err)
+	require.True(t, result.decision.Reserved)
+
+	time.Sleep(50 * time.Millisecond)
+
+	err := s.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: result.decision.ReservationToken,
+		Task:             dispatchAdmissionTask("queue-a", req.AttemptKey, req.AttemptID),
+	})
+
+	require.ErrorIs(t, err, exec.ErrDispatchAdmissionNotFound)
+}
+
+func TestDispatchAdmissionStore_FinalizeAdmissionAttemptReleasesSlot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stores := newDispatchAdmissionTestStores(t)
+	s := stores.first
+
+	first := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1))
+	require.NoError(t, first.err)
+	require.True(t, first.decision.Reserved)
+
+	full := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-b", "attempt-b", 1))
+	require.NoError(t, full.err)
+	require.False(t, full.decision.Reserved)
+
+	require.NoError(t, s.FinalizeAdmissionAttempt(ctx, "attempt-key-a"))
+
+	second := reserveAdmission(ctx, s, dispatchAdmissionRequest("queue-a", "attempt-key-b", "attempt-b", 1))
+	require.NoError(t, second.err)
+	require.True(t, second.decision.Reserved)
+}
+
+func TestDispatchAdmissionStore_ReserveAdmissionRequiresLivenessStores(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := store.NewDispatchTaskStore(testutil.NewMemoryBackend().Collection("dispatch_tasks"))
+
+	_, err := s.ReserveAdmission(ctx, dispatchAdmissionRequest("queue-a", "attempt-key-a", "attempt-a", 1))
+
+	require.ErrorIs(t, err, exec.ErrDispatchAdmissionLivenessNotConfigured)
+}
+
+type admissionReserveResult struct {
+	decision *exec.DispatchAdmissionDecision
+	err      error
+}
+
+type dispatchAdmissionTestStores struct {
+	first       *store.DispatchTaskStore
+	second      *store.DispatchTaskStore
+	leaseStore  *store.DAGRunLeaseStore
+	activeStore *store.ActiveDistributedRunStore
+}
+
+func newDispatchAdmissionTestStores(t *testing.T) dispatchAdmissionTestStores {
+	t.Helper()
+
+	backend := testutil.NewMemoryBackend()
+	dispatchCol := backend.Collection("dispatch_tasks")
+	leaseStore := store.NewDAGRunLeaseStore(backend.Collection("dag_run_leases"))
+	activeStore := store.NewActiveDistributedRunStore(backend.Collection("active_runs"))
+	first := store.NewDispatchTaskStore(dispatchCol, store.WithDispatchAdmissionLiveness(leaseStore, activeStore))
+	second := store.NewDispatchTaskStore(dispatchCol, store.WithDispatchAdmissionLiveness(leaseStore, activeStore))
+	return dispatchAdmissionTestStores{
+		first:       first,
+		second:      second,
+		leaseStore:  leaseStore,
+		activeStore: activeStore,
+	}
+}
+
+func dispatchAdmissionRequest(queueName, attemptKey, attemptID string, maxConcurrency int) exec.DispatchAdmissionRequest {
+	return exec.DispatchAdmissionRequest{
+		QueueName:      queueName,
+		MaxConcurrency: maxConcurrency,
+		AttemptKey:     attemptKey,
+		AttemptID:      attemptID,
+		DAGRun:         exec.NewDAGRunRef("dag-a", "run-"+attemptID),
+		StaleThreshold: time.Minute,
+	}
+}
+
+func dispatchAdmissionTask(queueName, attemptKey, attemptID string) *exec.DispatchTask {
+	return &exec.DispatchTask{
+		Operation:  exec.DispatchOperationRetry,
+		DAGRunID:   "run-" + attemptID,
+		Target:     "dag-a",
+		Definition: "steps:\n- command: echo ok\n",
+		AttemptID:  attemptID,
+		AttemptKey: attemptKey,
+		QueueName:  queueName,
+	}
+}
+
+func reserveAdmission(ctx context.Context, s exec.DispatchAdmissionStore, req exec.DispatchAdmissionRequest) admissionReserveResult {
+	decision, err := s.ReserveAdmission(ctx, req)
+	return admissionReserveResult{decision: decision, err: err}
+}
+
+func reserveAdmissionConcurrently(ctx context.Context, req exec.DispatchAdmissionRequest, stores ...exec.DispatchAdmissionStore) []admissionReserveResult {
+	results := make([]admissionReserveResult, len(stores))
+	var wg sync.WaitGroup
+	for i, s := range stores {
+		wg.Add(1)
+		go func(idx int, admissionStore exec.DispatchAdmissionStore) {
+			defer wg.Done()
+			results[idx] = reserveAdmission(ctx, admissionStore, req)
+		}(i, s)
+	}
+	wg.Wait()
+	return results
+}
+
+func countReservedDecisions(results []admissionReserveResult) int {
+	var count int
+	for _, result := range results {
+		if result.err == nil && result.decision != nil && result.decision.Reserved {
+			count++
+		}
+	}
+	return count
+}
+
+func countRejectReason(results []admissionReserveResult, reason exec.DispatchAdmissionRejectReason) int {
+	var count int
+	for _, result := range results {
+		if result.err == nil && result.decision != nil && !result.decision.Reserved && result.decision.Reason == reason {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -40,6 +40,7 @@ var (
 const dispatchNoMatchCacheLimit = 1024
 
 var _ exec.DispatchTaskStore = (*DispatchTaskStore)(nil)
+var _ exec.DispatchAdmissionStore = (*DispatchTaskStore)(nil)
 
 // DispatchTaskStoreOption configures a DispatchTaskStore.
 type DispatchTaskStoreOption func(*DispatchTaskStore)
@@ -51,6 +52,8 @@ type DispatchTaskStoreOption func(*DispatchTaskStore)
 type DispatchTaskStore struct {
 	col                      persis.Collection
 	reservationTTL           time.Duration
+	admissionLeaseStore      exec.DAGRunLeaseStore
+	admissionActiveRunStore  exec.ActiveDistributedRunStore
 	lastReservationCleanupAt time.Time
 	index                    *dispatchTaskIndex
 	// mu serializes the in-process recycle+scan+claim sequence;
@@ -76,20 +79,22 @@ type dispatchTaskIndexEntry struct {
 	hasTask        bool
 	enqueuedAt     int64
 	claimedAt      int64
+	admissionToken string
 	createdAt      time.Time
 	updatedAt      time.Time
 }
 
 type dispatchTaskPayload struct {
-	Version      int                      `json:"version"`
-	Task         *exec.DispatchTask       `json:"task"`
-	TaskFileName string                   `json:"taskFileName"`
-	EnqueuedAt   int64                    `json:"enqueuedAt"`
-	ClaimToken   string                   `json:"claimToken,omitempty"`
-	ClaimedAt    int64                    `json:"claimedAt,omitempty"`
-	WorkerID     string                   `json:"workerId,omitempty"`
-	PollerID     string                   `json:"pollerId,omitempty"`
-	Owner        exec.CoordinatorEndpoint `json:"owner,omitzero"`
+	Version                   int                      `json:"version"`
+	Task                      *exec.DispatchTask       `json:"task"`
+	TaskFileName              string                   `json:"taskFileName"`
+	EnqueuedAt                int64                    `json:"enqueuedAt"`
+	ClaimToken                string                   `json:"claimToken,omitempty"`
+	ClaimedAt                 int64                    `json:"claimedAt,omitempty"`
+	WorkerID                  string                   `json:"workerId,omitempty"`
+	PollerID                  string                   `json:"pollerId,omitempty"`
+	Owner                     exec.CoordinatorEndpoint `json:"owner,omitzero"`
+	AdmissionReservationToken string                   `json:"admissionReservationToken,omitempty"`
 }
 
 type legacyDAGRunStatusProto struct {
@@ -304,13 +309,14 @@ func (idx *dispatchTaskIndex) hasNoMatch(labels map[string]string) bool {
 
 func dispatchTaskIndexEntryFromRecord(rec *persis.Record, payload dispatchTaskPayload) dispatchTaskIndexEntry {
 	entry := dispatchTaskIndexEntry{
-		id:           rec.ID,
-		taskFileName: payload.TaskFileName,
-		claimToken:   payload.ClaimToken,
-		enqueuedAt:   payload.EnqueuedAt,
-		claimedAt:    payload.ClaimedAt,
-		createdAt:    rec.CreatedAt,
-		updatedAt:    rec.UpdatedAt,
+		id:             rec.ID,
+		taskFileName:   payload.TaskFileName,
+		claimToken:     payload.ClaimToken,
+		enqueuedAt:     payload.EnqueuedAt,
+		claimedAt:      payload.ClaimedAt,
+		admissionToken: payload.AdmissionReservationToken,
+		createdAt:      rec.CreatedAt,
+		updatedAt:      rec.UpdatedAt,
 	}
 	if payload.Task != nil {
 		entry.hasTask = true
@@ -348,6 +354,18 @@ func dispatchClaimLabelsKey(labels map[string]string) string {
 func WithDispatchReservationTTL(ttl time.Duration) DispatchTaskStoreOption {
 	return func(store *DispatchTaskStore) {
 		store.reservationTTL = normalizeDispatchReservationTTL(ttl)
+	}
+}
+
+// WithDispatchAdmissionLiveness enables admission cleanup against shared
+// distributed liveness stores.
+func WithDispatchAdmissionLiveness(
+	leaseStore exec.DAGRunLeaseStore,
+	activeRunStore exec.ActiveDistributedRunStore,
+) DispatchTaskStoreOption {
+	return func(store *DispatchTaskStore) {
+		store.admissionLeaseStore = leaseStore
+		store.admissionActiveRunStore = activeRunStore
 	}
 }
 

--- a/internal/persis/store/distributed_dispatch.go
+++ b/internal/persis/store/distributed_dispatch.go
@@ -79,7 +79,6 @@ type dispatchTaskIndexEntry struct {
 	hasTask        bool
 	enqueuedAt     int64
 	claimedAt      int64
-	admissionToken string
 	createdAt      time.Time
 	updatedAt      time.Time
 }
@@ -309,14 +308,13 @@ func (idx *dispatchTaskIndex) hasNoMatch(labels map[string]string) bool {
 
 func dispatchTaskIndexEntryFromRecord(rec *persis.Record, payload dispatchTaskPayload) dispatchTaskIndexEntry {
 	entry := dispatchTaskIndexEntry{
-		id:             rec.ID,
-		taskFileName:   payload.TaskFileName,
-		claimToken:     payload.ClaimToken,
-		enqueuedAt:     payload.EnqueuedAt,
-		claimedAt:      payload.ClaimedAt,
-		admissionToken: payload.AdmissionReservationToken,
-		createdAt:      rec.CreatedAt,
-		updatedAt:      rec.UpdatedAt,
+		id:           rec.ID,
+		taskFileName: payload.TaskFileName,
+		claimToken:   payload.ClaimToken,
+		enqueuedAt:   payload.EnqueuedAt,
+		claimedAt:    payload.ClaimedAt,
+		createdAt:    rec.CreatedAt,
+		updatedAt:    rec.UpdatedAt,
 	}
 	if payload.Task != nil {
 		entry.hasTask = true

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -170,7 +170,8 @@ func New(registry exec.ServiceRegistry, config *Config) Client {
 }
 
 // Dispatch sends a task to the coordinator.
-func (cli *clientImpl) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
+func (cli *clientImpl) Dispatch(ctx context.Context, req exec.DispatchRequest) error {
+	task := req.Task
 	if task == nil {
 		return fmt.Errorf("dispatch task is nil")
 	}
@@ -205,14 +206,17 @@ func (cli *clientImpl) Dispatch(ctx context.Context, task *exec.DispatchTask) er
 
 		return cli.attemptCall(ctx, members, func(ctx context.Context, member exec.HostInfo, client *client) error {
 			// Create request
-			req := &coordinatorv1.DispatchRequest{Task: protoTask}
+			protoReq := &coordinatorv1.DispatchRequest{
+				Task:                      protoTask,
+				AdmissionReservationToken: req.AdmissionReservationToken,
+			}
 
 			// Apply request timeout
 			dispatchCtx, cancel := context.WithTimeout(ctx, cli.config.RequestTimeout)
 			defer cancel()
 
 			// Try to dispatch
-			if _, err := client.client.Dispatch(dispatchCtx, req); err != nil {
+			if _, err := client.client.Dispatch(dispatchCtx, protoReq); err != nil {
 				logger.Warn(ctx, "Failed to dispatch task to coordinator",
 					tag.RunID(task.DAGRunID),
 					tag.Target(task.Target),

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -89,7 +89,45 @@ func TestClientDispatch(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
-		err := client.Dispatch(ctx, task)
+		err := client.Dispatch(ctx, exec.DispatchRequest{Task: task})
+		require.NoError(t, err)
+	})
+
+	t.Run("SendsAdmissionReservationToken", func(t *testing.T) {
+		t.Parallel()
+		config := coordinator.DefaultConfig()
+		config.MaxRetries = 0
+		config.RequestTimeout = 100 * time.Millisecond
+
+		mockCoord := &mockCoordinatorService{
+			dispatchFunc: func(_ context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
+				assert.Equal(t, "reservation-token-a", req.AdmissionReservationToken)
+				return &coordinatorv1.DispatchResponse{}, nil
+			},
+		}
+
+		server, addr := startMockServer(t, mockCoord)
+		defer server.Stop()
+
+		host, port := parseHostPort(addr)
+		monitor := &mockServiceMonitor{
+			members: []exec.HostInfo{
+				{ID: "coord-1", Host: host, Port: port, Status: exec.ServiceStatusActive},
+			},
+		}
+
+		client := coordinator.New(monitor, config)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		err := client.Dispatch(ctx, exec.DispatchRequest{
+			Task: &exec.DispatchTask{
+				DAGRunID: "test-dag-run",
+				Target:   "test.yaml",
+			},
+			AdmissionReservationToken: "reservation-token-a",
+		})
 		require.NoError(t, err)
 	})
 
@@ -114,7 +152,7 @@ func TestClientDispatch(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
-		err := client.Dispatch(ctx, task)
+		err := client.Dispatch(ctx, exec.DispatchRequest{Task: task})
 		require.Error(t, err)
 		// Could be either error depending on timing
 		assert.True(t, strings.Contains(err.Error(), "no coordinators available") ||
@@ -148,9 +186,11 @@ func TestClientDispatch(t *testing.T) {
 
 		client := coordinator.New(monitor, config)
 
-		err := client.Dispatch(context.Background(), &exec.DispatchTask{
-			DAGRunID: "run-123",
-			Target:   "test-dag",
+		err := client.Dispatch(context.Background(), exec.DispatchRequest{
+			Task: &exec.DispatchTask{
+				DAGRunID: "run-123",
+				Target:   "test-dag",
+			},
 		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, backoff.ErrPermanent)
@@ -1165,7 +1205,7 @@ func TestClientMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := client.Dispatch(ctx, task)
+	err := client.Dispatch(ctx, exec.DispatchRequest{Task: task})
 	require.Error(t, err)
 
 	// Check failure metrics
@@ -1203,7 +1243,7 @@ func TestClientCleanup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := client.Dispatch(ctx, task)
+	err := client.Dispatch(ctx, exec.DispatchRequest{Task: task})
 	require.NoError(t, err)
 
 	// Cleanup should close all connections
@@ -1214,7 +1254,7 @@ func TestClientCleanup(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel2()
 
-	err = client.Dispatch(ctx2, task)
+	err = client.Dispatch(ctx2, exec.DispatchRequest{Task: task})
 	require.NoError(t, err)
 }
 
@@ -1236,7 +1276,7 @@ func TestClientDispatch_NoCoordinators(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	err := client.Dispatch(ctx, task)
+	err := client.Dispatch(ctx, exec.DispatchRequest{Task: task})
 	require.Error(t, err)
 	// Could be either error depending on timing
 	assert.True(t, strings.Contains(err.Error(), "no coordinators available") ||

--- a/internal/service/coordinator/distributed_store_test.go
+++ b/internal/service/coordinator/distributed_store_test.go
@@ -14,6 +14,15 @@ func newTestDispatchTaskStore(baseDir string) *store.DispatchTaskStore {
 	return store.NewDispatchTaskStore(file.NewCollection(baseDir))
 }
 
+func newTestDispatchAdmissionTaskStore(baseDir string) (*store.DispatchTaskStore, *store.DAGRunLeaseStore, *store.ActiveDistributedRunStore) {
+	leaseStore := newTestDAGRunLeaseStore(baseDir)
+	activeStore := newTestActiveDistributedRunStore(baseDir)
+	return store.NewDispatchTaskStore(
+		file.NewCollection(baseDir),
+		store.WithDispatchAdmissionLiveness(leaseStore, activeStore),
+	), leaseStore, activeStore
+}
+
 func newTestWorkerHeartbeatStore(baseDir string) *store.WorkerHeartbeatStore {
 	return store.NewWorkerHeartbeatStore(file.NewCollection(filepath.Join(baseDir, "workers")))
 }

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -112,6 +112,7 @@ type Handler struct {
 	stateStore                dagstate.Store                 // For persistent DAG state shared across DAG runs
 	workspaceBundleStore      *workspacebundle.Store         // For immutable action workspace bundles
 	dispatchTaskStore         exec.DispatchTaskStore         // Shared distributed dispatch queue
+	dispatchAdmissionStore    exec.DispatchAdmissionStore    // Shared distributed admission state
 	workerHeartbeatStore      exec.WorkerHeartbeatStore      // Shared worker presence
 	dagRunLeaseStore          exec.DAGRunLeaseStore          // Shared distributed run leases
 	activeDistributedRunStore exec.ActiveDistributedRunStore // Shared active distributed attempt index
@@ -167,6 +168,9 @@ type HandlerConfig struct {
 	// DispatchTaskStore is the shared store for distributed pending tasks.
 	DispatchTaskStore exec.DispatchTaskStore
 
+	// DispatchAdmissionStore reserves and binds distributed queue admission.
+	DispatchAdmissionStore exec.DispatchAdmissionStore
+
 	// WorkerHeartbeatStore is the shared store for worker presence.
 	WorkerHeartbeatStore exec.WorkerHeartbeatStore
 
@@ -213,6 +217,12 @@ func NewHandler(cfg HandlerConfig) *Handler {
 	if cfg.WorkspaceBundleDir != "" {
 		bundleStore = workspacebundle.NewStore(cfg.WorkspaceBundleDir, workspacebundle.DefaultLimits())
 	}
+	dispatchAdmissionStore := cfg.DispatchAdmissionStore
+	if dispatchAdmissionStore == nil {
+		if admissionStore, ok := cfg.DispatchTaskStore.(exec.DispatchAdmissionStore); ok {
+			dispatchAdmissionStore = admissionStore
+		}
+	}
 	return &Handler{
 		waitingPollers:            make(map[string]*workerInfo),
 		heartbeats:                make(map[string]*heartbeatInfo),
@@ -228,6 +238,7 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		stateStore:                cfg.StateStore,
 		workspaceBundleStore:      bundleStore,
 		dispatchTaskStore:         cfg.DispatchTaskStore,
+		dispatchAdmissionStore:    dispatchAdmissionStore,
 		workerHeartbeatStore:      cfg.WorkerHeartbeatStore,
 		dagRunLeaseStore:          cfg.DAGRunLeaseStore,
 		activeDistributedRunStore: cfg.ActiveDistributedRunStore,
@@ -429,6 +440,7 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	if req.Task == nil {
 		return nil, status.Error(codes.InvalidArgument, "task is required")
 	}
+	admissionToken := strings.TrimSpace(req.AdmissionReservationToken)
 
 	// Validate task.Definition is provided - required for distributed execution
 	if req.Task.Definition == "" {
@@ -442,6 +454,9 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	)
 
 	if h.dispatchTaskStore == nil {
+		if admissionToken != "" {
+			return nil, status.Error(codes.FailedPrecondition, "admission reservation requires dispatch task storage")
+		}
 		if err := h.ensureWaitingWorkerAvailability(req.Task.WorkerSelector); err != nil {
 			return nil, status.Error(dispatchErrorCode(err), err.Error())
 		}
@@ -466,6 +481,9 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	if h.dagRunStore == nil {
 		return nil, status.Error(codes.FailedPrecondition, "distributed dispatch requires DAG run storage")
 	}
+	if admissionToken != "" && h.dispatchAdmissionStore == nil {
+		return nil, status.Error(codes.FailedPrecondition, "dispatch admission store is not configured")
+	}
 
 	healthyWorkers, err := h.listHealthyWorkers(ctx)
 	if err != nil {
@@ -480,19 +498,77 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 
 	prepared, err := h.prepareAttemptForDispatch(ctx, req.Task)
 	if err != nil {
+		h.releaseAdmissionToken(ctx, admissionToken)
 		return nil, status.Error(prepareAttemptErrorCode(err), "failed to prepare attempt: "+err.Error())
 	}
 	dispatchTask, err := convert.ProtoToDispatchTask(req.Task)
 	if err != nil {
 		h.markPreparedAttemptDispatchFailed(ctx, req.Task, prepared, err)
+		h.releaseAdmissionToken(ctx, admissionToken)
 		return nil, status.Error(codes.Internal, "failed to encode task: "+err.Error())
 	}
-	if err := h.dispatchTaskStore.Enqueue(ctx, dispatchTask); err != nil {
+	if err := h.enqueueOrBindDispatchTask(ctx, admissionToken, dispatchTask); err != nil {
 		h.markPreparedAttemptDispatchFailed(ctx, req.Task, prepared, err)
+		h.releaseAdmissionToken(ctx, admissionToken)
 		return nil, status.Error(codes.Internal, "failed to enqueue task: "+err.Error())
 	}
 	h.notifyDispatchAvailable()
 	return &coordinatorv1.DispatchResponse{}, nil
+}
+
+func (h *Handler) enqueueOrBindDispatchTask(ctx context.Context, admissionToken string, task *exec.DispatchTask) error {
+	if admissionToken == "" {
+		return h.dispatchTaskStore.Enqueue(ctx, task)
+	}
+	return h.dispatchAdmissionStore.BindAdmission(ctx, exec.DispatchAdmissionBindRequest{
+		ReservationToken: admissionToken,
+		Task:             task,
+	})
+}
+
+func (h *Handler) releaseAdmissionToken(ctx context.Context, token string) {
+	if token == "" || h.dispatchAdmissionStore == nil {
+		return
+	}
+	err := h.dispatchAdmissionStore.ReleaseAdmissionToken(context.WithoutCancel(ctx), token)
+	if err == nil ||
+		errors.Is(err, exec.ErrDispatchAdmissionConflict) ||
+		errors.Is(err, exec.ErrDispatchAdmissionNotFound) {
+		return
+	}
+	logger.Warn(ctx, "Failed to release dispatch admission reservation",
+		tag.Error(err),
+	)
+}
+
+func (h *Handler) finalizeAdmissionForStatus(ctx context.Context, status *exec.DAGRunStatus, attemptID string) {
+	if h.dispatchAdmissionStore == nil || status == nil || !isTerminalRunStatus(status.Status) {
+		return
+	}
+	attemptKey := exec.AttemptKeyForStatus(status, attemptID)
+	if attemptKey == "" {
+		return
+	}
+	if err := h.dispatchAdmissionStore.FinalizeAdmissionAttempt(context.WithoutCancel(ctx), attemptKey); err != nil {
+		logger.Warn(ctx, "Failed to finalize dispatch admission",
+			tag.AttemptKey(attemptKey),
+			tag.Error(err),
+		)
+	}
+}
+
+func (h *Handler) finalizeAdmissionForAttempt(ctx context.Context, attempt exec.DAGRunAttempt) {
+	if h.dispatchAdmissionStore == nil || attempt == nil {
+		return
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		logger.Warn(ctx, "Failed to read status for dispatch admission finalization",
+			tag.Error(err),
+		)
+		return
+	}
+	h.finalizeAdmissionForStatus(ctx, status, attempt.ID())
 }
 
 func queueDispatchStatusForTask(task *coordinatorv1.Task) (*exec.DAGRunStatus, error) {
@@ -1548,6 +1624,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	// Keep distributed liveness in the dedicated lease store and active index,
 	// not in run history.
 	ownership.syncFromStatus(ctx, req.WorkerId, dagRunStatus, attempt.ID())
+	h.finalizeAdmissionForStatus(ctx, dagRunStatus, attempt.ID())
 
 	// Note: We don't close the attempt immediately on terminal status because
 	// the agent may push the same terminal status multiple times from different
@@ -2612,6 +2689,14 @@ func (h *Handler) failDistributedAttemptIfCurrent(
 		"Failed to delete stale distributed lease after failure",
 		"Failed to delete active distributed run after failure",
 	)
+	if h.dispatchAdmissionStore != nil && attemptKey != "" {
+		if err := h.dispatchAdmissionStore.FinalizeAdmissionAttempt(storeCtx, attemptKey); err != nil {
+			logger.Warn(ctx, "Failed to finalize dispatch admission after stale-run failure",
+				tag.AttemptKey(attemptKey),
+				tag.Error(err),
+			)
+		}
+	}
 
 	logger.Warn(ctx, "Marked stale distributed run as FAILED",
 		tag.DAG(dagRun.Name),
@@ -2723,6 +2808,7 @@ func (h *Handler) markRunFailed(ctx context.Context, dagName, dagRunID, reason s
 			tag.DAG(dagName), tag.RunID(dagRunID), tag.Error(err))
 		return
 	}
+	h.finalizeAdmissionForStatus(ctx, dagRunStatus, attempt.ID())
 
 	logger.Warn(ctx, "Marked zombie run as FAILED",
 		tag.DAG(dagName), tag.RunID(dagRunID), slog.String("reason", reason))
@@ -2802,6 +2888,7 @@ func (h *Handler) RequestCancel(ctx context.Context, req *coordinatorv1.RequestC
 			Error:    fmt.Sprintf("failed to finalize cancellation: %v", err),
 		}, nil
 	}
+	h.finalizeAdmissionForAttempt(ctx, attempt)
 
 	logger.Info(ctx, "DAG run cancellation requested successfully")
 	return &coordinatorv1.RequestCancelResponse{Accepted: true}, nil

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -510,10 +510,18 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	if err := h.enqueueOrBindDispatchTask(ctx, admissionToken, dispatchTask); err != nil {
 		h.markPreparedAttemptDispatchFailed(ctx, req.Task, prepared, err)
 		h.releaseAdmissionToken(ctx, admissionToken)
-		return nil, status.Error(codes.Internal, "failed to enqueue task: "+err.Error())
+		return nil, status.Error(dispatchBindErrorCode(err), "failed to enqueue task: "+err.Error())
 	}
 	h.notifyDispatchAvailable()
 	return &coordinatorv1.DispatchResponse{}, nil
+}
+
+func dispatchBindErrorCode(err error) codes.Code {
+	if errors.Is(err, exec.ErrDispatchAdmissionNotFound) ||
+		errors.Is(err, exec.ErrDispatchAdmissionConflict) {
+		return codes.FailedPrecondition
+	}
+	return codes.Internal
 }
 
 func (h *Handler) enqueueOrBindDispatchTask(ctx context.Context, admissionToken string, task *exec.DispatchTask) error {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -34,6 +34,14 @@ func coordinatorTestTimeout(timeout time.Duration) time.Duration {
 	return timeout
 }
 
+func TestDispatchBindErrorCode(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, codes.FailedPrecondition, dispatchBindErrorCode(exec.ErrDispatchAdmissionNotFound))
+	assert.Equal(t, codes.FailedPrecondition, dispatchBindErrorCode(exec.ErrDispatchAdmissionConflict))
+	assert.Equal(t, codes.Internal, dispatchBindErrorCode(errors.New("disk full")))
+}
+
 // mockDAGRunStore is a test implementation of execution.DAGRunStore
 type mockDAGRunStore struct {
 	attempts            map[string]*mockDAGRunAttempt
@@ -774,6 +782,7 @@ func TestHandler_Poll(t *testing.T) {
 
 		_, err = h.Dispatch(ctx, req)
 		require.NoError(t, err)
+		require.NoError(t, dispatchStore.DeleteClaim(ctx, claimed.ClaimToken))
 
 		claimedAgain, err := dispatchStore.ClaimNext(ctx, exec.DispatchTaskClaim{
 			WorkerID:     "worker-1",

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -715,6 +715,75 @@ func TestHandler_Poll(t *testing.T) {
 		assert.Zero(t, count)
 	})
 
+	t.Run("DispatchBindsAdmissionReservationIdempotently", func(t *testing.T) {
+		t.Parallel()
+		registerCommandExecutorCapsForCoordinatorTest()
+
+		ctx := context.Background()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		dispatchStore, leaseStore, activeStore := newTestDispatchAdmissionTaskStore(baseDir)
+		heartbeatStore := newTestWorkerHeartbeatStore(baseDir)
+		require.NoError(t, heartbeatStore.Upsert(ctx, exec.WorkerHeartbeatRecord{
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+		}))
+
+		dagRunStore := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:               dagRunStore,
+			DispatchTaskStore:         dispatchStore,
+			WorkerHeartbeatStore:      heartbeatStore,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+		})
+
+		runRef := exec.NewDAGRunRef("test-dag", "run-123")
+		attemptID := "test-attempt"
+		attemptKey := exec.GenerateAttemptKey(runRef.Name, runRef.ID, runRef.Name, runRef.ID, attemptID)
+		decision, err := dispatchStore.ReserveAdmission(ctx, exec.DispatchAdmissionRequest{
+			QueueName:      "test-queue",
+			MaxConcurrency: 1,
+			AttemptKey:     attemptKey,
+			AttemptID:      attemptID,
+			DAGRun:         runRef,
+			StaleThreshold: time.Minute,
+		})
+		require.NoError(t, err)
+		require.True(t, decision.Reserved)
+
+		req := &coordinatorv1.DispatchRequest{
+			AdmissionReservationToken: decision.ReservationToken,
+			Task: &coordinatorv1.Task{
+				Operation:  coordinatorv1.Operation_OPERATION_RETRY,
+				DagRunId:   runRef.ID,
+				Target:     runRef.Name,
+				Definition: "name: test-dag\nsteps:\n  - name: step1\n    run: echo hello",
+				QueueName:  "test-queue",
+			},
+		}
+		_, err = h.Dispatch(ctx, req)
+		require.NoError(t, err)
+
+		claimed, err := dispatchStore.ClaimNext(ctx, exec.DispatchTaskClaim{
+			WorkerID:     "worker-1",
+			PollerID:     "poller-1",
+			ClaimTimeout: time.Minute,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, claimed)
+
+		_, err = h.Dispatch(ctx, req)
+		require.NoError(t, err)
+
+		claimedAgain, err := dispatchStore.ClaimNext(ctx, exec.DispatchTaskClaim{
+			WorkerID:     "worker-1",
+			PollerID:     "poller-2",
+			ClaimTimeout: time.Minute,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, claimedAgain)
+	})
+
 	t.Run("DispatchMarksNewAttemptFailedWhenEnqueueFails", func(t *testing.T) {
 		t.Parallel()
 		registerCommandExecutorCapsForCoordinatorTest()

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -2690,7 +2690,7 @@ func (a *API) retryDAGRun(ctx context.Context, dagName, dagRunID, retryDagRunID,
 			opts...,
 		)
 
-		if err := a.coordinatorCli.Dispatch(ctx, task); err != nil {
+		if err := a.coordinatorCli.Dispatch(ctx, exec.DispatchRequest{Task: task}); err != nil {
 			return retryDAGRunResult{}, fmt.Errorf("error dispatching retry to coordinator: %w", err)
 		}
 

--- a/internal/service/frontend/api/v1/dagruns_edit_retry.go
+++ b/internal/service/frontend/api/v1/dagruns_edit_retry.go
@@ -857,7 +857,7 @@ func (a *API) dispatchEditRetry(ctx context.Context, dag *core.DAG, status *exec
 		status.DAGRunID,
 		opts...,
 	)
-	if err := a.coordinatorCli.Dispatch(ctx, task); err != nil {
+	if err := a.coordinatorCli.Dispatch(ctx, exec.DispatchRequest{Task: task}); err != nil {
 		return fmt.Errorf("error dispatching edit retry to coordinator: %w", err)
 	}
 	return nil

--- a/internal/service/frontend/api/v1/dagruns_retry_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_retry_internal_test.go
@@ -30,8 +30,8 @@ type retryCoordinatorRecorder struct {
 
 var _ coordinator.Client = (*retryCoordinatorRecorder)(nil)
 
-func (c *retryCoordinatorRecorder) Dispatch(_ context.Context, task *exec.DispatchTask) error {
-	c.dispatched = append(c.dispatched, task)
+func (c *retryCoordinatorRecorder) Dispatch(_ context.Context, req exec.DispatchRequest) error {
+	c.dispatched = append(c.dispatched, req.Task)
 	return c.dispatchErr
 }
 

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1446,7 +1446,7 @@ func (a *API) dispatchStartToCoordinator(ctx context.Context, dag *core.DAG, dag
 		taskOpts...,
 	)
 
-	if err := a.coordinatorCli.Dispatch(ctx, task); err != nil {
+	if err := a.coordinatorCli.Dispatch(ctx, exec.DispatchRequest{Task: task}); err != nil {
 		return fmt.Errorf("error dispatching to coordinator: %w", err)
 	}
 

--- a/internal/service/frontend/api/v1/workers_internal_test.go
+++ b/internal/service/frontend/api/v1/workers_internal_test.go
@@ -25,7 +25,7 @@ type stubCoordinatorClient struct {
 	err     error
 }
 
-func (s *stubCoordinatorClient) Dispatch(context.Context, *exec.DispatchTask) error {
+func (s *stubCoordinatorClient) Dispatch(context.Context, exec.DispatchRequest) error {
 	return nil
 }
 

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -157,7 +157,7 @@ func (e *DAGExecutor) HandleJob(
 	}
 
 	// For all other cases (local execution or non-START operations), use ExecuteDAG
-	return e.executeDAG(ctx, dag, operation, runID, nil, triggerType, stringutil.FormatTime(scheduleTime), profileName)
+	return e.executeDAG(ctx, dag, operation, runID, nil, triggerType, stringutil.FormatTime(scheduleTime), profileName, "")
 }
 
 // ExecuteDAG executes or dispatches an already-persisted DAG.
@@ -178,7 +178,20 @@ func (e *DAGExecutor) ExecuteDAG(
 	triggerType core.TriggerType,
 	scheduleTime string,
 ) error {
-	return e.executeDAG(ctx, dag, operation, runID, previousStatus, triggerType, scheduleTime, "")
+	return e.executeDAG(ctx, dag, operation, runID, previousStatus, triggerType, scheduleTime, "", "")
+}
+
+func (e *DAGExecutor) ExecuteDAGWithAdmission(
+	ctx context.Context,
+	dag *core.DAG,
+	operation exec.DispatchOperation,
+	runID string,
+	previousStatus *exec.DAGRunStatus,
+	triggerType core.TriggerType,
+	scheduleTime string,
+	admissionReservationToken string,
+) error {
+	return e.executeDAG(ctx, dag, operation, runID, previousStatus, triggerType, scheduleTime, "", admissionReservationToken)
 }
 
 func (e *DAGExecutor) executeDAG(
@@ -190,6 +203,7 @@ func (e *DAGExecutor) executeDAG(
 	triggerType core.TriggerType,
 	scheduleTime string,
 	defaultProfileName string,
+	admissionReservationToken string,
 ) error {
 	if err := validateDispatchOperation(operation); err != nil {
 		return err
@@ -234,7 +248,10 @@ func (e *DAGExecutor) executeDAG(
 			runID,
 			taskOpts...,
 		)
-		return e.dispatchToCoordinator(ctx, task)
+		return e.dispatchToCoordinator(ctx, exec.DispatchRequest{
+			Task:                      task,
+			AdmissionReservationToken: admissionReservationToken,
+		})
 	}
 
 	// Local execution
@@ -329,13 +346,14 @@ func (e *DAGExecutor) IsDistributed(dag *core.DAG) bool {
 // 1. Select an appropriate worker based on the task's workerSelector
 // 2. Forward the task to the selected worker
 // 3. Track the execution status
-func (e *DAGExecutor) dispatchToCoordinator(ctx context.Context, task *exec.DispatchTask) error {
+func (e *DAGExecutor) dispatchToCoordinator(ctx context.Context, req exec.DispatchRequest) error {
+	task := req.Task
 	ctx = logger.WithValues(ctx,
 		tag.Target(task.Target),
 		tag.RunID(task.DAGRunID),
 	)
 
-	if err := e.coordinatorCli.Dispatch(ctx, task); err != nil {
+	if err := e.coordinatorCli.Dispatch(ctx, req); err != nil {
 		logger.Error(ctx, "Failed to dispatch task to coordinator",
 			tag.Error(err),
 			slog.String("operation", task.Operation.String()),

--- a/internal/service/scheduler/dag_executor_test.go
+++ b/internal/service/scheduler/dag_executor_test.go
@@ -160,10 +160,10 @@ func TestDAGExecutor_DistributedRetryUsesPreviousStatusParamsList(t *testing.T) 
 		"",
 	)
 	require.NoError(t, err)
-	require.NotNil(t, dispatcher.task)
-	require.Empty(t, dispatcher.task.Params)
-	require.NotNil(t, dispatcher.task.PreviousStatus)
-	require.Equal(t, previousStatus.ParamsList, dispatcher.task.PreviousStatus.ParamsList)
+	require.NotNil(t, dispatcher.req.Task)
+	require.Empty(t, dispatcher.req.Task.Params)
+	require.NotNil(t, dispatcher.req.Task.PreviousStatus)
+	require.Equal(t, previousStatus.ParamsList, dispatcher.req.Task.PreviousStatus.ParamsList)
 }
 
 func TestDAGExecutor_DistributedRetryPassesLegacyQueuedParams(t *testing.T) {
@@ -190,17 +190,42 @@ func TestDAGExecutor_DistributedRetryPassesLegacyQueuedParams(t *testing.T) {
 		"",
 	)
 	require.NoError(t, err)
-	require.NotNil(t, dispatcher.task)
-	require.Equal(t, "content_hash=sha256:abc123", dispatcher.task.Params)
-	require.NotNil(t, dispatcher.task.PreviousStatus)
+	require.NotNil(t, dispatcher.req.Task)
+	require.Equal(t, "content_hash=sha256:abc123", dispatcher.req.Task.Params)
+	require.NotNil(t, dispatcher.req.Task.PreviousStatus)
+}
+
+func TestDAGExecutor_DistributedRetryCarriesAdmissionReservationToken(t *testing.T) {
+	dispatcher := &capturingDispatcher{}
+	dagExecutor := scheduler.NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil)
+
+	dag := &core.DAG{
+		Name:           "admitted-dag",
+		YamlData:       []byte("name: admitted-dag\n"),
+		WorkerSelector: map[string]string{"type": "test-worker"},
+	}
+
+	err := dagExecutor.ExecuteDAGWithAdmission(
+		context.Background(),
+		dag,
+		exec.DispatchOperationRetry,
+		"admitted-run",
+		&exec.DAGRunStatus{Status: core.Queued},
+		core.TriggerTypeManual,
+		"",
+		"reservation-token-a",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, dispatcher.req.Task)
+	require.Equal(t, "reservation-token-a", dispatcher.req.AdmissionReservationToken)
 }
 
 type capturingDispatcher struct {
-	task *exec.DispatchTask
+	req exec.DispatchRequest
 }
 
-func (d *capturingDispatcher) Dispatch(_ context.Context, task *exec.DispatchTask) error {
-	d.task = task
+func (d *capturingDispatcher) Dispatch(_ context.Context, req exec.DispatchRequest) error {
+	d.req = req
 	return nil
 }
 

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -20,38 +20,48 @@ import (
 )
 
 type queueDispatchDeps struct {
-	queueStore          exec.QueueStore
-	dagRunStore         exec.DAGRunStore
-	procStore           exec.ProcStore
-	dagRunLeaseStore    exec.DAGRunLeaseStore
-	dispatchTaskStore   exec.DispatchTaskStore
-	dagExecutor         *DAGExecutor
-	isSuspended         IsSuspendedFunc
-	backoffConfig       BackoffConfig
-	leaseStaleThreshold time.Duration
-	isClosed            func() bool
-	wakeUp              func()
+	queueStore             exec.QueueStore
+	dagRunStore            exec.DAGRunStore
+	procStore              exec.ProcStore
+	dagRunLeaseStore       exec.DAGRunLeaseStore
+	dispatchTaskStore      exec.DispatchTaskStore
+	dispatchAdmissionStore exec.DispatchAdmissionStore
+	dagExecutor            *DAGExecutor
+	isSuspended            IsSuspendedFunc
+	backoffConfig          BackoffConfig
+	leaseStaleThreshold    time.Duration
+	isClosed               func() bool
+	wakeUp                 func()
 }
 
 // queueDispatcher owns queue-item dispatch decisions after a queue has capacity.
 type queueDispatcher struct {
-	queueStore          exec.QueueStore
-	dagRunStore         exec.DAGRunStore
-	procStore           exec.ProcStore
-	dagRunLeaseStore    exec.DAGRunLeaseStore
-	dispatchTaskStore   exec.DispatchTaskStore
-	dagExecutor         *DAGExecutor
-	isSuspended         IsSuspendedFunc
-	backoffConfig       BackoffConfig
-	leaseStaleThreshold time.Duration
-	isClosed            func() bool
-	wakeUp              func()
+	queueStore             exec.QueueStore
+	dagRunStore            exec.DAGRunStore
+	procStore              exec.ProcStore
+	dagRunLeaseStore       exec.DAGRunLeaseStore
+	dispatchTaskStore      exec.DispatchTaskStore
+	dispatchAdmissionStore exec.DispatchAdmissionStore
+	dagExecutor            *DAGExecutor
+	isSuspended            IsSuspendedFunc
+	backoffConfig          BackoffConfig
+	leaseStaleThreshold    time.Duration
+	isClosed               func() bool
+	wakeUp                 func()
 }
 
 type queueDispatchBatch struct {
-	items          []exec.QueuedItemData
-	maxConcurrency int
-	aliveCount     int
+	items                 []exec.QueuedItemData
+	maxConcurrency        int
+	aliveCount            int
+	nonAdmissionOccupancy int
+}
+
+type dispatchAdmissionInput struct {
+	status                *exec.DAGRunStatus
+	maxConcurrency        int
+	nonAdmissionOccupancy int
+	leaseStaleThreshold   time.Duration
 }
 
 func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
@@ -65,17 +75,18 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 		deps.wakeUp = func() {}
 	}
 	return &queueDispatcher{
-		queueStore:          deps.queueStore,
-		dagRunStore:         deps.dagRunStore,
-		procStore:           deps.procStore,
-		dagRunLeaseStore:    deps.dagRunLeaseStore,
-		dispatchTaskStore:   deps.dispatchTaskStore,
-		dagExecutor:         deps.dagExecutor,
-		isSuspended:         deps.isSuspended,
-		backoffConfig:       deps.backoffConfig,
-		leaseStaleThreshold: deps.leaseStaleThreshold,
-		isClosed:            deps.isClosed,
-		wakeUp:              deps.wakeUp,
+		queueStore:             deps.queueStore,
+		dagRunStore:            deps.dagRunStore,
+		procStore:              deps.procStore,
+		dagRunLeaseStore:       deps.dagRunLeaseStore,
+		dispatchTaskStore:      deps.dispatchTaskStore,
+		dispatchAdmissionStore: deps.dispatchAdmissionStore,
+		dagExecutor:            deps.dagExecutor,
+		isSuspended:            deps.isSuspended,
+		backoffConfig:          deps.backoffConfig,
+		leaseStaleThreshold:    deps.leaseStaleThreshold,
+		isClosed:               deps.isClosed,
+		wakeUp:                 deps.wakeUp,
 	}
 }
 
@@ -97,12 +108,16 @@ func (d *queueDispatcher) selectDispatchBatch(
 		logger.Error(ctx, "Failed to count distributed leases", tag.Error(err), tag.Queue(queueName))
 		return queueDispatchBatch{}, fmt.Errorf("count distributed leases: %w", err)
 	}
-	outstandingDispatchCount, err := d.countOutstandingDispatchReservations(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
-		return queueDispatchBatch{}, fmt.Errorf("count outstanding distributed dispatch reservations: %w", err)
-	}
 	aliveCount := localAliveCount + distributedAliveCount
+	outstandingDispatchCount := 0
+	if d.dispatchAdmissionStore == nil {
+		outstandingDispatchCount, err = d.countOutstandingDispatchReservations(ctx, queueName)
+		if err != nil {
+			logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
+			return queueDispatchBatch{}, fmt.Errorf("count outstanding distributed dispatch reservations: %w", err)
+		}
+	}
+	nonAdmissionOccupancy := localAliveCount + inflightCount
 	freeSlots := maxConcurrency - aliveCount - inflightCount - outstandingDispatchCount
 
 	logger.Debug(ctx, "Queue capacity check",
@@ -131,13 +146,21 @@ func (d *queueDispatcher) selectDispatchBatch(
 	}
 
 	return queueDispatchBatch{
-		items:          runnableItems,
-		maxConcurrency: maxConcurrency,
-		aliveCount:     aliveCount,
+		items:                 runnableItems,
+		maxConcurrency:        maxConcurrency,
+		aliveCount:            aliveCount,
+		nonAdmissionOccupancy: nonAdmissionOccupancy,
 	}, nil
 }
 
-func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.QueuedItemData, queueName string, incInflight, decInflight func()) bool {
+func (d *queueDispatcher) dispatchQueuedItem(
+	ctx context.Context,
+	item exec.QueuedItemData,
+	queueName string,
+	batch queueDispatchBatch,
+	incInflight,
+	decInflight func(),
+) bool {
 	if d.isClosed() {
 		return false
 	}
@@ -219,7 +242,16 @@ func (d *queueDispatcher) dispatchQueuedItem(ctx context.Context, item exec.Queu
 	defer decInflight()
 
 	if d.dagExecutor.IsDistributed(dag) {
-		return d.dispatchAndWaitForStartup(ctx, queueName, runRef, dag, runID, status)
+		token, reserved := d.reserveDistributedAdmission(ctx, queueName, runRef, attempt, dispatchAdmissionInput{
+			status:                status,
+			maxConcurrency:        batch.maxConcurrency,
+			nonAdmissionOccupancy: batch.nonAdmissionOccupancy,
+			leaseStaleThreshold:   d.leaseStaleThresholdOrDefault(),
+		})
+		if !reserved {
+			return false
+		}
+		return d.dispatchAndWaitForStartup(ctx, queueName, runRef, dag, runID, status, token)
 	}
 
 	execErrCh := make(chan error, 1)
@@ -309,6 +341,7 @@ func (d *queueDispatcher) dispatchAndWaitForStartup(
 	dag *core.DAG,
 	runID string,
 	dagStatus *exec.DAGRunStatus,
+	admissionReservationToken string,
 ) bool {
 	policy := backoff.NewExponentialBackoffPolicy(d.backoffConfig.InitialInterval)
 	policy.MaxInterval = d.backoffConfig.MaxInterval
@@ -325,8 +358,8 @@ func (d *queueDispatcher) dispatchAndWaitForStartup(
 		}
 
 		if !dispatched {
-			err := d.dagExecutor.ExecuteDAG(ctx, dag, exec.DispatchOperationRetry,
-				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime)
+			err := d.dagExecutor.ExecuteDAGWithAdmission(ctx, dag, exec.DispatchOperationRetry,
+				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime, admissionReservationToken)
 			if err != nil {
 				var staleErr *exec.StaleQueueDispatchError
 				if errors.As(err, &staleErr) {
@@ -350,6 +383,7 @@ func (d *queueDispatcher) dispatchAndWaitForStartup(
 	}
 
 	if err := backoff.Retry(retryCtx, operation, policy, nil); err != nil {
+		d.releaseAdmissionToken(ctx, admissionReservationToken)
 		var staleErr *exec.StaleQueueDispatchError
 		if errors.As(err, &staleErr) {
 			logger.Info(ctx, "Discarding stale distributed queue dispatch",
@@ -365,6 +399,78 @@ func (d *queueDispatcher) dispatchAndWaitForStartup(
 
 	defer d.wakeUp()
 	return started
+}
+
+func (d *queueDispatcher) reserveDistributedAdmission(
+	ctx context.Context,
+	queueName string,
+	runRef exec.DAGRunRef,
+	attempt exec.DAGRunAttempt,
+	input dispatchAdmissionInput,
+) (string, bool) {
+	if d.dispatchAdmissionStore == nil {
+		return "", true
+	}
+	if input.status == nil {
+		return "", false
+	}
+	attemptID := input.status.AttemptID
+	if attemptID == "" && attempt != nil {
+		attemptID = attempt.ID()
+	}
+	attemptKey := queueAttemptKey(runRef, attempt, input.status)
+	if attemptKey == "" || attemptID == "" {
+		logger.Warn(ctx, "Skipping distributed queue dispatch because admission identity is incomplete",
+			tag.RunID(runRef.ID),
+			tag.Queue(queueName),
+		)
+		return "", false
+	}
+	decision, err := d.dispatchAdmissionStore.ReserveAdmission(ctx, exec.DispatchAdmissionRequest{
+		QueueName:             queueName,
+		MaxConcurrency:        input.maxConcurrency,
+		NonAdmissionOccupancy: input.nonAdmissionOccupancy,
+		AttemptKey:            attemptKey,
+		AttemptID:             attemptID,
+		DAGRun:                runRef,
+		StaleThreshold:        input.leaseStaleThreshold,
+	})
+	if err != nil {
+		logger.Error(ctx, "Failed to reserve distributed queue admission",
+			tag.Error(err),
+			tag.RunID(runRef.ID),
+			tag.Queue(queueName),
+		)
+		return "", false
+	}
+	if decision == nil || !decision.Reserved {
+		reason := ""
+		if decision != nil {
+			reason = string(decision.Reason)
+		}
+		logger.Debug(ctx, "Distributed queue admission rejected",
+			tag.RunID(runRef.ID),
+			tag.Queue(queueName),
+			slog.String("reason", reason),
+		)
+		return "", false
+	}
+	return decision.ReservationToken, true
+}
+
+func (d *queueDispatcher) releaseAdmissionToken(ctx context.Context, token string) {
+	if token == "" || d.dispatchAdmissionStore == nil {
+		return
+	}
+	err := d.dispatchAdmissionStore.ReleaseAdmissionToken(context.WithoutCancel(ctx), token)
+	if err == nil ||
+		errors.Is(err, exec.ErrDispatchAdmissionConflict) ||
+		errors.Is(err, exec.ErrDispatchAdmissionNotFound) {
+		return
+	}
+	logger.Warn(ctx, "Failed to release distributed queue admission reservation",
+		tag.Error(err),
+	)
 }
 
 func (d *queueDispatcher) waitForStartup(ctx context.Context, queueName string, runRef exec.DAGRunRef, waitState startupWaitState) bool {
@@ -490,7 +596,7 @@ func (d *queueDispatcher) selectRunnableQueueItems(
 			logger.Error(ctx, "Failed to get item data while selecting runnable queue items", tag.Error(err))
 			continue
 		}
-		if d.dispatchTaskStore != nil {
+		if d.dispatchAdmissionStore == nil && d.dispatchTaskStore != nil {
 			reserved, err := d.hasOutstandingDispatchReservation(ctx, *runRef)
 			if err != nil {
 				return nil, err

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -61,7 +61,6 @@ type dispatchAdmissionInput struct {
 	status                *exec.DAGRunStatus
 	maxConcurrency        int
 	nonAdmissionOccupancy int
-	leaseStaleThreshold   time.Duration
 }
 
 func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
@@ -246,7 +245,6 @@ func (d *queueDispatcher) dispatchQueuedItem(
 			status:                status,
 			maxConcurrency:        batch.maxConcurrency,
 			nonAdmissionOccupancy: batch.nonAdmissionOccupancy,
-			leaseStaleThreshold:   d.leaseStaleThresholdOrDefault(),
 		})
 		if !reserved {
 			return false
@@ -433,7 +431,7 @@ func (d *queueDispatcher) reserveDistributedAdmission(
 		AttemptKey:            attemptKey,
 		AttemptID:             attemptID,
 		DAGRun:                runRef,
-		StaleThreshold:        input.leaseStaleThreshold,
+		StaleThreshold:        d.leaseStaleThresholdOrDefault(),
 	})
 	if err != nil {
 		logger.Error(ctx, "Failed to reserve distributed queue admission",

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -140,6 +140,7 @@ func WithDAGRunLeaseStore(store exec.DAGRunLeaseStore) QueueProcessorOption {
 func WithDispatchTaskStore(store exec.DispatchTaskStore) QueueProcessorOption {
 	return func(p *QueueProcessor) {
 		p.dispatchTaskStore = store
+		p.dispatchAdmissionStore = nil
 		if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
 			p.dispatchAdmissionStore = admissionStore
 		}

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -66,22 +66,23 @@ func (s startupWaitState) executionDone() (bool, error) {
 
 // QueueProcessor is responsible for processing queued DAG runs.
 type QueueProcessor struct {
-	queueStore          exec.QueueStore
-	dagRunStore         exec.DAGRunStore
-	procStore           exec.ProcStore
-	dagRunLeaseStore    exec.DAGRunLeaseStore
-	dispatchTaskStore   exec.DispatchTaskStore
-	dagExecutor         *DAGExecutor
-	isSuspended         IsSuspendedFunc
-	queues              sync.Map // map[string]*queue
-	wakeUpCh            chan struct{}
-	quit                chan struct{}
-	wg                  sync.WaitGroup
-	stopOnce            sync.Once
-	prevTime            time.Time
-	lock                sync.Mutex
-	backoffConfig       BackoffConfig
-	leaseStaleThreshold time.Duration
+	queueStore             exec.QueueStore
+	dagRunStore            exec.DAGRunStore
+	procStore              exec.ProcStore
+	dagRunLeaseStore       exec.DAGRunLeaseStore
+	dispatchTaskStore      exec.DispatchTaskStore
+	dispatchAdmissionStore exec.DispatchAdmissionStore
+	dagExecutor            *DAGExecutor
+	isSuspended            IsSuspendedFunc
+	queues                 sync.Map // map[string]*queue
+	wakeUpCh               chan struct{}
+	quit                   chan struct{}
+	wg                     sync.WaitGroup
+	stopOnce               sync.Once
+	prevTime               time.Time
+	lock                   sync.Mutex
+	backoffConfig          BackoffConfig
+	leaseStaleThreshold    time.Duration
 }
 
 type queue struct {
@@ -139,6 +140,15 @@ func WithDAGRunLeaseStore(store exec.DAGRunLeaseStore) QueueProcessorOption {
 func WithDispatchTaskStore(store exec.DispatchTaskStore) QueueProcessorOption {
 	return func(p *QueueProcessor) {
 		p.dispatchTaskStore = store
+		if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
+			p.dispatchAdmissionStore = admissionStore
+		}
+	}
+}
+
+func WithDispatchAdmissionStore(store exec.DispatchAdmissionStore) QueueProcessorOption {
+	return func(p *QueueProcessor) {
+		p.dispatchAdmissionStore = store
 	}
 }
 
@@ -302,17 +312,18 @@ func (p *QueueProcessor) isClosed() bool {
 
 func (p *QueueProcessor) newQueueDispatcher() *queueDispatcher {
 	return newQueueDispatcher(queueDispatchDeps{
-		queueStore:          p.queueStore,
-		dagRunStore:         p.dagRunStore,
-		procStore:           p.procStore,
-		dagRunLeaseStore:    p.dagRunLeaseStore,
-		dispatchTaskStore:   p.dispatchTaskStore,
-		dagExecutor:         p.dagExecutor,
-		isSuspended:         p.isSuspended,
-		backoffConfig:       p.backoffConfig,
-		leaseStaleThreshold: p.leaseStaleThreshold,
-		isClosed:            p.isClosed,
-		wakeUp:              p.wakeUp,
+		queueStore:             p.queueStore,
+		dagRunStore:            p.dagRunStore,
+		procStore:              p.procStore,
+		dagRunLeaseStore:       p.dagRunLeaseStore,
+		dispatchTaskStore:      p.dispatchTaskStore,
+		dispatchAdmissionStore: p.dispatchAdmissionStore,
+		dagExecutor:            p.dagExecutor,
+		isSuspended:            p.isSuspended,
+		backoffConfig:          p.backoffConfig,
+		leaseStaleThreshold:    p.leaseStaleThreshold,
+		isClosed:               p.isClosed,
+		wakeUp:                 p.wakeUp,
 	})
 }
 
@@ -368,7 +379,7 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 					logger.Error(ctx, "Queue item processing panicked", tag.Error(panicToError(r)))
 				}
 			}()
-			if !dispatcher.dispatchQueuedItem(ctx, queuedItem, queueName, q.incInflight, q.decInflight) {
+			if !dispatcher.dispatchQueuedItem(ctx, queuedItem, queueName, batch, q.incInflight, q.decInflight) {
 				return
 			}
 			data, err := queuedItem.Data()

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -140,10 +140,7 @@ func WithDAGRunLeaseStore(store exec.DAGRunLeaseStore) QueueProcessorOption {
 func WithDispatchTaskStore(store exec.DispatchTaskStore) QueueProcessorOption {
 	return func(p *QueueProcessor) {
 		p.dispatchTaskStore = store
-		p.dispatchAdmissionStore = nil
-		if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
-			p.dispatchAdmissionStore = admissionStore
-		}
+		p.dispatchAdmissionStore = dispatchAdmissionStoreFromTaskStore(store)
 	}
 }
 
@@ -151,6 +148,11 @@ func WithDispatchAdmissionStore(store exec.DispatchAdmissionStore) QueueProcesso
 	return func(p *QueueProcessor) {
 		p.dispatchAdmissionStore = store
 	}
+}
+
+func dispatchAdmissionStoreFromTaskStore(store exec.DispatchTaskStore) exec.DispatchAdmissionStore {
+	admissionStore, _ := store.(exec.DispatchAdmissionStore)
+	return admissionStore
 }
 
 // WithIsSuspended sets the suspend-flag checker used by the queue processor.

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	osexec "os/exec"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -292,15 +293,26 @@ func TestIsPreStartExecutionFailure(t *testing.T) {
 // mockDispatcher implements exec.Dispatcher for testing dispatch behavior.
 type mockDispatcher struct {
 	callCount atomic.Int32
+	mu        sync.Mutex
+	lastReq   exec.DispatchRequest
 	errFunc   func(callNum int32) error
 }
 
-func (m *mockDispatcher) Dispatch(_ context.Context, _ *exec.DispatchTask) error {
+func (m *mockDispatcher) Dispatch(_ context.Context, req exec.DispatchRequest) error {
+	m.mu.Lock()
+	m.lastReq = req
+	m.mu.Unlock()
 	n := m.callCount.Add(1)
 	if m.errFunc != nil {
 		return m.errFunc(n)
 	}
 	return nil
+}
+
+func (m *mockDispatcher) LastRequest() exec.DispatchRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastReq
 }
 
 func (m *mockDispatcher) Cleanup(_ context.Context) error { return nil }
@@ -347,7 +359,7 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_TransientRetryThenSuccess(t *
 		},
 	})
 
-	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
 	require.True(t, started)
 	require.GreaterOrEqual(t, disp.callCount.Load(), int32(3))
 	procStore.AssertExpectations(t)
@@ -382,7 +394,7 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded
 		},
 	})
 
-	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
 	require.True(t, started)
 	require.Equal(t, int32(1), disp.callCount.Load())
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
@@ -415,7 +427,7 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_RawStaleQueueDispatchStopsRet
 		},
 	})
 
-	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
 	require.True(t, started)
 	require.Equal(t, int32(1), disp.callCount.Load())
 	procStore.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
@@ -449,7 +461,7 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_PermanentErrorStopsRetry(t *t
 		},
 	})
 
-	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status)
+	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
 	require.False(t, started)
 	// Should have been called exactly once (permanent error stops retries).
 	require.Equal(t, int32(1), disp.callCount.Load())

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -436,6 +436,47 @@ func TestQueueProcessor_StaleOutstandingDispatchReservationsExpire(t *testing.T)
 	assert.Empty(t, pendingEntries)
 }
 
+func TestQueueDispatcher_DistributedDispatchReservesAdmissionToken(t *testing.T) {
+	f := newQueueFixture(t).withDAG("distributed-admission-dag", 1)
+	f.enqueueRuns(1)
+
+	activeStore := store.NewActiveDistributedRunStore(file.NewCollection(filepath.Join(f.distributedDir, "active-runs")))
+	dispatchStore := store.NewDispatchTaskStore(
+		file.NewCollection(f.distributedDir),
+		store.WithDispatchAdmissionLiveness(f.leaseStore, activeStore),
+	)
+
+	items, err := f.queueStore.List(f.ctx, f.dag.Name)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	runRef := exec.NewDAGRunRef(f.dag.Name, "run-1")
+	procStore := &mockProcStore{}
+	procStore.On("IsRunAlive", mock.Anything, f.dag.Name, runRef).Return(false, nil).Once()
+	procStore.On("IsRunAlive", mock.Anything, f.dag.Name, runRef).Return(true, nil).Once()
+	dispatcher := &mockDispatcher{}
+
+	queueDispatcher := newQueueDispatcher(queueDispatchDeps{
+		queueStore:             f.queueStore,
+		dagRunStore:            f.dagRunStore,
+		procStore:              procStore,
+		dagRunLeaseStore:       f.leaseStore,
+		dispatchTaskStore:      dispatchStore,
+		dispatchAdmissionStore: dispatchStore,
+		dagExecutor:            NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "", nil),
+		backoffConfig:          BackoffConfig{InitialInterval: 10 * time.Millisecond, MaxInterval: 50 * time.Millisecond, MaxRetries: 2, StartupGracePeriod: time.Second},
+		leaseStaleThreshold:    time.Minute,
+	})
+
+	dispatched := queueDispatcher.dispatchQueuedItem(f.ctx, items[0], f.dag.Name, queueDispatchBatch{
+		maxConcurrency:        1,
+		nonAdmissionOccupancy: 0,
+	}, func() {}, func() {})
+	require.True(t, dispatched)
+	assert.NotEmpty(t, dispatcher.LastRequest().AdmissionReservationToken)
+	procStore.AssertExpectations(t)
+}
+
 func TestQueueProcessor_SuspendedSchedulerManagedQueuedRunsAreAbortedAndDequeued(t *testing.T) {
 	triggers := []core.TriggerType{
 		core.TriggerTypeScheduler,
@@ -502,7 +543,10 @@ func TestQueueProcessor_SuspendedManualQueuedRunStillDispatches(t *testing.T) {
 		},
 	})
 
-	dispatched := queueDispatcher.dispatchQueuedItem(f.ctx, items[0], dagName, func() {}, func() {})
+	dispatched := queueDispatcher.dispatchQueuedItem(f.ctx, items[0], dagName, queueDispatchBatch{
+		maxConcurrency:        1,
+		nonAdmissionOccupancy: 0,
+	}, func() {}, func() {})
 	require.True(t, dispatched)
 	assert.Equal(t, int32(1), dispatcher.callCount.Load())
 

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -97,6 +97,32 @@ func newSchedulerTestProcStore(procDir string, cfg *config.Config) exec.ProcStor
 	return proc.New(procDir, opts...)
 }
 
+func TestWithDispatchTaskStoreClearsAdmissionStore(t *testing.T) {
+	t.Parallel()
+
+	distributedDir := filepath.Join(t.TempDir(), "distributed")
+	admissionStore := store.NewDispatchTaskStore(file.NewCollection(distributedDir))
+	processor := &QueueProcessor{dispatchAdmissionStore: admissionStore}
+
+	WithDispatchTaskStore(&mockDispatchTaskStore{})(processor)
+
+	assert.Nil(t, processor.dispatchAdmissionStore)
+}
+
+func TestSchedulerSetDispatchTaskStoreClearsAdmissionStore(t *testing.T) {
+	t.Parallel()
+
+	distributedDir := filepath.Join(t.TempDir(), "distributed")
+	admissionStore := store.NewDispatchTaskStore(file.NewCollection(distributedDir))
+	scheduler := &Scheduler{
+		queueProcessor: &QueueProcessor{dispatchAdmissionStore: admissionStore},
+	}
+
+	scheduler.SetDispatchTaskStore(&mockDispatchTaskStore{})
+
+	assert.Nil(t, scheduler.queueProcessor.dispatchAdmissionStore)
+}
+
 func (f *queueFixture) withDAG(name string, maxActiveRuns int) *queueFixture {
 	f.dag = &core.DAG{
 		Name: name, MaxActiveRuns: maxActiveRuns,

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -330,10 +330,7 @@ func (s *Scheduler) SetDispatchTaskStore(store exec.DispatchTaskStore) {
 		return
 	}
 	s.queueProcessor.dispatchTaskStore = store
-	s.queueProcessor.dispatchAdmissionStore = nil
-	if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
-		s.queueProcessor.dispatchAdmissionStore = admissionStore
-	}
+	s.queueProcessor.dispatchAdmissionStore = dispatchAdmissionStoreFromTaskStore(store)
 }
 
 // SetRestartFunc overrides the planner's restart function for testing purposes.

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -330,6 +330,7 @@ func (s *Scheduler) SetDispatchTaskStore(store exec.DispatchTaskStore) {
 		return
 	}
 	s.queueProcessor.dispatchTaskStore = store
+	s.queueProcessor.dispatchAdmissionStore = nil
 	if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
 		s.queueProcessor.dispatchAdmissionStore = admissionStore
 	}

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -330,6 +330,9 @@ func (s *Scheduler) SetDispatchTaskStore(store exec.DispatchTaskStore) {
 		return
 	}
 	s.queueProcessor.dispatchTaskStore = store
+	if admissionStore, ok := store.(exec.DispatchAdmissionStore); ok {
+		s.queueProcessor.dispatchAdmissionStore = admissionStore
+	}
 }
 
 // SetRestartFunc overrides the planner's restart function for testing purposes.

--- a/internal/service/worker/coordreport/status_pusher_test.go
+++ b/internal/service/worker/coordreport/status_pusher_test.go
@@ -38,7 +38,7 @@ func (m *mockCoordinatorClient) ReportStatus(ctx context.Context, req *coordinat
 }
 
 // Stub methods for interface compliance - panic if called unexpectedly
-func (m *mockCoordinatorClient) Dispatch(_ context.Context, _ *exec.DispatchTask) error {
+func (m *mockCoordinatorClient) Dispatch(_ context.Context, _ exec.DispatchRequest) error {
 	panic("Dispatch not implemented in mock")
 }
 

--- a/internal/service/worker/poller_test.go
+++ b/internal/service/worker/poller_test.go
@@ -410,13 +410,13 @@ func (m *mockCoordinatorCli) Poll(ctx context.Context, policy backoff.RetryPolic
 	return nil, nil
 }
 
-func (m *mockCoordinatorCli) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
+func (m *mockCoordinatorCli) Dispatch(ctx context.Context, req exec.DispatchRequest) error {
 	m.mu.Lock()
 	dispatchFunc := m.DispatchFunc
 	m.mu.Unlock()
 
 	if dispatchFunc != nil {
-		return dispatchFunc(ctx, task)
+		return dispatchFunc(ctx, req.Task)
 	}
 	return nil
 }

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -410,9 +410,9 @@ func (m *mockRemoteCoordinatorClient) GetDAG(ctx context.Context, name string) (
 	return "", nil
 }
 
-func (m *mockRemoteCoordinatorClient) Dispatch(ctx context.Context, task *exec.DispatchTask) error {
+func (m *mockRemoteCoordinatorClient) Dispatch(ctx context.Context, req exec.DispatchRequest) error {
 	if m.DispatchFunc != nil {
-		return m.DispatchFunc(ctx, task)
+		return m.DispatchFunc(ctx, req.Task)
 	}
 	return nil
 }

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -238,7 +238,7 @@ func (r *Runner) dispatchStart(ctx context.Context, req executor.SubWorkflowRequ
 		slog.Any("worker-selector", task.WorkerSelector),
 	)
 
-	if err := r.dispatcher.Dispatch(ctx, task); err != nil {
+	if err := r.dispatcher.Dispatch(ctx, exec.DispatchRequest{Task: task}); err != nil {
 		return fmt.Errorf("failed to dispatch task: %w", err)
 	}
 	return nil
@@ -272,7 +272,7 @@ func (r *Runner) dispatchRetryWithStatus(
 		slog.Any("worker-selector", task.WorkerSelector),
 	)
 
-	if err := r.dispatcher.Dispatch(ctx, task); err != nil {
+	if err := r.dispatcher.Dispatch(ctx, exec.DispatchRequest{Task: task}); err != nil {
 		return fmt.Errorf("failed to dispatch retry task: %w", err)
 	}
 	return nil

--- a/internal/subflow/runner_test.go
+++ b/internal/subflow/runner_test.go
@@ -358,8 +358,8 @@ type cancelRequest struct {
 	root *exec.DAGRunRef
 }
 
-func (m *mockDispatcher) Dispatch(_ context.Context, task *exec.DispatchTask) error {
-	m.dispatches = append(m.dispatches, task)
+func (m *mockDispatcher) Dispatch(_ context.Context, req exec.DispatchRequest) error {
+	m.dispatches = append(m.dispatches, req.Task)
 	return nil
 }
 

--- a/proto/coordinator/v1/coordinator.pb.go
+++ b/proto/coordinator/v1/coordinator.pb.go
@@ -322,10 +322,11 @@ func (b0 PollResponse_builder) Build() *PollResponse {
 
 // Request message for dispatching a task.
 type DispatchRequest struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	Task          *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                     protoimpl.MessageState `protogen:"hybrid.v1"`
+	Task                      *Task                  `protobuf:"bytes,1,opt,name=task,proto3" json:"task,omitempty"`
+	AdmissionReservationToken string                 `protobuf:"bytes,2,opt,name=admission_reservation_token,json=admissionReservationToken,proto3" json:"admission_reservation_token,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *DispatchRequest) Reset() {
@@ -360,8 +361,19 @@ func (x *DispatchRequest) GetTask() *Task {
 	return nil
 }
 
+func (x *DispatchRequest) GetAdmissionReservationToken() string {
+	if x != nil {
+		return x.AdmissionReservationToken
+	}
+	return ""
+}
+
 func (x *DispatchRequest) SetTask(v *Task) {
 	x.Task = v
+}
+
+func (x *DispatchRequest) SetAdmissionReservationToken(v string) {
+	x.AdmissionReservationToken = v
 }
 
 func (x *DispatchRequest) HasTask() bool {
@@ -378,7 +390,8 @@ func (x *DispatchRequest) ClearTask() {
 type DispatchRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Task *Task
+	Task                      *Task
+	AdmissionReservationToken string
 }
 
 func (b0 DispatchRequest_builder) Build() *DispatchRequest {
@@ -386,6 +399,7 @@ func (b0 DispatchRequest_builder) Build() *DispatchRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.Task = b.Task
+	x.AdmissionReservationToken = b.AdmissionReservationToken
 	return m0
 }
 
@@ -4808,9 +4822,10 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"8\n" +
 	"\fPollResponse\x12(\n" +
-	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\";\n" +
+	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\"{\n" +
 	"\x0fDispatchRequest\x12(\n" +
-	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\"\x12\n" +
+	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\x12>\n" +
+	"\x1badmission_reservation_token\x18\x02 \x01(\tR\x19admissionReservationToken\"\x12\n" +
 	"\x10DispatchResponse\"\xb0\v\n" +
 	"\x04Task\x127\n" +
 	"\toperation\x18\x06 \x01(\x0e2\x19.coordinator.v1.OperationR\toperation\x12)\n" +

--- a/proto/coordinator/v1/coordinator.proto
+++ b/proto/coordinator/v1/coordinator.proto
@@ -88,6 +88,7 @@ message PollResponse {
 // Request message for dispatching a task.
 message DispatchRequest {
   Task task = 1;
+  string admission_reservation_token = 2;
 }
 
 // Response message for dispatching a task.

--- a/proto/coordinator/v1/coordinator_protoopaque.pb.go
+++ b/proto/coordinator/v1/coordinator_protoopaque.pb.go
@@ -322,10 +322,11 @@ func (b0 PollResponse_builder) Build() *PollResponse {
 
 // Request message for dispatching a task.
 type DispatchRequest struct {
-	state           protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Task *Task                  `protobuf:"bytes,1,opt,name=task,proto3"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state                                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Task                      *Task                  `protobuf:"bytes,1,opt,name=task,proto3"`
+	xxx_hidden_AdmissionReservationToken string                 `protobuf:"bytes,2,opt,name=admission_reservation_token,json=admissionReservationToken,proto3"`
+	unknownFields                        protoimpl.UnknownFields
+	sizeCache                            protoimpl.SizeCache
 }
 
 func (x *DispatchRequest) Reset() {
@@ -360,8 +361,19 @@ func (x *DispatchRequest) GetTask() *Task {
 	return nil
 }
 
+func (x *DispatchRequest) GetAdmissionReservationToken() string {
+	if x != nil {
+		return x.xxx_hidden_AdmissionReservationToken
+	}
+	return ""
+}
+
 func (x *DispatchRequest) SetTask(v *Task) {
 	x.xxx_hidden_Task = v
+}
+
+func (x *DispatchRequest) SetAdmissionReservationToken(v string) {
+	x.xxx_hidden_AdmissionReservationToken = v
 }
 
 func (x *DispatchRequest) HasTask() bool {
@@ -378,7 +390,8 @@ func (x *DispatchRequest) ClearTask() {
 type DispatchRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Task *Task
+	Task                      *Task
+	AdmissionReservationToken string
 }
 
 func (b0 DispatchRequest_builder) Build() *DispatchRequest {
@@ -386,6 +399,7 @@ func (b0 DispatchRequest_builder) Build() *DispatchRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Task = b.Task
+	x.xxx_hidden_AdmissionReservationToken = b.AdmissionReservationToken
 	return m0
 }
 
@@ -4795,9 +4809,10 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"8\n" +
 	"\fPollResponse\x12(\n" +
-	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\";\n" +
+	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\"{\n" +
 	"\x0fDispatchRequest\x12(\n" +
-	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\"\x12\n" +
+	"\x04task\x18\x01 \x01(\v2\x14.coordinator.v1.TaskR\x04task\x12>\n" +
+	"\x1badmission_reservation_token\x18\x02 \x01(\tR\x19admissionReservationToken\"\x12\n" +
 	"\x10DispatchResponse\"\xb0\v\n" +
 	"\x04Task\x127\n" +
 	"\toperation\x18\x06 \x01(\x0e2\x19.coordinator.v1.OperationR\toperation\x12)\n" +


### PR DESCRIPTION
## Summary

- add durable dispatch admission reservations and binding tokens for distributed queue dispatch
- pass admission tokens through scheduler, coordinator RPC, and dispatch call sites
- add store, scheduler, coordinator, and API test coverage for admission capacity, idempotency, expiry, cleanup, and retry paths

## Testing

- make protoc
- make fmt
- go test ./internal/persis/store ./internal/service/scheduler ./internal/service/coordinator ./internal/service/frontend/api/v1 ./internal/service/worker ./internal/service/worker/coordreport ./internal/subflow ./internal/engine -count=1
- go test ./internal/... -run TestDoesNotExist -count=1
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable, token-based admission for distributed dispatch with a simplified reserved/binding/bound state. Updates the dispatch API and coordinator to reserve, bind, and finalize tokens end-to-end for stronger capacity control and idempotency.

- **New Features**
  - Added durable admission in `persis/store` with `ReserveAdmission`, `BindAdmission`, `ReleaseAdmissionToken`, and `FinalizeAdmissionAttempt`, plus cleanup. Simplified admission state to reserved/binding/bound.
  - Scheduler reserves before dispatch, passes the token via `exec.DispatchRequest`, releases on failure; occupancy includes inflight and legacy pending/claims/leases; auto-wires admission when the store implements `DispatchAdmissionStore`.
  - Coordinator accepts the token in gRPC `DispatchRequest`, atomically binds it on enqueue, finalizes on terminal status/cancel, releases on failures, and maps missing/conflict to `FailedPrecondition` with clear errors; binding is idempotent.
  - `DispatchTaskStore` now implements `DispatchAdmissionStore`; `WithDispatchAdmissionLiveness(leaseStore, activeRunStore)` enables cross-process liveness checks.
  - Client `Dispatch` now sends `AdmissionReservationToken`; proto `coordinator.v1.DispatchRequest` adds `admission_reservation_token`.
  - Expanded tests for capacity, idempotency (including bind), expiry, cleanup, and retry across store, scheduler, coordinator, and API.

- **Migration**
  - Replace `Dispatch(ctx, *exec.DispatchTask)` with `Dispatch(ctx, exec.DispatchRequest)` at all call sites.
  - Regenerate protobufs to include `admission_reservation_token`.
  - If using admission, construct `DispatchTaskStore` with `WithDispatchAdmissionLiveness(leaseStore, activeRunStore)`; tokens are optional for setups that don’t use admission.

<sup>Written for commit a3a5d5f087977392ccecc6a0bac266cf0e3c8cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced distributed dispatch admission system for managing task queue capacity with reservation tokens and duplicate detection.
  * Integrated admission reservation and binding throughout distributed execution paths to enforce concurrency limits during dispatch.
  * Enhanced capacity accounting to include both reservation-based and legacy occupancy sources for improved slot management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->