### PR TITLE
feat: run harness in root containers

### DIFF
--- a/internal/intg/queue/proc_liveness_test.go
+++ b/internal/intg/queue/proc_liveness_test.go
@@ -5,6 +5,8 @@ package queue_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/transform"
 	"github.com/dagucloud/dagu/internal/test"
+	"github.com/dagucloud/dagu/internal/test/intgharness"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -22,21 +25,31 @@ const (
 )
 
 func TestSchedulerProcHeartbeat_QueuedRun(t *testing.T) {
+	releaseFile := filepath.Join(t.TempDir(), "release")
 	f := newFixture(t, fmt.Sprintf(`
 name: queued-proc-heartbeat
 steps:
   - name: sleep
-    run: %s
-`, test.ShellQuote(test.Sleep(6*time.Second))), WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcHeartbeatInterval, queueTestProcStaleThreshold)).
+    run: |
+%s
+`, indentQueueTestScript(intgharness.PortableCommands().WaitForFile(releaseFile), 6)), WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcHeartbeatInterval, queueTestProcStaleThreshold)).
 		Enqueue(1).
-		StartScheduler(30 * time.Second)
+		StartScheduler(60 * time.Second)
 	defer f.Stop()
+	released := false
+	defer func() {
+		if !released {
+			_ = os.WriteFile(releaseFile, []byte("release"), 0o600)
+		}
+	}()
 
 	runID := f.runIDs[0]
-	f.WaitForStatus(runID, core.Running, 10*time.Second)
+	f.WaitForStatus(runID, core.Running, 30*time.Second)
 
 	f.RequireRunHeartbeatAdvance(runID, 10*time.Second)
 
+	require.NoError(t, os.WriteFile(releaseFile, []byte("release"), 0o600))
+	released = true
 	f.WaitForStatus(runID, core.Succeeded, 20*time.Second)
 }
 

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -1044,11 +1044,15 @@ func wrapCommandWithPIDFile(cmd []string, pidFile string) []string {
 shift
 dir="${pidfile%/*}"
 if [ "$dir" != "$pidfile" ]; then
-  mkdir -p "$dir" 2>/dev/null || true
+  mkdir -p "$dir" || exit 125
 fi
 "$@" &
 child=$!
-printf '%s\n' "$child" > "$pidfile"
+if ! printf '%s\n' "$child" > "$pidfile"; then
+  kill "$child" 2>/dev/null || true
+  wait "$child" 2>/dev/null || true
+  exit 125
+fi
 wait "$child"
 status=$?
 rm -f "$pidfile" 2>/dev/null || true
@@ -1079,7 +1083,13 @@ func terminateExecProcess(cli *client.Client, execID string, pidFile string) err
 	if execStoppedWithin(cli, execID, 2*time.Second) {
 		return nil
 	}
-	return signalContainerPIDFileProcess(cli, inspectResp.ContainerID, pidFile, "KILL")
+	if err := signalContainerPIDFileProcess(cli, inspectResp.ContainerID, pidFile, "KILL"); err != nil {
+		return err
+	}
+	if execStoppedWithin(cli, execID, 2*time.Second) {
+		return nil
+	}
+	return fmt.Errorf("exec %s is still running after KILL", execID)
 }
 
 func signalContainerPIDFileProcess(cli *client.Client, containerID string, pidFile string, signalName string) error {

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -93,6 +93,14 @@ type Client struct {
 type ExecOptions struct {
 	// WorkingDir overrides the working directory for the exec command.
 	WorkingDir string
+	// Env adds or overrides environment variables for this exec command.
+	Env []string
+	// Direct executes cmd as argv without applying the configured shell wrapper.
+	Direct bool
+	// PIDFile records the container-local process ID for targeted cancellation.
+	PIDFile string
+	// TerminateOnCancel attempts to terminate only the exec process when ctx is canceled.
+	TerminateOnCancel bool
 }
 
 func inspectContainer(ctx context.Context, cli *client.Client, containerID string) (container.InspectResponse, error) {
@@ -879,38 +887,41 @@ func (c *Client) execInContainer(ctx context.Context, cli *client.Client, cmd []
 		return 1, fmt.Errorf("failed to inspect container %s: %w", containerID, err)
 	}
 
-	if !info.State.Running {
+	if info.State == nil || !info.State.Running {
 		return 1, fmt.Errorf("container %s is not running", containerID)
 	}
 
-	// Wrap command with shell if specified
-	cmd = wrapCommandWithShell(c.cfg.Shell, cmd)
+	cmd = execCommand(c.cfg.Shell, cmd, opts)
+
+	var cfgExec client.ExecCreateOptions
+	if c.cfg.ExecOptions != nil {
+		cfgExec = *c.cfg.ExecOptions
+	}
 
 	// Merge container env vars with exec env vars.
 	// ExecCreateOptions.Env replaces the container's environment, so we must
 	// merge the container's Config.Env (from container.env:) with any exec-level env.
-	var execEnv []string
+	var containerEnv []string
 	if info.Config != nil {
-		execEnv = append(execEnv, info.Config.Env...)
+		containerEnv = append(containerEnv, info.Config.Env...)
 	}
+	var configuredEnv []string
 	if c.cfg.Container != nil {
-		execEnv = append(execEnv, c.cfg.Container.Env...)
+		configuredEnv = append(configuredEnv, c.cfg.Container.Env...)
 	}
-	if c.cfg.ExecOptions != nil {
-		execEnv = append(execEnv, c.cfg.ExecOptions.Env...)
-	}
+	execEnv := mergeEnvByKey(containerEnv, configuredEnv, cfgExec.Env, opts.Env)
 
 	// Create exec configuration
 	execOpts := client.ExecCreateOptions{
-		User:         c.cfg.ExecOptions.User,
-		Privileged:   c.cfg.ExecOptions.Privileged,
-		TTY:          c.cfg.ExecOptions.TTY,
+		User:         cfgExec.User,
+		Privileged:   cfgExec.Privileged,
+		TTY:          cfgExec.TTY,
 		AttachStdin:  false,
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          cmd,
 		Env:          execEnv,
-		WorkingDir:   c.cfg.ExecOptions.WorkingDir,
+		WorkingDir:   cfgExec.WorkingDir,
 	}
 
 	// Override the working dir if specified
@@ -925,20 +936,23 @@ func (c *Client) execInContainer(ctx context.Context, cli *client.Client, cmd []
 	}
 
 	// Start exec instance
-	resp, err := cli.ExecAttach(ctx, execCreateResp.ID, client.ExecAttachOptions{TTY: c.cfg.ExecOptions.TTY})
+	resp, err := cli.ExecAttach(ctx, execCreateResp.ID, client.ExecAttachOptions{TTY: cfgExec.TTY})
 	if err != nil {
 		return 1, fmt.Errorf("failed to start exec: %w", err)
 	}
-	defer resp.Close()
 
 	// Copy output
 	var wg sync.WaitGroup
 	wg.Add(1)
-	defer wg.Wait()
+	defer func() {
+		resp.Close()
+		wg.Wait()
+	}()
 
 	go func() {
+		defer wg.Done()
 		var copyErr error
-		if c.cfg.ExecOptions.TTY {
+		if cfgExec.TTY {
 			_, copyErr = io.Copy(stdout, resp.Reader)
 		} else {
 			_, copyErr = stdcopy.StdCopy(stdout, stderr, resp.Reader)
@@ -946,7 +960,6 @@ func (c *Client) execInContainer(ctx context.Context, cli *client.Client, cmd []
 		if copyErr != nil {
 			logger.Error(ctx, "Docker executor: exec output copy", tag.Error(copyErr))
 		}
-		wg.Done()
 	}()
 
 	time.Sleep(defaultPollInterval) // Give some time for the exec to start
@@ -955,6 +968,15 @@ func (c *Client) execInContainer(ctx context.Context, cli *client.Client, cmd []
 	for {
 		inspectResp, err := cli.ExecInspect(ctx, execCreateResp.ID, client.ExecInspectOptions{})
 		if err != nil {
+			if ctx.Err() != nil {
+				if opts.TerminateOnCancel {
+					if err := terminateExecProcess(cli, execCreateResp.ID, opts.PIDFile); err != nil {
+						logger.Warn(ctx, "Docker executor: terminate exec process after cancellation", tag.Error(err))
+					}
+				}
+				resp.Close()
+				return 1, ctx.Err()
+			}
 			return 1, fmt.Errorf("failed to inspect exec: %w", err)
 		}
 
@@ -967,11 +989,162 @@ func (c *Client) execInContainer(ctx context.Context, cli *client.Client, cmd []
 
 		select {
 		case <-ctx.Done():
+			if opts.TerminateOnCancel {
+				if err := terminateExecProcess(cli, execCreateResp.ID, opts.PIDFile); err != nil {
+					logger.Warn(ctx, "Docker executor: terminate exec process after cancellation", tag.Error(err))
+				}
+			}
+			resp.Close()
 			return 1, ctx.Err()
 
 		default:
 			time.Sleep(defaultPollInterval)
 		}
+	}
+}
+
+func mergeEnvByKey(layers ...[]string) []string {
+	var merged []string
+	indexByKey := make(map[string]int)
+	for _, layer := range layers {
+		for _, entry := range layer {
+			key, _, ok := strings.Cut(entry, "=")
+			if !ok || key == "" {
+				continue
+			}
+			if idx, exists := indexByKey[key]; exists {
+				merged[idx] = entry
+				continue
+			}
+			indexByKey[key] = len(merged)
+			merged = append(merged, entry)
+		}
+	}
+	return merged
+}
+
+func execCommand(shell, cmd []string, opts ExecOptions) []string {
+	var execCmd []string
+	if opts.Direct {
+		execCmd = append([]string(nil), cmd...)
+	} else {
+		execCmd = wrapCommandWithShell(shell, cmd)
+	}
+	if opts.PIDFile != "" {
+		return wrapCommandWithPIDFile(execCmd, opts.PIDFile)
+	}
+	return execCmd
+}
+
+func wrapCommandWithPIDFile(cmd []string, pidFile string) []string {
+	if len(cmd) == 0 {
+		return cmd
+	}
+	script := `pidfile="$1"
+shift
+dir="${pidfile%/*}"
+if [ "$dir" != "$pidfile" ]; then
+  mkdir -p "$dir" 2>/dev/null || true
+fi
+"$@" &
+child=$!
+printf '%s\n' "$child" > "$pidfile"
+wait "$child"
+status=$?
+rm -f "$pidfile" 2>/dev/null || true
+exit "$status"`
+	wrapped := []string{"sh", "-c", script, "dagu-exec-wrapper", pidFile}
+	return append(wrapped, cmd...)
+}
+
+func terminateExecProcess(cli *client.Client, execID string, pidFile string) error {
+	inspectCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	inspectResp, err := cli.ExecInspect(inspectCtx, execID, client.ExecInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("inspect exec %s: %w", execID, err)
+	}
+	if !inspectResp.Running {
+		return nil
+	}
+
+	if pidFile == "" {
+		return fmt.Errorf("exec %s has no PID file for targeted cancellation", execID)
+	}
+
+	if err := signalContainerPIDFileProcess(cli, inspectResp.ContainerID, pidFile, "TERM"); err != nil {
+		return err
+	}
+	if execStoppedWithin(cli, execID, 2*time.Second) {
+		return nil
+	}
+	return signalContainerPIDFileProcess(cli, inspectResp.ContainerID, pidFile, "KILL")
+}
+
+func signalContainerPIDFileProcess(cli *client.Client, containerID string, pidFile string, signalName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	script := `sig="$1"
+pidfile="$2"
+pid="$(cat "$pidfile" 2>/dev/null || true)"
+[ -n "$pid" ] || exit 0
+kill_tree() {
+  for child in $(ps -eo pid,ppid 2>/dev/null | awk -v parent="$1" 'NR > 1 && $2 == parent { print $1 }'); do
+    kill_tree "$child"
+  done
+  kill "-$sig" "$1" 2>/dev/null || true
+}
+kill "-$sig" -- "-$pid" 2>/dev/null || true
+kill_tree "$pid"
+rm -f "$pidfile" 2>/dev/null || true`
+	resp, err := cli.ExecCreate(ctx, containerID, client.ExecCreateOptions{
+		User: "0",
+		Cmd:  []string{"sh", "-c", script, "dagu-kill-exec", signalName, pidFile},
+	})
+	if err != nil {
+		return fmt.Errorf("create %s signal exec for pid file %q: %w", signalName, pidFile, err)
+	}
+	if _, err := cli.ExecStart(ctx, resp.ID, client.ExecStartOptions{Detach: true}); err != nil {
+		return fmt.Errorf("start %s signal exec for pid file %q: %w", signalName, pidFile, err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		inspectResp, err := cli.ExecInspect(ctx, resp.ID, client.ExecInspectOptions{})
+		if err != nil {
+			return fmt.Errorf("inspect %s signal exec for pid file %q: %w", signalName, pidFile, err)
+		}
+		if !inspectResp.Running {
+			if inspectResp.ExitCode != 0 {
+				return fmt.Errorf("%s signal exec for pid file %q exited with code %d", signalName, pidFile, inspectResp.ExitCode)
+			}
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%s signal exec for pid file %q did not finish", signalName, pidFile)
+		}
+		time.Sleep(defaultPollInterval)
+	}
+}
+
+func execStoppedWithin(cli *client.Client, execID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultPollInterval)
+		inspectResp, err := cli.ExecInspect(ctx, execID, client.ExecInspectOptions{})
+		cancel()
+		if err != nil {
+			return false
+		}
+		if !inspectResp.Running {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(defaultPollInterval)
 	}
 }
 

--- a/internal/runtime/builtin/docker/exec_options_external_test.go
+++ b/internal/runtime/builtin/docker/exec_options_external_test.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/runtime/builtin/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommandForTest_DirectBypassesShell(t *testing.T) {
+	cmd := []string{"agent", "--prompt", "a && b"}
+
+	got := docker.ExecCommandForTest(
+		[]string{"/bin/sh", "-c"},
+		cmd,
+		docker.ExecOptions{Direct: true},
+	)
+
+	assert.Equal(t, cmd, got)
+}
+
+func TestExecCommandForTest_DefaultHonorsShell(t *testing.T) {
+	got := docker.ExecCommandForTest(
+		[]string{"/bin/sh"},
+		[]string{"echo", "hello"},
+		docker.ExecOptions{},
+	)
+
+	assert.Equal(t, []string{"/bin/sh", "-c", "echo hello"}, got)
+}
+
+func TestExecCommandForTest_PIDFileWrapsDirectCommand(t *testing.T) {
+	cmd := []string{"agent", "--prompt", "a && b"}
+
+	got := docker.ExecCommandForTest(
+		[]string{"/bin/sh", "-c"},
+		cmd,
+		docker.ExecOptions{Direct: true, PIDFile: "/tmp/dagu/pid"},
+	)
+
+	require.GreaterOrEqual(t, len(got), 5+len(cmd))
+	assert.Equal(t, []string{"sh", "-c"}, got[:2])
+	assert.Contains(t, got[2], `printf '%s\n' "$child" > "$pidfile"`)
+	assert.Equal(t, "dagu-exec-wrapper", got[3])
+	assert.Equal(t, "/tmp/dagu/pid", got[4])
+	assert.Equal(t, cmd, got[5:])
+}
+
+func TestExecCommandForTest_PIDFileWrapsShellCommand(t *testing.T) {
+	got := docker.ExecCommandForTest(
+		[]string{"/bin/sh"},
+		[]string{"echo", "hello"},
+		docker.ExecOptions{PIDFile: "/tmp/dagu/pid"},
+	)
+
+	require.GreaterOrEqual(t, len(got), 8)
+	assert.Equal(t, []string{"sh", "-c"}, got[:2])
+	assert.Equal(t, "dagu-exec-wrapper", got[3])
+	assert.Equal(t, "/tmp/dagu/pid", got[4])
+	assert.Equal(t, []string{"/bin/sh", "-c", "echo hello"}, got[5:])
+}
+
+func TestMergeEnvByKeyForTest_DeterministicOverride(t *testing.T) {
+	got := docker.MergeEnvByKeyForTest(
+		[]string{"PATH=/bin", "TOKEN=old", "KEEP=1"},
+		[]string{"TOKEN=new", "BAD", "=ignored"},
+		[]string{"PATH=/usr/bin"},
+	)
+
+	assert.Equal(t, []string{"PATH=/usr/bin", "TOKEN=new", "KEEP=1"}, got)
+}

--- a/internal/runtime/builtin/docker/export_test.go
+++ b/internal/runtime/builtin/docker/export_test.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker
+
+func ExecCommandForTest(shell, cmd []string, opts ExecOptions) []string {
+	return execCommand(shell, cmd, opts)
+}
+
+func MergeEnvByKeyForTest(layers ...[]string) []string {
+	return mergeEnvByKey(layers...)
+}

--- a/internal/runtime/builtin/harness/export_test.go
+++ b/internal/runtime/builtin/harness/export_test.go
@@ -3,7 +3,12 @@
 
 package harness
 
-import "github.com/dagucloud/dagu/internal/core"
+import (
+	"context"
+	"os"
+
+	"github.com/dagucloud/dagu/internal/core"
+)
 
 func AgentConfigFromBuiltinHarnessConfigForTest(cfg map[string]any) (*core.AgentStepConfig, error) {
 	return agentConfigFromBuiltinHarnessConfig(cfg)
@@ -11,4 +16,43 @@ func AgentConfigFromBuiltinHarnessConfigForTest(cfg map[string]any) (*core.Agent
 
 func BuiltinRunCanceledForTest(stopped bool, runCtxErr, parentCtxErr error) bool {
 	return builtinRunCanceled(stopped, runCtxErr, parentCtxErr)
+}
+
+func NewTestExecutorForTest(step core.Step, prompt string, script string, workDir string) *harnessExecutor {
+	return &harnessExecutor{
+		step:    step,
+		prompt:  prompt,
+		script:  script,
+		workDir: workDir,
+	}
+}
+
+func NewTestExecutorWithProviderConfigsForTest(step core.Step, prompt string, script string, workDir string, configs ...providerConfig) *harnessExecutor {
+	return &harnessExecutor{
+		step:    step,
+		configs: configs,
+		prompt:  prompt,
+		script:  script,
+		workDir: workDir,
+	}
+}
+
+func NewTestBuiltinProviderConfigForTest(name string) providerConfig {
+	return providerConfig{name: name, builtin: true}
+}
+
+func NewTestProviderConfigForTest(name string, definition core.HarnessDefinition, flags map[string]any) providerConfig {
+	return providerConfig{
+		name:       name,
+		definition: &definition,
+		flags:      flags,
+	}
+}
+
+func (e *harnessExecutor) RunOnceForTest(ctx context.Context, cfg providerConfig) (*os.File, error) {
+	return e.runOnce(ctx, cfg)
+}
+
+func SharedContainerHarnessEnvForTest(userEnv map[string]string) []string {
+	return sharedContainerHarnessEnv(userEnv)
 }

--- a/internal/runtime/builtin/harness/harness.go
+++ b/internal/runtime/builtin/harness/harness.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
@@ -75,6 +76,9 @@ type harnessExecutor struct {
 	// container-run state (SDK path); set under mu while a containerized step runs
 	containerClient *dockerexec.Client
 	containerCancel context.CancelFunc
+
+	// shared-container exec state; set while running in the DAG-level container
+	sharedContainerCancel context.CancelFunc
 }
 
 func (e *harnessExecutor) ExitCode() int {
@@ -130,6 +134,13 @@ func (e *harnessExecutor) stop(req cmdutil.StopRequest) error {
 			if cli != nil {
 				return cli.Stop(req.Intent.Signal)
 			}
+			return nil
+		}
+		if e.sharedContainerCancel != nil {
+			cancel := e.sharedContainerCancel
+			e.sharedContainerCancel = nil
+			e.mu.Unlock()
+			cancel()
 			return nil
 		}
 		e.mu.Unlock()
@@ -217,8 +228,10 @@ func (e *harnessExecutor) Run(ctx context.Context) error {
 }
 
 func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.File, error) {
+	hasRootContainer := rootContainerConfigured(ctx)
+
 	if cfg.builtin {
-		if e.step.Container != nil {
+		if e.step.Container != nil || hasRootContainer {
 			e.exitCode = 1
 			return nil, fmt.Errorf("harness: builtin provider does not support container execution")
 		}
@@ -229,7 +242,16 @@ func (e *harnessExecutor) runOnce(ctx context.Context, cfg providerConfig) (*os.
 		return e.runContainerOnce(ctx, cfg)
 	}
 
+	if hasRootContainer {
+		return e.runSharedContainerOnce(ctx, cfg)
+	}
+
 	return e.runHostSubprocessOnce(ctx, cfg)
+}
+
+func rootContainerConfigured(ctx context.Context) bool {
+	env, ok := runtime.LookupEnv(ctx)
+	return ok && env.DAG != nil && env.DAG.Container != nil
 }
 
 // runHostSubprocessOnce runs the agent CLI as a host subprocess (the
@@ -562,6 +584,117 @@ func (e *harnessExecutor) runContainerOnce(ctx context.Context, cfg providerConf
 		return nil, fmt.Errorf("harness: failed to rewind stdout spool: %w", err)
 	}
 	return stdout, nil
+}
+
+func (e *harnessExecutor) runSharedContainerOnce(ctx context.Context, cfg providerConfig) (*os.File, error) {
+	e.mu.Lock()
+
+	env := runtime.GetEnv(ctx)
+	tw := executor.NewTailWriterWithEncoding(e.stderrWriter(), 0, env.LogEncodingCharset)
+	e.stderrTail = tw
+
+	args, stdin, err := cfg.buildInvocation(e.effectivePrompt(), e.script)
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, err
+	}
+	if stdin != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: containerized harness does not support stdin input (prompt_mode: stdin); use a provider that passes the prompt as arguments")
+	}
+
+	cli := dockerexec.GetContainerClient(ctx)
+	if cli == nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: root-level container is configured but no shared container client is available")
+	}
+
+	stdout, err := newStdoutSpool()
+	if err != nil {
+		e.exitCode = 1
+		e.mu.Unlock()
+		return nil, fmt.Errorf("harness: failed to create stdout spool: %w", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	e.sharedContainerCancel = cancel
+	e.mu.Unlock()
+
+	defer func() {
+		e.mu.Lock()
+		e.sharedContainerCancel = nil
+		e.mu.Unlock()
+		cancel()
+	}()
+
+	runCmd := append([]string{cfg.binaryName()}, args...)
+	exitCode, runErr := cli.Exec(runCtx, runCmd, stdout, tw, dockerexec.ExecOptions{
+		Env:               sharedContainerHarnessEnv(env.UserEnvsMap()),
+		Direct:            true,
+		PIDFile:           sharedContainerHarnessPIDFile(e.step.Name),
+		TerminateOnCancel: true,
+	})
+	e.exitCode = exitCode
+	if runErr != nil {
+		if exitCode == 0 {
+			e.exitCode = exitCodeFromError(runErr)
+		}
+		stdoutTail, tailErr := readSpoolTail(stdout, failedStdoutTailLimit, env.LogEncodingCharset)
+		_ = cleanupStdoutSpool(stdout)
+		if tailErr != nil {
+			return nil, fmt.Errorf("harness: failed to read stdout tail: %w", tailErr)
+		}
+		if stdoutTail != "" {
+			_, _ = fmt.Fprintf(e.stderrWriter(), "recent stdout (tail):\n%s\n", stdoutTail)
+		}
+		return nil, formatProcessFailure(runErr, tw.Tail(), stdoutTail)
+	}
+
+	if _, err := stdout.Seek(0, io.SeekStart); err != nil {
+		e.exitCode = 1
+		_ = cleanupStdoutSpool(stdout)
+		return nil, fmt.Errorf("harness: failed to rewind stdout spool: %w", err)
+	}
+	return stdout, nil
+}
+
+var sharedContainerHostPathEnvKeys = map[string]struct{}{
+	"PWD":                                        {},
+	coreexec.EnvKeyDAGDocsDir:                    {},
+	coreexec.EnvKeyDAGRunArtifactsDir:            {},
+	coreexec.EnvKeyDAGRunLogFile:                 {},
+	coreexec.EnvKeyDAGRunStepStderrFile:          {},
+	coreexec.EnvKeyDAGRunStepStdoutFile:          {},
+	coreexec.EnvKeyDAGRunWorkDir:                 {},
+	coreexec.EnvKeyDAGPushBackPreviousStdoutFile: {},
+}
+
+func sharedContainerHarnessEnv(userEnv map[string]string) []string {
+	keys := make([]string, 0, len(userEnv))
+	for key := range userEnv {
+		if _, hostPath := sharedContainerHostPathEnvKeys[key]; hostPath {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	envs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		envs = append(envs, key+"="+userEnv[key])
+	}
+	return envs
+}
+
+func sharedContainerHarnessPIDFile(stepName string) string {
+	safeStepName := fileutil.SafeName(stepName)
+	if safeStepName == "" {
+		safeStepName = "step"
+	}
+	return fmt.Sprintf("/tmp/dagu-harness-%s-%d.pid", safeStepName, time.Now().UnixNano())
 }
 
 func (e *harnessExecutor) startAndWaitLocked(ctx context.Context, cmd *exec.Cmd, stdout *os.File, tw *executor.TailWriter, logEncoding string) (*os.File, error) {

--- a/internal/runtime/builtin/harness/harness.go
+++ b/internal/runtime/builtin/harness/harness.go
@@ -639,7 +639,9 @@ func (e *harnessExecutor) runSharedContainerOnce(ctx context.Context, cfg provid
 	})
 	e.exitCode = exitCode
 	if runErr != nil {
-		if exitCode == 0 {
+		if ctx.Err() != nil && (errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded)) {
+			e.exitCode = 124
+		} else if exitCode == 0 {
 			e.exitCode = exitCodeFromError(runErr)
 		}
 		stdoutTail, tailErr := readSpoolTail(stdout, failedStdoutTailLimit, env.LogEncodingCharset)

--- a/internal/runtime/builtin/harness/root_container_external_test.go
+++ b/internal/runtime/builtin/harness/root_container_external_test.go
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package harness_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/builtin/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunOnce_RootContainerWithoutSharedClientFails(t *testing.T) {
+	dag := testRootContainerDAG(t)
+	step := core.Step{Name: "review"}
+	ctx := testHarnessContext(t, dag, step)
+	exec := harness.NewTestExecutorForTest(step, "inspect repo", "", dag.WorkingDir)
+	cfg := harness.NewTestProviderConfigForTest("agent", core.HarnessDefinition{
+		Binary:     "agent",
+		PromptMode: core.HarnessPromptModeArg,
+	}, map[string]any{"provider": "agent"})
+
+	_, err := exec.RunOnceForTest(ctx, cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root-level container is configured")
+	assert.Contains(t, err.Error(), "no shared container client")
+	assert.Equal(t, 1, exec.ExitCode())
+}
+
+func TestRunOnce_BuiltinProviderWithRootContainerRejected(t *testing.T) {
+	dag := testRootContainerDAG(t)
+	step := core.Step{Name: "review"}
+	ctx := testHarnessContext(t, dag, step)
+	exec := harness.NewTestExecutorForTest(step, "inspect repo", "", dag.WorkingDir)
+
+	_, err := exec.RunOnceForTest(ctx, harness.NewTestBuiltinProviderConfigForTest("builtin"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "builtin provider does not support container execution")
+	assert.Equal(t, 1, exec.ExitCode())
+}
+
+func TestRun_RootContainerBuiltinFallbackContinuesToCLI(t *testing.T) {
+	dag := testRootContainerDAG(t)
+	step := core.Step{Name: "review"}
+	ctx := testHarnessContext(t, dag, step)
+	exec := harness.NewTestExecutorWithProviderConfigsForTest(
+		step,
+		"inspect repo",
+		"",
+		dag.WorkingDir,
+		harness.NewTestBuiltinProviderConfigForTest("builtin"),
+		harness.NewTestProviderConfigForTest("agent", core.HarnessDefinition{
+			Binary:     "agent",
+			PromptMode: core.HarnessPromptModeArg,
+		}, map[string]any{"provider": "agent"}),
+	)
+	var stderr strings.Builder
+	exec.SetStderr(&stderr)
+
+	err := exec.Run(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no shared container client")
+	assert.Contains(t, stderr.String(), "with builtin failed; trying fallback")
+}
+
+func TestRunOnce_RootContainerStdinProviderRejectedBeforeSharedClientLookup(t *testing.T) {
+	dag := testRootContainerDAG(t)
+	step := core.Step{Name: "review"}
+	ctx := testHarnessContext(t, dag, step)
+	exec := harness.NewTestExecutorForTest(step, "inspect repo", "stdin context", dag.WorkingDir)
+	cfg := harness.NewTestProviderConfigForTest("stdin-agent", core.HarnessDefinition{
+		Binary:     "stdin-agent",
+		PromptMode: core.HarnessPromptModeStdin,
+	}, map[string]any{"provider": "stdin-agent"})
+
+	_, err := exec.RunOnceForTest(ctx, cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support stdin")
+	assert.NotContains(t, err.Error(), "no shared container client")
+	assert.Equal(t, 1, exec.ExitCode())
+}
+
+func TestSharedContainerHarnessEnvForTest_FiltersHostPathRuntimeVariables(t *testing.T) {
+	got := harness.SharedContainerHarnessEnvForTest(map[string]string{
+		"API_TOKEN":                                  "secret",
+		coreexec.EnvKeyDAGName:                       "workflow",
+		coreexec.EnvKeyDAGRunID:                      "run-1",
+		coreexec.EnvKeyDAGRunWorkDir:                 "/host/work",
+		coreexec.EnvKeyDAGRunLogFile:                 "/host/log/main.log",
+		coreexec.EnvKeyDAGRunArtifactsDir:            "/host/artifacts",
+		coreexec.EnvKeyDAGRunStepStdoutFile:          "/host/log/stdout.log",
+		coreexec.EnvKeyDAGRunStepStderrFile:          "/host/log/stderr.log",
+		coreexec.EnvKeyDAGPushBackPreviousStdoutFile: "/host/log/previous.log",
+		coreexec.EnvKeyDAGDocsDir:                    "/host/docs/workflow",
+		"PWD":                                        "/host/work",
+	})
+
+	assert.Equal(t, []string{
+		"API_TOKEN=secret",
+		coreexec.EnvKeyDAGName + "=workflow",
+		coreexec.EnvKeyDAGRunID + "=run-1",
+	}, got)
+}
+
+func testRootContainerDAG(t *testing.T) *core.DAG {
+	t.Helper()
+	return &core.DAG{
+		Name:       "harness-root-container-test",
+		WorkingDir: t.TempDir(),
+		Container:  &core.Container{Image: "alpine:latest"},
+	}
+}
+
+func testHarnessContext(t *testing.T, dag *core.DAG, step core.Step, envs ...string) context.Context {
+	t.Helper()
+	ctx := runtime.NewContext(context.Background(), dag, "run-1", "", runtime.WithEnvVars(envs...))
+	return runtime.WithEnv(ctx, runtime.NewEnv(ctx, step))
+}


### PR DESCRIPTION
## Summary

- make CLI-based `harness.run` inherit the DAG-level root `container:` as a shared sandbox
- fail clearly instead of falling back to the host when a root container is configured but unavailable
- add Docker exec options for direct argv execution, deterministic env merging, and targeted cancellation
- stabilize the queue heartbeat integration test by replacing a short sleep window with explicit test coordination

## Changes

- route non-builtin `harness.run` providers into the shared DAG container when root `container:` is configured
- reject builtin harness providers and stdin-mode custom providers for containerized harness execution
- filter host-only runtime path variables before injecting user env into shared-container harness execs
- wrap cancellable Docker exec commands with a container-local PID file so timeouts can terminate the provider process tree without stopping the shared container
- add external-package tests for harness root-container decisions and Docker exec command shaping
- make `TestSchedulerProcHeartbeat_QueuedRun` wait on a release marker until heartbeat assertions complete

## Related Issues

N/A

## Checklist

- [x] Code style follows existing patterns
- [x] Self-review completed
- [x] Tests added or updated where needed
- [x] Documentation handled in the separate docs repository
- [x] Local validation completed

## Testing

- `go test ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness -count=1`
- `go test ./internal/runtime/... -count=1`
- `go test -race ./internal/intg/queue -run TestSchedulerProcHeartbeat_QueuedRun -count=1 -v`
- `go test -race ./internal/intg/queue -count=1`
- `make fmt`
- `make lint`
- `git diff --check`
- `make test`
- Docker smoke: root image container printed `ROOT_IMAGE_HARNESS_OK`
- Docker smoke: root exec container printed `ROOT_EXEC_HARNESS_OK`
- Docker smoke: timeout cleanup printed `TIMEOUT_CLEANUP_OK` from the next shared-container step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `harness.run` inside the DAG’s root `container:` using a shared sandbox with deterministic env merging and cancellable execs. Adds clear errors when the container isn’t available and hardens cancellation to stop only the provider process; also stabilizes a flaky heartbeat test.

- **New Features**
  - Route non-builtin harness providers into the shared DAG container when `container:` is set; reject builtin and stdin-mode providers for containerized execution, and fail clearly if the shared container client is missing.
  - Add Docker exec options (`Env`, `Direct`, `PIDFile`, `TerminateOnCancel`) for direct argv execution, deterministic env merging, and targeted cancellation that kills the provider process tree without stopping the container; return exit code 124 on cancel.
  - Filter host-only runtime path variables before injecting user env into shared-container harness execs.

- **Bug Fixes**
  - Stabilized `TestSchedulerProcHeartbeat_QueuedRun` by waiting on a release file instead of a short sleep.

<sup>Written for commit 7119958330174b60c0c532e8c9c9d7189efc5a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker exec operations now support per-exec environment overrides, direct command execution (bypassing shell), PID-file-based process targeting, and selective termination on cancellation
  * Harness executor can now execute steps inside a shared DAG-level root container

* **Tests**
  * Added Docker exec command option behavior tests
  * Added harness root-container executor tests
  * Updated task coordination test to use file-based release mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->