### PR TITLE
perf: avoid bcrypt on API key requests

### DIFF
--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -65,6 +65,9 @@ type APIKey struct {
 	// KeyHash is the bcrypt hash of the API key secret.
 	// Excluded from JSON serialization for security.
 	KeyHash string `json:"-"`
+	// KeyDigest is the versioned digest used for API key lookup.
+	// Excluded from JSON serialization for security.
+	KeyDigest string `json:"-"`
 	// KeyPrefix stores the first 8 characters of the key for identification.
 	KeyPrefix string `json:"key_prefix"`
 	// CreatedAt is the timestamp when the API key was created.
@@ -108,7 +111,7 @@ func NewAPIKey(name, description string, role Role, keyHash, keyPrefix, createdB
 }
 
 // APIKeyForStorage is used for JSON serialization to persistent storage.
-// It includes the key hash which is excluded from the regular APIKey JSON.
+// It includes credential fields excluded from the regular APIKey JSON.
 type APIKeyForStorage struct {
 	ID                       string                 `json:"id"`
 	Name                     string                 `json:"name"`
@@ -123,6 +126,7 @@ type APIKeyForStorage struct {
 	ServiceAccountName       string                 `json:"service_account_name,omitempty"`
 	MigratedAsServiceAccount bool                   `json:"migrated_as_service_account,omitempty"`
 	KeyHash                  string                 `json:"key_hash"`
+	KeyDigest                string                 `json:"key_digest,omitempty"`
 	KeyPrefix                string                 `json:"key_prefix"`
 	CreatedAt                time.Time              `json:"created_at"`
 	UpdatedAt                time.Time              `json:"updated_at"`
@@ -149,6 +153,7 @@ func (k *APIKey) ToStorage() *APIKeyForStorage {
 		ServiceAccountName:       normalized.ServiceAccountName,
 		MigratedAsServiceAccount: normalized.MigratedAsServiceAccount,
 		KeyHash:                  normalized.KeyHash,
+		KeyDigest:                normalized.KeyDigest,
 		KeyPrefix:                normalized.KeyPrefix,
 		CreatedAt:                normalized.CreatedAt,
 		UpdatedAt:                normalized.UpdatedAt,
@@ -175,6 +180,7 @@ func (s *APIKeyForStorage) ToAPIKey() *APIKey {
 		ServiceAccountName:       s.ServiceAccountName,
 		MigratedAsServiceAccount: s.MigratedAsServiceAccount,
 		KeyHash:                  s.KeyHash,
+		KeyDigest:                s.KeyDigest,
 		KeyPrefix:                s.KeyPrefix,
 		CreatedAt:                s.CreatedAt,
 		UpdatedAt:                s.UpdatedAt,

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -109,6 +109,7 @@ func TestAPIKey_ToStorage(t *testing.T) {
 		Description: "Test description",
 		Role:        RoleAdmin,
 		KeyHash:     "hash123",
+		KeyDigest:   "sha256:v1:digest123",
 		KeyPrefix:   "dagu_tes",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -123,6 +124,7 @@ func TestAPIKey_ToStorage(t *testing.T) {
 	assert.Equal(t, key.Description, storage.Description)
 	assert.Equal(t, key.Role, storage.Role)
 	assert.Equal(t, key.KeyHash, storage.KeyHash)
+	assert.Equal(t, key.KeyDigest, storage.KeyDigest)
 	assert.Equal(t, key.KeyPrefix, storage.KeyPrefix)
 	assert.Equal(t, key.CreatedAt, storage.CreatedAt)
 	assert.Equal(t, key.UpdatedAt, storage.UpdatedAt)
@@ -140,6 +142,7 @@ func TestAPIKeyForStorage_ToAPIKey(t *testing.T) {
 		Description: "Test description",
 		Role:        RoleViewer,
 		KeyHash:     "hash456",
+		KeyDigest:   "sha256:v1:digest456",
 		KeyPrefix:   "dagu_xyz",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -154,6 +157,7 @@ func TestAPIKeyForStorage_ToAPIKey(t *testing.T) {
 	assert.Equal(t, storage.Description, key.Description)
 	assert.Equal(t, storage.Role, key.Role)
 	assert.Equal(t, storage.KeyHash, key.KeyHash)
+	assert.Equal(t, storage.KeyDigest, key.KeyDigest)
 	assert.Equal(t, storage.KeyPrefix, key.KeyPrefix)
 	assert.Equal(t, storage.CreatedAt, key.CreatedAt)
 	assert.Equal(t, storage.UpdatedAt, key.UpdatedAt)
@@ -246,6 +250,7 @@ func TestAPIKey_ToStorage_ToAPIKey_Roundtrip(t *testing.T) {
 		Description: "Roundtrip test",
 		Role:        RoleOperator,
 		KeyHash:     "secret-hash",
+		KeyDigest:   "sha256:v1:roundtrip",
 		KeyPrefix:   "dagu_rnd",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -267,6 +272,7 @@ func TestAPIKey_ToStorage_ToAPIKey_Roundtrip(t *testing.T) {
 	assert.Equal(t, original.Description, recovered.Description)
 	assert.Equal(t, original.Role, recovered.Role)
 	assert.Equal(t, original.KeyHash, recovered.KeyHash)
+	assert.Equal(t, original.KeyDigest, recovered.KeyDigest)
 	assert.Equal(t, original.KeyPrefix, recovered.KeyPrefix)
 	assert.Equal(t, original.CreatedAt, recovered.CreatedAt)
 	assert.Equal(t, original.UpdatedAt, recovered.UpdatedAt)
@@ -286,6 +292,7 @@ func TestAPIKey_JSONSerialization(t *testing.T) {
 		Description: "JSON test",
 		Role:        RoleAdmin,
 		KeyHash:     "should-be-excluded",
+		KeyDigest:   "sha256:v1:should-also-be-excluded",
 		KeyPrefix:   "dagu_jsn",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -322,6 +329,7 @@ func TestAPIKeyForStorage_JSONSerialization(t *testing.T) {
 		Description: "Storage test",
 		Role:        RoleManager,
 		KeyHash:     "included-hash",
+		KeyDigest:   "sha256:v1:included-digest",
 		KeyPrefix:   "dagu_str",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -336,6 +344,8 @@ func TestAPIKeyForStorage_JSONSerialization(t *testing.T) {
 	jsonStr := string(data)
 	assert.Contains(t, jsonStr, "included-hash")
 	assert.Contains(t, jsonStr, "key_hash")
+	assert.Contains(t, jsonStr, "sha256:v1:included-digest")
+	assert.Contains(t, jsonStr, "key_digest")
 
 	// Deserialize back
 	var recovered APIKeyForStorage
@@ -346,8 +356,8 @@ func TestAPIKeyForStorage_JSONSerialization(t *testing.T) {
 	assert.Equal(t, storage.Name, recovered.Name)
 	assert.Equal(t, storage.Role, recovered.Role)
 	assert.Equal(t, storage.KeyHash, recovered.KeyHash)
+	assert.Equal(t, storage.KeyDigest, recovered.KeyDigest)
 }
-
 func TestAPIKey_NilLastUsedAt(t *testing.T) {
 	key := &APIKey{
 		ID:        "key-id",

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -113,10 +113,15 @@ type APIKeyStore interface {
 	// Returns ErrAPIKeyNotFound if the API key does not exist.
 	GetByID(ctx context.Context, id string) (*APIKey, error)
 
+	// GetByDigest retrieves an API key by its credential digest.
+	// Returns ErrAPIKeyNotFound if the API key does not exist.
+	GetByDigest(ctx context.Context, digest string) (*APIKey, error)
+
 	// List returns all API keys in the store.
 	List(ctx context.Context) ([]*APIKey, error)
 
 	// Update modifies an existing API key.
+	// Credential fields and a newer LastUsedAt value in storage are preserved.
 	// Returns ErrAPIKeyNotFound if the API key does not exist.
 	Update(ctx context.Context, key *APIKey) error
 
@@ -124,8 +129,11 @@ type APIKeyStore interface {
 	// Returns ErrAPIKeyNotFound if the API key does not exist.
 	Delete(ctx context.Context, id string) error
 
-	// UpdateLastUsed updates the LastUsedAt timestamp for an API key.
-	// This is called when the API key is used for authentication.
+	// PromoteDigest atomically assigns a credential digest to an API key.
+	// Repeating the promotion with the same digest is idempotent.
+	PromoteDigest(ctx context.Context, id, digest string) error
+
+	// UpdateLastUsed records recent API key use without persisting more than once per minute.
 	UpdateLastUsed(ctx context.Context, id string) error
 }
 

--- a/internal/persis/store/apikey.go
+++ b/internal/persis/store/apikey.go
@@ -17,21 +17,25 @@ import (
 
 var _ auth.APIKeyStore = (*APIKeyStore)(nil)
 
+const apiKeyLastUsedWriteInterval = time.Minute
+
 // APIKeyStore implements [auth.APIKeyStore].
-// Name lookups use an in-memory index (byName) rebuilt from the
-// collection on startup; all writes keep it in sync under mu.
+// Name and credential-digest lookups use in-memory indexes rebuilt from the
+// collection on startup; all writes keep them in sync under mu.
 type APIKeyStore struct {
 	col persis.Collection
 
-	mu     sync.RWMutex
-	byName map[string]string // name → keyID
+	mu       sync.RWMutex
+	byName   map[string]string // name → keyID
+	byDigest map[string]string // digest → keyID
 }
 
 // NewAPIKeyStore creates a APIKeyStore backed by col.
 func NewAPIKeyStore(col persis.Collection) (*APIKeyStore, error) {
 	s := &APIKeyStore{
-		col:    col,
-		byName: make(map[string]string),
+		col:      col,
+		byName:   make(map[string]string),
+		byDigest: make(map[string]string),
 	}
 	if err := s.rebuildIndex(context.Background()); err != nil {
 		return nil, fmt.Errorf("apikey store: build index: %w", err)
@@ -52,6 +56,13 @@ func (s *APIKeyStore) rebuildIndex(ctx context.Context) error {
 			continue
 		}
 		s.byName[stored.Name] = stored.ID
+		if stored.KeyDigest == "" {
+			continue
+		}
+		if id, exists := s.byDigest[stored.KeyDigest]; exists && id != stored.ID {
+			return fmt.Errorf("duplicate API key digest for %q and %q", id, stored.ID)
+		}
+		s.byDigest[stored.KeyDigest] = stored.ID
 	}
 	return nil
 }
@@ -80,6 +91,11 @@ func (s *APIKeyStore) Create(ctx context.Context, key *auth.APIKey) error {
 	if _, exists := s.byName[key.Name]; exists {
 		return auth.ErrAPIKeyAlreadyExists
 	}
+	if key.KeyDigest != "" {
+		if _, exists := s.byDigest[key.KeyDigest]; exists {
+			return auth.ErrAPIKeyAlreadyExists
+		}
+	}
 	if _, err := s.col.Get(ctx, key.ID); err == nil {
 		return auth.ErrAPIKeyAlreadyExists
 	}
@@ -92,6 +108,9 @@ func (s *APIKeyStore) Create(ctx context.Context, key *auth.APIKey) error {
 		return err
 	}
 	s.byName[key.Name] = key.ID
+	if key.KeyDigest != "" {
+		s.byDigest[key.KeyDigest] = key.ID
+	}
 	return nil
 }
 
@@ -109,6 +128,37 @@ func (s *APIKeyStore) GetByID(ctx context.Context, id string) (*auth.APIKey, err
 		return nil, err
 	}
 	return apikeyFromRecord(rec)
+}
+
+// GetByDigest retrieves an API key by its credential digest.
+// Returns [auth.ErrAPIKeyNotFound] if the key does not exist.
+func (s *APIKeyStore) GetByDigest(ctx context.Context, digest string) (*auth.APIKey, error) {
+	if digest == "" {
+		return nil, auth.ErrAPIKeyNotFound
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id, ok := s.byDigest[digest]
+	if !ok {
+		return nil, auth.ErrAPIKeyNotFound
+	}
+	rec, err := s.col.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return nil, auth.ErrAPIKeyNotFound
+		}
+		return nil, err
+	}
+	key, err := apikeyFromRecord(rec)
+	if err != nil {
+		return nil, err
+	}
+	if key.KeyDigest != digest {
+		return nil, auth.ErrAPIKeyNotFound
+	}
+	return key, nil
 }
 
 // List returns all API keys in the store.
@@ -129,6 +179,7 @@ func (s *APIKeyStore) List(ctx context.Context) ([]*auth.APIKey, error) {
 }
 
 // Update modifies an existing API key.
+// Credential fields and a newer LastUsedAt value in storage are preserved.
 // Returns [auth.ErrAPIKeyNotFound] if the key does not exist.
 func (s *APIKeyStore) Update(ctx context.Context, key *auth.APIKey) error {
 	if key == nil {
@@ -155,17 +206,25 @@ func (s *APIKeyStore) Update(ctx context.Context, key *auth.APIKey) error {
 	if err := persis.Decode(existingRec, &existingStored); err != nil {
 		return fmt.Errorf("apikey store: decode existing: %w", err)
 	}
-
-	data, err := persis.Encode(key.ToStorage())
-	if err != nil {
-		return err
-	}
-
 	if existingStored.Name != key.Name {
 		if id, taken := s.byName[key.Name]; taken && id != key.ID {
 			return auth.ErrAPIKeyAlreadyExists
 		}
 	}
+
+	updatedStored := key.ToStorage()
+	updatedStored.KeyHash = existingStored.KeyHash
+	updatedStored.KeyDigest = existingStored.KeyDigest
+	updatedStored.LastUsedAt = latestTime(existingStored.LastUsedAt, updatedStored.LastUsedAt)
+	key.KeyHash = updatedStored.KeyHash
+	key.KeyDigest = updatedStored.KeyDigest
+	key.LastUsedAt = updatedStored.LastUsedAt
+
+	data, err := persis.Encode(updatedStored)
+	if err != nil {
+		return err
+	}
+
 	if err := s.col.Put(ctx, &persis.Record{
 		ID:        key.ID,
 		Data:      data,
@@ -207,10 +266,66 @@ func (s *APIKeyStore) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	delete(s.byName, stored.Name)
+	if stored.KeyDigest != "" && s.byDigest[stored.KeyDigest] == id {
+		delete(s.byDigest, stored.KeyDigest)
+	}
 	return nil
 }
 
-// UpdateLastUsed updates the LastUsedAt timestamp for an API key.
+// PromoteDigest atomically assigns a credential digest to an API key.
+// Repeating the promotion with the same digest is idempotent.
+func (s *APIKeyStore) PromoteDigest(ctx context.Context, id, digest string) error {
+	if id == "" {
+		return auth.ErrInvalidAPIKeyID
+	}
+	if digest == "" {
+		return auth.ErrInvalidAPIKeyHash
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rec, err := s.col.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, persis.ErrNotFound) {
+			return auth.ErrAPIKeyNotFound
+		}
+		return err
+	}
+	var stored auth.APIKeyForStorage
+	if err := persis.Decode(rec, &stored); err != nil {
+		return fmt.Errorf("apikey store: decode for PromoteDigest: %w", err)
+	}
+	if stored.KeyDigest == digest {
+		s.byDigest[digest] = id
+		return nil
+	}
+	if stored.KeyDigest != "" {
+		return fmt.Errorf("apikey store: API key %q already has a credential digest", id)
+	}
+	if ownerID, exists := s.byDigest[digest]; exists && ownerID != id {
+		return auth.ErrAPIKeyAlreadyExists
+	}
+
+	stored.KeyDigest = digest
+	data, err := persis.Encode(stored)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if err := s.col.Put(ctx, &persis.Record{
+		ID:        rec.ID,
+		Data:      data,
+		CreatedAt: rec.CreatedAt,
+		UpdatedAt: now,
+	}); err != nil {
+		return err
+	}
+	s.byDigest[digest] = id
+	return nil
+}
+
+// UpdateLastUsed records recent API key use without persisting more than once per minute.
 func (s *APIKeyStore) UpdateLastUsed(ctx context.Context, id string) error {
 	if id == "" {
 		return auth.ErrInvalidAPIKeyID
@@ -229,6 +344,9 @@ func (s *APIKeyStore) UpdateLastUsed(ctx context.Context, id string) error {
 		return fmt.Errorf("apikey store: decode for UpdateLastUsed: %w", err)
 	}
 	now := time.Now().UTC()
+	if stored.LastUsedAt != nil && now.Sub(*stored.LastUsedAt) < apiKeyLastUsedWriteInterval {
+		return nil
+	}
 	stored.LastUsedAt = &now
 	data, err := persis.Encode(stored)
 	if err != nil {
@@ -248,4 +366,17 @@ func apikeyFromRecord(rec *persis.Record) (*auth.APIKey, error) {
 		return nil, fmt.Errorf("apikey store: decode record %q: %w", rec.ID, err)
 	}
 	return stored.ToAPIKey(), nil
+}
+
+func latestTime(a, b *time.Time) *time.Time {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	case a.After(*b):
+		return a
+	default:
+		return b
+	}
 }

--- a/internal/persis/store/apikey_test.go
+++ b/internal/persis/store/apikey_test.go
@@ -5,6 +5,7 @@ package store_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ func newKey(name string) *auth.APIKey {
 		Name:      name,
 		Role:      auth.RoleAdmin,
 		KeyHash:   "hash-" + name,
+		KeyDigest: "digest-" + name,
 		KeyPrefix: "pfx1",
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -50,7 +52,22 @@ func TestAPIKeyCreate(t *testing.T) {
 	assert.Equal(t, key.ID, got.ID)
 	assert.Equal(t, key.Name, got.Name)
 	assert.Equal(t, key.KeyHash, got.KeyHash)
+	assert.Equal(t, key.KeyDigest, got.KeyDigest)
 	assert.Equal(t, key.Role, got.Role)
+}
+
+func TestAPIKeyGetByDigest(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("digest")
+	require.NoError(t, s.Create(ctx, key))
+
+	got, err := s.GetByDigest(ctx, key.KeyDigest)
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, got.ID)
+
+	_, err = s.GetByDigest(ctx, "missing")
+	assert.ErrorIs(t, err, auth.ErrAPIKeyNotFound)
 }
 
 func TestAPIKeyCreate_DuplicateName(t *testing.T) {
@@ -99,6 +116,34 @@ func TestAPIKeyUpdate(t *testing.T) {
 	assert.Equal(t, auth.RoleViewer, got.Role)
 }
 
+func TestAPIKeyUpdatePreservesCredentialAndLatestUsage(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("stale")
+	key.KeyDigest = ""
+	require.NoError(t, s.Create(ctx, key))
+
+	stale, err := s.GetByID(ctx, key.ID)
+	require.NoError(t, err)
+	require.NoError(t, s.PromoteDigest(ctx, key.ID, "promoted-digest"))
+	require.NoError(t, s.UpdateLastUsed(ctx, key.ID))
+
+	stale.Name = "updated-name"
+	stale.KeyHash = "stale-hash"
+	stale.KeyDigest = "stale-digest"
+	oldUsage := time.Now().UTC().Add(-time.Hour)
+	stale.LastUsedAt = &oldUsage
+	require.NoError(t, s.Update(ctx, stale))
+
+	got, err := s.GetByID(ctx, key.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated-name", got.Name)
+	assert.Equal(t, key.KeyHash, got.KeyHash)
+	assert.Equal(t, "promoted-digest", got.KeyDigest)
+	require.NotNil(t, got.LastUsedAt)
+	assert.True(t, got.LastUsedAt.After(oldUsage))
+}
+
 func TestAPIKeyUpdate_NotFound(t *testing.T) {
 	ctx := context.Background()
 	err := newAPIKeyStore(t).Update(ctx, newKey("ghost"))
@@ -117,6 +162,7 @@ func TestAPIKeyUpdate_NameChange(t *testing.T) {
 	// old name slot is free
 	another := newKey("old-name")
 	another.ID = "another-id"
+	another.KeyDigest = "another-digest"
 	assert.NoError(t, s.Create(ctx, another))
 }
 
@@ -141,6 +187,8 @@ func TestAPIKeyDelete(t *testing.T) {
 
 	_, err := s.GetByID(ctx, key.ID)
 	assert.ErrorIs(t, err, auth.ErrAPIKeyNotFound)
+	_, err = s.GetByDigest(ctx, key.KeyDigest)
+	assert.ErrorIs(t, err, auth.ErrAPIKeyNotFound)
 
 	// name slot freed
 	another := newKey("del")
@@ -151,6 +199,34 @@ func TestAPIKeyDelete(t *testing.T) {
 func TestAPIKeyDelete_NotFound(t *testing.T) {
 	ctx := context.Background()
 	assert.ErrorIs(t, newAPIKeyStore(t).Delete(ctx, "nope"), auth.ErrAPIKeyNotFound)
+}
+
+func TestAPIKeyPromoteDigest(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("legacy")
+	key.KeyDigest = ""
+	require.NoError(t, s.Create(ctx, key))
+
+	require.NoError(t, s.PromoteDigest(ctx, key.ID, "promoted-digest"))
+	require.NoError(t, s.PromoteDigest(ctx, key.ID, "promoted-digest"))
+
+	got, err := s.GetByDigest(ctx, "promoted-digest")
+	require.NoError(t, err)
+	assert.Equal(t, key.ID, got.ID)
+	assert.Equal(t, key.KeyHash, got.KeyHash)
+}
+
+func TestAPIKeyPromoteDigestRejectsDuplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	first := newKey("first")
+	second := newKey("second")
+	second.KeyDigest = ""
+	require.NoError(t, s.Create(ctx, first))
+	require.NoError(t, s.Create(ctx, second))
+
+	assert.ErrorIs(t, s.PromoteDigest(ctx, second.ID, first.KeyDigest), auth.ErrAPIKeyAlreadyExists)
 }
 
 func TestAPIKeyUpdateLastUsed(t *testing.T) {
@@ -166,6 +242,63 @@ func TestAPIKeyUpdateLastUsed(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got.LastUsedAt)
 	assert.False(t, got.LastUsedAt.Before(before))
+}
+
+func TestAPIKeyUpdateLastUsedKeepsRecentTimestamp(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("recent")
+	recent := time.Now().UTC().Add(-30 * time.Second)
+	key.LastUsedAt = &recent
+	require.NoError(t, s.Create(ctx, key))
+
+	require.NoError(t, s.UpdateLastUsed(ctx, key.ID))
+
+	got, err := s.GetByID(ctx, key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastUsedAt)
+	assert.Equal(t, recent, *got.LastUsedAt)
+}
+
+func TestAPIKeyUpdateLastUsedConcurrent(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("concurrent-usage")
+	require.NoError(t, s.Create(ctx, key))
+
+	const workers = 100
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			errs <- s.UpdateLastUsed(ctx, key.ID)
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	got, err := s.GetByID(ctx, key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastUsedAt)
+}
+
+func TestAPIKeyUpdateLastUsedRefreshesStaleTimestamp(t *testing.T) {
+	ctx := context.Background()
+	s := newAPIKeyStore(t)
+	key := newKey("stale-usage")
+	stale := time.Now().UTC().Add(-time.Minute - time.Second)
+	key.LastUsedAt = &stale
+	require.NoError(t, s.Create(ctx, key))
+
+	require.NoError(t, s.UpdateLastUsed(ctx, key.ID))
+
+	got, err := s.GetByID(ctx, key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastUsedAt)
+	assert.True(t, got.LastUsedAt.After(stale))
 }
 
 func TestAPIKeyUpdateLastUsed_NotFound(t *testing.T) {
@@ -194,4 +327,9 @@ func TestAPIKeyIndexRebuiltOnStartup(t *testing.T) {
 	dupe := newKey("k1")
 	dupe.ID = "other"
 	assert.ErrorIs(t, s2.Create(ctx, dupe), auth.ErrAPIKeyAlreadyExists)
+
+	// Digest lookup is available after rebuild.
+	got, err := s2.GetByDigest(ctx, "digest-k2")
+	require.NoError(t, err)
+	assert.Equal(t, "id-k2", got.ID)
 }

--- a/internal/service/auth/service.go
+++ b/internal/service/auth/service.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/auth"
@@ -58,6 +59,12 @@ const (
 	apiKeyRandomBytes = 32
 	// apiKeyPrefixLength is the length of the key prefix stored for identification.
 	apiKeyPrefixLength = 8
+	// apiKeyDigestPrefix identifies the digest format stored with API keys.
+	apiKeyDigestPrefix = "sha256:v1:"
+	// apiKeyDigestDomain separates API key digests from other SHA-256 uses.
+	apiKeyDigestDomain = "dagu-api-key:v1\x00" //nolint:gosec // Domain separator, not a credential.
+	// apiKeyLastUsedUpdateInterval limits persistence writes for active API keys.
+	apiKeyLastUsedUpdateInterval = time.Minute
 	// webhookTokenPrefix is the fixed prefix for all webhook tokens.
 	webhookTokenPrefix = "dagu_wh_" //nolint:gosec // Not a credential, just a token prefix
 	// webhookTokenRandomBytes is the number of random bytes for webhook token generation.
@@ -93,10 +100,11 @@ type Claims struct {
 
 // Service provides authentication and user management functionality.
 type Service struct {
-	store        auth.UserStore
-	apiKeyStore  auth.APIKeyStore
-	webhookStore auth.WebhookStore
-	config       Config
+	store             auth.UserStore
+	apiKeyStore       auth.APIKeyStore
+	webhookStore      auth.WebhookStore
+	config            Config
+	apiKeyMigrationMu sync.Mutex
 }
 
 // Option is a functional option for configuring the Service.
@@ -509,6 +517,7 @@ func (s *Service) CreateAPIKey(ctx context.Context, input CreateAPIKeyInput, cre
 	if err != nil {
 		return nil, err
 	}
+	apiKey.KeyDigest = keyParts.keyDigest
 	apiKey.WorkspaceAccess = auth.CloneWorkspaceAccess(input.WorkspaceAccess)
 	if err := s.applyAPIKeyCreateMetadata(ctx, apiKey, input); err != nil {
 		return nil, err
@@ -528,6 +537,7 @@ type apiKeyParts struct {
 	fullKey   string
 	keyPrefix string
 	keyHash   string
+	keyDigest string
 }
 
 // generateAPIKey generates a new API key with prefix, hash, and prefix for display.
@@ -558,7 +568,13 @@ func generateAPIKey(bcryptCost int) (*apiKeyParts, error) {
 		fullKey:   fullKey,
 		keyPrefix: keyPrefix,
 		keyHash:   string(hashBytes),
+		keyDigest: apiKeyDigest(fullKey),
 	}, nil
+}
+
+func apiKeyDigest(fullKey string) string {
+	sum := sha256.Sum256([]byte(apiKeyDigestDomain + fullKey))
+	return apiKeyDigestPrefix + hex.EncodeToString(sum[:])
 }
 
 // GetAPIKey retrieves an API key by ID.
@@ -659,7 +675,6 @@ func (s *Service) DeleteAPIKey(ctx context.Context, id string) error {
 }
 
 // ValidateAPIKey validates an API key and returns the associated APIKey if valid.
-// Uses the stored KeyPrefix to skip non-matching keys before bcrypt comparison.
 func (s *Service) ValidateAPIKey(ctx context.Context, keySecret string) (*auth.APIKey, error) {
 	if s.apiKeyStore == nil {
 		return nil, ErrAPIKeyNotConfigured
@@ -670,36 +685,78 @@ func (s *Service) ValidateAPIKey(ctx context.Context, keySecret string) (*auth.A
 		return nil, ErrInvalidAPIKey
 	}
 
+	digest := apiKeyDigest(keySecret)
+	key, err := s.apiKeyStore.GetByDigest(ctx, digest)
+	if err == nil {
+		return s.finishAPIKeyValidation(ctx, key)
+	}
+	if !errors.Is(err, auth.ErrAPIKeyNotFound) {
+		return nil, fmt.Errorf("failed to get API key by digest: %w", err)
+	}
+
+	return s.validateLegacyAPIKey(ctx, keySecret, digest)
+}
+
+func (s *Service) validateLegacyAPIKey(ctx context.Context, keySecret, digest string) (*auth.APIKey, error) {
+	s.apiKeyMigrationMu.Lock()
+	defer s.apiKeyMigrationMu.Unlock()
+
+	key, err := s.apiKeyStore.GetByDigest(ctx, digest)
+	if err == nil {
+		return s.finishAPIKeyValidation(ctx, key)
+	}
+	if !errors.Is(err, auth.ErrAPIKeyNotFound) {
+		return nil, fmt.Errorf("failed to recheck API key digest: %w", err)
+	}
+
 	keys, err := s.apiKeyStore.List(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list API keys: %w", err)
+		return nil, fmt.Errorf("failed to list legacy API keys: %w", err)
 	}
 
-	// Extract the candidate prefix for fast filtering before bcrypt.
-	var candidatePrefix string
-	if len(keySecret) >= apiKeyPrefixLength {
-		candidatePrefix = keySecret[:apiKeyPrefixLength]
+	candidatePrefix := keySecret
+	if len(candidatePrefix) > apiKeyPrefixLength {
+		candidatePrefix = candidatePrefix[:apiKeyPrefixLength]
 	}
-
 	for _, key := range keys {
-		if candidatePrefix != "" && key.KeyPrefix != candidatePrefix {
+		if key.KeyDigest != "" || key.KeyPrefix != candidatePrefix {
 			continue
 		}
-		if err := bcrypt.CompareHashAndPassword([]byte(key.KeyHash), []byte(keySecret)); err == nil {
-			key = auth.NormalizeAPIKeyMetadata(key)
-			if err := s.validateAPIKeyOwner(ctx, key); err != nil {
-				return nil, err
-			}
-			// Update last used timestamp synchronously.
-			// This avoids goroutine leaks and race conditions with Delete.
-			if err := s.apiKeyStore.UpdateLastUsed(ctx, key.ID); err != nil {
-				slog.Error("failed to update API key last used timestamp", "keyID", key.ID, "error", err)
-			}
-			return key, nil
+		if err := bcrypt.CompareHashAndPassword([]byte(key.KeyHash), []byte(keySecret)); err != nil {
+			continue
 		}
+
+		if err := s.apiKeyStore.PromoteDigest(ctx, key.ID, digest); err != nil {
+			slog.Error("failed to promote legacy API key digest", "keyID", key.ID, "error", err)
+		} else {
+			key.KeyDigest = digest
+		}
+		return s.finishAPIKeyValidation(ctx, key)
 	}
 
 	return nil, ErrInvalidAPIKey
+}
+
+func (s *Service) finishAPIKeyValidation(ctx context.Context, key *auth.APIKey) (*auth.APIKey, error) {
+	if key == nil {
+		return nil, ErrInvalidAPIKey
+	}
+	key = auth.NormalizeAPIKeyMetadata(key)
+	if err := s.validateAPIKeyOwner(ctx, key); err != nil {
+		return nil, err
+	}
+	s.updateAPIKeyLastUsed(ctx, key)
+	return key, nil
+}
+
+func (s *Service) updateAPIKeyLastUsed(ctx context.Context, key *auth.APIKey) {
+	now := time.Now().UTC()
+	if key.LastUsedAt != nil && now.Sub(*key.LastUsedAt) < apiKeyLastUsedUpdateInterval {
+		return
+	}
+	if err := s.apiKeyStore.UpdateLastUsed(ctx, key.ID); err != nil {
+		slog.Error("failed to update API key last used timestamp", "keyID", key.ID, "error", err)
+	}
 }
 
 func (s *Service) applyAPIKeyCreateMetadata(ctx context.Context, key *auth.APIKey, input CreateAPIKeyInput) error {

--- a/internal/service/auth/service_test.go
+++ b/internal/service/auth/service_test.go
@@ -5,8 +5,10 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -745,16 +747,69 @@ func TestService_GetUserFromToken_NoPasswordChangeTokenStillValid(t *testing.T) 
 func setupTestServiceWithAPIKeys(t *testing.T) (*Service, func()) {
 	t.Helper()
 	backend := testutil.NewMemoryBackend()
-	userStore, err := persiststore.NewUserStore(backend.Collection("users"))
-	require.NoError(t, err, "failed to create user store")
 	apiKeyStore, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
 	require.NoError(t, err, "failed to create API key store")
+	return newTestServiceWithAPIKeyStore(t, apiKeyStore), func() {}
+}
+
+func newTestServiceWithAPIKeyStore(tb testing.TB, apiKeyStore auth.APIKeyStore) *Service {
+	tb.Helper()
+	userStore, err := persiststore.NewUserStore(testutil.NewMemoryBackend().Collection("users"))
+	require.NoError(tb, err, "failed to create user store")
 	config := Config{
 		TokenSecret: mustTokenSecret("test-secret-key-for-jwt-signing"),
 		TokenTTL:    time.Hour,
 		BcryptCost:  4, // Low cost for faster tests
 	}
-	return New(userStore, config, WithAPIKeyStore(apiKeyStore)), func() {}
+	return New(userStore, config, WithAPIKeyStore(apiKeyStore))
+}
+
+type observedAPIKeyStore struct {
+	auth.APIKeyStore
+
+	mu                  sync.Mutex
+	promoteCalls        int
+	updateLastUsedCalls int
+	promoteErr          error
+	updateLastUsedErr   error
+}
+
+func (s *observedAPIKeyStore) PromoteDigest(ctx context.Context, id, digest string) error {
+	s.mu.Lock()
+	s.promoteCalls++
+	err := s.promoteErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.APIKeyStore.PromoteDigest(ctx, id, digest)
+}
+
+func (s *observedAPIKeyStore) UpdateLastUsed(ctx context.Context, id string) error {
+	s.mu.Lock()
+	s.updateLastUsedCalls++
+	err := s.updateLastUsedErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.APIKeyStore.UpdateLastUsed(ctx, id)
+}
+
+func (s *observedAPIKeyStore) counts() (promote, updateLastUsed int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.promoteCalls, s.updateLastUsedCalls
+}
+
+func createLegacyAPIKey(tb testing.TB, store auth.APIKeyStore, name string) (*auth.APIKey, *apiKeyParts) {
+	tb.Helper()
+	parts, err := generateAPIKey(4)
+	require.NoError(tb, err)
+	key, err := auth.NewAPIKey(name, "", auth.RoleViewer, parts.keyHash, parts.keyPrefix, "creator-id")
+	require.NoError(tb, err)
+	require.NoError(tb, store.Create(context.Background(), key))
+	return key, parts
 }
 
 func TestService_CreateAPIKey(t *testing.T) {
@@ -779,6 +834,7 @@ func TestService_CreateAPIKey(t *testing.T) {
 	assert.True(t, strings.HasPrefix(result.FullKey, "dagu_"), "full key should start with 'dagu_'")
 	assert.NotEmpty(t, result.APIKey.KeyPrefix)
 	assert.NotEmpty(t, result.APIKey.KeyHash)
+	assert.Equal(t, apiKeyDigest(result.FullKey), result.APIKey.KeyDigest)
 }
 
 func TestService_CreateAPIKey_EmptyName(t *testing.T) {
@@ -1072,6 +1128,131 @@ func TestService_ValidateAPIKey(t *testing.T) {
 	assert.Equal(t, auth.RoleManager, apiKey.Role)
 }
 
+func TestService_ValidateAPIKey_LazilyPersistsLegacyDigest(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{APIKeyStore: store}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+	legacy, parts := createLegacyAPIKey(t, store, "legacy-key")
+
+	validated, err := svc.ValidateAPIKey(context.Background(), parts.fullKey)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.ID, validated.ID)
+
+	digest := apiKeyDigest(parts.fullKey)
+	persisted, err := store.GetByID(context.Background(), legacy.ID)
+	require.NoError(t, err)
+	assert.Equal(t, digest, persisted.KeyDigest)
+	indexed, err := store.GetByDigest(context.Background(), digest)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.ID, indexed.ID)
+	restartedStore, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	restartedSvc := newTestServiceWithAPIKeyStore(t, restartedStore)
+	restartedKey, err := restartedSvc.ValidateAPIKey(context.Background(), parts.fullKey)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.ID, restartedKey.ID)
+
+	_, err = svc.ValidateAPIKey(context.Background(), parts.fullKey)
+	require.NoError(t, err)
+	promoteCalls, _ := observed.counts()
+	assert.Equal(t, 1, promoteCalls)
+}
+
+func TestService_ValidateAPIKey_SerializesLegacyMigration(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{APIKeyStore: store}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+	legacy, parts := createLegacyAPIKey(t, store, "concurrent-legacy-key")
+
+	const workers = 24
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			<-start
+			key, err := svc.ValidateAPIKey(context.Background(), parts.fullKey)
+			if err == nil && key.ID != legacy.ID {
+				err = fmt.Errorf("validated key ID %q, want %q", key.ID, legacy.ID)
+			}
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	promoteCalls, _ := observed.counts()
+	assert.Equal(t, 1, promoteCalls)
+}
+
+func TestService_ValidateAPIKey_PromotionFailureDoesNotRejectLegacyKey(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{
+		APIKeyStore: store,
+		promoteErr:  errors.New("promotion failed"),
+	}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+	legacy, parts := createLegacyAPIKey(t, store, "promotion-failure-key")
+
+	validated, err := svc.ValidateAPIKey(context.Background(), parts.fullKey)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.ID, validated.ID)
+
+	persisted, err := store.GetByID(context.Background(), legacy.ID)
+	require.NoError(t, err)
+	assert.Empty(t, persisted.KeyDigest)
+}
+
+func TestService_ValidateAPIKey_DoesNotPromoteLegacyKeyForWrongSecret(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{APIKeyStore: store}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+	legacy, parts := createLegacyAPIKey(t, store, "wrong-secret-legacy-key")
+	wrongSecret := parts.keyPrefix + "different-secret"
+
+	_, err = svc.ValidateAPIKey(context.Background(), wrongSecret)
+	require.ErrorIs(t, err, ErrInvalidAPIKey)
+
+	persisted, err := store.GetByID(context.Background(), legacy.ID)
+	require.NoError(t, err)
+	assert.Empty(t, persisted.KeyDigest)
+	promoteCalls, _ := observed.counts()
+	assert.Zero(t, promoteCalls)
+}
+
+func TestService_ValidateAPIKey_PromotesLegacyKeyBeforeRejectingDisabledOwner(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	svc := newTestServiceWithAPIKeyStore(t, store)
+	owner := auth.NewUser("disabled-owner", "unused-password-hash", auth.RoleViewer)
+	owner.IsDisabled = true
+	require.NoError(t, svc.store.Create(context.Background(), owner))
+
+	legacy, parts := createLegacyAPIKey(t, store, "disabled-owner-legacy-key")
+	legacy.AttributionClass = auth.APIKeyAttributionUserOwned
+	legacy.OwnerUserID = owner.ID
+	require.NoError(t, store.Update(context.Background(), legacy))
+
+	_, err = svc.ValidateAPIKey(context.Background(), parts.fullKey)
+	require.ErrorIs(t, err, ErrInvalidAPIKey)
+	persisted, err := store.GetByID(context.Background(), legacy.ID)
+	require.NoError(t, err)
+	assert.Equal(t, apiKeyDigest(parts.fullKey), persisted.KeyDigest)
+}
+
 func TestService_ValidateAPIKey_InvalidPrefix(t *testing.T) {
 	svc, cleanup := setupTestServiceWithAPIKeys(t)
 	defer cleanup()
@@ -1079,6 +1260,9 @@ func TestService_ValidateAPIKey_InvalidPrefix(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := svc.ValidateAPIKey(ctx, "invalid_prefix_key")
+	require.ErrorIs(t, err, ErrInvalidAPIKey)
+
+	_, err = svc.ValidateAPIKey(ctx, apiKeyPrefix)
 	require.ErrorIs(t, err, ErrInvalidAPIKey)
 }
 
@@ -1165,6 +1349,47 @@ func TestService_ValidateAPIKey_UpdatesLastUsed(t *testing.T) {
 	require.NotNil(t, apiKey2.LastUsedAt, "LastUsedAt should be populated after validation")
 }
 
+func TestService_ValidateAPIKey_ThrottlesLastUsedUpdates(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{APIKeyStore: store}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+
+	result, err := svc.CreateAPIKey(context.Background(), CreateAPIKeyInput{
+		Name: "last-used-throttle-key",
+		Role: auth.RoleViewer,
+	}, "creator-id")
+	require.NoError(t, err)
+
+	_, err = svc.ValidateAPIKey(context.Background(), result.FullKey)
+	require.NoError(t, err)
+	_, err = svc.ValidateAPIKey(context.Background(), result.FullKey)
+	require.NoError(t, err)
+	_, updateCalls := observed.counts()
+	assert.Equal(t, 1, updateCalls)
+}
+
+func TestService_ValidateAPIKey_LastUsedFailureDoesNotRejectKey(t *testing.T) {
+	backend := testutil.NewMemoryBackend()
+	store, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(t, err)
+	observed := &observedAPIKeyStore{
+		APIKeyStore:       store,
+		updateLastUsedErr: errors.New("last-used update failed"),
+	}
+	svc := newTestServiceWithAPIKeyStore(t, observed)
+
+	result, err := svc.CreateAPIKey(context.Background(), CreateAPIKeyInput{
+		Name: "last-used-failure-key",
+		Role: auth.RoleViewer,
+	}, "creator-id")
+	require.NoError(t, err)
+	validated, err := svc.ValidateAPIKey(context.Background(), result.FullKey)
+	require.NoError(t, err)
+	assert.Equal(t, result.APIKey.ID, validated.ID)
+}
+
 func TestGenerateAPIKey(t *testing.T) {
 	// Test API key generation
 	keyParts, err := generateAPIKey(4) // Low cost for fast tests
@@ -1182,9 +1407,17 @@ func TestGenerateAPIKey(t *testing.T) {
 	// Verify hash is valid bcrypt hash
 	assert.NotEmpty(t, keyParts.keyHash, "Key hash should not be empty")
 	assert.True(t, strings.HasPrefix(keyParts.keyHash, "$2"), "Key hash should be bcrypt format")
+	assert.Equal(t, apiKeyDigest(keyParts.fullKey), keyParts.keyDigest)
 
 	// Verify full key is long enough (should be at least 40 chars: 5 prefix + 32 bytes base58)
 	assert.GreaterOrEqual(t, len(keyParts.fullKey), 40, "Full key should be at least 40 characters")
+}
+
+func TestAPIKeyDigest(t *testing.T) {
+	assert.Equal(t,
+		"sha256:v1:dffc41464f28bdb8ce95d13ecf9acd5ee6bf07a4b56860688431d8e803200514",
+		apiKeyDigest("dagu_example"),
+	)
 }
 
 func TestGenerateAPIKey_UniqueKeys(t *testing.T) {
@@ -1195,5 +1428,41 @@ func TestGenerateAPIKey_UniqueKeys(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, keys[keyParts.fullKey], "Generated key should be unique")
 		keys[keyParts.fullKey] = true
+	}
+}
+
+func BenchmarkService_ValidateAPIKey_DigestPath(b *testing.B) {
+	backend := testutil.NewMemoryBackend()
+	apiKeyStore, err := persiststore.NewAPIKeyStore(backend.Collection("apikeys"))
+	require.NoError(b, err)
+	svc := newTestServiceWithAPIKeyStore(b, apiKeyStore)
+	const fullKey = "dagu_benchmark_digest_path_secret"
+	key, err := auth.NewAPIKey(
+		"benchmark-key",
+		"",
+		auth.RoleViewer,
+		"unused-bcrypt-hash",
+		fullKey[:apiKeyPrefixLength],
+		"creator-id",
+	)
+	require.NoError(b, err)
+	key.KeyDigest = apiKeyDigest(fullKey)
+	require.NoError(b, apiKeyStore.Create(context.Background(), key))
+	_, err = svc.ValidateAPIKey(context.Background(), fullKey)
+	require.NoError(b, err)
+
+	var firstErr error
+	var errOnce sync.Once
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := svc.ValidateAPIKey(context.Background(), fullKey); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+		}
+	})
+	if firstErr != nil {
+		b.Fatal(firstErr)
 	}
 }


### PR DESCRIPTION
## Summary

- add a versioned SHA-256 digest and an in-memory digest-to-ID index for API key lookup
- lazily promote existing bcrypt-only keys after their next successful credential check
- serialize legacy verification and skip migrated records so concurrent API requests do not run bcrypt in parallel
- coalesce API key `LastUsedAt` writes to at most once per minute

## Root cause

Every API-key-authenticated REST and MCP request listed all stored keys and ran a cost-12 bcrypt comparison for the matching prefix. Concurrent clients therefore consumed CPU in proportion to request rate, and every successful request also performed a synchronous atomic file write for `LastUsedAt`.

## Compatibility and migration

The stored `key_digest` field is optional. New keys populate it immediately, while existing keys are upgraded automatically on first valid use. The bcrypt hash remains stored for rollback compatibility. No configuration, public API, key format, or startup migration is required.

Metadata updates preserve the latest credential fields and `LastUsedAt`, preventing concurrent promotion or usage tracking from being overwritten.

## Validation

- `make lint`
- `go test -race ./internal/auth ./internal/persis/store ./internal/service/auth -count=1`
- `go test ./internal/service/frontend/auth ./internal/service/frontend/api/v1 -count=1`
- `go test ./... -run '^$' -count=1`
- parallel digest-path benchmark with a CPU profile; bcrypt and Blowfish had no samples on the steady-state path


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoided cost-12 bcrypt on API key requests by switching to a fast, indexed validation path and throttling `LastUsedAt` writes. Existing keys migrate automatically on first successful use; no config or API changes required.

- **Refactors**
  - Store: added `GetByDigest` and `PromoteDigest`, in-memory digest→ID index, and `UpdateLastUsed` coalesced to once per minute; updates preserve stored credential fields and newer `LastUsedAt`.
  - Service: validation computes a versioned SHA-256 digest and uses digest lookup; legacy bcrypt path is serialized and promotes the digest on success; last-used updates are throttled and non-fatal.
  - Data model and tests: introduced `KeyDigest` on `APIKey`/`APIKeyForStorage` (optional, populated for new keys), indices rebuilt on startup with uniqueness enforcement; added tests for migration, throttling, concurrency, and a steady-state benchmark.

<sup>Written for commit 6a2cec381680c87ee9bfa4c5ea02bc1b2fb0540b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now support faster digest-based validation and lookup.
  * Existing legacy API keys are automatically migrated when successfully validated.
  * API key credentials and usage timestamps are preserved during updates.
  * “Last used” activity updates are throttled to reduce unnecessary writes.
  * Duplicate credential digests are detected and rejected.

* **Bug Fixes**
  * Improved consistency of API key indexes after creation, updates, deletion, and restart.
  * Validation remains successful when recording usage metadata fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->