### PR TITLE
fix: preserve retry status metadata

### DIFF
--- a/internal/core/exec/enqueue_retry.go
+++ b/internal/core/exec/enqueue_retry.go
@@ -48,7 +48,7 @@ func EnqueueRetry(
 	dagRun := status.DAGRun()
 	originalStatus, err := retryStatusSnapshot(ctx, dagRunStore, dagRun)
 	if err != nil {
-		return fmt.Errorf("persist queued retry status: %w", err)
+		return fmt.Errorf("read retry status snapshot: %w", err)
 	}
 
 	updatedStatus, swapped, err := dagRunStore.CompareAndSwapLatestAttemptStatus(

--- a/internal/core/exec/enqueue_retry.go
+++ b/internal/core/exec/enqueue_retry.go
@@ -45,12 +45,19 @@ func EnqueueRetry(
 		return nil
 	}
 
+	dagRun := status.DAGRun()
+	originalStatus, err := retryStatusSnapshot(ctx, dagRunStore, dagRun)
+	if err != nil {
+		return fmt.Errorf("persist queued retry status: %w", err)
+	}
+
 	updatedStatus, swapped, err := dagRunStore.CompareAndSwapLatestAttemptStatus(
 		ctx,
-		status.DAGRun(),
+		dagRun,
 		status.AttemptID,
 		status.Status,
 		func(latest *DAGRunStatus) error {
+			*latest = *originalStatus
 			now := time.Now()
 			latest.Status = core.Queued
 			latest.QueuedAt = stringutil.FormatTime(now)
@@ -78,38 +85,13 @@ func EnqueueRetry(
 	}
 
 	// Enqueue after status is persisted. If this fails, roll back the status.
-	dagRun := status.DAGRun()
 	procGroup := retryProcGroup(dag, updatedStatus)
 	if procGroup == "" {
-		_, _, _ = dagRunStore.CompareAndSwapLatestAttemptStatus(
-			ctx,
-			dagRun,
-			updatedStatus.AttemptID,
-			core.Queued,
-			func(latest *DAGRunStatus) error {
-				latest.Status = status.Status
-				latest.QueuedAt = status.QueuedAt
-				latest.TriggerType = status.TriggerType
-				latest.AutoRetryCount = status.AutoRetryCount
-				return nil
-			},
-		)
+		rollbackQueuedRetry(ctx, dagRunStore, dagRun, updatedStatus, originalStatus)
 		return errors.New("enqueue retry: proc group is empty")
 	}
 	if err := queueStore.Enqueue(ctx, procGroup, QueuePriorityLow, dagRun); err != nil {
-		_, _, _ = dagRunStore.CompareAndSwapLatestAttemptStatus(
-			ctx,
-			dagRun,
-			updatedStatus.AttemptID,
-			core.Queued,
-			func(latest *DAGRunStatus) error {
-				latest.Status = status.Status
-				latest.QueuedAt = status.QueuedAt
-				latest.TriggerType = status.TriggerType
-				latest.AutoRetryCount = status.AutoRetryCount
-				return nil
-			},
-		)
+		rollbackQueuedRetry(ctx, dagRunStore, dagRun, updatedStatus, originalStatus)
 		return fmt.Errorf("enqueue retry: %w", err)
 	}
 
@@ -120,6 +102,45 @@ func EnqueueRetry(
 	}
 
 	return nil
+}
+
+func retryStatusSnapshot(ctx context.Context, dagRunStore DAGRunStore, dagRun DAGRunRef) (*DAGRunStatus, error) {
+	attempt, err := dagRunStore.FindAttempt(ctx, dagRun)
+	if err != nil {
+		return nil, err
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if status == nil {
+		return nil, ErrNoStatusData
+	}
+	snapshot := *status
+	return &snapshot, nil
+}
+
+func rollbackQueuedRetry(
+	ctx context.Context,
+	dagRunStore DAGRunStore,
+	dagRun DAGRunRef,
+	queued *DAGRunStatus,
+	original *DAGRunStatus,
+) {
+	_, _, _ = dagRunStore.CompareAndSwapLatestAttemptStatus(
+		ctx,
+		dagRun,
+		queued.AttemptID,
+		core.Queued,
+		func(latest *DAGRunStatus) error {
+			*latest = *queued
+			latest.Status = original.Status
+			latest.QueuedAt = original.QueuedAt
+			latest.TriggerType = original.TriggerType
+			latest.AutoRetryCount = original.AutoRetryCount
+			return nil
+		},
+	)
 }
 
 func retryProcGroup(dag *core.DAG, status *DAGRunStatus) string {

--- a/internal/core/exec/enqueue_retry_test.go
+++ b/internal/core/exec/enqueue_retry_test.go
@@ -51,7 +51,6 @@ func TestEnqueueRetry(t *testing.T) {
 				AttemptID:      "att-1",
 				Status:         core.Failed,
 				AutoRetryCount: 2,
-				ProfileName:    "old-profile",
 			},
 			store: &stubDAGRunStore{
 				status: &exec.DAGRunStatus{
@@ -60,7 +59,19 @@ func TestEnqueueRetry(t *testing.T) {
 					AttemptID:      "att-1",
 					Status:         core.Failed,
 					AutoRetryCount: 2,
+					Log:            "/tmp/test-dag/run-1.log",
+					WorkingDir:     "/tmp/test-dag/run-1",
 					ProfileName:    "old-profile",
+					ProfileResolvedAt: time.Date(
+						2026, 3, 14, 14, 30, 0, 0, time.UTC,
+					).Format(time.RFC3339),
+				},
+				casStatus: &exec.DAGRunStatus{
+					Name:           "test-dag",
+					DAGRunID:       "run-1",
+					AttemptID:      "att-1",
+					Status:         core.Failed,
+					AutoRetryCount: 2,
 				},
 			},
 			setupQueue: func(qs *exec.MockQueueStore) {
@@ -75,6 +86,9 @@ func TestEnqueueRetry(t *testing.T) {
 				assert.Empty(t, store.status.Conditions)
 				assert.Equal(t, 2, store.status.AutoRetryCount)
 				assert.Equal(t, "old-profile", store.status.ProfileName)
+				assert.Equal(t, "/tmp/test-dag/run-1.log", store.status.Log)
+				assert.Equal(t, "/tmp/test-dag/run-1", store.status.WorkingDir)
+				assert.NotEmpty(t, store.status.ProfileResolvedAt)
 				assert.Equal(t, 1, store.casCalls)
 			},
 		},
@@ -125,6 +139,15 @@ func TestEnqueueRetry(t *testing.T) {
 					Status:         core.Failed,
 					AutoRetryCount: 1,
 					ProcGroup:      "custom-queue",
+					Log:            "/tmp/test-dag/run-fast-path.log",
+				},
+				casStatus: &exec.DAGRunStatus{
+					Name:           "test-dag",
+					DAGRunID:       "run-fast-path",
+					AttemptID:      "att-fast-path",
+					Status:         core.Failed,
+					AutoRetryCount: 1,
+					ProcGroup:      "input-queue",
 				},
 			},
 			setupQueue: func(qs *exec.MockQueueStore) {
@@ -313,6 +336,7 @@ func TestEnqueueRetry(t *testing.T) {
 
 type stubDAGRunStore struct {
 	status        *exec.DAGRunStatus
+	casStatus     *exec.DAGRunStatus
 	firstErr      error
 	secondErr     error
 	firstSwapped  bool
@@ -376,6 +400,9 @@ func (s *stubDAGRunStore) CompareAndSwapLatestAttemptStatus(
 	}
 
 	updated := s.cloneStatus()
+	if s.casCalls == 1 && s.casStatus != nil {
+		updated = cloneDAGRunStatus(s.casStatus)
+	}
 	if err := mutate(updated); err != nil {
 		return nil, false, err
 	}
@@ -384,7 +411,10 @@ func (s *stubDAGRunStore) CompareAndSwapLatestAttemptStatus(
 }
 
 func (s *stubDAGRunStore) FindAttempt(context.Context, exec.DAGRunRef) (exec.DAGRunAttempt, error) {
-	return nil, errors.New("unexpected call")
+	if s.status == nil {
+		return nil, exec.ErrDAGRunIDNotFound
+	}
+	return &exec.MockDAGRunAttempt{Status: s.cloneStatus()}, nil
 }
 
 func (s *stubDAGRunStore) FindSubAttempt(context.Context, exec.DAGRunRef, string) (exec.DAGRunAttempt, error) {
@@ -408,9 +438,13 @@ func (s *stubDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.
 }
 
 func (s *stubDAGRunStore) cloneStatus() *exec.DAGRunStatus {
-	if s.status == nil {
+	return cloneDAGRunStatus(s.status)
+}
+
+func cloneDAGRunStatus(status *exec.DAGRunStatus) *exec.DAGRunStatus {
+	if status == nil {
 		return nil
 	}
-	cloned := *s.status
+	cloned := *status
 	return &cloned
 }

--- a/internal/service/scheduler/retry_scanner_test.go
+++ b/internal/service/scheduler/retry_scanner_test.go
@@ -233,7 +233,7 @@ func TestRetryScannerScanEnqueuesRetry(t *testing.T) {
 	assert.Equal(t, 2, latest.AutoRetryCount)
 	assert.Equal(t, 0, store.latestAttemptCalls)
 	assert.Len(t, store.listCalls, 1)
-	assert.Equal(t, 0, store.findAttemptCalls)
+	assert.Equal(t, 1, store.findAttemptCalls)
 
 	queueStore.AssertExpectations(t)
 }
@@ -328,7 +328,7 @@ func TestRetryScannerScanEnqueuesRetryWithoutLiveTargets(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, core.Queued, store.mustStatus(status.DAGRun()).Status)
 	assert.Len(t, store.listCalls, 1)
-	assert.Equal(t, 0, store.findAttemptCalls)
+	assert.Equal(t, 1, store.findAttemptCalls)
 	queueStore.AssertExpectations(t)
 }
 
@@ -385,7 +385,7 @@ func TestRetryScannerScanRetriesOlderFailedRunEvenWhenNewerRunExists(t *testing.
 	assert.Equal(t, core.Running, store.mustStatus(active.DAGRun()).Status)
 	assert.Equal(t, 0, store.latestAttemptCalls)
 	assert.Len(t, store.listCalls, 1)
-	assert.Equal(t, 0, store.findAttemptCalls)
+	assert.Equal(t, 1, store.findAttemptCalls)
 	queueStore.AssertExpectations(t)
 }
 
@@ -447,7 +447,7 @@ func TestRetryScannerScanUsesPersistedRetryPolicy(t *testing.T) {
 	assert.Len(t, store.listCalls, 1)
 	assert.Equal(t, 1, store.mustStatus(retryStatus.DAGRun()).AutoRetryCount)
 	assert.Equal(t, core.Failed, store.mustStatus(plainStatus.DAGRun()).Status)
-	assert.Equal(t, 0, store.findAttemptCalls)
+	assert.Equal(t, 1, store.findAttemptCalls)
 	queueStore.AssertExpectations(t)
 }
 
@@ -639,7 +639,7 @@ func TestRetryScannerScanIsIdempotentForQueuedRun(t *testing.T) {
 	assert.Equal(t, core.Queued, store.mustStatus(status.DAGRun()).Status)
 	assert.Equal(t, 0, store.latestAttemptCalls)
 	assert.Len(t, store.listCalls, 2)
-	assert.Equal(t, 0, store.findAttemptCalls)
+	assert.Equal(t, 1, store.findAttemptCalls)
 	queueStore.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- preserve persisted DAG-run metadata when queueing retries from sparse statuses
- keep retry rollback based on the persisted pre-queue status
- update retry scanner expectations for the additional status read

## Testing
- go test ./internal/core/exec ./internal/service/scheduler -run 'TestEnqueueRetry|TestRetryScanner' -count=1
- go test ./internal/core/exec ./internal/service/scheduler -count=1
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DAG run status metadata when queueing retries so sparse input statuses don’t drop fields. Takes a snapshot of the latest persisted status for CAS updates and safe rollback; improves error context and updates retry scanner expectations.

- **Bug Fixes**
  - Snapshot latest persisted attempt status and seed the queued status from it to keep Log, WorkingDir, ProfileName, ProfileResolvedAt, ProcGroup, etc.
  - Roll back to the original persisted status if enqueue fails or proc group is empty.
  - Clearer error when the snapshot read fails; retry scanner now performs one attempt status read and tests expect a FindAttempt call.

<sup>Written for commit e7ced870a3cbe5a76dcdadacf14feb1f6ddbf860. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry requests now retain more of the latest attempt’s persisted information when queued, including execution context like log/working directory and profile-resolved timing.
  * If a retry can’t be enqueued, previously queued-state updates are now rolled back more reliably.
  * Retry scanning has been improved to correctly handle persisted attempt lookups, reducing retry processing mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->