### PR TITLE
feat(executor): add Tenki Cloud sandbox executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,31 @@ steps:
       command: cd /var/www && git pull && systemctl restart app
 ```
 
+### Tenki sandbox execution
+
+Run a step inside an ephemeral [Tenki Cloud](https://tenki.cloud) sandbox. Set `TENKI_API_KEY` and `TENKI_PROJECT_ID` in the environment (or pass `api_key` / `project_id` in `with:`); the sandbox is created, the command runs with output streamed back, and the sandbox is terminated when the step finishes.
+
+```yaml
+steps:
+  - name: run-in-sandbox
+    type: tenki
+    with:
+      env:
+        - GREETING=Hello
+    command: echo "$GREETING from Tenki sandboxes"
+```
+
+Reuse an existing sandbox with `session_id` (it is left running):
+
+```yaml
+steps:
+  - name: exec-in-existing
+    action: tenki.run
+    with:
+      session_id: <existing-session-id>
+      command: uname -a
+```
+
 ### Sub-DAG composition
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	dario.cat/mergo v1.0.2
+	github.com/TenkiCloud/tenki-sdk-go/sandbox v0.4.0
 	github.com/adrg/xdg v0.5.3
 	github.com/aquaproj/aqua/v2 v2.58.1
 	github.com/bmatcuk/doublestar/v4 v4.8.1
@@ -69,9 +70,11 @@ require (
 
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 // indirect
 	charm.land/lipgloss/v2 v2.0.3 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	codeberg.org/polyfloyd/go-errorlint v1.9.0 // indirect
+	connectrpc.com/connect v1.20.0 // indirect
 	dev.gaijin.team/go/exhaustruct/v4 v4.0.0 // indirect
 	dev.gaijin.team/go/golib v0.6.0 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
@@ -156,6 +159,7 @@ require (
 	github.com/google/go-github/v80 v80.0.0 // indirect
 	github.com/google/go-github/v85 v85.0.0 // indirect
 	github.com/google/wire v0.7.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@
 9fans.net/go v0.0.8-0.20250307142834-96bdba94b63f/go.mod h1:hHyrZRryGqVdqrknjq5OWDLGCTJ2NeEvtrpR96mjraM=
 al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
 al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 h1:s6hzCXtND/ICdGPTMGk7C+/BFlr2Jg5GyH0NKf4XGXg=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -28,6 +30,8 @@ codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6M
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 codeberg.org/polyfloyd/go-errorlint v1.9.0 h1:VkdEEmA1VBpH6ecQoMR4LdphVI3fA4RrCh2an7YmodI=
 codeberg.org/polyfloyd/go-errorlint v1.9.0/go.mod h1:GPRRu2LzVijNn4YkrZYJfatQIdS+TrcK8rL5Xs24qw8=
+connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
+connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dev.gaijin.team/go/exhaustruct/v4 v4.0.0 h1:873r7aNneqoBB3IaFIzhvt2RFYTuHgmMjoKfwODoI1Y=
@@ -79,6 +83,8 @@ github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQA
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/TenkiCloud/tenki-sdk-go/sandbox v0.4.0 h1:d2vbANaShCfAXr9zvByK1xojnmseygRvy5Jpymsved0=
+github.com/TenkiCloud/tenki-sdk-go/sandbox v0.4.0/go.mod h1:oRu7sR8Rjgj+R5YrKJNyRp5pfroTHpKSW0xAKDlvC9M=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=
@@ -541,6 +547,8 @@ github.com/gordonklaus/ineffassign v0.2.0 h1:Uths4KnmwxNJNzq87fwQQDDnbNb7De00VOk
 github.com/gordonklaus/ineffassign v0.2.0/go.mod h1:TIpymnagPSexySzs7F9FnO1XFTy8IT3a59vmZp5Y9Lw=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gostaticanalysis/analysisutil v0.7.1 h1:ZMCjoue3DtDWQ5WyU16YbjbQEQ3VuzwxALrpYd+HeKk=
 github.com/gostaticanalysis/analysisutil v0.7.1/go.mod h1:v21E3hY37WKMGSnbsw2S/ojApNWb6C1//mXO48CXbVc=
 github.com/gostaticanalysis/comment v1.4.2/go.mod h1:KLUTGDv6HOCotCH8h2erHKmpci2ZoR8VPu34YA2uzdM=

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -2370,6 +2370,18 @@
         },
         {
           "if": {
+            "properties": { "action": { "const": "tenki.run" } },
+            "required": ["action"]
+          },
+          "then": {
+            "required": ["with"],
+            "properties": {
+              "with": { "$ref": "#/definitions/tenkiExecutorConfig" }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": { "action": { "enum": ["archive.create", "archive.extract", "archive.list"] } },
             "required": ["action"]
           },
@@ -2730,6 +2742,19 @@
               "with": { "$ref": "#/definitions/sshExecutorConfig" },
               "config": {
                 "$ref": "#/definitions/sshExecutorConfig",
+                "deprecated": true,
+                "doNotSuggest": true
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "tenki" } }, "required": ["type"] },
+          "then": {
+            "properties": {
+              "with": { "$ref": "#/definitions/tenkiExecutorConfig" },
+              "config": {
+                "$ref": "#/definitions/tenkiExecutorConfig",
                 "deprecated": true,
                 "doNotSuggest": true
               }
@@ -3599,6 +3624,84 @@
         }
       },
       "description": "SSH executor configuration for remote command execution."
+    },
+    "tenkiExecutorConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable sandbox session name."
+        },
+        "image": {
+          "type": "string",
+          "description": "Tenki registry image ref to launch the sandbox from. If unset, uses the base image."
+        },
+        "cpu_cores": {
+          "type": "integer",
+          "description": "vCPU cores for a new sandbox (1-16)."
+        },
+        "memory_mb": {
+          "type": "integer",
+          "description": "Memory in MB for a new sandbox."
+        },
+        "session_id": {
+          "type": "string",
+          "description": "Reuse an existing sandbox session instead of creating one. The session is not terminated after the step."
+        },
+        "keep_session": {
+          "type": "boolean",
+          "default": false,
+          "description": "Keep a created sandbox running after the step instead of terminating it."
+        },
+        "create_timeout": {
+          "type": "string",
+          "description": "How long to wait for a new sandbox to become ready (e.g. '3m', '90s')."
+        },
+        "max_duration": {
+          "type": "string",
+          "description": "Lifetime cap for a created sandbox as a leak backstop (e.g. '1h'); '0s' defers to the server default."
+        },
+        "env": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Session environment variables in KEY=VALUE form."
+        },
+        "working_dir": {
+          "type": "string",
+          "description": "Working directory inside the sandbox."
+        },
+        "shell": {
+          "type": "string",
+          "description": "Shell used to run the command/script; defaults to /bin/sh. May embed args, e.g. '/bin/bash -o pipefail'."
+        },
+        "shell_args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional shell arguments (e.g. ['-o', 'pipefail'])."
+        },
+        "api_key": {
+          "type": "string",
+          "description": "Tenki API key. Falls back to the TENKI_API_KEY environment variable."
+        },
+        "api_url": {
+          "type": "string",
+          "description": "Tenki API base URL. Falls back to TENKI_API_URL or the default endpoint."
+        },
+        "project_id": {
+          "type": "string",
+          "description": "Tenki project ID to create the sandbox in. Falls back to the TENKI_PROJECT_ID environment variable."
+        },
+        "workspace_id": {
+          "type": "string",
+          "description": "Tenki workspace ID to create the sandbox in. Falls back to the TENKI_WORKSPACE_ID environment variable."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command to run in the sandbox; used by the tenki.run action form."
+        }
+      },
+      "description": "Tenki sandbox executor configuration for running commands in a Tenki Cloud sandbox."
     },
     "sftpExecutorConfig": {
       "type": "object",
@@ -6021,7 +6124,8 @@
         "action",
         "outputs",
         "sftp",
-        "template"
+        "template",
+        "tenki"
       ],
       "description": "Type of executor to use for this step, including aliases such as k8s / kubernetes."
     },
@@ -6096,6 +6200,7 @@
             "state.list",
             "state.set",
             "template.render",
+            "tenki.run",
             "wait.duration",
             "wait.file",
             "wait.http",
@@ -7428,6 +7533,14 @@
           "then": {
             "properties": {
               "config": { "$ref": "#/definitions/sshExecutorConfig" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "tenki" } }, "required": ["type"] },
+          "then": {
+            "properties": {
+              "config": { "$ref": "#/definitions/tenkiExecutorConfig" }
             }
           }
         },

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -106,6 +106,7 @@ var builtinStepTypeNames = map[string]struct{}{
 	"state":         {},
 	"subworkflow":   {},
 	"template":      {},
+	"tenki":         {},
 	"wait":          {},
 }
 

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -91,6 +91,7 @@ var builtinActionNormalizers = map[string]actionNormalizer{
 	"state.list":          operationAction("state", "list"),
 	"state.set":           operationAction("state", "set"),
 	"template.render":     normalizeTemplateAction,
+	"tenki.run":           commandAction("tenki", "command"),
 	"wait.duration":       operationAction("wait", "duration"),
 	"wait.file":           operationAction("wait", "file"),
 	"wait.http":           operationAction("wait", "http"),

--- a/internal/runtime/builtin/builtin.go
+++ b/internal/runtime/builtin/builtin.go
@@ -32,5 +32,6 @@ import (
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/ssh"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/state"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/template"
+	_ "github.com/dagucloud/dagu/internal/runtime/builtin/tenki"
 	_ "github.com/dagucloud/dagu/internal/runtime/builtin/wait"
 )

--- a/internal/runtime/builtin/tenki/config.go
+++ b/internal/runtime/builtin/tenki/config.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package tenki
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+const (
+	executorType = "tenki"
+
+	// defaultCreateTimeout bounds how long we wait for a fresh sandbox to
+	// become exec-ready before failing the step.
+	defaultCreateTimeout = 3 * time.Minute
+
+	// defaultMaxDuration caps a created sandbox's lifetime as a backstop against
+	// leaks when cleanup never runs, e.g. after a host crash; 0 defers to server.
+	defaultMaxDuration = time.Hour
+
+	// defaultShell runs the step command/script inside the sandbox. The base
+	// image ships /bin/sh, so it is a safe POSIX default.
+	defaultShell = "/bin/sh"
+)
+
+// config is the parsed `with:` configuration for the Tenki sandbox executor.
+type config struct {
+	Name          string
+	Image         string
+	CPUCores      int32
+	MemoryMB      int32
+	SessionID     string
+	KeepSession   bool
+	CreateTimeout time.Duration
+	MaxDuration   time.Duration
+	Env           []string
+	WorkingDir    string
+	Shell         string
+	ShellArgs     []string
+	APIKey        string
+	APIURL        string
+	ProjectID     string
+	WorkspaceID   string
+}
+
+// mapConfig mirrors config for mapstructure decoding of the `with:` map.
+type mapConfig struct {
+	Name          string   `mapstructure:"name"`
+	Image         string   `mapstructure:"image"`
+	CPUCores      int32    `mapstructure:"cpu_cores"`
+	MemoryMB      int32    `mapstructure:"memory_mb"`
+	SessionID     string   `mapstructure:"session_id"`
+	KeepSession   bool     `mapstructure:"keep_session"`
+	CreateTimeout string   `mapstructure:"create_timeout"`
+	MaxDuration   string   `mapstructure:"max_duration"`
+	Env           []string `mapstructure:"env"`
+	WorkingDir    string   `mapstructure:"working_dir"`
+	Shell         string   `mapstructure:"shell"`
+	ShellArgs     []string `mapstructure:"shell_args"`
+	APIKey        string   `mapstructure:"api_key"`
+	APIURL        string   `mapstructure:"api_url"`
+	ProjectID     string   `mapstructure:"project_id"`
+	WorkspaceID   string   `mapstructure:"workspace_id"`
+}
+
+func loadConfig(mapCfg map[string]any) (config, error) {
+	var def mapConfig
+	md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &def,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return config{}, fmt.Errorf("failed to create decoder: %w", err)
+	}
+	if err := md.Decode(mapCfg); err != nil {
+		return config{}, fmt.Errorf("failed to decode tenki config: %w", err)
+	}
+
+	createTimeout, err := parseDuration("create_timeout", def.CreateTimeout, defaultCreateTimeout)
+	if err != nil {
+		return config{}, err
+	}
+	maxDuration, err := parseDuration("max_duration", def.MaxDuration, defaultMaxDuration)
+	if err != nil {
+		return config{}, err
+	}
+	shell, shellArgs, err := parseShellConfig(def.Shell, def.ShellArgs)
+	if err != nil {
+		return config{}, fmt.Errorf("failed to parse shell config: %w", err)
+	}
+
+	return config{
+		Name:          def.Name,
+		Image:         def.Image,
+		CPUCores:      def.CPUCores,
+		MemoryMB:      def.MemoryMB,
+		SessionID:     def.SessionID,
+		KeepSession:   def.KeepSession,
+		CreateTimeout: createTimeout,
+		MaxDuration:   maxDuration,
+		Env:           def.Env,
+		WorkingDir:    def.WorkingDir,
+		Shell:         shell,
+		ShellArgs:     shellArgs,
+		APIKey:        def.APIKey,
+		APIURL:        def.APIURL,
+		ProjectID:     def.ProjectID,
+		WorkspaceID:   def.WorkspaceID,
+	}, nil
+}
+
+// parseDuration parses a duration string, returning def when empty.
+func parseDuration(field, s string, def time.Duration) (time.Duration, error) {
+	if s == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s duration %q: %w", field, s, err)
+	}
+	return d, nil
+}
+
+// parseShellConfig splits a shell string that may embed arguments like
+// "/bin/bash -o pipefail" and appends explicit shell_args, mirroring ssh.
+func parseShellConfig(shell string, args []string) (string, []string, error) {
+	shell = strings.TrimSpace(shell)
+	if shell == "" {
+		return "", slices.Clone(args), nil
+	}
+	parsedShell, parsedArgs, err := cmdutil.SplitCommand(shell)
+	if err != nil {
+		return "", nil, err
+	}
+	allArgs := append(parsedArgs, args...)
+	return strings.TrimSpace(parsedShell), allArgs, nil
+}
+
+var configSchema = &jsonschema.Schema{
+	Type: "object",
+	Properties: map[string]*jsonschema.Schema{
+		"name":           {Type: "string", Description: "Human-readable sandbox session name"},
+		"image":          {Type: "string", Description: "Tenki registry image ref to launch the sandbox from. If unset, uses the base image"},
+		"cpu_cores":      {Type: "integer", Description: "vCPU cores for a new sandbox (1-16)"},
+		"memory_mb":      {Type: "integer", Description: "Memory in MB for a new sandbox"},
+		"session_id":     {Type: "string", Description: "Reuse an existing sandbox session instead of creating one; the session is not terminated"},
+		"keep_session":   {Type: "boolean", Description: "Keep a created sandbox running after the step instead of terminating it"},
+		"create_timeout": {Type: "string", Description: "How long to wait for a new sandbox to become ready (e.g. '3m', '90s')"},
+		"max_duration":   {Type: "string", Description: "Lifetime cap for a created sandbox as a leak backstop (e.g. '1h'); '0s' defers to the server default"},
+		"env":            {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Session environment variables in KEY=VALUE form"},
+		"working_dir":    {Type: "string", Description: "Working directory inside the sandbox"},
+		"shell":          {Type: "string", Description: "Shell used to run the command/script; defaults to /bin/sh. May embed args, e.g. '/bin/bash -o pipefail'"},
+		"shell_args":     {Type: "array", Items: &jsonschema.Schema{Type: "string"}, Description: "Additional shell arguments (e.g. ['-o', 'pipefail'])"},
+		"api_key":        {Type: "string", Description: "Tenki API key; falls back to the TENKI_API_KEY environment variable"},
+		"api_url":        {Type: "string", Description: "Tenki API base URL; falls back to TENKI_API_URL or the default endpoint"},
+		"project_id":     {Type: "string", Description: "Tenki project ID to create the sandbox in; falls back to the TENKI_PROJECT_ID environment variable"},
+		"workspace_id":   {Type: "string", Description: "Tenki workspace ID to create the sandbox in; falls back to the TENKI_WORKSPACE_ID environment variable"},
+	},
+}
+
+func init() {
+	core.RegisterExecutorConfigSchema(executorType, configSchema)
+}

--- a/internal/runtime/builtin/tenki/config_test.go
+++ b/internal/runtime/builtin/tenki/config_test.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package tenki
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapCfg  map[string]any
+		want    config
+		wantErr bool
+	}{
+		{
+			name:    "When_field_type_is_invalid_then_should_return_error",
+			mapCfg:  map[string]any{"cpu_cores": "abc"},
+			wantErr: true,
+		},
+		{
+			name:    "When_create_timeout_is_invalid_then_should_return_error",
+			mapCfg:  map[string]any{"create_timeout": "not-a-duration"},
+			wantErr: true,
+		},
+		{
+			name:    "When_max_duration_is_invalid_then_should_return_error",
+			mapCfg:  map[string]any{"max_duration": "not-a-duration"},
+			wantErr: true,
+		},
+		{
+			name:   "When_config_is_empty_then_should_apply_defaults",
+			mapCfg: nil,
+			want:   config{CreateTimeout: defaultCreateTimeout, MaxDuration: defaultMaxDuration},
+		},
+		{
+			name: "When_config_is_fully_specified_then_should_decode_successfully",
+			mapCfg: map[string]any{
+				"name":           "my-sandbox",
+				"image":          "ubuntu",
+				"cpu_cores":      4,
+				"memory_mb":      8192,
+				"session_id":     "sess-123",
+				"keep_session":   true,
+				"create_timeout": "90s",
+				"max_duration":   "1h",
+				"env":            []string{"FOO=bar"},
+				"working_dir":    "/home/tenki/work",
+				"shell":          "/bin/bash",
+				"shell_args":     []string{"-o", "pipefail"},
+				"api_key":        "tk_test",
+				"api_url":        "https://api.example.com",
+				"project_id":     "proj-123",
+				"workspace_id":   "ws-123",
+			},
+			want: config{
+				Name:          "my-sandbox",
+				Image:         "ubuntu",
+				CPUCores:      4,
+				MemoryMB:      8192,
+				SessionID:     "sess-123",
+				KeepSession:   true,
+				CreateTimeout: 90 * time.Second,
+				MaxDuration:   time.Hour,
+				Env:           []string{"FOO=bar"},
+				WorkingDir:    "/home/tenki/work",
+				Shell:         "/bin/bash",
+				ShellArgs:     []string{"-o", "pipefail"},
+				APIKey:        "tk_test",
+				APIURL:        "https://api.example.com",
+				ProjectID:     "proj-123",
+				WorkspaceID:   "ws-123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadConfig(tt.mapCfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		def     time.Duration
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "When_string_is_empty_then_should_return_default",
+			input: "",
+			def:   5 * time.Second,
+			want:  5 * time.Second,
+		},
+		{
+			name:    "When_string_is_invalid_then_should_return_error",
+			input:   "not-a-duration",
+			def:     5 * time.Second,
+			wantErr: true,
+		},
+		{
+			name:  "When_string_is_valid_then_should_parse_duration",
+			input: "90s",
+			def:   5 * time.Second,
+			want:  90 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDuration("field", tt.input, tt.def)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseShellConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		shell     string
+		args      []string
+		wantShell string
+		wantArgs  []string
+	}{
+		{
+			name:      "When_shell_is_empty_then_should_return_empty_shell_and_given_args",
+			shell:     "",
+			args:      []string{"-e"},
+			wantShell: "",
+			wantArgs:  []string{"-e"},
+		},
+		{
+			name:      "When_shell_has_no_embedded_args_then_should_keep_given_args",
+			shell:     "/bin/bash",
+			args:      []string{"-e"},
+			wantShell: "/bin/bash",
+			wantArgs:  []string{"-e"},
+		},
+		{
+			name:      "When_shell_embeds_args_then_should_split_and_append",
+			shell:     "/bin/bash -o pipefail",
+			args:      []string{"-e"},
+			wantShell: "/bin/bash",
+			wantArgs:  []string{"-o", "pipefail", "-e"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shell, args, err := parseShellConfig(tt.shell, tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantShell, shell)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
+}

--- a/internal/runtime/builtin/tenki/executor.go
+++ b/internal/runtime/builtin/tenki/executor.go
@@ -101,6 +101,7 @@ func (e *tenkiExecutor) Run(ctx context.Context) error {
 
 	// Tail stderr so recent output can be surfaced in error messages.
 	env := runtime.GetEnv(ctx)
+	cleanupTimeout := cleanupTimeoutOf(env)
 	tw := executor.NewTailWriterWithEncoding(e.stderr, 0, env.LogEncodingCharset)
 	e.stderr = tw
 
@@ -113,14 +114,13 @@ func (e *tenkiExecutor) Run(ctx context.Context) error {
 	e.mu.Unlock()
 	defer client.Close()
 
-	session, ownsSession, err := e.resolveSession(ctx, client)
+	session, ownsSession, err := e.resolveSession(ctx, client, cleanupTimeout)
 	if err != nil {
 		if tail := tw.Tail(); tail != "" {
 			return fmt.Errorf("failed to set up tenki sandbox: %w\nrecent stderr (tail):\n%s", err, tail)
 		}
 		return fmt.Errorf("failed to set up tenki sandbox: %w", err)
 	}
-	cleanupTimeout := cleanupTimeoutOf(env)
 	e.mu.Lock()
 	e.session = session
 	e.ownsSession = ownsSession
@@ -141,7 +141,7 @@ func (e *tenkiExecutor) Run(ctx context.Context) error {
 
 // resolveSession returns an existing sandbox when session_id is set, otherwise
 // creates a new one and reports ownership so Run knows whether to terminate it.
-func (e *tenkiExecutor) resolveSession(ctx context.Context, client *sandbox.Client) (*sandbox.Session, bool, error) {
+func (e *tenkiExecutor) resolveSession(ctx context.Context, client *sandbox.Client, cleanupTimeout time.Duration) (*sandbox.Session, bool, error) {
 	if id := strings.TrimSpace(e.cfg.SessionID); id != "" {
 		session, err := client.Get(ctx, id)
 		if err != nil {
@@ -157,7 +157,9 @@ func (e *tenkiExecutor) resolveSession(ctx context.Context, client *sandbox.Clie
 	// Wait for readiness ourselves so a sandbox that was created but never
 	// becomes ready is torn down instead of leaking.
 	if err := session.WaitReady(ctx, e.cfg.CreateTimeout); err != nil {
-		_ = session.CloseIfOpen(context.WithoutCancel(ctx))
+		termCtx, cancel := withCleanupTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+		defer cancel()
+		_ = session.CloseIfOpen(termCtx)
 		return nil, false, fmt.Errorf("sandbox did not become ready: %w", err)
 	}
 	return session, true, nil

--- a/internal/runtime/builtin/tenki/executor.go
+++ b/internal/runtime/builtin/tenki/executor.go
@@ -1,0 +1,415 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package tenki provides an executor that runs a step's command or script
+// inside a Tenki Cloud sandbox (https://tenki.cloud) via the Go sandbox SDK.
+package tenki
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/TenkiCloud/tenki-sdk-go/sandbox"
+
+	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/runtime/executor"
+)
+
+// Tenki executor runs a command or script inside a Tenki Cloud sandbox; auth and
+// target come from the TENKI_API_KEY and TENKI_PROJECT_ID environment variables.
+/* Example DAG:
+```yaml
+steps:
+ - name: run-in-sandbox
+   type: tenki
+   with:
+     name: my-sandbox    # optional
+     cpu_cores: 2        # optional
+     memory_mb: 4096     # optional
+     env:                # optional session env
+       - GREETING=Hello
+   command: echo "$GREETING from Tenki sandboxes"
+
+ - name: reuse-session
+   type: tenki
+   with:
+     session_id: <existing-session-id>  # exec in an existing sandbox; not terminated
+   command: uname -a
+```
+*/
+
+var _ executor.Executor = (*tenkiExecutor)(nil)
+var _ executor.ExitCoder = (*tenkiExecutor)(nil)
+
+type tenkiExecutor struct {
+	mu             sync.Mutex
+	step           core.Step
+	cfg            config
+	stdout         io.Writer
+	stderr         io.Writer
+	cancel         context.CancelFunc
+	client         *sandbox.Client
+	session        *sandbox.Session
+	ownsSession    bool
+	cleanupTimeout time.Duration
+	closed         bool
+	exitCode       int
+}
+
+func newTenki(_ context.Context, step core.Step) (executor.Executor, error) {
+	cfg, err := loadConfig(step.ExecutorConfig.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &tenkiExecutor{
+		step:   step,
+		cfg:    cfg,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}, nil
+}
+
+func (e *tenkiExecutor) SetStdout(out io.Writer) { e.stdout = out }
+func (e *tenkiExecutor) SetStderr(out io.Writer) { e.stderr = out }
+
+// ExitCode implements executor.ExitCoder.
+func (e *tenkiExecutor) ExitCode() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.exitCode
+}
+
+func (e *tenkiExecutor) Run(ctx context.Context) error {
+	if len(e.step.Commands) == 0 && e.step.Script == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	e.mu.Lock()
+	e.cancel = cancel
+	e.mu.Unlock()
+	defer cancel()
+
+	// Tail stderr so recent output can be surfaced in error messages.
+	env := runtime.GetEnv(ctx)
+	tw := executor.NewTailWriterWithEncoding(e.stderr, 0, env.LogEncodingCharset)
+	e.stderr = tw
+
+	client, err := e.newClient()
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.client = client
+	e.mu.Unlock()
+	defer client.Close()
+
+	session, ownsSession, err := e.resolveSession(ctx, client)
+	if err != nil {
+		if tail := tw.Tail(); tail != "" {
+			return fmt.Errorf("failed to set up tenki sandbox: %w\nrecent stderr (tail):\n%s", err, tail)
+		}
+		return fmt.Errorf("failed to set up tenki sandbox: %w", err)
+	}
+	cleanupTimeout := cleanupTimeoutOf(env)
+	e.mu.Lock()
+	e.session = session
+	e.ownsSession = ownsSession
+	e.cleanupTimeout = cleanupTimeout
+	e.mu.Unlock()
+
+	if ownsSession && !e.cfg.KeepSession {
+		defer func() {
+			// Detach from the run context so teardown still runs after cancellation.
+			termCtx, cancel := withCleanupTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+			defer cancel()
+			_ = session.CloseIfOpen(termCtx)
+		}()
+	}
+
+	return e.exec(ctx, session, tw)
+}
+
+// resolveSession returns an existing sandbox when session_id is set, otherwise
+// creates a new one and reports ownership so Run knows whether to terminate it.
+func (e *tenkiExecutor) resolveSession(ctx context.Context, client *sandbox.Client) (*sandbox.Session, bool, error) {
+	if id := strings.TrimSpace(e.cfg.SessionID); id != "" {
+		session, err := client.Get(ctx, id)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get sandbox session %q: %w", id, err)
+		}
+		return session, false, nil
+	}
+
+	session, err := client.Create(ctx, e.createOptions()...)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create sandbox session: %w", err)
+	}
+	// Wait for readiness ourselves so a sandbox that was created but never
+	// becomes ready is torn down instead of leaking.
+	if err := session.WaitReady(ctx, e.cfg.CreateTimeout); err != nil {
+		_ = session.CloseIfOpen(context.WithoutCancel(ctx))
+		return nil, false, fmt.Errorf("sandbox did not become ready: %w", err)
+	}
+	return session, true, nil
+}
+
+// createOptions builds the create options; WithWaitReady(false) returns the
+// session immediately so readiness and cleanup on failure are handled here.
+func (e *tenkiExecutor) createOptions() []sandbox.CreateOption {
+	opts := []sandbox.CreateOption{sandbox.WithWaitReady(false)}
+	if e.cfg.Name != "" {
+		opts = append(opts, sandbox.WithName(e.cfg.Name))
+	}
+	if e.cfg.Image != "" {
+		opts = append(opts, sandbox.WithImage(e.cfg.Image))
+	}
+	if e.cfg.CPUCores > 0 {
+		opts = append(opts, sandbox.WithCPUCores(e.cfg.CPUCores))
+	}
+	if e.cfg.MemoryMB > 0 {
+		opts = append(opts, sandbox.WithMemoryMB(e.cfg.MemoryMB))
+	}
+	if e.cfg.MaxDuration > 0 {
+		opts = append(opts, sandbox.WithMaxDuration(e.cfg.MaxDuration))
+	}
+	if envMap := envSliceToMap(e.cfg.Env); len(envMap) > 0 {
+		opts = append(opts, sandbox.WithEnvs(envMap))
+	}
+	if projectID := firstNonEmpty(e.cfg.ProjectID, os.Getenv("TENKI_PROJECT_ID")); projectID != "" {
+		opts = append(opts, sandbox.WithProjectID(projectID))
+	}
+	if workspaceID := firstNonEmpty(e.cfg.WorkspaceID, os.Getenv("TENKI_WORKSPACE_ID")); workspaceID != "" {
+		opts = append(opts, sandbox.WithWorkspaceID(workspaceID))
+	}
+	return opts
+}
+
+// exec streams the step command/script into the sandbox and reports the result.
+func (e *tenkiExecutor) exec(ctx context.Context, session *sandbox.Session, tw *executor.TailWriter) error {
+	shell, shellArgs := e.resolveShell()
+	argv := append([]string{shell}, shellArgs...)
+	argv = append(argv, "-c", e.buildScript())
+
+	runOpts := sandbox.RunOptions{
+		Env: e.execEnv(),
+		Dir: e.workingDir(),
+	}
+
+	handle, err := session.Command(argv, runOpts).Stream(ctx)
+	if err != nil {
+		if tail := tw.Tail(); tail != "" {
+			return fmt.Errorf("failed to start sandbox command: %w\nrecent stderr (tail):\n%s", err, tail)
+		}
+		return fmt.Errorf("failed to start sandbox command: %w", err)
+	}
+	_ = handle.Stdin.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _, _ = io.Copy(e.stdout, handle.Stdout) }()
+	go func() { defer wg.Done(); _, _ = io.Copy(e.stderr, handle.Stderr) }()
+
+	result, waitErr := handle.Wait()
+	wg.Wait()
+
+	if waitErr != nil {
+		if tail := tw.Tail(); tail != "" {
+			return fmt.Errorf("sandbox command failed: %w\nrecent stderr (tail):\n%s", waitErr, tail)
+		}
+		return fmt.Errorf("sandbox command failed: %w", waitErr)
+	}
+
+	e.setExitCode(int(result.ExitCode))
+
+	if result.ExitCode != 0 || result.Status.IsFailed() || result.Status.IsTimedOut() {
+		if tail := tw.Tail(); tail != "" {
+			return fmt.Errorf("sandbox command exited with status %s (code %d)\nrecent stderr (tail):\n%s", result.Status, result.ExitCode, tail)
+		}
+		return fmt.Errorf("sandbox command exited with status %s (code %d)", result.Status, result.ExitCode)
+	}
+	return nil
+}
+
+func (e *tenkiExecutor) Kill(_ os.Signal) error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	if e.cancel != nil {
+		e.cancel()
+	}
+	session, ownsSession, keepSession, timeout := e.session, e.ownsSession, e.cfg.KeepSession, e.cleanupTimeout
+	e.mu.Unlock()
+
+	if ownsSession && session != nil && !keepSession {
+		ctx, cancel := withCleanupTimeout(context.Background(), timeout)
+		defer cancel()
+		return session.CloseIfOpen(ctx)
+	}
+	return nil
+}
+
+func cleanupTimeoutOf(env runtime.Env) time.Duration {
+	if env.DAG != nil {
+		return env.DAG.MaxCleanUpTime
+	}
+	return 0
+}
+
+func withCleanupTimeout(base context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout > 0 {
+		return context.WithTimeout(base, timeout)
+	}
+	return base, func() {}
+}
+
+func (e *tenkiExecutor) newClient() (*sandbox.Client, error) {
+	var opts []sandbox.Option
+	if e.cfg.APIKey != "" {
+		opts = append(opts, sandbox.WithAuthToken(e.cfg.APIKey))
+	}
+	if e.cfg.APIURL != "" {
+		opts = append(opts, sandbox.WithBaseURL(e.cfg.APIURL))
+	}
+	client, err := sandbox.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tenki client: %w", err)
+	}
+	return client, nil
+}
+
+func (e *tenkiExecutor) setExitCode(code int) {
+	e.mu.Lock()
+	e.exitCode = code
+	e.mu.Unlock()
+}
+
+// resolveShell returns the in-sandbox shell and its args: with.shell, then step
+// shell, then /bin/sh.
+func (e *tenkiExecutor) resolveShell() (string, []string) {
+	if e.cfg.Shell != "" {
+		return e.cfg.Shell, slices.Clone(e.cfg.ShellArgs)
+	}
+	if e.step.Shell != "" {
+		return e.step.Shell, slices.Clone(e.step.ShellArgs)
+	}
+	return defaultShell, nil
+}
+
+// workingDir resolves the in-sandbox working directory; empty leaves the SDK
+// default of the guest home.
+func (e *tenkiExecutor) workingDir() string {
+	if d := strings.TrimSpace(e.cfg.WorkingDir); d != "" {
+		return d
+	}
+	return e.step.Dir
+}
+
+// execEnv merges with.env and step env so variables apply whether the sandbox
+// is created or reused; step env wins on conflicts.
+func (e *tenkiExecutor) execEnv() map[string]string {
+	entries := make([]string, 0, len(e.cfg.Env)+len(e.step.Env))
+	entries = append(entries, e.cfg.Env...)
+	entries = append(entries, e.step.Env...)
+	return envSliceToMap(entries)
+}
+
+// buildScript wraps the step command(s) or script for shell execution with
+// fail-fast semantics.
+func (e *tenkiExecutor) buildScript() string {
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	if e.step.Script != "" {
+		b.WriteString(e.step.Script)
+		if !strings.HasSuffix(e.step.Script, "\n") {
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+	for _, c := range e.step.Commands {
+		b.WriteString(commandString(c))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// commandString renders a command entry, preferring the original expanded
+// string so variable references pass through to the sandbox shell.
+func commandString(cmd core.CommandEntry) string {
+	if cmd.CmdWithArgs != "" {
+		return cmd.CmdWithArgs
+	}
+	if len(cmd.Args) == 0 {
+		return cmd.Command
+	}
+	return cmd.Command + " " + cmdutil.ShellQuoteArgs(cmd.Args)
+}
+
+// firstNonEmpty returns the first non-empty, trimmed value.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func envSliceToMap(entries []string) map[string]string {
+	if len(entries) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, val, found := strings.Cut(entry, "=")
+		if !found || key == "" {
+			continue
+		}
+		m[key] = val
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+func init() {
+	caps := core.ExecutorCapabilities{
+		Command:          true,
+		MultipleCommands: true,
+		Script:           true,
+		Shell:            true,
+		CommandContext: func(_ context.Context, step core.Step) cmnvalue.CommandContext {
+			return cmnvalue.CommandContext{
+				Target:          cmnvalue.CommandTargetSSH,
+				ShellConfigured: hasShellConfigured(step),
+			}
+		},
+		ScriptContext: func(_ context.Context, step core.Step) cmnvalue.CommandContext {
+			return cmnvalue.CommandContext{
+				Target:          cmnvalue.CommandTargetSSH,
+				ShellConfigured: hasShellConfigured(step),
+			}
+		},
+	}
+	executor.RegisterExecutor(executorType, newTenki, nil, caps)
+}
+
+func hasShellConfigured(step core.Step) bool {
+	if len(step.ExecutorConfig.Config) > 0 && cmdutil.IsShellValueSet(step.ExecutorConfig.Config["shell"]) {
+		return true
+	}
+	return step.Shell != ""
+}

--- a/internal/runtime/builtin/tenki/executor.go
+++ b/internal/runtime/builtin/tenki/executor.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Tenki executor runs a command or script inside a Tenki Cloud sandbox; auth and
-// target come from the TENKI_API_KEY and TENKI_PROJECT_ID environment variables.
+// project/workspace settings come from `with:` (api_key/project_id/workspace_id) with TENKI_* environment fallbacks.
 /* Example DAG:
 ```yaml
 steps:

