### PR TITLE
fix: bootstrap missing sub-attempt status reports

### DIFF
--- a/internal/intg/distr/parallel_test.go
+++ b/internal/intg/distr/parallel_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/test/intgharness"
 	"github.com/stretchr/testify/require"
@@ -213,6 +214,52 @@ steps:
 
 		st := agent.Status(f.coord.Context)
 		require.NotEqual(t, core.Succeeded, st.Status)
+	})
+}
+
+func TestParallel_ForceLocalSubDAGsFromDistributedWorker(t *testing.T) {
+	t.Run("workerDispatchedParentRunsLocalChildren", func(t *testing.T) {
+		f := newTestFixture(t, `
+steps:
+  - name: process-items
+    action: dag.run
+    with:
+      dag: local-child
+    parallel:
+      items: ["item1", "item2", "item3"]
+      max_concurrent: 3
+    output: RESULTS
+
+---
+name: local-child
+worker_selector: local
+steps:
+  - name: process
+    run: echo "processed $1 locally"
+`, withConfigMutator(func(c *config.Config) {
+			c.DefaultExecMode = config.ExecutionModeDistributed
+		}), withLogPersistence())
+		defer f.cleanup()
+
+		require.NoError(t, f.enqueue())
+		f.waitForQueued()
+		f.startScheduler(30 * time.Second)
+
+		status := f.waitForStatusIn([]core.Status{core.Succeeded, core.Failed, core.Aborted}, 25*time.Second)
+
+		require.Equal(t, core.Succeeded, status.Status)
+		require.Len(t, status.Nodes, 1)
+
+		node := status.Nodes[0]
+		require.Equal(t, "process-items", node.Step.Name)
+		require.Equal(t, core.NodeSucceeded, node.Status)
+		require.Len(t, node.SubRuns, 3)
+
+		value, ok := node.OutputVariables.Load("RESULTS")
+		require.True(t, ok)
+		results := value.(string)
+		require.Contains(t, results, `"succeeded": 3`)
+		require.Contains(t, results, `"failed": 0`)
 	})
 }
 

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1688,11 +1688,22 @@ func (h *Handler) bootstrapMissingSubAttempt(
 		return nil, false, nil
 	}
 
