### PR TITLE
feat(ui): give the dashboard a first-run landing

### DIFF
--- a/ui/src/pages/__tests__/index.test.tsx
+++ b/ui/src/pages/__tests__/index.test.tsx
@@ -298,6 +298,17 @@ describe('DashboardPage', () => {
     expect(screen.queryByText(/No runs on /)).not.toBeInTheDocument();
   });
 
+  it('does not show first-run guidance when the DAG inventory request fails', async () => {
+    clientGetMock.mockResolvedValue({});
+
+    renderPage();
+
+    expect(await screen.findByText(/No runs on /)).toBeVisible();
+    expect(
+      screen.queryByText('Create your first workflow')
+    ).not.toBeInTheDocument();
+  });
+
   it('shows placeholders instead of zeros while runs load', async () => {
     mockDAGInventory(['etl'], 1);
     usePaginatedDAGRunsMock.mockReturnValue({

--- a/ui/src/pages/__tests__/index.test.tsx
+++ b/ui/src/pages/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +20,10 @@ vi.mock('../../features/dashboard/components/DashboardTimechart', () => ({
 
 vi.mock('../../features/dag-runs/components/dag-run-details', () => ({
   DAGRunDetailsModal: () => null,
+}));
+
+vi.mock('../../features/dags/components/common', () => ({
+  CreateDAGModal: () => <button type="button">New workflow</button>,
 }));
 
 vi.mock('../../features/dag-runs/hooks/dagRunPagination', () => ({
@@ -135,6 +139,7 @@ describe('DashboardPage', () => {
           dags: [],
           pagination: {
             totalPages: 1,
+            totalRecords: 0,
           },
         },
       }),
@@ -226,5 +231,92 @@ describe('DashboardPage', () => {
         },
       })
     );
+  });
+
+  function mockDAGInventory(names: string[], totalRecords: number) {
+    clientGetMock.mockResolvedValue({
+      data: {
+        dags: names.map((name) => ({ fileName: `${name}.yaml`, dag: { name } })),
+        pagination: {
+          totalPages: 1,
+          totalRecords,
+        },
+      },
+    });
+  }
+
+  it('invites creating the first workflow when no workflows exist', async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText('Create your first workflow')
+    ).toBeVisible();
+    expect(screen.getByText('New workflow')).toBeVisible();
+    expect(screen.queryByTestId('dashboard-timechart')).not.toBeInTheDocument();
+  });
+
+  it('points at the Workflows page when workflows exist but nothing ran', async () => {
+    mockDAGInventory(['etl', 'backup'], 2);
+
+    renderPage();
+
+    expect(await screen.findByText(/No runs on /)).toBeVisible();
+    expect(screen.getByText(/Start a workflow from the/)).toBeVisible();
+    expect(screen.queryByTestId('dashboard-timechart')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Create your first workflow')
+    ).not.toBeInTheDocument();
+  });
+
+  it('suggests the example workflows when only seeded examples exist', async () => {
+    mockDAGInventory(['example-01-basic-sequential'], 1);
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/Run one of the example workflows/)
+    ).toBeVisible();
+  });
+
+  it('keeps the timechart when runs exist', async () => {
+    mockDAGInventory(['etl'], 1);
+    usePaginatedDAGRunsMock.mockReturnValue({
+      dagRuns: [{ name: 'etl', status: Status.Success } as never],
+      headPage: undefined,
+      error: null,
+      isInitialLoading: false,
+      isLoadingMore: false,
+      loadMoreError: null,
+      hasMore: false,
+      refresh: vi.fn(),
+      loadMore: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('dashboard-timechart')).toBeVisible();
+    expect(screen.queryByText(/No runs on /)).not.toBeInTheDocument();
+  });
+
+  it('shows placeholders instead of zeros while runs load', async () => {
+    mockDAGInventory(['etl'], 1);
+    usePaginatedDAGRunsMock.mockReturnValue({
+      dagRuns: [],
+      headPage: undefined,
+      error: null,
+      isInitialLoading: true,
+      isLoadingMore: false,
+      loadMoreError: null,
+      hasMore: false,
+      refresh: vi.fn(),
+      loadMore: vi.fn(),
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(4);
+    });
+    expect(screen.queryByText(/No runs on /)).not.toBeInTheDocument();
   });
 });

