### PR TITLE
fix: resolve workspace base config for scheduled runs

### DIFF
--- a/internal/cmd/retry_test.go
+++ b/internal/cmd/retry_test.go
@@ -477,6 +477,7 @@ steps:
 			th.Config.Paths.LogDir,
 			th.Config.Paths.ArtifactDir,
 			th.Config.Paths.BaseConfig,
+			"",
 			metadataOnly,
 			runID,
 			core.TriggerTypeCatchUp,

--- a/internal/core/spec/dparams_runtime.go
+++ b/internal/core/spec/dparams_runtime.go
@@ -21,7 +21,8 @@ const maxSafeFloat64Integer = 1 << 53
 
 // ResolveRuntimeParamsOptions controls how a DAG is reloaded for runtime param validation.
 type ResolveRuntimeParamsOptions struct {
-	BaseConfig string
+	BaseConfig             string
+	WorkspaceBaseConfigDir string
 }
 
 // ResolveRuntimeParams reloads a DAG from its source with runtime params applied.
@@ -66,6 +67,9 @@ func runtimeParamLoadOptions(dag *core.DAG, params any, opts ResolveRuntimeParam
 	}
 	if opts.BaseConfig != "" {
 		loadOpts = append(loadOpts, WithBaseConfig(opts.BaseConfig))
+	}
+	if opts.WorkspaceBaseConfigDir != "" {
+		loadOpts = append(loadOpts, WithWorkspaceBaseConfigDir(opts.WorkspaceBaseConfigDir))
 	}
 	if len(dag.BaseConfigData) > 0 {
 		loadOpts = append(loadOpts, WithBaseConfigContent(dag.BaseConfigData))

--- a/internal/core/spec/runtime_env.go
+++ b/internal/core/spec/runtime_env.go
@@ -15,7 +15,8 @@ import (
 // ResolveEnvOptions controls how a DAG is reloaded to recover resolved env
 // values for subprocess launchers.
 type ResolveEnvOptions struct {
-	BaseConfig string
+	BaseConfig             string
+	WorkspaceBaseConfigDir string
 }
 
 // ResolveEnvResult contains resolved env entries and warnings encountered while

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -473,6 +473,7 @@ func (f *testFixture) enqueueCatchup(scheduleTime time.Time) (string, error) {
 		f.coord.Config.Paths.LogDir,
 		f.coord.Config.Paths.ArtifactDir,
 		f.coord.Config.Paths.BaseConfig,
+		"",
 		f.dagWrapper.DAG,
 		runID,
 		core.TriggerTypeCatchUp,

--- a/internal/intg/queue/fixture_test.go
+++ b/internal/intg/queue/fixture_test.go
@@ -219,6 +219,7 @@ func (f *fixture) enqueueCatchup(scheduleTime time.Time) string {
 		f.th.Config.Paths.LogDir,
 		f.th.Config.Paths.ArtifactDir,
 		f.th.Config.Paths.BaseConfig,
+		"",
 		f.dag,
 		runID,
 		core.TriggerTypeCatchUp,

--- a/internal/service/scheduler/dag_executor.go
+++ b/internal/service/scheduler/dag_executor.go
@@ -55,11 +55,12 @@ import (
 // - HandleJob(): Entry point for new scheduled jobs (handles persistence)
 // - ExecuteDAG(): Executes/dispatches already-persisted jobs (no persistence)
 type DAGExecutor struct {
-	coordinatorCli  exec.Dispatcher
-	subCmdBuilder   *launcher.SubCmdBuilder
-	defaultExecMode config.ExecutionMode
-	baseConfigPath  string
-	profileResolver DAGProfileResolver
+	coordinatorCli         exec.Dispatcher
+	subCmdBuilder          *launcher.SubCmdBuilder
+	defaultExecMode        config.ExecutionMode
+	baseConfigPath         string
+	workspaceBaseConfigDir string
+	profileResolver        DAGProfileResolver
 }
 
 type DAGProfileResolver interface {
@@ -71,6 +72,13 @@ type DAGExecutorOption func(*DAGExecutor)
 func WithDAGExecutorProfileResolver(resolver DAGProfileResolver) DAGExecutorOption {
 	return func(e *DAGExecutor) {
 		e.profileResolver = resolver
+	}
+}
+
+// WithDAGExecutorWorkspaceBaseConfigDir sets the directory used to resolve workspace base configs.
+func WithDAGExecutorWorkspaceBaseConfigDir(dir string) DAGExecutorOption {
+	return func(e *DAGExecutor) {
+		e.workspaceBaseConfigDir = dir
 	}
 }
 
@@ -375,7 +383,8 @@ func (e *DAGExecutor) prepareDAGForSubprocess(ctx context.Context, dag *core.DAG
 	}
 
 	result, err := spec.ResolveEnvWithWarnings(ctx, dag, params, spec.ResolveEnvOptions{
-		BaseConfig: e.baseConfigPath,
+		BaseConfig:             e.baseConfigPath,
+		WorkspaceBaseConfigDir: e.workspaceBaseConfigDir,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/scheduler/dag_executor_internal_test.go
+++ b/internal/service/scheduler/dag_executor_internal_test.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/cmn/buildenv"
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAGExecutorPrepareScheduledDAGUsesWorkspaceBaseConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	dagsDir := filepath.Join(root, "dags")
+	workspaceBaseConfigDir := workspace.BaseConfigDir(dagsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceBaseConfigDir, "ops"), 0o750))
+
+	baseConfigPath := filepath.Join(root, "base.yaml")
+	require.NoError(t, os.WriteFile(baseConfigPath, []byte(`
+env:
+  - GREETING: from-global
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(workspaceBaseConfigDir, "ops", "base.yaml"), []byte(`
+env:
+  - GREETING: from-workspace
+  - OPS_ONLY: only-in-workspace
+actions:
+  ops.hello:
+    input_schema:
+      type: object
+      additionalProperties: false
+    template:
+      run: echo hello
+`), 0o600))
+
+	dagPath := filepath.Join(dagsDir, "hello.yaml")
+	require.NoError(t, os.WriteFile(dagPath, []byte(`
+name: hello
+schedule: "* * * * *"
+labels:
+  - workspace=ops
+steps:
+  - id: hello
+    action: ops.hello
+`), 0o600))
+
+	dag, err := loadDAGMetadata(ctx, dagPath)
+	require.NoError(t, err)
+
+	executor := NewDAGExecutor(
+		nil,
+		nil,
+		config.ExecutionModeLocal,
+		baseConfigPath,
+		WithDAGExecutorWorkspaceBaseConfigDir(workspaceBaseConfigDir),
+	)
+	prepared, err := executor.prepareDAGForSubprocess(ctx, dag, "")
+	require.NoError(t, err)
+
+	env := buildenv.ToMap(prepared.Env)
+	require.Equal(t, "from-workspace", env["GREETING"])
+	require.Equal(t, "only-in-workspace", env["OPS_ONLY"])
+}

--- a/internal/service/scheduler/enqueue.go
+++ b/internal/service/scheduler/enqueue.go
@@ -35,6 +35,7 @@ func EnqueueCatchupRun(
 	baseLogDir string,
 	baseArtifactDir string,
 	baseConfig string,
+	workspaceBaseConfigDir string,
 	dag *core.DAG,
 	runID string,
 	triggerType core.TriggerType,
@@ -52,7 +53,7 @@ func EnqueueCatchupRun(
 		return nil
 	}
 
-	fullDAG, err := rehydrateExecutionDAG(ctx, dag, nil, baseConfig)
+	fullDAG, err := rehydrateExecutionDAG(ctx, dag, nil, baseConfig, workspaceBaseConfigDir)
 	if err != nil {
 		return fmt.Errorf("failed to load full DAG for catchup enqueue: %w", err)
 	}

--- a/internal/service/scheduler/enqueue_test.go
+++ b/internal/service/scheduler/enqueue_test.go
@@ -4,16 +4,19 @@
 package scheduler_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/buildenv"
 	"github.com/dagucloud/dagu/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
 	"github.com/dagucloud/dagu/internal/service/scheduler"
 	"github.com/dagucloud/dagu/internal/test"
+	"github.com/dagucloud/dagu/internal/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +41,7 @@ steps:
 		th.Config.Paths.LogDir,
 		th.Config.Paths.ArtifactDir,
 		th.Config.Paths.BaseConfig,
+		"",
 		dag.DAG,
 		runID,
 		core.TriggerTypeCatchUp,
@@ -104,6 +108,7 @@ steps:
 		th.Config.Paths.LogDir,
 		th.Config.Paths.ArtifactDir,
 		th.Config.Paths.BaseConfig,
+		"",
 		metadataOnly,
 		runID,
 		core.TriggerTypeCatchUp,
@@ -124,4 +129,72 @@ steps:
 		Key:      "SECRET_SOURCE",
 	}, persisted.Secrets[0])
 	require.Equal(t, []string{".env", ".env.secret"}, persisted.Dotenv)
+}
+
+func TestEnqueueCatchupRun_RehydratesWorkspaceBaseConfig(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+	workspaceBaseConfigDir := workspace.BaseConfigDir(th.Config.Paths.DAGsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceBaseConfigDir, "ops"), 0o750))
+	require.NoError(t, os.WriteFile(th.Config.Paths.BaseConfig, []byte(`
+env:
+  - GREETING: from-global
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(workspaceBaseConfigDir, "ops", "base.yaml"), []byte(`
+env:
+  - GREETING: from-workspace
+  - OPS_ONLY: only-in-workspace
+actions:
+  ops.hello:
+    input_schema:
+      type: object
+      additionalProperties: false
+    template:
+      run: echo hello
+`), 0o600))
+
+	dag := th.DAG(t, `name: enqueue-catchup-workspace
+labels:
+  - workspace=ops
+steps:
+  - id: hello
+    action: ops.hello
+`)
+	metadataOnly, err := spec.Load(
+		th.Context,
+		dag.Location,
+		spec.OnlyMetadata(),
+		spec.WithoutEval(),
+		spec.SkipSchemaValidation(),
+	)
+	require.NoError(t, err)
+
+	runID := "catchup-run-workspace"
+	err = scheduler.EnqueueCatchupRun(
+		th.Context,
+		th.DAGRunStore,
+		th.QueueStore,
+		th.Config.Paths.LogDir,
+		th.Config.Paths.ArtifactDir,
+		th.Config.Paths.BaseConfig,
+		workspaceBaseConfigDir,
+		metadataOnly,
+		runID,
+		core.TriggerTypeCatchUp,
+		time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC),
+		"",
+	)
+	require.NoError(t, err)
+
+	attempt, err := th.DAGRunStore.FindAttempt(th.Context, exec.NewDAGRunRef(dag.Name, runID))
+	require.NoError(t, err)
+	persisted, err := attempt.ReadDAG(th.Context)
+	require.NoError(t, err)
+
+	resolvedEnv, err := spec.ResolveEnv(th.Context, persisted, nil, spec.ResolveEnvOptions{})
+	require.NoError(t, err)
+	env := buildenv.ToMap(resolvedEnv)
+	require.Equal(t, "from-workspace", env["GREETING"])
+	require.Equal(t, "only-in-workspace", env["OPS_ONLY"])
 }

--- a/internal/service/scheduler/enqueue_webhook.go
+++ b/internal/service/scheduler/enqueue_webhook.go
@@ -42,7 +42,7 @@ func EnqueueWebhookRun(
 		return fmt.Errorf("failed to check existing webhook run: %w", err)
 	}
 
-	fullDAG, err := rehydrateExecutionDAG(ctx, dag, params, baseConfig)
+	fullDAG, err := rehydrateExecutionDAG(ctx, dag, params, baseConfig, "")
 	if err != nil {
 		return fmt.Errorf("failed to load full DAG for webhook enqueue: %w", err)
 	}

--- a/internal/service/scheduler/execution_dag.go
+++ b/internal/service/scheduler/execution_dag.go
@@ -13,9 +13,16 @@ import (
 
 // rehydrateExecutionDAG reloads a full DAG from source before scheduler-owned
 // execution or persistence paths use it as an execution snapshot.
-func rehydrateExecutionDAG(ctx context.Context, dag *core.DAG, params any, baseConfig string) (*core.DAG, error) {
+func rehydrateExecutionDAG(
+	ctx context.Context,
+	dag *core.DAG,
+	params any,
+	baseConfig string,
+	workspaceBaseConfigDir string,
+) (*core.DAG, error) {
 	fresh, err := spec.ResolveRuntimeParams(ctx, dag, params, spec.ResolveRuntimeParamsOptions{
-		BaseConfig: baseConfig,
+		BaseConfig:             baseConfig,
+		WorkspaceBaseConfigDir: workspaceBaseConfigDir,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("rehydrate execution DAG: %w", err)

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/launcher"
 	"github.com/dagucloud/dagu/internal/runtime"
+	"github.com/dagucloud/dagu/internal/workspace"
 )
 
 // Clock is a function that returns the current time.
@@ -149,6 +150,7 @@ func newScheduler(
 		cfg.DefaultExecMode,
 		cfg.Paths.BaseConfig,
 		WithDAGExecutorProfileResolver(options.profileResolver),
+		WithDAGExecutorWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
 	)
 	healthServer := NewHealthServer(cfg.Scheduler.Port)
 

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -144,13 +144,14 @@ func newScheduler(
 	dirLock := dirlock.New(lockDir, lockOpts)
 	subCmdBuilder := launcher.NewSubCmdBuilder(cfg)
 	dagStore := er.DAGStore()
+	workspaceBaseConfigDir := workspace.BaseConfigDir(cfg.Paths.DAGsDir)
 	dagExecutor := NewDAGExecutor(
 		coordinatorCli,
 		subCmdBuilder,
 		cfg.DefaultExecMode,
 		cfg.Paths.BaseConfig,
 		WithDAGExecutorProfileResolver(options.profileResolver),
-		WithDAGExecutorWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
+		WithDAGExecutorWorkspaceBaseConfigDir(workspaceBaseConfigDir),
 	)
 	healthServer := NewHealthServer(cfg.Scheduler.Port)
 
@@ -190,7 +191,20 @@ func newScheduler(
 			if err != nil {
 				return fmt.Errorf("failed to resolve DAG profile: %w", err)
 			}
-			return EnqueueCatchupRun(ctx, dagRunStore, queueStore, cfg.Paths.LogDir, cfg.Paths.ArtifactDir, cfg.Paths.BaseConfig, dag, runID, triggerType, scheduleTime, profileName)
+			return EnqueueCatchupRun(
+				ctx,
+				dagRunStore,
+				queueStore,
+				cfg.Paths.LogDir,
+				cfg.Paths.ArtifactDir,
+				cfg.Paths.BaseConfig,
+				workspaceBaseConfigDir,
+				dag,
+				runID,
+				triggerType,
+				scheduleTime,
+				profileName,
+			)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- pass the workspace base-config directory through runtime DAG reload options
- configure the scheduler DAG executor and catch-up enqueue path with the workspace base-config directory
- cover normal scheduled runs and persisted catch-up snapshots with focused workspace action and environment-precedence tests

## Root cause

The scheduler keeps metadata-only DAG snapshots, which intentionally do not contain effective base-config data. Normal scheduled execution and catch-up enqueue rehydrate those snapshots through separate paths, and both paths previously received only the global base-config path.

As a result, workspace-defined actions could fail as unknown and shared environment keys could resolve to global values. Catch-up runs could also persist an incomplete execution snapshot for later queue dispatch or retry.

Both rehydration paths now receive the workspace base-config directory. Embedded `BaseConfigData` still takes precedence, preserving persisted and distributed snapshot behavior.

## Impact

Manual, scheduled, and catch-up runs now use the same workspace base configuration for action resolution and environment precedence.

## Testing

- `go test ./internal/core/spec ./internal/service/scheduler -count=1`
- `go test ./internal/service/scheduler -count=1`
- `go test ./internal/cmd ./internal/intg/queue ./internal/intg/distr -run '^$' -count=1`
- `go test -race -count=1 -ldflags=-extldflags=-Wl,-ld_classic ./internal/service/scheduler -run '^TestEnqueueCatchupRun_RehydratesWorkspaceBaseConfig$'`
- `go vet ./internal/service/scheduler ./internal/cmd ./internal/intg/queue ./internal/intg/distr`
- `go fix -diff ./internal/service/scheduler ./internal/cmd ./internal/intg/queue ./internal/intg/distr`

Closes #2418

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scheduled and catch‑up runs ignoring workspace base config by passing the workspace base-config directory through DAG reload and executor paths. All run types now resolve workspace actions and env values the same way.

- **Bug Fixes**
  - Propagate `WorkspaceBaseConfigDir` via `ResolveEnvOptions`/`ResolveRuntimeParamsOptions`, `rehydrateExecutionDAG`, and `EnqueueCatchupRun`, and wire it into the scheduler/executor with `WithDAGExecutorWorkspaceBaseConfigDir`.
  - Add tests for executor prep and catch-up enqueue to confirm workspace-scoped actions load and workspace env overrides global; embedded `BaseConfigData` precedence is unchanged.

<sup>Written for commit 0079997fc01f26b80d92a7e19ecd4cf318405e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace-specific base configuration is now applied when scheduled workflows run.
  * Workspace settings can override global configuration and add workspace-only environment values.
  * Scheduler execution supports configuring the workspace base configuration directory.

* **Bug Fixes**
  * Improved configuration resolution for both local and distributed scheduled workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->