-	if _, err := h.dagRunStore.FindAttempt(ctx, rootRef); err != nil {
+	rootAttempt, err := h.dagRunStore.FindAttempt(ctx, rootRef)
+	if err != nil {
 		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("find root attempt: %w", err)
+	}
+	rootStatus, err := rootAttempt.ReadStatus(ctx)
+	if err != nil {
+		if errors.Is(err, exec.ErrNoStatusData) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read root status: %w", err)
+	}
+	if rootStatus == nil || isTerminalRunStatus(rootStatus.Status) {
+		return nil, false, nil
 	}
 
 	attempt, err := h.dagRunStore.CreateSubAttempt(ctx, rootRef, runStatus.DAGRunID)
@@ -1731,11 +1742,14 @@ func remoteWorkerIDForBootstrap(runStatus *exec.DAGRunStatus, fallbackWorkerID s
 	if runStatus == nil {
 		return "", false
 	}
-	if exec.IsRemoteWorkerID(runStatus.WorkerID) {
-		return runStatus.WorkerID, true
-	}
 	if runStatus.WorkerID != "" {
-		return "", false
+		if !exec.IsRemoteWorkerID(runStatus.WorkerID) {
+			return "", false
+		}
+		if fallbackWorkerID != "" && fallbackWorkerID != runStatus.WorkerID {
+			return "", false
+		}
+		return runStatus.WorkerID, true
 	}
 	if !exec.IsRemoteWorkerID(fallbackWorkerID) {
 		return "", false

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1602,6 +1602,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 			return nil, status.Error(codes.Internal, "failed to bootstrap sub-attempt: "+bootstrapErr.Error())
 		}
 		if bootstrapped {
+			h.transformLogPaths(dagRunStatus)
 			if err := h.transformArtifactPaths(ctx, bootstrappedAttempt, nil, dagRunStatus); err != nil {
 				return nil, status.Error(codes.Internal, "failed to resolve artifact path: "+err.Error())
 			}

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1597,6 +1597,26 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 
 	latestAttempt, latestStatus, err := h.resolveLatestAttempt(ctx, dagRunStatus.Name, dagRunStatus.DAGRunID, dagRunStatus.Root)
 	if err != nil {
+		bootstrappedAttempt, bootstrapped, bootstrapErr := h.bootstrapMissingSubAttempt(ctx, req.WorkerId, dagRunStatus, err)
+		if bootstrapErr != nil {
+			return nil, status.Error(codes.Internal, "failed to bootstrap sub-attempt: "+bootstrapErr.Error())
+		}
+		if bootstrapped {
+			if err := h.transformArtifactPaths(ctx, bootstrappedAttempt, nil, dagRunStatus); err != nil {
+				return nil, status.Error(codes.Internal, "failed to resolve artifact path: "+err.Error())
+			}
+			if err := bootstrappedAttempt.Write(ctx, *dagRunStatus); err != nil {
+				return nil, status.Error(codes.Internal, "failed to write status: "+err.Error())
+			}
+
+			h.persistChatMessages(ctx, bootstrappedAttempt, dagRunStatus)
+
+			ownership := h.distributedAttempts()
+			ownership.syncFromStatus(ctx, req.WorkerId, dagRunStatus, bootstrappedAttempt.ID())
+			h.finalizeAdmissionForStatus(ctx, dagRunStatus, bootstrappedAttempt.ID())
+
+			return &coordinatorv1.ReportStatusResponse{Accepted: true}, nil
+		}
 		if errors.Is(err, exec.ErrDAGRunIDNotFound) || errors.Is(err, exec.ErrNoStatusData) {
 			logRejectedRemoteStatusUpdate(ctx, req.WorkerId, dagRunStatus, nil, remoteAttemptRejectedLeaseInactive)
 			return &coordinatorv1.ReportStatusResponse{
@@ -1643,6 +1663,84 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	// the agent may push the same terminal status multiple times from different
 	// code paths. Attempts are cleaned up during coordinator shutdown.
 	return &coordinatorv1.ReportStatusResponse{Accepted: true}, nil
+}
+
+func (h *Handler) bootstrapMissingSubAttempt(
+	ctx context.Context,
+	workerID string,
+	runStatus *exec.DAGRunStatus,
+	resolveErr error,
+) (exec.DAGRunAttempt, bool, error) {
+	if !errors.Is(resolveErr, exec.ErrDAGRunIDNotFound) || runStatus == nil {
+		return nil, false, nil
+	}
+
+	rootRef := runStatus.Root
+	if rootRef.ID == "" || rootRef.Name == "" || rootRef.ID == runStatus.DAGRunID {
+		return nil, false, nil
+	}
+	if runStatus.Name == "" || runStatus.DAGRunID == "" {
+		return nil, false, nil
+	}
+
+	reportingWorkerID, ok := remoteWorkerIDForBootstrap(runStatus, workerID)
+	if !ok {
+		return nil, false, nil
+	}
+
+	if _, err := h.dagRunStore.FindAttempt(ctx, rootRef); err != nil {
+		if errors.Is(err, exec.ErrDAGRunIDNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("find root attempt: %w", err)
+	}
+
+	attempt, err := h.dagRunStore.CreateSubAttempt(ctx, rootRef, runStatus.DAGRunID)
+	if err != nil {
+		return nil, false, fmt.Errorf("create sub-attempt: %w", err)
+	}
+	attempt.SetDAG(&core.DAG{Name: runStatus.Name})
+	if err := attempt.Open(ctx); err != nil {
+		return nil, false, fmt.Errorf("open sub-attempt: %w", err)
+	}
+
+	attemptID := runStatus.AttemptID
+	if attemptID == "" {
+		attemptID = attempt.ID()
+		runStatus.AttemptID = attemptID
+	}
+	runStatus.AttemptKey = exec.GenerateAttemptKey(
+		rootRef.Name,
+		rootRef.ID,
+		runStatus.Name,
+		runStatus.DAGRunID,
+		attemptID,
+	)
+	if runStatus.WorkerID == "" {
+		runStatus.WorkerID = reportingWorkerID
+	}
+
+	h.attemptsMu.Lock()
+	h.openAttempts[runStatus.DAGRunID] = attempt
+	h.attemptsMu.Unlock()
+
+	return attempt, true, nil
+}
+
+func remoteWorkerIDForBootstrap(runStatus *exec.DAGRunStatus, fallbackWorkerID string) (string, bool) {
+	if runStatus == nil {
+		return "", false
+	}
+	if exec.IsRemoteWorkerID(runStatus.WorkerID) {
+		return runStatus.WorkerID, true
+	}
+	if runStatus.WorkerID != "" {
+		return "", false
+	}
+	if !exec.IsRemoteWorkerID(fallbackWorkerID) {
+		return "", false
+	}
+	return fallbackWorkerID, true
 }
 
 func (h *Handler) sameAttemptCancellationRequested(

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -368,7 +368,11 @@ func (m *mockDAGRunAttempt) ReadStatus(_ context.Context) (*exec.DAGRunStatus, e
 	return &cloned, nil
 }
 func (m *mockDAGRunAttempt) ReadDAG(_ context.Context) (*core.DAG, error) { return m.dag, nil }
-func (m *mockDAGRunAttempt) SetDAG(_ *core.DAG)                           {}
+func (m *mockDAGRunAttempt) SetDAG(dag *core.DAG) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dag = dag
+}
 func (m *mockDAGRunAttempt) Abort(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2998,6 +3002,133 @@ func TestHandler_ReportStatus(t *testing.T) {
 
 		_, err = leaseStore.Get(ctx, "attempt-key-1")
 		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+	})
+
+	t.Run("BootstrapsMissingSubAttemptFromRemoteStatus", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		leaseStore := newTestDAGRunLeaseStore(baseDir)
+		activeStore := newTestActiveDistributedRunStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:               store,
+			DAGRunLeaseStore:          leaseStore,
+			ActiveDistributedRunStore: activeStore,
+			Owner:                     exec.CoordinatorEndpoint{ID: "coord-a", Host: "127.0.0.1", Port: 1234},
+		})
+		ctx := context.Background()
+
+		rootRef := exec.DAGRunRef{Name: "root-dag", ID: "root-run-123"}
+		store.addAttempt(rootRef, &exec.DAGRunStatus{
+			Name:     rootRef.Name,
+			DAGRunID: rootRef.ID,
+			Root:     rootRef,
+			Status:   core.Running,
+		})
+
+		runningProto, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:      "child-dag",
+			DAGRunID:  "child-run-123",
+			Root:      rootRef,
+			AttemptID: "child-attempt-1",
+			ProcGroup: "child-queue",
+			Status:    core.Running,
+			WorkerID:  "worker-1",
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:             runningProto,
+			WorkerId:           "worker-1",
+			OwnerCoordinatorId: "coord-a",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.Accepted)
+
+		attempt, err := store.FindSubAttempt(ctx, rootRef, "child-run-123")
+		require.NoError(t, err)
+		current, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+
+		attemptKey := exec.GenerateAttemptKey(rootRef.Name, rootRef.ID, "child-dag", "child-run-123", "child-attempt-1")
+		assert.Equal(t, "child-dag", current.Name)
+		assert.Equal(t, "child-run-123", current.DAGRunID)
+		assert.Equal(t, rootRef, current.Root)
+		assert.Equal(t, "child-attempt-1", current.AttemptID)
+		assert.Equal(t, attemptKey, current.AttemptKey)
+		assert.Equal(t, core.Running, current.Status)
+		assert.Equal(t, "worker-1", current.WorkerID)
+
+		lease, err := leaseStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.Equal(t, "child-attempt-1", lease.AttemptID)
+		assert.Equal(t, "child-queue", lease.QueueName)
+		assert.Equal(t, "worker-1", lease.WorkerID)
+		assert.Equal(t, "coord-a", lease.Owner.ID)
+
+		record, err := activeStore.Get(ctx, attemptKey)
+		require.NoError(t, err)
+		assert.Equal(t, "child-attempt-1", record.AttemptID)
+		assert.Equal(t, "worker-1", record.WorkerID)
+		assert.Equal(t, core.Running, record.Status)
+
+		succeededProto, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:       "child-dag",
+			DAGRunID:   "child-run-123",
+			Root:       rootRef,
+			AttemptID:  "child-attempt-1",
+			AttemptKey: attemptKey,
+			Status:     core.Succeeded,
+			WorkerID:   "worker-1",
+		})
+		require.NoError(t, convErr)
+
+		resp, err = h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:             succeededProto,
+			WorkerId:           "worker-1",
+			OwnerCoordinatorId: "coord-a",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.Accepted)
+
+		_, err = leaseStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrDAGRunLeaseNotFound)
+
+		_, err = activeStore.Get(ctx, attemptKey)
+		assert.ErrorIs(t, err, exec.ErrActiveRunNotFound)
+	})
+
+	t.Run("DoesNotBootstrapMissingSubAttemptWithoutRootAttempt", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunStore: store})
+		ctx := context.Background()
+
+		rootRef := exec.DAGRunRef{Name: "root-dag", ID: "missing-root-run"}
+		protoStatus, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:     "child-dag",
+			DAGRunID: "child-run-123",
+			Root:     rootRef,
+			Status:   core.Running,
+			WorkerID: "worker-1",
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:   protoStatus,
+			WorkerId: "worker-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.Accepted)
+		assert.Equal(t, remoteAttemptRejectedLeaseInactive, resp.Error)
+
+		_, err = store.FindSubAttempt(ctx, rootRef, "child-run-123")
+		assert.ErrorIs(t, err, exec.ErrDAGRunIDNotFound)
 	})
 
 	t.Run("AcceptsCancelledTerminalStatusAfterLeaseFailure", func(t *testing.T) {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -3101,6 +3101,67 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.ErrorIs(t, err, exec.ErrActiveRunNotFound)
 	})
 
