### PR TITLE
fix: release dir locks atomically on windows

### DIFF
--- a/internal/cmn/dirlock/dirlock.go
+++ b/internal/cmn/dirlock/dirlock.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 )
 
 // Error types for lock operations
@@ -347,18 +349,26 @@ func ForceUnlock(directory string) error {
 }
 
 func removeLockDir(lockPath string) error {
-	// The scheduler lock directory is intentionally shallow: Dagu creates only
-	// the owner token file inside it. Avoid os.RemoveAll here because recent Go
-	// releases use recursive open-at cleanup paths that are not reliable on old
-	// Windows versions such as Windows Server 2012 R2.
-	ownerPath := filepath.Join(lockPath, lockOwnerFileName)
-	if err := os.Remove(ownerPath); err != nil && !os.IsNotExist(err) {
+	releasedPath := releasedLockPath(lockPath)
+	if err := fileutil.Rename(lockPath, releasedPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
-	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
+	// The live lock name is released after the rename. Cleanup failures should
+	// not keep other lock contenders blocked on a lock this process no longer
+	// owns.
+	_ = fileutil.RemoveAll(releasedPath)
 	return nil
+}
+
+func releasedLockPath(lockPath string) string {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err == nil {
+		return fmt.Sprintf("%s.releasing.%d.%s", lockPath, os.Getpid(), hex.EncodeToString(suffix[:]))
+	}
+	return fmt.Sprintf("%s.releasing.%d.%d", lockPath, os.Getpid(), time.Now().UnixNano())
 }
 
 // isStaleInfo checks if a lock is stale based on file info

--- a/internal/cmn/dirlock/dirlock_external_test.go
+++ b/internal/cmn/dirlock/dirlock_external_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dirlock_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/dirlock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnlockReleasesLiveLockNameBeforeCleanup(t *testing.T) {
+	dir := t.TempDir()
+	lock := dirlock.New(dir, nil)
+	require.NoError(t, lock.TryLock())
+
+	lockDir := filepath.Join(dir, ".dagu_lock")
+	unexpectedDir := filepath.Join(lockDir, "unexpected")
+	require.NoError(t, os.Mkdir(unexpectedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(unexpectedDir, "file"), []byte("data"), 0o600))
+
+	require.NoError(t, lock.Unlock())
+	require.NoDirExists(t, lockDir)
+
+	next := dirlock.New(dir, nil)
+	require.NoError(t, next.TryLock())
+	require.NoError(t, next.Unlock())
+}


### PR DESCRIPTION
## Summary
- release directory locks by renaming `.dagu_lock` out of the live lock path before cleanup
- add regression coverage for lock release when cleanup would otherwise leave a blocking lock directory

## Root cause
On Windows, removing the lock owner file before removing `.dagu_lock` could leave an ownerless live lock directory when directory removal hit a transient sharing violation. Later DAG-run attempts treated that directory as an active lock until the stale timeout and timed out.

## Validation
- go test ./internal/cmn/dirlock -count=1
- go test ./internal/cmn/fileutil -count=1
- go test ./internal/persis/file/dagrun -count=1
- go test ./internal/intg -run TestApprovalPushBackExposesHistoricalFeedbackEnvAcrossRewoundScope -count=1
- go test ./internal/intg -count=1
- GOOS=windows GOARCH=amd64 go test ./internal/cmn/dirlock -run TestUnlockReleasesLiveLockNameBeforeCleanup -c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atomically release Windows directory locks by renaming `.dagu_lock` to a temporary “releasing” path before cleanup. This prevents stale live lock directories after transient sharing violations and unblocks subsequent DAG runs immediately.

- **Bug Fixes**
  - On unlock, rename the live lock dir to a unique releasing path via `fileutil.Rename`, then clean up with `fileutil.RemoveAll` so contention is released even if cleanup fails.
  - Added `releasedLockPath` helper (PID + random/clock suffix) to avoid collisions.
  - Added regression test `TestUnlockReleasesLiveLockNameBeforeCleanup` to ensure `.dagu_lock` is freed and a new lock can be acquired.

<sup>Written for commit 2d14553f9604d99abe339c03f776f543da97e248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock cleanup so directories are removed more reliably, even when extra files or subfolders are present.
  * Unlocking now handles missing lock directories more gracefully.
  * Reduced the chance of stale lock data blocking future access to the same location.

* **Tests**
  * Added coverage for unlocking and re-locking behavior in lock cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->