### PR TITLE
feat: let a sub-workflow declare the outputs its caller sees

### DIFF
--- a/internal/intg/controller_child_outputs_test.go
+++ b/internal/intg/controller_child_outputs_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedModel serves the OpenAI-compatible chat completions API with a fixed
+// script of controller decisions, and records the observations it was sent.
+type scriptedModel struct {
+	mu       sync.Mutex
+	calls    int
+	tools    []string
+	observed []string
+}
+
+func (m *scriptedModel) observations() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.observed...)
+}
+
+func (m *scriptedModel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var req struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	_ = json.Unmarshal(body, &req)
+
+	m.mu.Lock()
+	m.observed = m.observed[:0]
+	for _, msg := range req.Messages {
+		if msg.Role == "tool" {
+			m.observed = append(m.observed, msg.Content)
+		}
+	}
+	turn := m.calls
+	m.calls++
+	m.mu.Unlock()
+
+	message := map[string]any{"role": "assistant"}
+	finish := "stop"
+	if turn < len(m.tools) {
+		args := "{}"
+		if m.tools[turn] == "set_task_status" {
+			args = `{"task":"checked","status":"completed","reason":"check ran"}`
+		}
+		message["tool_calls"] = []map[string]any{{
+			"id":       fmt.Sprintf("call_%d", turn),
+			"type":     "function",
+			"function": map[string]any{"name": m.tools[turn], "arguments": args},
+		}}
+		finish = "tool_calls"
+	} else {
+		message["content"] = "no further actions"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"choices": []map[string]any{{"index": 0, "message": message, "finish_reason": finish}},
+		"usage":   map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+	})
+}
+
+// controllerWithChild runs a controller whose single action is a sub-workflow,
+// and returns what the controller observed when that action finished.
+func controllerWithChild(t *testing.T, childTail string) []string {
+	t.Helper()
+
+	model := &scriptedModel{tools: []string{"check", "set_task_status"}}
+	server := httptest.NewServer(model)
+	t.Cleanup(server.Close)
+
+	th := test.Setup(t)
+	dag := th.DAG(t, fmt.Sprintf(`
+type: controller
+llm:
+  provider: local
+  model: test-model
+  base_url: %s
+  system: drive the workflow
+steps:
+  - name: check
+    description: check the draft
+    action: dag.run
+    with:
+      dag: check_child
+tasks:
+  - name: checked
+    description: done when check ran
+---
+name: check_child
+steps:
+  - id: load
+    run: echo scratch-value
+    output: SCRATCH
+%s
+`, server.URL, childTail))
+
+	dag.Agent().RunSuccess(t)
+	dag.AssertLatestStatus(t, core.Succeeded)
+
+	return model.observations()
+}
+
+func TestControllerObservesDeclaredChildOutputs(t *testing.T) {
+	t.Parallel()
+
+	observed := controllerWithChild(t, `  - id: publish
+    depends: [load]
+    action: outputs.write
+    with:
+      values:
+        verdict: clean`)
+
+	require.NotEmpty(t, observed)
+	assert.Contains(t, observed[0], `outputs: {"verdict":"clean"}`)
+	// The child declared its surface, so its internal variables are not appended
+	// on top of it.
+	assert.NotContains(t, observed[0], "SCRATCH")
+}
+
+func TestControllerObservesChildVariablesWhenNothingIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	observed := controllerWithChild(t, "")
+
+	require.NotEmpty(t, observed)
+	assert.Contains(t, observed[0], "SCRATCH=scratch-value")
+}

--- a/internal/intg/output_test.go
+++ b/internal/intg/output_test.go
@@ -505,6 +505,65 @@ steps:
 	assert.Equal(t, "RESULT=42", fullOutputs.Outputs["result"])
 }
 
