### PR TITLE
feat: reload OIDC policy at login

### DIFF
--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -289,17 +289,17 @@ type AuthOIDC struct {
 	RoleMapping    OIDCRoleMapping
 }
 
-// OIDCProvisioningPolicy contains the OIDC settings evaluated for each login.
-type OIDCProvisioningPolicy struct {
+// OIDCPolicy contains the OIDC settings evaluated for each login.
+type OIDCPolicy struct {
 	AutoSignup     bool
 	AllowedDomains []string
 	Whitelist      []string
 	RoleMapping    OIDCRoleMapping
 }
 
-// ProvisioningPolicy returns the login-time policy from the OIDC configuration.
-func (o AuthOIDC) ProvisioningPolicy() OIDCProvisioningPolicy {
-	return OIDCProvisioningPolicy{
+// Policy returns the login-time policy from the OIDC configuration.
+func (o AuthOIDC) Policy() OIDCPolicy {
+	return OIDCPolicy{
 		AutoSignup:     o.AutoSignup,
 		AllowedDomains: o.AllowedDomains,
 		Whitelist:      o.Whitelist,

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -289,6 +289,24 @@ type AuthOIDC struct {
 	RoleMapping    OIDCRoleMapping
 }
 
+// OIDCProvisioningPolicy contains the OIDC settings evaluated for each login.
+type OIDCProvisioningPolicy struct {
+	AutoSignup     bool
+	AllowedDomains []string
+	Whitelist      []string
+	RoleMapping    OIDCRoleMapping
+}
+
+// ProvisioningPolicy returns the login-time policy from the OIDC configuration.
+func (o AuthOIDC) ProvisioningPolicy() OIDCProvisioningPolicy {
+	return OIDCProvisioningPolicy{
+		AutoSignup:     o.AutoSignup,
+		AllowedDomains: o.AllowedDomains,
+		Whitelist:      o.Whitelist,
+		RoleMapping:    o.RoleMapping,
+	}
+}
+
 // IsConfigured returns true if all required OIDC fields are set.
 func (o AuthOIDC) IsConfigured() bool {
 	return o.ClientID != "" && o.ClientSecret != "" && o.ClientURL != "" && o.Issuer != ""
@@ -389,6 +407,7 @@ type PathsConfig struct {
 	WorkspacesDir      string
 	ViewsDir           string
 	ConfigFileUsed     string
+	ConfigFilesUsed    []string
 }
 
 // SecretsConfig holds global defaults for external secret providers.

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -202,6 +202,11 @@ func (l *ConfigLoader) Load() (*Config, error) {
 		}
 	}
 
+	var configFilesUsed []string
+	if l.v.ConfigFileUsed() != "" {
+		configFilesUsed = append(configFilesUsed, l.v.ConfigFileUsed())
+	}
+
 	if err := checkForLegacyKeys(l.v); err != nil {
 		return nil, err
 	}
@@ -223,6 +228,7 @@ func (l *ConfigLoader) Load() (*Config, error) {
 			return nil, fmt.Errorf("failed to read admin config: %w", err)
 		}
 	} else if l.requires(SectionServer) {
+		configFilesUsed = append(configFilesUsed, l.v.ConfigFileUsed())
 		if err := l.mergeTrustedProxyMappingsFile(l.v.ConfigFileUsed()); err != nil {
 			return nil, err
 		}
@@ -251,6 +257,13 @@ func (l *ConfigLoader) Load() (*Config, error) {
 	}
 
 	cfg.Paths.ConfigFileUsed = configFileUsed
+	for _, filename := range configFilesUsed {
+		resolved, err := l.resolvePath("config file", filename)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Paths.ConfigFilesUsed = append(cfg.Paths.ConfigFilesUsed, resolved)
+	}
 	l.finalizeBaseEnv(cfg)
 	cfg.Notices = l.notices
 	cfg.Warnings = l.warnings

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -183,6 +183,7 @@ func TestLoad_Env(t *testing.T) {
 
 	require.NotEmpty(t, cfg.Paths.ConfigFileUsed)
 	cfg.Paths.ConfigFileUsed = ""
+	cfg.Paths.ConfigFilesUsed = nil
 
 	expected := &Config{
 		Core: Core{
@@ -1201,6 +1202,7 @@ func loadFromYAML(t *testing.T, yamlContent string) *Config {
 
 	cfg := testLoad(t, WithConfigFile(configFile))
 	cfg.Paths.ConfigFileUsed = ""
+	cfg.Paths.ConfigFilesUsed = nil
 	return cfg
 }
 

--- a/internal/cmn/config/oidc_policy.go
+++ b/internal/cmn/config/oidc_policy.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/auth"
+	"github.com/spf13/viper"
+)
+
+// OIDCProvisioningPolicyLoader loads the effective login-time OIDC policy.
+type OIDCProvisioningPolicyLoader struct {
+	configFiles []string
+	fallback    OIDCProvisioningPolicy
+}
+
+// NewOIDCProvisioningPolicyLoader creates a loader for the configuration files
+// that contributed to the startup configuration.
+func NewOIDCProvisioningPolicyLoader(
+	configFiles []string,
+	fallback OIDCProvisioningPolicy,
+) *OIDCProvisioningPolicyLoader {
+	return &OIDCProvisioningPolicyLoader{
+		configFiles: append([]string(nil), configFiles...),
+		fallback:    fallback,
+	}
+}
+
+// Load returns the current effective OIDC provisioning policy.
+func (l *OIDCProvisioningPolicyLoader) Load() (OIDCProvisioningPolicy, error) {
+	if len(l.configFiles) == 0 {
+		return l.fallback, nil
+	}
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	bindOIDCPolicyEnvironment(v)
+
+	for i, filename := range l.configFiles {
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			return OIDCProvisioningPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
+		}
+		if i == 0 {
+			if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
+				return OIDCProvisioningPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
+			}
+			continue
+		}
+		if err := v.MergeConfig(bytes.NewReader(data)); err != nil {
+			return OIDCProvisioningPolicy{}, fmt.Errorf("merge OIDC policy config %q: %w", filename, err)
+		}
+	}
+
+	if err := checkForLegacyKeys(v); err != nil {
+		return OIDCProvisioningPolicy{}, err
+	}
+
+	configLoader := NewConfigLoader(v, WithService(ServiceServer))
+	if err := configLoader.loadOIDCWorkspaceMappingsEnv(); err != nil {
+		return OIDCProvisioningPolicy{}, err
+	}
+
+	var def Definition
+	if err := v.Unmarshal(&def); err != nil {
+		return OIDCProvisioningPolicy{}, fmt.Errorf("unmarshal OIDC policy config: %w", err)
+	}
+
+	cfg := Config{Server: Server{Auth: Auth{OIDC: AuthOIDC{AutoSignup: true}}}}
+	if def.Auth != nil {
+		configLoader.loadOIDCAuth(&cfg, def.Auth)
+	}
+	configLoader.setAuthDefaults(&cfg)
+
+	policy := cfg.Server.Auth.OIDC.ProvisioningPolicy()
+	if _, err := auth.ParseRole(policy.RoleMapping.DefaultRole); err != nil {
+		return OIDCProvisioningPolicy{}, fmt.Errorf("OIDC roleMapping.defaultRole: %w", err)
+	}
+	if err := validateOIDCWorkspaceMappings(policy.RoleMapping); err != nil {
+		return OIDCProvisioningPolicy{}, err
+	}
+	return policy, nil
+}
+
+func bindOIDCPolicyEnvironment(v *viper.Viper) {
+	prefix := strings.ToUpper(AppSlug) + "_"
+	for _, binding := range envBindings {
+		if !strings.HasPrefix(binding.key, "auth.oidc.") {
+			continue
+		}
+		_ = v.BindEnv(binding.key, prefix+binding.env)
+	}
+}

--- a/internal/cmn/config/oidc_policy.go
+++ b/internal/cmn/config/oidc_policy.go
@@ -13,26 +13,22 @@ import (
 	"github.com/spf13/viper"
 )
 
-// OIDCProvisioningPolicyLoader loads the effective login-time OIDC policy.
-type OIDCProvisioningPolicyLoader struct {
+// OIDCPolicyLoader loads the effective login-time OIDC policy.
+type OIDCPolicyLoader struct {
 	configFiles []string
-	fallback    OIDCProvisioningPolicy
+	fallback    OIDCPolicy
 }
 
-// NewOIDCProvisioningPolicyLoader creates a loader for the configuration files
-// that contributed to the startup configuration.
-func NewOIDCProvisioningPolicyLoader(
-	configFiles []string,
-	fallback OIDCProvisioningPolicy,
-) *OIDCProvisioningPolicyLoader {
-	return &OIDCProvisioningPolicyLoader{
+// NewOIDCPolicyLoader creates a loader for the files used at startup.
+func NewOIDCPolicyLoader(configFiles []string, fallback OIDCPolicy) *OIDCPolicyLoader {
+	return &OIDCPolicyLoader{
 		configFiles: append([]string(nil), configFiles...),
 		fallback:    fallback,
 	}
 }
 
-// Load returns the current effective OIDC provisioning policy.
-func (l *OIDCProvisioningPolicyLoader) Load() (OIDCProvisioningPolicy, error) {
+// Load returns the current effective OIDC policy.
+func (l *OIDCPolicyLoader) Load() (OIDCPolicy, error) {
 	if len(l.configFiles) == 0 {
 		return l.fallback, nil
 	}
@@ -44,31 +40,31 @@ func (l *OIDCProvisioningPolicyLoader) Load() (OIDCProvisioningPolicy, error) {
 	for i, filename := range l.configFiles {
 		data, err := os.ReadFile(filename)
 		if err != nil {
-			return OIDCProvisioningPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
+			return OIDCPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
 		}
 		if i == 0 {
 			if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
-				return OIDCProvisioningPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
+				return OIDCPolicy{}, fmt.Errorf("read OIDC policy config %q: %w", filename, err)
 			}
 			continue
 		}
 		if err := v.MergeConfig(bytes.NewReader(data)); err != nil {
-			return OIDCProvisioningPolicy{}, fmt.Errorf("merge OIDC policy config %q: %w", filename, err)
+			return OIDCPolicy{}, fmt.Errorf("merge OIDC policy config %q: %w", filename, err)
 		}
 	}
 
 	if err := checkForLegacyKeys(v); err != nil {
-		return OIDCProvisioningPolicy{}, err
+		return OIDCPolicy{}, err
 	}
 
 	configLoader := NewConfigLoader(v, WithService(ServiceServer))
 	if err := configLoader.loadOIDCWorkspaceMappingsEnv(); err != nil {
-		return OIDCProvisioningPolicy{}, err
+		return OIDCPolicy{}, err
 	}
 
 	var def Definition
 	if err := v.Unmarshal(&def); err != nil {
-		return OIDCProvisioningPolicy{}, fmt.Errorf("unmarshal OIDC policy config: %w", err)
+		return OIDCPolicy{}, fmt.Errorf("unmarshal OIDC policy config: %w", err)
 	}
 
 	cfg := Config{Server: Server{Auth: Auth{OIDC: AuthOIDC{AutoSignup: true}}}}
@@ -77,12 +73,12 @@ func (l *OIDCProvisioningPolicyLoader) Load() (OIDCProvisioningPolicy, error) {
 	}
 	configLoader.setAuthDefaults(&cfg)
 
-	policy := cfg.Server.Auth.OIDC.ProvisioningPolicy()
+	policy := cfg.Server.Auth.OIDC.Policy()
 	if _, err := auth.ParseRole(policy.RoleMapping.DefaultRole); err != nil {
-		return OIDCProvisioningPolicy{}, fmt.Errorf("OIDC roleMapping.defaultRole: %w", err)
+		return OIDCPolicy{}, fmt.Errorf("OIDC roleMapping.defaultRole: %w", err)
 	}
 	if err := validateOIDCWorkspaceMappings(policy.RoleMapping); err != nil {
-		return OIDCProvisioningPolicy{}, err
+		return OIDCPolicy{}, err
 	}
 	return policy, nil
 }

--- a/internal/cmn/config/oidc_policy_test.go
+++ b/internal/cmn/config/oidc_policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOIDCProvisioningPolicyLoaderReadsCurrentMergedPolicy(t *testing.T) {
+func TestOIDCPolicyLoaderReadsCurrentMergedPolicy(t *testing.T) {
 	homeDir := t.TempDir()
 	configFile := filepath.Join(homeDir, "config.yaml")
 	adminFile := filepath.Join(homeDir, "admin.yaml")
@@ -43,9 +43,9 @@ auth:
 	require.NoError(t, err)
 	require.Equal(t, []string{configFile, adminFile}, cfg.Paths.ConfigFilesUsed)
 
-	loader := NewOIDCProvisioningPolicyLoader(
+	loader := NewOIDCPolicyLoader(
 		cfg.Paths.ConfigFilesUsed,
-		cfg.Server.Auth.OIDC.ProvisioningPolicy(),
+		cfg.Server.Auth.OIDC.Policy(),
 	)
 	policy, err := loader.Load()
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ auth:
 	require.Equal(t, "operator", policy.RoleMapping.GroupMappings["team"])
 }
 
-func TestOIDCProvisioningPolicyLoaderRejectsInvalidCurrentMapping(t *testing.T) {
+func TestOIDCPolicyLoaderRejectsInvalidCurrentMapping(t *testing.T) {
 	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 auth:
@@ -82,15 +82,15 @@ auth:
       default_workspace_access: none
 `), 0600))
 
-	loader := NewOIDCProvisioningPolicyLoader(
+	loader := NewOIDCPolicyLoader(
 		[]string{configFile},
-		OIDCProvisioningPolicy{},
+		OIDCPolicy{},
 	)
 	_, err := loader.Load()
 	require.ErrorContains(t, err, "invalid role")
 }
 
-func TestOIDCProvisioningPolicyLoaderAppliesEnvironmentOverrides(t *testing.T) {
+func TestOIDCPolicyLoaderAppliesEnvironmentOverrides(t *testing.T) {
 	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(configFile, []byte(`
 auth:
@@ -104,9 +104,9 @@ auth:
 	t.Setenv("DAGU_AUTH_OIDC_ALLOWED_DOMAINS", "env.example.com")
 	t.Setenv("DAGU_AUTH_OIDC_DEFAULT_ROLE", "developer")
 
-	policy, err := NewOIDCProvisioningPolicyLoader(
+	policy, err := NewOIDCPolicyLoader(
 		[]string{configFile},
-		OIDCProvisioningPolicy{},
+		OIDCPolicy{},
 	).Load()
 	require.NoError(t, err)
 	require.False(t, policy.AutoSignup)
@@ -114,13 +114,13 @@ auth:
 	require.Equal(t, "developer", policy.RoleMapping.DefaultRole)
 }
 
-func TestOIDCProvisioningPolicyLoaderAppliesPolicyDefaults(t *testing.T) {
+func TestOIDCPolicyLoaderAppliesPolicyDefaults(t *testing.T) {
 	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(configFile, []byte("# provider configured through environment"), 0600))
 
-	policy, err := NewOIDCProvisioningPolicyLoader(
+	policy, err := NewOIDCPolicyLoader(
 		[]string{configFile},
-		OIDCProvisioningPolicy{},
+		OIDCPolicy{},
 	).Load()
 	require.NoError(t, err)
 	require.True(t, policy.AutoSignup)
@@ -128,8 +128,8 @@ func TestOIDCProvisioningPolicyLoaderAppliesPolicyDefaults(t *testing.T) {
 	require.Equal(t, OIDCDefaultWorkspaceAccessAll, policy.RoleMapping.DefaultWorkspaceAccess)
 }
 
-func TestOIDCProvisioningPolicyLoaderUsesFallbackWithoutConfigFiles(t *testing.T) {
-	fallback := OIDCProvisioningPolicy{
+func TestOIDCPolicyLoaderUsesFallbackWithoutConfigFiles(t *testing.T) {
+	fallback := OIDCPolicy{
 		AutoSignup:     true,
 		AllowedDomains: []string{"example.com"},
 		RoleMapping: OIDCRoleMapping{
@@ -137,7 +137,7 @@ func TestOIDCProvisioningPolicyLoaderUsesFallbackWithoutConfigFiles(t *testing.T
 		},
 	}
 
-	policy, err := NewOIDCProvisioningPolicyLoader(nil, fallback).Load()
+	policy, err := NewOIDCPolicyLoader(nil, fallback).Load()
 	require.NoError(t, err)
 	require.Equal(t, fallback, policy)
 }

--- a/internal/cmn/config/oidc_policy_test.go
+++ b/internal/cmn/config/oidc_policy_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDCProvisioningPolicyLoaderReadsCurrentMergedPolicy(t *testing.T) {
+	homeDir := t.TempDir()
+	configFile := filepath.Join(homeDir, "config.yaml")
+	adminFile := filepath.Join(homeDir, "admin.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+auth:
+  mode: builtin
+  oidc:
+    auto_signup: true
+    allowed_domains: [example.com]
+    role_mapping:
+      default_role: viewer
+      group_mappings:
+        team: viewer
+`), 0600))
+	require.NoError(t, os.WriteFile(adminFile, []byte(`
+auth:
+  oidc:
+    role_mapping:
+      group_mappings:
+        team: manager
+`), 0600))
+
+	cfg, err := NewConfigLoader(
+		viper.New(),
+		WithAppHomeDir(homeDir),
+		WithService(ServiceServer),
+	).Load()
+	require.NoError(t, err)
+	require.Equal(t, []string{configFile, adminFile}, cfg.Paths.ConfigFilesUsed)
+
+	loader := NewOIDCProvisioningPolicyLoader(
+		cfg.Paths.ConfigFilesUsed,
+		cfg.Server.Auth.OIDC.ProvisioningPolicy(),
+	)
+	policy, err := loader.Load()
+	require.NoError(t, err)
+	require.True(t, policy.AutoSignup)
+	require.Equal(t, []string{"example.com"}, policy.AllowedDomains)
+	require.Equal(t, "manager", policy.RoleMapping.GroupMappings["team"])
+
+	require.NoError(t, os.WriteFile(adminFile, []byte(`
+auth:
+  oidc:
+    auto_signup: false
+    allowed_domains: [new.example.com]
+    role_mapping:
+      group_mappings:
+        team: operator
+`), 0600))
+	policy, err = loader.Load()
+	require.NoError(t, err)
+	require.False(t, policy.AutoSignup)
+	require.Equal(t, []string{"new.example.com"}, policy.AllowedDomains)
+	require.Equal(t, "operator", policy.RoleMapping.GroupMappings["team"])
+}
+
+func TestOIDCProvisioningPolicyLoaderRejectsInvalidCurrentMapping(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+auth:
+  oidc:
+    role_mapping:
+      workspace_mappings:
+        team:
+          - workspace: payments
+            role: invalid
+      default_workspace_access: none
+`), 0600))
+
+	loader := NewOIDCProvisioningPolicyLoader(
+		[]string{configFile},
+		OIDCProvisioningPolicy{},
+	)
+	_, err := loader.Load()
+	require.ErrorContains(t, err, "invalid role")
+}
+
+func TestOIDCProvisioningPolicyLoaderAppliesEnvironmentOverrides(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+auth:
+  oidc:
+    auto_signup: true
+    allowed_domains: [yaml.example.com]
+    role_mapping:
+      default_role: viewer
+`), 0600))
+	t.Setenv("DAGU_AUTH_OIDC_AUTO_SIGNUP", "false")
+	t.Setenv("DAGU_AUTH_OIDC_ALLOWED_DOMAINS", "env.example.com")
+	t.Setenv("DAGU_AUTH_OIDC_DEFAULT_ROLE", "developer")
+
+	policy, err := NewOIDCProvisioningPolicyLoader(
+		[]string{configFile},
+		OIDCProvisioningPolicy{},
+	).Load()
+	require.NoError(t, err)
+	require.False(t, policy.AutoSignup)
+	require.Equal(t, []string{"env.example.com"}, policy.AllowedDomains)
+	require.Equal(t, "developer", policy.RoleMapping.DefaultRole)
+}
+
+func TestOIDCProvisioningPolicyLoaderAppliesPolicyDefaults(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("# provider configured through environment"), 0600))
+
+	policy, err := NewOIDCProvisioningPolicyLoader(
+		[]string{configFile},
+		OIDCProvisioningPolicy{},
+	).Load()
+	require.NoError(t, err)
+	require.True(t, policy.AutoSignup)
+	require.Equal(t, "viewer", policy.RoleMapping.DefaultRole)
+	require.Equal(t, OIDCDefaultWorkspaceAccessAll, policy.RoleMapping.DefaultWorkspaceAccess)
+}
+
+func TestOIDCProvisioningPolicyLoaderUsesFallbackWithoutConfigFiles(t *testing.T) {
+	fallback := OIDCProvisioningPolicy{
+		AutoSignup:     true,
+		AllowedDomains: []string{"example.com"},
+		RoleMapping: OIDCRoleMapping{
+			DefaultRole: "developer",
+		},
+	}
+
+	policy, err := NewOIDCProvisioningPolicyLoader(nil, fallback).Load()
+	require.NoError(t, err)
+	require.Equal(t, fallback, policy)
+}

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -94,6 +94,7 @@ type API struct {
 	schedulerStateStore  scheduler.WatermarkStore
 	dagMutationNotifier  func(fileName string)
 	baseConfigFactory    WorkspaceBaseConfigStoreFactory
+	oidcPolicyLoader     func() (config.OIDCProvisioningPolicy, error)
 }
 
 type WorkspaceBaseConfigStoreFactory func(dagsDir, workspaceName string) (baseconfig.Store, error)
@@ -282,6 +283,15 @@ func WithRemoteNodeStore(s remotenode.Store) APIOption {
 func WithWorkspaceStore(s workspace.Store) APIOption {
 	return func(a *API) {
 		a.workspaceStore = s
+	}
+}
+
+// WithOIDCProvisioningPolicyLoader sets the source used for current OIDC policy metadata.
+func WithOIDCProvisioningPolicyLoader(
+	load func() (config.OIDCProvisioningPolicy, error),
+) APIOption {
+	return func(a *API) {
+		a.oidcPolicyLoader = load
 	}
 }
 

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -94,7 +94,7 @@ type API struct {
 	schedulerStateStore  scheduler.WatermarkStore
 	dagMutationNotifier  func(fileName string)
 	baseConfigFactory    WorkspaceBaseConfigStoreFactory
-	oidcPolicyLoader     func() (config.OIDCProvisioningPolicy, error)
+	oidcRoleMapping      func() config.OIDCRoleMapping
 }
 
 type WorkspaceBaseConfigStoreFactory func(dagsDir, workspaceName string) (baseconfig.Store, error)
@@ -286,12 +286,10 @@ func WithWorkspaceStore(s workspace.Store) APIOption {
 	}
 }
 
-// WithOIDCProvisioningPolicyLoader sets the source used for current OIDC policy metadata.
-func WithOIDCProvisioningPolicyLoader(
-	load func() (config.OIDCProvisioningPolicy, error),
-) APIOption {
+// WithOIDCRoleMapping sets the source used for current OIDC policy metadata.
+func WithOIDCRoleMapping(load func() config.OIDCRoleMapping) APIOption {
 	return func(a *API) {
-		a.oidcPolicyLoader = load
+		a.oidcRoleMapping = load
 	}
 }
 

--- a/internal/service/frontend/api/v1/users.go
+++ b/internal/service/frontend/api/v1/users.go
@@ -11,8 +11,6 @@ import (
 	"github.com/dagucloud/dagu/api/v1"
 	"github.com/dagucloud/dagu/internal/auth"
 	"github.com/dagucloud/dagu/internal/cmn/config"
-	"github.com/dagucloud/dagu/internal/cmn/logger"
-	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/license"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	authservice "github.com/dagucloud/dagu/internal/service/auth"
@@ -31,14 +29,14 @@ func (a *API) ListUsers(ctx context.Context, _ api.ListUsersRequestObject) (api.
 	if err != nil {
 		return nil, err
 	}
-	roleMapping := a.currentOIDCRoleMapping(ctx)
-	workspaceAccessSyncEnabled := a.oidcWorkspaceAccessSyncEnabled(roleMapping)
+	mapping := a.currentOIDCMapping()
+	workspaceSync := a.oidcWorkspaceSync(mapping)
 
 	return api.ListUsers200JSONResponse{
 		Users:                           toAPIUsers(users),
-		OidcWorkspaceAccessSyncEnabled:  &workspaceAccessSyncEnabled,
-		ManagedRoleProviders:            a.managedProviders(a.oidcAuthorizationSyncEnabled(roleMapping)),
-		ManagedWorkspaceAccessProviders: a.managedProviders(workspaceAccessSyncEnabled),
+		OidcWorkspaceAccessSyncEnabled:  &workspaceSync,
+		ManagedRoleProviders:            a.managedProviders(a.oidcRoleSync(mapping)),
+		ManagedWorkspaceAccessProviders: a.managedProviders(workspaceSync),
 	}, nil
 }
 
@@ -62,26 +60,21 @@ func (a *API) managedProviders(oidcSyncEnabled bool) []api.UserAuthProvider {
 	return providers
 }
 
-func (a *API) currentOIDCRoleMapping(ctx context.Context) config.OIDCRoleMapping {
+func (a *API) currentOIDCMapping() config.OIDCRoleMapping {
 	if a.config == nil {
 		return config.OIDCRoleMapping{}
 	}
-	if a.oidcPolicyLoader == nil {
-		return a.config.Server.Auth.OIDC.RoleMapping
+	if a.oidcRoleMapping != nil {
+		return a.oidcRoleMapping()
 	}
-	policy, err := a.oidcPolicyLoader()
-	if err != nil {
-		logger.Warn(ctx, "Failed to load current OIDC provisioning policy", tag.Error(err))
-		return a.config.Server.Auth.OIDC.RoleMapping
-	}
-	return policy.RoleMapping
+	return a.config.Server.Auth.OIDC.RoleMapping
 }
 
-func (a *API) oidcWorkspaceAccessSyncEnabled(mapping config.OIDCRoleMapping) bool {
+func (a *API) oidcWorkspaceSync(mapping config.OIDCRoleMapping) bool {
 	return a.oidcSyncEnabled(mapping) && mapping.WorkspaceAccessPolicyActive()
 }
 
-func (a *API) oidcAuthorizationSyncEnabled(mapping config.OIDCRoleMapping) bool {
+func (a *API) oidcRoleSync(mapping config.OIDCRoleMapping) bool {
 	if !a.oidcSyncEnabled(mapping) {
 		return false
 	}

--- a/internal/service/frontend/api/v1/users.go
+++ b/internal/service/frontend/api/v1/users.go
@@ -11,6 +11,8 @@ import (
 	"github.com/dagucloud/dagu/api/v1"
 	"github.com/dagucloud/dagu/internal/auth"
 	"github.com/dagucloud/dagu/internal/cmn/config"
+	"github.com/dagucloud/dagu/internal/cmn/logger"
+	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/license"
 	"github.com/dagucloud/dagu/internal/service/audit"
 	authservice "github.com/dagucloud/dagu/internal/service/auth"
@@ -29,12 +31,13 @@ func (a *API) ListUsers(ctx context.Context, _ api.ListUsersRequestObject) (api.
 	if err != nil {
 		return nil, err
 	}
-	workspaceAccessSyncEnabled := a.oidcWorkspaceAccessSyncEnabled()
+	roleMapping := a.currentOIDCRoleMapping(ctx)
+	workspaceAccessSyncEnabled := a.oidcWorkspaceAccessSyncEnabled(roleMapping)
 
 	return api.ListUsers200JSONResponse{
 		Users:                           toAPIUsers(users),
 		OidcWorkspaceAccessSyncEnabled:  &workspaceAccessSyncEnabled,
-		ManagedRoleProviders:            a.managedProviders(a.oidcAuthorizationSyncEnabled()),
+		ManagedRoleProviders:            a.managedProviders(a.oidcAuthorizationSyncEnabled(roleMapping)),
 		ManagedWorkspaceAccessProviders: a.managedProviders(workspaceAccessSyncEnabled),
 	}, nil
 }
@@ -59,22 +62,35 @@ func (a *API) managedProviders(oidcSyncEnabled bool) []api.UserAuthProvider {
 	return providers
 }
 
-func (a *API) oidcWorkspaceAccessSyncEnabled() bool {
-	return a.oidcSyncEnabled() &&
-		a.config.Server.Auth.OIDC.RoleMapping.WorkspaceAccessPolicyActive()
+func (a *API) currentOIDCRoleMapping(ctx context.Context) config.OIDCRoleMapping {
+	if a.config == nil {
+		return config.OIDCRoleMapping{}
+	}
+	if a.oidcPolicyLoader == nil {
+		return a.config.Server.Auth.OIDC.RoleMapping
+	}
+	policy, err := a.oidcPolicyLoader()
+	if err != nil {
+		logger.Warn(ctx, "Failed to load current OIDC provisioning policy", tag.Error(err))
+		return a.config.Server.Auth.OIDC.RoleMapping
+	}
+	return policy.RoleMapping
 }
 
-func (a *API) oidcAuthorizationSyncEnabled() bool {
-	if !a.oidcSyncEnabled() {
+func (a *API) oidcWorkspaceAccessSyncEnabled(mapping config.OIDCRoleMapping) bool {
+	return a.oidcSyncEnabled(mapping) && mapping.WorkspaceAccessPolicyActive()
+}
+
+func (a *API) oidcAuthorizationSyncEnabled(mapping config.OIDCRoleMapping) bool {
+	if !a.oidcSyncEnabled(mapping) {
 		return false
 	}
-	mapping := a.config.Server.Auth.OIDC.RoleMapping
 	return len(mapping.GroupMappings) > 0 ||
 		mapping.RoleAttributePath != "" ||
 		mapping.WorkspaceAccessPolicyActive()
 }
 
-func (a *API) oidcSyncEnabled() bool {
+func (a *API) oidcSyncEnabled(mapping config.OIDCRoleMapping) bool {
 	if a.config == nil {
 		return false
 	}
@@ -84,7 +100,7 @@ func (a *API) oidcSyncEnabled() bool {
 	authConfig := a.config.Server.Auth
 	return authConfig.Mode == config.AuthModeBuiltin &&
 		authConfig.OIDC.IsConfigured() &&
-		!authConfig.OIDC.RoleMapping.SkipOrgRoleSync
+		!mapping.SkipOrgRoleSync
 }
 
 // CreateUser creates a new user. Requires admin role.

--- a/internal/service/frontend/api/v1/users_internal_test.go
+++ b/internal/service/frontend/api/v1/users_internal_test.go
@@ -85,8 +85,8 @@ func TestOIDCWorkspaceAccessSyncEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			a := &API{config: tt.config, licenseManager: tt.licenseManager}
-			mapping := a.currentOIDCRoleMapping(context.Background())
-			assert.Equal(t, tt.want, a.oidcWorkspaceAccessSyncEnabled(mapping))
+			mapping := a.currentOIDCMapping()
+			assert.Equal(t, tt.want, a.oidcWorkspaceSync(mapping))
 		})
 	}
 }
@@ -115,12 +115,10 @@ func TestListUsersReportsCurrentOIDCPolicy(t *testing.T) {
 	a := &API{
 		config:      cfg,
 		authService: listUsersAuthService{},
-		oidcPolicyLoader: func() (config.OIDCProvisioningPolicy, error) {
-			return config.OIDCProvisioningPolicy{
-				RoleMapping: config.OIDCRoleMapping{
-					DefaultWorkspaceAccess: config.OIDCDefaultWorkspaceAccessNone,
-				},
-			}, nil
+		oidcRoleMapping: func() config.OIDCRoleMapping {
+			return config.OIDCRoleMapping{
+				DefaultWorkspaceAccess: config.OIDCDefaultWorkspaceAccessNone,
+			}
 		},
 	}
 	ctx := auth.WithUser(context.Background(), &auth.User{Role: auth.RoleAdmin})

--- a/internal/service/frontend/api/v1/users_internal_test.go
+++ b/internal/service/frontend/api/v1/users_internal_test.go
@@ -85,7 +85,8 @@ func TestOIDCWorkspaceAccessSyncEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			a := &API{config: tt.config, licenseManager: tt.licenseManager}
-			assert.Equal(t, tt.want, a.oidcWorkspaceAccessSyncEnabled())
+			mapping := a.currentOIDCRoleMapping(context.Background())
+			assert.Equal(t, tt.want, a.oidcWorkspaceAccessSyncEnabled(mapping))
 		})
 	}
 }
@@ -94,6 +95,34 @@ func TestListUsersReportsOIDCWorkspaceAccessSyncState(t *testing.T) {
 	t.Parallel()
 
 	a := &API{config: newOIDCWorkspaceSyncConfig(), authService: listUsersAuthService{}}
+	ctx := auth.WithUser(context.Background(), &auth.User{Role: auth.RoleAdmin})
+
+	result, err := a.ListUsers(ctx, generatedapi.ListUsersRequestObject{})
+	require.NoError(t, err)
+	response, ok := result.(generatedapi.ListUsers200JSONResponse)
+	require.True(t, ok)
+	require.NotNil(t, response.OidcWorkspaceAccessSyncEnabled)
+	assert.True(t, *response.OidcWorkspaceAccessSyncEnabled)
+	assert.Equal(t, []generatedapi.UserAuthProvider{generatedapi.UserAuthProviderOidc}, response.ManagedRoleProviders)
+	assert.Equal(t, []generatedapi.UserAuthProvider{generatedapi.UserAuthProviderOidc}, response.ManagedWorkspaceAccessProviders)
+}
+
+func TestListUsersReportsCurrentOIDCPolicy(t *testing.T) {
+	t.Parallel()
+
+	cfg := newOIDCWorkspaceSyncConfig()
+	cfg.Server.Auth.OIDC.RoleMapping.DefaultWorkspaceAccess = config.OIDCDefaultWorkspaceAccessAll
+	a := &API{
+		config:      cfg,
+		authService: listUsersAuthService{},
+		oidcPolicyLoader: func() (config.OIDCProvisioningPolicy, error) {
+			return config.OIDCProvisioningPolicy{
+				RoleMapping: config.OIDCRoleMapping{
+					DefaultWorkspaceAccess: config.OIDCDefaultWorkspaceAccessNone,
+				},
+			}, nil
+		},
+	}
 	ctx := auth.WithUser(context.Background(), &auth.User{Role: auth.RoleAdmin})
 
 	result, err := a.ListUsers(ctx, generatedapi.ListUsersRequestObject{})

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -190,6 +190,42 @@ func toOIDCProvisioningPolicy(policy config.OIDCProvisioningPolicy) oidcprovisio
 	}
 }
 
+func toConfigOIDCWorkspaceMappings(mappings map[string][]oidcprovision.WorkspaceGrantConfig) map[string][]config.OIDCWorkspaceGrant {
+	if len(mappings) == 0 {
+		return nil
+	}
+	result := make(map[string][]config.OIDCWorkspaceGrant, len(mappings))
+	for group, grants := range mappings {
+		converted := make([]config.OIDCWorkspaceGrant, len(grants))
+		for i, grant := range grants {
+			converted[i] = config.OIDCWorkspaceGrant{
+				Workspace: grant.Workspace,
+				Role:      grant.Role,
+			}
+		}
+		result[group] = converted
+	}
+	return result
+}
+
+func toConfigOIDCProvisioningPolicy(policy oidcprovision.ProvisioningPolicy) config.OIDCProvisioningPolicy {
+	return config.OIDCProvisioningPolicy{
+		AutoSignup:     policy.AutoSignup,
+		AllowedDomains: policy.AllowedDomains,
+		Whitelist:      policy.Whitelist,
+		RoleMapping: config.OIDCRoleMapping{
+			GroupsClaim:            policy.RoleMapping.GroupsClaim,
+			GroupMappings:          policy.RoleMapping.GroupMappings,
+			WorkspaceMappings:      toConfigOIDCWorkspaceMappings(policy.RoleMapping.WorkspaceMappings),
+			DefaultWorkspaceAccess: policy.RoleMapping.DefaultWorkspaceAccess,
+			RoleAttributePath:      policy.RoleMapping.RoleAttributePath,
+			RoleAttributeStrict:    policy.RoleMapping.RoleAttributeStrict,
+			SkipOrgRoleSync:        policy.RoleMapping.SkipOrgRoleSync,
+			DefaultRole:            string(policy.RoleMapping.DefaultRole),
+		},
+	}
+}
+
 func toTrustedProxyGroupMappings(mappings map[string]string) map[string]authmodel.Role {
 	if len(mappings) == 0 {
 		return nil
@@ -364,7 +400,6 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 				cfg.Paths.ConfigFilesUsed,
 				initialPolicy,
 			)
-			apiOpts = append(apiOpts, apiv1.WithOIDCProvisioningPolicyLoader(policyLoader.Load))
 
 			provisionCfg := oidcprovision.Config{
 				Issuer:         oidcCfg.Issuer,
@@ -386,6 +421,11 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 			if err != nil {
 				return nil, fmt.Errorf("failed to create OIDC provisioning service: %w", err)
 			}
+			apiOpts = append(apiOpts, apiv1.WithOIDCProvisioningPolicyLoader(
+				func() (config.OIDCProvisioningPolicy, error) {
+					return toConfigOIDCProvisioningPolicy(provisionSvc.CurrentPolicy()), nil
+				},
+			))
 
 			builtinOIDCCfg, err = auth.InitBuiltinOIDCConfig(
 				ctx,

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -172,6 +172,24 @@ func toOIDCWorkspaceMappings(mappings map[string][]config.OIDCWorkspaceGrant) ma
 	return result
 }
 
+func toOIDCProvisioningPolicy(policy config.OIDCProvisioningPolicy) oidcprovision.ProvisioningPolicy {
+	return oidcprovision.ProvisioningPolicy{
+		AutoSignup:     policy.AutoSignup,
+		AllowedDomains: policy.AllowedDomains,
+		Whitelist:      policy.Whitelist,
+		RoleMapping: oidcprovision.RoleMapperConfig{
+			GroupsClaim:            policy.RoleMapping.GroupsClaim,
+			GroupMappings:          policy.RoleMapping.GroupMappings,
+			WorkspaceMappings:      toOIDCWorkspaceMappings(policy.RoleMapping.WorkspaceMappings),
+			DefaultWorkspaceAccess: policy.RoleMapping.DefaultWorkspaceAccess,
+			RoleAttributePath:      policy.RoleMapping.RoleAttributePath,
+			RoleAttributeStrict:    policy.RoleMapping.RoleAttributeStrict,
+			SkipOrgRoleSync:        policy.RoleMapping.SkipOrgRoleSync,
+			DefaultRole:            authmodel.Role(policy.RoleMapping.DefaultRole),
+		},
+	}
+}
+
 func toTrustedProxyGroupMappings(mappings map[string]string) map[string]authmodel.Role {
 	if len(mappings) == 0 {
 		return nil
@@ -340,22 +358,27 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 		if oidcCfg.IsConfigured() {
 			oidcEnabled = true
 			oidcButtonLabel = oidcCfg.ButtonLabel
+			initialPolicy := oidcCfg.ProvisioningPolicy()
+			initialProvisioningPolicy := toOIDCProvisioningPolicy(initialPolicy)
+			policyLoader := config.NewOIDCProvisioningPolicyLoader(
+				cfg.Paths.ConfigFilesUsed,
+				initialPolicy,
+			)
+			apiOpts = append(apiOpts, apiv1.WithOIDCProvisioningPolicyLoader(policyLoader.Load))
 
 			provisionCfg := oidcprovision.Config{
 				Issuer:         oidcCfg.Issuer,
-				AutoSignup:     oidcCfg.AutoSignup,
-				DefaultRole:    authmodel.Role(oidcCfg.RoleMapping.DefaultRole),
-				AllowedDomains: oidcCfg.AllowedDomains,
-				Whitelist:      oidcCfg.Whitelist,
-				RoleMapping: oidcprovision.RoleMapperConfig{
-					GroupsClaim:            oidcCfg.RoleMapping.GroupsClaim,
-					GroupMappings:          oidcCfg.RoleMapping.GroupMappings,
-					WorkspaceMappings:      toOIDCWorkspaceMappings(oidcCfg.RoleMapping.WorkspaceMappings),
-					DefaultWorkspaceAccess: oidcCfg.RoleMapping.DefaultWorkspaceAccess,
-					RoleAttributePath:      oidcCfg.RoleMapping.RoleAttributePath,
-					RoleAttributeStrict:    oidcCfg.RoleMapping.RoleAttributeStrict,
-					SkipOrgRoleSync:        oidcCfg.RoleMapping.SkipOrgRoleSync,
-					DefaultRole:            authmodel.Role(oidcCfg.RoleMapping.DefaultRole),
+				AutoSignup:     initialProvisioningPolicy.AutoSignup,
+				DefaultRole:    initialProvisioningPolicy.RoleMapping.DefaultRole,
+				AllowedDomains: initialProvisioningPolicy.AllowedDomains,
+				Whitelist:      initialProvisioningPolicy.Whitelist,
+				RoleMapping:    initialProvisioningPolicy.RoleMapping,
+				LoadPolicy: func(context.Context) (oidcprovision.ProvisioningPolicy, error) {
+					policy, err := policyLoader.Load()
+					if err != nil {
+						return oidcprovision.ProvisioningPolicy{}, err
+					}
+					return toOIDCProvisioningPolicy(policy), nil
 				},
 			}
 			provisionCfg.WorkspaceExists = workspaceExists

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -172,8 +172,8 @@ func toOIDCWorkspaceMappings(mappings map[string][]config.OIDCWorkspaceGrant) ma
 	return result
 }
 
-func toOIDCProvisioningPolicy(policy config.OIDCProvisioningPolicy) oidcprovision.ProvisioningPolicy {
-	return oidcprovision.ProvisioningPolicy{
+func toOIDCPolicy(policy config.OIDCPolicy) oidcprovision.Policy {
+	return oidcprovision.Policy{
 		AutoSignup:     policy.AutoSignup,
 		AllowedDomains: policy.AllowedDomains,
 		Whitelist:      policy.Whitelist,
@@ -208,21 +208,16 @@ func toConfigOIDCWorkspaceMappings(mappings map[string][]oidcprovision.Workspace
 	return result
 }
 
-func toConfigOIDCProvisioningPolicy(policy oidcprovision.ProvisioningPolicy) config.OIDCProvisioningPolicy {
-	return config.OIDCProvisioningPolicy{
-		AutoSignup:     policy.AutoSignup,
-		AllowedDomains: policy.AllowedDomains,
-		Whitelist:      policy.Whitelist,
-		RoleMapping: config.OIDCRoleMapping{
-			GroupsClaim:            policy.RoleMapping.GroupsClaim,
-			GroupMappings:          policy.RoleMapping.GroupMappings,
-			WorkspaceMappings:      toConfigOIDCWorkspaceMappings(policy.RoleMapping.WorkspaceMappings),
-			DefaultWorkspaceAccess: policy.RoleMapping.DefaultWorkspaceAccess,
-			RoleAttributePath:      policy.RoleMapping.RoleAttributePath,
-			RoleAttributeStrict:    policy.RoleMapping.RoleAttributeStrict,
-			SkipOrgRoleSync:        policy.RoleMapping.SkipOrgRoleSync,
-			DefaultRole:            string(policy.RoleMapping.DefaultRole),
-		},
+func toConfigOIDCMapping(mapping oidcprovision.RoleMapperConfig) config.OIDCRoleMapping {
+	return config.OIDCRoleMapping{
+		GroupsClaim:            mapping.GroupsClaim,
+		GroupMappings:          mapping.GroupMappings,
+		WorkspaceMappings:      toConfigOIDCWorkspaceMappings(mapping.WorkspaceMappings),
+		DefaultWorkspaceAccess: mapping.DefaultWorkspaceAccess,
+		RoleAttributePath:      mapping.RoleAttributePath,
+		RoleAttributeStrict:    mapping.RoleAttributeStrict,
+		SkipOrgRoleSync:        mapping.SkipOrgRoleSync,
+		DefaultRole:            string(mapping.DefaultRole),
 	}
 }
 
@@ -394,26 +389,26 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 		if oidcCfg.IsConfigured() {
 			oidcEnabled = true
 			oidcButtonLabel = oidcCfg.ButtonLabel
-			initialPolicy := oidcCfg.ProvisioningPolicy()
-			initialProvisioningPolicy := toOIDCProvisioningPolicy(initialPolicy)
-			policyLoader := config.NewOIDCProvisioningPolicyLoader(
+			configPolicy := oidcCfg.Policy()
+			policy := toOIDCPolicy(configPolicy)
+			loader := config.NewOIDCPolicyLoader(
 				cfg.Paths.ConfigFilesUsed,
-				initialPolicy,
+				configPolicy,
 			)
 
 			provisionCfg := oidcprovision.Config{
 				Issuer:         oidcCfg.Issuer,
-				AutoSignup:     initialProvisioningPolicy.AutoSignup,
-				DefaultRole:    initialProvisioningPolicy.RoleMapping.DefaultRole,
-				AllowedDomains: initialProvisioningPolicy.AllowedDomains,
-				Whitelist:      initialProvisioningPolicy.Whitelist,
-				RoleMapping:    initialProvisioningPolicy.RoleMapping,
-				LoadPolicy: func(context.Context) (oidcprovision.ProvisioningPolicy, error) {
-					policy, err := policyLoader.Load()
+				AutoSignup:     policy.AutoSignup,
+				DefaultRole:    policy.RoleMapping.DefaultRole,
+				AllowedDomains: policy.AllowedDomains,
+				Whitelist:      policy.Whitelist,
+				RoleMapping:    policy.RoleMapping,
+				LoadPolicy: func(context.Context) (oidcprovision.Policy, error) {
+					policy, err := loader.Load()
 					if err != nil {
-						return oidcprovision.ProvisioningPolicy{}, err
+						return oidcprovision.Policy{}, err
 					}
-					return toOIDCProvisioningPolicy(policy), nil
+					return toOIDCPolicy(policy), nil
 				},
 			}
 			provisionCfg.WorkspaceExists = workspaceExists
@@ -421,9 +416,9 @@ func NewServer(ctx context.Context, cfg *config.Config, dr exec.DAGStore, drs ex
 			if err != nil {
 				return nil, fmt.Errorf("failed to create OIDC provisioning service: %w", err)
 			}
-			apiOpts = append(apiOpts, apiv1.WithOIDCProvisioningPolicyLoader(
-				func() (config.OIDCProvisioningPolicy, error) {
-					return toConfigOIDCProvisioningPolicy(provisionSvc.CurrentPolicy()), nil
+			apiOpts = append(apiOpts, apiv1.WithOIDCRoleMapping(
+				func() config.OIDCRoleMapping {
+					return toConfigOIDCMapping(provisionSvc.RoleMapping())
 				},
 			))
 

--- a/internal/service/oidcprovision/service.go
+++ b/internal/service/oidcprovision/service.go
@@ -27,7 +27,20 @@ var (
 	ErrAutoSignupDisabled = errors.New("automatic account creation is disabled, contact administrator")
 	// ErrEmailRequired is returned when the email claim is not provided by the identity provider.
 	ErrEmailRequired = errors.New("email claim is required but not provided by identity provider")
+	// ErrPolicyUnavailable is returned when the current OIDC provisioning policy cannot be loaded.
+	ErrPolicyUnavailable = errors.New("authorization policy is unavailable")
 )
+
+// ProvisioningPolicy contains the OIDC settings evaluated for a login.
+type ProvisioningPolicy struct {
+	AutoSignup     bool
+	AllowedDomains []string
+	Whitelist      []string
+	RoleMapping    RoleMapperConfig
+}
+
+// PolicyLoader returns the current OIDC provisioning policy.
+type PolicyLoader func(context.Context) (ProvisioningPolicy, error)
 
 // Config holds the configuration for the OIDC provisioning service.
 type Config struct {
@@ -48,6 +61,9 @@ type Config struct {
 	// WorkspaceExists checks whether a configured workspace currently exists.
 	// Missing workspaces are reported but do not prevent authentication.
 	WorkspaceExists func(context.Context, string) (bool, error)
+	// LoadPolicy resolves the provisioning policy used for each login.
+	// When unset, the static policy in Config is used.
+	LoadPolicy PolicyLoader
 }
 
 // OIDCClaims contains the claims extracted from an OIDC ID token.
@@ -66,10 +82,15 @@ type OIDCClaims struct {
 
 // Service provides OIDC user provisioning functionality.
 type Service struct {
-	userStore  auth.AuthorizationSyncUserStore
-	config     Config
+	userStore    auth.AuthorizationSyncUserStore
+	config       Config
+	staticPolicy ProvisioningPolicy
+	logger       *slog.Logger
+}
+
+type policySnapshot struct {
+	ProvisioningPolicy
 	roleMapper *RoleMapper
-	logger     *slog.Logger
 }
 
 // New creates a new OIDC provisioning service.
@@ -81,16 +102,22 @@ func New(userStore auth.UserStore, config Config) (*Service, error) {
 	if config.RoleMapping.DefaultRole == auth.RoleNone {
 		config.RoleMapping.DefaultRole = config.DefaultRole
 	}
-	roleMapper, err := NewRoleMapper(config.RoleMapping)
+	staticPolicy := ProvisioningPolicy{
+		AutoSignup:     config.AutoSignup,
+		AllowedDomains: config.AllowedDomains,
+		Whitelist:      config.Whitelist,
+		RoleMapping:    config.RoleMapping,
+	}
+	_, err := newPolicySnapshot(staticPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role mapper: %w", err)
 	}
 
 	return &Service{
-		userStore:  authorizationStore,
-		config:     config,
-		roleMapper: roleMapper,
-		logger:     slog.Default().With(slog.String("service", "oidcprovision")),
+		userStore:    authorizationStore,
+		config:       config,
+		staticPolicy: staticPolicy,
+		logger:       slog.Default().With(slog.String("service", "oidcprovision")),
 	}, nil
 }
 
@@ -102,8 +129,15 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 		return nil, false, ErrEmailRequired
 	}
 
+	policy, err := s.loadPolicy(ctx)
+	if err != nil {
+		s.logger.Error("failed to load OIDC authorization policy",
+			slog.String("error", err.Error()))
+		return nil, false, ErrPolicyUnavailable
+	}
+
 	// 1. Check access control (whitelist + allowedDomains)
-	if !s.isEmailAllowed(claims.Email) {
+	if !isEmailAllowed(policy.ProvisioningPolicy, claims.Email) {
 		s.logger.Warn("OIDC login rejected: email not allowed",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
 			slog.String("subject", claims.Subject))
@@ -122,16 +156,16 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 		}
 
 		// Synchronize mapped authorization, or enforce strict matching when synchronization is disabled.
-		if s.config.RoleMapping.SkipOrgRoleSync {
-			if err := s.validateStrictMapping(claims); err != nil {
+		if policy.RoleMapping.SkipOrgRoleSync {
+			if err := validateStrictMapping(policy, claims); err != nil {
 				s.logger.Warn("OIDC login rejected: authorization mapping failed",
 					slog.String("user_id", user.ID),
 					slog.String("error", err.Error()))
 				return nil, false, err
 			}
 		} else {
-			if err := s.syncUserAccess(ctx, user, claims); err != nil {
-				if s.roleMapper.WorkspaceAccessPolicyActive() ||
+			if err := s.syncUserAccess(ctx, policy, user, claims); err != nil {
+				if policy.roleMapper.WorkspaceAccessPolicyActive() ||
 					errors.Is(err, ErrNoRoleFound) ||
 					errors.Is(err, auth.ErrUserDisabled) {
 					s.logger.Warn("OIDC login rejected: authorization mapping failed",
@@ -157,7 +191,7 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	}
 
 	// 4. Check if auto-signup is enabled
-	if !s.config.AutoSignup {
+	if !policy.AutoSignup {
 		s.logger.Info("OIDC login rejected: auto-signup disabled",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
 			slog.String("subject", claims.Subject))
@@ -165,7 +199,7 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	}
 
 	// 5. Determine authorization for the new user.
-	role, workspaceAccess, err := s.determineAccess(ctx, claims)
+	role, workspaceAccess, err := s.determineAccess(ctx, policy, claims)
 	if err != nil {
 		s.logger.Warn("OIDC login rejected: authorization mapping failed",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
@@ -217,18 +251,45 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	return user, true, nil // New user created
 }
 
-func (s *Service) validateStrictMapping(claims OIDCClaims) error {
-	if !s.config.RoleMapping.RoleAttributeStrict || !s.roleMapper.IsConfigured() {
+func (s *Service) loadPolicy(ctx context.Context) (*policySnapshot, error) {
+	policy := s.staticPolicy
+	if s.config.LoadPolicy != nil {
+		loaded, err := s.config.LoadPolicy(ctx)
+		if err != nil {
+			return nil, err
+		}
+		policy = loaded
+	}
+	return newPolicySnapshot(policy)
+}
+
+func newPolicySnapshot(policy ProvisioningPolicy) (*policySnapshot, error) {
+	roleMapper, err := NewRoleMapper(policy.RoleMapping)
+	if err != nil {
+		return nil, err
+	}
+	return &policySnapshot{
+		ProvisioningPolicy: policy,
+		roleMapper:         roleMapper,
+	}, nil
+}
+
+func validateStrictMapping(policy *policySnapshot, claims OIDCClaims) error {
+	if !policy.RoleMapping.RoleAttributeStrict || !policy.roleMapper.IsConfigured() {
 		return nil
 	}
-	_, _, err := s.roleMapper.MapAccess(claims.RawClaims)
+	_, _, err := policy.roleMapper.MapAccess(claims.RawClaims)
 	return err
 }
 
 // determineAccess determines authorization for a user based on OIDC claims.
-func (s *Service) determineAccess(ctx context.Context, claims OIDCClaims) (auth.Role, *auth.WorkspaceAccess, error) {
-	if s.roleMapper.IsConfigured() {
-		role, workspaceAccess, err := s.roleMapper.MapAccess(claims.RawClaims)
+func (s *Service) determineAccess(
+	ctx context.Context,
+	policy *policySnapshot,
+	claims OIDCClaims,
+) (auth.Role, *auth.WorkspaceAccess, error) {
+	if policy.roleMapper.IsConfigured() {
+		role, workspaceAccess, err := policy.roleMapper.MapAccess(claims.RawClaims)
 		if err != nil {
 			return "", nil, err
 		}
@@ -236,25 +297,30 @@ func (s *Service) determineAccess(ctx context.Context, claims OIDCClaims) (auth.
 		return role, workspaceAccess, nil
 	}
 
-	return s.config.DefaultRole, auth.AllWorkspaceAccess(), nil
+	return policy.RoleMapping.DefaultRole, auth.AllWorkspaceAccess(), nil
 }
 
 // syncUserAccess updates mapped authorization without exposing unpersisted values.
-func (s *Service) syncUserAccess(ctx context.Context, user *auth.User, claims OIDCClaims) error {
-	if !s.roleMapper.IsConfigured() {
+func (s *Service) syncUserAccess(
+	ctx context.Context,
+	policy *policySnapshot,
+	user *auth.User,
+	claims OIDCClaims,
+) error {
+	if !policy.roleMapper.IsConfigured() {
 		return nil
 	}
 
-	accessPolicyActive := s.roleMapper.WorkspaceAccessPolicyActive()
+	accessPolicyActive := policy.roleMapper.WorkspaceAccessPolicyActive()
 	var (
 		newRole   auth.Role
 		newAccess *auth.WorkspaceAccess
 		err       error
 	)
 	if accessPolicyActive {
-		newRole, newAccess, err = s.determineAccess(ctx, claims)
+		newRole, newAccess, err = s.determineAccess(ctx, policy, claims)
 	} else {
-		newRole, err = s.roleMapper.MapRole(claims.RawClaims)
+		newRole, err = policy.roleMapper.MapRole(claims.RawClaims)
 	}
 	if err != nil {
 		return err
@@ -342,14 +408,14 @@ func canonicalWorkspaceAccess(workspaceAccess *auth.WorkspaceAccess) auth.Worksp
 //   - If allowedDomains is not empty and email domain is in allowedDomains: ALLOW
 //   - If either whitelist or allowedDomains is configured but email doesn't match: DENY
 //   - If both whitelist and allowedDomains are empty: ALLOW (no restrictions)
-func (s *Service) isEmailAllowed(email string) bool {
+func isEmailAllowed(policy ProvisioningPolicy, email string) bool {
 	email = strings.ToLower(email)
-	hasWhitelist := len(s.config.Whitelist) > 0
-	hasAllowedDomains := len(s.config.AllowedDomains) > 0
+	hasWhitelist := len(policy.Whitelist) > 0
+	hasAllowedDomains := len(policy.AllowedDomains) > 0
 
 	// Check whitelist first (takes precedence)
 	if hasWhitelist {
-		for _, allowed := range s.config.Whitelist {
+		for _, allowed := range policy.Whitelist {
 			if strings.EqualFold(email, allowed) {
 				return true
 			}
@@ -359,7 +425,7 @@ func (s *Service) isEmailAllowed(email string) bool {
 	// Check allowed domains
 	if hasAllowedDomains {
 		domain := stringutil.ExtractEmailDomain(email)
-		for _, allowed := range s.config.AllowedDomains {
+		for _, allowed := range policy.AllowedDomains {
 			if strings.EqualFold(domain, allowed) {
 				return true
 			}

--- a/internal/service/oidcprovision/service.go
+++ b/internal/service/oidcprovision/service.go
@@ -11,7 +11,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/auth"
@@ -84,8 +84,7 @@ type OIDCClaims struct {
 type Service struct {
 	userStore auth.AuthorizationSyncUserStore
 	config    Config
-	policyMu  sync.Mutex
-	policy    *policySnapshot
+	policy    atomic.Pointer[policySnapshot]
 	logger    *slog.Logger
 }
 
@@ -114,12 +113,13 @@ func New(userStore auth.UserStore, config Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create role mapper: %w", err)
 	}
 
-	return &Service{
+	service := &Service{
 		userStore: authorizationStore,
 		config:    config,
-		policy:    policy,
 		logger:    slog.Default().With(slog.String("service", "oidcprovision")),
-	}, nil
+	}
+	service.policy.Store(policy)
+	return service, nil
 }
 
 // ProcessLogin handles OIDC authentication with auto-provisioning.
@@ -248,34 +248,29 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 }
 
 func (s *Service) loadPolicy(ctx context.Context) *policySnapshot {
-	s.policyMu.Lock()
-	defer s.policyMu.Unlock()
-
 	if s.config.LoadPolicy == nil {
-		return s.policy
+		return s.policy.Load()
 	}
 
 	loaded, err := s.config.LoadPolicy(ctx)
 	if err != nil {
 		s.logger.Warn("OIDC authorization policy reload rejected",
 			slog.String("error", err.Error()))
-		return s.policy
+		return s.policy.Load()
 	}
 	policy, err := newPolicySnapshot(loaded)
 	if err != nil {
 		s.logger.Warn("OIDC authorization policy reload rejected",
 			slog.String("error", err.Error()))
-		return s.policy
+		return s.policy.Load()
 	}
-	s.policy = policy
+	s.policy.Store(policy)
 	return policy
 }
 
 // CurrentPolicy returns the latest successfully loaded provisioning policy.
 func (s *Service) CurrentPolicy() ProvisioningPolicy {
-	s.policyMu.Lock()
-	defer s.policyMu.Unlock()
-	return s.policy.ProvisioningPolicy
+	return s.policy.Load().ProvisioningPolicy
 }
 
 func newPolicySnapshot(policy ProvisioningPolicy) (*policySnapshot, error) {

--- a/internal/service/oidcprovision/service.go
+++ b/internal/service/oidcprovision/service.go
@@ -30,16 +30,16 @@ var (
 	ErrEmailRequired = errors.New("email claim is required but not provided by identity provider")
 )
 
-// ProvisioningPolicy contains the OIDC settings evaluated for a login.
-type ProvisioningPolicy struct {
+// Policy contains the OIDC settings evaluated for a login.
+type Policy struct {
 	AutoSignup     bool
 	AllowedDomains []string
 	Whitelist      []string
 	RoleMapping    RoleMapperConfig
 }
 
-// PolicyLoader returns the current OIDC provisioning policy.
-type PolicyLoader func(context.Context) (ProvisioningPolicy, error)
+// PolicyLoader returns the current OIDC policy.
+type PolicyLoader func(context.Context) (Policy, error)
 
 // Config holds the configuration for the OIDC provisioning service.
 type Config struct {
@@ -60,7 +60,7 @@ type Config struct {
 	// WorkspaceExists checks whether a configured workspace currently exists.
 	// Missing workspaces are reported but do not prevent authentication.
 	WorkspaceExists func(context.Context, string) (bool, error)
-	// LoadPolicy resolves the provisioning policy used for each login.
+	// LoadPolicy resolves the policy used for each login.
 	// When unset, the static policy in Config is used.
 	// A failed load leaves the latest valid policy active.
 	LoadPolicy PolicyLoader
@@ -89,7 +89,7 @@ type Service struct {
 }
 
 type policySnapshot struct {
-	ProvisioningPolicy
+	Policy
 	roleMapper *RoleMapper
 }
 
@@ -102,13 +102,13 @@ func New(userStore auth.UserStore, config Config) (*Service, error) {
 	if config.RoleMapping.DefaultRole == auth.RoleNone {
 		config.RoleMapping.DefaultRole = config.DefaultRole
 	}
-	staticPolicy := ProvisioningPolicy{
+	initialPolicy := Policy{
 		AutoSignup:     config.AutoSignup,
 		AllowedDomains: config.AllowedDomains,
 		Whitelist:      config.Whitelist,
 		RoleMapping:    config.RoleMapping,
 	}
-	policy, err := newPolicySnapshot(staticPolicy)
+	policy, err := newPolicySnapshot(initialPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role mapper: %w", err)
 	}
@@ -130,10 +130,10 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 		return nil, false, ErrEmailRequired
 	}
 
-	policy := s.loadPolicy(ctx)
+	snapshot := s.loadPolicy(ctx)
 
 	// 1. Check access control (whitelist + allowedDomains)
-	if !isEmailAllowed(policy.ProvisioningPolicy, claims.Email) {
+	if !isEmailAllowed(snapshot.Policy, claims.Email) {
 		s.logger.Warn("OIDC login rejected: email not allowed",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
 			slog.String("subject", claims.Subject))
@@ -152,16 +152,16 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 		}
 
 		// Synchronize mapped authorization, or enforce strict matching when synchronization is disabled.
-		if policy.RoleMapping.SkipOrgRoleSync {
-			if err := validateStrictMapping(policy, claims); err != nil {
+		if snapshot.RoleMapping.SkipOrgRoleSync {
+			if err := validateStrictMapping(snapshot, claims); err != nil {
 				s.logger.Warn("OIDC login rejected: authorization mapping failed",
 					slog.String("user_id", user.ID),
 					slog.String("error", err.Error()))
 				return nil, false, err
 			}
 		} else {
-			if err := s.syncUserAccess(ctx, policy, user, claims); err != nil {
-				if policy.roleMapper.WorkspaceAccessPolicyActive() ||
+			if err := s.syncUserAccess(ctx, snapshot, user, claims); err != nil {
+				if snapshot.roleMapper.WorkspaceAccessPolicyActive() ||
 					errors.Is(err, ErrNoRoleFound) ||
 					errors.Is(err, auth.ErrUserDisabled) {
 					s.logger.Warn("OIDC login rejected: authorization mapping failed",
@@ -187,7 +187,7 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	}
 
 	// 4. Check if auto-signup is enabled
-	if !policy.AutoSignup {
+	if !snapshot.AutoSignup {
 		s.logger.Info("OIDC login rejected: auto-signup disabled",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
 			slog.String("subject", claims.Subject))
@@ -195,7 +195,7 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	}
 
 	// 5. Determine authorization for the new user.
-	role, workspaceAccess, err := s.determineAccess(ctx, policy, claims)
+	role, workspaceAccess, err := s.determineAccess(ctx, snapshot, claims)
 	if err != nil {
 		s.logger.Warn("OIDC login rejected: authorization mapping failed",
 			slog.String("email_domain", stringutil.ExtractEmailDomain(claims.Email)),
@@ -258,48 +258,48 @@ func (s *Service) loadPolicy(ctx context.Context) *policySnapshot {
 			slog.String("error", err.Error()))
 		return s.policy.Load()
 	}
-	policy, err := newPolicySnapshot(loaded)
+	snapshot, err := newPolicySnapshot(loaded)
 	if err != nil {
 		s.logger.Warn("OIDC authorization policy reload rejected",
 			slog.String("error", err.Error()))
 		return s.policy.Load()
 	}
-	s.policy.Store(policy)
-	return policy
+	s.policy.Store(snapshot)
+	return snapshot
 }
 
-// CurrentPolicy returns the latest successfully loaded provisioning policy.
-func (s *Service) CurrentPolicy() ProvisioningPolicy {
-	return s.policy.Load().ProvisioningPolicy
+// RoleMapping returns the latest successfully loaded role mapping.
+func (s *Service) RoleMapping() RoleMapperConfig {
+	return s.policy.Load().RoleMapping
 }
 
-func newPolicySnapshot(policy ProvisioningPolicy) (*policySnapshot, error) {
+func newPolicySnapshot(policy Policy) (*policySnapshot, error) {
 	roleMapper, err := NewRoleMapper(policy.RoleMapping)
 	if err != nil {
 		return nil, err
 	}
 	return &policySnapshot{
-		ProvisioningPolicy: policy,
-		roleMapper:         roleMapper,
+		Policy:     policy,
+		roleMapper: roleMapper,
 	}, nil
 }
 
-func validateStrictMapping(policy *policySnapshot, claims OIDCClaims) error {
-	if !policy.RoleMapping.RoleAttributeStrict || !policy.roleMapper.IsConfigured() {
+func validateStrictMapping(snapshot *policySnapshot, claims OIDCClaims) error {
+	if !snapshot.RoleMapping.RoleAttributeStrict || !snapshot.roleMapper.IsConfigured() {
 		return nil
 	}
-	_, _, err := policy.roleMapper.MapAccess(claims.RawClaims)
+	_, _, err := snapshot.roleMapper.MapAccess(claims.RawClaims)
 	return err
 }
 
 // determineAccess determines authorization for a user based on OIDC claims.
 func (s *Service) determineAccess(
 	ctx context.Context,
-	policy *policySnapshot,
+	snapshot *policySnapshot,
 	claims OIDCClaims,
 ) (auth.Role, *auth.WorkspaceAccess, error) {
-	if policy.roleMapper.IsConfigured() {
-		role, workspaceAccess, err := policy.roleMapper.MapAccess(claims.RawClaims)
+	if snapshot.roleMapper.IsConfigured() {
+		role, workspaceAccess, err := snapshot.roleMapper.MapAccess(claims.RawClaims)
 		if err != nil {
 			return "", nil, err
 		}
@@ -307,30 +307,30 @@ func (s *Service) determineAccess(
 		return role, workspaceAccess, nil
 	}
 
-	return policy.RoleMapping.DefaultRole, auth.AllWorkspaceAccess(), nil
+	return snapshot.RoleMapping.DefaultRole, auth.AllWorkspaceAccess(), nil
 }
 
 // syncUserAccess updates mapped authorization without exposing unpersisted values.
 func (s *Service) syncUserAccess(
 	ctx context.Context,
-	policy *policySnapshot,
+	snapshot *policySnapshot,
 	user *auth.User,
 	claims OIDCClaims,
 ) error {
-	if !policy.roleMapper.IsConfigured() {
+	if !snapshot.roleMapper.IsConfigured() {
 		return nil
 	}
 
-	accessPolicyActive := policy.roleMapper.WorkspaceAccessPolicyActive()
+	accessPolicyActive := snapshot.roleMapper.WorkspaceAccessPolicyActive()
 	var (
 		newRole   auth.Role
 		newAccess *auth.WorkspaceAccess
 		err       error
 	)
 	if accessPolicyActive {
-		newRole, newAccess, err = s.determineAccess(ctx, policy, claims)
+		newRole, newAccess, err = s.determineAccess(ctx, snapshot, claims)
 	} else {
-		newRole, err = policy.roleMapper.MapRole(claims.RawClaims)
+		newRole, err = snapshot.roleMapper.MapRole(claims.RawClaims)
 	}
 	if err != nil {
 		return err
@@ -418,7 +418,7 @@ func canonicalWorkspaceAccess(workspaceAccess *auth.WorkspaceAccess) auth.Worksp
 //   - If allowedDomains is not empty and email domain is in allowedDomains: ALLOW
 //   - If either whitelist or allowedDomains is configured but email doesn't match: DENY
 //   - If both whitelist and allowedDomains are empty: ALLOW (no restrictions)
-func isEmailAllowed(policy ProvisioningPolicy, email string) bool {
+func isEmailAllowed(policy Policy, email string) bool {
 	email = strings.ToLower(email)
 	hasWhitelist := len(policy.Whitelist) > 0
 	hasAllowedDomains := len(policy.AllowedDomains) > 0

--- a/internal/service/oidcprovision/service.go
+++ b/internal/service/oidcprovision/service.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/internal/auth"
@@ -27,8 +28,6 @@ var (
 	ErrAutoSignupDisabled = errors.New("automatic account creation is disabled, contact administrator")
 	// ErrEmailRequired is returned when the email claim is not provided by the identity provider.
 	ErrEmailRequired = errors.New("email claim is required but not provided by identity provider")
-	// ErrPolicyUnavailable is returned when the current OIDC provisioning policy cannot be loaded.
-	ErrPolicyUnavailable = errors.New("authorization policy is unavailable")
 )
 
 // ProvisioningPolicy contains the OIDC settings evaluated for a login.
@@ -63,6 +62,7 @@ type Config struct {
 	WorkspaceExists func(context.Context, string) (bool, error)
 	// LoadPolicy resolves the provisioning policy used for each login.
 	// When unset, the static policy in Config is used.
+	// A failed load leaves the latest valid policy active.
 	LoadPolicy PolicyLoader
 }
 
@@ -82,10 +82,11 @@ type OIDCClaims struct {
 
 // Service provides OIDC user provisioning functionality.
 type Service struct {
-	userStore    auth.AuthorizationSyncUserStore
-	config       Config
-	staticPolicy ProvisioningPolicy
-	logger       *slog.Logger
+	userStore auth.AuthorizationSyncUserStore
+	config    Config
+	policyMu  sync.Mutex
+	policy    *policySnapshot
+	logger    *slog.Logger
 }
 
 type policySnapshot struct {
@@ -108,16 +109,16 @@ func New(userStore auth.UserStore, config Config) (*Service, error) {
 		Whitelist:      config.Whitelist,
 		RoleMapping:    config.RoleMapping,
 	}
-	_, err := newPolicySnapshot(staticPolicy)
+	policy, err := newPolicySnapshot(staticPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role mapper: %w", err)
 	}
 
 	return &Service{
-		userStore:    authorizationStore,
-		config:       config,
-		staticPolicy: staticPolicy,
-		logger:       slog.Default().With(slog.String("service", "oidcprovision")),
+		userStore: authorizationStore,
+		config:    config,
+		policy:    policy,
+		logger:    slog.Default().With(slog.String("service", "oidcprovision")),
 	}, nil
 }
 
@@ -129,12 +130,7 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 		return nil, false, ErrEmailRequired
 	}
 
-	policy, err := s.loadPolicy(ctx)
-	if err != nil {
-		s.logger.Error("failed to load OIDC authorization policy",
-			slog.String("error", err.Error()))
-		return nil, false, ErrPolicyUnavailable
-	}
+	policy := s.loadPolicy(ctx)
 
 	// 1. Check access control (whitelist + allowedDomains)
 	if !isEmailAllowed(policy.ProvisioningPolicy, claims.Email) {
@@ -251,16 +247,35 @@ func (s *Service) ProcessLogin(ctx context.Context, claims OIDCClaims) (*auth.Us
 	return user, true, nil // New user created
 }
 
-func (s *Service) loadPolicy(ctx context.Context) (*policySnapshot, error) {
-	policy := s.staticPolicy
-	if s.config.LoadPolicy != nil {
-		loaded, err := s.config.LoadPolicy(ctx)
-		if err != nil {
-			return nil, err
-		}
-		policy = loaded
+func (s *Service) loadPolicy(ctx context.Context) *policySnapshot {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	if s.config.LoadPolicy == nil {
+		return s.policy
 	}
-	return newPolicySnapshot(policy)
+
+	loaded, err := s.config.LoadPolicy(ctx)
+	if err != nil {
+		s.logger.Warn("OIDC authorization policy reload rejected",
+			slog.String("error", err.Error()))
+		return s.policy
+	}
+	policy, err := newPolicySnapshot(loaded)
+	if err != nil {
+		s.logger.Warn("OIDC authorization policy reload rejected",
+			slog.String("error", err.Error()))
+		return s.policy
+	}
+	s.policy = policy
+	return policy
+}
+
+// CurrentPolicy returns the latest successfully loaded provisioning policy.
+func (s *Service) CurrentPolicy() ProvisioningPolicy {
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+	return s.policy.ProvisioningPolicy
 }
 
 func newPolicySnapshot(policy ProvisioningPolicy) (*policySnapshot, error) {

--- a/internal/service/oidcprovision/service_test.go
+++ b/internal/service/oidcprovision/service_test.go
@@ -870,37 +870,51 @@ func TestProcessLoginLoadsCurrentPolicy(t *testing.T) {
 	require.Equal(t, 2, loadCalls)
 }
 
-func TestProcessLoginRejectsUnavailablePolicyWithoutChangingAuthorization(t *testing.T) {
+func TestProcessLoginKeepsLastValidPolicyWhenReloadFails(t *testing.T) {
 	store := newMockUserStore()
-	existing := &auth.User{
-		ID:              "existing-id",
-		Username:        "existing",
-		Role:            auth.RoleManager,
-		WorkspaceAccess: auth.AllWorkspaceAccess(),
-		AuthProvider:    auth.AuthProviderOIDC,
-		OIDCIssuer:      "https://issuer.example.com",
-		OIDCSubject:     "subject",
+	validPolicy := ProvisioningPolicy{
+		AutoSignup: true,
+		RoleMapping: RoleMapperConfig{
+			GroupMappings: map[string]string{"team": "manager"},
+			DefaultRole:   auth.RoleViewer,
+		},
 	}
-	require.NoError(t, store.Create(context.Background(), existing))
+	loadCalls := 0
 
 	svc, err := New(store, Config{
 		Issuer:      "https://issuer.example.com",
+		AutoSignup:  true,
 		DefaultRole: auth.RoleViewer,
 		LoadPolicy: func(context.Context) (ProvisioningPolicy, error) {
+			loadCalls++
+			if loadCalls == 1 {
+				return validPolicy, nil
+			}
 			return ProvisioningPolicy{}, errors.New("invalid mapping")
 		},
 	})
 	require.NoError(t, err)
 
-	_, created, err := svc.ProcessLogin(context.Background(), OIDCClaims{
-		Subject:   "subject",
-		Email:     "existing@example.com",
-		RawClaims: map[string]any{"groups": []any{"team"}},
+	first, created, err := svc.ProcessLogin(context.Background(), OIDCClaims{
+		Subject:           "first-subject",
+		Email:             "first@example.com",
+		PreferredUsername: "first",
+		RawClaims:         map[string]any{"groups": []any{"team"}},
 	})
-	require.ErrorIs(t, err, ErrPolicyUnavailable)
-	require.False(t, created)
-	require.Equal(t, auth.RoleManager, existing.Role)
-	require.Zero(t, store.updateCalls)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, auth.RoleManager, first.Role)
+
+	second, created, err := svc.ProcessLogin(context.Background(), OIDCClaims{
+		Subject:           "second-subject",
+		Email:             "second@example.com",
+		PreferredUsername: "second",
+		RawClaims:         map[string]any{"groups": []any{"team"}},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, auth.RoleManager, second.Role)
+	require.Equal(t, 2, loadCalls)
 }
 
 type authorizationChangedAfterOIDCLookupStore struct {

--- a/internal/service/oidcprovision/service_test.go
+++ b/internal/service/oidcprovision/service_test.go
@@ -576,7 +576,7 @@ func TestIsEmailAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isEmailAllowed(ProvisioningPolicy{
+			result := isEmailAllowed(Policy{
 				AllowedDomains: tt.allowedDomains,
 				Whitelist:      tt.whitelist,
 			}, tt.email)
@@ -832,7 +832,7 @@ func TestProcessLogin_SyncsAuthorizationOnce(t *testing.T) {
 
 func TestProcessLoginLoadsCurrentPolicy(t *testing.T) {
 	store := newMockUserStore()
-	currentPolicy := ProvisioningPolicy{
+	currentPolicy := Policy{
 		AutoSignup: true,
 		RoleMapping: RoleMapperConfig{
 			GroupMappings: map[string]string{"team": "manager"},
@@ -844,7 +844,7 @@ func TestProcessLoginLoadsCurrentPolicy(t *testing.T) {
 		Issuer:      "https://issuer.example.com",
 		AutoSignup:  true,
 		DefaultRole: auth.RoleViewer,
-		LoadPolicy: func(context.Context) (ProvisioningPolicy, error) {
+		LoadPolicy: func(context.Context) (Policy, error) {
 			loadCalls++
 			return currentPolicy, nil
 		},
@@ -872,7 +872,7 @@ func TestProcessLoginLoadsCurrentPolicy(t *testing.T) {
 
 func TestProcessLoginKeepsLastValidPolicyWhenReloadFails(t *testing.T) {
 	store := newMockUserStore()
-	validPolicy := ProvisioningPolicy{
+	validPolicy := Policy{
 		AutoSignup: true,
 		RoleMapping: RoleMapperConfig{
 			GroupMappings: map[string]string{"team": "manager"},
@@ -885,12 +885,12 @@ func TestProcessLoginKeepsLastValidPolicyWhenReloadFails(t *testing.T) {
 		Issuer:      "https://issuer.example.com",
 		AutoSignup:  true,
 		DefaultRole: auth.RoleViewer,
-		LoadPolicy: func(context.Context) (ProvisioningPolicy, error) {
+		LoadPolicy: func(context.Context) (Policy, error) {
 			loadCalls++
 			if loadCalls == 1 {
 				return validPolicy, nil
 			}
-			return ProvisioningPolicy{}, errors.New("invalid mapping")
+			return Policy{}, errors.New("invalid mapping")
 		},
 	})
 	require.NoError(t, err)

--- a/internal/service/oidcprovision/service_test.go
+++ b/internal/service/oidcprovision/service_test.go
@@ -576,13 +576,10 @@ func TestIsEmailAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &Service{
-				config: Config{
-					AllowedDomains: tt.allowedDomains,
-					Whitelist:      tt.whitelist,
-				},
-			}
-			result := svc.isEmailAllowed(tt.email)
+			result := isEmailAllowed(ProvisioningPolicy{
+				AllowedDomains: tt.allowedDomains,
+				Whitelist:      tt.whitelist,
+			}, tt.email)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -831,6 +828,79 @@ func TestProcessLogin_SyncsAuthorizationOnce(t *testing.T) {
 	_, _, err = svc.ProcessLogin(context.Background(), claims)
 	require.NoError(t, err)
 	assert.Equal(t, 1, store.updateCalls)
+}
+
+func TestProcessLoginLoadsCurrentPolicy(t *testing.T) {
+	store := newMockUserStore()
+	currentPolicy := ProvisioningPolicy{
+		AutoSignup: true,
+		RoleMapping: RoleMapperConfig{
+			GroupMappings: map[string]string{"team": "manager"},
+			DefaultRole:   auth.RoleViewer,
+		},
+	}
+	loadCalls := 0
+	svc, err := New(store, Config{
+		Issuer:      "https://issuer.example.com",
+		AutoSignup:  true,
+		DefaultRole: auth.RoleViewer,
+		LoadPolicy: func(context.Context) (ProvisioningPolicy, error) {
+			loadCalls++
+			return currentPolicy, nil
+		},
+	})
+	require.NoError(t, err)
+
+	claims := OIDCClaims{
+		Subject:           "subject",
+		Email:             "user@example.com",
+		PreferredUsername: "user",
+		RawClaims:         map[string]any{"groups": []any{"team"}},
+	}
+	user, created, err := svc.ProcessLogin(context.Background(), claims)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, auth.RoleManager, user.Role)
+
+	currentPolicy.RoleMapping.GroupMappings = map[string]string{"team": "viewer"}
+	user, created, err = svc.ProcessLogin(context.Background(), claims)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.Equal(t, auth.RoleViewer, user.Role)
+	require.Equal(t, 2, loadCalls)
+}
+
+func TestProcessLoginRejectsUnavailablePolicyWithoutChangingAuthorization(t *testing.T) {
+	store := newMockUserStore()
+	existing := &auth.User{
+		ID:              "existing-id",
+		Username:        "existing",
+		Role:            auth.RoleManager,
+		WorkspaceAccess: auth.AllWorkspaceAccess(),
+		AuthProvider:    auth.AuthProviderOIDC,
+		OIDCIssuer:      "https://issuer.example.com",
+		OIDCSubject:     "subject",
+	}
+	require.NoError(t, store.Create(context.Background(), existing))
+
+	svc, err := New(store, Config{
+		Issuer:      "https://issuer.example.com",
+		DefaultRole: auth.RoleViewer,
+		LoadPolicy: func(context.Context) (ProvisioningPolicy, error) {
+			return ProvisioningPolicy{}, errors.New("invalid mapping")
+		},
+	})
+	require.NoError(t, err)
+
+	_, created, err := svc.ProcessLogin(context.Background(), OIDCClaims{
+		Subject:   "subject",
+		Email:     "existing@example.com",
+		RawClaims: map[string]any{"groups": []any{"team"}},
+	})
+	require.ErrorIs(t, err, ErrPolicyUnavailable)
+	require.False(t, created)
+	require.Equal(t, auth.RoleManager, existing.Role)
+	require.Zero(t, store.updateCalls)
 }
 
 type authorizationChangedAfterOIDCLookupStore struct {


### PR DESCRIPTION
## Summary

- Reload the effective OIDC provisioning policy from the configuration files used at startup before each OIDC login.
- Replace the active policy only after the new candidate is fully loaded and compiled.
- Keep the users API's managed-role and workspace metadata aligned with the latest accepted policy.

## Why

The OIDC role mapper was compiled once during server startup and retained by the provisioning service. Changes to `auth.oidc.role_mapping` therefore required restarting the server even though the policy is only consumed when an OIDC login is processed.

Loading at the authentication boundary avoids a file watcher, reload endpoint, or separate runtime configuration store. Retaining one last-known-good snapshot also prevents a malformed runtime edit from causing an OIDC login outage.

## Behavior

- `auto_signup`, `allowed_domains`, `whitelist`, and `role_mapping` are evaluated from current configuration on each login.
- A valid candidate atomically replaces the active policy for that login and later logins.
- An invalid or unreadable candidate is rejected and logged; the login continues with the latest valid policy.
- Invalid startup configuration still prevents the server from starting.
- Provider settings such as issuer, client credentials, callback URL, and scopes remain startup configuration.
- Existing sessions continue to use stored authorization; after a successful login synchronizes new access, existing sessions observe it on their next request.

## Testing

- `make fmt`
- `go test ./internal/cmn/config ./internal/service/oidcprovision ./internal/service/frontend/api/v1 -count=1`
- `make test TEST_TARGET='./internal/cmn/config ./internal/service/oidcprovision ./internal/service/frontend/api/v1'`

Closes #2457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OIDC provisioning policies now reflect the latest configuration files and environment overrides.
  * OIDC login behavior can update dynamically without restarting the service.
  * User listings now report current OIDC workspace and role synchronization settings.
  * Multiple configuration files are tracked and reported.

* **Bug Fixes**
  * Failed policy reloads now safely retain the last valid policy.
  * Invalid role mappings are detected and reported with clearer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->