### PR TITLE
feat: implement parallel foreach spec

### DIFF
--- a/conformance/spec018_parallel_foreach/parallel_foreach_test.go
+++ b/conformance/spec018_parallel_foreach/parallel_foreach_test.go
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec018_parallel_foreach_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/harness"
+)
+
+func TestParallelValidation(t *testing.T) {
+	t.Parallel()
+
+	validCases := []string{
+		"parallel_flat_mapping_valid.yaml",
+	}
+	for _, file := range validCases {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", file)
+			result.ExpectExitCode(0)
+			result.ExpectStdout("")
+			result.ExpectStderr("")
+		})
+	}
+
+	invalidCases := []struct {
+		file        string
+		stderrParts []string
+	}{
+		{
+			file:        "parallel_unknown_object_field.yaml",
+			stderrParts: []string{"parallel", "unexpected"},
+		},
+		{
+			file:        "parallel_max_concurrent_float.yaml",
+			stderrParts: []string{"parallel.max_concurrent", "integer"},
+		},
+		{
+			file:        "parallel_max_concurrent_too_high.yaml",
+			stderrParts: []string{"parallel.max_concurrent", "1000"},
+		},
+		{
+			file:        "parallel_nested_mapping_item.yaml",
+			stderrParts: []string{"parallel"},
+		},
+		{
+			file:        "parallel_nested_array_item.yaml",
+			stderrParts: []string{"parallel"},
+		},
+	}
+	for _, tc := range invalidCases {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", tc.file)
+			result.ExpectExitCode(1)
+			result.ExpectStdout("")
+			result.ExpectStderrContains(tc.stderrParts...)
+			result.ExpectStderrNotContains("Usage:")
+		})
+	}
+}
+
+func TestParallelDAGRunRuntime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("object items use item fields and duplicate child runs coalesce", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "parallel_dag_run_object_items.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContains(
+			"parallel-object-results.txt",
+			`"total": 2`,
+			`"succeeded": 2`,
+			`"CHILD_VALUE": "acct-1/us"`,
+			`"CHILD_VALUE": "acct-2/eu"`,
+		)
+	})
+
+	t.Run("string item source parses runtime params", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "parallel_string_items.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContains(
+			"parallel-string-results.txt",
+			`"total": 2`,
+			`"succeeded": 2`,
+			`"CHILD_VALUE": "alpha"`,
+			`"CHILD_VALUE": "beta"`,
+		)
+	})
+}
+
+func TestForeachValidation(t *testing.T) {
+	t.Parallel()
+
+	validCases := []string{
+		"foreach_success_collect.yaml",
+		"foreach_string_items.yaml",
+		"foreach_zero_items.yaml",
+	}
+	for _, file := range validCases {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", file)
+			result.ExpectExitCode(0)
+			result.ExpectStdout("")
+			result.ExpectStderr("")
+		})
+	}
+}
+
+func TestForeachRuntime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runs inline body with item scope and collect output", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "foreach_success_collect.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContains(
+			"foreach-success-results.txt",
+			`"total":2`,
+			`"succeeded":2`,
+			`"failed":0`,
+			`"key":"one"`,
+			`"key":"two"`,
+			`"markdown":"https://example.com/one"`,
+			`"markdown":"https://example.com/two"`,
+		)
+	})
+
+	t.Run("string item source must resolve to json array", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "foreach_string_items.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContains(
+			"foreach-string-results.txt",
+			`"total":2`,
+			`"markdown":"alpha"`,
+			`"markdown":"beta"`,
+		)
+	})
+
+	t.Run("zero items succeeds with empty output arrays", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "foreach_zero_items.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContains(
+			"foreach-zero-results.txt",
+			`"total":0`,
+			`"succeeded":0`,
+			`"items":[]`,
+			`"outputs":[]`,
+		)
+	})
+
+	t.Run("duplicate keys fail before body starts", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "foreach_duplicate_keys.yaml")
+		result.ExpectExitCode(1)
+		result.ExpectStderrContains("duplicate foreach item key")
+		dagu.ExpectNoFile("foreach-duplicate-body-ran.txt")
+	})
+
+	t.Run("non json string item source fails", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "foreach_non_json_string_items.yaml")
+		result.ExpectExitCode(1)
+		result.ExpectStderrContains("foreach.items string must resolve to a JSON array")
+		dagu.ExpectNoFile("foreach-non-json-ran.txt")
+	})
+}

--- a/conformance/spec018_parallel_foreach/testdata/foreach_duplicate_keys.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/foreach_duplicate_keys.yaml
@@ -1,0 +1,13 @@
+working_dir: .
+steps:
+  - name: each
+    foreach:
+      items:
+        - slug: duplicate
+        - slug: duplicate
+      key: ${foreach.item.slug}
+      steps:
+        - id: should_not_run
+          run: |
+            printf 'ran\n' > foreach-duplicate-body-ran.txt
+    output: FOREACH_RESULTS

--- a/conformance/spec018_parallel_foreach/testdata/foreach_non_json_string_items.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/foreach_non_json_string_items.yaml
@@ -1,0 +1,13 @@
+params:
+  - name: episodes
+    default: alpha,beta
+working_dir: .
+steps:
+  - name: each
+    foreach:
+      items: ${params.episodes}
+      steps:
+        - id: should_not_run
+          run: |
+            printf 'ran\n' > foreach-non-json-ran.txt
+    output: FOREACH_RESULTS

--- a/conformance/spec018_parallel_foreach/testdata/foreach_string_items.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/foreach_string_items.yaml
@@ -1,0 +1,21 @@
+params:
+  - name: episodes
+    default: '["alpha","beta"]'
+working_dir: .
+steps:
+  - name: each
+    foreach:
+      items: ${params.episodes}
+      max_concurrent: 2
+      steps:
+        - id: summarize
+          run: |
+            printf '%s\n' '${foreach.item}'
+          output: BODY_RESULT
+      collect:
+        markdown: ${summarize.output}
+    output: FOREACH_RESULTS
+  - name: consume
+    depends: each
+    run: |
+      printf '%s\n' "$FOREACH_RESULTS" > foreach-string-results.txt

--- a/conformance/spec018_parallel_foreach/testdata/foreach_success_collect.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/foreach_success_collect.yaml
@@ -1,0 +1,24 @@
+working_dir: .
+steps:
+  - name: each
+    foreach:
+      items:
+        - slug: one
+          url: https://example.com/one
+        - slug: two
+          url: https://example.com/two
+      as: episode
+      key: ${foreach.episode.slug}
+      max_concurrent: 2
+      steps:
+        - id: summarize
+          run: |
+            printf '%s\n' '${foreach.episode.url}'
+          output: BODY_RESULT
+      collect:
+        markdown: ${summarize.output}
+    output: FOREACH_RESULTS
+  - name: consume
+    depends: each
+    run: |
+      printf '%s\n' "$FOREACH_RESULTS" > foreach-success-results.txt

--- a/conformance/spec018_parallel_foreach/testdata/foreach_zero_items.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/foreach_zero_items.yaml
@@ -1,0 +1,14 @@
+working_dir: .
+steps:
+  - name: each
+    foreach:
+      items: []
+      steps:
+        - id: should_not_run
+          run: |
+            printf 'ran\n' > foreach-zero-body-ran.txt
+    output: FOREACH_RESULTS
+  - name: consume
+    depends: each
+    run: |
+      printf '%s\n' "$FOREACH_RESULTS" > foreach-zero-results.txt

--- a/conformance/spec018_parallel_foreach/testdata/parallel_dag_run_object_items.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_dag_run_object_items.yaml
@@ -1,0 +1,35 @@
+working_dir: .
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child-object-item
+      params:
+        - value: ${ITEM.account}/${ITEM.region}
+    parallel:
+      max_concurrent: 2
+      items:
+        - account: acct-1
+          region: us
+        - account: acct-1
+          region: us
+        - account: acct-2
+          region: eu
+    output: PARALLEL_RESULTS
+  - name: consume
+    depends: fanout
+    run: |
+      printf '%s\n' "$PARALLEL_RESULTS" > parallel-object-results.txt
+
+---
+
+name: child-object-item
+params:
+  - name: value
+    description: Resolved item value.
+working_dir: .
+steps:
+  - name: write
+    run: |
+      printf '%s\n' '${params.value}'
+    output: CHILD_VALUE

--- a/conformance/spec018_parallel_foreach/testdata/parallel_flat_mapping_valid.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_flat_mapping_valid.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - account: acct-1
+          count: 2
+          enabled: true
+      max_concurrent: 1
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec018_parallel_foreach/testdata/parallel_max_concurrent_float.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_max_concurrent_float.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items: [one]
+      max_concurrent: 1.5
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec018_parallel_foreach/testdata/parallel_max_concurrent_too_high.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_max_concurrent_too_high.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items: [one]
+      max_concurrent: 1001
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec018_parallel_foreach/testdata/parallel_nested_array_item.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_nested_array_item.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - nested: [one]
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec018_parallel_foreach/testdata/parallel_nested_mapping_item.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_nested_mapping_item.yaml
@@ -1,0 +1,16 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - nested:
+            value: one
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/conformance/spec018_parallel_foreach/testdata/parallel_string_items.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_string_items.yaml
@@ -1,0 +1,31 @@
+params:
+  - name: items
+    description: Runtime item list.
+    default: '["alpha","beta"]'
+working_dir: .
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child-string-item
+      params:
+        - value: ${ITEM}
+    parallel: ${params.items}
+    output: PARALLEL_RESULTS
+  - name: consume
+    depends: fanout
+    run: |
+      printf '%s\n' "$PARALLEL_RESULTS" > parallel-string-results.txt
+
+---
+
+name: child-string-item
+params:
+  - name: value
+    description: Resolved item value.
+working_dir: .
+steps:
+  - name: write
+    run: |
+      printf '%s\n' '${params.value}'
+    output: CHILD_VALUE

--- a/conformance/spec018_parallel_foreach/testdata/parallel_unknown_object_field.yaml
+++ b/conformance/spec018_parallel_foreach/testdata/parallel_unknown_object_field.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:
+      items: [one]
+      unexpected: value
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2003,7 +2003,13 @@
                   },
                   {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "type": "number" },
+                        { "type": "boolean" }
+                      ]
+                    }
                   }
                 ]
               },
@@ -2030,7 +2036,13 @@
                           },
                           {
                             "type": "object",
-                            "additionalProperties": true
+                            "additionalProperties": {
+                              "oneOf": [
+                                { "type": "string" },
+                                { "type": "number" },
+                                { "type": "boolean" }
+                              ]
+                            }
                           }
                         ]
                       },
@@ -2052,6 +2064,68 @@
             }
           ],
           "description": "Configuration for parallel execution of child DAGs. Currently only valid with action: dag.run or dag.enqueue. Allows processing multiple items concurrently using the same workflow definition."
+        },
+        "foreach": {
+          "type": "object",
+          "required": ["items", "steps"],
+          "additionalProperties": false,
+          "properties": {
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Value expression resolving to an array of items"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/stepOutputJSONValue"
+                  },
+                  "description": "Static array of JSON-compatible items"
+                }
+              ],
+              "description": "Items iterated by the foreach body"
+            },
+            "as": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+              "not": {
+                "enum": ["index", "key"]
+              },
+              "default": "item",
+              "description": "Name used for the current item in the foreach namespace"
+            },
+            "key": {
+              "type": "string",
+              "description": "Optional expression producing a stable key for each item"
+            },
+            "max_concurrent": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 10,
+              "description": "Maximum number of foreach item bodies running concurrently"
+            },
+            "steps": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/step"
+              },
+              "description": "Inline body steps executed once per item"
+            },
+            "collect": {
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^[A-Za-z][A-Za-z0-9_]*$"
+              },
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Output names mapped to value expressions evaluated after each item body"
+            }
+          },
+          "description": "Inline item-body iteration. The body steps run once for each item and may publish collected outputs."
         },
         "worker_selector": {
           "oneOf": [
@@ -2207,6 +2281,25 @@
         {
           "not": {
             "required": ["run", "action"]
+          }
+        },
+        {
+          "if": {
+            "required": ["foreach"]
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                { "required": ["run"] },
+                { "required": ["action"] },
+                { "required": ["command"] },
+                { "required": ["exec"] },
+                { "required": ["script"] },
+                { "required": ["call"] },
+                { "required": ["parallel"] },
+                { "required": ["type"] }
+              ]
+            }
           }
         },
         {
@@ -6134,6 +6227,7 @@
         "dag",
         "subworkflow",
         "parallel",
+        "foreach",
         "archive",
         "chat",
         "log",

--- a/internal/cmn/schema/dag_schema_spec018_test.go
+++ b/internal/cmn/schema/dag_schema_spec018_test.go
@@ -183,7 +183,7 @@ func mustResolveDAGSchema(t *testing.T) *jsonschema.Resolved {
 	var schema jsonschema.Schema
 	require.NoError(t, json.Unmarshal(dagschema.DAGSchemaJSON, &schema))
 
-	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{})
+	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
 	require.NoError(t, err)
 	return resolved
 }

