### PR TITLE
fix: resolve shared-nothing secret refs via coordinator

### DIFF
--- a/internal/cmd/coord.go
+++ b/internal/cmd/coord.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 
+	cmdprocess "github.com/dagucloud/dagu/internal/cmd/process"
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
@@ -225,6 +226,7 @@ func newCoordinator(
 	}
 
 	// Create handler with DAGRunStore for status persistence and LogDir for log streaming
+	agentStores := cmdprocess.NewRuntimeAgentStores(ctx.Context, cfg)
 	handler := coordinator.NewHandler(coordinator.HandlerConfig{
 		DAGRunStore:               dagRunStore,
 		StateStore:                stateStore,
@@ -237,6 +239,7 @@ func newCoordinator(
 		DAGRunLeaseStore:          dagRunLeaseStore,
 		ActiveDistributedRunStore: activeDistributedRunStore,
 		DAGStore:                  dagStore,
+		SecretStore:               agentStores.SecretStore,
 		EventService:              ctx.EventService,
 		EventSourceInstance:       ctx.EventSourceInstance,
 	})

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -237,6 +237,8 @@ type Agent struct {
 	profileResolvedAt string
 	// profileEntries records non-secret injected key metadata for status/history.
 	profileEntries []exec.RuntimeProfileEntry
+	// secretReferenceResolver resolves registry refs without requiring local store access.
+	secretReferenceResolver secrets.ReferenceResolver
 	// secretMasker redacts resolved secret values from status/history snapshots.
 	secretMasker *masking.Masker
 
@@ -331,8 +333,11 @@ type Options struct {
 	QueueStore exec.QueueStore
 	// StateStore is the persistent state store shared across DAG runs.
 	StateStore dagstate.Store
-	// SecretStore resolves workspace-local team-managed secret references.
+	// SecretStore resolves local registry refs and runtime profile secrets.
 	SecretStore secretpkg.Store
+	// SecretReferenceResolver resolves DAG-level registry refs.
+	// When nil, SecretStore supplies the local resolver.
+	SecretReferenceResolver secrets.ReferenceResolver
 	// ProfileStore resolves named runtime profiles.
 	ProfileStore profilepkg.Store
 	// ProfileName selects the runtime profile for this DAG run.
@@ -413,6 +418,7 @@ func New(
 		queueStore:                 opts.QueueStore,
 		stateStore:                 opts.StateStore,
 		secretStore:                opts.SecretStore,
+		secretReferenceResolver:    secretReferenceResolverForDAG(dag, opts),
 		profileStore:               opts.ProfileStore,
 		registry:                   opts.ServiceRegistry,
 		extraEnvs:                  append([]string{}, opts.ExtraEnvs...),
@@ -455,6 +461,27 @@ func New(
 	}
 
 	return a
+}
+
+func secretReferenceResolverForDAG(dag *core.DAG, opts Options) secrets.ReferenceResolver {
+	if opts.SecretReferenceResolver != nil {
+		return opts.SecretReferenceResolver
+	}
+	if opts.SecretStore == nil {
+		return nil
+	}
+	return secretpkg.NewReferenceResolver(opts.SecretStore, workspaceNameFromDAG(dag))
+}
+
+func workspaceNameFromDAG(dag *core.DAG) string {
+	if dag == nil {
+		return ""
+	}
+	name, ok := exec.WorkspaceNameFromLabels(dag.Labels)
+	if !ok {
+		return ""
+	}
+	return name
 }
 
 // Run setups the runner and runs the DAG.
@@ -1815,17 +1842,7 @@ func (a *Agent) resolveSecrets(ctx context.Context) ([]string, error) {
 	secretCtx := cmnvalue.WithEnvScope(ctx, envScope)
 
 	baseDirs := a.buildSecretBaseDirs(envScope)
-	secretRegistry := secrets.NewRegistry(baseDirs...)
-	if a.secretStore != nil {
-		workspaceName := ""
-		if name, ok := exec.WorkspaceNameFromLabels(a.dag.Labels); ok {
-			workspaceName = name
-		}
-		secretRegistry = secrets.NewRegistryWithReferenceResolver(
-			secretpkg.NewReferenceResolver(a.secretStore, workspaceName),
-			baseDirs...,
-		)
-	}
+	secretRegistry := secrets.NewRegistryWithReferenceResolver(a.secretReferenceResolver, baseDirs...)
 
 	resolvedSecrets, err := secretRegistry.ResolveAll(secretCtx, a.dag.Secrets)
 	if err != nil {

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -110,8 +110,9 @@ type Metrics struct {
 }
 
 var (
-	_ Client          = (*clientImpl)(nil)
-	_ exec.Dispatcher = (*clientImpl)(nil)
+	_ Client                = (*clientImpl)(nil)
+	_ SecretReferenceClient = (*clientImpl)(nil)
+	_ exec.Dispatcher       = (*clientImpl)(nil)
 )
 
 // clientImpl is the concrete implementation

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
+	secretpkg "github.com/dagucloud/dagu/internal/secret"
 	"github.com/dagucloud/dagu/internal/service/eventstore"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/google/uuid"
@@ -117,6 +118,7 @@ type Handler struct {
 	dagRunLeaseStore          exec.DAGRunLeaseStore          // Shared distributed run leases
 	activeDistributedRunStore exec.ActiveDistributedRunStore // Shared active distributed attempt index
 	dagStore                  exec.DAGStore                  // DAG definitions for the GetDAG RPC
+	secretStore               secretpkg.Store                // Secret registry for shared-nothing workers
 
 	// Open attempts cache for status persistence
 	attemptsMu   sync.RWMutex
@@ -185,6 +187,10 @@ type HandlerConfig struct {
 	// Optional - when nil, GetDAG returns Unimplemented.
 	DAGStore exec.DAGStore
 
+	// SecretStore resolves Dagu-managed secret registry refs for shared-nothing workers.
+	// Optional - when nil, ResolveSecretReference returns FailedPrecondition.
+	SecretStore secretpkg.Store
+
 	// StaleHeartbeatThreshold is the duration after which a worker's heartbeat
 	// is considered stale. Defaults to 30 seconds if not set.
 	StaleHeartbeatThreshold time.Duration
@@ -243,6 +249,7 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		dagRunLeaseStore:          cfg.DAGRunLeaseStore,
 		activeDistributedRunStore: cfg.ActiveDistributedRunStore,
 		dagStore:                  cfg.DAGStore,
+		secretStore:               cfg.SecretStore,
 		staleHeartbeatThreshold:   cfg.StaleHeartbeatThreshold,
 		staleLeaseThreshold:       cfg.StaleLeaseThreshold,
 		eventService:              cfg.EventService,

--- a/internal/service/coordinator/secret_reference.go
+++ b/internal/service/coordinator/secret_reference.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dagucloud/dagu/internal/cmn/secrets"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type SecretReferenceClient interface {
+	ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error)
+}
+
+type secretReferenceResolver struct {
+	client    SecretReferenceClient
+	workspace string
+	owner     exec.HostInfo
+}
+
+func NewSecretReferenceResolver(client SecretReferenceClient, workspace string, owner exec.HostInfo) secrets.ReferenceResolver {
+	if client == nil {
+		return nil
+	}
+	return &secretReferenceResolver{
+		client:    client,
+		workspace: secretpkg.NormalizeWorkspace(workspace),
+		owner:     owner,
+	}
+}
+
+func (r *secretReferenceResolver) ResolveReference(ctx context.Context, ref core.SecretRef) (string, error) {
+	return r.resolve(ctx, ref, false)
+}
+
+func (r *secretReferenceResolver) CheckReferenceAccessibility(ctx context.Context, ref core.SecretRef) error {
+	_, err := r.resolve(ctx, ref, true)
+	return err
+}
+
+func (r *secretReferenceResolver) resolve(ctx context.Context, ref core.SecretRef, checkOnly bool) (string, error) {
+	return r.client.ResolveSecretReference(ctx, r.owner, ref, r.workspace, checkOnly)
+}
+
+func (cli *clientImpl) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error) {
+	if !emptySecretReferenceOwner(owner) && !completeSecretReferenceOwner(owner) {
+		return "", fmt.Errorf("secret reference owner coordinator endpoint is incomplete")
+	}
+
+	req := secretReferenceRequest(ref, workspace, checkOnly)
+	if completeSecretReferenceOwner(owner) {
+		return cli.resolveSecretReferenceTo(ctx, owner, req)
+	}
+	return cli.resolveSecretReference(ctx, req)
+}
+
+func (cli *clientImpl) resolveSecretReference(ctx context.Context, req *coordinatorv1.ResolveSecretReferenceRequest) (string, error) {
+	members, err := cli.getCoordinatorMembers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var resp *coordinatorv1.ResolveSecretReferenceResponse
+	err = cli.attemptCall(ctx, members, func(ctx context.Context, member exec.HostInfo, client *client) error {
+		var callErr error
+		resp, callErr = resolveSecretReferenceRPC(ctx, member.ID, client, req)
+		return callErr
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetValue(), nil
+}
+
+func (cli *clientImpl) resolveSecretReferenceTo(ctx context.Context, owner exec.HostInfo, req *coordinatorv1.ResolveSecretReferenceRequest) (string, error) {
+	var resp *coordinatorv1.ResolveSecretReferenceResponse
+	err := cli.callMemberWithTimeout(ctx, owner, func(ctx context.Context, client *client) error {
+		var callErr error
+		resp, callErr = resolveSecretReferenceRPC(ctx, owner.ID, client, req)
+		return callErr
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetValue(), nil
+}
+
+func emptySecretReferenceOwner(owner exec.HostInfo) bool {
+	return owner.ID == "" && owner.Host == "" && owner.Port == 0
+}
+
+func resolveSecretReferenceRPC(ctx context.Context, coordinatorID string, client *client, req *coordinatorv1.ResolveSecretReferenceRequest) (*coordinatorv1.ResolveSecretReferenceResponse, error) {
+	resp, err := client.client.ResolveSecretReference(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("resolve secret reference failed: %w", err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("coordinator %s returned empty secret reference response", coordinatorID)
+	}
+	return resp, nil
+}
+
+func completeSecretReferenceOwner(owner exec.HostInfo) bool {
+	return owner.ID != "" && owner.Host != "" && owner.Port != 0
+}
+
+func secretReferenceRequest(ref core.SecretRef, workspace string, checkOnly bool) *coordinatorv1.ResolveSecretReferenceRequest {
+	return &coordinatorv1.ResolveSecretReferenceRequest{
+		Name:      ref.Name,
+		Ref:       ref.Ref,
+		Workspace: secretpkg.NormalizeWorkspace(workspace),
+		CheckOnly: checkOnly,
+	}
+}
+
+func (h *Handler) ResolveSecretReference(ctx context.Context, req *coordinatorv1.ResolveSecretReferenceRequest) (*coordinatorv1.ResolveSecretReferenceResponse, error) {
+	if h.secretStore == nil {
+		return nil, status.Error(codes.FailedPrecondition, "secret store is not configured")
+	}
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "secret reference request is required")
+	}
+	ref := core.SecretRef{
+		Name: req.GetName(),
+		Ref:  req.GetRef(),
+	}
+	if ref.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "secret name is required")
+	}
+	if ref.Ref == "" {
+		return nil, status.Error(codes.InvalidArgument, "secret ref is required")
+	}
+	if err := secretpkg.ValidateRef(ref.Ref); err != nil {
+		return nil, secretReferenceRPCError(err)
+	}
+
+	resolver := secretpkg.NewReferenceResolver(h.secretStore, req.GetWorkspace())
+	if req.GetCheckOnly() {
+		if err := resolver.CheckReferenceAccessibility(ctx, ref); err != nil {
+			return nil, secretReferenceRPCError(err)
+		}
+		return &coordinatorv1.ResolveSecretReferenceResponse{}, nil
+	}
+
+	value, err := resolver.ResolveReference(ctx, ref)
+	if err != nil {
+		return nil, secretReferenceRPCError(err)
+	}
+	return &coordinatorv1.ResolveSecretReferenceResponse{Value: value}, nil
+}
+
+func secretReferenceRPCError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, secretpkg.ErrInvalidRef), errors.Is(err, secretpkg.ErrInvalidWorkspace):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, secretpkg.ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, secretpkg.ErrDisabled), errors.Is(err, secretpkg.ErrNoValue), errors.Is(err, secretpkg.ErrUnsupportedProvider):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, context.Canceled):
+		return status.Error(codes.Canceled, err.Error())
+	case errors.Is(err, context.DeadlineExceeded):
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}

--- a/internal/service/coordinator/secret_reference.go
+++ b/internal/service/coordinator/secret_reference.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/secrets"
 	"github.com/dagucloud/dagu/internal/core"
@@ -18,16 +19,23 @@ import (
 )
 
 type SecretReferenceClient interface {
-	ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error)
+	ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool, run SecretReferenceRun) (string, error)
+}
+
+type SecretReferenceRun struct {
+	WorkerID   string
+	AttemptKey string
+	AttemptID  string
 }
 
 type secretReferenceResolver struct {
 	client    SecretReferenceClient
 	workspace string
 	owner     exec.HostInfo
+	run       SecretReferenceRun
 }
 
