### PR TITLE
fix: allow runtime state version references

### DIFF
--- a/internal/runtime/builtin/state/config.go
+++ b/internal/runtime/builtin/state/config.go
@@ -32,6 +32,17 @@ type config struct {
 
 var stateListLimitMinimum = float64(0)
 
+var expectedVersionSchema = &jsonschema.Schema{
+	Description: "Optimistic concurrency version required for state.set or state.diff.",
+	OneOf: []*jsonschema.Schema{
+		{Type: "integer"},
+		{
+			Type:    "string",
+			Pattern: `^\$\{(?:consts|params|env|steps|foreach|context)(?:\.[A-Za-z_][A-Za-z0-9_]*)+\}$`,
+		},
+	},
+}
+
 func decodeConfig(raw map[string]any, cfg *config) error {
 	if raw == nil {
 		raw = map[string]any{}
@@ -81,7 +92,7 @@ var configSchema = &jsonschema.Schema{
 		"prefix":           {Type: "string", Description: "Key prefix for state.list."},
 		"value":            {Description: "JSON-serializable value for state.set and state.diff."},
 		"default":          {Description: "Default JSON-serializable value returned by state.get when the key is missing."},
-		"expected_version": {Type: "integer", Description: "Optimistic concurrency version required for state.set or state.diff."},
+		"expected_version": expectedVersionSchema,
 		"create_only":      {Type: "boolean", Description: "Fail state.set when the key already exists."},
 		"required":         {Type: "boolean", Description: "Fail state.get when the key is missing."},
 		"update":           {Type: "boolean", Description: "Whether state.diff writes the new value when changed. Defaults to true."},

--- a/internal/runtime/builtin/state/state_test.go
+++ b/internal/runtime/builtin/state/state_test.go
@@ -137,6 +137,24 @@ func TestStateExecutorRequiresStateStore(t *testing.T) {
 	assert.Contains(t, err.Error(), "state store")
 }
 
+func TestStateConfigSchemaAcceptsExpectedVersionReference(t *testing.T) {
+	t.Parallel()
+
+	err := core.ValidateExecutorConfig(executorType, map[string]any{
+		"key":              "cursors/api",
+		"value":            "next",
+		"expected_version": "${steps.load.outputs.version}",
+	})
+	require.NoError(t, err)
+
+	err = core.ValidateExecutorConfig(executorType, map[string]any{
+		"key":              "cursors/api",
+		"value":            "next",
+		"expected_version": "not-a-version",
+	})
+	require.Error(t, err)
+}
+
 func newStateStoreForTest(t *testing.T) dagstate.Store {
 	t.Helper()
 	return store.NewDAGStateStore(testutil.NewMemoryBackend().Collection("dag_state"))


### PR DESCRIPTION
## Summary
- allow canonical runtime value references for state action expected_version inputs
- keep literal expected_version values restricted to integers
- cover valid runtime references and invalid literal strings

## Testing
- go test ./internal/runtime/builtin/state ./internal/core/spec -count=1
- documentation workflow example validation with the built branch binary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable runtime references for `expected_version` in `state.set` and `state.diff`, so versions can come from `${steps.*}`, `${params.*}`, `${env.*}`, and other canonical sources. Reject non-integer string literals; integers remain valid.

- **Bug Fixes**
  - Updated config schema to accept an integer or a canonical runtime reference for `expected_version`.
  - Added tests: `${steps.load.outputs.version}` is accepted; arbitrary strings (e.g., `"not-a-version"`) are rejected.

<sup>Written for commit 756df2ffec810724443b21dbd6fc8a4c0c828428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports using variable references for the expected state version.
  * Integer version values continue to be supported.

* **Bug Fixes**
  * Improved validation rejects invalid literal version values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->