### PR TITLE
feat: implement step run script spec

### DIFF
--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -273,6 +273,15 @@ func (r *Result) ExpectStdout(stdout string) {
 	require.Equal(r.t, stdout, r.stdout)
 }
 
+// ExpectStdoutNotContains fails the test when stdout contains forbidden text.
+func (r *Result) ExpectStdoutNotContains(parts ...string) {
+	r.t.Helper()
+
+	for _, part := range parts {
+		require.NotContains(r.t, r.stdout, part)
+	}
+}
+
 // ExpectStderr fails the test when stderr differs.
 func (r *Result) ExpectStderr(stderr string) {
 	r.t.Helper()

--- a/conformance/spec005_params/testdata/root_shell_array_args.yaml
+++ b/conformance/spec005_params/testdata/root_shell_array_args.yaml
@@ -7,5 +7,4 @@ shell:
   - "${params.shell_arg}"
 steps:
   - name: write
-    run: |
-      printf '%s\n' prod > root-shell-array-args.txt
+    run: printf '%s\n' prod > root-shell-array-args.txt

--- a/conformance/spec005_params/testdata/root_shell_string.yaml
+++ b/conformance/spec005_params/testdata/root_shell_string.yaml
@@ -5,5 +5,4 @@ working_dir: .
 shell: "bash ${params.shell_arg}"
 steps:
   - name: write
-    run: |
-      printf '%s\n' prod > root-shell-string.txt
+    run: printf '%s\n' prod > root-shell-string.txt

--- a/conformance/spec006_env/testdata/container_env_ordering.yaml
+++ b/conformance/spec006_env/testdata/container_env_ordering.yaml
@@ -9,5 +9,4 @@ container:
     - AFTER=done
 steps:
   - name: noop
-    run: |
-      true
+    run: "true"

--- a/conformance/spec015_step_run_script/step_run_script_test.go
+++ b/conformance/spec015_step_run_script/step_run_script_test.go
@@ -4,6 +4,7 @@
 package spec015_step_run_script_test
 
 import (
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -137,7 +138,8 @@ func TestScriptDiagnosticsDoNotDumpResolvedScript(t *testing.T) {
 	const file = "diagnostics_do_not_dump_script.yaml"
 
 	dagu := harness.NewRunner(t)
-	result := dagu.Run("start", "--run-id", runID, file)
+	sharedEnv := []string{"DAGU_HOME=" + filepath.Join(t.TempDir(), "dagu")}
+	result := dagu.RunWithEnv(sharedEnv, "start", "--run-id", runID, file)
 	result.ExpectExitCode(1)
 	result.ExpectStderrContains("nonexistent_command_015")
 	result.ExpectStderrNotContains(
@@ -147,12 +149,12 @@ func TestScriptDiagnosticsDoNotDumpResolvedScript(t *testing.T) {
 		"dagu_script-",
 	)
 
-	status := dagu.Run("status", "--run-id", runID, file)
+	status := dagu.RunWithEnv(sharedEnv, "status", "--run-id", runID, file)
+	status.ExpectExitCode(0)
 	status.ExpectStdoutNotContains(
 		"SPEC015_SCRIPT_DUMP_SENTINEL",
 		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
 		"--- script content ---",
-		"dagu_script-",
 	)
 	status.ExpectStderrNotContains(
 		"SPEC015_SCRIPT_DUMP_SENTINEL",
@@ -161,7 +163,8 @@ func TestScriptDiagnosticsDoNotDumpResolvedScript(t *testing.T) {
 		"dagu_script-",
 	)
 
-	history := dagu.Run("history", "--run-id", runID, "--format", "json")
+	history := dagu.RunWithEnv(sharedEnv, "history", "--run-id", runID, "--format", "json")
+	history.ExpectExitCode(0)
 	history.ExpectStdoutNotContains(
 		"SPEC015_SCRIPT_DUMP_SENTINEL",
 		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",

--- a/conformance/spec015_step_run_script/step_run_script_test.go
+++ b/conformance/spec015_step_run_script/step_run_script_test.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec015_step_run_script_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/harness"
+)
+
+func TestScriptFormRuntimeUnix(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixtures use POSIX shell snippets")
+	}
+
+	cases := []struct {
+		name    string
+		file    string
+		output  string
+		content string
+		env     []string
+	}{
+		{
+			name:    "multiline shell state remains in one script",
+			file:    "multiline_state.yaml",
+			output:  "multiline-state.txt",
+			content: "prod\n",
+		},
+		{
+			name:    "shell operators remain inside the script",
+			file:    "operators_preserved.yaml",
+			output:  "operators-preserved.txt",
+			content: "beta\n",
+		},
+		{
+			name:    "leading blank line does not hide shebang position",
+			file:    "leading_blank_shebang_ignored.yaml",
+			output:  "leading-blank-shebang.txt",
+			content: "not-a-shebang\n",
+		},
+		{
+			name:    "root shell does not suppress shebang",
+			file:    "shebang_root_shell_bypass.yaml",
+			output:  "root-shell-bypass.txt",
+			content: "shebang-won\n",
+		},
+		{
+			name:    "runtime default shell does not suppress shebang",
+			file:    "shebang_runtime_default_bypass.yaml",
+			output:  "runtime-default-bypass.txt",
+			content: "shebang-won\n",
+			env:     []string{"DAGU_DEFAULT_SHELL=sh -c"},
+		},
+		{
+			name:    "explicit step shell suppresses direct shebang invocation",
+			file:    "step_shell_suppresses_shebang.yaml",
+			output:  "step-shell-suppresses-shebang.txt",
+			content: "step-shell-won\n",
+		},
+		{
+			name:    "background work must be waited by script",
+			file:    "background_wait.yaml",
+			output:  "background-wait.txt",
+			content: "done\n",
+		},
+		{
+			name:    "script outputs collect after success",
+			file:    "valid_outputs.yaml",
+			output:  "outputs-valid.txt",
+			content: "from-script\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			var result *harness.Result
+			if len(tc.env) > 0 {
+				result = dagu.RunWithEnv(tc.env, "start", tc.file)
+			} else {
+				result = dagu.Run("start", tc.file)
+			}
+			result.ExpectExitCode(0)
+			dagu.ExpectFileContent(tc.output, tc.content)
+		})
+	}
+}
+
+func TestScriptFormFailuresUnix(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixtures use POSIX shell snippets")
+	}
+
+	t.Run("default shell fail fast", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "default_fail_fast.yaml")
+		result.ExpectExitCode(1)
+		dagu.ExpectFileContent("default-fail-fast.txt", "before\n")
+	})
+
+	t.Run("unix command carrier fails before script body", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "unix_reject_c_carrier.yaml")
+		result.ExpectExitCode(1)
+		result.ExpectStderrContains("script form", "-c")
+		dagu.ExpectNoFile("carrier-ran.txt")
+	})
+
+	t.Run("invalid outputs fail after script success", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "invalid_outputs.yaml")
+		result.ExpectExitCode(1)
+		result.ExpectStderrContains("undeclared_value", "undeclared step output")
+		dagu.ExpectNoFile("invalid-output-downstream.txt")
+	})
+}
+
+func TestScriptDiagnosticsDoNotDumpResolvedScript(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses POSIX shell snippets")
+	}
+
+	const runID = "spec015-diagnostics"
+	const file = "diagnostics_do_not_dump_script.yaml"
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "--run-id", runID, file)
+	result.ExpectExitCode(1)
+	result.ExpectStderrContains("nonexistent_command_015")
+	result.ExpectStderrNotContains(
+		"SPEC015_SCRIPT_DUMP_SENTINEL",
+		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
+		"--- script content ---",
+		"dagu_script-",
+	)
+
+	status := dagu.Run("status", "--run-id", runID, file)
+	status.ExpectStdoutNotContains(
+		"SPEC015_SCRIPT_DUMP_SENTINEL",
+		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
+		"--- script content ---",
+		"dagu_script-",
+	)
+	status.ExpectStderrNotContains(
+		"SPEC015_SCRIPT_DUMP_SENTINEL",
+		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
+		"--- script content ---",
+		"dagu_script-",
+	)
+
+	history := dagu.Run("history", "--run-id", runID, "--format", "json")
+	history.ExpectStdoutNotContains(
+		"SPEC015_SCRIPT_DUMP_SENTINEL",
+		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
+		"--- script content ---",
+		"dagu_script-",
+	)
+	history.ExpectStderrNotContains(
+		"SPEC015_SCRIPT_DUMP_SENTINEL",
+		"printf 'SPEC015_SCRIPT_DUMP_SENTINEL",
+		"--- script content ---",
+		"dagu_script-",
+	)
+}

--- a/conformance/spec015_step_run_script/testdata/background_wait.yaml
+++ b/conformance/spec015_step_run_script/testdata/background_wait.yaml
@@ -1,0 +1,9 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      (
+        sleep 0.1
+        printf 'done\n' > background-wait.txt
+      ) &
+      wait

--- a/conformance/spec015_step_run_script/testdata/default_fail_fast.yaml
+++ b/conformance/spec015_step_run_script/testdata/default_fail_fast.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      printf 'before\n' > default-fail-fast.txt
+      false
+      printf 'after\n' >> default-fail-fast.txt

--- a/conformance/spec015_step_run_script/testdata/diagnostics_do_not_dump_script.yaml
+++ b/conformance/spec015_step_run_script/testdata/diagnostics_do_not_dump_script.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - id: fail
+    run: |
+      printf 'visible-before\n' >&2
+      nonexistent_command_015
+      printf 'SPEC015_SCRIPT_DUMP_SENTINEL\n' > should-not-run.txt

--- a/conformance/spec015_step_run_script/testdata/invalid_outputs.yaml
+++ b/conformance/spec015_step_run_script/testdata/invalid_outputs.yaml
@@ -1,0 +1,12 @@
+working_dir: .
+steps:
+  - id: build
+    run: |
+      printf 'undeclared_value=from-script\n' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: declared_value
+
+  - id: consume
+    depends: build
+    run: |
+      printf 'should not run\n' > invalid-output-downstream.txt

--- a/conformance/spec015_step_run_script/testdata/leading_blank_shebang_ignored.yaml
+++ b/conformance/spec015_step_run_script/testdata/leading_blank_shebang_ignored.yaml
@@ -1,0 +1,6 @@
+working_dir: .
+steps:
+  - id: write
+    run: |2
+       #!/bin/false
+       printf 'not-a-shebang\n' > leading-blank-shebang.txt

--- a/conformance/spec015_step_run_script/testdata/multiline_state.yaml
+++ b/conformance/spec015_step_run_script/testdata/multiline_state.yaml
@@ -1,0 +1,6 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      value=prod
+      printf '%s\n' "$value" > multiline-state.txt

--- a/conformance/spec015_step_run_script/testdata/operators_preserved.yaml
+++ b/conformance/spec015_step_run_script/testdata/operators_preserved.yaml
@@ -1,0 +1,5 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      printf 'alpha\nbeta\n' | grep beta > operators-preserved.txt

--- a/conformance/spec015_step_run_script/testdata/shebang_root_shell_bypass.yaml
+++ b/conformance/spec015_step_run_script/testdata/shebang_root_shell_bypass.yaml
@@ -1,0 +1,9 @@
+working_dir: .
+shell:
+  - sh
+  - -c
+steps:
+  - id: write
+    run: |
+      #!/bin/sh
+      printf 'shebang-won\n' > root-shell-bypass.txt

--- a/conformance/spec015_step_run_script/testdata/shebang_runtime_default_bypass.yaml
+++ b/conformance/spec015_step_run_script/testdata/shebang_runtime_default_bypass.yaml
@@ -1,0 +1,6 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      #!/bin/sh
+      printf 'shebang-won\n' > runtime-default-bypass.txt

--- a/conformance/spec015_step_run_script/testdata/step_shell_suppresses_shebang.yaml
+++ b/conformance/spec015_step_run_script/testdata/step_shell_suppresses_shebang.yaml
@@ -1,0 +1,8 @@
+working_dir: .
+steps:
+  - id: write
+    run: |
+      #!/bin/false
+      printf 'step-shell-won\n' > step-shell-suppresses-shebang.txt
+    with:
+      shell: sh

--- a/conformance/spec015_step_run_script/testdata/unix_reject_c_carrier.yaml
+++ b/conformance/spec015_step_run_script/testdata/unix_reject_c_carrier.yaml
@@ -1,0 +1,8 @@
+working_dir: .
+shell:
+  - sh
+  - -c
+steps:
+  - id: write
+    run: |
+      printf 'ran\n' > carrier-ran.txt

