### PR TITLE
fix: secure CORS defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ The embedded API is experimental and may change. See the embedded API documentat
 | `DAGU_LOG_FORMAT` | `text` | `text` or `json` |
 | `DAGU_CERT_FILE` | — | TLS certificate |
 | `DAGU_KEY_FILE` | — | TLS private key |
-| `DAGU_CORS_ALLOWED_ORIGINS` | — | Comma-separated list of allowed CORS origins (e.g. `https://app.example.com`). When unset, all origins are allowed without credentials. When set, only listed origins are allowed and credentials are enabled. |
+| `DAGU_CORS_ALLOWED_ORIGINS` | — | Comma-separated list of allowed CORS origins (e.g. `https://app.example.com`). When unset, cross-origin browser access is disabled. Exact origins enable credentials. An explicit `*` allows every origin without credentials and emits a security warning. |
 
 ### Paths
 

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -150,9 +150,9 @@ type Server struct {
 	RemoteNodes       []RemoteNode
 	Permissions       map[Permission]bool
 	StrictValidation  bool
-	// CORSAllowedOrigins lists explicit origins for CORS. When empty, all
-	// origins are allowed but AllowCredentials is disabled (spec-compliant).
-	// When set, only listed origins are allowed and AllowCredentials is enabled.
+	// CORSAllowedOrigins lists origins allowed to make cross-origin requests.
+	// An empty list disables CORS. A literal wildcard explicitly allows every
+	// origin without credentials; exact origins enable credentials.
 	CORSAllowedOrigins []string
 	Metrics            MetricsAccess // "private" or "public"
 	Terminal           TerminalConfig

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -654,6 +654,17 @@ func (l *ConfigLoader) loadServerDefaults(cfg *Config, def Definition) {
 	cfg.Server.BasePath = cleanServerBasePath(cfg.Server.BasePath)
 	cfg.Server.CheckUpdates = l.v.GetBool("check_updates")
 	cfg.Server.CORSAllowedOrigins = parseStringList(l.v.Get("cors_allowed_origins"))
+	for _, origin := range cfg.Server.CORSAllowedOrigins {
+		if strings.TrimSpace(origin) != "*" {
+			continue
+		}
+		warning := `cors_allowed_origins contains "*"; any website may make browser requests to the Dagu API`
+		if cfg.Server.Auth.Mode == AuthModeNone {
+			warning += `, and auth.mode "none" allows those requests to execute workflows without authentication`
+		}
+		l.warnings = append(l.warnings, warning)
+		break
+	}
 
 	cfg.Server.Metrics = MetricsAccessPrivate
 	if def.Metrics != nil {

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -1607,6 +1607,55 @@ metrics: "invalid_value"
 	})
 }
 
