### PR TITLE
feat: combine profiles and secrets management

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import React from 'react';
-import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router-dom';
 import { SWRConfig, mutate as globalMutate } from 'swr';
 
 import { Shield } from 'lucide-react';
@@ -42,7 +42,7 @@ import {
 import { UserRole } from './api/v1/schema';
 import LoginPage from './pages/login';
 import SetupPage from './pages/setup';
-import LoadingIndicator from './components/ui/loading-indicator';
+import LoadingIndicator from '@/components/ui/loading-indicator';
 
 const AdministrationPage = React.lazy(() => import('./pages/administration'));
 const APIKeysPage = React.lazy(() => import('./pages/api-keys'));
@@ -78,7 +78,6 @@ const ProfilesPage = React.lazy(() => import('./pages/profiles'));
 const Queues = React.lazy(() => import('./pages/queues'));
 const QueueDetailsPage = React.lazy(() => import('./pages/queues/queue'));
 const Search = React.lazy(() => import('./pages/search'));
-const SecretsPage = React.lazy(() => import('./pages/secrets'));
 const SystemStatus = React.lazy(() => import('./pages/system-status'));
 const TerminalPage = React.lazy(() => import('./pages/terminal'));
 const RemoteNodesPage = React.lazy(() => import('./pages/remote-nodes'));
@@ -747,9 +746,10 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
                                       <Route
                                         path="/secrets"
                                         element={
-                                          <ManagerElement>
-                                            <SecretsPage />
-                                          </ManagerElement>
+                                          <Navigate
+                                            to="/profiles#secret-refs"
+                                            replace
+                                          />
                                         }
                                       />
                                       <Route

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -93,13 +93,14 @@ vi.mock('../pages/overview', () => {
   return { default: () => <h1>Overview</h1> };
 });
 vi.mock('../pages/views', () => ({ default: () => <h1>View</h1> }));
-vi.mock('../pages/profiles', () => ({ default: () => <h1>Profiles</h1> }));
+vi.mock('../pages/profiles', () => ({
+  default: () => <h1>Profiles &amp; Secrets</h1>,
+}));
 vi.mock('../pages/queues', () => ({ default: () => <h1>Queues</h1> }));
 vi.mock('../pages/queues/queue', () => ({
   default: () => <h1>Queue Details</h1>,
 }));
 vi.mock('../pages/search', () => ({ default: () => <h1>Search</h1> }));
-vi.mock('../pages/secrets', () => ({ default: () => <h1>Secrets</h1> }));
 vi.mock('../pages/setup', () => ({ default: () => <h1>Setup</h1> }));
 vi.mock('../pages/system-status', () => ({
   default: () => <h1>System Status</h1>,
@@ -213,6 +214,16 @@ describe('App license routing', () => {
     expect(
       screen.queryByRole('heading', { name: 'Incidents' })
     ).not.toBeInTheDocument();
+  });
+
+  it('redirects the legacy secrets route to the secret refs section', async () => {
+    renderAt('/secrets');
+
+    expect(
+      await screen.findByRole('heading', { name: 'Profiles & Secrets' })
+    ).toBeVisible();
+    expect(window.location.pathname).toBe('/profiles');
+    expect(window.location.hash).toBe('#secret-refs');
   });
 
   it('offers a reload when a lazy route chunk fails to load', async () => {

--- a/ui/src/__tests__/menu.test.tsx
+++ b/ui/src/__tests__/menu.test.tsx
@@ -242,13 +242,9 @@ describe('sidebar menu', () => {
     expect(
       screen.getByRole('button', { name: 'Toggle Integrations section' })
     ).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getByRole('link', { name: 'Profiles' })).toHaveAttribute(
-      'href',
-      '/profiles'
-    );
     expect(
-      screen.queryByRole('link', { name: 'Secrets' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('link', { name: 'Profiles & Secrets' })
+    ).toHaveAttribute('href', '/profiles');
     expect(
       screen.getByRole('link', { name: 'Administration' })
     ).toHaveAttribute('href', '/administration');

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -825,7 +825,7 @@ export const mainListItems = React.forwardRef<
           {canManageProfiles && (
             <NavItem
               to="/profiles"
-              text="Profiles"
+              text="Profiles & Secrets"
               icon={<SlidersHorizontal size={18} />}
               isOpen={isOpen}
               onClick={onNavItemClick}

--- a/ui/src/pages/administration/index.tsx
+++ b/ui/src/pages/administration/index.tsx
@@ -80,8 +80,8 @@ export default function AdministrationPage(): React.ReactElement {
       links: [
         {
           to: '/profiles',
-          label: 'Profiles',
-          description: 'Manage runtime variables and secrets.',
+          label: 'Profiles & Secrets',
+          description: 'Manage environment profiles and DAG secret refs.',
         },
       ],
     },

--- a/ui/src/pages/profiles/__tests__/index.test.tsx
+++ b/ui/src/pages/profiles/__tests__/index.test.tsx
@@ -94,32 +94,52 @@ describe('ProfilesPage', () => {
   it('switches between separate profile and secret ref tabs', async () => {
     const user = userEvent.setup();
     renderPage();
+    const profilesTab = screen.getByRole('tab', { name: 'Profiles' });
+    const secretRefsTab = screen.getByRole('tab', {
+      name: 'DAG Secret Refs',
+    });
+    const profilesPanel = document.getElementById('profiles-panel');
+    const secretRefsPanel = document.getElementById('secret-refs-panel');
 
     expect(
       screen.getByRole('heading', { name: 'Profiles & Secrets', level: 1 })
     ).toBeVisible();
-    expect(screen.getByRole('tab', { name: 'Profiles' })).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(profilesTab).toHaveAttribute('aria-selected', 'true');
+    expect(profilesTab).toHaveAttribute('tabindex', '0');
+    expect(secretRefsTab).toHaveAttribute('tabindex', '-1');
+    expect(profilesPanel).toBeVisible();
+    expect(secretRefsPanel).not.toBeVisible();
     expect(
       screen.getByRole('heading', { name: 'Profiles', level: 2 })
     ).toBeVisible();
     expect(
-      screen.queryByRole('heading', { name: 'DAG Secret Refs', level: 2 })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', {
+        name: 'DAG Secret Refs',
+        level: 2,
+        hidden: true,
+      })
+    ).not.toBeVisible();
 
-    await user.click(screen.getByRole('tab', { name: 'DAG Secret Refs' }));
+    profilesTab.focus();
+    await user.keyboard('{ArrowRight}');
 
     expect(
       screen.getByRole('heading', { name: 'DAG Secret Refs', level: 2 })
     ).toBeVisible();
+    expect(secretRefsTab).toHaveAttribute('aria-selected', 'true');
+    expect(secretRefsTab).toHaveAttribute('tabindex', '0');
+    expect(secretRefsTab).toHaveFocus();
+    expect(profilesTab).toHaveAttribute('tabindex', '-1');
+    expect(profilesPanel).not.toBeVisible();
+    expect(secretRefsPanel).toBeVisible();
+
+    await user.keyboard('{ArrowLeft}');
+
+    expect(profilesTab).toHaveAttribute('aria-selected', 'true');
+    expect(profilesTab).toHaveFocus();
     expect(
-      screen.getByRole('tab', { name: 'DAG Secret Refs' })
-    ).toHaveAttribute('aria-selected', 'true');
-    expect(
-      screen.queryByRole('heading', { name: 'Profiles', level: 2 })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Profiles', level: 2 })
+    ).toBeVisible();
   });
 
   it('disables protected profile mutations for non-admin managers', async () => {

--- a/ui/src/pages/profiles/__tests__/index.test.tsx
+++ b/ui/src/pages/profiles/__tests__/index.test.tsx
@@ -3,6 +3,7 @@
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RuntimeProfileEntryKind, RuntimeProfileStatus } from '@/api/v1/schema';
@@ -14,6 +15,7 @@ const mutateMock = vi.fn();
 
 vi.mock('@/contexts/AuthContext', () => ({
   useCanManageProfiles: () => true,
+  useCanManageSecrets: () => true,
   useCanWriteForWorkspace: () => false,
   useIsAdmin: () => false,
 }));
@@ -34,16 +36,18 @@ const useQueryMock = useQuery as unknown as {
 
 function renderPage() {
   render(
-    <AppBarContext.Provider
-      value={
-        {
-          setTitle: vi.fn(),
-          selectedRemoteNode: 'local',
-        } as never
-      }
-    >
-      <ProfilesPage />
-    </AppBarContext.Provider>
+    <MemoryRouter>
+      <AppBarContext.Provider
+        value={
+          {
+            setTitle: vi.fn(),
+            selectedRemoteNode: 'local',
+          } as never
+        }
+      >
+        <ProfilesPage />
+      </AppBarContext.Provider>
+    </MemoryRouter>
   );
 }
 
@@ -85,6 +89,20 @@ describe('ProfilesPage', () => {
         isLoading: false,
       };
     });
+  });
+
+  it('separates profiles from DAG secret refs on one page', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Profiles & Secrets', level: 1 })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('heading', { name: 'Profiles', level: 2 })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('heading', { name: 'DAG Secret Refs', level: 2 })
+    ).toBeVisible();
   });
 
   it('disables protected profile mutations for non-admin managers', async () => {

--- a/ui/src/pages/profiles/__tests__/index.test.tsx
+++ b/ui/src/pages/profiles/__tests__/index.test.tsx
@@ -34,9 +34,9 @@ const useQueryMock = useQuery as unknown as {
   mockImplementation: (fn: (path: string) => unknown) => void;
 };
 
-function renderPage() {
+function renderPage(initialEntry = '/profiles') {
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <AppBarContext.Provider
         value={
           {
@@ -91,18 +91,35 @@ describe('ProfilesPage', () => {
     });
   });
 
-  it('separates profiles from DAG secret refs on one page', () => {
+  it('switches between separate profile and secret ref tabs', async () => {
+    const user = userEvent.setup();
     renderPage();
 
     expect(
       screen.getByRole('heading', { name: 'Profiles & Secrets', level: 1 })
     ).toBeVisible();
+    expect(screen.getByRole('tab', { name: 'Profiles' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
     expect(
       screen.getByRole('heading', { name: 'Profiles', level: 2 })
     ).toBeVisible();
     expect(
+      screen.queryByRole('heading', { name: 'DAG Secret Refs', level: 2 })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'DAG Secret Refs' }));
+
+    expect(
       screen.getByRole('heading', { name: 'DAG Secret Refs', level: 2 })
     ).toBeVisible();
+    expect(
+      screen.getByRole('tab', { name: 'DAG Secret Refs' })
+    ).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.queryByRole('heading', { name: 'Profiles', level: 2 })
+    ).not.toBeInTheDocument();
   });
 
   it('disables protected profile mutations for non-admin managers', async () => {

--- a/ui/src/pages/profiles/index.tsx
+++ b/ui/src/pages/profiles/index.tsx
@@ -52,6 +52,7 @@ import { useClient, useQuery } from '@/hooks/api';
 import { whenEnabled } from '@/hooks/queryUtils';
 import dayjs from '@/lib/dayjs';
 import { workspaceNameForSelection } from '@/lib/workspace';
+import { SecretRefsSection } from '@/pages/secrets';
 import {
   Building2,
   Globe2,
@@ -71,6 +72,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import { useLocation } from 'react-router-dom';
 
 type RuntimeProfileResponse = components['schemas']['RuntimeProfileResponse'];
 type InheritedRuntimeProfileResponse =
@@ -343,6 +345,7 @@ function targetFromWorkspaceDefaults(
 export default function ProfilesPage(): React.ReactNode {
   const client = useClient();
   const appBarContext = useContext(AppBarContext);
+  const location = useLocation();
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
   const canManageProfiles = useCanManageProfiles();
   const canManageProtectedProfiles = useIsAdmin();
@@ -368,8 +371,14 @@ export default function ProfilesPage(): React.ReactNode {
   const [actionProfile, setActionProfile] = useState<string | null>(null);
 
   useEffect(() => {
-    appBarContext.setTitle('Profiles');
+    appBarContext.setTitle('Profiles & Secrets');
   }, [appBarContext]);
+
+  useEffect(() => {
+    if (location.hash === '#secret-refs') {
+      document.getElementById('secret-refs')?.scrollIntoView?.();
+    }
+  }, [location.hash]);
 
   const queryInit = useMemo(
     () =>
@@ -614,11 +623,19 @@ export default function ProfilesPage(): React.ReactNode {
 
   return (
     <div className="flex h-full min-h-0 max-w-7xl flex-col gap-4 overflow-auto">
+      <div>
+        <h1 className="text-lg font-semibold">Profiles &amp; Secrets</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage environment profiles and individual secret references used by
+          DAG runs.
+        </p>
+      </div>
+
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold">Profiles</h1>
+          <h2 className="text-base font-semibold">Profiles</h2>
           <p className="text-sm text-muted-foreground">
-            Managed runtime variables and secrets.
+            Environment bundles selected when a run starts.
           </p>
         </div>
         <Button
@@ -940,6 +957,8 @@ export default function ProfilesPage(): React.ReactNode {
           </TableBody>
         </Table>
       </div>
+
+      <SecretRefsSection />
 
       <ProfileFormDialog
         open={profileFormOpen}

--- a/ui/src/pages/profiles/index.tsx
+++ b/ui/src/pages/profiles/index.tsx
@@ -41,6 +41,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tab, Tabs } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import {
@@ -72,7 +73,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 type RuntimeProfileResponse = components['schemas']['RuntimeProfileResponse'];
 type InheritedRuntimeProfileResponse =
@@ -346,6 +347,9 @@ export default function ProfilesPage(): React.ReactNode {
   const client = useClient();
   const appBarContext = useContext(AppBarContext);
   const location = useLocation();
+  const navigate = useNavigate();
+  const activeTab =
+    location.hash === '#secret-refs' ? 'secret-refs' : 'profiles';
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
   const canManageProfiles = useCanManageProfiles();
   const canManageProtectedProfiles = useIsAdmin();
@@ -373,12 +377,6 @@ export default function ProfilesPage(): React.ReactNode {
   useEffect(() => {
     appBarContext.setTitle('Profiles & Secrets');
   }, [appBarContext]);
-
-  useEffect(() => {
-    if (location.hash === '#secret-refs') {
-      document.getElementById('secret-refs')?.scrollIntoView?.();
-    }
-  }, [location.hash]);
 
   const queryInit = useMemo(
     () =>
@@ -621,9 +619,20 @@ export default function ProfilesPage(): React.ReactNode {
     }
   }
 
+  function selectTab(tab: 'profiles' | 'secret-refs'): void {
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+        hash: tab === 'secret-refs' ? '#secret-refs' : '',
+      },
+      { replace: true }
+    );
+  }
+
   return (
-    <div className="flex h-full min-h-0 max-w-7xl flex-col gap-4 overflow-auto">
-      <div>
+    <div className="flex h-full min-h-0 max-w-7xl flex-col gap-4 overflow-hidden">
+      <div className="shrink-0">
         <h1 className="text-lg font-semibold">Profiles &amp; Secrets</h1>
         <p className="text-sm text-muted-foreground">
           Manage environment profiles and individual secret references used by
@@ -631,334 +640,394 @@ export default function ProfilesPage(): React.ReactNode {
         </p>
       </div>
 
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-base font-semibold">Profiles</h2>
-          <p className="text-sm text-muted-foreground">
-            Environment bundles selected when a run starts.
-          </p>
-        </div>
-        <Button
-          size="sm"
-          className="h-8"
-          disabled={!canManageProfiles}
-          onClick={() => {
-            setEditingProfile(null);
-            setProfileFormOpen(true);
-          }}
+      <Tabs
+        role="tablist"
+        aria-label="Profiles and secrets"
+        className="shrink-0"
+      >
+        <Tab
+          id="profiles-tab"
+          role="tab"
+          aria-selected={activeTab === 'profiles'}
+          aria-controls="profiles-panel"
+          isActive={activeTab === 'profiles'}
+          onClick={() => selectTab('profiles')}
+          className="cursor-pointer gap-2"
         >
-          <Plus className="mr-1.5 h-4 w-4" />
-          Add Profile
-        </Button>
-      </div>
+          <SlidersHorizontal className="h-4 w-4" />
+          Profiles
+        </Tab>
+        <Tab
+          id="secret-refs-tab"
+          role="tab"
+          aria-selected={activeTab === 'secret-refs'}
+          aria-controls="secret-refs-panel"
+          isActive={activeTab === 'secret-refs'}
+          onClick={() => selectTab('secret-refs')}
+          className="cursor-pointer gap-2"
+        >
+          <KeyRound className="h-4 w-4" />
+          DAG Secret Refs
+        </Tab>
+      </Tabs>
 
-      {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
-      {success && (
-        <div className="rounded-md bg-success/10 p-3 text-sm text-success">
-          {success}
-        </div>
-      )}
+      {activeTab === 'profiles' && (
+        <section
+          id="profiles-panel"
+          role="tabpanel"
+          aria-labelledby="profiles-tab"
+          className="min-h-0 flex-1 overflow-auto pr-1"
+        >
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold">Profiles</h2>
+                <p className="text-sm text-muted-foreground">
+                  Environment bundles selected when a run starts.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                className="h-8"
+                disabled={!canManageProfiles}
+                onClick={() => {
+                  setEditingProfile(null);
+                  setProfileFormOpen(true);
+                }}
+              >
+                <Plus className="mr-1.5 h-4 w-4" />
+                Add Profile
+              </Button>
+            </div>
 
-      {(canManageProtectedProfiles ||
-        (workspaceTarget && canManageWorkspaceDefaults)) && (
-        <div className="card-obsidian min-h-0 overflow-auto">
-          <Table className="text-xs">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[260px]">Default Layer</TableHead>
-                <TableHead className="w-[120px]">Scope</TableHead>
-                <TableHead>Entries</TableHead>
-                <TableHead className="w-[170px]">Updated</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {canManageProtectedProfiles && (
-                <TableRow>
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <Globe2 className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                        <span className="font-medium">
-                          {globalTarget.title}
-                        </span>
-                        <code className="whitespace-normal break-words text-xs text-muted-foreground">
-                          {globalTarget.name}
-                        </code>
-                      </div>
-                      {globalTarget.description && (
-                        <span className="text-xs text-muted-foreground">
-                          {globalTarget.description}
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline">Global</Badge>
-                  </TableCell>
-                  <TableCell>
-                    <ProfileEntriesCell
-                      target={globalTarget}
-                      busy={actionProfile === globalTarget.actionKey}
-                      isLoading={isGlobalDefaultsLoading}
-                      onAdd={openEntryDialog}
-                      onEdit={editEntry}
-                      onDelete={confirmDeleteEntry}
-                    />
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {globalTarget.updatedAt
-                      ? dayjs(globalTarget.updatedAt).format(
-                          'MMM D, YYYY HH:mm'
-                        )
-                      : 'Never'}
-                  </TableCell>
-                </TableRow>
-              )}
-              {workspaceTarget && canManageWorkspaceDefaults && (
-                <TableRow>
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <Building2 className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                        <span className="font-medium">
-                          {workspaceTarget.title}
-                        </span>
-                        <code className="whitespace-normal break-words text-xs text-muted-foreground">
-                          {workspaceTarget.name}
-                        </code>
-                      </div>
-                      {workspaceTarget.description && (
-                        <span className="text-xs text-muted-foreground">
-                          {workspaceTarget.description}
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline">Workspace</Badge>
-                  </TableCell>
-                  <TableCell>
-                    <ProfileEntriesCell
-                      target={workspaceTarget}
-                      busy={actionProfile === workspaceTarget.actionKey}
-                      isLoading={isWorkspaceDefaultsLoading}
-                      onAdd={openEntryDialog}
-                      onEdit={editEntry}
-                      onDelete={confirmDeleteEntry}
-                    />
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {workspaceTarget.updatedAt
-                      ? dayjs(workspaceTarget.updatedAt).format(
-                          'MMM D, YYYY HH:mm'
-                        )
-                      : 'Never'}
-                  </TableCell>
-                </TableRow>
-              )}
-              {workspaceTarget && canManageWorkspaceDefaults && (
-                <TableRow>
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <SlidersHorizontal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                        <span className="font-medium">
-                          Workspace default profile
-                        </span>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        Fallback when the run and DAG do not choose a profile.
-                      </span>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline">Workspace</Badge>
-                  </TableCell>
-                  <TableCell>
-                    <WorkspaceDefaultProfileCell
-                      profiles={activeProfiles}
-                      value={workspaceDefaults?.defaultProfile || ''}
-                      busy={actionProfile === workspaceDefaultProfileActionKey}
-                      disabled={!canManageProfiles}
-                      isLoading={isLoading || isWorkspaceDefaultsLoading}
-                      onChange={updateWorkspaceDefaultProfile}
-                    />
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {workspaceTarget.updatedAt
-                      ? dayjs(workspaceTarget.updatedAt).format(
-                          'MMM D, YYYY HH:mm'
-                        )
-                      : 'Never'}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-
-      <div className="card-obsidian min-h-0 overflow-auto">
-        <Table className="text-xs">
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[260px]">Profile</TableHead>
-              <TableHead className="w-[110px]">Status</TableHead>
-              <TableHead>Entries</TableHead>
-              <TableHead className="w-[170px]">Updated</TableHead>
-              <TableHead className="w-[80px]"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {!canManageProfiles ? (
-              <TableRow>
-                <TableCell
-                  colSpan={5}
-                  className="py-8 text-center text-muted-foreground"
-                >
-                  You do not have permission to manage profiles.
-                </TableCell>
-              </TableRow>
-            ) : isLoading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={5}
-                  className="py-8 text-center text-muted-foreground"
-                >
-                  Loading profiles...
-                </TableCell>
-              </TableRow>
-            ) : profiles.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={5}
-                  className="py-8 text-center text-muted-foreground"
-                >
-                  No profiles found.
-                </TableCell>
-              </TableRow>
-            ) : (
-              profiles.map((profile) => {
-                const profileManageDisabled = !canManageProfile(profile);
-                const profileBusy = actionProfile === profile.name;
-                const target = targetFromProfile(
-                  profile,
-                  !profileManageDisabled
-                );
-
-                return (
-                  <TableRow key={profile.id}>
-                    <TableCell>
-                      <div className="flex min-w-0 flex-col gap-1">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <SlidersHorizontal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
-                          <code className="whitespace-normal break-words text-xs">
-                            {profile.name}
-                          </code>
-                          {profile.protected && (
-                            <Badge
-                              variant="outline"
-                              className="h-5 px-1.5 text-[10px]"
-                            >
-                              Protected
-                            </Badge>
-                          )}
-                          {profile.protected && !canManageProtectedProfiles && (
-                            <Badge
-                              variant="secondary"
-                              className="h-5 px-1.5 text-[10px]"
-                            >
-                              Admin
-                            </Badge>
-                          )}
-                        </div>
-                        {profile.description && (
-                          <span className="text-xs text-muted-foreground">
-                            {profile.description}
-                          </span>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={
-                          profile.status === RuntimeProfileStatus.active
-                            ? 'success'
-                            : 'warning'
-                        }
-                      >
-                        {profile.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <ProfileEntriesCell
-                        target={target}
-                        busy={profileBusy}
-                        onAdd={openEntryDialog}
-                        onEdit={editEntry}
-                        onDelete={confirmDeleteEntry}
-                      />
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {dayjs(profile.updatedAt).format('MMM D, YYYY HH:mm')}
-                    </TableCell>
-                    <TableCell>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            aria-label={`Actions for ${profile.name}`}
-                            disabled={profileManageDisabled || profileBusy}
-                          >
-                            {profileBusy ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : (
-                              <MoreHorizontal className="h-4 w-4" />
-                            )}
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setEditingProfile(profile);
-                              setProfileFormOpen(true);
-                            }}
-                          >
-                            <Pencil className="mr-2 h-4 w-4" />
-                            Edit
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() => toggleStatus(profile)}
-                          >
-                            <Power className="mr-2 h-4 w-4" />
-                            {profile.status === RuntimeProfileStatus.active
-                              ? 'Disable'
-                              : 'Enable'}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className="text-destructive"
-                            onClick={() => setDeletingProfile(profile)}
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </TableCell>
-                  </TableRow>
-                );
-              })
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
             )}
-          </TableBody>
-        </Table>
-      </div>
+            {success && (
+              <div className="rounded-md bg-success/10 p-3 text-sm text-success">
+                {success}
+              </div>
+            )}
 
-      <SecretRefsSection />
+            {(canManageProtectedProfiles ||
+              (workspaceTarget && canManageWorkspaceDefaults)) && (
+              <div className="card-obsidian min-h-0 overflow-auto">
+                <Table className="text-xs">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[260px]">Default Layer</TableHead>
+                      <TableHead className="w-[120px]">Scope</TableHead>
+                      <TableHead>Entries</TableHead>
+                      <TableHead className="w-[170px]">Updated</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {canManageProtectedProfiles && (
+                      <TableRow>
+                        <TableCell>
+                          <div className="flex min-w-0 flex-col gap-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Globe2 className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                              <span className="font-medium">
+                                {globalTarget.title}
+                              </span>
+                              <code className="whitespace-normal break-words text-xs text-muted-foreground">
+                                {globalTarget.name}
+                              </code>
+                            </div>
+                            {globalTarget.description && (
+                              <span className="text-xs text-muted-foreground">
+                                {globalTarget.description}
+                              </span>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">Global</Badge>
+                        </TableCell>
+                        <TableCell>
+                          <ProfileEntriesCell
+                            target={globalTarget}
+                            busy={actionProfile === globalTarget.actionKey}
+                            isLoading={isGlobalDefaultsLoading}
+                            onAdd={openEntryDialog}
+                            onEdit={editEntry}
+                            onDelete={confirmDeleteEntry}
+                          />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {globalTarget.updatedAt
+                            ? dayjs(globalTarget.updatedAt).format(
+                                'MMM D, YYYY HH:mm'
+                              )
+                            : 'Never'}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {workspaceTarget && canManageWorkspaceDefaults && (
+                      <TableRow>
+                        <TableCell>
+                          <div className="flex min-w-0 flex-col gap-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Building2 className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                              <span className="font-medium">
+                                {workspaceTarget.title}
+                              </span>
+                              <code className="whitespace-normal break-words text-xs text-muted-foreground">
+                                {workspaceTarget.name}
+                              </code>
+                            </div>
+                            {workspaceTarget.description && (
+                              <span className="text-xs text-muted-foreground">
+                                {workspaceTarget.description}
+                              </span>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">Workspace</Badge>
+                        </TableCell>
+                        <TableCell>
+                          <ProfileEntriesCell
+                            target={workspaceTarget}
+                            busy={actionProfile === workspaceTarget.actionKey}
+                            isLoading={isWorkspaceDefaultsLoading}
+                            onAdd={openEntryDialog}
+                            onEdit={editEntry}
+                            onDelete={confirmDeleteEntry}
+                          />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {workspaceTarget.updatedAt
+                            ? dayjs(workspaceTarget.updatedAt).format(
+                                'MMM D, YYYY HH:mm'
+                              )
+                            : 'Never'}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {workspaceTarget && canManageWorkspaceDefaults && (
+                      <TableRow>
+                        <TableCell>
+                          <div className="flex min-w-0 flex-col gap-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <SlidersHorizontal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                              <span className="font-medium">
+                                Workspace default profile
+                              </span>
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              Fallback when the run and DAG do not choose a
+                              profile.
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">Workspace</Badge>
+                        </TableCell>
+                        <TableCell>
+                          <WorkspaceDefaultProfileCell
+                            profiles={activeProfiles}
+                            value={workspaceDefaults?.defaultProfile || ''}
+                            busy={
+                              actionProfile === workspaceDefaultProfileActionKey
+                            }
+                            disabled={!canManageProfiles}
+                            isLoading={isLoading || isWorkspaceDefaultsLoading}
+                            onChange={updateWorkspaceDefaultProfile}
+                          />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {workspaceTarget.updatedAt
+                            ? dayjs(workspaceTarget.updatedAt).format(
+                                'MMM D, YYYY HH:mm'
+                              )
+                            : 'Never'}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+
+            <div className="card-obsidian min-h-0 overflow-auto">
+              <Table className="text-xs">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[260px]">Profile</TableHead>
+                    <TableHead className="w-[110px]">Status</TableHead>
+                    <TableHead>Entries</TableHead>
+                    <TableHead className="w-[170px]">Updated</TableHead>
+                    <TableHead className="w-[80px]"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {!canManageProfiles ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={5}
+                        className="py-8 text-center text-muted-foreground"
+                      >
+                        You do not have permission to manage profiles.
+                      </TableCell>
+                    </TableRow>
+                  ) : isLoading ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={5}
+                        className="py-8 text-center text-muted-foreground"
+                      >
+                        Loading profiles...
+                      </TableCell>
+                    </TableRow>
+                  ) : profiles.length === 0 ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={5}
+                        className="py-8 text-center text-muted-foreground"
+                      >
+                        No profiles found.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    profiles.map((profile) => {
+                      const profileManageDisabled = !canManageProfile(profile);
+                      const profileBusy = actionProfile === profile.name;
+                      const target = targetFromProfile(
+                        profile,
+                        !profileManageDisabled
+                      );
+
+                      return (
+                        <TableRow key={profile.id}>
+                          <TableCell>
+                            <div className="flex min-w-0 flex-col gap-1">
+                              <div className="flex min-w-0 items-center gap-2">
+                                <SlidersHorizontal className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                                <code className="whitespace-normal break-words text-xs">
+                                  {profile.name}
+                                </code>
+                                {profile.protected && (
+                                  <Badge
+                                    variant="outline"
+                                    className="h-5 px-1.5 text-[10px]"
+                                  >
+                                    Protected
+                                  </Badge>
+                                )}
+                                {profile.protected &&
+                                  !canManageProtectedProfiles && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-[10px]"
+                                    >
+                                      Admin
+                                    </Badge>
+                                  )}
+                              </div>
+                              {profile.description && (
+                                <span className="text-xs text-muted-foreground">
+                                  {profile.description}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant={
+                                profile.status === RuntimeProfileStatus.active
+                                  ? 'success'
+                                  : 'warning'
+                              }
+                            >
+                              {profile.status}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <ProfileEntriesCell
+                              target={target}
+                              busy={profileBusy}
+                              onAdd={openEntryDialog}
+                              onEdit={editEntry}
+                              onDelete={confirmDeleteEntry}
+                            />
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {dayjs(profile.updatedAt).format(
+                              'MMM D, YYYY HH:mm'
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label={`Actions for ${profile.name}`}
+                                  disabled={
+                                    profileManageDisabled || profileBusy
+                                  }
+                                >
+                                  {profileBusy ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <MoreHorizontal className="h-4 w-4" />
+                                  )}
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  onClick={() => {
+                                    setEditingProfile(profile);
+                                    setProfileFormOpen(true);
+                                  }}
+                                >
+                                  <Pencil className="mr-2 h-4 w-4" />
+                                  Edit
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => toggleStatus(profile)}
+                                >
+                                  <Power className="mr-2 h-4 w-4" />
+                                  {profile.status ===
+                                  RuntimeProfileStatus.active
+                                    ? 'Disable'
+                                    : 'Enable'}
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  className="text-destructive"
+                                  onClick={() => setDeletingProfile(profile)}
+                                >
+                                  <Trash2 className="mr-2 h-4 w-4" />
+                                  Delete
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {activeTab === 'secret-refs' && (
+        <div
+          id="secret-refs-panel"
+          role="tabpanel"
+          aria-labelledby="secret-refs-tab"
+          className="min-h-0 flex-1 overflow-hidden"
+        >
+          <SecretRefsSection />
+        </div>
+      )}
 
       <ProfileFormDialog
         open={profileFormOpen}

--- a/ui/src/pages/profiles/index.tsx
+++ b/ui/src/pages/profiles/index.tsx
@@ -630,6 +630,31 @@ export default function ProfilesPage(): React.ReactNode {
     );
   }
 
+  function handleTabKeyDown(
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    currentTab: 'profiles' | 'secret-refs'
+  ): void {
+    let nextTab: 'profiles' | 'secret-refs';
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowRight':
+        nextTab = currentTab === 'profiles' ? 'secret-refs' : 'profiles';
+        break;
+      case 'Home':
+        nextTab = 'profiles';
+        break;
+      case 'End':
+        nextTab = 'secret-refs';
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    document.getElementById(`${nextTab}-tab`)?.focus();
+    selectTab(nextTab);
+  }
+
   return (
     <div className="flex h-full min-h-0 max-w-7xl flex-col gap-4 overflow-hidden">
       <div className="shrink-0">
@@ -651,7 +676,9 @@ export default function ProfilesPage(): React.ReactNode {
           aria-selected={activeTab === 'profiles'}
           aria-controls="profiles-panel"
           isActive={activeTab === 'profiles'}
+          tabIndex={activeTab === 'profiles' ? 0 : -1}
           onClick={() => selectTab('profiles')}
+          onKeyDown={(event) => handleTabKeyDown(event, 'profiles')}
           className="cursor-pointer gap-2"
         >
           <SlidersHorizontal className="h-4 w-4" />
@@ -663,7 +690,9 @@ export default function ProfilesPage(): React.ReactNode {
           aria-selected={activeTab === 'secret-refs'}
           aria-controls="secret-refs-panel"
           isActive={activeTab === 'secret-refs'}
+          tabIndex={activeTab === 'secret-refs' ? 0 : -1}
           onClick={() => selectTab('secret-refs')}
+          onKeyDown={(event) => handleTabKeyDown(event, 'secret-refs')}
           className="cursor-pointer gap-2"
         >
           <KeyRound className="h-4 w-4" />
@@ -671,13 +700,14 @@ export default function ProfilesPage(): React.ReactNode {
         </Tab>
       </Tabs>
 
-      {activeTab === 'profiles' && (
-        <section
-          id="profiles-panel"
-          role="tabpanel"
-          aria-labelledby="profiles-tab"
-          className="min-h-0 flex-1 overflow-auto pr-1"
-        >
+      <div
+        id="profiles-panel"
+        role="tabpanel"
+        aria-labelledby="profiles-tab"
+        hidden={activeTab !== 'profiles'}
+        className="min-h-0 flex-1 overflow-hidden"
+      >
+        <section className="h-full min-h-0 overflow-auto pr-1">
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between gap-3">
               <div>
@@ -1016,18 +1046,17 @@ export default function ProfilesPage(): React.ReactNode {
             </div>
           </div>
         </section>
-      )}
+      </div>
 
-      {activeTab === 'secret-refs' && (
-        <div
-          id="secret-refs-panel"
-          role="tabpanel"
-          aria-labelledby="secret-refs-tab"
-          className="min-h-0 flex-1 overflow-hidden"
-        >
-          <SecretRefsSection />
-        </div>
-      )}
+      <div
+        id="secret-refs-panel"
+        role="tabpanel"
+        aria-labelledby="secret-refs-tab"
+        hidden={activeTab !== 'secret-refs'}
+        className="min-h-0 flex-1 overflow-hidden"
+      >
+        <SecretRefsSection />
+      </div>
 
       <ProfileFormDialog
         open={profileFormOpen}

--- a/ui/src/pages/secrets/index.tsx
+++ b/ui/src/pages/secrets/index.tsx
@@ -164,7 +164,14 @@ function errorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
-export default function SecretsPage(): React.ReactNode {
+function isProfileBackingSecret(secret: SecretResponse): boolean {
+  return (
+    secret.ref.startsWith('runtime-profiles/') ||
+    secret.ref.startsWith('runtime-profile-defaults/')
+  );
+}
+
+export function SecretRefsSection(): React.ReactNode {
   const client = useClient();
   const appBarContext = useContext(AppBarContext);
   const remoteNode = appBarContext.selectedRemoteNode || 'local';
@@ -194,10 +201,6 @@ export default function SecretsPage(): React.ReactNode {
   const [actionSecretId, setActionSecretId] = useState<string | null>(null);
 
   useEffect(() => {
-    appBarContext.setTitle('Secrets');
-  }, [appBarContext]);
-
-  useEffect(() => {
     setSelectedScope(workspaceSelectionScope);
   }, [workspaceSelectionScope]);
 
@@ -214,7 +217,9 @@ export default function SecretsPage(): React.ReactNode {
     })
   );
 
-  const secrets = data?.secrets || [];
+  const secrets = (data?.secrets || []).filter(
+    (secret) => !isProfileBackingSecret(secret)
+  );
 
   const reload = useCallback(() => {
     void mutate();
@@ -279,12 +284,19 @@ export default function SecretsPage(): React.ReactNode {
   }
 
   return (
-    <div className="flex h-full min-h-0 max-w-7xl flex-col gap-4 overflow-auto">
+    <section
+      id="secret-refs"
+      aria-labelledby="secret-refs-heading"
+      className="flex min-h-0 scroll-mt-4 flex-col gap-4 border-t pt-6"
+    >
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold">Secrets</h1>
+          <h2 id="secret-refs-heading" className="text-base font-semibold">
+            DAG Secret Refs
+          </h2>
           <p className="text-sm text-muted-foreground">
-            Manage secret refs and values.
+            Individual secrets that DAGs reference with{' '}
+            <code className="text-xs">secrets[].ref</code>.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -311,7 +323,7 @@ export default function SecretsPage(): React.ReactNode {
             }}
           >
             <Plus className="mr-1.5 h-4 w-4" />
-            Add Secret
+            Add Secret Ref
           </Button>
         </div>
       </div>
@@ -355,7 +367,7 @@ export default function SecretsPage(): React.ReactNode {
                   colSpan={6}
                   className="py-8 text-center text-muted-foreground"
                 >
-                  Loading secrets...
+                  Loading secret refs...
                 </TableCell>
               </TableRow>
             ) : secrets.length === 0 ? (
@@ -364,7 +376,7 @@ export default function SecretsPage(): React.ReactNode {
                   colSpan={6}
                   className="py-8 text-center text-muted-foreground"
                 >
-                  No secrets found.
+                  No secret refs found.
                 </TableCell>
               </TableRow>
             ) : (
@@ -497,7 +509,7 @@ export default function SecretsPage(): React.ReactNode {
       />
 
       <ConfirmModal
-        title="Delete Secret"
+        title="Delete Secret Ref"
         buttonText="Delete"
         visible={!!deletingSecret}
         dismissModal={() => setDeletingSecret(null)}
@@ -507,7 +519,7 @@ export default function SecretsPage(): React.ReactNode {
           {deletingSecret ? `Delete ${deletingSecret.ref}?` : ''}
         </span>
       </ConfirmModal>
-    </div>
+    </section>
   );
 }
 
@@ -610,7 +622,9 @@ function SecretFormDialog({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>{isEditing ? 'Edit Secret' : 'Add Secret'}</DialogTitle>
+          <DialogTitle>
+            {isEditing ? 'Edit Secret Ref' : 'Add Secret Ref'}
+          </DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="mt-2 space-y-4">

--- a/ui/src/pages/secrets/index.tsx
+++ b/ui/src/pages/secrets/index.tsx
@@ -287,9 +287,9 @@ export function SecretRefsSection(): React.ReactNode {
     <section
       id="secret-refs"
       aria-labelledby="secret-refs-heading"
-      className="flex min-h-0 scroll-mt-4 flex-col gap-4 border-t pt-6"
+      className="flex h-full min-h-0 flex-col gap-4 overflow-hidden"
     >
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex shrink-0 items-center justify-between gap-3">
         <div>
           <h2 id="secret-refs-heading" className="text-base font-semibold">
             DAG Secret Refs
@@ -329,17 +329,17 @@ export function SecretRefsSection(): React.ReactNode {
       </div>
 
       {error && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+        <div className="shrink-0 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
           {error}
         </div>
       )}
       {success && (
-        <div className="rounded-md bg-success/10 p-3 text-sm text-success">
+        <div className="shrink-0 rounded-md bg-success/10 p-3 text-sm text-success">
           {success}
         </div>
       )}
 
-      <div className="card-obsidian min-h-0 overflow-auto">
+      <div className="card-obsidian min-h-0 flex-1 !overflow-auto">
         <Table className="text-xs">
           <TableHeader>
             <TableRow>


### PR DESCRIPTION
## Summary

- replace the separate Secrets navigation entry with a single **Profiles & Secrets** destination
- present Profiles and DAG Secret Refs as distinct URL-backed tabs
- keep `/secrets` working by redirecting it to the Secret Refs tab
- hide profile-owned backing records from the DAG Secret Refs list
- give each tab a bounded, independent scroll area for large profile and secret collections

## Why

Profiles and DAG-level secret refs are related runtime inputs, but presenting both as one long page made their roles unclear and caused large collections to be clipped. The tabbed layout keeps the concepts distinct while preserving one discoverable management destination.

The Secret Refs table also inherited `overflow: hidden` from the shared card style, so its constrained list could not scroll. The table container now explicitly owns overflow.

## Backend impact

No backend or storage changes. Profiles and secrets continue using their existing APIs and IDs.

## Validation

- `pnpm test` (113 test files, 474 tests)
- focused ESLint on the modified UI files
- Prettier verification
- `git diff --check`
- browser verification of both tab routes and computed scroll containers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combine Profiles and Secrets into a single “Profiles & Secrets” page with tabbed navigation, keyboard support, and stable scrolling for large lists. The legacy /secrets route now redirects to the Secret Refs tab and navigation points to the unified page.

- **New Features**
  - Replaced the separate Secrets entry with one “Profiles & Secrets”; sidebar and Administration labels updated.
  - Added URL-backed tabs for Profiles and DAG Secret Refs (linkable via #secret-refs) with Arrow/Home/End keyboard navigation.
  - Secret Refs hides profile-owned backing secrets and uses clearer labels (e.g., “Add Secret Ref”).

- **Migration**
  - /secrets redirects to /profiles#secret-refs; update bookmarks if needed.
  - No backend or storage changes.

<sup>Written for commit 1a38fb05ca91e4449e533ab7fb9f0ad3513d7b6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Combined Profiles and DAG Secret Refs into a single “Profiles & Secrets” area.
  - Added tabs for switching between profiles and DAG secret references.
  - Added URL-based navigation to open the Secret Refs tab directly.

- **Bug Fixes**
  - Updated the legacy `/secrets` route to redirect to the appropriate Profiles & Secrets section.
  - Improved secret reference labels, filtering, and empty/loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->