### PR TITLE
refactor(persis): remove dead DAG-run rename machinery

### DIFF
--- a/internal/cmd/enqueue_internal_test.go
+++ b/internal/cmd/enqueue_internal_test.go
@@ -118,10 +118,6 @@ func (s *enqueueTrackingDAGRunStore) RemoveOldDAGRuns(context.Context, string, i
 	return nil, nil
 }
 
-func (s *enqueueTrackingDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
-}
-
 func (s *enqueueTrackingDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	return nil
 }

--- a/internal/cmn/telemetry/collector_test.go
+++ b/internal/cmn/telemetry/collector_test.go
@@ -216,11 +216,6 @@ func (m *mockDAGRunStore) RemoveOldDAGRuns(ctx context.Context, name string, ret
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockDAGRunStore) RenameDAGRuns(ctx context.Context, oldName, newName string) error {
-	args := m.Called(ctx, oldName, newName)
-	return args.Error(0)
-}
-
 type mockQueueStore struct {
 	mock.Mock
 }

--- a/internal/core/exec/dagrun.go
+++ b/internal/core/exec/dagrun.go
@@ -89,10 +89,6 @@ type DAGRunStore interface {
 	// But it will not delete the records with non-final statuses (e.g., running, queued).
 	// Returns a list of dag-run IDs that were removed (or would be removed in dry-run mode).
 	RemoveOldDAGRuns(ctx context.Context, name string, retentionDays int, opts ...RemoveOldDAGRunsOption) ([]string, error)
-	// RenameDAGRuns renames all run data from oldName to newName
-	// The name means the DAG name, renaming it will allow user to manage those runs
-	// with the new DAG name.
-	RenameDAGRuns(ctx context.Context, oldName, newName string) error
 	// RemoveDAGRun removes a dag-run record by its reference.
 	RemoveDAGRun(ctx context.Context, dagRun DAGRunRef, opts ...RemoveDAGRunOption) error
 }

--- a/internal/core/exec/enqueue_retry_test.go
+++ b/internal/core/exec/enqueue_retry_test.go
@@ -429,10 +429,6 @@ func (s *stubDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec
 	return nil, nil
 }
 
-func (s *stubDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
-}
-
 func (s *stubDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	return nil
 }

--- a/internal/dagrun/intake/queue_test.go
+++ b/internal/dagrun/intake/queue_test.go
@@ -181,10 +181,6 @@ func (s *queueRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exec.R
 	return nil, nil
 }
 
