### PR TITLE
feat: reconnect worker to coordinator after heartbeat timeout

### DIFF
--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -317,12 +317,13 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 		}
 
 		// Check if the coordinator is healthy
-		if err := cli.isHealthy(ctx, member); err != nil {
+		if err := cli.isHealthy(ctx, client); err != nil {
 			logger.Warn(ctx, "Failed to check coordinator health",
 				slog.String("coordinator-id", member.ID),
 				tag.Host(member.Host),
 				tag.Port(member.Port),
 				tag.Error(err))
+			cli.resetClientOnTransientError(member, client, err)
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -341,6 +342,7 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 			if errors.Is(err, backoff.ErrPermanent) {
 				return err
 			}
+			cli.resetClientOnTransientError(member, client, err)
 
 			lastErr = err
 		} else {
@@ -523,13 +525,7 @@ func (cli *clientImpl) callMemberWithTimeout(ctx context.Context, member exec.Ho
 	return cli.callMember(callCtx, member, callback)
 }
 
-func (cli *clientImpl) isHealthy(ctx context.Context, member exec.HostInfo) error {
-	// Get or create client for this coordinator
-	client, err := cli.getOrCreateClient(member)
-	if err != nil {
-		return fmt.Errorf("failed to get coordinator client: %w", err)
-	}
-
+func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	// Check health
 	req := &grpc_health_v1.HealthCheckRequest{
 		Service: "", // Check overall server health
@@ -605,14 +601,31 @@ func (cli *clientImpl) createClient(member exec.HostInfo) (*client, error) {
 
 // removeClient removes a client from the cache
 func (cli *clientImpl) removeClient(member exec.HostInfo) {
+	cli.removeClientIfCurrent(member, nil)
+}
+
+// removeClientIfCurrent removes the cached client for member. A non-nil
+// failedClient restricts removal to that instance, so a replacement created
+// by a concurrent caller is preserved.
+func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient *client) {
 	key := coordinatorMemberKey(member)
 
 	cli.clientsMu.Lock()
 	defer cli.clientsMu.Unlock()
 
-	if c, exists := cli.clients[key]; exists {
-		_ = c.conn.Close()
-		delete(cli.clients, key)
+	current, exists := cli.clients[key]
+	if !exists || (failedClient != nil && current != failedClient) {
+		return
+	}
+	_ = current.conn.Close()
+	delete(cli.clients, key)
+}
+
+// resetClientOnTransientError drops the cached client so the next call
+// re-dials, when err indicates the connection may be stale.
+func (cli *clientImpl) resetClientOnTransientError(member exec.HostInfo, failedClient *client, err error) {
+	if errors.Is(err, context.DeadlineExceeded) || shouldRefreshPinnedStateCoordinator(err) {
+		cli.removeClientIfCurrent(member, failedClient)
 	}
 }
 
@@ -811,6 +824,12 @@ func selectAuthoritativeWorker(current, candidate *coordinatorv1.WorkerInfo) *co
 
 // Heartbeat sends a heartbeat to coordinators and returns the response
 func (cli *clientImpl) Heartbeat(ctx context.Context, req *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+	if cli.config.HeartbeatTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cli.config.HeartbeatTimeout)
+		defer cancel()
+	}
+
 	members, err := cli.getCoordinatorMembers(ctx)
 	if err != nil {
 		return nil, err
@@ -943,7 +962,7 @@ func openStreamWithFailover[T any](
 			lastErr = err
 			continue
 		}
-		if err := cli.isHealthy(ctx, member); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -1105,7 +1124,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue
 		}
-		if err := cli.isHealthy(ctx, member); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q is unhealthy: %w", member.ID, err))
 			continue
 		}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -140,6 +140,7 @@ type pinnedStateCoordinator struct {
 // it should be closed and removed when no longer needed or when the coordinator
 // is unhealthy.
 type client struct {
+	address      string
 	conn         *grpc.ClientConn
 	client       coordinatorv1.CoordinatorServiceClient
 	healthClient grpc_health_v1.HealthClient
@@ -310,14 +311,13 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 				tag.Host(member.Host),
 				tag.Port(member.Port),
 				tag.Error(err))
-			cli.removeClient(member) // Remove failed client
 			cli.recordFailure(err)
 			lastErr = err
 			continue
 		}
 
 		// Check if the coordinator is healthy
-		if err := cli.checkHealthy(ctx, member, client); err != nil {
+		if err := cli.isHealthy(ctx, client); err != nil {
 			logger.Warn(ctx, "Failed to check coordinator health",
 				slog.String("coordinator-id", member.ID),
 				tag.Host(member.Host),
@@ -341,8 +341,6 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 			if errors.Is(err, backoff.ErrPermanent) {
 				return err
 			}
-			cli.resetClientOnTransientError(member, client, err)
-
 			lastErr = err
 		} else {
 			// Success - record and return immediately
@@ -362,11 +360,13 @@ func (cli *clientImpl) callPinnedStateCoordinator(ctx context.Context, routingKe
 		return err
 	}
 
+	var failedClient *client
 	err = cli.callMemberWithTimeout(ctx, member, func(ctx context.Context, client *client) error {
+		failedClient = client
 		return callback(ctx, member, client)
 	})
 	if shouldRefreshPinnedStateCoordinator(err) {
-		cli.removeClient(member)
+		cli.removeClientIfCurrent(member, failedClient)
 		cli.refreshPinnedStateCoordinator(ctx, routingKey, member)
 	}
 	return err
@@ -506,7 +506,7 @@ func (cli *clientImpl) callMember(ctx context.Context, member exec.HostInfo, cal
 	if err := callback(ctx, client); err != nil {
 		cli.recordFailure(err)
 		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
-			cli.removeClient(member)
+			cli.removeClientIfCurrent(member, client)
 		}
 		return err
 	}
@@ -542,26 +542,14 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	return nil
 }
 
-// checkHealthy verifies the coordinator is serving and evicts the cached
-// client when the failure indicates a stale connection.
-func (cli *clientImpl) checkHealthy(ctx context.Context, member exec.HostInfo, client *client) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if err := cli.isHealthy(ctx, client); err != nil {
-		cli.resetClientOnTransientError(member, client, err)
-		return err
-	}
-	return nil
-}
-
 // getOrCreateClient gets an existing client or creates a new one for the given member
 func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) {
 	key := coordinatorMemberKey(member)
+	address := coordinatorAddress(member)
 
 	// Try to get existing client with read lock
 	cli.clientsMu.RLock()
-	if c, exists := cli.clients[key]; exists {
+	if c, exists := cli.clients[key]; exists && c.address == address {
 		cli.clientsMu.RUnlock()
 		return c, nil
 	}
@@ -572,7 +560,7 @@ func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) 
 	defer cli.clientsMu.Unlock()
 
 	// Double-check after acquiring write lock
-	if c, exists := cli.clients[key]; exists {
+	if c, exists := cli.clients[key]; exists && c.address == address {
 		return c, nil
 	}
 
@@ -580,6 +568,10 @@ func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) 
 	c, err := cli.createClient(member)
 	if err != nil {
 		return nil, err
+	}
+
+	if stale, exists := cli.clients[key]; exists {
+		_ = stale.conn.Close()
 	}
 
 	// Cache it
@@ -596,7 +588,7 @@ func (cli *clientImpl) createClient(member exec.HostInfo) (*client, error) {
 	}
 
 	// Construct address from host and port
-	address := net.JoinHostPort(member.Host, strconv.Itoa(member.Port))
+	address := coordinatorAddress(member)
 
 	// Create gRPC connection
 	conn, err := grpc.NewClient(address, dialOpts...)
@@ -605,20 +597,13 @@ func (cli *clientImpl) createClient(member exec.HostInfo) (*client, error) {
 	}
 
 	return &client{
+		address:      address,
 		conn:         conn,
 		client:       coordinatorv1.NewCoordinatorServiceClient(conn),
 		healthClient: grpc_health_v1.NewHealthClient(conn),
 	}, nil
 }
 
-// removeClient removes a client from the cache
-func (cli *clientImpl) removeClient(member exec.HostInfo) {
-	cli.removeClientIfCurrent(member, nil)
-}
-
-// removeClientIfCurrent removes the cached client for member. A non-nil
-// failedClient restricts removal to that instance, so a replacement created
-// by a concurrent caller is preserved.
 func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient *client) {
 	key := coordinatorMemberKey(member)
 
@@ -626,22 +611,11 @@ func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient 
 	defer cli.clientsMu.Unlock()
 
 	current, exists := cli.clients[key]
-	if !exists || (failedClient != nil && current != failedClient) {
+	if !exists || current != failedClient {
 		return
 	}
 	_ = current.conn.Close()
 	delete(cli.clients, key)
-}
-
-// resetClientOnTransientError drops the cached client so the next call
-// re-dials, when err indicates the connection may be stale. A deadline is a
-// stale signal alongside Unavailable: a coordinator that moved to a new address
-// under the same ID can leave the cached connection dialing an endpoint that
-// hangs rather than refusing, which surfaces as a timeout.
-func (cli *clientImpl) resetClientOnTransientError(member exec.HostInfo, failedClient *client, err error) {
-	if errors.Is(err, context.DeadlineExceeded) || shouldRefreshPinnedStateCoordinator(err) {
-		cli.removeClientIfCurrent(member, failedClient)
-	}
 }
 
 // Cleanup cleans up all connections
@@ -745,7 +719,7 @@ func (cli *clientImpl) GetWorkers(ctx context.Context) ([]*coordinatorv1.WorkerI
 
 			// If this is a connection error, remove the client from cache
 			if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
-				cli.removeClient(member)
+				cli.removeClientIfCurrent(member, c)
 			}
 			continue
 		}
@@ -822,6 +796,10 @@ func coordinatorMemberKey(member exec.HostInfo) string {
 		return member.ID
 	}
 	return fmt.Sprintf("%s:%d", member.Host, member.Port)
+}
+
+func coordinatorAddress(member exec.HostInfo) string {
+	return net.JoinHostPort(member.Host, strconv.Itoa(member.Port))
 }
 
 func selectAuthoritativeWorker(current, candidate *coordinatorv1.WorkerInfo) *coordinatorv1.WorkerInfo {
@@ -977,7 +955,7 @@ func openStreamWithFailover[T any](
 			lastErr = err
 			continue
 		}
-		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -1139,7 +1117,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue
 		}
-		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q is unhealthy: %w", member.ID, err))
 			continue
 		}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -321,7 +321,7 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 		}
 
 		// Check if the coordinator is healthy
