### PR TITLE
fix: repair stale local subdag retry status

### DIFF
--- a/internal/intg/queue/fixture_test.go
+++ b/internal/intg/queue/fixture_test.go
@@ -281,6 +281,13 @@ func (f *fixture) WaitForAllStatuses(expected core.Status, timeout time.Duration
 	return f
 }
 
+func (f *fixture) WaitForAllStatusesAndDrain(expected core.Status, statusTimeout, drainTimeout time.Duration) *fixture {
+	f.t.Helper()
+	f.WaitForAllStatuses(expected, statusTimeout)
+	f.WaitDrain(drainTimeout)
+	return f
+}
+
 func (f *fixture) WaitForAllStopped(timeout time.Duration) *fixture {
 	f.t.Helper()
 	timeout = queueTestTimeout(timeout)

--- a/internal/intg/queue/queue_test.go
+++ b/internal/intg/queue/queue_test.go
@@ -32,10 +32,9 @@ steps:
   - name: echo
     run: echo hello
 `).Enqueue(3).StartScheduler(30 * time.Second)
+	defer f.Stop()
 
-	f.WaitDrain(35 * time.Second)
-	f.WaitForAllStatuses(core.Succeeded, 20*time.Second)
-	f.Stop()
+	f.WaitForAllStatusesAndDrain(core.Succeeded, 20*time.Second, 35*time.Second)
 
 	items, err := f.th.QueueStore.List(f.th.Context, f.queue)
 	require.NoError(t, err)
@@ -166,10 +165,9 @@ steps:
 		EnqueueWithPriority(exec.QueuePriorityHigh).
 		EnqueueWithPriority(exec.QueuePriorityHigh).
 		StartScheduler(30 * time.Second)
+	defer f.Stop()
 
-	f.WaitDrain(35 * time.Second)
-	f.WaitForAllStatuses(core.Succeeded, 20*time.Second)
-	f.Stop()
+	f.WaitForAllStatusesAndDrain(core.Succeeded, 20*time.Second, 35*time.Second)
 
 	times := f.collectStartTimes()
 	require.Len(t, times, 4)

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -318,7 +318,10 @@ func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun exec.DAGRu
 	if err != nil {
 		return nil, fmt.Errorf("failed to read status: %w", err)
 	}
-	if status == nil || status.Status != core.Running || !isLocalWorkerID(status.WorkerID) {
+	if status == nil {
+		return nil, exec.ErrNoStatusData
+	}
+	if status.Status != core.Running || !isLocalWorkerID(status.WorkerID) {
 		return status, nil
 	}
 

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -304,8 +304,12 @@ func (m *Manager) getPersistedOrCurrentStatus(ctx context.Context, dag *core.DAG
 }
 
 // FindSubDAGRunStatus retrieves the status of a sub dag-run by its ID.
-// It looks up the child attempt in the dag-run store and reads its status.
+// It repairs stale local child runs before returning their status.
 func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun exec.DAGRunRef, subRunID string) (*exec.DAGRunStatus, error) {
+	if m == nil || m.dagRunStore == nil {
+		return nil, exec.ErrNoStatusData
+	}
+
 	attempt, err := m.dagRunStore.FindSubAttempt(ctx, rootDAGRun, subRunID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sub dag-run attempt: %w", err)
@@ -314,7 +318,20 @@ func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun exec.DAGRu
 	if err != nil {
 		return nil, fmt.Errorf("failed to read status: %w", err)
 	}
-	return status, nil
+	if status == nil || status.Status != core.Running || !isLocalWorkerID(status.WorkerID) {
+		return status, nil
+	}
+
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil {
+		logger.Error(ctx, "Failed to read sub DAG for stale status check",
+			tag.RunID(subRunID),
+			tag.Error(err),
+		)
+		return status, nil
+	}
+
+	return m.resolveRunningStatus(ctx, dag, attempt, status, false), nil
 }
 
 // currentStatus retrieves the current status of a running DAG by querying its socket.

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -164,6 +164,113 @@ steps:
 		require.NoError(t, err)
 		require.Equal(t, core.NodeFailed.String(), subDAGRunStatus.Nodes[0].Status.String())
 	})
+	t.Run("FindSubDAGRunStatusRepairsStaleLocalChildRun", func(t *testing.T) {
+		rootDAG := th.DAG(t, `name: stale-local-root
+steps:
+  - name: child
+    run: echo child
+`)
+		childDAG := th.DAG(t, `name: stale-local-child
+steps:
+  - name: work
+    run: echo ok
+`)
+
+		rootRunID := uuid.Must(uuid.NewV7()).String()
+		childRunID := uuid.Must(uuid.NewV7()).String()
+		staleAt := time.Now().Add(-3 * time.Second)
+		childStatus := testNewStatus(childDAG.DAG, childRunID, core.Running, core.NodeRunning)
+		childStatus.WorkerID = "local"
+		childStatus.StartedAt = exec.FormatTime(staleAt)
+		childStatus.CreatedAt = staleAt.UnixMilli()
+		childAttempt := createRunningSubAttempt(t, th, rootDAG.DAG, childDAG.DAG, rootRunID, childRunID, childStatus)
+
+		rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+		status, err := th.DAGRunMgr.FindSubDAGRunStatus(th.Context, rootRef, childRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, core.Failed, status.Status)
+		require.Equal(t, core.NodeFailed, status.Nodes[0].Status)
+		require.Equal(t, "process terminated unexpectedly - stale local process detected", status.Nodes[0].Error)
+
+		persisted, err := childAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Failed, persisted.Status)
+		require.Equal(t, core.NodeFailed, persisted.Nodes[0].Status)
+	})
+	t.Run("FindSubDAGRunStatusKeepsFreshLocalChildRunDuringStartupGrace", func(t *testing.T) {
+		rootDAG := th.DAG(t, `name: fresh-local-root
+steps:
+  - name: child
+    run: echo child
+`)
+		childDAG := th.DAG(t, `name: fresh-local-child
+steps:
+  - name: work
+    run: echo ok
+`)
+
+		rootRunID := uuid.Must(uuid.NewV7()).String()
+		childRunID := uuid.Must(uuid.NewV7()).String()
+		statusTime := time.Now().UTC()
+		mgr := runtime.NewManager(
+			th.DAGRunStore,
+			th.ProcStore,
+			th.Config,
+			runtime.WithManagerClock(func() time.Time { return statusTime }),
+		)
+		childStatus := testNewStatus(childDAG.DAG, childRunID, core.Running, core.NodeRunning)
+		childStatus.WorkerID = "local"
+		childStatus.StartedAt = exec.FormatTime(statusTime)
+		childStatus.CreatedAt = statusTime.UnixMilli()
+		childAttempt := createRunningSubAttempt(t, th, rootDAG.DAG, childDAG.DAG, rootRunID, childRunID, childStatus)
+
+		rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+		status, err := mgr.FindSubDAGRunStatus(th.Context, rootRef, childRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, core.Running, status.Status)
+		require.Equal(t, core.NodeRunning, status.Nodes[0].Status)
+
+		persisted, err := childAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Running, persisted.Status)
+		require.Equal(t, core.NodeRunning, persisted.Nodes[0].Status)
+	})
+	t.Run("FindSubDAGRunStatusDoesNotRepairDistributedChildRun", func(t *testing.T) {
+		rootDAG := th.DAG(t, `name: distributed-child-root
+steps:
+  - name: child
+    run: echo child
+`)
+		childDAG := th.DAG(t, `name: distributed-child
+steps:
+  - name: work
+    run: echo ok
+`)
+
+		rootRunID := uuid.Must(uuid.NewV7()).String()
+		childRunID := uuid.Must(uuid.NewV7()).String()
+		staleAt := time.Now().Add(-3 * time.Second)
+		childStatus := testNewStatus(childDAG.DAG, childRunID, core.Running, core.NodeRunning)
+		childStatus.WorkerID = "worker-1"
+		childStatus.StartedAt = exec.FormatTime(staleAt)
+		childStatus.CreatedAt = staleAt.UnixMilli()
+		childAttempt := createRunningSubAttempt(t, th, rootDAG.DAG, childDAG.DAG, rootRunID, childRunID, childStatus)
+
+		rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+		status, err := th.DAGRunMgr.FindSubDAGRunStatus(th.Context, rootRef, childRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, core.Running, status.Status)
+		require.Equal(t, "worker-1", status.WorkerID)
+		require.Equal(t, core.NodeRunning, status.Nodes[0].Status)
+
+		persisted, err := childAttempt.ReadStatus(th.Context)
+		require.NoError(t, err)
+		require.Equal(t, core.Running, persisted.Status)
+		require.Equal(t, core.NodeRunning, persisted.Nodes[0].Status)
+	})
 	t.Run("InvalidUpdateStatusWithInvalidDAGRunID", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
   - name: "1"
@@ -654,6 +761,43 @@ steps:
 func testNewStatus(dag *core.DAG, dagRunID string, dagStatus core.Status, nodeStatus core.NodeStatus) exec.DAGRunStatus {
 	nodes := []runtime.NodeData{{State: runtime.NodeState{Status: nodeStatus}}}
 	return transform.NewStatusBuilder(dag).Create(dagRunID, dagStatus, 0, time.Now(), transform.WithNodes(nodes))
+}
+
+func createRunningSubAttempt(
+	t *testing.T,
+	th test.Helper,
+	rootDAG *core.DAG,
+	childDAG *core.DAG,
+	rootRunID string,
+	childRunID string,
+	status exec.DAGRunStatus,
+) exec.DAGRunAttempt {
+	t.Helper()
+
+	ctx := th.Context
+	rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+
+	rootAttempt, err := th.DAGRunStore.CreateAttempt(ctx, rootDAG, time.Now(), rootRunID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, rootAttempt.Open(ctx))
+	rootStatus := testNewStatus(rootDAG, rootRunID, core.Running, core.NodeRunning)
+	rootStatus.AttemptID = rootAttempt.ID()
+	rootStatus.AttemptKey = exec.GenerateAttemptKey(rootDAG.Name, rootRunID, rootDAG.Name, rootRunID, rootStatus.AttemptID)
+	require.NoError(t, rootAttempt.Write(ctx, rootStatus))
+	require.NoError(t, rootAttempt.Close(ctx))
+
+	childAttempt, err := th.DAGRunStore.CreateSubAttempt(ctx, rootRef, childRunID)
+	require.NoError(t, err)
+	childAttempt.SetDAG(childDAG)
+	require.NoError(t, childAttempt.Open(ctx))
+	status.AttemptID = childAttempt.ID()
+	status.AttemptKey = exec.GenerateAttemptKey(rootRef.Name, rootRef.ID, childDAG.Name, childRunID, status.AttemptID)
+	status.Root = rootRef
+	status.Parent = rootRef
+	status.DAGRunID = childRunID
+	require.NoError(t, childAttempt.Write(ctx, status))
+	require.NoError(t, childAttempt.Close(ctx))
+	return childAttempt
 }
 
 // startStatusSocketServer serves a fixed status over the DAG run socket.

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -271,6 +271,19 @@ steps:
 		require.Equal(t, core.Running, persisted.Status)
 		require.Equal(t, core.NodeRunning, persisted.Nodes[0].Status)
 	})
+	t.Run("FindSubDAGRunStatusReturnsNoStatusDataForNilChildStatus", func(t *testing.T) {
+		ctx := th.Context
+		attempt := new(exec.MockDAGRunAttempt)
+		attempt.On("ReadStatus", ctx).Return(nil, nil).Once()
+		store := &managerDAGRunStore{subAttempt: attempt}
+		mgr := runtime.NewManager(store, th.ProcStore, th.Config)
+
+		status, err := mgr.FindSubDAGRunStatus(ctx, exec.NewDAGRunRef("root", "root-run"), "child-run")
+
+		require.Nil(t, status)
+		require.ErrorIs(t, err, exec.ErrNoStatusData)
+		attempt.AssertExpectations(t)
+	})
 	t.Run("InvalidUpdateStatusWithInvalidDAGRunID", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
   - name: "1"
@@ -798,6 +811,68 @@ func createRunningSubAttempt(
 	require.NoError(t, childAttempt.Write(ctx, status))
 	require.NoError(t, childAttempt.Close(ctx))
 	return childAttempt
+}
+
+type managerDAGRunStore struct {
+	subAttempt exec.DAGRunAttempt
+}
+
+func (s *managerDAGRunStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
+	return nil, nil
+}
+
+func (s *managerDAGRunStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
+	return nil
+}
+
+func (s *managerDAGRunStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *managerDAGRunStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
+	return nil, nil
+}
+
+func (s *managerDAGRunStore) ListStatusesPage(context.Context, ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
+	return exec.DAGRunStatusPage{}, nil
+}
+
+func (s *managerDAGRunStore) CompareAndSwapLatestAttemptStatus(
+	context.Context,
+	exec.DAGRunRef,
+	string,
+	core.Status,
+	func(*exec.DAGRunStatus) error,
+	...exec.CompareAndSwapStatusOption,
+) (*exec.DAGRunStatus, bool, error) {
+	return nil, false, nil
+}
+
+func (s *managerDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
+	return nil, exec.ErrDAGRunIDNotFound
+}
+
+func (s *managerDAGRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	if s.subAttempt == nil {
+		return nil, exec.ErrDAGRunIDNotFound
+	}
+	return s.subAttempt, nil
+}
+
+func (s *managerDAGRunStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
+	return nil, nil
+}
+
+func (s *managerDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.RemoveOldDAGRunsOption) ([]string, error) {
+	return nil, nil
+}
+
+func (s *managerDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
+	return nil
+}
+
+func (s *managerDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
+	return nil
 }
 
 // startStatusSocketServer serves a fixed status over the DAG run socket.

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -818,23 +818,23 @@ type managerDAGRunStore struct {
 }
 
 func (s *managerDAGRunStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {
-	return nil, nil
+	panic("unexpected call: CreateAttempt")
 }
 
 func (s *managerDAGRunStore) RecentAttempts(context.Context, string, int) []exec.DAGRunAttempt {
-	return nil
+	panic("unexpected call: RecentAttempts")
 }
 
 func (s *managerDAGRunStore) LatestAttempt(context.Context, string) (exec.DAGRunAttempt, error) {
-	return nil, exec.ErrDAGRunIDNotFound
+	panic("unexpected call: LatestAttempt")
 }
 
 func (s *managerDAGRunStore) ListStatuses(context.Context, ...exec.ListDAGRunStatusesOption) ([]*exec.DAGRunStatus, error) {
-	return nil, nil
+	panic("unexpected call: ListStatuses")
 }
 
 func (s *managerDAGRunStore) ListStatusesPage(context.Context, ...exec.ListDAGRunStatusesOption) (exec.DAGRunStatusPage, error) {
-	return exec.DAGRunStatusPage{}, nil
+	panic("unexpected call: ListStatusesPage")
 }
 
 func (s *managerDAGRunStore) CompareAndSwapLatestAttemptStatus(
@@ -845,11 +845,11 @@ func (s *managerDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	func(*exec.DAGRunStatus) error,
 	...exec.CompareAndSwapStatusOption,
 ) (*exec.DAGRunStatus, bool, error) {
-	return nil, false, nil
+	panic("unexpected call: CompareAndSwapLatestAttemptStatus")
 }
 
 func (s *managerDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
-	return nil, exec.ErrDAGRunIDNotFound
+	panic("unexpected call: FindAttempt")
 }
 
 func (s *managerDAGRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
@@ -860,19 +860,19 @@ func (s *managerDAGRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, str
 }
 
 func (s *managerDAGRunStore) CreateSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
-	return nil, nil
+	panic("unexpected call: CreateSubAttempt")
 }
 
 func (s *managerDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.RemoveOldDAGRunsOption) ([]string, error) {
-	return nil, nil
+	panic("unexpected call: RemoveOldDAGRuns")
 }
 
 func (s *managerDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
+	panic("unexpected call: RenameDAGRuns")
 }
 
 func (s *managerDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
-	return nil
+	panic("unexpected call: RemoveDAGRun")
 }
 
 // startStatusSocketServer serves a fixed status over the DAG run socket.

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -269,7 +270,7 @@ func (n *Node) runCommand(ctx context.Context, cmd executor.Executor, stepTimeou
 		step := n.Step()
 
 		// Check if this is a timeout error
-		if stepTimeout > 0 && (ctx.Err() == context.DeadlineExceeded || elapsed >= stepTimeout) {
+		if stepTimeout > 0 && (errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded || elapsed >= stepTimeout) {
 			return n.handleTimeout(ctx, step, stepTimeout, elapsed)
 		}
 

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -214,17 +214,9 @@ func (r *Local) Retry(ctx context.Context, req executor.SubWorkflowRetryRequest)
 		return nil, errStepNameNotSet
 	}
 
-	runStateStore := r.runStateStoreFromContext(ctx)
-	if runStateStore == nil {
-		return nil, errNoRunDatabase
-	}
-	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
+	retryTarget, err := r.existingChildStatus(ctx, req.SubWorkflowRequest)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find child workflow attempt: %w", err)
-	}
-	retryTarget, err := attempt.ReadStatus(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read child workflow status: %w", err)
+		return nil, err
 	}
 
 	dag, cleanup, err := loadInProcessDAG(ctx, req.SubWorkflowRequest)
@@ -248,15 +240,39 @@ func (r *Local) existingChildRetryTarget(
 	ctx context.Context,
 	req executor.SubWorkflowRequest,
 ) (*exec.DAGRunStatus, error) {
+	retryTarget, err := r.existingChildStatus(ctx, req)
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) || errors.Is(err, errNoRunDatabase) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return retryTarget, nil
+}
+
+func (r *Local) existingChildStatus(
+	ctx context.Context,
+	req executor.SubWorkflowRequest,
+) (*exec.DAGRunStatus, error) {
+	if req.RootDAGRun.ID != "" && req.RunID != "" {
+		status, err := r.dagRunMgr.FindSubDAGRunStatus(ctx, req.RootDAGRun, req.RunID)
+		if err == nil {
+			if status == nil {
+				return nil, fmt.Errorf("failed to read child workflow status: status data is nil")
+			}
+			return status, nil
+		}
+		if !errors.Is(err, exec.ErrNoStatusData) && !errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return nil, fmt.Errorf("failed to find child workflow attempt: %w", err)
+		}
+	}
+
 	runStateStore := r.runStateStoreFromContext(ctx)
 	if runStateStore == nil {
-		return nil, nil
+		return nil, errNoRunDatabase
 	}
 	attempt, err := runStateStore.OpenChildAttempt(ctx, req.RootDAGRun, req.RunID)
 	if err != nil {
-		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
-			return nil, nil
-		}
 		return nil, fmt.Errorf("failed to find child workflow attempt: %w", err)
 	}
 	retryTarget, err := attempt.ReadStatus(ctx)

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -154,19 +154,19 @@ steps:
 
 func TestLocalRunRepairsStaleChildBeforeRetry(t *testing.T) {
 	th := test.Setup(t)
-	rootDAG := th.DAG(t, `name: local-stale-parent
+	rootDAG := th.DAG(t, `name: stale-parent
 steps:
   - name: child
     run: echo child
 `)
-	childDAG := th.DAG(t, `name: local-stale-child
+	childDAG := th.DAG(t, `name: stale-child
 steps:
   - name: work
     run: echo ok
 `)
 
-	rootRunID := uuid.Must(uuid.NewV7()).String()
-	childRunID := uuid.Must(uuid.NewV7()).String()
+	rootRunID := "root-run"
+	childRunID := "child-run"
 	staleAt := time.Now().Add(-3 * time.Second)
 	childStatus := localRunStatus(childDAG.DAG, childRunID, core.Running, core.NodeRunning)
 	childStatus.WorkerID = "local"

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagucloud/dagu/internal/core"
@@ -16,6 +17,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/subflow"
+	"github.com/dagucloud/dagu/internal/test"
 )
 
 func TestLocalCancelRequestsStoredChildAttemptWhenInactive(t *testing.T) {
@@ -126,6 +128,118 @@ func TestLocalRetryReadsStoredChildAttemptStatus(t *testing.T) {
 	require.Equal(t, root, store.findRoot)
 	require.Equal(t, "child-run", store.findRunID)
 	attempt.AssertExpectations(t)
+}
+
+func TestLocalRunWithoutStatusStoreStartsFresh(t *testing.T) {
+	th := test.Setup(t)
+	child := th.DAG(t, `name: local-no-store-child
+steps:
+  - name: work
+    run: echo ok
+`)
+	root := exec.NewDAGRunRef("root", uuid.Must(uuid.NewV7()).String())
+	runner := subflow.NewLocal(th.DAGRunMgr, th.DAGStore)
+
+	result, err := runner.Run(th.Context, executor.SubWorkflowRequest{
+		DAG:          child.DAG,
+		RootDAGRun:   root,
+		ParentDAGRun: root,
+		RunID:        uuid.Must(uuid.NewV7()).String(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, core.Succeeded, result.Status)
+}
+
+func TestLocalRunRepairsStaleChildBeforeRetry(t *testing.T) {
+	th := test.Setup(t)
+	rootDAG := th.DAG(t, `name: local-stale-parent
+steps:
+  - name: child
+    run: echo child
+`)
+	childDAG := th.DAG(t, `name: local-stale-child
+steps:
+  - name: work
+    run: echo ok
+`)
+
+	rootRunID := uuid.Must(uuid.NewV7()).String()
+	childRunID := uuid.Must(uuid.NewV7()).String()
+	staleAt := time.Now().Add(-3 * time.Second)
+	childStatus := localRunStatus(childDAG.DAG, childRunID, core.Running, core.NodeRunning)
+	childStatus.WorkerID = "local"
+	childStatus.StartedAt = exec.FormatTime(staleAt)
+	childStatus.CreatedAt = staleAt.UnixMilli()
+	createStoredRunningChildAttempt(t, th, rootDAG.DAG, childDAG.DAG, rootRunID, childRunID, childStatus)
+
+	rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+	runner := subflow.NewLocal(th.DAGRunMgr, th.DAGStore, subflow.WithLocalDAGRunStore(th.DAGRunStore))
+
+	result, err := runner.Run(th.Context, executor.SubWorkflowRequest{
+		DAG:          childDAG.DAG,
+		RootDAGRun:   rootRef,
+		ParentDAGRun: rootRef,
+		RunID:        childRunID,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, core.Succeeded, result.Status)
+
+	persisted, err := th.DAGRunMgr.FindSubDAGRunStatus(th.Context, rootRef, childRunID)
+	require.NoError(t, err)
+	require.Equal(t, core.Succeeded, persisted.Status)
+}
+
+func localRunStatus(dag *core.DAG, dagRunID string, dagStatus core.Status, nodeStatus core.NodeStatus) exec.DAGRunStatus {
+	status := exec.InitialStatus(dag)
+	status.DAGRunID = dagRunID
+	status.Status = dagStatus
+	status.StartedAt = exec.FormatTime(time.Now())
+	status.CreatedAt = time.Now().UnixMilli()
+	for _, node := range status.Nodes {
+		node.Status = nodeStatus
+	}
+	return status
+}
+
+func createStoredRunningChildAttempt(
+	t *testing.T,
+	th test.Helper,
+	rootDAG *core.DAG,
+	childDAG *core.DAG,
+	rootRunID string,
+	childRunID string,
+	status exec.DAGRunStatus,
+) exec.DAGRunAttempt {
+	t.Helper()
+
+	ctx := th.Context
+	rootRef := exec.NewDAGRunRef(rootDAG.Name, rootRunID)
+
+	rootAttempt, err := th.DAGRunStore.CreateAttempt(ctx, rootDAG, time.Now(), rootRunID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, rootAttempt.Open(ctx))
+	rootStatus := localRunStatus(rootDAG, rootRunID, core.Running, core.NodeRunning)
+	rootStatus.AttemptID = rootAttempt.ID()
+	rootStatus.AttemptKey = exec.GenerateAttemptKey(rootDAG.Name, rootRunID, rootDAG.Name, rootRunID, rootStatus.AttemptID)
+	require.NoError(t, rootAttempt.Write(ctx, rootStatus))
+	require.NoError(t, rootAttempt.Close(ctx))
+
+	childAttempt, err := th.DAGRunStore.CreateSubAttempt(ctx, rootRef, childRunID)
+	require.NoError(t, err)
+	childAttempt.SetDAG(childDAG)
+	require.NoError(t, childAttempt.Open(ctx))
+	status.AttemptID = childAttempt.ID()
+	status.AttemptKey = exec.GenerateAttemptKey(rootRef.Name, rootRef.ID, childDAG.Name, childRunID, status.AttemptID)
+	status.Root = rootRef
+	status.Parent = rootRef
+	status.DAGRunID = childRunID
+	require.NoError(t, childAttempt.Write(ctx, status))
+	require.NoError(t, childAttempt.Close(ctx))
+	return childAttempt
 }
 
 type localDAGRunStore struct {


### PR DESCRIPTION
## Summary
- repair stale local child DAG-run statuses before local retry planning
- keep fresh local child runs and distributed worker-owned child runs untouched
- add regression coverage for manager child-status repair and local subflow retry behavior

## Root Cause
A parent retry reuses the deterministic child sub-DAG run ID. If the child attempt is still persisted as Running after the local process has died, the local runner can treat that stale status as the retry target. The retry plan then preserves a running child node with no corresponding local goroutine, which leaves the retry path unable to make progress.

## Testing
- go test ./internal/runtime -run 'TestManager/(FindSubDAGRunStatus|GetSavedStatusRepairsStaleRun|GetLatestStatusKeepsRunAliveWithFreshRunHeartbeat)' -count=1
- go test ./internal/subflow -run 'TestLocalRunRepairsStaleChildBeforeRetry|TestLocalRunWithoutStatusStoreStartsFresh|TestLocalRetryReadsStoredChildAttemptStatus|TestLocalRetryRejectsMissingRunDatabase|TestLocalCancel' -count=1
- make test TEST_TARGET='./internal/runtime ./internal/subflow ./internal/runtime/agent ./internal/service/scheduler ./internal/service/frontend/api/v1'
- make test TEST_TARGET=./internal/intg
- make lint
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck local sub-DAG retries by repairing stale local child-run statuses and improving missing-status errors. Also normalizes timeout detection and stabilizes queue tests by draining before scheduler shutdown.

- **Bug Fixes**
  - `Manager.FindSubDAGRunStatus` repairs stale local “Running” children, returns `exec.ErrNoStatusData` when the manager/store is nil or status is missing, and leaves fresh local (startup grace) and distributed runs unchanged.
  - Local subflow retry consults the manager first (repair then read), falls back to the local run DB with `errNoRunDatabase` when missing, and can start cleanly without a store.
  - `Node.runCommand` treats wrapped deadline exceeded errors as timeouts using `errors.Is`.
  - Queue tests wait for all statuses and drain before stopping the scheduler to avoid flakes.

<sup>Written for commit 28ff10a852f710abeb75e2c0660a0ceb80b8a807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-run status handling now returns “no status data” early when required runtime/storage data is missing, and repairs only stale *local* running sub-runs (non-local/distributed runs are left unchanged).
  * Local sub-workflow retry now prefers manager-based sub-DAG status lookup with safe fallbacks to the run-state store.
  * Step timeout detection is more reliable by using `errors.Is(..., context.DeadlineExceeded)`.

* **Tests**
  * Added coverage for stale vs fresh local child runs, distributed behavior, and nil status-data scenarios; expanded queue fixture draining assertions and simplified queue test cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2298

