### PR TITLE
fix: resolve a relative working_dir against the file the DAG was written in

### DIFF
--- a/internal/core/spec/builder.go
+++ b/internal/core/spec/builder.go
@@ -124,6 +124,10 @@ type BuildOpts struct {
 	DAGsDir string
 	// DefaultWorkingDir is the default working directory for DAGs without explicit workingDir.
 	DefaultWorkingDir string
+	// SourceFile is the path the DAG was authored at. It is set when the
+	// definition is loaded from a copy, so relative paths keep resolving
+	// against the file the author wrote rather than the copy.
+	SourceFile string
 	// Flags stores all boolean options controlling build behaviour.
 	Flags BuildFlag
 	// BuildEnv provides pre-populated environment variables for the build.

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1918,7 +1918,7 @@ func buildShellArgs(ctx BuildContext, d *dag) ([]string, error) {
 
 func buildWorkingDir(ctx BuildContext, d *dag) (string, error) {
 	if d.WorkingDir != "" {
-		return resolveWorkingDirPath(d.WorkingDir, ctx.file)
+		return resolveWorkingDirPath(d.WorkingDir, authoredFile(ctx))
 	}
 	if ctx.opts.DefaultWorkingDir != "" {
 		return ctx.opts.DefaultWorkingDir, nil
@@ -1926,6 +1926,17 @@ func buildWorkingDir(ctx BuildContext, d *dag) (string, error) {
 	// Return empty to allow inheritance from base config.
 	// Default is applied post-merge in loadDAG.
 	return "", nil
+}
+
+// authoredFile returns the path the DAG was written at. It differs from the
+// file being read whenever a definition is executed from a copy, which is the
+// case for a sub-workflow defined in the same document and for a task a worker
+// received from the coordinator.
+func authoredFile(ctx BuildContext) string {
+	if ctx.opts.SourceFile != "" {
+		return ctx.opts.SourceFile
+	}
+	return ctx.file
 }
 
 // resolveWorkingDirPath resolves the working directory path at build time.

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -1861,6 +1861,21 @@ func TestBuildWorkingDir_Relative(t *testing.T) {
 	assert.Equal(t, filepath.Join(tmpDir, "subdir"), result)
 }
 
+func TestBuildWorkingDir_RelativeToAuthoredFile(t *testing.T) {
+	// A definition executed from a copy, such as a sub-workflow written in the
+	// same document or a task a worker received, still resolves against the file
+	// the author wrote.
+	authored := filepath.Join(t.TempDir(), "workflows", "pipeline.yaml")
+	copied := filepath.Join(t.TempDir(), "local-dags", "child-1234.yaml")
+
+	ctx := BuildContext{file: copied, opts: BuildOpts{SourceFile: authored}}
+	d := &dag{WorkingDir: "checkout"}
+
+	result, err := buildWorkingDir(ctx, d)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(filepath.Dir(authored), "checkout"), result)
+}
+
 func TestBuildWorkingDir_NoExpansion(t *testing.T) {
 	// WorkingDir is no longer expanded at build time - expansion happens at runtime
 	// See runtime/env.go resolveWorkingDir()

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -42,6 +42,7 @@ type LoadOptions struct {
 	flags                  BuildFlag
 	dagsDir                string            // Directory containing the core.DAG files.
 	defaultWorkingDir      string            // Default working directory for DAGs without explicit workingDir.
+	sourceFile             string            // Path the DAG was authored at, used to resolve relative paths.
 	buildEnv               map[string]string // Pre-populated env vars for build (used for retry with dotenv).
 }
 
@@ -163,6 +164,16 @@ func WithDefaultWorkingDir(defaultWorkingDir string) LoadOption {
 	}
 }
 
+// WithSourceFile sets the path the DAG was authored at. A definition executed
+// from a temporary copy, such as a sub-workflow or a task dispatched to a
+// worker, resolves its relative paths against this rather than against the
+// copy.
+func WithSourceFile(sourceFile string) LoadOption {
+	return func(o *LoadOptions) {
+		o.sourceFile = strings.TrimSpace(sourceFile)
+	}
+}
+
 // WithBuildEnv provides additional environment variables for the build.
 // These are added to the envScope before building, allowing YAML to
 // reference them via ${VAR}. This is used for retry scenarios where
@@ -253,6 +264,7 @@ func loadBuildOpts(options LoadOptions) BuildOpts {
 		Name:                   options.name,
 		DAGsDir:                options.dagsDir,
 		DefaultWorkingDir:      options.defaultWorkingDir,
+		SourceFile:             options.sourceFile,
 		Flags:                  options.flags,
 		BuildEnv:               options.buildEnv,
 	}

--- a/internal/intg/working_dir_test.go
+++ b/internal/intg/working_dir_test.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intg_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/internal/core"
+	"github.com/dagucloud/dagu/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+// A sub-workflow written in the same document runs from a temporary copy of
+// that document. Its relative working_dir still means the directory beside the
+// file the author wrote, which is where the files it refers to actually are.
+func TestSubDAGRelativeWorkingDirResolvesAgainstAuthoredFile(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `
+steps:
+  - name: call
+    action: dag.run
+    with:
+      dag: reader
+    output: CHILD
+---
+name: reader
+working_dir: ./checkout
+steps:
+  - name: read
+    run: cat marker.txt
+    output: MARKER
+`)
+
+	checkout := filepath.Join(filepath.Dir(dag.Location), "checkout")
+	require.NoError(t, os.MkdirAll(checkout, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(checkout, "marker.txt"), []byte("beside the author's file"), 0o600))
+
+	dag.Agent().RunSuccess(t)
+	dag.AssertLatestStatus(t, core.Succeeded)
+
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.Len(t, status.Nodes, 1)
+	require.NotNil(t, status.Nodes[0].OutputVariables)
+
+	value, ok := status.Nodes[0].OutputVariables.Load("CHILD")
+	require.True(t, ok)
+	require.Contains(t, value, "beside the author's file",
+		"the child read the file beside the authored DAG")
+}

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -440,6 +440,9 @@ func (h *remoteTaskHandler) loadDAG(ctx context.Context, task *coordinatorv1.Tas
 	loadOpts := []spec.LoadOption{
 		spec.WithName(task.Target), // Use original DAG name, not temp file path
 	}
+	if task.SourceFile != "" {
+		loadOpts = append(loadOpts, spec.WithSourceFile(task.SourceFile))
+	}
 
 	// Use embedded base config from the task if available (distributed mode).
 	// Fall back to local base config path if the task doesn't include one.

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -507,6 +507,9 @@ func inProcessLoadOptions(
 		spec.WithName(req.DAG.Name),
 		spec.WithSkipBaseHandlers(),
 	}
+	if req.DAG.SourceFile != "" {
+		loadOpts = append(loadOpts, spec.WithSourceFile(req.DAG.SourceFile))
+	}
 	if cfg != nil {
 		loadOpts = append(loadOpts, spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)))
 	}


### PR DESCRIPTION
## The bug

A definition does not always execute from the file it was authored in.

- A sub-workflow written in the same document is materialized to a temporary copy first (`internal/runtime/executor/dag_runner.go`, `T/dagu/local-dags/<name>-<hash>.yaml`).
- A task dispatched to a worker travels as YAML text, which the worker writes out and loads (`internal/service/worker/remote_handler.go`, `T/dagu/worker-dags/...`).

Only `YamlData` travels, so the build runs again on the receiving side with the copy as the DAG file. `resolveWorkingDirPath` joins a relative path to `filepath.Dir(dagFile)`, so `working_dir: ./checkout` resolved beside the copy:

```
workingDir: /var/folders/.../T/dagu/local-dags/checkout
```

Nothing had put files there. It does not fail either, because a missing working directory is created on purpose (`internal/runtime/agent/agent.go`, "Ensure working directory exists"), so the step started in an empty directory. What surfaced it was a coding-agent step reporting `top_n.py was not found in the workspace. The current working directory is empty` while exiting zero, so the run kept going against a file it never touched.

## The rule this settles on

Relative paths resolve against **the file the author wrote**, and that binding survives materialization.

| Form | Resolved | When |
|---|---|---|
| `/srv/checkout` | as written | at runtime, on the executing host |
| `~/checkout` | executing host's home | at runtime |
| `${CHECKOUT}` | the run's environment | at runtime |
| `./checkout` | beside the authored file | once, at build time |

A DAG written after `---` in another file was authored in that file, so it shares the base. Only the last row changes.

## Distributed

A relative `working_dir` now becomes a path bound to the authoring host's layout, which a worker must also have. That is already true of an absolute `working_dir`, which is stored as written and expanded wherever the step runs; this brings the relative form under the same rule instead of pointing it at a temp directory that happens to exist and is empty. `${VAR}` remains the way to name a location that differs per host, and it is what the fix leaves untouched.

Nothing under `internal/intg/distr/` sets `working_dir`, so no distributed test covers the combination today.

## Changes

- `internal/core/spec` — `WithSourceFile` load option, carried into `BuildOpts`; `buildWorkingDir` resolves against it when set
- `internal/subflow/local.go` — pass the child's `SourceFile` when loading in-process
- `internal/service/worker/remote_handler.go` — pass `task.SourceFile`, which the coordinator already sends

`dag.SourceFile` is set per document at load, so a sub-workflow in a shared file already carries the parent's real path.

## What is not in here

An earlier draft also failed a run whose `working_dir` did not exist. That was wrong: creating it is deliberate existing behaviour with a comment saying so, and `working_dir: ./nope` currently creates `./nope` and runs. Changing that is a separate argument from fixing where the path points, and it would affect the relative `working_dir` spelled 346 times in this repository alone, including `specs/030-git-worktree-action.md` and `docs/step-types/git.md`. Dropped from this PR.

## Tests

- `TestBuildWorkingDir_RelativeToAuthoredFile` — unit, resolution base
- `TestSubDAGRelativeWorkingDirResolvesAgainstAuthoredFile` — a sub-workflow in a shared document reads a file beside the authored DAG

Both were confirmed to fail against the previous behaviour. Verified end to end as well: a parent and a local sub-workflow both declaring `working_dir: ./checkout` now report the same directory and read the same file, where before the child landed in the temp copy's neighbourhood.

`make lint` reports 0 issues on both platforms. Full matrix left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relative `working_dir` resolution by binding `./...` to the file the DAG was authored in, not a temp copy, so sub-workflows and distributed tasks run in the expected directory. Absolute paths, `~`, and `$VAR` are unchanged; missing directories are still created.

- **Bug Fixes**
  - Carries the authored path via `spec.WithSourceFile` into `BuildOpts.SourceFile`, and resolves relative paths against it in `buildWorkingDir`.
  - Propagates `SourceFile` when loading local subflows and in the worker’s remote task handler.
  - Adds unit and integration tests to verify sub-DAGs read files beside the authored DAG.

<sup>Written for commit b0127832676d6352641dc4cad93d2f4649a40625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relative `working_dir` paths so they resolve from the original authored workflow location, including when workflows run from temporary copies or as sub-workflows.
  * Improved consistency of path resolution for both local and remote workflow execution.
* **Tests**
  * Added coverage validating authored-file path resolution for sub-workflows and copied workflow files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->