### PR TITLE
fix: restore Windows installer and add CI coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ on:
       - "Makefile"
       - "proto/**"
       - "scripts/e2e/**"
+      - "scripts/installer.cmd"
+      - "scripts/installer.ps1"
       - "ui/**"
       - ".github/workflows/ci.yaml"
   pull_request:
@@ -38,6 +40,8 @@ on:
       - "Makefile"
       - "proto/**"
       - "scripts/e2e/**"
+      - "scripts/installer.cmd"
+      - "scripts/installer.ps1"
       - "ui/**"
       - ".github/workflows/ci.yaml"
   workflow_dispatch:
@@ -56,6 +60,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      windows_installer: ${{ steps.filter.outputs.windows_installer }}
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -69,6 +74,7 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "go=true" >> "${GITHUB_OUTPUT}"
             echo "e2e=true" >> "${GITHUB_OUTPUT}"
+            echo "windows_installer=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -82,6 +88,7 @@ jobs:
           if [[ -z "${base_sha}" || "${base_sha}" == "0000000000000000000000000000000000000000" ]]; then
             echo "go=true" >> "${GITHUB_OUTPUT}"
             echo "e2e=true" >> "${GITHUB_OUTPUT}"
+            echo "windows_installer=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -89,6 +96,7 @@ jobs:
             echo "Base commit ${base_sha} is not available locally; running CI conservatively."
             echo "go=true" >> "${GITHUB_OUTPUT}"
             echo "e2e=true" >> "${GITHUB_OUTPUT}"
+            echo "windows_installer=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -97,6 +105,7 @@ jobs:
 
           go_changed=false
           e2e_changed=false
+          windows_installer_changed=false
           while IFS= read -r file; do
             case "${file}" in
               *.go|go.mod|go.sum|Makefile|.github/workflows/ci.yaml)
@@ -109,10 +118,17 @@ jobs:
                 e2e_changed=true
                 ;;
             esac
+
+            case "${file}" in
+              scripts/installer.cmd|scripts/installer.ps1|.github/workflows/ci.yaml)
+                windows_installer_changed=true
+                ;;
+            esac
           done <<< "${changed_files}"
 
           echo "go=${go_changed}" >> "${GITHUB_OUTPUT}"
           echo "e2e=${e2e_changed}" >> "${GITHUB_OUTPUT}"
+          echo "windows_installer=${windows_installer_changed}" >> "${GITHUB_OUTPUT}"
 
   # Lint Go code
   golint:
@@ -327,6 +343,45 @@ jobs:
         run: |
           make test-e2e-build
           make test-e2e-run
+
+  test-windows-installer:
+    name: Test Windows installer
+    needs: changes
+    if: needs.changes.outputs.windows_installer == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Test PowerShell installer
+        shell: powershell
+        run: |
+          $source = [IO.File]::ReadAllText(
+            (Resolve-Path "scripts/installer.ps1").Path,
+            [Text.Encoding]::UTF8
+          )
+
+          & ([scriptblock]::Create($source)) `
+            -NoPrompt -DryRun -Service no -OpenBrowser no `
+            -InstallDir "$env:RUNNER_TEMP\dagu-user-install"
+
+          & ([scriptblock]::Create($source)) `
+            -NoPrompt -DryRun -Service yes -OpenBrowser no `
+            -InstallDir "$env:RUNNER_TEMP\dagu-service-install"
+
+          & ([scriptblock]::Create($source)) `
+            -NoPrompt -DryRun -Uninstall `
+            -InstallDir "$env:RUNNER_TEMP\dagu-uninstall"
+
+      - name: Test CMD installer
+        shell: cmd
+        env:
+          _DAGU_INSTALLER_PS1_PATH: ${{ github.workspace }}\scripts\installer.ps1
+        run: >-
+          scripts\installer.cmd
+          -NoPrompt -DryRun -Service no -OpenBrowser no
+          -InstallDir "%RUNNER_TEMP%\dagu-cmd-install"
 
   test-windows:
     name: Test on windows-latest (${{ matrix.suite_index }}/${{ matrix.suite_total }})

