### PR TITLE
feat: support dynamic template references

### DIFF
--- a/README_SCHEMA.md
+++ b/README_SCHEMA.md
@@ -199,7 +199,7 @@ Current builtin actions:
 | `router.route` | Conditional routing | `value`, `routes` |
 | `chat.completion` | LLM chat completion | `prompt` or `messages`, model config |
 | `harness.run` | CLI coding-agent harnesses | `prompt`, provider config, optional `stdin` |
-| `template.render` | Text/template rendering | `template`, optional data/config |
+| `template.render` | Text/template rendering | Exactly one of `template` or `template_ref`, optional data/config |
 | `log.write` | Log messages | `message` |
 | `mail.send` | Email sending | mail executor config |
 | `archive.create`, `archive.extract`, `archive.list` | Archive operations | archive config |

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -6679,13 +6679,27 @@
     },
     "templateRenderActionConfig": {
       "type": "object",
-      "required": ["template"],
       "additionalProperties": true,
+      "oneOf": [
+        {
+          "required": ["template"],
+          "not": { "required": ["template_ref"] }
+        },
+        {
+          "required": ["template_ref"],
+          "not": { "required": ["template"] }
+        }
+      ],
       "properties": {
         "template": {
           "type": "string",
           "minLength": 1,
           "description": "Template text rendered by the template executor."
+        },
+        "template_ref": {
+          "type": "string",
+          "pattern": "^\\$\\{(?:consts\\.[A-Za-z][A-Za-z0-9_]*|params\\.[A-Za-z][A-Za-z0-9_]*|env\\.[A-Za-z_][A-Za-z0-9_]*|steps\\.[A-Za-z][A-Za-z0-9_]*\\.outputs\\.[A-Za-z_][A-Za-z0-9_]*|foreach\\.[A-Za-z][A-Za-z0-9_]*(?:\\.[A-Za-z][A-Za-z0-9_]*)?|context\\.(?:dag\\.name|run\\.(?:id|status|scheduled_at|root_name|root_id)|attempt\\.(?:id|started_at)|step\\.(?:id|name)|trigger\\.(?:type|actor)|paths\\.(?:log_file|work_dir|artifacts_dir|step_stdout_file|step_stderr_file|step_output_file)|profile\\.(?:name|resolved_at)|pushback\\.(?:iteration|previous_stdout_file)))\\}$",
+          "description": "One complete scoped Dagu value reference resolved once to template text at runtime."
         }
       },
       "description": "Configuration for action: template.render."

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -507,6 +507,70 @@ steps:
 `,
 		},
 		{
+			name: "TemplateRenderLiteral",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      template: "Hello, {{ .name }}!"
+      data:
+        name: Alice
+`,
+		},
+		{
+			name: "TemplateRenderReference",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      template_ref: ${env.TEMPLATE}
+      data:
+        name: Alice
+`,
+		},
+		{
+			name: "RejectTemplateRenderMissingSource",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      data:
+        name: Alice
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectTemplateRenderBothSources",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      template: "Hello"
+      template_ref: ${env.TEMPLATE}
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectTemplateRenderBareReference",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      template_ref: TEMPLATE
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "RejectTemplateRenderUnknownContextReference",
+			spec: `
+steps:
+  - action: template.render
+    with:
+      template_ref: ${context.unknown.value}
+`,
+			wantErr: "did not validate",
+		},
+		{
 			name: "ArtifactActions",
 			spec: `
 steps:

--- a/internal/cmn/value/references.go
+++ b/internal/cmn/value/references.go
@@ -89,14 +89,13 @@ func HasValueReference(raw string) bool {
 	return false
 }
 
-// IsScopedReferenceToken reports whether token is one complete canonical Dagu
-// value reference.
-func IsScopedReferenceToken(token string) bool {
-	_, ok := parseScopedReferenceToken(token)
+// IsExactRef reports whether token is an exact canonical scoped reference.
+func IsExactRef(token string) bool {
+	_, ok := parseExactRef(token)
 	return ok
 }
 
-func parseScopedReferenceToken(token string) (reference, bool) {
+func parseExactRef(token string) (reference, bool) {
 	refs := scanReferences(token)
 	if len(refs) != 1 {
 		return reference{}, false

--- a/internal/cmn/value/references.go
+++ b/internal/cmn/value/references.go
@@ -89,6 +89,37 @@ func HasValueReference(raw string) bool {
 	return false
 }
 
+// IsScopedReferenceToken reports whether token is one complete canonical Dagu
+// value reference.
+func IsScopedReferenceToken(token string) bool {
+	_, ok := parseScopedReferenceToken(token)
+	return ok
+}
+
+func parseScopedReferenceToken(token string) (reference, bool) {
+	refs := scanReferences(token)
+	if len(refs) != 1 {
+		return reference{}, false
+	}
+	ref := refs[0]
+	if ref.Kind != referenceStrict || !ref.Braced || ref.Start != 0 || ref.End != len(token) {
+		return reference{}, false
+	}
+	if ref.Raw != "${"+ref.Expr+"}" {
+		return reference{}, false
+	}
+
+	switch ref.Namespace {
+	case "consts", "env", "steps", "foreach", "context":
+		return ref, true
+	case "params":
+		// The aggregate ${params} form is JSON data, not a named value reference.
+		return ref, len(ref.Segments) == 2
+	default:
+		return reference{}, false
+	}
+}
+
 func classifyBracedReference(rawRef, expr string, start, end int) reference {
 	segments := strings.Split(expr, ".")
 	ref := reference{

--- a/internal/cmn/value/references_test.go
+++ b/internal/cmn/value/references_test.go
@@ -60,6 +60,35 @@ func TestScanReferencesMarksExactStepOutputRefs(t *testing.T) {
 	assert.Equal(t, "${steps.extract.outputs.user}", outputRefs[0].Expression)
 }
 
+func TestIsScopedReferenceToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{token: "${consts.template}", want: true},
+		{token: "${params.template}", want: true},
+		{token: "${env.TEMPLATE}", want: true},
+		{token: "${steps.fetch.outputs.template}", want: true},
+		{token: "${foreach.item}", want: true},
+		{token: "${foreach.item.template}", want: true},
+		{token: "${context.run.id}", want: true},
+		{token: "${params}", want: false},
+		{token: "${run.id}", want: false},
+		{token: "${TEMPLATE}", want: false},
+		{token: "$env.TEMPLATE", want: false},
+		{token: "${ env.TEMPLATE }", want: false},
+		{token: "prefix-${env.TEMPLATE}", want: false},
+		{token: "${env.TEMPLATE}-${params.suffix}", want: false},
+		{token: `\${env.TEMPLATE}`, want: false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, value.IsScopedReferenceToken(tt.token), tt.token)
+	}
+}
+
 func TestResolverStringResolvesParamsAndPreservesOtherNamespaces(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/value/references_test.go
+++ b/internal/cmn/value/references_test.go
@@ -60,7 +60,7 @@ func TestScanReferencesMarksExactStepOutputRefs(t *testing.T) {
 	assert.Equal(t, "${steps.extract.outputs.user}", outputRefs[0].Expression)
 }
 
-func TestIsScopedReferenceToken(t *testing.T) {
+func TestIsExactRef(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -85,7 +85,7 @@ func TestIsScopedReferenceToken(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, value.IsScopedReferenceToken(tt.token), tt.token)
+		assert.Equal(t, tt.want, value.IsExactRef(tt.token), tt.token)
 	}
 }
 

--- a/internal/cmn/value/resolver.go
+++ b/internal/cmn/value/resolver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/dagucloud/dagu/internal/cmn/cmdutil"
 )
@@ -49,6 +50,35 @@ func WithoutCommandSubstitution() ResolverOption {
 // String resolves raw according to field.
 func (r Resolver) String(ctx context.Context, raw string, field Field) (string, error) {
 	return r.resolveString(ctx, raw, field)
+}
+
+// ResolveScopedReference resolves one complete canonical Dagu value reference
+// to non-empty string content.
+func (r Resolver) ResolveScopedReference(ctx context.Context, token string, field Field) (string, error) {
+	ref, ok := parseScopedReferenceToken(token)
+	if !ok {
+		return "", fieldError(field, fmt.Errorf("must be one complete scoped value reference"))
+	}
+
+	value, err := bindingValue(ctx, ref.Expr, r.bindingScope(), true)
+	if err != nil {
+		return "", fieldError(field, fmt.Errorf("failed to resolve %s: %w", token, err))
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fieldError(field, fmt.Errorf("%s must resolve to a string, got %T", token, value))
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", fieldError(field, fmt.Errorf("%s resolved to an empty string", token))
+	}
+	return text, nil
+}
+
+func fieldError(field Field, err error) error {
+	if field.path == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", field.path, err)
 }
 
 // Int resolves raw according to field and converts the result to an integer.

--- a/internal/cmn/value/resolver.go
+++ b/internal/cmn/value/resolver.go
@@ -52,10 +52,9 @@ func (r Resolver) String(ctx context.Context, raw string, field Field) (string, 
 	return r.resolveString(ctx, raw, field)
 }
 
-// ResolveScopedReference resolves one complete canonical Dagu value reference
-// to non-empty string content.
-func (r Resolver) ResolveScopedReference(ctx context.Context, token string, field Field) (string, error) {
-	ref, ok := parseScopedReferenceToken(token)
+// ResolveRef resolves an exact scoped reference to a non-empty string.
+func (r Resolver) ResolveRef(ctx context.Context, token string, field Field) (string, error) {
+	ref, ok := parseExactRef(token)
 	if !ok {
 		return "", fieldError(field, fmt.Errorf("must be one complete scoped value reference"))
 	}

--- a/internal/cmn/value/resolver_test.go
+++ b/internal/cmn/value/resolver_test.go
@@ -28,7 +28,7 @@ func TestResolverConstLoadResolvesConstsAndPreservesRuntimeBindings(t *testing.T
 	assert.Equal(t, "${params.environment}", got)
 }
 
-func TestResolveScopedReferenceReturnsTemplateTextWithoutFurtherExpansion(t *testing.T) {
+func TestResolveRefSinglePass(t *testing.T) {
 	t.Parallel()
 
 	templateText := "  Hello, {{ .name }}! ${env.NESTED} `command`\n"
@@ -42,7 +42,7 @@ func TestResolveScopedReferenceReturnsTemplateTextWithoutFurtherExpansion(t *tes
 		},
 	)
 
-	got, err := resolver.ResolveScopedReference(
+	got, err := resolver.ResolveRef(
 		context.Background(),
 		"${env.TEMPLATE}",
 		value.TemplateConfigField("with.template_ref"),
@@ -51,7 +51,7 @@ func TestResolveScopedReferenceReturnsTemplateTextWithoutFurtherExpansion(t *tes
 	assert.Equal(t, templateText, got)
 }
 
-func TestResolveScopedReferenceRequiresAvailableNonEmptyString(t *testing.T) {
+func TestResolveRefValidation(t *testing.T) {
 	t.Parallel()
 
 	resolver := value.NewResolver(
@@ -77,7 +77,7 @@ func TestResolveScopedReferenceRequiresAvailableNonEmptyString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := resolver.ResolveScopedReference(
+			_, err := resolver.ResolveRef(
 				context.Background(),
 				tt.token,
 				value.TemplateConfigField("with.template_ref"),

--- a/internal/cmn/value/resolver_test.go
+++ b/internal/cmn/value/resolver_test.go
@@ -28,6 +28,65 @@ func TestResolverConstLoadResolvesConstsAndPreservesRuntimeBindings(t *testing.T
 	assert.Equal(t, "${params.environment}", got)
 }
 
+func TestResolveScopedReferenceReturnsTemplateTextWithoutFurtherExpansion(t *testing.T) {
+	t.Parallel()
+
+	templateText := "  Hello, {{ .name }}! ${env.NESTED} `command`\n"
+	resolver := value.NewResolver(
+		value.StaticScope{},
+		value.RuntimeScope{
+			Env: testEnvScope(map[string]string{
+				"TEMPLATE": templateText,
+				"NESTED":   "must-not-expand",
+			}),
+		},
+	)
+
+	got, err := resolver.ResolveScopedReference(
+		context.Background(),
+		"${env.TEMPLATE}",
+		value.TemplateConfigField("with.template_ref"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, templateText, got)
+}
+
+func TestResolveScopedReferenceRequiresAvailableNonEmptyString(t *testing.T) {
+	t.Parallel()
+
+	resolver := value.NewResolver(
+		value.StaticScope{Consts: value.Values{"object": map[string]any{"template": "value"}}},
+		value.RuntimeScope{
+			Consts: value.Values{"object": map[string]any{"template": "value"}},
+			Env:    testEnvScope(map[string]string{"EMPTY": " \n"}),
+		},
+	)
+
+	tests := []struct {
+		name  string
+		token string
+		err   string
+	}{
+		{name: "invalid token", token: "env.TEMPLATE", err: "must be one complete scoped value reference"},
+		{name: "missing value", token: "${env.MISSING}", err: "unknown env.MISSING binding"},
+		{name: "non-string value", token: "${consts.object}", err: "must resolve to a string"},
+		{name: "empty value", token: "${env.EMPTY}", err: "resolved to an empty string"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolver.ResolveScopedReference(
+				context.Background(),
+				tt.token,
+				value.TemplateConfigField("with.template_ref"),
+			)
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
 func TestResolverUnresolvedStrictReferencesPreserve(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
 	"github.com/dagucloud/dagu/internal/core"
 )
 
@@ -672,12 +673,30 @@ func validateGitWorktreeOutputOverrides(normalized map[string]any) error {
 }
 
 func normalizeTemplateAction(normalized map[string]any, with map[string]any) error {
-	template, err := requireActionStringField(with, "template")
-	if err != nil {
-		return err
+	if with == nil {
+		return core.NewValidationError("with", nil, fmt.Errorf("template.render requires exactly one of with.template or with.template_ref"))
 	}
-	delete(with, "template")
-	normalized["script"] = template
+
+	templateValue, hasTemplate := with["template"]
+	templateRefValue, hasTemplateRef := with["template_ref"]
+	if hasTemplate == hasTemplateRef {
+		return core.NewValidationError("with", with, fmt.Errorf("template.render requires exactly one of with.template or with.template_ref"))
+	}
+
+	if hasTemplate {
+		template, ok := templateValue.(string)
+		if !ok || strings.TrimSpace(template) == "" {
+			return core.NewValidationError("with", with, fmt.Errorf("with.template must be a non-empty string"))
+		}
+		delete(with, "template")
+		normalized["script"] = strings.TrimSpace(template)
+		return finishAction(normalized, "template", with)
+	}
+
+	templateRef, ok := templateRefValue.(string)
+	if !ok || !cmnvalue.IsScopedReferenceToken(templateRef) {
+		return core.NewValidationError("with", with, fmt.Errorf("with.template_ref must be one complete scoped value reference such as ${env.NAME}"))
+	}
 	return finishAction(normalized, "template", with)
 }
 

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -673,28 +673,24 @@ func validateGitWorktreeOutputOverrides(normalized map[string]any) error {
 }
 
 func normalizeTemplateAction(normalized map[string]any, with map[string]any) error {
-	if with == nil {
-		return core.NewValidationError("with", nil, fmt.Errorf("template.render requires exactly one of with.template or with.template_ref"))
-	}
-
-	templateValue, hasTemplate := with["template"]
-	templateRefValue, hasTemplateRef := with["template_ref"]
-	if hasTemplate == hasTemplateRef {
+	_, hasTemplate := with["template"]
+	refValue, hasRef := with["template_ref"]
+	if hasTemplate == hasRef {
 		return core.NewValidationError("with", with, fmt.Errorf("template.render requires exactly one of with.template or with.template_ref"))
 	}
 
 	if hasTemplate {
-		template, ok := templateValue.(string)
-		if !ok || strings.TrimSpace(template) == "" {
-			return core.NewValidationError("with", with, fmt.Errorf("with.template must be a non-empty string"))
+		template, err := requireActionStringField(with, "template")
+		if err != nil {
+			return err
 		}
 		delete(with, "template")
-		normalized["script"] = strings.TrimSpace(template)
+		normalized["script"] = template
 		return finishAction(normalized, "template", with)
 	}
 
-	templateRef, ok := templateRefValue.(string)
-	if !ok || !cmnvalue.IsScopedReferenceToken(templateRef) {
+	ref, ok := refValue.(string)
+	if !ok || !cmnvalue.IsExactRef(ref) {
 		return core.NewValidationError("with", with, fmt.Errorf("with.template_ref must be one complete scoped value reference such as ${env.NAME}"))
 	}
 	return finishAction(normalized, "template", with)

--- a/internal/core/spec/step_v2_test.go
+++ b/internal/core/spec/step_v2_test.go
@@ -426,6 +426,79 @@ steps:
 	assert.Contains(t, err.Error(), `jq.filter does not allow both with.data and with.input`)
 }
 
+func TestStepSchemaV2_ActionTemplateReference(t *testing.T) {
+	t.Parallel()
+
+	dag, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: render
+    action: template.render
+    with:
+      template_ref: ${env.TEMPLATE}
+      data:
+        name: Alice
+`))
+	require.NoError(t, err)
+	require.Len(t, dag.Steps, 1)
+
+	step := dag.Steps[0]
+	assert.Equal(t, "template", step.ExecutorConfig.Type)
+	assert.Empty(t, step.Script)
+	assert.Equal(t, "${env.TEMPLATE}", step.ExecutorConfig.Config["template_ref"])
+	assert.Equal(t, map[string]any{"name": "Alice"}, step.ExecutorConfig.Config["data"])
+}
+
+func TestStepSchemaV2_ActionTemplateRequiresOneUnambiguousSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		with string
+		err  string
+	}{
+		{
+			name: "missing source",
+			with: "data: {name: Alice}",
+			err:  "requires exactly one of with.template or with.template_ref",
+		},
+		{
+			name: "both sources",
+			with: "template: hello\n      template_ref: ${env.TEMPLATE}",
+			err:  "requires exactly one of with.template or with.template_ref",
+		},
+		{
+			name: "bare name",
+			with: "template_ref: TEMPLATE",
+			err:  "must be one complete scoped value reference",
+		},
+		{
+			name: "mixed reference",
+			with: "template_ref: prefix-${env.TEMPLATE}",
+			err:  "must be one complete scoped value reference",
+		},
+		{
+			name: "legacy alias",
+			with: "template_ref: ${run.id}",
+			err:  "must be one complete scoped value reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := LoadYAML(context.Background(), []byte(`
+steps:
+  - id: render
+    action: template.render
+    with:
+      `+tt.with+`
+`))
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
 func TestStepSchemaV2_ActionDataConvert(t *testing.T) {
 	t.Parallel()
 

--- a/internal/intg/template_test.go
+++ b/internal/intg/template_test.go
@@ -44,6 +44,91 @@ func TestTemplateExecutor(t *testing.T) {
 		})
 	})
 
+	t.Run("EnvironmentTemplateReference", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `env:
+  - TEMPLATE: "Hello, {{ .name }}!"
+
+steps:
+  - id: render
+    action: template.render
+    with:
+      template_ref: ${env.TEMPLATE}
+      data:
+        name: Alice
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "Hello, Alice!",
+		})
+	})
+
+	t.Run("StepOutputTemplateReference", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `steps:
+  - id: produce
+    run: |
+      printf 'template=%s\n' 'Hello, {{ .name }}!' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: template
+
+  - id: render
+    depends:
+      - produce
+    action: template.render
+    with:
+      template_ref: ${steps.produce.outputs.template}
+      data:
+        name: Bob
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "Hello, Bob!",
+		})
+	})
+
+	t.Run("TemplateReferenceUsesSinglePassResolution", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.Setup(t)
+		dag := th.DAG(t, `params:
+  - name: template
+    type: string
+    default: 'Hello, {{ .name }}! ${env.NESTED}'
+
+env:
+  - NESTED: must-not-expand
+
+steps:
+  - id: render
+    action: template.render
+    with:
+      template_ref: ${params.template}
+      data:
+        name: Alice
+    output: RESULT
+`)
+		agent := dag.Agent()
+		agent.RunSuccess(t)
+
+		dag.AssertLatestStatus(t, core.Succeeded)
+		dag.AssertOutputs(t, map[string]any{
+			"RESULT": "Hello, Alice! ${env.NESTED}",
+		})
+	})
+
 	t.Run("FileOnly", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/runtime/builtin/template/config.go
+++ b/internal/runtime/builtin/template/config.go
@@ -11,8 +11,9 @@ import (
 var configSchema = &jsonschema.Schema{
 	Type: "object",
 	Properties: map[string]*jsonschema.Schema{
-		"data":   {Type: "object", Description: "Template data variables accessible as {{ .key }} in the template"},
-		"output": {Type: "string", Description: "File path to write the rendered output to. If empty, output is written to stdout."},
+		"data":         {Type: "object", Description: "Template data variables accessible as {{ .key }} in the template"},
+		"output":       {Type: "string", Description: "File path to write the rendered output to. If empty, output is written to stdout."},
+		"template_ref": {Type: "string", Description: "Complete scoped Dagu value reference that resolves to template text."},
 	},
 }
 

--- a/internal/runtime/builtin/template/template.go
+++ b/internal/runtime/builtin/template/template.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/internal/cmn/templatefuncs"
+	cmnvalue "github.com/dagucloud/dagu/internal/cmn/value"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/runtime"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
@@ -125,8 +126,19 @@ func decodeConfig(dat map[string]any, cfg *templateConfig) error {
 }
 
 func validateTemplate(step core.Step) error {
-	if step.Script == "" {
+	templateRef, hasTemplateRef := step.ExecutorConfig.Config["template_ref"]
+	if step.Script != "" && hasTemplateRef {
+		return core.NewValidationError("with.template_ref", templateRef, fmt.Errorf("template step cannot use both script and with.template_ref"))
+	}
+	if step.Script != "" {
+		return nil
+	}
+	if !hasTemplateRef {
 		return core.NewValidationError("script", nil, fmt.Errorf("script field is required"))
+	}
+	ref, ok := templateRef.(string)
+	if !ok || !cmnvalue.IsScopedReferenceToken(ref) {
+		return core.NewValidationError("with.template_ref", templateRef, fmt.Errorf("must be one complete scoped value reference such as ${env.NAME}"))
 	}
 	return nil
 }

--- a/internal/runtime/builtin/template/template.go
+++ b/internal/runtime/builtin/template/template.go
@@ -126,19 +126,19 @@ func decodeConfig(dat map[string]any, cfg *templateConfig) error {
 }
 
 func validateTemplate(step core.Step) error {
-	templateRef, hasTemplateRef := step.ExecutorConfig.Config["template_ref"]
-	if step.Script != "" && hasTemplateRef {
-		return core.NewValidationError("with.template_ref", templateRef, fmt.Errorf("template step cannot use both script and with.template_ref"))
+	refValue, hasRef := step.ExecutorConfig.Config["template_ref"]
+	if step.Script != "" && hasRef {
+		return core.NewValidationError("with.template_ref", refValue, fmt.Errorf("template step cannot use both script and with.template_ref"))
 	}
 	if step.Script != "" {
 		return nil
 	}
-	if !hasTemplateRef {
+	if !hasRef {
 		return core.NewValidationError("script", nil, fmt.Errorf("script field is required"))
 	}
-	ref, ok := templateRef.(string)
-	if !ok || !cmnvalue.IsScopedReferenceToken(ref) {
-		return core.NewValidationError("with.template_ref", templateRef, fmt.Errorf("must be one complete scoped value reference such as ${env.NAME}"))
+	ref, ok := refValue.(string)
+	if !ok || !cmnvalue.IsExactRef(ref) {
+		return core.NewValidationError("with.template_ref", refValue, fmt.Errorf("must be one complete scoped value reference such as ${env.NAME}"))
 	}
 	return nil
 }

--- a/internal/runtime/builtin/template/template_test.go
+++ b/internal/runtime/builtin/template/template_test.go
@@ -23,6 +23,56 @@ func TestValidateTemplateRequiresScriptMessage(t *testing.T) {
 	assert.NotContains(t, err.Error(), "executor")
 }
 
+func TestValidateTemplateAcceptsScopedTemplateReference(t *testing.T) {
+	t.Parallel()
+
+	err := validateTemplate(core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Config: map[string]any{"template_ref": "${env.TEMPLATE}"},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateTemplateRejectsAmbiguousTemplateReference(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		step core.Step
+		err  string
+	}{
+		{
+			name: "script and reference",
+			step: core.Step{
+				Script: "literal",
+				ExecutorConfig: core.ExecutorConfig{
+					Config: map[string]any{"template_ref": "${env.TEMPLATE}"},
+				},
+			},
+			err: "cannot use both script and with.template_ref",
+		},
+		{
+			name: "invalid reference",
+			step: core.Step{
+				ExecutorConfig: core.ExecutorConfig{
+					Config: map[string]any{"template_ref": "TEMPLATE"},
+				},
+			},
+			err: "must be one complete scoped value reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateTemplate(tt.step)
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
 func TestNewTemplateRequiresScriptMessage(t *testing.T) {
 	_, err := newTemplate(context.Background(), core.Step{})
 	require.Error(t, err)

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -783,6 +784,16 @@ func (n *Node) setupExecutor(ctx context.Context) (context.Context, executor.Exe
 	if err != nil {
 		return ctx, nil, fmt.Errorf("failed to evaluate step configuration: %w", err)
 	}
+	if execConfig.Type == "template" && n.Step().Script == "" {
+		if templateText, ok := cfg["template_ref"]; ok {
+			resolvedTemplate, ok := templateText.(string)
+			if !ok {
+				return ctx, nil, fmt.Errorf("failed to evaluate step configuration: with.template_ref must resolve to a string")
+			}
+			n.SetScript(resolvedTemplate)
+			delete(cfg, "template_ref")
+		}
+	}
 	execConfig.Config = cfg
 	n.SetExecutorConfig(execConfig)
 
@@ -887,11 +898,38 @@ func evalExecutorConfig(ctx context.Context, step core.Step) (map[string]any, er
 			scope = cmnvalue.NewEnvScope(nil, false)
 		}
 		scope = scope.WithEntries(templateConfigEvalVariables(env), cmnvalue.EnvSourceStepEnv)
-		got, err := resolveRuntimeObjectWithScope(ctx, env, scope, step.ExecutorConfig.Config, cmnvalue.TemplateConfigField("with"))
+		config := maps.Clone(step.ExecutorConfig.Config)
+		templateRef, hasTemplateRef := config["template_ref"]
+		delete(config, "template_ref")
+
+		got, err := resolveRuntimeObjectWithScope(ctx, env, scope, config, cmnvalue.TemplateConfigField("with"))
 		if err != nil {
 			return nil, err
 		}
-		return objectAsConfig(got)
+		resolved, err := objectAsConfig(got)
+		if err != nil {
+			return nil, err
+		}
+		if !hasTemplateRef {
+			return resolved, nil
+		}
+
+		ref, ok := templateRef.(string)
+		if !ok {
+			return nil, fmt.Errorf("with.template_ref must be a string")
+		}
+		scopedEnv := env
+		scopedEnv.Scope = scope
+		templateText, err := resolverFromEnv(scopedEnv).ResolveScopedReference(
+			ctx,
+			ref,
+			cmnvalue.TemplateConfigField("with.template_ref"),
+		)
+		if err != nil {
+			return nil, err
+		}
+		resolved["template_ref"] = templateText
+		return resolved, nil
 	}
 	got, err := resolveRuntimeObject(ctx, step.ExecutorConfig.Config, cmnvalue.ExecutorConfigField("with"))
 	if err != nil {

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -891,51 +891,55 @@ func (n *Node) cleanupStepOutputFile() error {
 }
 
 func evalExecutorConfig(ctx context.Context, step core.Step) (map[string]any, error) {
-	env := GetEnv(ctx)
 	if step.ExecutorConfig.Type == "template" {
-		scope := env.Scope
-		if scope == nil {
-			scope = cmnvalue.NewEnvScope(nil, false)
-		}
-		scope = scope.WithEntries(templateConfigEvalVariables(env), cmnvalue.EnvSourceStepEnv)
-		config := maps.Clone(step.ExecutorConfig.Config)
-		templateRef, hasTemplateRef := config["template_ref"]
-		delete(config, "template_ref")
-
-		got, err := resolveRuntimeObjectWithScope(ctx, env, scope, config, cmnvalue.TemplateConfigField("with"))
-		if err != nil {
-			return nil, err
-		}
-		resolved, err := objectAsConfig(got)
-		if err != nil {
-			return nil, err
-		}
-		if !hasTemplateRef {
-			return resolved, nil
-		}
-
-		ref, ok := templateRef.(string)
-		if !ok {
-			return nil, fmt.Errorf("with.template_ref must be a string")
-		}
-		scopedEnv := env
-		scopedEnv.Scope = scope
-		templateText, err := resolverFromEnv(scopedEnv).ResolveScopedReference(
-			ctx,
-			ref,
-			cmnvalue.TemplateConfigField("with.template_ref"),
-		)
-		if err != nil {
-			return nil, err
-		}
-		resolved["template_ref"] = templateText
-		return resolved, nil
+		return evalTemplateConfig(ctx, step.ExecutorConfig.Config)
 	}
 	got, err := resolveRuntimeObject(ctx, step.ExecutorConfig.Config, cmnvalue.ExecutorConfigField("with"))
 	if err != nil {
 		return nil, err
 	}
 	return objectAsConfig(got)
+}
+
+func evalTemplateConfig(ctx context.Context, config map[string]any) (map[string]any, error) {
+	env := GetEnv(ctx)
+	scope := env.Scope
+	if scope == nil {
+		scope = cmnvalue.NewEnvScope(nil, false)
+	}
+	scope = scope.WithEntries(templateConfigEvalVariables(env), cmnvalue.EnvSourceStepEnv)
+
+	config = maps.Clone(config)
+	rawRef, hasRef := config["template_ref"]
+	delete(config, "template_ref")
+
+	got, err := resolveRuntimeObjectWithScope(ctx, env, scope, config, cmnvalue.TemplateConfigField("with"))
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := objectAsConfig(got)
+	if err != nil {
+		return nil, err
+	}
+	if !hasRef {
+		return resolved, nil
+	}
+
+	ref, ok := rawRef.(string)
+	if !ok {
+		return nil, fmt.Errorf("with.template_ref must be a string")
+	}
+	env.Scope = scope
+	templateText, err := resolverFromEnv(env).ResolveRef(
+		ctx,
+		ref,
+		cmnvalue.TemplateConfigField("with.template_ref"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	resolved["template_ref"] = templateText
+	return resolved, nil
 }
 
 func scriptField(ctx context.Context, step core.Step) cmnvalue.Field {

--- a/internal/runtime/node_internal_test.go
+++ b/internal/runtime/node_internal_test.go
@@ -91,6 +91,59 @@ func TestEvalExecutorConfig_TemplatePreservesLiteralCodeFencesInData(t *testing.
 	require.Equal(t, "```yaml\nenv:\n  TEST_FILE: ~/dagu-test.txt\n\nsteps:\n  - command: touch $TEST_FILE\n```", data["issue_text"])
 }
 
+func TestEvalExecutorConfig_TemplateReferenceResolvesOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := exec.NewContext(
+		context.Background(),
+		&core.DAG{Name: "test-dag"},
+		"",
+		"",
+	)
+	env := NewEnv(ctx, core.Step{Name: "render"})
+	env.Scope = env.Scope.WithEntries(map[string]string{
+		"TEMPLATE": "  Hello, {{ .name }}! ${env.NESTED} `command`\n",
+		"NESTED":   "must-not-expand",
+	}, cmnvalue.EnvSourceStepEnv)
+	ctx = WithEnv(ctx, env)
+
+	result, err := evalExecutorConfig(ctx, core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "template",
+			Config: map[string]any{
+				"template_ref": "${env.TEMPLATE}",
+				"data":         map[string]any{"name": "Alice"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "  Hello, {{ .name }}! ${env.NESTED} `command`\n", result["template_ref"])
+	require.Equal(t, map[string]any{"name": "Alice"}, result["data"])
+}
+
+func TestEvalExecutorConfig_TemplateReferenceMustResolve(t *testing.T) {
+	t.Parallel()
+
+	ctx := exec.NewContext(
+		context.Background(),
+		&core.DAG{Name: "test-dag"},
+		"",
+		"",
+	)
+	env := NewEnv(ctx, core.Step{Name: "render"})
+	ctx = WithEnv(ctx, env)
+
+	_, err := evalExecutorConfig(ctx, core.Step{
+		ExecutorConfig: core.ExecutorConfig{
+			Type: "template",
+			Config: map[string]any{
+				"template_ref": "${env.MISSING}",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "unknown env.MISSING binding")
+}
+
 // TestEvalExecutorConfig_DefaultPreservesLiteralCodeFencesInData verifies that
 // non-template executor config is also treated as step data and should not
 // execute backticks while resolving variable references.

--- a/llms.txt
+++ b/llms.txt
@@ -682,7 +682,7 @@ steps:
     output: RESULT
 ```
 
-`with.template` is required and is rendered as a template, not executed as shell. `with.output` writes rendered content to a file; top-level `output:` captures or publishes step output.
+Set exactly one of `with.template` or `with.template_ref`. `with.template` is literal template text. `with.template_ref` must be one complete canonical Dagu reference such as `${env.TEMPLATE}` or `${steps.fetch.outputs.template}`; it resolves once to a non-empty string, and references inside the resulting template remain literal. The selected text is rendered as a template, not executed as shell. `with.output` writes rendered content to a file; top-level `output:` captures or publishes step output.
 
 ## file.stat / file.read / file.write / file.copy / file.move / file.delete / file.mkdir / file.list
 

--- a/skills/dagu/references/steptypes.md
+++ b/skills/dagu/references/steptypes.md
@@ -472,7 +472,7 @@ steps:
     output: RESULT
 ```
 
-`with.template` is required and is rendered as a template, not executed as shell. `with.output` writes rendered content to a file; top-level `output:` captures or publishes step output.
+Set exactly one of `with.template` or `with.template_ref`. `with.template` is literal template text. `with.template_ref` must be one complete canonical Dagu reference such as `${env.TEMPLATE}` or `${steps.fetch.outputs.template}`; it resolves once to a non-empty string, and references inside the resulting template remain literal. The selected text is rendered as a template, not executed as shell. `with.output` writes rendered content to a file; top-level `output:` captures or publishes step output.
 
 ## file.stat / file.read / file.write / file.copy / file.move / file.delete / file.mkdir / file.list
 


### PR DESCRIPTION
## Summary

Add an unambiguous way for `template.render` to source its complete Go template from a runtime value.

## Changes

- add `with.template_ref` for exact canonical scoped references
- require exactly one of `template` or `template_ref`
- resolve the referenced value once to a non-empty string while preserving nested `${...}` text literally
- update runtime handling, validation, schemas, generated references, and documentation
- add unit, schema, runtime, and end-to-end coverage

## Related Issues

None.

## User Impact

```yaml
with:
  template_ref: ${env.MY_TEMPLATE}
```

The reference can target an environment value, named parameter, constant, step output, foreach value, or runtime context. Bare names, mixed text, multiple references, and legacy aliases are rejected.

## Validation

- `go test ./internal/cmn/value ./internal/core/spec ./internal/runtime/builtin/template ./internal/runtime ./internal/cmn/schema -count=1`
- `go test ./internal/intg -run '^TestTemplateExecutor$' -count=1`
- `make lint`
- `pnpm --dir docs build`

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally
