### PR TITLE
fix: recover corrupt distributed records

### DIFF
--- a/internal/cmn/fileutil/atomic_test.go
+++ b/internal/cmn/fileutil/atomic_test.go
@@ -4,6 +4,7 @@
 package fileutil
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,6 +72,25 @@ func TestWriteFileAtomic(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
 	})
+}
+
+func TestWriteFileAtomicExclusive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "exclusive.txt")
+	require.NoError(t, WriteFileAtomicExclusive(filePath, []byte("first"), 0o600))
+
+	err := WriteFileAtomicExclusive(filePath, []byte("second"), 0o600)
+	assert.ErrorIs(t, err, fs.ErrExist)
+
+	data, readErr := os.ReadFile(filePath)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("first"), data)
+
+	temps, globErr := filepath.Glob(filePath + ".tmp.*")
+	require.NoError(t, globErr)
+	assert.Empty(t, temps)
 }
 
 func TestWriteJSONAtomic(t *testing.T) {

--- a/internal/cmn/fileutil/fileutil.go
+++ b/internal/cmn/fileutil/fileutil.go
@@ -317,12 +317,12 @@ func WriteFileAtomicExclusive(filePath string, data []byte, perm os.FileMode) er
 	return nil
 }
 
-// RenameFileDurable renames source to target and persists the directory entry.
-func RenameFileDurable(source, target string) error {
-	if err := ReplaceFile(source, target); err != nil {
+// RemoveFileDurable removes path and persists the directory entry change.
+func RemoveFileDurable(path string) error {
+	if err := Remove(path); err != nil {
 		return err
 	}
-	return syncDir(filepath.Dir(target))
+	return syncDir(filepath.Dir(path))
 }
 
 func writeSyncedTempFile(dir, base string, data []byte, perm os.FileMode) (string, error) {

--- a/internal/cmn/fileutil/fileutil.go
+++ b/internal/cmn/fileutil/fileutil.go
@@ -274,47 +274,85 @@ func CreateTempDAGFile(subDir, dagName string, yamlData []byte, extraDocs ...[]b
 	return tempFileName, nil
 }
 
-// WriteFileAtomic writes data to a file atomically using a temp file and rename.
-// This ensures the file is never left in a partial state.
-// Uses os.CreateTemp with a unique filename to prevent race conditions with
-// concurrent writers to the same file.
+// WriteFileAtomic durably replaces filePath with data. Once it returns nil,
+// the destination contains the complete new contents after a process or host
+// crash, provided the underlying filesystem honors fsync.
 func WriteFileAtomic(filePath string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(filePath)
 	base := filepath.Base(filePath)
 
-	// Create temp file in the same directory to ensure atomic rename works
-	// (rename across filesystems would fail)
-	tempFile, err := os.CreateTemp(dir, base+".tmp.*")
+	tempPath, err := writeSyncedTempFile(dir, base, data, perm)
 	if err != nil {
-		return fmt.Errorf("failed to create temp file in %s: %w", dir, err)
-	}
-	tempPath := tempFile.Name()
-
-	// Clean up temp file on any error
-	cleanup := func() { _ = os.Remove(tempPath) }
-
-	if _, err := tempFile.Write(data); err != nil {
-		_ = tempFile.Close()
-		cleanup()
-		return fmt.Errorf("failed to write temp file %s: %w", tempPath, err)
-	}
-
-	if err := tempFile.Chmod(perm); err != nil {
-		_ = tempFile.Close()
-		cleanup()
-		return fmt.Errorf("failed to set permissions on temp file %s: %w", tempPath, err)
-	}
-
-	if err := tempFile.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("failed to close temp file %s: %w", tempPath, err)
+		return err
 	}
 
 	if err := ReplaceFile(tempPath, filePath); err != nil {
-		cleanup()
+		_ = os.Remove(tempPath)
 		return fmt.Errorf("failed to rename %s to %s: %w", tempPath, filePath, err)
 	}
+	if err := syncDir(dir); err != nil {
+		return fmt.Errorf("failed to sync directory %s: %w", dir, err)
+	}
 	return nil
+}
+
+// WriteFileAtomicExclusive durably creates filePath without replacing an
+// existing file. It returns an error satisfying fs.ErrExist when the
+// destination already exists.
+func WriteFileAtomicExclusive(filePath string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+
+	tempPath, err := writeSyncedTempFile(dir, base, data, perm)
+	if err != nil {
+		return err
+	}
+	if err := installFileNoReplace(tempPath, filePath); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("failed to install %s as %s: %w", tempPath, filePath, err)
+	}
+	if err := syncDir(dir); err != nil {
+		return fmt.Errorf("failed to sync directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+// RenameFileDurable renames source to target and persists the directory entry.
+func RenameFileDurable(source, target string) error {
+	if err := ReplaceFile(source, target); err != nil {
+		return err
+	}
+	return syncDir(filepath.Dir(target))
+}
+
+func writeSyncedTempFile(dir, base string, data []byte, perm os.FileMode) (string, error) {
+	tempFile, err := os.CreateTemp(dir, base+".tmp.*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file in %s: %w", dir, err)
+	}
+	tempPath := tempFile.Name()
+	cleanup := func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+	}
+
+	if _, err := tempFile.Write(data); err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to write temp file %s: %w", tempPath, err)
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to set permissions on temp file %s: %w", tempPath, err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to sync temp file %s: %w", tempPath, err)
+	}
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("failed to close temp file %s: %w", tempPath, err)
+	}
+	return tempPath, nil
 }
 
 // WriteJSONAtomic marshals v to indented JSON and writes it atomically to filePath.

--- a/internal/cmn/fileutil/replace_unix.go
+++ b/internal/cmn/fileutil/replace_unix.go
@@ -10,3 +10,19 @@ import "os"
 func replaceFile(source, target string) error {
 	return os.Rename(source, target)
 }
