### PR TITLE
feat: add controller model failover

### DIFF
--- a/internal/runtime/controller_loop.go
+++ b/internal/runtime/controller_loop.go
@@ -6,7 +6,6 @@ package runtime
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -21,7 +20,6 @@ import (
 	cmnvalue "github.com/dagucloud/dagu/v2/internal/cmn/value"
 	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
-	llmpkg "github.com/dagucloud/dagu/v2/internal/llm"
 	"github.com/dagucloud/dagu/v2/internal/runtime/controller"
 )
 
@@ -68,17 +66,9 @@ func (r *Runner) runControllerLoop(ctx context.Context, plan *Plan, progressCh c
 	}
 	ctrlNode.SetToolDefinitions(catalog.Definitions())
 
-	// Resolve the model the same way a chat step does, so array-form llm.model
-	// and value references work here too. A controller uses one model; the
-	// fallback list a chat step walks does not apply to a decision loop.
+	// Resolve the models the same way a chat step does, so array-form llm.model
+	// and value references work here too.
 	models, err := ResolveModels(ctrlCtx, dag.LLM.GetModels())
-	if err != nil {
-		r.failController(ctrlCtx, plan, ctrlNode, err, progressCh)
-		return
-	}
-	llmCfg := EffectiveLLMConfig(dag.LLM, models[0])
-
-	provider, err := NewLLMProvider(ctrlCtx, llmCfg)
 	if err != nil {
 		r.failController(ctrlCtx, plan, ctrlNode, err, progressCh)
 		return
@@ -86,7 +76,7 @@ func (r *Runner) runControllerLoop(ctx context.Context, plan *Plan, progressCh c
 	// The system prompt and the task descriptions are author-written prompt
 	// text, so they take variables the same way any other workflow field does.
 	system, err := resolveRuntimeString(
-		ctrlCtx, llmCfg.System, cmnvalue.WorkflowField("llm.system"))
+		ctrlCtx, dag.LLM.System, cmnvalue.WorkflowField("llm.system"))
 	if err != nil {
 		r.failController(ctrlCtx, plan, ctrlNode, fmt.Errorf(
 			"failed to evaluate llm.system: %w", err), progressCh)
@@ -96,9 +86,11 @@ func (r *Runner) runControllerLoop(ctx context.Context, plan *Plan, progressCh c
 		r.failController(ctrlCtx, plan, ctrlNode, err, progressCh)
 		return
 	}
-	planner := controller.NewPlanner(provider, llmCfg, catalog, system, func(msgs []exec.LLMMessage) []exec.LLMMessage {
-		return MaskSecretsForProvider(ctrlCtx, msgs)
-	})
+	planner := newControllerModelPlanner(
+		ctrlCtx, dag.LLM, models, catalog, system,
+		func(msgs []exec.LLMMessage) []exec.LLMMessage {
+			return MaskSecretsForProvider(ctrlCtx, msgs)
+		})
 
 	// A run that suspended mid-action resumes here: report what became of the
 	// action before asking for the next decision.
@@ -158,19 +150,8 @@ func (r *Runner) runControllerLoop(ctx context.Context, plan *Plan, progressCh c
 				observationKeepRecent, dag.ControllerObservationMaxBytes())
 		}
 
-		decision, err := planner.Next(ctrlCtx, state)
-		if errors.Is(err, llmpkg.ErrContextTooLong) && observationKeepRecent > 0 {
-			compacted := state.CompactAllObservations(dag.ControllerObservationMaxBytes())
-			if compacted > 0 {
-				state.EnableObservationAging()
-				logger.Warn(ctrlCtx, "Controller context overflowed; retrying with aged observations",
-					slog.Int("compactedObservations", compacted))
-				decision, err = planner.Next(ctrlCtx, state)
-				if err != nil {
-					err = fmt.Errorf("controller decision failed after aging observations: %w", err)
-				}
-			}
-		}
+		decision, err := planner.Next(
+			ctrlCtx, state, observationKeepRecent, dag.ControllerObservationMaxBytes())
 		if err != nil {
 			r.failController(ctrlCtx, plan, ctrlNode, err, progressCh)
 			if state.ObservationAging {

--- a/internal/runtime/controller_loop_test.go
+++ b/internal/runtime/controller_loop_test.go
@@ -48,6 +48,8 @@ type fakeModel struct {
 	calls                  int
 	requests               int
 	contextFailureRequests map[int]bool
+	failureStatus          int
+	failureFromRequest     int
 	promptTokens           int
 	system                 string
 	toolResults            []string
@@ -130,27 +132,45 @@ func (m *fakeModel) failContextOnRequests(requests ...int) {
 	}
 }
 
+func (m *fakeModel) failWithStatusFromRequest(status, request int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failureStatus = status
+	m.failureFromRequest = request
+}
+
 func (m *fakeModel) setPromptTokens(tokens int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.promptTokens = tokens
 }
 
-func (m *fakeModel) beginRequest() (failContext bool, promptTokens int) {
+func (m *fakeModel) beginRequest() (failureStatus int, failContext bool, promptTokens int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.requests++
+	if m.failureFromRequest > 0 && m.requests >= m.failureFromRequest {
+		failureStatus = m.failureStatus
+	}
 	failContext = m.contextFailureRequests[m.requests]
 	promptTokens = m.promptTokens
 	if promptTokens == 0 {
 		promptTokens = 1
 	}
-	return failContext, promptTokens
+	return failureStatus, failContext, promptTokens
 }
 
 func (m *fakeModel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.captureSystem(r)
-	failContext, promptTokens := m.beginRequest()
+	failureStatus, failContext, promptTokens := m.beginRequest()
+	if failureStatus != 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(failureStatus)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "injected model failure"},
+		})
+		return
+	}
 	if failContext {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -208,11 +228,27 @@ func setupController(t *testing.T, yamlTemplate string, turns ...turn) *controll
 	t.Helper()
 
 	model := &fakeModel{turns: turns}
-	server := httptest.NewServer(model)
-	t.Cleanup(server.Close)
+	return setupControllerModels(t, yamlTemplate, model)
+}
+
+func setupControllerModels(
+	t *testing.T,
+	yamlTemplate string,
+	primary *fakeModel,
+	fallbacks ...*fakeModel,
+) *controllerHelper {
+	t.Helper()
+
+	models := append([]*fakeModel{primary}, fallbacks...)
+	formatArgs := make([]any, 0, len(models))
+	for _, model := range models {
+		server := httptest.NewServer(model)
+		t.Cleanup(server.Close)
+		formatArgs = append(formatArgs, server.URL)
+	}
 
 	th := test.Setup(t)
-	dag, err := spec.LoadYAML(th.Context, fmt.Appendf(nil, yamlTemplate, server.URL))
+	dag, err := spec.LoadYAML(th.Context, fmt.Appendf(nil, yamlTemplate, formatArgs...))
 	require.NoError(t, err)
 
 	plan, err := runtime.NewPlan(dag.Steps...)
@@ -229,7 +265,7 @@ func setupController(t *testing.T, yamlTemplate string, turns ...turn) *controll
 		cfg:    cfg,
 		dag:    dag,
 		plan:   plan,
-		model:  model,
+		model:  primary,
 	}
 }
 
