### PR TITLE
feat: implement dynamic evaluation syntax and conformance tests

### DIFF
--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -74,7 +74,12 @@ func (r *Runner) run(extraEnv []string, args ...string) *Result {
 
 	err := cmd.Run()
 	if ctx.Err() != nil {
-		r.t.Fatalf("dagu command timed out: dagu %s", strings.Join(args, " "))
+		r.t.Fatalf(
+			"dagu command timed out: dagu %s\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "),
+			stdout.String(),
+			stderr.String(),
+		)
 	}
 
 	exitCode := 0
@@ -380,8 +385,9 @@ func isolatedEnv(t *testing.T) []string {
 		"USERPROFILE="+home,
 	)
 	if runtime.GOOS == "windows" {
-		// The conformance fixtures use POSIX shell snippets. GitHub-hosted
-		// Windows runners provide Bash through Git for Windows.
+		// Most conformance fixtures use POSIX shell snippets. GitHub-hosted
+		// Windows runners provide Bash through Git for Windows; Windows-specific
+		// suites can override this default with RunWithEnv.
 		env = append(env, "DAGU_DEFAULT_SHELL=bash")
 	}
 

--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -48,6 +48,17 @@ func NewRunner(t *testing.T) *Runner {
 // Run executes the configured Dagu binary inside the isolated project.
 func (r *Runner) Run(args ...string) *Result {
 	r.t.Helper()
+	return r.run(nil, args...)
+}
+
+// RunWithEnv executes the configured Dagu binary with extra environment entries.
+func (r *Runner) RunWithEnv(env []string, args ...string) *Result {
+	r.t.Helper()
+	return r.run(env, args...)
+}
+
+func (r *Runner) run(extraEnv []string, args ...string) *Result {
+	r.t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -57,7 +68,7 @@ func (r *Runner) Run(args ...string) *Result {
 	// Binary-level tests intentionally execute the configured Dagu binary.
 	cmd := exec.CommandContext(ctx, daguBinary(r.t), args...) //nolint:gosec
 	cmd.Dir = r.dir
-	cmd.Env = append(isolatedEnv(r.t), "PWD="+r.dir)
+	cmd.Env = appendEnv(append(isolatedEnv(r.t), "PWD="+r.dir), extraEnv...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
@@ -81,6 +92,37 @@ func (r *Runner) Run(args ...string) *Result {
 		stdout:   stdout.String(),
 		stderr:   stderr.String(),
 	}
+}
+
+func appendEnv(env []string, extra ...string) []string {
+	result := append([]string(nil), env...)
+	for _, entry := range extra {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			result = removeEnvKey(result, key)
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func removeEnvKey(env []string, key string) []string {
+	result := env[:0]
+	for _, entry := range env {
+		entryKey, _, ok := strings.Cut(entry, "=")
+		if ok && sameEnvKey(entryKey, key) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func sameEnvKey(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 // ExpectNoFile fails the test when name exists in the isolated project.

--- a/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
+++ b/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec011_dynamic_evaluation_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/harness"
+)
+
+type runtimeCase struct {
+	name    string
+	file    string
+	output  string
+	content string
+	setup   func(*testing.T)
+}
+
+func TestRuntimeDynamicEvaluation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixtures use POSIX command snippets")
+	}
+
+	cases := []runtimeCase{
+		{
+			name:    "backtick substitution populates param",
+			file:    "params_eval_backtick.yaml",
+			output:  "backtick.txt",
+			content: "20260131\n",
+		},
+		{
+			name:    "dollar paren substitution populates param",
+			file:    "params_eval_dollar.yaml",
+			output:  "dollar.txt",
+			content: "20260131\n",
+		},
+		{
+			name:    "dagu refs resolve before command substitution",
+			file:    "params_eval_reference_order.yaml",
+			output:  "reference-order.txt",
+			content: "prod-api\n",
+		},
+		{
+			name:   "scoped env resolves before command substitution",
+			file:   "params_eval_env_order.yaml",
+			output: "env-order.txt",
+			setup: func(t *testing.T) {
+				t.Setenv("SPEC011_DYNAMIC_VALUE", "scope")
+			},
+			content: "scope-prod\n",
+		},
+		{
+			name:    "failed eval falls back to default",
+			file:    "params_eval_failure_fallback.yaml",
+			output:  "fallback.txt",
+			content: "fallback-date\n",
+		},
+		{
+			name:    "dollar paren text outside params eval stays literal",
+			file:    "outside_params_eval_dollar_literal.yaml",
+			output:  "outside-dollar.txt",
+			content: "$(printf should-not-run)\n",
+		},
+		{
+			name:    "backtick text outside params eval stays literal",
+			file:    "outside_params_eval_backtick_literal.yaml",
+			output:  "outside-backtick.txt",
+			content: "`printf should-not-run`\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("start", tc.file)
+			result.ExpectExitCode(0)
+			dagu.ExpectFileContent(tc.output, tc.content)
+		})
+	}
+}
+
+func TestDynamicEvaluationFailureWithoutDefaultFails(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses POSIX command snippets")
+	}
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "params_eval_failure_no_default.yaml")
+	result.ExpectExitCode(1)
+	result.ExpectStderrContains("params", "eval failed")
+	dagu.ExpectNoFile("should-not-run.txt")
+}
+
+func TestValidateParsesButDoesNotExecuteDynamicEvaluation(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses POSIX command snippets")
+	}
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("validate", "validate_does_not_execute.yaml")
+	result.ExpectExitCode(0)
+	result.ExpectStdout("")
+	dagu.ExpectNoFile("validate-executed.txt")
+}

--- a/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
+++ b/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
@@ -94,19 +94,19 @@ func TestRuntimeDynamicEvaluationWindows(t *testing.T) {
 			name:    "backtick substitution populates param",
 			file:    "win_eval_backtick.yaml",
 			output:  "windows-backtick.txt",
-			content: "20260131",
+			content: "20260131\r\n",
 		},
 		{
 			name:    "dollar paren substitution populates param",
 			file:    "win_eval_dollar.yaml",
 			output:  "windows-dollar.txt",
-			content: "20260131",
+			content: "20260131\r\n",
 		},
 		{
 			name:    "dagu refs resolve before command substitution",
 			file:    "win_eval_ref_order.yaml",
 			output:  "windows-reference-order.txt",
-			content: "prod-api",
+			content: "prod-api\r\n",
 		},
 		{
 			name:   "scoped env resolves before command substitution",
@@ -115,25 +115,25 @@ func TestRuntimeDynamicEvaluationWindows(t *testing.T) {
 			setup: func(t *testing.T) {
 				t.Setenv("SPEC011_DYNAMIC_VALUE", "scope")
 			},
-			content: "scope-prod",
+			content: "scope-prod\r\n",
 		},
 		{
 			name:    "failed eval falls back to default",
 			file:    "win_eval_fallback.yaml",
 			output:  "windows-fallback.txt",
-			content: "fallback-date",
+			content: "fallback-date\r\n",
 		},
 		{
 			name:    "dollar paren text outside params eval stays literal",
 			file:    "win_outside_dollar.yaml",
 			output:  "windows-outside-dollar.txt",
-			content: "$(Write-Output should-not-run)",
+			content: "$(Write-Output should-not-run)\r\n",
 		},
 		{
 			name:    "backtick text outside params eval stays literal",
 			file:    "win_outside_backtick.yaml",
 			output:  "windows-outside-backtick.txt",
-			content: "`Write-Output should-not-run`",
+			content: "`Write-Output should-not-run`\r\n",
 		},
 	}
 

--- a/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
+++ b/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
@@ -84,6 +84,72 @@ func TestRuntimeDynamicEvaluation(t *testing.T) {
 	}
 }
 
+func TestRuntimeDynamicEvaluationWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("fixtures use PowerShell command snippets")
+	}
+
+	cases := []runtimeCase{
+		{
+			name:    "backtick substitution populates param",
+			file:    "win_eval_backtick.yaml",
+			output:  "windows-backtick.txt",
+			content: "20260131",
+		},
+		{
+			name:    "dollar paren substitution populates param",
+			file:    "win_eval_dollar.yaml",
+			output:  "windows-dollar.txt",
+			content: "20260131",
+		},
+		{
+			name:    "dagu refs resolve before command substitution",
+			file:    "win_eval_ref_order.yaml",
+			output:  "windows-reference-order.txt",
+			content: "prod-api",
+		},
+		{
+			name:   "scoped env resolves before command substitution",
+			file:   "win_eval_env_order.yaml",
+			output: "windows-env-order.txt",
+			setup: func(t *testing.T) {
+				t.Setenv("SPEC011_DYNAMIC_VALUE", "scope")
+			},
+			content: "scope-prod",
+		},
+		{
+			name:    "failed eval falls back to default",
+			file:    "win_eval_fallback.yaml",
+			output:  "windows-fallback.txt",
+			content: "fallback-date",
+		},
+		{
+			name:    "dollar paren text outside params eval stays literal",
+			file:    "win_outside_dollar.yaml",
+			output:  "windows-outside-dollar.txt",
+			content: "$(Write-Output should-not-run)",
+		},
+		{
+			name:    "backtick text outside params eval stays literal",
+			file:    "win_outside_backtick.yaml",
+			output:  "windows-outside-backtick.txt",
+			content: "`Write-Output should-not-run`",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			dagu := harness.NewRunner(t)
+			result := dagu.RunWithEnv([]string{"DAGU_DEFAULT_SHELL=powershell"}, "start", tc.file)
+			result.ExpectExitCode(0)
+			dagu.ExpectFileContent(tc.output, tc.content)
+		})
+	}
+}
+
 func TestDynamicEvaluationFailureWithoutDefaultFails(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -97,6 +163,19 @@ func TestDynamicEvaluationFailureWithoutDefaultFails(t *testing.T) {
 	dagu.ExpectNoFile("should-not-run.txt")
 }
 
+func TestDynamicEvaluationFailureWithoutDefaultFailsWindows(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("fixture uses PowerShell command snippets")
+	}
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"DAGU_DEFAULT_SHELL=powershell"}, "start", "win_eval_no_default.yaml")
+	result.ExpectExitCode(1)
+	result.ExpectStderrContains("params", "eval failed")
+	dagu.ExpectNoFile("windows-should-not-run.txt")
+}
+
 func TestValidateParsesButDoesNotExecuteDynamicEvaluation(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -108,4 +187,17 @@ func TestValidateParsesButDoesNotExecuteDynamicEvaluation(t *testing.T) {
 	result.ExpectExitCode(0)
 	result.ExpectStdout("")
 	dagu.ExpectNoFile("validate-executed.txt")
+}
+
+func TestValidateParsesButDoesNotExecuteDynamicEvaluationWindows(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("fixture uses PowerShell command snippets")
+	}
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"DAGU_DEFAULT_SHELL=powershell"}, "validate", "win_validate_no_exec.yaml")
+	result.ExpectExitCode(0)
+	result.ExpectStdout("")
+	dagu.ExpectNoFile("windows-validate-executed.txt")
 }

