### PR TITLE
fix: preserve scoped notification routing

### DIFF
--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/cmdutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,13 +37,13 @@ type Result struct {
 
 // Process is a running Dagu command.
 type Process struct {
-	t          *testing.T
-	cancel     context.CancelFunc
-	done       chan struct{}
-	stdout     *bytes.Buffer
-	stderr     *bytes.Buffer
-	err        error
-	cancelOnce sync.Once
+	t        *testing.T
+	proc     *cmdutil.ManagedProcess
+	done     chan struct{}
+	stdout   *bytes.Buffer
+	stderr   *bytes.Buffer
+	err      error
+	stopOnce sync.Once
 }
 
 // ExitCode returns the command's process exit code.
@@ -99,29 +100,29 @@ func (r *Runner) RunWithEnv(env []string, args ...string) *Result {
 func (r *Runner) StartWithEnv(env []string, args ...string) *Process {
 	r.t.Helper()
 
-	ctx, cancel := context.WithCancel(context.Background())
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	// Binary-level tests intentionally execute the configured Dagu binary.
-	cmd := exec.CommandContext(ctx, daguBinary(r.t), args...) //nolint:gosec
+	cmd := exec.Command(daguBinary(r.t), args...) //nolint:gosec
 	cmd.Dir = r.dir
 	cmd.Env = appendEnv(append(isolatedEnv(r.t), "PWD="+r.dir), env...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	if err := cmd.Start(); err != nil {
-		cancel()
+	proc, err := cmdutil.StartManagedProcess(cmd)
+	if err != nil {
 		r.t.Fatalf("starting dagu %s: %v", strings.Join(args, " "), err)
 	}
 
 	process := &Process{
 		t:      r.t,
-		cancel: cancel,
+		proc:   proc,
 		done:   make(chan struct{}),
 		stdout: stdout,
 		stderr: stderr,
 	}
 	go func() {
-		process.err = cmd.Wait()
+		process.err = proc.Wait()
+		_ = proc.Release()
 		close(process.done)
 	}()
 	r.t.Cleanup(func() {
@@ -153,7 +154,12 @@ func (p *Process) Done() <-chan struct{} {
 // Stop terminates the command and waits for it to exit.
 func (p *Process) Stop() {
 	p.t.Helper()
-	p.cancelOnce.Do(p.cancel)
+	p.stopOnce.Do(func() {
+		_, _ = p.proc.Stop(cmdutil.StopRequest{
+			Intent: cmdutil.ForceTermination(),
+			Reason: cmdutil.StopReasonShutdown,
+		})
+	})
 	<-p.done
 }
 

--- a/internal/incident/model.go
+++ b/internal/incident/model.go
@@ -169,7 +169,7 @@ type Store interface {
 
 	SaveState(ctx context.Context, state *IncidentState) error
 	GetState(ctx context.Context, providerID, dedupKey string) (*IncidentState, error)
-	ListOpenStatesByDAG(ctx context.Context, dagName string) ([]*IncidentState, error)
+	ListOpenStates(ctx context.Context) ([]*IncidentState, error)
 	DeleteState(ctx context.Context, providerID, dedupKey string) error
 }
 

--- a/internal/intg/reschedule_source_file_api_test.go
+++ b/internal/intg/reschedule_source_file_api_test.go
@@ -48,7 +48,7 @@ steps:
 	attempt, dag := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, enqBody.DagRunId)
 	require.NotNil(t, attempt)
 	require.Empty(t, dag.Location)
-	require.Equal(t, dagPath, dag.SourceFile)
+	requireSameFile(t, dagPath, dag.SourceFile)
 
 	assertQueuedRunSpecFromFile(t, server, dagName, enqBody.DagRunId, true)
 
@@ -73,7 +73,16 @@ steps:
 
 	_, rescheduledDAG := test.WaitForAttemptSnapshotWithDAG(t, server, dagName, rescheduleBody.DagRunId)
 	require.Contains(t, string(rescheduledDAG.YamlData), "echo current file")
-	require.Equal(t, dagPath, rescheduledDAG.SourceFile)
+	requireSameFile(t, dagPath, rescheduledDAG.SourceFile)
+}
+
+func requireSameFile(t *testing.T, expected, actual string) {
+	t.Helper()
+	expectedInfo, err := os.Stat(expected)
+	require.NoError(t, err)
+	actualInfo, err := os.Stat(actual)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(expectedInfo, actualInfo), "%q and %q do not identify the same file", expected, actual)
 }
 
 func assertQueuedRunSpecFromFile(t *testing.T, server test.Server, dagName, dagRunID string, want bool) {

--- a/internal/intg/reschedule_source_file_api_test.go
+++ b/internal/intg/reschedule_source_file_api_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -78,9 +79,9 @@ steps:
 
 func requireSameFile(t *testing.T, expected, actual string) {
 	t.Helper()
-	expectedInfo, err := os.Stat(expected)
+	expectedInfo, err := fileutil.Stat(expected)
 	require.NoError(t, err)
-	actualInfo, err := os.Stat(actual)
+	actualInfo, err := fileutil.Stat(actual)
 	require.NoError(t, err)
 	require.True(t, os.SameFile(expectedInfo, actualInfo), "%q and %q do not identify the same file", expected, actual)
 }

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -172,6 +172,8 @@ func (att *Attempt) Open(ctx context.Context) error {
 		if err := fileutil.WriteFileAtomic(filepath.Join(dir, DAGDefinition), dagJSON, 0600); err != nil {
 			return fmt.Errorf("failed to write DAG definition: %w", err)
 		}
+	} else if dag, err := att.ReadDAG(ctx); err == nil {
+		att.dag = dag
 	}
 
 	// Create the per-run work directory so steps can use DAG_RUN_WORK_DIR immediately

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -172,8 +172,14 @@ func (att *Attempt) Open(ctx context.Context) error {
 		if err := fileutil.WriteFileAtomic(filepath.Join(dir, DAGDefinition), dagJSON, 0600); err != nil {
 			return fmt.Errorf("failed to write DAG definition: %w", err)
 		}
-	} else if dag, err := att.ReadDAG(ctx); err == nil {
-		att.dag = dag
+	} else {
+		dag, err := att.ReadDAG(ctx)
+		switch {
+		case err == nil:
+			att.dag = dag
+		case !errors.Is(err, os.ErrNotExist):
+			return fmt.Errorf("failed to restore DAG definition: %w", err)
+		}
 	}
 
 	// Create the per-run work directory so steps can use DAG_RUN_WORK_DIR immediately

--- a/internal/persis/file/dagrun/attempt_test.go
+++ b/internal/persis/file/dagrun/attempt_test.go
@@ -40,6 +40,23 @@ func TestAttempt_Open(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAttempt_OpenRejectsCorruptDAGDefinition(t *testing.T) {
+	dir := createTempDir(t)
+	file := filepath.Join(dir, "status.dat")
+	ctx := context.Background()
+
+	att, err := NewAttempt(file, nil, WithDAG(&core.DAG{Name: "test"}))
+	require.NoError(t, err)
+	require.NoError(t, att.Open(ctx))
+	require.NoError(t, att.Close(ctx))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DAGDefinition), []byte("{"), 0600))
+
+	reopened, err := NewAttempt(file, nil)
+	require.NoError(t, err)
+	err = reopened.Open(ctx)
+	require.ErrorContains(t, err, "failed to restore DAG definition")
+}
+
 func TestAttempt_Write(t *testing.T) {
 	dir := createTempDir(t)
 	file := filepath.Join(dir, "status.dat")

--- a/internal/persis/file/dagrun/attempt_test.go
+++ b/internal/persis/file/dagrun/attempt_test.go
@@ -906,7 +906,11 @@ func TestAttempt_WriteEmitsLifecycleTransitionsAndStatusUpdates(t *testing.T) {
 	service := eventstore.New(store)
 	ctx := eventstore.WithContext(context.Background(), service, eventstore.Source{Service: eventstore.SourceServiceServer})
 
-	dag := &core.DAG{Name: "TestDAG", Location: filepath.Join(dir, "test-dag.yaml")}
+	dag := &core.DAG{
+		Name:     "TestDAG",
+		Location: filepath.Join(dir, "test-dag.yaml"),
+		Labels:   core.NewLabels([]string{"workspace=ops"}),
+	}
 	att, err := NewAttempt(file, nil, WithDAG(dag))
 	require.NoError(t, err)
 	require.NoError(t, att.Open(ctx))
@@ -914,6 +918,7 @@ func TestAttempt_WriteEmitsLifecycleTransitionsAndStatusUpdates(t *testing.T) {
 	queued := createTestStatus(core.Queued)
 	queued.AttemptID = "attempt-1"
 	queued.QueuedAt = time.Now().UTC().Format(time.RFC3339)
+	queued.Labels = dag.Labels.Strings()
 	require.NoError(t, att.Write(ctx, queued))
 	require.NoError(t, att.Write(ctx, queued))
 
@@ -942,6 +947,7 @@ func TestAttempt_WriteEmitsLifecycleTransitionsAndStatusUpdates(t *testing.T) {
 	snapshot, err := eventstore.DAGRunSnapshotFromEvent(store.events[0])
 	require.NoError(t, err)
 	assert.Equal(t, "test-dag", snapshot.DAGFile)
+	assert.Equal(t, []string{"workspace=ops"}, snapshot.Labels)
 	assert.Equal(t, core.Queued, snapshot.Status)
 }
 

--- a/internal/persis/file/dagrun/attempt_test.go
+++ b/internal/persis/file/dagrun/attempt_test.go
@@ -972,7 +972,7 @@ func TestAttempt_OpenRestoresLastEmittedLifecycleState(t *testing.T) {
 	require.NoError(t, att.Close(ctx))
 	require.Len(t, store.events, 1)
 
-	reopened, err := NewAttempt(file, nil, WithDAG(dag))
+	reopened, err := NewAttempt(file, nil)
 	require.NoError(t, err)
 	require.NoError(t, reopened.Open(ctx))
 	require.NoError(t, reopened.Write(ctx, queued))
@@ -988,6 +988,9 @@ func TestAttempt_OpenRestoresLastEmittedLifecycleState(t *testing.T) {
 		eventstore.TypeDAGRunUpdated,
 		eventstore.TypeDAGRunRunning,
 	}, captureEventTypes(store.events))
+	snapshot, err := eventstore.DAGRunSnapshotFromEvent(store.events[2])
+	require.NoError(t, err)
+	assert.Equal(t, "test-dag", snapshot.DAGFile)
 }
 
 type captureEventStore struct {

--- a/internal/persis/file/incident/store.go
+++ b/internal/persis/file/incident/store.go
@@ -243,7 +243,7 @@ func (s *Store) GetState(_ context.Context, providerID, dedupKey string) (*incid
 	return state, nil
 }
 
-func (s *Store) ListOpenStatesByDAG(_ context.Context, dagName string) ([]*incident.IncidentState, error) {
+func (s *Store) ListOpenStates(_ context.Context) ([]*incident.IncidentState, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	entries, err := os.ReadDir(s.stateDir())
@@ -262,7 +262,7 @@ func (s *Store) ListOpenStatesByDAG(_ context.Context, dagName string) ([]*incid
 		if err != nil {
 			return nil, err
 		}
-		if state.DAGName != dagName || state.Status != incident.IncidentStatusOpen {
+		if state.Status != incident.IncidentStatusOpen {
 			continue
 		}
 		states = append(states, state)

--- a/internal/persis/file/incident/store_test.go
+++ b/internal/persis/file/incident/store_test.go
@@ -97,7 +97,7 @@ func TestStorePersistsPolicySetAndState(t *testing.T) {
 	assert.Equal(t, incident.IncidentStatusOpen, loadedState.Status)
 	assert.Equal(t, "daily", loadedState.DAGName)
 
-	openStates, err := store.ListOpenStatesByDAG(context.Background(), "daily")
+	openStates, err := store.ListOpenStates(context.Background())
 	require.NoError(t, err)
 	require.Len(t, openStates, 1)
 	assert.Equal(t, state.DedupKey, openStates[0].DedupKey)

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -222,6 +222,8 @@ func (m *NotificationMonitor) NotifyCompletion(status *exec.DAGRunStatus) bool {
 		Key:        NotificationSeenKey(status),
 		Type:       eventType,
 		Status:     cloneNotificationStatus(status),
+		DAGFile:    status.Name,
+		DAGLabels:  append([]string{}, status.Labels...),
 		ObservedAt: time.Now().UTC(),
 	}
 	return m.enqueueEvents(context.Background(), nil, []NotificationEvent{event})
@@ -419,7 +421,7 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 		if event == nil || !m.isInterestedEventType(event.Type) {
 			continue
 		}
-		status, err := eventstore.DAGRunStatusFromEvent(event)
+		snapshot, err := eventstore.DAGRunSnapshotFromEvent(event)
 		if err != nil {
 			m.logger.Warn("Failed to decode DAG-run event payload",
 				slog.String("event_id", event.ID),
@@ -427,6 +429,7 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 			)
 			continue
 		}
+		status := snapshot.DAGRunStatus()
 		observedAt := event.RecordedAt
 		if observedAt.IsZero() {
 			observedAt = time.Now().UTC()
@@ -435,6 +438,8 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 			Key:        NotificationSeenKey(status),
 			Type:       event.Type,
 			Status:     status,
+			DAGFile:    snapshot.DAGFile,
+			DAGLabels:  cloneNotificationEventLabels(snapshot.Labels),
 			ObservedAt: observedAt.UTC(),
 		})
 	}
@@ -1176,12 +1181,7 @@ func cloneNotificationMonitorState(state notificationMonitorState) notificationM
 		}
 		pending := make(map[string]NotificationEvent, len(destState.Pending))
 		for key, event := range destState.Pending {
-			pending[key] = NotificationEvent{
-				Key:        event.Key,
-				Type:       event.Type,
-				Status:     cloneNotificationStatus(event.Status),
-				ObservedAt: event.ObservedAt,
-			}
+			pending[key] = cloneNotificationEvent(event)
 		}
 		clone.Destinations[destination] = &notificationDestinationState{
 			Pending:   pending,
@@ -1303,12 +1303,7 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 				delete(destState.Pending, pendingKey)
 			}
 
-			destState.Pending[event.Key] = NotificationEvent{
-				Key:        event.Key,
-				Type:       event.Type,
-				Status:     cloneNotificationStatus(event.Status),
-				ObservedAt: event.ObservedAt,
-			}
+			destState.Pending[event.Key] = cloneNotificationEvent(event)
 			queued = append(queued, queuedNotification{
 				destination: destination,
 				event:       event,

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -222,8 +222,6 @@ func (m *NotificationMonitor) NotifyCompletion(status *exec.DAGRunStatus) bool {
 		Key:        NotificationSeenKey(status),
 		Type:       eventType,
 		Status:     cloneNotificationStatus(status),
-		DAGFile:    status.Name,
-		DAGLabels:  append([]string{}, status.Labels...),
 		ObservedAt: time.Now().UTC(),
 	}
 	return m.enqueueEvents(context.Background(), nil, []NotificationEvent{event})
@@ -439,7 +437,6 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 			Type:       event.Type,
 			Status:     status,
 			DAGFile:    snapshot.DAGFile,
-			DAGLabels:  cloneNotificationEventLabels(snapshot.Labels),
 			ObservedAt: observedAt.UTC(),
 		})
 	}

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -75,7 +75,7 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 
 	var (
 		mu        sync.Mutex
-		delivered []string
+		delivered []NotificationEvent
 	)
 	transport := &fakeNotificationTransport{
 		destinations: []string{"dest-1"},
@@ -84,7 +84,7 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 			defer mu.Unlock()
 			for _, event := range batch.Events {
 				if event.Status != nil {
-					delivered = append(delivered, event.Status.DAGRunID)
+					delivered = append(delivered, cloneNotificationEvent(event))
 				}
 			}
 			return true
@@ -108,20 +108,28 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 		AttemptID:  "attempt-new",
 		Status:     core.Failed,
 		Error:      "new failure",
+		Labels:     []string{"workspace=ops", "team=platform"},
 		FinishedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
 		eventstore.TypeDAGRunFailed,
 		newStatus,
-		nil,
+		map[string]any{eventstore.DAGFileNameDataKey: "briefing-file"},
 	)))
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(delivered) == 1 && delivered[0] == "run-new"
+		return len(delivered) == 1
 	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
+	mu.Lock()
+	deliveredEvent := cloneNotificationEvent(delivered[0])
+	mu.Unlock()
+	require.NotNil(t, deliveredEvent.Status)
+	assert.Equal(t, "run-new", deliveredEvent.Status.DAGRunID)
+	assert.Equal(t, "briefing-file", deliveredEvent.DAGFile)
+	assert.Equal(t, []string{"workspace=ops", "team=platform"}, deliveredEvent.DAGLabels)
 
 	require.Eventually(t, func() bool {
 		return !monitor.IsDelivered("dest-1", oldStatus) && monitor.IsDelivered("dest-1", newStatus)
@@ -149,6 +157,8 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 			NotificationSeenKey(status): {
 				Key:        NotificationSeenKey(status),
 				Status:     cloneNotificationStatus(status),
+				DAGFile:    "briefing-file",
+				DAGLabels:  []string{"workspace=ops"},
 				ObservedAt: time.Now().UTC(),
 			},
 		},
@@ -168,6 +178,8 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 			assert.Equal(t, "dest-1", destination)
 			require.Len(t, batch.Events, 1)
 			assert.Equal(t, "run-1", batch.Events[0].Status.DAGRunID)
+			assert.Equal(t, "briefing-file", batch.Events[0].DAGFile)
+			assert.Equal(t, []string{"workspace=ops"}, batch.Events[0].DAGLabels)
 			calls++
 			return true
 		},

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -129,7 +129,7 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 	require.NotNil(t, deliveredEvent.Status)
 	assert.Equal(t, "run-new", deliveredEvent.Status.DAGRunID)
 	assert.Equal(t, "briefing-file", deliveredEvent.DAGFile)
-	assert.Equal(t, []string{"workspace=ops", "team=platform"}, deliveredEvent.DAGLabels)
+	assert.Equal(t, []string{"workspace=ops", "team=platform"}, deliveredEvent.Status.Labels)
 
 	require.Eventually(t, func() bool {
 		return !monitor.IsDelivered("dest-1", oldStatus) && monitor.IsDelivered("dest-1", newStatus)
@@ -145,6 +145,7 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 
 	status := &exec.DAGRunStatus{
 		Name:      "briefing",
+		Labels:    []string{"workspace=ops"},
 		Status:    core.Failed,
 		DAGRunID:  "run-1",
 		AttemptID: "attempt-1",
@@ -158,7 +159,6 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 				Key:        NotificationSeenKey(status),
 				Status:     cloneNotificationStatus(status),
 				DAGFile:    "briefing-file",
-				DAGLabels:  []string{"workspace=ops"},
 				ObservedAt: time.Now().UTC(),
 			},
 		},
@@ -179,7 +179,7 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 			require.Len(t, batch.Events, 1)
 			assert.Equal(t, "run-1", batch.Events[0].Status.DAGRunID)
 			assert.Equal(t, "briefing-file", batch.Events[0].DAGFile)
-			assert.Equal(t, []string{"workspace=ops"}, batch.Events[0].DAGLabels)
+			assert.Equal(t, []string{"workspace=ops"}, batch.Events[0].Status.Labels)
 			calls++
 			return true
 		},

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -38,7 +38,32 @@ type NotificationEvent struct {
 	Key        string
 	Type       eventstore.EventType
 	Status     *exec.DAGRunStatus
+	DAGFile    string
+	DAGLabels  []string
 	ObservedAt time.Time
+}
+
+// DAGKey returns the file-backed identifier used by DAG-scoped configuration.
+// Events created before the file identifier was captured use the runtime name.
+func (e NotificationEvent) DAGKey() string {
+	if e.DAGFile != "" {
+		return e.DAGFile
+	}
+	if e.Status != nil {
+		return e.Status.Name
+	}
+	return ""
+}
+
+// RoutingLabels returns the DAG labels captured with the event.
+func (e NotificationEvent) RoutingLabels() []string {
+	if e.DAGLabels != nil {
+		return e.DAGLabels
+	}
+	if e.Status != nil {
+		return e.Status.Labels
+	}
+	return nil
 }
 
 // NotificationBatch is a flushed batch of buffered notification events.
@@ -194,12 +219,9 @@ func (b *NotificationBatcher) Enqueue(destination string, event NotificationEven
 	if observedAt.IsZero() {
 		observedAt = time.Now().UTC()
 	}
-	snapshot := NotificationEvent{
-		Key:        event.Key,
-		Type:       eventType,
-		Status:     cloneNotificationStatus(event.Status),
-		ObservedAt: observedAt,
-	}
+	snapshot := cloneNotificationEvent(event)
+	snapshot.Type = eventType
+	snapshot.ObservedAt = observedAt
 	runKey := NotificationRunKey(snapshot.Status)
 	destRunKey := notificationDestinationRunKey(destination, runKey)
 
@@ -749,6 +771,20 @@ func cloneNotificationStatus(status *exec.DAGRunStatus) *exec.DAGRunStatus {
 		return &fallback
 	}
 	return &clone
+}
+
+func cloneNotificationEvent(event NotificationEvent) NotificationEvent {
+	clone := event
+	clone.Status = cloneNotificationStatus(event.Status)
+	clone.DAGLabels = cloneNotificationEventLabels(event.DAGLabels)
+	return clone
+}
+
+func cloneNotificationEventLabels(labels []string) []string {
+	if labels == nil {
+		return nil
+	}
+	return append([]string{}, labels...)
 }
 
 func notificationBatchFromBucket(bucket *notificationBucket, windowEnd time.Time) NotificationBatch {

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -39,12 +39,10 @@ type NotificationEvent struct {
 	Type       eventstore.EventType
 	Status     *exec.DAGRunStatus
 	DAGFile    string
-	DAGLabels  []string
 	ObservedAt time.Time
 }
 
-// DAGKey returns the file-backed identifier used by DAG-scoped configuration.
-// Events created before the file identifier was captured use the runtime name.
+// DAGKey returns the DAG-scoped configuration key, falling back to the runtime name.
 func (e NotificationEvent) DAGKey() string {
 	if e.DAGFile != "" {
 		return e.DAGFile
@@ -53,17 +51,6 @@ func (e NotificationEvent) DAGKey() string {
 		return e.Status.Name
 	}
 	return ""
-}
-
-// RoutingLabels returns the DAG labels captured with the event.
-func (e NotificationEvent) RoutingLabels() []string {
-	if e.DAGLabels != nil {
-		return e.DAGLabels
-	}
-	if e.Status != nil {
-		return e.Status.Labels
-	}
-	return nil
 }
 
 // NotificationBatch is a flushed batch of buffered notification events.
@@ -776,15 +763,7 @@ func cloneNotificationStatus(status *exec.DAGRunStatus) *exec.DAGRunStatus {
 func cloneNotificationEvent(event NotificationEvent) NotificationEvent {
 	clone := event
 	clone.Status = cloneNotificationStatus(event.Status)
-	clone.DAGLabels = cloneNotificationEventLabels(event.DAGLabels)
 	return clone
-}
-
-func cloneNotificationEventLabels(labels []string) []string {
-	if labels == nil {
-		return nil
-	}
-	return append([]string{}, labels...)
 }
 
 func notificationBatchFromBucket(bucket *notificationBucket, windowEnd time.Time) NotificationBatch {

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -42,8 +42,8 @@ type NotificationEvent struct {
 	ObservedAt time.Time
 }
 
-// DAGKey returns the DAG-scoped configuration key, falling back to the runtime name.
-func (e NotificationEvent) DAGKey() string {
+// DAGRouteKey returns the DAG-scoped configuration key, falling back to the runtime name.
+func (e NotificationEvent) DAGRouteKey() string {
 	if e.DAGFile != "" {
 		return e.DAGFile
 	}

--- a/internal/service/chatbridge/notifications_test.go
+++ b/internal/service/chatbridge/notifications_test.go
@@ -293,16 +293,23 @@ func TestNotificationBatcher_ClonesStatusSnapshot(t *testing.T) {
 			Error: "handler failed",
 		},
 	}
-	require.True(t, batcher.Enqueue("dest-1", testNotificationEvent(status)))
+	event := testNotificationEvent(status)
+	event.DAGFile = "briefing-file"
+	event.DAGLabels = []string{"workspace=ops"}
+	require.True(t, batcher.Enqueue("dest-1", event))
 
 	status.Error = "mutated error"
 	status.Nodes[0].Error = "mutated node error"
 	status.Nodes[0].Step.Name = "mutated"
 	status.OnFailure.Error = "mutated handler error"
+	event.DAGLabels[0] = "workspace=mutated"
 
 	ready := waitForReadyBatch(t, batcher)
 	require.Len(t, ready.Batch.Events, 1)
-	got := ready.Batch.Events[0].Status
+	gotEvent := ready.Batch.Events[0]
+	assert.Equal(t, "briefing-file", gotEvent.DAGFile)
+	assert.Equal(t, []string{"workspace=ops"}, gotEvent.DAGLabels)
+	got := gotEvent.Status
 	require.NotNil(t, got)
 	assert.Equal(t, "original error", got.Error)
 	require.Len(t, got.Nodes, 1)

--- a/internal/service/chatbridge/notifications_test.go
+++ b/internal/service/chatbridge/notifications_test.go
@@ -277,6 +277,7 @@ func TestNotificationBatcher_ClonesStatusSnapshot(t *testing.T) {
 
 	status := &exec.DAGRunStatus{
 		Name:      "briefing",
+		Labels:    []string{"workspace=ops"},
 		DAGRunID:  "run-1",
 		AttemptID: "a1",
 		Status:    core.Failed,
@@ -295,23 +296,22 @@ func TestNotificationBatcher_ClonesStatusSnapshot(t *testing.T) {
 	}
 	event := testNotificationEvent(status)
 	event.DAGFile = "briefing-file"
-	event.DAGLabels = []string{"workspace=ops"}
 	require.True(t, batcher.Enqueue("dest-1", event))
 
 	status.Error = "mutated error"
+	status.Labels[0] = "workspace=mutated"
 	status.Nodes[0].Error = "mutated node error"
 	status.Nodes[0].Step.Name = "mutated"
 	status.OnFailure.Error = "mutated handler error"
-	event.DAGLabels[0] = "workspace=mutated"
 
 	ready := waitForReadyBatch(t, batcher)
 	require.Len(t, ready.Batch.Events, 1)
 	gotEvent := ready.Batch.Events[0]
 	assert.Equal(t, "briefing-file", gotEvent.DAGFile)
-	assert.Equal(t, []string{"workspace=ops"}, gotEvent.DAGLabels)
 	got := gotEvent.Status
 	require.NotNil(t, got)
 	assert.Equal(t, "original error", got.Error)
+	assert.Equal(t, []string{"workspace=ops"}, got.Labels)
 	require.Len(t, got.Nodes, 1)
 	assert.Equal(t, "fetch", got.Nodes[0].Step.Name)
 	assert.Equal(t, "node failed", got.Nodes[0].Error)

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -629,6 +629,8 @@ func (h *Handler) createAttemptForTask(ctx context.Context, task *coordinatorv1.
 		return nil, fmt.Errorf("failed to parse DAG definition: %w", err)
 	}
 	dag.SourceFile = task.SourceFile
+	labels := labelsForInitialStatus(task, dag)
+	task.Labels = strings.Join(labels, ",")
 
 	ref := exec.DAGRunRef{Name: dag.Name, ID: task.DagRunId}
 	queueDispatchStatus, err := queueDispatchStatusForTask(task)
@@ -707,7 +709,7 @@ func (h *Handler) createAttemptForTask(ctx context.Context, task *coordinatorv1.
 		return nil, fmt.Errorf("failed to open attempt: %w", err)
 	}
 
-	if err := h.writeInitialStatus(ctx, attempt, task, dag.Name, exec.DAGRunRef{}, labelsForInitialStatus(task, dag)); err != nil {
+	if err := h.writeInitialStatus(ctx, attempt, task, dag.Name, exec.DAGRunRef{}, labels); err != nil {
 		return nil, fmt.Errorf("failed to write initial status: %w", err)
 	}
 
@@ -781,6 +783,8 @@ func (h *Handler) createSubAttemptForTask(ctx context.Context, task *coordinator
 		return nil, fmt.Errorf("failed to parse DAG definition: %w", err)
 	}
 	dag.SourceFile = task.SourceFile
+	labels := labelsForInitialStatus(task, dag)
+	task.Labels = strings.Join(labels, ",")
 	attempt.SetDAG(dag)
 
 	task.AttemptId = attempt.ID()
@@ -793,7 +797,7 @@ func (h *Handler) createSubAttemptForTask(ctx context.Context, task *coordinator
 		return nil, fmt.Errorf("failed to open sub-attempt: %w", err)
 	}
 
-	if err := h.writeInitialStatus(ctx, attempt, task, task.Target, rootRef, labelsForInitialStatus(task, dag)); err != nil {
+	if err := h.writeInitialStatus(ctx, attempt, task, task.Target, rootRef, labels); err != nil {
 		return nil, fmt.Errorf("failed to write initial status: %w", err)
 	}
 
@@ -1602,6 +1606,9 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	if convErr != nil {
 		return nil, status.Error(codes.InvalidArgument, "failed to convert status: "+convErr.Error())
 	}
+	if len(dagRunStatus.Labels) == 0 {
+		dagRunStatus.Labels = splitTaskLabels(req.Labels)
+	}
 
 	// Transform worker-local log paths to coordinator paths.
 	h.transformLogPaths(dagRunStatus)
@@ -1616,7 +1623,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 
 	latestAttempt, latestStatus, err := h.resolveLatestAttempt(ctx, dagRunStatus.Name, dagRunStatus.DAGRunID, dagRunStatus.Root)
 	if err != nil {
-		bootstrappedAttempt, bootstrapped, bootstrapErr := h.bootstrapMissingSubAttempt(ctx, req.WorkerId, dagRunStatus, err)
+		bootstrappedAttempt, bootstrapped, bootstrapErr := h.bootstrapMissingSubAttempt(ctx, req.WorkerId, req.SourceFile, dagRunStatus, err)
 		if bootstrapErr != nil {
 			return nil, status.Error(codes.Internal, "failed to bootstrap sub-attempt: "+bootstrapErr.Error())
 		}
@@ -1813,6 +1820,7 @@ func (h *Handler) closeCachedWaitingAttempt(
 func (h *Handler) bootstrapMissingSubAttempt(
 	ctx context.Context,
 	workerID string,
+	sourceFile string,
 	runStatus *exec.DAGRunStatus,
 	resolveErr error,
 ) (exec.DAGRunAttempt, bool, error) {
@@ -1855,7 +1863,7 @@ func (h *Handler) bootstrapMissingSubAttempt(
 	if err != nil {
 		return nil, false, fmt.Errorf("create sub-attempt: %w", err)
 	}
-	attempt.SetDAG(&core.DAG{Name: runStatus.Name})
+	attempt.SetDAG(&core.DAG{Name: runStatus.Name, SourceFile: sourceFile})
 	if err := attempt.Open(ctx); err != nil {
 		return nil, false, fmt.Errorf("open sub-attempt: %w", err)
 	}

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1665,6 +1665,9 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	if err := h.transformArtifactPaths(ctx, latestAttempt, latestStatus, dagRunStatus); err != nil {
 		return nil, status.Error(codes.Internal, "failed to resolve artifact path: "+err.Error())
 	}
+	if len(latestStatus.Labels) > 0 {
+		dagRunStatus.Labels = append([]string(nil), latestStatus.Labels...)
+	}
 
 	attempt := latestAttempt
 	if dagRunStatus.Status == core.Waiting {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -3040,6 +3040,39 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.WithinDuration(t, time.Now(), time.UnixMilli(status.LeaseAt), 2*time.Second)
 	})
 
+	t.Run("PreservesPersistedLabels", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunStore: store})
+		ctx := context.Background()
+
+		ref := exec.DAGRunRef{Name: "test-dag", ID: "run-123"}
+		attempt := store.addAttempt(ref, &exec.DAGRunStatus{
+			Name:      ref.Name,
+			DAGRunID:  ref.ID,
+			AttemptID: "attempt-1",
+			Status:    core.Running,
+			Labels:    []string{"workspace=ops"},
+		})
+
+		protoStatus, convErr := convert.DAGRunStatusToProto(&exec.DAGRunStatus{
+			Name:      ref.Name,
+			DAGRunID:  ref.ID,
+			AttemptID: "attempt-1",
+			Status:    core.Failed,
+		})
+		require.NoError(t, convErr)
+
+		resp, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{Status: protoStatus})
+		require.NoError(t, err)
+		require.True(t, resp.Accepted)
+
+		persisted, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"workspace=ops"}, persisted.Labels)
+	})
+
 	t.Run("WaitingStatusClosesCachedAttemptBeforePersisting", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -558,6 +558,26 @@ func TestTransformArtifactPathsUsesDAGSpecificDirWithoutGlobalArtifactDir(t *tes
 	assert.Equal(t, filepath.Join(baseDir, "test-dag", "dag-run_20260412_000000Z_run-123"), incoming.ArchiveDir)
 }
 
+func TestCreateAttemptForTaskCarriesDAGLabels(t *testing.T) {
+	registerCommandExecutorCapsForCoordinatorTest()
+
+	h := NewHandler(HandlerConfig{DAGRunStore: newMockDAGRunStore()})
+	task := &coordinatorv1.Task{
+		DagRunId:   "run-123",
+		Target:     "daily",
+		SourceFile: "/dags/daily-file.yaml",
+		Definition: "name: daily\nlabels: [workspace=ops, team=platform]\nsteps:\n  - name: step1\n    run: echo hello",
+	}
+	prepared, err := h.createAttemptForTask(context.Background(), task)
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+
+	assert.Equal(t, "workspace=ops,team=platform", task.Labels)
+	status, err := prepared.attempt.ReadStatus(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"workspace=ops", "team=platform"}, status.Labels)
+}
+
 // Thread-safe getters for test assertions
 func (m *mockDAGRunAttempt) WasOpened() bool {
 	m.mu.Lock()
@@ -3479,6 +3499,8 @@ func TestHandler_ReportStatus(t *testing.T) {
 			Status:             runningProto,
 			WorkerId:           "worker-1",
 			OwnerCoordinatorId: "coord-a",
+			SourceFile:         "/dags/child-file.yaml",
+			Labels:             "workspace=ops, team=platform",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -3497,6 +3519,11 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.Equal(t, attemptKey, current.AttemptKey)
 		assert.Equal(t, core.Running, current.Status)
 		assert.Equal(t, "worker-1", current.WorkerID)
+		assert.Equal(t, []string{"workspace=ops", "team=platform"}, current.Labels)
+		dag, err := attempt.ReadDAG(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "child-dag", dag.Name)
+		assert.Equal(t, "/dags/child-file.yaml", dag.SourceFile)
 
 		lease, err := leaseStore.Get(ctx, attemptKey)
 		require.NoError(t, err)

--- a/internal/service/eventstore/eventstore_test.go
+++ b/internal/service/eventstore/eventstore_test.go
@@ -86,6 +86,7 @@ func TestNewDAGRunEventEmbedsDAGRunSnapshot(t *testing.T) {
 		Root:           exec.NewDAGRunRef("root-briefing", "root-run"),
 		Parent:         exec.NewDAGRunRef("root-briefing", "parent-run"),
 		Name:           "briefing",
+		Labels:         []string{"workspace=ops", "team=platform"},
 		DAGRunID:       "run-1",
 		AttemptID:      "attempt-1",
 		ProcGroup:      "priority-high",
@@ -125,6 +126,7 @@ func TestNewDAGRunEventEmbedsDAGRunSnapshot(t *testing.T) {
 	assert.Equal(t, status.Root.Name, snapshot.Root.Name)
 	assert.Equal(t, status.Parent.ID, snapshot.Parent.DAGRunID)
 	assert.Equal(t, status.ProcGroup, snapshot.ProcGroup)
+	assert.Equal(t, status.Labels, snapshot.Labels)
 
 	restored, err := DAGRunStatusFromEvent(event)
 	require.NoError(t, err)
@@ -132,6 +134,7 @@ func TestNewDAGRunEventEmbedsDAGRunSnapshot(t *testing.T) {
 	assert.Equal(t, status.Root, restored.Root)
 	assert.Equal(t, status.Parent, restored.Parent)
 	assert.Equal(t, status.Name, restored.Name)
+	assert.Equal(t, status.Labels, restored.Labels)
 	assert.Equal(t, status.DAGRunID, restored.DAGRunID)
 	assert.Equal(t, status.AttemptID, restored.AttemptID)
 	assert.Equal(t, status.ProcGroup, restored.ProcGroup)

--- a/internal/service/eventstore/notifications.go
+++ b/internal/service/eventstore/notifications.go
@@ -102,6 +102,7 @@ type DAGRunStatusSnapshot struct {
 	Parent         DAGRunRefSnapshot    `json:"parent"`
 	Name           string               `json:"name"`
 	DAGFile        string               `json:"dag_file,omitempty"`
+	Labels         []string             `json:"labels"`
 	DAGRunID       string               `json:"dag_run_id"`
 	AttemptID      string               `json:"attempt_id"`
 	ProcGroup      string               `json:"proc_group,omitempty"`
@@ -161,6 +162,7 @@ func newDAGRunStatusSnapshot(status *exec.DAGRunStatus, dagFile string) *DAGRunS
 		Parent:         newDAGRunRefSnapshot(status.Parent),
 		Name:           status.Name,
 		DAGFile:        dagFile,
+		Labels:         append([]string{}, status.Labels...),
 		DAGRunID:       status.DAGRunID,
 		AttemptID:      status.AttemptID,
 		ProcGroup:      status.ProcGroup,
@@ -193,6 +195,7 @@ func (s *DAGRunStatusSnapshot) DAGRunStatus() *exec.DAGRunStatus {
 		Root:           s.Root.DAGRunRef(),
 		Parent:         s.Parent.DAGRunRef(),
 		Name:           s.Name,
+		Labels:         append([]string(nil), s.Labels...),
 		DAGRunID:       s.DAGRunID,
 		AttemptID:      s.AttemptID,
 		Status:         s.Status,

--- a/internal/service/incident/memory_store_test.go
+++ b/internal/service/incident/memory_store_test.go
@@ -169,12 +169,12 @@ func (s *memoryStore) GetState(_ context.Context, providerID, dedupKey string) (
 	return &copy, nil
 }
 
-func (s *memoryStore) ListOpenStatesByDAG(_ context.Context, dagName string) ([]*incidentmodel.IncidentState, error) {
+func (s *memoryStore) ListOpenStates(_ context.Context) ([]*incidentmodel.IncidentState, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	states := make([]*incidentmodel.IncidentState, 0)
 	for _, state := range s.states {
-		if state.DAGName != dagName || state.Status != incidentmodel.IncidentStatusOpen {
+		if state.Status != incidentmodel.IncidentStatusOpen {
 			continue
 		}
 		copy := *state

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -638,18 +638,25 @@ func (s *Service) effectivePolicySetForEvent(ctx context.Context, event chatbrid
 	if event.Status == nil {
 		return nil
 	}
-	if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeDAG, "", event.Status.Name); err == nil {
+	dagKey := event.DAGKey()
+	if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeDAG, "", dagKey); err == nil {
 		if !policySet.InheritParent {
 			return policySet
 		}
 	} else if !errors.Is(err, incidentmodel.ErrPolicySetNotFound) {
 		s.logger.Warn("Failed to load DAG incident policy set",
-			slog.String("dag", event.Status.Name),
+			slog.String("dag", dagKey),
 			slog.String("error", err.Error()),
 		)
 	}
-	workspaceName := eventWorkspaceName(event)
-	if workspaceName != "" {
+	workspaceName, workspaceState := eventWorkspace(event)
+	switch workspaceState {
+	case exec.WorkspaceLabelInvalid:
+		s.logger.Warn("Skipping incident routing for invalid workspace labels",
+			slog.String("dag", dagKey),
+		)
+		return nil
+	case exec.WorkspaceLabelValid:
 		if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeWorkspace, workspaceName, ""); err == nil {
 			if !policySet.InheritParent {
 				return policySet
@@ -660,6 +667,9 @@ func (s *Service) effectivePolicySetForEvent(ctx context.Context, event chatbrid
 				slog.String("error", err.Error()),
 			)
 		}
+	case exec.WorkspaceLabelMissing:
+	default:
+		return nil
 	}
 	policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeGlobal, "", "")
 	if err != nil {
@@ -745,14 +755,15 @@ func isFinalFailure(status *exec.DAGRunStatus) bool {
 }
 
 func eventWorkspaceName(event chatbridge.NotificationEvent) string {
-	if event.Status == nil {
-		return ""
-	}
-	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+	workspaceName, state := eventWorkspace(event)
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}
 	return ""
+}
+
+func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
+	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.RoutingLabels()))
 }
 
 func findPolicy(policySet *incidentmodel.PolicySet, policyID string) (incidentmodel.Policy, bool) {
@@ -1143,8 +1154,10 @@ func rejectPrivateAddress(addr netip.Addr) error {
 func (s *Service) testEvent() chatbridge.NotificationEvent {
 	now := time.Now().UTC()
 	return chatbridge.NotificationEvent{
-		Key:  "incident-test:" + uuid.NewString(),
-		Type: eventstore.TypeDAGRunFailed,
+		Key:       "incident-test:" + uuid.NewString(),
+		Type:      eventstore.TypeDAGRunFailed,
+		DAGFile:   "incident-test",
+		DAGLabels: []string{},
 		Status: &exec.DAGRunStatus{
 			Name:       "incident-test",
 			DAGRunID:   "incident-test-" + uuid.NewString(),

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -649,14 +649,8 @@ func (s *Service) effectivePolicySetForEvent(ctx context.Context, event chatbrid
 			slog.String("error", err.Error()),
 		)
 	}
-	workspaceName, workspaceState := eventWorkspace(event)
-	switch workspaceState {
-	case exec.WorkspaceLabelInvalid:
-		s.logger.Warn("Skipping incident routing for invalid workspace labels",
-			slog.String("dag", dagKey),
-		)
-		return nil
-	case exec.WorkspaceLabelValid:
+	workspaceName := eventWorkspaceName(event)
+	if workspaceName != "" {
 		if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeWorkspace, workspaceName, ""); err == nil {
 			if !policySet.InheritParent {
 				return policySet
@@ -667,9 +661,6 @@ func (s *Service) effectivePolicySetForEvent(ctx context.Context, event chatbrid
 				slog.String("error", err.Error()),
 			)
 		}
-	case exec.WorkspaceLabelMissing:
-	default:
-		return nil
 	}
 	policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeGlobal, "", "")
 	if err != nil {
@@ -755,15 +746,14 @@ func isFinalFailure(status *exec.DAGRunStatus) bool {
 }
 
 func eventWorkspaceName(event chatbridge.NotificationEvent) string {
-	workspaceName, state := eventWorkspace(event)
+	if event.Status == nil {
+		return ""
+	}
+	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}
 	return ""
-}
-
-func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
-	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.RoutingLabels()))
 }
 
 func findPolicy(policySet *incidentmodel.PolicySet, policyID string) (incidentmodel.Policy, bool) {
@@ -1154,10 +1144,8 @@ func rejectPrivateAddress(addr netip.Addr) error {
 func (s *Service) testEvent() chatbridge.NotificationEvent {
 	now := time.Now().UTC()
 	return chatbridge.NotificationEvent{
-		Key:       "incident-test:" + uuid.NewString(),
-		Type:      eventstore.TypeDAGRunFailed,
-		DAGFile:   "incident-test",
-		DAGLabels: []string{},
+		Key:  "incident-test:" + uuid.NewString(),
+		Type: eventstore.TypeDAGRunFailed,
 		Status: &exec.DAGRunStatus{
 			Name:       "incident-test",
 			DAGRunID:   "incident-test-" + uuid.NewString(),

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -349,12 +349,12 @@ func (s *Service) NotificationDestinations() []string {
 	if !s.incidentsAllowed() || s.store == nil {
 		return nil
 	}
-	policySets, err := s.ListPolicySets(context.Background())
+	ctx := context.Background()
+	var destinations []string
+	policySets, err := s.ListPolicySets(ctx)
 	if err != nil {
 		s.logger.Warn("Failed to list incident destinations", slog.String("error", err.Error()))
-		return nil
 	}
-	var destinations []string
 	for _, policySet := range policySets {
 		if !policySetDeliversOwnPolicies(policySet) {
 			continue
@@ -364,6 +364,16 @@ func (s *Service) NotificationDestinations() []string {
 				destinations = append(destinations, policyDestinationID(policySet, policy.ID))
 			}
 		}
+	}
+	states, err := s.store.ListOpenStates(ctx)
+	if err != nil {
+		s.logger.Warn("Failed to list open incident destinations", slog.String("error", err.Error()))
+	}
+	for _, state := range states {
+		if state == nil || state.ProviderID == "" || state.DedupKey == "" {
+			continue
+		}
+		destinations = append(destinations, stateDestinationID(state.ProviderID, state.DedupKey))
 	}
 	slices.Sort(destinations)
 	return destinations
@@ -395,7 +405,7 @@ func (s *Service) resolveDestinationsForEvent(ctx context.Context, event chatbri
 	if s.store == nil || event.Status == nil || event.Status.Name == "" {
 		return nil
 	}
-	states, err := s.store.ListOpenStatesByDAG(ctx, event.Status.Name)
+	states, err := s.store.ListOpenStates(ctx)
 	if err != nil {
 		s.logger.Warn("Failed to list open incident states",
 			slog.String("dag", event.Status.Name),
@@ -405,7 +415,10 @@ func (s *Service) resolveDestinationsForEvent(ctx context.Context, event chatbri
 	}
 	destinations := make([]string, 0, len(states))
 	for _, state := range states {
-		if state == nil || state.ProviderID == "" || state.DedupKey == "" {
+		if state == nil || state.DAGName != event.Status.Name {
+			continue
+		}
+		if state.ProviderID == "" || state.DedupKey == "" {
 			continue
 		}
 		destinations = append(destinations, stateDestinationID(state.ProviderID, state.DedupKey))

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -392,13 +392,14 @@ func (s *Service) NotificationDestinationsForEvent(event chatbridge.Notification
 }
 
 func (s *Service) resolveDestinationsForEvent(ctx context.Context, event chatbridge.NotificationEvent) []string {
-	if s.store == nil || event.Status == nil || event.Status.Name == "" {
+	dagKey := event.DAGKey()
+	if s.store == nil || event.Status == nil || dagKey == "" {
 		return nil
 	}
-	states, err := s.store.ListOpenStatesByDAG(ctx, event.Status.Name)
+	states, err := s.store.ListOpenStatesByDAG(ctx, dagKey)
 	if err != nil {
 		s.logger.Warn("Failed to list open incident states",
-			slog.String("dag", event.Status.Name),
+			slog.String("dag", dagKey),
 			slog.String("error", err.Error()),
 		)
 		return nil
@@ -562,7 +563,7 @@ func (s *Service) openIncident(ctx context.Context, provider *incidentmodel.Prov
 		ProviderID:    provider.ID,
 		PolicyID:      policy.ID,
 		Workspace:     eventWorkspaceName(event),
-		DAGName:       event.Status.Name,
+		DAGName:       event.DAGKey(),
 		DedupKey:      dedupKey,
 		Status:        incidentmodel.IncidentStatusOpen,
 		ExternalID:    externalID,
@@ -592,7 +593,7 @@ func (s *Service) resolveIncident(ctx context.Context, provider *incidentmodel.P
 	if state.Status != incidentmodel.IncidentStatusOpen {
 		return true
 	}
-	if event.Status != nil && state.DAGName != "" && state.DAGName != event.Status.Name {
+	if state.DAGName != "" && state.DAGName != event.DAGKey() {
 		return true
 	}
 	delivery, err := s.withRetry(ctx, func() (*providerDeliveryResult, error) {
@@ -622,7 +623,9 @@ func (s *Service) resolveIncident(ctx context.Context, provider *incidentmodel.P
 	if delivery.EventID != "" {
 		state.LastEventID = delivery.EventID
 	}
-	state.PolicyID = policy.ID
+	if policy.ID != "" {
+		state.PolicyID = policy.ID
+	}
 	normalized, err := incidentmodel.NormalizeState(state)
 	if err != nil {
 		s.logger.Warn("Failed to normalize resolved incident state", slog.String("error", err.Error()))
@@ -720,6 +723,9 @@ func incidentEventSupported(event chatbridge.NotificationEvent) bool {
 	if event.Status == nil || event.Status.Name == "" {
 		return false
 	}
+	if _, state := eventWorkspace(event); state == exec.WorkspaceLabelInvalid {
+		return false
+	}
 	switch event.Type {
 	case eventstore.TypeDAGRunFailed:
 		return isFinalFailure(event.Status)
@@ -746,14 +752,18 @@ func isFinalFailure(status *exec.DAGRunStatus) bool {
 }
 
 func eventWorkspaceName(event chatbridge.NotificationEvent) string {
-	if event.Status == nil {
-		return ""
-	}
-	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+	workspaceName, state := eventWorkspace(event)
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}
 	return ""
+}
+
+func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
+	if event.Status == nil {
+		return "", exec.WorkspaceLabelMissing
+	}
+	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
 }
 
 func findPolicy(policySet *incidentmodel.PolicySet, policyID string) (incidentmodel.Policy, bool) {
@@ -839,13 +849,14 @@ func parseStateDestinationID(value string) parsedStateDestination {
 }
 
 func systemDedupKey(providerID string, event chatbridge.NotificationEvent) string {
-	if providerID == "" || event.Status == nil || event.Status.Name == "" {
+	dagKey := event.DAGKey()
+	if providerID == "" || event.Status == nil || dagKey == "" {
 		return ""
 	}
 	canonical := strings.Join([]string{
 		"provider", providerID,
 		"workspace", eventWorkspaceName(event),
-		"dag", event.Status.Name,
+		"dag", dagKey,
 	}, "\x00")
 	sum := sha256.Sum256([]byte(canonical))
 	return "dagu:v1:" + hex.EncodeToString(sum[:16])

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -392,14 +392,13 @@ func (s *Service) NotificationDestinationsForEvent(event chatbridge.Notification
 }
 
 func (s *Service) resolveDestinationsForEvent(ctx context.Context, event chatbridge.NotificationEvent) []string {
-	dagKey := event.DAGKey()
-	if s.store == nil || event.Status == nil || dagKey == "" {
+	if s.store == nil || event.Status == nil || event.Status.Name == "" {
 		return nil
 	}
-	states, err := s.store.ListOpenStatesByDAG(ctx, dagKey)
+	states, err := s.store.ListOpenStatesByDAG(ctx, event.Status.Name)
 	if err != nil {
 		s.logger.Warn("Failed to list open incident states",
-			slog.String("dag", dagKey),
+			slog.String("dag", event.Status.Name),
 			slog.String("error", err.Error()),
 		)
 		return nil
@@ -563,7 +562,7 @@ func (s *Service) openIncident(ctx context.Context, provider *incidentmodel.Prov
 		ProviderID:    provider.ID,
 		PolicyID:      policy.ID,
 		Workspace:     eventWorkspaceName(event),
-		DAGName:       event.DAGKey(),
+		DAGName:       event.Status.Name,
 		DedupKey:      dedupKey,
 		Status:        incidentmodel.IncidentStatusOpen,
 		ExternalID:    externalID,
@@ -593,7 +592,7 @@ func (s *Service) resolveIncident(ctx context.Context, provider *incidentmodel.P
 	if state.Status != incidentmodel.IncidentStatusOpen {
 		return true
 	}
-	if state.DAGName != "" && state.DAGName != event.DAGKey() {
+	if event.Status != nil && state.DAGName != "" && state.DAGName != event.Status.Name {
 		return true
 	}
 	delivery, err := s.withRetry(ctx, func() (*providerDeliveryResult, error) {
@@ -849,14 +848,13 @@ func parseStateDestinationID(value string) parsedStateDestination {
 }
 
 func systemDedupKey(providerID string, event chatbridge.NotificationEvent) string {
-	dagKey := event.DAGKey()
-	if providerID == "" || event.Status == nil || dagKey == "" {
+	if providerID == "" || event.Status == nil || event.Status.Name == "" {
 		return ""
 	}
 	canonical := strings.Join([]string{
 		"provider", providerID,
 		"workspace", eventWorkspaceName(event),
-		"dag", dagKey,
+		"dag", event.Status.Name,
 	}, "\x00")
 	sum := sha256.Sum256([]byte(canonical))
 	return "dagu:v1:" + hex.EncodeToString(sum[:16])

--- a/internal/service/incident/service.go
+++ b/internal/service/incident/service.go
@@ -415,7 +415,7 @@ func (s *Service) resolveDestinationsForEvent(ctx context.Context, event chatbri
 	}
 	destinations := make([]string, 0, len(states))
 	for _, state := range states {
-		if state == nil || state.DAGName != event.Status.Name {
+		if !stateMatchesEvent(state, event) {
 			continue
 		}
 		if state.ProviderID == "" || state.DedupKey == "" {
@@ -605,7 +605,7 @@ func (s *Service) resolveIncident(ctx context.Context, provider *incidentmodel.P
 	if state.Status != incidentmodel.IncidentStatusOpen {
 		return true
 	}
-	if event.Status != nil && state.DAGName != "" && state.DAGName != event.Status.Name {
+	if !stateMatchesEvent(state, event) {
 		return true
 	}
 	delivery, err := s.withRetry(ctx, func() (*providerDeliveryResult, error) {
@@ -653,14 +653,14 @@ func (s *Service) effectivePolicySetForEvent(ctx context.Context, event chatbrid
 	if event.Status == nil {
 		return nil
 	}
-	dagKey := event.DAGKey()
-	if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeDAG, "", dagKey); err == nil {
+	routeKey := event.DAGRouteKey()
+	if policySet, err := s.loadPolicySet(ctx, incidentmodel.PolicyScopeDAG, "", routeKey); err == nil {
 		if !policySet.InheritParent {
 			return policySet
 		}
 	} else if !errors.Is(err, incidentmodel.ErrPolicySetNotFound) {
 		s.logger.Warn("Failed to load DAG incident policy set",
-			slog.String("dag", dagKey),
+			slog.String("dag", routeKey),
 			slog.String("error", err.Error()),
 		)
 	}
@@ -776,6 +776,14 @@ func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceL
 		return "", exec.WorkspaceLabelMissing
 	}
 	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+}
+
+func stateMatchesEvent(state *incidentmodel.IncidentState, event chatbridge.NotificationEvent) bool {
+	if state == nil || event.Status == nil || state.DAGName != event.Status.Name {
+		return false
+	}
+	workspaceName, workspaceState := eventWorkspace(event)
+	return workspaceState != exec.WorkspaceLabelInvalid && state.Workspace == workspaceName
 }
 
 func findPolicy(policySet *incidentmodel.PolicySet, policyID string) (incidentmodel.Policy, bool) {

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -48,7 +48,7 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	})
 	dagSet := store.savePolicySet(t, &incidentmodel.PolicySet{
 		Scope:         incidentmodel.PolicyScopeDAG,
-		DAGName:       "daily",
+		DAGName:       "daily-file",
 		Enabled:       true,
 		InheritParent: false,
 		Policies: []incidentmodel.Policy{{
@@ -58,13 +58,14 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	})
 	svc := New(store)
 	event := failedEvent("daily", "run-1")
-	event.Status.Labels = []string{"workspace=ops"}
+	event.DAGFile = "daily-file"
+	event.DAGLabels = []string{"workspace=ops"}
 
 	destinations := svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
 	assert.Equal(t, dagSet.Policies[0].ID, parsePolicyDestinationID(destinations[0]).PolicyID)
 
-	require.NoError(t, store.DeletePolicySet(context.Background(), incidentmodel.PolicyScopeDAG, "", "daily"))
+	require.NoError(t, store.DeletePolicySet(context.Background(), incidentmodel.PolicyScopeDAG, "", "daily-file"))
 	destinations = svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
 	assert.Equal(t, workspaceSet.Policies[0].ID, parsePolicyDestinationID(destinations[0]).PolicyID)
@@ -74,6 +75,9 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	destinations = svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
 	assert.Equal(t, globalSet.Policies[0].ID, parsePolicyDestinationID(destinations[0]).PolicyID)
+
+	event.DAGLabels = []string{"workspace=ops", "workspace=engineering"}
+	assert.Empty(t, svc.NotificationDestinationsForEvent(event))
 }
 
 func TestServiceSuppressesFailureIncidentUntilAutoRetriesAreExhausted(t *testing.T) {
@@ -117,8 +121,10 @@ func TestServicePagerDutyTriggerAndResolvePayloads(t *testing.T) {
 	store := newMemoryStore(t)
 	provider := store.saveProvider(t, "PagerDuty", incidentmodel.ProviderPagerDuty)
 	policySet := store.savePolicySet(t, &incidentmodel.PolicySet{
-		Scope:   incidentmodel.PolicyScopeGlobal,
-		Enabled: true,
+		Scope:         incidentmodel.PolicyScopeDAG,
+		DAGName:       "daily-file",
+		Enabled:       true,
+		InheritParent: false,
 		Policies: []incidentmodel.Policy{{
 			ProviderID:          provider.ID,
 			Enabled:             true,
@@ -131,6 +137,7 @@ func TestServicePagerDutyTriggerAndResolvePayloads(t *testing.T) {
 	})
 	svc := New(store, WithHTTPClient(client), WithPublicURL("https://dagu.example.com/workflows"))
 	failure := failedEvent("daily", "run-1")
+	failure.DAGFile = "daily-file"
 	destinations := svc.NotificationDestinationsForEvent(failure)
 	require.Len(t, destinations, 1)
 

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +24,7 @@ import (
 	incidentmodel "github.com/dagucloud/dagu/v2/internal/incident"
 	"github.com/dagucloud/dagu/v2/internal/service/chatbridge"
 	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
+	"github.com/dagucloud/dagu/v2/internal/testutil"
 )
 
 func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *testing.T) {
@@ -235,13 +239,15 @@ func TestServiceResolvesOpenIncidentAfterRoutingIsDisabled(t *testing.T) {
 	assert.Equal(t, requests[0]["dedup_key"], requests[1]["dedup_key"])
 }
 
-func TestServiceResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
-	var requests []map[string]any
+func TestMonitorResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
+	requests := make(chan map[string]any, 1)
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		defer func() { _ = req.Body.Close() }()
 		var payload map[string]any
-		require.NoError(t, json.NewDecoder(req.Body).Decode(&payload))
-		requests = append(requests, payload)
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			return nil, err
+		}
+		requests <- payload
 		return &http.Response{
 			StatusCode: http.StatusAccepted,
 			Header:     make(http.Header),
@@ -262,25 +268,46 @@ func TestServiceResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
 	require.NoError(t, store.SaveState(context.Background(), state))
 
 	svc := New(store, WithHTTPClient(client))
-	success := failedEvent("daily", "run-1")
-	success.Type = eventstore.TypeDAGRunSucceeded
-	success.Status.Status = core.Succeeded
-	success.Status.Error = ""
-	success.DAGFile = "daily-file"
+	events := &incidentMonitorEventStore{}
+	eventService := eventstore.New(events)
+	cfg := chatbridge.DefaultNotificationMonitorConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	cfg.SuccessWindow = 5 * time.Millisecond
+	cfg.UrgentWindow = 5 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	monitor := chatbridge.NewNotificationMonitor(
+		eventService,
+		filepath.Join(t.TempDir(), "state.json"),
+		svc,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg,
+	)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+	require.Eventually(t, events.bootstrapped, time.Second, 10*time.Millisecond)
 
-	destinations := svc.NotificationDestinationsForEvent(success)
-	require.Len(t, destinations, 1)
-	require.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
-		Events: []chatbridge.NotificationEvent{success},
-	}, false))
+	success := failedEvent("daily", "run-1").Status
+	success.Status = core.Succeeded
+	success.Error = ""
+	require.NoError(t, eventService.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
+		eventstore.TypeDAGRunSucceeded,
+		success,
+		map[string]any{eventstore.DAGFileNameDataKey: "daily-file"},
+	)))
 
-	require.Len(t, requests, 1)
-	assert.Equal(t, "resolve", requests[0]["event_action"])
-	assert.Equal(t, "existing-dedup-key", requests[0]["dedup_key"])
-	state, err = store.GetState(context.Background(), provider.ID, "existing-dedup-key")
-	require.NoError(t, err)
-	assert.Equal(t, incidentmodel.IncidentStatusResolved, state.Status)
+	require.Eventually(t, func() bool {
+		state, err = store.GetState(context.Background(), provider.ID, "existing-dedup-key")
+		return err == nil && state.Status == incidentmodel.IncidentStatusResolved
+	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, "existing-policy", state.PolicyID)
+	select {
+	case request := <-requests:
+		assert.Equal(t, "resolve", request["event_action"])
+		assert.Equal(t, "existing-dedup-key", request["dedup_key"])
+	default:
+		t.Fatal("expected PagerDuty resolution request")
+	}
 }
 
 func TestServiceReopenedIncidentUsesFreshOpenedAt(t *testing.T) {
@@ -446,4 +473,50 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
+}
+
+type incidentMonitorEventStore struct {
+	mu        sync.Mutex
+	events    []*eventstore.Event
+	headCalls int
+}
+
+var _ eventstore.Store = (*incidentMonitorEventStore)(nil)
+var _ eventstore.NotificationReader = (*incidentMonitorEventStore)(nil)
+
+func (s *incidentMonitorEventStore) Emit(_ context.Context, event *eventstore.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *incidentMonitorEventStore) Query(context.Context, eventstore.QueryFilter) (*eventstore.QueryResult, error) {
+	return &eventstore.QueryResult{}, nil
+}
+
+func (s *incidentMonitorEventStore) NotificationHeadCursor(context.Context) (eventstore.NotificationCursor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.headCalls++
+	return s.cursor(), nil
+}
+
+func (s *incidentMonitorEventStore) ReadNotificationEvents(_ context.Context, cursor eventstore.NotificationCursor) ([]*eventstore.Event, eventstore.NotificationCursor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	index := int(cursor.Normalize().CommittedOffsets["events"])
+	return append([]*eventstore.Event(nil), s.events[index:]...), s.cursor(), nil
+}
+
+func (s *incidentMonitorEventStore) bootstrapped() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.headCalls > 0
+}
+
+func (s *incidentMonitorEventStore) cursor() eventstore.NotificationCursor {
+	return eventstore.NotificationCursor{
+		CommittedOffsets: map[string]int64{"events": int64(len(s.events))},
+	}
 }

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -239,7 +239,7 @@ func TestServiceResolvesOpenIncidentAfterRoutingIsDisabled(t *testing.T) {
 	assert.Equal(t, requests[0]["dedup_key"], requests[1]["dedup_key"])
 }
 
-func TestMonitorResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
+func TestMonitorKeepsIncidentRecoveryWithinWorkspace(t *testing.T) {
 	requests := make(chan map[string]any, 1)
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		defer func() { _ = req.Body.Close() }()
@@ -257,19 +257,36 @@ func TestMonitorResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
 
 	store := newMemoryStore(t)
 	provider := store.saveProvider(t, "PagerDuty", incidentmodel.ProviderPagerDuty)
-	state, err := incidentmodel.NormalizeState(&incidentmodel.IncidentState{
-		ProviderID: provider.ID,
-		PolicyID:   "existing-policy",
-		DAGName:    "daily",
-		DedupKey:   "existing-dedup-key",
-		Status:     incidentmodel.IncidentStatusOpen,
-	})
-	require.NoError(t, err)
-	require.NoError(t, store.SaveState(context.Background(), state))
+	const (
+		opsDedupKey         = "ops-dedup-key"
+		engineeringDedupKey = "engineering-dedup-key"
+	)
+	saveOpenState := func(workspace, dedupKey string) {
+		state, err := incidentmodel.NormalizeState(&incidentmodel.IncidentState{
+			ProviderID: provider.ID,
+			PolicyID:   workspace + "-policy",
+			Workspace:  workspace,
+			DAGName:    "daily",
+			DedupKey:   dedupKey,
+			Status:     incidentmodel.IncidentStatusOpen,
+		})
+		require.NoError(t, err)
+		require.NoError(t, store.SaveState(context.Background(), state))
+	}
+	saveOpenState("ops", opsDedupKey)
+	saveOpenState("engineering", engineeringDedupKey)
 
 	svc := New(store, WithHTTPClient(client))
-	events := &incidentMonitorEventStore{}
-	eventService := eventstore.New(events)
+	success := failedEvent("daily", "run-1")
+	success.Type = eventstore.TypeDAGRunSucceeded
+	success.Status.Status = core.Succeeded
+	success.Status.Error = ""
+	success.Status.Labels = []string{"workspace=engineering"}
+	success.DAGFile = "daily-file"
+	require.Equal(t, []string{stateDestinationID(provider.ID, engineeringDedupKey)}, svc.NotificationDestinationsForEvent(success))
+
+	eventStore := &monitorEventStore{}
+	eventService := eventstore.New(eventStore)
 	cfg := chatbridge.DefaultNotificationMonitorConfig()
 	cfg.PollInterval = 5 * time.Millisecond
 	cfg.SuccessWindow = 5 * time.Millisecond
@@ -284,30 +301,40 @@ func TestMonitorResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
 	)
 	stopMonitor := testutil.StartContextRunner(t, monitor)
 	defer stopMonitor()
-	require.Eventually(t, events.bootstrapped, time.Second, 10*time.Millisecond)
+	require.Eventually(t, eventStore.bootstrapped, time.Second, 10*time.Millisecond)
 
-	success := failedEvent("daily", "run-1").Status
-	success.Status = core.Succeeded
-	success.Error = ""
 	require.NoError(t, eventService.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer, Instance: "test"},
 		eventstore.TypeDAGRunSucceeded,
-		success,
+		success.Status,
 		map[string]any{eventstore.DAGFileNameDataKey: "daily-file"},
 	)))
 
+	var engineeringState *incidentmodel.IncidentState
 	require.Eventually(t, func() bool {
-		state, err = store.GetState(context.Background(), provider.ID, "existing-dedup-key")
-		return err == nil && state.Status == incidentmodel.IncidentStatusResolved
+		var err error
+		engineeringState, err = store.GetState(context.Background(), provider.ID, engineeringDedupKey)
+		return err == nil && engineeringState.Status == incidentmodel.IncidentStatusResolved
 	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, "existing-policy", state.PolicyID)
+	assert.Equal(t, "engineering-policy", engineeringState.PolicyID)
+	opsState, err := store.GetState(context.Background(), provider.ID, opsDedupKey)
+	require.NoError(t, err)
+	assert.Equal(t, incidentmodel.IncidentStatusOpen, opsState.Status)
+
 	select {
 	case request := <-requests:
 		assert.Equal(t, "resolve", request["event_action"])
-		assert.Equal(t, "existing-dedup-key", request["dedup_key"])
+		assert.Equal(t, engineeringDedupKey, request["dedup_key"])
 	default:
 		t.Fatal("expected PagerDuty resolution request")
 	}
+
+	require.True(t, svc.FlushNotificationBatch(context.Background(), stateDestinationID(provider.ID, opsDedupKey), chatbridge.NotificationBatch{
+		Events: []chatbridge.NotificationEvent{success},
+	}, false))
+	opsState, err = store.GetState(context.Background(), provider.ID, opsDedupKey)
+	require.NoError(t, err)
+	assert.Equal(t, incidentmodel.IncidentStatusOpen, opsState.Status)
 }
 
 func TestServiceReopenedIncidentUsesFreshOpenedAt(t *testing.T) {
@@ -475,47 +502,47 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
-type incidentMonitorEventStore struct {
+type monitorEventStore struct {
 	mu        sync.Mutex
 	events    []*eventstore.Event
 	headCalls int
 }
 
-var _ eventstore.Store = (*incidentMonitorEventStore)(nil)
-var _ eventstore.NotificationReader = (*incidentMonitorEventStore)(nil)
+var _ eventstore.Store = (*monitorEventStore)(nil)
+var _ eventstore.NotificationReader = (*monitorEventStore)(nil)
 
-func (s *incidentMonitorEventStore) Emit(_ context.Context, event *eventstore.Event) error {
+func (s *monitorEventStore) Emit(_ context.Context, event *eventstore.Event) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.events = append(s.events, event)
 	return nil
 }
 
-func (s *incidentMonitorEventStore) Query(context.Context, eventstore.QueryFilter) (*eventstore.QueryResult, error) {
+func (s *monitorEventStore) Query(context.Context, eventstore.QueryFilter) (*eventstore.QueryResult, error) {
 	return &eventstore.QueryResult{}, nil
 }
 
-func (s *incidentMonitorEventStore) NotificationHeadCursor(context.Context) (eventstore.NotificationCursor, error) {
+func (s *monitorEventStore) NotificationHeadCursor(context.Context) (eventstore.NotificationCursor, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.headCalls++
 	return s.cursor(), nil
 }
 
-func (s *incidentMonitorEventStore) ReadNotificationEvents(_ context.Context, cursor eventstore.NotificationCursor) ([]*eventstore.Event, eventstore.NotificationCursor, error) {
+func (s *monitorEventStore) ReadNotificationEvents(_ context.Context, cursor eventstore.NotificationCursor) ([]*eventstore.Event, eventstore.NotificationCursor, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	index := int(cursor.Normalize().CommittedOffsets["events"])
 	return append([]*eventstore.Event(nil), s.events[index:]...), s.cursor(), nil
 }
 
-func (s *incidentMonitorEventStore) bootstrapped() bool {
+func (s *monitorEventStore) bootstrapped() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.headCalls > 0
 }
 
-func (s *incidentMonitorEventStore) cursor() eventstore.NotificationCursor {
+func (s *monitorEventStore) cursor() eventstore.NotificationCursor {
 	return eventstore.NotificationCursor{
 		CommittedOffsets: map[string]int64{"events": int64(len(s.events))},
 	}

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -235,8 +235,13 @@ func TestServiceResolvesOpenIncidentAfterRoutingIsDisabled(t *testing.T) {
 	assert.Equal(t, requests[0]["dedup_key"], requests[1]["dedup_key"])
 }
 
-func TestServiceIncidentIdentityUsesDAGFile(t *testing.T) {
-	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+func TestServiceResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
+	var requests []map[string]any
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		defer func() { _ = req.Body.Close() }()
+		var payload map[string]any
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&payload))
+		requests = append(requests, payload)
 		return &http.Response{
 			StatusCode: http.StatusAccepted,
 			Header:     make(http.Header),
@@ -246,52 +251,35 @@ func TestServiceIncidentIdentityUsesDAGFile(t *testing.T) {
 
 	store := newMemoryStore(t)
 	provider := store.saveProvider(t, "PagerDuty", incidentmodel.ProviderPagerDuty)
-	store.savePolicySet(t, &incidentmodel.PolicySet{
-		Scope:   incidentmodel.PolicyScopeGlobal,
-		Enabled: true,
-		Policies: []incidentmodel.Policy{{
-			ProviderID: provider.ID,
-			Enabled:    true,
-		}},
+	state, err := incidentmodel.NormalizeState(&incidentmodel.IncidentState{
+		ProviderID: provider.ID,
+		PolicyID:   "existing-policy",
+		DAGName:    "daily",
+		DedupKey:   "existing-dedup-key",
+		Status:     incidentmodel.IncidentStatusOpen,
 	})
+	require.NoError(t, err)
+	require.NoError(t, store.SaveState(context.Background(), state))
+
 	svc := New(store, WithHTTPClient(client))
-
-	first := failedEvent("daily", "run-1")
-	first.DAGFile = "daily-a"
-	second := failedEvent("daily", "run-2")
-	second.DAGFile = "daily-b"
-	for _, event := range []chatbridge.NotificationEvent{first, second} {
-		destinations := svc.NotificationDestinationsForEvent(event)
-		require.Len(t, destinations, 1)
-		require.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
-			Events: []chatbridge.NotificationEvent{event},
-		}, false))
-	}
-
-	firstKey := systemDedupKey(provider.ID, first)
-	secondKey := systemDedupKey(provider.ID, second)
-	require.NotEqual(t, firstKey, secondKey)
-
-	success := first
+	success := failedEvent("daily", "run-1")
 	success.Type = eventstore.TypeDAGRunSucceeded
-	success.Status = cloneStatus(first.Status)
-	success.Status.Name = "renamed"
 	success.Status.Status = core.Succeeded
 	success.Status.Error = ""
+	success.DAGFile = "daily-file"
+
 	destinations := svc.NotificationDestinationsForEvent(success)
 	require.Len(t, destinations, 1)
 	require.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
 		Events: []chatbridge.NotificationEvent{success},
 	}, false))
 
-	firstState, err := store.GetState(context.Background(), provider.ID, firstKey)
+	require.Len(t, requests, 1)
+	assert.Equal(t, "resolve", requests[0]["event_action"])
+	assert.Equal(t, "existing-dedup-key", requests[0]["dedup_key"])
+	state, err = store.GetState(context.Background(), provider.ID, "existing-dedup-key")
 	require.NoError(t, err)
-	secondState, err := store.GetState(context.Background(), provider.ID, secondKey)
-	require.NoError(t, err)
-	assert.Equal(t, "daily-a", firstState.DAGName)
-	assert.Equal(t, incidentmodel.IncidentStatusResolved, firstState.Status)
-	assert.Equal(t, "daily-b", secondState.DAGName)
-	assert.Equal(t, incidentmodel.IncidentStatusOpen, secondState.Status)
+	assert.Equal(t, incidentmodel.IncidentStatusResolved, state.Status)
 }
 
 func TestServiceReopenedIncidentUsesFreshOpenedAt(t *testing.T) {

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -280,6 +280,7 @@ func TestServiceResolvesRuntimeNameIncidentWithDAGFileRouting(t *testing.T) {
 	state, err = store.GetState(context.Background(), provider.ID, "existing-dedup-key")
 	require.NoError(t, err)
 	assert.Equal(t, incidentmodel.IncidentStatusResolved, state.Status)
+	assert.Equal(t, "existing-policy", state.PolicyID)
 }
 
 func TestServiceReopenedIncidentUsesFreshOpenedAt(t *testing.T) {

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -75,6 +75,9 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	destinations = svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
 	assert.Equal(t, globalSet.Policies[0].ID, parsePolicyDestinationID(destinations[0]).PolicyID)
+
+	event.Status.Labels = []string{"workspace=ops", "workspace=engineering"}
+	assert.Empty(t, svc.NotificationDestinationsForEvent(event))
 }
 
 func TestServiceSuppressesFailureIncidentUntilAutoRetriesAreExhausted(t *testing.T) {
@@ -230,6 +233,65 @@ func TestServiceResolvesOpenIncidentAfterRoutingIsDisabled(t *testing.T) {
 	assert.Equal(t, "trigger", requests[0]["event_action"])
 	assert.Equal(t, "resolve", requests[1]["event_action"])
 	assert.Equal(t, requests[0]["dedup_key"], requests[1]["dedup_key"])
+}
+
+func TestServiceIncidentIdentityUsesDAGFile(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+		}, nil
+	})}
+
+	store := newMemoryStore(t)
+	provider := store.saveProvider(t, "PagerDuty", incidentmodel.ProviderPagerDuty)
+	store.savePolicySet(t, &incidentmodel.PolicySet{
+		Scope:   incidentmodel.PolicyScopeGlobal,
+		Enabled: true,
+		Policies: []incidentmodel.Policy{{
+			ProviderID: provider.ID,
+			Enabled:    true,
+		}},
+	})
+	svc := New(store, WithHTTPClient(client))
+
+	first := failedEvent("daily", "run-1")
+	first.DAGFile = "daily-a"
+	second := failedEvent("daily", "run-2")
+	second.DAGFile = "daily-b"
+	for _, event := range []chatbridge.NotificationEvent{first, second} {
+		destinations := svc.NotificationDestinationsForEvent(event)
+		require.Len(t, destinations, 1)
+		require.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
+			Events: []chatbridge.NotificationEvent{event},
+		}, false))
+	}
+
+	firstKey := systemDedupKey(provider.ID, first)
+	secondKey := systemDedupKey(provider.ID, second)
+	require.NotEqual(t, firstKey, secondKey)
+
+	success := first
+	success.Type = eventstore.TypeDAGRunSucceeded
+	success.Status = cloneStatus(first.Status)
+	success.Status.Name = "renamed"
+	success.Status.Status = core.Succeeded
+	success.Status.Error = ""
+	destinations := svc.NotificationDestinationsForEvent(success)
+	require.Len(t, destinations, 1)
+	require.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
+		Events: []chatbridge.NotificationEvent{success},
+	}, false))
+
+	firstState, err := store.GetState(context.Background(), provider.ID, firstKey)
+	require.NoError(t, err)
+	secondState, err := store.GetState(context.Background(), provider.ID, secondKey)
+	require.NoError(t, err)
+	assert.Equal(t, "daily-a", firstState.DAGName)
+	assert.Equal(t, incidentmodel.IncidentStatusResolved, firstState.Status)
+	assert.Equal(t, "daily-b", secondState.DAGName)
+	assert.Equal(t, incidentmodel.IncidentStatusOpen, secondState.Status)
 }
 
 func TestServiceReopenedIncidentUsesFreshOpenedAt(t *testing.T) {

--- a/internal/service/incident/service_test.go
+++ b/internal/service/incident/service_test.go
@@ -59,7 +59,7 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	svc := New(store)
 	event := failedEvent("daily", "run-1")
 	event.DAGFile = "daily-file"
-	event.DAGLabels = []string{"workspace=ops"}
+	event.Status.Labels = []string{"workspace=ops"}
 
 	destinations := svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
@@ -75,9 +75,6 @@ func TestServiceNotificationDestinationsUseDAGWorkspaceGlobalInheritance(t *test
 	destinations = svc.NotificationDestinationsForEvent(event)
 	require.Len(t, destinations, 1)
 	assert.Equal(t, globalSet.Policies[0].ID, parsePolicyDestinationID(destinations[0]).PolicyID)
-
-	event.DAGLabels = []string{"workspace=ops", "workspace=engineering"}
-	assert.Empty(t, svc.NotificationDestinationsForEvent(event))
 }
 
 func TestServiceSuppressesFailureIncidentUntilAutoRetriesAreExhausted(t *testing.T) {

--- a/internal/service/notification/service.go
+++ b/internal/service/notification/service.go
@@ -464,15 +464,16 @@ func (s *Service) NotificationDestinations() []string {
 }
 
 func (s *Service) NotificationDestinationsForEvent(event chatbridge.NotificationEvent) []string {
-	if event.Status == nil || event.Status.Name == "" {
+	dagKey := event.DAGKey()
+	if event.Status == nil || dagKey == "" {
 		return nil
 	}
 	ctx := context.Background()
-	setting, err := s.GetByDAGName(ctx, event.Status.Name)
+	setting, err := s.GetByDAGName(ctx, dagKey)
 	if err != nil {
 		if !errors.Is(err, notificationmodel.ErrSettingsNotFound) {
 			s.logger.Warn("Failed to load notification settings",
-				slog.String("dag", event.Status.Name),
+				slog.String("dag", dagKey),
 				slog.String("error", err.Error()),
 			)
 			return nil
@@ -824,17 +825,24 @@ func (s *Service) deliverTestTargets(ctx context.Context, targets []resolvedTarg
 
 func (s *Service) testEvent(ctx context.Context, dagName string, eventType eventstore.EventType) chatbridge.NotificationEvent {
 	status := testStatus(dagName, eventType)
-	if s.dagStore != nil {
-		if dag, err := s.dagStore.GetDetails(ctx, dagName); err == nil && dag != nil {
-			status.Labels = dag.Labels.Strings()
-		}
-	}
-	return chatbridge.NotificationEvent{
+	event := chatbridge.NotificationEvent{
 		Key:        "notification-test:" + dagName,
 		Type:       eventType,
 		Status:     status,
+		DAGFile:    dagName,
+		DAGLabels:  []string{},
 		ObservedAt: time.Now().UTC(),
 	}
+	if s.dagStore != nil {
+		if dag, err := s.dagStore.GetDetails(ctx, dagName); err == nil && dag != nil {
+			if dag.Name != "" {
+				status.Name = dag.Name
+			}
+			event.DAGLabels = append(event.DAGLabels, dag.Labels.Strings()...)
+			status.Labels = append([]string(nil), event.DAGLabels...)
+		}
+	}
+	return event
 }
 
 type resolvedTarget struct {
@@ -1109,8 +1117,14 @@ func (s *Service) routeSetDestinationsForEvent(
 }
 
 func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridge.NotificationEvent) *notificationmodel.RouteSet {
-	workspaceName := eventWorkspaceName(event)
-	if workspaceName != "" {
+	workspaceName, workspaceState := eventWorkspace(event)
+	switch workspaceState {
+	case exec.WorkspaceLabelInvalid:
+		s.logger.Warn("Skipping notification routing for invalid workspace labels",
+			slog.String("dag", event.DAGKey()),
+		)
+		return nil
+	case exec.WorkspaceLabelValid:
 		workspaceRouteSet, err := s.loadRouteSet(ctx, notificationmodel.RouteScopeWorkspace, workspaceName)
 		if err == nil {
 			if !workspaceRouteSet.InheritGlobal {
@@ -1123,6 +1137,9 @@ func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridg
 			)
 			return nil
 		}
+	case exec.WorkspaceLabelMissing:
+	default:
+		return nil
 	}
 	globalRouteSet, err := s.loadRouteSet(ctx, notificationmodel.RouteScopeGlobal, "")
 	if err == nil {
@@ -1139,7 +1156,7 @@ func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridg
 func matchingEvents(setting *notificationmodel.Settings, target notificationmodel.Target, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event.Status == nil || event.Status.Name != setting.DAGName {
+		if event.Status == nil || event.DAGKey() != setting.DAGName {
 			continue
 		}
 		if !notificationmodel.IsTargetEventEnabled(setting, target, event.Type) {
@@ -1153,7 +1170,7 @@ func matchingEvents(setting *notificationmodel.Settings, target notificationmode
 func matchingSubscriptionEvents(setting *notificationmodel.Settings, subscription notificationmodel.Subscription, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event.Status == nil || event.Status.Name != setting.DAGName {
+		if event.Status == nil || event.DAGKey() != setting.DAGName {
 			continue
 		}
 		if !notificationmodel.IsSubscriptionEventEnabled(setting, subscription, event.Type) {
@@ -1167,17 +1184,18 @@ func matchingSubscriptionEvents(setting *notificationmodel.Settings, subscriptio
 func (s *Service) matchingRouteEvents(ctx context.Context, routeSet *notificationmodel.RouteSet, route notificationmodel.Route, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event.Status == nil || event.Status.Name == "" {
+		dagKey := event.DAGKey()
+		if event.Status == nil || dagKey == "" {
 			continue
 		}
 		if !notificationmodel.IsRouteEventEnabled(routeSet, route, event.Type) {
 			continue
 		}
-		if _, err := s.GetByDAGName(ctx, event.Status.Name); err == nil {
+		if _, err := s.GetByDAGName(ctx, dagKey); err == nil {
 			continue
 		} else if !errors.Is(err, notificationmodel.ErrSettingsNotFound) {
 			s.logger.Warn("Failed to load notification settings",
-				slog.String("dag", event.Status.Name),
+				slog.String("dag", dagKey),
 				slog.String("error", err.Error()),
 			)
 			continue
@@ -1192,14 +1210,15 @@ func (s *Service) matchingRouteEvents(ctx context.Context, routeSet *notificatio
 }
 
 func eventWorkspaceName(event chatbridge.NotificationEvent) string {
-	if event.Status == nil {
-		return ""
-	}
-	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+	workspaceName, state := eventWorkspace(event)
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}
 	return ""
+}
+
+func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
+	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.RoutingLabels()))
 }
 
 func (s *Service) sendEmail(ctx context.Context, target notificationmodel.Target, events []chatbridge.NotificationEvent) error {

--- a/internal/service/notification/service.go
+++ b/internal/service/notification/service.go
@@ -825,24 +825,21 @@ func (s *Service) deliverTestTargets(ctx context.Context, targets []resolvedTarg
 
 func (s *Service) testEvent(ctx context.Context, dagName string, eventType eventstore.EventType) chatbridge.NotificationEvent {
 	status := testStatus(dagName, eventType)
-	event := chatbridge.NotificationEvent{
-		Key:        "notification-test:" + dagName,
-		Type:       eventType,
-		Status:     status,
-		DAGFile:    dagName,
-		DAGLabels:  []string{},
-		ObservedAt: time.Now().UTC(),
-	}
 	if s.dagStore != nil {
 		if dag, err := s.dagStore.GetDetails(ctx, dagName); err == nil && dag != nil {
 			if dag.Name != "" {
 				status.Name = dag.Name
 			}
-			event.DAGLabels = append(event.DAGLabels, dag.Labels.Strings()...)
-			status.Labels = append([]string(nil), event.DAGLabels...)
+			status.Labels = dag.Labels.Strings()
 		}
 	}
-	return event
+	return chatbridge.NotificationEvent{
+		Key:        "notification-test:" + dagName,
+		Type:       eventType,
+		Status:     status,
+		DAGFile:    dagName,
+		ObservedAt: time.Now().UTC(),
+	}
 }
 
 type resolvedTarget struct {
@@ -1117,14 +1114,8 @@ func (s *Service) routeSetDestinationsForEvent(
 }
 
 func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridge.NotificationEvent) *notificationmodel.RouteSet {
-	workspaceName, workspaceState := eventWorkspace(event)
-	switch workspaceState {
-	case exec.WorkspaceLabelInvalid:
-		s.logger.Warn("Skipping notification routing for invalid workspace labels",
-			slog.String("dag", event.DAGKey()),
-		)
-		return nil
-	case exec.WorkspaceLabelValid:
+	workspaceName := eventWorkspaceName(event)
+	if workspaceName != "" {
 		workspaceRouteSet, err := s.loadRouteSet(ctx, notificationmodel.RouteScopeWorkspace, workspaceName)
 		if err == nil {
 			if !workspaceRouteSet.InheritGlobal {
@@ -1137,9 +1128,6 @@ func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridg
 			)
 			return nil
 		}
-	case exec.WorkspaceLabelMissing:
-	default:
-		return nil
 	}
 	globalRouteSet, err := s.loadRouteSet(ctx, notificationmodel.RouteScopeGlobal, "")
 	if err == nil {
@@ -1210,15 +1198,14 @@ func (s *Service) matchingRouteEvents(ctx context.Context, routeSet *notificatio
 }
 
 func eventWorkspaceName(event chatbridge.NotificationEvent) string {
-	workspaceName, state := eventWorkspace(event)
+	if event.Status == nil {
+		return ""
+	}
+	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}
 	return ""
-}
-
-func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
-	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.RoutingLabels()))
 }
 
 func (s *Service) sendEmail(ctx context.Context, target notificationmodel.Target, events []chatbridge.NotificationEvent) error {

--- a/internal/service/notification/service.go
+++ b/internal/service/notification/service.go
@@ -464,19 +464,19 @@ func (s *Service) NotificationDestinations() []string {
 }
 
 func (s *Service) NotificationDestinationsForEvent(event chatbridge.NotificationEvent) []string {
-	dagKey := event.DAGKey()
-	if event.Status == nil || dagKey == "" {
+	routeKey := event.DAGRouteKey()
+	if event.Status == nil || routeKey == "" {
 		return nil
 	}
 	if _, state := eventWorkspace(event); state == exec.WorkspaceLabelInvalid {
 		return nil
 	}
 	ctx := context.Background()
-	setting, err := s.GetByDAGName(ctx, dagKey)
+	setting, err := s.GetByDAGName(ctx, routeKey)
 	if err != nil {
 		if !errors.Is(err, notificationmodel.ErrSettingsNotFound) {
 			s.logger.Warn("Failed to load notification settings",
-				slog.String("dag", dagKey),
+				slog.String("dag", routeKey),
 				slog.String("error", err.Error()),
 			)
 			return nil
@@ -1150,7 +1150,7 @@ func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridg
 func matchingEvents(setting *notificationmodel.Settings, target notificationmodel.Target, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event.Status == nil || event.DAGKey() != setting.DAGName {
+		if event.Status == nil || event.DAGRouteKey() != setting.DAGName {
 			continue
 		}
 		if !notificationmodel.IsTargetEventEnabled(setting, target, event.Type) {
@@ -1164,7 +1164,7 @@ func matchingEvents(setting *notificationmodel.Settings, target notificationmode
 func matchingSubscriptionEvents(setting *notificationmodel.Settings, subscription notificationmodel.Subscription, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event.Status == nil || event.DAGKey() != setting.DAGName {
+		if event.Status == nil || event.DAGRouteKey() != setting.DAGName {
 			continue
 		}
 		if !notificationmodel.IsSubscriptionEventEnabled(setting, subscription, event.Type) {
@@ -1178,18 +1178,18 @@ func matchingSubscriptionEvents(setting *notificationmodel.Settings, subscriptio
 func (s *Service) matchingRouteEvents(ctx context.Context, routeSet *notificationmodel.RouteSet, route notificationmodel.Route, events []chatbridge.NotificationEvent) []chatbridge.NotificationEvent {
 	result := make([]chatbridge.NotificationEvent, 0, len(events))
 	for _, event := range events {
-		dagKey := event.DAGKey()
-		if event.Status == nil || dagKey == "" {
+		routeKey := event.DAGRouteKey()
+		if event.Status == nil || routeKey == "" {
 			continue
 		}
 		if !notificationmodel.IsRouteEventEnabled(routeSet, route, event.Type) {
 			continue
 		}
-		if _, err := s.GetByDAGName(ctx, dagKey); err == nil {
+		if _, err := s.GetByDAGName(ctx, routeKey); err == nil {
 			continue
 		} else if !errors.Is(err, notificationmodel.ErrSettingsNotFound) {
 			s.logger.Warn("Failed to load notification settings",
-				slog.String("dag", dagKey),
+				slog.String("dag", routeKey),
 				slog.String("error", err.Error()),
 			)
 			continue

--- a/internal/service/notification/service.go
+++ b/internal/service/notification/service.go
@@ -468,6 +468,9 @@ func (s *Service) NotificationDestinationsForEvent(event chatbridge.Notification
 	if event.Status == nil || dagKey == "" {
 		return nil
 	}
+	if _, state := eventWorkspace(event); state == exec.WorkspaceLabelInvalid {
+		return nil
+	}
 	ctx := context.Background()
 	setting, err := s.GetByDAGName(ctx, dagKey)
 	if err != nil {
@@ -1114,7 +1117,10 @@ func (s *Service) routeSetDestinationsForEvent(
 }
 
 func (s *Service) effectiveRouteSetForEvent(ctx context.Context, event chatbridge.NotificationEvent) *notificationmodel.RouteSet {
-	workspaceName := eventWorkspaceName(event)
+	workspaceName, state := eventWorkspace(event)
+	if state == exec.WorkspaceLabelInvalid {
+		return nil
+	}
 	if workspaceName != "" {
 		workspaceRouteSet, err := s.loadRouteSet(ctx, notificationmodel.RouteScopeWorkspace, workspaceName)
 		if err == nil {
@@ -1197,11 +1203,15 @@ func (s *Service) matchingRouteEvents(ctx context.Context, routeSet *notificatio
 	return result
 }
 
-func eventWorkspaceName(event chatbridge.NotificationEvent) string {
+func eventWorkspace(event chatbridge.NotificationEvent) (string, exec.WorkspaceLabelState) {
 	if event.Status == nil {
-		return ""
+		return "", exec.WorkspaceLabelMissing
 	}
-	workspaceName, state := exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+	return exec.WorkspaceLabelFromLabels(core.NewLabels(event.Status.Labels))
+}
+
+func eventWorkspaceName(event chatbridge.NotificationEvent) string {
+	workspaceName, state := eventWorkspace(event)
 	if state == exec.WorkspaceLabelValid {
 		return workspaceName
 	}

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -294,7 +294,7 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 	defer server.Close()
 
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report-file",
+		DAGName: "daily-report",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunWaiting},
 		Targets: []notificationmodel.Target{{
@@ -315,11 +315,8 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 	}, "tester")
 	require.NoError(t, err)
 
-	svc := New(newMemoryStore(settings), testDAGStore{dag: &core.DAG{
-		Name:   "daily-report",
-		Labels: core.NewLabels([]string{"workspace=ops"}),
-	}})
-	results, err := svc.SendTest(context.Background(), "daily-report-file", "webhook-1", eventstore.TypeDAGRunFailed)
+	svc := New(newMemoryStore(settings), nil)
+	results, err := svc.SendTest(context.Background(), "daily-report", "webhook-1", eventstore.TypeDAGRunFailed)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.True(t, results[0].Delivered)
@@ -995,12 +992,11 @@ func TestService_WorkspaceInheritUsesGlobalRoutesOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:      eventstore.TypeDAGRunFailed,
-		DAGFile:   "daily-report-file",
-		DAGLabels: []string{"workspace=ops"},
+		Type: eventstore.TypeDAGRunFailed,
 		Status: &exec.DAGRunStatus{
 			Name:   "daily-report",
 			Status: core.Failed,
+			Labels: []string{"workspace=ops"},
 		},
 	})
 	assert.ElementsMatch(t, []string{
@@ -1014,12 +1010,6 @@ func TestService_WorkspaceInheritUsesGlobalRoutesOnly(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 	}, defaultDestinations)
-
-	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:      eventstore.TypeDAGRunFailed,
-		DAGLabels: []string{"workspace=ops", "workspace=engineering"},
-		Status:    &exec.DAGRunStatus{Name: "daily-report", Status: core.Failed},
-	}))
 
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
 		Type:   eventstore.TypeDAGRunSucceeded,
@@ -1179,12 +1169,12 @@ func TestService_DAGSettingsOverrideGlobalAndWorkspaceRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:      eventstore.TypeDAGRunFailed,
-		DAGFile:   "daily-report-file",
-		DAGLabels: []string{"workspace=ops"},
+		Type:    eventstore.TypeDAGRunFailed,
+		DAGFile: "daily-report-file",
 		Status: &exec.DAGRunStatus{
 			Name:   "daily-report",
 			Status: core.Failed,
+			Labels: []string{"workspace=ops"},
 		},
 	})
 	assert.ElementsMatch(t, []string{
@@ -1279,11 +1269,11 @@ func TestService_GlobalRouteFlushSkipsWorkspaceWithDisabledInheritance(t *testin
 		context.Background(),
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 		chatbridge.NotificationBatch{Events: []chatbridge.NotificationEvent{{
-			Type:      eventstore.TypeDAGRunFailed,
-			DAGLabels: []string{"workspace=ops"},
+			Type: eventstore.TypeDAGRunFailed,
 			Status: &exec.DAGRunStatus{
 				Name:   "daily-report",
 				Status: core.Failed,
+				Labels: []string{"workspace=ops"},
 			},
 			ObservedAt: time.Now().UTC(),
 		}}},

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -1011,6 +1011,16 @@ func TestService_WorkspaceInheritUsesGlobalRoutesOnly(t *testing.T) {
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 	}, defaultDestinations)
 
+	invalidWorkspace := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
+		Type: eventstore.TypeDAGRunFailed,
+		Status: &exec.DAGRunStatus{
+			Name:   "daily-report",
+			Status: core.Failed,
+			Labels: []string{"workspace=ops", "workspace=engineering"},
+		},
+	})
+	assert.Empty(t, invalidWorkspace)
+
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
 		Type:   eventstore.TypeDAGRunSucceeded,
 		Status: &exec.DAGRunStatus{Name: "daily-report", Status: core.Succeeded, Labels: []string{"workspace=ops"}},

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -294,7 +294,7 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 	defer server.Close()
 
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report",
+		DAGName: "daily-report-file",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunWaiting},
 		Targets: []notificationmodel.Target{{
@@ -315,8 +315,11 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 	}, "tester")
 	require.NoError(t, err)
 
-	svc := New(newMemoryStore(settings), nil)
-	results, err := svc.SendTest(context.Background(), "daily-report", "webhook-1", eventstore.TypeDAGRunFailed)
+	svc := New(newMemoryStore(settings), testDAGStore{dag: &core.DAG{
+		Name:   "daily-report",
+		Labels: core.NewLabels([]string{"workspace=ops"}),
+	}})
+	results, err := svc.SendTest(context.Background(), "daily-report-file", "webhook-1", eventstore.TypeDAGRunFailed)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.True(t, results[0].Delivered)
@@ -897,7 +900,7 @@ func TestService_SendTestUsesEffectiveWorkspaceRouteFromDAGLabels(t *testing.T) 
 	}, "tester")
 	require.NoError(t, err)
 
-	results, err := svc.SendTest(context.Background(), "daily-report", "", eventstore.TypeDAGRunFailed)
+	results, err := svc.SendTest(context.Background(), "daily-report-file", "", eventstore.TypeDAGRunFailed)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "workspace-route", results[0].TargetID)
@@ -992,11 +995,12 @@ func TestService_WorkspaceInheritUsesGlobalRoutesOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type: eventstore.TypeDAGRunFailed,
+		Type:      eventstore.TypeDAGRunFailed,
+		DAGFile:   "daily-report-file",
+		DAGLabels: []string{"workspace=ops"},
 		Status: &exec.DAGRunStatus{
 			Name:   "daily-report",
 			Status: core.Failed,
-			Labels: []string{"workspace=ops"},
 		},
 	})
 	assert.ElementsMatch(t, []string{
@@ -1010,6 +1014,12 @@ func TestService_WorkspaceInheritUsesGlobalRoutesOnly(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 	}, defaultDestinations)
+
+	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
+		Type:      eventstore.TypeDAGRunFailed,
+		DAGLabels: []string{"workspace=ops", "workspace=engineering"},
+		Status:    &exec.DAGRunStatus{Name: "daily-report", Status: core.Failed},
+	}))
 
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
 		Type:   eventstore.TypeDAGRunSucceeded,
@@ -1132,7 +1142,7 @@ func TestService_DAGSettingsOverrideGlobalAndWorkspaceRoutes(t *testing.T) {
 		require.NoError(t, store.SaveChannel(context.Background(), channel))
 	}
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report",
+		DAGName: "daily-report-file",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed},
 		Subscriptions: []notificationmodel.Subscription{{
@@ -1169,15 +1179,16 @@ func TestService_DAGSettingsOverrideGlobalAndWorkspaceRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type: eventstore.TypeDAGRunFailed,
+		Type:      eventstore.TypeDAGRunFailed,
+		DAGFile:   "daily-report-file",
+		DAGLabels: []string{"workspace=ops"},
 		Status: &exec.DAGRunStatus{
 			Name:   "daily-report",
 			Status: core.Failed,
-			Labels: []string{"workspace=ops"},
 		},
 	})
 	assert.ElementsMatch(t, []string{
-		channelDestinationID("daily-report", "dag-route"),
+		channelDestinationID("daily-report-file", "dag-route"),
 	}, destinations)
 }
 
@@ -1268,11 +1279,11 @@ func TestService_GlobalRouteFlushSkipsWorkspaceWithDisabledInheritance(t *testin
 		context.Background(),
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 		chatbridge.NotificationBatch{Events: []chatbridge.NotificationEvent{{
-			Type: eventstore.TypeDAGRunFailed,
+			Type:      eventstore.TypeDAGRunFailed,
+			DAGLabels: []string{"workspace=ops"},
 			Status: &exec.DAGRunStatus{
 				Name:   "daily-report",
 				Status: core.Failed,
-				Labels: []string{"workspace=ops"},
 			},
 			ObservedAt: time.Now().UTC(),
 		}}},
@@ -1305,7 +1316,7 @@ func TestService_RouteFlushSkipsDAGWithConfiguredNotifications(t *testing.T) {
 	}, "tester")
 	require.NoError(t, err)
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report",
+		DAGName: "daily-report-file",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed},
 	}, "tester")
@@ -1329,7 +1340,8 @@ func TestService_RouteFlushSkipsDAGWithConfiguredNotifications(t *testing.T) {
 		context.Background(),
 		routeDestinationID(notificationmodel.RouteScopeGlobal, "", "global-route"),
 		chatbridge.NotificationBatch{Events: []chatbridge.NotificationEvent{{
-			Type: eventstore.TypeDAGRunFailed,
+			Type:    eventstore.TypeDAGRunFailed,
+			DAGFile: "daily-report-file",
 			Status: &exec.DAGRunStatus{
 				Name:   "daily-report",
 				Status: core.Failed,
@@ -1345,8 +1357,13 @@ func TestService_RouteFlushSkipsDAGWithConfiguredNotifications(t *testing.T) {
 func TestService_NotificationDestinationsForEventFiltersByDAGAndEvent(t *testing.T) {
 	t.Parallel()
 
+	var requestCount atomic.Int32
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestCount.Add(1)
+		return acceptedResponse(req), nil
+	})}
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report",
+		DAGName: "daily-report-file",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunWaiting},
 		Targets: []notificationmodel.Target{
@@ -1356,7 +1373,8 @@ func TestService_NotificationDestinationsForEventFiltersByDAGAndEvent(t *testing
 				Enabled: true,
 				Events:  []eventstore.EventType{eventstore.TypeDAGRunWaiting},
 				Webhook: &notificationmodel.WebhookTarget{
-					URL: "https://example.com/webhook",
+					URL:                 "https://example.com/webhook",
+					AllowPrivateNetwork: true,
 				},
 			},
 			{
@@ -1372,27 +1390,35 @@ func TestService_NotificationDestinationsForEventFiltersByDAGAndEvent(t *testing
 		UpdatedAt: time.Now().UTC(),
 	}, "tester")
 	require.NoError(t, err)
-	svc := New(newMemoryStore(settings), nil)
+	svc := New(newMemoryStore(settings), nil, WithHTTPClient(httpClient))
 
-	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type: eventstore.TypeDAGRunWaiting,
+	waitingEvent := chatbridge.NotificationEvent{
+		Type:    eventstore.TypeDAGRunWaiting,
+		DAGFile: "daily-report-file",
 		Status: &exec.DAGRunStatus{
 			Name:      "daily-report",
 			Status:    core.Waiting,
 			DAGRunID:  "run-1",
 			AttemptID: "attempt-1",
 		},
-	})
+	}
+	destinations := svc.NotificationDestinationsForEvent(waitingEvent)
 	require.Len(t, destinations, 1)
 	assert.Contains(t, destinations[0], "webhook-1")
+	assert.True(t, svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
+		Events: []chatbridge.NotificationEvent{waitingEvent},
+	}, false))
+	assert.Equal(t, int32(1), requestCount.Load())
 
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:   eventstore.TypeDAGRunFailed,
-		Status: &exec.DAGRunStatus{Name: "daily-report", Status: core.Failed},
+		Type:    eventstore.TypeDAGRunFailed,
+		DAGFile: "daily-report-file",
+		Status:  &exec.DAGRunStatus{Name: "daily-report", Status: core.Failed},
 	}))
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:   eventstore.TypeDAGRunFailed,
-		Status: &exec.DAGRunStatus{Name: "other-dag", Status: core.Failed},
+		Type:    eventstore.TypeDAGRunFailed,
+		DAGFile: "other-file",
+		Status:  &exec.DAGRunStatus{Name: "other-dag", Status: core.Failed},
 	}))
 }
 
@@ -1564,7 +1590,7 @@ func TestService_ReusableChannelSubscriptionsDeliverForMatchingDAGEvent(t *testi
 	}, "tester")
 	require.NoError(t, err)
 	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
-		DAGName: "daily-report",
+		DAGName: "daily-report-file",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunSucceeded},
 		Subscriptions: []notificationmodel.Subscription{{
@@ -1580,7 +1606,8 @@ func TestService_ReusableChannelSubscriptionsDeliverForMatchingDAGEvent(t *testi
 	svc := New(store, nil)
 
 	destinations := svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type: eventstore.TypeDAGRunFailed,
+		Type:    eventstore.TypeDAGRunFailed,
+		DAGFile: "daily-report-file",
 		Status: &exec.DAGRunStatus{
 			Name:      "daily-report",
 			Status:    core.Failed,
@@ -1593,6 +1620,7 @@ func TestService_ReusableChannelSubscriptionsDeliverForMatchingDAGEvent(t *testi
 	delivered := svc.FlushNotificationBatch(context.Background(), destinations[0], chatbridge.NotificationBatch{
 		Events: []chatbridge.NotificationEvent{{
 			Type:       eventstore.TypeDAGRunFailed,
+			DAGFile:    "daily-report-file",
 			Status:     &exec.DAGRunStatus{Name: "daily-report", Status: core.Failed, DAGRunID: "run-1"},
 			ObservedAt: time.Now().UTC(),
 		}},
@@ -1602,8 +1630,9 @@ func TestService_ReusableChannelSubscriptionsDeliverForMatchingDAGEvent(t *testi
 	assert.Contains(t, body, `"dagName":"daily-report"`)
 
 	assert.Empty(t, svc.NotificationDestinationsForEvent(chatbridge.NotificationEvent{
-		Type:   eventstore.TypeDAGRunSucceeded,
-		Status: &exec.DAGRunStatus{Name: "daily-report", Status: core.Succeeded},
+		Type:    eventstore.TypeDAGRunSucceeded,
+		DAGFile: "daily-report-file",
+		Status:  &exec.DAGRunStatus{Name: "daily-report", Status: core.Succeeded},
 	}))
 }
 

--- a/internal/service/scheduler/scheduler_test.go
+++ b/internal/service/scheduler/scheduler_test.go
@@ -30,7 +30,9 @@ func schedulerTestTimeout(base time.Duration) time.Duration {
 
 func setupSchedulerWithoutDAGs(t *testing.T) *test.Scheduler {
 	t.Helper()
-	return test.SetupScheduler(t, test.WithDAGsDir(t.TempDir()))
+	th := test.SetupScheduler(t, test.WithDAGsDir(t.TempDir()))
+	th.ServiceRegistry = nil
+	return th
 }
 
 func TestScheduler(t *testing.T) {

--- a/internal/service/worker/coordreport/status_pusher.go
+++ b/internal/service/worker/coordreport/status_pusher.go
@@ -18,10 +18,23 @@ var _ runtime.StatusPusher = (*StatusPusher)(nil)
 
 // StatusPusher sends status updates to coordinator via gRPC
 type StatusPusher struct {
-	client   coordinator.Client
-	workerID string
-	owner    exec.HostInfo
-	claimKey string
+	client     coordinator.Client
+	workerID   string
+	owner      exec.HostInfo
+	claimKey   string
+	sourceFile string
+	labels     string
+}
+
+// NewTaskStatusPusher creates a StatusPusher bound to a dispatched task.
+func NewTaskStatusPusher(client coordinator.Client, workerID string, task *coordinatorv1.Task, owner ...exec.HostInfo) *StatusPusher {
+	if task == nil {
+		return NewStatusPusher(client, workerID, "", owner...)
+	}
+	pusher := NewStatusPusher(client, workerID, task.AttemptKey, owner...)
+	pusher.sourceFile = task.SourceFile
+	pusher.labels = task.Labels
+	return pusher
 }
 
 // AttemptRejectedError indicates the coordinator explicitly rejected a status
@@ -72,6 +85,8 @@ func (p *StatusPusher) Push(ctx context.Context, status exec.DAGRunStatus) error
 		WorkerId:           p.workerID,
 		Status:             protoStatus,
 		OwnerCoordinatorId: p.owner.ID,
+		SourceFile:         p.sourceFile,
+		Labels:             p.labels,
 	}
 
 	var resp *coordinatorv1.ReportStatusResponse

--- a/internal/service/worker/coordreport/status_pusher_test.go
+++ b/internal/service/worker/coordreport/status_pusher_test.go
@@ -133,7 +133,11 @@ func TestPush(t *testing.T) {
 			},
 		}
 
-		pusher := coordreport.NewStatusPusher(client, "worker-1", "claim-key")
+		pusher := coordreport.NewTaskStatusPusher(client, "worker-1", &coordinatorv1.Task{
+			AttemptKey: "claim-key",
+			SourceFile: "/dags/daily-file.yaml",
+			Labels:     "workspace=ops,team=platform",
+		})
 		status := exec.DAGRunStatus{
 			Name:     "test-dag",
 			DAGRunID: "run-123",
@@ -145,6 +149,8 @@ func TestPush(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, capturedReq)
 		assert.Equal(t, "worker-1", capturedReq.WorkerId)
+		assert.Equal(t, "/dags/daily-file.yaml", capturedReq.SourceFile)
+		assert.Equal(t, "workspace=ops,team=platform", capturedReq.Labels)
 		assert.NotNil(t, capturedReq.Status)
 		assert.NotEmpty(t, capturedReq.Status.JsonData)
 		// Verify the JSON contains the expected data

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -233,7 +233,7 @@ func retryTaskProfileName(status *exec.DAGRunStatus) string {
 
 func (h *remoteTaskHandler) reportTaskLoadFailure(ctx context.Context, run remoteRun, loadErr error) {
 	task := run.task
-	statusPusher := coordreport.NewStatusPusher(h.coordinatorClient, h.workerID, task.AttemptKey, run.owner)
+	statusPusher := coordreport.NewTaskStatusPusher(h.coordinatorClient, h.workerID, task, run.owner)
 	finishedAt := stringutil.FormatTime(time.Now())
 	logger.Warn(ctx, "Failed to load DAG on worker",
 		tag.Target(task.Target),
@@ -393,7 +393,7 @@ func taskExtraEnvs(task *coordinatorv1.Task) []string {
 // createRemoteHandlers creates the remote status, log, and artifact transport handlers.
 func (h *remoteTaskHandler) createRemoteHandlers(run remoteRun, dagName string) runHandlers {
 	task := run.task
-	statusPusher := coordreport.NewStatusPusher(h.coordinatorClient, h.workerID, task.AttemptKey, run.owner)
+	statusPusher := coordreport.NewTaskStatusPusher(h.coordinatorClient, h.workerID, task, run.owner)
 	reporter := newRemoteRunReporter(
 		h.coordinatorClient,
 		h.workerID,

--- a/proto/coordinator/v1/coordinator.pb.go
+++ b/proto/coordinator/v1/coordinator.pb.go
@@ -2019,6 +2019,8 @@ type ReportStatusRequest struct {
 	WorkerId           string                 `protobuf:"bytes,1,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
 	Status             *DAGRunStatusProto     `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	OwnerCoordinatorId string                 `protobuf:"bytes,3,opt,name=owner_coordinator_id,json=ownerCoordinatorId,proto3" json:"owner_coordinator_id,omitempty"`
+	SourceFile         string                 `protobuf:"bytes,4,opt,name=source_file,json=sourceFile,proto3" json:"source_file,omitempty"`
+	Labels             string                 `protobuf:"bytes,5,opt,name=labels,proto3" json:"labels,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -2069,6 +2071,20 @@ func (x *ReportStatusRequest) GetOwnerCoordinatorId() string {
 	return ""
 }
 
+func (x *ReportStatusRequest) GetSourceFile() string {
+	if x != nil {
+		return x.SourceFile
+	}
+	return ""
+}
+
+func (x *ReportStatusRequest) GetLabels() string {
+	if x != nil {
+		return x.Labels
+	}
+	return ""
+}
+
 func (x *ReportStatusRequest) SetWorkerId(v string) {
 	x.WorkerId = v
 }
@@ -2079,6 +2095,14 @@ func (x *ReportStatusRequest) SetStatus(v *DAGRunStatusProto) {
 
 func (x *ReportStatusRequest) SetOwnerCoordinatorId(v string) {
 	x.OwnerCoordinatorId = v
+}
+
+func (x *ReportStatusRequest) SetSourceFile(v string) {
+	x.SourceFile = v
+}
+
+func (x *ReportStatusRequest) SetLabels(v string) {
+	x.Labels = v
 }
 
 func (x *ReportStatusRequest) HasStatus() bool {
@@ -2098,6 +2122,8 @@ type ReportStatusRequest_builder struct {
 	WorkerId           string
 	Status             *DAGRunStatusProto
 	OwnerCoordinatorId string
+	SourceFile         string
+	Labels             string
 }
 
 func (b0 ReportStatusRequest_builder) Build() *ReportStatusRequest {
@@ -2107,6 +2133,8 @@ func (b0 ReportStatusRequest_builder) Build() *ReportStatusRequest {
 	x.WorkerId = b.WorkerId
 	x.Status = b.Status
 	x.OwnerCoordinatorId = b.OwnerCoordinatorId
+	x.SourceFile = b.SourceFile
+	x.Labels = b.Labels
 	return m0
 }
 
@@ -5144,11 +5172,14 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x13parent_dag_run_name\x18\x06 \x01(\tR\x10parentDagRunName\x12)\n" +
 	"\x11parent_dag_run_id\x18\a \x01(\tR\x0eparentDagRunId\x12\x1f\n" +
 	"\vattempt_key\x18\b \x01(\tR\n" +
-	"attemptKey\"\x9f\x01\n" +
+	"attemptKey\"\xd8\x01\n" +
 	"\x13ReportStatusRequest\x12\x1b\n" +
 	"\tworker_id\x18\x01 \x01(\tR\bworkerId\x129\n" +
 	"\x06status\x18\x02 \x01(\v2!.coordinator.v1.DAGRunStatusProtoR\x06status\x120\n" +
-	"\x14owner_coordinator_id\x18\x03 \x01(\tR\x12ownerCoordinatorId\"H\n" +
+	"\x14owner_coordinator_id\x18\x03 \x01(\tR\x12ownerCoordinatorId\x12\x1f\n" +
+	"\vsource_file\x18\x04 \x01(\tR\n" +
+	"sourceFile\x12\x16\n" +
+	"\x06labels\x18\x05 \x01(\tR\x06labels\"H\n" +
 	"\x14ReportStatusResponse\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\"0\n" +

--- a/proto/coordinator/v1/coordinator.proto
+++ b/proto/coordinator/v1/coordinator.proto
@@ -253,6 +253,8 @@ message ReportStatusRequest {
   string worker_id = 1;
   DAGRunStatusProto status = 2;
   string owner_coordinator_id = 3;
+  string source_file = 4;
+  string labels = 5;
 }
 
 // Response message for reporting DAG run status.

--- a/proto/coordinator/v1/coordinator_protoopaque.pb.go
+++ b/proto/coordinator/v1/coordinator_protoopaque.pb.go
@@ -2012,6 +2012,8 @@ type ReportStatusRequest struct {
 	xxx_hidden_WorkerId           string                 `protobuf:"bytes,1,opt,name=worker_id,json=workerId,proto3"`
 	xxx_hidden_Status             *DAGRunStatusProto     `protobuf:"bytes,2,opt,name=status,proto3"`
 	xxx_hidden_OwnerCoordinatorId string                 `protobuf:"bytes,3,opt,name=owner_coordinator_id,json=ownerCoordinatorId,proto3"`
+	xxx_hidden_SourceFile         string                 `protobuf:"bytes,4,opt,name=source_file,json=sourceFile,proto3"`
+	xxx_hidden_Labels             string                 `protobuf:"bytes,5,opt,name=labels,proto3"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }
@@ -2062,6 +2064,20 @@ func (x *ReportStatusRequest) GetOwnerCoordinatorId() string {
 	return ""
 }
 
+func (x *ReportStatusRequest) GetSourceFile() string {
+	if x != nil {
+		return x.xxx_hidden_SourceFile
+	}
+	return ""
+}
+
+func (x *ReportStatusRequest) GetLabels() string {
+	if x != nil {
+		return x.xxx_hidden_Labels
+	}
+	return ""
+}
+
 func (x *ReportStatusRequest) SetWorkerId(v string) {
 	x.xxx_hidden_WorkerId = v
 }
@@ -2072,6 +2088,14 @@ func (x *ReportStatusRequest) SetStatus(v *DAGRunStatusProto) {
 
 func (x *ReportStatusRequest) SetOwnerCoordinatorId(v string) {
 	x.xxx_hidden_OwnerCoordinatorId = v
+}
+
+func (x *ReportStatusRequest) SetSourceFile(v string) {
+	x.xxx_hidden_SourceFile = v
+}
+
+func (x *ReportStatusRequest) SetLabels(v string) {
+	x.xxx_hidden_Labels = v
 }
 
 func (x *ReportStatusRequest) HasStatus() bool {
@@ -2091,6 +2115,8 @@ type ReportStatusRequest_builder struct {
 	WorkerId           string
 	Status             *DAGRunStatusProto
 	OwnerCoordinatorId string
+	SourceFile         string
+	Labels             string
 }
 
 func (b0 ReportStatusRequest_builder) Build() *ReportStatusRequest {
@@ -2100,6 +2126,8 @@ func (b0 ReportStatusRequest_builder) Build() *ReportStatusRequest {
 	x.xxx_hidden_WorkerId = b.WorkerId
 	x.xxx_hidden_Status = b.Status
 	x.xxx_hidden_OwnerCoordinatorId = b.OwnerCoordinatorId
+	x.xxx_hidden_SourceFile = b.SourceFile
+	x.xxx_hidden_Labels = b.Labels
 	return m0
 }
 
@@ -5130,11 +5158,14 @@ const file_proto_coordinator_v1_coordinator_proto_rawDesc = "" +
 	"\x13parent_dag_run_name\x18\x06 \x01(\tR\x10parentDagRunName\x12)\n" +
 	"\x11parent_dag_run_id\x18\a \x01(\tR\x0eparentDagRunId\x12\x1f\n" +
 	"\vattempt_key\x18\b \x01(\tR\n" +
-	"attemptKey\"\x9f\x01\n" +
+	"attemptKey\"\xd8\x01\n" +
 	"\x13ReportStatusRequest\x12\x1b\n" +
 	"\tworker_id\x18\x01 \x01(\tR\bworkerId\x129\n" +
 	"\x06status\x18\x02 \x01(\v2!.coordinator.v1.DAGRunStatusProtoR\x06status\x120\n" +
-	"\x14owner_coordinator_id\x18\x03 \x01(\tR\x12ownerCoordinatorId\"H\n" +
+	"\x14owner_coordinator_id\x18\x03 \x01(\tR\x12ownerCoordinatorId\x12\x1f\n" +
+	"\vsource_file\x18\x04 \x01(\tR\n" +
+	"sourceFile\x12\x16\n" +
+	"\x06labels\x18\x05 \x01(\tR\x06labels\"H\n" +
 	"\x14ReportStatusResponse\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\"0\n" +


### PR DESCRIPTION
## Summary

- preserve the DAG filename and labels in persisted lifecycle events, including reopened and distributed attempts
- use the filename only to find DAG-scoped notification and incident configuration
- keep DAG runs, events, incident state, and incident deduplication keyed by the runtime DAG name
- fail closed when workspace labels are malformed or ambiguous
- carry source-file and label metadata through missing distributed sub-attempt recovery

## Root cause

Notification and incident configuration is stored under the DAG file identifier, while DAG runs and lifecycle events use the runtime DAG name. Those values usually match, but YAML can declare a different name. Events did not retain the file identifier needed for scoped configuration lookup. Reconstructed attempts also lost their DAG metadata, and early distributed failures could replace persisted workspace labels with an empty set.

## Impact

DAG-scoped settings now continue to apply when a YAML file declares a different runtime name. Workspace-scoped failures retain their routing boundary across coordinator recovery and cannot fall through to global routing because metadata was lost or invalid. Existing open incidents remain compatible because runtime-name state and `dagu:v1` deduplication semantics are unchanged.

## CI hardening

An earlier Windows run exposed two test-only lifecycle problems while the same PR commit passed on rerun. Scheduler lifecycle tests were waiting on an unrelated file-backed service registry before observing startup, and conformance cleanup could stop the parent Dagu process without owning its child process tree. The follow-up commit removes the registry dependency from those focused scheduler tests and uses the existing managed-process abstraction for conformance commands. No production behavior changed, and no timeouts or retries were added.

## Validation

- `make test`
- `make lint`
- focused incident, coordinator, worker, notification, event-store, and persistence package tests
- repeated scheduler lifecycle tests
- repeated human-task cleanup regression
- complete human-task conformance package

Closes #2467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * DAG labels and source-file metadata are preserved across task execution, status updates, event snapshots, and queued notifications.
  * Notifications and incident policies route more accurately using DAG file and runtime name information.
  * Status reporting provides more complete task metadata.
* **Bug Fixes**
  * Invalid or ambiguous workspace labels are rejected to prevent misrouted notifications and incidents.
  * Reopened and reconstructed DAG runs retain associated metadata.
  * Existing incident policies are preserved when resolving events without a policy ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->