### PR TITLE
test: add value resolution conformance coverage

### DIFF
--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -65,7 +65,7 @@ A Dagu file has three layers:
 | Layer | Fields | Purpose |
 |-------|--------|---------|
 | Workflow metadata | `name`, `description`, `group`, `labels` | Identify and organize the DAG. |
-| Workflow runtime | `schedule`, `params`, `env`, `working_dir`, `queue`, `worker_selector`, `timeout_sec`, `max_active_runs`, `artifacts`, `log_output` | Configure when and where the DAG runs. |
+| Workflow runtime | `schedule`, `params`, `env`, `working_dir`, `shell`, `shell_args`, `queue`, `worker_selector`, `timeout_sec`, `max_active_runs`, `artifacts`, `log_output` | Configure when and where the DAG runs. |
 | Step graph | `steps`, `handler_on`, `defaults`, `actions` | Define executable work, shared step defaults, lifecycle handlers, and custom actions. |
 
 Most workflows only need `name`, `type`, `params`, and `steps`.

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -931,6 +931,13 @@
       ],
       "description": "Default shell to use for all steps in this DAG. Can be specified as a string with arguments (e.g., '/bin/bash -e') which will be automatically tokenized, or as an array for explicit argument separation. If not specified, the system default shell ($SHELL or /bin/sh) is used. Can be overridden at the step level."
     },
