### PR TITLE
feat: support recursive DAG discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,10 +854,20 @@ The embedded API is experimental and may change. See the embedded API documentat
 |----------|---------|-------------|
 | `DAGU_HOME` | — | Overrides all path defaults |
 | `DAGU_DAGS_DIR` | `~/.config/dagu/dags` | DAG definitions directory |
+| `DAGU_DAG_DISCOVERY_RECURSIVE` | `false` | Discover DAGs in subdirectories |
 | `DAGU_LOG_DIR` | `~/.local/share/dagu/logs` | Log files |
 | `DAGU_DATA_DIR` | `~/.local/share/dagu/data` | Application state |
 | `DAGU_TOOLS_DIR` | `{DAGU_DATA_DIR}/tools` | Managed DAG tool cache |
 | `DAGU_DAG_STATE_DIR` | `{DAGU_DATA_DIR}/dag-state` | Persistent DAG state files |
+
+Recursive discovery can also be enabled in `config.yaml`:
+
+```yaml
+dag_discovery:
+  recursive: true
+```
+
+It scans `paths.dags_dir`, excluding `workspaces/`, dot-directories, and symlinks. File stems and effective DAG names must each be unique, using case-sensitive comparison; conflicting files are excluded until the conflict is resolved. `paths.alt_dags_dir` remains lookup-only.
 
 ### Authentication
 

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -57,7 +57,11 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 	}
 
 	coordinatorClient := NewCoordinatorClient(ctx, cfg.Config, cfg.ServiceRegistry)