+func TestSubDAGPublishesDeclaredOutputsToCaller(t *testing.T) {
+	outputsTestParallel(t)
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+steps:
+  - name: call
+    action: dag.run
+    with:
+      dag: declaring_child
+---
+name: declaring_child
+steps:
+  - id: load
+    run: echo scratch-value
+    output: SCRATCH
+  - id: publish
+    depends: [load]
+    action: outputs.write
+    with:
+      values:
+        verdict: clean
+`)
+	dag.Agent().RunSuccess(t)
+
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.Len(t, status.Nodes, 1)
+	require.NotNil(t, status.Nodes[0].OutputsValue)
+	// The child declared one output, so that is the whole surface the caller
+	// sees. SCRATCH stays internal to the child run.
+	require.JSONEq(t, `{"verdict":"clean"}`, *status.Nodes[0].OutputsValue)
+}
+
+func TestSubDAGWithoutDeclaredOutputsPublishesNothing(t *testing.T) {
+	outputsTestParallel(t)
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+steps:
+  - name: call
+    action: dag.run
+    with:
+      dag: plain_child
+---
+name: plain_child
+steps:
+  - id: load
+    run: echo scratch-value
+    output: SCRATCH
+`)
+	dag.Agent().RunSuccess(t)
+
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.Len(t, status.Nodes, 1)
+	assert.Nil(t, status.Nodes[0].OutputsValue)
+}
+
 // readOutputsFile reads the outputs.json file for a given DAG run
 // Returns just the outputs map for backward compatibility with existing tests
 func readOutputsFile(t *testing.T, th test.Helper, dag *core.DAG) map[string]string {

--- a/internal/runtime/builtin/dag/dag.go
+++ b/internal/runtime/builtin/dag/dag.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sync"
 
@@ -22,6 +23,7 @@ import (
 
 var _ executor.DAGExecutor = (*dagExecutor)(nil)
 var _ executor.NodeStatusDeterminer = (*dagExecutor)(nil)
+var _ executor.OutputsProvider = (*dagExecutor)(nil)
 
 type dagExecutor struct {
 	child     *executor.SubDAGExecutor
@@ -32,7 +34,39 @@ type dagExecutor struct {
 	runParams executor.RunParams
 	step      core.Step
 	result    *exec.RunStatus
+	outputs   map[string]any
 	cancel    context.CancelFunc
+}
+
+// declaredChildOutputs returns the outputs a child run published explicitly,
+// through `outputs.write`, `stdout.outputs`, or a step `outputs:` declaration.
+// It returns nil when the child declared nothing, so a step that publishes
+// only flat `output:` variables keeps reporting through the child run itself.
+func declaredChildOutputs(result *exec.RunStatus) map[string]any {
+	if result == nil || len(result.OutputValues) == 0 {
+		return nil
+	}
+	outputs := make(map[string]any, len(result.OutputValues))
+	maps.Copy(outputs, result.OutputValues)
+	return outputs
+}
+
+func (e *dagExecutor) setOutputs(outputs map[string]any) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.outputs = outputs
+}
+
+// GetOutputs implements executor.OutputsProvider.
+func (e *dagExecutor) GetOutputs() map[string]any {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	if len(e.outputs) == 0 {
+		return nil
+	}
+	outputs := make(map[string]any, len(e.outputs))
+	maps.Copy(outputs, e.outputs)
+	return outputs
 }
 
 // Errors for DAG executor
@@ -115,6 +149,8 @@ func (e *dagExecutor) Run(ctx context.Context) error {
 		e.result = result
 		e.lock.Unlock()
 	}
+
+	e.setOutputs(declaredChildOutputs(result))
 
 	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {

--- a/internal/runtime/controller_loop.go
+++ b/internal/runtime/controller_loop.go
@@ -560,16 +560,18 @@ func observe(ctx context.Context, node *Node, toolCallID string) exec.LLMMessage
 			fmt.Fprintf(&sb, "answered by: %s\n", state.HumanTaskCompletedBy)
 		}
 	}
-	if state.StepOutputsValue != nil && *state.StepOutputsValue != "" {
-		fmt.Fprintf(&sb, "outputs: %s\n", *state.StepOutputsValue)
+	declared := publishedOutputs(state)
+	if declared != "" {
+		fmt.Fprintf(&sb, "outputs: %s\n", declared)
 	} else if state.OutputValue != nil && *state.OutputValue != "" {
 		fmt.Fprintf(&sb, "output: %s\n", *state.OutputValue)
 	}
 	// A step that launched a child DAG is reported from the child run itself.
 	// Its stdout only mirrors the child's status JSON, once per internal retry,
-	// and is empty altogether on a repeated run.
+	// and is empty altogether on a repeated run. A child that declared its
+	// outputs has already reported them, so only its failures are worth adding.
 	if len(state.SubRuns) > 0 {
-		if summary := childRunSummary(ctx, state.SubRuns[0].DAGRunID); summary != "" {
+		if summary := childRunSummary(ctx, state.SubRuns[0].DAGRunID, declared != ""); summary != "" {
 			sb.WriteString(summary)
 			return toolResult(toolCallID, sb.String())
 		}
@@ -585,9 +587,24 @@ func observe(ctx context.Context, node *Node, toolCallID string) exec.LLMMessage
 	return toolResult(toolCallID, sb.String())
 }
 
+// publishedOutputs returns the outputs a step published explicitly, preferring
+// declared file-based outputs over the general payload. It is empty for a step
+// that published nothing.
+func publishedOutputs(state NodeState) string {
+	if state.StepOutputsValue != nil && *state.StepOutputsValue != "" {
+		return *state.StepOutputsValue
+	}
+	if state.OutputsValue != nil && *state.OutputsValue != "" {
+		return *state.OutputsValue
+	}
+	return ""
+}
+
 // childRunSummary reports what a child DAG run produced, read from the run
-// itself rather than scraped from the parent step's log.
-func childRunSummary(ctx context.Context, childRunID string) string {
+// itself rather than scraped from the parent step's log. When the child
+// declared its outputs, outputsReported suppresses the scraped fallback so
+// intermediate variables stay out of the transcript.
+func childRunSummary(ctx context.Context, childRunID string, outputsReported bool) string {
 	rCtx := exec.GetContext(ctx)
 	if childRunID == "" || rCtx.DAGRunStore == nil {
 		return ""
@@ -604,10 +621,12 @@ func childRunSummary(ctx context.Context, childRunID string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "child run: %s (%s)\n", status.Name, status.Status.String())
 
-	if outputs := childOutputs(status.Nodes); len(outputs) > 0 {
-		sb.WriteString("outputs:\n")
-		for _, key := range slices.Sorted(maps.Keys(outputs)) {
-			fmt.Fprintf(&sb, "  %s=%s\n", key, stringutil.TruncString(outputs[key], 2000))
+	if !outputsReported {
+		if outputs := childOutputs(status.Nodes); len(outputs) > 0 {
+			sb.WriteString("outputs:\n")
+			for _, key := range slices.Sorted(maps.Keys(outputs)) {
+				fmt.Fprintf(&sb, "  %s=%s\n", key, stringutil.TruncString(outputs[key], 2000))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

A `dag.run` step reports nothing structured to its caller. For a controller workflow, that means `observe()` falls back to `childRunSummary`, which scrapes **every output variable of every node** in the child run:

```go
// internal/runtime/controller_loop.go
if outputs := childOutputs(status.Nodes); len(outputs) > 0 {
    for _, key := range slices.Sorted(maps.Keys(outputs)) {
        fmt.Fprintf(&sb, "  %s=%s\n", key, stringutil.TruncString(outputs[key], 2000))
    }
}
```

Intermediate variables that exist only to feed a later step in the child end up in the controller's transcript, and the transcript is resent on every turn.

Concretely, writing an AI-writing-cleanup workflow as a controller, the review sub-workflow had to load a 24KB reference document into `output: STANDARD` just to interpolate it into a `chat.completion` prompt. Measured on a real run, the first observation was **3362 chars**; the only part the model needed was the ~600-char verdict. The workaround was to insert a wrapper DAG that calls the real one and republishes a single variable, purely so the caller sees less. That layer does nothing else.

## Change

The child run already carries the outputs a step published deliberately, via `outputs.write` or `stdout.outputs`. They live in `RunStatus.OutputValues`, which flat `output: VAR` never touches (`internal/runtime/node.go`). The action executor already reads exactly this (`actionOutputsFromRunStatus`); the dag executor did not.

- `internal/runtime/builtin/dag/dag.go` — implement `executor.OutputsProvider`, publishing the child's declared outputs. Returns nil when the child declared nothing, matching the existing `action` shape.
- `internal/runtime/controller_loop.go` — resolve published outputs the same way `NodeData.Outputs` does (declared file-based first, then the general payload), and skip the scraped fallback once the child has reported its own surface. Failed steps in the child are still reported either way.

No schema change. `outputs.write` in a sub-workflow already validates today.

```yaml
name: review-core
steps:
  - id: load_standard
    run: cat "$WORK/standard.txt"
    output: STANDARD        # stays internal to the child

  - id: check
    action: chat.completion
    with: { ... }
    output: FINDINGS

  - id: publish             # the surface the caller sees
    depends: [check]
    action: outputs.write
    with:
      values:
        verdict: ${FINDINGS}
```

## Compatibility

A child that declares nothing publishes nothing, so the caller keeps scraping and existing workflows are unchanged. Verified both paths on real runs:

| child | controller observation |
|---|---|
| declares `verdict` | `status: succeeded` / `outputs: {"verdict":"CLEAN"}` / `child run: check-core (succeeded)` — 81 chars |
| declares nothing | `status: succeeded` / `child run: check-core (succeeded)` / `outputs:` / `  HUGE=...` — 132 chars, same as before |

## What this does not do

It does not make the observation smaller than the wrapper-DAG workaround already achieves; the needed payload is the same either way. It removes the need for the workaround, and makes the child's public surface a declaration rather than a structural trick.

Two properties worth knowing, both pre-existing: the declared surface is the union of everything published structurally in that child, not a single return statement, and same-key collisions resolve by node order.

## Tests

- `internal/intg/output_test.go` — a sub-workflow that declares one output publishes exactly that to its caller; one that declares nothing publishes nothing.
- `internal/intg/controller_child_outputs_test.go` — a controller observing a declaring child sees the declared outputs and not the child's internals; observing a non-declaring child still sees its variables.

Run locally: `go test ./internal/intg/ -run 'TestSubDAG|TestControllerObserves' -count=1`. Full matrix left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sub-workflows can now declare the outputs their caller sees. Controllers read those outputs and stop scraping every child variable, reducing noisy transcripts and payload size.

- **New Features**
  - `dag.run` publishes a child’s declared outputs from `outputs.write`, `stdout.outputs`, or step `outputs:`.
  - Controller prefers declared outputs and suppresses scraped child variables when present; failures are still surfaced.
  - Backward compatible and no schema change. If a child declares nothing, the previous scraping behavior remains.

<sup>Written for commit 8466de8ff08e65aff1366b1c21df161a5b3c964a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child workflows can now publish explicitly declared outputs back to their parent workflow.
  * Parent workflows and controllers now report published outputs clearly without duplicating child workflow results.
  * Undeclared child workflow data remains internal when outputs are explicitly published.
  * When no outputs are declared, child results continue to be available through the existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Correction (post-merge):** an earlier version of this description listed a step `outputs:` declaration as a third boundary-crossing mechanism. It is not one. Per `docs/writing-workflows/sub-dags.md`, declared step outputs are scoped to the DAG document that defines them and are not visible to the parent; the two mechanisms that cross the run boundary are `outputs.write` and `stdout.outputs`. The code comment was corrected in dcfc7d4cb.
