### PR TITLE
feat: prepare MCP server for 2026-07-28

### DIFF
--- a/internal/service/frontend/cors.go
+++ b/internal/service/frontend/cors.go
@@ -25,7 +25,7 @@ func (p corsPolicy) middleware(next http.Handler) http.Handler {
 		allowAllOrigins := p.allowsAllOrigins()
 		options := cors.Options{
 			AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-			AllowedHeaders:   []string{"Content-Type", "Authorization", "Content-Encoding", "Accept", "MCP-Protocol-Version", "Mcp-Session-Id", "Last-Event-ID"},
+			AllowedHeaders:   []string{"Content-Type", "Authorization", "Content-Encoding", "Accept", "MCP-Protocol-Version", "Mcp-Method", "Mcp-Name", "Mcp-Session-Id", "Last-Event-ID"},
 			ExposedHeaders:   []string{"Mcp-Session-Id"},
 			AllowCredentials: !allowAllOrigins,
 			MaxAge:           300,

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -149,7 +149,10 @@ func TestCORSPolicy_AllowsMCPRequestHeaders(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 
 	require.Equal(t, http.StatusOK, resp.Code)
-	allowedHeaders := strings.ToLower(resp.Header().Get("Access-Control-Allow-Headers"))
+	allowedHeaders := strings.Split(strings.ToLower(resp.Header().Get("Access-Control-Allow-Headers")), ",")
+	for i := range allowedHeaders {
+		allowedHeaders[i] = strings.TrimSpace(allowedHeaders[i])
+	}
 	assert.Contains(t, allowedHeaders, "mcp-method")
 	assert.Contains(t, allowedHeaders, "mcp-name")
 }

--- a/internal/service/frontend/cors_test.go
+++ b/internal/service/frontend/cors_test.go
@@ -6,6 +6,7 @@ package frontend
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,6 +130,28 @@ func TestCORSPolicy_ExplicitOrigin(t *testing.T) {
 		assert.Empty(t, resp.Header().Get("Access-Control-Allow-Origin"))
 		assert.Contains(t, resp.Header().Values("Vary"), "Origin")
 	})
+}
+
+func TestCORSPolicy_AllowsMCPRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	policy := corsPolicy{
+		allowedOrigins: []string{"https://app.example"},
+		setupPath:      "/api/v1/auth/setup",
+	}
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := newPreflightRequest("/mcp", "https://app.example")
+	req.Header.Set("Access-Control-Request-Headers", "mcp-method,mcp-name")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	allowedHeaders := strings.ToLower(resp.Header().Get("Access-Control-Allow-Headers"))
+	assert.Contains(t, allowedHeaders, "mcp-method")
+	assert.Contains(t, allowedHeaders, "mcp-name")
 }
 
 func TestCORSPolicy_WildcardPattern(t *testing.T) {

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -75,6 +75,11 @@ func NewServer(api *frontendapi.API) *mcpsdk.Server {
 		Name:    "dagu",
 		Version: config.Version,
 	}, &mcpsdk.ServerOptions{
+		Capabilities: &mcpsdk.ServerCapabilities{
+			Prompts:   &mcpsdk.PromptCapabilities{},
+			Resources: &mcpsdk.ResourceCapabilities{Subscribe: true},
+			Tools:     &mcpsdk.ToolCapabilities{},
+		},
 		Instructions:       instructions,
 		SubscribeHandler:   svc.subscribe,
 		UnsubscribeHandler: svc.unsubscribe,

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -33,6 +33,19 @@ func TestServerExposesCompactToolSurface(t *testing.T) {
 	require.Equal(t, []string{toolChange, toolExecute, toolRead}, names)
 }
 
+func TestServerAdvertisesSupportedCapabilities(t *testing.T) {
+	ctx := context.Background()
+	session := connectTestClient(t, ctx, NewServer(nil))
+
+	result := session.InitializeResult()
+	require.NotNil(t, result)
+	require.Equal(t, &mcpsdk.ServerCapabilities{
+		Prompts:   &mcpsdk.PromptCapabilities{},
+		Resources: &mcpsdk.ResourceCapabilities{Subscribe: true},
+		Tools:     &mcpsdk.ToolCapabilities{},
+	}, result.Capabilities)
+}
+
 func TestHTTPHandlerServesStreamableMCP(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testConnectTimeout)
 	defer cancel()


### PR DESCRIPTION
## Summary

- advertise only Dagu's supported MCP capabilities: tools, prompts, and resource subscriptions
- stop advertising legacy logging and static list-change notifications
- allow the `Mcp-Method` and `Mcp-Name` request headers in CORS preflights while retaining legacy session headers
- add focused tests for the advertised capability contract and browser preflight behavior

## Why

MCP 2026-07-28 moves to a stateless transport and standard request metadata. The official Go SDK currently exposes that protocol only through the `v1.7.0-pre.*` line, so this change applies the preparation that is compatible with the stable `v1.6.1` dependency without introducing a prerelease SDK.

A follow-up can add dual-era routing, stateless request handling, cancellation propagation, and modern subscription behavior once a stable `v1.7.x` SDK is available.

## Impact

Existing stateful MCP clients continue using the same `/mcp` endpoint and session behavior. Browser MCP clients may send the new standard request headers. Tool, resource, prompt, authentication, and endpoint APIs are unchanged.

## Validation

- `go test ./internal/service/mcp ./internal/service/frontend -count=1`
- `go test ./conformance/spec020_mcp_server ./conformance/spec021_mcp_read_tool ./conformance/spec022_mcp_change_tool -run ^$ -count=1`
- `make check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the MCP server for the 2026-07-28 protocol by advertising supported capabilities and allowing the new `Mcp-Method` and `Mcp-Name` headers in CORS preflights. Existing clients continue to use the same `/mcp` endpoint and session behavior.

- **New Features**
  - Advertise only supported capabilities: prompts, tools, and subscribable resources.
  - Stop advertising legacy logging and static list-change notifications.
  - Keep legacy session headers while allowing the new standard request headers in browser preflights; tests assert exact CORS header tokens.

<sup>Written for commit 75fe15dd682defb8ba9c7778a91924621ffc54e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP servers now advertise support for prompts, tools, and subscribable resources.
  - Browser-based MCP requests can include the required method and name headers.

- **Bug Fixes**
  - Improved cross-origin request handling for MCP integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->