### PR TITLE
fix: repair README onboarding guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ helm install dagu dagu/dagu --set persistence.storageClass=<your-rwx-storage-cla
 
 > Replace `<your-rwx-storage-class>` with a StorageClass that supports `ReadWriteMany`. See [charts/dagu/README.md](./charts/dagu/README.md) for chart configuration.
 
-The script installers run a guided wizard that can add Dagu to your PATH, set it up as a background service, and create the initial admin account. Homebrew, npm, Docker, and Helm install without the wizard. See Installation docs for all options.
+The script installers run a guided wizard that can add Dagu to your PATH, set it up as a background service, and create the initial admin account. Homebrew, npm, Docker, and Helm install without the wizard. See the [Installation documentation](https://docs.dagu.sh/getting-started/installation/) for all options.
 
 ### Create and run a workflow
 
@@ -145,7 +145,7 @@ Dagu exposes a built-in MCP server from the running HTTP server. Start Dagu, the
 http://localhost:8080/mcp
 ```
 
-Use MCP when you want an AI agent to read Dagu state, preview or apply workflow changes, and start, enqueue, retry, or stop runs through `dagu_read`, `dagu_change`, and `dagu_execute`. See the MCP setup guide.
+Use MCP when you want an AI agent to read Dagu state, preview or apply workflow changes, and start, enqueue, retry, or stop runs through `dagu_read`, `dagu_change`, and `dagu_execute`. See the [MCP setup guide](https://docs.dagu.sh/mcp/quickstart).
 
 For authoring-only help in Claude Code, Codex, Gemini CLI, and other AI coding tools, install the Dagu workflow authoring skill:
 
@@ -155,7 +155,7 @@ gh skill install dagucloud/dagu dagu
 
 ## How You Run Dagu?
 
-Run Dagu on one machine, scale out with distributed workers, or use a managed Dagu instance operated by us. See the Deployment Models guide.
+Run Dagu on one machine, scale out with distributed workers, or use a managed Dagu instance operated by us. See the [Deployment Models guide](https://docs.dagu.sh/overview/deployment-models).
 
 <table>
   <tr>
@@ -189,7 +189,7 @@ Run Dagu on one machine, scale out with distributed workers, or use a managed Da
 
 ### Licensing
 
-- **Community self-host:** No license key required. You operate the server, storage, upgrades, networking, and workers. Start with the installation guide.
+- **Community self-host:** No license key required. You operate the server, storage, upgrades, networking, and workers. Start with the [installation guide](https://docs.dagu.sh/getting-started/installation/).
 - **Self-host license:** Adds SSO, RBAC, audit logging, and incident SaaS integration to Dagu. See [self-host licensing](https://dagu.sh/pricing#self-host).
 - **Dagu managed instance:** Includes its own managed license. Private workers can run on your infrastructure.
 
@@ -261,20 +261,13 @@ Distributed:
 
 ## Parameter Definition
 
-Workflows can define parameters that render as typed input forms in the Web UI and can be passed as environment variables to steps.
+Workflows can define parameters that render as typed input forms in the Web UI and can be referenced by steps.
 
 ```yaml
 params:
-  - id: extract
-    run: ./scripts/extract.sh > data/raw.json
-    retry_policy:
-      limit: 3
-      interval_sec: 30
-
   - name: customer_id
     type: string
     description: Customer or account identifier
-
   - name: change_scope
     type: string
     description: What the repair is allowed to change
@@ -286,6 +279,17 @@ params:
   - name: dry_run
     type: boolean
     default: true
+
+steps:
+  - id: extract
+    run: >-
+      ./scripts/extract.sh
+      --customer "${params.customer_id}"
+      --scope "${params.change_scope}"
+      --dry-run="${params.dry_run}"
+    retry_policy:
+      limit: 3
+      interval_sec: 30
 ```
 
 <div align="center">
@@ -346,7 +350,7 @@ steps:
         return {"total": sum(input["rows"])}
 ```
 
-Dagu installs declared portable CLIs before the DAG run, exposes them on `PATH` for host command steps, and caches them on each worker. Tool provisioning uses [aqua](https://aquaproj.github.io/) as the default provider. See the Tools documentation and Dagu Actions for more details.
+Dagu installs declared portable CLIs before the DAG run, exposes them on `PATH` for host command steps, and caches them on each worker. Tool provisioning uses [aqua](https://aquaproj.github.io/) as the default provider. See the [Tools documentation](https://docs.dagu.sh/writing-workflows/tools) and [Dagu Actions](https://docs.dagu.sh/dagu-actions/) for more details.
 
 ### Third-party Dagu Actions
 
@@ -365,7 +369,7 @@ steps:
     run: echo "Notification result: ${notify.outputs.messageId}"
 ```
 
-A third-party Dagu Action package contains a DAG, manifest, schemas, and helper files behind an `action:` reference. See the Dagu Actions and Third-Party Actions documentation for details.
+A third-party Dagu Action package contains a DAG, manifest, schemas, and helper files behind an `action:` reference. See the [Dagu Actions](https://docs.dagu.sh/dagu-actions/) and [Third-Party Actions](https://docs.dagu.sh/dagu-actions/third-party) documentation for details.
 
 ### Docker step
 
@@ -561,7 +565,7 @@ model decides what runs next, so a failing test can be fixed and retried without
 that path being wired in advance. When it opens the human task the run releases
 its worker slot and resumes on the same run once someone answers.
 
-For more examples, see the Examples documentation.
+For more examples, see the [Examples documentation](https://docs.dagu.sh/writing-workflows/examples).
 
 ## Built-in Actions
 
@@ -633,7 +637,7 @@ steps:
       text: deploy complete
 ```
 
-See Custom Actions and the YAML Specification for the exact `actions`, `action`, and `run` field behavior.
+See [Custom Actions](https://docs.dagu.sh/dagu-actions/custom) and the [YAML Specification](https://docs.dagu.sh/writing-workflows/yaml-specification) for the exact `actions`, `action`, and `run` field behavior.
 
 ## Official Dagu Actions
 
@@ -649,9 +653,9 @@ Dagu Actions are official action packages maintained in the `dagucloud` GitHub o
 | `github-cli@v1` | Run GitHub issue, pull request, release, repository, and API automation through `gh` |
 | `rclone@v1` | Run portable copy, sync, check, list, and storage-management workflows through rclone |
 
-Versions are required. Pin production workflows to a version tag or commit SHA. See Official Dagu Actions for the current Dagu Action list and exact input/output contracts.
+Versions are required. Pin production workflows to a version tag or commit SHA. See [Official Dagu Actions](https://docs.dagu.sh/dagu-actions/official) for the current Dagu Action list and exact input/output contracts.
 
-For non-official packages, use Third-Party Actions such as `action: owner/repo@version`. They contain a `dagu-action.yaml` manifest and a DAG entrypoint, run as sub-DAGs, and are transferred to distributed workers as workspace bundles after the reference is resolved. See Third-Party Actions for package layout and reference formats.
+For non-official packages, use [Third-Party Actions](https://docs.dagu.sh/dagu-actions/third-party) such as `action: owner/repo@version`. They contain a `dagu-action.yaml` manifest and a DAG entrypoint, run as sub-DAGs, and are transferred to distributed workers as workspace bundles after the reference is resolved. See the documentation for package layout and reference formats.
 
 ## Security and Access Control
 
@@ -694,7 +698,7 @@ For self-hosted production deployments, treat network exposure and execution bou
 - In distributed deployments, set `peer.insecure=false` and configure peer TLS when coordinator and workers communicate across host or network boundaries.
 - Treat Docker socket mounts, root containers, and host-level executors as privileged access to the underlying machine.
 
-See Server Configuration, Docker deployment, and Distributed execution for the operator-focused guidance.
+See [Server Configuration](https://docs.dagu.sh/server-admin/configuration), [Docker deployment](https://docs.dagu.sh/server-admin/deployment/docker), and [Distributed execution](https://docs.dagu.sh/server-admin/distributed/) for operator-focused guidance.
 
 ## Observability
 
@@ -734,7 +738,7 @@ Dagu runs can write arbitrary files under `${context.paths.artifacts_dir}` in va
 
 This is useful for generated reports, screenshots, charts, exported JSON or CSV files, and other outputs that do not fit simple key/value outputs.
 
-See the Artifacts documentation and the Web UI guide for the full artifact browser workflow and screenshots.
+See the [Artifacts documentation](https://docs.dagu.sh/writing-workflows/artifacts) and the [Web UI guide](https://docs.dagu.sh/overview/web-ui) for the full artifact browser workflow and screenshots.
 
 ## Scheduling and Reliability
 
@@ -766,7 +770,7 @@ dagu coordinator
 DAGU_WORKER_LABELS=gpu=true,memory=64G dagu worker
 ```
 
-See the distributed execution documentation for setup details.
+See the [distributed execution documentation](https://docs.dagu.sh/server-admin/distributed/) for setup details.
 
 ## CLI Reference
 
@@ -832,7 +836,7 @@ if err != nil {
 fmt.Println(status.Status)
 ```
 
-The embedded API is experimental and may change. See the embedded API documentation and [examples/embedded](./examples/embedded).
+The embedded API is experimental and may change. See the [embedded API documentation](https://docs.dagu.sh/embedding/go-api) and [examples/embedded](./examples/embedded).
 
 ### Server
 


### PR DESCRIPTION
## Summary

- correct the typed-parameter example so workflow steps live under `steps:` and reference declared parameters
- link installation, MCP, deployment, actions, operations, artifacts, distributed execution, and embedding references to their canonical documentation
- keep the README quickstart aligned with the current docs structure

## Why

The parameter example accidentally placed a runnable step inside `params:`, producing misleading YAML for new users. Several onboarding references were also plain text, which added friction when readers tried to continue into the documentation.

## Impact

New users can copy a structurally valid parameter example and reach the relevant setup and reference pages directly from the README.

## Validation

- validated the corrected parameter example with `dagu validate`
- verified every README documentation URL resolves successfully
- ran `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README onboarding by correcting the parameter YAML example and adding canonical docs links. New users can copy a valid example and reach the right setup pages quickly.

- **Bug Fixes**
  - Move the runnable step out of `params:` into `steps:` and reference declared params via `${params.*}`.
  - Add canonical links across onboarding sections (Installation, MCP, deployment models, tools/actions, examples, artifacts, distributed execution, embedded API, Web UI).
  - Align quickstart wording with the current docs structure.

<sup>Written for commit abec5afb8f5e2fd1a835cc2cec24f21ae9d15e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to specific guides and reference pages.
  * Expanded workflow examples to show passing scope and dry-run options to extraction steps.
  * Added details about package layouts and official and third-party actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->