### PR TITLE
fix: prepare tools for local sub-DAG runs

### DIFF
--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -45,7 +45,7 @@ type Local struct {
 	workerID                 string
 	dagRunLogDir             string
 	dagRunArtifactDir        string
-	toolInstaller            dagutools.Installer
+	installer                dagutools.Installer
 
 	mu     sync.Mutex
 	active map[string]*rtagent.Agent
@@ -59,7 +59,7 @@ type LocalOption func(*Local)
 // WithLocalToolInstaller sets the installer used to make child DAG tools available.
 func WithLocalToolInstaller(installer dagutools.Installer) LocalOption {
 	return func(r *Local) {
-		r.toolInstaller = installer
+		r.installer = installer
 	}
 }
 
@@ -158,10 +158,10 @@ func WithLocalDAGRunDirs(logDir, artifactDir string) LocalOption {
 // NewLocal creates an in-process child workflow runner.
 func NewLocal(dagRunMgr runtime.Manager, dagStore exec.DAGStore, opts ...LocalOption) *Local {
 	r := &Local{
-		dagRunMgr:     dagRunMgr,
-		dagStore:      dagStore,
-		toolInstaller: daguaqua.New(),
-		active:        make(map[string]*rtagent.Agent),
+		dagRunMgr: dagRunMgr,
+		dagStore:  dagStore,
+		installer: daguaqua.New(),
+		active:    make(map[string]*rtagent.Agent),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -409,11 +409,11 @@ func (r *Local) prepareDAGTools(ctx context.Context, rCtx exec.Context, dag *cor
 	if dag != nil {
 		workDir = dag.WorkingDir
 	}
-	return dagutools.PrepareDAG(ctx, dag, r.toolInstaller, dagutools.InstallOptions{
+	return dagutools.PrepareDAG(ctx, dag, r.installer, dagutools.InstallOptions{
 		ToolsDir: cfg.Paths.ToolsDir,
 		DataDir:  cfg.Paths.DataDir,
 		WorkDir:  workDir,
-	}, dagToolsBasePathForLocalRunner(rCtx))
+	}, toolsBasePath(rCtx))
 }
 
 func (r *Local) runAgent(ctx context.Context, runID string, child *rtagent.Agent) (*exec.RunStatus, error) {

--- a/internal/subflow/local.go
+++ b/internal/subflow/local.go
@@ -22,6 +22,8 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/runstate"
 	secretpkg "github.com/dagucloud/dagu/internal/secret"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
+	daguaqua "github.com/dagucloud/dagu/internal/tools/aqua"
 	"github.com/dagucloud/dagu/internal/workspace"
 )
 
@@ -43,6 +45,7 @@ type Local struct {
 	workerID                 string
 	dagRunLogDir             string
 	dagRunArtifactDir        string
+	toolInstaller            dagutools.Installer
 
 	mu     sync.Mutex
 	active map[string]*rtagent.Agent
@@ -52,6 +55,13 @@ var _ executor.SubWorkflowRunner = (*Local)(nil)
 
 // LocalOption configures Local.
 type LocalOption func(*Local)
+
+// WithLocalToolInstaller sets the installer used to make child DAG tools available.
+func WithLocalToolInstaller(installer dagutools.Installer) LocalOption {
+	return func(r *Local) {
+		r.toolInstaller = installer
+	}
+}
 
 // WithLocalDAGRunStore sets the dag-run store used by child workflow agents.
 func WithLocalDAGRunStore(store exec.DAGRunStore) LocalOption {
@@ -148,9 +158,10 @@ func WithLocalDAGRunDirs(logDir, artifactDir string) LocalOption {
 // NewLocal creates an in-process child workflow runner.
 func NewLocal(dagRunMgr runtime.Manager, dagStore exec.DAGStore, opts ...LocalOption) *Local {
 	r := &Local{
-		dagRunMgr: dagRunMgr,
-		dagStore:  dagStore,
-		active:    make(map[string]*rtagent.Agent),
+		dagRunMgr:     dagRunMgr,
+		dagStore:      dagStore,
+		toolInstaller: daguaqua.New(),
+		active:        make(map[string]*rtagent.Agent),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -348,12 +359,16 @@ func (r *Local) newAgent(
 	if err != nil {
 		return nil, err
 	}
+	toolEnvs, err := r.prepareDAGTools(ctx, rCtx, dag)
+	if err != nil {
+		return nil, err
+	}
 
 	opts.ParentDAGRun = req.ParentDAGRun
 	opts.RootDAGRun = req.RootDAGRun
 	opts.TriggerActor = req.TriggerActor
 	opts.RetryPath = req.RetryPath
-	opts.ExtraEnvs = inProcessExtraEnvs(rCtx, req)
+	opts.ExtraEnvs = append(inProcessExtraEnvs(rCtx, req), toolEnvs...)
 	opts.WorkerID = r.workerID
 	opts.StatusPusher = r.statusPusher
 	opts.SubWorkflowRunnerFactory = r.subWorkflowRunnerFactory
@@ -386,6 +401,19 @@ func (r *Local) newAgent(
 		r.dagStoreFromContext(ctx),
 		opts,
 	), nil
+}
+
+func (r *Local) prepareDAGTools(ctx context.Context, rCtx exec.Context, dag *core.DAG) ([]string, error) {
+	cfg := config.GetConfig(ctx)
+	workDir := ""
+	if dag != nil {
+		workDir = dag.WorkingDir
+	}
+	return dagutools.PrepareDAG(ctx, dag, r.toolInstaller, dagutools.InstallOptions{
+		ToolsDir: cfg.Paths.ToolsDir,
+		DataDir:  cfg.Paths.DataDir,
+		WorkDir:  workDir,
+	}, dagToolsBasePathForLocalRunner(rCtx))
 }
 
 func (r *Local) runAgent(ctx context.Context, runID string, child *rtagent.Agent) (*exec.RunStatus, error) {

--- a/internal/subflow/local_helpers.go
+++ b/internal/subflow/local_helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	coreexec "github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/runtime/workspacebundle"
 	dagutools "github.com/dagucloud/dagu/internal/tools"
@@ -66,6 +67,18 @@ func inheritedEnvForLocalRunner(envs []string) []string {
 		filtered = append(filtered, env)
 	}
 	return filtered
+}
+
+func dagToolsBasePathForLocalRunner(rCtx coreexec.Context) string {
+	if rCtx.BaseEnv != nil {
+		for _, env := range rCtx.BaseEnv.AsSlice() {
+			key, value, ok := strings.Cut(env, "=")
+			if ok && strings.EqualFold(key, "PATH") {
+				return value
+			}
+		}
+	}
+	return os.Getenv("PATH")
 }
 
 func hasDAGToolsEnv(envs []string) bool {

--- a/internal/subflow/local_helpers.go
+++ b/internal/subflow/local_helpers.go
@@ -69,7 +69,7 @@ func inheritedEnvForLocalRunner(envs []string) []string {
 	return filtered
 }
 
-func dagToolsBasePathForLocalRunner(rCtx coreexec.Context) string {
+func toolsBasePath(rCtx coreexec.Context) string {
 	if rCtx.BaseEnv != nil {
 		for _, env := range rCtx.BaseEnv.AsSlice() {
 			key, value, ok := strings.Cut(env, "=")

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -6,6 +6,9 @@ package subflow_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	"github.com/dagucloud/dagu/internal/runtime/executor"
 	"github.com/dagucloud/dagu/internal/subflow"
 	"github.com/dagucloud/dagu/internal/test"
+	dagutools "github.com/dagucloud/dagu/internal/tools"
 )
 
 func TestLocalCancelRequestsStoredChildAttemptWhenInactive(t *testing.T) {
@@ -151,6 +155,55 @@ steps:
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, core.Succeeded, result.Status)
+}
+
+func TestLocalRunPreparesDeclaredTools(t *testing.T) {
+	th := test.Setup(t)
+	binDir := t.TempDir()
+	toolPath := filepath.Join(binDir, "child-tool")
+	toolScript := "#!/bin/sh\nexit 0\n"
+	if goruntime.GOOS == "windows" {
+		toolPath += ".cmd"
+		toolScript = "@echo off\r\nexit /b 0\r\n"
+	}
+	require.NoError(t, os.WriteFile(toolPath, []byte(toolScript), 0o755))
+
+	installer := &localToolInstaller{
+		manifest: &dagutools.Manifest{
+			RootDir:      binDir,
+			EnvDir:       binDir,
+			BinDir:       binDir,
+			ManifestFile: filepath.Join(binDir, "manifest.json"),
+		},
+	}
+	child := th.DAG(t, `name: local-tools-child
+tools:
+  - test/child-tool@v1.0.0
+steps:
+  - name: use-tool
+    run: |
+      child-tool
+`)
+	root := exec.NewDAGRunRef("root", uuid.Must(uuid.NewV7()).String())
+	runner := subflow.NewLocal(
+		th.DAGRunMgr,
+		th.DAGStore,
+		subflow.WithLocalToolInstaller(installer),
+	)
+
+	result, err := runner.Run(th.Context, executor.SubWorkflowRequest{
+		DAG:          child.DAG,
+		RootDAGRun:   root,
+		ParentDAGRun: root,
+		RunID:        uuid.Must(uuid.NewV7()).String(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, core.Succeeded, result.Status)
+	require.Equal(t, 1, installer.calls)
+	require.Equal(t, "test/child-tool", installer.config.Packages[0].Package)
+	require.Equal(t, th.Config.Paths.ToolsDir, installer.options.ToolsDir)
 }
 
 func TestLocalRunReusesSucceededChildForExternalStepRetry(t *testing.T) {
@@ -303,6 +356,24 @@ type localDAGRunStore struct {
 	findErr    error
 	findRoot   exec.DAGRunRef
 	findRunID  string
+}
+
+type localToolInstaller struct {
+	manifest *dagutools.Manifest
+	config   *core.ToolConfig
+	options  dagutools.InstallOptions
+	calls    int
+}
+
+func (i *localToolInstaller) Install(
+	_ context.Context,
+	cfg *core.ToolConfig,
+	opts dagutools.InstallOptions,
+) (*dagutools.Manifest, error) {
+	i.calls++
+	i.config = cfg
+	i.options = opts
+	return i.manifest, nil
 }
 
 func (s *localDAGRunStore) CreateAttempt(context.Context, *core.DAG, time.Time, string, exec.NewDAGRunAttemptOptions) (exec.DAGRunAttempt, error) {

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -168,7 +168,7 @@ func TestLocalRunPreparesDeclaredTools(t *testing.T) {
 	}
 	require.NoError(t, os.WriteFile(toolPath, []byte(toolScript), 0o755))
 
-	installer := &localToolInstaller{
+	installer := &staticInstaller{
 		manifest: &dagutools.Manifest{
 			RootDir:      binDir,
 			EnvDir:       binDir,
@@ -201,9 +201,6 @@ steps:
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, core.Succeeded, result.Status)
-	require.Equal(t, 1, installer.calls)
-	require.Equal(t, "test/child-tool", installer.config.Packages[0].Package)
-	require.Equal(t, th.Config.Paths.ToolsDir, installer.options.ToolsDir)
 }
 
 func TestLocalRunReusesSucceededChildForExternalStepRetry(t *testing.T) {
@@ -358,21 +355,15 @@ type localDAGRunStore struct {
 	findRunID  string
 }
 
-type localToolInstaller struct {
+type staticInstaller struct {
 	manifest *dagutools.Manifest
-	config   *core.ToolConfig
-	options  dagutools.InstallOptions
-	calls    int
 }
 
-func (i *localToolInstaller) Install(
+func (i *staticInstaller) Install(
 	_ context.Context,
-	cfg *core.ToolConfig,
-	opts dagutools.InstallOptions,
+	_ *core.ToolConfig,
+	_ dagutools.InstallOptions,
 ) (*dagutools.Manifest, error) {
-	i.calls++
-	i.config = cfg
-	i.options = opts
 	return i.manifest, nil
 }
 


### PR DESCRIPTION
## Summary

- prepare tools declared by in-process child DAGs before their runtime agent starts
- build the child tool environment from the configured base `PATH`, preserving toolset isolation from the parent DAG
- cover local child execution with a declared CLI resolved through the injected tool environment

## Root cause

The in-process subworkflow refactor in #2248 replaced the local `dagu start` subprocess with direct agent construction. The subprocess had entered the normal DAG startup path, which prepares declared tools. The new local runner preserved the logic that removes the parent DAG's Aqua environment, but it did not prepare and inject the child DAG's own tool environment.

Official actions execute through this local sub-DAG path, so actions that declare their runtime through `tools:` could not find that runtime on `PATH`.

## Impact

Child DAGs and official actions now install or reuse their declared toolset and receive the same Aqua environment as root and worker runs.

Closes #2451

## Testing

- `make fmt`
- `make test TEST_TARGET=./internal/subflow/...`
- `go test ./internal/subflow ./internal/node ./internal/runtime/builtin/action -count=1`
- `go test ./internal/runtime/agent -run 'TestAgent_(LocalSubDAG|DAGRun.*Child|SubDAG)' -count=1`
- end-to-end parent/child reproduction from #2451 using cached `duckdb@v1.5.2`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local sub-DAG runs by preparing declared tools before the child agent starts and injecting a clean tool PATH. Child DAGs and official actions can now resolve their tools like root and worker runs.

- Bug Fixes
  - Build the child tool environment from the configured base PATH (case-insensitive), isolated from the parent.
  - Prepare tools via `dagutools.PrepareDAG` with the default `daguaqua` installer; allow override with `WithLocalToolInstaller`.
  - Append the prepared tool env to agent `ExtraEnvs` so steps find declared CLIs.
  - Added tests verifying a declared CLI runs via the injected tool env and a custom installer.

<sup>Written for commit 7d6d2e27ce9e3c91f42d91db9b1364010820d1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local sub-workflows now automatically prepare and expose declared tools to child processes.
  * Added an option to configure the tool installer used by local sub-workflows.
  * Tool lookup now respects the configured environment path, including case-insensitive path settings.

* **Tests**
  * Added coverage confirming declared tools are installed and available during local sub-workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->