### PR TITLE
refactor: remove shallow node package

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/dagstate"
 	"github.com/dagucloud/dagu/v2/internal/license"
-	"github.com/dagucloud/dagu/v2/internal/node"
 	"github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/persis/store"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
@@ -580,7 +579,7 @@ func (c *Context) NewCoordinatorClient() coordinator.Client {
 
 func (c *Context) SubWorkflowRunnerFactory() func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
 	stores := c.runtimeStores()
-	return node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+	return coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
 		DAGRunMgr: c.DAGRunMgr,
 		DAGStoreFactory: func(context.Context) (exec.DAGStore, error) {
 			return c.dagStore(dagStoreConfig{})

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core"
 	coreexec "github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/dagstate"
-	"github.com/dagucloud/dagu/v2/internal/node"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
@@ -205,7 +204,7 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 }
 
 func (e *Engine) subWorkflowRunnerFactory(stores RuntimeStores) func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
-	return node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+	return coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
 		DAGRunMgr:         e.dagRunMgr,
 		DAGStore:          e.dagStore,
 		DAGRunStore:       e.dagRunStore,

--- a/internal/service/coordinator/subworkflow.go
+++ b/internal/service/coordinator/subworkflow.go
@@ -1,8 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package node wires runtime node adapters.
-package node
+package coordinator
 
 import (
 	"context"
@@ -15,7 +14,6 @@ import (
 	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/v2/internal/secret"
-	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 	"github.com/dagucloud/dagu/v2/internal/subflow"
 )
 
@@ -52,7 +50,7 @@ func NewSubWorkflowRunnerFactory(cfg SubWorkflowRunnerConfig) func(context.Conte
 		if err != nil {
 			return nil, err
 		}
-		dispatcher, err := coordinator.NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
+		dispatcher, err := NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core/exec"
 	"github.com/dagucloud/dagu/v2/internal/core/spec"
 	"github.com/dagucloud/dagu/v2/internal/dagstate"
-	"github.com/dagucloud/dagu/v2/internal/node"
 	"github.com/dagucloud/dagu/v2/internal/profile"
 	"github.com/dagucloud/dagu/v2/internal/proto/convert"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
@@ -654,7 +653,7 @@ func (h *remoteTaskHandler) executeDAGRun(
 	}
 	extraEnvs := append(taskExtraEnvs(task), toolEnvs...)
 
-	subWorkflowRunnerFactory := node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+	subWorkflowRunnerFactory := coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
 		DAGRunMgr:         h.dagRunMgr,
 		DAGStore:          h.dagStore,
 		StateStore:        h.stateStore,

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -32,11 +32,11 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/core/spec"
 	"github.com/dagucloud/dagu/v2/internal/dagstate"
 	"github.com/dagucloud/dagu/v2/internal/launcher"
-	"github.com/dagucloud/dagu/v2/internal/node"
 	"github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/persis/store"
 	runtimepkg "github.com/dagucloud/dagu/v2/internal/runtime"
 	"github.com/dagucloud/dagu/v2/internal/runtime/agent"
+	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 	"github.com/dagucloud/dagu/v2/internal/service/frontend"
 	"github.com/dagucloud/dagu/v2/internal/workspace"
 	"github.com/google/uuid"
@@ -789,7 +789,7 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 	helper.opts.DAGRunLogDir = d.Config.Paths.LogDir
 	helper.opts.DAGRunArtifactDir = d.Config.Paths.ArtifactDir
 	if helper.opts.SubWorkflowRunnerFactory == nil {
-		helper.opts.SubWorkflowRunnerFactory = node.NewSubWorkflowRunnerFactory(node.SubWorkflowRunnerConfig{
+		helper.opts.SubWorkflowRunnerFactory = coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
 			DAGRunMgr:         d.DAGRunMgr,
 			DAGStore:          d.DAGStore,
 			DAGRunStore:       d.DAGRunStore,


### PR DESCRIPTION
## Summary

- move the subworkflow runner factory from the single-file `internal/node` package into `internal/service/coordinator`
- update command, engine, worker, and test wiring to use the coordinator package directly
- remove the now-empty `internal/node` package

## Why

`internal/node` did not own node behavior. It only combined the coordinator dispatcher with local and distributed subworkflow runners. Keeping that wiring next to `NewRuntimeDispatcher` makes the ownership clear and removes an unnecessary package without changing execution behavior.

## Impact

This is an internal refactor. Child workflow routing, recursive runner creation, DAG store selection, and error behavior are unchanged.

## Testing

- `go test ./internal/service/coordinator ./internal/subflow ./internal/engine ./internal/service/worker ./internal/cmd ./internal/test`
- `go test -run '^$' ./...`
- `golangci-lint` on affected packages for native and Windows targets


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the subworkflow runner factory from `internal/node` to `internal/service/coordinator` and removed the redundant `internal/node` package. All call sites now use the coordinator directly with no behavior changes.

- **Refactors**
  - Introduced `coordinator.NewSubWorkflowRunnerFactory` and co-located wiring with `NewRuntimeDispatcher`.
  - Updated `cmd`, `engine`, `worker`, and tests to replace `node` imports with `coordinator`.

<sup>Written for commit 3a9578656adaf9f3ddbb002437a0ca014f3923f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated subworkflow runner creation under the coordinator service.
  * Preserved existing runtime, storage, and execution configurations.
  * Updated workflow execution paths and test helpers to use the consolidated implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->