### PR TITLE
fix: publish lifecycle handler outputs to the DAG run outputs

### DIFF
--- a/internal/core/exec/runstatus.go
+++ b/internal/core/exec/runstatus.go
@@ -259,6 +259,25 @@ func (st *DAGRunStatus) DAGRun() DAGRunRef {
 	return NewDAGRunRef(st.Name, st.DAGRunID)
 }
 
+// NodesInRunOrder returns the run's step nodes together with the lifecycle
+// handler nodes that were configured, ordered by when they run. Handlers that
+// the DAG does not declare are omitted.
+func (st *DAGRunStatus) NodesInRunOrder() []*Node {
+	afterSteps := []*Node{st.OnWait, st.OnSuccess, st.OnFailure, st.OnAbort, st.OnExit}
+
+	nodes := make([]*Node, 0, len(st.Nodes)+1+len(afterSteps))
+	if st.OnInit != nil {
+		nodes = append(nodes, st.OnInit)
+	}
+	nodes = append(nodes, st.Nodes...)
+	for _, node := range afterSteps {
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
 // Errors returns a slice of errors for the current status
 func (st *DAGRunStatus) Errors() []error {
 	var errs []error

--- a/internal/intg/output_test.go
+++ b/internal/intg/output_test.go
@@ -353,6 +353,46 @@ func TestOutputsCollection_CamelCaseConversion_AlreadyCamelCase(t *testing.T) {
 	runOutputsCollectionCamelCaseConversion(t, "ALREADY_CAMEL_Case", "alreadyCamelCase", "ALREADY_CAMEL_Case=test_value")
 }
 
+func TestOutputsCollection_LifecycleHandlerReachesCaller(t *testing.T) {
+	outputsTestParallel(t)
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `steps:
+  - action: dag.run
+    with:
+      dag: handler_outputs_child
+    output: CHILD
+  - run: echo "${CHILD.outputValues.from_step}|${CHILD.outputValues.from_handler}"
+    depends: dag_1
+    output: RESULT
+---
+name: handler_outputs_child
+handler_on:
+  exit:
+    run: echo '{"value":"from-handler"}'
+    stdout:
+      outputs:
+        fields:
+          from_handler:
+            decode: json
+            select: .value
+steps:
+  - name: emit-from-step
+    run: echo '{"value":"from-step"}'
+    stdout:
+      outputs:
+        fields:
+          from_step:
+            decode: json
+            select: .value
+`)
+	dag.Agent().RunSuccess(t)
+
+	dag.AssertOutputs(t, map[string]any{
+		"RESULT": "from-step|from-handler",
+	})
+}
+
 func TestOutputsCollection_SecretsMasked(t *testing.T) {
 	outputsTestParallel(t)
 

--- a/internal/intg/output_test.go
+++ b/internal/intg/output_test.go
@@ -393,6 +393,49 @@ steps:
 	})
 }
 
+// The wait handler runs after the steps that already finished, so its value for
+// a key a step also published is the one that survives.
+func TestOutputsCollection_WaitHandlerOverridesEarlierStep(t *testing.T) {
+	outputsTestParallel(t)
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+handler_on:
+  wait:
+    run: echo '{"value":"from-wait-handler"}'
+    stdout:
+      outputs:
+        fields:
+          shared:
+            decode: json
+            select: .value
+
+steps:
+  - name: emit
+    run: echo '{"value":"from-step"}'
+    stdout:
+      outputs:
+        fields:
+          shared:
+            decode: json
+            select: .value
+  - name: wait-step
+    run: "true"
+    depends: [emit]
+    approval: {}
+`)
+	agent := dag.Agent()
+	_ = agent.Run(agent.Context)
+
+	status := agent.Status(agent.Context)
+	require.Equal(t, core.Waiting, status.Status)
+	require.NotNil(t, status.OnWait, "wait handler should have been executed")
+
+	outputs := readOutputsFile(t, th, dag.DAG)
+	require.NotNil(t, outputs)
+	assert.Equal(t, "from-wait-handler", outputs["shared"])
+}
+
 func TestOutputsCollection_SecretsMasked(t *testing.T) {
 	outputsTestParallel(t)
 

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1211,8 +1211,8 @@ func errorString(err error) string {
 func (a *Agent) collectOutputs(ctx context.Context) map[string]string {
 	outputs := make(map[string]string)
 
-	// Get nodes from the plan in execution order
-	nodes := a.plan.Nodes()
+	// Steps and lifecycle handlers both publish to the run's outputs.
+	nodes := a.runner.NodesInRunOrder(a.plan)
 
 	for _, node := range nodes {
 		nodeData := node.NodeData()

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -1035,6 +1035,40 @@ steps:
     run: %q`, "exit 0"),
 			expected: map[string]string{},
 		},
