### PR TITLE
fix: stop the controller overriding parameters a step already decided

### DIFF
--- a/internal/llm/toolschema/toolschema.go
+++ b/internal/llm/toolschema/toolschema.go
@@ -30,8 +30,18 @@ var paramRegex = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)(?:=(.*))?`)
 // invoked as a tool. Rich parameter definitions take precedence over the
 // positional default-params string.
 func ForDAG(dag *core.DAG) (map[string]any, error) {
+	params, err := ParamsForDAG(dag)
+	if err != nil {
+		return nil, err
+	}
+	return Build(params), nil
+}
+
+// ParamsForDAG lists the parameters a DAG accepts, preferring its rich
+// definitions and falling back to its default-params string.
+func ParamsForDAG(dag *core.DAG) ([]Param, error) {
 	if dag == nil {
-		return Build(nil), nil
+		return nil, nil
 	}
 
 	params := ParamsFromDefs(dag.ParamDefs)
@@ -42,7 +52,7 @@ func ForDAG(dag *core.DAG) (map[string]any, error) {
 			return nil, err
 		}
 	}
-	return Build(params), nil
+	return params, nil
 }
 
 // ParamsFromDefs converts rich parameter definitions into tool parameters.

--- a/internal/runtime/controller/catalog.go
+++ b/internal/runtime/controller/catalog.go
@@ -170,16 +170,47 @@ func (c *Catalog) Definitions() []exec.ToolDefinition {
 
 // stepParameters derives the JSON Schema of the arguments a step accepts. Only
 // steps that launch a child DAG take arguments; everything else is a nullary
-// action.
+// action. A parameter the step already supplies a value for is left out: the
+// author has decided it, so it is not the controller's to choose.
 func stepParameters(child *core.DAG, step core.Step) (map[string]any, error) {
 	if child == nil {
 		return toolschema.Build(nil), nil
 	}
-	schema, err := toolschema.ForDAG(child)
+	params, err := toolschema.ParamsForDAG(child)
 	if err != nil {
 		return nil, fmt.Errorf("step %q: %w", step.Name, err)
 	}
-	return schema, nil
+	return toolschema.Build(omitPinned(params, PinnedParams(step))), nil
+}
+
+// PinnedParams lists the parameter names a step supplies itself.
+func PinnedParams(step core.Step) map[string]struct{} {
+	values, err := step.Params.AsStringMap()
+	if err != nil || len(values) == 0 {
+		return nil
+	}
+	pinned := make(map[string]struct{}, len(values))
+	for name := range values {
+		if name != "" {
+			pinned[name] = struct{}{}
+		}
+	}
+	return pinned
+}
+
+// omitPinned drops the parameters the step already decided.
+func omitPinned(params []toolschema.Param, pinned map[string]struct{}) []toolschema.Param {
+	if len(pinned) == 0 {
+		return params
+	}
+	kept := make([]toolschema.Param, 0, len(params))
+	for _, param := range params {
+		if _, ok := pinned[param.Name]; ok {
+			continue
+		}
+		kept = append(kept, param)
+	}
+	return kept
 }
 
 // resolveChildDAG looks up a child DAG by name, preferring DAGs defined inline

--- a/internal/runtime/controller/catalog.go
+++ b/internal/runtime/controller/catalog.go
@@ -173,6 +173,11 @@ func (c *Catalog) Definitions() []exec.ToolDefinition {
 // action. A parameter the step already supplies a value for is left out: the
 // author has decided it, so it is not the controller's to choose.
 func stepParameters(child *core.DAG, step core.Step) (map[string]any, error) {
+	if step.SubDAG != nil {
+		if err := validateNamedSubDAGParams(step); err != nil {
+			return nil, err
+		}
+	}
 	if child == nil {
 		return toolschema.Build(nil), nil
 	}
@@ -181,6 +186,17 @@ func stepParameters(child *core.DAG, step core.Step) (map[string]any, error) {
 		return nil, fmt.Errorf("step %q: %w", step.Name, err)
 	}
 	return toolschema.Build(omitPinned(params, PinnedParams(step))), nil
+}
+
+func validateNamedSubDAGParams(step core.Step) error {
+	values, err := step.Params.AsStringMap()
+	if err != nil {
+		return fmt.Errorf("step %q: invalid child DAG parameters: %w", step.Name, err)
+	}
+	if _, positional := values[""]; positional {
+		return fmt.Errorf("step %q: controller child DAG parameters must be named", step.Name)
+	}
+	return nil
 }
 
 // PinnedParams lists the parameter names a step supplies itself.

--- a/internal/runtime/controller/controller_test.go
+++ b/internal/runtime/controller/controller_test.go
@@ -179,6 +179,92 @@ func TestNewCatalog(t *testing.T) {
 	assert.Contains(t, tools[1].Function.Description, "ok?")
 }
 
+// TestNewCatalog_HidesParametersTheStepPins covers the case that let a run pass
+// while doing nothing: a step fixed the aspect to grade, the model saw the
+// parameter anyway, sent an empty string for it, and the check graded against no
+// criteria and reported clean.
+func TestNewCatalog_HidesParametersTheStepPins(t *testing.T) {
+	t.Parallel()
+
+	dag := testDAG()
+	dag.LocalDAGs = map[string]*core.DAG{
+		"check": {
+			Name: "check",
+			ParamDefs: []core.ParamDef{
+				{Name: "aspect", Type: core.ParamDefTypeString, Required: true},
+				{Name: "strict", Type: core.ParamDefTypeString},
+			},
+		},
+	}
+	dag.Steps = []core.Step{
+		{
+			Name:   "check vocabulary",
+			SubDAG: &core.SubDAG{Name: "check", Params: `aspect="vocabulary"`},
+			Params: core.NewSimpleParams(map[string]string{"aspect": "vocabulary"}),
+		},
+		core.NewControllerStep(dag),
+	}
+
+	catalog, err := controller.NewCatalog(t.Context(), dag)
+	require.NoError(t, err)
+
+	params := catalog.Tools()[0].Function.Parameters
+	properties, _ := params["properties"].(map[string]any)
+	assert.NotContains(t, properties, "aspect", "the step decided this one")
+	assert.Contains(t, properties, "strict", "the model still chooses the rest")
+	assert.Empty(t, params["required"], "a pinned parameter is not asked for")
+}
+
+func TestMergeParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		stepParams string
+		args       map[string]any
+		pinned     []string
+		want       string
+	}{
+		{
+			name:       "an argument naming a pinned parameter is dropped",
+			stepParams: `aspect="vocabulary"`,
+			args:       map[string]any{"aspect": ""},
+			pinned:     []string{"aspect"},
+			want:       `aspect="vocabulary"`,
+		},
+		{
+			name:       "parameters the step pinned survive alongside chosen ones",
+			stepParams: `aspect="vocabulary" strict="high"`,
+			args:       map[string]any{"depth": 2},
+			pinned:     []string{"aspect", "strict"},
+			want:       `aspect="vocabulary" strict="high" depth="2"`,
+		},
+		{
+			name: "arguments alone render as before",
+			args: map[string]any{"target": "prod"},
+			want: `target="prod"`,
+		},
+		{
+			name:       "a step that pins everything ignores the arguments",
+			stepParams: `aspect="vocabulary"`,
+			pinned:     []string{"aspect"},
+			want:       `aspect="vocabulary"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pinned := make(map[string]struct{}, len(tt.pinned))
+			for _, name := range tt.pinned {
+				pinned[name] = struct{}{}
+			}
+			assert.Equal(t, tt.want, controller.MergeParams(tt.stepParams, tt.args, pinned))
+		})
+	}
+}
+
 func TestParamString(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/controller/controller_test.go
+++ b/internal/runtime/controller/controller_test.go
@@ -215,6 +215,38 @@ func TestNewCatalog_HidesParametersTheStepPins(t *testing.T) {
 	assert.Empty(t, params["required"], "a pinned parameter is not asked for")
 }
 
+func TestNewCatalog_RejectsPositionalPinnedParameters(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(t.Context(), []byte(`
+type: controller
+llm: {provider: anthropic, model: claude-opus-5}
+steps:
+  - name: check vocabulary
+    action: dag.run
+    with:
+      dag: check
+      params: vocabulary
+tasks:
+  - name: checked
+    description: The check ran.
+---
+name: check
+params:
+  - name: aspect
+    type: string
+    required: true
+steps:
+  - run: echo ${params.aspect}
+`))
+	require.NoError(t, err)
+
+	_, err = controller.NewCatalog(t.Context(), dag)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		`step "check vocabulary": controller child DAG parameters must be named`)
+}
+
 func TestMergeParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/controller/params.go
