### PR TITLE
feat(runtime): service-selected Docker/Podman container runtime

### DIFF
--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -1932,6 +1932,36 @@ steps:
 `,
 		},
 		{
+			name: "HarnessRunWithContainer",
+			spec: `
+steps:
+  - action: harness.run
+    container:
+      image: localhost/reviewer-claude:latest
+    with:
+      prompt: Summarize the repository state
+      provider: claude
+`,
+		},
+		{
+			name: "RejectContainerRuntimeKey",
+			spec: `
+steps:
+  - action: harness.run
+    container:
+      image: localhost/reviewer-claude:latest
+      runtime: podman
+    with:
+      prompt: Summarize the repository state
+      provider: claude
+`,
+			// Runtime selection is service-level (DAGU_CONTAINER_RUNTIME), not a YAML
+			// field. The container schema sets additionalProperties:false, so a stray
+			// runtime: key must fail validation as an unknown property. This guards the
+			// contract that the removed per-step field cannot be reintroduced silently.
+			wantErr: "steps",
+		},
+		{
 			name: "RequirePromptFlagForFlagPromptMode",
 			spec: `
 harnesses:

--- a/internal/core/container.go
+++ b/internal/core/container.go
@@ -6,6 +6,7 @@ package core
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -96,6 +97,14 @@ const (
 	WaitForHealthy ContainerWaitFor = "healthy"
 )
 
+// ContainerRuntime is the runtime used to launch or exec into a container.
+type ContainerRuntime string
+
+const (
+	ContainerRuntimeDocker ContainerRuntime = "docker"
+	ContainerRuntimePodman ContainerRuntime = "podman"
+)
+
 // GetWorkingDir returns the working directory inside the container
 func (ct Container) GetWorkingDir() string {
 	return ct.WorkingDir
@@ -104,6 +113,21 @@ func (ct Container) GetWorkingDir() string {
 // IsExecMode returns true if this container is configured to exec into an existing container
 func (ct Container) IsExecMode() bool {
 	return ct.Exec != ""
+}
+
+// ParseContainerRuntime parses a container runtime from a raw string.
+func ParseContainerRuntime(raw string) (ContainerRuntime, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "":
+		return "", nil
+	case string(ContainerRuntimeDocker):
+		return ContainerRuntimeDocker, nil
+	case string(ContainerRuntimePodman):
+		return ContainerRuntimePodman, nil
+	default:
+		return "", fmt.Errorf("invalid container runtime %q (supported: docker, podman)", raw)
+	}
 }
 
 // PullPolicy defines image pull policy for a container execution

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -3284,6 +3284,30 @@ steps:
 		assert.Equal(t, []string{"run"}, dag.Harnesses["gemini"].PrefixArgs)
 	})
 
