### PR TITLE
validate: separate spec defects from values a run supplies

### DIFF
--- a/api/v1/api.gen.go
+++ b/api/v1/api.gen.go
@@ -440,12 +440,20 @@ const (
 	UserRoleViewer    UserRole = "viewer"
 )
 
+// Defines values for ValueReferenceNoticeClass.
+const (
+	ValueReferenceNoticeClassDefect      ValueReferenceNoticeClass = "defect"
+	ValueReferenceNoticeClassRuntimeOnly ValueReferenceNoticeClass = "runtime_only"
+)
+
 // Defines values for ValueReferenceNoticeReason.
 const (
 	ValueReferenceNoticeReasonMissingDependency    ValueReferenceNoticeReason = "missing_dependency"
 	ValueReferenceNoticeReasonNamespaceUnavailable ValueReferenceNoticeReason = "namespace_unavailable"
 	ValueReferenceNoticeReasonSelfReference        ValueReferenceNoticeReason = "self_reference"
 	ValueReferenceNoticeReasonUnknownContextField  ValueReferenceNoticeReason = "unknown_context_field"
+	ValueReferenceNoticeReasonUnknownConstName     ValueReferenceNoticeReason = "unknown_const_name"
+	ValueReferenceNoticeReasonUnknownEnvBinding    ValueReferenceNoticeReason = "unknown_env_binding"
 	ValueReferenceNoticeReasonUnknownOutputName    ValueReferenceNoticeReason = "unknown_output_name"
 	ValueReferenceNoticeReasonUnknownStepId        ValueReferenceNoticeReason = "unknown_step_id"
 )
