### PR TITLE
fix: absorb Windows PowerShell cold start in command substitution

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -69,6 +69,15 @@ jobs:
             choco install make --no-progress -y
           }
 
+      # Conformance fixtures spawn Windows PowerShell (powershell.exe) under a
+      # bounded command-substitution timeout. The first spawn on a fresh runner
+      # pays a JIT/antivirus penalty that can exceed the timeout, so pay it here
+      # instead of inside a test.
+      - name: Warm up Windows PowerShell
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Write-Output warmup
+
       - name: Run conformance tests
         shell: bash
         run: make conformance GO_TEST_FLAGS="${{ matrix.go_test_flags }}"

--- a/internal/cmn/value/substitute.go
+++ b/internal/cmn/value/substitute.go
@@ -20,7 +20,9 @@ import (
 
 func substituteCommandTimeout() time.Duration {
 	if runtime.GOOS == "windows" {
-		return 10 * time.Second
+		// Cold-start of powershell.exe (JIT + antivirus scan) can exceed 10s
+		// on a fresh machine before process caches warm up.
+		return 30 * time.Second
 	}
 	return 2 * time.Second
 }


### PR DESCRIPTION
## Problem

Windows conformance job intermittently fails in `spec011_dynamic_evaluation` ([example run](https://github.com/dagucloud/dagu/actions/runs/29634414112)):

```
parameter "today" eval failed: phase substitute: failed to execute command "Write-Output 20260131": timed out after 10s
```

The first spawns of `powershell.exe` on a fresh runner VM pay a JIT/antivirus penalty that can exceed the 10s Windows command-substitution timeout. In the failing run the first four PowerShell spawns each took >10.6s, then the fifth completed in under 5s and the rest in ~1.5s — a cold-start signature, not a code regression. The workflow only ever ran `pwsh` (PowerShell 7), a separate binary with separate caches, so the first `powershell.exe` spawn always happened inside a test under the deadline.

## Fix

- Warm up `powershell.exe` in the conformance workflow before tests run, paying the cold-start penalty outside any timeout.
- Widen the Windows substitution timeout to cover residual slowness (parallel test packages contending for CPU, slow user machines). Spec 011 only requires "a short bounded timeout", so the duration is implementation-defined; no fixture depends on timeout expiry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Absorbs Windows PowerShell cold start to prevent timeouts in command substitution on fresh runners. Adds a warm-up in the conformance workflow and increases the Windows timeout to 30s.

- **Bug Fixes**
  - Warm up `powershell.exe` on Windows runners before tests to avoid JIT/antivirus cold-start delays.
  - Increase Windows command-substitution timeout from 10s to 30s; non-Windows remains at 2s.

<sup>Written for commit 8f35d2115933aeeff658e91a03db6af5e7744341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command substitution reliability on Windows by allowing additional startup time.
  * Reduced intermittent conformance test failures on fresh Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->