### PR TITLE
feat: add fallback pull policy

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -3117,12 +3117,12 @@
             },
             {
               "type": "string",
-              "enum": ["always", "never", "missing"],
-              "description": "String policy: 'always' pulls the image every time, 'never' uses only local images, 'missing' pulls only if not present locally"
+              "enum": ["always", "never", "missing", "fallback"],
+              "description": "String policy: 'always' pulls the image every time, 'never' uses only local images, 'missing' pulls only if not present locally, 'fallback' attempts a pull and falls back to a local image if the pull fails"
             }
           ],
           "default": "missing",
-          "description": "Image pull policy. Accepts boolean (true='always', false='never') or string ('always', 'never', 'missing'). Default is 'missing'. Not applicable in exec mode."
+          "description": "Image pull policy. Accepts boolean (true='always', false='never') or string ('always', 'never', 'missing', 'fallback'). Default is 'missing'. Not applicable in exec mode."
         },
         "env": {
           "oneOf": [
@@ -3726,12 +3726,12 @@
             },
             {
               "type": "string",
-              "enum": ["always", "never", "missing"],
-              "description": "Pull policy string"
+              "enum": ["always", "never", "missing", "fallback"],
+              "description": "Pull policy string: 'always', 'never', 'missing', or 'fallback'"
             }
           ],
           "default": "missing",
