### PR TITLE
fix: preserve run links in scheduler notifications

### DIFF
--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -144,6 +144,7 @@ func newNotificationMonitor(
 	notificationService := notificationservice.New(
 		store,
 		dagStore,
+		notificationservice.WithPublicURL(cfg.Server.PublicURL),
 	)
 	stateFile := file.NotificationMonitorStateFile(cfg)
 	return chatbridge.NewNotificationMonitor(

--- a/internal/cmd/process/scheduler.go
+++ b/internal/cmd/process/scheduler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/license"
+	notificationmodel "github.com/dagucloud/dagu/v2/internal/notification"
 	"github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	"github.com/dagucloud/dagu/v2/internal/service/chatbridge"
@@ -141,11 +142,7 @@ func newNotificationMonitor(
 		logger.Warn(ctx, "Failed to create notification settings store", tag.Error(err))
 		return nil
 	}
-	notificationService := notificationservice.New(
-		store,
-		dagStore,
-		notificationservice.WithPublicURL(cfg.Server.PublicURL),
-	)
+	notificationService := newSchedulerNotificationService(cfg, store, dagStore)
 	stateFile := file.NotificationMonitorStateFile(cfg)
 	return chatbridge.NewNotificationMonitor(
 		eventService,
@@ -153,6 +150,22 @@ func newNotificationMonitor(
 		notificationService,
 		slog.Default(),
 		chatbridge.DefaultNotificationMonitorConfig(),
+	)
+}
+
+func newSchedulerNotificationService(
+	cfg *config.Config,
+	store notificationmodel.Store,
+	dagStore exec.DAGStore,
+	opts ...notificationservice.Option,
+) *notificationservice.Service {
+	opts = append([]notificationservice.Option{
+		notificationservice.WithPublicURL(cfg.Server.PublicURL),
+	}, opts...)
+	return notificationservice.New(
+		store,
+		dagStore,
+		opts...,
 	)
 }
 

--- a/internal/cmd/process/scheduler_test.go
+++ b/internal/cmd/process/scheduler_test.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package process
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/cmn/crypto"
+	notificationmodel "github.com/dagucloud/dagu/v2/internal/notification"
+	"github.com/dagucloud/dagu/v2/internal/persis/file"
+	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
+	notificationservice "github.com/dagucloud/dagu/v2/internal/service/notification"
+)
+
+type notificationRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn notificationRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestNewSchedulerNotificationServiceUsesConfiguredPublicURL(t *testing.T) {
+	t.Parallel()
+
+	type receivedRequest struct {
+		body string
+		err  error
+	}
+	received := make(chan receivedRequest, 1)
+	httpClient := &http.Client{Transport: notificationRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		received <- receivedRequest{body: string(body), err: err}
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	})}
+
+	cfg := &config.Config{
+		Paths:  config.PathsConfig{DataDir: t.TempDir()},
+		Server: config.Server{PublicURL: "https://dagu.example.com/workflows"},
+	}
+	key, err := crypto.ResolveKey(cfg.Paths.DataDir)
+	require.NoError(t, err)
+	encryptor, err := crypto.NewEncryptor(key)
+	require.NoError(t, err)
+	store, err := file.NewNotificationStore(cfg, encryptor)
+	require.NoError(t, err)
+
+	settings, err := notificationmodel.Normalize(&notificationmodel.Settings{
+		DAGName: "daily-report",
+		Enabled: true,
+		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed},
+		Targets: []notificationmodel.Target{{
+			ID:      "webhook-1",
+			Type:    notificationmodel.ProviderWebhook,
+			Enabled: true,
+			Webhook: &notificationmodel.WebhookTarget{
+				URL:             "https://93.184.216.34/webhook",
+				MessageTemplate: "{{run.url}}",
+			},
+		}},
+	}, "tester")
+	require.NoError(t, err)
+	require.NoError(t, store.Save(context.Background(), settings))
+
+	service := newSchedulerNotificationService(
+		cfg,
+		store,
+		nil,
+		notificationservice.WithHTTPClient(httpClient),
+	)
+	results, err := service.SendTest(
+		context.Background(),
+		"daily-report",
+		"webhook-1",
+		eventstore.TypeDAGRunFailed,
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].Delivered)
+	request := <-received
+	require.NoError(t, request.err)
+	assert.Contains(
+		t,
+		request.body,
+		`"message":"https://dagu.example.com/workflows/dag-runs/daily-report/notification-test"`,
+	)
+}


### PR DESCRIPTION
## Summary

- pass the configured public URL to the scheduler-owned notification service
- keep `{{run.url}}` and `{{run.link}}` consistent regardless of which notification monitor owns delivery
- cover scheduler-specific public URL wiring with a delivery-level regression test

## Root cause

The frontend notification service received `cfg.Server.PublicURL`, but the scheduler-created service used its empty default resolver. In `start-all`, the scheduler monitor can own the shared notification lock and render run URLs as empty for its lifetime.

## Testing

- `make fmt`
- `go test -race ./internal/cmd/process ./internal/service/notification ./internal/service/chatbridge`

Closes #2486