@@ -3823,6 +3831,9 @@ type UsersListResponse struct {
 
 // ValueReferenceNotice A passive notice for a supported value reference left unresolved while loading a spec.
 type ValueReferenceNotice struct {
+	// Class Whether the reference names something the spec does not define, or is well-formed and only lacks a value until a run supplies one.
+	Class *ValueReferenceNoticeClass `json:"class,omitempty"`
+
 	// FieldPath DAG field path associated with the unresolved reference.
 	FieldPath *string `json:"fieldPath,omitempty"`
 
@@ -3835,6 +3846,9 @@ type ValueReferenceNotice struct {
 	// Token Original value-reference token that was preserved.
 	Token *string `json:"token,omitempty"`
 }
+
+// ValueReferenceNoticeClass Whether the reference names something the spec does not define, or is well-formed and only lacks a value until a run supplies one.
+type ValueReferenceNoticeClass string
 
 // ValueReferenceNoticeReason Machine-readable reason why the reference was preserved.
 type ValueReferenceNoticeReason string

--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -11324,6 +11324,16 @@ components:
             - self_reference
             - namespace_unavailable
             - unknown_context_field
+            - unknown_env_binding
+            - unknown_const_name
+        class:
+          type: string
+          description: >-
+            Whether the reference names something the spec does not define, or
+            is well-formed and only lacks a value until a run supplies one.
+          enum:
+            - defect
+            - runtime_only
       required:
         - message
 

--- a/conformance/spec004_consts/value_resolution_consts_test.go
+++ b/conformance/spec004_consts/value_resolution_consts_test.go
@@ -79,7 +79,9 @@ func TestValidate(t *testing.T) {
 
 			dagu := harness.NewRunner(t)
 
-			result := dagu.Run("validate", tc.file)
+			// These references are well formed and only lack a value outside a
+			// run, so validation stays quiet about them by default.
+			result := dagu.Run("validate", "--show-unresolved", tc.file)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec005_params/value_resolution_params_test.go
+++ b/conformance/spec005_params/value_resolution_params_test.go
@@ -92,7 +92,9 @@ func TestValidate(t *testing.T) {
 
 			dagu := harness.NewRunner(t)
 
-			result := dagu.Run("validate", tc.file)
+			// A caller can pass these at start time, so validation stays quiet
+			// about them by default.
+			result := dagu.Run("validate", "--show-unresolved", tc.file)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec006_env/value_resolution_env_test.go
+++ b/conformance/spec006_env/value_resolution_env_test.go
@@ -118,7 +118,9 @@ func TestValidate(t *testing.T) {
 			t.Parallel()
 
 			dagu := harness.NewRunner(t)
-			result := dagu.Run("validate", tc.file)
+			// The operator supplies these when the workflow runs, so
+			// validation stays quiet about them by default.
+			result := dagu.Run("validate", "--show-unresolved", tc.file)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
+++ b/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
@@ -29,11 +29,8 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 	}
 
 	noticeCases := []struct {
-		file string
-		// showUnresolved marks cases whose reference is well-formed and only
-		// lacks a value outside a run, so validation stays quiet by default.
-		showUnresolved bool
-		stderrParts    []string
+		file        string
+		stderrParts []string
 	}{
 		{
 			file:        "missing_dependency.yaml",
@@ -52,14 +49,12 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 			stderrParts: []string{"${steps.build.outputs.tag}", "reason=unknown_output_name", "steps[1].run"},
 		},
 		{
-			file:           "namespace_root_env.yaml",
-			showUnresolved: true,
-			stderrParts:    []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "env[0]"},
+			file:        "namespace_root_env.yaml",
+			stderrParts: []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "env[0]"},
 		},
 		{
-			file:           "namespace_handler.yaml",
-			showUnresolved: true,
-			stderrParts:    []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "handler_on.success.run"},
+			file:        "namespace_handler.yaml",
+			stderrParts: []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "handler_on.success.run"},
 		},
 		{
 			file:        "legacy_outputs_not_step_outputs.yaml",
@@ -71,11 +66,7 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 			t.Parallel()
 
 			dagu := harness.NewRunner(t)
-			args := []string{"validate"}
-			if tc.showUnresolved {
-				args = append(args, "--show-unresolved")
-			}
-			result := dagu.Run(append(args, tc.file)...)
+			result := dagu.Run("validate", tc.file)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
+++ b/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
@@ -29,8 +29,11 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 	}
 
 	noticeCases := []struct {
-		file        string
-		stderrParts []string
+		file string
+		// showUnresolved marks cases whose reference is well-formed and only
+		// lacks a value outside a run, so validation stays quiet by default.
+		showUnresolved bool
+		stderrParts    []string
 	}{
 		{
 			file:        "missing_dependency.yaml",
@@ -49,12 +52,14 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 			stderrParts: []string{"${steps.build.outputs.tag}", "reason=unknown_output_name", "steps[1].run"},
 		},
 		{
-			file:        "namespace_root_env.yaml",
-			stderrParts: []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "env[0]"},
+			file:           "namespace_root_env.yaml",
+			showUnresolved: true,
+			stderrParts:    []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "env[0]"},
 		},
 		{
-			file:        "namespace_handler.yaml",
-			stderrParts: []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "handler_on.success.run"},
+			file:           "namespace_handler.yaml",
+			showUnresolved: true,
+			stderrParts:    []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "handler_on.success.run"},
 		},
 		{
 			file:        "legacy_outputs_not_step_outputs.yaml",
@@ -66,7 +71,11 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 			t.Parallel()
 
 			dagu := harness.NewRunner(t)
-			result := dagu.Run("validate", tc.file)
+			args := []string{"validate"}
+			if tc.showUnresolved {
+				args = append(args, "--show-unresolved")
+			}
+			result := dagu.Run(append(args, tc.file)...)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec009_step_reference/step_reference_test.go
+++ b/conformance/spec009_step_reference/step_reference_test.go
@@ -84,7 +84,7 @@ func TestValidateStepReferences(t *testing.T) {
 			t.Parallel()
 
 			dagu := harness.NewRunner(t)
-			result := dagu.Run("validate", tc.file)
+			result := dagu.Run("validate", "--show-unresolved", tc.file)
 			result.ExpectExitCode(0)
 			result.ExpectStdout("")
 			result.ExpectStderrContains(tc.stderrParts...)

--- a/conformance/spec017_built_in_run_context/built_in_run_context_test.go
+++ b/conformance/spec017_built_in_run_context/built_in_run_context_test.go
@@ -16,14 +16,8 @@ func TestValidateBuiltInRunContextNotices(t *testing.T) {
 	result := dagu.Run("validate", "validation_notices.yaml")
 	result.ExpectExitCode(0)
 	result.ExpectStdout("")
+	// References to fields the spec does not define are reported by default.
 	result.ExpectStderrContains(
-		"${context.run.id}",
-		"${context.attempt.id}",
-		"${context.run.status}",
-		"${context.trigger.actor}",
-		"${context.profile.name}",
-		"${context.pushback.iteration}",
-		"reason=namespace_unavailable",
 		"${context.paths.context}",
 		"${context.trigger.payload}",
 		"${context.run.foo}",
@@ -31,8 +25,23 @@ func TestValidateBuiltInRunContextNotices(t *testing.T) {
 		"reason=unknown_context_field",
 		"was left unchanged",
 	)
+	// Supported fields carry a value only during a run, so validation stays
+	// quiet about them unless the operator asks.
 	result.ExpectStderrNotContains(
 		"${unrelated.context}",
+		"reason=namespace_unavailable",
+	)
+
+	verbose := dagu.Run("validate", "--show-unresolved", "validation_notices.yaml")
+	verbose.ExpectExitCode(0)
+	verbose.ExpectStderrContains(
+		"${context.run.id}",
+		"${context.attempt.id}",
+		"${context.run.status}",
+		"${context.trigger.actor}",
+		"${context.profile.name}",
+		"${context.pushback.iteration}",
+		"reason=namespace_unavailable",
 	)
 	dagu.ExpectNoFile("validation-notices.txt")
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -48,6 +48,12 @@ var (
 		usage:  "Enable CPU profiling (saves to cpu.pprof)",
 		isBool: true,
 	}
+
+	showUnresolvedFlag = commandLineFlag{
+		name:   "show-unresolved",
+		usage:  "Also report references whose value only exists during a run",
+		isBool: true,
+	}
 )
 
 // Server and directory flags

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -39,24 +40,32 @@ func Validate() *cobra.Command {
 
 Prints a human-readable result instead of structured logs.
 Checks structural correctness and references (e.g., step dependencies)
-similar to the server-side spec validation.`,
+similar to the server-side spec validation.
+
+References whose value only exists during a run, such as ${context.paths.*}
+or an environment variable supplied by the operator, are not reported by
+default. Pass --show-unresolved to list them as well.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := NewContext(cmd, nil)
 			if err != nil {
 				return fmt.Errorf("initialization error: %w", err)
 			}
-			return runValidate(ctx, args)
+			showUnresolved, err := cmd.Flags().GetBool("show-unresolved")
+			if err != nil {
+				return fmt.Errorf("initialization error: %w", err)
+			}
+			return runValidate(ctx, args, showUnresolved)
 		},
 	}
 
 	// Initialize flags required by NewContext
-	initFlags(cmd)
+	initFlags(cmd, showUnresolvedFlag)
 
 	return cmd
 }
 
-func runValidate(ctx *Context, args []string) error {
+func runValidate(ctx *Context, args []string, showUnresolved bool) error {
 	validatedInput, err := validateWorkflowFile(args[0])
 	if err != nil {
 		return errors.New(formatValidationErrors(args[0], err))
@@ -91,21 +100,35 @@ func runValidate(ctx *Context, args []string) error {
 	}
 
 	logValidationWarnings(ctx, args[0], append(dag.BuildWarnings, collectDeprecatedSyntaxWarnings(dag)...))
-	logValueReferenceNotices(ctx, args[0], loadResult.ValueReferenceNotices)
+	logValueReferenceNotices(ctx, args[0], loadResult.ValueReferenceNotices, showUnresolved)
 
 	return nil
 }
 
-func logValueReferenceNotices(ctx *Context, file string, notices []cmnvalue.ValueReferenceNotice) {
+// logValueReferenceNotices reports value-reference notices, separating the ones
+// that name something the spec does not define from the ones that only lack a
+// value because validation evaluates the spec outside a run.
+func logValueReferenceNotices(ctx *Context, file string, notices []cmnvalue.ValueReferenceNotice, showUnresolved bool) {
 	for _, notice := range notices {
 		if notice.Message == "" {
 			continue
 		}
-		if notice.Reason != "" {
-			logger.Info(ctx, notice.Message, tag.File(file), tag.Reason(string(notice.Reason)))
+		class := notice.Class
+		if class == "" {
+			class = notice.Reason.Class()
+		}
+		if class == cmnvalue.NoticeClassRuntimeOnly && !showUnresolved {
 			continue
 		}
-		logger.Info(ctx, notice.Message, tag.File(file))
+		fields := []slog.Attr{tag.File(file)}
+		if notice.Reason != "" {
+			fields = append(fields, tag.Reason(string(notice.Reason)))
+		}
+		if class == cmnvalue.NoticeClassDefect {
+			logger.Warn(ctx, notice.Message, fields...)
+			continue
+		}
+		logger.Info(ctx, notice.Message, fields...)
 	}
 }
 

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -85,6 +85,67 @@ steps:
 		})
 	})
 
+	t.Run("RuntimeOnlyNoticesAreHiddenByDefault", func(t *testing.T) {
+		th.LoggingOutput.Reset()
+		dagFile := th.CreateDAGFile(t, "runtime_only_notice.yaml", `
+steps:
+  - id: archive
+    run: cp report.csv "${context.paths.artifacts_dir}/"
+`)
+
+		th.RunCommand(t, cmd.Validate(), test.CmdTest{
+			Args: []string{"validate", dagFile},
+		})
+		require.NotContains(t, th.LoggingOutput.String(), "context.paths.artifacts_dir")
+	})
+
+	t.Run("RuntimeOnlyNoticesAreShownOnRequest", func(t *testing.T) {
+		th.LoggingOutput.Reset()
+		dagFile := th.CreateDAGFile(t, "runtime_only_notice_shown.yaml", `
+steps:
+  - id: archive
+    run: cp report.csv "${context.paths.artifacts_dir}/"
+`)
+
+		th.RunCommand(t, cmd.Validate(), test.CmdTest{
+			Args:        []string{"validate", "--show-unresolved", dagFile},
+			ExpectedOut: []string{"${context.paths.artifacts_dir}", "reason=namespace_unavailable"},
+		})
+	})
+
+	t.Run("UnknownContextFieldIsReported", func(t *testing.T) {
+		th.LoggingOutput.Reset()
+		dagFile := th.CreateDAGFile(t, "unknown_context_field.yaml", `
+steps:
+  - id: archive
+    run: cp report.csv "${context.paths.artifact_dir}/"
+`)
+
+		th.RunCommand(t, cmd.Validate(), test.CmdTest{
+			Args:        []string{"validate", dagFile},
+			ExpectedOut: []string{"${context.paths.artifact_dir}", "reason=unknown_context_field"},
+		})
+	})
+
+	t.Run("StepEnvIsInScopeForOtherStepFields", func(t *testing.T) {
+		th.LoggingOutput.Reset()
+		dagFile := th.CreateDAGFile(t, "step_env_scope.yaml", `
+steps:
+  - id: call
+    env:
+      - MY_ENDPOINT: https://example.internal/api
+    action: http.request
+    with:
+      method: GET
+      url: ${env.MY_ENDPOINT}
+`)
+
+		th.RunCommand(t, cmd.Validate(), test.CmdTest{
+			Args: []string{"validate", "--show-unresolved", dagFile},
+		})
+		require.NotContains(t, th.LoggingOutput.String(), "MY_ENDPOINT")
+	})
+
 	t.Run("StepOutputValueReferenceNoticeReason", func(t *testing.T) {
 		th.LoggingOutput.Reset()
 		dagFile := th.CreateDAGFile(t, "step_value_resolution_notice.yaml", `

--- a/internal/cmn/value/notices.go
+++ b/internal/cmn/value/notices.go
@@ -15,6 +15,7 @@ type ValueReferenceNotice struct {
 	FieldPath string
 	Token     string
 	Reason    ValueReferenceNoticeReason
+	Class     ValueReferenceNoticeClass
 }
 
 // ValueReferenceNoticeReason explains why a supported reference was preserved.
@@ -27,7 +28,45 @@ const (
 	ValueReferenceReasonSelfReference        ValueReferenceNoticeReason = "self_reference"
 	ValueReferenceReasonNamespaceUnavailable ValueReferenceNoticeReason = "namespace_unavailable"
 	ValueReferenceReasonUnknownContextField  ValueReferenceNoticeReason = "unknown_context_field"
+	ValueReferenceReasonUnknownEnvBinding    ValueReferenceNoticeReason = "unknown_env_binding"
+	ValueReferenceReasonUnknownConstName     ValueReferenceNoticeReason = "unknown_const_name"
 )
+
+// ValueReferenceNoticeClass separates references that no run can resolve from
+// references whose value simply does not exist yet.
+type ValueReferenceNoticeClass string
+
+const (
+	// NoticeClassDefect marks a reference that names something the spec does
+	// not define, so no run can resolve it.
+	NoticeClassDefect ValueReferenceNoticeClass = "defect"
+	// NoticeClassRuntimeOnly marks a well-formed reference whose value only
+	// exists once a run supplies it.
+	NoticeClassRuntimeOnly ValueReferenceNoticeClass = "runtime_only"
+)
+
+// Class reports whether the reason describes a defect or a runtime-only value.
+//
+// Reasons that name a missing step, output, or context field are defects.
+// Reasons that only report an absent value are runtime-only, because a scope
+// built for inspection carries far less than a scope built for a run.
+func (r ValueReferenceNoticeReason) Class() ValueReferenceNoticeClass {
+	switch r {
+	case ValueReferenceReasonUnknownStepID,
+		ValueReferenceReasonUnknownOutputName,
+		ValueReferenceReasonMissingDependency,
+		ValueReferenceReasonSelfReference,
+		ValueReferenceReasonUnknownContextField,
+		ValueReferenceReasonUnknownConstName:
+		return NoticeClassDefect
+	case ValueReferenceReasonNamespaceUnavailable,
+		ValueReferenceReasonUnknownEnvBinding:
+		return NoticeClassRuntimeOnly
+	}
+	// An unclassified reason says nothing about the spec being wrong, so treat
+	// it the same as a value that only a run can supply.
+	return NoticeClassRuntimeOnly
+}
 
 type noticeReasonError struct {
 	reason ValueReferenceNoticeReason
@@ -122,6 +161,7 @@ func addUnresolvedReferenceNotice(sink ValueReferenceNoticeSink, field, token st
 		FieldPath: field,
 		Token:     token,
 		Reason:    reason,
+		Class:     reason.Class(),
 	})
 }
 
@@ -151,12 +191,15 @@ func ReportStepOutputReferenceNotice(sink ValueReferenceNoticeSink, field, token
 		message = fmt.Sprintf("%s was left unchanged because %s has no step-output lookup scope.", token, evaluatedField)
 	case ValueReferenceReasonUnknownContextField:
 		message = fmt.Sprintf("%s was left unchanged because the context field is not defined when %s was evaluated.", token, evaluatedField)
+	case ValueReferenceReasonUnknownEnvBinding, ValueReferenceReasonUnknownConstName:
+		// Not reachable from a step-output reference; keep the generic message.
 	}
 	sink.Report(ValueReferenceNotice{
 		Message:   message,
 		FieldPath: field,
 		Token:     token,
 		Reason:    reason,
+		Class:     reason.Class(),
 	})
 }
 
@@ -179,7 +222,10 @@ func ReportUnresolvedEnvExpansionNotices(input, field string, scope *EnvScope, s
 		if _, found := scope.Get(key); found {
 			continue
 		}
-		addUnresolvedReferenceNotice(sink, field, match, fmt.Errorf("unknown env.%s binding", key))
+		addUnresolvedReferenceNotice(sink, field, match, newNoticeReasonError(
+			ValueReferenceReasonUnknownEnvBinding,
+			fmt.Sprintf("unknown env.%s binding", key),
+		))
 	}
 }
 

--- a/internal/cmn/value/notices.go
+++ b/internal/cmn/value/notices.go
@@ -194,12 +194,18 @@ func ReportStepOutputReferenceNotice(sink ValueReferenceNoticeSink, field, token
 	case ValueReferenceReasonUnknownEnvBinding, ValueReferenceReasonUnknownConstName:
 		// Not reachable from a step-output reference; keep the generic message.
 	}
+	class := reason.Class()
+	if reason == ValueReferenceReasonNamespaceUnavailable {
+		// A field without step-output lookup scope cannot resolve the reference
+		// during a run.
+		class = NoticeClassDefect
+	}
 	sink.Report(ValueReferenceNotice{
 		Message:   message,
 		FieldPath: field,
 		Token:     token,
 		Reason:    reason,
-		Class:     reason.Class(),
+		Class:     class,
 	})
 }
 