@@ -1106,4 +1142,121 @@ func TestControllerLoop_UsesArrayFormModel(t *testing.T) {
 
 	require.Equal(t, core.Succeeded, ch.run(t))
 	require.NoError(t, ch.runErr)
+}
+
+const controllerFallbackModelsDAG = `
+type: controller
+llm:
+  model:
+    - provider: local
+      name: primary-model
+      base_url: %s
+    - provider: local
+      name: fallback-model
+      base_url: %s
+  max_tool_iterations: 5
+steps:
+  - name: alpha
+    run: echo alpha
+  - name: beta
+    run: echo beta
+tasks:
+  - name: finished
+    description: Finished when alpha and beta ran.
+`
+
+const controllerThreeModelsDAG = `
+type: controller
+llm:
+  model:
+    - provider: local
+      name: primary-model
+      base_url: %s
+    - provider: local
+      name: fallback-one
+      base_url: %s
+    - provider: local
+      name: fallback-two
+      base_url: %s
+  max_tool_iterations: 5
+steps:
+  - name: alpha
+    run: echo alpha
+  - name: beta
+    run: echo beta
+tasks:
+  - name: finished
+    description: Finished when alpha and beta ran.
+`
+
+func TestControllerLoop_FallsBackMidConversation(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakeModel{turns: []turn{{tool: "alpha"}}}
+	primary.failWithStatusFromRequest(http.StatusUnauthorized, 2)
+	fallback := &fakeModel{turns: []turn{
+		{tool: "beta"},
+		{tool: controller.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "both ran"}},
+	}}
+	ch := setupControllerModels(t, controllerFallbackModelsDAG, primary, fallback)
+
+	require.Equal(t, core.Succeeded, ch.run(t))
+	require.NoError(t, ch.runErr)
+	assert.Equal(t, 2, primary.requestCount())
+	assert.Equal(t, 2, fallback.requestCount())
+
+	var models []string
+	for _, msg := range ch.node(t, core.ControllerStepName).GetChatMessages() {
+		if msg.Role == exec.RoleAssistant && msg.Metadata != nil {
+			models = append(models, msg.Metadata.Model)
+		}
+	}
+	assert.Equal(t, []string{"primary-model", "fallback-model", "fallback-model"}, models)
+	assert.Contains(t, strings.Join(fallback.observations(), "\n"), "alpha")
+}
+
+func TestControllerLoop_RecoversContextBeforeFallback(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakeModel{turns: []turn{
+		{tool: "alpha"},
+		{tool: "beta"},
+		{tool: controller.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "both ran"}},
+	}}
+	primary.failContextOnRequests(3)
+	fallback := &fakeModel{}
+	ch := setupControllerModels(t, controllerFallbackModelsDAG, primary, fallback)
+
+	require.Equal(t, core.Succeeded, ch.run(t))
+	require.NoError(t, ch.runErr)
+	assert.Equal(t, 4, primary.requestCount())
+	assert.Zero(t, fallback.requestCount())
+}
+
+func TestControllerLoop_FailsAfterAllModelsAreExhausted(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakeModel{turns: []turn{{tool: "alpha"}}}
+	primary.failWithStatusFromRequest(http.StatusUnauthorized, 2)
+	fallbackOne := &fakeModel{turns: []turn{{tool: "beta"}}}
+	fallbackOne.failWithStatusFromRequest(http.StatusUnauthorized, 2)
+	fallbackTwo := &fakeModel{}
+	fallbackTwo.failWithStatusFromRequest(http.StatusUnauthorized, 1)
+	ch := setupControllerModels(
+		t, controllerThreeModelsDAG, primary, fallbackOne, fallbackTwo)
+
+	require.Equal(t, core.Failed, ch.run(t))
+	require.Error(t, ch.runErr)
+	var apiErr *llm.APIError
+	require.ErrorAs(t, ch.runErr, &apiErr)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.ErrorContains(t, ch.runErr, "all 3 controller models exhausted")
+	assert.ErrorContains(t, ch.runErr, "local/primary-model")
+	assert.ErrorContains(t, ch.runErr, "local/fallback-one")
+	assert.ErrorContains(t, ch.runErr, "local/fallback-two")
+	assert.Equal(t, 2, primary.requestCount())
+	assert.Equal(t, 2, fallbackOne.requestCount())
+	assert.Equal(t, 1, fallbackTwo.requestCount())
 }

