### PR TITLE
fix: stretch artifact previews in detail panes

### DIFF
--- a/ui/src/features/dag-runs/components/dag-run-details/DAGRunDetailsPanel.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-details/DAGRunDetailsPanel.tsx
@@ -203,12 +203,13 @@ function DAGRunDetailsPanel({
           </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="min-h-0 flex-1 overflow-hidden">
           <DAGRunDetailsContent
             name={name}
             dagRun={dagRunDetails}
             refreshFn={refreshFn}
             dagRunId={dagRunId}
+            fillHeight
           />
         </div>
       </div>

--- a/ui/src/features/dag-runs/components/dag-run-details/__tests__/DAGRunDetailsPanel.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-details/__tests__/DAGRunDetailsPanel.test.tsx
@@ -14,8 +14,16 @@ vi.mock('../../../hooks/useBoundedDAGRunDetails', () => ({
 }));
 
 vi.mock('../DAGRunDetailsContent', () => ({
-  default: ({ dagRun }: { dagRun: { dagRunId: string } }) => (
-    <div>run {dagRun.dagRunId}</div>
+  default: ({
+    dagRun,
+    fillHeight,
+  }: {
+    dagRun: { dagRunId: string };
+    fillHeight?: boolean;
+  }) => (
+    <div data-fill-height={String(fillHeight)} data-testid="dag-run-content">
+      run {dagRun.dagRunId}
+    </div>
   ),
 }));
 
@@ -79,6 +87,10 @@ describe('DAGRunDetailsPanel', () => {
       })
     );
     expect(screen.getByText('run child-run')).toBeInTheDocument();
+    expect(screen.getByTestId('dag-run-content')).toHaveAttribute(
+      'data-fill-height',
+      'true'
+    );
   });
 
   it('enables the sub-dag details target when sub-dag params exist', () => {

--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { Tabs } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 import {
   AlertTriangle,
   Bell,
@@ -61,6 +62,7 @@ type DAGDetailsContentProps = {
   /** When true, automatically opens the start/enqueue modal on mount */
   autoOpenStartModal?: boolean;
   buildScopedUrl?: (path: string) => string;
+  fillHeight?: boolean;
 };
 
 type LogViewerState = {
@@ -90,6 +92,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
   forceEnqueue = false,
   autoOpenStartModal = false,
   buildScopedUrl,
+  fillHeight = false,
 }) => {
   const baseUrl = isModal ? '#' : `/dags/${fileName}`;
   const scopedUrl = React.useCallback(
@@ -142,7 +145,12 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
         onRunStarted,
       }}
     >
-      <div className="flex w-full min-w-0 flex-col">
+      <div
+        className={cn(
+          'flex w-full min-w-0 flex-col',
+          fillHeight && 'h-full min-h-0'
+        )}
+      >
         {/* Only render the header if skipHeader is not true */}
         {!skipHeader && (
           <DAGHeader
@@ -480,13 +488,14 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
             />
           </div>
         </div>
-        <div className="flex-1 flex flex-col min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col">
           {activeTab === 'status' && currentDAGRun ? (
             <>
               <DAGStatus
                 dagRun={currentDAGRun}
                 fileName={fileName || ''}
                 artifactEnabled={!!dag.artifacts?.enabled}
+                fillHeight={fillHeight}
               />
               <div className="h-6 flex-shrink-0" />
             </>

--- a/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsPanel.tsx
@@ -246,6 +246,11 @@ function DAGDetailsPanel({
     );
   }
 
+  const contentClassName =
+    activeTab === 'status'
+      ? 'min-h-0 flex-1 overflow-hidden pr-4'
+      : 'min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-4';
+
   return (
     <UnsavedChangesProvider>
       <RemoteNodeProvider remoteNode={remoteNode}>
@@ -288,7 +293,7 @@ function DAGDetailsPanel({
                 </div>
               </div>
 
-              <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0 pr-4">
+              <div className={contentClassName}>
                 <DAGDetailsContent
                   fileName={fileName}
                   filePath={data.filePath}
@@ -305,6 +310,7 @@ function DAGDetailsPanel({
                   localDags={data.localDags}
                   editorHints={data.editorHints}
                   onRunStarted={handleRunStarted}
+                  fillHeight
                 />
               </div>
             </div>

--- a/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsSidePanel.tsx
@@ -322,6 +322,12 @@ function DAGDetailsSidePanel({
     'fixed top-0 bottom-0 right-0 md:w-3/4 w-full h-screen bg-background border-l border-border z-50 overflow-y-auto transition-all duration-200 ease-out',
     isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
   );
+  const contentClassName = cn(
+    'min-h-0 flex-1 pr-4',
+    activeTab === 'status'
+      ? 'overflow-hidden'
+      : 'overflow-y-auto overflow-x-hidden'
+  );
 
   const panel = (
     <>
@@ -370,7 +376,7 @@ function DAGDetailsSidePanel({
                   </div>
                 </div>
 
-                <div className="flex-1 overflow-y-auto overflow-x-hidden pr-4">
+                <div className={contentClassName}>
                   {loadState.state === 'loading' && (
                     <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
                       <LoadingIndicator />
@@ -428,6 +434,7 @@ function DAGDetailsSidePanel({
                       onEnqueue={onEnqueue ? handleEnqueue : undefined}
                       forceEnqueue={forceEnqueue}
                       autoOpenStartModal={false}
+                      fillHeight
                     />
                   )}
                 </div>

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import DAGDetailsContent from '../DAGDetailsContent';
+
+vi.mock('../..', () => ({
+  DAGStatus: vi.fn(({ fillHeight }) => (
+    <div data-fill-height={String(fillHeight)} data-testid="dag-status" />
+  )),
+}));
+
+vi.mock('../', () => ({
+  DAGHeader: () => null,
+}));
+
+vi.mock('../../common', () => ({
+  LinkTab: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
+vi.mock('../../common/ModalLinkTab', () => ({
+  default: ({ label }: { label: string }) => <button>{label}</button>,
+}));
+
+vi.mock('../../dag-editor', () => ({
+  DAGEditButtons: () => null,
+  DAGSpec: () => null,
+}));
+
+vi.mock('../../dag-execution', () => ({
+  DAGExecutionHistory: () => null,
+  ExecutionLog: () => null,
+  LogViewer: () => null,
+  StepLog: () => null,
+}));
+
+vi.mock('../DAGSettingsTab', () => ({
+  default: () => null,
+}));
+
+vi.mock('../IncidentsTab', () => ({
+  default: () => null,
+}));
+
+vi.mock('../NotificationsTab', () => ({
+  default: () => null,
+}));
+
+vi.mock('../WebhookTab', () => ({
+  default: () => null,
+}));
+
+const dag = {
+  name: 'release-notes',
+  artifacts: {
+    enabled: true,
+  },
+} as never;
+
+const currentDAGRun = {
+  name: 'release-notes',
+  dagRunId: 'run-1',
+  artifactsAvailable: true,
+} as never;
+
+function renderContent() {
+  render(
+    <MemoryRouter>
+      <DAGDetailsContent
+        fileName="release-notes"
+        dag={dag}
+        currentDAGRun={currentDAGRun}
+        refreshFn={vi.fn()}
+        formatDuration={vi.fn()}
+        activeTab="status"
+        isModal
+        fillHeight
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('DAGDetailsContent', () => {
+  it('passes full-height layout through to the latest-run status tabs', () => {
+    renderContent();
+
+    expect(screen.getByTestId('dag-status')).toHaveAttribute(
+      'data-fill-height',
+      'true'
+    );
+  });
+});

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx
@@ -36,15 +36,17 @@ vi.mock('../DAGDetailsContent', () => ({
     dagRunId,
     editorHints,
     onRunStarted,
+    fillHeight,
   }: {
     dag: { name: string };
     activeTab: string;
     dagRunId?: string;
     editorHints?: { inheritedLegacyDefinitions?: unknown[] };
     onRunStarted?: (dagRunId: string) => void;
+    fillHeight?: boolean;
   }) => (
     <div>
-      <div>
+      <div data-fill-height={String(fillHeight)} data-testid="dag-details-content">
         Previewing {dag.name} [{activeTab}] {dagRunId || 'latest'}
       </div>
       <div>
@@ -129,6 +131,10 @@ describe('DAGDetailsPanel', () => {
     expect(
       screen.getByText('Previewing example-dag [status] latest')
     ).toBeInTheDocument();
+    expect(screen.getByTestId('dag-details-content')).toHaveAttribute(
+      'data-fill-height',
+      'true'
+    );
     expect(screen.getByText('Inherited hints: 1')).toBeInTheDocument();
   });
 

--- a/ui/src/pages/dag-runs/dag-run/__tests__/index.test.tsx
+++ b/ui/src/pages/dag-runs/dag-run/__tests__/index.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { PageContextProvider } from '@/contexts/PageContext';
+import { useBoundedDAGRunDetails } from '@/features/dag-runs/hooks/useBoundedDAGRunDetails';
+import DAGRunDetailsPage from '..';
+
+vi.mock('@/features/dag-runs/hooks/useBoundedDAGRunDetails', () => ({
+  useBoundedDAGRunDetails: vi.fn(),
+}));
+
+vi.mock('@/features/dag-runs/components/dag-run-details', () => ({
+  DAGRunDetailsContent: vi.fn(({ fillHeight }) => (
+    <div data-fill-height={String(fillHeight)} data-testid="dag-run-content" />
+  )),
+}));
+
+const useBoundedDAGRunDetailsMock = vi.mocked(useBoundedDAGRunDetails);
+
+const dagRunDetails = {
+  name: 'release-notes',
+  dagRunId: 'run-1',
+  artifactsAvailable: true,
+} as never;
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={['/dag-runs/release-notes/run-1']}>
+      <AppBarContext.Provider
+        value={
+          {
+            selectedRemoteNode: 'local',
+            setContext: vi.fn(),
+          } as never
+        }
+      >
+        <PageContextProvider>
+          <Routes>
+            <Route
+              path="/dag-runs/:name/:dagRunId"
+              element={<DAGRunDetailsPage />}
+            />
+          </Routes>
+        </PageContextProvider>
+      </AppBarContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('DAGRunDetailsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBoundedDAGRunDetailsMock.mockReturnValue({
+      data: dagRunDetails,
+      error: null,
+      refresh: vi.fn(),
+    } as never);
+  });
+
+  it('uses full-height layout for DAG run details content', () => {
+    renderPage();
+
+    const content = screen.getByTestId('dag-run-content');
+    expect(content).toHaveAttribute('data-fill-height', 'true');
+    expect(content.parentElement).toHaveClass('h-full');
+    expect(content.parentElement).toHaveClass('min-h-0');
+  });
+});

--- a/ui/src/pages/dag-runs/dag-run/index.tsx
+++ b/ui/src/pages/dag-runs/dag-run/index.tsx
@@ -138,7 +138,7 @@ function DAGRunDetailsPage() {
   }
 
   return (
-    <div className="max-w-7xl px-4">
+    <div className="flex h-full min-h-0 w-full max-w-7xl flex-col px-4">
       <RemoteNodeProvider remoteNode={remoteNode}>
         <DAGRunContext.Provider
           value={{
@@ -152,6 +152,7 @@ function DAGRunDetailsPage() {
             dagRun={dagRunDetails}
             refreshFn={refreshFn}
             dagRunId={displayDAGRunId}
+            fillHeight
           />
         </DAGRunContext.Provider>
       </RemoteNodeProvider>

--- a/ui/src/pages/dags/dag/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/dag/__tests__/index.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import { PageContextProvider } from '@/contexts/PageContext';
+import { useQuery } from '@/hooks/api';
+import { WorkspaceKind } from '@/lib/workspace';
+import DAGDetails from '..';
+
+vi.mock('@/features/dags/components/dag-details', () => ({
+  DAGHeader: () => null,
+  DAGDetailsContent: vi.fn(({ fillHeight }) => (
+    <div data-fill-height={String(fillHeight)} data-testid="dag-details-content" />
+  )),
+}));
+
+vi.mock('@/hooks/api', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDAGSSE', () => ({
+  useDAGSSE: vi.fn(() => ({})),
+}));
+
+vi.mock('@/hooks/useDAGRunSSE', () => ({
+  useDAGRunSSE: vi.fn(() => ({})),
+}));
+
+vi.mock('@/hooks/useSubDAGRunSSE', () => ({
+  useSubDAGRunSSE: vi.fn(() => ({})),
+}));
+
+vi.mock('@/hooks/useSSECacheSync', () => ({
+  sseFallbackOptions: vi.fn(() => ({})),
+  useSSECacheSync: vi.fn(),
+}));
+
+const useQueryMock = useQuery as unknown as {
+  mockImplementation: (fn: (path: string) => unknown) => void;
+};
+
+const appBarValue = {
+  selectedRemoteNode: 'local',
+  workspaceSelection: { kind: WorkspaceKind.all },
+} as never;
+
+const dagData = {
+  dag: {
+    name: 'release-notes',
+    artifacts: { enabled: true },
+  },
+  filePath: '/tmp/release-notes.yaml',
+  latestDAGRun: {
+    name: 'release-notes',
+    dagRunId: 'run-1',
+    artifactsAvailable: true,
+  },
+  localDags: [],
+};
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={['/dags/release-notes']}>
+      <AppBarContext.Provider value={appBarValue}>
+        <PageContextProvider>
+          <Routes>
+            <Route path="/dags/:fileName" element={<DAGDetails />} />
+          </Routes>
+        </PageContextProvider>
+      </AppBarContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('DAGDetails page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.mockImplementation((path) => {
+      if (path === '/dags/{fileName}') {
+        return {
+          data: dagData,
+          mutate: vi.fn(),
+        } as never;
+      }
+
+      return {
+        data: undefined,
+        mutate: vi.fn(),
+      } as never;
+    });
+  });
+
+  it('uses full-height layout for DAG details content', () => {
+    renderPage();
+
+    const content = screen.getByTestId('dag-details-content');
+    expect(content).toHaveAttribute('data-fill-height', 'true');
+    expect(content.parentElement).toHaveClass('min-h-0');
+    expect(content.parentElement).toHaveClass('flex-1');
+  });
+});

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -339,7 +339,7 @@ function DAGDetails() {
               setData: setRootDAGRunData,
             }}
           >
-            <div className="flex w-full min-w-0 max-w-7xl flex-col">
+            <div className="flex h-full min-h-0 w-full min-w-0 max-w-7xl flex-col">
               {dagData?.dag && dagMatchesWorkspace && (
                 <>
                   <DAGHeader
@@ -352,25 +352,28 @@ function DAGDetails() {
                     navigateToStatusTab={navigateToStatusTab}
                     buildScopedUrl={buildUrl}
                   />
-                  <DAGDetailsContent
-                    fileName={fileName}
-                    filePath={dagData.filePath}
-                    dag={dagData.dag}
-                    currentDAGRun={displayDAGRun}
-                    refreshFn={refreshData}
-                    formatDuration={formatDuration}
-                    activeTab={tab}
-                    onTabChange={handleTabChange}
-                    dagRunId={currentDAGRun?.dagRunId}
-                    stepName={stepName}
-                    isModal={false}
-                    navigateToStatusTab={navigateToStatusTab}
-                    skipHeader={true}
-                    localDags={dagData?.localDags}
-                    editorHints={dagData?.editorHints}
-                    onRunStarted={handleRunStarted}
-                    buildScopedUrl={buildUrl}
-                  />
+                  <div className="min-h-0 flex-1">
+                    <DAGDetailsContent
+                      fileName={fileName}
+                      filePath={dagData.filePath}
+                      dag={dagData.dag}
+                      currentDAGRun={displayDAGRun}
+                      refreshFn={refreshData}
+                      formatDuration={formatDuration}
+                      activeTab={tab}
+                      onTabChange={handleTabChange}
+                      dagRunId={currentDAGRun?.dagRunId}
+                      stepName={stepName}
+                      isModal={false}
+                      navigateToStatusTab={navigateToStatusTab}
+                      skipHeader={true}
+                      localDags={dagData?.localDags}
+                      editorHints={dagData?.editorHints}
+                      onRunStarted={handleRunStarted}
+                      buildScopedUrl={buildUrl}
+                      fillHeight
+                    />
+                  </div>
                 </>
               )}
               {dagData?.dag && !dagMatchesWorkspace && (


### PR DESCRIPTION
## Summary
- propagate full-height layout from DAG and DAG-run detail containers into artifact previews
- keep non-status DAG detail tabs on their existing scroll containers
- add regression coverage for full-height DAG and DAG-run detail paths

## Testing
- pnpm -C ui exec vitest run src/features/dags/components/dag-details/__tests__/DAGDetailsPanel.test.tsx src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx src/pages/dags/dag/__tests__/index.test.tsx src/features/dag-runs/components/dag-run-details/__tests__/DAGRunDetailsPanel.test.tsx src/pages/dag-runs/dag-run/__tests__/index.test.tsx
- pnpm -C ui exec tsc --noEmit
- Playwright browser layout check against /dags/release-notes with mocked API data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes artifact previews not stretching to full height in DAG and DAG-run detail views. Status tabs now fill the pane so previews and logs are easier to read.

- **Bug Fixes**
  - Propagated full-height layout via `fillHeight` into `DAGDetailsContent` and `DAGRunDetailsContent`; Status tab uses `overflow-hidden`, other tabs remain scrollable.
  - Updated page/panel wrappers to use `h-full` and `min-h-0` for proper flex behavior and to avoid nested-scroll clipping.
  - Added regression tests for DAG and DAG-run pages and panels to verify the full-height layout.

<sup>Written for commit c8c245079e00d6b69dd9ab3184f203e68e9d4da1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced layout and scrolling behavior for DAG and DAG run detail panels, with optimized vertical space utilization based on active views.

* **Tests**
  * Added comprehensive test coverage to verify detail panel layout behavior and full-height rendering across multiple pages and views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->