-		if err := cli.isHealthy(ctx, client); err != nil {
+		if err := cli.checkHealthy(ctx, member, client); err != nil {
 			logger.Warn(ctx, "Failed to check coordinator health",
 				slog.String("coordinator-id", member.ID),
 				tag.Host(member.Host),
@@ -345,6 +345,7 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 			if errors.Is(err, backoff.ErrPermanent) {
 				return err
 			}
+			cli.resetClientOnTransientError(member, client, err)
 			lastErr = err
 		} else {
 			// Success - record and return immediately
@@ -546,6 +547,17 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	return nil
 }
 
+func (cli *clientImpl) checkHealthy(ctx context.Context, member exec.HostInfo, client *client) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := cli.isHealthy(ctx, client); err != nil {
+		cli.resetClientOnTransientError(member, client, err)
+		return err
+	}
+	return nil
+}
+
 // getOrCreateClient gets a client for the member without changing the cached address.
 func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) {
 	return cli.getOrCreateClientWithAddressRefresh(member, false)
@@ -629,6 +641,13 @@ func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient 
 	}
 	_ = current.conn.Close()
 	delete(cli.clients, key)
+}
+
+// resetClientOnTransientError evicts a failed cached client whose transport may be stale.
+func (cli *clientImpl) resetClientOnTransientError(member exec.HostInfo, failedClient *client, err error) {
+	if errors.Is(err, context.DeadlineExceeded) || shouldRefreshPinnedStateCoordinator(err) {
+		cli.removeClientIfCurrent(member, failedClient)
+	}
 }
 
 // Cleanup cleans up all connections
@@ -968,7 +987,7 @@ func openStreamWithFailover[T any](
 			lastErr = err
 			continue
 		}
