### PR TITLE
fix: stream distributed logs while runs are active

### DIFF
--- a/internal/cmn/fileutil/fileutil.go
+++ b/internal/cmn/fileutil/fileutil.go
@@ -63,7 +63,17 @@ func IsFile(path string) bool {
 // OpenOrCreateFile opens or creates the named file for appending with synchronous I/O and sets permissions to 0600.
 // It returns the opened *os.File or a non-nil error if the operation fails.
 func OpenOrCreateFile(filepath string) (*os.File, error) {
-	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND | os.O_SYNC
+	return openOrCreateFile(filepath, os.O_SYNC)
+}
+
+// OpenOrCreateFileWithoutSync opens or creates the named file for appending using OS buffering and sets permissions to 0600.
+// Writes are visible to readers, but callers must call Sync when durable persistence is required.
+func OpenOrCreateFileWithoutSync(filepath string) (*os.File, error) {
+	return openOrCreateFile(filepath, 0)
+}
+
+func openOrCreateFile(filepath string, extraFlags int) (*os.File, error) {
+	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND | extraFlags
 
 	var file *os.File
 	err := retryWindowsFileOp(func() error {

--- a/internal/cmn/fileutil/fileutil_test.go
+++ b/internal/cmn/fileutil/fileutil_test.go
@@ -53,6 +53,37 @@ func TestCreateFile(t *testing.T) {
 	})
 }
 
+func TestOpenOrCreateFileWithoutSync(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "stream.log")
+	file, err := OpenOrCreateFileWithoutSync(filePath)
+	require.NoError(t, err)
+	defer func() {
+		_ = file.Close()
+	}()
+
+	_, err = file.WriteString("first")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(data))
+
+	second, err := OpenOrCreateFileWithoutSync(filePath)
+	require.NoError(t, err)
+	defer func() {
+		_ = second.Close()
+	}()
+
+	_, err = second.WriteString("-second")
+	require.NoError(t, err)
+
+	data, err = os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "first-second", string(data))
+}
+
 func TestResolvePath(t *testing.T) {
 	// Get current working directory for absolute path tests
 	cwd, err := os.Getwd()

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -96,6 +96,21 @@ func artifactWriteCommand(content string, fail bool) string {
 	return test.JoinLines(commands...)
 }
 
+func gatedLogCommand(stdoutMarker, stderrMarker, releasePath string) string {
+	if runtime.GOOS == "windows" {
+		return test.JoinLines(
+			fmt.Sprintf("[Console]::Out.WriteLine(%s)", test.PowerShellQuote(stdoutMarker)),
+			fmt.Sprintf("[Console]::Error.WriteLine(%s)", test.PowerShellQuote(stderrMarker)),
+			fmt.Sprintf("while (-not (Test-Path -LiteralPath %s)) { Start-Sleep -Milliseconds 100 }", test.PowerShellQuote(releasePath)),
+		)
+	}
+	return test.JoinLines(
+		fmt.Sprintf("printf '%%s\\n' %s", test.PosixQuote(stdoutMarker)),
+		fmt.Sprintf("printf '%%s\\n' %s >&2", test.PosixQuote(stderrMarker)),
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.1; done", test.PosixQuote(releasePath)),
+	)
+}
+
 func artifactNoWriteCommand() string {
 	if runtime.GOOS == "windows" {
 		return test.JoinLines(
@@ -223,6 +238,81 @@ steps:
 	for _, line := range []string{firstStdout, firstStderr, secondStdout, secondStderr} {
 		assert.Contains(t, runLog, line, "run-level scheduler log should contain distributed step output evidence")
 	}
+}
+
+func TestExecution_SmallDistributedWorkerLogsVisibleBeforeStepCompletes(t *testing.T) {
+	stdoutMarker := "small-running-stdout-marker"
+	stderrMarker := "small-running-stderr-marker"
+	releasePath := filepath.Join(t.TempDir(), "release")
+	releaseStep := func() error {
+		return os.WriteFile(releasePath, []byte("release"), 0600)
+	}
+
+	f := newTestFixture(t, `
+name: small-running-distributed-logs-test
+worker_selector:
+  test: "true"
+steps:
+  - name: gated-step
+`+artifactStepShellYAML()+`    command: |
+`+indentYAMLBlock(gatedLogCommand(stdoutMarker, stderrMarker, releasePath), 6)+`
+`, withLogPersistence())
+	defer f.cleanup()
+	defer func() { _ = releaseStep() }()
+
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(30 * time.Second)
+
+	running := f.waitForStatus(core.Running, executionStatusTimeout())
+	require.Equal(t, core.Running, running.Status)
+	require.NotEmpty(t, running.Log)
+
+	f.requireEventuallyNoSchedulerError(
+		"small step logs should be visible on the coordinator while the step is running",
+		executionStatusTimeout(),
+		100*time.Millisecond,
+		func() bool {
+			current, err := f.latestStoredStatus()
+			if err != nil || current.Status != core.Running {
+				return false
+			}
+
+			stdoutFiles := findLogFiles(t, f.logDir(), f.dagWrapper.Name, current.DAGRunID, "gated-step", "stdout")
+			stderrFiles := findLogFiles(t, f.logDir(), f.dagWrapper.Name, current.DAGRunID, "gated-step", "stderr")
+			if len(stdoutFiles) == 0 || len(stderrFiles) == 0 {
+				return false
+			}
+
+			stdout, err := os.ReadFile(stdoutFiles[0])
+			if err != nil || !strings.Contains(string(stdout), stdoutMarker) {
+				return false
+			}
+			stderr, err := os.ReadFile(stderrFiles[0])
+			if err != nil || !strings.Contains(string(stderr), stderrMarker) {
+				return false
+			}
+			combined, err := os.ReadFile(current.Log)
+			return err == nil &&
+				strings.Contains(string(combined), stdoutMarker) &&
+				strings.Contains(string(combined), stderrMarker)
+		},
+	)
+
+	require.NoError(t, releaseStep())
+	status := f.waitForStatus(core.Succeeded, executionStatusTimeout())
+	f.assertAllNodesSucceeded(status)
+
+	stdoutFiles := findLogFiles(t, f.logDir(), f.dagWrapper.Name, status.DAGRunID, "gated-step", "stdout")
+	stderrFiles := findLogFiles(t, f.logDir(), f.dagWrapper.Name, status.DAGRunID, "gated-step", "stderr")
+	require.NotEmpty(t, stdoutFiles)
+	require.NotEmpty(t, stderrFiles)
+	require.Equal(t, 1, strings.Count(getLogContent(t, stdoutFiles[0]), stdoutMarker))
+	require.Equal(t, 1, strings.Count(getLogContent(t, stderrFiles[0]), stderrMarker))
+
+	combined := getLogContent(t, status.Log)
+	require.Equal(t, 1, strings.Count(combined, stdoutMarker))
+	require.Equal(t, 1, strings.Count(combined, stderrMarker))
 }
 
 func TestExecution_LargeOutput(t *testing.T) {

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -245,7 +245,7 @@ func (n *Node) startOutputFlusher() *flusherControl {
 			case <-ctrl.done:
 				return
 			case <-ticker.C:
-				_ = n.outputs.flushWriters()
+				_ = n.outputs.flushWritersIfDue()
 			}
 		}
 	}()

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -189,6 +189,14 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 }
 
 func (oc *OutputCoordinator) flushWriters() error {
+	return oc.flushWritersWithMode(false)
+}
+
+func (oc *OutputCoordinator) flushWritersIfDue() error {
+	return oc.flushWritersWithMode(true)
+}
+
+func (oc *OutputCoordinator) flushWritersWithMode(ifDue bool) error {
 	oc.mu.Lock()
 	defer oc.mu.Unlock()
 
@@ -200,6 +208,14 @@ func (oc *OutputCoordinator) flushWriters() error {
 	for _, w := range []io.Writer{oc.stdoutWriter, oc.stderrWriter, oc.stdoutRedirectWriter, oc.stderrRedirectWriter} {
 		if w == nil {
 			continue
+		}
+		if ifDue {
+			if v, ok := w.(interface{ FlushIfDue() error }); ok {
+				if err := v.FlushIfDue(); err != nil {
+					lastErr = err
+				}
+				continue
+			}
 		}
 		switch v := w.(type) {
 		case interface{ Flush() error }:

--- a/internal/runtime/step_executor_test.go
+++ b/internal/runtime/step_executor_test.go
@@ -4,10 +4,13 @@
 package runtime_test
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
@@ -15,6 +18,8 @@ import (
 	runtimeexec "github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/stretchr/testify/require"
 )
+
+const periodicFlushExecutorType = "test-step-executor-periodic-flush"
 
 type sideChannelExecutor struct {
 	inputMessages     []exec.LLMMessage
@@ -61,6 +66,136 @@ func (e *sideChannelExecutor) GetToolDefinitions() []exec.ToolDefinition {
 }
 func (e *sideChannelExecutor) GetOutputs() map[string]any {
 	return e.outputs
+}
+
+type periodicFlushExecutor struct {
+	stdout  io.Writer
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (e *periodicFlushExecutor) SetStdout(out io.Writer) { e.stdout = out }
+func (e *periodicFlushExecutor) SetStderr(io.Writer)     {}
+func (e *periodicFlushExecutor) Kill(os.Signal) error    { return nil }
+func (e *periodicFlushExecutor) Run(ctx context.Context) error {
+	if _, err := io.WriteString(e.stdout, "small remote output\n"); err != nil {
+		return err
+	}
+	close(e.started)
+	select {
+	case <-e.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type flushObservingWriter struct {
+	mu       sync.Mutex
+	buf      bytes.Buffer
+	expected []byte
+	observed chan struct{}
+}
+
+func (w *flushObservingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *flushObservingWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if bytes.Contains(w.buf.Bytes(), w.expected) {
+		select {
+		case w.observed <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (w *flushObservingWriter) Close() error { return nil }
+
+type flushObservingLogWriterFactory struct {
+	stdout *flushObservingWriter
+}
+
+func (f *flushObservingLogWriterFactory) NewStepWriter(_ context.Context, _ string, streamType int) io.WriteCloser {
+	if streamType == exec.StreamTypeStdout {
+		return f.stdout
+	}
+	return &flushObservingWriter{}
+}
+
+func TestStepExecutorPeriodicallyFlushesRemoteOutputWhileExecutorRuns(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseExecutor := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	defer releaseExecutor()
+
+	runtimeexec.RegisterExecutor(periodicFlushExecutorType, func(context.Context, core.Step) (runtimeexec.Executor, error) {
+		return &periodicFlushExecutor{
+			started: started,
+			release: release,
+		}, nil
+	}, nil, core.ExecutorCapabilities{})
+	t.Cleanup(func() { runtimeexec.UnregisterExecutor(periodicFlushExecutorType) })
+
+	writer := &flushObservingWriter{
+		expected: []byte("small remote output"),
+		observed: make(chan struct{}, 1),
+	}
+	factory := &flushObservingLogWriterFactory{stdout: writer}
+	dag := &core.DAG{Name: "periodic-flush-dag"}
+	ctx := runtime.NewContext(
+		context.Background(),
+		dag,
+		"run-1",
+		"dag.log",
+		runtime.WithLogWriterFactory(factory),
+	)
+	node := runtime.NewNode(core.Step{
+		Name: "periodic-flush-step",
+		ExecutorConfig: core.ExecutorConfig{
+			Type: periodicFlushExecutorType,
+		},
+	}, runtime.NodeState{})
+	require.NoError(t, node.Prepare(ctx, t.TempDir(), "run-1"))
+	defer func() { require.NoError(t, node.Teardown()) }()
+
+	executionDone := make(chan error, 1)
+	go func() {
+		executionDone <- runtime.NewStepExecutor().Execute(ctx, node)
+	}()
+
+	select {
+	case <-started:
+	case err := <-executionDone:
+		require.FailNow(t, "executor completed before blocking", "error: %v", err)
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "executor did not start")
+	}
+
+	select {
+	case <-writer.observed:
+	case err := <-executionDone:
+		require.FailNow(t, "executor completed before periodic output flush", "error: %v", err)
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "remote output was not flushed while executor was running")
+	}
+
+	select {
+	case err := <-executionDone:
+		require.FailNow(t, "executor completed before release", "error: %v", err)
+	default:
+	}
+
+	releaseExecutor()
+	require.NoError(t, <-executionDone)
 }
 
 func TestStepExecutorCapturesExecutorSideChannels(t *testing.T) {

--- a/internal/service/coordinator/log_handler.go
+++ b/internal/service/coordinator/log_handler.go
@@ -223,7 +223,7 @@ func (h *logHandler) getOrCreateWriter(chunk *coordinatorv1.LogChunk) (*streamLo
 	}
 
 	// Open or create the file
-	file, err := fileutil.OpenOrCreateFile(logPath)
+	file, err := fileutil.OpenOrCreateFileWithoutSync(logPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}

--- a/internal/service/coordinator/log_handler.go
+++ b/internal/service/coordinator/log_handler.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// flushThreshold is the number of bytes after which to flush a writer
+// flushThreshold is the number of buffered bytes after which artifact data is flushed.
 const flushThreshold = 65536
 
 // logHandler handles log streaming from workers
@@ -29,11 +29,44 @@ type logHandler struct {
 	ownerID string
 
 	// Active writers: streamKey -> writer
-	writers   map[string]*logWriter
+	writers   map[string]*streamLogWriter
 	writersMu sync.Mutex
 }
 
-// logWriter manages writing to a single log file
+// streamLogWriter writes streamed logs directly to a single log file.
+type streamLogWriter struct {
+	file *os.File
+	path string
+	mu   sync.Mutex
+}
+
+// write appends data to the log file.
+func (w *streamLogWriter) write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.file.Write(data)
+}
+
+// close syncs and closes the file.
+// Errors are logged but not returned since this is typically called during cleanup.
+func (w *streamLogWriter) close(ctx context.Context) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if err := w.file.Sync(); err != nil {
+		logger.Warn(ctx, "Failed to sync log file",
+			slog.String("path", w.path),
+			slog.String("error", err.Error()))
+	}
+	if err := w.file.Close(); err != nil {
+		logger.Warn(ctx, "Failed to close log file",
+			slog.String("path", w.path),
+			slog.String("error", err.Error()))
+	}
+}
+
+// logWriter manages buffered artifact writes to a single file.
 type logWriter struct {
 	file            *os.File
 	writer          *bufio.Writer
@@ -99,7 +132,7 @@ func newLogHandler(logDir string, ownerID ...string) *logHandler {
 	return &logHandler{
 		logDir:  logDir,
 		ownerID: expectedOwner,
-		writers: make(map[string]*logWriter),
+		writers: make(map[string]*streamLogWriter),
 	}
 }
 
@@ -169,7 +202,7 @@ func (h *logHandler) streamKey(chunk *coordinatorv1.LogChunk) string {
 }
 
 // getOrCreateWriter returns an existing writer or creates a new one
-func (h *logHandler) getOrCreateWriter(chunk *coordinatorv1.LogChunk) (*logWriter, error) {
+func (h *logHandler) getOrCreateWriter(chunk *coordinatorv1.LogChunk) (*streamLogWriter, error) {
 	key := h.streamKey(chunk)
 
 	h.writersMu.Lock()
@@ -195,11 +228,9 @@ func (h *logHandler) getOrCreateWriter(chunk *coordinatorv1.LogChunk) (*logWrite
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 
-	// Create buffered writer
-	w := &logWriter{
-		file:   file,
-		writer: bufio.NewWriterSize(file, 64*1024), // 64KB buffer
-		path:   logPath,
+	w := &streamLogWriter{
+		file: file,
+		path: logPath,
 	}
 
 	h.writers[key] = w
@@ -279,5 +310,5 @@ func (h *logHandler) Close(ctx context.Context) {
 	for _, w := range h.writers {
 		w.close(ctx)
 	}
-	h.writers = make(map[string]*logWriter)
+	h.writers = make(map[string]*streamLogWriter)
 }

--- a/internal/service/coordinator/log_handler_test.go
+++ b/internal/service/coordinator/log_handler_test.go
@@ -5,9 +5,11 @@ package coordinator
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	coordinatorv1 "github.com/dagucloud/dagu/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
@@ -197,7 +199,6 @@ func TestLogHandler_GetOrCreateWriter(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, writer)
 		require.NotNil(t, writer.file)
-		require.NotNil(t, writer.writer)
 	})
 
 	t.Run("ReturnsExistingWriter", func(t *testing.T) {
@@ -393,7 +394,7 @@ func TestLogHandler_Close(t *testing.T) {
 	})
 }
 
-func TestLogWriter_WriteAndFlush(t *testing.T) {
+func TestStreamLogWriter_Write(t *testing.T) {
 	t.Parallel()
 
 	t.Run("WritesDataToFile", func(t *testing.T) {
@@ -530,6 +531,56 @@ func TestLogHandler_HandleStream(t *testing.T) {
 		content, err := os.ReadFile(expectedPath)
 		require.NoError(t, err)
 		assert.Equal(t, "line 1\nline 2\n", string(content))
+	})
+
+	t.Run("MakesTinyChunkVisibleBeforeStreamCompletion", func(t *testing.T) {
+		t.Parallel()
+
+		logDir := t.TempDir()
+		h := newLogHandler(logDir)
+		defer h.Close(context.Background())
+
+		chunk := &coordinatorv1.LogChunk{
+			DagName:    "test-dag",
+			DagRunId:   "run-live",
+			AttemptId:  "attempt-1",
+			StepName:   "step1",
+			StreamType: coordinatorv1.LogStreamType_LOG_STREAM_TYPE_STDOUT,
+			Data:       []byte("live\n"),
+		}
+		stream := &blockingStreamLogsServer{
+			mockStreamLogsServer: mockStreamLogsServer{ctx: context.Background()},
+			chunk:                chunk,
+			waiting:              make(chan struct{}),
+			release:              make(chan struct{}),
+		}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- h.handleStream(stream)
+		}()
+
+		select {
+		case <-stream.waiting:
+		case <-time.After(5 * time.Second):
+			t.Fatal("stream handler did not process the first chunk")
+		}
+
+		select {
+		case err := <-errCh:
+			t.Fatalf("stream handler completed before stream EOF: %v", err)
+		default:
+		}
+
+		content, err := os.ReadFile(h.logFilePath(chunk))
+		require.NoError(t, err)
+		assert.Equal(t, chunk.Data, content)
+
+		close(stream.release)
+		require.NoError(t, <-errCh)
+		require.NotNil(t, stream.response)
+		assert.Equal(t, uint64(1), stream.response.ChunksReceived)
+		assert.Equal(t, uint64(len(chunk.Data)), stream.response.BytesWritten)
 	})
 
 	t.Run("HandlesEmptyChunks", func(t *testing.T) {
@@ -677,4 +728,23 @@ func TestLogHandler_HandleStream(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "stderr output\n", string(stderrContent))
 	})
+}
+
+type blockingStreamLogsServer struct {
+	mockStreamLogsServer
+	chunk     *coordinatorv1.LogChunk
+	waiting   chan struct{}
+	release   chan struct{}
+	delivered bool
+}
+
+func (s *blockingStreamLogsServer) Recv() (*coordinatorv1.LogChunk, error) {
+	if !s.delivered {
+		s.delivered = true
+		return s.chunk, nil
+	}
+
+	close(s.waiting)
+	<-s.release
+	return nil, io.EOF
 }

--- a/internal/service/worker/coordreport/export_test.go
+++ b/internal/service/worker/coordreport/export_test.go
@@ -108,7 +108,7 @@ func FlushStepLogWriterWithBuffer(w *StepLogWriter, data []byte) StepLogWriterFl
 
 	initialSequence := w.sequence
 	w.buffer = data
-	err := w.flush()
+	err := w.flushLocked()
 
 	return StepLogWriterFlushResult{
 		Err:             err,

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/logger"
@@ -29,6 +30,9 @@ const (
 	// maxChunkSize is the maximum size of a single log chunk sent via gRPC.
 	// Keep below 4MB to leave room for proto overhead and stay within gRPC limits.
 	maxChunkSize = 3 * 1024 * 1024 // 3MB
+
+	logFlushInterval          = 500 * time.Millisecond
+	logStreamOperationTimeout = 5 * time.Second
 )
 
 func isLogStreamingNotConfigured(err error) bool {
@@ -133,8 +137,13 @@ func (s *LogStreamer) openStream(ctx context.Context) (coordinatorv1.Coordinator
 // NewStepWriter creates a writer that streams to coordinator
 // streamType should be execution.StreamTypeStdout or execution.StreamTypeStderr
 func (s *LogStreamer) NewStepWriter(ctx context.Context, stepName string, streamType int) io.WriteCloser {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	streamCtx, cancel := context.WithCancel(ctx)
 	return &stepLogWriter{
-		ctx:        ctx,
+		ctx:        streamCtx,
+		cancel:     cancel,
 		streamer:   s,
 		stepName:   stepName,
 		streamType: streamType,
@@ -151,13 +160,18 @@ func (s *LogStreamer) NewSchedulerLogWriter(ctx context.Context, localFile *os.F
 	}
 	streamCtx, cancel := context.WithCancel(ctx)
 	w := &schedulerLogWriter{
-		ctx:       streamCtx,
-		cancel:    cancel,
-		streamer:  s,
-		localFile: localFile,
-		buffer:    make([]byte, 0, logBufferSize),
+		ctx:           streamCtx,
+		cancel:        cancel,
+		streamer:      s,
+		localFile:     localFile,
+		buffer:        make([]byte, 0, logBufferSize),
+		flushStop:     make(chan struct{}),
+		flushFinished: make(chan struct{}),
+		flushWake:     make(chan struct{}, 1),
+		closeDone:     make(chan struct{}),
 	}
 	s.registerSchedulerWriter(w)
+	go w.runFlushLoop()
 	return w
 }
 
@@ -257,6 +271,7 @@ func (s *LogStreamer) StreamSchedulerLog(ctx context.Context, logFilePath string
 // stepLogWriter implements io.WriteCloser for streaming logs
 type stepLogWriter struct {
 	ctx              context.Context
+	cancel           context.CancelFunc
 	streamer         *LogStreamer
 	stepName         string
 	streamType       int
@@ -265,7 +280,7 @@ type stepLogWriter struct {
 	stream           coordinatorv1.CoordinatorService_StreamLogsClient
 	mu               sync.Mutex
 	closed           bool
-	streamInitFailed bool // Tracks permanent stream initialization failure
+	streamInitFailed bool // Tracks terminal stream failure
 }
 
 // Write implements io.Writer
@@ -281,23 +296,27 @@ func (w *stepLogWriter) Write(p []byte) (int, error) {
 
 	// Flush when buffer exceeds threshold
 	if len(w.buffer) >= logBufferSize {
-		if err := w.flush(); err != nil {
-			// Log streaming is best-effort - don't fail the command
-			logger.Warn(w.ctx, "Failed to stream logs, discarding buffer",
-				tag.Error(err),
-				tag.Step(w.stepName),
-			)
-			w.buffer = w.buffer[:0] // Discard to prevent memory growth
-		}
+		_ = w.flushLocked()
 	}
 
 	return len(p), nil
 }
 
-// flush sends buffered data to coordinator.
+// Flush sends pending log data to the coordinator.
+func (w *stepLogWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return nil
+	}
+	return w.flushLocked()
+}
+
+// flushLocked sends buffered data to coordinator.
 // Implements chunk splitting for large buffers to stay within gRPC message size limits.
 // Sequence numbers are only incremented after successful Send to avoid gaps.
-func (w *stepLogWriter) flush() error {
+func (w *stepLogWriter) flushLocked() error {
 	if len(w.buffer) == 0 {
 		return nil
 	}
@@ -323,11 +342,14 @@ func (w *stepLogWriter) flush() error {
 
 		// Initialize stream if needed
 		if w.stream == nil {
-			var err error
-			w.stream, err = w.streamer.openStream(w.ctx)
+			var stream coordinatorv1.CoordinatorService_StreamLogsClient
+			err := w.withOperationTimeout(func() error {
+				var err error
+				stream, err = w.streamer.openStream(w.ctx)
+				return err
+			})
 			if err != nil {
-				// Mark as permanently failed to prevent tight retry loop
-				w.streamInitFailed = true
+				w.disableStreamLocked(err)
 				streamingDisabled = true
 				if isLogStreamingNotConfigured(err) {
 					continue
@@ -335,12 +357,9 @@ func (w *stepLogWriter) flush() error {
 				if firstErr == nil {
 					firstErr = err
 				}
-				logger.Error(w.ctx, "Stream initialization failed permanently",
-					tag.Error(err),
-					tag.Step(w.stepName),
-				)
 				continue
 			}
+			w.stream = stream
 		}
 
 		// Use peek value for sequence - only increment after successful Send
@@ -359,23 +378,49 @@ func (w *stepLogWriter) flush() error {
 			OwnerCoordinatorId: w.streamer.owner.ID,
 		}
 
-		if err := w.stream.Send(chunk); err != nil {
+		if err := w.withOperationTimeout(func() error {
+			return w.stream.Send(chunk)
+		}); err != nil {
+			w.disableStreamLocked(err)
+			streamingDisabled = true
 			if isLogStreamingNotConfigured(err) {
-				w.streamInitFailed = true
-				w.stream = nil
-				streamingDisabled = true
 				continue
 			}
 			if firstErr == nil {
 				firstErr = err
 			}
-			streamingDisabled = true
 			continue
 		}
 		w.sequence = nextSeq // Only increment after successful Send
 	}
 
 	return firstErr
+}
+
+func (w *stepLogWriter) disableStreamLocked(err error) {
+	if w.streamInitFailed {
+		return
+	}
+	w.streamInitFailed = true
+	if isLogStreamingNotConfigured(err) {
+		return
+	}
+	logger.Warn(w.ctx, "Step log streaming disabled after stream failure",
+		tag.Error(err),
+		tag.Step(w.stepName),
+	)
+}
+
+func (w *stepLogWriter) cancelStream() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+}
+
+func (w *stepLogWriter) withOperationTimeout(operation func() error) error {
+	cancelTimer := time.AfterFunc(logStreamOperationTimeout, w.cancelStream)
+	defer cancelTimer.Stop()
+	return operation()
 }
 
 // Close implements io.Closer
@@ -387,59 +432,59 @@ func (w *stepLogWriter) Close() error {
 		return nil
 	}
 	w.closed = true
+	defer w.cancelStream()
 
 	var firstErr error
 
 	// Flush any remaining data
-	if err := w.flush(); err != nil {
-		logger.Error(w.ctx, "Failed to flush log buffer", tag.Error(err))
+	if err := w.flushLocked(); err != nil {
 		firstErr = err
 	}
 
 	// Send final marker
-	if w.stream != nil && !w.streamInitFailed {
-		// Use peek value for sequence - only increment after successful Send
-		nextSeq := w.sequence + 1
-		finalChunk := &coordinatorv1.LogChunk{
-			WorkerId:           w.streamer.workerID,
-			DagRunId:           w.streamer.dagRunID,
-			DagName:            w.streamer.dagName,
-			StepName:           w.stepName,
-			StreamType:         toProtoStreamType(w.streamType),
-			IsFinal:            true,
-			Sequence:           nextSeq,
-			RootDagRunName:     w.streamer.rootRef.Name,
-			RootDagRunId:       w.streamer.rootRef.ID,
-			AttemptId:          w.streamer.getAttemptID(),
-			OwnerCoordinatorId: w.streamer.owner.ID,
-		}
-		closeStream := true
-		if err := w.stream.Send(finalChunk); err != nil {
-			if isLogStreamingNotConfigured(err) {
-				w.streamInitFailed = true
-				w.stream = nil
-				closeStream = false
-			} else {
-				logger.Error(w.ctx, "Failed to send final log chunk", tag.Error(err))
-				if firstErr == nil {
-					firstErr = err
-				}
+	if w.stream != nil {
+		if !w.streamInitFailed {
+			// Use peek value for sequence - only increment after successful Send
+			nextSeq := w.sequence + 1
+			finalChunk := &coordinatorv1.LogChunk{
+				WorkerId:           w.streamer.workerID,
+				DagRunId:           w.streamer.dagRunID,
+				DagName:            w.streamer.dagName,
+				StepName:           w.stepName,
+				StreamType:         toProtoStreamType(w.streamType),
+				IsFinal:            true,
+				Sequence:           nextSeq,
+				RootDagRunName:     w.streamer.rootRef.Name,
+				RootDagRunId:       w.streamer.rootRef.ID,
+				AttemptId:          w.streamer.getAttemptID(),
+				OwnerCoordinatorId: w.streamer.owner.ID,
 			}
-		} else {
-			w.sequence = nextSeq // Only increment after successful Send
-		}
-
-		// Close and receive response
-		if closeStream {
-			_, err := w.stream.CloseAndRecv()
-			if err != nil {
-				if isLogStreamingNotConfigured(err) {
-					w.streamInitFailed = true
-				} else {
-					logger.Error(w.ctx, "Failed to close log stream", tag.Error(err))
+			if err := w.withOperationTimeout(func() error {
+				return w.stream.Send(finalChunk)
+			}); err != nil {
+				w.disableStreamLocked(err)
+				if !isLogStreamingNotConfigured(err) {
 					if firstErr == nil {
 						firstErr = err
 					}
+				}
+			} else {
+				w.sequence = nextSeq // Only increment after successful Send
+			}
+		}
+
+		err := w.withOperationTimeout(func() error {
+			_, err := w.stream.CloseAndRecv()
+			return err
+		})
+		w.stream = nil
+		if err != nil {
+			if isLogStreamingNotConfigured(err) {
+				w.streamInitFailed = true
+			} else {
+				logger.Error(w.ctx, "Failed to close log stream", tag.Error(err))
+				if firstErr == nil {
+					firstErr = err
 				}
 			}
 		}
@@ -474,7 +519,14 @@ type schedulerLogWriter struct {
 	stream           coordinatorv1.CoordinatorService_StreamLogsClient
 	mu               sync.Mutex
 	closed           bool
+	streamMu         sync.Mutex
 	streamInitFailed bool // Tracks permanent stream initialization failure
+	flushStop        chan struct{}
+	flushFinished    chan struct{}
+	flushWake        chan struct{}
+	flushStopOnce    sync.Once
+	closeOnce        sync.Once
+	closeDone        chan struct{}
 }
 
 func (w *schedulerLogWriter) cancelStream() {
@@ -483,27 +535,53 @@ func (w *schedulerLogWriter) cancelStream() {
 	}
 }
 
+func (w *schedulerLogWriter) runFlushLoop() {
+	defer close(w.flushFinished)
+
+	ticker := time.NewTicker(logFlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.flushStop:
+			return
+		case <-w.flushWake:
+			_ = w.Flush()
+		case <-ticker.C:
+			_ = w.Flush()
+		}
+	}
+}
+
+func (w *schedulerLogWriter) stopFlushLoop() {
+	w.flushStopOnce.Do(func() {
+		close(w.flushStop)
+	})
+	<-w.flushFinished
+}
+
+func (w *schedulerLogWriter) requestFlush() {
+	select {
+	case w.flushWake <- struct{}{}:
+	default:
+	}
+}
+
 // Write implements io.Writer - writes to local file and buffers for streaming
 func (w *schedulerLogWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	if w.closed {
+		w.mu.Unlock()
 		return 0, io.ErrClosedPipe
 	}
 
-	n, err := w.writeLocalAndBufferLocked(p)
+	n, shouldFlush, err := w.writeLocalAndBufferLocked(p)
+	w.mu.Unlock()
+	if shouldFlush {
+		w.requestFlush()
+	}
 	if err != nil {
 		return n, err
-	}
-
-	// Flush to coordinator when buffer exceeds threshold
-	if len(w.buffer) >= logBufferSize {
-		if err := w.flush(); err != nil {
-			// Log streaming is best-effort - don't fail the write
-			// Avoid recursive logging by not using logger here
-			w.buffer = w.buffer[:0] // Discard to prevent memory growth
-		}
 	}
 
 	return n, nil
@@ -511,54 +589,78 @@ func (w *schedulerLogWriter) Write(p []byte) (int, error) {
 
 func (w *schedulerLogWriter) mirrorStepOutput(p []byte) {
 	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	_, _, _ = w.writeLocalAndBufferLocked(p)
+	w.mu.Unlock()
+
+	w.requestFlush()
+}
+
+func (w *schedulerLogWriter) takePendingData() ([]byte, int64, bool) {
+	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	if w.closed {
-		return
+		return nil, w.localBytes, true
+	}
+	if len(w.buffer) == 0 {
+		return nil, w.localBytes, false
 	}
 
-	_, _ = w.writeLocalAndBufferLocked(p)
-	if len(w.buffer) >= logBufferSize {
-		_ = w.flush()
-	}
+	data := w.buffer
+	w.buffer = make([]byte, 0, logBufferSize)
+	return data, w.localBytes, false
 }
 
-func (w *schedulerLogWriter) writeLocalAndBufferLocked(p []byte) (int, error) {
+func (w *schedulerLogWriter) writeLocalAndBufferLocked(p []byte) (int, bool, error) {
 	// Always write to local file first (primary storage)
 	n, err := w.localFile.Write(p)
 	if n > 0 {
 		w.localBytes += int64(n)
+		if len(w.buffer)+n >= logBufferSize {
+			w.buffer = w.buffer[:0]
+			return n, true, err
+		}
 		w.buffer = append(w.buffer, p[:n]...)
 	}
-	return n, err
+	return n, false, err
 }
 
-// flush sends buffered data to coordinator
-func (w *schedulerLogWriter) flush() error {
-	if len(w.buffer) == 0 {
+// Flush sends pending scheduler log data to the coordinator.
+func (w *schedulerLogWriter) Flush() error {
+	data, localBytes, closed := w.takePendingData()
+	if closed {
 		return nil
 	}
 
+	w.streamMu.Lock()
+	defer w.streamMu.Unlock()
+	return w.flushDataLocked(data, localBytes)
+}
+
+func (w *schedulerLogWriter) flushDataLocked(data []byte, localBytes int64) error {
 	// Check for permanent stream initialization failure
 	if w.streamInitFailed {
-		w.buffer = w.buffer[:0]
 		return nil // Silently fail - already logged on first failure
 	}
 
-	// Initialize stream if needed
-	if err := w.ensureStreamLocked(); err != nil {
-		w.buffer = w.buffer[:0]
-		return err
+	if w.streamedBytes >= localBytes {
+		return nil
 	}
 
-	// Split buffer into chunks if necessary
-	if w.streamedBytes < w.localBytes-int64(len(w.buffer)) {
-		w.buffer = w.buffer[:0]
-		return w.streamUnsentLocalFileLocked()
+	bufferStart := localBytes - int64(len(data))
+	if len(data) == 0 || w.streamedBytes < bufferStart {
+		return w.streamUnsentLocalFileLocked(localBytes)
 	}
-	data := w.buffer
-	w.buffer = w.buffer[:0]
-	return w.sendSchedulerDataLocked(data)
+
+	offset := w.streamedBytes - bufferStart
+	if offset >= int64(len(data)) {
+		return nil
+	}
+	return w.sendSchedulerDataLocked(data[offset:])
 }
 
 func (w *schedulerLogWriter) ensureStreamLocked() error {
@@ -623,35 +725,74 @@ func (w *schedulerLogWriter) sendSchedulerDataLocked(data []byte) error {
 	return nil
 }
 
-func (w *schedulerLogWriter) streamUnsentLocalFileLocked() error {
+func (w *schedulerLogWriter) streamUnsentLocalFileLocked(localBytes int64) error {
 	if w.streamInitFailed || w.localFile == nil {
 		return nil
 	}
+	if err := w.ensureStreamLocked(); err != nil {
+		return err
+	}
+	if w.streamInitFailed || w.streamedBytes >= localBytes {
+		return nil
+	}
 
-	data, err := os.ReadFile(w.localFile.Name())
+	// #nosec G304 -- the path belongs to the scheduler log file opened by the runtime.
+	replayFile, err := os.Open(w.localFile.Name())
 	if err != nil {
 		return err
 	}
-	if w.streamedBytes >= int64(len(data)) {
-		return nil
+	defer func() { _ = replayFile.Close() }()
+
+	for w.streamedBytes < localBytes {
+		chunkSize := int(min(localBytes-w.streamedBytes, int64(maxChunkSize)))
+		data := make([]byte, chunkSize)
+		n, readErr := replayFile.ReadAt(data, w.streamedBytes)
+		if n > 0 {
+			if err := w.sendSchedulerDataLocked(data[:n]); err != nil {
+				return err
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF && w.streamedBytes >= localBytes {
+				return nil
+			}
+			return readErr
+		}
 	}
-	return w.sendSchedulerDataLocked(data[w.streamedBytes:])
+	return nil
 }
 
 // Close implements io.Closer - flushes remaining data and closes the stream
 func (w *schedulerLogWriter) Close() error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.closeOnce.Do(func() {
+		defer close(w.closeDone)
+		w.close()
+	})
+	<-w.closeDone
+	return nil
+}
+
+func (w *schedulerLogWriter) close() {
+	cancelTimer := time.AfterFunc(logStreamOperationTimeout, w.cancelStream)
+	defer cancelTimer.Stop()
 	defer w.cancelStream()
 
-	if w.closed {
-		return nil
-	}
+	w.mu.Lock()
 	w.closed = true
+	data := w.buffer
+	w.buffer = nil
+	localBytes := w.localBytes
+	w.mu.Unlock()
 
-	// Flush any remaining buffered data
-	_ = w.flush() // Ignore error - best effort
-	_ = w.streamUnsentLocalFileLocked()
+	w.stopFlushLoop()
+
+	w.streamMu.Lock()
+	defer w.streamMu.Unlock()
+
+	_ = w.flushDataLocked(data, localBytes)
+	if w.streamedBytes < localBytes {
+		_ = w.streamUnsentLocalFileLocked(localBytes)
+	}
 
 	// Send final marker if stream was initialized
 	if w.stream != nil {
@@ -674,9 +815,6 @@ func (w *schedulerLogWriter) Close() error {
 	}
 
 	w.streamer.unregisterSchedulerWriter(w)
-
-	// The caller owns localFile.
-	return nil
 }
 
 func (w *schedulerLogWriter) CloseWithContext(ctx context.Context) error {

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -31,7 +31,7 @@ const (
 	// Keep below 4MB to leave room for proto overhead and stay within gRPC limits.
 	maxChunkSize = 3 * 1024 * 1024 // 3MB
 
-	logFlushInterval          = 500 * time.Millisecond
+	logFlushInterval          = 2 * time.Second
 	logStreamOperationTimeout = 5 * time.Second
 )
 
@@ -281,6 +281,7 @@ type stepLogWriter struct {
 	mu               sync.Mutex
 	closed           bool
 	streamInitFailed bool // Tracks terminal stream failure
+	pendingSince     time.Time
 }
 
 // Write implements io.Writer
@@ -292,6 +293,9 @@ func (w *stepLogWriter) Write(p []byte) (int, error) {
 		return 0, io.ErrClosedPipe
 	}
 
+	if len(w.buffer) == 0 {
+		w.pendingSince = time.Now()
+	}
 	w.buffer = append(w.buffer, p...)
 
 	// Flush when buffer exceeds threshold
@@ -313,6 +317,17 @@ func (w *stepLogWriter) Flush() error {
 	return w.flushLocked()
 }
 
+// FlushIfDue sends pending log data after the buffering interval has elapsed.
+func (w *stepLogWriter) FlushIfDue() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed || len(w.buffer) == 0 || time.Since(w.pendingSince) < logFlushInterval {
+		return nil
+	}
+	return w.flushLocked()
+}
+
 // flushLocked sends buffered data to coordinator.
 // Implements chunk splitting for large buffers to stay within gRPC message size limits.
 // Sequence numbers are only incremented after successful Send to avoid gaps.
@@ -324,6 +339,7 @@ func (w *stepLogWriter) flushLocked() error {
 	// Split buffer into chunks if necessary to stay within gRPC limits
 	data := w.buffer
 	w.buffer = w.buffer[:0]
+	w.pendingSince = time.Time{}
 	streamingDisabled := w.streamInitFailed
 	var firstErr error
 

--- a/internal/service/worker/coordreport/log_streamer.go
+++ b/internal/service/worker/coordreport/log_streamer.go
@@ -610,8 +610,8 @@ func (w *schedulerLogWriter) takePendingData() ([]byte, int64, bool) {
 		return nil, w.localBytes, false
 	}
 
-	data := w.buffer
-	w.buffer = make([]byte, 0, logBufferSize)
+	data := append([]byte(nil), w.buffer...)
+	w.buffer = w.buffer[:0]
 	return data, w.localBytes, false
 }
 

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -313,6 +313,34 @@ func TestFlush_SmallDataBeforeClose(t *testing.T) {
 	assert.True(t, chunks[1].IsFinal)
 }
 
+func TestFlushIfDue_SmallDataWhileOpen(t *testing.T) {
+	t.Parallel()
+
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
+	defer func() { require.NoError(t, writer.Close()) }()
+
+	data := []byte("small log message")
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.FlushIfDue())
+	assert.Empty(t, mockStream.getSentChunks())
+
+	require.Eventually(t, func() bool {
+		if err := writer.FlushIfDue(); err != nil {
+			return false
+		}
+		chunks := mockStream.getSentChunks()
+		return len(chunks) == 1 && string(chunks[0].Data) == string(data)
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
 func TestWrite_ExactThreshold(t *testing.T) {
 	t.Parallel()
 	mockStream := &mockStreamLogsClient{}
@@ -1599,7 +1627,7 @@ func TestSchedulerLogWriterRetriesSparseDataAfterStreamOpenFailure(t *testing.T)
 			}
 		}
 		return false
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 8*time.Second, 10*time.Millisecond)
 	assert.GreaterOrEqual(t, openCount.Load(), int32(2))
 }
 

--- a/internal/service/worker/coordreport/log_streamer_test.go
+++ b/internal/service/worker/coordreport/log_streamer_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/service/coordinator"
@@ -277,6 +278,39 @@ func TestWrite_SmallData(t *testing.T) {
 	assert.Equal(t, len(data), n)
 	// No chunks sent yet - buffer not full
 	assert.Empty(t, mockStream.getSentChunks())
+}
+
+func TestFlush_SmallDataBeforeClose(t *testing.T) {
+	t.Parallel()
+
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+	writer := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
+
+	data := []byte("small log message")
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Flush())
+
+	chunks := mockStream.getSentChunks()
+	require.Len(t, chunks, 1)
+	assert.Equal(t, data, chunks[0].Data)
+	assert.False(t, chunks[0].IsFinal)
+	assert.Equal(t, uint64(1), chunks[0].Sequence)
+
+	require.NoError(t, writer.Flush())
+	assert.Len(t, mockStream.getSentChunks(), 1)
+
+	require.NoError(t, writer.Close())
+	require.NoError(t, writer.Flush())
+	chunks = mockStream.getSentChunks()
+	require.Len(t, chunks, 2)
+	assert.True(t, chunks[1].IsFinal)
 }
 
 func TestWrite_ExactThreshold(t *testing.T) {
@@ -1370,6 +1404,7 @@ func TestLogStreamer_StepOutputMirrorsToSchedulerLog(t *testing.T) {
 		const schedulerData = "scheduler live data\n"
 		const stdoutData = "stdout mirror data\n"
 		const stderrData = "stderr mirror data\n"
+		const afterData = "scheduler after step output\n"
 
 		_, err = scheduler.Write([]byte(schedulerData))
 		require.NoError(t, err)
@@ -1380,17 +1415,18 @@ func TestLogStreamer_StepOutputMirrorsToSchedulerLog(t *testing.T) {
 
 		require.NoError(t, stdout.Close())
 		require.NoError(t, stderr.Close())
+		_, err = scheduler.Write([]byte(afterData))
+		require.NoError(t, err)
 		require.NoError(t, scheduler.Close())
 
 		logData, err := os.ReadFile(localFile.Name())
 		require.NoError(t, err)
 		logContent := string(logData)
-		assert.Equal(t, 1, strings.Count(logContent, stdoutData))
-		assert.Equal(t, 1, strings.Count(logContent, stderrData))
+		assert.Equal(t, schedulerData+stdoutData+stderrData+afterData, logContent)
 
 		chunks := mockStream.getSentChunks()
 		var stdoutChunk, stderrChunk bool
-		var schedulerChunks []string
+		var schedulerLog strings.Builder
 		for _, chunk := range chunks {
 			switch {
 			case chunk.StreamType == coordinatorv1.LogStreamType_LOG_STREAM_TYPE_STDOUT &&
@@ -1401,25 +1437,26 @@ func TestLogStreamer_StepOutputMirrorsToSchedulerLog(t *testing.T) {
 				stderrChunk = true
 			case chunk.StreamType == coordinatorv1.LogStreamType_LOG_STREAM_TYPE_SCHEDULER &&
 				!chunk.IsFinal:
-				schedulerChunks = append(schedulerChunks, string(chunk.Data))
+				schedulerLog.Write(chunk.Data)
 			}
 		}
 		assert.True(t, stdoutChunk)
 		assert.True(t, stderrChunk)
-		assert.Equal(t, []string{schedulerData + stdoutData + stderrData}, schedulerChunks)
+		assert.Equal(t, schedulerData+stdoutData+stderrData+afterData, schedulerLog.String())
 	})
 
 	t.Run("failed step send still mirrors to scheduler stream", func(t *testing.T) {
-		stepStream := &mockStreamLogsClient{sendErr: errors.New("step send failed")}
-		schedulerStream := &mockStreamLogsClient{}
-		var streamCalls int
+		mockStream := &mockStreamLogsClient{
+			sendFunc: func(_ int, chunk *coordinatorv1.LogChunk) error {
+				if chunk.StreamType != coordinatorv1.LogStreamType_LOG_STREAM_TYPE_SCHEDULER {
+					return errors.New("step send failed")
+				}
+				return nil
+			},
+		}
 		client := &logStreamerMockClient{
 			streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
-				streamCalls++
-				if streamCalls == 1 {
-					return schedulerStream, nil
-				}
-				return stepStream, nil
+				return mockStream, nil
 			},
 		}
 		streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
@@ -1446,16 +1483,16 @@ func TestLogStreamer_StepOutputMirrorsToSchedulerLog(t *testing.T) {
 
 		logData, err := os.ReadFile(localFile.Name())
 		require.NoError(t, err)
-		assert.Equal(t, 1, strings.Count(string(logData), marker))
+		assert.Equal(t, schedulerData+stepData, string(logData))
 
-		var schedulerChunks []string
-		for _, chunk := range schedulerStream.getSentChunks() {
+		var schedulerLog strings.Builder
+		for _, chunk := range mockStream.getSentChunks() {
 			if chunk.StreamType == coordinatorv1.LogStreamType_LOG_STREAM_TYPE_SCHEDULER &&
 				!chunk.IsFinal {
-				schedulerChunks = append(schedulerChunks, string(chunk.Data))
+				schedulerLog.Write(chunk.Data)
 			}
 		}
-		assert.Equal(t, []string{schedulerData + stepData}, schedulerChunks)
+		assert.Equal(t, schedulerData+stepData, schedulerLog.String())
 	})
 
 	t.Run("scheduler send failure preserves tail order", func(t *testing.T) {
@@ -1496,6 +1533,143 @@ func TestLogStreamer_StepOutputMirrorsToSchedulerLog(t *testing.T) {
 		}
 		assert.Equal(t, first+second, schedulerLog.String())
 	})
+}
+
+func TestSchedulerLogWriterFlushesSparseDataWhileOpen(t *testing.T) {
+	t.Parallel()
+
+	mockStream := &mockStreamLogsClient{}
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			return mockStream, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+
+	localFile, err := os.CreateTemp(t.TempDir(), "scheduler-*.log")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, localFile.Close()) }()
+
+	writer := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+	defer func() { require.NoError(t, writer.Close()) }()
+
+	data := []byte("sparse scheduler log\n")
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		chunks := mockStream.getSentChunks()
+		return len(chunks) == 1 &&
+			!chunks[0].IsFinal &&
+			chunks[0].StreamType == coordinatorv1.LogStreamType_LOG_STREAM_TYPE_SCHEDULER &&
+			string(chunks[0].Data) == string(data)
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestSchedulerLogWriterRetriesSparseDataAfterStreamOpenFailure(t *testing.T) {
+	t.Parallel()
+
+	mockStream := &mockStreamLogsClient{}
+	var openCount atomic.Int32
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(_ context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			if openCount.Add(1) == 1 {
+				return nil, errors.New("temporary open failure")
+			}
+			return mockStream, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+
+	localFile, err := os.CreateTemp(t.TempDir(), "scheduler-*.log")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, localFile.Close()) }()
+
+	writer := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+	defer func() { require.NoError(t, writer.Close()) }()
+
+	data := []byte("sparse scheduler retry\n")
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		for _, chunk := range mockStream.getSentChunks() {
+			if !chunk.IsFinal && string(chunk.Data) == string(data) {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.GreaterOrEqual(t, openCount.Load(), int32(2))
+}
+
+func TestStepFlushDoesNotWaitForBlockedSchedulerStream(t *testing.T) {
+	sendStarted := make(chan struct{})
+	releaseSend := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseScheduler := func() {
+		releaseOnce.Do(func() { close(releaseSend) })
+	}
+	defer releaseScheduler()
+
+	var streamCount atomic.Int32
+	client := &logStreamerMockClient{
+		streamLogsFunc: func(ctx context.Context) (coordinatorv1.CoordinatorService_StreamLogsClient, error) {
+			if streamCount.Add(1) != 1 {
+				return &mockStreamLogsClient{}, nil
+			}
+
+			var startedOnce sync.Once
+			return &mockStreamLogsClient{
+				sendFunc: func(_ int, _ *coordinatorv1.LogChunk) error {
+					startedOnce.Do(func() { close(sendStarted) })
+					select {
+					case <-releaseSend:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
+			}, nil
+		},
+	}
+	streamer := coordreport.NewLogStreamer(client, "w", "r", "d", "a", exec.DAGRunRef{})
+
+	localFile, err := os.CreateTemp(t.TempDir(), "scheduler-*.log")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, localFile.Close()) }()
+
+	scheduler := streamer.NewSchedulerLogWriter(context.Background(), localFile)
+	_, err = scheduler.Write([]byte("scheduler data\n"))
+	require.NoError(t, err)
+
+	select {
+	case <-sendStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler stream did not begin sending")
+	}
+
+	step := streamer.NewStepWriter(context.Background(), "step", exec.StreamTypeStdout).(*coordreport.StepLogWriter)
+	_, err = step.Write([]byte("step data\n"))
+	require.NoError(t, err)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- step.Flush()
+	}()
+
+	select {
+	case err := <-flushDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		releaseScheduler()
+		<-flushDone
+		t.Fatal("step flush waited for the scheduler stream")
+	}
+
+	require.NoError(t, step.Close())
+	releaseScheduler()
+	require.NoError(t, scheduler.Close())
 }
 
 func TestLogStreamer_LargeOutput(t *testing.T) {


### PR DESCRIPTION
## Summary
- flush distributed step stdout and stderr on a time cadence as well as the existing size threshold
- preserve scheduler/step log ordering while keeping local logs writable during coordinator stalls
- make coordinator log chunks visible immediately without a synchronous disk barrier per chunk
- add runtime, worker, coordinator, file, and distributed regression coverage for live sub-threshold logs

## Changes
- expose explicit flush behavior on distributed step writers and invoke it through the runtime output flusher
- stream sparse scheduler logs asynchronously while preserving local ordering and bounded replay
- write coordinator stream chunks through OS buffering, then sync when the stream closes
- retain the scheduler accumulation buffer and snapshot only pending bytes during background sends
- bound log-stream operations and shutdown during coordinator failures
- cover live visibility, ordering, retry, timeout, and cross-platform file behavior

## Root cause
Small distributed log writes were buffered at multiple layers. Worker step streams waited for the size threshold or close, scheduler streams could retain sparse writes, and the coordinator added another buffered writer. A step that emitted less than the thresholds could therefore appear silent until it finished.

## Impact
Distributed stdout, stderr, and combined scheduler logs become readable while a run is still active. Coordinator writes remain immediately visible without forcing synchronous persistence for every chunk; stream close supplies the durability boundary. Stream failures remain bounded, local scheduler logging continues during coordinator stalls, and unsent scheduler data is replayed in order after recovery. No configuration or API changes are required.

## Related Issues
Closes #2310

## Testing
- `go test ./internal/service/worker/coordreport -count=1`
- `go test -race ./internal/cmn/fileutil ./internal/service/coordinator ./internal/service/worker/coordreport -count=1`
- `go test ./internal/service/worker -count=1`
- `go test ./internal/service/coordinator -count=1`
- `go test ./internal/runtime -count=1`
- `go test ./internal/intg/distr -run '^TestExecution_(LogStreaming|DistributedWorkerLogsVisibleFromCoordinator|SmallDistributedWorkerLogsVisibleBeforeStepCompletes)$' -count=1`
- repeated sparse-flush and pre-completion visibility tests
- `make lint`
- `git diff --check`

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make distributed logs visible while runs are still active by periodically flushing small step output and writing coordinator chunks straight to disk with OS buffering. Preserves log order, keeps scheduler logs writable during stalls, avoids blocking step streams, and reduces I/O and flush overhead.

- **Bug Fixes**
  - Worker: periodically flush stdout/stderr; add `Flush()`/`FlushIfDue()` on step writers; bound gRPC send/close with a short timeout.
  - Coordinator: write streamed chunks directly to log files via OS-buffered appends (sync on close) so tiny logs are visible immediately.
  - Scheduler: keep local writes during coordinator stalls; flush sparse data on a timer while open; replay unsent bytes in order after recovery; step flushes no longer wait on a blocked scheduler stream.
  - Runtime/Tests: only flush when due to reduce noisy flushes; add coverage for live sub-threshold logs, sparse flush, stream-open retry, and executor periodic flushing.

<sup>Written for commit c1fe42e490f996bc377667a0f337743037f561ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time visibility of step and scheduler logs while tasks are still running (including earlier stdout/stderr availability).
  * Added/strengthened time-based and periodic log flushing so small or sparse updates show up without waiting for completion.
  * Improved log streaming reliability with operation timeouts, better cancellation handling, and more resilient retry behavior.
  * Ensured stdout/stderr content is mirrored and ordered correctly across coordinator and scheduler logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
