### PR TITLE
Security: Windows Process Tree Termination Ignores Errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,16 @@ jobs:
           version: v2.12.2
           args: --timeout=10m
 
+      # Files behind //go:build windows are invisible to a linter running at the
+      # host GOOS, so lint them explicitly.
+      - name: Run golangci-lint (GOOS=windows)
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        env:
+          GOOS: windows
+        with:
+          version: v2.12.2
+          args: --timeout=10m
+
   test-ubuntu:
     name: Test on ubuntu-latest (${{ matrix.suite_index }}/${{ matrix.suite_total }})
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,8 @@ fmt:
 	@printf '%b\n' "${COLOR_GREEN}Running linter with --fix...${COLOR_RESET}"
 	@GOBIN=${LOCAL_BIN_DIR} go install $(PKG_golangci_lint)
 	@${LOCAL_BIN_DIR}/golangci-lint run --fix ./...
+	@printf '%b\n' "${COLOR_GREEN}Running linter with --fix (GOOS=windows)...${COLOR_RESET}"
+	@GOOS=windows ${LOCAL_BIN_DIR}/golangci-lint run --fix ./...
 
 # check verifies code style without modifying files (for CI).
 .PHONY: check
@@ -450,6 +452,8 @@ check:
 	@printf '%b\n' "${COLOR_GREEN}Running linter...${COLOR_RESET}"
 	@GOBIN=${LOCAL_BIN_DIR} go install $(PKG_golangci_lint)
 	@${LOCAL_BIN_DIR}/golangci-lint run --timeout=10m ./...
+	@printf '%b\n' "${COLOR_GREEN}Running linter (GOOS=windows)...${COLOR_RESET}"
+	@GOOS=windows ${LOCAL_BIN_DIR}/golangci-lint run --timeout=10m ./...
 
 # golangci-lint run linting tool.
 .PHONY: golangci-lint
@@ -457,6 +461,8 @@ golangci-lint:
 	@printf '%b\n' "${COLOR_GREEN}Running linter...${COLOR_RESET}"
 	@GOBIN=${LOCAL_BIN_DIR} go install $(PKG_golangci_lint)
 	@${LOCAL_BIN_DIR}/golangci-lint run --fix ./...
+	@printf '%b\n' "${COLOR_GREEN}Running linter (GOOS=windows)...${COLOR_RESET}"
+	@GOOS=windows ${LOCAL_BIN_DIR}/golangci-lint run --fix ./...
 
 # changelog generates a changelog from the releases.
 .PHONY: changelog

--- a/internal/cmn/cmdutil/cmd_windows.go
+++ b/internal/cmn/cmdutil/cmd_windows.go
@@ -57,7 +57,9 @@ func killProcessTree(pid uint32) error {
 	for {
 		if entry.ParentProcessID == pid {
 			// Recursively kill children first
-			killProcessTree(entry.ProcessID)
+			if err := killProcessTree(entry.ProcessID); err != nil {
+				return fmt.Errorf("failed to kill child process %d: %w", entry.ProcessID, err)
+			}
 		}
 
 		err = windows.Process32Next(snapshot, (*windows.ProcessEntry32)(unsafe.Pointer(&entry)))

--- a/internal/cmn/cmdutil/cmd_windows.go
+++ b/internal/cmn/cmdutil/cmd_windows.go
@@ -6,6 +6,7 @@
 package cmdutil
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"syscall"
@@ -27,53 +28,69 @@ func setupCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
 }
 
-// killProcessTree kills a process and its subprocess tree on Windows
+// killProcessTree terminates pid and its descendant processes on Windows,
+// children before parents. A process that cannot be terminated does not stop the
+// rest of the tree from being killed; all such failures are returned together.
 func killProcessTree(pid uint32) error {
-	var entry struct {
-		Size              uint32
-		CntUsage          uint32
-		ProcessID         uint32
-		DefaultHeapID     uintptr
-		ModuleID          uint32
-		Threads           uint32
-		ParentProcessID   uint32
-		PriorityClassBase int32
-		Flags             uint32
-		ExeFile           [windows.MAX_PATH]uint16
+	// Process ID 0 is the System Idle Process, which is its own parent.
+	if pid == 0 {
+		return nil
 	}
+
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
 	if err != nil {
 		return fmt.Errorf("CreateToolhelp32Snapshot failed: %w", err)
 	}
-	defer windows.CloseHandle(snapshot)
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ProcessEntry32
 	entry.Size = uint32(unsafe.Sizeof(entry))
 
 	// Find first process
-	if err := windows.Process32First(snapshot, (*windows.ProcessEntry32)(unsafe.Pointer(&entry))); err != nil {
-		return err
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("Process32First failed: %w", err)
 	}
 
 	// Iterate all processes
+	var errs []error
 	for {
-		if entry.ParentProcessID == pid {
+		if entry.ParentProcessID == pid && entry.ProcessID != pid {
 			// Recursively kill children first
 			if err := killProcessTree(entry.ProcessID); err != nil {
-				return fmt.Errorf("failed to kill child process %d: %w", entry.ProcessID, err)
+				errs = append(errs, err)
 			}
 		}
 
-		err = windows.Process32Next(snapshot, (*windows.ProcessEntry32)(unsafe.Pointer(&entry)))
-		if err != nil {
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
 			break
 		}
 	}
 
 	// Finally, kill this process
-	h, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
-	if err == nil {
-		defer windows.CloseHandle(h)
-		windows.TerminateProcess(h, 1)
+	if err := terminateProcess(pid); err != nil {
+		errs = append(errs, err)
 	}
 
+	return errors.Join(errs...)
+}
+
+// terminateProcess force-terminates a single process. A process that has already
+// exited is not an error.
+func terminateProcess(pid uint32) error {
+	h, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
+	switch {
+	case errors.Is(err, windows.ERROR_INVALID_PARAMETER):
+		// The process exited and its kernel object is already gone.
+		return nil
+	case err != nil:
+		return fmt.Errorf("open process %d: %w", pid, err)
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+
+	// The handle carries PROCESS_TERMINATE, so ERROR_ACCESS_DENIED here means the
+	// process exited while another open handle kept its kernel object alive.
+	if err := windows.TerminateProcess(h, 1); err != nil && !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		return fmt.Errorf("terminate process %d: %w", pid, err)
+	}
 	return nil
 }

--- a/internal/cmn/cmdutil/cmd_windows_test.go
+++ b/internal/cmn/cmdutil/cmd_windows_test.go
@@ -10,14 +10,17 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-// TestKillProcessTree_Integration starts a dummy process and kills it using killProcessTree.
+// TestKillProcessTree_Integration starts a dummy process tree and kills it using
+// killProcessTree.
 func TestKillProcessTree_Integration(t *testing.T) {
-	// Start a harmless process that sleeps for a while
-	cmd := exec.Command("cmd", "/C", "timeout", "/T", "30", "/NOBREAK")
+	// Start a harmless process that runs for a while. cmd.exe launches ping.exe
+	// as a separate process, so the root has a child to recurse into.
+	cmd := exec.Command("cmd", "/C", "ping", "-n", "30", "127.0.0.1")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 
 	if err := cmd.Start(); err != nil {
@@ -27,8 +30,14 @@ func TestKillProcessTree_Integration(t *testing.T) {
 	pid := uint32(cmd.Process.Pid)
 	t.Logf("Started test process with PID %d", pid)
 
-	// Give it a moment to fully start
+	// Give it a moment to fully start and spawn its child
 	time.Sleep(500 * time.Millisecond)
+
+	children := childProcessIDs(t, pid)
+	if len(children) == 0 {
+		t.Fatalf("test process %d spawned no children, so the tree walk would not be exercised", pid)
+	}
+	t.Logf("Test process has child PIDs %v", children)
 
 	// Try to kill it
 	err := killProcessTree(pid)
@@ -51,10 +60,56 @@ func TestKillProcessTree_Integration(t *testing.T) {
 		}
 	}
 
-	// Verify the process handle no longer exists
-	h, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
-	if err == nil {
-		defer windows.CloseHandle(h)
-		t.Fatalf("expected process to be gone, but OpenProcess succeeded")
+	// Verify the whole tree is gone, not just the root
+	waitProcessGone(t, pid, "root process")
+	for _, child := range children {
+		waitProcessGone(t, child, "child process")
+	}
+}
+
+// childProcessIDs returns the process IDs whose recorded creator is pid.
+func childProcessIDs(t *testing.T, pid uint32) []uint32 {
+	t.Helper()
+
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		t.Fatalf("CreateToolhelp32Snapshot failed: %v", err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		t.Fatalf("Process32First failed: %v", err)
+	}
+
+	var children []uint32
+	for {
+		if entry.ParentProcessID == pid && entry.ProcessID != pid {
+			children = append(children, entry.ProcessID)
+		}
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+	return children
+}
+
+// waitProcessGone fails the test unless pid stops being openable within a few seconds.
+func waitProcessGone(t *testing.T, pid uint32, what string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		h, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
+		if err != nil {
+			return
+		}
+		_ = windows.CloseHandle(h)
+
+		if time.Now().After(deadline) {
+			t.Fatalf("expected %s (PID %d) to be gone, but OpenProcess succeeded", what, pid)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/internal/cmn/cmdutil/lifecycle_windows.go
+++ b/internal/cmn/cmdutil/lifecycle_windows.go
@@ -38,7 +38,7 @@ func (p *windowsManagedProcess) prepare(*exec.Cmd) error {
 	if _, err := windows.SetInformationJobObject(
 		job,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		uintptr(unsafe.Pointer(&info)), //nolint:gosec // SetInformationJobObject takes the struct address as a uintptr.
 		uint32(unsafe.Sizeof(info)),
 	); err != nil {
 		_ = windows.CloseHandle(job)
@@ -85,12 +85,13 @@ func (p *windowsManagedProcess) stop(cmd *exec.Cmd, req StopRequest) (StopOutcom
 		outcome.Contained = true
 		return outcome, nil
 	}
+	pid := uint32(cmd.Process.Pid) //nolint:gosec // Windows process IDs are DWORDs and always fit in uint32.
 	if p.job != 0 && p.assigned {
 		outcome.Mechanism = StopMechanismJobObject
 		outcome.Contained = true
 		if err := windows.TerminateJobObject(p.job, 1); err == nil {
 			return outcome, nil
-		} else if fallbackErr := killProcessTree(uint32(cmd.Process.Pid)); fallbackErr != nil {
+		} else if fallbackErr := killProcessTree(pid); fallbackErr != nil {
 			outcome.Mechanism = StopMechanismProcessTree
 			outcome.Contained = false
 			outcome.Partial = true
@@ -101,7 +102,7 @@ func (p *windowsManagedProcess) stop(cmd *exec.Cmd, req StopRequest) (StopOutcom
 		outcome.Partial = true
 		return outcome, nil
 	}
-	if err := killProcessTree(uint32(cmd.Process.Pid)); err != nil {
+	if err := killProcessTree(pid); err != nil {
 		return outcome, err
 	}
 	return outcome, nil

--- a/internal/cmn/procutil/process_windows.go
+++ b/internal/cmn/procutil/process_windows.go
@@ -18,7 +18,7 @@ func isAlive(pid int) bool {
 	if !canUseWindowsPID(pid) {
 		return false
 	}
-	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid)) //nolint:gosec // canUseWindowsPID bounds pid to the uint32 range.
 	if err != nil {
 		return err == windows.ERROR_ACCESS_DENIED
 	}
@@ -40,7 +40,7 @@ func canUseWindowsPID(pid int) bool {
 }
 
 func startTime(pid int) (int64, bool) {
-	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid)) //nolint:gosec // callers gate on canLookupStartTime, which bounds pid to the uint32 range.
 	if err != nil {
 		return 0, false
 	}

--- a/internal/runtime/resourcelimit/native_windows.go
+++ b/internal/runtime/resourcelimit/native_windows.go
@@ -54,7 +54,7 @@ func configureJobObject(handle windows.Handle, opts Options) error {
 		_, err := windows.SetInformationJobObject(
 			handle,
 			windows.JobObjectExtendedLimitInformation,
-			uintptr(unsafe.Pointer(&info)),
+			uintptr(unsafe.Pointer(&info)), //nolint:gosec // SetInformationJobObject takes the struct address as a uintptr.
 			uint32(unsafe.Sizeof(info)),
 		)
 		if err != nil {
@@ -71,7 +71,7 @@ func configureJobObject(handle windows.Handle, opts Options) error {
 		_, err := windows.SetInformationJobObject(
 			handle,
 			jobObjectCPURateControlInformationClass,
-			uintptr(unsafe.Pointer(&info)),
+			uintptr(unsafe.Pointer(&info)), //nolint:gosec // SetInformationJobObject takes the struct address as a uintptr.
 			uint32(unsafe.Sizeof(info)),
 		)
 		if err != nil {
@@ -86,11 +86,11 @@ func (g *windowsJobGuard) AssignProcess(pid int) error {
 	if g == nil || g.handle == 0 || pid <= 0 {
 		return nil
 	}
-	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid))
+	process, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid)) //nolint:gosec // Windows process IDs are DWORDs and always fit in uint32.
 	if err != nil {
 		return fmt.Errorf("open process for job assignment: %w", err)
 	}
-	defer windows.CloseHandle(process)
+	defer func() { _ = windows.CloseHandle(process) }()
 	if err := windows.AssignProcessToJobObject(g.handle, process); err != nil {
 		return fmt.Errorf("assign process to job object: %w", err)
 	}


### PR DESCRIPTION
## Summary

Security: Windows Process Tree Termination Ignores Errors

## Problem

**Severity**: `Low` | **File**: `internal/cmn/cmdutil/cmd_windows.go:L49`

In `killProcessTree` on Windows, the recursive call to kill child processes (`killProcessTree(entry.ProcessID)`) ignores the returned error. If a child process cannot be killed, the function continues silently, potentially leaving orphaned processes running.

## Solution

Check the error returned by the recursive `killProcessTree` call and handle it appropriately, such as logging the failure or aggregating errors to return to the caller.

## Changes

- `internal/cmn/cmdutil/cmd_windows.go` (modified)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates and aggregates errors in Windows `killProcessTree` to stop silent failures and prevent orphaned processes. Adds a Windows-specific lint pass and stronger tests to cover recursive termination.

- **Bug Fixes**
  - In `internal/cmn/cmdutil/cmd_windows.go`, aggregate child failures with `errors.Join`, always kill the parent last, check `OpenProcess`/`TerminateProcess` results, treat `ERROR_INVALID_PARAMETER`/`ERROR_ACCESS_DENIED` as non-errors when safe, and guard PID 0/self-parented entries.

<sup>Written for commit 8416f12b737adadcbf58086e88b85d4e9a22928b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when terminating child processes fails on Windows.
  * Error messages now include the affected child process ID for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->