### PR TITLE
fix: stabilize Windows cancellation CI

### DIFF
--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -56,10 +56,9 @@ func TestStatusCommand(t *testing.T) {
   - name: "1"
     run: %q
 `, holdUntilFileExistsCommand(release)))
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		go func() {
-			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
-			close(done)
+			done <- th.ExecuteCommand(cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
 		}()
 
 		waitForDAGRunning(t, th, dagFile.Location)
@@ -68,7 +67,7 @@ func TestStatusCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		releaseHoldFile(t, release)
-		<-done
+		require.NoError(t, <-done)
 	})
 
 	t.Run("StatusDAGSuccess", func(t *testing.T) {
@@ -262,16 +261,15 @@ steps:
   - name: "1"
     run: %q
 `, holdUntilFileExistsCommand(release)))
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		go func() {
-			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
-			close(done)
+			done <- th.ExecuteCommand(cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
 		}()
 
 		waitForDAGRunning(t, th, dagFile.Location)
 
 		th.RunCommand(t, cmd.Stop(), test.CmdTest{Args: []string{"stop", dagFile.Location}})
-		<-done
+		require.NoError(t, <-done)
 
 		err := executeCommand(th.Context, cmd.Status(), []string{dagFile.Location})
 		require.NoError(t, err)
@@ -327,10 +325,9 @@ steps:
   - name: "1"
     run: %q
 `, holdUntilFileExistsCommand(release)))
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		go func() {
-			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
-			close(done)
+			done <- th.ExecuteCommand(cmd.Start(), test.CmdTest{Args: []string{"start", dagFile.Location}})
 		}()
 
 		waitForDAGRunning(t, th, dagFile.Location)
@@ -339,7 +336,7 @@ steps:
 		require.NoError(t, err)
 
 		releaseHoldFile(t, release)
-		<-done
+		require.NoError(t, <-done)
 	})
 
 	t.Run("StatusDAGWithAttemptID", func(t *testing.T) {

--- a/internal/cmd/stop_test.go
+++ b/internal/cmd/stop_test.go
@@ -28,12 +28,11 @@ func TestStopCommand(t *testing.T) {
     run: %q
 `, holdUntilFileExistsCommand(release)))
 
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		go func() {
 			// Start the DAG to stop.
 			args := []string{"start", dag.Location}
-			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: args})
-			close(done)
+			done <- th.ExecuteCommand(cmd.Start(), test.CmdTest{Args: args})
 		}()
 
 		// Wait for the dag-run running.
