### PR TITLE
feat: support custom TLS certs for Vault client

### DIFF
--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -426,8 +426,11 @@ type AlibabaSecretsConfig struct {
 
 // VaultSecretsConfig holds shared HashiCorp Vault client defaults.
 type VaultSecretsConfig struct {
-	Address string
-	Token   string
+	Address    string
+	Token      string
+	CACert     string
+	ClientCert string
+	ClientKey  string
 }
 
 // KubernetesSecretsConfig holds shared Kubernetes client defaults.

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -270,8 +270,11 @@ type AlibabaSecretsDef struct {
 
 // VaultSecretsDef configures global HashiCorp Vault client defaults.
 type VaultSecretsDef struct {
-	Address string `mapstructure:"address"`
-	Token   string `mapstructure:"token"`
+	Address    string `mapstructure:"address"`
+	Token      string `mapstructure:"token"`
+	CACert     string `mapstructure:"ca_cert"`
+	ClientCert string `mapstructure:"client_cert"`
+	ClientKey  string `mapstructure:"client_key"`
 }
 
 // KubernetesSecretsDef configures global Kubernetes client defaults.

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -442,9 +442,30 @@ func (l *ConfigLoader) loadSecretsConfig(cfg *Config, def Definition) {
 	}
 
 	if def.Secrets.Vault != nil {
+		vaultCACert := def.Secrets.Vault.CACert
+		if resolved, err := l.resolvePath("secrets.vault.ca_cert", vaultCACert); err != nil {
+			l.warnings = append(l.warnings, err.Error())
+		} else {
+			vaultCACert = resolved
+		}
+		vaultClientCert := def.Secrets.Vault.ClientCert
+		if resolved, err := l.resolvePath("secrets.vault.client_cert", vaultClientCert); err != nil {
+			l.warnings = append(l.warnings, err.Error())
+		} else {
+			vaultClientCert = resolved
+		}
+		vaultClientKey := def.Secrets.Vault.ClientKey
+		if resolved, err := l.resolvePath("secrets.vault.client_key", vaultClientKey); err != nil {
+			l.warnings = append(l.warnings, err.Error())
+		} else {
+			vaultClientKey = resolved
+		}
 		cfg.Secrets.Vault = VaultSecretsConfig{
-			Address: def.Secrets.Vault.Address,
-			Token:   def.Secrets.Vault.Token,
+			Address:    def.Secrets.Vault.Address,
+			Token:      def.Secrets.Vault.Token,
+			CACert:     vaultCACert,
+			ClientCert: vaultClientCert,
+			ClientKey:  vaultClientKey,
 		}
 	}
 
@@ -1987,6 +2008,9 @@ var envBindings = []envBinding{
 	// Secrets
 	{key: "secrets.vault.address", env: "SECRETS_VAULT_ADDRESS"},
 	{key: "secrets.vault.token", env: "SECRETS_VAULT_TOKEN"},
+	{key: "secrets.vault.ca_cert", env: "SECRETS_VAULT_CA_CERT", isPath: true},
+	{key: "secrets.vault.client_cert", env: "SECRETS_VAULT_CLIENT_CERT", isPath: true},
+	{key: "secrets.vault.client_key", env: "SECRETS_VAULT_CLIENT_KEY", isPath: true},
 	{key: "secrets.kubernetes.namespace", env: "SECRETS_KUBERNETES_NAMESPACE"},
 	{key: "secrets.kubernetes.kubeconfig", env: "SECRETS_KUBERNETES_KUBECONFIG", isPath: true},
 	{key: "secrets.kubernetes.context", env: "SECRETS_KUBERNETES_CONTEXT"},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -1466,6 +1466,9 @@ secrets:
   vault:
     address: "https://vault.example.com"
     token: "yaml-token"
+    ca_cert: "relative/vault-ca.pem"
+    client_cert: "relative/vault-client-cert.pem"
+    client_key: "relative/vault-client-key.pem"
   kubernetes:
     namespace: "secret-ns"
     kubeconfig: "relative/kubeconfig"
@@ -1485,6 +1488,9 @@ secrets:
 
 		assert.Equal(t, "https://vault.example.com", cfg.Secrets.Vault.Address)
 		assert.Equal(t, "yaml-token", cfg.Secrets.Vault.Token)
+		assert.Equal(t, resolvedTestPath(t, "relative/vault-ca.pem"), cfg.Secrets.Vault.CACert)
+		assert.Equal(t, resolvedTestPath(t, "relative/vault-client-cert.pem"), cfg.Secrets.Vault.ClientCert)
+		assert.Equal(t, resolvedTestPath(t, "relative/vault-client-key.pem"), cfg.Secrets.Vault.ClientKey)
 		assert.Equal(t, "secret-ns", cfg.Secrets.Kubernetes.Namespace)
 		assert.Equal(t, resolvedTestPath(t, "relative/kubeconfig"), cfg.Secrets.Kubernetes.Kubeconfig)
 		assert.Equal(t, "prod", cfg.Secrets.Kubernetes.Context)
@@ -1500,9 +1506,15 @@ secrets:
 	t.Run("FromEnv", func(t *testing.T) {
 		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
 		alibabaCAFile := filepath.Join(t.TempDir(), "alibaba-ca.pem")
+		vaultCACert := filepath.Join(t.TempDir(), "vault-ca.pem")
+		vaultClientCert := filepath.Join(t.TempDir(), "vault-client-cert.pem")
+		vaultClientKey := filepath.Join(t.TempDir(), "vault-client-key.pem")
 		cfg := loadWithEnv(t, "# empty", map[string]string{
 			"DAGU_SECRETS_VAULT_ADDRESS":         "https://vault.example.com",
 			"DAGU_SECRETS_VAULT_TOKEN":           "env-token",
+			"DAGU_SECRETS_VAULT_CA_CERT":         vaultCACert,
+			"DAGU_SECRETS_VAULT_CLIENT_CERT":     vaultClientCert,
+			"DAGU_SECRETS_VAULT_CLIENT_KEY":      vaultClientKey,
 			"DAGU_SECRETS_KUBERNETES_NAMESPACE":  "env-ns",
 			"DAGU_SECRETS_KUBERNETES_KUBECONFIG": kubeconfig,
 			"DAGU_SECRETS_KUBERNETES_CONTEXT":    "env-context",
@@ -1517,6 +1529,9 @@ secrets:
 
 		assert.Equal(t, "https://vault.example.com", cfg.Secrets.Vault.Address)
 		assert.Equal(t, "env-token", cfg.Secrets.Vault.Token)
+		assert.Equal(t, vaultCACert, cfg.Secrets.Vault.CACert)
+		assert.Equal(t, vaultClientCert, cfg.Secrets.Vault.ClientCert)
+		assert.Equal(t, vaultClientKey, cfg.Secrets.Vault.ClientKey)
 		assert.Equal(t, "env-ns", cfg.Secrets.Kubernetes.Namespace)
 		assert.Equal(t, kubeconfig, cfg.Secrets.Kubernetes.Kubeconfig)
 		assert.Equal(t, "env-context", cfg.Secrets.Kubernetes.Context)

--- a/internal/cmn/secrets/vault.go
+++ b/internal/cmn/secrets/vault.go
@@ -37,8 +37,11 @@ type vaultResolver struct {
 }
 
 type vaultClientSettings struct {
-	address string
-	token   string
+	address    string
+	token      string
+	caCert     string
+	clientCert string
+	clientKey  string
 }
 
 // Name returns the provider identifier.
@@ -154,11 +157,29 @@ func (r *vaultResolver) resolveClientSettings(ctx context.Context, ref core.Secr
 	if cfg.Secrets.Vault.Token != "" {
 		settings.token = cfg.Secrets.Vault.Token
 	}
+	if cfg.Secrets.Vault.CACert != "" {
+		settings.caCert = cfg.Secrets.Vault.CACert
+	}
+	if cfg.Secrets.Vault.ClientCert != "" {
+		settings.clientCert = cfg.Secrets.Vault.ClientCert
+	}
+	if cfg.Secrets.Vault.ClientKey != "" {
+		settings.clientKey = cfg.Secrets.Vault.ClientKey
+	}
 	if addr := ref.Options["vault_address"]; addr != "" {
 		settings.address = addr
 	}
 	if token := ref.Options["vault_token"]; token != "" {
 		settings.token = token
+	}
+	if v := ref.Options["vault_ca_cert"]; v != "" {
+		settings.caCert = v
+	}
+	if v := ref.Options["vault_client_cert"]; v != "" {
+		settings.clientCert = v
+	}
+	if v := ref.Options["vault_client_key"]; v != "" {
+		settings.clientKey = v
 	}
 
 	return settings
@@ -171,6 +192,15 @@ func (r *vaultResolver) newClient(settings vaultClientSettings) (vaultClient, er
 
 	cfg := api.DefaultConfig()
 	cfg.Address = settings.address
+
+	tlsConfig := &api.TLSConfig{
+		CACert:     settings.caCert,
+		ClientCert: settings.clientCert,
+		ClientKey:  settings.clientKey,
+	}
+	if err := cfg.ConfigureTLS(tlsConfig); err != nil {
+		return nil, fmt.Errorf("failed to configure vault TLS: %w", err)
+	}
 
 	client, err := api.NewClient(cfg)
 	if err != nil {

--- a/internal/cmn/secrets/vault_test.go
+++ b/internal/cmn/secrets/vault_test.go
@@ -331,6 +331,52 @@ func TestVaultResolver_resolveClientSettings(t *testing.T) {
 		assert.Equal(t, "https://override.example.com", settings.address)
 		assert.Equal(t, "config-token", settings.token)
 	})
+
+	t.Run("TLSFromConfig", func(t *testing.T) {
+		resolver := &vaultResolver{}
+		ctx := config.WithConfig(context.Background(), &config.Config{
+			Secrets: config.SecretsConfig{
+				Vault: config.VaultSecretsConfig{
+					Address:    "https://vault.example.com",
+					Token:      "config-token",
+					CACert:     "/path/to/ca.pem",
+					ClientCert: "/path/to/client.pem",
+					ClientKey:  "/path/to/client-key.pem",
+				},
+			},
+		})
+
+		settings := resolver.resolveClientSettings(ctx, core.SecretRef{})
+
+		assert.Equal(t, "/path/to/ca.pem", settings.caCert)
+		assert.Equal(t, "/path/to/client.pem", settings.clientCert)
+		assert.Equal(t, "/path/to/client-key.pem", settings.clientKey)
+	})
+
+	t.Run("TLSOptionsOverride", func(t *testing.T) {
+		resolver := &vaultResolver{}
+		ctx := config.WithConfig(context.Background(), &config.Config{
+			Secrets: config.SecretsConfig{
+				Vault: config.VaultSecretsConfig{
+					Address: "https://vault.example.com",
+					CACert:  "/path/to/ca.pem",
+				},
+			},
+		})
+		ref := core.SecretRef{
+			Options: map[string]string{
+				"vault_ca_cert":     "/other/ca.pem",
+				"vault_client_cert": "/other/client.pem",
+				"vault_client_key":  "/other/client-key.pem",
+			},
+		}
+
+		settings := resolver.resolveClientSettings(ctx, ref)
+
+		assert.Equal(t, "/other/ca.pem", settings.caCert)
+		assert.Equal(t, "/other/client.pem", settings.clientCert)
+		assert.Equal(t, "/other/client-key.pem", settings.clientKey)
+	})
 }
 
 func TestVaultResolver_getClient_CachesByResolvedSettings(t *testing.T) {


### PR DESCRIPTION
## Summary

Add ca_cert, client_cert, and client_key to the Vault secrets config so the Vault HTTP client can present a client certificate and verify a custom CA.

## Changes

- Add CACert, ClientCert, ClientKey fields to VaultSecretsConfig / VaultSecretsDef
- Add SECRETS_VAULT_CA_CERT, SECRETS_VAULT_CLIENT_CERT, SECRETS_VAULT_CLIENT_KEY env bindings (with isPath: true)
- Resolve the three cert/key paths to absolute when loaded from YAML, matching secrets.kubernetes.kubeconfig and secrets.alibaba.ca_file
- Apply TLS config via cfg.ConfigureTLS(&api.TLSConfig{...}) before creating the Vault client
- Support per-ref options vault_ca_cert, vault_client_cert, vault_client_key (override config values)
- Add tests: TLSFromConfig and TLSOptionsOverride subtests in vault_test.go; extend TestLoad_SecretsConfig/FromYAML and /FromEnv in loader_test.go

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (https://github.com/dagucloud/docs/pull/26)
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom TLS support to the Vault client with custom CA and optional mTLS (client cert/key). Enables connecting to Vault instances using private CAs or requiring client auth.

- **New Features**
  - Added config fields in `VaultSecretsConfig`/`VaultSecretsDef`: `CACert`, `ClientCert`, `ClientKey`.
  - New env vars: `SECRETS_VAULT_CA_CERT`, `SECRETS_VAULT_CLIENT_CERT`, `SECRETS_VAULT_CLIENT_KEY` (path values).
  - YAML values are resolved to absolute paths.
  - Per-ref overrides: `vault_ca_cert`, `vault_client_cert`, `vault_client_key`.
  - TLS applied via `cfg.ConfigureTLS(&api.TLSConfig{...})` before creating the client.
  - Tests cover config/env loading and per-ref TLS overrides.

<sup>Written for commit a4b4d90107a4e2928744bd35e2c4b4d3b48cad23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Vault connections with CA certificates and client TLS certificates/keys.
  * TLS settings can be provided globally or customized for individual Vault secrets.
  * Added environment variable support for Vault certificate and key paths.

* **Bug Fixes**
  * Vault certificate and key paths are now resolved consistently, with configuration warnings for invalid paths.
  * Clear errors are returned when Vault TLS configuration cannot be applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->