+	t.Run("BootstrapsMissingSubAttemptRecomputesLogPathsAfterAttemptID", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		baseDir := filepath.Join(t.TempDir(), "distributed")
+		logDir := filepath.Join(t.TempDir(), "logs")
+		leaseStore := newTestDAGRunLeaseStore(baseDir)
+		h := NewHandler(HandlerConfig{
+			DAGRunStore:      store,
+			DAGRunLeaseStore: leaseStore,
+			LogDir:           logDir,
+			Owner:            exec.CoordinatorEndpoint{ID: "coord-a"},
+		})
+		ctx := context.Background()
+
+		rootRef := exec.DAGRunRef{Name: "root-dag", ID: "root-run-123"}
+		store.addAttempt(rootRef, &exec.DAGRunStatus{
+			Name:     rootRef.Name,
+			DAGRunID: rootRef.ID,
+			Root:     rootRef,
+			Status:   core.Running,
+		})
+
+		runningProto, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:      "child-dag",
+			DAGRunID:  "child-run-123",
+			Root:      rootRef,
+			ProcGroup: "child-queue",
+			Status:    core.Running,
+			WorkerID:  "worker-1",
+			Nodes: []*exec.Node{
+				{
+					Step:   core.Step{Name: "child-step"},
+					Status: core.NodeRunning,
+				},
+			},
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:             runningProto,
+			WorkerId:           "worker-1",
+			OwnerCoordinatorId: "coord-a",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.Accepted)
+
+		attempt, err := store.FindSubAttempt(ctx, rootRef, "child-run-123")
+		require.NoError(t, err)
+		current, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-attempt", current.AttemptID)
+		expectedDir := filepath.Join(logDir, "root-dag", "root-run-123", "test-attempt")
+		assert.Equal(t, filepath.Join(expectedDir, "scheduler.log"), current.Log)
+		require.Len(t, current.Nodes, 1)
+		assert.Equal(t, filepath.Join(expectedDir, "child-step.stdout.log"), current.Nodes[0].Stdout)
+		assert.Equal(t, filepath.Join(expectedDir, "child-step.stderr.log"), current.Nodes[0].Stderr)
+	})
+
 	t.Run("DoesNotBootstrapMissingSubAttemptWithoutRootAttempt", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -3131,6 +3131,80 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.ErrorIs(t, err, exec.ErrDAGRunIDNotFound)
 	})
 