-		if err := cli.isHealthy(ctx, memberClient); err != nil {
+		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -977,6 +996,7 @@ func openStreamWithFailover[T any](
 		stream, err := open(ctx, memberClient)
 		if err != nil {
 			cli.recordFailure(err)
+			cli.resetClientOnTransientError(member, memberClient, err)
 			lastErr = err
 			continue
 		}
@@ -1130,7 +1150,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue
 		}
-		if err := cli.isHealthy(ctx, memberClient); err != nil {
+		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q is unhealthy: %w", member.ID, err))
 			continue
 		}
@@ -1138,6 +1158,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 		exists, err := hasWorkspaceBundleInMember(callCtx, memberClient, desc.Digest)
 		cancel()
 		if err != nil {
+			cli.resetClientOnTransientError(member, memberClient, err)
 			errs = append(errs, fmt.Errorf("check workspace bundle on coordinator %q: %w", member.ID, err))
 			continue
 		}
@@ -1150,6 +1171,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 		err = putWorkspaceBundleToMember(callCtx, memberClient, desc, data)
 		cancel()
 		if err != nil {
+			cli.resetClientOnTransientError(member, memberClient, err)
 			errs = append(errs, fmt.Errorf("upload workspace bundle to coordinator %q: %w", member.ID, err))
 			continue
 		}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -545,6 +545,9 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 // checkHealthy verifies the coordinator is serving and evicts the cached
 // client when the failure indicates a stale connection.
 func (cli *clientImpl) checkHealthy(ctx context.Context, member exec.HostInfo, client *client) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := cli.isHealthy(ctx, client); err != nil {
 		cli.resetClientOnTransientError(member, client, err)
 		return err

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -304,7 +304,7 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 	var lastErr error
 	for _, member := range members {
 		// Get or create client for this coordinator
-		client, err := cli.getOrCreateClient(member)
+		client, err := cli.getOrCreateDiscoveredClient(member)
 		if err != nil {
 			logger.Warn(ctx, "Failed to connect to coordinator",
 				slog.String("coordinator-id", member.ID),
@@ -542,14 +542,23 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	return nil
 }
 
-// getOrCreateClient gets an existing client or creates a new one for the given member
+// getOrCreateClient gets a client for the member without changing the cached address.
 func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) {
+	return cli.getOrCreateClientWithAddressRefresh(member, false)
+}
+
+// getOrCreateDiscoveredClient treats the discovered address as authoritative.
+func (cli *clientImpl) getOrCreateDiscoveredClient(member exec.HostInfo) (*client, error) {
+	return cli.getOrCreateClientWithAddressRefresh(member, true)
+}
+
+func (cli *clientImpl) getOrCreateClientWithAddressRefresh(member exec.HostInfo, refreshAddress bool) (*client, error) {
 	key := coordinatorMemberKey(member)
 	address := coordinatorAddress(member)
 
 	// Try to get existing client with read lock
 	cli.clientsMu.RLock()
-	if c, exists := cli.clients[key]; exists && c.address == address {
+	if c, exists := cli.clients[key]; exists && (!refreshAddress || c.address == address) {
 		cli.clientsMu.RUnlock()
 		return c, nil
 	}
@@ -560,7 +569,7 @@ func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) 
 	defer cli.clientsMu.Unlock()
 
 	// Double-check after acquiring write lock
-	if c, exists := cli.clients[key]; exists && c.address == address {
+	if c, exists := cli.clients[key]; exists && (!refreshAddress || c.address == address) {
 		return c, nil
 	}
 
@@ -696,7 +705,7 @@ func (cli *clientImpl) GetWorkers(ctx context.Context) ([]*coordinatorv1.WorkerI
 
 	for _, member := range members {
 		// Get or create client for this member
-		c, err := cli.getOrCreateClient(member)
+		c, err := cli.getOrCreateDiscoveredClient(member)
 		if err != nil {
 			logger.Warn(ctx, "Failed to connect to coordinator",
 				tag.ID(member.ID),
@@ -949,7 +958,7 @@ func openStreamWithFailover[T any](
 
 	var lastErr error
 	for _, member := range members {
-		memberClient, err := cli.getOrCreateClient(member)
+		memberClient, err := cli.getOrCreateDiscoveredClient(member)
 		if err != nil {
 			cli.recordFailure(err)
 			lastErr = err
@@ -1112,7 +1121,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 	var satisfied int
 	errs := make([]error, 0)
 	for _, member := range members {
-		memberClient, err := cli.getOrCreateClient(member)
+		memberClient, err := cli.getOrCreateDiscoveredClient(member)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -136,11 +136,11 @@ type pinnedStateCoordinator struct {
 	lastUsed  time.Time
 }
 
-// client holds the gRPC connection and clients for the coordinator service.
-// it should be closed and removed when no longer needed or when the coordinator
-// is unhealthy.
+// client holds the gRPC connection and clients for one coordinator endpoint.
+// The connection is closed when the endpoint is replaced or during cleanup.
 type client struct {
 	address      string
+	startedAt    time.Time
 	conn         *grpc.ClientConn
 	client       coordinatorv1.CoordinatorServiceClient
 	healthClient grpc_health_v1.HealthClient
@@ -321,7 +321,7 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 		}
 
 		// Check if the coordinator is healthy
-		if err := cli.checkHealthy(ctx, member, client); err != nil {
+		if err := cli.isHealthy(ctx, client); err != nil {
 			logger.Warn(ctx, "Failed to check coordinator health",
 				slog.String("coordinator-id", member.ID),
 				tag.Host(member.Host),
@@ -345,7 +345,6 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 			if errors.Is(err, backoff.ErrPermanent) {
 				return err
 			}
-			cli.resetClientOnTransientError(member, client, err)
 			lastErr = err
 		} else {
 			// Success - record and return immediately
@@ -365,13 +364,10 @@ func (cli *clientImpl) callPinnedStateCoordinator(ctx context.Context, routingKe
 		return err
 	}
 
-	var failedClient *client
 	err = cli.callMemberWithTimeout(ctx, member, func(ctx context.Context, client *client) error {
-		failedClient = client
 		return callback(ctx, member, client)
 	})
 	if shouldRefreshPinnedStateCoordinator(err) {
-		cli.removeClientIfCurrent(member, failedClient)
 		cli.refreshPinnedStateCoordinator(ctx, routingKey, member)
 	}
 	return err
@@ -398,6 +394,9 @@ func (cli *clientImpl) pinnedStateCoordinator(ctx context.Context, routingKey st
 
 	member, err := selectStateCoordinatorOwner(members, routingKey)
 	if err != nil {
+		return exec.HostInfo{}, err
+	}
+	if _, err := cli.getOrCreateDiscoveredClient(member); err != nil {
 		return exec.HostInfo{}, err
 	}
 
@@ -487,6 +486,16 @@ func (cli *clientImpl) refreshPinnedStateCoordinator(ctx context.Context, routin
 			break
 		}
 	}
+	if replacement != nil {
+		if _, err := cli.getOrCreateDiscoveredClient(*replacement); err != nil {
+			logger.Debug(ctx, "Failed to refresh pinned state coordinator client",
+				slog.String("coordinator-id", replacement.ID),
+				tag.Host(replacement.Host),
+				tag.Port(replacement.Port),
+				tag.Error(err))
+			return
+		}
+	}
 
 	cli.stateCoordinatorMu.Lock()
 	defer cli.stateCoordinatorMu.Unlock()
@@ -510,9 +519,6 @@ func (cli *clientImpl) callMember(ctx context.Context, member exec.HostInfo, cal
 	}
 	if err := callback(ctx, client); err != nil {
 		cli.recordFailure(err)
-		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
-			cli.removeClientIfCurrent(member, client)
-		}
 		return err
 	}
 	cli.recordSuccess(ctx)
@@ -547,17 +553,6 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	return nil
 }
 
-func (cli *clientImpl) checkHealthy(ctx context.Context, member exec.HostInfo, client *client) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if err := cli.isHealthy(ctx, client); err != nil {
-		cli.resetClientOnTransientError(member, client, err)
-		return err
-	}
-	return nil
-}
-
 // getOrCreateClient gets a client for the member without changing the cached address.
 func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) {
 	return cli.getOrCreateClientWithAddressRefresh(member, false)
@@ -574,7 +569,10 @@ func (cli *clientImpl) getOrCreateClientWithAddressRefresh(member exec.HostInfo,
 
 	// Try to get existing client with read lock
 	cli.clientsMu.RLock()
-	if c, exists := cli.clients[key]; exists && (!refreshAddress || c.address == address) {
+	if c, exists := cli.clients[key]; exists &&
+		(!refreshAddress ||
+			isOlderCoordinatorIncarnation(member.StartedAt, c.startedAt) ||
+			(c.address == address && !member.StartedAt.After(c.startedAt))) {
 		cli.clientsMu.RUnlock()
 		return c, nil
 	}
@@ -585,14 +583,25 @@ func (cli *clientImpl) getOrCreateClientWithAddressRefresh(member exec.HostInfo,
 	defer cli.clientsMu.Unlock()
 
 	// Double-check after acquiring write lock
-	if c, exists := cli.clients[key]; exists && (!refreshAddress || c.address == address) {
-		return c, nil
+	if c, exists := cli.clients[key]; exists {
+		if !refreshAddress || isOlderCoordinatorIncarnation(member.StartedAt, c.startedAt) {
+			return c, nil
+		}
+		if c.address == address {
+			if member.StartedAt.After(c.startedAt) {
+				c.startedAt = member.StartedAt
+			}
+			return c, nil
+		}
 	}
 
 	// Create new client
 	c, err := cli.createClient(member)
 	if err != nil {
 		return nil, err
+	}
+	if refreshAddress {
+		c.startedAt = member.StartedAt
 	}
 
 	if stale, exists := cli.clients[key]; exists {
@@ -602,6 +611,10 @@ func (cli *clientImpl) getOrCreateClientWithAddressRefresh(member exec.HostInfo,
 	// Cache it
 	cli.clients[key] = c
 	return c, nil
+}
+
+func isOlderCoordinatorIncarnation(candidate, current time.Time) bool {
+	return !candidate.IsZero() && !current.IsZero() && candidate.Before(current)
 }
 
 // createClient creates a new gRPC client for the given coordinator
@@ -627,27 +640,6 @@ func (cli *clientImpl) createClient(member exec.HostInfo) (*client, error) {
 		client:       coordinatorv1.NewCoordinatorServiceClient(conn),
 		healthClient: grpc_health_v1.NewHealthClient(conn),
 	}, nil
-}
-
-func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient *client) {
-	key := coordinatorMemberKey(member)
-
-	cli.clientsMu.Lock()
-	defer cli.clientsMu.Unlock()
-
-	current, exists := cli.clients[key]
-	if !exists || current != failedClient {
-		return
-	}
-	_ = current.conn.Close()
-	delete(cli.clients, key)
-}
-
-// resetClientOnTransientError evicts a failed cached client whose transport may be stale.
-func (cli *clientImpl) resetClientOnTransientError(member exec.HostInfo, failedClient *client, err error) {
-	if errors.Is(err, context.DeadlineExceeded) || shouldRefreshPinnedStateCoordinator(err) {
-		cli.removeClientIfCurrent(member, failedClient)
-	}
 }
 
 // Cleanup cleans up all connections
@@ -748,11 +740,6 @@ func (cli *clientImpl) GetWorkers(ctx context.Context) ([]*coordinatorv1.WorkerI
 				tag.Port(member.Port),
 				tag.Error(err))
 			lastErr = err
-
-			// If this is a connection error, remove the client from cache
-			if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
-				cli.removeClientIfCurrent(member, c)
-			}
 			continue
 		}
 		successfulReads = true
@@ -861,15 +848,41 @@ func (cli *clientImpl) Heartbeat(ctx context.Context, req *coordinatorv1.Heartbe
 	}
 
 	var resp *coordinatorv1.HeartbeatResponse
-	err = cli.attemptCall(ctx, members, func(ctx context.Context, _ exec.HostInfo, client *client) error {
-		var callErr error
-		resp, callErr = client.client.Heartbeat(ctx, req)
+	call := func(ctx context.Context, _ exec.HostInfo, client *client) error {
+		callResp, callErr := client.client.Heartbeat(ctx, req)
 		if callErr != nil {
 			return fmt.Errorf("heartbeat failed: %w", callErr)
 		}
+		resp = callResp
 		return nil
+	}
+
+	deadline, hasDeadline := ctx.Deadline()
+	if !hasDeadline || len(members) == 1 {
+		err = cli.attemptCall(ctx, members, call)
+		return resp, err
+	}
+
+	rand.Shuffle(len(members), func(i, j int) {
+		members[i], members[j] = members[j], members[i]
 	})
-	return resp, err
+
+	var lastErr error
+	for i := range members {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		remainingAttempts := len(members) - i
+		attemptTimeout := time.Until(deadline) / time.Duration(remainingAttempts)
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		lastErr = cli.attemptCall(attemptCtx, members[i:i+1], call)
+		cancel()
+		if lastErr == nil {
+			return resp, nil
+		}
+	}
+	return nil, lastErr
 }
 
 func (cli *clientImpl) AckTaskClaimTo(ctx context.Context, owner exec.HostInfo, req *coordinatorv1.AckTaskClaimRequest) (*coordinatorv1.AckTaskClaimResponse, error) {
@@ -987,7 +1000,7 @@ func openStreamWithFailover[T any](
 			lastErr = err
 			continue
 		}
-		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -996,7 +1009,6 @@ func openStreamWithFailover[T any](
 		stream, err := open(ctx, memberClient)
 		if err != nil {
 			cli.recordFailure(err)
-			cli.resetClientOnTransientError(member, memberClient, err)
 			lastErr = err
 			continue
 		}
@@ -1150,7 +1162,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue
 		}
-		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
+		if err := cli.isHealthy(ctx, memberClient); err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q is unhealthy: %w", member.ID, err))
 			continue
 		}
@@ -1158,7 +1170,6 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 		exists, err := hasWorkspaceBundleInMember(callCtx, memberClient, desc.Digest)
 		cancel()
 		if err != nil {
-			cli.resetClientOnTransientError(member, memberClient, err)
 			errs = append(errs, fmt.Errorf("check workspace bundle on coordinator %q: %w", member.ID, err))
 			continue
 		}
@@ -1171,7 +1182,6 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 		err = putWorkspaceBundleToMember(callCtx, memberClient, desc, data)
 		cancel()
 		if err != nil {
-			cli.resetClientOnTransientError(member, memberClient, err)
 			errs = append(errs, fmt.Errorf("upload workspace bundle to coordinator %q: %w", member.ID, err))
 			continue
 		}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -317,13 +317,12 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 		}
 
 		// Check if the coordinator is healthy
-		if err := cli.isHealthy(ctx, client); err != nil {
+		if err := cli.checkHealthy(ctx, member, client); err != nil {
 			logger.Warn(ctx, "Failed to check coordinator health",
 				slog.String("coordinator-id", member.ID),
 				tag.Host(member.Host),
 				tag.Port(member.Port),
 				tag.Error(err))
-			cli.resetClientOnTransientError(member, client, err)
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -543,6 +542,16 @@ func (cli *clientImpl) isHealthy(ctx context.Context, client *client) error {
 	return nil
 }
 
+// checkHealthy verifies the coordinator is serving and evicts the cached
+// client when the failure indicates a stale connection.
+func (cli *clientImpl) checkHealthy(ctx context.Context, member exec.HostInfo, client *client) error {
+	if err := cli.isHealthy(ctx, client); err != nil {
+		cli.resetClientOnTransientError(member, client, err)
+		return err
+	}
+	return nil
+}
+
 // getOrCreateClient gets an existing client or creates a new one for the given member
 func (cli *clientImpl) getOrCreateClient(member exec.HostInfo) (*client, error) {
 	key := coordinatorMemberKey(member)
@@ -622,7 +631,10 @@ func (cli *clientImpl) removeClientIfCurrent(member exec.HostInfo, failedClient 
 }
 
 // resetClientOnTransientError drops the cached client so the next call
-// re-dials, when err indicates the connection may be stale.
+// re-dials, when err indicates the connection may be stale. A deadline is a
+// stale signal alongside Unavailable: a coordinator that moved to a new address
+// under the same ID can leave the cached connection dialing an endpoint that
+// hangs rather than refusing, which surfaces as a timeout.
 func (cli *clientImpl) resetClientOnTransientError(member exec.HostInfo, failedClient *client, err error) {
 	if errors.Is(err, context.DeadlineExceeded) || shouldRefreshPinnedStateCoordinator(err) {
 		cli.removeClientIfCurrent(member, failedClient)
@@ -962,7 +974,7 @@ func openStreamWithFailover[T any](
 			lastErr = err
 			continue
 		}
-		if err := cli.isHealthy(ctx, memberClient); err != nil {
+		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
 			cli.recordFailure(err)
 			lastErr = err
 			continue
@@ -1124,7 +1136,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			errs = append(errs, fmt.Errorf("coordinator %q: %w", member.ID, err))
 			continue
 		}
-		if err := cli.isHealthy(ctx, memberClient); err != nil {
+		if err := cli.checkHealthy(ctx, member, memberClient); err != nil {
 			errs = append(errs, fmt.Errorf("coordinator %q is unhealthy: %w", member.ID, err))
 			continue
 		}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -303,6 +303,10 @@ func (cli *clientImpl) attemptCall(ctx context.Context, members []exec.HostInfo,
 	// Try each coordinator in order (round-robin style)
 	var lastErr error
 	for _, member := range members {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		// Get or create client for this coordinator
 		client, err := cli.getOrCreateDiscoveredClient(member)
 		if err != nil {

--- a/internal/service/coordinator/client_internal_test.go
+++ b/internal/service/coordinator/client_internal_test.go
@@ -111,12 +111,5 @@ func TestClientCacheUsesDerivedKeyForEmptyCoordinatorIDs(t *testing.T) {
 	require.Len(t, cli.clients, 2)
 	require.Contains(t, cli.clients, coordinatorMemberKey(member1))
 	require.Contains(t, cli.clients, coordinatorMemberKey(member2))
-
-	cli.removeClientIfCurrent(member1, client1)
-	require.Len(t, cli.clients, 1)
-	require.NotContains(t, cli.clients, coordinatorMemberKey(member1))
-	require.Contains(t, cli.clients, coordinatorMemberKey(member2))
-
-	cli.removeClientIfCurrent(member2, client2)
-	require.Empty(t, cli.clients)
+	require.NoError(t, cli.Cleanup(t.Context()))
 }

--- a/internal/service/coordinator/client_internal_test.go
+++ b/internal/service/coordinator/client_internal_test.go
@@ -112,11 +112,11 @@ func TestClientCacheUsesDerivedKeyForEmptyCoordinatorIDs(t *testing.T) {
 	require.Contains(t, cli.clients, coordinatorMemberKey(member1))
 	require.Contains(t, cli.clients, coordinatorMemberKey(member2))
 
-	cli.removeClient(member1)
+	cli.removeClientIfCurrent(member1, client1)
 	require.Len(t, cli.clients, 1)
 	require.NotContains(t, cli.clients, coordinatorMemberKey(member1))
 	require.Contains(t, cli.clients, coordinatorMemberKey(member2))
 
-	cli.removeClient(member2)
+	cli.removeClientIfCurrent(member2, client2)
 	require.Empty(t, cli.clients)
 }

--- a/internal/service/coordinator/client_state_internal_test.go
+++ b/internal/service/coordinator/client_state_internal_test.go
@@ -54,9 +54,11 @@ func TestPinnedStateCoordinatorUsesDeterministicOwnerWithoutHealthFailover(t *te
 	cli := &clientImpl{
 		config:            DefaultConfig(),
 		registry:          staticStateRegistry{members: members},
+		clients:           make(map[string]*client),
 		stateCoordinators: make(map[string]pinnedStateCoordinator),
 		state:             &Metrics{IsConnected: true},
 	}
+	t.Cleanup(func() { require.NoError(t, cli.Cleanup(t.Context())) })
 
 	pinned, err := cli.pinnedStateCoordinator(context.Background(), key)
 	require.NoError(t, err)

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -1088,6 +1090,65 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, oldReports.Load())
 	assert.Equal(t, int32(1), newReports.Load())
+}
+
+func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+
+	var peerMu sync.Mutex
+	var initialPeer string
+	var reconnectedHeartbeats atomic.Int32
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			peerInfo, ok := peer.FromContext(ctx)
+			if !ok {
+				return nil, status.Error(codes.Internal, "missing peer information")
+			}
+
+			peerMu.Lock()
+			if initialPeer == "" {
+				initialPeer = peerInfo.Addr.String()
+				peerMu.Unlock()
+				return &coordinatorv1.HeartbeatResponse{}, nil
+			}
+			sameConnection := initialPeer == peerInfo.Addr.String()
+			peerMu.Unlock()
+
+			if sameConnection {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+
+			reconnectedHeartbeats.Add(1)
+			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+	}
+	server, addr := startMockServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: exec.ServiceStatusActive}},
+	}
+	client := coordinator.New(monitor, config)
+
+	request := &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"}
+	_, err := client.Heartbeat(context.Background(), request)
+	require.NoError(t, err)
+
+	stalledCtx, cancelStalled := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	_, err = client.Heartbeat(stalledCtx, request)
+	cancelStalled()
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	recoveredCtx, cancelRecovered := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelRecovered()
+	_, err = client.Heartbeat(recoveredCtx, request)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), reconnectedHeartbeats.Load())
 }
 
 func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -5,10 +5,10 @@ package coordinator_test
 
 import (
 	"context"
+	"io"
 	"net"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -1035,14 +1034,21 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	config := coordinator.DefaultConfig()
 	config.MaxRetries = 0
 
+	var oldHeartbeats atomic.Int32
 	var oldReports atomic.Int32
+	var oldPuts atomic.Int32
 	oldCoord := &mockCoordinatorService{
 		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			oldHeartbeats.Add(1)
 			return &coordinatorv1.HeartbeatResponse{}, nil
 		},
 		reportStatusFunc: func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
 			oldReports.Add(1)
 			return &coordinatorv1.ReportStatusResponse{}, nil
+		},
+		putStateFunc: func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error) {
+			oldPuts.Add(1)
+			return &coordinatorv1.PutStateResponse{}, nil
 		},
 	}
 	oldServer, oldAddr := startMockServer(t, oldCoord)
@@ -1050,6 +1056,7 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 
 	var newHeartbeats atomic.Int32
 	var newReports atomic.Int32
+	var newPuts atomic.Int32
 	newCoord := &mockCoordinatorService{
 		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
 			newHeartbeats.Add(1)
@@ -1059,14 +1066,19 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 			newReports.Add(1)
 			return &coordinatorv1.ReportStatusResponse{}, nil
 		},
+		putStateFunc: func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error) {
+			newPuts.Add(1)
+			return &coordinatorv1.PutStateResponse{}, nil
+		},
 	}
 	newServer, newAddr := startMockServer(t, newCoord)
 	defer newServer.Stop()
 
 	oldHost, oldPort := parseHostPort(oldAddr)
 	newHost, newPort := parseHostPort(newAddr)
-	oldMember := exec.HostInfo{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive}
-	newMember := exec.HostInfo{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive}
+	oldStartedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	oldMember := exec.HostInfo{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive, StartedAt: oldStartedAt}
+	newMember := exec.HostInfo{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive, StartedAt: oldStartedAt.Add(time.Minute)}
 	monitor := &mockServiceMonitor{
 		members: []exec.HostInfo{oldMember},
 	}
@@ -1076,13 +1088,39 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	_, err := client.Heartbeat(context.Background(), request)
 	require.NoError(t, err)
 
+	stateClient, ok := client.(coordinator.StateClient)
+	require.True(t, ok)
+	_, err = stateClient.PutState(context.Background(), &coordinatorv1.PutStateRequest{
+		Ref: &coordinatorv1.StateRef{Scope: "dag", Namespace: "test", Key: "state"},
+	})
+	require.NoError(t, err)
+
 	monitor.members = []exec.HostInfo{newMember}
+	_, err = stateClient.PutState(context.Background(), &coordinatorv1.PutStateRequest{
+		Ref: &coordinatorv1.StateRef{Scope: "dag", Namespace: "new", Key: "state"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), oldPuts.Load())
+	assert.Equal(t, int32(1), newPuts.Load())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	_, err = client.Heartbeat(ctx, request)
 	cancel()
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), newHeartbeats.Load())
+
+	_, err = stateClient.PutState(context.Background(), &coordinatorv1.PutStateRequest{
+		Ref: &coordinatorv1.StateRef{Scope: "dag", Namespace: "test", Key: "state"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), oldPuts.Load())
+	assert.Equal(t, int32(2), newPuts.Load())
+
+	monitor.members = []exec.HostInfo{oldMember}
+	_, err = client.Heartbeat(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), oldHeartbeats.Load())
+	assert.Equal(t, int32(2), newHeartbeats.Load())
 
 	ctx, cancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
 	_, err = client.ReportStatusTo(ctx, oldMember, &coordinatorv1.ReportStatusRequest{})
@@ -1092,38 +1130,121 @@ func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	assert.Equal(t, int32(1), newReports.Load())
 }
 
-func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
+func TestClientHeartbeatFailsOverWithinConfiguredTimeout(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
 	config.MaxRetries = 0
+	config.HeartbeatTimeout = time.Second
 
-	var peerMu sync.Mutex
-	var initialPeer string
-	var reconnectedHeartbeats atomic.Int32
+	var heartbeatCalls atomic.Int32
+	heartbeatFunc := func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+		if heartbeatCalls.Add(1) == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return &coordinatorv1.HeartbeatResponse{}, nil
+	}
+
+	firstServer, firstAddr := startMockServer(t, &mockCoordinatorService{
+		heartbeatFunc: heartbeatFunc,
+	})
+	defer firstServer.Stop()
+	secondServer, secondAddr := startMockServer(t, &mockCoordinatorService{
+		heartbeatFunc: heartbeatFunc,
+	})
+	defer secondServer.Stop()
+
+	firstHost, firstPort := parseHostPort(firstAddr)
+	secondHost, secondPort := parseHostPort(secondAddr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{
+			{ID: "coord-a", Host: firstHost, Port: firstPort, Status: exec.ServiceStatusActive},
+			{ID: "coord-b", Host: secondHost, Port: secondPort, Status: exec.ServiceStatusActive},
+		},
+	}
+	client := coordinator.New(monitor, config)
+
+	resp, err := client.Heartbeat(context.Background(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), heartbeatCalls.Load())
+}
+
+func TestClientHeartbeatFailsOverAfterHealthCheckStalls(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+	config.HeartbeatTimeout = time.Second
+
+	healthServer := &stallFirstHealthCheckServer{}
+	var heartbeatCalls atomic.Int32
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			heartbeatCalls.Add(1)
+			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+	}
+	firstServer, firstAddr := startMockServerWithHealth(t, mockCoord, healthServer)
+	defer firstServer.Stop()
+	secondServer, secondAddr := startMockServerWithHealth(t, mockCoord, healthServer)
+	defer secondServer.Stop()
+
+	firstHost, firstPort := parseHostPort(firstAddr)
+	secondHost, secondPort := parseHostPort(secondAddr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{
+			{ID: "coord-a", Host: firstHost, Port: firstPort, Status: exec.ServiceStatusActive},
+			{ID: "coord-b", Host: secondHost, Port: secondPort, Status: exec.ServiceStatusActive},
+		},
+	}
+	client := coordinator.New(monitor, config)
+
+	resp, err := client.Heartbeat(context.Background(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), healthServer.calls.Load())
+	assert.Equal(t, int32(1), heartbeatCalls.Load())
+}
+
+func TestClientRPCFailuresPreserveActiveLogStream(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+	config.HeartbeatTimeout = 100 * time.Millisecond
+
+	received := make(chan string, 2)
 	mockCoord := &mockCoordinatorService{
 		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
-			peerInfo, ok := peer.FromContext(ctx)
-			if !ok {
-				return nil, status.Error(codes.Internal, "missing peer information")
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		reportStatusFunc: func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
+			return nil, status.Error(codes.Unavailable, "report unavailable")
+		},
+		getWorkersFunc: func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error) {
+			return nil, status.Error(codes.Unavailable, "workers unavailable")
+		},
+		putStateFunc: func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error) {
+			return nil, status.Error(codes.DeadlineExceeded, "state deadline exceeded")
+		},
+		streamLogsFunc: func(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
+			var chunksReceived uint64
+			for {
+				chunk, err := stream.Recv()
+				if err == io.EOF {
+					return stream.SendAndClose(&coordinatorv1.StreamLogsResponse{
+						ChunksReceived: chunksReceived,
+					})
+				}
+				if err != nil {
+					return err
+				}
+				chunksReceived++
+				received <- string(chunk.Data)
 			}
-
-			peerMu.Lock()
-			if initialPeer == "" {
-				initialPeer = peerInfo.Addr.String()
-				peerMu.Unlock()
-				return &coordinatorv1.HeartbeatResponse{}, nil
-			}
-			sameConnection := initialPeer == peerInfo.Addr.String()
-			peerMu.Unlock()
-
-			if sameConnection {
-				<-ctx.Done()
-				return nil, ctx.Err()
-			}
-
-			reconnectedHeartbeats.Add(1)
-			return &coordinatorv1.HeartbeatResponse{}, nil
 		},
 	}
 	server, addr := startMockServer(t, mockCoord)
@@ -1135,20 +1256,46 @@ func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
 	}
 	client := coordinator.New(monitor, config)
 
-	request := &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"}
-	_, err := client.Heartbeat(context.Background(), request)
+	stream, err := client.StreamLogsTo(t.Context(), monitor.members[0])
 	require.NoError(t, err)
 
-	stalledCtx, cancelStalled := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	_, err = client.Heartbeat(stalledCtx, request)
-	cancelStalled()
+	require.NoError(t, stream.Send(&coordinatorv1.LogChunk{Data: []byte("before")}))
+	select {
+	case chunk := <-received:
+		require.Equal(t, "before", chunk)
+	case <-time.After(time.Second):
+		t.Fatal("coordinator did not receive the first log chunk")
+	}
+
+	_, err = client.Heartbeat(context.Background(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
 	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
 
-	recoveredCtx, cancelRecovered := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancelRecovered()
-	_, err = client.Heartbeat(recoveredCtx, request)
+	_, err = client.ReportStatusTo(
+		context.Background(),
+		monitor.members[0],
+		&coordinatorv1.ReportStatusRequest{},
+	)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	_, err = client.GetWorkers(context.Background())
+	require.Error(t, err)
+
+	stateClient, ok := client.(coordinator.StateClient)
+	require.True(t, ok)
+	_, err = stateClient.PutState(context.Background(), &coordinatorv1.PutStateRequest{})
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	require.NoError(t, stream.Send(&coordinatorv1.LogChunk{Data: []byte("after")}))
+	select {
+	case chunk := <-received:
+		require.Equal(t, "after", chunk)
+	case <-time.After(time.Second):
+		t.Fatal("coordinator did not receive the second log chunk")
+	}
+
+	resp, err := stream.CloseAndRecv()
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), reconnectedHeartbeats.Load())
+	assert.Equal(t, uint64(2), resp.ChunksReceived)
 }
 
 func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
@@ -1187,6 +1334,44 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		cancel()
 		t.Fatal("Heartbeat did not respect its configured timeout")
+	}
+}
+
+func TestClientHeartbeatHonorsCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+	config.HeartbeatTimeout = time.Second
+
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	server, addr := startMockServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: exec.ServiceStatusActive}},
+	}
+	client := coordinator.New(monitor, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Heartbeat did not respect the caller deadline")
 	}
 }
 
