### PR TITLE
fix: avoid DAG-run list refreshes for progress updates

### DIFF
--- a/internal/service/frontend/sse/dagrun_invalidator.go
+++ b/internal/service/frontend/sse/dagrun_invalidator.go
@@ -97,7 +97,9 @@ func wakeTopicsForDAGRunEvent(mux *Multiplexer, event *eventstore.Event) {
 		}
 	}
 
-	mux.WakeTopicType(TopicTypeDAGRuns)
+	if event.Type != eventstore.TypeDAGRunUpdated {
+		mux.WakeTopicType(TopicTypeDAGRuns)
+	}
 	mux.WakeTopicType(TopicTypeQueues)
 	mux.WakeTopicType(TopicTypeDAGsList)
 

--- a/internal/service/frontend/sse/dagrun_invalidator_test.go
+++ b/internal/service/frontend/sse/dagrun_invalidator_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package sse
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/internal/core"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
+	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
+	tests := []struct {
+		name              string
+		eventType         eventstore.EventType
+		wantListRefreshes int64
+	}{
+		{
+			name:              "progress update",
+			eventType:         eventstore.TypeDAGRunUpdated,
+			wantListRefreshes: 0,
+		},
+		{
+			name:              "lifecycle update",
+			eventType:         eventstore.TypeDAGRunRunning,
+			wantListRefreshes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := NewMultiplexer(StreamConfig{}, nil)
+			t.Cleanup(mux.Shutdown)
+
+			var detailRefreshes atomic.Int64
+			mux.RegisterFetcher(TopicTypeDAGRun, func(_ context.Context, _ string) (any, error) {
+				detailRefreshes.Add(1)
+				return nil, nil
+			})
+			mux.SetRefreshMode(TopicTypeDAGRun, TopicRefreshModeOnDemand)
+
+			var listRefreshes atomic.Int64
+			mux.RegisterFetcher(TopicTypeDAGRuns, func(_ context.Context, _ string) (any, error) {
+				listRefreshes.Add(1)
+				return nil, nil
+			})
+			mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
+
+			result, err := mux.createSession(
+				context.Background(),
+				httptest.NewRecorder(),
+				[]string{"dagrun:test/run-1", "dagruns:status=running"},
+				0,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result.session)
+			defer mux.removeSession(result.session)
+
+			status := &exec.DAGRunStatus{
+				Name:      "test",
+				DAGRunID:  "run-1",
+				AttemptID: "attempt-1",
+				Status:    core.Running,
+			}
+			event := eventstore.NewDAGRunEvent(
+				eventstore.Source{Service: eventstore.SourceServiceServer},
+				tt.eventType,
+				status,
+				nil,
+			)
+
+			wakeTopicsForDAGRunEvent(mux, event)
+
+			require.Eventually(t, func() bool {
+				return detailRefreshes.Load() == 1 && listRefreshes.Load() == tt.wantListRefreshes
+			}, time.Second, 10*time.Millisecond)
+			if tt.wantListRefreshes == 0 {
+				require.Never(t, func() bool {
+					return listRefreshes.Load() != 0
+				}, 200*time.Millisecond, 20*time.Millisecond)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- keep same-status progress events refreshing exact DAG-run detail subscriptions
- skip aggregate DAG-run list invalidation for progress-only events
- retain aggregate list refreshes for lifecycle transitions
- cover both paths through the SSE multiplexer

## Root cause

`dag.run.updated` events are emitted to keep active run details current. The invalidator also woke every aggregate `dagruns` topic for each of those events, so Cockpit's status buckets repeatedly rebuilt the same date index while a run progressed without changing lifecycle status.

## Scope

This PR fixes the sustained CPU load reported in #2501 by removing aggregate list invalidation from progress-only updates. Broader index architecture improvements can be tracked separately.

## Testing

- `go test ./internal/service/frontend/sse -count=1`
- `go test -race ./internal/service/frontend/sse -count=3`
- `go test ./internal/service/frontend/... -count=1`
- native and Windows `golangci-lint run --timeout=10m ./...`

Closes #2501