-func NewSecretReferenceResolver(client SecretReferenceClient, workspace string, owner exec.HostInfo) secrets.ReferenceResolver {
+func NewSecretReferenceResolver(client SecretReferenceClient, workspace string, owner exec.HostInfo, run SecretReferenceRun) secrets.ReferenceResolver {
 	if client == nil {
 		return nil
 	}
@@ -35,6 +43,7 @@ func NewSecretReferenceResolver(client SecretReferenceClient, workspace string, 
 		client:    client,
 		workspace: secretpkg.NormalizeWorkspace(workspace),
 		owner:     owner,
+		run:       run,
 	}
 }
 
@@ -48,15 +57,15 @@ func (r *secretReferenceResolver) CheckReferenceAccessibility(ctx context.Contex
 }
 
 func (r *secretReferenceResolver) resolve(ctx context.Context, ref core.SecretRef, checkOnly bool) (string, error) {
-	return r.client.ResolveSecretReference(ctx, r.owner, ref, r.workspace, checkOnly)
+	return r.client.ResolveSecretReference(ctx, r.owner, ref, r.workspace, checkOnly, r.run)
 }
 
-func (cli *clientImpl) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error) {
+func (cli *clientImpl) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool, run SecretReferenceRun) (string, error) {
 	if !emptySecretReferenceOwner(owner) && !completeSecretReferenceOwner(owner) {
 		return "", fmt.Errorf("secret reference owner coordinator endpoint is incomplete")
 	}
 
-	req := secretReferenceRequest(ref, workspace, checkOnly)
+	req := secretReferenceRequest(ref, workspace, checkOnly, run)
 	if completeSecretReferenceOwner(owner) {
 		return cli.resolveSecretReferenceTo(ctx, owner, req)
 	}
@@ -113,12 +122,15 @@ func completeSecretReferenceOwner(owner exec.HostInfo) bool {
 	return owner.ID != "" && owner.Host != "" && owner.Port != 0
 }
 
-func secretReferenceRequest(ref core.SecretRef, workspace string, checkOnly bool) *coordinatorv1.ResolveSecretReferenceRequest {
+func secretReferenceRequest(ref core.SecretRef, workspace string, checkOnly bool, run SecretReferenceRun) *coordinatorv1.ResolveSecretReferenceRequest {
 	return &coordinatorv1.ResolveSecretReferenceRequest{
-		Name:      ref.Name,
-		Ref:       ref.Ref,
-		Workspace: secretpkg.NormalizeWorkspace(workspace),
-		CheckOnly: checkOnly,
+		Name:       ref.Name,
+		Ref:        ref.Ref,
+		Workspace:  secretpkg.NormalizeWorkspace(workspace),
+		CheckOnly:  checkOnly,
+		WorkerId:   run.WorkerID,
+		AttemptKey: run.AttemptKey,
+		AttemptId:  run.AttemptID,
 	}
 }
 
@@ -142,6 +154,9 @@ func (h *Handler) ResolveSecretReference(ctx context.Context, req *coordinatorv1
 	if err := secretpkg.ValidateRef(ref.Ref); err != nil {
 		return nil, secretReferenceRPCError(err)
 	}
+	if err := h.authorizeSecretReference(ctx, req, ref); err != nil {
+		return nil, err
+	}
 
 	resolver := secretpkg.NewReferenceResolver(h.secretStore, req.GetWorkspace())
 	if req.GetCheckOnly() {
@@ -156,6 +171,106 @@ func (h *Handler) ResolveSecretReference(ctx context.Context, req *coordinatorv1
 		return nil, secretReferenceRPCError(err)
 	}
 	return &coordinatorv1.ResolveSecretReferenceResponse{Value: value}, nil
+}
+
+func (h *Handler) authorizeSecretReference(ctx context.Context, req *coordinatorv1.ResolveSecretReferenceRequest, ref core.SecretRef) error {
+	if req.GetWorkerId() == "" {
+		return status.Error(codes.InvalidArgument, "worker_id is required")
+	}
+	if req.GetAttemptKey() == "" {
+		return status.Error(codes.InvalidArgument, "attempt_key is required")
+	}
+	if req.GetAttemptId() == "" {
+		return status.Error(codes.InvalidArgument, "attempt_id is required")
+	}
+	if h.dagRunLeaseStore == nil {
+		return status.Error(codes.FailedPrecondition, "dag-run lease store is not configured")
+	}
+	if h.dagRunStore == nil {
+		return status.Error(codes.FailedPrecondition, "dag-run store is not configured")
+	}
+
+	lease, err := h.dagRunLeaseStore.Get(ctx, req.GetAttemptKey())
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunLeaseNotFound) {
+			return status.Error(codes.PermissionDenied, "secret reference access denied")
+		}
+		return status.Error(codes.Internal, err.Error())
+	}
+	if lease.WorkerID != req.GetWorkerId() || lease.AttemptID != req.GetAttemptId() {
+		return status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+	if !lease.IsFresh(time.Now().UTC(), h.staleLeaseThreshold) {
+		return status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+
+	dag, err := h.secretReferenceDAG(ctx, lease)
+	if err != nil {
+		return err
+	}
+	if secretpkg.NormalizeWorkspace(req.GetWorkspace()) != secretReferenceWorkspace(dag) {
+		return status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+	if !secretReferenceDeclared(dag, ref) {
+		return status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+	return nil
+}
+
+func (h *Handler) secretReferenceDAG(ctx context.Context, lease *exec.DAGRunLease) (*core.DAG, error) {
+	if lease == nil {
+		return nil, status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+
+	var (
+		attempt exec.DAGRunAttempt
+		err     error
+	)
+	if !lease.Root.Zero() && lease.Root != lease.DAGRun {
+		attempt, err = h.dagRunStore.FindSubAttempt(ctx, lease.Root, lease.DAGRun.ID)
+	} else {
+		attempt, err = h.dagRunStore.FindAttempt(ctx, lease.DAGRun)
+	}
+	if err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) || errors.Is(err, exec.ErrNoStatusData) || errors.Is(err, exec.ErrCorruptedStatusFile) {
+			return nil, status.Error(codes.PermissionDenied, "secret reference access denied")
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if attempt.ID() != lease.AttemptID {
+		return nil, status.Error(codes.PermissionDenied, "secret reference access denied")
+	}
+
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if dag == nil {
+		return nil, status.Error(codes.FailedPrecondition, "dag definition is not available")
+	}
+	return dag, nil
+}
+
+func secretReferenceWorkspace(dag *core.DAG) string {
+	if dag == nil {
+		return secretpkg.GlobalWorkspace
+	}
+	if workspaceName, found := exec.WorkspaceNameFromLabels(dag.Labels); found {
+		return secretpkg.NormalizeWorkspace(workspaceName)
+	}
+	return secretpkg.GlobalWorkspace
+}
+
+func secretReferenceDeclared(dag *core.DAG, ref core.SecretRef) bool {
+	if dag == nil {
+		return false
+	}
+	for _, declared := range dag.Secrets {
+		if declared.Name == ref.Name && declared.Ref == ref.Ref && declared.Provider == "" && declared.Key == "" && len(declared.Options) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func secretReferenceRPCError(err error) error {

--- a/internal/service/coordinator/secret_reference_test.go
+++ b/internal/service/coordinator/secret_reference_test.go
@@ -5,10 +5,14 @@ package coordinator_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/crypto"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
 	"github.com/dagucloud/dagu/internal/persis/store"
 	"github.com/dagucloud/dagu/internal/persis/testutil"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
@@ -16,6 +20,8 @@ import (
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestResolveSecretReference(t *testing.T) {
@@ -41,22 +47,90 @@ func TestResolveSecretReference(t *testing.T) {
 		CreatedAt: now,
 	}))
 
-	handler := coordinator.NewHandler(coordinator.HandlerConfig{SecretStore: secretStore})
+	dagRunStore := dagrun.New(filepath.Join(t.TempDir(), "dag-runs"))
+	leaseStore := store.NewDAGRunLeaseStore(testutil.NewMemoryBackend().Collection("leases"))
+	dag := &core.DAG{
+		Name:   "registry-secret-dag",
+		Labels: core.NewLabels([]string{"workspace=payments"}),
+		Secrets: []core.SecretRef{{
+			Name: "MY_SECRET",
+			Ref:  "prod/my-secret",
+		}},
+	}
+	attempt, err := dagRunStore.CreateAttempt(ctx, dag, now, "run-1", exec.NewDAGRunAttemptOptions{AttemptID: "attempt-1"})
+	require.NoError(t, err)
+	attemptKey := exec.GenerateAttemptKey(dag.Name, "run-1", dag.Name, "run-1", attempt.ID())
+	require.NoError(t, attempt.Open(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, attempt.Close(context.Background()))
+	})
+	require.NoError(t, attempt.Write(ctx, exec.DAGRunStatus{
+		Name:       dag.Name,
+		DAGRunID:   "run-1",
+		AttemptID:  attempt.ID(),
+		AttemptKey: attemptKey,
+		Status:     core.Running,
+		Labels:     dag.Labels.Strings(),
+	}))
+	require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+		AttemptKey:      attemptKey,
+		DAGRun:          exec.DAGRunRef{Name: dag.Name, ID: "run-1"},
+		Root:            exec.DAGRunRef{Name: dag.Name, ID: "run-1"},
+		AttemptID:       attempt.ID(),
+		WorkerID:        "worker-1",
+		ClaimedAt:       now.UnixMilli(),
+		LastHeartbeatAt: now.UnixMilli(),
+	}))
+
+	handler := coordinator.NewHandler(coordinator.HandlerConfig{
+		SecretStore:         secretStore,
+		DAGRunStore:         dagRunStore,
+		DAGRunLeaseStore:    leaseStore,
+		StaleLeaseThreshold: time.Minute,
+	})
 
 	resp, err := handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
-		Name:      "MY_SECRET",
-		Ref:       "prod/my-secret",
-		Workspace: "payments",
+		Name:       "MY_SECRET",
+		Ref:        "prod/my-secret",
+		Workspace:  "payments",
+		WorkerId:   "worker-1",
+		AttemptKey: attemptKey,
+		AttemptId:  attempt.ID(),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "secret-value", resp.GetValue())
 
 	checkResp, err := handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
-		Name:      "MY_SECRET",
-		Ref:       "prod/my-secret",
-		Workspace: "payments",
-		CheckOnly: true,
+		Name:       "MY_SECRET",
+		Ref:        "prod/my-secret",
+		Workspace:  "payments",
+		CheckOnly:  true,
+		WorkerId:   "worker-1",
+		AttemptKey: attemptKey,
+		AttemptId:  attempt.ID(),
 	})
 	require.NoError(t, err)
 	assert.Empty(t, checkResp.GetValue())
+
+	_, err = handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
+		Name:       "MY_SECRET",
+		Ref:        "prod/my-secret",
+		Workspace:  "other",
+		WorkerId:   "worker-1",
+		AttemptKey: attemptKey,
+		AttemptId:  attempt.ID(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
+		Name:       "OTHER_SECRET",
+		Ref:        "prod/other-secret",
+		Workspace:  "payments",
+		WorkerId:   "worker-1",
+		AttemptKey: attemptKey,
+		AttemptId:  attempt.ID(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }

--- a/internal/service/coordinator/secret_reference_test.go
+++ b/internal/service/coordinator/secret_reference_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/crypto"
+	"github.com/dagucloud/dagu/internal/persis/store"
+	"github.com/dagucloud/dagu/internal/persis/testutil"
+	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSecretReference(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	enc, err := crypto.NewEncryptor("test-key-for-secrets")
+	require.NoError(t, err)
+	secretStore, err := store.NewSecretStore(testutil.NewMemoryBackend().Collection("secrets"), enc)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	sec, err := secretpkg.New(secretpkg.CreateInput{
+		Workspace:    "payments",
+		Ref:          "prod/my-secret",
+		ProviderType: secretpkg.ProviderDaguManaged,
+		CreatedBy:    "test",
+	}, now)
+	require.NoError(t, err)
+	require.NoError(t, secretStore.Create(ctx, sec, &secretpkg.WriteValueInput{
+		Value:     "secret-value",
+		CreatedBy: "test",
+		CreatedAt: now,
+	}))
+
+	handler := coordinator.NewHandler(coordinator.HandlerConfig{SecretStore: secretStore})
+
+	resp, err := handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
+		Name:      "MY_SECRET",
+		Ref:       "prod/my-secret",
+		Workspace: "payments",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value", resp.GetValue())
+
+	checkResp, err := handler.ResolveSecretReference(ctx, &coordinatorv1.ResolveSecretReferenceRequest{
+		Name:      "MY_SECRET",
+		Ref:       "prod/my-secret",
+		Workspace: "payments",
+		CheckOnly: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, checkResp.GetValue())
+}

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -821,16 +821,22 @@ func TestService_SendTestUsesEffectiveWorkspaceRouteFromDAGLabels(t *testing.T) 
 
 	var globalRequests atomic.Int32
 	var workspaceRequests atomic.Int32
-	globalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		globalRequests.Add(1)
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer globalServer.Close()
-	workspaceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		workspaceRequests.Add(1)
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer workspaceServer.Close()
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Hostname() {
+		case "global.example.com":
+			globalRequests.Add(1)
+		case "workspace.example.com":
+			workspaceRequests.Add(1)
+		default:
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}
+		return acceptedResponse(req), nil
+	})}
 
 	store := newMemoryStore()
 	for _, channel := range []*notificationmodel.Channel{
@@ -840,7 +846,7 @@ func TestService_SendTestUsesEffectiveWorkspaceRouteFromDAGLabels(t *testing.T) 
 			Type:    notificationmodel.ProviderWebhook,
 			Enabled: true,
 			Webhook: &notificationmodel.WebhookTarget{
-				URL:                 globalServer.URL,
+				URL:                 "https://global.example.com/webhook",
 				AllowInsecureHTTP:   true,
 				AllowPrivateNetwork: true,
 			},
@@ -851,7 +857,7 @@ func TestService_SendTestUsesEffectiveWorkspaceRouteFromDAGLabels(t *testing.T) 
 			Type:    notificationmodel.ProviderWebhook,
 			Enabled: true,
 			Webhook: &notificationmodel.WebhookTarget{
-				URL:                 workspaceServer.URL,
+				URL:                 "https://workspace.example.com/webhook",
 				AllowInsecureHTTP:   true,
 				AllowPrivateNetwork: true,
 			},
@@ -864,7 +870,7 @@ func TestService_SendTestUsesEffectiveWorkspaceRouteFromDAGLabels(t *testing.T) 
 	svc := New(store, testDAGStore{dag: &core.DAG{
 		Name:   "daily-report",
 		Labels: core.NewLabels([]string{"workspace=ops"}),
-	}})
+	}}, WithHTTPClient(httpClient))
 	_, err := svc.SaveRouteSet(context.Background(), &notificationmodel.RouteSet{
 		Scope:         notificationmodel.RouteScopeGlobal,
 		Enabled:       true,

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -148,7 +148,7 @@ func (h *remoteTaskHandler) handleStart(ctx context.Context, task *coordinatorv1
 	}
 
 	statusPusher, logStreamer, artifactUploader := h.createRemoteHandlers(task.DagRunId, dag.Name, root, owner)
-	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, queuedRun, nil, task.AgentSnapshot, taskExtraEnvs(task), task.ProfileName)
+	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.AttemptKey, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, queuedRun, nil, task.AgentSnapshot, taskExtraEnvs(task), task.ProfileName)
 	var initErr *taskInitError
 	if errors.As(err, &initErr) {
 		h.reportTaskInitFailure(ctx, task, root, parent, statusPusher, initErr.err, task.ProfileName)
@@ -189,7 +189,7 @@ func (h *remoteTaskHandler) handleRetry(ctx context.Context, task *coordinatorv1
 	statusPusher, logStreamer, artifactUploader := h.createRemoteHandlers(task.DagRunId, dag.Name, root, owner)
 	triggerType := exec.PreservedQueueTriggerType(status)
 
-	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, false, &retryConfig{
+	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.AttemptKey, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, false, &retryConfig{
 		target:      status,
 		stepName:    task.Step,
 		triggerType: triggerType,
@@ -555,6 +555,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 	dag *core.DAG,
 	dagRunID string,
 	attemptID string,
+	attemptKey string,
 	scheduleTime string,
 	root exec.DAGRunRef,
 	parent exec.DAGRunRef,
@@ -665,7 +666,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 		DAGRunStore:              h.dagRunStore,
 		StateStore:               h.stateStore,
 		SecretStore:              agentStores.SecretStore,
-		SecretReferenceResolver:  h.secretReferenceResolver(dag, owner),
+		SecretReferenceResolver:  h.secretReferenceResolver(dag, owner, coordinator.SecretReferenceRun{WorkerID: h.workerID, AttemptKey: attemptKey, AttemptID: attemptID}),
 		ProfileStore:             agentStores.ProfileStore,
 		ProfileName:              profileName,
 		ServiceRegistry:          h.serviceRegistry,
@@ -715,7 +716,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 	return nil
 }
 
-func (h *remoteTaskHandler) secretReferenceResolver(dag *core.DAG, owner exec.HostInfo) secrets.ReferenceResolver {
+func (h *remoteTaskHandler) secretReferenceResolver(dag *core.DAG, owner exec.HostInfo, run coordinator.SecretReferenceRun) secrets.ReferenceResolver {
 	client, ok := h.coordinatorClient.(coordinator.SecretReferenceClient)
 	if !ok {
 		return nil
@@ -726,7 +727,7 @@ func (h *remoteTaskHandler) secretReferenceResolver(dag *core.DAG, owner exec.Ho
 			workspaceName = name
 		}
 	}
-	return coordinator.NewSecretReferenceResolver(client, workspaceName, owner)
+	return coordinator.NewSecretReferenceResolver(client, workspaceName, owner, run)
 }
 
 func (h *remoteTaskHandler) prepareDAGTools(ctx context.Context, dag *core.DAG) ([]string, error) {

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger"
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/cmn/logpath"
+	"github.com/dagucloud/dagu/internal/cmn/secrets"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -147,7 +148,7 @@ func (h *remoteTaskHandler) handleStart(ctx context.Context, task *coordinatorv1
 	}
 
 	statusPusher, logStreamer, artifactUploader := h.createRemoteHandlers(task.DagRunId, dag.Name, root, owner)
-	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, statusPusher, logStreamer, artifactUploader, queuedRun, nil, task.AgentSnapshot, taskExtraEnvs(task), task.ProfileName)
+	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, queuedRun, nil, task.AgentSnapshot, taskExtraEnvs(task), task.ProfileName)
 	var initErr *taskInitError
 	if errors.As(err, &initErr) {
 		h.reportTaskInitFailure(ctx, task, root, parent, statusPusher, initErr.err, task.ProfileName)
@@ -188,7 +189,7 @@ func (h *remoteTaskHandler) handleRetry(ctx context.Context, task *coordinatorv1
 	statusPusher, logStreamer, artifactUploader := h.createRemoteHandlers(task.DagRunId, dag.Name, root, owner)
 	triggerType := exec.PreservedQueueTriggerType(status)
 
-	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, statusPusher, logStreamer, artifactUploader, false, &retryConfig{
+	err = h.executeDAGRun(ctx, dag, task.DagRunId, task.AttemptId, task.ScheduleTime, root, parent, owner, statusPusher, logStreamer, artifactUploader, false, &retryConfig{
 		target:      status,
 		stepName:    task.Step,
 		triggerType: triggerType,
@@ -557,6 +558,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 	scheduleTime string,
 	root exec.DAGRunRef,
 	parent exec.DAGRunRef,
+	owner exec.HostInfo,
 	statusPusher runtime.StatusPusher,
 	logStreamer runtime.SchedulerLogStreamer,
 	artifactUploader runtime.ArtifactFinalizer,
@@ -663,6 +665,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 		DAGRunStore:              h.dagRunStore,
 		StateStore:               h.stateStore,
 		SecretStore:              agentStores.SecretStore,
+		SecretReferenceResolver:  h.secretReferenceResolver(dag, owner),
 		ProfileStore:             agentStores.ProfileStore,
 		ProfileName:              profileName,
 		ServiceRegistry:          h.serviceRegistry,
@@ -710,6 +713,20 @@ func (h *remoteTaskHandler) executeDAGRun(
 		tag.RunID(dagRunID))
 
 	return nil
+}
+
+func (h *remoteTaskHandler) secretReferenceResolver(dag *core.DAG, owner exec.HostInfo) secrets.ReferenceResolver {
+	client, ok := h.coordinatorClient.(coordinator.SecretReferenceClient)
+	if !ok {
+		return nil
+	}
+	workspaceName := ""
+	if dag != nil {
+		if name, found := exec.WorkspaceNameFromLabels(dag.Labels); found {
+			workspaceName = name
+		}
+	}
+	return coordinator.NewSecretReferenceResolver(client, workspaceName, owner)
 }
 
 func (h *remoteTaskHandler) prepareDAGTools(ctx context.Context, dag *core.DAG) ([]string, error) {

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -1919,7 +1919,7 @@ steps:
 	statusPusher, logStreamer, artifactUploader := handler.createRemoteHandlers("run-error", dag.Name, root)
 
 	// Call executeDAGRun directly - should fail at createAgentEnv
-	err := handler.executeDAGRun(context.Background(), dag, "run-error", "", "", root, parent, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(context.Background(), dag, "run-error", "", "", root, parent, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 
 	// On systems where null byte in path fails, we should get an error
 	if err != nil {
@@ -1965,7 +1965,7 @@ steps:
 
 	// Call executeDAGRun - this should succeed and log completion
 	// For top-level runs, pass empty parent and ensure root matches dagRunID
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 
 	// Should succeed for simple echo command
 	require.NoError(t, err, "executeDAGRun should succeed for simple echo command")
@@ -2002,7 +2002,7 @@ func TestExecuteDAGRun_FailedExecutionStillUploadsArtifacts(t *testing.T) {
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 
 	var sawData bool
@@ -2067,7 +2067,7 @@ func TestExecuteDAGRun_ArtifactUploadFailureMarksRunFailed(t *testing.T) {
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upload artifacts")
 	reportedMu.Lock()
@@ -2124,7 +2124,7 @@ func TestExecuteDAGRun_FailedExecutionWithArtifactUploadFailurePreservesFailedSt
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upload artifacts")
 	reportedMu.Lock()

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -1919,7 +1919,7 @@ steps:
 	statusPusher, logStreamer, artifactUploader := handler.createRemoteHandlers("run-error", dag.Name, root)
 
 	// Call executeDAGRun directly - should fail at createAgentEnv
-	err := handler.executeDAGRun(context.Background(), dag, "run-error", "", "", root, parent, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(context.Background(), dag, "run-error", "", "", "", root, parent, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 
 	// On systems where null byte in path fails, we should get an error
 	if err != nil {
@@ -1965,7 +1965,7 @@ steps:
 
 	// Call executeDAGRun - this should succeed and log completion
 	// For top-level runs, pass empty parent and ensure root matches dagRunID
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 
 	// Should succeed for simple echo command
 	require.NoError(t, err, "executeDAGRun should succeed for simple echo command")
@@ -2002,7 +2002,7 @@ func TestExecuteDAGRun_FailedExecutionStillUploadsArtifacts(t *testing.T) {
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 
 	var sawData bool
@@ -2067,7 +2067,7 @@ func TestExecuteDAGRun_ArtifactUploadFailureMarksRunFailed(t *testing.T) {
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upload artifacts")
 	reportedMu.Lock()
@@ -2124,7 +2124,7 @@ func TestExecuteDAGRun_FailedExecutionWithArtifactUploadFailurePreservesFailedSt
 	logStreamer := coordreport.NewLogStreamer(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 	artifactUploader := coordreport.NewArtifactUploader(client, "integration-test-worker", dagRunID, dag.Name, "", root)
 
-	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
+	err := handler.executeDAGRun(th.Context, dag.DAG, dagRunID, "", "", "", root, exec.DAGRunRef{}, exec.HostInfo{}, statusPusher, logStreamer, artifactUploader, false, nil, nil, nil, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upload artifacts")
 	reportedMu.Lock()

--- a/internal/service/worker/remote_secret_reference_test.go
+++ b/internal/service/worker/remote_secret_reference_test.go
@@ -6,6 +6,7 @@ package worker_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -80,23 +81,26 @@ func TestRemoteTaskHandlerResolvesRegistrySecretsViaCoordinator(t *testing.T) {
 		RootDagRunName:       "registry-secret-dag",
 		RootDagRunId:         dagRunID,
 		DagRunId:             dagRunID,
+		AttemptId:            "attempt-1",
+		AttemptKey:           "attempt-key-1",
 		OwnerCoordinatorId:   "coord-1",
 		OwnerCoordinatorHost: "127.0.0.1",
 		OwnerCoordinatorPort: 4521,
-		Definition: `
+		Definition: fmt.Sprintf(`
 secrets:
   - name: MY_SECRET
     ref: prod/my-secret
 steps:
   - name: main
-    run: test "$MY_SECRET" = "coordinator-secret-value"
-`,
+%s
+`, secretAssertionStep()),
 	}
 
 	err = handler.Handle(ctx, task)
 	require.NoError(t, err)
 	require.Equal(t, []core.SecretRef{{Name: "MY_SECRET", Ref: "prod/my-secret"}}, client.resolvedRefs())
 	require.Equal(t, []exec.HostInfo{{ID: "coord-1", Host: "127.0.0.1", Port: 4521}}, client.resolvedOwners())
+	require.Equal(t, []coordinator.SecretReferenceRun{{WorkerID: workerID, AttemptKey: "attempt-key-1", AttemptID: "attempt-1"}}, client.resolvedRuns())
 
 	reported := client.reportedStatuses()
 	require.NotEmpty(t, reported)
@@ -105,11 +109,22 @@ steps:
 	assert.Equal(t, core.Succeeded, status.Status)
 }
 
+func secretAssertionStep() string {
+	if runtime.GOOS == "windows" {
+		return `    run: |
+      if ($env:MY_SECRET -ne 'coordinator-secret-value') { throw "unexpected secret value: $env:MY_SECRET" }
+    with:
+      shell: powershell`
+	}
+	return `    run: test "$MY_SECRET" = "coordinator-secret-value"`
+}
+
 type secretResolvingRemoteCoordinatorClient struct {
 	mu            sync.Mutex
 	reported      []*coordinatorv1.ReportStatusRequest
 	resolved      []core.SecretRef
 	owners        []exec.HostInfo
+	runs          []coordinator.SecretReferenceRun
 	resolveSecret func(context.Context, core.SecretRef, string, bool) (string, error)
 }
 
@@ -132,6 +147,12 @@ func (c *secretResolvingRemoteCoordinatorClient) resolvedOwners() []exec.HostInf
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]exec.HostInfo(nil), c.owners...)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) resolvedRuns() []coordinator.SecretReferenceRun {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]coordinator.SecretReferenceRun(nil), c.runs...)
 }
 
 func (c *secretResolvingRemoteCoordinatorClient) Dispatch(context.Context, exec.DispatchRequest) error {
@@ -205,13 +226,14 @@ func (c *secretResolvingRemoteCoordinatorClient) Metrics() coordinator.Metrics {
 	return coordinator.Metrics{IsConnected: true}
 }
 
-func (c *secretResolvingRemoteCoordinatorClient) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error) {
+func (c *secretResolvingRemoteCoordinatorClient) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool, run coordinator.SecretReferenceRun) (string, error) {
 	if owner == (exec.HostInfo{}) {
 		return "", fmt.Errorf("secret resolution for %q did not target the owner coordinator", ref.Ref)
 	}
 	c.mu.Lock()
 	c.resolved = append(c.resolved, ref)
 	c.owners = append(c.owners, owner)
+	c.runs = append(c.runs, run)
 	c.mu.Unlock()
 	return c.resolveSecret(ctx, ref, workspace, checkOnly)
 }

--- a/internal/service/worker/remote_secret_reference_test.go
+++ b/internal/service/worker/remote_secret_reference_test.go
@@ -1,0 +1,277 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/agent"
+	"github.com/dagucloud/dagu/internal/cmn/backoff"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/crypto"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis/file"
+	"github.com/dagucloud/dagu/internal/persis/store"
+	"github.com/dagucloud/dagu/internal/persis/testutil"
+	"github.com/dagucloud/dagu/internal/proto/convert"
+	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	"github.com/dagucloud/dagu/internal/service/coordinator"
+	workersvc "github.com/dagucloud/dagu/internal/service/worker"
+	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestRemoteTaskHandlerResolvesRegistrySecretsViaCoordinator(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	enc, err := crypto.NewEncryptor("test-key-for-secrets")
+	require.NoError(t, err)
+	coordinatorSecrets, err := store.NewSecretStore(testutil.NewMemoryBackend().Collection("secrets"), enc)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	sec, err := secretpkg.New(secretpkg.CreateInput{
+		Ref:          "prod/my-secret",
+		ProviderType: secretpkg.ProviderDaguManaged,
+		CreatedBy:    "test",
+	}, now)
+	require.NoError(t, err)
+	require.NoError(t, coordinatorSecrets.Create(ctx, sec, &secretpkg.WriteValueInput{
+		Value:     "coordinator-secret-value",
+		CreatedBy: "test",
+		CreatedAt: now,
+	}))
+
+	client := &secretResolvingRemoteCoordinatorClient{
+		resolveSecret: func(ctx context.Context, ref core.SecretRef, workspace string, checkOnly bool) (string, error) {
+			resolver := secretpkg.NewReferenceResolver(coordinatorSecrets, workspace)
+			if checkOnly {
+				return "", resolver.CheckReferenceAccessibility(ctx, ref)
+			}
+			return resolver.ResolveReference(ctx, ref)
+		},
+	}
+	workerID := "secret-reference-worker"
+	dagRunID := "secret-reference-run"
+
+	handler := workersvc.NewRemoteTaskHandler(workersvc.RemoteTaskHandlerConfig{
+		WorkerID:          workerID,
+		CoordinatorClient: client,
+		Config: &config.Config{
+			Paths: config.PathsConfig{DataDir: t.TempDir()},
+		},
+		AgentStoresFactory: func(ctx context.Context, cfg *config.Config) agent.RuntimeStores {
+			return file.NewAgentStores(ctx, cfg)
+		},
+	})
+
+	task := &coordinatorv1.Task{
+		Operation:            coordinatorv1.Operation_OPERATION_START,
+		Target:               "registry-secret-dag",
+		RootDagRunName:       "registry-secret-dag",
+		RootDagRunId:         dagRunID,
+		DagRunId:             dagRunID,
+		OwnerCoordinatorId:   "coord-1",
+		OwnerCoordinatorHost: "127.0.0.1",
+		OwnerCoordinatorPort: 4521,
+		Definition: `
+secrets:
+  - name: MY_SECRET
+    ref: prod/my-secret
+steps:
+  - name: main
+    run: test "$MY_SECRET" = "coordinator-secret-value"
+`,
+	}
+
+	err = handler.Handle(ctx, task)
+	require.NoError(t, err)
+	require.Equal(t, []core.SecretRef{{Name: "MY_SECRET", Ref: "prod/my-secret"}}, client.resolvedRefs())
+	require.Equal(t, []exec.HostInfo{{ID: "coord-1", Host: "127.0.0.1", Port: 4521}}, client.resolvedOwners())
+
+	reported := client.reportedStatuses()
+	require.NotEmpty(t, reported)
+	status, convErr := convert.ProtoToDAGRunStatus(reported[len(reported)-1].Status)
+	require.NoError(t, convErr)
+	assert.Equal(t, core.Succeeded, status.Status)
+}
+
+type secretResolvingRemoteCoordinatorClient struct {
+	mu            sync.Mutex
+	reported      []*coordinatorv1.ReportStatusRequest
+	resolved      []core.SecretRef
+	owners        []exec.HostInfo
+	resolveSecret func(context.Context, core.SecretRef, string, bool) (string, error)
+}
+
+var _ coordinator.Client = (*secretResolvingRemoteCoordinatorClient)(nil)
+var _ coordinator.SecretReferenceClient = (*secretResolvingRemoteCoordinatorClient)(nil)
+
+func (c *secretResolvingRemoteCoordinatorClient) reportedStatuses() []*coordinatorv1.ReportStatusRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*coordinatorv1.ReportStatusRequest(nil), c.reported...)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) resolvedRefs() []core.SecretRef {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]core.SecretRef(nil), c.resolved...)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) resolvedOwners() []exec.HostInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]exec.HostInfo(nil), c.owners...)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) Dispatch(context.Context, exec.DispatchRequest) error {
+	return nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) Cleanup(context.Context) error {
+	return nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) GetDAGRunStatus(context.Context, string, string, *exec.DAGRunRef) (*exec.DAGRunStatusResult, error) {
+	return &exec.DAGRunStatusResult{Found: false}, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) RequestCancel(context.Context, string, string, *exec.DAGRunRef) error {
+	return nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) Poll(context.Context, backoff.RetryPolicy, *coordinatorv1.PollRequest) (*coordinatorv1.Task, error) {
+	return nil, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) GetWorkers(context.Context) ([]*coordinatorv1.WorkerInfo, error) {
+	return nil, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) Heartbeat(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+	return &coordinatorv1.HeartbeatResponse{}, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) AckTaskClaimTo(context.Context, exec.HostInfo, *coordinatorv1.AckTaskClaimRequest) (*coordinatorv1.AckTaskClaimResponse, error) {
+	return &coordinatorv1.AckTaskClaimResponse{Accepted: true}, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) RunHeartbeatTo(context.Context, exec.HostInfo, *coordinatorv1.RunHeartbeatRequest) (*coordinatorv1.RunHeartbeatResponse, error) {
+	return &coordinatorv1.RunHeartbeatResponse{}, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) ReportStatus(_ context.Context, req *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
+	c.mu.Lock()
+	c.reported = append(c.reported, req)
+	c.mu.Unlock()
+	return &coordinatorv1.ReportStatusResponse{Accepted: true}, nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) ReportStatusTo(ctx context.Context, _ exec.HostInfo, req *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
+	return c.ReportStatus(ctx, req)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) StreamLogs(context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+	return newSecretTestStreamLogsClient(), nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) StreamLogsTo(ctx context.Context, _ exec.HostInfo) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+	return c.StreamLogs(ctx)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) StreamArtifacts(context.Context) (coordinatorv1.CoordinatorService_StreamArtifactsClient, error) {
+	return newSecretTestStreamArtifactsClient(), nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) StreamArtifactsTo(ctx context.Context, _ exec.HostInfo) (coordinatorv1.CoordinatorService_StreamArtifactsClient, error) {
+	return c.StreamArtifacts(ctx)
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) GetDAG(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) Metrics() coordinator.Metrics {
+	return coordinator.Metrics{IsConnected: true}
+}
+
+func (c *secretResolvingRemoteCoordinatorClient) ResolveSecretReference(ctx context.Context, owner exec.HostInfo, ref core.SecretRef, workspace string, checkOnly bool) (string, error) {
+	if owner == (exec.HostInfo{}) {
+		return "", fmt.Errorf("secret resolution for %q did not target the owner coordinator", ref.Ref)
+	}
+	c.mu.Lock()
+	c.resolved = append(c.resolved, ref)
+	c.owners = append(c.owners, owner)
+	c.mu.Unlock()
+	return c.resolveSecret(ctx, ref, workspace, checkOnly)
+}
+
+type secretTestStreamLogsClient struct {
+	mu     sync.Mutex
+	chunks []*coordinatorv1.LogChunk
+	ctx    context.Context
+}
+
+func newSecretTestStreamLogsClient() *secretTestStreamLogsClient {
+	return &secretTestStreamLogsClient{ctx: context.Background()}
+}
+
+func (c *secretTestStreamLogsClient) Send(chunk *coordinatorv1.LogChunk) error {
+	c.mu.Lock()
+	c.chunks = append(c.chunks, chunk)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *secretTestStreamLogsClient) CloseAndRecv() (*coordinatorv1.StreamLogsResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &coordinatorv1.StreamLogsResponse{ChunksReceived: uint64(len(c.chunks))}, nil
+}
+
+func (c *secretTestStreamLogsClient) Header() (metadata.MD, error) { return nil, nil }
+func (c *secretTestStreamLogsClient) Trailer() metadata.MD         { return nil }
+func (c *secretTestStreamLogsClient) CloseSend() error             { return nil }
+func (c *secretTestStreamLogsClient) Context() context.Context     { return c.ctx }
+func (c *secretTestStreamLogsClient) SendMsg(any) error            { return nil }
+func (c *secretTestStreamLogsClient) RecvMsg(any) error            { return nil }
+
+type secretTestStreamArtifactsClient struct {
+	mu     sync.Mutex
+	chunks []*coordinatorv1.ArtifactChunk
+	ctx    context.Context
+}
+
+func newSecretTestStreamArtifactsClient() *secretTestStreamArtifactsClient {
+	return &secretTestStreamArtifactsClient{ctx: context.Background()}
+}
+
+func (c *secretTestStreamArtifactsClient) Send(chunk *coordinatorv1.ArtifactChunk) error {
+	c.mu.Lock()
+	c.chunks = append(c.chunks, chunk)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *secretTestStreamArtifactsClient) CloseAndRecv() (*coordinatorv1.StreamArtifactsResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return &coordinatorv1.StreamArtifactsResponse{ChunksReceived: uint64(len(c.chunks))}, nil
+}
+
+func (c *secretTestStreamArtifactsClient) Header() (metadata.MD, error) { return nil, nil }
+func (c *secretTestStreamArtifactsClient) Trailer() metadata.MD         { return nil }
+func (c *secretTestStreamArtifactsClient) CloseSend() error             { return nil }
+func (c *secretTestStreamArtifactsClient) Context() context.Context     { return c.ctx }
+func (c *secretTestStreamArtifactsClient) SendMsg(any) error            { return nil }
+func (c *secretTestStreamArtifactsClient) RecvMsg(any) error            { return nil }

--- a/proto/coordinator/v1/coordinator.pb.go
+++ b/proto/coordinator/v1/coordinator.pb.go
@@ -4809,6 +4809,163 @@ func (b0 GetDAGResponse_builder) Build() *GetDAGResponse {
 	return m0
 }
 
+// ResolveSecretReference resolves or checks one Dagu-managed registry ref.
+type ResolveSecretReferenceRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                             // Environment variable name requested by the DAG
+	Ref           string                 `protobuf:"bytes,2,opt,name=ref,proto3" json:"ref,omitempty"`                               // Registry ref, for example "prod/db-password"
+	Workspace     string                 `protobuf:"bytes,3,opt,name=workspace,proto3" json:"workspace,omitempty"`                   // Workspace scope; empty means global
+	CheckOnly     bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3" json:"check_only,omitempty"` // When true, verify access without returning plaintext
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveSecretReferenceRequest) Reset() {
+	*x = ResolveSecretReferenceRequest{}
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveSecretReferenceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveSecretReferenceRequest) ProtoMessage() {}
+
+func (x *ResolveSecretReferenceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ResolveSecretReferenceRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetRef() string {
+	if x != nil {
+		return x.Ref
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetCheckOnly() bool {
+	if x != nil {
+		return x.CheckOnly
+	}
+	return false
+}
+
+func (x *ResolveSecretReferenceRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetRef(v string) {
+	x.Ref = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetWorkspace(v string) {
+	x.Workspace = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetCheckOnly(v bool) {
+	x.CheckOnly = v
+}
+
+type ResolveSecretReferenceRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Name      string
+	Ref       string
+	Workspace string
+	CheckOnly bool
+}
+
+func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceRequest {
+	m0 := &ResolveSecretReferenceRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Ref = b.Ref
+	x.Workspace = b.Workspace
+	x.CheckOnly = b.CheckOnly
+	return m0
+}
+
+type ResolveSecretReferenceResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Value         string                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"` // Plaintext secret value; empty for check_only
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResolveSecretReferenceResponse) Reset() {
+	*x = ResolveSecretReferenceResponse{}
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveSecretReferenceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveSecretReferenceResponse) ProtoMessage() {}
+
+func (x *ResolveSecretReferenceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ResolveSecretReferenceResponse) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceResponse) SetValue(v string) {
+	x.Value = v
+}
+
+type ResolveSecretReferenceResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Value string
+}
+
+func (b0 ResolveSecretReferenceResponse_builder) Build() *ResolveSecretReferenceResponse {
+	m0 := &ResolveSecretReferenceResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Value = b.Value
+	return m0
+}
+
 var File_proto_coordinator_v1_coordinator_proto protoreflect.FileDescriptor
 
 const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
@@ -5074,7 +5231,15 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\":\n" +
 	"\x0eGetDAGResponse\x12\x12\n" +
 	"\x04spec\x18\x01 \x01(\tR\x04spec\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error*P\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\x82\x01\n" +
+	"\x1dResolveSecretReferenceRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
+	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x1c\n" +
+	"\tworkspace\x18\x03 \x01(\tR\tworkspace\x12\x1d\n" +
+	"\n" +
+	"check_only\x18\x04 \x01(\bR\tcheckOnly\"6\n" +
+	"\x1eResolveSecretReferenceResponse\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value*P\n" +
 	"\tOperation\x12\x19\n" +
 	"\x15OPERATION_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fOPERATION_START\x10\x01\x12\x13\n" +
@@ -5088,7 +5253,7 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x1bLOG_STREAM_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16LOG_STREAM_TYPE_STDOUT\x10\x01\x12\x1a\n" +
 	"\x16LOG_STREAM_TYPE_STDERR\x10\x02\x12\x1d\n" +
-	"\x19LOG_STREAM_TYPE_SCHEDULER\x10\x032\x9c\r\n" +
+	"\x19LOG_STREAM_TYPE_SCHEDULER\x10\x032\x95\x0e\n" +
 	"\x12CoordinatorService\x12A\n" +
 	"\x04Poll\x12\x1b.coordinator.v1.PollRequest\x1a\x1c.coordinator.v1.PollResponse\x12M\n" +
 	"\bDispatch\x12\x1f.coordinator.v1.DispatchRequest\x1a .coordinator.v1.DispatchResponse\x12S\n" +
@@ -5110,78 +5275,81 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\bPutState\x12\x1f.coordinator.v1.PutStateRequest\x1a .coordinator.v1.PutStateResponse\x12V\n" +
 	"\vDeleteState\x12\".coordinator.v1.DeleteStateRequest\x1a#.coordinator.v1.DeleteStateResponse\x12P\n" +
 	"\tListState\x12 .coordinator.v1.ListStateRequest\x1a!.coordinator.v1.ListStateResponse\x12G\n" +
-	"\x06GetDAG\x12\x1d.coordinator.v1.GetDAGRequest\x1a\x1e.coordinator.v1.GetDAGResponseB>Z<github.com/dagucloud/dagu/proto/coordinator/v1;coordinatorv1b\x06proto3"
+	"\x06GetDAG\x12\x1d.coordinator.v1.GetDAGRequest\x1a\x1e.coordinator.v1.GetDAGResponse\x12w\n" +
+	"\x16ResolveSecretReference\x12-.coordinator.v1.ResolveSecretReferenceRequest\x1a..coordinator.v1.ResolveSecretReferenceResponseB>Z<github.com/dagucloud/dagu/proto/coordinator/v1;coordinatorv1b\x06proto3"
 
 var file_proto_coordinator_v1_coordinator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_proto_coordinator_v1_coordinator_proto_goTypes = []any{
-	(Operation)(0),                     // 0: coordinator.v1.Operation
-	(WorkerHealthStatus)(0),            // 1: coordinator.v1.WorkerHealthStatus
-	(LogStreamType)(0),                 // 2: coordinator.v1.LogStreamType
-	(*PollRequest)(nil),                // 3: coordinator.v1.PollRequest
-	(*PollResponse)(nil),               // 4: coordinator.v1.PollResponse
-	(*DispatchRequest)(nil),            // 5: coordinator.v1.DispatchRequest
-	(*DispatchResponse)(nil),           // 6: coordinator.v1.DispatchResponse
-	(*Task)(nil),                       // 7: coordinator.v1.Task
-	(*GetWorkersRequest)(nil),          // 8: coordinator.v1.GetWorkersRequest
-	(*GetWorkersResponse)(nil),         // 9: coordinator.v1.GetWorkersResponse
-	(*WorkerInfo)(nil),                 // 10: coordinator.v1.WorkerInfo
-	(*HeartbeatRequest)(nil),           // 11: coordinator.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),          // 12: coordinator.v1.HeartbeatResponse
-	(*AckTaskClaimRequest)(nil),        // 13: coordinator.v1.AckTaskClaimRequest
-	(*AckTaskClaimResponse)(nil),       // 14: coordinator.v1.AckTaskClaimResponse
-	(*RunHeartbeatRequest)(nil),        // 15: coordinator.v1.RunHeartbeatRequest
-	(*RunHeartbeatResponse)(nil),       // 16: coordinator.v1.RunHeartbeatResponse
-	(*CancelledRun)(nil),               // 17: coordinator.v1.CancelledRun
-	(*WorkerStats)(nil),                // 18: coordinator.v1.WorkerStats
-	(*RunningTask)(nil),                // 19: coordinator.v1.RunningTask
-	(*ReportStatusRequest)(nil),        // 20: coordinator.v1.ReportStatusRequest
-	(*ReportStatusResponse)(nil),       // 21: coordinator.v1.ReportStatusResponse
-	(*DAGRunStatusProto)(nil),          // 22: coordinator.v1.DAGRunStatusProto
-	(*LogChunk)(nil),                   // 23: coordinator.v1.LogChunk
-	(*StreamLogsResponse)(nil),         // 24: coordinator.v1.StreamLogsResponse
-	(*ArtifactChunk)(nil),              // 25: coordinator.v1.ArtifactChunk
-	(*StreamArtifactsResponse)(nil),    // 26: coordinator.v1.StreamArtifactsResponse
-	(*WorkspaceBundle)(nil),            // 27: coordinator.v1.WorkspaceBundle
-	(*WorkspaceBundleChunk)(nil),       // 28: coordinator.v1.WorkspaceBundleChunk
-	(*PutWorkspaceBundleResponse)(nil), // 29: coordinator.v1.PutWorkspaceBundleResponse
-	(*HasWorkspaceBundleRequest)(nil),  // 30: coordinator.v1.HasWorkspaceBundleRequest
-	(*HasWorkspaceBundleResponse)(nil), // 31: coordinator.v1.HasWorkspaceBundleResponse
-	(*GetWorkspaceBundleRequest)(nil),  // 32: coordinator.v1.GetWorkspaceBundleRequest
-	(*GetDAGRunStatusRequest)(nil),     // 33: coordinator.v1.GetDAGRunStatusRequest
-	(*GetDAGRunStatusResponse)(nil),    // 34: coordinator.v1.GetDAGRunStatusResponse
-	(*RequestCancelRequest)(nil),       // 35: coordinator.v1.RequestCancelRequest
-	(*RequestCancelResponse)(nil),      // 36: coordinator.v1.RequestCancelResponse
-	(*StateRef)(nil),                   // 37: coordinator.v1.StateRef
-	(*StateUpdateSource)(nil),          // 38: coordinator.v1.StateUpdateSource
-	(*StateEntry)(nil),                 // 39: coordinator.v1.StateEntry
-	(*GetStateRequest)(nil),            // 40: coordinator.v1.GetStateRequest
-	(*GetStateResponse)(nil),           // 41: coordinator.v1.GetStateResponse
-	(*PutStateRequest)(nil),            // 42: coordinator.v1.PutStateRequest
-	(*PutStateResponse)(nil),           // 43: coordinator.v1.PutStateResponse
-	(*DeleteStateRequest)(nil),         // 44: coordinator.v1.DeleteStateRequest
-	(*DeleteStateResponse)(nil),        // 45: coordinator.v1.DeleteStateResponse
-	(*ListStateRequest)(nil),           // 46: coordinator.v1.ListStateRequest
-	(*ListStateResponse)(nil),          // 47: coordinator.v1.ListStateResponse
-	(*GetDAGRequest)(nil),              // 48: coordinator.v1.GetDAGRequest
-	(*GetDAGResponse)(nil),             // 49: coordinator.v1.GetDAGResponse
-	nil,                                // 50: coordinator.v1.PollRequest.LabelsEntry
-	nil,                                // 51: coordinator.v1.Task.WorkerSelectorEntry
-	nil,                                // 52: coordinator.v1.WorkerInfo.LabelsEntry
-	nil,                                // 53: coordinator.v1.HeartbeatRequest.LabelsEntry
+	(Operation)(0),                         // 0: coordinator.v1.Operation
+	(WorkerHealthStatus)(0),                // 1: coordinator.v1.WorkerHealthStatus
+	(LogStreamType)(0),                     // 2: coordinator.v1.LogStreamType
+	(*PollRequest)(nil),                    // 3: coordinator.v1.PollRequest
+	(*PollResponse)(nil),                   // 4: coordinator.v1.PollResponse
+	(*DispatchRequest)(nil),                // 5: coordinator.v1.DispatchRequest
+	(*DispatchResponse)(nil),               // 6: coordinator.v1.DispatchResponse
+	(*Task)(nil),                           // 7: coordinator.v1.Task
+	(*GetWorkersRequest)(nil),              // 8: coordinator.v1.GetWorkersRequest
+	(*GetWorkersResponse)(nil),             // 9: coordinator.v1.GetWorkersResponse
+	(*WorkerInfo)(nil),                     // 10: coordinator.v1.WorkerInfo
+	(*HeartbeatRequest)(nil),               // 11: coordinator.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),              // 12: coordinator.v1.HeartbeatResponse
+	(*AckTaskClaimRequest)(nil),            // 13: coordinator.v1.AckTaskClaimRequest
+	(*AckTaskClaimResponse)(nil),           // 14: coordinator.v1.AckTaskClaimResponse
+	(*RunHeartbeatRequest)(nil),            // 15: coordinator.v1.RunHeartbeatRequest
+	(*RunHeartbeatResponse)(nil),           // 16: coordinator.v1.RunHeartbeatResponse
+	(*CancelledRun)(nil),                   // 17: coordinator.v1.CancelledRun
+	(*WorkerStats)(nil),                    // 18: coordinator.v1.WorkerStats
+	(*RunningTask)(nil),                    // 19: coordinator.v1.RunningTask
+	(*ReportStatusRequest)(nil),            // 20: coordinator.v1.ReportStatusRequest
+	(*ReportStatusResponse)(nil),           // 21: coordinator.v1.ReportStatusResponse
+	(*DAGRunStatusProto)(nil),              // 22: coordinator.v1.DAGRunStatusProto
+	(*LogChunk)(nil),                       // 23: coordinator.v1.LogChunk
+	(*StreamLogsResponse)(nil),             // 24: coordinator.v1.StreamLogsResponse
+	(*ArtifactChunk)(nil),                  // 25: coordinator.v1.ArtifactChunk
+	(*StreamArtifactsResponse)(nil),        // 26: coordinator.v1.StreamArtifactsResponse
+	(*WorkspaceBundle)(nil),                // 27: coordinator.v1.WorkspaceBundle
+	(*WorkspaceBundleChunk)(nil),           // 28: coordinator.v1.WorkspaceBundleChunk
+	(*PutWorkspaceBundleResponse)(nil),     // 29: coordinator.v1.PutWorkspaceBundleResponse
+	(*HasWorkspaceBundleRequest)(nil),      // 30: coordinator.v1.HasWorkspaceBundleRequest
+	(*HasWorkspaceBundleResponse)(nil),     // 31: coordinator.v1.HasWorkspaceBundleResponse
+	(*GetWorkspaceBundleRequest)(nil),      // 32: coordinator.v1.GetWorkspaceBundleRequest
+	(*GetDAGRunStatusRequest)(nil),         // 33: coordinator.v1.GetDAGRunStatusRequest
+	(*GetDAGRunStatusResponse)(nil),        // 34: coordinator.v1.GetDAGRunStatusResponse
+	(*RequestCancelRequest)(nil),           // 35: coordinator.v1.RequestCancelRequest
+	(*RequestCancelResponse)(nil),          // 36: coordinator.v1.RequestCancelResponse
+	(*StateRef)(nil),                       // 37: coordinator.v1.StateRef
+	(*StateUpdateSource)(nil),              // 38: coordinator.v1.StateUpdateSource
+	(*StateEntry)(nil),                     // 39: coordinator.v1.StateEntry
+	(*GetStateRequest)(nil),                // 40: coordinator.v1.GetStateRequest
+	(*GetStateResponse)(nil),               // 41: coordinator.v1.GetStateResponse
+	(*PutStateRequest)(nil),                // 42: coordinator.v1.PutStateRequest
+	(*PutStateResponse)(nil),               // 43: coordinator.v1.PutStateResponse
+	(*DeleteStateRequest)(nil),             // 44: coordinator.v1.DeleteStateRequest
+	(*DeleteStateResponse)(nil),            // 45: coordinator.v1.DeleteStateResponse
+	(*ListStateRequest)(nil),               // 46: coordinator.v1.ListStateRequest
+	(*ListStateResponse)(nil),              // 47: coordinator.v1.ListStateResponse
+	(*GetDAGRequest)(nil),                  // 48: coordinator.v1.GetDAGRequest
+	(*GetDAGResponse)(nil),                 // 49: coordinator.v1.GetDAGResponse
+	(*ResolveSecretReferenceRequest)(nil),  // 50: coordinator.v1.ResolveSecretReferenceRequest
+	(*ResolveSecretReferenceResponse)(nil), // 51: coordinator.v1.ResolveSecretReferenceResponse
+	nil,                                    // 52: coordinator.v1.PollRequest.LabelsEntry
+	nil,                                    // 53: coordinator.v1.Task.WorkerSelectorEntry
+	nil,                                    // 54: coordinator.v1.WorkerInfo.LabelsEntry
+	nil,                                    // 55: coordinator.v1.HeartbeatRequest.LabelsEntry
 }
 var file_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
-	50, // 0: coordinator.v1.PollRequest.labels:type_name -> coordinator.v1.PollRequest.LabelsEntry
+	52, // 0: coordinator.v1.PollRequest.labels:type_name -> coordinator.v1.PollRequest.LabelsEntry
 	7,  // 1: coordinator.v1.PollResponse.task:type_name -> coordinator.v1.Task
 	7,  // 2: coordinator.v1.DispatchRequest.task:type_name -> coordinator.v1.Task
 	0,  // 3: coordinator.v1.Task.operation:type_name -> coordinator.v1.Operation
-	51, // 4: coordinator.v1.Task.worker_selector:type_name -> coordinator.v1.Task.WorkerSelectorEntry
+	53, // 4: coordinator.v1.Task.worker_selector:type_name -> coordinator.v1.Task.WorkerSelectorEntry
 	22, // 5: coordinator.v1.Task.previous_status:type_name -> coordinator.v1.DAGRunStatusProto
 	10, // 6: coordinator.v1.GetWorkersResponse.workers:type_name -> coordinator.v1.WorkerInfo
-	52, // 7: coordinator.v1.WorkerInfo.labels:type_name -> coordinator.v1.WorkerInfo.LabelsEntry
+	54, // 7: coordinator.v1.WorkerInfo.labels:type_name -> coordinator.v1.WorkerInfo.LabelsEntry
 	19, // 8: coordinator.v1.WorkerInfo.running_tasks:type_name -> coordinator.v1.RunningTask
 	1,  // 9: coordinator.v1.WorkerInfo.health_status:type_name -> coordinator.v1.WorkerHealthStatus
-	53, // 10: coordinator.v1.HeartbeatRequest.labels:type_name -> coordinator.v1.HeartbeatRequest.LabelsEntry
+	55, // 10: coordinator.v1.HeartbeatRequest.labels:type_name -> coordinator.v1.HeartbeatRequest.LabelsEntry
 	18, // 11: coordinator.v1.HeartbeatRequest.stats:type_name -> coordinator.v1.WorkerStats
 	17, // 12: coordinator.v1.HeartbeatResponse.cancelled_runs:type_name -> coordinator.v1.CancelledRun
 	19, // 13: coordinator.v1.RunHeartbeatRequest.running_tasks:type_name -> coordinator.v1.RunningTask
@@ -5219,27 +5387,29 @@ var file_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
 	44, // 45: coordinator.v1.CoordinatorService.DeleteState:input_type -> coordinator.v1.DeleteStateRequest
 	46, // 46: coordinator.v1.CoordinatorService.ListState:input_type -> coordinator.v1.ListStateRequest
 	48, // 47: coordinator.v1.CoordinatorService.GetDAG:input_type -> coordinator.v1.GetDAGRequest
-	4,  // 48: coordinator.v1.CoordinatorService.Poll:output_type -> coordinator.v1.PollResponse
-	6,  // 49: coordinator.v1.CoordinatorService.Dispatch:output_type -> coordinator.v1.DispatchResponse
-	9,  // 50: coordinator.v1.CoordinatorService.GetWorkers:output_type -> coordinator.v1.GetWorkersResponse
-	12, // 51: coordinator.v1.CoordinatorService.Heartbeat:output_type -> coordinator.v1.HeartbeatResponse
-	14, // 52: coordinator.v1.CoordinatorService.AckTaskClaim:output_type -> coordinator.v1.AckTaskClaimResponse
-	16, // 53: coordinator.v1.CoordinatorService.RunHeartbeat:output_type -> coordinator.v1.RunHeartbeatResponse
-	21, // 54: coordinator.v1.CoordinatorService.ReportStatus:output_type -> coordinator.v1.ReportStatusResponse
-	24, // 55: coordinator.v1.CoordinatorService.StreamLogs:output_type -> coordinator.v1.StreamLogsResponse
-	26, // 56: coordinator.v1.CoordinatorService.StreamArtifacts:output_type -> coordinator.v1.StreamArtifactsResponse
-	29, // 57: coordinator.v1.CoordinatorService.PutWorkspaceBundle:output_type -> coordinator.v1.PutWorkspaceBundleResponse
-	31, // 58: coordinator.v1.CoordinatorService.HasWorkspaceBundle:output_type -> coordinator.v1.HasWorkspaceBundleResponse
-	28, // 59: coordinator.v1.CoordinatorService.GetWorkspaceBundle:output_type -> coordinator.v1.WorkspaceBundleChunk
-	34, // 60: coordinator.v1.CoordinatorService.GetDAGRunStatus:output_type -> coordinator.v1.GetDAGRunStatusResponse
-	36, // 61: coordinator.v1.CoordinatorService.RequestCancel:output_type -> coordinator.v1.RequestCancelResponse
-	41, // 62: coordinator.v1.CoordinatorService.GetState:output_type -> coordinator.v1.GetStateResponse
-	43, // 63: coordinator.v1.CoordinatorService.PutState:output_type -> coordinator.v1.PutStateResponse
-	45, // 64: coordinator.v1.CoordinatorService.DeleteState:output_type -> coordinator.v1.DeleteStateResponse
-	47, // 65: coordinator.v1.CoordinatorService.ListState:output_type -> coordinator.v1.ListStateResponse
-	49, // 66: coordinator.v1.CoordinatorService.GetDAG:output_type -> coordinator.v1.GetDAGResponse
-	48, // [48:67] is the sub-list for method output_type
-	29, // [29:48] is the sub-list for method input_type
+	50, // 48: coordinator.v1.CoordinatorService.ResolveSecretReference:input_type -> coordinator.v1.ResolveSecretReferenceRequest
+	4,  // 49: coordinator.v1.CoordinatorService.Poll:output_type -> coordinator.v1.PollResponse
+	6,  // 50: coordinator.v1.CoordinatorService.Dispatch:output_type -> coordinator.v1.DispatchResponse
+	9,  // 51: coordinator.v1.CoordinatorService.GetWorkers:output_type -> coordinator.v1.GetWorkersResponse
+	12, // 52: coordinator.v1.CoordinatorService.Heartbeat:output_type -> coordinator.v1.HeartbeatResponse
+	14, // 53: coordinator.v1.CoordinatorService.AckTaskClaim:output_type -> coordinator.v1.AckTaskClaimResponse
+	16, // 54: coordinator.v1.CoordinatorService.RunHeartbeat:output_type -> coordinator.v1.RunHeartbeatResponse
+	21, // 55: coordinator.v1.CoordinatorService.ReportStatus:output_type -> coordinator.v1.ReportStatusResponse
+	24, // 56: coordinator.v1.CoordinatorService.StreamLogs:output_type -> coordinator.v1.StreamLogsResponse
+	26, // 57: coordinator.v1.CoordinatorService.StreamArtifacts:output_type -> coordinator.v1.StreamArtifactsResponse
+	29, // 58: coordinator.v1.CoordinatorService.PutWorkspaceBundle:output_type -> coordinator.v1.PutWorkspaceBundleResponse
+	31, // 59: coordinator.v1.CoordinatorService.HasWorkspaceBundle:output_type -> coordinator.v1.HasWorkspaceBundleResponse
+	28, // 60: coordinator.v1.CoordinatorService.GetWorkspaceBundle:output_type -> coordinator.v1.WorkspaceBundleChunk
+	34, // 61: coordinator.v1.CoordinatorService.GetDAGRunStatus:output_type -> coordinator.v1.GetDAGRunStatusResponse
+	36, // 62: coordinator.v1.CoordinatorService.RequestCancel:output_type -> coordinator.v1.RequestCancelResponse
+	41, // 63: coordinator.v1.CoordinatorService.GetState:output_type -> coordinator.v1.GetStateResponse
+	43, // 64: coordinator.v1.CoordinatorService.PutState:output_type -> coordinator.v1.PutStateResponse
+	45, // 65: coordinator.v1.CoordinatorService.DeleteState:output_type -> coordinator.v1.DeleteStateResponse
+	47, // 66: coordinator.v1.CoordinatorService.ListState:output_type -> coordinator.v1.ListStateResponse
+	49, // 67: coordinator.v1.CoordinatorService.GetDAG:output_type -> coordinator.v1.GetDAGResponse
+	51, // 68: coordinator.v1.CoordinatorService.ResolveSecretReference:output_type -> coordinator.v1.ResolveSecretReferenceResponse
+	49, // [49:69] is the sub-list for method output_type
+	29, // [29:49] is the sub-list for method input_type
 	29, // [29:29] is the sub-list for extension type_name
 	29, // [29:29] is the sub-list for extension extendee
 	0,  // [0:29] is the sub-list for field type_name
@@ -5256,7 +5426,7 @@ func file_proto_coordinator_v1_coordinator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_coordinator_v1_coordinator_proto_rawDesc), len(file_proto_coordinator_v1_coordinator_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   51,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/coordinator/v1/coordinator.pb.go
+++ b/proto/coordinator/v1/coordinator.pb.go
@@ -4812,10 +4812,13 @@ func (b0 GetDAGResponse_builder) Build() *GetDAGResponse {
 // ResolveSecretReference resolves or checks one Dagu-managed registry ref.
 type ResolveSecretReferenceRequest struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                             // Environment variable name requested by the DAG
-	Ref           string                 `protobuf:"bytes,2,opt,name=ref,proto3" json:"ref,omitempty"`                               // Registry ref, for example "prod/db-password"
-	Workspace     string                 `protobuf:"bytes,3,opt,name=workspace,proto3" json:"workspace,omitempty"`                   // Workspace scope; empty means global
-	CheckOnly     bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3" json:"check_only,omitempty"` // When true, verify access without returning plaintext
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                               // Environment variable name requested by the DAG
+	Ref           string                 `protobuf:"bytes,2,opt,name=ref,proto3" json:"ref,omitempty"`                                 // Registry ref, for example "prod/db-password"
+	Workspace     string                 `protobuf:"bytes,3,opt,name=workspace,proto3" json:"workspace,omitempty"`                     // Workspace scope; empty means global
+	CheckOnly     bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3" json:"check_only,omitempty"`   // When true, verify access without returning plaintext
+	WorkerId      string                 `protobuf:"bytes,5,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`       // Worker currently owning the dispatched attempt
+	AttemptKey    string                 `protobuf:"bytes,6,opt,name=attempt_key,json=attemptKey,proto3" json:"attempt_key,omitempty"` // Active distributed attempt lease key
+	AttemptId     string                 `protobuf:"bytes,7,opt,name=attempt_id,json=attemptId,proto3" json:"attempt_id,omitempty"`    // Attempt ID created by the coordinator
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4873,6 +4876,27 @@ func (x *ResolveSecretReferenceRequest) GetCheckOnly() bool {
 	return false
 }
 
+func (x *ResolveSecretReferenceRequest) GetWorkerId() string {
+	if x != nil {
+		return x.WorkerId
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetAttemptKey() string {
+	if x != nil {
+		return x.AttemptKey
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetAttemptId() string {
+	if x != nil {
+		return x.AttemptId
+	}
+	return ""
+}
+
 func (x *ResolveSecretReferenceRequest) SetName(v string) {
 	x.Name = v
 }
@@ -4889,13 +4913,28 @@ func (x *ResolveSecretReferenceRequest) SetCheckOnly(v bool) {
 	x.CheckOnly = v
 }
 
+func (x *ResolveSecretReferenceRequest) SetWorkerId(v string) {
+	x.WorkerId = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetAttemptKey(v string) {
+	x.AttemptKey = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetAttemptId(v string) {
+	x.AttemptId = v
+}
+
 type ResolveSecretReferenceRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Name      string
-	Ref       string
-	Workspace string
-	CheckOnly bool
+	Name       string
+	Ref        string
+	Workspace  string
+	CheckOnly  bool
+	WorkerId   string
+	AttemptKey string
+	AttemptId  string
 }
 
 func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceRequest {
@@ -4906,6 +4945,9 @@ func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceR
 	x.Ref = b.Ref
 	x.Workspace = b.Workspace
 	x.CheckOnly = b.CheckOnly
+	x.WorkerId = b.WorkerId
+	x.AttemptKey = b.AttemptKey
+	x.AttemptId = b.AttemptId
 	return m0
 }
 
@@ -5231,13 +5273,18 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\":\n" +
 	"\x0eGetDAGResponse\x12\x12\n" +
 	"\x04spec\x18\x01 \x01(\tR\x04spec\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\x82\x01\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\xdf\x01\n" +
 	"\x1dResolveSecretReferenceRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x1c\n" +
 	"\tworkspace\x18\x03 \x01(\tR\tworkspace\x12\x1d\n" +
 	"\n" +
-	"check_only\x18\x04 \x01(\bR\tcheckOnly\"6\n" +
+	"check_only\x18\x04 \x01(\bR\tcheckOnly\x12\x1b\n" +
+	"\tworker_id\x18\x05 \x01(\tR\bworkerId\x12\x1f\n" +
+	"\vattempt_key\x18\x06 \x01(\tR\n" +
+	"attemptKey\x12\x1d\n" +
+	"\n" +
+	"attempt_id\x18\a \x01(\tR\tattemptId\"6\n" +
 	"\x1eResolveSecretReferenceResponse\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value*P\n" +
 	"\tOperation\x12\x19\n" +

--- a/proto/coordinator/v1/coordinator.proto
+++ b/proto/coordinator/v1/coordinator.proto
@@ -481,6 +481,9 @@ message ResolveSecretReferenceRequest {
   string ref = 2;       // Registry ref, for example "prod/db-password"
   string workspace = 3; // Workspace scope; empty means global
   bool check_only = 4;  // When true, verify access without returning plaintext
+  string worker_id = 5;   // Worker currently owning the dispatched attempt
+  string attempt_key = 6; // Active distributed attempt lease key
+  string attempt_id = 7;  // Attempt ID created by the coordinator
 }
 
 message ResolveSecretReferenceResponse {

--- a/proto/coordinator/v1/coordinator.proto
+++ b/proto/coordinator/v1/coordinator.proto
@@ -71,6 +71,10 @@ service CoordinatorService {
   // Used as a fallback when a worker's local DAG store misses a definition during
   // sub-DAG execution.
   rpc GetDAG (GetDAGRequest) returns (GetDAGResponse);
+
+  // ResolveSecretReference resolves or checks a Dagu-managed secret registry ref.
+  // Used by shared-nothing workers that cannot read the coordinator's secret store.
+  rpc ResolveSecretReference (ResolveSecretReferenceRequest) returns (ResolveSecretReferenceResponse);
 }
 
 // Request message for polling a task.
@@ -469,4 +473,16 @@ message GetDAGRequest {
 message GetDAGResponse {
   string spec = 1;  // Raw YAML content of the DAG definition (empty if not found)
   string error = 2; // Error description when the DAG cannot be retrieved
+}
+
+// ResolveSecretReference resolves or checks one Dagu-managed registry ref.
+message ResolveSecretReferenceRequest {
+  string name = 1;      // Environment variable name requested by the DAG
+  string ref = 2;       // Registry ref, for example "prod/db-password"
+  string workspace = 3; // Workspace scope; empty means global
+  bool check_only = 4;  // When true, verify access without returning plaintext
+}
+
+message ResolveSecretReferenceResponse {
+  string value = 1; // Plaintext secret value; empty for check_only
 }

--- a/proto/coordinator/v1/coordinator_grpc.pb.go
+++ b/proto/coordinator/v1/coordinator_grpc.pb.go
@@ -22,25 +22,26 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	CoordinatorService_Poll_FullMethodName               = "/coordinator.v1.CoordinatorService/Poll"
-	CoordinatorService_Dispatch_FullMethodName           = "/coordinator.v1.CoordinatorService/Dispatch"
-	CoordinatorService_GetWorkers_FullMethodName         = "/coordinator.v1.CoordinatorService/GetWorkers"
-	CoordinatorService_Heartbeat_FullMethodName          = "/coordinator.v1.CoordinatorService/Heartbeat"
-	CoordinatorService_AckTaskClaim_FullMethodName       = "/coordinator.v1.CoordinatorService/AckTaskClaim"
-	CoordinatorService_RunHeartbeat_FullMethodName       = "/coordinator.v1.CoordinatorService/RunHeartbeat"
-	CoordinatorService_ReportStatus_FullMethodName       = "/coordinator.v1.CoordinatorService/ReportStatus"
-	CoordinatorService_StreamLogs_FullMethodName         = "/coordinator.v1.CoordinatorService/StreamLogs"
-	CoordinatorService_StreamArtifacts_FullMethodName    = "/coordinator.v1.CoordinatorService/StreamArtifacts"
-	CoordinatorService_PutWorkspaceBundle_FullMethodName = "/coordinator.v1.CoordinatorService/PutWorkspaceBundle"
-	CoordinatorService_HasWorkspaceBundle_FullMethodName = "/coordinator.v1.CoordinatorService/HasWorkspaceBundle"
-	CoordinatorService_GetWorkspaceBundle_FullMethodName = "/coordinator.v1.CoordinatorService/GetWorkspaceBundle"
-	CoordinatorService_GetDAGRunStatus_FullMethodName    = "/coordinator.v1.CoordinatorService/GetDAGRunStatus"
-	CoordinatorService_RequestCancel_FullMethodName      = "/coordinator.v1.CoordinatorService/RequestCancel"
-	CoordinatorService_GetState_FullMethodName           = "/coordinator.v1.CoordinatorService/GetState"
-	CoordinatorService_PutState_FullMethodName           = "/coordinator.v1.CoordinatorService/PutState"
-	CoordinatorService_DeleteState_FullMethodName        = "/coordinator.v1.CoordinatorService/DeleteState"
-	CoordinatorService_ListState_FullMethodName          = "/coordinator.v1.CoordinatorService/ListState"
-	CoordinatorService_GetDAG_FullMethodName             = "/coordinator.v1.CoordinatorService/GetDAG"
+	CoordinatorService_Poll_FullMethodName                   = "/coordinator.v1.CoordinatorService/Poll"
+	CoordinatorService_Dispatch_FullMethodName               = "/coordinator.v1.CoordinatorService/Dispatch"
+	CoordinatorService_GetWorkers_FullMethodName             = "/coordinator.v1.CoordinatorService/GetWorkers"
+	CoordinatorService_Heartbeat_FullMethodName              = "/coordinator.v1.CoordinatorService/Heartbeat"
+	CoordinatorService_AckTaskClaim_FullMethodName           = "/coordinator.v1.CoordinatorService/AckTaskClaim"
+	CoordinatorService_RunHeartbeat_FullMethodName           = "/coordinator.v1.CoordinatorService/RunHeartbeat"
+	CoordinatorService_ReportStatus_FullMethodName           = "/coordinator.v1.CoordinatorService/ReportStatus"
+	CoordinatorService_StreamLogs_FullMethodName             = "/coordinator.v1.CoordinatorService/StreamLogs"
+	CoordinatorService_StreamArtifacts_FullMethodName        = "/coordinator.v1.CoordinatorService/StreamArtifacts"
+	CoordinatorService_PutWorkspaceBundle_FullMethodName     = "/coordinator.v1.CoordinatorService/PutWorkspaceBundle"
+	CoordinatorService_HasWorkspaceBundle_FullMethodName     = "/coordinator.v1.CoordinatorService/HasWorkspaceBundle"
+	CoordinatorService_GetWorkspaceBundle_FullMethodName     = "/coordinator.v1.CoordinatorService/GetWorkspaceBundle"
+	CoordinatorService_GetDAGRunStatus_FullMethodName        = "/coordinator.v1.CoordinatorService/GetDAGRunStatus"
+	CoordinatorService_RequestCancel_FullMethodName          = "/coordinator.v1.CoordinatorService/RequestCancel"
+	CoordinatorService_GetState_FullMethodName               = "/coordinator.v1.CoordinatorService/GetState"
+	CoordinatorService_PutState_FullMethodName               = "/coordinator.v1.CoordinatorService/PutState"
+	CoordinatorService_DeleteState_FullMethodName            = "/coordinator.v1.CoordinatorService/DeleteState"
+	CoordinatorService_ListState_FullMethodName              = "/coordinator.v1.CoordinatorService/ListState"
+	CoordinatorService_GetDAG_FullMethodName                 = "/coordinator.v1.CoordinatorService/GetDAG"
+	CoordinatorService_ResolveSecretReference_FullMethodName = "/coordinator.v1.CoordinatorService/ResolveSecretReference"
 )
 
 // CoordinatorServiceClient is the client API for CoordinatorService service.
@@ -96,6 +97,9 @@ type CoordinatorServiceClient interface {
 	// Used as a fallback when a worker's local DAG store misses a definition during
 	// sub-DAG execution.
 	GetDAG(ctx context.Context, in *GetDAGRequest, opts ...grpc.CallOption) (*GetDAGResponse, error)
+	// ResolveSecretReference resolves or checks a Dagu-managed secret registry ref.
+	// Used by shared-nothing workers that cannot read the coordinator's secret store.
+	ResolveSecretReference(ctx context.Context, in *ResolveSecretReferenceRequest, opts ...grpc.CallOption) (*ResolveSecretReferenceResponse, error)
 }
 
 type coordinatorServiceClient struct {
@@ -314,6 +318,16 @@ func (c *coordinatorServiceClient) GetDAG(ctx context.Context, in *GetDAGRequest
 	return out, nil
 }
 
+func (c *coordinatorServiceClient) ResolveSecretReference(ctx context.Context, in *ResolveSecretReferenceRequest, opts ...grpc.CallOption) (*ResolveSecretReferenceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResolveSecretReferenceResponse)
+	err := c.cc.Invoke(ctx, CoordinatorService_ResolveSecretReference_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CoordinatorServiceServer is the server API for CoordinatorService service.
 // All implementations must embed UnimplementedCoordinatorServiceServer
 // for forward compatibility.
@@ -367,6 +381,9 @@ type CoordinatorServiceServer interface {
 	// Used as a fallback when a worker's local DAG store misses a definition during
 	// sub-DAG execution.
 	GetDAG(context.Context, *GetDAGRequest) (*GetDAGResponse, error)
+	// ResolveSecretReference resolves or checks a Dagu-managed secret registry ref.
+	// Used by shared-nothing workers that cannot read the coordinator's secret store.
+	ResolveSecretReference(context.Context, *ResolveSecretReferenceRequest) (*ResolveSecretReferenceResponse, error)
 	mustEmbedUnimplementedCoordinatorServiceServer()
 }
 
@@ -433,6 +450,9 @@ func (UnimplementedCoordinatorServiceServer) ListState(context.Context, *ListSta
 }
 func (UnimplementedCoordinatorServiceServer) GetDAG(context.Context, *GetDAGRequest) (*GetDAGResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetDAG not implemented")
+}
+func (UnimplementedCoordinatorServiceServer) ResolveSecretReference(context.Context, *ResolveSecretReferenceRequest) (*ResolveSecretReferenceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResolveSecretReference not implemented")
 }
 func (UnimplementedCoordinatorServiceServer) mustEmbedUnimplementedCoordinatorServiceServer() {}
 func (UnimplementedCoordinatorServiceServer) testEmbeddedByValue()                            {}
@@ -757,6 +777,24 @@ func _CoordinatorService_GetDAG_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CoordinatorService_ResolveSecretReference_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResolveSecretReferenceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CoordinatorServiceServer).ResolveSecretReference(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CoordinatorService_ResolveSecretReference_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CoordinatorServiceServer).ResolveSecretReference(ctx, req.(*ResolveSecretReferenceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CoordinatorService_ServiceDesc is the grpc.ServiceDesc for CoordinatorService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -823,6 +861,10 @@ var CoordinatorService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDAG",
 			Handler:    _CoordinatorService_GetDAG_Handler,
+		},
+		{
+			MethodName: "ResolveSecretReference",
+			Handler:    _CoordinatorService_ResolveSecretReference_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/proto/coordinator/v1/coordinator_protoopaque.pb.go
+++ b/proto/coordinator/v1/coordinator_protoopaque.pb.go
@@ -4796,6 +4796,163 @@ func (b0 GetDAGResponse_builder) Build() *GetDAGResponse {
 	return m0
 }
 
+// ResolveSecretReference resolves or checks one Dagu-managed registry ref.
+type ResolveSecretReferenceRequest struct {
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name      string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Ref       string                 `protobuf:"bytes,2,opt,name=ref,proto3"`
+	xxx_hidden_Workspace string                 `protobuf:"bytes,3,opt,name=workspace,proto3"`
+	xxx_hidden_CheckOnly bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ResolveSecretReferenceRequest) Reset() {
+	*x = ResolveSecretReferenceRequest{}
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveSecretReferenceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveSecretReferenceRequest) ProtoMessage() {}
+
+func (x *ResolveSecretReferenceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ResolveSecretReferenceRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetRef() string {
+	if x != nil {
+		return x.xxx_hidden_Ref
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetWorkspace() string {
+	if x != nil {
+		return x.xxx_hidden_Workspace
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetCheckOnly() bool {
+	if x != nil {
+		return x.xxx_hidden_CheckOnly
+	}
+	return false
+}
+
+func (x *ResolveSecretReferenceRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetRef(v string) {
+	x.xxx_hidden_Ref = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetWorkspace(v string) {
+	x.xxx_hidden_Workspace = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetCheckOnly(v bool) {
+	x.xxx_hidden_CheckOnly = v
+}
+
+type ResolveSecretReferenceRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Name      string
+	Ref       string
+	Workspace string
+	CheckOnly bool
+}
+
+func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceRequest {
+	m0 := &ResolveSecretReferenceRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Ref = b.Ref
+	x.xxx_hidden_Workspace = b.Workspace
+	x.xxx_hidden_CheckOnly = b.CheckOnly
+	return m0
+}
+
+type ResolveSecretReferenceResponse struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Value string                 `protobuf:"bytes,1,opt,name=value,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ResolveSecretReferenceResponse) Reset() {
+	*x = ResolveSecretReferenceResponse{}
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResolveSecretReferenceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResolveSecretReferenceResponse) ProtoMessage() {}
+
+func (x *ResolveSecretReferenceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_coordinator_v1_coordinator_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ResolveSecretReferenceResponse) GetValue() string {
+	if x != nil {
+		return x.xxx_hidden_Value
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceResponse) SetValue(v string) {
+	x.xxx_hidden_Value = v
+}
+
+type ResolveSecretReferenceResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Value string
+}
+
+func (b0 ResolveSecretReferenceResponse_builder) Build() *ResolveSecretReferenceResponse {
+	m0 := &ResolveSecretReferenceResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Value = b.Value
+	return m0
+}
+
 var File_proto_coordinator_v1_coordinator_proto protoreflect.FileDescriptor
 
 const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
@@ -5061,7 +5218,15 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\":\n" +
 	"\x0eGetDAGResponse\x12\x12\n" +
 	"\x04spec\x18\x01 \x01(\tR\x04spec\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error*P\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\x82\x01\n" +
+	"\x1dResolveSecretReferenceRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
+	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x1c\n" +
+	"\tworkspace\x18\x03 \x01(\tR\tworkspace\x12\x1d\n" +
+	"\n" +
+	"check_only\x18\x04 \x01(\bR\tcheckOnly\"6\n" +
+	"\x1eResolveSecretReferenceResponse\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value*P\n" +
 	"\tOperation\x12\x19\n" +
 	"\x15OPERATION_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fOPERATION_START\x10\x01\x12\x13\n" +
@@ -5075,7 +5240,7 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x1bLOG_STREAM_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16LOG_STREAM_TYPE_STDOUT\x10\x01\x12\x1a\n" +
 	"\x16LOG_STREAM_TYPE_STDERR\x10\x02\x12\x1d\n" +
-	"\x19LOG_STREAM_TYPE_SCHEDULER\x10\x032\x9c\r\n" +
+	"\x19LOG_STREAM_TYPE_SCHEDULER\x10\x032\x95\x0e\n" +
 	"\x12CoordinatorService\x12A\n" +
 	"\x04Poll\x12\x1b.coordinator.v1.PollRequest\x1a\x1c.coordinator.v1.PollResponse\x12M\n" +
 	"\bDispatch\x12\x1f.coordinator.v1.DispatchRequest\x1a .coordinator.v1.DispatchResponse\x12S\n" +
@@ -5097,78 +5262,81 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\bPutState\x12\x1f.coordinator.v1.PutStateRequest\x1a .coordinator.v1.PutStateResponse\x12V\n" +
 	"\vDeleteState\x12\".coordinator.v1.DeleteStateRequest\x1a#.coordinator.v1.DeleteStateResponse\x12P\n" +
 	"\tListState\x12 .coordinator.v1.ListStateRequest\x1a!.coordinator.v1.ListStateResponse\x12G\n" +
-	"\x06GetDAG\x12\x1d.coordinator.v1.GetDAGRequest\x1a\x1e.coordinator.v1.GetDAGResponseB>Z<github.com/dagucloud/dagu/proto/coordinator/v1;coordinatorv1b\x06proto3"
+	"\x06GetDAG\x12\x1d.coordinator.v1.GetDAGRequest\x1a\x1e.coordinator.v1.GetDAGResponse\x12w\n" +
+	"\x16ResolveSecretReference\x12-.coordinator.v1.ResolveSecretReferenceRequest\x1a..coordinator.v1.ResolveSecretReferenceResponseB>Z<github.com/dagucloud/dagu/proto/coordinator/v1;coordinatorv1b\x06proto3"
 
 var file_proto_coordinator_v1_coordinator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_proto_coordinator_v1_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_proto_coordinator_v1_coordinator_proto_goTypes = []any{
-	(Operation)(0),                     // 0: coordinator.v1.Operation
-	(WorkerHealthStatus)(0),            // 1: coordinator.v1.WorkerHealthStatus
-	(LogStreamType)(0),                 // 2: coordinator.v1.LogStreamType
-	(*PollRequest)(nil),                // 3: coordinator.v1.PollRequest
-	(*PollResponse)(nil),               // 4: coordinator.v1.PollResponse
-	(*DispatchRequest)(nil),            // 5: coordinator.v1.DispatchRequest
-	(*DispatchResponse)(nil),           // 6: coordinator.v1.DispatchResponse
-	(*Task)(nil),                       // 7: coordinator.v1.Task
-	(*GetWorkersRequest)(nil),          // 8: coordinator.v1.GetWorkersRequest
-	(*GetWorkersResponse)(nil),         // 9: coordinator.v1.GetWorkersResponse
-	(*WorkerInfo)(nil),                 // 10: coordinator.v1.WorkerInfo
-	(*HeartbeatRequest)(nil),           // 11: coordinator.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),          // 12: coordinator.v1.HeartbeatResponse
-	(*AckTaskClaimRequest)(nil),        // 13: coordinator.v1.AckTaskClaimRequest
-	(*AckTaskClaimResponse)(nil),       // 14: coordinator.v1.AckTaskClaimResponse
-	(*RunHeartbeatRequest)(nil),        // 15: coordinator.v1.RunHeartbeatRequest
-	(*RunHeartbeatResponse)(nil),       // 16: coordinator.v1.RunHeartbeatResponse
-	(*CancelledRun)(nil),               // 17: coordinator.v1.CancelledRun
-	(*WorkerStats)(nil),                // 18: coordinator.v1.WorkerStats
-	(*RunningTask)(nil),                // 19: coordinator.v1.RunningTask
-	(*ReportStatusRequest)(nil),        // 20: coordinator.v1.ReportStatusRequest
-	(*ReportStatusResponse)(nil),       // 21: coordinator.v1.ReportStatusResponse
-	(*DAGRunStatusProto)(nil),          // 22: coordinator.v1.DAGRunStatusProto
-	(*LogChunk)(nil),                   // 23: coordinator.v1.LogChunk
-	(*StreamLogsResponse)(nil),         // 24: coordinator.v1.StreamLogsResponse
-	(*ArtifactChunk)(nil),              // 25: coordinator.v1.ArtifactChunk
-	(*StreamArtifactsResponse)(nil),    // 26: coordinator.v1.StreamArtifactsResponse
-	(*WorkspaceBundle)(nil),            // 27: coordinator.v1.WorkspaceBundle
-	(*WorkspaceBundleChunk)(nil),       // 28: coordinator.v1.WorkspaceBundleChunk
-	(*PutWorkspaceBundleResponse)(nil), // 29: coordinator.v1.PutWorkspaceBundleResponse
-	(*HasWorkspaceBundleRequest)(nil),  // 30: coordinator.v1.HasWorkspaceBundleRequest
-	(*HasWorkspaceBundleResponse)(nil), // 31: coordinator.v1.HasWorkspaceBundleResponse
-	(*GetWorkspaceBundleRequest)(nil),  // 32: coordinator.v1.GetWorkspaceBundleRequest
-	(*GetDAGRunStatusRequest)(nil),     // 33: coordinator.v1.GetDAGRunStatusRequest
-	(*GetDAGRunStatusResponse)(nil),    // 34: coordinator.v1.GetDAGRunStatusResponse
-	(*RequestCancelRequest)(nil),       // 35: coordinator.v1.RequestCancelRequest
-	(*RequestCancelResponse)(nil),      // 36: coordinator.v1.RequestCancelResponse
-	(*StateRef)(nil),                   // 37: coordinator.v1.StateRef
-	(*StateUpdateSource)(nil),          // 38: coordinator.v1.StateUpdateSource
-	(*StateEntry)(nil),                 // 39: coordinator.v1.StateEntry
-	(*GetStateRequest)(nil),            // 40: coordinator.v1.GetStateRequest
-	(*GetStateResponse)(nil),           // 41: coordinator.v1.GetStateResponse
-	(*PutStateRequest)(nil),            // 42: coordinator.v1.PutStateRequest
-	(*PutStateResponse)(nil),           // 43: coordinator.v1.PutStateResponse
-	(*DeleteStateRequest)(nil),         // 44: coordinator.v1.DeleteStateRequest
-	(*DeleteStateResponse)(nil),        // 45: coordinator.v1.DeleteStateResponse
-	(*ListStateRequest)(nil),           // 46: coordinator.v1.ListStateRequest
-	(*ListStateResponse)(nil),          // 47: coordinator.v1.ListStateResponse
-	(*GetDAGRequest)(nil),              // 48: coordinator.v1.GetDAGRequest
-	(*GetDAGResponse)(nil),             // 49: coordinator.v1.GetDAGResponse
-	nil,                                // 50: coordinator.v1.PollRequest.LabelsEntry
-	nil,                                // 51: coordinator.v1.Task.WorkerSelectorEntry
-	nil,                                // 52: coordinator.v1.WorkerInfo.LabelsEntry
-	nil,                                // 53: coordinator.v1.HeartbeatRequest.LabelsEntry
+	(Operation)(0),                         // 0: coordinator.v1.Operation
+	(WorkerHealthStatus)(0),                // 1: coordinator.v1.WorkerHealthStatus
+	(LogStreamType)(0),                     // 2: coordinator.v1.LogStreamType
+	(*PollRequest)(nil),                    // 3: coordinator.v1.PollRequest
+	(*PollResponse)(nil),                   // 4: coordinator.v1.PollResponse
+	(*DispatchRequest)(nil),                // 5: coordinator.v1.DispatchRequest
+	(*DispatchResponse)(nil),               // 6: coordinator.v1.DispatchResponse
+	(*Task)(nil),                           // 7: coordinator.v1.Task
+	(*GetWorkersRequest)(nil),              // 8: coordinator.v1.GetWorkersRequest
+	(*GetWorkersResponse)(nil),             // 9: coordinator.v1.GetWorkersResponse
+	(*WorkerInfo)(nil),                     // 10: coordinator.v1.WorkerInfo
+	(*HeartbeatRequest)(nil),               // 11: coordinator.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),              // 12: coordinator.v1.HeartbeatResponse
+	(*AckTaskClaimRequest)(nil),            // 13: coordinator.v1.AckTaskClaimRequest
+	(*AckTaskClaimResponse)(nil),           // 14: coordinator.v1.AckTaskClaimResponse
+	(*RunHeartbeatRequest)(nil),            // 15: coordinator.v1.RunHeartbeatRequest
+	(*RunHeartbeatResponse)(nil),           // 16: coordinator.v1.RunHeartbeatResponse
+	(*CancelledRun)(nil),                   // 17: coordinator.v1.CancelledRun
+	(*WorkerStats)(nil),                    // 18: coordinator.v1.WorkerStats
+	(*RunningTask)(nil),                    // 19: coordinator.v1.RunningTask
+	(*ReportStatusRequest)(nil),            // 20: coordinator.v1.ReportStatusRequest
+	(*ReportStatusResponse)(nil),           // 21: coordinator.v1.ReportStatusResponse
+	(*DAGRunStatusProto)(nil),              // 22: coordinator.v1.DAGRunStatusProto
+	(*LogChunk)(nil),                       // 23: coordinator.v1.LogChunk
+	(*StreamLogsResponse)(nil),             // 24: coordinator.v1.StreamLogsResponse
+	(*ArtifactChunk)(nil),                  // 25: coordinator.v1.ArtifactChunk
+	(*StreamArtifactsResponse)(nil),        // 26: coordinator.v1.StreamArtifactsResponse
+	(*WorkspaceBundle)(nil),                // 27: coordinator.v1.WorkspaceBundle
+	(*WorkspaceBundleChunk)(nil),           // 28: coordinator.v1.WorkspaceBundleChunk
+	(*PutWorkspaceBundleResponse)(nil),     // 29: coordinator.v1.PutWorkspaceBundleResponse
+	(*HasWorkspaceBundleRequest)(nil),      // 30: coordinator.v1.HasWorkspaceBundleRequest
+	(*HasWorkspaceBundleResponse)(nil),     // 31: coordinator.v1.HasWorkspaceBundleResponse
+	(*GetWorkspaceBundleRequest)(nil),      // 32: coordinator.v1.GetWorkspaceBundleRequest
+	(*GetDAGRunStatusRequest)(nil),         // 33: coordinator.v1.GetDAGRunStatusRequest
+	(*GetDAGRunStatusResponse)(nil),        // 34: coordinator.v1.GetDAGRunStatusResponse
+	(*RequestCancelRequest)(nil),           // 35: coordinator.v1.RequestCancelRequest
+	(*RequestCancelResponse)(nil),          // 36: coordinator.v1.RequestCancelResponse
+	(*StateRef)(nil),                       // 37: coordinator.v1.StateRef
+	(*StateUpdateSource)(nil),              // 38: coordinator.v1.StateUpdateSource
+	(*StateEntry)(nil),                     // 39: coordinator.v1.StateEntry
+	(*GetStateRequest)(nil),                // 40: coordinator.v1.GetStateRequest
+	(*GetStateResponse)(nil),               // 41: coordinator.v1.GetStateResponse
+	(*PutStateRequest)(nil),                // 42: coordinator.v1.PutStateRequest
+	(*PutStateResponse)(nil),               // 43: coordinator.v1.PutStateResponse
+	(*DeleteStateRequest)(nil),             // 44: coordinator.v1.DeleteStateRequest
+	(*DeleteStateResponse)(nil),            // 45: coordinator.v1.DeleteStateResponse
+	(*ListStateRequest)(nil),               // 46: coordinator.v1.ListStateRequest
+	(*ListStateResponse)(nil),              // 47: coordinator.v1.ListStateResponse
+	(*GetDAGRequest)(nil),                  // 48: coordinator.v1.GetDAGRequest
+	(*GetDAGResponse)(nil),                 // 49: coordinator.v1.GetDAGResponse
+	(*ResolveSecretReferenceRequest)(nil),  // 50: coordinator.v1.ResolveSecretReferenceRequest
+	(*ResolveSecretReferenceResponse)(nil), // 51: coordinator.v1.ResolveSecretReferenceResponse
+	nil,                                    // 52: coordinator.v1.PollRequest.LabelsEntry
+	nil,                                    // 53: coordinator.v1.Task.WorkerSelectorEntry
+	nil,                                    // 54: coordinator.v1.WorkerInfo.LabelsEntry
+	nil,                                    // 55: coordinator.v1.HeartbeatRequest.LabelsEntry
 }
 var file_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
-	50, // 0: coordinator.v1.PollRequest.labels:type_name -> coordinator.v1.PollRequest.LabelsEntry
+	52, // 0: coordinator.v1.PollRequest.labels:type_name -> coordinator.v1.PollRequest.LabelsEntry
 	7,  // 1: coordinator.v1.PollResponse.task:type_name -> coordinator.v1.Task
 	7,  // 2: coordinator.v1.DispatchRequest.task:type_name -> coordinator.v1.Task
 	0,  // 3: coordinator.v1.Task.operation:type_name -> coordinator.v1.Operation
-	51, // 4: coordinator.v1.Task.worker_selector:type_name -> coordinator.v1.Task.WorkerSelectorEntry
+	53, // 4: coordinator.v1.Task.worker_selector:type_name -> coordinator.v1.Task.WorkerSelectorEntry
 	22, // 5: coordinator.v1.Task.previous_status:type_name -> coordinator.v1.DAGRunStatusProto
 	10, // 6: coordinator.v1.GetWorkersResponse.workers:type_name -> coordinator.v1.WorkerInfo
-	52, // 7: coordinator.v1.WorkerInfo.labels:type_name -> coordinator.v1.WorkerInfo.LabelsEntry
+	54, // 7: coordinator.v1.WorkerInfo.labels:type_name -> coordinator.v1.WorkerInfo.LabelsEntry
 	19, // 8: coordinator.v1.WorkerInfo.running_tasks:type_name -> coordinator.v1.RunningTask
 	1,  // 9: coordinator.v1.WorkerInfo.health_status:type_name -> coordinator.v1.WorkerHealthStatus
-	53, // 10: coordinator.v1.HeartbeatRequest.labels:type_name -> coordinator.v1.HeartbeatRequest.LabelsEntry
+	55, // 10: coordinator.v1.HeartbeatRequest.labels:type_name -> coordinator.v1.HeartbeatRequest.LabelsEntry
 	18, // 11: coordinator.v1.HeartbeatRequest.stats:type_name -> coordinator.v1.WorkerStats
 	17, // 12: coordinator.v1.HeartbeatResponse.cancelled_runs:type_name -> coordinator.v1.CancelledRun
 	19, // 13: coordinator.v1.RunHeartbeatRequest.running_tasks:type_name -> coordinator.v1.RunningTask
@@ -5206,27 +5374,29 @@ var file_proto_coordinator_v1_coordinator_proto_depIdxs = []int32{
 	44, // 45: coordinator.v1.CoordinatorService.DeleteState:input_type -> coordinator.v1.DeleteStateRequest
 	46, // 46: coordinator.v1.CoordinatorService.ListState:input_type -> coordinator.v1.ListStateRequest
 	48, // 47: coordinator.v1.CoordinatorService.GetDAG:input_type -> coordinator.v1.GetDAGRequest
-	4,  // 48: coordinator.v1.CoordinatorService.Poll:output_type -> coordinator.v1.PollResponse
-	6,  // 49: coordinator.v1.CoordinatorService.Dispatch:output_type -> coordinator.v1.DispatchResponse
-	9,  // 50: coordinator.v1.CoordinatorService.GetWorkers:output_type -> coordinator.v1.GetWorkersResponse
-	12, // 51: coordinator.v1.CoordinatorService.Heartbeat:output_type -> coordinator.v1.HeartbeatResponse
-	14, // 52: coordinator.v1.CoordinatorService.AckTaskClaim:output_type -> coordinator.v1.AckTaskClaimResponse
-	16, // 53: coordinator.v1.CoordinatorService.RunHeartbeat:output_type -> coordinator.v1.RunHeartbeatResponse
-	21, // 54: coordinator.v1.CoordinatorService.ReportStatus:output_type -> coordinator.v1.ReportStatusResponse
-	24, // 55: coordinator.v1.CoordinatorService.StreamLogs:output_type -> coordinator.v1.StreamLogsResponse
-	26, // 56: coordinator.v1.CoordinatorService.StreamArtifacts:output_type -> coordinator.v1.StreamArtifactsResponse
-	29, // 57: coordinator.v1.CoordinatorService.PutWorkspaceBundle:output_type -> coordinator.v1.PutWorkspaceBundleResponse
-	31, // 58: coordinator.v1.CoordinatorService.HasWorkspaceBundle:output_type -> coordinator.v1.HasWorkspaceBundleResponse
-	28, // 59: coordinator.v1.CoordinatorService.GetWorkspaceBundle:output_type -> coordinator.v1.WorkspaceBundleChunk
-	34, // 60: coordinator.v1.CoordinatorService.GetDAGRunStatus:output_type -> coordinator.v1.GetDAGRunStatusResponse
-	36, // 61: coordinator.v1.CoordinatorService.RequestCancel:output_type -> coordinator.v1.RequestCancelResponse
-	41, // 62: coordinator.v1.CoordinatorService.GetState:output_type -> coordinator.v1.GetStateResponse
-	43, // 63: coordinator.v1.CoordinatorService.PutState:output_type -> coordinator.v1.PutStateResponse
-	45, // 64: coordinator.v1.CoordinatorService.DeleteState:output_type -> coordinator.v1.DeleteStateResponse
-	47, // 65: coordinator.v1.CoordinatorService.ListState:output_type -> coordinator.v1.ListStateResponse
-	49, // 66: coordinator.v1.CoordinatorService.GetDAG:output_type -> coordinator.v1.GetDAGResponse
-	48, // [48:67] is the sub-list for method output_type
-	29, // [29:48] is the sub-list for method input_type
+	50, // 48: coordinator.v1.CoordinatorService.ResolveSecretReference:input_type -> coordinator.v1.ResolveSecretReferenceRequest
+	4,  // 49: coordinator.v1.CoordinatorService.Poll:output_type -> coordinator.v1.PollResponse
+	6,  // 50: coordinator.v1.CoordinatorService.Dispatch:output_type -> coordinator.v1.DispatchResponse
+	9,  // 51: coordinator.v1.CoordinatorService.GetWorkers:output_type -> coordinator.v1.GetWorkersResponse
+	12, // 52: coordinator.v1.CoordinatorService.Heartbeat:output_type -> coordinator.v1.HeartbeatResponse
+	14, // 53: coordinator.v1.CoordinatorService.AckTaskClaim:output_type -> coordinator.v1.AckTaskClaimResponse
+	16, // 54: coordinator.v1.CoordinatorService.RunHeartbeat:output_type -> coordinator.v1.RunHeartbeatResponse
+	21, // 55: coordinator.v1.CoordinatorService.ReportStatus:output_type -> coordinator.v1.ReportStatusResponse
+	24, // 56: coordinator.v1.CoordinatorService.StreamLogs:output_type -> coordinator.v1.StreamLogsResponse
+	26, // 57: coordinator.v1.CoordinatorService.StreamArtifacts:output_type -> coordinator.v1.StreamArtifactsResponse
+	29, // 58: coordinator.v1.CoordinatorService.PutWorkspaceBundle:output_type -> coordinator.v1.PutWorkspaceBundleResponse
+	31, // 59: coordinator.v1.CoordinatorService.HasWorkspaceBundle:output_type -> coordinator.v1.HasWorkspaceBundleResponse
+	28, // 60: coordinator.v1.CoordinatorService.GetWorkspaceBundle:output_type -> coordinator.v1.WorkspaceBundleChunk
+	34, // 61: coordinator.v1.CoordinatorService.GetDAGRunStatus:output_type -> coordinator.v1.GetDAGRunStatusResponse
+	36, // 62: coordinator.v1.CoordinatorService.RequestCancel:output_type -> coordinator.v1.RequestCancelResponse
+	41, // 63: coordinator.v1.CoordinatorService.GetState:output_type -> coordinator.v1.GetStateResponse
+	43, // 64: coordinator.v1.CoordinatorService.PutState:output_type -> coordinator.v1.PutStateResponse
+	45, // 65: coordinator.v1.CoordinatorService.DeleteState:output_type -> coordinator.v1.DeleteStateResponse
+	47, // 66: coordinator.v1.CoordinatorService.ListState:output_type -> coordinator.v1.ListStateResponse
+	49, // 67: coordinator.v1.CoordinatorService.GetDAG:output_type -> coordinator.v1.GetDAGResponse
+	51, // 68: coordinator.v1.CoordinatorService.ResolveSecretReference:output_type -> coordinator.v1.ResolveSecretReferenceResponse
+	49, // [49:69] is the sub-list for method output_type
+	29, // [29:49] is the sub-list for method input_type
 	29, // [29:29] is the sub-list for extension type_name
 	29, // [29:29] is the sub-list for extension extendee
 	0,  // [0:29] is the sub-list for field type_name
@@ -5243,7 +5413,7 @@ func file_proto_coordinator_v1_coordinator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_coordinator_v1_coordinator_proto_rawDesc), len(file_proto_coordinator_v1_coordinator_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   51,
+			NumMessages:   53,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/coordinator/v1/coordinator_protoopaque.pb.go
+++ b/proto/coordinator/v1/coordinator_protoopaque.pb.go
@@ -4798,13 +4798,16 @@ func (b0 GetDAGResponse_builder) Build() *GetDAGResponse {
 
 // ResolveSecretReference resolves or checks one Dagu-managed registry ref.
 type ResolveSecretReferenceRequest struct {
-	state                protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name      string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Ref       string                 `protobuf:"bytes,2,opt,name=ref,proto3"`
-	xxx_hidden_Workspace string                 `protobuf:"bytes,3,opt,name=workspace,proto3"`
-	xxx_hidden_CheckOnly bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name       string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Ref        string                 `protobuf:"bytes,2,opt,name=ref,proto3"`
+	xxx_hidden_Workspace  string                 `protobuf:"bytes,3,opt,name=workspace,proto3"`
+	xxx_hidden_CheckOnly  bool                   `protobuf:"varint,4,opt,name=check_only,json=checkOnly,proto3"`
+	xxx_hidden_WorkerId   string                 `protobuf:"bytes,5,opt,name=worker_id,json=workerId,proto3"`
+	xxx_hidden_AttemptKey string                 `protobuf:"bytes,6,opt,name=attempt_key,json=attemptKey,proto3"`
+	xxx_hidden_AttemptId  string                 `protobuf:"bytes,7,opt,name=attempt_id,json=attemptId,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ResolveSecretReferenceRequest) Reset() {
@@ -4860,6 +4863,27 @@ func (x *ResolveSecretReferenceRequest) GetCheckOnly() bool {
 	return false
 }
 
+func (x *ResolveSecretReferenceRequest) GetWorkerId() string {
+	if x != nil {
+		return x.xxx_hidden_WorkerId
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetAttemptKey() string {
+	if x != nil {
+		return x.xxx_hidden_AttemptKey
+	}
+	return ""
+}
+
+func (x *ResolveSecretReferenceRequest) GetAttemptId() string {
+	if x != nil {
+		return x.xxx_hidden_AttemptId
+	}
+	return ""
+}
+
 func (x *ResolveSecretReferenceRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -4876,13 +4900,28 @@ func (x *ResolveSecretReferenceRequest) SetCheckOnly(v bool) {
 	x.xxx_hidden_CheckOnly = v
 }
 
+func (x *ResolveSecretReferenceRequest) SetWorkerId(v string) {
+	x.xxx_hidden_WorkerId = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetAttemptKey(v string) {
+	x.xxx_hidden_AttemptKey = v
+}
+
+func (x *ResolveSecretReferenceRequest) SetAttemptId(v string) {
+	x.xxx_hidden_AttemptId = v
+}
+
 type ResolveSecretReferenceRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	Name      string
-	Ref       string
-	Workspace string
-	CheckOnly bool
+	Name       string
+	Ref        string
+	Workspace  string
+	CheckOnly  bool
+	WorkerId   string
+	AttemptKey string
+	AttemptId  string
 }
 
 func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceRequest {
@@ -4893,6 +4932,9 @@ func (b0 ResolveSecretReferenceRequest_builder) Build() *ResolveSecretReferenceR
 	x.xxx_hidden_Ref = b.Ref
 	x.xxx_hidden_Workspace = b.Workspace
 	x.xxx_hidden_CheckOnly = b.CheckOnly
+	x.xxx_hidden_WorkerId = b.WorkerId
+	x.xxx_hidden_AttemptKey = b.AttemptKey
+	x.xxx_hidden_AttemptId = b.AttemptId
 	return m0
 }
 
@@ -5218,13 +5260,18 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\":\n" +
 	"\x0eGetDAGResponse\x12\x12\n" +
 	"\x04spec\x18\x01 \x01(\tR\x04spec\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"\x82\x01\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\xdf\x01\n" +
 	"\x1dResolveSecretReferenceRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x1c\n" +
 	"\tworkspace\x18\x03 \x01(\tR\tworkspace\x12\x1d\n" +
 	"\n" +
-	"check_only\x18\x04 \x01(\bR\tcheckOnly\"6\n" +
+	"check_only\x18\x04 \x01(\bR\tcheckOnly\x12\x1b\n" +
+	"\tworker_id\x18\x05 \x01(\tR\bworkerId\x12\x1f\n" +
+	"\vattempt_key\x18\x06 \x01(\tR\n" +
+	"attemptKey\x12\x1d\n" +
+	"\n" +
+	"attempt_id\x18\a \x01(\tR\tattemptId\"6\n" +
 	"\x1eResolveSecretReferenceResponse\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value*P\n" +
 	"\tOperation\x12\x19\n" +


### PR DESCRIPTION
## Summary
- add coordinator-backed secret reference resolution for shared-nothing workers
- route DAG registry refs through one ReferenceResolver abstraction while preserving local/shared-volume behavior
- add regression coverage for coordinator-owned secrets with an empty worker-local store

## Root cause
Shared-nothing workers reloaded the dispatched DAG and resolved secrets[].ref through their own local SecretStore. That store does not contain coordinator-owned registry secrets, so valid refs failed with secret not found.

## Testing
- go test ./internal/runtime/agent ./internal/service/worker ./internal/service/coordinator -run 'TestAgent_OutputSecretMasking|TestAgent_RegistryRefSecretResolution|TestRemoteTaskHandlerResolvesRegistrySecretsViaCoordinator|TestResolveSecretReference' -count=1
- make test TEST_TARGET="./internal/service/worker ./internal/service/coordinator ./internal/runtime/agent ./internal/proto/convert ./internal/cmd"

Closes #2318

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route DAG secret registry refs through the coordinator for shared‑nothing workers to fix “secret not found” failures. Resolution is scoped to active attempts so workers can resolve or check refs without local store access. Closes #2318.

- **New Features**
  - Added `ResolveSecretReference` RPC on `CoordinatorService` with check‑only mode and run scoping (worker ID, attempt key/ID).
  - Injected a coordinator‑backed `SecretReferenceResolver` into remote workers; local runs keep using the local store.

- **Bug Fixes**
  - Shared‑nothing workers no longer read an empty local secret store; registry refs resolve via the coordinator.
  - Coordinator enforces active‑attempt checks before returning values; notification route tests are now deterministic to avoid flakiness.

<sup>Written for commit 3373043c9a08852d505e56f6e906a3089c85a93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secret reference resolution for shared-nothing worker deployments through the coordinator
  * Workers can now resolve and validate managed secrets, including workspace-scoped references
  * Added verification mode for access validation without exposing plaintext values

* **Tests**
  * Added comprehensive test coverage for secret resolution flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->