### PR TITLE
test: implement MCP change conformance

### DIFF
--- a/conformance/spec022_mcp_change_tool/change_apply_test.go
+++ b/conformance/spec022_mcp_change_tool/change_apply_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec022_mcp_change_tool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeApplyCreatesDAG(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_apply_create"
+	spec := fixtureSpec(t, "valid_initial.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	result := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, spec))
+	output := requireChangeSuccess(t, result, "DAG change applied.", dagURI)
+	require.Equal(t, "apply", requireString(t, output, "mode"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.True(t, requireBool(t, output, "applied"))
+	require.True(t, requireBool(t, output, "created"))
+	require.False(t, requireBool(t, output, "updated"))
+	require.Empty(t, requireArray(t, output, "errors"))
+	require.Contains(t, output, "dag")
+
+	require.Equal(t, spec, requireReadDAGSpec(t, fixture.session, dagName))
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangeApplyUpdatesExistingDAG(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_apply_update"
+	initialSpec := fixtureSpec(t, "valid_initial.yaml")
+	updatedSpec := fixtureSpec(t, "valid_updated.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	createResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, initialSpec))
+	createOutput := requireChangeSuccess(t, createResult, "DAG change applied.", dagURI)
+	require.True(t, requireBool(t, createOutput, "created"))
+	require.False(t, requireBool(t, createOutput, "updated"))
+
+	updateResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, updatedSpec))
+	updateOutput := requireChangeSuccess(t, updateResult, "DAG change applied.", dagURI)
+	require.Equal(t, "apply", requireString(t, updateOutput, "mode"))
+	require.Equal(t, dagName, requireString(t, updateOutput, "dagName"))
+	require.True(t, requireBool(t, updateOutput, "valid"))
+	require.True(t, requireBool(t, updateOutput, "applied"))
+	require.False(t, requireBool(t, updateOutput, "created"))
+	require.True(t, requireBool(t, updateOutput, "updated"))
+	require.Contains(t, updateOutput, "dag")
+
+	require.Equal(t, updatedSpec, requireReadDAGSpec(t, fixture.session, dagName))
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangeApplyInvalidDoesNotOverwriteExistingDAG(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_apply_invalid"
+	initialSpec := fixtureSpec(t, "valid_initial.yaml")
+	invalidSpec := fixtureSpec(t, "invalid_malformed_yaml.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	createResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, initialSpec))
+	createOutput := requireChangeSuccess(t, createResult, "DAG change applied.", dagURI)
+	require.True(t, requireBool(t, createOutput, "created"))
+
+	invalidResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, invalidSpec))
+	invalidOutput := requireChangeSuccess(t, invalidResult, "DAG spec is not valid; no changes were applied.", dagURI)
+	require.Equal(t, "apply", requireString(t, invalidOutput, "mode"))
+	require.False(t, requireBool(t, invalidOutput, "valid"))
+	require.False(t, requireBool(t, invalidOutput, "applied"))
+	require.NotEmpty(t, requireArray(t, invalidOutput, "errors"))
+	require.NotContains(t, invalidOutput, "created")
+	require.NotContains(t, invalidOutput, "updated")
+
+	require.Equal(t, initialSpec, requireReadDAGSpec(t, fixture.session, dagName))
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangeApplyAffectsOnlyNamedDAG(t *testing.T) {
+	fixture := newChangeFixture(t)
+	targetName := "mcp_change_apply_target"
+	otherName := "mcp_change_apply_other"
+	targetSpec := fixtureSpec(t, "valid_initial.yaml")
+	otherSpec := fixtureSpec(t, "valid_updated.yaml")
+	dagURI := "dagu://dags/" + targetName + "/spec"
+	fixture.server.CreateDAG(t, otherName, otherSpec)
+
+	result := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", targetName, targetSpec))
+	output := requireChangeSuccess(t, result, "DAG change applied.", dagURI)
+	require.Equal(t, "apply", requireString(t, output, "mode"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.True(t, requireBool(t, output, "applied"))
+	require.True(t, requireBool(t, output, "created"))
+	require.False(t, requireBool(t, output, "updated"))
+	require.Contains(t, output, "dag")
+
+	require.Equal(t, targetSpec, requireReadDAGSpec(t, fixture.session, targetName))
+	require.Equal(t, otherSpec, requireReadDAGSpec(t, fixture.session, otherName))
+	requireNoDAGRuns(t, fixture.session, targetName)
+	requireNoDAGRuns(t, fixture.session, otherName)
+}

--- a/conformance/spec022_mcp_change_tool/change_apply_test.go
+++ b/conformance/spec022_mcp_change_tool/change_apply_test.go
@@ -13,7 +13,7 @@ func TestChangeApplyCreatesDAG(t *testing.T) {
 	fixture := newChangeFixture(t)
 	dagName := "mcp_change_apply_create"
 	spec := fixtureSpec(t, "valid_initial.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	result := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, spec))
 	output := requireChangeSuccess(t, result, "DAG change applied.", dagURI)
@@ -35,7 +35,7 @@ func TestChangeApplyUpdatesExistingDAG(t *testing.T) {
 	dagName := "mcp_change_apply_update"
 	initialSpec := fixtureSpec(t, "valid_initial.yaml")
 	updatedSpec := fixtureSpec(t, "valid_updated.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	createResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, initialSpec))
 	createOutput := requireChangeSuccess(t, createResult, "DAG change applied.", dagURI)
@@ -61,7 +61,7 @@ func TestChangeApplyInvalidDoesNotOverwriteExistingDAG(t *testing.T) {
 	dagName := "mcp_change_apply_invalid"
 	initialSpec := fixtureSpec(t, "valid_initial.yaml")
 	invalidSpec := fixtureSpec(t, "invalid_malformed_yaml.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	createResult := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", dagName, initialSpec))
 	createOutput := requireChangeSuccess(t, createResult, "DAG change applied.", dagURI)
@@ -86,7 +86,7 @@ func TestChangeApplyAffectsOnlyNamedDAG(t *testing.T) {
 	otherName := "mcp_change_apply_other"
 	targetSpec := fixtureSpec(t, "valid_initial.yaml")
 	otherSpec := fixtureSpec(t, "valid_updated.yaml")
-	dagURI := "dagu://dags/" + targetName + "/spec"
+	dagURI := changeDAGSpecURI(targetName)
 	fixture.server.CreateDAG(t, otherName, otherSpec)
 
 	result := callChange(t, fixture.session, changeArguments("apply", "upsert_dag", targetName, targetSpec))

--- a/conformance/spec022_mcp_change_tool/change_errors_test.go
+++ b/conformance/spec022_mcp_change_tool/change_errors_test.go
@@ -112,7 +112,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			code:    "invalid_tool_input",
 			field:   "spec",
 			dagName: "mcp_change_error_missing_spec",
-			dagURI:  "dagu://dags/mcp_change_error_missing_spec/spec",
+			dagURI:  changeDAGSpecURI("mcp_change_error_missing_spec"),
 		},
 		{
 			name: "null spec",
@@ -123,7 +123,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			code:    "invalid_tool_input",
 			field:   "spec",
 			dagName: "mcp_change_error_null_spec",
-			dagURI:  "dagu://dags/mcp_change_error_null_spec/spec",
+			dagURI:  changeDAGSpecURI("mcp_change_error_null_spec"),
 		},
 		{
 			name: "empty spec",
@@ -134,7 +134,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			code:    "invalid_tool_input",
 			field:   "spec",
 			dagName: "mcp_change_error_empty_spec",
-			dagURI:  "dagu://dags/mcp_change_error_empty_spec/spec",
+			dagURI:  changeDAGSpecURI("mcp_change_error_empty_spec"),
 		},
 		{
 			name: "unsupported mode",
@@ -147,7 +147,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			field:   "mode",
 			mode:    "write",
 			dagName: "mcp_change_error_mode",
-			dagURI:  "dagu://dags/mcp_change_error_mode/spec",
+			dagURI:  changeDAGSpecURI("mcp_change_error_mode"),
 		},
 		{
 			name: "case-sensitive unsupported mode",
@@ -160,7 +160,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			field:   "mode",
 			mode:    "Preview",
 			dagName: "mcp_change_error_mode_case",
-			dagURI:  "dagu://dags/mcp_change_error_mode_case/spec",
+			dagURI:  changeDAGSpecURI("mcp_change_error_mode_case"),
 		},
 		{
 			name: "unsupported type",
@@ -173,7 +173,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			field:      "type",
 			changeType: "delete_dag",
 			dagName:    "mcp_change_error_type",
-			dagURI:     "dagu://dags/mcp_change_error_type/spec",
+			dagURI:     changeDAGSpecURI("mcp_change_error_type"),
 		},
 		{
 			name: "case-sensitive unsupported type",
@@ -186,7 +186,7 @@ func TestChangeInputValidationErrors(t *testing.T) {
 			field:      "type",
 			changeType: "UPSERT_DAG",
 			dagName:    "mcp_change_error_type_case",
-			dagURI:     "dagu://dags/mcp_change_error_type_case/spec",
+			dagURI:     changeDAGSpecURI("mcp_change_error_type_case"),
 		},
 	}
 
@@ -237,5 +237,5 @@ func TestChangeAuthenticationErrors(t *testing.T) {
 	require.Equal(t, "apply", output["mode"])
 	require.Equal(t, "upsert_dag", output["type"])
 	require.Equal(t, "mcp_change_auth_denied", output["dagName"])
-	require.Equal(t, "dagu://dags/mcp_change_auth_denied/spec", output["dagUri"])
+	require.Equal(t, changeDAGSpecURI("mcp_change_auth_denied"), output["dagUri"])
 }

--- a/conformance/spec022_mcp_change_tool/change_errors_test.go
+++ b/conformance/spec022_mcp_change_tool/change_errors_test.go
@@ -1,0 +1,241 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec022_mcp_change_tool_test
+
+import (
+	"testing"
+
+	api "github.com/dagucloud/dagu/api/v1"
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeInputValidationErrors(t *testing.T) {
+	fixture := newChangeFixture(t)
+	validSpec := fixtureSpec(t, "valid_initial.yaml")
+
+	tests := []struct {
+		name       string
+		arguments  any
+		code       string
+		field      string
+		mode       string
+		changeType string
+		dagName    string
+		dagURI     string
+	}{
+		{
+			name:      "non-object input",
+			arguments: []any{"not", "object"},
+			code:      "invalid_tool_input",
+		},
+		{
+			name: "unknown field",
+			arguments: map[string]any{
+				"name":  "mcp_change_error_unknown",
+				"spec":  validSpec,
+				"extra": "value",
+			},
+			code:  "invalid_tool_input",
+			field: "extra",
+		},
+		{
+			name: "non-string mode",
+			arguments: map[string]any{
+				"mode": 123,
+				"name": "mcp_change_error_mode_type",
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "mode",
+		},
+		{
+			name: "non-string type",
+			arguments: map[string]any{
+				"type": 123,
+				"name": "mcp_change_error_type_type",
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "type",
+		},
+		{
+			name: "non-string name",
+			arguments: map[string]any{
+				"name": 123,
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "name",
+		},
+		{
+			name: "non-string spec",
+			arguments: map[string]any{
+				"name": "mcp_change_error_spec_type",
+				"spec": 123,
+			},
+			code:  "invalid_tool_input",
+			field: "spec",
+		},
+		{
+			name: "missing name",
+			arguments: map[string]any{
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "name",
+		},
+		{
+			name: "null name",
+			arguments: map[string]any{
+				"name": nil,
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "name",
+		},
+		{
+			name: "empty name",
+			arguments: map[string]any{
+				"name": "   ",
+				"spec": validSpec,
+			},
+			code:  "invalid_tool_input",
+			field: "name",
+		},
+		{
+			name: "missing spec",
+			arguments: map[string]any{
+				"name": "mcp_change_error_missing_spec",
+			},
+			code:    "invalid_tool_input",
+			field:   "spec",
+			dagName: "mcp_change_error_missing_spec",
+			dagURI:  "dagu://dags/mcp_change_error_missing_spec/spec",
+		},
+		{
+			name: "null spec",
+			arguments: map[string]any{
+				"name": "mcp_change_error_null_spec",
+				"spec": nil,
+			},
+			code:    "invalid_tool_input",
+			field:   "spec",
+			dagName: "mcp_change_error_null_spec",
+			dagURI:  "dagu://dags/mcp_change_error_null_spec/spec",
+		},
+		{
+			name: "empty spec",
+			arguments: map[string]any{
+				"name": "mcp_change_error_empty_spec",
+				"spec": "   ",
+			},
+			code:    "invalid_tool_input",
+			field:   "spec",
+			dagName: "mcp_change_error_empty_spec",
+			dagURI:  "dagu://dags/mcp_change_error_empty_spec/spec",
+		},
+		{
+			name: "unsupported mode",
+			arguments: map[string]any{
+				"mode": "write",
+				"name": "mcp_change_error_mode",
+				"spec": validSpec,
+			},
+			code:    "unsupported_change_mode",
+			field:   "mode",
+			mode:    "write",
+			dagName: "mcp_change_error_mode",
+			dagURI:  "dagu://dags/mcp_change_error_mode/spec",
+		},
+		{
+			name: "case-sensitive unsupported mode",
+			arguments: map[string]any{
+				"mode": "Preview",
+				"name": "mcp_change_error_mode_case",
+				"spec": validSpec,
+			},
+			code:    "unsupported_change_mode",
+			field:   "mode",
+			mode:    "Preview",
+			dagName: "mcp_change_error_mode_case",
+			dagURI:  "dagu://dags/mcp_change_error_mode_case/spec",
+		},
+		{
+			name: "unsupported type",
+			arguments: map[string]any{
+				"type": "delete_dag",
+				"name": "mcp_change_error_type",
+				"spec": validSpec,
+			},
+			code:       "unsupported_change_type",
+			field:      "type",
+			changeType: "delete_dag",
+			dagName:    "mcp_change_error_type",
+			dagURI:     "dagu://dags/mcp_change_error_type/spec",
+		},
+		{
+			name: "case-sensitive unsupported type",
+			arguments: map[string]any{
+				"type": "UPSERT_DAG",
+				"name": "mcp_change_error_type_case",
+				"spec": validSpec,
+			},
+			code:       "unsupported_change_type",
+			field:      "type",
+			changeType: "UPSERT_DAG",
+			dagName:    "mcp_change_error_type_case",
+			dagURI:     "dagu://dags/mcp_change_error_type_case/spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callChange(t, fixture.session, tt.arguments)
+			output := requireChangeError(t, result, tt.code)
+			if tt.field == "" {
+				require.NotContains(t, output, "field")
+			} else {
+				require.Equal(t, tt.field, output["field"])
+			}
+			if tt.mode != "" {
+				require.Equal(t, tt.mode, output["mode"])
+			}
+			if tt.changeType != "" {
+				require.Equal(t, tt.changeType, output["type"])
+			}
+			if tt.dagName != "" {
+				require.Equal(t, tt.dagName, output["dagName"])
+			}
+			if tt.dagURI != "" {
+				require.Equal(t, tt.dagURI, output["dagUri"])
+			}
+		})
+	}
+}
+
+func TestChangeAuthenticationErrors(t *testing.T) {
+	server := mcptest.NewAuthServer(t)
+	rejected, err := server.TryConnect(t, "")
+	if rejected != nil {
+		t.Cleanup(func() { _ = rejected.Close() })
+	}
+	require.Error(t, err)
+
+	restOnlyKey := server.CreateAPIKey(t, "rest-only", api.CreateAPIKeyRequestAllowedSurfacesRestApi)
+	rejected, err = server.TryConnect(t, restOnlyKey)
+	if rejected != nil {
+		t.Cleanup(func() { _ = rejected.Close() })
+	}
+	require.Error(t, err)
+
+	mcpKey := server.CreateAPIKey(t, "mcp-viewer", api.CreateAPIKeyRequestAllowedSurfacesMcp)
+	session := server.Connect(t, mcpKey)
+	result := callChange(t, session, changeArguments("apply", "upsert_dag", "mcp_change_auth_denied", fixtureSpec(t, "valid_initial.yaml")))
+	output := requireChangeError(t, result, "unauthorized")
+	require.Equal(t, "apply", output["mode"])
+	require.Equal(t, "upsert_dag", output["type"])
+	require.Equal(t, "mcp_change_auth_denied", output["dagName"])
+	require.Equal(t, "dagu://dags/mcp_change_auth_denied/spec", output["dagUri"])
+}

--- a/conformance/spec022_mcp_change_tool/change_helpers_test.go
+++ b/conformance/spec022_mcp_change_tool/change_helpers_test.go
@@ -158,6 +158,10 @@ func changeArguments(mode, changeType, name, spec string) map[string]any {
 	}
 }
 
+func changeDAGSpecURI(name string) string {
+	return "dagu://dags/" + url.PathEscape(name) + "/spec"
+}
+
 func requireString(t *testing.T, data map[string]any, key string) string {
 	t.Helper()
 

--- a/conformance/spec022_mcp_change_tool/change_helpers_test.go
+++ b/conformance/spec022_mcp_change_tool/change_helpers_test.go
@@ -1,0 +1,232 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec022_mcp_change_tool_test
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+type changeFixture struct {
+	server  *mcptest.Server
+	session *mcpsdk.ClientSession
+}
+
+func newChangeFixture(t *testing.T) changeFixture {
+	t.Helper()
+
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+	return changeFixture{
+		server:  server,
+		session: session,
+	}
+}
+
+func fixtureSpec(t *testing.T, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func callChange(t *testing.T, session *mcpsdk.ClientSession, arguments any) *mcpsdk.CallToolResult {
+	t.Helper()
+
+	ctx := mcptest.Context(t)
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "dagu_change",
+		Arguments: arguments,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func callRead(t *testing.T, session *mcpsdk.ClientSession, arguments map[string]any) *mcpsdk.CallToolResult {
+	t.Helper()
+
+	ctx := mcptest.Context(t)
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "dagu_read",
+		Arguments: arguments,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func requireChangeSuccess(t *testing.T, result *mcpsdk.CallToolResult, text, dagURI string) map[string]any {
+	t.Helper()
+
+	require.False(t, result.IsError)
+	require.Len(t, result.Content, 2)
+
+	contentText, ok := result.Content[0].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	require.Equal(t, text, contentText.Text)
+
+	link, ok := result.Content[1].(*mcpsdk.ResourceLink)
+	require.True(t, ok)
+	requireURIEqual(t, dagURI, link.URI)
+	require.Equal(t, "dag_spec", link.Name)
+	require.Equal(t, "application/yaml", link.MIMEType)
+
+	output := mcptest.StructuredMap(t, result)
+	require.Equal(t, "upsert_dag", requireString(t, output, "type"))
+	require.Equal(t, dagURI, requireString(t, output, "dagUri"))
+	requireBool(t, output, "valid")
+	requireArray(t, output, "errors")
+	requireBool(t, output, "applied")
+	requireReferences(t, output["references"])
+	return output
+}
+
+func requireChangeError(t *testing.T, result *mcpsdk.CallToolResult, code string) map[string]any {
+	t.Helper()
+
+	require.True(t, result.IsError)
+	output := mcptest.StructuredMap(t, result)
+	require.Equal(t, code, output["code"])
+	require.NotEmpty(t, requireString(t, output, "message"))
+	for key := range output {
+		require.Contains(t, []string{"code", "message", "mode", "type", "dagName", "field", "dagUri", "details"}, key)
+	}
+	if details, ok := output["details"]; ok {
+		_, isObject := details.(map[string]any)
+		require.True(t, isObject)
+	}
+	return output
+}
+
+func requireReadDAGSpec(t *testing.T, session *mcpsdk.ClientSession, name string) string {
+	t.Helper()
+
+	result := callRead(t, session, map[string]any{
+		"target": "dag_spec",
+		"name":   name,
+	})
+	require.False(t, result.IsError)
+
+	output := mcptest.StructuredMap(t, result)
+	data, ok := output["data"].(map[string]any)
+	require.True(t, ok)
+	return requireString(t, data, "spec")
+}
+
+func requireDAGSpecNotFound(t *testing.T, session *mcpsdk.ClientSession, name string) {
+	t.Helper()
+
+	result := callRead(t, session, map[string]any{
+		"target": "dag_spec",
+		"name":   name,
+	})
+	require.True(t, result.IsError)
+	output := mcptest.StructuredMap(t, result)
+	require.Equal(t, "resource_not_found", output["code"])
+}
+
+func requireNoDAGRuns(t *testing.T, session *mcpsdk.ClientSession, name string) {
+	t.Helper()
+
+	result := callRead(t, session, map[string]any{
+		"target": "runs",
+		"query":  "name=" + url.QueryEscape(name),
+	})
+	require.False(t, result.IsError)
+
+	output := mcptest.StructuredMap(t, result)
+	data, ok := output["data"].(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, requireArray(t, data, "items"))
+}
+
+func changeArguments(mode, changeType, name, spec string) map[string]any {
+	return map[string]any{
+		"mode": mode,
+		"type": changeType,
+		"name": name,
+		"spec": spec,
+	}
+}
+
+func requireString(t *testing.T, data map[string]any, key string) string {
+	t.Helper()
+
+	value, ok := data[key].(string)
+	require.True(t, ok)
+	return value
+}
+
+func requireBool(t *testing.T, data map[string]any, key string) bool {
+	t.Helper()
+
+	value, ok := data[key].(bool)
+	require.True(t, ok)
+	return value
+}
+
+func requireArray(t *testing.T, data map[string]any, key string) []any {
+	t.Helper()
+
+	switch value := data[key].(type) {
+	case []any:
+		return value
+	case []string:
+		items := make([]any, 0, len(value))
+		for _, item := range value {
+			items = append(items, item)
+		}
+		return items
+	default:
+		require.Failf(t, "field is not an array", "%s has type %T", key, data[key])
+		return nil
+	}
+}
+
+func requireReferences(t *testing.T, raw any) {
+	t.Helper()
+
+	var got []string
+	switch values := raw.(type) {
+	case []any:
+		got = make([]string, 0, len(values))
+		for _, value := range values {
+			text, ok := value.(string)
+			require.True(t, ok)
+			got = append(got, text)
+		}
+	case []string:
+		got = values
+	default:
+		require.Failf(t, "references is not an array", "references has type %T", raw)
+	}
+
+	require.ElementsMatch(t, []string{
+		"dagu://reference/authoring",
+		"dagu://reference/tools",
+		"dagu://reference/notifications",
+	}, got)
+}
+
+func requireURIEqual(t *testing.T, expected, actual string) {
+	t.Helper()
+
+	expectedURI, err := url.Parse(expected)
+	require.NoError(t, err)
+	actualURI, err := url.Parse(actual)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedURI.Scheme, actualURI.Scheme)
+	require.Equal(t, expectedURI.Host, actualURI.Host)
+	require.Equal(t, expectedURI.EscapedPath(), actualURI.EscapedPath())
+	require.Equal(t, expectedURI.RawQuery, actualURI.RawQuery)
+}

--- a/conformance/spec022_mcp_change_tool/change_identity_test.go
+++ b/conformance/spec022_mcp_change_tool/change_identity_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec022_mcp_change_tool_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dagucloud/dagu/conformance/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeToolIdentityAndInputSchema(t *testing.T) {
+	server := mcptest.NewServer(t)
+	session := server.Connect(t, "")
+	ctx := mcptest.Context(t)
+
+	result, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	var tool *mcpsdk.Tool
+	for _, candidate := range result.Tools {
+		if candidate.Name == "dagu_change" {
+			tool = candidate
+			break
+		}
+	}
+	require.NotNil(t, tool)
+	require.NotNil(t, tool.Annotations)
+	require.NotNil(t, tool.Annotations.DestructiveHint)
+	require.True(t, *tool.Annotations.DestructiveHint)
+	require.NotNil(t, tool.Annotations.OpenWorldHint)
+	require.False(t, *tool.Annotations.OpenWorldHint)
+
+	schema := toolInputSchema(t, tool)
+	require.Equal(t, "object", schema["type"])
+	require.Equal(t, false, schema["additionalProperties"])
+	require.ElementsMatch(t, []any{"name", "spec"}, requireArray(t, schema, "required"))
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	for _, field := range []string{"mode", "type", "name", "spec"} {
+		property, ok := properties[field].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "string", property["type"])
+	}
+}
+
+func toolInputSchema(t *testing.T, tool *mcpsdk.Tool) map[string]any {
+	t.Helper()
+
+	data, err := json.Marshal(tool.InputSchema)
+	require.NoError(t, err)
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(data, &schema))
+	return schema
+}

--- a/conformance/spec022_mcp_change_tool/change_preview_test.go
+++ b/conformance/spec022_mcp_change_tool/change_preview_test.go
@@ -13,7 +13,7 @@ func TestChangePreviewValidDoesNotWrite(t *testing.T) {
 	fixture := newChangeFixture(t)
 	dagName := "mcp_change_preview_valid"
 	spec := fixtureSpec(t, "valid_initial.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	result := callChange(t, fixture.session, changeArguments("preview", "upsert_dag", dagName, spec))
 	output := requireChangeSuccess(t, result, "DAG spec is valid. Re-run with mode=apply to write it.", dagURI)
@@ -35,7 +35,7 @@ func TestChangePreviewExistingDAGDoesNotUpdate(t *testing.T) {
 	dagName := "mcp_change_preview_existing"
 	initialSpec := fixtureSpec(t, "valid_initial.yaml")
 	updatedSpec := fixtureSpec(t, "valid_updated.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 	fixture.server.CreateDAG(t, dagName, initialSpec)
 
 	result := callChange(t, fixture.session, changeArguments("preview", "upsert_dag", dagName, updatedSpec))
@@ -55,7 +55,7 @@ func TestChangePreviewInvalidReturnsValidationResult(t *testing.T) {
 	fixture := newChangeFixture(t)
 	dagName := "mcp_change_preview_invalid"
 	spec := fixtureSpec(t, "invalid_malformed_yaml.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	result := callChange(t, fixture.session, map[string]any{
 		"name": dagName,
@@ -79,7 +79,7 @@ func TestChangeDefaultsNullAndTrimmedFields(t *testing.T) {
 	fixture := newChangeFixture(t)
 	dagName := "mcp_change_defaults"
 	spec := fixtureSpec(t, "valid_initial.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	result := callChange(t, fixture.session, map[string]any{
 		"mode": nil,
@@ -102,7 +102,7 @@ func TestChangeTrimsModeTypeAndName(t *testing.T) {
 	fixture := newChangeFixture(t)
 	dagName := "mcp_change_trimmed_fields"
 	spec := fixtureSpec(t, "valid_initial.yaml")
-	dagURI := "dagu://dags/" + dagName + "/spec"
+	dagURI := changeDAGSpecURI(dagName)
 
 	result := callChange(t, fixture.session, map[string]any{
 		"mode": "  preview  ",

--- a/conformance/spec022_mcp_change_tool/change_preview_test.go
+++ b/conformance/spec022_mcp_change_tool/change_preview_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec022_mcp_change_tool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangePreviewValidDoesNotWrite(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_preview_valid"
+	spec := fixtureSpec(t, "valid_initial.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	result := callChange(t, fixture.session, changeArguments("preview", "upsert_dag", dagName, spec))
+	output := requireChangeSuccess(t, result, "DAG spec is valid. Re-run with mode=apply to write it.", dagURI)
+	require.Equal(t, "preview", requireString(t, output, "mode"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.False(t, requireBool(t, output, "applied"))
+	require.Empty(t, requireArray(t, output, "errors"))
+	require.Contains(t, output, "dag")
+	require.NotContains(t, output, "created")
+	require.NotContains(t, output, "updated")
+
+	requireDAGSpecNotFound(t, fixture.session, dagName)
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangePreviewExistingDAGDoesNotUpdate(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_preview_existing"
+	initialSpec := fixtureSpec(t, "valid_initial.yaml")
+	updatedSpec := fixtureSpec(t, "valid_updated.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+	fixture.server.CreateDAG(t, dagName, initialSpec)
+
+	result := callChange(t, fixture.session, changeArguments("preview", "upsert_dag", dagName, updatedSpec))
+	output := requireChangeSuccess(t, result, "DAG spec is valid. Re-run with mode=apply to write it.", dagURI)
+	require.Equal(t, "preview", requireString(t, output, "mode"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.False(t, requireBool(t, output, "applied"))
+	require.NotContains(t, output, "created")
+	require.NotContains(t, output, "updated")
+
+	require.Equal(t, initialSpec, requireReadDAGSpec(t, fixture.session, dagName))
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangePreviewInvalidReturnsValidationResult(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_preview_invalid"
+	spec := fixtureSpec(t, "invalid_malformed_yaml.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	result := callChange(t, fixture.session, map[string]any{
+		"name": dagName,
+		"spec": spec,
+	})
+	output := requireChangeSuccess(t, result, "DAG spec is not valid; no changes were applied.", dagURI)
+	require.Equal(t, "preview", requireString(t, output, "mode"))
+	require.Equal(t, "upsert_dag", requireString(t, output, "type"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.False(t, requireBool(t, output, "valid"))
+	require.False(t, requireBool(t, output, "applied"))
+	require.NotEmpty(t, requireArray(t, output, "errors"))
+	require.NotContains(t, output, "created")
+	require.NotContains(t, output, "updated")
+
+	requireDAGSpecNotFound(t, fixture.session, dagName)
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangeDefaultsNullAndTrimmedFields(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_defaults"
+	spec := fixtureSpec(t, "valid_initial.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	result := callChange(t, fixture.session, map[string]any{
+		"mode": nil,
+		"type": nil,
+		"name": "  " + dagName + "  ",
+		"spec": spec,
+	})
+	output := requireChangeSuccess(t, result, "DAG spec is valid. Re-run with mode=apply to write it.", dagURI)
+	require.Equal(t, "preview", requireString(t, output, "mode"))
+	require.Equal(t, "upsert_dag", requireString(t, output, "type"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.False(t, requireBool(t, output, "applied"))
+
+	requireDAGSpecNotFound(t, fixture.session, dagName)
+	requireNoDAGRuns(t, fixture.session, dagName)
+}
+
+func TestChangeTrimsModeTypeAndName(t *testing.T) {
+	fixture := newChangeFixture(t)
+	dagName := "mcp_change_trimmed_fields"
+	spec := fixtureSpec(t, "valid_initial.yaml")
+	dagURI := "dagu://dags/" + dagName + "/spec"
+
+	result := callChange(t, fixture.session, map[string]any{
+		"mode": "  preview  ",
+		"type": "  upsert_dag  ",
+		"name": "  " + dagName + "  ",
+		"spec": spec,
+	})
+	output := requireChangeSuccess(t, result, "DAG spec is valid. Re-run with mode=apply to write it.", dagURI)
+	require.Equal(t, "preview", requireString(t, output, "mode"))
+	require.Equal(t, "upsert_dag", requireString(t, output, "type"))
+	require.Equal(t, dagName, requireString(t, output, "dagName"))
+	require.True(t, requireBool(t, output, "valid"))
+	require.False(t, requireBool(t, output, "applied"))
+
+	requireDAGSpecNotFound(t, fixture.session, dagName)
+	requireNoDAGRuns(t, fixture.session, dagName)
+}

--- a/conformance/spec022_mcp_change_tool/testdata/invalid_malformed_yaml.yaml
+++ b/conformance/spec022_mcp_change_tool/testdata/invalid_malformed_yaml.yaml
@@ -1,0 +1,2 @@
+steps:
+  - name: [

--- a/conformance/spec022_mcp_change_tool/testdata/valid_initial.yaml
+++ b/conformance/spec022_mcp_change_tool/testdata/valid_initial.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: hello
+    run: echo initial

--- a/conformance/spec022_mcp_change_tool/testdata/valid_updated.yaml
+++ b/conformance/spec022_mcp_change_tool/testdata/valid_updated.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: hello
+    run: echo updated

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -1,0 +1,323 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	frontendapi "github.com/dagucloud/dagu/internal/service/frontend/api/v1"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	changeModePreview = "preview"
+	changeModeApply   = "apply"
+
+	changeTypeUpsertDAG = "upsert_dag"
+
+	changeErrorUnauthenticated       = "unauthenticated"
+	changeErrorUnauthorized          = "unauthorized"
+	changeErrorInvalidToolInput      = "invalid_tool_input"
+	changeErrorUnsupportedChangeMode = "unsupported_change_mode"
+	changeErrorUnsupportedChangeType = "unsupported_change_type"
+	changeErrorResourceUnavailable   = "resource_unavailable"
+	changeErrorInternal              = "internal_error"
+	changeFieldMode                  = "mode"
+	changeFieldType                  = "type"
+	changeFieldName                  = "name"
+	changeFieldSpec                  = "spec"
+)
+
+type changeToolError struct {
+	Code    string
+	Message string
+	Mode    string
+	Type    string
+	DAGName string
+	Field   string
+	DAGURI  string
+	Details map[string]any
+}
+
+func (e *changeToolError) Error() string {
+	return e.Message
+}
+
+func changeToolInputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"mode": {
+				"type": "string",
+				"description": "Change execution mode: preview or apply. Defaults to preview."
+			},
+			"type": {
+				"type": "string",
+				"description": "Change type. The only supported value is upsert_dag."
+			},
+			"name": {
+				"type": "string",
+				"description": "Target DAG name."
+			},
+			"spec": {
+				"type": "string",
+				"description": "DAG YAML document to validate and optionally store."
+			}
+		},
+		"additionalProperties": false
+	}`)
+}
+
+func (svc *Service) changeTool(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+	raw := json.RawMessage(nil)
+	if req != nil && req.Params != nil {
+		raw = req.Params.Arguments
+	}
+
+	input, changeErr := parseChangeToolInput(raw)
+	if changeErr != nil {
+		return changeErrorResult(changeErr), nil
+	}
+
+	result, output, err := auditToolCall(ctx, svc.api, req, toolChange, changeAuditMetadata(input), func(ctx context.Context) (*mcpsdk.CallToolResult, map[string]any, error) {
+		return svc.changeToolImpl(ctx, input)
+	})
+	if err != nil {
+		return changeErrorResult(classifyChangeToolError(input, err)), nil
+	}
+	result.StructuredContent = output
+	return result, nil
+}
+
+func (svc *Service) changeToolImpl(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
+	if err := svc.requireAPI(); err != nil {
+		return nil, nil, err
+	}
+
+	validation, err := svc.validateDAGSpec(ctx, input.Name, input.Spec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	validationErrors := make([]string, 0, len(validation.Errors))
+	validationErrors = append(validationErrors, validation.Errors...)
+
+	output := map[string]any{
+		"mode":       input.Mode,
+		"type":       input.Type,
+		"dagName":    input.Name,
+		"valid":      validation.Valid,
+		"errors":     validationErrors,
+		"applied":    false,
+		"references": defaultReferenceURIs(),
+		"dagUri":     dagSpecURI(input.Name),
+	}
+	if validation.Valid && validation.Dag != nil {
+		output["dag"] = validation.Dag
+	}
+
+	if !validation.Valid {
+		return resultWithLinks("DAG spec is not valid; no changes were applied.", linkForDAGSpec(input.Name)), output, nil
+	}
+	if input.Mode == changeModePreview {
+		return resultWithLinks("DAG spec is valid. Re-run with mode=apply to write it.", linkForDAGSpec(input.Name)), output, nil
+	}
+
+	created, err := svc.upsertDAG(ctx, input.Name, input.Spec)
+	if err != nil {
+		return nil, nil, err
+	}
+	output["applied"] = true
+	output["created"] = created
+	output["updated"] = !created
+
+	return resultWithLinks("DAG change applied.", linkForDAGSpec(input.Name)), output, nil
+}
+
+func parseChangeToolInput(raw json.RawMessage) (changeInput, *changeToolError) {
+	if len(raw) == 0 {
+		raw = json.RawMessage(`{}`)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		return changeInput{}, &changeToolError{
+			Code:    changeErrorInvalidToolInput,
+			Message: "Tool input must be a JSON object.",
+		}
+	}
+
+	var input changeInput
+	keys := make([]string, 0, len(fields))
+	for field := range fields {
+		keys = append(keys, field)
+	}
+	sort.Strings(keys)
+
+	for _, field := range keys {
+		value := fields[field]
+		if !isChangeInputField(field) {
+			return changeInput{}, &changeToolError{
+				Code:    changeErrorInvalidToolInput,
+				Message: "Unknown field " + field + ".",
+				Field:   field,
+			}
+		}
+		if string(value) == "null" {
+			continue
+		}
+
+		var text string
+		if err := json.Unmarshal(value, &text); err != nil {
+			return changeInput{}, &changeToolError{
+				Code:    changeErrorInvalidToolInput,
+				Message: "Field " + field + " must be a string.",
+				Field:   field,
+			}
+		}
+
+		switch field {
+		case changeFieldMode:
+			input.Mode = strings.TrimSpace(text)
+		case changeFieldType:
+			input.Type = strings.TrimSpace(text)
+		case changeFieldName:
+			input.Name = strings.TrimSpace(text)
+		case changeFieldSpec:
+			input.Spec = text
+		}
+	}
+
+	if input.Mode == "" {
+		input.Mode = changeModePreview
+	}
+	if input.Type == "" {
+		input.Type = changeTypeUpsertDAG
+	}
+	if input.Name == "" {
+		return input, changeInputError(input, "The name field is required.", changeFieldName)
+	}
+	if strings.TrimSpace(input.Spec) == "" {
+		return input, changeInputError(input, "The spec field is required.", changeFieldSpec)
+	}
+	if input.Mode != changeModePreview && input.Mode != changeModeApply {
+		return input, &changeToolError{
+			Code:    changeErrorUnsupportedChangeMode,
+			Message: "Unsupported change mode.",
+			Mode:    input.Mode,
+			Type:    input.Type,
+			DAGName: input.Name,
+			Field:   changeFieldMode,
+			DAGURI:  dagSpecURI(input.Name),
+		}
+	}
+	if input.Type != changeTypeUpsertDAG {
+		return input, &changeToolError{
+			Code:    changeErrorUnsupportedChangeType,
+			Message: "Unsupported change type.",
+			Mode:    input.Mode,
+			Type:    input.Type,
+			DAGName: input.Name,
+			Field:   changeFieldType,
+			DAGURI:  dagSpecURI(input.Name),
+		}
+	}
+
+	return input, nil
+}
+
+func isChangeInputField(field string) bool {
+	switch field {
+	case changeFieldMode, changeFieldType, changeFieldName, changeFieldSpec:
+		return true
+	default:
+		return false
+	}
+}
+
+func changeInputError(input changeInput, message, field string) *changeToolError {
+	err := &changeToolError{
+		Code:    changeErrorInvalidToolInput,
+		Message: message,
+		Mode:    input.Mode,
+		Type:    input.Type,
+		Field:   field,
+	}
+	if input.Name != "" {
+		err.DAGName = input.Name
+		err.DAGURI = dagSpecURI(input.Name)
+	}
+	return err
+}
+
+func classifyChangeToolError(input changeInput, err error) *changeToolError {
+	out := &changeToolError{
+		Code:    changeErrorInternal,
+		Message: "Internal MCP change error.",
+		Mode:    input.Mode,
+		Type:    input.Type,
+		DAGName: input.Name,
+	}
+	if input.Name != "" {
+		out.DAGURI = dagSpecURI(input.Name)
+	}
+
+	var apiErr *frontendapi.Error
+	if errors.As(err, &apiErr) {
+		out.Message = apiErr.Message
+		switch apiErr.HTTPStatus {
+		case http.StatusUnauthorized:
+			out.Code = changeErrorUnauthenticated
+		case http.StatusForbidden:
+			out.Code = changeErrorUnauthorized
+		default:
+			out.Code = changeErrorResourceUnavailable
+		}
+		return out
+	}
+
+	if isDAGNotFound(err) {
+		out.Code = changeErrorResourceUnavailable
+		out.Message = err.Error()
+		return out
+	}
+
+	out.Message = err.Error()
+	return out
+}
+
+func changeErrorResult(err *changeToolError) *mcpsdk.CallToolResult {
+	output := map[string]any{
+		"code":    err.Code,
+		"message": err.Message,
+	}
+	if err.Mode != "" {
+		output["mode"] = err.Mode
+	}
+	if err.Type != "" {
+		output["type"] = err.Type
+	}
+	if err.DAGName != "" {
+		output["dagName"] = err.DAGName
+	}
+	if err.Field != "" {
+		output["field"] = err.Field
+	}
+	if err.DAGURI != "" {
+		output["dagUri"] = err.DAGURI
+	}
+	if err.Details != nil {
+		output["details"] = err.Details
+	}
+	return &mcpsdk.CallToolResult{
+		Content:           []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Message}},
+		StructuredContent: output,
+		IsError:           true,
+	}
+}

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -70,6 +70,7 @@ func changeToolInputSchema() json.RawMessage {
 				"description": "DAG YAML document to validate and optionally store."
 			}
 		},
+		"required": ["name", "spec"],
 		"additionalProperties": false
 	}`)
 }

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -285,11 +285,10 @@ func classifyChangeToolError(input changeInput, err error) *changeToolError {
 
 	if isDAGNotFound(err) {
 		out.Code = changeErrorResourceUnavailable
-		out.Message = err.Error()
+		out.Message = "The requested DAG resource is unavailable."
 		return out
 	}
 
-	out.Message = err.Error()
 	return out
 }
 

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -124,10 +124,11 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 		},
 	}, svc.readTool)
 
-	mcpsdk.AddTool(server, &mcpsdk.Tool{
+	server.AddTool(&mcpsdk.Tool{
 		Name:        toolChange,
 		Title:       "Preview or apply DAG changes",
 		Description: "Validate and optionally apply a DAG YAML change. Use mode=preview before mode=apply unless the user explicitly asked to write immediately.",
+		InputSchema: changeToolInputSchema(),
 		Annotations: &mcpsdk.ToolAnnotations{
 			DestructiveHint: truePtr,
 			OpenWorldHint:   falsePtr,
@@ -212,74 +213,6 @@ func registerPrompts(server *mcpsdk.Server) {
 			{Name: "dagRunId", Description: "DAG-run ID.", Required: true},
 		},
 	}, promptDebugRun)
-}
-
-func (svc *Service) changeTool(ctx context.Context, req *mcpsdk.CallToolRequest, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
-	return auditToolCall(ctx, svc.api, req, toolChange, changeAuditMetadata(input), func(ctx context.Context) (*mcpsdk.CallToolResult, map[string]any, error) {
-		return svc.changeToolImpl(ctx, input)
-	})
-}
-
-func (svc *Service) changeToolImpl(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
-	if err := svc.requireAPI(); err != nil {
-		return nil, nil, err
-	}
-	if err := requireName(input.Name); err != nil {
-		return nil, nil, err
-	}
-	if strings.TrimSpace(input.Spec) == "" {
-		return nil, nil, errors.New("spec is required")
-	}
-
-	changeType := input.Type
-	if changeType == "" {
-		changeType = "upsert_dag"
-	}
-	if changeType != "upsert_dag" {
-		return nil, nil, fmt.Errorf("unsupported change type %q", changeType)
-	}
-
-	mode := input.Mode
-	if mode == "" {
-		mode = "preview"
-	}
-	if mode != "preview" && mode != "apply" {
-		return nil, nil, fmt.Errorf("unsupported change mode %q", mode)
-	}
-
-	validation, err := svc.validateDAGSpec(ctx, input.Name, input.Spec)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	output := map[string]any{
-		"mode":       mode,
-		"type":       changeType,
-		"dagName":    input.Name,
-		"valid":      validation.Valid,
-		"errors":     validation.Errors,
-		"dag":        validation.Dag,
-		"applied":    false,
-		"references": defaultReferenceURIs(),
-		"dagUri":     dagSpecURI(input.Name),
-	}
-
-	if !validation.Valid {
-		return resultWithLinks("DAG spec is not valid; no changes were applied.", linkForDAGSpec(input.Name)), output, nil
-	}
-	if mode == "preview" {
-		return resultWithLinks("DAG spec is valid. Re-run with mode=apply to write it.", linkForDAGSpec(input.Name)), output, nil
-	}
-
-	created, err := svc.upsertDAG(ctx, input.Name, input.Spec)
-	if err != nil {
-		return nil, nil, err
-	}
-	output["applied"] = true
-	output["created"] = created
-	output["updated"] = !created
-
-	return resultWithLinks("DAG change applied.", linkForDAGSpec(input.Name)), output, nil
 }
 
 func (svc *Service) executeTool(ctx context.Context, req *mcpsdk.CallToolRequest, input executeInput) (*mcpsdk.CallToolResult, map[string]any, error) {

--- a/specs/022-mcp-change-tool.md
+++ b/specs/022-mcp-change-tool.md
@@ -1,0 +1,317 @@
+# Spec: MCP Change Tool
+
+Status: Implemented.
+
+## Scope
+
+This spec defines the `dagu_change` MCP tool-call contract: input fields,
+preview behavior, apply behavior, successful output, resource links, mutation
+effects, and tool-level errors.
+
+This spec does not define the MCP endpoint, authentication, API-key surfaces,
+`dagu://` URI grammar, DAG YAML language semantics, `dagu_read`,
+`dagu_execute`, prompts, subscriptions, Web UI behavior, storage internals,
+workspace selection, or MCP SDK internals.
+
+Related specs:
+
+- [020: MCP Server](020-mcp-server.md) defines the MCP endpoint,
+  authentication, and `dagu://` resource URI model used by this tool.
+- [021: MCP Read Tool](021-mcp-read-tool.md) defines how clients read the DAG
+  spec resource linked from this tool.
+
+## Goal
+
+`dagu_change` gives MCP clients one safe way to validate a DAG YAML change
+before writing it. Preview is the default behavior. Apply is explicit and
+writes only after the same validation succeeds.
+
+## Behavior
+
+### Tool Identity
+
+Rules:
+
+- The tool name is `dagu_change`.
+- The tool supports DAG YAML upsert only.
+- A preview call must not create, update, delete, start, enqueue, retry, or
+  stop any DAG or DAG run.
+- An apply call may create or update one stored DAG only when validation
+  succeeds.
+- Audit, metrics, logging, and transport side effects are allowed.
+
+### Input
+
+Tool input is a JSON object. Fields outside this table fail with
+`invalid_tool_input`.
+
+| Field | Type | Required rule | Meaning |
+| --- | --- | --- | --- |
+| `mode` | string | Optional. Defaults to `preview`. | Change execution mode. Supported values are `preview` and `apply`. |
+| `type` | string | Optional. Defaults to `upsert_dag`. | Change type. The only supported value is `upsert_dag`. |
+| `name` | string | Required. | Target DAG name. |
+| `spec` | string | Required. | DAG YAML document to validate and optionally store. |
+
+Rules:
+
+- Supported fields, when present and not `null`, must be strings.
+- `null` is treated as absent.
+- `mode`, `type`, and `name` are trimmed of leading and trailing whitespace
+  before validation.
+- `spec` is not trimmed or normalized. It fails only when it is empty or all
+  whitespace.
+- Supported values are case-sensitive.
+- A missing or empty `name` fails with `invalid_tool_input`.
+- A missing or all-whitespace `spec` fails with `invalid_tool_input`.
+- An unsupported `mode` fails with `unsupported_change_mode`.
+- An unsupported `type` fails with `unsupported_change_type`.
+
+### Change Type
+
+`upsert_dag` validates a DAG YAML document for the supplied DAG name.
+
+Rules:
+
+- Validation uses Dagu's DAG validation rules.
+- A validation failure is not a tool-level error.
+- When validation fails, the tool returns a successful MCP tool result with
+  `valid=false`, `applied=false`, and validation errors in the structured
+  output.
+- This spec defines the MCP tool contract. The DAG YAML fields and validation
+  rules are owned by the DAG YAML specs.
+
+### Preview Mode
+
+Rules:
+
+- `mode=preview` validates the supplied DAG YAML and returns the validation
+  result.
+- `mode=preview` must not write the DAG even when validation succeeds.
+- `mode=preview` must not write the DAG when validation fails.
+- `applied` is `false` in preview output.
+- `created` and `updated` are omitted in preview output.
+
+### Apply Mode
+
+Rules:
+
+- `mode=apply` validates the supplied DAG YAML before writing.
+- If validation fails, the call must not write the DAG and returns
+  `valid=false` with `applied=false`.
+- If validation succeeds and no stored DAG exists for `name`, the call creates
+  the DAG and returns `created=true`, `updated=false`, and `applied=true`.
+- If validation succeeds and a stored DAG exists for `name`, the call updates
+  that DAG and returns `created=false`, `updated=true`, and `applied=true`.
+- A successful apply affects only the DAG identified by `name`.
+- A successful apply must not start, enqueue, retry, or stop a DAG run.
+
+### Output
+
+A successful MCP tool result has one text content item and structured output.
+
+Text content is mode and validation dependent:
+
+| Condition | Text |
+| --- | --- |
+| Validation failed. | `DAG spec is not valid; no changes were applied.` |
+| Preview validation succeeded. | `DAG spec is valid. Re-run with mode=apply to write it.` |
+| Apply validation succeeded and the DAG was written. | `DAG change applied.` |
+
+Structured output has this top-level envelope:
+
+```json
+{
+  "mode": "preview",
+  "type": "upsert_dag",
+  "dagName": "nightly-report",
+  "valid": true,
+  "errors": [],
+  "applied": false,
+  "dag": {},
+  "dagUri": "dagu://dags/nightly-report/spec",
+  "references": [
+    "dagu://reference/authoring",
+    "dagu://reference/tools",
+    "dagu://reference/notifications"
+  ]
+}
+```
+
+Required fields:
+
+| Field | Required shape |
+| --- | --- |
+| `mode` | Effective mode: `preview` or `apply`. |
+| `type` | Effective type: `upsert_dag`. |
+| `dagName` | Effective DAG name. |
+| `valid` | Boolean validation result. |
+| `errors` | Array of validation errors. Empty when `valid=true`. |
+| `applied` | Boolean. `true` only when the DAG was written. |
+| `dagUri` | Canonical `dagu://dags/{name}/spec` URI for the target DAG. |
+| `references` | Exactly `dagu://reference/authoring`, `dagu://reference/tools`, and `dagu://reference/notifications`; order is not normative. |
+
+Conditional fields:
+
+| Field | Required when |
+| --- | --- |
+| `dag` | Validation succeeds and Dagu can return a normalized DAG model. |
+| `created` | `applied=true`. |
+| `updated` | `applied=true`. |
+
+Implementations may add fields inside the structured output. Conformance tests
+must not require absence of additional fields.
+
+The successful result includes a resource-link content item for `dagUri` when
+`dagUri` is present.
+
+Resource-link content item rules:
+
+- MCP content type is `resource_link`.
+- `uri` is the canonical `dagu://dags/{name}/spec` URI.
+- `name` is `dag_spec`.
+- `mimeType` is `application/yaml`.
+
+URI path segments in returned URIs follow Spec 020 escaping.
+
+## Errors
+
+Failed tool calls return an MCP tool result with `isError=true`. When the
+transport supports structured output, the structured output is the error object.
+Text content may include the error message as a fallback.
+
+The error object has this shape:
+
+```json
+{
+  "code": "invalid_tool_input",
+  "message": "The spec field is required.",
+  "mode": "preview",
+  "type": "upsert_dag",
+  "dagName": "nightly-report",
+  "field": "spec",
+  "dagUri": "dagu://dags/nightly-report/spec",
+  "details": {}
+}
+```
+
+`code` and `message` are required. Clients must branch on `code`, not parse
+`message`.
+
+Optional field rules:
+
+| Field | Required when |
+| --- | --- |
+| `mode` | A valid mode has been resolved, or an unsupported mode value was supplied. |
+| `type` | A valid type has been resolved, or an unsupported type value was supplied. |
+| `dagName` | A non-empty DAG name has been resolved. |
+| `field` | Exactly one input field caused the failure. For an unknown field, this is the unknown field name. |
+| `dagUri` | A non-empty DAG name has been resolved. |
+| `details` | More than one field caused the failure, or the server needs to expose structured error details. |
+
+Common conditions map to codes as follows:
+
+| Condition | Code |
+| --- | --- |
+| Authentication is required and the request is not authenticated. | `unauthenticated` |
+| The accepted credential is not authorized for the requested change. | `unauthorized` |
+| Tool input is not a JSON object. | `invalid_tool_input` |
+| Tool input contains an unknown field. | `invalid_tool_input` |
+| A supported field has a non-string, non-null value. | `invalid_tool_input` |
+| `name` is absent or empty after trimming. | `invalid_tool_input` |
+| `spec` is absent, empty, or all whitespace. | `invalid_tool_input` |
+| `mode` is present but is not `preview` or `apply`. | `unsupported_change_mode` |
+| `type` is present but is not `upsert_dag`. | `unsupported_change_type` |
+| DAG validation fails. | No tool error. Return `valid=false`. |
+| The target DAG cannot currently be read or written during apply. | `resource_unavailable` |
+| The server fails unexpectedly while handling the change. | `internal_error` |
+
+## Examples
+
+Preview a valid DAG:
+
+```json
+{
+  "mode": "preview",
+  "type": "upsert_dag",
+  "name": "nightly-report",
+  "spec": "steps:\n  - name: hello\n    run: echo hello\n"
+}
+```
+
+Expected structured output subset:
+
+```json
+{
+  "mode": "preview",
+  "type": "upsert_dag",
+  "dagName": "nightly-report",
+  "valid": true,
+  "applied": false,
+  "dagUri": "dagu://dags/nightly-report/spec"
+}
+```
+
+Apply a valid DAG:
+
+```json
+{
+  "mode": "apply",
+  "type": "upsert_dag",
+  "name": "nightly-report",
+  "spec": "steps:\n  - name: hello\n    run: echo hello\n"
+}
+```
+
+Expected structured output subset:
+
+```json
+{
+  "mode": "apply",
+  "type": "upsert_dag",
+  "dagName": "nightly-report",
+  "valid": true,
+  "applied": true,
+  "created": true,
+  "updated": false,
+  "dagUri": "dagu://dags/nightly-report/spec"
+}
+```
+
+Preview an invalid DAG:
+
+```json
+{
+  "name": "broken",
+  "spec": "steps:\n  - name: [\n"
+}
+```
+
+Expected structured output subset:
+
+```json
+{
+  "mode": "preview",
+  "type": "upsert_dag",
+  "dagName": "broken",
+  "valid": false,
+  "applied": false
+}
+```
+
+Unsupported mode:
+
+```json
+{
+  "mode": "write",
+  "name": "nightly-report",
+  "spec": "steps:\n  - name: hello\n    run: echo hello\n"
+}
+```
+
+Expected error code:
+
+```json
+{
+  "code": "unsupported_change_mode"
+}
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,6 +29,7 @@ It must not be treated as product behavior until implementation catches up.
 | [018: Parallel Fan-Out and Foreach Iteration](018-parallel-and-foreach.md) | Implemented |
 | [020: MCP Server](020-mcp-server.md) | Not implemented |
 | [021: MCP Read Tool](021-mcp-read-tool.md) | Implemented |
+| [022: MCP Change Tool](022-mcp-change-tool.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary
- add Spec 022 for the MCP change tool and mark it implemented
- add black-box conformance coverage for preview, apply, validation, input errors, and authorization
- make dagu_change return the structured output and structured errors required by the spec

## Testing
- go test ./internal/service/mcp ./conformance/spec020_mcp_server ./conformance/spec021_mcp_read_tool ./conformance/spec022_mcp_change_tool -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Spec 022 for the MCP change tool with full conformance. `dagu_change` now supports preview/apply for DAG YAML upserts with structured results, resource links, and hardened error handling.

- **New Features**
  - Added `specs/022-mcp-change-tool.md` and marked it Implemented; updated specs README.
  - Implemented `dagu_change` with registered `InputSchema`, trimmed/defaulted inputs, validation-first flow, and structured success output (`mode`, `type`, `dagName`, `valid`, `errors`, `applied`, `created/updated`, `dagUri`, `references`, and `dag` when valid); removed the old inline implementation in `server.go`.

- **Bug Fixes**
  - Hardened errors: reject non-object/unknown fields and non-string values; map backend failures to `unauthenticated`, `unauthorized`, `resource_unavailable`, or `internal_error`; include `field`, `dagUri`, and resolved `mode`, `type`, `dagName` when available.
  - Expanded conformance tests for input validation, identity/schema, preview/apply behavior, auth, and no unintended side effects.

<sup>Written for commit 6f5f3ad3b89981af7aecb0bfb060d89c5611cbb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new MCP change tool for previewing and applying DAG updates.
  * Introduced support for validating changes before writing, with clear success, preview, and error responses.
  * Added conformance coverage for tool identity, input validation, authentication, preview behavior, and apply behavior.

* **Bug Fixes**
  * Ensured invalid changes do not overwrite existing DAGs.
  * Confirmed updates affect only the targeted DAG and do not trigger runs.

* **Documentation**
  * Added the MCP change tool specification and marked it as implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->