### PR TITLE
refactor: simplify workflow log output

### DIFF
--- a/internal/cmd/agent_executor.go
+++ b/internal/cmd/agent_executor.go
@@ -32,9 +32,8 @@ func ExecuteAgent(ctx *Context, agentInstance *agent.Agent, dag *core.DAG, dagRu
 
 	// Run the DAG
 	if err := agentInstance.Run(ctx); err != nil {
-		logger.Error(ctx, "Failed to execute dag-run",
-			tag.DAG(dag.Name),
-			tag.RunID(dagRunID),
+		logCtx := logger.WithValues(ctx, tag.DAG(dag.Name), tag.RunID(dagRunID))
+		logger.Error(logCtx, "Failed to execute dag-run",
 			tag.Error(err),
 		)
 		if ctx.Proc != nil {
@@ -81,7 +80,7 @@ func configureLoggerForProgress(ctx *Context, logFile *os.File) {
 		opts = append(opts, logger.WithFormat(ctx.Config.Core.LogFormat))
 	}
 	if logFile != nil {
-		opts = append(opts, logger.WithWriter(logFile))
+		opts = append(opts, logger.WithRunWriter(logFile))
 	}
 	ctx.Context = logger.WithLogger(ctx.Context, logger.NewLogger(opts...))
 }

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -136,7 +136,7 @@ func (c *Context) LogToFile(f *os.File) {
 		opts = append(opts, logger.WithFormat(c.Config.Core.LogFormat))
 	}
 	if f != nil {
-		opts = append(opts, logger.WithWriter(f))
+		opts = append(opts, logger.WithRunWriter(f))
 	}
 	c.Context = logger.WithLogger(c.Context, logger.NewLogger(opts...))
 }

--- a/internal/cmd/restart.go
+++ b/internal/cmd/restart.go
@@ -191,6 +191,7 @@ func executeDAGWithRunID(ctx *Context, cli runtime.Manager, dag *core.DAG, dagRu
 			DAGRunArtifactDir:        ctx.Config.Paths.ArtifactDir,
 		})
 
+	ctx.LogToFile(logFile)
 	listenSignals(ctx, agentInstance)
 	if err := agentInstance.Run(ctx); err != nil {
 		if !ctx.Quiet {

--- a/internal/cmn/logger/logger.go
+++ b/internal/cmn/logger/logger.go
@@ -46,10 +46,11 @@ type appLogger struct {
 }
 
 type Config struct {
-	debug  bool
-	format string
-	writer io.Writer
-	quiet  bool
+	debug     bool
+	format    string
+	writer    io.Writer
+	quiet     bool
+	runWriter bool
 }
 
 type Option func(*Config)
@@ -72,6 +73,14 @@ func WithFormat(format string) Option {
 func WithWriter(w io.Writer) Option {
 	return func(o *Config) {
 		o.writer = w
+	}
+}
+
+// WithRunWriter writes logs without context already identified by the run stream.
+func WithRunWriter(w io.Writer) Option {
+	return func(o *Config) {
+		o.writer = w
+		o.runWriter = true
 	}
 }
 
@@ -123,6 +132,9 @@ func NewLogger(opts ...Option) Logger {
 
 	if cfg.writer != nil {
 		handler := newHandler(cfg.writer, cfg.format, handlerOpts)
+		if cfg.runWriter {
+			handler = newRunWriterHandler(handler)
+		}
 		guardedHandler = newGuardedHandler(handler, cfg.writer)
 		handlers = append(handlers, guardedHandler)
 	}
@@ -133,6 +145,39 @@ func NewLogger(opts ...Option) Logger {
 		quiet:          cfg.quiet,
 		debug:          cfg.debug,
 	}
+}
+
+func isRunContext(key string) bool {
+	switch key {
+	case "dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags":
+		return true
+	default:
+		return false
+	}
+}
+
+type runWriterHandler struct {
+	slog.Handler
+}
+
+var _ slog.Handler = (*runWriterHandler)(nil)
+
+func newRunWriterHandler(handler slog.Handler) slog.Handler {
+	return &runWriterHandler{Handler: handler}
+}
+
+func (h *runWriterHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	filtered := make([]slog.Attr, 0, len(attrs))
+	for _, attr := range attrs {
+		if !isRunContext(attr.Key) {
+			filtered = append(filtered, attr)
+		}
+	}
+	return &runWriterHandler{Handler: h.Handler.WithAttrs(filtered)}
+}
+
+func (h *runWriterHandler) WithGroup(name string) slog.Handler {
+	return &runWriterHandler{Handler: h.Handler.WithGroup(name)}
 }
 
 var _ slog.Handler = (*guardedHandler)(nil)

--- a/internal/cmn/logger/logger.go
+++ b/internal/cmn/logger/logger.go
@@ -149,7 +149,7 @@ func NewLogger(opts ...Option) Logger {
 
 func isRunContext(key string) bool {
 	switch key {
-	case "dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags":
+	case "dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags", "root", "parent":
 		return true
 	default:
 		return false

--- a/internal/cmn/logger/logger_test.go
+++ b/internal/cmn/logger/logger_test.go
@@ -300,6 +300,57 @@ func TestLogger_SourceLocationWithGroup(t *testing.T) {
 	}
 }
 
+func TestLogger_RunWriterOmitsAmbientRunContext(t *testing.T) {
+	baseContext := []slog.Attr{
+		slog.String("dag", "daily-report"),
+		slog.String("run-id", "run-1"),
+		slog.String("worker-id", "worker-1"),
+		slog.String("trace-id", "trace-1"),
+		slog.String("span-id", "span-1"),
+		slog.String("trace-flags", "01"),
+	}
+	runContext := append([]slog.Attr{}, baseContext...)
+	runContext = append(runContext, slog.String("attempt-id", "attempt-1"))
+
+	var runOutput bytes.Buffer
+	runLogger := NewLogger(
+		WithFormat("text"),
+		WithRunWriter(&runOutput),
+		WithQuiet(),
+	)
+	runLogger.With(runContext...).Info("Step started", slog.String("step", "collect_metrics"))
+	runLogger.With(baseContext...).Info("DAG run started", slog.String("attempt-id", "attempt-1"))
+
+	runLines := strings.Split(strings.TrimSpace(runOutput.String()), "\n")
+	if len(runLines) != 2 {
+		t.Fatalf("expected 2 run log lines, got %d: %s", len(runLines), runOutput.String())
+	}
+	for _, key := range []string{"dag=", "run-id=", "attempt-id=", "worker-id=", "trace-id=", "span-id=", "trace-flags="} {
+		if strings.Contains(runLines[0], key) {
+			t.Errorf("step log contains ambient %s: %s", key, runLines[0])
+		}
+	}
+	if !strings.Contains(runLines[0], "step=collect_metrics") {
+		t.Errorf("step log is missing event context: %s", runLines[0])
+	}
+	if !strings.Contains(runLines[1], "attempt-id=attempt-1") {
+		t.Errorf("attempt boundary is missing its attempt ID: %s", runLines[1])
+	}
+
+	var centralOutput bytes.Buffer
+	centralLogger := NewLogger(
+		WithFormat("text"),
+		WithWriter(&centralOutput),
+		WithQuiet(),
+	)
+	centralLogger.With(runContext...).Info("Step started", slog.String("step", "collect_metrics"))
+	for _, key := range []string{"dag=daily-report", "run-id=run-1", "attempt-id=attempt-1", "worker-id=worker-1", "trace-id=trace-1", "span-id=span-1", "trace-flags=01"} {
+		if !strings.Contains(centralOutput.String(), key) {
+			t.Errorf("central log is missing %s: %s", key, centralOutput.String())
+		}
+	}
+}
+
 func TestLogger_SourceLocationDisabledInProduction(t *testing.T) {
 	var buf bytes.Buffer
 	logger := NewLogger(

--- a/internal/cmn/logger/logger_test.go
+++ b/internal/cmn/logger/logger_test.go
@@ -308,6 +308,8 @@ func TestLogger_RunWriterOmitsAmbientRunContext(t *testing.T) {
 		slog.String("trace-id", "trace-1"),
 		slog.String("span-id", "span-1"),
 		slog.String("trace-flags", "01"),
+		slog.String("root", "root-run"),
+		slog.String("parent", "parent-run"),
 	}
 	runContext := append([]slog.Attr{}, baseContext...)
 	runContext = append(runContext, slog.String("attempt-id", "attempt-1"))
@@ -325,7 +327,7 @@ func TestLogger_RunWriterOmitsAmbientRunContext(t *testing.T) {
 	if len(runLines) != 2 {
 		t.Fatalf("expected 2 run log lines, got %d: %s", len(runLines), runOutput.String())
 	}
-	for _, key := range []string{"dag=", "run-id=", "attempt-id=", "worker-id=", "trace-id=", "span-id=", "trace-flags="} {
+	for _, key := range []string{"dag=", "run-id=", "attempt-id=", "worker-id=", "trace-id=", "span-id=", "trace-flags=", "root=", "parent="} {
 		if strings.Contains(runLines[0], key) {
 			t.Errorf("step log contains ambient %s: %s", key, runLines[0])
 		}
@@ -344,7 +346,7 @@ func TestLogger_RunWriterOmitsAmbientRunContext(t *testing.T) {
 		WithQuiet(),
 	)
 	centralLogger.With(runContext...).Info("Step started", slog.String("step", "collect_metrics"))
-	for _, key := range []string{"dag=daily-report", "run-id=run-1", "attempt-id=attempt-1", "worker-id=worker-1", "trace-id=trace-1", "span-id=span-1", "trace-flags=01"} {
+	for _, key := range []string{"dag=daily-report", "run-id=run-1", "attempt-id=attempt-1", "worker-id=worker-1", "trace-id=trace-1", "span-id=span-1", "trace-flags=01", "root=root-run", "parent=parent-run"} {
 		if !strings.Contains(centralOutput.String(), key) {
 			t.Errorf("central log is missing %s: %s", key, centralOutput.String())
 		}

--- a/internal/cmn/telemetry/propagation.go
+++ b/internal/cmn/telemetry/propagation.go
@@ -85,10 +85,7 @@ func InjectTraceContext(ctx context.Context) []string {
 	spanCtx := span.SpanContext()
 
 	logger.Debug(ctx, "InjectTraceContext called",
-		slog.Bool("has_active_span", spanCtx.IsValid()),
-		tag.TraceID(spanCtx.TraceID().String()),
-		tag.SpanID(spanCtx.SpanID().String()),
-		tag.TraceFlags(spanCtx.TraceFlags()))
+		slog.Bool("has_active_span", spanCtx.IsValid()))
 
 	// Get the global propagator
 	prop := otel.GetTextMapPropagator()

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -474,12 +474,15 @@ func (a *Agent) Run(ctx context.Context) error {
 		<-runningStatusDone
 	}()
 
-	// Set DAG context for all logs in this function
-	ctx = logger.WithValues(ctx,
-		tag.Name(a.dag.Name),
+	// Set DAG context for all logs in this function.
+	centralLogFields := []slog.Attr{
+		tag.DAG(a.dag.Name),
 		tag.RunID(a.dagRunID),
-		tag.AttemptID(a.dagRunAttemptID),
-	)
+	}
+	if a.workerID != "" {
+		centralLogFields = append(centralLogFields, tag.WorkerID(a.workerID))
+	}
+	ctx = logger.WithValues(ctx, centralLogFields...)
 	if !a.parentDAGRun.Zero() && a.dag.HasHumanTaskSteps() {
 		return fmt.Errorf("DAG %q contains human task steps and cannot run as a sub-DAG", a.dag.Name)
 	}
@@ -527,6 +530,9 @@ func (a *Agent) Run(ctx context.Context) error {
 			attribute.String("dag.name", a.dag.Name),
 			attribute.String("dag.run_id", a.dagRunID),
 		}
+		if a.workerID != "" {
+			spanAttrs = append(spanAttrs, attribute.String("dag.worker_id", a.workerID))
+		}
 		if a.parentDAGRun.Name != "" {
 			spanAttrs = append(spanAttrs, attribute.String("dag.parent_run_id", a.parentDAGRun.ID))
 			spanAttrs = append(spanAttrs, attribute.String("dag.parent_name", a.parentDAGRun.Name))
@@ -541,6 +547,15 @@ func (a *Agent) Run(ctx context.Context) error {
 			span.SetAttributes(attribute.String("dag.status", status.Status.String()))
 			span.End()
 		}()
+	}
+	if spanContext := trace.SpanContextFromContext(ctx); spanContext.IsValid() {
+		traceLogFields := []slog.Attr{
+			tag.TraceID(spanContext.TraceID().String()),
+			tag.SpanID(spanContext.SpanID().String()),
+			tag.TraceFlags(spanContext.TraceFlags().String()),
+		}
+		centralLogFields = append(centralLogFields, traceLogFields...)
+		ctx = logger.WithValues(ctx, traceLogFields...)
 	}
 
 	if a.rootDAGRun.ID != a.dagRunID {
@@ -571,6 +586,9 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 		attempt = att
 		a.dagRunAttemptID = attempt.ID()
+		if span != nil {
+			span.SetAttributes(attribute.String("dag.attempt_id", a.dagRunAttemptID))
+		}
 
 		// Set the attemptID on the log writer factory if it supports it
 		if a.logWriterFactory != nil {
@@ -664,21 +682,22 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 	ctx = runtime.NewContext(ctx, a.dag, a.dagRunID, a.logFile, contextOpts...)
 	ctx = runtimeexec.WithSubWorkflowRunner(ctx, subWorkflowRunner)
-	ctx, closeSubDAGRunSchedulerLog := a.withSubDAGRunSchedulerLogWriter(ctx)
+	ctx, closeSubDAGRunSchedulerLog, replacedLogger := a.withSubDAGRunSchedulerLogWriter(ctx)
 	defer closeSubDAGRunSchedulerLog()
 
-	// Add structured logging context
-	logFields := []slog.Attr{
-		tag.DAG(a.dag.Name),
-		tag.RunID(a.dagRunID),
+	if replacedLogger {
+		ctx = logger.WithValues(ctx, centralLogFields...)
 	}
 	if a.isSubDAGRun.Load() {
-		logFields = append(logFields,
+		ctx = logger.WithValues(ctx,
 			slog.String("root", a.rootDAGRun.String()),
 			slog.String("parent", a.parentDAGRun.String()),
 		)
 	}
-	ctx = logger.WithValues(ctx, logFields...)
+	attemptBoundaryLogger := logger.FromContext(ctx)
+	if a.dagRunAttemptID != "" {
+		ctx = logger.WithValues(ctx, tag.AttemptID(a.dagRunAttemptID))
+	}
 
 	if cleaner, ok := subWorkflowRunner.(interface{ Cleanup(context.Context) error }); ok {
 		defer func() {
@@ -984,12 +1003,17 @@ func (a *Agent) Run(ctx context.Context) error {
 	})
 
 	// Start the dag-run.
+	attemptBoundaryCtx := logger.WithLogger(ctx, attemptBoundaryLogger)
 	if a.retryTarget != nil {
-		logger.Info(ctx, "DAG run retry started",
+		logger.Info(attemptBoundaryCtx, "DAG run retry started",
+			tag.AttemptID(a.dagRunAttemptID),
 			slog.String("retry-target-attempt-id", a.retryTarget.AttemptID),
 		)
 	} else {
-		logger.Info(ctx, "DAG run started", slog.Any("params", a.dag.Params))
+		logger.Info(attemptBoundaryCtx, "DAG run started",
+			tag.AttemptID(a.dagRunAttemptID),
+			slog.Any("params", a.dag.Params),
+		)
 	}
 
 	go execWithRecovery(ctx, func() {
@@ -1049,7 +1073,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	if a.artifactFinalizer != nil && a.artifactDir != "" {
 		artifactFinalizeStartedAt := time.Now()
 		logger.Info(ctx, "Finalizing DAG run artifacts before writing terminal status",
-			slog.String("attempt-id", finishedStatus.AttemptID),
 			slog.String("artifact-dir", a.artifactDir),
 		)
 		finalizeCtx, cancelFinalize := context.WithTimeout(context.WithoutCancel(ctx), artifactFinalizeTimeout)
@@ -1057,7 +1080,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		if err := a.artifactFinalizer.Finalize(finalizeCtx, finishedStatus.AttemptID, a.artifactDir); err != nil {
 			logger.Error(ctx, "Failed to finalize DAG run artifacts before writing terminal status",
 				tag.Error(err),
-				slog.String("attempt-id", finishedStatus.AttemptID),
 				slog.String("artifact-dir", a.artifactDir),
 				slog.Duration("elapsed", time.Since(artifactFinalizeStartedAt)),
 			)
@@ -1077,7 +1099,6 @@ func (a *Agent) Run(ctx context.Context) error {
 			}
 		} else {
 			logger.Info(ctx, "Finished DAG run artifact finalization; terminal status can be written",
-				slog.String("attempt-id", finishedStatus.AttemptID),
 				slog.String("artifact-dir", a.artifactDir),
 				slog.Duration("elapsed", time.Since(artifactFinalizeStartedAt)),
 			)
@@ -1243,8 +1264,6 @@ func (a *Agent) collectOutputs(ctx context.Context) map[string]string {
 		}
 		if totalSize > 1024*1024 {
 			logger.Warn(ctx, "Outputs size exceeds 1MB",
-				slog.String("dag", a.dag.Name),
-				slog.String("dagRunId", a.dagRunID),
 				slog.Int("size", totalSize),
 				slog.Int("count", len(outputs)),
 			)
@@ -1524,7 +1543,6 @@ func (a *Agent) pushStatus(ctx context.Context, status exec.DAGRunStatus) {
 		var rejectedErr runtime.AttemptRejected
 		if errors.As(err, &rejectedErr) && !a.finished.Load() {
 			logger.Warn(ctx, "Coordinator rejected the worker attempt; stopping execution",
-				tag.AttemptID(a.dagRunAttemptID),
 				slog.String("reason", rejectedErr.AttemptRejectedReason()),
 			)
 			a.stopChildren(context.Background(), syscall.SIGTERM, true)
@@ -1688,23 +1706,23 @@ func (a *Agent) createSubWorkflowRunner(ctx context.Context) (runtimeexec.SubWor
 	return a.subWorkflowRunnerFactory(ctx)
 }
 
-func (a *Agent) withSubDAGRunSchedulerLogWriter(ctx context.Context) (context.Context, func()) {
+func (a *Agent) withSubDAGRunSchedulerLogWriter(ctx context.Context) (context.Context, func(), bool) {
 	if !a.isSubDAGRun.Load() || a.logFile == "" {
-		return ctx, func() {}
+		return ctx, func() {}, false
 	}
 	streamer, ok := a.logWriterFactory.(runtime.SchedulerLogStreamer)
 	if !ok || streamer == nil {
-		return ctx, func() {}
+		return ctx, func() {}, false
 	}
 
 	file, err := os.OpenFile(a.logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		logger.Warn(ctx, "Failed to open sub DAG scheduler log file", tag.File(a.logFile), tag.Error(err))
-		return ctx, func() {}
+		return ctx, func() {}, false
 	}
 
 	writer := streamer.NewSchedulerLogWriter(ctx, file)
-	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.WithWriter(writer)))
+	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.WithRunWriter(writer)))
 	return ctx, func() {
 		if err := writer.Close(); err != nil {
 			logger.Warn(ctx, "Failed to close sub DAG scheduler log streamer", tag.Error(err))
@@ -1712,7 +1730,7 @@ func (a *Agent) withSubDAGRunSchedulerLogWriter(ctx context.Context) (context.Co
 		if err := file.Close(); err != nil {
 			logger.Warn(ctx, "Failed to close sub DAG scheduler log file", tag.File(a.logFile), tag.Error(err))
 		}
-	}
+	}, true
 }
 
 type resolvedProfileValues struct {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -8,14 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -109,120 +106,6 @@ func agentRunStartTimeout() time.Duration {
 		return 30 * time.Second
 	}
 	return 5 * time.Second
-}
-
-func TestAgent_SubDAGSchedulerLogContext(t *testing.T) {
-	th := test.Setup(t)
-	dag := th.DAG(t, `steps:
-  - name: collect_metrics
-    run: exit 0
-`)
-	logs := &schedulerLogCapture{}
-	const (
-		runID     = "child-run"
-		attemptID = "attempt-1"
-	)
-	rootRef := exec.NewDAGRunRef(dag.Name, "root-run")
-	_, err := th.DAGRunStore.CreateAttempt(
-		th.Context,
-		dag.DAG,
-		time.Now(),
-		rootRef.ID,
-		exec.NewDAGRunAttemptOptions{},
-	)
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(th.Config.Paths.LogDir, 0o750))
-	logFile := filepath.Join(th.Config.Paths.LogDir, runID+".log")
-	dagAgent := agent.New(
-		runID,
-		dag.DAG,
-		th.Config.Paths.LogDir,
-		logFile,
-		th.DAGRunMgr,
-		th.DAGStore,
-		agent.Options{
-			RootDAGRun:        rootRef,
-			ParentDAGRun:      rootRef,
-			AttemptID:         attemptID,
-			DAGRunStore:       th.DAGRunStore,
-			QueueStore:        th.QueueStore,
-			StateStore:        th.StateStore,
-			ServiceRegistry:   th.ServiceRegistry,
-			LogWriterFactory:  logs,
-			PeerConfig:        th.Config.Core.Peer,
-			DefaultExecMode:   th.Config.DefaultExecMode,
-			DAGRunLogDir:      th.Config.Paths.LogDir,
-			DAGRunArtifactDir: th.Config.Paths.ArtifactDir,
-		},
-	)
-
-	require.NoError(t, dagAgent.Run(th.Context))
-
-	var records []map[string]any
-	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
-		var record map[string]any
-		require.NoError(t, json.Unmarshal([]byte(line), &record))
-		records = append(records, record)
-	}
-
-	var boundary, step map[string]any
-	attemptCount := 0
-	for _, record := range records {
-		if _, ok := record["attempt-id"]; ok {
-			attemptCount++
-		}
-		if _, ok := record["step"]; ok {
-			for _, key := range []string{"dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags", "root", "parent"} {
-				require.NotContains(t, record, key)
-			}
-		}
-		switch record["msg"] {
-		case "DAG run started":
-			boundary = record
-		case "Step started":
-			step = record
-		}
-	}
-	require.Equal(t, attemptID, boundary["attempt-id"])
-	require.Equal(t, 1, attemptCount)
-	require.Equal(t, "collect_metrics", step["step"])
-}
-
-type schedulerLogCapture struct {
-	mu     sync.Mutex
-	output strings.Builder
-}
-
-func (c *schedulerLogCapture) NewStepWriter(context.Context, string, int) io.WriteCloser {
-	return nopWriteCloser{Writer: io.Discard}
-}
-
-func (c *schedulerLogCapture) NewSchedulerLogWriter(context.Context, *os.File) io.WriteCloser {
-	return nopWriteCloser{Writer: c}
-}
-
-func (*schedulerLogCapture) StreamSchedulerLog(context.Context, string) error {
-	return nil
-}
-
-func (c *schedulerLogCapture) Write(data []byte) (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.output.Write(data)
-}
-
-func (c *schedulerLogCapture) String() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.output.String()
-}
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (nopWriteCloser) Close() error {
-	return nil
 }
 
 func pwdCommand() string {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -8,11 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -106,6 +109,118 @@ func agentRunStartTimeout() time.Duration {
 		return 30 * time.Second
 	}
 	return 5 * time.Second
+}
+
+func TestAgent_SubDAGSchedulerLogContext(t *testing.T) {
+	th := test.Setup(t)
+	dag := th.DAG(t, `steps:
+  - name: collect_metrics
+    run: exit 0
+`)
+	logs := &schedulerLogCapture{}
+	const (
+		runID     = "child-run"
+		attemptID = "attempt-1"
+	)
+	rootRef := exec.NewDAGRunRef(dag.Name, "root-run")
+	_, err := th.DAGRunStore.CreateAttempt(
+		th.Context,
+		dag.DAG,
+		time.Now(),
+		rootRef.ID,
+		exec.NewDAGRunAttemptOptions{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(th.Config.Paths.LogDir, 0o750))
+	logFile := filepath.Join(th.Config.Paths.LogDir, runID+".log")
+	dagAgent := agent.New(
+		runID,
+		dag.DAG,
+		th.Config.Paths.LogDir,
+		logFile,
+		th.DAGRunMgr,
+		th.DAGStore,
+		agent.Options{
+			RootDAGRun:        rootRef,
+			ParentDAGRun:      rootRef,
+			AttemptID:         attemptID,
+			DAGRunStore:       th.DAGRunStore,
+			QueueStore:        th.QueueStore,
+			StateStore:        th.StateStore,
+			ServiceRegistry:   th.ServiceRegistry,
+			LogWriterFactory:  logs,
+			PeerConfig:        th.Config.Core.Peer,
+			DefaultExecMode:   th.Config.DefaultExecMode,
+			DAGRunLogDir:      th.Config.Paths.LogDir,
+			DAGRunArtifactDir: th.Config.Paths.ArtifactDir,
+		},
+	)
+
+	require.NoError(t, dagAgent.Run(th.Context))
+
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record))
+		records = append(records, record)
+	}
+
+	var boundary, step map[string]any
+	attemptCount := 0
+	for _, record := range records {
+		if _, ok := record["attempt-id"]; ok {
+			attemptCount++
+		}
+		switch record["msg"] {
+		case "DAG run started":
+			boundary = record
+		case "Step started":
+			step = record
+		}
+	}
+	require.Equal(t, attemptID, boundary["attempt-id"])
+	require.Equal(t, 1, attemptCount)
+	require.Equal(t, "collect_metrics", step["step"])
+	for _, key := range []string{"dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags", "root", "parent"} {
+		require.NotContains(t, step, key)
+	}
+}
+
+type schedulerLogCapture struct {
+	mu     sync.Mutex
+	output strings.Builder
+}
+
+func (c *schedulerLogCapture) NewStepWriter(context.Context, string, int) io.WriteCloser {
+	return nopWriteCloser{Writer: io.Discard}
+}
+
+func (c *schedulerLogCapture) NewSchedulerLogWriter(context.Context, *os.File) io.WriteCloser {
+	return nopWriteCloser{Writer: c}
+}
+
+func (*schedulerLogCapture) StreamSchedulerLog(context.Context, string) error {
+	return nil
+}
+
+func (c *schedulerLogCapture) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.output.Write(data)
+}
+
+func (c *schedulerLogCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.output.String()
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error {
+	return nil
 }
 
 func pwdCommand() string {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -171,6 +171,11 @@ func TestAgent_SubDAGSchedulerLogContext(t *testing.T) {
 		if _, ok := record["attempt-id"]; ok {
 			attemptCount++
 		}
+		if _, ok := record["step"]; ok {
+			for _, key := range []string{"dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags", "root", "parent"} {
+				require.NotContains(t, record, key)
+			}
+		}
 		switch record["msg"] {
 		case "DAG run started":
 			boundary = record
@@ -181,9 +186,6 @@ func TestAgent_SubDAGSchedulerLogContext(t *testing.T) {
 	require.Equal(t, attemptID, boundary["attempt-id"])
 	require.Equal(t, 1, attemptCount)
 	require.Equal(t, "collect_metrics", step["step"])
-	for _, key := range []string{"dag", "run-id", "attempt-id", "worker-id", "trace-id", "span-id", "trace-flags", "root", "parent"} {
-		require.NotContains(t, step, key)
-	}
 }
 
 type schedulerLogCapture struct {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -159,7 +159,7 @@ func TestAgent_SubDAGSchedulerLogContext(t *testing.T) {
 	require.NoError(t, dagAgent.Run(th.Context))
 
 	var records []map[string]any
-	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
 		var record map[string]any
 		require.NoError(t, json.Unmarshal([]byte(line), &record))
 		records = append(records, record)

--- a/internal/runtime/agent/dbclient.go
+++ b/internal/runtime/agent/dbclient.go
@@ -32,19 +32,19 @@ func newDBClient(drs exec.DAGRunStore, ds exec.DAGStore, remoteDAGLoader RemoteD
 func (o *dbClient) GetDAG(ctx context.Context, name string) (*core.DAG, error) {
 	// Guard against nil DAG store
 	if o.ds == nil {
-		logger.Info(ctx, "No local DAG store, trying remote fallback", tag.DAG(name))
+		logger.Info(ctx, "No local DAG store, trying remote fallback", tag.SubDAG(name))
 		if o.remoteDAGLoader == nil {
 			return nil, fmt.Errorf("no local DAG store and no remote loader configured for DAG %s", name)
 		}
 		remoteDAG, remoteErr := o.remoteDAGLoader(ctx, name)
 		if remoteErr != nil {
-			logger.Warn(ctx, "Remote DAG fallback failed", tag.DAG(name), tag.Error(remoteErr))
+			logger.Warn(ctx, "Remote DAG fallback failed", tag.SubDAG(name), tag.Error(remoteErr))
 			return nil, fmt.Errorf("remote DAG load failed for %s: %w", name, remoteErr)
 		}
 		if remoteDAG == nil {
 			return nil, fmt.Errorf("DAG %s not found locally or remotely", name)
 		}
-		logger.Info(ctx, "DAG loaded from remote fallback", tag.DAG(name))
+		logger.Info(ctx, "DAG loaded from remote fallback", tag.SubDAG(name))
 		return remoteDAG, nil
 	}
 
@@ -61,12 +61,12 @@ func (o *dbClient) GetDAG(ctx context.Context, name string) (*core.DAG, error) {
 		return nil, err
 	}
 	logger.Info(ctx, "DAG not found locally, trying remote fallback",
-		tag.DAG(name),
+		tag.SubDAG(name),
 	)
 	remoteDAG, remoteErr := o.remoteDAGLoader(ctx, name)
 	if remoteErr != nil {
 		logger.Warn(ctx, "Remote DAG fallback failed",
-			tag.DAG(name),
+			tag.SubDAG(name),
 			tag.Error(remoteErr),
 		)
 		return nil, err // Return the original local error
@@ -75,7 +75,7 @@ func (o *dbClient) GetDAG(ctx context.Context, name string) (*core.DAG, error) {
 		return nil, err // Return the original local error
 	}
 	logger.Info(ctx, "DAG loaded from remote fallback",
-		tag.DAG(name),
+		tag.SubDAG(name),
 	)
 	return remoteDAG, nil
 }

--- a/internal/runtime/builtin/chat/tool_executor.go
+++ b/internal/runtime/builtin/chat/tool_executor.go
@@ -144,8 +144,8 @@ func (e *ToolExecutor) executeToolCall(ctx context.Context, tc llmpkg.ToolCall) 
 	}
 
 	logger.Info(ctx, "Starting tool DAG execution",
-		tag.RunID(runID),
-		tag.DAG(dag.Name),
+		tag.SubRunID(runID),
+		tag.SubDAG(dag.Name),
 		slog.String("params", params),
 	)
 
@@ -171,7 +171,7 @@ func (e *ToolExecutor) executeToolCall(ctx context.Context, tc llmpkg.ToolCall) 
 	content := formatToolResult(result)
 
 	logger.Info(ctx, "Tool execution completed successfully",
-		tag.RunID(runID),
+		tag.SubRunID(runID),
 		slog.Int("output_length", len(content)),
 	)
 

--- a/internal/runtime/builtin/dag/enqueue.go
+++ b/internal/runtime/builtin/dag/enqueue.go
@@ -265,8 +265,8 @@ func (e *enqueueExecutor) enqueueOne(ctx context.Context, runParams executor.Run
 	}
 
 	logger.Info(ctx, "Enqueued sub DAG run",
-		tag.DAG(dagCopy.Name),
-		tag.RunID(runParams.RunID),
+		tag.SubDAG(dagCopy.Name),
+		tag.SubRunID(runParams.RunID),
 		tag.Queue(queueName),
 		slog.Any("params", dagCopy.Params),
 	)

--- a/internal/runtime/builtin/dag/parallel.go
+++ b/internal/runtime/builtin/dag/parallel.go
@@ -124,7 +124,7 @@ func (e *parallelExecutor) Run(ctx context.Context) error {
 	logger.Info(ctx, "Starting parallel execution",
 		slog.Int("total", len(e.runParamsList)),
 		slog.Int("max-concurrent", e.maxConcurrent),
-		tag.DAG(e.step.SubDAG.Name),
+		tag.SubDAG(e.step.SubDAG.Name),
 	)
 
 	pending := make([]scheduledAttempt, 0, len(e.runParamsList))
@@ -213,7 +213,7 @@ func (e *parallelExecutor) Run(ctx context.Context) error {
 
 			if res.err != nil && !e.cancelled() {
 				logger.Error(ctx, "Sub DAG execution failed",
-					tag.RunID(res.attempt.runParams.RunID),
+					tag.SubRunID(res.attempt.runParams.RunID),
 					tag.Error(res.err),
 				)
 			}

--- a/internal/runtime/executor/dag_runner.go
+++ b/internal/runtime/executor/dag_runner.go
@@ -376,14 +376,14 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 			}); err != nil {
 				errs = append(errs, err)
 				logger.Warn(ctx, "Failed to request sub DAG cancellation",
-					tag.RunID(run.runID),
-					tag.DAG(e.DAG.Name),
+					tag.SubRunID(run.runID),
+					tag.SubDAG(e.DAG.Name),
 					tag.Error(err),
 				)
 			} else {
 				logger.Info(ctx, "Requested sub DAG cancellation",
-					tag.RunID(run.runID),
-					tag.DAG(e.DAG.Name),
+					tag.SubRunID(run.runID),
+					tag.SubDAG(e.DAG.Name),
 				)
 			}
 		} else if e.dagCtx.DB != nil {
@@ -391,15 +391,15 @@ func (e *SubDAGExecutor) Stop(intent cmdutil.TerminationIntent) error {
 				if !errors.Is(err, exec.ErrDAGRunIDNotFound) {
 					errs = append(errs, err)
 					logger.Warn(ctx, "Failed to request child cancel via local DB",
-						tag.RunID(run.runID),
-						tag.DAG(e.DAG.Name),
+						tag.SubRunID(run.runID),
+						tag.SubDAG(e.DAG.Name),
 						tag.Error(err),
 					)
 				}
 			} else {
 				logger.Info(ctx, "Requested sub DAG cancellation via local DB",
-					tag.RunID(run.runID),
-					tag.DAG(e.DAG.Name),
+					tag.SubRunID(run.runID),
+					tag.SubDAG(e.DAG.Name),
 				)
 			}
 		}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -64,7 +64,7 @@ type Manager struct {
 // still pending DAG-level auto-retry when dagRunID is provided.
 func (m *Manager) Stop(ctx context.Context, dag *core.DAG, dagRunID string) error {
 	// Set DAG name in context for all logs in this function
-	ctx = logger.WithValues(ctx, tag.Name(dag.Name))
+	ctx = logger.WithValues(ctx, tag.DAG(dag.Name))
 	logger.Info(ctx, "Stopping DAG")
 
 	if dagRunID == "" {
@@ -344,7 +344,7 @@ func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun exec.DAGRu
 	dag, err := attempt.ReadDAG(ctx)
 	if err != nil {
 		logger.Error(ctx, "Failed to read sub DAG for stale status check",
-			tag.RunID(subRunID),
+			tag.SubRunID(subRunID),
 			tag.Error(err),
 		)
 		return status, nil

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -1156,7 +1156,6 @@ func (n *Node) SetupEnv(ctx context.Context) context.Context {
 	).WithEntry(
 		exec.EnvKeyDAGRunStepStderrFile, n.GetStderr(), cmnvalue.EnvSourceStepEnv,
 	)
-	ctx = logger.WithValues(ctx, tag.Step(n.Name()))
 	return WithEnv(ctx, env)
 }
 

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1250,7 +1250,6 @@ func (r *Runner) setup(ctx context.Context) (err error) {
 	r.metrics.startTime = time.Now()
 
 	logger.Debug(ctx, "Runner setup complete",
-		slog.String("dagRunId", r.dagRunID),
 		slog.Int("maxActiveRuns", r.maxActiveRuns),
 		slog.Duration("timeout", r.timeout),
 		slog.Bool("dry", r.dry),
@@ -1437,7 +1436,6 @@ func (r *Runner) recoverNodePanic(ctx context.Context, node *Node, progressCh ch
 		logger.Error(ctx, "Panic occurred",
 			tag.Error(err),
 			slog.String("stack", stack),
-			tag.RunID(r.dagRunID),
 		)
 		node.MarkError(err)
 		r.setLastError(err)

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/dirlock"
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/service/eventstore"
 )
@@ -214,9 +215,9 @@ func (m *NotificationMonitor) NotifyCompletion(status *exec.DAGRunStatus) bool {
 	}
 
 	m.logger.Info("DAG run notification queued",
-		slog.String("dag", status.Name),
+		tag.DAG(status.Name),
 		slog.String("status", status.Status.String()),
-		slog.String("dag_run_id", status.DAGRunID),
+		tag.RunID(status.DAGRunID),
 	)
 
 	event := NotificationEvent{

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1050,10 +1050,14 @@ func (a *API) GetDAGRunOutputs(ctx context.Context, request api.GetDAGRunOutputs
 
 	outputs, err := attempt.ReadOutputs(ctx)
 	if err != nil {
+		resolvedRunID := request.DagRunId
+		if status, statusErr := attempt.ReadStatus(ctx); statusErr == nil && status != nil && status.DAGRunID != "" {
+			resolvedRunID = status.DAGRunID
+		}
 		logger.Error(ctx, "Failed to read outputs",
 			tag.Error(err),
 			tag.DAG(request.Name),
-			tag.RunID(request.DagRunId),
+			tag.RunID(resolvedRunID),
 		)
 		return nil, fmt.Errorf("error reading outputs: %w", err)
 	}

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -1052,8 +1052,8 @@ func (a *API) GetDAGRunOutputs(ctx context.Context, request api.GetDAGRunOutputs
 	if err != nil {
 		logger.Error(ctx, "Failed to read outputs",
 			tag.Error(err),
-			slog.String("dag", request.Name),
-			slog.String("dagRunId", request.DagRunId),
+			tag.DAG(request.Name),
+			tag.RunID(request.DagRunId),
 		)
 		return nil, fmt.Errorf("error reading outputs: %w", err)
 	}
@@ -1360,7 +1360,7 @@ func (a *API) ApproveDAGRunStep(ctx context.Context, request api.ApproveDAGRunSt
 			shouldResume = false
 		} else {
 			logger.Info(ctx, "DAG resumed after approval",
-				slog.String("dagRunId", request.DagRunId),
+				tag.RunID(request.DagRunId),
 				slog.String("step", request.StepName),
 			)
 		}
@@ -1490,7 +1490,7 @@ func (a *API) ApproveSubDAGRunStep(ctx context.Context, request api.ApproveSubDA
 			shouldResume = false
 		} else {
 			logger.Info(ctx, "Sub DAG resumed after approval",
-				slog.String("subDagRunId", request.SubDAGRunId),
+				tag.SubRunID(request.SubDAGRunId),
 				slog.String("step", request.StepName),
 			)
 		}
@@ -1682,7 +1682,7 @@ func (a *API) RejectDAGRunStep(ctx context.Context, request api.RejectDAGRunStep
 	}
 
 	logger.Info(ctx, "Step rejected",
-		slog.String("dagRunId", request.DagRunId),
+		tag.RunID(request.DagRunId),
 		slog.String("step", request.StepName),
 	)
 
@@ -1797,7 +1797,7 @@ func (a *API) RejectSubDAGRunStep(ctx context.Context, request api.RejectSubDAGR
 	}
 
 	logger.Info(ctx, "Sub DAG step rejected",
-		slog.String("subDagRunId", request.SubDAGRunId),
+		tag.SubRunID(request.SubDAGRunId),
 		slog.String("step", request.StepName),
 	)
 
@@ -1930,7 +1930,7 @@ func (a *API) PushBackDAGRunStep(ctx context.Context, request api.PushBackDAGRun
 	}
 
 	logger.Info(ctx, "DAG resumed after push-back",
-		slog.String("dagRunId", request.DagRunId),
+		tag.RunID(request.DagRunId),
 		slog.String("step", request.StepName),
 		slog.Int("iteration", approvalIteration),
 	)
@@ -2078,7 +2078,7 @@ func (a *API) PushBackSubDAGRunStep(ctx context.Context, request api.PushBackSub
 	}
 
 	logger.Info(ctx, "Sub DAG resumed after push-back",
-		slog.String("subDagRunId", request.SubDAGRunId),
+		tag.SubRunID(request.SubDAGRunId),
 		slog.String("step", request.StepName),
 		slog.Int("iteration", approvalIteration),
 	)

--- a/internal/service/frontend/api/v1/humantasks.go
+++ b/internal/service/frontend/api/v1/humantasks.go
@@ -197,8 +197,8 @@ func completeHumanTaskErrorResponse(ctx context.Context, err error) (api.Complet
 	if errors.As(err, &resumeErr) {
 		logger.Error(ctx, "Failed to queue DAG-run after human-task completion",
 			tag.Error(resumeErr.Err),
-			slog.String("dag", resumeErr.Result.DAGName),
-			slog.String("dagRunId", resumeErr.Result.DAGRunID),
+			tag.DAG(resumeErr.Result.DAGName),
+			tag.RunID(resumeErr.Result.DAGRunID),
 			slog.String("step", resumeErr.Result.StepID),
 		)
 		details := map[string]any{
@@ -231,8 +231,8 @@ func resumeHumanTaskErrorResponse(ctx context.Context, err error) (api.ResumeHum
 	if errors.As(err, &resumeErr) {
 		logger.Error(ctx, "Failed to queue human-task DAG-run resume",
 			tag.Error(resumeErr.Err),
-			slog.String("dag", resumeErr.Result.DAGName),
-			slog.String("dagRunId", resumeErr.Result.DAGRunID),
+			tag.DAG(resumeErr.Result.DAGName),
+			tag.RunID(resumeErr.Result.DAGRunID),
 		)
 		details := map[string]any{
 			"completionStored": true,

--- a/internal/service/frontend/api/v1/queues.go
+++ b/internal/service/frontend/api/v1/queues.go
@@ -355,7 +355,7 @@ func (a *API) listVisibleQueuedItems(ctx context.Context, queueName string, limi
 				logger.Warn(ctx, "Failed to fetch queued DAG run summary",
 					tag.Queue(queueName),
 					tag.Error(err),
-					slog.String("dagRunId", dagRunRef.ID),
+					tag.RunID(dagRunRef.ID),
 				)
 				continue
 			}

--- a/internal/service/frontend/api/v1/webhooks.go
+++ b/internal/service/frontend/api/v1/webhooks.go
@@ -543,8 +543,8 @@ func (a *API) TriggerWebhook(ctx context.Context, request api.TriggerWebhookRequ
 		if err == nil && len(statuses) > 0 {
 			// DAG run already exists - return 409 Conflict
 			logger.Info(ctx, "Webhook: DAG run already exists (idempotency)",
-				tag.Name(dag.Name),
-				tag.Key("dagRunID"), tag.Value(dagRunID),
+				tag.DAG(dag.Name),
+				tag.RunID(dagRunID),
 			)
 			return api.TriggerWebhook409JSONResponse{
 				Code:    api.ErrorCodeAlreadyExists,
@@ -565,7 +565,7 @@ func (a *API) TriggerWebhook(ctx context.Context, request api.TriggerWebhookRequ
 	// need to fit in a subprocess command line.
 	if err := a.enqueuePreparedDAGRun(ctx, dag, params, dagRunID, core.TriggerTypeWebhook, profileName); err != nil {
 		logger.Error(ctx, "Webhook: failed to enqueue DAG run",
-			tag.Name(dag.Name),
+			tag.DAG(dag.Name),
 			tag.Error(err),
 		)
 		return nil, &Error{
@@ -576,8 +576,8 @@ func (a *API) TriggerWebhook(ctx context.Context, request api.TriggerWebhookRequ
 	}
 
 	logger.Info(ctx, "Webhook: DAG run enqueued",
-		tag.Name(dag.Name),
-		tag.Key("dagRunID"), tag.Value(dagRunID),
+		tag.DAG(dag.Name),
+		tag.RunID(dagRunID),
 		tag.Key("webhookID"), tag.Value(webhook.ID),
 	)
 
@@ -596,7 +596,7 @@ func buildWebhookRequestRuntimeParams(
 	payload, err := marshalWebhookPayload(ctx, body)
 	if err != nil {
 		logger.Warn(ctx, "Webhook: failed to marshal payload",
-			tag.Name(dag.Name),
+			tag.DAG(dag.Name),
 			tag.Error(err),
 		)
 		return "", &Error{
@@ -607,7 +607,7 @@ func buildWebhookRequestRuntimeParams(
 	}
 	if len(payload) > maxPayloadSize {
 		logger.Warn(ctx, "Webhook: payload too large",
-			tag.Name(dag.Name),
+			tag.DAG(dag.Name),
 			tag.Key("size"), tag.Value(len(payload)),
 			tag.Key("maxSize"), tag.Value(maxPayloadSize),
 		)
@@ -626,7 +626,7 @@ func buildWebhookRequestRuntimeParams(
 	headers, err := marshalWebhookHeaders(ctx, headerAllowList)
 	if err != nil {
 		logger.Warn(ctx, "Webhook: failed to marshal headers",
-			tag.Name(dag.Name),
+			tag.DAG(dag.Name),
 			tag.Error(err),
 		)
 		return "", &Error{

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -631,7 +631,7 @@ func (d *queueDispatcher) dispatchQueuedItem(
 	runRef := *data
 	runID := runRef.ID
 	ctx = logger.WithValues(ctx, tag.RunID(runID))
-	logger.Debug(ctx, "Processing queue item", tag.Name(runRef.Name))
+	logger.Debug(ctx, "Processing queue item", tag.DAG(runRef.Name))
 
 	running, err := d.procStore.IsRunAlive(ctx, queueName, runRef)
 	if err != nil {

--- a/internal/service/scheduler/zombie_detector.go
+++ b/internal/service/scheduler/zombie_detector.go
@@ -160,7 +160,7 @@ func (z *ZombieDetector) detectAndCleanZombies(ctx context.Context) {
 
 		if err := z.checkAndCleanZombie(ctx, entry, freshByRunScope); err != nil {
 			logger.Error(ctx, "Failed to check zombie status",
-				tag.Name(entry.Meta.Name),
+				tag.DAG(entry.Meta.Name),
 				tag.RunID(entry.Meta.DAGRunID),
 				tag.AttemptID(entry.Meta.AttemptID),
 				tag.Error(err))

--- a/internal/subflow/runner.go
+++ b/internal/subflow/runner.go
@@ -437,7 +437,7 @@ func (r *Runner) waitCompletion(ctx context.Context, req executor.SubWorkflowReq
 				continue
 			}
 
-			logger.Info(waitCtx, "Distributed child workflow completed", tag.Name(result.Name))
+			logger.Info(waitCtx, "Distributed child workflow completed", tag.SubDAG(result.Name))
 			return result, nil
 
 		case <-logTicker.C:

--- a/ui/src/features/dags/components/dag-execution/ActivityLine.tsx
+++ b/ui/src/features/dags/components/dag-execution/ActivityLine.tsx
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import React from 'react';
+import { AnsiLine } from '@/lib/ansi';
+import type { SchedulerLogLine } from '@/lib/scheduler-log';
+
+function shortTimestamp(timestamp?: string): string {
+  return timestamp?.match(/T(\d{2}:\d{2}:\d{2}(?:\.\d{3})?)/)?.[1] || '';
+}
+
+function levelClass(level?: string): string {
+  switch (level) {
+    case 'ERROR':
+      return 'bg-error/10 text-error';
+    case 'WARN':
+      return 'bg-warning/10 text-warning';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+export function ActivityLine({
+  line,
+  lineNumber,
+}: {
+  line: SchedulerLogLine;
+  lineNumber: number;
+}) {
+  if (!line.structured) {
+    return (
+      <div
+        data-line-number={lineNumber}
+        className="whitespace-normal break-words border-b border-border px-3 py-2 font-mono text-sm last:border-b-0"
+      >
+        <AnsiLine text={line.message} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-line-number={lineNumber}
+      className="flex items-start gap-3 border-b border-border px-3 py-2 last:border-b-0"
+    >
+      <time
+        className="w-[5.5rem] shrink-0 pt-0.5 font-mono text-xs text-muted-foreground"
+        title={line.timestamp}
+      >
+        {shortTimestamp(line.timestamp)}
+      </time>
+      <span
+        className={`w-12 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold ${levelClass(line.level)}`}
+      >
+        {line.level}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <span className="whitespace-normal break-words font-medium text-foreground">
+            <AnsiLine text={line.message} />
+          </span>
+          {line.step && (
+            <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
+              {line.step}
+            </span>
+          )}
+        </div>
+        {line.details && (
+          <details className="mt-1 text-xs text-muted-foreground">
+            <summary className="w-fit cursor-pointer select-none">
+              Details
+            </summary>
+            <code className="mt-1 block whitespace-pre-wrap break-words font-mono">
+              {line.details}
+            </code>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/dags/components/dag-execution/ActivityLine.tsx
+++ b/ui/src/features/dags/components/dag-execution/ActivityLine.tsx
@@ -41,30 +41,29 @@ export function ActivityLine({
   return (
     <div
       data-line-number={lineNumber}
-      className="flex items-start gap-3 border-b border-border px-3 py-2 last:border-b-0"
+      className="grid grid-cols-[5.5rem_3rem_minmax(0,1fr)] items-start gap-x-3 gap-y-1 border-b border-border px-3 py-2 last:border-b-0 sm:grid-cols-[5.5rem_3rem_minmax(8rem,12rem)_minmax(0,1fr)]"
     >
       <time
-        className="w-[5.5rem] shrink-0 pt-0.5 font-mono text-xs text-muted-foreground"
+        className="pt-0.5 font-mono text-xs text-muted-foreground"
         title={line.timestamp}
       >
         {shortTimestamp(line.timestamp)}
       </time>
       <span
-        className={`w-12 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold ${levelClass(line.level)}`}
+        className={`rounded px-1.5 py-0.5 text-center text-[10px] font-semibold ${levelClass(line.level)}`}
       >
         {line.level}
       </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-2">
-          <span className="whitespace-normal break-words font-medium text-foreground">
-            <AnsiLine text={line.message} />
-          </span>
-          {line.step && (
-            <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
-              {line.step}
-            </span>
-          )}
-        </div>
+      <span
+        className="min-w-0 truncate pt-0.5 font-mono text-sm font-semibold text-foreground"
+        title={line.step}
+      >
+        {line.step}
+      </span>
+      <div className="col-span-3 min-w-0 sm:col-span-1">
+        <span className="whitespace-normal break-words text-sm text-foreground">
+          <AnsiLine text={line.message} />
+        </span>
         {line.details && (
           <details className="mt-1 text-xs text-muted-foreground">
             <summary className="w-fit cursor-pointer select-none">

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -21,11 +21,9 @@ import { useQuery } from '../../../../hooks/api';
 import { whenEnabled } from '../../../../hooks/queryUtils';
 import { useDAGRunLogsSSE } from '../../../../hooks/useDAGRunLogsSSE';
 import { AnsiLine } from '@/lib/ansi';
-import {
-  parseSchedulerLogLine,
-  type SchedulerLogLine,
-} from '@/lib/scheduler-log';
+import { parseSchedulerLogLine } from '@/lib/scheduler-log';
 import LoadingIndicator from '@/components/ui/loading-indicator';
+import { ActivityLine } from './ActivityLine';
 
 // Extended Log type with pagination fields
 interface LogWithPagination {
@@ -38,69 +36,6 @@ interface LogWithPagination {
 
 function calculateTotalPages(totalLines: number, pageSize: number): number {
   return Math.ceil(totalLines / pageSize);
-}
-
-function shortTimestamp(timestamp?: string): string {
-  return timestamp?.match(/T(\d{2}:\d{2}:\d{2}(?:\.\d{3})?)/)?.[1] || '';
-}
-
-function levelClass(level?: string): string {
-  switch (level) {
-    case 'ERROR':
-      return 'bg-error/10 text-error';
-    case 'WARN':
-      return 'bg-warning/10 text-warning';
-    default:
-      return 'bg-muted text-muted-foreground';
-  }
-}
-
-function ActivityLine({ line }: { line: SchedulerLogLine }) {
-  if (!line.structured) {
-    return (
-      <div className="border-b border-border px-3 py-2 font-mono text-sm last:border-b-0">
-        <AnsiLine text={line.message} />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex items-start gap-3 border-b border-border px-3 py-2 last:border-b-0">
-      <time
-        className="w-[5.5rem] shrink-0 pt-0.5 font-mono text-xs text-muted-foreground"
-        title={line.timestamp}
-      >
-        {shortTimestamp(line.timestamp)}
-      </time>
-      <span
-        className={`w-12 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold ${levelClass(line.level)}`}
-      >
-        {line.level}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-2">
-          <span className="font-medium text-foreground">
-            <AnsiLine text={line.message} />
-          </span>
-          {line.step && (
-            <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
-              {line.step}
-            </span>
-          )}
-        </div>
-        {line.details && (
-          <details className="mt-1 text-xs text-muted-foreground">
-            <summary className="w-fit cursor-pointer select-none">
-              Details
-            </summary>
-            <code className="mt-1 block whitespace-pre-wrap break-words font-mono">
-              {line.details}
-            </code>
-          </details>
-        )}
-      </div>
-    </div>
-  );
 }
 
 /**
@@ -636,7 +571,11 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
         {displayMode === 'activity' ? (
           <div>
             {activityLines.map((line, index) => (
-              <ActivityLine key={index} line={line} />
+              <ActivityLine
+                key={index}
+                line={line}
+                lineNumber={getLineNumber(index)}
+              />
             ))}
           </div>
         ) : (

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -21,6 +21,10 @@ import { useQuery } from '../../../../hooks/api';
 import { whenEnabled } from '../../../../hooks/queryUtils';
 import { useDAGRunLogsSSE } from '../../../../hooks/useDAGRunLogsSSE';
 import { AnsiLine } from '@/lib/ansi';
+import {
+  parseSchedulerLogLine,
+  type SchedulerLogLine,
+} from '@/lib/scheduler-log';
 import LoadingIndicator from '@/components/ui/loading-indicator';
 
 // Extended Log type with pagination fields
@@ -34,6 +38,69 @@ interface LogWithPagination {
 
 function calculateTotalPages(totalLines: number, pageSize: number): number {
   return Math.ceil(totalLines / pageSize);
+}
+
+function shortTimestamp(timestamp?: string): string {
+  return timestamp?.match(/T(\d{2}:\d{2}:\d{2}(?:\.\d{3})?)/)?.[1] || '';
+}
+
+function levelClass(level?: string): string {
+  switch (level) {
+    case 'ERROR':
+      return 'bg-error/10 text-error';
+    case 'WARN':
+      return 'bg-warning/10 text-warning';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function ActivityLine({ line }: { line: SchedulerLogLine }) {
+  if (!line.structured) {
+    return (
+      <div className="border-b border-border px-3 py-2 font-mono text-sm last:border-b-0">
+        <AnsiLine text={line.message} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-3 border-b border-border px-3 py-2 last:border-b-0">
+      <time
+        className="w-[5.5rem] shrink-0 pt-0.5 font-mono text-xs text-muted-foreground"
+        title={line.timestamp}
+      >
+        {shortTimestamp(line.timestamp)}
+      </time>
+      <span
+        className={`w-12 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold ${levelClass(line.level)}`}
+      >
+        {line.level}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <span className="font-medium text-foreground">
+            <AnsiLine text={line.message} />
+          </span>
+          {line.step && (
+            <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-primary">
+              {line.step}
+            </span>
+          )}
+        </div>
+        {line.details && (
+          <details className="mt-1 text-xs text-muted-foreground">
+            <summary className="w-fit cursor-pointer select-none">
+              Details
+            </summary>
+            <code className="mt-1 block whitespace-pre-wrap break-words font-mono">
+              {line.details}
+            </code>
+          </details>
+        )}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -60,6 +127,9 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
   const [pageSize, setPageSize] = useState(1000);
   const [currentPage, setCurrentPage] = useState(1);
   const [jumpToLine, setJumpToLine] = useState<number | ''>('');
+  const [displayMode, setDisplayMode] = useState<'activity' | 'raw'>(
+    'activity'
+  );
 
   const isRunning = dagRun?.status === Status.Running;
   const [isLiveMode, setIsLiveMode] = useState(isRunning);
@@ -343,6 +413,8 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
     totalLines - lines.length <= 1 ? lines.length : totalLines;
 
   const totalPages = calculateTotalPages(effectiveTotalLines, pageSize);
+  const showNavigation = effectiveTotalLines > lines.length || hasMore;
+  const activityLines = lines.map(parseSchedulerLogLine);
 
   function getLineNumber(index: number): number {
     switch (viewMode) {
@@ -358,61 +430,83 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
   return (
     <div className="w-full h-full flex flex-col">
       {/* Controls for log navigation */}
-      <div className="flex flex-col gap-2 mb-2 p-4 bg-muted rounded">
+      <div className="mb-2 flex flex-col gap-2 rounded bg-muted p-3">
         <div className="flex flex-wrap items-center gap-2">
-          {/* Responsive button container */}
-          <div className="flex flex-wrap gap-1">
+          <div className="flex gap-1">
             <Button
               size="sm"
-              variant={viewMode === 'tail' ? 'primary' : 'default'}
-              onClick={() => handleViewModeChange('tail')}
-              disabled={isNavigating}
+              variant={displayMode === 'activity' ? 'primary' : 'default'}
+              onClick={() => setDisplayMode('activity')}
+              aria-pressed={displayMode === 'activity'}
             >
-              Show End
+              Activity
             </Button>
             <Button
               size="sm"
-              variant={viewMode === 'head' ? 'primary' : 'default'}
-              onClick={() => handleViewModeChange('head')}
-              disabled={isNavigating}
+              variant={displayMode === 'raw' ? 'primary' : 'default'}
+              onClick={() => setDisplayMode('raw')}
+              aria-pressed={displayMode === 'raw'}
             >
-              Show Beginning
-            </Button>
-            <Button
-              size="sm"
-              variant={viewMode === 'page' ? 'primary' : 'default'}
-              onClick={() => handleViewModeChange('page')}
-              disabled={isNavigating}
-            >
-              Page View
+              Raw
             </Button>
           </div>
 
-          <select
-            className="h-7 px-2 text-xs border border-border rounded-md bg-surface text-foreground flex-shrink-0 focus:outline-none focus:border-ring"
-            value={pageSize}
-            onChange={(e) => setPageSize(Number(e.target.value))}
-            disabled={isNavigating}
-          >
-            <option value="100">100 lines</option>
-            <option value="500">500 lines</option>
-            <option value="1000">1000 lines</option>
-            <option value="5000">5000 lines</option>
-            <option value="10000">10000 lines</option>
-          </select>
+          {showNavigation && (
+            <>
+              <div className="flex flex-wrap gap-1">
+                <Button
+                  size="sm"
+                  variant={viewMode === 'tail' ? 'primary' : 'default'}
+                  onClick={() => handleViewModeChange('tail')}
+                  disabled={isNavigating}
+                >
+                  Show End
+                </Button>
+                <Button
+                  size="sm"
+                  variant={viewMode === 'head' ? 'primary' : 'default'}
+                  onClick={() => handleViewModeChange('head')}
+                  disabled={isNavigating}
+                >
+                  Show Beginning
+                </Button>
+                <Button
+                  size="sm"
+                  variant={viewMode === 'page' ? 'primary' : 'default'}
+                  onClick={() => handleViewModeChange('page')}
+                  disabled={isNavigating}
+                >
+                  Page View
+                </Button>
+              </div>
 
-          {/* Wrap toggle, Live mode toggle and reload button */}
-          <div className="flex items-center gap-2 ml-auto">
-            {/* Wrap toggle */}
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs text-muted-foreground">Wrap</span>
-              <Switch
-                checked={preferences.logWrap}
-                onCheckedChange={(checked) =>
-                  updatePreference('logWrap', checked)
-                }
-              />
-            </div>
+              <select
+                className="h-7 flex-shrink-0 rounded-md border border-border bg-surface px-2 text-xs text-foreground focus:border-ring focus:outline-none"
+                value={pageSize}
+                onChange={(e) => setPageSize(Number(e.target.value))}
+                disabled={isNavigating}
+              >
+                <option value="100">100 lines</option>
+                <option value="500">500 lines</option>
+                <option value="1000">1000 lines</option>
+                <option value="5000">5000 lines</option>
+                <option value="10000">10000 lines</option>
+              </select>
+            </>
+          )}
+
+          <div className="ml-auto flex items-center gap-2">
+            {displayMode === 'raw' && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Wrap</span>
+                <Switch
+                  checked={preferences.logWrap}
+                  onCheckedChange={(checked) =>
+                    updatePreference('logWrap', checked)
+                  }
+                />
+              </div>
+            )}
 
             {/* Reload button */}
             <ReloadButton
@@ -452,14 +546,15 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
           </div>
         </div>
 
-        {/* Stats line - full width on mobile */}
         <div className="text-xs text-muted-foreground flex items-center">
-          Showing {lines.length} of {effectiveTotalLines} lines{' '}
+          {showNavigation
+            ? `Showing ${lines.length} of ${effectiveTotalLines} lines`
+            : `${effectiveTotalLines} ${effectiveTotalLines === 1 ? 'line' : 'lines'}`}{' '}
           {isEstimate ? '(estimated)' : ''} {hasMore ? '(more available)' : ''}
         </div>
 
         {/* Page navigation controls */}
-        {viewMode === 'page' && totalLines > 0 && (
+        {showNavigation && viewMode === 'page' && totalLines > 0 && (
           <div className="flex items-center gap-2 mt-2">
             <Button
               size="sm"
@@ -483,51 +578,53 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
           </div>
         )}
 
-        {/* Jump to line controls */}
-        <div className="flex items-center gap-2 mt-2">
-          <span className="text-xs text-muted-foreground">Jump to line:</span>
-          <Input
-            type="number"
-            min={1}
-            max={effectiveTotalLines}
-            value={jumpToLine}
-            onChange={(e) =>
-              setJumpToLine(e.target.value === '' ? '' : Number(e.target.value))
-            }
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                if (
-                  !isNavigating &&
-                  jumpToLine !== '' &&
-                  (jumpToLine as number) >= 1 &&
-                  (jumpToLine as number) <= effectiveTotalLines
-                ) {
-                  handleJumpToLine();
-                }
+        {showNavigation && (
+          <div className="flex items-center gap-2 mt-2">
+            <span className="text-xs text-muted-foreground">Jump to line:</span>
+            <Input
+              type="number"
+              min={1}
+              max={effectiveTotalLines}
+              value={jumpToLine}
+              onChange={(e) =>
+                setJumpToLine(
+                  e.target.value === '' ? '' : Number(e.target.value)
+                )
               }
-            }}
-            className="w-20 h-7 text-xs"
-            disabled={isNavigating}
-          />
-          <Button
-            size="sm"
-            onClick={handleJumpToLine}
-            disabled={
-              isNavigating ||
-              jumpToLine === '' ||
-              (jumpToLine as number) < 1 ||
-              (jumpToLine as number) > effectiveTotalLines
-            }
-          >
-            Go
-          </Button>
-        </div>
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  if (
+                    !isNavigating &&
+                    jumpToLine !== '' &&
+                    (jumpToLine as number) >= 1 &&
+                    (jumpToLine as number) <= effectiveTotalLines
+                  ) {
+                    handleJumpToLine();
+                  }
+                }
+              }}
+              className="w-20 h-7 text-xs"
+              disabled={isNavigating}
+            />
+            <Button
+              size="sm"
+              onClick={handleJumpToLine}
+              disabled={
+                isNavigating ||
+                jumpToLine === '' ||
+                (jumpToLine as number) < 1 ||
+                (jumpToLine as number) > effectiveTotalLines
+              }
+            >
+              Go
+            </Button>
+          </div>
+        )}
       </div>
 
-      {/* Log content with overlay loading indicator when navigating */}
       <div
         ref={logContainerRef}
-        className={`flex-1 rounded-lg bg-muted pt-4 pr-4 pb-4 relative ${preferences.logWrap ? 'overflow-auto' : 'overflow-x-auto overflow-y-auto'}`}
+        className={`relative flex-1 overflow-auto rounded-lg ${displayMode === 'raw' ? `bg-muted pb-4 pr-4 pt-4 ${preferences.logWrap ? '' : 'overflow-x-auto'}` : 'border border-border bg-card'}`}
       >
         {isNavigating && (
           <div className="absolute inset-0 bg-black/20 flex items-center justify-center z-10 pointer-events-none">
@@ -536,25 +633,33 @@ function ExecutionLog({ name, dagRunId, dagRun }: Props) {
             </div>
           </div>
         )}
-        <pre
-          className={`h-full font-mono text-sm text-foreground log-content ${preferences.logWrap ? '' : 'min-w-max'}`}
-        >
-          {lines.map((line, index) => (
-            <div key={index} className="flex pr-2 py-0.5">
-              <span
-                className="text-muted-foreground mr-4 select-none w-14 text-right flex-shrink-0 self-start sticky left-0 bg-muted pl-4 pr-2 z-10"
-                data-line-number={getLineNumber(index)}
-              >
-                {getLineNumber(index)}
-              </span>
-              <span
-                className={`flex-grow select-text cursor-text ${preferences.logWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}
-              >
-                {line ? <AnsiLine text={line} /> : ' '}
-              </span>
-            </div>
-          ))}
-        </pre>
+        {displayMode === 'activity' ? (
+          <div>
+            {activityLines.map((line, index) => (
+              <ActivityLine key={index} line={line} />
+            ))}
+          </div>
+        ) : (
+          <pre
+            className={`h-full font-mono text-sm text-foreground log-content ${preferences.logWrap ? '' : 'min-w-max'}`}
+          >
+            {lines.map((line, index) => (
+              <div key={index} className="flex pr-2 py-0.5">
+                <span
+                  className="text-muted-foreground mr-4 select-none w-14 text-right flex-shrink-0 self-start sticky left-0 bg-muted pl-4 pr-2 z-10"
+                  data-line-number={getLineNumber(index)}
+                >
+                  {getLineNumber(index)}
+                </span>
+                <span
+                  className={`flex-grow select-text cursor-text ${preferences.logWrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'}`}
+                >
+                  {line ? <AnsiLine text={line} /> : ' '}
+                </span>
+              </div>
+            ))}
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/ui/src/features/dags/components/dag-execution/LogSideModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/LogSideModal.tsx
@@ -1,6 +1,4 @@
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
-import { useUserPreferences } from '@/contexts/UserPreference';
 import { ExternalLink, Maximize2, Minimize2, X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
@@ -31,8 +29,6 @@ const LogSideModal: React.FC<LogSideModalProps> = ({
   stepName = '',
   logType = 'execution',
 }) => {
-  const { preferences, updatePreference } = useUserPreferences();
-
   // State to track whether the modal is expanded
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -165,14 +161,6 @@ const LogSideModal: React.FC<LogSideModalProps> = ({
         <div className={`flex justify-between items-center ${isMobile ? 'p-3' : 'p-4'} border-b`}>
           <h2 className={`${isMobile ? 'text-base' : 'text-lg'} font-semibold`}>{title}</h2>
           <div className="flex items-center gap-2">
-            {/* Wrap toggle */}
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs text-muted-foreground">Wrap</span>
-              <Switch
-                checked={preferences.logWrap}
-                onCheckedChange={(checked) => updatePreference('logWrap', checked)}
-              />
-            </div>
             <div className="flex gap-1">
               {/* Hide expand/minimize button on mobile since it's always full screen */}
               {!isMobile && (

--- a/ui/src/features/dags/components/dag-execution/__tests__/ExecutionLog.test.tsx
+++ b/ui/src/features/dags/components/dag-execution/__tests__/ExecutionLog.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { ActivityLine } from '../ActivityLine';
+
+describe('ActivityLine', () => {
+  it('exposes its source line for jump navigation and wraps messages', () => {
+    const { container, rerender } = render(
+      <ActivityLine
+        line={{
+          timestamp: '2026-08-06T12:00:00Z',
+          level: 'INFO',
+          message: 'structured-message',
+          structured: true,
+        }}
+        lineNumber={42}
+      />
+    );
+
+    expect(container.firstChild).toHaveAttribute('data-line-number', '42');
+    expect(screen.getByText('structured-message').parentElement).toHaveClass(
+      'whitespace-normal',
+      'break-words'
+    );
+
+    rerender(
+      <ActivityLine
+        line={{ message: 'plain-message', structured: false }}
+        lineNumber={43}
+      />
+    );
+
+    expect(container.firstChild).toHaveAttribute('data-line-number', '43');
+    expect(container.firstChild).toHaveClass(
+      'whitespace-normal',
+      'break-words'
+    );
+  });
+});

--- a/ui/src/lib/__tests__/scheduler-log.test.ts
+++ b/ui/src/lib/__tests__/scheduler-log.test.ts
@@ -8,7 +8,7 @@ describe('parseSchedulerLogLine', () => {
   it('extracts the readable fields from text scheduler logs', () => {
     expect(
       parseSchedulerLogLine(
-        'time=2026-04-23T23:58:52.652+09:00 level=INFO msg="Step started" dag=daily-report run-id=run-1 attempt-id=attempt-1 step=collect_metrics'
+        'time=2026-04-23T23:58:52.652+09:00 level=INFO msg="Step started" dag=daily-report run-id=run-1 attempt-id=attempt-1 worker-id=worker-1 trace-id=trace-1 span-id=span-1 trace-flags=01 step=collect_metrics'
       )
     ).toEqual({
       timestamp: '2026-04-23T23:58:52.652+09:00',

--- a/ui/src/lib/__tests__/scheduler-log.test.ts
+++ b/ui/src/lib/__tests__/scheduler-log.test.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+import { parseSchedulerLogLine } from '../scheduler-log';
+
+describe('parseSchedulerLogLine', () => {
+  it('extracts the readable fields from text scheduler logs', () => {
+    expect(
+      parseSchedulerLogLine(
+        'time=2026-04-23T23:58:52.652+09:00 level=INFO msg="Step started" dag=daily-report run-id=run-1 attempt-id=attempt-1 step=collect_metrics'
+      )
+    ).toEqual({
+      timestamp: '2026-04-23T23:58:52.652+09:00',
+      level: 'INFO',
+      message: 'Step started',
+      step: 'collect_metrics',
+      details: undefined,
+      structured: true,
+    });
+  });
+
+  it('keeps useful metadata from JSON scheduler logs', () => {
+    expect(
+      parseSchedulerLogLine(
+        '{"time":"2026-04-23T23:58:52Z","level":"ERROR","msg":"Step failed","dag":"daily-report","run-id":"run-1","step":"publish","err":"exit status 1"}'
+      )
+    ).toEqual({
+      timestamp: '2026-04-23T23:58:52Z',
+      level: 'ERROR',
+      message: 'Step failed',
+      step: 'publish',
+      details: 'err=exit status 1',
+      structured: true,
+    });
+  });
+
+  it('shows unrecognized lines unchanged', () => {
+    expect(parseSchedulerLogLine('plain output')).toEqual({
+      message: 'plain output',
+      structured: false,
+    });
+  });
+});

--- a/ui/src/lib/scheduler-log.ts
+++ b/ui/src/lib/scheduler-log.ts
@@ -19,6 +19,10 @@ const HIDDEN_FIELDS = new Set([
   'dag',
   'run-id',
   'attempt-id',
+  'worker-id',
+  'trace-id',
+  'span-id',
+  'trace-flags',
   'step',
 ]);
 

--- a/ui/src/lib/scheduler-log.ts
+++ b/ui/src/lib/scheduler-log.ts
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export type SchedulerLogLine = {
+  timestamp?: string;
+  level?: string;
+  message: string;
+  step?: string;
+  details?: string;
+  structured: boolean;
+};
+
+const TEXT_ATTRIBUTE_RE = /(?:^|\s)([\w.-]+)=("(?:\\.|[^"])*"|\S+)/g;
+const HIDDEN_FIELDS = new Set([
+  'time',
+  'level',
+  'msg',
+  'name',
+  'dag',
+  'run-id',
+  'attempt-id',
+  'step',
+]);
+
+function decodeValue(value: string): string {
+  if (!value.startsWith('"')) return value;
+  try {
+    return JSON.parse(value) as string;
+  } catch {
+    return value.slice(1, -1);
+  }
+}
+
+function parseJSONLine(line: string): SchedulerLogLine | null {
+  if (!line.trimStart().startsWith('{')) return null;
+
+  try {
+    const value = JSON.parse(line) as Record<string, unknown>;
+    if (typeof value.msg !== 'string') return null;
+
+    const details = Object.entries(value)
+      .filter(([key]) => !HIDDEN_FIELDS.has(key))
+      .map(
+        ([key, entry]) =>
+          `${key}=${typeof entry === 'string' ? entry : JSON.stringify(entry)}`
+      )
+      .join(' ');
+
+    return {
+      timestamp: typeof value.time === 'string' ? value.time : undefined,
+      level:
+        typeof value.level === 'string' ? value.level.toUpperCase() : undefined,
+      message: value.msg,
+      step: typeof value.step === 'string' ? value.step : undefined,
+      details: details || undefined,
+      structured: true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Parses Dagu's text or JSON scheduler log format, falling back to plain text. */
+export function parseSchedulerLogLine(line: string): SchedulerLogLine {
+  const jsonLine = parseJSONLine(line);
+  if (jsonLine) return jsonLine;
+
+  const fields = new Map<string, string>();
+  const details: string[] = [];
+  for (const match of line.matchAll(TEXT_ATTRIBUTE_RE)) {
+    const key = match[1];
+    const rawValue = match[2];
+    if (!key || !rawValue) continue;
+    fields.set(key, decodeValue(rawValue));
+    if (!HIDDEN_FIELDS.has(key)) details.push(`${key}=${rawValue}`);
+  }
+
+  const message = fields.get('msg');
+  if (!message || !fields.has('time') || !fields.has('level')) {
+    return { message: line, structured: false };
+  }
+
+  return {
+    timestamp: fields.get('time'),
+    level: fields.get('level')?.toUpperCase(),
+    message,
+    step: fields.get('step'),
+    details: details.join(' ') || undefined,
+    structured: true,
+  };
+}


### PR DESCRIPTION
## Summary

- add a readable Activity view for workflow execution logs while preserving raw log access
- omit invariant run context from run-scoped files and UI presentation
- retain canonical correlation fields in centralized logs and OpenTelemetry spans
- emit the current attempt ID at attempt boundaries instead of repeating it on every run-file line
- normalize workflow log keys and use distinct sub-DAG fields where parent and child context coexist

## Why

Workflow log lines repeated DAG, run, attempt, worker, and trace identity even when the surrounding file or page already established that context. This made the useful event, step, and error information unnecessarily difficult to scan. Some paths also used aliases or repeated correlation keys, which made centralized search and aggregation less reliable.

## Impact

Run files and the Activity UI now emphasize the event-specific fields. Centralized logs retain `dag`, `run-id`, `attempt-id`, worker identity, and valid trace context so records remain independently searchable. Existing raw text and JSON log formats remain supported.

## Validation

- `go test ./internal/cmn/logger ./internal/runtime/agent ./internal/runtime ./internal/runtime/builtin/chat ./internal/runtime/builtin/dag ./internal/runtime/executor`
- `go test ./internal/cmd ./internal/service/chatbridge ./internal/service/frontend/api/v1 ./internal/service/scheduler ./internal/subflow`
- `go test ./internal/cmn/telemetry`
- `pnpm test -- scheduler-log`
- `pnpm exec vitest run src/lib/__tests__/scheduler-log.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified workflow log output and added a readable Activity view that highlights event details. Step names are now easy to scan, and run-scoped files drop redundant context while centralized logs stay searchable.

- New Features
  - Activity view in the DAG Execution UI with compact timestamps, level badges, a dedicated scannable step column, and expandable details; added `ActivityLine`.
  - `parseSchedulerLogLine` parses text/JSON scheduler logs, hiding run context and surfacing meaningful details.
  - Toggle between Activity and Raw; navigation controls appear only when needed; wrapping is Raw-only; tests cover the parser and Activity rendering.

- Refactors
  - Added `WithRunWriter` to omit ambient run context (`dag`, `run-id`, `attempt-id`, `worker-id`, trace fields, parent/root) in run-scoped outputs; used for run files, restart path, and sub‑DAG scheduler logs.
  - Centralized logs use `tag.DAG`, `tag.RunID`, `tag.SubDAG`, and `tag.SubRunID`; include worker ID when present; attach trace context once; reduced telemetry debug noise.
  - Emit attempt ID only at attempt boundaries; updated agent context and span attributes accordingly.

<sup>Written for commit e09bbc5ac11ddcd65af7f7fd89ac8a5a78bbbbc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Activity and Raw display modes for execution logs.
  * Activity mode shows timestamps, severity, steps, expandable details, and formatted output.
  * Added parsing for structured scheduler logs in JSON and text formats.
  * Added improved log navigation with pagination, line statistics, wrapping, and jump-to-line controls when applicable.
  * Activity mode is selected by default.

* **Bug Fixes**
  * Improved log labels and context for workflows, sub-workflows, runs, attempts, and workers.
  * Reduced unnecessary trace details while preserving relevant event information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->