### PR TITLE
fix: update Go to 1.26.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -35,7 +35,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   conformance:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagucloud/dagu
 
-go 1.26.4
+go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
## Summary

- update the root module's Go patch version to 1.26.5
- use the standard-library fixes for GO-2026-5856 and GO-2026-4970

## Root cause

The scheduled `govulncheck` job used Go 1.26.4 from `go.mod`. That release contains reachable vulnerabilities in `crypto/tls` and `os`, causing the security workflow to fail.

## Impact

CI and builds using the root module now select Go 1.26.5, which contains the standard-library fixes.

## Testing

- `go run golang.org/x/vuln/cmd/govulncheck@v1.2.0 ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Go to 1.26.5 in the root `go.mod` and CI workflows to pick up standard library fixes for GO-2026-5856 (`crypto/tls`) and GO-2026-4970 (`os`). This resolves `golang.org/x/vuln/cmd/govulncheck` failures and ensures CI/builds use 1.26.5.

<sup>Written for commit 2e36fca80a4554819ff4900cdd8833b424de8c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to version 1.26.5.
  * Updated automated CI and conformance checks to run with the newer Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->