### PR TITLE
fix: target DAG-run lifecycle invalidations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -526,7 +526,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af

--- a/internal/core/exec/dagrun_read_batch.go
+++ b/internal/core/exec/dagrun_read_batch.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package exec
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type dagRunListReadBatchContextKey struct{}
+
+var nextDAGRunListReadBatchID atomic.Uint64
+
+// DAGRunListReadBatch identifies list reads that may share the same storage work.
+type DAGRunListReadBatch struct {
+	id uint64
+}
+
+// NewDAGRunListReadBatch creates a new list-read batch.
+func NewDAGRunListReadBatch() *DAGRunListReadBatch {
+	return &DAGRunListReadBatch{id: nextDAGRunListReadBatchID.Add(1)}
+}
+
+// WithDAGRunListReadBatch associates a list-read batch with a context.
+func WithDAGRunListReadBatch(ctx context.Context, batch *DAGRunListReadBatch) context.Context {
+	return context.WithValue(ctx, dagRunListReadBatchContextKey{}, batch)
+}
+
+// DAGRunListReadBatchID returns the list-read batch ID associated with ctx.
+func DAGRunListReadBatchID(ctx context.Context) (uint64, bool) {
+	batch, ok := ctx.Value(dagRunListReadBatchContextKey{}).(*DAGRunListReadBatch)
+	if !ok {
+		return 0, false
+	}
+	return batch.id, true
+}

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -91,6 +91,9 @@ func TryLoadForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 	if len(runDirs) < MinRunsForIndex {
 		return nil, false, nil
 	}