+		{
+			name: "LifecycleHandlerOutputs",
+			dag: `handler_on:
+  exit:
+    run: echo '{"value":"from-handler"}'
+    stdout:
+      outputs:
+        fields:
+          from_handler:
+            decode: json
+            select: .value
+steps:
+  - name: step1
+    run: echo '{"value":"from-step"}'
+    stdout:
+      outputs:
+        fields:
+          from_step:
+            decode: json
+            select: .value`,
+			expected: map[string]string{"from_step": "from-step", "from_handler": "from-handler"},
+		},
+		{
+			name: "LifecycleHandlerOutputVariable",
+			dag: `handler_on:
+  exit:
+    run: echo "done"
+    output: HANDLER_RESULT
+steps:
+  - name: step1
+    run: echo "one"
+    output: OUTPUT_ONE`,
+			expected: map[string]string{"outputOne": "one", "handlerResult": "done"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/runtime/agent/collect_outputs_test.go
+++ b/internal/runtime/agent/collect_outputs_test.go
@@ -35,7 +35,7 @@ func TestCollectOutputsUsesCanonicalStringOutputValue(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		a := &Agent{plan: plan}
+		a := &Agent{plan: plan, runner: runtime.New(&runtime.Config{})}
 		assert.Equal(t, map[string]string{"result": "canonical"}, a.collectOutputs(context.Background()))
 	})
 
@@ -55,7 +55,7 @@ func TestCollectOutputsUsesCanonicalStringOutputValue(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		a := &Agent{plan: plan}
+		a := &Agent{plan: plan, runner: runtime.New(&runtime.Config{})}
 		assert.Equal(t, map[string]string{"result": "legacy"}, a.collectOutputs(context.Background()))
 	})
 
