### PR TITLE
feat: expand container volume source env vars

### DIFF
--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -56,6 +56,9 @@ func mustAddr(s string) netip.Addr {
 // which cannot be triggered in practice because we always pass valid struct pointers.
 // These error checks exist as defensive programming for potential future changes.
 func TestLoadConfigFromMap(t *testing.T) {
+	hostWorkPath := testAbsoluteVolumePath("/workhost", "C:/workhost")
+	t.Setenv("DAGU_TEST_WORKHOST", hostWorkPath)
+
 	tests := []struct {
 		name        string
 		input       map[string]any
@@ -655,7 +658,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 				Pull:      core.PullPolicyMissing,
 				Container: &container.Config{},
 				Host: &container.HostConfig{
-					Binds: []string{"/host/path:/container/path", "/data:/data:ro"},
+					Binds: []string{"/host/path:/container/path:rw", "/data:/data:ro"},
 				},
 				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},
@@ -666,7 +669,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 			input: map[string]any{
 				"image":       "golang:1.22",
 				"working_dir": "/work",
-				"volumes":     []string{"$PWD:/work"},
+				"volumes":     []string{"${DAGU_TEST_WORKHOST}:/work"},
 			},
 			expected: &Config{
 				Image: "golang:1.22",
@@ -675,7 +678,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 					WorkingDir: "/work",
 				},
 				Host: &container.HostConfig{
-					Binds: []string{"$PWD:/work"},
+					Binds: []string{hostWorkPath + ":/work:rw"},
 				},
 				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},
@@ -715,7 +718,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 				Pull:      core.PullPolicyMissing,
 				Container: &container.Config{},
 				Host: &container.HostConfig{
-					Binds: []string{"/existing:/existing", "/new:/new"},
+					Binds: []string{"/existing:/existing", "/new:/new:rw"},
 				},
 				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},