@@ -46,7 +45,7 @@ func TestStopCommand(t *testing.T) {
 
 		// Check the dag-run is stopped.
 		dag.AssertLatestStatus(t, core.Aborted)
-		<-done
+		require.NoError(t, <-done)
 	})
 	t.Run("StopDAGRunWithRunID", func(t *testing.T) {
 		t.Parallel()
@@ -58,13 +57,12 @@ func TestStopCommand(t *testing.T) {
     run: %q
 `, holdUntilFileExistsCommand(release)))
 
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		dagRunID := uuid.Must(uuid.NewV7()).String()
 		go func() {
 			// Start the dag-run to stop.
 			args := []string{"start", "--run-id=" + dagRunID, dag.Location}
-			th.RunCommand(t, cmd.Start(), test.CmdTest{Args: args})
-			close(done)
+			done <- th.ExecuteCommand(cmd.Start(), test.CmdTest{Args: args})
 		}()
 
 		// Wait for the dag-run running
@@ -77,7 +75,7 @@ func TestStopCommand(t *testing.T) {
 
 		// Check the dag-run is stopped.
 		dag.AssertLatestStatus(t, core.Aborted)
-		<-done
+		require.NoError(t, <-done)
 	})
 	t.Run("CancelFailedAutoRetryPendingDAGRunWithRunID", func(t *testing.T) {
 		t.Parallel()

--- a/internal/intg/distr/lifecycle_test.go
+++ b/internal/intg/distr/lifecycle_test.go
@@ -108,7 +108,7 @@ steps:
 				return false
 			}
 			return status.Status == core.Aborted || status.Status == core.Failed
-		}, 15*time.Second, 500*time.Millisecond, "Timeout waiting for DAG to be cancelled")
+		}, distrTestTimeout(15*time.Second), 500*time.Millisecond, "Timeout waiting for DAG to be cancelled")
 
 		finalStatus, err := f.latestStatus()
 		require.NoError(t, err)

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1466,7 +1466,7 @@ func (r *Runner) handleNodeExecutionError(ctx context.Context, plan *Plan, node 
 		r.setLastError(execErr)
 
 	case r.isCanceled():
-		r.setLastError(execErr)
+		node.SetStatus(core.NodeAborted)
 
 	case node.retryPolicy.Limit > node.GetRetryCount():
 		if r.shouldRetryNode(ctx, node, execErr) {

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -21,11 +22,75 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/builtin/chat"
+	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/test"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stoppedStatusExecutor struct {
+	ready    chan struct{}
+	stopped  chan struct{}
+	stopOnce sync.Once
+	stdout   io.Writer
+	stderr   io.Writer
+}
+
+func newStoppedStatusExecutor() *stoppedStatusExecutor {
+	return &stoppedStatusExecutor{
+		ready:   make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (e *stoppedStatusExecutor) SetStdout(out io.Writer) { e.stdout = out }
+
+func (e *stoppedStatusExecutor) SetStderr(out io.Writer) { e.stderr = out }
+
+func (e *stoppedStatusExecutor) Run(ctx context.Context) error {
+	close(e.ready)
+
+	select {
+	case <-e.stopped:
+		return fmt.Errorf("executor stopped")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (e *stoppedStatusExecutor) Kill(os.Signal) error {
+	e.stopOnce.Do(func() {
+		close(e.stopped)
+	})
+	return nil
+}
+
+func (e *stoppedStatusExecutor) DetermineNodeStatus() (core.NodeStatus, error) {
+	return core.NodeFailed, nil
+}
+
+func registerStoppedStatusExecutor(t *testing.T) (string, <-chan *stoppedStatusExecutor) {
+	t.Helper()
+
+	executorType := "test-stopped-status-" + uuid.Must(uuid.NewV7()).String()
+	execCh := make(chan *stoppedStatusExecutor, 1)
+	runtimeexec.RegisterExecutor(
+		executorType,
+		func(context.Context, core.Step) (runtimeexec.Executor, error) {
+			exec := newStoppedStatusExecutor()
+			execCh <- exec
+			return exec, nil
+		},
+		nil,
+		core.ExecutorCapabilities{},
+	)
+	t.Cleanup(func() {
+		runtimeexec.UnregisterExecutor(executorType)
+	})
+
+	return executorType, execCh
+}
 
 func shellTestPath(path string) string {
 	return filepath.ToSlash(path)
@@ -2164,6 +2229,38 @@ func TestRunner_SignalHandling(t *testing.T) {
 		result := plan.assertRun(t, core.Aborted)
 		result.assertNodeStatus(t, "1", core.NodeAborted)
 	})
+}
+
+func TestRunner_CancelSuppressesPostStopExecutorStatusError(t *testing.T) {
+	executorType, execCh := registerStoppedStatusExecutor(t)
+	r := setupRunner(t)
+
+	plan := r.newPlan(t, newStep("1", withExecutorType(executorType)))
+	dag := &core.DAG{Name: "test_dag", WorkingDir: plan.workDir}
+	logFilename := fmt.Sprintf("%s_%s.log", dag.Name, r.cfg.DAGRunID)
+	logFilePath := path.Join(r.cfg.LogDir, logFilename)
+	ctx := runtime.NewContext(plan.Context, dag, r.cfg.DAGRunID, logFilePath)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.runner.Run(ctx, plan.Plan, nil)
+	}()
+
+	exec := <-execCh
+	<-exec.ready
+
+	r.runner.Signal(ctx, plan.Plan, syscall.SIGTERM, nil, false)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not finish after cancellation")
+	}
+
+	require.Equal(t, core.Aborted, r.runner.Status(ctx, plan.Plan))
+	result := runResult{planHelper: plan}
+	result.assertNodeStatus(t, "1", core.NodeAborted)
 }
 
 func TestRunner_ComplexDependencyChains(t *testing.T) {

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -2254,7 +2254,7 @@ func TestRunner_CancelSuppressesPostStopExecutorStatusError(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
+	case <-time.After(platformTestDuration(2*time.Second, 10*time.Second)):
 		t.Fatal("runner did not finish after cancellation")
 	}
 


### PR DESCRIPTION
## Summary
- treat executor errors after explicit cancellation as aborted runner state
- make background CLI command failures surface directly in stop/status tests
- apply existing Windows timeout scaling to distributed cancellation wait

## Root Cause
Windows cancellation could return an executor-level error after the runner had already been canceled, causing `cmd start` to fail instead of completing as an aborted run. Some CLI tests also called fatal assertions inside goroutines, which hid the real error behind a package timeout.

## Validation
- `go test ./internal/runtime -count=1`
- `go test ./internal/cmd -count=1`
- `go test ./internal/intg -run TestAPITerminateLocalRun_DoesNotRequireCoordinator -count=1`
- `go test ./internal/intg/distr -run 'TestCancellation_SubDAG/parentCancelPropagatesToChildOnWorker' -count=1`
- `git diff --check -- internal/runtime/runner.go internal/runtime/runner_test.go internal/cmd/status_test.go internal/cmd/stop_test.go internal/intg/distr/lifecycle_test.go`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows cancellation in CI by treating post-cancel executor errors as Aborted and making CLI test failures surface immediately. Scales cancellation waits in distributed tests on Windows to reduce flakiness.

- **Bug Fixes**
  - On cancel, suppress executor errors and set node status to Aborted so `start` completes cleanly; added a unit test to cover this.
  - `status`/`stop` tests now capture command errors via a channel and assert `require.NoError` to surface background failures.
  - Distributed cancellation waits use `distrTestTimeout(...)` to apply Windows timeout scaling.

<sup>Written for commit 5d29ccc90bf239752fc84233963d5c9f01cb5955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so node status is consistently reported as aborted when runs are interrupted.
  * Fixed stop/cancel sequencing to avoid inconsistent execution status after cancellation.

* **Tests**
  * Strengthened coverage by asserting successful DAG start when testing concurrent start/stop flows.
  * Adjusted integration cancellation timing to improve reliability.
  * Added a new test ensuring post-stop status errors are suppressed after cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->