### PR TITLE
fix: preserve scheduled run id compatibility

### DIFF
--- a/internal/service/scheduler/catchup_runid.go
+++ b/internal/service/scheduler/catchup_runid.go
@@ -21,53 +21,52 @@ const (
 	maxRunIDLen = 64
 
 	// hashLen is the number of hex characters from the SHA-256 hash.
-	hashLen = 8
+	hashLen       = 12
+	legacyHashLen = 8
 
 	// timestampLayout is the format for the scheduled time portion.
 	timestampLayout = "20060102T150405"
 )
 
 // GenerateCatchupRunID produces a deterministic run ID for a catchup run.
-// The format is: catchup-{sanitizedName}-{hash8}-{20060102T150405}
-//
-// The hash is derived from the original (unsanitized) DAG name, ensuring
-// that DAGs whose names differ only in characters that get sanitized
-// (e.g., dots vs underscores) still produce distinct run IDs.
-//
-// When the sanitized name exceeds the available space, it is truncated.
 func GenerateCatchupRunID(dagName string, scheduledTime time.Time) string {
-	return generateScheduledRunID(catchupPrefix, dagName, dagName, scheduledTime)
+	return generateScheduledRunID(catchupPrefix, dagName, scheduledTime)
 }
 
 // GenerateOneOffRunID produces a deterministic run ID for a one-off schedule.
 func GenerateOneOffRunID(dagName, fingerprint string, scheduledTime time.Time) string {
-	return generateScheduledRunID(oneOffPrefix, dagName, dagName+":"+fingerprint, scheduledTime)
+	return generateScheduledRunID(oneOffPrefix, dagName+":"+fingerprint, scheduledTime)
 }
 