+	t.Run("DoesNotBootstrapMissingSubAttemptUnderTerminalRoot", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunStore: store})
+		ctx := context.Background()
+
+		rootRef := exec.DAGRunRef{Name: "root-dag", ID: "root-run-123"}
+		store.addAttempt(rootRef, &exec.DAGRunStatus{
+			Name:     rootRef.Name,
+			DAGRunID: rootRef.ID,
+			Root:     rootRef,
+			Status:   core.Succeeded,
+		})
+
+		protoStatus, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:     "child-dag",
+			DAGRunID: "child-run-123",
+			Root:     rootRef,
+			Status:   core.Running,
+			WorkerID: "worker-1",
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:   protoStatus,
+			WorkerId: "worker-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.Accepted)
+		assert.Equal(t, remoteAttemptRejectedLeaseInactive, resp.Error)
+
+		_, err = store.FindSubAttempt(ctx, rootRef, "child-run-123")
+		assert.ErrorIs(t, err, exec.ErrDAGRunIDNotFound)
+	})
+
+	t.Run("DoesNotBootstrapMissingSubAttemptWithMismatchedWorkerID", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunStore: store})
+		ctx := context.Background()
+
+		rootRef := exec.DAGRunRef{Name: "root-dag", ID: "root-run-123"}
+		store.addAttempt(rootRef, &exec.DAGRunStatus{
+			Name:     rootRef.Name,
+			DAGRunID: rootRef.ID,
+			Root:     rootRef,
+			Status:   core.Running,
+		})
+
+		protoStatus, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:     "child-dag",
+			DAGRunID: "child-run-123",
+			Root:     rootRef,
+			Status:   core.Running,
+			WorkerID: "worker-1",
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:   protoStatus,
+			WorkerId: "worker-2",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.Accepted)
+		assert.Equal(t, remoteAttemptRejectedLeaseInactive, resp.Error)
+
+		_, err = store.FindSubAttempt(ctx, rootRef, "child-run-123")
+		assert.ErrorIs(t, err, exec.ErrDAGRunIDNotFound)
+	})
+
 	t.Run("AcceptsCancelledTerminalStatusAfterLeaseFailure", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -908,10 +908,15 @@ steps:
 }
 
 func TestApproveDAGRunStepResumeRefreshesProcessIdentity(t *testing.T) {
+	const (
+		procHeartbeatInterval = 150 * time.Millisecond
+		procStaleThreshold    = 2 * time.Second
+	)
+
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
-		cfg.Proc.HeartbeatInterval = 50 * time.Millisecond
-		cfg.Proc.HeartbeatSyncInterval = 50 * time.Millisecond
-		cfg.Proc.StaleThreshold = 300 * time.Millisecond
+		cfg.Proc.HeartbeatInterval = procHeartbeatInterval
+		cfg.Proc.HeartbeatSyncInterval = procHeartbeatInterval
+		cfg.Proc.StaleThreshold = procStaleThreshold
 	}))
 	release := newHoldFile(t)
 
