### PR TITLE
fix: reject approval while DAG run is active

### DIFF
--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -264,10 +264,23 @@ func (b *SubCmdBuilder) Restart(dag *core.DAG, opts RestartOptions) CmdSpec {
 
 // Retry creates a retry command spec.
 func (b *SubCmdBuilder) Retry(dag *core.DAG, dagRunID string, stepName string) CmdSpec {
+	return b.retry(dag, dagRunID, stepName, exec1.DAGRunRef{})
+}
+
+// RetryWithRootDAGRun creates a retry command spec for a sub DAG-run with an
+// explicit root DAG-run reference.
+func (b *SubCmdBuilder) RetryWithRootDAGRun(dag *core.DAG, dagRunID string, stepName string, root exec1.DAGRunRef) CmdSpec {
+	return b.retry(dag, dagRunID, stepName, root)
+}
+
+func (b *SubCmdBuilder) retry(dag *core.DAG, dagRunID string, stepName string, root exec1.DAGRunRef) CmdSpec {
 	args := []string{"retry", fmt.Sprintf("--run-id=%s", dagRunID), "-q"}
 
 	if stepName != "" {
 		args = append(args, fmt.Sprintf("--step=%s", stepName))
+	}
+	if !root.Zero() {
+		args = append(args, fmt.Sprintf("--root=%s", root.String()))
 	}
 
 	if b.configFile != "" {

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -668,6 +668,14 @@ func TestRetry(t *testing.T) {
 		assert.Contains(t, spec.Args, "--step=step-1")
 	})
 
+	t.Run("RetryWithRootDAGRun", func(t *testing.T) {
+		t.Parallel()
+		root := exec.NewDAGRunRef("root-dag", "root-run-id")
+		spec := builder.RetryWithRootDAGRun(dag, "child-run-id", "", root)
+
+		assert.Contains(t, spec.Args, "--root=root-dag:root-run-id")
+	})
+
 	t.Run("RetryWithAllOptions", func(t *testing.T) {
 		t.Parallel()
 		spec := builder.Retry(dag, "full-retry-id", "step-2")

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1251,6 +1251,12 @@ func (a *API) ApproveDAGRunStep(ctx context.Context, request api.ApproveDAGRunSt
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for dag-run to settle: %w", err)
 	}
+	if dagStatus.Status == core.Running {
+		return &api.ApproveDAGRunStep400JSONResponse{
+			Code:    api.ErrorCodeBadRequest,
+			Message: "dag-run is still running; wait until it enters waiting status before approving a step",
+		}, nil
+	}
 
 	stepIdx := findStepByName(dagStatus.Nodes, request.StepName)
 	if stepIdx < 0 {
@@ -1329,6 +1335,24 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 	dagStatus, err = a.waitForManualStepMutationReady(ctx, attempt, dagStatus)
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for sub DAG-run to settle: %w", err)
+	}
+	if dagStatus.Status == core.Running {
+		return &api.ApproveSubDAGRunStep400JSONResponse{
+			Code:    api.ErrorCodeBadRequest,
+			Message: "sub DAG-run is still running; wait until it enters waiting status before approving a step",
+		}, nil
+	}
+	if mutationRef == rootRef {
+		rootStatus, err := a.dagRunMgr.GetSavedStatus(ctx, rootRef)
+		if err != nil {
+			return nil, fmt.Errorf("error reading root dag-run status: %w", err)
+		}
+		if rootStatus.Status == core.Running {
+			return &api.ApproveSubDAGRunStep400JSONResponse{
+				Code:    api.ErrorCodeBadRequest,
+				Message: "root dag-run is still running; wait until it enters waiting status before approving a sub DAG-run step",
+			}, nil
+		}
 	}
 
 	stepIdx := findStepByName(dagStatus.Nodes, request.StepName)
@@ -3509,6 +3533,9 @@ func (a *API) resumeSubDAGRun(ctx context.Context, rootRef exec.DAGRunRef, subDA
 	}
 
 	retrySpec := a.subCmdBuilder.Retry(prepared, subDAGRunID, "")
+	if !status.Root.Zero() && status.Root.ID != subDAGRunID {
+		retrySpec = a.subCmdBuilder.RetryWithRootDAGRun(prepared, subDAGRunID, "", status.Root)
+	}
 	return launcher.Start(ctx, retrySpec)
 }
 

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1251,10 +1251,10 @@ func (a *API) ApproveDAGRunStep(ctx context.Context, request api.ApproveDAGRunSt
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for dag-run to settle: %w", err)
 	}
-	if dagStatus.Status == core.Running {
+	if dagStatus.Status != core.Waiting {
 		return &api.ApproveDAGRunStep400JSONResponse{
 			Code:    api.ErrorCodeBadRequest,
-			Message: "dag-run is still running; wait until it enters waiting status before approving a step",
+			Message: fmt.Sprintf("dag-run is not waiting for approval (status: %s)", dagStatus.Status),
 		}, nil
 	}
 
@@ -1336,10 +1336,10 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for sub DAG-run to settle: %w", err)
 	}
-	if dagStatus.Status == core.Running {
+	if dagStatus.Status != core.Waiting {
 		return &api.ApproveSubDAGRunStep400JSONResponse{
 			Code:    api.ErrorCodeBadRequest,
-			Message: "sub DAG-run is still running; wait until it enters waiting status before approving a step",
+			Message: fmt.Sprintf("sub DAG-run is not waiting for approval (status: %s)", dagStatus.Status),
 		}, nil
 	}
 	if mutationRef == rootRef {

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -123,6 +123,38 @@ func waitForStoredDAGRunStatus(
 	return status
 }
 
+func waitForStoredSubDAGRunStatus(
+	t *testing.T,
+	server test.Server,
+	root exec.DAGRunRef,
+	subDAGRunID string,
+	timeout time.Duration,
+	predicate func(*exec.DAGRunStatus) bool,
+) *exec.DAGRunStatus {
+	t.Helper()
+
+	store := dagrun.New(
+		server.Config.Paths.DAGRunsDir,
+		dagrun.WithLatestStatusToday(server.Config.Server.LatestStatusToday),
+		dagrun.WithLocation(server.Config.Core.Location),
+	)
+	var status *exec.DAGRunStatus
+	require.Eventually(t, func() bool {
+		attempt, err := store.FindSubAttempt(server.Context, root, subDAGRunID)
+		if err != nil {
+			return false
+		}
+		current, err := attempt.ReadStatus(server.Context)
+		if err != nil || current == nil {
+			return false
+		}
+		status = current
+		return predicate(current)
+	}, dagRunEventuallyTimeout(timeout), 200*time.Millisecond)
+
+	return status
+}
+
 func hasNodeWithStatus(status *exec.DAGRunStatus, stepName string, nodeStatus core.NodeStatus) bool {
 	if status == nil {
 		return false
@@ -135,6 +167,30 @@ func hasNodeWithStatus(status *exec.DAGRunStatus, stepName string, nodeStatus co
 	}
 
 	return false
+}
+
+func findNodeByName(status *exec.DAGRunStatus, stepName string) *exec.Node {
+	if status == nil {
+		return nil
+	}
+	for _, node := range status.Nodes {
+		if node.Step.Name == stepName {
+			return node
+		}
+	}
+	return nil
+}
+
+func requireNodeByName(t *testing.T, status *exec.DAGRunStatus, stepName string) *exec.Node {
+	t.Helper()
+
+	node := findNodeByName(status, stepName)
+	if node != nil {
+		return node
+	}
+
+	require.Failf(t, "node not found", "step %q not found", stepName)
+	return nil
 }
 
 func hasRunProcessIdentity(status *exec.DAGRunStatus) bool {
@@ -683,6 +739,170 @@ steps:
 
 	// Wait for DAG to complete
 	waitForStoredDAGRunStatus(t, server, "approval_test_dag", startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Succeeded
+	})
+}
+
+func TestApproveDAGRunStepRejectsWhileDAGRunIsRunning(t *testing.T) {
+	server := test.SetupServer(t)
+	release := newHoldFile(t)
+
+	dagName := "approval_running_dag"
+	dagSpec := fmt.Sprintf(`type: graph
+steps:
+  - name: wait-step
+    run: "exit 0"
+    approval:
+      prompt: "Please approve"
+  - name: long-step
+    run: |
+%s`, indentCommandBlock(holdUntilFileExistsCommand(release), 6))
+
+	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &dagSpec,
+	}).ExpectStatus(http.StatusCreated).Send(t)
+
+	startResp := server.Client().Post("/api/v1/dags/"+dagName+"/start", api.ExecuteDAGJSONRequestBody{}).
+		ExpectStatus(http.StatusOK).Send(t)
+
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+
+	waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Running &&
+			hasNodeWithStatus(status, "wait-step", core.NodeWaiting) &&
+			hasNodeWithStatus(status, "long-step", core.NodeRunning)
+	})
+
+	resp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/steps/wait-step/approve", dagName, startBody.DagRunId),
+		api.ApproveStepRequest{},
+	).ExpectStatus(http.StatusBadRequest).Send(t)
+
+	var body api.ApproveDAGRunStep400JSONResponse
+	resp.Unmarshal(t, &body)
+	require.Contains(t, body.Message, "dag-run is still running")
+
+	runningStatus := waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Running &&
+			hasNodeWithStatus(status, "wait-step", core.NodeWaiting) &&
+			hasNodeWithStatus(status, "long-step", core.NodeRunning)
+	})
+	waitStep := requireNodeByName(t, runningStatus, "wait-step")
+	require.Empty(t, waitStep.ApprovedAt)
+	require.Empty(t, waitStep.ApprovedBy)
+
+	releaseHoldFile(t, release)
+	waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "wait-step", core.NodeWaiting) &&
+			hasNodeWithStatus(status, "long-step", core.NodeSucceeded)
+	})
+
+	approveResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/steps/wait-step/approve", dagName, startBody.DagRunId),
+		api.ApproveStepRequest{},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var approveBody api.ApproveDAGRunStep200JSONResponse
+	approveResp.Unmarshal(t, &approveBody)
+	require.True(t, approveBody.Resumed)
+
+	waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Succeeded
+	})
+}
+
+func TestApproveSubDAGRunStepRejectsWhileRootDAGRunIsRunning(t *testing.T) {
+	server := test.SetupServer(t)
+	release := newHoldFile(t)
+
+	dagName := "approval_subdag_root_running"
+	dagSpec := fmt.Sprintf(`type: graph
+steps:
+  - name: call-child
+    action: dag.run
+    with:
+      dag: child_dag
+  - name: parent-long
+    run: |
+%s
+
+---
+name: child_dag
+steps:
+  - name: child-wait
+    run: "exit 0"
+    approval:
+      prompt: "Approve child"`, indentCommandBlock(holdUntilFileExistsCommand(release), 6))
+
+	_ = server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &dagSpec,
+	}).ExpectStatus(http.StatusCreated).Send(t)
+
+	startResp := server.Client().Post("/api/v1/dags/"+dagName+"/start", api.ExecuteDAGJSONRequestBody{}).
+		ExpectStatus(http.StatusOK).Send(t)
+
+	var startBody api.ExecuteDAG200JSONResponse
+	startResp.Unmarshal(t, &startBody)
+	require.NotEmpty(t, startBody.DagRunId)
+
+	var subDAGRunID string
+	rootStatus := waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		callChild := findNodeByName(status, "call-child")
+		if callChild == nil || len(callChild.SubRuns) != 1 {
+			return false
+		}
+		subDAGRunID = callChild.SubRuns[0].DAGRunID
+		return status.Status == core.Running &&
+			callChild.Status == core.NodeWaiting &&
+			hasNodeWithStatus(status, "parent-long", core.NodeRunning) &&
+			subDAGRunID != ""
+	})
+	rootRef := exec.NewDAGRunRef(dagName, startBody.DagRunId)
+
+	waitForStoredSubDAGRunStatus(t, server, rootRef, subDAGRunID, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "child-wait", core.NodeWaiting)
+	})
+
+	resp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/sub-dag-runs/%s/steps/child-wait/approve", dagName, startBody.DagRunId, subDAGRunID),
+		api.ApproveStepRequest{},
+	).ExpectStatus(http.StatusBadRequest).Send(t)
+
+	var body api.ApproveSubDAGRunStep400JSONResponse
+	resp.Unmarshal(t, &body)
+	require.Contains(t, body.Message, "root dag-run is still running")
+
+	childStatus := waitForStoredSubDAGRunStatus(t, server, rootRef, subDAGRunID, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "child-wait", core.NodeWaiting)
+	})
+	childWait := requireNodeByName(t, childStatus, "child-wait")
+	require.Empty(t, childWait.ApprovedAt)
+	require.Empty(t, childWait.ApprovedBy)
+
+	releaseHoldFile(t, release)
+	waitForStoredDAGRunStatus(t, server, dagName, rootStatus.DAGRunID, 10*time.Second, func(status *exec.DAGRunStatus) bool {
+		return status.Status == core.Waiting &&
+			hasNodeWithStatus(status, "call-child", core.NodeWaiting) &&
+			hasNodeWithStatus(status, "parent-long", core.NodeSucceeded)
+	})
+
+	approveResp := server.Client().Post(
+		fmt.Sprintf("/api/v1/dag-runs/%s/%s/sub-dag-runs/%s/steps/child-wait/approve", dagName, startBody.DagRunId, subDAGRunID),
+		api.ApproveStepRequest{},
+	).ExpectStatus(http.StatusOK).Send(t)
+
+	var approveBody api.ApproveSubDAGRunStep200JSONResponse
+	approveResp.Unmarshal(t, &approveBody)
+	require.True(t, approveBody.Resumed)
+
+	waitForStoredSubDAGRunStatus(t, server, rootRef, subDAGRunID, 10*time.Second, func(status *exec.DAGRunStatus) bool {
 		return status.Status == core.Succeeded
 	})
 }

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -783,7 +783,7 @@ steps:
 
 	var body api.ApproveDAGRunStep400JSONResponse
 	resp.Unmarshal(t, &body)
