### PR TITLE
feat: add HTTP response file output

### DIFF
--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -29,6 +29,7 @@ const dagRunArtifactsDirEnvKey = "DAG_RUN_ARTIFACTS_DIR"
 
 var dagRunArtifactsDirReferencePattern = regexp.MustCompile(
 	`(?:\$\{` + regexp.QuoteMeta(dagRunArtifactsDirEnvKey) + `\}` +
+		`|\$\{env\.` + regexp.QuoteMeta(dagRunArtifactsDirEnvKey) + `\}` +
 		`|\$` + regexp.QuoteMeta(dagRunArtifactsDirEnvKey) + `(?:\b|[^A-Za-z0-9_])` +
 		`|\$env:` + regexp.QuoteMeta(dagRunArtifactsDirEnvKey) + `(?:\b|[^A-Za-z0-9_])` +
 		`|%` + regexp.QuoteMeta(dagRunArtifactsDirEnvKey) + `%` +

--- a/internal/core/spec/http_action_output_external_test.go
+++ b/internal/core/spec/http_action_output_external_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPRequestWithOutputKeepsActionOutputSeparateFromStepOutput(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+steps:
+  - id: download
+    action: http.request
+    with:
+      method: GET
+      url: https://example.com/data.bin
+      output: "${env.DAG_RUN_ARTIFACTS_DIR}/data.bin"
+    output: RESPONSE
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+	require.NotNil(t, dag.Artifacts)
+	assert.True(t, dag.Artifacts.Enabled)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "RESPONSE", step.Output)
+	assert.Equal(t, "${env.DAG_RUN_ARTIFACTS_DIR}/data.bin", step.ExecutorConfig.Config["output"])
+}

--- a/internal/runtime/builtin/http/config.go
+++ b/internal/runtime/builtin/http/config.go
@@ -27,6 +27,8 @@ var configSchema = &jsonschema.Schema{
 		"body":            {Type: "string", Description: "Request body content"},
 		"silent":          {Type: "boolean", Description: "Suppress headers/status output on success"},
 		"debug":           {Type: "boolean", Description: "Enable debug mode"},
+		"format":          {Type: "string", Description: "Response output format. Use json for structured stdout."},
+		"output":          {Type: "string", Description: "File path to write the response body to. When set, the response body is written to this file instead of stdout."},
 		"json":            {Type: "boolean", Description: "Format output as JSON"},
 		"skip_tls_verify": {Type: "boolean", Description: "Skip TLS certificate verification"},
 	},

--- a/internal/runtime/builtin/http/file_output_test.go
+++ b/internal/runtime/builtin/http/file_output_test.go
@@ -132,6 +132,43 @@ func TestHTTPExecutorFileOutputKeepsExistingFileOnHTTPError(t *testing.T) {
 	assert.Equal(t, "old", string(got))
 }
 