--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -58,6 +58,14 @@ func mustAddr(s string) netip.Addr {
 func TestLoadConfigFromMap(t *testing.T) {
 	hostWorkPath := testAbsoluteVolumePath("/workhost", "C:/workhost")
 	t.Setenv("DAGU_TEST_WORKHOST", hostWorkPath)
+	absVolumeSource := func(path string) string {
+		resolved, err := filepath.Abs(path)
+		require.NoError(t, err)
+		return filepath.Clean(resolved)
+	}
+	hostPath := absVolumeSource("/host/path")
+	dataPath := absVolumeSource("/data")
+	newPath := absVolumeSource("/new")
 
 	tests := []struct {
 		name        string
@@ -658,7 +666,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 				Pull:      core.PullPolicyMissing,
 				Container: &container.Config{},
 				Host: &container.HostConfig{
-					Binds: []string{"/host/path:/container/path:rw", "/data:/data:ro"},
+					Binds: []string{hostPath + ":/container/path:rw", dataPath + ":/data:ro"},
 				},
 				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},
@@ -718,7 +726,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 				Pull:      core.PullPolicyMissing,
 				Container: &container.Config{},
 				Host: &container.HostConfig{
-					Binds: []string{"/existing:/existing", "/new:/new:rw"},
+					Binds: []string{"/existing:/existing", newPath + ":/new:rw"},
 				},
 				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},

--- a/internal/runtime/builtin/docker/config.go
+++ b/internal/runtime/builtin/docker/config.go
@@ -64,8 +64,14 @@ type Config struct {
 	Shell []string
 }
 
-// LoadConfig parses executorConfig into Container struct with registry auth
+// LoadConfigFromMap parses executorConfig into Container struct with registry auth.
 func LoadConfigFromMap(data map[string]any, registryAuths map[string]*core.AuthConfig) (*Config, error) {
+	return LoadConfigFromMapWithWorkDir("", data, registryAuths)
+}
+
+// LoadConfigFromMapWithWorkDir parses executorConfig and resolves shortcut
+// volume sources relative to workDir.
+func LoadConfigFromMapWithWorkDir(workDir string, data map[string]any, registryAuths map[string]*core.AuthConfig) (*Config, error) {
 	ret := struct {
 		Container     container.Config         `mapstructure:"container"`
 		Host          container.HostConfig     `mapstructure:"host"`
@@ -153,9 +159,14 @@ func LoadConfigFromMap(data map[string]any, registryAuths map[string]*core.AuthC
 		ret.Container.WorkingDir = ret.WorkingDir
 	}
 
-	// volumes -> host.Binds (append to existing binds)
+	// volumes -> host.Binds or host.Mounts (append to existing host config)
 	if len(ret.Volumes) > 0 {
-		ret.Host.Binds = append(ret.Host.Binds, ret.Volumes...)
+		binds, mounts, err := parseVolumes(workDir, ret.Volumes, "executor.config.volumes")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse volumes: %w", err)
+		}
+		ret.Host.Binds = append(ret.Host.Binds, binds...)
+		ret.Host.Mounts = append(ret.Host.Mounts, mounts...)
 	}
 
 	// Set up registry authentication if provided
@@ -225,7 +236,7 @@ func LoadConfig(workDir string, ct core.Container, registryAuths map[string]*cor
 
 	// Parse volumes
 	if len(ct.Volumes) > 0 {
-		binds, mounts, err := parseVolumes(workDir, ct.Volumes)
+		binds, mounts, err := parseVolumes(workDir, ct.Volumes, "container.volumes")
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse volumes: %w", err)
 		}

--- a/internal/runtime/builtin/docker/executor.go
+++ b/internal/runtime/builtin/docker/executor.go
@@ -397,7 +397,8 @@ func newDocker(ctx context.Context, step core.Step) (executor.Executor, error) {
 		cfg = c
 	} else if len(execCfg.Config) > 0 {
 		// Priority 2: Executor config map (legacy syntax: executor.config)
-		c, err := LoadConfigFromMap(execCfg.Config, registryAuths)
+		env := runtime.GetEnv(ctx)
+		c, err := LoadConfigFromMapWithWorkDir(env.WorkingDir, execCfg.Config, registryAuths)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load container config: %w", err)
 		}

--- a/internal/runtime/builtin/docker/parser.go
+++ b/internal/runtime/builtin/docker/parser.go
@@ -6,10 +6,8 @@ package docker
 import (
 	"fmt"
 	"net/netip"
-	"path/filepath"
 	"strings"
 
-	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
@@ -22,51 +20,34 @@ type volumeSpec struct {
 	Mode   string // "ro", "rw", or empty (defaults to rw)
 }
 
-// parseVolumes parses volume specifications into bind mounts and volume mounts
-func parseVolumes(workDir string, volumes []string) ([]string, []mount.Mount, error) {
+// parseVolumes parses volume specifications into bind mounts and volume mounts.
+func parseVolumes(workDir string, volumes []string, fieldPrefix string) ([]string, []mount.Mount, error) {
 	var binds []string
 	var mounts []mount.Mount
 
-	for _, vol := range volumes {
+	for i, vol := range volumes {
+		fieldPath := fmt.Sprintf("%s[%d]", fieldPrefix, i)
 		spec, err := parseVolumeSpec(vol)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("%s: %w", fieldPath, err)
 		}
 
-		source := spec.Source
 		target := spec.Target
 		readOnly := false
 
 		if spec.Mode == "ro" {
 			readOnly = true
 		} else if spec.Mode != "" && spec.Mode != "rw" {
-			return nil, nil, fmt.Errorf("%w: invalid mode %s in %s", ErrInvalidVolumeFormat, spec.Mode, vol)
+			return nil, nil, fmt.Errorf("%s: %w: invalid mode %s in %s", fieldPath, ErrInvalidVolumeFormat, spec.Mode, vol)
 		}
 
-		// Determine if it's a bind mount or volume
-		if filepath.IsAbs(source) || strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~") {
-			if !filepath.IsAbs(source) {
-				if workDir != "" && strings.HasPrefix(source, ".") {
-					// Handle relative paths starting with "." or "./"
-					if source == "." || source == "./" {
-						source = workDir
-					} else if strings.HasPrefix(source, "./") {
-						source = filepath.Join(workDir, source[2:])
-					} else {
-						source = filepath.Join(workDir, source[1:])
-					}
-					source = filepath.Clean(source)
-				} else {
-					p, err := fileutil.ResolvePath(source)
-					if err != nil {
-						return nil, nil, fmt.Errorf("failed to resolve path %s: %w", source, err)
-					}
-					source = p
-				}
-			}
+		source, err := resolveVolumeSource(workDir, spec.Source, fieldPath)
+		if err != nil {
+			return nil, nil, err
+		}
 
-			// It's a bind mount
-			bindStr := source + ":" + target
+		if source.isBind {
+			bindStr := source.value + ":" + target
 			if readOnly {
 				bindStr += ":ro"
 			} else {
@@ -74,10 +55,9 @@ func parseVolumes(workDir string, volumes []string) ([]string, []mount.Mount, er
 			}
 			binds = append(binds, bindStr)
 		} else {
-			// It's a named volume
 			mnt := mount.Mount{
 				Type:     mount.TypeVolume,
-				Source:   source,
+				Source:   source.value,
 				Target:   target,
 				ReadOnly: readOnly,
 			}

--- a/internal/runtime/builtin/docker/volume_source.go
+++ b/internal/runtime/builtin/docker/volume_source.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type volumeSource struct {
+	value  string
+	isBind bool
+}
+
+func resolveVolumeSource(workDir, source, fieldPath string) (volumeSource, error) {
+	expanded, err := expandHostEnv(source, fieldPath)
+	if err != nil {
+		return volumeSource{}, err
+	}
+
+	if isPathLikeVolumeSource(expanded) {
+		resolved, err := resolveBindSource(workDir, expanded)
+		if err != nil {
+			return volumeSource{}, fmt.Errorf("%s: failed to resolve volume source %q: %w", fieldPath, source, err)
+		}
+		return volumeSource{value: resolved, isBind: true}, nil
+	}
+
+	return volumeSource{value: expanded}, nil
+}
+
+func expandHostEnv(source, fieldPath string) (string, error) {
+	var expanded strings.Builder
+	for i := 0; i < len(source); {
+		if source[i] != '$' {
+			expanded.WriteByte(source[i])
+			i++
+			continue
+		}
+
+		name, next, err := parseEnvReference(source, i)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w in volume source %q", fieldPath, err, source)
+		}
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			return "", fmt.Errorf("%s: unresolved environment variable %q in volume source %q", fieldPath, name, source)
+		}
+		expanded.WriteString(value)
+		i = next
+	}
+
+	return expanded.String(), nil
+}
+
+func parseEnvReference(source string, start int) (name string, next int, err error) {
+	if start+1 >= len(source) {
+		return "", 0, fmt.Errorf("invalid environment variable reference")
+	}
+	if source[start+1] == '{' {
+		end := strings.IndexByte(source[start+2:], '}')
+		if end == -1 {
+			return "", 0, fmt.Errorf("invalid environment variable reference")
+		}
+		name = source[start+2 : start+2+end]
+		if !isEnvName(name) {
+			return "", 0, fmt.Errorf("invalid environment variable reference")
+		}
+		return name, start + 3 + end, nil
+	}
+
+	if !isEnvNameStart(source[start+1]) {
+		return "", 0, fmt.Errorf("invalid environment variable reference")
+	}
+	next = start + 2
+	for next < len(source) && isEnvNameChar(source[next]) {
+		next++
+	}
+	return source[start+1 : next], next, nil
+}
+
+func isEnvName(name string) bool {
+	if name == "" || !isEnvNameStart(name[0]) {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if !isEnvNameChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEnvNameStart(ch byte) bool {
+	return ch == '_' || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z')
+}
+
+func isEnvNameChar(ch byte) bool {
+	return isEnvNameStart(ch) || ('0' <= ch && ch <= '9')
+}
+
+func isPathLikeVolumeSource(source string) bool {
+	return filepath.IsAbs(source) ||
+		strings.HasPrefix(source, ".") ||
+		strings.HasPrefix(source, "~") ||
+		strings.ContainsAny(source, `/\`)
+}
+
+func resolveBindSource(workDir, source string) (string, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", nil
+	}
+	if isWindowsDriveSource(source) || isDockerToolboxSource(source) {
+		return source, nil
+	}
+
+	if strings.HasPrefix(source, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		source = filepath.Join(homeDir, source[1:])
+	} else if !filepath.IsAbs(source) {
+		if workDir != "" && strings.HasPrefix(source, ".") {
+			switch {
+			case source == "." || source == "./":
+				source = workDir
+			case strings.HasPrefix(source, "./"):
+				source = filepath.Join(workDir, source[2:])
+			default:
+				source = filepath.Join(workDir, source[1:])
+			}
+		} else if workDir != "" {
+			source = filepath.Join(workDir, source)
+		}
+	}
+
+	absPath, err := filepath.Abs(source)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	return filepath.Clean(absPath), nil
+}
+
+func isWindowsDriveSource(source string) bool {
+	return len(source) >= 3 &&
+		isASCIIAlpha(source[0]) &&
+		source[1] == ':' &&
+		(source[2] == '\\' || source[2] == '/')
+}
+
+func isDockerToolboxSource(source string) bool {
+	return len(source) >= 5 &&
+		strings.HasPrefix(source, "//") &&
+		isASCIIAlpha(source[2]) &&
+		source[3] == ':' &&
+		(source[4] == '\\' || source[4] == '/')
+}
+
+func isASCIIAlpha(ch byte) bool {
+	return ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z')
+}

--- a/internal/runtime/builtin/docker/volume_source.go
+++ b/internal/runtime/builtin/docker/volume_source.go
@@ -125,16 +125,7 @@ func resolveBindSource(workDir, source string) (string, error) {
 		}
 		source = filepath.Join(homeDir, source[1:])
 	} else if !filepath.IsAbs(source) {
-		if workDir != "" && strings.HasPrefix(source, ".") {
-			switch {
-			case source == "." || source == "./":
-				source = workDir
-			case strings.HasPrefix(source, "./"):
-				source = filepath.Join(workDir, source[2:])
-			default:
-				source = filepath.Join(workDir, source[1:])
-			}
-		} else if workDir != "" {
+		if workDir != "" {
 			source = filepath.Join(workDir, source)
 		}
 	}

--- a/internal/runtime/builtin/docker/volume_source_external_test.go
+++ b/internal/runtime/builtin/docker/volume_source_external_test.go
@@ -95,6 +95,41 @@ func TestLoadConfigFromMapWithWorkDirResolvesShortcutRelativeSource(t *testing.T
 	require.Equal(t, []string{filepath.Join(workDir, ".codex") + ":/codex-home:rw"}, cfg.Host.Binds)
 }
 
+func TestLoadConfigFromMapWithWorkDirPreservesDotRelativeSourceComponents(t *testing.T) {
+	workDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name:     "DotPrefixedDirectory",
+			source:   ".codex",
+			expected: filepath.Join(workDir, ".codex"),
+		},
+		{
+			name:     "ParentRelativeDirectory",
+			source:   "../data",
+			expected: filepath.Clean(filepath.Join(workDir, "../data")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DAGU_TEST_REL_SOURCE", tt.source)
+
+			cfg, err := dockerruntime.LoadConfigFromMapWithWorkDir(workDir, map[string]any{
+				"image":   "alpine",
+				"volumes": []string{"${DAGU_TEST_REL_SOURCE}:/data"},
+			}, nil)
+
+			require.NoError(t, err)
+			require.Equal(t, []string{tt.expected + ":/data:rw"}, cfg.Host.Binds)
+		})
+	}
+}
+
 func TestLoadConfigFromMapWithWorkDirFailsClearlyForMissingShortcutVolumeEnv(t *testing.T) {
 	_, err := dockerruntime.LoadConfigFromMapWithWorkDir("", map[string]any{
 		"image":   "dagu-codex-runner:local",

--- a/internal/runtime/builtin/docker/volume_source_external_test.go
+++ b/internal/runtime/builtin/docker/volume_source_external_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package docker_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	dockerruntime "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigExpandsHostEnvInVolumeSource(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	t.Setenv("DAGU_TEST_CODEX_HOME", codexHome)
+
+	cfg, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "dagu-codex-runner:local",
+		Volumes: []string{"${DAGU_TEST_CODEX_HOME}:/codex-home:ro"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{codexHome + ":/codex-home:ro"}, cfg.Host.Binds)
+}
+
+func TestLoadConfigFailsClearlyForMissingHostEnvInVolumeSource(t *testing.T) {
+	_, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "dagu-codex-runner:local",
+		Volumes: []string{"${DAGU_TEST_MISSING_CODEX_HOME}:/codex-home"},
+	}, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "container.volumes[0]")
+	require.Contains(t, err.Error(), "DAGU_TEST_MISSING_CODEX_HOME")
+}
+
+func TestLoadConfigPreservesExpandedNamedVolume(t *testing.T) {
+	t.Setenv("DAGU_TEST_VOLUME_NAME", "dagu-cache")
+
+	cfg, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "alpine",
+		Volumes: []string{"${DAGU_TEST_VOLUME_NAME}:/cache"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, cfg.Host.Binds)
+	require.Equal(t, []mount.Mount{{
+		Type:   mount.TypeVolume,
+		Source: "dagu-cache",
+		Target: "/cache",
+	}}, cfg.Host.Mounts)
+}
+
+func TestLoadConfigResolvesExpandedRelativeBindSourceFromWorkDir(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv("DAGU_TEST_REL_CODEX_HOME", "./.codex")
+
+	cfg, err := dockerruntime.LoadConfig(workDir, core.Container{
+		Image:   "dagu-codex-runner:local",
+		Volumes: []string{"${DAGU_TEST_REL_CODEX_HOME}:/codex-home"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Host.Binds, 1)
+	require.True(t, strings.HasPrefix(cfg.Host.Binds[0], filepath.Join(workDir, ".codex")+":/codex-home:"))
+}
+
+func TestLoadConfigFromMapWithWorkDirExpandsShortcutVolumeSource(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	t.Setenv("DAGU_TEST_CODEX_HOME", codexHome)
+
+	cfg, err := dockerruntime.LoadConfigFromMapWithWorkDir("", map[string]any{
+		"image":   "dagu-codex-runner:local",
+		"volumes": []string{"${DAGU_TEST_CODEX_HOME}:/codex-home:ro"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{codexHome + ":/codex-home:ro"}, cfg.Host.Binds)
+}
+
+func TestLoadConfigFromMapWithWorkDirResolvesShortcutRelativeSource(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv("DAGU_TEST_REL_CODEX_HOME", "./.codex")
+
+	cfg, err := dockerruntime.LoadConfigFromMapWithWorkDir(workDir, map[string]any{
+		"image":   "dagu-codex-runner:local",
+		"volumes": []string{"${DAGU_TEST_REL_CODEX_HOME}:/codex-home"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.Join(workDir, ".codex") + ":/codex-home:rw"}, cfg.Host.Binds)
+}
+
+func TestLoadConfigFromMapWithWorkDirFailsClearlyForMissingShortcutVolumeEnv(t *testing.T) {
+	_, err := dockerruntime.LoadConfigFromMapWithWorkDir("", map[string]any{
+		"image":   "dagu-codex-runner:local",
+		"volumes": []string{"${DAGU_TEST_MISSING_CODEX_HOME}:/codex-home"},
+	}, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "executor.config.volumes[0]")
+	require.Contains(t, err.Error(), "DAGU_TEST_MISSING_CODEX_HOME")
+}

--- a/internal/runtime/builtin/docker/volume_source_windows_external_test.go
+++ b/internal/runtime/builtin/docker/volume_source_windows_external_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package docker_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	dockerruntime "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigPreservesWindowsDriveLetterBindSource(t *testing.T) {
+	cfg, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "alpine",
+		Volumes: []string{`C:\temp\data:/data:ro`},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{`C:\temp\data:/data:ro`}, cfg.Host.Binds)
+}
+
+func TestLoadConfigPreservesWindowsForwardSlashDriveLetterBindSource(t *testing.T) {
+	cfg, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "alpine",
+		Volumes: []string{"C:/temp/data:/data"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"C:/temp/data:/data:rw"}, cfg.Host.Binds)
+}
+
+func TestLoadConfigPreservesDockerToolboxStyleBindSource(t *testing.T) {
+	cfg, err := dockerruntime.LoadConfig("", core.Container{
+		Image:   "alpine",
+		Volumes: []string{"//C:/temp/data:/data:rw"},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"//C:/temp/data:/data:rw"}, cfg.Host.Binds)
+}


### PR DESCRIPTION
## Summary

- expand host environment variables only on the source side of Docker volume specs
- apply the same volume source resolver to `container.volumes` and legacy `docker.run` shortcut `volumes`
- preserve named volume behavior and return indexed Dagu validation errors for unresolved source variables
- add external Docker config tests, including Windows drive-letter preservation coverage

## Testing

- `go test ./internal/runtime/builtin/docker ./internal/runtime/builtin/harness ./internal/core/spec -count=1`
- `pnpm build` in `docs/`
- `git diff --check`
- `git diff --check` in `docs/`
- live smoke with `dagu-codex-runner:local` and `${HOME}/.codex:/codex-home`, verifying `codex login status` reports ChatGPT login

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands env var and relative-path handling for Docker volume source paths and unifies parsing across `container.volumes` and `executor.config.volumes`. Adds workdir-aware resolution, Windows-safe bind detection, indexed error paths, and defaults `:rw` for binds.

- New Features
  - Expand env vars only on the source side.
  - Resolve relative sources (`~`, `.`, `..`) against the working dir; preserve dot/parent components.
  - Preserve named volumes; treat path-like sources as bind mounts.
  - Preserve Windows paths: `C:\...`, `C:/...`, and `//C:/...`.
  - Introduce `LoadConfigFromMapWithWorkDir`; executor resolves shortcut volumes relative to the runtime workdir.
  - Error messages include exact field paths, e.g. `container.volumes[0]` or `executor.config.volumes[0]`.

<sup>Written for commit a5f53bff3c68b5c52d8a9c75a55cda3fdc9da6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker volumes now support environment variable expansion in source paths (e.g., `$VAR` and `${VAR}`).
  * Relative paths in volume sources are now resolved relative to the working directory.
  * Enhanced Windows drive letter path handling for Docker volumes.

* **Bug Fixes**
  * Improved error messages when volume sources reference missing environment variables.
  * Volume mode specifications now correctly default to read-write (`:rw`) when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->