--- a/internal/cmn/value/notices_test.go
+++ b/internal/cmn/value/notices_test.go
@@ -77,3 +77,19 @@ func TestValueReferenceNoticeCarriesClass(t *testing.T) {
 	require.Len(t, notices, 1)
 	assert.Equal(t, value.NoticeClassDefect, notices[0].Class)
 }
+
+func TestStepOutputNamespaceUnavailableIsDefect(t *testing.T) {
+	t.Parallel()
+
+	var collector value.ValueReferenceNoticeCollector
+	value.ReportStepOutputReferenceNotice(
+		&collector,
+		"env[0]",
+		"${steps.build.outputs.tag}",
+		value.ValueReferenceReasonNamespaceUnavailable,
+	)
+
+	notices := collector.Notices()
+	require.Len(t, notices, 1)
+	assert.Equal(t, value.NoticeClassDefect, notices[0].Class)
+}

--- a/internal/cmn/value/notices_test.go
+++ b/internal/cmn/value/notices_test.go
@@ -37,3 +37,43 @@ func TestReportStepOutputReferenceNoticeUsesFallbackFieldLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestValueReferenceNoticeReasonClass(t *testing.T) {
+	t.Parallel()
+
+	defects := []value.ValueReferenceNoticeReason{
+		value.ValueReferenceReasonUnknownStepID,
+		value.ValueReferenceReasonUnknownOutputName,
+		value.ValueReferenceReasonMissingDependency,
+		value.ValueReferenceReasonSelfReference,
+		value.ValueReferenceReasonUnknownContextField,
+		value.ValueReferenceReasonUnknownConstName,
+	}
+	for _, reason := range defects {
+		assert.Equal(t, value.NoticeClassDefect, reason.Class(), string(reason))
+	}
+
+	runtimeOnly := []value.ValueReferenceNoticeReason{
+		value.ValueReferenceReasonNamespaceUnavailable,
+		value.ValueReferenceReasonUnknownEnvBinding,
+	}
+	for _, reason := range runtimeOnly {
+		assert.Equal(t, value.NoticeClassRuntimeOnly, reason.Class(), string(reason))
+	}
+}
+
+func TestValueReferenceNoticeCarriesClass(t *testing.T) {
+	t.Parallel()
+
+	var collector value.ValueReferenceNoticeCollector
+	value.ReportStepOutputReferenceNotice(
+		&collector,
+		"steps[1].run",
+		"${steps.build.outputs.tag}",
+		value.ValueReferenceReasonUnknownOutputName,
+	)
+
+	notices := collector.Notices()
+	require.Len(t, notices, 1)
+	assert.Equal(t, value.NoticeClassDefect, notices[0].Class)
+}

