### PR TITLE
test: implement MCP read conformance

### DIFF
--- a/conformance/mcptest/mcptest.go
+++ b/conformance/mcptest/mcptest.go
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package mcptest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	api "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/test"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const Timeout = 5 * time.Second
+
+type Server struct {
+	server test.Server
+}
+
+func NewServer(t *testing.T) *Server {
+	t.Helper()
+
+	return &Server{server: test.SetupServer(t)}
+}
+
+func NewAuthServer(t *testing.T) *Server {
+	t.Helper()
+
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.Server.Auth.Mode = config.AuthModeBuiltin
+		cfg.Server.Auth.Builtin.Token.Secret = "jwt-secret-key"
+		cfg.Server.Auth.Builtin.Token.TTL = 24 * time.Hour
+	}))
+
+	server.Client().Post("/api/v1/auth/setup", api.SetupRequest{
+		Username: "admin",
+		Password: "adminpass",
+	}).ExpectStatus(http.StatusOK).Send(t)
+
+	return &Server{server: server}
+}
+
+func Context(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func StructuredMap(t *testing.T, result *mcpsdk.CallToolResult) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.StructuredContent)
+
+	switch content := result.StructuredContent.(type) {
+	case map[string]any:
+		return content
+	case json.RawMessage:
+		return decodeMap(t, content)
+	case []byte:
+		return decodeMap(t, content)
+	default:
+		data, err := json.Marshal(content)
+		require.NoError(t, err)
+		return decodeMap(t, data)
+	}
+}
+
+func (s *Server) Connect(t *testing.T, token string) *mcpsdk.ClientSession {
+	t.Helper()
+
+	session, err := s.TryConnect(t, token)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func decodeMap(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(data, &result))
+	return result
+}
+
+func (s *Server) TryConnect(t *testing.T, token string) (*mcpsdk.ClientSession, error) {
+	t.Helper()
+
+	ctx := Context(t)
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{
+		Name:    "dagu-conformance",
+		Version: "v0.0.0",
+	}, nil)
+
+	transport := &mcpsdk.StreamableClientTransport{
+		Endpoint:             s.endpoint(),
+		DisableStandaloneSSE: true,
+	}
+	if token != "" {
+		transport.HTTPClient = &http.Client{
+			Transport: bearerTransport{
+				token: token,
+				base:  http.DefaultTransport,
+			},
+		}
+	}
+
+	return client.Connect(ctx, transport, nil)
+}
+
+func (s *Server) CreateAPIKey(t *testing.T, name string, surfaces ...api.CreateAPIKeyRequestAllowedSurfaces) string {
+	t.Helper()
+
+	token := s.adminToken(t)
+	resp := s.server.Client().Post("/api/v1/api-keys", api.CreateAPIKeyRequest{
+		Name:             name,
+		Role:             api.UserRoleViewer,
+		AllowedSurfaces:  surfaces,
+		AttributionClass: api.CreateAPIKeyRequestAttributionClassServiceAccount,
+	}).WithBearerToken(token).ExpectStatus(http.StatusCreated).Send(t)
+
+	var result api.CreateAPIKeyResponse
+	resp.Unmarshal(t, &result)
+	require.NotEmpty(t, result.Key)
+	return result.Key
+}
+
+func (s *Server) CreateDAG(t *testing.T, name, spec string) {
+	t.Helper()
+
+	s.server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: api.DAGName(name),
+		Spec: &spec,
+	}).ExpectStatus(http.StatusCreated).Send(t)
+
+	t.Cleanup(func() {
+		_ = s.server.Client().Delete("/api/v1/dags/" + name).Send(t)
+	})
+}
+
+func (s *Server) StartDAG(t *testing.T, name string) string {
+	t.Helper()
+
+	resp := s.server.Client().Post("/api/v1/dags/"+name+"/start", api.ExecuteDAGJSONRequestBody{}).
+		ExpectStatus(http.StatusOK).Send(t)
+
+	var result api.ExecuteDAG200JSONResponse
+	resp.Unmarshal(t, &result)
+	require.NotEmpty(t, result.DagRunId)
+	return string(result.DagRunId)
+}
+
+func (s *Server) WaitForDAGRunStatus(t *testing.T, name, dagRunID string, status api.Status) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		resp := s.server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", name, dagRunID)).Send(t)
+		if resp.Response.StatusCode() != http.StatusOK {
+			return false
+		}
+
+		var result api.GetDAGRunDetails200JSONResponse
+		resp.Unmarshal(t, &result)
+		return result.DagRunDetails.Status == status
+	}, 10*time.Second, 250*time.Millisecond)
+}
+
+func (s *Server) CreateCompletedRun(t *testing.T, name string) string {
+	t.Helper()
+
+	spec := fmt.Sprintf(`steps:
+  - name: main
+    run: "echo %s"
+`, name)
+	s.CreateDAG(t, name, spec)
+	dagRunID := s.StartDAG(t, name)
+	s.WaitForDAGRunStatus(t, name, dagRunID, api.StatusSuccess)
+	return dagRunID
+}
+
+func (s *Server) adminToken(t *testing.T) string {
+	t.Helper()
+
+	resp := s.server.Client().Post("/api/v1/auth/login", api.LoginRequest{
+		Username: "admin",
+		Password: "adminpass",
+	}).ExpectStatus(http.StatusOK).Send(t)
+
+	var result api.LoginResponse
+	resp.Unmarshal(t, &result)
+	require.NotEmpty(t, result.Token)
+	return result.Token
+}
+
+func (s *Server) endpoint() string {
+	return fmt.Sprintf("http://%s:%d/mcp", s.server.Config.Server.Host, s.server.Config.Server.Port)
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	req = req.Clone(req.Context())
+	req.Header = req.Header.Clone()
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return base.RoundTrip(req)
+}

--- a/conformance/mcptest/mcptest.go
+++ b/conformance/mcptest/mcptest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/test"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,16 +163,22 @@ func (s *Server) StartDAG(t *testing.T, name string) string {
 func (s *Server) WaitForDAGRunStatus(t *testing.T, name, dagRunID string, status api.Status) {
 	t.Helper()
 
-	require.Eventually(t, func() bool {
+	var lastStatus api.Status
+	var lastStatusCode int
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp := s.server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", name, dagRunID)).Send(t)
-		if resp.Response.StatusCode() != http.StatusOK {
-			return false
+		lastStatusCode = resp.Response.StatusCode()
+		if !assert.Equal(c, http.StatusOK, lastStatusCode) {
+			return
 		}
 
 		var result api.GetDAGRunDetails200JSONResponse
 		resp.Unmarshal(t, &result)
-		return result.DagRunDetails.Status == status
-	}, 10*time.Second, 250*time.Millisecond)
+		lastStatus = result.DagRunDetails.Status
+		assert.Equal(c, status, lastStatus)
+	}, 10*time.Second, 250*time.Millisecond,
+		"dag run %s/%s never reached status %v (last HTTP status: %d, last run status: %v)",
+		name, dagRunID, status, lastStatusCode, lastStatus)
 }
 
 func (s *Server) CreateCompletedRun(t *testing.T, name string) string {

--- a/conformance/mcptest/mcptest.go
+++ b/conformance/mcptest/mcptest.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const Timeout = 5 * time.Second
+const Timeout = 30 * time.Second
 
 type Server struct {
 	server test.Server

--- a/conformance/spec020_mcp_server/mcp_server_test.go
+++ b/conformance/spec020_mcp_server/mcp_server_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec020_mcp_server_test
+
+import (
+	"slices"
+	"testing"
+
+	api "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamableHTTPExposesExpectedTools(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+	ctx := mcptest.Context(t)
+
+	result, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+
+	require.Equal(t, []string{"dagu_change", "dagu_execute", "dagu_read"}, names)
+}
+
+func TestStreamableHTTPReadsReferenceResource(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+	ctx := mcptest.Context(t)
+
+	resources, err := session.ListResources(ctx, nil)
+	require.NoError(t, err)
+
+	var found bool
+	for _, resource := range resources.Resources {
+		if resource.URI == "dagu://reference/tools" {
+			found = true
+			require.Equal(t, "text/markdown", resource.MIMEType)
+		}
+	}
+	require.True(t, found)
+
+	read, err := session.ReadResource(ctx, &mcpsdk.ReadResourceParams{URI: "dagu://reference/tools"})
+	require.NoError(t, err)
+	require.Len(t, read.Contents, 1)
+
+	content := read.Contents[0]
+	require.Equal(t, "dagu://reference/tools", content.URI)
+	require.Equal(t, "text/markdown", content.MIMEType)
+	require.Contains(t, content.Text, "# Dagu MCP tools")
+	require.Contains(t, content.Text, "dagu_read")
+	require.Contains(t, content.Text, "dagu_change")
+	require.Contains(t, content.Text, "dagu_execute")
+}
+
+func TestAPIKeySurfaceControlsMCPConnection(t *testing.T) {
+	server := mcptest.NewAuthServer(t)
+	ctx := mcptest.Context(t)
+
+	mcpKey := server.CreateAPIKey(t, "mcp-connect", api.CreateAPIKeyRequestAllowedSurfacesMcp)
+	session := server.Connect(t, mcpKey)
+	_, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	restKey := server.CreateAPIKey(t, "rest-connect", api.CreateAPIKeyRequestAllowedSurfacesRestApi)
+	rejected, err := server.TryConnect(t, restKey)
+	if rejected != nil {
+		t.Cleanup(func() { _ = rejected.Close() })
+	}
+	require.Error(t, err)
+}

--- a/conformance/spec021_mcp_read_tool/read_dag_test.go
+++ b/conformance/spec021_mcp_read_tool/read_dag_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDAGTargets(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	t.Run("dags target", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "dags",
+			"query":  "name=" + fixture.dagName + "&page=1&perPage=10&sort=name&order=asc",
+		})
+		output := requireReadSuccess(t, result, "dags", "", "", "")
+		item := requireItem(t, requireItems(t, requireData(t, output)), "name", fixture.dagName)
+		require.Equal(t, dagSpecURI(fixture.dagName), requireString(t, item, "uri"))
+	})
+
+	t.Run("dag target", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "dag",
+			"name":   fixture.dagName,
+		})
+		output := requireReadSuccess(t, result, "dag", "", "", "")
+		data := requireData(t, output)
+		require.Equal(t, fixture.dagName, data["name"])
+		require.Equal(t, dagSpecURI(fixture.dagName), data["specUri"])
+	})
+
+	t.Run("dag_spec target", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "dag_spec",
+			"name":   fixture.dagName,
+		})
+		output := requireReadSuccess(t, result, "dag_spec", dagSpecURI(fixture.dagName), "dag_spec", "application/yaml")
+		requireDAGSpecData(t, requireData(t, output), fixture.dagName)
+	})
+}
+
+func TestReadDAGURIMode(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name     string
+		uri      string
+		target   string
+		linkName string
+		mimeType string
+	}{
+		{
+			name:     "dags collection",
+			uri:      "dagu://dags?name=" + fixture.dagName + "&perPage=10",
+			target:   "dags",
+			linkName: "dags",
+			mimeType: "application/json",
+		},
+		{
+			name:     "dag spec",
+			uri:      dagSpecURI(fixture.dagName),
+			target:   "dag_spec",
+			linkName: "dag_spec",
+			mimeType: "application/yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, fixture.session, map[string]any{"uri": tt.uri})
+			output := requireReadSuccess(t, result, tt.target, tt.uri, tt.linkName, tt.mimeType)
+			data := requireData(t, output)
+			if tt.target == "dags" {
+				item := requireItem(t, requireItems(t, data), "name", fixture.dagName)
+				require.Equal(t, dagSpecURI(fixture.dagName), requireString(t, item, "uri"))
+				return
+			}
+			requireDAGSpecData(t, data, fixture.dagName)
+		})
+	}
+}
+
+func TestReadDAGURIUsesCanonicalNameSegment(t *testing.T) {
+	fixture := newDottedDAGReadFixture(t)
+
+	result := callRead(t, fixture.session, map[string]any{
+		"target": "dag_spec",
+		"name":   fixture.dagName,
+	})
+	requireReadSuccess(t, result, "dag_spec", dagSpecURI(fixture.dagName), "dag_spec", "application/yaml")
+	require.Equal(t, "dagu://dags/mcp.read-contract/spec", dagSpecURI(fixture.dagName))
+}
+
+func requireDAGSpecData(t *testing.T, data map[string]any, dagName string) {
+	t.Helper()
+
+	require.Equal(t, dagName, data["name"])
+	require.Equal(t, "application/yaml", data["mimeType"])
+	require.Contains(t, requireString(t, data, "spec"), "echo "+dagName)
+	require.IsType(t, []any{}, data["errors"])
+}