--- a/internal/cmn/schema/dag_schema_spec018_test.go
+++ b/internal/cmn/schema/dag_schema_spec018_test.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package schema_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	dagschema "github.com/dagucloud/dagu/internal/cmn/schema"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDAGSchemaSpec018ParallelItems(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchema(t)
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "flat mapping item is valid",
+			spec: `
+steps:
+  - action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - name: alpha
+          count: 2
+          enabled: true
+`,
+		},
+		{
+			name: "nested mapping item value is invalid",
+			spec: `
+steps:
+  - action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - nested:
+            name: alpha
+`,
+			wantErr: "steps",
+		},
+		{
+			name: "nested array item value is invalid",
+			spec: `
+steps:
+  - action: dag.run
+    with:
+      dag: child
+    parallel:
+      items:
+        - nested: [alpha]
+`,
+			wantErr: "steps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := mustParseYAMLDocument(t, tt.spec)
+			err := resolved.Validate(doc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestDAGSchemaSpec018Foreach(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchema(t)
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "valid foreach body",
+			spec: `
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha, beta]
+      as: episode
+      key: ${foreach.episode}
+      max_concurrent: 2
+      steps:
+        - id: write
+          run: echo ${foreach.episode}
+      collect:
+        value: ${steps.write.stdout}
+`,
+		},
+		{
+			name: "requires steps",
+			spec: `
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha]
+`,
+			wantErr: "steps",
+		},
+		{
+			name: "rejects reserved alias",
+			spec: `
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha]
+      as: key
+      steps:
+        - run: echo ${foreach.key}
+`,
+			wantErr: "steps",
+		},
+		{
+			name: "rejects unknown field",
+			spec: `
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha]
+      mode: all
+      steps:
+        - run: echo ${foreach.item}
+`,
+			wantErr: "steps",
+		},
+		{
+			name: "rejects non string collect value",
+			spec: `
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha]
+      steps:
+        - run: echo ${foreach.item}
+      collect:
+        value: 1
+`,
+			wantErr: "steps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := mustParseYAMLDocument(t, tt.spec)
+			err := resolved.Validate(doc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func mustResolveDAGSchema(t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+
+	var schema jsonschema.Schema
+	require.NoError(t, json.Unmarshal(dagschema.DAGSchemaJSON, &schema))
+
+	resolved, err := schema.Resolve(&jsonschema.ResolveOptions{})
+	require.NoError(t, err)
+	return resolved
+}
+
+func mustParseYAMLDocument(t *testing.T, spec string) any {
+	t.Helper()
+
+	var doc any
+	require.NoError(t, yaml.Unmarshal([]byte(spec), &doc))
+	return doc
+}

--- a/internal/cmn/value/resolver.go
+++ b/internal/cmn/value/resolver.go
@@ -102,7 +102,7 @@ func (r Resolver) resolveString(ctx context.Context, raw string, field Field) (s
 }
 
 func (r Resolver) bindingScope() RuntimeScope {
-	if r.runtime.Consts != nil || r.runtime.Params != nil || r.runtime.Env != nil || len(r.runtime.Steps) > 0 || len(r.runtime.BuiltinContext.values) > 0 {
+	if r.runtime.Consts != nil || r.runtime.Params != nil || r.runtime.Env != nil || len(r.runtime.Steps) > 0 || r.runtime.Foreach != nil || len(r.runtime.BuiltinContext.values) > 0 {
 		return r.runtime
 	}
 	return RuntimeScope{Consts: r.static.Consts}

--- a/internal/cmn/value/scope.go
+++ b/internal/cmn/value/scope.go
@@ -55,6 +55,7 @@ type RuntimeScope struct {
 	Params         Values
 	Env            *EnvScope
 	Steps          map[string]StepInfo
+	Foreach        Values
 	BuiltinContext BuiltinContext
 }
 

--- a/internal/cmn/value/template.go
+++ b/internal/cmn/value/template.go
@@ -315,6 +315,8 @@ func bindingValue(ctx context.Context, path string, scope RuntimeScope, requireV
 		return bindingEnvValue(segments[1], scope.Env, requireValue)
 	case "steps":
 		return bindingStepOutputValue(ctx, segments, scope.Steps, requireValue)
+	case "foreach":
+		return bindingForeachValue(path, segments, scope.Foreach, requireValue)
 	case "context", "dag", "run", "attempt", "step", "trigger", "paths", "profile", "pushback":
 		return bindingBuiltinContextValue(path, scope.BuiltinContext, requireValue)
 	default:
@@ -365,6 +367,71 @@ func bindingMapValue(namespace, name string, values Values, requireValue bool) (
 	return value, nil
 }
 
+func bindingForeachValue(path string, segments []string, values Values, requireValue bool) (any, error) {
+	if len(values) == 0 {
+		if !requireValue {
+			return nil, nil
+		}
+		return nil, newNoticeReasonError(
+			ValueReferenceReasonNamespaceUnavailable,
+			fmt.Sprintf("%s is unavailable in this context", path),
+		)
+	}
+
+	value, ok := values[segments[1]]
+	if !ok {
+		if !requireValue {
+			return nil, nil
+		}
+		return nil, newNoticeReasonError(
+			ValueReferenceReasonNamespaceUnavailable,
+			fmt.Sprintf("%s is unavailable in this context", path),
+		)
+	}
+
+	if len(segments) == 2 {
+		return formatForeachItemValue(value), nil
+	}
+
+	field, ok := foreachObjectField(value, segments[2])
+	if !ok {
+		if !requireValue {
+			return nil, nil
+		}
+		return nil, newNoticeReasonError(
+			ValueReferenceReasonNamespaceUnavailable,
+			fmt.Sprintf("%s is unavailable in this context", path),
+		)
+	}
+	return formatForeachItemValue(field), nil
+}
+
+func foreachObjectField(value any, field string) (any, bool) {
+	switch v := value.(type) {
+	case map[string]any:
+		got, ok := v[field]
+		return got, ok
+	case map[string]string:
+		got, ok := v[field]
+		return got, ok
+	default:
+		return nil, false
+	}
+}
+
+func formatForeachItemValue(value any) any {
+	switch value.(type) {
+	case map[string]any, map[string]string, []any, []string:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return value
+		}
+		return string(data)
+	default:
+		return value
+	}
+}
+
 func bindingEnvValue(name string, scope *EnvScope, requireValue bool) (any, error) {
 	if scope == nil && !requireValue {
 		return nil, nil
@@ -392,6 +459,16 @@ func supportedStrictBinding(segments []string) bool {
 			return false
 		}
 		return validOutputPathSegment(segments[3])
+	case "foreach":
+		if len(segments) != 2 && len(segments) != 3 {
+			return false
+		}
+		for _, segment := range segments[1:] {
+			if !bindingNamePattern.MatchString(segment) {
+				return false
+			}
+		}
+		return true
 	case "context":
 		if len(segments) != 3 {
 			return false

--- a/internal/cmn/value/template_test.go
+++ b/internal/cmn/value/template_test.go
@@ -83,6 +83,53 @@ func TestExpandStringResolvesConstBindingsWithScope(t *testing.T) {
 	assert.Equal(t, "api prod /workspace repo/api:v1", got)
 }
 
+func TestExpandStringResolvesForeachBindingsWithScope(t *testing.T) {
+	t.Parallel()
+
+	resolver := value.NewResolver(
+		value.StaticScope{},
+		value.RuntimeScope{
+			Foreach: value.Values{
+				"index": "2",
+				"key":   "episode-3",
+				"episode": map[string]any{
+					"slug": "episode-3",
+					"url":  "https://example.test/episode-3",
+				},
+			},
+		},
+	)
+
+	got, err := resolver.String(
+		context.Background(),
+		"${foreach.index} ${foreach.key} ${foreach.episode.url} ${foreach.episode}",
+		value.WorkflowField("run"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, `2 episode-3 https://example.test/episode-3 {"slug":"episode-3","url":"https://example.test/episode-3"}`, got)
+}
+
+func TestExpandStringPreservesUnavailableForeachBinding(t *testing.T) {
+	t.Parallel()
+
+	var collector value.ValueReferenceNoticeCollector
+	resolver := value.NewResolver(
+		value.StaticScope{},
+		value.RuntimeScope{},
+		value.WithValueReferenceNotices(&collector),
+	)
+
+	got, err := resolver.String(
+		context.Background(),
+		"${foreach.item}",
+		value.WorkflowField("run"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "${foreach.item}", got)
+	require.Len(t, collector.Notices(), 1)
+	assert.Equal(t, value.ValueReferenceReasonNamespaceUnavailable, collector.Notices()[0].Reason)
+}
+
 func TestExpandStringDoesNotRejectFutureNamespaceShorthand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/foreach.go
+++ b/internal/core/foreach.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// ForeachConfig contains the configuration for inline item-body iteration.
+type ForeachConfig struct {
+	// Items is the static list of items to iterate.
+	Items []any `json:"items,omitempty"`
+
+	// ItemsExpr is a value-resolved expression that must produce a JSON array.
+	ItemsExpr string `json:"itemsExpr,omitempty"`
+
+	// As is the item alias exposed under the foreach namespace.
+	As string `json:"as,omitempty"`
+
+	// Key is an optional item key expression.
+	Key string `json:"key,omitempty"`
+
+	// MaxConcurrent is the maximum number of item bodies running at once.
+	MaxConcurrent int `json:"maxConcurrent,omitempty"`
+
+	// Steps is the item body graph.
+	Steps []Step `json:"steps,omitempty"`
+
+	// Collect maps output names to value-resolved expressions.
+	Collect map[string]string `json:"collect,omitempty"`
+}

--- a/internal/core/foreach_validation_spec018_test.go
+++ b/internal/core/foreach_validation_spec018_test.go
@@ -44,6 +44,43 @@ func TestValidateStepsSpec018ForeachBodyDependencyByID(t *testing.T) {
 	assert.Equal(t, []string{"First"}, dag.Steps[0].Foreach.Steps[1].Depends)
 }
 
+func TestValidateStepsSpec018ForeachBodyApprovalRewindByID(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Steps: []core.Step{
+			{
+				ID:             "loop",
+				Name:           "loop",
+				ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+				Foreach: &core.ForeachConfig{
+					Items: []any{"one"},
+					Steps: []core.Step{
+						{
+							ID:             "prepare_id",
+							Name:           "prepare",
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+						},
+						{
+							ID:             "review_id",
+							Name:           "review",
+							Depends:        []string{"prepare"},
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+							Approval: &core.ApprovalConfig{
+								RewindTo: "prepare_id",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, core.ValidateSteps(dag))
+	require.NotNil(t, dag.Steps[0].Foreach.Steps[1].Approval)
+	assert.Equal(t, "prepare", dag.Steps[0].Foreach.Steps[1].Approval.RewindTo)
+}
+
 func TestValidateStepsSpec018ForeachRejectsVisibleIdentityCollision(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +112,42 @@ func TestValidateStepsSpec018ForeachRejectsVisibleIdentityCollision(t *testing.T
 	err := core.ValidateSteps(dag)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "collides with a visible step")
+}
+
+func TestValidateStepsSpec018ForeachRejectsVisibleApprovalRewindTarget(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Steps: []core.Step{
+			{
+				ID:             "setup",
+				Name:           "setup",
+				ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+			},
+			{
+				ID:             "loop",
+				Name:           "loop",
+				ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+				Foreach: &core.ForeachConfig{
+					Items: []any{"one"},
+					Steps: []core.Step{
+						{
+							ID:             "review",
+							Name:           "review",
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+							Approval: &core.ApprovalConfig{
+								RewindTo: "setup",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := core.ValidateSteps(dag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "approval.rewind_to")
 }
 
 func TestValidateStepsSpec018ForeachRejectsTopLevelBodyDependency(t *testing.T) {

--- a/internal/core/foreach_validation_spec018_test.go
+++ b/internal/core/foreach_validation_spec018_test.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateStepsSpec018ForeachBodyDependencyByID(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Steps: []core.Step{
+			{
+				ID:             "loop",
+				Name:           "loop",
+				ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+				Foreach: &core.ForeachConfig{
+					Items: []any{"one"},
+					Steps: []core.Step{
+						{
+							ID:             "first",
+							Name:           "First",
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+						},
+						{
+							ID:             "second",
+							Name:           "Second",
+							Depends:        []string{"first"},
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, core.ValidateSteps(dag))
+	assert.Equal(t, []string{"First"}, dag.Steps[0].Foreach.Steps[1].Depends)
+}
+
+func TestValidateStepsSpec018ForeachRejectsVisibleIdentityCollision(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Steps: []core.Step{
+			{
+				ID:             "setup",
+				Name:           "setup",
+				ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+			},
+			{
+				ID:             "loop",
+				Name:           "loop",
+				ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+				Foreach: &core.ForeachConfig{
+					Items: []any{"one"},
+					Steps: []core.Step{
+						{
+							ID:             "setup",
+							Name:           "write",
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := core.ValidateSteps(dag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides with a visible step")
+}
+
+func TestValidateStepsSpec018ForeachRejectsTopLevelBodyDependency(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Steps: []core.Step{
+			{
+				ID:             "setup",
+				Name:           "setup",
+				ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+			},
+			{
+				ID:             "loop",
+				Name:           "loop",
+				Depends:        []string{"setup"},
+				ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+				Foreach: &core.ForeachConfig{
+					Items: []any{"one"},
+					Steps: []core.Step{
+						{
+							ID:             "write",
+							Name:           "write",
+							Depends:        []string{"setup"},
+							ExecutorConfig: core.ExecutorConfig{Type: "test-no-validator"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := core.ValidateSteps(dag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body dependencies must stay inside foreach.steps")
+}

--- a/internal/core/parallel.go
+++ b/internal/core/parallel.go
@@ -20,8 +20,11 @@ type ParallelConfig struct {
 	MaxConcurrent int `json:"max_concurrent,omitempty"`
 }
 
-// DefaultMaxConcurrent is the default maximum concurrent executions for parallel steps
+// DefaultMaxConcurrent is the default maximum concurrent executions for parallel steps.
 const DefaultMaxConcurrent = 10
+
+// MaxExpansionConcurrency is the maximum concurrency accepted by expansion constructs.
+const MaxExpansionConcurrency = 1000
 
 // ParallelItemVariable is the special variable name that represents the current item in parallel execution
 const ParallelItemVariable = "ITEM"

--- a/internal/core/parallel_test.go
+++ b/internal/core/parallel_test.go
@@ -157,7 +157,7 @@ steps:
       max_concurrent: 0
 `,
 			wantErr:    true,
-			wantErrMsg: "max_concurrent must be greater than 0",
+			wantErrMsg: "max_concurrent must be an integer from 1 through 1000",
 		},
 		{
 			name: "ErrorEmptyItems",

--- a/internal/core/spec/foreach_spec018_test.go
+++ b/internal/core/spec/foreach_spec018_test.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForeachSpec018LoadsModel(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(strings.TrimSpace(`
+steps:
+  - id: summarize
+    foreach:
+      items: [alpha, beta]
+      as: episode
+      key: ${foreach.episode}
+      max_concurrent: 2
+      steps:
+        - id: write
+          run: echo ${foreach.episode}
+          outputs:
+            - name: value
+      collect:
+        value: ${steps.write.outputs.value}
+    output: FOREACH_RESULTS
+`)), spec.SkipSchemaValidation(), spec.WithoutEval())
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	require.NotNil(t, step.Foreach)
+	assert.Equal(t, core.ExecutorTypeForeach, step.ExecutorConfig.Type)
+	assert.Equal(t, "episode", step.Foreach.As)
+	assert.Equal(t, "${foreach.episode}", step.Foreach.Key)
+	assert.Equal(t, 2, step.Foreach.MaxConcurrent)
+	assert.Len(t, step.Foreach.Items, 2)
+	assert.Len(t, step.Foreach.Steps, 1)
+	assert.Equal(t, "write", step.Foreach.Steps[0].ID)
+	assert.Equal(t, map[string]string{"value": "${steps.write.outputs.value}"}, step.Foreach.Collect)
+}
+
+func TestForeachSpec018ItemScopeReferencesDoNotEmitStaticNotices(t *testing.T) {
+	t.Parallel()
+
+	result, err := spec.LoadYAMLWithResult(context.Background(), []byte(strings.TrimSpace(`
+steps:
+  - id: summarize
+    foreach:
+      items: [{slug: alpha, url: https://example.test/alpha}]
+      as: episode
+      key: ${foreach.episode.slug}
+      steps:
+        - id: write
+          run: echo ${foreach.episode.url}
+      collect:
+        slug: ${foreach.episode.slug}
+`)))
+
+	require.NoError(t, err)
+	require.Empty(t, result.ValueReferenceNotices)
+}
+
+func TestForeachSpec018Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantParts []string
+	}{
+		{
+			name: "rejects mixed run selector",
+			body: `
+    run: echo no
+    foreach:
+      items: [one]
+      steps:
+        - run: echo ${foreach.item}`,
+			wantParts: []string{"foreach", "run"},
+		},
+		{
+			name: "requires items",
+			body: `
+    foreach:
+      steps:
+        - run: echo ${foreach.item}`,
+			wantParts: []string{"foreach.items"},
+		},
+		{
+			name: "requires non empty steps",
+			body: `
+    foreach:
+      items: [one]
+      steps: []`,
+			wantParts: []string{"foreach.steps"},
+		},
+		{
+			name: "rejects reserved item alias",
+			body: `
+    foreach:
+      items: [one]
+      as: key
+      steps:
+        - run: echo ${foreach.key}`,
+			wantParts: []string{"foreach.as", "key"},
+		},
+		{
+			name: "rejects non string collect value",
+			body: `
+    foreach:
+      items: [one]
+      steps:
+        - run: echo ${foreach.item}
+      collect:
+        value: 1`,
+			wantParts: []string{"foreach.collect", "string"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := spec.LoadYAML(context.Background(), []byte(strings.TrimSpace(`
+steps:
+  - name: each
+`+tt.body)), spec.SkipSchemaValidation(), spec.WithoutEval())
+			require.Error(t, err)
+			for _, part := range tt.wantParts {
+				require.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}

--- a/internal/core/spec/parallel_spec018_test.go
+++ b/internal/core/spec/parallel_spec018_test.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelSpec018Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		parallel  string
+		wantParts []string
+	}{
+		{
+			name: "rejects unknown object field",
+			parallel: `
+      items: [one]
+      unexpected: value`,
+			wantParts: []string{"parallel", "unexpected"},
+		},
+		{
+			name: "rejects max_concurrent above limit",
+			parallel: `
+      items: [one]
+      max_concurrent: 1001`,
+			wantParts: []string{"parallel.max_concurrent", "1000"},
+		},
+		{
+			name: "rejects non integer max_concurrent",
+			parallel: `
+      items: [one]
+      max_concurrent: 1.5`,
+			wantParts: []string{"parallel.max_concurrent", "integer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := spec.LoadYAML(context.Background(), []byte(strings.TrimSpace(`
+steps:
+  - name: fanout
+    action: dag.run
+    with:
+      dag: child
+    parallel:`+tt.parallel+`
+
+---
+
+name: child
+steps:
+  - name: ok
+    run: "true"
+`)), spec.SkipSchemaValidation(), spec.WithoutEval())
+			require.Error(t, err)
+			for _, part := range tt.wantParts {
+				require.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -97,6 +97,8 @@ type step struct {
 	// - Static array: parallel: [item1, item2]
 	// - Object configuration: parallel: {items: ${ITEMS}, max_concurrent: 5}
 	Parallel any `yaml:"parallel,omitempty"`
+	// Foreach specifies inline item-body iteration configuration.
+	Foreach any `yaml:"foreach,omitempty"`
 	// WorkerSelector specifies required worker labels for execution.
 	WorkerSelector map[string]string `yaml:"worker_selector,omitempty"`
 	// Env specifies the environment variables for the step.
@@ -499,8 +501,18 @@ type stepActionStage []stepActionBuilder
 var stepExecutionTargetStage = stepActionStage{
 	{"container", buildStepContainer, false},
 	{"parallel", buildStepParallel, false},
+	{"foreach", nil, false},
 	{"subDAG", buildStepSubDAG, false},
 	{"executor", buildStepExecutor, true},
+}
+
+func init() {
+	for idx := range stepExecutionTargetStage {
+		if stepExecutionTargetStage[idx].name == "foreach" {
+			stepExecutionTargetStage[idx].build = buildStepForeach
+			return
+		}
+	}
 }
 
 var stepInteractionActionStage = stepActionStage{
@@ -2252,17 +2264,20 @@ func buildStepParallel(_ StepBuildContext, s *step, result *core.Step) error {
 				case int:
 					result.Parallel.MaxConcurrent = mc
 				case int64:
+					if mc > math.MaxInt || mc < math.MinInt {
+						return core.NewValidationError("parallel.max_concurrent", mc, fmt.Errorf("value %d exceeds integer range", mc))
+					}
 					result.Parallel.MaxConcurrent = int(mc)
 				case uint64:
 					if mc > math.MaxInt {
 						return core.NewValidationError("parallel.max_concurrent", mc, fmt.Errorf("value %d exceeds maximum int", mc))
 					}
 					result.Parallel.MaxConcurrent = int(mc)
-				case float64:
-					result.Parallel.MaxConcurrent = int(mc)
 				default:
-					return core.NewValidationError("parallel.max_concurrent", val, fmt.Errorf("parallel.max_concurrent must be int, got %T", val))
+					return core.NewValidationError("parallel.max_concurrent", val, fmt.Errorf("parallel.max_concurrent must be an integer, got %T", val))
 				}
+			default:
+				return core.NewValidationError("parallel", v, fmt.Errorf("unknown parallel field %q", key))
 			}
 		}
 
@@ -2270,6 +2285,220 @@ func buildStepParallel(_ StepBuildContext, s *step, result *core.Step) error {
 		return core.NewValidationError("parallel", v, fmt.Errorf("parallel must be string, array, or object, got %T", v))
 	}
 
+	return nil
+}
+
+var foreachIdentifierPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// buildStepForeach parses the foreach field in the step definition.
+func buildStepForeach(ctx StepBuildContext, s *step, result *core.Step) error {
+	if s.Foreach == nil {
+		return nil
+	}
+
+	if err := validateForeachExecutionTarget(s); err != nil {
+		return err
+	}
+
+	cfg, err := parseForeachConfig(ctx, s.Foreach)
+	if err != nil {
+		return err
+	}
+
+	result.Foreach = cfg
+	result.ExecutorConfig.Type = core.ExecutorTypeForeach
+	return nil
+}
+
+func validateForeachExecutionTarget(s *step) error {
+	targets := map[string]bool{
+		"run":      s.Run != nil,
+		"action":   s.Action != "",
+		"command":  s.Command != nil,
+		"exec":     s.Exec != nil,
+		"script":   s.Script != "",
+		"call":     s.Call != "",
+		"parallel": s.Parallel != nil,
+		"type":     s.Type != "",
+	}
+	for name, present := range targets {
+		if present {
+			return core.NewValidationError("foreach", s.Foreach,
+				fmt.Errorf("foreach cannot be combined with %q on the same step", name))
+		}
+	}
+	return nil
+}
+
+func parseForeachConfig(ctx StepBuildContext, raw any) (*core.ForeachConfig, error) {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, core.NewValidationError("foreach", raw,
+			fmt.Errorf("foreach must be an object, got %T", raw))
+	}
+
+	cfg := &core.ForeachConfig{
+		As:            "item",
+		MaxConcurrent: core.DefaultMaxConcurrent,
+	}
+
+	for key, value := range obj {
+		switch key {
+		case "items":
+			if err := parseForeachItems(value, cfg); err != nil {
+				return nil, err
+			}
+		case "as":
+			alias, ok := value.(string)
+			if !ok {
+				return nil, core.NewValidationError("foreach.as", value,
+					fmt.Errorf("foreach.as must be a string, got %T", value))
+			}
+			if err := validateForeachIdentifier("foreach.as", alias); err != nil {
+				return nil, core.NewValidationError("foreach.as", alias, err)
+			}
+			if alias == "index" || alias == "key" {
+				return nil, core.NewValidationError("foreach.as", alias,
+					fmt.Errorf("foreach.as %q is reserved", alias))
+			}
+			cfg.As = alias
+		case "key":
+			keyExpr, ok := value.(string)
+			if !ok {
+				return nil, core.NewValidationError("foreach.key", value,
+					fmt.Errorf("foreach.key must be a string, got %T", value))
+			}
+			cfg.Key = keyExpr
+		case "max_concurrent":
+			maxConcurrent, err := parseForeachMaxConcurrent(value)
+			if err != nil {
+				return nil, err
+			}
+			cfg.MaxConcurrent = maxConcurrent
+		case "steps":
+			steps, err := parseForeachSteps(ctx, value)
+			if err != nil {
+				return nil, err
+			}
+			cfg.Steps = steps
+		case "collect":
+			collect, err := parseForeachCollect(value)
+			if err != nil {
+				return nil, err
+			}
+			cfg.Collect = collect
+		default:
+			return nil, core.NewValidationError("foreach", raw,
+				fmt.Errorf("unknown foreach field %q", key))
+		}
+	}
+
+	if cfg.ItemsExpr == "" && cfg.Items == nil {
+		return nil, core.NewValidationError("foreach.items", nil,
+			fmt.Errorf("foreach.items is required"))
+	}
+	if len(cfg.Steps) == 0 {
+		return nil, core.NewValidationError("foreach.steps", nil,
+			fmt.Errorf("foreach.steps must contain at least one step"))
+	}
+	return cfg, nil
+}
+
+func parseForeachItems(value any, cfg *core.ForeachConfig) error {
+	switch items := value.(type) {
+	case string:
+		cfg.ItemsExpr = items
+	case []any:
+		cfg.Items = slices.Clone(items)
+	default:
+		return core.NewValidationError("foreach.items", value,
+			fmt.Errorf("foreach.items must be string or array, got %T", value))
+	}
+	return nil
+}
+
+func parseForeachMaxConcurrent(value any) (int, error) {
+	var maxConcurrent int
+	switch mc := value.(type) {
+	case int:
+		maxConcurrent = mc
+	case int64:
+		if mc > math.MaxInt || mc < math.MinInt {
+			return 0, core.NewValidationError("foreach.max_concurrent", mc,
+				fmt.Errorf("value %d exceeds integer range", mc))
+		}
+		maxConcurrent = int(mc)
+	case uint64:
+		if mc > math.MaxInt {
+			return 0, core.NewValidationError("foreach.max_concurrent", mc,
+				fmt.Errorf("value %d exceeds maximum int", mc))
+		}
+		maxConcurrent = int(mc)
+	default:
+		return 0, core.NewValidationError("foreach.max_concurrent", value,
+			fmt.Errorf("foreach.max_concurrent must be an integer, got %T", value))
+	}
+	if maxConcurrent < 1 || maxConcurrent > core.MaxExpansionConcurrency {
+		return 0, core.NewValidationError("foreach.max_concurrent", value,
+			fmt.Errorf("max_concurrent must be an integer from 1 through %d", core.MaxExpansionConcurrency))
+	}
+	return maxConcurrent, nil
+}
+
+func parseForeachSteps(ctx StepBuildContext, value any) ([]core.Step, error) {
+	rawSteps, ok := value.([]any)
+	if !ok {
+		return nil, core.NewValidationError("foreach.steps", value,
+			fmt.Errorf("foreach.steps must be an array, got %T", value))
+	}
+	if len(rawSteps) == 0 {
+		return nil, core.NewValidationError("foreach.steps", value,
+			fmt.Errorf("foreach.steps must contain at least one step"))
+	}
+
+	steps := make([]core.Step, 0, len(rawSteps))
+	names := map[string]struct{}{}
+	for idx, rawStep := range rawSteps {
+		stepMap, ok := rawStep.(map[string]any)
+		if !ok {
+			return nil, core.NewValidationError("foreach.steps", rawStep,
+				fmt.Errorf("foreach.steps[%d] must be an object, got %T", idx, rawStep))
+		}
+		builtStep, err := buildStepFromRaw(ctx, idx, stepMap, names, nil)
+		if err != nil {
+			return nil, core.NewValidationError("foreach.steps", rawStep, err)
+		}
+		steps = append(steps, *builtStep)
+	}
+	return steps, nil
+}
+
+func parseForeachCollect(value any) (map[string]string, error) {
+	rawCollect, ok := value.(map[string]any)
+	if !ok {
+		return nil, core.NewValidationError("foreach.collect", value,
+			fmt.Errorf("foreach.collect must be an object, got %T", value))
+	}
+
+	collect := make(map[string]string, len(rawCollect))
+	for name, rawExpr := range rawCollect {
+		if err := validateForeachIdentifier("foreach.collect", name); err != nil {
+			return nil, core.NewValidationError("foreach.collect", name, err)
+		}
+		expr, ok := rawExpr.(string)
+		if !ok {
+			return nil, core.NewValidationError("foreach.collect", rawExpr,
+				fmt.Errorf("foreach.collect.%s must be a string, got %T", name, rawExpr))
+		}
+		collect[name] = expr
+	}
+	return collect, nil
+}
+
+func validateForeachIdentifier(fieldName, value string) error {
+	if !foreachIdentifierPattern.MatchString(value) {
+		return fmt.Errorf("%s must match %s", fieldName, foreachIdentifierPattern.String())
+	}
 	return nil
 }
 

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -1700,17 +1700,14 @@ func TestBuildStepParallel(t *testing.T) {
 				MaxConcurrent: 10,
 			},
 		},
-		{
-			name: "MaxConcurrentAsFloat64",
-			parallel: map[string]any{
-				"items":          "${ITEMS}",
-				"max_concurrent": float64(7),
+			{
+				name: "InvalidMaxConcurrentAsFloat64",
+				parallel: map[string]any{
+					"items":          "${ITEMS}",
+					"max_concurrent": float64(7),
+				},
+				wantErr: true,
 			},
-			expected: &core.ParallelConfig{
-				Variable:      "${ITEMS}",
-				MaxConcurrent: 7,
-			},
-		},
 		{
 			name:     "InvalidType",
 			parallel: 123,

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -1700,14 +1700,14 @@ func TestBuildStepParallel(t *testing.T) {
 				MaxConcurrent: 10,
 			},
 		},
-			{
-				name: "InvalidMaxConcurrentAsFloat64",
-				parallel: map[string]any{
-					"items":          "${ITEMS}",
-					"max_concurrent": float64(7),
-				},
-				wantErr: true,
+		{
+			name: "InvalidMaxConcurrentAsFloat64",
+			parallel: map[string]any{
+				"items":          "${ITEMS}",
+				"max_concurrent": float64(7),
 			},
+			wantErr: true,
+		},
 		{
 			name:     "InvalidType",
 			parallel: 123,

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -81,6 +81,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"dag_enqueue":   {},
 	"docker":        {},
 	"file":          {},
+	"foreach":       {},
 	"gha":           {},
 	"git":           {},
 	"github-action": {},

--- a/internal/core/step.go
+++ b/internal/core/step.go
@@ -94,6 +94,8 @@ type Step struct {
 	WorkerSelector map[string]string `json:"workerSelector,omitempty"`
 	// Parallel contains the configuration for parallel execution.
 	Parallel *ParallelConfig `json:"parallel,omitempty"`
+	// Foreach contains the configuration for inline item-body iteration.
+	Foreach *ForeachConfig `json:"foreach,omitempty"`
 	// Env contains environment variables for the step.
 	Env []string `json:"env,omitempty"`
 	// Params contains parameters/inputs for the step.
@@ -437,6 +439,9 @@ const (
 
 	// ExecutorTypeParallel is the executor type for parallel steps.
 	ExecutorTypeParallel = "parallel"
+
+	// ExecutorTypeForeach is the executor type for foreach steps.
+	ExecutorTypeForeach = "foreach"
 
 	// ExecutorTypeRouter is the executor type for router steps.
 	ExecutorTypeRouter = "router"

--- a/internal/core/validator.go
+++ b/internal/core/validator.go
@@ -293,6 +293,7 @@ func validateForeachConfig(step Step, visibleNames, visibleIDs map[string]struct
 	validateNameIDConflicts(bodyDAG, bodyNames, bodyIDs, errs)
 	validateForeachBodyCollisions(step, bodyDAG.Steps, visibleNames, visibleIDs, errs)
 	validateForeachBodyDependencies(step, bodyDAG.Steps, bodyNames, visibleNames, visibleIDs, errs)
+	validateApprovalRewindTargets(bodyDAG, bodyNames, errs)
 
 	for _, bodyStep := range bodyDAG.Steps {
 		*errs = append(*errs, validateStep(bodyStep)...)

--- a/internal/core/validator.go
+++ b/internal/core/validator.go
@@ -83,11 +83,13 @@ func ValidateSteps(dag *DAG) error {
 	stepNames, stepIDs := collectNamesAndIDs(dag, &errs)
 	validateNameIDConflicts(dag, stepNames, stepIDs, &errs)
 	resolveStepDependencies(dag)
+	resolveForeachStepDependencies(dag.Steps)
 	validateDependenciesExist(dag, stepNames, &errs)
 	validateApprovalRewindTargets(dag, stepNames, &errs)
 
 	for _, step := range dag.Steps {
 		errs = append(errs, validateStep(step)...)
+		validateForeachConfig(step, stepNames, stepIDs, &errs)
 	}
 
 	if len(errs) == 0 {
@@ -270,8 +272,8 @@ func validateParallelConfig(step Step) ErrorList {
 		errs = append(errs, NewValidationError("parallel", step.Parallel, fmt.Errorf("parallel currently requires action: dag.run or dag.enqueue")))
 	}
 
-	if step.Parallel.MaxConcurrent <= 0 {
-		errs = append(errs, NewValidationError("parallel.max_concurrent", step.Parallel.MaxConcurrent, fmt.Errorf("max_concurrent must be greater than 0")))
+	if step.Parallel.MaxConcurrent < 1 || step.Parallel.MaxConcurrent > MaxExpansionConcurrency {
+		errs = append(errs, NewValidationError("parallel.max_concurrent", step.Parallel.MaxConcurrent, fmt.Errorf("max_concurrent must be an integer from 1 through %d", MaxExpansionConcurrency)))
 	}
 
 	if len(step.Parallel.Items) == 0 && step.Parallel.Variable == "" {
@@ -279,6 +281,66 @@ func validateParallelConfig(step Step) ErrorList {
 	}
 
 	return errs
+}
+
+func validateForeachConfig(step Step, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
+	if step.Foreach == nil {
+		return
+	}
+
+	bodyDAG := &DAG{Steps: step.Foreach.Steps}
+	bodyNames, bodyIDs := collectNamesAndIDs(bodyDAG, errs)
+	validateNameIDConflicts(bodyDAG, bodyNames, bodyIDs, errs)
+	validateForeachBodyCollisions(step, bodyDAG.Steps, visibleNames, visibleIDs, errs)
+	validateForeachBodyDependencies(step, bodyDAG.Steps, bodyNames, visibleNames, visibleIDs, errs)
+
+	for _, bodyStep := range bodyDAG.Steps {
+		*errs = append(*errs, validateStep(bodyStep)...)
+		validateForeachConfig(bodyStep, bodyNames, bodyIDs, errs)
+	}
+}
+
+func validateForeachBodyCollisions(parent Step, bodySteps []Step, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
+	for _, bodyStep := range bodySteps {
+		validateForeachBodyIdentityCollision(parent, bodyStep, "name", bodyStep.Name, visibleNames, visibleIDs, errs)
+		validateForeachBodyIdentityCollision(parent, bodyStep, "id", bodyStep.ID, visibleNames, visibleIDs, errs)
+	}
+}
+
+func validateForeachBodyIdentityCollision(parent, bodyStep Step, kind, value string, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
+	if value == "" {
+		return
+	}
+	if _, ok := visibleNames[value]; ok {
+		*errs = append(*errs, NewValidationError("foreach.steps", value,
+			fmt.Errorf("foreach step %s body step %s %q collides with a visible step name", parent.Name, kind, value)))
+	}
+	if _, ok := visibleIDs[value]; ok {
+		*errs = append(*errs, NewValidationError("foreach.steps", value,
+			fmt.Errorf("foreach step %s body step %s %q collides with a visible step ID", parent.Name, kind, value)))
+	}
+}
+
+func validateForeachBodyDependencies(parent Step, bodySteps []Step, bodyNames, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
+	for _, bodyStep := range bodySteps {
+		for _, dep := range bodyStep.Depends {
+			if _, ok := bodyNames[dep]; ok {
+				continue
+			}
+			if _, ok := visibleNames[dep]; ok {
+				*errs = append(*errs, NewValidationError("foreach.steps.depends", dep,
+					fmt.Errorf("foreach step %s body step %s depends on visible top-level step %s; body dependencies must stay inside foreach.steps", parent.Name, bodyStep.Name, dep)))
+				continue
+			}
+			if _, ok := visibleIDs[dep]; ok {
+				*errs = append(*errs, NewValidationError("foreach.steps.depends", dep,
+					fmt.Errorf("foreach step %s body step %s depends on visible top-level step ID %s; body dependencies must stay inside foreach.steps", parent.Name, bodyStep.Name, dep)))
+				continue
+			}
+			*errs = append(*errs, NewValidationError("foreach.steps.depends", dep,
+				fmt.Errorf("foreach step %s body step %s depends on non-existent body step %s", parent.Name, bodyStep.Name, dep)))
+		}
+	}
 }
 
 func validateStepWithValidator(step Step) error {
@@ -330,5 +392,17 @@ func resolveStepDependencies(dag *DAG) {
 				dag.Steps[i].Approval.RewindTo = name
 			}
 		}
+	}
+}
+
+func resolveForeachStepDependencies(steps []Step) {
+	for i := range steps {
+		if steps[i].Foreach == nil {
+			continue
+		}
+		bodyDAG := &DAG{Steps: steps[i].Foreach.Steps}
+		resolveStepDependencies(bodyDAG)
+		steps[i].Foreach.Steps = bodyDAG.Steps
+		resolveForeachStepDependencies(steps[i].Foreach.Steps)
 	}
 }

--- a/internal/core/validator.go
+++ b/internal/core/validator.go
@@ -302,12 +302,12 @@ func validateForeachConfig(step Step, visibleNames, visibleIDs map[string]struct
 
 func validateForeachBodyCollisions(parent Step, bodySteps []Step, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
 	for _, bodyStep := range bodySteps {
-		validateForeachBodyIdentityCollision(parent, bodyStep, "name", bodyStep.Name, visibleNames, visibleIDs, errs)
-		validateForeachBodyIdentityCollision(parent, bodyStep, "id", bodyStep.ID, visibleNames, visibleIDs, errs)
+		validateForeachBodyIdentityCollision(parent, "name", bodyStep.Name, visibleNames, visibleIDs, errs)
+		validateForeachBodyIdentityCollision(parent, "id", bodyStep.ID, visibleNames, visibleIDs, errs)
 	}
 }
 
-func validateForeachBodyIdentityCollision(parent, bodyStep Step, kind, value string, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
+func validateForeachBodyIdentityCollision(parent Step, kind, value string, visibleNames, visibleIDs map[string]struct{}, errs *ErrorList) {
 	if value == "" {
 		return
 	}

--- a/internal/core/validator_test.go
+++ b/internal/core/validator_test.go
@@ -394,7 +394,7 @@ func TestValidateSteps(t *testing.T) {
 		}
 		err := ValidateSteps(dag)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "max_concurrent must be greater than 0")
+		assert.Contains(t, err.Error(), "max_concurrent must be an integer from 1 through 1000")
 	})
 
 	t.Run("parallel config with negative max_concurrent fails", func(t *testing.T) {
@@ -413,7 +413,7 @@ func TestValidateSteps(t *testing.T) {
 		}
 		err := ValidateSteps(dag)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "max_concurrent must be greater than 0")
+		assert.Contains(t, err.Error(), "max_concurrent must be an integer from 1 through 1000")
 	})
 
 	t.Run("parallel config without items or variable fails", func(t *testing.T) {

--- a/internal/core/value_fields.go
+++ b/internal/core/value_fields.go
@@ -139,6 +139,9 @@ func (w *referenceFieldWalker) walkStep(path string, step Step) {
 	if step.Parallel != nil {
 		w.walkParallel(path+".parallel", step.Parallel, base)
 	}
+	if step.Foreach != nil {
+		w.walkForeach(path+".foreach", step.Foreach, base)
+	}
 	w.add(base.withPathValue(path+".stdout", step.Stdout).withField(cmnvalue.StepArtifactOutputField(path + ".stdout")))
 	w.add(base.withPathValue(path+".stdout.artifact", step.StdoutArtifact).withField(cmnvalue.StepArtifactOutputField(path + ".stdout.artifact")))
 	w.add(base.withPathValue(path+".stderr", step.Stderr).withField(cmnvalue.StepArtifactOutputField(path + ".stderr")))
@@ -237,6 +240,19 @@ func (w *referenceFieldWalker) walkParallel(path string, parallel *ParallelConfi
 			fieldPath := itemPath + ".params." + key
 			w.add(base.withPathValue(fieldPath, item.Params[key]).withField(cmnvalue.ParallelItemParamField(fieldPath)))
 		}
+	}
+}
+
+func (w *referenceFieldWalker) walkForeach(path string, foreach *ForeachConfig, base ReferenceField) {
+	w.add(base.withPathValue(path+".items", foreach.ItemsExpr).withField(cmnvalue.WorkflowField(path + ".items")))
+	w.walkStringLeaves(path+".items", foreach.Items, base.withField(cmnvalue.WorkflowField(path+".items")))
+	w.add(base.withPathValue(path+".key", foreach.Key).withField(cmnvalue.WorkflowField(path + ".key")))
+	for i, step := range foreach.Steps {
+		w.walkStep(fmt.Sprintf("%s.steps[%d]", path, i), step)
+	}
+	for _, key := range sortedStringKeys(foreach.Collect) {
+		fieldPath := path + ".collect." + key
+		w.add(base.withPathValue(fieldPath, foreach.Collect[key]).withField(cmnvalue.WorkflowField(fieldPath)))
 	}
 }
 

--- a/internal/core/value_fields_test.go
+++ b/internal/core/value_fields_test.go
@@ -84,6 +84,22 @@ func TestReferenceFieldsEmitsValidationPathSet(t *testing.T) {
 						},
 					},
 				},
+				Foreach: &core.ForeachConfig{
+					Items: []any{
+						map[string]any{"source": "${params.foreach_source}"},
+					},
+					Key: "${foreach.item.source}",
+					Steps: []core.Step{
+						{
+							Name:   "summarize",
+							Script: "echo ${foreach.item.source}",
+							Env:    []string{"ITEM=${foreach.item.source}"},
+						},
+					},
+					Collect: map[string]string{
+						"summary": "${steps.summarize.stdout}",
+					},
+				},
 				Stdout:         "${consts.stdout}",
 				StdoutArtifact: "${consts.stdout_artifact}",
 				Stderr:         "${consts.stderr}",
@@ -178,6 +194,11 @@ func TestReferenceFieldsEmitsValidationPathSet(t *testing.T) {
 		"steps[0].parallel.variable",
 		"steps[0].parallel.items[0].value",
 		"steps[0].parallel.items[0].params.target",
+		"steps[0].foreach.items[0].source",
+		"steps[0].foreach.key",
+		"steps[0].foreach.steps[0].run",
+		"steps[0].foreach.steps[0].env[0]",
+		"steps[0].foreach.collect.summary",
 		"steps[0].stdout",
 		"steps[0].stdout.artifact",
 		"steps[0].stderr",

--- a/internal/core/value_notices.go
+++ b/internal/core/value_notices.go
@@ -65,7 +65,10 @@ func ReportValueReferenceNotices(dag *DAG, sink cmnvalue.ValueReferenceNoticeSin
 		if !strings.Contains(field.Value, "$") {
 			continue
 		}
-		stepOutputNotices.report(field.noticeFieldPath(), field.Value, field.OwnerStepName, field.OwnerStepID, sink)
+		foreachItemScopeField := isForeachItemScopeFieldPath(field.noticeFieldPath())
+		if !foreachItemScopeField {
+			stepOutputNotices.report(field.noticeFieldPath(), field.Value, field.OwnerStepName, field.OwnerStepID, sink)
+		}
 		fieldRuntimeScope := runtimeScope
 		fieldRuntimeScope.BuiltinContext = noticeBuiltinContext(dag.Name, field.OwnerStepName, field.OwnerStepID)
 		resolver := cmnvalue.NewResolver(
@@ -75,10 +78,17 @@ func ReportValueReferenceNotices(dag *DAG, sink cmnvalue.ValueReferenceNoticeSin
 				sink:                         sink,
 				fieldPath:                    field.noticeFieldPath(),
 				suppressStepOutputReferences: true,
+				suppressForeachReferences:    foreachItemScopeField,
 			}),
 		)
 		_, _ = resolver.String(context.Background(), field.Value, field.Field)
 	}
+}
+
+func isForeachItemScopeFieldPath(path string) bool {
+	return strings.Contains(path, ".foreach.key") ||
+		strings.Contains(path, ".foreach.steps[") ||
+		strings.Contains(path, ".foreach.collect.")
 }
 
 func reportStepEnvValueReferenceNotices(
@@ -333,10 +343,14 @@ type valueReferenceNoticeFieldSink struct {
 	sink                         cmnvalue.ValueReferenceNoticeSink
 	fieldPath                    string
 	suppressStepOutputReferences bool
+	suppressForeachReferences    bool
 }
 
 func (s valueReferenceNoticeFieldSink) Report(notice cmnvalue.ValueReferenceNotice) {
 	if s.suppressStepOutputReferences && cmnvalue.IsStepOutputReferenceToken(notice.Token) {
+		return
+	}
+	if s.suppressForeachReferences && strings.HasPrefix(notice.Token, "${foreach.") {
 		return
 	}
 	if s.fieldPath != "" {

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/data"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/docker"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/file"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/foreach"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/git"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/harness"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/http"

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -144,10 +144,7 @@ func (e *enqueueExecutor) enqueueParallel(ctx context.Context, paramsList []exec
 	}
 
 	for i, params := range paramsList {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()
@@ -161,7 +158,7 @@ func (e *enqueueExecutor) enqueueParallel(ctx context.Context, paramsList []exec
 				return
 			}
 			outputs[i] = output
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -80,19 +80,14 @@ func (e *enqueueExecutor) Run(ctx context.Context) error {
 		return fmt.Errorf("no sub DAG runs to enqueue")
 	}
 
-	outputs := make([]enqueueRunOutput, 0, len(paramsList))
-	subRuns := make([]exec1.SubDAGRun, 0, len(paramsList))
-	for _, params := range paramsList {
-		output, err := e.enqueueOne(ctx, params)
-		if err != nil {
-			return err
-		}
-		outputs = append(outputs, output)
-		subRuns = append(subRuns, exec1.SubDAGRun{
-			DAGRunID: output.DAGRunID,
-			Params:   output.Params,
-			DAGName:  output.Name,
-		})
+	outputs, err := e.enqueueAll(ctx, paramsList, parallel)
+	if err != nil {
+		return err
+	}
+
+	subRuns := make([]exec1.SubDAGRun, 0, len(outputs))
+	for _, output := range outputs {
+		subRuns = append(subRuns, subDAGRunFromEnqueueOutput(output))
 	}
 
 	e.lock.Lock()
@@ -100,6 +95,94 @@ func (e *enqueueExecutor) Run(ctx context.Context) error {
 	e.lock.Unlock()
 
 	return e.writeOutput(outputs, parallel)
+}
+
+func (e *enqueueExecutor) enqueueAll(ctx context.Context, paramsList []executor.RunParams, parallel bool) ([]enqueueRunOutput, error) {
+	if !parallel || len(paramsList) == 1 {
+		return e.enqueueSequential(ctx, paramsList)
+	}
+	return e.enqueueParallel(ctx, paramsList)
+}
+
+func (e *enqueueExecutor) enqueueSequential(ctx context.Context, paramsList []executor.RunParams) ([]enqueueRunOutput, error) {
+	outputs := make([]enqueueRunOutput, 0, len(paramsList))
+	for _, params := range paramsList {
+		output, err := e.enqueueOne(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs, nil
+}
+
+func (e *enqueueExecutor) enqueueParallel(ctx context.Context, paramsList []executor.RunParams) ([]enqueueRunOutput, error) {
+	limit := core.DefaultMaxConcurrent
+	if e.step.Parallel != nil && e.step.Parallel.MaxConcurrent > 0 {
+		limit = e.step.Parallel.MaxConcurrent
+	}
+	if limit > len(paramsList) {
+		limit = len(paramsList)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	outputs := make([]enqueueRunOutput, len(paramsList))
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	var errMu sync.Mutex
+	var firstErr error
+
+	setErr := func(err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		if firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+	}
+
+	for i, params := range paramsList {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			output, err := e.enqueueOne(ctx, params)
+			if err != nil {
+				setErr(err)
+				return
+			}
+			outputs[i] = output
+		}()
+	}
+	wg.Wait()
+
+	errMu.Lock()
+	err := firstErr
+	errMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return outputs, nil
+}
+
+func subDAGRunFromEnqueueOutput(output enqueueRunOutput) exec1.SubDAGRun {
+	return exec1.SubDAGRun{
+		DAGRunID: output.DAGRunID,
+		Params:   output.Params,
+		DAGName:  output.Name,
+	}
 }
 
 func (e *enqueueExecutor) enqueueOne(ctx context.Context, runParams executor.RunParams) (enqueueRunOutput, error) {

--- a/internal/runtime/builtin/dag/enqueue_test.go
+++ b/internal/runtime/builtin/dag/enqueue_test.go
@@ -5,8 +5,11 @@ package dag_test
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
@@ -79,4 +82,99 @@ func TestEnqueueExecutorPersistsInheritedProfile(t *testing.T) {
 	assert.Equal(t, "prod", status.ProfileName)
 	assert.Equal(t, exec.NewDAGRunRef("child", "child-run"), status.Root)
 	assert.True(t, status.Parent.Zero())
+}
+
+func TestEnqueueExecutorParallelHonorsMaxConcurrent(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Queues.Enabled = true
+		cfg.Queues.Config = []config.QueueConfig{{Name: "default", MaxActiveRuns: 1}}
+	}))
+
+	parent := &core.DAG{
+		Name: "parent",
+		LocalDAGs: map[string]*core.DAG{
+			"child": {
+				Name:     "child",
+				YamlData: []byte("name: child\nsteps:\n  - name: step\n    run: echo child\n"),
+				Steps: []core.Step{
+					{Name: "step", ExecutorConfig: core.ExecutorConfig{Type: "noop"}},
+				},
+			},
+		},
+	}
+	parentRun := exec.NewDAGRunRef(parent.Name, "parent-run")
+	queueStore := &recordingQueueStore{
+		QueueStore: th.QueueStore,
+		delay:      50 * time.Millisecond,
+	}
+	ctx := runtime.NewContext(
+		th.Context,
+		parent,
+		parentRun.ID,
+		filepath.Join(th.Config.Paths.LogDir, "parent.log"),
+		runtime.WithRootDAGRun(parentRun),
+		runtime.WithDAGRunStore(th.DAGRunStore),
+		runtime.WithQueueStore(queueStore),
+		runtime.WithDAGRunLogDir(th.Config.Paths.LogDir),
+		runtime.WithDAGRunArtifactDir(th.Config.Paths.ArtifactDir),
+	)
+
+	step := core.Step{
+		Name:           "enqueue-child",
+		ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeDAGEnqueue},
+		SubDAG:         &core.SubDAG{Name: "child"},
+		Parallel:       &core.ParallelConfig{MaxConcurrent: 2},
+	}
+	execImpl, err := executor.NewExecutor(ctx, step)
+	require.NoError(t, err)
+
+	parallelExec, ok := execImpl.(executor.ParallelExecutor)
+	require.True(t, ok)
+	parallelExec.SetParamsList([]executor.RunParams{
+		{RunID: "child-run-1", DAGName: "child", Params: "VALUE=one"},
+		{RunID: "child-run-2", DAGName: "child", Params: "VALUE=two"},
+		{RunID: "child-run-3", DAGName: "child", Params: "VALUE=three"},
+	})
+
+	var stdout bytes.Buffer
+	execImpl.SetStdout(&stdout)
+	require.NoError(t, execImpl.Run(ctx))
+
+	assert.Equal(t, 2, queueStore.MaxActive())
+}
+
+type recordingQueueStore struct {
+	exec.QueueStore
+
+	mu        sync.Mutex
+	active    int
+	maxActive int
+	delay     time.Duration
+}
+
+func (s *recordingQueueStore) Enqueue(ctx context.Context, name string, priority exec.QueuePriority, dagRun exec.DAGRunRef) error {
+	s.mu.Lock()
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+
+	time.Sleep(s.delay)
+
+	err := s.QueueStore.Enqueue(ctx, name, priority, dagRun)
+
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
+
+	return err
+}
+
+func (s *recordingQueueStore) MaxActive() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxActive
 }

--- a/internal/runtime/builtin/foreach/foreach.go
+++ b/internal/runtime/builtin/foreach/foreach.go
@@ -190,10 +190,13 @@ func (e *foreachExecutor) runItems(ctx context.Context, items []expandedItem) ([
 
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxConcurrent)
+	var dispatchErr error
+dispatch:
 	for _, item := range items {
 		select {
 		case <-ctx.Done():
-			return results, ctx.Err()
+			dispatchErr = ctx.Err()
+			break dispatch
 		case sem <- struct{}{}:
 		}
 
@@ -205,6 +208,9 @@ func (e *foreachExecutor) runItems(ctx context.Context, items []expandedItem) ([
 		}(item)
 	}
 	wg.Wait()
+	if dispatchErr != nil {
+		return results, dispatchErr
+	}
 
 	var failed bool
 	for _, result := range results {

--- a/internal/runtime/builtin/foreach/foreach.go
+++ b/internal/runtime/builtin/foreach/foreach.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -262,9 +263,7 @@ func cloneSteps(steps []core.Step) []core.Step {
 		cloned[i] = step
 		if step.ExecutorConfig.Config != nil {
 			cloned[i].ExecutorConfig.Config = make(map[string]any, len(step.ExecutorConfig.Config))
-			for key, value := range step.ExecutorConfig.Config {
-				cloned[i].ExecutorConfig.Config[key] = value
-			}
+			maps.Copy(cloned[i].ExecutorConfig.Config, step.ExecutorConfig.Config)
 		}
 		cloned[i].Depends = append([]string(nil), step.Depends...)
 		cloned[i].Env = append([]string(nil), step.Env...)

--- a/internal/runtime/builtin/foreach/foreach.go
+++ b/internal/runtime/builtin/foreach/foreach.go
@@ -1,0 +1,406 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package foreach
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
+	"github.com/dagucloud/dagu/internal/core"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+)
+
+var errForeachItemFailed = errors.New("one or more foreach item bodies failed")
+
+type foreachExecutor struct {
+	step   core.Step
+	stdout io.Writer
+	stderr io.Writer
+	cancel context.CancelFunc
+}
+
+type expandedItem struct {
+	index int
+	key   string
+	value any
+}
+
+type itemResult struct {
+	Index   int               `json:"index"`
+	Key     string            `json:"key"`
+	Status  string            `json:"status"`
+	Outputs map[string]string `json:"outputs,omitempty"`
+	Error   string            `json:"error,omitempty"`
+}
+
+type aggregateOutput struct {
+	Summary struct {
+		Total     int `json:"total"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	} `json:"summary"`
+	Items   []itemResult        `json:"items"`
+	Outputs []map[string]string `json:"outputs"`
+}
+
+func newExecutor(_ context.Context, step core.Step) (executor.Executor, error) {
+	if step.Foreach == nil {
+		return nil, fmt.Errorf("foreach configuration is missing")
+	}
+	return &foreachExecutor{step: step}, nil
+}
+
+func (e *foreachExecutor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *foreachExecutor) SetStderr(out io.Writer) {
+	e.stderr = out
+}
+
+func (e *foreachExecutor) Kill(_ os.Signal) error {
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil
+}
+
+func (e *foreachExecutor) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	e.cancel = cancel
+	defer cancel()
+
+	items, err := e.expandItems(ctx)
+	if err != nil {
+		return err
+	}
+
+	results, runErr := e.runItems(ctx, items)
+	if err := e.writeAggregate(results); err != nil {
+		return err
+	}
+	return runErr
+}
+
+func (e *foreachExecutor) expandItems(ctx context.Context) ([]expandedItem, error) {
+	cfg := e.step.Foreach
+	values, err := resolveItems(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(values) > core.MaxExpansionConcurrency {
+		return nil, fmt.Errorf("foreach expansion produced %d items; maximum is %d", len(values), core.MaxExpansionConcurrency)
+	}
+
+	items := make([]expandedItem, len(values))
+	seen := make(map[string]int, len(values))
+	for idx, value := range values {
+		key := strconv.Itoa(idx)
+		if cfg.Key != "" {
+			itemCtx, err := contextWithItemScope(ctx, cfg.As, idx, "", value)
+			if err != nil {
+				return nil, err
+			}
+			key, err = resolveStringValue(itemCtx, cfg.Key, "foreach.key")
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve foreach.key for item %d: %w", idx, err)
+			}
+			if key == "" {
+				return nil, fmt.Errorf("foreach.key resolved to an empty string for item %d", idx)
+			}
+			if containsUnresolvedSupportedReference(key) {
+				return nil, fmt.Errorf("foreach.key resolved with unresolved reference for item %d: %s", idx, key)
+			}
+		}
+		if prev, exists := seen[key]; exists {
+			return nil, fmt.Errorf("duplicate foreach item key %q at item %d; first seen at item %d", key, idx, prev)
+		}
+		seen[key] = idx
+		items[idx] = expandedItem{index: idx, key: key, value: value}
+	}
+	return items, nil
+}
+
+func resolveItems(ctx context.Context, cfg *core.ForeachConfig) ([]any, error) {
+	if cfg.ItemsExpr != "" {
+		resolved, err := resolveStringValue(ctx, cfg.ItemsExpr, "foreach.items")
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve foreach.items: %w", err)
+		}
+		var items []any
+		if err := json.Unmarshal([]byte(resolved), &items); err != nil {
+			return nil, fmt.Errorf("foreach.items string must resolve to a JSON array: %w", err)
+		}
+		return items, nil
+	}
+
+	resolved, err := runtime.EvalObject(ctx, map[string]any{"items": cfg.Items})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve foreach.items: %w", err)
+	}
+	items, ok := resolved["items"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("foreach.items must resolve to an array, got %T", resolved["items"])
+	}
+	return normalizeJSONItems(items)
+}
+
+func normalizeJSONItems(items []any) ([]any, error) {
+	data, err := json.Marshal(items)
+	if err != nil {
+		return nil, fmt.Errorf("foreach.items must contain JSON-compatible values: %w", err)
+	}
+	var normalized []any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return nil, fmt.Errorf("foreach.items must contain JSON-compatible values: %w", err)
+	}
+	return normalized, nil
+}
+
+func (e *foreachExecutor) runItems(ctx context.Context, items []expandedItem) ([]itemResult, error) {
+	results := make([]itemResult, len(items))
+	for _, item := range items {
+		results[item.index] = itemResult{
+			Index:  item.index,
+			Key:    item.key,
+			Status: core.NodeNotStarted.String(),
+		}
+	}
+	if len(items) == 0 {
+		return results, nil
+	}
+
+	maxConcurrent := e.step.Foreach.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = core.DefaultMaxConcurrent
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxConcurrent)
+	for _, item := range items {
+		select {
+		case <-ctx.Done():
+			return results, ctx.Err()
+		case sem <- struct{}{}:
+		}
+
+		wg.Add(1)
+		go func(item expandedItem) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[item.index] = e.runItem(ctx, item)
+		}(item)
+	}
+	wg.Wait()
+
+	var failed bool
+	for _, result := range results {
+		if result.Status != core.NodeSucceeded.String() {
+			failed = true
+			break
+		}
+	}
+	if failed {
+		return results, errForeachItemFailed
+	}
+	return results, nil
+}
+
+func (e *foreachExecutor) runItem(ctx context.Context, item expandedItem) itemResult {
+	itemCtx, err := contextWithItemScope(ctx, e.step.Foreach.As, item.index, item.key, item.value)
+	if err != nil {
+		return itemResult{Index: item.index, Key: item.key, Status: core.NodeFailed.String(), Error: err.Error()}
+	}
+
+	plan, err := runtime.NewPlan(cloneSteps(e.step.Foreach.Steps)...)
+	if err != nil {
+		return itemResult{Index: item.index, Key: item.key, Status: core.NodeFailed.String(), Error: err.Error()}
+	}
+
+	bodyRunID := bodyDAGRunID(ctx, item.index)
+	runner := runtime.New(&runtime.Config{
+		LogDir:   bodyLogDir(ctx),
+		DAGRunID: bodyRunID,
+	})
+	err = runner.Run(itemCtx, plan, nil)
+	status := runner.Status(itemCtx, plan)
+	if err != nil || status != core.Succeeded {
+		message := status.String()
+		if err != nil {
+			message = err.Error()
+		}
+		return itemResult{Index: item.index, Key: item.key, Status: core.NodeFailed.String(), Error: message}
+	}
+
+	outputs, err := e.collectOutputs(itemCtx, plan)
+	if err != nil {
+		return itemResult{Index: item.index, Key: item.key, Status: core.NodeFailed.String(), Error: err.Error()}
+	}
+	return itemResult{
+		Index:   item.index,
+		Key:     item.key,
+		Status:  core.NodeSucceeded.String(),
+		Outputs: outputs,
+	}
+}
+
+func cloneSteps(steps []core.Step) []core.Step {
+	cloned := make([]core.Step, len(steps))
+	for i, step := range steps {
+		cloned[i] = step
+		if step.ExecutorConfig.Config != nil {
+			cloned[i].ExecutorConfig.Config = make(map[string]any, len(step.ExecutorConfig.Config))
+			for key, value := range step.ExecutorConfig.Config {
+				cloned[i].ExecutorConfig.Config[key] = value
+			}
+		}
+		cloned[i].Depends = append([]string(nil), step.Depends...)
+		cloned[i].Env = append([]string(nil), step.Env...)
+		cloned[i].Commands = append([]core.CommandEntry(nil), step.Commands...)
+		cloned[i].Outputs = append([]core.StepOutputDeclaration(nil), step.Outputs...)
+	}
+	return cloned
+}
+
+func (e *foreachExecutor) collectOutputs(ctx context.Context, plan *runtime.Plan) (map[string]string, error) {
+	collect := e.step.Foreach.Collect
+	outputs := make(map[string]string, len(collect))
+	if len(collect) == 0 {
+		return outputs, nil
+	}
+
+	env := runtime.NewPlanEnv(ctx, core.Step{}, plan)
+	ctx = runtime.WithEnv(ctx, env)
+	for _, name := range sortedCollectNames(collect) {
+		value, err := resolveStringValue(ctx, collect[name], "foreach.collect."+name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve foreach.collect.%s: %w", name, err)
+		}
+		if containsUnresolvedSupportedReference(value) {
+			return nil, fmt.Errorf("foreach.collect.%s resolved with unresolved reference: %s", name, value)
+		}
+		outputs[name] = value
+	}
+	return outputs, nil
+}
+
+func resolveStringValue(ctx context.Context, raw, key string) (string, error) {
+	resolved, err := runtime.EvalObject(ctx, map[string]any{key: raw})
+	if err != nil {
+		return "", err
+	}
+	value, ok := resolved[key].(string)
+	if !ok {
+		return "", fmt.Errorf("%s must resolve to a string, got %T", key, resolved[key])
+	}
+	return value, nil
+}
+
+func contextWithItemScope(ctx context.Context, alias string, index int, key string, item any) (context.Context, error) {
+	env := runtime.GetEnv(ctx)
+	scope := env.Scope
+	if scope == nil {
+		scope = cmnvalue.NewEnvScope(nil, false)
+	}
+
+	payload := map[string]any{
+		"index": strconv.Itoa(index),
+		"key":   key,
+		alias:   item,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return ctx, fmt.Errorf("failed to serialize foreach item scope: %w", err)
+	}
+	env.Scope = scope.WithEntry("foreach", string(data), cmnvalue.EnvSourceStepEnv)
+	env.Foreach = cmnvalue.Values(payload)
+	return runtime.WithEnv(ctx, env), nil
+}
+
+func containsUnresolvedSupportedReference(value string) bool {
+	return strings.Contains(value, "${foreach.") ||
+		strings.Contains(value, "${steps.") ||
+		(strings.Contains(value, "${") && strings.Contains(value, ".outputs."))
+}
+
+func (e *foreachExecutor) writeAggregate(results []itemResult) error {
+	output := aggregateOutput{
+		Items:   results,
+		Outputs: make([]map[string]string, 0, len(results)),
+	}
+	output.Summary.Total = len(results)
+	for _, result := range results {
+		if result.Status == core.NodeSucceeded.String() {
+			output.Summary.Succeeded++
+			if result.Outputs == nil {
+				output.Outputs = append(output.Outputs, map[string]string{})
+			} else {
+				output.Outputs = append(output.Outputs, result.Outputs)
+			}
+			continue
+		}
+		output.Summary.Failed++
+	}
+
+	w := e.stdout
+	if w == nil {
+		w = io.Discard
+	}
+	data, err := json.Marshal(output)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func bodyLogDir(ctx context.Context) string {
+	env := runtime.GetEnv(ctx)
+	if env.Scope != nil {
+		if stdout, ok := env.Scope.Get(coreexec.EnvKeyDAGRunStepStdoutFile); ok && stdout != "" {
+			return filepath.Join(filepath.Dir(stdout), "foreach")
+		}
+	}
+	rCtx := runtime.GetDAGContext(ctx)
+	if rCtx.DAGRunLogDir != "" {
+		return filepath.Join(rCtx.DAGRunLogDir, "foreach")
+	}
+	return filepath.Join(os.TempDir(), "dagu-foreach")
+}
+
+func bodyDAGRunID(ctx context.Context, index int) string {
+	runID := runtime.GetDAGContext(ctx).DAGRunID
+	if runID == "" {
+		runID = "foreach"
+	}
+	return fmt.Sprintf("%s-foreach-%d", runID, index)
+}
+
+func sortedCollectNames(values map[string]string) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j] < names[j-1]; j-- {
+			names[j], names[j-1] = names[j-1], names[j]
+		}
+	}
+	return names
+}
+
+func init() {
+	executor.RegisterExecutor(core.ExecutorTypeForeach, newExecutor, nil, core.ExecutorCapabilities{})
+}

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -106,9 +106,6 @@ func newEnv(ctx context.Context, step core.Step, rCtx Context, workingDir string
 	scope := rCtx.EnvScope
 	var foreach cmnvalue.Values
 	if inherited, ok := LookupEnv(ctx); ok {
-		if inherited.Scope != nil {
-			scope = inherited.Scope
-		}
 		foreach = inherited.Foreach
 	}
 	if scope == nil {
@@ -177,9 +174,6 @@ func expandRuntimeValue(ctx context.Context, raw string, rCtx Context, dag *core
 	}
 	var foreach cmnvalue.Values
 	if inherited, ok := LookupEnv(ctx); ok {
-		if inherited.Scope != nil {
-			scope = inherited.Scope
-		}
 		foreach = inherited.Foreach
 	}
 	resolver := cmnvalue.NewResolver(

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -45,6 +45,9 @@ type Env struct {
 	// Step references are resolved separately from environment variables.
 	StepMap map[string]cmnvalue.StepInfo
 
+	// Foreach contains the current item scope for foreach body evaluation.
+	Foreach cmnvalue.Values
+
 	// Resolved absolute path for the step's working directory, determined by:
 	// 1. Step's Dir field if specified (resolved to absolute path)
 	// 2. Current working directory if Dir is not specified
@@ -77,7 +80,7 @@ func (e Env) UserEnvsMap() map[string]string {
 func NewEnv(ctx context.Context, step core.Step) Env {
 	rCtx := GetDAGContext(ctx)
 	workingDir := resolveWorkingDir(ctx, step, rCtx)
-	return newEnv(step, rCtx, workingDir)
+	return newEnv(ctx, step, rCtx, workingDir)
 }
 
 // NewEnvWithError creates an Env and returns working directory resolution errors.
@@ -87,10 +90,10 @@ func NewEnvWithError(ctx context.Context, step core.Step) (Env, error) {
 	if err != nil {
 		return Env{}, err
 	}
-	return newEnv(step, rCtx, workingDir), nil
+	return newEnv(ctx, step, rCtx, workingDir), nil
 }
 
-func newEnv(step core.Step, rCtx Context, workingDir string) Env {
+func newEnv(ctx context.Context, step core.Step, rCtx Context, workingDir string) Env {
 	// Build step-specific env vars
 	stepEnvs := map[string]string{
 		exec.EnvKeyDAGRunStepName: step.Name,
@@ -101,6 +104,13 @@ func newEnv(step core.Step, rCtx Context, workingDir string) Env {
 	// The scope chain inherits from rCtx.EnvScope (filtered BaseEnv + DAG env + secrets).
 	// and adds step-specific environment variables
 	scope := rCtx.EnvScope
+	var foreach cmnvalue.Values
+	if inherited, ok := LookupEnv(ctx); ok {
+		if inherited.Scope != nil {
+			scope = inherited.Scope
+		}
+		foreach = inherited.Foreach
+	}
 	if scope == nil {
 		scope = cmnvalue.NewEnvScope(nil, true) // Fallback: OS layer only
 	}
@@ -111,6 +121,7 @@ func newEnv(step core.Step, rCtx Context, workingDir string) Env {
 		Scope:      scope,
 		Step:       step,
 		StepMap:    make(map[string]cmnvalue.StepInfo),
+		Foreach:    foreach,
 		WorkingDir: workingDir,
 	}
 }
@@ -164,12 +175,20 @@ func expandRuntimeValue(ctx context.Context, raw string, rCtx Context, dag *core
 	if rCtx.DAG == nil {
 		rCtx.DAG = dag
 	}
+	var foreach cmnvalue.Values
+	if inherited, ok := LookupEnv(ctx); ok {
+		if inherited.Scope != nil {
+			scope = inherited.Scope
+		}
+		foreach = inherited.Foreach
+	}
 	resolver := cmnvalue.NewResolver(
 		cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations},
 		cmnvalue.RuntimeScope{
 			Consts:         consts,
 			Params:         params,
 			Env:            scope,
+			Foreach:        foreach,
 			BuiltinContext: builtinContextFromDAGContext(rCtx, scope, step),
 		},
 	)

--- a/internal/runtime/env_test.go
+++ b/internal/runtime/env_test.go
@@ -756,6 +756,28 @@ func TestNewEnvForStep_BasicFields(t *testing.T) {
 	assert.Equal(t, tempDir, env.WorkingDir)
 }
 
+func TestNewEnvUsesDAGScopeWhenContextHasInheritedEnv(t *testing.T) {
+	t.Parallel()
+
+	childScope := cmnvalue.NewEnvScope(nil, false).WithEntry("VALUE", "child", cmnvalue.EnvSourceDAGEnv)
+	parentScope := cmnvalue.NewEnvScope(nil, false).WithEntry("VALUE", "parent", cmnvalue.EnvSourceStepEnv)
+	ctx := runtime.WithDAGContext(context.Background(), exec.Context{
+		DAG:      &core.DAG{Name: "child"},
+		EnvScope: childScope,
+	})
+	ctx = runtime.WithEnv(ctx, runtime.Env{
+		Scope:   parentScope,
+		Foreach: cmnvalue.Values{"item": "one"},
+	})
+
+	env := runtime.NewEnv(ctx, core.Step{Name: "child-step"})
+
+	got, ok := env.Scope.Get("VALUE")
+	require.True(t, ok)
+	assert.Equal(t, "child", got)
+	assert.Equal(t, cmnvalue.Values{"item": "one"}, env.Foreach)
+}
+
 func TestNewEnvForStep_WorkingDirectory_DAGEnvExpansion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -54,6 +54,7 @@ func resolverFromEnv(env Env) cmnvalue.Resolver {
 		Params:         params,
 		Env:            env.Scope,
 		Steps:          env.StepMap,
+		Foreach:        env.Foreach,
 		BuiltinContext: builtinContextFromEnv(env),
 	}
 	return cmnvalue.NewResolver(cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations}, scope)

--- a/internal/runtime/foreach_spec018_test.go
+++ b/internal/runtime/foreach_spec018_test.go
@@ -1,0 +1,245 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/foreach"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForeachRuntimeRunsBodyAndPublishesAggregate(t *testing.T) {
+	probeType, state := registerForeachProbeExecutor(t)
+	r := setupRunner(t)
+
+	parent := foreachRuntimeStep(probeType, []any{
+		map[string]any{"slug": "one", "url": "https://example.com/one"},
+		map[string]any{"slug": "two", "url": "https://example.com/two"},
+	}, 2)
+
+	result := r.newPlan(t, parent).assertRun(t, core.Succeeded)
+	node := result.nodeByName(t, "each")
+	raw, ok := node.NodeData().StringFormOutputValue()
+	require.True(t, ok)
+
+	var aggregate foreachAggregate
+	require.NoError(t, json.Unmarshal([]byte(raw), &aggregate))
+
+	assert.Equal(t, 2, aggregate.Summary.Total)
+	assert.Equal(t, 2, aggregate.Summary.Succeeded)
+	assert.Equal(t, 0, aggregate.Summary.Failed)
+	require.Len(t, aggregate.Items, 2)
+	assert.Equal(t, foreachAggregateItem{
+		Index:   0,
+		Key:     "one",
+		Status:  core.NodeSucceeded.String(),
+		Outputs: map[string]string{"summary": "https://example.com/one"},
+	}, aggregate.Items[0])
+	assert.Equal(t, foreachAggregateItem{
+		Index:   1,
+		Key:     "two",
+		Status:  core.NodeSucceeded.String(),
+		Outputs: map[string]string{"summary": "https://example.com/two"},
+	}, aggregate.Items[1])
+	assert.Equal(t, []map[string]string{
+		{"summary": "https://example.com/one"},
+		{"summary": "https://example.com/two"},
+	}, aggregate.Outputs)
+
+	assert.ElementsMatch(t, []foreachProbeRecord{
+		{Value: "https://example.com/one", Key: "one"},
+		{Value: "https://example.com/two", Key: "two"},
+	}, state.records())
+}
+
+func TestForeachRuntimeHonorsMaxConcurrent(t *testing.T) {
+	probeType, state := registerForeachProbeExecutor(t)
+	r := setupRunner(t)
+
+	parent := foreachRuntimeStep(probeType, []any{
+		map[string]any{"slug": "a", "url": "a"},
+		map[string]any{"slug": "b", "url": "b"},
+		map[string]any{"slug": "c", "url": "c"},
+	}, 2)
+	parent.Foreach.Steps[0].ExecutorConfig.Config["delay_ms"] = "80"
+
+	r.newPlan(t, parent).assertRun(t, core.Succeeded)
+
+	assert.Equal(t, 2, state.maxActive())
+}
+
+type foreachAggregate struct {
+	Summary struct {
+		Total     int `json:"total"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	} `json:"summary"`
+	Items   []foreachAggregateItem `json:"items"`
+	Outputs []map[string]string    `json:"outputs"`
+}
+
+type foreachAggregateItem struct {
+	Index   int               `json:"index"`
+	Key     string            `json:"key"`
+	Status  string            `json:"status"`
+	Outputs map[string]string `json:"outputs,omitempty"`
+	Error   string            `json:"error,omitempty"`
+}
+
+func foreachRuntimeStep(probeType string, items []any, maxConcurrent int) core.Step {
+	return core.Step{
+		Name:           "each",
+		Output:         "RESULT",
+		ExecutorConfig: core.ExecutorConfig{Type: core.ExecutorTypeForeach},
+		Foreach: &core.ForeachConfig{
+			Items:         items,
+			As:            "episode",
+			Key:           "${foreach.episode.slug}",
+			MaxConcurrent: maxConcurrent,
+			Steps: []core.Step{
+				{
+					Name: "write",
+					ID:   "write",
+					ExecutorConfig: core.ExecutorConfig{
+						Type: probeType,
+						Config: map[string]any{
+							"value": "${foreach.episode.url}",
+							"key":   "${foreach.key}",
+						},
+					},
+				},
+			},
+			Collect: map[string]string{
+				"summary": "${write.outputs.value}",
+			},
+		},
+	}
+}
+
+func registerForeachProbeExecutor(t *testing.T) (string, *foreachProbeState) {
+	t.Helper()
+
+	state := &foreachProbeState{}
+	executorType := "foreach_probe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	executor.RegisterExecutor(executorType, func(_ context.Context, step core.Step) (executor.Executor, error) {
+		return &foreachProbeExecutor{
+			state: state,
+			cfg:   step.ExecutorConfig.Config,
+		}, nil
+	}, nil, core.ExecutorCapabilities{})
+	t.Cleanup(func() {
+		executor.UnregisterExecutor(executorType)
+		core.UnregisterExecutorCapabilities(executorType)
+	})
+	return executorType, state
+}
+
+type foreachProbeState struct {
+	mu     sync.Mutex
+	active int
+	max    int
+	seen   []foreachProbeRecord
+}
+
+type foreachProbeRecord struct {
+	Value string
+	Key   string
+}
+
+func (s *foreachProbeState) start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active++
+	if s.active > s.max {
+		s.max = s.active
+	}
+}
+
+func (s *foreachProbeState) finish(record foreachProbeRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active--
+	s.seen = append(s.seen, record)
+}
+
+func (s *foreachProbeState) maxActive() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.max
+}
+
+func (s *foreachProbeState) records() []foreachProbeRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]foreachProbeRecord(nil), s.seen...)
+}
+
+type foreachProbeExecutor struct {
+	state  *foreachProbeState
+	cfg    map[string]any
+	stdout io.Writer
+	stderr io.Writer
+	output map[string]any
+}
+
+func (e *foreachProbeExecutor) SetStdout(out io.Writer) {
+	e.stdout = out
+}
+
+func (e *foreachProbeExecutor) SetStderr(out io.Writer) {
+	e.stderr = out
+}
+
+func (e *foreachProbeExecutor) Kill(_ os.Signal) error {
+	return nil
+}
+
+func (e *foreachProbeExecutor) Run(ctx context.Context) error {
+	e.state.start()
+	defer func() {
+		e.state.finish(foreachProbeRecord{
+			Value: stringConfigValue(e.cfg["value"]),
+			Key:   stringConfigValue(e.cfg["key"]),
+		})
+	}()
+
+	if delay := stringConfigValue(e.cfg["delay_ms"]); delay != "" {
+		millis, err := strconv.Atoi(delay)
+		if err == nil && millis > 0 {
+			timer := time.NewTimer(time.Duration(millis) * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+
+	e.output = map[string]any{
+		"value": stringConfigValue(e.cfg["value"]),
+		"key":   stringConfigValue(e.cfg["key"]),
+	}
+	return nil
+}
+
+func (e *foreachProbeExecutor) GetOutputs() map[string]any {
+	return e.output
+}
+
+func stringConfigValue(value any) string {
+	v, _ := value.(string)
+	return v
+}

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1580,6 +1580,7 @@ func (r *Runner) prepareNodeForRepeat(ctx context.Context, node *Node, progressC
 
 func NewPlanEnv(ctx context.Context, step core.Step, plan *Plan) Env {
 	env := NewEnv(ctx, step)
+	addInheritedStepMap(ctx, &env)
 	addPlanStepsToEnv(&env, plan)
 	return env
 }
@@ -1589,12 +1590,14 @@ func NewPlanEnvWithError(ctx context.Context, step core.Step, plan *Plan) (Env, 
 	if err != nil {
 		return Env{}, err
 	}
+	addInheritedStepMap(ctx, &env)
 	addPlanStepsToEnv(&env, plan)
 	return env, nil
 }
 
 func NewPlanEnvForNode(ctx context.Context, node *Node, plan *Plan) Env {
 	env := NewEnv(ctx, node.Step())
+	addInheritedStepMap(ctx, &env)
 	addPlanPredecessorStepsToEnv(&env, plan, node)
 	return env
 }
@@ -1604,8 +1607,27 @@ func NewPlanEnvForNodeWithError(ctx context.Context, node *Node, plan *Plan) (En
 	if err != nil {
 		return Env{}, err
 	}
+	addInheritedStepMap(ctx, &env)
 	addPlanPredecessorStepsToEnv(&env, plan, node)
 	return env, nil
+}
+
+func addInheritedStepMap(ctx context.Context, env *Env) {
+	if env == nil {
+		return
+	}
+	inherited, ok := LookupEnv(ctx)
+	if !ok || len(inherited.StepMap) == 0 {
+		return
+	}
+	if env.StepMap == nil {
+		env.StepMap = make(map[string]cmnvalue.StepInfo, len(inherited.StepMap))
+	}
+	for id, info := range inherited.StepMap {
+		if _, exists := env.StepMap[id]; !exists {
+			env.StepMap[id] = info
+		}
+	}
 }
 
 func addPlanStepsToEnv(env *Env, plan *Plan) {

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -697,9 +697,10 @@ steps:
         - approver
       required:
         - reason
-  - name: after-wait
-    depends: [wait-step]
-    run: %q`, "exit 0", test.EnvOutput("reason", "approver"))
+  - name: hold-step
+    run: %q
+    approval:
+      prompt: "Keep the DAG waiting"`, "exit 0", "exit 0")
 
 	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
 		Name: "approval_inputs_dag",
@@ -716,7 +717,9 @@ steps:
 
 	// Wait for DAG to enter Wait status
 	waitForStoredDAGRunStatus(t, server, "approval_inputs_dag", startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
-		return status.Status == core.Waiting && hasNodeWithStatus(status, "wait-step", core.NodeWaiting)
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "wait-step", core.NodeWaiting) &&
+			hasNodeWithStatus(status, "hold-step", core.NodeWaiting)
 	})
 
 	// Approve with inputs
@@ -731,30 +734,33 @@ steps:
 
 	var approveBody api.ApproveDAGRunStep200JSONResponse
 	approveResp.Unmarshal(t, &approveBody)
-	require.True(t, approveBody.Resumed)
+	require.False(t, approveBody.Resumed)
 
-	// Wait for DAG to complete
+	// The second waiting step keeps the DAG in a non-terminal state while the
+	// approved node's API-side mutation is persisted.
 	status := waitForStoredDAGRunStatus(t, server, "approval_inputs_dag", startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
-		return status.Status == core.Succeeded
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "wait-step", core.NodeSucceeded) &&
+			hasNodeWithStatus(status, "hold-step", core.NodeWaiting)
 	})
 	require.Len(t, status.Nodes, 2)
 
-	var waitNode, afterWaitNode *exec.Node
+	var waitNode *exec.Node
 	for _, node := range status.Nodes {
-		switch node.Step.Name {
-		case "wait-step":
+		if node.Step.Name == "wait-step" {
 			waitNode = node
-		case "after-wait":
-			afterWaitNode = node
 		}
 	}
 	require.NotNil(t, waitNode)
-	require.NotNil(t, afterWaitNode)
 	require.Equal(t, inputs, waitNode.ApprovalInputs)
 
-	stdout, err := os.ReadFile(afterWaitNode.Stdout)
-	require.NoError(t, err)
-	require.Equal(t, "testing|test-user", strings.TrimSpace(string(stdout)))
+	require.NotNil(t, waitNode.OutputVariables)
+	reasonRaw, ok := waitNode.OutputVariables.Load("reason")
+	require.True(t, ok)
+	require.Equal(t, "reason=testing", reasonRaw)
+	approverRaw, ok := waitNode.OutputVariables.Load("approver")
+	require.True(t, ok)
+	require.Equal(t, "approver=test-user", approverRaw)
 }
 
 func TestApproveDAGRunStepMissingRequired(t *testing.T) {

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -25,6 +25,7 @@ ${consts.name}
 ${params.name}
 ${env.NAME}
 ${steps.step_id.outputs.name}
+${foreach.item}
 ```
 
 This spec defines field evaluation modes, where Dagu-owned references are allowed, how their text is parsed, and when values are resolved.
@@ -61,6 +62,7 @@ Dagu must be explicit about which syntax it owns and which syntax remains owned 
 - Step identity: [Spec 009: Step Reference](009-step-reference.md)
 - Dynamic evaluation: [Spec 011: Dynamic Evaluation](011-dynamic-evaluation.md)
 - Step output publication: [Spec 012: Step Outputs](012-step-outputs.md)
+- Parallel and foreach item scopes: [Spec 018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md)
 
 ## Behavior
 
@@ -146,6 +148,7 @@ runtime but produce inspection-only passive notices.
 | `params` | Spec 005 | `params.<name>` | Preserve with passive notice. | No |
 | `env` | Spec 006 | `env.<NAME>` | Preserve with passive notice. | No |
 | `steps` | Spec 007 | `steps.<step_id>.outputs.<name>` | Preserve with reason-specific passive notice. | No |
+| `foreach` | Spec 018 | `foreach.index`, `foreach.key`, `foreach.<as>`, or `foreach.<as>.<field>` | Preserve with passive notice when item scope is unavailable or the item field is missing. | Yes |
 | `context` | Spec 017 | `context.<namespace>.<field>` | Preserve with passive notice. | Yes |
 
 Spec 017 also defines frozen top-level compatibility aliases `dag`, `run`,
@@ -238,6 +241,7 @@ Dagu-owned references are supported only in value-resolved fields and dynamic-ev
 | `steps[].repeat_policy.limit`, `steps[].repeat_policy.interval_sec`, and `steps[].repeat_policy.max_interval_sec` string forms | Value-resolved | Before the repeat policy uses the value | Step repeat policy string numeric fields resolve Dagu-owned references. Other repeat policy fields remain literal unless an owning spec opts in. |
 | Sub-DAG invocation target and params | Value-resolved | Before the sub-DAG run or enqueue request is created | Canonical `dag.run` and `dag.enqueue` `with.dag` resolves Dagu-owned references. Scalar string `with.params` resolves as one value. Nested string leaves under object-form or array-form `with.params` resolve individually. Accepted legacy `call` and legacy `params` follow the same target and params rules. |
 | `steps[].parallel` | Value-resolved | Before expanding the parallel step | `variable`, `items[]`, `items[].value`, and `items[].params.*` string values resolve Dagu-owned references. |
+| `steps[].foreach` | Value-resolved | Before and during the foreach step | `items`, `key`, value-resolved string fields inside `foreach.steps`, and `collect` values resolve Dagu-owned references. Spec 018 defines the scoped `foreach` namespace available to those fields. |
 | `steps[].stdout`, `steps[].stdout.artifact` | Value-resolved | Step start or stdout setup | Stdout file path strings and artifact path strings resolve Dagu-owned references. For unqualified environment syntax in these path strings, backslashes remain path text unless Spec 006 assigns them escape behavior. |
 | `steps[].stderr`, `steps[].stderr.artifact` | Value-resolved | Step start or stderr setup | Stderr file path strings and artifact path strings resolve Dagu-owned references. For unqualified environment syntax in these path strings, backslashes remain path text unless Spec 006 assigns them escape behavior. |
 | `steps[].stdout.outputs.fields.*` | Value-resolved | Output publication | Literal string values under field entries resolve Dagu-owned references. Selection and decode metadata remain literal unless an owning spec opts in. |
@@ -254,6 +258,7 @@ Explicitly literal or excluded field surfaces:
 | Root identity and metadata, such as `name` and `description` | Dagu does not resolve value references in these fields. |
 | Root run-control fields, such as `retry_policy`, `timeout_sec`, `delay_sec`, `max_active_steps`, `max_clean_up_time_sec`, and `max_output_size` | Dagu does not resolve value references in these fields unless an owning spec later opts in. |
 | Step identity, graph, and action-selection fields, such as `steps[].id`, `steps[].name`, `steps[].description`, `steps[].depends`, and `steps[].action` | Dagu does not resolve value references in these fields. A value reference cannot select a step, dependency, or action. |
+| `steps[].foreach.as`, `steps[].foreach.max_concurrent`, and body step identity or dependency fields | Dagu does not resolve value references in these fields. A value reference cannot select an item alias, concurrency limit, body step, or body dependency. |
 | Step output declaration contracts, such as `steps[].outputs[].name` and `steps[].outputs[].type` | Dagu does not resolve value references in declaration metadata. Published output values are separate runtime data. |
 | Step control fields not listed in the value-resolution matrix, such as `steps[].timeout_sec`, `steps[].continue_on`, `steps[].worker_selector`, `steps[].mail_on_error`, and `steps[].signal_on_stop` | Dagu does not resolve value references in these fields unless an owning spec later opts in. |
 | LLM selection and credential fields, such as provider names, model names, API key names, and tool-name lists | This spec does not opt these fields into value resolution. They remain literal unless an LLM-owning spec explicitly opts in. |

--- a/specs/005-value-resolution-params.md
+++ b/specs/005-value-resolution-params.md
@@ -131,6 +131,7 @@ This matrix defines the required `${params.name}` behavior for value-resolution 
 | `steps[].preconditions[].condition` | Step precondition condition strings resolve declared params. |
 | `steps[].repeat_policy.condition` | Repeat condition strings resolve declared params. |
 | `steps[].parallel` | `variable`, `items[]`, `items[].value`, and `items[].params.*` string values resolve declared params. |
+| `steps[].foreach` | `items`, `key`, value-resolved string fields inside `foreach.steps`, and `collect` values resolve declared params. |
 | `steps[].stdout`, `steps[].stdout.artifact` | Stdout file path strings and artifact path strings resolve declared params. |
 | `steps[].stderr`, `steps[].stderr.artifact` | Stderr file path strings and artifact path strings resolve declared params. |
 | `steps[].stdout.outputs.fields.*` | Literal string values under field entries resolve declared params. |

--- a/specs/006-value-resolution-env.md
+++ b/specs/006-value-resolution-env.md
@@ -360,7 +360,7 @@ environment references.
 | General `steps[].with` nested strings for action and executor inputs | Dagu expands against the step environment scope unless a more specific row or owning action spec applies. | Not allowed. |
 | Root `container` object strings and `steps[].container` object strings other than `env` | Dagu expands against the owning root or step environment scope. | Not allowed. |
 | `steps[].stdout`, `steps[].stderr`, artifact paths, `steps[].stdout.outputs.fields.*` literal strings, and `steps[].output.*` literal or path strings | Dagu expands against the step environment scope when the owning output surface is evaluated. | Not allowed. |
-| `steps[].parallel` strings, sub-DAG names, sub-DAG params, handler step fields, and nested value-resolved workflow strings not listed above | Dagu expands against the current environment scope when the owning field is evaluated. | Not allowed. |
+| `steps[].parallel` strings, `steps[].foreach` strings, sub-DAG names, sub-DAG params, handler step fields, and nested value-resolved workflow strings not listed above | Dagu expands against the current environment scope when the owning field is evaluated. | Not allowed. |
 | Template script text or fields owned by a template executor | Dagu does not expand unqualified environment syntax unless the owning template spec explicitly opts in. | Not applicable. |
 
 When host process environment fallback is not allowed, an unqualified reference

--- a/specs/007-value-resolution-steps.md
+++ b/specs/007-value-resolution-steps.md
@@ -87,6 +87,24 @@ Explicit inspection surfaces report a passive notice for that preserved referenc
 
 - Step output references do not read singular `output`, `stdout.outputs`, legacy DAG/action outputs, stdout, stderr, logs, artifacts, or nested output paths.
 
+### Foreach Body Scope
+
+Spec 018 adds `foreach.steps` body scopes.
+
+Rules:
+
+- A `foreach` body step can reference top-level step outputs when the top-level
+  producer is ordered before the owning `foreach` step.
+- A `foreach` body step can reference an earlier body step output from the same
+  item body.
+- Body step output references never cross item bodies.
+- A top-level step after a `foreach` step cannot reference body step outputs
+  directly.
+- A top-level step after a `foreach` step must consume the `foreach` aggregate
+  output when it needs values collected from body steps.
+- `foreach.collect` expressions resolve after a successful item body with item
+  scope and that item body's step-output scope available.
+
 ### Validation
 
 - An unresolved supported step-output reference in a value-resolution field must preserve the original reference text.

--- a/specs/009-step-reference.md
+++ b/specs/009-step-reference.md
@@ -139,6 +139,22 @@ steps:
     run: ./deploy.sh
 ```
 
+### Foreach Body Steps
+
+Spec 018 adds `foreach.steps` body scopes.
+
+Rules:
+
+- Body step identity is scoped to one `foreach` body.
+- Body step ids and names must be unique inside that body.
+- Body step ids and names must not collide with top-level step ids or names
+  visible to the owning `foreach` step.
+- Body step dependencies stay inside the body.
+- A body step dependency can identify another body step by name or id.
+- A body step dependency cannot identify a top-level step.
+- A top-level step dependency cannot identify a body step.
+- Dependency and strict step-output references never cross item bodies.
+
 ### Value References
 
 Strict step-output references under the `steps` namespace use step ids:

--- a/specs/018-parallel-and-foreach.md
+++ b/specs/018-parallel-and-foreach.md
@@ -2,31 +2,7 @@
 
 ## Status
 
-Partially implemented.
-
-Implemented `parallel` behavior covers:
-
-- `parallel` on `action: dag.run` and `action: dag.enqueue`
-- string, direct-array, and object-form item sources
-- default `max_concurrent: 10`
-- `max_concurrent` limiting active child DAG runs for `action: dag.run`
-- `${ITEM}` and top-level `${ITEM.field}` item references in child DAG target
-  and params
-- string item source compatibility parsing
-- coalescing duplicate resolved child DAG target and params into one represented
-  child run
-- aggregate JSON output for `dag.run` and `dag.enqueue`
-
-Target-only behavior in this spec includes:
-
-- the `foreach` field
-- strict `parallel` validation for unknown object fields, `max_concurrent`
-  upper bound, and strict integer handling where current product behavior is
-  looser
-- `max_concurrent` enforcement for `dag.enqueue` request creation
-
-Target-only behavior must not be treated as product behavior until
-implementation and black-box conformance tests catch up.
+Implemented.
 
 ## Scope
 
@@ -51,26 +27,12 @@ This spec does not define:
 
 - graph DAG scheduling of independent top-level steps
 - nested-array step shorthand for parallel branches
-- the legacy `call` and `params` aliases as normative syntax
+- the `call` and `params` aliases as normative syntax
 - scheduler, queue worker, coordinator, storage, API, or UI internals
 - how a child DAG or body step executes after the item-specific inputs have
   been resolved
 - action-specific behavior other than the `dag.run` and `dag.enqueue` fan-out
   surfaces named here
-
-Compatibility aliases may continue to exist, but conformance for this spec is
-measured against the canonical syntax shown in the examples.
-
-## Goal
-
-Workflow authors can express item-based fan-out without guessing whether an
-item is passed to a child DAG, to an inline body, to a shell, or to the queue.
-
-`parallel` keeps the existing child-DAG fan-out contract stable.
-
-`foreach` gives workflow authors an inline iteration construct for cases where
-creating a separate child DAG only to process one item would add avoidable
-workflow structure.
 
 ## Related Specs
 
@@ -119,19 +81,13 @@ An item run is one represented child DAG run or enqueue request created by
 
 #### Concurrency
 
-- For target conformance, `max_concurrent` limits the number of represented
-  child runs, enqueue requests, or item bodies that may be active at the same
-  time for the owning expansion construct.
+- `max_concurrent` limits the number of represented child runs, enqueue
+  requests, or item bodies that may be active at the same time for the owning
+  expansion construct.
 
 - `max_concurrent` must be an integer from `1` through `1000`.
 
 - When `max_concurrent` is omitted, Dagu uses `10`.
-
-- Current implemented `parallel` behavior enforces `max_concurrent` for active
-  `dag.run` child DAG runs.
-
-- `max_concurrent` enforcement for `foreach` and for `dag.enqueue` request
-  creation is target-only behavior.
 
 - `max_concurrent` does not limit normal top-level graph scheduling outside the
   owning expansion step.
@@ -223,7 +179,7 @@ steps:
 
 #### String Item Sources
 
-For `parallel`, a string item source supports existing compatibility forms.
+For `parallel`, a string item source supports these forms.
 
 Rules:
 
@@ -276,8 +232,8 @@ Rules:
   whole parameter payload.
 
 - If `with.params` is present, the resolved `with.params` value is the child
-  DAG parameter payload. Workflow authors must include `${ITEM}` or
-  `${ITEM.field}` there when the child needs item data.
+  DAG parameter payload. Child DAG parameter payloads include item data only
+  when `with.params` contains `${ITEM}` or `${ITEM.field}`.
 
 #### Represented Child Runs
 
@@ -290,14 +246,13 @@ Rules:
   resolved child DAG params.
 
 - If more than one item slot resolves to the same child DAG target and the same
-  child DAG params, current implemented behavior represents those item slots as
-  one child run.
+  child DAG params, Dagu represents those item slots as one child run.
 
 - Parent step child-run lists and `parallel` aggregate counts count represented
   child runs, not raw expanded item slots.
 
-- Workflow authors that need one child run per item slot must make the resolved
-  child DAG params distinct for each item slot.
+- One child run per item slot requires distinct resolved child DAG params for
+  each item slot.
 
 #### `dag.run` Semantics
 
@@ -624,8 +579,8 @@ Each `items` entry must include:
 
 Each successful `items` entry must include `outputs`.
 
-Each failed `items` entry should include an error message when an error message
-is available.
+Each failed `items` entry must include `error` when an error message is
+available.
 
 Rules:
 
@@ -636,14 +591,11 @@ Rules:
 
 - If `foreach.collect` is omitted, successful item output maps are empty.
 
-- Dagu must not include the raw item value in the aggregate output unless a
-  future spec adds an explicit field for that.
+- Dagu must not include the raw item value in the aggregate output.
 
 ## Errors
 
-The errors below define target conformance. The Status section identifies
-implemented `parallel` behavior and target-only behavior where current product
-behavior is looser.
+The errors below define conformance behavior.
 
 ### Parallel Errors
 
@@ -704,8 +656,8 @@ Rules:
 
 - Timeout and abort must not start new pending item runs or item bodies.
 
-- Active child DAG runs or item bodies must receive the same stop signal that a
-  normal running step would receive in the same lifecycle state.
+- Active child DAG runs or item bodies must receive the same stop signal as a
+  normal running step in the same lifecycle state.
 
 - A timed-out or aborted expansion step must not be reported as succeeded.
 

--- a/specs/018-parallel-and-foreach.md
+++ b/specs/018-parallel-and-foreach.md
@@ -1,0 +1,844 @@
+# Spec: Parallel Fan-Out and Foreach Iteration
+
+## Status
+
+Partially implemented.
+
+Implemented `parallel` behavior covers:
+
+- `parallel` on `action: dag.run` and `action: dag.enqueue`
+- string, direct-array, and object-form item sources
+- default `max_concurrent: 10`
+- `max_concurrent` limiting active child DAG runs for `action: dag.run`
+- `${ITEM}` and top-level `${ITEM.field}` item references in child DAG target
+  and params
+- string item source compatibility parsing
+- coalescing duplicate resolved child DAG target and params into one represented
+  child run
+- aggregate JSON output for `dag.run` and `dag.enqueue`
+
+Target-only behavior in this spec includes:
+
+- the `foreach` field
+- strict `parallel` validation for unknown object fields, `max_concurrent`
+  upper bound, and strict integer handling where current product behavior is
+  looser
+- `max_concurrent` enforcement for `dag.enqueue` request creation
+
+Target-only behavior must not be treated as product behavior until
+implementation and black-box conformance tests catch up.
+
+## Scope
+
+This spec defines two item-expansion step fields:
+
+- `parallel`, which expands items into represented child DAG runs or enqueue
+  requests.
+- `foreach`, which runs an inline step body once for each item in the same DAG
+  document.
+
+This spec covers:
+
+- accepted field shapes
+- item source parsing
+- item-scoped value references
+- concurrency limits
+- parent step status
+- aggregate outputs
+- validation and runtime errors
+
+This spec does not define:
+
+- graph DAG scheduling of independent top-level steps
+- nested-array step shorthand for parallel branches
+- the legacy `call` and `params` aliases as normative syntax
+- scheduler, queue worker, coordinator, storage, API, or UI internals
+- how a child DAG or body step executes after the item-specific inputs have
+  been resolved
+- action-specific behavior other than the `dag.run` and `dag.enqueue` fan-out
+  surfaces named here
+
+Compatibility aliases may continue to exist, but conformance for this spec is
+measured against the canonical syntax shown in the examples.
+
+## Goal
+
+Workflow authors can express item-based fan-out without guessing whether an
+item is passed to a child DAG, to an inline body, to a shell, or to the queue.
+
+`parallel` keeps the existing child-DAG fan-out contract stable.
+
+`foreach` gives workflow authors an inline iteration construct for cases where
+creating a separate child DAG only to process one item would add avoidable
+workflow structure.
+
+## Related Specs
+
+- YAML schema: [Spec 002: YAML Schema](002-yaml-schema.md)
+- Value resolution: [Spec 003: Value Resolution and Field Evaluation](003-value-resolution.md)
+- Environment values: [Spec 006: Value Resolution Env](006-value-resolution-env.md)
+- Step output references: [Spec 007: Value Resolution Steps](007-value-resolution-steps.md)
+- Step identity: [Spec 009: Step Reference](009-step-reference.md)
+- Step outputs: [Spec 012: Step Outputs](012-step-outputs.md)
+- Step run: [Spec 013: Step Run](013-step-run.md)
+
+## Terms
+
+An item source is a workflow value that expands to zero or more items.
+
+An item is one expanded value from an item source.
+
+An item slot is the zero-based position of an item in the expanded item list.
+
+An item key is the stable string identity for one item slot inside one
+`foreach` step.
+
+An item body is the inline `steps` list under `foreach`.
+
+An item run is one represented child DAG run or enqueue request created by
+`parallel` after item-specific child DAG target and params are resolved.
+
+## Behavior
+
+### Common Behavior
+
+#### Item Ordering
+
+- Item sources are expanded after the owning step's dependencies have reached
+  the status required for the owning step to start.
+
+- Static YAML arrays are expanded in YAML array order.
+
+- JSON arrays are expanded in JSON array order.
+
+- A spec section below must explicitly say when consumers may rely on aggregate
+  output array order.
+
+- Starting and completion order are not guaranteed unless an owning action spec
+  explicitly says otherwise.
+
+#### Concurrency
+
+- For target conformance, `max_concurrent` limits the number of represented
+  child runs, enqueue requests, or item bodies that may be active at the same
+  time for the owning expansion construct.
+
+- `max_concurrent` must be an integer from `1` through `1000`.
+
+- When `max_concurrent` is omitted, Dagu uses `10`.
+
+- Current implemented `parallel` behavior enforces `max_concurrent` for active
+  `dag.run` child DAG runs.
+
+- `max_concurrent` enforcement for `foreach` and for `dag.enqueue` request
+  creation is target-only behavior.
+
+- `max_concurrent` does not limit normal top-level graph scheduling outside the
+  owning expansion step.
+
+#### Value Resolution
+
+- Item source strings are value-resolved before expansion.
+
+- Item-scoped references are available only in the fields explicitly named by
+  the `parallel` or `foreach` sections below.
+
+- Item-scoped references do not create dependencies.
+
+- References to prior top-level step outputs still require normal dependency
+  ordering under Spec 007.
+
+- Dynamic evaluation is not run for item-scoped references unless another spec
+  explicitly opts in.
+
+### Parallel
+
+#### Field Shape
+
+`parallel` is an optional step field.
+
+Rules:
+
+- A step with `parallel` must use `action: dag.run` or `action: dag.enqueue`.
+
+- A step with `parallel` must not define `foreach`.
+
+- `parallel` accepts a string item source:
+
+```yaml
+steps:
+  - id: fanout
+    action: dag.run
+    with:
+      dag: process-item
+    parallel: ${params.items}
+```
+
+- `parallel` accepts a direct array item source:
+
+```yaml
+steps:
+  - id: fanout
+    action: dag.run
+    with:
+      dag: process-item
+    parallel:
+      - item-a
+      - item-b
+```
+
+- `parallel` accepts an object form with required `items` and optional
+  `max_concurrent`:
+
+```yaml
+steps:
+  - id: fanout
+    action: dag.run
+    with:
+      dag: process-item
+    parallel:
+      items:
+        - item-a
+        - item-b
+      max_concurrent: 2
+```
+
+- Object-form `parallel` must not contain fields other than `items` and
+  `max_concurrent`.
+
+- `parallel.items` may be a string item source or a direct array item source.
+
+- Direct array items may be strings, numbers, or flat mappings.
+
+- A flat mapping item represents item fields.
+
+- Flat mapping item values may be strings, numbers, or booleans.
+
+- Nested mapping items and nested array items are invalid for static
+  `parallel` arrays.
+
+- A `parallel` expansion must produce at least one item.
+
+- A `parallel` expansion must not produce more than `1000` items.
+
+#### String Item Sources
+
+For `parallel`, a string item source supports existing compatibility forms.
+
+Rules:
+
+- If the resolved string is a valid JSON array, each JSON array entry is one
+  item.
+
+- If the resolved string is a valid JSON object, the whole object is one item.
+
+- If the resolved string is not JSON, non-empty tokens become items.
+
+- Token separators are line breaks, commas, semicolons, pipes, tabs, or runs of
+  unquoted whitespace.
+
+- Double-quoted token groups preserve whitespace inside the group.
+
+- Empty tokens are ignored.
+
+- An empty or whitespace-only resolved string produces zero items and therefore
+  fails the `parallel` step.
+
+#### Item Scope
+
+For each expanded item, Dagu evaluates the child DAG target and child DAG
+params with an item scope.
+
+Rules:
+
+- `${ITEM}` resolves to the current item.
+
+- For a scalar item, `${ITEM}` resolves to that scalar as text.
+
+- For an object item, `${ITEM}` resolves to a compact JSON object.
+
+- `${ITEM.field}` resolves to a top-level field from an object item.
+
+- `${ITEM.field}` is not defined for scalar items.
+
+- Nested item paths such as `${ITEM.a.b}` are outside this spec.
+
+- Item scope is available to `with.dag`.
+
+- Item scope is available to `with.params`.
+
+- Item scope is not available to `with.queue`.
+
+- Item scope is not available to unrelated step fields unless another spec
+  explicitly opts in.
+
+- If `with.params` is omitted, the child DAG receives the current item as its
+  whole parameter payload.
+
+- If `with.params` is present, the resolved `with.params` value is the child
+  DAG parameter payload. Workflow authors must include `${ITEM}` or
+  `${ITEM.field}` there when the child needs item data.
+
+#### Represented Child Runs
+
+`parallel` first expands item slots, then resolves the child DAG target and
+child DAG params for each item slot.
+
+Rules:
+
+- A represented child run is identified by the resolved child DAG target and
+  resolved child DAG params.
+
+- If more than one item slot resolves to the same child DAG target and the same
+  child DAG params, current implemented behavior represents those item slots as
+  one child run.
+
+- Parent step child-run lists and `parallel` aggregate counts count represented
+  child runs, not raw expanded item slots.
+
+- Workflow authors that need one child run per item slot must make the resolved
+  child DAG params distinct for each item slot.
+
+#### `dag.run` Semantics
+
+When `parallel` is used with `action: dag.run`, the parent step starts child
+DAG runs and waits for their terminal status.
+
+Rules:
+
+- If every represented child DAG run is `succeeded`, the parent step is
+  `succeeded`.
+
+- If one or more represented child DAG runs fail, the parent step fails after
+  the fan-out reaches a terminal state.
+
+- If no represented child DAG run fails, aborts, is rejected, or ends in
+  another non-success terminal status, and at least one represented child DAG run
+  is `partially_succeeded`, the parent step is `partially_succeeded`.
+
+- If one or more represented child DAG runs wait for external approval or input,
+  the parent step waits.
+
+- Aborting the parent step stops launching pending item runs and asks active
+  child DAG runs to abort.
+
+- A parent step timeout is handled as a parent step failure or abort according
+  to the step timeout contract.
+
+- Parent step retry retries the fan-out step. This spec does not define
+  per-item retry of only failed items.
+
+#### `dag.enqueue` Semantics
+
+When `parallel` is used with `action: dag.enqueue`, the parent step creates or
+finds queued child DAG runs and does not wait for those child runs to execute.
+
+Rules:
+
+- The parent step succeeds when every represented child enqueue request is
+  accepted or resolves to an existing child run.
+
+- The parent step fails when any represented child enqueue request fails.
+
+- `with.queue` selects the queue for all item runs in that step.
+
+- `max_concurrent` does not control later queue processing. Queue processing is
+  owned by the queue configuration.
+
+#### Aggregate Outputs
+
+When a `parallel` step writes an aggregate output, the payload is JSON.
+
+For `action: dag.run`, the payload object has these required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `summary.total` | Number of represented child DAG runs in the aggregate. |
+| `summary.succeeded` | Number of represented child DAG runs counted as successful. |
+| `summary.failed` | Number of represented child DAG runs not counted as successful. |
+| `results` | Child run result objects. |
+| `outputs` | Output maps from successful child DAG runs. |
+
+Rules:
+
+- `summary.succeeded` includes child DAG runs that are `succeeded` or
+  `partially_succeeded`.
+
+- `outputs` contains only child DAG runs counted as successful.
+
+- A failed child DAG run contributes to `summary.failed` and must not contribute
+  an output map to `outputs`.
+
+- Consumers must not infer item slot identity from `results` or `outputs` array
+  position unless a later spec adds an explicit ordering guarantee.
+
+For a `parallel` step using `action: dag.enqueue`, the payload object has these
+required fields, including when expansion or duplicate coalescing leaves exactly
+one represented enqueue request:
+
+| Field | Meaning |
+| --- | --- |
+| `summary.total` | Number of represented enqueue requests. |
+| `summary.queued` | Number of child runs newly queued by this step. |
+| `runs` | Per-child enqueue result objects. |
+
+Each `runs` entry must include:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Child DAG name. |
+| `dagRunId` | Child DAG-run id. |
+| `queue` | Queue selected for that child run. |
+| `status` | Status observed after the enqueue request. |
+
+Each `runs` entry may include:
+
+| Field | Meaning |
+| --- | --- |
+| `params` | Child parameter payload. |
+| `alreadyExists` | True when the child run already existed. |
+
+### Foreach
+
+#### Field Shape
+
+`foreach` is an optional step field.
+
+Rules:
+
+- A step with `foreach` must not define another execution selector, such as
+  `run`, `action`, `command`, `script`, `call`, or `parallel`.
+
+- `foreach` must be an object.
+
+- `foreach.items` is required.
+
+- `foreach.steps` is required.
+
+- `foreach.steps` must be a non-empty sequence of step objects.
+
+- `foreach.as` is optional and defaults to `item`.
+
+- `foreach.as` must match `^[A-Za-z][A-Za-z0-9_]*$`.
+
+- `foreach.as` must not be `index` or `key`.
+
+- `foreach.key` is optional.
+
+- `foreach.max_concurrent` is optional and follows the common concurrency
+  rules above.
+
+- `foreach.collect` is optional.
+
+- `foreach` must not contain fields other than `items`, `as`, `key`,
+  `max_concurrent`, `steps`, and `collect`.
+
+Example shape:
+
+```yaml
+steps:
+  - id: summarize_episodes
+    foreach:
+      items: ${steps.list_episodes.outputs.episodes}
+      as: episode
+      key: ${foreach.episode.slug}
+      max_concurrent: 3
+      steps:
+        - id: summarize
+          run: ./summarize.sh ${foreach.episode.url}
+          outputs:
+            - name: markdown
+      collect:
+        markdown: ${steps.summarize.outputs.markdown}
+    output: EPISODE_SUMMARIES
+```
+
+#### Item Sources
+
+Rules:
+
+- `foreach.items` may be a YAML array.
+
+- `foreach.items` may be a string that resolves to a JSON array.
+
+- A non-array JSON value is invalid for `foreach.items`.
+
+- A non-JSON resolved string is invalid for `foreach.items`.
+
+- An empty array is valid and produces zero item body executions.
+
+- A `foreach` expansion must not produce more than `1000` items.
+
+- Static YAML array items may be any JSON-compatible value.
+
+#### Item Keys
+
+Rules:
+
+- If `foreach.key` is omitted, the item key is the decimal item slot index.
+
+- If `foreach.key` is present, Dagu resolves it once per item with item scope
+  available.
+
+- The resolved item key must be a non-empty string.
+
+- Item keys must be unique inside one `foreach` step.
+
+- Duplicate item keys fail the `foreach` step before any item body starts.
+
+#### Item Scope
+
+For each item body execution, Dagu exposes structured item references.
+
+Rules:
+
+- `${foreach.index}` resolves to the zero-based item slot index as decimal text.
+
+- `${foreach.key}` resolves to the item key.
+
+- `${foreach.<as>}` resolves to the current item.
+
+- When `as` is omitted, `${foreach.item}` resolves to the current item.
+
+- For a scalar item, `${foreach.<as>}` resolves to that scalar as text.
+
+- For an object or array item, `${foreach.<as>}` resolves to compact JSON.
+
+- `${foreach.<as>.field}` resolves to a top-level object field.
+
+- Nested item field paths such as `${foreach.item.a.b}` are outside this spec.
+
+- Item scope is available to `foreach.key`.
+
+- Item scope is available to every value-resolved string field inside
+  `foreach.steps`.
+
+- Item scope is available to every `foreach.collect` value.
+
+- The uppercase `${ITEM}` item reference is owned by `parallel`. It is not a
+  `foreach` item reference.
+
+#### Body Step Scope
+
+`foreach.steps` defines steps scoped to one item body.
+
+Rules:
+
+- Body step ids must be unique inside the body.
+
+- Body step names must be unique inside the body after loading.
+
+- Body step ids and names must not collide with top-level step ids or names
+  visible to the `foreach` step.
+
+- Body step dependencies stay inside the body.
+
+- Body steps must not depend on top-level steps directly.
+
+- Top-level steps must not depend on body steps directly.
+
+- A body step can reference top-level step outputs when the top-level producer
+  is ordered before the owning `foreach` step under Spec 007.
+
+- A body step can reference an earlier body step output from the same item body
+  using normal step-output reference syntax.
+
+- Body step output references never cross item bodies.
+
+- Top-level steps after the `foreach` step cannot reference body step outputs
+  directly. They must consume the `foreach` aggregate output.
+
+#### Collect
+
+`foreach.collect` defines output values copied from each successful item body
+into the parent aggregate output.
+
+Rules:
+
+- `foreach.collect` must be a mapping from output names to string expressions.
+
+- Collect output names must match `^[A-Za-z][A-Za-z0-9_]*$`.
+
+- Collect output names must be unique inside one `foreach` step.
+
+- Collect expressions are value-resolved after an item body succeeds.
+
+- Collect expressions are resolved with both item scope and that item body's
+  step-output scope available.
+
+- A collect expression that still contains a supported unresolved reference
+  after item body success fails that item.
+
+- Unsupported braced text follows Spec 003 preservation behavior.
+
+#### Execution Semantics
+
+Rules:
+
+- A `foreach` step with zero items succeeds without running body steps.
+
+- A `foreach` step with one or more items starts at most `max_concurrent` item
+  bodies at a time.
+
+- Each item body runs the same `foreach.steps` graph with that item's scope.
+
+- Item body execution order is not guaranteed.
+
+- The parent `foreach` step does not finish until every item body has reached a
+  terminal status, unless the parent step is aborted or times out.
+
+- If every item body succeeds, the parent `foreach` step succeeds.
+
+- If one or more item bodies fail, the parent `foreach` step fails after all
+  item bodies that can run have reached a terminal status.
+
+- A failed item body does not prevent later item bodies from starting unless
+  the parent step is aborted or times out.
+
+- Aborting the parent `foreach` step stops launching pending item bodies and
+  asks active item bodies to abort.
+
+- Parent step retry retries the entire `foreach` step. This spec does not
+  define per-item retry of only failed item bodies.
+
+#### Aggregate Outputs
+
+When a `foreach` step defines `output`, the captured value is a JSON object with
+these required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `summary.total` | Number of expanded items. |
+| `summary.succeeded` | Number of item bodies that succeeded. |
+| `summary.failed` | Number of item bodies that failed. |
+| `items` | Per-item status records. |
+| `outputs` | Collect maps from successful item bodies. |
+
+Each `items` entry must include:
+
+| Field | Meaning |
+| --- | --- |
+| `index` | Zero-based item slot index. |
+| `key` | Item key. |
+| `status` | Item body status. |
+
+Each successful `items` entry must include `outputs`.
+
+Each failed `items` entry should include an error message when an error message
+is available.
+
+Rules:
+
+- `items` is ordered by item slot index.
+
+- `outputs` is ordered by item slot index and includes only successful item
+  bodies.
+
+- If `foreach.collect` is omitted, successful item output maps are empty.
+
+- Dagu must not include the raw item value in the aggregate output unless a
+  future spec adds an explicit field for that.
+
+## Errors
+
+The errors below define target conformance. The Status section identifies
+implemented `parallel` behavior and target-only behavior where current product
+behavior is looser.
+
+### Parallel Errors
+
+Validation must fail when:
+
+- `parallel` appears on a step whose action is not `dag.run` or `dag.enqueue`.
+- `parallel` and `foreach` appear on the same step.
+- `parallel` has an invalid shape.
+- object-form `parallel` omits `items`.
+- object-form `parallel` contains an unknown field.
+- `max_concurrent` is not an integer from `1` through `1000`.
+- a static array item is a nested array.
+- a static array item is a nested mapping.
+- a static mapping item contains a value that is not a string, number, or
+  boolean.
+
+Runtime execution must fail when:
+
+- value resolution for an item source fails.
+- value resolution for a child DAG target or child params fails.
+- item expansion produces zero items.
+- item expansion produces more than `1000` items.
+- an expanded string item source cannot be parsed according to the `parallel`
+  string item source rules.
+- a child DAG target cannot be loaded.
+- a `dag.run` child DAG run fails.
+- a `dag.enqueue` child enqueue request fails.
+
+### Foreach Errors
+
+Validation must fail when:
+
+- `foreach` appears with another execution selector.
+- `foreach` has an invalid shape.
+- `foreach.items` is missing.
+- `foreach.steps` is missing or empty.
+- `foreach.as` is invalid.
+- `foreach.max_concurrent` is not an integer from `1` through `1000`.
+- `foreach.collect` is not a mapping from valid output names to strings.
+- a body step identity collides with another body step identity.
+- a body step identity collides with a visible top-level step identity.
+- a body step dependency names a top-level step.
+- a top-level step dependency names a body step.
+
+Runtime execution must fail when:
+
+- value resolution for `foreach.items` fails.
+- a string `foreach.items` value does not resolve to a JSON array.
+- item expansion produces more than `1000` items.
+- `foreach.key` resolves to an empty string.
+- two item slots resolve to the same item key.
+- an item body fails.
+- a collect expression fails to resolve after item body success.
+
+### Timeout and Abort
+
+Rules:
+
+- Timeout and abort must not start new pending item runs or item bodies.
+
+- Active child DAG runs or item bodies must receive the same stop signal that a
+  normal running step would receive in the same lifecycle state.
+
+- A timed-out or aborted expansion step must not be reported as succeeded.
+
+- Partial aggregate output on timeout or abort is allowed only when the output
+  clearly reports that not all items succeeded.
+
+## Examples
+
+### Parallel Child DAG Run
+
+```yaml
+steps:
+  - id: fanout_accounts
+    action: dag.run
+    with:
+      dag: workflows/process-account
+      params:
+        account_id: ${ITEM.account_id}
+        region: ${ITEM.region}
+    parallel:
+      max_concurrent: 2
+      items:
+        - account_id: acct_1
+          region: us-east-1
+        - account_id: acct_2
+          region: eu-west-1
+    output: ACCOUNT_RESULTS
+```
+
+Expected behavior:
+
+- Two child DAG runs are represented.
+- Each child receives item-specific params.
+- The parent waits for both child DAG runs.
+- `ACCOUNT_RESULTS` is JSON with `summary`, `results`, and `outputs`.
+
+### Parallel Child Enqueue
+
+```yaml
+steps:
+  - id: enqueue_accounts
+    action: dag.enqueue
+    with:
+      dag: workflows/process-account
+      queue: background
+      params:
+        account_id: ${ITEM.account_id}
+    parallel:
+      items:
+        - account_id: acct_1
+        - account_id: acct_2
+    output: ENQUEUE_RESULTS
+```
+
+Expected behavior:
+
+- Two child enqueue requests are represented.
+- The parent succeeds after both enqueue requests are accepted or found.
+- The parent does not wait for queued child DAG execution.
+- `ENQUEUE_RESULTS` is JSON with `summary` and `runs`.
+
+### Foreach Inline Body
+
+```yaml
+steps:
+  - id: list_episodes
+    run: ./list-episodes.sh
+    outputs:
+      - name: episodes
+        type: json
+
+  - id: summarize_episodes
+    depends: list_episodes
+    foreach:
+      items: ${steps.list_episodes.outputs.episodes}
+      as: episode
+      key: ${foreach.episode.slug}
+      max_concurrent: 3
+      steps:
+        - id: fetch_transcript
+          run: ./fetch-transcript.sh ${foreach.episode.url}
+          outputs:
+            - name: transcript_path
+        - id: summarize
+          depends: fetch_transcript
+          run: ./summarize-ja.sh ${steps.fetch_transcript.outputs.transcript_path}
+          outputs:
+            - name: markdown
+      collect:
+        markdown: ${steps.summarize.outputs.markdown}
+    output: EPISODE_SUMMARIES
+```
+
+Expected behavior:
+
+- The `episodes` JSON array controls the number of item bodies.
+- Each item body sees `${foreach.episode.*}` for its own item only.
+- Each item body can pass data between body steps through normal step-output
+  references.
+- The top-level workflow consumes body results through `EPISODE_SUMMARIES`.
+
+### Foreach Empty Input
+
+```yaml
+steps:
+  - id: summarize_episodes
+    foreach:
+      items: []
+      steps:
+        - id: summarize
+          run: ./summarize.sh ${foreach.item}
+    output: EPISODE_SUMMARIES
+```
+
+Expected behavior:
+
+- No body step runs.
+- The `summarize_episodes` step succeeds.
+- `EPISODE_SUMMARIES.summary.total` is `0`.
+
+### Invalid Parallel Action
+
+```yaml
+steps:
+  - id: invalid
+    action: http.request
+    with:
+      url: https://example.com
+    parallel:
+      items: [a, b]
+```
+
+Expected behavior:
+
+- Validation fails because `parallel` is only valid with `dag.run` or
+  `dag.enqueue`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,7 +26,7 @@ It must not be treated as product behavior until implementation catches up.
 | [014: Step Run Command](014-step-run-command.md) | Implemented |
 | [015: Step Run Script](015-step-run-script.md) | Implemented |
 | [017: Built-In Run Context](017-built-in-run-context.md) | Implemented |
-| [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Partially implemented |
+| [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Implemented |
 
 **Writing guidelines:**
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,6 +26,7 @@ It must not be treated as product behavior until implementation catches up.
 | [014: Step Run Command](014-step-run-command.md) | Implemented |
 | [015: Step Run Script](015-step-run-script.md) | Implemented |
 | [017: Built-In Run Context](017-built-in-run-context.md) | Implemented |
+| [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Summary:
- Implement Spec 018 parallel and foreach behavior.
- Add foreach runtime, typed item scope, schema/parser validation, and conformance coverage.
- Update related value-resolution and step-reference specs.

Validation:
- go test ./internal/core ./internal/core/spec ./internal/cmn/schema ./internal/cmn/value ./internal/runtime ./internal/runtime/builtin/dag ./internal/runtime/builtin/foreach -count=1
- make conformance CONFORMANCE_TEST_TARGET=./conformance/spec018_parallel_foreach

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Spec 018 for parallel fan‑out and foreach iteration. Adds a `foreach` runtime with item-scoped `${foreach.*}` bindings and aggregate `collect`, tightens `parallel.max_concurrent` to 1–1000 with item shape checks, improves `dag.enqueue` concurrency, preserves child DAG env scope, and stabilizes the approval inputs test.

- **New Features**
  - Add `foreach` executor: iterate `items` (array or JSON string) with optional `as`/`key`, `max_concurrent`, and `collect` for aggregate output.
  - Expose `${foreach.index}`, `${foreach.key}`, and `${foreach.item}` (or alias) to body steps and `collect`; propagate `foreach` scope through env/resolver; preserve child DAG env scope over inherited step env.
  - Enforce bounds and shapes: `parallel.max_concurrent` in 1–1000; object item values must be scalars; `dag.enqueue` honors sequential/parallel concurrency; validate body scoping (deps by id/name within body, unique ids/names), and suppress out‑of‑scope `foreach` notices.

- **Migration**
  - `parallel.max_concurrent` must be an integer from 1 to 1000.
  - When `foreach.items` is a string, it must be a valid JSON array.
  - Object item values for `parallel`/`foreach` must be scalars (string/number/boolean), not nested objects/arrays.
  - Body step outputs are not addressable from outside `foreach`; consume the aggregate output instead.
  - When `key` is set for `foreach`, item keys must be unique.

<sup>Written for commit a34adbe3902844d8ebdda77d96a2bd01f53de403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `foreach` step construct for iterating over item sources and running an inline step body with concurrency control.
  * Added `${foreach.*}` template bindings within `foreach` bodies (including item fields and per-item key/index).
  * Added `collect` to aggregate `foreach` results into consolidated outputs.
* **Improvements**
  * Enforced stricter `parallel.max_concurrent` validation (integer-only, range 1–1000) and improved validation/runtime handling for invalid `foreach` configurations and duplicate keys.
  * Added support for `foreach` in the workflow schema and value/runner scoping.
* **Documentation**
  * Marked the parallel/foreach spec as implemented in the specs overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->