### PR TITLE
fix: re-check cached DAG load errors instead of serving them forever

### DIFF
--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -103,47 +103,97 @@ func Build(
 			break
 		}
 
-		filePath := filepath.Join(dagDir, f.Name)
 		entry := &indexv1.DAGIndexEntry{
 			FilePath: f.Name,
 			FileSize: f.Size,
 			ModTime:  f.ModTime,
 		}
-
-		opts := make([]spec.LoadOption, 0, len(loadOpts)+4)
-		opts = append(opts, loadOpts...)
-		opts = append(opts,
-			spec.OnlyMetadata(),
-			spec.WithoutEval(),
-			spec.SkipSchemaValidation(),
-			spec.WithAllowBuildErrors(),
-		)
-
-		dag, err := spec.Load(ctx, filePath, opts...)
-		if err != nil {
-			entry.Name = strings.TrimSuffix(f.Name, filepath.Ext(f.Name))
-			entry.LoadError = err.Error()
-			idx.Entries = append(idx.Entries, entry)
-			continue
-		}
-
-		entry.Name = dag.Name
-		entry.Group = dag.Group
-		entry.Description = dag.Description
-		entry.Labels = labelsToStrings(dag.Labels)
-		entry.Schedule = scheduleToString(dag.Schedule)
-
-		if len(dag.BuildErrors) > 0 {
-			entry.LoadError = joinErrors(dag.BuildErrors)
-		}
-
-		_, flagged := flags[SuspendFlagName(dag.Name)]
-		entry.Suspended = flagged
-
+		buildEntry(ctx, dagDir, entry, flags, loadOpts...)
 		idx.Entries = append(idx.Entries, entry)
 	}
 
 	return idx