@@ -1488,10 +1673,24 @@ type mockCoordinatorService struct {
 	getWorkersFunc   func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
 	heartbeatFunc    func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
 	reportStatusFunc func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
+	streamLogsFunc   func(coordinatorv1.CoordinatorService_StreamLogsServer) error
 	getStateFunc     func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
 	putStateFunc     func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
 	deleteStateFunc  func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
 	listStateFunc    func(context.Context, *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error)
+}
+
+type stallFirstHealthCheckServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	calls atomic.Int32
+}
+
+func (s *stallFirstHealthCheckServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if s.calls.Add(1) == 1 {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }
 
 func (m *mockCoordinatorService) Dispatch(ctx context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
@@ -1529,6 +1728,13 @@ func (m *mockCoordinatorService) ReportStatus(ctx context.Context, req *coordina
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (m *mockCoordinatorService) StreamLogs(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
+	if m.streamLogsFunc != nil {
+		return m.streamLogsFunc(stream)
+	}
+	return m.UnimplementedCoordinatorServiceServer.StreamLogs(stream)
+}
+
 func (m *mockCoordinatorService) GetState(ctx context.Context, req *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error) {
 	if m.getStateFunc != nil {
 		return m.getStateFunc(ctx, req)
@@ -1560,14 +1766,17 @@ func (m *mockCoordinatorService) ListState(ctx context.Context, req *coordinator
 // Helper to start a mock gRPC server
 func startMockServer(t *testing.T, service coordinatorv1.CoordinatorServiceServer) (*grpc.Server, string) {
 	t.Helper()
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	return startMockServerWithHealth(t, service, healthServer)
+}
 
+func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorServiceServer, healthServer grpc_health_v1.HealthServer) (*grpc.Server, string) {
+	t.Helper()
 	server := grpc.NewServer()
 	coordinatorv1.RegisterCoordinatorServiceServer(server, service)
 
-	// Register health service
-	healthServer := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, healthServer)
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
 	// Start server on random port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1027,6 +1027,103 @@ func TestClientHeartbeat(t *testing.T) {
 	assert.Equal(t, int32(2), receivedReq.Stats.BusyPollers)
 }
 
+func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+
+	var oldHeartbeats atomic.Int32
+	oldCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			if oldHeartbeats.Add(1) == 1 {
+				return &coordinatorv1.HeartbeatResponse{}, nil
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	oldServer, oldAddr := startMockServer(t, oldCoord)
+	defer oldServer.Stop()
+
+	var newHeartbeats atomic.Int32
+	newCoord := &mockCoordinatorService{
+		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			newHeartbeats.Add(1)
+			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+	}
+	newServer, newAddr := startMockServer(t, newCoord)
+	defer newServer.Stop()
+
+	oldHost, oldPort := parseHostPort(oldAddr)
+	newHost, newPort := parseHostPort(newAddr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{
+			{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive},
+		},
+	}
+	client := coordinator.New(monitor, config)
+
+	request := &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"}
+	_, err := client.Heartbeat(context.Background(), request)
+	require.NoError(t, err)
+
+	monitor.members = []exec.HostInfo{
+		{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive},
+	}
+
+	stalledCtx, cancelStalled := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	_, err = client.Heartbeat(stalledCtx, request)
+	cancelStalled()
+	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	recoveredCtx, cancelRecovered := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancelRecovered()
+	_, err = client.Heartbeat(recoveredCtx, request)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), newHeartbeats.Load())
+}
+
+func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.MaxRetries = 0
+	config.HeartbeatTimeout = 50 * time.Millisecond
+
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	server, addr := startMockServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: exec.ServiceStatusActive}},
+	}
+	client := coordinator.New(monitor, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(500 * time.Millisecond):
+		cancel()
+		t.Fatal("Heartbeat did not respect its configured timeout")
+	}
+}
+
 func TestClientReportStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/backoff"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
