### PR TITLE
fix: wait for replacement attempt initialization

### DIFF
--- a/internal/persis/file/dagrun/attempt_external_test.go
+++ b/internal/persis/file/dagrun/attempt_external_test.go
@@ -154,8 +154,6 @@ func TestCompareAndSwapLatestAttemptStatusReturnsNormalizedConditions(t *testing
 }
 
 func TestCompareAndSwapLatestAttemptStatusWaitsForReplacementInitialization(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	baseDir := t.TempDir()
 	store := dagrun.New(baseDir, dagrun.WithLatestStatusToday(false))
@@ -191,7 +189,7 @@ func TestCompareAndSwapLatestAttemptStatusWaitsForReplacementInitialization(t *t
 	replacementStatus.Status = core.Running
 	writeResult := make(chan error, 1)
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(250 * time.Millisecond)
 		writeResult <- replacement.Write(ctx, replacementStatus)
 	}()
 

--- a/internal/persis/file/dagrun/attempt_external_test.go
+++ b/internal/persis/file/dagrun/attempt_external_test.go
@@ -153,6 +153,65 @@ func TestCompareAndSwapLatestAttemptStatusReturnsNormalizedConditions(t *testing
 	require.Empty(t, updated.Conditions)
 }
 
+func TestCompareAndSwapLatestAttemptStatusWaitsForReplacementInitialization(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := dagrun.New(baseDir, dagrun.WithLatestStatusToday(false))
+	dag := &core.DAG{Name: "replacement-initialization"}
+	startedAt := time.Date(2026, 7, 21, 1, 2, 3, 0, time.UTC)
+	ref := exec.NewDAGRunRef(dag.Name, "run-replacement")
+
+	original, err := store.CreateAttempt(ctx, dag, startedAt, ref.ID, exec.NewDAGRunAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, original.Open(ctx))
+	originalStatus := exec.InitialStatus(dag)
+	originalStatus.DAGRunID = ref.ID
+	originalStatus.AttemptID = original.ID()
+	originalStatus.Status = core.Waiting
+	require.NoError(t, original.Write(ctx, originalStatus))
+	require.NoError(t, original.Close(ctx))
+
+	replacement, err := store.CreateAttempt(
+		ctx,
+		dag,
+		startedAt.Add(time.Second),
+		ref.ID,
+		exec.NewDAGRunAttemptOptions{Retry: true},
+	)
+	require.NoError(t, err)
+	require.NoError(t, replacement.Open(ctx))
+	t.Cleanup(func() {
+		_ = replacement.Close(ctx)
+	})
+
+	replacementStatus := originalStatus
+	replacementStatus.AttemptID = replacement.ID()
+	replacementStatus.Status = core.Running
+	writeResult := make(chan error, 1)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		writeResult <- replacement.Write(ctx, replacementStatus)
+	}()
+
+	updated, swapped, err := store.CompareAndSwapLatestAttemptStatus(
+		ctx,
+		ref,
+		original.ID(),
+		core.Waiting,
+		func(*exec.DAGRunStatus) error {
+			return nil
+		},
+	)
+	require.NoError(t, <-writeResult)
+	require.NoError(t, err)
+	require.False(t, swapped)
+	require.NotNil(t, updated)
+	require.Equal(t, replacement.ID(), updated.AttemptID)
+	require.Equal(t, core.Running, updated.Status)
+}
+
 func findOnlyStatusFile(t *testing.T, root string) string {
 	t.Helper()
 

--- a/internal/persis/file/dagrun/store.go
+++ b/internal/persis/file/dagrun/store.go
@@ -24,6 +24,11 @@ var (
 	ErrDAGRunIDEmpty = errors.New("dag-run ID is empty")
 )
 
+const (
+	replacementAttemptStatusReadTimeout  = time.Second
+	replacementAttemptStatusPollInterval = 10 * time.Millisecond
+)
+
 var _ exec.DAGRunStore = (*Store)(nil)
 
 // Store manages DAG run status files on the local filesystem.
@@ -286,7 +291,7 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 		return nil, false, err
 	}
 
