### PR TITLE
feat: business calendars for scheduled DAGs

### DIFF
--- a/internal/buscal/calendar.go
+++ b/internal/buscal/calendar.go
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package buscal implements business calendars: named sets of weekend days and
+// holidays that the scheduler consults to decide whether a scheduled DAG run
+// should dispatch on a given date.
+package buscal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+// dateLayout is the calendar date format used for holiday entries.
+const dateLayout = "2006-01-02"
+
+// Calendar is an immutable, evaluated business calendar.
+type Calendar struct {
+	// Name is the calendar identity, taken from the definition filename stem.
+	Name string
+	// Location is the timezone in which calendar dates are interpreted.
+	Location *time.Location
+
+	weekend  map[time.Weekday]bool
+	holidays map[string]bool
+}
+
+// definition is the YAML shape of a calendar file.
+type definition struct {
+	// Timezone is an IANA timezone name. Empty means the process-local zone.
+	Timezone string `yaml:"timezone,omitempty"`
+	// Weekends lists non-working weekday names. Defaults to saturday/sunday.
+	Weekends *[]string `yaml:"weekends,omitempty"`
+	// Holidays lists non-working dates in YYYY-MM-DD form.
+	Holidays []string `yaml:"holidays,omitempty"`
+}
+
+var weekdayNames = map[string]time.Weekday{
+	"sunday":    time.Sunday,
+	"monday":    time.Monday,
+	"tuesday":   time.Tuesday,
+	"wednesday": time.Wednesday,
+	"thursday":  time.Thursday,
+	"friday":    time.Friday,
+	"saturday":  time.Saturday,
+}
+
+// Parse parses a calendar definition. The name becomes the calendar identity
+// and must be a valid calendar name.
+func Parse(name string, data []byte) (*Calendar, error) {
+	if !core.ValidCalendarName(name) {
+		return nil, fmt.Errorf("invalid calendar name %q", name)
+	}
+
+	var def definition
+	if err := yaml.UnmarshalWithOptions(data, &def, yaml.Strict()); err != nil {
+		return nil, fmt.Errorf("invalid calendar definition %q: %w", name, err)
+	}
+
+	loc := time.Local
+	if def.Timezone != "" {
+		var err error
+		loc, err = time.LoadLocation(def.Timezone)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timezone %q in calendar %q: %w", def.Timezone, name, err)
+		}
+	}
+
+	weekend := map[time.Weekday]bool{time.Saturday: true, time.Sunday: true}
+	if def.Weekends != nil {
+		weekend = map[time.Weekday]bool{}
+		for _, dayName := range *def.Weekends {
+			day, ok := weekdayNames[dayName]
+			if !ok {
+				return nil, fmt.Errorf("invalid weekend day %q in calendar %q: use full lowercase day names (e.g. \"saturday\")", dayName, name)
+			}
+			weekend[day] = true
+		}
+	}
+	if len(weekend) >= 7 {
+		return nil, fmt.Errorf("calendar %q declares every weekday as weekend", name)
+	}
+
+	holidays := make(map[string]bool, len(def.Holidays))
+	for _, holidayDate := range def.Holidays {
+		parsedDate, err := time.ParseInLocation(dateLayout, holidayDate, loc)
+		if err != nil {
+			return nil, fmt.Errorf("invalid holiday date %q in calendar %q: must be YYYY-MM-DD", holidayDate, name)
+		}
+		holidays[parsedDate.Format(dateLayout)] = true
+	}
+
+	return &Calendar{
+		Name:     name,
+		Location: loc,
+		weekend:  weekend,
+		holidays: holidays,
+	}, nil
+}
+
+// IsHoliday reports whether t falls on a declared holiday date.
+func (c *Calendar) IsHoliday(t time.Time) bool {
+	return c.holidays[t.In(c.Location).Format(dateLayout)]
+}
+
+// IsWeekend reports whether t falls on a weekend day.
+func (c *Calendar) IsWeekend(t time.Time) bool {
+	return c.weekend[t.In(c.Location).Weekday()]
+}
+
+// IsBusinessDay reports whether t is neither a weekend day nor a holiday.
+func (c *Calendar) IsBusinessDay(t time.Time) bool {
+	return !c.IsWeekend(t) && !c.IsHoliday(t)
+}
+
+// sameDate reports whether a and b fall on the same calendar date.
+func (c *Calendar) sameDate(a, b time.Time) bool {
+	a, b = a.In(c.Location), b.In(c.Location)
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// LastBusinessDayOfMonth returns the last business day of t's month, or false
+// if the month contains no business day.
+func (c *Calendar) LastBusinessDayOfMonth(t time.Time) (time.Time, bool) {
+	t = t.In(c.Location)
+	year, month, _ := t.Date()
+	// Day 0 of the next month is the last day of this month.
+	day := time.Date(year, month+1, 0, 0, 0, 0, 0, c.Location)
+	for day.Month() == month {
+		if c.IsBusinessDay(day) {
+			return day, true
+		}
+		day = day.AddDate(0, 0, -1)
+	}
+	return time.Time{}, false
+}
+
+// FirstBusinessDayOfMonth returns the first business day of t's month, or
+// false if the month contains no business day.
+func (c *Calendar) FirstBusinessDayOfMonth(t time.Time) (time.Time, bool) {
+	t = t.In(c.Location)
+	year, month, _ := t.Date()
+	day := time.Date(year, month, 1, 0, 0, 0, 0, c.Location)
+	for day.Month() == month {
+		if c.IsBusinessDay(day) {
+			return day, true
+		}
+		day = day.AddDate(0, 0, 1)
+	}
+	return time.Time{}, false
+}
+
+// Decision is the outcome of evaluating a scheduled time against a calendar.
+type Decision struct {
+	// Skip reports whether the scheduled run must not dispatch.
+	Skip bool
+	// Reason is a human-readable explanation when Skip is true.
+	Reason string
+}
+
+// Evaluate decides whether a run scheduled at t should dispatch under the
+// given day filter. Without a filter, only holidays block dispatch; weekday
+// selection is left to the cron expression.
+func (c *Calendar) Evaluate(t time.Time, filter core.CalendarDayFilter) Decision {
+	date := t.In(c.Location).Format(dateLayout)
+	switch filter {
+	case core.CalendarDayFilterBusinessDays:
+		if !c.IsBusinessDay(t) {
+			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not a business day in calendar %q", date, c.Name)}
+		}
+	case core.CalendarDayFilterLastBusinessDay:
+		last, ok := c.LastBusinessDayOfMonth(t)
+		if !ok || !c.sameDate(t, last) {
+			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not the last business day of the month in calendar %q", date, c.Name)}
+		}
+	case core.CalendarDayFilterFirstBusinessDay:
+		first, ok := c.FirstBusinessDayOfMonth(t)
+		if !ok || !c.sameDate(t, first) {
+			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not the first business day of the month in calendar %q", date, c.Name)}
+		}
+	case core.CalendarDayFilterNone:
+		if c.IsHoliday(t) {
+			return Decision{Skip: true, Reason: fmt.Sprintf("%s is a holiday in calendar %q", date, c.Name)}
+		}
+	}
+	return Decision{}
+}

--- a/internal/buscal/calendar.go
+++ b/internal/buscal/calendar.go
@@ -87,11 +87,13 @@ func Parse(name string, data []byte) (*Calendar, error) {
 
 	holidays := make(map[string]bool, len(def.Holidays))
 	for _, holidayDate := range def.Holidays {
-		parsedDate, err := time.ParseInLocation(dateLayout, holidayDate, loc)
-		if err != nil {
+		// Validate without a location: in zones where midnight does not
+		// exist on a DST transition day, location-aware parsing normalizes
+		// the instant and can shift the date key by one day.
+		if _, err := time.Parse(dateLayout, holidayDate); err != nil {
 			return nil, fmt.Errorf("invalid holiday date %q in calendar %q: must be YYYY-MM-DD", holidayDate, name)
 		}
-		holidays[parsedDate.Format(dateLayout)] = true
+		holidays[holidayDate] = true
 	}
 
 	return &Calendar{

--- a/internal/buscal/calendar.go
+++ b/internal/buscal/calendar.go
@@ -158,12 +158,35 @@ func (c *Calendar) FirstBusinessDayOfMonth(t time.Time) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// Decision is the outcome of evaluating a scheduled time against a calendar.
+// DecisionKind classifies the dispatch outcome of a calendar evaluation.
+type DecisionKind int
+
+const (
+	// DecisionAllow dispatches the run normally.
+	DecisionAllow DecisionKind = iota
+	// DecisionSkip drops the run for this schedule slot.
+	DecisionSkip
+	// DecisionUnlicensed means the calendar config was ignored because the
+	// feature requires an active license; the run dispatches normally.
+	DecisionUnlicensed
+	// DecisionError means the calendar could not be evaluated; the run must
+	// not dispatch, because firing on what may be a non-business day is worse
+	// for calendar users than deferring.
+	DecisionError
+)
+
+// Decision is the outcome of evaluating a scheduled time against a DAG's
+// calendar config. The zero value allows dispatch.
 type Decision struct {
-	// Skip reports whether the scheduled run must not dispatch.
-	Skip bool
-	// Reason is a human-readable explanation when Skip is true.
+	Kind DecisionKind
+	// Reason is a human-readable explanation for DecisionSkip.
 	Reason string
+	// Err is the evaluation failure for DecisionError.
+	Err error
+}
+
+func skipDecision(format string, args ...any) Decision {
+	return Decision{Kind: DecisionSkip, Reason: fmt.Sprintf(format, args...)}
 }
 
 // Evaluate decides whether a run scheduled at t should dispatch under the
@@ -174,27 +197,27 @@ func (c *Calendar) Evaluate(t time.Time, filter core.CalendarDayFilter) Decision
 	switch filter {
 	case core.CalendarDayFilterBusinessDays:
 		if !c.IsBusinessDay(t) {
-			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not a business day in calendar %q", date, c.Name)}
+			return skipDecision("%s is not a business day in calendar %q", date, c.Name)
 		}
 	case core.CalendarDayFilterLastBusinessDay:
 		last, ok := c.LastBusinessDayOfMonth(t)
 		if !ok || !c.sameDate(t, last) {
-			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not the last business day of the month in calendar %q", date, c.Name)}
+			return skipDecision("%s is not the last business day of the month in calendar %q", date, c.Name)
 		}
 	case core.CalendarDayFilterFirstBusinessDay:
 		first, ok := c.FirstBusinessDayOfMonth(t)
 		if !ok || !c.sameDate(t, first) {
-			return Decision{Skip: true, Reason: fmt.Sprintf("%s is not the first business day of the month in calendar %q", date, c.Name)}
+			return skipDecision("%s is not the first business day of the month in calendar %q", date, c.Name)
 		}
 	case core.CalendarDayFilterNone:
 		if c.IsHoliday(t) {
-			return Decision{Skip: true, Reason: fmt.Sprintf("%s is a holiday in calendar %q", date, c.Name)}
+			return skipDecision("%s is a holiday in calendar %q", date, c.Name)
 		}
 	default:
 		// Fail closed: an unrecognized filter (a newer config read by an
 		// older binary, or an unvalidated embed-API config) must not
 		// dispatch as if no filter were set.
-		return Decision{Skip: true, Reason: fmt.Sprintf("unknown day filter %q in calendar %q", string(filter), c.Name)}
+		return skipDecision("unknown day filter %q in calendar %q", string(filter), c.Name)
 	}
 	return Decision{}
 }

--- a/internal/buscal/calendar.go
+++ b/internal/buscal/calendar.go
@@ -188,6 +188,11 @@ func (c *Calendar) Evaluate(t time.Time, filter core.CalendarDayFilter) Decision
 		if c.IsHoliday(t) {
 			return Decision{Skip: true, Reason: fmt.Sprintf("%s is a holiday in calendar %q", date, c.Name)}
 		}
+	default:
+		// Fail closed: an unrecognized filter (a newer config read by an
+		// older binary, or an unvalidated embed-API config) must not
+		// dispatch as if no filter were set.
+		return Decision{Skip: true, Reason: fmt.Sprintf("unknown day filter %q in calendar %q", string(filter), c.Name)}
 	}
 	return Decision{}
 }

--- a/internal/buscal/calendar_test.go
+++ b/internal/buscal/calendar_test.go
@@ -120,43 +120,47 @@ func TestEvaluate(t *testing.T) {
 	calendar := mustParse(t, "jp-banking", testDefinition)
 	tokyo := calendar.Location
 
+	kindAt := func(value string, filter core.CalendarDayFilter) DecisionKind {
+		return calendar.Evaluate(date(t, value, tokyo), filter).Kind
+	}
+
 	t.Run("NoFilterSkipsHolidayOnly", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterNone).Skip)
+		assert.Equal(t, DecisionSkip, kindAt("2026-01-01 01:00", core.CalendarDayFilterNone))
 		// Weekends pass without a filter: weekday selection belongs to cron.
-		assert.False(t, calendar.Evaluate(date(t, "2026-01-03 01:00", tokyo), core.CalendarDayFilterNone).Skip)
-		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterNone).Skip)
+		assert.Equal(t, DecisionAllow, kindAt("2026-01-03 01:00", core.CalendarDayFilterNone))
+		assert.Equal(t, DecisionAllow, kindAt("2026-01-05 01:00", core.CalendarDayFilterNone))
 	})
 
 	t.Run("BusinessDays", func(t *testing.T) {
 		t.Parallel()
-		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
-		assert.True(t, calendar.Evaluate(date(t, "2026-01-03 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
-		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
+		assert.Equal(t, DecisionSkip, kindAt("2026-01-01 01:00", core.CalendarDayFilterBusinessDays))
+		assert.Equal(t, DecisionSkip, kindAt("2026-01-03 01:00", core.CalendarDayFilterBusinessDays))
+		assert.Equal(t, DecisionAllow, kindAt("2026-01-05 01:00", core.CalendarDayFilterBusinessDays))
 	})
 
 	t.Run("LastBusinessDay", func(t *testing.T) {
 		t.Parallel()
 		// 2026-12-31 is a holiday and 2026-12-27 is a Sunday, so the last
 		// business day of December 2026 is Wednesday 2026-12-30.
-		assert.False(t, calendar.Evaluate(date(t, "2026-12-30 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
-		assert.True(t, calendar.Evaluate(date(t, "2026-12-31 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
-		assert.True(t, calendar.Evaluate(date(t, "2026-12-29 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
+		assert.Equal(t, DecisionAllow, kindAt("2026-12-30 01:00", core.CalendarDayFilterLastBusinessDay))
+		assert.Equal(t, DecisionSkip, kindAt("2026-12-31 01:00", core.CalendarDayFilterLastBusinessDay))
+		assert.Equal(t, DecisionSkip, kindAt("2026-12-29 01:00", core.CalendarDayFilterLastBusinessDay))
 	})
 
 	t.Run("FirstBusinessDay", func(t *testing.T) {
 		t.Parallel()
 		// 2026-01-01 and 01-02 are holidays, 01-03/01-04 are the weekend, so
 		// the first business day of January 2026 is Monday 2026-01-05.
-		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
-		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
-		assert.True(t, calendar.Evaluate(date(t, "2026-01-06 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
+		assert.Equal(t, DecisionAllow, kindAt("2026-01-05 01:00", core.CalendarDayFilterFirstBusinessDay))
+		assert.Equal(t, DecisionSkip, kindAt("2026-01-01 01:00", core.CalendarDayFilterFirstBusinessDay))
+		assert.Equal(t, DecisionSkip, kindAt("2026-01-06 01:00", core.CalendarDayFilterFirstBusinessDay))
 	})
 
 	t.Run("UnknownFilterFailsClosed", func(t *testing.T) {
 		t.Parallel()
 		decision := calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilter("bogus"))
-		assert.True(t, decision.Skip)
+		assert.Equal(t, DecisionSkip, decision.Kind)
 		assert.Contains(t, decision.Reason, "unknown day filter")
 	})
 }

--- a/internal/buscal/calendar_test.go
+++ b/internal/buscal/calendar_test.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buscal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+const testDefinition = `
+timezone: Asia/Tokyo
+holidays:
+  - 2026-01-01
+  - 2026-01-02
+  - 2026-12-31
+`
+
+func mustParse(t *testing.T, name, def string) *Calendar {
+	t.Helper()
+	calendar, err := Parse(name, []byte(def))
+	require.NoError(t, err)
+	return calendar
+}
+
+func date(t *testing.T, value string, loc *time.Location) time.Time {
+	t.Helper()
+	parsed, err := time.ParseInLocation("2006-01-02 15:04", value, loc)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Defaults", func(t *testing.T) {
+		t.Parallel()
+		calendar := mustParse(t, "default", "")
+		assert.True(t, calendar.IsWeekend(date(t, "2026-01-03 09:00", time.Local))) // Saturday
+		assert.True(t, calendar.IsWeekend(date(t, "2026-01-04 09:00", time.Local))) // Sunday
+		assert.False(t, calendar.IsWeekend(date(t, "2026-01-05 09:00", time.Local)))
+		assert.False(t, calendar.IsHoliday(date(t, "2026-01-01 09:00", time.Local)))
+	})
+
+	t.Run("CustomWeekends", func(t *testing.T) {
+		t.Parallel()
+		calendar := mustParse(t, "mideast", "weekends: [friday, saturday]")
+		assert.True(t, calendar.IsWeekend(date(t, "2026-01-02 09:00", time.Local)))  // Friday
+		assert.False(t, calendar.IsWeekend(date(t, "2026-01-04 09:00", time.Local))) // Sunday
+	})
+
+	t.Run("EmptyWeekends", func(t *testing.T) {
+		t.Parallel()
+		calendar := mustParse(t, "no-weekend", "weekends: []")
+		assert.False(t, calendar.IsWeekend(date(t, "2026-01-03 09:00", time.Local))) // Saturday
+	})
+
+	t.Run("InvalidWeekday", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("bad", []byte("weekends: [caturday]"))
+		assert.ErrorContains(t, err, "invalid weekend day")
+	})
+
+	t.Run("AllWeekend", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("bad", []byte("weekends: [sunday, monday, tuesday, wednesday, thursday, friday, saturday]"))
+		assert.ErrorContains(t, err, "every weekday as weekend")
+	})
+
+	t.Run("InvalidHolidayDate", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("bad", []byte("holidays: [2026-13-01]"))
+		assert.ErrorContains(t, err, "invalid holiday date")
+	})
+
+	t.Run("InvalidTimezone", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("bad", []byte("timezone: Mars/Olympus"))
+		assert.ErrorContains(t, err, "invalid timezone")
+	})
+
+	t.Run("UnknownKey", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("bad", []byte("holydays: [2026-01-01]"))
+		assert.Error(t, err)
+	})
+
+	t.Run("InvalidName", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse("../escape", []byte(""))
+		assert.ErrorContains(t, err, "invalid calendar name")
+	})
+}
+
+func TestCalendarTimezone(t *testing.T) {
+	t.Parallel()
+
+	calendar := mustParse(t, "jp-banking", testDefinition)
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+
+	// 2026-01-01 08:00 in Tokyo is 2025-12-31 23:00 UTC. The holiday check
+	// must interpret the instant in the calendar's zone, not the caller's.
+	utcInstant := date(t, "2026-01-01 08:00", tokyo).UTC()
+	assert.True(t, calendar.IsHoliday(utcInstant))
+
+	// 2026-01-03 07:00 Tokyo (Saturday) is 2026-01-02 22:00 UTC (Friday).
+	saturdayInTokyo := date(t, "2026-01-03 07:00", tokyo).UTC()
+	assert.True(t, calendar.IsWeekend(saturdayInTokyo))
+}
+
+func TestEvaluate(t *testing.T) {
+	t.Parallel()
+
+	calendar := mustParse(t, "jp-banking", testDefinition)
+	tokyo := calendar.Location
+
+	t.Run("NoFilterSkipsHolidayOnly", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterNone).Skip)
+		// Weekends pass without a filter: weekday selection belongs to cron.
+		assert.False(t, calendar.Evaluate(date(t, "2026-01-03 01:00", tokyo), core.CalendarDayFilterNone).Skip)
+		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterNone).Skip)
+	})
+
+	t.Run("BusinessDays", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
+		assert.True(t, calendar.Evaluate(date(t, "2026-01-03 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
+		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterBusinessDays).Skip)
+	})
+
+	t.Run("LastBusinessDay", func(t *testing.T) {
+		t.Parallel()
+		// 2026-12-31 is a holiday and 2026-12-27 is a Sunday, so the last
+		// business day of December 2026 is Wednesday 2026-12-30.
+		assert.False(t, calendar.Evaluate(date(t, "2026-12-30 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
+		assert.True(t, calendar.Evaluate(date(t, "2026-12-31 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
+		assert.True(t, calendar.Evaluate(date(t, "2026-12-29 01:00", tokyo), core.CalendarDayFilterLastBusinessDay).Skip)
+	})
+
+	t.Run("FirstBusinessDay", func(t *testing.T) {
+		t.Parallel()
+		// 2026-01-01 and 01-02 are holidays, 01-03/01-04 are the weekend, so
+		// the first business day of January 2026 is Monday 2026-01-05.
+		assert.False(t, calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
+		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
+		assert.True(t, calendar.Evaluate(date(t, "2026-01-06 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
+	})
+}
+
+func TestBusinessDayEdges(t *testing.T) {
+	t.Parallel()
+
+	calendar := mustParse(t, "jp-banking", testDefinition)
+	tokyo := calendar.Location
+
+	last, ok := calendar.LastBusinessDayOfMonth(date(t, "2026-12-15 00:00", tokyo))
+	require.True(t, ok)
+	assert.Equal(t, "2026-12-30", last.Format("2006-01-02"))
+
+	first, ok := calendar.FirstBusinessDayOfMonth(date(t, "2026-01-15 00:00", tokyo))
+	require.True(t, ok)
+	assert.Equal(t, "2026-01-05", first.Format("2006-01-02"))
+
+	// A month where every day is blocked yields no business day.
+	noBusiness := mustParse(t, "shutdown", `
+weekends: [sunday, monday, tuesday, wednesday, thursday, friday]
+holidays:
+  - 2026-02-07
+  - 2026-02-14
+  - 2026-02-21
+  - 2026-02-28
+`)
+	_, ok = noBusiness.LastBusinessDayOfMonth(date(t, "2026-02-10 00:00", time.Local))
+	assert.False(t, ok)
+	_, ok = noBusiness.FirstBusinessDayOfMonth(date(t, "2026-02-10 00:00", time.Local))
+	assert.False(t, ok)
+}

--- a/internal/buscal/calendar_test.go
+++ b/internal/buscal/calendar_test.go
@@ -152,6 +152,13 @@ func TestEvaluate(t *testing.T) {
 		assert.True(t, calendar.Evaluate(date(t, "2026-01-01 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
 		assert.True(t, calendar.Evaluate(date(t, "2026-01-06 01:00", tokyo), core.CalendarDayFilterFirstBusinessDay).Skip)
 	})
+
+	t.Run("UnknownFilterFailsClosed", func(t *testing.T) {
+		t.Parallel()
+		decision := calendar.Evaluate(date(t, "2026-01-05 01:00", tokyo), core.CalendarDayFilter("bogus"))
+		assert.True(t, decision.Skip)
+		assert.Contains(t, decision.Reason, "unknown day filter")
+	})
 }
 
 func TestBusinessDayEdges(t *testing.T) {

--- a/internal/buscal/service.go
+++ b/internal/buscal/service.go
@@ -22,35 +22,18 @@ func NewService(store *Store, licensed func() bool) *Service {
 	return &Service{store: store, licensed: licensed}
 }
 
-// Outcome is the dispatch decision for a scheduled run under a DAG's calendar
-// config.
-type Outcome struct {
-	// Skip reports whether the run must not dispatch.
-	Skip bool
-	// Reason explains a skip in human-readable form.
-	Reason string
-	// Unlicensed is set when the calendar config was ignored because the
-	// feature requires an active license. Skip is always false in that case.
-	Unlicensed bool
-	// Err is set when the calendar could not be loaded or evaluated. The run
-	// is skipped, because dispatching against a broken calendar could fire a
-	// run on a non-business day.
-	Err error
-}
-
 // Decide evaluates whether a run scheduled at t should dispatch under cfg.
 // A nil cfg always dispatches.
-func (s *Service) Decide(cfg *core.CalendarConfig, t time.Time) Outcome {
+func (s *Service) Decide(cfg *core.CalendarConfig, t time.Time) Decision {
 	if cfg == nil {
-		return Outcome{}
+		return Decision{}
 	}
 	if s.licensed == nil || !s.licensed() {
-		return Outcome{Unlicensed: true}
+		return Decision{Kind: DecisionUnlicensed}
 	}
 	calendar, err := s.store.Load(cfg.Name)
 	if err != nil {
-		return Outcome{Skip: true, Err: err}
+		return Decision{Kind: DecisionError, Err: err}
 	}
-	decision := calendar.Evaluate(t, cfg.Days)
-	return Outcome{Skip: decision.Skip, Reason: decision.Reason}
+	return calendar.Evaluate(t, cfg.Days)
 }

--- a/internal/buscal/service.go
+++ b/internal/buscal/service.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buscal
+
+import (
+	"time"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+// Service evaluates DAG calendar configs against registered calendars,
+// applying the license gate for the business-calendar feature.
+type Service struct {
+	store    *Store
+	licensed func() bool
+}
+
+// NewService creates a calendar evaluation service. The licensed func gates
+// the feature; a nil func means unlicensed.
+func NewService(store *Store, licensed func() bool) *Service {
+	return &Service{store: store, licensed: licensed}
+}
+
+// Outcome is the dispatch decision for a scheduled run under a DAG's calendar
+// config.
+type Outcome struct {
+	// Skip reports whether the run must not dispatch.
+	Skip bool
+	// Reason explains a skip in human-readable form.
+	Reason string
+	// Unlicensed is set when the calendar config was ignored because the
+	// feature requires an active license. Skip is always false in that case.
+	Unlicensed bool
+	// Err is set when the calendar could not be loaded or evaluated. The run
+	// is skipped, because dispatching against a broken calendar could fire a
+	// run on a non-business day.
+	Err error
+}
+
+// Decide evaluates whether a run scheduled at t should dispatch under cfg.
+// A nil cfg always dispatches.
+func (s *Service) Decide(cfg *core.CalendarConfig, t time.Time) Outcome {
+	if cfg == nil {
+		return Outcome{}
+	}
+	if s.licensed == nil || !s.licensed() {
+		return Outcome{Unlicensed: true}
+	}
+	calendar, err := s.store.Load(cfg.Name)
+	if err != nil {
+		return Outcome{Skip: true, Err: err}
+	}
+	decision := calendar.Evaluate(t, cfg.Days)
+	return Outcome{Skip: decision.Skip, Reason: decision.Reason}
+}

--- a/internal/buscal/store.go
+++ b/internal/buscal/store.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buscal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+// ErrNotFound indicates that no calendar definition exists for the requested name.
+var ErrNotFound = errors.New("calendar not found")
+
+// calendarExtensions are the recognized calendar definition file extensions,
+// in lookup order.
+var calendarExtensions = []string{".yaml", ".yml"}
+
+// Store loads calendar definitions from a directory. Definitions are cached
+// and reloaded when the underlying file changes.
+type Store struct {
+	dir string
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	calendar *Calendar
+	modTime  time.Time
+	size     int64
+	path     string
+}
+
+// NewStore creates a calendar store backed by dir. The directory does not
+// need to exist; lookups then report ErrNotFound.
+func NewStore(dir string) *Store {
+	return &Store{dir: dir, cache: map[string]cacheEntry{}}
+}
+
+// Load returns the calendar with the given name, reading
+// {dir}/{name}.yaml (or .yml). It returns ErrNotFound when no definition
+// file exists.
+func (s *Store) Load(name string) (*Calendar, error) {
+	if !core.ValidCalendarName(name) {
+		return nil, fmt.Errorf("invalid calendar name %q", name)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path, info, err := s.stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry, ok := s.cache[name]; ok &&
+		entry.path == path && entry.modTime.Equal(info.ModTime()) && entry.size == info.Size() {
+		return entry.calendar, nil
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from a validated name under the configured calendars dir
+	if err != nil {
+		return nil, fmt.Errorf("failed to read calendar %q: %w", name, err)
+	}
+	calendar, err := Parse(name, data)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cache[name] = cacheEntry{
+		calendar: calendar,
+		modTime:  info.ModTime(),
+		size:     info.Size(),
+		path:     path,
+	}
+	return calendar, nil
+}
+
+// stat finds the definition file for name and returns its path and file info.
+func (s *Store) stat(name string) (string, os.FileInfo, error) {
+	for _, ext := range calendarExtensions {
+		path := filepath.Join(s.dir, name+ext)
+		info, err := os.Stat(path)
+		if err == nil && info.Mode().IsRegular() {
+			return path, info, nil
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return "", nil, fmt.Errorf("failed to stat calendar %q: %w", name, err)
+		}
+	}
+	return "", nil, fmt.Errorf("%w: %q (searched %s)", ErrNotFound, name, s.dir)
+}

--- a/internal/buscal/store_test.go
+++ b/internal/buscal/store_test.go
@@ -101,37 +101,35 @@ func TestServiceDecide(t *testing.T) {
 
 	t.Run("NilConfig", func(t *testing.T) {
 		t.Parallel()
-		outcome := NewService(store, func() bool { return true }).Decide(nil, holiday)
-		assert.Equal(t, Outcome{}, outcome)
+		decision := NewService(store, func() bool { return true }).Decide(nil, holiday)
+		assert.Equal(t, Decision{}, decision)
 	})
 
 	t.Run("Unlicensed", func(t *testing.T) {
 		t.Parallel()
-		outcome := NewService(store, func() bool { return false }).Decide(cfg, holiday)
-		assert.False(t, outcome.Skip)
-		assert.True(t, outcome.Unlicensed)
+		decision := NewService(store, func() bool { return false }).Decide(cfg, holiday)
+		assert.Equal(t, DecisionUnlicensed, decision.Kind)
 
-		outcome = NewService(store, nil).Decide(cfg, holiday)
-		assert.False(t, outcome.Skip)
-		assert.True(t, outcome.Unlicensed)
+		decision = NewService(store, nil).Decide(cfg, holiday)
+		assert.Equal(t, DecisionUnlicensed, decision.Kind)
 	})
 
 	t.Run("LicensedSkipsHoliday", func(t *testing.T) {
 		t.Parallel()
 		service := NewService(store, func() bool { return true })
-		outcome := service.Decide(cfg, holiday)
-		assert.True(t, outcome.Skip)
-		assert.Contains(t, outcome.Reason, "holiday")
+		decision := service.Decide(cfg, holiday)
+		assert.Equal(t, DecisionSkip, decision.Kind)
+		assert.Contains(t, decision.Reason, "holiday")
 
-		outcome = service.Decide(cfg, businessDay)
-		assert.False(t, outcome.Skip)
+		decision = service.Decide(cfg, businessDay)
+		assert.Equal(t, DecisionAllow, decision.Kind)
 	})
 
-	t.Run("MissingCalendarSkipsWithError", func(t *testing.T) {
+	t.Run("MissingCalendarErrors", func(t *testing.T) {
 		t.Parallel()
 		service := NewService(store, func() bool { return true })
-		outcome := service.Decide(&core.CalendarConfig{Name: "missing"}, businessDay)
-		assert.True(t, outcome.Skip)
-		assert.ErrorIs(t, outcome.Err, ErrNotFound)
+		decision := service.Decide(&core.CalendarConfig{Name: "missing"}, businessDay)
+		assert.Equal(t, DecisionError, decision.Kind)
+		assert.ErrorIs(t, decision.Err, ErrNotFound)
 	})
 }

--- a/internal/buscal/store_test.go
+++ b/internal/buscal/store_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buscal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+func writeCalendar(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestStoreLoad(t *testing.T) {
+	t.Parallel()
+
+	t.Run("LoadAndCache", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeCalendar(t, dir, "jp-banking.yaml", "holidays: [2026-01-01]")
+
+		store := NewStore(dir)
+		calendar, err := store.Load("jp-banking")
+		require.NoError(t, err)
+		assert.Equal(t, "jp-banking", calendar.Name)
+
+		again, err := store.Load("jp-banking")
+		require.NoError(t, err)
+		assert.Same(t, calendar, again)
+	})
+
+	t.Run("ReloadOnChange", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := writeCalendar(t, dir, "cal.yaml", "holidays: [2026-01-01]")
+
+		store := NewStore(dir)
+		calendar, err := store.Load("cal")
+		require.NoError(t, err)
+		assert.True(t, calendar.IsHoliday(time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local)))
+
+		require.NoError(t, os.WriteFile(path, []byte("holidays: [2026-01-02]"), 0o600))
+		// Force a distinct mtime on filesystems with coarse timestamps.
+		require.NoError(t, os.Chtimes(path, time.Now(), time.Now().Add(2*time.Second)))
+
+		reloaded, err := store.Load("cal")
+		require.NoError(t, err)
+		assert.False(t, reloaded.IsHoliday(time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local)))
+		assert.True(t, reloaded.IsHoliday(time.Date(2026, 1, 2, 9, 0, 0, 0, time.Local)))
+	})
+
+	t.Run("YmlExtension", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeCalendar(t, dir, "alt.yml", "")
+
+		_, err := NewStore(dir).Load("alt")
+		require.NoError(t, err)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewStore(t.TempDir()).Load("missing")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("MissingDir", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewStore(filepath.Join(t.TempDir(), "nope")).Load("missing")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("RejectsTraversal", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewStore(t.TempDir()).Load("../etc/passwd")
+		assert.ErrorContains(t, err, "invalid calendar name")
+	})
+}
+
+func TestServiceDecide(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeCalendar(t, dir, "jp-banking.yaml", "holidays: [2026-01-01]")
+	store := NewStore(dir)
+
+	holiday := time.Date(2026, 1, 1, 1, 0, 0, 0, time.Local)
+	businessDay := time.Date(2026, 1, 5, 1, 0, 0, 0, time.Local)
+	cfg := &core.CalendarConfig{Name: "jp-banking"}
+
+	t.Run("NilConfig", func(t *testing.T) {
+		t.Parallel()
+		outcome := NewService(store, func() bool { return true }).Decide(nil, holiday)
+		assert.Equal(t, Outcome{}, outcome)
+	})
+
+	t.Run("Unlicensed", func(t *testing.T) {
+		t.Parallel()
+		outcome := NewService(store, func() bool { return false }).Decide(cfg, holiday)
+		assert.False(t, outcome.Skip)
+		assert.True(t, outcome.Unlicensed)
+
+		outcome = NewService(store, nil).Decide(cfg, holiday)
+		assert.False(t, outcome.Skip)
+		assert.True(t, outcome.Unlicensed)
+	})
+
+	t.Run("LicensedSkipsHoliday", func(t *testing.T) {
+		t.Parallel()
+		service := NewService(store, func() bool { return true })
+		outcome := service.Decide(cfg, holiday)
+		assert.True(t, outcome.Skip)
+		assert.Contains(t, outcome.Reason, "holiday")
+
+		outcome = service.Decide(cfg, businessDay)
+		assert.False(t, outcome.Skip)
+	})
+
+	t.Run("MissingCalendarSkipsWithError", func(t *testing.T) {
+		t.Parallel()
+		service := NewService(store, func() bool { return true })
+		outcome := service.Decide(&core.CalendarConfig{Name: "missing"}, businessDay)
+		assert.True(t, outcome.Skip)
+		assert.ErrorIs(t, outcome.Err, ErrNotFound)
+	})
+}

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -81,6 +81,11 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 	}
 	profileStore := file.NewProfileStore(ctx, cfg.Config)
 
+	var licenseChecker license.Checker
+	if cfg.LicenseManager != nil {
+		licenseChecker = cfg.LicenseManager.Checker()
+	}
+
 	sched, err := scheduler.New(
 		cfg.Config,
 		entryReader,
@@ -92,6 +97,9 @@ func NewScheduler(cfg SchedulerConfig) (*scheduler.Scheduler, error) {
 		coordinatorClient,
 		watermarkStore,
 		scheduler.WithDAGProfileResolver(scheduler.NewDAGProfileResolver(dagSettingsStore, profileStore)),
+		scheduler.WithBusinessCalendarLicensed(func() bool {
+			return license.HasActiveLicense(licenseChecker)
+		}),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -390,6 +390,7 @@ const (
 // PathsConfig represents the file system paths configuration.
 type PathsConfig struct {
 	DAGsDir            string
+	CalendarsDir       string
 	Executable         string
 	LogDir             string
 	ArtifactDir        string

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -219,6 +219,7 @@ type PermissionsDef struct {
 // PathsDef configures file system paths.
 type PathsDef struct {
 	DAGsDir            string `mapstructure:"dags_dir"`
+	CalendarsDir       string `mapstructure:"calendars_dir"`
 	Executable         string `mapstructure:"executable"`
 	LogDir             string `mapstructure:"log_dir"`
 	ArtifactDir        string `mapstructure:"artifact_dir"`

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -417,6 +417,7 @@ func (l *ConfigLoader) loadPathsConfig(cfg *Config, def Definition) error {
 		source string
 	}{
 		{"DAGsDir", &cfg.Paths.DAGsDir, def.Paths.DAGsDir},
+		{"CalendarsDir", &cfg.Paths.CalendarsDir, def.Paths.CalendarsDir},
 		{"AltDAGsDir", &cfg.Paths.AltDAGsDir, def.Paths.AltDagsDir},
 		{"SuspendFlagsDir", &cfg.Paths.SuspendFlagsDir, def.Paths.SuspendFlagsDir},
 		{"DataDir", &cfg.Paths.DataDir, def.Paths.DataDir},
@@ -1899,6 +1900,7 @@ func (l *ConfigLoader) setViperDefaultValues(paths Paths) {
 	l.v.SetDefault("skip_examples", false)
 	l.v.SetDefault("dag_discovery.recursive", false)
 	l.v.SetDefault("paths.dags_dir", paths.DAGsDir)
+	l.v.SetDefault("paths.calendars_dir", paths.CalendarsDir)
 	l.v.SetDefault("paths.suspend_flags_dir", paths.SuspendFlagsDir)
 	l.v.SetDefault("paths.data_dir", paths.DataDir)
 	l.v.SetDefault("paths.log_dir", paths.LogsDir)

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -419,11 +419,24 @@ worker:
 	assert.Zero(t, cfg.Worker.HealthPort)
 }
 
+func TestLoad_CalendarsDirOverride(t *testing.T) {
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config.yaml")
+	customDir := filepath.Join(tempDir, "custom-calendars")
+	err := os.WriteFile(configFile, []byte("paths:\n  calendars_dir: "+customDir+"\n"), 0600)
+	require.NoError(t, err)
+
+	cfg := testLoad(t, WithConfigFile(configFile))
+
+	assert.Equal(t, customDir, cfg.Paths.CalendarsDir)
+}
+
 func TestLoad_WithAppHomeDir(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := testLoad(t, WithAppHomeDir(tempDir))
 
 	assert.Equal(t, filepath.Join(tempDir, "dags"), cfg.Paths.DAGsDir)
+	assert.Equal(t, filepath.Join(tempDir, "calendars"), cfg.Paths.CalendarsDir)
 	assert.Equal(t, filepath.Join(tempDir, "data"), cfg.Paths.DataDir)
 	assert.Equal(t, filepath.Join(tempDir, "logs"), cfg.Paths.LogDir)
 	assert.Equal(t, filepath.Join(tempDir, "data", "artifacts"), cfg.Paths.ArtifactDir)

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -285,6 +285,7 @@ func TestLoad_Env(t *testing.T) {
 		},
 		Paths: PathsConfig{
 			DAGsDir:            filepath.Join(testPaths, "dags"),
+			CalendarsDir:       cfg.Paths.CalendarsDir,
 			AltDAGsDir:         filepath.Join(testPaths, "alt-dags"),
 			Executable:         filepath.Join(testPaths, "bin", "dagu"),
 			LogDir:             filepath.Join(testPaths, "logs"),
@@ -746,6 +747,7 @@ scheduler:
 		},
 		Paths: PathsConfig{
 			DAGsDir:            resolvedTestPath(t, "/var/dagu/dags"),
+			CalendarsDir:       cfg.Paths.CalendarsDir,
 			LogDir:             resolvedTestPath(t, "/var/dagu/logs"),
 			DataDir:            resolvedTestPath(t, "/var/dagu/data"),
 			DAGStateDir:        resolvedTestPath(t, "/var/dagu/data/dag-state"),

--- a/internal/cmn/config/path.go
+++ b/internal/cmn/config/path.go
@@ -18,6 +18,8 @@ type Paths struct {
 	ConfigDir string
 	// DAGsDir is the directory containing DAG definitions.
 	DAGsDir string
+	// CalendarsDir is the directory containing business calendar definitions.
+	CalendarsDir string
 	// SuspendFlagsDir is the directory for storing flags that indicate DAG suspension.
 	SuspendFlagsDir string
 	// DataDir is the directory for persisting application data (e.g., history).
@@ -107,6 +109,7 @@ func setXDGPaths(xdg XDGConfig, configDir string) Paths {
 		EventStoreDir:   filepath.Join(xdg.DataHome, AppSlug, "logs", "admin", "events"),
 		SuspendFlagsDir: filepath.Join(xdg.DataHome, AppSlug, "suspend"),
 		DAGsDir:         filepath.Join(xdg.ConfigHome, AppSlug, "dags"),
+		CalendarsDir:    filepath.Join(xdg.ConfigHome, AppSlug, "calendars"),
 	}
 }
 
@@ -124,5 +127,6 @@ func setUnifiedPaths(configDir string) Paths {
 		EventStoreDir:   filepath.Join(configDir, "logs", "admin", "events"),
 		SuspendFlagsDir: filepath.Join(configDir, "suspend"),
 		DAGsDir:         filepath.Join(configDir, "dags"),
+		CalendarsDir:    filepath.Join(configDir, "calendars"),
 	}
 }

--- a/internal/cmn/config/path_test.go
+++ b/internal/cmn/config/path_test.go
@@ -28,6 +28,7 @@ func TestResolver(t *testing.T) {
 		assert.Equal(t, config.Paths{
 			ConfigDir:       filepath.Join(tmpDir, config.AppSlug),
 			DAGsDir:         filepath.Join(tmpDir, config.AppSlug, "dags"),
+			CalendarsDir:    filepath.Join(tmpDir, config.AppSlug, "calendars"),
 			SuspendFlagsDir: filepath.Join(tmpDir, config.AppSlug, "suspend"),
 			DataDir:         filepath.Join(tmpDir, config.AppSlug, "data"),
 			LogsDir:         filepath.Join(tmpDir, config.AppSlug, "logs"),
@@ -69,6 +70,7 @@ func TestResolver(t *testing.T) {
 		assert.Equal(t, config.Paths{
 			ConfigDir:       legacyPath,
 			DAGsDir:         filepath.Join(legacyPath, "dags"),
+			CalendarsDir:    filepath.Join(legacyPath, "calendars"),
 			SuspendFlagsDir: filepath.Join(legacyPath, "suspend"),
 			DataDir:         filepath.Join(legacyPath, "data"),
 			LogsDir:         filepath.Join(legacyPath, "logs"),
@@ -97,6 +99,7 @@ func TestResolver(t *testing.T) {
 		assert.Equal(t, config.Paths{
 			ConfigDir:       filepath.Join(configHome, config.AppSlug),
 			DAGsDir:         filepath.Join(configHome, config.AppSlug, "dags"),
+			CalendarsDir:    filepath.Join(configHome, config.AppSlug, "calendars"),
 			SuspendFlagsDir: filepath.Join(dataHome, config.AppSlug, "suspend"),
 			DataDir:         filepath.Join(dataHome, config.AppSlug, "data"),
 			LogsDir:         filepath.Join(dataHome, config.AppSlug, "logs"),

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -130,6 +130,38 @@
       "type": "boolean",
       "description": "When true, Dagu checks if this DAG has already succeeded since the last scheduled time. If it has, Dagu will skip the current scheduled run. This is useful for resource-intensive tasks or data processing jobs that shouldn't run twice. Note: Manual triggers always run regardless of this setting."
     },
+    "calendar": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Name of a registered business calendar. Scheduled runs are skipped on the calendar's holidays."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of a registered business calendar (the calendar definition filename stem)."
+            },
+            "days": {
+              "type": "string",
+              "enum": ["business-days", "last-business-day", "first-business-day"],
+              "description": "Restricts dispatch to a business-day pattern. \"business-days\" skips weekends and holidays. \"last-business-day\" and \"first-business-day\" dispatch only on that day of each month; pair them with a daily cron expression."
+            },
+            "on_holiday": {
+              "type": "string",
+              "enum": ["skip"],
+              "default": "skip",
+              "description": "Behavior when the scheduled date is not runnable under the calendar. Only \"skip\" is currently supported."
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false,
+          "description": "Business calendar configuration for the schedule."
+        }
+      ],
+      "description": "Attaches a registered business calendar that gates scheduled dispatch (holiday skip and business-day filters). Without a days filter, only holidays are skipped; weekday selection is left to the cron expression. Manual triggers always run regardless of the calendar. Requires an active license."
+    },
     "catchup_window": {
       "type": "string",
       "description": "Lookback horizon for replaying missed cron runs when the scheduler restarts. Accepts Go duration syntax with day support (e.g. \"6h\", \"2d12h\", \"30m\"). Must be positive. If omitted, missed runs are not replayed."

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -147,12 +147,6 @@
               "type": "string",
               "enum": ["business-days", "last-business-day", "first-business-day"],
               "description": "Restricts dispatch to a business-day pattern. \"business-days\" skips weekends and holidays. \"last-business-day\" and \"first-business-day\" dispatch only on that day of each month; pair them with a daily cron expression."
-            },
-            "on_holiday": {
-              "type": "string",
-              "enum": ["skip"],
-              "default": "skip",
-              "description": "Behavior when the scheduled date is not runnable under the calendar. Only \"skip\" is currently supported."
             }
           },
           "required": ["name"],
@@ -160,7 +154,7 @@
           "description": "Business calendar configuration for the schedule."
         }
       ],
-      "description": "Attaches a registered business calendar that gates scheduled dispatch (holiday skip and business-day filters). Without a days filter, only holidays are skipped; weekday selection is left to the cron expression. Manual triggers always run regardless of the calendar. Requires an active license."
+      "description": "Attaches a registered business calendar that gates scheduled dispatch. Scheduled runs on non-runnable dates are skipped. Without a days filter, only holidays are skipped; weekday selection is left to the cron expression. Manual triggers always run regardless of the calendar. Requires an active license."
     },
     "catchup_window": {
       "type": "string",

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -1486,6 +1486,89 @@ steps:
 	}
 }
 
+func TestDAGSchemaCalendar(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchema(t)
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "ValidStringForm",
+			spec: `
+name: cal-dag
+calendar: jp-banking
+steps:
+  - run: echo hi
+`,
+		},
+		{
+			name: "ValidObjectForm",
+			spec: `
+name: cal-dag
+calendar:
+  name: jp-banking
+  days: last-business-day
+steps:
+  - run: echo hi
+`,
+		},
+		{
+			name: "RejectsMissingName",
+			spec: `
+name: cal-dag
+calendar:
+  days: business-days
+steps:
+  - run: echo hi
+`,
+			wantErr: "calendar",
+		},
+		{
+			name: "RejectsInvalidDays",
+			spec: `
+name: cal-dag
+calendar:
+  name: jp-banking
+  days: weekdays
+steps:
+  - run: echo hi
+`,
+			wantErr: "calendar",
+		},
+		{
+			name: "RejectsUnknownField",
+			spec: `
+name: cal-dag
+calendar:
+  name: jp-banking
+  shift: next
+steps:
+  - run: echo hi
+`,
+			wantErr: "calendar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := mustParseYAMLDocument(t, tt.spec)
+			err := resolved.Validate(doc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestDAGSchemaStepRetryPolicyRejectsUnknownField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/calendar.go
+++ b/internal/core/calendar.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// CalendarDayFilter restricts which scheduled days actually dispatch when a
+// business calendar is attached to a DAG.
+type CalendarDayFilter string
+
+const (
+	// CalendarDayFilterNone applies no day filter: only holidays are skipped.
+	CalendarDayFilterNone CalendarDayFilter = ""
+	// CalendarDayFilterBusinessDays dispatches only on business days
+	// (neither a weekend day nor a holiday in the calendar).
+	CalendarDayFilterBusinessDays CalendarDayFilter = "business-days"
+	// CalendarDayFilterLastBusinessDay dispatches only when the scheduled date
+	// is the last business day of its month.
+	CalendarDayFilterLastBusinessDay CalendarDayFilter = "last-business-day"
+	// CalendarDayFilterFirstBusinessDay dispatches only when the scheduled date
+	// is the first business day of its month.
+	CalendarDayFilterFirstBusinessDay CalendarDayFilter = "first-business-day"
+)
+
+// ParseCalendarDayFilter parses a calendar day filter value.
+func ParseCalendarDayFilter(s string) (CalendarDayFilter, error) {
+	switch CalendarDayFilter(s) {
+	case CalendarDayFilterNone, CalendarDayFilterBusinessDays,
+		CalendarDayFilterLastBusinessDay, CalendarDayFilterFirstBusinessDay:
+		return CalendarDayFilter(s), nil
+	default:
+		return CalendarDayFilterNone, fmt.Errorf(
+			"invalid calendar day filter %q: must be one of %q, %q, %q",
+			s, CalendarDayFilterBusinessDays, CalendarDayFilterLastBusinessDay, CalendarDayFilterFirstBusinessDay,
+		)
+	}
+}
+
+// CalendarHolidayPolicy controls what happens when a scheduled time falls on a
+// non-business day of the attached calendar.
+type CalendarHolidayPolicy string
+
+const (
+	// CalendarHolidaySkip drops the scheduled run entirely.
+	CalendarHolidaySkip CalendarHolidayPolicy = "skip"
+)
+
+// ParseCalendarHolidayPolicy parses a holiday policy value. An empty string
+// defaults to CalendarHolidaySkip.
+func ParseCalendarHolidayPolicy(s string) (CalendarHolidayPolicy, error) {
+	switch CalendarHolidayPolicy(s) {
+	case "", CalendarHolidaySkip:
+		return CalendarHolidaySkip, nil
+	default:
+		return CalendarHolidaySkip, fmt.Errorf(
+			"invalid calendar holiday policy %q: only %q is supported", s, CalendarHolidaySkip,
+		)
+	}
+}
+
+// calendarNameRegex validates business calendar names, which double as the
+// calendar definition filename stem.
+var calendarNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// ValidCalendarName reports whether name is a valid business calendar name.
+func ValidCalendarName(name string) bool {
+	return calendarNameRegex.MatchString(name)
+}
+
+// CalendarConfig attaches a registered business calendar to a DAG's schedule.
+// The scheduler consults the calendar at dispatch time, so calendar edits take
+// effect without reloading the DAG.
+type CalendarConfig struct {
+	// Name is the registered calendar name (the definition filename stem).
+	Name string `json:"name"`
+	// Days optionally restricts dispatch to a business-day pattern.
+	Days CalendarDayFilter `json:"days,omitempty"`
+	// OnHoliday controls behavior when the scheduled date is not runnable.
+	OnHoliday CalendarHolidayPolicy `json:"onHoliday,omitempty"`
+}

--- a/internal/core/calendar.go
+++ b/internal/core/calendar.go
@@ -40,28 +40,6 @@ func ParseCalendarDayFilter(s string) (CalendarDayFilter, error) {
 	}
 }
 
-// CalendarHolidayPolicy controls what happens when a scheduled time falls on a
-// non-business day of the attached calendar.
-type CalendarHolidayPolicy string
-
-const (
-	// CalendarHolidaySkip drops the scheduled run entirely.
-	CalendarHolidaySkip CalendarHolidayPolicy = "skip"
-)
-
-// ParseCalendarHolidayPolicy parses a holiday policy value. An empty string
-// defaults to CalendarHolidaySkip.
-func ParseCalendarHolidayPolicy(s string) (CalendarHolidayPolicy, error) {
-	switch CalendarHolidayPolicy(s) {
-	case "", CalendarHolidaySkip:
-		return CalendarHolidaySkip, nil
-	default:
-		return CalendarHolidaySkip, fmt.Errorf(
-			"invalid calendar holiday policy %q: only %q is supported", s, CalendarHolidaySkip,
-		)
-	}
-}
-
 // calendarNameRegex validates business calendar names, which double as the
 // calendar definition filename stem.
 var calendarNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
@@ -73,12 +51,11 @@ func ValidCalendarName(name string) bool {
 
 // CalendarConfig attaches a registered business calendar to a DAG's schedule.
 // The scheduler consults the calendar at dispatch time, so calendar edits take
-// effect without reloading the DAG.
+// effect without reloading the DAG. Scheduled runs falling on non-runnable
+// dates are skipped.
 type CalendarConfig struct {
 	// Name is the registered calendar name (the definition filename stem).
 	Name string `json:"name"`
 	// Days optionally restricts dispatch to a business-day pattern.
 	Days CalendarDayFilter `json:"days,omitempty"`
-	// OnHoliday controls behavior when the scheduled date is not runnable.
-	OnHoliday CalendarHolidayPolicy `json:"onHoliday,omitempty"`
 }

--- a/internal/core/calendar_test.go
+++ b/internal/core/calendar_test.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCalendarDayFilter(t *testing.T) {
+	t.Parallel()
+
+	for _, valid := range []string{"", "business-days", "last-business-day", "first-business-day"} {
+		filter, err := ParseCalendarDayFilter(valid)
+		require.NoError(t, err)
+		assert.Equal(t, CalendarDayFilter(valid), filter)
+	}
+
+	_, err := ParseCalendarDayFilter("weekdays")
+	assert.ErrorContains(t, err, "invalid calendar day filter")
+}
+
+func TestValidCalendarName(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, ValidCalendarName("jp-banking"))
+	assert.True(t, ValidCalendarName("ops_2026.v1"))
+	assert.False(t, ValidCalendarName(""))
+	assert.False(t, ValidCalendarName(".hidden"))
+	assert.False(t, ValidCalendarName("-lead"))
+	assert.False(t, ValidCalendarName("../escape"))
+	assert.False(t, ValidCalendarName("a/b"))
+}
+
+func TestDAGCloneDeepCopiesCalendar(t *testing.T) {
+	t.Parallel()
+
+	original := &DAG{Calendar: &CalendarConfig{Name: "jp-banking", Days: CalendarDayFilterBusinessDays}}
+	cloned := original.Clone()
+	require.NotNil(t, cloned.Calendar)
+
+	cloned.Calendar.Name = "other"
+	cloned.Calendar.Days = CalendarDayFilterNone
+	assert.Equal(t, "jp-banking", original.Calendar.Name)
+	assert.Equal(t, CalendarDayFilterBusinessDays, original.Calendar.Days)
+}

--- a/internal/core/dag.go
+++ b/internal/core/dag.go
@@ -112,6 +112,9 @@ type DAG struct {
 	StopSchedule []Schedule `json:"stopSchedule,omitempty"`
 	// RestartSchedule contains the cron expressions for restarting the DAG.
 	RestartSchedule []Schedule `json:"restartSchedule,omitempty"`
+	// Calendar attaches a registered business calendar that gates scheduled
+	// dispatch (holiday skip and business-day filters).
+	Calendar *CalendarConfig `json:"calendar,omitempty"`
 	// SkipIfSuccessful indicates whether to skip the DAG if it was successful previously.
 	// E.g., when the DAG has already been executed manually before the scheduled time.
 	SkipIfSuccessful bool `json:"skipIfSuccessful,omitempty"`
@@ -387,6 +390,10 @@ func (d *DAG) Clone() *DAG {
 	if d.Artifacts != nil {
 		artifactsCopy := *d.Artifacts
 		clone.Artifacts = &artifactsCopy
+	}
+	if d.Calendar != nil {
+		calendarCopy := *d.Calendar
+		clone.Calendar = &calendarCopy
 	}
 	if d.Resources != nil {
 		clone.Resources = d.Resources.Clone()

--- a/internal/core/spec/calendar_test.go
+++ b/internal/core/spec/calendar_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+func TestBuildCalendar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected *core.CalendarConfig
+		wantErr  string
+	}{
+		{
+			name:     "NilReturnsNil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:  "StringForm",
+			input: "jp-banking",
+			expected: &core.CalendarConfig{
+				Name:      "jp-banking",
+				OnHoliday: core.CalendarHolidaySkip,
+			},
+		},
+		{
+			name: "ObjectForm",
+			input: map[string]any{
+				"name":       "jp-banking",
+				"days":       "last-business-day",
+				"on_holiday": "skip",
+			},
+			expected: &core.CalendarConfig{
+				Name:      "jp-banking",
+				Days:      core.CalendarDayFilterLastBusinessDay,
+				OnHoliday: core.CalendarHolidaySkip,
+			},
+		},
+		{
+			name:  "ObjectFormNameOnly",
+			input: map[string]any{"name": "ops"},
+			expected: &core.CalendarConfig{
+				Name:      "ops",
+				OnHoliday: core.CalendarHolidaySkip,
+			},
+		},
+		{
+			name:    "EmptyStringName",
+			input:   "  ",
+			wantErr: "calendar name is required",
+		},
+		{
+			name:    "ObjectMissingName",
+			input:   map[string]any{"days": "business-days"},
+			wantErr: "calendar name is required",
+		},
+		{
+			name:    "InvalidName",
+			input:   "../escape",
+			wantErr: "calendar name may contain only",
+		},
+		{
+			name:    "InvalidDays",
+			input:   map[string]any{"name": "ops", "days": "weekdays"},
+			wantErr: "invalid calendar day filter",
+		},
+		{
+			name:    "InvalidHolidayPolicy",
+			input:   map[string]any{"name": "ops", "on_holiday": "next-business-day"},
+			wantErr: "invalid calendar holiday policy",
+		},
+		{
+			name:    "UnknownKey",
+			input:   map[string]any{"name": "ops", "shift": "next"},
+			wantErr: "invalid keys",
+		},
+		{
+			name:    "InvalidType",
+			input:   42,
+			wantErr: "must be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := &dag{Calendar: tt.input}
+			result, err := buildCalendar(testBuildContext(), d)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/core/spec/calendar_test.go
+++ b/internal/core/spec/calendar_test.go
@@ -4,6 +4,7 @@
 package spec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,33 +28,25 @@ func TestBuildCalendar(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:  "StringForm",
-			input: "jp-banking",
-			expected: &core.CalendarConfig{
-				Name:      "jp-banking",
-				OnHoliday: core.CalendarHolidaySkip,
-			},
+			name:     "StringForm",
+			input:    "jp-banking",
+			expected: &core.CalendarConfig{Name: "jp-banking"},
 		},
 		{
 			name: "ObjectForm",
 			input: map[string]any{
-				"name":       "jp-banking",
-				"days":       "last-business-day",
-				"on_holiday": "skip",
+				"name": "jp-banking",
+				"days": "last-business-day",
 			},
 			expected: &core.CalendarConfig{
-				Name:      "jp-banking",
-				Days:      core.CalendarDayFilterLastBusinessDay,
-				OnHoliday: core.CalendarHolidaySkip,
+				Name: "jp-banking",
+				Days: core.CalendarDayFilterLastBusinessDay,
 			},
 		},
 		{
-			name:  "ObjectFormNameOnly",
-			input: map[string]any{"name": "ops"},
-			expected: &core.CalendarConfig{
-				Name:      "ops",
-				OnHoliday: core.CalendarHolidaySkip,
-			},
+			name:     "ObjectFormNameOnly",
+			input:    map[string]any{"name": "ops"},
+			expected: &core.CalendarConfig{Name: "ops"},
 		},
 		{
 			name:    "EmptyStringName",
@@ -68,17 +61,12 @@ func TestBuildCalendar(t *testing.T) {
 		{
 			name:    "InvalidName",
 			input:   "../escape",
-			wantErr: "calendar name may contain only",
+			wantErr: "calendar name must start with",
 		},
 		{
 			name:    "InvalidDays",
 			input:   map[string]any{"name": "ops", "days": "weekdays"},
 			wantErr: "invalid calendar day filter",
-		},
-		{
-			name:    "InvalidHolidayPolicy",
-			input:   map[string]any{"name": "ops", "on_holiday": "next-business-day"},
-			wantErr: "invalid calendar holiday policy",
 		},
 		{
 			name:    "UnknownKey",
@@ -109,4 +97,54 @@ func TestBuildCalendar(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestLoadYAMLCalendar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StringForm", func(t *testing.T) {
+		t.Parallel()
+		dag, err := LoadYAML(context.Background(), []byte(`
+schedule: "0 1 * * *"
+calendar: jp-banking
+steps:
+  - name: s1
+    command: "true"
+`))
+		require.NoError(t, err)
+		require.NotNil(t, dag.Calendar)
+		assert.Equal(t, "jp-banking", dag.Calendar.Name)
+		assert.Equal(t, core.CalendarDayFilterNone, dag.Calendar.Days)
+	})
+
+	t.Run("ObjectForm", func(t *testing.T) {
+		t.Parallel()
+		dag, err := LoadYAML(context.Background(), []byte(`
+schedule: "0 1 * * *"
+calendar:
+  name: jp-banking
+  days: business-days
+steps:
+  - name: s1
+    command: "true"
+`))
+		require.NoError(t, err)
+		require.NotNil(t, dag.Calendar)
+		assert.Equal(t, "jp-banking", dag.Calendar.Name)
+		assert.Equal(t, core.CalendarDayFilterBusinessDays, dag.Calendar.Days)
+	})
+
+	t.Run("InvalidDays", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadYAML(context.Background(), []byte(`
+calendar:
+  name: jp-banking
+  days: weekdays
+steps:
+  - name: s1
+    command: "true"
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid calendar day filter")
+	})
 }

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -71,7 +71,7 @@ type dag struct {
 	// Schedule is the cron schedule to run the DAG.
 	Schedule types.ScheduleValue `yaml:"schedule,omitempty"`
 	// Calendar attaches a registered business calendar to the schedule.
-	// Can be a string (calendar name) or an object with name/days/on_holiday.
+	// Can be a string (calendar name) or an object with name and days.
 	Calendar any `yaml:"calendar,omitempty"`
 	// SkipIfSuccessful is the flag to skip the DAG on schedule when it is
 	// executed manually before the schedule.
@@ -1599,8 +1599,6 @@ type calendarConfig struct {
 	Name string `yaml:"name,omitempty"`
 	// Days restricts dispatch to a business-day pattern.
 	Days string `yaml:"days,omitempty"`
-	// OnHoliday controls behavior on non-runnable dates.
-	OnHoliday string `yaml:"on_holiday,omitempty"`
 }
 
 func buildCalendar(_ BuildContext, d *dag) (*core.CalendarConfig, error) {
@@ -1637,21 +1635,16 @@ func buildCalendar(_ BuildContext, d *dag) (*core.CalendarConfig, error) {
 	}
 	if !core.ValidCalendarName(spec.Name) {
 		return nil, core.NewValidationError("calendar.name", spec.Name,
-			fmt.Errorf("calendar name may contain only letters, digits, '.', '_', and '-'"))
+			fmt.Errorf("calendar name must start with a letter or digit and may contain only letters, digits, '.', '_', and '-'"))
 	}
 	days, err := core.ParseCalendarDayFilter(spec.Days)
 	if err != nil {
 		return nil, core.NewValidationError("calendar.days", spec.Days, err)
 	}
-	onHoliday, err := core.ParseCalendarHolidayPolicy(spec.OnHoliday)
-	if err != nil {
-		return nil, core.NewValidationError("calendar.on_holiday", spec.OnHoliday, err)
-	}
 
 	return &core.CalendarConfig{
-		Name:      spec.Name,
-		Days:      days,
-		OnHoliday: onHoliday,
+		Name: spec.Name,
+		Days: days,
 	}, nil
 }
 

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -70,6 +70,9 @@ type dag struct {
 	Dotenv types.StringOrArray `yaml:"dotenv,omitempty"`
 	// Schedule is the cron schedule to run the DAG.
 	Schedule types.ScheduleValue `yaml:"schedule,omitempty"`
+	// Calendar attaches a registered business calendar to the schedule.
+	// Can be a string (calendar name) or an object with name/days/on_holiday.
+	Calendar any `yaml:"calendar,omitempty"`
 	// SkipIfSuccessful is the flag to skip the DAG on schedule when it is
 	// executed manually before the schedule.
 	SkipIfSuccessful bool `yaml:"skip_if_successful,omitempty"`
@@ -557,6 +560,7 @@ var metadataScheduleStage = transformStage{
 	{"schedule", newTransformer("Schedule", buildSchedule)},
 	{"stop_schedule", newTransformer("StopSchedule", buildStopSchedule)},
 	{"restart_schedule", newTransformer("RestartSchedule", buildRestartSchedule)},
+	{"calendar", newTransformer("Calendar", buildCalendar)},
 }
 
 var metadataExecutionPlacementStage = transformStage{
@@ -1587,6 +1591,68 @@ func buildSchedule(_ BuildContext, d *dag) ([]core.Schedule, error) {
 		return nil, nil
 	}
 	return slices.Clone(d.Schedule.Starts()), nil
+}
+
+// calendarConfig is the object form of the calendar field.
+type calendarConfig struct {
+	// Name is the registered calendar name.
+	Name string `yaml:"name,omitempty"`
+	// Days restricts dispatch to a business-day pattern.
+	Days string `yaml:"days,omitempty"`
+	// OnHoliday controls behavior on non-runnable dates.
+	OnHoliday string `yaml:"on_holiday,omitempty"`
+}
+
+func buildCalendar(_ BuildContext, d *dag) (*core.CalendarConfig, error) {
+	if d.Calendar == nil {
+		return nil, nil
+	}
+
+	var spec calendarConfig
+	switch v := d.Calendar.(type) {
+	case string:
+		spec.Name = strings.TrimSpace(v)
+	case map[string]any:
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result:      &spec,
+			ErrorUnused: true,
+			TagName:     "yaml",
+		})
+		if err != nil {
+			return nil, core.NewValidationError("calendar", nil,
+				fmt.Errorf("failed to create decoder: %w", err))
+		}
+		if err := decoder.Decode(v); err != nil {
+			return nil, core.NewValidationError("calendar", nil,
+				fmt.Errorf("failed to decode calendar: %w", withSnakeCaseKeyHint(err)))
+		}
+	default:
+		return nil, core.NewValidationError("calendar", d.Calendar,
+			fmt.Errorf("must be a string (calendar name) or an object"))
+	}
+
+	if spec.Name == "" {
+		return nil, core.NewValidationError("calendar.name", spec.Name,
+			fmt.Errorf("calendar name is required"))
+	}
+	if !core.ValidCalendarName(spec.Name) {
+		return nil, core.NewValidationError("calendar.name", spec.Name,
+			fmt.Errorf("calendar name may contain only letters, digits, '.', '_', and '-'"))
+	}
+	days, err := core.ParseCalendarDayFilter(spec.Days)
+	if err != nil {
+		return nil, core.NewValidationError("calendar.days", spec.Days, err)
+	}
+	onHoliday, err := core.ParseCalendarHolidayPolicy(spec.OnHoliday)
+	if err != nil {
+		return nil, core.NewValidationError("calendar.on_holiday", spec.OnHoliday, err)
+	}
+
+	return &core.CalendarConfig{
+		Name:      spec.Name,
+		Days:      days,
+		OnHoliday: onHoliday,
+	}, nil
 }
 
 func buildStopSchedule(_ BuildContext, d *dag) ([]core.Schedule, error) {

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -1020,53 +1020,27 @@ type mergeTransformer struct{}
 
 var _ mergo.Transformers = (*mergeTransformer)(nil)
 
+// wholesaleReplaceTypes lists the single-object root configs whose base-config
+// inheritance replaces the object entirely instead of field-merging.
+var wholesaleReplaceTypes = map[reflect.Type]bool{
+	reflect.TypeFor[core.MailOn]():         true,
+	reflect.TypeFor[core.DAGRetryPolicy](): true,
+	reflect.TypeFor[core.CalendarConfig](): true,
+	reflect.TypeFor[core.WebhookConfig]():  true,
+}
+
 // Transformer customizes merge behavior for fields that need non-default semantics.
 func (*mergeTransformer) Transformer(
 	typ reflect.Type,
 ) func(dst, src reflect.Value) error {
-	// mergo does not override a value with zero value for a pointer.
-	if typ == reflect.TypeFor[core.MailOn]() {
-		// We need to explicitly override the value for a pointer with a zero
-		// value.
-		return func(dst, src reflect.Value) error {
-			if dst.CanSet() {
-				dst.Set(src)
-			}
-
-			return nil
-		}
-	}
-
-	if typ == reflect.TypeFor[core.DAGRetryPolicy]() {
-		// DAG retry policies are configured as a single root object. Replace the
-		// inherited policy wholesale so limit: 0 can intentionally disable retries.
-		return func(dst, src reflect.Value) error {
-			if dst.CanSet() {
-				dst.Set(src)
-			}
-
-			return nil
-		}
-	}
-
-	if typ == reflect.TypeFor[core.CalendarConfig]() {
-		// The calendar config is a single root object. Replace the inherited
-		// object wholesale so a child DAG's calendar fully overrides the base
-		// one instead of field-merging with it (a child without a days filter
-		// must not inherit the base calendar's filter).
-		return func(dst, src reflect.Value) error {
-			if dst.CanSet() {
-				dst.Set(src)
-			}
-
-			return nil
-		}
-	}
-
-	if typ == reflect.TypeFor[core.WebhookConfig]() {
-		// Webhook forwarding config is a single DAG-level object. Replace the
-		// inherited object wholesale so child DAGs can override or clear the
-		// header allowlist deterministically.
+	// Single-object root configs replace the inherited base-config object
+	// wholesale. Default mergo behavior field-merges nested structs and never
+	// overrides with zero values, which would leak base sub-fields into a
+	// child's override (e.g. a base calendar's days filter merging into a
+	// child's calendar) and make explicit zero values unable to disable
+	// inherited settings (e.g. retry_policy limit: 0). Every new
+	// single-object root config on core.DAG must be listed here.
+	if wholesaleReplaceTypes[typ] {
 		return func(dst, src reflect.Value) error {
 			if dst.CanSet() {
 				dst.Set(src)

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -1049,6 +1049,20 @@ func (*mergeTransformer) Transformer(
 		}
 	}
 
+	if typ == reflect.TypeFor[core.CalendarConfig]() {
+		// The calendar config is a single root object. Replace the inherited
+		// object wholesale so a child DAG's calendar fully overrides the base
+		// one instead of field-merging with it (a child without a days filter
+		// must not inherit the base calendar's filter).
+		return func(dst, src reflect.Value) error {
+			if dst.CanSet() {
+				dst.Set(src)
+			}
+
+			return nil
+		}
+	}
+
 	if typ == reflect.TypeFor[core.WebhookConfig]() {
 		// Webhook forwarding config is a single DAG-level object. Replace the
 		// inherited object wholesale so child DAGs can override or clear the

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -2648,6 +2648,48 @@ steps:
 		require.Equal(t, time.Hour, dag.RetryPolicy.MaxInterval)
 	})
 
+	t.Run("BaseConfigCalendarInherited", func(t *testing.T) {
+		t.Parallel()
+
+		base := createTempYAMLFile(t, `
+calendar:
+  name: corp
+  days: business-days
+`)
+		child := createTempYAMLFile(t, `
+steps:
+  - name: step1
+    run: echo "test"
+`)
+		dag, err := spec.Load(context.Background(), child, spec.WithBaseConfig(base))
+		require.NoError(t, err)
+		require.NotNil(t, dag.Calendar)
+		require.Equal(t, "corp", dag.Calendar.Name)
+		require.Equal(t, core.CalendarDayFilterBusinessDays, dag.Calendar.Days)
+	})
+
+	t.Run("BaseConfigCalendarReplacedWholesaleByChild", func(t *testing.T) {
+		t.Parallel()
+
+		base := createTempYAMLFile(t, `
+calendar:
+  name: corp
+  days: business-days
+`)
+		child := createTempYAMLFile(t, `
+calendar: jp-banking
+steps:
+  - name: step1
+    run: echo "test"
+`)
+		dag, err := spec.Load(context.Background(), child, spec.WithBaseConfig(base))
+		require.NoError(t, err)
+		require.NotNil(t, dag.Calendar)
+		require.Equal(t, "jp-banking", dag.Calendar.Name)
+		require.Equal(t, core.CalendarDayFilterNone, dag.Calendar.Days,
+			"the base calendar's days filter must not merge into the child's calendar")
+	})
+
 	t.Run("DAGRetryPolicyNormalization", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/service/scheduler/calendar_gate_test.go
+++ b/internal/service/scheduler/calendar_gate_test.go
@@ -133,4 +133,61 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		defer tp.mu.RUnlock()
 		assert.Equal(t, scheduledTime, tp.watermarkState.DAGs["calendar-dag"].LastScheduledTime)
 	})
+
+	t.Run("CatchupErrorReinsertsWithoutAdvancingWatermark", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Err: errors.New("calendar unreadable")}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeCatchUp))
+		assert.Zero(t, dispatched)
+
+		buf := tp.buffers["calendar-dag"]
+		if assert.NotNil(t, buf, "catchup item must be re-inserted for retry") {
+			item, ok := buf.Peek()
+			assert.True(t, ok)
+			assert.Equal(t, scheduledTime, item.ScheduledTime)
+		}
+
+		tp.mu.RLock()
+		defer tp.mu.RUnlock()
+		assert.True(t, tp.watermarkState.DAGs["calendar-dag"].LastScheduledTime.IsZero(),
+			"evaluation error must not consume the catchup slot")
+	})
+
+	t.Run("RetryTriggerGated", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		}, &dispatched)
+
+		// Scheduler-managed retries follow the calendar, matching suspension
+		// behavior.
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeRetry))
+		assert.Zero(t, dispatched)
+	})
+
+	t.Run("StopScheduleBypassesCalendar", func(t *testing.T) {
+		t.Parallel()
+		stopped := 0
+		tp := NewTickPlanner(TickPlannerConfig{
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
+				return buscal.Outcome{Skip: true, Reason: "holiday"}
+			},
+			Stop:   func(context.Context, *core.DAG) error { stopped++; return nil },
+			Events: make(chan DAGChangeEvent, 1),
+		})
+		require.NoError(t, tp.Init(context.Background(), nil))
+
+		tp.DispatchRun(context.Background(), PlannedRun{
+			DAG:           calendarDAG(),
+			ScheduleType:  ScheduleTypeStop,
+			ScheduledTime: scheduledTime,
+			TriggerType:   core.TriggerTypeScheduler,
+		})
+		assert.Equal(t, 1, stopped)
+	})
 }

--- a/internal/service/scheduler/calendar_gate_test.go
+++ b/internal/service/scheduler/calendar_gate_test.go
@@ -6,6 +6,8 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -54,8 +56,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("SkipBlocksDispatch", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
@@ -65,8 +67,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("NoSkipDispatches", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
@@ -76,8 +78,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("UnlicensedIgnoresCalendar", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Unlicensed: true}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionUnlicensed}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
@@ -87,8 +89,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("EvaluationErrorBlocksDispatch", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Err: errors.New("calendar not found")}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionError, Err: errors.New("calendar not found")}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
@@ -98,8 +100,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("ManualTriggerBypassesCalendar", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeManual))
@@ -109,9 +111,9 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("NoCalendarConfigDispatches", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
 			t.Error("decide must not be called without a calendar config")
-			return buscal.Outcome{}
+			return buscal.Decision{}
 		}, &dispatched)
 
 		dag := &core.DAG{Name: "plain-dag"}
@@ -122,8 +124,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("CatchupSkipAdvancesWatermark", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeCatchUp))
@@ -137,8 +139,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("CatchupErrorReinsertsWithoutAdvancingWatermark", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Err: errors.New("calendar unreadable")}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionError, Err: errors.New("calendar unreadable")}
 		}, &dispatched)
 
 		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeCatchUp))
@@ -160,8 +162,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("RetryTriggerGated", func(t *testing.T) {
 		t.Parallel()
 		dispatched := 0
-		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
-			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Decision {
+			return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 		}, &dispatched)
 
 		// Scheduler-managed retries follow the calendar, matching suspension
@@ -176,8 +178,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		dispatched := 0
 		tp := NewTickPlanner(TickPlannerConfig{
 			WatermarkStore: store,
-			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
-				return buscal.Outcome{Skip: true, Reason: "holiday"}
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Decision {
+				return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 			},
 			Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
 				dispatched++
@@ -220,8 +222,8 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		t.Parallel()
 		stopped := 0
 		tp := NewTickPlanner(TickPlannerConfig{
-			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
-				return buscal.Outcome{Skip: true, Reason: "holiday"}
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Decision {
+				return buscal.Decision{Kind: buscal.DecisionSkip, Reason: "holiday"}
 			},
 			Stop:   func(context.Context, *core.DAG) error { stopped++; return nil },
 			Events: make(chan DAGChangeEvent, 1),
@@ -240,10 +242,10 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 	t.Run("RestartScheduleGated", func(t *testing.T) {
 		t.Parallel()
 		restarted := 0
-		skip := true
+		kind := buscal.DecisionSkip
 		tp := NewTickPlanner(TickPlannerConfig{
-			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
-				return buscal.Outcome{Skip: skip, Reason: "holiday"}
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Decision {
+				return buscal.Decision{Kind: kind, Reason: "holiday"}
 			},
 			Restart: func(context.Context, *core.DAG, time.Time) error { restarted++; return nil },
 			Events:  make(chan DAGChangeEvent, 1),
@@ -261,8 +263,55 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		tp.DispatchRun(context.Background(), restartRun)
 		assert.Zero(t, restarted)
 
-		skip = false
+		kind = buscal.DecisionAllow
 		tp.DispatchRun(context.Background(), restartRun)
 		assert.Equal(t, 1, restarted)
 	})
+}
+
+// TestTickPlanner_CalendarGate_RealStore exercises the production composition
+// (buscal.Store → buscal.Service → planner gate) against a real calendar file
+// instead of a fake decide func.
+func TestTickPlanner_CalendarGate_RealStore(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "jp-banking.yaml"),
+		[]byte("holidays: [2026-01-01]"),
+		0o600,
+	))
+	service := buscal.NewService(buscal.NewStore(dir), func() bool { return true })
+
+	dispatched := 0
+	tp := NewTickPlanner(TickPlannerConfig{
+		DecideCalendar: service.Decide,
+		Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
+			dispatched++
+			return nil
+		},
+		Events: make(chan DAGChangeEvent, 1),
+	})
+	require.NoError(t, tp.Init(context.Background(), nil))
+
+	dag := &core.DAG{
+		Name:     "real-cal-dag",
+		Calendar: &core.CalendarConfig{Name: "jp-banking"},
+	}
+	run := func(scheduled time.Time, runID string) PlannedRun {
+		return PlannedRun{
+			DAG:           dag,
+			ScheduleType:  ScheduleTypeStart,
+			ScheduledTime: scheduled,
+			TriggerType:   core.TriggerTypeScheduler,
+			RunID:         runID,
+		}
+	}
+
+	// The calendar file declares no timezone, so dates evaluate in time.Local.
+	tp.DispatchRun(context.Background(), run(time.Date(2026, 1, 1, 1, 0, 0, 0, time.Local), "r1"))
+	assert.Zero(t, dispatched, "holiday must skip")
+
+	tp.DispatchRun(context.Background(), run(time.Date(2026, 1, 5, 1, 0, 0, 0, time.Local), "r2"))
+	assert.Equal(t, 1, dispatched, "business day must dispatch")
 }

--- a/internal/service/scheduler/calendar_gate_test.go
+++ b/internal/service/scheduler/calendar_gate_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/buscal"
+	"github.com/dagucloud/dagu/v2/internal/core"
+)
+
+func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
+	t.Parallel()
+
+	scheduledTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	newPlanner := func(t *testing.T, decide CalendarDecideFunc, dispatched *int) *TickPlanner {
+		t.Helper()
+		tp := NewTickPlanner(TickPlannerConfig{
+			DecideCalendar: decide,
+			Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
+				*dispatched++
+				return nil
+			},
+			Events: make(chan DAGChangeEvent, 1),
+		})
+		require.NoError(t, tp.Init(context.Background(), nil))
+		return tp
+	}
+
+	calendarDAG := func() *core.DAG {
+		return &core.DAG{
+			Name:     "calendar-dag",
+			Calendar: &core.CalendarConfig{Name: "jp-banking"},
+		}
+	}
+	plannedRun := func(dag *core.DAG, triggerType core.TriggerType) PlannedRun {
+		return PlannedRun{
+			DAG:           dag,
+			ScheduleType:  ScheduleTypeStart,
+			ScheduledTime: scheduledTime,
+			TriggerType:   triggerType,
+			RunID:         "run-1",
+		}
+	}
+
+	t.Run("SkipBlocksDispatch", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
+		assert.Zero(t, dispatched)
+	})
+
+	t.Run("NoSkipDispatches", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
+		assert.Equal(t, 1, dispatched)
+	})
+
+	t.Run("UnlicensedIgnoresCalendar", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Unlicensed: true}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
+		assert.Equal(t, 1, dispatched)
+	})
+
+	t.Run("EvaluationErrorBlocksDispatch", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Err: errors.New("calendar not found")}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeScheduler))
+		assert.Zero(t, dispatched)
+	})
+
+	t.Run("ManualTriggerBypassesCalendar", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeManual))
+		assert.Equal(t, 1, dispatched)
+	})
+
+	t.Run("NoCalendarConfigDispatches", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			t.Error("decide must not be called without a calendar config")
+			return buscal.Outcome{}
+		}, &dispatched)
+
+		dag := &core.DAG{Name: "plain-dag"}
+		tp.DispatchRun(context.Background(), plannedRun(dag, core.TriggerTypeScheduler))
+		assert.Equal(t, 1, dispatched)
+	})
+
+	t.Run("CatchupSkipAdvancesWatermark", func(t *testing.T) {
+		t.Parallel()
+		dispatched := 0
+		tp := newPlanner(t, func(*core.CalendarConfig, time.Time) buscal.Outcome {
+			return buscal.Outcome{Skip: true, Reason: "holiday"}
+		}, &dispatched)
+
+		tp.DispatchRun(context.Background(), plannedRun(calendarDAG(), core.TriggerTypeCatchUp))
+		assert.Zero(t, dispatched)
+
+		tp.mu.RLock()
+		defer tp.mu.RUnlock()
+		assert.Equal(t, scheduledTime, tp.watermarkState.DAGs["calendar-dag"].LastScheduledTime)
+	})
+}

--- a/internal/service/scheduler/calendar_gate_test.go
+++ b/internal/service/scheduler/calendar_gate_test.go
@@ -236,4 +236,33 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		})
 		assert.Equal(t, 1, stopped)
 	})
+
+	t.Run("RestartScheduleGated", func(t *testing.T) {
+		t.Parallel()
+		restarted := 0
+		skip := true
+		tp := NewTickPlanner(TickPlannerConfig{
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
+				return buscal.Outcome{Skip: skip, Reason: "holiday"}
+			},
+			Restart: func(context.Context, *core.DAG, time.Time) error { restarted++; return nil },
+			Events:  make(chan DAGChangeEvent, 1),
+		})
+		require.NoError(t, tp.Init(context.Background(), nil))
+
+		restartRun := PlannedRun{
+			DAG:           calendarDAG(),
+			ScheduleType:  ScheduleTypeRestart,
+			ScheduledTime: scheduledTime,
+			TriggerType:   core.TriggerTypeScheduler,
+		}
+
+		// A restart launches a fresh run, so it follows the calendar.
+		tp.DispatchRun(context.Background(), restartRun)
+		assert.Zero(t, restarted)
+
+		skip = false
+		tp.DispatchRun(context.Background(), restartRun)
+		assert.Equal(t, 1, restarted)
+	})
 }

--- a/internal/service/scheduler/calendar_gate_test.go
+++ b/internal/service/scheduler/calendar_gate_test.go
@@ -170,6 +170,52 @@ func TestTickPlanner_DispatchRun_CalendarGate(t *testing.T) {
 		assert.Zero(t, dispatched)
 	})
 
+	t.Run("OneOffSkipConsumesState", func(t *testing.T) {
+		t.Parallel()
+		store := &mockWatermarkStore{}
+		dispatched := 0
+		tp := NewTickPlanner(TickPlannerConfig{
+			WatermarkStore: store,
+			DecideCalendar: func(*core.CalendarConfig, time.Time) buscal.Outcome {
+				return buscal.Outcome{Skip: true, Reason: "holiday"}
+			},
+			Dispatch: func(context.Context, *core.DAG, string, core.TriggerType, time.Time) error {
+				dispatched++
+				return nil
+			},
+			Events: make(chan DAGChangeEvent, 1),
+			Clock:  func() time.Time { return scheduledTime },
+		})
+
+		schedule := mustOneOffSchedule(t, "2026-01-01T01:00:00Z")
+		dag := calendarDAG()
+		dag.Schedule = []core.Schedule{schedule}
+		store.state = &SchedulerState{
+			Version: SchedulerStateVersion,
+			DAGs: map[string]DAGWatermark{
+				dag.Name: {
+					OneOffs: map[string]OneOffScheduleState{
+						schedule.Fingerprint(): {
+							ScheduledTime: scheduledTime,
+							Status:        OneOffStatusPending,
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, tp.Init(context.Background(), []*core.DAG{dag}))
+
+		run, ok := tp.createPlannedRun(context.Background(), dag, schedule, scheduledTime, core.TriggerTypeScheduler)
+		require.True(t, ok)
+		tp.DispatchRun(context.Background(), run)
+
+		assert.Zero(t, dispatched)
+		state := store.lastSaved()
+		require.NotNil(t, state)
+		assert.Equal(t, OneOffStatusConsumed, state.DAGs[dag.Name].OneOffs[schedule.Fingerprint()].Status,
+			"a calendar-skipped one-off must resolve instead of re-planning every tick")
+	})
+
 	t.Run("StopScheduleBypassesCalendar", func(t *testing.T) {
 		t.Parallel()
 		stopped := 0

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/buscal"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
@@ -66,7 +67,8 @@ type schedulerHooks struct {
 }
 
 type schedulerOptions struct {
-	profileResolver DAGProfileResolver
+	profileResolver  DAGProfileResolver
+	calendarLicensed func() bool
 }
 
 type Option func(*schedulerOptions)
@@ -74,6 +76,15 @@ type Option func(*schedulerOptions)
 func WithDAGProfileResolver(resolver DAGProfileResolver) Option {
 	return func(opts *schedulerOptions) {
 		opts.profileResolver = resolver
+	}
+}
+
+// WithBusinessCalendarLicensed wires the license gate for the business
+// calendar feature. Without it, DAG calendar configs are ignored with a
+// warning.
+func WithBusinessCalendarLicensed(licensed func() bool) Option {
+	return func(opts *schedulerOptions) {
+		opts.calendarLicensed = licensed
 	}
 }
 
@@ -208,9 +219,15 @@ func newScheduler(
 		}
 	}
 
+	calendarService := buscal.NewService(
+		buscal.NewStore(cfg.Paths.CalendarsDir),
+		options.calendarLicensed,
+	)
+
 	planner := NewTickPlanner(TickPlannerConfig{
 		WatermarkStore:  watermarkStore,
 		IsSuspended:     isSuspended,
+		DecideCalendar:  calendarService.Decide,
 		GetLatestStatus: drm.GetLatestStatus,
 		IsRunning: func(ctx context.Context, dag *core.DAG) (bool, error) {
 			count, err := procStore.CountAliveByDAGName(ctx, dag.ProcGroup(), dag.Name)

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -66,7 +66,7 @@ type IsSuspendedFunc func(ctx context.Context, dagName string) bool
 
 // CalendarDecideFunc evaluates a DAG's business calendar config for a
 // scheduled time.
-type CalendarDecideFunc func(cfg *core.CalendarConfig, t time.Time) buscal.Outcome
+type CalendarDecideFunc func(cfg *core.CalendarConfig, t time.Time) buscal.Decision
 
 // StopFunc stops a running DAG.
 type StopFunc func(ctx context.Context, dag *core.DAG) error
@@ -1476,7 +1476,7 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 
 	switch tp.decideCalendarDispatch(ctx, run) {
-	case calendarDecisionSkip:
+	case buscal.DecisionSkip:
 		// A deliberate skip consumes the schedule slot: catchup watermarks
 		// advance and one-off schedules resolve, so the slot is not
 		// re-planned on the next tick.
@@ -1490,7 +1490,7 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 			}
 		}
 		return
-	case calendarDecisionError:
+	case buscal.DecisionError:
 		// An evaluation failure must not consume a durable slot: catchup
 		// items are re-inserted like a failed dispatch and one-off schedules
 		// stay pending, so those replay once the calendar loads again. Live
@@ -1500,7 +1500,7 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 			tp.reinsertCatchupItem(ctx, run)
 		}
 		return
-	case calendarDecisionAllow:
+	default:
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
@@ -1628,59 +1628,46 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 }
 
-// calendarDecision is the dispatch outcome of a business calendar check.
-type calendarDecision int
-
-const (
-	// calendarDecisionAllow dispatches the run normally.
-	calendarDecisionAllow calendarDecision = iota
-	// calendarDecisionSkip drops the run for this schedule slot.
-	calendarDecisionSkip
-	// calendarDecisionError blocks dispatch without consuming the slot: the
-	// calendar could not be evaluated, and firing a run on what may be a
-	// non-business day is worse for calendar users than deferring it.
-	calendarDecisionError
-)
-
 // decideCalendarDispatch evaluates the DAG's business calendar for a
 // scheduler-managed start or restart run. Restart schedules follow the
 // calendar because a restart of a stopped DAG launches a fresh run, which
 // must not fire on a non-runnable date. Stop schedules always dispatch, and
 // so do runs without a calendar config or runs the calendar feature does not
-// apply to. Evaluation errors are surfaced in the scheduler log.
-func (tp *TickPlanner) decideCalendarDispatch(ctx context.Context, run PlannedRun) calendarDecision {
+// apply to. An unlicensed decision is logged and dispatches as allowed;
+// evaluation errors are surfaced in the scheduler log.
+func (tp *TickPlanner) decideCalendarDispatch(ctx context.Context, run PlannedRun) buscal.DecisionKind {
 	if (run.ScheduleType != ScheduleTypeStart && run.ScheduleType != ScheduleTypeRestart) ||
 		!isSchedulerManagedTriggerType(run.TriggerType) ||
 		run.DAG.Calendar == nil || tp.cfg.DecideCalendar == nil {
-		return calendarDecisionAllow
+		return buscal.DecisionAllow
 	}
 
-	outcome := tp.cfg.DecideCalendar(run.DAG.Calendar, run.ScheduledTime)
-	switch {
-	case outcome.Unlicensed:
+	decision := tp.cfg.DecideCalendar(run.DAG.Calendar, run.ScheduledTime)
+	switch decision.Kind {
+	case buscal.DecisionUnlicensed:
 		logger.Warn(ctx, "Business calendars require an active license; ignoring calendar config",
 			tag.DAG(run.DAG.Name),
 			slog.String("calendar", run.DAG.Calendar.Name),
 		)
-		return calendarDecisionAllow
-	case outcome.Err != nil:
+		return buscal.DecisionAllow
+	case buscal.DecisionError:
 		logger.Error(ctx, "Business calendar evaluation failed; deferring run dispatch",
 			tag.DAG(run.DAG.Name),
 			slog.String("calendar", run.DAG.Calendar.Name),
 			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
-			tag.Error(outcome.Err),
+			tag.Error(decision.Err),
 		)
-		return calendarDecisionError
-	case outcome.Skip:
+		return buscal.DecisionError
+	case buscal.DecisionSkip:
 		logger.Info(ctx, "Skipping run dispatch on business calendar",
 			tag.DAG(run.DAG.Name),
 			slog.String("calendar", run.DAG.Calendar.Name),
 			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
-			slog.String("reason", outcome.Reason),
+			slog.String("reason", decision.Reason),
 		)
-		return calendarDecisionSkip
+		return buscal.DecisionSkip
 	default:
-		return calendarDecisionAllow
+		return buscal.DecisionAllow
 	}
 }
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1475,11 +1475,21 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 		return
 	}
 
-	if !tp.calendarAllowsDispatch(ctx, run) {
+	switch tp.decideCalendarDispatch(ctx, run) {
+	case calendarDecisionSkip:
 		if run.TriggerType == core.TriggerTypeCatchUp {
 			tp.advanceDAGWatermark(run.DAG.Name, run.ScheduledTime)
 		}
 		return
+	case calendarDecisionError:
+		// An evaluation failure must not consume the catchup slot: re-insert
+		// like a failed dispatch so the run replays once the calendar loads
+		// again.
+		if run.TriggerType == core.TriggerTypeCatchUp {
+			tp.reinsertCatchupItem(ctx, run)
+		}
+		return
+	case calendarDecisionAllow:
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
@@ -1607,17 +1617,29 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 	}
 }
 
-// calendarAllowsDispatch evaluates the DAG's business calendar for a
+// calendarDecision is the dispatch outcome of a business calendar check.
+type calendarDecision int
+
+const (
+	// calendarDecisionAllow dispatches the run normally.
+	calendarDecisionAllow calendarDecision = iota
+	// calendarDecisionSkip drops the run for this schedule slot.
+	calendarDecisionSkip
+	// calendarDecisionError blocks dispatch without consuming the slot: the
+	// calendar could not be evaluated, and firing a run on what may be a
+	// non-business day is worse for calendar users than deferring it.
+	calendarDecisionError
+)
+
+// decideCalendarDispatch evaluates the DAG's business calendar for a
 // scheduler-managed start run. Runs without a calendar config, and runs the
-// calendar feature does not apply to, always dispatch. A calendar that cannot
-// be evaluated blocks dispatch: firing a run on what may be a non-business day
-// is worse for calendar users than skipping it, and the error is surfaced in
-// the scheduler log.
-func (tp *TickPlanner) calendarAllowsDispatch(ctx context.Context, run PlannedRun) bool {
+// calendar feature does not apply to, always dispatch. Evaluation errors are
+// surfaced in the scheduler log.
+func (tp *TickPlanner) decideCalendarDispatch(ctx context.Context, run PlannedRun) calendarDecision {
 	if run.ScheduleType != ScheduleTypeStart ||
 		!isSchedulerManagedTriggerType(run.TriggerType) ||
 		run.DAG.Calendar == nil || tp.cfg.DecideCalendar == nil {
-		return true
+		return calendarDecisionAllow
 	}
 
 	outcome := tp.cfg.DecideCalendar(run.DAG.Calendar, run.ScheduledTime)
@@ -1627,15 +1649,15 @@ func (tp *TickPlanner) calendarAllowsDispatch(ctx context.Context, run PlannedRu
 			tag.DAG(run.DAG.Name),
 			slog.String("calendar", run.DAG.Calendar.Name),
 		)
-		return true
+		return calendarDecisionAllow
 	case outcome.Err != nil:
-		logger.Error(ctx, "Business calendar evaluation failed; skipping run dispatch",
+		logger.Error(ctx, "Business calendar evaluation failed; deferring run dispatch",
 			tag.DAG(run.DAG.Name),
 			slog.String("calendar", run.DAG.Calendar.Name),
 			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
 			tag.Error(outcome.Err),
 		)
-		return false
+		return calendarDecisionError
 	case outcome.Skip:
 		logger.Info(ctx, "Skipping run dispatch on business calendar",
 			tag.DAG(run.DAG.Name),
@@ -1643,9 +1665,9 @@ func (tp *TickPlanner) calendarAllowsDispatch(ctx context.Context, run PlannedRu
 			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
 			slog.String("reason", outcome.Reason),
 		)
-		return false
+		return calendarDecisionSkip
 	default:
-		return true
+		return calendarDecisionAllow
 	}
 }
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1491,9 +1491,11 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 		}
 		return
 	case calendarDecisionError:
-		// An evaluation failure must not consume the slot: catchup items are
-		// re-inserted like a failed dispatch, and one-off schedules stay
-		// pending, so the run replays once the calendar loads again.
+		// An evaluation failure must not consume a durable slot: catchup
+		// items are re-inserted like a failed dispatch and one-off schedules
+		// stay pending, so those replay once the calendar loads again. Live
+		// cron slots are not replayed; the error is surfaced in the
+		// scheduler log and the next cron slot evaluates normally.
 		if run.TriggerType == core.TriggerTypeCatchUp {
 			tp.reinsertCatchupItem(ctx, run)
 		}
@@ -1641,11 +1643,13 @@ const (
 )
 
 // decideCalendarDispatch evaluates the DAG's business calendar for a
-// scheduler-managed start run. Runs without a calendar config, and runs the
-// calendar feature does not apply to, always dispatch. Evaluation errors are
-// surfaced in the scheduler log.
+// scheduler-managed start or restart run. Restart schedules follow the
+// calendar because a restart of a stopped DAG launches a fresh run, which
+// must not fire on a non-runnable date. Stop schedules always dispatch, and
+// so do runs without a calendar config or runs the calendar feature does not
+// apply to. Evaluation errors are surfaced in the scheduler log.
 func (tp *TickPlanner) decideCalendarDispatch(ctx context.Context, run PlannedRun) calendarDecision {
-	if run.ScheduleType != ScheduleTypeStart ||
+	if (run.ScheduleType != ScheduleTypeStart && run.ScheduleType != ScheduleTypeRestart) ||
 		!isSchedulerManagedTriggerType(run.TriggerType) ||
 		run.DAG.Calendar == nil || tp.cfg.DecideCalendar == nil {
 		return calendarDecisionAllow

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/buscal"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
@@ -63,6 +64,10 @@ type GetLatestStatusFunc func(ctx context.Context, dag *core.DAG) (exec.DAGRunSt
 // IsSuspendedFunc checks whether a DAG is currently suspended.
 type IsSuspendedFunc func(ctx context.Context, dagName string) bool
 
+// CalendarDecideFunc evaluates a DAG's business calendar config for a
+// scheduled time.
+type CalendarDecideFunc func(cfg *core.CalendarConfig, t time.Time) buscal.Outcome
+
 // StopFunc stops a running DAG.
 type StopFunc func(ctx context.Context, dag *core.DAG) error
 
@@ -82,6 +87,7 @@ type RunExistsFunc func(ctx context.Context, dag *core.DAG, runID string) (bool,
 type TickPlannerConfig struct {
 	WatermarkStore  WatermarkStore
 	IsSuspended     IsSuspendedFunc
+	DecideCalendar  CalendarDecideFunc
 	GetLatestStatus GetLatestStatusFunc
 	IsRunning       IsRunningFunc
 	GenRunID        RunIDFunc
@@ -1469,6 +1475,13 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 		return
 	}
 
+	if !tp.calendarAllowsDispatch(ctx, run) {
+		if run.TriggerType == core.TriggerTypeCatchUp {
+			tp.advanceDAGWatermark(run.DAG.Name, run.ScheduledTime)
+		}
+		return
+	}
+
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
 		exists, err := tp.cfg.RunExists(ctx, run.DAG, run.RunID)
 		if err != nil {
@@ -1591,6 +1604,48 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 			tp.recomputeDAGProjection(ctx, run.DAG)
 			tp.Flush(ctx)
 		}
+	}
+}
+
+// calendarAllowsDispatch evaluates the DAG's business calendar for a
+// scheduler-managed start run. Runs without a calendar config, and runs the
+// calendar feature does not apply to, always dispatch. A calendar that cannot
+// be evaluated blocks dispatch: firing a run on what may be a non-business day
+// is worse for calendar users than skipping it, and the error is surfaced in
+// the scheduler log.
+func (tp *TickPlanner) calendarAllowsDispatch(ctx context.Context, run PlannedRun) bool {
+	if run.ScheduleType != ScheduleTypeStart ||
+		!isSchedulerManagedTriggerType(run.TriggerType) ||
+		run.DAG.Calendar == nil || tp.cfg.DecideCalendar == nil {
+		return true
+	}
+
+	outcome := tp.cfg.DecideCalendar(run.DAG.Calendar, run.ScheduledTime)
+	switch {
+	case outcome.Unlicensed:
+		logger.Warn(ctx, "Business calendars require an active license; ignoring calendar config",
+			tag.DAG(run.DAG.Name),
+			slog.String("calendar", run.DAG.Calendar.Name),
+		)
+		return true
+	case outcome.Err != nil:
+		logger.Error(ctx, "Business calendar evaluation failed; skipping run dispatch",
+			tag.DAG(run.DAG.Name),
+			slog.String("calendar", run.DAG.Calendar.Name),
+			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
+			tag.Error(outcome.Err),
+		)
+		return false
+	case outcome.Skip:
+		logger.Info(ctx, "Skipping run dispatch on business calendar",
+			tag.DAG(run.DAG.Name),
+			slog.String("calendar", run.DAG.Calendar.Name),
+			slog.String("scheduledTime", run.ScheduledTime.Format(time.RFC3339)),
+			slog.String("reason", outcome.Reason),
+		)
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1477,14 +1477,23 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 
 	switch tp.decideCalendarDispatch(ctx, run) {
 	case calendarDecisionSkip:
+		// A deliberate skip consumes the schedule slot: catchup watermarks
+		// advance and one-off schedules resolve, so the slot is not
+		// re-planned on the next tick.
 		if run.TriggerType == core.TriggerTypeCatchUp {
 			tp.advanceDAGWatermark(run.DAG.Name, run.ScheduledTime)
 		}
+		if run.Schedule.IsOneOff() {
+			if tp.markOneOffConsumed(run.DAG.Name, run.Fingerprint, run.ScheduledTime) {
+				tp.recomputeDAGProjection(ctx, run.DAG)
+				tp.Flush(ctx)
+			}
+		}
 		return
 	case calendarDecisionError:
-		// An evaluation failure must not consume the catchup slot: re-insert
-		// like a failed dispatch so the run replays once the calendar loads
-		// again.
+		// An evaluation failure must not consume the slot: catchup items are
+		// re-inserted like a failed dispatch, and one-off schedules stay
+		// pending, so the run replays once the calendar loads again.
 		if run.TriggerType == core.TriggerTypeCatchUp {
 			tp.reinsertCatchupItem(ctx, run)
 		}

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1500,7 +1500,7 @@ func (tp *TickPlanner) DispatchRun(ctx context.Context, run PlannedRun) {
 			tp.reinsertCatchupItem(ctx, run)
 		}
 		return
-	default:
+	case buscal.DecisionAllow, buscal.DecisionUnlicensed:
 	}
 
 	if run.ScheduleType == ScheduleTypeStart && run.Schedule.IsOneOff() {
@@ -1666,6 +1666,8 @@ func (tp *TickPlanner) decideCalendarDispatch(ctx context.Context, run PlannedRu
 			slog.String("reason", decision.Reason),
 		)
 		return buscal.DecisionSkip
+	case buscal.DecisionAllow:
+		return buscal.DecisionAllow
 	default:
 		return buscal.DecisionAllow
 	}


### PR DESCRIPTION
## Summary

Adds license-gated business calendars: named holiday/weekend definitions that gate scheduled dispatch, closing the Control-M parity gap ("skip national holidays", "last business day of month") for legacy batch workloads.

**Domain & storage**
- `internal/buscal`: calendar definitions as YAML files (`timezone`, `weekends`, `holidays`) loaded by name from a calendars directory (`{configDir}/calendars`, configurable via `paths.calendars_dir`), with mtime-cached reloads. Evaluation is timezone-aware (`IsBusinessDay`, first/last business day of month) and fails closed on unknown day filters.
- License gate lives in `buscal.Service`: without an active license the calendar config is ignored with a warning; the run still fires.

**Spec surface**
- New top-level `calendar:` field — string (`calendar: jp-banking`) or object:
  ```yaml
  schedule: "0 1 * * *"
  calendar:
    name: jp-banking
    days: last-business-day   # business-days | last-business-day | first-business-day
  ```
  Without a `days` filter only holidays are skipped; weekday selection stays in cron. Validated at build time, carried as DAG metadata, JSON schema updated (editor autocomplete/validation). Base-config calendars replace wholesale on inheritance — a child's calendar never field-merges with the base one.

**Scheduler**
- `TickPlanner.DispatchRun` consults the calendar for scheduler-managed start *and restart* runs (a restart launches a fresh run), mirroring the suspension skip. Manual, webhook, and sub-DAG triggers always bypass the calendar.
- Slot semantics: a deliberate skip consumes the slot (catchup watermark advances, one-off schedules resolve). An evaluation failure does not — catchup items re-insert for retry, one-offs stay pending — so a transient calendar read error never silently drops a missed run, and a broken calendar never fires a run on what may be a non-business day.

## Test Coverage

AI coverage audit (pre-fix-pass): 52/67 branch-level paths (~77%), 0 regression-priority gaps. The fix pass then closed the flagged gaps: LoadYAML wiring for the calendar field, catchup-error reinsertion, one-off skip consumption, retry-trigger gating, stop-schedule bypass, restart gating, Clone deep-copy, unknown-filter fail-closed, JSON-schema calendar cases, explicit `paths.calendars_dir` override, and base-config inheritance (both directions).

Remaining known gaps (accepted): scheduler composition wiring (`WithBusinessCalendarLicensed` → real store) exercised only via fakes; store cache staleness window (same-size edit within mtime granularity); gate log lines unasserted.

## Pre-Landing Review

4 specialists (testing, maintainability, security, performance) + adversarial pass. All confirmed findings fixed in `fix:` commits:

- **Catchup + eval-error consumed the missed slot permanently** (multi-specialist confirmed) → errors now re-insert the catchup item; only deliberate skips advance the watermark.
- **Calendar-skipped one-off re-planned every tick forever** (adversarial) → skip now consumes the one-off slot.
- **Base-config mergo field-merge leaked the base `days` filter into child calendars** (adversarial) → wholesale-replace transformer, matching `retry_policy`/`webhook` semantics.
- **Restart schedules bypassed the calendar** and started fresh runs on holidays (adversarial) → restarts now gated.
- **`Evaluate` failed open on unknown day filters** → fails closed.
- **DST-gap holiday-key shift** (zones where midnight doesn't exist on transition days) → dates validated location-free, raw string keys.
- **`on_holiday` config key parsed but never consumed** → removed; skipping is the calendar behavior.
- Accepted as-is: store mutex held across file I/O (microseconds at once-per-minute call rates; snapshot pattern noted for future), narrow cache-staleness window.

Cross-model note: Codex adversarial + structured passes both timed out (5m cap) — coverage is Claude-only (specialists, coverage audit, adversarial retry).

## Scope Check

CLEAN — intent was Phase-1 business calendars with license gating; the diff delivers exactly that plus its tests. No plan file (designed in-conversation).

## Follow-ups (deliberately out of v1 scope)

- **Next-run projection & UI/API awareness**: `ProjectedNextRun` doesn't consult calendars, so a `last-business-day` DAG shows tomorrow as its next run; the API doesn't expose the calendar field yet. Planned alongside the calendar-editor UI with a projection preview ("next 15 fire dates, skips annotated").
- **`dagu validate` existence warning** for referenced-but-missing calendar files (today: loud scheduler error, run deferred, not consumed).
- **Shift policies** (`next-business-day` / `previous-business-day`) — v1 is skip-only; `days: last-business-day` + daily cron covers the EOM pattern.
- Live cron slots hitting a calendar *error* are logged but not replayed (catchup/one-off slots are); revisit with the SLA/monitoring phase.
- Docs live in the separate docs repo — needs a companion PR there.

## Test plan

- [x] Full `make test` (race detection) green locally through the review-fix commits
- [x] Final three fixes (base-config merge, restart gate, DST keys) verified with targeted package tests: `internal/buscal`, `internal/core/spec`, `internal/service/scheduler -race`
- [x] `make fmt` / golangci-lint clean, including `GOOS=windows`
- [ ] Full suite on CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds license-gated business calendars to gate scheduled DAG dispatch, including holiday/weekend skips and first/last business day patterns. Internals now use a single `Decision` type for calendar outcomes and a table-driven base-config merge transformer; the scheduler consumes the unified decision directly.

- **New Features**
  - Business calendars as YAML in `paths.calendars_dir` (defaults to `{configDir}/calendars`); supports `timezone`, custom `weekends`, and `holidays`. Store is mtime-cached and timezone-aware; validation fails closed on bad filters.
  - New DAG `calendar:` field. Use a string (`calendar: jp-banking`) or object:
    - `name: <calendar-name>`
    - optional `days: business-days | last-business-day | first-business-day`
    Validated at build time; JSON schema updated. Base-config calendars replace wholesale on inheritance.
  - Scheduler consults the calendar for scheduler-managed start and restart schedules. Manual, webhook, and sub-DAG triggers bypass. Without a license the config is ignored with a warning. Exhaustive switch handling added for calendar decision kinds.
  - Slot semantics: a deliberate skip consumes the slot (catchup watermark advances; one-off resolved). Evaluation errors defer without consuming (catchup reinserted; one-off stays pending).

- **Migration**
  - Create a calendars directory or set `paths.calendars_dir`. Add YAML files named by calendar (e.g. `jp-banking.yaml`).
  - Add `calendar` to DAGs. For end/start-of-month patterns, pair a daily cron with `days: last-business-day` or `first-business-day`.
  - Note: restart schedules now follow calendars; manual/webhook/sub-DAG triggers are unchanged. A license is required for calendars to take effect.

<sup>Written for commit 224c1b13a831835e93cc2cba7ff312843525a974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added business-calendar scheduling for DAGs, including custom weekends, holidays, time zones, and first/last business-day rules.
  * Configure calendars by name and optionally restrict runs to business days or monthly business-day boundaries.
  * Added calendar directory configuration and support for YAML calendar definitions.
* **Bug Fixes**
  * Invalid calendar definitions and unknown scheduling filters are safely rejected.
  * Calendar-gated runs now handle licensing, retries, catch-up schedules, and manual triggers consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->