--- a/conformance/spec015_step_run_script/testdata/valid_outputs.yaml
+++ b/conformance/spec015_step_run_script/testdata/valid_outputs.yaml
@@ -1,0 +1,12 @@
+working_dir: .
+steps:
+  - id: build
+    run: |
+      printf 'declared_value=from-script\n' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: declared_value
+
+  - id: consume
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.declared_value}' > outputs-valid.txt

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -553,7 +553,7 @@ steps:
 		require.Len(t, th.Steps, 1)
 		step := th.Steps[0]
 		assert.Equal(t, "script", step.Name)
-		assert.Equal(t, "echo hello\necho world", step.Script)
+		assert.Equal(t, "echo hello\necho world\n", step.Script)
 		assert.Empty(t, step.Command)
 		assert.Empty(t, step.CmdWithArgs)
 		assert.Empty(t, step.CmdArgsSys)
@@ -1766,7 +1766,7 @@ steps:
 
 		require.Len(t, th.Steps, 6)
 		assert.Equal(t, "cmd_1", th.Steps[0].Name)
-		assert.Equal(t, "cmd_2", th.Steps[1].Name)
+		assert.Equal(t, "script_2", th.Steps[1].Name)
 		assert.Equal(t, "http_3", th.Steps[2].Name)
 		assert.Equal(t, "dag_4", th.Steps[3].Name)
 		assert.Equal(t, "docker_5", th.Steps[4].Name)

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -482,7 +482,7 @@ steps:
 		step := dag.Steps[0]
 		assert.Equal(t, "harness", step.ExecutorConfig.Type)
 		assert.Equal(t, "passthrough", step.ExecutorConfig.Config["provider"])