+}
+
+// buildEntry loads one DAG file and fills the entry, recording why it could not
+// be read when that happens.
+func buildEntry(
+	ctx context.Context,
+	dagDir string,
+	entry *indexv1.DAGIndexEntry,
+	flags SuspendFlags,
+	loadOpts ...spec.LoadOption,
+) {
+	entry.LoadError = ""
+
+	opts := make([]spec.LoadOption, 0, len(loadOpts)+4)
+	opts = append(opts, loadOpts...)
+	opts = append(opts,
+		spec.OnlyMetadata(),
+		spec.WithoutEval(),
+		spec.SkipSchemaValidation(),
+		spec.WithAllowBuildErrors(),
+	)
+
+	dag, err := spec.Load(ctx, filepath.Join(dagDir, entry.FilePath), opts...)
+	if err != nil {
+		entry.Name = strings.TrimSuffix(entry.FilePath, filepath.Ext(entry.FilePath))
+		entry.LoadError = err.Error()
+		return
+	}
+
+	entry.Name = dag.Name
+	entry.Group = dag.Group
+	entry.Description = dag.Description
+	entry.Labels = labelsToStrings(dag.Labels)
+	entry.Schedule = scheduleToString(dag.Schedule)
+
+	if len(dag.BuildErrors) > 0 {
+		entry.LoadError = joinErrors(dag.BuildErrors)
+	}
+
+	_, flagged := flags[SuspendFlagName(dag.Name)]
+	entry.Suspended = flagged
+}
+
+// RefreshFailures re-reads the files whose cached entry records a load error and
+// reports whether any of them changed.
+//
+// A cached success stays valid as long as the file is untouched, but a cached
+// failure does not: the error describes the parser that produced it, so a DAG
+// using syntax a newer binary understands would keep showing the old error until
+// its file happened to change.
+func RefreshFailures(
+	ctx context.Context,
+	dagDir string,
+	entries []*indexv1.DAGIndexEntry,
+	flags SuspendFlags,
+	loadOpts ...spec.LoadOption,
+) bool {
+	var changed bool
+	for _, entry := range entries {
+		if entry.LoadError == "" {
+			continue
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		previous := entry.LoadError
+		buildEntry(ctx, dagDir, entry, flags, loadOpts...)
+		if entry.LoadError != previous {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// NewIndex wraps entries in an index ready to be written.
+func NewIndex(entries []*indexv1.DAGIndexEntry) *indexv1.DAGIndex {
+	return &indexv1.DAGIndex{
+		Version:     IndexVersion,
+		BuiltAtUnix: time.Now().Unix(),
+		Entries:     entries,
+	}
 }
 
 // Write atomically writes the index to disk.

--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -115,8 +115,8 @@ func Build(
 	return idx
 }
 
-// buildEntry loads one DAG file and fills the entry, recording why it could not
-// be read when that happens.
+// buildEntry loads one DAG file and fills the rest of a freshly allocated entry,
+// recording why the file could not be read when that happens.
 func buildEntry(
 	ctx context.Context,
 	dagDir string,
@@ -124,8 +124,6 @@ func buildEntry(
 	flags SuspendFlags,
 	loadOpts ...spec.LoadOption,
 ) {
-	entry.LoadError = ""
-
 	opts := make([]spec.LoadOption, 0, len(loadOpts)+4)
 	opts = append(opts, loadOpts...)
 	opts = append(opts,
@@ -171,18 +169,24 @@ func RefreshFailures(
 	loadOpts ...spec.LoadOption,
 ) bool {
 	var changed bool
-	for _, entry := range entries {
+	for i, entry := range entries {
 		if entry.LoadError == "" {
 			continue
 		}
 		if ctx.Err() != nil {
 			break
 		}
-		previous := entry.LoadError
-		buildEntry(ctx, dagDir, entry, flags, loadOpts...)
-		if entry.LoadError != previous {
-			changed = true
+		refreshed := &indexv1.DAGIndexEntry{
+			FilePath: entry.FilePath,
+			FileSize: entry.FileSize,
+			ModTime:  entry.ModTime,
 		}
+		buildEntry(ctx, dagDir, refreshed, flags, loadOpts...)
+		if proto.Equal(entry, refreshed) {
+			continue
+		}
+		entries[i] = refreshed
+		changed = true
 	}
 	return changed
 }

--- a/internal/persis/file/dag/dagindex/refresh_test.go
+++ b/internal/persis/file/dag/dagindex/refresh_test.go
@@ -57,6 +57,30 @@ func TestRefreshFailures_KeepsARealError(t *testing.T) {
 	assert.NotEmpty(t, entries[0].LoadError)
 }
 
+// TestRefreshFailures_ReportsMetadataChangesUnderAnUnchangedError covers a DAG a
+// newer parser reads further into without being able to load it: the error text
+// is the same, but the metadata around it is not, and that correction has to
+// reach the index rather than being recomputed on every listing.
+func TestRefreshFailures_ReportsMetadataChangesUnderAnUnchangedError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yaml"),
+		[]byte("type: nonsense\nsteps:\n  - name: a\n    run: echo a\n"), 0o600))
+
+	entries := []*indexv1.DAGIndexEntry{{FilePath: "bad.yaml", LoadError: "placeholder"}}
+	require.True(t, dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{}))
+	require.NotEmpty(t, entries[0].LoadError, "the file is expected to stay unloadable")
+
+	// Same error, metadata only the previous parser produced.
+	entries[0].Labels = []string{"team=infra"}
+
+	changed := dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+
+	assert.True(t, changed, "a metadata-only correction still has to be persisted")
+	assert.Empty(t, entries[0].Labels)
+}
+
 // TestRefreshFailures_LeavesHealthyEntriesAlone keeps the fast path intact: a
 // cached success is not re-parsed on every listing.
 func TestRefreshFailures_LeavesHealthyEntriesAlone(t *testing.T) {

--- a/internal/persis/file/dag/dagindex/refresh_test.go
+++ b/internal/persis/file/dag/dagindex/refresh_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagindex_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/persis/file/dag/dagindex"
+	indexv1 "github.com/dagucloud/dagu/proto/index/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefreshFailures_ClearsAnErrorAnOlderBuildRecorded covers what a user sees
+// after upgrading Dagu: a DAG using syntax the previous binary could not parse
+// stays listed as broken, because the file never changed and the cached entry is
+// therefore still considered fresh.
+func TestRefreshFailures_ClearsAnErrorAnOlderBuildRecorded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.yaml"),
+		[]byte("steps:\n  - name: a\n    run: echo a\n"), 0o600))
+
+	entries := []*indexv1.DAGIndexEntry{{
+		FilePath:  "ok.yaml",
+		Name:      "ok",
+		LoadError: "decoding failed due to the following error(s): 'spec.dag' has invalid keys: tasks",
+	}}
+
+	changed := dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+
+	assert.True(t, changed, "the correction must be persisted")
+	assert.Empty(t, entries[0].LoadError, "the stale error is dropped once the file parses")
+	assert.Equal(t, "ok", entries[0].Name)
+}
+
+// TestRefreshFailures_KeepsARealError checks the other direction: a file that is
+// still broken keeps reporting why.
+func TestRefreshFailures_KeepsARealError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yaml"),
+		[]byte("steps: [unclosed\n  bad: : yaml\n"), 0o600))
+
+	entries := []*indexv1.DAGIndexEntry{{
+		FilePath:  "bad.yaml",
+		Name:      "bad",
+		LoadError: "some older message",
+	}}
+
+	dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+	assert.NotEmpty(t, entries[0].LoadError)
+}
+
+// TestRefreshFailures_LeavesHealthyEntriesAlone keeps the fast path intact: a
+// cached success is not re-parsed on every listing.
+func TestRefreshFailures_LeavesHealthyEntriesAlone(t *testing.T) {
+	t.Parallel()
+
+	entries := []*indexv1.DAGIndexEntry{{FilePath: "gone.yaml", Name: "cached"}}
+
+	changed := dagindex.RefreshFailures(
+		t.Context(), t.TempDir(), entries, dagindex.SuspendFlags{})
+
+	assert.False(t, changed)
+	assert.Equal(t, "cached", entries[0].Name, "a healthy entry is served from cache")
+	assert.Empty(t, entries[0].LoadError)
+}

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -450,8 +450,15 @@ func (store *Storage) loadOrRebuildIndex(ctx context.Context) []*indexv1.DAGInde
 
 	indexPath := filepath.Join(store.baseDir, dagindex.IndexFileName)
 
