### PR TITLE
fix: constrain DAG resolution to configured directories

### DIFF
--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -188,7 +189,9 @@ func extractDAGName(ctx *Context, name string) (string, error) {
 		return name, nil
 	}
 
-	dagStore, err := ctx.dagStore(dagStoreConfig{})
+	dagStore, err := ctx.dagStore(dagStoreConfig{
+		SearchPaths: []string{filepath.Dir(name)},
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize DAG store: %w", err)
 	}

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -189,14 +189,19 @@ func extractDAGName(ctx *Context, name string) (string, error) {
 		return name, nil
 	}
 
+	absolutePath, err := filepath.Abs(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve DAG file path %s: %w", name, err)
+	}
+
 	dagStore, err := ctx.dagStore(dagStoreConfig{
-		SearchPaths: []string{filepath.Dir(name)},
+		SearchPaths: []string{filepath.Dir(absolutePath)},
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize DAG store: %w", err)
 	}
 
-	dag, err := dagStore.GetMetadata(ctx, name)
+	dag, err := dagStore.GetMetadata(ctx, absolutePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read DAG metadata from file %s: %w", name, err)
 	}

--- a/internal/cmd/start_test.go
+++ b/internal/cmd/start_test.go
@@ -89,15 +89,13 @@ steps:
 
 func TestStartCommandResolvesRelativeNestedDAGPath(t *testing.T) {
 	th := test.SetupCommand(t)
-	dagFile := th.CreateDAGFile(t, filepath.Join("nested", "relative.yaml"), `
+	relativePath := filepath.Join("nested", "relative.yaml")
+	th.CreateDAGFile(t, relativePath, `
 steps:
   - name: run
     run: "true"
 `)
-	workingDir, err := os.Getwd()
-	require.NoError(t, err)
-	relativePath, err := filepath.Rel(workingDir, dagFile)
-	require.NoError(t, err)
+	t.Chdir(th.Config.Paths.DAGsDir)
 
 	th.RunCommand(t, cmd.Start(), test.CmdTest{
 		Name:        "StartRelativeNestedDAG",

--- a/internal/cmd/start_test.go
+++ b/internal/cmd/start_test.go
@@ -87,6 +87,25 @@ steps:
 	}
 }
 
+func TestStartCommandResolvesRelativeNestedDAGPath(t *testing.T) {
+	th := test.SetupCommand(t)
+	dagFile := th.CreateDAGFile(t, filepath.Join("nested", "relative.yaml"), `
+steps:
+  - name: run
+    run: "true"
+`)
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	relativePath, err := filepath.Rel(workingDir, dagFile)
+	require.NoError(t, err)
+
+	th.RunCommand(t, cmd.Start(), test.CmdTest{
+		Name:        "StartRelativeNestedDAG",
+		Args:        []string{"start", relativePath},
+		ExpectedOut: []string{"Step started"},
+	})
+}
+
 func TestStartCommand_BuiltExecutablePreservesExplicitEnv(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -108,10 +108,10 @@ func New(baseDir string, opts ...Option) exec.DAGStore {
 	if options.FlagsBaseDir == "" {
 		options.FlagsBaseDir = filepath.Join(baseDir, "flags")
 	}
-	// Build search paths in deterministic order: baseDir first, then ".", then additional paths.
+	// Build search paths in deterministic order: baseDir first, then additional paths.
 	seen := make(map[string]struct{})
 	var searchPaths []string
-	for _, p := range append([]string{baseDir, "."}, options.SearchPaths...) {
+	for _, p := range append([]string{baseDir}, options.SearchPaths...) {
 		if _, ok := seen[p]; ok {
 			continue
 		}
@@ -1037,29 +1037,41 @@ func (store *Storage) generateFilePath(name string) string {
 	return filePath
 }
 
-// locateDAG locates the DAG file by its name or path.
+// locateDAG resolves a DAG beneath the configured DAG directories.
 func (store *Storage) locateDAG(nameOrPath string) (string, error) {
-	if strings.Contains(nameOrPath, string(filepath.Separator)) {
-		foundPath, err := findDAGFile(nameOrPath)
-		if err == nil {
-			return foundPath, nil
-		}
-	}
-
 	for _, dir := range store.searchPaths {
 		absDir, err := filepath.Abs(dir)
 		if err != nil {
 			continue
 		}
-		candidatePath := filepath.Join(absDir, nameOrPath)
-		foundPath, err := findDAGFile(candidatePath)
-		if err == nil {
-			return foundPath, nil
+
+		relativePath := filepath.FromSlash(nameOrPath)
+		if filepath.IsAbs(relativePath) {
+			relativePath, err = filepath.Rel(absDir, relativePath)
+			if err != nil {
+				continue
+			}
+		}
+
+		for _, candidatePath := range dagFileCandidates(relativePath) {
+			_, err := fileutil.ResolveExistingPathWithinBase(absDir, candidatePath)
+			if err == nil {
+				return filepath.Clean(filepath.Join(absDir, candidatePath)), nil
+			}
 		}
 	}
 
 	// DAG not found
 	return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
+}
+
+func dagFileCandidates(name string) []string {
+	switch filepath.Ext(name) {
+	case ".yaml", ".yml":
+		return []string{name}
+	default:
+		return []string{name + ".yaml", name + ".yml"}
+	}
 }
 
 // LabelList lists all unique labels from the DAGs.
@@ -1231,23 +1243,4 @@ func (store *Storage) createExampleDAGs() error {
 
 	logger.Info(context.Background(), "Example DAGs created successfully. Check the web UI to explore them!")
 	return nil
-}
-
-// findDAGFile finds the DAG file with the given file name.
-func findDAGFile(name string) (string, error) {
-	ext := path.Ext(name)
-	switch ext {
-	case ".yaml", ".yml":
-		if fileutil.FileExists(name) {
-			return filepath.Abs(name)
-		}
-	default:
-		// try all supported extensions
-		for _, ext := range fileutil.ValidYAMLExtensions {
-			if fileutil.FileExists(name + ext) {
-				return filepath.Abs(name + ext)
-			}
-		}
-	}
-	return "", fmt.Errorf("file %s not found: %w", name, os.ErrNotExist)
 }

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -1054,9 +1054,9 @@ func (store *Storage) locateDAG(nameOrPath string) (string, error) {
 		}
 
 		for _, candidatePath := range dagFileCandidates(relativePath) {
-			_, err := fileutil.ResolveExistingPathWithinBase(absDir, candidatePath)
+			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(absDir, candidatePath)
 			if err == nil {
-				return filepath.Clean(filepath.Join(absDir, candidatePath)), nil
+				return resolvedPath, nil
 			}
 		}
 	}

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -224,6 +224,69 @@ steps:
 	assert.Equal(t, exec.ErrDAGNotFound, err)
 }
 
+func TestGetSpecAllowsNestedPathsWithinConfiguredDirectories(t *testing.T) {
+	baseDir := t.TempDir()
+	nestedDir := filepath.Join(baseDir, "team", "jobs")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+
+	const dagContent = "name: nested-dag\nsteps: []\n"
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "nested-dag.yaml"), []byte(dagContent), 0600))
+
+	store := New(baseDir, WithSkipExamples(true))
+	spec, err := store.GetSpec(context.Background(), "team/jobs/nested-dag")
+
+	require.NoError(t, err)
+	assert.Equal(t, dagContent, spec)
+}
+
+func TestGetSpecRejectsPathsOutsideConfiguredDirectories(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("name: outside\nsteps: []\n"), 0600))
+
+	store := New(baseDir, WithSkipExamples(true))
+	relativePath, err := filepath.Rel(baseDir, outsidePath)
+	require.NoError(t, err)
+
+	for _, path := range []string{outsidePath, relativePath} {
+		_, err := store.GetSpec(context.Background(), path)
+		assert.ErrorIs(t, err, exec.ErrDAGNotFound)
+	}
+}
+
+func TestGetSpecRejectsSymlinkOutsideConfiguredDirectories(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outsideDir, "outside.yaml"),
+		[]byte("name: outside\nsteps: []\n"),
+		0600,
+	))
+	if err := os.Symlink(outsideDir, filepath.Join(baseDir, "linked")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	store := New(baseDir, WithSkipExamples(true))
+	_, err := store.GetSpec(context.Background(), "linked/outside.yaml")
+
+	assert.ErrorIs(t, err, exec.ErrDAGNotFound)
+}
+
+func TestGetSpecAllowsExplicitSearchPaths(t *testing.T) {
+	baseDir := t.TempDir()
+	searchDir := t.TempDir()
+	const dagContent = "name: searched\nsteps: []\n"
+	searchPath := filepath.Join(searchDir, "searched.yaml")
+	require.NoError(t, os.WriteFile(searchPath, []byte(dagContent), 0600))
+
+	store := New(baseDir, WithSearchPaths([]string{searchDir}), WithSkipExamples(true))
+	spec, err := store.GetSpec(context.Background(), searchPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, dagContent, spec)
+}
+
 func TestCreate(t *testing.T) {
 	tmpDir := fileutil.MustTempDir("test-create")
 	defer func() {

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1589,10 +1589,12 @@ steps:
   - name: main
     run: echo "${MESSAGE} current file"`
 	dagPath := filepath.Join(server.Config.Paths.DAGsDir, dagName+".yaml")
+	resolvedDAGPath, err := filepath.EvalSymlinks(dagPath)
+	require.NoError(t, err)
 	assertRescheduleSpecSourceFlag(t, server, dagName, startBody.DagRunId, true)
 	originalAttempt, originalDAG := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, startBody.DagRunId)
 	require.NotNil(t, originalAttempt)
-	require.Equal(t, dagPath, originalDAG.SourceFile)
+	require.Equal(t, resolvedDAGPath, originalDAG.SourceFile)
 	require.NoError(t, os.WriteFile(dagPath, []byte(currentSpec), 0o600))
 	useCurrentDagFile := true
 
@@ -1610,7 +1612,7 @@ steps:
 
 	_, dag := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, body.DagRunId)
 	require.Contains(t, string(dag.YamlData), "current file")
-	require.Equal(t, dagPath, dag.SourceFile)
+	require.Equal(t, resolvedDAGPath, dag.SourceFile)
 
 	rescheduledStatus := waitForStoredDAGRunStatus(t, server, dagName, body.DagRunId, 10*time.Second, func(status *exec.DAGRunStatus) bool {
 		return status.Status == core.Succeeded


### PR DESCRIPTION
## Summary

- constrain DAG file resolution to the configured DAG directory and explicit alternate/runtime search directories
- allow nested DAG paths when they remain beneath an approved directory
- reject absolute, parent-traversal, and symlink paths that escape those directories
- make CLI-local YAML lookup opt in to its containing directory explicitly

## Root cause

`locateDAG` returned separator-containing paths directly and implicitly searched the process working directory. Callers that invoke the API service in process do not pass through the REST filename-validation middleware, so an untrusted path could reach the filesystem resolver.

Resolution is now enforced at the shared storage boundary with lexical and symlink-aware containment. This covers REST, MCP, and other callers consistently while preserving explicitly configured search directories needed by local and distributed execution.

## Behavior

Existing DAG files can be resolved through paths such as `team/jobs/report.yaml` when they are beneath the configured DAG directory. Resolution outside approved roots returns DAG-not-found. DAG listing and creation behavior remain unchanged; this PR makes nested paths safe to resolve without expanding the broader DAG identity model.

## Testing

- `make fmt`
- complete tests for `internal/persis/file/dag`, `internal/cmd`, `internal/service/mcp`, and `internal/service/frontend/api/v1`
- race-enabled tests for `internal/persis/file/dag` and `internal/cmd`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain DAG resolution to configured directories and explicit search paths to prevent escapes, while allowing nested paths under approved roots. Normalize stored `SourceFile` to the symlink-resolved file path.

- **Bug Fixes**
  - Enforce lexical and symlink-aware containment with `fileutil.ResolveExistingPathWithinBase` in `internal/persis/file/dag`; handle YAML extensions inside the containment check.
  - Drop "." from default search paths; search base dir first, then `SearchPaths`.
  - Make CLI YAML lookup opt-in by scoping to the file’s directory and resolving absolute/relative nested paths (`internal/cmd`).
  - Add/adjust tests to allow nested paths and explicit search dirs, reject outside and symlink escapes, expect `SourceFile` to match `EvalSymlinks`, and make the relative nested-path start case portable.

<sup>Written for commit bd0d2e93d833146c6b561927dfd07cbf942ea3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DAG file discovery for YAML files provided by path.
  * Added support for nested DAG paths within configured directories.
  * Prevented access to files outside configured directories, including through path traversal and symlinks.
  * Improved handling of explicitly configured search paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->