### PR TITLE
fix: support long builtin auth token TTLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,7 +809,7 @@ The embedded API is experimental and may change. See the embedded API documentat
 | `DAGU_AUTH_BASIC_USERNAME` | — | Basic auth username |
 | `DAGU_AUTH_BASIC_PASSWORD` | — | Basic auth password |
 | `DAGU_AUTH_TOKEN_SECRET` | (auto) | JWT signing secret |
-| `DAGU_AUTH_TOKEN_TTL` | `24h` | JWT token lifetime |
+| `DAGU_AUTH_TOKEN_TTL` | `24h` | JWT token lifetime (maximum: `8760h` / 365 days) |
 
 OIDC variables: `DAGU_AUTH_OIDC_CLIENT_ID`, `DAGU_AUTH_OIDC_CLIENT_SECRET`, `DAGU_AUTH_OIDC_ISSUER`, `DAGU_AUTH_OIDC_SCOPES`, `DAGU_AUTH_OIDC_WHITELIST`, `DAGU_AUTH_OIDC_AUTO_SIGNUP`, `DAGU_AUTH_OIDC_DEFAULT_ROLE`, `DAGU_AUTH_OIDC_ALLOWED_DOMAINS`.
 

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -246,6 +246,8 @@ type AuthBuiltin struct {
 	InitialAdmin InitialAdmin
 }
 
+const maxBuiltinAuthTokenTTL = 365 * 24 * time.Hour
+
 // TokenConfig represents JWT token configuration.
 type TokenConfig struct {
 	Secret string
@@ -694,6 +696,9 @@ func (c *Config) validateBuiltinAuth() error {
 	}
 	if c.Server.Auth.Builtin.Token.TTL <= 0 {
 		return fmt.Errorf("builtin auth requires a positive token TTL")
+	}
+	if c.Server.Auth.Builtin.Token.TTL > maxBuiltinAuthTokenTTL {
+		return fmt.Errorf("builtin auth token TTL must not exceed 8760h (365 days)")
 	}
 
 	// Validate initial_admin: both fields must be set, or neither.

--- a/internal/cmn/config/config_test.go
+++ b/internal/cmn/config/config_test.go
@@ -331,6 +331,36 @@ func TestConfig_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "positive token TTL")
 	})
 
+	t.Run("BuiltinAuth_MaxTokenTTL", func(t *testing.T) {
+		t.Parallel()
+		cfg := validBaseConfig()
+		cfg.Server.Auth = Auth{
+			Mode: AuthModeBuiltin,
+			Builtin: AuthBuiltin{
+				Token: TokenConfig{Secret: "secret", TTL: 365 * 24 * time.Hour},
+			},
+		}
+		cfg.Paths.UsersDir = "/tmp/users"
+		cfg.UI.MaxDashboardPageLimit = 1
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("BuiltinAuth_TokenTTLAboveMaximum", func(t *testing.T) {
+		t.Parallel()
+		cfg := validBaseConfig()
+		cfg.Server.Auth = Auth{
+			Mode: AuthModeBuiltin,
+			Builtin: AuthBuiltin{
+				Token: TokenConfig{Secret: "secret", TTL: 365*24*time.Hour + time.Second},
+			},
+		}
+		cfg.Paths.UsersDir = "/tmp/users"
+		cfg.UI.MaxDashboardPageLimit = 1
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not exceed 8760h (365 days)")
+	})
+
 	t.Run("BuiltinAuth_InitialAdmin_BothSet", func(t *testing.T) {
 		t.Parallel()
 		cfg := validBaseConfig()

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -404,7 +404,7 @@
         },
         "ttl": {
           "type": "string",
-          "description": "Token time-to-live duration (e.g., '24h')."
+          "description": "Token time-to-live duration up to 8760h (365 days), e.g. '24h'."
         }
       }
     },

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -18,8 +18,8 @@ import {
   TOKEN_KEY,
   addAuthSessionListener,
   clearAuthSession,
-  getAuthExpiresAt,
   getAuthToken,
+  scheduleAuthSessionExpiry,
   setAuthSession,
 } from '@/lib/authSession';
 import {
@@ -181,19 +181,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (!token) {
       return;
     }
-    const expiresAt = getAuthExpiresAt();
-    if (!expiresAt) {
-      return;
-    }
-    const delay = Date.parse(expiresAt) - Date.now();
-    if (delay <= 0) {
-      clearAuthSession('expired');
-      return;
-    }
-    const timeout = window.setTimeout(() => {
-      clearAuthSession('expired');
-    }, delay);
-    return () => window.clearTimeout(timeout);
+    return scheduleAuthSessionExpiry();
   }, [token]);
 
   useEffect(() => {

--- a/ui/src/lib/__tests__/authSession.test.ts
+++ b/ui/src/lib/__tests__/authSession.test.ts
@@ -7,14 +7,12 @@ import {
   clearAuthSession,
   getAuthToken,
   handleAuthResponse,
+  scheduleAuthSessionExpiry,
   setAuthSession,
 } from '../authSession';
 
 function base64URL(value: string): string {
-  return btoa(value)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 function createJWT(payload: Record<string, unknown>): string {
@@ -28,6 +26,8 @@ describe('authSession', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     localStorage.clear();
   });
@@ -68,6 +68,26 @@ describe('authSession', () => {
       token: null,
       reason: 'expired',
     });
+  });
+
+  it('keeps a long-lived session until its actual expiry', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const day = 24 * 60 * 60 * 1000;
+    const expiresAt = new Date(Date.now() + 90 * day).toISOString();
+    setAuthSession('long-lived-token', expiresAt);
+
+    const cancel = scheduleAuthSessionExpiry();
+    const firstDelay = Number(setTimeoutSpy.mock.calls[0]?.[1]);
+    expect(firstDelay).toBeLessThanOrEqual(2 ** 31 - 1);
+
+    vi.advanceTimersByTime(89 * day);
+    expect(getAuthToken()).toBe('long-lived-token');
+
+    vi.advanceTimersByTime(day);
+    expect(getAuthToken()).toBeNull();
+    cancel();
   });
 
   it('ignores login failures when there is no active token to invalidate', () => {

--- a/ui/src/lib/authSession.ts
+++ b/ui/src/lib/authSession.ts
@@ -5,6 +5,8 @@ export const TOKEN_KEY = 'dagu_auth_token';
 export const AUTH_TOKEN_EXPIRES_AT_KEY = 'dagu_auth_token_expires_at';
 export const AUTH_SESSION_CHANGED_EVENT = 'dagu:auth-session-changed';
 
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
 declare const getConfig: undefined | (() => { authMode?: string });
 
 type AuthSessionReason =
@@ -98,9 +100,7 @@ export function setAuthSession(
   });
 }
 
