### PR TITLE
fix: improve DAG spec layout and readability

### DIFF
--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -164,7 +164,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
             buildScopedUrl={buildScopedUrl}
           />
         )}
-        <div className="mb-4 mt-3 flex min-w-0 flex-col items-center justify-between gap-3 2xl:flex-row 2xl:gap-0">
+        <div className="mb-4 mt-3 flex min-w-0 flex-col items-center justify-between gap-3 lg:flex-row 2xl:gap-0">
           {/* Desktop Tabs */}
           <div className="hidden min-w-0 flex-1 overflow-x-auto 2xl:block">
             <Tabs className="whitespace-nowrap">
@@ -308,7 +308,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
           </div>
 
           {/* Compact Tabs */}
-          <div className="w-full min-w-0 overflow-x-auto 2xl:hidden">
+          <div className="w-full min-w-0 overflow-x-auto lg:flex-1 2xl:hidden">
             <div className="flex min-w-max space-x-1">
               {isModal ? (
                 <ModalLinkTab

--- a/ui/src/features/dags/components/dag-details/DAGStepTable.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGStepTable.tsx
@@ -33,25 +33,23 @@ function DAGStepTable({ steps }: Props) {
   }
 
   return (
-    <div className="w-full overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow className="h-8">
-            <TableHead className="w-[4%] text-center">No</TableHead>
-            <TableHead className="w-[20%]">Step Details</TableHead>
-            <TableHead className="w-[22%]">Execution</TableHead>
-            <TableHead className="w-[18%]">Dependencies</TableHead>
-            <TableHead className="w-[18%]">Configuration</TableHead>
-            <TableHead className="w-[18%]">Conditions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {steps.map((step, idx) => (
-            <DAGStepTableRow key={idx} step={step} index={idx} />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <Table className="min-w-[960px] table-fixed">
+      <TableHeader>
+        <TableRow className="h-8">
+          <TableHead className="w-[4%] text-center">No</TableHead>
+          <TableHead className="w-[28%]">Step Details</TableHead>
+          <TableHead className="w-[22%]">Execution</TableHead>
+          <TableHead className="w-[14%]">Dependencies</TableHead>
+          <TableHead className="w-[18%]">Configuration</TableHead>
+          <TableHead className="w-[14%]">Conditions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {steps.map((step, idx) => (
+          <DAGStepTableRow key={idx} step={step} index={idx} />
+        ))}
+      </TableBody>
+    </Table>
   );
 }
 

--- a/ui/src/features/dags/components/dag-details/DAGStepTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGStepTableRow.tsx
@@ -56,7 +56,7 @@ function DAGStepTableRow({ step, index }: Props) {
   ));
 
   return (
-    <TableRow className="hover:bg-muted/50 transition-colors duration-200 h-auto">
+    <TableRow className="h-auto transition-colors duration-200 hover:bg-muted/50 [&_td]:align-top">
       {/* Number */}
       <TableCell className="text-center font-semibold text-foreground/90 text-xs py-2">
         {index + 1}
@@ -65,16 +65,22 @@ function DAGStepTableRow({ step, index }: Props) {
       {/* Step Details */}
       <TableCell>
         <div className="space-y-1">
-          <div className="text-sm font-semibold text-foreground break-all">
+          <div className="break-words text-sm font-semibold text-foreground">
             {step.name}
           </div>
           {step.id && (
-            <div className="text-xs text-muted-foreground font-mono">
+            <div
+              className="truncate font-mono text-xs text-muted-foreground"
+              title={step.id}
+            >
               ID: {step.id}
             </div>
           )}
           {step.description && (
-            <div className="text-xs text-muted-foreground">
+            <div
+              className="line-clamp-2 text-xs leading-relaxed text-muted-foreground"
+              title={step.description}
+            >
               {step.description}
             </div>
           )}
@@ -121,7 +127,7 @@ function DAGStepTableRow({ step, index }: Props) {
       <TableCell>
         <div className="space-y-1.5">
           {isHarnessStep(step) ? (
-            <HarnessStepSummary step={step} />
+            <HarnessStepSummary step={step} compact />
           ) : logMessage !== null ? (
             <LogStepMessage message={logMessage} compact />
           ) : step.commands && step.commands.length > 0 ? (
@@ -159,9 +165,12 @@ function DAGStepTableRow({ step, index }: Props) {
 
           {/* Directory */}
           {step.dir && (
-            <div className="flex items-center gap-1.5 text-xs bg-muted rounded-md px-1.5 py-0.5 w-fit">
-              <Folder className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="font-medium text-muted-foreground">
+            <div className="flex w-fit max-w-full items-center gap-1.5 rounded-md bg-muted px-1.5 py-0.5 text-xs">
+              <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span
+                className="truncate font-medium text-muted-foreground"
+                title={step.dir}
+              >
                 {step.dir}
               </span>
             </div>
@@ -202,7 +211,7 @@ function DAGStepTableRow({ step, index }: Props) {
 
       {/* Configuration */}
       <TableCell>
-        <div className="space-y-1.5">
+        <div className="min-w-0 space-y-1.5">
           {/* Repeat Policy */}
           {step.repeatPolicy?.repeat && (
             <div className="space-y-1">
@@ -300,13 +309,18 @@ function DAGStepTableRow({ step, index }: Props) {
           {step.params && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="text-xs text-muted-foreground bg-muted rounded-md p-1.5 truncate cursor-pointer leading-tight">
-                  <span className="font-medium">Params:</span>{' '}
-                  <span className="font-mono">{step.params}</span>
-                </div>
+                <button
+                  type="button"
+                  className="block w-full min-w-0 cursor-pointer rounded-md bg-muted p-1.5 text-left text-xs leading-tight text-muted-foreground"
+                >
+                  <span className="mb-0.5 block font-medium">Params</span>
+                  <span className="block truncate font-mono">
+                    {step.params}
+                  </span>
+                </button>
               </TooltipTrigger>
-              <TooltipContent>
-                <span className="max-w-[400px] break-all font-mono text-xs">
+              <TooltipContent className="max-w-[400px]">
+                <span className="break-all font-mono text-xs">
                   {step.params}
                 </span>
               </TooltipContent>

--- a/ui/src/features/dags/components/dag-details/HarnessStepSummary.tsx
+++ b/ui/src/features/dags/components/dag-details/HarnessStepSummary.tsx
@@ -4,7 +4,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { getHarnessStepSummary, type HarnessAttemptSummary } from '@/lib/harness-step';
+import {
+  getHarnessStepSummary,
+  type HarnessAttemptSummary,
+  type HarnessStepSummary as HarnessSummary,
+} from '@/lib/harness-step';
 import { cn } from '@/lib/utils';
 import { Bot } from 'lucide-react';
 import { components } from '../../../../api/v1/schema';
@@ -12,16 +16,21 @@ import { components } from '../../../../api/v1/schema';
 type Props = {
   step: components['schemas']['Step'];
   className?: string;
+  compact?: boolean;
 };
 
 const visibleOptionCount = 3;
 const promptTooltipThreshold = 120;
 
-function HarnessStepSummary({ step, className }: Props) {
+function HarnessStepSummary({ step, className, compact = false }: Props) {
   const summary = getHarnessStepSummary(step);
 
   if (!summary) {
     return null;
+  }
+
+  if (compact) {
+    return <CompactHarnessSummary summary={summary} className={className} />;
   }
 
   const promptContent = summary.prompt ? (
@@ -60,8 +69,7 @@ function HarnessStepSummary({ step, className }: Props) {
         />
       ))}
 
-      {summary.prompt &&
-      summary.prompt.length > promptTooltipThreshold ? (
+      {summary.prompt && summary.prompt.length > promptTooltipThreshold ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="cursor-help">{promptContent}</div>
@@ -75,6 +83,59 @@ function HarnessStepSummary({ step, className }: Props) {
       ) : (
         promptContent
       )}
+    </div>
+  );
+}
+
+function CompactHarnessSummary({
+  summary,
+  className,
+}: {
+  summary: HarnessSummary;
+  className?: string;
+}) {
+  const primary = summary.attempts[0];
+  const fallbackCount = Math.max(summary.attempts.length - 1, 0);
+  const optionCount = summary.attempts.reduce(
+    (count, attempt) => count + attempt.options.length,
+    0
+  );
+
+  return (
+    <div className={cn('min-w-0 space-y-1.5', className)}>
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <Badge variant="info" className="normal-case tracking-normal">
+          <Bot className="h-3 w-3" />
+          Harness
+        </Badge>
+        {primary?.provider ? (
+          <Badge
+            variant="secondary"
+            className="font-mono normal-case tracking-normal"
+            title="Primary provider"
+          >
+            {primary.provider}
+          </Badge>
+        ) : null}
+        {optionCount > 0 ? (
+          <Badge variant="outline" className="normal-case tracking-normal">
+            {optionCount} option{optionCount === 1 ? '' : 's'}
+          </Badge>
+        ) : null}
+        {fallbackCount > 0 ? (
+          <Badge variant="outline" className="normal-case tracking-normal">
+            {fallbackCount} fallback{fallbackCount === 1 ? '' : 's'}
+          </Badge>
+        ) : null}
+      </div>
+      {summary.prompt ? (
+        <div
+          className="truncate text-xs text-muted-foreground"
+          title={summary.prompt}
+        >
+          {summary.prompt}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/features/dags/components/dag-details/HarnessStepSummary.tsx
+++ b/ui/src/features/dags/components/dag-details/HarnessStepSummary.tsx
@@ -1,3 +1,4 @@
+import { Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   Tooltip,
@@ -10,7 +11,6 @@ import {
   type HarnessStepSummary as HarnessSummary,
 } from '@/lib/harness-step';
 import { cn } from '@/lib/utils';
-import { Bot } from 'lucide-react';
 import { components } from '../../../../api/v1/schema';
 
 type Props = {

--- a/ui/src/features/dags/components/dag-details/__tests__/HarnessStepSummary.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/HarnessStepSummary.test.tsx
@@ -67,4 +67,38 @@ describe('HarnessStepSummary', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('renders a compact summary for step tables', () => {
+    const step = {
+      name: 'review',
+      commands: [
+        {
+          command: 'Review',
+          args: ['this', 'repository'],
+        },
+      ],
+      executorConfig: {
+        type: 'harness',
+        config: {
+          provider: 'claude',
+          model: 'sonnet',
+          bare: true,
+          fallback: [
+            {
+              provider: 'codex',
+              'full-auto': true,
+            },
+          ],
+        },
+      },
+    } as components['schemas']['Step'];
+
+    render(<HarnessStepSummary step={step} compact />);
+
+    expect(screen.getByText('Harness')).toBeInTheDocument();
+    expect(screen.getByText('claude')).toBeInTheDocument();
+    expect(screen.getByText('3 options')).toBeInTheDocument();
+    expect(screen.getByText('1 fallback')).toBeInTheDocument();
+    expect(screen.getByText('Review this repository')).toBeInTheDocument();
+  });
 });

--- a/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
+++ b/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
@@ -3,17 +3,9 @@
 
 import type { components } from '@/api/v1/schema';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { parseParams } from '@/lib/parseParams';
-import {
-  Bot,
-  CircleHelp,
-  FileCode2,
-  GitBranch,
-  Pencil,
-  Target,
-} from 'lucide-react';
+import { FileCode2, GitBranch, Target } from 'lucide-react';
 import React from 'react';
 
 type DAG = components['schemas']['DAGDetails'];
@@ -23,22 +15,15 @@ const CONTROLLER_SYSTEM_STEPS = new Set(['__controller__', 'ask_user']);
 
 type Props = {
   dag: DAG;
-  onEditYAML: () => void;
-  yamlActionLabel?: string;
 };
 
 /** Controller-oriented summary and inspection surface for runtime actions. */
-export function ControllerSpecOverview({
-  dag,
-  onEditYAML,
-  yamlActionLabel = 'Edit YAML',
-}: Props) {
+export function ControllerSpecOverview({ dag }: Props) {
   const tasks = dag.tasks ?? [];
   const steps = dag.steps ?? [];
   const actions = steps.filter(
     (step) => !CONTROLLER_SYSTEM_STEPS.has(step.name)
   );
-  const canAskUser = steps.some((step) => step.name === 'ask_user');
   const [selectedActionName, setSelectedActionName] = React.useState(
     actions[0]?.name ?? null
   );
@@ -46,83 +31,46 @@ export function ControllerSpecOverview({
     actions.find((step) => step.name === selectedActionName) ?? actions[0];
 
   return (
-    <div className="space-y-4 pb-8">
-      <div className="grid items-stretch gap-4 lg:grid-cols-2">
-        <section className="rounded-md border border-border bg-card px-5 py-4 shadow-sm">
-          <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
-            <Bot className="h-4 w-4 text-primary" />
-            Controller workflow
-          </h2>
+    <div className="space-y-4">
+      <section className="rounded-md border border-border bg-card px-5 py-4 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+          <Target className="h-4 w-4 text-primary" />
+          Tasks
+        </h2>
 
-          <div className="mt-4 flex items-center divide-x divide-border">
-            <Metric value={actions.length} label="Available actions" />
-            <Metric
-              value={tasks.length}
-              label={tasks.length === 1 ? 'Goal' : 'Goals'}
-            />
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge variant="primary">Runtime-selected order</Badge>
-            {canAskUser ? (
-              <Badge variant="outline">
-                <CircleHelp className="h-3 w-3" />
-                Can ask user
-              </Badge>
-            ) : null}
-          </div>
-        </section>
-
-        <section className="rounded-md border border-border bg-card px-5 py-4 shadow-sm">
-          <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
-            <Target className="h-4 w-4 text-primary" />
-            {tasks.length === 1 ? 'Goal' : 'Goals'}
-          </h2>
-
-          {tasks.length > 0 ? (
-            <div className="mt-3 divide-y divide-border">
-              {tasks.map((task) => (
-                <div
-                  key={task.name}
-                  className="flex gap-3 py-2.5 first:pt-1 last:pb-0"
-                >
-                  <Target className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-foreground">
-                      {task.name}
-                    </div>
-                    {task.description ? (
-                      <div className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                        {task.description}
-                      </div>
-                    ) : null}
+        {tasks.length > 0 ? (
+          <div className="mt-3 divide-y divide-border">
+            {tasks.map((task) => (
+              <div key={task.name} className="py-2.5 first:pt-1 last:pb-0">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-foreground">
+                    {task.name}
                   </div>
+                  {task.description ? (
+                    <div className="mt-1 text-sm leading-relaxed text-foreground">
+                      {task.description}
+                    </div>
+                  ) : null}
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="mt-3 text-sm text-muted-foreground">
-              No goals are defined.
-            </div>
-          )}
-        </section>
-      </div>
-
-      <section className="overflow-hidden rounded-md border border-border bg-card shadow-sm lg:grid lg:grid-cols-[minmax(280px,0.75fr)_minmax(0,1.25fr)]">
-        <div className="min-w-0 border-b border-border lg:border-b-0 lg:border-r">
-          <div className="border-b border-border px-5 py-4">
-            <h2 className="text-base font-semibold text-foreground">
-              Available actions
-            </h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Select an action to inspect its configuration.
-            </p>
+              </div>
+            ))}
           </div>
+        ) : (
+          <div className="mt-3 text-sm text-foreground">
+            No tasks are defined.
+          </div>
+        )}
+      </section>
 
+      <section className="overflow-hidden rounded-md border border-border bg-card shadow-sm lg:grid lg:h-[clamp(32rem,calc(100vh-22rem),48rem)] lg:grid-cols-[minmax(280px,0.75fr)_minmax(0,1.25fr)]">
+        <div
+          role="group"
+          className="min-w-0 border-b border-border lg:overflow-y-auto lg:border-b-0 lg:border-r"
+          aria-label="Available actions"
+        >
           {actions.length > 0 ? (
             <div className="divide-y divide-border">
               {actions.map((step) => {
-                const execution = getExecutionSummary(step);
                 const isSelected = selectedAction?.name === step.name;
 
                 return (
@@ -131,7 +79,7 @@ export function ControllerSpecOverview({
                     type="button"
                     aria-pressed={isSelected}
                     className={cn(
-                      'relative grid min-h-[76px] w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-5 py-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
+                      'relative block min-h-[76px] w-full px-5 py-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
                       isSelected &&
                         'bg-primary/[0.08] before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary'
                     )}
@@ -142,65 +90,39 @@ export function ControllerSpecOverview({
                         <span className="text-sm font-semibold text-foreground">
                           {step.name}
                         </span>
-                        {step.id ? (
-                          <span className="truncate font-mono text-[11px] text-muted-foreground">
-                            ID: {step.id}
+                        {step.id && step.id !== step.name ? (
+                          <span className="truncate font-mono text-xs text-foreground">
+                            {step.id}
                           </span>
                         ) : null}
                       </div>
                       {step.description ? (
-                        <p className="mt-1 line-clamp-1 text-xs leading-5 text-muted-foreground">
+                        <p className="mt-1 line-clamp-1 text-sm leading-5 text-foreground">
                           {step.description}
                         </p>
                       ) : null}
                     </div>
-
-                    <Badge variant={step.call ? 'primary' : 'outline'}>
-                      {step.call ? <GitBranch className="h-3 w-3" /> : null}
-                      {execution.label}
-                    </Badge>
                   </button>
                 );
               })}
             </div>
           ) : (
-            <div className="px-5 py-6 text-sm text-muted-foreground">
+            <div className="px-5 py-6 text-sm text-foreground">
               No actions are defined.
             </div>
           )}
         </div>
 
-        <ActionDetails
-          step={selectedAction}
-          onEditYAML={onEditYAML}
-          yamlActionLabel={yamlActionLabel}
-        />
+        <ActionDetails step={selectedAction} />
       </section>
     </div>
   );
 }
 
-function Metric({ value, label }: { value: number; label: string }) {
-  return (
-    <div className="flex min-w-0 flex-1 items-baseline gap-2 px-5 first:pl-0 last:pr-0">
-      <span className="text-2xl font-semibold text-primary">{value}</span>
-      <span className="text-xs text-muted-foreground">{label}</span>
-    </div>
-  );
-}
-
-function ActionDetails({
-  step,
-  onEditYAML,
-  yamlActionLabel,
-}: {
-  step?: Step;
-  onEditYAML: () => void;
-  yamlActionLabel: string;
-}) {
+function ActionDetails({ step }: { step?: Step }) {
   if (!step) {
     return (
-      <div className="flex min-h-64 items-center justify-center px-6 py-10 text-sm text-muted-foreground">
+      <div className="flex min-h-64 items-center justify-center px-6 py-10 text-sm text-foreground">
         Select an action to inspect its configuration.
       </div>
     );
@@ -211,34 +133,23 @@ function ActionDetails({
   const executorConfig = Object.entries(step.executorConfig?.config ?? {});
 
   return (
-    <div className="min-w-0 px-5 py-5 lg:min-h-[460px] lg:px-6">
-      <div className="flex items-start justify-between gap-4">
+    <div className="min-w-0 px-5 py-5 lg:h-full lg:overflow-y-auto lg:px-6">
+      <div>
         <div className="min-w-0">
           <h2 className="break-words text-lg font-semibold text-foreground">
             {step.name}
           </h2>
           {step.id ? (
-            <div className="mt-1 font-mono text-xs text-muted-foreground">
+            <div className="mt-1 font-mono text-sm text-foreground">
               ID: {step.id}
             </div>
           ) : null}
           {step.description ? (
-            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-foreground">
               {step.description}
             </p>
           ) : null}
         </div>
-
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="text-primary hover:text-primary"
-          onClick={onEditYAML}
-        >
-          <Pencil className="h-4 w-4" />
-          {yamlActionLabel}
-        </Button>
       </div>
 
       <DetailSection title="Execution" className="mt-5">
@@ -248,7 +159,7 @@ function ActionDetails({
             {execution.label}
           </Badge>
           {execution.detail ? (
-            <code className="break-all text-xs text-foreground">
+            <code className="break-all text-sm text-foreground">
               {execution.detail}
             </code>
           ) : null}
@@ -289,31 +200,17 @@ function ActionDetails({
 
       <AdditionalSettings step={step} />
 
-      <div className="grid gap-3 pt-5 sm:grid-cols-2">
-        <InfoCard title="Dependencies">
-          {step.depends?.length ? (
-            <div className="flex flex-wrap gap-1.5">
-              {step.depends.map((dependency) => (
-                <Badge key={dependency} variant="outline">
-                  {dependency}
-                </Badge>
-              ))}
-            </div>
-          ) : (
-            <EmptyValue>None</EmptyValue>
-          )}
-        </InfoCard>
-
+      <div className="pt-5">
         <InfoCard title="Conditions">
           {step.preconditions?.length ? (
             <div className="space-y-2">
               {step.preconditions.map((condition, index) => (
                 <div
                   key={`${condition.condition}-${index}`}
-                  className="text-xs leading-relaxed text-foreground"
+                  className="text-sm leading-relaxed text-foreground"
                 >
                   <code className="break-all">{condition.condition}</code>
-                  <span className="px-1.5 text-muted-foreground">→</span>
+                  <span className="px-1.5 text-foreground">→</span>
                   <code className="break-all">{condition.expected}</code>
                 </div>
               ))}
@@ -356,10 +253,10 @@ function KeyValueGrid({
           key={`${item.name}-${index}`}
           className="grid min-w-0 border-b border-border last:border-b-0 sm:grid-cols-[minmax(120px,0.55fr)_minmax(0,1.45fr)]"
         >
-          <dt className="bg-muted/20 px-3 py-2 text-xs font-medium text-foreground sm:border-r sm:border-border">
+          <dt className="bg-muted/20 px-3 py-2 text-sm font-medium text-foreground sm:border-r sm:border-border">
             {item.name}
           </dt>
-          <dd className="min-w-0 px-3 py-2 font-mono text-xs text-muted-foreground">
+          <dd className="min-w-0 px-3 py-2 font-mono text-sm text-foreground">
             <span className="whitespace-pre-wrap break-all">{item.value}</span>
           </dd>
         </div>
@@ -372,7 +269,7 @@ function CodePreview({ value }: { value: string }) {
   return (
     <div className="flex min-w-0 gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5">
       <FileCode2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-      <pre className="max-h-40 min-w-0 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground">
+      <pre className="max-h-40 min-w-0 overflow-auto whitespace-pre-wrap break-words font-mono text-[13px] leading-6 text-foreground">
         {value}
       </pre>
     </div>
@@ -426,7 +323,7 @@ function InfoCard({
 }
 
 function EmptyValue({ children }: { children: React.ReactNode }) {
-  return <div className="text-xs text-muted-foreground">{children}</div>;
+  return <div className="text-sm text-foreground">{children}</div>;
 }
 
 function getExecutionSummary(step: Step): {

--- a/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
+++ b/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
@@ -3,15 +3,18 @@
 
 import type { components } from '@/api/v1/schema';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { parseParams } from '@/lib/parseParams';
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Bot, ChevronRight, CircleHelp, GitBranch, Target } from 'lucide-react';
-import DAGAttributes from './DAGAttributes';
+  Bot,
+  CircleHelp,
+  FileCode2,
+  GitBranch,
+  Pencil,
+  Target,
+} from 'lucide-react';
+import React from 'react';
 
 type DAG = components['schemas']['DAGDetails'];
 type Step = components['schemas']['Step'];
@@ -20,202 +23,410 @@ const CONTROLLER_SYSTEM_STEPS = new Set(['__controller__', 'ask_user']);
 
 type Props = {
   dag: DAG;
-  onSelectStep: (step: Step) => void;
+  onEditYAML: () => void;
+  yamlActionLabel?: string;
 };
 
-/** Controller-oriented summary of goals and actions available at runtime. */
-export function ControllerSpecOverview({ dag, onSelectStep }: Props) {
+/** Controller-oriented summary and inspection surface for runtime actions. */
+export function ControllerSpecOverview({
+  dag,
+  onEditYAML,
+  yamlActionLabel = 'Edit YAML',
+}: Props) {
   const tasks = dag.tasks ?? [];
   const steps = dag.steps ?? [];
   const actions = steps.filter(
     (step) => !CONTROLLER_SYSTEM_STEPS.has(step.name)
   );
   const canAskUser = steps.some((step) => step.name === 'ask_user');
+  const [selectedActionName, setSelectedActionName] = React.useState(
+    actions[0]?.name ?? null
+  );
+  const selectedAction =
+    actions.find((step) => step.name === selectedActionName) ?? actions[0];
 
   return (
-    <div className="space-y-6 pb-8">
-      <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(260px,0.75fr)_minmax(0,1.25fr)]">
-        <Card className="gap-0 overflow-hidden">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Bot className="h-4 w-4 text-primary" />
-              Controller workflow
-            </CardTitle>
-            <CardDescription>
-              Chooses and may repeat available actions until every goal is
-              resolved.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-lg font-semibold text-foreground">
-                  {actions.length}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  Available actions
-                </div>
-              </div>
-              <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-lg font-semibold text-foreground">
-                  {tasks.length}
-                </div>
-                <div className="text-xs text-muted-foreground">Goals</div>
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="primary">Runtime-selected order</Badge>
-              {canAskUser ? (
-                <Badge variant="outline">
-                  <CircleHelp className="h-3 w-3" />
-                  Can ask user
-                </Badge>
-              ) : null}
-            </div>
-          </CardContent>
-        </Card>
+    <div className="space-y-4 pb-8">
+      <div className="grid items-stretch gap-4 lg:grid-cols-2">
+        <section className="rounded-md border border-border bg-card px-5 py-4 shadow-sm">
+          <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+            <Bot className="h-4 w-4 text-primary" />
+            Controller workflow
+          </h2>
 
-        <Card className="gap-0 overflow-hidden">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Target className="h-4 w-4 text-primary" />
-              Goals
-            </CardTitle>
-            <CardDescription>
-              Completion criteria the controller evaluates during the run.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="p-0">
-            {tasks.length > 0 ? (
-              <div className="divide-y divide-border">
-                {tasks.map((task, index) => (
-                  <div key={task.name} className="flex gap-3 px-5 py-3">
-                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-                      {index + 1}
+          <div className="mt-4 flex items-center divide-x divide-border">
+            <Metric value={actions.length} label="Available actions" />
+            <Metric
+              value={tasks.length}
+              label={tasks.length === 1 ? 'Goal' : 'Goals'}
+            />
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Badge variant="primary">Runtime-selected order</Badge>
+            {canAskUser ? (
+              <Badge variant="outline">
+                <CircleHelp className="h-3 w-3" />
+                Can ask user
+              </Badge>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="rounded-md border border-border bg-card px-5 py-4 shadow-sm">
+          <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+            <Target className="h-4 w-4 text-primary" />
+            {tasks.length === 1 ? 'Goal' : 'Goals'}
+          </h2>
+
+          {tasks.length > 0 ? (
+            <div className="mt-3 divide-y divide-border">
+              {tasks.map((task) => (
+                <div
+                  key={task.name}
+                  className="flex gap-3 py-2.5 first:pt-1 last:pb-0"
+                >
+                  <Target className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-foreground">
+                      {task.name}
                     </div>
-                    <div className="min-w-0">
-                      <div className="text-sm font-medium text-foreground">
-                        {task.name}
+                    {task.description ? (
+                      <div className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                        {task.description}
                       </div>
-                      {task.description ? (
-                        <div className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                          {task.description}
-                        </div>
-                      ) : null}
-                    </div>
+                    ) : null}
                   </div>
-                ))}
-              </div>
-            ) : (
-              <div className="px-5 py-4 text-sm text-muted-foreground">
-                No goals are defined.
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      <DAGAttributes dag={dag} />
-
-      <Card className="gap-0 overflow-hidden">
-        <CardHeader>
-          <CardTitle>Available actions</CardTitle>
-          <CardDescription>
-            Select an action to inspect its complete configuration.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="p-0">
-          {actions.length > 0 ? (
-            <div>
-              <div className="hidden grid-cols-[minmax(260px,1.4fr)_minmax(150px,0.7fr)_minmax(180px,0.8fr)_20px] gap-4 border-b border-border bg-surface-variant/40 px-5 py-2 text-xs font-semibold text-muted-foreground md:grid">
-                <div>Action</div>
-                <div>Execution</div>
-                <div>Configuration</div>
-                <div />
-              </div>
-              <div className="divide-y divide-border">
-                {actions.map((step) => {
-                  const execution = getExecutionSummary(step);
-                  const configuration = getConfigurationSummary(step);
-
-                  return (
-                    <button
-                      key={step.name}
-                      type="button"
-                      className="grid w-full gap-3 px-5 py-3 text-left transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary md:grid-cols-[minmax(260px,1.4fr)_minmax(150px,0.7fr)_minmax(180px,0.8fr)_20px] md:items-center md:gap-4"
-                      onClick={() => onSelectStep(step)}
-                    >
-                      <div className="min-w-0">
-                        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                          <span className="break-words text-sm font-semibold text-foreground">
-                            {step.name}
-                          </span>
-                          {step.id ? (
-                            <span className="truncate font-mono text-[11px] text-muted-foreground">
-                              ID: {step.id}
-                            </span>
-                          ) : null}
-                        </div>
-                        {step.description ? (
-                          <div className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                            {step.description}
-                          </div>
-                        ) : null}
-                      </div>
-
-                      <div className="min-w-0">
-                        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground md:hidden">
-                          Execution
-                        </div>
-                        <div className="flex min-w-0 items-center gap-2">
-                          <Badge
-                            variant={step.call ? 'info' : 'outline'}
-                            className="max-w-full"
-                          >
-                            {step.call ? (
-                              <GitBranch className="h-3 w-3" />
-                            ) : null}
-                            {execution.label}
-                          </Badge>
-                          {execution.detail ? (
-                            <span
-                              className="truncate text-xs text-muted-foreground"
-                              title={execution.detail}
-                            >
-                              {execution.detail}
-                            </span>
-                          ) : null}
-                        </div>
-                      </div>
-
-                      <div className="min-w-0">
-                        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground md:hidden">
-                          Configuration
-                        </div>
-                        <div className="flex flex-wrap gap-1.5">
-                          {configuration.map((item) => (
-                            <Badge key={item} variant="default">
-                              {item}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-
-                      <ChevronRight className="hidden h-4 w-4 text-muted-foreground md:block" />
-                    </button>
-                  );
-                })}
-              </div>
+                </div>
+              ))}
             </div>
           ) : (
-            <div className="px-5 py-4 text-sm text-muted-foreground">
+            <div className="mt-3 text-sm text-muted-foreground">
+              No goals are defined.
+            </div>
+          )}
+        </section>
+      </div>
+
+      <section className="overflow-hidden rounded-md border border-border bg-card shadow-sm lg:grid lg:grid-cols-[minmax(280px,0.75fr)_minmax(0,1.25fr)]">
+        <div className="min-w-0 border-b border-border lg:border-b-0 lg:border-r">
+          <div className="border-b border-border px-5 py-4">
+            <h2 className="text-base font-semibold text-foreground">
+              Available actions
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Select an action to inspect its configuration.
+            </p>
+          </div>
+
+          {actions.length > 0 ? (
+            <div className="divide-y divide-border">
+              {actions.map((step) => {
+                const execution = getExecutionSummary(step);
+                const isSelected = selectedAction?.name === step.name;
+
+                return (
+                  <button
+                    key={step.name}
+                    type="button"
+                    aria-pressed={isSelected}
+                    className={cn(
+                      'relative grid min-h-[76px] w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-5 py-3 text-left outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
+                      isSelected &&
+                        'bg-primary/[0.08] before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary'
+                    )}
+                    onClick={() => setSelectedActionName(step.name)}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                        <span className="text-sm font-semibold text-foreground">
+                          {step.name}
+                        </span>
+                        {step.id ? (
+                          <span className="truncate font-mono text-[11px] text-muted-foreground">
+                            ID: {step.id}
+                          </span>
+                        ) : null}
+                      </div>
+                      {step.description ? (
+                        <p className="mt-1 line-clamp-1 text-xs leading-5 text-muted-foreground">
+                          {step.description}
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <Badge variant={step.call ? 'primary' : 'outline'}>
+                      {step.call ? <GitBranch className="h-3 w-3" /> : null}
+                      {execution.label}
+                    </Badge>
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="px-5 py-6 text-sm text-muted-foreground">
               No actions are defined.
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+
+        <ActionDetails
+          step={selectedAction}
+          onEditYAML={onEditYAML}
+          yamlActionLabel={yamlActionLabel}
+        />
+      </section>
     </div>
   );
+}
+
+function Metric({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex min-w-0 flex-1 items-baseline gap-2 px-5 first:pl-0 last:pr-0">
+      <span className="text-2xl font-semibold text-primary">{value}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function ActionDetails({
+  step,
+  onEditYAML,
+  yamlActionLabel,
+}: {
+  step?: Step;
+  onEditYAML: () => void;
+  yamlActionLabel: string;
+}) {
+  if (!step) {
+    return (
+      <div className="flex min-h-64 items-center justify-center px-6 py-10 text-sm text-muted-foreground">
+        Select an action to inspect its configuration.
+      </div>
+    );
+  }
+
+  const execution = getExecutionSummary(step);
+  const parameters = step.params ? parseParams(step.params) : [];
+  const executorConfig = Object.entries(step.executorConfig?.config ?? {});
+
+  return (
+    <div className="min-w-0 px-5 py-5 lg:min-h-[460px] lg:px-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="break-words text-lg font-semibold text-foreground">
+            {step.name}
+          </h2>
+          {step.id ? (
+            <div className="mt-1 font-mono text-xs text-muted-foreground">
+              ID: {step.id}
+            </div>
+          ) : null}
+          {step.description ? (
+            <p className="mt-3 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+              {step.description}
+            </p>
+          ) : null}
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-primary hover:text-primary"
+          onClick={onEditYAML}
+        >
+          <Pencil className="h-4 w-4" />
+          {yamlActionLabel}
+        </Button>
+      </div>
+
+      <DetailSection title="Execution" className="mt-5">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <Badge variant={step.call ? 'primary' : 'outline'}>
+            {step.call ? <GitBranch className="h-3 w-3" /> : null}
+            {execution.label}
+          </Badge>
+          {execution.detail ? (
+            <code className="break-all text-xs text-foreground">
+              {execution.detail}
+            </code>
+          ) : null}
+        </div>
+
+        {step.script ? <CodePreview value={step.script} /> : null}
+        {step.commands?.length ? (
+          <CodePreview
+            value={step.commands
+              .map((command) =>
+                [command.command, ...(command.args ?? [])].join(' ')
+              )
+              .join('\n')}
+          />
+        ) : null}
+        {executorConfig.length > 0 ? (
+          <KeyValueGrid
+            items={executorConfig.map(([name, value]) => ({
+              name,
+              value: formatValue(value),
+            }))}
+          />
+        ) : null}
+      </DetailSection>
+
+      <DetailSection title="Parameters">
+        {parameters.length > 0 ? (
+          <KeyValueGrid
+            items={parameters.map((parameter, index) => ({
+              name: parameter.Name ?? `Argument ${index + 1}`,
+              value: parameter.Value,
+            }))}
+          />
+        ) : (
+          <EmptyValue>No parameters</EmptyValue>
+        )}
+      </DetailSection>
+
+      <AdditionalSettings step={step} />
+
+      <div className="grid gap-3 pt-5 sm:grid-cols-2">
+        <InfoCard title="Dependencies">
+          {step.depends?.length ? (
+            <div className="flex flex-wrap gap-1.5">
+              {step.depends.map((dependency) => (
+                <Badge key={dependency} variant="outline">
+                  {dependency}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <EmptyValue>None</EmptyValue>
+          )}
+        </InfoCard>
+
+        <InfoCard title="Conditions">
+          {step.preconditions?.length ? (
+            <div className="space-y-2">
+              {step.preconditions.map((condition, index) => (
+                <div
+                  key={`${condition.condition}-${index}`}
+                  className="text-xs leading-relaxed text-foreground"
+                >
+                  <code className="break-all">{condition.condition}</code>
+                  <span className="px-1.5 text-muted-foreground">→</span>
+                  <code className="break-all">{condition.expected}</code>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyValue>None</EmptyValue>
+          )}
+        </InfoCard>
+      </div>
+    </div>
+  );
+}
+
+function DetailSection({
+  title,
+  className,
+  children,
+}: {
+  title: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={cn('space-y-3 border-b border-border py-5', className)}>
+      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function KeyValueGrid({
+  items,
+}: {
+  items: Array<{ name: string; value: string }>;
+}) {
+  return (
+    <dl className="overflow-hidden rounded-md border border-border">
+      {items.map((item, index) => (
+        <div
+          key={`${item.name}-${index}`}
+          className="grid min-w-0 border-b border-border last:border-b-0 sm:grid-cols-[minmax(120px,0.55fr)_minmax(0,1.45fr)]"
+        >
+          <dt className="bg-muted/20 px-3 py-2 text-xs font-medium text-foreground sm:border-r sm:border-border">
+            {item.name}
+          </dt>
+          <dd className="min-w-0 px-3 py-2 font-mono text-xs text-muted-foreground">
+            <span className="whitespace-pre-wrap break-all">{item.value}</span>
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function CodePreview({ value }: { value: string }) {
+  return (
+    <div className="flex min-w-0 gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5">
+      <FileCode2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      <pre className="max-h-40 min-w-0 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground">
+        {value}
+      </pre>
+    </div>
+  );
+}
+
+function AdditionalSettings({ step }: { step: Step }) {
+  const settings = [
+    step.dir ? { name: 'Working directory', value: step.dir } : null,
+    step.output ? { name: 'Output variable', value: step.output } : null,
+    step.stdout ? { name: 'stdout', value: step.stdout } : null,
+    step.stderr ? { name: 'stderr', value: step.stderr } : null,
+    step.timeoutSec !== undefined
+      ? { name: 'Timeout', value: `${step.timeoutSec}s` }
+      : null,
+    step.repeatPolicy
+      ? { name: 'Repeat policy', value: formatValue(step.repeatPolicy) }
+      : null,
+    step.parallel
+      ? { name: 'Parallel', value: formatValue(step.parallel) }
+      : null,
+    step.outputs?.length
+      ? { name: 'Outputs', value: formatValue(step.outputs) }
+      : null,
+  ].filter((setting): setting is { name: string; value: string } => !!setting);
+
+  if (settings.length === 0) {
+    return null;
+  }
+
+  return (
+    <DetailSection title="Configuration">
+      <KeyValueGrid items={settings} />
+    </DetailSection>
+  );
+}
+
+function InfoCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="min-w-0 rounded-md border border-border bg-muted/10 p-4">
+      <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function EmptyValue({ children }: { children: React.ReactNode }) {
+  return <div className="text-xs text-muted-foreground">{children}</div>;
 }
 
 function getExecutionSummary(step: Step): {
@@ -243,23 +454,17 @@ function getExecutionSummary(step: Step): {
   return { label: 'Step' };
 }
 
-function getConfigurationSummary(step: Step): string[] {
-  const items: string[] = [];
-  if (step.params) items.push('Parameters');
-  if (step.repeatPolicy?.repeat) {
-    items.push(`Repeat ${step.repeatPolicy.repeat}`);
-  }
-  if (step.timeoutSec) items.push(`${step.timeoutSec}s timeout`);
-  if (step.preconditions?.length) {
-    items.push(
-      `${step.preconditions.length} condition${step.preconditions.length === 1 ? '' : 's'}`
-    );
-  }
-  if (step.output || step.outputs?.length) items.push('Outputs');
-  return items.length > 0 ? items : ['Default'];
-}
-
 function formatLabel(value: string): string {
   const label = value.replace(/[-_]+/g, ' ');
   return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
 }

--- a/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
+++ b/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
@@ -43,11 +43,11 @@ export function ControllerSpecOverview({ dag }: Props) {
             {tasks.map((task) => (
               <div key={task.name} className="py-2.5 first:pt-1 last:pb-0">
                 <div className="min-w-0">
-                  <div className="text-sm font-medium text-foreground">
+                  <div className="whitespace-normal break-words text-sm font-medium text-foreground">
                     {task.name}
                   </div>
                   {task.description ? (
-                    <div className="mt-1 text-sm leading-relaxed text-foreground">
+                    <div className="mt-1 whitespace-normal break-words text-sm leading-relaxed text-foreground">
                       {task.description}
                     </div>
                   ) : null}
@@ -87,7 +87,7 @@ export function ControllerSpecOverview({ dag }: Props) {
                   >
                     <div className="min-w-0">
                       <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                        <span className="text-sm font-semibold text-foreground">
+                        <span className="whitespace-normal break-words text-sm font-semibold text-foreground">
                           {step.name}
                         </span>
                         {step.id && step.id !== step.name ? (
@@ -97,7 +97,7 @@ export function ControllerSpecOverview({ dag }: Props) {
                         ) : null}
                       </div>
                       {step.description ? (
-                        <p className="mt-1 line-clamp-1 text-sm leading-5 text-foreground">
+                        <p className="mt-1 line-clamp-1 whitespace-normal break-words text-sm leading-5 text-foreground">
                           {step.description}
                         </p>
                       ) : null}

--- a/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
+++ b/ui/src/features/dags/components/dag-editor/ControllerSpecOverview.tsx
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import type { components } from '@/api/v1/schema';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Bot, ChevronRight, CircleHelp, GitBranch, Target } from 'lucide-react';
+import DAGAttributes from './DAGAttributes';
+
+type DAG = components['schemas']['DAGDetails'];
+type Step = components['schemas']['Step'];
+
+const CONTROLLER_SYSTEM_STEPS = new Set(['__controller__', 'ask_user']);
+
+type Props = {
+  dag: DAG;
+  onSelectStep: (step: Step) => void;
+};
+
+/** Controller-oriented summary of goals and actions available at runtime. */
+export function ControllerSpecOverview({ dag, onSelectStep }: Props) {
+  const tasks = dag.tasks ?? [];
+  const steps = dag.steps ?? [];
+  const actions = steps.filter(
+    (step) => !CONTROLLER_SYSTEM_STEPS.has(step.name)
+  );
+  const canAskUser = steps.some((step) => step.name === 'ask_user');
+
+  return (
+    <div className="space-y-6 pb-8">
+      <div className="grid items-stretch gap-4 lg:grid-cols-[minmax(260px,0.75fr)_minmax(0,1.25fr)]">
+        <Card className="gap-0 overflow-hidden">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bot className="h-4 w-4 text-primary" />
+              Controller workflow
+            </CardTitle>
+            <CardDescription>
+              Chooses and may repeat available actions until every goal is
+              resolved.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-md border border-border bg-muted/30 p-3">
+                <div className="text-lg font-semibold text-foreground">
+                  {actions.length}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Available actions
+                </div>
+              </div>
+              <div className="rounded-md border border-border bg-muted/30 p-3">
+                <div className="text-lg font-semibold text-foreground">
+                  {tasks.length}
+                </div>
+                <div className="text-xs text-muted-foreground">Goals</div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="primary">Runtime-selected order</Badge>
+              {canAskUser ? (
+                <Badge variant="outline">
+                  <CircleHelp className="h-3 w-3" />
+                  Can ask user
+                </Badge>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="gap-0 overflow-hidden">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Target className="h-4 w-4 text-primary" />
+              Goals
+            </CardTitle>
+            <CardDescription>
+              Completion criteria the controller evaluates during the run.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            {tasks.length > 0 ? (
+              <div className="divide-y divide-border">
+                {tasks.map((task, index) => (
+                  <div key={task.name} className="flex gap-3 px-5 py-3">
+                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                      {index + 1}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground">
+                        {task.name}
+                      </div>
+                      {task.description ? (
+                        <div className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                          {task.description}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="px-5 py-4 text-sm text-muted-foreground">
+                No goals are defined.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <DAGAttributes dag={dag} />
+
+      <Card className="gap-0 overflow-hidden">
+        <CardHeader>
+          <CardTitle>Available actions</CardTitle>
+          <CardDescription>
+            Select an action to inspect its complete configuration.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {actions.length > 0 ? (
+            <div>
+              <div className="hidden grid-cols-[minmax(260px,1.4fr)_minmax(150px,0.7fr)_minmax(180px,0.8fr)_20px] gap-4 border-b border-border bg-surface-variant/40 px-5 py-2 text-xs font-semibold text-muted-foreground md:grid">
+                <div>Action</div>
+                <div>Execution</div>
+                <div>Configuration</div>
+                <div />
+              </div>
+              <div className="divide-y divide-border">
+                {actions.map((step) => {
+                  const execution = getExecutionSummary(step);
+                  const configuration = getConfigurationSummary(step);
+
+                  return (
+                    <button
+                      key={step.name}
+                      type="button"
+                      className="grid w-full gap-3 px-5 py-3 text-left transition-colors hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary md:grid-cols-[minmax(260px,1.4fr)_minmax(150px,0.7fr)_minmax(180px,0.8fr)_20px] md:items-center md:gap-4"
+                      onClick={() => onSelectStep(step)}
+                    >
+                      <div className="min-w-0">
+                        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                          <span className="break-words text-sm font-semibold text-foreground">
+                            {step.name}
+                          </span>
+                          {step.id ? (
+                            <span className="truncate font-mono text-[11px] text-muted-foreground">
+                              ID: {step.id}
+                            </span>
+                          ) : null}
+                        </div>
+                        {step.description ? (
+                          <div className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                            {step.description}
+                          </div>
+                        ) : null}
+                      </div>
+
+                      <div className="min-w-0">
+                        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground md:hidden">
+                          Execution
+                        </div>
+                        <div className="flex min-w-0 items-center gap-2">
+                          <Badge
+                            variant={step.call ? 'info' : 'outline'}
+                            className="max-w-full"
+                          >
+                            {step.call ? (
+                              <GitBranch className="h-3 w-3" />
+                            ) : null}
+                            {execution.label}
+                          </Badge>
+                          {execution.detail ? (
+                            <span
+                              className="truncate text-xs text-muted-foreground"
+                              title={execution.detail}
+                            >
+                              {execution.detail}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+
+                      <div className="min-w-0">
+                        <div className="mb-1 text-[11px] font-medium uppercase text-muted-foreground md:hidden">
+                          Configuration
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {configuration.map((item) => (
+                            <Badge key={item} variant="default">
+                              {item}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+
+                      <ChevronRight className="hidden h-4 w-4 text-muted-foreground md:block" />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : (
+            <div className="px-5 py-4 text-sm text-muted-foreground">
+              No actions are defined.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function getExecutionSummary(step: Step): {
+  label: string;
+  detail?: string;
+} {
+  if (step.call) {
+    return { label: 'Sub-DAG', detail: step.call };
+  }
+  if (step.executorConfig?.type) {
+    return { label: formatLabel(step.executorConfig.type) };
+  }
+  if (step.script) {
+    return { label: 'Script' };
+  }
+  if (step.commands?.length) {
+    return {
+      label: step.commands.length === 1 ? 'Command' : 'Commands',
+      detail: `${step.commands.length}`,
+    };
+  }
+  if (step.humanTask) {
+    return { label: 'Human task' };
+  }
+  return { label: 'Step' };
+}
+
+function getConfigurationSummary(step: Step): string[] {
+  const items: string[] = [];
+  if (step.params) items.push('Parameters');
+  if (step.repeatPolicy?.repeat) {
+    items.push(`Repeat ${step.repeatPolicy.repeat}`);
+  }
+  if (step.timeoutSec) items.push(`${step.timeoutSec}s timeout`);
+  if (step.preconditions?.length) {
+    items.push(
+      `${step.preconditions.length} condition${step.preconditions.length === 1 ? '' : 's'}`
+    );
+  }
+  if (step.output || step.outputs?.length) items.push('Outputs');
+  return items.length > 0 ? items : ['Default'];
+}
+
+function formatLabel(value: string): string {
+  const label = value.replace(/[-_]+/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { useErrorModal } from '@/components/ui/error-modal';
 import { useSimpleToast } from '@/components/ui/simple-toast';
 import { Tab, Tabs } from '@/components/ui/tabs';
+import { ToggleButton, ToggleGroup } from '@/components/ui/toggle-group';
 import {
   Tooltip,
   TooltipContent,
@@ -53,6 +54,7 @@ import {
 } from './customActionSchema';
 import DAGAttributes from './DAGAttributes';
 import DAGEditorWithDocs from './DAGEditorWithDocs';
+import { ControllerSpecOverview } from './ControllerSpecOverview';
 import ExternalChangeDialog from './ExternalChangeDialog';
 
 /**
@@ -81,6 +83,9 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
 
   const [scrollPosition, setScrollPosition] = React.useState(0);
   const [activeTab, setActiveTab] = React.useState('parent');
+  const [specView, setSpecView] = React.useState<'overview' | 'yaml'>(
+    'overview'
+  );
   const [selectedSpecStepName, setSelectedSpecStepName] = React.useState<
     string | null
   >(null);
@@ -96,6 +101,16 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       setActiveTab(tab);
       setSelectedSpecStepName(null);
       closeSpecStepDetails();
+    },
+    [closeSpecStepDetails]
+  );
+
+  const handleSpecViewChange = React.useCallback(
+    (view: 'overview' | 'yaml') => {
+      setSpecView(view);
+      if (view === 'yaml') {
+        closeSpecStepDetails();
+      }
     },
     [closeSpecStepDetails]
   );
@@ -430,6 +445,11 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       ? dag.steps?.find((step) => step.name === selectedSpecStepName)
       : undefined;
 
+    const handleStepSelect = (step: components['schemas']['Step']) => {
+      setSelectedSpecStepName(step.name);
+      setIsSpecStepDetailsOpen(true);
+    };
+
     const handleGraphNodeSelect = (nodeId: string) => {
       const step = dag.steps?.find(
         (item) => toMermaidNodeId(item.name) === nodeId
@@ -437,8 +457,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       if (!step) {
         return;
       }
-      setSelectedSpecStepName(step.name);
-      setIsSpecStepDetailsOpen(true);
+      handleStepSelect(step);
     };
 
     return (
@@ -457,55 +476,61 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
           </div>
         ) : null}
 
-        {errors?.length || !dag.steps || dag.steps.length === 0 ? (
-          <div className="py-8 px-4 text-center">
-            <AlertTriangle className="h-12 w-12 text-warning mx-auto mb-4" />
-            <p className="text-muted-foreground mb-2">
-              Cannot render graph due to configuration errors
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Please fix the errors above and save the configuration to view the
-              graph
-            </p>
-          </div>
+        {dag.type === 'controller' ? (
+          <ControllerSpecOverview dag={dag} onSelectStep={handleStepSelect} />
         ) : (
-          <div>
-            <BorderedBox className="py-4 px-4 flex flex-col overflow-x-auto">
-              <Graph
-                steps={dag.steps}
-                type="config"
-                flowchart={flowchart}
-                onChangeFlowchart={onChangeFlowchart}
-                onClickNode={handleGraphNodeSelect}
-                selectOnClick
-                showIcons={false}
-              />
-            </BorderedBox>
-            <div className="mt-2 flex justify-end">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className="flex h-7 w-7 items-center justify-center rounded bg-muted text-muted-foreground cursor-help"
-                    aria-label="Graph interactions"
-                  >
-                    <MousePointerClick className="h-3.5 w-3.5" />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Click: Inspect step details</p>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
+          <>
+            {errors?.length || !dag.steps || dag.steps.length === 0 ? (
+              <div className="py-8 px-4 text-center">
+                <AlertTriangle className="h-12 w-12 text-warning mx-auto mb-4" />
+                <p className="text-muted-foreground mb-2">
+                  Cannot render graph due to configuration errors
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Please fix the errors above and save the configuration to view
+                  the graph
+                </p>
+              </div>
+            ) : (
+              <div>
+                <BorderedBox className="py-4 px-4 flex flex-col overflow-x-auto">
+                  <Graph
+                    steps={dag.steps}
+                    type="config"
+                    flowchart={flowchart}
+                    onChangeFlowchart={onChangeFlowchart}
+                    onClickNode={handleGraphNodeSelect}
+                    selectOnClick
+                    showIcons={false}
+                  />
+                </BorderedBox>
+                <div className="mt-2 flex justify-end">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div
+                        className="flex h-7 w-7 items-center justify-center rounded bg-muted text-muted-foreground cursor-help"
+                        aria-label="Graph interactions"
+                      >
+                        <MousePointerClick className="h-3.5 w-3.5" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Click: Inspect step details</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              </div>
+            )}
+
+            <DAGAttributes dag={dag} />
+
+            {dag.steps ? (
+              <div className="overflow-hidden">
+                <DAGStepTable steps={dag.steps} />
+              </div>
+            ) : null}
+          </>
         )}
-
-        <DAGAttributes dag={dag} />
-
-        {dag.steps ? (
-          <div className="overflow-hidden">
-            <DAGStepTable steps={dag.steps} />
-          </div>
-        ) : null}
 
         {getHandlers(dag)?.length ? (
           <div className="overflow-hidden">
@@ -610,51 +635,86 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                   </div>
                 )}
 
-                {(() => {
-                  if (activeTab === 'parent') {
-                    return (
-                      data?.dag && (
-                        <div className="flex-shrink-0">
-                          {renderDAGContent(data.dag, data?.errors)}
-                        </div>
-                      )
-                    );
-                  }
-                  const selectedLocalDag = localDags?.find(
-                    (ld: components['schemas']['LocalDag']) =>
-                      ld.name === activeTab
-                  );
-                  return (
-                    selectedLocalDag?.dag && (
-                      <div className="flex-shrink-0">
-                        {renderDAGContent(
-                          selectedLocalDag.dag,
-                          selectedLocalDag.errors
-                        )}
-                      </div>
-                    )
-                  );
-                })()}
+                <div className="flex flex-shrink-0 justify-end">
+                  <ToggleGroup aria-label="Spec view">
+                    <ToggleButton
+                      value="overview"
+                      groupValue={specView}
+                      onClick={() => handleSpecViewChange('overview')}
+                      aria-label="Overview"
+                    >
+                      Overview
+                    </ToggleButton>
+                    <ToggleButton
+                      value="yaml"
+                      groupValue={specView}
+                      onClick={() => handleSpecViewChange('yaml')}
+                      aria-label={
+                        localHasUnsavedChanges
+                          ? 'YAML editor, unsaved changes'
+                          : 'YAML editor'
+                      }
+                    >
+                      YAML
+                      {localHasUnsavedChanges ? (
+                        <span
+                          className="ml-2 h-1.5 w-1.5 rounded-full bg-current"
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                    </ToggleButton>
+                  </ToggleGroup>
+                </div>
 
-                <DAGEditorWithDocs
-                  value={
-                    editable
-                      ? (currentValue ?? serverSpec ?? '')
-                      : (serverSpec ?? '')
-                  }
-                  readOnly={!editable}
-                  onChange={
-                    editable
-                      ? (newValue) => {
-                          setCurrentValue(newValue ?? '');
-                        }
-                      : undefined
-                  }
-                  className="min-h-[400px]"
-                  modelUri={editorModelUri}
-                  schema={editorSchema}
-                  headerActions={editorHeaderActions}
-                />
+                {specView === 'overview'
+                  ? (() => {
+                      if (activeTab === 'parent') {
+                        return (
+                          data?.dag && (
+                            <div className="flex-shrink-0">
+                              {renderDAGContent(data.dag, data?.errors)}
+                            </div>
+                          )
+                        );
+                      }
+                      const selectedLocalDag = localDags?.find(
+                        (ld: components['schemas']['LocalDag']) =>
+                          ld.name === activeTab
+                      );
+                      return (
+                        selectedLocalDag?.dag && (
+                          <div className="flex-shrink-0">
+                            {renderDAGContent(
+                              selectedLocalDag.dag,
+                              selectedLocalDag.errors
+                            )}
+                          </div>
+                        )
+                      );
+                    })()
+                  : null}
+
+                {specView === 'yaml' ? (
+                  <DAGEditorWithDocs
+                    value={
+                      editable
+                        ? (currentValue ?? serverSpec ?? '')
+                        : (serverSpec ?? '')
+                    }
+                    readOnly={!editable}
+                    onChange={
+                      editable
+                        ? (newValue) => {
+                            setCurrentValue(newValue ?? '');
+                          }
+                        : undefined
+                    }
+                    className="min-h-[640px] flex-1"
+                    modelUri={editorModelUri}
+                    schema={editorSchema}
+                    headerActions={editorHeaderActions}
+                  />
+                ) : null}
               </div>
             </React.Fragment>
           )

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -19,7 +19,6 @@ import { Button } from '@/components/ui/button';
 import { useErrorModal } from '@/components/ui/error-modal';
 import { useSimpleToast } from '@/components/ui/simple-toast';
 import { Tab, Tabs } from '@/components/ui/tabs';
-import { ToggleButton, ToggleGroup } from '@/components/ui/toggle-group';
 import {
   Tooltip,
   TooltipContent,
@@ -83,9 +82,6 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
 
   const [scrollPosition, setScrollPosition] = React.useState(0);
   const [activeTab, setActiveTab] = React.useState('parent');
-  const [specView, setSpecView] = React.useState<'overview' | 'yaml'>(
-    'overview'
-  );
   const [selectedSpecStepName, setSelectedSpecStepName] = React.useState<
     string | null
   >(null);
@@ -101,16 +97,6 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       setActiveTab(tab);
       setSelectedSpecStepName(null);
       closeSpecStepDetails();
-    },
-    [closeSpecStepDetails]
-  );
-
-  const handleSpecViewChange = React.useCallback(
-    (view: 'overview' | 'yaml') => {
-      setSpecView(view);
-      if (view === 'yaml') {
-        closeSpecStepDetails();
-      }
     },
     [closeSpecStepDetails]
   );
@@ -477,11 +463,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
         ) : null}
 
         {dag.type === 'controller' ? (
-          <ControllerSpecOverview
-            dag={dag}
-            onEditYAML={() => handleSpecViewChange('yaml')}
-            yamlActionLabel={editable ? 'Edit YAML' : 'View YAML'}
-          />
+          <ControllerSpecOverview dag={dag} />
         ) : (
           <>
             {errors?.length || !dag.steps || dag.steps.length === 0 ? (
@@ -606,7 +588,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
               />
 
               <div
-                className="flex flex-col flex-1 min-h-0 space-y-6 mb-6"
+                className="flex min-h-0 flex-1 flex-col space-y-6 pb-8"
                 ref={containerRef}
               >
                 {hasLocalDags && (
@@ -639,66 +621,36 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                   </div>
                 )}
 
-                <div className="flex flex-shrink-0 justify-end">
-                  <ToggleGroup aria-label="Spec view">
-                    <ToggleButton
-                      value="overview"
-                      groupValue={specView}
-                      onClick={() => handleSpecViewChange('overview')}
-                      aria-label="Overview"
-                    >
-                      Overview
-                    </ToggleButton>
-                    <ToggleButton
-                      value="yaml"
-                      groupValue={specView}
-                      onClick={() => handleSpecViewChange('yaml')}
-                      aria-label={
-                        localHasUnsavedChanges
-                          ? 'YAML editor, unsaved changes'
-                          : 'YAML editor'
-                      }
-                    >
-                      YAML
-                      {localHasUnsavedChanges ? (
-                        <span
-                          className="ml-2 h-1.5 w-1.5 rounded-full bg-current"
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                    </ToggleButton>
-                  </ToggleGroup>
-                </div>
+                {(() => {
+                  if (activeTab === 'parent') {
+                    return (
+                      data?.dag && (
+                        <div className="flex-shrink-0">
+                          {renderDAGContent(data.dag, data?.errors)}
+                        </div>
+                      )
+                    );
+                  }
+                  const selectedLocalDag = localDags?.find(
+                    (ld: components['schemas']['LocalDag']) =>
+                      ld.name === activeTab
+                  );
+                  return (
+                    selectedLocalDag?.dag && (
+                      <div className="flex-shrink-0">
+                        {renderDAGContent(
+                          selectedLocalDag.dag,
+                          selectedLocalDag.errors
+                        )}
+                      </div>
+                    )
+                  );
+                })()}
 
-                {specView === 'overview'
-                  ? (() => {
-                      if (activeTab === 'parent') {
-                        return (
-                          data?.dag && (
-                            <div className="flex-shrink-0">
-                              {renderDAGContent(data.dag, data?.errors)}
-                            </div>
-                          )
-                        );
-                      }
-                      const selectedLocalDag = localDags?.find(
-                        (ld: components['schemas']['LocalDag']) =>
-                          ld.name === activeTab
-                      );
-                      return (
-                        selectedLocalDag?.dag && (
-                          <div className="flex-shrink-0">
-                            {renderDAGContent(
-                              selectedLocalDag.dag,
-                              selectedLocalDag.errors
-                            )}
-                          </div>
-                        )
-                      );
-                    })()
-                  : null}
-
-                {specView === 'yaml' ? (
+                <section className="flex-shrink-0 space-y-3">
+                  <h2 className="text-lg font-semibold text-foreground">
+                    YAML
+                  </h2>
                   <DAGEditorWithDocs
                     value={
                       editable
@@ -713,12 +665,12 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                           }
                         : undefined
                     }
-                    className="min-h-[640px] flex-1"
+                    className="min-h-[640px]"
                     modelUri={editorModelUri}
                     schema={editorSchema}
                     headerActions={editorHeaderActions}
                   />
-                ) : null}
+                </section>
               </div>
             </React.Fragment>
           )

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -477,7 +477,11 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
         ) : null}
 
         {dag.type === 'controller' ? (
-          <ControllerSpecOverview dag={dag} onSelectStep={handleStepSelect} />
+          <ControllerSpecOverview
+            dag={dag}
+            onEditYAML={() => handleSpecViewChange('yaml')}
+            yamlActionLabel={editable ? 'Edit YAML' : 'View YAML'}
+          />
         ) : (
           <>
             {errors?.length || !dag.steps || dag.steps.length === 0 ? (

--- a/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
+++ b/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import {
+  components,
+  ControllerTaskStatus,
+  DAGDetailsType,
+} from '@/api/v1/schema';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ControllerSpecOverview } from '../ControllerSpecOverview';
+
+describe('ControllerSpecOverview', () => {
+  it('presents controller goals and selectable declared actions', async () => {
+    const user = userEvent.setup();
+    const onSelectStep = vi.fn();
+    const reviewStep = {
+      name: 'review',
+      description: 'Review the package from one focused angle.',
+      call: 'quality-review-pass',
+      params: 'angle=complexity repo=${params.repo}',
+    } satisfies components['schemas']['Step'];
+    const dag = {
+      name: 'code-quality-audit',
+      type: DAGDetailsType.controller,
+      tasks: [
+        {
+          name: 'confirmed-findings',
+          description:
+            'Every reported finding has been independently verified.',
+          status: ControllerTaskStatus.open,
+        },
+      ],
+      steps: [
+        {
+          name: 'inspect',
+          description: 'Build the deterministic package inventory.',
+          script: 'go list ./...',
+        },
+        reviewStep,
+        {
+          name: '__controller__',
+          description: 'LLM controller',
+          executorConfig: { type: 'controller' },
+        },
+        {
+          name: 'ask_user',
+          id: 'ask_user',
+          description: 'Question asked by the controller',
+        },
+      ],
+    } satisfies components['schemas']['DAGDetails'];
+
+    render(<ControllerSpecOverview dag={dag} onSelectStep={onSelectStep} />);
+
+    expect(screen.getByText('confirmed-findings')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /inspect/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Can ask user')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /review/i }));
+
+    expect(onSelectStep).toHaveBeenCalledWith(reviewStep);
+  });
+});

--- a/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
+++ b/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
@@ -6,22 +6,16 @@ import {
   ControllerTaskStatus,
   DAGDetailsType,
 } from '@/api/v1/schema';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ControllerSpecOverview } from '../ControllerSpecOverview';
 
 describe('ControllerSpecOverview', () => {
-  it('presents controller goals and selectable declared actions', async () => {
+  it('shows compact actions and the selected action configuration', async () => {
     const user = userEvent.setup();
-    const onSelectStep = vi.fn();
-    const reviewStep = {
-      name: 'review',
-      description: 'Review the package from one focused angle.',
-      call: 'quality-review-pass',
-      params: 'angle=complexity repo=${params.repo}',
-    } satisfies components['schemas']['Step'];
+    const onEditYAML = vi.fn();
     const dag = {
       name: 'code-quality-audit',
       type: DAGDetailsType.controller,
@@ -36,10 +30,18 @@ describe('ControllerSpecOverview', () => {
       steps: [
         {
           name: 'inspect',
+          id: 'inspect',
           description: 'Build the deterministic package inventory.',
           script: 'go list ./...',
+          dir: '${params.repo}',
         },
-        reviewStep,
+        {
+          name: 'review',
+          id: 'review',
+          description: 'Review the package from one focused angle.',
+          call: 'quality-review-pass',
+          params: 'angle=complexity repo=${params.repo}',
+        },
         {
           name: '__controller__',
           description: 'LLM controller',
@@ -53,16 +55,35 @@ describe('ControllerSpecOverview', () => {
       ],
     } satisfies components['schemas']['DAGDetails'];
 
-    render(<ControllerSpecOverview dag={dag} onSelectStep={onSelectStep} />);
+    render(<ControllerSpecOverview dag={dag} onEditYAML={onEditYAML} />);
 
     expect(screen.getByText('confirmed-findings')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /inspect/i })
-    ).toBeInTheDocument();
     expect(screen.getByText('Can ask user')).toBeInTheDocument();
+    expect(screen.queryByText('LLM controller')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /review/i }));
+    const inspectButton = screen.getByRole('button', { name: /inspect/i });
+    const reviewButton = screen.getByRole('button', { name: /review/i });
+    expect(inspectButton).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('go list ./...')).toBeInTheDocument();
 
-    expect(onSelectStep).toHaveBeenCalledWith(reviewStep);
+    await user.click(reviewButton);
+
+    expect(reviewButton).toHaveAttribute('aria-pressed', 'true');
+    expect(inspectButton).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText('quality-review-pass')).toBeInTheDocument();
+
+    const parameters = screen
+      .getByRole('heading', {
+        name: 'Parameters',
+      })
+      .closest('section');
+    expect(parameters).not.toBeNull();
+    expect(within(parameters!).getByText('angle')).toBeInTheDocument();
+    expect(within(parameters!).getByText('complexity')).toBeInTheDocument();
+    expect(within(parameters!).getByText('repo')).toBeInTheDocument();
+    expect(within(parameters!).getByText('${params.repo}')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit YAML' }));
+    expect(onEditYAML).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
+++ b/ui/src/features/dags/components/dag-editor/__tests__/ControllerSpecOverview.test.tsx
@@ -9,13 +9,12 @@ import {
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ControllerSpecOverview } from '../ControllerSpecOverview';
 
 describe('ControllerSpecOverview', () => {
   it('shows compact actions and the selected action configuration', async () => {
     const user = userEvent.setup();
-    const onEditYAML = vi.fn();
     const dag = {
       name: 'code-quality-audit',
       type: DAGDetailsType.controller,
@@ -55,11 +54,15 @@ describe('ControllerSpecOverview', () => {
       ],
     } satisfies components['schemas']['DAGDetails'];
 
-    render(<ControllerSpecOverview dag={dag} onEditYAML={onEditYAML} />);
+    render(<ControllerSpecOverview dag={dag} />);
 
+    expect(screen.getByRole('heading', { name: 'Tasks' })).toBeInTheDocument();
     expect(screen.getByText('confirmed-findings')).toBeInTheDocument();
-    expect(screen.getByText('Can ask user')).toBeInTheDocument();
-    expect(screen.queryByText('LLM controller')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Every reported finding has been independently verified.'
+      )
+    ).toBeInTheDocument();
 
     const inspectButton = screen.getByRole('button', { name: /inspect/i });
     const reviewButton = screen.getByRole('button', { name: /review/i });
@@ -82,8 +85,5 @@ describe('ControllerSpecOverview', () => {
     expect(within(parameters!).getByText('complexity')).toBeInTheDocument();
     expect(within(parameters!).getByText('repo')).toBeInTheDocument();
     expect(within(parameters!).getByText('${params.repo}')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Edit YAML' }));
-    expect(onEditYAML).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- add a controller-specific master-detail Spec overview with stable action selection, readable task text, and structured action configuration
- compact generic DAG step and Harness summaries so long execution details no longer distort table rows
- keep DAG navigation actions responsive and place the YAML editor below the visual overview with consistent bottom spacing

## Why

Controller DAGs do not have a fixed graph execution order, but the Spec page rendered them through the same graph/table presentation as regular DAGs. Long descriptions, scripts, and raw configuration values made rows excessively tall and difficult to scan. The separate Overview/YAML mode also constrained the editor and added unnecessary navigation.

## Impact

Controller workflows now present runtime-selectable actions directly, preserve a stable layout while switching actions, and expose the YAML editor in the same continuous page. Regular DAG tables retain their existing behavior with more compact execution summaries and safer column sizing.

## Validation

- `pnpm test` — 555 tests passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the DAG Spec page: controller DAGs now use a master–detail action overview with wrapped text, and regular DAG step tables are more compact and scannable. The YAML editor now sits below the overview with a larger default height.

- **New Features**
  - Added `ControllerSpecOverview` with a wrapped task list, selectable actions, and structured panels for execution, parameters, and configuration.
  - Introduced a compact Harness step summary for tables showing provider, total option count, fallback count, and a truncated prompt; moved the YAML editor under the overview with a "YAML" header and a 640px min height.

- **Bug Fixes**
  - Prevented oversized step rows with top-aligned cells, a fixed/balanced column layout (960px min width), and truncation/clamping for long IDs, descriptions, directories, and params (with a full-value tooltip).
  - Improved responsiveness for tabs and overflow (now tuned at the `lg` breakpoint), and ensured controller overview text wraps instead of overflowing.

<sup>Written for commit 708437c6c5a3ed56a6a438154c2f4b927e56d9b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a controller-focused DAG inspection view with task selection and detailed execution information, including parameters, conditions, scripts, commands, and executor settings.
  * Added compact harness step summaries showing provider, option and fallback counts, and truncated prompts.

* **Improvements**
  * Improved DAG step table responsiveness, text wrapping, truncation, spacing, and parameter accessibility.
  * Updated tab layouts to use more screen widths effectively.
  * Increased the editor’s minimum height and clarified the YAML section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->