### PR TITLE
fix: use configured Location for all schedule evaluations #2312

### DIFF
--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -250,7 +250,7 @@ func (tp *TickPlanner) Init(ctx context.Context, dags []*core.DAG) error {
 	}
 	stateChanged := pruned > 0
 
-	observedAt := tp.cfg.Clock()
+	observedAt := tp.cfg.Clock().In(tp.cfg.Location)
 	for _, dag := range dags {
 		current := state.DAGs[dag.Name]
 		next, changed := reconcileOneOffState(current, dag, observedAt)
@@ -485,6 +485,10 @@ func (tp *TickPlanner) Plan(ctx context.Context, now time.Time) []PlannedRun {
 			hasStartCandidate bool
 		)
 
+		// All schedule evaluations use the configured Location so that
+		// cron evaluation matches the wall-clock time the user expects.
+		evalTime := now.In(tp.cfg.Location)
+
 		// Evaluate pending one-off schedules.
 		for _, schedule := range entry.dag.Schedule {
 			if !schedule.IsOneOff() {
@@ -497,7 +501,7 @@ func (tp *TickPlanner) Plan(ctx context.Context, now time.Time) []PlannedRun {
 			}
 
 			oneOffState, ok := tp.pendingOneOffState(entry.dag.Name, fingerprint)
-			if !ok || oneOffState.ScheduledTime.After(now) {
+			if !ok || oneOffState.ScheduledTime.After(evalTime) {
 				continue
 			}
 
@@ -513,13 +517,11 @@ func (tp *TickPlanner) Plan(ctx context.Context, now time.Time) []PlannedRun {
 		}
 
 		// Evaluate cron schedules for live start runs.
-		// Start schedules use raw `now`: the robfig/cron library applies the
-		// schedule's timezone internally, so no extra conversion is needed.
 		for _, schedule := range entry.dag.Schedule {
 			if !schedule.IsCron() {
 				continue
 			}
-			next, due := scheduleDueAt(schedule, now)
+			next, due := scheduleDueAt(schedule, evalTime)
 			if !due {
 				continue
 			}
@@ -538,10 +540,6 @@ func (tp *TickPlanner) Plan(ctx context.Context, now time.Time) []PlannedRun {
 		}
 
 		// Evaluate stop schedules.
-		// Stop and restart schedules convert `now` to the configured Location so
-		// that the cron evaluation matches the wall-clock time the user expects.
-		// This preserves parity with the legacy invokeJobs implementation.
-		evalTime := now.In(tp.cfg.Location)
 		for _, schedule := range entry.dag.StopSchedule {
 			next, due := scheduleDueAt(schedule, evalTime)
 			if !due {
@@ -1225,7 +1223,7 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, dag *core.DAG) bool 
 	}
 	tp.mu.RUnlock()
 
-	now := tp.cfg.Clock()
+	now := tp.cfg.Clock().In(tp.cfg.Location)
 
 	replayFrom := ComputeReplayFrom(dag.CatchupWindow, lastTick, lastScheduledTime, now)
 	missed := ComputeMissedIntervals(dag.Schedule, replayFrom, now)


### PR DESCRIPTION
Closes #2312

## Problem

The scheduler had a timezone asymmetry: start schedules and one-off schedules used raw `now` (system clock time) while stop/restart schedules converted `now` to the configured `cfg.Location`. When `DAGU_TZ` is configured to a different timezone than the server's local time, start schedules, one-off schedules, and catchup computations fire at the wrong wall-clock time.

## Root Cause

The misleading comment in `tick_planner.go` claimed robfig/cron applies the schedule's timezone internally — but the 5-field standard parser has no timezone support (no `CRON_TZ=`).

Additionally, `os.Setenv("TZ", cfg.TZ)` partially masks the bug by making `time.Local == cfg.Location`, but any code path that creates times without going through `time.Now()` (persisted watermarks, replay times, concurrent access) carries the wrong location.

## Fix

Use `now.In(tp.cfg.Location)` consistently for ALL schedule evaluations:

| Location | Change |
|---|---|
| `Plan()` start schedules | `now` → `evalTime` (now.In(cfg.Location)) |
| `Plan()` one-off schedules | `now` → `evalTime` |
| `Init()` one-off reconciliation | `tp.cfg.Clock()` → `tp.cfg.Clock().In(tp.cfg.Location)` |
| `recomputeBuffer()` catchup | `tp.cfg.Clock()` → `tp.cfg.Clock().In(tp.cfg.Location)` |

`evalTime` is now computed once at the top of `Plan()` and used in all four schedule loops (start, stop, restart, one-off).

## Impact

- Remote DAGs with timezone-aware schedules now evaluate correctly
- Consistent with existing stop/restart behavior
- No behavior change when `cfg.Location == time.Local`
- All existing scheduler tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a timezone mismatch in the scheduler. All schedules now use the configured location, so triggers fire at the expected wall-clock time when `DAGU_TZ` differs from the server timezone. Fixes #2312.

- **Bug Fixes**
  - Use a single `evalTime := now.In(tp.cfg.Location)` for all checks in `Plan()` (cron start and one-off).
  - Convert `tp.cfg.Clock()` to `tp.cfg.Location` in `Init()` reconciliation and `recomputeBuffer()` catchup.
  - Avoid relying on `robfig/cron` 5-field parser for timezone handling; no change when `cfg.Location == time.Local`.

<sup>Written for commit 7249a674fd423c0919e777b3e150d2689d536cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler timing evaluation to consistently apply configured timezone settings across all schedule due-time checks. Resolves potential timing misalignment issues when using non-UTC timezones for schedule execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->