### PR TITLE
fix: disable HTTP access logs by default

### DIFF
--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -154,7 +154,7 @@ type Server struct {
 	APIBasePath       string
 	Headless          bool
 	CheckUpdates      bool
-	AccessLog         AccessLogMode // "all" (default), "non-public", or "none"
+	AccessLog         AccessLogMode // "all", "non-public", or "none" (default)
 	LatestStatusToday bool
 	TLS               *TLSConfig
 	Auth              Auth

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -22,7 +22,7 @@ type Definition struct {
 	Debug                  bool     `mapstructure:"debug"`
 	DefaultShell           string   `mapstructure:"default_shell"`
 	LogFormat              string   `mapstructure:"log_format"`      // "json" or "text"
-	AccessLog              *string  `mapstructure:"access_log_mode"` // "all" (default), "non-public", or "none"
+	AccessLog              *string  `mapstructure:"access_log_mode"` // "all", "non-public", or "none" (default)
 	TZ                     string   `mapstructure:"tz"`
 	EnvPassthrough         []string `mapstructure:"env_passthrough"`
 	EnvPassthroughPrefixes []string `mapstructure:"env_passthrough_prefixes"`

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -594,14 +594,14 @@ func (l *ConfigLoader) loadServerFlags(cfg *Config, def Definition) {
 	if def.Headless != nil {
 		cfg.Server.Headless = *def.Headless
 	}
-	cfg.Server.AccessLog = AccessLogAll
+	cfg.Server.AccessLog = AccessLogNone
 	if def.AccessLog != nil {
 		switch AccessLogMode(*def.AccessLog) {
 		case AccessLogAll, AccessLogNonPublic, AccessLogNone:
 			cfg.Server.AccessLog = AccessLogMode(*def.AccessLog)
 		default:
 			l.warnings = append(l.warnings, fmt.Sprintf(
-				"Invalid access_log_mode value: %q, defaulting to 'all'", *def.AccessLog))
+				"Invalid access_log_mode value: %q, defaulting to 'none'", *def.AccessLog))
 		}
 	}
 	if def.LatestStatusToday != nil {
@@ -1908,7 +1908,7 @@ func (l *ConfigLoader) setViperDefaultValues(paths Paths) {
 	l.v.SetDefault("metrics", "private")
 	l.v.SetDefault("cache", "normal")
 	l.v.SetDefault("log_format", "text")
-	l.v.SetDefault("access_log_mode", "all")
+	l.v.SetDefault("access_log_mode", "none")
 
 	// Coordinator
 	l.v.SetDefault("coordinator.host", "127.0.0.1")

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -668,7 +668,7 @@ scheduler:
 			APIBasePath:       "/api/v1",
 			Headless:          true,
 			CheckUpdates:      false,
-			AccessLog:         AccessLogAll,
+			AccessLog:         AccessLogNone,
 			LatestStatusToday: true,
 			Auth: Auth{
 				Mode:  AuthModeBasic, // Explicit basic mode from YAML
@@ -1915,7 +1915,7 @@ access_log_mode: "none"
 
 	t.Run("AccessLogDefault", func(t *testing.T) {
 		cfg := loadFromYAML(t, "# empty")
-		assert.Equal(t, AccessLogAll, cfg.Server.AccessLog)
+		assert.Equal(t, AccessLogNone, cfg.Server.AccessLog)
 	})
 
 	t.Run("AccessLogFromEnv", func(t *testing.T) {
@@ -1931,7 +1931,7 @@ auth:
   mode: none
 access_log_mode: "invalid"
 `)
-		assert.Equal(t, AccessLogAll, cfg.Server.AccessLog)
+		assert.Equal(t, AccessLogNone, cfg.Server.AccessLog)
 		require.Len(t, cfg.Warnings, 1)
 		assert.Contains(t, cfg.Warnings[0], "Invalid access_log_mode value")
 		assert.Contains(t, cfg.Warnings[0], "invalid")

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -54,8 +54,8 @@
     "access_log_mode": {
       "type": "string",
       "enum": ["all", "non-public", "none"],
-      "description": "HTTP access log mode. 'all' logs every request, 'non-public' skips public endpoints (/health, /auth/login, /auth/setup), 'none' disables access logging entirely. Default: 'all'.",
-      "default": "all"
+      "description": "HTTP access log mode. 'all' logs every request, 'non-public' skips public endpoints (/health, /auth/login, /auth/setup), 'none' disables access logging entirely. Default: 'none'.",
+      "default": "none"
     },
     "default_shell": {
       "type": "string",


### PR DESCRIPTION
## Summary

- disable HTTP access logging by default
- preserve the explicit `all`, `non-public`, and `none` modes
- update the invalid-value fallback, configuration schema, and existing loader tests

## Why

The previous `all` default logged every Web UI and API request, producing high-volume server output. Debug mode also adds request headers, making each access log entry substantially larger. Access logging is now opt-in.

## Impact

Installations that do not set `access_log_mode` will stop emitting HTTP access logs after upgrading. Set `access_log_mode: all` or `DAGU_ACCESS_LOG_MODE=all` to retain the previous behavior. Application logs, including warnings and errors, are unaffected.

## Testing

- `go test ./internal/cmn/config`
- `go test ./internal/cmn/schema`
- `go test ./internal/service/frontend`
- `make fmt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable HTTP access logs by default to reduce noisy server output. Modes `all`, `non-public`, and `none` are preserved, and invalid values now fall back to `none`; schema, loader defaults, and tests updated.

- **Migration**
  - If you don’t set `access_log_mode`, HTTP access logs will stop after upgrade.
  - To keep previous behavior, set `access_log_mode: all` or `DAGU_ACCESS_LOG_MODE=all`.

<sup>Written for commit 546ff4f74bbdf4439b82cec1874d68670d8d2ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Access logging is now disabled by default.
  * Invalid access-log mode values also fall back to disabled logging.
  * Configuration guidance and validation now reflect the updated default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->