### PR TITLE
refactor(exec): unexport package-local helpers

### DIFF
--- a/internal/core/exec/node.go
+++ b/internal/core/exec/node.go
@@ -119,8 +119,8 @@ func NewNodeFromStep(step core.Step) *Node {
 	}
 }
 
-// NewNodeOrNil creates a Node from a Step or returns nil if the step is nil.
-func NewNodeOrNil(s *core.Step) *Node {
+// newNodeOrNil creates a Node from a Step or returns nil if the step is nil.
+func newNodeOrNil(s *core.Step) *Node {
 	if s == nil {
 		return nil
 	}

--- a/internal/core/exec/runstatus.go
+++ b/internal/core/exec/runstatus.go
@@ -50,12 +50,12 @@ func InitialStatus(dag *core.DAG) DAGRunStatus {
 		Status:               core.NotStarted,
 		PID:                  PID(0),
 		Nodes:                NewNodesFromSteps(dag.Steps),
-		OnInit:               NewNodeOrNil(dag.HandlerOn.Init),
-		OnExit:               NewNodeOrNil(dag.HandlerOn.Exit),
-		OnSuccess:            NewNodeOrNil(dag.HandlerOn.Success),
-		OnFailure:            NewNodeOrNil(dag.HandlerOn.Failure),
-		OnAbort:              NewNodeOrNil(dag.HandlerOn.Abort),
-		OnWait:               NewNodeOrNil(dag.HandlerOn.Wait),
+		OnInit:               newNodeOrNil(dag.HandlerOn.Init),
+		OnExit:               newNodeOrNil(dag.HandlerOn.Exit),
+		OnSuccess:            newNodeOrNil(dag.HandlerOn.Success),
+		OnFailure:            newNodeOrNil(dag.HandlerOn.Failure),
+		OnAbort:              newNodeOrNil(dag.HandlerOn.Abort),
+		OnWait:               newNodeOrNil(dag.HandlerOn.Wait),
 		Params:               strings.Join(dag.Params, " "),
 		ParamsList:           dag.Params,
 		AutoRetryCount:       0,
@@ -286,9 +286,9 @@ func (st *DAGRunStatus) Errors() []error {
 	return errs
 }
 
-// PendingStepRetriesFromNodes extracts pending parent-managed step retries from
+// pendingStepRetriesFromNodes extracts pending parent-managed step retries from
 // a DAG status snapshot.
-func PendingStepRetriesFromNodes(nodes []*Node) []PendingStepRetry {
+func pendingStepRetriesFromNodes(nodes []*Node) []PendingStepRetry {
 	var retries []PendingStepRetry
 	for _, node := range nodes {
 		if retry, ok := pendingStepRetryForNode(node.Step.Name, node); ok {
@@ -309,7 +309,7 @@ func PendingStepRetriesFromStatus(status *DAGRunStatus) []PendingStepRetry {
 		return status.PendingStepRetries
 	}
 
-	retries := PendingStepRetriesFromNodes(status.Nodes)
+	retries := pendingStepRetriesFromNodes(status.Nodes)
 	for _, handler := range status.handlerNodes() {
 		stepName := handler.name
 		if handler.node != nil && handler.node.Step.Name != "" {

--- a/internal/core/exec/workspace.go
+++ b/internal/core/exec/workspace.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/workspace"
 )
 
-const WorkspaceLabelKey = "workspace"
+const workspaceLabelKey = "workspace"
 
 // WorkspaceLabelState describes whether labels contain a usable workspace.
 type WorkspaceLabelState int
@@ -36,7 +36,7 @@ func WorkspaceNameFromLabels(labels core.Labels) (string, bool) {
 
 func WorkspaceLabelFromLabels(labels core.Labels) (string, WorkspaceLabelState) {
 	var workspaceName string
-	for _, value := range labels.Get(WorkspaceLabelKey) {
+	for _, value := range labels.Get(workspaceLabelKey) {
 		if value == "" {
 			return "", WorkspaceLabelInvalid
 		}


### PR DESCRIPTION
Second of a series of cleanups for `internal/core/exec`, following a code-quality audit of the package. Rename-only — no behavior change.

**Stacked on #2510.** Base is `refactor/exec-dead-code`; retarget to `main` once that merges.

Three declarations are exported but referenced only from within the package, and each advertises an entry point callers should not reach for:

| Renamed | Call sites | Why |
|---|---|---|
| `NewNodeOrNil` → `newNodeOrNil` | 6, all in `InitialStatus` | A second node-construction entry point beside `NewNodeFromStep` |
| `PendingStepRetriesFromNodes` → `pendingStepRetriesFromNodes` | 1, in `PendingStepRetriesFromStatus` | Omits persisted-state precedence and handler-node processing, so external use could derive an incomplete retry set |
| `WorkspaceLabelKey` → `workspaceLabelKey` | 1, in `WorkspaceLabelFromLabels` | Exposes the raw storage key, inviting direct label lookups that bypass validation for empty, malformed, or conflicting workspace values |

Exported contracts that stay: `NewNodeFromStep`, `PendingStepRetriesFromStatus`, `WorkspaceNameFromLabels`, `WorkspaceLabelFromLabels`.

Every call site is inside `internal/core/exec` — no other package, test, or template referenced these names.

## Verification

- `go build ./...`
- `go vet ./internal/core/exec/...`
- `go test -race ./internal/core/exec/...`
- `golangci-lint run ./internal/core/exec/...` — 0 issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unexported internal-only helpers in `internal/core/exec` to tighten the package API and prevent misuse. Rename-only; no behavior changes or external impact.

- **Refactors**
  - `NewNodeOrNil` → `newNodeOrNil` (used only by `InitialStatus`)
  - `PendingStepRetriesFromNodes` → `pendingStepRetriesFromNodes`; `PendingStepRetriesFromStatus` stays the public API
  - `WorkspaceLabelKey` → `workspaceLabelKey`; keep using `WorkspaceNameFromLabels` or `WorkspaceLabelFromLabels`

<sup>Written for commit 536aedc7da34c6fb4d29ed4c6aa8dddbf22de310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

