### PR TITLE
fix: limit app stream file watching

### DIFF
--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/config"
+	filedagrun "github.com/dagucloud/dagu/internal/persis/file/dagrun"
 	"github.com/dagucloud/dagu/internal/remotenode"
 	"github.com/dagucloud/dagu/internal/service/scheduler/filenotify"
 	"github.com/fsnotify/fsnotify"
@@ -25,7 +26,7 @@ const (
 	defaultAppStreamBufferSize = 32
 	appStreamDebounceInterval  = 200 * time.Millisecond
 	dagRunStatusPollInterval   = time.Second
-	dagRunStatusFileName       = "status.jsonl"
+	dagRunStatusFileName       = filedagrun.JSONLStatusFile
 )
 
 type AppEventType string
@@ -231,15 +232,25 @@ func (w *directoryWatcher) Start(ctx context.Context) error {
 		return nil
 	}
 
-	paths, err := initialWatchPaths(w.root, w.scope)
-	if err != nil {
+	w.watcher = filenotify.New(time.Second)
+	if err := w.watcher.Add(w.root); err != nil {
+		_ = w.watcher.Close()
 		return err
 	}
-	w.watcher = filenotify.New(time.Second)
-	for _, path := range paths {
-		if err := w.watcher.Add(path); err != nil {
+	if w.scope == watchScopeOneLevel {
+		paths, err := oneLevelWatchPaths(w.root)
+		if err != nil {
 			_ = w.watcher.Close()
 			return err
+		}
+		for _, path := range paths {
+			if path == w.root {
+				continue
+			}
+			if err := w.watcher.Add(path); err != nil {
+				_ = w.watcher.Close()
+				return err
+			}
 		}
 	}
 
@@ -299,8 +310,8 @@ func (w *directoryWatcher) handleEvent(event fsnotify.Event) {
 }
 
 func (w *directoryWatcher) addCreatedChildDir(path string) error {
-	info, err := os.Stat(path)
-	if err != nil || !info.IsDir() {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return nil
 	}
 	parent := filepath.Clean(filepath.Dir(path))
@@ -442,29 +453,152 @@ func scanDAGRunStatusFiles(root string) (map[string]statusFileSnapshot, error) {
 		return files, nil
 	}
 
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || d.Name() != dagRunStatusFileName {
-			return err
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		files[filepath.ToSlash(relPath)] = statusFileSnapshot{
-			modTime: info.ModTime(),
-			size:    info.Size(),
-		}
-		return nil
-	})
-	if errors.Is(err, os.ErrNotExist) {
-		return files, nil
+	dagDirs, err := readDirIfExists(root)
+	if err != nil {
+		return nil, err
 	}
-	return files, err
+	for _, dagDir := range dagDirs {
+		if !dagDir.IsDir() {
+			continue
+		}
+		dagRunsDir := filepath.Join(root, dagDir.Name(), "dag-runs")
+		if err := scanDAGRunHistoryDir(root, dagRunsDir, files); err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+func scanDAGRunHistoryDir(root, dagRunsDir string, files map[string]statusFileSnapshot) error {
+	years, err := readDirIfExists(dagRunsDir)
+	if err != nil {
+		return err
+	}
+	for _, year := range years {
+		if !year.IsDir() || !isFixedDigitName(year.Name(), 4) {
+			continue
+		}
+		yearDir := filepath.Join(dagRunsDir, year.Name())
+		months, err := readDirIfExists(yearDir)
+		if err != nil {
+			return err
+		}
+		for _, month := range months {
+			if !month.IsDir() || !isFixedDigitName(month.Name(), 2) {
+				continue
+			}
+			monthDir := filepath.Join(yearDir, month.Name())
+			days, err := readDirIfExists(monthDir)
+			if err != nil {
+				return err
+			}
+			for _, day := range days {
+				if !day.IsDir() || !isFixedDigitName(day.Name(), 2) {
+					continue
+				}
+				dayDir := filepath.Join(monthDir, day.Name())
+				if err := scanDAGRunDayDir(root, dayDir, files); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func scanDAGRunDayDir(root, dayDir string, files map[string]statusFileSnapshot) error {
+	runDirs, err := readDirIfExists(dayDir)
+	if err != nil {
+		return err
+	}
+	for _, runDir := range runDirs {
+		if !runDir.IsDir() || !strings.HasPrefix(runDir.Name(), filedagrun.DAGRunDirPrefix) {
+			continue
+		}
+		if err := scanDAGRunAttemptStatuses(root, filepath.Join(dayDir, runDir.Name()), files); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func scanDAGRunAttemptStatuses(root, runDir string, files map[string]statusFileSnapshot) error {
+	entries, err := readDirIfExists(runDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !isAttemptDirName(entry.Name()) {
+			continue
+		}
+		statusPath := filepath.Join(runDir, entry.Name(), dagRunStatusFileName)
+		if err := recordDAGRunStatusFile(root, statusPath, files); err != nil {
+			return err
+		}
+	}
+
+	childrenDir := filepath.Join(runDir, filedagrun.SubDAGRunsDir)
+	children, err := readDirIfExists(childrenDir)
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		if !child.IsDir() || !strings.HasPrefix(child.Name(), filedagrun.SubDAGRunDirPrefix) {
+			continue
+		}
+		childRunDir := filepath.Join(childrenDir, child.Name())
+		if err := scanDAGRunAttemptStatuses(root, childRunDir, files); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recordDAGRunStatusFile(root, path string, files map[string]statusFileSnapshot) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	relPath, err := filepath.Rel(root, path)
+	if err != nil {
+		return err
+	}
+	files[filepath.ToSlash(relPath)] = statusFileSnapshot{
+		modTime: info.ModTime(),
+		size:    info.Size(),
+	}
+	return nil
+}
+
+func readDirIfExists(path string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return entries, err
+}
+
+func isAttemptDirName(name string) bool {
+	return strings.HasPrefix(name, filedagrun.AttemptDirPrefix) ||
+		strings.HasPrefix(name, "."+filedagrun.AttemptDirPrefix)
+}
+
+func isFixedDigitName(name string, size int) bool {
+	if len(name) != size {
+		return false
+	}
+	for i := range len(name) {
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 type AppStreamService struct {
@@ -607,7 +741,7 @@ func (s *AppStreamService) handleSuspendFlagEvent(_, relPath string, op fsnotify
 }
 
 func (s *AppStreamService) handleDAGRunEvent(_, relPath string, op fsnotify.Op) {
-	if filepath.Base(relPath) != "status.jsonl" {
+	if filepath.Base(relPath) != dagRunStatusFileName {
 		return
 	}
 	s.coalescer.Enqueue(AppEvent{

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -285,12 +285,9 @@ func (w *directoryWatcher) handleEvent(event fsnotify.Event) {
 		return
 	}
 
-	if event.Op&fsnotify.Create != 0 {
-		switch w.scope {
-		case watchScopeOneLevel:
-			if err := w.addCreatedChildDir(event.Name); err != nil {
-				w.onReset(fmt.Sprintf("failed to register watcher for %s: %v", event.Name, err))
-			}
+	if event.Op&fsnotify.Create != 0 && w.scope == watchScopeOneLevel {
+		if err := w.addCreatedChildDir(event.Name); err != nil {
+			w.onReset(fmt.Sprintf("failed to register watcher for %s: %v", event.Name, err))
 		}
 	}
 

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -221,22 +221,16 @@ func newWatcher(root string, createRoot bool, scope watchScope, onEvent func(roo
 }
 
 func (w *directoryWatcher) Start(ctx context.Context) error {
-	if w.root == "" {
-		return nil
-	}
-	if w.createRoot {
-		if err := os.MkdirAll(w.root, 0750); err != nil {
-			return err
-		}
-	} else if _, err := os.Stat(w.root); errors.Is(err, os.ErrNotExist) {
-		return nil
+	ready, err := prepareWatchRoot(w.root, w.createRoot)
+	if err != nil || !ready {
+		return err
 	}
 
 	w.watcher = filenotify.New(time.Second)
-	if err := w.watcher.Add(w.root); err != nil {
-		_ = w.watcher.Close()
+	if err := w.addWatch(w.root); err != nil {
 		return err
 	}
+
 	if w.scope == watchScopeOneLevel {
 		paths, err := oneLevelWatchPaths(w.root)
 		if err != nil {
@@ -247,8 +241,7 @@ func (w *directoryWatcher) Start(ctx context.Context) error {
 			if path == w.root {
 				continue
 			}
-			if err := w.watcher.Add(path); err != nil {
-				_ = w.watcher.Close()
+			if err := w.addWatch(path); err != nil {
 				return err
 			}
 		}
@@ -257,6 +250,14 @@ func (w *directoryWatcher) Start(ctx context.Context) error {
 	w.wg.Go(func() {
 		w.loop(ctx)
 	})
+	return nil
+}
+
+func (w *directoryWatcher) addWatch(path string) error {
+	if err := w.watcher.Add(path); err != nil {
+		_ = w.watcher.Close()
+		return err
+	}
 	return nil
 }
 
@@ -321,20 +322,6 @@ func (w *directoryWatcher) addCreatedChildDir(path string) error {
 	return w.watcher.Add(path)
 }
 
-func initialWatchPaths(root string, scope watchScope) ([]string, error) {
-	if root == "" {
-		return nil, nil
-	}
-	switch scope {
-	case watchScopeRootOnly:
-		return []string{root}, nil
-	case watchScopeOneLevel:
-		return oneLevelWatchPaths(root)
-	default:
-		return []string{root}, nil
-	}
-}
-
 func oneLevelWatchPaths(root string) ([]string, error) {
 	paths := []string{root}
 	entries, err := os.ReadDir(root)
@@ -378,15 +365,9 @@ func newDAGRunStatusWatcher(root string, createRoot bool, onEvent func(root, rel
 }
 
 func (w *dagRunStatusWatcher) Start(ctx context.Context) error {
-	if w.root == "" {
-		return nil
-	}
-	if w.createRoot {
-		if err := os.MkdirAll(w.root, 0750); err != nil {
-			return err
-		}
-	} else if _, err := os.Stat(w.root); errors.Is(err, os.ErrNotExist) {
-		return nil
+	ready, err := prepareWatchRoot(w.root, w.createRoot)
+	if err != nil || !ready {
+		return err
 	}
 
 	files, err := scanDAGRunStatusFiles(w.root)
@@ -453,69 +434,53 @@ func scanDAGRunStatusFiles(root string) (map[string]statusFileSnapshot, error) {
 		return files, nil
 	}
 
-	dagDirs, err := readDirIfExists(root)
+	dagDirs, err := childDirs(root, anyDirName)
 	if err != nil {
 		return nil, err
 	}
 	for _, dagDir := range dagDirs {
-		if !dagDir.IsDir() {
-			continue
-		}
-		dagRunsDir := filepath.Join(root, dagDir.Name(), "dag-runs")
-		if err := scanDAGRunHistoryDir(root, dagRunsDir, files); err != nil {
+		dayDirs, err := dagRunDayDirs(filepath.Join(dagDir, "dag-runs"))
+		if err != nil {
 			return nil, err
+		}
+		for _, dayDir := range dayDirs {
+			if err := scanDAGRunDayStatuses(root, dayDir, files); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return files, nil
 }
 
-func scanDAGRunHistoryDir(root, dagRunsDir string, files map[string]statusFileSnapshot) error {
-	years, err := readDirIfExists(dagRunsDir)
+func dagRunDayDirs(dagRunsDir string) ([]string, error) {
+	years, err := childDirs(dagRunsDir, isYearDirName)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, year := range years {
-		if !year.IsDir() || !isFixedDigitName(year.Name(), 4) {
-			continue
-		}
-		yearDir := filepath.Join(dagRunsDir, year.Name())
-		months, err := readDirIfExists(yearDir)
+	var days []string
+	for _, yearDir := range years {
+		months, err := childDirs(yearDir, isTwoDigitName)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		for _, month := range months {
-			if !month.IsDir() || !isFixedDigitName(month.Name(), 2) {
-				continue
-			}
-			monthDir := filepath.Join(yearDir, month.Name())
-			days, err := readDirIfExists(monthDir)
+		for _, monthDir := range months {
+			monthDays, err := childDirs(monthDir, isTwoDigitName)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			for _, day := range days {
-				if !day.IsDir() || !isFixedDigitName(day.Name(), 2) {
-					continue
-				}
-				dayDir := filepath.Join(monthDir, day.Name())
-				if err := scanDAGRunDayDir(root, dayDir, files); err != nil {
-					return err
-				}
-			}
+			days = append(days, monthDays...)
 		}
 	}
-	return nil
+	return days, nil
 }
 
-func scanDAGRunDayDir(root, dayDir string, files map[string]statusFileSnapshot) error {
-	runDirs, err := readDirIfExists(dayDir)
+func scanDAGRunDayStatuses(root, dayDir string, files map[string]statusFileSnapshot) error {
+	runDirs, err := childDirs(dayDir, isDAGRunDirName)
 	if err != nil {
 		return err
 	}
 	for _, runDir := range runDirs {
-		if !runDir.IsDir() || !strings.HasPrefix(runDir.Name(), filedagrun.DAGRunDirPrefix) {
-			continue
-		}
-		if err := scanDAGRunAttemptStatuses(root, filepath.Join(dayDir, runDir.Name()), files); err != nil {
+		if err := scanDAGRunAttemptStatuses(root, runDir, files); err != nil {
 			return err
 		}
 	}
@@ -523,30 +488,22 @@ func scanDAGRunDayDir(root, dayDir string, files map[string]statusFileSnapshot) 
 }
 
 func scanDAGRunAttemptStatuses(root, runDir string, files map[string]statusFileSnapshot) error {
-	entries, err := readDirIfExists(runDir)
+	attemptDirs, err := childDirs(runDir, isAttemptDirName)
 	if err != nil {
 		return err
 	}
-	for _, entry := range entries {
-		if !entry.IsDir() || !isAttemptDirName(entry.Name()) {
-			continue
-		}
-		statusPath := filepath.Join(runDir, entry.Name(), dagRunStatusFileName)
+	for _, attemptDir := range attemptDirs {
+		statusPath := filepath.Join(attemptDir, dagRunStatusFileName)
 		if err := recordDAGRunStatusFile(root, statusPath, files); err != nil {
 			return err
 		}
 	}
 
-	childrenDir := filepath.Join(runDir, filedagrun.SubDAGRunsDir)
-	children, err := readDirIfExists(childrenDir)
+	childRunDirs, err := childDirs(filepath.Join(runDir, filedagrun.SubDAGRunsDir), isSubDAGRunDirName)
 	if err != nil {
 		return err
 	}
-	for _, child := range children {
-		if !child.IsDir() || !strings.HasPrefix(child.Name(), filedagrun.SubDAGRunDirPrefix) {
-			continue
-		}
-		childRunDir := filepath.Join(childrenDir, child.Name())
+	for _, childRunDir := range childRunDirs {
 		if err := scanDAGRunAttemptStatuses(root, childRunDir, files); err != nil {
 			return err
 		}
@@ -584,12 +541,62 @@ func readDirIfExists(path string) ([]os.DirEntry, error) {
 	return entries, err
 }
 
+func childDirs(root string, match func(string) bool) ([]string, error) {
+	entries, err := readDirIfExists(root)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() && match(entry.Name()) {
+			paths = append(paths, filepath.Join(root, entry.Name()))
+		}
+	}
+	return paths, nil
+}
+
+func prepareWatchRoot(root string, createRoot bool) (bool, error) {
+	if root == "" {
+		return false, nil
+	}
+	if createRoot {
+		if err := os.MkdirAll(root, 0750); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if _, err := os.Stat(root); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func anyDirName(string) bool {
+	return true
+}
+
+func isDAGRunDirName(name string) bool {
+	return strings.HasPrefix(name, filedagrun.DAGRunDirPrefix)
+}
+
+func isSubDAGRunDirName(name string) bool {
+	return strings.HasPrefix(name, filedagrun.SubDAGRunDirPrefix)
+}
+
 func isAttemptDirName(name string) bool {
 	return strings.HasPrefix(name, filedagrun.AttemptDirPrefix) ||
 		strings.HasPrefix(name, "."+filedagrun.AttemptDirPrefix)
 }
 
-func isFixedDigitName(name string, size int) bool {
+func isYearDirName(name string) bool {
+	return isDigitName(name, 4)
+}
+
+func isTwoDigitName(name string) bool {
+	return isDigitName(name, 2)
+}
+
+func isDigitName(name string, size int) bool {
 	if len(name) != size {
 		return false
 	}

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -24,6 +24,8 @@ import (
 const (
 	defaultAppStreamBufferSize = 32
 	appStreamDebounceInterval  = 200 * time.Millisecond
+	dagRunStatusPollInterval   = time.Second
+	dagRunStatusFileName       = "status.jsonl"
 )
 
 type AppEventType string
@@ -174,9 +176,10 @@ func (c *appEventCoalescer) flush() {
 	}
 }
 
-type recursiveWatcher struct {
+type directoryWatcher struct {
 	root       string
 	createRoot bool
+	scope      watchScope
 	watcher    filenotify.FileWatcher
 	onEvent    func(root, relPath string, op fsnotify.Op)
 	onReset    func(reason string)
@@ -185,17 +188,38 @@ type recursiveWatcher struct {
 	wg         sync.WaitGroup
 }
 
-func newRecursiveWatcher(root string, createRoot bool, onEvent func(root, relPath string, op fsnotify.Op), onReset func(reason string)) *recursiveWatcher {
-	return &recursiveWatcher{
+type appWatcher interface {
+	Start(context.Context) error
+	Stop()
+}
+
+type watchScope int
+
+const (
+	watchScopeRootOnly watchScope = iota
+	watchScopeOneLevel
+)
+
+func newDirectoryWatcher(root string, createRoot bool, onEvent func(root, relPath string, op fsnotify.Op), onReset func(reason string)) *directoryWatcher {
+	return newWatcher(root, createRoot, watchScopeRootOnly, onEvent, onReset)
+}
+
+func newOneLevelDirectoryWatcher(root string, createRoot bool, onEvent func(root, relPath string, op fsnotify.Op), onReset func(reason string)) *directoryWatcher {
+	return newWatcher(root, createRoot, watchScopeOneLevel, onEvent, onReset)
+}
+
+func newWatcher(root string, createRoot bool, scope watchScope, onEvent func(root, relPath string, op fsnotify.Op), onReset func(reason string)) *directoryWatcher {
+	return &directoryWatcher{
 		root:       root,
 		createRoot: createRoot,
+		scope:      scope,
 		onEvent:    onEvent,
 		onReset:    onReset,
 		done:       make(chan struct{}),
 	}
 }
 
-func (w *recursiveWatcher) Start(ctx context.Context) error {
+func (w *directoryWatcher) Start(ctx context.Context) error {
 	if w.root == "" {
 		return nil
 	}
@@ -207,10 +231,16 @@ func (w *recursiveWatcher) Start(ctx context.Context) error {
 		return nil
 	}
 
-	w.watcher = filenotify.New(time.Second)
-	if err := w.addDirRecursive(w.root); err != nil {
-		_ = w.watcher.Close()
+	paths, err := initialWatchPaths(w.root, w.scope)
+	if err != nil {
 		return err
+	}
+	w.watcher = filenotify.New(time.Second)
+	for _, path := range paths {
+		if err := w.watcher.Add(path); err != nil {
+			_ = w.watcher.Close()
+			return err
+		}
 	}
 
 	w.wg.Go(func() {
@@ -219,7 +249,7 @@ func (w *recursiveWatcher) Start(ctx context.Context) error {
 	return nil
 }
 
-func (w *recursiveWatcher) Stop() {
+func (w *directoryWatcher) Stop() {
 	w.stopOnce.Do(func() {
 		close(w.done)
 		if w.watcher != nil {
@@ -229,7 +259,7 @@ func (w *recursiveWatcher) Stop() {
 	w.wg.Wait()
 }
 
-func (w *recursiveWatcher) loop(ctx context.Context) {
+func (w *directoryWatcher) loop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -250,14 +280,15 @@ func (w *recursiveWatcher) loop(ctx context.Context) {
 	}
 }
 
-func (w *recursiveWatcher) handleEvent(event fsnotify.Event) {
+func (w *directoryWatcher) handleEvent(event fsnotify.Event) {
 	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) == 0 {
 		return
 	}
 
 	if event.Op&fsnotify.Create != 0 {
-		if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-			if err := w.addDirRecursive(event.Name); err != nil {
+		switch w.scope {
+		case watchScopeOneLevel:
+			if err := w.addCreatedChildDir(event.Name); err != nil {
 				w.onReset(fmt.Sprintf("failed to register watcher for %s: %v", event.Name, err))
 			}
 		}
@@ -270,22 +301,179 @@ func (w *recursiveWatcher) handleEvent(event fsnotify.Event) {
 	w.onEvent(w.root, filepath.ToSlash(relPath), event.Op)
 }
 
-func (w *recursiveWatcher) addDirRecursive(root string) error {
-	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+func (w *directoryWatcher) addCreatedChildDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	parent := filepath.Clean(filepath.Dir(path))
+	if parent != filepath.Clean(w.root) {
+		return nil
+	}
+	return w.watcher.Add(path)
+}
+
+func initialWatchPaths(root string, scope watchScope) ([]string, error) {
+	if root == "" {
+		return nil, nil
+	}
+	switch scope {
+	case watchScopeRootOnly:
+		return []string{root}, nil
+	case watchScopeOneLevel:
+		return oneLevelWatchPaths(root)
+	default:
+		return []string{root}, nil
+	}
+}
+
+func oneLevelWatchPaths(root string) ([]string, error) {
+	paths := []string{root}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			paths = append(paths, filepath.Join(root, entry.Name()))
+		}
+	}
+	return paths, nil
+}
+
+type statusFileSnapshot struct {
+	modTime time.Time
+	size    int64
+}
+
+type dagRunStatusWatcher struct {
+	root       string
+	createRoot bool
+	interval   time.Duration
+	onEvent    func(root, relPath string, op fsnotify.Op)
+	onReset    func(reason string)
+	done       chan struct{}
+	stopOnce   sync.Once
+	wg         sync.WaitGroup
+	files      map[string]statusFileSnapshot
+}
+
+func newDAGRunStatusWatcher(root string, createRoot bool, onEvent func(root, relPath string, op fsnotify.Op), onReset func(reason string)) *dagRunStatusWatcher {
+	return &dagRunStatusWatcher{
+		root:       root,
+		createRoot: createRoot,
+		interval:   dagRunStatusPollInterval,
+		onEvent:    onEvent,
+		onReset:    onReset,
+		done:       make(chan struct{}),
+	}
+}
+
+func (w *dagRunStatusWatcher) Start(ctx context.Context) error {
+	if w.root == "" {
+		return nil
+	}
+	if w.createRoot {
+		if err := os.MkdirAll(w.root, 0750); err != nil {
+			return err
+		}
+	} else if _, err := os.Stat(w.root); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	files, err := scanDAGRunStatusFiles(w.root)
+	if err != nil {
+		return err
+	}
+	w.files = files
+	w.wg.Go(func() {
+		w.loop(ctx)
+	})
+	return nil
+}
+
+func (w *dagRunStatusWatcher) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.done)
+	})
+	w.wg.Wait()
+}
+
+func (w *dagRunStatusWatcher) loop(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.done:
+			return
+		case <-ticker.C:
+			w.poll()
+		}
+	}
+}
+
+func (w *dagRunStatusWatcher) poll() {
+	next, err := scanDAGRunStatusFiles(w.root)
+	if err != nil {
+		w.onReset(fmt.Sprintf("failed to scan dag-run status files for %s: %v", w.root, err))
+		return
+	}
+
+	for relPath, nextFile := range next {
+		prevFile, ok := w.files[relPath]
+		switch {
+		case !ok:
+			w.onEvent(w.root, relPath, fsnotify.Create)
+		case prevFile != nextFile:
+			w.onEvent(w.root, relPath, fsnotify.Write)
+		}
+	}
+	for relPath := range w.files {
+		if _, ok := next[relPath]; !ok {
+			w.onEvent(w.root, relPath, fsnotify.Remove)
+		}
+	}
+	w.files = next
+}
+
+func scanDAGRunStatusFiles(root string) (map[string]statusFileSnapshot, error) {
+	files := map[string]statusFileSnapshot{}
+	if root == "" {
+		return files, nil
+	}
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != dagRunStatusFileName {
+			return err
+		}
+
+		info, err := d.Info()
 		if err != nil {
 			return err
 		}
-		if !d.IsDir() {
-			return nil
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
 		}
-		return w.watcher.Add(path)
+		files[filepath.ToSlash(relPath)] = statusFileSnapshot{
+			modTime: info.ModTime(),
+			size:    info.Size(),
+		}
+		return nil
 	})
+	if errors.Is(err, os.ErrNotExist) {
+		return files, nil
+	}
+	return files, err
 }
 
 type AppStreamService struct {
 	hub       *AppHub
 	coalescer *appEventCoalescer
-	watchers  []*recursiveWatcher
+	watchers  []appWatcher
 	nodeName  string
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -323,7 +511,7 @@ func NewAppStreamService(cfg AppStreamConfig) (*AppStreamService, error) {
 		cfg.Paths.AltDAGsDir,
 	)
 	for _, dagRoot := range paths {
-		service.watchers = append(service.watchers, newRecursiveWatcher(
+		service.watchers = append(service.watchers, newDirectoryWatcher(
 			dagRoot,
 			dagRoot == primaryDAGRoot,
 			service.handleDAGFileEvent,
@@ -331,10 +519,10 @@ func NewAppStreamService(cfg AppStreamConfig) (*AppStreamService, error) {
 		))
 	}
 	service.watchers = append(service.watchers,
-		newRecursiveWatcher(cfg.Paths.SuspendFlagsDir, true, service.handleSuspendFlagEvent, service.publishReset),
-		newRecursiveWatcher(cfg.Paths.DAGRunsDir, true, service.handleDAGRunEvent, service.publishReset),
-		newRecursiveWatcher(cfg.Paths.QueueDir, true, service.handleQueueEvent, service.publishReset),
-		newRecursiveWatcher(cfg.Paths.DocsDir, true, service.handleDocEvent, service.publishReset),
+		newDirectoryWatcher(cfg.Paths.SuspendFlagsDir, true, service.handleSuspendFlagEvent, service.publishReset),
+		newDAGRunStatusWatcher(cfg.Paths.DAGRunsDir, true, service.handleDAGRunEvent, service.publishReset),
+		newOneLevelDirectoryWatcher(cfg.Paths.QueueDir, true, service.handleQueueEvent, service.publishReset),
+		newDirectoryWatcher(cfg.Paths.DocsDir, true, service.handleDocEvent, service.publishReset),
 	)
 
 	for _, watcher := range service.watchers {

--- a/internal/service/frontend/sse/app_stream_external_test.go
+++ b/internal/service/frontend/sse/app_stream_external_test.go
@@ -25,13 +25,23 @@ func TestInitialRootWatchPathsDoesNotDescend(t *testing.T) {
 
 func TestDAGRunStatusFilePathsOnlyIncludesStatusJSONL(t *testing.T) {
 	root := t.TempDir()
-	statusFile := filepath.Join(root, "dag", "dag-runs", "2026", "06", "29", "run", "attempt", "status.jsonl")
+	runDir := filepath.Join(root, "dag", "dag-runs", "2026", "06", "29", "dag-run_20260629_010203Z_run")
+	statusFile := filepath.Join(runDir, "attempt_20260629_010203_000Z_attempt", "status.jsonl")
+	childStatusFile := filepath.Join(runDir, "children", "child_child-run", "attempt_20260629_010204_000Z_child", "status.jsonl")
+	noiseStatusFile := filepath.Join(runDir, "work", "status.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(statusFile), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Dir(childStatusFile), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Dir(noiseStatusFile), 0o750))
 	require.NoError(t, os.WriteFile(statusFile, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(childStatusFile, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(noiseStatusFile, []byte("{}\n"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(statusFile), "dag.json"), []byte("{}\n"), 0o600))
 
 	paths, err := sse.DAGRunStatusFilePathsForTest(root)
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"dag/dag-runs/2026/06/29/run/attempt/status.jsonl"}, paths)
+	assert.Equal(t, []string{
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/attempt_20260629_010203_000Z_attempt/status.jsonl",
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/children/child_child-run/attempt_20260629_010204_000Z_child/status.jsonl",
+	}, paths)
 }

--- a/internal/service/frontend/sse/app_stream_external_test.go
+++ b/internal/service/frontend/sse/app_stream_external_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sse_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/service/frontend/sse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialRootWatchPathsDoesNotDescend(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "nested", "child"), 0o750))
+
+	paths, err := sse.InitialRootWatchPathsForTest(root)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{root}, paths)
+}
+
+func TestDAGRunStatusFilePathsOnlyIncludesStatusJSONL(t *testing.T) {
+	root := t.TempDir()
+	statusFile := filepath.Join(root, "dag", "dag-runs", "2026", "06", "29", "run", "attempt", "status.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(statusFile), 0o750))
+	require.NoError(t, os.WriteFile(statusFile, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(statusFile), "dag.json"), []byte("{}\n"), 0o600))
+
+	paths, err := sse.DAGRunStatusFilePathsForTest(root)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dag/dag-runs/2026/06/29/run/attempt/status.jsonl"}, paths)
+}

--- a/internal/service/frontend/sse/app_stream_external_test.go
+++ b/internal/service/frontend/sse/app_stream_external_test.go
@@ -13,16 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitialRootWatchPathsDoesNotDescend(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "nested", "child"), 0o750))
-
-	paths, err := sse.InitialRootWatchPathsForTest(root)
-
-	require.NoError(t, err)
-	assert.Equal(t, []string{root}, paths)
-}
-
 func TestDAGRunStatusFilePathsOnlyIncludesStatusJSONL(t *testing.T) {
 	root := t.TempDir()
 	runDir := filepath.Join(root, "dag", "dag-runs", "2026", "06", "29", "dag-run_20260629_010203Z_run")

--- a/internal/service/frontend/sse/app_stream_test.go
+++ b/internal/service/frontend/sse/app_stream_test.go
@@ -29,8 +29,8 @@ func TestWriteAppEventFrame(t *testing.T) {
 	assert.Contains(t, body, `"reason":"updated"`)
 }
 
-func TestRecursiveWatcherStopIsIdempotent(_ *testing.T) {
-	watcher := &recursiveWatcher{
+func TestDirectoryWatcherStopIsIdempotent(_ *testing.T) {
+	watcher := &directoryWatcher{
 		done: make(chan struct{}),
 	}
 
@@ -42,8 +42,8 @@ func TestRecursiveWatcherStopIsIdempotent(_ *testing.T) {
 func TestAppStreamServiceShutdownIsIdempotent(_ *testing.T) {
 	service := &AppStreamService{
 		cancel: func() {},
-		watchers: []*recursiveWatcher{
-			{done: make(chan struct{})},
+		watchers: []appWatcher{
+			&directoryWatcher{done: make(chan struct{})},
 		},
 	}
 

--- a/internal/service/frontend/sse/app_stream_test.go
+++ b/internal/service/frontend/sse/app_stream_test.go
@@ -29,17 +29,18 @@ func TestWriteAppEventFrame(t *testing.T) {
 	assert.Contains(t, body, `"reason":"updated"`)
 }
 
-func TestDirectoryWatcherStopIsIdempotent(_ *testing.T) {
+func TestDirectoryWatcherStopIsIdempotent(t *testing.T) {
 	watcher := &directoryWatcher{
 		done: make(chan struct{}),
 	}
 
-	// Calling Stop twice asserts the method is idempotent and does not panic.
-	watcher.Stop()
-	watcher.Stop()
+	require.NotPanics(t, func() {
+		watcher.Stop()
+		watcher.Stop()
+	})
 }
 
-func TestAppStreamServiceShutdownIsIdempotent(_ *testing.T) {
+func TestAppStreamServiceShutdownIsIdempotent(t *testing.T) {
 	service := &AppStreamService{
 		cancel: func() {},
 		watchers: []appWatcher{
@@ -47,9 +48,10 @@ func TestAppStreamServiceShutdownIsIdempotent(_ *testing.T) {
 		},
 	}
 
-	// Calling Shutdown twice asserts the method is idempotent and does not panic.
-	service.Shutdown()
-	service.Shutdown()
+	require.NotPanics(t, func() {
+		service.Shutdown()
+		service.Shutdown()
+	})
 }
 
 func TestAppHandlerHandleStreamUnavailable(t *testing.T) {

--- a/internal/service/frontend/sse/export_test.go
+++ b/internal/service/frontend/sse/export_test.go
@@ -5,10 +5,6 @@ package sse
 
 import "sort"
 
-func InitialRootWatchPathsForTest(root string) ([]string, error) {
-	return initialWatchPaths(root, watchScopeRootOnly)
-}
-
 func DAGRunStatusFilePathsForTest(root string) ([]string, error) {
 	files, err := scanDAGRunStatusFiles(root)
 	if err != nil {

--- a/internal/service/frontend/sse/export_test.go
+++ b/internal/service/frontend/sse/export_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sse
+
+import "sort"
+
+func InitialRootWatchPathsForTest(root string) ([]string, error) {
+	return initialWatchPaths(root, watchScopeRootOnly)
+}
+
+func DAGRunStatusFilePathsForTest(root string) ([]string, error) {
+	files, err := scanDAGRunStatusFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(files))
+	for relPath := range files {
+		paths = append(paths, relPath)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}


### PR DESCRIPTION
## Summary
- limit app-stream DAG, docs, and suspend watchers to their configured root directories
- limit queue watching to the queue root and immediate queue directories
- replace recursive DAG-run watching with status.jsonl-only polling for run invalidation

## Testing
- go test ./internal/service/frontend/sse ./internal/service/frontend ./internal/service/frontend/api/v1 -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits app-stream file watching to root-only or one-level scopes and replaces recursive DAG-run monitoring with `status.jsonl` polling to reduce CPU and event noise.

- **Bug Fixes**
  - DAG, docs, and suspend-flag watchers now watch only their configured root directories.
  - Queue watcher covers the queue root and immediate subdirectories and auto-registers new child dirs.
  - DAG-run invalidation polls `status.jsonl` under attempt dirs (including child runs) every second, ignores non-attempt files, and emits create/write/remove events.

- **Refactors**
  - Replaced `recursiveWatcher` with scoped `directoryWatcher` and a unified `appWatcher` interface; added helpers for one-level path discovery and status-file scanning; `Stop()` is idempotent with tests.

<sup>Written for commit 3bf13d5794c2d591e1846fe9739e97a7c4887e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file-change detection for live updates, including more targeted monitoring of project folders and run-status files.
  * Added support for tracking status updates in ongoing runs so changes appear more reliably in streaming views.

* **Bug Fixes**
  * Reduced unnecessary directory scanning and improved handling of newly created folders.
  * Made shutdown behavior for change watchers more reliable and repeatable.

* **Tests**
  * Added coverage for path selection and run-status file detection to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->