--- a/ui/src/pages/__tests__/index.test.tsx
+++ b/ui/src/pages/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -298,15 +298,27 @@ describe('DashboardPage', () => {
     expect(screen.queryByText(/No runs on /)).not.toBeInTheDocument();
   });
 
-  it('does not show first-run guidance when the DAG inventory request fails', async () => {
+  it('offers a retry instead of first-run guidance when the inventory request fails', async () => {
     clientGetMock.mockResolvedValue({});
 
     renderPage();
 
-    expect(await screen.findByText(/No runs on /)).toBeVisible();
+    expect(
+      await screen.findByText('Failed to load the workflow list.')
+    ).toBeVisible();
     expect(
       screen.queryByText('Create your first workflow')
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No runs on /)).not.toBeInTheDocument();
+
+    const callsBeforeRetry = clientGetMock.mock.calls.length;
+    mockDAGInventory(['etl'], 1);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(clientGetMock.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
+    });
+    expect(await screen.findByText(/No runs on /)).toBeVisible();
   });
 
   it('shows placeholders instead of zeros while runs load', async () => {

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -233,6 +233,7 @@ function Dashboard(): React.ReactElement | null {
     names: [],
     totalCount: 0,
   });
+  const [inventoryRetryNonce, setInventoryRetryNonce] = React.useState(0);
   const lastWindowScrollYRef = React.useRef(0);
 
   type DashboardFilters = {
@@ -438,7 +439,7 @@ function Dashboard(): React.ReactElement | null {
       });
 
     return () => controller.abort();
-  }, [client, remoteNode, workspaceQuery]);
+  }, [client, remoteNode, workspaceQuery, inventoryRetryNonce]);
 
   React.useEffect(() => {
     lastWindowScrollYRef.current = window.scrollY;
@@ -518,8 +519,15 @@ function Dashboard(): React.ReactElement | null {
 
   const showGettingStarted =
     dagInventory.status === 'loaded' && dagInventory.totalCount === 0;
+  // With the inventory pending or failed, "no runs" cannot be distinguished
+  // from "request failed", so first-run guidance stays off.
   const showNoRunsNotice =
-    !showGettingStarted && !isLoading && totalDAGRuns === 0;
+    dagInventory.status === 'loaded' &&
+    !showGettingStarted &&
+    !isLoading &&
+    totalDAGRuns === 0;
+  const showInventoryError =
+    dagInventory.status === 'error' && !isLoading && totalDAGRuns === 0;
   const hasExampleDAGs = dagInventory.names.some((name) =>
     name.startsWith('example-')
   );
@@ -656,6 +664,18 @@ function Dashboard(): React.ReactElement | null {
                     .format('MMM D, YYYY')}
                   hasExampleDAGs={hasExampleDAGs}
                 />
+              ) : showInventoryError ? (
+                <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+                  <p className="text-sm font-medium text-foreground">
+                    Failed to load the workflow list.
+                  </p>
+                  <Button
+                    variant="outline"
+                    onClick={() => setInventoryRetryNonce((n) => n + 1)}
+                  >
+                    Retry
+                  </Button>
+                </div>
               ) : (
                 <DashboardTimeChart
                   data={dagRunsList}

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -13,12 +13,14 @@ import {
 } from '@/components/ui/select';
 import { Filter } from 'lucide-react';
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
   PathsDagsGetParametersQueryOrder,
   PathsDagsGetParametersQuerySort,
   Status,
 } from '../api/v1/schema';
 import { AppBarContext } from '../contexts/AppBarContext';
+import { CreateDAGModal } from '../features/dags/components/common';
 import { useConfig } from '../contexts/ConfigContext';
 import { useSearchState } from '../contexts/SearchStateContext';
 import { DAGRunDetailsModal } from '../features/dag-runs/components/dag-run-details';
@@ -80,8 +82,9 @@ async function fetchAllDashboardDAGNames(
   remoteNode: string,
   workspaceQuery: ReturnType<typeof workspaceSelectionQuery>,
   signal: AbortSignal
-): Promise<string[]> {
+): Promise<{ names: string[]; totalCount: number }> {
   const names = new Set<string>();
+  let totalCount: number | undefined;
   let page = 1;
 
   for (;;) {
@@ -110,6 +113,7 @@ async function fetchAllDashboardDAGNames(
     }
 
     const data = response.data;
+    totalCount ??= data?.pagination?.totalRecords;
     for (const dag of data?.dags ?? []) {
       if (dag.dag.name) {
         names.add(dag.dag.name);
@@ -123,7 +127,72 @@ async function fetchAllDashboardDAGNames(
     page += 1;
   }
 
-  return Array.from(names).sort(compareDAGNames);
+  const sortedNames = Array.from(names).sort(compareDAGNames);
+  return { names: sortedNames, totalCount: totalCount ?? sortedNames.length };
+}
+
+type DAGInventory = {
+  status: 'loading' | 'loaded' | 'error';
+  names: string[];
+  totalCount: number;
+};
+
+function GettingStartedPanel(): React.ReactElement {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-border bg-surface p-8 text-center">
+      <h2 className="text-xl font-semibold text-foreground">
+        Create your first workflow
+      </h2>
+      <p className="max-w-md text-sm text-muted-foreground">
+        Dagu runs workflows defined in YAML. Create one from scratch or start
+        from the documentation examples.
+      </p>
+      <CreateDAGModal />
+      <div className="flex flex-wrap items-center justify-center gap-4 text-sm">
+        <a
+          href="https://docs.dagu.sh"
+          target="_blank"
+          rel="noreferrer"
+          className="text-primary hover:underline"
+        >
+          Documentation
+        </a>
+        <a
+          href="https://docs.dagu.sh/writing-workflows/examples"
+          target="_blank"
+          rel="noreferrer"
+          className="text-primary hover:underline"
+        >
+          Example workflows
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function NoRunsNotice({
+  dateLabel,
+  hasExampleDAGs,
+}: {
+  dateLabel: string;
+  hasExampleDAGs: boolean;
+}): React.ReactElement {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <p className="text-sm font-medium text-foreground">
+        No runs on {dateLabel}.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        {hasExampleDAGs
+          ? 'Run one of the example workflows from the '
+          : 'Start a workflow from the '}
+        <Link to="/dags" className="text-primary hover:underline">
+          Workflows page
+        </Link>{' '}
+        to see activity here.
+      </p>
+    </div>
+  );
 }
 
 function Dashboard(): React.ReactElement | null {
@@ -153,9 +222,11 @@ function Dashboard(): React.ReactElement | null {
   } | null>(null);
   const autoLoadSentinelRef = React.useRef<HTMLDivElement>(null);
   const [autoLoadRequested, setAutoLoadRequested] = React.useState(false);
-  const [availableDAGNames, setAvailableDAGNames] = React.useState<string[]>(
-    []
-  );
+  const [dagInventory, setDAGInventory] = React.useState<DAGInventory>({
+    status: 'loading',
+    names: [],
+    totalCount: 0,
+  });
   const lastWindowScrollYRef = React.useRef(0);
 
   type DashboardFilters = {
@@ -307,7 +378,7 @@ function Dashboard(): React.ReactElement | null {
   };
 
   const uniqueDAGRunNames = React.useMemo(() => {
-    const names = new Set(availableDAGNames);
+    const names = new Set(dagInventory.names);
 
     for (const dagRun of dagRunsList) {
       if (dagRun.name) {
@@ -319,7 +390,7 @@ function Dashboard(): React.ReactElement | null {
     }
 
     return Array.from(names).sort(compareDAGNames);
-  }, [availableDAGNames, dagRunsList, selectedDAGRun]);
+  }, [dagInventory.names, dagRunsList, selectedDAGRun]);
 
   const handleDAGRunChange = (value: string) => {
     setSelectedDAGRun(value);
@@ -341,7 +412,7 @@ function Dashboard(): React.ReactElement | null {
 
   React.useEffect(() => {
     const controller = new AbortController();
-    setAvailableDAGNames([]);
+    setDAGInventory({ status: 'loading', names: [], totalCount: 0 });
 
     void fetchAllDashboardDAGNames(
       client,
@@ -349,14 +420,14 @@ function Dashboard(): React.ReactElement | null {
       workspaceQuery,
       controller.signal
     )
-      .then((names) => {
+      .then(({ names, totalCount }) => {
         if (!controller.signal.aborted) {
-          setAvailableDAGNames(names);
+          setDAGInventory({ status: 'loaded', names, totalCount });
         }
       })
       .catch(() => {
         if (!controller.signal.aborted) {
-          setAvailableDAGNames([]);
+          setDAGInventory({ status: 'error', names: [], totalCount: 0 });
         }
       });
 
@@ -439,6 +510,16 @@ function Dashboard(): React.ReactElement | null {
   const hasFailures = metrics[Status.Failed] > 0;
   const hasRunning = metrics[Status.Running] > 0;
 
+  const showGettingStarted =
+    dagInventory.status === 'loaded' && dagInventory.totalCount === 0;
+  const showNoRunsNotice =
+    !showGettingStarted && !isLoading && totalDAGRuns === 0;
+  const hasExampleDAGs = dagInventory.names.some((name) =>
+    name.startsWith('example-')
+  );
+  // Show placeholders instead of zeros while the first page is loading.
+  const stat = (value: number) => (isLoading ? '-' : value);
+
   return (
     <div className="flex flex-col max-w-7xl h-full overflow-hidden">
       {/* Main Content Area */}
@@ -501,79 +582,97 @@ function Dashboard(): React.ReactElement | null {
           <RefreshButton onRefresh={handleRefreshAll} />
         </div>
 
-        {/* Stats Row */}
-        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 sm:gap-x-6 text-sm text-muted-foreground flex-shrink-0">
-          <div className="flex items-baseline gap-1">
-            <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-              {totalDAGRuns}
-              {hasMore ? '+' : ''}
-            </span>
-            <span className="text-xs">recent runs</span>
-          </div>
-          <div className="flex items-baseline gap-1">
-            <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-              {metrics[Status.Success]}
-            </span>
-            <span className="text-xs">ok</span>
-          </div>
-          <div className="flex items-baseline gap-1">
-            <span
-              className={`text-lg sm:text-xl font-light tabular-nums ${hasFailures ? 'text-foreground' : 'text-muted-foreground/50'}`}
-            >
-              {metrics[Status.Failed]}
-            </span>
-            <span className="text-xs">failed</span>
-          </div>
-          <div className="flex items-baseline gap-1">
-            <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-              {metrics[Status.Aborted]}
-            </span>
-            <span className="text-xs">aborted</span>
-          </div>
-          {hasRunning && (
-            <div className="flex items-baseline gap-1">
-              <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-                {metrics[Status.Running]}
-              </span>
-              <span className="text-xs">active</span>
+        {showGettingStarted ? (
+          <GettingStartedPanel />
+        ) : (
+          <>
+            {/* Stats Row */}
+            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 sm:gap-x-6 text-sm text-muted-foreground flex-shrink-0">
+              <div className="flex items-baseline gap-1">
+                <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                  {stat(totalDAGRuns)}
+                  {hasMore ? '+' : ''}
+                </span>
+                <span className="text-xs">recent runs</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                  {stat(metrics[Status.Success])}
+                </span>
+                <span className="text-xs">ok</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span
+                  className={`text-lg sm:text-xl font-light tabular-nums ${hasFailures ? 'text-foreground' : 'text-muted-foreground/50'}`}
+                >
+                  {stat(metrics[Status.Failed])}
+                </span>
+                <span className="text-xs">failed</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                  {stat(metrics[Status.Aborted])}
+                </span>
+                <span className="text-xs">aborted</span>
+              </div>
+              {hasRunning && (
+                <div className="flex items-baseline gap-1">
+                  <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                    {metrics[Status.Running]}
+                  </span>
+                  <span className="text-xs">active</span>
+                </div>
+              )}
+              {metrics[Status.Waiting] > 0 && (
+                <div className="flex items-baseline gap-1">
+                  <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                    {metrics[Status.Waiting]}
+                  </span>
+                  <span className="text-xs">waiting</span>
+                </div>
+              )}
+              {metrics[Status.Rejected] > 0 && (
+                <div className="flex items-baseline gap-1">
+                  <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
+                    {metrics[Status.Rejected]}
+                  </span>
+                  <span className="text-xs">rejected</span>
+                </div>
+              )}
             </div>
-          )}
-          {metrics[Status.Waiting] > 0 && (
-            <div className="flex items-baseline gap-1">
-              <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-                {metrics[Status.Waiting]}
-              </span>
-              <span className="text-xs">waiting</span>
-            </div>
-          )}
-          {metrics[Status.Rejected] > 0 && (
-            <div className="flex items-baseline gap-1">
-              <span className="text-lg sm:text-xl font-light tabular-nums text-foreground">
-                {metrics[Status.Rejected]}
-              </span>
-              <span className="text-xs">rejected</span>
-            </div>
-          )}
-        </div>
 
-        {/* Timeline Visualization - Hero */}
-        <div className="flex-1 min-h-[250px] rounded-xl border border-border bg-surface overflow-hidden">
-          <DashboardTimeChart
-            data={dagRunsList}
-            selectedDate={selectedTimelineDate}
-          />
-        </div>
-        {hasMore && (
-          <div className="flex flex-col items-center justify-center gap-2 flex-shrink-0">
-            <Button
-              variant="outline"
-              onClick={() => void loadMore()}
-              disabled={isLoadingMore}
-            >
-              {isLoadingMore ? 'Loading...' : 'Load older runs'}
-            </Button>
-            <div ref={autoLoadSentinelRef} className="h-1 w-full shrink-0" />
-          </div>
+            {/* Timeline Visualization - Hero */}
+            <div className="flex-1 min-h-[250px] rounded-xl border border-border bg-surface overflow-hidden">
+              {showNoRunsNotice ? (
+                <NoRunsNotice
+                  dateLabel={dayjs
+                    .unix(dateRange.startDate)
+                    .format('MMM D, YYYY')}
+                  hasExampleDAGs={hasExampleDAGs}
+                />
+              ) : (
+                <DashboardTimeChart
+                  data={dagRunsList}
+                  selectedDate={selectedTimelineDate}
+                />
+              )}
+            </div>
+            {hasMore && (
+              <div className="flex flex-col items-center justify-center gap-2 flex-shrink-0">
+                <Button
+                  variant="outline"
+                  onClick={() => void loadMore()}
+                  disabled={isLoadingMore}
+                >
+                  {isLoadingMore ? 'Loading...' : 'Load older runs'}
+                </Button>
+                <div
+                  ref={autoLoadSentinelRef}
+                  className="h-1 w-full shrink-0"
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -113,6 +113,12 @@ async function fetchAllDashboardDAGNames(
     }
 
     const data = response.data;
+    // A failed response with an unparsable body yields neither data nor
+    // error; treating it as "zero DAGs" would show first-run guidance to
+    // users whose requests merely failed.
+    if (!data) {
+      throw new Error('Empty response for DAG definitions');
+    }
     totalCount ??= data?.pagination?.totalRecords;
     for (const dag of data?.dags ?? []) {
       if (dag.dag.name) {

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Filter } from 'lucide-react';
+import { Filter, GanttChart } from 'lucide-react';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -149,7 +149,7 @@ function GettingStartedPanel(): React.ReactElement {
       <h2 className="text-xl font-semibold text-foreground">
         Create your first workflow
       </h2>
-      <p className="max-w-md text-sm text-muted-foreground">
+      <p className="max-w-md text-base text-muted-foreground">
         Dagu runs workflows defined in YAML. Create one from scratch or start
         from the documentation examples.
       </p>
@@ -184,11 +184,12 @@ function NoRunsNotice({
   hasExampleDAGs: boolean;
 }): React.ReactElement {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
-      <p className="text-sm font-medium text-foreground">
-        No runs on {dateLabel}.
-      </p>
-      <p className="text-sm text-muted-foreground">
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+      <GanttChart className="h-12 w-12 text-muted-foreground/40" />
+      <h2 className="text-xl font-semibold text-foreground">
+        No runs on {dateLabel}
+      </h2>
+      <p className="text-base text-muted-foreground">
         {hasExampleDAGs
           ? 'Run one of the example workflows from the '
           : 'Start a workflow from the '}
@@ -665,8 +666,8 @@ function Dashboard(): React.ReactElement | null {
                   hasExampleDAGs={hasExampleDAGs}
                 />
               ) : showInventoryError ? (
-                <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
-                  <p className="text-sm font-medium text-foreground">
+                <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+                  <p className="text-base font-medium text-foreground">
                     Failed to load the workflow list.
                   </p>
                   <Button


### PR DESCRIPTION
## Summary

The default landing page rendered a stats row of literal zeros above an empty timeline for every new install, with no pointer to the seeded example workflows one click away. The dashboard now distinguishes three states:

- **Zero workflows** (loaded inventory, count 0): a getting-started panel replaces stats + chart, with a "New workflow" CTA and links to the documentation and example gallery
- **Workflows but no runs in the selected day**: the chart area explains "No runs on {date}" and points at the Workflows page, phrased around the seeded examples when only \`example-*\` workflows exist
- **Initial load**: stat values render \`-\` placeholders instead of confident zeros

Mechanically, the one-shot \`/dags\` inventory fetch now captures \`pagination.totalRecords\` from the first page (previously discarded) and tracks a \`loading | loaded | error\` state, so an empty name list no longer conflates loading, error, and genuinely-zero.

## Validation

- \`cd ui && pnpm test\` (dashboard suite: 7 tests incl. 5 new cases), \`pnpm exec tsc --noEmit\`, \`pnpm build\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a first-run landing to the dashboard, improve empty-state behavior, and adopt a readable empty-state layout. The “No runs” notice now appears only after the workflow list loads; failed `/dags` inventory shows a retry.

- **New Features**
  - Show a getting-started panel when there are zero workflows, with a "New workflow" CTA and links to docs and examples.
  - Replace the empty chart with a date-aware “No runs on {date}” notice and link to the Workflows page; reference `example-*` when only seeded examples exist.
  - Use an icon and larger heading/body text for empty states; stats show “-” during initial load.

- **Bug Fixes**
  - Treat empty `/dags` inventory responses as failures and show a retry in the chart area instead of first-run guidance.
  - Record `pagination.totalRecords` and an inventory status (`loading | loaded | error`) to disambiguate zero vs loading/error; the “No runs” notice only renders after a loaded inventory.

<sup>Written for commit 7f28b599d3eb8bbdc500431547a169ded9f91e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a getting-started panel for dashboards with no workflows.
  * Added guidance and navigation to workflows when no runs are available.
  * Added loading placeholders for dashboard statistics.
  * Improved workflow filtering using the total workflow count and names.
  * Updated timeline behavior to show helpful messaging instead of an empty chart.

* **Tests**
  * Added coverage for empty, seeded, loading, no-run, and active-run dashboard states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->