### PR TITLE
fix: show active DAG runs in dashboard timeline

### DIFF
--- a/ui/src/features/dashboard/components/DashboardTimechart.tsx
+++ b/ui/src/features/dashboard/components/DashboardTimechart.tsx
@@ -341,7 +341,10 @@ function DashboardTimeChart({ data: input, selectedDate }: Props) {
       const start = dagRun.startedAt;
       if (start && start !== '-') {
         const startMoment = dayjs(start);
-        const end = dagRun.finishedAt !== '-' ? dayjs(dagRun.finishedAt) : now;
+        const end =
+          dagRun.finishedAt && dagRun.finishedAt !== '-'
+            ? dayjs(dagRun.finishedAt)
+            : now;
 
         const startDate = startMoment.tz(validTimezone).toDate();
         const endDate = end.tz(validTimezone).toDate();

--- a/ui/src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx
+++ b/ui/src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { components, Status, StatusLabel } from '@/api/v1/schema';
+import DashboardTimeChart from '../DashboardTimechart';
+
+type TimelineDataSet = {
+  get: () => Array<{
+    id: string;
+    content: string;
+    start: Date;
+    end: Date;
+  }>;
+};
+
+const timelineState = vi.hoisted(() => ({
+  dataSet: null as TimelineDataSet | null,
+}));
+
+vi.mock('vis-timeline/standalone', () => ({
+  Timeline: class {
+    constructor(_element: HTMLElement, dataSet: TimelineDataSet) {
+      timelineState.dataSet = dataSet;
+    }
+
+    getWindow() {
+      return {
+        start: new Date('2026-08-01T00:00:00Z'),
+        end: new Date('2026-08-02T00:00:00Z'),
+      };
+    }
+
+    setOptions() {}
+    on() {}
+    off() {}
+    destroy() {}
+    setWindow() {}
+    zoomIn() {}
+    zoomOut() {}
+    fit() {}
+  },
+}));
+
+vi.mock('@/contexts/ConfigContext', () => ({
+  useConfig: () => ({ tz: 'UTC' }),
+}));
+
+vi.mock(
+  '@/features/dag-runs/components/dag-run-details/DAGRunDetailsModal',
+  () => ({ default: () => null })
+);
+
+type DAGRunSummary = components['schemas']['DAGRunSummary'];
+
+beforeEach(() => {
+  timelineState.dataSet = null;
+});
+
+describe('DashboardTimeChart', () => {
+  it('renders a running DAG run without a finished timestamp', () => {
+    const runningDAGRun: DAGRunSummary = {
+      dagRunId: 'run-1',
+      name: 'long-running-dag',
+      status: Status.Running,
+      statusLabel: StatusLabel.running,
+      startedAt: '2026-08-01T01:00:00Z',
+      finishedAt: '',
+      artifactsAvailable: false,
+      autoRetryCount: 0,
+    };
+
+    render(
+      <DashboardTimeChart
+        data={[runningDAGRun]}
+        selectedDate={{
+          startTimestamp: 1785542400,
+          endTimestamp: 1785628800,
+        }}
+      />
+    );
+
+    const items = timelineState.dataSet?.get() ?? [];
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        id: 'long-running-dag_run-1',
+        content: 'long-running-dag',
+      })
+    );
+    expect(items[0]?.end.getTime()).not.toBeNaN();
+  });
+});

--- a/ui/src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx
+++ b/ui/src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx
@@ -3,7 +3,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { components, Status, StatusLabel } from '@/api/v1/schema';
 import DashboardTimeChart from '../DashboardTimechart';
 
@@ -59,8 +59,15 @@ beforeEach(() => {
   timelineState.dataSet = null;
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('DashboardTimeChart', () => {
   it('renders a running DAG run without a finished timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T02:00:00Z'));
+
     const runningDAGRun: DAGRunSummary = {
       dagRunId: 'run-1',
       name: 'long-running-dag',
@@ -90,6 +97,8 @@ describe('DashboardTimeChart', () => {
         content: 'long-running-dag',
       })
     );
-    expect(items[0]?.end.getTime()).not.toBeNaN();
+    expect(items[0]?.end.getTime()).toBe(
+      new Date('2026-08-01T02:00:00Z').getTime()
+    );
   });
 });


### PR DESCRIPTION
## Summary

- show active DAG runs in the dashboard Timeline while they are still running
- retain compatibility with the legacy `"-"` unfinished-time sentinel
- add component-level regression coverage for an empty `finishedAt` value

## Root cause

Running DAG-run summaries represent the unset finish time as an empty string. The Timeline only recognized the legacy `"-"` sentinel, parsed the empty string as an invalid date, and then discarded the run while constructing chart items.

## Impact

Active runs now appear in the Timeline using the current time as the interval end. Completed-run rendering is unchanged.

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm exec eslint src/features/dashboard/components/DashboardTimechart.tsx src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx`
- `pnpm exec prettier --check src/features/dashboard/components/DashboardTimechart.tsx src/features/dashboard/components/__tests__/DashboardTimechart.test.tsx`

Closes #2475

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dashboard Timeline so active DAG runs appear while still running by treating an empty `finishedAt` as ongoing and using the current time as the end. Legacy `'-'` support remains; completed runs are unchanged.

- **Bug Fixes**
  - Treat empty `finishedAt` as active and set the end to now.
  - Keep `'-'` sentinel compatibility and add a component test asserting empty `finishedAt` uses now for the timeline end.

<sup>Written for commit 66b86ff9b8202d12512bff6b333cfeb9cb3b3f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline display for running workflows by using the current time when no valid finish time is available.

* **Tests**
  * Added coverage to verify that active workflow runs appear correctly with a valid timeline end time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->