### PR TITLE
refactor: shorten dag-run storage prefixes

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -43,7 +43,6 @@ import (
 	"github.com/dagucloud/dagu/internal/service/frontend"
 	"github.com/dagucloud/dagu/internal/service/resource"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -734,13 +733,9 @@ func NewCommand(cmd *cobra.Command, flags []commandLineFlag, runFunc func(cmd *C
 	return cmd
 }
 
-// genRunID creates a new UUID string to be used as a dag-run IDentifier.
+// genRunID creates a new auto-generated dag-run ID.
 func genRunID() (string, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return "", err
-	}
-	return id.String(), nil
+	return exec.NewDAGRunID()
 }
 
 // validateRunID checks if the dag-run ID is valid and not empty.

--- a/internal/core/exec/runid.go
+++ b/internal/core/exec/runid.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec
+
+import (
+	"math/big"
+
+	"github.com/google/uuid"
+)
+
+const (
+	base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	base62UUIDLen  = 22
+)
+
+// NewDAGRunID returns a compact UUIDv7-derived DAG-run ID.
+func NewDAGRunID() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	return encodeBase62UUID(id), nil
+}
+
+func encodeBase62UUID(id uuid.UUID) string {
+	var n big.Int
+	n.SetBytes(id[:])
+
+	base := big.NewInt(int64(len(base62Alphabet)))
+	var rem big.Int
+	out := make([]byte, base62UUIDLen)
+	for i := len(out) - 1; i >= 0; i-- {
+		n.DivMod(&n, base, &rem)
+		out[i] = base62Alphabet[rem.Int64()]
+	}
+	return string(out)
+}