--- a/internal/runtime/controller_models.go
+++ b/internal/runtime/controller_models.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/v2/internal/core"
+	llmpkg "github.com/dagucloud/dagu/v2/internal/llm"
+	"github.com/dagucloud/dagu/v2/internal/runtime/controller"
+)
+
+type controllerModelPlanner struct {
+	candidates []controllerModelCandidate
+	current    int
+	failures   []error
+}
+
+type controllerModelCandidate struct {
+	cfg      *core.LLMConfig
+	planner  *controller.Planner
+	setupErr error
+}
+
+func newControllerModelPlanner(
+	ctx context.Context,
+	cfg *core.LLMConfig,
+	models []core.ModelEntry,
+	catalog *controller.Catalog,
+	system string,
+	mask controller.MaskFunc,
+) *controllerModelPlanner {
+	candidates := make([]controllerModelCandidate, len(models))
+	for i, model := range models {
+		effectiveCfg := EffectiveLLMConfig(cfg, model)
+		provider, err := NewLLMProvider(ctx, effectiveCfg)
+		candidates[i] = controllerModelCandidate{cfg: effectiveCfg, setupErr: err}
+		if err == nil {
+			candidates[i].planner = controller.NewPlanner(
+				provider, effectiveCfg, catalog, system, mask)
+		}
+	}
+	return &controllerModelPlanner{candidates: candidates}
+}
+
+func (p *controllerModelPlanner) Next(
+	ctx context.Context,
+	state *controller.State,
+	observationKeepRecent int,
+	observationMaxBytes int,
+) (*controller.Decision, error) {
+	recoveryAttempted := false
+
+	for {
+		candidate := &p.candidates[p.current]
+		if len(p.candidates) > 1 {
+			logger.Info(ctx, "Attempting controller decision",
+				slog.String("provider", candidate.cfg.Provider),
+				slog.String("model", candidate.cfg.Model),
+				slog.Int("modelIndex", p.current))
+		}
+
+		decision, err := candidate.Next(ctx, state)
+		if err == nil {
+			return decision, nil
+		}
+
+		if errors.Is(err, llmpkg.ErrContextTooLong) &&
+			observationKeepRecent > 0 && !recoveryAttempted {
+			compacted := state.CompactAllObservations(observationMaxBytes)
+			if compacted > 0 {
+				state.EnableObservationAging()
+				recoveryAttempted = true
+				logger.Warn(ctx, "Controller context overflowed; retrying with aged observations",
+					slog.String("provider", candidate.cfg.Provider),
+					slog.String("model", candidate.cfg.Model),
+					slog.Int("compactedObservations", compacted))
+				decision, err = candidate.Next(ctx, state)
+				if err == nil {
+					return decision, nil
+				}
+				err = fmt.Errorf("controller decision failed after aging observations: %w", err)
+			}
+		}
+
+		if len(p.candidates) == 1 || ctx.Err() != nil {
+			return nil, err
+		}
+
+		logger.Warn(ctx, "Controller model failed",
+			slog.String("provider", candidate.cfg.Provider),
+			slog.String("model", candidate.cfg.Model),
+			tag.Error(err))
+		p.failures = append(p.failures, fmt.Errorf(
+			"%s/%s: %w", candidate.cfg.Provider, candidate.cfg.Model, err))
+
+		if p.current == len(p.candidates)-1 {
+			return nil, fmt.Errorf("all %d controller models exhausted: %w",
+				len(p.candidates), errors.Join(p.failures...))
+		}
+
+		p.current++
+		next := &p.candidates[p.current]
+		logger.Info(ctx, "Falling back to next controller model",
+			slog.String("provider", next.cfg.Provider),
+			slog.String("model", next.cfg.Model),
+			slog.Int("modelIndex", p.current))
+	}
+}
+
+func (c *controllerModelCandidate) Next(
+	ctx context.Context,
+	state *controller.State,
+) (*controller.Decision, error) {
+	if c.setupErr != nil {
+		return nil, c.setupErr
+	}
+	return c.planner.Next(ctx, state)
+}