-	require.Contains(t, body.Message, "dag-run is still running")
+	require.Contains(t, body.Message, "dag-run is not waiting for approval")
 
 	runningStatus := waitForStoredDAGRunStatus(t, server, dagName, startBody.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
 		return status.Status == core.Running &&

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -6,7 +6,6 @@ package scheduler
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -415,7 +414,7 @@ func TestQueueProcessor_SelectRunnableQueueItemsSkipsOutstandingReservations(t *
 
 func TestQueueProcessor_StaleOutstandingDispatchReservationsExpire(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-stale-select-dag", 1).
-		withProcessor(config.Queues{}, WithLeaseStaleThreshold(50*time.Millisecond)).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(time.Nanosecond)).
 		simulateQueue(1, false)
 
 	f.enqueueRuns(1)
@@ -433,7 +432,6 @@ func TestQueueProcessor_StaleOutstandingDispatchReservationsExpire(t *testing.T)
 		AttemptID:  attempt.ID(),
 		AttemptKey: queueAttemptKey(runRef, attempt, status),
 	}))
-	agePendingDispatchReservationFiles(t, f.distributedDir, 2*time.Second)
 
 	var count int
 	var countErr error
@@ -622,34 +620,6 @@ func (m *mockDispatchTaskStore) HasOutstandingAttempt(ctx context.Context, attem
 		return m.hasOutstandingAttemptFunc(ctx, attemptKey, claimTimeout)
 	}
 	return false, nil
