### PR TITLE
fix: preserve startup cancellation

### DIFF
--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1091,6 +1091,12 @@ func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 		v = v.Elem()
 	}
 
+	if v.CanInterface() {
+		if provider, ok := v.Interface().(interface{ Value() any }); ok {
+			return valueReferencesRunArtifactsDir(reflect.ValueOf(provider.Value()))
+		}
+	}
+
 	switch v.Kind() {
 	case reflect.String:
 		return referencesArtifactsEnvVar(v.String())
@@ -1108,8 +1114,12 @@ func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 			}
 		}
 	case reflect.Struct:
-		for _, field := range v.Fields() {
-			if valueReferencesRunArtifactsDir(field) {
+		t := v.Type()
+		for i := range v.NumField() {
+			if t.Field(i).PkgPath != "" {
+				continue
+			}
+			if valueReferencesRunArtifactsDir(v.Field(i)) {
 				return true
 			}
 		}

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -2797,6 +2797,16 @@ steps:
 			expected: &core.ArtifactsConfig{Enabled: true},
 		},
 		{
+			name: "AutoEnableWhenEnvReferencesArtifactsDir",
+			yaml: `
+env:
+  REPORT_DIR: ${DAG_RUN_ARTIFACTS_DIR}/reports
+steps:
+  - run: ./generate-report
+`,
+			expected: &core.ArtifactsConfig{Enabled: true},
+		},
+		{
 			name: "AutoEnableWhenStdoutArtifactIsUsed",
 			yaml: `
 steps:

--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -23,8 +23,9 @@ var (
 // Plan represents a plan of execution for a set of steps.
 // It encapsulates the graph structure and ensures thread-safe access.
 type Plan struct {
-	startedAt  time.Time
-	finishedAt time.Time
+	startedAt       time.Time
+	finishedAt      time.Time
+	cancelRequested bool
 
 	// Graph structure (immutable after construction)
 	nodes      []*Node
@@ -397,6 +398,18 @@ func (p *Plan) Finish() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.finishedAt = time.Now()
+}
+
+func (p *Plan) requestCancel() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelRequested = true
+}
+
+func (p *Plan) isCancelRequested() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cancelRequested
 }
 
 // PlanNodeStates holds the state flags for nodes in a plan.

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -134,7 +134,7 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	if err := r.setup(ctx); err != nil {
 		return err
 	}
-	r.resetRunState()
+	r.resetRunState(plan)
 
 	// Create a cancellable context for the entire execution
 	var cancel context.CancelFunc
@@ -903,12 +903,13 @@ func (r *Runner) Stop(
 ) {
 	isTermination := intent.IsTermination()
 
-	// Set canceled flag FIRST so execution loops see it immediately.
-	// This prevents a race where the execution loop checks isCanceled()
-	// before we've set the flag, causing it to mark nodes as Succeeded
-	// instead of Aborted.
-	if !r.isCanceled() && isTermination {
-		r.setCanceled()
+	// Record termination before inspecting nodes so execution that has not
+	// started yet observes the request.
+	if isTermination {
+		plan.requestCancel()
+		if !r.isCanceled() {
+			r.setCanceled()
+		}
 	}
 
 	for _, node := range plan.Nodes() {
@@ -935,6 +936,7 @@ func (r *Runner) Stop(
 
 // Cancel sends -1 signal to all nodes.
 func (r *Runner) Cancel(p *Plan) {
+	p.requestCancel()
 	r.setCanceled()
 	for _, node := range p.Nodes() {
 		node.Cancel()
@@ -1183,10 +1185,15 @@ func (r *Runner) setFailed() {
 	r.failed = 1
 }
 
-func (r *Runner) resetRunState() {
+func (r *Runner) resetRunState(plan *Plan) {
+	cancelRequested := plan.isCancelRequested()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.canceled = 0
+	if cancelRequested {
+		r.canceled = 1
+	}
 	r.failed = 0
 	r.lastError = nil
 }

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1186,12 +1186,10 @@ func (r *Runner) setFailed() {
 }
 
 func (r *Runner) resetRunState(plan *Plan) {
-	cancelRequested := plan.isCancelRequested()
-
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.canceled = 0
-	if cancelRequested {
+	if plan.isCancelRequested() {
 		r.canceled = 1
 	}
 	r.failed = 0

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -2181,6 +2181,16 @@ func TestRunner_StatusDefersForcedStatusUntilTerminal(t *testing.T) {
 }
 
 func TestRunner_SignalHandling(t *testing.T) {
+	t.Run("SignalBeforeRun", func(t *testing.T) {
+		r := setupRunner(t)
+		plan := r.newPlan(t, successStep("1"))
+
+		r.runner.Signal(r.Context, plan.Plan, syscall.SIGTERM, nil, false)
+
+		result := plan.assertRun(t, core.Aborted)
+		result.assertNodeStatus(t, "1", core.NodeNotStarted)
+	})
+
 	t.Run("SignalWithDoneChannel", func(t *testing.T) {
 		r := setupRunner(t)
 


### PR DESCRIPTION
## Summary

- latch termination requests on the execution plan before inspecting active nodes
- preserve a pre-start cancellation when the runner resets reusable run state
- add deterministic coverage for a signal received before `Runner.Run`
- stop artifact-reference inference from reflecting into opaque runtime values

## Root cause

The runner reset its cancellation flag when `Run` started. A termination request received after the plan was exposed but before the first node became active was acknowledged, then erased by that reset. The step subsequently started without observing the cancellation, causing Windows CI to time out.

While validating the review fix, the race-enabled Ubuntu suite also exposed the artifact-reference scanner traversing unexported `time.Time` and `time.Location` internals. The scanner now reads authored values through their public value contract and skips unexported implementation fields.

## Impact

Startup cancellation is now durable for the targeted plan while cancellation from a previous plan still does not leak when a runner is reused.

Artifact auto-enablement still recognizes references in typed YAML values such as `env`, without racing against runtime initialization of opaque standard-library types.

## Validation

- `make fmt`
- `go test ./internal/runtime -run '^TestRunner_SignalHandling$' -count=20`
- `go test ./internal/runtime -run '^TestRunner_DAGPreconditions$' -count=5`
- `go test ./internal/runtime/agent -run '^TestAgent_Run$/ReceiveSignal$' -count=10`
- `go test -race ./internal/runtime -run '^(TestRunner_SignalHandling|TestRunner_DAGPreconditions)$' -count=5`
- `go test -race ./internal/runtime/agent -run '^TestAgent_Run$/ReceiveSignal$' -count=5`
- `go test ./internal/runtime/... -count=1`
- `go test -race ./internal/core/spec -count=1`
- 20 fresh race-enabled runs of the parallel schedule/schema/load/artifact tests
