### PR TITLE
test: avoid Windows fault in scheduler panic recovery

### DIFF
--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -5,12 +5,13 @@ package scheduler
 
 import (
 	"context"
-	"github.com/dagucloud/dagu/internal/cmn/config"
 	"os"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/core"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,7 +42,7 @@ func TestWaitForTickSignalStopsScheduler(t *testing.T) {
 func TestRunTickSafelyRecoversTickPanic(t *testing.T) {
 	t.Parallel()
 
-	sc := &Scheduler{}
+	sc := newPanickingScheduler(t)
 
 	require.NotPanics(t, func() {
 		sc.runTickSafely(context.Background(), time.Now())
@@ -51,11 +52,10 @@ func TestRunTickSafelyRecoversTickPanic(t *testing.T) {
 func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 	t.Parallel()
 
-	sc := &Scheduler{
-		quit: make(chan any),
-		clock: func() time.Time {
-			return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-		},
+	sc := newPanickingScheduler(t)
+	sc.quit = make(chan any)
+	sc.clock = func() time.Time {
+		return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	}
 	sig := make(chan os.Signal, 1)
 	done := make(chan struct{})
@@ -93,6 +93,19 @@ func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 		require.FailNow(t, "cronLoop exited after tick panic")
 	case <-time.After(100 * time.Millisecond):
 	}
+}
+
+func newPanickingScheduler(t *testing.T) *Scheduler {
+	t.Helper()
+
+	planner := NewTickPlanner(TickPlannerConfig{
+		IsSuspended: func(context.Context, string) bool {
+			panic("test tick panic")
+		},
+	})
+	require.NoError(t, planner.Init(t.Context(), []*core.DAG{{Name: "panic-dag"}}))
+
+	return &Scheduler{planner: planner}
 }
 
 func requireCronLoopRunning(t *testing.T, sc *Scheduler, done <-chan struct{}, panicCh <-chan any) {

--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -42,17 +42,18 @@ func TestWaitForTickSignalStopsScheduler(t *testing.T) {
 func TestRunTickSafelyRecoversTickPanic(t *testing.T) {
 	t.Parallel()
 
-	sc := newPanickingScheduler(t)
+	sc, panicTriggered := newPanickingScheduler(t)
 
 	require.NotPanics(t, func() {
 		sc.runTickSafely(context.Background(), time.Now())
 	})
+	requirePanicTriggered(t, panicTriggered)
 }
 
 func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 	t.Parallel()
 
-	sc := newPanickingScheduler(t)
+	sc, panicTriggered := newPanickingScheduler(t)
 	sc.quit = make(chan any)
 	sc.clock = func() time.Time {
 		return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
@@ -84,6 +85,7 @@ func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 		}
 	}()
 
+	requirePanicTriggered(t, panicTriggered)
 	requireCronLoopRunning(t, sc, done, panicCh)
 
 	select {
@@ -95,17 +97,29 @@ func TestCronLoopRecoversTickPanicAndKeepsRunning(t *testing.T) {
 	}
 }
 
-func newPanickingScheduler(t *testing.T) *Scheduler {
+func newPanickingScheduler(t *testing.T) (*Scheduler, <-chan struct{}) {
 	t.Helper()
 
+	panicTriggered := make(chan struct{}, 1)
 	planner := NewTickPlanner(TickPlannerConfig{
 		IsSuspended: func(context.Context, string) bool {
+			panicTriggered <- struct{}{}
 			panic("test tick panic")
 		},
 	})
 	require.NoError(t, planner.Init(t.Context(), []*core.DAG{{Name: "panic-dag"}}))
 
-	return &Scheduler{planner: planner}
+	return &Scheduler{planner: planner}, panicTriggered
+}
+
+func requirePanicTriggered(t *testing.T, panicTriggered <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-panicTriggered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "scheduler tick did not reach panic dependency")
+	}
 }
 
 func requireCronLoopRunning(t *testing.T, sc *Scheduler, done <-chan struct{}, panicCh <-chan any) {


### PR DESCRIPTION
## Summary

- initialize a real tick planner in the scheduler panic recovery tests
- trigger a controlled Go panic through the planner dependency instead of dereferencing a nil planner
- keep production scheduler behavior unchanged

## Root cause

The recovery tests constructed an empty `Scheduler` and relied on a nil `TickPlanner` dereference to produce the panic. Under Windows with Go 1.26.5, the two parallel tests could surface that memory fault as `0xc0000005` and crash during runtime stack handling instead of completing normal panic recovery. This made the Windows unit-test shard fail intermittently.

## Impact

Scheduler tick panic recovery remains covered without intentionally generating an OS-level memory fault.

## Testing

- `go test ./internal/service/scheduler -run 'Test(RunTickSafelyRecoversTickPanic|CronLoopRecoversTickPanicAndKeepsRunning)$' -count=100`
- `go test -race -ldflags=-extldflags=-Wl,-ld_classic ./internal/service/scheduler -run 'Test(RunTickSafelyRecoversTickPanic|CronLoopRecoversTickPanicAndKeepsRunning)$' -count=20`
- `go test -race -ldflags=-extldflags=-Wl,-ld_classic ./internal/service/scheduler`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /private/tmp/dagu6-scheduler-windows.test ./internal/service/scheduler`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks scheduler panic recovery tests to use a real `TickPlanner` that triggers a controlled panic. Adds an assertion that the panic path is exercised, avoiding Windows access violations while keeping production behavior unchanged.

- **Bug Fixes**
  - Added `newPanickingScheduler` and `requirePanicTriggered` to trigger and assert a planner-driven panic using a dummy `core.DAG`.
  - Updated panic recovery tests to use these helpers, ensuring the panic path runs and is handled cleanly on Windows and in parallel.

<sup>Written for commit f9081708e5673797bd1cddb3718d991832e16dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scheduler test setup with a shared test constructor.
  * Updated recovery and continuation coverage for scheduler tick handling.
  * Reorganized test imports for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->