+	t.Run("HarnessRunAcceptsStepContainer", func(t *testing.T) {
+		yaml := `
+steps:
+  - name: review
+    action: harness.run
+    container:
+      image: localhost/reviewer-claude:latest
+      volumes:
+        - ./src:/src:ro
+    with:
+      prompt: "Review this repository"
+      provider: claude
+`
+		dag, err := spec.LoadYAML(context.Background(), []byte(yaml))
+		require.NoError(t, err)
+		require.Len(t, dag.Steps, 1)
+
+		step := dag.Steps[0]
+		assert.Equal(t, "harness", step.ExecutorConfig.Type)
+		require.NotNil(t, step.Container)
+		assert.Equal(t, "localhost/reviewer-claude:latest", step.Container.Image)
+		assert.Equal(t, []string{"./src:/src:ro"}, step.Container.Volumes)
+	})
+
 	t.Run("UnknownCustomHarnessProviderFailsBuild", func(t *testing.T) {
 		yaml := `
 steps:

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -1993,6 +1993,16 @@ func TestBuildStepContainer(t *testing.T) {
 				PullPolicy: core.PullPolicyMissing,
 			},
 		},
+		{
+			name: "RuntimeDefaultsToDocker",
+			input: &container{
+				Image: "alpine:3.18",
+			},
+			expected: &core.Container{
+				Image:      "alpine:3.18",
+				PullPolicy: core.PullPolicyMissing,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -799,6 +799,16 @@ func (a *Agent) Run(ctx context.Context) error {
 		if a.dag.Resources.HasLimits() && !docker.ApplyResourceLimitsToConfig(ctCfg, a.dag.Resources.Limits) {
 			logger.Warn(ctx, "Resource limits requested but cannot be applied to an existing container")
 		}
+		// Select the daemon (docker or podman) for the DAG-level container from the
+		// service-level DAGU_CONTAINER_RUNTIME setting, the same selector used by
+		// step-level container jobs and harness.run container steps. Empty
+		// (docker/unset) preserves upstream client.FromEnv behavior.
+		host, err := docker.ResolveDaemonHost(docker.ServiceRuntimeEnv())
+		if err != nil {
+			initErr = err
+			return initErr
+		}
+		ctCfg.DaemonHost = host
 		ctCli, err := docker.InitializeClient(ctx, ctCfg)
 		if err != nil {
 			initErr = fmt.Errorf("failed to initialize container client: %w", err)

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -103,6 +103,33 @@ func inspectContainer(ctx context.Context, cli *client.Client, containerID strin
 	return result.Container, nil
 }
 
+// daemonClientOpts builds the Moby client options for the given daemon host.
+//
+// Empty host is the Docker default and is exactly client.FromEnv — byte-identical
+// to upstream behavior (honoring DOCKER_HOST, DOCKER_CERT_PATH, DOCKER_API_VERSION).
+//
+// A non-empty host is the service-selected runtime (podman's Docker-compatible
+// socket via DAGU_CONTAINER_RUNTIME). It deliberately does NOT use client.FromEnv,
+// which is WithTLSClientConfigFromEnv + WithHostFromEnv + WithAPIVersionFromEnv:
+//   - WithTLSClientConfigFromEnv would couple the selected plain socket to Docker
+//     TLS env (DOCKER_CERT_PATH) — making client.New pick scheme=https, and failing
+//     client construction outright if those cert files are stale/missing.
+//   - WithHostFromEnv (DOCKER_HOST) must not override the explicit selection.
+//
+// So the selected-host client is built from only the intended pieces: the host, a
+// pinned http scheme for the plain Docker-compatible socket, and DOCKER_API_VERSION
+// negotiation.
+func daemonClientOpts(daemonHost string) []client.Opt {
+	if host := strings.TrimSpace(daemonHost); host != "" {
+		return []client.Opt{
+			client.WithHost(host),
+			client.WithScheme("http"),
+			client.WithAPIVersionFromEnv(),
+		}
+	}
+	return []client.Opt{client.FromEnv}
+}
+
 // InitializeClient creates a new container client
 func InitializeClient(ctx context.Context, cfg *Config) (*Client, error) {
 	logger.Debug(ctx, "Docker: InitializeClient started",
@@ -111,7 +138,7 @@ func InitializeClient(ctx context.Context, cfg *Config) (*Client, error) {
 		slog.Bool("autoRemove", cfg.AutoRemove),
 	)
 
-	dockerCli, err := client.New(client.FromEnv)
+	dockerCli, err := client.New(daemonClientOpts(cfg.DaemonHost)...)
 	if err != nil {
 		logger.Error(ctx, "Docker: failed to create docker client", tag.Error(err))
 		return nil, err
@@ -638,6 +665,15 @@ func (c *Client) StartBackground(ctx context.Context) error {
 func (c *Client) Stop(sig os.Signal) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// A closed client (Close set c.cli = nil) can no longer stop anything. This
+	// guards the cancel/Stop-vs-cleanup race: a captured *Client can have Stop
+	// called after a concurrent Close has nilled the underlying SDK handle (e.g.
+	// a containerized harness.run step cancelled as runContainerOnce's deferred
+	// Close runs). Without this guard the inspect below dereferences a nil client.
+	if c.cli == nil {
+		return nil
+	}
 
 	if c.containerID == "" {
 		return nil

--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -4,11 +4,13 @@
 package docker
 
 import (
+	"context"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"syscall"
 	"testing"
 
 	"github.com/dagucloud/dagu/internal/core"
@@ -1527,4 +1529,60 @@ func TestDockerClientRespectsDockerHostEnv(t *testing.T) {
 	defer cli.Close()
 
 	assert.Equal(t, "tcp://test-host:2375", cli.DaemonHost())
+}
+
+// TestDaemonClientOpts_SelectedHostIsolatedFromDockerTLSEnv guards the contract
+// that a service-selected daemon host (podman's Docker-compatible socket) is
+// isolated from Docker TLS environment. With a stale DOCKER_CERT_PATH, the Docker
+// default path (empty host -> client.FromEnv) fails client construction loading
+// certs, while the selected-host opts succeed because they do not apply
+// WithTLSClientConfigFromEnv. The selected host is also driven over plain http,
+// not https, and DOCKER_HOST does not override the explicit selection.
+func TestDaemonClientOpts_SelectedHostIsolatedFromDockerTLSEnv(t *testing.T) {
+	t.Setenv("DOCKER_CERT_PATH", filepath.Join(t.TempDir(), "missing-certs"))
+	t.Setenv("DOCKER_TLS_VERIFY", "1")
+	t.Setenv("DOCKER_HOST", "tcp://should-not-win:2375")
+
+	// Docker default path inherits the (stale) TLS env and fails to construct.
+	_, derr := client.New(daemonClientOpts("")...)
+	require.Error(t, derr, "docker default path inherits stale DOCKER_CERT_PATH and fails")
+
+	// Selected podman socket is isolated: construction succeeds, host is the
+	// selected socket (DOCKER_HOST did not win), and the scheme is plain http.
+	sockHost := "unix:///run/podman/podman.sock"
+	cli, err := client.New(daemonClientOpts(sockHost)...)
+	require.NoError(t, err, "selected host must not inherit Docker TLS env")
+	defer cli.Close()
+	assert.Equal(t, sockHost, cli.DaemonHost(), "explicit selection wins over DOCKER_HOST")
+}
+
+// TestClientStopAfterCloseIsNilSafe is a regression guard for the cancel/Stop
+// race: a captured *Client can have Stop() called after a concurrent Close()
+// has nilled the underlying SDK handle (e.g. a containerized harness.run step
+// cancelled as runContainerOnce's deferred Close runs). Close and Stop serialize
+// on c.mu, but serialization does not prevent the Close-then-Stop ordering, so
+// Stop must tolerate a nil c.cli rather than dereferencing it.
+func TestClientStopAfterCloseIsNilSafe(t *testing.T) {
+	sdkCli, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+
+	c := &Client{
+		// AutoRemove false so Close() does not attempt a daemon ContainerRemove;
+		// this test must stay daemon-free. The race we reproduce is purely the
+		// nil-handle ordering, not container teardown.
+		cfg:         &Config{AutoRemove: false},
+		cli:         sdkCli,
+		containerID: "deadbeef",
+	}
+	c.started.Store(true) // simulate a started container so Stop passes its guards
+
+	// Close() nils c.cli, exactly as the runContainerOnce cleanup defer does.
+	c.Close(context.Background())
+
+	// A Stop() that captured this *Client before cleanup now runs after Close.
+	// Without the nil guard this panics dereferencing c.cli; with it, it returns nil.
+	require.NotPanics(t, func() {
+		err := c.Stop(syscall.SIGTERM)
+		assert.NoError(t, err)
+	})
 }

--- a/internal/runtime/builtin/docker/config.go
+++ b/internal/runtime/builtin/docker/config.go
@@ -18,6 +18,13 @@ import (
 
 // Config holds the configuration for creating or using a container.
 type Config struct {
+	// DaemonHost optionally overrides the Docker-compatible daemon API host the
+	// Moby SDK client connects to (e.g. "unix:///run/podman/podman.sock"). Empty
+	// preserves the upstream client.FromEnv behavior (DOCKER_HOST or the default
+	// docker socket). Set from the DAGU_CONTAINER_RUNTIME service setting for all
+	// container forms: DAG-level container, step-level container jobs, and
+	// harness.run container steps (see ResolveDaemonHost in runtime.go).
+	DaemonHost string
 	// Image is the Docker image to use for creating a new container.
 	Image string
 	// Platform is the target platform for the container (e.g., linux/amd64).

--- a/internal/runtime/builtin/docker/executor.go
+++ b/internal/runtime/builtin/docker/executor.go
@@ -85,6 +85,13 @@ func getRegistryAuth(ctx context.Context) map[string]*core.AuthConfig {
 	return nil
 }
 
+// RegistryAuthFromContext exposes the context registry auth to other executors
+// (the harness executor reuses it so containerized harness steps pull private
+// images with the same auth as the docker executor).
+func RegistryAuthFromContext(ctx context.Context) map[string]*core.AuthConfig {
+	return getRegistryAuth(ctx)
+}
+
 type docker struct {
 	step      core.Step
 	stdout    io.Writer
@@ -379,6 +386,14 @@ func newDocker(ctx context.Context, step core.Step) (executor.Executor, error) {
 		// Set ShouldStart to true for step-level containers
 		// This ensures the container is automatically created and started
 		c.ShouldStart = true
+		// Select the daemon (docker or podman) from the service-level
+		// DAGU_CONTAINER_RUNTIME setting. Empty (docker/unset) preserves upstream
+		// client.FromEnv behavior.
+		host, err := ResolveDaemonHost(ServiceRuntimeEnv())
+		if err != nil {
+			return nil, err
+		}
+		c.DaemonHost = host
 		cfg = c
 	} else if len(execCfg.Config) > 0 {
 		// Priority 2: Executor config map (legacy syntax: executor.config)
@@ -390,6 +405,11 @@ func newDocker(ctx context.Context, step core.Step) (executor.Executor, error) {
 		// This ensures the container is automatically created and started
 		// if it does not exist or is stopped.
 		c.ShouldStart = true
+		host, err := ResolveDaemonHost(ServiceRuntimeEnv())
+		if err != nil {
+			return nil, err
+		}
+		c.DaemonHost = host
 		cfg = c
 	}
 

--- a/internal/runtime/builtin/docker/executor_test.go
+++ b/internal/runtime/builtin/docker/executor_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewDocker_SelectsDaemonHostFromServiceEnv proves that NATIVE container jobs
+// (step-level container: blocks and the legacy executor.config map) honor the
+// service-level DAGU_CONTAINER_RUNTIME setting, the same selector used by the
+// harness and DAG-level container paths. Runtime selection comes from the engine
+// process env (ServiceRuntimeEnv), so these tests set it with t.Setenv.
+func TestNewDocker_SelectsDaemonHostFromServiceEnv(t *testing.T) {
+	withEnv := func(ctx context.Context) context.Context {
+		return runtime.WithEnv(ctx, runtime.NewEnv(ctx, core.Step{Name: "test"}))
+	}
+	daemonHostOf := func(t *testing.T, e interface{}) string {
+		t.Helper()
+		d, ok := e.(*docker)
+		require.True(t, ok, "executor is *docker")
+		require.NotNil(t, d.cfg, "native container job should build a Config")
+		return d.cfg.DaemonHost
+	}
+
+	t.Run("step_container_image_mode_podman", func(t *testing.T) {
+		t.Setenv(ContainerRuntimeEnv, "podman")
+		ctx := withEnv(context.Background())
+		step := core.Step{Name: "job", Container: &core.Container{Image: "alpine:latest"}}
+		exec, err := newDocker(ctx, step)
+		require.NoError(t, err)
+		assert.Equal(t, PodmanDaemonHostDefault, daemonHostOf(t, exec))
+	})
+
+	t.Run("step_container_exec_mode_podman", func(t *testing.T) {
+		t.Setenv(ContainerRuntimeEnv, "podman")
+		ctx := withEnv(context.Background())
+		step := core.Step{Name: "job", Container: &core.Container{Exec: "existing"}}
+		exec, err := newDocker(ctx, step)
+		require.NoError(t, err)
+		assert.Equal(t, PodmanDaemonHostDefault, daemonHostOf(t, exec))
+	})
+
+	t.Run("legacy_map_config_podman", func(t *testing.T) {
+		t.Setenv(ContainerRuntimeEnv, "podman")
+		ctx := withEnv(context.Background())
+		step := core.Step{
+			Name: "job",
+			ExecutorConfig: core.ExecutorConfig{
+				Type:   "docker",
+				Config: map[string]any{"image": "alpine:latest"},
+			},
+		}
+		exec, err := newDocker(ctx, step)
+		require.NoError(t, err)
+		assert.Equal(t, PodmanDaemonHostDefault, daemonHostOf(t, exec))
+	})
+
+	t.Run("docker_and_unset_leave_daemon_host_empty", func(t *testing.T) {
+		// Unset -> docker default; explicit docker -> docker default. Either way
+		// DaemonHost stays empty so the client keeps upstream client.FromEnv.
+		for _, val := range []string{"", "docker"} {
+			if val == "" {
+				osUnsetForTest(t, ContainerRuntimeEnv)
+			} else {
+				t.Setenv(ContainerRuntimeEnv, val)
+			}
+			ctx := withEnv(context.Background())
+			step := core.Step{Name: "job", Container: &core.Container{Image: "alpine:latest"}}
+			exec, err := newDocker(ctx, step)
+			require.NoError(t, err)
+			assert.Equal(t, "", daemonHostOf(t, exec), "runtime %q must leave DaemonHost empty", val)
+		}
+	})
+
+	t.Run("invalid_runtime_fails_the_step", func(t *testing.T) {
+		t.Setenv(ContainerRuntimeEnv, "nerdctl")
+		ctx := withEnv(context.Background())
+		step := core.Step{Name: "job", Container: &core.Container{Image: "alpine:latest"}}
+		_, err := newDocker(ctx, step)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ContainerRuntimeEnv)
+	})
+}

--- a/internal/runtime/builtin/docker/runtime.go
+++ b/internal/runtime/builtin/docker/runtime.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/core"
+)
+
+// Container runtime selection is a SERVICE-LEVEL setting, not a per-step or
+// per-DAG YAML field. DAGU_CONTAINER_RUNTIME chooses docker (default) or podman
+// for every containerized step in this engine: harness.run agent steps,
+// step-level container jobs, and the DAG-level container. DAGU_PODMAN_HOST
+// optionally overrides podman's Docker-compatible socket path.
+const (
+	PodmanDaemonHostDefault = "unix:///run/podman/podman.sock"
+	PodmanDaemonHostEnv     = "DAGU_PODMAN_HOST"
+	ContainerRuntimeEnv     = "DAGU_CONTAINER_RUNTIME"
+)
+
+// ServiceRuntimeEnv returns the runtime-selection variables read from the engine
+// PROCESS environment only (os.LookupEnv), never from the DAG/step runtime scope.
+// Runtime selection is a service-level decision, so it must not be overridable by
+// a DAG- or step-level env: entry (the runtime scope precedence is
+// StepEnv > Outputs > Secrets > DAGEnv > OS, which would let a workflow redirect
+// the daemon socket). Only the two selection keys are surfaced.
+func ServiceRuntimeEnv() map[string]string {
+	m := make(map[string]string, 2)
+	if v, ok := os.LookupEnv(ContainerRuntimeEnv); ok {
+		m[ContainerRuntimeEnv] = v
+	}
+	if v, ok := os.LookupEnv(PodmanDaemonHostEnv); ok {
+		m[PodmanDaemonHostEnv] = v
+	}
+	return m
+}
+
+// ResolveContainerRuntime reads the deployment's DAGU_CONTAINER_RUNTIME setting
+// and parses it into the runtime enum, defaulting to docker when unset. This is
+// the single place that decides docker vs podman; there is no per-step field.
+func ResolveContainerRuntime(envs map[string]string) (core.ContainerRuntime, error) {
+	raw := ""
+	if envs != nil {
+		raw = strings.TrimSpace(envs[ContainerRuntimeEnv])
+	}
+	if raw == "" {
+		return core.ContainerRuntimeDocker, nil
+	}
+	rt, err := core.ParseContainerRuntime(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid %s: %w", ContainerRuntimeEnv, err)
+	}
+	return rt, nil
+}
+
+// ContainerDaemonHost maps the resolved container runtime to the daemon API host
+// the Moby SDK client should drive. docker (or empty) returns "" so the client
+// keeps upstream client.FromEnv behavior (honoring DOCKER_HOST). podman returns
+// its Docker-compatible socket, overridable via DAGU_PODMAN_HOST.
+func ContainerDaemonHost(rt core.ContainerRuntime, envs map[string]string) (string, error) {
+	switch rt {
+	case "", core.ContainerRuntimeDocker:
+		return "", nil
+	case core.ContainerRuntimePodman:
+		if envs != nil {
+			if host := strings.TrimSpace(envs[PodmanDaemonHostEnv]); host != "" {
+				return host, nil
+			}
+		}
+		return PodmanDaemonHostDefault, nil
+	default:
+		return "", fmt.Errorf("unsupported container runtime %q", rt)
+	}
+}
+
+// ResolveDaemonHost is the production call site: it resolves DAGU_CONTAINER_RUNTIME
+// from the given env map and returns the daemon API host to drive ("" for docker,
+// the podman socket for podman). Callers pass ServiceRuntimeEnv() so the selection
+// comes only from the engine process environment.
+func ResolveDaemonHost(envs map[string]string) (string, error) {
+	rt, err := ResolveContainerRuntime(envs)
+	if err != nil {
+		return "", err
+	}
+	return ContainerDaemonHost(rt, envs)
+}

--- a/internal/runtime/builtin/docker/runtime_test.go
+++ b/internal/runtime/builtin/docker/runtime_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveContainerRuntime(t *testing.T) {
+	t.Run("unset_defaults_to_docker", func(t *testing.T) {
+		rt, err := ResolveContainerRuntime(nil)
+		require.NoError(t, err)
+		assert.Equal(t, core.ContainerRuntimeDocker, rt)
+	})
+	t.Run("empty_defaults_to_docker", func(t *testing.T) {
+		rt, err := ResolveContainerRuntime(map[string]string{ContainerRuntimeEnv: "  "})
+		require.NoError(t, err)
+		assert.Equal(t, core.ContainerRuntimeDocker, rt)
+	})
+	t.Run("docker", func(t *testing.T) {
+		rt, err := ResolveContainerRuntime(map[string]string{ContainerRuntimeEnv: "docker"})
+		require.NoError(t, err)
+		assert.Equal(t, core.ContainerRuntimeDocker, rt)
+	})
+	t.Run("podman", func(t *testing.T) {
+		rt, err := ResolveContainerRuntime(map[string]string{ContainerRuntimeEnv: "podman"})
+		require.NoError(t, err)
+		assert.Equal(t, core.ContainerRuntimePodman, rt)
+	})
+	t.Run("invalid_errors", func(t *testing.T) {
+		_, err := ResolveContainerRuntime(map[string]string{ContainerRuntimeEnv: "nerdctl"})
+		require.Error(t, err)
+	})
+}
+
+func TestContainerDaemonHost(t *testing.T) {
+	t.Run("docker_and_empty_use_from_env", func(t *testing.T) {
+		for _, rt := range []core.ContainerRuntime{"", core.ContainerRuntimeDocker} {
+			host, err := ContainerDaemonHost(rt, nil)
+			require.NoError(t, err)
+			assert.Equal(t, "", host)
+		}
+	})
+	t.Run("podman_default_socket", func(t *testing.T) {
+		host, err := ContainerDaemonHost(core.ContainerRuntimePodman, nil)
+		require.NoError(t, err)
+		assert.Equal(t, PodmanDaemonHostDefault, host)
+	})
+	t.Run("podman_env_override", func(t *testing.T) {
+		host, err := ContainerDaemonHost(core.ContainerRuntimePodman,
+			map[string]string{PodmanDaemonHostEnv: "unix:///x.sock"})
+		require.NoError(t, err)
+		assert.Equal(t, "unix:///x.sock", host)
+	})
+	t.Run("unknown_runtime_errors", func(t *testing.T) {
+		_, err := ContainerDaemonHost(core.ContainerRuntime("nerdctl"), nil)
+		require.Error(t, err)
+	})
+}
+
+// ResolveDaemonHost is the production call site (resolve + map in one step).
+func TestResolveDaemonHost(t *testing.T) {
+	t.Run("nil_and_docker_yield_empty", func(t *testing.T) {
+		for _, envs := range []map[string]string{
+			nil,
+			{ContainerRuntimeEnv: "  "},
+			{ContainerRuntimeEnv: "docker"},
+		} {
+			host, err := ResolveDaemonHost(envs)
+			require.NoError(t, err)
+			assert.Equal(t, "", host, "envs %v should resolve to the docker default (empty host)", envs)
+		}
+	})
+	t.Run("podman_default_socket", func(t *testing.T) {
+		host, err := ResolveDaemonHost(map[string]string{ContainerRuntimeEnv: "podman"})
+		require.NoError(t, err)
+		assert.Equal(t, PodmanDaemonHostDefault, host)
+	})
+	t.Run("podman_host_override", func(t *testing.T) {
+		host, err := ResolveDaemonHost(map[string]string{
+			ContainerRuntimeEnv: "podman",
+			PodmanDaemonHostEnv: "unix:///custom/podman.sock",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "unix:///custom/podman.sock", host)
+	})
+	t.Run("invalid_errors", func(t *testing.T) {
+		_, err := ResolveDaemonHost(map[string]string{ContainerRuntimeEnv: "nerdctl"})
+		require.Error(t, err)
+	})
+}
+
+// TestServiceRuntimeEnv_ReadsProcessEnvOnly locks the contract that runtime/socket
+// selection is a SERVICE-LEVEL decision: ServiceRuntimeEnv must source the two
+// selection keys from the engine process environment (os.LookupEnv) only, so a
+// DAG- or step-level env: entry cannot override it. Regression guard for the
+// workflow-overridable-selector finding.
+func TestServiceRuntimeEnv_ReadsProcessEnvOnly(t *testing.T) {
+	t.Run("unset_yields_empty_map", func(t *testing.T) {
+		osUnsetForTest(t, ContainerRuntimeEnv)
+		osUnsetForTest(t, PodmanDaemonHostEnv)
+		got := ServiceRuntimeEnv()
+		_, hasRT := got[ContainerRuntimeEnv]
+		_, hasHost := got[PodmanDaemonHostEnv]
+		assert.False(t, hasRT, "DAGU_CONTAINER_RUNTIME must be absent when unset in process env")
+		assert.False(t, hasHost, "DAGU_PODMAN_HOST must be absent when unset in process env")
+	})
+	t.Run("reads_process_env_values", func(t *testing.T) {
+		t.Setenv(ContainerRuntimeEnv, "podman")
+		t.Setenv(PodmanDaemonHostEnv, "unix:///run/podman/podman.sock")
+		got := ServiceRuntimeEnv()
+		assert.Equal(t, "podman", got[ContainerRuntimeEnv])
+		assert.Equal(t, "unix:///run/podman/podman.sock", got[PodmanDaemonHostEnv])
+	})
+}
+
+// osUnsetForTest unsets an environment variable for the duration of the test,
+// restoring any prior value on cleanup. t.Setenv cannot unset, so we manage it here.
+func osUnsetForTest(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}

--- a/internal/runtime/builtin/harness/harness.go
+++ b/internal/runtime/builtin/harness/harness.go
@@ -24,9 +24,11 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	coreexec "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime"
+	dockerexec "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/resourcelimit"
 	"github.com/goccy/go-yaml"
+	dockerclient "github.com/moby/moby/client"
 )
 
 var _ executor.Executor = (*harnessExecutor)(nil)
@@ -69,6 +71,10 @@ type harnessExecutor struct {
 	pushBackInputs         map[string]string
 	pushBackIteration      int
 	pushBackPreviousStdout string
+
+	// container-run state (SDK path); set under mu while a containerized step runs
+	containerClient *dockerexec.Client
+	containerCancel context.CancelFunc
 }
 
 func (e *harnessExecutor) ExitCode() int {
@@ -104,15 +110,32 @@ func (e *harnessExecutor) Stop(intent cmdutil.TerminationIntent) error {
 
 func (e *harnessExecutor) stop(req cmdutil.StopRequest) error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if e.process == nil {
 		if e.cancelBuiltin != nil {
 			e.builtinStopped = true
 			e.cancelBuiltin()
 			e.cancelBuiltin = nil
 		}
+		// Containerized run: cancel the run context and stop the container via
+		// the SDK so a cancelled step leaves no running orphan (Close auto-removes
+		// when AutoRemove is set, i.e. keep_container is false).
+		if e.containerClient != nil || e.containerCancel != nil {
+			cli := e.containerClient
+			cancel := e.containerCancel
+			e.containerCancel = nil
+			e.mu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
+			if cli != nil {
+				return cli.Stop(req.Intent.Signal)
+			}
+			return nil
+		}
+		e.mu.Unlock()
 		return nil
 	}
+	defer e.mu.Unlock()
 	_, err := e.process.Stop(req)
 	return err
 }
@@ -195,9 +218,23 @@ func (e *harnessExecutor) Run(ctx context.Context) error {
 
 func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.File, error) {
 	if cfg.builtin {
+		if e.step.Container != nil {
+			e.exitCode = 1
+			return nil, fmt.Errorf("harness: builtin provider does not support container execution")
+		}
 		return e.runBuiltinOnce(ctx, cfg)
 	}
 
+	if e.step.Container != nil {
+		return e.runContainerOnce(ctx, cfg)
+	}
+
+	return e.runHostSubprocessOnce(ctx, cfg)
+}
+
+// runHostSubprocessOnce runs the agent CLI as a host subprocess (the
+// non-container path). Unchanged from the original runOnce behavior.
+func (e *harnessExecutor) runHostSubprocessOnce(ctx context.Context, cfg providerConfig) (*os.File, error) {
 	e.mu.Lock()
 
 	env := runtime.GetEnv(ctx)
@@ -210,16 +247,6 @@ func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.
 		return nil, err
 	}
 
-	binaryPath, err := resolveBinaryPath(cfg.binaryName(), e.workDir, runtime.AllEnvsMap(ctx))
-	if err != nil {
-		e.exitCode = exitCodeFromError(err)
-		e.mu.Unlock()
-		if errors.Is(err, exec.ErrNotFound) {
-			return nil, fmt.Errorf("harness: %q CLI not found in PATH; install it first: %w", cfg.binaryName(), err)
-		}
-		return nil, fmt.Errorf("harness: failed to resolve binary %q: %w", cfg.binaryName(), err)
-	}
-
 	stdout, err := newStdoutSpool()
 	if err != nil {
 		e.exitCode = 1
@@ -227,14 +254,14 @@ func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.
 		return nil, fmt.Errorf("harness: failed to create stdout spool: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...)
-	if len(cmd.Args) > 0 {
-		cmd.Args[0] = cfg.binaryName()
+	cmd, err := e.invocationCommand(ctx, cfg, args, stdin, stdout, tw)
+	if err != nil {
+		e.exitCode = exitCodeFromError(err)
+		_ = cleanupStdoutSpool(stdout)
+		e.mu.Unlock()
+		return nil, err
 	}
-	cmd.Env = append(cmd.Env, runtime.AllEnvs(ctx)...)
-	cmd.Dir = e.workDir
-	cmd.Stdout = stdout
-	cmd.Stderr = tw
+
 	if cmd.Dir != "" {
 		if err := os.MkdirAll(cmd.Dir, 0o750); err != nil {
 			e.exitCode = 1
@@ -244,10 +271,300 @@ func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.
 		}
 	}
 
+	return e.startAndWaitLocked(ctx, cmd, stdout, tw, env.LogEncodingCharset)
+}
+
+func (e *harnessExecutor) invocationCommand(ctx context.Context, cfg providerConfig, args []string, stdin io.Reader, stdout *os.File, stderr io.Writer) (*exec.Cmd, error) {
+	binaryPath, err := resolveBinaryPath(cfg.binaryName(), e.workDir, runtime.AllEnvsMap(ctx))
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("harness: %q CLI not found in PATH; install it first: %w", cfg.binaryName(), err)
+		}
+		return nil, fmt.Errorf("harness: failed to resolve binary %q: %w", cfg.binaryName(), err)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	if len(cmd.Args) > 0 {
+		cmd.Args[0] = cfg.binaryName()
+	}
+	cmd.Env = append(cmd.Env, runtime.AllEnvs(ctx)...)
+	cmd.Dir = e.workDir
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
+	return cmd, nil
+}
 
+// mergedContainerEnv merges inherited engine env and explicit container.env into
+// full KEY=value entries (explicit wins by key). Used as the SDK container's
+// Config.Env, so secret values are passed as container env, never in argv.
+func mergedContainerEnv(inherited, explicit []string) []string {
+	merged := append([]string(nil), inherited...)
+	indexByKey := make(map[string]int, len(merged))
+	for i, entry := range merged {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key != "" {
+			indexByKey[key] = i
+		}
+	}
+	for _, entry := range explicit {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if idx, exists := indexByKey[key]; exists {
+			merged[idx] = entry
+			continue
+		}
+		indexByKey[key] = len(merged)
+		merged = append(merged, entry)
+	}
+	return merged
+}
+
+// buildHarnessContainerRunConfig builds the Moby SDK container config for running
+// the agent CLI inside a container, plus the command slice to hand to the client.
+// Pure (no daemon/IO) so it is unit-testable. The agent binary becomes the
+// container entrypoint (image mode) so an image ENTRYPOINT does not double it.
+func buildHarnessContainerRunConfig(
+	workDir string,
+	ct core.Container,
+	registryAuths map[string]*core.AuthConfig,
+	binaryName string,
+	args []string,
+	inheritedEnv []string,
+	envs map[string]string,
+) (*dockerexec.Config, []string, error) {
+	if strings.TrimSpace(binaryName) == "" {
+		return nil, nil, fmt.Errorf("harness: empty container command")
+	}
+
+	host, err := dockerexec.ResolveDaemonHost(envs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mergedEnv := mergedContainerEnv(inheritedEnv, ct.Env)
+
+	cfg, err := dockerexec.LoadConfig(workDir, ct, registryAuths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("harness: failed to build container config: %w", err)
+	}
+	cfg.DaemonHost = host
+	cfg.ShouldStart = true
+
+	var runCmd []string
+	if ct.IsExecMode() {
+		// exec into an existing container: no image entrypoint to collide with,
+		// so the command is the full [binary, args...]. Env goes on ExecOptions.
+		if cfg.ExecOptions == nil {
+			cfg.ExecOptions = &dockerclient.ExecCreateOptions{}
+		}
+		cfg.ExecOptions.Env = mergedEnv
+		runCmd = append([]string{binaryName}, args...)
+		return cfg, runCmd, nil
+	}
+
+	// image mode: agent binary is the entrypoint, args are the command. Setting
+	// Entrypoint=[binary] avoids doubling an image-level ENTRYPOINT (e.g. the
+	// reviewer-claude image has ENTRYPOINT ["claude"]).
+	//
+	// That entrypoint+args shaping is correct only on the container-CREATE path.
+	// A named container (container.name) can resolve to an already-running
+	// container, in which case Client.Run execs the args INTO it; docker exec
+	// ignores the image/Config entrypoint, so the agent binary would be dropped
+	// and the wrong command run. The harness container model is a fresh ephemeral
+	// container, so reject container.name in image mode; targeting an existing
+	// container is the job of exec mode (container.exec).
+	if strings.TrimSpace(ct.Name) != "" {
+		return nil, nil, fmt.Errorf("harness: container.name is not supported for an image-mode container step (it would exec into an existing container without the agent entrypoint); use exec mode (container.exec) to run inside an existing container")
+	}
+	if cfg.Container == nil {
+		return nil, nil, fmt.Errorf("harness: container config missing for image %q", ct.Image)
+	}
+	cfg.Container.Entrypoint = []string{binaryName}
+	cfg.Container.Cmd = []string{}
+	cfg.Container.Env = mergedEnv
+	runCmd = append([]string(nil), args...)
+	return cfg, runCmd, nil
+}
+
+// runContainerOnce runs the agent CLI inside a container by driving Dagu's Moby
+// SDK Client (create + start + stream + auto-remove), against the daemon socket
+// chosen by the DAGU_CONTAINER_RUNTIME service setting. No docker/podman CLI subprocess is used.
+func (e *harnessExecutor) runContainerOnce(ctx context.Context, cfg providerConfig) (*os.File, error) {
+	e.mu.Lock()
+
+	env := runtime.GetEnv(ctx)
+	tw := executor.NewTailWriterWithEncoding(e.stderrWriter(), 0, env.LogEncodingCharset)
+	e.stderrTail = tw
+
+	args, stdin, err := cfg.buildInvocation(e.effectivePrompt(), e.script)
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, err
+	}
+	if stdin != nil {
+		// Client.Run has no stdin. The script + container combination is rejected
+		// earlier at validation (validateHarnessStep); this guards the remaining
+		// stdin source — a custom harness with prompt_mode: stdin — which can only
+		// be known after provider resolution. The CLI providers we containerize
+		// (claude/codex/copilot) pass the prompt as argv, not stdin.
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: containerized harness does not support stdin input (prompt_mode: stdin); use a provider that passes the prompt as arguments")
+	}
+
+	expanded, err := dockerexec.EvalContainerFields(ctx, *e.step.Container)
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: failed to evaluate container config: %w", err)
+	}
+
+	// Inject only USER-declared env (DAG env, step env, outputs, secrets, params)
+	// into the container, NOT the engine's OS env. The container has its own
+	// HOME/PATH/USER from its image; injecting the engine container's os.Environ
+	// would clobber them (e.g. HOME=/home/iand.guest, which is unwritable as the
+	// image's uid and breaks the agent CLI). This mirrors the docker executor,
+	// which injects only ct.Env.
+	userEnv := env.UserEnvsMap()
+	inheritedEnv := make([]string, 0, len(userEnv))
+	for k, v := range userEnv {
+		inheritedEnv = append(inheritedEnv, k+"="+v)
+	}
+
+	dcfg, runCmd, err := buildHarnessContainerRunConfig(
+		e.workDir,
+		expanded,
+		dockerexec.RegistryAuthFromContext(ctx),
+		cfg.binaryName(),
+		args,
+		inheritedEnv,
+		// Runtime/socket selection comes from the engine PROCESS env only, so a
+		// DAG/step env: cannot override the service-level DAGU_CONTAINER_RUNTIME
+		// or DAGU_PODMAN_HOST and redirect the daemon socket.
+		dockerexec.ServiceRuntimeEnv(),
+	)
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, err
+	}
+
+	// Apply DAG resource limits to the harness container, mirroring the native
+	// docker executor (newDocker) and the DAG-level container path (agent.go).
+	// The host-subprocess harness path is constrained via the resourcelimit guard
+	// on the child PID, but a daemon-created container is only constrained through
+	// its HostConfig, so without this a containerized harness.run step would run
+	// unbounded by the DAG's configured CPU/memory limits.
+	if env.DAG != nil && env.DAG.Resources.HasLimits() &&
+		!dockerexec.ApplyResourceLimitsToConfig(dcfg, env.DAG.Resources.Limits) {
+		logger.Warn(ctx, "Resource limits requested but cannot be applied to the harness container")
+	}
+
+	stdout, err := newStdoutSpool()
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: failed to create stdout spool: %w", err)
+	}
+
+	// Publish the cancellable run context BEFORE the (potentially slow)
+	// InitializeClient and release e.mu across init. Exec-mode readiness can wait
+	// up to ~120s inside InitializeClient; Node.Stop dispatches to this executor's
+	// Stop (it does not cancel the run ctx once an executor exists), and Stop needs
+	// e.mu. Holding e.mu across init would block Stop until init returned. Mirrors
+	// the native docker executor, which sets its cancel before InitializeClient.
+	// The client itself is published only after init succeeds.
+	runCtx, cancel := context.WithCancel(ctx)
+	e.containerCancel = cancel
+	e.mu.Unlock()
+
+	cli, err := dockerexec.InitializeClient(runCtx, dcfg)
+	if err != nil {
+		e.mu.Lock()
+		e.containerCancel = nil
+		e.exitCode = 1
+		e.mu.Unlock()
+		cancel()
+		_ = cleanupStdoutSpool(stdout)
+		return nil, fmt.Errorf("harness: failed to initialize container client: %w", err)
+	}
+
+	e.mu.Lock()
+	e.containerClient = cli
+	e.mu.Unlock()
+
+	defer func() {
+		// Clear the client references under the lock BEFORE closing the client, so
+		// a concurrent Stop()/Kill() cannot observe a non-nil containerClient and
+		// then call Stop() on a client whose Close() has nil'd the underlying SDK
+		// handle.
+		e.mu.Lock()
+		e.containerClient = nil
+		e.containerCancel = nil
+		e.mu.Unlock()
+		cli.Close(ctx)
+		cancel()
+	}()
+
+	// Run the container in a goroutine and watch ctx so a cancelled step (e.g.
+	// timeout_sec, which arrives only as ctx cancellation, not as a Stop() call)
+	// stops the container instead of blocking forever in Client.Run's post-wait
+	// loop. Mirrors the host subprocess path in startAndWaitLocked.
+	type containerRunResult struct {
+		exitCode int
+		err      error
+	}
+	runDone := make(chan containerRunResult, 1)
+	go func() {
+		ec, re := cli.Run(runCtx, runCmd, stdout, tw)
+		runDone <- containerRunResult{exitCode: ec, err: re}
+	}()
+
+	var exitCode int
+	var runErr error
+	select {
+	case <-ctx.Done():
+		// Stop the container via the SDK, then wait for Run to unwind.
+		_ = e.stop(cmdutil.StopRequest{Intent: cmdutil.ForceTermination(), Reason: cmdutil.StopReasonTimeout})
+		<-runDone
+		e.exitCode = 124
+		_ = cleanupStdoutSpool(stdout)
+		return nil, ctx.Err()
+	case res := <-runDone:
+		exitCode, runErr = res.exitCode, res.err
+	}
+
+	e.exitCode = exitCode
+	if runErr != nil {
+		if exitCode == 0 {
+			e.exitCode = exitCodeFromError(runErr)
+		}
+		stdoutTail, tailErr := readSpoolTail(stdout, failedStdoutTailLimit, env.LogEncodingCharset)
+		_ = cleanupStdoutSpool(stdout)
+		if tailErr != nil {
+			return nil, fmt.Errorf("harness: failed to read stdout tail: %w", tailErr)
+		}
+		if stdoutTail != "" {
+			_, _ = fmt.Fprintf(e.stderrWriter(), "recent stdout (tail):\n%s\n", stdoutTail)
+		}
+		return nil, formatProcessFailure(runErr, tw.Tail(), stdoutTail)
+	}
+
+	if _, err := stdout.Seek(0, io.SeekStart); err != nil {
+		e.exitCode = 1
+		_ = cleanupStdoutSpool(stdout)
+		return nil, fmt.Errorf("harness: failed to rewind stdout spool: %w", err)
+	}
+	return stdout, nil
+}
+
+func (e *harnessExecutor) startAndWaitLocked(ctx context.Context, cmd *exec.Cmd, stdout *os.File, tw *executor.TailWriter, logEncoding string) (*os.File, error) {
 	process, err := cmdutil.StartManagedProcess(cmd)
 	if err != nil {
 		e.exitCode = exitCodeFromError(err)
@@ -279,7 +596,7 @@ func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.
 	case err := <-waitDone:
 		if err != nil {
 			e.exitCode = exitCodeFromError(err)
-			stdoutTail, tailErr := readSpoolTail(stdout, failedStdoutTailLimit, env.LogEncodingCharset)
+			stdoutTail, tailErr := readSpoolTail(stdout, failedStdoutTailLimit, logEncoding)
 			_ = cleanupStdoutSpool(stdout)
 			if tailErr != nil {
 				return nil, fmt.Errorf("harness: failed to read stdout tail: %w", tailErr)
@@ -673,6 +990,16 @@ func validateHarnessStep(step core.Step) error {
 	if err := validatePromptCommand(step); err != nil {
 		return err
 	}
+	// A containerized harness step runs the agent via the Moby SDK Client.Run,
+	// which has no stdin; script input is piped to stdin only on the host
+	// subprocess path. Reject the script + container combination at validation
+	// time (fail fast at DAG load) instead of letting it pass and fail at run
+	// time, since the executor advertises both Script and Container capability.
+	// Use container.exec or drop script: to run a scripted harness in a container.
+	if step.Container != nil && strings.TrimSpace(step.Script) != "" {
+		return core.NewValidationError("script", nil,
+			fmt.Errorf("action %q does not support script with a container; the containerized agent has no stdin", "harness"))
+	}
 	cfg := step.ExecutorConfig.Config
 	if cfg == nil {
 		return core.NewValidationError("with", nil, fmt.Errorf("config is required"))
@@ -991,8 +1318,9 @@ func exitCodeFromError(err error) int {
 
 func init() {
 	caps := core.ExecutorCapabilities{
-		Command: true,
-		Script:  true,
+		Command:   true,
+		Script:    true,
+		Container: true,
 	}
 	executor.RegisterExecutor("harness", newHarness, validateHarnessStep, caps)
 }

--- a/internal/runtime/builtin/harness/harness_test.go
+++ b/internal/runtime/builtin/harness/harness_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/runtime"
+	dockerexec "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -835,6 +836,303 @@ func TestHarnessExecutorRun_UsesPATHFromRuntimeEnv(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "resolved from path\n", stdout.String())
 	assert.Empty(t, stderr.String())
+}
+
+func TestBuildHarnessContainerRunConfig_PodmanImageMode(t *testing.T) {
+	ct := core.Container{
+		Image:      "localhost/reviewer:latest",
+		WorkingDir: "/work",
+		Network:    "host",
+		Volumes:    []string{"/host/src:/src:ro"},
+		Env:        []string{"HARNESS_TOKEN=secret"},
+	}
+	inherited := []string{"PATH=/bin", "HARNESS_TOKEN=old"}
+	// DAGU_CONTAINER_RUNTIME=podman selects the podman runtime for the engine.
+	envs := map[string]string{dockerexec.ContainerRuntimeEnv: "podman"}
+
+	cfg, runCmd, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "missing-agent", []string{"hello from harness"}, inherited, envs,
+	)
+	require.NoError(t, err)
+
+	// podman runtime selects podman's Docker-compatible socket.
+	assert.Equal(t, dockerexec.PodmanDaemonHostDefault, cfg.DaemonHost)
+	assert.Equal(t, "localhost/reviewer:latest", cfg.Image)
+	assert.True(t, cfg.AutoRemove, "ephemeral by default (keep_container false)")
+	assert.True(t, cfg.ShouldStart)
+
+	require.NotNil(t, cfg.Container)
+	// The agent binary is the entrypoint (so an image ENTRYPOINT is not doubled),
+	// and the args are the command.
+	assert.Equal(t, []string{"missing-agent"}, cfg.Container.Entrypoint)
+	assert.Equal(t, []string{"hello from harness"}, runCmd)
+
+	// Env is full KEY=value on the container config (secrets never in argv);
+	// explicit container.env overrides inherited by key.
+	assert.Contains(t, cfg.Container.Env, "PATH=/bin")
+	assert.Contains(t, cfg.Container.Env, "HARNESS_TOKEN=secret")
+	assert.NotContains(t, cfg.Container.Env, "HARNESS_TOKEN=old")
+
+	// network: host maps to the SDK host network mode.
+	require.NotNil(t, cfg.Host)
+	assert.Equal(t, "host", string(cfg.Host.NetworkMode))
+}
+
+func TestBuildHarnessContainerRunConfig_DockerRuntimeUsesFromEnv(t *testing.T) {
+	// docker is the default: both an unset env and an explicit "docker" leave
+	// DaemonHost empty, preserving upstream client.FromEnv behavior.
+	for _, envs := range []map[string]string{
+		nil,
+		{dockerexec.ContainerRuntimeEnv: "docker"},
+	} {
+		ct := core.Container{Image: "localhost/reviewer:latest"}
+		cfg, _, err := buildHarnessContainerRunConfig(
+			"/work", ct, nil, "claude", []string{"-p", "hi"}, nil, envs,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "", cfg.DaemonHost, "env %v should not override the daemon host", envs)
+	}
+}
+
+func TestBuildHarnessContainerRunConfig_PodmanHostOverride(t *testing.T) {
+	ct := core.Container{Image: "localhost/reviewer:latest"}
+	envs := map[string]string{
+		dockerexec.ContainerRuntimeEnv: "podman",
+		dockerexec.PodmanDaemonHostEnv: "unix:///custom/podman.sock",
+	}
+	cfg, _, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "unix:///custom/podman.sock", cfg.DaemonHost)
+}
+
+func TestBuildHarnessContainerRunConfig_InvalidRuntimeRejected(t *testing.T) {
+	ct := core.Container{Image: "localhost/reviewer:latest"}
+	envs := map[string]string{dockerexec.ContainerRuntimeEnv: "containerd"}
+	_, _, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.Error(t, err)
+}
+
+func TestBuildHarnessContainerRunConfig_ExecModeUsesFullCommand(t *testing.T) {
+	ct := core.Container{Exec: "existing-container"}
+	envs := map[string]string{dockerexec.ContainerRuntimeEnv: "podman"}
+	cfg, runCmd, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "missing-agent", []string{"hello"}, []string{"FOO=bar"}, envs,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "existing-container", cfg.ContainerName)
+	assert.Equal(t, dockerexec.PodmanDaemonHostDefault, cfg.DaemonHost)
+	// exec into an existing container: full [binary, args...], no image entrypoint.
+	assert.Equal(t, []string{"missing-agent", "hello"}, runCmd)
+	require.NotNil(t, cfg.ExecOptions)
+	assert.Contains(t, cfg.ExecOptions.Env, "FOO=bar")
+}
+
+func TestBuildHarnessContainerRunConfig_EmptyBinaryRejected(t *testing.T) {
+	ct := core.Container{Image: "localhost/reviewer:latest"}
+	_, _, err := buildHarnessContainerRunConfig("/work", ct, nil, "", nil, nil, nil)
+	require.Error(t, err)
+}
+
+// TestBuildHarnessContainerRunConfig_ImageModeNamedContainerRejected guards the
+// image-mode command-shape invariant: in image mode the agent binary is supplied
+// via the container Entrypoint, which the daemon applies only on container CREATE.
+// A container.name can resolve to an already-running container, where Client.Run
+// execs the args INTO it and docker exec ignores the entrypoint, dropping the
+// agent binary. So image mode must reject container.name; exec mode is the
+// supported way to run inside an existing container.
+func TestBuildHarnessContainerRunConfig_ImageModeNamedContainerRejected(t *testing.T) {
+	ct := core.Container{Image: "localhost/reviewer:latest", Name: "already-running"}
+	envs := map[string]string{dockerexec.ContainerRuntimeEnv: "podman"}
+	_, _, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container.name is not supported")
+
+	// Sanity: the same image WITHOUT a name still builds fine (the proven path).
+	ctNoName := core.Container{Image: "localhost/reviewer:latest"}
+	_, _, err = buildHarnessContainerRunConfig(
+		"/work", ctNoName, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.NoError(t, err)
+
+	// Exec mode legitimately targets an existing container and must NOT be rejected
+	// by the image-mode guard (it returns the full [binary, args...] command).
+	ctExec := core.Container{Exec: "already-running"}
+	cfg, runCmd, err := buildHarnessContainerRunConfig(
+		"/work", ctExec, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "already-running", cfg.ContainerName)
+	assert.Equal(t, []string{"claude", "-p", "hi"}, runCmd)
+}
+
+// TestServiceRuntimeEnv_ReadsProcessEnvOnly locks the contract that runtime/socket
+// selection is a SERVICE-LEVEL decision: dockerexec.ServiceRuntimeEnv must source
+// the two selection keys from the engine process environment (os.LookupEnv) only,
+// so a DAG- or step-level env: entry cannot override it. This harness-side test
+// proves the property end-to-end through buildHarnessContainerRunConfig (the
+// resolver's own unit tests live in the docker package).
+func TestServiceRuntimeEnv_ReadsProcessEnvOnly(t *testing.T) {
+	t.Run("ignores_dag_and_step_scope", func(t *testing.T) {
+		// Process env selects docker (default). A DAG/step env: entry that sets the
+		// selector to podman must NOT leak in, because ServiceRuntimeEnv never
+		// consults the runtime scope. Assert that buildHarnessContainerRunConfig,
+		// fed by ServiceRuntimeEnv(), keeps the docker default daemon host even
+		// though the inheritedEnv below carries a podman selector.
+		osUnsetForTest(t, dockerexec.ContainerRuntimeEnv) // process: unset -> docker default
+		osUnsetForTest(t, dockerexec.PodmanDaemonHostEnv)
+
+		got := dockerexec.ServiceRuntimeEnv()
+		_, leaked := got[dockerexec.ContainerRuntimeEnv]
+		assert.False(t, leaked, "selector must not come from anywhere but process env")
+
+		ct := core.Container{Image: "localhost/reviewer:latest"}
+		// inheritedEnv simulates a DAG/step env: trying to redirect the runtime;
+		// the resolver must ignore it because it reads ServiceRuntimeEnv() only.
+		cfg, _, err := buildHarnessContainerRunConfig(
+			"/work", ct, nil, "claude", []string{"-p", "hi"},
+			[]string{dockerexec.ContainerRuntimeEnv + "=podman"},
+			dockerexec.ServiceRuntimeEnv(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "", cfg.DaemonHost,
+			"with process env unset, daemon host stays docker default even if a DAG/step set podman")
+	})
+}
+
+// osUnsetForTest unsets an environment variable for the duration of the test,
+// restoring any prior value on cleanup. t.Setenv cannot unset, so we manage it here.
+func osUnsetForTest(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+// TestRunOnce_BuiltinProviderWithContainerRejected covers the daemon-free rejection
+// path: a builtin (in-process) provider cannot run inside a container. The error
+// must surface before any SDK client is initialized, so no Docker daemon is needed.
+func TestRunOnce_BuiltinProviderWithContainerRejected(t *testing.T) {
+	exec := &harnessExecutor{
+		step: core.Step{
+			Name:      "review",
+			Container: &core.Container{Image: "localhost/reviewer:latest"},
+		},
+	}
+	_, err := exec.runOnce(context.Background(), providerConfig{name: "builtin", builtin: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "builtin provider does not support container execution")
+	assert.Equal(t, 1, exec.ExitCode())
+}
+
+// TestRunContainerOnce_StdinScriptRejected covers the daemon-free rejection path:
+// containerized harness does not support stdin input, because Client.Run has no
+// stdin. The script + container combination is rejected earlier at validation
+// (see TestValidateHarnessStep_ScriptWithContainerRejected); this guards the
+// remaining stdin source — a custom provider with prompt_mode: stdin — which is
+// only knowable after provider resolution, so it must be rejected before any SDK
+// client is initialized.
+func TestRunContainerOnce_StdinScriptRejected(t *testing.T) {
+	exec := &harnessExecutor{
+		step: core.Step{
+			Name:      "review",
+			Container: &core.Container{Image: "localhost/reviewer:latest"},
+		},
+		prompt: "do the thing",
+		script: "extra stdin context",
+	}
+	cfg := providerConfig{
+		name: "stdinly",
+		definition: &core.HarnessDefinition{
+			Binary:     "stdinly",
+			PromptMode: core.HarnessPromptModeStdin,
+			FlagStyle:  core.HarnessFlagStyleGNULong,
+		},
+		flags: map[string]any{"provider": "stdinly"},
+	}
+	_, err := exec.runContainerOnce(newHarnessTestContext(t, nil, exec.step), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support stdin")
+	assert.Equal(t, 1, exec.ExitCode())
+}
+
+// TestValidateHarnessStep_ScriptWithContainerRejected proves the script + container
+// combination fails fast at DAG-load validation rather than at run time. The
+// containerized agent runs via Client.Run which has no stdin, so a script (piped
+// to stdin on the host path) cannot be delivered. The executor advertises both
+// Script and Container capability, so without this validation a scripted harness
+// step that adds container: would pass load and only fail mid-run.
+func TestValidateHarnessStep_ScriptWithContainerRejected(t *testing.T) {
+	step := core.Step{
+		Name:           "review",
+		Commands:       []core.CommandEntry{{Command: "do the thing"}},
+		Script:         "extra stdin context",
+		Container:      &core.Container{Image: "localhost/reviewer:latest"},
+		ExecutorConfig: core.ExecutorConfig{Config: map[string]any{"provider": "claude"}},
+	}
+	err := validateHarnessStep(step)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "script")
+	assert.Contains(t, err.Error(), "container")
+
+	// Same step WITHOUT a container is valid (script on the host path is fine).
+	stepNoContainer := step
+	stepNoContainer.Container = nil
+	require.NoError(t, validateHarnessStep(stepNoContainer))
+
+	// Same step WITHOUT a script is valid (containerized harness, no stdin needed).
+	stepNoScript := step
+	stepNoScript.Script = ""
+	require.NoError(t, validateHarnessStep(stepNoScript))
+}
+
+// TestBuildHarnessContainerRunConfig_AcceptsResourceLimits proves the harness
+// container config can carry DAG resource limits: ApplyResourceLimitsToConfig
+// (which runContainerOnce calls before InitializeClient, mirroring the docker
+// executor and DAG-level container paths) maps CPU/memory onto the container
+// HostConfig. Without that call a containerized harness.run step would run
+// unbounded by the DAG's configured limits.
+func TestBuildHarnessContainerRunConfig_AcceptsResourceLimits(t *testing.T) {
+	ct := core.Container{Image: "localhost/reviewer:latest"}
+	envs := map[string]string{dockerexec.ContainerRuntimeEnv: "podman"}
+	cfg, _, err := buildHarnessContainerRunConfig(
+		"/work", ct, nil, "claude", []string{"-p", "hi"}, nil, envs,
+	)
+	require.NoError(t, err)
+
+	limits := &core.ResourceLimits{CPUMillis: 500, MemoryBytes: 1024 * 1024 * 1024}
+	applied := dockerexec.ApplyResourceLimitsToConfig(cfg, limits)
+	require.True(t, applied, "image-mode harness config must accept resource limits")
+	require.NotNil(t, cfg.Host)
+	assert.Equal(t, int64(500)*1_000_000, cfg.Host.Resources.NanoCPUs)
+	assert.Equal(t, int64(1024*1024*1024), cfg.Host.Resources.Memory)
+}
+
+func TestMergedContainerEnv(t *testing.T) {
+	got := mergedContainerEnv(
+		[]string{"PATH=/bin", "TOKEN=old", "KEEP=1"},
+		[]string{"TOKEN=new", "EXTRA=2", "=ignored", "bad"},
+	)
+	assert.Contains(t, got, "PATH=/bin")
+	assert.Contains(t, got, "KEEP=1")
+	assert.Contains(t, got, "TOKEN=new") // explicit overrides inherited
+	assert.NotContains(t, got, "TOKEN=old")
+	assert.Contains(t, got, "EXTRA=2")
+	// Malformed entries without a key are ignored.
+	assert.NotContains(t, got, "=ignored")
+	assert.NotContains(t, got, "bad")
 }
 
 func TestHarnessExecutorRun_ResolvesRelativeBinaryFromWorkingDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds service-level container runtime selection so Dagu can drive **Podman** (via its Docker-compatible socket) as well as Docker, chosen by a single environment variable, and runs `action: harness.run` agent steps inside the step's declared `container:` block over the same Moby SDK lifecycle Dagu already uses.

`DAGU_CONTAINER_RUNTIME` (`docker` | `podman`) selects the daemon for every container form. Unset/empty = `docker`, byte-for-byte the existing path. A narrow `DaemonHost` seam keeps Docker on upstream `client.FromEnv` and points Podman at its Docker-compatible socket. No `docker`/`podman` CLI shell-out, no new step type, no new DAG YAML field, no new container abstraction.

For work I need to use Podman and Podman Compose, which is what led me to fork this originally. I've been running this change for about a week with zero issues, so I figured I'd open a proper PR to see if y'all are interested in this upstream. No worries at all if it's not a fit, and feedback on the approach is welcome.

## Changes

- Runtime is a **service setting**, not DAG YAML — the same DAGs run on either runtime unchanged:

  ```yaml
  # service / compose environment
  environment:
    DAGU_CONTAINER_RUNTIME: podman   # default is docker
  ```

- Read from the engine **process** env only (`os.LookupEnv`), never DAG/step `env:`, so a workflow cannot redirect the daemon socket.
- `docker`/unset leaves `DaemonHost` empty → upstream `client.FromEnv`, unchanged. `podman` defaults to `unix:///run/podman/podman.sock` (overridable by `DAGU_PODMAN_HOST`).
- A stray `runtime:` key under `container:` fails validation as an unknown key (no new YAML surface).
- All three container forms (DAG-level, step-level, `harness.run`) go through one seam, `docker.ResolveDaemonHost(docker.ServiceRuntimeEnv())`. Not a Podman-native executor — selection just points the existing Moby client at the chosen socket.
- For the selected non-default socket the client uses `WithHost + WithScheme("http") + WithAPIVersionFromEnv`, isolating the plain podman socket from Docker TLS env (`DOCKER_CERT_PATH`/`DOCKER_HOST`) while keeping API-version negotiation.
- ~14 files, engine + tests.

## Related Issues

None — opening this to gauge interest in upstreaming Podman support.

## Testing

Unit tests (all daemon-free, so they run in CI) cover runtime resolution, daemon-host + TLS-env isolation, schema rejection of a stray `container.runtime` key, env merge, image/exec command shaping, and the nil-safe `Client.Stop` cancel race.

```bash
go build ./...
go test ./internal/runtime/builtin/docker/... ./internal/runtime/builtin/harness/... ./internal/core/... ./internal/cmn/schema/...
```

I've also run all three container forms end-to-end on a live Podman deployment (the engine container has no `docker`/`podman` CLI — it drives the daemon purely through the Moby SDK socket), confirming each workload runs in an isolated child container. Happy to share a fuller reproduction if useful.

## Checklist

- [x] Code follows the project style guidelines (`gofmt`, `golangci-lint` clean)
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (the `DAGU_CONTAINER_RUNTIME` setting is described above; no new DAG YAML)
- [x] Changes have been tested locally (build, race tests, and a live Podman end-to-end run)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds service-level runtime selection so the engine can use Docker or Podman via DAGU_CONTAINER_RUNTIME, and runs harness.run steps inside their declared container using the existing SDK lifecycle. Docker remains the default; no DAG YAML changes.

- New Features
  - DAGU_CONTAINER_RUNTIME (docker default | podman) with optional DAGU_PODMAN_HOST; applies to DAG-level containers, step-level container jobs, and containerized harness.run.
  - Read selection only from the process env; workflows cannot override it. A stray container.runtime key is rejected.
  - For a selected podman socket, build the client with WithHost + WithScheme("http") + WithAPIVersionFromEnv; empty host still uses client.FromEnv.
  - harness.run containerization
    - Supports image and exec modes; agent binary is the entrypoint in image mode; merges explicit container.env over inherited user env; reuses registry auth; applies DAG resource limits.
    - Rejects container.name in image mode, script+container, and stdin-based providers (no container stdin).
    - Responsive cancel/stop with cancel-before-init and auto-remove.

- Bug Fixes
  - Make Client.Stop nil-safe after Close to avoid cancel/cleanup races.
  - Isolate a selected podman socket from DOCKER_CERT_PATH/DOCKER_HOST so stale Docker TLS env cannot break client creation.
  - Tests cover runtime resolution, daemon-host/TLS-env isolation, schema validation of container.runtime, command shaping, and rejection paths.

<sup>Written for commit 4979b9daa2aebd2952bfe91ad9f9c26e9999f7fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerized step execution support using Docker or Podman
  * Steps now support container specifications including images and volumes
  * Introduced environment-based container runtime selection and daemon host configuration

* **Tests**
  * Expanded test coverage for container runtime resolution and execution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->