### PR TITLE
fix: flush the output of a step attempt that follows an earlier one

### DIFF
--- a/internal/runtime/controller_loop_test.go
+++ b/internal/runtime/controller_loop_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -275,6 +276,28 @@ func TestControllerLoop_RerunsAnActionWithFreshArguments(t *testing.T) {
 	alpha := ch.node(t, "alpha")
 	assert.Equal(t, core.NodeSucceeded, alpha.State().Status)
 	assert.True(t, alpha.State().Repeated, "a re-run action is marked repeated")
+}
+
+func TestControllerLoop_ObservesTheOutputOfARerunAction(t *testing.T) {
+	t.Parallel()
+
+	ch := setupController(t, controllerDAG,
+		turn{tool: "alpha"},
+		turn{tool: "alpha"},
+		turn{tool: controller.SetTaskStatusTool, args: map[string]any{"task": "first", "status": "completed", "reason": "alpha ran twice"}},
+		turn{tool: controller.SetTaskStatusTool, args: map[string]any{"task": "second", "status": "completed", "reason": "not needed"}},
+	)
+
+	require.Equal(t, core.Succeeded, ch.run(t))
+
+	// Each attempt writes its own log, and the controller decides what to do
+	// next from what it reads there. An attempt whose output never reached the
+	// file leaves the controller guessing.
+	stdout := ch.node(t, "alpha").State().Stdout
+	require.NotEmpty(t, stdout)
+	written, err := os.ReadFile(stdout)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", strings.TrimSpace(string(written)))
 }
 
 func TestControllerLoop_RejectsUnknownToolAndTask(t *testing.T) {

--- a/internal/runtime/controller_loop_test.go
+++ b/internal/runtime/controller_loop_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -43,10 +42,11 @@ type turn struct {
 // fakeModel serves the OpenAI-compatible chat completions API, replying with a
 // fixed script of decisions so the controller loop can be driven deterministically.
 type fakeModel struct {
-	mu     sync.Mutex
-	turns  []turn
-	calls  int
-	system string
+	mu          sync.Mutex
+	turns       []turn
+	calls       int
+	system      string
+	toolResults []string
 }
 
 // lastSystemPrompt returns the system message of the most recent request.
@@ -54,6 +54,14 @@ func (m *fakeModel) lastSystemPrompt() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.system
+}
+
+// observations returns the tool results carried by the most recent request,
+// which is the whole transcript the controller had built by that point.
+func (m *fakeModel) observations() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.toolResults...)
 }
 
 // captureSystem records the system message so tests can assert on the prompt.
@@ -73,9 +81,13 @@ func (m *fakeModel) captureSystem(r *http.Request) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.toolResults = m.toolResults[:0]
 	for _, msg := range req.Messages {
-		if msg.Role == "system" {
+		switch msg.Role {
+		case "system":
 			m.system = msg.Content
+		case "tool":
+			m.toolResults = append(m.toolResults, msg.Content)
 		}
 	}
 }
