### PR TITLE
fix(ui): close first-contact UX gaps across the web interface

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -35,6 +35,7 @@
       "description": "An organizational label used to group related DAGs together. Useful for categorizing DAGs in the UI, e.g., 'DailyJobs', 'Analytics'."
     },
     "dotenv": {
+      "examples": [".env"],
       "oneOf": [
         {
           "type": "string",
@@ -51,6 +52,7 @@
       "description": "Specifies .env files to load environment variables from. By default, '.env' is loaded. When files are specified, '.env' is automatically prepended to the list. All files are loaded sequentially with later files overriding earlier values. Set to empty array [] to disable all .env loading. Files are loaded relative to the DAG's working_dir."
     },
     "working_dir": {
+      "examples": ["/var/data/etl"],
       "type": "string",
       "description": "Working directory for the DAG. All relative paths (including dotenv files) are resolved relative to this directory. Defaults to the directory containing the DAG file."
     },
@@ -70,6 +72,7 @@
       }
     },
     "schedule": {
+      "examples": ["0 * * * *", "*/15 8-18 * * MON-FRI"],
       "oneOf": [
         {
           "type": "string",
@@ -273,6 +276,7 @@
       }
     },
     "env": {
+      "examples": [{ "LOG_LEVEL": "debug" }],
       "oneOf": [
         {
           "type": "array",
@@ -462,6 +466,7 @@
       "description": "Controls how stdout and stderr are logged. 'separate' writes stdout to .out and stderr to .err files. 'merged' writes both to a single .log file with interleaved output."
     },
     "handler_on": {
+      "examples": [{ "failure": { "run": "./notify.sh" } }],
       "type": "object",
       "properties": {
         "init": {
@@ -551,6 +556,7 @@
       "description": "Email configuration for informational notifications."
     },
     "timeout_sec": {
+      "examples": [3600],
       "type": "integer",
       "description": "Maximum number of seconds allowed for the entire DAG to finish. If exceeded, the DAG is considered timed out."
     },
@@ -572,6 +578,7 @@
       "description": "Number of DAG runs to retain in execution history. Mutually exclusive with hist_retention_days."
     },
     "max_active_runs": {
+      "examples": [1],
       "type": "integer",
       "default": 1,
       "description": "DEPRECATED: This field is ignored for local (DAG-based) queues. For concurrency control, define a global queue in config and use the 'queue' field.",
@@ -595,6 +602,7 @@
       "description": "Maximum size in bytes for the output of each step. If a step's output exceeds this limit, it will fail with an error. Defaults to 1MB (1048576 bytes). This limit also applies to pattern matching in preconditions and continue_on conditions."
     },
     "preconditions": {
+      "examples": ["test -f /tmp/input.csv"],
       "oneOf": [
         {
           "type": "string"
@@ -609,6 +617,7 @@
       "description": "Conditions that must be satisfied before the DAG can run. Use condition for command checks or literal/value-resolved comparisons, and eval with expected for dynamic command substitutions."
     },
     "params": {
+      "examples": ["ENVIRONMENT=dev REGION=local"],
       "oneOf": [
         {
           "type": "string",
@@ -929,6 +938,7 @@
       "description": "CPU and memory limits requested for a DAG run."
     },
     "stepRetryPolicy": {
+      "examples": [{ "limit": 2, "interval_sec": 30 }],
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -1588,6 +1598,7 @@
           "description": "Working directory for the step. Inherits from DAG's working_dir if not specified. Overrides DAG-level working_dir for this step."
         },
         "run": {
+          "examples": ["echo hello", "python scripts/etl.py"],
           "oneOf": [
             {
               "type": "string",
@@ -1719,6 +1730,7 @@
           "description": "Override DAG-level log output mode. 'separate' writes stdout to .out and stderr to .err files. 'merged' writes both to a single .log file."
         },
         "output": {
+          "examples": ["RESULT"],
           "oneOf": [
             {
               "type": "string",
@@ -1756,6 +1768,7 @@
           "description": "Named regular-file inputs for incremental execution."
         },
         "depends": {
+          "examples": ["build", ["build", "test"]],
           "oneOf": [
             {
               "type": "string",
@@ -1835,6 +1848,7 @@
           "$ref": "#/definitions/stepRetryPolicy"
         },
         "repeat_policy": {
+          "examples": [{ "repeat": true, "interval_sec": 60, "limit": 10 }],
           "type": "object",
           "properties": {
             "repeat": {
@@ -3107,6 +3121,7 @@
       "description": "OpenTelemetry configuration for distributed tracing. Enables detailed execution traces for DAGs and steps, providing visibility into workflow performance and debugging."
     },
     "container": {
+      "examples": [{ "image": "python:3.13" }],
       "oneOf": [
         {
           "type": "string",

--- a/internal/core/spec/builder.go
+++ b/internal/core/spec/builder.go
@@ -440,7 +440,7 @@ func decodeStep(raw map[string]any) (*step, error) {
 		DecodeHook:  typedUnionDecodeHook(),
 	})
 	if err := md.Decode(raw); err != nil {
-		return nil, core.NewValidationError("steps", raw, withSnakeCaseKeyHint(err))
+		return nil, core.NewValidationError("steps", raw, withLegacyKeyHint(err))
 	}
 	_, st.outputsSet = raw["outputs"]
 	_, st.inputsSet = raw["inputs"]

--- a/internal/core/spec/dag.go
+++ b/internal/core/spec/dag.go
@@ -2112,7 +2112,7 @@ func buildContainerField(ctx buildContext, raw any) (*core.Container, error) {
 		}
 		if err := decoder.Decode(v); err != nil {
 			return nil, core.NewValidationError("container", nil,
-				fmt.Errorf("failed to decode container: %w", withSnakeCaseKeyHint(err)))
+				fmt.Errorf("failed to decode container: %w", withLegacyKeyHint(err)))
 		}
 		return buildContainerFromSpec(ctx, &c)
 

--- a/internal/core/spec/defaults.go
+++ b/internal/core/spec/defaults.go
@@ -41,7 +41,7 @@ func decodeDefaults(raw any) (*defaults, error) {
 		return nil, core.NewValidationError("defaults", raw, err)
 	}
 	if err := decoder.Decode(raw); err != nil {
-		return nil, core.NewValidationError("defaults", raw, withSnakeCaseKeyHint(err))
+		return nil, core.NewValidationError("defaults", raw, withLegacyKeyHint(err))
 	}
 	return d, nil
 }

--- a/internal/core/spec/key_hints.go
+++ b/internal/core/spec/key_hints.go
@@ -77,13 +77,19 @@ var legacyToSnakeCaseKey = map[string]string{
 	"maxContextTokens":      "max_context_tokens",
 	"observationMaxBytes":   "observation_max_bytes",
 	"observationKeepRecent": "observation_keep_recent",
-	// Semantic renames (not just casing changes): these map legacy keys to their new equivalents.
-	"precondition": "preconditions",
-	"dir":          "working_dir",
-	"run":          "call",
 }
 
-func withSnakeCaseKeyHint(err error) error {
+// removedKeyHint maps keys that were renamed or removed (not just re-cased) to
+// a complete replacement hint.
+var removedKeyHint = map[string]string{
+	"precondition": `"precondition" is no longer supported; use "preconditions"`,
+	"dir":          `"dir" is no longer supported; use "working_dir"`,
+	"executor":     `"executor" has been removed; use "action" and pass executor options under "with"`,
+}
+
+// withLegacyKeyHint appends replacement hints to decoder errors that report
+// unknown keys, covering both camelCase-to-snake_case renames and removed keys.
+func withLegacyKeyHint(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -101,21 +107,29 @@ func withSnakeCaseKeyHint(err error) error {
 	}
 
 	keys := strings.Split(raw, ",")
-	suggestions := make([]string, 0, len(keys))
+	snakeCasePairs := make([]string, 0, len(keys))
+	clauses := make([]string, 0, len(keys))
 	for _, key := range keys {
 		k := strings.TrimSpace(strings.Trim(key, `"'`))
 		if k == "" {
 			continue
 		}
-		snake, ok := legacyToSnakeCaseKey[k]
-		if !ok {
+		if hint, ok := removedKeyHint[k]; ok {
+			clauses = append(clauses, hint)
 			continue
 		}
-		suggestions = append(suggestions, fmt.Sprintf("%s -> %s", k, snake))
+		if snake, ok := legacyToSnakeCaseKey[k]; ok {
+			snakeCasePairs = append(snakeCasePairs, fmt.Sprintf("%s -> %s", k, snake))
+		}
 	}
 
-	if len(suggestions) == 0 {
+	if len(snakeCasePairs) > 0 {
+		clauses = append([]string{
+			fmt.Sprintf("use snake_case keys (%s)", strings.Join(snakeCasePairs, ", ")),
+		}, clauses...)
+	}
+	if len(clauses) == 0 {
 		return err
 	}
-	return fmt.Errorf("%w; use snake_case keys (%s)", err, strings.Join(suggestions, ", "))
+	return fmt.Errorf("%w; %s", err, strings.Join(clauses, "; "))
 }

--- a/internal/core/spec/loader_test.go
+++ b/internal/core/spec/loader_test.go
@@ -59,6 +59,24 @@ func TestLoad(t *testing.T) {
 			useFile:     true,
 			errContains: "invalidyaml",
 		},
+		{
+			name:        "RemovedExecutorKeyHint",
+			content:     "steps:\n  - name: a\n    executor: docker\n",
+			useFile:     true,
+			errContains: `"executor" has been removed; use "action"`,
+		},
+		{
+			name:        "LegacyCamelCaseKeyHint",
+			content:     "steps:\n  - name: a\n    run: \"true\"\n    retryPolicy:\n      limit: 2\n",
+			useFile:     true,
+			errContains: "use snake_case keys (retryPolicy -> retry_policy)",
+		},
+		{
+			name:        "RenamedPreconditionKeyHint",
+			content:     "steps:\n  - name: a\n    run: \"true\"\n    precondition: \"test -f /tmp/x\"\n",
+			useFile:     true,
+			errContains: `use "preconditions"`,
+		},
 	}
 
 	for _, tt := range errorTests {

--- a/internal/core/spec/manifest_decoder.go
+++ b/internal/core/spec/manifest_decoder.go
@@ -65,7 +65,7 @@ func (d *manifestDecoder) Decode(input map[string]any) (*dag, error) {
 		return nil, err
 	}
 
-	if err := withSnakeCaseKeyHint(mapDecoder.Decode(input)); err != nil {
+	if err := withLegacyKeyHint(mapDecoder.Decode(input)); err != nil {
 		return nil, err
 	}
 

--- a/ui/e2e/helpers/e2e.ts
+++ b/ui/e2e/helpers/e2e.ts
@@ -513,7 +513,7 @@ export async function enqueueRunFromUI(page: Page, fileName: string): Promise<st
       response.url().includes(`/api/v1/dags/${encodeURIComponent(fileName)}/enqueue`)
   );
 
-  await page.getByRole('button', { name: 'Enqueue' }).first().click();
+  await page.getByRole('button', { name: 'Start' }).first().click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -565,6 +565,11 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
     document.documentElement.style.backgroundColor = 'var(--background)';
   }, [theme]);
 
+  React.useEffect(() => {
+    const base = config.title || 'Dagu';
+    document.title = title ? `${title} - ${base}` : base;
+  }, [title, config.title]);
+
   return (
     <SWRConfig
       value={{

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Config } from '@/contexts/ConfigContext';
+import { AppBarContext } from '@/contexts/AppBarContext';
 import App from '../App';
 
 const { clientMock, clientGetMock, overviewImportError, useQueryMock } =
@@ -104,7 +105,15 @@ vi.mock('../pages/queues', () => ({ default: () => <h1>Queues</h1> }));
 vi.mock('../pages/queues/queue', () => ({
   default: () => <h1>Queue Details</h1>,
 }));
-vi.mock('../pages/search', () => ({ default: () => <h1>Search</h1> }));
+vi.mock('../pages/search', () => ({
+  default: () => {
+    const { setTitle } = React.useContext(AppBarContext);
+    React.useEffect(() => {
+      setTitle('Search');
+    }, [setTitle]);
+    return <h1>Search</h1>;
+  },
+}));
 vi.mock('../pages/setup', () => ({ default: () => <h1>Setup</h1> }));
 vi.mock('../pages/system-status', () => ({
   default: () => <h1>System Status</h1>,
@@ -176,27 +185,44 @@ function renderAt(path: string, config = makeConfig()): void {
   render(<App config={config} />);
 }
 
-describe('App license routing', () => {
-  beforeEach(() => {
-    localStorage.clear();
-    sessionStorage.clear();
-    clientGetMock.mockReset();
-    clientGetMock.mockResolvedValue({ data: { workspaces: [] } });
-    useQueryMock.mockReset();
-    useQueryMock.mockReturnValue({ data: undefined });
-    overviewImportError.current = false;
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        Response.json({
-          remoteNodes: [],
-          type: 'object',
-          properties: {},
-        })
-      )
-    );
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  clientGetMock.mockReset();
+  clientGetMock.mockResolvedValue({ data: { workspaces: [] } });
+  useQueryMock.mockReset();
+  useQueryMock.mockReturnValue({ data: undefined });
+  overviewImportError.current = false;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      Response.json({
+        remoteNodes: [],
+        type: 'object',
+        properties: {},
+      })
+    )
+  );
+});
+
+describe('App document title', () => {
+  it('reflects the page title in the browser tab', async () => {
+    renderAt('/search');
+
+    await waitFor(() => {
+      expect(document.title).toBe('Search - Dagu');
+    });
   });
 
+  it('falls back to the configured title when a page sets none', async () => {
+    renderAt('/queues');
+
+    expect(await screen.findByRole('heading', { name: 'Queues' })).toBeVisible();
+    expect(document.title).toBe('Dagu');
+  });
+});
+
+describe('App license routing', () => {
   it.each([
     { path: '/notifications', heading: 'Notifications' },
     { path: '/notification-rules', heading: 'Notification Rules' },

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -215,10 +215,10 @@ describe('App document title', () => {
   });
 
   it('falls back to the configured title when a page sets none', async () => {
-    renderAt('/queues');
+    renderAt('/queues', makeConfig({ title: 'Operations' }));
 
     expect(await screen.findByRole('heading', { name: 'Queues' })).toBeVisible();
-    expect(document.title).toBe('Dagu');
+    expect(document.title).toBe('Operations');
   });
 });
 

--- a/ui/src/components/ui/__tests__/error-modal.test.tsx
+++ b/ui/src/components/ui/__tests__/error-modal.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { ErrorModalProvider, useErrorModal } from '../error-modal';
+
+function Trigger({
+  message,
+  hint,
+  title,
+  details,
+}: {
+  message: string;
+  hint?: string;
+  title?: string;
+  details?: string[];
+}) {
+  const { showError } = useErrorModal();
+  return (
+    <button onClick={() => showError(message, hint, title, details)}>
+      trigger
+    </button>
+  );
+}
+
+describe('ErrorModalProvider', () => {
+  it('shows the message and hint', async () => {
+    const user = userEvent.setup();
+    render(
+      <ErrorModalProvider>
+        <Trigger message="Failed to save spec" hint="Check the YAML syntax." />
+      </ErrorModalProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'trigger' }));
+
+    expect(screen.getByText('Failed to save spec')).toBeInTheDocument();
+    expect(screen.getByText('Check the YAML syntax.')).toBeInTheDocument();
+  });
+
+  it('renders detail lines in one block that preserves line breaks', async () => {
+    const user = userEvent.setup();
+    const details = [
+      '[3:4] value is not allowed in this context',
+      "field 'steps': invalid keys: nosuchfield",
+    ];
+    render(
+      <ErrorModalProvider>
+        <Trigger
+          message="The spec was not saved"
+          title="Validation errors"
+          details={details}
+        />
+      </ErrorModalProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'trigger' }));
+
+    expect(screen.getByText('Validation errors')).toBeInTheDocument();
+    const block = screen.getByText((_, element) => {
+      return (
+        element?.tagName === 'PRE' &&
+        element.textContent === details.join('\n')
+      );
+    });
+    expect(block).toHaveClass('whitespace-pre-wrap');
+  });
+});

--- a/ui/src/components/ui/error-modal.tsx
+++ b/ui/src/components/ui/error-modal.tsx
@@ -14,6 +14,8 @@ interface ErrorModalProps {
   title?: string;
   message: string;
   hint?: string;
+  /** Machine-generated diagnostics (e.g. validation errors); rendered monospace with line breaks preserved. */
+  details?: string[];
   isOpen: boolean;
   onClose: () => void;
 }
@@ -22,12 +24,16 @@ export const ErrorModal: FC<ErrorModalProps> = ({
   title = 'Error',
   message,
   hint,
+  details,
   isOpen,
   onClose,
 }) => {
+  const hasDetails = details != null && details.length > 0;
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-[450px]">
+      <DialogContent
+        className={hasDetails ? 'sm:max-w-[640px]' : 'sm:max-w-[450px]'}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-error">
             <AlertTriangle className="h-5 w-5" />
@@ -41,6 +47,11 @@ export const ErrorModal: FC<ErrorModalProps> = ({
             <p className="text-xs text-muted-foreground bg-muted px-3 py-2 rounded-md">
               {hint}
             </p>
+          )}
+          {hasDetails && (
+            <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-muted px-3 py-2 rounded-md max-h-60 overflow-y-auto">
+              {details.join('\n')}
+            </pre>
           )}
         </div>
 
@@ -59,10 +70,16 @@ interface ErrorState {
   title?: string;
   message: string;
   hint?: string;
+  details?: string[];
 }
 
 interface ErrorModalContextType {
-  showError: (message: string, hint?: string, title?: string) => void;
+  showError: (
+    message: string,
+    hint?: string,
+    title?: string,
+    details?: string[]
+  ) => void;
 }
 
 export const ErrorModalContext = createContext<ErrorModalContextType>({
@@ -78,8 +95,13 @@ export const ErrorModalProvider: FC<ErrorModalProviderProps> = ({
 }) => {
   const [error, setError] = useState<ErrorState | null>(null);
 
-  const showError = (message: string, hint?: string, title?: string) => {
-    setError({ message, hint, title });
+  const showError = (
+    message: string,
+    hint?: string,
+    title?: string,
+    details?: string[]
+  ) => {
+    setError({ message, hint, title, details });
   };
 
   const handleClose = () => {
@@ -94,6 +116,7 @@ export const ErrorModalProvider: FC<ErrorModalProviderProps> = ({
           title={error.title}
           message={error.message}
           hint={error.hint}
+          details={error.details}
           isOpen={true}
           onClose={handleClose}
         />

--- a/ui/src/features/dag-runs/components/dag-run-details/DAGRunHeader.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-details/DAGRunHeader.tsx
@@ -3,7 +3,9 @@
 
 import {
   Calendar,
+  Check,
   FileText,
+  Link2,
   RefreshCw,
   Server,
   SlidersHorizontal,
@@ -13,7 +15,9 @@ import {
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { components, Status } from '../../../../api/v1/schema';
+import { useConfig } from '../../../../contexts/ConfigContext';
 import { useRemoteNode } from '../../../../contexts/RemoteNodeContext';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import dayjs from '../../../../lib/dayjs';
 import StatusChip from '@/components/ui/status-chip';
 import AutoRetryBadge from '../common/AutoRetryBadge';
@@ -33,7 +37,22 @@ const DAGRunHeader: React.FC<DAGRunHeaderProps> = ({
 }) => {
   const navigate = useNavigate();
   const remoteNode = useRemoteNode();
+  const config = useConfig();
   const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const { copied: linkCopied, copy: copyLink } = useCopyFeedback();
+
+  const copyRunLink = () => {
+    const basePrefix =
+      config.basePath === '/' ? '' : (config.basePath ?? '');
+    const runPath = buildDAGRunPageURL({
+      rootDAGRunName: dagRun.rootDAGRunName,
+      rootDAGRunId: dagRun.rootDAGRunId,
+      remoteNode,
+      subDAGRunId:
+        dagRun.dagRunId !== dagRun.rootDAGRunId ? dagRun.dagRunId : undefined,
+    });
+    void copyLink(`${window.location.origin}${basePrefix}${runPath}`);
+  };
 
   function formatDuration(startDate: string, endDate: string): string {
     if (!startDate || !endDate) return '--';
@@ -199,6 +218,23 @@ const DAGRunHeader: React.FC<DAGRunHeaderProps> = ({
                 <span>Definition</span>
               </a>
             )}
+            <button
+              type="button"
+              onClick={copyRunLink}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+              title={linkCopied ? 'Link copied' : 'Copy link to this run'}
+              aria-label={linkCopied ? 'Link copied' : 'Copy link to this run'}
+            >
+              {linkCopied ? (
+                <Check className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <Link2 className="h-3.5 w-3.5" />
+              )}
+              <span>{linkCopied ? 'Copied' : 'Copy link'}</span>
+            </button>
+            <span className="sr-only" aria-live="polite">
+              {linkCopied ? 'Run link copied to clipboard' : ''}
+            </span>
           </div>
         </div>
       </div>

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
@@ -167,8 +167,8 @@ function DAGRunGroupedView({
         No DAG runs found
       </h3>
       <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
-        There are no DAG runs matching your current filters. Try adjusting your
-        search criteria or date range.
+        No DAG runs in the selected time range. Adjust the date range or
+        filters, or start a workflow from the Workflows page.
       </p>
     </div>
   );

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
@@ -19,6 +19,8 @@ import { DAGRunArtifactsButton } from './DAGRunArtifactsButton';
 
 interface DAGRunGroupedViewProps {
   dagRuns: components['schemas']['DAGRunSummary'][];
+  /** True while the first page is being fetched; suppresses the empty state. */
+  isLoading?: boolean;
   selectedRunKeys?: Set<string>;
   selectedDAGRun?: { name: string; dagRunId: string } | null;
   onSelectDAGRun?: (dagRun: { name: string; dagRunId: string } | null) => void;
@@ -32,6 +34,7 @@ interface GroupedDAGRuns {
 
 function DAGRunGroupedView({
   dagRuns,
+  isLoading = false,
   selectedRunKeys,
   selectedDAGRun = null,
   onSelectDAGRun,
@@ -171,6 +174,13 @@ function DAGRunGroupedView({
   );
 
   if (dagRuns.length === 0) {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading DAG runs...
+        </div>
+      );
+    }
     return <EmptyState />;
   }
 

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
@@ -29,6 +29,8 @@ import { DAGRunArtifactsButton } from './DAGRunArtifactsButton';
 
 interface DAGRunTableProps {
   dagRuns: components['schemas']['DAGRunSummary'][];
+  /** True while the first page is being fetched; suppresses the empty state. */
+  isLoading?: boolean;
   selectedRunKeys?: Set<string>;
   selectedDAGRun?: { name: string; dagRunId: string } | null;
   onSelectDAGRun?: (dagRun: { name: string; dagRunId: string } | null) => void;
@@ -54,6 +56,7 @@ function isInteractiveEventTarget(target: EventTarget | null): boolean {
 
 function DAGRunTable({
   dagRuns,
+  isLoading = false,
   selectedRunKeys,
   selectedDAGRun = null,
   onSelectDAGRun,
@@ -286,8 +289,15 @@ function DAGRunTable({
     </div>
   );
 
-  // If there are no DAG runs, show empty state
+  // If there are no DAG runs, show empty state (unless the first page is still loading)
   if (dagRuns.length === 0) {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading DAG runs...
+        </div>
+      );
+    }
     return <EmptyState />;
   }
 

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
@@ -283,8 +283,8 @@ function DAGRunTable({
         No DAG runs found
       </h3>
       <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
-        There are no DAG runs matching your current filters. Try adjusting your
-        search criteria or date range.
+        No DAG runs in the selected time range. Adjust the date range or
+        filters, or start a workflow from the Workflows page.
       </p>
     </div>
   );

--- a/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunGroupedView.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunGroupedView.test.tsx
@@ -18,6 +18,13 @@ afterEach(() => {
 });
 
 describe('DAGRunGroupedView', () => {
+  it('shows a loading row instead of the empty state while the first page loads', () => {
+    render(<DAGRunGroupedView dagRuns={[]} isLoading />);
+
+    expect(screen.getByText('Loading DAG runs...')).toBeInTheDocument();
+    expect(screen.queryByText('No DAG runs found')).not.toBeInTheDocument();
+  });
+
   it('sorts grouped runs by schedule time before queued time', () => {
     render(
       <DAGRunGroupedView

--- a/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
@@ -68,6 +68,31 @@ const config = {
 } as Config;
 
 describe('DAGRunTable', () => {
+  it('shows a loading row instead of the empty state while the first page loads', () => {
+    render(
+      <MemoryRouter>
+        <ConfigContext.Provider value={config}>
+          <DAGRunTable dagRuns={[]} isLoading />
+        </ConfigContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading DAG runs...')).toBeInTheDocument();
+    expect(screen.queryByText('No DAG runs found')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state once loading finishes with no runs', () => {
+    render(
+      <MemoryRouter>
+        <ConfigContext.Provider value={config}>
+          <DAGRunTable dagRuns={[]} />
+        </ConfigContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('No DAG runs found')).toBeInTheDocument();
+  });
+
   it('shows the scheduled at column and value when schedule time exists', () => {
     render(
       <MemoryRouter>

--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -774,8 +774,6 @@ function DAGStatus({
                             ? onRightClickStepOnGraph
                             : undefined
                         }
-                        showIcons={displayDAGRun.status > Status.NotStarted}
-                        animate={displayDAGRun.status == Status.Running}
                         height={graphHeight}
                       />
                     </div>

--- a/ui/src/features/dags/components/common/DAGActions.tsx
+++ b/ui/src/features/dags/components/common/DAGActions.tsx
@@ -287,7 +287,7 @@ function DAGActions({
       <div
         className={`flex items-center ${displayMode === 'compact' ? 'space-x-1' : 'space-x-2'}`}
       >
-        {/* Enqueue Button */}
+        {/* Start Button */}
         <Tooltip>
           <TooltipTrigger asChild>
             <ActionButton
@@ -303,7 +303,7 @@ function DAGActions({
               }}
               className="cursor-pointer"
             >
-              Enqueue
+              Start
             </ActionButton>
           </TooltipTrigger>
           <TooltipContent>

--- a/ui/src/features/dags/components/dag-details/DAGHeader.tsx
+++ b/ui/src/features/dags/components/dag-details/DAGHeader.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { components, Status } from '../../../../api/v1/schema';
 import dayjs from '../../../../lib/dayjs';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import StatusChip from '@/components/ui/status-chip';
 import AutoRetryBadge from '../../../dag-runs/components/common/AutoRetryBadge';
 import { RootDAGRunContext } from '../../contexts/RootDAGRunContext';
@@ -36,8 +36,7 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
   const rootDAGRunContext = React.useContext(RootDAGRunContext);
   const [isRefreshing, setIsRefreshing] = React.useState(false);
   const [currentDuration, setCurrentDuration] = React.useState<string>('--');
-  const [copiedName, setCopiedName] = React.useState<string | null>(null);
-  const copiedNameResetRef = React.useRef<ReturnType<typeof setTimeout>>(null);
+  const { copied: nameCopied, copy: copyName } = useCopyFeedback();
 
   const scopedUrl = useCallback(
     (path: string) => (buildScopedUrl ? buildScopedUrl(path) : path),
@@ -48,26 +47,6 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
   const dagRunToDisplay = rootDAGRunContext.data || currentDAGRun;
 
   const displayName = dagRunToDisplay?.name || dag.name;
-  const nameCopied = copiedName !== null && copiedName === displayName;
-
-  const copyName = useCallback(async () => {
-    if (!displayName) return;
-    if (!(await copyText(displayName))) return;
-    setCopiedName(displayName);
-    if (copiedNameResetRef.current) {
-      clearTimeout(copiedNameResetRef.current);
-    }
-    copiedNameResetRef.current = setTimeout(() => setCopiedName(null), 2000);
-  }, [displayName]);
-
-  useEffect(
-    () => () => {
-      if (copiedNameResetRef.current) {
-        clearTimeout(copiedNameResetRef.current);
-      }
-    },
-    []
-  );
 
   // Calculate duration between start and end times
   const calculateDuration = React.useCallback(() => {
@@ -238,7 +217,7 @@ const DAGHeader: React.FC<DAGHeaderProps> = ({
             </h1>
             {displayName && (
               <button
-                onClick={copyName}
+                onClick={() => copyName(displayName)}
                 className="flex-shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
                 title={nameCopied ? 'Name copied' : `Copy name: ${displayName}`}
                 aria-label={nameCopied ? 'Name copied' : 'Copy name'}

--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -9,6 +9,7 @@
 import { Button } from '@/components/ui/button';
 import { CommandDisplay } from '@/components/ui/command-display';
 import { useErrorModal } from '@/components/ui/error-modal';
+import { useSimpleToast } from '@/components/ui/simple-toast';
 import { ScriptBadge } from '@/components/ui/script-dialog';
 import { TableCell } from '@/components/ui/table';
 import {
@@ -310,6 +311,7 @@ function NodeStatusTableRow({
   const dagRunContext = useContext(DAGRunContext);
   const remoteNode = useRemoteNode();
   const { showError } = useErrorModal();
+  const { showToast } = useSimpleToast();
   // State to store the current duration for running tasks
   const [currentDuration, setCurrentDuration] = useState<string>('-');
   // State for expanding/collapsing parallel executions
@@ -382,7 +384,7 @@ function NodeStatusTableRow({
     loading || dagRun.status === Status.Running || rootRunning;
   const retryTitle = rootRunning
     ? 'Retry unavailable while the root DAG run is running.'
-    : 'Retry from this step';
+    : 'Retry this step';
 
   const subDAGLogQuery = useQuery(
     '/dag-runs/{name}/{dagRunId}/sub-dag-runs/{subDAGRunId}/steps/{stepName}/log',
@@ -618,6 +620,8 @@ function NodeStatusTableRow({
         return;
       }
       setShowDialog(false);
+      showToast('Step retry started');
+      dagContext.refresh();
     } catch (e) {
       const requestError = e as {
         data?: { message?: string };
@@ -690,7 +694,7 @@ function NodeStatusTableRow({
     <Dialog open={showDialog} onOpenChange={handleRetryDialogOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Retry from this step?</DialogTitle>
+          <DialogTitle>Retry this step?</DialogTitle>
         </DialogHeader>
         <div className="py-2 text-sm">
           This will re-execute <b>{node.step.name}</b>. Are you sure?

--- a/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx
@@ -13,6 +13,7 @@ import {
   Status,
   StatusLabel,
 } from '@/api/v1/schema';
+import { ToastProvider } from '@/components/ui/simple-toast';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { DAGRunContext } from '@/features/dag-runs/contexts/DAGRunContext';
 import { useQuery } from '@/hooks/api';
@@ -468,6 +469,7 @@ describe('NodeStatusTableRow', () => {
   it('retries a child step through its root DAG run', async () => {
     const user = userEvent.setup();
     postMock.mockResolvedValueOnce({});
+    const refresh = vi.fn();
     const node = {
       step: { name: 'build' },
       status: NodeStatus.Failed,
@@ -482,33 +484,35 @@ describe('NodeStatusTableRow', () => {
 
     render(
       <MemoryRouter>
-        <AppBarContext.Provider value={appBarValue}>
-          <DAGContext.Provider
-            value={{
-              refresh: vi.fn(),
-              name: 'child',
-              fileName: 'child.yaml',
-            }}
-          >
-            <table>
-              <tbody>
-                <NodeStatusTableRow
-                  rownum={1}
-                  node={node}
-                  name="child.yaml"
-                  dagRun={{
-                    ...dagRun,
-                    name: 'child',
-                    dagRunId: 'child-run',
-                    rootDAGRunName: 'root',
-                    rootDAGRunId: 'root-run',
-                  }}
-                  view="desktop"
-                />
-              </tbody>
-            </table>
-          </DAGContext.Provider>
-        </AppBarContext.Provider>
+        <ToastProvider>
+          <AppBarContext.Provider value={appBarValue}>
+            <DAGContext.Provider
+              value={{
+                refresh,
+                name: 'child',
+                fileName: 'child.yaml',
+              }}
+            >
+              <table>
+                <tbody>
+                  <NodeStatusTableRow
+                    rownum={1}
+                    node={node}
+                    name="child.yaml"
+                    dagRun={{
+                      ...dagRun,
+                      name: 'child',
+                      dagRunId: 'child-run',
+                      rootDAGRunName: 'root',
+                      rootDAGRunId: 'root-run',
+                    }}
+                    view="desktop"
+                  />
+                </tbody>
+              </table>
+            </DAGContext.Provider>
+          </AppBarContext.Provider>
+        </ToastProvider>
       </MemoryRouter>
     );
 
@@ -534,6 +538,8 @@ describe('NodeStatusTableRow', () => {
         }
       );
     });
+    expect(await screen.findByText('Step retry started')).toBeVisible();
+    expect(refresh).toHaveBeenCalled();
   });
 
   it.each(['desktop', 'mobile'] as const)(

--- a/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditor.tsx
@@ -223,11 +223,6 @@ function DAGEditor({
       });
     }
 
-    // Format document after a short delay
-    setTimeout(() => {
-      editor.getAction('editor.action.formatDocument')?.run();
-    }, 100);
-
     // Prevent 'f' key from propagating to prevent fullscreen shortcuts
     // when user is typing in the editor
     editor.onKeyDown((e) => {
@@ -283,7 +278,7 @@ function DAGEditor({
             ? false
             : { other: true, comments: false, strings: true },
           suggestOnTriggerCharacters: !readOnly,
-          formatOnType: !readOnly,
+          formatOnType: false,
           formatOnPaste: !readOnly,
           renderValidationDecorations: readOnly ? 'off' : 'on',
           lineNumbers: lineNumbers ? 'on' : 'off',

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -7,11 +7,19 @@
  * @module features/dags/components/dag-editor
  */
 import { useCanWriteForWorkspace } from '@/contexts/AuthContext';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { StepDetailsDrawer } from '@/features/dags/components/step-details';
 import { toMermaidNodeId } from '@/lib/utils';
 import { workspaceNameFromLabels } from '@/lib/workspace';
 import BorderedBox from '@/components/ui/bordered-box';
-import { AlertTriangle, MousePointerClick, Save, Undo2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  MousePointerClick,
+  Save,
+  Undo2,
+} from 'lucide-react';
 import React, { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 import { components } from '../../../../api/v1/schema';
@@ -185,6 +193,8 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
     key: `${fileName}:${remoteNode}`,
     serverContent: serverSpec,
   });
+
+  const { copied: specCopied, copy: copySpec } = useCopyFeedback();
 
   const [lastGoodLegacyDefinitions, setLastGoodLegacyDefinitions] =
     React.useState(
@@ -543,8 +553,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       {(props) => {
         // Update refresh callback ref directly (safe in render)
         refreshCallbackRef.current = props.refresh;
-        const editorHeaderActions =
-          valueReferenceNotices.length > 0 || editable ? (
+        const editorHeaderActions = (
             <div className="flex items-center gap-2">
               {valueReferenceNotices.length > 0 && (
                 <ValueReferenceNoticesButton
@@ -552,6 +561,19 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                   description="Value-reference notices produced while loading this spec."
                 />
               )}
+              <Button
+                variant="ghost"
+                title="Copy YAML"
+                aria-label={specCopied ? 'YAML copied' : 'Copy YAML'}
+                onClick={() => copySpec(currentValue ?? serverSpec ?? '')}
+              >
+                {specCopied ? (
+                  <Check className="h-4 w-4 text-green-500" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+                Copy
+              </Button>
               {editable && (
                 <>
                   {localHasUnsavedChanges && (
@@ -579,7 +601,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                 </>
               )}
             </div>
-          ) : undefined;
+          );
 
         return (
           data?.dag && (

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -487,7 +487,6 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
                     onChangeFlowchart={onChangeFlowchart}
                     onClickNode={handleGraphNodeSelect}
                     selectOnClick
-                    showIcons={false}
                   />
                 </BorderedBox>
                 <div className="mt-2 flex justify-end">

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -337,8 +337,13 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
       return;
     }
 
-    if (responseData?.errors) {
-      showError('Validation errors', responseData.errors.join('\n'));
+    if (responseData?.errors?.length) {
+      showError(
+        'The spec was not saved',
+        undefined,
+        'Validation errors',
+        responseData.errors
+      );
       return;
     }
 

--- a/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
@@ -486,7 +486,12 @@ function DAGSpecReadOnly({
       }
 
       if (responseData?.errors?.length) {
-        showError('Validation errors', responseData.errors.join('\n'));
+        showError(
+          'The spec was not saved',
+          undefined,
+          'Validation errors',
+          responseData.errors
+        );
         return;
       }
 

--- a/ui/src/features/dags/components/dag-list/DAGTable.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGTable.tsx
@@ -985,6 +985,38 @@ function getDefaultSortOrder(field: string): string {
   return 'asc';
 }
 
+function WorkflowsEmptyState({
+  icon,
+  heading,
+  description,
+  showAllButton,
+  onShowAllWorkflows,
+}: {
+  icon: string;
+  heading: string;
+  description: string;
+  showAllButton: boolean;
+  onShowAllWorkflows?: () => void;
+}) {
+  return (
+    <>
+      <div className="text-6xl mb-4">{icon}</div>
+      <h3 className="text-lg font-medium text-foreground mb-2">{heading}</h3>
+      <p className="text-sm text-muted-foreground text-center max-w-md mb-4 whitespace-normal break-words">
+        {description}
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {showAllButton && (
+          <Button type="button" variant="outline" onClick={onShowAllWorkflows}>
+            Show all workflows
+          </Button>
+        )}
+        <CreateDAGModal />
+      </div>
+    </>
+  );
+}
+
 function buildGrepSearchUrl(searchText: string): string {
   const params = new URLSearchParams();
   const query = searchText.trim();
@@ -1590,9 +1622,26 @@ function DAGTable({
   const activeWorkflowViewName = workflowViews.find(
     (view) => view.id === activeWorkflowViewId
   )?.name;
-  const emptyStateDescription = activeWorkflowViewName
-    ? `No workflows match the “${activeWorkflowViewName}” view. Try adjusting its filters or show all workflows.`
-    : 'There are no workflows matching your current filters. Try adjusting your search criteria or labels.';
+  const isPristineAllView =
+    isAllWorkflowsView && !searchText && searchLabels.length === 0 && !activeOnly;
+  const emptyState = activeWorkflowViewName
+    ? {
+        icon: '🔍',
+        heading: 'No workflows found',
+        description: `No workflows match the “${activeWorkflowViewName}” view. Try adjusting its filters or show all workflows.`,
+      }
+    : isPristineAllView
+      ? {
+          icon: '🌱',
+          heading: 'No workflows yet',
+          description: 'Create your first workflow to get started.',
+        }
+      : {
+          icon: '🔍',
+          heading: 'No workflows found',
+          description:
+            'There are no workflows matching your current filters. Try adjusting your search criteria or labels.',
+        };
 
   return (
     <div className="space-y-2">
@@ -1888,25 +1937,11 @@ function DAGTable({
                   className="h-64 text-center"
                 >
                   <div className="flex flex-col items-center justify-center py-8">
-                    <div className="text-6xl mb-4">🔍</div>
-                    <h3 className="text-lg font-medium text-foreground mb-2">
-                      No workflows found
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center max-w-md mb-4 whitespace-normal break-words">
-                      {emptyStateDescription}
-                    </p>
-                    <div className="flex flex-wrap items-center justify-center gap-2">
-                      {!isAllWorkflowsView && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={onShowAllWorkflows}
-                        >
-                          Show all workflows
-                        </Button>
-                      )}
-                      <CreateDAGModal />
-                    </div>
+                    <WorkflowsEmptyState
+                      {...emptyState}
+                      showAllButton={!isAllWorkflowsView}
+                      onShowAllWorkflows={onShowAllWorkflows}
+                    />
                   </div>
                 </TableCell>
               </TableRow>
@@ -2021,23 +2056,11 @@ function DAGTable({
           })
         ) : (
           <div className="flex flex-col items-center justify-center py-12 px-4 border rounded-md bg-card">
-            <div className="text-6xl mb-4">🔍</div>
-            <h3 className="text-lg font-medium mb-2">No workflows found</h3>
-            <p className="text-sm text-muted-foreground text-center max-w-md mb-4 whitespace-normal break-words">
-              {emptyStateDescription}
-            </p>
-            <div className="flex flex-wrap items-center justify-center gap-2">
-              {!isAllWorkflowsView && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onShowAllWorkflows}
-                >
-                  Show all workflows
-                </Button>
-              )}
-              <CreateDAGModal />
-            </div>
+            <WorkflowsEmptyState
+              {...emptyState}
+              showAllButton={!isAllWorkflowsView}
+              onShowAllWorkflows={onShowAllWorkflows}
+            />
           </div>
         )}
       </div>

--- a/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
+++ b/ui/src/features/dags/components/dag-list/__tests__/DAGTable.test.tsx
@@ -419,6 +419,16 @@ describe('DAGTable', () => {
     });
   });
 
+  it('invites creating the first workflow when none exist and no filters are set', () => {
+    renderTable('', { dags: [] });
+
+    expect(screen.getAllByText('No workflows yet').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Create your first workflow to get started.').length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText('No workflows found')).not.toBeInTheDocument();
+  });
+
   it('explains an empty saved view and offers to show all workflows', () => {
     const { onShowAllWorkflows } = renderTable('', {
       dags: [],

--- a/ui/src/features/dags/components/visualization/DAGGraph.tsx
+++ b/ui/src/features/dags/components/visualization/DAGGraph.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import React from 'react';
 import { useCookies } from 'react-cookie';
-import { components, Status } from '../../../../api/v1/schema';
+import { components } from '../../../../api/v1/schema';
 import { useConfig } from '../../../../contexts/ConfigContext';
 import BorderedBox from '@/components/ui/bordered-box';
 import { FlowchartType, Graph, TimelineChart } from './';
@@ -148,8 +148,6 @@ function DAGGraph({
               onRightClickNode={
                 config.permissions.runDags ? onRightClickStep : undefined
               }
-              showIcons={dagRun.status > Status.NotStarted}
-              animate={dagRun.status == Status.Running}
               height={graphHeight}
             />
           ) : (

--- a/ui/src/features/dags/components/visualization/Graph.tsx
+++ b/ui/src/features/dags/components/visualization/Graph.tsx
@@ -63,10 +63,6 @@ type Props = {
   onDoubleClickNode?: onClickNode;
   /** Callback for node right-click events */
   onRightClickNode?: onRightClickNode;
-  /** Whether to show status icons */
-  showIcons?: boolean;
-  /** Whether to animate running nodes */
-  animate?: boolean;
   /** Whether the graph is currently displayed in an expanded modal view */
   isExpandedView?: boolean;
   /** Custom height for the graph container */
@@ -131,7 +127,6 @@ function Graph({
   selectOnClick = false,
   onDoubleClickNode,
   onRightClickNode,
-  showIcons = true,
   isExpandedView = false,
   height,
 }: Props): React.JSX.Element {
@@ -395,7 +390,7 @@ function Graph({
     });
 
     return dat.join('\n');
-  }, [steps, onClickNode, flowchart, showIcons, isDarkMode]);
+  }, [steps, onClickNode, flowchart, isDarkMode]);
 
   return (
     <div
@@ -538,7 +533,6 @@ function Graph({
                 selectOnClick={selectOnClick}
                 onDoubleClickNode={onDoubleClickNode}
                 onRightClickNode={onRightClickNode}
-                showIcons={showIcons}
                 isExpandedView={true}
               />
             </div>

--- a/ui/src/features/dags/components/visualization/Graph.tsx
+++ b/ui/src/features/dags/components/visualization/Graph.tsx
@@ -390,7 +390,7 @@ function Graph({
     });
 
     return dat.join('\n');
-  }, [steps, onClickNode, flowchart, isDarkMode]);
+  }, [steps, type, onClickNode, flowchart, isDarkMode]);
 
   return (
     <div

--- a/ui/src/features/dags/components/visualization/__tests__/Graph.test.tsx
+++ b/ui/src/features/dags/components/visualization/__tests__/Graph.test.tsx
@@ -57,7 +57,6 @@ describe('Graph', () => {
           node('prepare', NodeStatus.Success),
           node('load', NodeStatus.Success, ['prepare']),
         ]}
-        showIcons={false}
       />
     );
 
@@ -90,7 +89,6 @@ describe('Graph', () => {
       <Graph
         type="status"
         steps={[node('load', NodeStatus.Running)]}
-        showIcons={false}
       />
     );
 
@@ -127,7 +125,6 @@ describe('Graph', () => {
           node('prepare', NodeStatus.Success),
           node('load', NodeStatus.Running),
         ]}
-        showIcons={false}
       />
     );
 
@@ -186,7 +183,6 @@ describe('Graph', () => {
         steps={[node('load', NodeStatus.Running)]}
         flowchart="LR"
         onChangeFlowchart={vi.fn()}
-        showIcons={false}
       />
     );
 

--- a/ui/src/hooks/__tests__/useCopyFeedback.test.tsx
+++ b/ui/src/hooks/__tests__/useCopyFeedback.test.tsx
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCopyFeedback } from '../useCopyFeedback';
+
+const copyTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/clipboard', () => ({
+  copyText: copyTextMock,
+}));
+
+afterEach(() => {
+  copyTextMock.mockReset();
+  vi.useRealTimers();
+});
+
+describe('useCopyFeedback', () => {
+  it('flips copied on and back off after the reset delay', async () => {
+    vi.useFakeTimers();
+    copyTextMock.mockResolvedValue(true);
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy('hello: world');
+    });
+    expect(copyTextMock).toHaveBeenCalledWith('hello: world');
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('stays unset when the clipboard write fails', async () => {
+    copyTextMock.mockResolvedValue(false);
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy('hello');
+    });
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/ui/src/hooks/useCopyFeedback.ts
+++ b/ui/src/hooks/useCopyFeedback.ts
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { copyText } from '@/lib/clipboard';
+
+/**
+ * Copies text to the clipboard and exposes a transient `copied` flag for
+ * button feedback. The flag resets after `resetMs` milliseconds.
+ */
+export function useCopyFeedback(resetMs = 2000): {
+  copied: boolean;
+  copy: (text: string) => Promise<void>;
+} {
+  const [copied, setCopied] = useState(false);
+  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (!text) return;
+      if (!(await copyText(text))) return;
+      setCopied(true);
+      if (resetRef.current) {
+        clearTimeout(resetRef.current);
+      }
+      resetRef.current = setTimeout(() => setCopied(false), resetMs);
+    },
+    [resetMs]
+  );
+
+  useEffect(
+    () => () => {
+      if (resetRef.current) {
+        clearTimeout(resetRef.current);
+      }
+    },
+    []
+  );
+
+  return { copied, copy };
+}

--- a/ui/src/pages/base-config/index.tsx
+++ b/ui/src/pages/base-config/index.tsx
@@ -173,7 +173,12 @@ function BaseConfigPage(): React.ReactNode {
     }
 
     if (responseData?.errors && responseData.errors.length > 0) {
-      showError('Validation errors', responseData.errors.join('\n'));
+      showError(
+        'The config was not saved',
+        undefined,
+        'Validation errors',
+        responseData.errors
+      );
       return;
     }
 

--- a/ui/src/pages/dag-runs/__tests__/index.test.tsx
+++ b/ui/src/pages/dag-runs/__tests__/index.test.tsx
@@ -40,15 +40,10 @@ vi.mock('@/hooks/api', () => ({
   }),
 }));
 
+const usePaginatedDAGRunsMock = vi.hoisted(() => vi.fn());
+
 vi.mock('@/features/dag-runs/hooks/dagRunPagination', () => ({
-  usePaginatedDAGRuns: () => ({
-    dagRuns: [],
-    isLoadingMore: false,
-    loadMoreError: null,
-    hasMore: false,
-    refresh: vi.fn(),
-    loadMore: vi.fn(),
-  }),
+  usePaginatedDAGRuns: usePaginatedDAGRunsMock,
 }));
 
 vi.mock('@/features/dag-runs/hooks/useBulkDAGRunSelection', () => ({
@@ -94,14 +89,17 @@ vi.mock(
   })
 );
 
+const dagRunTableProps = vi.hoisted(() => ({ current: {} as { isLoading?: boolean } }));
+
 vi.mock('@/features/dag-runs/components/dag-run-list/DAGRunTable', () => ({
-  default: ({
-    onSelectDAGRun,
-    onViewArtifacts,
-  }: {
+  default: (props: {
+    isLoading?: boolean;
     onSelectDAGRun: (run: { name: string; dagRunId: string }) => void;
     onViewArtifacts: (run: { name: string; dagRunId: string }) => void;
-  }) => (
+  }) => {
+    dagRunTableProps.current = props;
+    const { onSelectDAGRun, onViewArtifacts } = props;
+    return (
     <div>
       <div>Run Table</div>
       <button
@@ -117,7 +115,8 @@ vi.mock('@/features/dag-runs/components/dag-run-list/DAGRunTable', () => ({
         Open artifacts
       </button>
     </div>
-  ),
+    );
+  },
 }));
 
 const config = {
@@ -128,6 +127,16 @@ beforeEach(() => {
   readSearchStateMock.mockReset();
   readSearchStateMock.mockReturnValue(null);
   writeSearchStateMock.mockReset();
+  usePaginatedDAGRunsMock.mockReset();
+  usePaginatedDAGRunsMock.mockReturnValue({
+    dagRuns: [],
+    isInitialLoading: false,
+    isLoadingMore: false,
+    loadMoreError: null,
+    hasMore: false,
+    refresh: vi.fn(),
+    loadMore: vi.fn(),
+  });
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -184,6 +193,22 @@ describe('DAGRuns page', () => {
     ).toBeVisible();
     expect(screen.queryByRole('heading', { name: /dag runs/i })).toBeNull();
     expect(setTitle).toHaveBeenCalledWith('Executions');
+  });
+
+  it('passes the initial-load state to the runs table', () => {
+    usePaginatedDAGRunsMock.mockReturnValue({
+      dagRuns: [],
+      isInitialLoading: true,
+      isLoadingMore: false,
+      loadMoreError: null,
+      hasMore: false,
+      refresh: vi.fn(),
+      loadMore: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(dagRunTableProps.current.isLoading).toBe(true);
   });
 
   it('uses consistent filter control sizing', () => {

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -557,6 +557,7 @@ function DAGRuns() {
   );
   const {
     dagRuns,
+    isInitialLoading,
     isLoadingMore,
     loadMoreError,
     hasMore,
@@ -1047,6 +1048,7 @@ function DAGRuns() {
         {viewMode === 'list' ? (
           <DAGRunTable
             dagRuns={dagRuns}
+            isLoading={isInitialLoading}
             selectedDAGRun={selectedDAGRun}
             onSelectDAGRun={selectDAGRun}
             onViewArtifacts={viewDAGRunArtifacts}
@@ -1056,6 +1058,7 @@ function DAGRuns() {
         ) : (
           <DAGRunGroupedView
             dagRuns={dagRuns}
+            isLoading={isInitialLoading}
             selectedDAGRun={selectedDAGRun}
             onSelectDAGRun={selectDAGRun}
             onViewArtifacts={viewDAGRunArtifacts}

--- a/ui/src/pages/docs/components/DocEditor.tsx
+++ b/ui/src/pages/docs/components/DocEditor.tsx
@@ -16,7 +16,7 @@ import {
   workspaceDocumentSelectionQuery,
 } from '@/lib/workspace';
 import { cn } from '@/lib/utils';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { AppBarContext } from '@/contexts/AppBarContext';
 import {
   Check,
@@ -272,49 +272,10 @@ function DocEditor({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const [copiedName, setCopiedName] = useState<string | null>(null);
-  const [copiedContent, setCopiedContent] = useState(false);
-  const copiedNameResetRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const copiedContentResetRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const { copied: nameCopied, copy: copyName } = useCopyFeedback();
+  const { copied: copiedContent, copy: copyContent } = useCopyFeedback();
 
   const title = doc?.title || docPath.split('/').pop() || docPath;
-  const nameCopied = copiedName !== null && copiedName === title;
-
-  const copyName = useCallback(async () => {
-    if (!title) return;
-    if (!(await copyText(title))) return;
-    setCopiedName(title);
-    if (copiedNameResetRef.current) {
-      clearTimeout(copiedNameResetRef.current);
-    }
-    copiedNameResetRef.current = setTimeout(() => setCopiedName(null), 2000);
-  }, [title]);
-
-  const copyContent = useCallback(async () => {
-    const text = currentValue ?? '';
-    if (!text) return;
-    if (!(await copyText(text))) return;
-    setCopiedContent(true);
-    if (copiedContentResetRef.current) {
-      clearTimeout(copiedContentResetRef.current);
-    }
-    copiedContentResetRef.current = setTimeout(
-      () => setCopiedContent(false),
-      2000
-    );
-  }, [currentValue]);
-
-  useEffect(
-    () => () => {
-      if (copiedNameResetRef.current) {
-        clearTimeout(copiedNameResetRef.current);
-      }
-      if (copiedContentResetRef.current) {
-        clearTimeout(copiedContentResetRef.current);
-      }
-    },
-    []
-  );
 
   return (
     <div className="flex flex-col h-full">
@@ -329,7 +290,7 @@ function DocEditor({
         {title && (
           <button
             type="button"
-            onClick={copyName}
+            onClick={() => copyName(title)}
             className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all shrink-0"
             title={nameCopied ? 'Name copied' : `Copy name: ${title}`}
             aria-label={nameCopied ? 'Name copied' : 'Copy name'}
@@ -350,7 +311,7 @@ function DocEditor({
         {/* Copy content */}
         <button
           type="button"
-          onClick={copyContent}
+          onClick={() => copyContent(currentValue ?? '')}
           disabled={!currentValue}
           className="flex items-center gap-1 px-2 py-0.5 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-all"
           title="Copy content"

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -433,6 +433,18 @@
   }
 }
 
+/* Pulse running graph nodes. The graph styler force-sets stroke properties
+   inline with !important, so only opacity is safe to animate here. */
+@media (prefers-reduced-motion: no-preference) {
+  .mermaid g.node.running rect,
+  .mermaid g.node.running polygon,
+  .mermaid g.node.running path,
+  .mermaid g.node.running circle,
+  .mermaid g.node.running ellipse {
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+}
+
 /* Toast Shadow Utility */
 .shadow-toast {
   box-shadow: var(--shadow-lg);


### PR DESCRIPTION
## Summary

Eleven small, self-contained fixes from a UX audit of the web UI, each targeting a moment that shapes a newcomer's first impression:

- Running graph nodes now pulse (the \`animate\` prop was dead code); dead \`showIcons\`/\`animate\` props removed
- The DAG editor no longer auto-formats on mount and on every newline, which marked untouched files as modified (23% of doc-style YAML was rewritten on open) and armed the external-change conflict dialog
- Backend validation errors render monospace with line breaks preserved instead of collapsing into a muted 450px paragraph; empty error arrays no longer count as failures
- Per-step retry is labeled honestly ("Retry this step"; the API retries only that step) and confirms success with a toast and refresh
- The primary DAG action is labeled "Start", matching its tooltip, the modal, and \`dagu start\`
- The executions list no longer flashes "No DAG runs found" while the first page loads
- Empty states stop blaming filters the user never set; a pristine install now invites creating the first workflow
- The DAG JSON schema carries \`examples\` for high-traffic properties, lighting up the docs sidebar Examples panel, hover cards, and completion snippets at once
- The browser tab title reflects the current page instead of the static "Dagu"
- Copy-YAML button on the spec editor (read-only viewers included) and Copy-link button on the run header; the three hand-rolled copy-feedback blocks consolidate into \`useCopyFeedback\`
- Rejected v1 \`executor:\` keys now hint the \`action\`/\`with\` replacement, and renamed keys (\`precondition\`, \`dir\`) get accurate hints instead of being mislabeled as snake_case fixes

## Validation

- \`cd ui && pnpm test\` (624 tests), \`pnpm exec tsc --noEmit\`, \`pnpm build\`
- \`go test ./internal/core/spec/...\`, \`golangci-lint run internal/core/spec/...\`
- \`ui/e2e/helpers/e2e.ts\` updated for the Start rename (exercised by \`distributed-stack.spec.ts\` in CI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves first‑time UX across the web UI with small, focused changes. Adds clearer actions, better errors, helpful examples, and easier sharing.

- **New Features**
  - Running nodes pulse in graphs; removed dead `showIcons`/`animate` props.
  - Copy buttons: YAML in the spec editor and run link in run headers, with unified `useCopyFeedback`.
  - Browser tab title reflects the current page title.
  - DAG JSON schema now includes `examples` for common fields to power docs, hover cards, and editor completion.

- **Bug Fixes**
  - Editor and errors: no auto‑format on open or Enter; empty validation error arrays don’t block saves; error modal renders details in monospace with preserved line breaks.
  - Action clarity: primary DAG action is “Start”; per‑step retry is “Retry this step” and shows a success toast and refreshes.
  - Lists and empty states: executions no longer flash “No DAG runs” during initial load (shows a loading row); workflow empty states no longer blame filters and invite creating the first workflow; runs copy is date‑range aware.
  - Spec hints: legacy key guidance now suggests replacements (e.g., `executor` -> `action` + `with`, `precondition` -> `preconditions`, `dir` -> `working_dir`).
  - Graphs: include graph type in memo deps to prevent stale definitions when switching modes.

<sup>Written for commit e9525df374b5b01d661badf8064335717373981c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy actions for DAG names, YAML specifications, documentation, and DAG run links with visual confirmation.
  * Added clearer workflow and DAG-run empty states, including loading indicators and relevant actions.
  * Added running-node pulse animations that respect reduced-motion preferences.
  * Improved error dialogs with structured validation details and readable formatting.
  * Browser titles now reflect the current page and configured application name.

* **Improvements**
  * Renamed the primary workflow action from “Enqueue” to “Start.”
  * Retry actions now show success notifications and refresh workflow details.
  * Configuration validation errors provide clearer guidance for renamed or removed settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->