### PR TITLE
fix: enforce clicontext store path and marker invariants

### DIFF
--- a/internal/clicontext/store.go
+++ b/internal/clicontext/store.go
@@ -167,10 +167,16 @@ func (s *Store) Delete(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	path := s.contextPath(name)
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
 		return ErrNotFound
 	} else if err != nil {
 		return err
+	}
+	// A directory or other non-regular entry at this path is not a stored
+	// context, so it must not be removed or drive a marker change.
+	if !info.Mode().IsRegular() {
+		return ErrNotFound
 	}
 	// Move the current marker off the context before the file disappears, so a
 	// failure to update the marker cannot leave it naming a deleted context.

--- a/internal/clicontext/store.go
+++ b/internal/clicontext/store.go
@@ -105,15 +105,8 @@ func (s *Store) ValidateContext(ctx *Context) error {
 		return errors.New("context is required")
 	}
 	normalizeContext(ctx)
-	name := ctx.Name
-	if name == "" {
-		return errors.New("context name is required")
-	}
-	if name == LocalContextName || name == currentFileName {
-		return fmt.Errorf("%q and %q are reserved", LocalContextName, currentFileName)
-	}
-	if strings.ContainsAny(name, `/\`) {
-		return errors.New("context name cannot contain path separators")
+	if err := validateStoredName(ctx.Name); err != nil {
+		return err
 	}
 	if !strings.HasPrefix(ctx.APIKey, "dagu_") {
 		return errors.New("api key must use the dagu_ prefix")
@@ -168,26 +161,42 @@ func (s *Store) Delete(_ context.Context, name string) error {
 	if name == "" || name == LocalContextName {
 		return ErrNotFound
 	}
+	if err := validateStoredName(name); err != nil {
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := os.Remove(s.contextPath(name)); errors.Is(err, os.ErrNotExist) {
+	path := s.contextPath(name)
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		return ErrNotFound
 	} else if err != nil {
 		return err
 	}
+	// Move the current marker off the context before the file disappears, so a
+	// failure to update the marker cannot leave it naming a deleted context.
 	current, err := s.currentLocked()
-	if err == nil && current == name {
-		return s.writeCurrentLocked(LocalContextName)
+	switch {
+	case err == nil && current == name:
+		if err := s.writeCurrentLocked(LocalContextName); err != nil {
+			return err
+		}
+	case err != nil && !errors.Is(err, os.ErrNotExist):
+		return err
 	}
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	if err := os.Remove(path); errors.Is(err, os.ErrNotExist) {
+		return ErrNotFound
+	} else if err != nil {
+		return err
 	}
-	return err
+	return nil
 }
 
 func (s *Store) Get(_ context.Context, name string) (*Context, error) {
 	if name == LocalContextName {
 		return &Context{Name: LocalContextName}, nil
+	}
+	if err := validateStoredName(name); err != nil {
+		return nil, err
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -212,7 +221,7 @@ func (s *Store) List(_ context.Context) ([]*Context, error) {
 		}
 		ctx, err := s.readContext(filepath.Join(s.baseDir, entry.Name()))
 		if err != nil {
-			readErrs = append(readErrs, fmt.Errorf("read %s: %w", entry.Name(), err))
+			readErrs = append(readErrs, err)
 			continue
 		}
 		contexts = append(contexts, ctx)
@@ -234,20 +243,43 @@ func (s *Store) Current(_ context.Context) (string, error) {
 	return current, err
 }
 
-func (s *Store) Use(ctx context.Context, name string) error {
-	switch name {
-	case "", LocalContextName:
+func (s *Store) Use(_ context.Context, name string) error {
+	if name == "" || name == LocalContextName {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		return s.writeCurrentLocked(LocalContextName)
-	default:
-		if _, err := s.Get(ctx, name); err != nil {
-			return err
-		}
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return s.writeCurrentLocked(name)
 	}
+	if err := validateStoredName(name); err != nil {
+		return err
+	}
+	// Read the context and write the marker under one exclusive lock so the
+	// marker cannot end up naming a context removed after the check.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.readContext(s.contextPath(name)); err != nil {
+		return err
+	}
+	return s.writeCurrentLocked(name)
+}
+
+// validateStoredName reports whether name may address a context file in the
+// store directory. Reserved names and anything that does not resolve to a flat
+// file name directly inside the directory are rejected. Every caller must pass
+// a name through this before building a path with contextPath.
+func validateStoredName(name string) error {
+	if name == "" {
+		return errors.New("context name is required")
+	}
+	if name == LocalContextName || name == currentFileName {
+		return fmt.Errorf("%q and %q are reserved", LocalContextName, currentFileName)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return errors.New("context name cannot contain path separators")
+	}
+	if !filepath.IsLocal(name) {
+		return fmt.Errorf("invalid context name %q", name)
+	}
+	return nil
 }
 
 func (s *Store) contextPath(name string) string {
@@ -263,18 +295,23 @@ func (s *Store) writeContext(path string, ctx *Context) error {
 }
 
 func (s *Store) readContext(path string) (*Context, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // internal path
+	data, err := os.ReadFile(path) //nolint:gosec // path is built from a validated context name
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, ErrNotFound
 	}
+	file := filepath.Base(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read %s: %w", file, err)
 	}
 	var stored storedContext
 	if err := json.Unmarshal(data, &stored); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode %s: %w", file, err)
 	}
-	return stored.toContext(s.encryptor)
+	ctx, err := stored.toContext(s.encryptor)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", file, err)
+	}
+	return ctx, nil
 }
 
 func normalizeContext(ctx *Context) {

--- a/internal/clicontext/store_test.go
+++ b/internal/clicontext/store_test.go
@@ -239,6 +239,34 @@ func TestStore_DeleteKeepsUnrelatedCurrentMarker(t *testing.T) {
 	assert.Equal(t, "prod", current)
 }
 
+func TestStore_DeleteIgnoresNonRegularEntries(t *testing.T) {
+	t.Parallel()
+
+	enc, err := crypto.NewEncryptor("test-key")
+	require.NoError(t, err)
+
+	baseDir := t.TempDir()
+	store, err := NewStore(baseDir, enc)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Create(context.Background(), &Context{
+		Name:      "prod",
+		ServerURL: "https://example.com",
+		APIKey:    "dagu_test",
+	}))
+	require.NoError(t, store.Use(context.Background(), "prod"))
+
+	strayDir := filepath.Join(baseDir, "staging"+fileExtension)
+	require.NoError(t, os.Mkdir(strayDir, 0o750))
+
+	require.ErrorIs(t, store.Delete(context.Background(), "staging"), ErrNotFound)
+	assert.DirExists(t, strayDir)
+
+	current, err := store.Current(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "prod", current)
+}
+
 func TestStore_GetReportsCorruptFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/clicontext/store_test.go
+++ b/internal/clicontext/store_test.go
@@ -186,3 +186,71 @@ func TestStore_ListReturnsPartialResultsAndErrorOnCorruptEntry(t *testing.T) {
 	assert.Equal(t, "prod", items[0].Name)
 	assert.Contains(t, err.Error(), "broken.json")
 }
+
+func TestStore_RejectsNamesOutsideStoreDir(t *testing.T) {
+	t.Parallel()
+
+	enc, err := crypto.NewEncryptor("test-key")
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	store, err := NewStore(filepath.Join(root, "contexts"), enc)
+	require.NoError(t, err)
+
+	outside := filepath.Join(root, "outside.json")
+	require.NoError(t, os.WriteFile(outside, []byte(`{"name":"outside"}`), 0o600))
+
+	const escaping = "../outside"
+
+	_, err = store.Get(context.Background(), escaping)
+	require.Error(t, err)
+
+	require.Error(t, store.Delete(context.Background(), escaping))
+	assert.FileExists(t, outside)
+
+	require.Error(t, store.Use(context.Background(), escaping))
+	current, err := store.Current(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, LocalContextName, current)
+}
+
+func TestStore_DeleteKeepsUnrelatedCurrentMarker(t *testing.T) {
+	t.Parallel()
+
+	enc, err := crypto.NewEncryptor("test-key")
+	require.NoError(t, err)
+
+	store, err := NewStore(t.TempDir(), enc)
+	require.NoError(t, err)
+
+	for _, name := range []string{"prod", "staging"} {
+		require.NoError(t, store.Create(context.Background(), &Context{
+			Name:      name,
+			ServerURL: "https://example.com",
+			APIKey:    "dagu_test",
+		}))
+	}
+	require.NoError(t, store.Use(context.Background(), "prod"))
+
+	require.NoError(t, store.Delete(context.Background(), "staging"))
+
+	current, err := store.Current(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "prod", current)
+}
+
+func TestStore_GetReportsCorruptFile(t *testing.T) {
+	t.Parallel()
+
+	enc, err := crypto.NewEncryptor("test-key")
+	require.NoError(t, err)
+
+	baseDir := t.TempDir()
+	store, err := NewStore(baseDir, enc)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "prod.json"), []byte("not-json"), 0o600))
+
+	_, err = store.Get(context.Background(), "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prod.json")
+}

--- a/internal/runtime/builtin/dag/enqueue_test.go
+++ b/internal/runtime/builtin/dag/enqueue_test.go
@@ -257,7 +257,7 @@ func TestEnqueueExecutorParallelHonorsMaxConcurrent(t *testing.T) {
 	var stdout bytes.Buffer
 	execImpl.SetStdout(&stdout)
 
-	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	runCtx, cancel := context.WithTimeout(ctx, enqueueConcurrencyWaitTimeout(t))
 	defer cancel()
 
 	done := make(chan error, 1)
@@ -278,6 +278,23 @@ func TestEnqueueExecutorParallelHonorsMaxConcurrent(t *testing.T) {
 	require.NoError(t, <-done)
 
 	assert.Equal(t, 2, queueStore.MaxActive())
+}
+
+// enqueueConcurrencyWaitTimeout bounds the wait for the executor to reach the
+// queue store. Each child run performs filesystem setup before it gets there,
+// and that cost varies widely with host load and platform, so the budget is
+// generous and shrinks only to stay inside the test deadline.
+func enqueueConcurrencyWaitTimeout(t *testing.T) time.Duration {
+	t.Helper()
+
+	timeout := time.Minute
+	if deadline, ok := t.Deadline(); ok {
+		remaining := time.Until(deadline) - 15*time.Second
+		if remaining > 0 && remaining < timeout {
+			return remaining
+		}
+	}
+	return timeout
 }
 
 type recordingQueueStore struct {


### PR DESCRIPTION
## Summary

Audit of `internal/clicontext` surfaced four state-safety issues. This PR fixes all four.

### 1. Name-based operations bypassed the path invariant

Only `Create` and `Update` validated names. `Get`, `Delete`, and `Use` built paths from unvalidated input, so a name like `../other` escaped `baseDir` through `filepath.Join` and addressed files outside the context directory. Reachable from `dagu context get|remove|use|test <name>` and from the `--context` flag via `resolveCLIContext`.

Scope note: this is a local single-user CLI store, so it is not a privilege boundary — the blast radius is deleting or reading a stray `.json` outside the store, and `Use` persisting an escaping name that every later command re-resolves.

Fixed by centralizing the invariant in `validateStoredName` and applying it before any path is built. This also closes a gap the audit missed: `Get`/`Delete` accepted the reserved name `current`, which `Create`/`Update` already rejected.

### 2. `Delete` could leave the current marker dangling

The context file was removed *before* the marker was read and repaired. A marker read/write failure returned an error for an already-completed delete, and left `current` naming a context that no longer exists — every subsequent command then fails to resolve it.

Now the marker is moved to `local` first and the file removed last, guarded by an existence check so a failed delete cannot flip the marker as a side effect. Worst case degrades to a stale-but-valid selection.

### 3. `Use` had a check-then-act split across two lock acquisitions

`Get` released its read lock before `Use` took the write lock. Now one exclusive lock covers both the read and the marker write.

### 4. Read/decode failures escaped without naming the file

A corrupt context surfaced only a bare JSON syntax error through `Get` and `context test`, while `List` added the filename separately. `readContext` now labels read, decode, and decrypt failures once; the duplicate wrapper in `List` is gone. `ErrNotFound` stays unwrapped so callers keep classifying it and the CLI does not leak storage filenames into "not found" messages.

## Deliberately not changed

Two low-severity audit suggestions were rejected as net-negative:

- **Unexport `ErrNotFound`/`ErrAlreadyExists`** — no external caller today, but unexporting removes the ability to classify these, and exported store sentinels match the rest of the codebase.
- **Drop the unused `context.Context` parameters** — this would make `clicontext` the only store that does not take a context (`persis/store/dagstate.go`, `dagsettings.go`, `workerheartbeat.go`, and others all do).

## Tests

Three behavior-level tests, all verifying observable outcomes rather than implementation details:

- escaping names are rejected by `Get`/`Delete`/`Use`, the file outside the store survives, and the marker is untouched
- deleting a non-current context leaves the current marker intact
- `Get` on a corrupt file names the file in the error

`make fmt` clean (including `GOOS=windows`), `go test -race ./internal/clicontext/... ./internal/cmd/...` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces safe context-name, path, and marker invariants in `internal/clicontext` to prevent path escapes, non-context deletions, and dangling selections. Also stabilizes the enqueue concurrency test by deriving its wait budget from the test deadline.

- **Bug Fixes**
  - Validate names via `validateStoredName` in `Get`/`Delete`/`Use`; block reserved names, traversal, and non-local paths.
  - `Delete`: require a regular file; leave directories untouched; move `current` to `local` before removal; guard with existence checks to avoid dangling markers.
  - `Use`: hold one exclusive lock for the existence check and marker write.
  - `readContext`: prefix read/decode/decrypt errors with the filename; drop duplicate wrapping in `List`; keep `ErrNotFound` unwrapped.
  - Test: bound the enqueue concurrency wait to the test deadline to avoid flakiness on slow runners.

<sup>Written for commit 86bd8df84028cb40f26cfff7b434e1852631e190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of context names to reject unsafe file paths.
  * Prevented deletion from affecting unrelated current-context markers.
  * Improved handling of missing, corrupt, unreadable, or invalid context files with clearer error messages.
  * Ensured active contexts are cleared safely before deletion.

* **Tests**
  * Added coverage for path traversal, marker preservation, and corrupt context files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also: unflaked `TestEnqueueExecutorParallelHonorsMaxConcurrent`

Unrelated to the `clicontext` change, but it turned the Windows shard red on this PR (and the same shard has failed on `main` recently), so it is fixed here rather than retried.

The test waited a fixed 5s for two enqueue goroutines to reach the recording queue store. Each child run writes a temporary DAG file and initializes its dag-run status file first, and on a loaded Windows runner that setup alone consumed the budget — the executor was behaving correctly, the observation point just was not reached in time.

The budget now derives from the test deadline, so it scales with the configured `-timeout` instead of a magic constant.

Verified the test is not neutered: forcing `MaxConcurrent: 1` leaves the single goroutine parked in the store and the wait still expires with `enqueue did not reach target concurrency`.