-	// Try loading existing index.
+	// Try loading existing index. A cached load error is re-checked against the
+	// current parser before it is served, so upgrading Dagu clears errors that
+	// only an older build produced.
 	if cached := dagindex.Load(indexPath, yamlFiles, flags); cached != nil {
+		if dagindex.RefreshFailures(ctx, store.baseDir, cached, flags, store.defaultLoadOptions()...) {
+			if err := dagindex.Write(indexPath, dagindex.NewIndex(cached)); err != nil {
+				logger.Warn(ctx, "Failed to write DAG definition index", tag.Error(err))
+			}
+		}
 		return cached
 	}
 


### PR DESCRIPTION
## The bug

A DAG whose YAML a previous Dagu build could not parse stays listed as broken
after upgrading, showing the old error indefinitely.

Reported after `type: controller` merged: every controller DAG in the UI showed

```
controller-demo: failed to process document 0: decoding failed due to the
following error(s): 'spec.dag' has invalid keys: tasks
```

even on a binary that parses `tasks` correctly. Rebuilding and restarting the
server does not help.

## Why

`dagindex` caches the parse result of every DAG file, including the failure:

```go
entry.LoadError = err.Error()                             // Build
dag.BuildErrors = []error{errors.New(entry.LoadError)}    // DAGFromEntry
```

`Load` decides the cache is still good from the index format version, the entry
count, each file's size and mtime, and the suspend flags. None of that changes
when the binary is replaced, so an error produced by an older parser is served
back to the UI for as long as the file is left untouched.

Any release that widens the schema hits this. `tasks` is simply the first field
that made it visible.

## The fix

A cached success stays authoritative; a cached failure does not. On a cache hit,
entries carrying a load error are re-read with the current parser, and the index
is rewritten only when something actually changed.

Healthy entries are untouched, so the fast path that the index exists for is
unaffected. The extra work is bounded by the number of files that are currently
failing to parse.

I deliberately did not key the cache on the build version instead: `make run`
uses `go run` without ldflags, so a development build always reports `0.0.0` and
would not have invalidated anything in the case that was reported.

## Verification

Reproduced end to end against a real index rather than only in unit tests:

1. built a pre-`controller` binary, listed the DAGs with it, confirmed the index
   on disk contained `invalid keys: tasks`
2. served the same directory with current `main`, confirmed the API still
   returned that error: `errors: ["... 'spec.dag' has invalid keys: tasks"]`
3. served it with this branch: `errors: []`, and the poisoned string was gone
   from the index file afterwards

Unit tests cover the three cases: a stale error is cleared, a genuine error is
kept, and a healthy entry is not re-parsed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-check cached DAG load errors on index load so old parser errors don’t stick around after upgrades. Also persist metadata updates for still-failing DAGs; healthy cached entries stay fast.

- **Bug Fixes**
  - On cache hits, re-parse only entries with `LoadError` using `dagindex.RefreshFailures`; rebuild from scratch and compare the whole entry before deciding to rewrite, so metadata-only fixes are saved even if the error text is unchanged.
  - Storage calls `RefreshFailures` before serving a cached index and writes back with `dagindex.NewIndex` only when something changed.
  - Tests verify stale errors are cleared, real errors are kept, metadata corrections are persisted, and healthy entries aren’t re-parsed.

<sup>Written for commit 28333c1e6e15a90874ed037784bc290edcf96801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cached DAG index load failures are now rechecked when the index is loaded.
  - Resolved file errors are cleared automatically, while ongoing parse errors remain recorded.
  - Updated index data is saved after successful failure refreshes.
  - Healthy cached entries remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->