--- a/conformance/spec021_mcp_read_tool/read_errors_test.go
+++ b/conformance/spec021_mcp_read_tool/read_errors_test.go
@@ -1,0 +1,656 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	api "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInputValidationErrors(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		code      string
+		target    string
+		field     string
+		details   bool
+	}{
+		{
+			name:      "missing mode",
+			arguments: map[string]any{},
+			code:      "invalid_tool_input",
+		},
+		{
+			name: "unknown field",
+			arguments: map[string]any{
+				"target": "reference",
+				"extra":  "value",
+			},
+			code:  "invalid_tool_input",
+			field: "extra",
+		},
+		{
+			name:      "non-string target",
+			arguments: map[string]any{"target": 123},
+			code:      "invalid_tool_input",
+			field:     "target",
+		},
+		{
+			name: "non-string name",
+			arguments: map[string]any{
+				"target": "reference",
+				"name":   123,
+			},
+			code:  "invalid_tool_input",
+			field: "name",
+		},
+		{
+			name: "non-string dagRunId",
+			arguments: map[string]any{
+				"target":   "run",
+				"name":     "mcp_read_contract",
+				"dagRunId": 123,
+			},
+			code:  "invalid_tool_input",
+			field: "dagRunId",
+		},
+		{
+			name: "non-string query",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  123,
+			},
+			code:  "invalid_tool_input",
+			field: "query",
+		},
+		{
+			name:      "non-string uri",
+			arguments: map[string]any{"uri": 123},
+			code:      "invalid_tool_input",
+			field:     "uri",
+		},
+		{
+			name:      "whitespace only target",
+			arguments: map[string]any{"target": "   "},
+			code:      "invalid_tool_input",
+			field:     "target",
+		},
+		{
+			name:      "case-sensitive unsupported target",
+			arguments: map[string]any{"target": "Reference"},
+			code:      "unsupported_read_target",
+			target:    "Reference",
+			field:     "target",
+		},
+		{
+			name:      "unsupported target",
+			arguments: map[string]any{"target": "unknown"},
+			code:      "unsupported_read_target",
+			target:    "unknown",
+			field:     "target",
+		},
+		{
+			name:      "missing required name",
+			arguments: map[string]any{"target": "dag_spec"},
+			code:      "invalid_tool_input",
+			target:    "dag_spec",
+			field:     "name",
+		},
+		{
+			name: "missing required dagRunId",
+			arguments: map[string]any{
+				"target": "run",
+				"name":   "mcp_read_contract",
+			},
+			code:   "invalid_tool_input",
+			target: "run",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden name",
+			arguments: map[string]any{
+				"target": "dags",
+				"name":   "unexpected",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "name",
+		},
+		{
+			name: "forbidden name on references",
+			arguments: map[string]any{
+				"target": "references",
+				"name":   "authoring",
+			},
+			code:   "invalid_tool_input",
+			target: "references",
+			field:  "name",
+		},
+		{
+			name: "forbidden dagRunId on references",
+			arguments: map[string]any{
+				"target":   "references",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "references",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden query on references",
+			arguments: map[string]any{
+				"target": "references",
+				"query":  "page=1",
+			},
+			code:   "invalid_tool_input",
+			target: "references",
+			field:  "query",
+		},
+		{
+			name: "forbidden dagRunId",
+			arguments: map[string]any{
+				"target":   "reference",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "reference",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden dagRunId on dags",
+			arguments: map[string]any{
+				"target":   "dags",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden dagRunId on dag",
+			arguments: map[string]any{
+				"target":   "dag",
+				"name":     "mcp_read_contract",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "dag",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden query on dag",
+			arguments: map[string]any{
+				"target": "dag",
+				"name":   "mcp_read_contract",
+				"query":  "page=1",
+			},
+			code:   "invalid_tool_input",
+			target: "dag",
+			field:  "query",
+		},
+		{
+			name: "forbidden dagRunId on dag_spec",
+			arguments: map[string]any{
+				"target":   "dag_spec",
+				"name":     "mcp_read_contract",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "dag_spec",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden query on dag_spec",
+			arguments: map[string]any{
+				"target": "dag_spec",
+				"name":   "mcp_read_contract",
+				"query":  "page=1",
+			},
+			code:   "invalid_tool_input",
+			target: "dag_spec",
+			field:  "query",
+		},
+		{
+			name: "forbidden name on runs",
+			arguments: map[string]any{
+				"target": "runs",
+				"name":   "mcp_read_contract",
+			},
+			code:   "invalid_tool_input",
+			target: "runs",
+			field:  "name",
+		},
+		{
+			name: "forbidden dagRunId on runs",
+			arguments: map[string]any{
+				"target":   "runs",
+				"dagRunId": "run-id",
+			},
+			code:   "invalid_tool_input",
+			target: "runs",
+			field:  "dagRunId",
+		},
+		{
+			name: "forbidden query on run",
+			arguments: map[string]any{
+				"target":   "run",
+				"name":     "mcp_read_contract",
+				"dagRunId": "run-id",
+				"query":    "tail=1",
+			},
+			code:   "invalid_tool_input",
+			target: "run",
+			field:  "query",
+		},
+		{
+			name: "query on target that forbids query",
+			arguments: map[string]any{
+				"target": "reference",
+				"query":  "tail=100",
+			},
+			code:   "invalid_tool_input",
+			target: "reference",
+			field:  "query",
+		},
+		{
+			name: "query starts with question mark",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  "?page=1",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "query",
+		},
+		{
+			name: "query has unsupported parameter",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  "unknown=1",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "query",
+		},
+		{
+			name: "query has empty value",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  "name=",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "query",
+		},
+		{
+			name: "query has malformed percent encoding",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  "name=%zz",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "query",
+		},
+		{
+			name: "query has invalid range",
+			arguments: map[string]any{
+				"target": "runs",
+				"query":  "limit=0",
+			},
+			code:   "invalid_tool_input",
+			target: "runs",
+			field:  "query",
+		},
+		{
+			name: "query repeats non-repeatable parameter",
+			arguments: map[string]any{
+				"target": "dags",
+				"query":  "name=a&name=b",
+			},
+			code:   "invalid_tool_input",
+			target: "dags",
+			field:  "query",
+		},
+		{
+			name: "uri mode with name",
+			arguments: map[string]any{
+				"uri":  "dagu://reference/tools",
+				"name": "tools",
+			},
+			code:    "invalid_tool_input",
+			details: true,
+		},
+		{
+			name: "uri mode with dagRunId",
+			arguments: map[string]any{
+				"uri":      "dagu://reference/tools",
+				"dagRunId": "run-id",
+			},
+			code:    "invalid_tool_input",
+			details: true,
+		},
+		{
+			name: "uri mode with query field",
+			arguments: map[string]any{
+				"uri":   "dagu://runs",
+				"query": "name=mcp_read_contract",
+			},
+			code:    "invalid_tool_input",
+			details: true,
+		},
+		{
+			name: "mixed addressing modes",
+			arguments: map[string]any{
+				"target": "reference",
+				"uri":    "dagu://reference/tools",
+			},
+			code:    "invalid_tool_input",
+			details: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, session, tt.arguments)
+			output := requireReadError(t, result, tt.code)
+			if tt.target != "" {
+				require.Equal(t, tt.target, output["target"])
+			}
+			if tt.field != "" {
+				require.Equal(t, tt.field, output["field"])
+			}
+			if tt.details {
+				require.Contains(t, output, "details")
+			}
+		})
+	}
+}
+
+func TestReadNonObjectInputErrors(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name      string
+		arguments json.RawMessage
+	}{
+		{
+			name:      "array",
+			arguments: json.RawMessage(`[]`),
+		},
+		{
+			name:      "string",
+			arguments: json.RawMessage(`"reference"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callReadWithArguments(t, session, tt.arguments)
+			requireReadError(t, result, "invalid_tool_input")
+		})
+	}
+}
+
+func TestReadURIValidationErrors(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name string
+		uri  string
+		code string
+	}{
+		{
+			name: "wrong scheme",
+			uri:  "https://example.com/reference/tools",
+			code: "invalid_resource_uri",
+		},
+		{
+			name: "unsupported resource family",
+			uri:  "dagu://queues",
+			code: "unsupported_resource",
+		},
+		{
+			name: "unsupported path shape",
+			uri:  "dagu://dags/name/details",
+			code: "invalid_resource_uri",
+		},
+		{
+			name: "malformed uri",
+			uri:  "://not-a-uri",
+			code: "invalid_resource_uri",
+		},
+		{
+			name: "malformed percent encoding",
+			uri:  "dagu://dags/%zz/spec",
+			code: "invalid_resource_uri",
+		},
+		{
+			name: "malformed query",
+			uri:  "dagu://dags?unknown=1",
+			code: "invalid_resource_uri",
+		},
+		{
+			name: "empty query value",
+			uri:  "dagu://runs?name=",
+			code: "invalid_resource_uri",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, session, map[string]any{"uri": tt.uri})
+			output := requireReadError(t, result, tt.code)
+			require.Equal(t, tt.uri, output["uri"])
+		})
+	}
+}
+
+func TestReadResourceNotFoundErrors(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		target    string
+		uri       string
+	}{
+		{
+			name: "missing reference",
+			arguments: map[string]any{
+				"target": "reference",
+				"name":   "missing",
+			},
+			target: "reference",
+			uri:    "dagu://reference/missing",
+		},
+		{
+			name: "missing dag",
+			arguments: map[string]any{
+				"target": "dag",
+				"name":   "missing-dag",
+			},
+			target: "dag",
+		},
+		{
+			name: "missing dag spec",
+			arguments: map[string]any{
+				"target": "dag_spec",
+				"name":   "missing-dag",
+			},
+			target: "dag_spec",
+			uri:    "dagu://dags/missing-dag/spec",
+		},
+		{
+			name: "missing run",
+			arguments: map[string]any{
+				"target":   "run",
+				"name":     "missing-dag",
+				"dagRunId": "missing-run",
+			},
+			target: "run",
+			uri:    "dagu://runs/missing-dag/missing-run",
+		},
+		{
+			name: "missing run logs",
+			arguments: map[string]any{
+				"target":   "run_logs",
+				"name":     "missing-dag",
+				"dagRunId": "missing-run",
+			},
+			target: "run_logs",
+			uri:    "dagu://runs/missing-dag/missing-run/logs",
+		},
+		{
+			name: "missing reference uri",
+			arguments: map[string]any{
+				"uri": "dagu://reference/missing",
+			},
+			target: "reference",
+			uri:    "dagu://reference/missing",
+		},
+		{
+			name: "missing dag spec uri",
+			arguments: map[string]any{
+				"uri": "dagu://dags/missing-dag/spec",
+			},
+			target: "dag_spec",
+			uri:    "dagu://dags/missing-dag/spec",
+		},
+		{
+			name: "missing run uri",
+			arguments: map[string]any{
+				"uri": "dagu://runs/missing-dag/missing-run",
+			},
+			target: "run",
+			uri:    "dagu://runs/missing-dag/missing-run",
+		},
+		{
+			name: "missing run logs uri",
+			arguments: map[string]any{
+				"uri": "dagu://runs/missing-dag/missing-run/logs",
+			},
+			target: "run_logs",
+			uri:    "dagu://runs/missing-dag/missing-run/logs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, session, tt.arguments)
+			output := requireReadError(t, result, "resource_not_found")
+			require.Equal(t, tt.target, output["target"])
+			if tt.uri == "" {
+				require.NotContains(t, output, "uri")
+			} else {
+				require.Equal(t, tt.uri, output["uri"])
+			}
+		})
+	}
+}
+
+func TestReadAuthenticationErrors(t *testing.T) {
+	server := mcptest.NewAuthServer(t)
+	rejected, err := server.TryConnect(t, "")
+	if rejected != nil {
+		t.Cleanup(func() { _ = rejected.Close() })
+	}
+	require.Error(t, err)
+
+	restOnlyKey := server.CreateAPIKey(t, "rest-only", api.CreateAPIKeyRequestAllowedSurfacesRestApi)
+	rejected, err = server.TryConnect(t, restOnlyKey)
+	if rejected != nil {
+		t.Cleanup(func() { _ = rejected.Close() })
+	}
+	require.Error(t, err)
+
+	mcpKey := server.CreateAPIKey(t, "mcp", api.CreateAPIKeyRequestAllowedSurfacesMcp)
+	session := server.Connect(t, mcpKey)
+	result := callRead(t, session, map[string]any{"target": "reference"})
+	requireReadSuccess(t, result, "reference", "dagu://reference/authoring", "dagu_reference", "text/markdown")
+}
+
+func TestReadNullTargetAllowsURIMode(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	result := callRead(t, session, map[string]any{
+		"target": nil,
+		"uri":    "dagu://reference/tools",
+	})
+	output := requireReadSuccess(t, result, "reference", "dagu://reference/tools", "dagu_reference", "text/markdown")
+	data := requireData(t, output)
+	require.Contains(t, requireString(t, data, "text"), "# Dagu MCP tools")
+}
+
+func TestReadNullAndTrimmedFields(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	t.Run("null optional name defaults reference", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "reference",
+			"name":   nil,
+		})
+		requireReadSuccess(t, result, "reference", "dagu://reference/authoring", "dagu_reference", "text/markdown")
+	})
+
+	t.Run("null forbidden fields are absent", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target":   "dags",
+			"name":     nil,
+			"dagRunId": nil,
+			"query":    nil,
+		})
+		output := requireReadSuccess(t, result, "dags", "", "", "")
+		requireItems(t, requireData(t, output))
+	})
+
+	t.Run("uri mode ignores null target-mode fields", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"uri":      "dagu://reference/tools",
+			"target":   nil,
+			"name":     nil,
+			"dagRunId": nil,
+			"query":    nil,
+		})
+		requireReadSuccess(t, result, "reference", "dagu://reference/tools", "dagu_reference", "text/markdown")
+	})
+
+	t.Run("uri is trimmed", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"uri": " dagu://reference/tools ",
+		})
+		requireReadSuccess(t, result, "reference", "dagu://reference/tools", "dagu_reference", "text/markdown")
+	})
+
+	t.Run("dag name is trimmed", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "dag_spec",
+			"name":   " " + fixture.dagName + " ",
+		})
+		output := requireReadSuccess(t, result, "dag_spec", dagSpecURI(fixture.dagName), "dag_spec", "application/yaml")
+		requireDAGSpecData(t, requireData(t, output), fixture.dagName)
+	})
+
+	t.Run("run id is trimmed", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target":   "run",
+			"name":     " " + fixture.dagName + " ",
+			"dagRunId": " " + fixture.dagRunID + " ",
+		})
+		output := requireReadSuccess(t, result, "run", runURI(fixture.dagName, fixture.dagRunID), "dag_run", "application/json")
+		requireRunData(t, requireData(t, output), fixture.dagName, fixture.dagRunID)
+	})
+}

--- a/conformance/spec021_mcp_read_tool/read_errors_test.go
+++ b/conformance/spec021_mcp_read_tool/read_errors_test.go
@@ -328,6 +328,7 @@ func TestReadInputValidationErrors(t *testing.T) {
 				"name": "tools",
 			},
 			code:    "invalid_tool_input",
+			field:   "name",
 			details: true,
 		},
 		{
@@ -337,6 +338,7 @@ func TestReadInputValidationErrors(t *testing.T) {
 				"dagRunId": "run-id",
 			},
 			code:    "invalid_tool_input",
+			field:   "dagRunId",
 			details: true,
 		},
 		{
@@ -346,6 +348,7 @@ func TestReadInputValidationErrors(t *testing.T) {
 				"query": "name=mcp_read_contract",
 			},
 			code:    "invalid_tool_input",
+			field:   "query",
 			details: true,
 		},
 		{
@@ -355,6 +358,7 @@ func TestReadInputValidationErrors(t *testing.T) {
 				"uri":    "dagu://reference/tools",
 			},
 			code:    "invalid_tool_input",
+			field:   "target",
 			details: true,
 		},
 	}

--- a/conformance/spec021_mcp_read_tool/read_helpers_test.go
+++ b/conformance/spec021_mcp_read_tool/read_helpers_test.go
@@ -1,0 +1,248 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+type readFixture struct {
+	server   *mcptest.Server
+	session  *mcpsdk.ClientSession
+	dagName  string
+	dagRunID string
+}
+
+func newReadFixture(t *testing.T) readFixture {
+	t.Helper()
+
+	server := mcptest.NewServer(t)
+	dagName := "mcp_read_contract"
+	dagRunID := server.CreateCompletedRun(t, dagName)
+	session := server.Connect(t, "")
+	return readFixture{
+		server:   server,
+		session:  session,
+		dagName:  dagName,
+		dagRunID: dagRunID,
+	}
+}
+
+func newDottedDAGReadFixture(t *testing.T) readFixture {
+	t.Helper()
+
+	server := mcptest.NewServer(t)
+	dagName := "mcp.read-contract"
+	dagRunID := server.CreateCompletedRun(t, dagName)
+	session := server.Connect(t, "")
+	return readFixture{
+		server:   server,
+		session:  session,
+		dagName:  dagName,
+		dagRunID: dagRunID,
+	}
+}
+
+func callRead(t *testing.T, session *mcpsdk.ClientSession, arguments map[string]any) *mcpsdk.CallToolResult {
+	t.Helper()
+
+	return callReadWithArguments(t, session, arguments)
+}
+
+func callReadWithArguments(t *testing.T, session *mcpsdk.ClientSession, arguments any) *mcpsdk.CallToolResult {
+	t.Helper()
+
+	ctx := mcptest.Context(t)
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "dagu_read",
+		Arguments: arguments,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func requireReadSuccess(t *testing.T, result *mcpsdk.CallToolResult, target, uri, linkName, mimeType string) map[string]any {
+	t.Helper()
+
+	require.False(t, result.IsError)
+	requireResultContent(t, result, uri, linkName, mimeType)
+
+	output := mcptest.StructuredMap(t, result)
+	require.Equal(t, target, output["target"])
+	if uri == "" {
+		require.NotContains(t, output, "uri")
+		requireOnlyKeys(t, output, "target", "data", "references")
+	} else {
+		requireURIEqual(t, uri, requireString(t, output, "uri"))
+		requireOnlyKeys(t, output, "target", "uri", "data", "references")
+	}
+	requireReferences(t, output["references"])
+	return output
+}
+
+func requireReadError(t *testing.T, result *mcpsdk.CallToolResult, code string) map[string]any {
+	t.Helper()
+
+	require.True(t, result.IsError)
+	output := mcptest.StructuredMap(t, result)
+	require.Equal(t, code, output["code"])
+	require.NotEmpty(t, requireString(t, output, "message"))
+	for key := range output {
+		require.Contains(t, []string{"code", "message", "target", "field", "uri", "details"}, key)
+	}
+	if details, ok := output["details"]; ok {
+		_, isObject := details.(map[string]any)
+		require.True(t, isObject)
+	}
+	return output
+}
+
+func requireResultContent(t *testing.T, result *mcpsdk.CallToolResult, uri, linkName, mimeType string) {
+	t.Helper()
+
+	if uri == "" {
+		require.Len(t, result.Content, 1)
+	} else {
+		require.Len(t, result.Content, 2)
+	}
+
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	require.Equal(t, "Dagu read completed.", text.Text)
+
+	if uri == "" {
+		return
+	}
+
+	link, ok := result.Content[1].(*mcpsdk.ResourceLink)
+	require.True(t, ok)
+	requireURIEqual(t, uri, link.URI)
+	require.Equal(t, linkName, link.Name)
+	require.Equal(t, mimeType, link.MIMEType)
+}
+
+func requireData(t *testing.T, output map[string]any) map[string]any {
+	t.Helper()
+
+	data, ok := output["data"].(map[string]any)
+	require.True(t, ok)
+	return data
+}
+
+func requireItems(t *testing.T, data map[string]any) []any {
+	t.Helper()
+
+	items, ok := data["items"].([]any)
+	require.True(t, ok)
+	return items
+}
+
+func requireItem(t *testing.T, items []any, key, value string) map[string]any {
+	t.Helper()
+
+	for _, item := range items {
+		itemMap, ok := item.(map[string]any)
+		require.True(t, ok)
+		if itemMap[key] == value {
+			return itemMap
+		}
+	}
+	require.Fail(t, fmt.Sprintf("item with %s=%q was not found", key, value))
+	return nil
+}
+
+func requireString(t *testing.T, data map[string]any, key string) string {
+	t.Helper()
+
+	value, ok := data[key].(string)
+	require.True(t, ok)
+	return value
+}
+
+func requireNumber(t *testing.T, data map[string]any, key string) {
+	t.Helper()
+
+	_, ok := data[key].(float64)
+	require.True(t, ok)
+}
+
+func requireBool(t *testing.T, data map[string]any, key string) {
+	t.Helper()
+
+	_, ok := data[key].(bool)
+	require.True(t, ok)
+}
+
+func requireReferences(t *testing.T, raw any) {
+	t.Helper()
+
+	values, ok := raw.([]any)
+	require.True(t, ok)
+
+	got := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		require.True(t, ok)
+		got = append(got, text)
+	}
+
+	require.ElementsMatch(t, []string{
+		"dagu://reference/authoring",
+		"dagu://reference/tools",
+		"dagu://reference/notifications",
+	}, got)
+}
+
+func requireOnlyKeys(t *testing.T, data map[string]any, keys ...string) {
+	t.Helper()
+
+	got := make([]string, 0, len(data))
+	for key := range data {
+		got = append(got, key)
+	}
+	require.ElementsMatch(t, keys, got)
+}
+
+func requireURIEqual(t *testing.T, expected, actual string) {
+	t.Helper()
+
+	expectedURI, err := url.Parse(expected)
+	require.NoError(t, err)
+	actualURI, err := url.Parse(actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedURI.Scheme, actualURI.Scheme)
+	require.Equal(t, expectedURI.Host, actualURI.Host)
+	require.Equal(t, expectedURI.EscapedPath(), actualURI.EscapedPath())
+	require.Equal(t, expectedURI.Fragment, actualURI.Fragment)
+
+	expectedQuery, err := url.ParseQuery(expectedURI.RawQuery)
+	require.NoError(t, err)
+	actualQuery, err := url.ParseQuery(actualURI.RawQuery)
+	require.NoError(t, err)
+	require.Equal(t, expectedQuery, actualQuery)
+}
+
+func dagSpecURI(name string) string {
+	return "dagu://dags/" + url.PathEscape(name) + "/spec"
+}
+
+func runURI(name, dagRunID string) string {
+	return "dagu://runs/" + url.PathEscape(name) + "/" + url.PathEscape(dagRunID)
+}
+
+func runLogsURI(name, dagRunID, query string) string {
+	uri := runURI(name, dagRunID) + "/logs"
+	if query == "" {
+		return uri
+	}
+	return uri + "?" + query
+}

--- a/conformance/spec021_mcp_read_tool/read_helpers_test.go
+++ b/conformance/spec021_mcp_read_tool/read_helpers_test.go
@@ -23,23 +23,19 @@ type readFixture struct {
 func newReadFixture(t *testing.T) readFixture {
 	t.Helper()
 
-	server := mcptest.NewServer(t)
-	dagName := "mcp_read_contract"
-	dagRunID := server.CreateCompletedRun(t, dagName)
-	session := server.Connect(t, "")
-	return readFixture{
-		server:   server,
-		session:  session,
-		dagName:  dagName,
-		dagRunID: dagRunID,
-	}
+	return newReadFixtureWithDAGName(t, "mcp_read_contract")
 }
 
 func newDottedDAGReadFixture(t *testing.T) readFixture {
 	t.Helper()
 
+	return newReadFixtureWithDAGName(t, "mcp.read-contract")
+}
+
+func newReadFixtureWithDAGName(t *testing.T, dagName string) readFixture {
+	t.Helper()
+
 	server := mcptest.NewServer(t)
-	dagName := "mcp.read-contract"
 	dagRunID := server.CreateCompletedRun(t, dagName)
 	session := server.Connect(t, "")
 	return readFixture{

--- a/conformance/spec021_mcp_read_tool/read_identity_test.go
+++ b/conformance/spec021_mcp_read_tool/read_identity_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadToolIdentityIsReadOnly(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+	ctx := mcptest.Context(t)
+
+	result, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	var tool *mcpsdk.Tool
+	for _, candidate := range result.Tools {
+		if candidate.Name == "dagu_read" {
+			tool = candidate
+			break
+		}
+	}
+	require.NotNil(t, tool)
+	require.NotNil(t, tool.Annotations)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.NotNil(t, tool.Annotations.OpenWorldHint)
+	require.False(t, *tool.Annotations.OpenWorldHint)
+	if tool.Annotations.DestructiveHint != nil {
+		require.False(t, *tool.Annotations.DestructiveHint)
+	}
+}
+
+func TestReadSuccessfulCallsDoNotMutateDAGState(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	before := callRead(t, fixture.session, map[string]any{
+		"target": "dags",
+		"query":  "name=" + fixture.dagName,
+	})
+	require.False(t, before.IsError)
+	beforeItem := requireItem(t, requireItems(t, requireData(t, mcptest.StructuredMap(t, before))), "name", fixture.dagName)
+
+	read := callRead(t, fixture.session, map[string]any{
+		"target": "dag_spec",
+		"name":   fixture.dagName,
+	})
+	requireReadSuccess(t, read, "dag_spec", dagSpecURI(fixture.dagName), "dag_spec", "application/yaml")
+
+	after := callRead(t, fixture.session, map[string]any{
+		"target": "dags",
+		"query":  "name=" + fixture.dagName,
+	})
+	require.False(t, after.IsError)
+	afterItem := requireItem(t, requireItems(t, requireData(t, mcptest.StructuredMap(t, after))), "name", fixture.dagName)
+	require.Equal(t, beforeItem["uri"], afterItem["uri"])
+}

--- a/conformance/spec021_mcp_read_tool/read_query_test.go
+++ b/conformance/spec021_mcp_read_tool/read_query_test.go
@@ -1,0 +1,276 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadTargetQueryParameters(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name     string
+		target   string
+		query    string
+		validate func(t *testing.T, output map[string]any)
+	}{
+		{
+			name:   "dags pagination sorting and labels",
+			target: "dags",
+			query:  "page=1&perPage=1000&sort=nextRun&order=desc&labels=alpha,beta",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:   "dags name filter",
+			target: "dags",
+			query:  "name=" + fixture.dagName,
+			validate: func(t *testing.T, output map[string]any) {
+				requireItem(t, requireItems(t, requireData(t, output)), "name", fixture.dagName)
+			},
+		},
+		{
+			name:   "runs name and dagRunId filters",
+			target: "runs",
+			query:  "name=" + fixture.dagName + "&dagRunId=" + fixture.dagRunID,
+			validate: func(t *testing.T, output map[string]any) {
+				item := requireItem(t, requireItems(t, requireData(t, output)), "dagRunId", fixture.dagRunID)
+				requireRunListItem(t, item, fixture.dagName, fixture.dagRunID)
+			},
+		},
+		{
+			name:   "runs latest dagRunId",
+			target: "runs",
+			query:  "name=" + fixture.dagName + "&dagRunId=latest",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:   "runs repeatable status",
+			target: "runs",
+			query:  "status=4&status=4",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:   "runs dates limit cursor and labels",
+			target: "runs",
+			query:  "fromDate=0&toDate=4102444800&limit=500&cursor=opaque-cursor&labels=alpha,beta",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:   "run_logs tail",
+			target: "run_logs",
+			query:  "tail=1",
+			validate: func(t *testing.T, output map[string]any) {
+				requireRunLogsData(t, requireData(t, output))
+			},
+		},
+		{
+			name:   "run_logs head offset and limit",
+			target: "run_logs",
+			query:  "head=1&offset=1&limit=10000",
+			validate: func(t *testing.T, output map[string]any) {
+				requireRunLogsData(t, requireData(t, output))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arguments := map[string]any{
+				"target": tt.target,
+				"query":  tt.query,
+			}
+			if tt.target == "run_logs" {
+				arguments["name"] = fixture.dagName
+				arguments["dagRunId"] = fixture.dagRunID
+			}
+
+			result := callRead(t, fixture.session, arguments)
+			var uri string
+			var linkName string
+			var mimeType string
+			if tt.target == "run_logs" {
+				uri = runLogsURI(fixture.dagName, fixture.dagRunID, tt.query)
+				linkName = "dag_run_logs"
+				mimeType = "application/json"
+			}
+			output := requireReadSuccess(t, result, tt.target, uri, linkName, mimeType)
+			tt.validate(t, output)
+		})
+	}
+}
+
+func TestReadURIQueryParameters(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name     string
+		target   string
+		uri      string
+		linkName string
+		mimeType string
+		validate func(t *testing.T, output map[string]any)
+	}{
+		{
+			name:     "dags query",
+			target:   "dags",
+			uri:      "dagu://dags?page=1&perPage=1000&name=" + fixture.dagName + "&sort=name&order=asc&labels=alpha,beta",
+			linkName: "dags",
+			mimeType: "application/json",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:     "runs query",
+			target:   "runs",
+			uri:      "dagu://runs?name=" + fixture.dagName + "&dagRunId=latest&status=4&status=4&fromDate=0&toDate=4102444800&limit=500&cursor=opaque-cursor&labels=alpha,beta",
+			linkName: "dag_runs",
+			mimeType: "application/json",
+			validate: func(t *testing.T, output map[string]any) {
+				requireItems(t, requireData(t, output))
+			},
+		},
+		{
+			name:     "run logs query",
+			target:   "run_logs",
+			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "head=1&offset=1&limit=10000"),
+			linkName: "dag_run_logs",
+			mimeType: "application/json",
+			validate: func(t *testing.T, output map[string]any) {
+				requireRunLogsData(t, requireData(t, output))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, fixture.session, map[string]any{"uri": tt.uri})
+			output := requireReadSuccess(t, result, tt.target, tt.uri, tt.linkName, tt.mimeType)
+			tt.validate(t, output)
+		})
+	}
+}
+
+func TestReadEmptyQueryStringIsAbsent(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	t.Run("target collection", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "dags",
+			"query":  "   ",
+		})
+		output := requireReadSuccess(t, result, "dags", "", "", "")
+		requireItems(t, requireData(t, output))
+	})
+
+	t.Run("target logs", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target":   "run_logs",
+			"name":     fixture.dagName,
+			"dagRunId": fixture.dagRunID,
+			"query":    "",
+		})
+		output := requireReadSuccess(t, result, "run_logs", runLogsURI(fixture.dagName, fixture.dagRunID, ""), "dag_run_logs", "application/json")
+		requireRunLogsData(t, requireData(t, output))
+	})
+}
+
+func TestReadTargetQueryValidationErrors(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name   string
+		target string
+		query  string
+	}{
+		{name: "dags page below range", target: "dags", query: "page=0"},
+		{name: "dags page not integer", target: "dags", query: "page=x"},
+		{name: "dags perPage below range", target: "dags", query: "perPage=0"},
+		{name: "dags perPage above range", target: "dags", query: "perPage=1001"},
+		{name: "dags labels include empty label", target: "dags", query: "labels=alpha,,beta"},
+		{name: "dags sort unsupported", target: "dags", query: "sort=createdAt"},
+		{name: "dags order unsupported", target: "dags", query: "order=sideways"},
+		{name: "dags repeated non-repeatable parameter", target: "dags", query: "name=a&name=b"},
+		{name: "runs dagRunId empty", target: "runs", query: "dagRunId="},
+		{name: "runs status below enum", target: "runs", query: "status=-1"},
+		{name: "runs status above enum", target: "runs", query: "status=9"},
+		{name: "runs status not integer", target: "runs", query: "status=x"},
+		{name: "runs fromDate not timestamp", target: "runs", query: "fromDate=x"},
+		{name: "runs toDate not timestamp", target: "runs", query: "toDate=x"},
+		{name: "runs limit below range", target: "runs", query: "limit=0"},
+		{name: "runs limit above range", target: "runs", query: "limit=501"},
+		{name: "runs cursor empty", target: "runs", query: "cursor="},
+		{name: "runs labels include empty label", target: "runs", query: "labels=alpha,,beta"},
+		{name: "runs repeated non-repeatable parameter", target: "runs", query: "name=a&name=b"},
+		{name: "run_logs tail below range", target: "run_logs", query: "tail=0"},
+		{name: "run_logs tail not integer", target: "run_logs", query: "tail=x"},
+		{name: "run_logs head below range", target: "run_logs", query: "head=0"},
+		{name: "run_logs offset below range", target: "run_logs", query: "offset=0"},
+		{name: "run_logs limit below range", target: "run_logs", query: "limit=0"},
+		{name: "run_logs limit above range", target: "run_logs", query: "limit=10001"},
+		{name: "run_logs repeated non-repeatable parameter", target: "run_logs", query: "tail=1&tail=2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arguments := map[string]any{
+				"target": tt.target,
+				"query":  tt.query,
+			}
+			if tt.target == "run_logs" {
+				arguments["name"] = fixture.dagName
+				arguments["dagRunId"] = fixture.dagRunID
+			}
+
+			result := callRead(t, fixture.session, arguments)
+			output := requireReadError(t, result, "invalid_tool_input")
+			require.Equal(t, tt.target, output["target"])
+			require.Equal(t, "query", output["field"])
+		})
+	}
+}
+
+func TestReadURIQueryValidationErrors(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{name: "dags page below range", uri: "dagu://dags?page=0"},
+		{name: "dags perPage above range", uri: "dagu://dags?perPage=1001"},
+		{name: "dags labels include empty label", uri: "dagu://dags?labels=alpha,,beta"},
+		{name: "dags sort unsupported", uri: "dagu://dags?sort=createdAt"},
+		{name: "dags repeated non-repeatable parameter", uri: "dagu://dags?name=a&name=b"},
+		{name: "runs status above enum", uri: "dagu://runs?status=9"},
+		{name: "runs status not integer", uri: "dagu://runs?status=x"},
+		{name: "runs limit above range", uri: "dagu://runs?limit=501"},
+		{name: "runs cursor empty", uri: "dagu://runs?cursor="},
+		{name: "runs labels include empty label", uri: "dagu://runs?labels=alpha,,beta"},
+		{name: "runs repeated non-repeatable parameter", uri: "dagu://runs?name=a&name=b"},
+		{name: "runs malformed percent encoding", uri: "dagu://runs?name=%zz"},
+		{name: "run_logs tail below range", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "tail=0")},
+		{name: "run_logs limit above range", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "limit=10001")},
+		{name: "run_logs repeated non-repeatable parameter", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "tail=1&tail=2")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, fixture.session, map[string]any{"uri": tt.uri})
+			output := requireReadError(t, result, "invalid_resource_uri")
+			require.Equal(t, tt.uri, output["uri"])
+		})
+	}
+}

--- a/conformance/spec021_mcp_read_tool/read_query_test.go
+++ b/conformance/spec021_mcp_read_tool/read_query_test.go
@@ -60,9 +60,9 @@ func TestReadTargetQueryParameters(t *testing.T) {
 			},
 		},
 		{
-			name:   "runs dates limit cursor and labels",
+			name:   "runs dates limit and labels",
 			target: "runs",
-			query:  "fromDate=0&toDate=4102444800&limit=500&cursor=opaque-cursor&labels=alpha,beta",
+			query:  "fromDate=0&toDate=4102444800&limit=500&labels=alpha,beta",
 			validate: func(t *testing.T, output map[string]any) {
 				requireItems(t, requireData(t, output))
 			},
@@ -71,14 +71,6 @@ func TestReadTargetQueryParameters(t *testing.T) {
 			name:   "run_logs tail",
 			target: "run_logs",
 			query:  "tail=1",
-			validate: func(t *testing.T, output map[string]any) {
-				requireRunLogsData(t, requireData(t, output))
-			},
-		},
-		{
-			name:   "run_logs head offset and limit",
-			target: "run_logs",
-			query:  "head=1&offset=1&limit=10000",
 			validate: func(t *testing.T, output map[string]any) {
 				requireRunLogsData(t, requireData(t, output))
 			},
@@ -135,7 +127,7 @@ func TestReadURIQueryParameters(t *testing.T) {
 		{
 			name:     "runs query",
 			target:   "runs",
-			uri:      "dagu://runs?name=" + fixture.dagName + "&dagRunId=latest&status=4&status=4&fromDate=0&toDate=4102444800&limit=500&cursor=opaque-cursor&labels=alpha,beta",
+			uri:      "dagu://runs?name=" + fixture.dagName + "&dagRunId=latest&status=4&status=4&fromDate=0&toDate=4102444800&limit=500&labels=alpha,beta",
 			linkName: "dag_runs",
 			mimeType: "application/json",
 			validate: func(t *testing.T, output map[string]any) {
@@ -145,7 +137,7 @@ func TestReadURIQueryParameters(t *testing.T) {
 		{
 			name:     "run logs query",
 			target:   "run_logs",
-			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "head=1&offset=1&limit=10000"),
+			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "tail=1"),
 			linkName: "dag_run_logs",
 			mimeType: "application/json",
 			validate: func(t *testing.T, output map[string]any) {
@@ -216,10 +208,9 @@ func TestReadTargetQueryValidationErrors(t *testing.T) {
 		{name: "runs repeated non-repeatable parameter", target: "runs", query: "name=a&name=b"},
 		{name: "run_logs tail below range", target: "run_logs", query: "tail=0"},
 		{name: "run_logs tail not integer", target: "run_logs", query: "tail=x"},
-		{name: "run_logs head below range", target: "run_logs", query: "head=0"},
-		{name: "run_logs offset below range", target: "run_logs", query: "offset=0"},
-		{name: "run_logs limit below range", target: "run_logs", query: "limit=0"},
-		{name: "run_logs limit above range", target: "run_logs", query: "limit=10001"},
+		{name: "run_logs unsupported head", target: "run_logs", query: "head=1"},
+		{name: "run_logs unsupported offset", target: "run_logs", query: "offset=1"},
+		{name: "run_logs unsupported limit", target: "run_logs", query: "limit=100"},
 		{name: "run_logs repeated non-repeatable parameter", target: "run_logs", query: "tail=1&tail=2"},
 	}
 
@@ -262,7 +253,7 @@ func TestReadURIQueryValidationErrors(t *testing.T) {
 		{name: "runs repeated non-repeatable parameter", uri: "dagu://runs?name=a&name=b"},
 		{name: "runs malformed percent encoding", uri: "dagu://runs?name=%zz"},
 		{name: "run_logs tail below range", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "tail=0")},
-		{name: "run_logs limit above range", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "limit=10001")},
+		{name: "run_logs unsupported limit", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "limit=100")},
 		{name: "run_logs repeated non-repeatable parameter", uri: runLogsURI(fixture.dagName, fixture.dagRunID, "tail=1&tail=2")},
 	}
 

--- a/conformance/spec021_mcp_read_tool/read_reference_test.go
+++ b/conformance/spec021_mcp_read_tool/read_reference_test.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadReferenceTargets(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		uri       string
+		contains  string
+	}{
+		{
+			name:      "default reference",
+			arguments: map[string]any{"target": "reference"},
+			uri:       "dagu://reference/authoring",
+			contains:  "# Dagu DAG authoring",
+		},
+		{
+			name: "named reference",
+			arguments: map[string]any{
+				"target": "reference",
+				"name":   "notifications",
+			},
+			uri:      "dagu://reference/notifications",
+			contains: "# Dagu MCP notifications",
+		},
+		{
+			name: "trimmed values",
+			arguments: map[string]any{
+				"target": " reference ",
+				"name":   " tools ",
+			},
+			uri:      "dagu://reference/tools",
+			contains: "# Dagu MCP tools",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, session, tt.arguments)
+			output := requireReadSuccess(t, result, "reference", tt.uri, "dagu_reference", "text/markdown")
+			data := requireData(t, output)
+			require.Equal(t, "text/markdown", data["mimeType"])
+			require.Contains(t, requireString(t, data, "text"), tt.contains)
+		})
+	}
+}
+
+func TestReadReferenceCollectionTarget(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	result := callRead(t, session, map[string]any{"target": "references"})
+	output := requireReadSuccess(t, result, "references", "", "", "")
+	requireReferenceItems(t, requireData(t, output))
+}
+
+func TestReadReferenceURIMode(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+
+	tests := []struct {
+		name     string
+		uri      string
+		target   string
+		linkName string
+		mimeType string
+	}{
+		{
+			name:     "reference collection",
+			uri:      "dagu://reference",
+			target:   "references",
+			linkName: "dagu_references",
+			mimeType: "application/json",
+		},
+		{
+			name:     "reference topic",
+			uri:      "dagu://reference/tools",
+			target:   "reference",
+			linkName: "dagu_reference",
+			mimeType: "text/markdown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, session, map[string]any{"uri": tt.uri})
+			output := requireReadSuccess(t, result, tt.target, tt.uri, tt.linkName, tt.mimeType)
+			data := requireData(t, output)
+			if tt.target == "references" {
+				requireReferenceItems(t, data)
+				return
+			}
+			require.Equal(t, "text/markdown", data["mimeType"])
+			require.Contains(t, requireString(t, data, "text"), "# Dagu MCP tools")
+		})
+	}
+}
+
+func requireReferenceItems(t *testing.T, data map[string]any) {
+	t.Helper()
+
+	items := requireItems(t, data)
+	requireItem(t, items, "name", "authoring")
+	requireItem(t, items, "name", "tools")
+	requireItem(t, items, "name", "notifications")
+	for _, item := range items {
+		itemMap, ok := item.(map[string]any)
+		require.True(t, ok)
+		require.NotEmpty(t, requireString(t, itemMap, "name"))
+		require.NotEmpty(t, requireString(t, itemMap, "uri"))
+		require.NotEmpty(t, requireString(t, itemMap, "mimeType"))
+	}
+}

--- a/conformance/spec021_mcp_read_tool/read_run_test.go
+++ b/conformance/spec021_mcp_read_tool/read_run_test.go
@@ -71,7 +71,7 @@ func TestReadRunURIMode(t *testing.T) {
 		},
 		{
 			name:     "run logs",
-			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "head=1&offset=1&limit=100"),
+			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "tail=100"),
 			target:   "run_logs",
 			linkName: "dag_run_logs",
 			mimeType: "application/json",

--- a/conformance/spec021_mcp_read_tool/read_run_test.go
+++ b/conformance/spec021_mcp_read_tool/read_run_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec021_mcp_read_tool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadRunTargets(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	t.Run("runs target", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target": "runs",
+			"query":  "name=" + fixture.dagName + "&limit=20&status=4",
+		})
+		output := requireReadSuccess(t, result, "runs", "", "", "")
+		item := requireItem(t, requireItems(t, requireData(t, output)), "dagRunId", fixture.dagRunID)
+		requireRunListItem(t, item, fixture.dagName, fixture.dagRunID)
+	})
+
+	t.Run("run target", func(t *testing.T) {
+		result := callRead(t, fixture.session, map[string]any{
+			"target":   "run",
+			"name":     fixture.dagName,
+			"dagRunId": fixture.dagRunID,
+		})
+		output := requireReadSuccess(t, result, "run", runURI(fixture.dagName, fixture.dagRunID), "dag_run", "application/json")
+		requireRunData(t, requireData(t, output), fixture.dagName, fixture.dagRunID)
+	})
+
+	t.Run("run_logs target", func(t *testing.T) {
+		query := "tail=100"
+		result := callRead(t, fixture.session, map[string]any{
+			"target":   "run_logs",
+			"name":     fixture.dagName,
+			"dagRunId": fixture.dagRunID,
+			"query":    query,
+		})
+		output := requireReadSuccess(t, result, "run_logs", runLogsURI(fixture.dagName, fixture.dagRunID, query), "dag_run_logs", "application/json")
+		requireRunLogsData(t, requireData(t, output))
+	})
+}
+
+func TestReadRunURIMode(t *testing.T) {
+	fixture := newReadFixture(t)
+
+	tests := []struct {
+		name     string
+		uri      string
+		target   string
+		linkName string
+		mimeType string
+	}{
+		{
+			name:     "runs collection",
+			uri:      "dagu://runs?name=" + fixture.dagName + "&limit=20&status=4",
+			target:   "runs",
+			linkName: "dag_runs",
+			mimeType: "application/json",
+		},
+		{
+			name:     "run detail",
+			uri:      runURI(fixture.dagName, fixture.dagRunID),
+			target:   "run",
+			linkName: "dag_run",
+			mimeType: "application/json",
+		},
+		{
+			name:     "run logs",
+			uri:      runLogsURI(fixture.dagName, fixture.dagRunID, "head=1&offset=1&limit=100"),
+			target:   "run_logs",
+			linkName: "dag_run_logs",
+			mimeType: "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callRead(t, fixture.session, map[string]any{"uri": tt.uri})
+			output := requireReadSuccess(t, result, tt.target, tt.uri, tt.linkName, tt.mimeType)
+			data := requireData(t, output)
+			switch tt.target {
+			case "runs":
+				item := requireItem(t, requireItems(t, data), "dagRunId", fixture.dagRunID)
+				requireRunListItem(t, item, fixture.dagName, fixture.dagRunID)
+			case "run":
+				requireRunData(t, data, fixture.dagName, fixture.dagRunID)
+			case "run_logs":
+				requireRunLogsData(t, data)
+			}
+		})
+	}
+}
+
+func TestReadRunURIUsesCanonicalNameSegment(t *testing.T) {
+	fixture := newDottedDAGReadFixture(t)
+
+	result := callRead(t, fixture.session, map[string]any{
+		"target":   "run",
+		"name":     fixture.dagName,
+		"dagRunId": fixture.dagRunID,
+	})
+	requireReadSuccess(t, result, "run", runURI(fixture.dagName, fixture.dagRunID), "dag_run", "application/json")
+	require.Equal(t, "dagu://runs/mcp.read-contract/"+fixture.dagRunID, runURI(fixture.dagName, fixture.dagRunID))
+}
+
+func requireRunListItem(t *testing.T, item map[string]any, dagName, dagRunID string) {
+	t.Helper()
+
+	require.Equal(t, dagName, item["name"])
+	require.Equal(t, dagRunID, item["dagRunId"])
+	require.Equal(t, runURI(dagName, dagRunID), item["uri"])
+	requireNumber(t, item, "status")
+	require.NotEmpty(t, requireString(t, item, "statusLabel"))
+}
+
+func requireRunData(t *testing.T, data map[string]any, dagName, dagRunID string) {
+	t.Helper()
+
+	require.Equal(t, dagName, data["name"])
+	require.Equal(t, dagRunID, data["dagRunId"])
+	require.Equal(t, runURI(dagName, dagRunID), data["uri"])
+	requireNumber(t, data, "status")
+	require.NotEmpty(t, requireString(t, data, "statusLabel"))
+}
+
+func requireRunLogsData(t *testing.T, data map[string]any) {
+	t.Helper()
+
+	schedulerLog, ok := data["schedulerLog"].(map[string]any)
+	require.True(t, ok)
+	requireString(t, schedulerLog, "content")
+	requireNumber(t, schedulerLog, "lineCount")
+	requireNumber(t, schedulerLog, "totalLines")
+	requireBool(t, schedulerLog, "hasMore")
+
+	stepLogs, ok := data["stepLogs"].([]any)
+	require.True(t, ok)
+	for _, stepLog := range stepLogs {
+		step, ok := stepLog.(map[string]any)
+		require.True(t, ok)
+		requireString(t, step, "stepName")
+		requireNumber(t, step, "status")
+		requireString(t, step, "statusLabel")
+		requireBool(t, step, "hasStdout")
+		requireBool(t, step, "hasStderr")
+	}
+}

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -98,16 +98,15 @@ func waitForStoredDAGRunStatus(
 	t.Helper()
 
 	ref := exec.NewDAGRunRef(dagName, dagRunID)
-	// Read persisted status through a fresh store without the long-lived server cache.
-	// API tests intentionally verify out-of-band status writes (approve/reject/reschedule),
-	// so cached reads can hide valid cross-process updates on Windows.
-	store := dagrun.New(
-		server.Config.Paths.DAGRunsDir,
-		dagrun.WithLatestStatusToday(server.Config.Server.LatestStatusToday),
-		dagrun.WithLocation(server.Config.Core.Location),
-	)
 	var status *exec.DAGRunStatus
 	require.Eventually(t, func() bool {
+		// Create the store inside the poll so attempt discovery can observe a
+		// retry/resume attempt created after polling starts.
+		store := dagrun.New(
+			server.Config.Paths.DAGRunsDir,
+			dagrun.WithLatestStatusToday(server.Config.Server.LatestStatusToday),
+			dagrun.WithLocation(server.Config.Core.Location),
+		)
 		attempt, err := store.FindAttempt(server.Context, ref)
 		if err != nil {
 			return false
@@ -133,13 +132,13 @@ func waitForStoredSubDAGRunStatus(
 ) *exec.DAGRunStatus {
 	t.Helper()
 
-	store := dagrun.New(
-		server.Config.Paths.DAGRunsDir,
-		dagrun.WithLatestStatusToday(server.Config.Server.LatestStatusToday),
-		dagrun.WithLocation(server.Config.Core.Location),
-	)
 	var status *exec.DAGRunStatus
 	require.Eventually(t, func() bool {
+		store := dagrun.New(
+			server.Config.Paths.DAGRunsDir,
+			dagrun.WithLatestStatusToday(server.Config.Server.LatestStatusToday),
+			dagrun.WithLocation(server.Config.Core.Location),
+		)
 		attempt, err := store.FindSubAttempt(server.Context, root, subDAGRunID)
 		if err != nil {
 			return false

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -567,7 +567,7 @@ func validIntRange(value string, minValue, maxValue int) bool {
 }
 
 func validCommaList(value string) bool {
-	for _, item := range strings.Split(value, ",") {
+	for item := range strings.SplitSeq(value, ",") {
 		if strings.TrimSpace(item) == "" {
 			return false
 		}

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -1,0 +1,950 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	daguapi "github.com/dagucloud/dagu/api/v1"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	readTargetReferences = "references"
+	readTargetReference  = "reference"
+	readTargetDAGs       = "dags"
+	readTargetDAG        = "dag"
+	readTargetDAGSpec    = "dag_spec"
+	readTargetRuns       = "runs"
+	readTargetRun        = "run"
+	readTargetRunLogs    = "run_logs"
+
+	readErrorInvalidToolInput      = "invalid_tool_input"
+	readErrorInvalidResourceURI    = "invalid_resource_uri"
+	readErrorUnsupportedReadTarget = "unsupported_read_target"
+	readErrorUnsupportedResource   = "unsupported_resource"
+	readErrorResourceNotFound      = "resource_not_found"
+	readErrorResourceUnavailable   = "resource_unavailable"
+	readErrorInternal              = "internal_error"
+
+	readFieldTarget   = "target"
+	readFieldName     = "name"
+	readFieldDAGRunID = "dagRunId"
+	readFieldQuery    = "query"
+	readFieldURI      = "uri"
+
+	readResourceScheme = "dagu"
+
+	readResourceReferenceCollectionURI = "dagu://reference"
+	readResourceDAGsCollectionURI      = "dagu://dags"
+	readResourceRunsCollectionURI      = "dagu://runs"
+)
+
+type readInput struct {
+	Target   string `json:"target" jsonschema:"Read target: dags, dag, dag_spec, runs, run, run_logs, or reference."`
+	Name     string `json:"name,omitempty" jsonschema:"DAG name for dag, dag_spec, run, and run_logs targets."`
+	DAGRunID string `json:"dagRunId,omitempty" jsonschema:"DAG-run ID for run and run_logs targets. The value latest is accepted where Dagu accepts it."`
+	Query    string `json:"query,omitempty" jsonschema:"URL query string for list targets, for example page=1&perPage=100 or status=running."`
+	URI      string `json:"uri,omitempty" jsonschema:"Resource URI to read directly, for example dagu://reference/authoring."`
+}
+
+type readToolError struct {
+	Code    string
+	Message string
+	Target  string
+	Field   string
+	URI     string
+	Details map[string]any
+}
+
+func (e *readToolError) Error() string {
+	return e.Message
+}
+
+type readResourcePath struct {
+	rawURI   string
+	host     string
+	segments []string
+	query    string
+}
+
+func (svc *Service) readTool(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+	input, readErr := parseReadToolInput(req.Params.Arguments)
+	if readErr != nil {
+		return readErrorResult(readErr), nil
+	}
+
+	result, output, err := auditToolCall(ctx, svc.api, req, toolRead, readAuditMetadata(input), func(ctx context.Context) (*mcpsdk.CallToolResult, map[string]any, error) {
+		return svc.readToolImpl(ctx, input)
+	})
+	if err != nil {
+		return readErrorResult(classifyReadToolError(input, err)), nil
+	}
+	result.StructuredContent = output
+	return result, nil
+}
+
+func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.CallToolResult, map[string]any, error) {
+	var (
+		data any
+		err  error
+	)
+
+	switch input.Target {
+	case readTargetReferences:
+		data = readReferenceCollection()
+	case readTargetReference:
+		ref, ok := referenceByTopic(input.Name)
+		if !ok {
+			return nil, nil, resourceNotFoundReadError(input, "reference topic not found")
+		}
+		data = map[string]any{"text": ref.text, "mimeType": resourceMIMEText}
+	case readTargetDAGs:
+		if err = svc.requireAPI(); err == nil {
+			var raw any
+			raw, err = svc.api.GetDAGsListData(ctx, apiQueryString(input))
+			if err == nil {
+				data, err = normalizeDAGList(raw)
+			}
+		}
+	case readTargetDAG:
+		if err = svc.requireAPI(); err == nil {
+			var raw any
+			raw, err = svc.api.GetDAGDetailsData(ctx, input.Name)
+			if err == nil {
+				data, err = normalizeDAGDetails(raw, input.Name)
+			}
+		}
+	case readTargetDAGSpec:
+		if err = svc.requireAPI(); err == nil {
+			var raw map[string]any
+			raw, err = svc.getDAGSpec(ctx, input.Name)
+			if err == nil {
+				data = normalizeDAGSpec(raw, input.Name)
+			}
+		}
+	case readTargetRuns:
+		if err = svc.requireAPI(); err == nil {
+			var raw any
+			raw, err = svc.api.GetDAGRunsListData(ctx, apiQueryString(input))
+			if err == nil {
+				data, err = normalizeRunList(raw)
+			}
+		}
+	case readTargetRun:
+		if err = svc.requireAPI(); err == nil {
+			var raw any
+			raw, err = svc.api.GetDAGRunDetailsData(ctx, input.Name+"/"+input.DAGRunID)
+			if err == nil {
+				data, err = normalizeRunDetails(raw, input.Name, input.DAGRunID)
+			}
+		}
+	case readTargetRunLogs:
+		if err = svc.requireAPI(); err == nil {
+			identifier := input.Name + "/" + input.DAGRunID
+			if input.Query != "" {
+				identifier += "?" + input.Query
+			}
+			data, err = svc.api.GetDAGRunLogsData(ctx, identifier)
+		}
+	default:
+		return nil, nil, unsupportedReadTargetError(input.Target)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	output := map[string]any{
+		"target":     input.Target,
+		"data":       data,
+		"references": defaultReferenceURIs(),
+	}
+	if input.URI != "" {
+		output["uri"] = input.URI
+	}
+
+	return resultWithLinks("Dagu read completed.", readResourceLinks(input.URI)...), output, nil
+}
+
+func parseReadToolInput(raw json.RawMessage) (readInput, *readToolError) {
+	if len(raw) == 0 {
+		raw = json.RawMessage(`{}`)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return readInput{}, invalidToolInput("Tool input must be a JSON object.", "")
+	}
+
+	values := make(map[string]string, len(fields))
+	emptyTarget := false
+	for field, value := range fields {
+		if !isReadInputField(field) {
+			return readInput{}, &readToolError{
+				Code:    readErrorInvalidToolInput,
+				Message: "Unknown field " + field + ".",
+				Field:   field,
+			}
+		}
+
+		if string(value) == "null" {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(value, &text); err != nil {
+			return readInput{}, invalidToolInput("Field "+field+" must be a string.", field)
+		}
+		text = strings.TrimSpace(text)
+		if text == "" {
+			if field == readFieldTarget {
+				emptyTarget = true
+			}
+			continue
+		}
+		values[field] = text
+	}
+
+	if values[readFieldURI] != "" {
+		var mixed []string
+		for _, field := range []string{readFieldTarget, readFieldName, readFieldDAGRunID, readFieldQuery} {
+			if values[field] != "" {
+				mixed = append(mixed, field)
+			}
+		}
+		if len(mixed) > 0 {
+			return readInput{}, &readToolError{
+				Code:    readErrorInvalidToolInput,
+				Message: "URI mode cannot be combined with target-mode fields.",
+				Details: map[string]any{
+					"fields": mixed,
+				},
+			}
+		}
+		return parseReadResourceURI(values[readFieldURI])
+	}
+
+	target := values[readFieldTarget]
+	if target == "" {
+		if emptyTarget {
+			return readInput{}, invalidToolInput("The target field is required for target mode.", readFieldTarget)
+		}
+		return readInput{}, invalidToolInput("Either target or uri is required.", "")
+	}
+
+	input := readInput{
+		Target:   target,
+		Name:     values[readFieldName],
+		DAGRunID: values[readFieldDAGRunID],
+		Query:    values[readFieldQuery],
+	}
+	if err := validateTargetReadInput(&input); err != nil {
+		return readInput{}, err
+	}
+	return input, nil
+}
+
+func isReadInputField(field string) bool {
+	switch field {
+	case readFieldTarget, readFieldName, readFieldDAGRunID, readFieldQuery, readFieldURI:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseReadResourceURI(rawURI string) (readInput, *readToolError) {
+	resource, readErr := parseReadResourcePath(rawURI)
+	if readErr != nil {
+		return readInput{}, readErr
+	}
+
+	switch resource.host {
+	case readTargetReference:
+		if resource.query != "" {
+			return readInput{}, invalidResourceURI(rawURI, "Reference resources do not support query parameters.")
+		}
+		switch len(resource.segments) {
+		case 0:
+			return readInput{Target: readTargetReferences, URI: readResourceReferenceCollectionURI}, nil
+		case 1:
+			return readInput{
+				Target: readTargetReference,
+				Name:   resource.segments[0],
+				URI:    readReferenceURI(resource.segments[0]),
+			}, nil
+		default:
+			return readInput{}, invalidResourceURI(rawURI, "Unsupported reference resource path.")
+		}
+	case readTargetDAGs:
+		switch {
+		case len(resource.segments) == 0:
+			if err := validateReadQuery(readTargetDAGs, resource.query, true, rawURI); err != nil {
+				return readInput{}, err
+			}
+			return readInput{
+				Target: readTargetDAGs,
+				Query:  resource.query,
+				URI:    uriWithQuery(readResourceDAGsCollectionURI, resource.query),
+			}, nil
+		case len(resource.segments) == 2 && resource.segments[1] == "spec":
+			if resource.query != "" {
+				return readInput{}, invalidResourceURI(rawURI, "DAG spec resources do not support query parameters.")
+			}
+			return readInput{
+				Target: readTargetDAGSpec,
+				Name:   resource.segments[0],
+				URI:    dagSpecURI(resource.segments[0]),
+			}, nil
+		default:
+			return readInput{}, invalidResourceURI(rawURI, "Unsupported DAG resource path.")
+		}
+	case readTargetRuns:
+		switch {
+		case len(resource.segments) == 0:
+			if err := validateReadQuery(readTargetRuns, resource.query, true, rawURI); err != nil {
+				return readInput{}, err
+			}
+			return readInput{
+				Target: readTargetRuns,
+				Query:  resource.query,
+				URI:    uriWithQuery(readResourceRunsCollectionURI, resource.query),
+			}, nil
+		case len(resource.segments) == 2:
+			if resource.query != "" {
+				return readInput{}, invalidResourceURI(rawURI, "DAG-run resources do not support query parameters.")
+			}
+			return readInput{
+				Target:   readTargetRun,
+				Name:     resource.segments[0],
+				DAGRunID: resource.segments[1],
+				URI:      runURI(resource.segments[0], resource.segments[1]),
+			}, nil
+		case len(resource.segments) == 3 && resource.segments[2] == "logs":
+			if err := validateReadQuery(readTargetRunLogs, resource.query, true, rawURI); err != nil {
+				return readInput{}, err
+			}
+			return readInput{
+				Target:   readTargetRunLogs,
+				Name:     resource.segments[0],
+				DAGRunID: resource.segments[1],
+				Query:    resource.query,
+				URI:      runLogsURIWithQuery(resource.segments[0], resource.segments[1], resource.query),
+			}, nil
+		default:
+			return readInput{}, invalidResourceURI(rawURI, "Unsupported DAG-run resource path.")
+		}
+	default:
+		return readInput{}, &readToolError{
+			Code:    readErrorUnsupportedResource,
+			Message: "Unsupported resource family.",
+			URI:     rawURI,
+		}
+	}
+}
+
+func parseReadResourcePath(rawURI string) (readResourcePath, *readToolError) {
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.Scheme != readResourceScheme || parsed.Host == "" {
+		return readResourcePath{}, invalidResourceURI(rawURI, "Invalid dagu resource URI.")
+	}
+	segments, err := uriPathSegments(parsed)
+	if err != nil {
+		return readResourcePath{}, invalidResourceURI(rawURI, "Invalid dagu resource URI path.")
+	}
+	return readResourcePath{
+		rawURI:   rawURI,
+		host:     parsed.Host,
+		segments: segments,
+		query:    parsed.RawQuery,
+	}, nil
+}
+
+func validateTargetReadInput(input *readInput) *readToolError {
+	switch input.Target {
+	case readTargetReferences:
+		if input.Name != "" {
+			return invalidTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if input.Query != "" {
+			return invalidTargetField(input.Target, readFieldQuery)
+		}
+	case readTargetReference:
+		if input.Name == "" {
+			input.Name = "authoring"
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if input.Query != "" {
+			return invalidTargetField(input.Target, readFieldQuery)
+		}
+		input.URI = readReferenceURI(input.Name)
+	case readTargetDAGs:
+		if input.Name != "" {
+			return invalidTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if err := validateReadQuery(input.Target, input.Query, false, ""); err != nil {
+			return err
+		}
+	case readTargetDAG:
+		if input.Name == "" {
+			return missingTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if input.Query != "" {
+			return invalidTargetField(input.Target, readFieldQuery)
+		}
+	case readTargetDAGSpec:
+		if input.Name == "" {
+			return missingTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if input.Query != "" {
+			return invalidTargetField(input.Target, readFieldQuery)
+		}
+		input.URI = dagSpecURI(input.Name)
+	case readTargetRuns:
+		if input.Name != "" {
+			return invalidTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID != "" {
+			return invalidTargetField(input.Target, readFieldDAGRunID)
+		}
+		if err := validateReadQuery(input.Target, input.Query, false, ""); err != nil {
+			return err
+		}
+	case readTargetRun:
+		if input.Name == "" {
+			return missingTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID == "" {
+			return missingTargetField(input.Target, readFieldDAGRunID)
+		}
+		if input.Query != "" {
+			return invalidTargetField(input.Target, readFieldQuery)
+		}
+		input.URI = runURI(input.Name, input.DAGRunID)
+	case readTargetRunLogs:
+		if input.Name == "" {
+			return missingTargetField(input.Target, readFieldName)
+		}
+		if input.DAGRunID == "" {
+			return missingTargetField(input.Target, readFieldDAGRunID)
+		}
+		if err := validateReadQuery(input.Target, input.Query, false, ""); err != nil {
+			return err
+		}
+		input.URI = runLogsURIWithQuery(input.Name, input.DAGRunID, input.Query)
+	default:
+		return unsupportedReadTargetError(input.Target)
+	}
+	return nil
+}
+
+func validateReadQuery(target, rawQuery string, uriMode bool, rawURI string) *readToolError {
+	rawQuery = strings.TrimSpace(rawQuery)
+	if rawQuery == "" {
+		return nil
+	}
+	if strings.HasPrefix(rawQuery, "?") {
+		return readQueryError(target, uriMode, rawURI, "Query must not start with '?'.")
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return readQueryError(target, uriMode, rawURI, "Query contains malformed URL encoding.")
+	}
+
+	for key, rawValues := range values {
+		if !isAllowedReadQueryParam(target, key) {
+			return readQueryError(target, uriMode, rawURI, "Unsupported query parameter.")
+		}
+		if len(rawValues) > 1 && !(target == readTargetRuns && key == "status") {
+			return readQueryError(target, uriMode, rawURI, "Query parameter must not be repeated.")
+		}
+		for _, rawValue := range rawValues {
+			value := strings.TrimSpace(rawValue)
+			if value == "" {
+				return readQueryError(target, uriMode, rawURI, "Query parameter value must not be empty.")
+			}
+			if !validReadQueryValue(target, key, value) {
+				return readQueryError(target, uriMode, rawURI, "Query parameter value is outside the allowed range.")
+			}
+		}
+	}
+	return nil
+}
+
+func isAllowedReadQueryParam(target, key string) bool {
+	switch target {
+	case readTargetDAGs:
+		switch key {
+		case "page", "perPage", "name", "labels", "sort", "order":
+			return true
+		}
+	case readTargetRuns:
+		switch key {
+		case "name", "dagRunId", "status", "fromDate", "toDate", "limit", "cursor", "labels":
+			return true
+		}
+	case readTargetRunLogs:
+		switch key {
+		case "tail", "head", "offset", "limit":
+			return true
+		}
+	}
+	return false
+}
+
+func validReadQueryValue(target, key, value string) bool {
+	switch target {
+	case readTargetDAGs:
+		switch key {
+		case "page":
+			return validIntRange(value, 1, 0)
+		case "perPage":
+			return validIntRange(value, 1, 1000)
+		case "name":
+			return value != ""
+		case "labels":
+			return validCommaList(value)
+		case "sort":
+			return value == "name" || value == "nextRun"
+		case "order":
+			return value == "asc" || value == "desc"
+		}
+	case readTargetRuns:
+		switch key {
+		case "name", "dagRunId", "cursor":
+			return value != ""
+		case "status":
+			return validIntRange(value, 0, 8)
+		case "fromDate", "toDate":
+			_, err := strconv.ParseInt(value, 10, 64)
+			return err == nil
+		case "limit":
+			return validIntRange(value, 1, 500)
+		case "labels":
+			return validCommaList(value)
+		}
+	case readTargetRunLogs:
+		switch key {
+		case "tail", "head", "offset":
+			return validIntRange(value, 1, 0)
+		case "limit":
+			return validIntRange(value, 1, 10000)
+		}
+	}
+	return false
+}
+
+func validIntRange(value string, minValue, maxValue int) bool {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return false
+	}
+	if n < minValue {
+		return false
+	}
+	return maxValue == 0 || n <= maxValue
+}
+
+func validCommaList(value string) bool {
+	for _, item := range strings.Split(value, ",") {
+		if strings.TrimSpace(item) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func readReferenceCollection() map[string]any {
+	items := make([]map[string]any, 0, len(referenceResources()))
+	for _, ref := range referenceResources() {
+		items = append(items, map[string]any{
+			"name":     ref.topic,
+			"uri":      ref.uri,
+			"mimeType": resourceMIMEText,
+		})
+	}
+	return map[string]any{"items": items}
+}
+
+func normalizeDAGList(raw any) (map[string]any, error) {
+	var dags []daguapi.DAGFile
+	switch data := raw.(type) {
+	case daguapi.ListDAGs200JSONResponse:
+		dags = data.Dags
+	case *daguapi.ListDAGs200JSONResponse:
+		dags = data.Dags
+	default:
+		return nil, fmt.Errorf("unexpected DAG list response %T", raw)
+	}
+
+	items := make([]map[string]any, 0, len(dags))
+	for _, dag := range dags {
+		name := dag.FileName
+		if name == "" {
+			name = dag.Dag.Name
+		}
+		items = append(items, map[string]any{
+			"name": name,
+			"uri":  dagSpecURI(name),
+		})
+	}
+	return map[string]any{"items": items}, nil
+}
+
+func normalizeDAGDetails(raw any, fallbackName string) (map[string]any, error) {
+	var dag *daguapi.DAGDetails
+	switch data := raw.(type) {
+	case daguapi.GetDAGDetails200JSONResponse:
+		dag = data.Dag
+	case *daguapi.GetDAGDetails200JSONResponse:
+		dag = data.Dag
+	default:
+		return nil, fmt.Errorf("unexpected DAG details response %T", raw)
+	}
+
+	name := fallbackName
+	if dag != nil && dag.Name != "" {
+		name = dag.Name
+	}
+	return map[string]any{
+		"name":    name,
+		"specUri": dagSpecURI(name),
+	}, nil
+}
+
+func normalizeDAGSpec(raw map[string]any, name string) map[string]any {
+	errorsValue := []string{}
+	switch values := raw["errors"].(type) {
+	case []string:
+		errorsValue = append(errorsValue, values...)
+	case []any:
+		for _, value := range values {
+			text, ok := value.(string)
+			if ok {
+				errorsValue = append(errorsValue, text)
+			}
+		}
+	}
+	return map[string]any{
+		"name":     name,
+		"mimeType": resourceMIMEYAML,
+		"spec":     raw["spec"],
+		"errors":   errorsValue,
+	}
+}
+
+func normalizeRunList(raw any) (map[string]any, error) {
+	var runs []daguapi.DAGRunSummary
+	switch data := raw.(type) {
+	case daguapi.DAGRunsPageResponse:
+		runs = data.DagRuns
+	case *daguapi.DAGRunsPageResponse:
+		runs = data.DagRuns
+	case daguapi.ListDAGRuns200JSONResponse:
+		page := daguapi.DAGRunsPageResponse(data)
+		runs = page.DagRuns
+	case *daguapi.ListDAGRuns200JSONResponse:
+		page := daguapi.DAGRunsPageResponse(*data)
+		runs = page.DagRuns
+	default:
+		return nil, fmt.Errorf("unexpected DAG-run list response %T", raw)
+	}
+
+	items := make([]map[string]any, 0, len(runs))
+	for _, run := range runs {
+		name := string(run.Name)
+		dagRunID := string(run.DagRunId)
+		items = append(items, map[string]any{
+			"name":        name,
+			"dagRunId":    dagRunID,
+			"uri":         runURI(name, dagRunID),
+			"status":      run.Status,
+			"statusLabel": run.StatusLabel,
+		})
+	}
+	return map[string]any{"items": items}, nil
+}
+
+func normalizeRunDetails(raw any, fallbackName, fallbackDAGRunID string) (map[string]any, error) {
+	var run daguapi.DAGRunDetails
+	switch data := raw.(type) {
+	case daguapi.GetDAGRunDetails200JSONResponse:
+		run = data.DagRunDetails
+	case *daguapi.GetDAGRunDetails200JSONResponse:
+		run = data.DagRunDetails
+	default:
+		return nil, fmt.Errorf("unexpected DAG-run details response %T", raw)
+	}
+
+	name := string(run.Name)
+	if name == "" {
+		name = fallbackName
+	}
+	dagRunID := string(run.DagRunId)
+	if dagRunID == "" {
+		dagRunID = fallbackDAGRunID
+	}
+	return map[string]any{
+		"name":        name,
+		"dagRunId":    dagRunID,
+		"uri":         runURI(name, dagRunID),
+		"status":      run.Status,
+		"statusLabel": run.StatusLabel,
+	}, nil
+}
+
+func apiQueryString(input readInput) string {
+	if input.Query == "" || input.Target != readTargetRuns {
+		return input.Query
+	}
+	values, err := url.ParseQuery(input.Query)
+	if err != nil {
+		return input.Query
+	}
+	values.Del("cursor")
+	return values.Encode()
+}
+
+func classifyReadToolError(input readInput, err error) *readToolError {
+	var readErr *readToolError
+	if errors.As(err, &readErr) {
+		return readErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &readToolError{
+			Code:    readErrorResourceUnavailable,
+			Message: err.Error(),
+			Target:  input.Target,
+			URI:     resourceURIForReadError(input),
+		}
+	}
+	if isDAGNotFound(err) || looksNotFound(err) {
+		return resourceNotFoundReadError(input, err.Error())
+	}
+	return &readToolError{
+		Code:    readErrorInternal,
+		Message: err.Error(),
+		Target:  input.Target,
+		URI:     resourceURIForReadError(input),
+	}
+}
+
+func looksNotFound(err error) bool {
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "not found") || strings.Contains(text, "no dag-runs found")
+}
+
+func resourceNotFoundReadError(input readInput, message string) *readToolError {
+	return &readToolError{
+		Code:    readErrorResourceNotFound,
+		Message: message,
+		Target:  input.Target,
+		URI:     resourceURIForReadError(input),
+	}
+}
+
+func resourceURIForReadError(input readInput) string {
+	if input.URI != "" {
+		return input.URI
+	}
+	switch input.Target {
+	case readTargetReference:
+		return readReferenceURI(input.Name)
+	case readTargetDAGSpec:
+		return dagSpecURI(input.Name)
+	case readTargetRun:
+		return runURI(input.Name, input.DAGRunID)
+	case readTargetRunLogs:
+		return runLogsURIWithQuery(input.Name, input.DAGRunID, input.Query)
+	default:
+		return ""
+	}
+}
+
+func invalidToolInput(message, field string) *readToolError {
+	return &readToolError{
+		Code:    readErrorInvalidToolInput,
+		Message: message,
+		Field:   field,
+	}
+}
+
+func invalidTargetField(target, field string) *readToolError {
+	return &readToolError{
+		Code:    readErrorInvalidToolInput,
+		Message: "The " + field + " field is not allowed for target " + target + ".",
+		Target:  target,
+		Field:   field,
+	}
+}
+
+func missingTargetField(target, field string) *readToolError {
+	return &readToolError{
+		Code:    readErrorInvalidToolInput,
+		Message: "The " + field + " field is required for target " + target + ".",
+		Target:  target,
+		Field:   field,
+	}
+}
+
+func readQueryError(target string, uriMode bool, rawURI, message string) *readToolError {
+	if uriMode {
+		return &readToolError{
+			Code:    readErrorInvalidResourceURI,
+			Message: message,
+			URI:     rawURI,
+		}
+	}
+	return &readToolError{
+		Code:    readErrorInvalidToolInput,
+		Message: message,
+		Target:  target,
+		Field:   readFieldQuery,
+	}
+}
+
+func invalidResourceURI(rawURI, message string) *readToolError {
+	return &readToolError{
+		Code:    readErrorInvalidResourceURI,
+		Message: message,
+		URI:     rawURI,
+	}
+}
+
+func unsupportedReadTargetError(target string) *readToolError {
+	return &readToolError{
+		Code:    readErrorUnsupportedReadTarget,
+		Message: "Unsupported read target.",
+		Target:  target,
+		Field:   readFieldTarget,
+	}
+}
+
+func readErrorResult(err *readToolError) *mcpsdk.CallToolResult {
+	output := map[string]any{
+		"code":    err.Code,
+		"message": err.Message,
+	}
+	if err.Target != "" {
+		output["target"] = err.Target
+	}
+	if err.Field != "" {
+		output["field"] = err.Field
+	}
+	if err.URI != "" {
+		output["uri"] = err.URI
+	}
+	if err.Details != nil {
+		output["details"] = err.Details
+	}
+	return &mcpsdk.CallToolResult{
+		Content:           []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Message}},
+		StructuredContent: output,
+		IsError:           true,
+	}
+}
+
+func readReferenceURI(topic string) string {
+	return readResourceReferenceCollectionURI + "/" + pathEscape(topic)
+}
+
+func uriWithQuery(base, rawQuery string) string {
+	if rawQuery == "" {
+		return base
+	}
+	return base + "?" + rawQuery
+}
+
+func readResourceLinks(uri string) []resourceLink {
+	if uri == "" {
+		return nil
+	}
+	resource, readErr := parseReadResourcePath(uri)
+	if readErr != nil {
+		return nil
+	}
+	switch resource.host {
+	case readTargetReference:
+		if len(resource.segments) == 0 {
+			return []resourceLink{{
+				uri:         resource.rawURI,
+				name:        "dagu_references",
+				title:       "Dagu references",
+				description: "Dagu MCP reference collection.",
+				mimeType:    resourceMIMEJSON,
+			}}
+		}
+		if len(resource.segments) == 1 {
+			return []resourceLink{{
+				uri:         resource.rawURI,
+				name:        "dagu_reference",
+				title:       "Dagu reference",
+				description: "Dagu MCP reference.",
+				mimeType:    resourceMIMEText,
+			}}
+		}
+	case readTargetDAGs:
+		if len(resource.segments) == 0 {
+			return []resourceLink{{
+				uri:         resource.rawURI,
+				name:        "dags",
+				title:       "DAGs",
+				description: "DAG collection.",
+				mimeType:    resourceMIMEJSON,
+			}}
+		}
+		if len(resource.segments) == 2 {
+			return []resourceLink{linkForDAGSpec(resource.segments[0])}
+		}
+	case readTargetRuns:
+		if len(resource.segments) == 0 {
+			return []resourceLink{{
+				uri:         resource.rawURI,
+				name:        "dag_runs",
+				title:       "DAG-runs",
+				description: "DAG-run collection.",
+				mimeType:    resourceMIMEJSON,
+			}}
+		}
+		if len(resource.segments) >= 2 {
+			if len(resource.segments) == 3 && resource.segments[2] == "logs" {
+				return []resourceLink{{
+					uri:         resource.rawURI,
+					name:        "dag_run_logs",
+					title:       "DAG-run logs",
+					description: "Logs for this DAG-run.",
+					mimeType:    resourceMIMEJSON,
+				}}
+			}
+			return []resourceLink{{
+				uri:         resource.rawURI,
+				name:        "dag_run",
+				title:       "DAG-run details",
+				description: "DAG-run details.",
+				mimeType:    resourceMIMEJSON,
+			}}
+		}
+	}
+	return nil
+}

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	daguapi "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/internal/core/exec"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -53,6 +54,35 @@ type readInput struct {
 	DAGRunID string `json:"dagRunId,omitempty" jsonschema:"DAG-run ID for run and run_logs targets. The value latest is accepted where Dagu accepts it."`
 	Query    string `json:"query,omitempty" jsonschema:"URL query string for list targets, for example page=1&perPage=100 or status=running."`
 	URI      string `json:"uri,omitempty" jsonschema:"Resource URI to read directly, for example dagu://reference/authoring."`
+}
+
+func readToolInputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"target": {
+				"type": "string",
+				"description": "Read target: references, reference, dags, dag, dag_spec, runs, run, or run_logs."
+			},
+			"name": {
+				"type": "string",
+				"description": "DAG name or reference topic name."
+			},
+			"dagRunId": {
+				"type": "string",
+				"description": "DAG-run identifier for run and run_logs targets."
+			},
+			"query": {
+				"type": "string",
+				"description": "URL query string without a leading question mark."
+			},
+			"uri": {
+				"type": "string",
+				"description": "dagu:// resource URI to read directly."
+			}
+		},
+		"additionalProperties": false
+	}`)
 }
 
 type readToolError struct {
@@ -109,7 +139,7 @@ func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.
 	case readTargetDAGs:
 		if err = svc.requireAPI(); err == nil {
 			var raw any
-			raw, err = svc.api.GetDAGsListData(ctx, apiQueryString(input))
+			raw, err = svc.api.GetDAGsListData(ctx, input.Query)
 			if err == nil {
 				data, err = normalizeDAGList(raw)
 			}
@@ -133,7 +163,7 @@ func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.
 	case readTargetRuns:
 		if err = svc.requireAPI(); err == nil {
 			var raw any
-			raw, err = svc.api.GetDAGRunsListData(ctx, apiQueryString(input))
+			raw, err = svc.api.GetDAGRunsListData(ctx, input.Query)
 			if err == nil {
 				data, err = normalizeRunList(raw)
 			}
@@ -219,13 +249,17 @@ func parseReadToolInput(raw json.RawMessage) (readInput, *readToolError) {
 			}
 		}
 		if len(mixed) > 0 {
-			return readInput{}, &readToolError{
+			readErr := &readToolError{
 				Code:    readErrorInvalidToolInput,
 				Message: "URI mode cannot be combined with target-mode fields.",
 				Details: map[string]any{
 					"fields": mixed,
 				},
 			}
+			if len(mixed) == 1 {
+				readErr.Field = mixed[0]
+			}
+			return readInput{}, readErr
 		}
 		return parseReadResourceURI(values[readFieldURI])
 	}
@@ -506,7 +540,7 @@ func isAllowedReadQueryParam(target, key string) bool {
 		}
 	case readTargetRunLogs:
 		switch key {
-		case "tail", "head", "offset", "limit":
+		case "tail":
 			return true
 		}
 	}
@@ -546,10 +580,8 @@ func validReadQueryValue(target, key, value string) bool {
 		}
 	case readTargetRunLogs:
 		switch key {
-		case "tail", "head", "offset":
+		case "tail":
 			return validIntRange(value, 1, 0)
-		case "limit":
-			return validIntRange(value, 1, 10000)
 		}
 	}
 	return false
@@ -714,18 +746,6 @@ func normalizeRunDetails(raw any, fallbackName, fallbackDAGRunID string) (map[st
 	}, nil
 }
 
-func apiQueryString(input readInput) string {
-	if input.Query == "" || input.Target != readTargetRuns {
-		return input.Query
-	}
-	values, err := url.ParseQuery(input.Query)
-	if err != nil {
-		return input.Query
-	}
-	values.Del("cursor")
-	return values.Encode()
-}
-
 func classifyReadToolError(input readInput, err error) *readToolError {
 	var readErr *readToolError
 	if errors.As(err, &readErr) {
@@ -739,7 +759,7 @@ func classifyReadToolError(input readInput, err error) *readToolError {
 			URI:     resourceURIForReadError(input),
 		}
 	}
-	if isDAGNotFound(err) || looksNotFound(err) {
+	if isReadResourceNotFound(err) {
 		return resourceNotFoundReadError(input, err.Error())
 	}
 	return &readToolError{
@@ -748,6 +768,13 @@ func classifyReadToolError(input readInput, err error) *readToolError {
 		Target:  input.Target,
 		URI:     resourceURIForReadError(input),
 	}
+}
+
+func isReadResourceNotFound(err error) bool {
+	return isDAGNotFound(err) ||
+		errors.Is(err, exec.ErrDAGRunIDNotFound) ||
+		errors.Is(err, exec.ErrNoStatusData) ||
+		looksNotFound(err)
 }
 
 func looksNotFound(err error) bool {

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -476,7 +476,7 @@ func validateReadQuery(target, rawQuery string, uriMode bool, rawURI string) *re
 		if !isAllowedReadQueryParam(target, key) {
 			return readQueryError(target, uriMode, rawURI, "Unsupported query parameter.")
 		}
-		if len(rawValues) > 1 && !(target == readTargetRuns && key == "status") {
+		if len(rawValues) > 1 && (target != readTargetRuns || key != "status") {
 			return readQueryError(target, uriMode, rawURI, "Query parameter must not be repeated.")
 		}
 		for _, rawValue := range rawValues {

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -71,7 +71,145 @@ The server intentionally exposes three tools.
 - dagu_change: preview or apply a DAG YAML upsert.
 - dagu_execute: start, enqueue, retry, or stop a DAG-run.
 
+Detailed tool references:
+
+- dagu://reference/read-tool: dagu_read inputs, targets, URI mode, query parameters, outputs, and errors.
+- dagu://reference/change-tool: dagu_change preview and apply contract for DAG YAML upsert.
+- dagu://reference/execute-tool: dagu_execute start, enqueue, retry, and stop contract.
+
 Use dagu_execute action=retry with name and dagRunId for retry. Use action=stop with name and dagRunId for stop. Use action=start or action=enqueue with targetType=dag for a stored DAG, or targetType=inline_spec with spec for an ad hoc run.`,
+		},
+		{
+			topic:       "read-tool",
+			uri:         "dagu://reference/read-tool",
+			name:        "dagu_mcp_read_tool_reference",
+			title:       "Dagu MCP read tool",
+			description: "Detailed dagu_read input, output, and error reference.",
+			text: `# dagu_read reference
+
+Purpose: read Dagu state and built-in reference content. The tool is read-only.
+
+Addressing:
+
+- Target mode uses target plus target-specific fields.
+- URI mode uses uri and forbids target, name, dagRunId, and query.
+
+Fields:
+
+- target: required in target mode. Values are references, reference, dags, dag, dag_spec, runs, run, and run_logs.
+- name: DAG name or reference topic name. Required for dag, dag_spec, run, and run_logs. Optional for reference; defaults to authoring. Forbidden for references, dags, and runs.
+- dagRunId: required for run and run_logs. Forbidden for other targets.
+- query: URL query string without a leading question mark. Allowed for dags, runs, and run_logs.
+- uri: dagu:// resource URI for URI mode.
+
+Targets:
+
+- references lists built-in reference topics.
+- reference reads one Markdown reference topic.
+- dags lists DAGs.
+- dag reads DAG details.
+- dag_spec reads the current DAG YAML.
+- runs lists DAG-runs.
+- run reads one DAG-run.
+- run_logs reads scheduler and step log metadata.
+
+Query parameters:
+
+- dags: page, perPage, name, labels, sort, order.
+- runs: name, dagRunId, status, fromDate, toDate, limit, cursor, labels. status may repeat.
+- run_logs: tail.
+
+Output:
+
+- Successful result text is Dagu read completed.
+- Structured output has target, data, references, and uri when the read has a canonical resource URI.
+- Reference URIs in references point to built-in guidance resources.
+
+Errors:
+
+- invalid_tool_input for malformed target-mode input.
+- invalid_resource_uri for malformed URI-mode input.
+- unsupported_read_target for unknown target.
+- unsupported_resource for unknown dagu:// family.
+- resource_not_found, resource_unavailable, or internal_error for runtime failures.`,
+		},
+		{
+			topic:       "change-tool",
+			uri:         "dagu://reference/change-tool",
+			name:        "dagu_mcp_change_tool_reference",
+			title:       "Dagu MCP change tool",
+			description: "Detailed dagu_change input, output, and error reference.",
+			text: `# dagu_change reference
+
+Purpose: validate or write a DAG YAML upsert.
+
+Fields:
+
+- mode: preview or apply. Defaults to preview.
+- type: change type. The supported value is upsert_dag. Defaults to upsert_dag.
+- name: target DAG name. Required.
+- spec: DAG YAML document. Required.
+
+Mode behavior:
+
+- preview validates the spec and returns validation output without writing a DAG.
+- apply validates the spec and writes the DAG only when validation succeeds.
+- apply returns whether the DAG was created or updated.
+
+Output:
+
+- Successful result text is Dagu change completed.
+- Structured output has mode, type, dagName, valid, errors, applied, references, and DAG data when validation succeeds.
+- dagUri is present when the DAG spec resource can be identified.
+
+Errors:
+
+- invalid_tool_input for missing fields, unknown mode, unknown type, malformed input, or validation failure shape that cannot be represented.
+- unauthorized when the caller cannot perform the requested write.
+- internal_error for unexpected failures.`,
+		},
+		{
+			topic:       "execute-tool",
+			uri:         "dagu://reference/execute-tool",
+			name:        "dagu_mcp_execute_tool_reference",
+			title:       "Dagu MCP execute tool",
+			description: "Detailed dagu_execute input, output, and error reference.",
+			text: `# dagu_execute reference
+
+Purpose: control DAG execution through start, enqueue, retry, and stop actions.
+
+Fields:
+
+- action: required. Values are start, enqueue, retry, and stop.
+- targetType: dag, inline_spec, or run. Defaults to run for retry and stop, inline_spec when spec is present, otherwise dag.
+- name: DAG name. Required for stored DAG runs and run actions.
+- spec: inline DAG YAML for targetType=inline_spec.
+- dagRunId: DAG-run identifier. Required for retry and stop. Optional override for start and enqueue.
+- params: run parameters string for start and enqueue.
+- queue: queue name for enqueue.
+- singleton: singleton run flag for start and enqueue.
+- labels: labels for start and enqueue.
+- stepName: optional failed step name for retry.
+
+Action behavior:
+
+- start runs a stored DAG when targetType=dag and runs an inline spec when targetType=inline_spec.
+- enqueue enqueues a stored DAG or inline spec.
+- retry retries an existing DAG-run and may target a step with stepName.
+- stop stops an existing DAG-run.
+
+Output:
+
+- Successful result text is Dagu execute completed.
+- Structured output has action, targetType, dagName, dagRunId, and references.
+- When a run is identified, output includes runUri, logsUri, and subscribe guidance.
+
+Errors:
+
+- invalid_tool_input for missing fields, unknown action, unsupported targetType, or malformed input.
+- unauthorized when the caller cannot perform the requested execution operation.
+- resource_not_found when the named DAG or DAG-run does not exist.
+- resource_unavailable or internal_error for runtime failures.`,
 		},
 		{
 			topic:       "notifications",
@@ -92,9 +230,12 @@ Clients without resource subscription support should poll dagu_read target=run w
 
 func defaultReferenceURIs() []string {
 	refs := referenceResources()
-	uris := make([]string, 0, len(refs))
+	uris := make([]string, 0, 3)
 	for _, ref := range refs {
-		uris = append(uris, ref.uri)
+		switch ref.topic {
+		case "authoring", "tools", "notifications":
+			uris = append(uris, ref.uri)
+		}
 	}
 	return uris
 }

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -116,7 +116,7 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 		Name:        toolRead,
 		Title:       "Read Dagu state",
 		Description: "Read DAG specs, DAG details, DAG-run details, logs, list views, and Dagu MCP reference resources.",
-		InputSchema: json.RawMessage(`{"type":"object"}`),
+		InputSchema: readToolInputSchema(),
 		Annotations: &mcpsdk.ToolAnnotations{
 			OpenWorldHint: falsePtr,
 			ReadOnlyHint:  true,

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -88,14 +88,6 @@ func NewServer(api *frontendapi.API) *mcpsdk.Server {
 	return server
 }
 
-type readInput struct {
-	Target   string `json:"target" jsonschema:"Read target: dags, dag, dag_spec, runs, run, run_logs, or reference."`
-	Name     string `json:"name,omitempty" jsonschema:"DAG name for dag, dag_spec, run, and run_logs targets."`
-	DAGRunID string `json:"dagRunId,omitempty" jsonschema:"DAG-run ID for run and run_logs targets. The value latest is accepted where Dagu accepts it."`
-	Query    string `json:"query,omitempty" jsonschema:"URL query string for list targets, for example page=1&perPage=100 or status=running."`
-	URI      string `json:"uri,omitempty" jsonschema:"Resource URI to read directly, for example dagu://reference/authoring."`
-}
-
 type changeInput struct {
 	Mode string `json:"mode,omitempty" jsonschema:"preview or apply. Defaults to preview."`
 	Type string `json:"type,omitempty" jsonschema:"Change type. Currently upsert_dag."`
@@ -120,10 +112,11 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 	falsePtr := new(false)
 	truePtr := new(true)
 
-	mcpsdk.AddTool(server, &mcpsdk.Tool{
+	server.AddTool(&mcpsdk.Tool{
 		Name:        toolRead,
 		Title:       "Read Dagu state",
 		Description: "Read DAG specs, DAG details, DAG-run details, logs, list views, and Dagu MCP reference resources.",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
 		Annotations: &mcpsdk.ToolAnnotations{
 			OpenWorldHint: falsePtr,
 			ReadOnlyHint:  true,
@@ -219,98 +212,6 @@ func registerPrompts(server *mcpsdk.Server) {
 			{Name: "dagRunId", Description: "DAG-run ID.", Required: true},
 		},
 	}, promptDebugRun)
-}
-
-func (svc *Service) readTool(ctx context.Context, req *mcpsdk.CallToolRequest, input readInput) (*mcpsdk.CallToolResult, map[string]any, error) {
-	return auditToolCall(ctx, svc.api, req, toolRead, readAuditMetadata(input), func(ctx context.Context) (*mcpsdk.CallToolResult, map[string]any, error) {
-		return svc.readToolImpl(ctx, input)
-	})
-}
-
-func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.CallToolResult, map[string]any, error) {
-	target := strings.TrimSpace(input.Target)
-	if target == "" && input.URI != "" {
-		target = "reference"
-	}
-
-	var (
-		data any
-		uri  string
-		err  error
-	)
-
-	switch target {
-	case "reference":
-		uri = input.URI
-		if uri == "" {
-			topic := strings.TrimSpace(input.Name)
-			if topic == "" {
-				topic = "authoring"
-			}
-			uri = "dagu://reference/" + pathEscape(topic)
-		}
-		content, mime, readErr := svc.readResourceText(ctx, uri)
-		if readErr != nil {
-			return nil, nil, readErr
-		}
-		data = map[string]any{"text": content, "mimeType": mime}
-	case "dags":
-		if err = svc.requireAPI(); err == nil {
-			data, err = svc.api.GetDAGsListData(ctx, input.Query)
-		}
-	case "dag":
-		if err = requireName(input.Name); err == nil {
-			if err = svc.requireAPI(); err == nil {
-				data, err = svc.api.GetDAGDetailsData(ctx, input.Name)
-				uri = dagSpecURI(input.Name)
-			}
-		}
-	case "dag_spec":
-		if err = requireName(input.Name); err == nil {
-			if err = svc.requireAPI(); err == nil {
-				data, err = svc.getDAGSpec(ctx, input.Name)
-				uri = dagSpecURI(input.Name)
-			}
-		}
-	case "runs":
-		if err = svc.requireAPI(); err == nil {
-			data, err = svc.api.GetDAGRunsListData(ctx, input.Query)
-		}
-	case "run":
-		if err = requireRun(input.Name, input.DAGRunID); err == nil {
-			if err = svc.requireAPI(); err == nil {
-				data, err = svc.api.GetDAGRunDetailsData(ctx, input.Name+"/"+input.DAGRunID)
-				uri = runURI(input.Name, input.DAGRunID)
-			}
-		}
-	case "run_logs":
-		if err = requireRun(input.Name, input.DAGRunID); err == nil {
-			if err = svc.requireAPI(); err == nil {
-				identifier := input.Name + "/" + input.DAGRunID
-				if input.Query != "" {
-					identifier += "?" + input.Query
-				}
-				data, err = svc.api.GetDAGRunLogsData(ctx, identifier)
-				uri = runLogsURIWithQuery(input.Name, input.DAGRunID, input.Query)
-			}
-		}
-	default:
-		err = fmt.Errorf("unknown read target %q", input.Target)
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	output := map[string]any{
-		"target":     target,
-		"data":       data,
-		"references": defaultReferenceURIs(),
-	}
-	if uri != "" {
-		output["uri"] = uri
-	}
-
-	return resultWithLinks("Dagu read completed.", linksForURI(uri)...), output, nil
 }
 
 func (svc *Service) changeTool(ctx context.Context, req *mcpsdk.CallToolRequest, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
@@ -994,53 +895,6 @@ func resultWithLinks(message string, links ...resourceLink) *mcpsdk.CallToolResu
 		})
 	}
 	return &mcpsdk.CallToolResult{Content: content}
-}
-
-func linksForURI(uri string) []resourceLink {
-	if uri == "" {
-		return nil
-	}
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return nil
-	}
-	switch parsed.Host {
-	case "dags":
-		segments, err := uriPathSegments(parsed)
-		if err != nil || len(segments) != 2 {
-			return nil
-		}
-		return []resourceLink{linkForDAGSpec(segments[0])}
-	case "runs":
-		segments, err := uriPathSegments(parsed)
-		if err != nil || len(segments) < 2 {
-			return nil
-		}
-		if len(segments) == 3 && segments[2] == "logs" {
-			return []resourceLink{{
-				uri:         uri,
-				name:        "dag_run_logs",
-				title:       "DAG-run logs",
-				description: "Logs for this DAG-run.",
-				mimeType:    resourceMIMEJSON,
-			}}
-		}
-		return []resourceLink{{
-			uri:         uri,
-			name:        "dag_run",
-			title:       "DAG-run details",
-			description: "DAG-run details.",
-			mimeType:    resourceMIMEJSON,
-		}}
-	default:
-		return []resourceLink{{
-			uri:         uri,
-			name:        "dagu_reference",
-			title:       "Dagu reference",
-			description: "Dagu MCP reference.",
-			mimeType:    resourceMIMEText,
-		}}
-	}
 }
 
 func linkForDAGSpec(name string) resourceLink {

--- a/specs/020-mcp-server.md
+++ b/specs/020-mcp-server.md
@@ -126,6 +126,8 @@ Rules:
 
 - Reference collection resources return the available reference resource URIs
   and titles or descriptions when available.
+- The built-in reference topic set includes `authoring`, `tools`,
+  `read-tool`, `change-tool`, `execute-tool`, and `notifications`.
 - Reference topic resources return Markdown text owned by the Dagu MCP server.
 - DAG collection resources return a paginated or bounded list of DAG summaries
   visible to the caller.
@@ -204,6 +206,14 @@ Built-in reference topic:
 
 ```text
 dagu://reference/authoring
+```
+
+Detailed tool reference topics:
+
+```text
+dagu://reference/read-tool
+dagu://reference/change-tool
+dagu://reference/execute-tool
 ```
 
 DAG collection with list filters:

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -4,9 +4,9 @@ Status: Draft.
 
 ## Scope
 
-This spec defines the `dagu_read` MCP tool-call contract: input fields, target
-selection, successful output, resource links, read-only effects, and tool-level
-errors.
+This spec defines the `dagu_read` MCP tool-call contract: input fields,
+addressing modes, target contracts, successful output, resource links,
+read-only effects, and tool-level errors.
 
 This spec does not define the MCP endpoint, authentication, API-key surfaces,
 `dagu://` URI grammar, MCP resource reads, `dagu_change`, `dagu_execute`,
@@ -15,6 +15,10 @@ internals, or MCP SDK internals.
 
 Related specs: [020: MCP Server](020-mcp-server.md) defines the MCP endpoint,
 authentication, and `dagu://` resource URI model used by this tool.
+
+The `data` object returned by this tool is part of the `dagu_read` contract.
+REST API response schemas may be used by an implementation, but they are not
+the MCP tool output contract.
 
 ## Goal
 
@@ -36,81 +40,171 @@ Rules:
 
 ### Input
 
-Tool input is a JSON object. Supported fields are:
+Tool input is a JSON object. Fields outside this table fail with
+`invalid_tool_input`.
 
-| Field | Type | Required | Meaning |
-| --- | --- | --- | --- |
-| `target` | string | Required when `uri` is absent. | Named read target. |
-| `name` | string | Target-specific. | DAG name or reference topic name. |
-| `dagRunId` | string | Target-specific. | DAG-run identifier for run reads. |
-| `query` | string | Optional. | Query string for supported list or log targets, without a leading `?`. |
-| `uri` | string | Alternative to `target`. | Direct `dagu://` resource URI. |
+| Field | Type | Allowed in mode | Required rule | Meaning |
+| --- | --- | --- | --- | --- |
+| `target` | string | Target mode only. | Required for target mode. | Case-sensitive read target literal. |
+| `name` | string | Target mode only. | Required for `dag`, `dag_spec`, `run`, and `run_logs`; optional for `reference`; forbidden for `references`, `dags`, and `runs`. | DAG name or reference topic name. |
+| `dagRunId` | string | Target mode only. | Required for `run` and `run_logs`; forbidden for all other targets. | DAG-run identifier. |
+| `query` | string | Target mode only. | Optional only for `dags`, `runs`, and `run_logs`; forbidden for all other targets. | URL query string without a leading `?`. |
+| `uri` | string | URI mode only. | Required for URI mode. | Direct `dagu://` resource URI. Query parameters for URI mode live inside this value. |
 
-Target selection rules:
+Supported fields, when present and not `null`, must be strings. `null` is
+treated as absent. String field values are trimmed of leading and trailing
+whitespace. The trimmed value is the effective value used for mode selection,
+resource lookup, returned `target`, returned `uri`, and error fields. A string
+that is empty after trimming is treated as absent. A forbidden field fails when
+its trimmed value is non-empty. Supported target names are case-sensitive.
 
-- A request identifies the read by either `uri` or `target`.
-- When `uri` is present, the tool reads that `dagu://` resource according to
-  Spec 020.
-- Direct URI query parameters must be encoded in `uri`, not `query`.
-- `query` is valid only for `dags`, `runs`, and `run_logs`.
-- `query` does not include a leading `?`.
-- `target=reference` defaults to `authoring` when both `uri` and `name` are
-  absent.
+### Addressing modes
 
-Supported targets:
+| Mode | Required fields | Forbidden fields | Read identity | Resolved output `target` |
+| --- | --- | --- | --- | --- |
+| Target mode | `target` | `uri` | Reads one named target using target-specific fields. | The supplied `target` value. |
+| URI mode | `uri` | `target`, `name`, `dagRunId`, `query` | Reads the MCP resource identified by `uri`. URI query parameters live inside `uri`. | Derived from the URI family and path. |
 
-| Target | Required fields | Optional fields | Content |
-| --- | --- | --- | --- |
-| `reference` | None. | `name` or `uri`. | Built-in MCP reference text. |
-| `dags` | None. | `query`. | DAG summaries visible to the caller. |
-| `dag` | `name`. | None. | DAG details. |
-| `dag_spec` | `name`. | None. | Current YAML spec data. |
-| `runs` | None. | `query`. | DAG-run summaries visible to the caller. |
-| `run` | `name`, `dagRunId`. | None. | DAG-run details. |
-| `run_logs` | `name`, `dagRunId`. | `query`. | DAG-run logs. |
+Rules:
+
+- A request with neither addressing mode fails with `invalid_tool_input`.
+- A request with fields from both addressing modes fails with
+  `invalid_tool_input`.
+- In target mode, `target=reference` defaults `name` to `authoring` when
+  `name` is absent.
+- In URI mode, output `target` is derived as follows:
+  - `dagu://reference` resolves to `references`.
+  - `dagu://reference/{topic}` resolves to `reference`.
+  - `dagu://dags` resolves to `dags`.
+  - `dagu://dags/{name}/spec` resolves to `dag_spec`.
+  - `dagu://runs` resolves to `runs`.
+  - `dagu://runs/{name}/{dagRunId}` resolves to `run`.
+  - `dagu://runs/{name}/{dagRunId}/logs` resolves to `run_logs`.
+  - Query parameters do not affect target derivation.
+
+### Target contracts
+
+| Target | Required fields | Optional fields | Output `uri` | Minimum `data` contract |
+| --- | --- | --- | --- | --- |
+| `references` | None. | None. | Omitted in target mode; `dagu://reference` in URI mode. | Reference collection model. |
+| `reference` | None. | `name`. | `dagu://reference/{name}` after applying the default topic when needed. | `data.mimeType` is `text/markdown`; `data.text` is a string. |
+| `dags` | None. | `query`. | Omitted in target mode; `dagu://dags` plus query in URI mode. | DAG collection model. |
+| `dag` | `name`. | None. | Omitted. Spec 020 does not define a DAG-details resource URI. | DAG detail model. |
+| `dag_spec` | `name`. | None. | `dagu://dags/{name}/spec`. | DAG spec model. |
+| `runs` | None. | `query`. | Omitted in target mode; `dagu://runs` plus query in URI mode. | Run collection model. |
+| `run` | `name`, `dagRunId`. | None. | `dagu://runs/{name}/{dagRunId}`. | Run detail model. |
+| `run_logs` | `name`, `dagRunId`. | `query`. | `dagu://runs/{name}/{dagRunId}/logs`, with the supplied query appended when present. | Run-log model. |
+
+Minimum `data` models:
+
+| Model | Required shape |
+| --- | --- |
+| Reference collection | `data.items` is an array. Each item has `name` string, `uri` string, and `mimeType` string. The array includes `authoring`, `tools`, and `notifications`. |
+| Reference topic | `data.mimeType` is `text/markdown`; `data.text` is the Markdown content string. |
+| DAG collection | `data.items` is an array. Each item has `name` string and `uri` string. `uri` is the canonical `dagu://dags/{name}/spec` URI for that DAG. |
+| DAG detail | `data.name` is the DAG name string. `data.specUri` is the canonical `dagu://dags/{name}/spec` URI. |
+| DAG spec | `data.name` is the DAG name string. `data.mimeType` is `application/yaml`. `data.spec` is the YAML document string. `data.errors` is an array of strings. |
+| Run collection | `data.items` is an array. Each item has `name` string, `dagRunId` string, `uri` string, `status` number, and `statusLabel` string. `uri` is the canonical `dagu://runs/{name}/{dagRunId}` URI. |
+| Run detail | `data.name` is the DAG name string. `data.dagRunId` is the DAG-run ID string. `data.uri` is the canonical `dagu://runs/{name}/{dagRunId}` URI. `data.status` is a number. `data.statusLabel` is a string. |
+| Run logs | `data.schedulerLog` is an object with `content` string, `lineCount` number, `totalLines` number, and `hasMore` boolean. `data.stepLogs` is an array. Each step-log item has `stepName` string, `status` number, `statusLabel` string, `hasStdout` boolean, and `hasStderr` boolean. |
+
+Implementations may add fields inside `data`. Conformance tests must not require
+absence of additional fields.
+
+### Query handling
+
+Rules:
+
+- The `query` field is allowed only in target mode for `dags`, `runs`, and
+  `run_logs`.
+- The `query` field must not start with `?`.
+- The same parameter names are allowed in URI-mode collection and log URIs.
+- Query parameter order is not normative.
+
+The effective query string is parsed as URL query data. An empty effective
+query string is treated as absent. Invalid percent-encoding, unknown
+parameters, repeated parameters not marked repeatable, empty values, and values
+outside the table below fail with `invalid_tool_input` in target mode and
+`invalid_resource_uri` in URI mode.
+
+| Target | Parameter | Value contract |
+| --- | --- | --- |
+| `dags` | `page` | Integer greater than or equal to `1`. |
+| `dags` | `perPage` | Integer from `1` through `1000`. |
+| `dags` | `name` | Non-empty string. |
+| `dags` | `labels` | Comma-separated non-empty label strings. |
+| `dags` | `sort` | One of `name` or `nextRun`. |
+| `dags` | `order` | One of `asc` or `desc`. |
+| `runs` | `name` | Non-empty string. |
+| `runs` | `dagRunId` | Non-empty string. The value `latest` is allowed. |
+| `runs` | `status` | Repeatable integer enum value from `0` through `8`. |
+| `runs` | `fromDate` | Unix timestamp in seconds. |
+| `runs` | `toDate` | Unix timestamp in seconds. |
+| `runs` | `limit` | Integer from `1` through `500`. |
+| `runs` | `cursor` | Non-empty opaque string. |
+| `runs` | `labels` | Comma-separated non-empty label strings. |
+| `run_logs` | `tail` | Integer greater than or equal to `1`. |
+| `run_logs` | `head` | Integer greater than or equal to `1`. |
+| `run_logs` | `offset` | Integer greater than or equal to `1`. |
+| `run_logs` | `limit` | Integer from `1` through `10000`. |
 
 ### Output
 
-A successful MCP tool result includes human-readable result content. Its
-structured output uses this JSON object shape:
+A successful MCP tool result has:
+
+- A first text content item whose text is exactly `Dagu read completed.`.
+- Structured output with this exact top-level envelope:
 
 ```json
 {
   "target": "run_logs",
   "uri": "dagu://runs/nightly-report/20260701T010000Z/logs?tail=100",
-  "data": {
-    "message": "Read run logs.",
-    "content": {}
-  },
+  "data": {},
   "references": [
-    "dagu://reference/authoring"
+    "dagu://reference/authoring",
+    "dagu://reference/tools",
+    "dagu://reference/notifications"
   ]
 }
 ```
 
 Rules:
 
-- `target` is the selected read target.
-- `uri` is omitted when no concrete resource URI is known.
-- Result content includes a human-readable completion message and may include a
-  resource link when a concrete URI is known.
-- `data` contains the read result, and the exact JSON field set inside `data` is
-  not frozen by this spec.
-- `references` contains built-in reference resource URIs useful to clients.
+- `target` is the resolved read target.
+- `uri` is present when the read has a canonical `dagu://` resource URI. URI
+  mode always returns the validated resource URI, including collection URIs.
+- `data` contains the read result and must satisfy the target contract above.
+- `references` contains exactly `dagu://reference/authoring`,
+  `dagu://reference/tools`, and `dagu://reference/notifications`; order is not
+  normative.
+- A result with `uri` has exactly two content items: `content[0]` is a text
+  content item with text `Dagu read completed.`, and `content[1]` is a
+  resource-link content item for that URI.
+- A result without `uri` has exactly one content item: `content[0]` is a text
+  content item with text `Dagu read completed.`.
+- URI path segments in returned URIs follow Spec 020 escaping.
 
-Resource link rules:
+Resource-link content items have MCP content type `resource_link`. The required
+fields are `uri`, `name`, and `mimeType`. Optional MCP resource-link fields,
+such as `title` and `description`, may be present.
 
-- `dag` and `dag_spec` use canonical URI `dagu://dags/{name}/spec`.
-- `run` uses canonical URI `dagu://runs/{name}/{dagRunId}`.
-- `run_logs` uses canonical URI `dagu://runs/{name}/{dagRunId}/logs`,
-  including query parameters when supplied.
-- `reference` uses the reference URI read.
-- List targets are not required to return a singular `uri`.
-- URI path segments are encoded according to Spec 020.
+| URI shape | Resource-link `name` | Resource-link `mimeType` |
+| --- | --- | --- |
+| `dagu://reference` | `dagu_references` | `application/json` |
+| `dagu://reference/{topic}` | `dagu_reference` | `text/markdown` |
+| `dagu://dags` | `dags` | `application/json` |
+| `dagu://dags/{name}/spec` | `dag_spec` | `application/yaml` |
+| `dagu://runs` | `dag_runs` | `application/json` |
+| `dagu://runs/{name}/{dagRunId}` | `dag_run` | `application/json` |
+| `dagu://runs/{name}/{dagRunId}/logs` | `dag_run_logs` | `application/json` |
 
 ## Errors
 
-Tool-level failures return an error JSON object with this shape:
+Failed tool calls return an MCP tool result with `isError=true`. When the
+transport supports structured output, the structured output is the error object.
+Text content may include the error message as a fallback.
+
+The error object has this shape:
 
 ```json
 {
@@ -118,12 +212,22 @@ Tool-level failures return an error JSON object with this shape:
   "message": "The dagRunId field is required for target run_logs.",
   "target": "run_logs",
   "field": "dagRunId",
+  "uri": "dagu://runs/nightly-report/20260701T010000Z/logs",
   "details": {}
 }
 ```
 
-`target`, `field`, `uri`, and `details` are omitted when they do not apply.
-Clients must branch on `code`, not parse `message`.
+`code` and `message` are required. Clients must branch on `code`, not parse
+`message`.
+
+Optional field rules:
+
+| Field | Required when |
+| --- | --- |
+| `target` | A valid target has been resolved, or an unsupported target value was supplied. |
+| `field` | Exactly one input field caused the failure. For an unknown field, this is the unknown field name. |
+| `uri` | URI mode supplied a non-empty `uri`, or target mode resolved a singular resource URI before lookup failed. |
+| `details` | More than one field caused the failure, or the server needs to expose structured validation details. |
 
 Common conditions map to codes as follows:
 
@@ -131,8 +235,15 @@ Common conditions map to codes as follows:
 | --- | --- |
 | Authentication is required and the request is not authenticated. | `unauthenticated` |
 | The accepted credential is not authorized for the requested read. | `unauthorized` |
-| The tool input is not a JSON object, omits required fields, combines fields invalidly, or provides an invalid `query`. | `invalid_tool_input` |
-| `target` is present but is not a supported read target. | `unsupported_read_target` |
+| Tool input is not a JSON object. | `invalid_tool_input` |
+| Tool input contains an unknown field. | `invalid_tool_input` |
+| A supported field has a non-string, non-null value. | `invalid_tool_input` |
+| The request provides neither `target` nor `uri` after trimming. | `invalid_tool_input` |
+| The request combines URI mode with any non-empty target-mode field. | `invalid_tool_input` |
+| A required target-mode field is absent after trimming. | `invalid_tool_input` |
+| A field is supplied for a target that forbids it. | `invalid_tool_input` |
+| `target` is present but is not a supported case-sensitive read target. | `unsupported_read_target` |
+| The `query` field is supplied in URI mode, supplied for a target that does not allow it, starts with `?`, contains malformed URL query encoding, or contains unsupported parameters. | `invalid_tool_input` |
 | `uri` is malformed, uses the wrong scheme, has an unsupported path shape, or contains malformed query parameters. | `invalid_resource_uri` |
 | `uri` identifies a resource family that this tool cannot read. | `unsupported_resource` |
 | The named DAG, DAG run, log stream, or reference topic does not exist. | `resource_not_found` |
@@ -141,16 +252,15 @@ Common conditions map to codes as follows:
 
 ## Examples
 
-List DAGs:
+URI mode direct reference read:
 
 ```json
 {
-  "target": "dags",
-  "query": "name=nightly&perPage=20"
+  "uri": "dagu://reference/authoring"
 }
 ```
 
-Read the default reference topic:
+Target mode default reference:
 
 ```json
 {
@@ -158,16 +268,7 @@ Read the default reference topic:
 }
 ```
 
-Read a named reference topic:
-
-```json
-{
-  "target": "reference",
-  "name": "authoring"
-}
-```
-
-Read current DAG spec data:
+Target mode DAG spec:
 
 ```json
 {
@@ -176,10 +277,30 @@ Read current DAG spec data:
 }
 ```
 
-Read run logs by resource URI:
+Target mode run logs with query:
 
 ```json
 {
-  "uri": "dagu://runs/nightly-report/20260701T010000Z/logs?tail=100"
+  "target": "run_logs",
+  "name": "nightly-report",
+  "dagRunId": "20260701T010000Z",
+  "query": "tail=100"
+}
+```
+
+Invalid mixed-mode request:
+
+```json
+{
+  "uri": "dagu://reference/authoring",
+  "target": "reference"
+}
+```
+
+Expected error code:
+
+```json
+{
+  "code": "invalid_tool_input"
 }
 ```

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -1,6 +1,6 @@
 # Spec: MCP Read Tool
 
-Status: Draft.
+Status: Implemented.
 
 ## Scope
 

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -144,9 +144,6 @@ outside the table below fail with `invalid_tool_input` in target mode and
 | `runs` | `cursor` | Non-empty opaque string. |
 | `runs` | `labels` | Comma-separated non-empty label strings. |
 | `run_logs` | `tail` | Integer greater than or equal to `1`. |
-| `run_logs` | `head` | Integer greater than or equal to `1`. |
-| `run_logs` | `offset` | Integer greater than or equal to `1`. |
-| `run_logs` | `limit` | Integer from `1` through `10000`. |
 
 ### Output
 

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -99,7 +99,7 @@ Minimum `data` models:
 
 | Model | Required shape |
 | --- | --- |
-| Reference collection | `data.items` is an array. Each item has `name` string, `uri` string, and `mimeType` string. The array includes `authoring`, `tools`, and `notifications`. |
+| Reference collection | `data.items` is an array. Each item has `name` string, `uri` string, and `mimeType` string. The array includes `authoring`, `tools`, `read-tool`, `change-tool`, `execute-tool`, and `notifications`. |
 | Reference topic | `data.mimeType` is `text/markdown`; `data.text` is the Markdown content string. |
 | DAG collection | `data.items` is an array. Each item has `name` string and `uri` string. `uri` is the canonical `dagu://dags/{name}/spec` URI for that DAG. |
 | DAG detail | `data.name` is the DAG name string. `data.specUri` is the canonical `dagu://dags/{name}/spec` URI. |

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -1,0 +1,185 @@
+# Spec: MCP Read Tool
+
+Status: Draft.
+
+## Scope
+
+This spec defines the `dagu_read` MCP tool-call contract: input fields, target
+selection, successful output, resource links, read-only effects, and tool-level
+errors.
+
+This spec does not define the MCP endpoint, authentication, API-key surfaces,
+`dagu://` URI grammar, MCP resource reads, `dagu_change`, `dagu_execute`,
+prompts, subscriptions, REST response schemas, Web UI behavior, storage
+internals, or MCP SDK internals.
+
+Related specs: [020: MCP Server](020-mcp-server.md) defines the MCP endpoint,
+authentication, and `dagu://` resource URI model used by this tool.
+
+## Goal
+
+`dagu_read` gives MCP clients one read-only way to inspect Dagu state and
+built-in MCP reference content while preserving the resource URI model from
+Spec 020.
+
+## Behavior
+
+### Tool Identity
+
+Rules:
+
+- The tool name is `dagu_read`.
+- The tool is read-only from the Dagu domain perspective.
+- A successful call must not create, update, delete, start, enqueue, retry, or
+  stop DAGs or DAG runs.
+- Audit, metrics, logging, and transport side effects are allowed.
+
+### Input
+
+Tool input is a JSON object. Supported fields are:
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `target` | string | Required when `uri` is absent. | Named read target. |
+| `name` | string | Target-specific. | DAG name or reference topic name. |
+| `dagRunId` | string | Target-specific. | DAG-run identifier for run reads. |
+| `query` | string | Optional. | Query string for supported list or log targets, without a leading `?`. |
+| `uri` | string | Alternative to `target`. | Direct `dagu://` resource URI. |
+
+Target selection rules:
+
+- A request identifies the read by either `uri` or `target`.
+- When `uri` is present, the tool reads that `dagu://` resource according to
+  Spec 020.
+- Direct URI query parameters must be encoded in `uri`, not `query`.
+- `query` is valid only for `dags`, `runs`, and `run_logs`.
+- `query` does not include a leading `?`.
+- `target=reference` defaults to `authoring` when both `uri` and `name` are
+  absent.
+
+Supported targets:
+
+| Target | Required fields | Optional fields | Content |
+| --- | --- | --- | --- |
+| `reference` | None. | `name` or `uri`. | Built-in MCP reference text. |
+| `dags` | None. | `query`. | DAG summaries visible to the caller. |
+| `dag` | `name`. | None. | DAG details. |
+| `dag_spec` | `name`. | None. | Current YAML spec data. |
+| `runs` | None. | `query`. | DAG-run summaries visible to the caller. |
+| `run` | `name`, `dagRunId`. | None. | DAG-run details. |
+| `run_logs` | `name`, `dagRunId`. | `query`. | DAG-run logs. |
+
+### Output
+
+A successful MCP tool result includes human-readable result content. Its
+structured output uses this JSON object shape:
+
+```json
+{
+  "target": "run_logs",
+  "uri": "dagu://runs/nightly-report/20260701T010000Z/logs?tail=100",
+  "data": {
+    "message": "Read run logs.",
+    "content": {}
+  },
+  "references": [
+    "dagu://reference/authoring"
+  ]
+}
+```
+
+Rules:
+
+- `target` is the selected read target.
+- `uri` is omitted when no concrete resource URI is known.
+- Result content includes a human-readable completion message and may include a
+  resource link when a concrete URI is known.
+- `data` contains the read result, and the exact JSON field set inside `data` is
+  not frozen by this spec.
+- `references` contains built-in reference resource URIs useful to clients.
+
+Resource link rules:
+
+- `dag` and `dag_spec` use canonical URI `dagu://dags/{name}/spec`.
+- `run` uses canonical URI `dagu://runs/{name}/{dagRunId}`.
+- `run_logs` uses canonical URI `dagu://runs/{name}/{dagRunId}/logs`,
+  including query parameters when supplied.
+- `reference` uses the reference URI read.
+- List targets are not required to return a singular `uri`.
+- URI path segments are encoded according to Spec 020.
+
+## Errors
+
+Tool-level failures return an error JSON object with this shape:
+
+```json
+{
+  "code": "invalid_tool_input",
+  "message": "The dagRunId field is required for target run_logs.",
+  "target": "run_logs",
+  "field": "dagRunId",
+  "details": {}
+}
+```
+
+`target`, `field`, `uri`, and `details` are omitted when they do not apply.
+Clients must branch on `code`, not parse `message`.
+
+Common conditions map to codes as follows:
+
+| Condition | Code |
+| --- | --- |
+| Authentication is required and the request is not authenticated. | `unauthenticated` |
+| The accepted credential is not authorized for the requested read. | `unauthorized` |
+| The tool input is not a JSON object, omits required fields, combines fields invalidly, or provides an invalid `query`. | `invalid_tool_input` |
+| `target` is present but is not a supported read target. | `unsupported_read_target` |
+| `uri` is malformed, uses the wrong scheme, has an unsupported path shape, or contains malformed query parameters. | `invalid_resource_uri` |
+| `uri` identifies a resource family that this tool cannot read. | `unsupported_resource` |
+| The named DAG, DAG run, log stream, or reference topic does not exist. | `resource_not_found` |
+| The resource exists but cannot currently be read. | `resource_unavailable` |
+| The server fails unexpectedly while handling the read. | `internal_error` |
+
+## Examples
+
+List DAGs:
+
+```json
+{
+  "target": "dags",
+  "query": "name=nightly&perPage=20"
+}
+```
+
+Read the default reference topic:
+
+```json
+{
+  "target": "reference"
+}
+```
+
+Read a named reference topic:
+
+```json
+{
+  "target": "reference",
+  "name": "authoring"
+}
+```
+
+Read current DAG spec data:
+
+```json
+{
+  "target": "dag_spec",
+  "name": "nightly-report"
+}
+```
+
+Read run logs by resource URI:
+
+```json
+{
+  "uri": "dagu://runs/nightly-report/20260701T010000Z/logs?tail=100"
+}
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,6 +28,7 @@ It must not be treated as product behavior until implementation catches up.
 | [017: Built-In Run Context](017-built-in-run-context.md) | Implemented |
 | [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Implemented |
 | [020: MCP Server](020-mcp-server.md) | Not implemented |
+| [021: MCP Read Tool](021-mcp-read-tool.md) | Not implemented |
 
 **Writing guidelines:**
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ It must not be treated as product behavior until implementation catches up.
 | [017: Built-In Run Context](017-built-in-run-context.md) | Implemented |
 | [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Implemented |
 | [020: MCP Server](020-mcp-server.md) | Not implemented |
-| [021: MCP Read Tool](021-mcp-read-tool.md) | Not implemented |
+| [021: MCP Read Tool](021-mcp-read-tool.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary
- add Spec 021 MCP read tool documentation and conformance coverage
- implement dagu_read structured input validation, resource URI reads, normalized success envelopes, and structured tool errors
- split the read tool implementation into its own MCP service file

## Testing
- go test ./internal/service/mcp -count=1
- go test ./conformance/spec021_mcp_read_tool -count=1
- go test ./conformance/spec020_mcp_server -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the `dagu_read` MCP tool per Spec 021 with structured input validation and `dagu://` resource reads. Expands built-in MCP tool references (`read-tool`, `change-tool`, `execute-tool`) and adds conformance tests.

- **New Features**
  - Implemented `dagu_read` targets (references, reference, dags, dag, dag_spec, runs, run, run_logs) with spec-aligned errors and read-only, non-destructive, closed-world hints.
  - Added conformance tests for Spec 021 and MCP server tool listing, plus `conformance/mcptest` helpers; marked Spec 021 as implemented.
  - Exposed detailed tool reference topics via `dagu://reference/read-tool`, `dagu://reference/change-tool`, and `dagu://reference/execute-tool`, and documented them in Spec 020.

- **Bug Fixes**
  - Tightened error codes/messages, trimmed input whitespace, normalized resource identifiers, and finalized tool identity hints.
  - Modernized query parsing and simplified validation for predictable filters and clearer errors.
  - Refreshed DAG-run store inside polling in API tests to observe new attempts and reduce flakes.

<sup>Written for commit c72b4cf8d74261739305433680f45c82b92909b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP read support for DAGs, runs, references, and logs using either target-based input or DAGU URIs.
  * Added broader conformance coverage for MCP server discovery, resource reads, and API key access rules.

* **Bug Fixes**
  * Improved input validation, whitespace trimming, URI handling, and error reporting for read requests.
  * Normalized returned resource identifiers and preserved read-only behavior during repeated reads.

* **Documentation**
  * Added a draft spec for the MCP read tool and updated the conformance status list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->