### PR TITLE
fix: refresh DAG list SSE after file changes

### DIFF
--- a/conformance/spec014_step_run_command/step_run_command_test.go
+++ b/conformance/spec014_step_run_command/step_run_command_test.go
@@ -218,14 +218,11 @@ exit 64
 }
 
 func TestCommandFormPowerShellWhenAvailable(t *testing.T) {
-	t.Parallel()
 	if _, err := exec.LookPath("pwsh"); err != nil {
 		t.Skip("pwsh is not available")
 	}
 
 	t.Run("UTF-8 output is stable", func(t *testing.T) {
-		t.Parallel()
-
 		dagu := harness.NewRunner(t)
 		result := dagu.Run("start", "powershell_utf8.yaml")
 		result.ExpectExitCode(0)
@@ -233,8 +230,6 @@ func TestCommandFormPowerShellWhenAvailable(t *testing.T) {
 	})
 
 	t.Run("Write-Error fails command-form step", func(t *testing.T) {
-		t.Parallel()
-
 		dagu := harness.NewRunner(t)
 		result := dagu.Run("start", "powershell_error_fails.yaml")
 		result.ExpectExitCode(1)

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1196,8 +1196,15 @@ func (srv *Server) setupTerminalRoute(ctx context.Context, r *chi.Mux, apiV1Base
 }
 
 func (srv *Server) setupSSERoute(ctx context.Context, r *chi.Mux, apiV1BasePath string) {
-	srv.appStream = nil
-	logger.Info(ctx, "App SSE stream disabled; multiplexed SSE is the supported live-update transport")
+	appStream, err := sse.NewAppStreamService(sse.AppStreamConfig{
+		Paths:             srv.config.Paths,
+		HeartbeatInterval: srv.config.Server.SSE.HeartbeatInterval,
+	})
+	if err != nil {
+		logger.Warn(ctx, "Failed to start app SSE stream", tag.Error(err))
+	} else {
+		srv.appStream = appStream
+	}
 
 	var sseMetrics *sse.Metrics
 	if srv.metricsRegistry != nil {
@@ -1212,6 +1219,7 @@ func (srv *Server) setupSSERoute(ctx context.Context, r *chi.Mux, apiV1BasePath 
 		SlowClientTimeout:      srv.config.Server.SSE.SlowClientTimeout,
 	}, sseMetrics)
 	srv.registerDedicatedSSEFetchers(srv.sseMultiplexer)
+	srv.startAppStreamInvalidationBridge(ctx)
 	if srv.eventService != nil {
 		sse.StartDAGRunEventInvalidation(srv.sseMultiplexer.Context(), srv.eventService, srv.sseMultiplexer, slog.Default(), time.Second)
 	}
@@ -1233,6 +1241,74 @@ func (srv *Server) setupSSERoute(ctx context.Context, r *chi.Mux, apiV1BasePath 
 	})
 
 	logger.Info(ctx, "SSE routes configured", slog.String("basePath", apiV1BasePath))
+}
+
+func (srv *Server) startAppStreamInvalidationBridge(ctx context.Context) {
+	if srv.appStream == nil || srv.sseMultiplexer == nil {
+		return
+	}
+
+	bridgeCtx := srv.sseMultiplexer.Context()
+	events, unsubscribe := srv.appStream.Subscribe(bridgeCtx)
+	go func() {
+		defer unsubscribe()
+		for {
+			select {
+			case <-bridgeCtx.Done():
+				return
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				srv.wakeMultiplexedTopicsForAppEvent(event)
+			}
+		}
+	}()
+	logger.Info(ctx, "App SSE stream configured for multiplexed invalidation")
+}
+
+func (srv *Server) wakeMultiplexedTopicsForAppEvent(event sse.AppEvent) {
+	if srv.sseMultiplexer == nil {
+		return
+	}
+
+	switch event.Type {
+	case sse.AppEventTypeDAGChanged:
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAG)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGHistory)
+	case sse.AppEventTypeRunChanged:
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGRuns)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueues)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAG)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGHistory)
+	case sse.AppEventTypeQueue:
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueues)
+		if event.QueueName != "" {
+			srv.sseMultiplexer.WakeTopic(sse.TopicTypeQueueItems, event.QueueName)
+		} else {
+			srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueueItems)
+		}
+	case sse.AppEventTypeDoc:
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDocTree)
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDoc)
+	case sse.AppEventTypeReset:
+		srv.wakeAllMultiplexedFileBackedTopics()
+	}
+}
+
+func (srv *Server) wakeAllMultiplexedFileBackedTopics() {
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGRun)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeSubDAGRun)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAG)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGHistory)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGRuns)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueueItems)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueues)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDoc)
+	srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDocTree)
 }
 
 func (srv *Server) setupMCPRoute(ctx context.Context, r *chi.Mux) {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1273,6 +1273,8 @@ func (srv *Server) wakeMultiplexedTopicsForAppEvent(event sse.AppEvent) {
 	}
 
 	switch event.Type {
+	case sse.AppEventTypeConnected:
+		return
 	case sse.AppEventTypeDAGChanged:
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAG)
@@ -1358,14 +1360,17 @@ func (srv *Server) registerDedicatedSSEFetchers(registrar *sse.Multiplexer) {
 	registrar.RegisterFetcher(sse.TopicTypeDoc, srv.apiV1.GetDocContentData)
 	registrar.RegisterFetcher(sse.TopicTypeDocTree, srv.apiV1.GetDocTreeData)
 
-	// Document topics are invalidated by API doc mutations. They should not
-	// keep polling the docs store while an SSE connection is open.
-	registrar.SetRefreshMode(sse.TopicTypeDoc, sse.TopicRefreshModeOnDemand)
-	registrar.SetRefreshMode(sse.TopicTypeDocTree, sse.TopicRefreshModeOnDemand)
-	registrar.SetPublishOnWake(sse.TopicTypeDocTree, true)
+	appStreamAvailable := srv.appStream != nil
+	if appStreamAvailable {
+		// Document topics are invalidated by API doc mutations and file watcher
+		// events. They should not keep polling while those wakeups are available.
+		registrar.SetRefreshMode(sse.TopicTypeDoc, sse.TopicRefreshModeOnDemand)
+		registrar.SetRefreshMode(sse.TopicTypeDocTree, sse.TopicRefreshModeOnDemand)
+		registrar.SetPublishOnWake(sse.TopicTypeDocTree, true)
+	}
 
 	// Run-driven topics have an event-store invalidation path. Keeping them on
-	// demand avoids repeated full-list and history reads while browsers are
+	// demand avoids repeated history and run-list reads while browsers are
 	// connected; DAG-run event collection wakes the exact and aggregate topics.
 	if srv.eventService != nil {
 		for _, topicType := range []sse.TopicType{
@@ -1374,11 +1379,13 @@ func (srv *Server) registerDedicatedSSEFetchers(registrar *sse.Multiplexer) {
 			sse.TopicTypeDAGHistory,
 			sse.TopicTypeDAGRuns,
 			sse.TopicTypeQueues,
-			sse.TopicTypeDAGsList,
 		} {
 			registrar.SetRefreshMode(topicType, sse.TopicRefreshModeOnDemand)
 		}
-		registrar.SetPublishOnWake(sse.TopicTypeDAGsList, true)
+		if appStreamAvailable {
+			registrar.SetRefreshMode(sse.TopicTypeDAGsList, sse.TopicRefreshModeOnDemand)
+			registrar.SetPublishOnWake(sse.TopicTypeDAGsList, true)
+		}
 		registrar.SetPublishOnWake(sse.TopicTypeDAGRuns, true)
 		registrar.SetPublishOnWake(sse.TopicTypeQueues, true)
 	}

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -36,6 +36,14 @@ func testContext(t *testing.T) context.Context {
 	return ctx
 }
 
+func testAppStream(t *testing.T) *sse.AppStreamService {
+	t.Helper()
+	stream, err := sse.NewAppStreamService(sse.AppStreamConfig{})
+	require.NoError(t, err)
+	t.Cleanup(stream.Shutdown)
+	return stream
+}
+
 func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *testing.T) {
 	t.Parallel()
 
@@ -93,6 +101,7 @@ func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *t
 			srv := &Server{
 				apiV1:        &apiv1.API{},
 				eventService: eventstore.New(nil),
+				appStream:    testAppStream(t),
 			}
 			srv.registerDedicatedSSEFetchers(mux)
 
@@ -144,6 +153,56 @@ func TestRegisterDedicatedSSEFetchersUsesEventStoreInvalidationForRunTopics(t *t
 	}
 }
 
+func TestRegisterDedicatedSSEFetchersKeepsDAGsListPollingWithoutAppStream(t *testing.T) {
+	t.Parallel()
+
+	mux := sse.NewMultiplexer(sse.StreamConfig{HeartbeatInterval: time.Hour}, nil)
+	t.Cleanup(mux.Shutdown)
+
+	srv := &Server{
+		apiV1:        &apiv1.API{},
+		eventService: eventstore.New(nil),
+	}
+	srv.registerDedicatedSSEFetchers(mux)
+
+	var fetches atomic.Int64
+	mux.RegisterFetcher(sse.TopicTypeDAGsList, func(_ context.Context, identifier string) (any, error) {
+		return map[string]any{
+			"id":      identifier,
+			"fetches": fetches.Add(1),
+		}, nil
+	})
+
+	handler := sse.NewMultiplexHandler(mux, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/events/stream?topic="+url.QueryEscape("dagslist:page=1&perPage=100"),
+			nil,
+		).WithContext(ctx)
+		handler.HandleStream(httptest.NewRecorder(), req)
+	}()
+
+	require.Eventually(t, func() bool {
+		return fetches.Load() > 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestRegisterDedicatedSSEFetchersUsesMutationInvalidationForDocTopics(t *testing.T) {
 	t.Parallel()
 
@@ -175,7 +234,8 @@ func TestRegisterDedicatedSSEFetchersUsesMutationInvalidationForDocTopics(t *tes
 			t.Cleanup(mux.Shutdown)
 
 			srv := &Server{
-				apiV1: &apiv1.API{},
+				apiV1:     &apiv1.API{},
+				appStream: testAppStream(t),
 			}
 			srv.registerDedicatedSSEFetchers(mux)
 
@@ -250,6 +310,8 @@ func TestDAGFileChangeWakesDAGsListSSETopic(t *testing.T) {
 
 	router := chi.NewMux()
 	srv.setupSSERoute(testContext(t), router, "/api/v1")
+	require.NotNil(t, srv.appStream)
+	require.NotNil(t, srv.sseMultiplexer)
 	t.Cleanup(func() {
 		if srv.appStream != nil {
 			srv.appStream.Shutdown()

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -223,6 +225,84 @@ func TestRegisterDedicatedSSEFetchersUsesMutationInvalidationForDocTopics(t *tes
 			}, time.Second, 10*time.Millisecond)
 		})
 	}
+}
+
+func TestDAGFileChangeWakesDAGsListSSETopic(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	dagsDir := filepath.Join(rootDir, "dags")
+	require.NoError(t, os.MkdirAll(dagsDir, 0750))
+
+	srv := &Server{
+		config: &config.Config{
+			Paths: config.PathsConfig{
+				DAGsDir:         dagsDir,
+				SuspendFlagsDir: filepath.Join(rootDir, "flags"),
+				DAGRunsDir:      filepath.Join(rootDir, "dag-runs"),
+				QueueDir:        filepath.Join(rootDir, "queue"),
+				DocsDir:         filepath.Join(rootDir, "docs"),
+			},
+		},
+		apiV1:        &apiv1.API{},
+		eventService: eventstore.New(nil),
+	}
+
+	router := chi.NewMux()
+	srv.setupSSERoute(testContext(t), router, "/api/v1")
+	t.Cleanup(func() {
+		if srv.appStream != nil {
+			srv.appStream.Shutdown()
+		}
+		if srv.sseMultiplexer != nil {
+			srv.sseMultiplexer.Shutdown()
+		}
+	})
+
+	var fetches atomic.Int64
+	srv.sseMultiplexer.RegisterFetcher(sse.TopicTypeDAGsList, func(context.Context, string) (any, error) {
+		return map[string]any{
+			"fetches": fetches.Add(1),
+		}, nil
+	})
+
+	handler := sse.NewMultiplexHandler(srv.sseMultiplexer, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/events/stream?topic="+url.QueryEscape("dagslist:page=1&perPage=100"),
+			nil,
+		).WithContext(ctx)
+		handler.HandleStream(httptest.NewRecorder(), req)
+	}()
+
+	require.Eventually(t, func() bool {
+		return fetches.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dagsDir, "external-edit.yaml"), []byte(`schedule: "0 8 * * 6"
+steps:
+  - run: echo ok
+`), 0600))
+
+	require.Eventually(t, func() bool {
+		return fetches.Load() >= 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestCacheControlForAssetDisablesJavaScriptCaching(t *testing.T) {


### PR DESCRIPTION
## Summary
- start the existing app filesystem watcher when SSE routes are configured
- bridge app file-change events into multiplexed SSE topic wakeups
- add a regression test for externally edited DAG files refreshing the workflow list topic

## Root Cause
The workflow list consumes the multiplexed dagslist SSE topic. When the event store is enabled, that topic is on-demand and only refreshes after explicit wakeups. API mutations and DAG-run events already wake it, but external DAG file writes did not because setupSSERoute disabled the app filesystem stream that detects those changes. The detail/spec page fetched the DAG directly, so it could show the new schedule while the already-open workflow list still displayed the old schedule.

## Testing
- go test ./internal/service/frontend/... -count=1
- go test ./internal/persis/file/dag -run TestIndexInvalidationOnMutations|TestListUsesIndex -count=1
- git diff --check

Closes #2316

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale workflow lists by waking the SSE `dagslist` topic when DAG files change. Starts the app filesystem watcher and bridges its events to multiplexed invalidation; falls back to polling when the watcher isn’t available.

- **Bug Fixes**
  - Start `AppStreamService` during SSE setup; warn and continue if init fails.
  - Bridge app stream events to wake `dagslist`, DAG, runs, queues, docs, queue items, and reset topics.
  - Keep `dagslist` polling without the app stream; switch it to on-demand with publish‑on‑wake when the watcher is running.
  - Tests: add SSE regression cases; serialize PowerShell conformance cases to avoid flakiness.

<sup>Written for commit 37d642c63e759f1037d8e2fad0257270cd9b5590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved real-time Server-Sent Events behavior to react to application events (including DAG, queue, document, and reset) and refresh relevant topics automatically.
  * When an app-level SSE stream is available, certain document and DAG list topics now use on-demand refresh with publish-on-wake for more responsive updates.
* **Bug Fixes**
  * Fixed cases where dedicated SSE topic behavior could be unintentionally disabled or polled inconsistently depending on app stream availability.
* **Tests**
  * Added coverage for DAGs list waking after DAG/config file changes, and for preserving polling behavior without an app stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->