### PR TITLE
fix(api): preserve presolved build env when rebuilding a dag-run snapshot

### DIFF
--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -586,6 +586,7 @@ func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG, paramsOve
 		return dag, nil
 	}
 
+	loadedEnv := append([]string{}, dag.Env...)
 	buildEnvMap := buildenv.ToMap(dag.Env)
 	for key, value := range dag.PresolvedBuildEnv {
 		if buildEnvMap == nil {
@@ -598,6 +599,7 @@ func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG, paramsOve
 	if err != nil {
 		return nil, fmt.Errorf("failed to load presolved build env: %w", err)
 	}
+	transportEnv := buildenv.FromMap(presolvedBuildEnv)
 	for key, value := range presolvedBuildEnv {
 		if buildEnvMap == nil {
 			buildEnvMap = make(map[string]string)
@@ -629,7 +631,11 @@ func rebuildDAGRunSnapshotFromYAML(ctx context.Context, dag *core.DAG, paramsOve
 	}
 	// Restore the fields excluded from JSON serialization (json:"-"), which the
 	// snapshot cannot carry. Every other field is already stored in dag.json.
-	dag.Env = fresh.Env
+	//
+	// Env falls back, first-wins, to entries resolved when the run was first
+	// built. Keys the rebuilt YAML declares take precedence; keys it cannot
+	// resolve at all are recovered from the snapshot rather than dropped.
+	dag.Env = buildenv.AppendMissing(fresh.Env, loadedEnv, buildenv.FromMap(dag.PresolvedBuildEnv), transportEnv)
 	dag.Params = fresh.Params
 	dag.ParamsJSON = fresh.ParamsJSON
 	dag.SMTP = fresh.SMTP

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -1020,3 +1020,28 @@ steps:
 	// it nor replace it with the value it just parsed out of the YAML.
 	assert.Equal(t, snapshotWorkingDir, restored.WorkingDir)
 }
+
+func TestRebuildDAGRunSnapshotFromYAMLPreservesPresolvedBuildEnv(t *testing.T) {
+	t.Parallel()
+
+	dag := &core.DAG{
+		Name: "snapshot-presolved-env",
+		YamlData: []byte(`
+env:
+  - DECLARED: from-yaml
+steps:
+  - run: echo hello
+`),
+		// Resolved at original build time from a source the retrying process may
+		// no longer have. The DAG's own env block does not declare it, so
+		// rebuilding from YAML cannot recover it.
+		PresolvedBuildEnv: map[string]string{"SNAPSHOT_ONLY": "kept"},
+	}
+
+	restored, err := rebuildDAGRunSnapshotFromYAML(context.Background(), dag)
+	require.NoError(t, err)
+	require.Same(t, dag, restored)
+
+	assert.Contains(t, restored.Env, "DECLARED=from-yaml")
+	assert.Contains(t, restored.Env, "SNAPSHOT_ONLY=kept")
+}


### PR DESCRIPTION
Stacked on #2521 — review that one first. Base will retarget to `main` once it merges.

## Problem

`PresolvedBuildEnv` carries env entries resolved when the run was first built, specifically for keys a later rebuild cannot recover because the source that provided them is gone (`internal/core/dag.go:132`).

`rebuildDAGRunSnapshotFromYAML` fed it into the loader via `spec.WithBuildEnv`, so `${VAR}` references still expanded during the rebuild — then assigned `dag.Env = fresh.Env` and discarded it. Any key not declared by the DAG's own `env:` block was lost.

The CLI path (`internal/cmd/helper.go`) merges it back:

```go
dag.Env = buildenv.AppendMissing(fresh.Env, loadedEnv, buildenv.FromMap(dag.PresolvedBuildEnv), transportEnv)
```

So the same run retried from the CLI kept env vars that a retry through the API dropped.

Reached from `restoreDAGRunSnapshot` via `dagruns.go` (re-run) and `dagruns_edit_retry.go` (edit-and-retry).

## Why align to the CLI rather than the other way

The API path was already paying `PresolvedBuildEnv`'s entire cost — written to `dag.json`, read back, passed to the builder — and then throwing the result away. It took the storage and exposure downside and got none of the functional upside. Independently: two retry paths for the same run behaving differently is not defensible whichever one is "right", and the CLI behaviour is the established one.

`AppendMissing` makes this a fallback, not an override: keys the rebuilt YAML declares still take precedence, and only keys it cannot resolve at all are recovered from the snapshot.

Note the exact semantics, because they read wrong at a glance and the argument list is **not** a descending priority order: `base` wins outright, but among the `extras` the **last** occurrence of a key wins (`internal/cmn/buildenv/env.go` skips any entry where `lastIndex[key] != index`; the godoc says *"Duplicate extra keys use the last extra value, matching env slice semantics."*). Verified empirically:

```
AppendMissing([K=fresh], loaded, presolved, transport) -> [K=fresh M=transport]
AppendMissing(nil,       loaded, presolved, transport) -> [K=transport M=transport]
```

So the effective priority here is `fresh.Env > transportEnv > PresolvedBuildEnv > loadedEnv`. `buildEnvMap` is populated last-wins over the same three fallback sources, so the value used to expand `${VAR}` during the rebuild agrees with the value recorded in `dag.Env`.

## Test

`TestRebuildDAGRunSnapshotFromYAMLPreservesPresolvedBuildEnv` was written first and fails on the base branch:

```
Error: []string{"DECLARED=from-yaml"} does not contain "SNAPSHOT_ONLY=kept"
```

## Follow-up this unblocks

With this change the two rebuild functions are **line-for-line identical apart from their names** (verified by normalising and diffing both bodies — the only differences are the two `func` lines). That makes collapsing them into one shared function a pure deletion with no behaviour change, which is the next PR. Deriving the restored field set from the `json:"-"` tags, so it cannot drift again, follows that.

The drift fixed here and in #2521 both come from the same cause: two hand-maintained copies of one field list.

## Verification

- `go test -race ./internal/service/frontend/api/v1/` passes
- `golangci-lint run internal/service/frontend/api/v1/...` — 0 issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `PresolvedBuildEnv` when rebuilding a DAG-run snapshot via the API, so retries keep env vars resolved at the original build and match CLI behavior.

- **Bug Fixes**
  - Merge env with `buildenv.AppendMissing` in `rebuildDAGRunSnapshotFromYAML` (first-wins): `fresh.Env` (from rebuilt YAML) → original `dag.Env` (copied to `loadedEnv`) → `dag.PresolvedBuildEnv` → `transportEnv`.
  - Add test to confirm YAML-declared vars win and snapshot-only vars are kept.

<sup>Written for commit 58a7c6932d58bee122dec8867ae40dbcad4a479b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved environment variables when rebuilding DAG run snapshots from YAML.
  * Retained previously resolved environment values when they are unavailable during a rebuild.
  * Ensured rebuilt values take precedence while missing values are restored correctly.

* **Tests**
  * Added regression coverage for preserving YAML-defined and previously resolved environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