+
+func installFileNoReplace(source, target string) error {
+	if err := os.Link(source, target); err != nil {
+		return err
+	}
+	return os.Remove(source)
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path) //nolint:gosec // path is an existing destination directory
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/internal/cmn/fileutil/replace_windows.go
+++ b/internal/cmn/fileutil/replace_windows.go
@@ -12,6 +12,14 @@ import (
 )
 
 func replaceFile(source, target string) error {
+	return moveFile(source, target, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func installFileNoReplace(source, target string) error {
+	return moveFile(source, target, windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func moveFile(source, target string, flags uint32) error {
 	sourcePath, err := windows.UTF16PtrFromString(source)
 	if err != nil {
 		return &os.LinkError{Op: "rename", Old: source, New: target, Err: err}
@@ -21,9 +29,14 @@ func replaceFile(source, target string) error {
 		return &os.LinkError{Op: "rename", Old: source, New: target, Err: err}
 	}
 
-	flags := uint32(windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH)
 	if err := windows.MoveFileEx(sourcePath, targetPath, flags); err != nil {
 		return &os.LinkError{Op: "rename", Old: source, New: target, Err: err}
 	}
+	return nil
+}
+
+func syncDir(string) error {
+	// MoveFileEx with MOVEFILE_WRITE_THROUGH provides the durable rename
+	// behavior available through the Windows API.
 	return nil
 }

--- a/internal/persis/errors.go
+++ b/internal/persis/errors.go
@@ -14,4 +14,8 @@ var (
 	// ErrConflict is returned by CompareAndSwap when the current Data does not
 	// match the expected value.
 	ErrConflict = errors.New("persis: compare-and-swap conflict")
+
+	// ErrCorrupt is returned when a record exists but its stored representation
+	// cannot be decoded by the backend.
+	ErrCorrupt = errors.New("persis: corrupt record")
 )

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -189,10 +189,6 @@ func (c *Collection) WithLock(ctx context.Context, key string, fn func() error) 
 	if err != nil {
 		return err
 	}
-	return withDirLock(ctx, lockDir, fn)
-}
-
-func withDirLock(ctx context.Context, lockDir string, fn func() error) error {
 	lock := dirlock.New(lockDir, &dirlock.LockOptions{
 		StaleThreshold: 30 * time.Second,
 		RetryInterval:  50 * time.Millisecond,
@@ -282,44 +278,38 @@ func (c *Collection) CompareAndSwap(_ context.Context, id string, expected, next
 
 // RemoveCorrupt removes id only when its file is invalid JSON. A non-zero
 // staleBefore restricts removal to files last modified at or before that time.
-func (c *Collection) RemoveCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error) {
-	var removed bool
-	err := withDirLock(ctx, c.dir+".corrupt-lock", func() error {
-		c.mu.Lock()
-		defer c.mu.Unlock()
+func (c *Collection) RemoveCorrupt(_ context.Context, id string, staleBefore time.Time) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-		path, err := c.filePath(id)
-		if err != nil {
-			return err
+	path, err := c.filePath(id)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, persis.ErrNotFound
 		}
-		info, err := os.Stat(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return persis.ErrNotFound
-			}
-			return err
+		return false, err
+	}
+	if !staleBefore.IsZero() && info.ModTime().After(staleBefore) {
+		return false, nil
+	}
+	raw, err := fileutil.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, persis.ErrNotFound
 		}
-		if !staleBefore.IsZero() && info.ModTime().After(staleBefore) {
-			return nil
-		}
-		raw, err := fileutil.ReadFile(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return persis.ErrNotFound
-			}
-			return err
-		}
-		if json.Valid(raw) {
-			return persis.ErrConflict
-		}
-
-		if err := fileutil.RemoveFileDurable(path); err != nil {
-			return err
-		}
-		removed = true
-		return nil
-	})
-	return removed, err
+		return false, err
+	}
+	if json.Valid(raw) {
+		return false, persis.ErrConflict
+	}
+	if err := fileutil.RemoveFileDurable(path); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ─── internal helpers ─────────────────────────────────────────────────────────

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -77,8 +77,7 @@ func (c *Collection) Put(_ context.Context, rec *persis.Record) error {
 }
 
 // Create atomically inserts rec. Returns [persis.ErrConflict] when a
-// record with rec.ID already exists. Uses O_EXCL|O_CREATE for atomic
-// cross-process insert.
+// record with rec.ID already exists.
 func (c *Collection) Create(_ context.Context, rec *persis.Record) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -104,25 +103,10 @@ func (c *Collection) Create(_ context.Context, rec *persis.Record) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // path is sanitized via c.filePath -> pathUnderRoot
-	if err != nil {
+	if err := fileutil.WriteFileAtomicExclusive(path, body, 0o600); err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return persis.ErrConflict
 		}
-		return err
-	}
-	if _, err := f.Write(body); err != nil {
-		_ = f.Close()
-		_ = os.Remove(path)
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		_ = os.Remove(path)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(path)
 		return err
 	}
 	mtime := rec.UpdatedAt
@@ -292,6 +276,79 @@ func (c *Collection) CompareAndSwap(_ context.Context, id string, expected, next
 	return c.writeFile(path, rec)
 }
 
+// RepairCorrupt replaces rec.ID only when its current file is invalid JSON.
+func (c *Collection) RepairCorrupt(ctx context.Context, rec *persis.Record) error {
+	if rec == nil {
+		return fmt.Errorf("file backend: nil record")
+	}
+	if !json.Valid(rec.Data) {
+		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
+	}
+	return c.WithLock(ctx, ".repair/"+rec.ID, func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		path, err := c.filePath(rec.ID)
+		if err != nil {
+			return err
+		}
+		raw, err := fileutil.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return persis.ErrNotFound
+			}
+			return err
+		}
+		if json.Valid(raw) {
+			return persis.ErrConflict
+		}
+		return c.writeFile(path, rec)
+	})
+}
+
+// QuarantineCorrupt renames id out of the collection when its file is invalid
+// JSON and was last modified before staleBefore.
+func (c *Collection) QuarantineCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error) {
+	var quarantined bool
+	err := c.WithLock(ctx, ".repair/"+id, func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		path, err := c.filePath(id)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return persis.ErrNotFound
+			}
+			return err
+		}
+		if info.ModTime().After(staleBefore) {
+			return nil
+		}
+		raw, err := fileutil.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return persis.ErrNotFound
+			}
+			return err
+		}
+		if json.Valid(raw) {
+			return persis.ErrConflict
+		}
+
+		quarantinePath := fmt.Sprintf("%s.corrupt-%d", path, time.Now().UTC().UnixNano())
+		if err := fileutil.RenameFileDurable(path, quarantinePath); err != nil {
+			return err
+		}
+		quarantined = true
+		return nil
+	})
+	return quarantined, err
+}
+
 // ─── internal helpers ─────────────────────────────────────────────────────────
 
 func (c *Collection) filePath(id string) (string, error) {
@@ -328,7 +385,7 @@ func (c *Collection) readFile(path string) (*persis.Record, error) {
 		return nil, err
 	}
 	if !json.Valid(raw) {
-		return nil, fmt.Errorf("file backend: corrupt record at %q: invalid JSON", path)
+		return nil, fmt.Errorf("file backend: %w at %q: invalid JSON", persis.ErrCorrupt, path)
 	}
 
 	info, err := os.Stat(path)

--- a/internal/persis/file/collection.go
+++ b/internal/persis/file/collection.go
@@ -189,6 +189,10 @@ func (c *Collection) WithLock(ctx context.Context, key string, fn func() error) 
 	if err != nil {
 		return err
 	}
+	return withDirLock(ctx, lockDir, fn)
+}
+
+func withDirLock(ctx context.Context, lockDir string, fn func() error) error {
 	lock := dirlock.New(lockDir, &dirlock.LockOptions{
 		StaleThreshold: 30 * time.Second,
 		RetryInterval:  50 * time.Millisecond,
@@ -276,41 +280,11 @@ func (c *Collection) CompareAndSwap(_ context.Context, id string, expected, next
 	return c.writeFile(path, rec)
 }
 
-// RepairCorrupt replaces rec.ID only when its current file is invalid JSON.
-func (c *Collection) RepairCorrupt(ctx context.Context, rec *persis.Record) error {
-	if rec == nil {
-		return fmt.Errorf("file backend: nil record")
-	}
-	if !json.Valid(rec.Data) {
-		return fmt.Errorf("file backend: invalid JSON record %q", rec.ID)
-	}
-	return c.WithLock(ctx, ".repair/"+rec.ID, func() error {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
-		path, err := c.filePath(rec.ID)
-		if err != nil {
-			return err
-		}
-		raw, err := fileutil.ReadFile(path)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return persis.ErrNotFound
-			}
-			return err
-		}
-		if json.Valid(raw) {
-			return persis.ErrConflict
-		}
-		return c.writeFile(path, rec)
-	})
-}
-
-// QuarantineCorrupt renames id out of the collection when its file is invalid
-// JSON and was last modified before staleBefore.
-func (c *Collection) QuarantineCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error) {
-	var quarantined bool
-	err := c.WithLock(ctx, ".repair/"+id, func() error {
+// RemoveCorrupt removes id only when its file is invalid JSON. A non-zero
+// staleBefore restricts removal to files last modified at or before that time.
+func (c *Collection) RemoveCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error) {
+	var removed bool
+	err := withDirLock(ctx, c.dir+".corrupt-lock", func() error {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 
@@ -325,7 +299,7 @@ func (c *Collection) QuarantineCorrupt(ctx context.Context, id string, staleBefo
 			}
 			return err
 		}
-		if info.ModTime().After(staleBefore) {
+		if !staleBefore.IsZero() && info.ModTime().After(staleBefore) {
 			return nil
 		}
 		raw, err := fileutil.ReadFile(path)
@@ -339,14 +313,13 @@ func (c *Collection) QuarantineCorrupt(ctx context.Context, id string, staleBefo
 			return persis.ErrConflict
 		}
 
-		quarantinePath := fmt.Sprintf("%s.corrupt-%d", path, time.Now().UTC().UnixNano())
-		if err := fileutil.RenameFileDurable(path, quarantinePath); err != nil {
+		if err := fileutil.RemoveFileDurable(path); err != nil {
 			return err
 		}
-		quarantined = true
+		removed = true
 		return nil
 	})
-	return quarantined, err
+	return removed, err
 }
 
 // ─── internal helpers ─────────────────────────────────────────────────────────

--- a/internal/persis/file/collection_test.go
+++ b/internal/persis/file/collection_test.go
@@ -448,14 +448,23 @@ func TestFileCollectionPutNilReturnsError(t *testing.T) {
 	require.ErrorContains(t, err, "nil record")
 }
 
-// TestFileCollectionCreateIsAtomicAcrossGoroutines races 16 goroutines on the
-// same ID and asserts that exactly one Create succeeds and the rest see
-// ErrConflict. Exercises the O_EXCL guarantee against in-process concurrency.
+func TestFileCollectionGetReportsTypedCorruption(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "broken.json"), nil, 0o600))
+
+	_, err := file.NewCollection(root).Get(context.Background(), "broken")
+	assert.ErrorIs(t, err, persis.ErrCorrupt)
+}
+
+// TestFileCollectionCreateIsAtomicAcrossGoroutines races concurrent creators
+// on one ID and verifies the collection's exclusive-insert contract.
 func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	col := file.NewCollection(t.TempDir())
