### PR TITLE
fix: use configured timezone for webui next run

### DIFF
--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -2047,6 +2047,11 @@ func (a *API) projectNextRun(ctx context.Context, dag *core.DAG) *time.Time {
 }
 
 func (a *API) nextRunProjection(ctx context.Context) func(*core.DAG, time.Time) time.Time {
+	location := time.Local
+	if a.config != nil && a.config.Core.Location != nil {
+		location = a.config.Core.Location
+	}
+
 	var schedulerState *scheduler.SchedulerState
 	if a.schedulerStateStore != nil {
 		state, loadErr := a.schedulerStateStore.Load(ctx)
@@ -2058,7 +2063,7 @@ func (a *API) nextRunProjection(ctx context.Context) func(*core.DAG, time.Time) 
 	}
 
 	return func(dag *core.DAG, now time.Time) time.Time {
-		return scheduler.NextPlannedRun(dag, now, schedulerState)
+		return scheduler.NextPlannedRun(dag, now.In(location), schedulerState)
 	}
 }
 

--- a/internal/service/frontend/api/v1/dags_internal_test.go
+++ b/internal/service/frontend/api/v1/dags_internal_test.go
@@ -117,6 +117,40 @@ steps:
 	require.True(t, listResp.Dags[0].NextRun.Equal(*sseResp.Dags[0].NextRun))
 }
 
+func TestNextRunProjectionUsesConfiguredLocation(t *testing.T) {
+	t.Parallel()
+
+	helper := test.Setup(t, test.WithStatusPersistence())
+	est := time.FixedZone("EST", -5*3600)
+	helper.Config.Core.Location = est
+
+	schedule, err := core.NewCronSchedule("0 15 * * *")
+	require.NoError(t, err)
+
+	dag := &core.DAG{
+		Name:     "timezone-next-run-dag",
+		Schedule: []core.Schedule{schedule},
+	}
+
+	api := localapi.New(
+		helper.DAGStore,
+		helper.DAGRunStore,
+		helper.QueueStore,
+		helper.ProcStore,
+		helper.DAGRunMgr,
+		helper.Config,
+		nil,
+		helper.ServiceRegistry,
+		nil,
+		nil,
+	)
+
+	now := time.Date(2026, 2, 7, 20, 30, 0, 0, time.UTC)
+	next := localapi.NextRunProjectionForTest(context.Background(), api)(dag, now)
+
+	require.Equal(t, time.Date(2026, 2, 8, 15, 0, 0, 0, est), next)
+}
+
 func TestGetDAGsListDataUsesConfiguredListDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/api/v1/export_test.go
+++ b/internal/service/frontend/api/v1/export_test.go
@@ -3,7 +3,13 @@
 
 package api
 
-// Export internal functions for testing
+import (
+	"context"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+)
+
 var (
 	ExtractWebhookToken         = extractWebhookToken
 	MarshalWebhookPayload       = marshalWebhookPayload
@@ -15,3 +21,7 @@ var (
 )
 
 const ArtifactTextPreviewMaxBytesForTest = artifactTextPreviewMaxBytes
+
+func NextRunProjectionForTest(ctx context.Context, a *API) func(*core.DAG, time.Time) time.Time {
+	return a.nextRunProjection(ctx)
+}

--- a/internal/service/frontend/api/v1/export_test.go
+++ b/internal/service/frontend/api/v1/export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 )
 
+// Test exports expose internal helpers to external-package tests.
 var (
 	ExtractWebhookToken         = extractWebhookToken
 	MarshalWebhookPayload       = marshalWebhookPayload
@@ -20,8 +21,10 @@ var (
 	BuildArtifactPreviewForTest = buildArtifactPreview
 )
 
+// ArtifactTextPreviewMaxBytesForTest exposes the artifact preview size limit to external-package tests.
 const ArtifactTextPreviewMaxBytesForTest = artifactTextPreviewMaxBytes
 
+// NextRunProjectionForTest returns the API next-run projector for external-package tests.
 func NextRunProjectionForTest(ctx context.Context, a *API) func(*core.DAG, time.Time) time.Time {
 	return a.nextRunProjection(ctx)
 }


### PR DESCRIPTION
## Summary
- use the configured Core location when projecting API nextRun values for DAG list/details/spec responses
- add regression coverage for non-UTC next-run projection

## Testing
- go test ./internal/service/frontend/api/v1 -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the configured Core timezone for next-run calculations in the Web UI. DAG list, details, and spec now show correct next-run times when not using UTC.

- **Bug Fixes**
  - Convert the scheduler “now” to `config.Core.Location` (fallback to `time.Local`) before computing next run.
  - Added regression test for non-UTC projections and exported `NextRunProjectionForTest` with docs for clearer test use.

<sup>Written for commit e9bda08869016eb4ecc463921ce3551c6a6ed86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled “next planned run” projections now respect the configured timezone/location, ensuring DAG scheduling times are computed in the expected regional context.

* **Tests**
  * Added coverage to verify next-run projection uses the configured core timezone.
  * Exposed an internal projection helper to support the new timezone-focused test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->