### PR TITLE
refactor(spec): address code-quality audit findings for internal/core/spec

### DIFF
--- a/internal/core/spec/builder.go
+++ b/internal/core/spec/builder.go
@@ -437,7 +437,7 @@ func decodeStep(raw map[string]any) (*step, error) {
 		ErrorUnused: true,
 		Result:      &st,
 		TagName:     "yaml",
-		DecodeHook:  TypedUnionDecodeHook(),
+		DecodeHook:  typedUnionDecodeHook(),
 	})
 	if err := md.Decode(raw); err != nil {
 		return nil, core.NewValidationError("steps", raw, withSnakeCaseKeyHint(err))

--- a/internal/core/spec/builder.go
+++ b/internal/core/spec/builder.go
@@ -14,11 +14,11 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 )
 
-// BuildContext is the context for building a DAG.
-type BuildContext struct {
+// buildContext is the context for building a DAG.
+type buildContext struct {
 	ctx   context.Context
 	file  string
-	opts  BuildOpts
+	opts  buildOpts
 	index int
 
 	customStepTypes *customStepTypeRegistry
@@ -49,7 +49,7 @@ type BuildContext struct {
 }
 
 // envScopeState holds mutable state that needs to be shared across transformers.
-// Using a pointer allows value-passed BuildContext to share state.
+// Using a pointer allows value-passed buildContext to share state.
 type envScopeState struct {
 	scope             *cmnvalue.EnvScope
 	buildEnv          map[string]string // Also store as map for WithVariables
@@ -65,48 +65,46 @@ type paramsState struct {
 	err    error
 }
 
-// StepBuildContext is the context for building a step.
-type StepBuildContext struct {
-	BuildContext
+// stepBuildContext is the context for building a step.
+type stepBuildContext struct {
+	buildContext
 	dag *core.DAG
 }
 
-func (c BuildContext) WithOpts(opts BuildOpts) BuildContext {
+func (c buildContext) WithOpts(opts buildOpts) buildContext {
 	copy := c
 	copy.opts = opts
 	copy.paramsState = nil
 	return copy
 }
 
-func (c BuildContext) WithFile(file string) BuildContext {
+func (c buildContext) WithFile(file string) buildContext {
 	copy := c
 	copy.file = file
 	return copy
 }
 
-func (c BuildContext) WithCustomStepTypes(registry *customStepTypeRegistry) BuildContext {
+func (c buildContext) WithCustomStepTypes(registry *customStepTypeRegistry) buildContext {
 	copy := c
 	copy.customStepTypes = registry
 	return copy
 }
 
-// BuildFlag represents a bitmask option that influences DAG building behaviour.
-type BuildFlag uint32
+// buildFlag represents a bitmask option that influences DAG building behaviour.
+type buildFlag uint32
 
 const (
-	BuildFlagNone BuildFlag = 0
-
-	BuildFlagNoEval BuildFlag = 1 << iota
-	BuildFlagOnlyMetadata
-	BuildFlagAllowBuildErrors
-	BuildFlagSkipSchemaValidation
-	BuildFlagSkipBaseHandlers // Skip merging handlerOn from base config (for sub-DAG runs)
-	BuildFlagValidateRuntimeParams
-	BuildFlagDeferWorkerSelector
+	buildFlagNoEval buildFlag = 1 << iota
+	buildFlagOnlyMetadata
+	buildFlagAllowBuildErrors
+	buildFlagSkipSchemaValidation
+	buildFlagSkipBaseHandlers // Skip merging handlerOn from base config (for sub-DAG runs)
+	buildFlagValidateRuntimeParams
+	buildFlagDeferWorkerSelector
 )
 
-// BuildOpts is used to control the behavior of the builder.
-type BuildOpts struct {
+// buildOpts is used to control the behavior of the builder.
+type buildOpts struct {
 	// Base specifies the Base configuration file for the DAG.
 	Base string
 	// BaseConfigContent is the raw base config YAML content.
@@ -130,7 +128,7 @@ type BuildOpts struct {
 	// against the file the author wrote rather than the copy.
 	SourceFile string
 	// Flags stores all boolean options controlling build behaviour.
-	Flags BuildFlag
+	Flags buildFlag
 	// BuildEnv provides pre-populated environment variables for the build.
 	// These are added to envScope before building, allowing YAML to reference
 	// them via ${VAR}. Used for retry/restart where dotenv values need to be
@@ -138,13 +136,13 @@ type BuildOpts struct {
 	BuildEnv map[string]string
 }
 
-// Has reports whether the flag is enabled on the current BuildOpts.
-func (o BuildOpts) Has(flag BuildFlag) bool {
+// Has reports whether the flag is enabled on the current buildOpts.
+func (o buildOpts) Has(flag buildFlag) bool {
 	return o.Flags&flag != 0
 }
 
 // parsePrecondition parses the precondition field.
-func parsePrecondition(ctx BuildContext, precondition any) ([]*core.Condition, error) {
+func parsePrecondition(ctx buildContext, precondition any) ([]*core.Condition, error) {
 	switch v := precondition.(type) {
 	case nil:
 		return nil, nil
@@ -168,7 +166,7 @@ func parsePrecondition(ctx BuildContext, precondition any) ([]*core.Condition, e
 	}
 }
 
-func parsePreconditionEntry(_ BuildContext, precondition any) ([]*core.Condition, error) {
+func parsePreconditionEntry(_ buildContext, precondition any) ([]*core.Condition, error) {
 	switch v := precondition.(type) {
 	case string:
 		if strings.TrimSpace(v) == "" {
@@ -279,7 +277,7 @@ var reservedSecretEnvNames = []string{
 }
 
 // parseSecretRefs parses secret references from the YAML definition.
-func parseSecretRefs(ctx BuildContext, d *dag) ([]core.SecretRef, error) {
+func parseSecretRefs(ctx buildContext, d *dag) ([]core.SecretRef, error) {
 	secretRefs := d.Secrets
 
 	// Convert secretRef to core.SecretRef and validate
@@ -382,7 +380,7 @@ func generateTypedStepName(existingNames map[string]struct{}, step *core.Step, i
 }
 
 // normalizedStepData converts string to map[string]any for subsequent process
-func normalizeStepData(ctx BuildContext, data []any) []any {
+func normalizeStepData(ctx buildContext, data []any) []any {
 	// Convert string steps to map format for shorthand syntax support
 	normalized := make([]any, len(data))
 	for i, item := range data {
@@ -402,7 +400,7 @@ func normalizeStepData(ctx BuildContext, data []any) []any {
 // DAG-level harness: block used to allow. That spelling is indistinguishable
 // from a local command once normalized, so it is refused with the two spellings
 // that say which one was meant.
-func validateHarnessPromptCommand(ctx StepBuildContext, raw map[string]any) error {
+func validateHarnessPromptCommand(ctx stepBuildContext, raw map[string]any) error {
 	if raw == nil || ctx.dag == nil || ctx.dag.Harness == nil {
 		return nil
 	}
@@ -462,12 +460,12 @@ func finalizeBuiltStepName(names map[string]struct{}, builtStep *core.Step, idx 
 	names[builtStep.Name] = struct{}{}
 }
 
-func buildConcreteStep(ctx StepBuildContext, s *step) (*core.Step, error) {
+func buildConcreteStep(ctx stepBuildContext, s *step) (*core.Step, error) {
 	return s.build(ctx)
 }
 
 // buildStepFromRaw build core.Step from give raw data (map[string]any)
-func buildStepFromRaw(ctx StepBuildContext, idx int, raw map[string]any, names map[string]struct{}, defs *defaults) (*core.Step, error) {
+func buildStepFromRaw(ctx stepBuildContext, idx int, raw map[string]any, names map[string]struct{}, defs *defaults) (*core.Step, error) {
 	if err := validateHarnessPromptCommand(ctx, raw); err != nil {
 		return nil, err
 	}
@@ -487,7 +485,7 @@ func buildStepFromRaw(ctx StepBuildContext, idx int, raw map[string]any, names m
 }
 
 func buildStepFromSpec(
-	ctx StepBuildContext,
+	ctx stepBuildContext,
 	idx int,
 	st *step,
 	raw map[string]any,

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -4378,6 +4378,26 @@ steps:
 		assert.False(t, dag.Artifacts.Enabled)
 	})
 
+	t.Run("MapFormStepNamedParamsIsStillDetected", func(t *testing.T) {
+		t.Parallel()
+
+		// The step name is the map key, so a step named "params" must be
+		// detected like any other step.
+		data := []byte(`
+artifacts:
+  enabled: false
+steps:
+  params:
+    action: artifact.write
+    with:
+      path: out.txt
+      content: hello
+`)
+		_, err := spec.LoadYAML(context.Background(), data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "artifact actions require artifacts.enabled to be true")
+	})
+
 	t.Run("StepArtifactActionRequiresArtifactsEnabled", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -4378,6 +4378,115 @@ steps:
 		assert.False(t, dag.Artifacts.Enabled)
 	})
 
+	t.Run("ParamsPayloadPassedToChildDAGIsNotAnArtifactAction", func(t *testing.T) {
+		t.Parallel()
+
+		// with.params is data handed to the child DAG, not step syntax.
+		for name, data := range map[string]string{
+			"step": `
+artifacts:
+  enabled: false
+steps:
+  - name: s1
+    action: dag.run
+    with:
+      dag: child
+      params:
+        action: artifact.write
+`,
+			"handler": `
+artifacts:
+  enabled: false
+handler_on:
+  success:
+    action: dag.run
+    with:
+      dag: child
+      params:
+        action: artifact.write
+steps:
+  - name: s1
+    command: echo hello
+`,
+			"custom action template": `
+artifacts:
+  enabled: false
+actions:
+  myact:
+    input_schema: {type: object}
+    template:
+      action: dag.run
+      with:
+        dag: child
+        params:
+          action: artifact.write
+steps:
+  - name: s1
+    command: echo hello
+`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				dag, err := spec.LoadYAML(context.Background(), []byte(data))
+				require.NoError(t, err)
+				require.NotNil(t, dag.Artifacts)
+				assert.False(t, dag.Artifacts.Enabled)
+			})
+		}
+	})
+
+	t.Run("NestedAndHandlerArtifactActionsAreDetected", func(t *testing.T) {
+		t.Parallel()
+
+		for name, data := range map[string]string{
+			"handler": `
+artifacts:
+  enabled: false
+handler_on:
+  success:
+    action: artifact.write
+    with: {path: out.txt, content: hello}
+steps:
+  - name: s1
+    command: echo hello
+`,
+			"foreach": `
+artifacts:
+  enabled: false
+steps:
+  - name: s1
+    foreach:
+      items: [1]
+      steps:
+        - name: inner
+          action: artifact.write
+          with: {path: out.txt, content: hello}
+`,
+			"custom action template": `
+artifacts:
+  enabled: false
+actions:
+  myact:
+    input_schema: {type: object}
+    template:
+      action: artifact.write
+      with: {path: out.txt, content: hello}
+steps:
+  - name: s1
+    command: echo hello
+`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := spec.LoadYAML(context.Background(), []byte(data))
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "artifact actions require artifacts.enabled to be true")
+			})
+		}
+	})
+
 	t.Run("MapFormStepNamedParamsIsStillDetected", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -4288,3 +4288,81 @@ steps:
 		assert.Empty(t, dag.BuildWarnings)
 	})
 }
+
+func TestBuildDAGLevelLLMInheritance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ChatStepInheritsToolsAndWebSearch", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+llm:
+  provider: openai
+  model: gpt-4o
+  tools:
+    - helper-dag
+  web_search:
+    enabled: true
+    max_uses: 3
+steps:
+  - name: ask
+    type: chat
+    messages:
+      - role: user
+        content: hello
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+
+		require.NotNil(t, dag.LLM)
+		assert.Equal(t, []string{"helper-dag"}, dag.LLM.Tools)
+		require.NotNil(t, dag.LLM.WebSearch)
+		assert.True(t, dag.LLM.WebSearch.Enabled)
+
+		require.Len(t, dag.Steps, 1)
+		require.NotNil(t, dag.Steps[0].LLM)
+		assert.Equal(t, []string{"helper-dag"}, dag.Steps[0].LLM.Tools)
+		require.NotNil(t, dag.Steps[0].LLM.WebSearch)
+		assert.True(t, dag.Steps[0].LLM.WebSearch.Enabled)
+	})
+}
+
+func TestBuildArtifactActionDetection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ParamValueIsNotAnArtifactAction", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+artifacts:
+  enabled: false
+params:
+  - action: artifact.write
+steps:
+  - name: step1
+    command: echo hello
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		require.NotNil(t, dag.Artifacts)
+		assert.False(t, dag.Artifacts.Enabled)
+	})
+
+	t.Run("StepArtifactActionRequiresArtifactsEnabled", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+artifacts:
+  enabled: false
+steps:
+  - name: step1
+    action: artifact.write
+    with:
+      path: out.txt
+      content: hello
+`)
+		_, err := spec.LoadYAML(context.Background(), data)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "artifact actions require artifacts.enabled to be true")
+	})
+}

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -122,7 +122,7 @@ func TestEnvParams(t *testing.T) {
 	paramTests := []struct {
 		name       string
 		yaml       string
-		opts       *spec.BuildOpts
+		opts       []spec.LoadOption
 		wantParams []string
 	}{
 		{
@@ -157,7 +157,7 @@ params:
   - BAR: bar
   - BAZ: "` + "`echo baz`" + `"
 `,
-			opts:       &spec.BuildOpts{Parameters: "FOO=X BAZ=Y"},
+			opts:       []spec.LoadOption{spec.WithParams("FOO=X BAZ=Y")},
 			wantParams: []string{"FOO=X", "BAR=bar", "BAZ=Y"},
 		},
 		{
@@ -191,7 +191,7 @@ params:
   - BASE: ${SOURCE_ID}
   - PREFIX: ${BASE:0:5}
 `,
-			opts:       &spec.BuildOpts{Flags: spec.BuildFlagNoEval},
+			opts:       []spec.LoadOption{spec.WithoutEval()},
 			wantParams: []string{"BASE=${SOURCE_ID}", "PREFIX=${BASE:0:5}"},
 		},
 	}
@@ -199,13 +199,7 @@ params:
 	for _, tt := range paramTests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			var dag *core.DAG
-			var err error
-			if tt.opts != nil {
-				dag, err = spec.LoadYAMLWithOpts(context.Background(), []byte(tt.yaml), *tt.opts)
-			} else {
-				dag, err = spec.LoadYAML(context.Background(), []byte(tt.yaml))
-			}
+			dag, err := spec.LoadYAML(context.Background(), []byte(tt.yaml), tt.opts...)
 			require.NoError(t, err)
 			th := DAG{t: t, DAG: dag}
 			th.AssertParam(t, tt.wantParams...)
@@ -3692,7 +3686,7 @@ steps:
   - run: echo hello
 `, tempDir)
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), []byte(yaml), spec.WithoutEval())
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 
@@ -3721,7 +3715,7 @@ env:
 steps:
   - run: echo hello
 `
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), []byte(yaml), spec.WithoutEval())
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 
@@ -3751,7 +3745,7 @@ steps:
   - run: echo hello
 `, tempDir)
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(yaml), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), []byte(yaml), spec.WithoutEval())
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 
@@ -3878,7 +3872,7 @@ shell: $MY_SHELL -e
 steps:
   - run: echo hello
 `)
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), data, spec.WithoutEval())
 		require.NoError(t, err)
 		assert.Equal(t, "$MY_SHELL", dag.Shell)
 		assert.Equal(t, []string{"-e"}, dag.ShellArgs)
@@ -3893,7 +3887,7 @@ shell:
 steps:
   - run: echo hello
 `)
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), data, spec.WithoutEval())
 		require.NoError(t, err)
 		assert.Equal(t, "bash", dag.Shell)
 		assert.Equal(t, []string{"$SHELL_ARG"}, dag.ShellArgs)
@@ -4017,7 +4011,7 @@ steps:
   - name: test
     run: echo test
 `)
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+		dag, err := spec.LoadYAML(context.Background(), data, spec.WithoutEval())
 		require.NoError(t, err)
 
 		// When NoEval is set, the variable should not be expanded
@@ -4034,7 +4028,7 @@ steps:
     depends:
       - nonexistent
 `)
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagAllowBuildErrors})
+		dag, err := spec.LoadYAML(context.Background(), data, spec.WithAllowBuildErrors())
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 		assert.NotEmpty(t, dag.BuildErrors)
@@ -4042,7 +4036,7 @@ steps:
 
 	t.Run("SkipSchemaValidation_SkipsParamsSchema", func(t *testing.T) {
 		t.Parallel()
-		// BuildFlagSkipSchemaValidation skips JSON schema validation for params,
+		// SkipSchemaValidation skips JSON schema validation for params,
 		// not YAML structure validation
 		data := []byte(`
 params:
@@ -4058,7 +4052,7 @@ steps:
 		require.Error(t, err)
 
 		// With schema validation skipped, it succeeds
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), data, spec.BuildOpts{Flags: spec.BuildFlagSkipSchemaValidation})
+		dag, err := spec.LoadYAML(context.Background(), data, spec.SkipSchemaValidation())
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 	})

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -4344,12 +4344,16 @@ steps:
 		assert.Equal(t, []string{"helper-dag"}, dag.LLM.Tools)
 		require.NotNil(t, dag.LLM.WebSearch)
 		assert.True(t, dag.LLM.WebSearch.Enabled)
+		require.NotNil(t, dag.LLM.WebSearch.MaxUses)
+		assert.Equal(t, 3, *dag.LLM.WebSearch.MaxUses)
 
 		require.Len(t, dag.Steps, 1)
 		require.NotNil(t, dag.Steps[0].LLM)
 		assert.Equal(t, []string{"helper-dag"}, dag.Steps[0].LLM.Tools)
 		require.NotNil(t, dag.Steps[0].LLM.WebSearch)
 		assert.True(t, dag.Steps[0].LLM.WebSearch.Enabled)
+		require.NotNil(t, dag.Steps[0].LLM.WebSearch.MaxUses)
+		assert.Equal(t, 3, *dag.Steps[0].LLM.WebSearch.MaxUses)
 	})
 }
 

--- a/internal/core/spec/builder_test.go
+++ b/internal/core/spec/builder_test.go
@@ -511,8 +511,9 @@ steps:
 	}
 }
 
-func TestBuildStep(t *testing.T) {
+func TestBuildStepCommandsAndExecutors(t *testing.T) {
 	t.Parallel()
+
 	t.Run("ValidCommand", func(t *testing.T) {
 		t.Parallel()
 
@@ -679,6 +680,11 @@ steps:
 		assert.Equal(t, "param1=\"value1\" param2=\"value2\"", th.Steps[0].SubDAG.Params)
 		assert.Empty(t, dag.BuildWarnings)
 	})
+}
+
+func TestBuildStepContinueOn(t *testing.T) {
+	t.Parallel()
+
 	// ContinueOn success cases
 	continueOnTests := []struct {
 		name            string
@@ -817,6 +823,11 @@ steps:
 			}
 		})
 	}
+}
+
+func TestBuildStepRetryPolicy(t *testing.T) {
+	t.Parallel()
+
 	// RetryPolicy success tests
 	retryPolicyTests := []struct {
 		name            string
@@ -944,6 +955,11 @@ steps:
 			assert.Contains(t, err.Error(), tt.errContains)
 		})
 	}
+}
+
+func TestBuildStepRepeatPolicy(t *testing.T) {
+	t.Parallel()
+
 	// RepeatPolicy success tests
 	repeatPolicyTests := []struct {
 		name            string
@@ -1176,107 +1192,6 @@ steps:
 			}
 		})
 	}
-	t.Run("SignalOnStop", func(t *testing.T) {
-		t.Parallel()
-
-		data := []byte(`
-steps:
-  - run: echo 1
-    name: step1
-    signal_on_stop: SIGINT
-`)
-		dag, err := spec.LoadYAML(context.Background(), data)
-		require.NoError(t, err)
-		th := DAG{t: t, DAG: dag}
-		assert.Len(t, th.Steps, 1)
-		assert.Equal(t, "SIGINT", th.Steps[0].SignalOnStop)
-	})
-	t.Run("StepWithID", func(t *testing.T) {
-		t.Parallel()
-
-		data := []byte(`
-steps:
-  - name: step1
-    id: unique_step_1
-    run: echo "Step with ID"
-  - name: step2
-    run: echo "Step without ID"
-  - name: step3
-    id: custom_id_123
-    run: echo "Another step with ID"
-`)
-		dag, err := spec.LoadYAML(context.Background(), data)
-		require.NoError(t, err)
-		th := DAG{t: t, DAG: dag}
-		assert.Len(t, th.Steps, 3)
-
-		// First step has ID
-		assert.Equal(t, "step1", th.Steps[0].Name)
-		assert.Equal(t, "unique_step_1", th.Steps[0].ID)
-
-		// Second step has no ID
-		assert.Equal(t, "step2", th.Steps[1].Name)
-		assert.Equal(t, "", th.Steps[1].ID)
-
-		// Third step has ID
-		assert.Equal(t, "step3", th.Steps[2].Name)
-		assert.Equal(t, "custom_id_123", th.Steps[2].ID)
-	})
-	t.Run("Preconditions", func(t *testing.T) {
-		t.Parallel()
-
-		data := []byte(`
-steps:
-  - name: "2"
-    run: "echo 2"
-    preconditions:
-      - condition: "test -f file.txt"
-        expected: "true"
-`)
-		dag, err := spec.LoadYAML(context.Background(), data)
-		require.NoError(t, err)
-		th := DAG{t: t, DAG: dag}
-		assert.Len(t, th.Steps, 1)
-		assert.Len(t, th.Steps[0].Preconditions, 1)
-		assert.Equal(t, &core.Condition{Condition: "test -f file.txt", Expected: "true"}, th.Steps[0].Preconditions[0])
-	})
-	t.Run("PreconditionEval", func(t *testing.T) {
-		t.Parallel()
-
-		data := []byte(`
-steps:
-  - name: "eval_gate"
-    run: "echo eval"
-    preconditions:
-      - eval: "$(printf ready)"
-        expected: "ready"
-`)
-		dag, err := spec.LoadYAML(context.Background(), data)
-		require.NoError(t, err)
-		th := DAG{t: t, DAG: dag}
-		assert.Len(t, th.Steps, 1)
-		assert.Len(t, th.Steps[0].Preconditions, 1)
-		assert.Equal(t, &core.Condition{Eval: "$(printf ready)", Expected: "ready"}, th.Steps[0].Preconditions[0])
-	})
-	t.Run("StepPreconditionsWithNegate", func(t *testing.T) {
-		t.Parallel()
-
-		data := []byte(`
-steps:
-  - name: "step_with_negate"
-    run: "echo hello"
-    preconditions:
-      - condition: "${STATUS}"
-        expected: "success"
-        negate: true
-`)
-		dag, err := spec.LoadYAML(context.Background(), data)
-		require.NoError(t, err)
-		th := DAG{t: t, DAG: dag}
-		assert.Len(t, th.Steps, 1)
-		assert.Len(t, th.Steps[0].Preconditions, 1)
-		assert.Equal(t, &core.Condition{Condition: "${STATUS}", Expected: "success", Negate: true}, th.Steps[0].Preconditions[0])
-	})
 	// RepeatPolicy error tests
 	repeatPolicyErrorTests := []struct {
 		name        string
@@ -1370,6 +1285,117 @@ steps:
 			assert.Contains(t, err.Error(), tt.errContains)
 		})
 	}
+}
+
+func TestBuildStepSignalAndID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SignalOnStop", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+steps:
+  - run: echo 1
+    name: step1
+    signal_on_stop: SIGINT
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		th := DAG{t: t, DAG: dag}
+		assert.Len(t, th.Steps, 1)
+		assert.Equal(t, "SIGINT", th.Steps[0].SignalOnStop)
+	})
+	t.Run("StepWithID", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+steps:
+  - name: step1
+    id: unique_step_1
+    run: echo "Step with ID"
+  - name: step2
+    run: echo "Step without ID"
+  - name: step3
+    id: custom_id_123
+    run: echo "Another step with ID"
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		th := DAG{t: t, DAG: dag}
+		assert.Len(t, th.Steps, 3)
+
+		// First step has ID
+		assert.Equal(t, "step1", th.Steps[0].Name)
+		assert.Equal(t, "unique_step_1", th.Steps[0].ID)
+
+		// Second step has no ID
+		assert.Equal(t, "step2", th.Steps[1].Name)
+		assert.Equal(t, "", th.Steps[1].ID)
+
+		// Third step has ID
+		assert.Equal(t, "step3", th.Steps[2].Name)
+		assert.Equal(t, "custom_id_123", th.Steps[2].ID)
+	})
+}
+
+func TestBuildStepPreconditions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Preconditions", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+steps:
+  - name: "2"
+    run: "echo 2"
+    preconditions:
+      - condition: "test -f file.txt"
+        expected: "true"
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		th := DAG{t: t, DAG: dag}
+		assert.Len(t, th.Steps, 1)
+		assert.Len(t, th.Steps[0].Preconditions, 1)
+		assert.Equal(t, &core.Condition{Condition: "test -f file.txt", Expected: "true"}, th.Steps[0].Preconditions[0])
+	})
+	t.Run("PreconditionEval", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+steps:
+  - name: "eval_gate"
+    run: "echo eval"
+    preconditions:
+      - eval: "$(printf ready)"
+        expected: "ready"
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		th := DAG{t: t, DAG: dag}
+		assert.Len(t, th.Steps, 1)
+		assert.Len(t, th.Steps[0].Preconditions, 1)
+		assert.Equal(t, &core.Condition{Eval: "$(printf ready)", Expected: "ready"}, th.Steps[0].Preconditions[0])
+	})
+	t.Run("StepPreconditionsWithNegate", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+steps:
+  - name: "step_with_negate"
+    run: "echo hello"
+    preconditions:
+      - condition: "${STATUS}"
+        expected: "success"
+        negate: true
+`)
+		dag, err := spec.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		th := DAG{t: t, DAG: dag}
+		assert.Len(t, th.Steps, 1)
+		assert.Len(t, th.Steps[0].Preconditions, 1)
+		assert.Equal(t, &core.Condition{Condition: "${STATUS}", Expected: "success", Negate: true}, th.Steps[0].Preconditions[0])
+	})
 }
 
 func TestNestedArrayParallelSyntax(t *testing.T) {

--- a/internal/core/spec/consts.go
+++ b/internal/core/spec/consts.go
@@ -19,7 +19,7 @@ import (
 
 var constNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
 
-func buildConsts(ctx BuildContext, d *dag) (map[string]any, error) {
+func buildConsts(ctx buildContext, d *dag) (map[string]any, error) {
 	inherited := inheritedConsts(ctx)
 	if d.Consts == nil {
 		return inherited, nil
@@ -55,7 +55,7 @@ func buildConsts(ctx BuildContext, d *dag) (map[string]any, error) {
 	return resolved, nil
 }
 
-func inheritedConsts(ctx BuildContext) map[string]any {
+func inheritedConsts(ctx buildContext) map[string]any {
 	if ctx.envScope != nil && len(ctx.envScope.consts) > 0 {
 		return maps.Clone(ctx.envScope.consts)
 	}
@@ -94,7 +94,7 @@ func constEntry(idx int, item any) (string, any, error) {
 	return "", nil, core.NewValidationError(fmt.Sprintf("consts[%d]", idx), item, fmt.Errorf("consts entries must contain exactly one key"))
 }
 
-func resolveConstValue(ctx BuildContext, key string, value any, consts map[string]any) (any, error) {
+func resolveConstValue(ctx buildContext, key string, value any, consts map[string]any) (any, error) {
 	if value == nil {
 		return nil, fmt.Errorf("const %q must be a literal string, number, or boolean", key)
 	}

--- a/internal/core/spec/controller.go
+++ b/internal/core/spec/controller.go
@@ -18,7 +18,7 @@ type controllerTask struct {
 	Description string `yaml:"description,omitempty"`
 }
 
-func buildTasks(_ BuildContext, d *dag) ([]core.ControllerTask, error) {
+func buildTasks(_ buildContext, d *dag) ([]core.ControllerTask, error) {
 	if len(d.Tasks) == 0 {
 		return nil, nil
 	}

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"maps"
 	"math"
-	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -500,10 +499,10 @@ type Transformer[C any, T any] interface {
 // for the builder function while satisfying the DAGTransformer interface.
 type dagTransformer[T any] struct {
 	fieldName string
-	builder   func(ctx BuildContext, d *dag) (T, error)
+	builder   func(ctx buildContext, d *dag) (T, error)
 }
 
-func (t *dagTransformer[T]) Transform(ctx BuildContext, in *dag, out reflect.Value) error {
+func (t *dagTransformer[T]) Transform(ctx buildContext, in *dag, out reflect.Value) error {
 	v, err := t.builder(ctx, in)
 	if err != nil {
 		return err
@@ -516,7 +515,7 @@ func (t *dagTransformer[T]) Transform(ctx BuildContext, in *dag, out reflect.Val
 }
 
 // newTransformer creates a DAGTransformer for a single field transformation
-func newTransformer[T any](fieldName string, builder func(BuildContext, *dag) (T, error)) Transformer[BuildContext, *dag] {
+func newTransformer[T any](fieldName string, builder func(buildContext, *dag) (T, error)) Transformer[buildContext, *dag] {
 	return &dagTransformer[T]{
 		fieldName: fieldName,
 		builder:   builder,
@@ -526,7 +525,7 @@ func newTransformer[T any](fieldName string, builder func(BuildContext, *dag) (T
 // transform wraps a DAGTransformer with its name for error reporting
 type transform struct {
 	name        string
-	transformer Transformer[BuildContext, *dag]
+	transformer Transformer[buildContext, *dag]
 }
 
 type transformStage []transform
@@ -644,21 +643,21 @@ var fullTransformStages = []transformStage{
 }
 
 // runTransformers executes all transformers in the pipeline
-func runTransformers(ctx BuildContext, spec *dag, result *core.DAG) core.ErrorList {
+func runTransformers(ctx buildContext, spec *dag, result *core.DAG) core.ErrorList {
 	var errs core.ErrorList
 	out := reflect.ValueOf(result).Elem()
 
 	errs = append(errs, runTransformerStages(ctx, spec, out, metadataTransformStages)...)
 
 	// Run full transformers only when not in metadata-only mode
-	if !ctx.opts.Has(BuildFlagOnlyMetadata) {
+	if !ctx.opts.Has(buildFlagOnlyMetadata) {
 		errs = append(errs, runTransformerStages(ctx, spec, out, fullTransformStages)...)
 	}
 
 	return errs
 }
 
-func runTransformerStages(ctx BuildContext, spec *dag, out reflect.Value, stages []transformStage) core.ErrorList {
+func runTransformerStages(ctx buildContext, spec *dag, out reflect.Value, stages []transformStage) core.ErrorList {
 	var errs core.ErrorList
 	for _, stage := range stages {
 		for _, t := range stage {
@@ -680,13 +679,13 @@ func wrapTransformError(name string, err error) error {
 }
 
 type dagBuildState struct {
-	ctx    BuildContext
+	ctx    buildContext
 	spec   *dag
 	result *core.DAG
 	errs   core.ErrorList
 }
 
-func newDAGBuildState(ctx BuildContext, spec *dag) *dagBuildState {
+func newDAGBuildState(ctx buildContext, spec *dag) *dagBuildState {
 	result := &core.DAG{
 		Location: ctx.file,
 	}
@@ -742,8 +741,8 @@ func (s *dagBuildState) composeInheritedContext() {
 }
 
 func (s *dagBuildState) resolveWorkerSelector() {
-	if s.ctx.opts.Has(BuildFlagNoEval) ||
-		s.ctx.opts.Has(BuildFlagDeferWorkerSelector) ||
+	if s.ctx.opts.Has(buildFlagNoEval) ||
+		s.ctx.opts.Has(buildFlagDeferWorkerSelector) ||
 		len(s.result.WorkerSelector) == 0 {
 		return
 	}
@@ -834,7 +833,7 @@ func (s *dagBuildState) collectWarnings() {
 }
 
 func (s *dagBuildState) buildActionGraph() {
-	if s.ctx.opts.Has(BuildFlagOnlyMetadata) {
+	if s.ctx.opts.Has(buildFlagOnlyMetadata) {
 		return
 	}
 
@@ -861,7 +860,7 @@ func (s *dagBuildState) buildActionGraph() {
 }
 
 func (s *dagBuildState) validateResult() {
-	if !s.ctx.opts.Has(BuildFlagOnlyMetadata) {
+	if !s.ctx.opts.Has(buildFlagOnlyMetadata) {
 		if err := core.ValidateSteps(s.result); err != nil {
 			s.errs = append(s.errs, err)
 		}
@@ -887,7 +886,7 @@ func (s *dagBuildState) validateResult() {
 }
 
 func (s *dagBuildState) capturePresolvedBuildEnv() {
-	if s.ctx.opts.Has(BuildFlagNoEval) {
+	if s.ctx.opts.Has(buildFlagNoEval) {
 		return
 	}
 	if len(s.ctx.envScope.buildEnv) > 0 {
@@ -896,7 +895,7 @@ func (s *dagBuildState) capturePresolvedBuildEnv() {
 }
 
 func (s *dagBuildState) markEnvEvaluated() {
-	s.result.EnvEvaluated = !s.ctx.opts.Has(BuildFlagNoEval)
+	s.result.EnvEvaluated = !s.ctx.opts.Has(buildFlagNoEval)
 }
 
 func (s *dagBuildState) finish() (*core.DAG, error) {
@@ -905,7 +904,7 @@ func (s *dagBuildState) finish() (*core.DAG, error) {
 	// reported list has one entry per distinct failure.
 	errs := s.errs.Dedupe()
 	if len(errs) > 0 {
-		if s.ctx.opts.Has(BuildFlagAllowBuildErrors) {
+		if s.ctx.opts.Has(buildFlagAllowBuildErrors) {
 			s.result.BuildErrors = errs
 		} else {
 			return nil, fmt.Errorf("failed to build DAG: %w", errs)
@@ -915,7 +914,7 @@ func (s *dagBuildState) finish() (*core.DAG, error) {
 }
 
 // build transforms the dag specification into a core.DAG.
-func (d *dag) build(ctx BuildContext) (*core.DAG, error) {
+func (d *dag) build(ctx buildContext) (*core.DAG, error) {
 	state := newDAGBuildState(ctx, d)
 	state.validateSpecShape()
 	state.prepareParamEnvStage()
@@ -955,7 +954,7 @@ func applyHistoryRetentionOverride(effective *core.DAG, authoredDays, authoredRu
 
 // Builder functions - each returns a value instead of modifying result
 
-func buildType(_ BuildContext, d *dag) (string, error) {
+func buildType(_ buildContext, d *dag) (string, error) {
 	t := strings.TrimSpace(d.Type)
 	if t == "" {
 		return core.TypeGraph, nil
@@ -970,7 +969,7 @@ func buildType(_ BuildContext, d *dag) (string, error) {
 
 // Builder functions - all return values instead of modifying result
 
-func buildName(ctx BuildContext, d *dag) (string, error) {
+func buildName(ctx buildContext, d *dag) (string, error) {
 	if ctx.opts.Name != "" && ctx.index == 0 {
 		return strings.TrimSpace(ctx.opts.Name), nil
 	}
@@ -985,27 +984,27 @@ func buildName(ctx BuildContext, d *dag) (string, error) {
 	return "", nil
 }
 
-func buildGroup(_ BuildContext, d *dag) (string, error) {
+func buildGroup(_ buildContext, d *dag) (string, error) {
 	return strings.TrimSpace(d.Group), nil
 }
 
-func buildDescription(_ BuildContext, d *dag) (string, error) {
+func buildDescription(_ buildContext, d *dag) (string, error) {
 	return strings.TrimSpace(d.Description), nil
 }
 
-func buildTimeout(_ BuildContext, d *dag) (time.Duration, error) {
+func buildTimeout(_ buildContext, d *dag) (time.Duration, error) {
 	return time.Second * time.Duration(d.TimeoutSec), nil
 }
 
-func buildDelay(_ BuildContext, d *dag) (time.Duration, error) {
+func buildDelay(_ buildContext, d *dag) (time.Duration, error) {
 	return time.Second * time.Duration(d.DelaySec), nil
 }
 
-func buildRestartWait(_ BuildContext, d *dag) (time.Duration, error) {
+func buildRestartWait(_ buildContext, d *dag) (time.Duration, error) {
 	return time.Second * time.Duration(d.RestartWaitSec), nil
 }
 
-func buildLabels(_ BuildContext, d *dag) (core.Labels, error) {
+func buildLabels(_ buildContext, d *dag) (core.Labels, error) {
 	labelsValue := d.Labels
 	if labelsValue.IsZero() {
 		labelsValue = d.DeprecatedTags
@@ -1027,22 +1026,22 @@ func buildLabels(_ BuildContext, d *dag) (core.Labels, error) {
 	return labels, nil
 }
 
-func buildMaxActiveRuns(_ BuildContext, d *dag) (int, error) {
+func buildMaxActiveRuns(_ buildContext, d *dag) (int, error) {
 	if d.MaxActiveRuns != 0 {
 		return d.MaxActiveRuns, nil
 	}
 	return 1, nil // Default
 }
 
-func buildMaxActiveSteps(_ BuildContext, d *dag) (int, error) {
+func buildMaxActiveSteps(_ buildContext, d *dag) (int, error) {
 	return d.MaxActiveSteps, nil
 }
 
-func buildQueue(_ BuildContext, d *dag) (string, error) {
+func buildQueue(_ buildContext, d *dag) (string, error) {
 	return strings.TrimSpace(d.Queue), nil
 }
 
-func buildDAGRetryPolicy(_ BuildContext, d *dag) (*core.DAGRetryPolicy, error) {
+func buildDAGRetryPolicy(_ buildContext, d *dag) (*core.DAGRetryPolicy, error) {
 	if d.RetryPolicy == nil {
 		return nil, nil
 	}
@@ -1079,30 +1078,30 @@ func buildDAGRetryPolicy(_ BuildContext, d *dag) (*core.DAGRetryPolicy, error) {
 	}, nil
 }
 
-func buildMaxOutputSize(_ BuildContext, d *dag) (int, error) {
+func buildMaxOutputSize(_ buildContext, d *dag) (int, error) {
 	return d.MaxOutputSize, nil
 }
 
-func buildSkipIfSuccessful(_ BuildContext, d *dag) (bool, error) {
+func buildSkipIfSuccessful(_ buildContext, d *dag) (bool, error) {
 	return d.SkipIfSuccessful, nil
 }
 
-func buildCatchupWindow(_ BuildContext, d *dag) (time.Duration, error) {
+func buildCatchupWindow(_ buildContext, d *dag) (time.Duration, error) {
 	if d.CatchupWindow == "" {
 		return 0, nil
 	}
 	return core.ParseDuration(d.CatchupWindow)
 }
 
-func buildOverlapPolicy(_ BuildContext, d *dag) (core.OverlapPolicy, error) {
+func buildOverlapPolicy(_ buildContext, d *dag) (core.OverlapPolicy, error) {
 	return core.ParseOverlapPolicy(d.OverlapPolicy)
 }
 
-func buildLogDir(_ BuildContext, d *dag) (string, error) {
+func buildLogDir(_ buildContext, d *dag) (string, error) {
 	return d.LogDir, nil
 }
 
-func buildArtifacts(_ BuildContext, d *dag) (*core.ArtifactsConfig, error) {
+func buildArtifacts(_ buildContext, d *dag) (*core.ArtifactsConfig, error) {
 	usesArtifactAction := dagUsesBuiltinArtifactAction(d)
 	usesArtifactOutput := dagUsesArtifactOutput(d)
 	autoEnable := dagReferencesRunArtifactsDir(d) || usesArtifactAction || usesArtifactOutput
@@ -1149,8 +1148,27 @@ func dagReferencesRunArtifactsDir(d *dag) bool {
 	return valueReferencesRunArtifactsDir(reflect.ValueOf(d))
 }
 
+// dagUsesBuiltinArtifactAction reports whether the spec declares a builtin
+// artifact action. Only executable roots are searched: free-form data such as
+// DAG parameters may legitimately carry an "action" key without describing a
+// step to run.
 func dagUsesBuiltinArtifactAction(d *dag) bool {
-	return valueUsesBuiltinArtifactAction(reflect.ValueOf(d))
+	if d == nil {
+		return false
+	}
+	return valueUsesBuiltinArtifactAction(reflect.ValueOf(d.Steps)) ||
+		valueUsesBuiltinArtifactAction(reflect.ValueOf(d.HandlerOn)) ||
+		customStepSpecsUseBuiltinArtifactAction(d.StepTypes) ||
+		customStepSpecsUseBuiltinArtifactAction(d.Actions)
+}
+
+func customStepSpecsUseBuiltinArtifactAction(specs map[string]customStepTypeSpec) bool {
+	for _, spec := range specs {
+		if valueUsesBuiltinArtifactAction(reflect.ValueOf(spec.Template)) {
+			return true
+		}
+	}
+	return false
 }
 
 func dagUsesArtifactOutput(d *dag) bool {
@@ -1275,6 +1293,10 @@ func valueUsesBuiltinArtifactAction(v reflect.Value) bool {
 					return true
 				}
 			}
+			// Parameter payloads are data handed to a child DAG, not step syntax.
+			if key.Kind() == reflect.String && key.String() == "params" {
+				continue
+			}
 			if valueUsesBuiltinArtifactAction(key) || valueUsesBuiltinArtifactAction(value) {
 				return true
 			}
@@ -1297,6 +1319,10 @@ func valueUsesBuiltinArtifactAction(v reflect.Value) bool {
 				if action, ok := reflectString(field); ok && strings.HasPrefix(action, "artifact.") {
 					return true
 				}
+			}
+			// Parameter payloads are data handed to a child DAG, not step syntax.
+			if fieldInfo.Name == "Params" {
+				continue
 			}
 			if valueUsesBuiltinArtifactAction(field) {
 				return true
@@ -1450,7 +1476,7 @@ func reflectString(v reflect.Value) (string, bool) {
 	return strings.TrimSpace(v.String()), true
 }
 
-func buildLogOutput(_ BuildContext, d *dag) (core.LogOutputMode, error) {
+func buildLogOutput(_ buildContext, d *dag) (core.LogOutputMode, error) {
 	if d.LogOutput.IsZero() {
 		// Return empty to allow inheritance from base config.
 		// Default is applied in core.InitializeDefaults.
@@ -1459,7 +1485,7 @@ func buildLogOutput(_ BuildContext, d *dag) (core.LogOutputMode, error) {
 	return d.LogOutput.Mode(), nil
 }
 
-func buildMailOn(_ BuildContext, d *dag) (*core.MailOn, error) {
+func buildMailOn(_ buildContext, d *dag) (*core.MailOn, error) {
 	if d.MailOn == nil {
 		return nil, nil
 	}
@@ -1470,7 +1496,7 @@ func buildMailOn(_ BuildContext, d *dag) (*core.MailOn, error) {
 	}, nil
 }
 
-func buildRunConfig(_ BuildContext, d *dag) (*core.RunConfig, error) {
+func buildRunConfig(_ buildContext, d *dag) (*core.RunConfig, error) {
 	if d.RunConfig == nil {
 		return nil, nil
 	}
@@ -1480,7 +1506,7 @@ func buildRunConfig(_ BuildContext, d *dag) (*core.RunConfig, error) {
 	}, nil
 }
 
-func buildResources(_ BuildContext, d *dag) (*core.Resources, error) {
+func buildResources(_ buildContext, d *dag) (*core.Resources, error) {
 	if d.Resources == nil || d.Resources.Limits == nil {
 		return nil, nil
 	}
@@ -1494,7 +1520,7 @@ func buildResources(_ BuildContext, d *dag) (*core.Resources, error) {
 	return &core.Resources{Limits: limits}, nil
 }
 
-func buildWebhookConfig(_ BuildContext, d *dag) (*core.WebhookConfig, error) {
+func buildWebhookConfig(_ buildContext, d *dag) (*core.WebhookConfig, error) {
 	if d.Webhook == nil {
 		return nil, nil
 	}
@@ -1529,7 +1555,7 @@ func buildWebhookConfig(_ BuildContext, d *dag) (*core.WebhookConfig, error) {
 	return &core.WebhookConfig{ForwardHeaders: headers}, nil
 }
 
-func buildHistRetentionDays(_ BuildContext, d *dag) (int, error) {
+func buildHistRetentionDays(_ buildContext, d *dag) (int, error) {
 	if d.HistRetentionDays != nil {
 		if *d.HistRetentionDays < 0 {
 			return 0, fmt.Errorf("hist_retention_days must be >= 0")
@@ -1539,7 +1565,7 @@ func buildHistRetentionDays(_ BuildContext, d *dag) (int, error) {
 	return 0, nil
 }
 
-func buildHistRetentionRuns(_ BuildContext, d *dag) (int, error) {
+func buildHistRetentionRuns(_ buildContext, d *dag) (int, error) {
 	if d.HistRetentionRuns != nil {
 		if *d.HistRetentionRuns <= 0 {
 			return 0, fmt.Errorf("hist_retention_runs must be > 0")
@@ -1560,14 +1586,14 @@ func validateHistoryRetentionConfig(d *dag) error {
 	)
 }
 
-func buildMaxCleanUpTime(_ BuildContext, d *dag) (time.Duration, error) {
+func buildMaxCleanUpTime(_ buildContext, d *dag) (time.Duration, error) {
 	if d.MaxCleanUpTimeSec != nil {
 		return time.Second * time.Duration(*d.MaxCleanUpTimeSec), nil
 	}
 	return 0, nil
 }
 
-func buildEnvs(ctx BuildContext, d *dag) ([]string, error) {
+func buildEnvs(ctx buildContext, d *dag) ([]string, error) {
 	entries, vars, err := loadEnvEntriesFromEnvValue(ctx, d.Env)
 	if err != nil {
 		return nil, err
@@ -1587,21 +1613,21 @@ func buildEnvs(ctx BuildContext, d *dag) ([]string, error) {
 	return envs, nil
 }
 
-func buildSchedule(_ BuildContext, d *dag) ([]core.Schedule, error) {
+func buildSchedule(_ buildContext, d *dag) ([]core.Schedule, error) {
 	if d.Schedule.IsZero() {
 		return nil, nil
 	}
 	return slices.Clone(d.Schedule.Starts()), nil
 }
 
-func buildStopSchedule(_ BuildContext, d *dag) ([]core.Schedule, error) {
+func buildStopSchedule(_ buildContext, d *dag) ([]core.Schedule, error) {
 	if d.Schedule.IsZero() {
 		return nil, nil
 	}
 	return slices.Clone(d.Schedule.Stops()), nil
 }
 
-func buildRestartSchedule(_ BuildContext, d *dag) ([]core.Schedule, error) {
+func buildRestartSchedule(_ buildContext, d *dag) ([]core.Schedule, error) {
 	if d.Schedule.IsZero() {
 		return nil, nil
 	}
@@ -1617,7 +1643,7 @@ type paramsResult struct {
 	ParamsJSON    string // JSON representation of resolved params (original payload when provided as JSON)
 }
 
-func buildParams(ctx BuildContext, d *dag) ([]string, error) {
+func buildParams(ctx buildContext, d *dag) ([]string, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return nil, err
@@ -1673,7 +1699,7 @@ func paramValuesFromResult(result *paramsResult) cmnvalue.Values {
 	return params
 }
 
-func buildDefaultParams(ctx BuildContext, d *dag) (string, error) {
+func buildDefaultParams(ctx buildContext, d *dag) (string, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return "", err
@@ -1681,7 +1707,7 @@ func buildDefaultParams(ctx BuildContext, d *dag) (string, error) {
 	return result.DefaultParams, nil
 }
 
-func buildParamDefs(ctx BuildContext, d *dag) ([]core.ParamDef, error) {
+func buildParamDefs(ctx buildContext, d *dag) ([]core.ParamDef, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return nil, err
@@ -1689,7 +1715,7 @@ func buildParamDefs(ctx BuildContext, d *dag) ([]core.ParamDef, error) {
 	return result.ParamDefs, nil
 }
 
-func buildParamsJSON(ctx BuildContext, d *dag) (string, error) {
+func buildParamsJSON(ctx buildContext, d *dag) (string, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return "", err
@@ -1697,7 +1723,7 @@ func buildParamsJSON(ctx BuildContext, d *dag) (string, error) {
 	return result.ParamsJSON, nil
 }
 
-func buildParamSchema(ctx BuildContext, d *dag) (json.RawMessage, error) {
+func buildParamSchema(ctx buildContext, d *dag) (json.RawMessage, error) {
 	result, err := parseParamsInternal(ctx, d)
 	if err != nil {
 		return nil, err
@@ -1847,7 +1873,7 @@ func marshalParamPairs(paramPairs []paramPair) (string, error) {
 	return string(data), nil
 }
 
-func parseParamsInternal(ctx BuildContext, d *dag) (*paramsResult, error) {
+func parseParamsInternal(ctx buildContext, d *dag) (*paramsResult, error) {
 	if ctx.paramsState != nil && ctx.paramsState.cached {
 		return ctx.paramsState.result, ctx.paramsState.err
 	}
@@ -1864,7 +1890,7 @@ func parseParamsInternal(ctx BuildContext, d *dag) (*paramsResult, error) {
 // workerSelectorTransformer is a custom transformer that sets both WorkerSelector and ForceLocal fields.
 type workerSelectorTransformer struct{}
 
-func (t *workerSelectorTransformer) Transform(ctx BuildContext, in *dag, out reflect.Value) error {
+func (t *workerSelectorTransformer) Transform(ctx buildContext, in *dag, out reflect.Value) error {
 	ws, forceLocal, err := buildWorkerSelector(ctx, in)
 	if err != nil {
 		return err
@@ -1887,7 +1913,7 @@ func (t *workerSelectorTransformer) Transform(ctx BuildContext, in *dag, out ref
 	return nil
 }
 
-func buildWorkerSelector(_ BuildContext, d *dag) (map[string]string, bool, error) {
+func buildWorkerSelector(_ buildContext, d *dag) (map[string]string, bool, error) {
 	if d.WorkerSelector == nil {
 		return nil, false, nil
 	}
@@ -1945,7 +1971,7 @@ type shellResult struct {
 	Args  []string
 }
 
-func parseShellInternal(_ BuildContext, d *dag) (*shellResult, error) {
+func parseShellInternal(_ buildContext, d *dag) (*shellResult, error) {
 	if d.Shell.IsZero() {
 		return &shellResult{Shell: cmdutil.GetShellCommand(""), Args: nil}, nil
 	}
@@ -1976,7 +2002,7 @@ func parseShellInternal(_ BuildContext, d *dag) (*shellResult, error) {
 	return &shellResult{Shell: strings.TrimSpace(shell), Args: args}, nil
 }
 
-func buildShell(ctx BuildContext, d *dag) (string, error) {
+func buildShell(ctx buildContext, d *dag) (string, error) {
 	result, err := parseShellInternal(ctx, d)
 	if err != nil {
 		return "", err
@@ -1984,7 +2010,7 @@ func buildShell(ctx BuildContext, d *dag) (string, error) {
 	return result.Shell, nil
 }
 
-func buildShellArgs(ctx BuildContext, d *dag) ([]string, error) {
+func buildShellArgs(ctx buildContext, d *dag) ([]string, error) {
 	result, err := parseShellInternal(ctx, d)
 	if err != nil {
 		return nil, err
@@ -1992,7 +2018,7 @@ func buildShellArgs(ctx BuildContext, d *dag) ([]string, error) {
 	return append(result.Args, d.ShellArgs...), nil
 }
 
-func buildWorkingDir(ctx BuildContext, d *dag) (string, error) {
+func buildWorkingDir(ctx buildContext, d *dag) (string, error) {
 	if d.WorkingDir != "" {
 		return resolveWorkingDirPath(d.WorkingDir, authoredFile(ctx))
 	}
@@ -2008,7 +2034,7 @@ func buildWorkingDir(ctx BuildContext, d *dag) (string, error) {
 // file being read whenever a definition is executed from a copy, which is the
 // case for a sub-workflow defined in the same document and for a task a worker
 // received from the coordinator.
-func authoredFile(ctx BuildContext) string {
+func authoredFile(ctx buildContext) string {
 	if ctx.opts.SourceFile != "" {
 		return ctx.opts.SourceFile
 	}
@@ -2028,26 +2054,14 @@ func resolveWorkingDirPath(wd, dagFile string) (string, error) {
 	return wd, nil
 }
 
-// getDefaultWorkingDir returns the current working directory or user home as fallback.
-func getDefaultWorkingDir() (string, error) {
-	if dir, _ := os.Getwd(); dir != "" {
-		return dir, nil
-	}
-	dir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-	return dir, nil
-}
-
-func buildContainer(ctx BuildContext, d *dag) (*core.Container, error) {
+func buildContainer(ctx buildContext, d *dag) (*core.Container, error) {
 	return buildContainerField(ctx, d.Container)
 }
 
 // buildContainerField handles both string and object forms of container field.
 // String form: "container-name" -> exec into existing container
 // Object form: {image: "...", ...} or {exec: "...", ...} -> create new or exec into existing
-func buildContainerField(ctx BuildContext, raw any) (*core.Container, error) {
+func buildContainerField(ctx buildContext, raw any) (*core.Container, error) {
 	if raw == nil {
 		return nil, nil
 	}
@@ -2098,7 +2112,7 @@ func buildContainerField(ctx BuildContext, raw any) (*core.Container, error) {
 
 // buildContainerFromSpec is a shared function that builds a core.Container from a container spec.
 // It is used by both DAG-level and step-level container configuration.
-func buildContainerFromSpec(_ BuildContext, c *container) (*core.Container, error) {
+func buildContainerFromSpec(_ buildContext, c *container) (*core.Container, error) {
 	// Validate mutual exclusivity
 	if c.Exec != "" && c.Image != "" {
 		return nil, core.NewValidationError("container", nil,
@@ -2291,7 +2305,7 @@ func parseHealthcheck(h *healthcheck) (*core.Healthcheck, error) {
 	return hc, nil
 }
 
-func buildRegistryAuths(_ BuildContext, d *dag) (map[string]*core.AuthConfig, error) {
+func buildRegistryAuths(_ buildContext, d *dag) (map[string]*core.AuthConfig, error) {
 	if d.RegistryAuths == nil {
 		return nil, nil
 	}
@@ -2360,7 +2374,7 @@ func buildRegistryAuths(_ BuildContext, d *dag) (map[string]*core.AuthConfig, er
 	return registryAuths, nil
 }
 
-func buildSSH(_ BuildContext, d *dag) (*core.SSHConfig, error) {
+func buildSSH(_ buildContext, d *dag) (*core.SSHConfig, error) {
 	if d.SSH == nil {
 		return nil, nil
 	}
@@ -2429,7 +2443,7 @@ func defaultPort(port, defaultVal string) string {
 	return port
 }
 
-func buildS3(_ BuildContext, d *dag) (*core.S3Config, error) {
+func buildS3(_ buildContext, d *dag) (*core.S3Config, error) {
 	if d.S3 == nil {
 		return nil, nil
 	}
@@ -2447,7 +2461,7 @@ func buildS3(_ BuildContext, d *dag) (*core.S3Config, error) {
 	}, nil
 }
 
-func buildLLM(_ BuildContext, d *dag) (*core.LLMConfig, error) {
+func buildLLM(_ buildContext, d *dag) (*core.LLMConfig, error) {
 	if d.LLM == nil {
 		return nil, nil
 	}
@@ -2519,6 +2533,8 @@ func buildLLM(_ BuildContext, d *dag) (*core.LLMConfig, error) {
 		APIKeyName:  cfg.APIKeyName,
 		Stream:      cfg.Stream,
 		Thinking:    thinking,
+		Tools:       cfg.Tools,
+		WebSearch:   buildWebSearchConfig(cfg.WebSearch),
 
 		MaxToolIterations:     cfg.MaxToolIterations,
 		MaxContextTokens:      cfg.MaxContextTokens,
@@ -2527,7 +2543,7 @@ func buildLLM(_ BuildContext, d *dag) (*core.LLMConfig, error) {
 	}, nil
 }
 
-func buildRedis(_ BuildContext, d *dag) (*core.RedisConfig, error) {
+func buildRedis(_ buildContext, d *dag) (*core.RedisConfig, error) {
 	if d.Redis == nil {
 		return nil, nil
 	}
@@ -2549,7 +2565,7 @@ func buildRedis(_ BuildContext, d *dag) (*core.RedisConfig, error) {
 	}, nil
 }
 
-func buildHarnesses(_ BuildContext, d *dag) (core.HarnessDefinitions, error) {
+func buildHarnesses(_ buildContext, d *dag) (core.HarnessDefinitions, error) {
 	defs, err := parseHarnessDefinitions(d.Harnesses)
 	if err != nil {
 		return nil, err
@@ -2778,7 +2794,7 @@ func harnessStringMap(raw any) (map[string]string, error) {
 	}
 }
 
-func buildHarness(ctx BuildContext, d *dag) (*core.HarnessConfig, error) {
+func buildHarness(ctx buildContext, d *dag) (*core.HarnessConfig, error) {
 	if d.Harness == nil {
 		return nil, nil
 	}
@@ -2823,14 +2839,14 @@ func buildHarness(ctx BuildContext, d *dag) (*core.HarnessConfig, error) {
 	}, nil
 }
 
-func buildSecrets(ctx BuildContext, d *dag) ([]core.SecretRef, error) {
+func buildSecrets(ctx buildContext, d *dag) ([]core.SecretRef, error) {
 	if len(d.Secrets) == 0 {
 		return nil, nil
 	}
 	return parseSecretRefs(ctx, d)
 }
 
-func buildTools(_ BuildContext, d *dag) (*core.ToolConfig, error) {
+func buildTools(_ buildContext, d *dag) (*core.ToolConfig, error) {
 	if d.Tools == nil {
 		return nil, nil
 	}
@@ -3112,7 +3128,7 @@ func cloneHarnessSpecValue(value any) any {
 	}
 }
 
-func buildDotenv(_ BuildContext, d *dag) ([]string, error) {
+func buildDotenv(_ buildContext, d *dag) ([]string, error) {
 	if d.Dotenv.IsZero() {
 		return []string{".env"}, nil
 	}
@@ -3158,8 +3174,8 @@ func cloneStepPointer(step *core.Step) *core.Step {
 	return &cloned
 }
 
-func buildHandlers(ctx BuildContext, d *dag, result *core.DAG) (core.HandlerOn, error) {
-	buildCtx := StepBuildContext{BuildContext: ctx, dag: result}
+func buildHandlers(ctx buildContext, d *dag, result *core.DAG) (core.HandlerOn, error) {
+	buildCtx := stepBuildContext{buildContext: ctx, dag: result}
 	var handlerOn core.HandlerOn
 
 	localDefs, err := decodeDefaults(d.Defaults)
@@ -3211,7 +3227,7 @@ func buildHandlers(ctx BuildContext, d *dag, result *core.DAG) (core.HandlerOn, 
 	return handlerOn, nil
 }
 
-func buildSMTPConfig(_ BuildContext, d *dag) (*core.SMTPConfig, error) {
+func buildSMTPConfig(_ buildContext, d *dag) (*core.SMTPConfig, error) {
 	if d.SMTP.IsZero() {
 		return nil, nil
 	}
@@ -3224,23 +3240,23 @@ func buildSMTPConfig(_ BuildContext, d *dag) (*core.SMTPConfig, error) {
 	}, nil
 }
 
-func buildErrMailConfig(_ BuildContext, d *dag) (*core.MailConfig, error) {
+func buildErrMailConfig(_ buildContext, d *dag) (*core.MailConfig, error) {
 	return buildMailConfigInternal(d.ErrorMail)
 }
 
-func buildInfoMailConfig(_ BuildContext, d *dag) (*core.MailConfig, error) {
+func buildInfoMailConfig(_ buildContext, d *dag) (*core.MailConfig, error) {
 	return buildMailConfigInternal(d.InfoMail)
 }
 
-func buildWaitMailConfig(_ BuildContext, d *dag) (*core.MailConfig, error) {
+func buildWaitMailConfig(_ buildContext, d *dag) (*core.MailConfig, error) {
 	return buildMailConfigInternal(d.WaitMail)
 }
 
-func buildPreconditions(ctx BuildContext, d *dag) ([]*core.Condition, error) {
+func buildPreconditions(ctx buildContext, d *dag) ([]*core.Condition, error) {
 	return parsePrecondition(ctx, d.Preconditions)
 }
 
-func buildOTel(_ BuildContext, d *dag) (*core.OTelConfig, error) {
+func buildOTel(_ buildContext, d *dag) (*core.OTelConfig, error) {
 	if d.OTel == nil {
 		return nil, nil
 	}
@@ -3284,8 +3300,8 @@ func buildOTel(_ BuildContext, d *dag) (*core.OTelConfig, error) {
 	}
 }
 
-func buildSteps(ctx BuildContext, d *dag, result *core.DAG) ([]core.Step, error) {
-	buildCtx := StepBuildContext{BuildContext: ctx, dag: result}
+func buildSteps(ctx buildContext, d *dag, result *core.DAG) ([]core.Step, error) {
+	buildCtx := stepBuildContext{buildContext: ctx, dag: result}
 	names := make(map[string]struct{})
 
 	localDefs, err := decodeDefaults(d.Defaults)

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1138,6 +1138,9 @@ func dagReferencesRunArtifactsDir(d *dag) bool {
 // artifact action. Only executable roots are searched: free-form data such as
 // DAG parameters may legitimately carry an "action" key without describing a
 // step to run.
+//
+// Step names are searched like any other map key, so a step is detected
+// whichever name it is declared under.
 func dagUsesBuiltinArtifactAction(d *dag) bool {
 	if d == nil {
 		return false
@@ -1188,8 +1191,8 @@ type specVisitor struct {
 	// matchString reports whether a scalar string satisfies the search.
 	matchString func(string) bool
 	// matchNamed reports whether a map entry or exported struct field
-	// satisfies the search. skip suppresses recursion into that value.
-	matchNamed func(name string, value reflect.Value) (match, skip bool)
+	// satisfies the search.
+	matchNamed func(name string, value reflect.Value) bool
 }
 
 func (vis specVisitor) visit(v reflect.Value) bool {
@@ -1223,14 +1226,8 @@ func (vis specVisitor) visit(v reflect.Value) bool {
 		iter := v.MapRange()
 		for iter.Next() {
 			key, value := iter.Key(), iter.Value()
-			if key.Kind() == reflect.String {
-				match, skip := vis.named(key.String(), value)
-				if match {
-					return true
-				}
-				if skip {
-					continue
-				}
+			if key.Kind() == reflect.String && vis.named(key.String(), value) {
+				return true
 			}
 			if vis.visit(key) || vis.visit(value) {
 				return true
@@ -1244,12 +1241,8 @@ func (vis specVisitor) visit(v reflect.Value) bool {
 				continue
 			}
 			field := v.Field(i)
-			match, skip := vis.named(fieldInfo.Name, field)
-			if match {
+			if vis.named(fieldInfo.Name, field) {
 				return true
-			}
-			if skip {
-				continue
 			}
 			if vis.visit(field) {
 				return true
@@ -1285,11 +1278,8 @@ func (vis specVisitor) visit(v reflect.Value) bool {
 	return false
 }
 
-func (vis specVisitor) named(name string, value reflect.Value) (match, skip bool) {
-	if vis.matchNamed == nil {
-		return false, false
-	}
-	return vis.matchNamed(name, value)
+func (vis specVisitor) named(name string, value reflect.Value) bool {
+	return vis.matchNamed != nil && vis.matchNamed(name, value)
 }
 
 // runArtifactsDirVisitor finds a reference to the run artifacts directory
@@ -1300,25 +1290,22 @@ var runArtifactsDirVisitor = specVisitor{
 }
 
 // builtinArtifactActionVisitor finds a step declaring a builtin artifact
-// action. Parameter payloads are data handed to a child DAG, not step syntax.
+// action.
 var builtinArtifactActionVisitor = specVisitor{
-	matchNamed: func(name string, value reflect.Value) (bool, bool) {
-		switch name {
-		case "action", "Action":
-			action, ok := reflectString(value)
-			return ok && strings.HasPrefix(action, "artifact."), false
-		case "params", "Params":
-			return false, true
+	matchNamed: func(name string, value reflect.Value) bool {
+		if name != "action" && name != "Action" {
+			return false
 		}
-		return false, false
+		action, ok := reflectString(value)
+		return ok && strings.HasPrefix(action, "artifact.")
 	},
 }
 
 // artifactOutputVisitor finds a step redirecting an output stream to an
 // artifact.
 var artifactOutputVisitor = specVisitor{
-	matchNamed: func(name string, value reflect.Value) (bool, bool) {
-		return isArtifactOutputField(name) && valueIsArtifactOutputConfig(value), false
+	matchNamed: func(name string, value reflect.Value) bool {
+		return isArtifactOutputField(name) && valueIsArtifactOutputConfig(value)
 	},
 }
 

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1180,7 +1180,19 @@ func referencesArtifactsEnvVar(s string) bool {
 	return dagRunArtifactsDirReferencePattern.MatchString(s)
 }
 
-func valueReferencesRunArtifactsDir(v reflect.Value) bool {
+// specVisitor searches a decoded spec tree for a condition. A nil callback
+// never matches. Traversal stops at the first match.
+type specVisitor struct {
+	// expandValueProviders unwraps types exposing Value() any before matching.
+	expandValueProviders bool
+	// matchString reports whether a scalar string satisfies the search.
+	matchString func(string) bool
+	// matchNamed reports whether a map entry or exported struct field
+	// satisfies the search. skip suppresses recursion into that value.
+	matchNamed func(name string, value reflect.Value) (match, skip bool)
+}
+
+func (vis specVisitor) visit(v reflect.Value) bool {
 	if !v.IsValid() {
 		return false
 	}
@@ -1192,35 +1204,54 @@ func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 		v = v.Elem()
 	}
 
-	if v.CanInterface() {
+	if vis.expandValueProviders && v.CanInterface() {
 		if provider, ok := v.Interface().(interface{ Value() any }); ok {
-			return valueReferencesRunArtifactsDir(reflect.ValueOf(provider.Value()))
+			return vis.visit(reflect.ValueOf(provider.Value()))
 		}
 	}
 
 	switch v.Kind() {
 	case reflect.String:
-		return referencesArtifactsEnvVar(v.String())
+		return vis.matchString != nil && vis.matchString(v.String())
 	case reflect.Array, reflect.Slice:
-		for i := 0; i < v.Len(); i++ {
-			if valueReferencesRunArtifactsDir(v.Index(i)) {
+		for i := range v.Len() {
+			if vis.visit(v.Index(i)) {
 				return true
 			}
 		}
 	case reflect.Map:
 		iter := v.MapRange()
 		for iter.Next() {
-			if valueReferencesRunArtifactsDir(iter.Key()) || valueReferencesRunArtifactsDir(iter.Value()) {
+			key, value := iter.Key(), iter.Value()
+			if key.Kind() == reflect.String {
+				match, skip := vis.named(key.String(), value)
+				if match {
+					return true
+				}
+				if skip {
+					continue
+				}
+			}
+			if vis.visit(key) || vis.visit(value) {
 				return true
 			}
 		}
 	case reflect.Struct:
 		t := v.Type()
 		for i := range v.NumField() {
-			if t.Field(i).PkgPath != "" {
+			fieldInfo := t.Field(i)
+			if fieldInfo.PkgPath != "" {
 				continue
 			}
-			if valueReferencesRunArtifactsDir(v.Field(i)) {
+			field := v.Field(i)
+			match, skip := vis.named(fieldInfo.Name, field)
+			if match {
+				return true
+			}
+			if skip {
+				continue
+			}
+			if vis.visit(field) {
 				return true
 			}
 		}
@@ -1252,171 +1283,55 @@ func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 	}
 
 	return false
+}
+
+func (vis specVisitor) named(name string, value reflect.Value) (match, skip bool) {
+	if vis.matchNamed == nil {
+		return false, false
+	}
+	return vis.matchNamed(name, value)
+}
+
+// runArtifactsDirVisitor finds a reference to the run artifacts directory
+// anywhere in the spec, including free-form data.
+var runArtifactsDirVisitor = specVisitor{
+	expandValueProviders: true,
+	matchString:          referencesArtifactsEnvVar,
+}
+
+// builtinArtifactActionVisitor finds a step declaring a builtin artifact
+// action. Parameter payloads are data handed to a child DAG, not step syntax.
+var builtinArtifactActionVisitor = specVisitor{
+	matchNamed: func(name string, value reflect.Value) (bool, bool) {
+		switch name {
+		case "action", "Action":
+			action, ok := reflectString(value)
+			return ok && strings.HasPrefix(action, "artifact."), false
+		case "params", "Params":
+			return false, true
+		}
+		return false, false
+	},
+}
+
+// artifactOutputVisitor finds a step redirecting an output stream to an
+// artifact.
+var artifactOutputVisitor = specVisitor{
+	matchNamed: func(name string, value reflect.Value) (bool, bool) {
+		return isArtifactOutputField(name) && valueIsArtifactOutputConfig(value), false
+	},
+}
+
+func valueReferencesRunArtifactsDir(v reflect.Value) bool {
+	return runArtifactsDirVisitor.visit(v)
 }
 
 func valueUsesBuiltinArtifactAction(v reflect.Value) bool {
-	if !v.IsValid() {
-		return false
-	}
-
-	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
-		if v.IsNil() {
-			return false
-		}
-		v = v.Elem()
-	}
-
-	switch v.Kind() {
-	case reflect.String:
-		return false
-	case reflect.Map:
-		iter := v.MapRange()
-		for iter.Next() {
-			key := iter.Key()
-			value := iter.Value()
-			if key.Kind() == reflect.String && key.String() == "action" {
-				if action, ok := reflectString(value); ok && strings.HasPrefix(action, "artifact.") {
-					return true
-				}
-			}
-			// Parameter payloads are data handed to a child DAG, not step syntax.
-			if key.Kind() == reflect.String && key.String() == "params" {
-				continue
-			}
-			if valueUsesBuiltinArtifactAction(key) || valueUsesBuiltinArtifactAction(value) {
-				return true
-			}
-		}
-	case reflect.Slice, reflect.Array:
-		for i := range v.Len() {
-			if valueUsesBuiltinArtifactAction(v.Index(i)) {
-				return true
-			}
-		}
-	case reflect.Struct:
-		t := v.Type()
-		for i := range v.NumField() {
-			fieldInfo := t.Field(i)
-			if fieldInfo.PkgPath != "" {
-				continue
-			}
-			field := v.Field(i)
-			if fieldInfo.Name == "Action" {
-				if action, ok := reflectString(field); ok && strings.HasPrefix(action, "artifact.") {
-					return true
-				}
-			}
-			// Parameter payloads are data handed to a child DAG, not step syntax.
-			if fieldInfo.Name == "Params" {
-				continue
-			}
-			if valueUsesBuiltinArtifactAction(field) {
-				return true
-			}
-		}
-	case reflect.Invalid,
-		reflect.Bool,
-		reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64,
-		reflect.Uint,
-		reflect.Uint8,
-		reflect.Uint16,
-		reflect.Uint32,
-		reflect.Uint64,
-		reflect.Uintptr,
-		reflect.Float32,
-		reflect.Float64,
-		reflect.Complex64,
-		reflect.Complex128,
-		reflect.Chan,
-		reflect.Func,
-		reflect.Interface,
-		reflect.Pointer,
-		reflect.UnsafePointer:
-		return false
-	default:
-		return false
-	}
-	return false
+	return builtinArtifactActionVisitor.visit(v)
 }
 
 func valueUsesArtifactOutput(v reflect.Value) bool {
-	if !v.IsValid() {
-		return false
-	}
-
-	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
-		if v.IsNil() {
-			return false
-		}
-		v = v.Elem()
-	}
-
-	switch v.Kind() {
-	case reflect.Map:
-		iter := v.MapRange()
-		for iter.Next() {
-			key := iter.Key()
-			value := iter.Value()
-			if key.Kind() == reflect.String && isArtifactOutputField(key.String()) && valueIsArtifactOutputConfig(value) {
-				return true
-			}
-			if valueUsesArtifactOutput(key) || valueUsesArtifactOutput(value) {
-				return true
-			}
-		}
-	case reflect.Slice, reflect.Array:
-		for i := range v.Len() {
-			if valueUsesArtifactOutput(v.Index(i)) {
-				return true
-			}
-		}
-	case reflect.Struct:
-		t := v.Type()
-		for i := range v.NumField() {
-			fieldInfo := t.Field(i)
-			if fieldInfo.PkgPath != "" {
-				continue
-			}
-			field := v.Field(i)
-			if isArtifactOutputField(fieldInfo.Name) && valueIsArtifactOutputConfig(field) {
-				return true
-			}
-			if valueUsesArtifactOutput(field) {
-				return true
-			}
-		}
-	case reflect.String,
-		reflect.Invalid,
-		reflect.Bool,
-		reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64,
-		reflect.Uint,
-		reflect.Uint8,
-		reflect.Uint16,
-		reflect.Uint32,
-		reflect.Uint64,
-		reflect.Uintptr,
-		reflect.Float32,
-		reflect.Float64,
-		reflect.Complex64,
-		reflect.Complex128,
-		reflect.Chan,
-		reflect.Func,
-		reflect.Interface,
-		reflect.Pointer,
-		reflect.UnsafePointer:
-		return false
-	default:
-		return false
-	}
-	return false
+	return artifactOutputVisitor.visit(v)
 }
 
 func isArtifactOutputField(name string) bool {
@@ -2777,7 +2692,7 @@ func buildHarness(ctx buildContext, d *dag) (*core.HarnessConfig, error) {
 		return nil, nil
 	}
 
-	config := cloneHarnessSpecMap(d.Harness)
+	config := cloneMap(d.Harness)
 	fallbacks, err := extractHarnessFallback(config)
 	if err != nil {
 		return nil, core.NewValidationError("harness", d.Harness, err)
@@ -3018,7 +2933,7 @@ func extractHarnessFallback(config map[string]any) ([]map[string]any, error) {
 	case nil:
 		return nil, nil
 	case []map[string]any:
-		return cloneHarnessSpecFallback(v), nil
+		return cloneMapSlice(v), nil
 	case []any:
 		fallbacks := make([]map[string]any, len(v))
 		for i := range v {
@@ -3026,7 +2941,7 @@ func extractHarnessFallback(config map[string]any) ([]map[string]any, error) {
 			if !ok {
 				return nil, fmt.Errorf("harness: fallback[%d] must be an object", i)
 			}
-			fallbacks[i] = cloneHarnessSpecMap(item)
+			fallbacks[i] = cloneMap(item)
 		}
 		return fallbacks, nil
 	default:
@@ -3061,49 +2976,6 @@ func validateHarnessProviderConfig(defs core.HarnessDefinitions, cfg map[string]
 		}
 	}
 	return fmt.Errorf("harness: unknown provider %q", providerName)
-}
-
-func cloneHarnessSpecMap(cfg map[string]any) map[string]any {
-	if cfg == nil {
-		return nil
-	}
-
-	cloned := make(map[string]any, len(cfg))
-	for key, value := range cfg {
-		cloned[key] = cloneHarnessSpecValue(value)
-	}
-	return cloned
-}
-
-func cloneHarnessSpecFallback(cfgs []map[string]any) []map[string]any {
-	if cfgs == nil {
-		return nil
-	}
-
-	cloned := make([]map[string]any, len(cfgs))
-	for i := range cfgs {
-		cloned[i] = cloneHarnessSpecMap(cfgs[i])
-	}
-	return cloned
-}
-
-func cloneHarnessSpecValue(value any) any {
-	switch v := value.(type) {
-	case map[string]any:
-		return cloneHarnessSpecMap(v)
-	case []any:
-		cloned := make([]any, len(v))
-		for i := range v {
-			cloned[i] = cloneHarnessSpecValue(v[i])
-		}
-		return cloned
-	case []string:
-		return append([]string(nil), v...)
-	case []map[string]any:
-		return cloneHarnessSpecFallback(v)
-	default:
-		return value
-	}
 }
 
 func buildDotenv(_ buildContext, d *dag) ([]string, error) {

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -488,90 +488,77 @@ type toolPackage struct {
 	Digest   string   `yaml:"digest,omitempty"`
 }
 
-// Transformer transforms a spec field into output field(s).
-// C is the context type, T is the input type.
-type Transformer[C any, T any] interface {
-	// Transform performs the transformation and sets field(s) on out
-	Transform(ctx C, in T, out reflect.Value) error
-}
-
-// dagTransformer is a generic implementation that provides type safety
-// for the builder function while satisfying the DAGTransformer interface.
-type dagTransformer[T any] struct {
-	fieldName string
-	builder   func(ctx buildContext, d *dag) (T, error)
-}
-
-func (t *dagTransformer[T]) Transform(ctx buildContext, in *dag, out reflect.Value) error {
-	v, err := t.builder(ctx, in)
-	if err != nil {
-		return err
-	}
-	field := out.FieldByName(t.fieldName)
-	if field.IsValid() && field.CanSet() {
-		field.Set(reflect.ValueOf(v))
-	}
-	return nil
-}
-
-// newTransformer creates a DAGTransformer for a single field transformation
-func newTransformer[T any](fieldName string, builder func(buildContext, *dag) (T, error)) Transformer[buildContext, *dag] {
-	return &dagTransformer[T]{
-		fieldName: fieldName,
-		builder:   builder,
-	}
-}
-
-// transform wraps a DAGTransformer with its name for error reporting
+// transform builds one part of a DAG and applies it to the result. name
+// identifies the spec field in build errors.
 type transform struct {
-	name        string
-	transformer Transformer[buildContext, *dag]
+	name  string
+	apply func(ctx buildContext, in *dag, out *core.DAG) error
+}
+
+// dagField describes a spec field whose built value is assigned to a single
+// field of the result.
+func dagField[T any](
+	name string,
+	build func(buildContext, *dag) (T, error),
+	assign func(*core.DAG, T),
+) transform {
+	return transform{
+		name: name,
+		apply: func(ctx buildContext, in *dag, out *core.DAG) error {
+			v, err := build(ctx, in)
+			if err != nil {
+				return err
+			}
+			assign(out, v)
+			return nil
+		},
+	}
 }
 
 type transformStage []transform
 
 // Metadata stages are always run (for listing, scheduling, etc.).
 var metadataIdentityStage = transformStage{
-	{"name", newTransformer("Name", buildName)},
-	{"group", newTransformer("Group", buildGroup)},
-	{"description", newTransformer("Description", buildDescription)},
-	{"type", newTransformer("Type", buildType)},
-	{"labels", newTransformer("Labels", buildLabels)},
+	dagField("name", buildName, func(out *core.DAG, v string) { out.Name = v }),
+	dagField("group", buildGroup, func(out *core.DAG, v string) { out.Group = v }),
+	dagField("description", buildDescription, func(out *core.DAG, v string) { out.Description = v }),
+	dagField("type", buildType, func(out *core.DAG, v string) { out.Type = v }),
+	dagField("labels", buildLabels, func(out *core.DAG, v core.Labels) { out.Labels = v }),
 }
 
 var metadataConstsStage = transformStage{
-	{"consts", newTransformer("Consts", buildConsts)},
+	dagField("consts", buildConsts, func(out *core.DAG, v map[string]any) { out.Consts = v }),
 }
 
 // Params must run before env so that env: values can reference ${param_name}.
 var metadataParamsEnvStage = transformStage{
-	{"params", newTransformer("Params", buildParams)},
-	{"default_params", newTransformer("DefaultParams", buildDefaultParams)},
-	{"param_defs", newTransformer("ParamDefs", buildParamDefs)},
-	{"param_schema", newTransformer("ParamSchema", buildParamSchema)},
-	{"params_json", newTransformer("ParamsJSON", buildParamsJSON)},
-	{"env", newTransformer("Env", buildEnvs)},
+	dagField("params", buildParams, func(out *core.DAG, v []string) { out.Params = v }),
+	dagField("default_params", buildDefaultParams, func(out *core.DAG, v string) { out.DefaultParams = v }),
+	dagField("param_defs", buildParamDefs, func(out *core.DAG, v []core.ParamDef) { out.ParamDefs = v }),
+	dagField("param_schema", buildParamSchema, func(out *core.DAG, v json.RawMessage) { out.ParamSchema = v }),
+	dagField("params_json", buildParamsJSON, func(out *core.DAG, v string) { out.ParamsJSON = v }),
+	dagField("env", buildEnvs, func(out *core.DAG, v []string) { out.Env = v }),
 }
 
 var metadataScheduleStage = transformStage{
-	{"schedule", newTransformer("Schedule", buildSchedule)},
-	{"stop_schedule", newTransformer("StopSchedule", buildStopSchedule)},
-	{"restart_schedule", newTransformer("RestartSchedule", buildRestartSchedule)},
+	dagField("schedule", buildSchedule, func(out *core.DAG, v []core.Schedule) { out.Schedule = v }),
+	dagField("stop_schedule", buildStopSchedule, func(out *core.DAG, v []core.Schedule) { out.StopSchedule = v }),
+	dagField("restart_schedule", buildRestartSchedule, func(out *core.DAG, v []core.Schedule) { out.RestartSchedule = v }),
 }
 
 var metadataExecutionPlacementStage = transformStage{
-	{"worker_selector", &workerSelectorTransformer{}},
-	{"timeout", newTransformer("Timeout", buildTimeout)},
-	{"delay", newTransformer("Delay", buildDelay)},
-	{"restart_wait", newTransformer("RestartWait", buildRestartWait)},
-	{"max_active_runs", newTransformer("MaxActiveRuns", buildMaxActiveRuns)},
-	{"max_active_steps", newTransformer("MaxActiveSteps", buildMaxActiveSteps)},
-	{"queue", newTransformer("Queue", buildQueue)},
-	{"retry_policy", newTransformer("RetryPolicy", buildDAGRetryPolicy)},
-	{"max_output_size", newTransformer("MaxOutputSize", buildMaxOutputSize)},
-	{"skip_if_successful", newTransformer("SkipIfSuccessful", buildSkipIfSuccessful)},
-	{"catchup_window", newTransformer("CatchupWindow", buildCatchupWindow)},
-	{"overlap_policy", newTransformer("OverlapPolicy", buildOverlapPolicy)},
+	{"worker_selector", applyWorkerSelector},
+	dagField("timeout", buildTimeout, func(out *core.DAG, v time.Duration) { out.Timeout = v }),
+	dagField("delay", buildDelay, func(out *core.DAG, v time.Duration) { out.Delay = v }),
+	dagField("restart_wait", buildRestartWait, func(out *core.DAG, v time.Duration) { out.RestartWait = v }),
+	dagField("max_active_runs", buildMaxActiveRuns, func(out *core.DAG, v int) { out.MaxActiveRuns = v }),
+	dagField("max_active_steps", buildMaxActiveSteps, func(out *core.DAG, v int) { out.MaxActiveSteps = v }),
+	dagField("queue", buildQueue, func(out *core.DAG, v string) { out.Queue = v }),
+	dagField("retry_policy", buildDAGRetryPolicy, func(out *core.DAG, v *core.DAGRetryPolicy) { out.RetryPolicy = v }),
+	dagField("max_output_size", buildMaxOutputSize, func(out *core.DAG, v int) { out.MaxOutputSize = v }),
+	dagField("skip_if_successful", buildSkipIfSuccessful, func(out *core.DAG, v bool) { out.SkipIfSuccessful = v }),
+	dagField("catchup_window", buildCatchupWindow, func(out *core.DAG, v time.Duration) { out.CatchupWindow = v }),
+	dagField("overlap_policy", buildOverlapPolicy, func(out *core.DAG, v core.OverlapPolicy) { out.OverlapPolicy = v }),
 }
 
 var metadataTransformStages = []transformStage{
@@ -584,53 +571,53 @@ var metadataTransformStages = []transformStage{
 
 // Full stages are only run when building the full DAG (not metadata-only).
 var fullRunOutputStage = transformStage{
-	{"log_dir", newTransformer("LogDir", buildLogDir)},
-	{"artifacts", newTransformer("Artifacts", buildArtifacts)},
-	{"log_output", newTransformer("LogOutput", buildLogOutput)},
+	dagField("log_dir", buildLogDir, func(out *core.DAG, v string) { out.LogDir = v }),
+	dagField("artifacts", buildArtifacts, func(out *core.DAG, v *core.ArtifactsConfig) { out.Artifacts = v }),
+	dagField("log_output", buildLogOutput, func(out *core.DAG, v core.LogOutputMode) { out.LogOutput = v }),
 }
 
 var fullInteractionStage = transformStage{
-	{"mail_on", newTransformer("MailOn", buildMailOn)},
-	{"run_config", newTransformer("RunConfig", buildRunConfig)},
-	{"resources", newTransformer("Resources", buildResources)},
-	{"webhook", newTransformer("Webhook", buildWebhookConfig)},
+	dagField("mail_on", buildMailOn, func(out *core.DAG, v *core.MailOn) { out.MailOn = v }),
+	dagField("run_config", buildRunConfig, func(out *core.DAG, v *core.RunConfig) { out.RunConfig = v }),
+	dagField("resources", buildResources, func(out *core.DAG, v *core.Resources) { out.Resources = v }),
+	dagField("webhook", buildWebhookConfig, func(out *core.DAG, v *core.WebhookConfig) { out.Webhook = v }),
 }
 
 var fullRetentionStage = transformStage{
-	{"hist_retention_days", newTransformer("HistRetentionDays", buildHistRetentionDays)},
-	{"hist_retention_runs", newTransformer("HistRetentionRuns", buildHistRetentionRuns)},
-	{"max_clean_up_time_sec", newTransformer("MaxCleanUpTime", buildMaxCleanUpTime)},
+	dagField("hist_retention_days", buildHistRetentionDays, func(out *core.DAG, v int) { out.HistRetentionDays = v }),
+	dagField("hist_retention_runs", buildHistRetentionRuns, func(out *core.DAG, v int) { out.HistRetentionRuns = v }),
+	dagField("max_clean_up_time_sec", buildMaxCleanUpTime, func(out *core.DAG, v time.Duration) { out.MaxCleanUpTime = v }),
 }
 
 var fullExecutionDefaultsStage = transformStage{
-	{"shell", newTransformer("Shell", buildShell)},
-	{"shell_args", newTransformer("ShellArgs", buildShellArgs)},
-	{"working_dir", newTransformer("WorkingDir", buildWorkingDir)},
-	{"container", newTransformer("Container", buildContainer)},
-	{"registry_auths", newTransformer("RegistryAuths", buildRegistryAuths)},
-	{"ssh", newTransformer("SSH", buildSSH)},
-	{"s3", newTransformer("S3", buildS3)},
-	{"llm", newTransformer("LLM", buildLLM)},
-	{"redis", newTransformer("Redis", buildRedis)},
-	{"harnesses", newTransformer("Harnesses", buildHarnesses)},
-	{"harness", newTransformer("Harness", buildHarness)},
-	{"kubernetes", newTransformer("Kubernetes", buildKubernetes)},
-	{"secrets", newTransformer("Secrets", buildSecrets)},
-	{"tools", newTransformer("Tools", buildTools)},
-	{"dotenv", newTransformer("Dotenv", buildDotenv)},
+	dagField("shell", buildShell, func(out *core.DAG, v string) { out.Shell = v }),
+	dagField("shell_args", buildShellArgs, func(out *core.DAG, v []string) { out.ShellArgs = v }),
+	dagField("working_dir", buildWorkingDir, func(out *core.DAG, v string) { out.WorkingDir = v }),
+	dagField("container", buildContainer, func(out *core.DAG, v *core.Container) { out.Container = v }),
+	dagField("registry_auths", buildRegistryAuths, func(out *core.DAG, v map[string]*core.AuthConfig) { out.RegistryAuths = v }),
+	dagField("ssh", buildSSH, func(out *core.DAG, v *core.SSHConfig) { out.SSH = v }),
+	dagField("s3", buildS3, func(out *core.DAG, v *core.S3Config) { out.S3 = v }),
+	dagField("llm", buildLLM, func(out *core.DAG, v *core.LLMConfig) { out.LLM = v }),
+	dagField("redis", buildRedis, func(out *core.DAG, v *core.RedisConfig) { out.Redis = v }),
+	dagField("harnesses", buildHarnesses, func(out *core.DAG, v core.HarnessDefinitions) { out.Harnesses = v }),
+	dagField("harness", buildHarness, func(out *core.DAG, v *core.HarnessConfig) { out.Harness = v }),
+	dagField("kubernetes", buildKubernetes, func(out *core.DAG, v core.KubernetesConfig) { out.Kubernetes = v }),
+	dagField("secrets", buildSecrets, func(out *core.DAG, v []core.SecretRef) { out.Secrets = v }),
+	dagField("tools", buildTools, func(out *core.DAG, v *core.ToolConfig) { out.Tools = v }),
+	dagField("dotenv", buildDotenv, func(out *core.DAG, v []string) { out.Dotenv = v }),
 }
 
 var fullNotificationStage = transformStage{
-	{"smtp", newTransformer("SMTP", buildSMTPConfig)},
-	{"error_mail", newTransformer("ErrorMail", buildErrMailConfig)},
-	{"info_mail", newTransformer("InfoMail", buildInfoMailConfig)},
-	{"wait_mail", newTransformer("WaitMail", buildWaitMailConfig)},
-	{"preconditions", newTransformer("Preconditions", buildPreconditions)},
-	{"otel", newTransformer("OTel", buildOTel)},
+	dagField("smtp", buildSMTPConfig, func(out *core.DAG, v *core.SMTPConfig) { out.SMTP = v }),
+	dagField("error_mail", buildErrMailConfig, func(out *core.DAG, v *core.MailConfig) { out.ErrorMail = v }),
+	dagField("info_mail", buildInfoMailConfig, func(out *core.DAG, v *core.MailConfig) { out.InfoMail = v }),
+	dagField("wait_mail", buildWaitMailConfig, func(out *core.DAG, v *core.MailConfig) { out.WaitMail = v }),
+	dagField("preconditions", buildPreconditions, func(out *core.DAG, v []*core.Condition) { out.Preconditions = v }),
+	dagField("otel", buildOTel, func(out *core.DAG, v *core.OTelConfig) { out.OTel = v }),
 }
 
 var fullControllerStage = transformStage{
-	{"tasks", newTransformer("Tasks", buildTasks)},
+	dagField("tasks", buildTasks, func(out *core.DAG, v []core.ControllerTask) { out.Tasks = v }),
 }
 
 var fullTransformStages = []transformStage{
@@ -645,23 +632,22 @@ var fullTransformStages = []transformStage{
 // runTransformers executes all transformers in the pipeline
 func runTransformers(ctx buildContext, spec *dag, result *core.DAG) core.ErrorList {
 	var errs core.ErrorList
-	out := reflect.ValueOf(result).Elem()
 
-	errs = append(errs, runTransformerStages(ctx, spec, out, metadataTransformStages)...)
+	errs = append(errs, runTransformerStages(ctx, spec, result, metadataTransformStages)...)
 
 	// Run full transformers only when not in metadata-only mode
 	if !ctx.opts.Has(buildFlagOnlyMetadata) {
-		errs = append(errs, runTransformerStages(ctx, spec, out, fullTransformStages)...)
+		errs = append(errs, runTransformerStages(ctx, spec, result, fullTransformStages)...)
 	}
 
 	return errs
 }
 
-func runTransformerStages(ctx buildContext, spec *dag, out reflect.Value, stages []transformStage) core.ErrorList {
+func runTransformerStages(ctx buildContext, spec *dag, out *core.DAG, stages []transformStage) core.ErrorList {
 	var errs core.ErrorList
 	for _, stage := range stages {
 		for _, t := range stage {
-			if err := t.transformer.Transform(ctx, spec, out); err != nil {
+			if err := t.apply(ctx, spec, out); err != nil {
 				errs = append(errs, wrapTransformError(t.name, err))
 			}
 		}
@@ -1887,27 +1873,19 @@ func parseParamsInternal(ctx buildContext, d *dag) (*paramsResult, error) {
 	return result, err
 }
 
-// workerSelectorTransformer is a custom transformer that sets both WorkerSelector and ForceLocal fields.
-type workerSelectorTransformer struct{}
-
-func (t *workerSelectorTransformer) Transform(ctx buildContext, in *dag, out reflect.Value) error {
+// applyWorkerSelector sets both WorkerSelector and ForceLocal, leaving each
+// field untouched when the spec does not select a value for it.
+func applyWorkerSelector(ctx buildContext, in *dag, out *core.DAG) error {
 	ws, forceLocal, err := buildWorkerSelector(ctx, in)
 	if err != nil {
 		return err
 	}
 
 	if ws != nil {
-		wsField := out.FieldByName("WorkerSelector")
-		if wsField.IsValid() && wsField.CanSet() {
-			wsField.Set(reflect.ValueOf(ws))
-		}
+		out.WorkerSelector = ws
 	}
-
 	if forceLocal {
-		flField := out.FieldByName("ForceLocal")
-		if flField.IsValid() && flField.CanSet() {
-			flField.SetBool(true)
-		}
+		out.ForceLocal = true
 	}
 
 	return nil

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -1145,19 +1145,168 @@ func dagUsesBuiltinArtifactAction(d *dag) bool {
 	if d == nil {
 		return false
 	}
-	return valueUsesBuiltinArtifactAction(reflect.ValueOf(d.Steps)) ||
-		valueUsesBuiltinArtifactAction(reflect.ValueOf(d.HandlerOn)) ||
+	return artifactActionInStepContainer(reflect.ValueOf(d.Steps)) ||
+		artifactActionInStepContainer(reflect.ValueOf(d.HandlerOn)) ||
 		customStepSpecsUseBuiltinArtifactAction(d.StepTypes) ||
 		customStepSpecsUseBuiltinArtifactAction(d.Actions)
 }
 
 func customStepSpecsUseBuiltinArtifactAction(specs map[string]customStepTypeSpec) bool {
 	for _, spec := range specs {
-		if valueUsesBuiltinArtifactAction(reflect.ValueOf(spec.Template)) {
+		// A template is a single step declaration.
+		if artifactActionInStep(reflect.ValueOf(spec.Template)) {
 			return true
 		}
 	}
 	return false
+}
+
+// artifactActionInStepContainer searches a value holding step declarations. In
+// map form the keys name the steps, so they are not field names and carry no
+// meaning for this search.
+func artifactActionInStepContainer(v reflect.Value) bool {
+	v, ok := derefForSearch(v)
+	if !ok {
+		return false
+	}
+
+	if v.Kind() == reflect.Map {
+		iter := v.MapRange()
+		for iter.Next() {
+			if artifactActionInStep(iter.Value()) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		for i := range v.Len() {
+			item, ok := derefForSearch(v.Index(i))
+			if !ok {
+				continue
+			}
+			// A nested list declares steps that run at one position.
+			if item.Kind() == reflect.Slice || item.Kind() == reflect.Array {
+				if artifactActionInStepContainer(item) {
+					return true
+				}
+				continue
+			}
+			if artifactActionInStep(item) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// A struct groups steps by role, as the handlers do.
+	if v.Kind() == reflect.Struct {
+		t := v.Type()
+		for i := range v.NumField() {
+			if t.Field(i).PkgPath != "" {
+				continue
+			}
+			if artifactActionInStep(v.Field(i)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// artifactActionInStep searches one step declaration. Within a step every
+// params entry is a payload handed to a child DAG rather than step syntax,
+// and a steps entry opens a nested container whose keys name steps again.
+func artifactActionInStep(v reflect.Value) bool {
+	v, ok := derefForSearch(v)
+	if !ok {
+		return false
+	}
+
+	if v.Kind() == reflect.Map {
+		iter := v.MapRange()
+		for iter.Next() {
+			key, value := iter.Key(), iter.Value()
+			if key.Kind() != reflect.String {
+				if artifactActionInStep(value) {
+					return true
+				}
+				continue
+			}
+			switch key.String() {
+			case "params":
+				continue
+			case "steps":
+				if artifactActionInStepContainer(value) {
+					return true
+				}
+				continue
+			case "action":
+				if action, ok := reflectString(value); ok && strings.HasPrefix(action, "artifact.") {
+					return true
+				}
+			}
+			if artifactActionInStep(value) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		for i := range v.Len() {
+			if artifactActionInStep(v.Index(i)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if v.Kind() == reflect.Struct {
+		t := v.Type()
+		for i := range v.NumField() {
+			fieldInfo := t.Field(i)
+			if fieldInfo.PkgPath != "" {
+				continue
+			}
+			field := v.Field(i)
+			switch fieldInfo.Name {
+			case "Params":
+				continue
+			case "Steps":
+				if artifactActionInStepContainer(field) {
+					return true
+				}
+				continue
+			case "Action":
+				if action, ok := reflectString(field); ok && strings.HasPrefix(action, "artifact.") {
+					return true
+				}
+			}
+			if artifactActionInStep(field) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// derefForSearch unwraps pointers and interfaces, reporting false when the
+// value is absent.
+func derefForSearch(v reflect.Value) (reflect.Value, bool) {
+	if !v.IsValid() {
+		return v, false
+	}
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return v, false
+		}
+		v = v.Elem()
+	}
+	return v, true
 }
 
 func dagUsesArtifactOutput(d *dag) bool {
@@ -1289,18 +1438,6 @@ var runArtifactsDirVisitor = specVisitor{
 	matchString:          referencesArtifactsEnvVar,
 }
 
-// builtinArtifactActionVisitor finds a step declaring a builtin artifact
-// action.
-var builtinArtifactActionVisitor = specVisitor{
-	matchNamed: func(name string, value reflect.Value) bool {
-		if name != "action" && name != "Action" {
-			return false
-		}
-		action, ok := reflectString(value)
-		return ok && strings.HasPrefix(action, "artifact.")
-	},
-}
-
 // artifactOutputVisitor finds a step redirecting an output stream to an
 // artifact.
 var artifactOutputVisitor = specVisitor{
@@ -1311,10 +1448,6 @@ var artifactOutputVisitor = specVisitor{
 
 func valueReferencesRunArtifactsDir(v reflect.Value) bool {
 	return runArtifactsDirVisitor.visit(v)
-}
-
-func valueUsesBuiltinArtifactAction(v reflect.Value) bool {
-	return builtinArtifactActionVisitor.visit(v)
 }
 
 func valueUsesArtifactOutput(v reflect.Value) bool {

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -3165,121 +3165,152 @@ func buildSteps(ctx buildContext, d *dag, result *core.DAG) ([]core.Step, error)
 		return nil, nil
 
 	case []any:
-		normalized := normalizeStepData(ctx, v)
-
-		var builtSteps []*core.Step
-		var prevSteps []*core.Step
-		for i, raw := range normalized {
-			switch v := raw.(type) {
-			case map[string]any:
-				st, err := buildStepFromRaw(buildCtx, i, v, names, defs)
-				if err != nil {
-					return nil, err
-				}
-
-				if err := validateNoDependsForChainType(result, st); err != nil {
-					return nil, err
-				}
-
-				if err := validateNoRouterForChainType(result, st); err != nil {
-					return nil, err
-				}
-
-				injectChainDependencies(result, prevSteps, st)
-				builtSteps = append(builtSteps, st)
-				prevSteps = []*core.Step{st}
-
-			case []any:
-				var tempSteps []*core.Step
-				var normalizedNested = normalizeStepData(ctx, v)
-				for _, nested := range normalizedNested {
-					switch vv := nested.(type) {
-					case map[string]any:
-						st, err := buildStepFromRaw(buildCtx, i, vv, names, defs)
-						if err != nil {
-							return nil, err
-						}
-
-						if err := validateNoDependsForChainType(result, st); err != nil {
-							return nil, err
-						}
-
-						if err := validateNoRouterForChainType(result, st); err != nil {
-							return nil, err
-						}
-
-						injectChainDependencies(result, prevSteps, st)
-						builtSteps = append(builtSteps, st)
-						tempSteps = append(tempSteps, st)
-
-					default:
-						return nil, core.NewValidationError("steps", raw, ErrInvalidStepData)
-					}
-				}
-				prevSteps = tempSteps
-
-			default:
-				return nil, core.NewValidationError("steps", raw, ErrInvalidStepData)
-			}
-		}
-
-		var steps []core.Step
-		for _, st := range builtSteps {
-			steps = append(steps, *st)
-		}
-		// Transform router steps: inject preconditions into targets
-		if err := transformRouterSteps(steps); err != nil {
+		steps, err := buildStepsFromArray(buildCtx, ctx, v, result, names, defs)
+		if err != nil {
 			return nil, err
 		}
-		return steps, nil
+		return finishBuiltSteps(steps)
 
 	case map[string]any:
-		stepsMap := make(map[string]step)
-		md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-			ErrorUnused: true,
-			Result:      &stepsMap,
-			DecodeHook:  TypedUnionDecodeHook(),
-		})
-		if err := md.Decode(v); err != nil {
-			return nil, core.NewValidationError("steps", v, err)
-		}
-
-		var steps []core.Step
-		for name, st := range stepsMap {
-			rawStep, _ := v[name].(map[string]any)
-			if err := validateHarnessPromptCommand(buildCtx, rawStep); err != nil {
-				return nil, err
-			}
-			builtStep, err := buildStepFromSpec(buildCtx, 0, &st, rawStep, names, defs, name)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := validateNoDependsForChainType(result, builtStep); err != nil {
-				return nil, err
-			}
-
-			if err := validateNoRouterForChainType(result, builtStep); err != nil {
-				return nil, err
-			}
-
-			steps = append(steps, *builtStep)
-		}
-		// Sort steps by name for deterministic output when built from a map.
-		// Go map iteration is non-deterministic, which causes the SSE watcher's
-		// JSON hash to change on every poll, triggering unnecessary broadcasts.
-		slices.SortFunc(steps, func(a, b core.Step) int {
-			return strings.Compare(a.Name, b.Name)
-		})
-		// Transform router steps: inject preconditions into targets
-		if err := transformRouterSteps(steps); err != nil {
+		steps, err := buildStepsFromMap(buildCtx, v, result, names, defs)
+		if err != nil {
 			return nil, err
 		}
-		return steps, nil
+		return finishBuiltSteps(steps)
 
 	default:
 		return nil, core.NewValidationError("steps", v, ErrStepsMustBeArrayOrMap)
 	}
+}
+
+// validateBuiltStepForDAG applies the post-build rules a step must satisfy
+// whichever syntax declared it.
+func validateBuiltStepForDAG(result *core.DAG, st *core.Step) error {
+	if err := validateNoDependsForChainType(result, st); err != nil {
+		return err
+	}
+	return validateNoRouterForChainType(result, st)
+}
+
+// finishBuiltSteps applies the transformations that close out a step list.
+func finishBuiltSteps(steps []core.Step) ([]core.Step, error) {
+	// Transform router steps: inject preconditions into targets
+	if err := transformRouterSteps(steps); err != nil {
+		return nil, err
+	}
+	return steps, nil
+}
+
+// buildStepsFromArray builds the array syntax, in which each entry is either a
+// single step or a nested array whose steps share the previous entry as their
+// chain dependency.
+func buildStepsFromArray(
+	buildCtx stepBuildContext,
+	ctx buildContext,
+	entries []any,
+	result *core.DAG,
+	names map[string]struct{},
+	defs *defaults,
+) ([]core.Step, error) {
+	var builtSteps []*core.Step
+	var prevSteps []*core.Step
+
+	for i, raw := range normalizeStepData(ctx, entries) {
+		group, err := stepGroupFromRaw(ctx, raw)
+		if err != nil {
+			return nil, err
+		}
+
+		var current []*core.Step
+		for _, item := range group {
+			st, err := buildStepFromRaw(buildCtx, i, item, names, defs)
+			if err != nil {
+				return nil, err
+			}
+			if err := validateBuiltStepForDAG(result, st); err != nil {
+				return nil, err
+			}
+
+			injectChainDependencies(result, prevSteps, st)
+			builtSteps = append(builtSteps, st)
+			current = append(current, st)
+		}
+		prevSteps = current
+	}
+
+	var steps []core.Step
+	for _, st := range builtSteps {
+		steps = append(steps, *st)
+	}
+	return steps, nil
+}
+
+// stepGroupFromRaw returns the raw steps declared at one position of the steps
+// array. A nested array yields every step it declares.
+func stepGroupFromRaw(ctx buildContext, raw any) ([]map[string]any, error) {
+	switch v := raw.(type) {
+	case map[string]any:
+		return []map[string]any{v}, nil
+
+	case []any:
+		nested := normalizeStepData(ctx, v)
+		group := make([]map[string]any, 0, len(nested))
+		for _, item := range nested {
+			step, ok := item.(map[string]any)
+			if !ok {
+				return nil, core.NewValidationError("steps", raw, ErrInvalidStepData)
+			}
+			group = append(group, step)
+		}
+		return group, nil
+
+	default:
+		return nil, core.NewValidationError("steps", raw, ErrInvalidStepData)
+	}
+}
+
+// buildStepsFromMap builds the map syntax, in which each key names its step.
+func buildStepsFromMap(
+	buildCtx stepBuildContext,
+	entries map[string]any,
+	result *core.DAG,
+	names map[string]struct{},
+	defs *defaults,
+) ([]core.Step, error) {
+	stepsMap := make(map[string]step)
+	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      &stepsMap,
+		DecodeHook:  typedUnionDecodeHook(),
+	})
+	if err := md.Decode(entries); err != nil {
+		return nil, core.NewValidationError("steps", entries, err)
+	}
+
+	var steps []core.Step
+	for name, st := range stepsMap {
+		rawStep, _ := entries[name].(map[string]any)
+		if err := validateHarnessPromptCommand(buildCtx, rawStep); err != nil {
+			return nil, err
+		}
+		builtStep, err := buildStepFromSpec(buildCtx, 0, &st, rawStep, names, defs, name)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateBuiltStepForDAG(result, builtStep); err != nil {
+			return nil, err
+		}
+
+		steps = append(steps, *builtStep)
+	}
+
+	// Sort steps by name for deterministic output when built from a map.
+	// Go map iteration is non-deterministic, which causes the SSE watcher's
+	// JSON hash to change on every poll, triggering unnecessary broadcasts.
+	slices.SortFunc(steps, func(a, b core.Step) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return steps, nil
 }
 
 // buildMailConfigInternal builds a core.MailConfig from the mail configuration.

--- a/internal/core/spec/dag_test.go
+++ b/internal/core/spec/dag_test.go
@@ -18,16 +18,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testBuildContext creates a BuildContext for testing
-func testBuildContext() BuildContext {
-	return BuildContext{
+// testBuildContext creates a buildContext for testing
+func testBuildContext() buildContext {
+	return buildContext{
 		file:  "/test/dag.yaml",
-		opts:  BuildOpts{},
+		opts:  buildOpts{},
 		index: 0,
 	}
 }
 
-func testBuildContextWithOpts(opts BuildOpts) BuildContext {
+func testBuildContextWithOpts(opts buildOpts) buildContext {
 	ctx := testBuildContext()
 	ctx.opts = opts
 	return ctx
@@ -40,12 +40,12 @@ func TestBuildContextWithOpts_InvalidatesParamsState(t *testing.T) {
 		cached: true,
 		result: &paramsResult{Params: []string{"name=old"}},
 	}
-	ctx := BuildContext{
-		opts:        BuildOpts{Parameters: "name=old"},
+	ctx := buildContext{
+		opts:        buildOpts{Parameters: "name=old"},
 		paramsState: cached,
 	}
 
-	next := ctx.WithOpts(BuildOpts{Parameters: "name=new"})
+	next := ctx.WithOpts(buildOpts{Parameters: "name=new"})
 
 	require.Nil(t, next.paramsState)
 	require.Same(t, cached, ctx.paramsState)
@@ -405,7 +405,7 @@ func TestBuildParamsJSON(t *testing.T) {
 
 	tests := []struct {
 		name string
-		ctx  BuildContext
+		ctx  buildContext
 		dag  *dag
 		want string
 	}{
@@ -417,13 +417,13 @@ func TestBuildParamsJSON(t *testing.T) {
 		},
 		{
 			name: "OverridesMergedAndSerialized",
-			ctx:  testBuildContextWithOpts(BuildOpts{Parameters: "FOO=baz COUNT=2"}),
+			ctx:  testBuildContextWithOpts(buildOpts{Parameters: "FOO=baz COUNT=2"}),
 			dag:  &dag{Params: "FOO=bar COUNT=1"},
 			want: `{"FOO":"baz","COUNT":"2"}`,
 		},
 		{
 			name: "PreservesRawJSONInput",
-			ctx:  testBuildContextWithOpts(BuildOpts{Parameters: `{"alpha":"one","beta":2}`}),
+			ctx:  testBuildContextWithOpts(buildOpts{Parameters: `{"alpha":"one","beta":2}`}),
 			dag:  &dag{},
 			want: `{"alpha":"one","beta":2}`,
 		},
@@ -454,9 +454,9 @@ func TestBuildParamsJSON(t *testing.T) {
 func TestBuildParamsJSON_JSONOverrideSkipsEval(t *testing.T) {
 	t.Parallel()
 
-	// JSON-formatted override params should skip eval (BuildFlagNoEval).
+	// JSON-formatted override params should skip eval (buildFlagNoEval).
 	// Values containing backticks should NOT be executed.
-	ctx := testBuildContextWithOpts(BuildOpts{
+	ctx := testBuildContextWithOpts(buildOpts{
 		Parameters: `[{"topic":"` + "`echo pwned`" + `"}]`,
 	})
 	d := &dag{Params: `topic="default"`}
@@ -531,7 +531,7 @@ func TestBuildName(t *testing.T) {
 	tests := []struct {
 		name     string
 		dag      *dag
-		ctx      BuildContext
+		ctx      buildContext
 		expected string
 	}{
 		{
@@ -543,9 +543,9 @@ func TestBuildName(t *testing.T) {
 		{
 			name: "FromOptionsNameOverridesDAGName",
 			dag:  &dag{Name: "dag-name"},
-			ctx: BuildContext{
+			ctx: buildContext{
 				file:  "/test/dag.yaml",
-				opts:  BuildOpts{Name: "override-name"},
+				opts:  buildOpts{Name: "override-name"},
 				index: 0,
 			},
 			expected: "override-name",
@@ -553,13 +553,13 @@ func TestBuildName(t *testing.T) {
 		{
 			name:     "FallbackToFilenameForIndex0",
 			dag:      &dag{},
-			ctx:      BuildContext{file: "/path/to/my-workflow.yaml", index: 0},
+			ctx:      buildContext{file: "/path/to/my-workflow.yaml", index: 0},
 			expected: "my-workflow",
 		},
 		{
 			name:     "NoFallbackForIndexGreaterThan0",
 			dag:      &dag{},
-			ctx:      BuildContext{file: "/path/to/my-workflow.yaml", index: 1},
+			ctx:      buildContext{file: "/path/to/my-workflow.yaml", index: 1},
 			expected: "",
 		},
 	}
@@ -1953,9 +1953,9 @@ func TestBuildRegistryAuths_NoExpansion(t *testing.T) {
 func TestBuildRegistryAuths_NoEval(t *testing.T) {
 	t.Setenv("TEST_USER", "testuser")
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		file: "/test/dag.yaml",
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	d := &dag{
@@ -1984,7 +1984,7 @@ func TestBuildWorkingDir(t *testing.T) {
 	tests := []struct {
 		name     string
 		dag      *dag
-		ctx      BuildContext
+		ctx      buildContext
 		expected string
 	}{
 		{
@@ -1996,22 +1996,22 @@ func TestBuildWorkingDir(t *testing.T) {
 		{
 			name:     "EmptyWhenNoExplicitValue",
 			dag:      &dag{},
-			ctx:      BuildContext{file: "/path/to/dag.yaml"},
+			ctx:      buildContext{file: "/path/to/dag.yaml"},
 			expected: "",
 		},
 		{
 			name: "FromOptionsDefault",
 			dag:  &dag{},
-			ctx: BuildContext{
+			ctx: buildContext{
 				file: "",
-				opts: BuildOpts{DefaultWorkingDir: "/default/dir"},
+				opts: buildOpts{DefaultWorkingDir: "/default/dir"},
 			},
 			expected: "/default/dir",
 		},
 		{
 			name:     "EmptyWithNoFileOrDefault",
 			dag:      &dag{},
-			ctx:      BuildContext{},
+			ctx:      buildContext{},
 			expected: "",
 		},
 	}
@@ -2030,7 +2030,7 @@ func TestBuildWorkingDir_Relative(t *testing.T) {
 	tmpDir := t.TempDir()
 	dagFile := filepath.Join(tmpDir, "dag.yaml")
 
-	ctx := BuildContext{file: dagFile}
+	ctx := buildContext{file: dagFile}
 	d := &dag{WorkingDir: "subdir"}
 
 	result, err := buildWorkingDir(ctx, d)
@@ -2045,7 +2045,7 @@ func TestBuildWorkingDir_RelativeToAuthoredFile(t *testing.T) {
 	authored := filepath.Join(t.TempDir(), "workflows", "pipeline.yaml")
 	copied := filepath.Join(t.TempDir(), "local-dags", "child-1234.yaml")
 
-	ctx := BuildContext{file: copied, opts: BuildOpts{SourceFile: authored}}
+	ctx := buildContext{file: copied, opts: buildOpts{SourceFile: authored}}
 	d := &dag{WorkingDir: "checkout"}
 
 	result, err := buildWorkingDir(ctx, d)
@@ -2070,9 +2070,9 @@ func TestBuildWorkingDir_NoExpansion(t *testing.T) {
 func TestBuildWorkingDir_NoEval(t *testing.T) {
 	t.Setenv("TEST_PATH", "/expanded/path")
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		file: "/test/dag.yaml",
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 	d := &dag{WorkingDir: "$TEST_PATH/subdir"}
 
@@ -2098,8 +2098,8 @@ func TestBuildWorkingDir_TildePreserved(t *testing.T) {
 func TestBuildWorkingDir_DefaultWorkingDir(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
-		opts: BuildOpts{DefaultWorkingDir: "/default/work/dir"},
+	ctx := buildContext{
+		opts: buildOpts{DefaultWorkingDir: "/default/work/dir"},
 	}
 	d := &dag{} // No WorkingDir specified
 
@@ -2113,7 +2113,7 @@ func TestBuildWorkingDir_RelativeNoFileContext(t *testing.T) {
 
 	// Relative path without file context is stored as-is
 	// (no file context means we can't resolve the relative path at build time)
-	ctx := BuildContext{} // No file
+	ctx := buildContext{} // No file
 	d := &dag{WorkingDir: "subdir"}
 
 	result, err := buildWorkingDir(ctx, d)
@@ -2209,9 +2209,9 @@ func TestBuildShell_ArrayFormNoEval(t *testing.T) {
 	// With NoEval, env var references should be preserved as-is
 	d := &dag{Shell: shellValueArray([]string{"$SHELL_CMD", "$SHELL_ARG", "-x"})}
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		file: "/test/dag.yaml",
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 	shell, err := buildShell(ctx, d)
 	require.NoError(t, err)

--- a/internal/core/spec/defaults.go
+++ b/internal/core/spec/defaults.go
@@ -35,7 +35,7 @@ func decodeDefaults(raw any) (*defaults, error) {
 		ErrorUnused: true,
 		Result:      d,
 		TagName:     "yaml",
-		DecodeHook:  TypedUnionDecodeHook(),
+		DecodeHook:  typedUnionDecodeHook(),
 	})
 	if err != nil {
 		return nil, core.NewValidationError("defaults", raw, err)

--- a/internal/core/spec/dparams.go
+++ b/internal/core/spec/dparams.go
@@ -38,7 +38,7 @@ type dagParamEntry struct {
 	Eval     string
 }
 
-func buildDAGParamsResult(ctx BuildContext, d *dag) (*paramsResult, error) {
+func buildDAGParamsResult(ctx buildContext, d *dag) (*paramsResult, error) {
 	plan, err := buildDAGParamPlan(ctx, d)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func buildDAGParamsResult(ctx BuildContext, d *dag) (*paramsResult, error) {
 			// Eval-backed inline params may depend on mutable state or perform command
 			// execution, so reuse the execution-time resolution instead of running
 			// the same expressions again just to populate DefaultParams.
-			if paramPlanHasEval(plan) && !ctx.opts.Has(BuildFlagNoEval) {
+			if paramPlanHasEval(plan) && !ctx.opts.Has(buildFlagNoEval) {
 				defaultPairs = finalPairs
 				break
 			}
@@ -143,8 +143,8 @@ func buildDAGParamsResult(ctx BuildContext, d *dag) (*paramsResult, error) {
 	}, nil
 }
 
-func shouldResolveRuntimeParams(ctx BuildContext) bool {
-	return ctx.opts.Has(BuildFlagValidateRuntimeParams) || ctx.opts.Parameters != "" || len(ctx.opts.ParametersList) > 0
+func shouldResolveRuntimeParams(ctx buildContext) bool {
+	return ctx.opts.Has(buildFlagValidateRuntimeParams) || ctx.opts.Parameters != "" || len(ctx.opts.ParametersList) > 0
 }
 
 func finalizeDAGParamPlan(plan *dagParamPlan) error {
@@ -199,9 +199,9 @@ func paramPlanHasEval(plan *dagParamPlan) bool {
 	return false
 }
 
-func buildDAGParamPlan(ctx BuildContext, d *dag) (*dagParamPlan, error) {
+func buildDAGParamPlan(ctx buildContext, d *dag) (*dagParamPlan, error) {
 	if _, ok := extractParamsSchemaDeclaration(d.Params); ok {
-		if ctx.opts.Has(BuildFlagSkipSchemaValidation) {
+		if ctx.opts.Has(buildFlagSkipSchemaValidation) {
 			return buildLegacyParamPlan(extractSchemaValues(d.Params))
 		}
 		return buildExternalSchemaParamPlan(d.Params, d.WorkingDir, ctx.file)
@@ -210,13 +210,13 @@ func buildDAGParamPlan(ctx BuildContext, d *dag) (*dagParamPlan, error) {
 		return nil, err
 	}
 	if isInlineJSONSchema(d.Params) {
-		return buildInlineSchemaParamPlan(d.Params, ctx.opts.Has(BuildFlagSkipSchemaValidation))
+		return buildInlineSchemaParamPlan(d.Params, ctx.opts.Has(buildFlagSkipSchemaValidation))
 	}
 	return buildLegacyParamPlan(d.Params)
 }
 
 func buildLegacyParamPlan(input any) (*dagParamPlan, error) {
-	noEvalCtx := BuildContext{opts: BuildOpts{Flags: BuildFlagNoEval}}
+	noEvalCtx := buildContext{opts: buildOpts{Flags: buildFlagNoEval}}
 	plan := &dagParamPlan{kind: dagParamKindLegacy}
 	seenNames := map[string]struct{}{}
 
@@ -330,7 +330,7 @@ func buildExternalSchemaParamPlan(input any, workingDir, dagLocation string) (*d
 	}
 
 	values := extractSchemaValues(input)
-	noEvalCtx := BuildContext{opts: BuildOpts{Flags: BuildFlagNoEval}}
+	noEvalCtx := buildContext{opts: buildOpts{Flags: buildFlagNoEval}}
 	basePairs, err := parseParamValue(noEvalCtx, values)
 	if err != nil {
 		return nil, core.NewValidationError("params", values, fmt.Errorf("%w: %s", ErrInvalidParamValue, err))

--- a/internal/core/spec/dparams_runtime.go
+++ b/internal/core/spec/dparams_runtime.go
@@ -120,7 +120,7 @@ func parseRuntimeLegacyOverrideInput(value any) ([]paramPair, error) {
 	return pairs, nil
 }
 
-func resolveLegacyEntries(ctx BuildContext, plan *dagParamPlan, rawParams string, paramsList []string, metadataMode bool) ([]dagParamEntry, error) {
+func resolveLegacyEntries(ctx buildContext, plan *dagParamPlan, rawParams string, paramsList []string, metadataMode bool) ([]dagParamEntry, error) {
 	overridePairs, err := parseOverridePairs(rawParams, paramsList)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func resolveLegacyEntries(ctx BuildContext, plan *dagParamPlan, rawParams string
 }
 
 func parseOverridePairs(rawParams string, paramsList []string) ([]paramPair, error) {
-	noEvalCtx := BuildContext{opts: BuildOpts{Flags: BuildFlagNoEval}}
+	noEvalCtx := buildContext{opts: buildOpts{Flags: buildFlagNoEval}}
 	var pairs []paramPair
 	if rawParams != "" {
 		parsed, err := parseParamValue(noEvalCtx, rawParams)
@@ -388,7 +388,7 @@ func runtimePairsFromEntries(entries []dagParamEntry) []paramPair {
 	return pairs
 }
 
-func buildParamEvalScope(ctx BuildContext) *cmnvalue.EnvScope {
+func buildParamEvalScope(ctx buildContext) *cmnvalue.EnvScope {
 	if ctx.envScope != nil && ctx.envScope.scope != nil {
 		return ctx.envScope.scope
 	}
@@ -401,7 +401,7 @@ func buildParamEvalScope(ctx BuildContext) *cmnvalue.EnvScope {
 }
 
 func resolveLegacyEntry(
-	ctx BuildContext,
+	ctx buildContext,
 	entry *dagParamEntry,
 	base dagParamEntry,
 	overridden bool,
@@ -410,7 +410,7 @@ func resolveLegacyEntry(
 	paramDeclarations cmnvalue.Values,
 	index int,
 ) error {
-	if overridden || strings.TrimSpace(base.Eval) == "" || ctx.opts.Has(BuildFlagNoEval) {
+	if overridden || strings.TrimSpace(base.Eval) == "" || ctx.opts.Has(buildFlagNoEval) {
 		addEntryToParamScope(scope, *entry, index)
 		addEntryToParamValues(params, *entry)
 		return nil

--- a/internal/core/spec/human_task.go
+++ b/internal/core/spec/human_task.go
@@ -60,7 +60,7 @@ func normalizeHumanTaskAction(normalized map[string]any, with map[string]any) er
 	return nil
 }
 
-func buildStepHumanTask(_ StepBuildContext, s *step, result *core.Step) error {
+func buildStepHumanTask(_ stepBuildContext, s *step, result *core.Step) error {
 	if strings.TrimSpace(s.Action) != "human.task" {
 		return nil
 	}

--- a/internal/core/spec/kubernetes.go
+++ b/internal/core/spec/kubernetes.go
@@ -12,7 +12,7 @@ import (
 
 const kubernetesDefaultsSchemaType = "kubernetes_defaults"
 
-func buildKubernetes(_ BuildContext, d *dag) (core.KubernetesConfig, error) {
+func buildKubernetes(_ buildContext, d *dag) (core.KubernetesConfig, error) {
 	if d.Kubernetes == nil {
 		return nil, nil
 	}

--- a/internal/core/spec/kubernetes.go
+++ b/internal/core/spec/kubernetes.go
@@ -4,7 +4,6 @@
 package spec
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/dagucloud/dagu/v2/internal/core"
@@ -76,28 +75,10 @@ func cloneKubernetesConfigMap(cfg map[string]any) map[string]any {
 }
 
 func cloneKubernetesValue(value any) any {
-	switch v := value.(type) {
-	case core.KubernetesConfig:
-		return core.KubernetesConfig(cloneKubernetesConfigMap(map[string]any(v)))
-	case map[string]any:
-		return cloneKubernetesConfigMap(v)
-	case []any:
-		cloned := make([]any, len(v))
-		for i := range v {
-			cloned[i] = cloneKubernetesValue(v[i])
-		}
-		return cloned
-	case []string:
-		return slices.Clone(v)
-	case []map[string]any:
-		cloned := make([]map[string]any, len(v))
-		for i := range v {
-			cloned[i] = cloneKubernetesConfigMap(v[i])
-		}
-		return cloned
-	default:
-		return value
+	if cfg, ok := value.(core.KubernetesConfig); ok {
+		return core.KubernetesConfig(cloneMap(map[string]any(cfg)))
 	}
+	return cloneAny(value)
 }
 
 func asKubernetesConfigMap(value any) (map[string]any, bool) {

--- a/internal/core/spec/llm_test.go
+++ b/internal/core/spec/llm_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestBuildLLM_Validation(t *testing.T) {
-	ctx := BuildContext{
-		opts: BuildOpts{},
+	ctx := buildContext{
+		opts: buildOpts{},
 	}
 
 	tests := []struct {

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -296,33 +296,6 @@ func buildLoadErrorDAG(opts buildOpts, filePath string, err error) *core.DAG {
 	}
 }
 
-// loadBaseConfig loads the global configuration from the given file.
-// The global configuration can be overridden by the core.DAG configuration.
-func loadBaseConfig(ctx buildContext, file string) (*core.DAG, error) {
-	// The base config is optional.
-	if !fileutil.FileExists(file) {
-		return nil, nil
-	}
-
-	// Load the raw data from the file.
-	raw, err := readYAMLFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decode the raw data into a manifest.
-	def, err := decode(raw)
-	if err != nil {
-		return nil, core.ErrorList{err}
-	}
-
-	ctx = ctx.WithOpts(buildOpts{
-		Flags: ctx.opts.Flags,
-	}).WithFile(file)
-
-	return def.build(ctx)
-}
-
 // loadDAG loads the core.DAG from the given file.
 func loadDAG(ctx buildContext, nameOrPath string) (*core.DAG, error) {
 	filePath, err := resolveYamlFilePath(ctx, nameOrPath)
@@ -1120,16 +1093,6 @@ func (*mergeTransformer) Transformer(
 	return nil
 }
 
-// readYAMLFile reads the contents of the file into a map.
-func readYAMLFile(file string) (map[string]any, error) {
-	data, err := fileutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %q: %w", file, err)
-	}
-
-	return unmarshalData(data)
-}
-
 // unmarshalData unmarshals the data into a map.
 func unmarshalData(data []byte) (map[string]any, error) {
 	return newManifestDecoder().Unmarshal(data)
@@ -1170,9 +1133,9 @@ func extractRawDefaults(cm map[string]any) map[string]any {
 	return cloneMap(rawDefaults)
 }
 
-// TypedUnionDecodeHook returns a decode hook that handles our typed union types.
-// It converts raw map[string]any values to the appropriate typed values.
-func TypedUnionDecodeHook() mapstructure.DecodeHookFunc {
+// typedUnionDecodeHook returns a decode hook for the package typed union
+// types. It converts raw map[string]any values to the appropriate typed values.
+func typedUnionDecodeHook() mapstructure.DecodeHookFunc {
 	return func(_ reflect.Type, to reflect.Type, data any) (any, error) {
 		if to == reflect.TypeFor[toolsConfig]() {
 			return decodeViaYAML[toolsConfig](data)

--- a/internal/core/spec/loader.go
+++ b/internal/core/spec/loader.go
@@ -28,23 +28,7 @@ import (
 // Errors for loading DAGs
 var (
 	ErrNameOrPathRequired = errors.New("name or path is required")
-	ErrInvalidJSONFile    = errors.New("invalid JSON file")
 )
-
-// LoadOptions contains options for loading a DAG.
-type LoadOptions struct {
-	name                   string   // Name of the DAG.
-	baseConfig             string   // Path to the base core.DAG configuration file.
-	baseConfigContent      []byte   // Raw base config YAML content (used when file is unavailable, e.g., distributed mode).
-	workspaceBaseConfigDir string   // Directory containing workspace base configs (<workspace>/base.yaml).
-	params                 string   // Parameters to override default parameters in the DAG.
-	paramsList             []string // List of parameters to override default parameters in the DAG.
-	flags                  BuildFlag
-	dagsDir                string            // Directory containing the core.DAG files.
-	defaultWorkingDir      string            // Default working directory for DAGs without explicit workingDir.
-	sourceFile             string            // Path the DAG was authored at, used to resolve relative paths.
-	buildEnv               map[string]string // Pre-populated env vars for build (used for retry with dotenv).
-}
 
 // LoadResult contains a loaded DAG and transient value-reference notices produced by that load operation.
 type LoadResult struct {
@@ -52,13 +36,13 @@ type LoadResult struct {
 	ValueReferenceNotices []cmnvalue.ValueReferenceNotice
 }
 
-// LoadOption is a function type for setting LoadOptions.
-type LoadOption func(*LoadOptions)
+// LoadOption is a function type for setting load options.
+type LoadOption func(*buildOpts)
 
 // WithBaseConfig sets the base core.DAG configuration file.
 func WithBaseConfig(baseDAG string) LoadOption {
-	return func(o *LoadOptions) {
-		o.baseConfig = baseDAG
+	return func(o *buildOpts) {
+		o.Base = baseDAG
 	}
 }
 
@@ -66,28 +50,28 @@ func WithBaseConfig(baseDAG string) LoadOption {
 // This is used in distributed mode where workers may not have local base config files.
 // When set, this takes precedence over the base config file path.
 func WithBaseConfigContent(content []byte) LoadOption {
-	return func(o *LoadOptions) {
-		o.baseConfigContent = content
+	return func(o *buildOpts) {
+		o.BaseConfigContent = content
 	}
 }
 
 // WithWorkspaceBaseConfigDir sets the directory containing workspace base configs.
 // Named workspace DAGs inherit <dir>/<workspace>/base.yaml after the global base config.
 func WithWorkspaceBaseConfigDir(dir string) LoadOption {
-	return func(o *LoadOptions) {
-		o.workspaceBaseConfigDir = dir
+	return func(o *buildOpts) {
+		o.WorkspaceBaseConfigDir = dir
 	}
 }
 
 // WithParams sets the parameters for the DAG.
 func WithParams(params any) LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagValidateRuntimeParams
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagValidateRuntimeParams
 		switch params := params.(type) {
 		case string:
-			o.params = params
+			o.Parameters = params
 		case []string:
-			o.paramsList = params
+			o.ParametersList = params
 		default:
 			panic(fmt.Sprintf("invalid type %T for params", params))
 		}
@@ -96,22 +80,22 @@ func WithParams(params any) LoadOption {
 
 // WithoutEval disables the evaluation of dynamic fields.
 func WithoutEval() LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagNoEval
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagNoEval
 	}
 }
 
 // OnlyMetadata sets the flag to load only metadata.
 func OnlyMetadata() LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagOnlyMetadata
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagOnlyMetadata
 	}
 }
 
 // WithName sets the name of the DAG.
 func WithName(name string) LoadOption {
-	return func(o *LoadOptions) {
-		o.name = name
+	return func(o *buildOpts) {
+		o.Name = name
 	}
 }
 
@@ -121,8 +105,8 @@ func WithName(name string) LoadOption {
 // for the core.DAG file in this directory. If not specified, the current working
 // directory is used as the default.
 func WithDAGsDir(dagsDir string) LoadOption {
-	return func(o *LoadOptions) {
-		o.dagsDir = dagsDir
+	return func(o *buildOpts) {
+		o.DAGsDir = dagsDir
 	}
 }
 
@@ -132,15 +116,15 @@ func WithDAGsDir(dagsDir string) LoadOption {
 // the loader will return a core.DAG with the errors included in the DAG's `BuildErrors` field,
 // and will not fail the loading process.
 func WithAllowBuildErrors() LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagAllowBuildErrors
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagAllowBuildErrors
 	}
 }
 
 // SkipSchemaValidation disables schema resolution/validation during build.
 func SkipSchemaValidation() LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagSkipSchemaValidation
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagSkipSchemaValidation
 	}
 }
 
@@ -148,19 +132,19 @@ func SkipSchemaValidation() LoadOption {
 // This is used for sub-DAG runs to prevent handler inheritance from base config.
 // Sub-DAGs should have their own handlers defined explicitly if needed.
 func WithSkipBaseHandlers() LoadOption {
-	return func(o *LoadOptions) {
-		o.flags |= BuildFlagSkipBaseHandlers
+	return func(o *buildOpts) {
+		o.Flags |= buildFlagSkipBaseHandlers
 	}
 }
 
 // WithDefaultWorkingDir sets the default working directory for DAGs without explicit workingDir.
 func WithDefaultWorkingDir(defaultWorkingDir string) LoadOption {
-	return func(o *LoadOptions) {
+	return func(o *buildOpts) {
 		dir := strings.TrimSpace(defaultWorkingDir)
 		if dir == "" {
 			return
 		}
-		o.defaultWorkingDir = filepath.Clean(dir)
+		o.DefaultWorkingDir = filepath.Clean(dir)
 	}
 }
 
@@ -169,8 +153,8 @@ func WithDefaultWorkingDir(defaultWorkingDir string) LoadOption {
 // worker, resolves its relative paths against this rather than against the
 // copy.
 func WithSourceFile(sourceFile string) LoadOption {
-	return func(o *LoadOptions) {
-		o.sourceFile = strings.TrimSpace(sourceFile)
+	return func(o *buildOpts) {
+		o.SourceFile = strings.TrimSpace(sourceFile)
 	}
 }
 
@@ -179,8 +163,8 @@ func WithSourceFile(sourceFile string) LoadOption {
 // reference them via ${VAR}. This is used for retry scenarios where
 // dotenv values need to be available during rebuild from YamlData.
 func WithBuildEnv(env map[string]string) LoadOption {
-	return func(o *LoadOptions) {
-		o.buildEnv = env
+	return func(o *buildOpts) {
+		o.BuildEnv = env
 	}
 }
 
@@ -203,8 +187,8 @@ func Load(ctx context.Context, nameOrPath string, opts ...LoadOption) (*core.DAG
 	if nameOrPath == "" {
 		return nil, ErrNameOrPathRequired
 	}
-	buildContext := loadBuildContext(ctx, opts...)
-	return loadDAG(buildContext, nameOrPath)
+	bc := loadBuildContext(ctx, opts...)
+	return loadDAG(bc, nameOrPath)
 }
 
 // LoadWithResult loads a DAG and returns transient value-reference notices produced by that load operation.
@@ -213,9 +197,9 @@ func LoadWithResult(ctx context.Context, nameOrPath string, opts ...LoadOption) 
 		return nil, ErrNameOrPathRequired
 	}
 	var collector cmnvalue.ValueReferenceNoticeCollector
-	buildContext := loadBuildContext(ctx, opts...)
-	buildContext.valueReferenceNotices = &collector
-	dag, err := loadDAG(buildContext, nameOrPath)
+	bc := loadBuildContext(ctx, opts...)
+	bc.valueReferenceNotices = &collector
+	dag, err := loadDAG(bc, nameOrPath)
 	if err != nil {
 		return nil, err
 	}
@@ -223,22 +207,22 @@ func LoadWithResult(ctx context.Context, nameOrPath string, opts ...LoadOption) 
 	return &LoadResult{DAG: dag, ValueReferenceNotices: collector.Notices()}, nil
 }
 
-func loadBuildContext(ctx context.Context, opts ...LoadOption) BuildContext {
-	return BuildContext{
+func loadBuildContext(ctx context.Context, opts ...LoadOption) buildContext {
+	return buildContext{
 		ctx:  ctx,
-		opts: loadBuildOpts(loadOptions(opts...)),
+		opts: newBuildOpts(opts...),
 	}
 }
 
 // LoadYAML loads the core.DAG from the given YAML data with the specified options.
 func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*core.DAG, error) {
-	return LoadYAMLWithOpts(ctx, data, loadBuildOpts(loadOptions(opts...)))
+	return loadYAMLWithOptsAndNotices(ctx, data, newBuildOpts(opts...), nil)
 }
 
 // LoadYAMLWithResult loads a DAG from YAML and returns transient value-reference notices produced by that load operation.
 func LoadYAMLWithResult(ctx context.Context, data []byte, opts ...LoadOption) (*LoadResult, error) {
 	var collector cmnvalue.ValueReferenceNoticeCollector
-	dag, err := loadYAMLWithOptsAndNotices(ctx, data, loadBuildOpts(loadOptions(opts...)), &collector)
+	dag, err := loadYAMLWithOptsAndNotices(ctx, data, newBuildOpts(opts...), &collector)
 	if err != nil {
 		return nil, err
 	}
@@ -246,39 +230,18 @@ func LoadYAMLWithResult(ctx context.Context, data []byte, opts ...LoadOption) (*
 	return &LoadResult{DAG: dag, ValueReferenceNotices: collector.Notices()}, nil
 }
 
-func loadOptions(opts ...LoadOption) LoadOptions {
-	var options LoadOptions
+func newBuildOpts(opts ...LoadOption) buildOpts {
+	var options buildOpts
 	for _, opt := range opts {
 		opt(&options)
 	}
 	return options
 }
 
-func loadBuildOpts(options LoadOptions) BuildOpts {
-	return BuildOpts{
-		Base:                   options.baseConfig,
-		BaseConfigContent:      options.baseConfigContent,
-		WorkspaceBaseConfigDir: options.workspaceBaseConfigDir,
-		Parameters:             options.params,
-		ParametersList:         options.paramsList,
-		Name:                   options.name,
-		DAGsDir:                options.dagsDir,
-		DefaultWorkingDir:      options.defaultWorkingDir,
-		SourceFile:             options.sourceFile,
-		Flags:                  options.flags,
-		BuildEnv:               options.buildEnv,
-	}
-}
-
-// LoadYAMLWithOpts loads the core.DAG configuration from YAML data.
-func LoadYAMLWithOpts(ctx context.Context, data []byte, opts BuildOpts) (*core.DAG, error) {
-	return loadYAMLWithOptsAndNotices(ctx, data, opts, nil)
-}
-
 func loadYAMLWithOptsAndNotices(
 	ctx context.Context,
 	data []byte,
-	opts BuildOpts,
+	opts buildOpts,
 	valueReferenceNotices *cmnvalue.ValueReferenceNoticeCollector,
 ) (*core.DAG, error) {
 	baseDef, baseRaw, err := loadBaseDefinition(opts)
@@ -286,11 +249,11 @@ func loadYAMLWithOptsAndNotices(
 		return loadYAMLFailure(opts, err)
 	}
 
-	buildContext := BuildContext{ctx: ctx, opts: opts}
+	bc := buildContext{ctx: ctx, opts: opts}
 	if valueReferenceNotices != nil {
-		buildContext.valueReferenceNotices = valueReferenceNotices
+		bc.valueReferenceNotices = valueReferenceNotices
 	}
-	dags, err := loadDAGsFromData(buildContext, data, "", baseDef, baseRaw)
+	dags, err := loadDAGsFromData(bc, data, "", baseDef, baseRaw)
 	if err != nil {
 		return loadYAMLFailure(opts, err)
 	}
@@ -307,7 +270,7 @@ func loadYAMLWithOptsAndNotices(
 }
 
 // loadYAMLFailure returns a placeholder DAG when YAML loading is allowed to fail.
-func loadYAMLFailure(opts BuildOpts, err error) (*core.DAG, error) {
+func loadYAMLFailure(opts buildOpts, err error) (*core.DAG, error) {
 	if dag := buildLoadErrorDAG(opts, "", err); dag != nil {
 		return dag, nil
 	}
@@ -315,8 +278,8 @@ func loadYAMLFailure(opts BuildOpts, err error) (*core.DAG, error) {
 }
 
 // buildLoadErrorDAG creates a placeholder DAG when build errors are allowed.
-func buildLoadErrorDAG(opts BuildOpts, filePath string, err error) *core.DAG {
-	if !opts.Has(BuildFlagAllowBuildErrors) {
+func buildLoadErrorDAG(opts buildOpts, filePath string, err error) *core.DAG {
+	if !opts.Has(buildFlagAllowBuildErrors) {
 		return nil
 	}
 
@@ -333,9 +296,9 @@ func buildLoadErrorDAG(opts BuildOpts, filePath string, err error) *core.DAG {
 	}
 }
 
-// LoadBaseConfig loads the global configuration from the given file.
+// loadBaseConfig loads the global configuration from the given file.
 // The global configuration can be overridden by the core.DAG configuration.
-func LoadBaseConfig(ctx BuildContext, file string) (*core.DAG, error) {
+func loadBaseConfig(ctx buildContext, file string) (*core.DAG, error) {
 	// The base config is optional.
 	if !fileutil.FileExists(file) {
 		return nil, nil
@@ -353,7 +316,7 @@ func LoadBaseConfig(ctx BuildContext, file string) (*core.DAG, error) {
 		return nil, core.ErrorList{err}
 	}
 
-	ctx = ctx.WithOpts(BuildOpts{
+	ctx = ctx.WithOpts(buildOpts{
 		Flags: ctx.opts.Flags,
 	}).WithFile(file)
 
@@ -361,7 +324,7 @@ func LoadBaseConfig(ctx BuildContext, file string) (*core.DAG, error) {
 }
 
 // loadDAG loads the core.DAG from the given file.
-func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
+func loadDAG(ctx buildContext, nameOrPath string) (*core.DAG, error) {
 	filePath, err := resolveYamlFilePath(ctx, nameOrPath)
 	if err != nil {
 		return nil, err
@@ -385,15 +348,13 @@ func loadDAG(ctx BuildContext, nameOrPath string) (*core.DAG, error) {
 	}
 
 	core.InitializeDefaults(mainDAG)
-	if err := applyWorkingDirFallback(mainDAG, filePath); err != nil {
-		return nil, err
-	}
+	applyWorkingDirFallback(mainDAG, filePath)
 
 	return mainDAG, nil
 }
 
 // loadDAGFailure returns a placeholder DAG when file loading is allowed to fail.
-func loadDAGFailure(ctx BuildContext, filePath string, err error) (*core.DAG, error) {
+func loadDAGFailure(ctx buildContext, filePath string, err error) (*core.DAG, error) {
 	if dag := buildLoadErrorDAG(ctx.opts, filePath, err); dag != nil {
 		return dag, nil
 	}
@@ -432,27 +393,16 @@ func attachLocalDAGs(mainDAG *core.DAG, localDAGs []*core.DAG) error {
 }
 
 // applyWorkingDirFallback marks configured working directories as explicit,
-// then synthesizes a fallback from filePath or the process working directory
-// when the manifest omits one, returning an error if the process working
-// directory cannot be determined.
-func applyWorkingDirFallback(dag *core.DAG, filePath string) error {
+// then defaults the DAG working directory to the manifest's directory when the
+// manifest omits one. filePath must be non-empty.
+func applyWorkingDirFallback(dag *core.DAG, filePath string) {
 	markConfiguredWorkingDirsExplicit(dag)
 
 	if dag.WorkingDir != "" {
-		return nil
+		return
 	}
 
-	if filePath != "" {
-		dag.WorkingDir = filepath.Dir(filePath)
-		return nil
-	}
-
-	wd, err := getDefaultWorkingDir()
-	if err != nil {
-		return fmt.Errorf("failed to determine working directory: %w", err)
-	}
-	dag.WorkingDir = wd
-	return nil
+	dag.WorkingDir = filepath.Dir(filePath)
 }
 
 // markConfiguredWorkingDirsExplicit preserves configured working directories
@@ -470,7 +420,7 @@ func markConfiguredWorkingDirsExplicit(dag *core.DAG) {
 }
 
 // loadDAGsFromFile loads all DAGs from a multi-document YAML file.
-func loadDAGsFromFile(ctx BuildContext, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
+func loadDAGsFromFile(ctx buildContext, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
 	data, err := fileutil.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
@@ -484,7 +434,7 @@ type dagDocument struct {
 }
 
 // loadDAGsFromData builds DAGs from every non-empty YAML document in the input.
-func loadDAGsFromData(ctx BuildContext, data []byte, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
+func loadDAGsFromData(ctx buildContext, data []byte, filePath string, baseDef *dag, baseRaw []byte) ([]*core.DAG, error) {
 	docs, err := decodeDocuments(data)
 	if err != nil {
 		return nil, err
@@ -564,8 +514,8 @@ func decodeDocuments(data []byte) ([]dagDocument, error) {
 }
 
 // loadBaseDefinition loads and decodes the optional base manifest.
-func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
-	if opts.Has(BuildFlagOnlyMetadata) {
+func loadBaseDefinition(opts buildOpts) (*dag, []byte, error) {
+	if opts.Has(buildFlagOnlyMetadata) {
 		return nil, nil, nil
 	}
 
@@ -582,7 +532,7 @@ func loadBaseDefinition(opts BuildOpts) (*dag, []byte, error) {
 }
 
 // readBaseDefinitionData returns the raw bytes and label for the base manifest.
-func readBaseDefinitionData(opts BuildOpts) ([]byte, string, error) {
+func readBaseDefinitionData(opts buildOpts) ([]byte, string, error) {
 	if len(opts.BaseConfigContent) > 0 {
 		return opts.BaseConfigContent, "embedded base config", nil
 	}
@@ -615,7 +565,7 @@ func decodeDefinitionData(data []byte, description string) (*dag, error) {
 
 // processDAGDocument processes a single DAG document from the YAML file.
 func processDAGDocument(
-	ctx BuildContext,
+	ctx buildContext,
 	doc map[string]any,
 	baseDef *dag,
 	baseRaw []byte,
@@ -657,7 +607,7 @@ func processDAGDocument(
 // loadEffectiveBaseDefinition returns the base definition that applies to a document.
 // Embedded base configs are already effective for distributed workers, so local
 // workspace config files are only considered when loading from filesystem state.
-func loadEffectiveBaseDefinition(opts BuildOpts, doc map[string]any, baseDef *dag, baseRaw []byte) (*dag, []byte, error) {
+func loadEffectiveBaseDefinition(opts buildOpts, doc map[string]any, baseDef *dag, baseRaw []byte) (*dag, []byte, error) {
 	workspaceRaw, err := readWorkspaceBaseDefinitionData(opts, doc)
 	if err != nil {
 		return nil, nil, err
@@ -669,8 +619,8 @@ func loadEffectiveBaseDefinition(opts BuildOpts, doc map[string]any, baseDef *da
 }
 
 // readWorkspaceBaseDefinitionData returns raw per-workspace base config data for a named workspace DAG.
-func readWorkspaceBaseDefinitionData(opts BuildOpts, doc map[string]any) ([]byte, error) {
-	if opts.Has(BuildFlagOnlyMetadata) || opts.WorkspaceBaseConfigDir == "" || len(opts.BaseConfigContent) > 0 {
+func readWorkspaceBaseDefinitionData(opts buildOpts, doc map[string]any) ([]byte, error) {
+	if opts.Has(buildFlagOnlyMetadata) || opts.WorkspaceBaseConfigDir == "" || len(opts.BaseConfigContent) > 0 {
 		return nil, nil
 	}
 
@@ -827,7 +777,7 @@ func mergeBaseEnvRaw(base, override any) (any, error) {
 }
 
 // buildDocumentContext applies per-document overrides for multi-DAG files.
-func buildDocumentContext(ctx BuildContext, index int) BuildContext {
+func buildDocumentContext(ctx buildContext, index int) buildContext {
 	ctx.index = index
 	if index == 0 {
 		return ctx
@@ -836,12 +786,12 @@ func buildDocumentContext(ctx BuildContext, index int) BuildContext {
 	opts := ctx.opts
 	opts.Parameters = ""
 	opts.ParametersList = nil
-	opts.Flags &^= BuildFlagValidateRuntimeParams
+	opts.Flags &^= buildFlagValidateRuntimeParams
 	return ctx.WithOpts(opts)
 }
 
 // prepareDocumentContext builds the inherited context and destination DAG.
-func prepareDocumentContext(ctx BuildContext, baseDef, spec *dag) (BuildContext, *core.DAG, error) {
+func prepareDocumentContext(ctx buildContext, baseDef, spec *dag) (buildContext, *core.DAG, error) {
 	customStepTypes, err := buildCustomStepActionRegistry(
 		stepTypesOf(baseDef),
 		stepTypesOf(spec),
@@ -867,7 +817,7 @@ func prepareDocumentContext(ctx BuildContext, baseDef, spec *dag) (BuildContext,
 }
 
 // buildDocumentBase builds the reusable base DAG and decoded defaults.
-func buildDocumentBase(ctx BuildContext, baseDef *dag) (*core.DAG, *defaults, error) {
+func buildDocumentBase(ctx buildContext, baseDef *dag) (*core.DAG, *defaults, error) {
 	baseDAG, err := buildBaseDAG(ctx, baseDef)
 	if err != nil {
 		return nil, nil, err
@@ -890,11 +840,11 @@ func documentYAML(index int, doc map[string]any, fullData []byte) ([]byte, error
 }
 
 // buildBaseDAG builds a new base DAG from the base definition.
-func buildBaseDAG(ctx BuildContext, baseDef *dag) (*core.DAG, error) {
+func buildBaseDAG(ctx buildContext, baseDef *dag) (*core.DAG, error) {
 	buildOpts := ctx.opts
 	buildOpts.Parameters = ""
 	buildOpts.ParametersList = nil
-	buildOpts.Flags |= BuildFlagDeferWorkerSelector
+	buildOpts.Flags |= buildFlagDeferWorkerSelector
 
 	customStepTypes, err := buildCustomStepActionRegistry(stepTypesOf(baseDef), nil, actionsOf(baseDef), nil)
 	if err != nil {
@@ -908,7 +858,7 @@ func buildBaseDAG(ctx BuildContext, baseDef *dag) (*core.DAG, error) {
 
 	// Skip handlers from base config for sub-DAG runs to prevent inheritance.
 	// Sub-DAGs should define their own handlers explicitly if needed.
-	if ctx.opts.Has(BuildFlagSkipBaseHandlers) {
+	if ctx.opts.Has(buildFlagSkipBaseHandlers) {
 		baseDAG.HandlerOn = core.HandlerOn{}
 	}
 
@@ -976,13 +926,16 @@ func defaultName(file string) string {
 
 // resolveYamlFilePath resolves the YAML file path.
 // If the file name does not have an extension, it appends ".yaml".
-func resolveYamlFilePath(ctx BuildContext, file string) (string, error) {
+func resolveYamlFilePath(ctx buildContext, file string) (string, error) {
 	file = strings.TrimSpace(file)
 	if file == "" {
 		return "", errors.New("file path is required")
 	}
 
-	file = expandHomeDir(file)
+	file, err := expandHomeDir(file)
+	if err != nil {
+		return "", err
+	}
 
 	if filepath.IsAbs(file) {
 		return file, nil
@@ -1004,16 +957,18 @@ func resolveYamlFilePath(ctx BuildContext, file string) (string, error) {
 }
 
 // expandHomeDir expands a leading tilde when the caller used a home-relative path.
-func expandHomeDir(file string) string {
+// It reports an error when the home directory cannot be determined, so that a
+// home-relative path is never silently resolved against another directory.
+func expandHomeDir(file string) (string, error) {
 	if file != "~" && !strings.HasPrefix(file, "~/") && !strings.HasPrefix(file, `~\`) {
-		return file
+		return file, nil
 	}
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return file
+		return "", fmt.Errorf("failed to expand %q: %w", file, err)
 	}
-	return strings.Replace(file, "~", homeDir, 1)
+	return strings.Replace(file, "~", homeDir, 1), nil
 }
 
 type mergeTransformer struct{}
@@ -1166,10 +1121,10 @@ func (*mergeTransformer) Transformer(
 }
 
 // readYAMLFile reads the contents of the file into a map.
-func readYAMLFile(file string) (cfg map[string]any, err error) {
+func readYAMLFile(file string) (map[string]any, error) {
 	data, err := fileutil.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file %q: %v", file, err)
+		return nil, fmt.Errorf("failed to read file %q: %w", file, err)
 	}
 
 	return unmarshalData(data)

--- a/internal/core/spec/loader_internal_test.go
+++ b/internal/core/spec/loader_internal_test.go
@@ -20,13 +20,21 @@ func TestExpandHomeDir(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	assert.Equal(t, homeDir, expandHomeDir("~"))
+	expanded, err := expandHomeDir("~")
+	require.NoError(t, err)
+	assert.Equal(t, homeDir, expanded)
+
+	expanded, err = expandHomeDir("~/dags/test.yaml")
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		filepath.Clean(filepath.Join(homeDir, "dags", "test.yaml")),
-		filepath.Clean(expandHomeDir("~/dags/test.yaml")),
+		filepath.Clean(expanded),
 	)
-	assert.Equal(t, "~alice/dags/test.yaml", expandHomeDir("~alice/dags/test.yaml"))
+
+	expanded, err = expandHomeDir("~alice/dags/test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "~alice/dags/test.yaml", expanded)
 }
 
 // TestUnmarshalData verifies manifest decoding handles empty and malformed YAML inputs.

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -586,7 +586,7 @@ func TestLoadBaseConfig(t *testing.T) {
 	t.Run("LoadBaseConfigFile", func(t *testing.T) {
 		t.Parallel()
 
-		testDAG := createTempYAMLFile(t, `env:
+		baseDAG := createTempYAMLFile(t, `env:
   LOG_DIR: "${HOME}/logs"
 log_dir: "${LOG_DIR}"
 smtp:
@@ -603,9 +603,26 @@ info_mail:
 mail_on:
   failure: true
 `)
-		dag, err := spec.LoadBaseConfig(spec.BuildContext{}, testDAG)
-		require.NotNil(t, dag)
+		childDAG := createTempYAMLFile(t, `
+steps:
+  - name: "step1"
+    run: echo "step1"
+`)
+
+		dag, err := spec.Load(context.Background(), childDAG, spec.WithBaseConfig(baseDAG))
 		require.NoError(t, err)
+		require.NotNil(t, dag)
+
+		require.NotNil(t, dag.SMTP)
+		assert.Equal(t, "smtp.host", dag.SMTP.Host)
+		assert.Equal(t, "25", dag.SMTP.Port)
+
+		require.NotNil(t, dag.ErrorMail)
+		assert.Equal(t, "error@mail.com", dag.ErrorMail.To[0])
+		assert.Equal(t, "[ERROR]", dag.ErrorMail.Prefix)
+
+		require.NotNil(t, dag.MailOn)
+		assert.True(t, dag.MailOn.Failure)
 	})
 	t.Run("InheritBaseConfig", func(t *testing.T) {
 		t.Parallel()
@@ -1296,7 +1313,7 @@ func TestLoadYAML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ret, err := spec.LoadYAMLWithOpts(context.Background(), []byte(tt.input), spec.BuildOpts{})
+			ret, err := spec.LoadYAML(context.Background(), []byte(tt.input))
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -1332,12 +1349,12 @@ func TestLoadYAMLWithOpts_MarksConfiguredWorkingDirExplicit(t *testing.T) {
 		t.Parallel()
 
 		workDir := t.TempDir()
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), fmt.Appendf(nil, `
+		dag, err := spec.LoadYAML(context.Background(), fmt.Appendf(nil, `
 working_dir: %q
 steps:
   - name: step1
     run: echo hello
-`, workDir), spec.BuildOpts{})
+`, workDir))
 		require.NoError(t, err)
 		assert.Equal(t, workDir, dag.WorkingDir)
 		assert.True(t, dag.WorkingDirExplicit)
@@ -1347,13 +1364,11 @@ steps:
 		t.Parallel()
 
 		workDir := t.TempDir()
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: step1
     run: echo hello
-`), spec.BuildOpts{
-			BaseConfigContent: fmt.Appendf(nil, "working_dir: %q", workDir),
-		})
+`), spec.WithBaseConfigContent(fmt.Appendf(nil, "working_dir: %q", workDir)))
 		require.NoError(t, err)
 		assert.Equal(t, workDir, dag.WorkingDir)
 		assert.True(t, dag.WorkingDirExplicit)
@@ -1363,13 +1378,11 @@ steps:
 		t.Parallel()
 
 		workDir := t.TempDir()
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: step1
     run: echo hello
-`), spec.BuildOpts{
-			DefaultWorkingDir: workDir,
-		})
+`), spec.WithDefaultWorkingDir(workDir))
 		require.NoError(t, err)
 		assert.Equal(t, workDir, dag.WorkingDir)
 		assert.True(t, dag.WorkingDirExplicit)
@@ -1382,12 +1395,12 @@ func TestLoadYAMLWithOpts_PreservesLegacyContract(t *testing.T) {
 	t.Run("DoesNotInitializeDefaults", func(t *testing.T) {
 		t.Parallel()
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 name: test-dag
 steps:
   - name: step1
     run: echo hello
-`), spec.BuildOpts{})
+`))
 		require.NoError(t, err)
 		assert.Equal(t, core.LogOutputMode(""), dag.LogOutput)
 	})
@@ -1395,11 +1408,11 @@ steps:
 	t.Run("DoesNotSynthesizeWorkingDirWithoutContext", func(t *testing.T) {
 		t.Parallel()
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: step1
     run: echo hello
-`), spec.BuildOpts{})
+`))
 		require.NoError(t, err)
 		assert.Empty(t, dag.WorkingDir)
 		assert.False(t, dag.WorkingDirExplicit)
@@ -1408,13 +1421,13 @@ steps:
 	t.Run("WithoutBaseConfigDefaultsTypeToGraph", func(t *testing.T) {
 		t.Parallel()
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: step1
     run: echo one
   - name: step2
     run: echo two
-`), spec.BuildOpts{})
+`))
 		require.NoError(t, err)
 		assert.Equal(t, core.TypeGraph, dag.Type)
 		require.Len(t, dag.Steps, 2)
@@ -1492,9 +1505,7 @@ steps:
     run: "true"
 `
 
-	ret, err := spec.LoadYAMLWithOpts(context.Background(), []byte(testDAG), spec.BuildOpts{
-		Name: "testDAG",
-	})
+	ret, err := spec.LoadYAML(context.Background(), []byte(testDAG), spec.WithName("testDAG"))
 	require.NoError(t, err)
 	require.Equal(t, "testDAG", ret.Name)
 
@@ -1507,7 +1518,7 @@ steps:
 func TestLoadYAMLWithOpts_PreservesLocalDAGsFromMultiDocumentYAML(t *testing.T) {
 	t.Parallel()
 
-	dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: call-child
     action: dag.run
@@ -1519,7 +1530,7 @@ name: child-task
 steps:
   - name: work
     run: echo "child"
-`), spec.BuildOpts{Name: "parent-task"})
+`), spec.WithName("parent-task"))
 	require.NoError(t, err)
 
 	require.NotNil(t, dag.LocalDAGs)
@@ -1664,7 +1675,7 @@ func TestLoadYAMLWithOpts_TypeInheritanceInMultiDocumentYAML(t *testing.T) {
 		t.Parallel()
 
 		base := createTempYAMLFile(t, "type: graph\n")
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: call-child
     action: dag.run
@@ -1680,7 +1691,7 @@ steps:
     run: echo child
   - name: finish
     run: echo done
-`), spec.BuildOpts{Name: "parent-task", Base: base})
+`), spec.WithName("parent-task"), spec.WithBaseConfig(base))
 		require.NoError(t, err)
 
 		assert.Equal(t, core.TypeGraph, dag.Type)
@@ -1698,7 +1709,7 @@ steps:
 		t.Parallel()
 
 		base := createTempYAMLFile(t, "type: graph\n")
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+		dag, err := spec.LoadYAML(context.Background(), []byte(`
 steps:
   - name: call-child
     action: dag.run
@@ -1713,7 +1724,7 @@ steps:
     run: echo child
   - name: finish
     run: echo done
-`), spec.BuildOpts{Name: "parent-task", Base: base})
+`), spec.WithName("parent-task"), spec.WithBaseConfig(base))
 		require.NoError(t, err)
 
 		assert.Equal(t, core.TypeGraph, dag.Type)

--- a/internal/core/spec/manifest_decoder.go
+++ b/internal/core/spec/manifest_decoder.go
@@ -21,7 +21,7 @@ type manifestDecoder struct {
 }
 
 var defaultManifestDecoder = &manifestDecoder{
-	decodeHook: TypedUnionDecodeHook(),
+	decodeHook: typedUnionDecodeHook(),
 }
 
 // newManifestDecoder returns the shared manifest decoder instance.

--- a/internal/core/spec/params.go
+++ b/internal/core/spec/params.go
@@ -108,7 +108,7 @@ func quotedNames(names []string) string {
 // Parameter values are always treated as literal strings — no variable
 // expansion or command substitution is performed.
 func parseParams(value any, params *[]paramPair, envs *[]string) error {
-	noEvalCtx := BuildContext{opts: BuildOpts{Flags: BuildFlagNoEval}}
+	noEvalCtx := buildContext{opts: buildOpts{Flags: buildFlagNoEval}}
 
 	paramPairs, err := parseParamValue(noEvalCtx, value)
 	if err != nil {
@@ -131,7 +131,7 @@ func parseParams(value any, params *[]paramPair, envs *[]string) error {
 }
 
 // parseParamValue parses the parameters for the DAG.
-func parseParamValue(ctx BuildContext, input any) ([]paramPair, error) {
+func parseParamValue(ctx buildContext, input any) ([]paramPair, error) {
 	switch v := input.(type) {
 	case nil:
 		return nil, nil
@@ -167,7 +167,7 @@ func parseParamValue(ctx BuildContext, input any) ([]paramPair, error) {
 	}
 }
 
-func parseListParams(ctx BuildContext, input []string) ([]paramPair, error) {
+func parseListParams(ctx buildContext, input []string) ([]paramPair, error) {
 	var params []paramPair
 
 	for _, v := range input {
@@ -181,7 +181,7 @@ func parseListParams(ctx BuildContext, input []string) ([]paramPair, error) {
 	return params, nil
 }
 
-func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
+func parseMapParams(ctx buildContext, input []any) ([]paramPair, error) {
 	var params []paramPair
 
 	for _, m := range input {
@@ -233,7 +233,7 @@ var paramRegex = regexp.MustCompile(
 
 // tryParseJSONParams attempts to parse the input as JSON and convert it to paramPairs.
 // Returns an error if the input is not valid JSON.
-func tryParseJSONParams(ctx BuildContext, input string) ([]paramPair, error) {
+func tryParseJSONParams(ctx buildContext, input string) ([]paramPair, error) {
 	// Try parsing as JSON object first
 	var jsonObj map[string]any
 	if err := json.Unmarshal([]byte(input), &jsonObj); err == nil {
@@ -265,7 +265,7 @@ func tryParseJSONParams(ctx BuildContext, input string) ([]paramPair, error) {
 	return nil, fmt.Errorf("not valid JSON")
 }
 
-func parseStringParams(ctx BuildContext, input string) ([]paramPair, error) {
+func parseStringParams(ctx buildContext, input string) ([]paramPair, error) {
 	input = strings.TrimSpace(input)
 
 	// Check if input looks like a JSON object or array

--- a/internal/core/spec/params_test.go
+++ b/internal/core/spec/params_test.go
@@ -143,9 +143,9 @@ func TestParamPairSmartEscape(t *testing.T) {
 func TestParseStringParams(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	tests := []struct {
@@ -253,9 +253,9 @@ func TestParseStringParams(t *testing.T) {
 func TestParseStringParams_NoEval_Matrix(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	tests := []struct {
@@ -329,9 +329,9 @@ func TestParseStringParams_NoEval_Matrix(t *testing.T) {
 func TestParseStringParamsWithJSON(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	tests := []struct {
@@ -391,9 +391,9 @@ func TestParseStringParamsWithJSON(t *testing.T) {
 
 func TestParseStringParamsBackticksLiteral(t *testing.T) {
 	t.Run("BacktickValuesPreservedLiterally", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		result, err := parseStringParams(ctx, "val=`echo hello`")
@@ -407,9 +407,9 @@ func TestParseStringParamsBackticksLiteral(t *testing.T) {
 func TestParseListParams(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	tests := []struct {
@@ -459,9 +459,9 @@ func TestParseListParams(t *testing.T) {
 func TestParseMapParams(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	t.Run("EmptySlice", func(t *testing.T) {
@@ -555,9 +555,9 @@ func TestParseMapParams(t *testing.T) {
 func TestParseParamValue(t *testing.T) {
 	t.Parallel()
 
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{Flags: BuildFlagNoEval},
+		opts: buildOpts{Flags: buildFlagNoEval},
 	}
 
 	t.Run("Nil", func(t *testing.T) {
@@ -838,7 +838,7 @@ func TestMultilineParamRoundTrip(t *testing.T) {
 	t.Parallel()
 	pair := paramPair{Name: "MSG", Value: "line1\nline2"}
 	escaped := pair.Escaped() // MSG="line1\nline2" with \n escape
-	ctx := BuildContext{ctx: context.Background(), opts: BuildOpts{Flags: BuildFlagNoEval}}
+	ctx := buildContext{ctx: context.Background(), opts: buildOpts{Flags: buildFlagNoEval}}
 	result, err := parseStringParams(ctx, escaped)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
@@ -850,9 +850,9 @@ func TestJSONParamsSkipBacktickSubstitution(t *testing.T) {
 	t.Parallel()
 
 	// JSON params from the UI should not execute backtick commands.
-	ctx := BuildContext{
+	ctx := buildContext{
 		ctx:  context.Background(),
-		opts: BuildOpts{},
+		opts: buildOpts{},
 	}
 
 	// Value containing backticks — should be treated as literal, not executed.

--- a/internal/core/spec/runtime_env_external_test.go
+++ b/internal/core/spec/runtime_env_external_test.go
@@ -80,12 +80,12 @@ func TestResolveEnvWithWarningsReturnsDotenvWarnings(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("INVALID LINE\n"), 0o600))
 
-	dag, err := spec.LoadYAMLWithOpts(context.Background(), fmt.Appendf(nil, `
+	dag, err := spec.LoadYAML(context.Background(), fmt.Appendf(nil, `
 working_dir: %s
 dotenv: .env
 steps:
   - run: echo hello
-`, root), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+`, root), spec.WithoutEval())
 	require.NoError(t, err)
 
 	result, err := spec.ResolveEnvWithWarnings(context.Background(), dag, nil, spec.ResolveEnvOptions{})
@@ -207,12 +207,12 @@ func TestResolveEnvWithWarningsDoesNotMutateDAGBackingSlices(t *testing.T) {
 		root := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("DOTENV_VALUE=ready\n"), 0o600))
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), fmt.Appendf(nil, `
+		dag, err := spec.LoadYAML(context.Background(), fmt.Appendf(nil, `
 working_dir: %s
 dotenv: .env
 steps:
   - run: echo hello
-`, root), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+`, root), spec.WithoutEval())
 		require.NoError(t, err)
 
 		dag.Env = make([]string, 0, 1)
@@ -230,12 +230,12 @@ steps:
 		root := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(root, ".env"), []byte("INVALID LINE\n"), 0o600))
 
-		dag, err := spec.LoadYAMLWithOpts(context.Background(), fmt.Appendf(nil, `
+		dag, err := spec.LoadYAML(context.Background(), fmt.Appendf(nil, `
 working_dir: %s
 dotenv: .env
 steps:
   - run: echo hello
-`, root), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+`, root), spec.WithoutEval())
 		require.NoError(t, err)
 
 		dag.BuildWarnings = make([]string, 1, 2)

--- a/internal/core/spec/schema.go
+++ b/internal/core/spec/schema.go
@@ -5,6 +5,7 @@ package spec
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -162,6 +163,7 @@ func loadSchemaFromFile(workingDir string, dagLocation string, filePath string) 
 	// 3) Directory of the DAG file (where it was loaded from)
 
 	var tried []string
+	var causes []error
 
 	// Attempts a candidate by joining base and filePath (if base provided),
 	// resolving env/tilde + absolute path, checking existence, and reading.
@@ -175,15 +177,18 @@ func loadSchemaFromFile(workingDir string, dagLocation string, filePath string) 
 		resolved, err := fileutil.ResolvePath(candidate)
 		if err != nil {
 			tried = append(tried, fmt.Sprintf("%s: resolve error: %v", label, err))
+			causes = append(causes, fmt.Errorf("%s: %w", label, err))
 			return nil, "", err
 		}
 		if !fileutil.FileExists(resolved) {
 			tried = append(tried, fmt.Sprintf("%s: %s", label, resolved))
+			causes = append(causes, fmt.Errorf("%s: %s: %w", label, resolved, os.ErrNotExist))
 			return nil, resolved, os.ErrNotExist
 		}
 		data, err := fileutil.ReadFile(resolved)
 		if err != nil {
 			tried = append(tried, fmt.Sprintf("%s: %s (read error: %v)", label, resolved, err))
+			causes = append(causes, fmt.Errorf("%s: %s: %w", label, resolved, err))
 			return nil, resolved, err
 		}
 		return data, resolved, nil
@@ -209,10 +214,26 @@ func loadSchemaFromFile(workingDir string, dagLocation string, filePath string) 
 		}
 	}
 
-	if len(tried) == 0 {
+	if len(causes) == 0 {
 		return nil, fmt.Errorf("failed to resolve schema file path: %s (no candidates)", filePath)
 	}
-	return nil, fmt.Errorf("schema file not found for %q; tried %s", filePath, strings.Join(tried, ", "))
+
+	// A candidate that failed for a reason other than absence is reported as a
+	// load failure carrying only those causes, so that absence of the earlier
+	// candidates cannot mask it.
+	var blocking []error
+	for _, cause := range causes {
+		if !errors.Is(cause, os.ErrNotExist) {
+			blocking = append(blocking, cause)
+		}
+	}
+	if len(blocking) > 0 {
+		return nil, fmt.Errorf("failed to load schema file %q; tried %s: %w",
+			filePath, strings.Join(tried, ", "), errors.Join(blocking...))
+	}
+
+	return nil, fmt.Errorf("schema file not found for %q; tried %s: %w",
+		filePath, strings.Join(tried, ", "), errors.Join(causes...))
 }
 
 // extractParamsSchemaDeclaration extracts the schema declaration from a params map.

--- a/internal/core/spec/schema_test.go
+++ b/internal/core/spec/schema_test.go
@@ -857,9 +857,7 @@ params:
 		_, err := LoadYAML(context.Background(), data)
 		require.Error(t, err)
 
-		dag, err := LoadYAMLWithOpts(context.Background(), data, BuildOpts{
-			Flags: BuildFlagSkipSchemaValidation,
-		})
+		dag, err := LoadYAML(context.Background(), data, SkipSchemaValidation())
 		require.NoError(t, err)
 
 		require.Len(t, dag.Params, 1)

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -334,10 +334,10 @@ type llmMessage struct {
 // stepTransformer is a generic implementation for step field transformations
 type stepTransformer[T any] struct {
 	fieldName string
-	builder   func(ctx StepBuildContext, s *step) (T, error)
+	builder   func(ctx stepBuildContext, s *step) (T, error)
 }
 
-func (t *stepTransformer[T]) Transform(ctx StepBuildContext, in *step, out reflect.Value) error {
+func (t *stepTransformer[T]) Transform(ctx stepBuildContext, in *step, out reflect.Value) error {
 	v, err := t.builder(ctx, in)
 	if err != nil {
 		return err
@@ -350,7 +350,7 @@ func (t *stepTransformer[T]) Transform(ctx StepBuildContext, in *step, out refle
 }
 
 // newStepTransformer creates a step transformer for a single field
-func newStepTransformer[T any](fieldName string, builder func(StepBuildContext, *step) (T, error)) Transformer[StepBuildContext, *step] {
+func newStepTransformer[T any](fieldName string, builder func(stepBuildContext, *step) (T, error)) Transformer[stepBuildContext, *step] {
 	return &stepTransformer[T]{
 		fieldName: fieldName,
 		builder:   builder,
@@ -360,7 +360,7 @@ func newStepTransformer[T any](fieldName string, builder func(StepBuildContext, 
 // stepTransform wraps a step transformer with its name for error reporting
 type stepTransform struct {
 	name        string
-	transformer Transformer[StepBuildContext, *step]
+	transformer Transformer[stepBuildContext, *step]
 }
 
 type stepTransformStage []stepTransform
@@ -422,7 +422,7 @@ var stepTransformStages = []stepTransformStage{
 }
 
 // runStepTransformers executes all step transformers
-func runStepTransformers(ctx StepBuildContext, spec *step, result *core.Step) core.ErrorList {
+func runStepTransformers(ctx stepBuildContext, spec *step, result *core.Step) core.ErrorList {
 	var errs core.ErrorList
 	out := reflect.ValueOf(result).Elem()
 
@@ -439,7 +439,7 @@ func runStepTransformers(ctx StepBuildContext, spec *step, result *core.Step) co
 
 type stepActionBuilder struct {
 	name                     string
-	build                    func(StepBuildContext, *step, *core.Step) error
+	build                    func(stepBuildContext, *step, *core.Step) error
 	stopOnStepTypeValidation bool
 }
 
@@ -466,7 +466,7 @@ func init() {
 var stepInteractionActionStage = stepActionStage{
 	// LLM must be after executor so we know if type supports LLM.
 	{"llm", buildStepLLM, false},
-	{"messages", func(_ StepBuildContext, s *step, result *core.Step) error {
+	{"messages", func(_ stepBuildContext, s *step, result *core.Step) error {
 		return buildStepMessages(s, result)
 	}, false},
 	{"router", buildStepRouter, false},
@@ -484,7 +484,7 @@ var stepActionStages = []stepActionStage{
 	stepCommandActionStage,
 }
 
-func runStepActionStages(ctx StepBuildContext, spec *step, result *core.Step) (core.ErrorList, bool) {
+func runStepActionStages(ctx stepBuildContext, spec *step, result *core.Step) (core.ErrorList, bool) {
 	var errs core.ErrorList
 	for _, stage := range stepActionStages {
 		for _, builder := range stage {
@@ -543,7 +543,7 @@ func runStepValidationStages(result *core.Step) core.ErrorList {
 }
 
 // build transforms the step specification into a core.Step.
-func (s *step) build(ctx StepBuildContext) (*core.Step, error) {
+func (s *step) build(ctx stepBuildContext) (*core.Step, error) {
 	if err := validateStepConfigAliasStruct(s); err != nil {
 		return nil, err
 	}
@@ -599,47 +599,47 @@ func validateStdoutStderr(s *core.Step) error {
 
 // Simple field builders
 
-func buildStepName(_ StepBuildContext, s *step) (string, error) {
+func buildStepName(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.Name), nil
 }
 
-func buildStepID(_ StepBuildContext, s *step) (string, error) {
+func buildStepID(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.ID), nil
 }
 
-func buildStepDescription(_ StepBuildContext, s *step) (string, error) {
+func buildStepDescription(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.Description), nil
 }
 
-func buildStepShellPackages(_ StepBuildContext, s *step) ([]string, error) {
+func buildStepShellPackages(_ stepBuildContext, s *step) ([]string, error) {
 	return s.ShellPackages, nil
 }
 
-func buildStepScript(_ StepBuildContext, s *step) (string, error) {
+func buildStepScript(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.Script), nil
 }
 
-func buildStepStdout(_ StepBuildContext, s *step) (string, error) {
+func buildStepStdout(_ stepBuildContext, s *step) (string, error) {
 	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 	return redirect.filePath, err
 }
 
-func buildStepStdoutArtifact(_ StepBuildContext, s *step) (string, error) {
+func buildStepStdoutArtifact(_ stepBuildContext, s *step) (string, error) {
 	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 	return redirect.artifactPath, err
 }
 
-func buildStepStdoutOutputs(_ StepBuildContext, s *step) (*core.StepOutputsConfig, error) {
+func buildStepStdoutOutputs(_ stepBuildContext, s *step) (*core.StepOutputsConfig, error) {
 	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 	return redirect.outputs, err
 }
 
-func buildStepStderr(_ StepBuildContext, s *step) (string, error) {
+func buildStepStderr(_ stepBuildContext, s *step) (string, error) {
 	redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
 	return redirect.filePath, err
 }
 
-func buildStepStderrArtifact(_ StepBuildContext, s *step) (string, error) {
+func buildStepStderrArtifact(_ stepBuildContext, s *step) (string, error) {
 	redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
 	return redirect.artifactPath, err
 }
@@ -757,7 +757,7 @@ func hasWindowsDrive(value string) bool {
 	return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
 }
 
-func buildStepLogOutput(_ StepBuildContext, s *step) (core.LogOutputMode, error) {
+func buildStepLogOutput(_ stepBuildContext, s *step) (core.LogOutputMode, error) {
 	if s.LogOutput.IsZero() {
 		// Return empty string to indicate "inherit from DAG"
 		return "", nil
@@ -765,15 +765,15 @@ func buildStepLogOutput(_ StepBuildContext, s *step) (core.LogOutputMode, error)
 	return s.LogOutput.Mode(), nil
 }
 
-func buildStepMailOnError(_ StepBuildContext, s *step) (bool, error) {
+func buildStepMailOnError(_ stepBuildContext, s *step) (bool, error) {
 	return s.MailOnError, nil
 }
 
-func buildStepWorkerSelector(_ StepBuildContext, s *step) (map[string]string, error) {
+func buildStepWorkerSelector(_ stepBuildContext, s *step) (map[string]string, error) {
 	return s.WorkerSelector, nil
 }
 
-func buildStepWorkingDir(_ StepBuildContext, s *step) (string, error) {
+func buildStepWorkingDir(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.WorkingDir), nil
 }
 
@@ -783,7 +783,7 @@ type stepShellResult struct {
 	Args  []string
 }
 
-func parseStepShellInternal(_ StepBuildContext, s *step) (*stepShellResult, error) {
+func parseStepShellInternal(_ stepBuildContext, s *step) (*stepShellResult, error) {
 	if s.Shell.IsZero() {
 		return &stepShellResult{}, nil
 	}
@@ -811,7 +811,7 @@ func parseStepShellInternal(_ StepBuildContext, s *step) (*stepShellResult, erro
 	}, nil
 }
 
-func buildStepShell(ctx StepBuildContext, s *step) (string, error) {
+func buildStepShell(ctx stepBuildContext, s *step) (string, error) {
 	result, err := parseStepShellInternal(ctx, s)
 	if err != nil {
 		return "", err
@@ -819,7 +819,7 @@ func buildStepShell(ctx StepBuildContext, s *step) (string, error) {
 	return result.Shell, nil
 }
 
-func buildStepShellArgs(ctx StepBuildContext, s *step) ([]string, error) {
+func buildStepShellArgs(ctx stepBuildContext, s *step) ([]string, error) {
 	result, err := parseStepShellInternal(ctx, s)
 	if err != nil {
 		return nil, err
@@ -831,22 +831,22 @@ func buildStepShellArgs(ctx StepBuildContext, s *step) ([]string, error) {
 	return result.Args, nil
 }
 
-func buildStepTimeout(_ StepBuildContext, s *step) (time.Duration, error) {
+func buildStepTimeout(_ stepBuildContext, s *step) (time.Duration, error) {
 	if s.TimeoutSec < 0 {
 		return 0, core.NewValidationError("timeout_sec", s.TimeoutSec, ErrTimeoutSecMustBeNonNegative)
 	}
 	return time.Second * time.Duration(s.TimeoutSec), nil
 }
 
-func buildStepDepends(_ StepBuildContext, s *step) ([]string, error) {
+func buildStepDepends(_ stepBuildContext, s *step) ([]string, error) {
 	return s.Depends.Values(), nil
 }
 
-func buildStepExplicitlyNoDeps(_ StepBuildContext, s *step) (bool, error) {
+func buildStepExplicitlyNoDeps(_ stepBuildContext, s *step) (bool, error) {
 	return !s.Depends.IsZero() && s.Depends.IsEmpty(), nil
 }
 
-func buildStepContinueOn(_ StepBuildContext, s *step) (core.ContinueOn, error) {
+func buildStepContinueOn(_ stepBuildContext, s *step) (core.ContinueOn, error) {
 	if s.ContinueOn.IsZero() {
 		return core.ContinueOn{}, nil
 	}
@@ -860,7 +860,7 @@ func buildStepContinueOn(_ StepBuildContext, s *step) (core.ContinueOn, error) {
 	}, nil
 }
 
-func buildStepRetryPolicy(_ StepBuildContext, s *step) (core.RetryPolicy, error) {
+func buildStepRetryPolicy(_ stepBuildContext, s *step) (core.RetryPolicy, error) {
 	if s.RetryPolicy == nil {
 		return core.RetryPolicy{}, nil
 	}
@@ -969,7 +969,7 @@ func parseBackoffValue(val any, fieldName string) (float64, error) {
 	return backoff, nil
 }
 
-func buildStepRepeatPolicy(_ StepBuildContext, s *step) (core.RepeatPolicy, error) {
+func buildStepRepeatPolicy(_ stepBuildContext, s *step) (core.RepeatPolicy, error) {
 	if s.RepeatPolicy == nil {
 		return core.RepeatPolicy{}, nil
 	}
@@ -1042,7 +1042,7 @@ func buildStepRepeatPolicy(_ StepBuildContext, s *step) (core.RepeatPolicy, erro
 	return result, nil
 }
 
-func buildStepSignalOnStop(_ StepBuildContext, s *step) (string, error) {
+func buildStepSignalOnStop(_ stepBuildContext, s *step) (string, error) {
 	if s.SignalOnStop == nil {
 		return "", nil
 	}
@@ -1504,7 +1504,7 @@ func parseStructuredOutputEntry(raw any) (core.StepOutputEntry, error) {
 	return entry, nil
 }
 
-func buildStepOutput(_ StepBuildContext, s *step) (string, error) {
+func buildStepOutput(_ stepBuildContext, s *step) (string, error) {
 	cfg, err := s.parsedOutputConfig()
 	if err != nil {
 		return "", err
@@ -1515,7 +1515,7 @@ func buildStepOutput(_ StepBuildContext, s *step) (string, error) {
 	return cfg.Name, nil
 }
 
-func buildStepStructuredOutput(_ StepBuildContext, s *step) (map[string]core.StepOutputEntry, error) {
+func buildStepStructuredOutput(_ stepBuildContext, s *step) (map[string]core.StepOutputEntry, error) {
 	cfg, err := s.parsedOutputConfig()
 	if err != nil {
 		return nil, err
@@ -1526,7 +1526,7 @@ func buildStepStructuredOutput(_ StepBuildContext, s *step) (map[string]core.Ste
 	return cfg.StructuredOutput, nil
 }
 
-func buildStepOutputSchema(_ StepBuildContext, s *step) (map[string]any, error) {
+func buildStepOutputSchema(_ stepBuildContext, s *step) (map[string]any, error) {
 	if s.OutputSchema == nil {
 		return nil, nil
 	}
@@ -1537,7 +1537,7 @@ func buildStepOutputSchema(_ StepBuildContext, s *step) (map[string]any, error) 
 	return schemaMap, nil
 }
 
-func buildStepDeclaredOutputs(_ StepBuildContext, s *step) ([]core.StepOutputDeclaration, error) {
+func buildStepDeclaredOutputs(_ stepBuildContext, s *step) ([]core.StepOutputDeclaration, error) {
 	if !s.outputsSet {
 		return nil, nil
 	}
@@ -1547,7 +1547,7 @@ func buildStepDeclaredOutputs(_ StepBuildContext, s *step) ([]core.StepOutputDec
 	return parseDeclaredOutputs(s.Outputs)
 }
 
-func buildStepEnvs(_ StepBuildContext, s *step) ([]string, error) {
+func buildStepEnvs(_ stepBuildContext, s *step) ([]string, error) {
 	if s.Env.IsZero() {
 		return nil, nil
 	}
@@ -1565,12 +1565,12 @@ func buildStepEnvs(_ StepBuildContext, s *step) ([]string, error) {
 	return envs, nil
 }
 
-func buildStepPreconditions(ctx StepBuildContext, s *step) ([]*core.Condition, error) {
-	return parsePrecondition(ctx.BuildContext, s.Preconditions)
+func buildStepPreconditions(ctx stepBuildContext, s *step) ([]*core.Condition, error) {
+	return parsePrecondition(ctx.buildContext, s.Preconditions)
 }
 
 // buildStepCommand parses the command field in the step definition.
-func buildStepCommand(_ StepBuildContext, s *step, result *core.Step) error {
+func buildStepCommand(_ stepBuildContext, s *step, result *core.Step) error {
 	if s.Exec != nil {
 		if s.Command != nil {
 			return core.NewValidationError("exec", s.Exec, fmt.Errorf("exec cannot be used together with command"))
@@ -1960,13 +1960,13 @@ func validateMessages(result *core.Step) error {
 	return nil
 }
 
-func buildStepParamsField(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepParamsField(ctx stepBuildContext, s *step, result *core.Step) error {
 	if s.Params == nil {
 		return nil
 	}
 
 	// Parse params using existing parseParamValue function
-	paramPairs, err := parseParamValue(ctx.BuildContext, s.Params)
+	paramPairs, err := parseParamValue(ctx.buildContext, s.Params)
 	if err != nil {
 		return core.NewValidationError("params", s.Params, err)
 	}
@@ -1982,7 +1982,7 @@ func buildStepParamsField(ctx StepBuildContext, s *step, result *core.Step) erro
 }
 
 // buildStepExecutor parses the executor configuration from step fields.
-func buildStepExecutor(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepExecutor(ctx stepBuildContext, s *step, result *core.Step) error {
 	if err := validateStepConfigAliasStruct(s); err != nil {
 		return err
 	}
@@ -2170,7 +2170,7 @@ func isRedisZeroValue(v any) bool {
 }
 
 // buildStepParallel parses the parallel field in the step definition.
-func buildStepParallel(_ StepBuildContext, s *step, result *core.Step) error {
+func buildStepParallel(_ stepBuildContext, s *step, result *core.Step) error {
 	if s.Parallel == nil {
 		return nil
 	}
@@ -2242,7 +2242,7 @@ func buildStepParallel(_ StepBuildContext, s *step, result *core.Step) error {
 var foreachIdentifierPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
 
 // buildStepForeach parses the foreach field in the step definition.
-func buildStepForeach(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepForeach(ctx stepBuildContext, s *step, result *core.Step) error {
 	if s.Foreach == nil {
 		return nil
 	}
@@ -2281,7 +2281,7 @@ func validateForeachExecutionTarget(s *step) error {
 	return nil
 }
 
-func parseForeachConfig(ctx StepBuildContext, raw any) (*core.ForeachConfig, error) {
+func parseForeachConfig(ctx stepBuildContext, raw any) (*core.ForeachConfig, error) {
 	obj, ok := raw.(map[string]any)
 	if !ok {
 		return nil, core.NewValidationError("foreach", raw,
@@ -2396,7 +2396,7 @@ func parseForeachMaxConcurrent(value any) (int, error) {
 	return maxConcurrent, nil
 }
 
-func parseForeachSteps(ctx StepBuildContext, value any) ([]core.Step, error) {
+func parseForeachSteps(ctx stepBuildContext, value any) ([]core.Step, error) {
 	rawSteps, ok := value.([]any)
 	if !ok {
 		return nil, core.NewValidationError("foreach.steps", value,
@@ -2454,12 +2454,12 @@ func validateForeachIdentifier(fieldName, value string) error {
 }
 
 // buildStepContainer parses the container field in the step definition.
-func buildStepContainer(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepContainer(ctx stepBuildContext, s *step, result *core.Step) error {
 	if s.Container == nil {
 		return nil
 	}
 
-	ct, err := buildContainerField(ctx.BuildContext, s.Container)
+	ct, err := buildContainerField(ctx.buildContext, s.Container)
 	if err != nil {
 		return err
 	}
@@ -2473,7 +2473,7 @@ func buildStepContainer(ctx StepBuildContext, s *step, result *core.Step) error 
 // via type: chat in YAML (no auto-detection).
 // If step has no llm: config but DAG has one, the DAG config is inherited.
 // If step has llm: config, it completely overrides DAG-level (full override pattern).
-func buildStepLLM(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepLLM(ctx stepBuildContext, s *step, result *core.Step) error {
 	// Only process LLM for executors that support it
 	if !core.SupportsLLM(result.ExecutorConfig.Type) {
 		return nil
@@ -2699,7 +2699,7 @@ func buildStepMessages(s *step, result *core.Step) error {
 }
 
 // buildStepRouter parses the router configuration from step fields.
-func buildStepRouter(_ StepBuildContext, s *step, result *core.Step) error {
+func buildStepRouter(_ stepBuildContext, s *step, result *core.Step) error {
 	if s.Type != "router" {
 		return nil
 	}
@@ -2774,7 +2774,7 @@ func buildStepRouter(_ StepBuildContext, s *step, result *core.Step) error {
 }
 
 // buildStepApproval parses the approval configuration for a step.
-func buildStepApproval(_ StepBuildContext, s *step, result *core.Step) error {
+func buildStepApproval(_ stepBuildContext, s *step, result *core.Step) error {
 	if s.Approval == nil {
 		return nil
 	}
@@ -2794,7 +2794,7 @@ func buildStepApproval(_ StepBuildContext, s *step, result *core.Step) error {
 }
 
 // buildStepSubDAG parses the child core.DAG definition and sets up the step to run a sub DAG.
-func buildStepSubDAG(ctx StepBuildContext, s *step, result *core.Step) error {
+func buildStepSubDAG(ctx stepBuildContext, s *step, result *core.Step) error {
 	name := strings.TrimSpace(s.Call)
 
 	// if the call field is not set, return nil.
@@ -2807,8 +2807,8 @@ func buildStepSubDAG(ctx StepBuildContext, s *step, result *core.Step) error {
 	if s.Params != nil {
 		// Parse the params to convert them to string format
 		ctxCopy := ctx
-		ctxCopy.opts.Flags |= BuildFlagNoEval // Disable evaluation for params parsing
-		paramPairs, err := parseParamValue(ctxCopy.BuildContext, s.Params)
+		ctxCopy.opts.Flags |= buildFlagNoEval // Disable evaluation for params parsing
+		paramPairs, err := parseParamValue(ctxCopy.buildContext, s.Params)
 		if err != nil {
 			return core.NewValidationError("params", s.Params, err)
 		}

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -331,85 +330,128 @@ type llmMessage struct {
 	Content string `yaml:"content,omitempty"`
 }
 
-// stepTransformer is a generic implementation for step field transformations
-type stepTransformer[T any] struct {
-	fieldName string
-	builder   func(ctx stepBuildContext, s *step) (T, error)
-}
-
-func (t *stepTransformer[T]) Transform(ctx stepBuildContext, in *step, out reflect.Value) error {
-	v, err := t.builder(ctx, in)
-	if err != nil {
-		return err
-	}
-	field := out.FieldByName(t.fieldName)
-	if field.IsValid() && field.CanSet() {
-		field.Set(reflect.ValueOf(v))
-	}
-	return nil
-}
-
-// newStepTransformer creates a step transformer for a single field
-func newStepTransformer[T any](fieldName string, builder func(stepBuildContext, *step) (T, error)) Transformer[stepBuildContext, *step] {
-	return &stepTransformer[T]{
-		fieldName: fieldName,
-		builder:   builder,
-	}
-}
-
-// stepTransform wraps a step transformer with its name for error reporting
+// stepTransform builds one part of a step and applies it to the result. name
+// identifies the spec field in build errors.
 type stepTransform struct {
-	name        string
-	transformer Transformer[stepBuildContext, *step]
+	name  string
+	apply func(ctx stepBuildContext, in *step, out *core.Step) error
+}
+
+// stepField describes a spec field whose built value is assigned to a single
+// field of the result.
+func stepField[T any](
+	name string,
+	build func(stepBuildContext, *step) (T, error),
+	assign func(*core.Step, T),
+) stepTransform {
+	return stepTransform{
+		name: name,
+		apply: func(ctx stepBuildContext, in *step, out *core.Step) error {
+			v, err := build(ctx, in)
+			if err != nil {
+				return err
+			}
+			assign(out, v)
+			return nil
+		},
+	}
+}
+
+// stepOutputRedirectField parses one output redirect declaration and assigns
+// every result field derived from it. Parsing once keeps a malformed
+// declaration to a single error.
+func stepOutputRedirectField(
+	name string,
+	raw func(*step) any,
+	allowOutputs bool,
+	assign func(*core.Step, stepOutputRedirect),
+) stepTransform {
+	return stepTransform{
+		name: name,
+		apply: func(_ stepBuildContext, in *step, out *core.Step) error {
+			redirect, err := buildStepOutputRedirect(name, raw(in), allowOutputs)
+			if err != nil {
+				return err
+			}
+			assign(out, redirect)
+			return nil
+		},
+	}
+}
+
+// stepShellField parses the shell declaration once and assigns both the shell
+// and its arguments.
+func stepShellField() stepTransform {
+	return stepTransform{
+		name: "shell",
+		apply: func(ctx stepBuildContext, in *step, out *core.Step) error {
+			result, err := parseStepShellInternal(ctx, in)
+			if err != nil {
+				return err
+			}
+			out.Shell = result.Shell
+			out.ShellArgs = result.Args
+			if in.ShellArgs != nil {
+				args := append([]string{}, result.Args...)
+				out.ShellArgs = append(args, in.ShellArgs...)
+			}
+			return nil
+		},
+	}
 }
 
 type stepTransformStage []stepTransform
 
 var stepIdentityStage = stepTransformStage{
-	{"name", newStepTransformer("Name", buildStepName)},
-	{"id", newStepTransformer("ID", buildStepID)},
-	{"description", newStepTransformer("Description", buildStepDescription)},
+	stepField("name", buildStepName, func(out *core.Step, v string) { out.Name = v }),
+	stepField("id", buildStepID, func(out *core.Step, v string) { out.ID = v }),
+	stepField("description", buildStepDescription, func(out *core.Step, v string) { out.Description = v }),
 }
 
 var stepScriptStage = stepTransformStage{
-	{"shell_packages", newStepTransformer("ShellPackages", buildStepShellPackages)},
-	{"script", newStepTransformer("Script", buildStepScript)},
+	stepField("shell_packages", buildStepShellPackages, func(out *core.Step, v []string) { out.ShellPackages = v }),
+	stepField("script", buildStepScript, func(out *core.Step, v string) { out.Script = v }),
 }
 
 var stepLogOutputStage = stepTransformStage{
-	{"stdout", newStepTransformer("Stdout", buildStepStdout)},
-	{"stdout.artifact", newStepTransformer("StdoutArtifact", buildStepStdoutArtifact)},
-	{"stdout.outputs", newStepTransformer("StdoutOutputs", buildStepStdoutOutputs)},
-	{"stderr", newStepTransformer("Stderr", buildStepStderr)},
-	{"stderr.artifact", newStepTransformer("StderrArtifact", buildStepStderrArtifact)},
-	{"log_output", newStepTransformer("LogOutput", buildStepLogOutput)},
+	stepOutputRedirectField("stdout", func(s *step) any { return s.Stdout }, true,
+		func(out *core.Step, v stepOutputRedirect) {
+			out.Stdout = v.filePath
+			out.StdoutArtifact = v.artifactPath
+			out.StdoutOutputs = v.outputs
+		}),
+	stepOutputRedirectField("stderr", func(s *step) any { return s.Stderr }, false,
+		func(out *core.Step, v stepOutputRedirect) {
+			out.Stderr = v.filePath
+			out.StderrArtifact = v.artifactPath
+		}),
+	stepField("log_output", buildStepLogOutput, func(out *core.Step, v core.LogOutputMode) { out.LogOutput = v }),
 }
 
 var stepExecutionPlacementStage = stepTransformStage{
-	{"mail_on_error", newStepTransformer("MailOnError", buildStepMailOnError)},
-	{"worker_selector", newStepTransformer("WorkerSelector", buildStepWorkerSelector)},
-	{"working_dir", newStepTransformer("Dir", buildStepWorkingDir)},
-	{"shell", newStepTransformer("Shell", buildStepShell)},
-	{"shell_args", newStepTransformer("ShellArgs", buildStepShellArgs)},
-	{"timeout", newStepTransformer("Timeout", buildStepTimeout)},
-	{"depends", newStepTransformer("Depends", buildStepDepends)},
-	{"explicitly_no_deps", newStepTransformer("ExplicitlyNoDeps", buildStepExplicitlyNoDeps)},
-	{"continue_on", newStepTransformer("ContinueOn", buildStepContinueOn)},
-	{"retry_policy", newStepTransformer("RetryPolicy", buildStepRetryPolicy)},
-	{"repeat_policy", newStepTransformer("RepeatPolicy", buildStepRepeatPolicy)},
-	{"signal_on_stop", newStepTransformer("SignalOnStop", buildStepSignalOnStop)},
+	stepField("mail_on_error", buildStepMailOnError, func(out *core.Step, v bool) { out.MailOnError = v }),
+	stepField("worker_selector", buildStepWorkerSelector, func(out *core.Step, v map[string]string) { out.WorkerSelector = v }),
+	stepField("working_dir", buildStepWorkingDir, func(out *core.Step, v string) { out.Dir = v }),
+	stepShellField(),
+	stepField("timeout", buildStepTimeout, func(out *core.Step, v time.Duration) { out.Timeout = v }),
+	stepField("depends", buildStepDepends, func(out *core.Step, v []string) { out.Depends = v }),
+	stepField("explicitly_no_deps", buildStepExplicitlyNoDeps, func(out *core.Step, v bool) { out.ExplicitlyNoDeps = v }),
+	stepField("continue_on", buildStepContinueOn, func(out *core.Step, v core.ContinueOn) { out.ContinueOn = v }),
+	stepField("retry_policy", buildStepRetryPolicy, func(out *core.Step, v core.RetryPolicy) { out.RetryPolicy = v }),
+	stepField("repeat_policy", buildStepRepeatPolicy, func(out *core.Step, v core.RepeatPolicy) { out.RepeatPolicy = v }),
+	stepField("signal_on_stop", buildStepSignalOnStop, func(out *core.Step, v string) { out.SignalOnStop = v }),
 }
 
 var stepStructuredOutputStage = stepTransformStage{
-	{"output", newStepTransformer("Output", buildStepOutput)},
-	{"structured_output", newStepTransformer("StructuredOutput", buildStepStructuredOutput)},
-	{"output_schema", newStepTransformer("OutputSchema", buildStepOutputSchema)},
-	{"outputs", newStepTransformer("Outputs", buildStepDeclaredOutputs)},
+	stepField("output", buildStepOutput, func(out *core.Step, v string) { out.Output = v }),
+	stepField("structured_output", buildStepStructuredOutput, func(out *core.Step, v map[string]core.StepOutputEntry) { out.StructuredOutput = v }),
+	stepField("output_schema", buildStepOutputSchema, func(out *core.Step, v map[string]any) { out.OutputSchema = v }),
+	stepField("outputs", buildStepDeclaredOutputs, func(out *core.Step, v []core.StepOutputDeclaration) { out.Outputs = v }),
 }
 
 var stepEnvConditionStage = stepTransformStage{
-	{"env", newStepTransformer("Env", buildStepEnvs)},
-	{"preconditions", newStepTransformer("Preconditions", buildStepPreconditions)},
+	stepField("env", buildStepEnvs, func(out *core.Step, v []string) { out.Env = v }),
+	stepField("preconditions", buildStepPreconditions, func(out *core.Step, v []*core.Condition) { out.Preconditions = v }),
 }
 
 var stepTransformStages = []stepTransformStage{
@@ -424,11 +466,10 @@ var stepTransformStages = []stepTransformStage{
 // runStepTransformers executes all step transformers
 func runStepTransformers(ctx stepBuildContext, spec *step, result *core.Step) core.ErrorList {
 	var errs core.ErrorList
-	out := reflect.ValueOf(result).Elem()
 
 	for _, stage := range stepTransformStages {
 		for _, t := range stage {
-			if err := t.transformer.Transform(ctx, spec, out); err != nil {
+			if err := t.apply(ctx, spec, result); err != nil {
 				errs = append(errs, wrapTransformError(t.name, err))
 			}
 		}
@@ -619,31 +660,6 @@ func buildStepScript(_ stepBuildContext, s *step) (string, error) {
 	return strings.TrimSpace(s.Script), nil
 }
 
-func buildStepStdout(_ stepBuildContext, s *step) (string, error) {
-	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
-	return redirect.filePath, err
-}
-
-func buildStepStdoutArtifact(_ stepBuildContext, s *step) (string, error) {
-	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
-	return redirect.artifactPath, err
-}
-
-func buildStepStdoutOutputs(_ stepBuildContext, s *step) (*core.StepOutputsConfig, error) {
-	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
-	return redirect.outputs, err
-}
-
-func buildStepStderr(_ stepBuildContext, s *step) (string, error) {
-	redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
-	return redirect.filePath, err
-}
-
-func buildStepStderrArtifact(_ stepBuildContext, s *step) (string, error) {
-	redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
-	return redirect.artifactPath, err
-}
-
 type stepOutputRedirect struct {
 	filePath     string
 	artifactPath string
@@ -809,26 +825,6 @@ func parseStepShellInternal(_ stepBuildContext, s *step) (*stepShellResult, erro
 		Shell: strings.TrimSpace(shell),
 		Args:  args,
 	}, nil
-}
-
-func buildStepShell(ctx stepBuildContext, s *step) (string, error) {
-	result, err := parseStepShellInternal(ctx, s)
-	if err != nil {
-		return "", err
-	}
-	return result.Shell, nil
-}
-
-func buildStepShellArgs(ctx stepBuildContext, s *step) ([]string, error) {
-	result, err := parseStepShellInternal(ctx, s)
-	if err != nil {
-		return nil, err
-	}
-	if s.ShellArgs != nil {
-		args := append([]string{}, result.Args...)
-		return append(args, s.ShellArgs...), nil
-	}
-	return result.Args, nil
 }
 
 func buildStepTimeout(_ stepBuildContext, s *step) (time.Duration, error) {

--- a/internal/core/spec/step.go
+++ b/internal/core/spec/step.go
@@ -2045,7 +2045,7 @@ func buildStepExecutor(ctx stepBuildContext, s *step, result *core.Step) error {
 		if err := validateHarnessProviderConfig(defs, result.ExecutorConfig.Config); err != nil {
 			return err
 		}
-		fallbacks, err := extractHarnessFallback(cloneHarnessSpecMap(result.ExecutorConfig.Config))
+		fallbacks, err := extractHarnessFallback(cloneMap(result.ExecutorConfig.Config))
 		if err != nil {
 			return err
 		}
@@ -2109,7 +2109,7 @@ func mergeHarnessConfig(dagHarness *core.HarnessConfig, stepConfig map[string]an
 		stepConfig = core.NormalizeBuiltinHarnessFlagKeys(stepConfig)
 	}
 
-	merged := cloneHarnessSpecMap(stepConfig)
+	merged := cloneMap(stepConfig)
 	if merged == nil {
 		merged = make(map[string]any)
 	}
@@ -2125,14 +2125,14 @@ func mergeHarnessConfig(dagHarness *core.HarnessConfig, stepConfig map[string]an
 
 	for key, value := range dagConfig {
 		if _, exists := merged[key]; !exists {
-			merged[key] = cloneHarnessSpecValue(value)
+			merged[key] = cloneAny(value)
 		}
 	}
 
 	if _, exists := stepConfig["fallback"]; exists {
-		merged["fallback"] = cloneHarnessSpecValue(stepConfig["fallback"])
+		merged["fallback"] = cloneAny(stepConfig["fallback"])
 	} else if dagHarness.Fallback != nil {
-		merged["fallback"] = cloneHarnessSpecValue(dagHarness.Fallback)
+		merged["fallback"] = cloneAny(dagHarness.Fallback)
 	}
 
 	return merged

--- a/internal/core/spec/step_outputs_external_test.go
+++ b/internal/core/spec/step_outputs_external_test.go
@@ -15,7 +15,7 @@ import (
 func TestStepOutputsDeclarationBuilds(t *testing.T) {
 	t.Parallel()
 
-	dag, err := spec.LoadYAMLWithOpts(context.Background(), []byte(`
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
 name: test
 steps:
   - id: build
@@ -24,7 +24,7 @@ steps:
       - name: image_tag
       - name: metadata
         type: json
-`), spec.BuildOpts{Flags: spec.BuildFlagNoEval})
+`), spec.WithoutEval())
 	require.NoError(t, err)
 	require.Len(t, dag.Steps, 1)
 	require.Equal(t, []core.StepOutputDeclaration{
@@ -144,10 +144,10 @@ steps:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := spec.LoadYAMLWithOpts(
+			_, err := spec.LoadYAML(
 				context.Background(),
 				[]byte(tc.yaml),
-				spec.BuildOpts{Flags: spec.BuildFlagNoEval},
+				spec.WithoutEval(),
 			)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.message)

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -81,13 +81,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// testStepBuildContext creates a StepBuildContext for testing
-func testStepBuildContext() StepBuildContext {
-	return StepBuildContext{
-		BuildContext: BuildContext{
+// testStepBuildContext creates a stepBuildContext for testing
+func testStepBuildContext() stepBuildContext {
+	return stepBuildContext{
+		buildContext: buildContext{
 			ctx:   context.Background(),
 			file:  "/test/dag.yaml",
-			opts:  BuildOpts{},
+			opts:  buildOpts{},
 			index: 0,
 		},
 	}
@@ -1409,7 +1409,7 @@ func TestBuildStepExecutor(t *testing.T) {
 	tests := []struct {
 		name     string
 		step     *step
-		ctx      StepBuildContext
+		ctx      stepBuildContext
 		expected core.ExecutorConfig
 		wantErr  bool
 	}{
@@ -1484,8 +1484,8 @@ func TestBuildStepExecutor(t *testing.T) {
 		{
 			name: "InheritsContainerExecutor",
 			step: &step{},
-			ctx: StepBuildContext{
-				BuildContext: testBuildContext(),
+			ctx: stepBuildContext{
+				buildContext: testBuildContext(),
 				dag:          &core.DAG{Container: &core.Container{Image: "alpine"}},
 			},
 			expected: core.ExecutorConfig{Type: "container", Config: make(map[string]any)},
@@ -1493,8 +1493,8 @@ func TestBuildStepExecutor(t *testing.T) {
 		{
 			name: "InheritsSSHExecutor",
 			step: &step{},
-			ctx: StepBuildContext{
-				BuildContext: testBuildContext(),
+			ctx: stepBuildContext{
+				buildContext: testBuildContext(),
 				dag:          &core.DAG{SSH: &core.SSHConfig{Host: "example.com"}},
 			},
 			expected: core.ExecutorConfig{Type: "ssh", Config: make(map[string]any)},
@@ -3051,7 +3051,7 @@ func TestBuildStepExecutorNewFormat(t *testing.T) {
 	tests := []struct {
 		name     string
 		step     *step
-		ctx      StepBuildContext
+		ctx      stepBuildContext
 		expected core.ExecutorConfig
 		wantErr  bool
 	}{
@@ -3102,8 +3102,8 @@ func TestBuildStepExecutorNewFormat(t *testing.T) {
 			step: &step{
 				Type: "http",
 			},
-			ctx: StepBuildContext{
-				BuildContext: testBuildContext(),
+			ctx: stepBuildContext{
+				buildContext: testBuildContext(),
 				dag:          &core.DAG{Container: &core.Container{Image: "alpine"}},
 			},
 			expected: core.ExecutorConfig{
@@ -3478,8 +3478,8 @@ func TestBuildStepLLM(t *testing.T) {
 			result := &core.Step{ExecutorConfig: core.ExecutorConfig{Config: make(map[string]any)}}
 
 			// Build executor first to set the type
-			ctx := StepBuildContext{
-				BuildContext: BuildContext{ctx: context.Background()},
+			ctx := stepBuildContext{
+				buildContext: buildContext{ctx: context.Background()},
 				dag:          tt.dag,
 			}
 			_ = buildStepExecutor(ctx, tt.step, result)

--- a/internal/core/spec/step_test.go
+++ b/internal/core/spec/step_test.go
@@ -282,9 +282,9 @@ func TestBuildStepStdout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &step{Stdout: tt.input}
-			result, err := buildStepStdout(testStepBuildContext(), s)
+			redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, redirect.filePath)
 		})
 	}
 }
@@ -304,7 +304,7 @@ func TestBuildStepStdoutRejectsInvalidArtifactPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &step{Stdout: map[string]any{"artifact": tt.path}}
-			_, err := buildStepStdout(testStepBuildContext(), s)
+			_, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 			require.Error(t, err)
 		})
 	}
@@ -314,9 +314,9 @@ func TestBuildStepStdoutArtifact(t *testing.T) {
 	t.Parallel()
 
 	s := &step{Stdout: map[string]any{"artifact": " reports/report.md "}}
-	result, err := buildStepStdoutArtifact(testStepBuildContext(), s)
+	redirect, err := buildStepOutputRedirect("stdout", s.Stdout, true)
 	require.NoError(t, err)
-	assert.Equal(t, "reports/report.md", result)
+	assert.Equal(t, "reports/report.md", redirect.artifactPath)
 }
 
 func TestBuildStepStderr(t *testing.T) {
@@ -336,9 +336,9 @@ func TestBuildStepStderr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &step{Stderr: tt.input}
-			result, err := buildStepStderr(testStepBuildContext(), s)
+			redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, redirect.filePath)
 		})
 	}
 }
@@ -347,9 +347,9 @@ func TestBuildStepStderrArtifact(t *testing.T) {
 	t.Parallel()
 
 	s := &step{Stderr: map[string]any{"artifact": " reports/report.err "}}
-	result, err := buildStepStderrArtifact(testStepBuildContext(), s)
+	redirect, err := buildStepOutputRedirect("stderr", s.Stderr, false)
 	require.NoError(t, err)
-	assert.Equal(t, "reports/report.err", result)
+	assert.Equal(t, "reports/report.err", redirect.artifactPath)
 }
 
 func TestBuildStepMailOnError(t *testing.T) {
@@ -437,9 +437,9 @@ func TestBuildStepShell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &step{Shell: tt.shell}
-			result, err := buildStepShell(testStepBuildContext(), s)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			var out core.Step
+			require.NoError(t, stepShellField().apply(testStepBuildContext(), s, &out))
+			assert.Equal(t, tt.expected, out.Shell)
 		})
 	}
 }
@@ -461,9 +461,9 @@ func TestBuildStepShellArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &step{Shell: tt.shell}
-			result, err := buildStepShellArgs(testStepBuildContext(), s)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			var out core.Step
+			require.NoError(t, stepShellField().apply(testStepBuildContext(), s, &out))
+			assert.Equal(t, tt.expected, out.ShellArgs)
 		})
 	}
 }

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -909,6 +909,8 @@ func cloneMap(src map[string]any) map[string]any {
 	return dst
 }
 
+// cloneAny deep-copies the composite shapes a decoded manifest can hold.
+// Values of any other type are returned as-is.
 func cloneAny(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:
@@ -919,9 +921,24 @@ func cloneAny(value any) any {
 			dst[i] = cloneAny(item)
 		}
 		return dst
+	case []string:
+		return slices.Clone(typed)
+	case []map[string]any:
+		return cloneMapSlice(typed)
 	default:
 		return typed
 	}
+}
+
+func cloneMapSlice(src []map[string]any) []map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make([]map[string]any, len(src))
+	for i, item := range src {
+		dst[i] = cloneMap(item)
+	}
+	return dst
 }
 
 func buildCustomStepFromSpec(

--- a/internal/core/spec/step_types.go
+++ b/internal/core/spec/step_types.go
@@ -156,21 +156,6 @@ func isRegisteredExecutorTypeName(name string) bool {
 	return ok
 }
 
-// StepTypeNames returns the currently accepted builtin and runtime-registered
-// executor type names in sorted order. It excludes the implicit empty command
-// executor type; callers should mention omitted type handling separately.
-func StepTypeNames() []string {
-	stepTypeNamesMu.RLock()
-	defer stepTypeNamesMu.RUnlock()
-
-	names := make([]string, 0, len(builtinStepTypeNames))
-	for name := range builtinStepTypeNames {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
 var customStepForbiddenCallSiteFields = map[string]struct{}{
 	"call":           {},
 	"command":        {},
@@ -940,7 +925,7 @@ func cloneAny(value any) any {
 }
 
 func buildCustomStepFromSpec(
-	ctx StepBuildContext,
+	ctx stepBuildContext,
 	callSite *step,
 	raw map[string]any,
 	defs *defaults,
@@ -951,7 +936,7 @@ func buildCustomStepFromSpec(
 }
 
 func buildCustomStepFromSpecWithStack(
-	ctx StepBuildContext,
+	ctx stepBuildContext,
 	callSite *step,
 	raw map[string]any,
 	defs *defaults,
@@ -1035,7 +1020,7 @@ func customStepStackContains(stack []string, name string) bool {
 }
 
 func buildExpandedCustomStep(
-	ctx StepBuildContext,
+	ctx stepBuildContext,
 	expandedSpec *step,
 	normalizedRaw map[string]any,
 	defs *defaults,

--- a/internal/core/spec/step_v2.go
+++ b/internal/core/spec/step_v2.go
@@ -6,7 +6,6 @@ package spec
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	cmnvalue "github.com/dagucloud/dagu/v2/internal/cmn/value"
@@ -96,19 +95,6 @@ var builtinActionNormalizers = map[string]actionNormalizer{
 	"wait.file":           operationAction("wait", "file"),
 	"wait.http":           operationAction("wait", "http"),
 	"wait.until":          operationAction("wait", "until"),
-}
-
-// BuiltinActionNames returns the currently accepted built-in action names in
-// sorted order. Redis operations are intentionally exposed as a pattern because
-// they normalize dynamically from any redis.<operation> action.
-func BuiltinActionNames() []string {
-	names := make([]string, 0, len(builtinActionNormalizers)+1)
-	for name := range builtinActionNormalizers {
-		names = append(names, name)
-	}
-	names = append(names, "redis.<operation>")
-	sort.Strings(names)
-	return names
 }
 
 func normalizeStepExecutionRaw(raw map[string]any, registry *customStepTypeRegistry) (map[string]any, error) {

--- a/internal/core/spec/variables.go
+++ b/internal/core/spec/variables.go
@@ -19,11 +19,11 @@ import (
 // strVariables may be either a map[string]any or a []any containing maps and/or
 // "key=value" strings; entries are collected in input order. For each pair, the
 // value is optionally expanded with references to previously defined variables
-// unless the BuildFlagNoEval option is set on ctx. The environment is passed via
+// unless the buildFlagNoEval option is set on ctx. The environment is passed via
 // context to ensure thread-safety during concurrent DAG loading. The function
 // returns a validation error if the input is malformed or a value fails to
 // evaluate.
-func loadVariables(ctx BuildContext, strVariables any) (map[string]string, error) {
+func loadVariables(ctx buildContext, strVariables any) (map[string]string, error) {
 	var pairs []pair
 	switch a := strVariables.(type) {
 	case map[string]any:
@@ -58,12 +58,12 @@ func loadVariables(ctx BuildContext, strVariables any) (map[string]string, error
 // This function converts the typed EnvValue entries to the expected format
 // and processes them using the same logic as loadVariables without modifying
 // the global OS environment.
-func loadVariablesFromEnvValue(ctx BuildContext, env types.EnvValue) (map[string]string, error) {
+func loadVariablesFromEnvValue(ctx buildContext, env types.EnvValue) (map[string]string, error) {
 	_, vars, err := loadEnvEntriesFromEnvValue(ctx, env)
 	return vars, err
 }
 
-func loadEnvEntriesFromEnvValue(ctx BuildContext, env types.EnvValue) ([]evaluatedEnvEntry, map[string]string, error) {
+func loadEnvEntriesFromEnvValue(ctx buildContext, env types.EnvValue) ([]evaluatedEnvEntry, map[string]string, error) {
 	if env.IsZero() {
 		return nil, nil, nil
 	}
@@ -87,8 +87,8 @@ func (e evaluatedEnvEntry) String() string {
 }
 
 // evaluatePairs evaluates a list of key-value pairs, expanding environment
-// variables unless BuildFlagNoEval is set.
-func evaluatePairs(ctx BuildContext, pairs []pair) ([]evaluatedEnvEntry, map[string]string, error) {
+// variables unless buildFlagNoEval is set.
+func evaluatePairs(ctx buildContext, pairs []pair) ([]evaluatedEnvEntry, map[string]string, error) {
 	vars := make(map[string]string, len(pairs))
 	entries := make([]evaluatedEnvEntry, 0, len(pairs))
 
@@ -96,7 +96,7 @@ func evaluatePairs(ctx BuildContext, pairs []pair) ([]evaluatedEnvEntry, map[str
 	// New entries are chained immutably as each pair is evaluated.
 	var scope *cmnvalue.EnvScope
 	var evalCtx context.Context
-	if !ctx.opts.Has(BuildFlagNoEval) {
+	if !ctx.opts.Has(buildFlagNoEval) {
 		// Use the shared build scope (which includes resolved params)
 		// instead of a fresh OS-only scope, so env: can reference ${param_name}.
 		if ctx.envScope != nil && ctx.envScope.scope != nil {
@@ -126,7 +126,7 @@ func evaluatePairs(ctx BuildContext, pairs []pair) ([]evaluatedEnvEntry, map[str
 		}
 		value := p.val
 
-		if !ctx.opts.Has(BuildFlagNoEval) {
+		if !ctx.opts.Has(buildFlagNoEval) {
 			if presolved, ok := ctx.opts.BuildEnv[p.key]; ok {
 				value = presolved
 				scope = scope.WithEntry(p.key, value, cmnvalue.EnvSourcePresolved)
@@ -143,7 +143,8 @@ func evaluatePairs(ctx BuildContext, pairs []pair) ([]evaluatedEnvEntry, map[str
 			)
 			value, err = resolver.String(evalCtx, value, cmnvalue.DAGEnvField(fmt.Sprintf("env[%d]", i)))
 			if err != nil {
-				return nil, nil, core.NewValidationError("env", p.val, fmt.Errorf("%w: %s", ErrInvalidEnvValue, p.val))
+				return nil, nil, core.NewValidationError("env", p.val,
+					fmt.Errorf("%w: %s: %w", ErrInvalidEnvValue, p.val, err))
 			}
 
 			// Add evaluated value to scope for next iteration

--- a/internal/core/spec/variables_test.go
+++ b/internal/core/spec/variables_test.go
@@ -116,9 +116,9 @@ func TestLoadVariables(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
-				ctx := BuildContext{
+				ctx := buildContext{
 					ctx:  context.Background(),
-					opts: BuildOpts{Flags: BuildFlagNoEval},
+					opts: buildOpts{Flags: buildFlagNoEval},
 				}
 				result, err := loadVariables(ctx, tt.input)
 				require.NoError(t, err)
@@ -164,9 +164,9 @@ func TestLoadVariables(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
-				ctx := BuildContext{
+				ctx := buildContext{
 					ctx:  context.Background(),
-					opts: BuildOpts{Flags: BuildFlagNoEval},
+					opts: buildOpts{Flags: buildFlagNoEval},
 				}
 				result, err := loadVariables(ctx, tt.input)
 				require.NoError(t, err)
@@ -198,9 +198,9 @@ func TestLoadVariables(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
-				ctx := BuildContext{
+				ctx := buildContext{
 					ctx:  context.Background(),
-					opts: BuildOpts{Flags: BuildFlagNoEval},
+					opts: buildOpts{Flags: buildFlagNoEval},
 				}
 				_, err := loadVariables(ctx, tt.input)
 				require.Error(t, err)
@@ -210,9 +210,9 @@ func TestLoadVariables(t *testing.T) {
 	})
 
 	t.Run("WithEvaluation", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		input := map[string]any{"GREETING": "hello"}
@@ -222,9 +222,9 @@ func TestLoadVariables(t *testing.T) {
 	})
 
 	t.Run("PreservesBacktickSubstitution", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		input := map[string]any{"CMD": "`echo hello`"}
@@ -236,9 +236,9 @@ func TestLoadVariables(t *testing.T) {
 	t.Run("NoEvalFlag", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		// With NoEval, command-like text is preserved.
@@ -249,9 +249,9 @@ func TestLoadVariables(t *testing.T) {
 	})
 
 	t.Run("VariableReference", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		// Test that later variables can reference earlier ones
@@ -268,9 +268,9 @@ func TestLoadVariables(t *testing.T) {
 	t.Run("EmptyValue", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		input := map[string]any{"EMPTY": ""}
@@ -282,9 +282,9 @@ func TestLoadVariables(t *testing.T) {
 	t.Run("ValueWithEqualsSign", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		input := []any{"KEY=value=with=equals"}
@@ -309,9 +309,9 @@ func TestLoadVariablesFromEnvValue(t *testing.T) {
 	t.Run("EmptyEnvValue", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		var env types.EnvValue
@@ -323,9 +323,9 @@ func TestLoadVariablesFromEnvValue(t *testing.T) {
 	t.Run("MapFormat", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		env := envValueFromYAML(t, `
@@ -341,9 +341,9 @@ BAZ: qux
 	t.Run("ArrayFormat", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		env := envValueFromYAML(t, `
@@ -357,9 +357,9 @@ BAZ: qux
 	})
 
 	t.Run("WithEvaluation", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		env := envValueFromYAML(t, `
@@ -371,9 +371,9 @@ GREETING: hello
 	})
 
 	t.Run("PreservesBacktickSubstitution", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		env := envValueFromYAML(t, `
@@ -387,9 +387,9 @@ CMD: "`+"`echo hello`"+`"
 	t.Run("NoEvalFlag", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		env := envValueFromYAML(t, `
@@ -401,9 +401,9 @@ CMD: "$(echo hello)"
 	})
 
 	t.Run("VariableReference", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{},
+			opts: buildOpts{},
 		}
 
 		env := envValueFromYAML(t, `
@@ -417,7 +417,7 @@ CMD: "$(echo hello)"
 	})
 
 	t.Run("ParamReference", func(t *testing.T) {
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx: context.Background(),
 			envScope: &envScopeState{
 				scope:             cmnvalue.NewEnvScope(nil, false),
@@ -437,9 +437,9 @@ ENVIRONMENT: ${params.environment}
 	t.Run("IntegerValue", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		env := envValueFromYAML(t, `
@@ -453,9 +453,9 @@ PORT: 8080
 	t.Run("BooleanValue", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := BuildContext{
+		ctx := buildContext{
 			ctx:  context.Background(),
-			opts: BuildOpts{Flags: BuildFlagNoEval},
+			opts: buildOpts{Flags: buildFlagNoEval},
 		}
 
 		env := envValueFromYAML(t, `


### PR DESCRIPTION
Addresses all 18 findings from a code-quality audit of `internal/core/spec`. The
package was already clean under `go vet` and `golangci-lint`; every finding is a
correctness or maintainability issue those tools do not catch.

Net **-85 lines**. No behavior change except the four defects fixed below.

## Defects fixed

**DAG-level `llm.tools` and `llm.web_search` were silently dropped.** The DAG and
step LLM builders decode the same type, but only the step builder copied these
two fields. A chat step that inherits DAG-level LLM configuration therefore
received no tools and no web search, despite both being part of the documented
root contract — `chat/executor.go` reads `cfg.Tools` from exactly that inherited
config.

**Artifact-action detection scanned arbitrary data as step syntax.** Detection
recursed over the whole intermediate DAG and treated any map key `action` whose
value began with `artifact.` as an artifact action. A DAG carrying
`params: [action: artifact.write]` failed to load with
`artifact actions require artifacts.enabled to be true` when artifacts were
explicitly disabled. Detection is now scoped to executable roots — mirroring the
existing artifact-output detector — and skips parameter payloads.

**Schema lookup reported every failure as "file not found."** Permission and
resolution failures were indistinguishable from absence and lost their
`errors.Is`/`errors.As` chains. Candidate order and fallback are unchanged; a
candidate that failed for a reason other than absence is now reported as a load
failure carrying only those causes, so absence of earlier candidates cannot mask
it.

**Two error causes were erased.** DAG env resolution replaced the resolver error
with a sentinel plus the raw expression. `expandHomeDir` swallowed a
`UserHomeDir` failure and returned the unexpanded path, which was later resolved
against an unrelated directory — so the eventual read error named a path the
caller never requested.

## API surface

`LoadOption` now configures a single build-options struct. `LoadOptions` and
`BuildOpts` held the same eleven fields and were copied field by field on every
load, so each new setting had to be added twice.

Unexported or removed, none of which had callers outside the package:
`BuildContext`, `StepBuildContext`, `BuildOpts`, `BuildFlag`,
`TypedUnionDecodeHook`, `LoadYAMLWithOpts`, `LoadBaseConfig`,
`BuiltinActionNames`, `StepTypeNames`, `BuildFlagNone`, and the unreachable
`ErrInvalidJSONFile` sentinel. The base-config file loader and its read helper
are deleted outright — base config loads through `loadBaseDefinition`.

## Structure

**Typed field pipeline.** DAG and step building selected output fields by name
through `reflect.Value.FieldByName`, so a renamed field silently dropped its
value and an incompatible builder result could panic in `reflect.Set` — neither
visible to the compiler. Each stage entry now pairs a builder with a typed
assignment function. The worker selector, the one multi-field case that
justified the reflective escape hatch, is a plain typed function, and the
exported `Transformer` interface is gone.

**Shared declarations parse once.** `stdout`, `stderr`, and `shell` each fed
several single-field builders that reparsed the same declaration, so one
malformed value produced several equivalent errors that deduplication could not
collapse.

**One reflection visitor.** Three artifact detectors each implemented the same
recursive traversal across roughly 200 lines that had to stay synchronized. Each
detector keeps its own root scope and predicates.

**One clone helper.** `cloneAny`, `cloneHarnessSpecValue`, and
`cloneKubernetesValue` recognized different composite types, so the same decoded
shape was deep-copied on one path and left aliased on another.

**Shared step validation.** Flat arrays, nested parallel arrays, and map form
repeated the same post-build validation, so a new rule had to land in three
branches and validity could drift by syntax.

## Tests

`TestBuildStep` had grown to ~860 lines dispatching unrelated command, executor,
continue-on, retry, repeat, signal, ID, and precondition cases. Split into six
focused suites; blocks move unchanged, all 71 subtests preserved.

Added regression coverage for the two defects with observable behavior:
DAG-level LLM inheritance, and artifact-action detection over parameter
payloads.

## Verification

`go build ./...`, `go test ./internal/core/... ./internal/runtime/...`, and
`golangci-lint` under both `GOOS=darwin` and `GOOS=windows` are clean.

## Provenance

Findings came from an LLM-orchestrated audit whose adversarial verification pass
confirmed 21 of 21 submitted findings. A 100% confirmation rate means that stage
was not discriminating, so each finding was re-validated against the code before
any change — the two behavioral defects were reproduced first. Two findings were
narrowed as a result: artifact-action scoping follows the existing detector's
root scope rather than a new per-field exclusion list, and `LoadBaseConfig` is
deleted rather than privatized, since removing its only caller left it dead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `internal/core/spec` to replace reflective builders with typed assignments, consolidate load options, and fix four correctness issues found by the audit. No behavior change beyond the listed bug fixes.

- **Bug Fixes**
  - DAG-level LLM `tools` and `web_search` now inherit correctly into chat steps, including `web_search.max_uses`.
  - Artifact-action detection is scoped to executable roots and treats `params` as a payload only where it names a field; no false positives for `with.params` in steps, handlers, or templates, while steps named `params` and nested `foreach` still detect actions correctly.
  - Schema file lookup preserves real error causes instead of always reporting “file not found.”
  - Env resolution and `expandHomeDir` preserve underlying errors and avoid resolving to the wrong path.

- **Migration**
  - Replace `LoadYAMLWithOpts` with `LoadYAML(ctx, data, ...LoadOption)`; `LoadOptions` is removed in favor of functional `LoadOption`s.
  - Use `WithParams("...")`, `WithoutEval()`, and `SkipSchemaValidation()` instead of flags/`BuildOpts`.
  - Base config: pass via `WithBaseConfig(path)`; `LoadBaseConfig` is removed.
  - Removed/unexported: `BuildContext`, `StepBuildContext`, `BuildOpts`, `BuildFlag`, `TypedUnionDecodeHook`, `BuiltinActionNames`, `StepTypeNames`, `Transformer`, `ErrInvalidJSONFile`.

<sup>Written for commit 2f0f42e6c43161461179ecace457cb631f158d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading configuration now uses functional options for names, base configurations, working directories, evaluation, and schema validation.
  * Schema-loading errors now provide clearer details, including underlying causes across candidate paths.
  * Validation coverage has expanded for retry, repeat, continuation, precondition, inheritance, and artifact-related settings.

* **Breaking Changes**
  * Several previously public loading, step-type, action-name, and builder APIs are no longer available. Integrations using them must migrate to the supported loading APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->