### PR TITLE
fix: support dots in DAG file names

### DIFF
--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -1004,7 +1004,7 @@ func (store *Storage) locateDAG(ctx context.Context, nameOrPath string) (string,
 		if err != nil {
 			return "", fmt.Errorf("failed to discover DAGs: %w", err)
 		}
-		fileName := strings.TrimSuffix(filepath.Base(relativePath), filepath.Ext(relativePath))
+		fileName := fileutil.TrimYAMLFileExtension(filepath.Base(relativePath))
 		if entry, ok := catalog.byStem[fileName]; ok {
 			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(
 				store.baseDir,
@@ -1056,13 +1056,13 @@ func (store *Storage) stemExists(name, exceptPath string) bool {
 		return false
 	}
 	base := filepath.Base(filepath.FromSlash(name))
-	target := strings.TrimSuffix(base, filepath.Ext(base))
+	target := fileutil.TrimYAMLFileExtension(base)
 	for _, file := range scan.Files {
 		if exceptPath != "" && file.RelPath == exceptPath {
 			continue
 		}
 		fileBase := filepath.Base(filepath.FromSlash(file.RelPath))
-		if strings.TrimSuffix(fileBase, filepath.Ext(fileBase)) == target {
+		if fileutil.TrimYAMLFileExtension(fileBase) == target {
 			return true
 		}
 	}

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -378,13 +378,18 @@ steps:
 steps:
   - name: step1
     run: echo "dotted"`
-	err = os.WriteFile(filepath.Join(tmpDir, "dagu.update-cloud-image.yaml"), []byte(dottedDAGContent), 0600)
+	nestedDir := filepath.Join(tmpDir, "nested")
+	require.NoError(t, os.Mkdir(nestedDir, 0750))
+	err = os.WriteFile(filepath.Join(nestedDir, "dagu.update-cloud-image.yaml"), []byte(dottedDAGContent), 0600)
 	require.NoError(t, err)
 
 	recursiveStore := New(tmpDir, WithSkipExamples(true), WithRecursiveDiscovery(true))
 	dag, err = recursiveStore.GetDetails(ctx, "dagu.update-cloud-image")
 	require.NoError(t, err)
 	assert.Equal(t, "dagu.update-cloud-image", dag.Name)
+
+	err = recursiveStore.Create(ctx, "dagu.update-cloud-image", []byte(dottedDAGContent))
+	require.ErrorIs(t, err, exec.ErrDAGAlreadyExists)
 }
 
 func TestGetSpec(t *testing.T) {

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -372,6 +372,19 @@ steps:
 	_, err = store.GetDetails(ctx, "non-existent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to locate DAG non-existent")
+
+	// Dots remain part of the DAG's lookup identity.
+	dottedDAGContent := `name: dagu.update-cloud-image
+steps:
+  - name: step1
+    run: echo "dotted"`
+	err = os.WriteFile(filepath.Join(tmpDir, "dagu.update-cloud-image.yaml"), []byte(dottedDAGContent), 0600)
+	require.NoError(t, err)
+
+	recursiveStore := New(tmpDir, WithSkipExamples(true), WithRecursiveDiscovery(true))
+	dag, err = recursiveStore.GetDetails(ctx, "dagu.update-cloud-image")
+	require.NoError(t, err)
+	assert.Equal(t, "dagu.update-cloud-image", dag.Name)
 }
 
 func TestGetSpec(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve dots when resolving DAG file names through recursive discovery
- strip only `.yaml` and `.yml` extensions during lookup and duplicate detection
- cover dotted DAG names through the same store path used by the Web UI

## Root cause

Recursive DAG lookup used `filepath.Ext` on the requested DAG name. For a name such as `dagu.update-cloud-image`, it treated `.update-cloud-image` as a file extension and searched the catalog for `dagu`, causing the Web UI details request to fail even though dots are valid DAG-name characters.

## Impact

DAGs whose file names contain dots can be opened and managed from the Web UI without renaming them.

## Validation

- `go test ./internal/persis/file/dag -count=1`
- `go test ./internal/service/frontend/api/v1 -run 'DAGDetails' -count=1`
- `golangci-lint run --timeout=10m ./...`
- `GOOS=windows golangci-lint run --timeout=10m ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DAG lookup to support dotted file names during recursive discovery. Dotted DAGs now open and manage correctly in the Web UI, and duplicate detection respects dots.

- **Bug Fixes**
  - Preserve dots in DAG names when resolving paths during recursive discovery.
  - Strip only `.yaml`/`.yml` when matching names and detecting duplicates via `fileutil.TrimYAMLFileExtension`.
  - Add tests for `dagu.update-cloud-image`: recursive lookup via the Web UI store path and duplicate detection.

<sup>Written for commit 25564f7bb8393709ab3b8f7d74f07fe27a24d8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