--- a/internal/cmn/value/template.go
+++ b/internal/cmn/value/template.go
@@ -374,7 +374,15 @@ func bindingMapValue(namespace, name string, values Values, requireValue bool) (
 	value, ok := values[name]
 	if !ok {
 		if namespace == "params" {
+			// A caller can pass a param the spec never declared, so an absent
+			// one says nothing about the spec being wrong.
 			return nil, fmt.Errorf("unknown params.%s binding", name)
+		}
+		if namespace == "consts" {
+			return nil, newNoticeReasonError(
+				ValueReferenceReasonUnknownConstName,
+				fmt.Sprintf("unknown consts.%s binding", name),
+			)
 		}
 		return nil, fmt.Errorf("unknown %s binding %q", namespace, name)
 	}
@@ -456,7 +464,10 @@ func bindingEnvValue(name string, scope *EnvScope, requireValue bool) (any, erro
 	if !requireValue {
 		return nil, nil
 	}
-	return nil, fmt.Errorf("unknown env.%s binding", name)
+	return nil, newNoticeReasonError(
+		ValueReferenceReasonUnknownEnvBinding,
+		fmt.Sprintf("unknown env.%s binding", name),
+	)
 }
 
 func supportedStrictBinding(segments []string) bool {

--- a/internal/core/spec/foreach_spec018_test.go
+++ b/internal/core/spec/foreach_spec018_test.go
@@ -70,6 +70,28 @@ steps:
 	require.Empty(t, result.ValueReferenceNotices)
 }
 
+func TestForeachSpec018StepEnvIsInScope(t *testing.T) {
+	t.Parallel()
+
+	result, err := spec.LoadYAMLWithResult(context.Background(), []byte(strings.TrimSpace(`
+steps:
+  - id: loop
+    foreach:
+      items: [one]
+      steps:
+        - id: call
+          env:
+            - MY_ENDPOINT=https://example.internal/api
+          action: http.request
+          with:
+            method: GET
+            url: ${env.MY_ENDPOINT}
+`)))
+
+	require.NoError(t, err)
+	require.Empty(t, result.ValueReferenceNotices)
+}
+
 func TestForeachSpec018Validation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/value_fields.go
+++ b/internal/core/value_fields.go
@@ -20,6 +20,9 @@ type ReferenceField struct {
 	noticePath    string
 	OwnerStepName string
 	OwnerStepID   string
+	// OwnerStepPath is the spec path of the owning step, such as "steps[0]" or
+	// "handler_on.exit". It is empty for DAG-level fields.
+	OwnerStepPath string
 	Field         cmnvalue.Field
 }
 
@@ -88,6 +91,7 @@ func (w *referenceFieldWalker) walkStep(path string, step Step) {
 	base := ReferenceField{
 		OwnerStepName: step.Name,
 		OwnerStepID:   step.ID,
+		OwnerStepPath: path,
 		Field:         cmnvalue.WorkflowField(""),
 	}
 	command := step.CommandResolution(context.Background())

--- a/internal/core/value_notices.go
+++ b/internal/core/value_notices.go
@@ -57,7 +57,7 @@ func ReportValueReferenceNotices(dag *DAG, sink cmnvalue.ValueReferenceNoticeSin
 			sink,
 		)
 	}
-	reportStepEnvValueReferenceNotices(dag, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
+	stepEnvScopes := reportStepEnvValueReferenceNotices(dag, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
 
 	for _, field := range ReferenceFields(dag) {
 		if isEnvReferenceFieldPath(field.Path) {
@@ -72,6 +72,11 @@ func ReportValueReferenceNotices(dag *DAG, sink cmnvalue.ValueReferenceNoticeSin
 		}
 		fieldRuntimeScope := runtimeScope
 		fieldRuntimeScope.BuiltinContext = noticeBuiltinContext(dag.Name, field.OwnerStepName, field.OwnerStepID)
+		// A step's own env is in scope for its other fields, so resolve against
+		// the step scope rather than the DAG-level one.
+		if scope, ok := stepEnvScopes[field.OwnerStepPath]; ok && scope != nil {
+			fieldRuntimeScope.Env = scope
+		}
 		resolver := cmnvalue.NewResolver(
 			staticScope,
 			fieldRuntimeScope,
@@ -100,10 +105,12 @@ func reportStepEnvValueReferenceNotices(
 	rootEnvScope *cmnvalue.EnvScope,
 	stepOutputNotices *stepOutputNoticeContext,
 	sink cmnvalue.ValueReferenceNoticeSink,
-) {
+) map[string]*cmnvalue.EnvScope {
+	scopes := make(map[string]*cmnvalue.EnvScope)
 	for i := range dag.Steps {
-		reportSingleStepEnvValueReferenceNotices(
-			fmt.Sprintf("steps[%d]", i),
+		path := fmt.Sprintf("steps[%d]", i)
+		scopes[path] = reportSingleStepEnvValueReferenceNotices(
+			path,
 			dag.Steps[i],
 			dag.Name,
 			staticScope,
@@ -113,28 +120,33 @@ func reportStepEnvValueReferenceNotices(
 			sink,
 		)
 	}
-	reportHandlerStepEnvValueReferenceNotices("handler_on.init", dag.HandlerOn.Init, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-	reportHandlerStepEnvValueReferenceNotices("handler_on.success", dag.HandlerOn.Success, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-	reportHandlerStepEnvValueReferenceNotices("handler_on.failure", dag.HandlerOn.Failure, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-	reportHandlerStepEnvValueReferenceNotices("handler_on.abort", dag.HandlerOn.Abort, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-	reportHandlerStepEnvValueReferenceNotices("handler_on.exit", dag.HandlerOn.Exit, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-	reportHandlerStepEnvValueReferenceNotices("handler_on.wait", dag.HandlerOn.Wait, dag.Name, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
-}
-
-func reportHandlerStepEnvValueReferenceNotices(
-	path string,
-	step *Step,
-	dagName string,
-	staticScope cmnvalue.StaticScope,
-	runtimeScope cmnvalue.RuntimeScope,
-	rootEnvScope *cmnvalue.EnvScope,
-	stepOutputNotices *stepOutputNoticeContext,
-	sink cmnvalue.ValueReferenceNoticeSink,
-) {
-	if step == nil {
-		return
+	handlers := []struct {
+		path string
+		step *Step
+	}{
+		{"handler_on.init", dag.HandlerOn.Init},
+		{"handler_on.success", dag.HandlerOn.Success},
+		{"handler_on.failure", dag.HandlerOn.Failure},
+		{"handler_on.abort", dag.HandlerOn.Abort},
+		{"handler_on.exit", dag.HandlerOn.Exit},
+		{"handler_on.wait", dag.HandlerOn.Wait},
 	}
-	reportSingleStepEnvValueReferenceNotices(path, *step, dagName, staticScope, runtimeScope, rootEnvScope, stepOutputNotices, sink)
+	for _, handler := range handlers {
+		if handler.step == nil {
+			continue
+		}
+		scopes[handler.path] = reportSingleStepEnvValueReferenceNotices(
+			handler.path,
+			*handler.step,
+			dag.Name,
+			staticScope,
+			runtimeScope,
+			rootEnvScope,
+			stepOutputNotices,
+			sink,
+		)
+	}
+	return scopes
 }
 
 func reportSingleStepEnvValueReferenceNotices(
@@ -146,7 +158,7 @@ func reportSingleStepEnvValueReferenceNotices(
 	rootEnvScope *cmnvalue.EnvScope,
 	stepOutputNotices *stepOutputNoticeContext,
 	sink cmnvalue.ValueReferenceNoticeSink,
-) {
+) *cmnvalue.EnvScope {
 	stepEnvScope := reportEnvValueReferenceNotices(
 		step.Env,
 		path+".env",
@@ -178,6 +190,7 @@ func reportSingleStepEnvValueReferenceNotices(
 			sink,
 		)
 	}
+	return stepEnvScope
 }
 
 func reportEnvValueReferenceNotices(

--- a/internal/core/value_notices.go
+++ b/internal/core/value_notices.go
@@ -107,11 +107,11 @@ func reportStepEnvValueReferenceNotices(
 	sink cmnvalue.ValueReferenceNoticeSink,
 ) map[string]*cmnvalue.EnvScope {
 	scopes := make(map[string]*cmnvalue.EnvScope)
-	for i := range dag.Steps {
-		path := fmt.Sprintf("steps[%d]", i)
+	var reportStep func(string, Step)
+	reportStep = func(path string, step Step) {
 		scopes[path] = reportSingleStepEnvValueReferenceNotices(
 			path,
-			dag.Steps[i],
+			step,
 			dag.Name,
 			staticScope,
 			runtimeScope,
@@ -119,6 +119,15 @@ func reportStepEnvValueReferenceNotices(
 			stepOutputNotices,
 			sink,
 		)
+		if step.Foreach == nil {
+			return
+		}
+		for i := range step.Foreach.Steps {
+			reportStep(fmt.Sprintf("%s.foreach.steps[%d]", path, i), step.Foreach.Steps[i])
+		}
+	}
+	for i := range dag.Steps {
+		reportStep(fmt.Sprintf("steps[%d]", i), dag.Steps[i])
 	}
 	handlers := []struct {
 		path string
@@ -135,16 +144,7 @@ func reportStepEnvValueReferenceNotices(
 		if handler.step == nil {
 			continue
 		}
-		scopes[handler.path] = reportSingleStepEnvValueReferenceNotices(
-			handler.path,
-			*handler.step,
-			dag.Name,
-			staticScope,
-			runtimeScope,
-			rootEnvScope,
-			stepOutputNotices,
-			sink,
-		)
+		reportStep(handler.path, *handler.step)
 	}
 	return scopes
 }

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -299,11 +299,11 @@ func toAPIValueReferenceNotices(notices []cmnvalue.ValueReferenceNotice) []api.V
 		apiNotice := api.ValueReferenceNotice{
 			Message: notice.Message,
 		}
+		class := api.ValueReferenceNoticeClass(notice.Class)
+		apiNotice.Class = &class
 		if notice.Reason != "" {
 			reason := api.ValueReferenceNoticeReason(notice.Reason)
 			apiNotice.Reason = &reason
-			class := api.ValueReferenceNoticeClass(notice.Reason.Class())
-			apiNotice.Class = &class
 		}
 		if notice.FieldPath != "" {
 			apiNotice.FieldPath = ptrOf(notice.FieldPath)

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -302,6 +302,8 @@ func toAPIValueReferenceNotices(notices []cmnvalue.ValueReferenceNotice) []api.V
 		if notice.Reason != "" {
 			reason := api.ValueReferenceNoticeReason(notice.Reason)
 			apiNotice.Reason = &reason
+			class := api.ValueReferenceNoticeClass(notice.Reason.Class())
+			apiNotice.Class = &class
 		}
 		if notice.FieldPath != "" {
 			apiNotice.FieldPath = ptrOf(notice.FieldPath)

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -1869,3 +1869,39 @@ steps:
 	require.NotNil(t, notice.Reason)
 	require.Equal(t, api.ValueReferenceNoticeReasonMissingDependency, *notice.Reason)
 }
+
+func TestGetDAGSpecIncludesValueReferenceNoticeClassWithoutReason(t *testing.T) {
+	t.Parallel()
+
+	helper := test.Setup(t, test.WithStatusPersistence())
+	dag := helper.DAG(t, `
+name: spec-runtime-value-resolution-notice
+steps:
+  - run: echo ${params.missing}
+`)
+
+	apiImpl := localapi.New(
+		helper.DAGStore,
+		helper.DAGRunStore,
+		helper.QueueStore,
+		helper.ProcStore,
+		helper.DAGRunMgr,
+		helper.Config,
+		nil,
+		helper.ServiceRegistry,
+		nil,
+		nil,
+	)
+
+	specRespObj, err := apiImpl.GetDAGSpec(context.Background(), api.GetDAGSpecRequestObject{
+		FileName: dag.FileName(),
+	})
+	require.NoError(t, err)
+
+	specResp := asGetDAGSpecResp(t, specRespObj)
+	require.Len(t, specResp.ValueReferenceNotices, 1)
+
+	notice := specResp.ValueReferenceNotices[0]
+	require.NotNil(t, notice.Class)
+	require.Equal(t, api.ValueReferenceNoticeClassRuntimeOnly, *notice.Class)
+}

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -361,8 +361,9 @@ Escaped supported-looking text and unsupported braced text must not produce pass
 The notice must identify the owning field and the original reference text.
 
 Each notice must carry a class.
-A notice is a defect when the reference names a step, output, context field, or
-const the spec does not define, because no run can resolve it.
+A notice is a defect when no run can resolve the reference. This includes a
+reference that names a step, output, context field, or const the spec does not
+define, and a reference in a field that never has the required lookup scope.
 A notice is runtime-only when the reference is well-formed and the inspecting
 scope simply holds no value for it.
 

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -360,6 +360,15 @@ Escaped supported-looking text and unsupported braced text must not produce pass
 
 The notice must identify the owning field and the original reference text.
 The notice must not be shown as a normal validation warning.
+
+Each notice must carry a class.
+A notice is a defect when the reference names a step, output, context field, or
+const the spec does not define, because no run can resolve it.
+A notice is runtime-only when the reference is well formed and the inspecting
+scope simply holds no value for it.
+`dagu validate` must report defects by default and must keep runtime-only
+notices out of its default output; `--show-unresolved` reports both.
+Inspection surfaces that render notices must let a reader tell the two apart.
 Current inspection surfaces are `dagu validate`, the DAG spec inspection API response, and the Web UI spec editor.
 Normal run execution must stay silent.
 Dagu must not write these notices to run logs, workflow events, status files, history files, artifacts, or DAG-run detail responses.

--- a/specs/003-value-resolution.md
+++ b/specs/003-value-resolution.md
@@ -359,15 +359,20 @@ This rule applies only to unescaped supported reference forms.
 Escaped supported-looking text and unsupported braced text must not produce passive notices.
 
 The notice must identify the owning field and the original reference text.
-The notice must not be shown as a normal validation warning.
 
 Each notice must carry a class.
 A notice is a defect when the reference names a step, output, context field, or
 const the spec does not define, because no run can resolve it.
-A notice is runtime-only when the reference is well formed and the inspecting
+A notice is runtime-only when the reference is well-formed and the inspecting
 scope simply holds no value for it.
-`dagu validate` must report defects by default and must keep runtime-only
-notices out of its default output; `--show-unresolved` reports both.
+
+A runtime-only notice must not be shown as a normal validation warning, because
+supplying the value is the operator's job rather than a change to the spec.
+`dagu validate` must keep runtime-only notices out of its default output and
+must report them under `--show-unresolved`.
+A defect names something no run can resolve, so `dagu validate` must report it
+by default and may present it at warning level.
+Neither class changes the exit code: a notice is still not a validation error.
 Inspection surfaces that render notices must let a reader tell the two apart.
 Current inspection surfaces are `dagu validate`, the DAG spec inspection API response, and the Web UI spec editor.
 Normal run execution must stay silent.

--- a/specs/006-value-resolution-env.md
+++ b/specs/006-value-resolution-env.md
@@ -535,6 +535,11 @@ Secret-sensitive values:
   references, such as `${env.NAME}` and `${steps.step_id.outputs.name}`, in
   inspected value-resolved fields.
 
+- An unresolved `${env.NAME}` is a runtime-only notice, because the operator
+  supplies the value when the workflow runs. `dagu validate` records it and
+  exposes it through the inspection API, and prints it only under
+  `--show-unresolved`.
+
 - `dagu validate` must report passive notices for unresolved unqualified
   `$NAME` and `${NAME}` references in `env` declarations.
 

--- a/specs/007-value-resolution-steps.md
+++ b/specs/007-value-resolution-steps.md
@@ -134,6 +134,8 @@ Rules:
 - A step output reference to the owning step must use reason `self_reference`.
 
 - A step output reference in a field with no step-output lookup scope must use reason `namespace_unavailable`.
+- A `namespace_unavailable` step-output notice is a defect because the owning
+  field cannot resolve a step output during a run.
 
 - An unavailable step output value must preserve the original reference text before the owning field is used.
 

--- a/specs/017-built-in-run-context.md
+++ b/specs/017-built-in-run-context.md
@@ -394,6 +394,13 @@ Validation rules:
   unavailable during validation.
 - Explicit inspection surfaces must report passive notices for unresolved
   supported structured context references.
+- A supported structured context reference carries a value only during a run, so
+  its notice is runtime-only. `dagu validate` must keep it out of the default
+  output and print it under `--show-unresolved`.
+- A reference to an unsupported field under `context.` remains a defect and is
+  reported by default, which is what separates a typo such as
+  `${context.paths.artifact_dir}` from the supported
+  `${context.paths.artifacts_dir}`.
 - Explicit inspection surfaces must report passive notices with reason
   `unknown_context_field` for unknown fields under reserved context namespaces.
 - Normal run execution must not emit passive value-reference notices as run

--- a/ui/src/api/v1/schema.ts
+++ b/ui/src/api/v1/schema.ts
@@ -4431,6 +4431,11 @@ export interface components {
              * @enum {string}
              */
             reason?: ValueReferenceNoticeReason;
+            /**
+             * @description Whether the reference names something the spec does not define, or is well-formed and only lacks a value until a run supplies one.
+             * @enum {string}
+             */
+            class?: ValueReferenceNoticeClass;
         };
         /** @description Editor-only metadata used to synthesize per-document schema hints */
         DAGEditorHints: {
@@ -16862,7 +16867,13 @@ export enum ValueReferenceNoticeReason {
     missing_dependency = "missing_dependency",
     self_reference = "self_reference",
     namespace_unavailable = "namespace_unavailable",
-    unknown_context_field = "unknown_context_field"
+    unknown_context_field = "unknown_context_field",
+    unknown_env_binding = "unknown_env_binding",
+    unknown_const_name = "unknown_const_name"
+}
+export enum ValueReferenceNoticeClass {
+    defect = "defect",
+    runtime_only = "runtime_only"
 }
 export enum ParamDefType {
     string = "string",

--- a/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
+++ b/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
@@ -22,7 +22,7 @@ const REASON_LABELS: Record<string, string> = {
   self_reference: 'Step references its own output',
   unknown_context_field: 'Context field is not defined',
   unknown_const_name: 'Const is not declared',
-  namespace_unavailable: 'Value is supplied by a run',
+  namespace_unavailable: 'Value is unavailable in this context',
   unknown_env_binding: 'Environment variable is supplied by a run',
 };
 
@@ -39,10 +39,16 @@ export const DEFECT_REASONS = new Set([
 
 export { REASON_LABELS };
 
-// Older servers answer without a class, so fall back to the reason.
-function isDefect(notice: ValueReferenceNotice): boolean {
+// Older servers answer without a class, so fall back to the reason and token.
+export function isDefect(notice: ValueReferenceNotice): boolean {
   if (notice.class) {
     return notice.class === 'defect';
+  }
+  if (
+    notice.reason === 'namespace_unavailable' &&
+    notice.token?.startsWith('${steps.')
+  ) {
+    return true;
   }
   return notice.reason ? DEFECT_REASONS.has(notice.reason) : false;
 }
@@ -202,7 +208,9 @@ function NoticeCard({ notice }: { notice: ValueReferenceNotice }) {
         {notice.reason && (
           <>
             <dt>Reason</dt>
-            <dd className="min-w-0 break-words">{reasonLabel(notice.reason)}</dd>
+            <dd className="min-w-0 break-words">
+              {reasonLabel(notice.reason)}
+            </dd>
           </>
         )}
       </dl>

--- a/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
+++ b/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
@@ -15,6 +15,36 @@ import { components } from '../../../../api/v1/schema';
 
 type ValueReferenceNotice = components['schemas']['ValueReferenceNotice'];
 
+const REASON_LABELS: Record<string, string> = {
+  unknown_step_id: 'Step id does not exist',
+  unknown_output_name: 'Output name is not declared',
+  missing_dependency: 'Producing step is not a dependency',
+  self_reference: 'Step references its own output',
+  unknown_context_field: 'Context field is not defined',
+  namespace_unavailable: 'Value is supplied by a run',
+  unknown_env_binding: 'Environment variable is supplied by a run',
+};
+
+const DEFECT_REASONS = new Set([
+  'unknown_step_id',
+  'unknown_output_name',
+  'missing_dependency',
+  'self_reference',
+  'unknown_context_field',
+]);
+
+// Older servers answer without a class, so fall back to the reason.
+function isDefect(notice: ValueReferenceNotice): boolean {
+  if (notice.class) {
+    return notice.class === 'defect';
+  }
+  return notice.reason ? DEFECT_REASONS.has(notice.reason) : false;
+}
+
+function reasonLabel(reason: string): string {
+  return REASON_LABELS[reason] ?? reason;
+}
+
 type ValueReferenceNoticesButtonProps = {
   notices: ValueReferenceNotice[];
   description: string;
@@ -33,6 +63,12 @@ export function ValueReferenceNoticesButton({
   className,
 }: ValueReferenceNoticesButtonProps) {
   const [open, setOpen] = React.useState(false);
+
+  const defects = React.useMemo(() => notices.filter(isDefect), [notices]);
+  const runtimeOnly = React.useMemo(
+    () => notices.filter((notice) => !isDefect(notice)),
+    [notices]
+  );
 
   React.useEffect(() => {
     if (notices.length === 0) {
@@ -56,13 +92,14 @@ export function ValueReferenceNoticesButton({
         <Info className="h-3.5 w-3.5" />
         {label}
         <span className="ml-0.5 rounded-sm bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
-          {notices.length}
+          {defects.length > 0 ? defects.length : notices.length}
         </span>
       </Button>
       <ValueReferenceNoticesDialog
         open={open}
         onOpenChange={setOpen}
-        notices={notices}
+        defects={defects}
+        runtimeOnly={runtimeOnly}
         description={description}
       />
     </>
@@ -72,14 +109,20 @@ export function ValueReferenceNoticesButton({
 function ValueReferenceNoticesDialog({
   open,
   onOpenChange,
-  notices,
+  defects,
+  runtimeOnly,
   description,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  notices: ValueReferenceNotice[];
+  defects: ValueReferenceNotice[];
+  runtimeOnly: ValueReferenceNotice[];
   description: string;
 }) {
+  const [showRuntimeOnly, setShowRuntimeOnly] = React.useState(
+    defects.length === 0
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl">
@@ -92,45 +135,71 @@ function ValueReferenceNoticesDialog({
             {description}
           </DialogDescription>
         </DialogHeader>
-        <div className="max-h-[60vh] space-y-3 overflow-y-auto">
-          {notices.map((notice, index) => (
-            <div
-              key={`${notice.fieldPath ?? ''}:${notice.token ?? ''}:${index}`}
-              className="rounded-md border border-border bg-muted/30 p-3 text-sm"
-            >
-              <p className="whitespace-normal break-words text-foreground">
-                {notice.message}
-              </p>
-              <dl className="mt-2 grid gap-1 text-xs text-muted-foreground sm:grid-cols-[5rem_1fr]">
-                {notice.fieldPath && (
-                  <>
-                    <dt>Field</dt>
-                    <dd className="min-w-0 break-all font-mono">
-                      {notice.fieldPath}
-                    </dd>
-                  </>
-                )}
-                {notice.token && (
-                  <>
-                    <dt>Reference</dt>
-                    <dd className="min-w-0 break-all font-mono">
-                      {notice.token}
-                    </dd>
-                  </>
-                )}
-                {notice.reason && (
-                  <>
-                    <dt>Reason</dt>
-                    <dd className="min-w-0 break-all font-mono">
-                      {notice.reason}
-                    </dd>
-                  </>
-                )}
-              </dl>
-            </div>
-          ))}
+        <div className="max-h-[60vh] space-y-4 overflow-y-auto">
+          {defects.length > 0 && (
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-foreground">
+                Needs a fix
+              </h3>
+              {defects.map((notice, index) => (
+                <NoticeCard
+                  key={`defect:${notice.fieldPath ?? ''}:${notice.token ?? ''}:${index}`}
+                  notice={notice}
+                />
+              ))}
+            </section>
+          )}
+          {runtimeOnly.length > 0 && (
+            <section className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setShowRuntimeOnly((shown) => !shown)}
+                className="flex w-full items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+              >
+                <span>Resolved during a run ({runtimeOnly.length})</span>
+                <span aria-hidden="true">{showRuntimeOnly ? '−' : '+'}</span>
+              </button>
+              {showRuntimeOnly &&
+                runtimeOnly.map((notice, index) => (
+                  <NoticeCard
+                    key={`runtime:${notice.fieldPath ?? ''}:${notice.token ?? ''}:${index}`}
+                    notice={notice}
+                  />
+                ))}
+            </section>
+          )}
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function NoticeCard({ notice }: { notice: ValueReferenceNotice }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+      <p className="whitespace-normal break-words text-foreground">
+        {notice.message}
+      </p>
+      <dl className="mt-2 grid gap-1 text-xs text-muted-foreground sm:grid-cols-[5rem_1fr]">
+        {notice.fieldPath && (
+          <>
+            <dt>Field</dt>
+            <dd className="min-w-0 break-all font-mono">{notice.fieldPath}</dd>
+          </>
+        )}
+        {notice.token && (
+          <>
+            <dt>Reference</dt>
+            <dd className="min-w-0 break-all font-mono">{notice.token}</dd>
+          </>
+        )}
+        {notice.reason && (
+          <>
+            <dt>Reason</dt>
+            <dd className="min-w-0 break-words">{reasonLabel(notice.reason)}</dd>
+          </>
+        )}
+      </dl>
+    </div>
   );
 }

--- a/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
+++ b/ui/src/features/dags/components/value-reference-notices/ValueReferenceNoticesButton.tsx
@@ -21,17 +21,23 @@ const REASON_LABELS: Record<string, string> = {
   missing_dependency: 'Producing step is not a dependency',
   self_reference: 'Step references its own output',
   unknown_context_field: 'Context field is not defined',
+  unknown_const_name: 'Const is not declared',
   namespace_unavailable: 'Value is supplied by a run',
   unknown_env_binding: 'Environment variable is supplied by a run',
 };
 
-const DEFECT_REASONS = new Set([
+// Mirrors ValueReferenceNoticeReason.Class() on the server. Only consulted when
+// a response predates the class field.
+export const DEFECT_REASONS = new Set([
   'unknown_step_id',
   'unknown_output_name',
   'missing_dependency',
   'self_reference',
   'unknown_context_field',
+  'unknown_const_name',
 ]);
+
+export { REASON_LABELS };
 
 // Older servers answer without a class, so fall back to the reason.
 function isDefect(notice: ValueReferenceNotice): boolean {

--- a/ui/src/features/dags/components/value-reference-notices/__tests__/ValueReferenceNoticesButton.test.ts
+++ b/ui/src/features/dags/components/value-reference-notices/__tests__/ValueReferenceNoticesButton.test.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import { ValueReferenceNoticeReason } from '../../../../../api/v1/schema';
+import { DEFECT_REASONS, REASON_LABELS } from '../ValueReferenceNoticesButton';
+
+// A reason added to the API without a label here would render as a raw enum
+// string, and one missing from DEFECT_REASONS would be misclassified whenever a
+// response arrives without the class field.
+describe('value reference notice reasons', () => {
+  const reasons = Object.values(ValueReferenceNoticeReason);
+
+  it('covers every reason with a readable label', () => {
+    const unlabelled = reasons.filter((reason) => !REASON_LABELS[reason]);
+    expect(unlabelled).toEqual([]);
+  });
+
+  it('classifies every reason as a defect or as runtime-only', () => {
+    // Membership is the classification, so this only asserts the set stays a
+    // subset of the reasons the API actually defines.
+    const unknown = [...DEFECT_REASONS].filter(
+      (reason) => !reasons.includes(reason as ValueReferenceNoticeReason)
+    );
+    expect(unknown).toEqual([]);
+  });
+});

--- a/ui/src/features/dags/components/value-reference-notices/__tests__/ValueReferenceNoticesButton.test.ts
+++ b/ui/src/features/dags/components/value-reference-notices/__tests__/ValueReferenceNoticesButton.test.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from 'vitest';
-import { ValueReferenceNoticeReason } from '../../../../../api/v1/schema';
-import { DEFECT_REASONS, REASON_LABELS } from '../ValueReferenceNoticesButton';
+import {
+  ValueReferenceNoticeClass,
+  ValueReferenceNoticeReason,
+} from '../../../../../api/v1/schema';
+import {
+  DEFECT_REASONS,
+  isDefect,
+  REASON_LABELS,
+} from '../ValueReferenceNoticesButton';
 
-// A reason added to the API without a label here would render as a raw enum
-// string, and one missing from DEFECT_REASONS would be misclassified whenever a
-// response arrives without the class field.
+// Every reason needs a readable label. DEFECT_REASONS covers reasons that are
+// always defects when a response arrives without the class field.
 describe('value reference notice reasons', () => {
   const reasons = Object.values(ValueReferenceNoticeReason);
 
@@ -23,5 +29,33 @@ describe('value reference notice reasons', () => {
       (reason) => !reasons.includes(reason as ValueReferenceNoticeReason)
     );
     expect(unknown).toEqual([]);
+  });
+
+  it('classifies old-server step-output namespace notices as defects', () => {
+    expect(
+      isDefect({
+        message: 'Step outputs are unavailable',
+        reason: ValueReferenceNoticeReason.namespace_unavailable,
+        token: '${steps.build.outputs.image}',
+      })
+    ).toBe(true);
+    expect(
+      isDefect({
+        message: 'Run context is unavailable',
+        reason: ValueReferenceNoticeReason.namespace_unavailable,
+        token: '${context.run.id}',
+      })
+    ).toBe(false);
+  });
+
+  it('prefers the server class over fallback classification', () => {
+    expect(
+      isDefect({
+        message: 'Runtime-only value',
+        class: ValueReferenceNoticeClass.runtime_only,
+        reason: ValueReferenceNoticeReason.namespace_unavailable,
+        token: '${steps.build.outputs.image}',
+      })
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`dagu validate` reports every preserved value reference at the same level, so these three are indistinguishable in its output:

| Reference | Resolves at run time? |
|---|---|
| `${steps.build.outputs.undeclared}` | never, the output is not declared |
| `${context.paths.artifacts_dir}` | always |
| `${env.API_TOKEN}` | yes, the operator supplies it |

Only the first is a defect. The other two are reported because validation evaluates a spec outside a run, where a synthetic scope holds almost nothing: `noticeBuiltinContext` models 3 of the 22 supported `context.*` bindings, and the env scope is deliberately built with `includeOS=false` so validation does not depend on the shell it runs in.

The noise is not harmless. A correct workflow was deleted on the strength of a `reason=namespace_unavailable` line that was a false alarm. Dagu's own bundled examples trip it too, since `dagu example 12` uses `${context.paths.artifacts_dir}`.

The true positives are worth keeping. The undeclared-output check is what caught a wrong cursor example in the docs (dagucloud/docs#24).

## Approach

Classify instead of suppress.

Resolution semantics are unchanged. They already carried the needed distinction: `namespace_unavailable` means "well formed, absent from this scope", while a name the spec does not define already produced `unknown_context_field`. So no resolver behaviour moves, and the tests that pin it (`builtin_context_test.go`, `value_notices_test.go`) needed no edits.

- **defect** — `unknown_step_id`, `unknown_output_name`, `missing_dependency`, `self_reference`, `unknown_context_field`, `unknown_const_name`. Reported by default, now at warning level.
- **runtime_only** — `namespace_unavailable`, `unknown_env_binding`. Kept out of the default output; `--show-unresolved` prints them.

`noticeBuiltinContext` is deliberately **not** extended to cover all 22 keys. That would silence the symptom while duplicating the runtime list in `internal/runtime/eval.go`, so every new context key would reintroduce the bug.

## Two reasons that had no code

`bindingEnvValue` and the `consts` branch of `bindingMapValue` returned bare `fmt.Errorf`, so their notices arrived with an empty reason and could not be classified. They now report `unknown_env_binding` and `unknown_const_name`.

The split matters: a const is declared in the spec, so an unknown one can never resolve and is a defect. A param is not, and neither is an environment variable. Verified rather than assumed:

```
$ dagu start undeclared-param.yaml -- UNDECLARED=supplied
value=[supplied]
```

so `params` stays runtime-only.

## Unrelated false positive fixed alongside

A step's `with:` was resolved against the DAG-level env scope, so referencing the step's own `env:` was reported as unresolved. `reportSingleStepEnvValueReferenceNotices` already built the step scope and threw it away; it is now returned and threaded into the field walk via a new `ReferenceField.OwnerStepPath`.

## Verification

```
$ dagu validate defects.yaml
level=WARN ${steps.producer.outputs.undeclared} ... the referenced output name is not declared
level=WARN ${context.paths.typo_dir} ... unknown context field
# ${context.paths.artifacts_dir} and ${env.OPERATOR_SUPPLIED}: silent

$ dagu validate --show-unresolved defects.yaml
# ... plus both runtime-only references at INFO

$ dagu validate dbt-nightly.yaml      # the workflow that was deleted
$ dagu example 12 > ex.yaml && dagu validate ex.yaml
# both clean
```

Green: `make lint` (0 issues, both GOOS), and `internal/cmn/value`, `internal/core`, `internal/core/spec`, `internal/cmd`, `internal/service/frontend/api/v1`, plus the `spec007` and `spec017` conformance packages.

Note the defect subtests in `spec007` passed untouched; only the two `namespace_unavailable` cases needed `--show-unresolved`, which is a good sign the split lands where intended.

## Notes for review

- `api/v1/api.gen.go` is hand-edited (13 lines) rather than regenerated. `go.mod` pins oapi-codegen v2.7.1 but the checked-in file was produced by v2.5.1, so a real regeneration produces a 12,298-line diff unrelated to this change. That drift is pre-existing and worth a separate PR.
- `make api` cannot run on main at all: `api-validate` fails with `schema "DAG": extra sibling fields: [description]`. Confirmed present before this change.
- `class` is an optional API field and the UI falls back to deriving it from `reason`, so an older server keeps working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `dagu validate` separate real spec defects from values that only exist during a run. Adds context-aware classification, warns on defects by default, and hides runtime-only references unless you pass `--show-unresolved`.

- **New Features**
  - Classified notices: `defect` vs `runtime_only`, with context-aware handling (step-output refs in fields without lookup scope are defects; runtime context misses stay runtime-only).
  - New flag `--show-unresolved` to print runtime-only notices; defects log at warn, runtime-only at info.
  - API: added optional `ValueReferenceNotice.class` and reasons `unknown_env_binding` and `unknown_const_name`; responses include the computed class. UI groups notices into “Needs a fix” vs “Resolved during a run,” adds a label for `unknown_const_name`, and classifies old responses correctly (treats `${steps.*}` `namespace_unavailable` as defects), with tests.

- **Bug Fixes**
  - Step fields resolve against the step’s own `env:` (including `foreach` bodies and handlers), removing false positives.
  - Conformance and CLI tests updated to assert hidden-by-default behavior and `--show-unresolved` output.

<sup>Written for commit a98306780a14657d875d6f0fe65ff3df85d95044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--show-unresolved` to optionally display references resolved only during workflow execution.
  * Validation now distinguishes actionable defects from runtime-only unresolved references.
  * Inspection views categorize notices into “Needs a fix” and “Resolved during a run,” with clearer reason labels.
  * Added support for identifying unresolved environment bindings and constant names.
* **Bug Fixes**
  * Improved environment scoping so step-level variables resolve correctly within the same step.
  * Unsupported context references are reported by default, while supported runtime context remains hidden unless requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->