### PR TITLE
fix(spec): report a failing param eval once instead of five times

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -6,6 +6,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -72,6 +73,28 @@ func (e ErrorList) Error() string {
 		errStrings[i] = err.Error()
 	}
 	return strings.Join(errStrings, "; ")
+}
+
+// Dedupe returns the list with repeated occurrences of the same error
+// value removed, keeping first positions. Distinct errors with equal
+// messages are preserved; only identical instances collapse. Values of
+// non-comparable dynamic types are kept as-is.
+func (e ErrorList) Dedupe() ErrorList {
+	if len(e) < 2 {
+		return e
+	}
+	result := make(ErrorList, 0, len(e))
+	seen := make(map[error]struct{}, len(e))
+	for _, err := range e {
+		if t := reflect.TypeOf(err); t != nil && t.Comparable() {
+			if _, dup := seen[err]; dup {
+				continue
+			}
+			seen[err] = struct{}{}
+		}
+		result = append(result, err)
+	}
+	return result
 }
 
 // Unwrap implements the errors.Unwrap interface.

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -51,6 +51,47 @@ func TestErrorList_Error(t *testing.T) {
 	}
 }
 
+func TestErrorList_Dedupe(t *testing.T) {
+	t.Parallel()
+
+	shared := NewValidationError("params", "x", errors.New("eval failed"))
+
+	t.Run("identical instances collapse to one", func(t *testing.T) {
+		t.Parallel()
+		deduped := ErrorList{shared, shared, shared}.Dedupe()
+		require.Len(t, deduped, 1)
+		assert.Same(t, shared, deduped[0])
+	})
+
+	t.Run("distinct errors with equal messages are kept", func(t *testing.T) {
+		t.Parallel()
+		deduped := ErrorList{errors.New("same text"), errors.New("same text")}.Dedupe()
+		assert.Len(t, deduped, 2)
+	})
+
+	t.Run("non-comparable members pass through", func(t *testing.T) {
+		t.Parallel()
+		nested := ErrorList{errors.New("inner")}
+		deduped := ErrorList{nested, nested, shared}.Dedupe()
+		assert.Len(t, deduped, 3)
+	})
+
+	t.Run("order of first occurrences is preserved", func(t *testing.T) {
+		t.Parallel()
+		other := errors.New("other")
+		deduped := ErrorList{shared, other, shared}.Dedupe()
+		require.Len(t, deduped, 2)
+		assert.Same(t, shared, deduped[0])
+		assert.Equal(t, other, deduped[1])
+	})
+
+	t.Run("empty and single stay unchanged", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, ErrorList{}.Dedupe())
+		assert.Len(t, ErrorList{shared}.Dedupe(), 1)
+	})
+}
+
 func TestErrorList_ToStringList(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -899,11 +899,15 @@ func (s *dagBuildState) markEnvEvaluated() {
 }
 
 func (s *dagBuildState) finish() (*core.DAG, error) {
-	if len(s.errs) > 0 {
+	// Field builders sharing one memoized result (params) surface the same
+	// error instance once per consumer; collapse identical instances so the
+	// reported list has one entry per distinct failure.
+	errs := s.errs.Dedupe()
+	if len(errs) > 0 {
 		if s.ctx.opts.Has(BuildFlagAllowBuildErrors) {
-			s.result.BuildErrors = s.errs
+			s.result.BuildErrors = errs
 		} else {
-			return nil, fmt.Errorf("failed to build DAG: %w", s.errs)
+			return nil, fmt.Errorf("failed to build DAG: %w", errs)
 		}
 	}
 	return s.result, nil

--- a/internal/core/spec/dparams_test.go
+++ b/internal/core/spec/dparams_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
@@ -16,6 +17,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInlineParamDefs_EvalFailureReportedOnce(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses a POSIX shell snippet")
+	}
+
+	yaml := []byte(`
+params:
+  - name: v
+    type: string
+    eval: "` + "`exit 3`" + `"
+steps:
+  - name: ok
+    command: "true"
+`)
+
+	_, err := LoadYAML(context.Background(), yaml)
+	require.Error(t, err)
+	assert.Equal(t, 1, strings.Count(err.Error(), "field 'params'"),
+		"one failing eval must be reported exactly once, got: %s", err)
+}
 
 func TestInlineParamDefs_MetadataAndExecution(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

A DAG whose param `eval` command fails reported the identical error five times:

```
Error: failed to load DAG ...: field 'params': ... eval failed: ... exit status 3
stderr= (value: `exit 3`); field 'params': ... (x5)
```

Root cause: `parseParamsInternal` memoizes `(result, err)`, and five field builders (`Params`, `DefaultParams`, `ParamDefs`, `ParamsJSON`, `ParamSchema`) each consume that memoized result. On failure every consumer surfaces the same cached error instance, so `dagBuildState.errs` held one `*ValidationError` five times (verified by pointer identity), and `ErrorList.Error()` joined all five. The eval command itself executes exactly once, on both the success and failure paths — this is purely an error-reporting defect.

## Fix

`ErrorList.Dedupe()`: collapse repeated occurrences of the same error value, applied when the build state finalizes its error list. Distinct errors with equal messages are preserved (identity dedupe only), and values of non-comparable dynamic types (e.g. a nested `ErrorList`) pass through untouched.

## Tests

- `TestErrorList_Dedupe`: identical instances collapse, equal-message distinct errors kept, non-comparable members pass through, first-occurrence order preserved
- `TestInlineParamDefs_EvalFailureReportedOnce`: one failing eval yields exactly one `field 'params'` entry in the load error
- Repro before/after with the CLI: 5 occurrences on main, 1 with this change

Found while triaging the Windows conformance flake on #2488, whose log showed the same substitution timeout five times and initially read as five execution attempts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates identical build errors so a failing param eval is reported once instead of five times. Applies identity-based dedupe when finalizing DAG build errors.

- **Bug Fixes**
  - Added `ErrorList.Dedupe()` and used it in `dagBuildState.finish` to collapse repeated identical error instances while preserving order; distinct errors with the same message stay separate.
  - Tests cover dedupe behavior and verify a single failing param `eval` produces one "field 'params'" entry.

<sup>Written for commit 99d1f1a14a71ca877452c2df4f715500fbb4244c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Build and parameter evaluation errors are now deduplicated, preventing the same failure from being reported multiple times.
  - Distinct errors with identical messages remain separately visible, while repeated instances are shown only once.
  - Error ordering is preserved, making failure reports clearer and more consistent.

- **Tests**
  - Added coverage for duplicate, distinct, empty, and non-comparable error scenarios.
  - Added regression coverage for inline parameter evaluation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->