-	status, err := attempt.ReadStatus(ctx)
+	status, err := readCompareAndSwapStatus(ctx, attempt, expectedAttemptID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -316,6 +321,43 @@ func (store *Store) CompareAndSwapLatestAttemptStatus(
 		return nil, false, err
 	}
 	return status, true, nil
+}
+
+// readCompareAndSwapStatus waits for a replacement attempt to publish its initial status.
+func readCompareAndSwapStatus(
+	ctx context.Context,
+	attempt *Attempt,
+	expectedAttemptID string,
+) (*exec.DAGRunStatus, error) {
+	status, err := attempt.ReadStatus(ctx)
+	if !replacementAttemptIsInitializing(attempt, expectedAttemptID, err) {
+		return status, err
+	}
+
+	timeout := time.NewTimer(replacementAttemptStatusReadTimeout)
+	defer timeout.Stop()
+	ticker := time.NewTicker(replacementAttemptStatusPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timeout.C:
+			return nil, err
+		case <-ticker.C:
+			status, err = attempt.ReadStatus(ctx)
+			if !replacementAttemptIsInitializing(attempt, expectedAttemptID, err) {
+				return status, err
+			}
+		}
+	}
+}
+
+func replacementAttemptIsInitializing(attempt *Attempt, expectedAttemptID string, err error) bool {
+	return expectedAttemptID != "" &&
+		attempt.ID() != expectedAttemptID &&
+		errors.Is(err, exec.ErrCorruptedStatusFile)
 }
 
 func formatUnixToRFC3339(unix int64) string {


### PR DESCRIPTION
## Summary

- wait for a newer file-backed DAG-run attempt to publish its initial status before CAS reports a corrupted status file
- keep genuine corruption behavior unchanged for the expected attempt
- cover replacement-attempt initialization deterministically at the store contract boundary

## Root cause

Concurrent completion of the same human task can let the first command launch a retry while the second command is still resolving its CAS. The retry attempt becomes the latest attempt as soon as its status file is opened, but its first valid status is written slightly later. If the second completion reads during that window, the empty file is reported as `ErrCorruptedStatusFile` instead of resolving the newer attempt as a normal CAS conflict.

This caused the Ubuntu conformance failure in https://github.com/dagucloud/dagu/actions/runs/29801904971/job/88544457155.

## Impact

Concurrent idempotent human-task completions no longer fail when a resume retry is initializing. CAS still returns the replacement status without applying the stale mutation once initialization completes.

## Testing

- `go test ./internal/persis/file/dagrun -run 'TestCompareAndSwapLatestAttemptStatus' -count=20 -race`
- `go test ./internal/persis/file/dagrun -count=1 -race`
- `DAGU_BIN=.local/bin/dagu go test ./conformance/spec031_human_task -run 'TestConcurrentCompletion' -count=50 -race`
- `DAGU_BIN=.local/bin/dagu go test ./conformance/spec031_human_task -count=1 -race`
- `make lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the file-backed DAG-run store by waiting for a newer replacement attempt to write its first status before reading. Prevents false corruption errors during concurrent human-task completion and keeps CAS behavior unchanged.

- **Bug Fixes**
  - In CompareAndSwapLatestAttemptStatus, add a bounded poll (1s timeout, 10ms interval, respects context cancellation) via readCompareAndSwapStatus to wait for the newer attempt when ErrCorruptedStatusFile occurs on a non-expected attempt.
  - Genuine corruption on the expected attempt is unchanged.
  - Add a deterministic test, TestCompareAndSwapLatestAttemptStatusWaitsForReplacementInitialization, to stabilize the replacement-attempt initialization window.

<sup>Written for commit e73efb543b339cd90e0cade709a6698f1f34e77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status updates when a workflow attempt is replaced while its initial status is still being published.
  * The system now waits briefly for the replacement attempt’s status, while respecting timeouts and cancellation, reducing incorrect compare-and-swap results.

* **Tests**
  * Added coverage for replacement attempts transitioning to a running state during status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->