### PR TITLE
refactor: streamline cloud secret providers

### DIFF
--- a/internal/cmn/secrets/aws.go
+++ b/internal/cmn/secrets/aws.go
@@ -30,8 +30,8 @@ func init() {
 
 type awsSecretsManagerResolver struct {
 	mu            sync.Mutex
-	clientFactory func(context.Context, string) (awsSecretsManagerClient, error)
-	clients       map[string]awsSecretsManagerClient
+	clientFactory func(context.Context) (awsSecretsManagerClient, error)
+	client        awsSecretsManagerClient
 }
 
 type awsSecretReference struct {
@@ -87,7 +87,7 @@ func (r *awsSecretsManagerResolver) Resolve(ctx context.Context, ref core.Secret
 	if region == "" {
 		region = strings.TrimSpace(config.GetConfig(ctx).Secrets.AWS.Region)
 	}
-	client, err := r.getClient(ctx, region)
+	client, err := r.getClient(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -99,7 +99,13 @@ func (r *awsSecretsManagerResolver) Resolve(ctx context.Context, ref core.Secret
 	if versionStage := ref.Options["version_stage"]; versionStage != "" {
 		input.VersionStage = aws.String(versionStage)
 	}
-	output, err := client.GetSecretValue(ctx, input)
+	var options []func(*secretsmanager.Options)
+	if region != "" {
+		options = append(options, func(options *secretsmanager.Options) {
+			options.Region = region
+		})
+	}
+	output, err := client.GetSecretValue(ctx, input, options...)
 	if err != nil {
 		var notFound *types.ResourceNotFoundException
 		if errors.As(err, &notFound) {
@@ -128,33 +134,23 @@ func (r *awsSecretsManagerResolver) CheckAccessibility(ctx context.Context, ref 
 	return err
 }
 
-func (r *awsSecretsManagerResolver) getClient(ctx context.Context, region string) (awsSecretsManagerClient, error) {
+func (r *awsSecretsManagerResolver) getClient(ctx context.Context) (awsSecretsManagerClient, error) {
 	r.mu.Lock()
-	if client := r.clients[region]; client != nil {
-		r.mu.Unlock()
-		return client, nil
+	defer r.mu.Unlock()
+	if r.client != nil {
+		return r.client, nil
 	}
-	r.mu.Unlock()
 
 	factory := r.clientFactory
 	if factory == nil {
 		factory = newAWSSecretsManagerClient
 	}
-	client, err := factory(ctx, region)
+	client, err := factory(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS Secrets Manager client: %w", err)
 	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.clients == nil {
-		r.clients = make(map[string]awsSecretsManagerClient)
-	}
-	if existing := r.clients[region]; existing != nil {
-		return existing, nil
-	}
-	r.clients[region] = client
-	return client, nil
+	r.client = client
+	return r.client, nil
 }
 
 func parseAWSSecretsManagerARN(key string) (awsarn.ARN, bool, error) {
@@ -175,12 +171,8 @@ type awsSecretsManagerClient interface {
 	GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
-func newAWSSecretsManagerClient(ctx context.Context, region string) (awsSecretsManagerClient, error) {
-	var options []func(*awsconfig.LoadOptions) error
-	if region != "" {
-		options = append(options, awsconfig.WithRegion(region))
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, options...)
+func newAWSSecretsManagerClient(ctx context.Context) (awsSecretsManagerClient, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmn/secrets/aws_test.go
+++ b/internal/cmn/secrets/aws_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type awsSecretsManagerTestClient struct {
-	getSecretValue func(context.Context, *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+	getSecretValue func(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
-func (c *awsSecretsManagerTestClient) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
-	return c.getSecretValue(ctx, input)
+func (c *awsSecretsManagerTestClient) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, options ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return c.getSecretValue(ctx, input, options...)
 }
 
 func TestAWSSecretsManagerResolverValidate(t *testing.T) {
@@ -64,11 +64,17 @@ func TestAWSSecretsManagerResolverRegistered(t *testing.T) {
 func TestAWSSecretsManagerResolverResolve(t *testing.T) {
 	var regions []string
 	var inputs []*secretsmanager.GetSecretValueInput
+	var factoryCalls int
 	value := `{"token":"resolved","enabled":true}`
 	resolver := &awsSecretsManagerResolver{
-		clientFactory: func(_ context.Context, region string) (awsSecretsManagerClient, error) {
-			regions = append(regions, region)
-			return &awsSecretsManagerTestClient{getSecretValue: func(_ context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		clientFactory: func(context.Context) (awsSecretsManagerClient, error) {
+			factoryCalls++
+			return &awsSecretsManagerTestClient{getSecretValue: func(_ context.Context, input *secretsmanager.GetSecretValueInput, options ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+				requestOptions := secretsmanager.Options{}
+				for _, option := range options {
+					option(&requestOptions)
+				}
+				regions = append(regions, requestOptions.Region)
 				inputs = append(inputs, input)
 				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String(value)}, nil
 			}}, nil
@@ -102,6 +108,7 @@ func TestAWSSecretsManagerResolverResolve(t *testing.T) {
 	assert.Equal(t, value, got)
 
 	assert.Equal(t, []string{"us-west-2", "eu-west-1", "ap-northeast-1"}, regions)
+	assert.Equal(t, 1, factoryCalls)
 	require.Len(t, inputs, 3)
 	assert.Equal(t, "database-password", aws.ToString(inputs[0].SecretId))
 	assert.Equal(t, " 0123456789abcdef0123456789abcdef ", aws.ToString(inputs[0].VersionId))
@@ -111,8 +118,8 @@ func TestAWSSecretsManagerResolverResolve(t *testing.T) {
 
 func TestAWSSecretsManagerResolverBinaryValue(t *testing.T) {
 	resolver := &awsSecretsManagerResolver{
-		clientFactory: func(context.Context, string) (awsSecretsManagerClient, error) {
-			return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		clientFactory: func(context.Context) (awsSecretsManagerClient, error) {
+			return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 				return &secretsmanager.GetSecretValueOutput{SecretBinary: []byte{0xff, 0x00, 0x01}}, nil
 			}}, nil
 		},
@@ -138,8 +145,8 @@ func TestAWSSecretsManagerResolverErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			resolver := &awsSecretsManagerResolver{
-				clientFactory: func(context.Context, string) (awsSecretsManagerClient, error) {
-					return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+				clientFactory: func(context.Context) (awsSecretsManagerClient, error) {
+					return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 						return tc.output, tc.err
 					}}, nil
 				},
@@ -150,12 +157,12 @@ func TestAWSSecretsManagerResolverErrors(t *testing.T) {
 	}
 }
 
-func TestAWSSecretsManagerResolverCachesClients(t *testing.T) {
+func TestAWSSecretsManagerResolverCachesClient(t *testing.T) {
 	var factoryCalls int
 	resolver := &awsSecretsManagerResolver{
-		clientFactory: func(context.Context, string) (awsSecretsManagerClient, error) {
+		clientFactory: func(context.Context) (awsSecretsManagerClient, error) {
 			factoryCalls++
-			return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			return &awsSecretsManagerTestClient{getSecretValue: func(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("value")}, nil
 			}}, nil
 		},

--- a/internal/cmn/secrets/azure.go
+++ b/internal/cmn/secrets/azure.go
@@ -211,7 +211,7 @@ func parseAzureSecretURL(rawURL, optionVersion string) (azureSecretReference, er
 		return azureSecretReference{}, fmt.Errorf("invalid Azure Key Vault secret URL: %w", err)
 	}
 	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
-	if len(segments) < 2 || len(segments) > 3 || segments[0] != "secrets" || segments[1] == "" {
+	if len(segments) < 2 || len(segments) > 3 || !strings.EqualFold(segments[0], "secrets") || segments[1] == "" {
 		return azureSecretReference{}, fmt.Errorf("secret URL path for Azure Key Vault must be /secrets/{name} or /secrets/{name}/{version}")
 	}
 	name, err := url.PathUnescape(segments[1])

--- a/internal/cmn/secrets/azure_test.go
+++ b/internal/cmn/secrets/azure_test.go
@@ -44,7 +44,7 @@ func TestAzureKeyVaultResolverValidate(t *testing.T) {
 	}{
 		{name: "ShortName", ref: core.SecretRef{Key: "database-password"}},
 		{name: "ShortNameWithVault", ref: core.SecretRef{Key: "database-password", Options: map[string]string{"vault_url": "https://example.vault.azure.net/"}}},
-		{name: "FullURL", ref: core.SecretRef{Key: "https://example.vault.azure.net/secrets/database-password"}},
+		{name: "FullURLCaseInsensitiveObjectType", ref: core.SecretRef{Key: "https://example.vault.azure.net/SeCrEtS/database-password"}},
 		{name: "FullVersionURL", ref: core.SecretRef{Key: "https://example.vault.azure.net/secrets/database-password/" + azureTestVersion}},
 		{name: "Empty", ref: core.SecretRef{}, wantErr: "key"},
 		{name: "ShortNameWithSlash", ref: core.SecretRef{Key: "team/database-password"}, wantErr: "secret name"},


### PR DESCRIPTION
## Summary

- accept case-insensitive Azure Key Vault object-type URL segments
- reuse one AWS SDK configuration and client while selecting the region per secret request
- document the GCP `cloud-platform` OAuth-scope requirement in the separate docs repository

## Why

Azure Key Vault identifiers are case-insensitive, but mixed-case secret URL paths were rejected. AWS created a separate SDK configuration and credentials cache for each region even though operation-level region overrides are safe for concurrent use.

The GCP documentation change was committed directly to the docs repository's `main` branch as [dagucloud/docs@5afa8b5](https://github.com/dagucloud/docs/commit/5afa8b5e8772430cae71631c0e29522c90da79c5).

## Testing

- `go test -mod=readonly -race ./internal/cmn/secrets ./internal/cmn/config ./internal/cmn/schema -count=1`
- `make lint`
- `pnpm build` in the docs repository


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines cloud secret providers. Azure Key Vault accepts mixed-case `secrets` paths, and AWS Secrets Manager now uses one client with per-request region; docs updated separately for the GCP `cloud-platform` OAuth scope.

- **Refactors**
  - Reuse a single AWS SDK config and client; set region on `GetSecretValue` per call.
  - Remove per-region client cache; tests updated to confirm one factory call.

- **Bug Fixes**
  - Treat Azure Key Vault object-type segment (`secrets`) as case-insensitive.

<sup>Written for commit 52d6db33f4e5931f54c4d35cc19d2a793233b4c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS Secrets Manager now reuses a single client while still supporting secrets in different regions.
  * Azure Key Vault secret URLs are now accepted when the `/secrets/` path segment uses mixed or uppercase letters.
* **Tests**
  * Expanded coverage for AWS client reuse, regional secret access, and Azure URL case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->