--- a/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
+++ b/conformance/spec011_dynamic_evaluation/dynamic_evaluation_test.go
@@ -86,7 +86,7 @@ func TestRuntimeDynamicEvaluation(t *testing.T) {
 
 func TestRuntimeDynamicEvaluationWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		t.Skip("fixtures use PowerShell command snippets")
+		t.Skip("fixtures use Windows command snippets")
 	}
 
 	cases := []runtimeCase{
@@ -166,7 +166,7 @@ func TestDynamicEvaluationFailureWithoutDefaultFails(t *testing.T) {
 func TestDynamicEvaluationFailureWithoutDefaultFailsWindows(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
-		t.Skip("fixture uses PowerShell command snippets")
+		t.Skip("fixture uses Windows command snippets")
 	}
 
 	dagu := harness.NewRunner(t)
@@ -192,7 +192,7 @@ func TestValidateParsesButDoesNotExecuteDynamicEvaluation(t *testing.T) {
 func TestValidateParsesButDoesNotExecuteDynamicEvaluationWindows(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
-		t.Skip("fixture uses PowerShell command snippets")
+		t.Skip("fixture uses Windows command snippets")
 	}
 
 	dagu := harness.NewRunner(t)

--- a/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_backtick_literal.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_backtick_literal.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 env:
   OUTSIDE: "`printf should-not-run`"
 steps:

--- a/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_backtick_literal.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_backtick_literal.yaml
@@ -1,0 +1,5 @@
+env:
+  OUTSIDE: "`printf should-not-run`"
+steps:
+  - name: write
+    run: printf '%s\n' "$OUTSIDE" > outside-backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_dollar_literal.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_dollar_literal.yaml
@@ -1,0 +1,5 @@
+env:
+  OUTSIDE: $(printf should-not-run)
+steps:
+  - name: write
+    run: printf '%s\n' "$OUTSIDE" > outside-dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_dollar_literal.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/outside_params_eval_dollar_literal.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 env:
   OUTSIDE: $(printf should-not-run)
 steps:

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_backtick.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: today
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_backtick.yaml
@@ -1,0 +1,7 @@
+params:
+  - name: today
+    type: string
+    eval: "`printf 20260131`"
+steps:
+  - name: write
+    run: printf '%s\n' '${params.today}' > backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_dollar.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: today
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_dollar.yaml
@@ -1,0 +1,7 @@
+params:
+  - name: today
+    type: string
+    eval: $(printf 20260131)
+steps:
+  - name: write
+    run: printf '%s\n' '${params.today}' > dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_env_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_env_order.yaml
@@ -1,0 +1,10 @@
+params:
+  - name: environment
+    type: string
+    default: prod
+  - name: combined
+    type: string
+    eval: $(printf '%s-%s' "$SPEC011_DYNAMIC_VALUE" '${params.environment}')
+steps:
+  - name: write
+    run: printf '%s\n' '${params.combined}' > env-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_env_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_env_order.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: environment
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_fallback.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_fallback.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: run_date
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_fallback.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_fallback.yaml
@@ -1,0 +1,8 @@
+params:
+  - name: run_date
+    type: string
+    eval: "`command_that_does_not_exist_spec011`"
+    default: fallback-date
+steps:
+  - name: write
+    run: printf '%s\n' '${params.run_date}' > fallback.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_no_default.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_no_default.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: run_date
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_no_default.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_failure_no_default.yaml
@@ -1,0 +1,7 @@
+params:
+  - name: run_date
+    type: string
+    eval: "`command_that_does_not_exist_spec011`"
+steps:
+  - name: write
+    run: printf 'unexpected\n' > should-not-run.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_reference_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_reference_order.yaml
@@ -1,0 +1,10 @@
+params:
+  - name: environment
+    type: string
+    default: prod
+  - name: service_name
+    type: string
+    eval: $(printf '%s-api' '${params.environment}')
+steps:
+  - name: write
+    run: printf '%s\n' '${params.service_name}' > reference-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/params_eval_reference_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/params_eval_reference_order.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: environment
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/validate_does_not_execute.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/validate_does_not_execute.yaml
@@ -1,0 +1,7 @@
+params:
+  - name: marker
+    type: string
+    eval: $(sh -c 'printf bad > validate-executed.txt; printf ok')
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec011_dynamic_evaluation/testdata/validate_does_not_execute.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/validate_does_not_execute.yaml
@@ -1,3 +1,4 @@
+working_dir: .
 params:
   - name: marker
     type: string

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
@@ -1,0 +1,9 @@
+shell: powershell
+working_dir: .
+params:
+  - name: today
+    type: string
+    eval: "`Write-Output 20260131`"
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-backtick.txt -Value '${params.today}'

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
@@ -6,4 +6,4 @@ params:
     eval: "`Write-Output 20260131`"
 steps:
   - name: write
-    run: <nul set /p dummy=${params.today} > windows-backtick.txt
+    run: echo(${params.today}>windows-backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_backtick.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: today
@@ -6,4 +6,4 @@ params:
     eval: "`Write-Output 20260131`"
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-backtick.txt -Value '${params.today}'
+    run: <nul set /p dummy=${params.today} > windows-backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: today
@@ -6,4 +6,4 @@ params:
     eval: $(Write-Output 20260131)
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-dollar.txt -Value '${params.today}'
+    run: <nul set /p dummy=${params.today} > windows-dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
@@ -1,0 +1,9 @@
+shell: powershell
+working_dir: .
+params:
+  - name: today
+    type: string
+    eval: $(Write-Output 20260131)
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-dollar.txt -Value '${params.today}'

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_dollar.yaml
@@ -6,4 +6,4 @@ params:
     eval: $(Write-Output 20260131)
 steps:
   - name: write
-    run: <nul set /p dummy=${params.today} > windows-dollar.txt
+    run: echo(${params.today}>windows-dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
@@ -9,4 +9,4 @@ params:
     eval: $(Write-Output '${SPEC011_DYNAMIC_VALUE}-${params.environment}')
 steps:
   - name: write
-    run: <nul set /p dummy=${params.combined} > windows-env-order.txt
+    run: echo(${params.combined}>windows-env-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: environment
@@ -9,4 +9,4 @@ params:
     eval: $(Write-Output '${SPEC011_DYNAMIC_VALUE}-${params.environment}')
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-env-order.txt -Value '${params.combined}'
+    run: <nul set /p dummy=${params.combined} > windows-env-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_env_order.yaml
@@ -1,0 +1,12 @@
+shell: powershell
+working_dir: .
+params:
+  - name: environment
+    type: string
+    default: prod
+  - name: combined
+    type: string
+    eval: $(Write-Output '${SPEC011_DYNAMIC_VALUE}-${params.environment}')
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-env-order.txt -Value '${params.combined}'

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
@@ -1,0 +1,10 @@
+shell: powershell
+working_dir: .
+params:
+  - name: run_date
+    type: string
+    eval: "`CommandThatDoesNotExistSpec011`"
+    default: fallback-date
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-fallback.txt -Value '${params.run_date}'

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: run_date
@@ -7,4 +7,4 @@ params:
     default: fallback-date
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-fallback.txt -Value '${params.run_date}'
+    run: <nul set /p dummy=${params.run_date} > windows-fallback.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_fallback.yaml
@@ -3,8 +3,8 @@ working_dir: .
 params:
   - name: run_date
     type: string
-    eval: "`CommandThatDoesNotExistSpec011`"
+    eval: "`Write-Error 'spec011-fail'; exit 9`"
     default: fallback-date
 steps:
   - name: write
-    run: <nul set /p dummy=${params.run_date} > windows-fallback.txt
+    run: echo(${params.run_date}>windows-fallback.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
@@ -3,7 +3,7 @@ working_dir: .
 params:
   - name: run_date
     type: string
-    eval: "`CommandThatDoesNotExistSpec011`"
+    eval: "`Write-Error 'spec011-fail'; exit 9`"
 steps:
   - name: write
-    run: <nul set /p dummy=unexpected > windows-should-not-run.txt
+    run: echo(unexpected>windows-should-not-run.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: run_date
@@ -6,4 +6,4 @@ params:
     eval: "`CommandThatDoesNotExistSpec011`"
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-should-not-run.txt -Value unexpected
+    run: <nul set /p dummy=unexpected > windows-should-not-run.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_no_default.yaml
@@ -1,0 +1,9 @@
+shell: powershell
+working_dir: .
+params:
+  - name: run_date
+    type: string
+    eval: "`CommandThatDoesNotExistSpec011`"
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-should-not-run.txt -Value unexpected

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
@@ -1,0 +1,12 @@
+shell: powershell
+working_dir: .
+params:
+  - name: environment
+    type: string
+    default: prod
+  - name: service_name
+    type: string
+    eval: $(Write-Output '${params.environment}-api')
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-reference-order.txt -Value '${params.service_name}'

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
@@ -9,4 +9,4 @@ params:
     eval: $(Write-Output '${params.environment}-api')
 steps:
   - name: write
-    run: <nul set /p dummy=${params.service_name} > windows-reference-order.txt
+    run: echo(${params.service_name}>windows-reference-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_eval_ref_order.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: environment
@@ -9,4 +9,4 @@ params:
     eval: $(Write-Output '${params.environment}-api')
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-reference-order.txt -Value '${params.service_name}'
+    run: <nul set /p dummy=${params.service_name} > windows-reference-order.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
@@ -1,7 +1,7 @@
-shell: powershell
+shell: cmd
 working_dir: .
 env:
   OUTSIDE: "`Write-Output should-not-run`"
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-outside-backtick.txt -Value $env:OUTSIDE
+    run: <nul set /p dummy=%OUTSIDE% > windows-outside-backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
@@ -4,4 +4,4 @@ env:
   OUTSIDE: "`Write-Output should-not-run`"
 steps:
   - name: write
-    run: <nul set /p dummy=%OUTSIDE% > windows-outside-backtick.txt
+    run: echo(%OUTSIDE%>windows-outside-backtick.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_backtick.yaml
@@ -1,0 +1,7 @@
+shell: powershell
+working_dir: .
+env:
+  OUTSIDE: "`Write-Output should-not-run`"
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-outside-backtick.txt -Value $env:OUTSIDE

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
@@ -1,0 +1,7 @@
+shell: powershell
+working_dir: .
+env:
+  OUTSIDE: $(Write-Output should-not-run)
+steps:
+  - name: write
+    run: Set-Content -NoNewline -Path windows-outside-dollar.txt -Value $env:OUTSIDE

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
@@ -1,7 +1,7 @@
-shell: powershell
+shell: cmd
 working_dir: .
 env:
   OUTSIDE: $(Write-Output should-not-run)
 steps:
   - name: write
-    run: Set-Content -NoNewline -Path windows-outside-dollar.txt -Value $env:OUTSIDE
+    run: <nul set /p dummy=%OUTSIDE% > windows-outside-dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_outside_dollar.yaml
@@ -4,4 +4,4 @@ env:
   OUTSIDE: $(Write-Output should-not-run)
 steps:
   - name: write
-    run: <nul set /p dummy=%OUTSIDE% > windows-outside-dollar.txt
+    run: echo(%OUTSIDE%>windows-outside-dollar.txt

--- a/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
@@ -6,4 +6,4 @@ params:
     eval: $(Set-Content -NoNewline -Path windows-validate-executed.txt -Value bad; Write-Output ok)
 steps:
   - name: ok
-    run: echo ok
+    run: echo(ok

--- a/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
@@ -1,0 +1,9 @@
+shell: powershell
+working_dir: .
+params:
+  - name: marker
+    type: string
+    eval: $(Set-Content -NoNewline -Path windows-validate-executed.txt -Value bad; Write-Output ok)
+steps:
+  - name: ok
+    run: Write-Output ok

--- a/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
+++ b/conformance/spec011_dynamic_evaluation/testdata/win_validate_no_exec.yaml
@@ -1,4 +1,4 @@
-shell: powershell
+shell: cmd
 working_dir: .
 params:
   - name: marker
@@ -6,4 +6,4 @@ params:
     eval: $(Set-Content -NoNewline -Path windows-validate-executed.txt -Value bad; Write-Output ok)
 steps:
   - name: ok
-    run: Write-Output ok
+    run: echo ok

--- a/internal/cmd/restart_test.go
+++ b/internal/cmd/restart_test.go
@@ -71,6 +71,7 @@ func TestRestartCommand_BuiltExecutableRestoresExplicitEnv(t *testing.T) {
 	th := test.SetupCommand(t, test.WithBuiltExecutable())
 	t.Setenv("CMD_RESTART_EXPLICIT_ENV", "from-host")
 
+	holdTimeout := 3 * commandLogWaitTimeout()
 	release := newHoldFile(t)
 	dag := th.DAG(t, fmt.Sprintf(`name: built-restart-explicit-env
 env:
@@ -81,7 +82,7 @@ steps:
   - name: "capture"
     run: printf '%%s|%%s' "$EXPORTED_SECRET" "${CMD_RESTART_EXPLICIT_ENV:-}"
     output: RESULT
-`, holdUntilFileExistsCommand(release)))
+`, holdUntilFileExistsCommandWithin(release, holdTimeout)))
 
 	startDone := make(chan error, 1)
 	go func() {
@@ -95,7 +96,7 @@ steps:
 		return err == nil && status != nil && status.Status == core.Running
 	}, 10*time.Second, 100*time.Millisecond)
 
-	releaseDone := releaseHoldFileWhenRecentStatusCountAtLeast(t, th, dag.Name, 2, release)
+	releaseDone := releaseHoldFileWhenRecentStatusCountAtLeastWithin(t, th, dag.Name, 2, release, holdTimeout)
 	test.RunBuiltCLI(t, th.Helper, []string{"CMD_RESTART_EXPLICIT_ENV=from-host"}, "restart", dag.Name)
 	require.NoError(t, <-releaseDone)
 

--- a/internal/cmd/test_helpers_test.go
+++ b/internal/cmd/test_helpers_test.go
@@ -70,7 +70,11 @@ func releaseHoldFile(t *testing.T, path string) {
 }
 
 func holdUntilFileExistsCommand(path string) string {
-	iterations := int(commandLogWaitTimeout() / (50 * time.Millisecond))
+	return holdUntilFileExistsCommandWithin(path, commandLogWaitTimeout())
+}
+
+func holdUntilFileExistsCommandWithin(path string, timeout time.Duration) string {
+	iterations := int(timeout / (50 * time.Millisecond))
 	return test.ForOS(
 		fmt.Sprintf("for i in $(seq 1 %d); do [ -f %s ] && exit 0; sleep 0.05; done; exit 124", iterations, test.PosixQuote(path)),
 		fmt.Sprintf("for ($i = 0; $i -lt %d; $i++) { if (Test-Path %s) { exit 0 }; Start-Sleep -Milliseconds 50 }; exit 124", iterations, test.PowerShellQuote(path)),
@@ -84,11 +88,22 @@ func releaseHoldFileWhenRecentStatusCountAtLeast(
 	count int,
 	path string,
 ) <-chan error {
+	return releaseHoldFileWhenRecentStatusCountAtLeastWithin(t, th, dagName, count, path, commandLogWaitTimeout())
+}
+
+func releaseHoldFileWhenRecentStatusCountAtLeastWithin(
+	t *testing.T,
+	th test.Command,
+	dagName string,
+	count int,
+	path string,
+	timeout time.Duration,
+) <-chan error {
 	t.Helper()
 
 	done := make(chan error, 1)
 	go func() {
-		deadline := time.Now().Add(commandLogWaitTimeout())
+		deadline := time.Now().Add(timeout)
 		for time.Now().Before(deadline) {
 			if len(th.DAGRunMgr.ListRecentStatus(th.Context, dagName, count)) >= count {
 				done <- os.WriteFile(path, []byte("release"), 0o600)

--- a/internal/cmn/value/dynamic_evaluation_external_test.go
+++ b/internal/cmn/value/dynamic_evaluation_external_test.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package value_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/value"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicParamEvalSyntax(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX command snippets")
+	}
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+
+	got, err := resolver.String(context.Background(), "prefix `printf one` suffix", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "prefix one suffix", got)
+
+	got, err = resolver.String(context.Background(), "prefix $(printf two) suffix", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "prefix two suffix", got)
+}
+
+func TestDynamicParamEvalPreservesUnclosedCommandText(t *testing.T) {
+	t.Parallel()
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+
+	got, err := resolver.String(context.Background(), "`printf one", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "`printf one", got)
+
+	got, err = resolver.String(context.Background(), "$(printf two", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "$(printf two", got)
+}
+
+func TestDynamicParamEvalShellSyntaxUsesNextUnescapedClosingParen(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX command snippets")
+	}
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+
+	got, err := resolver.String(context.Background(), "$(printf a)b)", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "ab)", got)
+
+	got, err = resolver.String(context.Background(), "$(printf a\\)b)", value.DynamicParamEvalField("params[0].eval"))
+	require.NoError(t, err)
+	assert.Equal(t, "a)b", got)
+}
+
+func TestDynamicParamEvalRejectsNestedShellSubstitution(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX command snippets")
+	}
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+
+	_, err := resolver.String(context.Background(), "$(printf $(printf nested))", value.DynamicParamEvalField("params[0].eval"))
+	require.Error(t, err)
+}
+
+func TestWorkflowFieldsPreserveCommandSubstitutionText(t *testing.T) {
+	t.Parallel()
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+
+	got, err := resolver.String(context.Background(), "`printf one` and $(printf two)", value.WorkflowField("steps[0].run"))
+	require.NoError(t, err)
+	assert.Equal(t, "`printf one` and $(printf two)", got)
+}
+
+func TestNonDynamicFieldsPreserveCommandSubstitutionText(t *testing.T) {
+	t.Parallel()
+
+	fields := []struct {
+		name  string
+		field value.Field
+	}{
+		{name: "workflow", field: value.WorkflowField("steps[0].run")},
+		{name: "dag env", field: value.DAGEnvField("env.OUTSIDE")},
+		{name: "runtime dag env", field: value.RuntimeDAGEnvField("env.OUTSIDE")},
+		{name: "step env", field: value.StepEnvField("steps[0].env.OUTSIDE")},
+		{name: "container env", field: value.ContainerEnvField("steps[0].container.env.OUTSIDE")},
+		{name: "executor config", field: value.ExecutorConfigField("steps[0].with.value")},
+	}
+
+	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
+	for _, tc := range fields {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolver.String(context.Background(), "`printf one` and $(printf two)", tc.field)
+			require.NoError(t, err)
+			assert.Equal(t, "`printf one` and $(printf two)", got)
+		})
+	}
+}

--- a/internal/cmn/value/dynamic_evaluation_external_test.go
+++ b/internal/cmn/value/dynamic_evaluation_external_test.go
@@ -96,6 +96,11 @@ func TestNonDynamicFieldsPreserveCommandSubstitutionText(t *testing.T) {
 		{name: "step env", field: value.StepEnvField("steps[0].env.OUTSIDE")},
 		{name: "container env", field: value.ContainerEnvField("steps[0].container.env.OUTSIDE")},
 		{name: "executor config", field: value.ExecutorConfigField("steps[0].with.value")},
+		{name: "condition value", field: value.ConditionValueField("steps[0].preconditions[0].condition")},
+		{name: "retry integer", field: value.RetryIntegerField("steps[0].retryPolicy.limit")},
+		{name: "repeat integer", field: value.RepeatIntegerField("steps[0].repeatPolicy.repeat")},
+		{name: "server base path", field: value.ServerBasePathField("config.serverBasePath")},
+		{name: "coordinator artifact base dir", field: value.CoordinatorArtifactBaseDirField("config.coordinator.artifactBaseDir")},
 	}
 
 	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})

--- a/internal/cmn/value/field_test.go
+++ b/internal/cmn/value/field_test.go
@@ -106,10 +106,10 @@ func TestResolverFieldPolicyBacktickMatrix(t *testing.T) {
 		want  string
 	}{
 		{name: "workflow", field: value.WorkflowField("field"), want: "`printf matrix`"},
-		{name: "DAG env", field: value.DAGEnvField("field"), want: "matrix"},
+		{name: "DAG env", field: value.DAGEnvField("field"), want: "`printf matrix`"},
 		{name: "runtime DAG env", field: value.RuntimeDAGEnvField("field"), want: "`printf matrix`"},
-		{name: "step env", field: value.StepEnvField("field"), want: "matrix"},
-		{name: "container env", field: value.ContainerEnvField("field"), want: "matrix"},
+		{name: "step env", field: value.StepEnvField("field"), want: "`printf matrix`"},
+		{name: "container env", field: value.ContainerEnvField("field"), want: "`printf matrix`"},
 		{name: "dynamic params", field: value.DynamicParamEvalField("field"), want: "matrix"},
 		{name: "template script", field: value.TemplateScriptField("field"), want: "`printf matrix`"},
 		{name: "direct command", field: value.DirectCommandField("field", value.CommandContext{}), want: "`printf matrix`"},

--- a/internal/cmn/value/resolver.go
+++ b/internal/cmn/value/resolver.go
@@ -179,7 +179,7 @@ func policyForField(field Field) resolverPolicy {
 	case fieldWorkflowObject:
 		return workflowValuePolicy()
 	case fieldConditionValue:
-		return resolverPolicy{strict: true}
+		return resolverPolicy{strict: true, options: []option{withoutSubstitute()}}
 	case fieldDAGEnv:
 		return resolverPolicy{strict: true, envVariables: envVariablesUser, options: []option{withOSExpansion(), withoutSubstitute()}}
 	case fieldRuntimeDAGEnv:
@@ -195,7 +195,7 @@ func policyForField(field Field) resolverPolicy {
 	case fieldLogPath:
 		return resolverPolicy{options: []option{withOSExpansion(), withoutSubstitute()}}
 	case fieldServerBasePath, fieldCoordinatorArtifactBaseDir:
-		return resolverPolicy{options: []option{withOSExpansion()}}
+		return resolverPolicy{options: []option{withOSExpansion(), withoutSubstitute()}}
 	case fieldStructuredOutputPath, fieldStructuredOutputLiteral:
 		return resolverPolicy{strict: true, options: []option{withoutExpandShell(), withoutSubstitute()}}
 	case fieldStepArtifactOutput:
@@ -208,7 +208,7 @@ func policyForField(field Field) resolverPolicy {
 			},
 		}
 	case fieldRetryInteger, fieldRepeatInteger:
-		return resolverPolicy{strict: true, options: []option{withOSExpansion()}}
+		return resolverPolicy{strict: true, options: []option{withOSExpansion(), withoutSubstitute()}}
 	case fieldDAGShell, fieldStepShell:
 		return resolverPolicy{strict: true, options: append([]option{withoutSubstitute()}, commandPolicyOptions(field.command)...)}
 	case fieldShellCommand:

--- a/internal/cmn/value/resolver.go
+++ b/internal/cmn/value/resolver.go
@@ -181,11 +181,11 @@ func policyForField(field Field) resolverPolicy {
 	case fieldConditionValue:
 		return resolverPolicy{strict: true}
 	case fieldDAGEnv:
-		return resolverPolicy{strict: true, envVariables: envVariablesUser, options: []option{withOSExpansion()}}
+		return resolverPolicy{strict: true, envVariables: envVariablesUser, options: []option{withOSExpansion(), withoutSubstitute()}}
 	case fieldRuntimeDAGEnv:
 		return resolverPolicy{strict: true, envVariables: envVariablesUser, options: []option{withoutSubstitute()}}
 	case fieldStepEnv, fieldContainerEnv:
-		return resolverPolicy{strict: true}
+		return resolverPolicy{strict: true, options: []option{withoutSubstitute()}}
 	case fieldDynamicParamEval:
 		return resolverPolicy{strict: true, envVariables: envVariablesUser, options: []option{withOSExpansion(), withShellCommandSubstitution()}}
 	case fieldDotenvPath:

--- a/internal/cmn/value/resolver_test.go
+++ b/internal/cmn/value/resolver_test.go
@@ -413,17 +413,17 @@ func TestResolverDynamicParamEvalDoesNotSubstituteOSFallbackValue(t *testing.T) 
 	assert.Equal(t, "`printf unsafe`", got)
 }
 
-func TestResolverEnvEntryFieldsRunCommandSubstitution(t *testing.T) {
+func TestResolverEnvEntryFieldsPreserveCommandSubstitution(t *testing.T) {
 	ctx := context.Background()
 	resolver := value.NewResolver(value.StaticScope{}, value.RuntimeScope{})
 
 	stepValue, err := resolver.String(ctx, "`printf step`", value.StepEnvField("steps[0].env[0]"))
 	require.NoError(t, err)
-	assert.Equal(t, "step", stepValue)
+	assert.Equal(t, "`printf step`", stepValue)
 
 	containerValue, err := resolver.String(ctx, "`printf container`", value.ContainerEnvField("container.env.VALUE"))
 	require.NoError(t, err)
-	assert.Equal(t, "container", containerValue)
+	assert.Equal(t, "`printf container`", containerValue)
 }
 
 func TestResolverDAGEnvAndRuntimeDAGEnvHaveDistinctSubstitutionPolicy(t *testing.T) {
@@ -433,7 +433,7 @@ func TestResolverDAGEnvAndRuntimeDAGEnvHaveDistinctSubstitutionPolicy(t *testing
 
 	dagValue, err := resolver.String(ctx, "`printf dag`", value.DAGEnvField("env.VALUE"))
 	require.NoError(t, err)
-	assert.Equal(t, "dag", dagValue)
+	assert.Equal(t, "`printf dag`", dagValue)
 
 	dagOSValue, err := resolver.String(ctx, "$VALUE_RESOLUTION_DAG_ENV_OS", value.DAGEnvField("env.VALUE"))
 	require.NoError(t, err)

--- a/internal/cmn/value/substitute.go
+++ b/internal/cmn/value/substitute.go
@@ -221,27 +221,33 @@ func substituteShellCommandsWithContext(ctx context.Context, input string) (stri
 			continue
 		}
 
-		cmd, end, ok := readShellCommandSubstitution(runes, i+2)
-		if !ok {
+		read, err := readShellCommandSubstitution(runes, i+2)
+		if err != nil {
+			return "", err
+		}
+		if !read.ok {
 			result.WriteString("$(")
 			i++
 			continue
 		}
-		output, err := runCommandWithContext(ctx, unescapeDollars(ctx, cmd))
+		output, err := runCommandWithContext(ctx, unescapeDollars(ctx, read.cmd))
 		if err != nil {
 			return "", err
 		}
 		result.WriteString(output)
-		i = end
+		i = read.end
 	}
 	return result.String(), nil
 }
 
-func readShellCommandSubstitution(runes []rune, start int) (string, int, bool) {
+type shellCommandSubstitutionRead struct {
+	cmd string
+	end int
+	ok  bool
+}
+
+func readShellCommandSubstitution(runes []rune, start int) (shellCommandSubstitutionRead, error) {
 	var cmd strings.Builder
-	depth := 1
-	var singleQuoted bool
-	var doubleQuoted bool
 	var escaped bool
 
 	for i := start; i < len(runes); i++ {
@@ -256,30 +262,17 @@ func readShellCommandSubstitution(runes []rune, start int) (string, int, bool) {
 			escaped = true
 			continue
 		}
-		if r == '\'' && !doubleQuoted {
-			singleQuoted = !singleQuoted
-			cmd.WriteRune(r)
-			continue
-		}
-		if r == '"' && !singleQuoted {
-			doubleQuoted = !doubleQuoted
-			cmd.WriteRune(r)
-			continue
-		}
-		if singleQuoted {
-			cmd.WriteRune(r)
-			continue
-		}
 		switch r {
-		case '(':
-			depth++
+		case '`':
+			return shellCommandSubstitutionRead{}, fmt.Errorf("nested command substitution is not supported")
 		case ')':
-			depth--
-			if depth == 0 {
-				return cmd.String(), i, true
+			return shellCommandSubstitutionRead{cmd: cmd.String(), end: i, ok: true}, nil
+		case '$':
+			if i+1 < len(runes) && runes[i+1] == '(' {
+				return shellCommandSubstitutionRead{}, fmt.Errorf("nested command substitution is not supported")
 			}
 		}
 		cmd.WriteRune(r)
 	}
-	return "", 0, false
+	return shellCommandSubstitutionRead{}, nil
 }

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -374,7 +374,7 @@ steps:
 			},
 		},
 		{
-			name: "ValidEnvRunsCommandSubstitution",
+			name: "ValidEnvPreservesBacktickSubstitution",
 			yaml: `
 env:
   - VAR: "` + "`echo 123`" + `"
@@ -383,7 +383,7 @@ steps:
   - run: "true"
 `,
 			expected: map[string]string{
-				"VAR": "123",
+				"VAR": "`echo 123`",
 			},
 		},
 		{

--- a/internal/core/spec/variables_test.go
+++ b/internal/core/spec/variables_test.go
@@ -221,7 +221,7 @@ func TestLoadVariables(t *testing.T) {
 		assert.Equal(t, "hello", result["GREETING"])
 	})
 
-	t.Run("RunsBacktickSubstitution", func(t *testing.T) {
+	t.Run("PreservesBacktickSubstitution", func(t *testing.T) {
 		ctx := BuildContext{
 			ctx:  context.Background(),
 			opts: BuildOpts{},
@@ -230,7 +230,7 @@ func TestLoadVariables(t *testing.T) {
 		input := map[string]any{"CMD": "`echo hello`"}
 		result, err := loadVariables(ctx, input)
 		require.NoError(t, err)
-		assert.Equal(t, "hello", result["CMD"])
+		assert.Equal(t, "`echo hello`", result["CMD"])
 	})
 
 	t.Run("NoEvalFlag", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestLoadVariables(t *testing.T) {
 			opts: BuildOpts{Flags: BuildFlagNoEval},
 		}
 
-		// With NoEval, command substitution should not be executed
+		// With NoEval, command-like text is preserved.
 		input := map[string]any{"CMD": "$(echo hello)"}
 		result, err := loadVariables(ctx, input)
 		require.NoError(t, err)
@@ -370,7 +370,7 @@ GREETING: hello
 		assert.Equal(t, "hello", result["GREETING"])
 	})
 
-	t.Run("RunsBacktickSubstitution", func(t *testing.T) {
+	t.Run("PreservesBacktickSubstitution", func(t *testing.T) {
 		ctx := BuildContext{
 			ctx:  context.Background(),
 			opts: BuildOpts{},
@@ -381,7 +381,7 @@ CMD: "`+"`echo hello`"+`"
 `)
 		result, err := loadVariablesFromEnvValue(ctx, env)
 		require.NoError(t, err)
-		assert.Equal(t, "hello", result["CMD"])
+		assert.Equal(t, "`echo hello`", result["CMD"])
 	})
 
 	t.Run("NoEvalFlag", func(t *testing.T) {

--- a/internal/intg/cfg_test.go
+++ b/internal/intg/cfg_test.go
@@ -318,9 +318,14 @@ steps:
 		t.Parallel()
 
 		dataPrefix := filepath.ToSlash(filepath.Join(t.TempDir(), "dagu_test_integration"))
-		dag := th.DAG(t, fmt.Sprintf(`env:
+		dag := th.DAG(t, fmt.Sprintf(`params:
+  - name: process_date
+    type: string
+    eval: "`+"`"+`date '+%%Y%%m%%d_%%H%%M%%S'`+"`"+`"
+
+env:
   - DATA_DIR: %q
-  - PROCESS_DATE: "`+"`"+`date '+%%Y%%m%%d_%%H%%M%%S'`+"`"+`"
+  - PROCESS_DATE: "${params.process_date}"
 
 steps:
   - run: echo foo

--- a/internal/intg/repeat_test.go
+++ b/internal/intg/repeat_test.go
@@ -475,11 +475,22 @@ func TestRepeatPolicy_MaxIntervalSecFromEnvVar(t *testing.T) {
 	assert.Equal(t, 2, dagRunStatus.Nodes[0].DoneCount)
 }
 
-func TestRepeatPolicy_LimitFromCommandSubstitution(t *testing.T) {
+func TestRepeatPolicy_LimitFromDynamicParamEval(t *testing.T) {
 	repeatPolicyParallel(t)
 	th := test.Setup(t)
 
-	dag := th.DAG(t, fmt.Sprintf("steps:\n  - %s\n    repeat_policy:\n      repeat: true\n      limit: %q\n      interval_sec: 0\n", portableDirectSuccessStepYAML(t), repeatLiteralCommandSubstitution("3")))
+	dag := th.DAG(t, fmt.Sprintf(`params:
+  - name: repeat_limit
+    type: string
+    eval: %q
+
+steps:
+  - %s
+    repeat_policy:
+      repeat: true
+      limit: ${params.repeat_limit}
+      interval_sec: 0
+`, repeatLiteralCommandSubstitution("3"), portableDirectSuccessStepYAML(t)))
 	agent := dag.Agent()
 
 	ctx, cancel := context.WithTimeout(agent.Context, repeatPolicyTimeout(10*time.Second))

--- a/internal/runtime/condition_test.go
+++ b/internal/runtime/condition_test.go
@@ -81,8 +81,8 @@ func TestEvalConditions(t *testing.T) {
 			conditions: []*core.Condition{{Condition: "test", Expected: "re:^test$"}},
 		},
 		{
-			name:       "ValueMatchEvaluatesBacktickSubstitution",
-			conditions: []*core.Condition{{Condition: "`printf 100`", Expected: "100"}},
+			name:       "ValueMatchPreservesBacktickSubstitution",
+			conditions: []*core.Condition{{Condition: "`printf 100`", Expected: "`printf 100`"}},
 		},
 		// Negate tests
 		{

--- a/specs/011-dynamic-evaluation.md
+++ b/specs/011-dynamic-evaluation.md
@@ -2,9 +2,7 @@
 
 ## Status
 
-Not implemented.
-This spec describes target conformance behavior.
-It must not be treated as current product behavior.
+Implemented.
 
 ## Scope
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -20,7 +20,7 @@ It must not be treated as product behavior until implementation catches up.
 | [006: Value Resolution Env](006-value-resolution-env.md) | Not implemented |
 | [007: Value Resolution Steps](007-value-resolution-steps.md) | Not implemented |
 | [009: Step Reference](009-step-reference.md) | Not implemented |
-| [011: Dynamic Evaluation](011-dynamic-evaluation.md) | Not implemented |
+| [011: Dynamic Evaluation](011-dynamic-evaluation.md) | Implemented |
 | [012: Step Outputs](012-step-outputs.md) | Not implemented |
 | [013: Step Run](013-step-run.md) | Partially implemented |
 | [014: Step Run Command](014-step-run-command.md) | Partially implemented |


### PR DESCRIPTION
## Summary

- implement Spec 011 dynamic evaluation boundaries so command substitution executes only in `params[].eval`
- add Spec 011 conformance coverage for backticks, `$()` syntax, fallback behavior, reference/env ordering, literal non-dynamic fields, and validation non-execution
- mark Spec 011 implemented and stabilize a built restart CLI test that was brittle under full-suite load

## Testing

- make bin
- make lint
- make test
- go test ./internal/cmn/value ./internal/core/spec ./internal/cmd -count=1
- DAGU_BIN=.local/bin/dagu go test ./conformance/spec011_dynamic_evaluation -run TestValidateParsesButDoesNotExecuteDynamicEvaluation -count=1
- DAGU_BIN=.local/bin/dagu go test ./conformance/spec011_dynamic_evaluation -count=1 reached runtime execution locally, but the sandbox denied the Dagu Unix socket bind with operation not permitted; CI should verify the full binary conformance path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Spec 011 dynamic evaluation with command substitution limited to `params[].eval`; all other fields keep backticks and `$()` literal. Adds Windows conformance using `powershell` with deterministic CRLF output.

- **New Features**
  - Execute backticks and `$()` only in `params[].eval`.
  - Resolve `${params.*}` and scoped env before eval; reject nested substitution; preserve unclosed text.
  - `validate` parses but does not execute dynamic eval.
  - Windows conformance: POSIX suites default to `DAGU_DEFAULT_SHELL=bash`; Windows fixtures run with `powershell` and assert CRLF.

- **Bug Fixes**
  - Enforced literal handling for DAG/step/container env, condition values, retry/repeat integers, and config paths (server base path, coordinator artifact base dir).
  - Test harness adds `RunWithEnv`, merges env keys case-insensitively on Windows, and prints stdout/stderr on timeouts.
  - Stabilized built restart CLI test with tunable hold timeouts; sourced dynamic date and repeat limit from `params[].eval`.

<sup>Written for commit fdcc9c6abeaf2fbdd912dacee082f5883c94531f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic evaluation feature now fully implemented, supporting backtick and `$()` command substitution for parameters with environment variable resolution
  * Parameters can include evaluation expressions with fallback defaults
  * Validation stage no longer executes dynamic evaluations

* **Tests**
  * Added conformance tests for dynamic evaluation across multiple scenarios including syntax variants, environment ordering, and failure handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->