-func (s *queueRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
-}
-
 func (s *queueRunStore) RemoveDAGRun(_ context.Context, ref exec.DAGRunRef, _ ...exec.RemoveDAGRunOption) error {
 	s.removed = true
 	s.removedRef = ref

--- a/internal/persis/file/dagrun/dataroot.go
+++ b/internal/persis/file/dagrun/dataroot.go
@@ -254,18 +254,6 @@ func (dr DataRoot) Exists() bool {
 	return !os.IsNotExist(err)
 }
 
-// Create creates the dag-runs directory if it doesn't already exist.
-// Returns nil if the directory already exists or is successfully created.
-func (dr DataRoot) Create() error {
-	if dr.Exists() {
-		return nil
-	}
-	if err := os.MkdirAll(dr.dagRunsDir, 0750); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dr.dagRunsDir, err)
-	}
-	return nil
-}
-
 // IsEmpty checks if the dag-runs directory exists and contains no dag-run directories.
 // Returns true if the directory doesn't exist or contains no dag-runs.
 func (dr DataRoot) IsEmpty() bool {
@@ -288,70 +276,6 @@ func (dr DataRoot) IsEmpty() bool {
 func (dr DataRoot) Remove() error {
 	if err := fileutil.RemoveAll(dr.dagRunsDir); err != nil {
 		return fmt.Errorf("failed to remove directory %s: %w", dr.dagRunsDir, err)
-	}
-	return nil
-}
-
-// Rename moves all dag-run directories from this DataRoot to a new DataRoot location.
-// This operation preserves the hierarchical structure and removes empty directories.
-// Both DataRoots must share the same base directory.
-func (dr DataRoot) Rename(ctx context.Context, newRoot DataRoot) error {
-	if !dr.Exists() {
-		return nil
-	}
-	if dr.baseDir != newRoot.baseDir {
-		return fmt.Errorf("cannot rename to a different base directory: %s -> %s", dr.baseDir, newRoot.baseDir)
-	}
-	if !newRoot.Exists() {
-		if err := newRoot.Create(); err != nil {
-			return err
-		}
-	}
-
-	matches, err := filepath.Glob(dr.globPattern)
-	if err != nil {
-		return fmt.Errorf("failed to glob pattern: %w", err)
-	}
-
-	// Process files in parallel
-	errs := processFilesParallel(matches, func(targetDir string) error {
-		// Construct the new directory path
-		day := filepath.Base(filepath.Dir(targetDir))
-		month := filepath.Base(filepath.Dir(filepath.Dir(targetDir)))
-		year := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(targetDir))))
-		newDir := filepath.Join(newRoot.dagRunsDir, year, month, day, filepath.Base(targetDir))
-
-		// Enrich context with directory information for error logging
-		dirCtx := logger.WithValues(ctx,
-			slog.String("oldDir", targetDir),
-			slog.String("newDir", newDir))
-
-		// Make sure the new directory exists
-		if err := os.MkdirAll(filepath.Dir(newDir), 0750); err != nil {
-			logger.Error(dirCtx, "Failed to create new directory",
-				tag.Error(err))
-			return fmt.Errorf("failed to create directory %s: %w", newDir, err)
-		}
-
-		// Rename the file
-		if err := fileutil.Rename(targetDir, newDir); err != nil {
-			logger.Error(dirCtx, "Failed to rename directory", tag.Error(err))
-			return fmt.Errorf("failed to rename %s to %s: %w", targetDir, newDir, err)
-		}
-
-		dr.removeEmptyDir(ctx, filepath.Dir(targetDir))
-
-		return nil
-	})
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to rename files: %w", errors.Join(errs...))
-	}
-
-	if dr.IsEmpty() {
-		if err := dr.Remove(); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/internal/persis/file/dagrun/dataroot_test.go
+++ b/internal/persis/file/dagrun/dataroot_test.go
@@ -577,28 +577,6 @@ func TestDataRootRemoveOld(t *testing.T) {
 	})
 }
 
