### PR TITLE
perf(ui): defer heavy route dependencies

### DIFF
--- a/internal/intg/distr/lifecycle_test.go
+++ b/internal/intg/distr/lifecycle_test.go
@@ -81,7 +81,7 @@ worker_selector:
 steps:
   - name: long-sleep
     run: %s
-`, test.ShellQuote(test.Sleep(30*time.Second))), withLabels(map[string]string{"foo": "bar"}))
+`, test.ShellQuote(test.Sleep(1000*time.Second))), withLabels(map[string]string{"foo": "bar"}))
 		defer f.cleanup()
 
 		require.NoError(t, f.start())
@@ -90,22 +90,21 @@ steps:
 		var dagRunID string
 		var subRunID string
 		require.Eventually(t, func() bool {
-			status, err := f.latestStatus()
+			workers, err := f.coordinatorClient.GetWorkers(f.coord.Context)
 			if err != nil {
 				return false
 			}
-			if status.Status != core.Running {
-				return false
-			}
-			dagRunID = status.DAGRunID
-			for _, node := range status.Nodes {
-				if node.Status == core.NodeRunning && len(node.SubRuns) > 0 {
-					subRunID = node.SubRuns[0].DAGRunID
-					return subRunID != ""
+			for _, worker := range workers {
+				for _, task := range worker.RunningTasks {
+					if task.GetDagName() == "dotest" && task.GetRootDagRunName() == f.dagWrapper.Name {
+						dagRunID = task.GetRootDagRunId()
+						subRunID = task.GetDagRunId()
+						return dagRunID != "" && subRunID != ""
+					}
 				}
 			}
 			return false
-		}, distrTestTimeout(15*time.Second), 200*time.Millisecond, "Timeout waiting for DAG to start sub-DAG")
+		}, distrTestTimeout(15*time.Second), 200*time.Millisecond, "Timeout waiting for worker to start sub-DAG")
 
 		rootRef := exec.NewDAGRunRef(f.dagWrapper.Name, dagRunID)
 		require.Eventually(t, func() bool {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -902,7 +902,8 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 	}
 
 	r.Get(assetsPath, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", cacheControlForAsset(r.URL.Path))
+		isCurrentVersion := r.URL.Query().Get("v") == currentAssetVersion()
+		w.Header().Set("Cache-Control", cacheControlForAsset(r.URL.Path, isCurrentVersion))
 
 		// Serve schemas from shared package instead of embedded assets
 		if strings.HasSuffix(r.URL.Path, "dag.schema.json") {
@@ -923,9 +924,12 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 	})
 }
 