@@ -290,14 +302,16 @@ func TestControllerLoop_ObservesTheOutputOfARerunAction(t *testing.T) {
 
 	require.Equal(t, core.Succeeded, ch.run(t))
 
-	// Each attempt writes its own log, and the controller decides what to do
-	// next from what it reads there. An attempt whose output never reached the
-	// file leaves the controller guessing.
-	stdout := ch.node(t, "alpha").State().Stdout
-	require.NotEmpty(t, stdout)
-	written, err := os.ReadFile(stdout)
-	require.NoError(t, err)
-	assert.Equal(t, "alpha", strings.TrimSpace(string(written)))
+	// The controller decides what to do next from what an action reported, so
+	// every attempt has to come back with its output. An attempt that reports
+	// nothing reads as one that ran fine and had nothing to say.
+	reported := 0
+	for _, observation := range ch.model.observations() {
+		if strings.Contains(observation, "alpha") {
+			reported++
+		}
+	}
+	assert.Equal(t, 2, reported, "both attempts report their output")
 }
 
 func TestControllerLoop_RejectsUnknownToolAndTask(t *testing.T) {

--- a/internal/runtime/output.go
+++ b/internal/runtime/output.go
@@ -101,6 +101,13 @@ func (oc *OutputCoordinator) setupMasker(ctx context.Context, _ NodeData) error 
 }
 
 func (oc *OutputCoordinator) setup(ctx context.Context, data NodeData) error {
+	// This attempt gets its own writers, so the closed latch from the previous
+	// one must not survive: it guards every flush path, and a set latch would
+	// drop this attempt's buffered output on teardown.
+	oc.mu.Lock()
+	oc.closed = false
+	oc.mu.Unlock()
+
 	if err := oc.setupMasker(ctx, data); err != nil {
 		return fmt.Errorf("failed to setup masker: %w", err)
 	}


### PR DESCRIPTION
## The bug

A step that runs a second time on the same node writes its output nowhere.

`OutputCoordinator.closed` (`internal/runtime/output.go`) latches on the first teardown and is never cleared. Nothing in the repository assigns `false` to it. It guards both flush paths:

```go
func (oc *OutputCoordinator) flushWritersWithMode(ifDue bool) error {
	if oc.closed {
		return nil
	}

func (oc *OutputCoordinator) closeResources() error {
	_ = oc.flushWriters()      // returns immediately
	if oc.closed {
		return nil             // writers never closed
	}
```

The second attempt runs `setup` normally, so `setupLocalWriters` opens a fresh log file and installs a fresh buffered writer. The step writes into that buffer. Teardown then short-circuits, the buffer is discarded, and the new file is left at zero bytes. The output is not appended to the earlier attempt's file and does not reach the run log; it is gone.

Measured on a controller run before the fix, one file per attempt:

```
implement [22B]: implementation pass 1
test      [52B]: FAIL: back_pressure_test: buffer grew without bound
implement [ 0B]:
test      [ 0B]:
```

`repeat_policy` is unaffected: a repeat loops inside one `Prepare`/`Teardown` cycle, so the single close still happens with the latch clear.

## Why it matters beyond a missing log

Controller workflows re-run actions by design, and the controller decides what to do next from what the action reported. A silent attempt is not just an empty log: `observe` has nothing to add beyond `status: succeeded`, which reads as an action that ran fine and had nothing to say.

A workflow whose verdict travels on stdout settles its tasks against output nobody produced. In the run that surfaced this, two code reviewers printed `PASS` or `FAIL: <finding>`; from the second attempt onward the controller saw neither, concluded both reviews had passed, and finished green with the source file byte-identical to the broken original. Exit status still reaches the controller, so a workflow that signals through exit codes is unaffected, which is why this took a while to see.

## The fix

Clear the latch in `OutputCoordinator.setup`, the one place a new attempt installs its writers. That covers the controller re-run path and any other route that sets the coordinator up again, rather than patching a single caller.

After:

```
implement [22B]: implementation pass 1
test      [52B]: FAIL: back_pressure_test: buffer grew without bound
implement [22B]: implementation pass 2
test      [15B]: PASS: 14 tests
```

## Tests

`TestControllerLoop_ObservesTheOutputOfARerunAction` runs one action twice and asserts the attempt's log holds what the step printed. Confirmed to fail before the change:

```
--- FAIL: TestControllerLoop_ObservesTheOutputOfARerunAction
    expected: "alpha"
    actual  : ""
```

`go test ./internal/runtime/ -run TestControllerLoop -count=1` passes, `make lint` reports 0 issues on both platforms. Full matrix left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost output when rerunning a step on the same node by clearing the output coordinator latch so each attempt flushes and writes its logs. Ensures the controller sees each attempt’s output and avoids zero‑byte logs.

- **Bug Fixes**
  - Reset `OutputCoordinator.closed` in `setup` so each attempt can flush and close its writers.
  - Test now asserts both attempts appear in the controller transcript (`TestControllerLoop_ObservesTheOutputOfARerunAction`).

<sup>Written for commit 5d573ca4153c7513c78d845155d5848b4451dc97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repeated action runs so subsequent processing uses the latest run’s output.
  - Fixed output handling after an earlier run has closed, ensuring new output is properly captured and finalized.

- **Tests**
  - Added coverage verifying that rerun results are observed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->