-export function clearAuthSession(
-  reason: AuthSessionReason = 'logout'
-): void {
+export function clearAuthSession(reason: AuthSessionReason = 'logout'): void {
   const hadToken = localStorage.getItem(TOKEN_KEY) !== null;
   const hadExpiresAt = localStorage.getItem(AUTH_TOKEN_EXPIRES_AT_KEY) !== null;
   localStorage.removeItem(TOKEN_KEY);
@@ -117,6 +117,35 @@ export function getAuthExpiresAt(): string | null {
 export function isAuthSessionExpired(now: number): boolean {
   const expiresAt = parseExpiresAt(getAuthExpiresAt());
   return expiresAt !== null && expiresAt <= now;
+}
+
+export function scheduleAuthSessionExpiry(): () => void {
+  let timeout: number | null = null;
+
+  const scheduleNextCheck = () => {
+    const expiresAt = parseExpiresAt(getAuthExpiresAt());
+    if (expiresAt === null) {
+      return;
+    }
+
+    const remaining = expiresAt - Date.now();
+    if (remaining <= 0) {
+      clearAuthSession('expired');
+      return;
+    }
+
+    timeout = window.setTimeout(
+      scheduleNextCheck,
+      Math.min(remaining, MAX_TIMER_DELAY_MS)
+    );
+  };
+
+  scheduleNextCheck();
+  return () => {
+    if (timeout !== null) {
+      window.clearTimeout(timeout);
+    }
+  };
 }
 
 export function getAuthToken(): string | null {


### PR DESCRIPTION
## Summary

- schedule built-in auth expiration in browser-safe timer chunks
- preserve the configured expiration timestamp as the source of truth
- cap built-in auth token TTLs at 365 days and document the limit
- add regression coverage for a 90-day browser session and config boundary validation

## Root cause

The frontend passed the token's full remaining lifetime directly to `window.setTimeout`. Browser timers use a signed 32-bit millisecond delay, so TTLs of 25 days or longer overflowed and immediately cleared the stored auth session.

## Impact

Long-lived built-in auth tokens such as `2160h` now remain authenticated until their actual expiry. Configuration values above `8760h` are rejected during startup validation.

## Validation

- `pnpm test` (394 tests)
- `pnpm typecheck`
- `go test ./internal/cmn/config -count=1`
- config schema JSON validation
- formatting and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes immediate logout for long-lived built‑in auth tokens by scheduling expiry in browser-safe chunks and enforcing a 365‑day TTL cap.

- **Bug Fixes**
  - Schedule auth session expiry with chunked timers to avoid 32‑bit `setTimeout` overflow; long TTLs now expire at the correct time.
  - Enforce a max TTL of 365 days (reject > `8760h`) with config validation; updated schema and README.
  - Added tests for a 90‑day session and TTL boundary validation; `AuthContext` now uses `scheduleAuthSessionExpiry()`.

- **Migration**
  - Set `DAGU_AUTH_TOKEN_TTL` to `<= 8760h` (365 days). Values above this will fail validation at startup.

<sup>Written for commit c9cb7f80d6c34eb68ac5d20a420f1ace76d6e82c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication tokens can now remain valid for sessions lasting up to 365 days.
  - Long-lived sessions now stay active until their configured expiration, including durations exceeding typical browser timer limits.
  - Expired authentication sessions are automatically cleared.

- **Bug Fixes**
  - Improved handling of authentication session expiration and cleanup.

- **Documentation**
  - Clarified the maximum token lifetime as 8760 hours (365 days), with a 24-hour example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->