### PR TITLE
fix: omit redundant params from parallel child labels

### DIFF
--- a/internal/runtime/builtin/dag/parallel.go
+++ b/internal/runtime/builtin/dag/parallel.go
@@ -310,6 +310,14 @@ func (e *parallelExecutor) GetStatusDetails() []exec1.NodeStatusDetail {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
+	nameCounts := make(map[string]int, len(e.runParamsList))
+	for _, params := range e.runParamsList {
+		name := parallelRunName(params, e.results[params.RunID])
+		if name != "" {
+			nameCounts[name]++
+		}
+	}
+
 	details := make([]exec1.NodeStatusDetail, 0, len(e.runParamsList))
 	for _, params := range e.runParamsList {
 		result := e.results[params.RunID]
@@ -320,7 +328,7 @@ func (e *parallelExecutor) GetStatusDetails() []exec1.NodeStatusDetail {
 			status = parallelNodeStatus(result.Status)
 		}
 		details = append(details, exec1.NodeStatusDetail{
-			Label:  parallelRunLabel(params, result),
+			Label:  parallelRunLabel(params, result, nameCounts[parallelRunName(params, result)] > 1),
 			Status: status,
 		})
 	}
@@ -350,18 +358,21 @@ func parallelNodeStatus(status core.Status) core.NodeStatus {
 	}
 }
 
-func parallelRunLabel(params executor.RunParams, result *exec1.RunStatus) string {
+func parallelRunName(params executor.RunParams, result *exec1.RunStatus) string {
 	name := params.DAGName
-	values := params.Params
-	if result != nil {
-		if result.Name != "" {
-			name = result.Name
-		}
-		if result.Params != "" {
-			values = result.Params
-		}
+	if result != nil && result.Name != "" {
+		name = result.Name
 	}
-	if name != "" && values != "" {
+	return name
+}
+
+func parallelRunLabel(params executor.RunParams, result *exec1.RunStatus, duplicateName bool) string {
+	name := parallelRunName(params, result)
+	values := params.Params
+	if result != nil && result.Params != "" {
+		values = result.Params
+	}
+	if duplicateName && values != "" {
 		return fmt.Sprintf("%s (%s)", name, values)
 	}
 	if name != "" {

--- a/internal/runtime/builtin/dag/parallel_status_details_test.go
+++ b/internal/runtime/builtin/dag/parallel_status_details_test.go
@@ -15,19 +15,63 @@ import (
 func TestParallelStatusDetailsIdentifyChildRuns(t *testing.T) {
 	t.Parallel()
 
-	exec := &parallelExecutor{
-		runParamsList: []executor.RunParams{
-			{RunID: "run-a", DAGName: "child", Params: "CUSTOMER=a"},
-			{RunID: "run-b", DAGName: "child", Params: "CUSTOMER=b"},
+	tests := []struct {
+		name          string
+		runParamsList []executor.RunParams
+		results       map[string]*exec1.RunStatus
+		want          []exec1.NodeStatusDetail
+	}{
+		{
+			name: "unique child names omit params",
+			runParamsList: []executor.RunParams{
+				{RunID: "run-a", DAGName: "bnci/_intraday.yaml", Params: "SUBDAG=bnci/_intraday.yaml RUN_MODE=test"},
+				{RunID: "run-b", DAGName: "bnsu/_intraday.yaml", Params: "SUBDAG=bnsu/_intraday.yaml RUN_MODE=test"},
+			},
+			results: map[string]*exec1.RunStatus{
+				"run-a": {Name: "intraday-bnci", DAGRunID: "run-a", Status: core.Failed},
+				"run-b": {Name: "intraday-bnsu", DAGRunID: "run-b", Status: core.Succeeded},
+			},
+			want: []exec1.NodeStatusDetail{
+				{Label: "intraday-bnci", Status: core.NodeFailed},
+				{Label: "intraday-bnsu", Status: core.NodeSucceeded},
+			},
 		},
-		results: map[string]*exec1.RunStatus{
-			"run-a": {Name: "child", DAGRunID: "run-a", Params: "CUSTOMER=a", Status: core.Failed},
-			"run-b": {Name: "child", DAGRunID: "run-b", Params: "CUSTOMER=b", Status: core.Succeeded},
+		{
+			name: "duplicate child names retain params",
+			runParamsList: []executor.RunParams{
+				{RunID: "run-a", DAGName: "child", Params: "CUSTOMER=a"},
+				{RunID: "run-b", DAGName: "child", Params: "CUSTOMER=b"},
+			},
+			results: map[string]*exec1.RunStatus{
+				"run-a": {Name: "child", DAGRunID: "run-a", Params: "CUSTOMER=a", Status: core.Failed},
+				"run-b": {Name: "child", DAGRunID: "run-b", Params: "CUSTOMER=b", Status: core.Succeeded},
+			},
+			want: []exec1.NodeStatusDetail{
+				{Label: "child (CUSTOMER=a)", Status: core.NodeFailed},
+				{Label: "child (CUSTOMER=b)", Status: core.NodeSucceeded},
+			},
+		},
+		{
+			name: "missing child names use existing fallbacks",
+			runParamsList: []executor.RunParams{
+				{RunID: "run-a", Params: "CUSTOMER=a"},
+				{RunID: "run-b"},
+			},
+			want: []exec1.NodeStatusDetail{
+				{Label: "CUSTOMER=a", Status: core.NodeFailed},
+				{Label: "run-b", Status: core.NodeFailed},
+			},
 		},
 	}
 
-	assert.Equal(t, []exec1.NodeStatusDetail{
-		{Label: "child (CUSTOMER=a)", Status: core.NodeFailed},
-		{Label: "child (CUSTOMER=b)", Status: core.NodeSucceeded},
-	}, exec.GetStatusDetails())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &parallelExecutor{
+				runParamsList: tt.runParamsList,
+				results:       tt.results,
+			}
+
+			assert.Equal(t, tt.want, exec.GetStatusDetails())
+		})
+	}
 }

--- a/internal/runtime/builtin/dag/parallel_status_details_test.go
+++ b/internal/runtime/builtin/dag/parallel_status_details_test.go
@@ -37,6 +37,21 @@ func TestParallelStatusDetailsIdentifyChildRuns(t *testing.T) {
 			},
 		},
 		{
+			name: "resolved child names take precedence when checking uniqueness",
+			runParamsList: []executor.RunParams{
+				{RunID: "run-a", DAGName: "intraday", Params: "CUSTOMER=a"},
+				{RunID: "run-b", DAGName: "intraday", Params: "CUSTOMER=b"},
+			},
+			results: map[string]*exec1.RunStatus{
+				"run-a": {Name: "intraday-a", DAGRunID: "run-a", Status: core.Failed},
+				"run-b": {Name: "intraday-b", DAGRunID: "run-b", Status: core.Succeeded},
+			},
+			want: []exec1.NodeStatusDetail{
+				{Label: "intraday-a", Status: core.NodeFailed},
+				{Label: "intraday-b", Status: core.NodeSucceeded},
+			},
+		},
+		{
 			name: "duplicate child names retain params",
 			runParamsList: []executor.RunParams{
 				{RunID: "run-a", DAGName: "child", Params: "CUSTOMER=a"},

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -308,7 +308,7 @@ func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T
 			return false
 		}
 		return true
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	switch firstOwner {
 	case "monitor-1":
@@ -416,12 +416,12 @@ func TestNotificationMonitor_CorruptStateIsQuarantinedAndOnlyFutureEventsAreDeli
 			return false
 		}
 		return len(matches) == 1
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 	require.Eventually(t, func() bool {
 		monitor.stateMu.Lock()
 		defer monitor.stateMu.Unlock()
 		return monitor.state.Bootstrapped
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	newStatus := &exec.DAGRunStatus{
 		Name:       "briefing",
@@ -442,12 +442,12 @@ func TestNotificationMonitor_CorruptStateIsQuarantinedAndOnlyFutureEventsAreDeli
 		mu.Lock()
 		defer mu.Unlock()
 		return len(delivered) == 1 && delivered[0] == "run-new"
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	assert.False(t, monitor.IsDelivered("dest-1", oldStatus))
 	require.Eventually(t, func() bool {
 		return monitor.IsDelivered("dest-1", newStatus)
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 }
 
 func TestNotificationStateStore_LoadUnsupportedVersionQuarantinesState(t *testing.T) {
@@ -507,7 +507,7 @@ func TestNotificationMonitor_SaveFailureDoesNotLoseUnreadEvents(t *testing.T) {
 		monitor.stateMu.Lock()
 		defer monitor.stateMu.Unlock()
 		return monitor.state.Bootstrapped
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	require.NoError(t, os.Chmod(stateDir, 0o500))
 	defer func() {
@@ -541,7 +541,7 @@ func TestNotificationMonitor_SaveFailureDoesNotLoseUnreadEvents(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(delivered) == 1 && delivered[0] == "run-save-retry"
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	require.Never(t, func() bool {
 		mu.Lock()
@@ -694,7 +694,7 @@ func TestNotificationMonitor_RemovedDestinationsArePurgedOnStartup(t *testing.T)
 		_, removedExists := monitor.state.Destinations["removed-dest"]
 		_, keepExists := monitor.state.Destinations["keep-dest"]
 		return !removedExists && keepExists
-	}, time.Second, 10*time.Millisecond)
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
 
 	result := newNotificationStateStore(stateFile).Load(context.Background())
 	require.NoError(t, result.Warning)


### PR DESCRIPTION
## Summary

- render a parallel child DAG's resolved name without its parameter list when that name uniquely identifies the child
- retain parameters when sibling child runs share the same resolved name
- preserve parameter and run-ID fallbacks when a child name is unavailable

## Root cause

Parallel status-detail labels always combined the resolved child DAG name with every parameter. Notification templates then embedded that verbose label even when sibling child names were already distinct.

## Impact

Notifications now produce concise labels such as `run_downstreams[intraday-bnci]` while same-child fan-outs remain distinguishable.

Closes #2498.

## Validation

- `go test ./internal/runtime/... -count=1`
- `go test ./internal/service/notification -count=1`
- `go test -race ./internal/runtime/builtin/dag ./internal/service/notification -count=1`
- golangci-lint on changed files for native and Windows targets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes parallel child status labels concise by omitting params when the resolved child name is unique. Notifications now show shorter labels like intraday-bnci while still disambiguating same‑name children.

- **Bug Fixes**
  - Use resolved child names to check uniqueness; include params only for duplicates. Tests cover resolved-name cases and missing-name fallbacks.
  - Preserve fallbacks to params-only or run ID when no name is available, and stabilize `chatbridge` notification monitor tests on Windows with a platform-aware Eventually timeout.

<sup>Written for commit 49b4801be0e70170da33d26665d08d030bbcaeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel workflow status labels when multiple runs share the same child name.
  * Labels now include parameter values only when needed to distinguish duplicate runs.
  * Preserved fallback labels using available names, values, or run IDs when details are missing.

* **Tests**
  * Expanded coverage for unique names, duplicate names, and missing child-name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->