-	entryReader := scheduler.NewEntryReader(cfg.Config.Paths.DAGsDir, dagStore)
+	entryReader := scheduler.NewEntryReader(
+		cfg.Config.Paths.DAGsDir,
+		dagStore,
+		scheduler.WithRecursiveDiscovery(cfg.Config.DAGDiscovery.Recursive),
+	)
 	watermarkStore := scheduler.NewWatermarkStore(
 		file.NewCollection(filepath.Join(cfg.Config.Paths.DataDir, "scheduler"), file.WithIndentedJSON()),
 	)

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -60,7 +60,7 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 	entryReader := scheduler.NewEntryReader(
 		cfg.Config.Paths.DAGsDir,
 		dagStore,
-		scheduler.WithRecursiveDiscovery(cfg.Config.DAGDiscovery.Recursive),
+		cfg.Config.DAGDiscovery.Recursive,
 	)
 	watermarkStore := scheduler.NewWatermarkStore(
 		file.NewCollection(filepath.Join(cfg.Config.Paths.DataDir, "scheduler"), file.WithIndentedJSON()),

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	EventStore      EventStoreConfig
 	Webhooks        WebhooksConfig
 	Paths           PathsConfig
+	DAGDiscovery    DAGDiscoveryConfig
 	Secrets         SecretsConfig
 	UI              UI
 	Queues          Queues
@@ -38,6 +39,11 @@ type Config struct {
 	License         LicenseConfig
 	Notices         []string
 	Warnings        []string
+}
+
+// DAGDiscoveryConfig controls how DAG definitions are discovered.
+type DAGDiscoveryConfig struct {
+	Recursive bool
 }
 
 const DefaultWebhookMaxPayloadSize = 1 * 1024 * 1024

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -50,6 +50,9 @@ type Definition struct {
 	// Paths (structured)
 	Paths *PathsDef `mapstructure:"paths"`
 
+	// DAG discovery
+	DAGDiscovery *DAGDiscoveryDef `mapstructure:"dag_discovery"`
+
 	// Secrets
 	Secrets *SecretsDef `mapstructure:"secrets"`
 
@@ -91,6 +94,11 @@ type Definition struct {
 	GitSync    *GitSyncDef    `mapstructure:"git_sync"`
 	Tunnel     *TunnelDef     `mapstructure:"tunnel"`
 	License    *LicenseDef    `mapstructure:"license"`
+}
+
+// DAGDiscoveryDef configures DAG definition discovery.
+type DAGDiscoveryDef struct {
+	Recursive *bool `mapstructure:"recursive"`
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -343,6 +343,9 @@ func (l *ConfigLoader) loadCoreConfig(cfg *Config, def Definition) error {
 		BaseEnv:                baseEnv,
 		Peer:                   l.loadPeerConfig(def.Peer),
 	}
+	cfg.DAGDiscovery = DAGDiscoveryConfig{
+		Recursive: l.v.GetBool("dag_discovery.recursive"),
+	}
 
 	if err := setTimezone(&cfg.Core); err != nil {
 		return fmt.Errorf("failed to set timezone: %w", err)
@@ -1881,6 +1884,7 @@ func (l *ConfigLoader) setupViper(xdgConfig XDGConfig, homeDir, configFile, appH
 func (l *ConfigLoader) setViperDefaultValues(paths Paths) {
 	// Paths
 	l.v.SetDefault("skip_examples", false)
+	l.v.SetDefault("dag_discovery.recursive", false)
 	l.v.SetDefault("paths.dags_dir", paths.DAGsDir)
 	l.v.SetDefault("paths.suspend_flags_dir", paths.SuspendFlagsDir)
 	l.v.SetDefault("paths.data_dir", paths.DataDir)
@@ -2002,6 +2006,7 @@ var envBindings = []envBinding{
 	// Core
 	{key: "default_shell", env: "DEFAULT_SHELL"},
 	{key: "skip_examples", env: "SKIP_EXAMPLES"},
+	{key: "dag_discovery.recursive", env: "DAG_DISCOVERY_RECURSIVE"},
 	{key: "env_passthrough", env: "ENV_PASSTHROUGH"},
 	{key: "env_passthrough_prefixes", env: "ENV_PASSTHROUGH_PREFIXES"},
 

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -32,6 +32,28 @@ func testLoadWithError(t *testing.T, opts ...ConfigLoaderOption) error {
 	return err
 }
 
+func TestLoad_DAGDiscovery(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		t.Setenv("DAGU_DAG_DISCOVERY_RECURSIVE", "")
+		cfg := testLoad(t)
+		assert.False(t, cfg.DAGDiscovery.Recursive)
+	})
+
+	t.Run("YAML", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+dag_discovery:
+  recursive: true
+`)
+		assert.True(t, cfg.DAGDiscovery.Recursive)
+	})
+
+	t.Run("Environment", func(t *testing.T) {
+		t.Setenv("DAGU_DAG_DISCOVERY_RECURSIVE", "true")
+		cfg := testLoad(t)
+		assert.True(t, cfg.DAGDiscovery.Recursive)
+	})
+}
+
 func preserveTZEnv(t *testing.T) {
 	t.Helper()
 

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -141,6 +141,9 @@
     "paths": {
       "$ref": "#/definitions/PathsDef"
     },
+    "dag_discovery": {
+      "$ref": "#/definitions/DAGDiscoveryDef"
+    },
     "secrets": {
       "$ref": "#/definitions/SecretsDef"
     },
@@ -772,6 +775,18 @@
         "remote_nodes_dir": {
           "type": "string",
           "description": "Directory for remote node data storage."
+        }
+      }
+    },
+    "DAGDiscoveryDef": {
+      "type": "object",
+      "description": "DAG definition discovery settings.",
+      "additionalProperties": false,
+      "properties": {
+        "recursive": {
+          "type": "boolean",
+          "description": "Discover DAG definitions in subdirectories.",
+          "default": false
         }
       }
     },

--- a/internal/dagdiscovery/scan.go
+++ b/internal/dagdiscovery/scan.go
@@ -18,17 +18,16 @@ import (
 
 // File describes a discovered DAG definition.
 type File struct {
-	Path         string
-	RelativePath string
-	Size         int64
-	ModTime      int64
+	RelPath string
+	Size    int64
+	ModTime int64
 }
 
 // Result contains discoverable files, directories, and non-fatal traversal errors.
 type Result struct {
-	Files       []File
-	Directories []string
-	Errors      []error
+	Files  []File
+	Dirs   []string
+	Errors []error
 }
 
 // Scan enumerates DAG definitions beneath root.
@@ -52,16 +51,17 @@ func Scan(root string, recursive bool) (Result, error) {
 
 	result := Result{}
 	err = filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		rel := relativePath(walkRoot, path)
-		discoveredPath := root
-		if rel != "." {
-			discoveredPath = filepath.Join(root, filepath.FromSlash(rel))
+		relPath, err := filepath.Rel(walkRoot, path)
+		if err != nil {
+			return err
 		}
+		relPath = filepath.ToSlash(relPath)
+
 		if walkErr != nil {
 			if path == walkRoot {
 				return walkErr
 			}
-			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", rel, walkErr))
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", relPath, walkErr))
 			if entry != nil && entry.IsDir() {
 				return filepath.SkipDir
 			}
@@ -73,10 +73,15 @@ func Scan(root string, recursive bool) (Result, error) {
 		}
 
 		if entry.IsDir() {
-			if path != walkRoot && excludedDirectory(walkRoot, path) {
+			if path != walkRoot &&
+				(strings.HasPrefix(entry.Name(), ".") || relPath == workspace.BaseConfigDirName) {
 				return filepath.SkipDir
 			}
-			result.Directories = append(result.Directories, discoveredPath)
+			dir := root
+			if relPath != "." {
+				dir = filepath.Join(root, filepath.FromSlash(relPath))
+			}
+			result.Dirs = append(result.Dirs, dir)
 			return nil
 		}
 		if !fileutil.IsYAMLFile(entry.Name()) {
@@ -85,17 +90,16 @@ func Scan(root string, recursive bool) (Result, error) {
 
 		info, err := entry.Info()
 		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", rel, err))
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", relPath, err))
 			return nil
 		}
 		if !info.Mode().IsRegular() {
 			return nil
 		}
 		result.Files = append(result.Files, File{
-			Path:         discoveredPath,
-			RelativePath: rel,
-			Size:         info.Size(),
-			ModTime:      info.ModTime().UnixNano(),
+			RelPath: relPath,
+			Size:    info.Size(),
+			ModTime: info.ModTime().UnixNano(),
 		})
 		return nil
 	})
@@ -113,7 +117,7 @@ func scanRoot(root string) (Result, error) {
 		return Result{}, err
 	}
 
-	result := Result{Directories: []string{root}}
+	result := Result{Dirs: []string{root}}
 	for _, entry := range entries {
 		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
 			continue
@@ -124,10 +128,9 @@ func scanRoot(root string) (Result, error) {
 			continue
 		}
 		result.Files = append(result.Files, File{
-			Path:         filepath.Join(root, entry.Name()),
-			RelativePath: filepath.ToSlash(entry.Name()),
-			Size:         info.Size(),
-			ModTime:      info.ModTime().UnixNano(),
+			RelPath: filepath.ToSlash(entry.Name()),
+			Size:    info.Size(),
+			ModTime: info.ModTime().UnixNano(),
 		})
 	}
 
@@ -135,39 +138,11 @@ func scanRoot(root string) (Result, error) {
 	return result, nil
 }
 
-func excludedDirectory(root, path string) bool {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return true
-	}
-	parts := strings.Split(filepath.ToSlash(rel), "/")
-	if len(parts) == 0 {
-		return false
-	}
-	if parts[0] == workspace.BaseConfigDirName {
-		return true
-	}
-	for _, part := range parts {
-		if strings.HasPrefix(part, ".") {
-			return true
-		}
-	}
-	return false
-}
-
-func relativePath(root, path string) string {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return filepath.ToSlash(path)
-	}
-	return filepath.ToSlash(rel)
-}
-
 func sortResult(result *Result) {
 	sort.Slice(result.Files, func(i, j int) bool {
-		return result.Files[i].RelativePath < result.Files[j].RelativePath
+		return result.Files[i].RelPath < result.Files[j].RelPath
 	})
-	sort.Strings(result.Directories)
+	sort.Strings(result.Dirs)
 	sort.Slice(result.Errors, func(i, j int) bool {
 		return result.Errors[i].Error() < result.Errors[j].Error()
 	})

--- a/internal/dagdiscovery/scan.go
+++ b/internal/dagdiscovery/scan.go
@@ -1,0 +1,174 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package dagdiscovery enumerates DAG definition files and watchable directories.
+package dagdiscovery
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/internal/workspace"
+)
+
+// File describes a discovered DAG definition.
+type File struct {
+	Path         string
+	RelativePath string
+	Size         int64
+	ModTime      int64
+}
+
+// Result contains discoverable files, directories, and non-fatal traversal errors.
+type Result struct {
+	Files       []File
+	Directories []string
+	Errors      []error
+}
+
+// Scan enumerates DAG definitions beneath root.
+func Scan(root string, recursive bool) (Result, error) {
+	root = filepath.Clean(root)
+	if !recursive {
+		return scanRoot(root)
+	}
+
+	walkRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return Result{}, err
+	}
+	info, err := os.Stat(walkRoot)
+	if err != nil {
+		return Result{}, err
+	}
+	if !info.IsDir() {
+		return Result{}, fmt.Errorf("%s is not a directory", root)
+	}
+
+	result := Result{}
+	err = filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		rel := relativePath(walkRoot, path)
+		discoveredPath := root
+		if rel != "." {
+			discoveredPath = filepath.Join(root, filepath.FromSlash(rel))
+		}
+		if walkErr != nil {
+			if path == walkRoot {
+				return walkErr
+			}
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", rel, walkErr))
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if path != walkRoot && entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		if entry.IsDir() {
+			if path != walkRoot && excludedDirectory(walkRoot, path) {
+				return filepath.SkipDir
+			}
+			result.Directories = append(result.Directories, discoveredPath)
+			return nil
+		}
+		if !fileutil.IsYAMLFile(entry.Name()) {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", rel, err))
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		result.Files = append(result.Files, File{
+			Path:         discoveredPath,
+			RelativePath: rel,
+			Size:         info.Size(),
+			ModTime:      info.ModTime().UnixNano(),
+		})
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+
+	sortResult(&result)
+	return result, nil
+}
+
+func scanRoot(root string) (Result, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return Result{}, err
+	}
+
+	result := Result{Directories: []string{root}}
+	for _, entry := range entries {
+		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", entry.Name(), err))
+			continue
+		}
+		result.Files = append(result.Files, File{
+			Path:         filepath.Join(root, entry.Name()),
+			RelativePath: filepath.ToSlash(entry.Name()),
+			Size:         info.Size(),
+			ModTime:      info.ModTime().UnixNano(),
+		})
+	}
+
+	sortResult(&result)
+	return result, nil
+}
+
+func excludedDirectory(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return true
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) == 0 {
+		return false
+	}
+	if parts[0] == workspace.BaseConfigDirName {
+		return true
+	}
+	for _, part := range parts {
+		if strings.HasPrefix(part, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+func relativePath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func sortResult(result *Result) {
+	sort.Slice(result.Files, func(i, j int) bool {
+		return result.Files[i].RelativePath < result.Files[j].RelativePath
+	})
+	sort.Strings(result.Directories)
+	sort.Slice(result.Errors, func(i, j int) bool {
+		return result.Errors[i].Error() < result.Errors[j].Error()
+	})
+}

--- a/internal/dagdiscovery/scan_test.go
+++ b/internal/dagdiscovery/scan_test.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagdiscovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanRecursive(t *testing.T) {
+	baseDir := t.TempDir()
+	root := filepath.Join(baseDir, "dags")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "team", "nested"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".hidden"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "team", ".private"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "workspaces", "ops"), 0750))
+
+	for _, path := range []string{
+		filepath.Join(root, "root.yaml"),
+		filepath.Join(root, "team", "nested.yml"),
+		filepath.Join(root, "team", "nested", "deep.yaml"),
+		filepath.Join(root, ".hidden", "hidden.yaml"),
+		filepath.Join(root, "team", ".private", "private.yaml"),
+		filepath.Join(root, "workspaces", "ops", "base.yaml"),
+	} {
+		require.NoError(t, os.WriteFile(path, []byte("steps: []\n"), 0600))
+	}
+
+	externalDir := filepath.Join(baseDir, "external")
+	require.NoError(t, os.MkdirAll(externalDir, 0750))
+	externalFile := filepath.Join(externalDir, "linked.yaml")
+	require.NoError(t, os.WriteFile(externalFile, []byte("steps: []\n"), 0600))
+	_ = os.Symlink(externalDir, filepath.Join(root, "linked-dir"))
+	_ = os.Symlink(externalFile, filepath.Join(root, "linked-file.yaml"))
+
+	result, err := Scan(root, true)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	var files []string
+	for _, file := range result.Files {
+		files = append(files, file.RelativePath)
+	}
+	assert.Equal(t, []string{
+		"root.yaml",
+		"team/nested.yml",
+		"team/nested/deep.yaml",
+	}, files)
+	assert.Equal(t, []string{
+		root,
+		filepath.Join(root, "team"),
+		filepath.Join(root, "team", "nested"),
+	}, result.Directories)
+}
+
+func TestScanNonRecursiveOnlyReadsRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "nested"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "root.yaml"), []byte("steps: []\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "nested", "child.yaml"), []byte("steps: []\n"), 0600))
+
+	result, err := Scan(root, false)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Files, 1)
+	assert.Equal(t, "root.yaml", result.Files[0].RelativePath)
+	assert.Equal(t, []string{root}, result.Directories)
+}
+
+func TestScanRecursiveAllowsConfiguredSymlinkRoot(t *testing.T) {
+	baseDir := t.TempDir()
+	realRoot := filepath.Join(baseDir, "real")
+	require.NoError(t, os.MkdirAll(filepath.Join(realRoot, "nested"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(realRoot, "nested", "child.yaml"), []byte("steps: []\n"), 0600))
+
+	linkRoot := filepath.Join(baseDir, "dags")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	result, err := Scan(linkRoot, true)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Files, 1)
+	assert.Equal(t, "nested/child.yaml", result.Files[0].RelativePath)
+	assert.Equal(t, filepath.Join(linkRoot, "nested", "child.yaml"), result.Files[0].Path)
+	assert.Equal(t, []string{linkRoot, filepath.Join(linkRoot, "nested")}, result.Directories)
+}

--- a/internal/dagdiscovery/scan_test.go
+++ b/internal/dagdiscovery/scan_test.go
@@ -44,7 +44,7 @@ func TestScanRecursive(t *testing.T) {
 
 	var files []string
 	for _, file := range result.Files {
-		files = append(files, file.RelativePath)
+		files = append(files, file.RelPath)
 	}
 	assert.Equal(t, []string{
 		"root.yaml",
@@ -55,7 +55,7 @@ func TestScanRecursive(t *testing.T) {
 		root,
 		filepath.Join(root, "team"),
 		filepath.Join(root, "team", "nested"),
-	}, result.Directories)
+	}, result.Dirs)
 }
 
 func TestScanNonRecursiveOnlyReadsRoot(t *testing.T) {
@@ -68,8 +68,8 @@ func TestScanNonRecursiveOnlyReadsRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, result.Errors)
 	require.Len(t, result.Files, 1)
-	assert.Equal(t, "root.yaml", result.Files[0].RelativePath)
-	assert.Equal(t, []string{root}, result.Directories)
+	assert.Equal(t, "root.yaml", result.Files[0].RelPath)
+	assert.Equal(t, []string{root}, result.Dirs)
 }
 
 func TestScanRecursiveAllowsConfiguredSymlinkRoot(t *testing.T) {
@@ -87,7 +87,6 @@ func TestScanRecursiveAllowsConfiguredSymlinkRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, result.Errors)
 	require.Len(t, result.Files, 1)
-	assert.Equal(t, "nested/child.yaml", result.Files[0].RelativePath)
-	assert.Equal(t, filepath.Join(linkRoot, "nested", "child.yaml"), result.Files[0].Path)
-	assert.Equal(t, []string{linkRoot, filepath.Join(linkRoot, "nested")}, result.Directories)
+	assert.Equal(t, "nested/child.yaml", result.Files[0].RelPath)
+	assert.Equal(t, []string{linkRoot, filepath.Join(linkRoot, "nested")}, result.Dirs)
 }

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -317,7 +317,7 @@ func (f *testFixture) startSchedulerWithOptions(
 	em := scheduler.NewEntryReader(
 		f.coord.Config.Paths.DAGsDir,
 		f.coord.DAGStore,
-		scheduler.WithRecursiveDiscovery(f.coord.Config.DAGDiscovery.Recursive),
+		f.coord.Config.DAGDiscovery.Recursive,
 	)
 
 	schedulerInst, err := scheduler.New(

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -314,7 +314,11 @@ func (f *testFixture) startSchedulerWithOptions(
 ) {
 	f.t.Helper()
 
-	em := scheduler.NewEntryReader(f.coord.Config.Paths.DAGsDir, f.coord.DAGStore)
+	em := scheduler.NewEntryReader(
+		f.coord.Config.Paths.DAGsDir,
+		f.coord.DAGStore,
+		scheduler.WithRecursiveDiscovery(f.coord.Config.DAGDiscovery.Recursive),
+	)
 
 	schedulerInst, err := scheduler.New(
 		f.coord.Config,

--- a/internal/persis/file/dag/catalog.go
+++ b/internal/persis/file/dag/catalog.go
@@ -14,36 +14,36 @@ import (
 	indexv1 "github.com/dagucloud/dagu/proto/index/v1"
 )
 
-type dagCatalog struct {
-	entries        []*indexv1.DAGIndexEntry
-	byFileName     map[string]*indexv1.DAGIndexEntry
-	discoveryError []string
+type catalog struct {
+	entries []*indexv1.DAGIndexEntry
+	byStem  map[string]*indexv1.DAGIndexEntry
+	errors  []string
 }
 
-func (store *Storage) loadCatalog(ctx context.Context) (*dagCatalog, error) {
-	scan, err := dagdiscovery.Scan(store.baseDir, store.recursiveDiscovery)
+func (store *Storage) loadCatalog(ctx context.Context) (*catalog, error) {
+	scan, err := dagdiscovery.Scan(store.baseDir, store.recursive)
 	if err != nil {
 		return nil, err
 	}
 
-	entries := store.loadOrRebuildIndexForFiles(ctx, scan.Files)
-	return newDAGCatalog(entries, scan.Errors, store.recursiveDiscovery), nil
+	entries := store.loadIndex(ctx, scan.Files)
+	return newCatalog(entries, scan.Errors, store.recursive), nil
 }
 
-func newDAGCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, enforceUniqueness bool) *dagCatalog {
-	catalog := &dagCatalog{
-		byFileName: make(map[string]*indexv1.DAGIndexEntry),
+func newCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, checkConflicts bool) *catalog {
+	result := &catalog{
+		byStem: make(map[string]*indexv1.DAGIndexEntry),
 	}
 
-	fileNameGroups := make(map[string][]string)
+	stemGroups := make(map[string][]string)
 	nameGroups := make(map[string][]string)
 	for _, entry := range entries {
 		entry.FilePath = filepath.ToSlash(entry.FilePath)
-		fileName := dagEntryFileName(entry)
+		stem := entryStem(entry)
 		if entry.Name == "" {
-			entry.Name = fileName
+			entry.Name = stem
 		}
-		fileNameGroups[fileName] = append(fileNameGroups[fileName], entry.FilePath)
+		stemGroups[stem] = append(stemGroups[stem], entry.FilePath)
 		nameGroups[entry.Name] = append(nameGroups[entry.Name], entry.FilePath)
 	}
 
@@ -63,12 +63,12 @@ func newDAGCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, enforce
 			for _, path := range paths {
 				conflicted[path] = struct{}{}
 			}
-			catalog.discoveryError = append(catalog.discoveryError,
+			result.errors = append(result.errors,
 				fmt.Sprintf("duplicate DAG %s %q: %s", kind, key, strings.Join(paths, ", ")))
 		}
 	}
-	if enforceUniqueness {
-		appendCollisions("file name", fileNameGroups)
+	if checkConflicts {
+		appendCollisions("file name", stemGroups)
 		appendCollisions("name", nameGroups)
 	}
 
@@ -76,28 +76,28 @@ func newDAGCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, enforce
 		if _, excluded := conflicted[entry.FilePath]; excluded {
 			continue
 		}
-		catalog.entries = append(catalog.entries, entry)
-		catalog.byFileName[dagEntryFileName(entry)] = entry
+		result.entries = append(result.entries, entry)
+		result.byStem[entryStem(entry)] = entry
 	}
-	sort.Slice(catalog.entries, func(i, j int) bool {
-		if enforceUniqueness {
-			return dagEntryFileName(catalog.entries[i]) < dagEntryFileName(catalog.entries[j])
+	sort.Slice(result.entries, func(i, j int) bool {
+		if checkConflicts {
+			return entryStem(result.entries[i]) < entryStem(result.entries[j])
 		}
-		return catalog.entries[i].FilePath < catalog.entries[j].FilePath
+		return result.entries[i].FilePath < result.entries[j].FilePath
 	})
 
 	for _, err := range scanErrors {
-		catalog.discoveryError = append(catalog.discoveryError, fmt.Sprintf("DAG discovery failed: %s", err))
+		result.errors = append(result.errors, fmt.Sprintf("DAG discovery failed: %s", err))
 	}
-	sort.Strings(catalog.discoveryError)
-	return catalog
+	sort.Strings(result.errors)
+	return result
 }
 
-func dagEntryFileName(entry *indexv1.DAGIndexEntry) string {
+func entryStem(entry *indexv1.DAGIndexEntry) string {
 	base := filepath.Base(filepath.FromSlash(entry.FilePath))
 	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
-func (store *Storage) catalogEntryPath(entry *indexv1.DAGIndexEntry) string {
+func (store *Storage) entryPath(entry *indexv1.DAGIndexEntry) string {
 	return filepath.Join(store.baseDir, filepath.FromSlash(entry.FilePath))
 }

--- a/internal/persis/file/dag/catalog.go
+++ b/internal/persis/file/dag/catalog.go
@@ -80,10 +80,11 @@ func newCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, checkConfl
 		result.byStem[entryStem(entry)] = entry
 	}
 	sort.Slice(result.entries, func(i, j int) bool {
-		if checkConflicts {
-			return entryStem(result.entries[i]) < entryStem(result.entries[j])
+		left, right := entryStem(result.entries[i]), entryStem(result.entries[j])
+		if left == right {
+			return result.entries[i].FilePath < result.entries[j].FilePath
 		}
-		return result.entries[i].FilePath < result.entries[j].FilePath
+		return left < right
 	})
 
 	for _, err := range scanErrors {

--- a/internal/persis/file/dag/catalog.go
+++ b/internal/persis/file/dag/catalog.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dag
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dagucloud/dagu/internal/dagdiscovery"
+	indexv1 "github.com/dagucloud/dagu/proto/index/v1"
+)
+
+type dagCatalog struct {
+	entries        []*indexv1.DAGIndexEntry
+	byFileName     map[string]*indexv1.DAGIndexEntry
+	discoveryError []string
+}
+
+func (store *Storage) loadCatalog(ctx context.Context) (*dagCatalog, error) {
+	scan, err := dagdiscovery.Scan(store.baseDir, store.recursiveDiscovery)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := store.loadOrRebuildIndexForFiles(ctx, scan.Files)
+	return newDAGCatalog(entries, scan.Errors, store.recursiveDiscovery), nil
+}
+
+func newDAGCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, enforceUniqueness bool) *dagCatalog {
+	catalog := &dagCatalog{
+		byFileName: make(map[string]*indexv1.DAGIndexEntry),
+	}
+
+	fileNameGroups := make(map[string][]string)
+	nameGroups := make(map[string][]string)
+	for _, entry := range entries {
+		entry.FilePath = filepath.ToSlash(entry.FilePath)
+		fileName := dagEntryFileName(entry)
+		if entry.Name == "" {
+			entry.Name = fileName
+		}
+		fileNameGroups[fileName] = append(fileNameGroups[fileName], entry.FilePath)
+		nameGroups[entry.Name] = append(nameGroups[entry.Name], entry.FilePath)
+	}
+
+	conflicted := make(map[string]struct{})
+	appendCollisions := func(kind string, groups map[string][]string) {
+		keys := make([]string, 0, len(groups))
+		for key := range groups {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			paths := groups[key]
+			sort.Strings(paths)
+			if len(paths) < 2 {
+				continue
+			}
+			for _, path := range paths {
+				conflicted[path] = struct{}{}
+			}
+			catalog.discoveryError = append(catalog.discoveryError,
+				fmt.Sprintf("duplicate DAG %s %q: %s", kind, key, strings.Join(paths, ", ")))
+		}
+	}
+	if enforceUniqueness {
+		appendCollisions("file name", fileNameGroups)
+		appendCollisions("name", nameGroups)
+	}
+
+	for _, entry := range entries {
+		if _, excluded := conflicted[entry.FilePath]; excluded {
+			continue
+		}
+		catalog.entries = append(catalog.entries, entry)
+		catalog.byFileName[dagEntryFileName(entry)] = entry
+	}
+	sort.Slice(catalog.entries, func(i, j int) bool {
+		if enforceUniqueness {
+			return dagEntryFileName(catalog.entries[i]) < dagEntryFileName(catalog.entries[j])
+		}
+		return catalog.entries[i].FilePath < catalog.entries[j].FilePath
+	})
+
+	for _, err := range scanErrors {
+		catalog.discoveryError = append(catalog.discoveryError, fmt.Sprintf("DAG discovery failed: %s", err))
+	}
+	sort.Strings(catalog.discoveryError)
+	return catalog
+}
+
+func dagEntryFileName(entry *indexv1.DAGIndexEntry) string {
+	base := filepath.Base(filepath.FromSlash(entry.FilePath))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func (store *Storage) catalogEntryPath(entry *indexv1.DAGIndexEntry) string {
+	return filepath.Join(store.baseDir, filepath.FromSlash(entry.FilePath))
+}

--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -28,7 +28,7 @@ const (
 
 // YAMLFileMeta holds stat metadata for a single YAML file.
 type YAMLFileMeta struct {
-	Name    string // filename, e.g. "my-dag.yaml"
+	Name    string // Slash-normalized path relative to the DAG directory.
 	Size    int64
 	ModTime int64 // UnixNano
 }
@@ -133,9 +133,10 @@ func buildEntry(
 		spec.WithAllowBuildErrors(),
 	)
 
-	dag, err := spec.Load(ctx, filepath.Join(dagDir, entry.FilePath), opts...)
+	dag, err := spec.Load(ctx, filepath.Join(dagDir, filepath.FromSlash(entry.FilePath)), opts...)
 	if err != nil {
-		entry.Name = strings.TrimSuffix(entry.FilePath, filepath.Ext(entry.FilePath))
+		base := filepath.Base(filepath.FromSlash(entry.FilePath))
+		entry.Name = strings.TrimSuffix(base, filepath.Ext(base))
 		entry.LoadError = err.Error()
 		return
 	}
@@ -214,7 +215,7 @@ func Write(indexPath string, idx *indexv1.DAGIndex) error {
 func DAGFromEntry(entry *indexv1.DAGIndexEntry, baseDir string) *core.DAG {
 	dag := &core.DAG{
 		Name:        entry.Name,
-		Location:    filepath.Join(baseDir, entry.FilePath),
+		Location:    filepath.Join(baseDir, filepath.FromSlash(entry.FilePath)),
 		Group:       entry.Group,
 		Description: entry.Description,
 		Labels:      core.NewLabels(entry.Labels),

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -45,14 +45,14 @@ type Options struct {
 	BaseConfigPath         string                     // Optional base config file applied when loading DAGs
 	WorkspaceBaseConfigDir string                     // Optional directory containing workspace base configs
 	SkipExamples           bool                       // Skip creating example DAGs
-	RecursiveDiscovery     bool                       // Discover DAG definitions in subdirectories
+	Recursive              bool                       // Discover DAG definitions in subdirectories
 	SkipDirectoryCreation  bool                       // Skip creating base directory for execution-scoped stores
 }
 
 // WithRecursiveDiscovery controls whether DAG files are discovered recursively.
 func WithRecursiveDiscovery(recursive bool) Option {
 	return func(o *Options) {
-		o.RecursiveDiscovery = recursive
+		o.Recursive = recursive
 	}
 }
 
@@ -137,7 +137,7 @@ func New(baseDir string, opts ...Option) exec.DAGStore {
 		workspaceBaseConfigDir: options.WorkspaceBaseConfigDir,
 		baseConfigState:        describeBaseConfigStateSet(options.BaseConfigPath, options.WorkspaceBaseConfigDir),
 		skipExamples:           options.SkipExamples,
-		recursiveDiscovery:     options.RecursiveDiscovery,
+		recursive:              options.Recursive,
 		skipDirectoryCreation:  options.SkipDirectoryCreation,
 	}
 }
@@ -152,7 +152,7 @@ type Storage struct {
 	workspaceBaseConfigDir string                     // Optional directory containing workspace base configs
 	baseConfigState        string                     // Last observed base config state for cache/index invalidation
 	skipExamples           bool                       // Skip creating example DAGs
-	recursiveDiscovery     bool                       // Discover DAG definitions in subdirectories
+	recursive              bool                       // Discover DAG definitions in subdirectories
 	skipDirectoryCreation  bool                       // Skip creating base directory for execution-scoped stores
 	baseConfigMu           sync.Mutex                 // Protects base config state refresh and invalidation
 	indexMu                sync.Mutex                 // Protects index load/rebuild/invalidate
@@ -160,10 +160,6 @@ type Storage struct {
 
 func (store *Storage) useCachedLoads() bool {
 	return store.fileCache != nil
-}
-
-func (store *Storage) useIndexedMetadata() bool {
-	return true
 }
 
 func (store *Storage) readSuspendFlags(ctx context.Context) dagindex.SuspendFlags {
@@ -373,7 +369,7 @@ func (store *Storage) Create(_ context.Context, name string, spec []byte) error 
 		return fmt.Errorf("failed to create DAGs directory %s: %w", store.baseDir, err)
 	}
 	filePath := store.generateFilePath(name)
-	if fileExists(filePath) || store.recursiveDiscovery && store.discoveredFileNameExists(name, "") {
+	if fileExists(filePath) || store.recursive && store.stemExists(name, "") {
 		return exec.ErrDAGAlreadyExists
 	}
 	if err := fileutil.WriteFileAtomic(filePath, spec, defaultPerm); err != nil {
@@ -415,27 +411,15 @@ func (store *Storage) ensureDirExist() error {
 		_ = store.createExampleDAGs() // Errors are logged internally
 	} else {
 		// Check if directory is empty and create examples if needed
-		if shouldCreateExamples(store.baseDir, store.recursiveDiscovery) {
+		if shouldCreateExamples(store.baseDir, store.recursive) {
 			_ = store.createExampleDAGs() // Errors are logged internally
 		}
 	}
 	return nil
 }
 
-// loadOrRebuildIndex returns validated index entries, rebuilding if necessary.
-func (store *Storage) loadOrRebuildIndex(ctx context.Context) []*indexv1.DAGIndexEntry {
-	scan, err := dagdiscovery.Scan(store.baseDir, store.recursiveDiscovery)
-	if err != nil {
-		return nil
-	}
-	return store.loadOrRebuildIndexForFiles(ctx, scan.Files)
-}
-
-func (store *Storage) loadOrRebuildIndexForFiles(ctx context.Context, files []dagdiscovery.File) []*indexv1.DAGIndexEntry {
-	if !store.useIndexedMetadata() {
-		return nil
-	}
-
+// loadIndex returns validated index entries, rebuilding the index when needed.
+func (store *Storage) loadIndex(ctx context.Context, files []dagdiscovery.File) []*indexv1.DAGIndexEntry {
 	store.refreshBaseConfigState()
 
 	store.indexMu.Lock()
@@ -444,7 +428,7 @@ func (store *Storage) loadOrRebuildIndexForFiles(ctx context.Context, files []da
 	yamlFiles := make([]dagindex.YAMLFileMeta, 0, len(files))
 	for _, file := range files {
 		yamlFiles = append(yamlFiles, dagindex.YAMLFileMeta{
-			Name:    file.RelativePath,
+			Name:    file.RelPath,
 			Size:    file.Size,
 			ModTime: file.ModTime,
 		})
@@ -498,7 +482,7 @@ func (store *Storage) List(ctx context.Context, opts exec.ListDAGsOptions) (exec
 		errList = append(errList, fmt.Sprintf("failed to discover DAGs in %s: %s", store.baseDir, err))
 		return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), errList, err
 	}
-	errList = append(errList, catalog.discoveryError...)
+	errList = append(errList, catalog.errors...)
 	for _, entry := range catalog.entries {
 		if ctx.Err() != nil {
 			return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), errList, ctx.Err()
@@ -698,10 +682,10 @@ func (store *Storage) Grep(ctx context.Context, pattern string) (
 	if err != nil {
 		return nil, errs, fmt.Errorf("failed to discover DAGs in %s: %w", store.baseDir, err)
 	}
-	errs = append(errs, catalog.discoveryError...)
+	errs = append(errs, catalog.errors...)
 
 	for _, entry := range catalog.entries {
-		filePath := store.catalogEntryPath(entry)
+		filePath := store.entryPath(entry)
 		dat, err := fileutil.ReadFile(filePath)
 		if err != nil {
 			logger.Error(ctx, "Failed to read DAG file",
@@ -727,7 +711,7 @@ func (store *Storage) Grep(ctx context.Context, pattern string) (
 			continue
 		}
 		ret = append(ret, &exec.GrepDAGsResult{
-			Name:    dagEntryFileName(entry),
+			Name:    entryStem(entry),
 			DAG:     dag,
 			Matches: matches,
 		})
@@ -761,7 +745,7 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 	matchLimit := max(opts.MatchLimit, 1)
 	results := make([]exec.SearchDAGResult, 0, limit)
 	pattern := dagSearchPattern(opts.Query)
-	errs := append([]string(nil), catalog.discoveryError...)
+	errs := append([]string(nil), catalog.errors...)
 	var hasMore bool
 	var nextCursor string
 
@@ -770,12 +754,12 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 			return nil, errs, ctx.Err()
 		}
 
-		fileName := dagEntryFileName(entry)
+		fileName := entryStem(entry)
 		if cursor.FileName != "" && fileName <= cursor.FileName {
 			continue
 		}
 
-		filePath := store.catalogEntryPath(entry)
+		filePath := store.entryPath(entry)
 		var dag *core.DAG
 		if len(opts.Labels) > 0 || opts.WorkspaceFilter != nil {
 			dag, err = spec.Load(ctx, filePath, store.defaultLoadOptions(
@@ -975,10 +959,14 @@ func (store *Storage) Rename(ctx context.Context, oldID, newID string) error {
 		return fmt.Errorf("failed to locate DAG %s: %w", oldID, err)
 	}
 	newFilePath := store.generateFilePath(newID)
-	if store.recursiveDiscovery && pathWithinDirectory(store.baseDir, oldFilePath) {
-		newFilePath = fileutil.EnsureYAMLExtension(filepath.Join(filepath.Dir(oldFilePath), filepath.Base(newID)))
+	exceptPath := ""
+	if store.recursive {
+		if relPath, ok := relativeToBase(store.baseDir, oldFilePath); ok {
+			newFilePath = fileutil.EnsureYAMLExtension(filepath.Join(filepath.Dir(oldFilePath), filepath.Base(newID)))
+			exceptPath = relPath
+		}
 	}
-	if fileExists(newFilePath) || store.recursiveDiscovery && store.discoveredFileNameExists(newID, oldFilePath) {
+	if fileExists(newFilePath) || store.recursive && store.stemExists(newID, exceptPath) {
 		return exec.ErrDAGAlreadyExists
 	}
 	if err := fileutil.Rename(oldFilePath, newFilePath); err != nil {
@@ -1008,13 +996,13 @@ func (store *Storage) locateDAG(ctx context.Context, nameOrPath string) (string,
 	relativePath := filepath.FromSlash(nameOrPath)
 	explicitPath := filepath.IsAbs(relativePath) || strings.ContainsAny(nameOrPath, `/\`)
 
-	if store.recursiveDiscovery && !explicitPath {
+	if store.recursive && !explicitPath {
 		catalog, err := store.loadCatalog(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to discover DAGs: %w", err)
 		}
 		fileName := strings.TrimSuffix(filepath.Base(relativePath), filepath.Ext(relativePath))
-		if entry, ok := catalog.byFileName[fileName]; ok {
+		if entry, ok := catalog.byStem[fileName]; ok {
 			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(
 				store.baseDir,
 				filepath.FromSlash(entry.FilePath),
@@ -1059,19 +1047,18 @@ func locateDAGInDirectories(nameOrPath string, directories []string) (string, er
 	return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
 }
 
-func (store *Storage) discoveredFileNameExists(name, exceptPath string) bool {
+func (store *Storage) stemExists(name, exceptPath string) bool {
 	scan, err := dagdiscovery.Scan(store.baseDir, true)
 	if err != nil {
 		return false
 	}
 	base := filepath.Base(filepath.FromSlash(name))
 	target := strings.TrimSuffix(base, filepath.Ext(base))
-	exceptPath = filepath.Clean(exceptPath)
 	for _, file := range scan.Files {
-		if exceptPath != "." && filepath.Clean(file.Path) == exceptPath {
+		if exceptPath != "" && file.RelPath == exceptPath {
 			continue
 		}
-		fileBase := filepath.Base(filepath.FromSlash(file.RelativePath))
+		fileBase := filepath.Base(filepath.FromSlash(file.RelPath))
 		if strings.TrimSuffix(fileBase, filepath.Ext(fileBase)) == target {
 			return true
 		}
@@ -1079,25 +1066,28 @@ func (store *Storage) discoveredFileNameExists(name, exceptPath string) bool {
 	return false
 }
 
-func pathWithinDirectory(baseDir, path string) bool {
+func relativeToBase(baseDir, path string) (string, bool) {
 	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
-		return false
+		return "", false
 	}
 	absBase, err = filepath.EvalSymlinks(absBase)
 	if err != nil {
-		return false
+		return "", false
 	}
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return false
+		return "", false
 	}
 	absPath, err = filepath.EvalSymlinks(absPath)
 	if err != nil {
-		return false
+		return "", false
 	}
 	rel, err := filepath.Rel(absBase, absPath)
-	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
 }
 
 func dagFileCandidates(name string) []string {
@@ -1121,7 +1111,7 @@ func (store *Storage) LabelList(ctx context.Context) ([]string, []string, error)
 		errList = append(errList, fmt.Sprintf("failed to discover DAGs in %s: %s", store.baseDir, err))
 		return nil, errList, err
 	}
-	errList = append(errList, catalog.discoveryError...)
+	errList = append(errList, catalog.errors...)
 	for _, entry := range catalog.entries {
 		if entry.LoadError != "" {
 			continue

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
 	"github.com/dagucloud/dagu/internal/core/spec"
+	"github.com/dagucloud/dagu/internal/dagdiscovery"
 	"github.com/dagucloud/dagu/internal/persis/file/dag/dagindex"
 	"github.com/dagucloud/dagu/internal/persis/file/dag/grep"
 	"github.com/dagucloud/dagu/internal/workspace"
@@ -44,7 +45,15 @@ type Options struct {
 	BaseConfigPath         string                     // Optional base config file applied when loading DAGs
 	WorkspaceBaseConfigDir string                     // Optional directory containing workspace base configs
 	SkipExamples           bool                       // Skip creating example DAGs
+	RecursiveDiscovery     bool                       // Discover DAG definitions in subdirectories
 	SkipDirectoryCreation  bool                       // Skip creating base directory for execution-scoped stores
+}
+
+// WithRecursiveDiscovery controls whether DAG files are discovered recursively.
+func WithRecursiveDiscovery(recursive bool) Option {
+	return func(o *Options) {
+		o.RecursiveDiscovery = recursive
+	}
 }
 
 // WithFileCache returns a DAGRepositoryOption that sets the file cache for DAG objects
@@ -128,6 +137,7 @@ func New(baseDir string, opts ...Option) exec.DAGStore {
 		workspaceBaseConfigDir: options.WorkspaceBaseConfigDir,
 		baseConfigState:        describeBaseConfigStateSet(options.BaseConfigPath, options.WorkspaceBaseConfigDir),
 		skipExamples:           options.SkipExamples,
+		recursiveDiscovery:     options.RecursiveDiscovery,
 		skipDirectoryCreation:  options.SkipDirectoryCreation,
 	}
 }
@@ -142,6 +152,7 @@ type Storage struct {
 	workspaceBaseConfigDir string                     // Optional directory containing workspace base configs
 	baseConfigState        string                     // Last observed base config state for cache/index invalidation
 	skipExamples           bool                       // Skip creating example DAGs
+	recursiveDiscovery     bool                       // Discover DAG definitions in subdirectories
 	skipDirectoryCreation  bool                       // Skip creating base directory for execution-scoped stores
 	baseConfigMu           sync.Mutex                 // Protects base config state refresh and invalidation
 	indexMu                sync.Mutex                 // Protects index load/rebuild/invalidate
@@ -272,7 +283,7 @@ func (store *Storage) Initialize() error {
 
 // GetMetadata retrieves the metadata of a DAG by its name.
 func (store *Storage) GetMetadata(ctx context.Context, name string) (*core.DAG, error) {
-	filePath, err := store.locateDAG(name)
+	filePath, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate DAG %s in search paths (%v): %w", name, store.searchPaths, err)
 	}
@@ -292,7 +303,7 @@ func (store *Storage) GetMetadata(ctx context.Context, name string) (*core.DAG, 
 
 // GetDetails retrieves the details of a DAG by its name.
 func (store *Storage) GetDetails(ctx context.Context, name string, opts ...spec.LoadOption) (*core.DAG, error) {
-	filePath, err := store.locateDAG(name)
+	filePath, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
@@ -307,8 +318,8 @@ func (store *Storage) GetDetails(ctx context.Context, name string, opts ...spec.
 }
 
 // GetSpec retrieves the specification of a DAG by its name.
-func (store *Storage) GetSpec(_ context.Context, name string) (string, error) {
-	filePath, err := store.locateDAG(name)
+func (store *Storage) GetSpec(ctx context.Context, name string) (string, error) {
+	filePath, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return "", exec.ErrDAGNotFound
 	}
@@ -342,7 +353,7 @@ func (store *Storage) UpdateSpec(ctx context.Context, name string, yamlSpec []by
 	if err := dag.Validate(); err != nil {
 		return err
 	}
-	filePath, err := store.locateDAG(name)
+	filePath, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
@@ -362,7 +373,7 @@ func (store *Storage) Create(_ context.Context, name string, spec []byte) error 
 		return fmt.Errorf("failed to create DAGs directory %s: %w", store.baseDir, err)
 	}
 	filePath := store.generateFilePath(name)
-	if fileExists(filePath) {
+	if fileExists(filePath) || store.recursiveDiscovery && store.discoveredFileNameExists(name, "") {
 		return exec.ErrDAGAlreadyExists
 	}
 	if err := fileutil.WriteFileAtomic(filePath, spec, defaultPerm); err != nil {
@@ -373,8 +384,8 @@ func (store *Storage) Create(_ context.Context, name string, spec []byte) error 
 }
 
 // Delete deletes a DAG by its name.
-func (store *Storage) Delete(_ context.Context, name string) error {
-	filePath, err := store.locateDAG(name)
+func (store *Storage) Delete(ctx context.Context, name string) error {
+	filePath, err := store.locateDAG(ctx, name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -404,7 +415,7 @@ func (store *Storage) ensureDirExist() error {
 		_ = store.createExampleDAGs() // Errors are logged internally
 	} else {
 		// Check if directory is empty and create examples if needed
-		if shouldCreateExamples(store.baseDir) {
+		if shouldCreateExamples(store.baseDir, store.recursiveDiscovery) {
 			_ = store.createExampleDAGs() // Errors are logged internally
 		}
 	}
@@ -412,8 +423,15 @@ func (store *Storage) ensureDirExist() error {
 }
 
 // loadOrRebuildIndex returns validated index entries, rebuilding if necessary.
-// Returns nil on any failure (caller falls back to direct scan).
 func (store *Storage) loadOrRebuildIndex(ctx context.Context) []*indexv1.DAGIndexEntry {
+	scan, err := dagdiscovery.Scan(store.baseDir, store.recursiveDiscovery)
+	if err != nil {
+		return nil
+	}
+	return store.loadOrRebuildIndexForFiles(ctx, scan.Files)
+}
+
+func (store *Storage) loadOrRebuildIndexForFiles(ctx context.Context, files []dagdiscovery.File) []*indexv1.DAGIndexEntry {
 	if !store.useIndexedMetadata() {
 		return nil
 	}
@@ -423,25 +441,12 @@ func (store *Storage) loadOrRebuildIndex(ctx context.Context) []*indexv1.DAGInde
 	store.indexMu.Lock()
 	defer store.indexMu.Unlock()
 
-	entries, err := os.ReadDir(store.baseDir)
-	if err != nil {
-		return nil
-	}
-
-	// Collect YAML file metadata.
-	var yamlFiles []dagindex.YAMLFileMeta
-	for _, entry := range entries {
-		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return nil
-		}
+	yamlFiles := make([]dagindex.YAMLFileMeta, 0, len(files))
+	for _, file := range files {
 		yamlFiles = append(yamlFiles, dagindex.YAMLFileMeta{
-			Name:    entry.Name(),
-			Size:    info.Size(),
-			ModTime: info.ModTime().UnixNano(),
+			Name:    file.RelativePath,
+			Size:    file.Size,
+			ModTime: file.ModTime,
 		})
 	}
 
@@ -488,71 +493,29 @@ func (store *Storage) List(ctx context.Context, opts exec.ListDAGsOptions) (exec
 		opts.Paginator = &p
 	}
 
-	// Try index-accelerated path.
-	if indexEntries := store.loadOrRebuildIndex(ctx); indexEntries != nil {
-		for _, entry := range indexEntries {
-			if ctx.Err() != nil {
-				return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), nil, ctx.Err()
-			}
-
-			dag := dagindex.DAGFromEntry(entry, store.baseDir)
-			if opts.Name != "" && !matchesDAGListSearch(dag.Name, dag.FileName(), opts.Name) {
-				continue
-			}
-			if len(opts.Labels) > 0 && !containsAllLabels(dag.Labels, opts.Labels) {
-				continue
-			}
-			if !opts.WorkspaceFilter.MatchesLabels(dag.Labels) {
-				continue
-			}
-
-			allDags = append(allDags, dag)
-		}
-	} else {
-		// Fallback: direct filesystem scan.
-		entries, err := os.ReadDir(store.baseDir)
-		if err != nil {
-			errList = append(errList, fmt.Sprintf("failed to read directory %s: %s", store.baseDir, err))
-			return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), errList, err
+	catalog, err := store.loadCatalog(ctx)
+	if err != nil {
+		errList = append(errList, fmt.Sprintf("failed to discover DAGs in %s: %s", store.baseDir, err))
+		return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), errList, err
+	}
+	errList = append(errList, catalog.discoveryError...)
+	for _, entry := range catalog.entries {
+		if ctx.Err() != nil {
+			return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), errList, ctx.Err()
 		}
 
-		for _, entry := range entries {
-			if ctx.Err() != nil {
-				return exec.NewPaginatedResult([]*core.DAG{}, 0, *opts.Paginator), nil, ctx.Err()
-			}
-
-			if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
-				continue
-			}
-
-			baseName := path.Base(entry.Name())
-			fileName := strings.TrimSuffix(baseName, path.Ext(baseName))
-
-			filePath := filepath.Join(store.baseDir, entry.Name())
-			dag, err := spec.Load(ctx, filePath, store.defaultLoadOptions(
-				spec.OnlyMetadata(),
-				spec.WithoutEval(),
-				spec.SkipSchemaValidation(),
-				spec.WithAllowBuildErrors(),
-			)...)
-			if err != nil {
-				errList = append(errList, fmt.Sprintf("reading %s failed: %s", fileName, err))
-				continue
-			}
-
-			if opts.Name != "" && !matchesDAGListSearch(dag.Name, fileName, opts.Name) {
-				continue
-			}
-
-			if len(opts.Labels) > 0 && !containsAllLabels(dag.Labels, opts.Labels) {
-				continue
-			}
-			if !opts.WorkspaceFilter.MatchesLabels(dag.Labels) {
-				continue
-			}
-
-			allDags = append(allDags, dag)
+		dag := dagindex.DAGFromEntry(entry, store.baseDir)
+		if opts.Name != "" && !matchesDAGListSearch(dag.Name, dag.FileName(), opts.Name) {
+			continue
 		}
+		if len(opts.Labels) > 0 && !containsAllLabels(dag.Labels, opts.Labels) {
+			continue
+		}
+		if !opts.WorkspaceFilter.MatchesLabels(dag.Labels) {
+			continue
+		}
+
+		allDags = append(allDags, dag)
 	}
 
 	switch opts.Sort {
@@ -731,46 +694,43 @@ func (store *Storage) Grep(ctx context.Context, pattern string) (
 		return
 	}
 
-	entries, err := os.ReadDir(store.baseDir)
+	catalog, err := store.loadCatalog(ctx)
 	if err != nil {
-		logger.Error(ctx, "Failed to read directory",
-			tag.Dir(store.baseDir),
-			tag.Error(err))
+		return nil, errs, fmt.Errorf("failed to discover DAGs in %s: %w", store.baseDir, err)
 	}
+	errs = append(errs, catalog.discoveryError...)
 
-	for _, entry := range entries {
-		if fileutil.IsYAMLFile(entry.Name()) {
-			filePath := filepath.Join(store.baseDir, entry.Name())
-			dat, err := fileutil.ReadFile(filePath)
-			if err != nil {
-				logger.Error(ctx, "Failed to read DAG file",
-					tag.File(entry.Name()),
-					tag.Error(err))
-				continue
-			}
-			matches, err := grep.Grep(dat, fmt.Sprintf("(?i)%s", pattern), grep.DefaultGrepOptions)
-			if err != nil {
-				if errors.Is(err, grep.ErrNoMatch) {
-					continue
-				}
-				errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.Name(), err))
-				continue
-			}
-			dag, err := spec.Load(ctx, filePath, store.defaultLoadOptions(
-				spec.OnlyMetadata(),
-				spec.WithoutEval(),
-				spec.SkipSchemaValidation(),
-			)...)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("check %s failed: %s", entry.Name(), err))
-				continue
-			}
-			ret = append(ret, &exec.GrepDAGsResult{
-				Name:    strings.TrimSuffix(entry.Name(), path.Ext(entry.Name())),
-				DAG:     dag,
-				Matches: matches,
-			})
+	for _, entry := range catalog.entries {
+		filePath := store.catalogEntryPath(entry)
+		dat, err := fileutil.ReadFile(filePath)
+		if err != nil {
+			logger.Error(ctx, "Failed to read DAG file",
+				tag.File(entry.FilePath),
+				tag.Error(err))
+			continue
 		}
+		matches, err := grep.Grep(dat, fmt.Sprintf("(?i)%s", pattern), grep.DefaultGrepOptions)
+		if err != nil {
+			if errors.Is(err, grep.ErrNoMatch) {
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.FilePath, err))
+			continue
+		}
+		dag, err := spec.Load(ctx, filePath, store.defaultLoadOptions(
+			spec.OnlyMetadata(),
+			spec.WithoutEval(),
+			spec.SkipSchemaValidation(),
+		)...)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("check %s failed: %s", entry.FilePath, err))
+			continue
+		}
+		ret = append(ret, &exec.GrepDAGsResult{
+			Name:    dagEntryFileName(entry),
+			DAG:     dag,
+			Matches: matches,
+		})
 	}
 	return ret, errs, nil
 }
@@ -792,9 +752,8 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 		return nil, nil, err
 	}
 
-	entries, err := os.ReadDir(store.baseDir)
+	catalog, err := store.loadCatalog(ctx)
 	if err != nil {
-		logger.Error(ctx, "Failed to read directory", tag.Dir(store.baseDir), tag.Error(err))
 		return nil, nil, fmt.Errorf("failed to read DAGs directory %s: %w", store.baseDir, err)
 	}
 
@@ -802,24 +761,21 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 	matchLimit := max(opts.MatchLimit, 1)
 	results := make([]exec.SearchDAGResult, 0, limit)
 	pattern := dagSearchPattern(opts.Query)
-	var errs []string
+	errs := append([]string(nil), catalog.discoveryError...)
 	var hasMore bool
 	var nextCursor string
 
-	for _, entry := range entries {
+	for _, entry := range catalog.entries {
 		if ctx.Err() != nil {
 			return nil, errs, ctx.Err()
 		}
-		if !fileutil.IsYAMLFile(entry.Name()) {
-			continue
-		}
 
-		fileName := strings.TrimSuffix(entry.Name(), path.Ext(entry.Name()))
+		fileName := dagEntryFileName(entry)
 		if cursor.FileName != "" && fileName <= cursor.FileName {
 			continue
 		}
 
-		filePath := filepath.Join(store.baseDir, entry.Name())
+		filePath := store.catalogEntryPath(entry)
 		var dag *core.DAG
 		if len(opts.Labels) > 0 || opts.WorkspaceFilter != nil {
 			dag, err = spec.Load(ctx, filePath, store.defaultLoadOptions(
@@ -841,8 +797,8 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 		}
 		dat, err := fileutil.ReadFile(filePath)
 		if err != nil {
-			logger.Error(ctx, "Failed to read DAG file", tag.File(entry.Name()), tag.Error(err))
-			errs = append(errs, fmt.Sprintf("read %s failed: %s", entry.Name(), err))
+			logger.Error(ctx, "Failed to read DAG file", tag.File(entry.FilePath), tag.Error(err))
+			errs = append(errs, fmt.Sprintf("read %s failed: %s", entry.FilePath, err))
 			continue
 		}
 
@@ -856,7 +812,7 @@ func (store *Storage) SearchCursor(ctx context.Context, opts exec.SearchDAGsOpti
 			if errors.Is(err, grep.ErrNoMatch) {
 				continue
 			}
-			errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.Name(), err))
+			errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.FilePath, err))
 			continue
 		}
 
@@ -929,7 +885,7 @@ func (store *Storage) SearchMatches(ctx context.Context, fileName string, opts e
 		return nil, err
 	}
 
-	filePath, err := store.locateDAG(fileName)
+	filePath, err := store.locateDAG(ctx, fileName)
 	if err != nil {
 		return nil, exec.ErrDAGNotFound
 	}
@@ -1013,13 +969,16 @@ func fileName(id string) string {
 }
 
 // Rename renames a DAG from oldID to newID.
-func (store *Storage) Rename(_ context.Context, oldID, newID string) error {
-	oldFilePath, err := store.locateDAG(oldID)
+func (store *Storage) Rename(ctx context.Context, oldID, newID string) error {
+	oldFilePath, err := store.locateDAG(ctx, oldID)
 	if err != nil {
 		return fmt.Errorf("failed to locate DAG %s: %w", oldID, err)
 	}
 	newFilePath := store.generateFilePath(newID)
-	if fileExists(newFilePath) {
+	if store.recursiveDiscovery && pathWithinDirectory(store.baseDir, oldFilePath) {
+		newFilePath = fileutil.EnsureYAMLExtension(filepath.Join(filepath.Dir(oldFilePath), filepath.Base(newID)))
+	}
+	if fileExists(newFilePath) || store.recursiveDiscovery && store.discoveredFileNameExists(newID, oldFilePath) {
 		return exec.ErrDAGAlreadyExists
 	}
 	if err := fileutil.Rename(oldFilePath, newFilePath); err != nil {
@@ -1045,8 +1004,36 @@ func (store *Storage) generateFilePath(name string) string {
 }
 
 // locateDAG resolves a DAG beneath the configured DAG directories.
-func (store *Storage) locateDAG(nameOrPath string) (string, error) {
-	for _, dir := range store.searchPaths {
+func (store *Storage) locateDAG(ctx context.Context, nameOrPath string) (string, error) {
+	relativePath := filepath.FromSlash(nameOrPath)
+	explicitPath := filepath.IsAbs(relativePath) || strings.ContainsAny(nameOrPath, `/\`)
+
+	if store.recursiveDiscovery && !explicitPath {
+		catalog, err := store.loadCatalog(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to discover DAGs: %w", err)
+		}
+		fileName := strings.TrimSuffix(filepath.Base(relativePath), filepath.Ext(relativePath))
+		if entry, ok := catalog.byFileName[fileName]; ok {
+			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(
+				store.baseDir,
+				filepath.FromSlash(entry.FilePath),
+			)
+			if err == nil {
+				return resolvedPath, nil
+			}
+		}
+		if len(store.searchPaths) > 1 {
+			return locateDAGInDirectories(nameOrPath, store.searchPaths[1:])
+		}
+		return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
+	}
+
+	return locateDAGInDirectories(nameOrPath, store.searchPaths)
+}
+
+func locateDAGInDirectories(nameOrPath string, directories []string) (string, error) {
+	for _, dir := range directories {
 		absDir, err := filepath.Abs(dir)
 		if err != nil {
 			continue
@@ -1072,6 +1059,47 @@ func (store *Storage) locateDAG(nameOrPath string) (string, error) {
 	return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
 }
 
+func (store *Storage) discoveredFileNameExists(name, exceptPath string) bool {
+	scan, err := dagdiscovery.Scan(store.baseDir, true)
+	if err != nil {
+		return false
+	}
+	base := filepath.Base(filepath.FromSlash(name))
+	target := strings.TrimSuffix(base, filepath.Ext(base))
+	exceptPath = filepath.Clean(exceptPath)
+	for _, file := range scan.Files {
+		if exceptPath != "." && filepath.Clean(file.Path) == exceptPath {
+			continue
+		}
+		fileBase := filepath.Base(filepath.FromSlash(file.RelativePath))
+		if strings.TrimSuffix(fileBase, filepath.Ext(fileBase)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinDirectory(baseDir, path string) bool {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return false
+	}
+	absBase, err = filepath.EvalSymlinks(absBase)
+	if err != nil {
+		return false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absBase, absPath)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func dagFileCandidates(name string) []string {
 	switch filepath.Ext(name) {
 	case ".yaml", ".yml":
@@ -1088,47 +1116,20 @@ func (store *Storage) LabelList(ctx context.Context) ([]string, []string, error)
 		labelSet = make(map[string]struct{})
 	)
 
-	// Try index-accelerated path.
-	if indexEntries := store.loadOrRebuildIndex(ctx); indexEntries != nil {
-		for _, entry := range indexEntries {
-			if entry.LoadError != "" {
-				continue
-			}
-			for _, labelStr := range entry.Labels {
-				labelSet[strings.ToLower(labelStr)] = struct{}{}
-				if key, _, ok := strings.Cut(labelStr, "="); ok {
-					labelSet[strings.ToLower(key)] = struct{}{}
-				}
-			}
+	catalog, err := store.loadCatalog(ctx)
+	if err != nil {
+		errList = append(errList, fmt.Sprintf("failed to discover DAGs in %s: %s", store.baseDir, err))
+		return nil, errList, err
+	}
+	errList = append(errList, catalog.discoveryError...)
+	for _, entry := range catalog.entries {
+		if entry.LoadError != "" {
+			continue
 		}
-	} else {
-		// Fallback: direct filesystem scan.
-		entries, err := os.ReadDir(store.baseDir)
-		if err != nil {
-			errList = append(errList, fmt.Sprintf("failed to read directory %s: %s", store.baseDir, err))
-			return nil, errList, err
-		}
-
-		for _, entry := range entries {
-			if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
-				continue
-			}
-
-			baseName := path.Base(entry.Name())
-			dagName := strings.TrimSuffix(baseName, path.Ext(baseName))
-
-			parsedDAG, err := store.GetMetadata(ctx, dagName)
-			if err != nil {
-				errList = append(errList, fmt.Sprintf("reading %s failed: %s", entry.Name(), err))
-				continue
-			}
-
-			for _, t := range parsedDAG.Labels {
-				labelStr := t.String()
-				labelSet[strings.ToLower(labelStr)] = struct{}{}
-				if t.Value != "" {
-					labelSet[strings.ToLower(t.Key)] = struct{}{}
-				}
+		for _, labelStr := range entry.Labels {
+			labelSet[strings.ToLower(labelStr)] = struct{}{}
+			if key, _, ok := strings.Cut(labelStr, "="); ok {
+				labelSet[strings.ToLower(key)] = struct{}{}
 			}
 		}
 	}
@@ -1196,27 +1197,18 @@ func fileExists(file string) bool {
 }
 
 // shouldCreateExamples checks if we should create example DAGs
-func shouldCreateExamples(dir string) bool {
+func shouldCreateExamples(dir string, recursive bool) bool {
 	// Check for marker file that indicates examples were already created
 	markerFile := filepath.Join(dir, ".examples-created")
 	if fileExists(markerFile) {
 		return false
 	}
 
-	// Check if directory is empty (no YAML files)
-	entries, err := os.ReadDir(dir)
+	scan, err := dagdiscovery.Scan(dir, recursive)
 	if err != nil {
 		return false
 	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() && fileutil.IsYAMLFile(entry.Name()) {
-			// Found at least one YAML file, don't create examples
-			return false
-		}
-	}
-
-	return true
+	return len(scan.Files) == 0
 }
 
 // createExampleDAGs creates example DAG files for first-time users

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -1980,14 +1980,14 @@ func TestListUsesIndex(t *testing.T) {
 	assert.Equal(t, 3, result3.TotalCount)
 }
 
-func TestLoadOrRebuildIndex_NonExistentDir(t *testing.T) {
-	store := New("/nonexistent/path/that/does/not/exist", WithSkipExamples(true)).(*Storage)
+func TestList_NonExistentDir(t *testing.T) {
+	store := New("/nonexistent/path/that/does/not/exist", WithSkipExamples(true))
 	ctx := context.Background()
-	result := store.loadOrRebuildIndex(ctx)
-	assert.Nil(t, result, "should return nil when baseDir doesn't exist")
+	_, _, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.Error(t, err)
 }
 
-func TestLoadOrRebuildIndex_NonExistentFlagsDir(t *testing.T) {
+func TestList_NonExistentFlagsDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a valid DAG file so the index can try to build.
@@ -2002,8 +2002,10 @@ steps:
 	store.flagsBaseDir = filepath.Join(tmpDir, "nonexistent-flags-dir")
 
 	ctx := context.Background()
-	result := store.loadOrRebuildIndex(ctx)
-	assert.NotNil(t, result, "should still build index even with missing flags dir")
+	result, errs, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	assert.Equal(t, 1, result.TotalCount)
 }
 
 func TestInvalidateIndex_RemovesFile(t *testing.T) {
@@ -2018,8 +2020,8 @@ steps:
     run: echo ok`
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "inv-test.yaml"), []byte(dagContent), 0600))
 
-	result := store.loadOrRebuildIndex(ctx)
-	require.NotNil(t, result)
+	_, _, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
 	indexPath := filepath.Join(tmpDir, ".dag.index")
 	assert.True(t, fileExists(indexPath), "index should exist after build")
 

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -188,6 +188,41 @@ steps:
 	assert.NoFileExists(t, filepath.Join(tmpDir, "team", "services", "renamed.yaml"))
 }
 
+func TestRecursiveSearchCursorPaginatesByFileName(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "a"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "b"), 0750))
+	for path, name := range map[string]string{
+		filepath.Join(tmpDir, "a", "zebra.yaml"): "zebra",
+		filepath.Join(tmpDir, "b", "apple.yaml"): "apple",
+	} {
+		require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, `
+name: %s
+steps:
+  - run: echo needle
+`, name), 0600))
+	}
+
+	store := New(tmpDir, WithSkipExamples(true), WithRecursiveDiscovery(true))
+	opts := exec.SearchDAGsOptions{Query: "needle", Limit: 1, MatchLimit: 1}
+
+	first, errs, err := store.SearchCursor(context.Background(), opts)
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	require.Len(t, first.Items, 1)
+	require.Equal(t, "apple", first.Items[0].FileName)
+	require.True(t, first.HasMore)
+	require.NotEmpty(t, first.NextCursor)
+
+	opts.Cursor = first.NextCursor
+	second, errs, err := store.SearchCursor(context.Background(), opts)
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	require.Len(t, second.Items, 1)
+	require.Equal(t, "zebra", second.Items[0].FileName)
+	require.False(t, second.HasMore)
+}
+
 func TestRecursiveDiscoveryExcludesAndRecoversConflicts(t *testing.T) {
 	tmpDir := t.TempDir()
 	for _, dir := range []string{"a", "b", "c"} {

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -105,6 +105,148 @@ steps:
 	require.Equal(t, "root-dag", result.Items[0].Name, "Should only find root-dag")
 }
 
+func TestRecursiveDiscoverySupportsNestedDAGOperations(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "team", "services"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".hidden"), 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "workspaces", "ops"), 0750))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "root.yaml"), []byte(`
+name: root
+steps:
+  - run: echo root
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "team", "services", "nested.yaml"), []byte(`
+name: nested-effective-name
+labels:
+  - team=platform
+steps:
+  - run: echo needle
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".hidden", "ignored.yaml"), []byte(`
+name: ignored-hidden
+steps:
+  - run: echo needle
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "workspaces", "ops", "ignored.yaml"), []byte(`
+name: ignored-workspace
+steps:
+  - run: echo needle
+`), 0600))
+
+	store := New(tmpDir, WithSkipExamples(true), WithRecursiveDiscovery(true))
+	ctx := context.Background()
+
+	result, errs, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	require.Len(t, result.Items, 2)
+	assert.ElementsMatch(t, []string{"root", "nested-effective-name"}, []string{
+		result.Items[0].Name,
+		result.Items[1].Name,
+	})
+
+	nestedSpec, err := store.GetSpec(ctx, "nested")
+	require.NoError(t, err)
+	assert.Contains(t, nestedSpec, "nested-effective-name")
+
+	search, errs, err := store.SearchCursor(ctx, exec.SearchDAGsOptions{
+		Query:      "needle",
+		Limit:      10,
+		MatchLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	require.Len(t, search.Items, 1)
+	assert.Equal(t, "nested", search.Items[0].FileName)
+
+	labels, errs, err := store.LabelList(ctx)
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	assert.Contains(t, labels, "team=platform")
+
+	require.NoError(t, store.Rename(ctx, "nested", "renamed"))
+	assert.NoFileExists(t, filepath.Join(tmpDir, "renamed.yaml"))
+	assert.FileExists(t, filepath.Join(tmpDir, "team", "services", "renamed.yaml"))
+	require.NoError(t, store.UpdateSpec(ctx, "renamed", []byte(`
+name: nested-effective-name
+steps:
+  - run: echo updated
+`)))
+	updatedSpec, err := store.GetSpec(ctx, "renamed")
+	require.NoError(t, err)
+	assert.Contains(t, updatedSpec, "updated")
+
+	require.NoError(t, store.Create(ctx, "created", []byte(`
+name: created
+steps:
+  - run: echo created
+`)))
+	assert.FileExists(t, filepath.Join(tmpDir, "created.yaml"))
+
+	require.NoError(t, store.Delete(ctx, "renamed"))
+	assert.NoFileExists(t, filepath.Join(tmpDir, "team", "services", "renamed.yaml"))
+}
+
+func TestRecursiveDiscoveryExcludesAndRecoversConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, dir := range []string{"a", "b", "c"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, dir), 0750))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "a", "shared.yaml"), []byte(`
+name: one
+steps:
+  - run: echo a
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "b", "shared.yml"), []byte(`
+name: two
+steps:
+  - run: echo b
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "c", "unique.yaml"), []byte(`
+name: one
+steps:
+  - run: echo c
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "safe.yaml"), []byte(`
+name: safe
+steps:
+  - run: echo safe
+`), 0600))
+
+	store := New(tmpDir, WithSkipExamples(true), WithRecursiveDiscovery(true))
+	ctx := context.Background()
+
+	result, errs, err := store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "safe", result.Items[0].Name)
+	assert.Equal(t, []string{
+		`duplicate DAG file name "shared": a/shared.yaml, b/shared.yml`,
+		`duplicate DAG name "one": a/shared.yaml, c/unique.yaml`,
+	}, errs)
+
+	_, err = store.GetSpec(ctx, "shared")
+	assert.ErrorIs(t, err, exec.ErrDAGNotFound)
+	_, err = store.GetSpec(ctx, "a/shared")
+	require.NoError(t, err)
+
+	err = store.Create(ctx, "shared", []byte("steps: []\n"))
+	assert.ErrorIs(t, err, exec.ErrDAGAlreadyExists)
+
+	require.NoError(t, store.Delete(ctx, "b/shared"))
+	require.NoError(t, store.Delete(ctx, "c/unique"))
+
+	result, errs, err = store.List(ctx, exec.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, errs)
+	require.Len(t, result.Items, 2)
+	assert.ElementsMatch(t, []string{"one", "safe"}, []string{
+		result.Items[0].Name,
+		result.Items[1].Name,
+	})
+}
+
 func TestGetMetadata(t *testing.T) {
 	tmpDir := fileutil.MustTempDir("test-get-metadata")
 	defer func() {

--- a/internal/persis/file/dag_store.go
+++ b/internal/persis/file/dag_store.go
@@ -22,7 +22,15 @@ type DAGStoreOptions struct {
 	Cache                 *fileutil.Cache[*core.DAG]
 	SearchPaths           []string
 	SkipExamples          *bool
+	RecursiveDiscovery    *bool
 	SkipDirectoryCreation bool
+}
+
+// WithDAGRecursiveDiscovery controls whether DAG files are discovered recursively.
+func WithDAGRecursiveDiscovery(recursive bool) DAGStoreOption {
+	return func(o *DAGStoreOptions) {
+		o.RecursiveDiscovery = &recursive
+	}
 }
 
 // WithDAGFileCache sets the cache used for loading DAG definitions.
@@ -66,6 +74,10 @@ func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (exec.DAGStore, err
 	if options.SkipExamples != nil {
 		skipExamples = *options.SkipExamples
 	}
+	recursiveDiscovery := cfg.DAGDiscovery.Recursive
+	if options.RecursiveDiscovery != nil {
+		recursiveDiscovery = *options.RecursiveDiscovery
+	}
 	store := filedag.New(
 		cfg.Paths.DAGsDir,
 		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
@@ -74,6 +86,7 @@ func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (exec.DAGStore, err
 		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
 		filedag.WithFileCache(options.Cache),
 		filedag.WithSkipExamples(skipExamples),
+		filedag.WithRecursiveDiscovery(recursiveDiscovery),
 		filedag.WithSkipDirectoryCreation(options.SkipDirectoryCreation),
 	)
 	if s, ok := store.(*filedag.Storage); ok {

--- a/internal/persis/file/dag_store.go
+++ b/internal/persis/file/dag_store.go
@@ -22,15 +22,7 @@ type DAGStoreOptions struct {
 	Cache                 *fileutil.Cache[*core.DAG]
 	SearchPaths           []string
 	SkipExamples          *bool
-	RecursiveDiscovery    *bool
 	SkipDirectoryCreation bool
-}
-
-// WithDAGRecursiveDiscovery controls whether DAG files are discovered recursively.
-func WithDAGRecursiveDiscovery(recursive bool) DAGStoreOption {
-	return func(o *DAGStoreOptions) {
-		o.RecursiveDiscovery = &recursive
-	}
 }
 
 // WithDAGFileCache sets the cache used for loading DAG definitions.
@@ -74,10 +66,6 @@ func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (exec.DAGStore, err
 	if options.SkipExamples != nil {
 		skipExamples = *options.SkipExamples
 	}
-	recursiveDiscovery := cfg.DAGDiscovery.Recursive
-	if options.RecursiveDiscovery != nil {
-		recursiveDiscovery = *options.RecursiveDiscovery
-	}
 	store := filedag.New(
 		cfg.Paths.DAGsDir,
 		filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir),
@@ -86,7 +74,7 @@ func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (exec.DAGStore, err
 		filedag.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(cfg.Paths.DAGsDir)),
 		filedag.WithFileCache(options.Cache),
 		filedag.WithSkipExamples(skipExamples),
-		filedag.WithRecursiveDiscovery(recursiveDiscovery),
+		filedag.WithRecursiveDiscovery(cfg.DAGDiscovery.Recursive),
 		filedag.WithSkipDirectoryCreation(options.SkipDirectoryCreation),
 	)
 	if s, ok := store.(*filedag.Storage); ok {

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -900,6 +900,53 @@ steps:
 	require.Equal(t, "test_name", body.Dags[0].Dag.Name)
 }
 
+func TestRecursiveDAGDiscoveryUsesFileNameAPI(t *testing.T) {
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.DAGDiscovery.Recursive = true
+	}))
+
+	nestedDir := filepath.Join(server.Config.Paths.DAGsDir, "team", "services")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	dagSpec := fmt.Sprintf(`
+name: nested-effective-name
+steps:
+  - %s
+`, test.ShellQuote("exit 0"))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "nested-file.yaml"), []byte(dagSpec), 0600))
+
+	resp := server.Client().Get("/api/v1/dags?name=nested-file").ExpectStatus(http.StatusOK).Send(t)
+	var listBody api.ListDAGs200JSONResponse
+	resp.Unmarshal(t, &listBody)
+	require.Len(t, listBody.Dags, 1)
+	assert.Equal(t, "nested-file", listBody.Dags[0].FileName)
+	assert.Equal(t, "nested-effective-name", listBody.Dags[0].Dag.Name)
+
+	resp = server.Client().Get("/api/v1/dags/nested-file").ExpectStatus(http.StatusOK).Send(t)
+	var details api.GetDAGDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.NotNil(t, details.Dag)
+	assert.Equal(t, "nested-effective-name", details.Dag.Name)
+	require.NotNil(t, details.FilePath)
+	expectedPath, err := filepath.EvalSymlinks(filepath.Join(nestedDir, "nested-file.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, *details.FilePath)
+
+	resp = server.Client().Post("/api/v1/dags/nested-file/start", api.ExecuteDAGJSONRequestBody{}).
+		ExpectStatus(http.StatusOK).Send(t)
+	var executeBody api.ExecuteDAG200JSONResponse
+	resp.Unmarshal(t, &executeBody)
+	require.NotEmpty(t, executeBody.DagRunId)
+
+	require.Eventually(t, func() bool {
+		url := fmt.Sprintf("/api/v1/dags/nested-file/dag-runs/%s", executeBody.DagRunId)
+		var status api.GetDAGDAGRunDetails200JSONResponse
+		if !getJSONWhenAvailable(t, server, url, &status) {
+			return false
+		}
+		return status.DagRun.Status == api.Status(core.Succeeded)
+	}, dagRunEventuallyTimeout(5*time.Second), 200*time.Millisecond)
+}
+
 type stubSchedulerStateStore struct {
 	state *scheduler.SchedulerState
 }

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -44,60 +45,45 @@ type EntryReader interface {
 
 var _ EntryReader = (*entryReaderImpl)(nil)
 
-// EntryReaderOption configures DAG registry discovery.
-type EntryReaderOption func(*entryReaderImpl)
-
-// WithRecursiveDiscovery controls whether the scheduler discovers nested DAG files.
-func WithRecursiveDiscovery(recursive bool) EntryReaderOption {
-	return func(er *entryReaderImpl) {
-		er.recursiveDiscovery = recursive
-	}
-}
-
 type dagFileStamp struct {
 	size    int64
 	modTime int64
 }
 
-type recursiveDAGSnapshot struct {
-	registry        map[string]*core.DAG
-	stamps          map[string]dagFileStamp
-	discoveryErrors []string
+type registryState struct {
+	dags   map[string]*core.DAG
+	stamps map[string]dagFileStamp
+	issues []string
 }
 
 // entryReaderImpl manages DAGs on local filesystem.
 type entryReaderImpl struct {
-	targetDir          string
-	registry           map[string]*core.DAG
-	stamps             map[string]dagFileStamp
-	watchedDirs        map[string]struct{}
-	lock               sync.Mutex
-	dagStore           exec.DAGStore
-	dagSource          *dagFileSource
-	watcher            filenotify.FileWatcher
-	recursiveDiscovery bool
-	quit               chan struct{}
-	closeOnce          sync.Once
-	events             chan DAGChangeEvent
+	targetDir   string
+	registry    map[string]*core.DAG
+	stamps      map[string]dagFileStamp
+	watchedDirs map[string]struct{}
+	lock        sync.Mutex
+	dagStore    exec.DAGStore
+	dagSource   *dagFileSource
+	watcher     filenotify.FileWatcher
+	recursive   bool
+	quit        chan struct{}
+	closeOnce   sync.Once
+	events      chan DAGChangeEvent
 }
 
 // NewEntryReader creates a new DAG manager with the given configuration.
-func NewEntryReader(dir string, dagCli exec.DAGStore, opts ...EntryReaderOption) EntryReader {
-	er := &entryReaderImpl{
+func NewEntryReader(dir string, dagCli exec.DAGStore, recursive bool) EntryReader {
+	return &entryReaderImpl{
 		targetDir:   dir,
 		registry:    make(map[string]*core.DAG),
 		stamps:      make(map[string]dagFileStamp),
 		watchedDirs: make(map[string]struct{}),
 		dagStore:    dagCli,
 		dagSource:   newDAGFileSource(dir),
+		recursive:   recursive,
 		quit:        make(chan struct{}),
 	}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(er)
-		}
-	}
-	return er
 }
 
 // setEvents wires the event channel used to notify the TickPlanner of DAG
@@ -108,7 +94,7 @@ func (er *entryReaderImpl) setEvents(ch chan DAGChangeEvent) {
 
 // Init loads the initial DAG registry and starts watching the target directory.
 func (er *entryReaderImpl) Init(ctx context.Context) error {
-	if er.recursiveDiscovery {
+	if er.recursive {
 		return er.initRecursive(ctx)
 	}
 
@@ -137,7 +123,7 @@ func (er *entryReaderImpl) Start(ctx context.Context) {
 			logger.Error(ctx, "Entry reader watcher panicked", tag.Error(panicToError(r)))
 		}
 	}()
-	if er.recursiveDiscovery {
+	if er.recursive {
 		er.startRecursive(ctx)
 		return
 	}
@@ -206,12 +192,12 @@ func (er *entryReaderImpl) startRecursive(ctx context.Context) {
 			if !ok {
 				return
 			}
-			if recursiveEventMayChangeCatalog(event) {
+			if needsRecursiveRefresh(event) {
 				scheduleRefresh()
 			}
 		case <-refresh:
 			refresh = nil
-			if err := er.refreshRecursive(ctx, true, false); err != nil {
+			if err := er.refreshRecursive(ctx); err != nil {
 				logger.Error(ctx, "Failed to refresh recursive DAG registry", tag.Error(err))
 			}
 		case err, ok := <-er.watcher.Errors():
@@ -223,7 +209,7 @@ func (er *entryReaderImpl) startRecursive(ctx context.Context) {
 	}
 }
 
-func recursiveEventMayChangeCatalog(event fsnotify.Event) bool {
+func needsRecursiveRefresh(event fsnotify.Event) bool {
 	if fileutil.IsYAMLFile(event.Name) {
 		return true
 	}
@@ -367,48 +353,70 @@ func (er *entryReaderImpl) DAGStore() exec.DAGStore {
 
 func (er *entryReaderImpl) initRecursive(ctx context.Context) error {
 	er.watcher = filenotify.New(time.Minute)
-	if err := er.refreshRecursive(ctx, false, true); err != nil {
+
+	scan, err := dagdiscovery.Scan(er.targetDir, true)
+	if err != nil {
 		_ = er.watcher.Close()
 		return fmt.Errorf("failed to initialize recursive DAGs: %w", err)
 	}
+	for _, dir := range scan.Dirs {
+		if err := er.watcher.Add(dir); err != nil {
+			_ = er.watcher.Close()
+			return fmt.Errorf(
+				"failed to initialize recursive DAGs: failed to watch DAG directory %s: %w",
+				dir,
+				err,
+			)
+		}
+		er.watchedDirs[dir] = struct{}{}
+	}
+
+	state, err := er.loadRegistry(ctx)
+	if err != nil {
+		_ = er.watcher.Close()
+		return fmt.Errorf("failed to initialize recursive DAGs: %w", err)
+	}
+	for _, issue := range state.issues {
+		logger.Error(ctx, "DAG excluded from scheduler", tag.Error(errors.New(issue)))
+	}
+
+	er.lock.Lock()
+	er.registry = state.dags
+	er.stamps = state.stamps
+	er.lock.Unlock()
 	return nil
 }
 
-func (er *entryReaderImpl) refreshRecursive(ctx context.Context, emitEvents, strictWatches bool) error {
+func (er *entryReaderImpl) refreshRecursive(ctx context.Context) error {
 	scan, err := dagdiscovery.Scan(er.targetDir, true)
 	if err != nil {
 		return err
 	}
-	if err := er.syncRecursiveWatches(ctx, scan.Directories, strictWatches); err != nil {
-		return err
-	}
+	er.syncWatches(ctx, scan.Dirs)
 
-	snapshot, err := er.recursiveRegistrySnapshot(ctx)
+	state, err := er.loadRegistry(ctx)
 	if err != nil {
 		return err
 	}
-	for _, discoveryErr := range snapshot.discoveryErrors {
-		logger.Error(ctx, "DAG excluded from scheduler", tag.Error(errors.New(discoveryErr)))
+	for _, issue := range state.issues {
+		logger.Error(ctx, "DAG excluded from scheduler", tag.Error(errors.New(issue)))
 	}
 
-	events := er.replaceRecursiveRegistry(snapshot.registry, snapshot.stamps, emitEvents)
+	events := er.replaceRegistry(state)
 	for _, event := range events {
 		er.sendEvent(ctx, event)
 	}
 	return nil
 }
 
-func (er *entryReaderImpl) syncRecursiveWatches(ctx context.Context, directories []string, strict bool) error {
-	next := make(map[string]struct{}, len(directories))
-	for _, dir := range directories {
+func (er *entryReaderImpl) syncWatches(ctx context.Context, dirs []string) {
+	next := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
 		next[dir] = struct{}{}
 		if _, exists := er.watchedDirs[dir]; exists {
 			continue
 		}
 		if err := er.watcher.Add(dir); err != nil {
-			if strict {
-				return fmt.Errorf("failed to watch DAG directory %s: %w", dir, err)
-			}
 			logger.Error(ctx, "Failed to watch DAG directory", tag.Dir(dir), tag.Error(err))
 			continue
 		}
@@ -422,81 +430,66 @@ func (er *entryReaderImpl) syncRecursiveWatches(ctx context.Context, directories
 		_ = er.watcher.Remove(dir)
 		delete(er.watchedDirs, dir)
 	}
-	return nil
 }
 
-func (er *entryReaderImpl) recursiveRegistrySnapshot(
-	ctx context.Context,
-) (recursiveDAGSnapshot, error) {
-	paginator := exec.NewPaginator(1, int(^uint(0)>>1))
-	result, discoveryErrors, err := er.dagStore.List(ctx, exec.ListDAGsOptions{Paginator: &paginator})
+func (er *entryReaderImpl) loadRegistry(ctx context.Context) (registryState, error) {
+	paginator := exec.NewPaginator(1, math.MaxInt)
+	result, issues, err := er.dagStore.List(ctx, exec.ListDAGsOptions{Paginator: &paginator})
 	if err != nil {
-		return recursiveDAGSnapshot{}, err
+		return registryState{}, err
 	}
 
-	registry := make(map[string]*core.DAG, len(result.Items))
+	dags := make(map[string]*core.DAG, len(result.Items))
 	stamps := make(map[string]dagFileStamp, len(result.Items))
 	for _, listedDAG := range result.Items {
 		if len(listedDAG.BuildErrors) > 0 {
-			discoveryErrors = append(discoveryErrors,
+			issues = append(issues,
 				fmt.Sprintf("reading %s failed: %s", listedDAG.FileName(), errors.Join(listedDAG.BuildErrors...)))
 			continue
 		}
 
-		relativePath, err := filepath.Rel(er.targetDir, listedDAG.Location)
-		if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
-			discoveryErrors = append(discoveryErrors,
+		relPath, err := filepath.Rel(er.targetDir, listedDAG.Location)
+		if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+			issues = append(issues,
 				fmt.Sprintf("DAG path is outside the discovery directory: %s", listedDAG.Location))
 			continue
 		}
-		locator := filepath.ToSlash(relativePath)
+		key := filepath.ToSlash(relPath)
+		locator := key
 		if !strings.Contains(locator, "/") {
 			locator = "./" + locator
 		}
 		dag, err := er.dagStore.GetMetadata(ctx, locator)
 		if err != nil {
-			discoveryErrors = append(discoveryErrors,
-				fmt.Sprintf("reading %s failed: %s", filepath.ToSlash(relativePath), err))
+			issues = append(issues, fmt.Sprintf("reading %s failed: %s", key, err))
 			continue
 		}
 		info, err := os.Stat(dag.Location)
 		if err != nil {
-			discoveryErrors = append(discoveryErrors,
-				fmt.Sprintf("reading %s failed: %s", filepath.ToSlash(relativePath), err))
+			issues = append(issues, fmt.Sprintf("reading %s failed: %s", key, err))
 			continue
 		}
 
-		key := filepath.ToSlash(relativePath)
-		registry[key] = dag
+		dags[key] = dag
 		stamps[key] = dagFileStamp{size: info.Size(), modTime: info.ModTime().UnixNano()}
 	}
-	sort.Strings(discoveryErrors)
-	return recursiveDAGSnapshot{
-		registry:        registry,
-		stamps:          stamps,
-		discoveryErrors: discoveryErrors,
+	sort.Strings(issues)
+	return registryState{
+		dags:   dags,
+		stamps: stamps,
+		issues: issues,
 	}, nil
 }
 
-func (er *entryReaderImpl) replaceRecursiveRegistry(
-	registry map[string]*core.DAG,
-	stamps map[string]dagFileStamp,
-	emitEvents bool,
-) []DAGChangeEvent {
+func (er *entryReaderImpl) replaceRegistry(state registryState) []DAGChangeEvent {
 	er.lock.Lock()
 	defer er.lock.Unlock()
 
-	if !emitEvents {
-		er.registry = registry
-		er.stamps = stamps
-		return nil
-	}
-
-	oldKeys := sortedDAGRegistryKeys(er.registry)
-	newKeys := sortedDAGRegistryKeys(registry)
+	oldKeys := sortedRegistryKeys(er.registry)
+	newKeys := sortedRegistryKeys(state.dags)
 	events := make([]DAGChangeEvent, 0)
 	for _, key := range oldKeys {
-		if _, exists := registry[key]; exists {
+		if _, exists := state.dags[key]; exists {
 			continue
 		}
 		if oldDAG := er.registry[key]; oldDAG != nil {
@@ -507,7 +500,7 @@ func (er *entryReaderImpl) replaceRecursiveRegistry(
 		}
 	}
 	for _, key := range newKeys {
-		dag := registry[key]
+		dag := state.dags[key]
 		oldDAG, existed := er.registry[key]
 		if !existed {
 			events = append(events, DAGChangeEvent{
@@ -524,7 +517,7 @@ func (er *entryReaderImpl) replaceRecursiveRegistry(
 			)
 			continue
 		}
-		if er.stamps[key] != stamps[key] {
+		if er.stamps[key] != state.stamps[key] {
 			events = append(events, DAGChangeEvent{
 				Type:    DAGChangeUpdated,
 				DAG:     dag,
@@ -533,12 +526,12 @@ func (er *entryReaderImpl) replaceRecursiveRegistry(
 		}
 	}
 
-	er.registry = registry
-	er.stamps = stamps
+	er.registry = state.dags
+	er.stamps = state.stamps
 	return events
 }
 
-func sortedDAGRegistryKeys(registry map[string]*core.DAG) []string {
+func sortedRegistryKeys(registry map[string]*core.DAG) []string {
 	keys := make([]string, 0, len(registry))
 	for key := range registry {
 		keys = append(keys, key)

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -5,10 +5,12 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +20,7 @@ import (
 	"github.com/dagucloud/dagu/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/internal/core"
 	"github.com/dagucloud/dagu/internal/core/exec"
+	"github.com/dagucloud/dagu/internal/dagdiscovery"
 	"github.com/dagucloud/dagu/internal/service/scheduler/filenotify"
 
 	"github.com/fsnotify/fsnotify"
@@ -41,28 +44,60 @@ type EntryReader interface {
 
 var _ EntryReader = (*entryReaderImpl)(nil)
 
+// EntryReaderOption configures DAG registry discovery.
+type EntryReaderOption func(*entryReaderImpl)
+
+// WithRecursiveDiscovery controls whether the scheduler discovers nested DAG files.
+func WithRecursiveDiscovery(recursive bool) EntryReaderOption {
+	return func(er *entryReaderImpl) {
+		er.recursiveDiscovery = recursive
+	}
+}
+
+type dagFileStamp struct {
+	size    int64
+	modTime int64
+}
+
+type recursiveDAGSnapshot struct {
+	registry        map[string]*core.DAG
+	stamps          map[string]dagFileStamp
+	discoveryErrors []string
+}
+
 // entryReaderImpl manages DAGs on local filesystem.
 type entryReaderImpl struct {
-	targetDir string
-	registry  map[string]*core.DAG
-	lock      sync.Mutex
-	dagStore  exec.DAGStore
-	dagSource *dagFileSource
-	watcher   filenotify.FileWatcher
-	quit      chan struct{}
-	closeOnce sync.Once
-	events    chan DAGChangeEvent
+	targetDir          string
+	registry           map[string]*core.DAG
+	stamps             map[string]dagFileStamp
+	watchedDirs        map[string]struct{}
+	lock               sync.Mutex
+	dagStore           exec.DAGStore
+	dagSource          *dagFileSource
+	watcher            filenotify.FileWatcher
+	recursiveDiscovery bool
+	quit               chan struct{}
+	closeOnce          sync.Once
+	events             chan DAGChangeEvent
 }
 
 // NewEntryReader creates a new DAG manager with the given configuration.
-func NewEntryReader(dir string, dagCli exec.DAGStore) EntryReader {
-	return &entryReaderImpl{
-		targetDir: dir,
-		registry:  make(map[string]*core.DAG),
-		dagStore:  dagCli,
-		dagSource: newDAGFileSource(dir),
-		quit:      make(chan struct{}),
+func NewEntryReader(dir string, dagCli exec.DAGStore, opts ...EntryReaderOption) EntryReader {
+	er := &entryReaderImpl{
+		targetDir:   dir,
+		registry:    make(map[string]*core.DAG),
+		stamps:      make(map[string]dagFileStamp),
+		watchedDirs: make(map[string]struct{}),
+		dagStore:    dagCli,
+		dagSource:   newDAGFileSource(dir),
+		quit:        make(chan struct{}),
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(er)
+		}
+	}
+	return er
 }
 
 // setEvents wires the event channel used to notify the TickPlanner of DAG
@@ -73,6 +108,10 @@ func (er *entryReaderImpl) setEvents(ch chan DAGChangeEvent) {
 
 // Init loads the initial DAG registry and starts watching the target directory.
 func (er *entryReaderImpl) Init(ctx context.Context) error {
+	if er.recursiveDiscovery {
+		return er.initRecursive(ctx)
+	}
+
 	er.lock.Lock()
 	defer er.lock.Unlock()
 
@@ -98,6 +137,11 @@ func (er *entryReaderImpl) Start(ctx context.Context) {
 			logger.Error(ctx, "Entry reader watcher panicked", tag.Error(panicToError(r)))
 		}
 	}()
+	if er.recursiveDiscovery {
+		er.startRecursive(ctx)
+		return
+	}
+
 	for {
 		select {
 		case <-er.quit:
@@ -124,6 +168,66 @@ func (er *entryReaderImpl) Start(ctx context.Context) {
 			logger.Error(ctx, "Watcher error", tag.Error(err))
 		}
 	}
+}
+
+const recursiveRefreshDelay = 75 * time.Millisecond
+
+func (er *entryReaderImpl) startRecursive(ctx context.Context) {
+	var refreshTimer *time.Timer
+	var refresh <-chan time.Time
+	scheduleRefresh := func() {
+		if refreshTimer == nil {
+			refreshTimer = time.NewTimer(recursiveRefreshDelay)
+			refresh = refreshTimer.C
+			return
+		}
+		if !refreshTimer.Stop() {
+			select {
+			case <-refreshTimer.C:
+			default:
+			}
+		}
+		refreshTimer.Reset(recursiveRefreshDelay)
+		refresh = refreshTimer.C
+	}
+	defer func() {
+		if refreshTimer != nil {
+			refreshTimer.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-er.quit:
+			return
+		case <-ctx.Done():
+			return
+		case event, ok := <-er.watcher.Events():
+			if !ok {
+				return
+			}
+			if recursiveEventMayChangeCatalog(event) {
+				scheduleRefresh()
+			}
+		case <-refresh:
+			refresh = nil
+			if err := er.refreshRecursive(ctx, true, false); err != nil {
+				logger.Error(ctx, "Failed to refresh recursive DAG registry", tag.Error(err))
+			}
+		case err, ok := <-er.watcher.Errors():
+			if !ok {
+				return
+			}
+			logger.Error(ctx, "Watcher error", tag.Error(err))
+		}
+	}
+}
+
+func recursiveEventMayChangeCatalog(event fsnotify.Event) bool {
+	if fileutil.IsYAMLFile(event.Name) {
+		return true
+	}
+	return event.Op&(fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0
 }
 
 // handleFSEvent processes a filesystem event and emits a DAGChangeEvent.
@@ -259,6 +363,188 @@ func (er *entryReaderImpl) DAGs() []*core.DAG {
 // DAGStore returns the backing DAG store for full DAG details.
 func (er *entryReaderImpl) DAGStore() exec.DAGStore {
 	return er.dagStore
+}
+
+func (er *entryReaderImpl) initRecursive(ctx context.Context) error {
+	er.watcher = filenotify.New(time.Minute)
+	if err := er.refreshRecursive(ctx, false, true); err != nil {
+		_ = er.watcher.Close()
+		return fmt.Errorf("failed to initialize recursive DAGs: %w", err)
+	}
+	return nil
+}
+
+func (er *entryReaderImpl) refreshRecursive(ctx context.Context, emitEvents, strictWatches bool) error {
+	scan, err := dagdiscovery.Scan(er.targetDir, true)
+	if err != nil {
+		return err
+	}
+	if err := er.syncRecursiveWatches(ctx, scan.Directories, strictWatches); err != nil {
+		return err
+	}
+
+	snapshot, err := er.recursiveRegistrySnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	for _, discoveryErr := range snapshot.discoveryErrors {
+		logger.Error(ctx, "DAG excluded from scheduler", tag.Error(errors.New(discoveryErr)))
+	}
+
+	events := er.replaceRecursiveRegistry(snapshot.registry, snapshot.stamps, emitEvents)
+	for _, event := range events {
+		er.sendEvent(ctx, event)
+	}
+	return nil
+}
+
+func (er *entryReaderImpl) syncRecursiveWatches(ctx context.Context, directories []string, strict bool) error {
+	next := make(map[string]struct{}, len(directories))
+	for _, dir := range directories {
+		next[dir] = struct{}{}
+		if _, exists := er.watchedDirs[dir]; exists {
+			continue
+		}
+		if err := er.watcher.Add(dir); err != nil {
+			if strict {
+				return fmt.Errorf("failed to watch DAG directory %s: %w", dir, err)
+			}
+			logger.Error(ctx, "Failed to watch DAG directory", tag.Dir(dir), tag.Error(err))
+			continue
+		}
+		er.watchedDirs[dir] = struct{}{}
+	}
+
+	for dir := range er.watchedDirs {
+		if _, exists := next[dir]; exists {
+			continue
+		}
+		_ = er.watcher.Remove(dir)
+		delete(er.watchedDirs, dir)
+	}
+	return nil
+}
+
+func (er *entryReaderImpl) recursiveRegistrySnapshot(
+	ctx context.Context,
+) (recursiveDAGSnapshot, error) {
+	paginator := exec.NewPaginator(1, int(^uint(0)>>1))
+	result, discoveryErrors, err := er.dagStore.List(ctx, exec.ListDAGsOptions{Paginator: &paginator})
+	if err != nil {
+		return recursiveDAGSnapshot{}, err
+	}
+
+	registry := make(map[string]*core.DAG, len(result.Items))
+	stamps := make(map[string]dagFileStamp, len(result.Items))
+	for _, listedDAG := range result.Items {
+		if len(listedDAG.BuildErrors) > 0 {
+			discoveryErrors = append(discoveryErrors,
+				fmt.Sprintf("reading %s failed: %s", listedDAG.FileName(), errors.Join(listedDAG.BuildErrors...)))
+			continue
+		}
+
+		relativePath, err := filepath.Rel(er.targetDir, listedDAG.Location)
+		if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+			discoveryErrors = append(discoveryErrors,
+				fmt.Sprintf("DAG path is outside the discovery directory: %s", listedDAG.Location))
+			continue
+		}
+		locator := filepath.ToSlash(relativePath)
+		if !strings.Contains(locator, "/") {
+			locator = "./" + locator
+		}
+		dag, err := er.dagStore.GetMetadata(ctx, locator)
+		if err != nil {
+			discoveryErrors = append(discoveryErrors,
+				fmt.Sprintf("reading %s failed: %s", filepath.ToSlash(relativePath), err))
+			continue
+		}
+		info, err := os.Stat(dag.Location)
+		if err != nil {
+			discoveryErrors = append(discoveryErrors,
+				fmt.Sprintf("reading %s failed: %s", filepath.ToSlash(relativePath), err))
+			continue
+		}
+
+		key := filepath.ToSlash(relativePath)
+		registry[key] = dag
+		stamps[key] = dagFileStamp{size: info.Size(), modTime: info.ModTime().UnixNano()}
+	}
+	sort.Strings(discoveryErrors)
+	return recursiveDAGSnapshot{
+		registry:        registry,
+		stamps:          stamps,
+		discoveryErrors: discoveryErrors,
+	}, nil
+}
+
+func (er *entryReaderImpl) replaceRecursiveRegistry(
+	registry map[string]*core.DAG,
+	stamps map[string]dagFileStamp,
+	emitEvents bool,
+) []DAGChangeEvent {
+	er.lock.Lock()
+	defer er.lock.Unlock()
+
+	if !emitEvents {
+		er.registry = registry
+		er.stamps = stamps
+		return nil
+	}
+
+	oldKeys := sortedDAGRegistryKeys(er.registry)
+	newKeys := sortedDAGRegistryKeys(registry)
+	events := make([]DAGChangeEvent, 0)
+	for _, key := range oldKeys {
+		if _, exists := registry[key]; exists {
+			continue
+		}
+		if oldDAG := er.registry[key]; oldDAG != nil {
+			events = append(events, DAGChangeEvent{
+				Type:    DAGChangeDeleted,
+				DAGName: oldDAG.Name,
+			})
+		}
+	}
+	for _, key := range newKeys {
+		dag := registry[key]
+		oldDAG, existed := er.registry[key]
+		if !existed {
+			events = append(events, DAGChangeEvent{
+				Type:    DAGChangeAdded,
+				DAG:     dag,
+				DAGName: dag.Name,
+			})
+			continue
+		}
+		if oldDAG.Name != dag.Name {
+			events = append(events,
+				DAGChangeEvent{Type: DAGChangeDeleted, DAGName: oldDAG.Name},
+				DAGChangeEvent{Type: DAGChangeAdded, DAG: dag, DAGName: dag.Name},
+			)
+			continue
+		}
+		if er.stamps[key] != stamps[key] {
+			events = append(events, DAGChangeEvent{
+				Type:    DAGChangeUpdated,
+				DAG:     dag,
+				DAGName: dag.Name,
+			})
+		}
+	}
+
+	er.registry = registry
+	er.stamps = stamps
+	return events
+}
+
+func sortedDAGRegistryKeys(registry map[string]*core.DAG) []string {
+	keys := make([]string, 0, len(registry))
+	for key := range registry {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // initialize loads existing YAML files through the same stable snapshot path as watcher events.

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -304,7 +304,7 @@ overlap_policy: latest
 steps:
   - name: step1
     command: echo hello
-`), 0644))
+`), 0600))
 
 	store := filedag.New(
 		tmpDir,
@@ -377,11 +377,4 @@ func TestRecursiveEntryReaderWatchesNewDirectories(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected a nested DAG add event")
 	}
-
-	require.Eventually(t, func() bool {
-		er.lock.Lock()
-		defer er.lock.Unlock()
-		_, exists := er.watchedDirs[nestedDir]
-		return exists
-	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -312,7 +312,7 @@ steps:
 		filedag.WithRecursiveDiscovery(true),
 	)
 	events := make(chan DAGChangeEvent, 10)
-	er := NewEntryReader(tmpDir, store, WithRecursiveDiscovery(true)).(*entryReaderImpl)
+	er := NewEntryReader(tmpDir, store, true).(*entryReaderImpl)
 	er.events = events
 	require.NoError(t, er.Init(context.Background()))
 	t.Cleanup(er.Stop)
@@ -323,7 +323,7 @@ steps:
 
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "other"), 0750))
 	writeDAGFile(t, filepath.Join(tmpDir, "other"), "second.yaml", "shared-name")
-	require.NoError(t, er.refreshRecursive(context.Background(), true, false))
+	require.NoError(t, er.refreshRecursive(context.Background()))
 	require.Empty(t, er.DAGs())
 
 	select {
@@ -335,7 +335,7 @@ steps:
 	}
 
 	require.NoError(t, os.Remove(filepath.Join(tmpDir, "other", "second.yaml")))
-	require.NoError(t, er.refreshRecursive(context.Background(), true, false))
+	require.NoError(t, er.refreshRecursive(context.Background()))
 	require.Len(t, er.DAGs(), 1)
 
 	select {
@@ -355,7 +355,7 @@ func TestRecursiveEntryReaderWatchesNewDirectories(t *testing.T) {
 		filedag.WithRecursiveDiscovery(true),
 	)
 	events := make(chan DAGChangeEvent, 10)
-	er := NewEntryReader(tmpDir, store, WithRecursiveDiscovery(true)).(*entryReaderImpl)
+	er := NewEntryReader(tmpDir, store, true).(*entryReaderImpl)
 	er.events = events
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/internal/core"
+	filedag "github.com/dagucloud/dagu/internal/persis/file/dag"
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,4 +292,96 @@ func TestHandleFSEvent_NameChangeEmitsDeleteThenAdd(t *testing.T) {
 	assert.Equal(t, "old-name", receivedEvents[0].DAGName)
 	assert.Equal(t, DAGChangeAdded, receivedEvents[1].Type)
 	assert.Equal(t, "new-name", receivedEvents[1].DAGName)
+}
+
+func TestRecursiveEntryReaderRecoversFromNameConflict(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "team"), 0750))
+	firstPath := writeDAGFile(t, filepath.Join(tmpDir, "team"), "first.yaml", "shared-name")
+	require.NoError(t, os.WriteFile(firstPath, []byte(`
+name: shared-name
+overlap_policy: latest
+steps:
+  - name: step1
+    command: echo hello
+`), 0644))
+
+	store := filedag.New(
+		tmpDir,
+		filedag.WithSkipExamples(true),
+		filedag.WithRecursiveDiscovery(true),
+	)
+	events := make(chan DAGChangeEvent, 10)
+	er := NewEntryReader(tmpDir, store, WithRecursiveDiscovery(true)).(*entryReaderImpl)
+	er.events = events
+	require.NoError(t, er.Init(context.Background()))
+	t.Cleanup(er.Stop)
+
+	require.Len(t, er.DAGs(), 1)
+	assert.Equal(t, core.OverlapPolicyLatest, er.DAGs()[0].OverlapPolicy)
+	assert.Contains(t, er.watchedDirs, filepath.Join(tmpDir, "team"))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "other"), 0750))
+	writeDAGFile(t, filepath.Join(tmpDir, "other"), "second.yaml", "shared-name")
+	require.NoError(t, er.refreshRecursive(context.Background(), true, false))
+	require.Empty(t, er.DAGs())
+
+	select {
+	case event := <-events:
+		assert.Equal(t, DAGChangeDeleted, event.Type)
+		assert.Equal(t, "shared-name", event.DAGName)
+	case <-time.After(time.Second):
+		t.Fatal("expected conflict to remove the scheduled DAG")
+	}
+
+	require.NoError(t, os.Remove(filepath.Join(tmpDir, "other", "second.yaml")))
+	require.NoError(t, er.refreshRecursive(context.Background(), true, false))
+	require.Len(t, er.DAGs(), 1)
+
+	select {
+	case event := <-events:
+		assert.Equal(t, DAGChangeAdded, event.Type)
+		assert.Equal(t, "shared-name", event.DAGName)
+	case <-time.After(time.Second):
+		t.Fatal("expected the resolved DAG conflict to recover")
+	}
+}
+
+func TestRecursiveEntryReaderWatchesNewDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := filedag.New(
+		tmpDir,
+		filedag.WithSkipExamples(true),
+		filedag.WithRecursiveDiscovery(true),
+	)
+	events := make(chan DAGChangeEvent, 10)
+	er := NewEntryReader(tmpDir, store, WithRecursiveDiscovery(true)).(*entryReaderImpl)
+	er.events = events
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, er.Init(ctx))
+	go er.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		er.Stop()
+	})
+
+	nestedDir := filepath.Join(tmpDir, "new", "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	writeDAGFile(t, nestedDir, "watched.yaml", "watched")
+
+	select {
+	case event := <-events:
+		assert.Equal(t, DAGChangeAdded, event.Type)
+		assert.Equal(t, "watched", event.DAGName)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a nested DAG add event")
+	}
+
+	require.Eventually(t, func() bool {
+		er.lock.Lock()
+		defer er.lock.Unlock()
+		_, exists := er.watchedDirs[nestedDir]
+		return exists
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/service/scheduler/manger_test.go
+++ b/internal/service/scheduler/manger_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestReadEntries(t *testing.T) {
 	t.Run("InvalidDirectory", func(t *testing.T) {
-		manager := scheduler.NewEntryReader("invalid_directory", nil)
+		manager := scheduler.NewEntryReader("invalid_directory", nil, false)
 		err := manager.Init(context.Background())
 		require.Error(t, err)
 	})

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -373,6 +373,9 @@ func writeHelperConfigFile(t *testing.T, cfg *config.Config, configPath string) 
 		"users_dir":            cfg.Paths.UsersDir,
 		"executable":           cfg.Paths.Executable,
 	}
+	configData["dag_discovery"] = map[string]any{
+		"recursive": cfg.DAGDiscovery.Recursive,
+	}
 
 	if cfg.Queues.Enabled || len(cfg.Queues.Config) > 0 {
 		qcfg := map[string]any{

--- a/internal/test/scheduler.go
+++ b/internal/test/scheduler.go
@@ -72,7 +72,7 @@ func SetupScheduler(t *testing.T, opts ...HelperOption) *Scheduler {
 	em := scheduler.NewEntryReader(
 		helper.Config.Paths.DAGsDir,
 		ds,
-		scheduler.WithRecursiveDiscovery(helper.Config.DAGDiscovery.Recursive),
+		helper.Config.DAGDiscovery.Recursive,
 	)
 
 	// Update helper with scheduler-specific stores

--- a/internal/test/scheduler.go
+++ b/internal/test/scheduler.go
@@ -69,7 +69,11 @@ func SetupScheduler(t *testing.T, opts ...HelperOption) *Scheduler {
 
 	// Create entry reader
 	coordinatorCli := coordinator.New(helper.ServiceRegistry, coordinator.DefaultConfig())
-	em := scheduler.NewEntryReader(helper.Config.Paths.DAGsDir, ds)
+	em := scheduler.NewEntryReader(
+		helper.Config.Paths.DAGsDir,
+		ds,
+		scheduler.WithRecursiveDiscovery(helper.Config.DAGDiscovery.Recursive),
+	)
 
 	// Update helper with scheduler-specific stores
 	helper.DAGStore = ds


### PR DESCRIPTION
## Summary

- add opt-in recursive DAG discovery under the configured DAG directory
- keep nested DAG IDs stem-based while excluding file-stem and effective-name conflicts
- support nested CRUD, search, indexing, and scheduler updates as directories change
- skip workspace config directories, dot-directories, and symlink entries

## Configuration

```yaml
dag_discovery:
  recursive: true
```

The same setting is available through `DAGU_DAG_DISCOVERY_RECURSIVE`.

## Testing

- Go unit tests for discovery, configuration, persistence, scheduler, command wiring, and API behavior
- race tests for discovery, persistence, and recursive scheduler refreshes
- golangci-lint on native and Windows targets

Closes #2400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in recursive DAG discovery under `paths.dags_dir`, with the scheduler watching nested directories and emitting add/update/delete events. Duplicate file stems or DAG names are excluded and surfaced in API/list/search results. Closes #2400.

- **New Features**
  - Opt-in via `dag_discovery.recursive: true` or `DAGU_DAG_DISCOVERY_RECURSIVE=true`.
  - Scans YAML in subfolders; skips `workspaces/`, dot-directories, and symlinked entries (supports a symlinked root).
  - Uses slash-normalized relative paths; stem-based DAG IDs; excludes duplicates by stem or effective name and reports issues in errors and scheduler logs.
  - Full support across CRUD, list, search, grep, and labels; explicit path lookups (e.g. `team/service/dag`) are supported; nested paths resolve transparently.
  - Scheduler watches all discovered dirs, debounces refreshes, and emits add/update/delete on changes.
  - `NewEntryReader` now takes a `recursive` flag; index entries and loading use normalized relative paths; `paths.alt_dags_dir` remains lookup-only.
  - Updated config schema to include `dag_discovery.recursive`.

- **Migration**
  - Default is off; enable via config or env var.
  - Resolve any duplicate stems or DAG names across the tree; conflicting files are ignored until fixed.
  - In recursive mode, creates must not conflict with any existing stem; renames keep the file in its current directory.

<sup>Written for commit c74544eebee094a5c8169ef15d990ab633397fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional recursive discovery of DAG files in nested directories.
  * Added configuration through `dag_discovery.recursive` or `DAGU_DAG_DISCOVERY_RECURSIVE`.
  * Extended DAG listing, lookup, execution, search, metadata, and renaming for nested files.
  * Added conflict detection for duplicate DAG names and file stems.
  * Scheduler monitoring now detects nested DAG additions, updates, and removals.

* **Bug Fixes**
  * Improved cross-platform path handling and safer relative-path renaming.

* **Documentation**
  * Documented discovery exclusions, conflict handling, and alternate DAG directory lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->