### PR TITLE
fix: allow TLS skip verify without certificates

### DIFF
--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1052,14 +1052,16 @@ func TestClientHeartbeatWithSkipTLSVerify(t *testing.T) {
 	monitor := &mockServiceMonitor{
 		members: []exec.HostInfo{{Host: host, Port: port, Status: exec.ServiceStatusActive}},
 	}
-	client := coordinator.New(monitor, config)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+	client := coordinator.New(monitor, config)
+	defer func() {
+		require.NoError(t, client.Cleanup(ctx))
+	}()
 
 	_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
 	require.NoError(t, err)
-	require.NoError(t, client.Cleanup(ctx))
 }
 
 func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -17,11 +17,13 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/proto/convert"
 	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
+	"github.com/dagucloud/dagu/v2/internal/test"
 	coordinatorv1 "github.com/dagucloud/dagu/v2/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -1028,6 +1030,38 @@ func TestClientHeartbeat(t *testing.T) {
 	assert.Equal(t, int32(2), receivedReq.Stats.BusyPollers)
 }
 
+func TestClientHeartbeatWithSkipTLSVerify(t *testing.T) {
+	t.Parallel()
+
+	config := coordinator.DefaultConfig()
+	config.Insecure = false
+	config.SkipTLSVerify = true
+	config.MaxRetries = 0
+	require.NoError(t, config.Validate())
+
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(_ context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			return &coordinatorv1.HeartbeatResponse{}, nil
+		},
+	}
+
+	server, addr := startMockTLSServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []exec.HostInfo{{Host: host, Port: port, Status: exec.ServiceStatusActive}},
+	}
+	client := coordinator.New(monitor, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+	require.NoError(t, err)
+	require.NoError(t, client.Cleanup(ctx))
+}
+
 func TestClientDiscoveredAddressRemainsAuthoritative(t *testing.T) {
 	t.Parallel()
 
@@ -1771,9 +1805,9 @@ func startMockServer(t *testing.T, service coordinatorv1.CoordinatorServiceServe
 	return startMockServerWithHealth(t, service, healthServer)
 }
 
-func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorServiceServer, healthServer grpc_health_v1.HealthServer) (*grpc.Server, string) {
+func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorServiceServer, healthServer grpc_health_v1.HealthServer, opts ...grpc.ServerOption) (*grpc.Server, string) {
 	t.Helper()
-	server := grpc.NewServer()
+	server := grpc.NewServer(opts...)
 	coordinatorv1.RegisterCoordinatorServiceServer(server, service)
 
 	grpc_health_v1.RegisterHealthServer(server, healthServer)
@@ -1787,4 +1821,18 @@ func startMockServerWithHealth(t *testing.T, service coordinatorv1.CoordinatorSe
 	}()
 
 	return server, listener.Addr().String()
+}
+
+func startMockTLSServer(t *testing.T, service coordinatorv1.CoordinatorServiceServer) (*grpc.Server, string) {
+	t.Helper()
+
+	creds, err := credentials.NewServerTLSFromFile(
+		test.TestdataPath(t, "certs/cert.pem"),
+		test.TestdataPath(t, "certs/key.pem"),
+	)
+	require.NoError(t, err)
+
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	return startMockServerWithHealth(t, service, healthServer, grpc.Creds(creds))
 }

--- a/internal/service/coordinator/config.go
+++ b/internal/service/coordinator/config.go
@@ -38,7 +38,7 @@ func DefaultConfig() *Config {
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if !c.Insecure && c.CertFile == "" && c.KeyFile == "" && c.CAFile == "" {
+	if !c.Insecure && !c.SkipTLSVerify && c.CertFile == "" && c.KeyFile == "" && c.CAFile == "" {
 		return ErrMissingTLSConfig
 	}
 	if c.DialTimeout <= 0 {

--- a/internal/service/coordinator/config_test.go
+++ b/internal/service/coordinator/config_test.go
@@ -121,12 +121,10 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "TLSWithSkipVerify",
+			name: "TLSWithSkipVerifyWithoutCerts",
 			config: &coordinator.Config{
 				Insecure:       false,
 				SkipTLSVerify:  true,
-				CertFile:       "/path/to/cert.pem",
-				KeyFile:        "/path/to/key.pem",
 				DialTimeout:    10 * time.Second,
 				RequestTimeout: 5 * time.Minute,
 				MaxRetries:     3,


### PR DESCRIPTION
## Summary

- allow coordinator clients using `peer.skip_tls_verify` to establish TLS without a CA or client certificate
- preserve missing TLS material validation when server verification remains enabled

## Root cause

`coordinator.Config.Validate` rejected TLS configurations without certificate material before the gRPC dialer could apply `tls.Config.InsecureSkipVerify`. Coordinators without `peer.client_ca_file` do not require a client certificate, so skip-verification mode should not require client-side TLS files.

## Testing

- `go test ./internal/service/coordinator ./internal/cmd`

Closes #2493

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow coordinator clients using `peer.skip_tls_verify` to connect over TLS without a CA or client certificate. Keeps strict TLS validation when server verification is enabled.

- **Bug Fixes**
  - Relaxed `coordinator.Config.Validate` to require TLS files only when `Insecure=false` and `SkipTLSVerify=false`.
  - Added a TLS handshake + heartbeat test against a mock TLS server and ensured the client is always cleaned up.

<sup>Written for commit bdf046edf5f01aa915e24f93136f8c2e1324a4ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TLS configuration validation now allows non-insecure connections when verification is skipped, without requiring certificate, key, or CA files.
  * Improved TLS connection handling when certificate verification is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->