+func TestLoad_CORSAllowedOrigins(t *testing.T) {
+	t.Run("EmptyDisablesCORS", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+auth:
+  mode: none
+cors_allowed_origins: []
+`)
+		assert.Empty(t, cfg.Server.CORSAllowedOrigins)
+		assert.Empty(t, cfg.Warnings)
+	})
+
+	t.Run("ExplicitOrigins", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+auth:
+  mode: none
+cors_allowed_origins:
+  - https://app.example.com
+  - https://admin.example.com
+`)
+		assert.Equal(t, []string{"https://app.example.com", "https://admin.example.com"}, cfg.Server.CORSAllowedOrigins)
+		assert.Empty(t, cfg.Warnings)
+	})
+
+	t.Run("WildcardWarning", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+auth:
+  mode: builtin
+cors_allowed_origins:
+  - "*"
+`)
+		assert.Equal(t, []string{"*"}, cfg.Server.CORSAllowedOrigins)
+		require.Len(t, cfg.Warnings, 1)
+		assert.Contains(t, cfg.Warnings[0], "any website may make browser requests")
+	})
+
+	t.Run("WildcardWithoutAuthWarning", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+auth:
+  mode: none
+cors_allowed_origins:
+  - "*"
+`)
+		assert.Equal(t, []string{"*"}, cfg.Server.CORSAllowedOrigins)
+		require.Len(t, cfg.Warnings, 1)
+		assert.Contains(t, cfg.Warnings[0], `auth.mode "none"`)
+		assert.Contains(t, cfg.Warnings[0], "execute workflows without authentication")
+	})
+}
+
 func TestLoad_AccessLogMode(t *testing.T) {
 	t.Run("AccessLogAll", func(t *testing.T) {
 		cfg := loadFromYAML(t, `

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -45,7 +45,7 @@
     "cors_allowed_origins": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Explicit list of origins allowed to make cross-origin requests. When unset, all origins are allowed without credentials. When set, only listed origins are allowed and credentials are enabled. A wildcard '*' in the list is treated the same as unset."
+      "description": "Origins allowed to make cross-origin requests. When unset or empty, cross-origin browser access is disabled. Exact origins enable credentials. An explicit '*' allows every origin without credentials and emits a security warning."
     },
     "debug": {
       "type": "boolean",

--- a/internal/service/frontend/api/v1/cors_test.go
+++ b/internal/service/frontend/api/v1/cors_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORS_DefaultAndExplicitWildcard(t *testing.T) {
+	t.Run("default denies cross-origin API preflight", func(t *testing.T) {
+		server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+			cfg.Server.Auth.Mode = config.AuthModeNone
+			cfg.Server.CORSAllowedOrigins = nil
+		}))
+
+		resp := sendPreflight(t, server, "/api/v1/dag-runs", "https://evil.example")
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("explicit wildcard allows API but not setup", func(t *testing.T) {
+		server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+			cfg.Server.Auth.Mode = config.AuthModeNone
+			cfg.Server.CORSAllowedOrigins = []string{"*"}
+		}))
+
+		apiResp := sendPreflight(t, server, "/api/v1/dag-runs", "https://app.example")
+		defer func() { _ = apiResp.Body.Close() }()
+		require.Equal(t, http.StatusOK, apiResp.StatusCode)
+		assert.Equal(t, "*", apiResp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, apiResp.Header.Get("Access-Control-Allow-Credentials"))
+
+		setupResp := sendPreflight(t, server, "/api/v1/auth/setup", "https://app.example")
+		defer func() { _ = setupResp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, setupResp.StatusCode)
+		assert.Empty(t, setupResp.Header.Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func sendPreflight(t *testing.T, server test.Server, requestPath, origin string) *http.Response {
+	t.Helper()
+
+	requestURL := fmt.Sprintf(
+		"http://%s:%d%s",
+		server.Config.Server.Host,
+		server.Config.Server.Port,
+		requestPath,
+	)
+	req, err := http.NewRequest(http.MethodOptions, requestURL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}

--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -4,9 +4,9 @@
 package frontend
 
 import (
+	"net"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 
 	"github.com/go-chi/cors"
@@ -21,14 +21,22 @@ type corsPolicy struct {
 func (p corsPolicy) middleware(next http.Handler) http.Handler {
 	wrapped := next
 	if len(p.allowedOrigins) > 0 {
-		wrapped = cors.Handler(cors.Options{
-			AllowedOrigins:   p.allowedOrigins,
+		allowAllOrigins := p.allowsAllOrigins()
+		options := cors.Options{
 			AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 			AllowedHeaders:   []string{"Content-Type", "Authorization", "Content-Encoding", "Accept", "MCP-Protocol-Version", "Mcp-Session-Id", "Last-Event-ID"},
 			ExposedHeaders:   []string{"Mcp-Session-Id"},
-			AllowCredentials: !slices.Contains(p.allowedOrigins, "*"),
+			AllowCredentials: !allowAllOrigins,
 			MaxAge:           300,
-		})(next)
+		}
+		if allowAllOrigins {
+			options.AllowedOrigins = []string{"*"}
+		} else {
+			options.AllowOriginFunc = func(_ *http.Request, origin string) bool {
+				return p.allowsOrigin(origin)
+			}
+		}
+		wrapped = cors.Handler(options)(next)
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,9 +87,19 @@ func (p corsPolicy) allowsOrigin(origin string) bool {
 		if wildcardIndex := strings.IndexByte(candidate, '*'); wildcardIndex >= 0 {
 			prefix := candidate[:wildcardIndex]
 			suffix := candidate[wildcardIndex+1:]
-			if strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
+			if len(origin) >= len(prefix)+len(suffix) &&
+				strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func (p corsPolicy) allowsAllOrigins() bool {
+	for _, origin := range p.allowedOrigins {
+		if strings.TrimSpace(origin) == "*" {
+			return true
 		}
 	}
 	return false
@@ -99,5 +117,22 @@ func canonicalOrigin(value string) string {
 	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
 		return ""
 	}
-	return strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+
+	scheme := strings.ToLower(parsed.Scheme)
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return ""
+	}
+	port := parsed.Port()
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	return scheme + "://" + host
 }

--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -84,9 +84,7 @@ func (p corsPolicy) allowsOrigin(origin string) bool {
 		if candidate == "*" || candidate == origin {
 			return true
 		}
-		if wildcardIndex := strings.IndexByte(candidate, '*'); wildcardIndex >= 0 {
-			prefix := candidate[:wildcardIndex]
-			suffix := candidate[wildcardIndex+1:]
+		if prefix, suffix, ok := strings.Cut(candidate, "*"); ok {
 			if len(origin) >= len(prefix)+len(suffix) &&
 				strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
 				return true

--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -19,8 +19,9 @@ type corsPolicy struct {
 }
 
 func (p corsPolicy) middleware(next http.Handler) http.Handler {
+	corsConfigured := len(p.allowedOrigins) > 0
 	wrapped := next
-	if len(p.allowedOrigins) > 0 {
+	if corsConfigured {
 		allowAllOrigins := p.allowsAllOrigins()
 		options := cors.Options{
 			AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
@@ -40,9 +41,15 @@ func (p corsPolicy) middleware(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !corsConfigured {
+			w.Header().Add("Vary", "Origin")
+		}
 		origin := r.Header.Get("Origin")
 		if origin != "" && p.isCrossOrigin(r, origin) {
 			if p.isSetupPath(r.URL.Path) || !p.allowsOrigin(origin) {
+				if corsConfigured {
+					w.Header().Add("Vary", "Origin")
+				}
 				http.Error(w, "cross-origin request denied", http.StatusForbidden)
 				return
 			}

--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -56,7 +56,7 @@ func (p corsPolicy) isCrossOrigin(r *http.Request, origin string) bool {
 	if sourceOrigin == "" {
 		return true
 	}
-	if sourceOrigin == p.targetOrigin(r) {
+	if sourceOrigin == requestOrigin(r) || sourceOrigin == canonicalOrigin(p.publicURL) {
 		return false
 	}
 
@@ -65,11 +65,7 @@ func (p corsPolicy) isCrossOrigin(r *http.Request, origin string) bool {
 	return !strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")), "same-origin")
 }
 
-func (p corsPolicy) targetOrigin(r *http.Request) string {
-	if origin := canonicalOrigin(p.publicURL); origin != "" {
-		return origin
-	}
-
+func requestOrigin(r *http.Request) string {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -79,9 +75,10 @@ func (p corsPolicy) targetOrigin(r *http.Request) string {
 
 func (p corsPolicy) allowsOrigin(origin string) bool {
 	origin = strings.ToLower(strings.TrimSpace(origin))
+	canonicalRequestOrigin := canonicalOrigin(origin)
 	for _, candidate := range p.allowedOrigins {
 		candidate = strings.ToLower(strings.TrimSpace(candidate))
-		if candidate == "*" || candidate == origin {
+		if candidate == "*" {
 			return true
 		}
 		if prefix, suffix, ok := strings.Cut(candidate, "*"); ok {
@@ -89,6 +86,11 @@ func (p corsPolicy) allowsOrigin(origin string) bool {
 				strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
 				return true
 			}
+			continue
+		}
+		if candidate == origin ||
+			(canonicalRequestOrigin != "" && canonicalOrigin(candidate) == canonicalRequestOrigin) {
+			return true
 		}
 	}
 	return false

--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/cors"
+)
+
+type corsPolicy struct {
+	allowedOrigins []string
+	publicURL      string
+	setupPath      string
+}
+
+func (p corsPolicy) middleware(next http.Handler) http.Handler {
+	wrapped := next
+	if len(p.allowedOrigins) > 0 {
+		wrapped = cors.Handler(cors.Options{
+			AllowedOrigins:   p.allowedOrigins,
+			AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+			AllowedHeaders:   []string{"Content-Type", "Authorization", "Content-Encoding", "Accept", "MCP-Protocol-Version", "Mcp-Session-Id", "Last-Event-ID"},
+			ExposedHeaders:   []string{"Mcp-Session-Id"},
+			AllowCredentials: !slices.Contains(p.allowedOrigins, "*"),
+			MaxAge:           300,
+		})(next)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin != "" && p.isCrossOrigin(r, origin) {
+			if p.isSetupPath(r.URL.Path) || !p.allowsOrigin(origin) {
+				http.Error(w, "cross-origin request denied", http.StatusForbidden)
+				return
+			}
+		}
+		wrapped.ServeHTTP(w, r)
+	})
+}
+
+func (p corsPolicy) isCrossOrigin(r *http.Request, origin string) bool {
+	sourceOrigin := canonicalOrigin(origin)
+	if sourceOrigin == "" {
+		return true
+	}
+	if sourceOrigin == p.targetOrigin(r) {
+		return false
+	}
+
+	// Fetch Metadata preserves same-origin classification through reverse proxies
+	// that do not expose the public scheme and host to the application.
+	return !strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")), "same-origin")
+}
+
+func (p corsPolicy) targetOrigin(r *http.Request) string {
+	if origin := canonicalOrigin(p.publicURL); origin != "" {
+		return origin
+	}
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return canonicalOrigin(scheme + "://" + r.Host)
+}
+
+func (p corsPolicy) allowsOrigin(origin string) bool {
+	origin = strings.ToLower(strings.TrimSpace(origin))
+	for _, candidate := range p.allowedOrigins {
+		candidate = strings.ToLower(strings.TrimSpace(candidate))
+		if candidate == "*" || candidate == origin {
+			return true
+		}
+		if wildcardIndex := strings.IndexByte(candidate, '*'); wildcardIndex >= 0 {
+			prefix := candidate[:wildcardIndex]
+			suffix := candidate[wildcardIndex+1:]
+			if strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p corsPolicy) isSetupPath(requestPath string) bool {
+	return strings.TrimRight(requestPath, "/") == strings.TrimRight(p.setupPath, "/")
+}
+
+func canonicalOrigin(value string) string {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
+		return ""
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return ""
+	}
+	return strings.ToLower(parsed.Scheme + "://" + parsed.Host)
+}

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -102,6 +102,46 @@ func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
 	})
 }
 
+func TestCORSPolicy_WildcardPattern(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	policy := corsPolicy{
+		allowedOrigins: []string{"https://a*a.com"},
+		setupPath:      "/api/v1/auth/setup",
+	}
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("matches complete prefix and suffix", func(t *testing.T) {
+		called = false
+		req := newPreflightRequest("/api/v1/dag-runs", "https://aa.com")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "https://aa.com", resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header().Get("Access-Control-Allow-Credentials"))
+		assert.False(t, called)
+	})
+
+	t.Run("rejects overlapping prefix and suffix", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/dag-runs", nil)
+		req.Header.Set("Origin", "https://a.com")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.False(t, called)
+	})
+}
+
 func TestCORSPolicy_ExplicitWildcard(t *testing.T) {
 	t.Parallel()
 
@@ -165,26 +205,64 @@ func TestCORSPolicy_ExplicitWildcard(t *testing.T) {
 	})
 }
 
-func TestCORSPolicy_UsesPublicURLForSameOrigin(t *testing.T) {
+func TestCORSPolicy_SameOriginDetection(t *testing.T) {
 	t.Parallel()
 
-	called := false
-	policy := corsPolicy{
-		publicURL: "https://dagu.example/workflows",
-		setupPath: "/api/v1/auth/setup",
+	tests := []struct {
+		name         string
+		publicURL    string
+		requestURL   string
+		origin       string
+		secFetchSite string
+	}{
+		{
+			name:       "public URL behind reverse proxy",
+			publicURL:  "https://dagu.example/workflows",
+			requestURL: "http://internal:8080/api/v1/dag-runs",
+			origin:     "https://dagu.example",
+		},
+		{
+			name:       "default HTTP port",
+			requestURL: "http://dagu.example:80/api/v1/dag-runs",
+			origin:     "http://dagu.example",
+		},
+		{
+			name:       "default HTTPS port",
+			requestURL: "https://dagu.example:443/api/v1/dag-runs",
+			origin:     "https://dagu.example",
+		},
+		{
+			name:         "fetch metadata through TLS proxy",
+			requestURL:   "http://dagu.example/api/v1/dag-runs",
+			origin:       "https://dagu.example",
+			secFetchSite: "same-origin",
+		},
 	}
-	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	req := httptest.NewRequest(http.MethodPost, "http://internal:8080/api/v1/dag-runs", nil)
-	req.Header.Set("Origin", "https://dagu.example")
-	resp := httptest.NewRecorder()
 
-	handler.ServeHTTP(resp, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			policy := corsPolicy{
+				publicURL: tt.publicURL,
+				setupPath: "/api/v1/auth/setup",
+			}
+			handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodPost, tt.requestURL, nil)
+			req.Header.Set("Origin", tt.origin)
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+			resp := httptest.NewRecorder()
 
-	assert.Equal(t, http.StatusNoContent, resp.Code)
-	assert.True(t, called)
+			handler.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusNoContent, resp.Code)
+			assert.True(t, called)
+		})
+	}
 }
 
 func newPreflightRequest(requestPath, origin string) *http.Request {

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -73,8 +73,12 @@ func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
 	t.Parallel()
 
 	policy := corsPolicy{
-		allowedOrigins: []string{"https://app.example"},
-		setupPath:      "/api/v1/auth/setup",
+		allowedOrigins: []string{
+			"https://app.example",
+			"http://local.example:80",
+			"https://secure.example:443",
+		},
+		setupPath: "/api/v1/auth/setup",
 	}
 	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -89,6 +93,28 @@ func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "https://app.example", resp.Header().Get("Access-Control-Allow-Origin"))
 		assert.Equal(t, "true", resp.Header().Get("Access-Control-Allow-Credentials"))
+	})
+
+	t.Run("equivalent default ports", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			origin string
+		}{
+			{name: "HTTP", origin: "http://local.example"},
+			{name: "HTTPS", origin: "https://secure.example"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := newPreflightRequest("/api/v1/dag-runs", tt.origin)
+				resp := httptest.NewRecorder()
+
+				handler.ServeHTTP(resp, req)
+
+				require.Equal(t, http.StatusOK, resp.Code)
+				assert.Equal(t, tt.origin, resp.Header().Get("Access-Control-Allow-Origin"))
+				assert.Equal(t, "true", resp.Header().Get("Access-Control-Allow-Credentials"))
+			})
+		}
 	})
 
 	t.Run("not allowed", func(t *testing.T) {
@@ -220,6 +246,12 @@ func TestCORSPolicy_SameOriginDetection(t *testing.T) {
 			publicURL:  "https://dagu.example/workflows",
 			requestURL: "http://internal:8080/api/v1/dag-runs",
 			origin:     "https://dagu.example",
+		},
+		{
+			name:       "request URL when public URL differs",
+			publicURL:  "https://dagu.example/workflows",
+			requestURL: "http://internal:8080/api/v1/dag-runs",
+			origin:     "http://internal:8080",
 		},
 		{
 			name:       "default HTTP port",

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -30,6 +30,7 @@ func TestCORSPolicy_DefaultDeniesCrossOriginRequests(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, resp.Code)
 		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, resp.Header().Values("Vary"), "Origin")
 		assert.False(t, called)
 	})
 
@@ -54,6 +55,7 @@ func TestCORSPolicy_DefaultDeniesCrossOriginRequests(t *testing.T) {
 		handler.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusNoContent, resp.Code)
+		assert.Contains(t, resp.Header().Values("Vary"), "Origin")
 		assert.True(t, called)
 	})
 
@@ -125,6 +127,7 @@ func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, resp.Code)
 		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, resp.Header().Values("Vary"), "Origin")
 	})
 }
 

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSPolicy_DefaultDeniesCrossOriginRequests(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := corsPolicy{setupPath: "/api/v1/auth/setup"}.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("preflight", func(t *testing.T) {
+		called = false
+		req := newPreflightRequest("/api/v1/dag-runs", "https://evil.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.False(t, called)
+	})
+
+	t.Run("actual request", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/dag-runs", nil)
+		req.Header.Set("Origin", "https://evil.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("same origin", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/dag-runs", nil)
+		req.Header.Set("Origin", "http://dagu.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+		assert.True(t, called)
+	})
+
+	t.Run("non-browser client", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/dag-runs", nil)
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+		assert.True(t, called)
+	})
+}
+
+func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
+	t.Parallel()
+
+	policy := corsPolicy{
+		allowedOrigins: []string{"https://app.example"},
+		setupPath:      "/api/v1/auth/setup",
+	}
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("allowed", func(t *testing.T) {
+		req := newPreflightRequest("/api/v1/dag-runs", "https://app.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "https://app.example", resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header().Get("Access-Control-Allow-Credentials"))
+	})
+
+	t.Run("not allowed", func(t *testing.T) {
+		req := newPreflightRequest("/api/v1/dag-runs", "https://evil.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestCORSPolicy_ExplicitWildcard(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	policy := corsPolicy{
+		allowedOrigins: []string{"*"},
+		setupPath:      "/api/v1/auth/setup",
+	}
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("allows API preflight without credentials", func(t *testing.T) {
+		called = false
+		req := newPreflightRequest("/api/v1/dag-runs", "https://any.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "*", resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Credentials"))
+		assert.False(t, called)
+	})
+
+	t.Run("denies setup preflight", func(t *testing.T) {
+		called = false
+		req := newPreflightRequest("/api/v1/auth/setup", "https://any.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
+		assert.False(t, called)
+	})
+
+	t.Run("denies setup actual request", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/auth/setup", nil)
+		req.Header.Set("Origin", "https://any.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.False(t, called)
+	})
+
+	t.Run("allows same-origin setup", func(t *testing.T) {
+		called = false
+		req := httptest.NewRequest(http.MethodPost, "http://dagu.example/api/v1/auth/setup", nil)
+		req.Header.Set("Origin", "http://dagu.example")
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+		assert.True(t, called)
+	})
+}
+
+func TestCORSPolicy_UsesPublicURLForSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	policy := corsPolicy{
+		publicURL: "https://dagu.example/workflows",
+		setupPath: "/api/v1/auth/setup",
+	}
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "http://internal:8080/api/v1/dag-runs", nil)
+	req.Header.Set("Origin", "https://dagu.example")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusNoContent, resp.Code)
+	assert.True(t, called)
+}
+
+func newPreflightRequest(requestPath, origin string) *http.Request {
+	req := httptest.NewRequest(http.MethodOptions, "http://dagu.example"+requestPath, nil)
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	return req
+}

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -24,7 +23,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-chi/cors"
 	"github.com/go-chi/httplog/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -701,19 +699,11 @@ func (srv *Server) Serve(ctx context.Context) error {
 	}
 	r.Use(middleware.Recoverer)
 	r.Use(securityHeadersMiddleware(srv.config.Server.TLS != nil))
-	corsOrigins := srv.config.Server.CORSAllowedOrigins
-	allowCredentials := len(corsOrigins) > 0 && !slices.Contains(corsOrigins, "*")
-	if !allowCredentials {
-		corsOrigins = []string{"*"}
-	}
-	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   corsOrigins,
-		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Content-Type", "Authorization", "Content-Encoding", "Accept", "MCP-Protocol-Version", "Mcp-Session-Id", "Last-Event-ID"},
-		ExposedHeaders:   []string{"Mcp-Session-Id"},
-		AllowCredentials: allowCredentials,
-		MaxAge:           300,
-	}))
+	r.Use(corsPolicy{
+		allowedOrigins: srv.config.Server.CORSAllowedOrigins,
+		publicURL:      srv.config.Server.PublicURL,
+		setupPath:      path.Join(apiV1BasePath, "auth/setup"),
+	}.middleware)
 	r.Use(middleware.RedirectSlashes)
 
 	if err := srv.setupRoutes(ctx, r); err != nil {


### PR DESCRIPTION
## Summary

- disable cross-origin browser access when `cors_allowed_origins` is unset or empty
- preserve credentialed access for configured origins and explicit `*` opt-in without credentials
- emit a security warning for wildcard access, with stronger guidance when authentication is disabled
- prevent cross-origin access to `/api/v1/auth/setup` under every CORS policy
- use one origin matcher for enforcement and CORS headers, including wildcard and default-port handling

## Root cause

An empty CORS configuration was converted to `*`, so every website received browser access to the API by default. With authentication disabled, that could expose workflow execution to arbitrary origins.

## User impact

Same-origin UI requests and clients that do not send an `Origin` header are unchanged. Existing configured origins retain credential support. Users who intentionally need unrestricted browser access can configure `*` explicitly; Dagu allows it without credentials and reports the security risk.

## Testing

- `go test ./internal/cmn/config ./internal/cmn/schema ./internal/service/frontend ./internal/service/frontend/api/v1 -count=1`
- `go test ./internal/service/frontend -run TestCORSPolicy -count=1`
- `make lint`
- `git diff --check origin/main...HEAD`

Closes #726

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the default CORS policy by disabling cross-origin browser access unless `cors_allowed_origins` is set. Adds strict origin matching with wildcard support, blocks cross-origin `/api/v1/auth/setup`, and varies responses by `Origin`; explicit `*` is a no-credentials opt-in with a security warning.

- **Bug Fixes**
  - Unset/empty `cors_allowed_origins` now disables CORS; browsers can’t call the API cross-origin by default.
  - Exact origins allow credentials; explicit `*` allows all origins without credentials and logs a warning (stronger when auth is disabled).
  - Always deny cross-origin requests to `/api/v1/auth/setup`.
  - Single normalized matcher for enforcement and headers; supports prefix/suffix wildcards, default ports, IPv6, and reverse-proxy same-origin via Fetch Metadata.
  - Vary CORS responses by `Origin` to prevent incorrect caching across origins.
  - Updated docs and added unit tests.

- **Migration**
  - To keep the old permissive behavior: set `DAGU_CORS_ALLOWED_ORIGINS=*` (no credentials).
  - To allow credentials: list exact origins in `DAGU_CORS_ALLOWED_ORIGINS`.
  - Same-origin UI and non-browser clients are unaffected.

<sup>Written for commit c1494d48cc7a2fbaf6b6308b153354e476663a9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter CORS protection for browser access to the API.
  * Cross-origin access is disabled by default.
  * Configured origins support credentials, while an explicit wildcard allows access without credentials.
  * Setup endpoints remain protected from cross-origin requests.

* **Documentation**
  * Updated configuration documentation to explain CORS behavior and security implications.

* **Security**
  * Added warnings when wildcard CORS allows any website to access the API, especially when authentication is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->