-	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
@@ -1028,20 +1027,15 @@ func TestClientHeartbeat(t *testing.T) {
 	assert.Equal(t, int32(2), receivedReq.Stats.BusyPollers)
 }
 
-func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
+func TestClientHeartbeatUsesUpdatedCoordinatorAddress(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
 	config.MaxRetries = 0
 
-	var oldHeartbeats atomic.Int32
 	oldCoord := &mockCoordinatorService{
-		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
-			if oldHeartbeats.Add(1) == 1 {
-				return &coordinatorv1.HeartbeatResponse{}, nil
-			}
-			<-ctx.Done()
-			return nil, ctx.Err()
+		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			return &coordinatorv1.HeartbeatResponse{}, nil
 		},
 	}
 	oldServer, oldAddr := startMockServer(t, oldCoord)
@@ -1074,14 +1068,9 @@ func TestClientHeartbeatReconnectsAfterDeadline(t *testing.T) {
 		{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive},
 	}
 
-	stalledCtx, cancelStalled := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	_, err = client.Heartbeat(stalledCtx, request)
-	cancelStalled()
-	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
-
-	recoveredCtx, cancelRecovered := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancelRecovered()
-	_, err = client.Heartbeat(recoveredCtx, request)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err = client.Heartbeat(ctx, request)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), newHeartbeats.Load())
 }
