### PR TITLE
fix: resolve secret refs created after store startup

### DIFF
--- a/internal/persis/store/secret.go
+++ b/internal/persis/store/secret.go
@@ -20,7 +20,7 @@ var _ secret.Store = (*SecretStore)(nil)
 
 // SecretStore implements [secret.Store].
 // byRef is an in-memory index rebuilt on startup;
-// all writes keep it in sync under mu.
+// misses are resolved from persistence.
 type SecretStore struct {
 	col       persis.Collection
 	encryptor *crypto.Encryptor
@@ -151,13 +151,33 @@ func (s *SecretStore) GetByRef(ctx context.Context, workspace, ref string) (*sec
 		return nil, err
 	}
 
+	rk := secretRefKey(workspace, ref)
 	s.mu.RLock()
-	id, ok := s.byRef[secretRefKey(workspace, ref)]
+	id, ok := s.byRef[rk]
 	s.mu.RUnlock()
-	if !ok {
-		return nil, secret.ErrNotFound
+	if ok {
+		sec, err := s.GetByID(ctx, id)
+		if err == nil && secret.NormalizeWorkspace(sec.Workspace) == workspace && sec.Ref == ref {
+			return sec, nil
+		}
+		if err != nil && !errors.Is(err, secret.ErrNotFound) {
+			return nil, err
+		}
+		s.mu.Lock()
+		if s.byRef[rk] == id {
+			delete(s.byRef, rk)
+		}
+		s.mu.Unlock()
 	}
-	return s.GetByID(ctx, id)
+
+	sec, err := s.findByRef(ctx, workspace, ref)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.byRef[rk] = sec.ID
+	s.mu.Unlock()
+	return sec, nil
 }
 
 // List returns all secrets, optionally filtered by workspace.
@@ -381,6 +401,23 @@ func (s *SecretStore) ResolveValue(ctx context.Context, id string) (string, *sec
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
+
+func (s *SecretStore) findByRef(ctx context.Context, workspace, ref string) (*secret.Secret, error) {
+	recs, err := listAll(ctx, s.col, persis.ListQuery{})
+	if err != nil {
+		return nil, err
+	}
+	for _, rec := range recs {
+		var sr secretStoredRecord
+		if err := persis.Decode(rec, &sr); err != nil || sr.Secret == nil {
+			continue
+		}
+		if secret.NormalizeWorkspace(sr.Secret.Workspace) == workspace && sr.Secret.Ref == ref {
+			return sr.Secret.Clone(), nil
+		}
+	}
+	return nil, secret.ErrNotFound
+}
 
 func (s *SecretStore) loadByID(ctx context.Context, id string) (*secretStoredRecord, error) {
 	rec, err := s.col.Get(ctx, id)

--- a/internal/persis/store/secret.go
+++ b/internal/persis/store/secret.go
@@ -175,7 +175,9 @@ func (s *SecretStore) GetByRef(ctx context.Context, workspace, ref string) (*sec
 		return nil, err
 	}
 	s.mu.Lock()
-	s.byRef[rk] = sec.ID
+	if _, exists := s.byRef[rk]; !exists {
+		s.byRef[rk] = sec.ID
+	}
 	s.mu.Unlock()
 	return sec, nil
 }

--- a/internal/persis/store/secret_test.go
+++ b/internal/persis/store/secret_test.go
@@ -124,6 +124,25 @@ func TestSecretGetByRef_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, secret.ErrNotFound)
 }
 
+func TestSecretStoresShareRefLookups(t *testing.T) {
+	ctx := context.Background()
+	col := testutil.NewMemoryBackend().Collection("secrets")
+	enc, err := crypto.NewEncryptor("test-key")
+	require.NoError(t, err)
+
+	writer, err := store.NewSecretStore(col, enc)
+	require.NoError(t, err)
+	reader, err := store.NewSecretStore(col, enc)
+	require.NoError(t, err)
+
+	sec := newSecret("ops", "infra/token")
+	require.NoError(t, writer.Create(ctx, sec, nil))
+
+	got, err := reader.GetByRef(ctx, "ops", "infra/token")
+	require.NoError(t, err)
+	assert.Equal(t, sec.ID, got.ID)
+}
+
 func TestSecretList(t *testing.T) {
 	ctx := context.Background()
 	s := newSecretStore(t)


### PR DESCRIPTION
## Summary

- fall back to the persisted secret collection when the process-local ref index misses
- validate cached ref mappings against the current persisted secret before returning them
- add regression coverage with two stores created before the secret is written

## Root cause

The frontend and coordinator construct separate `SecretStore` instances over the same file-backed collection. Each instance has its own in-memory ref index, so a coordinator that started before a frontend-created secret treated an index miss as authoritative even though the secret was already persisted.

## Impact

A running coordinator can resolve managed secrets created through the frontend/API without requiring a restart.

## Testing

- `make fmt`
- `make test TEST_TARGET="./internal/persis/store ./internal/service/coordinator"`

Closes #2458

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes secret ref lookups when multiple `SecretStore` instances share the same persisted collection. Coordinators now resolve secrets created after startup without a restart, while preserving concurrent ref index updates.

- **Bug Fixes**
  - In `GetByRef`, validate and evict stale `byRef` entries before returning.
  - On miss or stale entry, scan persistence via `findByRef`, then conditionally add to `byRef` to avoid clobbering concurrent mappings.
  - Added regression test for separate reader/writer `SecretStore` instances.

<sup>Written for commit 8b3cd397a2ade7cf4ad866f6da140bb4ccbcaf90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret lookups by reference when cached mappings are stale or missing.
  * Added automatic recovery from persisted data so valid secrets remain discoverable across store instances.

* **Tests**
  * Added coverage verifying that reference-based lookups work across separate stores sharing the same storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->