--- a/internal/runtime/builtin/tenki/executor_test.go
+++ b/internal/runtime/builtin/tenki/executor_test.go
@@ -1,0 +1,531 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package tenki
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTenki(t *testing.T) {
+	tests := []struct {
+		name    string
+		step    core.Step
+		wantErr bool
+	}{
+		{
+			name:    "When_config_is_invalid_then_should_return_error",
+			step:    core.Step{ExecutorConfig: core.ExecutorConfig{Config: map[string]any{"cpu_cores": "abc"}}},
+			wantErr: true,
+		},
+		{
+			name: "When_config_is_valid_then_should_create_executor",
+			step: core.Step{ExecutorConfig: core.ExecutorConfig{Config: map[string]any{"name": "my-sandbox"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newTenki(context.Background(), tt.step)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestTenkiExecutor_SetStdoutAndStderr(t *testing.T) {
+	e := &tenkiExecutor{}
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+
+	e.SetStdout(out)
+	e.SetStderr(errOut)
+
+	assert.Same(t, out, e.stdout)
+	assert.Same(t, errOut, e.stderr)
+}
+
+func TestTenkiExecutor_ExitCode(t *testing.T) {
+	e := &tenkiExecutor{}
+	e.setExitCode(42)
+	assert.Equal(t, 42, e.ExitCode())
+}
+
+func TestTenkiExecutor_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		step    core.Step
+		wantErr bool
+	}{
+		{
+			name: "When_no_command_or_script_then_should_return_nil",
+			step: core.Step{},
+		},
+		{
+			name:    "When_client_creation_fails_then_should_return_error",
+			step:    core.Step{Commands: []core.CommandEntry{{CmdWithArgs: "echo hi"}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear the env token so client creation fails locally without
+			// reaching the API.
+			t.Setenv("TENKI_API_KEY", "")
+			t.Setenv("TENKI_AUTH_TOKEN", "")
+
+			e := &tenkiExecutor{step: tt.step, stdout: &bytes.Buffer{}, stderr: &bytes.Buffer{}}
+			err := e.Run(context.Background())
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestTenkiExecutor_CreateOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config
+		want int
+	}{
+		{
+			name: "When_config_is_minimal_then_should_only_set_wait_ready",
+			cfg:  config{},
+			want: 1,
+		},
+		{
+			name: "When_all_fields_are_set_then_should_add_one_option_each",
+			cfg: config{
+				Name:        "my-sandbox",
+				Image:       "ubuntu",
+				CPUCores:    2,
+				MemoryMB:    4096,
+				MaxDuration: time.Hour,
+				Env:         []string{"A=1"},
+				ProjectID:   "proj-1",
+				WorkspaceID: "ws-1",
+			},
+			want: 9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env fallbacks so the option count depends only on cfg.
+			t.Setenv("TENKI_PROJECT_ID", "")
+			t.Setenv("TENKI_WORKSPACE_ID", "")
+
+			e := &tenkiExecutor{cfg: tt.cfg}
+			assert.Len(t, e.createOptions(), tt.want)
+		})
+	}
+}
+
+func TestTenkiExecutor_Kill(t *testing.T) {
+	tests := []struct {
+		name       string
+		closed     bool
+		wantCancel bool
+	}{
+		{
+			name:       "When_already_closed_then_should_be_noop",
+			closed:     true,
+			wantCancel: false,
+		},
+		{
+			name:       "When_not_closed_and_no_owned_session_then_should_cancel",
+			closed:     false,
+			wantCancel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cancelled := false
+			e := &tenkiExecutor{closed: tt.closed, cancel: func() { cancelled = true }}
+			require.NoError(t, e.Kill(nil))
+			assert.Equal(t, tt.wantCancel, cancelled)
+		})
+	}
+}
+
+func TestTenkiExecutor_NewClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config
+		wantErr bool
+	}{
+		{
+			name: "When_api_key_is_set_then_should_create_client",
+			cfg:  config{APIKey: "tk_test"},
+		},
+		{
+			name: "When_api_url_is_set_then_should_create_client",
+			cfg:  config{APIKey: "tk_test", APIURL: "https://api.example.com"},
+		},
+		{
+			name:    "When_auth_token_is_missing_then_should_return_error",
+			cfg:     config{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Isolate from any TENKI_* token in the environment so the missing
+			// token case is deterministic.
+			t.Setenv("TENKI_API_KEY", "")
+			t.Setenv("TENKI_AUTH_TOKEN", "")
+
+			e := &tenkiExecutor{cfg: tt.cfg}
+			got, err := e.newClient()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestTenkiExecutor_ResolveShell(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       config
+		step      core.Step
+		wantShell string
+		wantArgs  []string
+	}{
+		{
+			name:      "When_config_shell_is_set_then_should_use_config_shell_and_args",
+			cfg:       config{Shell: "/bin/bash", ShellArgs: []string{"-o", "pipefail"}},
+			step:      core.Step{Shell: "/bin/zsh"},
+			wantShell: "/bin/bash",
+			wantArgs:  []string{"-o", "pipefail"},
+		},
+		{
+			name:      "When_only_step_shell_is_set_then_should_use_step_shell_and_args",
+			cfg:       config{},
+			step:      core.Step{Shell: "/bin/zsh", ShellArgs: []string{"-e"}},
+			wantShell: "/bin/zsh",
+			wantArgs:  []string{"-e"},
+		},
+		{
+			name:      "When_no_shell_is_set_then_should_use_default",
+			cfg:       config{},
+			step:      core.Step{},
+			wantShell: defaultShell,
+			wantArgs:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &tenkiExecutor{step: tt.step, cfg: tt.cfg}
+			shell, args := e.resolveShell()
+			assert.Equal(t, tt.wantShell, shell)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
+}
+
+func TestTenkiExecutor_WorkingDir(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config
+		step core.Step
+		want string
+	}{
+		{
+			name: "When_config_working_dir_is_set_then_should_use_config_dir",
+			cfg:  config{WorkingDir: "/home/tenki/a"},
+			step: core.Step{Dir: "/home/tenki/b"},
+			want: "/home/tenki/a",
+		},
+		{
+			name: "When_only_step_dir_is_set_then_should_use_step_dir",
+			cfg:  config{},
+			step: core.Step{Dir: "/home/tenki/b"},
+			want: "/home/tenki/b",
+		},
+		{
+			name: "When_no_dir_is_set_then_should_return_empty",
+			cfg:  config{},
+			step: core.Step{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &tenkiExecutor{step: tt.step, cfg: tt.cfg}
+			assert.Equal(t, tt.want, e.workingDir())
+		})
+	}
+}
+
+func TestTenkiExecutor_ExecEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config
+		step core.Step
+		want map[string]string
+	}{
+		{
+			name: "When_session_and_step_env_set_then_step_env_wins",
+			cfg:  config{Env: []string{"A=1", "B=2"}},
+			step: core.Step{Env: []string{"B=override", "C=3"}},
+			want: map[string]string{"A": "1", "B": "override", "C": "3"},
+		},
+		{
+			name: "When_no_env_set_then_should_return_nil",
+			cfg:  config{},
+			step: core.Step{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &tenkiExecutor{step: tt.step, cfg: tt.cfg}
+			assert.Equal(t, tt.want, e.execEnv())
+		})
+	}
+}
+
+func TestTenkiExecutor_BuildScript(t *testing.T) {
+	tests := []struct {
+		name string
+		step core.Step
+		want string
+	}{
+		{
+			name: "When_script_is_set_then_should_wrap_script",
+			step: core.Step{Script: "echo hi"},
+			want: "set -e\necho hi\n",
+		},
+		{
+			name: "When_script_ends_with_newline_then_should_not_add_extra_newline",
+			step: core.Step{Script: "echo hi\n"},
+			want: "set -e\necho hi\n",
+		},
+		{
+			name: "When_single_command_then_should_render_command",
+			step: core.Step{Commands: []core.CommandEntry{{CmdWithArgs: "echo hello"}}},
+			want: "set -e\necho hello\n",
+		},
+		{
+			name: "When_multiple_commands_then_should_render_each_line",
+			step: core.Step{Commands: []core.CommandEntry{
+				{CmdWithArgs: "echo one"},
+				{CmdWithArgs: "echo two"},
+			}},
+			want: "set -e\necho one\necho two\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &tenkiExecutor{step: tt.step}
+			assert.Equal(t, tt.want, e.buildScript())
+		})
+	}
+}
+
+func TestCommandString(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  core.CommandEntry
+		want string
+	}{
+		{
+			name: "When_cmd_with_args_is_set_then_should_use_original_string",
+			cmd:  core.CommandEntry{Command: "echo", Args: []string{"hi"}, CmdWithArgs: "echo $FOO"},
+			want: "echo $FOO",
+		},
+		{
+			name: "When_only_command_then_should_return_command",
+			cmd:  core.CommandEntry{Command: "ls"},
+			want: "ls",
+		},
+		{
+			name: "When_command_and_args_then_should_quote_args",
+			cmd:  core.CommandEntry{Command: "echo", Args: []string{"a b"}},
+			want: "echo 'a b'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commandString(tt.cmd))
+		})
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{
+			name:   "When_first_value_is_set_then_should_return_first",
+			values: []string{"a", "b"},
+			want:   "a",
+		},
+		{
+			name:   "When_first_is_empty_then_should_fall_back_to_next",
+			values: []string{"", "b"},
+			want:   "b",
+		},
+		{
+			name:   "When_first_is_whitespace_then_should_fall_back_to_next",
+			values: []string{"   ", "b"},
+			want:   "b",
+		},
+		{
+			name:   "When_all_values_are_empty_then_should_return_empty",
+			values: []string{"", "  "},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstNonEmpty(tt.values...))
+		})
+	}
+}
+
+func TestEnvSliceToMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    map[string]string
+	}{
+		{
+			name:    "When_entries_are_empty_then_should_return_nil",
+			entries: nil,
+			want:    nil,
+		},
+		{
+			name:    "When_entries_are_valid_then_should_map_pairs",
+			entries: []string{"A=1", "B=2"},
+			want:    map[string]string{"A": "1", "B": "2"},
+		},
+		{
+			name:    "When_some_entries_are_malformed_then_should_skip_them",
+			entries: []string{"NOEQUAL", "=novalue", "C=3"},
+			want:    map[string]string{"C": "3"},
+		},
+		{
+			name:    "When_all_entries_are_malformed_then_should_return_nil",
+			entries: []string{"NOEQUAL", "=novalue"},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, envSliceToMap(tt.entries))
+		})
+	}
+}
+
+func TestCleanupTimeoutOf(t *testing.T) {
+	tests := []struct {
+		name string
+		env  runtime.Env
+		want time.Duration
+	}{
+		{
+			name: "When_dag_sets_max_cleanup_time_then_should_return_it",
+			env:  runtime.Env{Context: exec.Context{DAG: &core.DAG{MaxCleanUpTime: 5 * time.Second}}},
+			want: 5 * time.Second,
+		},
+		{
+			name: "When_dag_max_cleanup_time_is_zero_then_should_return_zero",
+			env:  runtime.Env{Context: exec.Context{DAG: &core.DAG{}}},
+			want: 0,
+		},
+		{
+			name: "When_dag_is_nil_then_should_return_zero",
+			env:  runtime.Env{},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cleanupTimeoutOf(tt.env))
+		})
+	}
+}
+
+func TestWithCleanupTimeout(t *testing.T) {
+	t.Run("When_timeout_is_positive_then_should_bound_the_context", func(t *testing.T) {
+		ctx, cancel := withCleanupTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, ok := ctx.Deadline()
+		assert.True(t, ok)
+	})
+
+	t.Run("When_timeout_is_zero_then_should_leave_the_context_unbounded", func(t *testing.T) {
+		base := context.Background()
+		ctx, cancel := withCleanupTimeout(base, 0)
+		defer cancel()
+		assert.Equal(t, base, ctx)
+		_, ok := ctx.Deadline()
+		assert.False(t, ok)
+	})
+}
+
+func TestHasShellConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		step core.Step
+		want bool
+	}{
+		{
+			name: "When_config_shell_is_set_then_should_return_true",
+			step: core.Step{ExecutorConfig: core.ExecutorConfig{Config: map[string]any{"shell": "/bin/bash"}}},
+			want: true,
+		},
+		{
+			name: "When_only_step_shell_is_set_then_should_return_true",
+			step: core.Step{Shell: "/bin/bash"},
+			want: true,
+		},
+		{
+			name: "When_no_shell_is_set_then_should_return_false",
+			step: core.Step{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasShellConfigured(tt.step))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `tenki` executor that runs a step's command or script inside an ephemeral [Tenki Cloud](https://tenki.cloud) sandbox (microVM). The sandbox is created on demand, the command runs with stdout/stderr streamed back live, and the sandbox is terminated when the step finishes.

Verified end-to-end against the Tenki API: sandbox created, command executed with injected env, output streamed back, and sandbox terminated on completion.

## Changes

- Add the `tenki` executor under `internal/runtime/builtin/tenki` (create sandbox -> run command/script with live streaming -> terminate).
- Support reusing an existing sandbox via `session_id` (left running) and the `tenki.run` action form.
- Config: `name`, `image`, `cpu_cores`, `memory_mb`, `env`, `working_dir`, `shell`/`shell_args`, `create_timeout`, `max_duration`, `keep_session`, `api_key`/`api_url`, `project_id`/`workspace_id`, with `TENKI_API_KEY` / `TENKI_PROJECT_ID` / `TENKI_WORKSPACE_ID` env fallbacks.
- Register the `tenki` executor type and `tenki.run` action; add JSON schema (`tenkiExecutorConfig`) and type/action branches in `dag.schema.json`.
- Add dependency `github.com/TenkiCloud/tenki-sdk-go/sandbox`.
- Unit tests for config parsing and the executor's non-SDK logic; add a README section.

## Testing

- `make check` (fmt, modernize, golangci-lint) and `go test -race` pass.
- The lifecycle paths that call the SDK directly (`resolveSession`/`exec`) are covered by the end-to-end run rather than mocks — consistent with the `ssh`/`docker` executors, since the Tenki Go SDK returns concrete types.

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tenki` executor and `tenki.run` action to run step commands/scripts inside ephemeral Tenki Cloud sandboxes with live stdout/stderr and safe, bounded teardown.

- **New Features**
  - New `type: tenki` executor and `tenki.run` action for sandboxed execution with output streaming and exit code propagation.
  - Session reuse and retention: `session_id` runs in an existing session; `keep_session` leaves new sessions running.
  - Configurable image, CPU/memory, env, working dir, shell/`shell_args`, `create_timeout`, `max_duration`, and auth/project/workspace with env fallbacks (`TENKI_API_KEY`, `TENKI_PROJECT_ID`, `TENKI_WORKSPACE_ID`, `TENKI_API_URL`). Includes JSON schema, registration, and README examples/tests.

- **Bug Fixes**
  - Bound cleanup when a sandbox fails to become ready using the DAG `MaxCleanUpTime` to prevent leaking sessions.

<sup>Written for commit 3ee520078102ac78d60433ec96237d1b571b46b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running workflow steps in ephemeral Tenki Cloud sandboxes using `type: tenki` or `tenki.run`.
  - Streams command output and reports execution status and errors.
  - Supports configurable images, resources, environment variables, timeouts, shells, working directories, and session reuse.
  - Allows existing sandboxes to remain active when configured.

- **Documentation**
  - Added Tenki sandbox workflow examples, credential configuration, and session reuse guidance.

- **Tests**
  - Added coverage for configuration parsing and sandbox execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->