### PR TITLE
fix: avoid duplicate container cleanup

### DIFF
--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -985,8 +985,11 @@ func removeStoppedContainer(ctx context.Context, cli *client.Client, containerID
 	return nil
 }
 
+// removeContainerForCleanup reports whether the container no longer needs removal.
 func removeContainerForCleanup(ctx context.Context, cli *client.Client, containerID string, opts client.ContainerRemoveOptions) bool {
-	if _, err := cli.ContainerRemove(context.Background(), containerID, opts); err != nil {
+	// Cleanup should still run after the caller's context has been canceled.
+	cleanupCtx := context.Background()
+	if _, err := cli.ContainerRemove(cleanupCtx, containerID, opts); err != nil {
 		if errdefs.IsNotFound(err) {
 			return true
 		}

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -999,12 +999,14 @@ func removeContainerForCleanup(ctx context.Context, cli *client.Client, containe
 	return true
 }
 
+// clearContainerState forgets ownership of a container after cleanup.
 func (c *Client) clearContainerState(containerID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.clearContainerStateLocked(containerID)
 }
 
+// clearContainerStateLocked clears the tracked container only when it still matches.
 func (c *Client) clearContainerStateLocked(containerID string) {
 	if c.containerID != containerID {
 		return

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -312,10 +312,14 @@ func (c *Client) Close(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.cli == nil {
+		return
+	}
+
 	// If we have a running container and autoRemove is set, remove it
 	if c.cfg.AutoRemove && c.started.Load() && c.containerID != "" {
-		if _, err := c.cli.ContainerRemove(context.Background(), c.containerID, client.ContainerRemoveOptions{Force: true}); err != nil {
-			logger.Error(ctx, "Docker executor: remove container", tag.Error(err))
+		if removeContainerForCleanup(ctx, c.cli, c.containerID, client.ContainerRemoveOptions{Force: true}) {
+			c.clearContainerStateLocked(c.containerID)
 		}
 	}
 
@@ -592,17 +596,14 @@ func (c *Client) Run(ctx context.Context, cmd []string, stdout, stderr io.Writer
 	}
 	logger.Debug(ctx, "Docker: Run new container started", slog.String("containerID", ctID))
 
-	var once sync.Once
 	defer func() {
 		if !c.cfg.AutoRemove {
 			return
 		}
 
-		once.Do(func() {
-			if _, err := c.cli.ContainerRemove(context.Background(), c.containerID, client.ContainerRemoveOptions{Force: true}); err != nil {
-				logger.Error(ctx, "Docker executor: remove container", tag.Error(err))
-			}
-		})
+		if removeContainerForCleanup(ctx, c.cli, ctID, client.ContainerRemoveOptions{Force: true}) {
+			c.clearContainerState(ctID)
+		}
 	}()
 
 	logger.Debug(ctx, "Docker: Run calling attachAndWait", slog.String("containerID", ctID))
@@ -982,6 +983,31 @@ func removeStoppedContainer(ctx context.Context, cli *client.Client, containerID
 		return err
 	}
 	return nil
+}
+
+func removeContainerForCleanup(ctx context.Context, cli *client.Client, containerID string, opts client.ContainerRemoveOptions) bool {
+	if _, err := cli.ContainerRemove(context.Background(), containerID, opts); err != nil {
+		if errdefs.IsNotFound(err) {
+			return true
+		}
+		logger.Error(ctx, "Docker executor: remove container", tag.Error(err))
+		return false
+	}
+	return true
+}
+
+func (c *Client) clearContainerState(containerID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.clearContainerStateLocked(containerID)
+}
+
+func (c *Client) clearContainerStateLocked(containerID string) {
+	if c.containerID != containerID {
+		return
+	}
+	c.containerID = ""
+	c.started.Store(false)
 }
 
 func (c *Client) attachAndWait(ctx context.Context, cli *client.Client, containerID string, stdout, stderr io.Writer) (int, error) {

--- a/internal/runtime/builtin/docker/executor_test.go
+++ b/internal/runtime/builtin/docker/executor_test.go
@@ -22,7 +22,7 @@ func TestNewDocker_SelectsDaemonHostFromServiceEnv(t *testing.T) {
 	withEnv := func(ctx context.Context) context.Context {
 		return runtime.WithEnv(ctx, runtime.NewEnv(ctx, core.Step{Name: "test"}))
 	}
-	daemonHostOf := func(t *testing.T, e interface{}) string {
+	daemonHostOf := func(t *testing.T, e any) string {
 		t.Helper()
 		d, ok := e.(*docker)
 		require.True(t, ok, "executor is *docker")


### PR DESCRIPTION
## Summary

Fixes a noisy duplicate cleanup path for auto-removed containers.

## Changes

- avoid duplicate cleanup attempts after an auto-removed container run
- clear the Docker client container state once cleanup succeeds or the container is already gone
- keep Close idempotent after Run has already cleaned up the ephemeral container
- document why cleanup uses a context independent from the caller's run context
- modernize one Docker executor test helper required by the CI go fix check

## Why

Containerized harness runs with auto-remove could finish successfully but still emit a scary cleanup log because Run removed the container while Close later attempted to remove the same container again.

## Testing

- [x] go test ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness
- [x] go test ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness -count=1
- [x] go test -race ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness
- [x] go test -race ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness -count=1
- [x] go fix -diff ./...
- [x] make bin
- [x] live harness.run smoke with Docker/default runtime
- [x] live harness.run smoke with Podman runtime using DAGU_CONTAINER_RUNTIME=podman and DAGU_PODMAN_HOST pointed at the local Podman machine API socket

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker container cleanup reliability with enhanced state management
  * Better handling of edge cases during container removal operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->