### PR TITLE
feat(ui): improve workflow list actions and navigation

### DIFF
--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   ChevronUp,
   Search,
+  Trash2,
 } from 'lucide-react';
 import React, {
   useCallback,
@@ -70,6 +71,8 @@ function formatMs(ms: number): string {
 import { PanelWidthContext } from '../../../../components/SplitLayout';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import ConfirmDialog from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -113,6 +116,9 @@ interface DAGCardProps {
   onSelect: (fileName: string, title: string) => void;
   onLabelClick: (label: string) => void;
   refreshFn: () => void;
+  canDeleteDAGs: boolean;
+  isDeleteSelected: boolean;
+  onToggleDeleteSelection: (fileName: string) => void;
   className?: string;
 }
 
@@ -122,6 +128,9 @@ function DAGCard({
   onSelect,
   onLabelClick,
   refreshFn,
+  canDeleteDAGs,
+  isDeleteSelected,
+  onToggleDeleteSelection,
   className = '',
 }: DAGCardProps) {
   const fileName = dag.fileName;
@@ -149,8 +158,22 @@ function DAGCard({
     >
       {/* Header: Name + Status */}
       <div className="flex justify-between items-start gap-2 mb-1.5">
-        <div className="font-medium text-xs truncate flex-1 min-w-0">
-          {dag.dag.name}
+        <div className="flex min-w-0 flex-1 items-start gap-2">
+          {canDeleteDAGs && (
+            <div
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Checkbox
+                aria-label={`Select workflow ${title}`}
+                checked={isDeleteSelected}
+                onCheckedChange={() => onToggleDeleteSelection(fileName)}
+              />
+            </div>
+          )}
+          <div className="font-medium text-xs truncate flex-1 min-w-0">
+            {title}
+          </div>
         </div>
         <StatusChip status={status} size="xs">
           {statusLabel}
@@ -307,6 +330,8 @@ type Props = {
   isWorkflowViewEdited: boolean;
   /** Whether the current user can mutate shared views in this scope */
   canManageWorkflowViews: boolean;
+  /** Whether the current user can delete workflows in this scope */
+  canDeleteDAGs: boolean;
   /** Latest shared-view mutation error */
   workflowViewError?: string | null;
   onSelectWorkflowView: (viewId: string) => void;
@@ -321,6 +346,7 @@ type Props = {
   onSetDefaultWorkflowView: (viewId: string | undefined) => Promise<void>;
   onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
   onDeleteWorkflowView: (viewId: string) => Promise<void>;
+  onDeleteDAGs: (fileNames: string[]) => Promise<void>;
   /** Total workflows matching the server-side filters */
   resultCount?: number;
   /** Currently selected DAG file name */
@@ -355,11 +381,54 @@ declare module '@tanstack/react-table' {
     refreshFn: () => void;
     // Add label click handler to meta for direct access in cell
     onLabelClick?: (label: string) => void;
+    deleteSelectionState?: boolean | 'indeterminate';
+    isDeleteSelected?: (fileName: string) => boolean;
+    onToggleDeleteSelection?: (fileName: string) => void;
+    onToggleAllDeleteSelection?: (checked: boolean) => void;
   }
 }
 
 const columnHelper = createColumnHelper<Data>();
 // --- End Helper Functions ---
+
+const deleteSelectionColumn = columnHelper.display({
+  id: 'Select',
+  size: 40,
+  minSize: 40,
+  maxSize: 40,
+  header: ({ table }) => (
+    <div className="flex h-8 items-center justify-center">
+      <Checkbox
+        aria-label="Select all loaded workflows"
+        checked={table.options.meta?.deleteSelectionState ?? false}
+        onCheckedChange={(checked) =>
+          table.options.meta?.onToggleAllDeleteSelection?.(checked === true)
+        }
+      />
+    </div>
+  ),
+  cell: ({ row, table }) => {
+    const data = row.original;
+    if (data.kind !== ItemKind.DAG) {
+      return null;
+    }
+    const fileName = data.dag.fileName;
+    return (
+      <div
+        className="flex h-8 items-center justify-center"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Checkbox
+          aria-label={`Select workflow ${data.dag.dag.name}`}
+          checked={table.options.meta?.isDeleteSelected?.(fileName) ?? false}
+          onCheckedChange={() =>
+            table.options.meta?.onToggleDeleteSelection?.(fileName)
+          }
+        />
+      </div>
+    );
+  },
+});
 
 const defaultColumns = [
   columnHelper.accessor('name', {
@@ -953,6 +1022,7 @@ function DAGTable({
   isAllWorkflowsView,
   isWorkflowViewEdited,
   canManageWorkflowViews,
+  canDeleteDAGs,
   workflowViewError,
   onSelectWorkflowView,
   onShowAllWorkflows,
@@ -962,13 +1032,26 @@ function DAGTable({
   onSetDefaultWorkflowView,
   onSetPinnedWorkflowView,
   onDeleteWorkflowView,
+  onDeleteDAGs,
   resultCount,
   selectedDAG = null,
   onSelectDAG,
 }: Props) {
   const navigate = useNavigate();
-  const [columns] = useState(() => [...defaultColumns]);
+  const columns = useMemo(
+    () =>
+      canDeleteDAGs
+        ? [deleteSelectionColumn, ...defaultColumns]
+        : defaultColumns,
+    [canDeleteDAGs]
+  );
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [deleteSelection, setDeleteSelection] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<ExpandedState>(() => {
     try {
       const saved = localStorage.getItem('dagu_dag_table_expanded');
@@ -991,6 +1074,67 @@ function DAGTable({
 
   const [clientSort, setClientSort] = useState<string>('');
   const [clientOrder, setClientOrder] = useState<string>('asc');
+
+  useEffect(() => {
+    const loadedFileNames = new Set(dags.map((dag) => dag.fileName));
+    setDeleteSelection((current) => {
+      const next = new Set(
+        [...current].filter((fileName) => loadedFileNames.has(fileName))
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [dags]);
+
+  const toggleDeleteSelection = useCallback((fileName: string) => {
+    setDeleteSelection((current) => {
+      const next = new Set(current);
+      if (next.has(fileName)) {
+        next.delete(fileName);
+      } else {
+        next.add(fileName);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAllDeleteSelection = useCallback(
+    (checked: boolean) => {
+      setDeleteSelection(
+        checked ? new Set(dags.map((dag) => dag.fileName)) : new Set()
+      );
+    },
+    [dags]
+  );
+
+  const selectedDAGsForDelete = useMemo(
+    () => dags.filter((dag) => deleteSelection.has(dag.fileName)),
+    [dags, deleteSelection]
+  );
+  const deleteSelectionState: boolean | 'indeterminate' =
+    selectedDAGsForDelete.length === 0
+      ? false
+      : selectedDAGsForDelete.length === dags.length
+        ? true
+        : 'indeterminate';
+
+  const handleDeleteSubmit = useCallback(async () => {
+    if (selectedDAGsForDelete.length === 0) {
+      return;
+    }
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      await onDeleteDAGs(selectedDAGsForDelete.map((dag) => dag.fileName));
+      setDeleteSelection(new Set());
+      setIsDeleteDialogOpen(false);
+    } catch (error) {
+      setDeleteError(
+        error instanceof Error ? error.message : 'Failed to delete workflows'
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [onDeleteDAGs, selectedDAGsForDelete]);
 
   // Handler for client-side sorting
   const handleClientSort = (field: string, order: string) => {
@@ -1215,6 +1359,10 @@ function DAGTable({
       group,
       refreshFn,
       onLabelClick: handleLabelClick,
+      deleteSelectionState,
+      isDeleteSelected: (fileName) => deleteSelection.has(fileName),
+      onToggleDeleteSelection: toggleDeleteSelection,
+      onToggleAllDeleteSelection: toggleAllDeleteSelection,
     },
   });
 
@@ -1302,6 +1450,23 @@ function DAGTable({
             <CalendarCheck className="mr-1.5 h-4 w-4" />
             Active only
           </Button>
+
+          {canDeleteDAGs && (
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={selectedDAGsForDelete.length === 0 || isDeleting}
+              onClick={() => {
+                setDeleteError(null);
+                setIsDeleteDialogOpen(true);
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+              {selectedDAGsForDelete.length > 0
+                ? `Delete (${selectedDAGsForDelete.length})`
+                : 'Delete'}
+            </Button>
+          )}
 
           {/* Pagination - pushed to right */}
           {pagination && (
@@ -1401,8 +1566,9 @@ function DAGTable({
           className={`w-full text-xs ${isLoading ? 'opacity-70' : ''}`}
           style={{ tableLayout: 'fixed' }}
         >
-          {/* Column widths: Expand 32px fixed, Name auto, Status 10%, LastRun 18%, Schedule 20%, Actions 10% */}
+          {/* Column widths: Select 40px, Expand 32px, Name auto, Status 10%, LastRun 18%, Schedule 20%, Actions 10% */}
           <colgroup>
+            {canDeleteDAGs && <col style={{ width: '40px' }} />}
             <col style={{ width: '32px' }} />
             <col />
             <col style={{ width: '10%' }} />
@@ -1413,10 +1579,10 @@ function DAGTable({
           <TableHeader>
             {instance.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header, index) => (
+                {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
-                    className={`py-1 text-muted-foreground text-xs overflow-hidden ${index === 0 ? 'px-0' : 'px-2'}`}
+                    className={`py-1 text-muted-foreground text-xs overflow-hidden ${header.column.id === 'Select' || header.column.id === 'Expand' ? 'px-0' : 'px-2'}`}
                   >
                     {header.isPlaceholder ? null : (
                       <div>
@@ -1456,12 +1622,16 @@ function DAGTable({
               instance.getRowModel().rows.map((row) => {
                 // For DAG rows, make the entire row clickable
                 const isDAGRow = row.original?.kind === ItemKind.DAG;
+                const isDeleteSelected =
+                  isDAGRow &&
+                  'dag' in row.original &&
+                  deleteSelection.has((row.original as DAGRow).dag.fileName);
                 // Type guard to ensure we only access dag property when it exists
 
                 return (
                   <TableRow
                     key={row.id}
-                    data-state={row.getIsSelected() && 'selected'}
+                    data-state={isDeleteSelected ? 'selected' : undefined}
                     className={`text-[0.8125rem] ${
                       row.original?.kind === ItemKind.Group
                         ? 'bg-muted/50 font-semibold cursor-pointer hover:bg-muted/70'
@@ -1493,10 +1663,10 @@ function DAGTable({
                       }
                     }}
                   >
-                    {row.getVisibleCells().map((cell, index) => (
+                    {row.getVisibleCells().map((cell) => (
                       <TableCell
                         key={cell.id}
-                        className={`py-1 align-middle ${cell.column.id === 'Status' ? 'overflow-visible whitespace-nowrap' : 'overflow-hidden truncate'} ${index === 0 ? 'px-0' : 'px-2'}`}
+                        className={`py-1 align-middle ${cell.column.id === 'Status' ? 'overflow-visible whitespace-nowrap' : 'overflow-hidden truncate'} ${cell.column.id === 'Select' || cell.column.id === 'Expand' ? 'px-0' : 'px-2'}`}
                       >
                         {flexRender(
                           cell.column.columnDef.cell,
@@ -1597,6 +1767,11 @@ function DAGTable({
                               onSelect={handleSelectDAG}
                               onLabelClick={handleLabelClick}
                               refreshFn={refreshFn}
+                              canDeleteDAGs={canDeleteDAGs}
+                              isDeleteSelected={deleteSelection.has(
+                                dagRow.dag.fileName
+                              )}
+                              onToggleDeleteSelection={toggleDeleteSelection}
                               className="ml-2"
                             />
                           );
@@ -1625,6 +1800,9 @@ function DAGTable({
                   onSelect={handleSelectDAG}
                   onLabelClick={handleLabelClick}
                   refreshFn={refreshFn}
+                  canDeleteDAGs={canDeleteDAGs}
+                  isDeleteSelected={deleteSelection.has(dagRow.dag.fileName)}
+                  onToggleDeleteSelection={toggleDeleteSelection}
                 />
               );
             }
@@ -1653,6 +1831,50 @@ function DAGTable({
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        title={
+          selectedDAGsForDelete.length === 1
+            ? 'Delete workflow?'
+            : `Delete ${selectedDAGsForDelete.length} workflows?`
+        }
+        buttonText={isDeleting ? 'Deleting...' : 'Delete'}
+        visible={isDeleteDialogOpen}
+        dismissModal={() => {
+          if (!isDeleting) {
+            setIsDeleteDialogOpen(false);
+            setDeleteError(null);
+          }
+        }}
+        submitDisabled={isDeleting}
+        onSubmit={() => void handleDeleteSubmit()}
+      >
+        <div className="space-y-3 text-sm">
+          <p>
+            {selectedDAGsForDelete.length === 1
+              ? 'The workflow definition file will be removed.'
+              : 'The selected workflow definition files will be removed.'}{' '}
+            Past run history will be kept. This action cannot be undone.
+          </p>
+          <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md border bg-muted/30 p-2">
+            {selectedDAGsForDelete.map((dag) => (
+              <li key={dag.fileName} className="min-w-0">
+                <div className="truncate font-medium">{dag.dag.name}</div>
+                {dag.dag.name !== dag.fileName && (
+                  <div className="truncate font-mono text-xs text-muted-foreground">
+                    {dag.fileName}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+          {deleteError && (
+            <p role="alert" className="text-sm text-destructive">
+              {deleteError}
+            </p>
+          )}
+        </div>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -18,7 +18,6 @@ import {
   ArrowDown,
   ArrowUp,
   Calendar,
-  CalendarCheck,
   ChevronDown,
   ChevronUp,
   Search,
@@ -95,6 +94,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import type { WorkflowFilterView } from './workflowViews';
 import { useQuery } from '../../../../hooks/api';
@@ -1440,16 +1440,15 @@ function DAGTable({
             className="h-9 min-w-[170px] max-w-[220px]"
           />
 
-          <Button
-            type="button"
-            variant={activeOnly ? 'secondary' : 'outline'}
-            aria-pressed={activeOnly}
-            onClick={() => handleActiveOnlyChange(!activeOnly)}
-            className="h-9 px-3"
-          >
-            <CalendarCheck className="mr-1.5 h-4 w-4" />
-            Active only
-          </Button>
+          <label className="flex h-9 cursor-pointer items-center gap-2 rounded-md border border-input bg-card px-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:border-border-strong hover:bg-muted">
+            <span>Active only</span>
+            <Switch
+              checked={activeOnly}
+              onCheckedChange={handleActiveOnlyChange}
+              aria-label="Active only"
+              className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            />
+          </label>
 
           {canDeleteDAGs && (
             <Button

--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -20,6 +20,7 @@ import {
   Calendar,
   ChevronDown,
   ChevronUp,
+  PencilLine,
   Search,
   Trash2,
 } from 'lucide-react';
@@ -32,6 +33,7 @@ import React, {
   useState,
 } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { DAGNameInputModal } from '@/components/DAGNameInputModal';
 import { components, Status } from '../../../../api/v1/schema';
 import type { Config } from '../../../../contexts/ConfigContext';
 import dayjs from '../../../../lib/dayjs';
@@ -119,7 +121,52 @@ interface DAGCardProps {
   canDeleteDAGs: boolean;
   isDeleteSelected: boolean;
   onToggleDeleteSelection: (fileName: string) => void;
+  canRenameDAGs: boolean;
+  onRenameDAG: (dag: components['schemas']['DAGFile']) => void;
+  onDeleteDAG: (dag: components['schemas']['DAGFile']) => void;
   className?: string;
+}
+
+function RenameDAGButton({
+  dag,
+  onRename,
+}: {
+  dag: components['schemas']['DAGFile'];
+  onRename: (dag: components['schemas']['DAGFile']) => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="icon-sm"
+      aria-label={`Rename workflow ${dag.dag.name}`}
+      title="Rename workflow"
+      onClick={() => onRename(dag)}
+    >
+      <PencilLine className="h-4 w-4" />
+    </Button>
+  );
+}
+
+function DeleteDAGButton({
+  dag,
+  onDelete,
+}: {
+  dag: components['schemas']['DAGFile'];
+  onDelete: (dag: components['schemas']['DAGFile']) => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="destructive"
+      size="icon-sm"
+      aria-label={`Delete workflow ${dag.dag.name}`}
+      title="Delete workflow"
+      onClick={() => onDelete(dag)}
+    >
+      <Trash2 className="h-4 w-4" />
+    </Button>
+  );
 }
 
 function DAGCard({
@@ -131,6 +178,9 @@ function DAGCard({
   canDeleteDAGs,
   isDeleteSelected,
   onToggleDeleteSelection,
+  canRenameDAGs,
+  onRenameDAG,
+  onDeleteDAG,
   className = '',
 }: DAGCardProps) {
   const fileName = dag.fileName;
@@ -261,7 +311,10 @@ function DAGCard({
             {dag.suspended ? 'Suspended' : hasSchedule ? 'Live' : 'No schedule'}
           </span>
         </div>
-        <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="flex flex-shrink-0 items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
           <DAGActions
             dag={dag.dag}
             status={dag.latestDAGRun}
@@ -269,6 +322,12 @@ function DAGCard({
             label={false}
             refresh={refreshFn}
           />
+          {canRenameDAGs && (
+            <RenameDAGButton dag={dag} onRename={onRenameDAG} />
+          )}
+          {canDeleteDAGs && (
+            <DeleteDAGButton dag={dag} onDelete={onDeleteDAG} />
+          )}
         </div>
       </div>
     </div>
@@ -332,6 +391,8 @@ type Props = {
   canManageWorkflowViews: boolean;
   /** Whether the current user can delete workflows in this scope */
   canDeleteDAGs: boolean;
+  /** Whether the current user can rename workflows in this scope */
+  canRenameDAGs: boolean;
   /** Latest shared-view mutation error */
   workflowViewError?: string | null;
   onSelectWorkflowView: (viewId: string) => void;
@@ -347,6 +408,7 @@ type Props = {
   onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
   onDeleteWorkflowView: (viewId: string) => Promise<void>;
   onDeleteDAGs: (fileNames: string[]) => Promise<void>;
+  onRenameDAG: (fileName: string, newFileName: string) => Promise<void>;
   /** Total workflows matching the server-side filters */
   resultCount?: number;
   /** Currently selected DAG file name */
@@ -385,6 +447,10 @@ declare module '@tanstack/react-table' {
     isDeleteSelected?: (fileName: string) => boolean;
     onToggleDeleteSelection?: (fileName: string) => void;
     onToggleAllDeleteSelection?: (checked: boolean) => void;
+    canRenameDAGs?: boolean;
+    onOpenRenameDAG?: (dag: components['schemas']['DAGFile']) => void;
+    canDeleteDAGs?: boolean;
+    onOpenDeleteDAG?: (dag: components['schemas']['DAGFile']) => void;
   }
 }
 
@@ -829,9 +895,9 @@ const defaultColumns = [
   }),
   columnHelper.display({
     id: 'Actions',
-    size: 60,
-    minSize: 60,
-    maxSize: 60,
+    size: 160,
+    minSize: 160,
+    maxSize: 160,
     header: () => (
       <div className="flex flex-col items-center py-1">
         <span className="text-xs">Actions</span>
@@ -850,7 +916,7 @@ const defaultColumns = [
       return (
         // Wrap DAGActions in a div and stop propagation on its click
         <div
-          className="flex justify-center scale-90" // Scale down for density
+          className="flex items-center justify-center gap-1 scale-90" // Scale down for density
           onClick={(e) => e.stopPropagation()}
         >
           <DAGActions
@@ -860,6 +926,18 @@ const defaultColumns = [
             label={false}
             refresh={table.options.meta?.refreshFn}
           />
+          {table.options.meta?.canRenameDAGs && (
+            <RenameDAGButton
+              dag={data.dag}
+              onRename={(dag) => table.options.meta?.onOpenRenameDAG?.(dag)}
+            />
+          )}
+          {table.options.meta?.canDeleteDAGs && (
+            <DeleteDAGButton
+              dag={data.dag}
+              onDelete={(dag) => table.options.meta?.onOpenDeleteDAG?.(dag)}
+            />
+          )}
         </div>
       );
     },
@@ -1023,6 +1101,7 @@ function DAGTable({
   isWorkflowViewEdited,
   canManageWorkflowViews,
   canDeleteDAGs,
+  canRenameDAGs,
   workflowViewError,
   onSelectWorkflowView,
   onShowAllWorkflows,
@@ -1033,6 +1112,7 @@ function DAGTable({
   onSetPinnedWorkflowView,
   onDeleteWorkflowView,
   onDeleteDAGs,
+  onRenameDAG,
   resultCount,
   selectedDAG = null,
   onSelectDAG,
@@ -1049,9 +1129,16 @@ function DAGTable({
   const [deleteSelection, setDeleteSelection] = useState<Set<string>>(
     () => new Set()
   );
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [deleteTargets, setDeleteTargets] = useState<
+    components['schemas']['DAGFile'][] | null
+  >(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<
+    components['schemas']['DAGFile'] | null
+  >(null);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<ExpandedState>(() => {
     try {
       const saved = localStorage.getItem('dagu_dag_table_expanded');
@@ -1118,15 +1205,23 @@ function DAGTable({
         : 'indeterminate';
 
   const handleDeleteSubmit = useCallback(async () => {
-    if (selectedDAGsForDelete.length === 0) {
+    if (!deleteTargets || deleteTargets.length === 0) {
       return;
     }
     setIsDeleting(true);
     setDeleteError(null);
     try {
-      await onDeleteDAGs(selectedDAGsForDelete.map((dag) => dag.fileName));
-      setDeleteSelection(new Set());
-      setIsDeleteDialogOpen(false);
+      const deletedFileNames = new Set(
+        deleteTargets.map((dag) => dag.fileName)
+      );
+      await onDeleteDAGs([...deletedFileNames]);
+      setDeleteSelection(
+        (current) =>
+          new Set(
+            [...current].filter((fileName) => !deletedFileNames.has(fileName))
+          )
+      );
+      setDeleteTargets(null);
     } catch (error) {
       setDeleteError(
         error instanceof Error ? error.message : 'Failed to delete workflows'
@@ -1134,7 +1229,46 @@ function DAGTable({
     } finally {
       setIsDeleting(false);
     }
-  }, [onDeleteDAGs, selectedDAGsForDelete]);
+  }, [deleteTargets, onDeleteDAGs]);
+
+  const openDeleteDAG = useCallback((dag: components['schemas']['DAGFile']) => {
+    setDeleteError(null);
+    setDeleteTargets([dag]);
+  }, []);
+
+  const openRenameDAG = useCallback((dag: components['schemas']['DAGFile']) => {
+    setRenameError(null);
+    setRenameTarget(dag);
+  }, []);
+
+  const closeRenameDAG = useCallback(() => {
+    if (isRenaming) {
+      return;
+    }
+    setRenameTarget(null);
+    setRenameError(null);
+  }, [isRenaming]);
+
+  const handleRenameSubmit = useCallback(
+    async (newFileName: string) => {
+      if (!renameTarget) {
+        return;
+      }
+      setIsRenaming(true);
+      setRenameError(null);
+      try {
+        await onRenameDAG(renameTarget.fileName, newFileName);
+        setRenameTarget(null);
+      } catch (error) {
+        setRenameError(
+          error instanceof Error ? error.message : 'Failed to rename workflow'
+        );
+      } finally {
+        setIsRenaming(false);
+      }
+    },
+    [onRenameDAG, renameTarget]
+  );
 
   // Handler for client-side sorting
   const handleClientSort = (field: string, order: string) => {
@@ -1363,6 +1497,10 @@ function DAGTable({
       isDeleteSelected: (fileName) => deleteSelection.has(fileName),
       onToggleDeleteSelection: toggleDeleteSelection,
       onToggleAllDeleteSelection: toggleAllDeleteSelection,
+      canRenameDAGs,
+      onOpenRenameDAG: openRenameDAG,
+      canDeleteDAGs,
+      onOpenDeleteDAG: openDeleteDAG,
     },
   });
 
@@ -1450,20 +1588,18 @@ function DAGTable({
             />
           </label>
 
-          {canDeleteDAGs && (
+          {canDeleteDAGs && selectedDAGsForDelete.length > 0 && (
             <Button
               type="button"
               variant="destructive"
-              disabled={selectedDAGsForDelete.length === 0 || isDeleting}
+              disabled={isDeleting}
               onClick={() => {
                 setDeleteError(null);
-                setIsDeleteDialogOpen(true);
+                setDeleteTargets(selectedDAGsForDelete);
               }}
             >
               <Trash2 className="h-4 w-4" />
-              {selectedDAGsForDelete.length > 0
-                ? `Delete (${selectedDAGsForDelete.length})`
-                : 'Delete'}
+              Delete ({selectedDAGsForDelete.length})
             </Button>
           )}
 
@@ -1565,7 +1701,7 @@ function DAGTable({
           className={`w-full text-xs ${isLoading ? 'opacity-70' : ''}`}
           style={{ tableLayout: 'fixed' }}
         >
-          {/* Column widths: Select 40px, Expand 32px, Name auto, Status 10%, LastRun 18%, Schedule 20%, Actions 10% */}
+          {/* Column widths: Select 40px, Expand 32px, Name auto, Status 10%, LastRun 18%, Schedule 20%, Actions 160px */}
           <colgroup>
             {canDeleteDAGs && <col style={{ width: '40px' }} />}
             <col style={{ width: '32px' }} />
@@ -1573,7 +1709,7 @@ function DAGTable({
             <col style={{ width: '10%' }} />
             <col style={{ width: '18%' }} />
             <col style={{ width: '20%' }} />
-            <col style={{ width: '10%' }} />
+            <col style={{ width: '160px' }} />
           </colgroup>
           <TableHeader>
             {instance.getHeaderGroups().map((headerGroup) => (
@@ -1771,6 +1907,9 @@ function DAGTable({
                                 dagRow.dag.fileName
                               )}
                               onToggleDeleteSelection={toggleDeleteSelection}
+                              canRenameDAGs={canRenameDAGs}
+                              onRenameDAG={openRenameDAG}
+                              onDeleteDAG={openDeleteDAG}
                               className="ml-2"
                             />
                           );
@@ -1802,6 +1941,9 @@ function DAGTable({
                   canDeleteDAGs={canDeleteDAGs}
                   isDeleteSelected={deleteSelection.has(dagRow.dag.fileName)}
                   onToggleDeleteSelection={toggleDeleteSelection}
+                  canRenameDAGs={canRenameDAGs}
+                  onRenameDAG={openRenameDAG}
+                  onDeleteDAG={openDeleteDAG}
                 />
               );
             }
@@ -1833,15 +1975,15 @@ function DAGTable({
 
       <ConfirmDialog
         title={
-          selectedDAGsForDelete.length === 1
+          deleteTargets?.length === 1
             ? 'Delete workflow?'
-            : `Delete ${selectedDAGsForDelete.length} workflows?`
+            : `Delete ${deleteTargets?.length ?? 0} workflows?`
         }
         buttonText={isDeleting ? 'Deleting...' : 'Delete'}
-        visible={isDeleteDialogOpen}
+        visible={deleteTargets !== null}
         dismissModal={() => {
           if (!isDeleting) {
-            setIsDeleteDialogOpen(false);
+            setDeleteTargets(null);
             setDeleteError(null);
           }
         }}
@@ -1850,13 +1992,13 @@ function DAGTable({
       >
         <div className="space-y-3 text-sm">
           <p>
-            {selectedDAGsForDelete.length === 1
+            {deleteTargets?.length === 1
               ? 'The workflow definition file will be removed.'
               : 'The selected workflow definition files will be removed.'}{' '}
             Past run history will be kept. This action cannot be undone.
           </p>
           <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md border bg-muted/30 p-2">
-            {selectedDAGsForDelete.map((dag) => (
+            {(deleteTargets ?? []).map((dag) => (
               <li key={dag.fileName} className="min-w-0">
                 <div className="truncate font-medium">{dag.dag.name}</div>
                 {dag.dag.name !== dag.fileName && (
@@ -1874,6 +2016,16 @@ function DAGTable({
           )}
         </div>
       </ConfirmDialog>
+
+      <DAGNameInputModal
+        isOpen={renameTarget !== null}
+        onClose={closeRenameDAG}
+        onSubmit={(newFileName) => void handleRenameSubmit(newFileName)}
+        mode="rename"
+        initialValue={renameTarget?.fileName ?? ''}
+        isLoading={isRenaming}
+        externalError={renameError}
+      />
     </div>
   );
 }

--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -407,7 +407,7 @@ type Props = {
   onSetDefaultWorkflowView: (viewId: string | undefined) => Promise<void>;
   onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
   onDeleteWorkflowView: (viewId: string) => Promise<void>;
-  onDeleteDAGs: (fileNames: string[]) => Promise<void>;
+  onDeleteDAGs: (fileNames: string[]) => Promise<DAGDeleteResult[]>;
   onRenameDAG: (fileName: string, newFileName: string) => Promise<void>;
   /** Total workflows matching the server-side filters */
   resultCount?: number;
@@ -415,6 +415,11 @@ type Props = {
   selectedDAG?: string | null;
   /** Handler for DAG selection changes */
   onSelectDAG?: (fileName: string, title: string) => void;
+};
+
+export type DAGDeleteResult = {
+  fileName: string;
+  error?: string;
 };
 
 /**
@@ -443,7 +448,7 @@ declare module '@tanstack/react-table' {
     refreshFn: () => void;
     // Add label click handler to meta for direct access in cell
     onLabelClick?: (label: string) => void;
-    deleteSelectionState?: boolean | 'indeterminate';
+    getDeleteSelectionState?: () => boolean | 'indeterminate';
     isDeleteSelected?: (fileName: string) => boolean;
     onToggleDeleteSelection?: (fileName: string) => void;
     onToggleAllDeleteSelection?: (checked: boolean) => void;
@@ -466,7 +471,7 @@ const deleteSelectionColumn = columnHelper.display({
     <div className="flex h-8 items-center justify-center">
       <Checkbox
         aria-label="Select all loaded workflows"
-        checked={table.options.meta?.deleteSelectionState ?? false}
+        checked={table.options.meta?.getDeleteSelectionState?.() ?? false}
         onCheckedChange={(checked) =>
           table.options.meta?.onToggleAllDeleteSelection?.(checked === true)
         }
@@ -1125,6 +1130,9 @@ function DAGTable({
         : defaultColumns,
     [canDeleteDAGs]
   );
+  const tableInstanceRef = useRef<ReturnType<typeof useReactTable> | null>(
+    null
+  );
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [deleteSelection, setDeleteSelection] = useState<Set<string>>(
     () => new Set()
@@ -1134,6 +1142,9 @@ function DAGTable({
   >(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteFailures, setDeleteFailures] = useState<Record<string, string>>(
+    {}
+  );
   const [renameTarget, setRenameTarget] = useState<
     components['schemas']['DAGFile'] | null
   >(null);
@@ -1184,25 +1195,42 @@ function DAGTable({
     });
   }, []);
 
-  const toggleAllDeleteSelection = useCallback(
-    (checked: boolean) => {
-      setDeleteSelection(
-        checked ? new Set(dags.map((dag) => dag.fileName)) : new Set()
-      );
-    },
-    [dags]
+  const getFilteredDAGFileNames = useCallback(
+    () =>
+      (tableInstanceRef.current?.getFilteredRowModel().flatRows ?? [])
+        .filter((row) => (row.original as Data).kind === ItemKind.DAG)
+        .map((row) => (row.original as DAGRow).dag.fileName),
+    []
   );
 
-  const selectedDAGsForDelete = useMemo(
-    () => dags.filter((dag) => deleteSelection.has(dag.fileName)),
-    [dags, deleteSelection]
+  const toggleAllDeleteSelection = useCallback(
+    (checked: boolean) => {
+      const filteredFileNames = getFilteredDAGFileNames();
+      setDeleteSelection((current) => {
+        const next = new Set(current);
+        filteredFileNames.forEach((fileName) => {
+          if (checked) {
+            next.add(fileName);
+          } else {
+            next.delete(fileName);
+          }
+        });
+        return next;
+      });
+    },
+    [getFilteredDAGFileNames]
   );
-  const deleteSelectionState: boolean | 'indeterminate' =
-    selectedDAGsForDelete.length === 0
-      ? false
-      : selectedDAGsForDelete.length === dags.length
-        ? true
-        : 'indeterminate';
+
+  const getDeleteSelectionState = useCallback((): boolean | 'indeterminate' => {
+    const filteredFileNames = getFilteredDAGFileNames();
+    const selectedCount = filteredFileNames.filter((fileName) =>
+      deleteSelection.has(fileName)
+    ).length;
+    if (selectedCount === 0) {
+      return false;
+    }
+    return selectedCount === filteredFileNames.length ? true : 'indeterminate';
+  }, [deleteSelection, getFilteredDAGFileNames]);
 
   const handleDeleteSubmit = useCallback(async () => {
     if (!deleteTargets || deleteTargets.length === 0) {
@@ -1210,18 +1238,46 @@ function DAGTable({
     }
     setIsDeleting(true);
     setDeleteError(null);
+    setDeleteFailures({});
     try {
-      const deletedFileNames = new Set(
+      const results = await onDeleteDAGs(
         deleteTargets.map((dag) => dag.fileName)
       );
-      await onDeleteDAGs([...deletedFileNames]);
+      const failedFileNames = new Set(
+        results
+          .filter((result) => result.error)
+          .map((result) => result.fileName)
+      );
+      const deletedFileNames = new Set(
+        results
+          .filter((result) => !result.error)
+          .map((result) => result.fileName)
+      );
       setDeleteSelection(
         (current) =>
           new Set(
             [...current].filter((fileName) => !deletedFileNames.has(fileName))
           )
       );
-      setDeleteTargets(null);
+      if (failedFileNames.size > 0) {
+        setDeleteTargets(
+          deleteTargets.filter((dag) => failedFileNames.has(dag.fileName))
+        );
+        setDeleteFailures(
+          Object.fromEntries(
+            results.flatMap((result) =>
+              result.error ? [[result.fileName, result.error]] : []
+            )
+          )
+        );
+        setDeleteError(
+          failedFileNames.size === 1
+            ? 'The workflow could not be deleted. Review the error below and retry.'
+            : 'Some workflows could not be deleted. Review the errors below and retry.'
+        );
+      } else {
+        setDeleteTargets(null);
+      }
     } catch (error) {
       setDeleteError(
         error instanceof Error ? error.message : 'Failed to delete workflows'
@@ -1233,6 +1289,7 @@ function DAGTable({
 
   const openDeleteDAG = useCallback((dag: components['schemas']['DAGFile']) => {
     setDeleteError(null);
+    setDeleteFailures({});
     setDeleteTargets([dag]);
   }, []);
 
@@ -1424,10 +1481,6 @@ function DAGTable({
     return hierarchicalData;
   }, [dags, clientSort, compareDags]);
 
-  const tableInstanceRef = useRef<ReturnType<typeof useReactTable> | null>(
-    null
-  );
-
   useEffect(() => {
     if (!selectedDAG || !tableInstanceRef.current || !onSelectDAG) return;
 
@@ -1493,7 +1546,7 @@ function DAGTable({
       group,
       refreshFn,
       onLabelClick: handleLabelClick,
-      deleteSelectionState,
+      getDeleteSelectionState,
       isDeleteSelected: (fileName) => deleteSelection.has(fileName),
       onToggleDeleteSelection: toggleDeleteSelection,
       onToggleAllDeleteSelection: toggleAllDeleteSelection,
@@ -1505,6 +1558,12 @@ function DAGTable({
   });
 
   tableInstanceRef.current = instance as ReturnType<typeof useReactTable>;
+  const filteredDAGFileNames = new Set(getFilteredDAGFileNames());
+  const selectedDAGsForDelete = dags.filter(
+    (dag) =>
+      filteredDAGFileNames.has(dag.fileName) &&
+      deleteSelection.has(dag.fileName)
+  );
 
   const appBarContext = useContext(AppBarContext);
   const panelWidth = useContext(PanelWidthContext);
@@ -1595,6 +1654,7 @@ function DAGTable({
               disabled={isDeleting}
               onClick={() => {
                 setDeleteError(null);
+                setDeleteFailures({});
                 setDeleteTargets(selectedDAGsForDelete);
               }}
             >
@@ -1985,6 +2045,7 @@ function DAGTable({
           if (!isDeleting) {
             setDeleteTargets(null);
             setDeleteError(null);
+            setDeleteFailures({});
           }
         }}
         submitDisabled={isDeleting}
@@ -2004,6 +2065,11 @@ function DAGTable({
                 {dag.dag.name !== dag.fileName && (
                   <div className="truncate font-mono text-xs text-muted-foreground">
                     {dag.fileName}
+                  </div>
+                )}
+                {deleteFailures[dag.fileName] && (
+                  <div className="text-xs text-destructive">
+                    {deleteFailures[dag.fileName]}
                   </div>
                 )}
               </li>

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -48,12 +48,15 @@ function renderTable(
     isAllWorkflowsView?: boolean;
     panelWidth?: number | null;
     onDeleteDAGs?: (fileNames: string[]) => Promise<void>;
+    onRenameDAG?: (fileName: string, newFileName: string) => Promise<void>;
   } = {}
 ) {
   const onShowAllWorkflows = vi.fn();
   const handleActiveOnlyChange = vi.fn();
   const onDeleteDAGs =
     options.onDeleteDAGs ?? vi.fn().mockResolvedValue(undefined);
+  const onRenameDAG =
+    options.onRenameDAG ?? vi.fn().mockResolvedValue(undefined);
   const result = render(
     <MemoryRouter>
       <AppBarContext.Provider
@@ -99,6 +102,7 @@ function renderTable(
             isWorkflowViewEdited={false}
             canManageWorkflowViews={true}
             canDeleteDAGs={true}
+            canRenameDAGs={true}
             onSelectWorkflowView={vi.fn()}
             onShowAllWorkflows={onShowAllWorkflows}
             onResetWorkflowView={vi.fn()}
@@ -108,6 +112,7 @@ function renderTable(
             onSetPinnedWorkflowView={vi.fn()}
             onDeleteWorkflowView={vi.fn()}
             onDeleteDAGs={onDeleteDAGs}
+            onRenameDAG={onRenameDAG}
           />
         </PanelWidthContext.Provider>
       </AppBarContext.Provider>
@@ -117,6 +122,7 @@ function renderTable(
     ...result,
     handleActiveOnlyChange,
     onDeleteDAGs,
+    onRenameDAG,
     onShowAllWorkflows,
   };
 }
@@ -211,7 +217,9 @@ describe('DAGTable', () => {
       ],
     });
 
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    expect(
+      screen.queryByRole('button', { name: /^Delete \(/ })
+    ).not.toBeInTheDocument();
     fireEvent.click(
       within(screen.getByRole('table')).getByRole('checkbox', {
         name: 'Select all loaded workflows',
@@ -231,7 +239,55 @@ describe('DAGTable', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    expect(
+      screen.queryByRole('button', { name: /^Delete \(/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renames a workflow from the actions column', async () => {
+    const { onRenameDAG } = renderTable();
+
+    fireEvent.click(
+      within(screen.getByRole('table')).getByRole('button', {
+        name: 'Rename workflow example',
+      })
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Rename DAG');
+    const nameInput = within(dialog).getByLabelText('DAG Name');
+    expect(nameInput).toHaveValue('example.yaml');
+    fireEvent.change(nameInput, { target: { value: 'renamed.yaml' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => {
+      expect(onRenameDAG).toHaveBeenCalledWith('example.yaml', 'renamed.yaml');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('deletes a workflow from the actions column after confirmation', async () => {
+    const { onDeleteDAGs } = renderTable();
+
+    fireEvent.click(
+      within(screen.getByRole('table')).getByRole('button', {
+        name: 'Delete workflow example',
+      })
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Delete workflow?');
+    expect(dialog).toHaveTextContent('example.yaml');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(onDeleteDAGs).toHaveBeenCalledWith(['example.yaml']);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('explains an empty saved view and offers to show all workflows', () => {

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -1,7 +1,13 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -41,10 +47,13 @@ function renderTable(
     activeOnly?: boolean;
     isAllWorkflowsView?: boolean;
     panelWidth?: number | null;
+    onDeleteDAGs?: (fileNames: string[]) => Promise<void>;
   } = {}
 ) {
   const onShowAllWorkflows = vi.fn();
   const handleActiveOnlyChange = vi.fn();
+  const onDeleteDAGs =
+    options.onDeleteDAGs ?? vi.fn().mockResolvedValue(undefined);
   const result = render(
     <MemoryRouter>
       <AppBarContext.Provider
@@ -89,6 +98,7 @@ function renderTable(
             isAllWorkflowsView={options.isAllWorkflowsView ?? true}
             isWorkflowViewEdited={false}
             canManageWorkflowViews={true}
+            canDeleteDAGs={true}
             onSelectWorkflowView={vi.fn()}
             onShowAllWorkflows={onShowAllWorkflows}
             onResetWorkflowView={vi.fn()}
@@ -97,12 +107,18 @@ function renderTable(
             onSetDefaultWorkflowView={vi.fn()}
             onSetPinnedWorkflowView={vi.fn()}
             onDeleteWorkflowView={vi.fn()}
+            onDeleteDAGs={onDeleteDAGs}
           />
         </PanelWidthContext.Provider>
       </AppBarContext.Provider>
     </MemoryRouter>
   );
-  return { ...result, handleActiveOnlyChange, onShowAllWorkflows };
+  return {
+    ...result,
+    handleActiveOnlyChange,
+    onDeleteDAGs,
+    onShowAllWorkflows,
+  };
 }
 
 describe('DAGTable', () => {
@@ -165,6 +181,55 @@ describe('DAGTable', () => {
       'aria-pressed',
       'true'
     );
+  });
+
+  it('selects loaded workflows and deletes them after confirmation', async () => {
+    const { onDeleteDAGs } = renderTable('', {
+      dags: [
+        {
+          fileName: 'alpha.yaml',
+          dag: { name: 'alpha' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+        {
+          fileName: 'beta.yaml',
+          dag: { name: 'beta' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+      ],
+    });
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    fireEvent.click(
+      within(screen.getByRole('table')).getByRole('checkbox', {
+        name: 'Select all loaded workflows',
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete (2)' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Delete 2 workflows?');
+    expect(dialog).toHaveTextContent('alpha.yaml');
+    expect(dialog).toHaveTextContent('beta.yaml');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(onDeleteDAGs).toHaveBeenCalledWith(['alpha.yaml', 'beta.yaml']);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
   it('explains an empty saved view and offers to show all workflows', () => {

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -47,14 +47,21 @@ function renderTable(
     activeOnly?: boolean;
     isAllWorkflowsView?: boolean;
     panelWidth?: number | null;
-    onDeleteDAGs?: (fileNames: string[]) => Promise<void>;
+    canDeleteDAGs?: boolean;
+    canRenameDAGs?: boolean;
+    onDeleteDAGs?: React.ComponentProps<typeof DAGTable>['onDeleteDAGs'];
     onRenameDAG?: (fileName: string, newFileName: string) => Promise<void>;
   } = {}
 ) {
   const onShowAllWorkflows = vi.fn();
   const handleActiveOnlyChange = vi.fn();
   const onDeleteDAGs =
-    options.onDeleteDAGs ?? vi.fn().mockResolvedValue(undefined);
+    options.onDeleteDAGs ??
+    vi
+      .fn()
+      .mockImplementation(async (fileNames: string[]) =>
+        fileNames.map((fileName) => ({ fileName }))
+      );
   const onRenameDAG =
     options.onRenameDAG ?? vi.fn().mockResolvedValue(undefined);
   const result = render(
@@ -101,8 +108,8 @@ function renderTable(
             isAllWorkflowsView={options.isAllWorkflowsView ?? true}
             isWorkflowViewEdited={false}
             canManageWorkflowViews={true}
-            canDeleteDAGs={true}
-            canRenameDAGs={true}
+            canDeleteDAGs={options.canDeleteDAGs ?? true}
+            canRenameDAGs={options.canRenameDAGs ?? true}
             onSelectWorkflowView={vi.fn()}
             onShowAllWorkflows={onShowAllWorkflows}
             onResetWorkflowView={vi.fn()}
@@ -191,6 +198,65 @@ describe('DAGTable', () => {
     );
   });
 
+  it('hides workflow mutation controls without write permission', () => {
+    renderTable('', { canDeleteDAGs: false, canRenameDAGs: false });
+
+    const table = screen.getByRole('table');
+    expect(
+      within(table).queryByRole('checkbox', {
+        name: 'Select all loaded workflows',
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      within(table).queryByRole('button', { name: 'Rename workflow example' })
+    ).not.toBeInTheDocument();
+    expect(
+      within(table).queryByRole('button', { name: 'Delete workflow example' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('selects only workflows visible through the client-side filter', async () => {
+    renderTable('alpha', {
+      dags: [
+        {
+          fileName: 'alpha.yaml',
+          dag: { name: 'alpha' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+        {
+          fileName: 'beta.yaml',
+          dag: { name: 'beta' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+      ],
+    });
+
+    const table = screen.getByRole('table');
+    await waitFor(() => {
+      expect(within(table).queryByText('beta')).not.toBeInTheDocument();
+    });
+    fireEvent.click(
+      within(table).getByRole('checkbox', {
+        name: 'Select all loaded workflows',
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete (1)' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('alpha.yaml');
+    expect(dialog).not.toHaveTextContent('beta.yaml');
+  });
+
   it('selects loaded workflows and deletes them after confirmation', async () => {
     const { onDeleteDAGs } = renderTable('', {
       dags: [
@@ -242,6 +308,61 @@ describe('DAGTable', () => {
     expect(
       screen.queryByRole('button', { name: /^Delete \(/ })
     ).not.toBeInTheDocument();
+  });
+
+  it('keeps failed workflows selected with their individual errors', async () => {
+    const onDeleteDAGs = vi
+      .fn()
+      .mockResolvedValue([
+        { fileName: 'alpha.yaml' },
+        { fileName: 'beta.yaml', error: 'permission denied' },
+      ]);
+    renderTable('', {
+      dags: [
+        {
+          fileName: 'alpha.yaml',
+          dag: { name: 'alpha' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+        {
+          fileName: 'beta.yaml',
+          dag: { name: 'beta' },
+          latestDAGRun: {
+            status: Status.Success,
+            statusLabel: 'Success',
+          },
+          suspended: false,
+          errors: [],
+        } as never,
+      ],
+      onDeleteDAGs,
+    });
+
+    fireEvent.click(
+      within(screen.getByRole('table')).getByRole('checkbox', {
+        name: 'Select all loaded workflows',
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete (2)' }));
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' })
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).not.toHaveTextContent('alpha.yaml');
+      expect(dialog).toHaveTextContent('beta.yaml');
+      expect(dialog).toHaveTextContent('permission denied');
+    });
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' })
+    );
+    expect(screen.getByRole('button', { name: 'Delete (1)' })).toBeEnabled();
   });
 
   it('renames a workflow from the actions column', async () => {

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -170,15 +170,17 @@ describe('DAGTable', () => {
   it('toggles the active workflow filter', () => {
     const { handleActiveOnlyChange, unmount } = renderTable();
 
-    const button = screen.getByRole('button', { name: 'Active only' });
-    expect(button).toHaveAttribute('aria-pressed', 'false');
-    fireEvent.click(button);
+    const activeOnlySwitch = screen.getByRole('switch', {
+      name: 'Active only',
+    });
+    expect(activeOnlySwitch).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(activeOnlySwitch);
     expect(handleActiveOnlyChange).toHaveBeenCalledWith(true);
 
     unmount();
     renderTable('', { activeOnly: true });
-    expect(screen.getByRole('button', { name: 'Active only' })).toHaveAttribute(
-      'aria-pressed',
+    expect(screen.getByRole('switch', { name: 'Active only' })).toHaveAttribute(
+      'aria-checked',
       'true'
     );
   });

--- a/ui/src/features/dags/components/dag-list/index.ts
+++ b/ui/src/features/dags/components/dag-list/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { default as DAGTable } from './DAGTable';
+export type { DAGDeleteResult } from './DAGTable';

--- a/ui/src/layouts/ContentNavigation.tsx
+++ b/ui/src/layouts/ContentNavigation.tsx
@@ -5,7 +5,6 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
-  BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
@@ -16,7 +15,7 @@ import { Link } from 'react-router-dom';
 
 type BreadcrumbItemData = {
   label: string;
-  to?: string;
+  to: string;
 };
 
 const STATIC_ROUTE_LABELS: Record<string, string> = {
@@ -71,7 +70,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
   const items: BreadcrumbItemData[] = [{ label: 'Home', to: '/home' }];
 
   if (normalized === '/home') {
-    return [{ label: 'Home' }];
+    return items;
   }
 
   if (normalized === '/') {
@@ -79,7 +78,10 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
   }
 
   if (segments[0] === 'dags') {
-    items.push({ label: 'Workflows' }, { label: 'DAGs', to: '/dags' });
+    items.push(
+      { label: 'Workflows', to: '/dags' },
+      { label: 'DAGs', to: '/dags' }
+    );
     if (segments[1]) {
       items.push({
         label: decodePathSegment(segments[1]),
@@ -87,32 +89,54 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
       });
     }
     if (segments[2]) {
-      items.push({ label: humanizePathSegment(segments[2]) });
+      items.push({
+        label: humanizePathSegment(segments[2]),
+        to: `/dags/${segments[1]}/${segments[2]}`,
+      });
     }
     return items;
   }
 
   if (segments[0] === 'dag-runs') {
-    items.push({ label: 'Executions' }, { label: 'DAG Runs', to: '/dag-runs' });
+    items.push(
+      { label: 'Executions', to: '/dag-runs' },
+      { label: 'DAG Runs', to: '/dag-runs' }
+    );
     if (segments[1]) {
-      items.push({ label: decodePathSegment(segments[1]) });
+      const dagName = decodePathSegment(segments[1]);
+      items.push({
+        label: dagName,
+        to: `/dag-runs?name=${encodeURIComponent(dagName)}`,
+      });
     }
     if (segments[2]) {
-      items.push({ label: decodePathSegment(segments[2]) });
+      items.push({
+        label: decodePathSegment(segments[2]),
+        to: `/dag-runs/${segments[1]}/${segments[2]}`,
+      });
     }
     return items;
   }
 
   if (segments[0] === 'queues') {
-    items.push({ label: 'Executions' }, { label: 'Queues', to: '/queues' });
+    items.push(
+      { label: 'Executions', to: '/dag-runs' },
+      { label: 'Queues', to: '/queues' }
+    );
     if (segments[1]) {
-      items.push({ label: decodePathSegment(segments[1]) });
+      items.push({
+        label: decodePathSegment(segments[1]),
+        to: `/queues/${segments[1]}`,
+      });
     }
     return items;
   }
 
   if (segments[0] === 'docs') {
-    items.push({ label: 'Workflows' }, { label: 'Docs', to: '/docs' });
+    items.push(
+      { label: 'Workflows', to: '/dags' },
+      { label: 'Docs', to: '/docs' }
+    );
     let docsPath = '/docs';
     for (const segment of segments.slice(1)) {
       docsPath += `/${segment}`;
@@ -139,6 +163,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
       label:
         STATIC_ROUTE_LABELS[normalized] ??
         humanizePathSegment(segments[0] ?? ''),
+      to: normalized,
     });
     return items;
   }
@@ -146,11 +171,12 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
   if (
     ['system-status', 'event-logs', 'audit-logs'].includes(segments[0] ?? '')
   ) {
-    items.push({ label: 'Monitor' });
+    items.push({ label: 'Monitor', to: '/system-status' });
     items.push({
       label:
         STATIC_ROUTE_LABELS[normalized] ??
         humanizePathSegment(segments[0] ?? ''),
+      to: normalized,
     });
     return items;
   }
@@ -163,6 +189,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
       label:
         STATIC_ROUTE_LABELS[normalized] ??
         humanizePathSegment(segments[0] ?? ''),
+      to: normalized,
     });
     return items;
   }
@@ -179,6 +206,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
       label:
         STATIC_ROUTE_LABELS[normalized] ??
         humanizePathSegment(segments[0] ?? ''),
+      to: normalized,
     });
     return items;
   }
@@ -195,7 +223,19 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
       label:
         STATIC_ROUTE_LABELS[normalized] ??
         humanizePathSegment(segments[0] ?? ''),
+      to: normalized,
     });
+    return items;
+  }
+
+  if (segments[0] === 'views' && segments[1]) {
+    items.push(
+      { label: 'Cockpit', to: '/cockpit' },
+      {
+        label: decodePathSegment(segments[1]),
+        to: `/views/${segments[1]}`,
+      }
+    );
     return items;
   }
 
@@ -210,7 +250,7 @@ export function getBreadcrumbItems(pathname: string): BreadcrumbItemData[] {
     items.push({
       label:
         STATIC_ROUTE_LABELS[path] ?? humanizePathSegment(segments[index] ?? ''),
-      to: index === segments.length - 1 ? undefined : path,
+      to: path,
     });
   }
 
@@ -239,23 +279,19 @@ export function ContentNavigation({
               <React.Fragment key={`${item.label}-${index}`}>
                 {index > 0 && <BreadcrumbSeparator className="shrink-0" />}
                 <BreadcrumbItem className="min-w-0">
-                  {isLast || !item.to ? (
-                    <BreadcrumbPage
-                      className={cn(
-                        'block truncate',
-                        item.label.length > 28 && 'max-w-[28ch]'
-                      )}
-                    >
-                      {item.label}
-                    </BreadcrumbPage>
-                  ) : (
-                    <Link
-                      to={item.to}
-                      className="block truncate text-muted-foreground hover:text-foreground"
-                    >
-                      {item.label}
-                    </Link>
-                  )}
+                  <Link
+                    to={item.to}
+                    aria-current={isLast ? 'page' : undefined}
+                    className={cn(
+                      'block truncate hover:text-foreground',
+                      isLast
+                        ? 'font-medium text-foreground'
+                        : 'text-muted-foreground',
+                      item.label.length > 28 && 'max-w-[28ch]'
+                    )}
+                  >
+                    {item.label}
+                  </Link>
                 </BreadcrumbItem>
               </React.Fragment>
             );

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -56,13 +56,29 @@ describe('Layout', () => {
       'href',
       '/home'
     );
-    expect(screen.getByRole('link', { name: 'DAG Runs' })).toHaveAttribute(
-      'href',
-      '/dag-runs'
-    );
-    expect(screen.getByText('briefing_gmail_fetch_test')).toBeVisible();
+    const breadcrumbs = screen.getByRole('navigation', { name: 'breadcrumb' });
     expect(
-      screen.getByText('019df6cf-0127-7340-bd96-d51bc1453045')
-    ).toBeVisible();
+      within(breadcrumbs).getByRole('link', { name: 'Home' })
+    ).toHaveAttribute('href', '/home');
+    expect(
+      within(breadcrumbs).getByRole('link', { name: 'Executions' })
+    ).toHaveAttribute('href', '/dag-runs');
+    expect(
+      within(breadcrumbs).getByRole('link', { name: 'DAG Runs' })
+    ).toHaveAttribute('href', '/dag-runs');
+    expect(
+      within(breadcrumbs).getByRole('link', {
+        name: 'briefing_gmail_fetch_test',
+      })
+    ).toHaveAttribute('href', '/dag-runs?name=briefing_gmail_fetch_test');
+    expect(
+      within(breadcrumbs).getByRole('link', {
+        name: '019df6cf-0127-7340-bd96-d51bc1453045',
+      })
+    ).toHaveAttribute(
+      'href',
+      '/dag-runs/briefing_gmail_fetch_test/019df6cf-0127-7340-bd96-d51bc1453045'
+    );
+    expect(within(breadcrumbs).getAllByRole('link')).toHaveLength(5);
   });
 });

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -79,6 +79,11 @@ describe('Layout', () => {
       'href',
       '/dag-runs/briefing_gmail_fetch_test/019df6cf-0127-7340-bd96-d51bc1453045'
     );
+    expect(
+      within(breadcrumbs).getByRole('link', {
+        name: '019df6cf-0127-7340-bd96-d51bc1453045',
+      })
+    ).toHaveAttribute('aria-current', 'page');
     expect(within(breadcrumbs).getAllByRole('link')).toHaveLength(5);
   });
 });

--- a/ui/src/pages/dags/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/__tests__/index.test.tsx
@@ -30,7 +30,9 @@ const {
   clientGetMock,
   clientPostMock,
   createViewMock,
+  deleteResultsMock,
   deleteViewMock,
+  renameErrorMock,
   sharedWorkflowViewState,
   updateViewMock,
   userPreferences,
@@ -39,7 +41,9 @@ const {
   clientGetMock: vi.fn(),
   clientPostMock: vi.fn(),
   createViewMock: vi.fn(),
+  deleteResultsMock: vi.fn(),
   deleteViewMock: vi.fn(),
+  renameErrorMock: vi.fn(),
   sharedWorkflowViewState: { views: [] as View[] },
   updateViewMock: vi.fn(),
   userPreferences: {
@@ -121,7 +125,9 @@ vi.mock('@/features/dags/components/dag-list', () => ({
     onSetDefaultWorkflowView: (viewId: string | undefined) => Promise<void>;
     onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
     onDeleteWorkflowView: (viewId: string) => Promise<void>;
-    onDeleteDAGs: (fileNames: string[]) => Promise<void>;
+    onDeleteDAGs: (
+      fileNames: string[]
+    ) => Promise<Array<{ fileName: string; error?: string }>>;
     onRenameDAG: (fileName: string, newFileName: string) => Promise<void>;
   }) => (
     <div>
@@ -144,6 +150,7 @@ vi.mock('@/features/dags/components/dag-list', () => ({
       >
         Open demo workflow
       </button>
+      <span data-testid="selected-dag">{selectedDAG ?? 'none'}</span>
       <span data-testid="active-workflow-view">
         {activeWorkflowViewId ?? 'none'}
       </span>
@@ -185,12 +192,32 @@ vi.mock('@/features/dags/components/dag-list', () => ({
       >
         Delete production view
       </button>
-      <button type="button" onClick={() => void onDeleteDAGs(['demo.yaml'])}>
+      <button
+        type="button"
+        onClick={() => void onDeleteDAGs(['demo.yaml']).then(deleteResultsMock)}
+      >
         Delete demo workflow
       </button>
       <button
         type="button"
-        onClick={() => void onRenameDAG('demo.yaml', 'renamed.yaml')}
+        onClick={() =>
+          void onDeleteDAGs([
+            'one.yaml',
+            'two.yaml',
+            'three.yaml',
+            'four.yaml',
+            'five.yaml',
+            'six.yaml',
+          ]).then(deleteResultsMock)
+        }
+      >
+        Delete workflow batch
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void onRenameDAG('demo.yaml', 'renamed.yaml').catch(renameErrorMock)
+        }
       >
         Rename demo workflow
       </button>
@@ -383,9 +410,11 @@ describe('DagsPage', () => {
     calls.length = 0;
     clientDeleteMock.mockReset();
     clientDeleteMock.mockResolvedValue({});
+    deleteResultsMock.mockReset();
     clientGetMock.mockReset();
     clientPostMock.mockReset();
     clientPostMock.mockResolvedValue({});
+    renameErrorMock.mockReset();
     sharedWorkflowViewState.views = [];
     createViewMock.mockReset();
     updateViewMock.mockReset();
@@ -890,6 +919,9 @@ describe('DagsPage', () => {
   it('deletes selected workflows through the existing DAG endpoint', async () => {
     renderPage();
 
+    fireEvent.click(screen.getByRole('button', { name: 'Open demo workflow' }));
+    expect(screen.getByTestId('selected-dag')).toHaveTextContent('demo.yaml');
+
     await act(async () => {
       fireEvent.click(
         screen.getByRole('button', { name: 'Delete demo workflow' })
@@ -902,10 +934,65 @@ describe('DagsPage', () => {
         query: { remoteNode: 'remote-a' },
       },
     });
+    expect(screen.getByTestId('selected-dag')).toHaveTextContent('none');
+    expect(deleteResultsMock).toHaveBeenCalledWith([
+      { fileName: 'demo.yaml', error: undefined },
+    ]);
+  });
+
+  it('returns the individual delete error without clearing the selection', async () => {
+    clientDeleteMock.mockResolvedValueOnce({
+      error: { message: 'workflow is read-only' },
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Open demo workflow' }));
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Delete demo workflow' })
+      );
+    });
+
+    expect(deleteResultsMock).toHaveBeenCalledWith([
+      { fileName: 'demo.yaml', error: 'workflow is read-only' },
+    ]);
+    expect(screen.getByTestId('selected-dag')).toHaveTextContent('demo.yaml');
+  });
+
+  it('limits concurrent workflow deletion requests', async () => {
+    const pendingDeletes: Array<(value: object) => void> = [];
+    clientDeleteMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pendingDeletes.push(resolve);
+        })
+    );
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete workflow batch' })
+    );
+    expect(clientDeleteMock).toHaveBeenCalledTimes(5);
+
+    await act(async () => {
+      pendingDeletes.splice(0).forEach((resolve) => resolve({}));
+      await Promise.resolve();
+    });
+    expect(clientDeleteMock).toHaveBeenCalledTimes(6);
+
+    await act(async () => {
+      pendingDeletes.splice(0).forEach((resolve) => resolve({}));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(deleteResultsMock).toHaveBeenCalledOnce();
   });
 
   it('renames workflows through the existing DAG endpoint', async () => {
     renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open demo workflow' }));
+    expect(screen.getByTestId('selected-dag')).toHaveTextContent('demo.yaml');
 
     await act(async () => {
       fireEvent.click(
@@ -920,6 +1007,26 @@ describe('DagsPage', () => {
       },
       body: { newFileName: 'renamed.yaml' },
     });
+    expect(screen.getByTestId('selected-dag')).toHaveTextContent(
+      'renamed.yaml'
+    );
+  });
+
+  it('surfaces workflow rename errors', async () => {
+    clientPostMock.mockResolvedValueOnce({
+      error: { message: 'name already exists' },
+    });
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Rename demo workflow' })
+      );
+    });
+
+    expect(renameErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'name already exists' })
+    );
   });
 
   it('opens workflow details in the page-level modal when a table row is selected', () => {

--- a/ui/src/pages/dags/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/__tests__/index.test.tsx
@@ -26,6 +26,7 @@ import { WorkspaceKind, workspaceSelectionKey } from '@/lib/workspace';
 import DagsPage from '../index';
 
 const {
+  clientDeleteMock,
   clientGetMock,
   createViewMock,
   deleteViewMock,
@@ -33,6 +34,7 @@ const {
   updateViewMock,
   userPreferences,
 } = vi.hoisted(() => ({
+  clientDeleteMock: vi.fn(),
   clientGetMock: vi.fn(),
   createViewMock: vi.fn(),
   deleteViewMock: vi.fn(),
@@ -94,6 +96,7 @@ vi.mock('@/features/dags/components/dag-list', () => ({
     onSetDefaultWorkflowView,
     onSetPinnedWorkflowView,
     onDeleteWorkflowView,
+    onDeleteDAGs,
   }: {
     dags: Array<{ fileName: string; dag: { name: string } }>;
     searchText: string;
@@ -115,6 +118,7 @@ vi.mock('@/features/dags/components/dag-list', () => ({
     onSetDefaultWorkflowView: (viewId: string | undefined) => Promise<void>;
     onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
     onDeleteWorkflowView: (viewId: string) => Promise<void>;
+    onDeleteDAGs: (fileNames: string[]) => Promise<void>;
   }) => (
     <div>
       <input
@@ -177,6 +181,9 @@ vi.mock('@/features/dags/components/dag-list', () => ({
       >
         Delete production view
       </button>
+      <button type="button" onClick={() => void onDeleteDAGs(['demo.yaml'])}>
+        Delete demo workflow
+      </button>
       <ul>
         {dags.map((dag) => (
           <li key={dag.fileName}>{dag.fileName}</li>
@@ -193,6 +200,7 @@ vi.mock('@/features/dags/components/dag-list/DAGListHeader', () => ({
 vi.mock('@/hooks/api', () => ({
   useQuery: vi.fn(),
   useClient: () => ({
+    DELETE: clientDeleteMock,
     GET: clientGetMock,
   }),
 }));
@@ -362,6 +370,8 @@ describe('DagsPage', () => {
     localStorage.clear();
     sessionStorage.clear();
     calls.length = 0;
+    clientDeleteMock.mockReset();
+    clientDeleteMock.mockResolvedValue({});
     clientGetMock.mockReset();
     sharedWorkflowViewState.views = [];
     createViewMock.mockReset();
@@ -862,6 +872,23 @@ describe('DagsPage', () => {
     expect(screen.getByTestId('active-workflow-view')).toHaveTextContent(
       'none'
     );
+  });
+
+  it('deletes selected workflows through the existing DAG endpoint', async () => {
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Delete demo workflow' })
+      );
+    });
+
+    expect(clientDeleteMock).toHaveBeenCalledWith('/dags/{fileName}', {
+      params: {
+        path: { fileName: 'demo.yaml' },
+        query: { remoteNode: 'remote-a' },
+      },
+    });
   });
 
   it('opens workflow details in the page-level modal when a table row is selected', () => {

--- a/ui/src/pages/dags/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/__tests__/index.test.tsx
@@ -28,6 +28,7 @@ import DagsPage from '../index';
 const {
   clientDeleteMock,
   clientGetMock,
+  clientPostMock,
   createViewMock,
   deleteViewMock,
   sharedWorkflowViewState,
@@ -36,6 +37,7 @@ const {
 } = vi.hoisted(() => ({
   clientDeleteMock: vi.fn(),
   clientGetMock: vi.fn(),
+  clientPostMock: vi.fn(),
   createViewMock: vi.fn(),
   deleteViewMock: vi.fn(),
   sharedWorkflowViewState: { views: [] as View[] },
@@ -97,6 +99,7 @@ vi.mock('@/features/dags/components/dag-list', () => ({
     onSetPinnedWorkflowView,
     onDeleteWorkflowView,
     onDeleteDAGs,
+    onRenameDAG,
   }: {
     dags: Array<{ fileName: string; dag: { name: string } }>;
     searchText: string;
@@ -119,6 +122,7 @@ vi.mock('@/features/dags/components/dag-list', () => ({
     onSetPinnedWorkflowView: (viewId: string, pinned: boolean) => Promise<void>;
     onDeleteWorkflowView: (viewId: string) => Promise<void>;
     onDeleteDAGs: (fileNames: string[]) => Promise<void>;
+    onRenameDAG: (fileName: string, newFileName: string) => Promise<void>;
   }) => (
     <div>
       <input
@@ -184,6 +188,12 @@ vi.mock('@/features/dags/components/dag-list', () => ({
       <button type="button" onClick={() => void onDeleteDAGs(['demo.yaml'])}>
         Delete demo workflow
       </button>
+      <button
+        type="button"
+        onClick={() => void onRenameDAG('demo.yaml', 'renamed.yaml')}
+      >
+        Rename demo workflow
+      </button>
       <ul>
         {dags.map((dag) => (
           <li key={dag.fileName}>{dag.fileName}</li>
@@ -202,6 +212,7 @@ vi.mock('@/hooks/api', () => ({
   useClient: () => ({
     DELETE: clientDeleteMock,
     GET: clientGetMock,
+    POST: clientPostMock,
   }),
 }));
 
@@ -373,6 +384,8 @@ describe('DagsPage', () => {
     clientDeleteMock.mockReset();
     clientDeleteMock.mockResolvedValue({});
     clientGetMock.mockReset();
+    clientPostMock.mockReset();
+    clientPostMock.mockResolvedValue({});
     sharedWorkflowViewState.views = [];
     createViewMock.mockReset();
     updateViewMock.mockReset();
@@ -888,6 +901,24 @@ describe('DagsPage', () => {
         path: { fileName: 'demo.yaml' },
         query: { remoteNode: 'remote-a' },
       },
+    });
+  });
+
+  it('renames workflows through the existing DAG endpoint', async () => {
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Rename demo workflow' })
+      );
+    });
+
+    expect(clientPostMock).toHaveBeenCalledWith('/dags/{fileName}/rename', {
+      params: {
+        path: { fileName: 'demo.yaml' },
+        query: { remoteNode: 'remote-a' },
+      },
+      body: { newFileName: 'renamed.yaml' },
     });
   });
 

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -18,7 +18,10 @@ import { useSearchState } from '../../contexts/SearchStateContext';
 import { useUserPreferences } from '../../contexts/UserPreference';
 import { DAGDetailsModal } from '../../features/dags/components/dag-details';
 import { DAGErrors } from '../../features/dags/components/dag-editor';
-import { DAGTable } from '../../features/dags/components/dag-list';
+import {
+  DAGTable,
+  type DAGDeleteResult,
+} from '../../features/dags/components/dag-list';
 import DAGListHeader from '../../features/dags/components/dag-list/DAGListHeader';
 import type {
   WorkflowFilterSet,
@@ -73,6 +76,7 @@ const areDAGDefinitionsFiltersEqual = (
   a.sortOrder === b.sortOrder;
 
 const ALL_WORKFLOWS_VIEW_PARAM = 'all';
+const DELETE_BATCH_SIZE = 5;
 
 function normalizeWorkflowSortField(value?: string | null): ViewSortField {
   return value === ViewSortField.nextRun
@@ -671,37 +675,44 @@ function DAGsContent() {
   }, [mutate, resetLoadedPages]);
 
   const handleDeleteDAGs = React.useCallback(
-    async (fileNames: string[]): Promise<void> => {
-      const results = await Promise.all(
-        fileNames.map(async (fileName) => {
-          try {
-            const { error } = await client.DELETE('/dags/{fileName}', {
-              params: {
-                path: { fileName },
-                query: { remoteNode },
-              },
-            });
-            return {
-              fileName,
-              error: error
-                ? error.message || 'The delete request failed'
-                : undefined,
-            };
-          } catch (error) {
-            return {
-              fileName,
-              error:
-                error instanceof Error
-                  ? error.message
-                  : 'Unexpected server error',
-            };
-          }
-        })
-      );
+    async (fileNames: string[]): Promise<DAGDeleteResult[]> => {
+      const deleteOne = async (fileName: string): Promise<DAGDeleteResult> => {
+        try {
+          const { error } = await client.DELETE('/dags/{fileName}', {
+            params: {
+              path: { fileName },
+              query: { remoteNode },
+            },
+          });
+          return {
+            fileName,
+            error: error
+              ? error.message || 'The delete request failed'
+              : undefined,
+          };
+        } catch (error) {
+          return {
+            fileName,
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Unexpected server error',
+          };
+        }
+      };
+
+      const results: DAGDeleteResult[] = [];
+      for (
+        let index = 0;
+        index < fileNames.length;
+        index += DELETE_BATCH_SIZE
+      ) {
+        const batch = fileNames.slice(index, index + DELETE_BATCH_SIZE);
+        results.push(...(await Promise.all(batch.map(deleteOne))));
+      }
       const deletedFileNames = results
         .filter((result) => !result.error)
         .map((result) => result.fileName);
-      const failures = results.filter((result) => result.error);
 
       if (deletedFileNames.length > 0) {
         if (selectedDAG && deletedFileNames.includes(selectedDAG)) {
@@ -711,19 +722,7 @@ function DAGsContent() {
         await mutate();
       }
 
-      if (failures.length === 1) {
-        const [failure] = failures;
-        throw new Error(
-          `Failed to delete "${failure?.fileName}": ${failure?.error}`
-        );
-      }
-      if (failures.length > 1) {
-        throw new Error(
-          `Failed to delete ${failures.length} workflows: ${failures
-            .map((failure) => failure.fileName)
-            .join(', ')}`
-        );
-      }
+      return results;
     },
     [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
   );

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -670,6 +670,64 @@ function DAGsContent() {
     setTimeout(() => mutate(), 500);
   }, [mutate, resetLoadedPages]);
 
+  const handleDeleteDAGs = React.useCallback(
+    async (fileNames: string[]): Promise<void> => {
+      const results = await Promise.all(
+        fileNames.map(async (fileName) => {
+          try {
+            const { error } = await client.DELETE('/dags/{fileName}', {
+              params: {
+                path: { fileName },
+                query: { remoteNode },
+              },
+            });
+            return {
+              fileName,
+              error: error
+                ? error.message || 'The delete request failed'
+                : undefined,
+            };
+          } catch (error) {
+            return {
+              fileName,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Unexpected server error',
+            };
+          }
+        })
+      );
+      const deletedFileNames = results
+        .filter((result) => !result.error)
+        .map((result) => result.fileName);
+      const failures = results.filter((result) => result.error);
+
+      if (deletedFileNames.length > 0) {
+        if (selectedDAG && deletedFileNames.includes(selectedDAG)) {
+          setSelectedDAG(null);
+        }
+        resetLoadedPages();
+        await mutate();
+      }
+
+      if (failures.length === 1) {
+        const [failure] = failures;
+        throw new Error(
+          `Failed to delete "${failure?.fileName}": ${failure?.error}`
+        );
+      }
+      if (failures.length > 1) {
+        throw new Error(
+          `Failed to delete ${failures.length} workflows: ${failures
+            .map((failure) => failure.fileName)
+            .join(', ')}`
+        );
+      }
+    },
+    [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
+  );
+
   const handleSelectDAG = React.useCallback((fileName: string) => {
     setSelectedDAG(fileName);
   }, []);
@@ -1021,6 +1079,7 @@ function DAGsContent() {
             isAllWorkflowsView={isAllWorkflowsView}
             isWorkflowViewEdited={isWorkflowViewEdited}
             canManageWorkflowViews={canManageWorkflowViews}
+            canDeleteDAGs={canManageWorkflowViews}
             workflowViewError={workflowViewError}
             onSelectWorkflowView={handleSelectWorkflowView}
             onShowAllWorkflows={handleShowAllWorkflows}
@@ -1030,6 +1089,7 @@ function DAGsContent() {
             onSetDefaultWorkflowView={handleSetDefaultWorkflowView}
             onSetPinnedWorkflowView={handleSetPinnedWorkflowView}
             onDeleteWorkflowView={handleDeleteWorkflowView}
+            onDeleteDAGs={handleDeleteDAGs}
             resultCount={data.pagination.totalRecords}
             selectedDAG={selectedDAG}
             onSelectDAG={handleSelectDAG}

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -728,6 +728,28 @@ function DAGsContent() {
     [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
   );
 
+  const handleRenameDAG = React.useCallback(
+    async (fileName: string, newFileName: string): Promise<void> => {
+      const { error } = await client.POST('/dags/{fileName}/rename', {
+        params: {
+          path: { fileName },
+          query: { remoteNode },
+        },
+        body: { newFileName },
+      });
+      if (error) {
+        throw new Error(error.message || 'Failed to rename workflow');
+      }
+
+      if (selectedDAG === fileName) {
+        setSelectedDAG(newFileName);
+      }
+      resetLoadedPages();
+      await mutate();
+    },
+    [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
+  );
+
   const handleSelectDAG = React.useCallback((fileName: string) => {
     setSelectedDAG(fileName);
   }, []);
@@ -1080,6 +1102,7 @@ function DAGsContent() {
             isWorkflowViewEdited={isWorkflowViewEdited}
             canManageWorkflowViews={canManageWorkflowViews}
             canDeleteDAGs={canManageWorkflowViews}
+            canRenameDAGs={canManageWorkflowViews}
             workflowViewError={workflowViewError}
             onSelectWorkflowView={handleSelectWorkflowView}
             onShowAllWorkflows={handleShowAllWorkflows}
@@ -1090,6 +1113,7 @@ function DAGsContent() {
             onSetPinnedWorkflowView={handleSetPinnedWorkflowView}
             onDeleteWorkflowView={handleDeleteWorkflowView}
             onDeleteDAGs={handleDeleteDAGs}
+            onRenameDAG={handleRenameDAG}
             resultCount={data.pagination.totalRecords}
             selectedDAG={selectedDAG}
             onSelectDAG={handleSelectDAG}


### PR DESCRIPTION
## Summary

- add workflow selection with contextual bulk deletion and confirmation
- add per-workflow rename and delete actions using the existing APIs
- replace the ambiguous active-only button with a clear switch
- make every breadcrumb segment navigable

## Why

Workflow management actions were incomplete or visually unclear in the frontend. This makes destructive actions explicit, keeps bulk controls contextual, and improves navigation without changing the API.

## User impact

Users with workflow-management permission can rename or delete a single workflow from its action column, select multiple workflows for deletion, understand the active-only filter state at a glance, and navigate through every breadcrumb segment.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint --max-warnings=0 ...`
- `pnpm test` (571 tests)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-workflow rename/delete actions and bulk deletion with confirmation to the workflow list, replaces the ambiguous “Active only” button with a clear switch, and makes every breadcrumb segment clickable for easier navigation. Actions are permission-gated to users who can manage workflows and reuse existing DAG APIs.

- **New Features**
  - Bulk delete from the list with checkboxes and a confirmation dialog; run history is preserved; uses `DELETE /dags/{fileName}`.
  - Per-row rename and delete buttons; rename uses a modal and `POST /dags/{fileName}/rename`; error states are surfaced.
  - “Active only” is now a switch for clear on/off state.
  - Breadcrumbs are fully navigable; each segment is a link with proper aria-current.

- **Bug Fixes**
  - “Select all” now selects only workflows visible in the current client-side filter.
  - Partial deletes show per-item errors and keep failed workflows selected for retry.

<sup>Written for commit f964c15dd493d65c1356acdcb540732083bfaf5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permission-controlled options to rename and delete workflows.
  - Added single and bulk workflow selection with select-all support.
  - Added deletion confirmation dialogs and error reporting.
  - Improved the active-workflow filter with a switch control.
  - Added navigable breadcrumbs across key areas of the application.

- **Bug Fixes**
  - Workflow list refreshes and pagination now update correctly after renaming or deleting workflows.
  - Breadcrumbs now provide clearer navigation and current-page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->