-func TestDataRootRename(t *testing.T) {
-	root := setupTestDataRoot(t)
-
-	for date := 1; date <= 3; date++ {
-		ts := exec.NewUTC(time.Date(2021, 1, date, 0, 0, 0, 0, time.UTC))
-		_ = root.CreateTestDAGRun(t, fmt.Sprintf("test-id-%d", date), ts)
-	}
-
-	newRoot := NewDataRoot(root.baseDir, "new-dag")
-	err := root.Rename(root.Context, newRoot)
-	require.NoError(t, err)
-
-	// Check that the old directory is removed
-	assert.False(t, root.Exists(), "Old directory should be removed")
-	// Check files are moved to the new directory
-	assert.True(t, newRoot.Exists(), "New directory should exist")
-
-	matches, err := filepath.Glob(newRoot.globPattern)
-	require.NoError(t, err)
-	assert.Len(t, matches, 3, "All files should be moved to the new directory")
-}
-
 func TestDataRootUtils(t *testing.T) {
 	t.Parallel()
 
@@ -608,7 +586,7 @@ func TestDataRootUtils(t *testing.T) {
 	assert.False(t, root.Exists(), "Exists should return false when directory does not exist")
 
 	// Create the directory
-	err := root.Create()
+	err := os.MkdirAll(root.dagRunsDir, 0o750)
 	require.NoError(t, err)
 
 	// Directory exists
@@ -770,7 +748,7 @@ type DataRootTest struct {
 func (drt *DataRootTest) CreateTestDAGRun(t *testing.T, dagRunID string, ts exec.TimeInUTC) DAGRunTest {
 	t.Helper()
 
-	err := drt.Create()
+	err := os.MkdirAll(drt.dagRunsDir, 0o750)
 	require.NoError(t, err)
 
 	run, err := drt.CreateDAGRun(ts, dagRunID)

--- a/internal/persis/file/dagrun/store.go
+++ b/internal/persis/file/dagrun/store.go
@@ -655,13 +655,6 @@ func (store *Store) RemoveDAGRun(ctx context.Context, dagRun exec.DAGRunRef, opt
 	return nil
 }
 
-// RenameDAGRuns renames all history records for the specified DAG name.
-func (store *Store) RenameDAGRuns(ctx context.Context, oldNameOrPath, newNameOrPath string) error {
-	root := NewDataRoot(store.baseDir, oldNameOrPath)
-	newRoot := NewDataRoot(store.baseDir, newNameOrPath)
-	return root.Rename(ctx, newRoot)
-}
-
 // listRoot lists all root directories in the base directory.
 func (store *Store) listRoot(_ context.Context, include string) ([]DataRoot, error) {
 	rootDirs, err := listDirsSorted(store.baseDir, false, nil)

--- a/internal/persis/file/dagrun/writer_test.go
+++ b/internal/persis/file/dagrun/writer_test.go
@@ -5,7 +5,6 @@ package dagrun
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -133,27 +132,4 @@ func TestWriterErrorHandling(t *testing.T) {
 
 		assert.Equal(t, byte('\n'), data[len(data)-1])
 	})
-}
-
-// TestWriterRename verifies status files follow DAG rename operations.
-func TestWriterRename(t *testing.T) {
-	th := setupTestStore(t)
-
-	// Create a status file with old path
-	dag := th.DAG("test_rename_old")
-	writer := dag.Writer(t, "dag-run-id-1", time.Now())
-	dagRunID := uuid.Must(uuid.NewV7()).String()
-	dagRunStatus := transform.NewStatusBuilder(dag.DAG).Create(dagRunID, core.Running, 1, time.Now())
-	writer.Write(t, dagRunStatus)
-	writer.Close(t)
-	require.FileExists(t, writer.FilePath)
-
-	// Rename and verify the file
-	newDAG := th.DAG("test_rename_new")
-	err := th.Store.RenameDAGRuns(context.Background(), dag.Location, newDAG.Location)
-	require.NoError(t, err)
-	newWriter := newDAG.Writer(t, "dag-run-id-2", time.Now())
-
-	require.NoFileExists(t, writer.FilePath)
-	require.FileExists(t, newWriter.FilePath)
 }

--- a/internal/runtime/agent/dbclient_test.go
+++ b/internal/runtime/agent/dbclient_test.go
@@ -357,11 +357,6 @@ func (m *mockDAGRunStore) RemoveOldDAGRuns(ctx context.Context, name string, ret
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockDAGRunStore) RenameDAGRuns(ctx context.Context, oldName, newName string) error {
-	args := m.Called(ctx, oldName, newName)
-	return args.Error(0)
-}
-
 func TestDBClient_GetDAG(t *testing.T) {
 	testDAG := &core.DAG{Name: "test-dag"}
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -932,10 +932,6 @@ func (s *managerDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...e
 	panic("unexpected call: RemoveOldDAGRuns")
 }
 
-func (s *managerDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	panic("unexpected call: RenameDAGRuns")
-}
-
 func (s *managerDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	panic("unexpected call: RemoveDAGRun")
 }

--- a/internal/runtime/runstate/history_store_test.go
+++ b/internal/runtime/runstate/history_store_test.go
@@ -261,10 +261,6 @@ func (s *recordingDAGRunStore) RemoveOldDAGRuns(_ context.Context, _ string, ret
 	return nil, s.removeOldErr
 }
 
-func (s *recordingDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
-}
-
 func (s *recordingDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	return nil
 }

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -297,7 +297,6 @@ func (m *mockDAGRunStore) CreateSubAttempt(_ context.Context, rootRef exec.DAGRu
 func (m *mockDAGRunStore) RemoveOldDAGRuns(_ context.Context, _ string, _ int, _ ...exec.RemoveOldDAGRunsOption) ([]string, error) {
 	return nil, nil
 }
-func (m *mockDAGRunStore) RenameDAGRuns(_ context.Context, _, _ string) error { return nil }
 func (m *mockDAGRunStore) RemoveDAGRun(_ context.Context, _ exec.DAGRunRef, _ ...exec.RemoveDAGRunOption) error {
 	return nil
 }

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -795,10 +795,6 @@ func (blockingDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exe
 	panic("not implemented")
 }
 
-func (blockingDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	panic("not implemented")
-}
-
 func (blockingDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	panic("not implemented")
 }

--- a/internal/service/scheduler/retry_scanner_test.go
+++ b/internal/service/scheduler/retry_scanner_test.go
@@ -774,7 +774,6 @@ func (s *retryScannerStore) RemoveOldDAGRuns(context.Context, string, int, ...ex
 	return nil, nil
 }
 
-func (s *retryScannerStore) RenameDAGRuns(context.Context, string, string) error { return nil }
 func (s *retryScannerStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	return nil
 }

--- a/internal/service/scheduler/zombie_detector_test.go
+++ b/internal/service/scheduler/zombie_detector_test.go
@@ -421,11 +421,6 @@ func (m *mockDAGRunStore) RemoveOldDAGRuns(ctx context.Context, name string, ret
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockDAGRunStore) RenameDAGRuns(ctx context.Context, oldName, newName string) error {
-	args := m.Called(ctx, oldName, newName)
-	return args.Error(0)
-}
-
 func (m *mockDAGRunStore) RemoveDAGRun(ctx context.Context, dagRun exec.DAGRunRef, _ ...exec.RemoveDAGRunOption) error {
 	args := m.Called(ctx, dagRun)
 	return args.Error(0)

--- a/internal/subflow/local_test.go
+++ b/internal/subflow/local_test.go
@@ -422,10 +422,6 @@ func (s *localDAGRunStore) RemoveOldDAGRuns(context.Context, string, int, ...exe
 	return nil, nil
 }
 
-func (s *localDAGRunStore) RenameDAGRuns(context.Context, string, string) error {
-	return nil
-}
-
 func (s *localDAGRunStore) RemoveDAGRun(context.Context, exec.DAGRunRef, ...exec.RemoveDAGRunOption) error {
 	return nil
 }


### PR DESCRIPTION
## What

Removes rename machinery that has no production callers:

- `RenameDAGRuns` from the `exec.DAGRunStore` port
- `Store.RenameDAGRuns` and `DataRoot.Rename` in `persis/file/dagrun`
- `DataRoot.Create` (its only production caller was `Rename`; tests use `os.MkdirAll` directly)
- The rename tests and 12 stub implementations carried by `DAGRunStore` test doubles across the tree

Net: +2 / -180 lines, pure deletion.

## Why

The DAG rename API (`dags.go`) renames the spec file and migrates dagsettings only; it has never invoked `RenameDAGRuns`, so run history is not moved on rename today. Beyond being dead weight, this half-implementation is a trap: it performs a whole-tree move with no transactional journal, no destination preflight (a deleted DAG's stranded history at the destination name would be silently merged), and takes a lock that lives inside the tree being moved. A future "rename moves run data" feature needs a different shape; wiring this up as-is would ship those bugs.

## Verification

- `go build ./...` clean
- Race-enabled tests pass on `persis/file/dagrun`, `core/exec`, `runstate`
- Tests pass on every package whose test double was touched (cmd, telemetry, runtime, agent, subflow, coordinator, scheduler, api/v1, intake)
- `golangci-lint` on touched packages: 0 issues
- No spec/conformance impact: the removed code was unreachable from the binary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead DAG-run rename machinery to reduce complexity and avoid a risky half-implementation. No behavior change: DAG rename still only updates the spec file and dagsettings; run history is not moved.

- **Refactors**
  - Removed `RenameDAGRuns` from `exec.DAGRunStore` and its file-store implementation.
  - Deleted `DataRoot.Rename` and `DataRoot.Create` in `persis/file/dagrun`.
  - Dropped related tests and 12 stub methods across test doubles.
  - Net change: +2 / -180 LOC (pure deletion).

<sup>Written for commit e0ccff85c4fd64d4ff8897349e41fc8f03389066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the unused DAG-run renaming capability from internal storage interfaces and implementations.
  * Simplified file-based DAG-run directory management by eliminating rename-related behavior.

* **Tests**
  * Updated test fixtures and mocks to reflect the streamlined storage APIs.
  * Removed obsolete tests covering DAG-run renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->