+    "shell_args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Additional arguments appended to the DAG-level shell for run steps. Step-level with.shell and with.shell_args override the inherited shell invocation for that step."
+    },
     "redis": {
       "allOf": [
         {

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -54,6 +54,8 @@ type dag struct {
 	// Can be overridden at the step level.
 	// Can be a string (e.g., "bash -e") or an array (e.g., ["bash", "-e"]).
 	Shell types.ShellValue `yaml:"shell,omitempty"`
+	// ShellArgs is the list of additional arguments passed to the root shell.
+	ShellArgs []string `yaml:"shell_args,omitempty"`
 	// WorkingDir is working directory for DAG execution
 	WorkingDir string `yaml:"working_dir,omitempty"`
 	// Dotenv is the path to the dotenv file (string or []string).
@@ -1877,7 +1879,7 @@ func buildShellArgs(ctx BuildContext, d *dag) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return result.Args, nil
+	return append(result.Args, d.ShellArgs...), nil
 }
 
 func buildWorkingDir(ctx BuildContext, d *dag) (string, error) {

--- a/internal/core/spec/spec003_conformance_test.go
+++ b/internal/core/spec/spec003_conformance_test.go
@@ -1,0 +1,400 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpec003ConformanceValueResolvedFieldSurfaces(t *testing.T) {
+	t.Parallel()
+
+	dag := loadSpec003DAG(t, `
+name: spec003
+description: literal description
+params:
+  - name: environment
+    default: prod
+  - name: retry_limit
+    default: "3"
+  - name: retry_interval
+    default: "5"
+  - name: repeat_limit
+    default: "2"
+  - name: repeat_interval
+    default: "7"
+  - name: repeat_max_interval
+    default: "11"
+  - name: repeat_condition
+    default: "keep-going"
+env:
+  - ROOT_VALUE=${params.environment}
+dotenv:
+  - .env.${params.environment}
+shell: bash
+shell_args:
+  - -e
+  - ${params.environment}
+working_dir: /tmp/${params.environment}
+preconditions:
+  - condition: ready-${params.environment}
+container:
+  image: repo/${params.environment}:latest
+  env:
+    - CONTAINER_VALUE=${params.environment}
+steps:
+  - id: publish
+    run: echo ${params.environment}
+    working_dir: /work/${params.environment}
+    env:
+      - STEP_VALUE=${params.environment}
+    preconditions:
+      - condition: check-${params.environment}
+    retry_policy:
+      limit: ${params.retry_limit}
+      interval_sec: ${params.retry_interval}
+    repeat_policy:
+      repeat: while
+      condition: ${params.repeat_condition}
+      limit: ${params.repeat_limit}
+      interval_sec: ${params.repeat_interval}
+      max_interval_sec: ${params.repeat_max_interval}
+    stdout:
+      artifact: stdout/${params.environment}.log
+      outputs:
+        fields:
+          image:
+            value: repo:${params.environment}
+    stderr:
+      artifact: stderr/${params.environment}.log
+    output:
+      digest:
+        value: sha:${params.environment}
+      report:
+        from: file
+        path: outputs/${params.environment}.txt
+    outputs:
+      - name: literal_name
+        type: string
+
+  - id: container_step
+    action: harness.run
+    container:
+      image: step:${params.environment}
+    with:
+      prompt: review ${params.environment}
+      provider: codex
+
+  - id: log_message
+    action: log.write
+    with:
+      message: deploy ${params.environment}
+
+  - id: child
+    action: dag.run
+    with:
+      dag: child-${params.environment}
+      params: ENV=${params.environment}
+
+  - id: fanout
+    parallel:
+      items:
+        - ${params.environment}
+        - target: ${params.environment}
+    action: dag.run
+    with:
+      dag: fanout-${params.environment}
+      params:
+        env: ${params.environment}
+
+  - id: chat
+    action: chat.completion
+    with:
+      model:
+        - provider: openai
+          name: gpt-4o
+          base_url: https://${params.environment}.example/v1
+          api_key_name: OPENAI_API_KEY
+      system: system ${params.environment}
+      base_url: https://fallback-${params.environment}.example/v1
+      tools:
+        - literal_tool
+      messages:
+        - role: user
+          content: hello ${params.environment}
+
+  - id: render
+    action: template.render
+    with:
+      template: literal ${params.environment}
+      data:
+        message: resolved ${params.environment}
+`)
+
+	resolved := resolveSpec003Fields(t, dag, cmnvalue.Values{
+		"environment":         "prod",
+		"retry_limit":         "3",
+		"retry_interval":      "5",
+		"repeat_limit":        "2",
+		"repeat_interval":     "7",
+		"repeat_max_interval": "11",
+		"repeat_condition":    "keep-going",
+	})
+
+	assert.Equal(t, "prod", resolved["env[0]"])
+	assert.Equal(t, ".env.prod", resolved["dotenv[0]"])
+	assert.Equal(t, "prod", resolved["shell_args[1]"])
+	assert.Equal(t, "/tmp/prod", resolved["working_dir"])
+	assert.Equal(t, "ready-prod", resolved["preconditions[0].condition"])
+	assert.Equal(t, "repo/prod:latest", resolved["container.image"])
+	assert.Equal(t, "prod", resolved["container.env[0]"])
+
+	assert.Equal(t, "echo prod", resolved["steps[0].run[0].cmd_with_args"])
+	assert.Equal(t, "/work/prod", resolved["steps[0].working_dir"])
+	assert.Equal(t, "prod", resolved["steps[0].env[0]"])
+	assert.Equal(t, "check-prod", resolved["steps[0].preconditions[0].condition"])
+	assert.Equal(t, "3", resolved["steps[0].retry_policy.limit"])
+	assert.Equal(t, "5", resolved["steps[0].retry_policy.interval_sec"])
+	assert.Equal(t, "keep-going", resolved["steps[0].repeat_policy.condition"])
+	assert.Equal(t, "2", resolved["steps[0].repeat_policy.limit"])
+	assert.Equal(t, "7", resolved["steps[0].repeat_policy.interval_sec"])
+	assert.Equal(t, "11", resolved["steps[0].repeat_policy.max_interval_sec"])
+	assert.Equal(t, "stdout/prod.log", resolved["steps[0].stdout.artifact"])
+	assert.Equal(t, "stderr/prod.log", resolved["steps[0].stderr.artifact"])
+	assert.Equal(t, "repo:prod", resolved["steps[0].stdout.outputs.fields.image.value"])
+	assert.Equal(t, "sha:prod", resolved["steps[0].output.digest.value"])
+	assert.Equal(t, "outputs/prod.txt", resolved["steps[0].output.report.path"])
+
+	assert.Equal(t, "review prod", resolved["steps[1].run[0].cmd_with_args"])
+	assert.Equal(t, "step:prod", resolved["steps[1].container.image"])
+	assert.Equal(t, "deploy prod", resolved["steps[2].with.message"])
+
+	assert.Equal(t, "child-prod", resolved["steps[3].child_dag.name"])
+	assert.Equal(t, `ENV="prod"`, resolved["steps[3].child_dag.params"])
+	assert.Equal(t, "prod", resolved["steps[4].parallel.items[0].value"])
+	assert.Equal(t, "prod", resolved["steps[4].parallel.items[1].params.target"])
+	assert.Equal(t, "fanout-prod", resolved["steps[4].child_dag.name"])
+	assert.Contains(t, resolved["steps[4].child_dag.params"], `env="prod"`)
+
+	assert.Equal(t, "system prod", resolved["steps[5].llm.system"])
+	assert.Equal(t, "https://fallback-prod.example/v1", resolved["steps[5].llm.base_url"])
+	assert.Equal(t, "https://prod.example/v1", resolved["steps[5].llm.model[0].base_url"])
+	assert.Equal(t, "hello prod", resolved["steps[5].messages[0].content"])
+
+	assert.Equal(t, "literal ${params.environment}", resolved["steps[6].run"])
+	assert.Equal(t, "resolved prod", resolved["steps[6].with.data.message"])
+
+	assertSpec003FieldAbsent(t, resolved, "name")
+	assertSpec003FieldAbsent(t, resolved, "description")
+	assertSpec003FieldAbsent(t, resolved, "steps[0].id")
+	assertSpec003FieldAbsent(t, resolved, "steps[0].outputs[0].name")
+	assertSpec003FieldAbsent(t, resolved, "steps[0].outputs[0].type")
+	assertSpec003FieldAbsent(t, resolved, "steps[5].llm.model[0].provider")
+	assertSpec003FieldAbsent(t, resolved, "steps[5].llm.model[0].name")
+	assertSpec003FieldAbsent(t, resolved, "steps[5].llm.model[0].api_key_name")
+	assertSpec003FieldAbsent(t, resolved, "steps[5].llm.tools[0]")
+}
+
+func TestSpec003ConformanceConstsResolveBeforeLiteralParamDefaults(t *testing.T) {
+	t.Parallel()
+
+	dag := loadSpec003DAG(t, `
+name: consts-and-defaults
+consts:
+  - region: us-east-1
+  - endpoint: https://${consts.region}.example
+params:
+  - name: target
+    default: ${consts.region}
+steps:
+  - id: show
+    run: echo ${consts.endpoint} ${params.target}
+`)
+
+	require.Equal(t, "https://us-east-1.example", dag.Consts["endpoint"])
+	require.Equal(t, "${consts.region}", dag.ParamValues()["target"])
+
+	resolved := resolveSpec003Fields(t, dag, dag.ParamValues())
+	assert.Equal(t, "echo https://us-east-1.example ${consts.region}", resolved["steps[0].run[0].cmd_with_args"])
+}
+
+func TestSpec003ConformanceInheritedRootLLMTextFields(t *testing.T) {
+	t.Parallel()
+
+	dag := loadSpec003DAG(t, `
+name: root-llm
+params:
+  - name: environment
+    default: prod
+llm:
+  model:
+    - provider: openai
+      name: gpt-4o
+      base_url: https://${params.environment}.example/v1
+  system: root system ${params.environment}
+  base_url: https://fallback-${params.environment}.example/v1
+steps:
+  - id: chat
+    action: chat.completion
+    with:
+      messages:
+        - role: user
+          content: hello ${params.environment}
+`)
+
+	resolved := resolveSpec003Fields(t, dag, cmnvalue.Values{"environment": "prod"})
+
+	assert.Equal(t, "root system prod", resolved["steps[0].llm.system"])
+	assert.Equal(t, "https://fallback-prod.example/v1", resolved["steps[0].llm.base_url"])
+	assert.Equal(t, "https://prod.example/v1", resolved["steps[0].llm.model[0].base_url"])
+	assert.Equal(t, "hello prod", resolved["steps[0].messages[0].content"])
+	assertSpec003FieldAbsent(t, resolved, "steps[0].llm.model[0].provider")
+	assertSpec003FieldAbsent(t, resolved, "steps[0].llm.model[0].name")
+}
+
+func TestSpec003ConformanceEscapedDaguReferencesUseBackslashParity(t *testing.T) {
+	t.Parallel()
+
+	resolver := cmnvalue.NewResolver(
+		cmnvalue.StaticScope{Params: cmnvalue.Values{"name": nil}},
+		cmnvalue.RuntimeScope{Params: cmnvalue.Values{"name": "prod"}},
+	)
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "odd single backslash escapes",
+			raw:  `\${params.name}`,
+			want: `${params.name}`,
+		},
+		{
+			name: "even backslashes do not escape",
+			raw:  `\\${params.name}`,
+			want: `\\prod`,
+		},
+		{
+			name: "odd run keeps preceding pairs",
+			raw:  `\\\${params.name}`,
+			want: `\\${params.name}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolver.String(context.Background(), tt.raw, cmnvalue.WorkflowField("test"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSpec003ConformanceStringInsertionIsOnePass(t *testing.T) {
+	t.Parallel()
+
+	resolver := cmnvalue.NewResolver(
+		cmnvalue.StaticScope{
+			Params: cmnvalue.Values{
+				"nested": nil,
+				"name":   nil,
+			},
+		},
+		cmnvalue.RuntimeScope{
+			Params: cmnvalue.Values{
+				"nested": "${params.name}",
+				"name":   "prod",
+			},
+		},
+	)
+
+	got, err := resolver.String(context.Background(), "${params.nested}", cmnvalue.WorkflowField("test"))
+	require.NoError(t, err)
+	assert.Equal(t, "${params.name}", got)
+}
+
+func loadSpec003DAG(t *testing.T, yaml string) *core.DAG {
+	t.Helper()
+
+	registerSpec003ExecutorCapabilities()
+
+	dag, err := spec.LoadYAML(
+		context.Background(),
+		[]byte(strings.TrimSpace(yaml)),
+		spec.WithoutEval(),
+	)
+	require.NoError(t, err)
+	return dag
+}
+
+var registerSpec003ExecutorCapabilitiesOnce sync.Once
+
+func registerSpec003ExecutorCapabilities() {
+	registerSpec003ExecutorCapabilitiesOnce.Do(func() {
+		for _, typ := range []string{"", "shell", "command"} {
+			core.RegisterExecutorCapabilities(typ, core.ExecutorCapabilities{
+				Command: true, MultipleCommands: true, Script: true, Shell: true,
+			})
+		}
+		for _, typ := range []string{"docker", "container"} {
+			core.RegisterExecutorCapabilities(typ, core.ExecutorCapabilities{
+				Command: true, MultipleCommands: true, Container: true,
+			})
+		}
+		for _, typ := range []string{"dag", "subworkflow", "parallel", core.ExecutorTypeDAGEnqueue} {
+			core.RegisterExecutorCapabilities(typ, core.ExecutorCapabilities{
+				SubDAG: true, WorkerSelector: true,
+			})
+		}
+		core.RegisterExecutorCapabilities("chat", core.ExecutorCapabilities{LLM: true})
+		core.RegisterExecutorCapabilities("harness", core.ExecutorCapabilities{
+			Command: true, Script: true, Container: true,
+		})
+		core.RegisterExecutorCapabilities("log", core.ExecutorCapabilities{})
+		core.RegisterExecutorCapabilities("template", core.ExecutorCapabilities{Script: true})
+	})
+}
+
+func resolveSpec003Fields(t *testing.T, dag *core.DAG, params cmnvalue.Values) map[string]string {
+	t.Helper()
+
+	resolver := cmnvalue.NewResolver(
+		cmnvalue.StaticScope{
+			Consts: cmnvalue.Values(dag.Consts),
+			Params: dag.ParamDeclarations(),
+		},
+		cmnvalue.RuntimeScope{
+			Consts: cmnvalue.Values(dag.Consts),
+			Params: params,
+			Env:    cmnvalue.NewEnvScope(nil, false),
+		},
+	)
+
+	resolved := make(map[string]string)
+	for _, field := range core.ReferenceFields(dag) {
+		got, err := resolver.String(context.Background(), field.Value, field.Field)
+		require.NoError(t, err, "field %s", field.Path)
+		resolved[field.Path] = got
+	}
+	return resolved
+}
+
+func assertSpec003FieldAbsent(t *testing.T, resolved map[string]string, path string) {
+	t.Helper()
+
+	_, ok := resolved[path]
+	require.False(t, ok, "field %s must not opt into Spec 003 value resolution", path)
+}

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -866,7 +866,11 @@ func buildStepShellArgs(ctx StepBuildContext, s *step) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(result.Args, s.ShellArgs...), nil
+	if s.ShellArgs != nil {
+		args := append([]string{}, result.Args...)
+		return append(args, s.ShellArgs...), nil
+	}
+	return result.Args, nil
 }
 
 func buildStepTimeout(_ StepBuildContext, s *step) (time.Duration, error) {

--- a/internal/core/value_fields.go
+++ b/internal/core/value_fields.go
@@ -176,8 +176,8 @@ func (w *referenceFieldWalker) walkRetryPolicy(path string, policy RetryPolicy, 
 
 func (w *referenceFieldWalker) walkRepeatPolicy(path string, policy RepeatPolicy, base ReferenceField) {
 	w.add(base.withPathValue(path+".limit", policy.LimitStr).withField(cmnvalue.RepeatIntegerField(path + ".limit")))
-	w.add(base.withPathValue(path+".interval", policy.IntervalStr).withField(cmnvalue.RepeatIntegerField(path + ".interval")))
-	w.add(base.withPathValue(path+".max_interval", policy.MaxIntervalStr).withField(cmnvalue.RepeatIntegerField(path + ".max_interval")))
+	w.add(base.withPathValue(path+".interval_sec", policy.IntervalStr).withField(cmnvalue.RepeatIntegerField(path + ".interval_sec")))
+	w.add(base.withPathValue(path+".max_interval_sec", policy.MaxIntervalStr).withField(cmnvalue.RepeatIntegerField(path + ".max_interval_sec")))
 }
 
 func (w *referenceFieldWalker) walkSubDAG(path string, subDAG *SubDAG, base ReferenceField) {
@@ -192,21 +192,11 @@ func (w *referenceFieldWalker) walkLLM(path string, llm *LLMConfig, base Referen
 	if llm == nil {
 		return
 	}
-	w.add(base.withPathValue(path+".provider", llm.Provider).withField(cmnvalue.ExecutorConfigField(path + ".provider")))
-	w.add(base.withPathValue(path+".model", llm.Model).withField(cmnvalue.ExecutorConfigField(path + ".model")))
 	w.add(base.withPathValue(path+".system", llm.System).withField(cmnvalue.WorkflowField(path + ".system")))
 	w.add(base.withPathValue(path+".base_url", llm.BaseURL).withField(cmnvalue.ExecutorConfigField(path + ".base_url")))
-	w.add(base.withPathValue(path+".api_key_name", llm.APIKeyName).withField(cmnvalue.ExecutorConfigField(path + ".api_key_name")))
 	for i, model := range llm.Models {
-		modelPath := fmt.Sprintf("%s.models[%d]", path, i)
-		w.add(base.withPathValue(modelPath+".provider", model.Provider).withField(cmnvalue.ExecutorConfigField(modelPath + ".provider")))
-		w.add(base.withPathValue(modelPath+".name", model.Name).withField(cmnvalue.ExecutorConfigField(modelPath + ".name")))
+		modelPath := fmt.Sprintf("%s.model[%d]", path, i)
 		w.add(base.withPathValue(modelPath+".base_url", model.BaseURL).withField(cmnvalue.ExecutorConfigField(modelPath + ".base_url")))
-		w.add(base.withPathValue(modelPath+".api_key_name", model.APIKeyName).withField(cmnvalue.ExecutorConfigField(modelPath + ".api_key_name")))
-	}
-	for i, tool := range llm.Tools {
-		fieldPath := fmt.Sprintf("%s.tools[%d]", path, i)
-		w.add(base.withPathValue(fieldPath, tool).withField(cmnvalue.ExecutorConfigField(fieldPath)))
 	}
 }
 
@@ -257,8 +247,6 @@ func (w *referenceFieldWalker) walkStdoutOutputs(path string, outputs *StepOutpu
 			fieldPath := path + ".fields." + key + ".value"
 			w.walkStringLeaves(fieldPath, entry.Value, base.withField(cmnvalue.StructuredOutputLiteralField(fieldPath)))
 		}
-		fieldPath := path + ".fields." + key + ".path"
-		w.add(base.withPathValue(fieldPath, entry.Path).withField(cmnvalue.StructuredOutputPathField(fieldPath)))
 	}
 }
 

--- a/internal/core/value_fields_test.go
+++ b/internal/core/value_fields_test.go
@@ -170,8 +170,8 @@ func TestReferenceFieldsEmitsValidationPathSet(t *testing.T) {
 		"steps[0].retry_policy.limit",
 		"steps[0].retry_policy.interval_sec",
 		"steps[0].repeat_policy.limit",
-		"steps[0].repeat_policy.interval",
-		"steps[0].repeat_policy.max_interval",
+		"steps[0].repeat_policy.interval_sec",
+		"steps[0].repeat_policy.max_interval_sec",
 		"steps[0].repeat_policy.condition",
 		"steps[0].child_dag.name",
 		"steps[0].child_dag.params",
@@ -183,24 +183,24 @@ func TestReferenceFieldsEmitsValidationPathSet(t *testing.T) {
 		"steps[0].stderr",
 		"steps[0].stderr.artifact",
 		"steps[0].stdout.outputs.fields.image.value.tag",
-		"steps[0].stdout.outputs.fields.image.path",
 		"steps[0].output.digest.value[0]",
 		"steps[0].output.digest.path",
 		"steps[0].container.image",
 		"steps[0].container.working_dir",
-		"steps[0].llm.provider",
-		"steps[0].llm.model",
 		"steps[0].llm.system",
 		"steps[0].llm.base_url",
-		"steps[0].llm.api_key_name",
-		"steps[0].llm.models[0].provider",
-		"steps[0].llm.models[0].name",
-		"steps[0].llm.models[0].base_url",
-		"steps[0].llm.models[0].api_key_name",
-		"steps[0].llm.tools[0]",
+		"steps[0].llm.model[0].base_url",
 		"steps[0].messages[0].content",
 		"handler_on.init.run",
 	}, got)
 	assert.NotContains(t, got, "steps[0].stdout.outputs.fields.image.select")
+	assert.NotContains(t, got, "steps[0].stdout.outputs.fields.image.path")
 	assert.NotContains(t, got, "steps[0].output.digest.select")
+	assert.NotContains(t, got, "steps[0].llm.provider")
+	assert.NotContains(t, got, "steps[0].llm.model")
+	assert.NotContains(t, got, "steps[0].llm.api_key_name")
+	assert.NotContains(t, got, "steps[0].llm.model[0].provider")
+	assert.NotContains(t, got, "steps[0].llm.model[0].name")
+	assert.NotContains(t, got, "steps[0].llm.model[0].api_key_name")
+	assert.NotContains(t, got, "steps[0].llm.tools[0]")
 }

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -404,5 +404,6 @@ func commandContextShell(ctx context.Context, step core.Step) []string {
 	if shellCmd == "" {
 		return nil
 	}
-	return []string{shellCmd}
+	shell := []string{shellCmd}
+	return append(shell, step.ShellArgs...)
 }

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -371,6 +371,22 @@ func (e Env) ResolveShell(ctx context.Context) ([]string, error) {
 		return shell, nil
 	}
 
+	if len(e.Step.ShellArgs) > 0 {
+		if e.DAG != nil && e.DAG.Shell != "" {
+			shell, err := evalShellInvocationWithScope(ctx, e.DAG, e.Scope, e.DAG.Shell, e.Step.ShellArgs, cmnvalue.DAGShellField, cmnvalue.StepShellField)
+			if err != nil {
+				return nil, fmt.Errorf("failed to evaluate inherited DAG shell with step shell args: %w", err)
+			}
+			return shell, nil
+		}
+
+		shell, err := evalShellArgsWithScope(ctx, e.DAG, e.Scope, defaultShell(ctx), e.Step.ShellArgs, cmnvalue.StepShellField)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate step shell arguments: %w", err)
+		}
+		return shell, nil
+	}
+
 	if e.DAG != nil && e.DAG.Shell != "" {
 		shell, err := evalShellWithScope(ctx, e.DAG, e.Scope, e.DAG.Shell, e.DAG.ShellArgs, cmnvalue.DAGShellField)
 		if err != nil {
@@ -417,6 +433,10 @@ func ResolveDAGShell(ctx context.Context) ([]string, error) {
 
 // evalShellWithScope evaluates shell command and arguments using the given scope.
 func evalShellWithScope(ctx context.Context, dag *core.DAG, scope *cmnvalue.EnvScope, shell string, shellArgs []string, fieldForPath func(string) cmnvalue.Field) ([]string, error) {
+	return evalShellInvocationWithScope(ctx, dag, scope, shell, shellArgs, fieldForPath, fieldForPath)
+}
+
+func evalShellInvocationWithScope(ctx context.Context, dag *core.DAG, scope *cmnvalue.EnvScope, shell string, shellArgs []string, shellFieldForPath func(string) cmnvalue.Field, argFieldForPath func(string) cmnvalue.Field) ([]string, error) {
 	var consts cmnvalue.Values
 	var params cmnvalue.Values
 	var paramDeclarations cmnvalue.Values
@@ -429,12 +449,35 @@ func evalShellWithScope(ctx context.Context, dag *core.DAG, scope *cmnvalue.EnvS
 		cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations},
 		cmnvalue.RuntimeScope{Consts: consts, Params: params, Env: scope},
 	)
-	shellCmd, err := resolver.String(ctx, shell, fieldForPath("shell"))
+	shellCmd, err := resolver.String(ctx, shell, shellFieldForPath("shell"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate shell: %w", err)
 	}
 
-	result := []string{shellCmd}
+	return evalShellArgsWithResolver(ctx, []string{shellCmd}, shellArgs, argFieldForPath, resolver)
+}
+
+func evalShellArgsWithScope(ctx context.Context, dag *core.DAG, scope *cmnvalue.EnvScope, shell []string, shellArgs []string, fieldForPath func(string) cmnvalue.Field) ([]string, error) {
+	var consts cmnvalue.Values
+	var params cmnvalue.Values
+	var paramDeclarations cmnvalue.Values
+	if dag != nil {
+		consts = cmnvalue.Values(dag.Consts)
+		params = dag.ParamValues()
+		paramDeclarations = dag.ParamDeclarations()
+	}
+	resolver := cmnvalue.NewResolver(
+		cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations},
+		cmnvalue.RuntimeScope{Consts: consts, Params: params, Env: scope},
+	)
+	return evalShellArgsWithResolver(ctx, shell, shellArgs, fieldForPath, resolver)
+}
+
+func evalShellArgsWithResolver(ctx context.Context, shell []string, shellArgs []string, fieldForPath func(string) cmnvalue.Field, resolver cmnvalue.Resolver) ([]string, error) {
+	result := append([]string(nil), shell...)
+	if len(result) == 0 {
+		return result, nil
+	}
 	for i, arg := range shellArgs {
 		evaluated, err := resolver.String(ctx, arg, fieldForPath(fmt.Sprintf("shell_args[%d]", i)))
 		if err != nil {

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -371,7 +371,7 @@ func (e Env) ResolveShell(ctx context.Context) ([]string, error) {
 		return shell, nil
 	}
 
-	if len(e.Step.ShellArgs) > 0 {
+	if e.Step.ShellArgs != nil {
 		if e.DAG != nil && e.DAG.Shell != "" {
 			shell, err := evalShellInvocationWithScope(ctx, e.DAG, e.Scope, e.DAG.Shell, e.Step.ShellArgs, cmnvalue.DAGShellField, cmnvalue.StepShellField)
 			if err != nil {

--- a/internal/runtime/env_test.go
+++ b/internal/runtime/env_test.go
@@ -154,6 +154,40 @@ func TestEnvShell(t *testing.T) {
 		assert.Equal(t, []string{"/bin/zsh", "-e"}, result)
 	})
 
+	t.Run("StepShellArgsOverrideInheritedDAGShellArgs", func(t *testing.T) {
+		t.Parallel()
+		dag := &core.DAG{
+			Shell:     "/bin/bash",
+			ShellArgs: []string{"-c"},
+		}
+		ctx := runtime.NewContext(context.Background(), dag, "test-run", "test.log")
+		step := core.Step{
+			Name:      "test-step",
+			ShellArgs: []string{"-e", "-c"},
+		}
+		env := runtime.NewEnv(ctx, step)
+		result := env.Shell(ctx)
+		assert.Equal(t, []string{"/bin/bash", "-e", "-c"}, result)
+	})
+
+	t.Run("StepShellArgsExtendDefaultShell", func(t *testing.T) {
+		t.Parallel()
+		ctx := config.WithConfig(context.Background(), &config.Config{
+			Core: config.Core{
+				DefaultShell: "/bin/custom",
+			},
+		})
+		dag := &core.DAG{}
+		ctx = runtime.NewContext(ctx, dag, "test-run", "test.log")
+		step := core.Step{
+			Name:      "test-step",
+			ShellArgs: []string{"-e", "-c"},
+		}
+		env := runtime.NewEnv(ctx, step)
+		result := env.Shell(ctx)
+		assert.Equal(t, []string{"/bin/custom", "-e", "-c"}, result)
+	})
+
 	t.Run("FallsBackToDAGShell", func(t *testing.T) {
 		t.Parallel()
 		dag := &core.DAG{
@@ -246,6 +280,29 @@ func TestEnvResolveShellResolvesParams(t *testing.T) {
 	got, err := env.ResolveShell(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh", "-c"}, got)
+}
+
+func TestEnvResolveShellResolvesStepShellArgsWithInheritedDAGShell(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Shell:     "/bin/sh",
+		ShellArgs: []string{"-c"},
+		ParamDefs: []core.ParamDef{{
+			Name: "shell_arg",
+			Type: core.ParamDefTypeString,
+		}},
+		Params: []string{"shell_arg=-ec"},
+	}
+	ctx := runtime.NewContext(context.Background(), dag, "test-run", "test.log")
+	env := runtime.NewEnv(ctx, core.Step{
+		Name:      "test-step",
+		ShellArgs: []string{"${params.shell_arg}"},
+	})
+
+	got, err := env.ResolveShell(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/bin/sh", "-ec"}, got)
 }
 
 func TestEnvResolveShellPreservesMissingParam(t *testing.T) {

--- a/internal/runtime/env_test.go
+++ b/internal/runtime/env_test.go
@@ -14,6 +14,7 @@ import (
 	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,6 +171,22 @@ func TestEnvShell(t *testing.T) {
 		assert.Equal(t, []string{"/bin/bash", "-e", "-c"}, result)
 	})
 
+	t.Run("StepShellArgsEmptyClearsInheritedDAGShellArgs", func(t *testing.T) {
+		t.Parallel()
+		dag := &core.DAG{
+			Shell:     "/bin/bash",
+			ShellArgs: []string{"-e", "-c"},
+		}
+		ctx := runtime.NewContext(context.Background(), dag, "test-run", "test.log")
+		step := core.Step{
+			Name:      "test-step",
+			ShellArgs: []string{},
+		}
+		env := runtime.NewEnv(ctx, step)
+		result := env.Shell(ctx)
+		assert.Equal(t, []string{"/bin/bash"}, result)
+	})
+
 	t.Run("StepShellArgsExtendDefaultShell", func(t *testing.T) {
 		t.Parallel()
 		ctx := config.WithConfig(context.Background(), &config.Config{
@@ -303,6 +320,31 @@ func TestEnvResolveShellResolvesStepShellArgsWithInheritedDAGShell(t *testing.T)
 	got, err := env.ResolveShell(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh", "-ec"}, got)
+}
+
+func TestEnvResolveShellClearsDAGShellArgsFromYAML(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+shell: /bin/bash
+shell_args:
+  - -e
+  - -c
+steps:
+  - name: test-step
+    run: echo ok
+    with:
+      shell_args: []
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	ctx := runtime.NewContext(context.Background(), dag, "test-run", "test.log")
+	env := runtime.NewEnv(ctx, dag.Steps[0])
+
+	got, err := env.ResolveShell(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/bin/bash"}, got)
 }
 
 func TestEnvResolveShellPreservesMissingParam(t *testing.T) {

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,7 @@ Load only the reference file that matches the task.
 - Remote action manifests do not support `tools`. Declare external CLI tools in the action DAG itself so local and distributed workers prepare the right binaries for that action run.
 - In remote action examples, prefer `dag: workflow.yaml` for the action DAG filename. The `dag` field accepts any safe relative file path, but `workflow.yaml` avoids confusing the executable DAG with the `dagu-action.yaml` manifest.
 - Object-form `output:` with `decode: json` or `decode: yaml` can act as lightweight runtime validation. Malformed data or an unresolved `select:` path fails the step, so normal `retry_policy` applies.
+- Use DAG-level `shell` and `shell_args` only when every inherited `run:` step should use the same shell invocation. Use step-level `with.shell` and `with.shell_args` for a single step.
 - Use `dagu schema dag` to check the full list of available fields and their shapes.
 - Use `dagu example` to see different DAG patterns and how to express them in YAML.
 
@@ -203,6 +204,7 @@ Fields:
 
 Notes:
 
+- DAG-level `shell` and `shell_args` provide defaults for inherited `run` steps. Use `with.shell` and `with.shell_args` when one step needs a different shell invocation.
 - Dagu expands `${VAR}` before the shell runs. For large or arbitrary text, prefer `printenv VAR_NAME`, reading `${step_id.stdout}` as a file, or `action: template.render`.
 - When large command output should become an artifact, write it to stdout/stderr and attach the stream directly instead of redirecting inside shell:
 

--- a/skills/dagu/SKILL.md
+++ b/skills/dagu/SKILL.md
@@ -46,6 +46,7 @@ Load only the reference file that matches the task.
 - Remote action manifests do not support `tools`. Declare external CLI tools in the action DAG itself so local and distributed workers prepare the right binaries for that action run.
 - In remote action examples, prefer `dag: workflow.yaml` for the action DAG filename. The `dag` field accepts any safe relative file path, but `workflow.yaml` avoids confusing the executable DAG with the `dagu-action.yaml` manifest.
 - Object-form `output:` with `decode: json` or `decode: yaml` can act as lightweight runtime validation. Malformed data or an unresolved `select:` path fails the step, so normal `retry_policy` applies.
+- Use DAG-level `shell` and `shell_args` only when every inherited `run:` step should use the same shell invocation. Use step-level `with.shell` and `with.shell_args` for a single step.
 - Use `dagu schema dag` to check the full list of available fields and their shapes.
 - Use `dagu example` to see different DAG patterns and how to express them in YAML.
 

--- a/skills/dagu/references/steptypes.md
+++ b/skills/dagu/references/steptypes.md
@@ -31,6 +31,7 @@ Fields:
 
 Notes:
 
+- DAG-level `shell` and `shell_args` provide defaults for inherited `run` steps. Use `with.shell` and `with.shell_args` when one step needs a different shell invocation.
 - Dagu expands `${VAR}` before the shell runs. For large or arbitrary text, prefer `printenv VAR_NAME`, reading `${step_id.stdout}` as a file, or `action: template.render`.
 - When large command output should become an artifact, write it to stdout/stderr and attach the stream directly instead of redirecting inside shell:
 

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -87,6 +87,11 @@ Dagu uses three evaluation types.
 | Value-resolved | Dagu resolves Dagu-owned references such as `${params.name}`. It does not run dynamic evaluation. |
 | Dynamic-evaluated | Dagu runs the dynamic evaluation pipeline. In this spec, only `params[].eval` uses this type. |
 
+Unqualified environment expansion is a separate field-level ownership decision.
+A value-resolved field always resolves Dagu-owned references listed in this spec.
+That same field expands `$NAME`, `${NAME}`, or shell-style `${NAME...}` expressions only when Spec 006 says Dagu owns unqualified environment expansion for that field.
+When Spec 006 says a later runtime owns unqualified environment syntax, Dagu preserves that syntax after resolving Dagu-owned references.
+
 ### Reference Syntax
 
 - Dagu-owned references are only the unescaped supported reference forms listed below.
@@ -126,11 +131,19 @@ ${steps.step_id.outputs.name}
 
 ### Escaped Dagu References
 
-- A backslash immediately before `$` disables Dagu field evaluation for that dollar token.
+- A run of backslashes immediately before `$` controls whether that dollar token is escaped for Dagu field evaluation.
 
+- If the run length is odd, the last backslash in the run is the Dagu escape marker.
 - Dagu removes that escape marker before the owning field consumes the value.
+- The dollar token is protected from Dagu field evaluation.
 
-- The escape protects the dollar token through supported-reference detection, namespace validation, passive-notice collection, environment expansion, and command-substitution handling.
+- If the run length is even, the dollar token is not escaped for Dagu field evaluation.
+- Dagu removes no backslash from an even-length run.
+
+- The escape protects the dollar token through Dagu-owned supported-reference detection, namespace validation, passive-notice collection, and command-substitution handling.
+
+- Unqualified environment expansion has field-specific ownership rules in Spec 006.
+- For unqualified `$NAME` and `${NAME}` syntax, this section does not by itself require every field to treat a preceding backslash as an environment-expansion escape marker.
 
 - Escaped Dagu-looking text must not be resolved.
 
@@ -141,7 +154,6 @@ Examples:
 ```text
 \${params.name}
 \${steps.build.outputs.image}
-\$HOME
 ```
 
 The owning field receives these literal dollar forms:
@@ -149,15 +161,28 @@ The owning field receives these literal dollar forms:
 ```text
 ${params.name}
 ${steps.build.outputs.image}
-$HOME
 ```
+
+Fields whose Spec 006 ownership rule treats backslash as an unqualified environment escape may also use that field-specific escape for `$NAME` and `${NAME}`.
 
 YAML parsing happens before Dagu value resolution.
 In a YAML double-quoted scalar, an author writes `\\${params.name}` for Dagu to receive `\${params.name}`.
 In plain scalars, single-quoted scalars, and block scalars, `\${params.name}` reaches Dagu as written.
 
+Assuming `${params.name}` resolves to `prod` in a value-resolved field:
+
+| Text received by Dagu | Owning field receives |
+| --- | --- |
+| `\${params.name}` | `${params.name}` |
+| `\\${params.name}` | `\\prod` |
+| `\\\${params.name}` | `\\${params.name}` |
+
 Unsupported braced text such as `${step.xxx.foo}` is already ordinary string content.
 Escaping unsupported braced text is allowed but not required to avoid Dagu interpretation.
+
+For shell-backed fields, Dagu escaping does not quote or escape for the shell.
+After Dagu removes its escape marker, the selected shell or script interpreter may still interpret dollar syntax.
+To pass a literal dollar form through a shell-backed field, the authored text must also protect it according to that shell or script language.
 
 ### Single-Quoted Environment References
 
@@ -179,18 +204,36 @@ Dagu-owned references are supported only in value-resolved fields and dynamic-ev
 | `preconditions[].condition` | Value-resolved | Before checking the precondition | Root precondition condition strings resolve Dagu-owned references. |
 | `container` | Value-resolved | Before root container settings are used | Root container string form resolves Dagu-owned references. In object form, `exec`, `image`, `name`, `user`, `working_dir`, `network`, `volumes[]`, `ports[]`, `env` values, `command[]`, and `shell[]` resolve Dagu-owned references. |
 | `steps[].run` | Value-resolved | Step start | The string `run` value and each array-form `run` entry resolve Dagu-owned references. Dagu leaves shell syntax for the selected shell or script interpreter. |
-| `steps[].with` | Value-resolved | Step start | Every nested string value under the step `with` object resolves Dagu-owned references. This includes action inputs and run-step shell settings. |
+| `steps[].with` | Value-resolved | Step start | Nested string values under the step `with` object resolve Dagu-owned references unless a more specific row or owning action or executor spec defines another evaluation mode. This includes action inputs and run-step shell settings. |
 | `steps[].working_dir` | Value-resolved | Step start | Step working directory resolves Dagu-owned references. |
 | `steps[].env` | Value-resolved | Step start | Step environment values in map form, array-of-map form, or `KEY=value` list form resolve Dagu-owned references. |
 | `steps[].preconditions[].condition` | Value-resolved | Before checking the step precondition | Step precondition condition strings resolve Dagu-owned references. |
+| `steps[].retry_policy.limit` and `steps[].retry_policy.interval_sec` string forms | Value-resolved | Before the retry policy uses the value | Step retry policy string numeric fields resolve Dagu-owned references. Other retry policy fields remain literal unless an owning spec opts in. |
 | `steps[].repeat_policy.condition` | Value-resolved | Before checking the repeat policy | Repeat condition strings resolve Dagu-owned references. |
+| `steps[].repeat_policy.limit`, `steps[].repeat_policy.interval_sec`, and `steps[].repeat_policy.max_interval_sec` string forms | Value-resolved | Before the repeat policy uses the value | Step repeat policy string numeric fields resolve Dagu-owned references. Other repeat policy fields remain literal unless an owning spec opts in. |
+| Sub-DAG invocation target and params | Value-resolved | Before the sub-DAG run or enqueue request is created | Canonical `dag.run` and `dag.enqueue` `with.dag` resolves Dagu-owned references. Scalar string `with.params` resolves as one value. Nested string leaves under object-form or array-form `with.params` resolve individually. Accepted legacy `call` and legacy `params` follow the same target and params rules. |
 | `steps[].parallel` | Value-resolved | Before expanding the parallel step | `variable`, `items[]`, `items[].value`, and `items[].params.*` string values resolve Dagu-owned references. |
-| `steps[].stdout`, `steps[].stdout.artifact` | Value-resolved | Step start or stdout setup | Stdout file path strings and artifact path strings resolve Dagu-owned references. |
-| `steps[].stderr`, `steps[].stderr.artifact` | Value-resolved | Step start or stderr setup | Stderr file path strings and artifact path strings resolve Dagu-owned references. |
-| `steps[].stdout.outputs.fields.*` | Value-resolved | Output publication | Literal string values under field entries resolve Dagu-owned references. |
+| `steps[].stdout`, `steps[].stdout.artifact` | Value-resolved | Step start or stdout setup | Stdout file path strings and artifact path strings resolve Dagu-owned references. For unqualified environment syntax in these path strings, backslashes remain path text unless Spec 006 assigns them escape behavior. |
+| `steps[].stderr`, `steps[].stderr.artifact` | Value-resolved | Step start or stderr setup | Stderr file path strings and artifact path strings resolve Dagu-owned references. For unqualified environment syntax in these path strings, backslashes remain path text unless Spec 006 assigns them escape behavior. |
+| `steps[].stdout.outputs.fields.*` | Value-resolved | Output publication | Literal string values under field entries resolve Dagu-owned references. Selection and decode metadata remain literal unless an owning spec opts in. |
 | `steps[].output.*` | Value-resolved | Output publication | Literal string values and `path` strings under structured step `output` entries resolve Dagu-owned references. |
 | `steps[].container` | Value-resolved | Step start | Step container string form resolves Dagu-owned references. In object form, `exec`, `image`, `name`, `user`, `working_dir`, `network`, `volumes[]`, `ports[]`, `env` values, `command[]`, and `shell[]` resolve Dagu-owned references. |
-| `secrets[].key` and `secrets[].options` | Literal | Secret resolution | Provider inputs are literal strings. |
+| `steps[].messages[].content` | Value-resolved | Step start | Message content strings resolve Dagu-owned references. |
+| LLM prompt and endpoint text fields | Value-resolved | Step start | For LLM-capable steps, `steps[].llm.system`, `steps[].llm.base_url`, and array-form `steps[].llm.model[].base_url` resolve Dagu-owned references. When a step inherits root LLM settings, inherited `llm.system`, `llm.base_url`, and array-form `llm.model[].base_url` follow the same rule. |
+| `secrets[]` | Literal | Secret resolution | Secret names, provider names, provider keys, and provider options are literal strings. |
+
+Explicitly literal or excluded field surfaces:
+
+| YAML field or surface | Rule |
+| --- | --- |
+| Root identity and metadata, such as `name` and `description` | Dagu does not resolve value references in these fields. |
+| Root run-control fields, such as `retry_policy`, `timeout_sec`, `delay_sec`, `max_active_steps`, `max_clean_up_time_sec`, and `max_output_size` | Dagu does not resolve value references in these fields unless an owning spec later opts in. |
+| Step identity, graph, and action-selection fields, such as `steps[].id`, `steps[].name`, `steps[].description`, `steps[].depends`, and `steps[].action` | Dagu does not resolve value references in these fields. A value reference cannot select a step, dependency, or action. |
+| Step output declaration contracts, such as `steps[].outputs[].name` and `steps[].outputs[].type` | Dagu does not resolve value references in declaration metadata. Published output values are separate runtime data. |
+| Step control fields not listed in the value-resolution matrix, such as `steps[].timeout_sec`, `steps[].continue_on`, `steps[].worker_selector`, `steps[].mail_on_error`, and `steps[].signal_on_stop` | Dagu does not resolve value references in these fields unless an owning spec later opts in. |
+| LLM selection and credential fields, such as provider names, model names, API key names, and tool-name lists | This spec does not opt these fields into value resolution. They remain literal unless an LLM-owning spec explicitly opts in. |
+| Template body fields owned by a template action or executor | Dagu does not resolve value references in template body text unless the template-owning spec explicitly opts in. Template data fields that are otherwise covered by `steps[].with` keep the `steps[].with` behavior. |
+| Root executor, provider, and tool configuration fields not listed in the value-resolution matrix, such as `ssh`, `kubernetes`, and `tools` | This spec does not opt these fields into value resolution. They remain literal unless an owning executor, provider, or tool spec explicitly opts in. |
 
 - The `steps[]` rows also apply to handler steps.
 - Handler step surfaces are `handler_on.init`, `handler_on.success`, `handler_on.failure`, `handler_on.abort`, `handler_on.exit`, and `handler_on.wait`.
@@ -203,6 +246,8 @@ Dagu-owned references are supported only in value-resolved fields and dynamic-ev
 - Dagu-owned environment references in `run` must use `${env.NAME}`.
 
 - Defaults, custom `step_types`, and custom `actions` are checked after Dagu expands them into concrete steps.
+
+- For parallel sub-DAG invocations, Dagu resolves parallel item values before resolving the child DAG target and params for that item.
 
 - All other canonical fields are outside this spec unless the field evaluation matrix is updated or an owning spec explicitly opts in.
 
@@ -233,12 +278,19 @@ The same rule applies to each array-form `run` entry.
 
 Rules:
 
+- Parameter declarations are processed in source order.
 - If the caller provides a parameter value, Dagu uses that value and does not evaluate `params[].eval`.
 - If the caller does not provide a value and `eval` exists, Dagu evaluates `eval`.
 - The evaluated value becomes `params.<name>` for the DAG run.
 - If `eval` fails and `default` exists, Dagu uses `default` exactly as written.
 - If `eval` fails and no `default` exists, the DAG run fails before any step starts.
 - This `default` fallback is the only dynamic-evaluation failure fallback in this spec.
+- Caller-provided parameter values are available to later `params[].eval` expressions.
+- A parameter value selected from an earlier declaration is available to later `params[].eval` expressions.
+- A `params[].eval` expression cannot resolve its own computed value.
+- A `params[].eval` expression cannot resolve a later computed or default value that has not been selected yet.
+- Dagu does not topologically sort parameter declarations and does not retry preserved parameter references after later declarations are processed.
+- If parameter declarations form a reference cycle, at least one reference in that cycle cannot resolve under the source-order rule and follows the unresolved-reference rules.
 
 ### Unresolved Supported References
 
@@ -295,6 +347,10 @@ If a typed field later consumes the preserved text, that field may still fail be
 
 ### String Insertion
 
+- Dagu performs one value-resolution pass for the field being evaluated.
+- Inserted values are data.
+- Dagu must not recursively scan an inserted value for more Dagu-owned references or dynamic evaluation syntax during the same field evaluation.
+
 - When Dagu inserts a referenced value into a string field, strings are inserted as written.
 
 - When Dagu inserts a referenced value into a string field, booleans are inserted as `true` or `false`.
@@ -304,8 +360,13 @@ If a typed field later consumes the preserved text, that field may still fail be
 - When Dagu inserts a referenced value into a string field, non-integer numbers use base-10 decimal text.
 - Non-integer decimal text must use the shortest round-trippable representation.
 
+- If a namespace can expose a non-scalar value, that namespace's owning spec must define the string insertion form for that value before it can be inserted by this spec.
+
 - Dagu does not shell-escape, JSON-escape, URL-escape, or otherwise quote inserted values.
 - The owning field and any later runtime interpret the resulting text.
+
+- In shell-backed fields, inserted whitespace, quotes, command separators, command substitutions, redirects, glob characters, and other shell-significant text remain part of the shell input.
+- Workflow authors must use the quoting, escaping, environment passing, files, or direct-argument execution surface appropriate for the later runtime when inserted data must be treated as data.
 
 ### Evaluation Outputs
 
@@ -367,7 +428,7 @@ steps:
 Dagu passes `${steps.build.outputs.image}` to the later PHP interpreter as code text.
 The PHP single-quoted string then treats it as literal text.
 
-Step output references wait for the producing step:
+Step output references require an authored dependency and wait for the producing step:
 
 ```yaml
 steps:
@@ -383,6 +444,9 @@ steps:
       IMAGE: ${steps.build.outputs.image}
     run: ./deploy.sh "$IMAGE"
 ```
+
+Dagu does not create the `depends: build` relationship from the value reference.
+Without that dependency, the reference is preserved and inspection surfaces report a passive notice.
 
 Parameter value from dynamic evaluation:
 

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -2,11 +2,7 @@
 
 ## Status
 
-Partially implemented.
-
-This spec includes target conformance behavior.
-Current product behavior covers only rows whose owning namespace or field spec is implemented.
-Rows owned by a spec marked `Not implemented` in the spec index are target behavior until that owning spec is implemented.
+Implemented.
 
 ## Scope
 

--- a/specs/006-value-resolution-env.md
+++ b/specs/006-value-resolution-env.md
@@ -353,7 +353,7 @@ environment references.
 | Container executor configuration strings | Dagu expands values from the DAG or step environment scope. Unresolved unqualified references remain literal local configuration text. | Not allowed. |
 | General `steps[].with` nested strings for action and executor inputs | Dagu expands against the step environment scope unless a more specific row or owning action spec applies. | Not allowed. |
 | Root `container` object strings and `steps[].container` object strings other than `env` | Dagu expands against the owning root or step environment scope. | Not allowed. |
-| `steps[].stdout`, `steps[].stderr`, artifact paths, `steps[].stdout.outputs.fields.*`, and `steps[].output.*` literal or path strings | Dagu expands against the step environment scope when the owning output surface is evaluated. | Not allowed. |
+| `steps[].stdout`, `steps[].stderr`, artifact paths, `steps[].stdout.outputs.fields.*` literal strings, and `steps[].output.*` literal or path strings | Dagu expands against the step environment scope when the owning output surface is evaluated. | Not allowed. |
 | `steps[].parallel` strings, sub-DAG names, sub-DAG params, handler step fields, and nested value-resolved workflow strings not listed above | Dagu expands against the current environment scope when the owning field is evaluated. | Not allowed. |
 | Template script text or fields owned by a template executor | Dagu does not expand unqualified environment syntax unless the owning template spec explicitly opts in. | Not applicable. |
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@ It must not be treated as product behavior until implementation catches up.
 | --- | --- |
 | [001: Project](001-project.md) | Not implemented |
 | [002: YAML Schema](002-yaml-schema.md) | Implemented |
-| [003: Value Resolution and Field Evaluation](003-value-resolution.md) | Partially implemented |
+| [003: Value Resolution and Field Evaluation](003-value-resolution.md) | Implemented |
 | [004: Value Resolution Consts](004-value-resolution-consts.md) | Implemented |
 | [005: Value Resolution Params](005-value-resolution-params.md) | Implemented |
 | [006: Value Resolution Env](006-value-resolution-env.md) | Implemented |


### PR DESCRIPTION
## Summary
- add Spec 003 conformance tests for value-resolution field surfaces, escaping, one-pass insertion, const/default behavior, and root LLM inheritance
- align root shell_args schema/loading and reference traversal with the Spec 003 matrix
- update bundled Dagu skill references, generated llms.txt, and schema overview docs

## Testing
- jq empty internal/cmn/schema/dag.schema.json
- go test ./internal/cmn/schema ./internal/core ./internal/core/spec ./internal/tools/llmsgen -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Spec 003 value-resolution conformance tests and completes implementation per the spec. Introduces DAG-level `shell_args` and fully fixes step `with.shell_args` to override or clear inherited args, with shell args applied at runtime.

- **Refactors**
  - Aligned reference traversal to Spec 003: use `repeat_policy.interval_sec` and `repeat_policy.max_interval_sec`; limit LLM resolution to `llm.system`, `llm.base_url`, and `llm.model[].base_url`; drop `stdout.outputs.fields.*.path`.
  - Clarified and finalized docs: backslash-escape parity, one-pass insertion, explicit literal/excluded surfaces, sub-DAG/parallel ordering, and env-expansion ownership (Spec 006). Updated `README_SCHEMA.md`, `llms.txt`, Dagu skill refs, and marked Spec 003 as Implemented.

- **Bug Fixes**
  - Honor step `with.shell_args`: evaluate and use them with the inherited DAG shell (or default). Explicit empty `with.shell_args: []` now clears DAG-level `shell_args`. Command execution now passes step shell args to the shell. Added runtime/tests to ensure correct param/env resolution and invocation order.

<sup>Written for commit 66a3c50edc1cf04a71a01b821f3099a85ec6119f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DAG-level `shell_args` defaults for inherited `run` steps; step-level `with.shell_args` can override, clear, or extend the default shell arguments.
  * Shell command/script execution now incorporates step shell arguments into the command/script context.

* **Documentation**
  * Updated guidance across docs and skills on when to use DAG-level vs step-level `shell`/`shell_args`.

* **Bug Fixes / Behavior Updates**
  * Updated reference-field emission for repeat policy timing, LLM fields, and structured stdout value surfaces.

* **Tests**
  * Added Spec 003 conformance tests for value resolution and expanded shell-argument resolution coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->