### PR TITLE
fix: preserve YAML parameter order in Start DAG UI

### DIFF
--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -388,10 +388,9 @@ function StartDAGModal({
       paramSchema
         ? ({
             ...buildParamSchemaUiSchema(paramSchema),
-            'ui:order': [
-              ...paramDefs.flatMap(({ name }) => (name ? [name] : [])),
-              '*',
-            ],
+            'ui:order': paramDefs
+              .flatMap(({ name }) => (name ? [name] : []))
+              .concat('*'),
             'ui:submitButtonOptions': { norender: true },
           } as UiSchema<SchemaFormData>)
         : undefined,

--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -134,6 +134,18 @@ function createParamFields(paramDefs: ParamDef[] = []): ParamField[] {
   });
 }
 
+function createParamSchemaFieldOrder(
+  schema: JSONSchema,
+  paramDefs: ParamDef[]
+): string[] | undefined {
+  const properties = schema.properties ?? {};
+  const orderedNames = paramDefs.flatMap((def) =>
+    def.name && def.name in properties ? [def.name] : []
+  );
+
+  return orderedNames.length > 0 ? [...orderedNames, '*'] : undefined;
+}
+
 function serializeParamFields(fields: ParamField[]): string {
   const items = fields
     .filter((field) => field.hasValue)
@@ -381,6 +393,13 @@ function StartDAGModal({
 
   const paramsReadOnly = dagWithRunConfig?.runConfig?.disableParamEdit ?? false;
   const runIdReadOnly = dagWithRunConfig?.runConfig?.disableRunIdEdit ?? false;
+  const schemaFieldOrder = React.useMemo(
+    () =>
+      paramSchema
+        ? createParamSchemaFieldOrder(paramSchema, paramDefs)
+        : undefined,
+    [paramDefs, paramSchema]
+  );
   const schemaFormUiSchema = React.useMemo<
     UiSchema<SchemaFormData> | undefined
   >(
@@ -388,15 +407,16 @@ function StartDAGModal({
       paramSchema
         ? ({
             ...buildParamSchemaUiSchema(paramSchema),
+            ...(schemaFieldOrder ? { 'ui:order': schemaFieldOrder } : {}),
             'ui:submitButtonOptions': { norender: true },
           } as UiSchema<SchemaFormData>)
         : undefined,
-    [paramSchema]
+    [paramSchema, schemaFieldOrder]
   );
   const schemaFormRef = React.useRef<RJSFForm<
     SchemaFormData,
     RJSFSchema,
-    any
+    Record<string, unknown>
   > | null>(null);
 
   React.useEffect(() => {

--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -134,18 +134,6 @@ function createParamFields(paramDefs: ParamDef[] = []): ParamField[] {
   });
 }
 
-function createParamSchemaFieldOrder(
-  schema: JSONSchema,
-  paramDefs: ParamDef[]
-): string[] | undefined {
-  const properties = schema.properties ?? {};
-  const orderedNames = paramDefs.flatMap((def) =>
-    def.name && def.name in properties ? [def.name] : []
-  );
-
-  return orderedNames.length > 0 ? [...orderedNames, '*'] : undefined;
-}
-
 function serializeParamFields(fields: ParamField[]): string {
   const items = fields
     .filter((field) => field.hasValue)
@@ -393,13 +381,6 @@ function StartDAGModal({
 
   const paramsReadOnly = dagWithRunConfig?.runConfig?.disableParamEdit ?? false;
   const runIdReadOnly = dagWithRunConfig?.runConfig?.disableRunIdEdit ?? false;
-  const schemaFieldOrder = React.useMemo(
-    () =>
-      paramSchema
-        ? createParamSchemaFieldOrder(paramSchema, paramDefs)
-        : undefined,
-    [paramDefs, paramSchema]
-  );
   const schemaFormUiSchema = React.useMemo<
     UiSchema<SchemaFormData> | undefined
   >(
@@ -407,16 +388,19 @@ function StartDAGModal({
       paramSchema
         ? ({
             ...buildParamSchemaUiSchema(paramSchema),
-            ...(schemaFieldOrder ? { 'ui:order': schemaFieldOrder } : {}),
+            'ui:order': [
+              ...paramDefs.flatMap(({ name }) => (name ? [name] : [])),
+              '*',
+            ],
             'ui:submitButtonOptions': { norender: true },
           } as UiSchema<SchemaFormData>)
         : undefined,
-    [paramSchema, schemaFieldOrder]
+    [paramDefs, paramSchema]
   );
   const schemaFormRef = React.useRef<RJSFForm<
     SchemaFormData,
     RJSFSchema,
-    Record<string, unknown>
+    any
   > | null>(null);
 
   React.useEffect(() => {

--- a/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { orderProperties } from '@rjsf/utils';
 import userEvent from '@testing-library/user-event';
-import type { ForwardedRef } from 'react';
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuntimeProfileStatus } from '@/api/v1/schema';
 import StartDAGModal from '../StartDAGModal';
@@ -23,41 +22,24 @@ vi.mock('@rjsf/shadcn', async () => {
     default: React.forwardRef(function MockSchemaForm(
       props: {
         formData?: Record<string, unknown>;
-        schema?: {
-          properties?: Record<string, unknown>;
-        };
-        uiSchema?: Record<string, unknown>;
+        uiSchema?: Record<string, Record<string, unknown>>;
         onChange?: (event: { formData: Record<string, unknown> }) => void;
       },
-      ref: ForwardedRef<{ validateForm: () => boolean }>
+      ref: any
     ) {
       renderedFormProps(props);
       React.useImperativeHandle(ref, () => ({
         validateForm: () => true,
       }));
-      const messageUiSchema = props.uiSchema?.message as
-        | Record<string, unknown>
-        | undefined;
-      const widget = messageUiSchema?.['ui:widget'];
-      const propertyNames = Object.keys(props.schema?.properties ?? {});
-      const configuredOrder = props.uiSchema?.['ui:order'];
-      const fieldNames = orderProperties(
-        propertyNames,
-        Array.isArray(configuredOrder) ? configuredOrder : undefined
-      );
+      const widget = props.uiSchema?.message?.['ui:widget'];
 
       return (
         <div data-testid="schema-form">
-          {fieldNames.map((name) => (
-            <div key={name} data-testid="schema-field">
-              {name}
-              {name === 'message' && widget === 'textarea' ? (
-                <textarea aria-label={name} defaultValue="" />
-              ) : (
-                <input aria-label={name} defaultValue="" />
-              )}
-            </div>
-          ))}
+          {widget === 'textarea' ? (
+            <textarea aria-label="message" defaultValue="" />
+          ) : (
+            <input aria-label="message" defaultValue="" />
+          )}
           <button
             type="button"
             onClick={() =>
@@ -103,15 +85,19 @@ describe('StartDAGModal', () => {
             paramSchema: {
               type: 'object',
               properties: {
+                count: {
+                  type: 'integer',
+                },
                 region: {
                   type: 'string',
                   enum: ['us-east-1', 'us-west-2'],
                 },
-                count: {
-                  type: 'integer',
-                },
               },
             },
+            paramDefs: [
+              { name: 'region', type: 'string', required: false },
+              { name: 'count', type: 'integer', required: false },
+            ],
             defaultParams: 'region="us-east-1" count="3"',
           } as never
         }
@@ -123,6 +109,7 @@ describe('StartDAGModal', () => {
       expect.objectContaining({
         formData: { region: 'us-east-1', count: 3 },
         uiSchema: expect.objectContaining({
+          'ui:order': ['region', 'count', '*'],
           region: expect.objectContaining({ 'ui:widget': 'radio' }),
         }),
         templates: expect.objectContaining({
@@ -147,40 +134,6 @@ describe('StartDAGModal', () => {
         true
       )
     );
-  });
-
-  it('renders schema-backed parameters in declaration order', () => {
-    render(
-      <StartDAGModal
-        visible={true}
-        dismissModal={vi.fn()}
-        onSubmit={vi.fn()}
-        dag={
-          {
-            name: 'ordered-params-dag',
-            paramSchema: {
-              type: 'object',
-              properties: {
-                end: { type: 'string' },
-                image_tag: { type: 'string' },
-                name: { type: 'string' },
-                start: { type: 'string' },
-              },
-            },
-            paramDefs: [
-              { name: 'image_tag', type: 'string', required: false },
-              { name: 'name', type: 'string', required: false },
-              { name: 'start', type: 'string', required: false },
-              { name: 'end', type: 'string', required: false },
-            ],
-          } as never
-        }
-      />
-    );
-
-    expect(
-      screen.getAllByTestId('schema-field').map((field) => field.textContent)
-    ).toEqual(['image_tag', 'name', 'start', 'end']);
   });
 
   it('does not submit a schema-backed string param when Shift+Enter is pressed', () => {

--- a/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { orderProperties } from '@rjsf/utils';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import type { ForwardedRef } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuntimeProfileStatus } from '@/api/v1/schema';
 import StartDAGModal from '../StartDAGModal';
@@ -22,24 +23,41 @@ vi.mock('@rjsf/shadcn', async () => {
     default: React.forwardRef(function MockSchemaForm(
       props: {
         formData?: Record<string, unknown>;
-        uiSchema?: Record<string, Record<string, unknown>>;
+        schema?: {
+          properties?: Record<string, unknown>;
+        };
+        uiSchema?: Record<string, unknown>;
         onChange?: (event: { formData: Record<string, unknown> }) => void;
       },
-      ref: any
+      ref: ForwardedRef<{ validateForm: () => boolean }>
     ) {
       renderedFormProps(props);
       React.useImperativeHandle(ref, () => ({
         validateForm: () => true,
       }));
-      const widget = props.uiSchema?.message?.['ui:widget'];
+      const messageUiSchema = props.uiSchema?.message as
+        | Record<string, unknown>
+        | undefined;
+      const widget = messageUiSchema?.['ui:widget'];
+      const propertyNames = Object.keys(props.schema?.properties ?? {});
+      const configuredOrder = props.uiSchema?.['ui:order'];
+      const fieldNames = orderProperties(
+        propertyNames,
+        Array.isArray(configuredOrder) ? configuredOrder : undefined
+      );
 
       return (
         <div data-testid="schema-form">
-          {widget === 'textarea' ? (
-            <textarea aria-label="message" defaultValue="" />
-          ) : (
-            <input aria-label="message" defaultValue="" />
-          )}
+          {fieldNames.map((name) => (
+            <div key={name} data-testid="schema-field">
+              {name}
+              {name === 'message' && widget === 'textarea' ? (
+                <textarea aria-label={name} defaultValue="" />
+              ) : (
+                <input aria-label={name} defaultValue="" />
+              )}
+            </div>
+          ))}
           <button
             type="button"
             onClick={() =>
@@ -129,6 +147,40 @@ describe('StartDAGModal', () => {
         true
       )
     );
+  });
+
+  it('renders schema-backed parameters in declaration order', () => {
+    render(
+      <StartDAGModal
+        visible={true}
+        dismissModal={vi.fn()}
+        onSubmit={vi.fn()}
+        dag={
+          {
+            name: 'ordered-params-dag',
+            paramSchema: {
+              type: 'object',
+              properties: {
+                end: { type: 'string' },
+                image_tag: { type: 'string' },
+                name: { type: 'string' },
+                start: { type: 'string' },
+              },
+            },
+            paramDefs: [
+              { name: 'image_tag', type: 'string', required: false },
+              { name: 'name', type: 'string', required: false },
+              { name: 'start', type: 'string', required: false },
+              { name: 'end', type: 'string', required: false },
+            ],
+          } as never
+        }
+      />
+    );
+
+    expect(
+      screen.getAllByTestId('schema-field').map((field) => field.textContent)
+    ).toEqual(['image_tag', 'name', 'start', 'end']);
   });
 
   it('does not submit a schema-backed string param when Shift+Enter is pressed', () => {


### PR DESCRIPTION
## Summary

- render schema-backed Start DAG parameters in the order declared in the DAG YAML
- use the ordered `paramDefs` metadata while retaining schema-only fields as a fallback
- add regression coverage for the parameter sequence reported in #2420

## Root cause

The backend retains YAML declaration order in `paramDefs`, but the JSON Schema reaches the browser as an object whose property keys are serialized alphabetically. The Start DAG modal used that schema property order directly, so schema-backed fields appeared alphabetized.

## Impact

The Start DAG form now follows the author-defined parameter order. Parameter values and submission payloads are unchanged.

## Testing

- `pnpm exec vitest run src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx`
- full UI test suite
- `pnpm exec eslint src/features/dags/components/dag-execution/StartDAGModal.tsx src/features/dags/components/dag-execution/__tests__/StartDAGModal.test.tsx`
- `pnpm typecheck` remains blocked by pre-existing keyboard event type errors in `src/pages/profiles/index.tsx`

Closes #2420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DAG execution parameters now appear in the expected declaration order when starting a DAG.
  * Schema-based forms preserve the configured parameter ordering, including additional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Start DAG modal to render parameters in the YAML-declared order and ensures the frontend build target builds correctly. The form sets `ui:order` from ordered `paramDefs` (with a `*` fallback), includes `paramDefs` in memo deps, and updates tests; values and submissions are unchanged.

<sup>Written for commit 35b0f2c2400088be274080b1c9b4fb76112a5109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

