### PR TITLE
feat(cli): show the decision timeline for controller DAG runs

### DIFF
--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1170,6 +1170,7 @@ func (a *Agent) nodeToModelNode(nodeData runtime.NodeData) *exec.Node {
 		OutputVariables:  nodeData.State.OutputVariables,
 		OutputsValue:     nodeData.State.OutputsValue,
 		StepOutputsValue: nodeData.State.StepOutputsValue,
+		ControllerState:  nodeData.State.ControllerState,
 	}
 }
 

--- a/internal/runtime/agent/agent_progress.go
+++ b/internal/runtime/agent/agent_progress.go
@@ -11,6 +11,11 @@ import (
 
 // createProgressReporter creates the progress reporter
 func createProgressReporter(dag *core.DAG, dagRunID string, params []string) ProgressReporter {
+	if dag != nil && dag.Type == core.TypeController {
+		display := NewControllerProgressDisplay(dag)
+		display.SetDAGRunInfo(dagRunID, strings.Join(params, " "))
+		return display
+	}
 	display := NewSimpleProgressDisplay(dag)
 	display.SetDAGRunInfo(dagRunID, strings.Join(params, " "))
 	return display

--- a/internal/runtime/agent/progress_common.go
+++ b/internal/runtime/agent/progress_common.go
@@ -29,6 +29,22 @@ func newProgressWriter() progressWriter {
 	}
 }
 
+// statusIcon maps a run's final status to the mark shown on the closing line.
+// Success is explicit rather than the default, so a status outside the known
+// terminal set is never dressed up as one.
+func statusIcon(status core.Status) string {
+	switch status {
+	case core.Succeeded, core.PartiallySucceeded:
+		return "✓"
+	case core.Failed, core.Aborted:
+		return "✗"
+	case core.Waiting:
+		return "⏸"
+	default:
+		return "●"
+	}
+}
+
 // gray returns text in gray color when writing to a terminal.
 func (w *progressWriter) gray(s string) string {
 	if !w.tty {

--- a/internal/runtime/agent/progress_common.go
+++ b/internal/runtime/agent/progress_common.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+	"golang.org/x/term"
+)
+
+// progressWriter is the output half shared by the progress displays: where
+// lines are written, whether the destination is an interactive terminal, and
+// the run header format.
+type progressWriter struct {
+	out io.Writer
+	tty bool
+}
+
+// newProgressWriter writes to stderr, with terminal features enabled when
+// stderr is an interactive terminal.
+func newProgressWriter() progressWriter {
+	return progressWriter{
+		out: os.Stderr,
+		tty: term.IsTerminal(int(os.Stderr.Fd())),
+	}
+}
+
+// gray returns text in gray color when writing to a terminal.
+func (w *progressWriter) gray(s string) string {
+	if !w.tty {
+		return s
+	}
+	return "\033[38;5;245m" + s + "\033[0m"
+}
+
+// printHeader prints the run header line naming the DAG, run ID, and params.
+func (w *progressWriter) printHeader(dag *core.DAG, dagRunID, params string) {
+	dagName := "unknown"
+	if dag != nil {
+		dagName = dag.Name
+	}
+	runID := dagRunID
+	if runID == "" {
+		runID = "..."
+	}
+	if params != "" {
+		fmt.Fprintf(w.out, "▶ %s %s %s\n", dagName, w.gray("("+runID+")"), w.gray("["+params+"]"))
+	} else {
+		fmt.Fprintf(w.out, "▶ %s %s\n", dagName, w.gray("("+runID+")"))
+	}
+}

--- a/internal/runtime/agent/progress_common_test.go
+++ b/internal/runtime/agent/progress_common_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressWriter_PrintHeader(t *testing.T) {
+	var buf bytes.Buffer
+	writer := progressWriter{out: &buf}
+
+	writer.printHeader(&core.DAG{Name: "etl"}, "run-1", "REGION=eu")
+	assert.Equal(t, "▶ etl (run-1) [REGION=eu]\n", buf.String())
+
+	buf.Reset()
+	writer.printHeader(&core.DAG{Name: "etl"}, "", "")
+	assert.Equal(t, "▶ etl (...)\n", buf.String())
+
+	buf.Reset()
+	writer.printHeader(nil, "run-2", "")
+	assert.Equal(t, "▶ unknown (run-2)\n", buf.String())
+}
+
+func TestProgressWriter_Gray(t *testing.T) {
+	writer := progressWriter{}
+	assert.Equal(t, "plain", writer.gray("plain"))
+
+	writer.tty = true
+	assert.Equal(t, "\033[38;5;245mcolored\033[0m", writer.gray("colored"))
+}

--- a/internal/runtime/agent/progress_common_test.go
+++ b/internal/runtime/agent/progress_common_test.go
@@ -27,6 +27,17 @@ func TestProgressWriter_PrintHeader(t *testing.T) {
 	assert.Equal(t, "▶ unknown (run-2)\n", buf.String())
 }
 
+func TestStatusIcon(t *testing.T) {
+	assert.Equal(t, "✓", statusIcon(core.Succeeded))
+	assert.Equal(t, "✓", statusIcon(core.PartiallySucceeded))
+	assert.Equal(t, "✗", statusIcon(core.Failed))
+	assert.Equal(t, "✗", statusIcon(core.Aborted))
+	assert.Equal(t, "⏸", statusIcon(core.Waiting))
+	assert.Equal(t, "●", statusIcon(core.Rejected))
+	assert.Equal(t, "●", statusIcon(core.Queued))
+	assert.Equal(t, "●", statusIcon(core.Running))
+}
+
 func TestProgressWriter_Gray(t *testing.T) {
 	writer := progressWriter{}
 	assert.Equal(t, "plain", writer.gray("plain"))

--- a/internal/runtime/agent/progress_controller.go
+++ b/internal/runtime/agent/progress_controller.go
@@ -88,7 +88,7 @@ func (p *ControllerProgressDisplay) UpdateNode(node *exec.Node) {
 			return
 		}
 		p.state = state
-		p.flushEventsLocked()
+		p.flushEventsLocked(false)
 		return
 	}
 
@@ -149,13 +149,30 @@ func (p *ControllerProgressDisplay) run() {
 	}
 }
 
-// flushEventsLocked prints timeline entries that have not been shown yet. The
-// timeline is append-only within one run attempt, so entries are printed in
-// order exactly once.
-func (p *ControllerProgressDisplay) flushEventsLocked() {
+// flushEventsLocked prints timeline entries in order, each exactly once. An
+// action entry is held back until its status is settled: a resumed run
+// finalizes a suspended action in place, so printing it as waiting would
+// freeze a stale mark into the scrollback. The controller runs one action per
+// turn, so at most the newest entry is held back and every entry behind it has
+// settled. With final set, held-back entries print as they stand, because
+// nothing will settle them in this process.
+func (p *ControllerProgressDisplay) flushEventsLocked(final bool) {
 	for ; p.printedEvents < len(p.state.Events); p.printedEvents++ {
-		p.printLineLocked(p.formatEvent(p.state.Events[p.printedEvents]))
+		event := p.state.Events[p.printedEvents]
+		if !final && event.Kind == controller.EventAction && !actionSettled(event.Status) {
+			return
+		}
+		p.printLineLocked(p.formatEvent(event))
 	}
+}
+
+// actionSettled reports whether an action event carries its final outcome.
+func actionSettled(status string) bool {
+	switch status {
+	case "", core.NodeRunning.String(), core.NodeRetrying.String(), core.NodeWaiting.String():
+		return false
+	}
+	return true
 }
 
 // printLineLocked prints one permanent line, clearing the live line first so
@@ -232,19 +249,11 @@ func (p *ControllerProgressDisplay) printFinal() {
 	defer p.mu.Unlock()
 
 	// Show decisions that arrived after the last node update, such as the final
-	// task settlement.
-	p.flushEventsLocked()
+	// task settlement, and any action still unsettled at suspension.
+	p.flushEventsLocked(true)
 	if p.liveLineShown {
 		fmt.Fprint(p.out, "\r\033[K")
 		p.liveLineShown = false
-	}
-
-	icon := "✓"
-	switch p.status {
-	case core.Failed, core.Aborted:
-		icon = "✗"
-	case core.Waiting:
-		icon = "⏸"
 	}
 
 	actions := 0
@@ -255,7 +264,7 @@ func (p *ControllerProgressDisplay) printFinal() {
 	}
 
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
-	fmt.Fprintf(p.out, "%s %s\n", icon,
+	fmt.Fprintf(p.out, "%s %s\n", statusIcon(p.status),
 		p.gray(fmt.Sprintf("%d actions, %d turns, %s", actions, p.state.Turns, elapsed)))
 }
 
@@ -293,7 +302,7 @@ func nodeStatusMark(status string) string {
 	switch status {
 	case core.NodeSucceeded.String():
 		return "✓"
-	case core.NodeFailed.String(), core.NodeAborted.String():
+	case core.NodeFailed.String(), core.NodeAborted.String(), core.NodeRejected.String():
 		return "✗"
 	case core.NodeWaiting.String():
 		return "⏸"

--- a/internal/runtime/agent/progress_controller.go
+++ b/internal/runtime/agent/progress_controller.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/runtime/controller"
-	"golang.org/x/term"
 )
 
 // maxReasonWidth bounds how much of a controller justification is shown on one
@@ -30,6 +28,8 @@ const maxReasonWidth = 120
 // unknown in advance, an action may repeat, and a step the controller never
 // picks was never pending work.
 type ControllerProgressDisplay struct {
+	progressWriter
+
 	dag      *core.DAG
 	dagRunID string
 	params   string
@@ -41,7 +41,6 @@ type ControllerProgressDisplay struct {
 	runningAction string
 	spinnerIndex  int
 	startTime     time.Time
-	isTTY         bool
 	liveLineShown bool
 
 	stopOnce sync.Once
@@ -54,10 +53,10 @@ var _ ProgressReporter = (*ControllerProgressDisplay)(nil)
 // NewControllerProgressDisplay creates a progress display for a controller DAG.
 func NewControllerProgressDisplay(dag *core.DAG) *ControllerProgressDisplay {
 	return &ControllerProgressDisplay{
-		dag:    dag,
-		isTTY:  term.IsTerminal(int(os.Stderr.Fd())),
-		stopCh: make(chan struct{}),
-		done:   make(chan struct{}),
+		progressWriter: newProgressWriter(),
+		dag:            dag,
+		stopCh:         make(chan struct{}),
+		done:           make(chan struct{}),
 	}
 }
 
@@ -123,9 +122,12 @@ func (p *ControllerProgressDisplay) run() {
 	p.startTime = time.Now()
 	p.mu.Unlock()
 
-	p.printHeader()
+	p.mu.Lock()
+	dag, runID, params := p.dag, p.dagRunID, p.params
+	p.mu.Unlock()
+	p.printHeader(dag, runID, params)
 
-	if !p.isTTY {
+	if !p.tty {
 		// Timeline lines are printed as they arrive; there is no live line to
 		// animate.
 		<-p.stopCh
@@ -147,27 +149,6 @@ func (p *ControllerProgressDisplay) run() {
 	}
 }
 
-func (p *ControllerProgressDisplay) printHeader() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	dagName := "unknown"
-	if p.dag != nil {
-		dagName = p.dag.Name
-	}
-
-	runID := p.dagRunID
-	if runID == "" {
-		runID = "..."
-	}
-
-	if p.params != "" {
-		fmt.Fprintf(os.Stderr, "▶ %s %s %s\n", dagName, p.gray("("+runID+")"), p.gray("["+p.params+"]"))
-	} else {
-		fmt.Fprintf(os.Stderr, "▶ %s %s\n", dagName, p.gray("("+runID+")"))
-	}
-}
-
 // flushEventsLocked prints timeline entries that have not been shown yet. The
 // timeline is append-only within one run attempt, so entries are printed in
 // order exactly once.
@@ -181,10 +162,10 @@ func (p *ControllerProgressDisplay) flushEventsLocked() {
 // the timeline stays intact above it.
 func (p *ControllerProgressDisplay) printLineLocked(line string) {
 	if p.liveLineShown {
-		fmt.Fprint(os.Stderr, "\r\033[K")
+		fmt.Fprint(p.out, "\r\033[K")
 		p.liveLineShown = false
 	}
-	fmt.Fprintln(os.Stderr, line)
+	fmt.Fprintln(p.out, line)
 }
 
 func (p *ControllerProgressDisplay) formatEvent(event controller.Event) string {
@@ -242,7 +223,7 @@ func (p *ControllerProgressDisplay) renderLiveLine() {
 
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
 
-	fmt.Fprintf(os.Stderr, "\r\033[K%s %s %s %s", spinner, activity, p.gray(p.openTasksText()), p.gray(elapsed))
+	fmt.Fprintf(p.out, "\r\033[K%s %s %s %s", spinner, activity, p.gray(p.openTasksText()), p.gray(elapsed))
 	p.liveLineShown = true
 }
 
@@ -254,7 +235,7 @@ func (p *ControllerProgressDisplay) printFinal() {
 	// task settlement.
 	p.flushEventsLocked()
 	if p.liveLineShown {
-		fmt.Fprint(os.Stderr, "\r\033[K")
+		fmt.Fprint(p.out, "\r\033[K")
 		p.liveLineShown = false
 	}
 
@@ -274,7 +255,7 @@ func (p *ControllerProgressDisplay) printFinal() {
 	}
 
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
-	fmt.Fprintf(os.Stderr, "%s %s\n", icon,
+	fmt.Fprintf(p.out, "%s %s\n", icon,
 		p.gray(fmt.Sprintf("%d actions, %d turns, %s", actions, p.state.Turns, elapsed)))
 }
 
@@ -295,14 +276,6 @@ func (p *ControllerProgressDisplay) openTasksText() string {
 		return "1 task open"
 	}
 	return fmt.Sprintf("%d tasks open", open)
-}
-
-// gray returns text in gray color when writing to a terminal.
-func (p *ControllerProgressDisplay) gray(s string) string {
-	if !p.isTTY {
-		return s
-	}
-	return "\033[38;5;245m" + s + "\033[0m"
 }
 
 // compactReason renders a controller justification as one bounded line.

--- a/internal/runtime/agent/progress_controller.go
+++ b/internal/runtime/agent/progress_controller.go
@@ -1,0 +1,349 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
+	"github.com/dagucloud/dagu/v2/internal/core"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
+	"github.com/dagucloud/dagu/v2/internal/runtime/controller"
+	"golang.org/x/term"
+)
+
+// maxReasonWidth bounds how much of a controller justification is shown on one
+// timeline line. The full text is in the run's timeline and the Web UI.
+const maxReasonWidth = 120
+
+// ControllerProgressDisplay renders a controller run as its decision timeline:
+// one line per decision as it settles, a live line for what the controller is
+// doing now, and a final line with the outcome.
+//
+// Percent progress does not apply to a controller run: the number of turns is
+// unknown in advance, an action may repeat, and a step the controller never
+// picks was never pending work.
+type ControllerProgressDisplay struct {
+	dag      *core.DAG
+	dagRunID string
+	params   string
+
+	mu            sync.Mutex
+	status        core.Status
+	state         controller.State
+	printedEvents int
+	runningAction string
+	spinnerIndex  int
+	startTime     time.Time
+	isTTY         bool
+	liveLineShown bool
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	done     chan struct{}
+}
+
+var _ ProgressReporter = (*ControllerProgressDisplay)(nil)
+
+// NewControllerProgressDisplay creates a progress display for a controller DAG.
+func NewControllerProgressDisplay(dag *core.DAG) *ControllerProgressDisplay {
+	return &ControllerProgressDisplay{
+		dag:    dag,
+		isTTY:  term.IsTerminal(int(os.Stderr.Fd())),
+		stopCh: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start begins the progress display.
+func (p *ControllerProgressDisplay) Start() {
+	go p.run()
+}
+
+// Stop stops the progress display. Safe to call multiple times.
+func (p *ControllerProgressDisplay) Stop() {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+	})
+	<-p.done
+}
+
+// UpdateNode consumes node updates. The controller node carries the decision
+// timeline; every other node marks which action is in flight.
+func (p *ControllerProgressDisplay) UpdateNode(node *exec.Node) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if node.Step.Name == core.ControllerStepName {
+		if len(node.ControllerState) == 0 {
+			return
+		}
+		var state controller.State
+		if err := json.Unmarshal(node.ControllerState, &state); err != nil {
+			return
+		}
+		p.state = state
+		p.flushEventsLocked()
+		return
+	}
+
+	switch {
+	case node.Status == core.NodeRunning:
+		p.runningAction = node.Step.Name
+	case p.runningAction == node.Step.Name:
+		p.runningAction = ""
+	}
+}
+
+// UpdateStatus updates the overall DAG status.
+func (p *ControllerProgressDisplay) UpdateStatus(status *exec.DAGRunStatus) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.status = status.Status
+}
+
+// SetDAGRunInfo sets the DAG run ID and parameters.
+func (p *ControllerProgressDisplay) SetDAGRunInfo(dagRunID, params string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.dagRunID = dagRunID
+	p.params = params
+}
+
+func (p *ControllerProgressDisplay) run() {
+	defer close(p.done)
+
+	p.mu.Lock()
+	p.startTime = time.Now()
+	p.mu.Unlock()
+
+	p.printHeader()
+
+	if !p.isTTY {
+		// Timeline lines are printed as they arrive; there is no live line to
+		// animate.
+		<-p.stopCh
+		p.printFinal()
+		return
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			p.printFinal()
+			return
+		case <-ticker.C:
+			p.renderLiveLine()
+		}
+	}
+}
+
+func (p *ControllerProgressDisplay) printHeader() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	dagName := "unknown"
+	if p.dag != nil {
+		dagName = p.dag.Name
+	}
+
+	runID := p.dagRunID
+	if runID == "" {
+		runID = "..."
+	}
+
+	if p.params != "" {
+		fmt.Fprintf(os.Stderr, "▶ %s %s %s\n", dagName, p.gray("("+runID+")"), p.gray("["+p.params+"]"))
+	} else {
+		fmt.Fprintf(os.Stderr, "▶ %s %s\n", dagName, p.gray("("+runID+")"))
+	}
+}
+
+// flushEventsLocked prints timeline entries that have not been shown yet. The
+// timeline is append-only within one run attempt, so entries are printed in
+// order exactly once.
+func (p *ControllerProgressDisplay) flushEventsLocked() {
+	for ; p.printedEvents < len(p.state.Events); p.printedEvents++ {
+		p.printLineLocked(p.formatEvent(p.state.Events[p.printedEvents]))
+	}
+}
+
+// printLineLocked prints one permanent line, clearing the live line first so
+// the timeline stays intact above it.
+func (p *ControllerProgressDisplay) printLineLocked(line string) {
+	if p.liveLineShown {
+		fmt.Fprint(os.Stderr, "\r\033[K")
+		p.liveLineShown = false
+	}
+	fmt.Fprintln(os.Stderr, line)
+}
+
+func (p *ControllerProgressDisplay) formatEvent(event controller.Event) string {
+	turn := p.gray(fmt.Sprintf("turn %d", event.Turn))
+
+	switch event.Kind {
+	case controller.EventAction:
+		line := fmt.Sprintf("● %s  %s %s", turn, event.Name, nodeStatusMark(event.Status))
+		if duration := eventDuration(event); duration != "" {
+			line += " " + p.gray(duration)
+		}
+		if event.Attempt > 1 {
+			line += " " + p.gray(fmt.Sprintf("(attempt %d)", event.Attempt))
+		}
+		if event.Status == core.NodeFailed.String() && event.Reason != "" {
+			line += " " + p.gray(compactReason(event.Reason))
+		}
+		return line
+	case controller.EventTaskStatus:
+		verb := event.Status
+		if event.Status == string(controller.TaskOpen) {
+			verb = "reopened"
+		}
+		mark := "●"
+		if event.Status == string(controller.TaskFailed) {
+			mark = "✗"
+		}
+		line := fmt.Sprintf("%s %s  task %s %s", mark, turn, event.Name, verb)
+		if event.Reason != "" {
+			line += ": " + compactReason(event.Reason)
+		}
+		return line
+	case controller.EventAskUser:
+		return fmt.Sprintf("● %s  asked: %s", turn, compactReason(event.Reason))
+	case controller.EventRejected:
+		return fmt.Sprintf("● %s  rejected %s: %s", turn, event.Name, p.gray(compactReason(event.Reason)))
+	case controller.EventStalled:
+		return fmt.Sprintf("● %s  stalled: %s", turn, p.gray(compactReason(event.Reason)))
+	default:
+		return fmt.Sprintf("● %s  %s", turn, event.Kind)
+	}
+}
+
+func (p *ControllerProgressDisplay) renderLiveLine() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	spinner := stringutil.SpinnerFrames[p.spinnerIndex%len(stringutil.SpinnerFrames)]
+	p.spinnerIndex++
+
+	activity := "deciding"
+	if p.runningAction != "" {
+		activity = "running " + p.runningAction
+	}
+
+	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
+
+	fmt.Fprintf(os.Stderr, "\r\033[K%s %s %s %s", spinner, activity, p.gray(p.openTasksText()), p.gray(elapsed))
+	p.liveLineShown = true
+}
+
+func (p *ControllerProgressDisplay) printFinal() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Show decisions that arrived after the last node update, such as the final
+	// task settlement.
+	p.flushEventsLocked()
+	if p.liveLineShown {
+		fmt.Fprint(os.Stderr, "\r\033[K")
+		p.liveLineShown = false
+	}
+
+	icon := "✓"
+	switch p.status {
+	case core.Failed, core.Aborted:
+		icon = "✗"
+	case core.Waiting:
+		icon = "⏸"
+	}
+
+	actions := 0
+	for _, event := range p.state.Events {
+		if event.Kind == controller.EventAction {
+			actions++
+		}
+	}
+
+	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
+	fmt.Fprintf(os.Stderr, "%s %s\n", icon,
+		p.gray(fmt.Sprintf("%d actions, %d turns, %s", actions, p.state.Turns, elapsed)))
+}
+
+func (p *ControllerProgressDisplay) openTasksText() string {
+	open := 0
+	switch {
+	case len(p.state.Tasks) > 0:
+		for _, task := range p.state.Tasks {
+			if task.Status == controller.TaskOpen || task.Status == "" {
+				open++
+			}
+		}
+	case p.dag != nil:
+		// No controller state has arrived yet; every declared task is open.
+		open = len(p.dag.Tasks)
+	}
+	if open == 1 {
+		return "1 task open"
+	}
+	return fmt.Sprintf("%d tasks open", open)
+}
+
+// gray returns text in gray color when writing to a terminal.
+func (p *ControllerProgressDisplay) gray(s string) string {
+	if !p.isTTY {
+		return s
+	}
+	return "\033[38;5;245m" + s + "\033[0m"
+}
+
+// compactReason renders a controller justification as one bounded line.
+func compactReason(reason string) string {
+	reason = strings.Join(strings.Fields(reason), " ")
+	runes := []rune(reason)
+	if len(runes) <= maxReasonWidth {
+		return reason
+	}
+	return string(runes[:maxReasonWidth]) + "…"
+}
+
+// nodeStatusMark maps a node status to a one-character outcome mark.
+func nodeStatusMark(status string) string {
+	switch status {
+	case core.NodeSucceeded.String():
+		return "✓"
+	case core.NodeFailed.String(), core.NodeAborted.String():
+		return "✗"
+	case core.NodeWaiting.String():
+		return "⏸"
+	default:
+		return status
+	}
+}
+
+// eventDuration formats how long an action took, when both timestamps exist.
+func eventDuration(event controller.Event) string {
+	if event.StartedAt == "" || event.FinishedAt == "" {
+		return ""
+	}
+	started, err := stringutil.ParseTime(event.StartedAt)
+	if err != nil {
+		return ""
+	}
+	finished, err := stringutil.ParseTime(event.FinishedAt)
+	if err != nil {
+		return ""
+	}
+	if finished.Before(started) {
+		return ""
+	}
+	return stringutil.FormatDuration(finished.Sub(started))
+}

--- a/internal/runtime/agent/progress_controller_test.go
+++ b/internal/runtime/agent/progress_controller_test.go
@@ -1,0 +1,220 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
+	"github.com/dagucloud/dagu/v2/internal/runtime/controller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateProgressReporter_ControllerDAG(t *testing.T) {
+	controllerDAG := &core.DAG{Name: "triage", Type: core.TypeController}
+	reporter := createProgressReporter(controllerDAG, "run-1", nil)
+	assert.IsType(t, &ControllerProgressDisplay{}, reporter)
+
+	graphDAG := &core.DAG{Name: "etl"}
+	reporter = createProgressReporter(graphDAG, "run-2", nil)
+	assert.IsType(t, &SimpleProgressDisplay{}, reporter)
+}
+
+func TestControllerProgressDisplay_UpdateNode(t *testing.T) {
+	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	state := controller.State{
+		Tasks: []controller.TaskState{{Name: "triage", Status: controller.TaskOpen}},
+		Events: []controller.Event{
+			{Turn: 1, Kind: controller.EventAction, Name: "disk", Status: "succeeded"},
+			{Turn: 2, Kind: controller.EventAction, Name: "load", Status: "succeeded"},
+		},
+		Turns: 2,
+	}
+	raw, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	display.UpdateNode(&exec.Node{
+		Step:            core.Step{Name: core.ControllerStepName},
+		Status:          core.NodeRunning,
+		ControllerState: raw,
+	})
+
+	assert.Equal(t, 2, display.printedEvents)
+	assert.Equal(t, 2, display.state.Turns)
+
+	// A later update prints only events that were not shown yet.
+	state.Events = append(state.Events, controller.Event{
+		Turn: 3, Kind: controller.EventTaskStatus, Name: "triage",
+		Status: string(controller.TaskCompleted), Reason: "all good",
+	})
+	raw, err = json.Marshal(state)
+	require.NoError(t, err)
+	display.UpdateNode(&exec.Node{
+		Step:            core.Step{Name: core.ControllerStepName},
+		Status:          core.NodeRunning,
+		ControllerState: raw,
+	})
+	assert.Equal(t, 3, display.printedEvents)
+}
+
+func TestControllerProgressDisplay_UpdateNode_TracksRunningAction(t *testing.T) {
+	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	display.UpdateNode(&exec.Node{Step: core.Step{Name: "disk"}, Status: core.NodeRunning})
+	assert.Equal(t, "disk", display.runningAction)
+
+	display.UpdateNode(&exec.Node{Step: core.Step{Name: "disk"}, Status: core.NodeSucceeded})
+	assert.Equal(t, "", display.runningAction)
+
+	// A finished node that is not the one in flight leaves the marker alone.
+	display.UpdateNode(&exec.Node{Step: core.Step{Name: "load"}, Status: core.NodeRunning})
+	display.UpdateNode(&exec.Node{Step: core.Step{Name: "disk"}, Status: core.NodeSucceeded})
+	assert.Equal(t, "load", display.runningAction)
+}
+
+func TestControllerProgressDisplay_UpdateNode_IgnoresBadState(t *testing.T) {
+	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	display.UpdateNode(&exec.Node{
+		Step:            core.Step{Name: core.ControllerStepName},
+		Status:          core.NodeRunning,
+		ControllerState: json.RawMessage("{not json"),
+	})
+	assert.Equal(t, 0, display.printedEvents)
+
+	display.UpdateNode(&exec.Node{
+		Step:   core.Step{Name: core.ControllerStepName},
+		Status: core.NodeRunning,
+	})
+	assert.Equal(t, 0, display.printedEvents)
+}
+
+func TestControllerProgressDisplay_FormatEvent(t *testing.T) {
+	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	tests := []struct {
+		name  string
+		event controller.Event
+		want  []string
+	}{
+		{
+			name: "action succeeded with duration",
+			event: controller.Event{
+				Turn: 1, Kind: controller.EventAction, Name: "disk", Status: "succeeded",
+				StartedAt: "2026-08-02T16:31:21+09:00", FinishedAt: "2026-08-02T16:31:23+09:00",
+			},
+			want: []string{"turn 1", "disk", "✓", "2.0s"},
+		},
+		{
+			name: "action failed with reason",
+			event: controller.Event{
+				Turn: 2, Kind: controller.EventAction, Name: "probe", Status: "failed",
+				Reason: "exit status 6",
+			},
+			want: []string{"turn 2", "probe", "✗", "exit status 6"},
+		},
+		{
+			name: "repeated action shows attempt",
+			event: controller.Event{
+				Turn: 3, Kind: controller.EventAction, Name: "probe", Status: "succeeded", Attempt: 2,
+			},
+			want: []string{"probe", "✓", "(attempt 2)"},
+		},
+		{
+			name: "task completed with reason",
+			event: controller.Event{
+				Turn: 4, Kind: controller.EventTaskStatus, Name: "triage",
+				Status: string(controller.TaskCompleted), Reason: "machine healthy",
+			},
+			want: []string{"task triage completed", "machine healthy"},
+		},
+		{
+			name: "task reopened",
+			event: controller.Event{
+				Turn: 5, Kind: controller.EventTaskStatus, Name: "triage",
+				Status: string(controller.TaskOpen), Reason: "later work invalidated it",
+			},
+			want: []string{"task triage reopened"},
+		},
+		{
+			name: "task failed uses failure mark",
+			event: controller.Event{
+				Turn: 6, Kind: controller.EventTaskStatus, Name: "triage",
+				Status: string(controller.TaskFailed), Reason: "cannot reach host",
+			},
+			want: []string{"✗", "task triage failed", "cannot reach host"},
+		},
+		{
+			name: "question",
+			event: controller.Event{
+				Turn: 7, Kind: controller.EventAskUser, Name: core.AskUserStepName,
+				Reason: "Which region?",
+			},
+			want: []string{"asked", "Which region?"},
+		},
+		{
+			name: "rejected call",
+			event: controller.Event{
+				Turn: 8, Kind: controller.EventRejected, Name: "unknown_tool", Reason: "no such tool",
+			},
+			want: []string{"rejected unknown_tool", "no such tool"},
+		},
+		{
+			name:  "stalled turn",
+			event: controller.Event{Turn: 9, Kind: controller.EventStalled, Reason: "no action chosen"},
+			want:  []string{"stalled", "no action chosen"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			line := display.formatEvent(tc.event)
+			for _, fragment := range tc.want {
+				assert.Contains(t, line, fragment)
+			}
+		})
+	}
+}
+
+func TestCompactReason(t *testing.T) {
+	assert.Equal(t, "one line", compactReason("one\n line\t"))
+
+	long := strings.Repeat("あ", maxReasonWidth+10)
+	got := compactReason(long)
+	assert.Equal(t, maxReasonWidth+1, len([]rune(got)))
+	assert.True(t, strings.HasSuffix(got, "…"))
+}
+
+func TestEventDuration(t *testing.T) {
+	assert.Equal(t, "", eventDuration(controller.Event{StartedAt: "2026-08-02T16:31:21+09:00"}))
+	assert.Equal(t, "", eventDuration(controller.Event{
+		StartedAt: "not a time", FinishedAt: "2026-08-02T16:31:23+09:00",
+	}))
+	assert.NotEqual(t, "", eventDuration(controller.Event{
+		StartedAt: "2026-08-02T16:31:21+09:00", FinishedAt: "2026-08-02T16:31:23+09:00",
+	}))
+}
+
+func TestControllerProgressDisplay_OpenTasksText(t *testing.T) {
+	// Before any controller state arrives, every declared task is open.
+	display := NewControllerProgressDisplay(&core.DAG{
+		Name: "triage", Type: core.TypeController,
+		Tasks: []core.ControllerTask{{Name: "a"}, {Name: "b"}},
+	})
+	assert.Equal(t, "2 tasks open", display.openTasksText())
+
+	display.state = controller.State{Tasks: []controller.TaskState{
+		{Name: "a", Status: controller.TaskOpen},
+		{Name: "b", Status: controller.TaskCompleted},
+	}}
+	assert.Equal(t, "1 task open", display.openTasksText())
+
+	display.state.Tasks[1].Status = controller.TaskOpen
+	assert.Equal(t, "2 tasks open", display.openTasksText())
+}

--- a/internal/runtime/agent/progress_controller_test.go
+++ b/internal/runtime/agent/progress_controller_test.go
@@ -78,6 +78,74 @@ func TestControllerProgressDisplay_UpdateNode(t *testing.T) {
 	assert.Contains(t, out.String(), "task triage completed: all good")
 }
 
+// controllerStateNode wraps a controller state into the node update the
+// display receives.
+func controllerStateNode(t *testing.T, state controller.State) *exec.Node {
+	t.Helper()
+	raw, err := json.Marshal(state)
+	require.NoError(t, err)
+	return &exec.Node{
+		Step:            core.Step{Name: core.ControllerStepName},
+		Status:          core.NodeRunning,
+		ControllerState: raw,
+	}
+}
+
+func TestControllerProgressDisplay_HoldsBackUnsettledAction(t *testing.T) {
+	display, out := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	// A resumed run first reports the inherited timeline with the suspended
+	// action still waiting.
+	state := controller.State{
+		Events: []controller.Event{
+			{Turn: 1, Kind: controller.EventAction, Name: "disk", Status: "succeeded"},
+			{Turn: 2, Kind: controller.EventAction, Name: "review", Status: "waiting"},
+		},
+		Turns: 2,
+	}
+	display.UpdateNode(controllerStateNode(t, state))
+	assert.Contains(t, out.String(), "disk ✓")
+	assert.NotContains(t, out.String(), "review")
+	assert.Equal(t, 1, display.printedEvents)
+
+	// The action is then finalized in place: same timeline length, new status.
+	state.Events[1].Status = "succeeded"
+	display.UpdateNode(controllerStateNode(t, state))
+	assert.Contains(t, out.String(), "review ✓")
+	assert.Equal(t, 2, display.printedEvents)
+}
+
+func TestControllerProgressDisplay_PrintFinalFlushesUnsettledAction(t *testing.T) {
+	display, out := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+
+	state := controller.State{
+		Events: []controller.Event{
+			{Turn: 1, Kind: controller.EventAction, Name: "review", Status: "waiting"},
+		},
+		Turns: 1,
+	}
+	display.UpdateNode(controllerStateNode(t, state))
+	assert.NotContains(t, out.String(), "review")
+
+	// Suspension ends the process with the action still waiting; the final
+	// flush shows it as it stands.
+	display.UpdateStatus(&exec.DAGRunStatus{Status: core.Waiting})
+	display.printFinal()
+	assert.Contains(t, out.String(), "review ⏸")
+	assert.Contains(t, out.String(), "⏸ ")
+}
+
+func TestActionSettled(t *testing.T) {
+	assert.False(t, actionSettled(""))
+	assert.False(t, actionSettled("running"))
+	assert.False(t, actionSettled("waiting"))
+	assert.False(t, actionSettled("retrying"))
+	assert.True(t, actionSettled("succeeded"))
+	assert.True(t, actionSettled("failed"))
+	assert.True(t, actionSettled("aborted"))
+	assert.True(t, actionSettled("rejected"))
+}
+
 func TestControllerProgressDisplay_UpdateNode_TracksRunningAction(t *testing.T) {
 	display, _ := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
 

--- a/internal/runtime/agent/progress_controller_test.go
+++ b/internal/runtime/agent/progress_controller_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -14,6 +15,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newTestControllerDisplay returns a display writing to the returned buffer
+// instead of stderr.
+func newTestControllerDisplay(dag *core.DAG) (*ControllerProgressDisplay, *bytes.Buffer) {
+	display := NewControllerProgressDisplay(dag)
+	var buf bytes.Buffer
+	display.progressWriter = progressWriter{out: &buf}
+	return display, &buf
+}
 
 func TestCreateProgressReporter_ControllerDAG(t *testing.T) {
 	controllerDAG := &core.DAG{Name: "triage", Type: core.TypeController}
@@ -26,7 +36,7 @@ func TestCreateProgressReporter_ControllerDAG(t *testing.T) {
 }
 
 func TestControllerProgressDisplay_UpdateNode(t *testing.T) {
-	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+	display, out := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
 
 	state := controller.State{
 		Tasks: []controller.TaskState{{Name: "triage", Status: controller.TaskOpen}},
@@ -47,8 +57,11 @@ func TestControllerProgressDisplay_UpdateNode(t *testing.T) {
 
 	assert.Equal(t, 2, display.printedEvents)
 	assert.Equal(t, 2, display.state.Turns)
+	assert.Contains(t, out.String(), "turn 1  disk ✓")
+	assert.Contains(t, out.String(), "turn 2  load ✓")
 
 	// A later update prints only events that were not shown yet.
+	out.Reset()
 	state.Events = append(state.Events, controller.Event{
 		Turn: 3, Kind: controller.EventTaskStatus, Name: "triage",
 		Status: string(controller.TaskCompleted), Reason: "all good",
@@ -61,10 +74,12 @@ func TestControllerProgressDisplay_UpdateNode(t *testing.T) {
 		ControllerState: raw,
 	})
 	assert.Equal(t, 3, display.printedEvents)
+	assert.NotContains(t, out.String(), "disk")
+	assert.Contains(t, out.String(), "task triage completed: all good")
 }
 
 func TestControllerProgressDisplay_UpdateNode_TracksRunningAction(t *testing.T) {
-	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+	display, _ := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
 
 	display.UpdateNode(&exec.Node{Step: core.Step{Name: "disk"}, Status: core.NodeRunning})
 	assert.Equal(t, "disk", display.runningAction)
@@ -79,7 +94,7 @@ func TestControllerProgressDisplay_UpdateNode_TracksRunningAction(t *testing.T) 
 }
 
 func TestControllerProgressDisplay_UpdateNode_IgnoresBadState(t *testing.T) {
-	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+	display, out := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
 
 	display.UpdateNode(&exec.Node{
 		Step:            core.Step{Name: core.ControllerStepName},
@@ -93,10 +108,11 @@ func TestControllerProgressDisplay_UpdateNode_IgnoresBadState(t *testing.T) {
 		Status: core.NodeRunning,
 	})
 	assert.Equal(t, 0, display.printedEvents)
+	assert.Equal(t, "", out.String())
 }
 
 func TestControllerProgressDisplay_FormatEvent(t *testing.T) {
-	display := NewControllerProgressDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
+	display, _ := newTestControllerDisplay(&core.DAG{Name: "triage", Type: core.TypeController})
 
 	tests := []struct {
 		name  string
@@ -203,7 +219,7 @@ func TestEventDuration(t *testing.T) {
 
 func TestControllerProgressDisplay_OpenTasksText(t *testing.T) {
 	// Before any controller state arrives, every declared task is open.
-	display := NewControllerProgressDisplay(&core.DAG{
+	display, _ := newTestControllerDisplay(&core.DAG{
 		Name: "triage", Type: core.TypeController,
 		Tasks: []core.ControllerTask{{Name: "a"}, {Name: "b"}},
 	})

--- a/internal/runtime/agent/progress_simple.go
+++ b/internal/runtime/agent/progress_simple.go
@@ -146,13 +146,8 @@ func (p *SimpleProgressDisplay) printFinal() {
 		percent = (p.completed * 100) / p.total
 	}
 
-	icon := "✓"
-	if p.status == core.Failed || p.status == core.Aborted {
-		icon = "✗"
-	}
-
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
 
 	// Clear line and print final status
-	fmt.Fprintf(p.out, "\r%s %d%% (%d/%d steps) %s   \n", icon, percent, p.completed, p.total, p.gray(elapsed))
+	fmt.Fprintf(p.out, "\r%s %d%% (%d/%d steps) %s   \n", statusIcon(p.status), percent, p.completed, p.total, p.gray(elapsed))
 }

--- a/internal/runtime/agent/progress_simple.go
+++ b/internal/runtime/agent/progress_simple.go
@@ -5,18 +5,18 @@ package agent
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
-	"golang.org/x/term"
 )
 
 // SimpleProgressDisplay provides a minimal inline progress display.
 type SimpleProgressDisplay struct {
+	progressWriter
+
 	dag      *core.DAG
 	dagRunID string
 	params   string
@@ -28,7 +28,6 @@ type SimpleProgressDisplay struct {
 	status         core.Status
 	spinnerIndex   int
 	startTime      time.Time
-	colorEnabled   bool
 
 	stopOnce sync.Once
 	stopCh   chan struct{}
@@ -42,10 +41,10 @@ func NewSimpleProgressDisplay(dag *core.DAG) *SimpleProgressDisplay {
 		total = len(dag.Steps)
 	}
 	return &SimpleProgressDisplay{
+		progressWriter: newProgressWriter(),
 		dag:            dag,
 		total:          total,
 		completedNodes: make(map[string]bool),
-		colorEnabled:   term.IsTerminal(int(os.Stderr.Fd())),
 		stopCh:         make(chan struct{}),
 		done:           make(chan struct{}),
 	}
@@ -101,7 +100,10 @@ func (p *SimpleProgressDisplay) run() {
 	p.mu.Unlock()
 
 	// Print header
-	p.printHeader()
+	p.mu.Lock()
+	dag, runID, params := p.dag, p.dagRunID, p.params
+	p.mu.Unlock()
+	p.printHeader(dag, runID, params)
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -115,35 +117,6 @@ func (p *SimpleProgressDisplay) run() {
 			p.render()
 		}
 	}
-}
-
-func (p *SimpleProgressDisplay) printHeader() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	dagName := "unknown"
-	if p.dag != nil {
-		dagName = p.dag.Name
-	}
-
-	runID := p.dagRunID
-	if runID == "" {
-		runID = "..."
-	}
-
-	if p.params != "" {
-		fmt.Fprintf(os.Stderr, "▶ %s %s %s\n", dagName, p.gray("("+runID+")"), p.gray("["+p.params+"]"))
-	} else {
-		fmt.Fprintf(os.Stderr, "▶ %s %s\n", dagName, p.gray("("+runID+")"))
-	}
-}
-
-// gray returns text in gray color if color is enabled.
-func (p *SimpleProgressDisplay) gray(s string) string {
-	if !p.colorEnabled {
-		return s
-	}
-	return "\033[38;5;245m" + s + "\033[0m"
 }
 
 func (p *SimpleProgressDisplay) render() {
@@ -161,7 +134,7 @@ func (p *SimpleProgressDisplay) render() {
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
 
 	// Use \r to overwrite the line, pad with spaces to clear previous content
-	fmt.Fprintf(os.Stderr, "\r%s %d%% (%d/%d steps) %s   ", spinner, percent, p.completed, p.total, p.gray(elapsed))
+	fmt.Fprintf(p.out, "\r%s %d%% (%d/%d steps) %s   ", spinner, percent, p.completed, p.total, p.gray(elapsed))
 }
 
 func (p *SimpleProgressDisplay) printFinal() {
@@ -181,5 +154,5 @@ func (p *SimpleProgressDisplay) printFinal() {
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))
 
 	// Clear line and print final status
-	fmt.Fprintf(os.Stderr, "\r%s %d%% (%d/%d steps) %s   \n", icon, percent, p.completed, p.total, p.gray(elapsed))
+	fmt.Fprintf(p.out, "\r%s %d%% (%d/%d steps) %s   \n", icon, percent, p.completed, p.total, p.gray(elapsed))
 }


### PR DESCRIPTION
## Problem

Running a controller DAG from the CLI shows graph-run progress:

```
▶ triage2 (034037BmE9Mcnxx8cwxyYG)
✓ 100% (6/6 steps) 45.0s
Succeeded - 2026-08-02T16:40:26+09:00
```

Percent progress does not fit a controller run: the turn count is unknown in advance, actions may repeat (up to 5x), and steps the controller never picks were never pending work. The step count also includes the synthesized `__controller__` and `ask_user` steps. Meanwhile the decision sequence and the task verdicts, the actual product of a controller run, are invisible until you open the Web UI or the logs.

## Change

Controller DAG runs get their own progress display, rendering the decision timeline as it unfolds:

```
▶ triage2 (03403es3P0J40tFlDGnCMA)
● turn 2  disk ✓ 0s
● turn 3  load ✓ 0s
● turn 4  processes ✓ 0s
● turn 5  summarize ✓ 2.0s
● turn 6  task triage completed: Machine has been checked: disk is healthy (main volume 5%, Data volume 72%…
✓ 4 actions, 6 turns, 56.1s
```

- One permanent line per decision as it settles: actions with outcome mark, duration, and attempt number when repeated; task settlements with the controller's reason (single line, truncated at 120 runes); questions, rejected tool calls, and stalled turns.
- A live line shows the action in flight or `deciding`, plus open task count and elapsed time.
- The final line reports action and turn counts instead of a step percentage.

## Implementation

- The runner already persists `ControllerState` (tasks, decision timeline, turns) to the `__controller__` node on every turn and pushes it through the progress channel; the agent's node conversion just dropped the field. Carrying it over (one line in `nodeToModelNode`) is what feeds the display.
- `createProgressReporter` selects the new display when `dag.Type == controller`; graph and chain DAGs are untouched.
- The timeline is append-only within one run attempt, so the display prints each event exactly once in order.

## Testing

- Unit tests for reporter selection, event formatting per kind, incremental flushing, running-action tracking, malformed state handling, reason truncation (rune-safe), and duration formatting.
- Live-tested under a pty against real OpenRouter runs; one run organically produced a `stalled` turn, which rendered correctly. `golangci-lint` clean, `GOOS=windows` build green, full agent package tests pass with race detection.

## Out of scope

Remote runs (`progress_remote.go`) keep the step-based display for now; parity needs the worker status report checked for `ControllerState` and is a natural follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated CLI progress display for controller DAG runs that shows the decision timeline live, and refactors output into a shared `progressWriter` used by both displays. Also fixes stale waiting marks on resumed runs and uses explicit final status icons (including ⏸ for waiting) across both displays.

- **New Features**
  - Controller runs use a dedicated display when `dag.Type == controller`.
  - Prints one line per decision: actions with outcome/duration/attempt, task verdicts with reason, questions, rejections, and stalls.
  - Live line shows the running action or “deciding”, open task count, and elapsed time.
  - Final line reports action and turn counts instead of step percentage.

- **Bug Fixes**
  - Hold back action entries until their status settles; the final flush prints any held-back entries so resumed/suspended runs don’t show stale “waiting” marks.
  - Share an explicit status-to-icon mapping; non-success states (e.g., waiting) no longer close with a checkmark.

<sup>Written for commit fe83ab77c28a95c52ee7027ddec325a692a94374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated live progress view for controller-driven runs.
  * Displays decision timelines, active actions, task counts, statuses, attempts, durations, and terminal results.
  * Supports animated terminal output and readable non-interactive output.
  * Reports run metadata and final outcomes, including success, failure, aborted, and waiting states.

* **Bug Fixes**
  * Preserved controller state in execution progress information.
  * Improved handling of incomplete or malformed progress data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->