+func TestHTTPExecutorFileOutputWithJSONKeepsHTTPStatusOnError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusInternalServerError)
+		_, _ = w.Write([]byte("server failed"))
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "payload.bin")
+	require.NoError(t, os.WriteFile(output, []byte("old"), 0o600))
+
+	exec, err := executor.NewExecutor(context.Background(), httpStep(server.URL, map[string]any{
+		"output": output,
+		"format": "json",
+		"silent": true,
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	exec.SetStdout(&stdout)
+	exec.SetStderr(&bytes.Buffer{})
+
+	err = exec.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http status code not 2xx")
+
+	got, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &metadata))
+	assert.Equal(t, float64(nethttp.StatusInternalServerError), metadata["status_code"])
+	assert.Equal(t, "server failed", metadata["body"])
+}
+
 func httpStep(url string, cfg map[string]any) core.Step {
 	return core.Step{
 		Commands: []core.CommandEntry{{Command: "GET", Args: []string{url}}},

--- a/internal/runtime/builtin/http/file_output_test.go
+++ b/internal/runtime/builtin/http/file_output_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/http"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPExecutorFileOutputWritesResponseBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte{0, 1, 2, 'o', 'k'}
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "downloads", "payload.bin")
+	exec, err := executor.NewExecutor(context.Background(), httpStep(server.URL, map[string]any{
+		"output": output,
+		"silent": true,
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	exec.SetStdout(&stdout)
+	exec.SetStderr(&bytes.Buffer{})
+
+	require.NoError(t, exec.Run(context.Background()))
+
+	got, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+	assert.Empty(t, stdout.String())
+}
+
+func TestHTTPExecutorFileOutputWithJSONWritesMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  map[string]any
+	}{
+		{
+			name: "FormatJSON",
+			cfg:  map[string]any{"format": "json"},
+		},
+		{
+			name: "LegacyJSONBoolean",
+			cfg:  map[string]any{"json": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+				w.WriteHeader(nethttp.StatusOK)
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer server.Close()
+
+			output := filepath.Join(t.TempDir(), "payload.json")
+			tt.cfg["output"] = output
+
+			exec, err := executor.NewExecutor(context.Background(), httpStep(server.URL, tt.cfg))
+			require.NoError(t, err)
+
+			var stdout bytes.Buffer
+			exec.SetStdout(&stdout)
+			exec.SetStderr(&bytes.Buffer{})
+
+			require.NoError(t, exec.Run(context.Background()))
+
+			got, err := os.ReadFile(output)
+			require.NoError(t, err)
+			assert.JSONEq(t, `{"ok":true}`, string(got))
+
+			var metadata map[string]any
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &metadata))
+			assert.Equal(t, output, metadata["output"])
+			assert.NotContains(t, metadata, "body")
+		})
+	}
+}
+
+func TestHTTPExecutorFileOutputKeepsExistingFileOnHTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusNotFound)
+		_, _ = w.Write([]byte("missing"))
+	}))
+	defer server.Close()
+
+	output := filepath.Join(t.TempDir(), "payload.bin")
+	require.NoError(t, os.WriteFile(output, []byte("old"), 0o600))
+
+	exec, err := executor.NewExecutor(context.Background(), httpStep(server.URL, map[string]any{
+		"output": output,
+		"silent": true,
+	}))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	exec.SetStdout(&stdout)
+	exec.SetStderr(&bytes.Buffer{})
+
+	err = exec.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http status code not 2xx")
+	assert.Contains(t, stdout.String(), "missing")
+
+	got, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(got))
+}
+
+func httpStep(url string, cfg map[string]any) core.Step {
+	return core.Step{
+		Commands: []core.CommandEntry{{Command: "GET", Args: []string{url}}},
+		ExecutorConfig: core.ExecutorConfig{
+			Type:   "http",
+			Config: cfg,
+		},
+	}
+}

--- a/internal/runtime/builtin/http/http.go
+++ b/internal/runtime/builtin/http/http.go
@@ -130,6 +130,9 @@ func newHTTP(ctx context.Context, step core.Step) (executor.Executor, error) {
 		req = req.SetQueryParams(reqCfg.Query)
 	}
 	req = req.SetBody([]byte(reqCfg.Body))
