### PR TITLE
feat(ui): close web interface UX gaps

### DIFF
--- a/ui/src/__tests__/menu.test.tsx
+++ b/ui/src/__tests__/menu.test.tsx
@@ -234,8 +234,12 @@ describe('sidebar menu', () => {
     expect(
       screen.getByRole('button', { name: 'Toggle Notifications section' })
     ).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getByRole('link', { name: 'Rules' })).not.toBeVisible();
-    expect(screen.getByRole('link', { name: 'Channels' })).not.toBeVisible();
+    expect(
+      screen.queryByRole('link', { name: 'Rules' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Channels' })
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Integrations' })).toHaveAttribute(
       'href',
       '/integrations'
@@ -254,8 +258,8 @@ describe('sidebar menu', () => {
     ).toHaveAttribute('aria-expanded', 'false');
 
     expect(
-      screen.getByRole('link', { name: 'API Reference' })
-    ).not.toBeVisible();
+      screen.queryByRole('link', { name: 'API Reference' })
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Dashboard' })
     ).not.toBeInTheDocument();
@@ -512,7 +516,8 @@ describe('sidebar menu', () => {
   ])('marks %s as the active notification item', (path, label) => {
     renderMenu(path);
 
-    expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+    expect(screen.queryByRole('link', { name: label })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Notifications' })).toHaveAttribute(
       'aria-current',
       'page'
     );

--- a/ui/src/__tests__/webpack.dev.test.ts
+++ b/ui/src/__tests__/webpack.dev.test.ts
@@ -11,10 +11,18 @@ function proxyContexts(config: {
     }>;
   };
 }): string[] {
-  return (config.devServer?.proxy ?? []).flatMap((entry) => entry.context ?? []);
+  return (config.devServer?.proxy ?? []).flatMap(
+    (entry) => entry.context ?? []
+  );
 }
 
 describe('webpack dev server proxy', () => {
+  it('serves the SPA for dotted client-side routes', () => {
+    expect(webpackDevConfig.devServer.historyApiFallback).toEqual({
+      disableDotRule: true,
+    });
+  });
+
   it('proxies schema asset requests to the backend server', () => {
     expect(proxyContexts(webpackDevConfig)).toEqual(
       expect.arrayContaining([

--- a/ui/src/features/cockpit/components/KanbanBoard.tsx
+++ b/ui/src/features/cockpit/components/KanbanBoard.tsx
@@ -29,23 +29,6 @@ export function KanbanBoard({
     () => normalizeViewColumns(visibleColumns),
     [visibleColumns]
   );
-  const displayedColumns = useMemo(
-    () =>
-      visibleColumns !== undefined
-        ? columnOrder
-        : columnOrder.filter((column) => {
-            const data = columns[column];
-            return (
-              data.runs.length > 0 ||
-              data.hasMore ||
-              data.isInitialLoading ||
-              data.isLoadingMore ||
-              Boolean(data.error) ||
-              Boolean(data.loadMoreError)
-            );
-          }),
-    [columnOrder, columns, visibleColumns]
-  );
 
   if (isMobile) {
     return (
@@ -60,7 +43,7 @@ export function KanbanBoard({
 
   return (
     <div className="flex gap-3 min-h-0 overflow-x-auto p-1 max-h-[50vh] [&>section]:min-w-[260px] [&>section]:max-w-[420px]">
-      {displayedColumns.map((column) => (
+      {columnOrder.map((column) => (
         <KanbanColumn
           key={column}
           title={VIEW_COLUMN_LABELS[column]}

--- a/ui/src/features/cockpit/components/KanbanBoard.tsx
+++ b/ui/src/features/cockpit/components/KanbanBoard.tsx
@@ -29,6 +29,21 @@ export function KanbanBoard({
     () => normalizeViewColumns(visibleColumns),
     [visibleColumns]
   );
+  const displayedColumns = useMemo(
+    () =>
+      visibleColumns?.length
+        ? columnOrder
+        : columnOrder.filter((column) => {
+            const data = columns[column];
+            return (
+              data.runs.length > 0 ||
+              data.hasMore ||
+              data.isInitialLoading ||
+              Boolean(data.error)
+            );
+          }),
+    [columnOrder, columns, visibleColumns]
+  );
 
   if (isMobile) {
     return (
@@ -42,8 +57,8 @@ export function KanbanBoard({
   }
 
   return (
-    <div className="flex gap-3 min-h-0 overflow-x-auto p-1 max-h-[50vh]">
-      {columnOrder.map((column) => (
+    <div className="flex gap-3 min-h-0 overflow-x-auto p-1 max-h-[50vh] [&>section]:min-w-[260px] [&>section]:max-w-[420px]">
+      {displayedColumns.map((column) => (
         <KanbanColumn
           key={column}
           title={VIEW_COLUMN_LABELS[column]}

--- a/ui/src/features/cockpit/components/KanbanBoard.tsx
+++ b/ui/src/features/cockpit/components/KanbanBoard.tsx
@@ -31,7 +31,7 @@ export function KanbanBoard({
   );
   const displayedColumns = useMemo(
     () =>
-      visibleColumns?.length
+      visibleColumns !== undefined
         ? columnOrder
         : columnOrder.filter((column) => {
             const data = columns[column];
@@ -39,7 +39,9 @@ export function KanbanBoard({
               data.runs.length > 0 ||
               data.hasMore ||
               data.isInitialLoading ||
-              Boolean(data.error)
+              data.isLoadingMore ||
+              Boolean(data.error) ||
+              Boolean(data.loadMoreError)
             );
           }),
     [columnOrder, columns, visibleColumns]

--- a/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
+++ b/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
@@ -4,7 +4,6 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { Status, StatusLabel } from '@/api/v1/schema';
 import { KanbanBoard } from '../KanbanBoard';
 import type {
   KanbanColumnData,
@@ -19,7 +18,7 @@ vi.mock('../KanbanColumn', () => ({
   KanbanColumn: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
-function column(overrides: Partial<KanbanColumnData> = {}): KanbanColumnData {
+function column(): KanbanColumnData {
   return {
     runs: [],
     hasMore: false,
@@ -29,7 +28,6 @@ function column(overrides: Partial<KanbanColumnData> = {}): KanbanColumnData {
     loadMoreError: null,
     loadMore: vi.fn(async () => undefined),
     retry: vi.fn(async () => undefined),
-    ...overrides,
   };
 }
 
@@ -44,66 +42,24 @@ function emptyColumns(): KanbanColumns {
 }
 
 describe('KanbanBoard', () => {
-  it('omits empty desktop columns when another column has runs', () => {
-    const columns: KanbanColumns = {
-      ...emptyColumns(),
-      running: column({
-        runs: [
-          {
-            name: 'deploy',
-            dagRunId: 'run-1',
-            status: Status.Running,
-            statusLabel: StatusLabel.running,
-          } as KanbanColumnData['runs'][number],
-        ],
-      }),
-    };
-
-    render(
-      <KanbanBoard
-        columns={columns}
-        onCardClick={vi.fn()}
-        onArtifactsClick={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText('Running')).toBeInTheDocument();
-    expect(screen.queryByText('Queued')).not.toBeInTheDocument();
-    expect(screen.queryByText('Review')).not.toBeInTheDocument();
-    expect(screen.queryByText('Done')).not.toBeInTheDocument();
-    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
-  });
-
-  it('preserves configured columns when the explicit selection is empty', () => {
-    render(
-      <KanbanBoard
-        columns={emptyColumns()}
-        visibleColumns={[]}
-        onCardClick={vi.fn()}
-        onArtifactsClick={vi.fn()}
-      />
-    );
-
-    for (const label of ['Queued', 'Running', 'Review', 'Done', 'Failed']) {
-      expect(screen.getByText(label)).toBeInTheDocument();
-    }
-  });
-
   it.each([
-    ['loading more results', { isLoadingMore: true }],
-    ['showing a load-more error', { loadMoreError: 'Request failed' }],
-  ])('keeps a column visible while %s', (_description, state) => {
-    const columns = emptyColumns();
-    columns.failed = column(state);
+    ['without a column selection', undefined],
+    ['with an explicit empty selection', []],
+  ] as const)(
+    'keeps every default column visible %s',
+    (_name, visibleColumns) => {
+      render(
+        <KanbanBoard
+          columns={emptyColumns()}
+          visibleColumns={visibleColumns}
+          onCardClick={vi.fn()}
+          onArtifactsClick={vi.fn()}
+        />
+      );
 
-    render(
-      <KanbanBoard
-        columns={columns}
-        onCardClick={vi.fn()}
-        onArtifactsClick={vi.fn()}
-      />
-    );
-
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-  });
+      for (const label of ['Queued', 'Running', 'Review', 'Done', 'Failed']) {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      }
+    }
+  );
 });

--- a/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
+++ b/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Status, StatusLabel } from '@/api/v1/schema';
+import { KanbanBoard } from '../KanbanBoard';
+import type {
+  KanbanColumnData,
+  KanbanColumns,
+} from '../../hooks/useDateKanbanData';
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('../KanbanColumn', () => ({
+  KanbanColumn: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+function column(runs: KanbanColumnData['runs'] = []): KanbanColumnData {
+  return {
+    runs,
+    hasMore: false,
+    isInitialLoading: false,
+    isLoadingMore: false,
+    error: null,
+    loadMoreError: null,
+    loadMore: vi.fn(async () => undefined),
+    retry: vi.fn(async () => undefined),
+  };
+}
+
+describe('KanbanBoard', () => {
+  it('omits empty desktop columns when another column has runs', () => {
+    const columns: KanbanColumns = {
+      queued: column(),
+      running: column([
+        {
+          name: 'deploy',
+          dagRunId: 'run-1',
+          status: Status.Running,
+          statusLabel: StatusLabel.running,
+        } as KanbanColumnData['runs'][number],
+      ]),
+      review: column(),
+      done: column(),
+      failed: column(),
+    };
+
+    render(
+      <KanbanBoard
+        columns={columns}
+        onCardClick={vi.fn()}
+        onArtifactsClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.queryByText('Queued')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review')).not.toBeInTheDocument();
+    expect(screen.queryByText('Done')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
+++ b/ui/src/features/cockpit/components/__tests__/KanbanBoard.test.tsx
@@ -19,9 +19,9 @@ vi.mock('../KanbanColumn', () => ({
   KanbanColumn: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
-function column(runs: KanbanColumnData['runs'] = []): KanbanColumnData {
+function column(overrides: Partial<KanbanColumnData> = {}): KanbanColumnData {
   return {
-    runs,
+    runs: [],
     hasMore: false,
     isInitialLoading: false,
     isLoadingMore: false,
@@ -29,24 +29,34 @@ function column(runs: KanbanColumnData['runs'] = []): KanbanColumnData {
     loadMoreError: null,
     loadMore: vi.fn(async () => undefined),
     retry: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function emptyColumns(): KanbanColumns {
+  return {
+    queued: column(),
+    running: column(),
+    review: column(),
+    done: column(),
+    failed: column(),
   };
 }
 
 describe('KanbanBoard', () => {
   it('omits empty desktop columns when another column has runs', () => {
     const columns: KanbanColumns = {
-      queued: column(),
-      running: column([
-        {
-          name: 'deploy',
-          dagRunId: 'run-1',
-          status: Status.Running,
-          statusLabel: StatusLabel.running,
-        } as KanbanColumnData['runs'][number],
-      ]),
-      review: column(),
-      done: column(),
-      failed: column(),
+      ...emptyColumns(),
+      running: column({
+        runs: [
+          {
+            name: 'deploy',
+            dagRunId: 'run-1',
+            status: Status.Running,
+            statusLabel: StatusLabel.running,
+          } as KanbanColumnData['runs'][number],
+        ],
+      }),
     };
 
     render(
@@ -62,5 +72,38 @@ describe('KanbanBoard', () => {
     expect(screen.queryByText('Review')).not.toBeInTheDocument();
     expect(screen.queryByText('Done')).not.toBeInTheDocument();
     expect(screen.queryByText('Failed')).not.toBeInTheDocument();
+  });
+
+  it('preserves configured columns when the explicit selection is empty', () => {
+    render(
+      <KanbanBoard
+        columns={emptyColumns()}
+        visibleColumns={[]}
+        onCardClick={vi.fn()}
+        onArtifactsClick={vi.fn()}
+      />
+    );
+
+    for (const label of ['Queued', 'Running', 'Review', 'Done', 'Failed']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it.each([
+    ['loading more results', { isLoadingMore: true }],
+    ['showing a load-more error', { loadMoreError: 'Request failed' }],
+  ])('keeps a column visible while %s', (_description, state) => {
+    const columns = emptyColumns();
+    columns.failed = column(state);
+
+    render(
+      <KanbanBoard
+        columns={columns}
+        onCardClick={vi.fn()}
+        onArtifactsClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 });

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { SlidersHorizontal } from 'lucide-react';
 import { components, Status } from '../../../../api/v1/schema';
 import {
@@ -255,6 +255,14 @@ function DAGRunTable({
   };
 
   const timezoneInfo = getTimezoneInfo();
+  const formatScheduleTime = (scheduleTime: string): string => {
+    const value = dayjs(scheduleTime);
+    const configuredTime =
+      config.tzOffsetInSec === undefined
+        ? value
+        : value.utcOffset(config.tzOffsetInSec / 60);
+    return configuredTime.format('YYYY-MM-DD HH:mm:ss');
+  };
   const showScheduleColumn = dagRuns.some((dagRun) =>
     Boolean(dagRun.scheduleTime)
   );
@@ -335,7 +343,13 @@ function DAGRunTable({
                     />
                   </div>
                 )}
-                <div className="font-normal text-sm">{dagRun.name}</div>
+                <Link
+                  to={`/dag-runs/${dagRun.name}/${dagRun.dagRunId}`}
+                  className="font-normal text-sm hover:underline"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  {dagRun.name}
+                </Link>
               </div>
               <div className="flex items-start gap-2">
                 {onViewArtifacts && (
@@ -377,7 +391,9 @@ function DAGRunTable({
                 <div className="flex justify-between items-center">
                   <div className="whitespace-normal break-words">
                     <span className="text-muted-foreground">Scheduled: </span>
-                    {dagRun.scheduleTime}
+                    <span title={dagRun.scheduleTime}>
+                      {formatScheduleTime(dagRun.scheduleTime)}
+                    </span>
                   </div>
                 </div>
               )}
@@ -539,7 +555,13 @@ function DAGRunTable({
               )}
               <TableCell className="py-1 px-2 font-normal">
                 <div className="flex items-center gap-2">
-                  <span className="min-w-0 truncate">{dagRun.name}</span>
+                  <Link
+                    to={`/dag-runs/${dagRun.name}/${dagRun.dagRunId}`}
+                    className="min-w-0 truncate hover:underline"
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    {dagRun.name}
+                  </Link>
                   {onViewArtifacts && (
                     <DAGRunArtifactsButton
                       dagRun={dagRun}
@@ -589,7 +611,13 @@ function DAGRunTable({
               )}
               {showScheduleColumn && (
                 <TableCell className="py-1 px-2 text-left whitespace-normal break-words">
-                  {dagRun.scheduleTime || '-'}
+                  {dagRun.scheduleTime ? (
+                    <span title={dagRun.scheduleTime}>
+                      {formatScheduleTime(dagRun.scheduleTime)}
+                    </span>
+                  ) : (
+                    '-'
+                  )}
                 </TableCell>
               )}
               <TableCell className="py-1 px-2 text-left">

--- a/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
@@ -95,7 +95,14 @@ describe('DAGRunTable', () => {
     );
 
     expect(screen.getByText('Scheduled At')).toBeInTheDocument();
-    expect(screen.getByText('2026-03-13T10:00:00Z')).toBeInTheDocument();
+    expect(screen.getByText('2026-03-13 10:00:00')).toHaveAttribute(
+      'title',
+      '2026-03-13T10:00:00Z'
+    );
+    expect(screen.getByRole('link', { name: 'scheduled-dag' })).toHaveAttribute(
+      'href',
+      '/dag-runs/scheduled-dag/run-1'
+    );
     // Queued At renders as relative time with the absolute time in the tooltip
     expect(screen.getByTitle('2026-03-13T10:00:30Z')).toBeInTheDocument();
     expect(screen.getByText('1/3 auto retries')).toBeInTheDocument();

--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/tooltip';
 import {
   ActivitySquare,
+  AlertTriangle,
   Archive,
   ClipboardCheck,
   FileCode,
@@ -20,6 +21,7 @@ import {
   MousePointerClick,
   Package,
   ShieldCheck,
+  ScrollText,
 } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
@@ -456,6 +458,10 @@ function DAGStatus({
   // Controller DAG-runs track goal progress alongside their steps.
   const controllerTasks = displayDAGRun.controllerTasks ?? [];
   const hasControllerTasks = controllerTasks.length > 0;
+  const failedNode = displayDAGRun.nodes?.find(
+    (node) =>
+      node.status === NodeStatus.Failed || node.status === NodeStatus.Rejected
+  );
 
   // A controller has no dependency edges, so its graph carries no information.
   // The decision timeline takes that slot instead.
@@ -554,7 +560,7 @@ function DAGStatus({
                   className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                 >
                   <ActivitySquare className="h-4 w-4" />
-                  <span className="hidden sm:inline">Status</span>
+                  <span>Status</span>
                 </Tab>
                 {hasHumanTaskWork && (
                   <Tab
@@ -564,7 +570,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <ClipboardCheck className="h-4 w-4" />
-                    <span className="hidden sm:inline">Human tasks</span>
+                    <span>Human tasks</span>
                     {waitingHumanTaskCount > 0 && (
                       <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-medium text-warning">
                         {waitingHumanTaskCount}
@@ -580,7 +586,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <ShieldCheck className="h-4 w-4" />
-                    <span className="hidden sm:inline">Approval</span>
+                    <span>Approval</span>
                     <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-medium text-warning">
                       {waitingApprovalCount}
                     </span>
@@ -594,7 +600,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <GanttChart className="h-4 w-4" />
-                    <span className="hidden sm:inline">Timeline</span>
+                    <span>Timeline</span>
                   </Tab>
                 )}
                 <Tab
@@ -604,7 +610,7 @@ function DAGStatus({
                   className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                 >
                   <Package className="h-4 w-4" />
-                  <span className="hidden sm:inline">Outputs</span>
+                  <span>Outputs</span>
                 </Tab>
                 {hasArtifacts && (
                   <Tab
@@ -614,7 +620,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <Archive className="h-4 w-4" />
-                    <span className="hidden sm:inline">Artifacts</span>
+                    <span>Artifacts</span>
                   </Tab>
                 )}
                 {hasControllerTasks && (
@@ -625,7 +631,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <ListChecks className="h-4 w-4" />
-                    <span className="hidden sm:inline">Tasks</span>
+                    <span>Tasks</span>
                   </Tab>
                 )}
                 {hasChatSteps && (
@@ -636,7 +642,7 @@ function DAGStatus({
                     className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                   >
                     <MessageSquare className="h-4 w-4" />
-                    <span className="hidden sm:inline">Chat</span>
+                    <span>Chat</span>
                   </Tab>
                 )}
                 <Tab
@@ -646,7 +652,7 @@ function DAGStatus({
                   className="flex cursor-pointer items-center gap-2 px-3 sm:px-4"
                 >
                   <FileCode className="h-4 w-4" />
-                  <span className="hidden sm:inline">Spec</span>
+                  <span>Spec</span>
                 </Tab>
               </Tabs>
             </div>
@@ -666,6 +672,59 @@ function DAGStatus({
 
         {activeTab === 'status' && (
           <div className={cn('space-y-6', scrollPaneClassName)}>
+            {failedNode && (
+              <div
+                role="alert"
+                className="rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+              >
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div>
+                      <div className="font-medium text-destructive">
+                        {failedNode.status === NodeStatus.Rejected
+                          ? 'Rejected'
+                          : 'Failed'}{' '}
+                        at {failedNode.step.name}
+                      </div>
+                      <div className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap break-words text-sm text-foreground">
+                        {failedNode.error ||
+                          failedNode.rejectionReason ||
+                          'The step failed without an error message.'}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-muted"
+                        onClick={() =>
+                          handleViewLog(
+                            `${failedNode.step.name}_stderr`,
+                            displayDAGRun.dagRunId,
+                            failedNode
+                          )
+                        }
+                      >
+                        <ScrollText className="h-3.5 w-3.5" />
+                        View stderr
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium hover:bg-muted"
+                        onClick={() =>
+                          onInspectStepOnGraph(
+                            toMermaidNodeId(failedNode.step.name)
+                          )
+                        }
+                      >
+                        Inspect step
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Controller runs show execution order instead of a graph */}
             {isControllerRun && controllerEvents.length > 0 && (
               <ControllerTimeline

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -1,7 +1,13 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -226,6 +232,32 @@ afterEach(() => {
 });
 
 describe('DAGStatus', () => {
+  it('surfaces the failed step and error before the graph details', () => {
+    const failedRun = {
+      ...dagRun,
+      nodes: [
+        {
+          ...dagRun.nodes[0],
+          status: NodeStatus.Failed,
+          statusLabel: NodeStatusLabel.failed,
+          error: 'connection refused',
+        },
+      ],
+    } as components['schemas']['DAGRunDetails'];
+
+    render(dagStatusView(failedRun));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Failed at step');
+    expect(alert).toHaveTextContent('connection refused');
+    expect(
+      within(alert).getByRole('button', { name: 'View stderr' })
+    ).toBeInTheDocument();
+    expect(
+      within(alert).getByRole('button', { name: 'Inspect step' })
+    ).toBeInTheDocument();
+  });
+
   it('passes its workflow filename to the step table', () => {
     vi.mocked(useClient).mockReturnValue({
       PATCH: patchMock,

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -258,6 +258,32 @@ describe('DAGStatus', () => {
     ).toBeInTheDocument();
   });
 
+  it('surfaces a rejected step and its rejection reason', () => {
+    const rejectedRun = {
+      ...dagRun,
+      nodes: [
+        {
+          ...dagRun.nodes[0],
+          status: NodeStatus.Rejected,
+          statusLabel: NodeStatusLabel.rejected,
+          rejectionReason: 'approval was denied',
+        },
+      ],
+    } as components['schemas']['DAGRunDetails'];
+
+    render(dagStatusView(rejectedRun));
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Rejected at step');
+    expect(alert).toHaveTextContent('approval was denied');
+    expect(
+      within(alert).getByRole('button', { name: 'View stderr' })
+    ).toBeInTheDocument();
+    expect(
+      within(alert).getByRole('button', { name: 'Inspect step' })
+    ).toBeInTheDocument();
+  });
+
   it('passes its workflow filename to the step table', () => {
     vi.mocked(useClient).mockReturnValue({
       PATCH: patchMock,

--- a/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGDetailsContent.tsx
@@ -310,7 +310,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
             <div className="flex min-w-max space-x-1">
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Latest Run"
                   value="status"
                   isActive={activeTab === 'status'}
                   icon={PlayCircle}
@@ -320,7 +320,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Latest Run"
                   value={scopedUrl(baseUrl)}
                   isActive={activeTab === 'status'}
                   icon={PlayCircle}
@@ -331,7 +331,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Incidents"
                   value="incidents"
                   isActive={activeTab === 'incidents'}
                   icon={AlertTriangle}
@@ -341,7 +341,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Incidents"
                   value={scopedUrl(`${baseUrl}/incidents`)}
                   isActive={activeTab === 'incidents'}
                   icon={AlertTriangle}
@@ -352,7 +352,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Spec"
                   value="spec"
                   isActive={activeTab === 'spec'}
                   icon={FileCode}
@@ -362,7 +362,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Spec"
                   value={scopedUrl(`${baseUrl}/spec`)}
                   isActive={activeTab === 'spec'}
                   icon={FileCode}
@@ -373,7 +373,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Webhook"
                   value="webhook"
                   isActive={activeTab === 'webhook'}
                   icon={Webhook}
@@ -383,7 +383,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Webhook"
                   value={scopedUrl(`${baseUrl}/webhook`)}
                   isActive={activeTab === 'webhook'}
                   icon={Webhook}
@@ -394,7 +394,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Settings"
                   value="settings"
                   isActive={activeTab === 'settings'}
                   icon={SettingsIcon}
@@ -404,7 +404,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Settings"
                   value={scopedUrl(`${baseUrl}/settings`)}
                   isActive={activeTab === 'settings'}
                   icon={SettingsIcon}
@@ -415,7 +415,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="Notifications"
                   value="notifications"
                   isActive={activeTab === 'notifications'}
                   icon={Bell}
@@ -425,7 +425,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="Notifications"
                   value={scopedUrl(`${baseUrl}/notifications`)}
                   isActive={activeTab === 'notifications'}
                   icon={Bell}
@@ -436,7 +436,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
 
               {isModal ? (
                 <ModalLinkTab
-                  label=""
+                  label="History"
                   value="history"
                   isActive={activeTab === 'history'}
                   icon={History}
@@ -446,7 +446,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                 />
               ) : (
                 <LinkTab
-                  label=""
+                  label="History"
                   value={scopedUrl(`${baseUrl}/history`)}
                   isActive={activeTab === 'history'}
                   icon={History}
@@ -458,7 +458,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
               {(activeTab === 'log' || activeTab === 'dagRun-log') &&
                 (isModal ? (
                   <ModalLinkTab
-                    label=""
+                    label="Log"
                     value={activeTab}
                     isActive={true}
                     icon={ScrollText}
@@ -468,7 +468,7 @@ const DAGDetailsContent: React.FC<DAGDetailsContentProps> = ({
                   />
                 ) : (
                   <LinkTab
-                    label=""
+                    label="Log"
                     value={scopedUrl(baseUrl)}
                     isActive={true}
                     icon={ScrollText}

--- a/ui/src/features/dags/components/dag-details/DAGHeader.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGHeader.tsx
@@ -263,7 +263,7 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
               dag={dag}
               fileName={fileName}
               refresh={refreshFn}
-              displayMode="compact"
+              displayMode="full"
               navigateToStatusTab={navigateToStatusTab}
             />
           </div>

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
@@ -92,4 +92,20 @@ describe('DAGDetailsContent', () => {
       'true'
     );
   });
+
+  it('keeps compact navigation labels visible', () => {
+    renderContent();
+
+    for (const label of [
+      'Latest Run',
+      'Incidents',
+      'Spec',
+      'Webhook',
+      'Settings',
+      'Notifications',
+      'History',
+    ]) {
+      expect(screen.getAllByText(label)).toHaveLength(2);
+    }
+  });
 });

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGDetailsContent.test.tsx
@@ -66,7 +66,7 @@ const currentDAGRun = {
   artifactsAvailable: true,
 } as never;
 
-function renderContent() {
+function renderContent(activeTab = 'status') {
   render(
     <MemoryRouter>
       <DAGDetailsContent
@@ -75,7 +75,7 @@ function renderContent() {
         currentDAGRun={currentDAGRun}
         refreshFn={vi.fn()}
         formatDuration={vi.fn()}
-        activeTab="status"
+        activeTab={activeTab}
         isModal
         fillHeight
       />
@@ -108,4 +108,13 @@ describe('DAGDetailsContent', () => {
       expect(screen.getAllByText(label)).toHaveLength(2);
     }
   });
+
+  it.each(['log', 'dagRun-log'])(
+    'keeps both %s navigation labels visible',
+    (activeTab) => {
+      renderContent(activeTab);
+
+      expect(screen.getAllByText('Log')).toHaveLength(2);
+    }
+  );
 });

--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -221,9 +221,13 @@ function DAGCard({
               />
             </div>
           )}
-          <div className="font-medium text-xs truncate flex-1 min-w-0">
+          <Link
+            to={`/dags/${fileName}`}
+            className="font-medium text-xs truncate flex-1 min-w-0 hover:underline"
+            onClick={(event) => event.stopPropagation()}
+          >
             {title}
-          </div>
+          </Link>
         </div>
         <StatusChip status={status} size="xs">
           {statusLabel}
@@ -600,9 +604,13 @@ const defaultColumns = [
             style={{ paddingLeft: `${row.depth * 1.5}rem` }}
             className="space-y-0.5 min-w-0"
           >
-            <div className="font-medium text-foreground tracking-tight text-xs truncate">
+            <Link
+              to={`/dags/${data.dag.fileName}`}
+              className="block font-medium text-foreground tracking-tight text-xs truncate hover:underline"
+              onClick={(event) => event.stopPropagation()}
+            >
               {getValue()}
-            </div>
+            </Link>
 
             {description && (
               <div className="text-xs text-muted-foreground whitespace-normal leading-tight line-clamp-2">

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -145,6 +145,14 @@ describe('DAGTable', () => {
     vi.unstubAllGlobals();
   });
 
+  it('links workflow names to their canonical detail pages', () => {
+    renderTable();
+
+    for (const link of screen.getAllByRole('link', { name: 'example' })) {
+      expect(link).toHaveAttribute('href', '/dags/example.yaml');
+    }
+  });
+
   it('uses the same control surface sizing as the executions page', () => {
     renderTable();
 

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -122,6 +122,53 @@ function Content({ navbarColor, children }: LayoutProps) {
   });
   // Mobile sidebar state (hidden by default)
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = React.useState(false);
+  const openMenuButtonRef = React.useRef<HTMLButtonElement>(null);
+  const closeMenuButtonRef = React.useRef<HTMLButtonElement>(null);
+  const mobileSidebarRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!isMobileSidebarOpen) {
+      return;
+    }
+
+    closeMenuButtonRef.current?.focus();
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMobileSidebarOpen(false);
+        requestAnimationFrame(() => openMenuButtonRef.current?.focus());
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = Array.from(
+        mobileSidebarRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      ).filter((element) => !element.closest('[inert]'));
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      if (!first || !last) {
+        event.preventDefault();
+        return;
+      }
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [isMobileSidebarOpen]);
+
+  const closeMobileSidebar = () => {
+    setIsMobileSidebarOpen(false);
+    requestAnimationFrame(() => openMenuButtonRef.current?.focus());
+  };
 
   // Save sidebar state to localStorage when it changes
   React.useEffect(() => {
@@ -166,7 +213,11 @@ function Content({ navbarColor, children }: LayoutProps) {
       </aside>
 
       {/* Main Content Area - Developer-tool */}
-      <div className="flex flex-col flex-1 h-full overflow-hidden relative bg-background">
+      <div
+        className="flex flex-col flex-1 h-full overflow-hidden relative bg-background"
+        aria-hidden={isMobileSidebarOpen || undefined}
+        inert={isMobileSidebarOpen ? true : undefined}
+      >
         {/* Mobile Header Bar - Minimal Design */}
         <header
           className={cn(
@@ -177,6 +228,7 @@ function Content({ navbarColor, children }: LayoutProps) {
           style={sidebarStyle}
         >
           <button
+            ref={openMenuButtonRef}
             className="p-2 rounded-md hover:bg-muted transition-colors"
             onClick={() => setIsMobileSidebarOpen(true)}
             aria-label="Open menu"
@@ -209,9 +261,13 @@ function Content({ navbarColor, children }: LayoutProps) {
       {isMobileSidebarOpen && (
         <div
           className="fixed inset-0 bg-background/60 z-50 md:hidden flex backdrop-blur-sm"
-          onClick={() => setIsMobileSidebarOpen(false)}
+          onClick={closeMobileSidebar}
         >
           <div
+            ref={mobileSidebarRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mobile-navigation-title"
             className={cn(
               'h-full w-64 overflow-hidden shadow-lg border-r border-border',
               !hasCustomColor && 'bg-sidebar text-sidebar-foreground',
@@ -222,6 +278,7 @@ function Content({ navbarColor, children }: LayoutProps) {
           >
             <div className="flex justify-between items-center p-4 border-b border-sidebar-border">
               <span
+                id="mobile-navigation-title"
                 className={cn(
                   'font-semibold whitespace-normal leading-tight',
                   getResponsiveTitleClass(
@@ -233,7 +290,10 @@ function Content({ navbarColor, children }: LayoutProps) {
                 {config.title || 'Dagu'}
               </span>
               <button
-                onClick={() => setIsMobileSidebarOpen(false)}
+                ref={closeMenuButtonRef}
+                type="button"
+                aria-label="Close menu"
+                onClick={closeMobileSidebar}
                 className="p-1.5 hover:bg-sidebar-hover rounded-md transition-colors"
               >
                 <X className="h-5 w-5" />
@@ -243,7 +303,7 @@ function Content({ navbarColor, children }: LayoutProps) {
               <nav className="flex-1 overflow-y-auto min-h-0 px-2">
                 <MainListItems
                   isOpen={true}
-                  onNavItemClick={() => setIsMobileSidebarOpen(false)}
+                  onNavItemClick={closeMobileSidebar}
                   customColor={hasCustomColor}
                 />
               </nav>

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -85,5 +85,27 @@ describe('Layout', () => {
       })
     ).toHaveAttribute('aria-current', 'page');
     expect(within(breadcrumbs).getAllByRole('link')).toHaveLength(5);
+  });
+
+  it('opens the mobile navigation as a keyboard-contained dialog', () => {
+    renderLayout('/home');
+
+    const openButton = screen.getByRole('button', { name: 'Open menu' });
+    fireEvent.click(openButton);
+
+    const dialog = screen.getByRole('dialog', { name: 'Dagu' });
+    const closeButton = within(dialog).getByRole('button', {
+      name: 'Close menu',
+    });
+    expect(closeButton).toHaveFocus();
+    expect(
+      screen.getByText('Page Content').closest('[aria-hidden="true"]')
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Tab' });
+    expect(closeButton).toHaveFocus();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/layouts/__tests__/Layout.test.tsx
+++ b/ui/src/layouts/__tests__/Layout.test.tsx
@@ -1,7 +1,13 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -87,7 +93,7 @@ describe('Layout', () => {
     expect(within(breadcrumbs).getAllByRole('link')).toHaveLength(5);
   });
 
-  it('opens the mobile navigation as a keyboard-contained dialog', () => {
+  it('opens the mobile navigation as a keyboard-contained dialog', async () => {
     renderLayout('/home');
 
     const openButton = screen.getByRole('button', { name: 'Open menu' });
@@ -107,5 +113,6 @@ describe('Layout', () => {
 
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(openButton).toHaveFocus());
   });
 });

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -311,8 +311,7 @@ function NavGroup({
   children,
 }: NavGroupProps): React.ReactElement {
   const location = useLocation();
-  const isChildActive =
-    !suppressActive && isBasePathActive(location, basePath);
+  const isChildActive = !suppressActive && isBasePathActive(location, basePath);
   const isGroupTargetActive =
     !suppressActive && to ? isNavTargetActive(location, to) : false;
 
@@ -415,7 +414,11 @@ function NavGroup({
               to={to}
               onClick={onClick}
               className="flex h-full min-w-0 flex-1 items-center gap-3 px-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
-              aria-current={isGroupTargetActive ? 'page' : undefined}
+              aria-current={
+                isGroupTargetActive || (isChildActive && !effectivelyExpanded)
+                  ? 'page'
+                  : undefined
+              }
             >
               {labelNode}
             </Link>
@@ -449,6 +452,8 @@ function NavGroup({
         )}
       </div>
       <div
+        aria-hidden={!effectivelyExpanded}
+        inert={!effectivelyExpanded ? true : undefined}
         style={{
           transition:
             'max-height 250ms cubic-bezier(0.4, 0, 0.2, 1), opacity 200ms cubic-bezier(0.4, 0, 0.2, 1)',

--- a/ui/src/pages/dag-runs/__tests__/index.test.tsx
+++ b/ui/src/pages/dag-runs/__tests__/index.test.tsx
@@ -146,6 +146,12 @@ function LocationProbe(): React.JSX.Element {
   return <output data-testid="location-search">{location.search}</output>;
 }
 
+function locationSearchParams(): URLSearchParams {
+  return new URLSearchParams(
+    screen.getByTestId('location-search').textContent ?? ''
+  );
+}
+
 function renderPage(setTitle = vi.fn(), initialEntry = '/dag-runs'): void {
   render(
     <MemoryRouter initialEntries={[initialEntry]}>
@@ -248,16 +254,55 @@ describe('DAGRuns page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
 
     await waitFor(() => {
-      const search = screen.getByTestId('location-search').textContent ?? '';
-      expect(new URLSearchParams(search).get('name')).toBe('deploy');
+      expect(locationSearchParams().get('name')).toBe('deploy');
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Open run' }));
 
-    const search = screen.getByTestId('location-search').textContent ?? '';
-    expect(new URLSearchParams(search).get('name')).toBe('deploy');
-    expect(new URLSearchParams(search).get('selectedRunName')).toBe('demo');
-    expect(new URLSearchParams(search).get('selectedRunId')).toBe('run-1');
+    expect(locationSearchParams().get('name')).toBe('deploy');
+    expect(locationSearchParams().get('selectedRunName')).toBe('demo');
+    expect(locationSearchParams().get('selectedRunId')).toBe('run-1');
+  });
+
+  it('keeps only active date-mode parameters after Search', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => {
+      const params = locationSearchParams();
+      expect(params.get('dateMode')).toBe('preset');
+      expect(params.get('preset')).toBe('today');
+      expect(params.has('specificValue')).toBe(false);
+      expect(params.has('specificPeriod')).toBe(false);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Specific date/month/year' })
+    );
+    await waitFor(() => {
+      const params = locationSearchParams();
+      expect(params.get('dateMode')).toBe('specific');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => {
+      const params = locationSearchParams();
+      expect(params.has('preset')).toBe(false);
+      expect(params.get('specificValue')).not.toBeNull();
+      expect(params.get('specificPeriod')).toBe('date');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom range' }));
+    await waitFor(() => {
+      const params = locationSearchParams();
+      expect(params.get('dateMode')).toBe('custom');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => {
+      const params = locationSearchParams();
+      expect(params.has('preset')).toBe(false);
+      expect(params.has('specificValue')).toBe(false);
+      expect(params.has('specificPeriod')).toBe(false);
+    });
   });
 
   it('restores the run and artifact tab from the URL', () => {

--- a/ui/src/pages/dag-runs/__tests__/index.test.tsx
+++ b/ui/src/pages/dag-runs/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,11 +10,19 @@ import { ConfigContext, type Config } from '@/contexts/ConfigContext';
 import { WorkspaceKind } from '@/lib/workspace';
 import DAGRuns from '..';
 
+const { readSearchStateMock, searchStateMock, writeSearchStateMock } =
+  vi.hoisted(() => {
+    const readState = vi.fn(() => null);
+    const writeState = vi.fn();
+    return {
+      readSearchStateMock: readState,
+      searchStateMock: { readState, writeState },
+      writeSearchStateMock: writeState,
+    };
+  });
+
 vi.mock('@/contexts/SearchStateContext', () => ({
-  useSearchState: () => ({
-    readState: vi.fn(() => null),
-    writeState: vi.fn(),
-  }),
+  useSearchState: () => searchStateMock,
 }));
 
 vi.mock('@/contexts/UserPreference', () => ({
@@ -117,6 +125,9 @@ const config = {
 } as Config;
 
 beforeEach(() => {
+  readSearchStateMock.mockReset();
+  readSearchStateMock.mockReturnValue(null);
+  writeSearchStateMock.mockReset();
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -213,6 +224,40 @@ describe('DAGRuns page', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close run' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(screen.getByTestId('location-search')).toHaveTextContent('');
+  });
+
+  it('opens a run on the artifacts tab and stores that selection in the URL', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open artifacts' }));
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Run modal for demo/run-1 on artifacts'
+    );
+    expect(screen.getByTestId('location-search')).toHaveTextContent(
+      '?selectedRunName=demo&selectedRunId=run-1&selectedRunTab=artifacts'
+    );
+  });
+
+  it('preserves execution filters when opening a run', async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Filter by DAG name...'), {
+      target: { value: 'deploy' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      const search = screen.getByTestId('location-search').textContent ?? '';
+      expect(new URLSearchParams(search).get('name')).toBe('deploy');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open run' }));
+
+    const search = screen.getByTestId('location-search').textContent ?? '';
+    expect(new URLSearchParams(search).get('name')).toBe('deploy');
+    expect(new URLSearchParams(search).get('selectedRunName')).toBe('demo');
+    expect(new URLSearchParams(search).get('selectedRunId')).toBe('run-1');
   });
 
   it('restores the run and artifact tab from the URL', () => {

--- a/ui/src/pages/dag-runs/__tests__/index.test.tsx
+++ b/ui/src/pages/dag-runs/__tests__/index.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { ConfigContext, type Config } from '@/contexts/ConfigContext';
@@ -59,7 +59,24 @@ vi.mock('@/features/dag-runs/components/common/DAGRunBatchActions', () => ({
 }));
 
 vi.mock('@/features/dag-runs/components/dag-run-details', () => ({
-  DAGRunDetailsModal: () => null,
+  DAGRunDetailsModal: ({
+    name,
+    dagRunId,
+    initialTab,
+    onClose,
+  }: {
+    name: string;
+    dagRunId: string;
+    initialTab: string;
+    onClose: () => void;
+  }) => (
+    <div role="dialog">
+      Run modal for {name}/{dagRunId} on {initialTab}
+      <button type="button" onClick={onClose}>
+        Close run
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock(
@@ -70,7 +87,29 @@ vi.mock(
 );
 
 vi.mock('@/features/dag-runs/components/dag-run-list/DAGRunTable', () => ({
-  default: () => <div>Run Table</div>,
+  default: ({
+    onSelectDAGRun,
+    onViewArtifacts,
+  }: {
+    onSelectDAGRun: (run: { name: string; dagRunId: string }) => void;
+    onViewArtifacts: (run: { name: string; dagRunId: string }) => void;
+  }) => (
+    <div>
+      <div>Run Table</div>
+      <button
+        type="button"
+        onClick={() => onSelectDAGRun({ name: 'demo', dagRunId: 'run-1' })}
+      >
+        Open run
+      </button>
+      <button
+        type="button"
+        onClick={() => onViewArtifacts({ name: 'demo', dagRunId: 'run-1' })}
+      >
+        Open artifacts
+      </button>
+    </div>
+  ),
 }));
 
 const config = {
@@ -91,9 +130,15 @@ beforeEach(() => {
   });
 });
 
-function renderPage(setTitle = vi.fn()): void {
+function LocationProbe(): React.JSX.Element {
+  const location = useLocation();
+  return <output data-testid="location-search">{location.search}</output>;
+}
+
+function renderPage(setTitle = vi.fn(), initialEntry = '/dag-runs'): void {
   render(
-    <MemoryRouter initialEntries={['/dag-runs']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <LocationProbe />
       <ConfigContext.Provider value={config}>
         <AppBarContext.Provider
           value={
@@ -133,9 +178,9 @@ describe('DAGRuns page', () => {
     expect(
       screen.getByPlaceholderText('Filter by Run ID...').className
     ).toContain('h-9');
-    expect(screen.getByRole('combobox', { name: 'Status' }).className).toContain(
-      'h-9'
-    );
+    expect(
+      screen.getByRole('combobox', { name: 'Status' }).className
+    ).toContain('h-9');
     expect(
       screen.getByRole('combobox', { name: 'Date preset' }).className
     ).toContain('h-9');
@@ -151,6 +196,33 @@ describe('DAGRuns page', () => {
 
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
       'All Statuses'
+    );
+  });
+
+  it('stores the selected run in the URL and clears it on close', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open run' }));
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Run modal for demo/run-1 on status'
+    );
+    expect(screen.getByTestId('location-search')).toHaveTextContent(
+      '?selectedRunName=demo&selectedRunId=run-1'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close run' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('location-search')).toHaveTextContent('');
+  });
+
+  it('restores the run and artifact tab from the URL', () => {
+    renderPage(
+      vi.fn(),
+      '/dag-runs?selectedRunName=demo&selectedRunId=run-1&selectedRunTab=artifacts'
+    );
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Run modal for demo/run-1 on artifacts'
     );
   });
 });

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -630,9 +630,9 @@ function DAGRuns() {
       fromDate,
       toDate,
       dateMode: dateRangeMode,
-      preset: datePreset,
-      specificValue,
-      specificPeriod,
+      preset: dateRangeMode === 'preset' ? datePreset : undefined,
+      specificValue: dateRangeMode === 'specific' ? specificValue : undefined,
+      specificPeriod: dateRangeMode === 'specific' ? specificPeriod : undefined,
     });
   };
 

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -4,7 +4,7 @@
 import dayjs from 'dayjs';
 import { Layers, List, Search } from 'lucide-react';
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Status } from '../../api/v1/schema';
 import { Button } from '@/components/ui/button';
 import { DateRangePicker } from '@/components/ui/date-range-picker';
@@ -126,6 +126,7 @@ function supportsIntersectionObserver(): boolean {
 
 function DAGRuns() {
   const location = useLocation();
+  const navigate = useNavigate();
   const appBarContext = React.useContext(AppBarContext);
   const config = useConfig();
   const { preferences, updatePreference } = useUserPreferences();
@@ -254,22 +255,73 @@ function DAGRuns() {
   const [selectedDAGRun, setSelectedDAGRun] = React.useState<{
     name: string;
     dagRunId: string;
-  } | null>(null);
+  } | null>(() => {
+    const params = new URLSearchParams(location.search);
+    const name = params.get('selectedRunName');
+    const dagRunId = params.get('selectedRunId');
+    return name && dagRunId ? { name, dagRunId } : null;
+  });
   const [selectedDAGRunInitialTab, setSelectedDAGRunInitialTab] =
-    React.useState<StatusTab>('status');
+    React.useState<StatusTab>(() =>
+      new URLSearchParams(location.search).get('selectedRunTab') === 'artifacts'
+        ? 'artifacts'
+        : 'status'
+    );
+  const updateSelectedDAGRun = React.useCallback(
+    (
+      dagRun: { name: string; dagRunId: string } | null,
+      initialTab: StatusTab = 'status',
+      replace = false
+    ) => {
+      setSelectedDAGRun(dagRun);
+      setSelectedDAGRunInitialTab(initialTab);
+      const params = new URLSearchParams(location.search);
+      if (dagRun) {
+        params.set('selectedRunName', dagRun.name);
+        params.set('selectedRunId', dagRun.dagRunId);
+        if (initialTab === 'status') {
+          params.delete('selectedRunTab');
+        } else {
+          params.set('selectedRunTab', initialTab);
+        }
+      } else {
+        params.delete('selectedRunName');
+        params.delete('selectedRunId');
+        params.delete('selectedRunTab');
+      }
+      const search = params.toString();
+      navigate(
+        {
+          pathname: location.pathname,
+          search: search ? `?${search}` : '',
+        },
+        { replace }
+      );
+    },
+    [location.pathname, location.search, navigate]
+  );
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const name = params.get('selectedRunName');
+    const dagRunId = params.get('selectedRunId');
+    setSelectedDAGRun(name && dagRunId ? { name, dagRunId } : null);
+    setSelectedDAGRunInitialTab(
+      params.get('selectedRunTab') === 'artifacts' ? 'artifacts' : 'status'
+    );
+  }, [location.search]);
+
   const selectDAGRun = React.useCallback(
     (dagRun: { name: string; dagRunId: string } | null) => {
-      setSelectedDAGRunInitialTab('status');
-      setSelectedDAGRun(dagRun);
+      updateSelectedDAGRun(dagRun);
     },
-    []
+    [updateSelectedDAGRun]
   );
   const viewDAGRunArtifacts = React.useCallback(
     (dagRun: { name: string; dagRunId: string }) => {
-      setSelectedDAGRunInitialTab('artifacts');
-      setSelectedDAGRun(dagRun);
+      updateSelectedDAGRun(dagRun, 'artifacts');
     },
-    []
+    [updateSelectedDAGRun]
   );
   const loadMoreSentinelRef = React.useRef<HTMLDivElement>(null);
   const autoLoadPendingRef = React.useRef(false);
@@ -857,10 +909,7 @@ function DAGRuns() {
               placeholder="Filter by labels..."
               className="h-9 min-w-[170px] max-w-[220px]"
             />
-            <Button
-              onClick={() => handleSearch()}
-              className="px-4 font-medium"
-            >
+            <Button onClick={() => handleSearch()} className="px-4 font-medium">
               <Search className="mr-1.5 h-4 w-4" />
               Search
             </Button>
@@ -1039,7 +1088,7 @@ function DAGRuns() {
           name={selectedDAGRun.name}
           dagRunId={selectedDAGRun.dagRunId}
           isOpen={!!selectedDAGRun}
-          onClose={() => setSelectedDAGRun(null)}
+          onClose={() => updateSelectedDAGRun(null, 'status', true)}
           initialTab={selectedDAGRunInitialTab}
         />
       )}

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -591,21 +591,23 @@ function DAGRuns() {
     toggleSelection,
   } = useBulkDAGRunSelection(dagRuns);
 
-  const addSearchParam = (key: string, value: string | undefined) => {
-    const locationQuery = new URLSearchParams(window.location.search);
-    if (key === 'labels') {
-      locationQuery.delete('tags');
+  const updateSearchParams = (updates: Record<string, string | undefined>) => {
+    const params = new URLSearchParams(location.search);
+    if ('labels' in updates) {
+      params.delete('tags');
     }
-    if (value && value.length > 0) {
-      locationQuery.set(key, value);
-    } else {
-      locationQuery.delete(key);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
     }
-    window.history.pushState(
-      {},
-      '',
-      `${window.location.pathname}?${locationQuery.toString()}`
-    );
+    const search = params.toString();
+    navigate({
+      pathname: location.pathname,
+      search: search ? `?${search}` : '',
+    });
   };
 
   const handleSearch = (overrideStatus?: string) => {
@@ -620,20 +622,18 @@ function DAGRuns() {
     setApiFromDate(fromDate);
     setApiToDate(toDate);
 
-    // Update URL parameters
-    addSearchParam('name', searchText);
-    addSearchParam('dagRunId', dagRunId);
-    addSearchParam('status', statusToUse);
-    addSearchParam(
-      'labels',
-      selectedLabels.length > 0 ? selectedLabels.join(',') : undefined
-    );
-    addSearchParam('fromDate', fromDate);
-    addSearchParam('toDate', toDate);
-    addSearchParam('dateMode', dateRangeMode);
-    addSearchParam('preset', datePreset);
-    addSearchParam('specificValue', specificValue);
-    addSearchParam('specificPeriod', specificPeriod);
+    updateSearchParams({
+      name: searchText,
+      dagRunId,
+      status: statusToUse,
+      labels: selectedLabels.length > 0 ? selectedLabels.join(',') : undefined,
+      fromDate,
+      toDate,
+      dateMode: dateRangeMode,
+      preset: datePreset,
+      specificValue,
+      specificPeriod,
+    });
   };
 
   const handleNameInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -655,10 +655,9 @@ function DAGRuns() {
   const updateLabels = (newLabels: string[]) => {
     setSelectedLabels(newLabels);
     setApiLabels(newLabels);
-    addSearchParam(
-      'labels',
-      newLabels.length > 0 ? newLabels.join(',') : undefined
-    );
+    updateSearchParams({
+      labels: newLabels.length > 0 ? newLabels.join(',') : undefined,
+    });
   };
 
   const handleViewModeChange = (value: string) => {
@@ -705,10 +704,12 @@ function DAGRuns() {
     setToDate(dates.to);
     setApiFromDate(dates.from);
     setApiToDate(dates.to);
-    addSearchParam('preset', preset);
-    addSearchParam('dateMode', 'preset');
-    addSearchParam('fromDate', dates.from);
-    addSearchParam('toDate', dates.to);
+    updateSearchParams({
+      preset,
+      dateMode: 'preset',
+      fromDate: dates.from,
+      toDate: dates.to,
+    });
   };
 
   const getSpecificPeriodDates = (
@@ -762,18 +763,19 @@ function DAGRuns() {
     setToDate(dates.to);
     setApiFromDate(dates.from);
     setApiToDate(dates.to);
-    addSearchParam('specificValue', value);
-    addSearchParam('specificPeriod', periodToUse);
-    addSearchParam('dateMode', 'specific');
-    addSearchParam('fromDate', dates.from);
-    addSearchParam('toDate', dates.to);
+    updateSearchParams({
+      specificValue: value,
+      specificPeriod: periodToUse,
+      dateMode: 'specific',
+      fromDate: dates.from,
+      toDate: dates.to,
+    });
   };
 
   const handleDateRangeModeChange = (
     newMode: 'preset' | 'specific' | 'custom'
   ) => {
     setDateRangeMode(newMode);
-    addSearchParam('dateMode', newMode);
 
     if (newMode === 'preset') {
       // Apply current preset
@@ -782,11 +784,14 @@ function DAGRuns() {
       setToDate(dates.to);
       setApiFromDate(dates.from);
       setApiToDate(dates.to);
-      addSearchParam('preset', datePreset);
-      addSearchParam('fromDate', dates.from);
-      addSearchParam('toDate', dates.to);
-      addSearchParam('specificValue', '');
-      addSearchParam('specificPeriod', '');
+      updateSearchParams({
+        dateMode: newMode,
+        preset: datePreset,
+        fromDate: dates.from,
+        toDate: dates.to,
+        specificValue: undefined,
+        specificPeriod: undefined,
+      });
     } else if (newMode === 'specific') {
       // Apply current specific period value
       const dates = getSpecificPeriodDates(specificPeriod, specificValue);
@@ -794,15 +799,21 @@ function DAGRuns() {
       setToDate(dates.to);
       setApiFromDate(dates.from);
       setApiToDate(dates.to);
-      addSearchParam('specificPeriod', specificPeriod);
-      addSearchParam('specificValue', specificValue);
-      addSearchParam('fromDate', dates.from);
-      addSearchParam('toDate', dates.to);
-      addSearchParam('preset', '');
+      updateSearchParams({
+        dateMode: newMode,
+        specificPeriod,
+        specificValue,
+        fromDate: dates.from,
+        toDate: dates.to,
+        preset: undefined,
+      });
     } else {
-      addSearchParam('preset', '');
-      addSearchParam('specificValue', '');
-      addSearchParam('specificPeriod', '');
+      updateSearchParams({
+        dateMode: newMode,
+        preset: undefined,
+        specificValue: undefined,
+        specificPeriod: undefined,
+      });
     }
   };
 

--- a/ui/src/pages/dags/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/__tests__/index.test.tsx
@@ -22,7 +22,11 @@ import {
 } from '@/api/v1/schema';
 import { useQuery } from '@/hooks/api';
 import type { View, ViewSpec } from '@/hooks/useViews';
-import { WorkspaceKind, workspaceSelectionKey } from '@/lib/workspace';
+import {
+  WorkspaceKind,
+  type WorkspaceSelection,
+  workspaceSelectionKey,
+} from '@/lib/workspace';
 import DagsPage from '../index';
 
 const {
@@ -355,29 +359,44 @@ function LocationProbe() {
   return <output data-testid="location-search">{location.search}</output>;
 }
 
+function DagsPageHarness({
+  setTitle,
+  workspaceSelection,
+}: {
+  setTitle: (title: string) => void;
+  workspaceSelection: WorkspaceSelection;
+}) {
+  return (
+    <ConfigContext.Provider value={makeConfig()}>
+      <SearchStateProvider>
+        <AppBarContext.Provider
+          value={{
+            title: '',
+            setTitle,
+            remoteNodes: ['local', 'remote-a'],
+            setRemoteNodes: () => undefined,
+            selectedRemoteNode: 'remote-a',
+            selectRemoteNode: () => undefined,
+            workspaces: [],
+            workspaceSelection,
+            selectWorkspace: () => undefined,
+          }}
+        >
+          <DagsPage />
+        </AppBarContext.Provider>
+      </SearchStateProvider>
+    </ConfigContext.Provider>
+  );
+}
+
 function renderPage(setTitle = vi.fn(), initialEntry = '/dags') {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <LocationProbe />
-      <ConfigContext.Provider value={makeConfig()}>
-        <SearchStateProvider>
-          <AppBarContext.Provider
-            value={{
-              title: '',
-              setTitle,
-              remoteNodes: ['local', 'remote-a'],
-              setRemoteNodes: () => undefined,
-              selectedRemoteNode: 'remote-a',
-              selectRemoteNode: () => undefined,
-              workspaces: [],
-              workspaceSelection: { kind: WorkspaceKind.all },
-              selectWorkspace: () => undefined,
-            }}
-          >
-            <DagsPage />
-          </AppBarContext.Provider>
-        </SearchStateProvider>
-      </ConfigContext.Provider>
+      <DagsPageHarness
+        setTitle={setTitle}
+        workspaceSelection={{ kind: WorkspaceKind.all }}
+      />
     </MemoryRouter>
   );
 }
@@ -1065,6 +1084,53 @@ describe('DagsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close workflow' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(screen.getByTestId('location-search')).toHaveTextContent('');
+  });
+
+  it('closes workflow details and removes its URL state when the workspace changes', () => {
+    function WorkspaceSwitchHarness() {
+      const [workspaceSelection, setWorkspaceSelection] =
+        React.useState<WorkspaceSelection>({
+          kind: WorkspaceKind.all,
+        });
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              setWorkspaceSelection({
+                kind: WorkspaceKind.workspace,
+                workspace: 'production',
+              })
+            }
+          >
+            Switch workspace
+          </button>
+          <DagsPageHarness
+            setTitle={vi.fn()}
+            workspaceSelection={workspaceSelection}
+          />
+        </>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/dags?selectedDAG=demo.yaml']}>
+        <LocationProbe />
+        <WorkspaceSwitchHarness />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Workflow modal for demo.yaml'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch workspace' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('location-search')).not.toHaveTextContent(
+      'selectedDAG'
+    );
   });
 
   it('loads and appends the next workflow page from the footer control', async () => {

--- a/ui/src/pages/dags/__tests__/index.test.tsx
+++ b/ui/src/pages/dags/__tests__/index.test.tsx
@@ -75,8 +75,19 @@ vi.mock('@/hooks/useViews', () => ({
 }));
 
 vi.mock('@/features/dags/components/dag-details', () => ({
-  DAGDetailsModal: ({ fileName }: { fileName: string }) => (
-    <div role="dialog">Workflow modal for {fileName}</div>
+  DAGDetailsModal: ({
+    fileName,
+    onClose,
+  }: {
+    fileName: string;
+    onClose: () => void;
+  }) => (
+    <div role="dialog">
+      Workflow modal for {fileName}
+      <button type="button" onClick={onClose}>
+        Close workflow
+      </button>
+    </div>
   ),
 }));
 
@@ -1040,6 +1051,20 @@ describe('DagsPage', () => {
     expect(
       screen.getByRole('button', { name: 'Open demo workflow' })
     ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-search')).toHaveTextContent(
+      '?selectedDAG=demo.yaml'
+    );
+  });
+
+  it('restores and closes workflow details from the URL', () => {
+    renderPage(vi.fn(), '/dags?selectedDAG=demo.yaml');
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Workflow modal for demo.yaml'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close workflow' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('location-search')).toHaveTextContent('');
   });
 
   it('loads and appends the next workflow page from the footer control', async () => {

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -363,8 +363,8 @@ function DAGsContent() {
       return;
     }
     previousWorkspaceKeyRef.current = workspaceKey;
-    setSelectedDAG(null);
-  }, [workspaceKey]);
+    updateSelectedDAG(null, true);
+  }, [updateSelectedDAG, workspaceKey]);
 
   const resetLoadedPages = React.useCallback(() => {
     paginationGenerationRef.current += 1;

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -363,8 +363,8 @@ function DAGsContent() {
       return;
     }
     previousWorkspaceKeyRef.current = workspaceKey;
-    updateSelectedDAG(null, true);
-  }, [updateSelectedDAG, workspaceKey]);
+    setSelectedDAG(null);
+  }, [workspaceKey]);
 
   const resetLoadedPages = React.useCallback(() => {
     paginationGenerationRef.current += 1;
@@ -504,8 +504,9 @@ function DAGsContent() {
     };
 
     if (scopeChanged) {
+      params.delete('selectedDAG');
       const nextSearch = buildWorkflowFilterSearch(
-        location.search,
+        params.toString(),
         next,
         nextActiveViewId ?? ALL_WORKFLOWS_VIEW_PARAM
       );

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -290,7 +290,29 @@ function DAGsContent() {
     (view) => view.isDefault
   )?.id;
   const previousWorkspaceKeyRef = React.useRef(workspaceKey);
-  const [selectedDAG, setSelectedDAG] = React.useState<string | null>(null);
+  const [selectedDAG, setSelectedDAG] = React.useState<string | null>(() =>
+    query.get('selectedDAG')
+  );
+  const updateSelectedDAG = React.useCallback(
+    (fileName: string | null, replace = false) => {
+      setSelectedDAG(fileName);
+      const params = new URLSearchParams(location.search);
+      if (fileName) {
+        params.set('selectedDAG', fileName);
+      } else {
+        params.delete('selectedDAG');
+      }
+      const search = params.toString();
+      navigate(
+        {
+          pathname: location.pathname,
+          search: search ? `?${search}` : '',
+        },
+        { replace }
+      );
+    },
+    [location.pathname, location.search, navigate]
+  );
   const [olderDAGFiles, setOlderDAGFiles] = React.useState<
     components['schemas']['DAGFile'][]
   >([]);
@@ -333,12 +355,16 @@ function DAGsContent() {
   );
 
   React.useEffect(() => {
+    setSelectedDAG(query.get('selectedDAG'));
+  }, [query]);
+
+  React.useEffect(() => {
     if (previousWorkspaceKeyRef.current === workspaceKey) {
       return;
     }
     previousWorkspaceKeyRef.current = workspaceKey;
-    setSelectedDAG(null);
-  }, [workspaceKey]);
+    updateSelectedDAG(null, true);
+  }, [updateSelectedDAG, workspaceKey]);
 
   const resetLoadedPages = React.useCallback(() => {
     paginationGenerationRef.current += 1;
@@ -716,7 +742,7 @@ function DAGsContent() {
 
       if (deletedFileNames.length > 0) {
         if (selectedDAG && deletedFileNames.includes(selectedDAG)) {
-          setSelectedDAG(null);
+          updateSelectedDAG(null, true);
         }
         resetLoadedPages();
         await mutate();
@@ -724,7 +750,14 @@ function DAGsContent() {
 
       return results;
     },
-    [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
+    [
+      client,
+      mutate,
+      remoteNode,
+      resetLoadedPages,
+      selectedDAG,
+      updateSelectedDAG,
+    ]
   );
 
   const handleRenameDAG = React.useCallback(
@@ -741,17 +774,25 @@ function DAGsContent() {
       }
 
       if (selectedDAG === fileName) {
-        setSelectedDAG(newFileName);
+        updateSelectedDAG(newFileName, true);
       }
       resetLoadedPages();
       await mutate();
     },
-    [client, mutate, remoteNode, resetLoadedPages, selectedDAG]
+    [
+      client,
+      mutate,
+      remoteNode,
+      resetLoadedPages,
+      selectedDAG,
+      updateSelectedDAG,
+    ]
   );
 
-  const handleSelectDAG = React.useCallback((fileName: string) => {
-    setSelectedDAG(fileName);
-  }, []);
+  const handleSelectDAG = React.useCallback(
+    (fileName: string) => updateSelectedDAG(fileName),
+    [updateSelectedDAG]
+  );
 
   React.useEffect(() => {
     appBarContext.setTitle('Workflows');
@@ -1156,7 +1197,7 @@ function DAGsContent() {
         <DAGDetailsModal
           fileName={selectedDAG}
           isOpen={!!selectedDAG}
-          onClose={() => setSelectedDAG(null)}
+          onClose={() => updateSelectedDAG(null, true)}
         />
       )}
     </div>

--- a/ui/webpack.dev.js
+++ b/ui/webpack.dev.js
@@ -9,11 +9,15 @@ module.exports = merge(common, {
   devtool: 'eval-source-map',
   profile: true,
   devServer: {
-    historyApiFallback: true,
+    historyApiFallback: { disableDotRule: true },
     port: 8081,
     proxy: [
       {
-        context: ['/api', '/assets/dag.schema.json', '/assets/config.schema.json'],
+        context: [
+          '/api',
+          '/assets/dag.schema.json',
+          '/assets/config.schema.json',
+        ],
         target: 'http://localhost:8080',
         changeOrigin: true,
         ws: true,


### PR DESCRIPTION
## Summary

- make collapsed navigation and the mobile drawer keyboard- and screen-reader-safe
- add canonical links and URL-backed workflow/execution detail selection
- surface failed-step errors before the graph and keep action/tab labels visible
- reduce empty Cockpit columns, normalize scheduled timestamps, and support dotted development routes
- add focused regression coverage for the changed behavior

## Why

The current web UI hid important failure information below the graph, exposed click-only list interactions, lost side-panel state on refresh, left hidden navigation focusable, and used icon-only controls at common widths. Cockpit also spent space on unused columns, while dotted workflow names failed through the development fallback.

## Impact

Workflow and execution pages are easier to navigate with keyboard, assistive technology, browser history, and direct links. Failed runs expose the actionable error sooner, and desktop layouts use space more effectively.

## Validation

- `pnpm test` (605 tests)
- `pnpm typecheck`
- ESLint on changed files
- `pnpm build`
- live browser verification of URL state, failure hierarchy, semantic links, Cockpit density, and dotted deep-link routing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves navigation, accessibility, and error visibility across the web UI. Adds URL-backed run/workflow selection, clearer failed-step alerts, denser Cockpit columns, and normalizes routed filter state.

- New Features
  - Link workflow and run names to their canonical pages; dev server serves dotted client routes.
  - Persist selected run/workflow in the URL (incl. artifacts tab); restore on reload; clear on close or workspace change; keep existing filters when opening; normalize routed filter params (keep only active date-mode fields).
  - Show the first failed/rejected step above the graph with “View stderr” and “Inspect step” actions.
  - Normalize “Scheduled At” to “YYYY-MM-DD HH:mm:ss” in the configured timezone and keep the original timestamp as a tooltip.
  - Cockpit Kanban hides empty columns on desktop, keeps default columns visible when no selection is set, and applies sensible min/max column widths.

- Bug Fixes
  - Collapsed sidebar and mobile drawer are keyboard- and screen-reader-safe: focus trap, Escape to close with focus return, inert background, labeled dialog, and correct `aria-current`.
  - Collapsed child links are removed from the DOM and not focusable; the group remains marked active when a child is current.
  - Tab labels stay visible (no icon-only tabs); DAG header uses full display for clearer navigation.

<sup>Written for commit 0d60d5da8c2a78b5e0790587bd4205b39d6a507c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DAG and run names are directly linkable from list and table views.
  - DAG and run selections, filters, and date settings persist in the URL and restore through navigation.
  - Failed or rejected steps show status details, error messages, stderr access, and step inspection controls.
  - Compact DAG navigation labels remain visible.
  - Mobile sidebar navigation includes improved focus handling, keyboard navigation, and accessibility semantics.
  - Desktop Kanban columns use consistent width limits.

- **Bug Fixes**
  - Schedule times respect the configured timezone and retain the original timestamp as a tooltip.
  - Client-side routes containing periods load correctly in development.
  - Collapsed menu items are properly hidden from navigation and assistive technology.
  - Default Kanban columns remain visible when empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->