--- a/scripts/installer.cmd
+++ b/scripts/installer.cmd
@@ -23,6 +23,13 @@ if defined _DAGU_INSTALLER_PS1_PATH (
   )
 )
 
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$content=[IO.File]::ReadAllText('%TEMP_PS1%', [Text.Encoding]::UTF8); [IO.File]::WriteAllText('%TEMP_PS1%', $content, [Text.Encoding]::UTF8);"
+if errorlevel 1 (
+  echo Failed to prepare the PowerShell installer. >&2
+  exit /b 1
+)
+
 powershell -NoProfile -ExecutionPolicy Bypass -File "%TEMP_PS1%" %*
 set "EXIT_CODE=%ERRORLEVEL%"
 

--- a/scripts/installer.cmd
+++ b/scripts/installer.cmd
@@ -7,11 +7,20 @@ REM SPDX-License-Identifier: GPL-3.0-or-later
 set "PS1_URL=https://raw.githubusercontent.com/dagucloud/dagu/main/scripts/installer.ps1"
 set "TEMP_PS1=%TEMP%\dagu-installer-%RANDOM%.ps1"
 
-powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-  "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri '%PS1_URL%' -OutFile '%TEMP_PS1%';"
-if errorlevel 1 (
-  echo Failed to download the PowerShell installer. >&2
-  exit /b 1
+REM Internal source override for deterministic tests.
+if defined _DAGU_INSTALLER_PS1_PATH (
+  copy /y "%_DAGU_INSTALLER_PS1_PATH%" "%TEMP_PS1%" >nul
+  if errorlevel 1 (
+    echo Failed to stage the PowerShell installer. >&2
+    exit /b 1
+  )
+) else (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri '%PS1_URL%' -OutFile '%TEMP_PS1%';"
+  if errorlevel 1 (
+    echo Failed to download the PowerShell installer. >&2
+    exit /b 1
+  )
 )
 
 powershell -NoProfile -ExecutionPolicy Bypass -File "%TEMP_PS1%" %*

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -334,17 +334,17 @@ function Resolve-Defaults {
 }
 
 function Detect-SkillTargets {
-    $home = [Environment]::GetFolderPath("UserProfile")
+    $userHome = [Environment]::GetFolderPath("UserProfile")
     $count = 0
-    $agentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $home ".agents" }
-    $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $home ".codex" }
-    if (Test-Path (Join-Path $home ".claude\.claude.json")) { $count++ }
+    $agentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $userHome ".agents" }
+    $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $userHome ".codex" }
+    if (Test-Path (Join-Path $userHome ".claude\.claude.json")) { $count++ }
     if (Test-Path $agentsHome) { $count++ }
     elseif (Test-Path $codexHome) { $count++ }
-    if (Test-Path (Join-Path $home ".config\opencode")) { $count++ }
-    if (Test-Path (Join-Path $home ".gemini\GEMINI.md")) { $count++ }
-    $xdg = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $home }
-    if ((Test-Path (Join-Path $xdg ".copilot\config.json")) -or (Test-Path (Join-Path $home ".copilot\config.json"))) { $count++ }
+    if (Test-Path (Join-Path $userHome ".config\opencode")) { $count++ }
+    if (Test-Path (Join-Path $userHome ".gemini\GEMINI.md")) { $count++ }
+    $xdg = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $userHome }
+    if ((Test-Path (Join-Path $xdg ".copilot\config.json")) -or (Test-Path (Join-Path $userHome ".copilot\config.json"))) { $count++ }
     $Script:DetectedSkillTargets = $count
 }
 
