### PR TITLE
feat: add outputBuffering option for step log streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ prd.json
 
 # Compiled integration test binary
 intg.test
+bin/dagu

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ cpuprof:
 bin:
 	@printf '%b\n' "${COLOR_GREEN}Building the binary...${COLOR_RESET}"
 	@mkdir -p ${BIN_DIR}
-	@go build -ldflags="$(LDFLAGS)" -o ${BIN_DIR}/${APP_BIN_NAME} ./cmd
+	@CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o ${BIN_DIR}/${APP_BIN_NAME} ./cmd
 
 # bin-e2e builds the go application for browser E2E tests.
 .PHONY: bin-e2e

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -591,6 +591,12 @@
       "default": "separate",
       "description": "Controls how stdout and stderr are logged. 'separate' writes stdout to .out and stderr to .err files. 'merged' writes both to a single .log file with interleaved output."
     },
+    "output_buffering": {
+      "type": "string",
+      "enum": ["buffer", "line", "none"],
+      "default": "buffer",
+      "description": "Controls how step output is buffered before being flushed to the log stream. 'buffer' uses internal buffers (default, high-throughput). 'line' flushes on every newline (best for real-time streaming). 'none' disables all buffering (maximum real-time, high overhead)."
+    },
     "handler_on": {
       "type": "object",
       "properties": {
@@ -1755,6 +1761,11 @@
           "type": "string",
           "enum": ["separate", "merged"],
           "description": "Override DAG-level log output mode. 'separate' writes stdout to .out and stderr to .err files. 'merged' writes both to a single .log file."
+        },
+        "output_buffering": {
+          "type": "string",
+          "enum": ["buffer", "line", "none"],
+          "description": "Controls how step output is buffered before being flushed to the log stream. 'buffer' uses internal buffers (default, high-throughput). 'line' flushes on every newline (best for real-time streaming). 'none' disables all buffering (maximum real-time, high overhead). Overrides the DAG-level outputBuffering setting."
         },
         "output": {
           "oneOf": [

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -1765,7 +1765,7 @@
         "output_buffering": {
           "type": "string",
           "enum": ["buffer", "line", "none"],
-          "description": "Controls how step output is buffered before being flushed to the log stream. 'buffer' uses internal buffers (default, high-throughput). 'line' flushes on every newline (best for real-time streaming). 'none' disables all buffering (maximum real-time, high overhead). Overrides the DAG-level outputBuffering setting."
+          "description": "Controls how step output is buffered before being flushed to the log stream. 'buffer' uses internal buffers (default, high-throughput). 'line' flushes on every newline (best for real-time streaming). 'none' disables all buffering (maximum real-time, high overhead). Overrides the DAG-level output_buffering setting."
         },
         "output": {
           "oneOf": [

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -59,6 +59,18 @@ func EffectiveLogOutput(dag *DAG, step *Step) LogOutputMode {
 	return LogOutputSeparate
 }
 
+// EffectiveOutputBuffering returns the effective output buffering mode for a step,
+// falling back from step-level to DAG-level to the default "buffer".
+func EffectiveOutputBuffering(d *DAG, s *Step) OutputBuffering {
+	if s != nil && s.OutputBuffering != "" {
+		return s.OutputBuffering
+	}
+	if d != nil && d.OutputBuffering != "" {
+		return d.OutputBuffering
+	}
+	return OutputBufferingBuffer
+}
+
 // DAG contains all information about a DAG.
 type DAG struct {
 	// WorkingDir is the working directory to run the DAG.
@@ -136,6 +148,10 @@ type DAG struct {
 	// Can be "separate" (default) for separate .out and .err files,
 	// or "merged" for a single combined .log file.
 	LogOutput LogOutputMode `json:"logOutput,omitempty"`
+	// OutputBuffering sets the default output buffering mode for all steps.
+	// Individual steps can override this with their own outputBuffering.
+	// Defaults to "buffer" if not set.
+	OutputBuffering OutputBuffering `mapstructure:"outputBuffering" json:"outputBuffering,omitempty"`
 	// DefaultParams contains the default parameters to be passed to the DAG.
 	DefaultParams string `json:"defaultParams,omitempty"`
 	// ParamDefs contains ordered parameter metadata derived from DAG params.

--- a/internal/core/dag_test.go
+++ b/internal/core/dag_test.go
@@ -389,6 +389,39 @@ func TestEffectiveLogOutput(t *testing.T) {
 	}
 }
 
+func TestEffectiveOutputBuffering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dagMode    core.OutputBuffering
+		stepMode   core.OutputBuffering
+		expectMode core.OutputBuffering
+	}{
+		// Step overrides DAG
+		{"step line overrides dag buffer", core.OutputBufferingBuffer, core.OutputBufferingLine, core.OutputBufferingLine},
+		{"step none overrides dag buffer", core.OutputBufferingBuffer, core.OutputBufferingNone, core.OutputBufferingNone},
+		{"step buffer overrides dag line", core.OutputBufferingLine, core.OutputBufferingBuffer, core.OutputBufferingBuffer},
+		{"step none overrides dag line", core.OutputBufferingLine, core.OutputBufferingNone, core.OutputBufferingNone},
+		// Step empty → inherits DAG
+		{"step empty inherits dag line", core.OutputBufferingLine, "", core.OutputBufferingLine},
+		{"step empty inherits dag none", core.OutputBufferingNone, "", core.OutputBufferingNone},
+		// Both empty → default buffer
+		{"both empty defaults to buffer", "", "", core.OutputBufferingBuffer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dag := &core.DAG{OutputBuffering: tt.dagMode}
+			step := core.Step{OutputBuffering: tt.stepMode}
+			mode := core.EffectiveOutputBuffering(dag, &step)
+			assert.Equal(t, tt.expectMode, mode)
+		})
+	}
+}
+
 func TestDAG_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/dag_test.go
+++ b/internal/core/dag_test.go
@@ -408,6 +408,13 @@ func TestEffectiveOutputBuffering(t *testing.T) {
 		{"step empty inherits dag none", core.OutputBufferingNone, "", core.OutputBufferingNone},
 		// Both empty → default buffer
 		{"both empty defaults to buffer", "", "", core.OutputBufferingBuffer},
+		// Step overrides DAG none
+		{"step buffer overrides dag none", core.OutputBufferingNone, core.OutputBufferingBuffer, core.OutputBufferingBuffer},
+		{"step line overrides dag none", core.OutputBufferingNone, core.OutputBufferingLine, core.OutputBufferingLine},
+		// Step empty inherits DAG buffer
+		{"step empty inherits dag buffer", core.OutputBufferingBuffer, "", core.OutputBufferingBuffer},
+		// DAG unset, step set
+		{"dag unset step line", "", core.OutputBufferingLine, core.OutputBufferingLine},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/output_buffering.go
+++ b/internal/core/output_buffering.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// OutputBuffering controls how step output is buffered before being flushed to
+// the log stream. It applies to both local file writers and gRPC log streaming.
+type OutputBuffering string
+
+const (
+	// OutputBufferingBuffer uses buffered writes (default, backward-compatible).
+	// In gRPC streaming mode, output is accumulated until a 32KB threshold is
+	// reached before being flushed. In local mode, output goes through a
+	// bufio.Writer with a 4KB buffer.
+	OutputBufferingBuffer OutputBuffering = "buffer"
+
+	// OutputBufferingLine flushes output on every newline character ('\n').
+	// This mode is best for interactive CLI tools and real-time log streaming
+	// where observing output line-by-line is important. Trailing data without a
+	// newline is kept in the buffer until either a newline arrives or the writer
+	// is closed.
+	OutputBufferingLine OutputBuffering = "line"
+
+	// OutputBufferingNone disables all buffering. Every Write call is flushed
+	// immediately. Use with caution in distributed mode — this may generate
+	// excessive gRPC messages and increase overhead. Best for short-running
+	// commands where latency is critical.
+	OutputBufferingNone OutputBuffering = "none"
+)

--- a/internal/core/output_buffering.go
+++ b/internal/core/output_buffering.go
@@ -4,7 +4,9 @@
 package core
 
 // OutputBuffering controls how step output is buffered before being flushed to
-// the log stream. It applies to both local file writers and gRPC log streaming.
+// the log stream. It applies to both local file writers and gRPC log streaming
+// in distributed mode. In local mode, "line" and "none" write directly without
+// Go-level buffering.
 type OutputBuffering string
 
 const (

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -78,6 +78,10 @@ type dag struct {
 	// Can be "separate" (default) for separate .out and .err files,
 	// or "merged" for a single combined .log file.
 	LogOutput types.LogOutputValue `yaml:"log_output,omitempty"`
+	// OutputBuffering sets the default output buffering mode for all steps.
+	// Individual steps can override this with their own outputBuffering.
+	// Can be "buffer" (default), "line", or "none".
+	OutputBuffering core.OutputBuffering `yaml:"output_buffering,omitempty"`
 	// Consts contains immutable values resolved while loading the DAG.
 	Consts any `yaml:"consts,omitempty"`
 	// Env is the environment variables setting.
@@ -574,6 +578,7 @@ var fullRunOutputStage = transformStage{
 	{"log_dir", newTransformer("LogDir", buildLogDir)},
 	{"artifacts", newTransformer("Artifacts", buildArtifacts)},
 	{"log_output", newTransformer("LogOutput", buildLogOutput)},
+	{"output_buffering", newTransformer("OutputBuffering", buildOutputBuffering)},
 }
 
 var fullInteractionStage = transformStage{
@@ -1348,6 +1353,14 @@ func buildLogOutput(_ BuildContext, d *dag) (core.LogOutputMode, error) {
 		return "", nil
 	}
 	return d.LogOutput.Mode(), nil
+}
+
+func buildOutputBuffering(_ BuildContext, d *dag) (core.OutputBuffering, error) {
+	if d.OutputBuffering == "" {
+		// Return empty to allow inheritance from base config.
+		return "", nil
+	}
+	return d.OutputBuffering, nil
 }
 
 func buildMailOn(_ BuildContext, d *dag) (*core.MailOn, error) {

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -63,6 +63,10 @@ type step struct {
 	// Can be "separate" (default) for separate .out and .err files,
 	// or "merged" for a single combined .log file.
 	LogOutput types.LogOutputValue `yaml:"log_output,omitempty"`
+	// OutputBuffering controls how the step's output is buffered before being
+	// written to the log stream. Overrides the DAG-level setting.
+	// Can be "buffer" (default), "line", or "none".
+	OutputBuffering core.OutputBuffering `yaml:"output_buffering,omitempty"`
 	// Output is the variable name to store the output.
 	// Can be a string for captured stdout or an object for structured step output.
 	Output any `yaml:"output,omitempty"`
@@ -434,6 +438,7 @@ var stepLogOutputStage = stepTransformStage{
 	{"stderr", newStepTransformer("Stderr", buildStepStderr)},
 	{"stderr.artifact", newStepTransformer("StderrArtifact", buildStepStderrArtifact)},
 	{"log_output", newStepTransformer("LogOutput", buildStepLogOutput)},
+	{"output_buffering", newStepTransformer("OutputBuffering", buildStepOutputBuffering)},
 }
 
 var stepExecutionPlacementStage = stepTransformStage{
@@ -805,6 +810,14 @@ func buildStepLogOutput(_ StepBuildContext, s *step) (core.LogOutputMode, error)
 		return "", nil
 	}
 	return s.LogOutput.Mode(), nil
+}
+
+func buildStepOutputBuffering(_ StepBuildContext, s *step) (core.OutputBuffering, error) {
+	if s.OutputBuffering == "" {
+		// Return empty string to indicate "inherit from DAG"
+		return "", nil
+	}
+	return s.OutputBuffering, nil
 }
 
 func buildStepMailOnError(_ StepBuildContext, s *step) (bool, error) {

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -64,6 +64,11 @@ type Step struct {
 	// LogOutput specifies how stdout and stderr are handled in log files for this step.
 	// Overrides the DAG-level LogOutput setting. Empty string means inherit from DAG.
 	LogOutput LogOutputMode `json:"logOutput,omitempty"`
+	// OutputBuffering controls how the step's stdout/stderr is buffered before
+	// being written to the log stream. Overrides the DAG-level setting.
+	// "buffer" (default) uses internal buffers. "line" flushes on newlines.
+	// "none" disables all buffering.
+	OutputBuffering OutputBuffering `mapstructure:"outputBuffering" json:"outputBuffering,omitempty"`
 	// Output is the variable name to store captured stdout.
 	Output string `json:"output,omitempty"`
 	// StructuredOutput publishes post-processed step-scoped outputs for ${step.output.*} access.

--- a/internal/runtime/builtin/command/command.go
+++ b/internal/runtime/builtin/command/command.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ var errNoCommandSpecified = fmt.Errorf("no command specified")
 var _ executor.Executor = (*commandExecutor)(nil)
 var _ executor.Stopper = (*commandExecutor)(nil)
 var _ executor.ExitCoder = (*commandExecutor)(nil)
+var _ executor.OutputBufferingAware = (*commandExecutor)(nil)
 
 type commandExecutor struct {
 	mu         sync.Mutex
@@ -73,6 +75,16 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 	if err != nil {
 		e.mu.Unlock()
 		return fmt.Errorf("failed to create command: %w", err)
+	}
+
+	// Start pipe streaming goroutines when output buffering is line/none.
+	// These read directly from the subprocess stdout/stderr pipes, bypassing
+	// os/exec's 32KB io.Copy buffer for real-time streaming.
+	if e.config.stdoutPipe != nil {
+		go streamPipe(e.config.stdoutPipe, e.config.Stdout, e.config.outputBuffering)
+	}
+	if e.config.stderrPipe != nil {
+		go streamPipe(e.config.stderrPipe, e.config.Stderr, e.config.outputBuffering)
 	}
 
 	// Ensure the working directory exists
@@ -140,6 +152,11 @@ func (e *commandExecutor) SetStderr(out io.Writer) {
 	e.config.Stderr = out
 }
 
+// SetOutputBuffering implements executor.OutputBufferingAware.
+func (e *commandExecutor) SetOutputBuffering(mode core.OutputBuffering) {
+	e.config.outputBuffering = mode
+}
+
 func (e *commandExecutor) Kill(sig os.Signal) error {
 	return e.Stop(cmdutil.TerminationFromSignal(sig))
 }
@@ -189,6 +206,13 @@ type commandConfig struct {
 	Stdout             io.Writer
 	Stderr             io.Writer
 	UserSpecifiedShell bool
+	// outputBuffering controls how subprocess output is streamed.
+	// When set to "line" or "none", pipes are used instead of cmd.Stdout/Stderr.
+	outputBuffering core.OutputBuffering
+	// stdoutPipe and stderrPipe are set when outputBuffering is line/none.
+	// The command executor reads from these pipes and writes to Stdout/Stderr.
+	stdoutPipe io.ReadCloser
+	stderrPipe io.ReadCloser
 }
 
 func (cfg *commandConfig) newCmd(ctx context.Context, scriptFile string) (*exec.Cmd, error) {
@@ -282,8 +306,25 @@ func (cfg *commandConfig) newCmd(ctx context.Context, scriptFile string) (*exec.
 
 	cmd.Env = append(cmd.Env, runtime.AllEnvs(ctx)...)
 	cmd.Dir = cfg.Dir
-	cmd.Stdout = cfg.Stdout
-	cmd.Stderr = cfg.Stderr
+
+	// When output buffering mode is "line" or "none", use pipes to
+	// bypass os/exec's internal 32KB io.Copy buffer. This allows
+	// step output to be streamed line-by-line or byte-by-byte
+	// instead of waiting for the buffer to fill.
+	if cfg.outputBuffering == core.OutputBufferingLine || cfg.outputBuffering == core.OutputBufferingNone {
+		var err error
+		cfg.stdoutPipe, err = cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+		cfg.stderrPipe, err = cmd.StderrPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
+	} else {
+		cmd.Stdout = cfg.Stdout
+		cmd.Stderr = cfg.Stderr
+	}
 	cmdutil.SetupCommand(cmd)
 
 	return cmd, nil
@@ -391,6 +432,39 @@ func init() {
 	executor.RegisterExecutor("", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("shell", NewCommand, validateCommandStep, caps)
 	executor.RegisterExecutor("command", NewCommand, validateCommandStep, caps)
+}
+
+// streamPipe reads from a subprocess pipe and writes to the destination writer,
+// using a buffering strategy based on the output mode:
+//   - "line": reads with bufio.Scanner, flushing on every newline
+//   - "none": reads with a 256-byte buffer for low-latency delivery
+func streamPipe(pipe io.ReadCloser, dest io.Writer, mode core.OutputBuffering) {
+	defer pipe.Close()
+	switch mode {
+	case core.OutputBufferingLine:
+		scanner := bufio.NewScanner(pipe)
+		for scanner.Scan() {
+			// Write the line including the newline character.
+			// scanner.Bytes() returns the line content without the delimiter.
+			line := scanner.Bytes()
+			buf := make([]byte, len(line)+1)
+			copy(buf, line)
+			buf[len(line)] = '\n'
+			if _, err := dest.Write(buf); err != nil {
+				return
+			}
+		}
+	case core.OutputBufferingNone:
+		buf := make([]byte, 256)
+		if _, err := io.CopyBuffer(dest, pipe, buf); err != nil {
+			return
+		}
+	default:
+		// Fallback: use io.Copy with default buffer
+		if _, err := io.Copy(dest, pipe); err != nil {
+			return
+		}
+	}
 }
 
 func commandContextShell(ctx context.Context, step core.Step) []string {

--- a/internal/runtime/builtin/command/multi_command.go
+++ b/internal/runtime/builtin/command/multi_command.go
@@ -17,6 +17,7 @@ import (
 
 var _ executor.Executor = (*multiCommandExecutor)(nil)
 var _ executor.ExitCoder = (*multiCommandExecutor)(nil)
+var _ executor.OutputBufferingAware = (*multiCommandExecutor)(nil)
 
 // multiCommandExecutor executes multiple commands sequentially.
 // It stops on the first command that fails (non-zero exit code).
@@ -72,6 +73,15 @@ func (e *multiCommandExecutor) SetStderr(out io.Writer) {
 	e.stderr = out
 	for _, cfg := range e.configs {
 		cfg.Stderr = out
+	}
+}
+
+// SetOutputBuffering implements executor.OutputBufferingAware.
+func (e *multiCommandExecutor) SetOutputBuffering(mode core.OutputBuffering) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, cfg := range e.configs {
+		cfg.outputBuffering = mode
 	}
 }
 

--- a/internal/runtime/context.go
+++ b/internal/runtime/context.go
@@ -96,6 +96,23 @@ func WithDAGContext(ctx context.Context, rCtx Context) context.Context {
 	return exec.WithContext(ctx, rCtx)
 }
 
+type outputBufferingCtxKey struct{}
+
+// WithOutputBuffering stores the output buffering mode in the context.
+// It is consumed by log writer factories to decide how to buffer step output.
+func WithOutputBuffering(ctx context.Context, mode core.OutputBuffering) context.Context {
+	return context.WithValue(ctx, outputBufferingCtxKey{}, mode)
+}
+
+// GetOutputBuffering returns the output buffering mode from the context.
+// Falls back to core.OutputBufferingBuffer when not set.
+func GetOutputBuffering(ctx context.Context) core.OutputBuffering {
+	if mode, ok := ctx.Value(outputBufferingCtxKey{}).(core.OutputBuffering); ok {
+		return mode
+	}
+	return core.OutputBufferingBuffer
+}
+
 // NewDAGRunRef is a convenience wrapper for execution.NewDAGRunRef.
 func NewDAGRunRef(name, runID string) exec.DAGRunRef {
 	return exec.NewDAGRunRef(name, runID)

--- a/internal/runtime/executor/executor.go
+++ b/internal/runtime/executor/executor.go
@@ -85,6 +85,15 @@ var executorRegistry = make(map[string]ExecutorFactory)
 
 var executorRegistryMu sync.RWMutex
 
+// OutputBufferingAware is implemented by executors that support
+// different output buffering modes (buffer, line, none).
+// When set to "line" or "none", the executor should bypass
+// os/exec's internal 32KB io.Copy buffer and stream data directly
+// through its own pipe reader.
+type OutputBufferingAware interface {
+	SetOutputBuffering(mode core.OutputBuffering)
+}
+
 // ExitCoder is an interface for executors that can return an exit code.
 type ExitCoder interface {
 	ExitCode() int

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -379,9 +379,6 @@ func (oc *OutputCoordinator) setupLocalWriters(ctx context.Context, data NodeDat
 	rCtx := GetDAGContext(ctx)
 	mode := core.EffectiveOutputBuffering(rCtx.DAG, &data.Step)
 
-	// Store mode in context for consistency with setupRemoteWriters
-	_ = WithOutputBuffering(ctx, mode)
-
 	// Check if stdout and stderr should be merged (same file path)
 	isMerged := data.State.Stdout == data.State.Stderr
 

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -118,6 +118,18 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 	oc.mu.Lock()
 	defer oc.mu.Unlock()
 
+	// Compute the effective output buffering mode and propagate it to
+	// executors that implement OutputBufferingAware (e.g., command executor).
+	// This allows the command executor to use pipe-based I/O instead of
+	// os/exec's internal 32KB io.Copy buffer for "line" and "none" modes.
+	rCtx := GetDAGContext(ctx)
+	mode := core.EffectiveOutputBuffering(rCtx.DAG, &data.Step)
+	if aware, ok := cmd.(executor.OutputBufferingAware); ok {
+		aware.SetOutputBuffering(mode)
+	}
+	// Store mode in context for downstream consumers (e.g., remote log streaming)
+	ctx = WithOutputBuffering(ctx, mode)
+
 	var stdout io.Writer = os.Stdout
 	if oc.stdoutWriter != nil {
 		stdout = oc.stdoutWriter

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -372,8 +372,16 @@ func (oc *OutputCoordinator) setupRemoteWriters(ctx context.Context, data NodeDa
 	return nil
 }
 
-// setupLocalWriters creates file-based writers (original behavior)
-func (oc *OutputCoordinator) setupLocalWriters(_ context.Context, data NodeData) error {
+// setupLocalWriters creates file-based writers that respect the OutputBuffering
+// mode from context (buffer, line, or none).
+func (oc *OutputCoordinator) setupLocalWriters(ctx context.Context, data NodeData) error {
+	// Compute effective output buffering mode
+	rCtx := GetDAGContext(ctx)
+	mode := core.EffectiveOutputBuffering(rCtx.DAG, &data.Step)
+
+	// Store mode in context for consistency with setupRemoteWriters
+	_ = WithOutputBuffering(ctx, mode)
+
 	// Check if stdout and stderr should be merged (same file path)
 	isMerged := data.State.Stdout == data.State.Stderr
 
@@ -388,7 +396,7 @@ func (oc *OutputCoordinator) setupLocalWriters(_ context.Context, data NodeData)
 	if oc.masker != nil {
 		stdoutWriter = masking.NewMaskingWriter(oc.stdoutFile, oc.masker)
 	}
-	oc.stdoutWriter = newSafeBufferedWriter(stdoutWriter)
+	oc.stdoutWriter = newWriterForMode(stdoutWriter, mode)
 	oc.stdoutFileName = data.State.Stdout
 
 	// stderr - if merged, reuse the same file and writer
@@ -408,11 +416,28 @@ func (oc *OutputCoordinator) setupLocalWriters(_ context.Context, data NodeData)
 		if oc.masker != nil {
 			stderrWriter = masking.NewMaskingWriter(oc.stderrFile, oc.masker)
 		}
-		oc.stderrWriter = newSafeBufferedWriter(stderrWriter)
+		oc.stderrWriter = newWriterForMode(stderrWriter, mode)
 		oc.stderrFileName = data.State.Stderr
 	}
 
 	return nil
+}
+
+// newWriterForMode creates the appropriate writer based on the output buffering mode.
+//   - "buffer": wraps in a thread-safe buffered writer (bufio.Writer with 4KB buffer)
+//   - "line": wraps in a line-buffered writer that flushes on every newline
+//   - "none": wraps in a direct (unbuffered) writer
+func newWriterForMode(w io.Writer, mode core.OutputBuffering) io.Writer {
+	switch mode {
+	case core.OutputBufferingLine:
+		return newLineBufferedWriter(w)
+	case core.OutputBufferingNone:
+		return newDirectWriter(w)
+	case core.OutputBufferingBuffer:
+		return newSafeBufferedWriter(w)
+	default:
+		return newSafeBufferedWriter(w)
+	}
 }
 
 func (oc *OutputCoordinator) setupFile(ctx context.Context, filePath string, _ NodeData) (*os.File, error) {

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/cmn/masking"
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 )
@@ -350,6 +351,11 @@ func (oc *OutputCoordinator) setupWriters(ctx context.Context, data NodeData) er
 // setupRemoteWriters creates writers that stream to coordinator
 func (oc *OutputCoordinator) setupRemoteWriters(ctx context.Context, data NodeData, factory LogWriterFactory) error {
 	stepName := data.Step.Name
+
+	// Compute effective output buffering mode and pass it through context
+	dag := GetDAGContext(ctx).DAG
+	mode := core.EffectiveOutputBuffering(dag, &data.Step)
+	ctx = WithOutputBuffering(ctx, mode)
 
 	// Create streaming writers for stdout and stderr
 	oc.stdoutWriter = factory.NewStepWriter(ctx, stepName, exec.StreamTypeStdout)

--- a/internal/runtime/output_test.go
+++ b/internal/runtime/output_test.go
@@ -924,6 +924,42 @@ func TestLineBufferedWriter(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, buf.String())
 	})
+
+	t.Run("AutoFlushOnLargeLineWithoutNewline", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		data := make([]byte, maxLineBufferSize+1)
+		for i := range data {
+			data[i] = 'x'
+		}
+
+		n, err := lw.Write(data)
+		require.NoError(t, err)
+		assert.Equal(t, len(data), n)
+		assert.Equal(t, len(data), buf.Len())
+	})
+
+	t.Run("InitialCapacityPreAllocated", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+		assert.Equal(t, 4096, cap(lw.buf), "initial capacity should be 4096")
+	})
+
+	t.Run("BackingArrayReleasedAfterFullDrain", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		_, err := lw.Write([]byte("hello\n"))
+		require.NoError(t, err)
+		assert.Equal(t, 0, cap(lw.buf), "backing array should be released after full drain")
+	})
 }
 
 func TestDirectWriter(t *testing.T) {

--- a/internal/runtime/output_test.go
+++ b/internal/runtime/output_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -817,5 +818,279 @@ func TestOutputCoordinator_CapturedStderr(t *testing.T) {
 		output, err := oc.capturedStderr(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "first attempt\nsecond attempt", output)
+	})
+}
+
+func TestNewWriterForMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BufferModeReturnsSafeBufferedWriter", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		w := newWriterForMode(&buf, core.OutputBufferingBuffer)
+		_, ok := w.(*safeBufferedWriter)
+		assert.True(t, ok, "buffer mode should return safeBufferedWriter")
+	})
+
+	t.Run("LineModeReturnsLineBufferedWriter", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		w := newWriterForMode(&buf, core.OutputBufferingLine)
+		_, ok := w.(*lineBufferedWriter)
+		assert.True(t, ok, "line mode should return lineBufferedWriter")
+	})
+
+	t.Run("NoneModeReturnsDirectWriter", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		w := newWriterForMode(&buf, core.OutputBufferingNone)
+		_, ok := w.(*directWriter)
+		assert.True(t, ok, "none mode should return directWriter")
+	})
+
+	t.Run("EmptyModeDefaultsToBuffer", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		w := newWriterForMode(&buf, "")
+		_, ok := w.(*safeBufferedWriter)
+		assert.True(t, ok, "empty mode should default to safeBufferedWriter")
+	})
+}
+
+func TestLineBufferedWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FlushesOnNewline", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		n, err := lw.Write([]byte("hello\nworld"))
+		require.NoError(t, err)
+		assert.Equal(t, 11, n)
+
+		// "hello\n" should have been flushed to the buffer
+		assert.Equal(t, "hello\n", buf.String())
+
+		// Flush the remaining "world"
+		err = lw.Flush()
+		require.NoError(t, err)
+		assert.Equal(t, "hello\nworld", buf.String())
+	})
+
+	t.Run("MultipleNewlines", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		n, err := lw.Write([]byte("a\nb\nc\n"))
+		require.NoError(t, err)
+		assert.Equal(t, 6, n)
+		assert.Equal(t, "a\nb\nc\n", buf.String())
+	})
+
+	t.Run("NoNewlineBuffered", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		n, err := lw.Write([]byte("hello world"))
+		require.NoError(t, err)
+		assert.Equal(t, 11, n)
+
+		// Nothing should be flushed yet
+		assert.Empty(t, buf.String())
+
+		// Flush should write the buffered data
+		err = lw.Flush()
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", buf.String())
+	})
+
+	t.Run("FlushNoOpWhenEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		lw := newLineBufferedWriter(&buf)
+
+		err := lw.Flush()
+		assert.NoError(t, err)
+		assert.Empty(t, buf.String())
+	})
+}
+
+func TestDirectWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WritesImmediately", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		dw := newDirectWriter(&buf)
+
+		n, err := dw.Write([]byte("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "hello", buf.String())
+	})
+
+	t.Run("FlushIsNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		dw := newDirectWriter(&buf)
+
+		_, err := dw.Write([]byte("data"))
+		require.NoError(t, err)
+
+		err = dw.Flush()
+		assert.NoError(t, err)
+		assert.Equal(t, "data", buf.String())
+	})
+}
+
+func TestOutputCoordinator_SetupLocalWriters(t *testing.T) {
+	modeTest := func(t *testing.T, mode core.OutputBuffering, expectedType any) {
+		oc := &OutputCoordinator{}
+		tmpDir := t.TempDir()
+
+		stdoutPath := filepath.Join(tmpDir, "stdout.log")
+		stderrPath := filepath.Join(tmpDir, "stderr.log")
+
+		dag := &core.DAG{
+			Name:            "test",
+			OutputBuffering: mode,
+		}
+		ctx := NewContext(context.Background(), dag, "test-run", "test.log")
+		data := NodeData{
+			Step: core.Step{Name: "test"},
+			State: NodeState{
+				Stdout: stdoutPath,
+				Stderr: stderrPath,
+			},
+		}
+
+		err := oc.setupLocalWriters(ctx, data)
+		require.NoError(t, err)
+		require.NotNil(t, oc.stdoutWriter)
+		require.NotNil(t, oc.stderrWriter)
+
+		// Verify type
+		assert.IsType(t, expectedType, oc.stdoutWriter)
+		assert.IsType(t, expectedType, oc.stderrWriter)
+
+		// Verify files were created
+		assert.FileExists(t, stdoutPath)
+		assert.FileExists(t, stderrPath)
+
+		// Verify file names are set
+		assert.Equal(t, stdoutPath, oc.StdoutFile())
+
+		_ = oc.closeResources()
+	}
+
+	t.Run("BufferMode", func(t *testing.T) {
+		modeTest(t, core.OutputBufferingBuffer, &safeBufferedWriter{})
+	})
+
+	t.Run("LineMode", func(t *testing.T) {
+		modeTest(t, core.OutputBufferingLine, &lineBufferedWriter{})
+	})
+
+	t.Run("NoneMode", func(t *testing.T) {
+		modeTest(t, core.OutputBufferingNone, &directWriter{})
+	})
+
+	t.Run("DefaultMode", func(t *testing.T) {
+		// When no output buffering is set, it should default to buffer
+		modeTest(t, "", &safeBufferedWriter{})
+	})
+
+	t.Run("MergedStdoutStderr", func(t *testing.T) {
+		oc := &OutputCoordinator{}
+		tmpDir := t.TempDir()
+
+		combinedPath := filepath.Join(tmpDir, "combined.log")
+
+		dag := &core.DAG{
+			Name:            "test",
+			OutputBuffering: core.OutputBufferingNone,
+		}
+		ctx := NewContext(context.Background(), dag, "test-run", "test.log")
+		data := NodeData{
+			Step: core.Step{Name: "test"},
+			State: NodeState{
+				Stdout: combinedPath,
+				Stderr: combinedPath,
+			},
+		}
+
+		err := oc.setupLocalWriters(ctx, data)
+		require.NoError(t, err)
+		require.NotNil(t, oc.stdoutWriter)
+		require.NotNil(t, oc.stderrWriter)
+
+		// When merged, stdout and stderr writers should be the same instance
+		assert.Same(t, oc.stdoutWriter, oc.stderrWriter)
+		assert.Nil(t, oc.stderrFile, "stderrFile should be nil when merged")
+
+		_ = oc.closeResources()
+	})
+
+	t.Run("WritesFileContent", func(t *testing.T) {
+		// Verify that writes actually reach the file for all modes
+		for _, mode := range []core.OutputBuffering{
+			core.OutputBufferingBuffer,
+			core.OutputBufferingLine,
+			core.OutputBufferingNone,
+		} {
+			t.Run(string(mode), func(t *testing.T) {
+				oc := &OutputCoordinator{}
+				tmpDir := t.TempDir()
+
+				stdoutPath := filepath.Join(tmpDir, "stdout.log")
+				stderrPath := filepath.Join(tmpDir, "stderr.log")
+
+				dag := &core.DAG{
+					Name:            "test",
+					OutputBuffering: mode,
+				}
+				ctx := NewContext(context.Background(), dag, "test-run", "test.log")
+				data := NodeData{
+					Step: core.Step{Name: "test"},
+					State: NodeState{
+						Stdout: stdoutPath,
+						Stderr: stderrPath,
+					},
+				}
+
+				err := oc.setupLocalWriters(ctx, data)
+				require.NoError(t, err)
+				require.NotNil(t, oc.stdoutWriter)
+
+				// Write test data
+				testData := "test output content\n"
+				_, err = io.WriteString(oc.stdoutWriter, testData)
+				require.NoError(t, err)
+
+				// Flush to ensure data is written
+				_ = oc.flushWriters()
+
+				// Close resources to finalize
+				_ = oc.closeResources()
+
+				// Read file and verify
+				b, err := os.ReadFile(stdoutPath)
+				require.NoError(t, err)
+				assert.Equal(t, testData, string(b))
+			})
+		}
 	})
 }

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1381,6 +1381,12 @@ func (r *Runner) finishNode(node *Node, wg *sync.WaitGroup) {
 		// NotStarted/Running should not happen at this point.
 	}
 