+	if reqCfg.Output != "" {
+		req = req.SetDoNotParseResponse(true)
+	}
 
 	return &http{
 		stdout:    os.Stdout,
@@ -157,12 +160,15 @@ func (e *http) Kill(_ os.Signal) error {
 
 var errHTTPStatusCode = errors.New("http status code not 2xx")
 
-func (e *http) writeJSONResult(rsp *resty.Response) error {
+func (e *http) writeJSONResult(rsp *resty.Response, body []byte) error {
 	var (
 		httpJSONResultData  = &httpJSONResult{}
 		err                 error
 		httpJSONResultBytes []byte
 	)
+	if body == nil {
+		body = rsp.Body()
+	}
 
 	if !rsp.IsSuccess() || !e.cfg.Silent {
 		httpJSONResultData.Headers = rsp.Header()
@@ -172,8 +178,11 @@ func (e *http) writeJSONResult(rsp *resty.Response) error {
 	if e.cfg.Output != "" && rsp.IsSuccess() {
 		httpJSONResultData.Output = e.cfg.Output
 	} else {
-		if err = json.Unmarshal(rsp.Body(), &httpJSONResultData.Body); err != nil {
-			return err
+		if err = json.Unmarshal(body, &httpJSONResultData.Body); err != nil {
+			if e.cfg.Output == "" || rsp.IsSuccess() {
+				return err
+			}
+			httpJSONResultData.Body = string(body)
 		}
 	}
 
@@ -188,7 +197,7 @@ func (e *http) writeJSONResult(rsp *resty.Response) error {
 	return nil
 }
 
-func (e *http) writeTextResult(rsp *resty.Response) error {
+func (e *http) writeTextPrefix(rsp *resty.Response) error {
 	if !rsp.IsSuccess() || !e.cfg.Silent {
 		if _, err := e.stdout.Write([]byte(rsp.Status() + "\n")); err != nil {
 			return err
@@ -198,6 +207,13 @@ func (e *http) writeTextResult(rsp *resty.Response) error {
 		}
 	}
 
+	return nil
+}
+
+func (e *http) writeTextResult(rsp *resty.Response) error {
+	if err := e.writeTextPrefix(rsp); err != nil {
+		return err
+	}
 	if _, err := e.stdout.Write(rsp.Body()); err != nil {
 		return err
 	}
@@ -205,20 +221,54 @@ func (e *http) writeTextResult(rsp *resty.Response) error {
 	return nil
 }
 
-func (e *http) writeFileResult(rsp *resty.Response) error {
+func (e *http) writeTextResultFromReader(rsp *resty.Response, body io.Reader) error {
+	if err := e.writeTextPrefix(rsp); err != nil {
+		return err
+	}
+	_, err := io.Copy(e.stdout, body)
+	return err
+}
+
+func (e *http) writeFileResult(rsp *resty.Response, body io.Reader) error {
 	if !e.cfg.Silent && !e.isJSONFormat() {
-		if _, err := e.stdout.Write([]byte(rsp.Status() + "\n")); err != nil {
-			return err
-		}
-		if err := rsp.Header().Write(e.stdout); err != nil {
+		if err := e.writeTextPrefix(rsp); err != nil {
 			return err
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(e.cfg.Output), 0o750); err != nil {
+	return writeResponseBodyFile(e.cfg.Output, body)
+}
+
+func writeResponseBodyFile(output string, body io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(output), 0o750); err != nil {
 		return err
 	}
-	return fileutil.WriteFileAtomic(e.cfg.Output, rsp.Body(), 0o600)
+	tmpFile, err := os.CreateTemp(filepath.Dir(output), filepath.Base(output)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	cleanup := func() { _ = fileutil.Remove(tmpPath) }
+
+	if _, err = io.Copy(tmpFile, body); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return err
+	}
+	if err = tmpFile.Chmod(0o600); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return err
+	}
+	if err = tmpFile.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err = fileutil.ReplaceFile(tmpPath, output); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
 }
 
 func (e *http) isJSONFormat() bool {
@@ -237,17 +287,18 @@ func (e *http) Run(_ context.Context) error {
 
 	resCode := rsp.StatusCode()
 
-	if e.hasFileOutput() && rsp.IsSuccess() {
-		if err = e.writeFileResult(rsp); err != nil {
+	if e.hasFileOutput() {
+		if err = e.writeFileOutputResult(rsp); err != nil {
 			return err
 		}
-		if !e.isJSONFormat() {
-			return nil
+		if !rsp.IsSuccess() {
+			return fmt.Errorf("%w: %d", errHTTPStatusCode, resCode)
 		}
+		return nil
 	}
 
 	if e.isJSONFormat() {
-		if err = e.writeJSONResult(rsp); err != nil {
+		if err = e.writeJSONResult(rsp, rsp.Body()); err != nil {
 			return err
 		}
 	} else {
@@ -260,6 +311,34 @@ func (e *http) Run(_ context.Context) error {
 		return fmt.Errorf("%w: %d", errHTTPStatusCode, resCode)
 	}
 	return nil
+}
+
+func (e *http) writeFileOutputResult(rsp *resty.Response) error {
+	body := rsp.RawBody()
+	if body == nil {
+		return errors.New("http executor: response body is unavailable")
+	}
+	defer func() { _ = body.Close() }()
+
+	if rsp.IsSuccess() {
+		if err := e.writeFileResult(rsp, body); err != nil {
+			return err
+		}
+		if e.isJSONFormat() {
+			return e.writeJSONResult(rsp, nil)
+		}
+		return nil
+	}
+
+	if e.isJSONFormat() {
+		data, err := io.ReadAll(body)
+		if err != nil {
+			return err
+		}
+		return e.writeJSONResult(rsp, data)
+	}
+
+	return e.writeTextResultFromReader(rsp, body)
 }
 
 func prepareHTTPOutputConfig(ctx context.Context, cfg *httpConfig) error {

--- a/internal/runtime/builtin/http/http.go
+++ b/internal/runtime/builtin/http/http.go
@@ -11,10 +11,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/go-resty/resty/v2"
 	"github.com/go-viper/mapstructure/v2"
@@ -42,6 +45,7 @@ type httpConfig struct {
 	Silent        bool              `json:"silent" mapstructure:"silent"`
 	Debug         bool              `json:"debug" mapstructure:"debug"`
 	Format        string            `json:"format" mapstructure:"format"`
+	Output        string            `json:"output" mapstructure:"output"`
 	JSON          bool              `json:"json" mapstructure:"json"`
 	SkipTLSVerify bool              `json:"skip_tls_verify" mapstructure:"skip_tls_verify"`
 }
@@ -49,7 +53,8 @@ type httpConfig struct {
 type httpJSONResult struct {
 	StatusCode int                 `json:"status_code"`
 	Headers    map[string][]string `json:"headers"`
-	Body       any                 `json:"body"`
+	Body       any                 `json:"body,omitempty"`
+	Output     string              `json:"output,omitempty"`
 }
 
 func newHTTP(ctx context.Context, step core.Step) (executor.Executor, error) {
@@ -98,6 +103,9 @@ func newHTTP(ctx context.Context, step core.Step) (executor.Executor, error) {
 	}
 	if method == "" {
 		return nil, fmt.Errorf("http executor: method is required (set via command or with.method)")
+	}
+	if err := prepareHTTPOutputConfig(ctx, &reqCfg); err != nil {
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -161,8 +169,12 @@ func (e *http) writeJSONResult(rsp *resty.Response) error {
 		httpJSONResultData.StatusCode = rsp.StatusCode()
 	}
 
-	if err = json.Unmarshal(rsp.Body(), &httpJSONResultData.Body); err != nil {
-		return err
+	if e.cfg.Output != "" && rsp.IsSuccess() {
+		httpJSONResultData.Output = e.cfg.Output
+	} else {
+		if err = json.Unmarshal(rsp.Body(), &httpJSONResultData.Body); err != nil {
+			return err
+		}
 	}
 
 	if httpJSONResultBytes, err = json.MarshalIndent(httpJSONResultData, "", " "); err != nil {
@@ -193,8 +205,28 @@ func (e *http) writeTextResult(rsp *resty.Response) error {
 	return nil
 }
 
+func (e *http) writeFileResult(rsp *resty.Response) error {
+	if !e.cfg.Silent && !e.isJSONFormat() {
+		if _, err := e.stdout.Write([]byte(rsp.Status() + "\n")); err != nil {
+			return err
+		}
+		if err := rsp.Header().Write(e.stdout); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(e.cfg.Output), 0o750); err != nil {
+		return err
+	}
+	return fileutil.WriteFileAtomic(e.cfg.Output, rsp.Body(), 0o600)
+}
+
 func (e *http) isJSONFormat() bool {
 	return e.cfg.Format == "json" || e.cfg.JSON
+}
+
+func (e *http) hasFileOutput() bool {
+	return e.cfg.Output != ""
 }
 
 func (e *http) Run(_ context.Context) error {
@@ -204,6 +236,15 @@ func (e *http) Run(_ context.Context) error {
 	}
 
 	resCode := rsp.StatusCode()
+
+	if e.hasFileOutput() && rsp.IsSuccess() {
+		if err = e.writeFileResult(rsp); err != nil {
+			return err
+		}
+		if !e.isJSONFormat() {
+			return nil
+		}
+	}
 
 	if e.isJSONFormat() {
 		if err = e.writeJSONResult(rsp); err != nil {
@@ -218,6 +259,20 @@ func (e *http) Run(_ context.Context) error {
 	if !rsp.IsSuccess() {
 		return fmt.Errorf("%w: %d", errHTTPStatusCode, resCode)
 	}
+	return nil
+}
+
+func prepareHTTPOutputConfig(ctx context.Context, cfg *httpConfig) error {
+	output := strings.TrimSpace(cfg.Output)
+	if output == "" {
+		cfg.Output = ""
+		return nil
+	}
+	if !filepath.IsAbs(output) {
+		env := runtime.GetEnv(ctx)
+		output = filepath.Join(env.WorkingDir, output)
+	}
+	cfg.Output = filepath.Clean(output)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add first-class file output support to the HTTP executor via `with.output`.

## Changes

- Add `with.output` support so successful HTTP response bodies can be written directly to a file
- Keep JSON stdout independent from file output, returning metadata with the written output path when both are used
- Stream file-output responses through an atomic temp file before replacing the target
- Preserve the HTTP status error for non-2xx file-output responses, including `format: json`
- Auto-enable artifacts for `${env.DAG_RUN_ARTIFACTS_DIR}` references and cover the action-level `output` versus step `output` contract

## Related Issues

Closes #2353

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally