### PR TITLE
fix: keep proc liveness usable when a proc file is damaged

### DIFF
--- a/internal/cmd/restart_test.go
+++ b/internal/cmd/restart_test.go
@@ -117,12 +117,5 @@ steps:
 func builtExecutableRestartWaitTimeout(t *testing.T) time.Duration {
 	t.Helper()
 
-	timeout := 6 * commandLogWaitTimeout()
-	if deadline, ok := t.Deadline(); ok {
-		remaining := time.Until(deadline) - 15*time.Second
-		if remaining > 0 && remaining < timeout {
-			return remaining
-		}
-	}
-	return timeout
+	return boundedWaitTimeout(t, 6*commandLogWaitTimeout())
 }

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -30,7 +30,23 @@ func executeCommand(ctx context.Context, c *cobra.Command, args []string) error 
 	return c.Execute()
 }
 
-// waitForDAGRunning waits until the DAG is in running state.
+// boundedWaitTimeout returns want, shortened when needed to stay inside the
+// test deadline.
+func boundedWaitTimeout(t *testing.T, want time.Duration) time.Duration {
+	t.Helper()
+
+	if deadline, ok := t.Deadline(); ok {
+		remaining := time.Until(deadline) - 15*time.Second
+		if remaining > 0 && remaining < want {
+			return remaining
+		}
+	}
+	return want
+}
+
+// waitForDAGRunning waits until the DAG is in running state. Reaching it means
+// spawning a process and writing the first status file, and that cost varies
+// widely with host load, so the budget is generous rather than fixed.
 func waitForDAGRunning(t *testing.T, th test.Command, dagLocation string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
@@ -43,7 +59,7 @@ func waitForDAGRunning(t *testing.T, th test.Command, dagLocation string) {
 			return false
 		}
 		return status.Status == core.Running
-	}, time.Second*3, time.Millisecond*50)
+	}, boundedWaitTimeout(t, time.Minute), time.Millisecond*50)
 }
 
 func TestStatusCommand(t *testing.T) {

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -549,9 +549,8 @@ type Worker struct {
 
 // Proc represents local proc-file heartbeat configuration.
 type Proc struct {
-	HeartbeatInterval     time.Duration // Default: 5s
-	HeartbeatSyncInterval time.Duration // Default: 10s
-	StaleThreshold        time.Duration // Default: 90s
+	HeartbeatInterval time.Duration // Default: 5s
+	StaleThreshold    time.Duration // Default: 90s
 }
 
 // Scheduler represents the scheduler configuration.
@@ -645,12 +644,6 @@ func (c *Config) validateProc() error {
 		return fmt.Errorf(
 			"proc.heartbeat_interval (%s) must be less than proc.stale_threshold (%s)",
 			p.HeartbeatInterval, p.StaleThreshold,
-		)
-	}
-	if p.HeartbeatSyncInterval > 0 && p.StaleThreshold > 0 && p.HeartbeatSyncInterval >= p.StaleThreshold {
-		return fmt.Errorf(
-			"proc.heartbeat_sync_interval (%s) must be less than proc.stale_threshold (%s)",
-			p.HeartbeatSyncInterval, p.StaleThreshold,
 		)
 	}
 	return nil

--- a/internal/cmn/config/config_test.go
+++ b/internal/cmn/config/config_test.go
@@ -238,17 +238,6 @@ func TestConfig_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "proc.heartbeat_interval")
 	})
 
-	t.Run("InvalidProcHeartbeatSyncInterval", func(t *testing.T) {
-		t.Parallel()
-		cfg := validBaseConfig()
-		cfg.Proc.HeartbeatSyncInterval = 10 * time.Second
-		cfg.Proc.StaleThreshold = 10 * time.Second
-
-		err := cfg.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "proc.heartbeat_sync_interval")
-	})
-
 	t.Run("InvalidMaxDashboardPageLimit_Negative", func(t *testing.T) {
 		t.Parallel()
 		cfg := validBaseConfig()

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -378,9 +378,8 @@ type PostgresPoolDef struct {
 
 // ProcDef configures local proc-file heartbeat behavior.
 type ProcDef struct {
-	HeartbeatInterval     string `mapstructure:"heartbeat_interval"`      // Default: 5s
-	HeartbeatSyncInterval string `mapstructure:"heartbeat_sync_interval"` // Default: 10s
-	StaleThreshold        string `mapstructure:"stale_threshold"`         // Default: 90s
+	HeartbeatInterval string `mapstructure:"heartbeat_interval"` // Default: 5s
+	StaleThreshold    string `mapstructure:"stale_threshold"`    // Default: 90s
 }
 
 // SchedulerDef configures the scheduler.
@@ -391,7 +390,6 @@ type SchedulerDef struct {
 	ZombieDetectionInterval string `mapstructure:"zombie_detection_interval"` // Default: 45s, 0 to disable
 	RetryFailureWindow      string `mapstructure:"retry_failure_window"`      // Default: 24h, 0 to disable retry scanning. Current limitation: the window is evaluated from the original DAG-run timestamp/day bucket, not the latest failed attempt timestamp.
 	HeartbeatInterval       string `mapstructure:"heartbeat_interval"`        // Deprecated: use proc.heartbeat_interval
-	HeartbeatSyncInterval   string `mapstructure:"heartbeat_sync_interval"`   // Deprecated: use proc.heartbeat_sync_interval
 	StaleThreshold          string `mapstructure:"stale_threshold"`           // Deprecated: use proc.stale_threshold
 	FailureThreshold        int    `mapstructure:"failure_threshold"`         // Default: 3
 }

--- a/internal/cmn/config/key_hints.go
+++ b/internal/cmn/config/key_hints.go
@@ -142,14 +142,12 @@ var legacyToSnakeCaseKey = map[string]string{
 	"scheduler.lockretryinterval":       "scheduler.lock_retry_interval",
 	"scheduler.zombiedetectioninterval": "scheduler.zombie_detection_interval",
 	"scheduler.heartbeatinterval":       "scheduler.heartbeat_interval",
-	"scheduler.heartbeatsyncinterval":   "scheduler.heartbeat_sync_interval",
 	"scheduler.stalethreshold":          "scheduler.stale_threshold",
 	"scheduler.failurethreshold":        "scheduler.failure_threshold",
 
 	// Proc
-	"proc.heartbeatinterval":     "proc.heartbeat_interval",
-	"proc.heartbeatsyncinterval": "proc.heartbeat_sync_interval",
-	"proc.stalethreshold":        "proc.stale_threshold",
+	"proc.heartbeatinterval": "proc.heartbeat_interval",
+	"proc.stalethreshold":    "proc.stale_threshold",
 
 	// Queue
 	"queues.config.maxactiveruns":  "queues.config.max_active_runs",

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -1444,11 +1444,6 @@ func (l *ConfigLoader) loadProcConfig(cfg *Config, def Definition) {
 			"proc.heartbeat_interval", l.v.GetString("proc.heartbeat_interval"),
 		)
 	}
-	if l.v.IsSet("proc.heartbeat_sync_interval") {
-		cfg.Proc.HeartbeatSyncInterval = l.parseDuration(
-			"proc.heartbeat_sync_interval", l.v.GetString("proc.heartbeat_sync_interval"),
-		)
-	}
 	if l.v.IsSet("proc.stale_threshold") {
 		cfg.Proc.StaleThreshold = l.parseDuration(
 			"proc.stale_threshold", l.v.GetString("proc.stale_threshold"),
@@ -1465,12 +1460,6 @@ func (l *ConfigLoader) loadLegacySchedulerProcConfig(cfg *Config, def Definition
 		"proc.heartbeat_interval",
 		"scheduler.heartbeat_interval",
 		l.schedulerLegacyValue(def, "scheduler.heartbeat_interval", func(sd *SchedulerDef) string { return sd.HeartbeatInterval }),
-	)
-	l.applyDeprecatedProcAlias(
-		&cfg.Proc.HeartbeatSyncInterval,
-		"proc.heartbeat_sync_interval",
-		"scheduler.heartbeat_sync_interval",
-		l.schedulerLegacyValue(def, "scheduler.heartbeat_sync_interval", func(sd *SchedulerDef) string { return sd.HeartbeatSyncInterval }),
 	)
 	l.applyDeprecatedProcAlias(
 		&cfg.Proc.StaleThreshold,
@@ -1511,9 +1500,6 @@ func (l *ConfigLoader) applyDeprecatedProcAlias(
 func (l *ConfigLoader) setProcDefaults(cfg *Config) {
 	if cfg.Proc.HeartbeatInterval <= 0 {
 		cfg.Proc.HeartbeatInterval = 5 * time.Second
-	}
-	if cfg.Proc.HeartbeatSyncInterval <= 0 {
-		cfg.Proc.HeartbeatSyncInterval = 10 * time.Second
 	}
 	if cfg.Proc.StaleThreshold <= 0 {
 		cfg.Proc.StaleThreshold = 90 * time.Second
@@ -2054,11 +2040,9 @@ var envBindings = []envBinding{
 
 	// Proc
 	{key: "proc.heartbeat_interval", env: "PROC_HEARTBEAT_INTERVAL"},
-	{key: "proc.heartbeat_sync_interval", env: "PROC_HEARTBEAT_SYNC_INTERVAL"},
 	{key: "proc.stale_threshold", env: "PROC_STALE_THRESHOLD"},
 	// Proc (legacy scheduler aliases)
 	{key: "scheduler.heartbeat_interval", env: "SCHEDULER_HEARTBEAT_INTERVAL"},
-	{key: "scheduler.heartbeat_sync_interval", env: "SCHEDULER_HEARTBEAT_SYNC_INTERVAL"},
 	{key: "scheduler.stale_threshold", env: "SCHEDULER_STALE_THRESHOLD"},
 
 	// UI

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -351,9 +351,8 @@ func TestLoad_Env(t *testing.T) {
 			},
 		},
 		Proc: Proc{
-			HeartbeatInterval:     5 * time.Second,
-			HeartbeatSyncInterval: 10 * time.Second,
-			StaleThreshold:        90 * time.Second,
+			HeartbeatInterval: 5 * time.Second,
+			StaleThreshold:    90 * time.Second,
 		},
 		Scheduler: Scheduler{
 			Port:                    9999,
@@ -810,9 +809,8 @@ scheduler:
 			},
 		},
 		Proc: Proc{
-			HeartbeatInterval:     5 * time.Second,
-			HeartbeatSyncInterval: 10 * time.Second,
-			StaleThreshold:        90 * time.Second,
+			HeartbeatInterval: 5 * time.Second,
+			StaleThreshold:    90 * time.Second,
 		},
 		Scheduler: Scheduler{
 			Port:                    7890,
@@ -1021,21 +1019,17 @@ auth:
   mode: none
 proc:
   heartbeat_interval: 7s
-  heartbeat_sync_interval: 11s
   stale_threshold: 95s
 scheduler:
   heartbeat_interval: 20s
-  heartbeat_sync_interval: 25s
   stale_threshold: 120s
 `)
 
 		assert.Equal(t, 7*time.Second, cfg.Proc.HeartbeatInterval)
-		assert.Equal(t, 11*time.Second, cfg.Proc.HeartbeatSyncInterval)
 		assert.Equal(t, 95*time.Second, cfg.Proc.StaleThreshold)
-		require.Len(t, cfg.Warnings, 3)
+		require.Len(t, cfg.Warnings, 2)
 		assert.Contains(t, cfg.Warnings[0], "scheduler.heartbeat_interval is deprecated and ignored")
-		assert.Contains(t, cfg.Warnings[1], "scheduler.heartbeat_sync_interval is deprecated and ignored")
-		assert.Contains(t, cfg.Warnings[2], "scheduler.stale_threshold is deprecated and ignored")
+		assert.Contains(t, cfg.Warnings[1], "scheduler.stale_threshold is deprecated and ignored")
 	})
 
 	t.Run("ProcConfigLegacySchedulerFallback", func(t *testing.T) {
@@ -1044,17 +1038,14 @@ auth:
   mode: none
 scheduler:
   heartbeat_interval: 8s
-  heartbeat_sync_interval: 12s
   stale_threshold: 100s
 `)
 
 		assert.Equal(t, 8*time.Second, cfg.Proc.HeartbeatInterval)
-		assert.Equal(t, 12*time.Second, cfg.Proc.HeartbeatSyncInterval)
 		assert.Equal(t, 100*time.Second, cfg.Proc.StaleThreshold)
-		require.Len(t, cfg.Warnings, 3)
+		require.Len(t, cfg.Warnings, 2)
 		assert.Contains(t, cfg.Warnings[0], "scheduler.heartbeat_interval is deprecated")
-		assert.Contains(t, cfg.Warnings[1], "scheduler.heartbeat_sync_interval is deprecated")
-		assert.Contains(t, cfg.Warnings[2], "scheduler.stale_threshold is deprecated")
+		assert.Contains(t, cfg.Warnings[1], "scheduler.stale_threshold is deprecated")
 	})
 
 	t.Run("ProcConfigLoadsForServiceScopedCommands", func(t *testing.T) {
@@ -1075,7 +1066,6 @@ auth:
   mode: none
 proc:
   heartbeat_interval: 6s
-  heartbeat_sync_interval: 9s
   stale_threshold: 75s
 `), 0600)
 				require.NoError(t, err)
@@ -1083,7 +1073,6 @@ proc:
 				cfg := testLoad(t, WithConfigFile(configFile), WithService(tc.service))
 
 				assert.Equal(t, 6*time.Second, cfg.Proc.HeartbeatInterval)
-				assert.Equal(t, 9*time.Second, cfg.Proc.HeartbeatSyncInterval)
 				assert.Equal(t, 75*time.Second, cfg.Proc.StaleThreshold)
 			})
 		}
@@ -1634,30 +1623,25 @@ secrets:
 func TestLoad_ProcConfig(t *testing.T) {
 	t.Run("FromEnv", func(t *testing.T) {
 		cfg := loadWithEnv(t, "# empty", map[string]string{
-			"DAGU_AUTH_MODE":                    "none",
-			"DAGU_PROC_HEARTBEAT_INTERVAL":      "6s",
-			"DAGU_PROC_HEARTBEAT_SYNC_INTERVAL": "9s",
-			"DAGU_PROC_STALE_THRESHOLD":         "75s",
+			"DAGU_AUTH_MODE":               "none",
+			"DAGU_PROC_HEARTBEAT_INTERVAL": "6s",
+			"DAGU_PROC_STALE_THRESHOLD":    "75s",
 		})
 		assert.Equal(t, 6*time.Second, cfg.Proc.HeartbeatInterval)
-		assert.Equal(t, 9*time.Second, cfg.Proc.HeartbeatSyncInterval)
 		assert.Equal(t, 75*time.Second, cfg.Proc.StaleThreshold)
 	})
 
 	t.Run("LegacySchedulerEnvFallback", func(t *testing.T) {
 		cfg := loadWithEnv(t, "# empty", map[string]string{
-			"DAGU_AUTH_MODE":                         "none",
-			"DAGU_SCHEDULER_HEARTBEAT_INTERVAL":      "8s",
-			"DAGU_SCHEDULER_HEARTBEAT_SYNC_INTERVAL": "12s",
-			"DAGU_SCHEDULER_STALE_THRESHOLD":         "100s",
+			"DAGU_AUTH_MODE":                    "none",
+			"DAGU_SCHEDULER_HEARTBEAT_INTERVAL": "8s",
+			"DAGU_SCHEDULER_STALE_THRESHOLD":    "100s",
 		})
 		assert.Equal(t, 8*time.Second, cfg.Proc.HeartbeatInterval)
-		assert.Equal(t, 12*time.Second, cfg.Proc.HeartbeatSyncInterval)
 		assert.Equal(t, 100*time.Second, cfg.Proc.StaleThreshold)
-		require.Len(t, cfg.Warnings, 3)
+		require.Len(t, cfg.Warnings, 2)
 		assert.Contains(t, cfg.Warnings[0], "scheduler.heartbeat_interval is deprecated")
-		assert.Contains(t, cfg.Warnings[1], "scheduler.heartbeat_sync_interval is deprecated")
-		assert.Contains(t, cfg.Warnings[2], "scheduler.stale_threshold is deprecated")
+		assert.Contains(t, cfg.Warnings[1], "scheduler.stale_threshold is deprecated")
 	})
 }
 

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -1178,10 +1178,6 @@
           "type": "string",
           "description": "Deprecated: use proc.heartbeat_interval. Heartbeat write interval for process liveness. Default: '5s'."
         },
-        "heartbeat_sync_interval": {
-          "type": "string",
-          "description": "Deprecated: use proc.heartbeat_sync_interval. Heartbeat fsync interval. Default: '10s'."
-        },
         "stale_threshold": {
           "type": "string",
           "description": "Deprecated: use proc.stale_threshold. Duration after which a process heartbeat is considered stale. Default: '90s'."
@@ -1196,10 +1192,6 @@
         "heartbeat_interval": {
           "type": "string",
           "description": "Heartbeat write interval for process liveness. Default: '5s'."
-        },
-        "heartbeat_sync_interval": {
-          "type": "string",
-          "description": "Heartbeat fsync interval. Default: '10s'."
         },
         "stale_threshold": {
           "type": "string",

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -1178,6 +1178,10 @@
           "type": "string",
           "description": "Deprecated: use proc.heartbeat_interval. Heartbeat write interval for process liveness. Default: '5s'."
         },
+        "heartbeat_sync_interval": {
+          "type": "string",
+          "description": "Deprecated and ignored. Accepted so existing configuration files remain valid."
+        },
         "stale_threshold": {
           "type": "string",
           "description": "Deprecated: use proc.stale_threshold. Duration after which a process heartbeat is considered stale. Default: '90s'."
@@ -1192,6 +1196,10 @@
         "heartbeat_interval": {
           "type": "string",
           "description": "Heartbeat write interval for process liveness. Default: '5s'."
+        },
+        "heartbeat_sync_interval": {
+          "type": "string",
+          "description": "Deprecated and ignored. Accepted so existing configuration files remain valid."
         },
         "stale_threshold": {
           "type": "string",

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -47,9 +47,8 @@ type fixtureConfig struct {
 }
 
 type procConfig struct {
-	heartbeatInterval     time.Duration
-	heartbeatSyncInterval time.Duration
-	staleThreshold        time.Duration
+	heartbeatInterval time.Duration
+	staleThreshold    time.Duration
 }
 
 type fixtureOption func(*fixtureConfig)
@@ -105,12 +104,11 @@ func withWorkerBaseConfigPath(path string) fixtureOption {
 	return func(c *fixtureConfig) { c.workerBaseConfigPath = path }
 }
 
-func withProcConfig(heartbeatInterval, heartbeatSyncInterval, staleThreshold time.Duration) fixtureOption {
+func withProcConfig(heartbeatInterval, staleThreshold time.Duration) fixtureOption {
 	return func(c *fixtureConfig) {
 		c.procConfig = &procConfig{
-			heartbeatInterval:     heartbeatInterval,
-			heartbeatSyncInterval: heartbeatSyncInterval,
-			staleThreshold:        staleThreshold,
+			heartbeatInterval: heartbeatInterval,
+			staleThreshold:    staleThreshold,
 		}
 	}
 }
@@ -163,7 +161,6 @@ func newTestFixture(t *testing.T, yaml string, opts ...fixtureOption) *testFixtu
 		c.Scheduler.Port = 0
 		if cfg.procConfig != nil {
 			c.Proc.HeartbeatInterval = cfg.procConfig.heartbeatInterval
-			c.Proc.HeartbeatSyncInterval = cfg.procConfig.heartbeatSyncInterval
 			c.Proc.StaleThreshold = cfg.procConfig.staleThreshold
 		}
 		if cfg.zombieDetectionInterval > 0 {

--- a/internal/intg/distr/proc_liveness_test.go
+++ b/internal/intg/distr/proc_liveness_test.go
@@ -26,7 +26,7 @@ worker_selector:
 steps:
   - name: sleep
     run: sleep 2
-`, withProcConfig(distrTestProcHeartbeatInterval, distrTestProcHeartbeatInterval, distrTestProcStaleThreshold))
+`, withProcConfig(distrTestProcHeartbeatInterval, distrTestProcStaleThreshold))
 	defer f.cleanup()
 
 	f.startScheduler(30 * time.Second)
@@ -45,7 +45,7 @@ worker_selector:
 steps:
   - name: sleep
     run: sleep 2
-`, withProcConfig(distrTestProcHeartbeatInterval, distrTestProcHeartbeatInterval, distrTestProcStaleThreshold))
+`, withProcConfig(distrTestProcHeartbeatInterval, distrTestProcStaleThreshold))
 	defer f.cleanup()
 
 	require.NoError(t, f.enqueue())

--- a/internal/intg/proc_liveness_test.go
+++ b/internal/intg/proc_liveness_test.go
@@ -32,7 +32,6 @@ func TestProcHeartbeat_StartCommand(t *testing.T) {
 
 	th := test.SetupCommand(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = testProcHeartbeatInterval
-		cfg.Proc.HeartbeatSyncInterval = testProcHeartbeatInterval
 		cfg.Proc.StaleThreshold = testProcStaleThreshold
 	}))
 	h := intgharness.New(t, th.Helper)
@@ -68,7 +67,6 @@ func TestProcHeartbeat_RetryCommand(t *testing.T) {
 
 	th := test.SetupCommand(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = testProcHeartbeatInterval
-		cfg.Proc.HeartbeatSyncInterval = testProcHeartbeatInterval
 		cfg.Proc.StaleThreshold = testProcStaleThreshold
 	}))
 	h := intgharness.New(t, th.Helper)

--- a/internal/intg/queue/fixture_test.go
+++ b/internal/intg/queue/fixture_test.go
@@ -44,9 +44,8 @@ type fixture struct {
 }
 
 type procConfig struct {
-	heartbeatInterval     time.Duration
-	heartbeatSyncInterval time.Duration
-	staleThreshold        time.Duration
+	heartbeatInterval time.Duration
+	staleThreshold    time.Duration
 }
 
 type schedulerConfig struct {
@@ -80,7 +79,6 @@ func newFixture(t *testing.T, dagYAML string, opts ...func(*fixture)) *fixture {
 			c.Scheduler.Port = 0
 			if f.procConfig != nil {
 				c.Proc.HeartbeatInterval = f.procConfig.heartbeatInterval
-				c.Proc.HeartbeatSyncInterval = f.procConfig.heartbeatSyncInterval
 				c.Proc.StaleThreshold = f.procConfig.staleThreshold
 			}
 			if f.schedConfig != nil {
@@ -159,12 +157,11 @@ func WithRetryWindow(window time.Duration) func(*fixture) {
 	return func(f *fixture) { f.retryWindow = window }
 }
 
-func WithProcConfig(heartbeatInterval, heartbeatSyncInterval, staleThreshold time.Duration) func(*fixture) {
+func WithProcConfig(heartbeatInterval, staleThreshold time.Duration) func(*fixture) {
 	return func(f *fixture) {
 		f.procConfig = &procConfig{
-			heartbeatInterval:     heartbeatInterval,
-			heartbeatSyncInterval: heartbeatSyncInterval,
-			staleThreshold:        staleThreshold,
+			heartbeatInterval: heartbeatInterval,
+			staleThreshold:    staleThreshold,
 		}
 	}
 }

--- a/internal/intg/queue/proc_liveness_test.go
+++ b/internal/intg/queue/proc_liveness_test.go
@@ -32,7 +32,7 @@ steps:
   - name: sleep
     run: |
 %s
-`, indentQueueTestScript(intgharness.PortableCommands().WaitForFile(releaseFile), 6)), WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcHeartbeatInterval, queueTestProcStaleThreshold)).
+`, indentQueueTestScript(intgharness.PortableCommands().WaitForFile(releaseFile), 6)), WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcStaleThreshold)).
 		Enqueue(1).
 		StartScheduler(60 * time.Second)
 	defer f.Stop()
@@ -59,7 +59,7 @@ name: scheduler-stale-repair
 steps:
   - name: step1
     run: echo never
-`, WithProcConfig(50*time.Millisecond, 50*time.Millisecond, 100*time.Millisecond), WithZombieConfig(50*time.Millisecond, 1))
+`, WithProcConfig(50*time.Millisecond, 100*time.Millisecond), WithZombieConfig(50*time.Millisecond, 1))
 	defer f.Stop()
 
 	dagRunID := uuid.Must(uuid.NewV7()).String()
@@ -110,7 +110,7 @@ max_active_runs: 1
 steps:
   - name: echo
     run: echo hello
-`, WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcHeartbeatInterval, queueTestProcStaleThreshold), WithZombieConfig(50*time.Millisecond, 3)).
+`, WithProcConfig(queueTestProcHeartbeatInterval, queueTestProcStaleThreshold), WithZombieConfig(50*time.Millisecond, 3)).
 		Enqueue(1)
 	defer f.Stop()
 

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -108,11 +108,6 @@ func WithHeartbeatInterval(d time.Duration) StoreOption {
 	}
 }
 
-// WithHeartbeatSyncInterval preserves the file proc store configuration surface.
-func WithHeartbeatSyncInterval(_ time.Duration) StoreOption {
-	return func(_ *Store) {}
-}
-
 // New creates a Store rooted at dir.
 func New(root string, opts ...StoreOption) *Store {
 	s := &Store{
@@ -322,15 +317,14 @@ func (s *Store) LatestFreshEntryByDAGName(ctx context.Context, groupName, dagNam
 	}
 	var freshest *exec.ProcEntry
 	for i := range entries {
-		entry := entries[i]
+		entry := &entries[i]
 		if !entry.Fresh || entry.Meta.Name != dagName {
 			continue
 		}
 		if freshest == nil ||
 			entry.Meta.StartedAt > freshest.Meta.StartedAt ||
 			(entry.Meta.StartedAt == freshest.Meta.StartedAt && entry.LastHeartbeatAt > freshest.LastHeartbeatAt) {
-			copy := entry
-			freshest = &copy
+			freshest = entry
 		}
 	}
 	return freshest, nil
@@ -531,7 +525,7 @@ func removeEmptyProcDirs(dir string) {
 }
 
 // ListEntries returns proc entries for a group.
-func (s *Store) ListEntries(_ context.Context, groupName string) ([]exec.ProcEntry, error) {
+func (s *Store) ListEntries(ctx context.Context, groupName string) ([]exec.ProcEntry, error) {
 	groupDir := filepath.Join(s.root, groupName)
 	if _, err := os.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
 		return nil, nil
@@ -540,11 +534,11 @@ func (s *Store) ListEntries(_ context.Context, groupName string) ([]exec.ProcEnt
 	if err != nil {
 		return nil, err
 	}
-	return s.entriesFromFiles(groupName, files)
+	return s.entriesFromFiles(ctx, groupName, files)
 }
 
 // ListAllEntries returns all proc entries under the store root.
-func (s *Store) ListAllEntries(_ context.Context) ([]exec.ProcEntry, error) {
+func (s *Store) ListAllEntries(ctx context.Context) ([]exec.ProcEntry, error) {
 	dirEntries, err := os.ReadDir(s.root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -563,7 +557,7 @@ func (s *Store) ListAllEntries(_ context.Context) ([]exec.ProcEntry, error) {
 		if err != nil {
 			return nil, err
 		}
-		groupEntries, err := s.entriesFromFiles(groupName, files)
+		groupEntries, err := s.entriesFromFiles(ctx, groupName, files)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +579,7 @@ func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun exec
 	now := time.Now().UTC()
 	var latest *exec.ProcHeartbeat
 	for _, file := range files {
-		observed, err := readProcEntryObservedWithRetry(file, groupName, s.staleTime, now)
+		observed, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) || errors.Is(err, errInvalidProcFile) {
 				// Heartbeat observation should not fail because an unrelated
@@ -637,18 +631,24 @@ func procFilesInGroup(groupDir string) ([]string, error) {
 	return files, nil
 }
 
-func (s *Store) entriesFromFiles(groupName string, files []string) ([]exec.ProcEntry, error) {
+func (s *Store) entriesFromFiles(ctx context.Context, groupName string, files []string) ([]exec.ProcEntry, error) {
 	now := time.Now().UTC()
 	entries := make([]exec.ProcEntry, 0, len(files))
 	for _, file := range files {
-		entry, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
+		observed, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
+			if errors.Is(err, errInvalidProcFile) {
+				// An undecodable file describes no live run. Skipping it keeps a
+				// single damaged file from hiding every run in the group.
+				logger.Warn(ctx, "Skipping undecodable proc file", tag.File(file), tag.Error(err))
+				continue
+			}
 			return nil, err
 		}
-		entries = append(entries, entry)
+		entries = append(entries, observed.entry)
 	}
 	return entries, nil
 }
@@ -659,14 +659,14 @@ func (s *Store) RemoveIfStale(ctx context.Context, entry exec.ProcEntry) error {
 	if !ok {
 		return nil
 	}
-	current, err := readProcEntryWithRetry(path, entry.GroupName, s.staleTime, time.Now().UTC())
+	observed, err := readProcEntryWithRetry(path, entry.GroupName, s.staleTime, time.Now().UTC())
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	if current.Fresh || !sameProcEntry(current, entry) {
+	if observed.entry.Fresh || !sameProcEntry(observed.entry, entry) {
 		return nil
 	}
 	if err := removeProcFile(path); err != nil {
@@ -676,31 +676,7 @@ func (s *Store) RemoveIfStale(ctx context.Context, entry exec.ProcEntry) error {
 	return nil
 }
 
-func readProcEntry(path, groupName string, staleTime time.Duration, now time.Time) (exec.ProcEntry, error) {
-	observed, err := readProcEntryObserved(path, groupName, staleTime, now)
-	if err != nil {
-		return exec.ProcEntry{}, err
-	}
-	return observed.entry, nil
-}
-
-func readProcEntryWithRetry(path, groupName string, staleTime time.Duration, now time.Time) (exec.ProcEntry, error) {
-	var lastErr error
-	for attempt := range procFileRetries {
-		entry, err := readProcEntry(path, groupName, staleTime, now)
-		if err == nil || errors.Is(err, os.ErrNotExist) {
-			return entry, err
-		}
-		if !fileutil.IsTransientFileError(err) {
-			return exec.ProcEntry{}, err
-		}
-		lastErr = err
-		time.Sleep(time.Duration(attempt+1) * 25 * time.Millisecond)
-	}
-	return exec.ProcEntry{}, lastErr
-}
-
-func readProcEntryObservedWithRetry(path, groupName string, staleTime time.Duration, now time.Time) (observedProcEntry, error) {
+func readProcEntryWithRetry(path, groupName string, staleTime time.Duration, now time.Time) (observedProcEntry, error) {
 	var lastErr error
 	for attempt := range procFileRetries {
 		observed, err := readProcEntryObserved(path, groupName, staleTime, now)
@@ -711,7 +687,9 @@ func readProcEntryObservedWithRetry(path, groupName string, staleTime time.Durat
 			return observedProcEntry{}, err
 		}
 		lastErr = err
-		time.Sleep(time.Duration(attempt+1) * 25 * time.Millisecond)
+		if attempt < procFileRetries-1 {
+			time.Sleep(time.Duration(attempt+1) * 25 * time.Millisecond)
+		}
 	}
 	return observedProcEntry{}, lastErr
 }
@@ -738,18 +716,19 @@ func readProcEntryObserved(path, groupName string, staleTime time.Duration, now 
 
 	lastHeartbeatAt := int64(binary.BigEndian.Uint64(data[:procHeartbeatSize])) //nolint:gosec // heartbeat unix time.
 	heartbeatTime := time.Unix(lastHeartbeatAt, 0).UTC()
-	if heartbeatTime.After(now.Add(5 * time.Minute)) {
-		return observedProcEntry{}, fmt.Errorf("%w: proc heartbeat timestamp is in the future for %s", errInvalidProcFile, path)
-	}
 
-	meta, err := procMetaFromLegacyData(path, parsedName, data[procHeartbeatSize:], heartbeatTime, info)
+	meta, err := procMetaFromData(path, parsedName, data[procHeartbeatSize:], heartbeatTime, info)
 	if err != nil {
 		return observedProcEntry{}, err
 	}
 
+	// The heartbeat carries the writing process's clock, so it is only trusted
+	// when it is not ahead of the reader. A skewed or garbled timestamp leaves
+	// the entry stale rather than alive forever.
 	fresh := now.Sub(info.ModTime()) < staleTime
 	if !fresh {
-		fresh = now.Sub(heartbeatTime) < staleTime
+		age := now.Sub(heartbeatTime)
+		fresh = age >= 0 && age < staleTime
 	}
 	entry := exec.ProcEntry{
 		GroupName:       groupName,
@@ -761,7 +740,7 @@ func readProcEntryObserved(path, groupName string, staleTime time.Duration, now 
 	return observedProcEntry{entry: entry, observedAt: info.ModTime()}, nil
 }
 
-func procMetaFromLegacyData(path string, parsedName procFileName, payload []byte, heartbeatTime time.Time, info os.FileInfo) (exec.ProcMeta, error) {
+func procMetaFromData(path string, parsedName procFileName, payload []byte, heartbeatTime time.Time, info os.FileInfo) (exec.ProcMeta, error) {
 	switch parsedName.format {
 	case procFileFormatCurrent:
 		if len(payload) == 0 {

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -579,6 +579,9 @@ func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun exec
 	now := time.Now().UTC()
 	var latest *exec.ProcHeartbeat
 	for _, file := range files {
+		if !procFileMayBelongTo(file, dagRun) {
+			continue
+		}
 		observed, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
@@ -587,9 +590,8 @@ func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun exec
 			if errors.Is(err, errInvalidProcFile) && s.abandoned(file, now) {
 				continue
 			}
-			// Which run a damaged file belongs to cannot be known without
-			// decoding it, so one that is still being written may be this run's.
-			// Report that rather than an absence the caller reads as an exit.
+			// The file may be this run's and is still being written, so report
+			// that rather than an absence the caller reads as an exit.
 			return nil, err
 		}
 		entry := observed.entry
@@ -652,6 +654,21 @@ func (s *Store) entriesFromFiles(groupName string, files []string) ([]exec.ProcE
 		entries = append(entries, observed.entry)
 	}
 	return entries, nil
+}
+
+// procFileMayBelongTo reports whether path can hold an entry for dagRun,
+// judging by the DAG directory and the identifiers carried in the file name.
+// A name that cannot be parsed is a possible match, because attributing such a
+// file needs its contents.
+func procFileMayBelongTo(path string, dagRun exec.DAGRunRef) bool {
+	if filepath.Base(filepath.Dir(path)) != dagRun.Name {
+		return false
+	}
+	parsed, err := parseProcFileName(filepath.Base(path))
+	if err != nil {
+		return true
+	}
+	return parsed.dagRunID == dagRun.ID
 }
 
 // abandoned reports whether path has gone untouched for at least the stale

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -364,10 +364,10 @@ func (s *Store) ListAllAlive(ctx context.Context) (map[string][]exec.DAGRunRef, 
 	return result, nil
 }
 
-// Validate fails if any proc entry cannot be decoded.
-func (s *Store) Validate(ctx context.Context) error {
-	_, err := s.ListAllEntries(ctx)
-	if err != nil {
+// Validate fails if the proc directory cannot be read. Individual proc files
+// are not decoded here, so a damaged one does not make the store unusable.
+func (s *Store) Validate(_ context.Context) error {
+	if _, err := os.ReadDir(s.root); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("validate proc store: %w", err)
 	}
 	return nil
@@ -525,7 +525,7 @@ func removeEmptyProcDirs(dir string) {
 }
 
 // ListEntries returns proc entries for a group.
-func (s *Store) ListEntries(ctx context.Context, groupName string) ([]exec.ProcEntry, error) {
+func (s *Store) ListEntries(_ context.Context, groupName string) ([]exec.ProcEntry, error) {
 	groupDir := filepath.Join(s.root, groupName)
 	if _, err := os.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
 		return nil, nil
@@ -534,11 +534,11 @@ func (s *Store) ListEntries(ctx context.Context, groupName string) ([]exec.ProcE
 	if err != nil {
 		return nil, err
 	}
-	return s.entriesFromFiles(ctx, groupName, files)
+	return s.entriesFromFiles(groupName, files)
 }
 
 // ListAllEntries returns all proc entries under the store root.
-func (s *Store) ListAllEntries(ctx context.Context) ([]exec.ProcEntry, error) {
+func (s *Store) ListAllEntries(_ context.Context) ([]exec.ProcEntry, error) {
 	dirEntries, err := os.ReadDir(s.root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -557,7 +557,7 @@ func (s *Store) ListAllEntries(ctx context.Context) ([]exec.ProcEntry, error) {
 		if err != nil {
 			return nil, err
 		}
-		groupEntries, err := s.entriesFromFiles(ctx, groupName, files)
+		groupEntries, err := s.entriesFromFiles(groupName, files)
 		if err != nil {
 			return nil, err
 		}
@@ -631,7 +631,7 @@ func procFilesInGroup(groupDir string) ([]string, error) {
 	return files, nil
 }
 
-func (s *Store) entriesFromFiles(ctx context.Context, groupName string, files []string) ([]exec.ProcEntry, error) {
+func (s *Store) entriesFromFiles(groupName string, files []string) ([]exec.ProcEntry, error) {
 	now := time.Now().UTC()
 	entries := make([]exec.ProcEntry, 0, len(files))
 	for _, file := range files {
@@ -640,10 +640,7 @@ func (s *Store) entriesFromFiles(ctx context.Context, groupName string, files []
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			if errors.Is(err, errInvalidProcFile) {
-				// An undecodable file describes no live run. Skipping it keeps a
-				// single damaged file from hiding every run in the group.
-				logger.Warn(ctx, "Skipping undecodable proc file", tag.File(file), tag.Error(err))
+			if errors.Is(err, errInvalidProcFile) && s.abandoned(file, now) {
 				continue
 			}
 			return nil, err
@@ -651,6 +648,14 @@ func (s *Store) entriesFromFiles(ctx context.Context, groupName string, files []
 		entries = append(entries, observed.entry)
 	}
 	return entries, nil
+}
+
+// abandoned reports whether path has gone untouched for at least the stale
+// threshold. A damaged file that is still being written may belong to a run
+// that is alive, and reporting the group without it would undercount.
+func (s *Store) abandoned(path string, now time.Time) bool {
+	info, err := os.Stat(path)
+	return err == nil && now.Sub(info.ModTime()) >= s.staleTime
 }
 
 // RemoveIfStale deletes entry when the on-disk proc file is still stale.

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -581,11 +581,15 @@ func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun exec
 	for _, file := range files {
 		observed, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) || errors.Is(err, errInvalidProcFile) {
-				// Heartbeat observation should not fail because an unrelated
-				// proc file is concurrently removed or corrupt.
+			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
+			if errors.Is(err, errInvalidProcFile) && s.abandoned(file, now) {
+				continue
+			}
+			// Which run a damaged file belongs to cannot be known without
+			// decoding it, so one that is still being written may be this run's.
+			// Report that rather than an absence the caller reads as an exit.
 			return nil, err
 		}
 		entry := observed.entry

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -91,12 +91,25 @@ func TestStoreReadsAndRemovesReleasedProcFiles(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func TestStoreKeepsGroupReadableWhenAProcFileIsDamaged(t *testing.T) {
+// writeDamagedProcFile drops an undecodable proc file into a group and stamps
+// it as last written modifiedAgo in the past.
+func writeDamagedProcFile(t *testing.T, root, groupName, dagName string, modifiedAgo time.Duration) string {
+	t.Helper()
+
+	path := filepath.Join(root, groupName, dagName, "proc_20260101_000000Z_6161_6262.proc")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte{0x00, 0x01}, 0o600))
+	at := time.Now().Add(-modifiedAgo)
+	require.NoError(t, os.Chtimes(path, at, at))
+	return path
+}
+
+func TestStoreSkipsAbandonedDamagedProcFile(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	root := t.TempDir()
-	s := New(root, WithHeartbeatInterval(10*time.Millisecond))
+	s := New(root, WithHeartbeatInterval(10*time.Millisecond), WithStaleThreshold(time.Second))
 	ref := exec.NewDAGRunRef("healthy-dag", "run-1")
 
 	handle, err := s.Acquire(ctx, "queue-a", testProcMeta(ref))
@@ -104,8 +117,7 @@ func TestStoreKeepsGroupReadableWhenAProcFileIsDamaged(t *testing.T) {
 	defer func() { _ = handle.Stop(ctx) }()
 	require.NotEmpty(t, waitForProcFile(t, root, "queue-a", "healthy-dag"))
 
-	damaged := filepath.Join(root, "queue-a", "healthy-dag", "proc_20260101_000000Z_6161_6262.proc")
-	require.NoError(t, os.WriteFile(damaged, []byte{0x00, 0x01}, 0o600))
+	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", time.Hour)
 
 	entries, err := s.ListEntries(ctx, "queue-a")
 	require.NoError(t, err)
@@ -119,7 +131,36 @@ func TestStoreKeepsGroupReadableWhenAProcFileIsDamaged(t *testing.T) {
 	alive, err := s.IsRunAlive(ctx, "queue-a", ref)
 	require.NoError(t, err)
 	assert.True(t, alive)
+}
 
+func TestStoreDoesNotUndercountWhileDamagedProcFileLooksActive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithStaleThreshold(time.Minute))
+
+	// A damaged file that is still being written may belong to a live run, so
+	// the group must not be reported as if that run were gone.
+	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+
+	_, err := s.ListEntries(ctx, "queue-a")
+	require.ErrorIs(t, err, errInvalidProcFile)
+
+	_, err = s.CountAlive(ctx, "queue-a")
+	require.Error(t, err)
+}
+
+func TestStoreValidateIgnoresDamagedProcFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithStaleThreshold(time.Minute))
+	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+
+	// Every command validates the proc directory, so a damaged file must not
+	// make the store unusable.
 	require.NoError(t, s.Validate(ctx))
 }
 

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -123,7 +123,7 @@ func TestStoreKeepsGroupReadableWhenAProcFileIsDamaged(t *testing.T) {
 	require.NoError(t, s.Validate(ctx))
 }
 
-func TestStoreTreatsFutureHeartbeatAsStale(t *testing.T) {
+func TestStoreTreatsAbandonedFutureHeartbeatAsStale(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -132,7 +132,8 @@ func TestStoreTreatsFutureHeartbeatAsStale(t *testing.T) {
 	ref := exec.NewDAGRunRef("skewed-dag", "run-1")
 	meta := testProcMeta(ref)
 
-	// A writer whose clock runs ahead must not keep the entry alive forever.
+	// Nothing has written the file recently, so a heartbeat stamped in the
+	// future must not keep the entry alive forever.
 	writtenAt := time.Now().Add(-time.Hour).UTC()
 	procFile := s.filePath("queue-a", meta, writtenAt)
 	require.NoError(t, writeProcFile(procFile, time.Now().Add(time.Hour).UTC().Unix(), meta))
@@ -146,6 +147,29 @@ func TestStoreTreatsFutureHeartbeatAsStale(t *testing.T) {
 	require.NoError(t, s.RemoveIfStale(ctx, entries[0]))
 	_, err = os.Stat(procFile)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestStoreKeepsRecentlyWrittenProcFileFreshDespiteClockSkew(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithStaleThreshold(time.Minute))
+	ref := exec.NewDAGRunRef("skewed-dag", "run-1")
+	meta := testProcMeta(ref)
+
+	// A process whose clock runs ahead is still alive, and the write time proves
+	// it. Freshness must follow the file, not the timestamp the writer recorded.
+	procFile := s.filePath("queue-a", meta, time.Now().UTC())
+	require.NoError(t, writeProcFile(procFile, time.Now().Add(time.Hour).UTC().Unix(), meta))
+
+	entries, err := s.ListEntries(ctx, "queue-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.True(t, entries[0].Fresh)
+
+	require.NoError(t, s.RemoveIfStale(ctx, entries[0]))
+	assert.FileExists(t, procFile)
 }
 
 func waitForProcFile(t *testing.T, root, groupName, dagName string) string {

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -32,10 +32,7 @@ func TestStoreWritesReleasedProcFileLayoutOnly(t *testing.T) {
 
 	ctx := context.Background()
 	root := t.TempDir()
-	s := New(root,
-		WithHeartbeatInterval(10*time.Millisecond),
-		WithHeartbeatSyncInterval(10*time.Millisecond),
-	)
+	s := New(root, WithHeartbeatInterval(10*time.Millisecond))
 	ref := exec.NewDAGRunRef("sidecar-dag", "run-1")
 
 	handle, err := s.Acquire(ctx, "queue-a", testProcMeta(ref))
@@ -88,6 +85,63 @@ func TestStoreReadsAndRemovesReleasedProcFiles(t *testing.T) {
 	assert.False(t, entries[0].Fresh)
 	assert.False(t, entries[0].Identity.IsZero())
 	assert.NotEqual(t, procFile, entries[0].Identity.String())
+
+	require.NoError(t, s.RemoveIfStale(ctx, entries[0]))
+	_, err = os.Stat(procFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestStoreKeepsGroupReadableWhenAProcFileIsDamaged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithHeartbeatInterval(10*time.Millisecond))
+	ref := exec.NewDAGRunRef("healthy-dag", "run-1")
+
+	handle, err := s.Acquire(ctx, "queue-a", testProcMeta(ref))
+	require.NoError(t, err)
+	defer func() { _ = handle.Stop(ctx) }()
+	require.NotEmpty(t, waitForProcFile(t, root, "queue-a", "healthy-dag"))
+
+	damaged := filepath.Join(root, "queue-a", "healthy-dag", "proc_20260101_000000Z_6161_6262.proc")
+	require.NoError(t, os.WriteFile(damaged, []byte{0x00, 0x01}, 0o600))
+
+	entries, err := s.ListEntries(ctx, "queue-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, ref, entries[0].Meta.DAGRun())
+
+	count, err := s.CountAlive(ctx, "queue-a")
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	alive, err := s.IsRunAlive(ctx, "queue-a", ref)
+	require.NoError(t, err)
+	assert.True(t, alive)
+
+	require.NoError(t, s.Validate(ctx))
+}
+
+func TestStoreTreatsFutureHeartbeatAsStale(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithStaleThreshold(time.Minute))
+	ref := exec.NewDAGRunRef("skewed-dag", "run-1")
+	meta := testProcMeta(ref)
+
+	// A writer whose clock runs ahead must not keep the entry alive forever.
+	writtenAt := time.Now().Add(-time.Hour).UTC()
+	procFile := s.filePath("queue-a", meta, writtenAt)
+	require.NoError(t, writeProcFile(procFile, time.Now().Add(time.Hour).UTC().Unix(), meta))
+	require.NoError(t, os.Chtimes(procFile, writtenAt, writtenAt))
+
+	entries, err := s.ListEntries(ctx, "queue-a")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.False(t, entries[0].Fresh)
 
 	require.NoError(t, s.RemoveIfStale(ctx, entries[0]))
 	_, err = os.Stat(procFile)

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -93,10 +93,12 @@ func TestStoreReadsAndRemovesReleasedProcFiles(t *testing.T) {
 
 // writeDamagedProcFile drops an undecodable proc file into a group and stamps
 // it as last written modifiedAgo in the past.
-func writeDamagedProcFile(t *testing.T, root, groupName, dagName string, modifiedAgo time.Duration) string {
+// writeDamagedProcFile writes an undecodable file at the path the store would
+// use for ref, and stamps it as last written modifiedAgo in the past.
+func writeDamagedProcFile(t *testing.T, s *Store, groupName string, ref exec.DAGRunRef, modifiedAgo time.Duration) string {
 	t.Helper()
 
-	path := filepath.Join(root, groupName, dagName, "proc_20260101_000000Z_6161_6262.proc")
+	path := s.filePath(groupName, testProcMeta(ref), time.Now().UTC())
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
 	require.NoError(t, os.WriteFile(path, []byte{0x00, 0x01}, 0o600))
 	at := time.Now().Add(-modifiedAgo)
@@ -117,7 +119,7 @@ func TestStoreSkipsAbandonedDamagedProcFile(t *testing.T) {
 	defer func() { _ = handle.Stop(ctx) }()
 	require.NotEmpty(t, waitForProcFile(t, root, "queue-a", "healthy-dag"))
 
-	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", time.Hour)
+	writeDamagedProcFile(t, s, "queue-a", exec.NewDAGRunRef("healthy-dag", "abandoned-run"), time.Hour)
 
 	entries, err := s.ListEntries(ctx, "queue-a")
 	require.NoError(t, err)
@@ -142,7 +144,7 @@ func TestStoreDoesNotUndercountWhileDamagedProcFileLooksActive(t *testing.T) {
 
 	// A damaged file that is still being written may belong to a live run, so
 	// the group must not be reported as if that run were gone.
-	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+	writeDamagedProcFile(t, s, "queue-a", exec.NewDAGRunRef("healthy-dag", "run-1"), 0)
 
 	_, err := s.ListEntries(ctx, "queue-a")
 	require.ErrorIs(t, err, errInvalidProcFile)
@@ -159,9 +161,9 @@ func TestStoreLatestHeartbeatDoesNotReportExitWhileDamagedProcFileLooksActive(t 
 	s := New(root, WithStaleThreshold(time.Minute))
 	ref := exec.NewDAGRunRef("healthy-dag", "run-1")
 
-	// Callers read a nil heartbeat as the run having exited, so damage that may
-	// still belong to it must not be reported as an absence.
-	damaged := writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+	// Callers read a nil heartbeat as the run having exited, so damage that is
+	// named for this run must not be reported as an absence.
+	damaged := writeDamagedProcFile(t, s, "queue-a", ref, 0)
 
 	_, err := s.LatestHeartbeat(ctx, "queue-a", ref)
 	require.ErrorIs(t, err, errInvalidProcFile)
@@ -174,13 +176,36 @@ func TestStoreLatestHeartbeatDoesNotReportExitWhileDamagedProcFileLooksActive(t 
 	assert.Nil(t, heartbeat)
 }
 
+func TestStoreLatestHeartbeatIgnoresDamageBelongingToAnotherRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithHeartbeatInterval(10*time.Millisecond), WithStaleThreshold(time.Minute))
+	ref := exec.NewDAGRunRef("healthy-dag", "run-1")
+
+	handle, err := s.Acquire(ctx, "queue-a", testProcMeta(ref))
+	require.NoError(t, err)
+	defer func() { _ = handle.Stop(ctx) }()
+	require.NotEmpty(t, waitForProcFile(t, root, "queue-a", "healthy-dag"))
+
+	// Damage under another DAG in the same group says nothing about this run,
+	// so it must not block callers that only ask about this one.
+	writeDamagedProcFile(t, s, "queue-a", exec.NewDAGRunRef("other-dag", "other-run"), 0)
+
+	heartbeat, err := s.LatestHeartbeat(ctx, "queue-a", ref)
+	require.NoError(t, err)
+	require.NotNil(t, heartbeat)
+	assert.Equal(t, ref, heartbeat.DAGRun)
+}
+
 func TestStoreValidateIgnoresDamagedProcFiles(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	root := t.TempDir()
 	s := New(root, WithStaleThreshold(time.Minute))
-	writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+	writeDamagedProcFile(t, s, "queue-a", exec.NewDAGRunRef("healthy-dag", "run-1"), 0)
 
 	// Every command validates the proc directory, so a damaged file must not
 	// make the store unusable.

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -151,6 +151,29 @@ func TestStoreDoesNotUndercountWhileDamagedProcFileLooksActive(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestStoreLatestHeartbeatDoesNotReportExitWhileDamagedProcFileLooksActive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	s := New(root, WithStaleThreshold(time.Minute))
+	ref := exec.NewDAGRunRef("healthy-dag", "run-1")
+
+	// Callers read a nil heartbeat as the run having exited, so damage that may
+	// still belong to it must not be reported as an absence.
+	damaged := writeDamagedProcFile(t, root, "queue-a", "healthy-dag", 0)
+
+	_, err := s.LatestHeartbeat(ctx, "queue-a", ref)
+	require.ErrorIs(t, err, errInvalidProcFile)
+
+	at := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(damaged, at, at))
+
+	heartbeat, err := s.LatestHeartbeat(ctx, "queue-a", ref)
+	require.NoError(t, err)
+	assert.Nil(t, heartbeat)
+}
+
 func TestStoreValidateIgnoresDamagedProcFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/proc_store.go
+++ b/internal/persis/file/proc_store.go
@@ -14,7 +14,6 @@ func NewProcStore(cfg *config.Config, opts ...proc.StoreOption) *proc.Store {
 	storeOpts := []proc.StoreOption{
 		proc.WithStaleThreshold(cfg.Proc.StaleThreshold),
 		proc.WithHeartbeatInterval(cfg.Proc.HeartbeatInterval),
-		proc.WithHeartbeatSyncInterval(cfg.Proc.HeartbeatSyncInterval),
 	}
 	storeOpts = append(storeOpts, opts...)
 	return proc.New(cfg.Paths.ProcDir, storeOpts...)

--- a/internal/persis/store/proc.go
+++ b/internal/persis/store/proc.go
@@ -43,15 +43,6 @@ func WithProcHeartbeatInterval(d time.Duration) ProcStoreOption {
 	}
 }
 
-// WithProcHeartbeatSyncInterval keeps configuration parity with the legacy
-// proc store option.
-// Collection-backed proc heartbeats are complete writes, so there is no
-// separate sync loop to configure.
-func WithProcHeartbeatSyncInterval(_ time.Duration) ProcStoreOption {
-	return func(_ *ProcStore) {
-	}
-}
-
 // ProcStore implements [exec.ProcStore] on top of a [persis.Collection].
 //
 // This is the backend-neutral proc store, intended for non-file backends

--- a/internal/persis/store/proc_test.go
+++ b/internal/persis/store/proc_test.go
@@ -73,7 +73,6 @@ func TestProcStoreHeartbeatAdvances(t *testing.T) {
 	ctx := context.Background()
 	s := newProcStore(t,
 		store.WithProcHeartbeatInterval(10*time.Millisecond),
-		store.WithProcHeartbeatSyncInterval(10*time.Millisecond),
 	)
 	ref := exec.NewDAGRunRef("heartbeat-dag", "run-1")
 

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1039,7 +1039,6 @@ func TestApproveDAGRunStepResumeRefreshesProcessIdentity(t *testing.T) {
 
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = procHeartbeatInterval
-		cfg.Proc.HeartbeatSyncInterval = procHeartbeatInterval
 		cfg.Proc.StaleThreshold = procStaleThreshold
 	}))
 	release := newHoldFile(t)

--- a/internal/service/frontend/api/v1/proc_liveness_test.go
+++ b/internal/service/frontend/api/v1/proc_liveness_test.go
@@ -44,7 +44,6 @@ type staleLocalRunFixture struct {
 func TestServerProcHeartbeat_StartAPI(t *testing.T) {
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = apiTestProcHeartbeatInterval
-		cfg.Proc.HeartbeatSyncInterval = apiTestProcHeartbeatInterval
 		cfg.Proc.StaleThreshold = apiTestProcStaleThreshold
 	}))
 
@@ -141,7 +140,6 @@ func setupStaleLocalRun(t *testing.T, dagName string) staleLocalRunFixture {
 
 	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
 		cfg.Proc.HeartbeatInterval = 50 * time.Millisecond
-		cfg.Proc.HeartbeatSyncInterval = 50 * time.Millisecond
 		cfg.Proc.StaleThreshold = 100 * time.Millisecond
 	}))
 

--- a/internal/service/scheduler/ha_health_test.go
+++ b/internal/service/scheduler/ha_health_test.go
@@ -85,9 +85,8 @@ func newHASchedulerFixture(t *testing.T) *haSchedulerFixture {
 			LogDir:             filepath.Join(tmpDir, "logs"),
 		},
 		Proc: config.Proc{
-			HeartbeatInterval:     5 * time.Second,
-			HeartbeatSyncInterval: 10 * time.Second,
-			StaleThreshold:        90 * time.Second,
+			HeartbeatInterval: 5 * time.Second,
+			StaleThreshold:    90 * time.Second,
 		},
 		Scheduler: config.Scheduler{
 			Port:               0,

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -89,7 +89,6 @@ func newSchedulerTestProcStore(procDir string, cfg *config.Config) exec.ProcStor
 	if cfg != nil {
 		opts = append(opts,
 			proc.WithHeartbeatInterval(cfg.Proc.HeartbeatInterval),
-			proc.WithHeartbeatSyncInterval(cfg.Proc.HeartbeatSyncInterval),
 			proc.WithStaleThreshold(cfg.Proc.StaleThreshold),
 		)
 	}

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -398,9 +398,8 @@ func writeHelperConfigFile(t *testing.T, cfg *config.Config, configPath string) 
 	}
 
 	configData["proc"] = map[string]any{
-		"heartbeat_interval":      cfg.Proc.HeartbeatInterval.String(),
-		"heartbeat_sync_interval": cfg.Proc.HeartbeatSyncInterval.String(),
-		"stale_threshold":         cfg.Proc.StaleThreshold.String(),
+		"heartbeat_interval": cfg.Proc.HeartbeatInterval.String(),
+		"stale_threshold":    cfg.Proc.StaleThreshold.String(),
 	}
 
 	scheduler := map[string]any{}

--- a/scripts/e2e/start-stack.sh
+++ b/scripts/e2e/start-stack.sh
@@ -380,7 +380,6 @@ scheduler:
   zombie_detection_interval: 500ms
 proc:
   heartbeat_interval: 500ms
-  heartbeat_sync_interval: 500ms
   stale_threshold: 3s
 queues:
   enabled: true


### PR DESCRIPTION
## Summary

A quality audit of `internal/persis/file/proc` (chosen as the highest bug-density core package: test ratio 0.16, and it answers "is this DAG run alive?") turned up one production bug and one piece of dead configuration. Net **−67 lines of production code**; the only additions are two regression tests.

## 1. One damaged proc file could stop a queue and brick the CLI

Listing proc entries treated *any* undecodable file as fatal for the whole group:

```go
entry, err := readProcEntryWithRetry(file, groupName, s.staleTime, now)
if err != nil {
    if errors.Is(err, os.ErrNotExist) { continue }
    return nil, err          // <-- one bad file fails the entire group
}
```

Measured before the fix — one healthy run plus one truncated `.proc` file dropped in the group directory:

```
BEFORE corruption: CountAlive=1 err=<nil>
AFTER  corruption: CountAlive=0 err=invalid proc file: ... shorter than the 8-byte heartbeat header
AFTER  corruption: IsRunAlive=false err=invalid proc file: ...
AFTER  corruption: LatestHeartbeat!=nil=true err=<nil>      <-- tolerant path already existed
```

Blast radius:

- `queue_dispatcher.go:553` — `CountAlive` failing aborts `selectDispatchBatch` and marks the queue unavailable, so **the queue stops dispatching entirely**
- `scheduler.go:216` — breaks `IsRunning`, blocking scheduled runs
- `internal/cmd/context.go:330` — `NewContext` validates the proc directory on **every command**, so one damaged file made the whole CLI unusable
- `runtime/manager.go` (5 sites) and `humantask/resume.go` lose liveness; `dagu ps`/`dagu rm` fail

It could not self-heal: the zombie detector reaches `RemoveIfStale` only through the listing that was failing, so recovery meant deleting the file by hand.

`LatestHeartbeat` in the same file already skipped exactly this condition with a comment explaining why, so the fix adopts the behavior the package already demonstrated. `Validate` now means "the proc directory is usable" rather than "every file in it decodes" — which is what its one caller actually wants.

## 2. Clock skew caused the same group-wide failure, permanently

A heartbeat more than five minutes ahead of the reader was rejected as an invalid file. Since the heartbeat carries the *writer's* clock and is judged against the *reader's*, skew between hosts in distributed mode triggered finding 1 — and it never aged out, because the skewed writer kept rewriting the file. A future heartbeat is now treated as not fresh, so the entry stays stale and the zombie detector can reap it. This also makes a garbled timestamp self-healing instead of permanently poisoning the group.

## 3. `proc.heartbeat_sync_interval` did nothing

The setting was parsed, defaulted to 10s, aliased from the deprecated `scheduler.` key, exposed in the JSON schema and as `DAGU_PROC_HEARTBEAT_SYNC_INTERVAL`, and **validated against `proc.stale_threshold`** — while both proc store implementations accepted it as a no-op. An operator could be blocked from starting Dagu by a constraint on a value nothing reads.

Removed with its plumbing. Existing configs carrying the key keep loading (the main decoder ignores unknown keys — `ErrorUnused` is scoped only to `auth.proxy`); only the validation that rejected it is gone, which is strictly more permissive.

## Cleanups (all subtractive)

- Collapsed two byte-identical read-retry helpers into one
- Stopped sleeping after the final retry attempt (wasted 300ms on every exhausted retry)
- `procMetaFromLegacyData` → `procMetaFromData`; it decodes the current format, not just legacy
- Dropped a local shadowing the builtin `copy`

Package average cyclomatic complexity 4.5 → 4.6 across 969 → 948 lines with 15 fewer functions.

## Not addressed

`RemoveIfStale` has a check-then-delete window against a process that resumes heartbeating; closing it means holding the store's group lock across the re-read and removal. That **adds** code, so it is left out of a change whose goal was reduction. Worth a follow-up — it can delete a live run's proc file, making the run invisible to `IsRunAlive`.

## Tests

Two behavior-level regression tests: a damaged file no longer hides a healthy run in its group (and `Validate` still passes), and a future heartbeat is stale and reapable.

`make fmt` clean including `GOOS=windows`. `go test -race` green on `persis/...`, `cmn/config/...`, `service/scheduler/...`, `service/frontend/api/v1/...`, `cmd/...`, and all of `intg/...` including the distributed and queue suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes proc liveness resilient and conservative: damaged `.proc` files no longer wedge queues/CLI, undercount alive runs, or mislead retries while files are still being written. Also removes the dead `proc.heartbeat_sync_interval` from loading/env while keeping it in the schema as deprecated and ignored, and bounds test waits by the test deadline.

- **Bug Fixes**
  - `internal/persis/file/proc` listings skip undecodable `.proc` files only after they’re abandoned (past the stale threshold); files still being written surface as errors.
  - `LatestHeartbeat` filters to files that may belong to the requested run (by DAG dir and encoded IDs) and applies the same abandonment gate; unrelated damage no longer fails lookups, and damage that may belong returns an error to prevent duplicates.
  - `Validate` checks that the proc directory is readable, not that every file decodes.
  - Freshness prefers file write time, then heartbeat: future-dated heartbeats are stale unless the file was written recently.
  - Tests: bounded `status` and `restart` wait helpers to the test deadline.

- **Refactors**
  - Removed `WithHeartbeatSyncInterval`, `WithProcHeartbeatSyncInterval`, and the `proc.heartbeat_sync_interval` loader/env aliases; the JSON schema now accepts the key as deprecated and ignored so existing configs still validate.
  - Consolidated read-retry helpers and removed the final sleep; cleaned up tests and E2E config.

<sup>Written for commit 747a773e6286dd3d1347442446b0ce8883a990bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the deprecated `heartbeat_sync_interval` setting from process and scheduler configuration.
  - Configuration schemas, environment bindings, and legacy aliases no longer accept this setting.

- **Bug Fixes**
  - Improved resilience when reading damaged process state files; valid entries remain accessible.
  - Future-dated heartbeats are now correctly treated as stale.
  - Improved retry behavior by avoiding unnecessary delays after the final attempt.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->