+++ b/internal/runtime/controller/params.go
@@ -35,6 +35,31 @@ func ParamString(args map[string]any) string {
 	return strings.Join(parts, " ")
 }
 
+// MergeParams combines the parameters a step supplies itself with the arguments
+// the controller chose, rendering both as the "key=value" string a child DAG run
+// expects. A pinned parameter is passed through exactly as the step wrote it,
+// and an argument naming one is dropped: it was never offered, so a model that
+// invented it does not get to override the author.
+func MergeParams(stepParams string, args map[string]any, pinned map[string]struct{}) string {
+	chosen := make(map[string]any, len(args))
+	for key, value := range args {
+		if _, ok := pinned[key]; ok {
+			continue
+		}
+		chosen[key] = value
+	}
+
+	rendered := ParamString(chosen)
+	switch {
+	case stepParams == "":
+		return rendered
+	case rendered == "":
+		return stepParams
+	default:
+		return stepParams + " " + rendered
+	}
+}
+
 func formatArgValue(value any) string {
 	switch v := value.(type) {
 	case nil:

--- a/internal/runtime/controller_loop.go
+++ b/internal/runtime/controller_loop.go
@@ -378,10 +378,8 @@ func (r *Runner) runControllerAction(
 		node.AddSubRunsRepeated(previous...)
 	}
 	if step.SubDAG != nil {
-		params := step.SubDAG.Params
-		if len(decision.Args) > 0 {
-			params = controller.ParamString(decision.Args)
-		}
+		params := controller.MergeParams(
+			step.SubDAG.Params, decision.Args, controller.PinnedParams(step))
 		node.SetSubDAG(core.SubDAG{Name: step.SubDAG.Name, Params: params})
 	}
 	attempt := state.RecordStepRun(decision.Step)

--- a/llms.txt
+++ b/llms.txt
@@ -244,6 +244,8 @@ tasks:
 
 Use `type: controller` only when the step order cannot be written down in advance. `steps` become a catalog of actions the model may pick; `tasks` are the goals and the termination condition. `llm` and a non-empty `tasks` are required, `depends` and router steps are rejected, and `__controller__` and `ask_user` are reserved names.
 
+A `dag.run` step advertises its target's parameters as tool arguments. Write a value in `params` for anything the model should not decide: a parameter the step supplies is not advertised and cannot be overridden.
+
 The model settles each task with `set_task_status`, choosing `completed`, `skipped` when nothing needed doing, `failed` when it cannot be achieved, or `open` to undo an earlier decision. The run ends once no task is open, and fails if any is failed. It can also call `ask_user` to put a question of its own to a person, which suspends the run exactly like a declared human task.
 
 Bind API keys with `env:` as shown. Dagu only propagates `DAGU_*`, `DAG_*`, `LC_*`, and `KUBERNETES_*` from the shell, so an exported key alone never reaches the provider.

--- a/llms.txt
+++ b/llms.txt
@@ -244,7 +244,7 @@ tasks:
 
 Use `type: controller` only when the step order cannot be written down in advance. `steps` become a catalog of actions the model may pick; `tasks` are the goals and the termination condition. `llm` and a non-empty `tasks` are required, `depends` and router steps are rejected, and `__controller__` and `ask_user` are reserved names.
 
-A `dag.run` step advertises its target's parameters as tool arguments. Write a value in `params` for anything the model should not decide: a parameter the step supplies is not advertised and cannot be overridden.
+A `dag.run` step advertises its target's parameters as tool arguments. Write a named value in `params` for anything the model should not decide: a parameter the step supplies is not advertised and cannot be overridden. Positional child parameters are rejected in controller DAGs because tool arguments are identified by name.
 
 The model settles each task with `set_task_status`, choosing `completed`, `skipped` when nothing needed doing, `failed` when it cannot be achieved, or `open` to undo an earlier decision. The run ends once no task is open, and fails if any is failed. It can also call `ask_user` to put a question of its own to a person, which suspends the run exactly like a declared human task.
 

--- a/specs/032-controller-dag.md
+++ b/specs/032-controller-dag.md
@@ -129,6 +129,8 @@ Each declared step is advertised to the model as one function-calling tool.
 - A parameter the step supplies a value for MUST NOT appear in that schema. A
   value written in the workflow is the author's decision, not one the controller
   restates, and a step that supplies every parameter is a nullary action.
+- Parameters supplied by a child-DAG step MUST use named form. Positional
+  parameters are rejected because tool arguments are identified by name.
 
 The parameters a child DAG run receives are the ones the step supplies, plus an
 argument for each parameter the step left open. An argument naming a parameter

--- a/specs/032-controller-dag.md
+++ b/specs/032-controller-dag.md
@@ -126,6 +126,14 @@ Each declared step is advertised to the model as one function-calling tool.
 - Only a step that launches a child DAG accepts arguments. Its schema is derived
   from the target's parameter definitions, falling back to its default-params
   string. Every other step is a nullary action.
+- A parameter the step supplies a value for MUST NOT appear in that schema. A
+  value written in the workflow is the author's decision, not one the controller
+  restates, and a step that supplies every parameter is a nullary action.
+
+The parameters a child DAG run receives are the ones the step supplies, plus an
+argument for each parameter the step left open. An argument naming a parameter
+the step supplies MUST be discarded rather than override it: the model was never
+offered that choice.
 
 Two additional tools are always offered.
 


### PR DESCRIPTION
## The bug

A `dag.run` step in a controller DAG advertises its target's parameters as tool
arguments, so the controller can pass values through. It advertised them even
when the step had already written a value for one:

```yaml
  - name: check_vocabulary
    action: dag.run
    with:
      dag: check
      params:
        aspect: vocabulary      # decided by the author
```

The model sees `check_vocabulary(aspect)` and no indication that `aspect` is
settled, so it fills it. Applying the arguments then discarded the step's
parameters entirely:

```go
params := step.SubDAG.Params
if len(decision.Args) > 0 {
    params = controller.ParamString(decision.Args)   // wholesale replacement
}
```

Two separate failures come out of that.

**A pinned value can be replaced by a guess.** From a real run — the step's
parameters and what actually reached the child:

```json
{
  "params":   { "aspect": "puffery, elegant variation, copula avoidance, em-dash overuse" },
  "childDag": { "name": "check", "params": "aspect=\"\"" }
}
```

The model answered with an empty string. The child graded against no criteria,
reported clean, and every task settled as completed. No step failed, no child run
failed, nothing was logged: the run finished green having changed nothing. This
is the failure mode that costs the most to notice.

**A parameter the model did not name is dropped.** With `params: {aspect: …,
strict: …}`, a single argument for `aspect` throws `strict` away. That is wrong
under any reading of the intent — nothing overrode `strict`.

## The rule

A value written in the workflow is the author's decision. It is not offered to
the model, and an argument naming it is discarded rather than applied. A step
that supplies every parameter is a nullary action.

Arguments now merge into what the step wrote instead of displacing it, so the
parameters left open still come from the model.

This makes `params` the way to fix what a step is for. Two steps can point at one
child workflow, each pinning a different aspect, and the model picks between two
clearly distinct tools instead of having to reproduce the right string on every
call.

## Changes

- `internal/runtime/controller/catalog.go` — pinned parameters are left out of
  the advertised schema
- `internal/runtime/controller/params.go` — `MergeParams` combines the step's
  parameters with the chosen arguments, dropping arguments that name a pinned one
- `internal/llm/toolschema/toolschema.go` — `ParamsForDAG` exposes the parameter
  list that `ForDAG` already built, so the catalog can filter before building the
  schema
- `specs/032-controller-dag.md`, `llms.txt` — state the rule

## Verification

Both new tests were confirmed to fail against the previous behaviour before
being kept: `TestNewCatalog_HidesParametersTheStepPins` (the schema still
advertised `aspect`, and still marked it required) and `TestMergeParams`.

End to end against a real provider, two steps pinning different aspects of one
child workflow:

```
"VERDICT": "graded aspect=[vocabulary] depth=[normal]"
"VERDICT": "graded aspect=[structure] depth=[normal]"
```

Each step's pinned `aspect` survived, and `depth` — left open — still took its
default because the model chose not to send it.

`go test ./internal/runtime/... ./internal/llm/... ./internal/core/...` passes,
`go fix -diff ./internal/...` is clean, `make lint` reports 0 issues on both
platforms.

Docs for this rule go to the `docs` repository separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops controllers from overriding step-pinned params in `dag.run` and rejects positional child `params` in controller DAGs. Pinned params are hidden from the tool schema, and arguments now merge with the step’s params.

- **Bug Fixes**
  - Tool schema omits parameters the step supplies; fully pinned steps are nullary actions.
  - Advertises only unpinned params using `ParamsForDAG` with catalog-side filtering.
  - Runner merges step params with arguments; arguments naming pinned params are ignored.
  - Child `params` in controller DAGs must be named; positional params are rejected with a clear error.

<sup>Written for commit 89f20782819e0c24ebd6a6b268856134c276ef48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Controller actions now expose only the parameters that still require model input.
  - Step-provided parameters are automatically preserved when combining defaults with selected action arguments.

- **Bug Fixes**
  - Model-supplied values can no longer override parameters fixed by a DAG step.
  - Fully configured steps are treated as actions requiring no additional arguments.
  - Parameter schema generation now handles missing or empty DAG definitions correctly.

- **Documentation**
  - Clarified parameter visibility and override behavior for `dag.run` actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->