### PR TITLE
fix: propagate param constraints into LLM tool schemas

### DIFF
--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -71,9 +71,11 @@ func defaultCommandTimeoutForPlatform() time.Duration {
 }
 
 // WaitTimeout returns the budget for polling until an expected state is
-// observed, scaled up on platforms with slow process startup.
-func WaitTimeout() time.Duration {
-	return defaultCommandTimeoutForPlatform()
+// observed. It matches the budget a single command gets: the platform default,
+// or DAGU_CONFORMANCE_COMMAND_TIMEOUT when set.
+func WaitTimeout(t *testing.T) time.Duration {
+	t.Helper()
+	return commandTimeout(t)
 }
 
 // NewRunner creates an isolated project seeded with package-local testdata.

--- a/conformance/harness/runner.go
+++ b/conformance/harness/runner.go
@@ -70,6 +70,12 @@ func defaultCommandTimeoutForPlatform() time.Duration {
 	return defaultCommandTimeout
 }
 
+// WaitTimeout returns the budget for polling until an expected state is
+// observed, scaled up on platforms with slow process startup.
+func WaitTimeout() time.Duration {
+	return defaultCommandTimeoutForPlatform()
+}
+
 // NewRunner creates an isolated project seeded with package-local testdata.
 func NewRunner(t *testing.T) *Runner {
 	t.Helper()

--- a/conformance/spec031_human_task/distributed_test.go
+++ b/conformance/spec031_human_task/distributed_test.go
@@ -113,7 +113,7 @@ func startWorker(
 
 func waitForTCPService(t *testing.T, process *harness.Process, address string) {
 	t.Helper()
-	deadline := time.Now().Add(harness.WaitTimeout())
+	deadline := time.Now().Add(harness.WaitTimeout(t))
 	for time.Now().Before(deadline) {
 		select {
 		case <-process.Done():
@@ -139,7 +139,7 @@ func waitForDistributedSuccess(
 	services *harness.Process,
 ) {
 	t.Helper()
-	deadline := time.Now().Add(harness.WaitTimeout())
+	deadline := time.Now().Add(harness.WaitTimeout(t))
 	var status *harness.Result
 	for time.Now().Before(deadline) {
 		select {

--- a/conformance/spec031_human_task/distributed_test.go
+++ b/conformance/spec031_human_task/distributed_test.go
@@ -113,7 +113,7 @@ func startWorker(
 
 func waitForTCPService(t *testing.T, process *harness.Process, address string) {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
+	deadline := time.Now().Add(harness.WaitTimeout())
 	for time.Now().Before(deadline) {
 		select {
 		case <-process.Done():
@@ -139,7 +139,7 @@ func waitForDistributedSuccess(
 	services *harness.Process,
 ) {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
+	deadline := time.Now().Add(harness.WaitTimeout())
 	var status *harness.Result
 	for time.Now().Before(deadline) {
 		select {

--- a/conformance/spec031_human_task/helpers_test.go
+++ b/conformance/spec031_human_task/helpers_test.go
@@ -60,7 +60,7 @@ func waitForStatus(
 	status string,
 ) *harness.Result {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
+	deadline := time.Now().Add(harness.WaitTimeout())
 	var result *harness.Result
 	for time.Now().Before(deadline) {
 		result = dagu.RunWithEnv(env, "status", "--run-id="+runID, file)
@@ -78,7 +78,7 @@ func waitForStatus(
 
 func waitForFileContent(t *testing.T, path, expected string) {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
+	deadline := time.Now().Add(harness.WaitTimeout())
 	for time.Now().Before(deadline) {
 		actual, err := os.ReadFile(path) // #nosec G304 -- the caller supplies a test-project path.
 		if err == nil && string(actual) == expected {

--- a/conformance/spec031_human_task/helpers_test.go
+++ b/conformance/spec031_human_task/helpers_test.go
@@ -60,7 +60,7 @@ func waitForStatus(
 	status string,
 ) *harness.Result {
 	t.Helper()
-	deadline := time.Now().Add(harness.WaitTimeout())
+	deadline := time.Now().Add(harness.WaitTimeout(t))
 	var result *harness.Result
 	for time.Now().Before(deadline) {
 		result = dagu.RunWithEnv(env, "status", "--run-id="+runID, file)
@@ -78,7 +78,7 @@ func waitForStatus(
 
 func waitForFileContent(t *testing.T, path, expected string) {
 	t.Helper()
-	deadline := time.Now().Add(harness.WaitTimeout())
+	deadline := time.Now().Add(harness.WaitTimeout(t))
 	for time.Now().Before(deadline) {
 		actual, err := os.ReadFile(path) // #nosec G304 -- the caller supplies a test-project path.
 		if err == nil && string(actual) == expected {

--- a/internal/llm/toolschema/toolschema.go
+++ b/internal/llm/toolschema/toolschema.go
@@ -17,10 +17,17 @@ import (
 
 // Param is a single tool parameter.
 type Param struct {
-	Name     string
-	Type     string // "string", "integer", "number", "boolean", "array", "object"
-	Default  any
-	Required bool
+	Name        string
+	Type        string // "string", "integer", "number", "boolean", "array", "object"
+	Default     any
+	Description string
+	Required    bool
+	Enum        []any
+	Minimum     *float64
+	Maximum     *float64
+	MinLength   *int
+	MaxLength   *int
+	Pattern     *string
 }
 
 // paramRegex matches "name" or "name=value" patterns in param strings.
@@ -67,10 +74,17 @@ func ParamsFromDefs(defs []core.ParamDef) []Param {
 			continue
 		}
 		param := Param{
-			Name:     def.Name,
-			Type:     def.Type,
-			Required: def.Required,
-			Default:  def.Default,
+			Name:        def.Name,
+			Type:        def.Type,
+			Required:    def.Required,
+			Default:     def.Default,
+			Description: def.Description,
+			Enum:        def.Enum,
+			Minimum:     def.Minimum,
+			Maximum:     def.Maximum,
+			MinLength:   def.MinLength,
+			MaxLength:   def.MaxLength,
+			Pattern:     def.Pattern,
 		}
 		if param.Type == "" {
 			param.Type = "string"
@@ -208,13 +222,35 @@ func Build(params []Param) map[string]any {
 	var required []string
 
 	for _, param := range params {
+		description := param.Description
+		if description == "" {
+			description = fmt.Sprintf("%s parameter", param.Name)
+		}
 		prop := map[string]any{
 			"type":        param.Type,
-			"description": fmt.Sprintf("%s parameter", param.Name),
+			"description": description,
 		}
 
 		if param.Default != nil {
 			prop["default"] = param.Default
+		}
+		if len(param.Enum) > 0 {
+			prop["enum"] = param.Enum
+		}
+		if param.Minimum != nil {
+			prop["minimum"] = *param.Minimum
+		}
+		if param.Maximum != nil {
+			prop["maximum"] = *param.Maximum
+		}
+		if param.MinLength != nil {
+			prop["minLength"] = *param.MinLength
+		}
+		if param.MaxLength != nil {
+			prop["maxLength"] = *param.MaxLength
+		}
+		if param.Pattern != nil && *param.Pattern != "" {
+			prop["pattern"] = *param.Pattern
 		}
 
 		properties[param.Name] = prop

--- a/internal/llm/toolschema/toolschema_test.go
+++ b/internal/llm/toolschema/toolschema_test.go
@@ -106,6 +106,38 @@ func TestParamsFromDefs_PreservesRequiredWithDefault(t *testing.T) {
 	assert.Equal(t, "latest", params[0].Default)
 }
 
+func TestParamsFromDefs_CarriesConstraints(t *testing.T) {
+	t.Parallel()
+
+	minimum := 1.0
+	maximum := 10.0
+	minLength := 2
+	maxLength := 32
+	pattern := "^[a-z-]+$"
+	params := toolschema.ParamsFromDefs([]core.ParamDef{
+		{
+			Name:        "angle",
+			Type:        core.ParamDefTypeString,
+			Description: "Review lens for this pass.",
+			Enum:        []any{"duplication", "complexity"},
+			Minimum:     &minimum,
+			Maximum:     &maximum,
+			MinLength:   &minLength,
+			MaxLength:   &maxLength,
+			Pattern:     &pattern,
+		},
+	})
+
+	require.Len(t, params, 1)
+	assert.Equal(t, "Review lens for this pass.", params[0].Description)
+	assert.Equal(t, []any{"duplication", "complexity"}, params[0].Enum)
+	assert.Equal(t, &minimum, params[0].Minimum)
+	assert.Equal(t, &maximum, params[0].Maximum)
+	assert.Equal(t, &minLength, params[0].MinLength)
+	assert.Equal(t, &maxLength, params[0].MaxLength)
+	assert.Equal(t, &pattern, params[0].Pattern)
+}
+
 func TestInferTypeFromDefault(t *testing.T) {
 	t.Parallel()
 
@@ -289,6 +321,40 @@ func TestBuild(t *testing.T) {
 		assert.Equal(t, int64(10), limitProp["default"])
 
 		assert.Nil(t, result["required"])
+	})
+
+	t.Run("ConstrainedParam", func(t *testing.T) {
+		t.Parallel()
+
+		minimum := 1.0
+		maximum := 10.0
+		minLength := 2
+		maxLength := 32
+		pattern := "^[a-z-]+$"
+		params := []toolschema.Param{
+			{
+				Name:        "angle",
+				Type:        "string",
+				Description: "Review lens for this pass.",
+				Enum:        []any{"duplication", "complexity"},
+				Minimum:     &minimum,
+				Maximum:     &maximum,
+				MinLength:   &minLength,
+				MaxLength:   &maxLength,
+				Pattern:     &pattern,
+			},
+		}
+		result := toolschema.Build(params)
+
+		props := result["properties"].(map[string]any)
+		angleProp := props["angle"].(map[string]any)
+		assert.Equal(t, "Review lens for this pass.", angleProp["description"])
+		assert.Equal(t, []any{"duplication", "complexity"}, angleProp["enum"])
+		assert.Equal(t, 1.0, angleProp["minimum"])
+		assert.Equal(t, 10.0, angleProp["maximum"])
+		assert.Equal(t, 2, angleProp["minLength"])
+		assert.Equal(t, 32, angleProp["maxLength"])
+		assert.Equal(t, "^[a-z-]+$", angleProp["pattern"])
 	})
 
 	t.Run("MixedParams", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Tool schemas derived from DAG parameter definitions (`internal/llm/toolschema`) kept only `name`/`type`/`default`/`required`. Rich param definitions' `enum`, `description`, `minimum`/`maximum`, `minLength`/`maxLength`, and `pattern` were silently dropped when building the JSON Schema advertised to the LLM.

For a `type: controller` DAG this means the advertised tool schema is weaker than the contract enforced at child-DAG load: the model is offered a bare `string`, invents a value outside the enum, and the run attempt fails validation — burning one of the 5 capped runs per step. The only way the model learns the valid values is from the failure message.

Observed in a real controller run: the model passed `angle="structure-and-complexity"` against `enum: [duplication, complexity, api-surface, error-handling, dead-code, test-gaps]`, failed, and retried.

Spec 032 says the tool schema "is derived from the target's parameter definitions" — dropping the constraint half of those definitions falls short of that.

## Fix

- `toolschema.Param` carries `Description`, `Enum`, `Minimum`, `Maximum`, `MinLength`, `MaxLength`, `Pattern`, mirroring `core.ParamDef`
- `ParamsFromDefs` copies them; `Build` emits them into the schema properties
- Author-written `description` replaces the generated `"<name> parameter"` placeholder when present

Benefits both callers: controller step tools (`internal/runtime/controller/catalog.go`) and chat DAG tools (`internal/runtime/builtin/chat/tools.go`).

## Testing

- `TestParamsFromDefs_CarriesConstraints` and `Build/ConstrainedParam` added
- `go test -race` green for `internal/llm/toolschema`, `internal/runtime/controller`, `internal/runtime/builtin/chat`
- golangci-lint clean, `GOOS=windows` build green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates parameter constraints from DAG definitions into LLM tool JSON schemas so models follow the real contract. Also scales conformance wait deadlines via `harness.WaitTimeout`, honoring `DAGU_CONFORMANCE_COMMAND_TIMEOUT`, to reduce flaky spec031 runs.

- **Bug Fixes**
  - `toolschema.Param` now carries `Description`, `Enum`, `Minimum`, `Maximum`, `MinLength`, `MaxLength`, `Pattern`; `ParamsFromDefs` copies them, and `Build` emits them. Author-written `description` is preferred. Applies to controller step tools and chat DAG tools.
  - Conformance harness exposes `WaitTimeout()` derived from `commandTimeout`; spec031 status/file/TCP/distributed waits use it instead of a fixed 20s deadline and pick up `DAGU_CONFORMANCE_COMMAND_TIMEOUT`, improving stability on Windows.

<sup>Written for commit 252caf789c491fa757a3d963288da8aa4e8114e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced tool parameter schemas with descriptions, allowed values, numeric limits, string length limits, and pattern validation.
  * Parameter definitions now preserve these constraints for more precise tool interactions and validation.

* **Bug Fixes**
  * Improved distributed task and service-startup polling with configurable timeouts for more consistent behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->