@@ -73,7 +73,7 @@ func TestCollectOutputsUsesCanonicalStringOutputValue(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		a := &Agent{plan: plan}
+		a := &Agent{plan: plan, runner: runtime.New(&runtime.Config{})}
 		assert.Equal(t, map[string]string{
 			"messageId": "msg-123",
 			"accepted":  "true",

--- a/internal/runtime/agent/dbclient.go
+++ b/internal/runtime/agent/dbclient.go
@@ -90,8 +90,10 @@ func (o *dbClient) GetSubDAGRunStatus(ctx context.Context, dagRunID string, root
 		return nil, fmt.Errorf("failed to read status: %w", err)
 	}
 
+	nodes := status.NodesInRunOrder()
+
 	outputVariables := make(map[string]string)
-	for _, node := range status.Nodes {
+	for _, node := range nodes {
 		if node.OutputVariables != nil {
 			node.OutputVariables.Range(func(_, value any) bool {
 				// split the value by '=' to get the key and value
@@ -106,7 +108,7 @@ func (o *dbClient) GetSubDAGRunStatus(ctx context.Context, dagRunID string, root
 	return &runtime.RunStatus{
 		Status:             status.Status,
 		Outputs:            outputVariables,
-		OutputValues:       runtime.OutputValuesFromExecNodes(status.Nodes),
+		OutputValues:       runtime.OutputValuesFromExecNodes(nodes),
 		Name:               status.Name,
 		DAGRunID:           status.DAGRunID,
 		Params:             status.Params,

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1046,6 +1046,43 @@ func (r *Runner) HandlerNode(name core.HandlerType) *Node {
 	return nil
 }
 
+// handlersBeforeSteps and handlersAfterSteps list the lifecycle handlers by
+// when they run relative to the DAG's steps.
+var (
+	handlersBeforeSteps = []core.HandlerType{core.HandlerOnInit}
+	handlersAfterSteps  = []core.HandlerType{
+		core.HandlerOnWait,
+		core.HandlerOnSuccess,
+		core.HandlerOnFailure,
+		core.HandlerOnAbort,
+		core.HandlerOnExit,
+	}
+)
+
+// NodesInRunOrder returns the plan's step nodes together with the lifecycle
+// handler nodes that were configured, ordered by when they run. Handlers that
+// the DAG does not declare are omitted.
+func (r *Runner) NodesInRunOrder(plan *Plan) []*Node {
+	var steps []*Node
+	if plan != nil {
+		steps = plan.Nodes()
+	}
+
+	nodes := make([]*Node, 0, len(steps)+len(handlersBeforeSteps)+len(handlersAfterSteps))
+	for _, handler := range handlersBeforeSteps {
+		if node := r.HandlerNode(handler); node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	nodes = append(nodes, steps...)
+	for _, handler := range handlersAfterSteps {
+		if node := r.HandlerNode(handler); node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
 // isCanceled returns true if the runner is canceled.
 func (r *Runner) isCanceled() bool {
 	r.mu.RLock()

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -533,12 +533,13 @@ func (r *Runner) getFullStatus(
 }
 
 func statusToRunStatus(status *exec.DAGRunStatus, runID string) *exec.RunStatus {
+	nodes := status.NodesInRunOrder()
 	return &exec.RunStatus{
 		Name:               status.Name,
 		DAGRunID:           runID,
 		Params:             status.Params,
-		Outputs:            outputVariablesFromNodes(status.Nodes),
-		OutputValues:       outputValuesFromNodes(status.Nodes),
+		Outputs:            outputVariablesFromNodes(nodes),
+		OutputValues:       outputValuesFromNodes(nodes),
 		Status:             status.Status,
 		PendingStepRetries: exec.PendingStepRetriesFromStatus(status),
 	}


### PR DESCRIPTION
## Summary

A lifecycle handler (`handler_on.exit`, `.success`, `.failure`, …) could declare `stdout.outputs` (or `output: NAME`), and dagu accepted it, ran it, and recorded the extracted value on the handler node as `outputsValue` — but the value never reached the run's published outputs. It was silently dropped: `outputs.json` omitted it, and a caller invoking the workflow with `action: dag.run` received an object with the field missing.

Root cause: run outputs were assembled from the execution plan's step nodes only (`a.plan.Nodes()`). Lifecycle handlers are not part of the plan, so their nodes were never consulted. The same omission applied where a parent reads a child run's persisted status — only `status.Nodes` was scanned, never `status.OnExit` and friends.

This implements option 1 from the issue: handler-declared outputs are merged into the run outputs like step-declared ones.

## Changes

- `runtime.Runner.NodesInRunOrder` returns the plan's step nodes together with the configured lifecycle handler nodes, ordered by when they run — `onInit`, the steps, then the terminal handlers with `onExit` last — so last-value-wins for key conflicts matches execution order.
- `exec.DAGRunStatus.NodesInRunOrder` does the same for a persisted status snapshot.
- `Agent.collectOutputs` (which writes `outputs.json`) now iterates the run's nodes rather than only the plan's.
- `dbClient.GetSubDAGRunStatus` (local sub-DAG runs) and `subflow.statusToRunStatus` (runs resolved through the coordinator) both include handler nodes when building the caller-visible `outputs` / `outputValues`.
- Tests: handler-declared `stdout.outputs` and `output: NAME` reach `outputs.json`, plus an integration test reproducing the issue's parent/child case end to end.

## Related Issues

Closes #2428

## Test plan

- `go test ./internal/runtime/... ./internal/core/... ./internal/subflow/... ./internal/service/...` — pass
- `go test ./internal/intg/... ` — pass except `TestAPIRescheduleQueuedFileRunUsesStoredSourceFile`, which fails on `main` too on macOS (a `/var` vs `/private/var` symlink artifact in a DAG source-path assertion), unrelated to this change
- `go test ./internal/intg/distr/` — pass
- `make lint` — 0 issues

Both new tests were confirmed to fail without the fix:

```
--- FAIL: TestAgent_OutputCollection/LifecycleHandlerOutputs
    expected: "from-handler"  actual: ""
--- FAIL: TestOutputsCollection_LifecycleHandlerReachesCaller
    expected: "RESULT=from-step|from-handler"  actual: "RESULT=from-step|<nil>"
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed (no tracked docs cover run-output assembly)
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped lifecycle handler outputs by merging handler nodes into DAG run outputs and child run statuses in execution order. Outputs from `handler_on.*` now appear in `outputs.json` and in `dag.run` caller `outputValues` (addresses #2428).

- **Bug Fixes**
  - Collect outputs from steps and lifecycle handlers in true run order (onInit → steps → onWait → onSuccess → onFailure → onAbort → onExit); last value wins.
  - Agent writes `outputs.json` by iterating run nodes, not just the plan.
  - Sub-DAG status mapping uses the same ordering for local and coordinator paths, so handler outputs populate `Outputs`/`OutputValues`.
  - Tests cover handler `stdout.outputs`, `output: NAME`, parent/child propagation, and wait-handler precedence over earlier step values.

<sup>Written for commit 1d356ef89bffb0f74868503d456085f08c8b0061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle-handler outputs are now included when collecting DAG results.
  * Outputs are processed in execution order, ensuring consistent values when keys overlap.
  * Child DAG outputs from exit handlers can now be accessed by parent workflows.
  * Structured and scalar handler outputs are correctly decoded and exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->