--- a/specs/032-controller-dag.md
+++ b/specs/032-controller-dag.md
@@ -19,7 +19,7 @@ This spec defines:
 
 This spec does not define:
 
-- provider selection, model behavior, or prompt engineering beyond the framing
+- provider-specific model behavior or prompt engineering beyond the framing
   the controller supplies
 - `action: human.task` semantics, which are defined in `031-human-task.md`
 - REST, Web UI, MCP, notification, authentication, or authorization behavior
@@ -81,6 +81,11 @@ when `type` is `controller`, and `type: controller` requires it.
 
 `llm` MUST be present. Its `system` value, when set, is prepended to the
 controller's own framing rather than replacing it.
+
+`llm.model` MAY be an ordered array of model entries. The first entry is the
+primary model and each later entry is a fallback. Provider, model name, base
+URL, API-key name, and sampling overrides are taken from the selected entry in
+the same way as for a chat step.
 
 `llm.system` and every task `description` are author-written prompt text and
 MUST be resolved against the run's variables before the controller sees them, so
@@ -203,6 +208,24 @@ Each turn:
 The loop ends when no task is open, when an action opens a human task, or when a
 limit is reached.
 
+### Model fallback
+
+When `llm.model` is an array, every decision starts with the currently selected
+model. If its request still fails after the provider and logical retry budgets
+are exhausted, the controller advances through the remaining entries in order.
+A fallback that succeeds remains selected for later turns in the same controller
+process, so a sustained primary outage is not retried on every decision. A new
+process after suspension starts from the configured primary again.
+
+A failed model request MUST NOT consume a controller turn or append an assistant
+message. The next model receives the existing conversation unchanged, including
+assistant tool calls and tool results produced through earlier models. Every
+successful assistant message records the provider and model that produced it.
+
+Context-length recovery runs against the current model before advancing to a
+fallback. If all configured models fail, the run fails with an error identifying
+the exhausted models and preserving their underlying errors.
+
 ### Observation aging and context recovery
 
 Every successful decision records the provider-reported prompt token count. If