-}
-
-func agePendingDispatchReservationFiles(t *testing.T, distributedDir string, age time.Duration) {
-	t.Helper()
-
-	pendingDir := filepath.Join(distributedDir, "pending")
-	entries, err := os.ReadDir(pendingDir)
-	require.NoError(t, err)
-	require.NotEmpty(t, entries)
-
-	targetTime := time.Now().Add(-age).UTC().UnixMilli()
-	for _, entry := range entries {
-		path := filepath.Join(pendingDir, entry.Name())
-		data, err := os.ReadFile(path)
-		require.NoError(t, err)
-
-		var record map[string]any
-		require.NoError(t, json.Unmarshal(data, &record))
-		if payload, ok := record["data"].(map[string]any); ok {
-			payload["enqueuedAt"] = targetTime
-		} else {
-			record["enqueuedAt"] = targetTime
-		}
-
-		updated, err := json.Marshal(record)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(path, updated, 0o600))
-	}
 }
 
 func TestQueueProcessor_CheckStartupStatusTreatsRunningStatusAsStarted(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject approval requests while the target DAG run is still running
- also block embedded sub-DAG approval while the root DAG run is still running
- pass the root DAG-run reference when resuming embedded sub-DAG approvals

## Testing
- go test ./internal/launcher ./internal/service/frontend/api/v1 -count=1
- go test ./internal/cmd -run 'TestRetry|TestRootDAGRunFlag' -count=1

Refs #2251

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject approval requests unless the target DAG run (or the root run for sub-DAGs) is in Waiting, preventing premature approvals. When resuming sub-DAG approvals, send the root DAG-run reference to keep lineage correct. Refs #2251.

- Bug Fixes
  - Return 400 when approving a DAG or sub-DAG step while the run is not Waiting; also block if the root run is still Running.
  - Add launcher support `RetryWithRootDAGRun` to pass `--root` on retries and use it in `resumeSubDAGRun`.
  - Expand tests for rejection/resume; simplify a scheduler test to avoid mutating dispatch store internals.

<sup>Written for commit db220cd59017185cb55865828ae1b57fa8485d7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resuming sub-DAG runs with the correct root reference when needed.
* **Bug Fixes**
  * Approval requests now return a clear error while a DAG run is still running, instead of proceeding too early.
  * Sub-DAG approvals are also blocked until the parent/root run is ready, helping prevent inconsistent approvals.
* **Tests**
  * Added coverage for approval behavior during concurrent execution and for retrying sub-DAG runs with a root reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->