-func cacheControlForAsset(assetPath string) string {
+func cacheControlForAsset(assetPath string, isCurrentVersion bool) string {
 	base := path.Base(assetPath)
 	lowerBase := strings.ToLower(base)
+	if strings.EqualFold(base, "bundle.js") && isCurrentVersion {
+		return "max-age=31536000, immutable"
+	}
 	if hasContentHashSuffix(lowerBase, ".worker.js") {
 		return "max-age=31536000, immutable"
 	}

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -927,7 +927,7 @@ func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
 func cacheControlForAsset(assetPath string, isCurrentVersion bool) string {
 	base := path.Base(assetPath)
 	lowerBase := strings.ToLower(base)
-	if strings.EqualFold(base, "bundle.js") && isCurrentVersion {
+	if lowerBase == "bundle.js" && isCurrentVersion {
 		return "max-age=31536000, immutable"
 	}
 	if hasContentHashSuffix(lowerBase, ".worker.js") {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"mime"
 	"net"
@@ -894,9 +895,13 @@ func publicURLWithBasePath(publicURL, basePath string) string {
 }
 
 func (srv *Server) setupAssetRoutes(r *chi.Mux, basePath string) {
+	srv.setupAssetRoutesWithFS(r, basePath, assetsFS)
+}
+
+func (srv *Server) setupAssetRoutesWithFS(r *chi.Mux, basePath string, assetFS fs.FS) {
 	assetsPath := ensureLeadingSlash(path.Join(strings.TrimRight(basePath, "/"), "assets/*"))
 
-	fileServer := http.FileServer(http.FS(assetsFS))
+	fileServer := http.FileServer(http.FS(assetFS))
 	if basePath != "" && basePath != "/" {
 		fileServer = http.StripPrefix(strings.TrimRight(basePath, "/"), fileServer)
 	}
@@ -933,7 +938,7 @@ func cacheControlForAsset(assetPath string, isCurrentVersion bool) string {
 	if hasContentHashSuffix(lowerBase, ".worker.js") {
 		return "max-age=31536000, immutable"
 	}
-	if strings.HasSuffix(lowerBase, ".bundle.js") && !strings.EqualFold(base, "bundle.js") {
+	if strings.HasSuffix(lowerBase, ".bundle.js") && lowerBase != "bundle.js" {
 		return "max-age=31536000, immutable"
 	}
 	if strings.HasSuffix(lowerBase, ".js") {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -310,8 +310,27 @@ func TestSetupSSERouteDoesNotExposeAppStreamEndpoint(t *testing.T) {
 func TestCacheControlForAssetDisablesJavaScriptCaching(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/bundle.js"))
-	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/legacy.js"))
+	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/bundle.js", false))
+	assert.Equal(t, "no-cache, no-store, must-revalidate", cacheControlForAsset("/assets/legacy.js", false))
+}
+
+func TestCacheControlForAssetCachesCurrentVersionedMainBundle(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "max-age=31536000, immutable", cacheControlForAsset("/assets/bundle.js", true))
+}
+
+func TestAssetRouteCachesCurrentVersionedMainBundle(t *testing.T) {
+	router := chi.NewMux()
+	srv := &Server{}
+	srv.setupAssetRoutes(router, "")
+
+	requestURL := "/assets/bundle.js?v=" + url.QueryEscape(currentAssetVersion())
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, requestURL, nil))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "max-age=31536000, immutable", recorder.Header().Get("Cache-Control"))
 }
 
 func TestCacheControlForAssetCachesContentHashedJavaScriptChunks(t *testing.T) {
@@ -320,7 +339,7 @@ func TestCacheControlForAssetCachesContentHashedJavaScriptChunks(t *testing.T) {
 	assert.Equal(
 		t,
 		"max-age=31536000, immutable",
-		cacheControlForAsset("/assets/vendors.a1b2c3d4e5f6a1b2.bundle.js"),
+		cacheControlForAsset("/assets/vendors.a1b2c3d4e5f6a1b2.bundle.js", false),
 	)
 }
 
@@ -330,19 +349,19 @@ func TestCacheControlForAssetCachesContentHashedJavaScriptWorkers(t *testing.T) 
 	assert.Equal(
 		t,
 		"max-age=31536000, immutable",
-		cacheControlForAsset("/assets/yaml.a1b2c3d4e5f6a1b2.worker.js"),
+		cacheControlForAsset("/assets/yaml.a1b2c3d4e5f6a1b2.worker.js", false),
 	)
 	assert.Equal(
 		t,
 		"no-cache, no-store, must-revalidate",
-		cacheControlForAsset("/assets/yaml.worker.js"),
+		cacheControlForAsset("/assets/yaml.worker.js", false),
 	)
 }
 
 func TestCacheControlForAssetCachesNonJavaScriptAssets(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "max-age=86400", cacheControlForAsset("/assets/favicon.ico"))
+	assert.Equal(t, "max-age=86400", cacheControlForAsset("/assets/favicon.ico", false))
 }
 
 func TestServerUsesEvaluatedBasePathForOIDCAndAPI(t *testing.T) {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -323,7 +324,9 @@ func TestCacheControlForAssetCachesCurrentVersionedMainBundle(t *testing.T) {
 func TestAssetRouteCachesCurrentVersionedMainBundle(t *testing.T) {
 	router := chi.NewMux()
 	srv := &Server{}
-	srv.setupAssetRoutes(router, "")
+	srv.setupAssetRoutesWithFS(router, "", fstest.MapFS{
+		"assets/bundle.js": {Data: []byte("bundle")},
+	})
 
 	requestURL := "/assets/bundle.js?v=" + url.QueryEscape(currentAssetVersion())
 	recorder := httptest.NewRecorder()

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,40 +40,50 @@ import {
   type WorkspaceSelection,
 } from './lib/workspace';
 import { UserRole } from './api/v1/schema';
-import AdministrationPage from './pages/administration';
-import APIKeysPage from './pages/api-keys';
-import APIDocsPage from './pages/api-docs';
-import AuditLogsPage from './pages/audit-logs';
-import BaseConfigPage from './pages/base-config';
-import DAGRuns from './pages/dag-runs';
-import DAGRunDetails from './pages/dag-runs/dag-run';
-import DAGs from './pages/dags';
-import DAGDetails from './pages/dags/dag';
-import EventLogsPage from './pages/event-logs';
-import GitSyncPage from './pages/git-sync';
-import HomePage from './pages/home';
-import IncidentPoliciesPage from './pages/incident-policies';
-import IncidentProvidersPage from './pages/incident-providers';
-import IncidentsPage from './pages/incidents';
-import IntegrationsPage from './pages/integrations';
-import LicensePage from './pages/license';
 import LoginPage from './pages/login';
-import NotificationChannelsPage from './pages/notification-channels';
-import NotificationRulesPage from './pages/notification-rules';
-import NotificationsPage from './pages/notifications';
-import OverviewPage from './pages/overview';
-import ViewPage from './pages/views';
-import ProfilesPage from './pages/profiles';
-import Queues from './pages/queues';
-import QueueDetailsPage from './pages/queues/queue';
-import Search from './pages/search';
-import SecretsPage from './pages/secrets';
 import SetupPage from './pages/setup';
-import SystemStatus from './pages/system-status';
-import TerminalPage from './pages/terminal';
-import RemoteNodesPage from './pages/remote-nodes';
-import UsersPage from './pages/users';
-import WebhooksPage from './pages/webhooks';
+import LoadingIndicator from './components/ui/loading-indicator';
+
+const AdministrationPage = React.lazy(() => import('./pages/administration'));
+const APIKeysPage = React.lazy(() => import('./pages/api-keys'));
+const APIDocsPage = React.lazy(() => import('./pages/api-docs'));
+const AuditLogsPage = React.lazy(() => import('./pages/audit-logs'));
+const BaseConfigPage = React.lazy(() => import('./pages/base-config'));
+const DAGRuns = React.lazy(() => import('./pages/dag-runs'));
+const DAGRunDetails = React.lazy(() => import('./pages/dag-runs/dag-run'));
+const DAGs = React.lazy(() => import('./pages/dags'));
+const DAGDetails = React.lazy(() => import('./pages/dags/dag'));
+const EventLogsPage = React.lazy(() => import('./pages/event-logs'));
+const GitSyncPage = React.lazy(() => import('./pages/git-sync'));
+const HomePage = React.lazy(() => import('./pages/home'));
+const IncidentPoliciesPage = React.lazy(
+  () => import('./pages/incident-policies')
+);
+const IncidentProvidersPage = React.lazy(
+  () => import('./pages/incident-providers')
+);
+const IncidentsPage = React.lazy(() => import('./pages/incidents'));
+const IntegrationsPage = React.lazy(() => import('./pages/integrations'));
+const LicensePage = React.lazy(() => import('./pages/license'));
+const NotificationChannelsPage = React.lazy(
+  () => import('./pages/notification-channels')
+);
+const NotificationRulesPage = React.lazy(
+  () => import('./pages/notification-rules')
+);
+const NotificationsPage = React.lazy(() => import('./pages/notifications'));
+const OverviewPage = React.lazy(() => import('./pages/overview'));
+const ViewPage = React.lazy(() => import('./pages/views'));
+const ProfilesPage = React.lazy(() => import('./pages/profiles'));
+const Queues = React.lazy(() => import('./pages/queues'));
+const QueueDetailsPage = React.lazy(() => import('./pages/queues/queue'));
+const Search = React.lazy(() => import('./pages/search'));
+const SecretsPage = React.lazy(() => import('./pages/secrets'));
+const SystemStatus = React.lazy(() => import('./pages/system-status'));
+const TerminalPage = React.lazy(() => import('./pages/terminal'));
+const RemoteNodesPage = React.lazy(() => import('./pages/remote-nodes'));
+const UsersPage = React.lazy(() => import('./pages/users'));
+const WebhooksPage = React.lazy(() => import('./pages/webhooks'));
 
 type Props = {
   config: Config;
@@ -207,6 +217,18 @@ function LicenseRequiredMessage(): React.ReactElement {
         page to activate your license.
       </p>
     </div>
+  );
+}
+
+function LazyRoutes({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <React.Suspense fallback={<LoadingIndicator />}>
+      <Routes>{children}</Routes>
+    </React.Suspense>
   );
 }
 
@@ -509,7 +531,7 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
                               element={
                                 <ProtectedRoute>
                                   <Layout navbarColor={config.navbarColor}>
-                                    <Routes>
+                                    <LazyRoutes>
                                       <Route
                                         path="/"
                                         element={<OverviewPage />}
@@ -733,7 +755,7 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
                                           </AdminElement>
                                         }
                                       />
-                                    </Routes>
+                                    </LazyRoutes>
                                   </Layout>
                                 </ProtectedRoute>
                               }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -220,15 +220,62 @@ function LicenseRequiredMessage(): React.ReactElement {
   );
 }
 
+type LazyRouteErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type LazyRouteErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class LazyRouteErrorBoundary extends React.Component<
+  LazyRouteErrorBoundaryProps,
+  LazyRouteErrorBoundaryState
+> {
+  state: LazyRouteErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): LazyRouteErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center"
+        >
+          <h2 className="text-xl font-semibold">Unable to load this page</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            The page may have changed since this tab was opened. Reload to use
+            the latest version.
+          </p>
+          <button
+            type="button"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
 function LazyRoutes({
   children,
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
   return (
-    <React.Suspense fallback={<LoadingIndicator />}>
-      <Routes>{children}</Routes>
-    </React.Suspense>
+    <LazyRouteErrorBoundary>
+      <React.Suspense fallback={<LoadingIndicator />}>
+        <Routes>{children}</Routes>
+      </React.Suspense>
+    </LazyRouteErrorBoundary>
   );
 }
 

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -8,10 +8,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '@/contexts/ConfigContext';
 import App from '../App';
 
-const { clientMock, clientGetMock } = vi.hoisted(() => {
+const { clientMock, clientGetMock, overviewImportError } = vi.hoisted(() => {
   const clientGetMock = vi.fn();
   return {
     clientGetMock,
+    overviewImportError: { current: false },
     clientMock: {
       GET: clientGetMock,
       POST: vi.fn(),
@@ -85,7 +86,12 @@ vi.mock('../pages/notification-rules', () => ({
 vi.mock('../pages/notifications', () => ({
   default: () => <h1>Notifications</h1>,
 }));
-vi.mock('../pages/overview', () => ({ default: () => <h1>Overview</h1> }));
+vi.mock('../pages/overview', () => {
+  if (overviewImportError.current) {
+    throw new Error('Loading chunk failed');
+  }
+  return { default: () => <h1>Overview</h1> };
+});
 vi.mock('../pages/views', () => ({ default: () => <h1>View</h1> }));
 vi.mock('../pages/profiles', () => ({ default: () => <h1>Profiles</h1> }));
 vi.mock('../pages/queues', () => ({ default: () => <h1>Queues</h1> }));
@@ -168,6 +174,7 @@ describe('App license routing', () => {
     sessionStorage.clear();
     clientGetMock.mockReset();
     clientGetMock.mockResolvedValue({ data: { workspaces: [] } });
+    overviewImportError.current = false;
     vi.stubGlobal(
       'fetch',
       vi.fn(async () =>
@@ -204,5 +211,21 @@ describe('App license routing', () => {
     expect(
       screen.queryByRole('heading', { name: 'Incidents' })
     ).not.toBeInTheDocument();
+  });
+
+  it('offers a reload when a lazy route chunk fails to load', async () => {
+    overviewImportError.current = true;
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderAt('/');
+
+    expect(
+      await screen.findByRole('heading', { name: 'Unable to load this page' })
+    ).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeVisible();
+
+    consoleError.mockRestore();
   });
 });

--- a/ui/src/features/dags/components/dag-editor/DAGEditorWithDocs.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditorWithDocs.tsx
@@ -9,10 +9,13 @@ import { BookOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { JSONSchema } from '@/lib/schema-utils';
 import { Button } from '@/components/ui/button';
+import LoadingIndicator from '@/components/ui/loading-indicator';
 import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 import { useYamlCursorPath } from '../../../../hooks/useYamlCursorPath';
-import DAGEditor, { type CursorPosition } from './DAGEditor';
+import type { CursorPosition } from './DAGEditor';
 import { SchemaDocSidebar } from './SchemaDocSidebar';
+
+const DAGEditor = React.lazy(() => import('./DAGEditor'));
 
 /**
  * Props for the DAGEditorWithDocs component
@@ -139,15 +142,17 @@ function DAGEditorWithDocs({
       {/* Editor and Sidebar */}
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 min-w-0">
-          <DAGEditor
-            value={value}
-            readOnly={readOnly}
-            lineNumbers={true}
-            onChange={readOnly ? undefined : onChange}
-            onCursorPositionChange={handleCursorPositionChange}
-            modelUri={modelUri}
-            schema={schema}
-          />
+          <React.Suspense fallback={<LoadingIndicator />}>
+            <DAGEditor
+              value={value}
+              readOnly={readOnly}
+              lineNumbers={true}
+              onChange={readOnly ? undefined : onChange}
+              onCursorPositionChange={handleCursorPositionChange}
+              modelUri={modelUri}
+              schema={schema}
+            />
+          </React.Suspense>
         </div>
         <SchemaDocSidebar
           isOpen={sidebarOpen}

--- a/ui/src/pages/api-docs/index.tsx
+++ b/ui/src/pages/api-docs/index.tsx
@@ -13,7 +13,8 @@ import {
   ShieldCheck,
 } from 'lucide-react';
 import * as React from 'react';
-import ScalarViewer from './ScalarViewer';
+
+const ScalarViewer = React.lazy(() => import('./ScalarViewer'));
 
 type OpenAPIDocument = Record<string, unknown>;
 
@@ -138,10 +139,18 @@ export default function APIDocsPage(): React.ReactElement {
         )}
 
         {state.status === 'ready' && (
-          <ScalarViewer
-            spec={state.spec}
-            preferredBearerToken={preferredBearerToken}
-          />
+          <React.Suspense
+            fallback={
+              <div className="flex h-full min-h-[420px] items-center justify-center">
+                <RefreshCw className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            }
+          >
+            <ScalarViewer
+              spec={state.spec}
+              preferredBearerToken={preferredBearerToken}
+            />
+          </React.Suspense>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- split protected UI pages into route-level lazy chunks while keeping login and setup in the bootstrap
- load the Scalar API reference only after its document is ready and load Monaco only when the DAG editor renders
- cache the versioned main bundle only when its query version matches the embedded bundle hash

## Why

Every page was synchronously reachable from `App.tsx`, which pulled Scalar, Vue, CodeMirror, Monaco, terminal, charting, and administration code into the startup bundle even when those routes were not visited.

## Impact

The production entry bundle drops from 18.02 MB to 1.03 MB raw and from 4.63 MB to about 303 KB with the server's gzip level. Total generated assets remain essentially flat because the heavy code moves into content-hashed deferred chunks.

## Validation

- `pnpm typecheck`
- `pnpm test` (104 files, 419 tests)
- focused App and API docs tests
- `go test ./internal/service/frontend -count=1`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers heavy UI route dependencies and adds version-aware caching for the main `bundle.js`, dropping the production entry bundle from 18.02 MB to 1.03 MB raw (4.63 MB → ~303 KB gzipped). Adds a lazy-route error boundary with a reload prompt and tests to validate bundle caching and stabilize distributed cancellation checks.

- **Refactors**
  - Lazy-load protected pages and heavy editors (`ScalarViewer`, `DAGEditor`) behind `React.Suspense` with lightweight loaders; keep login and setup in the bootstrap.
  - Add an error boundary for lazy routes that shows a reload action when a chunk fails to load.
  - Cache `bundle.js` for 1 year when `?v` matches `currentAssetVersion()`; otherwise, disable JS caching.
  - Add tests for current-version bundle caching via asset routes and for the lazy-load failure UI; stabilize distributed lifecycle checks by reading running tasks from the coordinator.

<sup>Written for commit 9d2f0a7f232115cc5d2a30e843321532e4ea32c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved long-lived caching for the main `bundle.js` only when it’s the current client-referenced version.
  * Refined cache-control for JavaScript assets, workers, and other static files for more accurate browser behavior.
* **User Experience**
  * Implemented lazy loading across most pages/components with a loading indicator.
  * Added a user-facing “Unable to load this page” message and a “Reload” button on lazy-load failures.
* **Bug Fixes**
  * Corrected frontend asset cache-control for both versioned and non-versioned requests.
* **Tests**
  * Updated cache-header assertions and expanded lazy-load failure coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->