-		assert.Equal(t, "summarize the current branch", step.Script)
+		assert.Equal(t, "summarize the current branch\n", step.Script)
 	})
 
 	t.Run("ChildStepCanReferenceBaseHarnessDefinition", func(t *testing.T) {

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -482,7 +482,7 @@ steps:
 		step := dag.Steps[0]
 		assert.Equal(t, "harness", step.ExecutorConfig.Type)
 		assert.Equal(t, "passthrough", step.ExecutorConfig.Config["provider"])
-		assert.Equal(t, "summarize the current branch\n", step.Script)
+		assert.Equal(t, "summarize the current branch", step.Script)
 	})
 
 	t.Run("ChildStepCanReferenceBaseHarnessDefinition", func(t *testing.T) {

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -658,7 +658,7 @@ func buildStepShellPackages(_ StepBuildContext, s *step) ([]string, error) {
 }
 
 func buildStepScript(_ StepBuildContext, s *step) (string, error) {
-	return strings.TrimSpace(s.Script), nil
+	return s.Script, nil
 }
 
 func buildStepStdout(_ StepBuildContext, s *step) (string, error) {
@@ -1694,27 +1694,30 @@ func buildDisplayArgsSuffix(args []string) string {
 
 // buildSingleCommand parses a single command string and populates the Step fields.
 func buildSingleCommand(val string, result *core.Step) error {
-	val = strings.TrimSpace(val)
-	if val == "" {
-		return core.NewValidationError("command", val, ErrStepCommandIsEmpty)
+	raw := val
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return core.NewValidationError("command", raw, ErrStepCommandIsEmpty)
 	}
 
 	// Harness uses command as a prompt, so preserve multiline text as a single
 	// command entry instead of reclassifying it as an inline script.
-	if strings.Contains(val, "\n") && result.ExecutorConfig.Type == "harness" {
+	if strings.Contains(raw, "\n") && result.ExecutorConfig.Type == "harness" {
 		result.Commands = []core.CommandEntry{
 			{
-				CmdWithArgs: val,
+				CmdWithArgs: raw,
 			},
 		}
 		return nil
 	}
 
 	// If the value is multi-line, treat it as a script
-	if strings.Contains(val, "\n") {
-		result.Script = val
+	if strings.Contains(raw, "\n") {
+		result.Script = raw
 		return nil
 	}
+
+	val = trimmed
 
 	// We need to split the command into command and args.
 	cmd, args, err := cmdutil.SplitCommand(val)

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -658,7 +658,7 @@ func buildStepShellPackages(_ StepBuildContext, s *step) ([]string, error) {
 }
 
 func buildStepScript(_ StepBuildContext, s *step) (string, error) {
-	return s.Script, nil
+	return strings.TrimSpace(s.Script), nil
 }
 
 func buildStepStdout(_ StepBuildContext, s *step) (string, error) {

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -233,7 +233,7 @@ func TestBuildStepScript(t *testing.T) {
 	}{
 		{name: "SimpleScript", input: "echo hello", expected: "echo hello"},
 		{name: "MultilineScript", input: "echo hello\necho world", expected: "echo hello\necho world"},
-		{name: "PreservesWhitespace", input: "  script  \n", expected: "  script  \n"},
+		{name: "Trimmed", input: "  script  \n", expected: "script"},
 		{name: "Empty", input: "", expected: ""},
 	}
 

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -233,7 +233,7 @@ func TestBuildStepScript(t *testing.T) {
 	}{
 		{name: "SimpleScript", input: "echo hello", expected: "echo hello"},
 		{name: "MultilineScript", input: "echo hello\necho world", expected: "echo hello\necho world"},
-		{name: "Trimmed", input: "  script  ", expected: "script"},
+		{name: "PreservesWhitespace", input: "  script  \n", expected: "  script  \n"},
 		{name: "Empty", input: "", expected: ""},
 	}
 
@@ -1013,6 +1013,11 @@ func TestBuildStepCommand(t *testing.T) {
 			expectedScript: "echo hello\necho world",
 		},
 		{
+			name:           "MultilineCommandPreservesBoundaryWhitespace",
+			command:        "\n  echo hello  \n",
+			expectedScript: "\n  echo hello  \n",
+		},
+		{
 			name:    "EmptyStringCommand",
 			command: "   ",
 			wantErr: true,
@@ -1213,6 +1218,11 @@ func TestBuildSingleCommand(t *testing.T) {
 			name:           "MultilineBecomesScript",
 			command:        "echo line1\necho line2",
 			expectedScript: "echo line1\necho line2",
+		},
+		{
+			name:           "MultilinePreservesBoundaryWhitespace",
+			command:        "  echo line1\n echo line2\n",
+			expectedScript: "  echo line1\n echo line2\n",
 		},
 		{
 			name:            "CommandOnly",

--- a/internal/intg/cfg_test.go
+++ b/internal/intg/cfg_test.go
@@ -276,13 +276,15 @@ steps:
 		out1Command := test.Output("abc run def")
 		out2Command := test.Output("match")
 		dag := th.DAG(t, `steps:
-  - run: |
+  - id: source
+    run: |
 `+indentTestScript(out1Command, 6)+`
     output: OUT1
-  - run: |
+  - id: match
+    run: |
 `+indentTestScript(out2Command, 6)+`
     output: OUT2
-    depends: cmd_1
+    depends: source
     preconditions:
       - condition: "$OUT1"
         expected: "re:^abc.*def$"
@@ -299,12 +301,13 @@ steps:
 		t.Parallel()
 
 		dag := th.DAG(t, `steps:
-  - run: |
+  - id: config
+    run: |
       echo '{"port": 8080, "host": "localhost"}'
     output: CONFIG
 
   - run: echo "Starting server at ${CONFIG.host}:${CONFIG.port}"
-    depends: cmd_1
+    depends: config
     output: OUT1
 `)
 		agent := dag.Agent()
@@ -478,12 +481,13 @@ steps:
 		t.Parallel()
 
 		dag := th.DAG(t, `steps:
-  - run: |
+  - id: config
+    run: |
       echo '{"port": 8080, "host": "localhost"}'
     output: CONFIG
 
   - name: start_server
-    depends: cmd_1
+    depends: config
     run: echo "Starting server at ${CONFIG.host}:${CONFIG.port}"
     output: OUT1
 `)
@@ -628,8 +632,7 @@ steps:
 		t.Parallel()
 
 		dag := th.DAG(t, `steps:
-  - run: |
-      echo 'hello world' && ls -al /
+  - run: echo 'hello world' && ls -al /
     with:
       shell: bash -o errexit -o xtrace -o pipefail -c
     output: OUT1

--- a/internal/intg/harness_test.go
+++ b/internal/intg/harness_test.go
@@ -85,7 +85,7 @@ steps:
     action: harness.run
     with:
       provider: passthrough
-      prompt: |
+      prompt: |-
         hey
         you
 `)

--- a/internal/intg/parallel_test.go
+++ b/internal/intg/parallel_test.go
@@ -1061,7 +1061,8 @@ func TestParallelExecution_ObjectItemProperties(t *testing.T) {
 	}
 
 	dagContent := fmt.Sprintf(`steps:
-  - run: |
+  - id: configs
+    run: |
       echo '%s'
     output: CONFIGS
 
@@ -1071,7 +1072,7 @@ func TestParallelExecution_ObjectItemProperties(t *testing.T) {
       params:
         - REGION: ${ITEM.region}
         - BUCKET: ${ITEM.bucket}
-    depends: cmd_1
+    depends: configs
     parallel:
       items: ${CONFIGS}
       max_concurrent: 2
@@ -1172,7 +1173,8 @@ steps:
 
 	dag := helper.DAG(t, fmt.Sprintf(`
 steps:
-  - run: %s
+  - id: files
+    run: %s
     output: FILES
 
   - action: dag.run
@@ -1180,7 +1182,7 @@ steps:
       dag: process-file
       params:
         - ITEM: ${ITEM}
-    depends: cmd_1
+    depends: files
     parallel: ${FILES}
     output: RESULTS
 `, discoverCommand))
@@ -1362,7 +1364,8 @@ steps:
 // correctly handles a single JSON item from output (should dispatch 1 job)
 func TestIssue1274_ParallelJSONSingleItem(t *testing.T) {
 	const dagContent = `steps:
-  - run: |
+  - id: json_list
+    run: |
       echo '{"file": "params.txt", "config": "env"}'
     output: jsonList
 
@@ -1371,7 +1374,7 @@ func TestIssue1274_ParallelJSONSingleItem(t *testing.T) {
       dag: issue-1274-worker
       params:
         aJson: ${ITEM}
-    depends: cmd_1
+    depends: json_list
     parallel:
       items: ${jsonList}
       max_concurrent: 1
@@ -1417,7 +1420,8 @@ func TestIssue1274_ParallelJSONMultipleItems(t *testing.T) {
 		jsonLines = jsonLines[:2]
 	}
 	dagContent := fmt.Sprintf(`steps:
-  - run: |
+  - id: json_list
+    run: |
 %s
     output: jsonList
 
@@ -1426,7 +1430,7 @@ func TestIssue1274_ParallelJSONMultipleItems(t *testing.T) {
       dag: issue-1274-worker-multi
       params:
         aJson: ${ITEM}
-    depends: script_1
+    depends: json_list
     parallel:
       items: ${jsonList}
       max_concurrent: 1
@@ -1541,7 +1545,8 @@ func TestIssue1658_ParallelCallExpandedParamsSplitting(t *testing.T) {
 		{
 			name: "positional_expands_to_multiple_params",
 			dag: fmt.Sprintf(`steps:
-  - run: |
+  - id: items
+    run: |
       echo '[{"name": "test", "extra": "A=1 B=2"}]'
     output: ITEMS
 
@@ -1549,7 +1554,7 @@ func TestIssue1658_ParallelCallExpandedParamsSplitting(t *testing.T) {
     with:
       dag: child-params-split
       params: "NAME=${ITEM.name} ${ITEM.extra}"
-    depends: cmd_1
+    depends: items
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1575,7 +1580,8 @@ steps:
 		{
 			name: "multiple_items_different_expansions",
 			dag: fmt.Sprintf(`steps:
-  - run: |
+  - id: items
+    run: |
       echo '[{"name":"alpha","extra":"X=10 Y=20"}, {"name":"beta","extra":"X=30 Y=40"}]'
     output: ITEMS
 
@@ -1583,7 +1589,7 @@ steps:
     with:
       dag: child-multi-expand
       params: "NAME=${ITEM.name} ${ITEM.extra}"
-    depends: cmd_1
+    depends: items
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1620,7 +1626,8 @@ steps:
 		{
 			name: "named_param_with_spaces_preserved",
 			dag: fmt.Sprintf(`steps:
-  - run: |
+  - id: items
+    run: |
       echo '[{"label": "hello world", "id": "1"}]'
     output: ITEMS
 
@@ -1628,7 +1635,7 @@ steps:
     with:
       dag: child-named-spaces
       params: "LABEL=${ITEM.label} ID=${ITEM.id}"
-    depends: cmd_1
+    depends: items
     parallel:
       items: ${ITEMS}
     output: RESULTS
@@ -1653,7 +1660,8 @@ steps:
 		{
 			name: "positional_single_value_no_split",
 			dag: fmt.Sprintf(`steps:
-  - run: |
+  - id: items
+    run: |
       echo '[{"tag": "simple"}]'
     output: ITEMS
 
@@ -1661,7 +1669,7 @@ steps:
     with:
       dag: child-positional-single
       params: "${ITEM.tag}"
-    depends: cmd_1
+    depends: items
     parallel:
       items: ${ITEMS}
     output: RESULTS

--- a/internal/intg/stepref_test.go
+++ b/internal/intg/stepref_test.go
@@ -251,7 +251,7 @@ steps:
 	t.Run("StepIDInScript", func(t *testing.T) {
 		th := test.Setup(t)
 
-		yaml := `
+		yaml := fmt.Sprintf(`
 type: graph
 steps:
   - id: setup_step
@@ -261,12 +261,9 @@ steps:
   - depends:
       - setup_step
     run: |
-      set -e
-
-      # Access file paths
-      echo "Setup logs available at: ${setup_step.stdout}"
+%s
     output: SCRIPT_OUTPUT
-`
+`, indentScript(test.Output("Setup logs available at: ${setup_step.stdout}"), 6))
 		testDAG := th.DAG(t, yaml)
 
 		agent := testDAG.Agent()
@@ -517,13 +514,12 @@ steps:
 		},
 		{
 			name: "StructuredOutputFromFileAndStderr",
-			yaml: `
+			yaml: fmt.Sprintf(`
 type: graph
 steps:
   - id: producer
     run: |
-      printf '{"artifact":{"path":"build/report.md"}}' > meta.json
-      printf '{"warning":"retry required"}' >&2
+%s
     output:
       artifactPath:
         from: file
@@ -538,9 +534,18 @@ steps:
   - id: consumer
     depends: [producer]
     run: |
-      printf 'artifact=%s\nwarning=%s' "${producer.output.artifactPath}" "${producer.output.warning}"
+%s
     output: RESULT
-`,
+`, indentScript(test.JoinLines(
+				test.ForOS(
+					`printf '%s' '{"artifact":{"path":"build/report.md"}}' > meta.json`,
+					`Set-Content -Path meta.json -Value '{"artifact":{"path":"build/report.md"}}' -NoNewline`,
+				),
+				test.Stderr(`{"warning":"retry required"}`),
+			), 6), indentScript(test.ForOS(
+				`printf 'artifact=%s\nwarning=%s' "${producer.output.artifactPath}" "${producer.output.warning}"`,
+				`Write-Output ("artifact={0}{1}warning={2}" -f "${producer.output.artifactPath}", [Environment]::NewLine, "${producer.output.warning}")`,
+			), 6)),
 			expectedStatus: core.Succeeded,
 			expectedOutput: map[string]any{
 				"RESULT": "artifact=build/report.md\nwarning=retry required",

--- a/internal/intg/stepref_test.go
+++ b/internal/intg/stepref_test.go
@@ -261,7 +261,6 @@ steps:
   - depends:
       - setup_step
     run: |
-      #!/bin/bash
       set -e
 
       # Access file paths
@@ -523,7 +522,6 @@ type: graph
 steps:
   - id: producer
     run: |
-      #!/bin/sh
       printf '{"artifact":{"path":"build/report.md"}}' > meta.json
       printf '{"warning":"retry required"}' >&2
     output:

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -12,8 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -54,7 +51,7 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 	e.mu.Lock()
 
 	if e.config.Script != "" {
-		scriptFile, err := setupScript(e.config.Dir, e.config.Script, e.config.Command, e.config.Shell)
+		scriptFile, err := setupScriptForExecution(e.config.Dir, e.config.Script, e.config.Command, e.config.Shell, e.config.UserSpecifiedShell)
 		if err != nil {
 			e.mu.Unlock()
 			return fmt.Errorf("failed to setup script: %w", err)
@@ -162,15 +159,12 @@ func (e *commandExecutor) stop(req cmdutil.StopRequest) error {
 	return err
 }
 
-// annotateStderrTail writes the full script to the stderr log with the
-// failing line(s) marked, and returns a cleaned version of the tail with
-// the temp script path stripped for use in the error field.
+// annotateStderrTail returns a cleaned version of the tail with the temp script
+// path stripped for use in the error field.
 func (e *commandExecutor) annotateStderrTail(tail string) string {
 	if e.config.Script == "" || e.scriptFile == "" {
 		return tail
 	}
-	offset := scriptLineOffset(e.scriptFile)
-	errorLines := extractErrorLines(tail, e.scriptFile)
 
 	// Strip temp script path from stderr for clean display.
 	// e.g. "/tmp/dagu_script-123.sh:3: not found" → "line 3: not found"
@@ -180,48 +174,7 @@ func (e *commandExecutor) annotateStderrTail(tail string) string {
 	cleaned = strings.ReplaceAll(cleaned, e.scriptFile+": ", "")
 	cleaned = strings.ReplaceAll(cleaned, baseName+": ", "")
 
-	// Write cleaned error + full script dump to stderr log
-	_, _ = fmt.Fprintf(e.config.Stderr, "\n--- error ---\n%s\n", strings.TrimRight(cleaned, "\n"))
-	writeScriptToStderr(e.config.Stderr, e.config.Script, offset, errorLines)
-
 	return cleaned
-}
-
-// extractErrorLines parses stderr for line-number references to the script
-// file and returns a set of those line numbers.
-func extractErrorLines(stderr, scriptFile string) map[int]bool {
-	baseName := filepath.Base(scriptFile)
-	escaped := regexp.QuoteMeta(baseName)
-	// Match patterns like "filename:3:" or "filename: line 3:"
-	re := regexp.MustCompile(escaped + `(?::|\: line )(\d+)`)
-
-	lines := make(map[int]bool)
-	for _, match := range re.FindAllStringSubmatch(stderr, -1) {
-		if n, err := strconv.Atoi(match[1]); err == nil {
-			lines[n] = true
-		}
-	}
-	return lines
-}
-
-// writeScriptToStderr writes the full script content with line numbers to
-// the stderr writer. Lines in errorLines are marked with ">>" for visibility.
-func writeScriptToStderr(w io.Writer, script string, lineOffset int, errorLines map[int]bool) {
-	_, _ = fmt.Fprintln(w, "\n--- script content ---")
-	for i, line := range strings.Split(script, "\n") {
-		num := i + 1
-		scriptLineNum := num + lineOffset
-		prefix := "    "
-		if errorLines[scriptLineNum] {
-			prefix = " >> "
-		}
-		if lineOffset > 0 {
-			_, _ = fmt.Fprintf(w, "%s%4d (orig %d): %s\n", prefix, scriptLineNum, num, line)
-		} else {
-			_, _ = fmt.Fprintf(w, "%s%4d: %s\n", prefix, num, line)
-		}
-	}
-	_, _ = fmt.Fprintln(w, "---")
 }
 
 type commandConfig struct {
@@ -259,14 +212,17 @@ func (cfg *commandConfig) newCmd(ctx context.Context, scriptFile string) (*exec.
 		cmd = c
 
 	case len(cfg.Shell) > 0 && scriptFile != "":
-		// Check if the script has shebang and user did not specify a shell
-		shebang, shebangArgs, err := cfg.detectShebang(scriptFile)
+		// Check if the resolved script has a shebang and the step did not force a shell.
+		shebang, shebangArgs, err := cfg.detectShebang()
 		if err != nil {
 			return nil, fmt.Errorf("failed to detect shebang: %w", err)
 		}
 		if shebang != "" {
-			// Use the shebang interpreter to run the script
-			cmd = exec.CommandContext(cfg.Ctx, cmdutil.ResolveExecutable(shebang), append(shebangArgs, scriptFile)...) // nolint: gosec
+			shebangPath, err := resolveShebangExecutable(ctx, shebang)
+			if err != nil {
+				return nil, err
+			}
+			cmd = exec.CommandContext(cfg.Ctx, shebangPath, append(shebangArgs, scriptFile)...) // nolint: gosec
 			cmdutil.SetupCommand(cmd)
 			break
 		}
@@ -275,6 +231,7 @@ func (cfg *commandConfig) newCmd(ctx context.Context, scriptFile string) (*exec.
 		cmdBuilder := &shellCommandBuilder{
 			Dir:                cfg.Dir,
 			Shell:              cfg.Shell,
+			ShellPackages:      cfg.ShellPackages,
 			Script:             scriptFile,
 			UserSpecifiedShell: cfg.UserSpecifiedShell,
 		}
@@ -328,45 +285,11 @@ func (cfg *commandConfig) newCmd(ctx context.Context, scriptFile string) (*exec.
 	return cmd, nil
 }
 
-func (cfg *commandConfig) detectShebang(scriptFile string) (string, []string, error) {
+func (cfg *commandConfig) detectShebang() (string, []string, error) {
 	if cfg.UserSpecifiedShell {
 		return "", nil, nil
 	}
-	// read the first line of the script file
-	firstLine, err := readFirstLine(scriptFile)
-	if err != nil {
-		return "", nil, err
-	}
-	return cmdutil.DetectShebang(firstLine)
-}
-
-func readFirstLine(filePath string) (string, error) {
-	filePath = filepath.Clean(filePath)
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file: %w", err)
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	scanner := bufio.NewScanner(file)
-	// Set a reasonable limit to prevent memory issues with extremely long lines
-	// Shebangs are typically < 256 bytes, but allow up to 4KB to be safe
-	const maxLineSize = 4 * 1024
-	buf := make([]byte, maxLineSize)
-	scanner.Buffer(buf, maxLineSize)
-
-	if scanner.Scan() {
-		return scanner.Text(), nil
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
-	}
-
-	// Empty file
-	return "", nil
+	return parseScriptShebang(cfg.Script)
 }
 
 // exitCodeFromError returns the process exit code represented by err.

--- a/internal/runtime/builtin/command/command_script.go
+++ b/internal/runtime/builtin/command/command_script.go
@@ -15,24 +15,25 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 )
 
-// setupScript creates a temporary executable script file containing the provided
-// script after applying shell-specific preprocessing (e.g., PowerShell error-handling
-// directives). If workDir is non-empty, the file is created there; otherwise it falls
-// back to the system temp directory. The file extension is chosen based on the shell.
-// Returns the created file path or an error if file creation, writing, syncing, or
-// permission setting fails.
+// setupScript creates a temporary executable script file containing the provided script.
 func setupScript(workDir, script, command string, shell []string) (string, error) {
+	return setupScriptForExecution(workDir, script, command, shell, false)
+}
+
+func setupScriptForExecution(workDir, script, command string, shell []string, userSpecifiedShell bool) (string, error) {
+	_ = workDir
+
 	// Determine file extension based on the actual execution path. Scripts that
-	// are passed to an explicit command or start with a shebang should preserve
-	// their original first line so the intended interpreter can handle them.
+	// are passed to an explicit command or directly to a shebang interpreter should
+	// preserve their original first line so the intended interpreter can handle them.
 	shellCmd := ""
-	if command == "" && !hasShebang(script) && len(shell) > 0 {
+	if command == "" && len(shell) > 0 && (userSpecifiedShell || !hasShebang(script)) {
 		shellCmd = shell[0]
 	}
 	ext := cmdutil.GetScriptExtension(shellCmd)
 	pattern := "dagu_script-*" + ext
 
-	file, err := os.CreateTemp(workDir, pattern)
+	file, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", fmt.Errorf("failed to create script file: %w", err)
 	}

--- a/internal/runtime/builtin/command/command_script.go
+++ b/internal/runtime/builtin/command/command_script.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
@@ -21,8 +22,6 @@ func setupScript(workDir, script, command string, shell []string) (string, error
 }
 
 func setupScriptForExecution(workDir, script, command string, shell []string, userSpecifiedShell bool) (string, error) {
-	_ = workDir
-
 	// Determine file extension based on the actual execution path. Scripts that
 	// are passed to an explicit command or directly to a shebang interpreter should
 	// preserve their original first line so the intended interpreter can handle them.
@@ -33,7 +32,7 @@ func setupScriptForExecution(workDir, script, command string, shell []string, us
 	ext := cmdutil.GetScriptExtension(shellCmd)
 	pattern := "dagu_script-*" + ext
 
-	file, err := os.CreateTemp("", pattern)
+	file, err := createScriptTemp(workDir, pattern)
 	if err != nil {
 		return "", fmt.Errorf("failed to create script file: %w", err)
 	}
@@ -65,6 +64,37 @@ func setupScriptForExecution(workDir, script, command string, shell []string, us
 
 	_ = file.Close()
 	return file.Name(), nil
+}
+
+func createScriptTemp(workDir, pattern string) (*os.File, error) {
+	file, err := os.CreateTemp("", pattern)
+	if err == nil {
+		return file, nil
+	}
+	return createScriptTempFallback(workDir, pattern, err)
+}
+
+func createScriptTempFallback(workDir, pattern string, systemTempErr error) (*os.File, error) {
+	if strings.TrimSpace(workDir) == "" {
+		return nil, fmt.Errorf("system temp unavailable: %w", systemTempErr)
+	}
+
+	fallbackDir := filepath.Join(workDir, ".dagu", "tmp", "scripts")
+	if err := os.MkdirAll(fallbackDir, 0o700); err != nil {
+		return nil, fmt.Errorf(
+			"system temp unavailable: %w; fallback %q unavailable: %v",
+			systemTempErr, fallbackDir, err,
+		)
+	}
+
+	file, err := os.CreateTemp(fallbackDir, pattern)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"system temp unavailable: %w; fallback %q failed: %v",
+			systemTempErr, fallbackDir, err,
+		)
+	}
+	return file, nil
 }
 
 func hasShebang(script string) bool {

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -551,40 +551,6 @@ func TestCommandExecutor_ExitCode(t *testing.T) {
 	}
 }
 
-func TestReadFirstLine(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		expected string
-	}{
-		{"ShebangLine", "#!/bin/bash\necho hello", "#!/bin/bash"},
-		{"SingleLine", "single line", "single line"},
-		{"EmptyFile", "", ""},
-		{"MultipleLines", "first\nsecond\nthird", "first"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tmpFile, err := os.CreateTemp("", "test-*.sh")
-			require.NoError(t, err)
-			defer func() { _ = os.Remove(tmpFile.Name()) }()
-
-			_, err = tmpFile.WriteString(tt.content)
-			require.NoError(t, err)
-			_ = tmpFile.Close()
-
-			result, err := readFirstLine(tmpFile.Name())
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-
-	t.Run("NonExistentFile", func(t *testing.T) {
-		_, err := readFirstLine("/non/existent/file")
-		assert.Error(t, err)
-	})
-}
-
 // setupTestContext creates a test context with DAG and execution environment
 func setupTestContext(t *testing.T, dag *core.DAG, step core.Step) context.Context {
 	t.Helper()
@@ -1032,14 +998,12 @@ func TestCommandExecutor_ScriptErrorAnnotation(t *testing.T) {
 	assert.NotContains(t, errMsg, "--- script content ---")
 	assert.NotContains(t, errMsg, "dagu_script-")
 
-	// Full script with error marker should appear in stderr log output
+	// Dagu-generated diagnostics must not dump the full resolved script.
 	stderrOutput := stderr.String()
-	assert.Contains(t, stderrOutput, "--- script content ---")
 	assert.Contains(t, stderrOutput, "nonexistent_command_xyz_12345")
-	assert.Contains(t, stderrOutput, "echo line1")
-	assert.Contains(t, stderrOutput, "echo line4")
-	// Failing line should be marked with >>
-	assert.Contains(t, stderrOutput, " >>    3: nonexistent_command_xyz_12345")
+	assert.NotContains(t, stderrOutput, "--- script content ---")
+	assert.NotContains(t, stderrOutput, "echo line1")
+	assert.NotContains(t, stderrOutput, "echo line4")
 
 	ce := exec.(*commandExecutor)
 	assert.NotEmpty(t, ce.scriptFile)
@@ -1454,20 +1418,12 @@ func TestDetectShebang(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create temp script file
-			tmpFile, err := os.CreateTemp("", "test-*.sh")
-			require.NoError(t, err)
-			defer func() { _ = os.Remove(tmpFile.Name()) }()
-
-			_, err = tmpFile.WriteString(tt.scriptContent)
-			require.NoError(t, err)
-			_ = tmpFile.Close()
-
 			cfg := &commandConfig{
 				UserSpecifiedShell: tt.userSpecifiedShell,
+				Script:             tt.scriptContent,
 			}
 
-			shebang, _, err := cfg.detectShebang(tmpFile.Name())
+			shebang, _, err := cfg.detectShebang()
 			require.NoError(t, err)
 
 			if tt.expectedShebangEmpty {
@@ -1688,6 +1644,7 @@ func TestCommandConfig_NewCmd_AllBranches(t *testing.T) {
 			config: commandConfig{
 				Ctx:                ctx,
 				Shell:              []string{"/bin/sh"},
+				Script:             "#!/bin/bash\necho shebang",
 				UserSpecifiedShell: false,
 			},
 			scriptFile: shebangScript,
@@ -1914,13 +1871,15 @@ func TestCreateDirectCommand(t *testing.T) {
 	}
 }
 
-// TestSetupScript_Errors tests error paths in setupScript
-func TestSetupScript_Errors(t *testing.T) {
-	t.Run("invalid directory", func(t *testing.T) {
-		_, err := setupScript("/nonexistent/dir/that/does/not/exist", "echo hello", "", []string{"/bin/sh"})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to create script file")
-	})
+func TestSetupScriptDoesNotRequireWorkDir(t *testing.T) {
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0o600))
+
+	scriptFile, err := setupScript(filepath.Join(blockingFile, "child"), "echo hello", "", []string{"/bin/sh"})
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(scriptFile) }()
+
+	assert.NotContains(t, scriptFile, blockingFile)
 }
 
 // TestShellCommandBuilder_Build_Errors tests error paths in Build
@@ -2080,13 +2039,13 @@ func TestCommandConfig_NewCmd_Errors(t *testing.T) {
 	})
 
 	t.Run("DetectShebangError", func(t *testing.T) {
-		// Create a config that will trigger detectShebang with non-existent file
 		config := commandConfig{
 			Ctx:                ctx,
 			Shell:              []string{"/bin/sh"},
+			Script:             "#!/bin/sh 'unterminated\n",
 			UserSpecifiedShell: false,
 		}
-		_, err := config.newCmd(ctx, "/nonexistent/script.sh")
+		_, err := config.newCmd(ctx, scriptFile)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to detect shebang")
 	})
@@ -2115,14 +2074,17 @@ func TestCommandExecutor_Run_SetupScriptError(t *testing.T) {
 	cfg, err := NewCommandConfig(ctx, step)
 	require.NoError(t, err)
 
-	// Set invalid directory to cause setupScript to fail
-	cfg.Dir = "/nonexistent/directory/that/does/not/exist"
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0o600))
+	// Set invalid directory to cause working-directory creation to fail after
+	// script preparation succeeds outside the workflow directory.
+	cfg.Dir = filepath.Join(blockingFile, "child")
 
 	executor := &commandExecutor{config: cfg}
 
 	err = executor.Run(ctx)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to setup script")
+	assert.Contains(t, err.Error(), "failed to create working directory")
 }
 
 // TestCommandExecutor_Run_NewCmdError tests Run when newCmd fails
@@ -2205,29 +2167,6 @@ func TestCommandExecutor_Run_StartErrorWithStderr(t *testing.T) {
 
 	err := executor.Run(ctx)
 	assert.Error(t, err)
-}
-
-// TestDetectShebang_ReadError tests detectShebang when readFirstLine fails
-func TestDetectShebang_ReadError(t *testing.T) {
-	cfg := &commandConfig{
-		UserSpecifiedShell: false,
-	}
-
-	_, _, err := cfg.detectShebang("/nonexistent/file.sh")
-	assert.Error(t, err)
-}
-
-// TestReadFirstLine_ScannerError tests readFirstLine with a problematic file
-func TestReadFirstLine_ScannerError(t *testing.T) {
-	// Test with an empty file (should return empty string, no error)
-	tmpFile, err := os.CreateTemp("", "test-empty-*.sh")
-	require.NoError(t, err)
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
-	_ = tmpFile.Close()
-
-	result, err := readFirstLine(tmpFile.Name())
-	require.NoError(t, err)
-	assert.Equal(t, "", result)
 }
 
 // TestExitCodeFromError_WithExitError tests exitCodeFromError with actual ExitError
@@ -2471,26 +2410,6 @@ func TestCommandConfig_NewCmd_ShellScriptNoShebang(t *testing.T) {
 	assert.NotNil(t, cmd)
 	// Should use /bin/sh to run the script
 	assert.Contains(t, cmd.Path, "sh")
-}
-
-// TestReadFirstLine_LongLine tests readFirstLine with extremely long content
-// This tests the scanner error path (line 219-221)
-func TestReadFirstLine_LongLine(t *testing.T) {
-	// Create a file with a very long first line (longer than 4KB buffer)
-	tmpFile, err := os.CreateTemp("", "test-long-*.sh")
-	require.NoError(t, err)
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
-
-	// Write a line longer than the buffer limit (4KB) without newline
-	longLine := strings.Repeat("a", 5000)
-	_, err = tmpFile.WriteString(longLine)
-	require.NoError(t, err)
-	_ = tmpFile.Close()
-
-	// This should return an error because the line is too long for the buffer
-	_, err = readFirstLine(tmpFile.Name())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read file")
 }
 
 func TestMultiCommandExecutor(t *testing.T) {

--- a/internal/runtime/builtin/command/command_test.go
+++ b/internal/runtime/builtin/command/command_test.go
@@ -1882,6 +1882,34 @@ func TestSetupScriptDoesNotRequireWorkDir(t *testing.T) {
 	assert.NotContains(t, scriptFile, blockingFile)
 }
 
+func TestCreateScriptTempFallbackUsesWorkDirWhenSystemTempUnavailable(t *testing.T) {
+	workDir := t.TempDir()
+	file, err := createScriptTempFallback(workDir, "dagu_script-*.sh", assert.AnError)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(file.Name()) })
+	t.Cleanup(func() { _ = file.Close() })
+
+	fallbackDir := filepath.Join(workDir, ".dagu", "tmp", "scripts")
+	require.Equal(t, filepath.Clean(fallbackDir), filepath.Clean(filepath.Dir(file.Name())))
+
+	if goruntime.GOOS != "windows" {
+		info, err := os.Stat(fallbackDir)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	}
+}
+
+func TestCreateScriptTempFallbackReportsSystemAndFallbackErrors(t *testing.T) {
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0o600))
+
+	_, err := createScriptTempFallback(filepath.Join(blockingFile, "child"), "dagu_script-*", assert.AnError)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "system temp unavailable")
+	assert.Contains(t, err.Error(), "fallback")
+	assert.NotContains(t, err.Error(), "echo")
+}
+
 // TestShellCommandBuilder_Build_Errors tests error paths in Build
 func TestShellCommandBuilder_Build_Errors(t *testing.T) {
 	ctx := context.Background()

--- a/internal/runtime/builtin/command/export_test.go
+++ b/internal/runtime/builtin/command/export_test.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package command
+
+import "context"
+
+type ShellCommandBuilderForTest struct {
+	Dir                string
+	Command            string
+	Args               []string
+	Shell              []string
+	ShellCommandArgs   string
+	ShellPackages      []string
+	Script             string
+	UserSpecifiedShell bool
+}
+
+func BuildShellCommandForTest(ctx context.Context, b ShellCommandBuilderForTest) ([]string, error) {
+	builder := &shellCommandBuilder{
+		Dir:                b.Dir,
+		Command:            b.Command,
+		Args:               b.Args,
+		Shell:              b.Shell,
+		ShellCommandArgs:   b.ShellCommandArgs,
+		ShellPackages:      b.ShellPackages,
+		Script:             b.Script,
+		UserSpecifiedShell: b.UserSpecifiedShell,
+	}
+	cmd, err := builder.Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.Args, nil
+}
+
+func ParseScriptShebangForTest(script string) (string, []string, error) {
+	return parseScriptShebang(script)
+}
+
+func ResolveShebangExecutableForTest(ctx context.Context, command string) (string, error) {
+	return resolveShebangExecutable(ctx, command)
+}
+
+func SetupScriptForExecutionForTest(workDir, script, command string, shell []string, userSpecifiedShell bool) (string, error) {
+	return setupScriptForExecution(workDir, script, command, shell, userSpecifiedShell)
+}

--- a/internal/runtime/builtin/command/script_shebang.go
+++ b/internal/runtime/builtin/command/script_shebang.go
@@ -115,8 +115,10 @@ func resolveShebangExecutable(ctx context.Context, command string) (string, erro
 		return command, nil
 	}
 
-	if pathEnv, ok := lookupEnv(runtime.AllEnvs(ctx), "PATH"); ok {
-		resolved, err := lookPathInPATH(command, pathEnv)
+	envs := runtime.AllEnvs(ctx)
+	if pathEnv, ok := lookupEnv(envs, "PATH"); ok {
+		pathextEnv, _ := lookupEnv(envs, "PATHEXT")
+		resolved, err := lookPathInPATH(command, pathEnv, pathextEnv)
 		if err == nil {
 			return resolved, nil
 		}
@@ -152,13 +154,13 @@ func lookupEnv(env []string, key string) (string, bool) {
 	return "", false
 }
 
-func lookPathInPATH(command, pathEnv string) (string, error) {
+func lookPathInPATH(command, pathEnv, pathextEnv string) (string, error) {
 	var lastErr error
 	for _, dir := range filepath.SplitList(pathEnv) {
 		if dir == "" {
 			dir = "."
 		}
-		for _, candidate := range pathCandidates(filepath.Join(dir, command)) {
+		for _, candidate := range pathCandidates(filepath.Join(dir, command), pathextEnv) {
 			if isExecutableFile(candidate) {
 				return candidate, nil
 			}
@@ -173,12 +175,12 @@ func lookPathInPATH(command, pathEnv string) (string, error) {
 	return "", os.ErrNotExist
 }
 
-func pathCandidates(candidate string) []string {
+func pathCandidates(candidate, pathextEnv string) []string {
 	if goruntime.GOOS != "windows" || filepath.Ext(candidate) != "" {
 		return []string{candidate}
 	}
 
-	pathext := os.Getenv("PATHEXT")
+	pathext := pathextEnv
 	if pathext == "" {
 		pathext = ".COM;.EXE;.BAT;.CMD"
 	}

--- a/internal/runtime/builtin/command/script_shebang.go
+++ b/internal/runtime/builtin/command/script_shebang.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/runtime"
+)
+
+func parseScriptShebang(script string) (string, []string, error) {
+	line := script
+	if idx := strings.IndexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	line = strings.TrimSuffix(line, "\r")
+	if !strings.HasPrefix(line, "#!") {
+		return "", nil, nil
+	}
+
+	words, err := parseShebangWords(strings.TrimLeft(line[2:], " \t"))
+	if err != nil {
+		return "", nil, err
+	}
+	if len(words) == 0 || words[0] == "" {
+		return "", nil, fmt.Errorf("shebang line has no interpreter command")
+	}
+	return words[0], words[1:], nil
+}
+
+func parseShebangWords(input string) ([]string, error) {
+	var words []string
+	var current strings.Builder
+	wordStarted := false
+	inSingle := false
+	inDouble := false
+
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		switch {
+		case inSingle:
+			if ch == '\'' {
+				inSingle = false
+				wordStarted = true
+				continue
+			}
+			current.WriteByte(ch)
+
+		case inDouble:
+			switch ch {
+			case '"':
+				inDouble = false
+				wordStarted = true
+			case '\\':
+				if i+1 >= len(input) {
+					return nil, fmt.Errorf("shebang line contains trailing unpaired backslash")
+				}
+				i++
+				current.WriteByte(input[i])
+				wordStarted = true
+			default:
+				current.WriteByte(ch)
+				wordStarted = true
+			}
+
+		default:
+			switch ch {
+			case ' ', '\t':
+				if wordStarted {
+					words = append(words, current.String())
+					current.Reset()
+					wordStarted = false
+				}
+			case '\'':
+				inSingle = true
+				wordStarted = true
+			case '"':
+				inDouble = true
+				wordStarted = true
+			case '\\':
+				if i+1 >= len(input) {
+					return nil, fmt.Errorf("shebang line contains trailing unpaired backslash")
+				}
+				i++
+				current.WriteByte(input[i])
+				wordStarted = true
+			default:
+				current.WriteByte(ch)
+				wordStarted = true
+			}
+		}
+	}
+
+	switch {
+	case inSingle:
+		return nil, fmt.Errorf("shebang line contains unterminated single quote")
+	case inDouble:
+		return nil, fmt.Errorf("shebang line contains unterminated double quote")
+	}
+	if wordStarted {
+		words = append(words, current.String())
+	}
+	return words, nil
+}
+
+func resolveShebangExecutable(ctx context.Context, command string) (string, error) {
+	if hasPathSeparator(command) {
+		return command, nil
+	}
+
+	if pathEnv, ok := lookupEnv(runtime.AllEnvs(ctx), "PATH"); ok {
+		resolved, err := lookPathInPATH(command, pathEnv)
+		if err == nil {
+			return resolved, nil
+		}
+		return "", fmt.Errorf("failed to resolve shebang interpreter %q in step PATH: %w", command, err)
+	}
+
+	if resolved, ok := cmdutil.FindExecutable(command); ok {
+		return resolved, nil
+	}
+	return "", fmt.Errorf("failed to resolve shebang interpreter %q in PATH", command)
+}
+
+func hasPathSeparator(path string) bool {
+	return strings.Contains(path, "/") || strings.Contains(path, `\`)
+}
+
+func lookupEnv(env []string, key string) (string, bool) {
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if goruntime.GOOS == "windows" {
+			if strings.EqualFold(name, key) {
+				return value, true
+			}
+			continue
+		}
+		if name == key {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func lookPathInPATH(command, pathEnv string) (string, error) {
+	var lastErr error
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			dir = "."
+		}
+		for _, candidate := range pathCandidates(filepath.Join(dir, command)) {
+			if isExecutableFile(candidate) {
+				return candidate, nil
+			}
+			if _, err := os.Stat(candidate); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", os.ErrNotExist
+}
+
+func pathCandidates(candidate string) []string {
+	if goruntime.GOOS != "windows" || filepath.Ext(candidate) != "" {
+		return []string{candidate}
+	}
+
+	pathext := os.Getenv("PATHEXT")
+	if pathext == "" {
+		pathext = ".COM;.EXE;.BAT;.CMD"
+	}
+	exts := strings.Split(pathext, ";")
+	candidates := make([]string, 0, len(exts)+1)
+	candidates = append(candidates, candidate)
+	for _, ext := range exts {
+		if ext == "" {
+			continue
+		}
+		candidates = append(candidates, candidate+ext)
+	}
+	return candidates
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if goruntime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}

--- a/internal/runtime/builtin/command/shell_cmd.go
+++ b/internal/runtime/builtin/command/shell_cmd.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +79,11 @@ func (s *cmdShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd
 	if b.Script != "" {
 		args := cloneArgs(b.Shell[1:])
 		args = append(args, b.Args...)
-		if !slices.Contains(args, "/c") && !slices.Contains(args, "/C") {
+		carrierIdx := indexOfCmdCarrier(args)
+		if carrierIdx >= 0 && carrierIdx != len(args)-1 {
+			return nil, fmt.Errorf("script form cannot be used with cmd carrier %q followed by authored command text", args[carrierIdx])
+		}
+		if carrierIdx < 0 {
 			args = append(args, "/c")
 		}
 		args = append(args, b.Script)
@@ -98,4 +103,13 @@ func (s *cmdShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd
 	}
 
 	return exec.CommandContext(ctx, cmd, args...), nil // nolint: gosec
+}
+
+func indexOfCmdCarrier(args []string) int {
+	for i, arg := range args {
+		if arg == "/c" || arg == "/C" {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/runtime/builtin/command/shell_nix.go
+++ b/internal/runtime/builtin/command/shell_nix.go
@@ -5,9 +5,12 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"slices"
 	"strings"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 )
 
 // nixShell handles nix-shell with package management support.
@@ -22,15 +25,18 @@ func (s *nixShell) Match(name string) bool {
 func (s *nixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd, error) {
 	cmd := b.Shell[0]
 	args := cloneArgs(b.Shell[1:])
-
-	// Add packages
-	for _, pkg := range b.ShellPackages {
-		args = append(args, "-p", pkg)
+	scriptForm := b.Script != ""
+	if scriptForm {
+		if idx := indexOfNixRun(args); idx >= 0 && idx != len(args)-1 {
+			return nil, fmt.Errorf("script form cannot be used with nix-shell --run followed by authored command text")
+		}
 	}
+
+	args = insertNixGeneratedArgs(args, nixPackageArgs(b.ShellPackages)...)
 
 	// Add pure mode if not already specified
 	if !slices.Contains(args, "--pure") && !slices.Contains(args, "--impure") {
-		args = append(args, "--pure")
+		args = insertNixGeneratedArgs(args, "--pure")
 	}
 
 	if !slices.Contains(args, "--run") {
@@ -44,12 +50,7 @@ func (s *nixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd
 		cmdParts := []string{b.Command}
 		cmdParts = append(cmdParts, b.Args...)
 		cmdParts = append(cmdParts, b.Script)
-		cmdStr := strings.Join(cmdParts, " ")
-
-		// Apply set -e for error handling
-		if !b.UserSpecifiedShell && !strings.HasPrefix(cmdStr, "set -e") {
-			cmdStr = "set -e; " + cmdStr
-		}
+		cmdStr := nixShellCommandString(cmdParts, !b.UserSpecifiedShell)
 
 		return exec.CommandContext(ctx, cmd, append(args, cmdStr)...), nil // nolint: gosec
 	}
@@ -57,10 +58,7 @@ func (s *nixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd
 	// When running just a script file with nix-shell (no explicit command)
 	// e.g., nix-shell --run "set -e; ./script.sh"
 	if b.Script != "" {
-		scriptCmd := b.Script
-		if !b.UserSpecifiedShell && !strings.HasPrefix(scriptCmd, "set -e") {
-			scriptCmd = "set -e; " + scriptCmd
-		}
+		scriptCmd := nixShellCommandString([]string{b.Script}, !b.UserSpecifiedShell)
 		return exec.CommandContext(ctx, cmd, append(args, scriptCmd)...), nil // nolint: gosec
 	}
 
@@ -75,4 +73,44 @@ func (s *nixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cmd
 	}
 
 	return exec.CommandContext(ctx, cmd, args...), nil // nolint: gosec
+}
+
+func indexOfNixRun(args []string) int {
+	for i, arg := range args {
+		if arg == "--run" {
+			return i
+		}
+	}
+	return -1
+}
+
+func nixPackageArgs(packages []string) []string {
+	args := make([]string, 0, len(packages)*2)
+	for _, pkg := range packages {
+		args = append(args, "-p", pkg)
+	}
+	return args
+}
+
+func insertNixGeneratedArgs(args []string, additions ...string) []string {
+	if len(additions) == 0 {
+		return args
+	}
+	insertAt := len(args)
+	if idx := indexOfNixRun(args); idx >= 0 {
+		insertAt = idx
+	}
+	result := make([]string, 0, len(args)+len(additions))
+	result = append(result, args[:insertAt]...)
+	result = append(result, additions...)
+	result = append(result, args[insertAt:]...)
+	return result
+}
+
+func nixShellCommandString(parts []string, failFast bool) string {
+	cmdStr := cmdutil.ShellQuoteArgs(parts)
+	if failFast && !strings.HasPrefix(cmdStr, "set -e") {
+		cmdStr = "set -e; " + cmdStr
+	}
+	return cmdStr
 }

--- a/internal/runtime/builtin/command/shell_powershell.go
+++ b/internal/runtime/builtin/command/shell_powershell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"slices"
 	"strings"
 )
 
@@ -42,7 +41,7 @@ func appendPowerShellStartupArgs(args []string) []string {
 
 func containsPowerShellArg(args []string, target string) bool {
 	for _, arg := range args {
-		if strings.EqualFold(arg, target) {
+		if strings.EqualFold(powerShellArgName(arg), target) {
 			return true
 		}
 	}
@@ -52,12 +51,28 @@ func containsPowerShellArg(args []string, target string) bool {
 func indexOfPowerShellArg(args []string, targets ...string) int {
 	for i, arg := range args {
 		for _, target := range targets {
-			if strings.EqualFold(arg, target) {
+			if strings.EqualFold(powerShellArgName(arg), target) {
 				return i
 			}
 		}
 	}
 	return -1
+}
+
+func powerShellArgName(arg string) string {
+	if !strings.HasPrefix(arg, "-") {
+		return arg
+	}
+	name, _, _ := strings.Cut(arg, ":")
+	return name
+}
+
+func powerShellArgHasInlineValue(arg string) bool {
+	if !strings.HasPrefix(arg, "-") {
+		return false
+	}
+	_, _, ok := strings.Cut(arg, ":")
+	return ok
 }
 
 func (s *powerShell) Match(name string) bool {
@@ -96,7 +111,7 @@ func (s *powerShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.C
 	args := appendPowerShellStartupArgs(cloneArgs(b.Shell[1:]))
 
 	// PowerShell uses -Command instead of -c
-	if !slices.Contains(args, "-Command") && !slices.Contains(args, "-C") {
+	if !containsPowerShellArg(args, "-Command") && !containsPowerShellArg(args, "-C") {
 		args = append(args, "-Command")
 	}
 
@@ -119,8 +134,13 @@ func powerShellScriptArgs(configured []string, script string) ([]string, error) 
 	}
 
 	fileIdx := indexOfPowerShellArg(configured, "-File", "-F")
-	if fileIdx >= 0 && fileIdx != len(configured)-1 {
-		return nil, fmt.Errorf("script form cannot be used with PowerShell file carrier %q followed by authored arguments", configured[fileIdx])
+	if fileIdx >= 0 {
+		if powerShellArgHasInlineValue(configured[fileIdx]) {
+			return nil, fmt.Errorf("script form cannot be used with PowerShell file carrier %q because it already supplies a script path", configured[fileIdx])
+		}
+		if fileIdx != len(configured)-1 {
+			return nil, fmt.Errorf("script form cannot be used with PowerShell file carrier %q followed by authored arguments", configured[fileIdx])
+		}
 	}
 
 	args := cloneArgs(configured)

--- a/internal/runtime/builtin/command/shell_powershell.go
+++ b/internal/runtime/builtin/command/shell_powershell.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"slices"
 	"strings"
@@ -82,7 +83,12 @@ func (s *powerShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.C
 	// When running just a script file with PowerShell (no explicit command)
 	// e.g., powershell -ExecutionPolicy Bypass -File script.ps1
 	if b.Script != "" {
-		args := appendPowerShellStartupArgs([]string{"-ExecutionPolicy", "Bypass", "-File", b.Script})
+		configured := cloneArgs(b.Shell[1:])
+		configured = append(configured, b.Args...)
+		args, err := powerShellScriptArgs(configured, b.Script)
+		if err != nil {
+			return nil, err
+		}
 		return exec.CommandContext(ctx, cmd, args...), nil // nolint: gosec
 	}
 
@@ -101,4 +107,43 @@ func (s *powerShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.C
 	}
 
 	return exec.CommandContext(ctx, cmd, args...), nil // nolint: gosec
+}
+
+func powerShellScriptArgs(configured []string, script string) ([]string, error) {
+	for _, arg := range configured {
+		if containsPowerShellArg([]string{arg}, "-Command") ||
+			containsPowerShellArg([]string{arg}, "-C") ||
+			containsPowerShellArg([]string{arg}, "-EncodedCommand") {
+			return nil, fmt.Errorf("script form cannot be used with PowerShell command carrier %q", arg)
+		}
+	}
+
+	fileIdx := indexOfPowerShellArg(configured, "-File", "-F")
+	if fileIdx >= 0 && fileIdx != len(configured)-1 {
+		return nil, fmt.Errorf("script form cannot be used with PowerShell file carrier %q followed by authored arguments", configured[fileIdx])
+	}
+
+	args := cloneArgs(configured)
+	if !containsPowerShellArg(args, "-ExecutionPolicy") {
+		args = insertBeforePowerShellFileCarrier(args, "-ExecutionPolicy", "Bypass")
+	}
+	args = appendPowerShellStartupArgs(args)
+	if indexOfPowerShellArg(args, "-File", "-F") < 0 {
+		args = append(args, "-File")
+	}
+	args = append(args, script)
+	return args, nil
+}
+
+func insertBeforePowerShellFileCarrier(args []string, additions ...string) []string {
+	insertAt := len(args)
+	if idx := indexOfPowerShellArg(args, "-File", "-F"); idx >= 0 {
+		insertAt = idx
+	}
+
+	result := make([]string, 0, len(args)+len(additions))
+	result = append(result, args[:insertAt]...)
+	result = append(result, additions...)
+	result = append(result, args[insertAt:]...)
+	return result
 }

--- a/internal/runtime/builtin/command/shell_unix.go
+++ b/internal/runtime/builtin/command/shell_unix.go
@@ -44,8 +44,10 @@ func (s *unixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cm
 	if b.Script != "" {
 		args := cloneArgs(b.Shell[1:])
 		args = append(args, b.Args...)
-		if arg, ok := unixScriptCarrierConflict(args); ok {
-			return nil, fmt.Errorf("script form cannot be used with shell argument %q because it consumes command text or stdin", arg)
+		if cmdutil.IsUnixLikeShell(cmd) {
+			if arg, ok := unixScriptCarrierConflict(args); ok {
+				return nil, fmt.Errorf("script form cannot be used with shell argument %q because it consumes command text or stdin", arg)
+			}
 		}
 		// Add errexit flag for Unix-like shells (unless user specified shell)
 		if !b.UserSpecifiedShell && cmdutil.IsUnixLikeShell(cmd) && !slices.Contains(args, "-e") {

--- a/internal/runtime/builtin/command/shell_unix.go
+++ b/internal/runtime/builtin/command/shell_unix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
+	"strings"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 )
@@ -43,6 +44,9 @@ func (s *unixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cm
 	if b.Script != "" {
 		args := cloneArgs(b.Shell[1:])
 		args = append(args, b.Args...)
+		if arg, ok := unixScriptCarrierConflict(args); ok {
+			return nil, fmt.Errorf("script form cannot be used with shell argument %q because it consumes command text or stdin", arg)
+		}
 		// Add errexit flag for Unix-like shells (unless user specified shell)
 		if !b.UserSpecifiedShell && cmdutil.IsUnixLikeShell(cmd) && !slices.Contains(args, "-e") {
 			args = append(args, "-e")
@@ -69,6 +73,21 @@ func (s *unixShell) Build(ctx context.Context, b *shellCommandBuilder) (*exec.Cm
 	args = append(args, b.ShellCommandArgs)
 
 	return exec.CommandContext(ctx, cmd, args...), nil // nolint: gosec
+}
+
+func unixScriptCarrierConflict(args []string) (string, bool) {
+	for _, arg := range args {
+		if arg == "-c" || arg == "-s" {
+			return arg, true
+		}
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			flags := strings.TrimLeft(arg, "-")
+			if strings.ContainsAny(flags, "cs") {
+				return arg, true
+			}
+		}
+	}
+	return "", false
 }
 
 // cloneArgs returns a shallow copy of the provided args slice so callers can modify the result without mutating the original.

--- a/internal/runtime/builtin/command/spec015_external_test.go
+++ b/internal/runtime/builtin/command/spec015_external_test.go
@@ -319,9 +319,24 @@ func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+			requireShellCommand(t, tt.want, got)
 		})
 	}
+}
+
+func requireShellCommand(t *testing.T, want, got []string) {
+	t.Helper()
+
+	require.NotEmpty(t, want)
+	require.NotEmpty(t, got)
+	require.Equal(t, shellCommandName(want[0]), shellCommandName(got[0]))
+	require.Equal(t, want[1:], got[1:])
+}
+
+func shellCommandName(command string) string {
+	name := filepath.Base(strings.ReplaceAll(command, "\\", "/"))
+	name = strings.ToLower(name)
+	return strings.TrimSuffix(name, ".exe")
 }
 
 func TestSpec015ScriptPreparationUsesSystemTempAndExplicitShellExtension(t *testing.T) {

--- a/internal/runtime/builtin/command/spec015_external_test.go
+++ b/internal/runtime/builtin/command/spec015_external_test.go
@@ -135,6 +135,33 @@ func TestSpec015BareShebangInterpreterResolvesFromStepPATH(t *testing.T) {
 	require.Equal(t, interpreter, got)
 }
 
+func TestSpec015BareShebangInterpreterUsesStepPATHEXT(t *testing.T) {
+	if goruntime.GOOS != "windows" {
+		t.Skip("PATHEXT executable probing is Windows-specific")
+	}
+
+	dir := t.TempDir()
+	commandName := "spec015-interp"
+	interpreter := filepath.Join(dir, commandName+".XYZ")
+	require.NoError(t, os.WriteFile(interpreter, []byte(""), 0o755))
+
+	dag := &core.DAG{
+		Name:       "spec015-test",
+		WorkingDir: t.TempDir(),
+	}
+	ctx := coreexec.NewContext(context.Background(), dag, "", "")
+	env := daguruntime.NewEnv(ctx, core.Step{Name: "script"})
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"PATH":    dir,
+		"PATHEXT": ".XYZ",
+	}, cmnvalue.EnvSourceStepEnv)
+	ctx = daguruntime.WithEnv(ctx, env)
+
+	got, err := command.ResolveShebangExecutableForTest(ctx, commandName)
+	require.NoError(t, err)
+	require.Equal(t, interpreter, got)
+}
+
 func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
 	ctx := context.Background()
 
@@ -178,6 +205,14 @@ func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
 			want: []string{"bash", "/tmp/script.sh"},
 		},
 		{
+			name: "fallback non-shell accepts unix-like s argument",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"python", "-s"},
+				Script: "/tmp/script.py",
+			},
+			want: []string{"python", "-s", "/tmp/script.py"},
+		},
+		{
 			name: "powershell includes defaults",
 			builder: command.ShellCommandBuilderForTest{
 				Shell:  []string{"pwsh"},
@@ -208,6 +243,30 @@ func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
 				Script: "script.ps1",
 			},
 			wantErr: "-Command",
+		},
+		{
+			name: "powershell rejects command colon carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-Command:Write-Host ok"},
+				Script: "script.ps1",
+			},
+			wantErr: "-Command:Write-Host ok",
+		},
+		{
+			name: "powershell rejects file colon carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-File:author.ps1"},
+				Script: "script.ps1",
+			},
+			wantErr: "-File:author.ps1",
+		},
+		{
+			name: "powershell honors execution policy colon carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-ExecutionPolicy:Bypass"},
+				Script: "script.ps1",
+			},
+			want: []string{"pwsh", "-ExecutionPolicy:Bypass", "-NoProfile", "-NonInteractive", "-File", "script.ps1"},
 		},
 		{
 			name: "cmd rejects authored body after c carrier",

--- a/internal/runtime/builtin/command/spec015_external_test.go
+++ b/internal/runtime/builtin/command/spec015_external_test.go
@@ -132,7 +132,7 @@ func TestSpec015BareShebangInterpreterResolvesFromStepPATH(t *testing.T) {
 
 	got, err := command.ResolveShebangExecutableForTest(ctx, commandName)
 	require.NoError(t, err)
-	require.Equal(t, interpreter, got)
+	requirePathEqual(t, interpreter, got)
 }
 
 func TestSpec015BareShebangInterpreterUsesStepPATHEXT(t *testing.T) {
@@ -159,7 +159,7 @@ func TestSpec015BareShebangInterpreterUsesStepPATHEXT(t *testing.T) {
 
 	got, err := command.ResolveShebangExecutableForTest(ctx, commandName)
 	require.NoError(t, err)
-	require.Equal(t, interpreter, got)
+	requirePathEqual(t, interpreter, got)
 }
 
 func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
@@ -337,6 +337,18 @@ func shellCommandName(command string) string {
 	name := filepath.Base(strings.ReplaceAll(command, "\\", "/"))
 	name = strings.ToLower(name)
 	return strings.TrimSuffix(name, ".exe")
+}
+
+func requirePathEqual(t *testing.T, want, got string) {
+	t.Helper()
+
+	want = filepath.Clean(want)
+	got = filepath.Clean(got)
+	if goruntime.GOOS == "windows" {
+		require.Truef(t, strings.EqualFold(want, got), "expected path %q, got %q", want, got)
+		return
+	}
+	require.Equal(t, want, got)
 }
 
 func TestSpec015ScriptPreparationUsesSystemTempAndExplicitShellExtension(t *testing.T) {

--- a/internal/runtime/builtin/command/spec015_external_test.go
+++ b/internal/runtime/builtin/command/spec015_external_test.go
@@ -1,0 +1,285 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package command_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	daguruntime "github.com/dagucloud/dagu/internal/runtime"
+	command "github.com/dagucloud/dagu/internal/runtime/builtin/command"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpec015ParseScriptShebang(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    string
+		wantCmd   string
+		wantArgs  []string
+		wantEmpty bool
+		wantErr   string
+	}{
+		{
+			name:     "bare interpreter and argument",
+			script:   "#!/usr/bin/env bash\necho ok\n",
+			wantCmd:  "/usr/bin/env",
+			wantArgs: []string{"bash"},
+		},
+		{
+			name:     "spaces and tabs after marker",
+			script:   "#! \t/usr/bin/env\tbash\n",
+			wantCmd:  "/usr/bin/env",
+			wantArgs: []string{"bash"},
+		},
+		{
+			name:    "quoted spans and backslash grammar",
+			script:  "#!interp 'arg one' \"two \\\"quoted\\\"\" '' a\\ b $PATH *.go a|b\n",
+			wantCmd: "interp",
+			wantArgs: []string{
+				"arg one",
+				`two "quoted"`,
+				"",
+				"a b",
+				"$PATH",
+				"*.go",
+				"a|b",
+			},
+		},
+		{
+			name:      "leading blank line suppresses shebang",
+			script:    "\n#!/bin/sh\necho ordinary text\n",
+			wantEmpty: true,
+		},
+		{
+			name:      "leading BOM suppresses shebang",
+			script:    "\ufeff#!/bin/sh\necho ordinary text\n",
+			wantEmpty: true,
+		},
+		{
+			name:     "CRLF first line",
+			script:   "#!/bin/sh\r\necho ok\r\n",
+			wantCmd:  "/bin/sh",
+			wantArgs: []string{},
+		},
+		{
+			name:    "empty interpreter",
+			script:  "#!   \n",
+			wantErr: "no interpreter",
+		},
+		{
+			name:    "unterminated single quote",
+			script:  "#!interp 'unterminated\n",
+			wantErr: "unterminated single quote",
+		},
+		{
+			name:    "unterminated double quote",
+			script:  "#!interp \"unterminated\n",
+			wantErr: "unterminated double quote",
+		},
+		{
+			name:    "trailing backslash",
+			script:  "#!interp arg\\\n",
+			wantErr: "trailing unpaired backslash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArgs, err := command.ParseScriptShebangForTest(tt.script)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantEmpty {
+				require.Empty(t, gotCmd)
+				require.Empty(t, gotArgs)
+				return
+			}
+			require.Equal(t, tt.wantCmd, gotCmd)
+			require.Equal(t, tt.wantArgs, gotArgs)
+		})
+	}
+}
+
+func TestSpec015BareShebangInterpreterResolvesFromStepPATH(t *testing.T) {
+	dir := t.TempDir()
+	commandName := "spec015-interp"
+	fileName := commandName
+	if goruntime.GOOS == "windows" {
+		fileName += ".exe"
+	}
+	interpreter := filepath.Join(dir, fileName)
+	require.NoError(t, os.WriteFile(interpreter, []byte(""), 0o755))
+
+	dag := &core.DAG{
+		Name:       "spec015-test",
+		WorkingDir: t.TempDir(),
+	}
+	ctx := coreexec.NewContext(context.Background(), dag, "", "")
+	env := daguruntime.NewEnv(ctx, core.Step{Name: "script"})
+	env.Scope = env.Scope.WithEntries(map[string]string{"PATH": dir}, cmnvalue.EnvSourceStepEnv)
+	ctx = daguruntime.WithEnv(ctx, env)
+
+	got, err := command.ResolveShebangExecutableForTest(ctx, commandName)
+	require.NoError(t, err)
+	require.Equal(t, interpreter, got)
+}
+
+func TestSpec015ShellBuilderScriptCarrierValidation(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		builder command.ShellCommandBuilderForTest
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "unix rejects c carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"sh", "-c"},
+				Script: "/tmp/script.sh",
+			},
+			wantErr: "-c",
+		},
+		{
+			name: "unix rejects combined c carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"bash", "-lc"},
+				Script: "/tmp/script.sh",
+			},
+			wantErr: "-lc",
+		},
+		{
+			name: "unix rejects s carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"sh", "-s"},
+				Script: "/tmp/script.sh",
+			},
+			wantErr: "-s",
+		},
+		{
+			name: "explicit unix shell does not add errexit",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:              []string{"bash"},
+				Script:             "/tmp/script.sh",
+				UserSpecifiedShell: true,
+			},
+			want: []string{"bash", "/tmp/script.sh"},
+		},
+		{
+			name: "powershell includes defaults",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh"},
+				Script: "script.ps1",
+			},
+			want: []string{"pwsh", "-ExecutionPolicy", "Bypass", "-NoProfile", "-NonInteractive", "-File", "script.ps1"},
+		},
+		{
+			name: "powershell honors final file carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-File"},
+				Script: "script.ps1",
+			},
+			want: []string{"pwsh", "-ExecutionPolicy", "Bypass", "-NoProfile", "-NonInteractive", "-File", "script.ps1"},
+		},
+		{
+			name: "powershell rejects args after file carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-File", "author.ps1"},
+				Script: "script.ps1",
+			},
+			wantErr: "-File",
+		},
+		{
+			name: "powershell rejects command carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"pwsh", "-Command"},
+				Script: "script.ps1",
+			},
+			wantErr: "-Command",
+		},
+		{
+			name: "cmd rejects authored body after c carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"cmd", "/c", "echo body"},
+				Script: "script.bat",
+			},
+			wantErr: "/c",
+		},
+		{
+			name: "cmd accepts final c carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"cmd", "/c"},
+				Script: "script.bat",
+			},
+			want: []string{"cmd", "/c", "script.bat"},
+		},
+		{
+			name: "nix rejects authored run body",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"nix-shell", "--run", "echo body"},
+				Script: "/tmp/script.sh",
+			},
+			wantErr: "--run",
+		},
+		{
+			name: "nix quotes prepared script path",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:  []string{"nix-shell"},
+				Script: "/tmp/dagu script;touch unexpected.sh",
+			},
+			want: []string{"nix-shell", "--pure", "--run", "set -e; '/tmp/dagu script;touch unexpected.sh'"},
+		},
+		{
+			name: "nix inserts packages before configured run carrier",
+			builder: command.ShellCommandBuilderForTest{
+				Shell:         []string{"nix-shell", "--run"},
+				ShellPackages: []string{"bash"},
+				Script:        "/tmp/script.sh",
+			},
+			want: []string{"nix-shell", "-p", "bash", "--pure", "--run", "set -e; /tmp/script.sh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := command.BuildShellCommandForTest(ctx, tt.builder)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSpec015ScriptPreparationUsesSystemTempAndExplicitShellExtension(t *testing.T) {
+	workDir := t.TempDir()
+	blockingFile := filepath.Join(workDir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0o600))
+
+	scriptFile, err := command.SetupScriptForExecutionForTest(
+		filepath.Join(blockingFile, "child"),
+		"#!/usr/bin/env pwsh\nWrite-Output ok\n",
+		"",
+		[]string{"pwsh"},
+		true,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(scriptFile) })
+
+	require.False(t, strings.HasPrefix(scriptFile, workDir+string(os.PathSeparator)))
+	require.Equal(t, ".ps1", filepath.Ext(scriptFile))
+}

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -1078,8 +1078,12 @@ func TestRunner(t *testing.T) {
 	t.Run("WorkingDirNoExist", func(t *testing.T) {
 		r := setupRunner(t)
 
+		blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+		require.NoError(t, os.WriteFile(blockingFile, nil, 0o600))
+		workingDir := filepath.Join(blockingFile, "child")
+
 		plan := r.newPlan(t,
-			newStep("1", withWorkingDir("/nonexistent"),
+			newStep("1", withWorkingDir(workingDir),
 				withScript("echo 1"),
 			),
 		)
@@ -1088,13 +1092,9 @@ func TestRunner(t *testing.T) {
 
 		result.assertNodeStatus(t, "1", core.NodeFailed)
 
-		if windowsShellTest() {
-			require.Contains(t, strings.ToLower(result.Error.Error()), "cannot find the path specified")
-		} else {
-			require.Contains(t, result.Error.Error(), "no such file or directory")
-		}
+		require.Contains(t, result.Error.Error(), "failed to create working directory")
 	})
-	t.Run("InvalidWorkingDirReferencePreservesThenFailsBeforeScript", func(t *testing.T) {
+	t.Run("InvalidWorkingDirReferencePreservesLiteralPathForScript", func(t *testing.T) {
 		r := setupRunner(t)
 
 		sentinel := filepath.Join(t.TempDir(), "executed")
@@ -1103,25 +1103,14 @@ func TestRunner(t *testing.T) {
 				withScript(createEmptyFileCommand(sentinel)),
 			),
 		)
-		dag := &core.DAG{
-			Name:       "test_dag",
-			WorkingDir: plan.workDir,
-			Consts:     map[string]any{},
-		}
-		logFilename := fmt.Sprintf("%s_%s.log", dag.Name, r.cfg.DAGRunID)
-		logFilePath := path.Join(r.cfg.LogDir, logFilename)
-		ctx := runtime.NewContext(r.Context, dag, r.cfg.DAGRunID, logFilePath)
 
-		err := r.runner.Run(ctx, plan.Plan, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to setup script")
-		require.Contains(t, err.Error(), "${consts.missing}")
-		require.Equal(t, core.Failed.String(), r.runner.Status(ctx, plan.Plan).String())
+		result := plan.assertRun(t, core.Succeeded)
 
 		node := plan.GetNodeByName("1")
 		require.NotNil(t, node)
-		assert.Equal(t, core.NodeFailed, node.State().Status)
-		require.NoFileExists(t, sentinel)
+		result.assertNodeStatus(t, "1", core.NodeSucceeded)
+		assert.Equal(t, filepath.Join(plan.workDir, "${consts.missing}"), node.State().WorkingDir)
+		require.FileExists(t, sentinel)
 	})
 	t.Run("OutputVariables", func(t *testing.T) {
 		t.Parallel()

--- a/specs/015-step-run-script.md
+++ b/specs/015-step-run-script.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Partially implemented. This spec defines script-form `run` behavior.
+Implemented.
 
 ## Scope
 
-This spec defines script-form `run`.
+This spec defines local script-form `run`.
 
 Script form is a multi-line string `run`.
 
@@ -19,11 +19,15 @@ This spec does not define:
 - Array-form `run`.
 - Direct argv execution through `action: exec`.
 - Non-local executor behavior.
+- The implementation mechanism used to prepare a script.
+- The path, filename, extension, mode bits, or lifetime details of any internal
+  script preparation resource beyond the observable guarantees below.
 
 ## Goal
 
-Workflow authors can write multi-line shell scripts inline in a workflow and
-get predictable line preservation, shell behavior, and shebang behavior.
+Workflow authors can write multi-line shell scripts inline in a workflow and get
+predictable value resolution, line preservation, interpreter selection, shell
+argument behavior, secrecy, and failure behavior.
 
 ## Behavior
 
@@ -33,15 +37,33 @@ get predictable line preservation, shell behavior, and shebang behavior.
 
 - Script-form `run` must contain one or more line breaks.
 
+- A line break is any line-break sequence preserved by YAML decoding.
+
 - Dagu resolves Dagu-owned references before the script starts.
 
-- Dagu preserves line breaks in the resolved script text.
+- Dagu preserves the resolved script text as script content.
 
-- Leading and trailing line breaks are preserved.
+- Dagu preserves line breaks, leading whitespace, trailing whitespace, leading
+  line breaks, and trailing line breaks in the resolved script content.
 
 - Dagu must run the resolved script text as one script.
 
 - Dagu must not split script-form `run` into multiple command-form invocations.
+
+- Value resolution must not reclassify script form as command form.
+
+- If resolved script-form text no longer contains a line break, it is still
+  script form.
+
+- The selected shell or shebang interpreter receives the script content through
+  a script input prepared by Dagu.
+
+- The script input identity exposed to the interpreter, such as a script path,
+  script name, or `$0` value, is not a stable workflow API.
+
+- A workflow must not depend on the script input identity, file extension, or
+  directory. Use `working_dir`, `DAG_RUN_WORK_DIR`, artifacts, or explicit files
+  when a stable path is required.
 
 ### Shell Operators
 
@@ -55,27 +77,127 @@ get predictable line preservation, shell behavior, and shebang behavior.
 
 - Shell state and control flow remain inside the script process according to the selected shell or shebang interpreter.
 
+- Background execution syntax is owned by the selected shell or shebang
+  interpreter.
+
+- Dagu determines the step result from the selected shell or shebang interpreter
+  process, not from detached background work.
+
+- A script that starts background work must wait for that work itself when the
+  step result should include that work.
+
 ### Script Preparation
 
 - Dagu must prepare the resolved script text before user script code starts.
 
 - If Dagu cannot prepare the script, the step fails before user script code starts.
 
-- The script runs from the step process working directory.
+- Dagu must prepare the script so the selected shell or shebang interpreter can
+  consume it as one script.
 
-- If the step process working directory is unavailable when Dagu prepares the script, script preparation fails.
+- The script process runs from the step process working directory.
+
+- Dagu must not require workflow authors to make the workflow file directory
+  writable for script preparation.
+
+- Dagu must not require workflow authors to make the script input path stable or
+  addressable from the script process working directory.
+
+- If the step process working directory cannot be used as a process working
+  directory, the step fails before user script code starts.
 
 - Script preparation fails when Dagu cannot make the resolved script text available to the selected shell or shebang interpreter.
 
-- Dagu removes script preparation resources after script execution.
+- After script preparation succeeds, Dagu must attempt to remove script
+  preparation resources when the step attempt no longer needs the prepared
+  script input.
 
-- Cleanup failure must not change a successful script exit into a failed step.
+- Cleanup must be attempted after selected shell or shebang interpreter start
+  failure, successful script exit, non-zero script exit, abort, and timeout.
+
+- Cleanup failure must not replace the original step result.
+
+- Cleanup failure may be reported as a diagnostic, but it must not be reported
+  as the step's execution error when the script process succeeded.
+
+- Dagu-generated diagnostics in normal step errors, run logs, status records,
+  history records, workflow events, and DAG-run detail responses must not
+  include the full resolved script text.
+
+- An explicit inspection or debug surface may show resolved script text only
+  when workflow authors opt in to that surface.
+
+- Dagu-generated diagnostics must not expose values that are secret-backed under
+  the environment and secret specs.
+
+- Any explicit inspection or debug surface that shows resolved script text must
+  apply secret masking owned by the environment and secret specs.
+
+- User script stdout and stderr are user-controlled output. Dagu captures them
+  as defined by the shared `run` spec.
 
 ### Shebang
 
-- If the first line of the script starts with `#!` and no step-level `with.shell` is explicitly specified, Dagu must invoke the shebang interpreter.
+- Shebang detection reads only the first line of the resolved script content.
+
+- The first line starts at the first byte or character of the resolved script
+  content.
+
+- Dagu must not skip leading whitespace, leading line breaks, or a byte order
+  mark before checking for `#!`.
+
+- If the first line of the resolved script content starts with `#!` and no
+  step-level `with.shell` is explicitly specified, Dagu must invoke the shebang
+  interpreter.
+
+- Dagu trims ASCII spaces and tabs after `#!` on the shebang line.
+
+- The interpreter command is the first shebang word after that trim.
+
+- Shebang words are separated by ASCII spaces and tabs outside quoted spans.
+
+- Single-quoted spans group text. Dagu removes the surrounding single quotes and
+  keeps the contained characters literally. A single quote cannot appear inside
+  a single-quoted span.
+
+- Double-quoted spans group text. Dagu removes the surrounding double quotes.
+  Inside a double-quoted span, a backslash escapes the following character, and
+  the escaped character is copied literally.
+
+- Outside quoted spans, a backslash escapes the following character, and the
+  escaped character is copied literally.
+
+- Backslashes are ordinary characters inside single-quoted spans.
+
+- An empty quoted span produces an empty shebang word.
+
+- Dagu does not perform shell expansion, environment expansion, glob expansion,
+  command substitution, pipe parsing, or redirect parsing while parsing a
+  shebang line.
+
+- Remaining shebang words on the first line are passed as interpreter
+  arguments.
+
+- If a shebang line is present but cannot be parsed into a non-empty interpreter
+  command, the step fails before user script code starts.
+
+- If a shebang line contains an unterminated single quote, an unterminated double
+  quote, or a trailing unpaired backslash outside single quotes, the step fails
+  before user script code starts.
+
+- If the interpreter command contains a path separator, Dagu uses that command
+  path as parsed.
+
+- If the interpreter command does not contain a path separator, Dagu resolves it
+  through the step process `PATH`.
 
 - A root shell does not count as an explicitly specified step-level shell for shebang suppression.
+
+- A runtime default shell does not count as an explicitly specified step-level
+  shell for shebang suppression.
+
+- When a shebang interpreter is used, root shell settings, runtime default shell
+  settings, and shell packages do not wrap the script.
 
 - If step-level `with.shell` is explicitly specified, Dagu must execute the script through that shell and must not use the shebang interpreter directly.
 
@@ -83,21 +205,97 @@ get predictable line preservation, shell behavior, and shebang behavior.
 
 ### Shell Behavior
 
+#### Common Rules
+
+- Shell construction uses the selected shell, configured shell arguments, the
+  prepared script input, and configured shell packages where the selected shell
+  supports packages.
+
+- Shell-specific defaults are part of the script-form contract and must be
+  covered by black-box tests before being changed.
+
+- Configured shell arguments are passed to the selected shell before the script
+  input unless a shell-specific rule below defines a different position.
+
+- If configured shell arguments conflict with the script carrier required by the
+  selected shell, Dagu must fail before user script code starts.
+
+- When Dagu needs to embed the prepared script input identity in shell-owned
+  command text, Dagu must pass that identity so its characters are treated as
+  data, not shell syntax.
+
+- Shell metacharacters in the prepared script input identity must not trigger
+  extra commands, redirection, expansion, globbing, or argument splitting.
+
+- For a selected shell that is not identified below, Dagu treats the selected
+  shell as a script interpreter and passes the prepared script input as an
+  argument after configured shell arguments.
+
 #### Unix-Like Shells
 
-- Unix-like script execution includes `-e` when the selected shell is Unix-like, no step-level shell is explicitly specified, and configured shell arguments do not already include `-e`.
+- Unix-like script execution passes the prepared script input to the selected
+  shell as a script file argument.
+
+- Unix-like script execution must reject configured shell arguments that select
+  command-string or stdin script carriers, including `-c` and `-s`.
+
+- Unix-like script execution includes `-e` when the selected shell is Unix-like,
+  no step-level shell is explicitly specified, and configured shell arguments do
+  not already include `-e`.
+
+- Step-level `with.shell` suppresses Dagu's automatic `-e` addition. Workflow
+  authors must include `-e` in `with.shell_args` when they want that behavior
+  with an explicit step shell.
 
 #### PowerShell
 
-- PowerShell script execution includes `-ExecutionPolicy Bypass -File`.
+- PowerShell script execution passes the prepared script input through
+  PowerShell file execution.
+
+- PowerShell script execution includes `-ExecutionPolicy Bypass` unless
+  configured shell arguments already specify an execution policy.
+
+- PowerShell script execution includes `-File` unless configured shell
+  arguments already specify the same file-execution carrier.
+
+- PowerShell file-execution carriers are `-File` and `-F`.
+
+- If configured shell arguments include a PowerShell file-execution carrier,
+  that carrier must be the final configured shell argument.
+
+- When configured shell arguments include a PowerShell file-execution carrier,
+  Dagu appends the prepared script input immediately after that carrier.
+
+- If any configured shell argument appears after `-File` or `-F`, Dagu must fail
+  before user script code starts because that argument would be interpreted as an
+  authored file path or script argument.
+
+- PowerShell script execution must reject configured shell arguments that select
+  command-string carriers, including `-Command`, `-C`, and `-EncodedCommand`.
 
 - PowerShell script execution includes `-NoProfile` and `-NonInteractive` unless configured shell arguments already include them.
 
-- PowerShell script execution normalizes error handling and UTF-8 encoding.
+- PowerShell script execution normalizes PowerShell error handling and UTF-8
+  text encoding before user script code starts.
+
+- Under PowerShell normalization, a PowerShell error written by `Write-Error`
+  fails the step unless the script handles the error.
+
+- Dagu determines PowerShell script success from the PowerShell process exit
+  code.
+
+- Native executable error semantics inside the script remain PowerShell-owned
+  unless Dagu's PowerShell normalization explicitly changes them.
 
 #### Windows cmd
 
 - `cmd` script execution includes `/c` unless configured shell arguments already include `/c` or `/C`.
+
+- `cmd` script execution must reject configured shell arguments that provide an
+  authored command body after `/c` or `/C`.
+
+- `cmd` resolves the configured `COMSPEC` path when the selected shell is `cmd`
+  or `cmd.exe` and `COMSPEC` points to an existing path.
 
 #### Nix Shell
 
@@ -107,6 +305,18 @@ get predictable line preservation, shell behavior, and shebang behavior.
 
 - Nix shell script execution includes `--run` unless configured shell arguments already include it.
 
+- Nix shell script execution must reject configured shell arguments that provide
+  an authored command body after `--run`.
+
+- Nix shell script execution runs the prepared script input inside the Nix shell
+  command environment.
+
+- Nix shell script execution includes fail-fast behavior when no step-level
+  `with.shell` is explicitly specified.
+
+- Under Nix shell fail-fast behavior, `echo before; false; echo after` must not
+  execute `echo after` unless the script handles the failing command.
+
 ## Errors
 
 Runtime must fail when:
@@ -115,11 +325,22 @@ Runtime must fail when:
 
 - Shebang detection fails.
 
+- A shebang line is present but has no interpreter command.
+
 - The selected shell or shebang interpreter cannot be started.
 
 - The selected shell or shebang interpreter cannot find the command path.
 
+- The selected `working_dir` value cannot be used as a process working directory.
+
+- Configured shell arguments conflict with the script carrier required by the
+  selected shell.
+
 - The script exits with a non-zero code.
+
+- The script process is terminated by abort or timeout.
+
+- The script emits invalid declared outputs.
 
 ## Examples
 
@@ -154,4 +375,39 @@ steps:
       echo "$0"
     with:
       shell: sh
+```
+
+Explicit step shell with fail-fast Unix behavior:
+
+```yaml
+steps:
+  - id: bash_script
+    run: |
+      echo before
+      false
+      echo after
+    with:
+      shell: bash
+      shell_args: [-e]
+```
+
+Do not rely on the prepared script path:
+
+```yaml
+steps:
+  - id: stable_paths
+    run: |
+      printf 'work dir: %s\n' "$PWD"
+      printf 'run work dir: %s\n' "$DAG_RUN_WORK_DIR"
+```
+
+Wait for background work that belongs to the step result:
+
+```yaml
+steps:
+  - id: background
+    run: |
+      ./long-task.sh &
+      task_pid=$!
+      wait "$task_pid"
 ```

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,7 +24,7 @@ It must not be treated as product behavior until implementation catches up.
 | [012: Step Outputs](012-step-outputs.md) | Implemented |
 | [013: Step Run](013-step-run.md) | Partially implemented |
 | [014: Step Run Command](014-step-run-command.md) | Partially implemented |
-| [015: Step Run Script](015-step-run-script.md) | Partially implemented |
+| [015: Step Run Script](015-step-run-script.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

Implement Spec 015 for local script-form run.

## Changes

- Preserve multiline script-form run text and execute it as one prepared script.
- Add shebang handling, step-scoped interpreter resolution, shell carrier validation, cleanup, and diagnostics that avoid dumping resolved script content.
- Add focused unit tests and conformance coverage for runtime behavior, failure modes, shell edge cases, and diagnostics.
- Mark Spec 015 as implemented in the spec index and spec document.

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- go test ./internal/runtime/builtin/command -count=1
- go test ./internal/core/spec -count=1
- make bin
- DAGU_BIN=.local/bin/dagu go test ./conformance/spec015_step_run_script -count=1
- make lint
- make conformance