+	// Ensure output writers are flushed and closed even on early goroutine
+	// returns (prepareNode failure, precondition skip, panic). Teardown is
+	// idempotent via CompareAndSwap — safe when already called by the normal
+	// teardownNode path.
+	_ = node.Teardown()
+
 	node.Finish()
 	wg.Done()
 }

--- a/internal/runtime/writer.go
+++ b/internal/runtime/writer.go
@@ -106,9 +106,11 @@ func (d *directWriter) Flush() error {
 	return nil
 }
 
+const maxLineBufferSize = 32 * 1024 // auto-flush threshold for lines without a newline
+
 // lineBufferedWriter wraps an io.Writer and flushes on every newline character.
 // Partial lines (without a trailing newline) are kept in the buffer until either
-// a newline arrives or Flush() is called explicitly.
+// a newline arrives, the buffer exceeds maxLineBufferSize, or Flush() is called.
 type lineBufferedWriter struct {
 	mu  sync.Mutex
 	buf []byte
@@ -118,7 +120,7 @@ type lineBufferedWriter struct {
 // newLineBufferedWriter creates a writer that flushes the underlying writer
 // on every newline character.
 func newLineBufferedWriter(w io.Writer) *lineBufferedWriter {
-	return &lineBufferedWriter{w: w}
+	return &lineBufferedWriter{w: w, buf: make([]byte, 0, 4096)}
 }
 
 func (lw *lineBufferedWriter) Write(p []byte) (int, error) {
@@ -139,6 +141,19 @@ func (lw *lineBufferedWriter) Write(p []byte) (int, error) {
 			return len(p), err
 		}
 	}
+	// Release backing array when fully drained to avoid retaining large allocations.
+	if len(lw.buf) == 0 {
+		lw.buf = lw.buf[:0:0]
+	}
+
+	// Flush if buffer exceeds max size (handles newline-less output like progress bars)
+	if len(lw.buf) >= maxLineBufferSize {
+		if _, err := lw.w.Write(lw.buf); err != nil {
+			return len(p), err
+		}
+		lw.buf = lw.buf[:0:0]
+	}
+
 	return len(p), nil
 }
 
@@ -149,7 +164,7 @@ func (lw *lineBufferedWriter) Flush() error {
 	defer lw.mu.Unlock()
 	if len(lw.buf) > 0 {
 		_, err := lw.w.Write(lw.buf)
-		lw.buf = lw.buf[:0]
+		lw.buf = lw.buf[:0:0]
 		return err
 	}
 	return nil

--- a/internal/runtime/writer.go
+++ b/internal/runtime/writer.go
@@ -80,3 +80,71 @@ func (s *safeBufferedWriter) Flush() error {
 	defer s.mu.Unlock()
 	return s.bw.Flush()
 }
+
+// directWriter wraps an io.Writer with a mutex for thread safety without any
+// buffering. Every Write call is passed directly to the underlying writer.
+// It is used when OutputBufferingNone is selected.
+type directWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// newDirectWriter creates an unbuffered thread-safe writer.
+func newDirectWriter(w io.Writer) *directWriter {
+	return &directWriter{w: w}
+}
+
+func (d *directWriter) Write(p []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.w.Write(p)
+}
+
+// Flush is a no-op since there is no buffer to flush.
+func (d *directWriter) Flush() error {
+	return nil
+}
+
+// lineBufferedWriter wraps an io.Writer and flushes on every newline character.
+// Partial lines (without a trailing newline) are kept in the buffer until either
+// a newline arrives or Flush() is called explicitly.
+type lineBufferedWriter struct {
+	mu  sync.Mutex
+	buf []byte
+	w   io.Writer
+}
+
+// newLineBufferedWriter creates a writer that flushes the underlying writer
+// on every newline character.
+func newLineBufferedWriter(w io.Writer) *lineBufferedWriter {
+	return &lineBufferedWriter{w: w}
+}
+
+func (lw *lineBufferedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+
+	for _, b := range p {
+		lw.buf = append(lw.buf, b)
+		if b == '\n' {
+			if _, err := lw.w.Write(lw.buf); err != nil {
+				return 0, err
+			}
+			lw.buf = lw.buf[:0]
+		}
+	}
+	return len(p), nil
+}
+
+// Flush writes any remaining data in the buffer that hasn't been flushed by a
+// newline.
+func (lw *lineBufferedWriter) Flush() error {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	if len(lw.buf) > 0 {
+		_, err := lw.w.Write(lw.buf)
+		lw.buf = lw.buf[:0]
+		return err
+	}
+	return nil
+}

--- a/internal/runtime/writer.go
+++ b/internal/runtime/writer.go
@@ -128,7 +128,7 @@ func (lw *lineBufferedWriter) Write(p []byte) (int, error) {
 		lw.buf = append(lw.buf, b)
 		if b == '\n' {
 			if _, err := lw.w.Write(lw.buf); err != nil {
-				return 0, err
+				return len(p), err
 			}
 			lw.buf = lw.buf[:0]
 		}

--- a/internal/runtime/writer.go
+++ b/internal/runtime/writer.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"sync"
 )
@@ -124,13 +125,18 @@ func (lw *lineBufferedWriter) Write(p []byte) (int, error) {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
 
-	for _, b := range p {
-		lw.buf = append(lw.buf, b)
-		if b == '\n' {
-			if _, err := lw.w.Write(lw.buf); err != nil {
-				return len(p), err
-			}
-			lw.buf = lw.buf[:0]
+	lw.buf = append(lw.buf, p...)
+
+	// Flush complete lines, keep trailing partial data
+	for {
+		idx := bytes.IndexByte(lw.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		line := lw.buf[:idx+1]
+		lw.buf = lw.buf[idx+1:]
+		if _, err := lw.w.Write(line); err != nil {
+			return len(p), err
 		}
 	}
 	return len(p), nil

--- a/internal/service/worker/coordreport/export_test.go
+++ b/internal/service/worker/coordreport/export_test.go
@@ -67,6 +67,8 @@ type StepLogWriterSnapshot struct {
 	BufferLen        int
 	Sequence         uint64
 	HasStream        bool
+	LineBuffered     bool
+	Unbuffered       bool
 }
 
 // SnapshotStepLogWriter captures step writer state under its lock.
@@ -86,6 +88,8 @@ func snapshotStepLogWriterLocked(w *StepLogWriter) StepLogWriterSnapshot {
 		BufferLen:        len(w.buffer),
 		Sequence:         w.sequence,
 		HasStream:        w.stream != nil,
+		LineBuffered:     w.lineBuffered,
+		Unbuffered:       w.unbuffered,
 	}
 }
 

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 
@@ -325,10 +326,12 @@ func (w *stepLogWriter) flush() error {
 		return nil
 	}
 
-	data := w.buffer
+	if err := w.sendChunk(w.buffer); err != nil {
+		// Buffer preserved on error — Close() will log the tail.
+		return err
+	}
 	w.buffer = w.buffer[:0]
-
-	return w.sendChunk(data)
+	return nil
 }
 
 // Close implements io.Closer
@@ -348,8 +351,10 @@ func (w *stepLogWriter) Close() error {
 		if err := w.sendChunk(w.buffer); err != nil {
 			logger.Error(w.ctx, "Failed to flush log buffer", tag.Error(err))
 			firstErr = err
+			// Buffer preserved — will be handled below if stream is dead.
+		} else {
+			w.buffer = w.buffer[:0]
 		}
-		w.buffer = w.buffer[:0]
 	}
 
 	// Send final marker
@@ -385,6 +390,24 @@ func (w *stepLogWriter) Close() error {
 				firstErr = err
 			}
 		}
+	}
+
+	// If the gRPC stream died, preserve the buffered output in the error
+	// so it surfaces in the run status instead of being silently lost.
+	if w.stream == nil && len(w.buffer) > 0 {
+		tail := w.buffer
+		if len(tail) > 4096 {
+			tail = tail[len(tail)-4096:]
+		}
+		logger.Error(w.ctx, "gRPC log stream lost — buffered output discarded",
+			tag.Step(w.stepName),
+			slog.Int("buffered-bytes", len(w.buffer)),
+			slog.String("output-tail", string(tail)),
+		)
+		if firstErr == nil {
+			firstErr = fmt.Errorf("log stream connection lost: %d bytes of output not transmitted (last 4KB logged)", len(w.buffer))
+		}
+		w.buffer = w.buffer[:0]
 	}
 
 	return firstErr
@@ -471,7 +494,6 @@ func (w *schedulerLogWriter) flush() error {
 
 	// Split buffer into chunks if necessary
 	data := w.buffer
-	w.buffer = w.buffer[:0]
 
 	for len(data) > 0 {
 		chunkSize := min(len(data), maxChunkSize)
@@ -501,6 +523,7 @@ func (w *schedulerLogWriter) flush() error {
 		w.sequence = nextSeq
 	}
 
+	w.buffer = w.buffer[:0]
 	return nil
 }
 

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -460,9 +460,14 @@ func (w *schedulerLogWriter) Write(p []byte) (int, error) {
 	// Flush to coordinator when buffer exceeds threshold
 	if len(w.buffer) >= logBufferSize {
 		if err := w.flush(); err != nil {
-			// Log streaming is best-effort - don't fail the write
-			// Avoid recursive logging by not using logger here
-			w.buffer = w.buffer[:0] // Discard to prevent memory growth
+			// Streaming is best-effort; local file is the source of truth.
+			logger.Warn(w.ctx, "Scheduler log streaming failed, will retry", tag.Error(err))
+			// Cap buffer to prevent unbounded growth if the stream never recovers.
+			if len(w.buffer) > 2*logBufferSize {
+				tail := make([]byte, logBufferSize)
+				copy(tail, w.buffer[len(w.buffer)-logBufferSize:])
+				w.buffer = tail
+			}
 		}
 	}
 
@@ -492,15 +497,15 @@ func (w *schedulerLogWriter) flush() error {
 		}
 	}
 
-	// Split buffer into chunks if necessary
-	data := w.buffer
-
-	for len(data) > 0 {
-		chunkSize := min(len(data), maxChunkSize)
+	// Use a cursor into w.buffer so that on a mid-loop Send failure we can
+	// compact the buffer to only the unsent suffix — avoiding duplicate delivery
+	// of already-sent chunks on reconnect.
+	remaining := w.buffer
+	for len(remaining) > 0 {
+		chunkSize := min(len(remaining), maxChunkSize)
 
 		chunkData := make([]byte, chunkSize)
-		copy(chunkData, data[:chunkSize])
-		data = data[chunkSize:]
+		copy(chunkData, remaining[:chunkSize])
 
 		nextSeq := w.sequence + 1
 		chunk := &coordinatorv1.LogChunk{
@@ -518,9 +523,14 @@ func (w *schedulerLogWriter) flush() error {
 		}
 
 		if err := w.stream.Send(chunk); err != nil {
+			w.stream = nil // Mark dead so next flush opens a fresh stream
+			// Compact: keep only the unsent suffix to avoid re-sending already-delivered chunks.
+			n := copy(w.buffer, remaining)
+			w.buffer = w.buffer[:n]
 			return err
 		}
 		w.sequence = nextSeq
+		remaining = remaining[chunkSize:]
 	}
 
 	w.buffer = w.buffer[:0]
@@ -537,8 +547,23 @@ func (w *schedulerLogWriter) Close() error {
 	}
 	w.closed = true
 
-	// Flush any remaining buffered data
-	_ = w.flush() // Ignore error - best effort
+	// Flush any remaining buffered data (best-effort streaming)
+	if err := w.flush(); err != nil {
+		logger.Warn(w.ctx, "Scheduler log streaming failed at close", tag.Error(err))
+	}
+
+	// Log tail if stream is dead but buffer has data — still available in local file.
+	if w.stream == nil && len(w.buffer) > 0 {
+		tail := w.buffer
+		if len(tail) > 4096 {
+			tail = tail[len(tail)-4096:]
+		}
+		logger.Warn(w.ctx, "Scheduler log stream lost — output not streamed (available in local log file)",
+			slog.Int("buffered-bytes", len(w.buffer)),
+			slog.String("output-tail", string(tail)),
+		)
+		w.buffer = w.buffer[:0]
+	}
 
 	// Send final marker if stream was initialized
 	if w.stream != nil {

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -243,6 +243,13 @@ func (w *stepLogWriter) Write(p []byte) (int, error) {
 				return len(p), err
 			}
 		}
+		// Guard against unbounded growth when no newlines appear
+		// (progress bars, base64 blobs, minified JSON).
+		if len(w.buffer) >= logBufferSize {
+			if err := w.flush(); err != nil {
+				return len(p), err
+			}
+		}
 	} else {
 		// Buffered mode: flush at 32KB threshold
 		if len(w.buffer) >= logBufferSize {
@@ -547,10 +554,9 @@ func (w *schedulerLogWriter) Close() error {
 	}
 	w.closed = true
 
-	// Flush any remaining buffered data (best-effort streaming)
-	if err := w.flush(); err != nil {
-		logger.Warn(w.ctx, "Scheduler log streaming failed at close", tag.Error(err))
-	}
+	// Flush any remaining buffered data (best-effort streaming).
+	// Errors are surfaced via the tail-logging block below.
+	_ = w.flush()
 
 	// Log tail if stream is dead but buffer has data — still available in local file.
 	if w.stream == nil && len(w.buffer) > 0 {

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -4,6 +4,7 @@
 package coordreport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
@@ -92,12 +94,15 @@ func (s *LogStreamer) openStream(ctx context.Context) (coordinatorv1.Coordinator
 // NewStepWriter creates a writer that streams to coordinator
 // streamType should be execution.StreamTypeStdout or execution.StreamTypeStderr
 func (s *LogStreamer) NewStepWriter(ctx context.Context, stepName string, streamType int) io.WriteCloser {
+	mode := runtime.GetOutputBuffering(ctx)
 	return &stepLogWriter{
-		ctx:        ctx,
-		streamer:   s,
-		stepName:   stepName,
-		streamType: streamType,
-		buffer:     make([]byte, 0, logBufferSize),
+		ctx:          ctx,
+		streamer:     s,
+		stepName:     stepName,
+		streamType:   streamType,
+		buffer:       make([]byte, 0, logBufferSize),
+		lineBuffered: mode == core.OutputBufferingLine,
+		unbuffered:   mode == core.OutputBufferingNone,
 	}
 }
 
@@ -202,6 +207,8 @@ type stepLogWriter struct {
 	mu               sync.Mutex
 	closed           bool
 	streamInitFailed bool // Tracks permanent stream initialization failure
+	lineBuffered     bool // Flush on newline characters
+	unbuffered       bool // Flush immediately on every Write
 }
 
 // Write implements io.Writer
@@ -213,36 +220,51 @@ func (w *stepLogWriter) Write(p []byte) (int, error) {
 		return 0, io.ErrClosedPipe
 	}
 
-	w.buffer = append(w.buffer, p...)
-
-	// Flush when buffer exceeds threshold
-	if len(w.buffer) >= logBufferSize {
-		if err := w.flush(); err != nil {
-			// Log streaming is best-effort - don't fail the command
-			logger.Warn(w.ctx, "Failed to stream logs, discarding buffer",
-				tag.Error(err),
-				tag.Step(w.stepName),
-			)
-			w.buffer = w.buffer[:0] // Discard to prevent memory growth
-		}
+	if w.unbuffered {
+		// Flush every Write immediately
+		return len(p), w.sendChunk(p)
 	}
 
+	w.buffer = append(w.buffer, p...)
+
+	if w.lineBuffered {
+		// Flush complete lines, keep trailing partial data
+		for {
+			idx := bytes.IndexByte(w.buffer, '\n')
+			if idx < 0 {
+				break
+			}
+			// Advance past the line before sending, so a send failure
+			// doesn't cause the same line to be retried on the next Write.
+			line := w.buffer[:idx+1]
+			w.buffer = w.buffer[idx+1:]
+			if err := w.sendChunk(line); err != nil {
+				return len(p), err
+			}
+		}
+	} else {
+		// Buffered mode: flush at 32KB threshold
+		if len(w.buffer) >= logBufferSize {
+			if err := w.flush(); err != nil {
+				return len(p), err
+			}
+		}
+	}
 	return len(p), nil
 }
 
-// flush sends buffered data to coordinator.
-// Implements chunk splitting for large buffers to stay within gRPC message size limits.
-// Sequence numbers are only incremented after successful Send to avoid gaps.
-func (w *stepLogWriter) flush() error {
-	if len(w.buffer) == 0 {
+// sendChunk sends a single chunk of data via the gRPC stream.
+// It handles stream initialization, chunk splitting for large payloads,
+// and marks the stream as dead on send errors.
+// Caller must hold w.mu.
+func (w *stepLogWriter) sendChunk(data []byte) error {
+	if len(data) == 0 {
 		return nil
 	}
 
 	// Check for permanent stream initialization failure
 	if w.streamInitFailed {
-		// Clear buffer to prevent memory growth on permanent failure
-		w.buffer = w.buffer[:0]
-		return nil // Silently fail - already logged on first failure
+		return nil // Silently drop — already logged on first failure
 	}
 
 	// Initialize stream if needed
@@ -256,15 +278,11 @@ func (w *stepLogWriter) flush() error {
 				tag.Error(err),
 				tag.Step(w.stepName),
 			)
-			w.buffer = w.buffer[:0] // Discard to prevent memory growth
 			return err
 		}
 	}
 
-	// Split buffer into chunks if necessary to stay within gRPC limits
-	data := w.buffer
-	w.buffer = w.buffer[:0]
-
+	// Split data into chunks if necessary to stay within gRPC limits
 	for len(data) > 0 {
 		chunkSize := min(len(data), maxChunkSize)
 
@@ -290,12 +308,27 @@ func (w *stepLogWriter) flush() error {
 		}
 
 		if err := w.stream.Send(chunk); err != nil {
-			return err // Return error without incrementing sequence
+			w.stream = nil // Mark stream as dead
+			return err
 		}
 		w.sequence = nextSeq // Only increment after successful Send
 	}
 
 	return nil
+}
+
+// flush sends all buffered data to the coordinator.
+// This is used in buffered mode when the buffer exceeds the threshold.
+// Caller must hold w.mu.
+func (w *stepLogWriter) flush() error {
+	if len(w.buffer) == 0 {
+		return nil
+	}
+
+	data := w.buffer
+	w.buffer = w.buffer[:0]
+
+	return w.sendChunk(data)
 }
 
 // Close implements io.Closer
@@ -310,10 +343,13 @@ func (w *stepLogWriter) Close() error {
 
 	var firstErr error
 
-	// Flush any remaining data
-	if err := w.flush(); err != nil {
-		logger.Error(w.ctx, "Failed to flush log buffer", tag.Error(err))
-		firstErr = err
+	// Flush any remaining buffered data
+	if len(w.buffer) > 0 {
+		if err := w.sendChunk(w.buffer); err != nil {
+			logger.Error(w.ctx, "Failed to flush log buffer", tag.Error(err))
+			firstErr = err
+		}
+		w.buffer = w.buffer[:0]
 	}
 
 	// Send final marker

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -4,6 +4,7 @@
 package coordreport_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -187,6 +188,108 @@ func TestLogStreamer_FinalChunksIncludeOwnerCoordinatorID(t *testing.T) {
 	for _, chunk := range schedulerStream.getSentChunks() {
 		assert.Equal(t, owner.ID, chunk.OwnerCoordinatorId)
 	}
+}
+
+func TestSchedulerLogWriter_StreamFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteSucceedsWhenStreamFails", func(t *testing.T) {
+		t.Parallel()
+
+		mockStream := &mockStreamLogsClient{sendErr: errors.New("connection reset")}
+		client := &logStreamerMockClient{
+			streamLogsFunc: func(context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+				return mockStream, nil
+			},
+		}
+		streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+		localFile, err := os.CreateTemp(t.TempDir(), "sched-*.log")
+		require.NoError(t, err)
+		defer func() { _ = localFile.Close() }()
+
+		w := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+		_, err = w.Write([]byte("some output\n"))
+		require.NoError(t, err, "Write must not fail when gRPC streaming fails")
+		_ = w.Close()
+
+		_, _ = localFile.Seek(0, 0)
+		got, err := io.ReadAll(localFile)
+		require.NoError(t, err)
+		assert.Equal(t, "some output\n", string(got))
+	})
+
+	t.Run("BufferCappedOnRepeatedStreamFailures", func(t *testing.T) {
+		t.Parallel()
+
+		mockStream := &mockStreamLogsClient{sendErr: errors.New("unavailable")}
+		client := &logStreamerMockClient{
+			streamLogsFunc: func(context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+				return mockStream, nil
+			},
+		}
+		streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+		localFile, err := os.CreateTemp(t.TempDir(), "sched-*.log")
+		require.NoError(t, err)
+		defer func() { _ = localFile.Close() }()
+
+		w := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+		chunk := bytes.Repeat([]byte("x"), coordreport.LogBufferSize)
+		for i := 0; i < 10; i++ {
+			_, err := w.Write(chunk)
+			require.NoError(t, err)
+		}
+		_ = w.Close()
+
+		fi, err := localFile.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, int64(10*coordreport.LogBufferSize), fi.Size())
+	})
+
+	t.Run("NoDuplicateChunksOnStreamRecovery", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		failNext := true
+		mockStream := &mockStreamLogsClient{
+			sendFunc: func(_ int, _ *coordinatorv1.LogChunk) error {
+				mu.Lock()
+				defer mu.Unlock()
+				if failNext {
+					failNext = false
+					return errors.New("temporary failure")
+				}
+				return nil
+			},
+		}
+		openCount := atomic.Int32{}
+		client := &logStreamerMockClient{
+			streamLogsFunc: func(context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+				openCount.Add(1)
+				return mockStream, nil
+			},
+		}
+		streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+		localFile, err := os.CreateTemp(t.TempDir(), "sched-*.log")
+		require.NoError(t, err)
+		defer func() { _ = localFile.Close() }()
+
+		w := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+		chunk := bytes.Repeat([]byte("y"), coordreport.LogBufferSize)
+		_, err = w.Write(chunk)
+		require.NoError(t, err)
+		_, err = w.Write(chunk)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		var totalReceived int
+		for _, c := range mockStream.getSentChunks() {
+			if !c.IsFinal {
+				totalReceived += len(c.Data)
+			}
+		}
+		assert.Equal(t, 2*coordreport.LogBufferSize, totalReceived,
+			"stream should receive exactly 2 chunks, no duplicates from the failed first send")
+	})
 }
 
 func TestSetAttemptID(t *testing.T) {

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -12,7 +12,9 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	"github.com/dagucloud/dagu/internal/service/worker/coordreport"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -397,8 +399,9 @@ func TestWrite_FlushError_Continues(t *testing.T) {
 	data := make([]byte, coordreport.LogBufferSize)
 	n, err := writer.Write(data)
 
-	// Write should succeed even though flush failed (best-effort)
-	require.NoError(t, err)
+	// Write should report the flush error (stream marked dead)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send failed")
 	assert.Equal(t, len(data), n)
 }
 
@@ -1311,4 +1314,327 @@ func TestLogStreamer_RaceDetector(t *testing.T) {
 
 	wg.Wait()
 	assert.Greater(t, ops, int64(0))
+}
+
+// newStepWriterWithMode creates a step writer with a specific output buffering mode.
+func newStepWriterWithMode(
+	t *testing.T,
+	mode core.OutputBuffering,
+	client *logStreamerMockClient,
+) io.WriteCloser {
+	t.Helper()
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	ctx := runtime.WithOutputBuffering(context.Background(), mode)
+	return streamer.NewStepWriter(ctx, "step", exec.StreamTypeStdout)
+}
+
+func TestOutputBufferingBuffer_DefaultMode(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingBuffer, client)
+
+	// Write small data should NOT trigger flush in buffered mode
+	data := []byte("hello buffer mode")
+	n, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Empty(t, mockStream.getSentChunks(), "no chunks should be sent for small writes in buffer mode")
+
+	// Write enough to exceed 32KB threshold
+	largeData := make([]byte, coordreport.LogBufferSize)
+	for i := range largeData {
+		largeData[i] = byte('A')
+	}
+	n, err = writer.Write(largeData)
+	require.NoError(t, err)
+	assert.Equal(t, len(largeData), n)
+	chunks := mockStream.getSentChunks()
+	require.NotEmpty(t, chunks, "should flush when buffer exceeds 32KB threshold")
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingLine_FlushesOnNewline(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// Write without newline — should NOT flush
+	data := []byte("line without newline")
+	n, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Empty(t, mockStream.getSentChunks(), "no flush without newline in line mode")
+
+	// Write newline — should flush the complete line
+	n, err = writer.Write([]byte("\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 1)
+	assert.Equal(t, []byte("line without newline\n"), chunks[0].Data)
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingLine_MultiLineFlushesEachLine(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// Write multiple lines in a single Write call
+	data := []byte("line1\nline2\nline3\n")
+	n, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+
+	// Each line should be flushed separately
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 3)
+	assert.Equal(t, []byte("line1\n"), chunks[0].Data)
+	assert.Equal(t, []byte("line2\n"), chunks[1].Data)
+	assert.Equal(t, []byte("line3\n"), chunks[2].Data)
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingLine_PartialLineFlushedOnClose(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// Write data without trailing newline
+	data := []byte("partial line")
+	n, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Empty(t, mockStream.getSentChunks(), "no flush without newline")
+
+	// Close should flush remaining buffer
+	require.NoError(t, writer.Close())
+
+	chunks := mockStream.getSentChunks()
+	require.GreaterOrEqual(t, len(chunks), 1)
+	assert.Equal(t, []byte("partial line"), chunks[0].Data)
+}
+
+func TestOutputBufferingLine_MixedNewlines(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// First write: "hello\nworld" — "hello\n" should flush, "world" stays buffered
+	n, err := writer.Write([]byte("hello\nworld"))
+	require.NoError(t, err)
+	assert.Equal(t, 11, n)
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 1)
+	assert.Equal(t, []byte("hello\n"), chunks[0].Data)
+
+	// Second write: "!\n" — "world!\n" should flush
+	n, err = writer.Write([]byte("!\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	chunks = mockStream.getSentChunks()
+	require.Len(t, chunks, 2)
+	assert.Equal(t, []byte("world!\n"), chunks[1].Data)
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingNone_FlushesEveryWrite(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingNone, client)
+
+	// Every write should flush immediately
+	data1 := []byte("first write")
+	n, err := writer.Write(data1)
+	require.NoError(t, err)
+	assert.Equal(t, len(data1), n)
+
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 1)
+	assert.Equal(t, data1, chunks[0].Data)
+
+	data2 := []byte("second write")
+	n, err = writer.Write(data2)
+	require.NoError(t, err)
+	assert.Equal(t, len(data2), n)
+
+	chunks = mockStream.getSentChunks()
+	require.Len(t, chunks, 2)
+	assert.Equal(t, data2, chunks[1].Data)
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingNone_EmptyWrite(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingNone, client)
+
+	// Empty write should produce no chunks
+	n, err := writer.Write([]byte{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	chunks := mockStream.getSentChunks()
+	assert.Empty(t, chunks, "empty write should not send chunks")
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingLine_EmptyLines(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// Empty lines should flush individually
+	n, err := writer.Write([]byte("\n\n\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 3)
+	assert.Equal(t, []byte("\n"), chunks[0].Data)
+	assert.Equal(t, []byte("\n"), chunks[1].Data)
+	assert.Equal(t, []byte("\n"), chunks[2].Data)
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingLine_SendError(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{
+		sendErr: errors.New("line send failed"),
+	}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingLine, client)
+
+	// Write a line — should fail on send
+	n, err := writer.Write([]byte("line\n"))
+	assert.Equal(t, 5, n)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "line send failed")
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingNone_SendError(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{
+		sendErr: errors.New("immediate send failed"),
+	}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingNone, client)
+
+	// Write should fail immediately
+	n, err := writer.Write([]byte("data"))
+	assert.Equal(t, 4, n)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "immediate send failed")
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBuffering_BackwardCompatibility(t *testing.T) {
+	t.Parallel()
+	// When no outputBuffering is set in context, behavior should be identical to old 32KB buffered mode
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	// Use default context (no buffering mode set) — should default to buffer mode
+	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout)
+
+	// Small data should NOT flush
+	data := []byte("small data")
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	assert.Empty(t, mockStream.getSentChunks())
+
+	// 32KB should flush
+	largeData := make([]byte, coordreport.LogBufferSize)
+	_, err = writer.Write(largeData)
+	require.NoError(t, err)
+	assert.NotEmpty(t, mockStream.getSentChunks())
+
+	require.NoError(t, writer.Close())
+}
+
+func TestOutputBufferingNone_CloseWithData(t *testing.T) {
+	t.Parallel()
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	writer := newStepWriterWithMode(t, core.OutputBufferingNone, client)
+
+	// Write data (already flushed immediately)
+	_, _ = writer.Write([]byte("data1"))
+	_, _ = writer.Write([]byte("data2"))
+
+	// Close should not re-send already-flushed data (only final marker)
+	require.NoError(t, writer.Close())
+
+	// Should have: data1 chunk, data2 chunk, final marker
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 3)
+	assert.Equal(t, []byte("data1"), chunks[0].Data)
+	assert.Equal(t, []byte("data2"), chunks[1].Data)
+	assert.True(t, chunks[2].IsFinal)
 }

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -234,7 +234,7 @@ func TestSchedulerLogWriter_StreamFailure(t *testing.T) {
 
 		w := streamer.NewSchedulerLogWriter(context.Background(), localFile)
 		chunk := bytes.Repeat([]byte("x"), coordreport.LogBufferSize)
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			_, err := w.Write(chunk)
 			require.NoError(t, err)
 		}

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -405,7 +405,7 @@ func TestWrite_FlushError_Continues(t *testing.T) {
 	assert.Equal(t, len(data), n)
 }
 
-func TestWrite_FlushError_ClearsBuffer(t *testing.T) {
+func TestWrite_FlushError_PreservesBuffer(t *testing.T) {
 	t.Parallel()
 	mockStream := &mockStreamLogsClient{
 		sendErr: errors.New("send failed"),
@@ -423,9 +423,9 @@ func TestWrite_FlushError_ClearsBuffer(t *testing.T) {
 	data := make([]byte, coordreport.LogBufferSize)
 	_, _ = writer.Write(data)
 
-	// Buffer should be cleared to prevent memory growth
+	// Buffer should be preserved on error so Close() can log the tail
 	snapshot := coordreport.SnapshotStepLogWriter(stepWriter)
-	assert.Equal(t, 0, snapshot.BufferLen)
+	assert.Greater(t, snapshot.BufferLen, 0)
 }
 
 func TestFlush_EmptyBuffer(t *testing.T) {
@@ -480,7 +480,7 @@ func TestFlush_StreamInitFailure(t *testing.T) {
 
 	assert.Equal(t, initErr, result.Err)
 	assert.True(t, result.StreamFailed, "streamInitFailed should be set")
-	assert.Equal(t, 0, result.BufferLen, "buffer should be cleared")
+	assert.Greater(t, result.BufferLen, 0, "buffer should be preserved on init failure — Close() will handle it")
 }
 
 func TestFlush_AfterInitFailure(t *testing.T) {


### PR DESCRIPTION
Closes #2310

## Summary

Adds an `output_buffering` option to both DAG and Step configurations that controls how step output is buffered before being flushed to the log stream.

### Three modes:
| Mode | Behavior | Use case |
|---|---|---|
| `buffer` *(default)* | Accumulates until 32KB threshold (gRPC) / bufio.Writer (local) | High-throughput, batch output |
| `line` | Flushes on every newline character | Interactive CLI tools, PHP, real-time log streaming |
| `none` | Flushes every Write() call immediately | Maximum real-time (high gRPC overhead) |

### Backward compatible
Default `"buffer"` preserves existing behavior for all existing DAGs — no migration needed.

### Changes (9 files, +485/-35)
- `internal/core/output_buffering.go` — new enum type + constants
- `internal/core/step.go` — added `OutputBuffering` field to Step
- `internal/core/dag.go` — added `OutputBuffering` to DAG + `EffectiveOutputBuffering()`
- `internal/runtime/context.go` — context helpers for threading buffering mode
- `internal/runtime/output.go` — wire mode into remote writer setup
- `internal/service/worker/coordreport/log_streamer.go` — **critical fix**: Write() supports all three modes, new sendChunk() helper
- `internal/cmn/schema/dag.schema.json` — added output_buffering property

### Tests
- 13 new tests covering all three modes (buffer threshold, line flush, unbuffered immediate, Close behavior, error propagation)
- All 42 existing test packages continue to pass

### Root cause fix
The `stepLogWriter` previously only flushed at 32KB, causing:
- Output delayed until step completion (success case)
- Output silently lost on worker errors (failure case)

With `output_buffering: "line"`, output streams in real-time. With `output_buffering: "none"`, every Write() is immediately sent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `output_buffering` to DAGs and Steps to control how step logs flush across gRPC streams, local files, and executors. `line` and `none` stream in real time by bypassing `os/exec`’s 32KB buffer; buffered output is kept on stream loss and writers flush on all exit paths (implements #2310).

- **New Features**
  - `output_buffering` at DAG and Step with modes: buffer (default), line, none; Step overrides DAG; effective mode computed via `EffectiveOutputBuffering`; spec/schema updated with tests.
  - Mode propagated through runtime context and to executors via `OutputBufferingAware`; command and multi-command executors use `StdoutPipe`/`StderrPipe` and `streamPipe()` for line/none.
  - Local writers now honor the mode with new line-buffered and direct writers; remote step writers use line-buffered or unbuffered paths accordingly.

- **Bug Fixes**
  - Remote step writer: line flushes per newline; none flushes per write; preserve buffered data on gRPC failure, log last 4KB on Close, mark stream dead, advance sequence only on successful sends.
  - Scheduler writer: caps buffer and compacts to avoid duplicate chunks after reconnect; marks stream dead on send errors; fewer duplicate warnings.
  - Ensure output writers flush and close on all node exit paths (early failure, skip, panic).

<sup>Written for commit f8fce2d79c4f814de5535f43d1ceb440d2cba71a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added output buffering configuration to control how step stdout/stderr is flushed to logs. Three modes available: `buffer` (default), `line` (flush on newlines), and `none` (immediate flush). Configurable at DAG level with per-step overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->