@@ -377,17 +377,17 @@ function Get-XmlEnvValue {
 }
 
 function Discover-SkillRemovals {
-    $home = [Environment]::GetFolderPath("UserProfile")
-    $agentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $home ".agents" }
-    $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $home ".codex" }
-    $xdg = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $home }
-    $claudeSkill = Join-Path $home ".claude\skills\dagu"
+    $userHome = [Environment]::GetFolderPath("UserProfile")
+    $agentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $userHome ".agents" }
+    $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $userHome ".codex" }
+    $xdg = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { $userHome }
+    $claudeSkill = Join-Path $userHome ".claude\skills\dagu"
     $agentsSkill = Join-Path $agentsHome "skills\dagu"
     $codexSkill = Join-Path $codexHome "skills\dagu"
-    $openCodeSkill = Join-Path $home ".config\opencode\skills\dagu"
-    $geminiSkill = Join-Path $home ".gemini\skills\dagu"
+    $openCodeSkill = Join-Path $userHome ".config\opencode\skills\dagu"
+    $geminiSkill = Join-Path $userHome ".gemini\skills\dagu"
     $xdgCopilot = Join-Path $xdg ".copilot\copilot-instructions.md"
-    $homeCopilot = Join-Path $home ".copilot\copilot-instructions.md"
+    $homeCopilot = Join-Path $userHome ".copilot\copilot-instructions.md"
     foreach ($dir in @($claudeSkill, $agentsSkill, $codexSkill, $openCodeSkill, $geminiSkill)) {
         if (Test-Path $dir) {
             Add-UniqueItem ([ref]$Script:UninstallSkillDirs) $dir

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -501,7 +501,7 @@ function Show-UninstallPlan {
     Write-Host ("Binary paths".PadRight(20) + $(if ($Script:UninstallInstallPaths.Count -gt 0) { Join-Values $Script:UninstallInstallPaths } else { "none" }))
     Write-Host ("Background service".PadRight(20) + $(if ($Script:UninstallServicePresent) { $Script:ServiceName } else { "none" }))
     $dataAction = if ($PurgeData) { "remove" } else { "keep" }
-    Write-Host ("Data directory".PadRight(20) + "$dataAction: $(if ($Script:UninstallDaguHomes.Count -gt 0) { Join-Values $Script:UninstallDaguHomes } else { 'none detected' })")
+    Write-Host ("Data directory".PadRight(20) + "${dataAction}: $(if ($Script:UninstallDaguHomes.Count -gt 0) { Join-Values $Script:UninstallDaguHomes } else { 'none detected' })")
     Write-Host ("PATH cleanup".PadRight(20) + $(if ($Script:UninstallPathScopes.Count -gt 0) { Join-Values $Script:UninstallPathScopes } else { "none detected" }))
     if ($RemoveSkill) {
         $skillTargets = @($Script:UninstallSkillDirs + $Script:UninstallCopilotFiles)


### PR DESCRIPTION
## Summary

- fix the invalid PowerShell interpolation that prevents the Windows installer from parsing
- avoid the Windows PowerShell `$HOME` automatic-variable collision in skill discovery
- normalize the CMD-staged script to UTF-8 with a BOM before Windows PowerShell 5.1 file execution
- add deterministic Windows PowerShell dry runs for user, service, and uninstall paths
- exercise the CMD launcher against the checked-out PowerShell script without network access or machine changes

## Root cause

The initial failure came from PowerShell interpreting `$dataAction:` as a drive-qualified variable reference. The new Windows smoke job then exposed two additional production issues: PowerShell variable names are case-insensitive, so assigning `$home` attempts to overwrite read-only `$HOME`; and CMD handed Windows PowerShell 5.1 a BOM-less UTF-8 file whose status symbols could be decoded as smart quotes and corrupt parsing.

## Testing

- `git diff --check`
- parsed `.github/workflows/ci.yaml` as YAML
- validated the embedded change-detector script with `bash -n`
- Windows installer CI passes PowerShell user, service, and uninstall dry runs plus the CMD launcher path
- Go lint and all Ubuntu and Windows test shards pass

Closes #2530