+	root := t.TempDir()
 
 	const goroutines = 16
 	var (
@@ -468,7 +477,7 @@ func TestFileCollectionCreateIsAtomicAcrossGoroutines(t *testing.T) {
 	for range goroutines {
 		wg.Go(func() {
 			<-start
-			err := col.Create(ctx, &persis.Record{
+			err := file.NewCollection(root).Create(ctx, &persis.Record{
 				ID:        "shared",
 				Data:      []byte(`{}`),
 				CreatedAt: time.Now().UTC(),

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -60,13 +60,16 @@ func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.Acti
 
 		existing, getErr := s.col.Get(ctx, id)
 		if errors.Is(getErr, persis.ErrCorrupt) {
-			repaired, repairErr := repairCorruptRecord(ctx, s.col, stored)
-			if repairErr != nil {
-				return repairErr
+			removed, removeErr := removeCorruptRecord(ctx, s.col, id, time.Time{})
+			if errors.Is(removeErr, persis.ErrNotFound) || errors.Is(removeErr, persis.ErrConflict) {
+				return persis.ErrConflict
 			}
-			if repaired {
-				logger.Warn(ctx, "Repaired corrupt active distributed run entry", tag.Name(id))
-				return nil
+			if removeErr != nil {
+				return removeErr
+			}
+			if removed {
+				logger.Warn(ctx, "Removed corrupt active distributed run entry before replacement", tag.Name(id))
+				return persis.ErrConflict
 			}
 			return getErr
 		}
@@ -113,23 +116,26 @@ func (s *ActiveDistributedRunStore) Get(ctx context.Context, attemptKey string) 
 func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveDistributedRun, error) {
 	recs, err := listAllStrictWithReadError(ctx, s.col, persis.ListQuery{}, func(id string, readErr error) (bool, error) {
 		if errors.Is(readErr, persis.ErrCorrupt) {
-			quarantined, quarantineErr := quarantineStaleCorruptRecord(
+			removed, removeErr := removeStaleCorruptRecord(
 				ctx,
 				s.col,
 				id,
 				s.corruptRecordGracePeriod,
 			)
-			if quarantineErr == nil && quarantined {
-				logger.Warn(ctx, "Quarantined stale corrupt active distributed run entry",
+			if removeErr == nil && removed {
+				logger.Warn(ctx, "Removed stale corrupt active distributed run entry",
 					tag.Name(id),
 					tag.Error(readErr),
 				)
 				return true, nil
 			}
-			if quarantineErr != nil && !errors.Is(quarantineErr, persis.ErrNotFound) {
-				logger.Warn(ctx, "Failed to quarantine corrupt active distributed run entry",
+			if errors.Is(removeErr, persis.ErrNotFound) {
+				return true, nil
+			}
+			if removeErr != nil && !errors.Is(removeErr, persis.ErrNotFound) {
+				logger.Warn(ctx, "Failed to remove corrupt active distributed run entry",
 					tag.Name(id),
-					tag.Error(quarantineErr),
+					tag.Error(removeErr),
 				)
 			}
 		}

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -22,12 +22,17 @@ var _ exec.ActiveDistributedRunStore = (*ActiveDistributedRunStore)(nil)
 // of a [persis.Collection]. Record IDs intentionally match the file-backed
 // distributed store SHA-256 key.
 type ActiveDistributedRunStore struct {
-	col persis.Collection
+	col                      persis.Collection
+	corruptRecordGracePeriod time.Duration
 }
 
 // NewActiveDistributedRunStore creates an ActiveDistributedRunStore backed by col.
-func NewActiveDistributedRunStore(col persis.Collection) *ActiveDistributedRunStore {
-	return &ActiveDistributedRunStore{col: col}
+func NewActiveDistributedRunStore(col persis.Collection, opts ...DistributedStoreOption) *ActiveDistributedRunStore {
+	resolved := resolveDistributedStoreOptions(opts)
+	return &ActiveDistributedRunStore{
+		col:                      col,
+		corruptRecordGracePeriod: resolved.corruptRecordGracePeriod,
+	}
 }
 
 // Upsert writes the active-run record. Get → Create if absent /
@@ -42,23 +47,35 @@ func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.Acti
 		now := time.Now().UTC()
 		record.UpdatedAt = now.UnixMilli()
 
-		existing, getErr := s.col.Get(ctx, id)
-		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
-			return getErr
-		}
-
 		data, err := persis.Encode(record)
 		if err != nil {
 			return err
 		}
+		stored := &persis.Record{
+			ID:        id,
+			Data:      data,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+
+		existing, getErr := s.col.Get(ctx, id)
+		if errors.Is(getErr, persis.ErrCorrupt) {
+			repaired, repairErr := repairCorruptRecord(ctx, s.col, stored)
+			if repairErr != nil {
+				return repairErr
+			}
+			if repaired {
+				logger.Warn(ctx, "Repaired corrupt active distributed run entry", tag.Name(id))
+				return nil
+			}
+			return getErr
+		}
+		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
+			return getErr
+		}
 
 		if existing == nil {
-			return s.col.Create(ctx, &persis.Record{
-				ID:        id,
-				Data:      data,
-				CreatedAt: now,
-				UpdatedAt: now,
-			})
+			return s.col.Create(ctx, stored)
 		}
 		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, data)
 		if errors.Is(casErr, persis.ErrNotFound) {
@@ -94,11 +111,33 @@ func (s *ActiveDistributedRunStore) Get(ctx context.Context, attemptKey string) 
 }
 
 func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveDistributedRun, error) {
-	recs, err := listAllBestEffort(ctx, s.col, persis.ListQuery{}, func(id string, err error) {
+	recs, err := listAllStrictWithReadError(ctx, s.col, persis.ListQuery{}, func(id string, readErr error) (bool, error) {
+		if errors.Is(readErr, persis.ErrCorrupt) {
+			quarantined, quarantineErr := quarantineStaleCorruptRecord(
+				ctx,
+				s.col,
+				id,
+				s.corruptRecordGracePeriod,
+			)
+			if quarantineErr == nil && quarantined {
+				logger.Warn(ctx, "Quarantined stale corrupt active distributed run entry",
+					tag.Name(id),
+					tag.Error(readErr),
+				)
+				return true, nil
+			}
+			if quarantineErr != nil && !errors.Is(quarantineErr, persis.ErrNotFound) {
+				logger.Warn(ctx, "Failed to quarantine corrupt active distributed run entry",
+					tag.Name(id),
+					tag.Error(quarantineErr),
+				)
+			}
+		}
 		logger.Warn(ctx, "Skipping corrupted active distributed run entry",
 			tag.Name(id),
-			tag.Error(err),
+			tag.Error(readErr),
 		)
+		return true, nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/persis/store/distributed_active.go
+++ b/internal/persis/store/distributed_active.go
@@ -60,18 +60,11 @@ func (s *ActiveDistributedRunStore) Upsert(ctx context.Context, record exec.Acti
 
 		existing, getErr := s.col.Get(ctx, id)
 		if errors.Is(getErr, persis.ErrCorrupt) {
-			removed, removeErr := removeCorruptRecord(ctx, s.col, id, time.Time{})
-			if errors.Is(removeErr, persis.ErrNotFound) || errors.Is(removeErr, persis.ErrConflict) {
-				return persis.ErrConflict
-			}
-			if removeErr != nil {
-				return removeErr
-			}
+			removed, retryErr := removeCorruptRecordForRetry(ctx, s.col, id, getErr)
 			if removed {
 				logger.Warn(ctx, "Removed corrupt active distributed run entry before replacement", tag.Name(id))
-				return persis.ErrConflict
 			}
-			return getErr
+			return retryErr
 		}
 		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
 			return getErr
@@ -115,34 +108,33 @@ func (s *ActiveDistributedRunStore) Get(ctx context.Context, attemptKey string) 
 
 func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveDistributedRun, error) {
 	recs, err := listAllStrictWithReadError(ctx, s.col, persis.ListQuery{}, func(id string, readErr error) (bool, error) {
-		if errors.Is(readErr, persis.ErrCorrupt) {
-			removed, removeErr := removeStaleCorruptRecord(
-				ctx,
-				s.col,
-				id,
-				s.corruptRecordGracePeriod,
-			)
-			if removeErr == nil && removed {
-				logger.Warn(ctx, "Removed stale corrupt active distributed run entry",
-					tag.Name(id),
-					tag.Error(readErr),
-				)
-				return true, nil
-			}
-			if errors.Is(removeErr, persis.ErrNotFound) {
-				return true, nil
-			}
-			if removeErr != nil && !errors.Is(removeErr, persis.ErrNotFound) {
-				logger.Warn(ctx, "Failed to remove corrupt active distributed run entry",
-					tag.Name(id),
-					tag.Error(removeErr),
-				)
-			}
+		if !errors.Is(readErr, persis.ErrCorrupt) {
+			logSkippedActiveDistributedRun(ctx, id, readErr)
+			return true, nil
 		}
-		logger.Warn(ctx, "Skipping corrupted active distributed run entry",
-			tag.Name(id),
-			tag.Error(readErr),
+
+		removed, removeErr := removeStaleCorruptRecord(
+			ctx,
+			s.col,
+			id,
+			s.corruptRecordGracePeriod,
 		)
+		if errors.Is(removeErr, persis.ErrNotFound) {
+			return true, nil
+		}
+		if removeErr != nil {
+			logger.Warn(ctx, "Failed to remove corrupt active distributed run entry",
+				tag.Name(id),
+				tag.Error(removeErr),
+			)
+		} else if removed {
+			logger.Warn(ctx, "Removed stale corrupt active distributed run entry",
+				tag.Name(id),
+				tag.Error(readErr),
+			)
+			return true, nil
+		}
+		logSkippedActiveDistributedRun(ctx, id, readErr)
 		return true, nil
 	})
 	if err != nil {
@@ -152,10 +144,7 @@ func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveD
 	for _, rec := range recs {
 		var record exec.ActiveDistributedRun
 		if err := persis.Decode(rec, &record); err != nil {
-			logger.Warn(ctx, "Skipping corrupted active distributed run entry",
-				tag.Name(rec.ID),
-				tag.Error(err),
-			)
+			logSkippedActiveDistributedRun(ctx, rec.ID, err)
 			continue
 		}
 		if record.AttemptKey == "" {
@@ -167,4 +156,11 @@ func (s *ActiveDistributedRunStore) ListAll(ctx context.Context) ([]exec.ActiveD
 		return records[i].AttemptKey < records[j].AttemptKey
 	})
 	return records, nil
+}
+
+func logSkippedActiveDistributedRun(ctx context.Context, id string, err error) {
+	logger.Warn(ctx, "Skipping corrupted active distributed run entry",
+		tag.Name(id),
+		tag.Error(err),
+	)
 }

--- a/internal/persis/store/distributed_corruption.go
+++ b/internal/persis/store/distributed_corruption.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -21,7 +20,7 @@ type distributedStoreOptions struct {
 }
 
 // WithCorruptRecordGracePeriod sets how long a corrupt distributed record
-// remains fail-closed before it can be quarantined as stale.
+// remains fail-closed before it can be removed as stale.
 func WithCorruptRecordGracePeriod(period time.Duration) DistributedStoreOption {
 	return func(opts *distributedStoreOptions) {
 		opts.corruptRecordGracePeriod = max(period, 0)
@@ -37,32 +36,28 @@ func resolveDistributedStoreOptions(opts []DistributedStoreOption) distributedSt
 }
 
 type corruptRecordCollection interface {
-	RepairCorrupt(ctx context.Context, rec *persis.Record) error
-	QuarantineCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error)
+	RemoveCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error)
 }
 
-func repairCorruptRecord(ctx context.Context, col persis.Collection, rec *persis.Record) (bool, error) {
-	repairer, ok := col.(corruptRecordCollection)
+func removeCorruptRecord(
+	ctx context.Context,
+	col persis.Collection,
+	id string,
+	staleBefore time.Time,
+) (bool, error) {
+	remover, ok := col.(corruptRecordCollection)
 	if !ok {
 		return false, nil
 	}
-	err := repairer.RepairCorrupt(ctx, rec)
-	if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
-		return false, persis.ErrConflict
-	}
-	return err == nil, err
+	return remover.RemoveCorrupt(ctx, id, staleBefore)
 }
 
-func quarantineStaleCorruptRecord(
+func removeStaleCorruptRecord(
 	ctx context.Context,
 	col persis.Collection,
 	id string,
 	gracePeriod time.Duration,
 ) (bool, error) {
-	quarantiner, ok := col.(corruptRecordCollection)
-	if !ok {
-		return false, nil
-	}
 	staleBefore := time.Now().UTC().Add(-gracePeriod)
-	return quarantiner.QuarantineCorrupt(ctx, id, staleBefore)
+	return removeCorruptRecord(ctx, col, id, staleBefore)
 }

--- a/internal/persis/store/distributed_corruption.go
+++ b/internal/persis/store/distributed_corruption.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis"
+)
+
+// DistributedStoreOption configures file-corruption recovery for distributed
+// control-plane stores.
+type DistributedStoreOption func(*distributedStoreOptions)
+
+type distributedStoreOptions struct {
+	corruptRecordGracePeriod time.Duration
+}
+
+// WithCorruptRecordGracePeriod sets how long a corrupt distributed record
+// remains fail-closed before it can be quarantined as stale.
+func WithCorruptRecordGracePeriod(period time.Duration) DistributedStoreOption {
+	return func(opts *distributedStoreOptions) {
+		opts.corruptRecordGracePeriod = max(period, 0)
+	}
+}
+
+func resolveDistributedStoreOptions(opts []DistributedStoreOption) distributedStoreOptions {
+	resolved := distributedStoreOptions{corruptRecordGracePeriod: exec.DefaultStaleLeaseThreshold}
+	for _, opt := range opts {
+		opt(&resolved)
+	}
+	return resolved
+}
+
+type corruptRecordCollection interface {
+	RepairCorrupt(ctx context.Context, rec *persis.Record) error
+	QuarantineCorrupt(ctx context.Context, id string, staleBefore time.Time) (bool, error)
+}
+
+func repairCorruptRecord(ctx context.Context, col persis.Collection, rec *persis.Record) (bool, error) {
+	repairer, ok := col.(corruptRecordCollection)
+	if !ok {
+		return false, nil
+	}
+	err := repairer.RepairCorrupt(ctx, rec)
+	if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
+		return false, persis.ErrConflict
+	}
+	return err == nil, err
+}
+
+func quarantineStaleCorruptRecord(
+	ctx context.Context,
+	col persis.Collection,
+	id string,
+	gracePeriod time.Duration,
+) (bool, error) {
+	quarantiner, ok := col.(corruptRecordCollection)
+	if !ok {
+		return false, nil
+	}
+	staleBefore := time.Now().UTC().Add(-gracePeriod)
+	return quarantiner.QuarantineCorrupt(ctx, id, staleBefore)
+}

--- a/internal/persis/store/distributed_corruption.go
+++ b/internal/persis/store/distributed_corruption.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -50,6 +51,25 @@ func removeCorruptRecord(
 		return false, nil
 	}
 	return remover.RemoveCorrupt(ctx, id, staleBefore)
+}
+
+func removeCorruptRecordForRetry(
+	ctx context.Context,
+	col persis.Collection,
+	id string,
+	readErr error,
+) (bool, error) {
+	removed, err := removeCorruptRecord(ctx, col, id, time.Time{})
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) || errors.Is(err, persis.ErrConflict) {
+			return false, persis.ErrConflict
+		}
+		return false, err
+	}
+	if !removed {
+		return false, readErr
+	}
+	return true, persis.ErrConflict
 }
 
 func removeStaleCorruptRecord(

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/persis"
 )
@@ -20,12 +22,17 @@ var _ exec.DAGRunLeaseStore = (*DAGRunLeaseStore)(nil)
 // [persis.Collection]. Record IDs use the file-backed distributed store
 // SHA-256 key.
 type DAGRunLeaseStore struct {
-	col persis.Collection
+	col                      persis.Collection
+	corruptRecordGracePeriod time.Duration
 }
 
 // NewDAGRunLeaseStore creates a DAGRunLeaseStore backed by col.
-func NewDAGRunLeaseStore(col persis.Collection) *DAGRunLeaseStore {
-	return &DAGRunLeaseStore{col: col}
+func NewDAGRunLeaseStore(col persis.Collection, opts ...DistributedStoreOption) *DAGRunLeaseStore {
+	resolved := resolveDistributedStoreOptions(opts)
+	return &DAGRunLeaseStore{
+		col:                      col,
+		corruptRecordGracePeriod: resolved.corruptRecordGracePeriod,
+	}
 }
 
 // Upsert writes lease for attemptKey. Get → Create if absent /
@@ -49,23 +56,35 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 			current.LastHeartbeatAt = now.UnixMilli()
 		}
 
-		existing, getErr := s.col.Get(ctx, id)
-		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
-			return getErr
-		}
-
 		data, err := persis.Encode(current)
 		if err != nil {
 			return err
 		}
+		stored := &persis.Record{
+			ID:        id,
+			Data:      data,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+
+		existing, getErr := s.col.Get(ctx, id)
+		if errors.Is(getErr, persis.ErrCorrupt) {
+			repaired, repairErr := repairCorruptRecord(ctx, s.col, stored)
+			if repairErr != nil {
+				return repairErr
+			}
+			if repaired {
+				logger.Warn(ctx, "Repaired corrupt distributed lease entry", tag.Name(id))
+				return nil
+			}
+			return getErr
+		}
+		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
+			return getErr
+		}
 
 		if existing == nil {
-			return s.col.Create(ctx, &persis.Record{
-				ID:        id,
-				Data:      data,
-				CreatedAt: now,
-				UpdatedAt: now,
-			})
+			return s.col.Create(ctx, stored)
 		}
 		casErr := s.col.CompareAndSwap(ctx, id, existing.Data, data)
 		if errors.Is(casErr, persis.ErrNotFound) {
@@ -143,7 +162,31 @@ func (s *DAGRunLeaseStore) ListByQueue(ctx context.Context, queueName string) ([
 }
 
 func (s *DAGRunLeaseStore) ListAll(ctx context.Context) ([]exec.DAGRunLease, error) {
-	recs, err := listAllStrict(ctx, s.col, persis.ListQuery{})
+	recs, err := listAllStrictWithReadError(ctx, s.col, persis.ListQuery{}, func(id string, readErr error) (bool, error) {
+		if !errors.Is(readErr, persis.ErrCorrupt) {
+			return false, nil
+		}
+		quarantined, quarantineErr := quarantineStaleCorruptRecord(
+			ctx,
+			s.col,
+			id,
+			s.corruptRecordGracePeriod,
+		)
+		if errors.Is(quarantineErr, persis.ErrNotFound) {
+			return true, nil
+		}
+		if quarantineErr != nil {
+			return false, quarantineErr
+		}
+		if !quarantined {
+			return false, nil
+		}
+		logger.Warn(ctx, "Quarantined stale corrupt distributed lease entry",
+			tag.Name(id),
+			tag.Error(readErr),
+		)
+		return true, nil
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -69,18 +69,11 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 
 		existing, getErr := s.col.Get(ctx, id)
 		if errors.Is(getErr, persis.ErrCorrupt) {
-			removed, removeErr := removeCorruptRecord(ctx, s.col, id, time.Time{})
-			if errors.Is(removeErr, persis.ErrNotFound) || errors.Is(removeErr, persis.ErrConflict) {
-				return persis.ErrConflict
-			}
-			if removeErr != nil {
-				return removeErr
-			}
+			removed, retryErr := removeCorruptRecordForRetry(ctx, s.col, id, getErr)
 			if removed {
 				logger.Warn(ctx, "Removed corrupt distributed lease entry before replacement", tag.Name(id))
-				return persis.ErrConflict
 			}
-			return getErr
+			return retryErr
 		}
 		if getErr != nil && !errors.Is(getErr, persis.ErrNotFound) {
 			return getErr

--- a/internal/persis/store/distributed_lease.go
+++ b/internal/persis/store/distributed_lease.go
@@ -69,13 +69,16 @@ func (s *DAGRunLeaseStore) Upsert(ctx context.Context, lease exec.DAGRunLease) e
 
 		existing, getErr := s.col.Get(ctx, id)
 		if errors.Is(getErr, persis.ErrCorrupt) {
-			repaired, repairErr := repairCorruptRecord(ctx, s.col, stored)
-			if repairErr != nil {
-				return repairErr
+			removed, removeErr := removeCorruptRecord(ctx, s.col, id, time.Time{})
+			if errors.Is(removeErr, persis.ErrNotFound) || errors.Is(removeErr, persis.ErrConflict) {
+				return persis.ErrConflict
 			}
-			if repaired {
-				logger.Warn(ctx, "Repaired corrupt distributed lease entry", tag.Name(id))
-				return nil
+			if removeErr != nil {
+				return removeErr
+			}
+			if removed {
+				logger.Warn(ctx, "Removed corrupt distributed lease entry before replacement", tag.Name(id))
+				return persis.ErrConflict
 			}
 			return getErr
 		}
@@ -166,22 +169,22 @@ func (s *DAGRunLeaseStore) ListAll(ctx context.Context) ([]exec.DAGRunLease, err
 		if !errors.Is(readErr, persis.ErrCorrupt) {
 			return false, nil
 		}
-		quarantined, quarantineErr := quarantineStaleCorruptRecord(
+		removed, removeErr := removeStaleCorruptRecord(
 			ctx,
 			s.col,
 			id,
 			s.corruptRecordGracePeriod,
 		)
-		if errors.Is(quarantineErr, persis.ErrNotFound) {
+		if errors.Is(removeErr, persis.ErrNotFound) {
 			return true, nil
 		}
-		if quarantineErr != nil {
-			return false, quarantineErr
+		if removeErr != nil {
+			return false, removeErr
 		}
-		if !quarantined {
+		if !removed {
 			return false, nil
 		}
-		logger.Warn(ctx, "Quarantined stale corrupt distributed lease entry",
+		logger.Warn(ctx, "Removed stale corrupt distributed lease entry",
 			tag.Name(id),
 			tag.Error(readErr),
 		)

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -197,7 +197,7 @@ func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
 	assert.NoError(t, statErr)
 }
 
-func TestDAGRunLeaseStore_UpsertRepairsCorruptRecord(t *testing.T) {
+func TestDAGRunLeaseStore_UpsertReplacesCorruptRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -222,7 +222,7 @@ func TestDAGRunLeaseStore_UpsertRepairsCorruptRecord(t *testing.T) {
 	assert.Equal(t, "queue-a", lease.QueueName)
 }
 
-func TestDAGRunLeaseStore_ListAllQuarantinesStaleCorruptRecord(t *testing.T) {
+func TestDAGRunLeaseStore_ListAllRemovesStaleCorruptRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -242,9 +242,9 @@ func TestDAGRunLeaseStore_ListAllQuarantinesStaleCorruptRecord(t *testing.T) {
 
 	_, err = os.Stat(path)
 	assert.ErrorIs(t, err, os.ErrNotExist)
-	quarantined, err := filepath.Glob(path + ".corrupt-*")
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	assert.Len(t, quarantined, 1)
+	assert.Empty(t, entries)
 }
 
 func TestActiveDistributedRunStore_UpsertListGetAndDelete(t *testing.T) {
@@ -381,7 +381,7 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 	assert.NoError(t, statErr)
 }
 
-func TestActiveDistributedRunStore_UpsertRepairsCorruptRecord(t *testing.T) {
+func TestActiveDistributedRunStore_UpsertReplacesCorruptRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -405,7 +405,7 @@ func TestActiveDistributedRunStore_UpsertRepairsCorruptRecord(t *testing.T) {
 	assert.Equal(t, "worker-1", record.WorkerID)
 }
 
-func TestActiveDistributedRunStore_ListAllQuarantinesStaleCorruptRecord(t *testing.T) {
+func TestActiveDistributedRunStore_ListAllRemovesStaleCorruptRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -425,9 +425,9 @@ func TestActiveDistributedRunStore_ListAllQuarantinesStaleCorruptRecord(t *testi
 
 	_, err = os.Stat(path)
 	assert.ErrorIs(t, err, os.ErrNotExist)
-	quarantined, err := filepath.Glob(path + ".corrupt-*")
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	assert.Len(t, quarantined, 1)
+	assert.Empty(t, entries)
 }
 
 func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {

--- a/internal/persis/store/distributed_test.go
+++ b/internal/persis/store/distributed_test.go
@@ -185,12 +185,66 @@ func TestDAGRunLeaseStore_ListAllSurfacesCorruptRecord(t *testing.T) {
 
 	ctx := context.Background()
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, encodedKey("corrupt-lease")+".json"), []byte("{"), 0o600))
+	corruptPath := filepath.Join(dir, encodedKey("corrupt-lease")+".json")
+	require.NoError(t, os.WriteFile(corruptPath, []byte("{"), 0o600))
 
 	s := store.NewDAGRunLeaseStore(file.NewCollection(dir))
 	_, err := s.ListAll(ctx)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, persis.ErrCorrupt)
 	assert.Contains(t, err.Error(), "corrupt")
+	_, statErr := os.Stat(corruptPath)
+	assert.NoError(t, statErr)
+}
+
+func TestDAGRunLeaseStore_UpsertRepairsCorruptRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodedKey("repair-lease")+".json")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+	s := store.NewDAGRunLeaseStore(file.NewCollection(dir))
+	require.NoError(t, s.Upsert(ctx, exec.DAGRunLease{
+		AttemptKey:      "repair-lease",
+		DAGRun:          exec.NewDAGRunRef("dag-a", "run-1"),
+		Root:            exec.NewDAGRunRef("dag-a", "run-1"),
+		AttemptID:       "attempt-1",
+		QueueName:       "queue-a",
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	lease, err := s.Get(ctx, "repair-lease")
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, "queue-a", lease.QueueName)
+}
+
+func TestDAGRunLeaseStore_ListAllQuarantinesStaleCorruptRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodedKey("stale-corrupt-lease")+".json")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+	old := time.Now().Add(-2 * time.Minute)
+	require.NoError(t, os.Chtimes(path, old, old))
+
+	s := store.NewDAGRunLeaseStore(
+		file.NewCollection(dir),
+		store.WithCorruptRecordGracePeriod(time.Minute),
+	)
+	leases, err := s.ListAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, leases)
+
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	quarantined, err := filepath.Glob(path + ".corrupt-*")
+	require.NoError(t, err)
+	assert.Len(t, quarantined, 1)
 }
 
 func TestActiveDistributedRunStore_UpsertListGetAndDelete(t *testing.T) {
@@ -316,12 +370,64 @@ func TestActiveDistributedRunStore_ListAllSkipsCorruptRecord(t *testing.T) {
 		WorkerID:   "worker-1",
 		Status:     core.Running,
 	}))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, encodedKey("corrupt-active")+".json"), []byte("{"), 0o600))
+	corruptPath := filepath.Join(dir, encodedKey("corrupt-active")+".json")
+	require.NoError(t, os.WriteFile(corruptPath, []byte("{"), 0o600))
 
 	records, err := s.ListAll(ctx)
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	assert.Equal(t, "attempt-key-1", records[0].AttemptKey)
+	_, statErr := os.Stat(corruptPath)
+	assert.NoError(t, statErr)
+}
+
+func TestActiveDistributedRunStore_UpsertRepairsCorruptRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodedKey("repair-active")+".json")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+	s := store.NewActiveDistributedRunStore(file.NewCollection(dir))
+	require.NoError(t, s.Upsert(ctx, exec.ActiveDistributedRun{
+		AttemptKey: "repair-active",
+		DAGRun:     exec.NewDAGRunRef("dag-a", "run-1"),
+		Root:       exec.NewDAGRunRef("dag-a", "run-1"),
+		AttemptID:  "attempt-1",
+		WorkerID:   "worker-1",
+		Status:     core.Running,
+	}))
+
+	record, err := s.Get(ctx, "repair-active")
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	assert.Equal(t, "worker-1", record.WorkerID)
+}
+
+func TestActiveDistributedRunStore_ListAllQuarantinesStaleCorruptRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodedKey("stale-corrupt-active")+".json")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+	old := time.Now().Add(-2 * time.Minute)
+	require.NoError(t, os.Chtimes(path, old, old))
+
+	s := store.NewActiveDistributedRunStore(
+		file.NewCollection(dir),
+		store.WithCorruptRecordGracePeriod(time.Minute),
+	)
+	records, err := s.ListAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	quarantined, err := filepath.Glob(path + ".corrupt-*")
+	require.NoError(t, err)
+	assert.Len(t, quarantined, 1)
 }
 
 func TestDispatchTaskStore_ClaimRecycleAndSelectorFiltering(t *testing.T) {

--- a/internal/persis/store/singlerecord.go
+++ b/internal/persis/store/singlerecord.go
@@ -15,7 +15,7 @@ import (
 // ErrCorrupt reports that a record exists but its payload could not be decoded.
 // It is distinct from a backend read failure so callers can choose to recover
 // (for example, start from a fresh value) rather than propagate the error.
-var ErrCorrupt = errors.New("persis/store: corrupt record")
+var ErrCorrupt = persis.ErrCorrupt
 
 // SingleRecord persists one value at a fixed record ID within a collection.
 //

--- a/internal/persis/store/util.go
+++ b/internal/persis/store/util.go
@@ -16,6 +16,8 @@ type strictRecordIDsCollection interface {
 	RecordIDs(ctx context.Context, prefix string) ([]string, error)
 }
 
+type recordReadErrorHandler func(id string, err error) (handled bool, handleErr error)
+
 // listAll drains all pages from col matching q, ignoring the Cursor field of q.
 func listAll(ctx context.Context, col persis.Collection, q persis.ListQuery) ([]*persis.Record, error) {
 	q.Cursor = ""
@@ -37,45 +39,14 @@ func listAll(ctx context.Context, col persis.Collection, q persis.ListQuery) ([]
 // so malformed file-backed records are surfaced by Get instead of being skipped
 // by collection-level listing.
 func listAllStrict(ctx context.Context, col persis.Collection, q persis.ListQuery) ([]*persis.Record, error) {
-	idCol, ok := col.(strictRecordIDsCollection)
-	if !ok {
-		return listAll(ctx, col, q)
-	}
-
-	ids, err := idCol.RecordIDs(ctx, q.Prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	recs := make([]*persis.Record, 0, len(ids))
-	for _, id := range ids {
-		rec, err := col.Get(ctx, id)
-		if err != nil {
-			if errors.Is(err, persis.ErrNotFound) {
-				continue
-			}
-			return nil, fmt.Errorf("list record %q: %w", id, err)
-		}
-		if q.Since != nil && rec.CreatedAt.Before(*q.Since) {
-			continue
-		}
-		if q.Until != nil && !rec.CreatedAt.Before(*q.Until) {
-			continue
-		}
-		recs = append(recs, rec)
-	}
-
-	sortRecordsByCreatedAt(recs)
-	return recs, nil
+	return listAllStrictWithReadError(ctx, col, q, nil)
 }
 
-// listAllBestEffort drains records like listAll, but uses RecordIDs when
-// available so callers can observe and skip individual unreadable records.
-func listAllBestEffort(
+func listAllStrictWithReadError(
 	ctx context.Context,
 	col persis.Collection,
 	q persis.ListQuery,
-	onReadError func(id string, err error),
+	onReadError recordReadErrorHandler,
 ) ([]*persis.Record, error) {
 	idCol, ok := col.(strictRecordIDsCollection)
 	if !ok {
@@ -95,9 +66,15 @@ func listAllBestEffort(
 				continue
 			}
 			if onReadError != nil {
-				onReadError(id, err)
+				handled, handleErr := onReadError(id, err)
+				if handleErr != nil {
+					return nil, handleErr
+				}
+				if handled {
+					continue
+				}
 			}
-			continue
+			return nil, fmt.Errorf("list record %q: %w", id, err)
 		}
 		if q.Since != nil && rec.CreatedAt.Before(*q.Since) {
 			continue

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/dagstate"
+	"github.com/dagucloud/dagu/internal/persis"
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
@@ -1174,8 +1175,8 @@ func (h *Handler) RunHeartbeat(ctx context.Context, req *coordinatorv1.RunHeartb
 		if task == nil || task.AttemptKey == "" {
 			continue
 		}
-		if err := h.dagRunLeaseStore.Touch(ctx, task.AttemptKey, observedAt); err != nil {
-			if errors.Is(err, exec.ErrDAGRunLeaseNotFound) {
+		if err := h.refreshRunLease(ctx, task.AttemptKey, observedAt); err != nil {
+			if errors.Is(err, exec.ErrDAGRunLeaseNotFound) || errors.Is(err, persis.ErrCorrupt) {
 				cancelledRuns = appendCancelledRunIfMissing(cancelledRuns, task.AttemptKey)
 				continue
 			}
@@ -1188,6 +1189,17 @@ func (h *Handler) RunHeartbeat(ctx context.Context, req *coordinatorv1.RunHeartb
 		RunningTasks: req.RunningTasks,
 	}))
 	return &coordinatorv1.RunHeartbeatResponse{CancelledRuns: cancelledRuns}, nil
+}
+
+func (h *Handler) refreshRunLease(ctx context.Context, attemptKey string, observedAt time.Time) error {
+	lease, err := h.dagRunLeaseStore.Get(ctx, attemptKey)
+	if err != nil {
+		return err
+	}
+	if lease != nil && observedAt.Before(lease.LastHeartbeatTime().Add(h.leaseRefreshWriteInterval())) {
+		return nil
+	}
+	return h.dagRunLeaseStore.Touch(ctx, attemptKey, observedAt)
 }
 
 func (h *Handler) repairStaleLeaseFailureFromRunHeartbeat(

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/persis"
 	"github.com/dagucloud/dagu/internal/persis/file/dagrun"
 	"github.com/dagucloud/dagu/internal/proto/convert"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
@@ -32,6 +33,18 @@ func coordinatorTestTimeout(timeout time.Duration) time.Duration {
 		return timeout * 5
 	}
 	return timeout
+}
+
+type corruptLeaseStore struct {
+	exec.DAGRunLeaseStore
+	attemptKey string
+}
+
+func (s corruptLeaseStore) Get(ctx context.Context, attemptKey string) (*exec.DAGRunLease, error) {
+	if attemptKey == s.attemptKey {
+		return nil, persis.ErrCorrupt
+	}
+	return s.DAGRunLeaseStore.Get(ctx, attemptKey)
 }
 
 func TestDispatchBindErrorCode(t *testing.T) {
@@ -1208,6 +1221,74 @@ func TestHandler_Heartbeat(t *testing.T) {
 		require.NoError(t, err)
 		assert.Greater(t, lease.LastHeartbeatAt, initial.UnixMilli())
 		assert.Equal(t, initial.UnixMilli(), lease.ClaimedAt)
+	})
+
+	t.Run("RunHeartbeatCoalescesFreshSharedLease", func(t *testing.T) {
+		t.Parallel()
+
+		leaseStore := newTestDAGRunLeaseStore(filepath.Join(t.TempDir(), "distributed"))
+		h := NewHandler(HandlerConfig{
+			DAGRunLeaseStore: leaseStore,
+			Owner:            exec.CoordinatorEndpoint{ID: "coord-a"},
+		})
+		ctx := context.Background()
+		initial := time.Now().UTC()
+		require.NoError(t, leaseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      "attempt-key-1",
+			DAGRun:          exec.NewDAGRunRef("test-dag", "run-123"),
+			AttemptID:       "attempt-1",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: initial.UnixMilli(),
+		}))
+
+		_, err := h.RunHeartbeat(ctx, &coordinatorv1.RunHeartbeatRequest{
+			WorkerId:           "worker-1",
+			OwnerCoordinatorId: "coord-a",
+			RunningTasks: []*coordinatorv1.RunningTask{
+				{AttemptKey: "attempt-key-1"},
+			},
+		})
+		require.NoError(t, err)
+
+		lease, err := leaseStore.Get(ctx, "attempt-key-1")
+		require.NoError(t, err)
+		assert.Equal(t, initial.UnixMilli(), lease.LastHeartbeatAt)
+	})
+
+	t.Run("RunHeartbeatIsolatesCorruptLease", func(t *testing.T) {
+		t.Parallel()
+
+		baseStore := newTestDAGRunLeaseStore(filepath.Join(t.TempDir(), "distributed"))
+		leaseStore := corruptLeaseStore{DAGRunLeaseStore: baseStore, attemptKey: "corrupt-key"}
+		h := NewHandler(HandlerConfig{
+			DAGRunLeaseStore: leaseStore,
+			Owner:            exec.CoordinatorEndpoint{ID: "coord-a"},
+		})
+		ctx := context.Background()
+		initial := time.Now().Add(-10 * time.Second).UTC()
+		require.NoError(t, baseStore.Upsert(ctx, exec.DAGRunLease{
+			AttemptKey:      "valid-key",
+			DAGRun:          exec.NewDAGRunRef("test-dag", "run-123"),
+			AttemptID:       "attempt-1",
+			WorkerID:        "worker-1",
+			LastHeartbeatAt: initial.UnixMilli(),
+		}))
+
+		resp, err := h.RunHeartbeat(ctx, &coordinatorv1.RunHeartbeatRequest{
+			WorkerId:           "worker-1",
+			OwnerCoordinatorId: "coord-a",
+			RunningTasks: []*coordinatorv1.RunningTask{
+				{AttemptKey: "corrupt-key"},
+				{AttemptKey: "valid-key"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.CancelledRuns, 1)
+		assert.Equal(t, "corrupt-key", resp.CancelledRuns[0].AttemptKey)
+
+		lease, err := baseStore.Get(ctx, "valid-key")
+		require.NoError(t, err)
+		assert.Greater(t, lease.LastHeartbeatAt, initial.UnixMilli())
 	})
 
 	t.Run("RunHeartbeatRepairsStaleLeaseFailureForOwnedAttempt", func(t *testing.T) {

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -330,6 +330,24 @@ func TestQueueProcessor_ProcessQueueItems_FailsClosedOnLeaseCountError(t *testin
 	assert.Contains(t, f.logs(), "Failed to count distributed leases")
 }
 
+func TestQueueProcessor_StaleCorruptLeaseDoesNotBlockCapacityCheck(t *testing.T) {
+	f := newQueueFixture(t).withDAG("stale-corrupt-lease-dag", 1).
+		withProcessor(config.Queues{}).
+		simulateQueue(1, false)
+
+	leaseDir := filepath.Join(f.distributedDir, "leases")
+	require.NoError(t, os.MkdirAll(leaseDir, 0o750))
+	path := filepath.Join(leaseDir, "stale-corrupt.json")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+	old := time.Now().Add(-2 * exec.DefaultStaleLeaseThreshold)
+	require.NoError(t, os.Chtimes(path, old, old))
+
+	count, err := f.processor.newQueueDispatcher().countActiveDistributedRuns(f.ctx, f.dag.Name)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	assert.Contains(t, f.logs(), "Quarantined stale corrupt distributed lease entry")
+}
+
 func TestQueueProcessor_ProcessQueueItems_FailsClosedOnOutstandingDispatchCountError(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-dispatch-count-error-dag", 1).
 		withProcessor(config.Queues{}).

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -345,7 +345,7 @@ func TestQueueProcessor_StaleCorruptLeaseDoesNotBlockCapacityCheck(t *testing.T)
 	count, err := f.processor.newQueueDispatcher().countActiveDistributedRuns(f.ctx, f.dag.Name)
 	require.NoError(t, err)
 	assert.Zero(t, count)
-	assert.Contains(t, f.logs(), "Quarantined stale corrupt distributed lease entry")
+	assert.Contains(t, f.logs(), "Removed stale corrupt distributed lease entry")
 }
 
 func TestQueueProcessor_ProcessQueueItems_FailsClosedOnOutstandingDispatchCountError(t *testing.T) {


### PR DESCRIPTION
## Summary

- make file-backed atomic writes crash-durable by syncing temporary file contents and parent-directory metadata
- add crash-safe exclusive record creation and typed corrupt-record errors
- recover distributed lease and active-run stores from invalid JSON without leaving quarantine files in collection scans
- remove stale corrupt records after the grace period while keeping recent lease corruption fail-closed
- immediately remove and recreate corrupt records when an authoritative upsert is available

## Root cause

The file backend renamed temporary files without syncing the file contents or the containing directory. A host power loss could therefore persist the renamed directory entry while losing the file data, leaving zero-byte or otherwise invalid JSON records.

Distributed lease listing treated any unreadable lease as a global failure. A single corrupt lease could make queue-capacity checks fail closed and leave scheduled runs queued indefinitely. Active-run listing skipped unreadable entries but retained them permanently, causing repeated scans and warnings.

## Impact

New writes are durable across process or host crashes when the underlying filesystem honors fsync. Existing corrupt distributed records are removed safely after the configured grace period, and fresh coordinator updates replace corrupt records immediately. Cleanup deletes the damaged file instead of accumulating quarantine artifacts, so collection scans do not degrade over time.

## Validation

- `make fmt`
- `make lint`
- `go test ./internal/cmn/fileutil ./internal/persis/file ./internal/persis/store ./internal/service/scheduler ./internal/service/coordinator -count=1`
- focused race tests for file persistence and distributed-store recovery
- Windows cross-compilation for the affected file persistence packages

Closes #2375

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make file-backed writes crash-durable and recover distributed records from invalid JSON. Coalesce lease heartbeats and safely clean up corrupt files so scheduling and capacity checks continue.

- **Bug Fixes**
  - `internal/cmn/fileutil`: Sync temp file and parent directory for atomic writes; add `WriteFileAtomicExclusive`; add durable delete; use write-through on Windows.
  - `persis`: Add `ErrCorrupt` and propagate it from the file backend and single-record store.
  - `internal/persis/file`: `Create` uses `WriteFileAtomicExclusive`; `Get` returns `ErrCorrupt` for invalid JSON; add `RemoveCorrupt` with durable deletes.
  - `internal/persis/store`: On upsert, replace corrupt lease/active-run records; on list, remove stale corrupt files after a grace period; lease listing no longer blocks capacity checks; active-run listing skips and cleans corrupt entries; grace period configurable via `WithCorruptRecordGracePeriod`.
  - `internal/service/coordinator`: Coalesce `RunHeartbeat` lease updates when already fresh; isolate corrupt leases by cancelling only the affected run.

<sup>Written for commit 605ba9f57b872cc4c712ab4e42d93928dcad8e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for corrupted persisted records.
  - Added support for identifying and removing stale corrupted records.
  - Added typed corruption errors for clearer failure reporting.

- **Bug Fixes**
  - Improved atomic file operations to ensure data and directory changes are durably persisted.
  - Prevented failed exclusive writes from overwriting existing data.
  - Distributed leases and active runs can now recover from corrupted records without blocking scheduling or capacity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->