### PR TITLE
test: scale coordinator dispatch timeout on Windows

### DIFF
--- a/internal/test/coordinator.go
+++ b/internal/test/coordinator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -160,7 +161,11 @@ func (c *Coordinator) DispatchTask(t *testing.T, task *coordinatorv1.Task) error
 
 	client := coordinatorv1.NewCoordinatorServiceClient(conn)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	timeout := 5 * time.Second
+	if runtime.GOOS == "windows" {
+		timeout *= 5
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	_, err = client.Dispatch(ctx, &coordinatorv1.DispatchRequest{Task: task})


### PR DESCRIPTION
## Summary

- scale the test coordinator's direct dispatch deadline on Windows
- keep the existing five-second baseline on other platforms
- prevent durable status persistence on a slow Windows runner from exhausting the test-only RPC deadline

## Root cause

`TestWorkerStart/MultiplePollers` failed because `internal/test.Coordinator.DispatchTask` imposed a fixed five-second deadline. The coordinator synchronously creates and persists a DAG-run attempt before completing dispatch. In the failing Windows job, that persistence work consumed nearly the entire deadline and the client received `DeadlineExceeded` immediately afterward.

The same repository tree passed the Windows shard shortly before the post-merge failure, and production coordinator clients use a separate five-minute request timeout. This is a test timing flake rather than a production dispatch regression.

Failing job: https://github.com/dagucloud/dagu/actions/runs/29651360706/job/88098160567

## Testing

- `make fmt`
- `go test ./internal/service/worker -run '^TestWorkerStart$/^MultiplePollers$' -count=10`
- `go test ./internal/test -count=1`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale the test coordinator’s dispatch RPC timeout on Windows to 25s to prevent DeadlineExceeded flakes during DAG-run attempt persistence. Non-Windows platforms keep the 5s timeout.

<sup>Written for commit fa315d488594785408ba97fdd872d6c38a19add5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task dispatch reliability on Windows by allowing additional time for RPC operations to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->