@@ -1122,146 +1111,6 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		cancel()
 		t.Fatal("Heartbeat did not respect its configured timeout")
-	}
-}
-
-func TestClientHeartbeatExpiredContextDoesNotEvictUntriedCoordinator(t *testing.T) {
-	t.Parallel()
-
-	healthServer := &blockFirstHealthCheckServer{}
-
-	startStreamCoord := func(id string) (member exec.HostInfo, started, canceled <-chan struct{}) {
-		startedCh := make(chan struct{})
-		canceledCh := make(chan struct{})
-		service := &mockCoordinatorService{
-			streamLogsFunc: func(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
-				close(startedCh)
-				<-stream.Context().Done()
-				close(canceledCh)
-				return stream.Context().Err()
-			},
-		}
-		server, addr := startMockServerWithHealth(t, service, healthServer)
-		t.Cleanup(server.Stop)
-		host, port := parseHostPort(addr)
-		return exec.HostInfo{ID: id, Host: host, Port: port, Status: exec.ServiceStatusActive}, startedCh, canceledCh
-	}
-
-	memberA, startedA, canceledA := startStreamCoord("coord-a")
-	memberB, startedB, canceledB := startStreamCoord("coord-b")
-
-	monitor := &mockServiceMonitor{members: []exec.HostInfo{memberA, memberB}}
-	config := coordinator.DefaultConfig()
-	config.HeartbeatTimeout = 50 * time.Millisecond
-	client := coordinator.New(monitor, config)
-
-	streamCtxA := t.Context()
-	_, err := client.StreamLogsTo(streamCtxA, memberA)
-	require.NoError(t, err)
-	streamCtxB := t.Context()
-	_, err = client.StreamLogsTo(streamCtxB, memberB)
-	require.NoError(t, err)
-
-	awaitStart := func(name string, started <-chan struct{}) {
-		select {
-		case <-started:
-		case <-time.After(time.Second):
-			t.Fatalf("%s log stream did not start", name)
-		}
-	}
-	awaitStart("coord-a", startedA)
-	awaitStart("coord-b", startedB)
-
-	_, err = client.Heartbeat(context.Background(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-
-	isClosed := func(ch <-chan struct{}) bool {
-		select {
-		case <-ch:
-			return true
-		default:
-			return false
-		}
-	}
-	require.Eventually(t, func() bool {
-		return isClosed(canceledA) || isClosed(canceledB)
-	}, time.Second, 10*time.Millisecond)
-	require.Never(t, func() bool {
-		return isClosed(canceledA) && isClosed(canceledB)
-	}, 200*time.Millisecond, 10*time.Millisecond)
-}
-
-func TestClientHealthCheckFailureEvictsStaleClientFromFailoverPaths(t *testing.T) {
-	t.Parallel()
-
-	bundleData := []byte("workspace bundle")
-	bundleDesc := workspacebundle.Descriptor{
-		Digest: workspacebundle.Digest(bundleData),
-		Size:   int64(len(bundleData)),
-	}
-	tests := []struct {
-		name string
-		call func(context.Context, coordinator.Client) error
-	}{
-		{
-			name: "stream logs",
-			call: func(ctx context.Context, client coordinator.Client) error {
-				_, err := client.StreamLogs(ctx)
-				return err
-			},
-		},
-		{
-			name: "put workspace bundle",
-			call: func(ctx context.Context, client coordinator.Client) error {
-				return client.(workspacebundle.Client).PutWorkspaceBundle(ctx, bundleDesc, bundleData)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			oldCoord := &mockCoordinatorService{
-				heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
-					return &coordinatorv1.HeartbeatResponse{}, nil
-				},
-			}
-			oldServer, oldAddr := startMockServer(t, oldCoord)
-
-			newCoord := &mockCoordinatorService{
-				hasWorkspaceBundleFunc: func(context.Context, *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error) {
-					return &coordinatorv1.HasWorkspaceBundleResponse{Exists: true}, nil
-				},
-			}
-			newServer, newAddr := startMockServer(t, newCoord)
-			defer newServer.Stop()
-
-			oldHost, oldPort := parseHostPort(oldAddr)
-			newHost, newPort := parseHostPort(newAddr)
-			monitor := &mockServiceMonitor{
-				members: []exec.HostInfo{{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive}},
-			}
-			client := coordinator.New(monitor, coordinator.DefaultConfig())
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
-			cancel()
-			require.NoError(t, err)
-
-			oldServer.Stop()
-			monitor.members = []exec.HostInfo{{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive}}
-
-			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-			err = tt.call(ctx, client)
-			cancel()
-			require.Error(t, err)
-
-			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-			err = tt.call(ctx, client)
-			cancel()
-			require.NoError(t, err)
-		})
 	}
 }
 
@@ -1558,17 +1407,15 @@ var _ coordinatorv1.CoordinatorServiceServer = (*mockCoordinatorService)(nil)
 type mockCoordinatorService struct {
 	coordinatorv1.UnimplementedCoordinatorServiceServer
 
-	dispatchFunc           func(context.Context, *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error)
-	pollFunc               func(context.Context, *coordinatorv1.PollRequest) (*coordinatorv1.PollResponse, error)
-	getWorkersFunc         func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
-	heartbeatFunc          func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
-	reportStatusFunc       func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
-	streamLogsFunc         func(coordinatorv1.CoordinatorService_StreamLogsServer) error
-	getStateFunc           func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
-	putStateFunc           func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
-	deleteStateFunc        func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
-	listStateFunc          func(context.Context, *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error)
-	hasWorkspaceBundleFunc func(context.Context, *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error)
+	dispatchFunc     func(context.Context, *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error)
+	pollFunc         func(context.Context, *coordinatorv1.PollRequest) (*coordinatorv1.PollResponse, error)
+	getWorkersFunc   func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
+	heartbeatFunc    func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
+	reportStatusFunc func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
+	getStateFunc     func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
+	putStateFunc     func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
+	deleteStateFunc  func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
+	listStateFunc    func(context.Context, *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error)
 }
 
 func (m *mockCoordinatorService) Dispatch(ctx context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
@@ -1606,13 +1453,6 @@ func (m *mockCoordinatorService) ReportStatus(ctx context.Context, req *coordina
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-func (m *mockCoordinatorService) StreamLogs(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
-	if m.streamLogsFunc != nil {
-		return m.streamLogsFunc(stream)
-	}
-	return m.UnimplementedCoordinatorServiceServer.StreamLogs(stream)
-}
-
 func (m *mockCoordinatorService) GetState(ctx context.Context, req *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error) {
 	if m.getStateFunc != nil {
 		return m.getStateFunc(ctx, req)
@@ -1641,42 +1481,17 @@ func (m *mockCoordinatorService) ListState(ctx context.Context, req *coordinator
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-func (m *mockCoordinatorService) HasWorkspaceBundle(ctx context.Context, req *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error) {
-	if m.hasWorkspaceBundleFunc != nil {
-		return m.hasWorkspaceBundleFunc(ctx, req)
-	}
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-type blockFirstHealthCheckServer struct {
-	grpc_health_v1.UnimplementedHealthServer
-	blocked atomic.Bool
-}
-
-func (s *blockFirstHealthCheckServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	if s.blocked.CompareAndSwap(false, true) {
-		<-ctx.Done()
-		return nil, ctx.Err()
-	}
-	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
-}
-
 // Helper to start a mock gRPC server
 func startMockServer(t *testing.T, service coordinatorv1.CoordinatorServiceServer) (*grpc.Server, string) {
-	t.Helper()
-	healthServer := health.NewServer()
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	return startMockServerWithHealth(t, service, healthServer)
-}
-
-func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorServiceServer, healthServer grpc_health_v1.HealthServer) (*grpc.Server, string) {
 	t.Helper()
 
 	server := grpc.NewServer()
 	coordinatorv1.RegisterCoordinatorServiceServer(server, service)
 
 	// Register health service
+	healthServer := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, healthServer)
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
 	// Start server on random port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/backoff"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/proto/convert"
+	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
@@ -1124,6 +1125,80 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	}
 }
 
+func TestClientHealthCheckFailureEvictsStaleClientFromFailoverPaths(t *testing.T) {
+	t.Parallel()
+
+	bundleData := []byte("workspace bundle")
+	bundleDesc := workspacebundle.Descriptor{
+		Digest: workspacebundle.Digest(bundleData),
+		Size:   int64(len(bundleData)),
+	}
+	tests := []struct {
+		name string
+		call func(context.Context, coordinator.Client) error
+	}{
+		{
+			name: "stream logs",
+			call: func(ctx context.Context, client coordinator.Client) error {
+				_, err := client.StreamLogs(ctx)
+				return err
+			},
+		},
+		{
+			name: "put workspace bundle",
+			call: func(ctx context.Context, client coordinator.Client) error {
+				return client.(workspacebundle.Client).PutWorkspaceBundle(ctx, bundleDesc, bundleData)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldCoord := &mockCoordinatorService{
+				heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+					return &coordinatorv1.HeartbeatResponse{}, nil
+				},
+			}
+			oldServer, oldAddr := startMockServer(t, oldCoord)
+
+			newCoord := &mockCoordinatorService{
+				hasWorkspaceBundleFunc: func(context.Context, *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error) {
+					return &coordinatorv1.HasWorkspaceBundleResponse{Exists: true}, nil
+				},
+			}
+			newServer, newAddr := startMockServer(t, newCoord)
+			defer newServer.Stop()
+
+			oldHost, oldPort := parseHostPort(oldAddr)
+			newHost, newPort := parseHostPort(newAddr)
+			monitor := &mockServiceMonitor{
+				members: []exec.HostInfo{{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive}},
+			}
+			client := coordinator.New(monitor, coordinator.DefaultConfig())
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+			cancel()
+			require.NoError(t, err)
+
+			oldServer.Stop()
+			monitor.members = []exec.HostInfo{{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive}}
+
+			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+			err = tt.call(ctx, client)
+			cancel()
+			require.Error(t, err)
+
+			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+			err = tt.call(ctx, client)
+			cancel()
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestClientReportStatus(t *testing.T) {
 	t.Parallel()
 
@@ -1417,15 +1492,16 @@ var _ coordinatorv1.CoordinatorServiceServer = (*mockCoordinatorService)(nil)
 type mockCoordinatorService struct {
 	coordinatorv1.UnimplementedCoordinatorServiceServer
 
-	dispatchFunc     func(context.Context, *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error)
-	pollFunc         func(context.Context, *coordinatorv1.PollRequest) (*coordinatorv1.PollResponse, error)
-	getWorkersFunc   func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
-	heartbeatFunc    func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
-	reportStatusFunc func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
-	getStateFunc     func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
-	putStateFunc     func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
-	deleteStateFunc  func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
-	listStateFunc    func(context.Context, *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error)
+	dispatchFunc           func(context.Context, *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error)
+	pollFunc               func(context.Context, *coordinatorv1.PollRequest) (*coordinatorv1.PollResponse, error)
+	getWorkersFunc         func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
+	heartbeatFunc          func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
+	reportStatusFunc       func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
+	getStateFunc           func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
+	putStateFunc           func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
+	deleteStateFunc        func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
+	listStateFunc          func(context.Context, *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error)
+	hasWorkspaceBundleFunc func(context.Context, *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error)
 }
 
 func (m *mockCoordinatorService) Dispatch(ctx context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
@@ -1487,6 +1563,13 @@ func (m *mockCoordinatorService) DeleteState(ctx context.Context, req *coordinat
 func (m *mockCoordinatorService) ListState(ctx context.Context, req *coordinatorv1.ListStateRequest) (*coordinatorv1.ListStateResponse, error) {
 	if m.listStateFunc != nil {
 		return m.listStateFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockCoordinatorService) HasWorkspaceBundle(ctx context.Context, req *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error) {
+	if m.hasWorkspaceBundleFunc != nil {
+		return m.hasWorkspaceBundleFunc(ctx, req)
 	}
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1027,25 +1027,35 @@ func TestClientHeartbeat(t *testing.T) {
 	assert.Equal(t, int32(2), receivedReq.Stats.BusyPollers)
 }
 
-func TestClientHeartbeatUsesUpdatedCoordinatorAddress(t *testing.T) {
+func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
 	config.MaxRetries = 0
 
+	var oldReports atomic.Int32
 	oldCoord := &mockCoordinatorService{
 		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
 			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+		reportStatusFunc: func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
+			oldReports.Add(1)
+			return &coordinatorv1.ReportStatusResponse{}, nil
 		},
 	}
 	oldServer, oldAddr := startMockServer(t, oldCoord)
 	defer oldServer.Stop()
 
 	var newHeartbeats atomic.Int32
+	var newReports atomic.Int32
 	newCoord := &mockCoordinatorService{
 		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
 			newHeartbeats.Add(1)
 			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+		reportStatusFunc: func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
+			newReports.Add(1)
+			return &coordinatorv1.ReportStatusResponse{}, nil
 		},
 	}
 	newServer, newAddr := startMockServer(t, newCoord)
@@ -1053,10 +1063,10 @@ func TestClientHeartbeatUsesUpdatedCoordinatorAddress(t *testing.T) {
 
 	oldHost, oldPort := parseHostPort(oldAddr)
 	newHost, newPort := parseHostPort(newAddr)
+	oldMember := exec.HostInfo{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive}
+	newMember := exec.HostInfo{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive}
 	monitor := &mockServiceMonitor{
-		members: []exec.HostInfo{
-			{ID: "coord-a", Host: oldHost, Port: oldPort, Status: exec.ServiceStatusActive},
-		},
+		members: []exec.HostInfo{oldMember},
 	}
 	client := coordinator.New(monitor, config)
 
@@ -1064,15 +1074,20 @@ func TestClientHeartbeatUsesUpdatedCoordinatorAddress(t *testing.T) {
 	_, err := client.Heartbeat(context.Background(), request)
 	require.NoError(t, err)
 
-	monitor.members = []exec.HostInfo{
-		{ID: "coord-a", Host: newHost, Port: newPort, Status: exec.ServiceStatusActive},
-	}
+	monitor.members = []exec.HostInfo{newMember}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
 	_, err = client.Heartbeat(ctx, request)
+	cancel()
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), newHeartbeats.Load())
+
+	ctx, cancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
+	_, err = client.ReportStatusTo(ctx, oldMember, &coordinatorv1.ReportStatusRequest{})
+	cancel()
+	require.NoError(t, err)
+	assert.Zero(t, oldReports.Load())
+	assert.Equal(t, int32(1), newReports.Load())
 }
 
 func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1125,6 +1125,74 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	}
 }
 
+func TestClientHeartbeatExpiredContextDoesNotEvictUntriedCoordinator(t *testing.T) {
+	t.Parallel()
+
+	healthServer := &blockFirstHealthCheckServer{}
+
+	startStreamCoord := func(id string) (member exec.HostInfo, started, canceled <-chan struct{}) {
+		startedCh := make(chan struct{})
+		canceledCh := make(chan struct{})
+		service := &mockCoordinatorService{
+			streamLogsFunc: func(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
+				close(startedCh)
+				<-stream.Context().Done()
+				close(canceledCh)
+				return stream.Context().Err()
+			},
+		}
+		server, addr := startMockServerWithHealth(t, service, healthServer)
+		t.Cleanup(server.Stop)
+		host, port := parseHostPort(addr)
+		return exec.HostInfo{ID: id, Host: host, Port: port, Status: exec.ServiceStatusActive}, startedCh, canceledCh
+	}
+
+	memberA, startedA, canceledA := startStreamCoord("coord-a")
+	memberB, startedB, canceledB := startStreamCoord("coord-b")
+
+	monitor := &mockServiceMonitor{members: []exec.HostInfo{memberA, memberB}}
+	config := coordinator.DefaultConfig()
+	config.HeartbeatTimeout = 50 * time.Millisecond
+	client := coordinator.New(monitor, config)
+
+	streamCtxA, cancelStreamA := context.WithCancel(context.Background())
+	defer cancelStreamA()
+	_, err := client.StreamLogsTo(streamCtxA, memberA)
+	require.NoError(t, err)
+	streamCtxB, cancelStreamB := context.WithCancel(context.Background())
+	defer cancelStreamB()
+	_, err = client.StreamLogsTo(streamCtxB, memberB)
+	require.NoError(t, err)
+
+	awaitStart := func(name string, started <-chan struct{}) {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("%s log stream did not start", name)
+		}
+	}
+	awaitStart("coord-a", startedA)
+	awaitStart("coord-b", startedB)
+
+	_, err = client.Heartbeat(context.Background(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	isClosed := func(ch <-chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}
+	require.Eventually(t, func() bool {
+		return isClosed(canceledA) || isClosed(canceledB)
+	}, time.Second, 10*time.Millisecond)
+	require.Never(t, func() bool {
+		return isClosed(canceledA) && isClosed(canceledB)
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
 func TestClientHealthCheckFailureEvictsStaleClientFromFailoverPaths(t *testing.T) {
 	t.Parallel()
 
@@ -1497,6 +1565,7 @@ type mockCoordinatorService struct {
 	getWorkersFunc         func(context.Context, *coordinatorv1.GetWorkersRequest) (*coordinatorv1.GetWorkersResponse, error)
 	heartbeatFunc          func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error)
 	reportStatusFunc       func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error)
+	streamLogsFunc         func(coordinatorv1.CoordinatorService_StreamLogsServer) error
 	getStateFunc           func(context.Context, *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error)
 	putStateFunc           func(context.Context, *coordinatorv1.PutStateRequest) (*coordinatorv1.PutStateResponse, error)
 	deleteStateFunc        func(context.Context, *coordinatorv1.DeleteStateRequest) (*coordinatorv1.DeleteStateResponse, error)
@@ -1539,6 +1608,13 @@ func (m *mockCoordinatorService) ReportStatus(ctx context.Context, req *coordina
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (m *mockCoordinatorService) StreamLogs(stream coordinatorv1.CoordinatorService_StreamLogsServer) error {
+	if m.streamLogsFunc != nil {
+		return m.streamLogsFunc(stream)
+	}
+	return m.UnimplementedCoordinatorServiceServer.StreamLogs(stream)
+}
+
 func (m *mockCoordinatorService) GetState(ctx context.Context, req *coordinatorv1.GetStateRequest) (*coordinatorv1.GetStateResponse, error) {
 	if m.getStateFunc != nil {
 		return m.getStateFunc(ctx, req)
@@ -1574,17 +1650,35 @@ func (m *mockCoordinatorService) HasWorkspaceBundle(ctx context.Context, req *co
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+type blockFirstHealthCheckServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	blocked atomic.Bool
+}
+
+func (s *blockFirstHealthCheckServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if s.blocked.CompareAndSwap(false, true) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
 // Helper to start a mock gRPC server
 func startMockServer(t *testing.T, service coordinatorv1.CoordinatorServiceServer) (*grpc.Server, string) {
+	t.Helper()
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	return startMockServerWithHealth(t, service, healthServer)
+}
+
+func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorServiceServer, healthServer grpc_health_v1.HealthServer) (*grpc.Server, string) {
 	t.Helper()
 
 	server := grpc.NewServer()
 	coordinatorv1.RegisterCoordinatorServiceServer(server, service)
 
 	// Register health service
-	healthServer := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(server, healthServer)
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
 	// Start server on random port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1155,12 +1155,10 @@ func TestClientHeartbeatExpiredContextDoesNotEvictUntriedCoordinator(t *testing.
 	config.HeartbeatTimeout = 50 * time.Millisecond
 	client := coordinator.New(monitor, config)
 
-	streamCtxA, cancelStreamA := context.WithCancel(context.Background())
-	defer cancelStreamA()
+	streamCtxA := t.Context()
 	_, err := client.StreamLogsTo(streamCtxA, memberA)
 	require.NoError(t, err)
-	streamCtxB, cancelStreamB := context.WithCancel(context.Background())
-	defer cancelStreamB()
+	streamCtxB := t.Context()
 	_, err = client.StreamLogsTo(streamCtxB, memberB)
 	require.NoError(t, err)
 

--- a/internal/service/coordinator/config.go
+++ b/internal/service/coordinator/config.go
@@ -15,8 +15,9 @@ type Config struct {
 	SkipTLSVerify bool   // Skip server certificate verification
 
 	// Timeouts
-	DialTimeout    time.Duration // Connection timeout (default: 10s)
-	RequestTimeout time.Duration // Per-request timeout (default: 5m)
+	DialTimeout      time.Duration // Connection timeout (default: 10s)
+	RequestTimeout   time.Duration // Per-request timeout (default: 5m)
+	HeartbeatTimeout time.Duration // Worker heartbeat timeout (default: 10s)
 
 	// Retry configuration
 	MaxRetries    int           // Max dispatch retries (default: 3)
@@ -26,11 +27,12 @@ type Config struct {
 // DefaultConfig returns a Config with default values
 func DefaultConfig() *Config {
 	return &Config{
-		Insecure:       true,
-		DialTimeout:    10 * time.Second,
-		RequestTimeout: 5 * time.Minute,
-		MaxRetries:     3,
-		RetryInterval:  time.Second,
+		Insecure:         true,
+		DialTimeout:      10 * time.Second,
+		RequestTimeout:   5 * time.Minute,
+		HeartbeatTimeout: 10 * time.Second,
+		MaxRetries:       3,
+		RetryInterval:    time.Second,
 	}
 }
 
@@ -44,6 +46,9 @@ func (c *Config) Validate() error {
 	}
 	if c.RequestTimeout <= 0 {
 		c.RequestTimeout = 5 * time.Minute
+	}
+	if c.HeartbeatTimeout <= 0 {
+		c.HeartbeatTimeout = 10 * time.Second
 	}
 	if c.MaxRetries < 0 {
 		c.MaxRetries = 0

--- a/internal/service/coordinator/config_test.go
+++ b/internal/service/coordinator/config_test.go
@@ -18,6 +18,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, config.Insecure)
 	assert.Equal(t, 10*time.Second, config.DialTimeout)
 	assert.Equal(t, 5*time.Minute, config.RequestTimeout)
+	assert.Equal(t, 10*time.Second, config.HeartbeatTimeout)
 	assert.Equal(t, 3, config.MaxRetries)
 	assert.Equal(t, time.Second, config.RetryInterval)
 	assert.Empty(t, config.CertFile)
@@ -179,6 +180,7 @@ func TestConfigValidateDefaults(t *testing.T) {
 
 	assert.Equal(t, 10*time.Second, config.DialTimeout)
 	assert.Equal(t, 5*time.Minute, config.RequestTimeout)
+	assert.Equal(t, 10*time.Second, config.HeartbeatTimeout)
 	assert.Equal(t, 0, config.MaxRetries)
 	assert.Equal(t, time.Second, config.RetryInterval)
 }


### PR DESCRIPTION
## Summary

Workers can get stuck talking to a dead cached coordinator connection when a
coordinator restarts or moves to a new address under the same ID. This drops
and re-dials the cached gRPC client on transient failures, and bounds the
worker heartbeat with a configurable timeout so a stalled coordinator cannot
block the heartbeat loop.

## Changes

- Reset (close + drop) the cached coordinator client on transient gRPC errors (Unavailable / deadline) so the next call re-dials
- Add configurable `HeartbeatTimeout` (default 10s) bounding the worker heartbeat
- Health check reuses the already-resolved client instead of re-resolving it

## Related Issues

_none_

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (N/A - config not user-facing)
- [x] Changes have been tested locally (`make test`, `make lint`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workers now reliably reconnect to coordinators after heartbeat timeouts and address/instance changes. Heartbeat failover is connection-safe and won’t tear down active streams.

- **Bug Fixes**
  - Make the discovered coordinator address and `StartedAt` authoritative; refresh the cached client only on address/instance changes under the same ID. Applied to dispatch, stream failover, workspace bundle uploads, status reporting, and worker listing.
  - Skip health checks when the context is done and check health on the resolved client to avoid evicting healthy connections; transient RPC errors no longer interrupt active log/artifact streams.
  - Stop failover when the request context ends; pre-warm the pinned state coordinator client to avoid late failures.

- **New Features**
  - Added `HeartbeatTimeout` to `coordinator.Config` (default 10s). The budget is split across members during failover, order is randomized, and caller deadlines are honored.

<sup>Written for commit 7ec212599dbf9e27482114e6b47ef64cd8107449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved coordinator recovery after transient failures and expired deadlines.
  * Prevented concurrent operations from discarding newer coordinator connections.
  * Added configurable heartbeat timeouts, defaulting to 10 seconds.
  * Improved failover for heartbeats, stream connections, and workspace uploads.

* **Bug Fixes**
  * Heartbeats now reconnect successfully after coordinator deadline failures.
  * Stale or unhealthy connections are safely removed before retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->