-func generateScheduledRunID(prefix, dagName, hashSource string, scheduledTime time.Time) string {
-	sanitized := sanitizeDagName(dagName)
-	hash := dagNameHash(hashSource)
+func generateScheduledRunID(prefix, hashSource string, scheduledTime time.Time) string {
+	hash := scheduledRunIDHash(hashSource, hashLen)
 	ts := scheduledTime.UTC().Format(timestampLayout)
+	return fmt.Sprintf("%s%s-%s", prefix, hash, ts)
+}
 
-	maxNameLen := maxRunIDLen - len(prefix) - 1 - hashLen - 1 - len(timestampLayout)
+func generateLegacyCatchupRunID(dagName string, scheduledTime time.Time) string {
+	return generateLegacyScheduledRunID(catchupPrefix, dagName, dagName, scheduledTime)
+}
+
+func generateLegacyOneOffRunID(dagName, fingerprint string, scheduledTime time.Time) string {
+	return generateLegacyScheduledRunID(oneOffPrefix, dagName, dagName+":"+fingerprint, scheduledTime)
+}
+
+func generateLegacyScheduledRunID(prefix, dagName, hashSource string, scheduledTime time.Time) string {
+	sanitized := sanitizeDagName(dagName)
+	ts := scheduledTime.UTC().Format(timestampLayout)
+	maxNameLen := maxRunIDLen - len(prefix) - 1 - legacyHashLen - 1 - len(timestampLayout)
 	if len(sanitized) > maxNameLen {
 		sanitized = sanitized[:maxNameLen]
 	}
-
-	return fmt.Sprintf("%s%s-%s-%s", prefix, sanitized, hash, ts)
+	return fmt.Sprintf("%s%s-%s-%s", prefix, sanitized, scheduledRunIDHash(hashSource, legacyHashLen), ts)
 }
 
-// sanitizeDagName replaces characters not allowed in run IDs.
-// Run IDs allow: [a-zA-Z0-9_-]. DAG names also allow dots,
-// which are replaced with underscores to avoid ambiguity.
 func sanitizeDagName(name string) string {
 	return strings.ReplaceAll(name, ".", "_")
 }
 
-// dagNameHash returns the first 8 hex characters of the SHA-256 hash
-// of the original DAG name. This ensures uniqueness even when sanitization
-// would collapse different names to the same string.
-func dagNameHash(name string) string {
-	h := sha256.Sum256([]byte(name))
-	return hex.EncodeToString(h[:])[:hashLen]
+func scheduledRunIDHash(source string, length int) string {
+	h := sha256.Sum256([]byte(source))
+	return hex.EncodeToString(h[:])[:length]
 }

--- a/internal/service/scheduler/catchup_runid_test.go
+++ b/internal/service/scheduler/catchup_runid_test.go
@@ -4,6 +4,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,8 +20,7 @@ func TestGenerateCatchupRunID(t *testing.T) {
 
 	t.Run("normal name", func(t *testing.T) {
 		id := GenerateCatchupRunID("etl-pipeline", ts)
-		assert.Contains(t, id, "catchup-etl-pipeline-")
-		assert.Contains(t, id, "-20260312T140000")
+		assert.Regexp(t, scheduledRunIDPattern(catchupPrefix, "20260312T140000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -37,9 +37,9 @@ func TestGenerateCatchupRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2)
 	})
 
-	t.Run("dots replaced with underscores", func(t *testing.T) {
+	t.Run("name with dots remains valid", func(t *testing.T) {
 		id := GenerateCatchupRunID("my.dag.name", ts)
-		assert.Contains(t, id, "my_dag_name")
+		assert.Regexp(t, scheduledRunIDPattern(catchupPrefix, "20260312T140000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -55,17 +55,18 @@ func TestGenerateCatchupRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2, "dot and underscore DAG names must produce different IDs due to hash")
 	})
 
-	t.Run("long name truncated", func(t *testing.T) {
+	t.Run("long name keeps fixed length", func(t *testing.T) {
 		longName := "a-very-extremely-long-dag-name-that-exceeds-the-limit"
 		id := GenerateCatchupRunID(longName, ts)
+		assert.Len(t, id, len(catchupPrefix)+hashLen+1+len(timestampLayout))
 		assert.LessOrEqual(t, len(id), maxRunIDLen)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
-	t.Run("max length exactly 64", func(t *testing.T) {
-		// maxNameLen = 64 - 8 - 1 - 8 - 1 - 15 = 31
-		name := "abcdefghijklmnopqrstuvwxyz12345" // 31 chars
+	t.Run("well below max length", func(t *testing.T) {
+		name := "abcdefghijklmnopqrstuvwxyz12345"
 		id := GenerateCatchupRunID(name, ts)
+		assert.Len(t, id, len(catchupPrefix)+hashLen+1+len(timestampLayout))
 		assert.LessOrEqual(t, len(id), maxRunIDLen)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
@@ -103,8 +104,7 @@ func TestGenerateOneOffRunID(t *testing.T) {
 
 	t.Run("normal name", func(t *testing.T) {
 		id := GenerateOneOffRunID("etl-pipeline", fingerprint, ts)
-		assert.Contains(t, id, "oneoff-etl-pipeline-")
-		assert.Contains(t, id, "-20260329T011000")
+		assert.Regexp(t, scheduledRunIDPattern(oneOffPrefix, "20260329T011000"), id)
 		require.NoError(t, exec.ValidateDAGRunID(id))
 	})
 
@@ -120,6 +120,12 @@ func TestGenerateOneOffRunID(t *testing.T) {
 		assert.NotEqual(t, id1, id2)
 	})
 
+	t.Run("dag name changes ID", func(t *testing.T) {
+		id1 := GenerateOneOffRunID("my-dag", fingerprint, ts)
+		id2 := GenerateOneOffRunID("other-dag", fingerprint, ts)
+		assert.NotEqual(t, id1, id2)
+	})
+
 	t.Run("UTC normalization", func(t *testing.T) {
 		loc, _ := time.LoadLocation("America/New_York")
 		tsLocal := ts.In(loc)
@@ -127,4 +133,26 @@ func TestGenerateOneOffRunID(t *testing.T) {
 		id2 := GenerateOneOffRunID("my-dag", fingerprint, tsLocal)
 		assert.Equal(t, id1, id2)
 	})
+}
+
+func TestGenerateLegacyScheduledRunIDs(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 3, 12, 14, 0, 0, 0, time.UTC)
+
+	t.Run("catchup", func(t *testing.T) {
+		id := generateLegacyCatchupRunID("etl.pipeline", ts)
+		assert.Regexp(t, fmt.Sprintf(`^catchup-etl_pipeline-[0-9a-f]{%d}-20260312T140000$`, legacyHashLen), id)
+		require.NoError(t, exec.ValidateDAGRunID(id))
+	})
+
+	t.Run("one-off", func(t *testing.T) {
+		id := generateLegacyOneOffRunID("etl.pipeline", "at:2026-03-12T14:00:00Z", ts)
+		assert.Regexp(t, fmt.Sprintf(`^oneoff-etl_pipeline-[0-9a-f]{%d}-20260312T140000$`, legacyHashLen), id)
+		require.NoError(t, exec.ValidateDAGRunID(id))
+	})
+}
+
+func scheduledRunIDPattern(prefix, timestamp string) string {
+	return fmt.Sprintf(`^%s[0-9a-f]{%d}-%s$`, prefix, hashLen, timestamp)
 }

--- a/internal/service/scheduler/one_off_schedule_test.go
+++ b/internal/service/scheduler/one_off_schedule_test.go
@@ -160,6 +160,56 @@ func TestTickPlanner_DispatchRun_ExistingOneOffAttemptConsumesState(t *testing.T
 	assert.Equal(t, OneOffStatusConsumed, state.DAGs[dag.Name].OneOffs[schedule.Fingerprint()].Status)
 }
 
+func TestTickPlanner_DispatchRun_LegacyOneOffAttemptConsumesState(t *testing.T) {
+	t.Parallel()
+
+	scheduledTime := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	schedule := mustOneOffSchedule(t, "2026-02-07T12:00:00Z")
+	dag := &core.DAG{Name: "one.off-dag", Schedule: []core.Schedule{schedule}}
+	legacyRunID := generateLegacyOneOffRunID(dag.Name, schedule.Fingerprint(), scheduledTime)
+
+	store := &mockWatermarkStore{}
+	var checkedRunIDs []string
+	tp := NewTickPlanner(TickPlannerConfig{
+		WatermarkStore: store,
+		Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
+			t.Fatal("dispatch should not be called when the legacy run already exists")
+			return nil
+		},
+		RunExists: func(_ context.Context, _ *core.DAG, runID string) (bool, error) {
+			checkedRunIDs = append(checkedRunIDs, runID)
+			return runID == legacyRunID, nil
+		},
+		Clock: func() time.Time {
+			return scheduledTime
+		},
+	})
+
+	store.state = &SchedulerState{
+		Version: SchedulerStateVersion,
+		DAGs: map[string]DAGWatermark{
+			dag.Name: {
+				OneOffs: map[string]OneOffScheduleState{
+					schedule.Fingerprint(): {
+						ScheduledTime: scheduledTime,
+						Status:        OneOffStatusPending,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+	run, ok := tp.createPlannedRun(context.Background(), dag, schedule, scheduledTime, core.TriggerTypeScheduler)
+	require.True(t, ok)
+	tp.DispatchRun(context.Background(), run)
+
+	assert.Equal(t, []string{run.RunID, legacyRunID}, checkedRunIDs)
+	state := store.lastSaved()
+	require.NotNil(t, state)
+	assert.Equal(t, OneOffStatusConsumed, state.DAGs[dag.Name].OneOffs[schedule.Fingerprint()].Status)
+}
+
 func TestTickPlanner_DispatchRun_OneOffFailureLeavesPendingState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1259,6 +1259,42 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, dag *core.DAG) bool 
 	return watermarkAdvanced
 }
 
+func (tp *TickPlanner) runExistsAny(ctx context.Context, run PlannedRun, runIDs ...string) (bool, string, error) {
+	for _, runID := range runIDs {
+		if runID == "" {
+			continue
+		}
+		exists, err := tp.cfg.RunExists(ctx, run.DAG, runID)
+		if err != nil {
+			return false, runID, err
+		}
+		if exists {
+			return true, runID, nil
+		}
+	}
+	return false, "", nil
+}
+
+func legacyScheduledRunID(run PlannedRun) string {
+	if run.ScheduleType != ScheduleTypeStart {
+		return ""
+	}
+	if run.TriggerType == core.TriggerTypeCatchUp {
+		return generateLegacyCatchupRunID(run.DAG.Name, run.ScheduledTime)
+	}
+	if !run.Schedule.IsOneOff() {
+		return ""
+	}
+	fingerprint := run.Fingerprint
+	if fingerprint == "" {
+		fingerprint = run.Schedule.Fingerprint()
+	}
+	if fingerprint == "" {
+		return ""
+	}
+	return generateLegacyOneOffRunID(run.DAG.Name, fingerprint, run.ScheduledTime)
+}
+
 // DispatchRun dispatches a PlannedRun using the configured dispatch functions.
 func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	logger.Info(ctx, "Dispatching planned run",
@@ -1281,11 +1317,11 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-		exists, err := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
+		exists, existingRunID, err := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
 		if err != nil {
 			logger.Error(ctx, "Failed to check for existing one-off dag-run",
 				tag.DAG(run.DAG.Name),
-				tag.RunID(run.RunID),
+				tag.RunID(existingRunID),
 				tag.Error(err),
 			)
 			return
@@ -1307,6 +1343,21 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 				)
 				return
 			}
+			legacyRunID := legacyScheduledRunID(run)
+			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, legacyRunID)
+			if existsErr != nil {
+				logger.Error(ctx, "Failed to check for existing catchup dag-run",
+					tag.DAG(run.DAG.Name),
+					tag.RunID(existingRunID),
+					tag.Error(existsErr),
+				)
+				tp.reinsertCatchupItem(ctx, run)
+				return
+			}
+			if exists {
+				tp.advanceDAGWatermark(run.DAG.Name, run.ScheduledTime)
+				return
+			}
 			err = tp.cfg.Enqueue(ctx, run.DAG, run.RunID, run.TriggerType, run.ScheduledTime)
 		} else {
 			err = tp.cfg.Dispatch(ctx, run.DAG, run.RunID, run.TriggerType, run.ScheduledTime)
@@ -1319,11 +1370,11 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 
 	if err != nil {
 		if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
-			exists, existsErr := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
+			exists, existingRunID, existsErr := tp.runExistsAny(ctx, run, run.RunID, legacyScheduledRunID(run))
 			if existsErr != nil {
 				logger.Error(ctx, "Failed to re-check one-off dag-run after dispatch error",
 					tag.DAG(run.DAG.Name),
-					tag.RunID(run.RunID),
+					tag.RunID(existingRunID),
 					tag.Error(existsErr),
 				)
 				return

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -1648,6 +1648,42 @@ func TestTickPlanner_DispatchRunSuspendedCatchupAdvancesWatermark(t *testing.T) 
 	assert.Equal(t, scheduledTime, wm.LastScheduledTime)
 }
 
+func TestTickPlanner_DispatchRunLegacyCatchupAttemptAdvancesWatermark(t *testing.T) {
+	t.Parallel()
+
+	store := &mockWatermarkStore{}
+	scheduledTime := time.Date(2026, 2, 7, 11, 0, 0, 0, time.UTC)
+	dag := newHourlyCatchupDAG(t, "legacy.catchup-dag")
+	legacyRunID := generateLegacyCatchupRunID(dag.Name, scheduledTime)
+	var checkedRunIDs []string
+
+	tp := NewTickPlanner(TickPlannerConfig{
+		WatermarkStore: store,
+		QueuesEnabled:  true,
+		Enqueue: func(_ context.Context, _ *core.DAG, _ string, _ core.TriggerType, _ time.Time) error {
+			t.Fatal("enqueue should not be called when the legacy run already exists")
+			return nil
+		},
+		RunExists: func(_ context.Context, _ *core.DAG, runID string) (bool, error) {
+			checkedRunIDs = append(checkedRunIDs, runID)
+			return runID == legacyRunID, nil
+		},
+		Events: make(chan DAGChangeEvent, 1),
+	})
+	require.NoError(t, tp.Init(context.Background(), nil))
+
+	run, ok := tp.createPlannedRun(context.Background(), dag, core.Schedule{}, scheduledTime, core.TriggerTypeCatchUp)
+	require.True(t, ok)
+	tp.DispatchRun(context.Background(), run)
+
+	assert.Equal(t, []string{legacyRunID}, checkedRunIDs)
+	tp.mu.RLock()
+	wm, ok := tp.watermarkState.DAGs[dag.Name]
+	tp.mu.RUnlock()
+	require.True(t, ok)
+	assert.Equal(t, scheduledTime, wm.LastScheduledTime)
+}
+
 func TestTickPlanner_DispatchRunRestartForwardsScheduledTime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- remove sanitized DAG names from generated catchup and one-off scheduled run IDs
- use 12 hex characters from the deterministic SHA-256 source for compact new scheduled run IDs
- keep legacy scheduled run IDs as fallback existence checks to avoid duplicate runs after upgrade

## Testing
- go test ./internal/service/scheduler
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens and stabilizes scheduled run IDs while preserving backward compatibility to avoid duplicate runs after upgrade. New IDs drop sanitized DAG names and use a 12-hex SHA-256 hash plus timestamp.

- **Bug Fixes**
  - New format: `catchup|oneoff` + 12-hex hash + `YYYYMMDDThhmmss` (no sanitized DAG name).
  - Tick planner checks both new and legacy IDs (8-hex + name) for one-off and catchup; advances watermark if a legacy run exists.
  - Introduced legacy ID generators; replaced `dagNameHash` with `scheduledRunIDHash`; capped IDs within 64 chars.
  - Tests updated for patterns, fixed length, UTC normalization, and legacy existence paths.

<sup>Written for commit 0e11ba0f058cbf95641d41e8c8634993bf186257. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler now recognizes both current and legacy run ID formats for catchup and one-off runs.
  * Legacy scheduled runs can now be detected and handled without creating duplicates.

* **Bug Fixes**
  * Improved run ID matching so existing scheduled runs are recognized more reliably.
  * Catchup dispatch now advances scheduling progress when a legacy run is already present.
  * One-off dispatch now correctly marks pending runs as consumed when a matching legacy run exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->