### PR TITLE
fix: hide replay action when DAG runs are disabled

### DIFF
--- a/ui/src/features/dags/components/dag-details/NodeStatusTable.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useConfig } from '@/contexts/ConfigContext';
 import { components, NodeStatus } from '../../../../api/v1/schema';
 import NodeStatusTableRow from './NodeStatusTableRow';
 
@@ -43,6 +44,11 @@ function NodeStatusTable({
   onViewLog,
   onNodeStatusUpdated,
 }: Props) {
+  const config = useConfig();
+  const showActionsColumn = Boolean(
+    status?.dagRunId && config.permissions.runDags
+  );
+
   // Don't render if there are no nodes
   if (!nodes || !nodes.length) {
     return null;
@@ -56,28 +62,16 @@ function NodeStatusTable({
           <Table className="w-full">
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[5%] text-center">
-                  No
-                </TableHead>
-                <TableHead className="w-[20%]">
-                  Step Name
-                </TableHead>
-                <TableHead className="w-[15%]">
-                  Execution
-                </TableHead>
-                <TableHead className="w-[15%]">
-                  Last Run
-                </TableHead>
-                <TableHead className="w-[10%] text-center">
-                  Status
-                </TableHead>
+                <TableHead className="w-[5%] text-center">No</TableHead>
+                <TableHead className="w-[20%]">Step Name</TableHead>
+                <TableHead className="w-[15%]">Execution</TableHead>
+                <TableHead className="w-[15%]">Last Run</TableHead>
+                <TableHead className="w-[10%] text-center">Status</TableHead>
                 <TableHead className="w-[35%] min-w-[150px]">
                   Error / Logs
                 </TableHead>
-                {status?.dagRunId && (
-                  <TableHead className="w-[8%] text-center">
-                    Actions
-                  </TableHead>
+                {showActionsColumn && (
+                  <TableHead className="w-[8%] text-center">Actions</TableHead>
                 )}
               </TableRow>
             </TableHeader>

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -16,6 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useConfig } from '@/contexts/ConfigContext';
 import { useRemoteNode } from '@/contexts/RemoteNodeContext';
 import { useClient, useQuery } from '@/hooks/api';
 import { whenEnabled } from '@/hooks/queryUtils';
@@ -152,6 +153,7 @@ function NodeStatusTableRow({
   const { dagRunId, name: dagName } = dagRun;
   const navigate = useNavigate();
   const client = useClient();
+  const config = useConfig();
   const dagContext = useContext(DAGContext);
   const remoteNode = useRemoteNode();
   const { showError } = useErrorModal();
@@ -189,6 +191,11 @@ function NodeStatusTableRow({
     dagRun.rootDAGRunId !== dagRun.dagRunId;
   const shouldFetchLogStepOutput =
     logMessage !== null && hasStdout && !!dagRunId;
+  const showStepActions = Boolean(dagRunId && config.permissions.runDags);
+  const canRetryStep =
+    showStepActions &&
+    node.status !== NodeStatus.Waiting &&
+    node.status !== NodeStatus.Rejected;
 
   const subDAGLogQuery = useQuery(
     '/dag-runs/{name}/{dagRunId}/sub-dag-runs/{subDAGRunId}/steps/{stepName}/log',
@@ -384,6 +391,10 @@ function NodeStatusTableRow({
   };
 
   const handleRetry = async () => {
+    if (!config.permissions.runDags) {
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
@@ -791,25 +802,23 @@ function NodeStatusTableRow({
               )}
             </div>
           </TableCell>
-          {dagRunId && (
+          {showStepActions && (
             <TableCell className="text-center">
               <div className="flex items-center justify-center gap-1">
-                {/* Retry button - hidden for Waiting and Rejected steps */}
-                {node.status !== NodeStatus.Waiting &&
-                  node.status !== NodeStatus.Rejected && (
-                    <Button
-                      size="icon-sm"
-                      variant="secondary"
-                      title="Retry from this step"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setShowDialog(true);
-                      }}
-                      disabled={loading || dagRun.status === Status.Running}
-                    >
-                      <Play className="h-4 w-4 text-success" />
-                    </Button>
-                  )}
+                {canRetryStep && (
+                  <Button
+                    size="icon-sm"
+                    variant="secondary"
+                    title="Retry from this step"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowDialog(true);
+                    }}
+                    disabled={loading || dagRun.status === Status.Running}
+                  >
+                    <Play className="h-4 w-4 text-success" />
+                  </Button>
+                )}
               </div>
               <Dialog open={showDialog} onOpenChange={setShowDialog}>
                 <DialogContent>
@@ -847,7 +856,7 @@ function NodeStatusTableRow({
         {/* Inline log viewer row - spans entire table width */}
         {isLogExpanded && hasLogs && (
           <StyledTableRow className="bg-muted">
-            <TableCell colSpan={dagRunId ? 7 : 6} className="p-3">
+            <TableCell colSpan={showStepActions ? 7 : 6} className="p-3">
               <div className="w-full">
                 {/* Header with tabs and expand button */}
                 <div className="flex items-center justify-between mb-2">
@@ -1216,20 +1225,18 @@ function NodeStatusTableRow({
         </div>
       )}
 
-      {dagRunId && (
+      {showStepActions && (
         <div className="flex justify-end mt-4 gap-2">
-          {/* Retry button - hidden for Waiting and Rejected steps */}
-          {node.status !== NodeStatus.Waiting &&
-            node.status !== NodeStatus.Rejected && (
-              <button
-                className="p-2 rounded-full hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
-                title="Retry from this step"
-                onClick={() => setShowDialog(true)}
-                disabled={loading || dagRun.status === Status.Running}
-              >
-                <Play className="h-6 w-6 text-success" />
-              </button>
-            )}
+          {canRetryStep && (
+            <button
+              className="p-2 rounded-full hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Retry from this step"
+              onClick={() => setShowDialog(true)}
+              disabled={loading || dagRun.status === Status.Running}
+            >
+              <Play className="h-6 w-6 text-success" />
+            </button>
+          )}
           <Dialog open={showDialog} onOpenChange={setShowDialog}>
             <DialogContent>
               <DialogHeader>

--- a/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
@@ -17,12 +17,24 @@ import { useQuery } from '@/hooks/api';
 import { DAGContext } from '../../../contexts/DAGContext';
 import NodeStatusTableRow from '../NodeStatusTableRow';
 
+const configMock = vi.hoisted(() => ({
+  runDags: true,
+}));
+
 vi.mock('@/hooks/api', () => ({
   useClient: () => ({
     PATCH: vi.fn(),
     POST: vi.fn(),
   }),
   useQuery: vi.fn(),
+}));
+
+vi.mock('@/contexts/ConfigContext', () => ({
+  useConfig: () => ({
+    permissions: {
+      runDags: configMock.runDags,
+    },
+  }),
 }));
 
 vi.mock('@/components/ui/error-modal', () => ({
@@ -58,6 +70,7 @@ const stepLogPath = '/dag-runs/{name}/{dagRunId}/steps/{stepName}/log';
 
 describe('NodeStatusTableRow', () => {
   beforeEach(() => {
+    configMock.runDags = true;
     mockedUseQuery.mockImplementation((path, init) => ({
       data:
         path === stepLogPath && init
@@ -186,5 +199,51 @@ describe('NodeStatusTableRow', () => {
       screen.getByLabelText('Log message: Deploying ${ENVIRONMENT}')
     ).toBeInTheDocument();
     expect(screen.queryByText('Loading log output...')).not.toBeInTheDocument();
+  });
+
+  it('hides step retry controls when DAG runs are disabled', () => {
+    configMock.runDags = false;
+
+    const node = {
+      step: {
+        name: 'build',
+      },
+      status: NodeStatus.Success,
+      statusLabel: NodeStatusLabel.succeeded,
+      stdout: '',
+      stderr: '',
+      startedAt: '',
+      finishedAt: '',
+      retryCount: 0,
+      doneCount: 1,
+    } as components['schemas']['Node'];
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={appBarValue}>
+          <DAGContext.Provider
+            value={{
+              refresh: vi.fn(),
+              name: 'example',
+              fileName: 'example.yaml',
+            }}
+          >
+            <table>
+              <tbody>
+                <NodeStatusTableRow
+                  rownum={1}
+                  node={node}
+                  name="example.yaml"
+                  dagRun={dagRun}
+                  view="desktop"
+                />
+              </tbody>
+            </table>
+          </DAGContext.Provider>
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTitle('Retry from this step')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
@@ -23,6 +23,7 @@ import {
 import { useErrorModal } from '@/components/ui/error-modal';
 import { useSimpleToast } from '@/components/ui/simple-toast';
 import { useCanWrite } from '@/contexts/AuthContext';
+import { useConfig } from '@/contexts/ConfigContext';
 import { useUserPreferences } from '@/contexts/UserPreference';
 import { cn } from '@/lib/utils';
 import { RefreshCw, Save, X } from 'lucide-react';
@@ -153,6 +154,7 @@ function DAGSpecReadOnly({
   const client = useClient();
   const navigate = useNavigate();
   const canWrite = useCanWrite();
+  const config = useConfig();
   const { showError } = useErrorModal();
   const { showToast } = useSimpleToast();
   const [sourceSpec, setSourceSpec] = React.useState('');
@@ -219,10 +221,12 @@ function DAGSpecReadOnly({
   const editorSpec = !hasLoadedSpec && data?.spec ? data.spec : editedSpec;
   const hasEdits =
     isEditableRetry && hasLoadedSpec && editorSpec !== sourceSpec;
+  const canRetryEditedSpec = config.permissions.runDags && isEditableRetry;
   const canOpenSourceDAGDiff = hasEdits && !!sourceFileName;
 
   const previewEditedSpec = React.useCallback(async () => {
     if (
+      !canRetryEditedSpec ||
       !hasEdits ||
       !editorSpec.trim() ||
       previewLoading ||
@@ -283,6 +287,7 @@ function DAGSpecReadOnly({
     }
   }, [
     client,
+    canRetryEditedSpec,
     dagName,
     dagRunId,
     editorSpec,
@@ -296,6 +301,7 @@ function DAGSpecReadOnly({
 
   const submitEditedRetry = React.useCallback(async () => {
     if (
+      !canRetryEditedSpec ||
       !retryPreview ||
       retryPreview.errors.length > 0 ||
       !editorSpec.trim() ||
@@ -363,6 +369,7 @@ function DAGSpecReadOnly({
     }
   }, [
     client,
+    canRetryEditedSpec,
     dagName,
     dagRunId,
     editorSpec,
@@ -616,22 +623,24 @@ function DAGSpecReadOnly({
                   {sourceDiffLoading ? 'Loading diff...' : 'Save source DAG'}
                 </Button>
               )}
-              <Button
-                type="button"
-                size="xs"
-                variant="primary"
-                disabled={
-                  !hasEdits ||
-                  previewLoading ||
-                  retrySubmitting ||
-                  sourceSaving ||
-                  !editorSpec.trim()
-                }
-                onClick={() => void previewEditedSpec()}
-              >
-                <RefreshCw className="h-3.5 w-3.5" />
-                {previewLoading ? 'Previewing...' : 'Retry as a new run'}
-              </Button>
+              {canRetryEditedSpec && (
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="primary"
+                  disabled={
+                    !hasEdits ||
+                    previewLoading ||
+                    retrySubmitting ||
+                    sourceSaving ||
+                    !editorSpec.trim()
+                  }
+                  onClick={() => void previewEditedSpec()}
+                >
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  {previewLoading ? 'Previewing...' : 'Retry as a new run'}
+                </Button>
+              )}
             </div>
           ) : undefined
         }

--- a/ui/src/features/dags/components/dag-editor/__tests__/DAGSpecReadOnly.test.tsx
+++ b/ui/src/features/dags/components/dag-editor/__tests__/DAGSpecReadOnly.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   showError: vi.fn(),
   showToast: vi.fn(),
   useQuery: vi.fn(),
+  runDags: true,
 }));
 
 vi.mock('@/hooks/api', () => ({
@@ -36,6 +37,14 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 vi.mock('@/contexts/UserPreference', () => ({
   useUserPreferences: () => ({ preferences: { theme: 'light' } }),
+}));
+
+vi.mock('@/contexts/ConfigContext', () => ({
+  useConfig: () => ({
+    permissions: {
+      runDags: mocks.runDags,
+    },
+  }),
 }));
 
 vi.mock('@/components/ui/error-modal', () => ({
@@ -165,9 +174,29 @@ afterEach(() => {
   mocks.showError.mockReset();
   mocks.showToast.mockReset();
   mocks.useQuery.mockReset();
+  mocks.runDags = true;
 });
 
 describe('DAGSpecReadOnly', () => {
+  it('hides edited retry controls when DAG runs are disabled', async () => {
+    mocks.runDags = false;
+    mocks.useQuery.mockReturnValue({
+      data: { spec: originalSpec },
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderSpec();
+
+    const editor = screen.getByLabelText('DAG spec');
+    await waitFor(() => expect(editor).toHaveValue(originalSpec));
+    fireEvent.change(editor, { target: { value: editedSpec } });
+
+    expect(
+      screen.queryByRole('button', { name: /retry as a new run/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('previews and confirms before creating an edited retry run', async () => {
     mocks.useQuery.mockReturnValue({
       data: { spec: originalSpec },


### PR DESCRIPTION
## Summary
- Hide step-level retry/replay controls in workflow execution status tables when DAG runs are disabled by config.
- Hide edited-spec Retry as a new run controls and guard the preview/submit paths behind the same runDags permission.
- Keep status viewing, log viewing, and source DAG saving behavior unchanged.

Closes #2322

## Testing
- pnpm test src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx src/features/dags/components/dag-editor/__tests__/DAGSpecReadOnly.test.tsx
- pnpm typecheck
- pnpm test
- pnpm build (completed with existing webpack asset size warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide step-level retry/replay controls when DAG runs are disabled by config. Aligns UI and actions with `permissions.runDags` while keeping status, logs, and saving the source DAG unchanged.

- **Bug Fixes**
  - Show Actions column and retry buttons only when a DAG run exists and `permissions.runDags` is true.
  - Hide “Retry as a new run” in the read-only editor; block preview/submit when runs are disabled.
  - Adjust log row colSpan for conditional Actions column; add tests to verify hidden controls when disabled.

<sup>Written for commit 72ad8f1db32b7b0f828094283722b7ab510bd5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted retry and action controls to users with run permissions.
  * Hid step and edited-run retry options when retries aren’t allowed.
  * Prevented retry actions from running if permissions are missing.

* **Tests**
  * Updated coverage for permission-based visibility and retry behavior.
  * Added checks that retry controls stay hidden when run permissions are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->