--- a/internal/core/exec/runid_test.go
+++ b/internal/core/exec/runid_test.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDAGRunID(t *testing.T) {
+	t.Parallel()
+
+	id, err := exec.NewDAGRunID()
+	require.NoError(t, err)
+	require.Regexp(t, `^[0-9A-Za-z]{22}$`, id)
+	require.NoError(t, exec.ValidateDAGRunID(id))
+}

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -90,11 +90,11 @@ func (att *Attempt) SetDAG(dag *core.DAG) {
 // NewAttempt creates a new Run for the specified file.
 func NewAttempt(file string, cache *fileutil.Cache[*exec.DAGRunStatus], opts ...AttemptOption) (*Attempt, error) {
 	dirName := filepath.Base(filepath.Dir(file))
-	info, ok := parseAttemptDirName(dirName)
+	attemptID, ok := attemptIDFromDir(dirName)
 	if !ok {
 		return nil, fmt.Errorf("invalid file path for run data: %s", file)
 	}
-	att := &Attempt{id: info.id, file: file, cache: cache}
+	att := &Attempt{id: attemptID, file: file, cache: cache}
 	for _, opt := range opts {
 		opt(att)
 	}
@@ -730,7 +730,7 @@ func subDAGWorkDirName(childRunID string) string {
 
 func subDAGWorkDirParts(dagRunDir string) (rootDir, childRunID string, ok bool) {
 	parentDir := filepath.Dir(dagRunDir)
-	childRunID, ok = parseSubDAGRunDirName(filepath.Base(parentDir), filepath.Base(dagRunDir))
+	childRunID, ok = subDAGRunIDFromDir(filepath.Base(parentDir), filepath.Base(dagRunDir))
 	if !ok {
 		return "", "", false
 	}

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -90,11 +90,11 @@ func (att *Attempt) SetDAG(dag *core.DAG) {
 // NewAttempt creates a new Run for the specified file.
 func NewAttempt(file string, cache *fileutil.Cache[*exec.DAGRunStatus], opts ...AttemptOption) (*Attempt, error) {
 	dirName := filepath.Base(filepath.Dir(file))
-	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(dirName, "."))
-	if len(matches) != 3 {
+	info, ok := parseAttemptDirName(dirName)
+	if !ok {
 		return nil, fmt.Errorf("invalid file path for run data: %s", file)
 	}
-	att := &Attempt{id: matches[2], file: file, cache: cache}
+	att := &Attempt{id: info.id, file: file, cache: cache}
 	for _, opt := range opts {
 		opt(att)
 	}
@@ -729,19 +729,12 @@ func subDAGWorkDirName(childRunID string) string {
 }
 
 func subDAGWorkDirParts(dagRunDir string) (rootDir, childRunID string, ok bool) {
-	childrenDir := filepath.Dir(dagRunDir)
-	if filepath.Base(childrenDir) != SubDAGRunsDir {
+	parentDir := filepath.Dir(dagRunDir)
+	childRunID, ok = parseSubDAGRunDirName(filepath.Base(parentDir), filepath.Base(dagRunDir))
+	if !ok {
 		return "", "", false
 	}
-	childDir := filepath.Base(dagRunDir)
-	if !strings.HasPrefix(childDir, SubDAGRunDirPrefix) {
-		return "", "", false
-	}
-	childRunID = strings.TrimPrefix(childDir, SubDAGRunDirPrefix)
-	if childRunID == "" {
-		return "", "", false
-	}
-	return filepath.Dir(childrenDir), childRunID, true
+	return filepath.Dir(parentDir), childRunID, true
 }
 
 // readLineFrom reads a line from the file starting at the specified offset.

--- a/internal/persis/file/dagrun/attempt_test.go
+++ b/internal/persis/file/dagrun/attempt_test.go
@@ -465,7 +465,7 @@ func createTempDir(t *testing.T) string {
 	attemptID, err := genAttemptID()
 	require.NoError(t, err)
 
-	dir, err := os.MkdirTemp("", "attempt_"+formatAttemptTimestamp(exec.NewUTC(time.Now()))+"_"+attemptID)
+	dir, err := os.MkdirTemp("", attemptDirName(exec.NewUTC(time.Now()), attemptID))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = os.RemoveAll(dir)
@@ -888,7 +888,7 @@ func TestAttempt_WorkDir(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	dagRunDir := filepath.Join(dir, "dag-run_20250101_000000Z_abc")
-	attemptDir := filepath.Join(dagRunDir, "attempt_20250101_000000_000Z_xyz")
+	attemptDir := filepath.Join(dagRunDir, "a_20250101_000000_000Z_xyz")
 	require.NoError(t, os.MkdirAll(attemptDir, 0750))
 	statusFile := filepath.Join(attemptDir, "status.jsonl")
 	require.NoError(t, os.WriteFile(statusFile, nil, 0600))

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -106,7 +106,7 @@ func NewDAGRun(dir string) (*DAGRun, error) {
 func newDAGRun(dir, artifactDir string) (*DAGRun, error) {
 	// Determine if the run is a sub dag-run or a regular dag-run.
 	parentDir := filepath.Dir(dir)
-	if dagRunID, ok := parseSubDAGRunDirName(filepath.Base(parentDir), filepath.Base(dir)); ok {
+	if dagRunID, ok := subDAGRunIDFromDir(filepath.Base(parentDir), filepath.Base(dir)); ok {
 		return &DAGRun{
 			baseDir:     dir,
 			artifactDir: artifactDir,
@@ -197,7 +197,7 @@ func (dr DAGRun) ListSubDAGRuns(ctx context.Context) ([]*DAGRun, error) {
 			if !entry.IsDir() {
 				continue
 			}
-			dagRunID, ok := parseSubDAGRunDirName(dirName, entry.Name())
+			dagRunID, ok := subDAGRunIDFromDir(dirName, entry.Name())
 			if !ok {
 				continue
 			}
@@ -367,7 +367,7 @@ func (dr DAGRun) listAttemptDirs() ([]string, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		if isAttemptDirName(entry.Name()) {
+		if IsAttemptDirName(entry.Name()) {
 			dirs = append(dirs, entry.Name())
 		}
 	}
@@ -486,10 +486,6 @@ func (dr DAGRun) validatedArtifactDir(dir string) (string, bool) {
 	return cleanDir, true
 }
 
-type attemptDirInfo struct {
-	id string
-}
-
 // Regular expressions for parsing directory names
 var reDAGRunDir = regexp.MustCompile(`^` + DAGRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`) // Matches dag-run directory names
 var reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(AttemptDirPrefix) + `|` + regexp.QuoteMeta(LegacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
@@ -498,21 +494,17 @@ func attemptDirName(ts exec.TimeInUTC, attemptID string) string {
 	return AttemptDirPrefix + formatAttemptTimestamp(ts) + "_" + attemptID
 }
 
-func parseAttemptDirName(name string) (attemptDirInfo, bool) {
+func attemptIDFromDir(name string) (string, bool) {
 	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
 	if len(matches) != 3 {
-		return attemptDirInfo{}, false
+		return "", false
 	}
-	return attemptDirInfo{id: matches[2]}, true
-}
-
-func isAttemptDirName(name string) bool {
-	return reAttemptDir.MatchString(strings.TrimPrefix(name, "."))
+	return matches[2], true
 }
 
 // IsAttemptDirName reports whether a directory name is a current or legacy attempt directory.
 func IsAttemptDirName(name string) bool {
-	return isAttemptDirName(name)
+	return reAttemptDir.MatchString(strings.TrimPrefix(name, "."))
 }
 
 func attemptDirNewer(a, b string) bool {
@@ -525,15 +517,10 @@ func attemptDirNewer(a, b string) bool {
 }
 
 func attemptDirOlder(a, b string) bool {
-	a = strings.TrimPrefix(a, ".")
-	b = strings.TrimPrefix(b, ".")
-	if aCurrent, bCurrent := strings.HasPrefix(a, AttemptDirPrefix), strings.HasPrefix(b, AttemptDirPrefix); aCurrent != bCurrent {
-		return !aCurrent
-	}
-	return a < b
+	return attemptDirNewer(b, a)
 }
 
-func parseSubDAGRunDirName(parentDirName, dirName string) (string, bool) {
+func subDAGRunIDFromDir(parentDirName, dirName string) (string, bool) {
 	switch parentDirName {
 	case SubDAGRunsDir:
 		if dirName == "" || strings.HasPrefix(dirName, ".") {
@@ -541,14 +528,8 @@ func parseSubDAGRunDirName(parentDirName, dirName string) (string, bool) {
 		}
 		return dirName, true
 	case LegacySubDAGRunsDir:
-		if !strings.HasPrefix(dirName, LegacySubDAGRunDirPrefix) {
-			return "", false
-		}
-		dagRunID := strings.TrimPrefix(dirName, LegacySubDAGRunDirPrefix)
-		if dagRunID == "" {
-			return "", false
-		}
-		return dagRunID, true
+		dagRunID, ok := strings.CutPrefix(dirName, LegacySubDAGRunDirPrefix)
+		return dagRunID, ok && dagRunID != ""
 	default:
 		return "", false
 	}

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -372,7 +372,7 @@ func (dr DAGRun) listAttemptDirs() ([]string, error) {
 		}
 	}
 
-	// Sort in reverse order (newest first) based on timestamp
+	// Sort current-format attempts before legacy attempts.
 	sort.Slice(dirs, func(i, j int) bool {
 		return attemptDirNewer(dirs[i], dirs[j])
 	})
@@ -487,8 +487,8 @@ func (dr DAGRun) validatedArtifactDir(dir string) (string, bool) {
 }
 
 type attemptDirInfo struct {
-	timestamp string
-	id        string
+	id      string
+	current bool
 }
 
 // Regular expressions for parsing directory names
@@ -500,11 +500,12 @@ func attemptDirName(ts exec.TimeInUTC, attemptID string) string {
 }
 
 func parseAttemptDirName(name string) (attemptDirInfo, bool) {
-	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
+	cleanName := strings.TrimPrefix(name, ".")
+	matches := reAttemptDir.FindStringSubmatch(cleanName)
 	if len(matches) != 3 {
 		return attemptDirInfo{}, false
 	}
-	return attemptDirInfo{timestamp: matches[1], id: matches[2]}, true
+	return attemptDirInfo{id: matches[2], current: strings.HasPrefix(cleanName, AttemptDirPrefix)}, true
 }
 
 func isAttemptDirName(name string) bool {
@@ -521,11 +522,8 @@ func attemptDirNewer(a, b string) bool {
 	aInfo, aOK := parseAttemptDirName(a)
 	bInfo, bOK := parseAttemptDirName(b)
 	if aOK && bOK {
-		if aInfo.timestamp != bInfo.timestamp {
-			return aInfo.timestamp > bInfo.timestamp
-		}
-		if aInfo.id != bInfo.id {
-			return aInfo.id > bInfo.id
+		if aInfo.current != bInfo.current {
+			return aInfo.current
 		}
 	}
 	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")
@@ -535,11 +533,8 @@ func attemptDirOlder(a, b string) bool {
 	aInfo, aOK := parseAttemptDirName(a)
 	bInfo, bOK := parseAttemptDirName(b)
 	if aOK && bOK {
-		if aInfo.timestamp != bInfo.timestamp {
-			return aInfo.timestamp < bInfo.timestamp
-		}
-		if aInfo.id != bInfo.id {
-			return aInfo.id < bInfo.id
+		if aInfo.current != bInfo.current {
+			return !aInfo.current
 		}
 	}
 	return strings.TrimPrefix(a, ".") < strings.TrimPrefix(b, ".")

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -487,8 +487,7 @@ func (dr DAGRun) validatedArtifactDir(dir string) (string, bool) {
 }
 
 type attemptDirInfo struct {
-	id      string
-	current bool
+	id string
 }
 
 // Regular expressions for parsing directory names
@@ -500,17 +499,15 @@ func attemptDirName(ts exec.TimeInUTC, attemptID string) string {
 }
 
 func parseAttemptDirName(name string) (attemptDirInfo, bool) {
-	cleanName := strings.TrimPrefix(name, ".")
-	matches := reAttemptDir.FindStringSubmatch(cleanName)
+	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
 	if len(matches) != 3 {
 		return attemptDirInfo{}, false
 	}
-	return attemptDirInfo{id: matches[2], current: strings.HasPrefix(cleanName, AttemptDirPrefix)}, true
+	return attemptDirInfo{id: matches[2]}, true
 }
 
 func isAttemptDirName(name string) bool {
-	_, ok := parseAttemptDirName(name)
-	return ok
+	return reAttemptDir.MatchString(strings.TrimPrefix(name, "."))
 }
 
 // IsAttemptDirName reports whether a directory name is a current or legacy attempt directory.
@@ -519,25 +516,21 @@ func IsAttemptDirName(name string) bool {
 }
 
 func attemptDirNewer(a, b string) bool {
-	aInfo, aOK := parseAttemptDirName(a)
-	bInfo, bOK := parseAttemptDirName(b)
-	if aOK && bOK {
-		if aInfo.current != bInfo.current {
-			return aInfo.current
-		}
+	a = strings.TrimPrefix(a, ".")
+	b = strings.TrimPrefix(b, ".")
+	if aCurrent, bCurrent := strings.HasPrefix(a, AttemptDirPrefix), strings.HasPrefix(b, AttemptDirPrefix); aCurrent != bCurrent {
+		return aCurrent
 	}
-	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")
+	return a > b
 }
 
 func attemptDirOlder(a, b string) bool {
-	aInfo, aOK := parseAttemptDirName(a)
-	bInfo, bOK := parseAttemptDirName(b)
-	if aOK && bOK {
-		if aInfo.current != bInfo.current {
-			return !aInfo.current
-		}
+	a = strings.TrimPrefix(a, ".")
+	b = strings.TrimPrefix(b, ".")
+	if aCurrent, bCurrent := strings.HasPrefix(a, AttemptDirPrefix), strings.HasPrefix(b, AttemptDirPrefix); aCurrent != bCurrent {
+		return !aCurrent
 	}
-	return strings.TrimPrefix(a, ".") < strings.TrimPrefix(b, ".")
+	return a < b
 }
 
 func parseSubDAGRunDirName(parentDirName, dirName string) (string, bool) {

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -170,12 +170,10 @@ func (dr DAGRun) FindSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, err
 	if err := exec.ValidateDAGRunID(dagRunID); err != nil {
 		return nil, fmt.Errorf("invalid sub dag-run ID: %w", err)
 	}
-	for _, parentDirName := range []string{SubDAGRunsDir, LegacySubDAGRunsDir} {
-		dirName, ok := subDAGRunDirName(parentDirName, dagRunID)
-		if !ok {
-			continue
-		}
-		dir := filepath.Join(dr.baseDir, parentDirName, dirName)
+	for _, dir := range []string{
+		filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID),
+		filepath.Join(dr.baseDir, LegacySubDAGRunsDir, LegacySubDAGRunDirPrefix+dagRunID),
+	} {
 		info, err := os.Stat(dir)
 		if err == nil && info.IsDir() {
 			return newDAGRun(dir, dr.artifactDir)
@@ -493,8 +491,7 @@ func (dr DAGRun) validatedArtifactDir(dir string) (string, bool) {
 	return cleanDir, true
 }
 
-// Regular expressions for parsing directory names
-var reDAGRunDir = regexp.MustCompile(`^` + DAGRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`) // Matches dag-run directory names
+var reDAGRunDir = regexp.MustCompile(`^` + DAGRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`)
 var reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(AttemptDirPrefix) + `|` + regexp.QuoteMeta(LegacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
 
 func attemptDirName(ts exec.TimeInUTC, attemptID string) string {
@@ -509,9 +506,9 @@ func attemptIDFromDir(name string) (string, bool) {
 	return matches[2], true
 }
 
-// IsAttemptDirName reports whether a directory name is a current or legacy attempt directory.
 func IsAttemptDirName(name string) bool {
-	return reAttemptDir.MatchString(strings.TrimPrefix(name, "."))
+	_, ok := attemptIDFromDir(name)
+	return ok
 }
 
 func attemptDirNewer(a, b string) bool {
@@ -525,23 +522,6 @@ func attemptDirNewer(a, b string) bool {
 
 func attemptDirOlder(a, b string) bool {
 	return attemptDirNewer(b, a)
-}
-
-func subDAGRunDirName(parentDirName, dagRunID string) (string, bool) {
-	switch parentDirName {
-	case SubDAGRunsDir:
-		if dagRunID == "" || strings.HasPrefix(dagRunID, ".") {
-			return "", false
-		}
-		return dagRunID, true
-	case LegacySubDAGRunsDir:
-		if dagRunID == "" {
-			return "", false
-		}
-		return LegacySubDAGRunDirPrefix + dagRunID, true
-	default:
-		return "", false
-	}
 }
 
 func subDAGRunIDFromDir(parentDirName, dirName string) (string, bool) {

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -155,6 +155,9 @@ func (dr DAGRun) CreateAttempt(_ context.Context, ts exec.TimeInUTC, cache *file
 
 // CreateSubDAGRun creates a new sub dag-run with the given timestamp and dag-run ID.
 func (dr DAGRun) CreateSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, error) {
+	if err := exec.ValidateDAGRunID(dagRunID); err != nil {
+		return nil, fmt.Errorf("invalid sub dag-run ID: %w", err)
+	}
 	dir := filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create sub dag-run directory: %w", err)
@@ -164,6 +167,9 @@ func (dr DAGRun) CreateSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, e
 
 // FindSubDAGRun searches for a sub dag-run by its run ID.
 func (dr DAGRun) FindSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, error) {
+	if err := exec.ValidateDAGRunID(dagRunID); err != nil {
+		return nil, fmt.Errorf("invalid sub dag-run ID: %w", err)
+	}
 	candidates := []string{
 		filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID),
 		filepath.Join(dr.baseDir, LegacySubDAGRunsDir, LegacySubDAGRunDirPrefix+dagRunID),

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -30,16 +30,22 @@ var (
 
 const (
 	// SubDAGRunsDir is the name of the directory where status files for sub dag-runs are stored.
-	SubDAGRunsDir = "children"
+	SubDAGRunsDir = "sub"
 
-	// SubDAGRunDirPrefix is the prefix for sub dag-run directories.
-	SubDAGRunDirPrefix = "child_"
+	// LegacySubDAGRunsDir is the previous directory where status files for sub dag-runs were stored.
+	LegacySubDAGRunsDir = "children"
+
+	// LegacySubDAGRunDirPrefix is the previous prefix for sub dag-run directories.
+	LegacySubDAGRunDirPrefix = "child_"
 
 	// DAGRunDirPrefix is the prefix for dag-run directories.
 	DAGRunDirPrefix = "dag-run_"
 
 	// AttemptDirPrefix is the prefix for attempt directories.
-	AttemptDirPrefix = "attempt_"
+	AttemptDirPrefix = "a_"
+
+	// LegacyAttemptDirPrefix is the previous prefix for attempt directories.
+	LegacyAttemptDirPrefix = "attempt_"
 
 	// SubDAGWorkDirPrefix is the prefix for sub dag-run working directories.
 	SubDAGWorkDirPrefix = "w_"
@@ -100,15 +106,11 @@ func NewDAGRun(dir string) (*DAGRun, error) {
 func newDAGRun(dir, artifactDir string) (*DAGRun, error) {
 	// Determine if the run is a sub dag-run or a regular dag-run.
 	parentDir := filepath.Dir(dir)
-	if filepath.Base(parentDir) == SubDAGRunsDir {
-		matches := reSubDAGRunDir.FindStringSubmatch(filepath.Base(dir))
-		if len(matches) != 2 {
-			return nil, ErrInvalidDAGRunsDir
-		}
+	if dagRunID, ok := parseSubDAGRunDirName(filepath.Base(parentDir), filepath.Base(dir)); ok {
 		return &DAGRun{
 			baseDir:     dir,
 			artifactDir: artifactDir,
-			dagRunID:    matches[1],
+			dagRunID:    dagRunID,
 		}, nil
 	}
 
@@ -140,7 +142,7 @@ func (dr DAGRun) CreateAttempt(_ context.Context, ts exec.TimeInUTC, cache *file
 			return nil, err
 		}
 	}
-	dir := filepath.Join(dr.baseDir, AttemptDirPrefix+formatAttemptTimestamp(ts)+"_"+attID)
+	dir := filepath.Join(dr.baseDir, attemptDirName(ts, attID))
 	// Error if the directory already exists
 	if _, err := os.Stat(dir); err == nil {
 		return nil, fmt.Errorf("run directory already exists: %s", dir)
@@ -153,8 +155,7 @@ func (dr DAGRun) CreateAttempt(_ context.Context, ts exec.TimeInUTC, cache *file
 
 // CreateSubDAGRun creates a new sub dag-run with the given timestamp and dag-run ID.
 func (dr DAGRun) CreateSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, error) {
-	dirName := SubDAGRunDirPrefix + dagRunID
-	dir := filepath.Join(dr.baseDir, SubDAGRunsDir, dirName)
+	dir := filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create sub dag-run directory: %w", err)
 	}
@@ -163,51 +164,58 @@ func (dr DAGRun) CreateSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, e
 
 // FindSubDAGRun searches for a sub dag-run by its run ID.
 func (dr DAGRun) FindSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, error) {
-	globPattern := filepath.Join(dr.baseDir, SubDAGRunsDir, SubDAGRunDirPrefix+dagRunID)
-	matches, err := filepath.Glob(globPattern)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list sub dag-runs: %w", err)
+	candidates := []string{
+		filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID),
+		filepath.Join(dr.baseDir, LegacySubDAGRunsDir, LegacySubDAGRunDirPrefix+dagRunID),
 	}
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no matching sub dag-run found for ID %s (glob=%s): %w", dagRunID, globPattern, exec.ErrDAGRunIDNotFound)
+	for _, dir := range candidates {
+		info, err := os.Stat(dir)
+		if err == nil && info.IsDir() {
+			return newDAGRun(dir, dr.artifactDir)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read sub dag-run %s: %w", dir, err)
+		}
 	}
-	// Sort the matches by timestamp
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i] > matches[j]
-	})
-	return newDAGRun(matches[0], dr.artifactDir)
+	return nil, fmt.Errorf("no matching sub dag-run found for ID %s: %w", dagRunID, exec.ErrDAGRunIDNotFound)
 }
 
 func (dr DAGRun) ListSubDAGRuns(ctx context.Context) ([]*DAGRun, error) {
-	subDir := filepath.Join(dr.baseDir, SubDAGRunsDir)
-	entries, err := os.ReadDir(subDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return []*DAGRun{}, nil
-		}
-		return nil, fmt.Errorf("failed to read sub dag-runs directory: %w", err)
-	}
-
 	var dagRuns []*DAGRun
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		// check if the directory name matches the sub dag-run directory pattern
-		if !reSubDAGRunDir.MatchString(entry.Name()) {
-			continue
-		}
-
-		subDAGRun, err := newDAGRun(filepath.Join(subDir, entry.Name()), dr.artifactDir)
+	seen := make(map[string]struct{})
+	for _, dirName := range []string{SubDAGRunsDir, LegacySubDAGRunsDir} {
+		subDir := filepath.Join(dr.baseDir, dirName)
+		entries, err := os.ReadDir(subDir)
 		if err != nil {
-			logger.Error(ctx, "Failed to read sub dag-run data",
-				tag.Error(err),
-				tag.RunID(dr.dagRunID),
-				tag.Dir(entry.Name()))
-			continue
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read sub dag-runs directory: %w", err)
 		}
-		dagRuns = append(dagRuns, subDAGRun)
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dagRunID, ok := parseSubDAGRunDirName(dirName, entry.Name())
+			if !ok {
+				continue
+			}
+			if _, ok := seen[dagRunID]; ok {
+				continue
+			}
+
+			subDAGRun, err := newDAGRun(filepath.Join(subDir, entry.Name()), dr.artifactDir)
+			if err != nil {
+				logger.Error(ctx, "Failed to read sub dag-run data",
+					tag.Error(err),
+					tag.RunID(dr.dagRunID),
+					tag.Dir(entry.Name()))
+				continue
+			}
+			seen[dagRunID] = struct{}{}
+			dagRuns = append(dagRuns, subDAGRun)
+		}
 	}
 	return dagRuns, nil
 }
@@ -216,7 +224,7 @@ func (dr DAGRun) ListSubDAGRuns(ctx context.Context) ([]*DAGRun, error) {
 // It searches through all run directories and returns the first valid Attempt found.
 // It skips hidden attempts (dequeued ones).
 func (dr DAGRun) LatestAttempt(ctx context.Context, cache *fileutil.Cache[*exec.DAGRunStatus]) (*Attempt, error) {
-	attDirs, err := listDirsSorted(dr.baseDir, true, reAttemptDir)
+	attDirs, err := dr.listAttemptDirs()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list run directories: %w", err)
 	}
@@ -359,23 +367,14 @@ func (dr DAGRun) listAttemptDirs() ([]string, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		// Trim the dot prefix if it is a hidden directory
-		name := strings.TrimPrefix(entry.Name(), ".")
-		if reAttemptDir.MatchString(name) {
+		if isAttemptDirName(entry.Name()) {
 			dirs = append(dirs, entry.Name())
 		}
 	}
 
 	// Sort in reverse order (newest first) based on timestamp
 	sort.Slice(dirs, func(i, j int) bool {
-		// Extract timestamps for comparison
-		// Remove dot prefix if present for comparison
-		nameI := strings.TrimPrefix(dirs[i], ".")
-		nameJ := strings.TrimPrefix(dirs[j], ".")
-
-		// Compare timestamps (the format ensures lexical sort = chronological sort)
-		// Reverse order: newer (larger) timestamps come first
-		return nameI > nameJ
+		return attemptDirNewer(dirs[i], dirs[j])
 	})
 	return dirs, nil
 }
@@ -487,10 +486,85 @@ func (dr DAGRun) validatedArtifactDir(dir string) (string, bool) {
 	return cleanDir, true
 }
 
+type attemptDirInfo struct {
+	timestamp string
+	id        string
+}
+
 // Regular expressions for parsing directory names
-var reDAGRunDir = regexp.MustCompile(`^` + DAGRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`)         // Matches dag-run directory names
-var reAttemptDir = regexp.MustCompile(`^` + AttemptDirPrefix + `(\d{8}_\d{6}_\d{3}Z)_(.*)$`) // Matches attempt directory names
-var reSubDAGRunDir = regexp.MustCompile(`^` + SubDAGRunDirPrefix + `(.*)$`)                  // Matches sub dag-run directory names
+var reDAGRunDir = regexp.MustCompile(`^` + DAGRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`) // Matches dag-run directory names
+var reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(AttemptDirPrefix) + `|` + regexp.QuoteMeta(LegacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
+
+func attemptDirName(ts exec.TimeInUTC, attemptID string) string {
+	return AttemptDirPrefix + formatAttemptTimestamp(ts) + "_" + attemptID
+}
+
+func parseAttemptDirName(name string) (attemptDirInfo, bool) {
+	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
+	if len(matches) != 3 {
+		return attemptDirInfo{}, false
+	}
+	return attemptDirInfo{timestamp: matches[1], id: matches[2]}, true
+}
+
+func isAttemptDirName(name string) bool {
+	_, ok := parseAttemptDirName(name)
+	return ok
+}
+
+// IsAttemptDirName reports whether a directory name is a current or legacy attempt directory.
+func IsAttemptDirName(name string) bool {
+	return isAttemptDirName(name)
+}
+
+func attemptDirNewer(a, b string) bool {
+	aInfo, aOK := parseAttemptDirName(a)
+	bInfo, bOK := parseAttemptDirName(b)
+	if aOK && bOK {
+		if aInfo.timestamp != bInfo.timestamp {
+			return aInfo.timestamp > bInfo.timestamp
+		}
+		if aInfo.id != bInfo.id {
+			return aInfo.id > bInfo.id
+		}
+	}
+	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")
+}
+
+func attemptDirOlder(a, b string) bool {
+	aInfo, aOK := parseAttemptDirName(a)
+	bInfo, bOK := parseAttemptDirName(b)
+	if aOK && bOK {
+		if aInfo.timestamp != bInfo.timestamp {
+			return aInfo.timestamp < bInfo.timestamp
+		}
+		if aInfo.id != bInfo.id {
+			return aInfo.id < bInfo.id
+		}
+	}
+	return strings.TrimPrefix(a, ".") < strings.TrimPrefix(b, ".")
+}
+
+func parseSubDAGRunDirName(parentDirName, dirName string) (string, bool) {
+	switch parentDirName {
+	case SubDAGRunsDir:
+		if dirName == "" || strings.HasPrefix(dirName, ".") {
+			return "", false
+		}
+		return dirName, true
+	case LegacySubDAGRunsDir:
+		if !strings.HasPrefix(dirName, LegacySubDAGRunDirPrefix) {
+			return "", false
+		}
+		dagRunID := strings.TrimPrefix(dirName, LegacySubDAGRunDirPrefix)
+		if dagRunID == "" {
+			return "", false
+		}
+		return dagRunID, true
+	default:
+		return "", false
+	}
+}
 
 // formatDAGRunTimestamp formats a models.TimeInUTC instance into a string representation (without milliseconds).
 // The format is "YYYYMMDD_HHMMSSZ".

--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -170,11 +170,12 @@ func (dr DAGRun) FindSubDAGRun(_ context.Context, dagRunID string) (*DAGRun, err
 	if err := exec.ValidateDAGRunID(dagRunID); err != nil {
 		return nil, fmt.Errorf("invalid sub dag-run ID: %w", err)
 	}
-	candidates := []string{
-		filepath.Join(dr.baseDir, SubDAGRunsDir, dagRunID),
-		filepath.Join(dr.baseDir, LegacySubDAGRunsDir, LegacySubDAGRunDirPrefix+dagRunID),
-	}
-	for _, dir := range candidates {
+	for _, parentDirName := range []string{SubDAGRunsDir, LegacySubDAGRunsDir} {
+		dirName, ok := subDAGRunDirName(parentDirName, dagRunID)
+		if !ok {
+			continue
+		}
+		dir := filepath.Join(dr.baseDir, parentDirName, dirName)
 		info, err := os.Stat(dir)
 		if err == nil && info.IsDir() {
 			return newDAGRun(dir, dr.artifactDir)
@@ -524,6 +525,23 @@ func attemptDirNewer(a, b string) bool {
 
 func attemptDirOlder(a, b string) bool {
 	return attemptDirNewer(b, a)
+}
+
+func subDAGRunDirName(parentDirName, dagRunID string) (string, bool) {
+	switch parentDirName {
+	case SubDAGRunsDir:
+		if dagRunID == "" || strings.HasPrefix(dagRunID, ".") {
+			return "", false
+		}
+		return dagRunID, true
+	case LegacySubDAGRunsDir:
+		if dagRunID == "" {
+			return "", false
+		}
+		return LegacySubDAGRunDirPrefix + dagRunID, true
+	default:
+		return "", false
+	}
 }
 
 func subDAGRunIDFromDir(parentDirName, dirName string) (string, bool) {

--- a/internal/persis/file/dagrun/dagrun_test.go
+++ b/internal/persis/file/dagrun/dagrun_test.go
@@ -160,6 +160,21 @@ func TestListSubDAGRuns(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, filepath.Join(currentSubDir, "shared"), shared.baseDir)
 	})
+
+	t.Run("RejectsInvalidSubDAGRunID", func(t *testing.T) {
+		root := setupTestDataRoot(t)
+		run := root.CreateTestDAGRun(t, "parent-dag-run", exec.NewUTC(time.Now()))
+
+		_, err := run.CreateSubDAGRun(run.Context, "../../escape")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid sub dag-run ID")
+
+		_, err = run.FindSubDAGRun(run.Context, "../../escape")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid sub dag-run ID")
+
+		require.NoDirExists(t, filepath.Join(filepath.Dir(run.baseDir), "escape"))
+	})
 }
 
 func TestListLogFiles(t *testing.T) {

--- a/internal/persis/file/dagrun/dagrun_test.go
+++ b/internal/persis/file/dagrun/dagrun_test.go
@@ -578,15 +578,14 @@ func TestDAGRun_listAttemptDirs(t *testing.T) {
 	// Should return 4 directories (2 normal + 2 hidden)
 	assert.Len(t, dirs, 4, "should return all attempt directories including hidden ones")
 
-	// Verify the directories are sorted in reverse order (newest first)
-	// The hidden attempt with latest timestamp should be first
+	// Verify current-format attempts are ordered before legacy attempts.
 	expected := []string{
-		".a_20250722_120200_789Z_ghi789",       // Latest (hidden)
-		".attempt_20250722_120150_789Z_legacy", // Second (hidden legacy)
-		"a_20250722_120100_456Z_def456",        // Third
-		"attempt_20250722_120000_123Z_abc123",  // Oldest
+		".a_20250722_120200_789Z_ghi789",
+		"a_20250722_120100_456Z_def456",
+		".attempt_20250722_120150_789Z_legacy",
+		"attempt_20250722_120000_123Z_abc123",
 	}
-	assert.Equal(t, expected, dirs, "directories should be sorted newest first with hidden directory in correct position")
+	assert.Equal(t, expected, dirs, "current-format attempts should be ordered before legacy attempts")
 
 	// Create status files so attempts are considered valid
 	for _, dir := range []string{normalAttempt1, normalAttempt2, legacyHiddenAttempt, hiddenAttempt} {

--- a/internal/persis/file/dagrun/dagrun_test.go
+++ b/internal/persis/file/dagrun/dagrun_test.go
@@ -114,8 +114,8 @@ func TestListSubDAGRuns(t *testing.T) {
 		require.NoError(t, os.MkdirAll(subDir, 0750))
 
 		// Create two sub dag-run directories
-		sub1Dir := filepath.Join(subDir, SubDAGRunDirPrefix+"sub1")
-		sub2Dir := filepath.Join(subDir, SubDAGRunDirPrefix+"sub2")
+		sub1Dir := filepath.Join(subDir, "sub1")
+		sub2Dir := filepath.Join(subDir, "sub2")
 		require.NoError(t, os.MkdirAll(sub1Dir, 0750))
 		require.NoError(t, os.MkdirAll(sub2Dir, 0750))
 
@@ -134,6 +134,31 @@ func TestListSubDAGRuns(t *testing.T) {
 		}
 		assert.Contains(t, subIDs, "sub1")
 		assert.Contains(t, subIDs, "sub2")
+	})
+
+	t.Run("WithCurrentAndLegacySubDAGRuns", func(t *testing.T) {
+		root := setupTestDataRoot(t)
+		run := root.CreateTestDAGRun(t, "parent-dag-run", exec.NewUTC(time.Now()))
+
+		currentSubDir := filepath.Join(run.baseDir, SubDAGRunsDir)
+		legacySubDir := filepath.Join(run.baseDir, LegacySubDAGRunsDir)
+		require.NoError(t, os.MkdirAll(filepath.Join(currentSubDir, "current"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(currentSubDir, "shared"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(legacySubDir, LegacySubDAGRunDirPrefix+"legacy"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(legacySubDir, LegacySubDAGRunDirPrefix+"shared"), 0750))
+
+		subRuns, err := run.ListSubDAGRuns(run.Context)
+		require.NoError(t, err)
+
+		subIDs := make([]string, len(subRuns))
+		for i, subRun := range subRuns {
+			subIDs[i] = subRun.dagRunID
+		}
+		assert.ElementsMatch(t, []string{"current", "shared", "legacy"}, subIDs)
+
+		shared, err := run.FindSubDAGRun(run.Context, "shared")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(currentSubDir, "shared"), shared.baseDir)
 	})
 }
 
@@ -282,7 +307,7 @@ func TestRemoveLogFiles(t *testing.T) {
 		subDir := filepath.Join(run.baseDir, SubDAGRunsDir)
 		require.NoError(t, os.MkdirAll(subDir, 0750))
 
-		subDAGRunDir := filepath.Join(subDir, SubDAGRunDirPrefix+"sub1")
+		subDAGRunDir := filepath.Join(subDir, "sub1")
 		require.NoError(t, os.MkdirAll(subDAGRunDir, 0750))
 
 		subDAGRun, err := NewDAGRun(subDAGRunDir)
@@ -440,7 +465,7 @@ func TestDAGRunRemove(t *testing.T) {
 		}
 
 		for _, subRun := range subDAGRuns {
-			subDAGRunDir := filepath.Join(subDir, SubDAGRunDirPrefix+subRun.dagRunID)
+			subDAGRunDir := filepath.Join(subDir, subRun.dagRunID)
 			require.NoError(t, os.MkdirAll(subDAGRunDir, 0750))
 
 			subDAGRun, err := NewDAGRun(subDAGRunDir)
@@ -529,12 +554,14 @@ func TestDAGRun_listAttemptDirs(t *testing.T) {
 
 	// Create some normal attempt directories with older timestamps
 	normalAttempt1 := filepath.Join(run.baseDir, "attempt_20250722_120000_123Z_abc123")
-	normalAttempt2 := filepath.Join(run.baseDir, "attempt_20250722_120100_456Z_def456")
+	normalAttempt2 := filepath.Join(run.baseDir, "a_20250722_120100_456Z_def456")
 	require.NoError(t, os.MkdirAll(normalAttempt1, 0755))
 	require.NoError(t, os.MkdirAll(normalAttempt2, 0755))
 
-	// Create a hidden attempt directory with the latest timestamp
-	hiddenAttempt := filepath.Join(run.baseDir, ".attempt_20250722_120200_789Z_ghi789")
+	// Create hidden attempt directories with old and new prefixes
+	legacyHiddenAttempt := filepath.Join(run.baseDir, ".attempt_20250722_120150_789Z_legacy")
+	hiddenAttempt := filepath.Join(run.baseDir, ".a_20250722_120200_789Z_ghi789")
+	require.NoError(t, os.MkdirAll(legacyHiddenAttempt, 0755))
 	require.NoError(t, os.MkdirAll(hiddenAttempt, 0755))
 
 	// Create some non-attempt directories that should be ignored
@@ -548,20 +575,21 @@ func TestDAGRun_listAttemptDirs(t *testing.T) {
 	dirs, err := run.listAttemptDirs()
 	require.NoError(t, err)
 
-	// Should return 3 directories (2 normal + 1 hidden)
-	assert.Len(t, dirs, 3, "should return all attempt directories including hidden ones")
+	// Should return 4 directories (2 normal + 2 hidden)
+	assert.Len(t, dirs, 4, "should return all attempt directories including hidden ones")
 
 	// Verify the directories are sorted in reverse order (newest first)
 	// The hidden attempt with latest timestamp should be first
 	expected := []string{
-		".attempt_20250722_120200_789Z_ghi789", // Latest (hidden)
-		"attempt_20250722_120100_456Z_def456",  // Second
+		".a_20250722_120200_789Z_ghi789",       // Latest (hidden)
+		".attempt_20250722_120150_789Z_legacy", // Second (hidden legacy)
+		"a_20250722_120100_456Z_def456",        // Third
 		"attempt_20250722_120000_123Z_abc123",  // Oldest
 	}
 	assert.Equal(t, expected, dirs, "directories should be sorted newest first with hidden directory in correct position")
 
 	// Create status files so attempts are considered valid
-	for _, dir := range []string{normalAttempt1, normalAttempt2, hiddenAttempt} {
+	for _, dir := range []string{normalAttempt1, normalAttempt2, legacyHiddenAttempt, hiddenAttempt} {
 		statusFile := filepath.Join(dir, JSONLStatusFile)
 		status := createTestStatus(core.Succeeded)
 		data, err := json.Marshal(status)

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -40,10 +40,6 @@ var (
 	reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(attemptDirPrefix) + `|` + regexp.QuoteMeta(legacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
 )
 
-type attemptDirInfo struct {
-	current bool
-}
-
 // Entry holds a cached summary for a single DAG run.
 type Entry struct {
 	DagRunDir            string
@@ -376,29 +372,17 @@ func findLatestAttempt(runDir string) (string, error) {
 	return attemptDirs[0], nil
 }
 
-func parseAttemptDirName(name string) (attemptDirInfo, bool) {
-	cleanName := strings.TrimPrefix(name, ".")
-	matches := reAttemptDir.FindStringSubmatch(cleanName)
-	if len(matches) != 3 {
-		return attemptDirInfo{}, false
-	}
-	return attemptDirInfo{current: strings.HasPrefix(cleanName, attemptDirPrefix)}, true
-}
-
 func isAttemptDirName(name string) bool {
-	_, ok := parseAttemptDirName(name)
-	return ok
+	return reAttemptDir.MatchString(strings.TrimPrefix(name, "."))
 }
 
 func attemptDirNewer(a, b string) bool {
-	aInfo, aOK := parseAttemptDirName(a)
-	bInfo, bOK := parseAttemptDirName(b)
-	if aOK && bOK {
-		if aInfo.current != bInfo.current {
-			return aInfo.current
-		}
+	a = strings.TrimPrefix(a, ".")
+	b = strings.TrimPrefix(b, ".")
+	if aCurrent, bCurrent := strings.HasPrefix(a, attemptDirPrefix), strings.HasPrefix(b, attemptDirPrefix); aCurrent != bCurrent {
+		return aCurrent
 	}
-	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")
+	return a > b
 }
 
 func parseDagRunID(dirName string) string {

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -29,15 +29,21 @@ const (
 	// MinRunsForIndex is the minimum number of runs needed to create an index.
 	MinRunsForIndex = 10
 
-	dagRunDirPrefix  = "dag-run_"
-	attemptDirPrefix = "attempt_"
-	statusFile       = "status.jsonl"
+	dagRunDirPrefix        = "dag-run_"
+	attemptDirPrefix       = "a_"
+	legacyAttemptDirPrefix = "attempt_"
+	statusFile             = "status.jsonl"
 )
 
 var (
 	reDAGRunDir  = regexp.MustCompile(`^` + dagRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`)
-	reAttemptDir = regexp.MustCompile(`^` + attemptDirPrefix + `(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
+	reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(attemptDirPrefix) + `|` + regexp.QuoteMeta(legacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
 )
+
+type attemptDirInfo struct {
+	timestamp string
+	id        string
+}
 
 // Entry holds a cached summary for a single DAG run.
 type Entry struct {
@@ -355,7 +361,7 @@ func findLatestAttempt(runDir string) (string, error) {
 		if strings.HasPrefix(name, ".") {
 			continue
 		}
-		if e.IsDir() && reAttemptDir.MatchString(name) {
+		if e.IsDir() && isAttemptDirName(name) {
 			attemptDirs = append(attemptDirs, name)
 		}
 	}
@@ -365,8 +371,37 @@ func findLatestAttempt(runDir string) (string, error) {
 	}
 
 	// Sort descending (newest first).
-	sort.Sort(sort.Reverse(sort.StringSlice(attemptDirs)))
+	sort.Slice(attemptDirs, func(i, j int) bool {
+		return attemptDirNewer(attemptDirs[i], attemptDirs[j])
+	})
 	return attemptDirs[0], nil
+}
+
+func parseAttemptDirName(name string) (attemptDirInfo, bool) {
+	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
+	if len(matches) != 3 {
+		return attemptDirInfo{}, false
+	}
+	return attemptDirInfo{timestamp: matches[1], id: matches[2]}, true
+}
+
+func isAttemptDirName(name string) bool {
+	_, ok := parseAttemptDirName(name)
+	return ok
+}
+
+func attemptDirNewer(a, b string) bool {
+	aInfo, aOK := parseAttemptDirName(a)
+	bInfo, bOK := parseAttemptDirName(b)
+	if aOK && bOK {
+		if aInfo.timestamp != bInfo.timestamp {
+			return aInfo.timestamp > bInfo.timestamp
+		}
+		if aInfo.id != bInfo.id {
+			return aInfo.id > bInfo.id
+		}
+	}
+	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")
 }
 
 func parseDagRunID(dirName string) string {

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -41,8 +41,7 @@ var (
 )
 
 type attemptDirInfo struct {
-	timestamp string
-	id        string
+	current bool
 }
 
 // Entry holds a cached summary for a single DAG run.
@@ -370,7 +369,7 @@ func findLatestAttempt(runDir string) (string, error) {
 		return "", nil
 	}
 
-	// Sort descending (newest first).
+	// Sort current-format attempts before legacy attempts.
 	sort.Slice(attemptDirs, func(i, j int) bool {
 		return attemptDirNewer(attemptDirs[i], attemptDirs[j])
 	})
@@ -378,11 +377,12 @@ func findLatestAttempt(runDir string) (string, error) {
 }
 
 func parseAttemptDirName(name string) (attemptDirInfo, bool) {
-	matches := reAttemptDir.FindStringSubmatch(strings.TrimPrefix(name, "."))
+	cleanName := strings.TrimPrefix(name, ".")
+	matches := reAttemptDir.FindStringSubmatch(cleanName)
 	if len(matches) != 3 {
 		return attemptDirInfo{}, false
 	}
-	return attemptDirInfo{timestamp: matches[1], id: matches[2]}, true
+	return attemptDirInfo{current: strings.HasPrefix(cleanName, attemptDirPrefix)}, true
 }
 
 func isAttemptDirName(name string) bool {
@@ -394,11 +394,8 @@ func attemptDirNewer(a, b string) bool {
 	aInfo, aOK := parseAttemptDirName(a)
 	bInfo, bOK := parseAttemptDirName(b)
 	if aOK && bOK {
-		if aInfo.timestamp != bInfo.timestamp {
-			return aInfo.timestamp > bInfo.timestamp
-		}
-		if aInfo.id != bInfo.id {
-			return aInfo.id > bInfo.id
+		if aInfo.current != bInfo.current {
+			return aInfo.current
 		}
 	}
 	return strings.TrimPrefix(a, ".") > strings.TrimPrefix(b, ".")

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
@@ -318,6 +318,7 @@ func TestFindLatestAttempt(t *testing.T) {
 	// Create current and legacy attempt directories.
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "attempt_20240115_120000_001Z_aaa"), 0750))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a_20240115_130000_002Z_bbb"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "attempt_20240115_140000_002Z_later-legacy"), 0750))
 	// Hidden attempt (dequeued).
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".a_20240115_140000_003Z_ccc"), 0750))
 

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
@@ -224,7 +224,7 @@ func TestTryLoadForDay_StaleIndex_NewAttempt(t *testing.T) {
 	dirEntries := readDayDir(t, dayDir)
 	for _, de := range dirEntries {
 		if de.IsDir() {
-			newAttemptDir := filepath.Join(dayDir, de.Name(), "attempt_20240115_130000_002Z_retry1")
+			newAttemptDir := filepath.Join(dayDir, de.Name(), "a_20240115_130000_002Z_retry1")
 			require.NoError(t, os.MkdirAll(newAttemptDir, 0750))
 			st := exec.DAGRunStatus{Status: core.Succeeded, StartedAt: "2024-01-15T13:00:00Z", FinishedAt: "2024-01-15T13:01:00Z"}
 			data, _ := json.Marshal(st)
@@ -242,7 +242,7 @@ func TestTryLoadForDay_StaleIndex_NewAttempt(t *testing.T) {
 	// Verify the rebuilt index reflects the new attempt.
 	found := false
 	for _, e := range entries {
-		if e.LatestAttemptDir == "attempt_20240115_130000_002Z_retry1" {
+		if e.LatestAttemptDir == "a_20240115_130000_002Z_retry1" {
 			found = true
 			break
 		}
@@ -315,15 +315,15 @@ func TestFilterDAGRunDirs(t *testing.T) {
 func TestFindLatestAttempt(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create attempt directories.
+	// Create current and legacy attempt directories.
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "attempt_20240115_120000_001Z_aaa"), 0750))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "attempt_20240115_130000_002Z_bbb"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a_20240115_130000_002Z_bbb"), 0750))
 	// Hidden attempt (dequeued).
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".attempt_20240115_140000_003Z_ccc"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".a_20240115_140000_003Z_ccc"), 0750))
 
 	latest, err := findLatestAttempt(dir)
 	require.NoError(t, err)
-	assert.Equal(t, "attempt_20240115_130000_002Z_bbb", latest)
+	assert.Equal(t, "a_20240115_130000_002Z_bbb", latest)
 }
 
 func TestFindLatestAttempt_Empty(t *testing.T) {

--- a/internal/persis/file/dagrun/latest_attempt.go
+++ b/internal/persis/file/dagrun/latest_attempt.go
@@ -143,7 +143,7 @@ func parseAttemptStatusFileInfo(statusFile string) (attemptStatusFileInfo, bool)
 
 	attemptDir := filepath.Dir(cleanStatusFile)
 	attemptDirName := filepath.Base(attemptDir)
-	if !isAttemptDirName(attemptDirName) {
+	if !IsAttemptDirName(attemptDirName) {
 		return attemptStatusFileInfo{}, false
 	}
 

--- a/internal/persis/file/dagrun/latest_attempt.go
+++ b/internal/persis/file/dagrun/latest_attempt.go
@@ -143,7 +143,7 @@ func parseAttemptStatusFileInfo(statusFile string) (attemptStatusFileInfo, bool)
 
 	attemptDir := filepath.Dir(cleanStatusFile)
 	attemptDirName := filepath.Base(attemptDir)
-	if !reAttemptDir.MatchString(attemptDirName) {
+	if !isAttemptDirName(attemptDirName) {
 		return attemptStatusFileInfo{}, false
 	}
 
@@ -182,7 +182,7 @@ func attemptStatusFileInfoLess(a, b attemptStatusFileInfo) bool {
 	if a.runDirName != b.runDirName {
 		return a.runDirName < b.runDirName
 	}
-	return a.attemptDirName < b.attemptDirName
+	return attemptDirOlder(a.attemptDirName, b.attemptDirName)
 }
 
 func latestAttemptPointerPath(dagRunsDir string) string {

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -185,7 +185,7 @@ func retryCandidateRootPaths(statusFile string) (runDir, dayDir string, ok bool)
 		return "", "", false
 	}
 	attemptDir := filepath.Dir(statusFile)
-	if !strings.HasPrefix(filepath.Base(attemptDir), AttemptDirPrefix) {
+	if !isAttemptDirName(filepath.Base(attemptDir)) {
 		return "", "", false
 	}
 	runDir = filepath.Dir(attemptDir)

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -185,7 +185,7 @@ func retryCandidateRootPaths(statusFile string) (runDir, dayDir string, ok bool)
 		return "", "", false
 	}
 	attemptDir := filepath.Dir(statusFile)
-	if !isAttemptDirName(filepath.Base(attemptDir)) {
+	if !IsAttemptDirName(filepath.Base(attemptDir)) {
 		return "", "", false
 	}
 	runDir = filepath.Dir(attemptDir)

--- a/internal/persis/file/dagrun/retry_candidates_external_test.go
+++ b/internal/persis/file/dagrun/retry_candidates_external_test.go
@@ -189,7 +189,7 @@ func TestStoreListRetryCandidatesIgnoresChildAttemptStatusFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, candidates)
 
-	childSidecarDir := filepath.Join(
+	runDir := filepath.Join(
 		baseDir,
 		parentDAG.Name,
 		"dag-runs",
@@ -197,10 +197,9 @@ func TestStoreListRetryCandidatesIgnoresChildAttemptStatusFiles(t *testing.T) {
 		"06",
 		"08",
 		"dag-run_20260608_120000Z_parent-run",
-		"children",
-		".dagrun.retry-candidates",
 	)
-	require.NoDirExists(t, childSidecarDir)
+	require.NoDirExists(t, filepath.Join(runDir, dagrun.SubDAGRunsDir, ".dagrun.retry-candidates"))
+	require.NoDirExists(t, filepath.Join(runDir, dagrun.LegacySubDAGRunsDir, ".dagrun.retry-candidates"))
 }
 
 func retryCandidateDAG() *core.DAG {

--- a/internal/persis/file/dagrun/store_test.go
+++ b/internal/persis/file/dagrun/store_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStorePreservesDAGRunFileCompatibilityLayout(t *testing.T) {
+func TestStoreWritesCurrentDAGRunFileCompatibilityLayout(t *testing.T) {
 	ctx := context.Background()
 	baseDir := t.TempDir()
 	store := New(baseDir, WithArtifactDir(filepath.Join(baseDir, "artifacts")))
@@ -78,7 +78,7 @@ func TestStorePreservesDAGRunFileCompatibilityLayout(t *testing.T) {
 	require.NoError(t, childAttempt.Close(ctx))
 
 	runDir := filepath.Join(baseDir, "compat-dag", "dag-runs", "2026", "05", "27", "dag-run_20260527_010203Z_run-compat")
-	attemptDir := filepath.Join(runDir, "attempt_20260527_010203_456Z_attempt-compat")
+	attemptDir := filepath.Join(runDir, "a_20260527_010203_456Z_attempt-compat")
 	statusFile := filepath.Join(attemptDir, JSONLStatusFile)
 	assert.Equal(t, statusFile, parentAttempt.(*Attempt).file)
 	assert.Equal(t, filepath.Join(runDir, "work"), parentAttempt.(*Attempt).WorkDir())
@@ -90,11 +90,11 @@ func TestStorePreservesDAGRunFileCompatibilityLayout(t *testing.T) {
 	require.DirExists(t, filepath.Join(runDir, "work"))
 	require.FileExists(t, filepath.Join(runDir, MessagesDir, "step-one.json"))
 
-	childAttemptDir := filepath.Join(runDir, SubDAGRunsDir, "child_child-run", "attempt_20260527_010204_789Z_child-attempt")
+	childAttemptDir := filepath.Join(runDir, SubDAGRunsDir, "child-run", "a_20260527_010204_789Z_child-attempt")
 	require.DirExists(t, childAttemptDir)
 	require.FileExists(t, filepath.Join(childAttemptDir, JSONLStatusFile))
 	require.FileExists(t, filepath.Join(childAttemptDir, DAGDefinition))
-	require.NoDirExists(t, filepath.Join(runDir, SubDAGRunsDir, "child_child-run", "work"))
+	require.NoDirExists(t, filepath.Join(runDir, SubDAGRunsDir, "child-run", "work"))
 	childWorkDir := filepath.Join(runDir, subDAGWorkDirName("child-run"))
 	assert.Equal(t, childWorkDir, childAttempt.(*Attempt).WorkDir())
 	require.DirExists(t, childWorkDir)
@@ -137,6 +137,44 @@ func TestStorePreservesDAGRunFileCompatibilityLayout(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, childStatus.DAGRunID, foundChildStatus.DAGRunID)
 	assert.Equal(t, childStatus.AttemptID, foundChildStatus.AttemptID)
+}
+
+func TestStoreRetriesLegacySubDAGRunInSameDirectory(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := New(baseDir, WithArtifactDir(filepath.Join(baseDir, "artifacts")))
+
+	parentDAG := &core.DAG{
+		Name:     "compat-dag",
+		Location: filepath.Join(baseDir, "compat-dag.yaml"),
+	}
+	parentTS := time.Date(2026, 5, 27, 1, 2, 3, 456_000_000, time.UTC)
+	_, err := store.CreateAttempt(ctx, parentDAG, parentTS, "run-compat", exec.NewDAGRunAttemptOptions{
+		AttemptID: "attempt-compat",
+	})
+	require.NoError(t, err)
+
+	runDir := filepath.Join(baseDir, "compat-dag", "dag-runs", "2026", "05", "27", "dag-run_20260527_010203Z_run-compat")
+	legacyChildDir := filepath.Join(runDir, LegacySubDAGRunsDir, LegacySubDAGRunDirPrefix+"child-run")
+	require.NoError(t, os.MkdirAll(legacyChildDir, 0750))
+
+	rootRef := exec.NewDAGRunRef(parentDAG.Name, "run-compat")
+	childDAG := &core.DAG{
+		Name:     "child-dag",
+		Location: filepath.Join(baseDir, "child-dag.yaml"),
+	}
+	childTS := time.Date(2026, 5, 27, 1, 2, 4, 789_000_000, time.UTC)
+	childAttempt, err := store.CreateAttempt(ctx, childDAG, childTS, "child-run", exec.NewDAGRunAttemptOptions{
+		RootDAGRun: &rootRef,
+		Retry:      true,
+		AttemptID:  "child-retry",
+	})
+	require.NoError(t, err)
+
+	expectedAttemptDir := filepath.Join(legacyChildDir, "a_20260527_010204_789Z_child-retry")
+	assert.Equal(t, filepath.Join(expectedAttemptDir, JSONLStatusFile), childAttempt.(*Attempt).file)
+	require.DirExists(t, expectedAttemptDir)
+	require.NoDirExists(t, filepath.Join(runDir, SubDAGRunsDir, "child-run"))
 }
 
 func TestJSONDB(t *testing.T) {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/launcher"
-	"github.com/google/uuid"
 )
 
 const staleLocalRunStartupGrace = 2 * time.Second
@@ -199,13 +198,13 @@ func (m *Manager) stopSingleDAGRun(ctx context.Context, dag *core.DAG, dagRunID 
 	return fmt.Errorf("failed to find dag-run attempt: %w", err)
 }
 
-// GenDAGRunID generates a unique ID for a dag-run using UUID version 7.
+// GenDAGRunID generates a unique ID for a dag-run.
 func (m *Manager) GenDAGRunID(_ context.Context) (string, error) {
-	id, err := uuid.NewV7()
+	id, err := exec.NewDAGRunID()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate dag-run ID: %w", err)
 	}
-	return id.String(), nil
+	return id, nil
 }
 
 // IsRunning checks if a dag-run is currently running. It prefers the live socket

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -498,13 +498,22 @@ func scanDAGRunAttemptStatuses(root, runDir string, files map[string]statusFileS
 		}
 	}
 
-	childRunDirs, err := childDirs(filepath.Join(runDir, filedagrun.SubDAGRunsDir), isSubDAGRunDirName)
-	if err != nil {
-		return err
+	childRunRoots := []struct {
+		dirName string
+		match   func(string) bool
+	}{
+		{dirName: filedagrun.SubDAGRunsDir, match: isCurrentSubDAGRunDirName},
+		{dirName: filedagrun.LegacySubDAGRunsDir, match: isLegacySubDAGRunDirName},
 	}
-	for _, childRunDir := range childRunDirs {
-		if err := scanDAGRunAttemptStatuses(root, childRunDir, files); err != nil {
+	for _, childRunRoot := range childRunRoots {
+		childRunDirs, err := childDirs(filepath.Join(runDir, childRunRoot.dirName), childRunRoot.match)
+		if err != nil {
 			return err
+		}
+		for _, childRunDir := range childRunDirs {
+			if err := scanDAGRunAttemptStatuses(root, childRunDir, files); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -578,13 +587,16 @@ func isDAGRunDirName(name string) bool {
 	return strings.HasPrefix(name, filedagrun.DAGRunDirPrefix)
 }
 
-func isSubDAGRunDirName(name string) bool {
-	return strings.HasPrefix(name, filedagrun.SubDAGRunDirPrefix)
+func isCurrentSubDAGRunDirName(name string) bool {
+	return name != "" && !strings.HasPrefix(name, ".")
+}
+
+func isLegacySubDAGRunDirName(name string) bool {
+	return strings.HasPrefix(name, filedagrun.LegacySubDAGRunDirPrefix)
 }
 
 func isAttemptDirName(name string) bool {
-	return strings.HasPrefix(name, filedagrun.AttemptDirPrefix) ||
-		strings.HasPrefix(name, "."+filedagrun.AttemptDirPrefix)
+	return filedagrun.IsAttemptDirName(name)
 }
 
 func isYearDirName(name string) bool {

--- a/internal/service/frontend/sse/app_stream_external_test.go
+++ b/internal/service/frontend/sse/app_stream_external_test.go
@@ -16,14 +16,20 @@ import (
 func TestDAGRunStatusFilePathsOnlyIncludesStatusJSONL(t *testing.T) {
 	root := t.TempDir()
 	runDir := filepath.Join(root, "dag", "dag-runs", "2026", "06", "29", "dag-run_20260629_010203Z_run")
-	statusFile := filepath.Join(runDir, "attempt_20260629_010203_000Z_attempt", "status.jsonl")
-	childStatusFile := filepath.Join(runDir, "children", "child_child-run", "attempt_20260629_010204_000Z_child", "status.jsonl")
+	statusFile := filepath.Join(runDir, "a_20260629_010203_000Z_attempt", "status.jsonl")
+	legacyStatusFile := filepath.Join(runDir, "attempt_20260629_010202_000Z_legacy", "status.jsonl")
+	childStatusFile := filepath.Join(runDir, "sub", "child-run", "a_20260629_010204_000Z_child", "status.jsonl")
+	legacyChildStatusFile := filepath.Join(runDir, "children", "child_legacy-child", "attempt_20260629_010205_000Z_legacy-child", "status.jsonl")
 	noiseStatusFile := filepath.Join(runDir, "work", "status.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(statusFile), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyStatusFile), 0o750))
 	require.NoError(t, os.MkdirAll(filepath.Dir(childStatusFile), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyChildStatusFile), 0o750))
 	require.NoError(t, os.MkdirAll(filepath.Dir(noiseStatusFile), 0o750))
 	require.NoError(t, os.WriteFile(statusFile, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(legacyStatusFile, []byte("{}\n"), 0o600))
 	require.NoError(t, os.WriteFile(childStatusFile, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(legacyChildStatusFile, []byte("{}\n"), 0o600))
 	require.NoError(t, os.WriteFile(noiseStatusFile, []byte("{}\n"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(statusFile), "dag.json"), []byte("{}\n"), 0o600))
 
@@ -31,7 +37,9 @@ func TestDAGRunStatusFilePathsOnlyIncludesStatusJSONL(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{
-		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/attempt_20260629_010203_000Z_attempt/status.jsonl",
-		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/children/child_child-run/attempt_20260629_010204_000Z_child/status.jsonl",
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/a_20260629_010203_000Z_attempt/status.jsonl",
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/attempt_20260629_010202_000Z_legacy/status.jsonl",
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/children/child_legacy-child/attempt_20260629_010205_000Z_legacy-child/status.jsonl",
+		"dag/dag-runs/2026/06/29/dag-run_20260629_010203Z_run/sub/child-run/a_20260629_010204_000Z_child/status.jsonl",
 	}, paths)
 }

--- a/internal/service/scheduler/catchup_runid.go
+++ b/internal/service/scheduler/catchup_runid.go
@@ -21,53 +21,52 @@ const (
 	maxRunIDLen = 64
 
 	// hashLen is the number of hex characters from the SHA-256 hash.
-	hashLen = 8
+	hashLen       = 12
+	legacyHashLen = 8
 
 	// timestampLayout is the format for the scheduled time portion.
 	timestampLayout = "20060102T150405"
 )
 
 // GenerateCatchupRunID produces a deterministic run ID for a catchup run.
-// The format is: catchup-{sanitizedName}-{hash8}-{20060102T150405}
-//
-// The hash is derived from the original (unsanitized) DAG name, ensuring
-// that DAGs whose names differ only in characters that get sanitized
-// (e.g., dots vs underscores) still produce distinct run IDs.
-//
-// When the sanitized name exceeds the available space, it is truncated.
 func GenerateCatchupRunID(dagName string, scheduledTime time.Time) string {
-	return generateScheduledRunID(catchupPrefix, dagName, dagName, scheduledTime)
+	return generateScheduledRunID(catchupPrefix, dagName, scheduledTime)
 }
 
 // GenerateOneOffRunID produces a deterministic run ID for a one-off schedule.
 func GenerateOneOffRunID(dagName, fingerprint string, scheduledTime time.Time) string {
-	return generateScheduledRunID(oneOffPrefix, dagName, dagName+":"+fingerprint, scheduledTime)
+	return generateScheduledRunID(oneOffPrefix, dagName+":"+fingerprint, scheduledTime)
 }
 
-func generateScheduledRunID(prefix, dagName, hashSource string, scheduledTime time.Time) string {
-	sanitized := sanitizeDagName(dagName)
-	hash := dagNameHash(hashSource)
+func generateScheduledRunID(prefix, hashSource string, scheduledTime time.Time) string {
+	hash := scheduledRunIDHash(hashSource, hashLen)
 	ts := scheduledTime.UTC().Format(timestampLayout)
+	return fmt.Sprintf("%s%s-%s", prefix, hash, ts)
+}
 
-	maxNameLen := maxRunIDLen - len(prefix) - 1 - hashLen - 1 - len(timestampLayout)
+func generateLegacyCatchupRunID(dagName string, scheduledTime time.Time) string {
+	return generateLegacyScheduledRunID(catchupPrefix, dagName, dagName, scheduledTime)
+}
+
+func generateLegacyOneOffRunID(dagName, fingerprint string, scheduledTime time.Time) string {
+	return generateLegacyScheduledRunID(oneOffPrefix, dagName, dagName+":"+fingerprint, scheduledTime)
+}
+
+func generateLegacyScheduledRunID(prefix, dagName, hashSource string, scheduledTime time.Time) string {
+	sanitized := sanitizeDagName(dagName)
+	ts := scheduledTime.UTC().Format(timestampLayout)
+	maxNameLen := maxRunIDLen - len(prefix) - 1 - legacyHashLen - 1 - len(timestampLayout)
 	if len(sanitized) > maxNameLen {
 		sanitized = sanitized[:maxNameLen]
 	}
-
-	return fmt.Sprintf("%s%s-%s-%s", prefix, sanitized, hash, ts)
+	return fmt.Sprintf("%s%s-%s-%s", prefix, sanitized, scheduledRunIDHash(hashSource, legacyHashLen), ts)
 }
 
-// sanitizeDagName replaces characters not allowed in run IDs.
-// Run IDs allow: [a-zA-Z0-9_-]. DAG names also allow dots,
-// which are replaced with underscores to avoid ambiguity.
 func sanitizeDagName(name string) string {
 	return strings.ReplaceAll(name, ".", "_")
 }
 
-// dagNameHash returns the first 8 hex characters of the SHA-256 hash
-// of the original DAG name. This ensures uniqueness even when sanitization
-// would collapse different names to the same string.
-func dagNameHash(name string) string {
-	h := sha256.Sum256([]byte(name))
-	return hex.EncodeToString(h[:])[:hashLen]
+func scheduledRunIDHash(source string, length int) string {
+	h := sha256.Sum256([]byte(source))
+	return hex.EncodeToString(h[:])[:length]
 }

--- a/internal/service/scheduler/catchup_runid_test.go
+++ b/internal/service/scheduler/catchup_runid_test.go
@@ -4,6 +4,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,8 +20,7 @@ func TestGenerateCatchupRunID(t *testing.T) {
 
 	t.Run("normal name", func(t *testing.T) {
 		id := GenerateCatchupRunID("etl-pipeline", ts)
-		assert.Contains(t, id, "catchup-etl-pipeline-")
-		assert.Contains(t, id, "-20260312T140000")
+		assert.Regexp(t, scheduledRunIDPattern(catchupPrefix, "20260312T140000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -37,9 +37,9 @@ func TestGenerateCatchupRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2)
 	})
 
-	t.Run("dots replaced with underscores", func(t *testing.T) {
+	t.Run("name with dots remains valid", func(t *testing.T) {
 		id := GenerateCatchupRunID("my.dag.name", ts)
-		assert.Contains(t, id, "my_dag_name")
+		assert.Regexp(t, scheduledRunIDPattern(catchupPrefix, "20260312T140000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -55,17 +55,18 @@ func TestGenerateCatchupRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2, "dot and underscore DAG names must produce different IDs due to hash")
 	})
 
-	t.Run("long name truncated", func(t *testing.T) {
+	t.Run("long name keeps fixed length", func(t *testing.T) {
 		longName := "a-very-extremely-long-dag-name-that-exceeds-the-limit"
 		id := GenerateCatchupRunID(longName, ts)
+		assert.Len(t, id, len(catchupPrefix)+hashLen+1+len(timestampLayout))
 		assert.LessOrEqual(t, len(id), maxRunIDLen)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
-	t.Run("max length exactly 64", func(t *testing.T) {
-		// maxNameLen = 64 - 8 - 1 - 8 - 1 - 15 = 31
-		name := "abcdefghijklmnopqrstuvwxyz12345" // 31 chars
+	t.Run("well below max length", func(t *testing.T) {
+		name := "abcdefghijklmnopqrstuvwxyz12345"
 		id := GenerateCatchupRunID(name, ts)
+		assert.Len(t, id, len(catchupPrefix)+hashLen+1+len(timestampLayout))
 		assert.LessOrEqual(t, len(id), maxRunIDLen)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
@@ -103,8 +104,7 @@ func TestGenerateOneOffRunID(t *testing.T) {
 
 	t.Run("normal name", func(t *testing.T) {
 		id := GenerateOneOffRunID("etl-pipeline", fingerprint, ts)
-		assert.Contains(t, id, "oneoff-etl-pipeline-")
-		assert.Contains(t, id, "-20260329T011000")
+		assert.Regexp(t, scheduledRunIDPattern(oneOffPrefix, "20260329T011000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -120,6 +120,12 @@ func TestGenerateOneOffRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2)
 	})
 
+	t.Run("dag name changes ID", func(t *testing.T) {
+		id1 := GenerateOneOffRunID("my-dag", fingerprint, ts)
+		id2 := GenerateOneOffRunID("other-dag", fingerprint, ts)
+		assert.NotEqual(t, id1, id2)
+	})
+
 	t.Run("UTC normalization", func(t *testing.T) {
 		loc, _ := time.LoadLocation("America/New_York")
 		tsLocal := ts.In(loc)
@@ -127,4 +133,26 @@ func TestGenerateOneOffRunID(t *testing.T) {
 		id2 := GenerateOneOffRunID("my-dag", fingerprint, tsLocal)
 		assert.Equal(t, id1, id2)
 	})
+}
+
+func TestGenerateLegacyScheduledRunIDs(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 3, 12, 14, 0, 0, 0, time.UTC)
+
+	t.Run("catchup", func(t *testing.T) {
+		id := generateLegacyCatchupRunID("etl.pipeline", ts)
+		assert.Regexp(t, fmt.Sprintf(`^catchup-etl_pipeline-[0-9a-f]{%d}-20260312T140000$`, legacyHashLen), id)
+		require.NoError(t, exec.ValidateDAGRunID(id))
+	})
+
+	t.Run("one-off", func(t *testing.T) {
+		id := generateLegacyOneOffRunID("etl.pipeline", "at:2026-03-12T14:00:00Z", ts)
+		assert.Regexp(t, fmt.Sprintf(`^oneoff-etl_pipeline-[0-9a-f]{%d}-20260312T140000$`, legacyHashLen), id)
+		require.NoError(t, exec.ValidateDAGRunID(id))
+	})
+}
+
+func scheduledRunIDPattern(prefix, timestamp string) string {
+	return fmt.Sprintf(`^%s[0-9a-f]{%d}-%s$`, prefix, hashLen, timestamp)
 }

--- a/internal/service/scheduler/one_off_schedule_test.go
+++ b/internal/service/scheduler/one_off_schedule_test.go
@@ -160,6 +160,56 @@ func TestTickPlanner_DispatchRun_ExistingOneOffAttemptConsumesState(t *testing.T
 	assert.Equal(t, OneOffStatusConsumed, state.DAGs[dag.Name].OneOffs[schedule.Fingerprint()].Status)
 }
 
+func TestTickPlanner_DispatchRun_LegacyOneOffAttemptConsumesState(t *testing.T) {
+	t.Parallel()
+
+	scheduledTime := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	schedule := mustOneOffSchedule(t, "2026-02-07T12:00:00Z")
+	dag := &core.DAG{Name: "one.off-dag", Schedule: []core.Schedule{schedule}}
+	legacyRunID := generateLegacyOneOffRunID(dag.Name, schedule.Fingerprint(), scheduledTime)
+
+	store := &mockWatermarkStore{}
+	var checkedRunIDs []string
+	tp := NewTickPlanner(TickPlannerConfig{
+		WatermarkStore: store,
+		Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
+			t.Fatal("dispatch should not be called when the legacy run already exists")
+			return nil
+		},
+		RunExists: func(_ context.Context, _ *core.DAG, runID string) (bool, error) {
+			checkedRunIDs = append(checkedRunIDs, runID)
+			return runID == legacyRunID, nil
+		},
+		Clock: func() time.Time {
+			return scheduledTime
+		},
+	})
+
+	store.state = &SchedulerState{
+		Version: SchedulerStateVersion,
+		DAGs: map[string]DAGWatermark{
+			dag.Name: {
+				OneOffs: map[string]OneOffScheduleState{
+					schedule.Fingerprint(): {
+						ScheduledTime: scheduledTime,
+						Status:        OneOffStatusPending,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+	run, ok := tp.createPlannedRun(context.Background(), dag, schedule, scheduledTime, core.TriggerTypeScheduler)
+	require.True(t, ok)
+	tp.DispatchRun(context.Background(), run)
+
+	assert.Equal(t, []string{run.RunID, legacyRunID}, checkedRunIDs)
+	state := store.lastSaved()
+	require.NotNil(t, state)
+	assert.Equal(t, OneOffStatusConsumed, state.DAGs[dag.Name].OneOffs[schedule.Fingerprint()].Status)
+}
+
 func TestTickPlanner_DispatchRun_OneOffFailureLeavesPendingState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1259,6 +1259,42 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, dag *core.DAG) bool 
 	return watermarkAdvanced
 }
 
+func (tp *TickPlanner) runExistsAny(ctx context.Context, run PlannedRun, runIDs ...string) (bool, string, error) {
+	for _, runID := range runIDs {
+		if runID == "" {
+			continue
+		}
+		exists, err := tp.cfg.RunExists(ctx, run.DAG, runID)
+		if err != nil {
+			return false, runID, err
+		}
+		if exists {
+			return true, runID, nil
+		}
+	}
+	return false, "", nil
+}
+
+func legacyScheduledRunID(run PlannedRun) string {
+	if run.ScheduleType != ScheduleTypeStart {
+		return ""
+	}
+	if run.TriggerType == core.TriggerTypeCatchUp {
+		return generateLegacyCatchupRunID(run.DAG.Name, run.ScheduledTime)
+	}
+	if !run.Schedule.IsOneOff() {
+		return ""
+	}
+	fingerprint := run.Fingerprint
+	if fingerprint == "" {
+		fingerprint = run.Schedule.Fingerprint()
+	}
+	if fingerprint == "" {
+		return ""
+	}
+	return generateLegacyOneOffRunID(run.DAG.Name, fingerprint, run.ScheduledTime)
+}
+
 // DispatchRun dispatches a PlannedRun using the configured dispatch functions.
 func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	logger.Info(ctx, "Dispatching planned run",
@@ -1281,11 +1317,11 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-		exists, err := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
+		exists, existingRunID, err := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
 		if err != nil {
 			logger.Error(ctx, "Failed to check for existing one-off dag-run",
 				tag.DAG(run.DAG.Name),
-				tag.RunID(run.RunID),
+				tag.RunID(existingRunID),
 				tag.Error(err),
 			)
 			return
@@ -1307,6 +1343,21 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 				)
 				return
 			}
+			legacyRunID := legacyScheduledRunID(run)
+			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, legacyRunID)
+			if existsErr != nil {
+				logger.Error(ctx, "Failed to check for existing catchup dag-run",
+					tag.DAG(run.DAG.Name),
+					tag.RunID(existingRunID),
+					tag.Error(existsErr),
+				)
+				tp.reinsertCatchupItem(ctx, run)
+				return
+			}
+			if exists {
+				tp.advanceDAGWatermark(run.DAG.Name, run.ScheduledTime)
+				return
+			}
 			err = tp.cfg.Enqueue(ctx, run.DAG, run.RunID, run.TriggerType, run.ScheduledTime)
 		} else {
 			err = tp.cfg.Dispatch(ctx, run.DAG, run.RunID, run.TriggerType, run.ScheduledTime)
@@ -1319,11 +1370,11 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 
 	if err != nil {
 		if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-			exists, existsErr := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
+			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
 			if existsErr != nil {
 				logger.Error(ctx, "Failed to re-check one-off dag-run after dispatch error",
 					tag.DAG(run.DAG.Name),
-					tag.RunID(run.RunID),
+					tag.RunID(existingRunID),
 					tag.Error(existsErr),
 				)
 				return

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1259,42 +1259,6 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, dag *core.DAG) bool 
 	return watermarkAdvanced
 }
 
-func (tp *TickPlanner) runExistsAny(ctx context.Context, run PlannedRun, runIDs ...string) (bool, string, error) {
-	for _, runID := range runIDs {
-		if runID == "" {
-			continue
-		}
-		exists, err := tp.cfg.RunExists(ctx, run.DAG, runID)
-		if err != nil {
-			return false, runID, err
-		}
-		if exists {
-			return true, runID, nil
-		}
-	}
-	return false, "", nil
-}
-
-func legacyScheduledRunID(run PlannedRun) string {
-	if run.ScheduleType != ScheduleTypeStart {
-		return ""
-	}
-	if run.TriggerType == core.TriggerTypeCatchUp {
-		return generateLegacyCatchupRunID(run.DAG.Name, run.ScheduledTime)
-	}
-	if !run.Schedule.IsOneOff() {
-		return ""
-	}
-	fingerprint := run.Fingerprint
-	if fingerprint == "" {
-		fingerprint = run.Schedule.Fingerprint()
-	}
-	if fingerprint == "" {
-		return ""
-	}
-	return generateLegacyOneOffRunID(run.DAG.Name, fingerprint, run.ScheduledTime)
-}
-
 // DispatchRun dispatches a PlannedRun using the configured dispatch functions.
 func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	logger.Info(ctx, "Dispatching planned run",
@@ -1317,15 +1281,28 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-		exists, existingRunID, err := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
+		exists, err := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
 		if err != nil {
 			logger.Error(ctx, "Failed to check for existing one-off dag-run",
 				tag.DAG(run.DAG.Name),
-				tag.RunID(existingRunID),
+				tag.RunID(run.RunID),
 				tag.Error(err),
 			)
 			return
-		} else if exists {
+		}
+		if !exists {
+			legacyRunID := generateLegacyOneOffRunID(run.DAG.Name, run.Fingerprint, run.ScheduledTime)
+			exists, err = tp.cfg.RunExists(ctx, run.DAG, legacyRunID)
+			if err != nil {
+				logger.Error(ctx, "Failed to check for existing one-off dag-run",
+					tag.DAG(run.DAG.Name),
+					tag.RunID(legacyRunID),
+					tag.Error(err),
+				)
+				return
+			}
+		}
+		if exists {
 			if tp.markOneOffConsumed(run.DAG.Name, run.Fingerprint, run.ScheduledTime) {
 				tp.Flush(ctx)
 			}
@@ -1343,12 +1320,12 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 				)
 				return
 			}
-			legacyRunID := legacyScheduledRunID(run)
-			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, legacyRunID)
+			legacyRunID := generateLegacyCatchupRunID(run.DAG.Name, run.ScheduledTime)
+			exists, existsErr := tp.cfg.RunExists(ctx, run.DAG, legacyRunID)
 			if existsErr != nil {
 				logger.Error(ctx, "Failed to check for existing catchup dag-run",
 					tag.DAG(run.DAG.Name),
-					tag.RunID(existingRunID),
+					tag.RunID(legacyRunID),
 					tag.Error(existsErr),
 				)
 				tp.reinsertCatchupItem(ctx, run)
@@ -1370,15 +1347,28 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 
 	if err != nil {
 		if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
+			exists, existsErr := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
 			if existsErr != nil {
 				logger.Error(ctx, "Failed to re-check one-off dag-run after dispatch error",
 					tag.DAG(run.DAG.Name),
-					tag.RunID(existingRunID),
+					tag.RunID(run.RunID),
 					tag.Error(existsErr),
 				)
 				return
-			} else if exists {
+			}
+			if !exists {
+				legacyRunID := generateLegacyOneOffRunID(run.DAG.Name, run.Fingerprint, run.ScheduledTime)
+				exists, existsErr = tp.cfg.RunExists(ctx, run.DAG, legacyRunID)
+				if existsErr != nil {
+					logger.Error(ctx, "Failed to re-check one-off dag-run after dispatch error",
+						tag.DAG(run.DAG.Name),
+						tag.RunID(legacyRunID),
+						tag.Error(existsErr),
+					)
+					return
+				}
+			}
+			if exists {
 				if tp.markOneOffConsumed(run.DAG.Name, run.Fingerprint, run.ScheduledTime) {
 					tp.Flush(ctx)
 				}

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -1648,6 +1648,42 @@ func TestTickPlanner_DispatchRunSuspendedCatchupAdvancesWatermark(t *testing.T) 
 	assert.Equal(t, scheduledTime, wm.LastScheduledTime)
 }
 
+func TestTickPlanner_DispatchRunLegacyCatchupAttemptAdvancesWatermark(t *testing.T) {
+	t.Parallel()
+
+	store := &mockWatermarkStore{}
+	scheduledTime := time.Date(2026, 2, 7, 11, 0, 0, 0, time.UTC)
+	dag := newHourlyCatchupDAG(t, "legacy.catchup-dag")
+	legacyRunID := generateLegacyCatchupRunID(dag.Name, scheduledTime)
+	var checkedRunIDs []string
+
+	tp := NewTickPlanner(TickPlannerConfig{
+		WatermarkStore: store,
+		QueuesEnabled:  true,
+		Enqueue: func(_ context.Context, _ *core.DAG, _ string, _ core.TriggerType, _ time.Time) error {
+			t.Fatal("enqueue should not be called when the legacy run already exists")
+			return nil
+		},
+		RunExists: func(_ context.Context, _ *core.DAG, runID string) (bool, error) {
+			checkedRunIDs = append(checkedRunIDs, runID)
+			return runID == legacyRunID, nil
+		},
+		Events: make(chan DAGChangeEvent, 1),
+	})
+	require.NoError(t, tp.Init(context.Background(), nil))
+
+	run, ok := tp.createPlannedRun(context.Background(), dag, core.Schedule{}, scheduledTime, core.TriggerTypeCatchUp)
+	require.True(t, ok)
+	tp.DispatchRun(context.Background(), run)
+
+	assert.Equal(t, []string{legacyRunID}, checkedRunIDs)
+	tp.mu.RLock()
+	wm, ok := tp.watermarkState.DAGs[dag.Name]
+	tp.mu.RUnlock()
+	require.True(t, ok)
+	assert.Equal(t, scheduledTime, wm.LastScheduledTime)
+}
+
 func TestTickPlanner_DispatchRunRestartForwardsScheduledTime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- write new DAG-run attempts under `a_<timestamp>_<attempt-id>` while continuing to read legacy `attempt_<timestamp>_<attempt-id>` directories
- write new sub-DAG runs under `sub/<child-run-id>` while continuing to read legacy `children/child_<child-run-id>` directories
- keep mixed-layout reads compatible across latest-attempt pointers, retry candidates, dagrun index rebuilds, workdirs, and SSE status scanning
- validate sub-DAG run IDs before creating or looking up sub-run directories

## Testing
- `go test ./internal/persis/file/dagrun ./internal/persis/file/dagrun/dagrunindex ./internal/service/frontend/sse`
- `go test ./internal/persis/file/... ./internal/service/frontend/...`
- `go test ./internal/runtime/...`
- `go test ./internal/cmd/...`
- `git diff --check`
- GitHub Actions CI and Conformance checks are green on `93ce1ac978`

Closes #2352