### PR TITLE
fix(api): restore S3, Redis and Kubernetes defaults on dag-run snapshot

### DIFF
--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -627,16 +627,20 @@ func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG, paramsOve
 	if err != nil {
 		return nil, err
 	}
-	fresh.SourceFile = dag.SourceFile
-
+	// Restore the fields excluded from JSON serialization (json:"-"), which the
+	// snapshot cannot carry. Every other field is already stored in dag.json.
 	dag.Env = fresh.Env
 	dag.Params = fresh.Params
 	dag.ParamsJSON = fresh.ParamsJSON
 	dag.SMTP = fresh.SMTP
 	dag.SSH = fresh.SSH
+	dag.S3 = fresh.S3
+	dag.Redis = fresh.Redis
 	dag.RegistryAuths = fresh.RegistryAuths
 	dag.Harness = fresh.Harness
 	dag.Harnesses = fresh.Harnesses
+	dag.Kubernetes = fresh.Kubernetes
+	dag.WorkingDirExplicit = fresh.WorkingDirExplicit
 
 	core.InitializeDefaults(dag)
 

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -976,8 +976,11 @@ func TestRebuildDAGRunSnapshotFromYAMLRestoresExecutorDefaults(t *testing.T) {
 	t.Parallel()
 
 	workingDir := t.TempDir()
+	// WorkingDir is persisted in dag.json while WorkingDirExplicit is not, so a
+	// snapshot arrives with the path set and the flag cleared.
 	dag := &core.DAG{
-		Name: "snapshot-executor-defaults",
+		Name:       "snapshot-executor-defaults",
+		WorkingDir: workingDir,
 		YamlData: fmt.Appendf(nil, `
 working_dir: %q
 s3:
@@ -1009,4 +1012,5 @@ steps:
 	assert.Equal(t, "dag-ns", restored.Kubernetes["namespace"])
 
 	assert.True(t, restored.WorkingDirExplicit)
+	assert.Equal(t, workingDir, restored.WorkingDir)
 }

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -969,4 +970,43 @@ steps:
 	assert.Equal(t, "gemini", restored.Harnesses["gemini"].Binary)
 	assert.Equal(t, core.HarnessPromptModeFlag, restored.Harnesses["gemini"].PromptMode)
 	assert.Equal(t, "--prompt", restored.Harnesses["gemini"].PromptFlag)
+}
+
+func TestRebuildDAGRunSnapshotFromYAMLRestoresExecutorDefaults(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	dag := &core.DAG{
+		Name: "snapshot-executor-defaults",
+		YamlData: fmt.Appendf(nil, `
+working_dir: %q
+s3:
+  region: us-west-2
+  bucket: snapshot-bucket
+redis:
+  host: redis.internal
+  port: 6380
+kubernetes:
+  namespace: dag-ns
+steps:
+  - run: echo hello
+`, workingDir),
+	}
+
+	restored, err := rebuildDAGRunSnapshotFromYAML(context.Background(), dag)
+	require.NoError(t, err)
+	require.Same(t, dag, restored)
+
+	require.NotNil(t, restored.S3)
+	assert.Equal(t, "us-west-2", restored.S3.Region)
+	assert.Equal(t, "snapshot-bucket", restored.S3.Bucket)
+
+	require.NotNil(t, restored.Redis)
+	assert.Equal(t, "redis.internal", restored.Redis.Host)
+	assert.Equal(t, 6380, restored.Redis.Port)
+
+	require.NotNil(t, restored.Kubernetes)
+	assert.Equal(t, "dag-ns", restored.Kubernetes["namespace"])
+
+	assert.True(t, restored.WorkingDirExplicit)
 }

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -975,12 +975,15 @@ steps:
 func TestRebuildDAGRunSnapshotFromYAMLRestoresExecutorDefaults(t *testing.T) {
 	t.Parallel()
 
-	workingDir := t.TempDir()
 	// WorkingDir is persisted in dag.json while WorkingDirExplicit is not, so a
-	// snapshot arrives with the path set and the flag cleared.
+	// snapshot arrives with the path set and the flag cleared. The YAML declares a
+	// different path so the assertions below distinguish the snapshot's persisted
+	// value from the one a rebuild would produce.
+	snapshotWorkingDir := t.TempDir()
+	yamlWorkingDir := t.TempDir()
 	dag := &core.DAG{
 		Name:       "snapshot-executor-defaults",
-		WorkingDir: workingDir,
+		WorkingDir: snapshotWorkingDir,
 		YamlData: fmt.Appendf(nil, `
 working_dir: %q
 s3:
@@ -993,7 +996,7 @@ kubernetes:
   namespace: dag-ns
 steps:
   - run: echo hello
-`, workingDir),
+`, yamlWorkingDir),
 	}
 
 	restored, err := rebuildDAGRunSnapshotFromYAML(context.Background(), dag)
@@ -1011,6 +1014,9 @@ steps:
 	require.NotNil(t, restored.Kubernetes)
 	assert.Equal(t, "dag-ns", restored.Kubernetes["namespace"])
 
+	// WorkingDirExplicit is json:"-", so only the rebuild can restore it.
 	assert.True(t, restored.WorkingDirExplicit)
-	assert.Equal(t, workingDir, restored.WorkingDir)
+	// WorkingDir already survived in dag.json, so the rebuild must neither blank
+	// it nor replace it with the value it just parsed out of the YAML.
+	assert.Equal(t, snapshotWorkingDir, restored.WorkingDir)
 }