-          "description": "Image pull policy. 'always' pulls every time, 'never' uses only local, 'missing' pulls if not present."
+          "description": "Image pull policy. 'always' pulls every time, 'never' uses only local, 'missing' pulls if not present, 'fallback' attempts a pull and falls back to a local image if the pull fails."
         },
         "auto_remove": {
           "oneOf": [{ "type": "boolean" }, { "type": "string" }],

--- a/internal/core/container.go
+++ b/internal/core/container.go
@@ -141,6 +141,8 @@ func (p PullPolicy) String() string {
 		return "never"
 	case PullPolicyMissing:
 		return "missing"
+	case PullPolicyFallback:
+		return "fallback"
 	default:
 		return "unknown"
 	}
@@ -150,12 +152,14 @@ const (
 	PullPolicyAlways PullPolicy = iota
 	PullPolicyNever
 	PullPolicyMissing
+	PullPolicyFallback
 )
 
 var pullPolicyMap = map[string]PullPolicy{
-	"always":  PullPolicyAlways,
-	"missing": PullPolicyMissing,
-	"never":   PullPolicyNever,
+	"always":   PullPolicyAlways,
+	"missing":  PullPolicyMissing,
+	"never":    PullPolicyNever,
+	"fallback": PullPolicyFallback,
 }
 
 // boolToPullPolicy converts a boolean to a PullPolicy.

--- a/internal/core/container_test.go
+++ b/internal/core/container_test.go
@@ -72,6 +72,12 @@ func TestPullPolicy(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "FallbackString",
+			pull:        "fallback",
+			expected:    core.PullPolicyFallback,
+			expectError: false,
+		},
+		{
 			name:        "Error",
 			pull:        "random pull policy should not exist",
 			expected:    core.PullPolicyMissing,

--- a/internal/core/executor_schema_test.go
+++ b/internal/core/executor_schema_test.go
@@ -83,7 +83,7 @@ func TestValidateExecutorConfig_EnumValidation(t *testing.T) {
 		Properties: map[string]*jsonschema.Schema{
 			"pull": {
 				Type: "string",
-				Enum: []any{"always", "never", "missing"},
+				Enum: []any{"always", "never", "missing", "fallback"},
 			},
 		},
 	}
@@ -91,6 +91,10 @@ func TestValidateExecutorConfig_EnumValidation(t *testing.T) {
 
 	// Valid enum value
 	err := ValidateExecutorConfig("test_enum", map[string]any{"pull": "always"})
+	require.NoError(t, err)
+
+	// Valid fallback enum value
+	err = ValidateExecutorConfig("test_enum", map[string]any{"pull": "fallback"})
 	require.NoError(t, err)
 
 	// Invalid enum value

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -2499,6 +2499,7 @@ steps:
 		{"Always", "always", core.PullPolicyAlways},
 		{"Never", "never", core.PullPolicyNever},
 		{"Missing", "missing", core.PullPolicyMissing},
+		{"Fallback", "fallback", core.PullPolicyFallback},
 		{"TrueString", "true", core.PullPolicyAlways},
 		{"FalseString", "false", core.PullPolicyNever},
 	}

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -2001,6 +2001,17 @@ func TestBuildStepContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "PullPolicyFallback",
+			input: &container{
+				Image:      "alpine:3.18",
+				PullPolicy: "fallback",
+			},
+			expected: &core.Container{
+				Image:      "alpine:3.18",
+				PullPolicy: core.PullPolicyFallback,
+			},
+		},
+		{
 			name: "RuntimeDefaultsToDocker",
 			input: &container{
 				Image: "alpine:3.18",

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -6,6 +6,7 @@ package docker
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -759,16 +760,38 @@ func (c *Client) startNewContainer(ctx context.Context, name string, cli *client
 
 		logger.Debug(ctx, "Docker: startNewContainer calling ImagePull")
 		reader, err := cli.ImagePull(ctx, c.cfg.Image, pullOpts)
+
+		// Check for API-level error
 		if err != nil {
 			logger.Error(ctx, "Docker: startNewContainer ImagePull failed", tag.Error(err))
-			return "", err
+		} else {
+			// Check for stream-level error (registry errors reported in JSON)
+			logger.Debug(ctx, "Docker: startNewContainer ImagePull returned, checking stream for errors")
+			err = checkImagePullStream(reader)
+			_ = reader.Close()
+			if err != nil {
+				logger.Error(ctx, "Docker: startNewContainer image pull stream error", tag.Error(err))
+			}
 		}
-		logger.Debug(ctx, "Docker: startNewContainer ImagePull returned, draining reader")
-		// Output pull-image log to stderr instead of stdout
-		_, _ = io.Copy(io.Discard, reader)
-		_ = reader.Close()
-		logger.Debug(ctx, "Docker: startNewContainer image pull completed")
-		logger.Infof(ctx, "Successfully pulled the image %q", c.cfg.Image)
+
+		// Handle pull failure with unified fallback logic
+		if err != nil {
+			if c.cfg.Pull == core.PullPolicyFallback {
+				hasLocal, checkErr := c.hasLocalImage(ctx, cli, &c.platform)
+				if checkErr != nil {
+					return "", fmt.Errorf("image pull failed and local image check failed: %w (original pull error: %v)", checkErr, err)
+				}
+				if !hasLocal {
+					return "", fmt.Errorf("image pull failed and no local image available: %w", err)
+				}
+				logger.Warnf(ctx, "Pull failed for %q, falling back to local image: %v", c.cfg.Image, err)
+			} else {
+				return "", err
+			}
+		} else {
+			logger.Debug(ctx, "Docker: startNewContainer image pull completed")
+			logger.Infof(ctx, "Successfully pulled the image %q", c.cfg.Image)
+		}
 	}
 
 	ctCfg := *c.cfg.Container // Copy to avoid mutating original
@@ -1320,6 +1343,33 @@ func getPlatform(ctx context.Context, cli *client.Client, cfg *Config) (specs.Pl
 	return platform, nil
 }
 
+// checkImagePullStream decodes the Docker image pull JSON stream and checks for errors.
+// Docker's ImagePull can return a successful io.ReadCloser even when the registry reports
+// errors in the JSON stream itself (e.g., authentication failures, not found, etc.).
+func checkImagePullStream(reader io.Reader) error {
+	decoder := json.NewDecoder(reader)
+	type pullMessage struct {
+		Status string `json:"status,omitempty"`
+		Error  string `json:"error,omitempty"`
+	}
+
+	for {
+		var msg pullMessage
+		if err := decoder.Decode(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("failed to decode stream message: %w", err)
+		}
+
+		if msg.Error != "" {
+			return fmt.Errorf("image pull error: %s", msg.Error)
+		}
+	}
+
+	return nil
+}
+
 func (c *Client) shouldPullImage(ctx context.Context, cli *client.Client, platform *specs.Platform) (bool, error) {
 	if c.cfg.Pull == core.PullPolicyAlways {
 		return true, nil
@@ -1327,9 +1377,16 @@ func (c *Client) shouldPullImage(ctx context.Context, cli *client.Client, platfo
 	if c.cfg.Pull == core.PullPolicyNever {
 		return false, nil
 	}
+	if c.cfg.Pull == core.PullPolicyFallback {
+		// Always attempt pull; fallback to local is handled by the caller.
+		return true, nil
+	}
 
-	// Loop through all locally available images that have the same reference with
-	// the input image to check if we have the correct platform.
+	return c.needsPull(ctx, cli, platform)
+}
+
+// hasLocalImage checks whether a local image matching the given platform exists.
+func (c *Client) hasLocalImage(ctx context.Context, cli *client.Client, platform *specs.Platform) (bool, error) {
 	filters := make(client.Filters).Add("reference", c.cfg.Image)
 
 	images, err := cli.ImageList(ctx, client.ImageListOptions{Filters: filters})
@@ -1343,12 +1400,22 @@ func (c *Client) shouldPullImage(ctx context.Context, cli *client.Client, platfo
 			return false, fmt.Errorf("failed to inspect image %s: %w", summary.ID, err)
 		}
 		if (platform.OS == inspect.Os) && (platform.Architecture == inspect.Architecture) && (platform.Variant == inspect.Variant) {
-			// We have the correct image locally, no need to pull
-			return false, nil
+			return true, nil
 		}
 	}
 
-	// We don't have the correct image
+	return false, nil
+}
+
+// needsPull checks if the image needs to be pulled for PullPolicyMissing.
+func (c *Client) needsPull(ctx context.Context, cli *client.Client, platform *specs.Platform) (bool, error) {
+	hasLocal, err := c.hasLocalImage(ctx, cli, platform)
+	if err != nil {
+		return false, err
+	}
+	if hasLocal {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/internal/runtime/builtin/docker/client.go
+++ b/internal/runtime/builtin/docker/client.go
@@ -1399,7 +1399,14 @@ func (c *Client) hasLocalImage(ctx context.Context, cli *client.Client, platform
 		if err != nil {
 			return false, fmt.Errorf("failed to inspect image %s: %w", summary.ID, err)
 		}
-		if (platform.OS == inspect.Os) && (platform.Architecture == inspect.Architecture) && (platform.Variant == inspect.Variant) {
+
+		localPlatform := specs.Platform{
+			OS:           inspect.Os,
+			Architecture: inspect.Architecture,
+			Variant:      inspect.Variant,
+		}
+
+		if platforms.OnlyStrict(*platform).Match(localPlatform) {
 			return true, nil
 		}
 	}

--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -327,6 +327,21 @@ func TestLoadConfigFromMap(t *testing.T) {
 			},
 		},
 		{
+			name: "PullPolicyFallback",
+			input: map[string]any{
+				"image": "alpine",
+				"pull":  "fallback",
+			},
+			expected: &Config{
+				Image:       "alpine",
+				Pull:        core.PullPolicyFallback,
+				Container:   &container.Config{},
+				Host:        &container.HostConfig{},
+				Network:     &network.NetworkingConfig{},
+				ExecOptions: &client.ExecCreateOptions{},
+			},
+		},
+		{
 			name: "PullPolicyAsBooleanTrue",
 			input: map[string]any{
 				"image": "alpine",

--- a/internal/runtime/builtin/docker/config.go
+++ b/internal/runtime/builtin/docker/config.go
@@ -358,7 +358,7 @@ var configSchema = &jsonschema.Schema{
 		"image":          {Type: "string", Description: "Docker image (for new container mode)"},
 		"container_name": {Type: "string", Description: "Container name (for exec mode or to name new container)"},
 		"platform":       {Type: "string", Description: "Target platform (e.g., linux/amd64)"},
-		"pull":           {Type: "string", Description: "Image pull policy (always, never, missing)"},
+		"pull":           {Type: "string", Description: "Image pull policy (always, never, missing, fallback)"},
 		"auto_remove":    {Type: "boolean", Description: "Remove container after exit"},
 		"working_dir":    {Type: "string", Description: "Working directory inside container"},
 		"volumes":        {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Volume bindings (host:container)"},

--- a/internal/runtime/builtin/kubernetes/config.go
+++ b/internal/runtime/builtin/kubernetes/config.go
@@ -20,15 +20,16 @@ import (
 )
 
 var (
-	ErrImageRequired            = errors.New("image is required")
-	ErrInvalidCleanupPolicy     = errors.New("cleanup_policy must be either delete or keep")
-	ErrInvalidImagePullPolicy   = errors.New("image_pull_policy must be one of Always, IfNotPresent, or Never")
-	ErrNegativeActiveDeadline   = errors.New("active_deadline must be >= 0")
-	ErrNegativeBackoffLimit     = errors.New("backoff_limit must be >= 0")
-	ErrNegativeTTLAfterFinished = errors.New("ttl_after_finished must be >= 0")
-	ErrNegativeTerminationGrace = errors.New("termination_grace_period_seconds must be >= 0")
-	ErrNegativeQuantity         = errors.New("resource quantity must be >= 0")
-	ErrInvalidVolumeSource      = errors.New("volume must define exactly one source")
+	ErrImageRequired             = errors.New("image is required")
+	ErrInvalidCleanupPolicy      = errors.New("cleanup_policy must be either delete or keep")
+	ErrInvalidImagePullPolicy    = errors.New("image_pull_policy must be one of Always, IfNotPresent, or Never")
+	ErrNegativeActiveDeadline    = errors.New("active_deadline must be >= 0")
+	ErrNegativeBackoffLimit      = errors.New("backoff_limit must be >= 0")
+	ErrNegativeTTLAfterFinished  = errors.New("ttl_after_finished must be >= 0")
+	ErrNegativeTerminationGrace  = errors.New("termination_grace_period_seconds must be >= 0")
+	ErrNegativeQuantity          = errors.New("resource quantity must be >= 0")
+	ErrInvalidVolumeSource       = errors.New("volume must define exactly one source")
+	ErrUnsupportedFallbackPolicy = errors.New("fallback is not supported for kubernetes executor (use Always, IfNotPresent, or Never)")
 )
 
 const (
@@ -1385,6 +1386,11 @@ func (cfg *Config) toK8sImagePullPolicy() (corev1.PullPolicy, error) {
 		return corev1.PullNever, nil
 	case "ifnotpresent":
 		return corev1.PullIfNotPresent, nil
+	case "fallback":
+		// Kubernetes does not have a native fallback policy equivalent to Docker's
+		// "try pull, fall back to local on failure" behavior. IfNotPresent has
+		// opposite semantics (prefer local, never try registry if cached).
+		return "", ErrUnsupportedFallbackPolicy
 	default:
 		return "", ErrInvalidImagePullPolicy
 	}

--- a/internal/runtime/builtin/kubernetes/config_test.go
+++ b/internal/runtime/builtin/kubernetes/config_test.go
@@ -87,6 +87,16 @@ func TestLoadConfigFromMapValidation(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidImagePullPolicy)
 	})
 
+	t.Run("UnsupportedFallbackPolicyReturnsError", func(t *testing.T) {
+		cfg, err := LoadConfigFromMap(map[string]any{
+			"image":             "busybox",
+			"image_pull_policy": "fallback",
+		})
+
+		require.Nil(t, cfg)
+		require.ErrorIs(t, err, ErrUnsupportedFallbackPolicy)
+	})
+
 	t.Run("NegativeNumericFieldsReturnError", func(t *testing.T) {
 		tests := []struct {
 			name string


### PR DESCRIPTION
## Summary

Add a new pull_policy: fallback that attempts to pull the image from the registry first but falls back to the existing local image if the pull fails (e.g., registry down). Fails with an error if no local image is available.

## Changes

- Add PullPolicyFallback enum to core.Container
- Extract hasLocalImage helper from shouldPullImage in docker client
- Handle ImagePull errors with local image fallback in startNewContainer
- Map fallback to PullIfNotPresent in Kubernetes config

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new image pull policy `fallback` that tries to pull first and, if the pull fails, uses a local, platform-compatible image; errors if none exists. Supported in Docker; Kubernetes rejects this policy.

- **New Features**
  - Added `PullPolicyFallback` to `core.Container` and schema; accepts "fallback".
  - Docker: parses the ImagePull JSON stream to detect registry errors and falls back to a local image on failure; warns and errors if no local image is found.
  - Kubernetes: returns `ErrUnsupportedFallbackPolicy` for "fallback" (use `Always`, `IfNotPresent`, or `Never`).

- **Bug Fixes**
  - Docker: variant-tolerant platform matching using `platforms.OnlyStrict` (treats arm64 and arm64/v8 as equivalent; does not match incompatible variants like arm64/v7).

<sup>Written for commit cce6aaf7e3eda852bd98231050b218e35d3896fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `fallback` image pull policy for Docker and Kubernetes workloads.
  * The policy attempts to pull the image first, then uses a matching local image if the pull fails.
  * Docker validates local image platform compatibility before falling back.
* **Bug Fixes**
  * Improved handling and reporting of image pull failures.
* **Tests**
  * Added coverage for parsing, validation, and execution of the new policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->