@@ -959,11 +964,12 @@ steps:
 	})
 	require.NotEqual(t, waitingStatus.PID, runningStatus.PID)
 	require.NotEqual(t, waitingStatus.PIDStartedAt, runningStatus.PIDStartedAt)
-	alive, err := server.ProcStore.IsAttemptAlive(server.Context, dagName, runningStatus.DAGRun(), runningStatus.AttemptID)
-	require.NoError(t, err)
-	require.True(t, alive)
+	require.Eventually(t, func() bool {
+		alive, err := server.ProcStore.IsAttemptAlive(server.Context, dagName, runningStatus.DAGRun(), runningStatus.AttemptID)
+		return err == nil && alive
+	}, dagRunEventuallyTimeout(5*time.Second), 100*time.Millisecond)
 
-	time.Sleep(900 * time.Millisecond)
+	time.Sleep(procStaleThreshold + time.Second)
 
 	resp := server.Client().Get(fmt.Sprintf("/api/v1/dag-runs/%s/%s", dagName, startBody.DagRunId)).
 		ExpectStatus(http.StatusOK).


### PR DESCRIPTION
## Summary
- bootstrap missing sub-DAG attempts when a remote worker reports the first status before the coordinator has a child attempt record
- preserve the worker-reported attempt identity so later status reports do not get rejected as superseded
- add coordinator and distributed integration coverage for remote worker local sub-DAG execution

## Root cause
A local sub-DAG started inside a remote worker inherited the remote status pusher, but the coordinator had no sub-attempt or lease record for that child run. The first status report was rejected as stale.

## Testing
- go test ./internal/service/coordinator -count=1
- go test ./internal/intg/distr -run TestParallel_ -count=1

Closes #2344

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps missing sub-attempts when the first status arrives from a remote worker and enforces worker ownership to prevent dropped reports. Refreshes sub-attempt log and artifact paths after bootstrap so logs land in the right files.

- **Bug Fixes**
  - In `ReportStatus`, auto-create the sub-attempt when the child run is unknown but the root is active; set AttemptID/AttemptKey/WorkerID/DAG, recompute log and artifact paths, write status, and initialize lease/ownership.
  - Enforce bootstrap ownership: only accept reports from remote worker IDs and require the status `WorkerID` to match the request; skip bootstrapping if the root attempt is missing or terminal.
  - Tests: unit tests for bootstrap accept/reject (mismatched worker, missing/terminal root, log path recompute), an integration test for distributed parent with forced-local children, and stabilized approval-resume liveness by tuning heartbeats and using eventual assertions.

<sup>Written for commit 47e3f53c168d64931a4c1a5fee2d2faa6e59168a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote status updates can now bootstrap a missing sub-attempt when the related root run exists, allowing distributed child runs to be accepted and tracked automatically.
  * Added support for parallel runs to succeed when a child run is explicitly configured to stay local, even from a distributed worker.

* **Bug Fixes**
  * Improved handling of status reporting for missing sub-runs, including better acceptance and rejection behavior in edge cases.
  * Distributed run tracking now more reliably records run state, ownership, and results for bootstrapped sub-attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->