+	sort.Slice(runDirs, func(i, j int) bool {
+		return runDirs[i].Name() < runDirs[j].Name()
+	})
 
 	var loadKey strings.Builder
 	loadKey.WriteString(filepath.Join(dayDir, IndexFileName))

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	indexv1 "github.com/dagucloud/dagu/v2/proto/index/v1"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -38,7 +39,13 @@ const (
 var (
 	reDAGRunDir  = regexp.MustCompile(`^` + dagRunDirPrefix + `(\d{8}_\d{6}Z)_(.*)$`)
 	reAttemptDir = regexp.MustCompile(`^(?:` + regexp.QuoteMeta(attemptDirPrefix) + `|` + regexp.QuoteMeta(legacyAttemptDirPrefix) + `)(\d{8}_\d{6}_\d{3}Z)_(.*)$`)
+	dayLoadGroup singleflight.Group
 )
+
+type dayLoadResult struct {
+	entries   []Entry
+	fromIndex bool
+}
 
 // Entry holds a cached summary for a single DAG run.
 type Entry struct {
@@ -85,15 +92,34 @@ func TryLoadForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 		return nil, false, nil
 	}
 
-	indexPath := filepath.Join(dayDir, IndexFileName)
-	idx, err := readIndex(indexPath)
-	if err == nil && validateIndex(dayDir, idx, runDirs) {
-		entries := protoToEntries(idx.Entries)
-		return entries, true, nil
+	var loadKey strings.Builder
+	loadKey.WriteString(filepath.Join(dayDir, IndexFileName))
+	for _, runDir := range runDirs {
+		loadKey.WriteByte(0)
+		loadKey.WriteString(runDir.Name())
+	}
+	value, err, _ := dayLoadGroup.Do(loadKey.String(), func() (any, error) {
+		indexPath := filepath.Join(dayDir, IndexFileName)
+		idx, readErr := readIndex(indexPath)
+		if readErr == nil && validateIndex(dayDir, idx, runDirs) {
+			return dayLoadResult{
+				entries:   protoToEntries(idx.Entries),
+				fromIndex: true,
+			}, nil
+		}
+
+		entries, fromIndex, rebuildErr := RebuildForDay(dayDir, dagRunDirs)
+		if rebuildErr != nil {
+			return nil, rebuildErr
+		}
+		return dayLoadResult{entries: entries, fromIndex: fromIndex}, nil
+	})
+	if err != nil {
+		return nil, false, err
 	}
 
-	// Rebuild.
-	return RebuildForDay(dayDir, dagRunDirs)
+	result := value.(dayLoadResult)
+	return result.entries, result.fromIndex, nil
 }
 
 // RebuildForDay scans a day directory, discovers latest attempts, reads statuses,

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -4,12 +4,14 @@
 package dagrunindex
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +78,9 @@ type Entry struct {
 	ProcGroup            string
 	SuspendFlagName      string
 	ArchiveDir           string
+	latestStatusSize     int64
+	latestStatusModTime  int64
+	runDirModTime        int64
 }
 
 // TryLoadForDay attempts to load and validate the index for a day directory.
@@ -86,7 +91,7 @@ type Entry struct {
 //   - (entries, false, nil) if entries were computed but no index was written (active runs or <10 runs)
 //   - (nil, false, nil) if the day has fewer than MinRunsForIndex runs
 //   - (nil, false, err) on unexpected I/O errors during rebuild
-func TryLoadForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, error) {
+func TryLoadForDay(ctx context.Context, dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, error) {
 	runDirs := filterDAGRunDirs(dagRunDirs)
 	if len(runDirs) < MinRunsForIndex {
 		return nil, false, nil
@@ -95,13 +100,7 @@ func TryLoadForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 		return runDirs[i].Name() < runDirs[j].Name()
 	})
 
-	var loadKey strings.Builder
-	loadKey.WriteString(filepath.Join(dayDir, IndexFileName))
-	for _, runDir := range runDirs {
-		loadKey.WriteByte(0)
-		loadKey.WriteString(runDir.Name())
-	}
-	value, err, _ := dayLoadGroup.Do(loadKey.String(), func() (any, error) {
+	load := func() (dayLoadResult, error) {
 		indexPath := filepath.Join(dayDir, IndexFileName)
 		idx, readErr := readIndex(indexPath)
 		if readErr == nil && validateIndex(dayDir, idx, runDirs) {
@@ -113,9 +112,27 @@ func TryLoadForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 
 		entries, fromIndex, rebuildErr := RebuildForDay(dayDir, dagRunDirs)
 		if rebuildErr != nil {
-			return nil, rebuildErr
+			return dayLoadResult{}, rebuildErr
 		}
 		return dayLoadResult{entries: entries, fromIndex: fromIndex}, nil
+	}
+
+	batchID, batched := exec.DAGRunListReadBatchID(ctx)
+	if !batched {
+		result, err := load()
+		return result.entries, result.fromIndex, err
+	}
+
+	var loadKey strings.Builder
+	loadKey.WriteString(strconv.FormatUint(batchID, 10))
+	loadKey.WriteByte(0)
+	loadKey.WriteString(filepath.Join(dayDir, IndexFileName))
+	for _, runDir := range runDirs {
+		loadKey.WriteByte(0)
+		loadKey.WriteString(runDir.Name())
+	}
+	value, err, _ := dayLoadGroup.Do(loadKey.String(), func() (any, error) {
+		return load()
 	})
 	if err != nil {
 		return nil, false, err
@@ -138,6 +155,10 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 
 	for _, rd := range runDirs {
 		runDir := filepath.Join(dayDir, rd.Name())
+		runDirInfo, err := os.Stat(runDir)
+		if err != nil {
+			continue
+		}
 
 		latestAttemptDir, err := findLatestAttempt(runDir)
 		if err != nil {
@@ -148,6 +169,10 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 		}
 
 		statusPath := filepath.Join(runDir, latestAttemptDir, statusFile)
+		statusInfo, err := os.Stat(statusPath)
+		if err != nil {
+			continue
+		}
 		status, err := parseStatusFile(statusPath)
 		if err != nil {
 			// Skip runs with unreadable status files; they'll be served from filesystem.
@@ -193,6 +218,9 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 			ProcGroup:            status.ProcGroup,
 			SuspendFlagName:      status.SuspendFlagName,
 			ArchiveDir:           status.ArchiveDir,
+			latestStatusSize:     statusInfo.Size(),
+			latestStatusModTime:  statusInfo.ModTime().UnixNano(),
+			runDirModTime:        runDirInfo.ModTime().UnixNano(),
 		})
 	}
 
@@ -269,28 +297,15 @@ func validateIndex(dayDir string, idx *indexv1.DAGRunIndex, runDirs []os.DirEntr
 }
 
 func writeIndex(dayDir string, entries []Entry) error {
-	// Stat the run dirs and status files to capture metadata for index validation.
 	protoEntries := make([]*indexv1.DAGRunIndexEntry, 0, len(entries))
 	for _, e := range entries {
-		runDir := filepath.Join(dayDir, e.DagRunDir)
-		runDirInfo, err := os.Stat(runDir)
-		if err != nil {
-			return err
-		}
-
-		statusPath := filepath.Join(runDir, e.LatestAttemptDir, statusFile)
-		info, err := os.Stat(statusPath)
-		if err != nil {
-			return err
-		}
-
 		protoEntries = append(protoEntries, &indexv1.DAGRunIndexEntry{
 			DagRunDir:            e.DagRunDir,
 			DagRunId:             e.DagRunID,
 			LatestAttemptDir:     e.LatestAttemptDir,
-			LatestStatusSize:     info.Size(),
-			LatestStatusModTime:  info.ModTime().UnixNano(),
-			RunDirModTime:        runDirInfo.ModTime().UnixNano(),
+			LatestStatusSize:     e.latestStatusSize,
+			LatestStatusModTime:  e.latestStatusModTime,
+			RunDirModTime:        e.runDirModTime,
 			Status:               int32(e.Status), //nolint:gosec
 			StartedAt:            e.StartedAtUnix,
 			FinishedAt:           e.FinishedAtUnix,
@@ -361,6 +376,9 @@ func protoToEntries(protoEntries []*indexv1.DAGRunIndexEntry) []Entry {
 			ProcGroup:            pe.ProcGroup,
 			SuspendFlagName:      pe.SuspendFlagName,
 			ArchiveDir:           pe.ArchiveDir,
+			latestStatusSize:     pe.LatestStatusSize,
+			latestStatusModTime:  pe.LatestStatusModTime,
+			runDirModTime:        pe.RunDirModTime,
 		}
 	}
 	return entries

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
@@ -55,7 +55,7 @@ func TestTryLoadForDay_FewRuns(t *testing.T) {
 	dayDir := t.TempDir()
 	createDayDir(t, dayDir, 5, core.Succeeded) // < 10
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Nil(t, entries)
 	assert.False(t, fromIndex)
@@ -65,7 +65,7 @@ func TestTryLoadForDay_NoIndex_AllTerminal(t *testing.T) {
 	dayDir := t.TempDir()
 	createDayDir(t, dayDir, 12, core.Succeeded)
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.Len(t, entries, 12)
 	assert.True(t, fromIndex)
@@ -99,7 +99,7 @@ func TestTryLoadForDay_NoIndex_ActiveRun(t *testing.T) {
 		}
 	}
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 10)
 	assert.False(t, fromIndex) // No index written because one run is active.
@@ -124,13 +124,13 @@ func TestTryLoadForDay_ValidIndex(t *testing.T) {
 	createDayDir(t, dayDir, 10, core.Succeeded)
 
 	// First call: builds index.
-	entries1, fromIndex1, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries1, fromIndex1, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.Len(t, entries1, 10)
 	assert.True(t, fromIndex1)
 
 	// Second call: loads from index.
-	entries2, fromIndex2, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries2, fromIndex2, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.Len(t, entries2, 10)
 	assert.True(t, fromIndex2)
@@ -165,7 +165,7 @@ func TestTryLoadForDay_PreservesRetryMetadata(t *testing.T) {
 	// Add enough runs for the index to be written.
 	createDayDir(t, dayDir, 9, core.Succeeded)
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.True(t, fromIndex)
 	require.Len(t, entries, 10)
@@ -194,7 +194,7 @@ func TestTryLoadForDay_StaleIndex_NewRun(t *testing.T) {
 	createDayDir(t, dayDir, 10, core.Succeeded)
 
 	// Build index.
-	_, _, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	_, _, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 
 	// Add another run.
@@ -206,7 +206,7 @@ func TestTryLoadForDay_StaleIndex_NewRun(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(attemptDir, "status.jsonl"), append(data, '\n'), 0600))
 
 	// Should detect new run and rebuild.
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 11)
 	assert.True(t, fromIndex)
@@ -217,7 +217,7 @@ func TestTryLoadForDay_StaleIndex_NewAttempt(t *testing.T) {
 	createDayDir(t, dayDir, 10, core.Succeeded)
 
 	// Build index.
-	_, _, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	_, _, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 
 	// Add a new attempt to an existing run (simulating a retry).
@@ -234,7 +234,7 @@ func TestTryLoadForDay_StaleIndex_NewAttempt(t *testing.T) {
 	}
 
 	// Should detect new attempt and rebuild.
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 10)
 	assert.True(t, fromIndex)
@@ -257,7 +257,7 @@ func TestTryLoadForDay_CorruptIndex(t *testing.T) {
 	// Write corrupt data to index file.
 	require.NoError(t, os.WriteFile(filepath.Join(dayDir, IndexFileName), []byte("garbage"), 0600))
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 10)
 	assert.True(t, fromIndex) // Rebuilt and wrote new index.
@@ -273,7 +273,7 @@ func TestTryLoadForDay_VersionMismatch(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dayDir, IndexFileName), data, 0600))
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 10)
 	assert.True(t, fromIndex)
@@ -364,7 +364,7 @@ func TestRebuildForDay_MixedStatuses(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(attemptDir, "status.jsonl"), append(data, '\n'), 0600))
 	}
 
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 12)
 	assert.False(t, fromIndex) // Not all terminal, so no index written.
@@ -479,7 +479,7 @@ func TestValidateIndex_RunDirDeleted(t *testing.T) {
 	createDayDir(t, dayDir, 12, core.Succeeded) // 12 so after deleting 1 we still have 11 >= MinRunsForIndex
 
 	// Build index.
-	_, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	_, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.True(t, fromIndex)
 
@@ -493,7 +493,7 @@ func TestValidateIndex_RunDirDeleted(t *testing.T) {
 	}
 
 	// Should detect missing dir and rebuild.
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 11)
 	assert.True(t, fromIndex, "should rebuild and write new index")
@@ -504,30 +504,43 @@ func TestValidateIndex_StatusFileModified(t *testing.T) {
 	createDayDir(t, dayDir, 10, core.Succeeded)
 
 	// Build index.
-	_, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	snapshot, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	require.True(t, fromIndex)
 
 	// Modify a status file (append data to change size).
 	dirEntries := readDayDir(t, dayDir)
+	modifiedRunDir := ""
 	for _, de := range dirEntries {
 		if de.IsDir() {
+			modifiedRunDir = de.Name()
 			attemptDir := filepath.Join(dayDir, de.Name(), "attempt_20240115_120000_001Z_abc123")
 			statusPath := filepath.Join(attemptDir, "status.jsonl")
 			f, err := os.OpenFile(statusPath, os.O_APPEND|os.O_WRONLY, 0600)
 			require.NoError(t, err)
-			_, err = f.WriteString(`{"status":4}` + "\n")
+			_, err = f.WriteString(`{"status":3}` + "\n")
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
 			break
 		}
 	}
+	require.NotEmpty(t, modifiedRunDir)
+
+	// Simulate an older rebuild finishing after the status update.
+	require.NoError(t, writeIndex(dayDir, snapshot))
 
 	// Should detect modified status and rebuild.
-	entries, fromIndex, err := TryLoadForDay(dayDir, readDayDir(t, dayDir))
+	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
 	assert.Len(t, entries, 10)
 	assert.True(t, fromIndex, "should rebuild and write new index")
+	for _, entry := range entries {
+		if entry.DagRunDir == modifiedRunDir {
+			assert.Equal(t, core.Aborted, entry.Status)
+			return
+		}
+	}
+	t.Fatalf("modified DAG run %q not found", modifiedRunDir)
 }
 
 func TestRebuildForDay_EmptyAttempts(t *testing.T) {

--- a/internal/persis/file/dagrun/dataroot.go
+++ b/internal/persis/file/dagrun/dataroot.go
@@ -532,7 +532,7 @@ SCAN:
 					continue
 				}
 
-				indexEntries, _, indexErr := dagrunindex.TryLoadForDay(dayPath, dayEntries)
+				indexEntries, _, indexErr := dagrunindex.TryLoadForDay(ctx, dayPath, dayEntries)
 				if indexErr != nil {
 					logger.Debug(ctx, "Failed to load day index, falling back to filesystem scan",
 						tag.Dir(dayPath),

--- a/internal/persis/file/dagrun/pagination.go
+++ b/internal/persis/file/dagrun/pagination.go
@@ -250,7 +250,7 @@ func (it *dagRunStatusIterator) loadDay(ctx context.Context, dayPath string) ([]
 		return nil, fmt.Errorf("read day directory %s: %w", dayPath, err)
 	}
 
-	runs, err := loadDayRuns(dayPath, entries, it.statusesFilter, it.hasStatusFilter)
+	runs, err := loadDayRuns(ctx, dayPath, entries, it.statusesFilter, it.hasStatusFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -352,8 +352,8 @@ func listDayPathsInRange(root DataRoot, from, to exec.TimeInUTC) ([]string, erro
 	return dayPaths, nil
 }
 
-func loadDayRuns(dayPath string, dayEntries []os.DirEntry, statusesFilter map[core.Status]struct{}, hasStatusFilter bool) ([]*DAGRun, error) {
-	indexEntries, _, indexErr := dagrunindex.TryLoadForDay(dayPath, dayEntries)
+func loadDayRuns(ctx context.Context, dayPath string, dayEntries []os.DirEntry, statusesFilter map[core.Status]struct{}, hasStatusFilter bool) ([]*DAGRun, error) {
+	indexEntries, _, indexErr := dagrunindex.TryLoadForDay(ctx, dayPath, dayEntries)
 	if indexErr == nil && indexEntries != nil && len(indexEntries) == countDAGRunDirs(dayEntries) {
 		runs := make([]*DAGRun, 0, len(indexEntries))
 		for _, indexEntry := range indexEntries {

--- a/internal/service/frontend/sse/dagrun_invalidator.go
+++ b/internal/service/frontend/sse/dagrun_invalidator.go
@@ -6,8 +6,12 @@ package sse
 import (
 	"context"
 	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/core"
 	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
 )
 
@@ -67,21 +71,34 @@ func StartDAGRunEventInvalidation(
 			}
 			cursor = nextCursor
 
-			for _, event := range events {
-				wakeTopicsForDAGRunEvent(mux, event)
-			}
+			wakeTopicsForDAGRunEvents(mux, events)
 		}
 	}()
 }
 
-func wakeTopicsForDAGRunEvent(mux *Multiplexer, event *eventstore.Event) {
-	if mux == nil || event == nil {
+func wakeTopicsForDAGRunEvents(mux *Multiplexer, events []*eventstore.Event) {
+	if mux == nil {
 		return
+	}
+
+	affectedStatuses := make(map[core.Status]struct{})
+	for _, event := range events {
+		for _, status := range wakeTopicsForDAGRunEvent(mux, event) {
+			affectedStatuses[status] = struct{}{}
+		}
+	}
+
+	wakeDAGRunListTopics(mux, affectedStatuses)
+}
+
+func wakeTopicsForDAGRunEvent(mux *Multiplexer, event *eventstore.Event) []core.Status {
+	if event == nil {
+		return nil
 	}
 
 	snapshot, err := eventstore.DAGRunSnapshotFromEvent(event)
 	if err != nil || snapshot == nil {
-		return
+		return nil
 	}
 
 	if snapshot.Name != "" && snapshot.DAGRunID != "" {
@@ -97,9 +114,6 @@ func wakeTopicsForDAGRunEvent(mux *Multiplexer, event *eventstore.Event) {
 		}
 	}
 
-	if event.Type != eventstore.TypeDAGRunUpdated {
-		mux.WakeTopicType(TopicTypeDAGRuns)
-	}
 	mux.WakeTopicType(TopicTypeQueues)
 	mux.WakeTopicType(TopicTypeDAGsList)
 
@@ -107,12 +121,87 @@ func wakeTopicsForDAGRunEvent(mux *Multiplexer, event *eventstore.Event) {
 		mux.WakeTopic(TopicTypeQueueItems, snapshot.ProcGroup)
 	}
 
+	affectedStatuses := affectedDAGRunListStatuses(event.Type, snapshot.Status)
 	if snapshot.DAGFile != "" {
 		mux.WakeTopic(TopicTypeDAG, snapshot.DAGFile)
 		mux.WakeTopic(TopicTypeDAGHistory, snapshot.DAGFile)
-		return
+		return affectedStatuses
 	}
 
 	mux.WakeTopicType(TopicTypeDAG)
 	mux.WakeTopicType(TopicTypeDAGHistory)
+	return affectedStatuses
+}
+
+func affectedDAGRunListStatuses(eventType eventstore.EventType, current core.Status) []core.Status {
+	switch eventType {
+	case eventstore.TypeDAGRunQueued:
+		return []core.Status{
+			core.NotStarted, core.Queued,
+			core.Succeeded, core.PartiallySucceeded, core.Failed, core.Aborted, core.Rejected,
+		}
+	case eventstore.TypeDAGRunRunning:
+		return []core.Status{core.NotStarted, core.Queued, core.Running, core.Waiting}
+	case eventstore.TypeDAGRunWaiting:
+		return []core.Status{core.Running, core.Waiting}
+	case eventstore.TypeDAGRunSucceeded, eventstore.TypeDAGRunPartiallySucceeded:
+		return []core.Status{core.Running, core.Waiting, current}
+	case eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunAborted:
+		return []core.Status{core.NotStarted, core.Queued, core.Running, core.Waiting, current}
+	case eventstore.TypeDAGRunRejected:
+		return []core.Status{core.Waiting, current}
+	case eventstore.TypeDAGRunUpdated, eventstore.TypeLLMUsageRecorded:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func wakeDAGRunListTopics(mux *Multiplexer, affectedStatuses map[core.Status]struct{}) {
+	if len(affectedStatuses) == 0 {
+		return
+	}
+
+	mux.mu.RLock()
+	topics := make([]*multiplexTopic, 0, len(mux.topics))
+	for _, topic := range mux.topics {
+		if topic != nil && topic.topicType == TopicTypeDAGRuns && dagRunListTopicMatchesStatuses(topic.identifier, affectedStatuses) {
+			topics = append(topics, topic)
+		}
+	}
+	mux.mu.RUnlock()
+
+	for _, topic := range topics {
+		topic.requestPoll()
+	}
+}
+
+func dagRunListTopicMatchesStatuses(identifier string, affectedStatuses map[core.Status]struct{}) bool {
+	values, err := url.ParseQuery(identifier)
+	if err != nil {
+		return true
+	}
+	rawStatuses, hasStatusFilter := values["status"]
+	if !hasStatusFilter {
+		return true
+	}
+
+	hasValue := false
+	for _, rawStatus := range rawStatuses {
+		for part := range strings.SplitSeq(rawStatus, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			hasValue = true
+			value, err := strconv.Atoi(part)
+			if err != nil {
+				return true
+			}
+			if _, ok := affectedStatuses[core.Status(value)]; ok {
+				return true
+			}
+		}
+	}
+	return !hasValue
 }

--- a/internal/service/frontend/sse/dagrun_invalidator.go
+++ b/internal/service/frontend/sse/dagrun_invalidator.go
@@ -198,7 +198,11 @@ func dagRunListTopicMatchesStatuses(identifier string, affectedStatuses map[core
 			if err != nil {
 				return true
 			}
-			if _, ok := affectedStatuses[core.Status(value)]; ok {
+			status := core.Status(value)
+			if status < core.NotStarted || status > core.Rejected {
+				return true
+			}
+			if _, ok := affectedStatuses[status]; ok {
 				return true
 			}
 		}

--- a/internal/service/frontend/sse/dagrun_invalidator.go
+++ b/internal/service/frontend/sse/dagrun_invalidator.go
@@ -137,7 +137,7 @@ func affectedDAGRunListStatuses(eventType eventstore.EventType, current core.Sta
 	switch eventType {
 	case eventstore.TypeDAGRunQueued:
 		return []core.Status{
-			core.NotStarted, core.Queued,
+			core.NotStarted, core.Queued, core.Waiting,
 			core.Succeeded, core.PartiallySucceeded, core.Failed, core.Aborted, core.Rejected,
 		}
 	case eventstore.TypeDAGRunRunning:
@@ -146,8 +146,10 @@ func affectedDAGRunListStatuses(eventType eventstore.EventType, current core.Sta
 		return []core.Status{core.Running, core.Waiting}
 	case eventstore.TypeDAGRunSucceeded, eventstore.TypeDAGRunPartiallySucceeded:
 		return []core.Status{core.Running, core.Waiting, current}
-	case eventstore.TypeDAGRunFailed, eventstore.TypeDAGRunAborted:
+	case eventstore.TypeDAGRunFailed:
 		return []core.Status{core.NotStarted, core.Queued, core.Running, core.Waiting, current}
+	case eventstore.TypeDAGRunAborted:
+		return []core.Status{core.NotStarted, core.Queued, core.Running, core.Waiting, core.Failed, current}
 	case eventstore.TypeDAGRunRejected:
 		return []core.Status{core.Waiting, current}
 	case eventstore.TypeDAGRunUpdated, eventstore.TypeLLMUsageRecorded:

--- a/internal/service/frontend/sse/dagrun_invalidator.go
+++ b/internal/service/frontend/sse/dagrun_invalidator.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/core"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
 )
 
@@ -173,8 +174,9 @@ func wakeDAGRunListTopics(mux *Multiplexer, affectedStatuses map[core.Status]str
 	}
 	mux.mu.RUnlock()
 
+	batch := exec.NewDAGRunListReadBatch()
 	for _, topic := range topics {
-		topic.requestPoll()
+		topic.requestPoll(batch)
 	}
 }
 

--- a/internal/service/frontend/sse/dagrun_invalidator_test.go
+++ b/internal/service/frontend/sse/dagrun_invalidator_test.go
@@ -6,6 +6,7 @@ package sse
 import (
 	"context"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
 				nil,
 			)
 
-			wakeTopicsForDAGRunEvent(mux, event)
+			wakeTopicsForDAGRunEvents(mux, []*eventstore.Event{event})
 
 			require.Eventually(t, func() bool {
 				return detailRefreshes.Load() == 1 && listRefreshes.Load() == tt.wantListRefreshes
@@ -88,4 +89,69 @@ func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDAGRunInvalidatorBatchesAndTargetsLifecycleListRefreshes(t *testing.T) {
+	mux := NewMultiplexer(StreamConfig{}, nil)
+	t.Cleanup(mux.Shutdown)
+
+	var counts sync.Map
+	mux.RegisterFetcher(TopicTypeDAGRuns, func(_ context.Context, identifier string) (any, error) {
+		counter, _ := counts.LoadOrStore(identifier, &atomic.Int64{})
+		counter.(*atomic.Int64).Add(1)
+		return nil, nil
+	})
+	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
+
+	topics := []string{
+		"dagruns:status=0&status=5",
+		"dagruns:status=1",
+		"dagruns:status=7",
+		"dagruns:status=4&status=6",
+		"dagruns:status=2&status=3&status=8",
+		"dagruns:workspace=all",
+	}
+	result, err := mux.createSession(context.Background(), httptest.NewRecorder(), topics, 0)
+	require.NoError(t, err)
+	require.NotNil(t, result.session)
+	defer mux.removeSession(result.session)
+
+	events := make([]*eventstore.Event, 0, 2)
+	for _, runID := range []string{"run-1", "run-2"} {
+		events = append(events, eventstore.NewDAGRunEvent(
+			eventstore.Source{Service: eventstore.SourceServiceServer},
+			eventstore.TypeDAGRunRunning,
+			&exec.DAGRunStatus{
+				Name:      "test",
+				DAGRunID:  runID,
+				AttemptID: "attempt-1",
+				Status:    core.Running,
+			},
+			nil,
+		))
+	}
+
+	wakeTopicsForDAGRunEvents(mux, events)
+
+	count := func(identifier string) int64 {
+		counter, ok := counts.Load(identifier)
+		if !ok {
+			return 0
+		}
+		return counter.(*atomic.Int64).Load()
+	}
+	require.Eventually(t, func() bool {
+		return count("status=0&status=5") == 1 &&
+			count("status=1") == 1 &&
+			count("status=7") == 1 &&
+			count("workspace=all") == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Never(t, func() bool {
+		return count("status=0&status=5") > 1 ||
+			count("status=1") > 1 ||
+			count("status=7") > 1 ||
+			count("workspace=all") > 1 ||
+			count("status=4&status=6") != 0 ||
+			count("status=2&status=3&status=8") != 0
+	}, 200*time.Millisecond, 20*time.Millisecond)
 }

--- a/internal/service/frontend/sse/dagrun_invalidator_test.go
+++ b/internal/service/frontend/sse/dagrun_invalidator_test.go
@@ -103,13 +103,29 @@ func TestDAGRunInvalidatorBatchesAndTargetsLifecycleListRefreshes(t *testing.T) 
 	})
 	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
 
-	topics := []string{
-		"dagruns:status=0&status=5",
-		"dagruns:status=1",
-		"dagruns:status=7",
-		"dagruns:status=4&status=6",
-		"dagruns:status=2&status=3&status=8",
-		"dagruns:workspace=all",
+	tests := []struct {
+		topic         string
+		wantRefreshes int64
+	}{
+		{topic: "dagruns:status=0&status=5", wantRefreshes: 1},
+		{topic: "dagruns:status=1", wantRefreshes: 1},
+		{topic: "dagruns:status=7", wantRefreshes: 1},
+		{topic: "dagruns:status=4&status=6"},
+		{topic: "dagruns:status=2&status=3&status=8"},
+		{topic: "dagruns:status=1%2C4", wantRefreshes: 1},
+		{topic: "dagruns:status=4%2C6"},
+		{topic: "dagruns:status=+1+", wantRefreshes: 1},
+		{topic: "dagruns:status=running", wantRefreshes: 1},
+		{topic: "dagruns:status=999", wantRefreshes: 1},
+		{topic: "dagruns:workspace=all", wantRefreshes: 1},
+	}
+	topics := make([]string, 0, len(tests))
+	identifiers := make([]string, 0, len(tests))
+	for _, tt := range tests {
+		topics = append(topics, tt.topic)
+		parsed, err := ParseTopic(tt.topic)
+		require.NoError(t, err)
+		identifiers = append(identifiers, parsed.Identifier)
 	}
 	result, err := mux.createSession(context.Background(), httptest.NewRecorder(), topics, 0)
 	require.NoError(t, err)
@@ -141,17 +157,19 @@ func TestDAGRunInvalidatorBatchesAndTargetsLifecycleListRefreshes(t *testing.T) 
 		return counter.(*atomic.Int64).Load()
 	}
 	require.Eventually(t, func() bool {
-		return count("status=0&status=5") == 1 &&
-			count("status=1") == 1 &&
-			count("status=7") == 1 &&
-			count("workspace=all") == 1
+		for i, tt := range tests {
+			if tt.wantRefreshes > 0 && count(identifiers[i]) != tt.wantRefreshes {
+				return false
+			}
+		}
+		return true
 	}, time.Second, 10*time.Millisecond)
 	require.Never(t, func() bool {
-		return count("status=0&status=5") > 1 ||
-			count("status=1") > 1 ||
-			count("status=7") > 1 ||
-			count("workspace=all") > 1 ||
-			count("status=4&status=6") != 0 ||
-			count("status=2&status=3&status=8") != 0
+		for i, tt := range tests {
+			if count(identifiers[i]) != tt.wantRefreshes {
+				return true
+			}
+		}
+		return false
 	}, 200*time.Millisecond, 20*time.Millisecond)
 }

--- a/internal/service/frontend/sse/dagrun_invalidator_test.go
+++ b/internal/service/frontend/sse/dagrun_invalidator_test.go
@@ -6,6 +6,7 @@ package sse
 import (
 	"context"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,16 +22,36 @@ func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
 	tests := []struct {
 		name              string
 		eventType         eventstore.EventType
+		currentStatus     core.Status
+		filterStatus      core.Status
 		wantListRefreshes int64
 	}{
 		{
 			name:              "progress update",
 			eventType:         eventstore.TypeDAGRunUpdated,
+			currentStatus:     core.Running,
+			filterStatus:      core.Running,
 			wantListRefreshes: 0,
 		},
 		{
 			name:              "lifecycle update",
 			eventType:         eventstore.TypeDAGRunRunning,
+			currentStatus:     core.Running,
+			filterStatus:      core.Running,
+			wantListRefreshes: 1,
+		},
+		{
+			name:              "human task resumed",
+			eventType:         eventstore.TypeDAGRunQueued,
+			currentStatus:     core.Queued,
+			filterStatus:      core.Waiting,
+			wantListRefreshes: 1,
+		},
+		{
+			name:              "failed auto retry canceled",
+			eventType:         eventstore.TypeDAGRunAborted,
+			currentStatus:     core.Aborted,
+			filterStatus:      core.Failed,
 			wantListRefreshes: 1,
 		},
 	}
@@ -57,7 +78,7 @@ func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
 			result, err := mux.createSession(
 				context.Background(),
 				httptest.NewRecorder(),
-				[]string{"dagrun:test/run-1", "dagruns:status=running"},
+				[]string{"dagrun:test/run-1", "dagruns:status=" + strconv.Itoa(int(tt.filterStatus))},
 				0,
 			)
 			require.NoError(t, err)
@@ -68,7 +89,7 @@ func TestDAGRunInvalidatorRefreshesListsOnlyForLifecycleEvents(t *testing.T) {
 				Name:      "test",
 				DAGRunID:  "run-1",
 				AttemptID: "attempt-1",
-				Status:    core.Running,
+				Status:    tt.currentStatus,
 			}
 			event := eventstore.NewDAGRunEvent(
 				eventstore.Source{Service: eventstore.SourceServiceServer},

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/backoff"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/google/uuid"
 )
 
@@ -209,8 +210,12 @@ func (m *Multiplexer) WakeTopicType(topicType TopicType) {
 	}
 	m.mu.RUnlock()
 
+	var batch *exec.DAGRunListReadBatch
+	if topicType == TopicTypeDAGRuns {
+		batch = exec.NewDAGRunListReadBatch()
+	}
 	for _, topic := range topics {
-		topic.requestPoll()
+		topic.requestPoll(batch)
 	}
 }
 
@@ -221,7 +226,11 @@ func (m *Multiplexer) wakeTopicKey(key string) {
 	if topic == nil {
 		return
 	}
-	topic.requestPoll()
+	var batch *exec.DAGRunListReadBatch
+	if topic.topicType == TopicTypeDAGRuns {
+		batch = exec.NewDAGRunListReadBatch()
+	}
+	topic.requestPoll(batch)
 }
 
 // Shutdown stops all multiplexed sessions and topic watchers.
@@ -794,6 +803,7 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 		return topic.topicType != TopicTypeDAGRuns
 	})
 	if allDAGRuns {
+		ctx = exec.WithDAGRunListReadBatch(ctx, exec.NewDAGRunListReadBatch())
 		type snapshotResult struct {
 			payload         []byte
 			attachmentID    uint64
@@ -1074,7 +1084,10 @@ type multiplexTopic struct {
 	nextAttachmentID         uint64
 	lastChangeEventID        uint64
 	stopCh                   chan struct{}
+	notifyMu                 sync.Mutex
 	notifyCh                 chan struct{}
+	pendingBatch             *exec.DAGRunListReadBatch
+	pollPending              bool
 	wg                       sync.WaitGroup
 	errorBackoff             backoff.Retrier
 	backoffUntil             time.Time
@@ -1193,7 +1206,7 @@ func (t *multiplexTopic) start() {
 				return
 			case <-timerCh:
 				timerCh = nil
-				t.poll(false)
+				t.poll(false, nil)
 				if delay, shouldRetry := t.nextRetryDelay(); shouldRetry {
 					t.resetTimer(timer, &timerCh, delay)
 					continue
@@ -1202,7 +1215,7 @@ func (t *multiplexTopic) start() {
 					t.resetTimer(timer, &timerCh, t.currentInterval)
 				}
 			case <-t.notifyCh:
-				t.poll(t.publishOnWake)
+				t.poll(t.publishOnWake, t.takePendingBatch())
 				if delay, shouldRetry := t.nextRetryDelay(); shouldRetry {
 					t.resetTimer(timer, &timerCh, delay)
 					continue
@@ -1226,11 +1239,25 @@ func (t *multiplexTopic) stop() {
 	t.wg.Wait()
 }
 
-func (t *multiplexTopic) requestPoll() {
-	select {
-	case t.notifyCh <- struct{}{}:
-	default:
+func (t *multiplexTopic) requestPoll(batch *exec.DAGRunListReadBatch) {
+	t.notifyMu.Lock()
+	t.pendingBatch = batch
+	if t.pollPending {
+		t.notifyMu.Unlock()
+		return
 	}
+	t.pollPending = true
+	t.notifyMu.Unlock()
+	t.notifyCh <- struct{}{}
+}
+
+func (t *multiplexTopic) takePendingBatch() *exec.DAGRunListReadBatch {
+	t.notifyMu.Lock()
+	defer t.notifyMu.Unlock()
+	batch := t.pendingBatch
+	t.pendingBatch = nil
+	t.pollPending = false
+	return batch
 }
 
 func (t *multiplexTopic) stopTimer(timer *time.Timer, timerCh *<-chan time.Time) {
@@ -1257,7 +1284,7 @@ func (t *multiplexTopic) nextRetryDelay() (time.Duration, bool) {
 	return delay, true
 }
 
-func (t *multiplexTopic) poll(forcePublish bool) {
+func (t *multiplexTopic) poll(forcePublish bool, batch *exec.DAGRunListReadBatch) {
 	if time.Now().Before(t.backoffUntil) {
 		return
 	}
@@ -1275,7 +1302,11 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 
 	for _, session := range sessions {
 		start := time.Now()
-		payload, err := t.fetchPayload(session.fetchCtx)
+		fetchCtx := session.fetchCtx
+		if batch != nil {
+			fetchCtx = exec.WithDAGRunListReadBatch(fetchCtx, batch)
+		}
+		payload, err := t.fetchPayload(fetchCtx)
 		fetchDuration := time.Since(start)
 		if err != nil {
 			if firstErr == nil {

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -793,13 +793,24 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 		return topic.topicType != TopicTypeDAGRuns
 	})
 	if allDAGRuns {
+		type snapshotResult struct {
+			payload []byte
+			err     error
+		}
+		results := make([]snapshotResult, len(eligible))
 		var wg sync.WaitGroup
-		for _, topic := range eligible {
+		for i, topic := range eligible {
 			wg.Go(func() {
-				_ = topic.sendSnapshot(ctx, s, s.mux.nextID())
+				results[i].payload, results[i].err = topic.fetchPayload(ctx)
 			})
 		}
 		wg.Wait()
+		for i, result := range results {
+			if result.err != nil {
+				continue
+			}
+			_ = eligible[i].sendSnapshotPayload(s, s.mux.nextID(), result.payload)
+		}
 		return
 	}
 
@@ -1294,6 +1305,10 @@ func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSessio
 	if err != nil {
 		return err
 	}
+	return t.sendSnapshotPayload(session, eventID, payload)
+}
+
+func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, eventID uint64, payload []byte) error {
 	hash := computeHash(payload)
 	t.clientsMu.Lock()
 	if _, ok := t.sessions[session]; !ok {

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -707,6 +707,7 @@ type streamSession struct {
 	slowClientTimeout time.Duration
 
 	mutationMu      sync.Mutex
+	publishMu       sync.Mutex
 	mu              sync.Mutex
 	closed          bool
 	topics          map[string]*multiplexTopic
@@ -809,13 +810,13 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 			if result.err != nil {
 				continue
 			}
-			_ = eligible[i].sendSnapshotPayload(s, s.mux.nextID(), result.payload)
+			_ = eligible[i].sendSnapshotPayload(s, result.payload)
 		}
 		return
 	}
 
 	for _, topic := range eligible {
-		if err := topic.sendSnapshot(ctx, s, s.mux.nextID()); err != nil {
+		if err := topic.sendSnapshot(ctx, s); err != nil {
 			continue
 		}
 	}
@@ -854,6 +855,14 @@ func (s *streamSession) enqueueMessage(topic string, eventID uint64, data []byte
 		existing.data = data
 		existing.size = size
 		s.queuedBytes += size
+		for i, msg := range s.queue {
+			if msg != existing {
+				continue
+			}
+			copy(s.queue[i:], s.queue[i+1:])
+			s.queue[len(s.queue)-1] = existing
+			break
+		}
 		for s.queuedBytes > s.writeBufferSize {
 			if !s.dropOldestExcept(topic) {
 				s.closed = true
@@ -1258,25 +1267,29 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		}
 
 		hash := computeHash(payload)
+		data, err := buildMessageData(t.key, payload)
+		if err != nil {
+			continue
+		}
+
+		session.publishMu.Lock()
 		t.clientsMu.Lock()
 		if _, ok := t.sessions[session]; !ok {
 			t.clientsMu.Unlock()
+			session.publishMu.Unlock()
 			continue
 		}
 		if hash == t.lastHashBySession[session] && !forcePublish {
 			t.clientsMu.Unlock()
+			session.publishMu.Unlock()
 			continue
 		}
 		t.lastHashBySession[session] = hash
 		eventID := t.mux.nextID()
 		t.lastChangeEventID = eventID
 		t.clientsMu.Unlock()
-
-		data, err := buildMessageData(t.key, payload)
-		if err != nil {
-			continue
-		}
 		session.enqueueMessage(t.key, eventID, data)
+		session.publishMu.Unlock()
 	}
 
 	if firstErr != nil && t.mux.metrics != nil {
@@ -1300,30 +1313,35 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 	)
 }
 
-func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSession, eventID uint64) error {
+func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSession) error {
 	payload, err := t.fetchPayload(ctx)
 	if err != nil {
 		return err
 	}
-	return t.sendSnapshotPayload(session, eventID, payload)
+	return t.sendSnapshotPayload(session, payload)
 }
 
-func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, eventID uint64, payload []byte) error {
+func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []byte) error {
 	hash := computeHash(payload)
+	data, err := buildMessageData(t.key, payload)
+	if err != nil {
+		return err
+	}
+
+	session.publishMu.Lock()
+	defer session.publishMu.Unlock()
+
 	t.clientsMu.Lock()
 	if _, ok := t.sessions[session]; !ok {
 		t.clientsMu.Unlock()
 		return nil
 	}
 	t.lastHashBySession[session] = hash
+	eventID := t.mux.nextID()
 	if t.lastChangeEventID == 0 {
 		t.lastChangeEventID = eventID
 	}
 	t.clientsMu.Unlock()
-	data, err := buildMessageData(t.key, payload)
-	if err != nil {
-		return err
-	}
 	session.enqueueMessage(t.key, eventID, data)
 	return nil
 }

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -780,10 +780,30 @@ func (s *streamSession) topicKeys() []string {
 }
 
 func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64, topics []*multiplexTopic) {
+	eligible := make([]*multiplexTopic, 0, len(topics))
 	for _, topic := range topics {
 		if lastEventID > 0 && !topic.changedSince(lastEventID) {
 			continue
 		}
+		eligible = append(eligible, topic)
+	}
+
+	// A list-only bootstrap can share one day load; mixed topic batches retain their ordering.
+	allDAGRuns := len(eligible) > 1 && !slices.ContainsFunc(eligible, func(topic *multiplexTopic) bool {
+		return topic.topicType != TopicTypeDAGRuns
+	})
+	if allDAGRuns {
+		var wg sync.WaitGroup
+		for _, topic := range eligible {
+			wg.Go(func() {
+				_ = topic.sendSnapshot(ctx, s, s.mux.nextID())
+			})
+		}
+		wg.Wait()
+		return
+	}
+
+	for _, topic := range eligible {
 		if err := topic.sendSnapshot(ctx, s, s.mux.nextID()); err != nil {
 			continue
 		}

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -795,13 +795,15 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 	})
 	if allDAGRuns {
 		type snapshotResult struct {
-			payload []byte
-			err     error
+			payload         []byte
+			lastPublishedID uint64
+			err             error
 		}
 		results := make([]snapshotResult, len(eligible))
 		var wg sync.WaitGroup
 		for i, topic := range eligible {
 			wg.Go(func() {
+				results[i].lastPublishedID = topic.lastPublishedID(s)
 				results[i].payload, results[i].err = topic.fetchPayload(ctx)
 			})
 		}
@@ -810,7 +812,7 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 			if result.err != nil {
 				continue
 			}
-			_ = eligible[i].sendSnapshotPayload(s, result.payload)
+			_ = eligible[i].sendSnapshotPayload(s, result.payload, result.lastPublishedID)
 		}
 		return
 	}
@@ -1050,24 +1052,25 @@ func (s *streamSession) Serve(ctx context.Context) error {
 }
 
 type multiplexTopic struct {
-	mux               *Multiplexer
-	key               string
-	topicType         TopicType
-	identifier        string
-	fetcher           FetchFunc
-	refreshMode       TopicRefreshMode
-	publishOnWake     bool
-	clientsMu         sync.RWMutex
-	sessions          map[*streamSession]struct{}
-	retiring          bool
-	lastHashBySession map[*streamSession]string
-	lastChangeEventID uint64
-	stopCh            chan struct{}
-	notifyCh          chan struct{}
-	wg                sync.WaitGroup
-	errorBackoff      backoff.Retrier
-	backoffUntil      time.Time
-	currentInterval   time.Duration
+	mux                      *Multiplexer
+	key                      string
+	topicType                TopicType
+	identifier               string
+	fetcher                  FetchFunc
+	refreshMode              TopicRefreshMode
+	publishOnWake            bool
+	clientsMu                sync.RWMutex
+	sessions                 map[*streamSession]struct{}
+	retiring                 bool
+	lastHashBySession        map[*streamSession]string
+	lastPublishedIDBySession map[*streamSession]uint64
+	lastChangeEventID        uint64
+	stopCh                   chan struct{}
+	notifyCh                 chan struct{}
+	wg                       sync.WaitGroup
+	errorBackoff             backoff.Retrier
+	backoffUntil             time.Time
+	currentInterval          time.Duration
 }
 
 func newMultiplexTopic(
@@ -1081,19 +1084,20 @@ func newMultiplexTopic(
 	policy.MaxInterval = 30 * time.Second
 
 	return &multiplexTopic{
-		mux:               mux,
-		key:               parsed.Key,
-		topicType:         parsed.Type,
-		identifier:        parsed.Identifier,
-		fetcher:           fetcher,
-		refreshMode:       refreshMode,
-		publishOnWake:     publishOnWake,
-		sessions:          make(map[*streamSession]struct{}),
-		lastHashBySession: make(map[*streamSession]string),
-		stopCh:            make(chan struct{}),
-		notifyCh:          make(chan struct{}, 1),
-		errorBackoff:      backoff.NewRetrier(policy),
-		currentInterval:   mux.watcherBaseInterval,
+		mux:                      mux,
+		key:                      parsed.Key,
+		topicType:                parsed.Type,
+		identifier:               parsed.Identifier,
+		fetcher:                  fetcher,
+		refreshMode:              refreshMode,
+		publishOnWake:            publishOnWake,
+		sessions:                 make(map[*streamSession]struct{}),
+		lastHashBySession:        make(map[*streamSession]string),
+		lastPublishedIDBySession: make(map[*streamSession]uint64),
+		stopCh:                   make(chan struct{}),
+		notifyCh:                 make(chan struct{}, 1),
+		errorBackoff:             backoff.NewRetrier(policy),
+		currentInterval:          mux.watcherBaseInterval,
 	}
 }
 
@@ -1119,6 +1123,13 @@ func (t *multiplexTopic) removeSession(session *streamSession) {
 	defer t.clientsMu.Unlock()
 	delete(t.sessions, session)
 	delete(t.lastHashBySession, session)
+	delete(t.lastPublishedIDBySession, session)
+}
+
+func (t *multiplexTopic) lastPublishedID(session *streamSession) uint64 {
+	t.clientsMu.RLock()
+	defer t.clientsMu.RUnlock()
+	return t.lastPublishedIDBySession[session]
 }
 
 func (t *multiplexTopic) sessionCount() int {
@@ -1286,6 +1297,7 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 		}
 		t.lastHashBySession[session] = hash
 		eventID := t.mux.nextID()
+		t.lastPublishedIDBySession[session] = eventID
 		t.lastChangeEventID = eventID
 		t.clientsMu.Unlock()
 		session.enqueueMessage(t.key, eventID, data)
@@ -1314,14 +1326,15 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 }
 
 func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSession) error {
+	lastPublishedID := t.lastPublishedID(session)
 	payload, err := t.fetchPayload(ctx)
 	if err != nil {
 		return err
 	}
-	return t.sendSnapshotPayload(session, payload)
+	return t.sendSnapshotPayload(session, payload, lastPublishedID)
 }
 
-func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []byte) error {
+func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []byte, lastPublishedID uint64) error {
 	hash := computeHash(payload)
 	data, err := buildMessageData(t.key, payload)
 	if err != nil {
@@ -1336,8 +1349,13 @@ func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []b
 		t.clientsMu.Unlock()
 		return nil
 	}
+	if t.lastPublishedIDBySession[session] != lastPublishedID {
+		t.clientsMu.Unlock()
+		return nil
+	}
 	t.lastHashBySession[session] = hash
 	eventID := t.mux.nextID()
+	t.lastPublishedIDBySession[session] = eventID
 	if t.lastChangeEventID == 0 {
 		t.lastChangeEventID = eventID
 	}

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -796,6 +796,7 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 	if allDAGRuns {
 		type snapshotResult struct {
 			payload         []byte
+			attachmentID    uint64
 			lastPublishedID uint64
 			err             error
 		}
@@ -803,7 +804,7 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 		var wg sync.WaitGroup
 		for i, topic := range eligible {
 			wg.Go(func() {
-				results[i].lastPublishedID = topic.lastPublishedID(s)
+				results[i].attachmentID, results[i].lastPublishedID = topic.snapshotState(s)
 				results[i].payload, results[i].err = topic.fetchPayload(ctx)
 			})
 		}
@@ -812,7 +813,12 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 			if result.err != nil {
 				continue
 			}
-			_ = eligible[i].sendSnapshotPayload(s, result.payload, result.lastPublishedID)
+			_ = eligible[i].sendSnapshotPayload(
+				s,
+				result.payload,
+				result.attachmentID,
+				result.lastPublishedID,
+			)
 		}
 		return
 	}
@@ -1064,6 +1070,8 @@ type multiplexTopic struct {
 	retiring                 bool
 	lastHashBySession        map[*streamSession]string
 	lastPublishedIDBySession map[*streamSession]uint64
+	attachmentIDBySession    map[*streamSession]uint64
+	nextAttachmentID         uint64
 	lastChangeEventID        uint64
 	stopCh                   chan struct{}
 	notifyCh                 chan struct{}
@@ -1094,6 +1102,7 @@ func newMultiplexTopic(
 		sessions:                 make(map[*streamSession]struct{}),
 		lastHashBySession:        make(map[*streamSession]string),
 		lastPublishedIDBySession: make(map[*streamSession]uint64),
+		attachmentIDBySession:    make(map[*streamSession]uint64),
 		stopCh:                   make(chan struct{}),
 		notifyCh:                 make(chan struct{}, 1),
 		errorBackoff:             backoff.NewRetrier(policy),
@@ -1111,7 +1120,9 @@ func (t *multiplexTopic) addSession(session *streamSession) bool {
 	if _, exists := t.sessions[session]; exists {
 		return true
 	}
+	t.nextAttachmentID++
 	t.sessions[session] = struct{}{}
+	t.attachmentIDBySession[session] = t.nextAttachmentID
 	if len(t.sessions) == 1 {
 		t.start()
 	}
@@ -1124,12 +1135,13 @@ func (t *multiplexTopic) removeSession(session *streamSession) {
 	delete(t.sessions, session)
 	delete(t.lastHashBySession, session)
 	delete(t.lastPublishedIDBySession, session)
+	delete(t.attachmentIDBySession, session)
 }
 
-func (t *multiplexTopic) lastPublishedID(session *streamSession) uint64 {
+func (t *multiplexTopic) snapshotState(session *streamSession) (uint64, uint64) {
 	t.clientsMu.RLock()
 	defer t.clientsMu.RUnlock()
-	return t.lastPublishedIDBySession[session]
+	return t.attachmentIDBySession[session], t.lastPublishedIDBySession[session]
 }
 
 func (t *multiplexTopic) sessionCount() int {
@@ -1326,15 +1338,20 @@ func (t *multiplexTopic) poll(forcePublish bool) {
 }
 
 func (t *multiplexTopic) sendSnapshot(ctx context.Context, session *streamSession) error {
-	lastPublishedID := t.lastPublishedID(session)
+	attachmentID, lastPublishedID := t.snapshotState(session)
 	payload, err := t.fetchPayload(ctx)
 	if err != nil {
 		return err
 	}
-	return t.sendSnapshotPayload(session, payload, lastPublishedID)
+	return t.sendSnapshotPayload(session, payload, attachmentID, lastPublishedID)
 }
 
-func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []byte, lastPublishedID uint64) error {
+func (t *multiplexTopic) sendSnapshotPayload(
+	session *streamSession,
+	payload []byte,
+	attachmentID uint64,
+	lastPublishedID uint64,
+) error {
 	hash := computeHash(payload)
 	data, err := buildMessageData(t.key, payload)
 	if err != nil {
@@ -1346,6 +1363,10 @@ func (t *multiplexTopic) sendSnapshotPayload(session *streamSession, payload []b
 
 	t.clientsMu.Lock()
 	if _, ok := t.sessions[session]; !ok {
+		t.clientsMu.Unlock()
+		return nil
+	}
+	if t.attachmentIDBySession[session] != attachmentID {
 		t.clientsMu.Unlock()
 		return nil
 	}

--- a/internal/service/frontend/sse/multiplex.go
+++ b/internal/service/frontend/sse/multiplex.go
@@ -811,10 +811,13 @@ func (s *streamSession) bootstrapTopics(ctx context.Context, lastEventID uint64,
 			err             error
 		}
 		results := make([]snapshotResult, len(eligible))
+		for i, topic := range eligible {
+			results[i].attachmentID, results[i].lastPublishedID = topic.snapshotState(s)
+		}
+
 		var wg sync.WaitGroup
 		for i, topic := range eligible {
 			wg.Go(func() {
-				results[i].attachmentID, results[i].lastPublishedID = topic.snapshotState(s)
 				results[i].payload, results[i].err = topic.fetchPayload(ctx)
 			})
 		}

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -187,6 +187,78 @@ func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) 
 	assert.Equal(t, 2, envelope.Payload.Revision)
 }
 
+func TestStreamSessionIgnoresBootstrapFromPreviousTopicAttachment(t *testing.T) {
+	const timeout = 5 * time.Second
+	const topicKey = "dagruns:status=4"
+
+	mux := NewMultiplexer(StreamConfig{}, nil)
+	t.Cleanup(mux.Shutdown)
+
+	started := make(chan struct{})
+	releaseBootstrap := make(chan struct{})
+	var calls atomic.Int32
+	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, _ string) (any, error) {
+		revision := calls.Add(1)
+		if revision == 1 {
+			close(started)
+			select {
+			case <-releaseBootstrap:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		return map[string]any{"revision": revision}, nil
+	})
+	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
+
+	result, err := mux.createSession(context.Background(), httptest.NewRecorder(), []string{topicKey}, 0)
+	require.NoError(t, err)
+	defer mux.removeSession(result.session)
+
+	holder, err := mux.createSession(context.Background(), httptest.NewRecorder(), []string{topicKey}, 0)
+	require.NoError(t, err)
+	defer mux.removeSession(holder.session)
+
+	done := make(chan struct{})
+	go func() {
+		result.session.bootstrapTopics(t.Context(), 0, result.topics)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(timeout):
+		require.FailNow(t, "initial snapshot did not start")
+	}
+
+	_, err = mux.mutateSession(t.Context(), result.session.id, nil, []string{topicKey})
+	require.NoError(t, err)
+	mutation, err := mux.mutateSession(t.Context(), result.session.id, []string{topicKey}, nil)
+	require.NoError(t, err)
+	require.Len(t, mutation.added, 1)
+	result.session.bootstrapTopics(t.Context(), 0, mutation.added)
+
+	close(releaseBootstrap)
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		require.FailNow(t, "initial snapshot did not finish")
+	}
+
+	message := result.session.popNext()
+	require.NotNil(t, message)
+	assert.Equal(t, topicKey, message.topic)
+	assert.Nil(t, result.session.popNext())
+
+	var envelope struct {
+		Payload struct {
+			Revision int `json:"revision"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(message.data, &envelope))
+	assert.Equal(t, 2, envelope.Payload.Revision)
+}
+
 func TestMultiplexerCreateSessionFiltersUnsupportedTopics(t *testing.T) {
 	mux := NewMultiplexer(StreamConfig{}, nil)
 	t.Cleanup(mux.Shutdown)

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -10,15 +10,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/remotenode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
 )
 
 func TestParseTopicCanonicalizesQuery(t *testing.T) {
@@ -108,20 +111,31 @@ func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) 
 	mux := NewMultiplexer(StreamConfig{}, nil)
 	t.Cleanup(mux.Shutdown)
 
-	started := make(chan string, 2)
-	releaseBootstrap := make(chan struct{}, 2)
-	var status4Calls atomic.Int32
+	started := make(chan struct{})
+	releaseBootstrap := make(chan struct{})
+	var dayLoads atomic.Int32
+	var dayLoadGroup singleflight.Group
 	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, identifier string) (any, error) {
-		if identifier == "status=4" && status4Calls.Add(1) > 1 {
-			return map[string]any{"id": identifier, "revision": 2}, nil
+		batchID, ok := exec.DAGRunListReadBatchID(ctx)
+		if !ok {
+			return nil, errors.New("missing DAG-run list read batch")
 		}
-		started <- identifier
-		select {
-		case <-releaseBootstrap:
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		value, err, _ := dayLoadGroup.Do(strconv.FormatUint(batchID, 10), func() (any, error) {
+			revision := dayLoads.Add(1)
+			if revision == 1 {
+				close(started)
+				select {
+				case <-releaseBootstrap:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return revision, nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return map[string]any{"id": identifier, "revision": 1}, nil
+		return map[string]any{"id": identifier, "revision": value}, nil
 	})
 	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
 
@@ -141,12 +155,10 @@ func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) 
 		close(done)
 	}()
 
-	for range 2 {
-		select {
-		case <-started:
-		case <-time.After(timeout):
-			require.FailNow(t, "DAG-run snapshots did not start together")
-		}
+	select {
+	case <-started:
+	case <-time.After(timeout):
+		require.FailNow(t, "DAG-run snapshot bootstrap did not start")
 	}
 
 	mux.WakeTopic(TopicTypeDAGRuns, "status=4")
@@ -156,8 +168,7 @@ func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) 
 		return len(result.session.queue) == 1 && result.session.queue[0].topic == "dagruns:status=4"
 	}, timeout, 10*time.Millisecond)
 
-	releaseBootstrap <- struct{}{}
-	releaseBootstrap <- struct{}{}
+	close(releaseBootstrap)
 
 	select {
 	case <-done:
@@ -185,6 +196,7 @@ func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) 
 	}
 	require.NoError(t, json.Unmarshal(status4Message.data, &envelope))
 	assert.Equal(t, 2, envelope.Payload.Revision)
+	assert.EqualValues(t, 2, dayLoads.Load())
 }
 
 func TestStreamSessionIgnoresBootstrapFromPreviousTopicAttachment(t *testing.T) {

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -102,7 +102,7 @@ func TestMultiplexerCreateSessionFiltersUnauthorizedTopics(t *testing.T) {
 	assert.Equal(t, "queueitems:default", result.control.Errors[0].Topic)
 }
 
-func TestStreamSessionPublishesConcurrentDAGRunBootstrapInOrder(t *testing.T) {
+func TestStreamSessionKeepsWakeNewerThanConcurrentDAGRunBootstrap(t *testing.T) {
 	const timeout = 5 * time.Second
 
 	mux := NewMultiplexer(StreamConfig{}, nil)
@@ -169,9 +169,22 @@ func TestStreamSessionPublishesConcurrentDAGRunBootstrapInOrder(t *testing.T) {
 	second := result.session.popNext()
 	require.NotNil(t, first)
 	require.NotNil(t, second)
-	assert.Equal(t, "dagruns:status=1", first.topic)
-	assert.Equal(t, "dagruns:status=4", second.topic)
 	assert.Less(t, first.eventID, second.eventID)
+
+	messages := map[string]*queuedMessage{
+		first.topic:  first,
+		second.topic: second,
+	}
+	require.Contains(t, messages, "dagruns:status=1")
+	require.Contains(t, messages, "dagruns:status=4")
+	status4Message := messages["dagruns:status=4"]
+	var envelope struct {
+		Payload struct {
+			Revision int `json:"revision"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(status4Message.data, &envelope))
+	assert.Equal(t, 2, envelope.Payload.Revision)
 }
 
 func TestMultiplexerCreateSessionFiltersUnsupportedTopics(t *testing.T) {

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -102,26 +102,26 @@ func TestMultiplexerCreateSessionFiltersUnauthorizedTopics(t *testing.T) {
 	assert.Equal(t, "queueitems:default", result.control.Errors[0].Topic)
 }
 
-func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
+func TestStreamSessionPublishesConcurrentDAGRunBootstrapInOrder(t *testing.T) {
 	const timeout = 5 * time.Second
 
 	mux := NewMultiplexer(StreamConfig{}, nil)
 	t.Cleanup(mux.Shutdown)
 
 	started := make(chan string, 2)
-	fastDone := make(chan struct{})
+	releaseBootstrap := make(chan struct{}, 2)
+	var status4Calls atomic.Int32
 	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, identifier string) (any, error) {
-		started <- identifier
-		if identifier == "status=1" {
-			select {
-			case <-fastDone:
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-		} else {
-			close(fastDone)
+		if identifier == "status=4" && status4Calls.Add(1) > 1 {
+			return map[string]any{"id": identifier, "revision": 2}, nil
 		}
-		return map[string]string{"id": identifier}, nil
+		started <- identifier
+		select {
+		case <-releaseBootstrap:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return map[string]any{"id": identifier, "revision": 1}, nil
 	})
 	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
 
@@ -148,6 +148,16 @@ func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
 			require.FailNow(t, "DAG-run snapshots did not start together")
 		}
 	}
+
+	mux.WakeTopic(TopicTypeDAGRuns, "status=4")
+	require.Eventually(t, func() bool {
+		result.session.mu.Lock()
+		defer result.session.mu.Unlock()
+		return len(result.session.queue) == 1 && result.session.queue[0].topic == "dagruns:status=4"
+	}, timeout, 10*time.Millisecond)
+
+	releaseBootstrap <- struct{}{}
+	releaseBootstrap <- struct{}{}
 
 	select {
 	case <-done:
@@ -362,7 +372,7 @@ func TestMultiplexTopicSendSnapshotDropsRemovedTopics(t *testing.T) {
 	require.True(t, session.addTopic(topic))
 
 	require.NotNil(t, session.removeTopic(parsed.Key))
-	require.NoError(t, topic.sendSnapshot(context.Background(), session, 1))
+	require.NoError(t, topic.sendSnapshot(context.Background(), session))
 	assert.Nil(t, session.popNext())
 }
 
@@ -517,7 +527,7 @@ func TestMultiplexerOnDemandTopicOnlyRefetchesOnWake(t *testing.T) {
 
 	topic := mux.topics["dagrun:test/run-1"]
 	require.NotNil(t, topic)
-	require.NoError(t, topic.sendSnapshot(context.Background(), result.session, 1))
+	require.NoError(t, topic.sendSnapshot(context.Background(), result.session))
 	assert.EqualValues(t, 1, fetches.Load())
 
 	require.Never(t, func() bool {
@@ -614,7 +624,7 @@ func TestMultiplexerPublishOnWakeEmitsMessageEvenWhenPayloadHashIsUnchanged(t *t
 	topic := mux.topics["dagruns:fromDate=1&toDate=2"]
 	require.NotNil(t, topic)
 
-	require.NoError(t, topic.sendSnapshot(context.Background(), result.session, 1))
+	require.NoError(t, topic.sendSnapshot(context.Background(), result.session))
 	first := result.session.popNext()
 	require.NotNil(t, first)
 

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,18 +109,19 @@ func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
 	t.Cleanup(mux.Shutdown)
 
 	started := make(chan string, 2)
-	releaseCh := make(chan struct{})
-	release := sync.OnceFunc(func() { close(releaseCh) })
-	t.Cleanup(release)
-
+	fastDone := make(chan struct{})
 	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, identifier string) (any, error) {
 		started <- identifier
-		select {
-		case <-releaseCh:
-			return map[string]string{"id": identifier}, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		if identifier == "status=1" {
+			select {
+			case <-fastDone:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		} else {
+			close(fastDone)
 		}
+		return map[string]string{"id": identifier}, nil
 	})
 	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
 
@@ -137,7 +137,7 @@ func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		result.session.bootstrapTopics(context.Background(), 0, result.topics)
+		result.session.bootstrapTopics(t.Context(), 0, result.topics)
 		close(done)
 	}()
 
@@ -148,13 +148,20 @@ func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
 			require.FailNow(t, "DAG-run snapshots did not start together")
 		}
 	}
-	release()
 
 	select {
 	case <-done:
 	case <-time.After(timeout):
 		require.FailNow(t, "DAG-run snapshot bootstrap did not finish")
 	}
+
+	first := result.session.popNext()
+	second := result.session.popNext()
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	assert.Equal(t, "dagruns:status=1", first.topic)
+	assert.Equal(t, "dagruns:status=4", second.topic)
+	assert.Less(t, first.eventID, second.eventID)
 }
 
 func TestMultiplexerCreateSessionFiltersUnsupportedTopics(t *testing.T) {

--- a/internal/service/frontend/sse/multiplex_test.go
+++ b/internal/service/frontend/sse/multiplex_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,6 +101,60 @@ func TestMultiplexerCreateSessionFiltersUnauthorizedTopics(t *testing.T) {
 	assert.Equal(t, []string{"dag:test.yaml"}, result.control.Subscribed)
 	require.Len(t, result.control.Errors, 1)
 	assert.Equal(t, "queueitems:default", result.control.Errors[0].Topic)
+}
+
+func TestStreamSessionBootstrapsDAGRunsTogether(t *testing.T) {
+	const timeout = 5 * time.Second
+
+	mux := NewMultiplexer(StreamConfig{}, nil)
+	t.Cleanup(mux.Shutdown)
+
+	started := make(chan string, 2)
+	releaseCh := make(chan struct{})
+	release := sync.OnceFunc(func() { close(releaseCh) })
+	t.Cleanup(release)
+
+	mux.RegisterFetcher(TopicTypeDAGRuns, func(ctx context.Context, identifier string) (any, error) {
+		started <- identifier
+		select {
+		case <-releaseCh:
+			return map[string]string{"id": identifier}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+	mux.SetRefreshMode(TopicTypeDAGRuns, TopicRefreshModeOnDemand)
+
+	result, err := mux.createSession(
+		context.Background(),
+		httptest.NewRecorder(),
+		[]string{"dagruns:status=1", "dagruns:status=4"},
+		0,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result.session)
+	defer mux.removeSession(result.session)
+
+	done := make(chan struct{})
+	go func() {
+		result.session.bootstrapTopics(context.Background(), 0, result.topics)
+		close(done)
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(timeout):
+			require.FailNow(t, "DAG-run snapshots did not start together")
+		}
+	}
+	release()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		require.FailNow(t, "DAG-run snapshot bootstrap did not finish")
+	}
 }
 
 func TestMultiplexerCreateSessionFiltersUnsupportedTopics(t *testing.T) {


### PR DESCRIPTION
## Summary

- coalesce DAG-run list invalidation once per event-store read
- refresh only subscriptions whose status filters can be affected by lifecycle transitions
- preserve detail, queue, DAG, and unfiltered list freshness

## Root cause

PR #2503 removed aggregate refreshes for progress-only updates, but concurrent lifecycle transitions still woke every active DAG-run list subscription. The cockpit then multiplied the same expensive day-index work across unrelated status buckets.

## Scope

This follow-up narrows lifecycle invalidation at the SSE boundary. It deliberately avoids adding a storage cache, journal, debounce layer, or UI changes.

Closes #2501.

## Testing

- `go test -race ./internal/service/frontend/sse -count=3`
- `go test ./internal/service/frontend/... -count=1`
- `golangci-lint run --timeout=10m --new-from-rev=origin/main ./internal/service/frontend/sse/...`
- `GOOS=windows golangci-lint run --timeout=10m --new-from-rev=origin/main ./internal/service/frontend/sse/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened DAG-run lifecycle invalidations so only matching status-filtered lists refresh, and batched list reads share day-index work to avoid duplicate scans. SSE now captures bootstrap state before loading and serializes publish order so wake snapshots stay newer than concurrent bootstraps; stale attachment snapshots are ignored.

- **Bug Fixes**
  - Batch lifecycle events and refresh `TopicTypeDAGRuns` only when a list’s `status` filter intersects affected statuses (supports repeated and comma-separated values; validates and falls back when missing/invalid).
  - Skip list refreshes for progress-only updates; still wake `TopicTypeDAG`, `TopicTypeDAGHistory`, `TopicTypeQueues`, and per-queue-item topics.
  - Coalesce day-index loads per list-read batch using `golang.org/x/sync/singleflight` keyed by batch and day to share scans across parallel bootstraps/wakes.
  - Serialize SSE publication and capture bootstrap state (attachment ID and last-published ID) before loading; move overwritten messages to the tail; ensure wake-driven snapshots publish after concurrent bootstraps; reject stale snapshots from previous attachments.

<sup>Written for commit 315bcdf483091b49d251b779206803488d8a3009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved real-time DAG-run list updates so status-filtered views refresh only when matching changes occur.
  - Preserved broad refresh behavior for unfiltered or invalid status filters.
  - Ensured multiple lifecycle events are handled together, reducing unnecessary refreshes while keeping relevant views current.
  - Fixed update ordering so newer DAG-run changes are not overwritten by older refresh results.
  - Continued updating related DAG-run, queue, DAG, and history views as events occur.
- **Performance**
  - Improved responsiveness when loading and refreshing DAG-run data during concurrent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