@@ -222,9 +245,11 @@ result whose deterministic summary is smaller, including results normally
 protected by `llm.observation_keep_recent`. It retries the decision once only
 when that compaction changed the transcript. The rejected request does not
 consume a controller turn or add an assistant message. If nothing can be made
-smaller, or if the rebuilt request also fails, the run fails with that error. No
-further overflow retries are made. When aging is disabled, a context-too-long
-response fails the run without a recovery retry.
+smaller, or if the rebuilt request also fails, that model attempt fails and
+ordinary model fallback applies. No further overflow retries are made for that
+decision. When aging is disabled, a context-too-long response advances to the
+next configured model without a recovery retry, or fails the run when no
+fallback remains.
 
 ### Task status
 


### PR DESCRIPTION
## Summary
- honor ordered `llm.model` arrays in controller decision loops
- fail over mid-conversation without changing or duplicating the controller transcript
- keep the first successful fallback sticky for later decisions in the same process
- perform context-overflow compaction recovery before advancing to another model
- retain actual provider/model metadata and all exhausted-model errors
- document the controller fallback contract

## Why
A controller run can be expensive and long-lived. A provider or model failure after earlier successful decisions should degrade to the configured fallback instead of terminating the run and losing that progress.

## Testing
- `make test`
- `make check`
- `go test ./internal/runtime/... -count=1`
- `go test -race ./internal/runtime -run 'TestControllerLoop_(FallsBackMidConversation|RecoversContextBeforeFallback|FailsAfterAllModelsAreExhausted)' -count=10`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ordered model failover for the controller. If a model request fails, the loop tries the next configured model without changing the conversation, and sticks with the first one that works for the rest of the run.

- **New Features**
  - Honors array-form `llm.model` for controller decisions and advances through models on failure.
  - Attempts context-length recovery (observation aging/compaction) before falling back.
  - Keeps the first successful fallback sticky for later turns in the same process.
  - Failed model attempts don’t consume a turn or alter the transcript; successful messages record provider/model.
  - Aggregates exhausted-model errors and updates `specs/032-controller-dag.md` to document fallback behavior.

<sup>Written for commit 0845dd9f87792a1294f09cb473019118bdfe7315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ordered primary and fallback models.
  * Preserves conversation context when switching models after failures.
  * Records the provider and model used for successful decisions.
  * Recovers from context limits by compacting observations before trying alternatives.
  * Reports clear errors when all configured models are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->