### PR DESCRIPTION
## Problem

Fields tagged `json:"-"` on `core.DAG` are absent from the persisted `dag.json`, so they exist only after the snapshot is rebuilt from the stored YAML.

`rebuildDAGRunSnapshotFromYAML` (`internal/service/frontend/api/v1/dagruns.go`) restored 8 of them. The equivalent CLI path, `rebuildDAGFromYAML` (`internal/cmd/helper.go`), restores 12.

| Field | CLI path | API path (before) |
|---|---|---|
| `Env`, `Params`, `ParamsJSON`, `SMTP`, `SSH`, `RegistryAuths`, `Harness`, `Harnesses` | yes | yes |
| `S3` | yes | **no** |
| `Redis` | yes | **no** |
| `Kubernetes` | yes | **no** |
| `WorkingDirExplicit` | yes | **no** |

Reached from `restoreDAGRunSnapshot` via `dagruns.go` (re-run) and `dagruns_edit_retry.go` (edit-and-retry) — both API retry paths.

Effect: steps inheriting DAG-level `s3:`, `redis:` or `kubernetes:` configuration lost it when a run was retried through the API, while the same retry from the CLI kept it. A DAG with an explicit `working_dir` had that directory treated as auto-defaulted.

## Fix

Restore the four missing fields. Also removes an assignment to `fresh.SourceFile` — the function returns `dag`, not `fresh`, so it had no effect.

## Test

`TestRebuildDAGRunSnapshotFromYAMLRestoresExecutorDefaults` was written first and fails on `main`:

```
--- FAIL: TestRebuildDAGRunSnapshotFromYAMLRestoresExecutorDefaults
    Error: Expected value not to be nil.
```

It passes with the fix.

## Note on the root cause

Both call sites maintain this field list by hand, so every new secret-bearing field has to be added in two places. This one was not — the adjacent `TestRebuildDAGRunSnapshotFromYAMLRestoresHarnessConfig` shows `Harness`/`Harnesses` being added the same ad-hoc way earlier. Sharing the list between the two paths, and deriving it from the struct tags so it cannot drift, is a separate change.

The two paths also merge `Env` differently (`buildenv.AppendMissing` over four sources in the CLI path vs. plain `fresh.Env` here). That needs a decision on which is correct and is deliberately left alone here.

## Verification

- `go test -race ./internal/service/frontend/api/v1/` passes
- `golangci-lint run internal/service/frontend/api/v1/...` — 0 issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores missing executor defaults in API dag-run snapshot rebuild: S3, Redis, Kubernetes, and the explicit working_dir flag. Aligns API retries with CLI and prevents loss of DAG-level config on retries.

- **Bug Fixes**
  - Restore `S3`, `Redis`, `Kubernetes`, and `WorkingDirExplicit` in `rebuildDAGRunSnapshotFromYAML`, matching `rebuildDAGFromYAML`.
  - Fix loss of inherited `s3`, `redis`, and `kubernetes` settings on API retries (re-run and edit-and-retry).
  - Remove no-op `fresh.SourceFile` assignment.
  - Strengthen tests: ensure `WorkingDir` survives snapshot rebuild and is not replaced by the YAML value; `WorkingDirExplicit` is restored.

<sup>Written for commit 39df789a8a8a00c83dc609c55231aadd9076bbbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DAG run snapshots now correctly restore executor settings from YAML, including working directory, S3, Redis, and Kubernetes configuration.
  - Explicit working-directory settings are preserved when rebuilding snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->