### PR TITLE
fix: run downloaded Windows installer in script scope

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -362,6 +362,9 @@ jobs:
             [Text.Encoding]::UTF8
           )
 
+          $Service = ""
+          & ([scriptblock]::Create($source)) -NoPrompt -DryRun
+
           & ([scriptblock]::Create($source)) `
             -NoPrompt -DryRun -Service no -OpenBrowser no `
             -InstallDir "$env:RUNNER_TEMP\dagu-user-install"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,8 +366,10 @@ jobs:
           $Service = ""
           & ([scriptblock]::Create($source)) -NoPrompt -DryRun
 
+          $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
+          [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)
           try {
-            & $installerPath -NoPrompt -DryRun -Uninstall -Version latest
+            & $stagedInstaller -NoPrompt -DryRun -Uninstall -Version latest
             throw "The installer accepted install-only flags during uninstall."
           }
           catch {
@@ -377,6 +379,9 @@ jobs:
             if ($_.Exception.Message -ne "-Version is only supported during install.") {
               throw
             }
+          }
+          finally {
+            Remove-Item -LiteralPath $stagedInstaller -Force -ErrorAction SilentlyContinue
           }
 
           & ([scriptblock]::Create($source)) `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,13 +357,27 @@ jobs:
       - name: Test PowerShell installer
         shell: powershell
         run: |
+          $installerPath = (Resolve-Path "scripts/installer.ps1").Path
           $source = [IO.File]::ReadAllText(
-            (Resolve-Path "scripts/installer.ps1").Path,
+            $installerPath,
             [Text.Encoding]::UTF8
           )
 
           $Service = ""
           & ([scriptblock]::Create($source)) -NoPrompt -DryRun
+
+          try {
+            & $installerPath -NoPrompt -DryRun -Uninstall -Version latest
+            throw "The installer accepted install-only flags during uninstall."
+          }
+          catch {
+            if ($_.Exception.Message -eq "The installer accepted install-only flags during uninstall.") {
+              throw
+            }
+            if ($_.Exception.Message -ne "-Version is only supported during install.") {
+              throw
+            }
+          }
 
           & ([scriptblock]::Create($source)) `
             -NoPrompt -DryRun -Service no -OpenBrowser no `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,8 +363,11 @@ jobs:
             [Text.Encoding]::UTF8
           )
 
-          $Service = ""
+          $Service = "caller-value"
           & ([scriptblock]::Create($source)) -NoPrompt -DryRun
+          if ($Service -ne "caller-value") {
+            throw "The installer changed the caller Service variable."
+          }
 
           $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
           [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm install -g --ignore-scripts=false @dagucloud/dagu
 **Windows (PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/dagucloud/dagu/main/scripts/installer.ps1 | iex
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/dagucloud/dagu/main/scripts/installer.ps1)))
 ```
 
 **Docker:**

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -63,6 +63,7 @@ $ProgressPreference = "SilentlyContinue"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $Script:InstallerSource = [IO.File]::ReadAllText($MyInvocation.MyCommand.Path, [Text.Encoding]::UTF8)
+$Script:InstallerBoundParameterNames = @($PSBoundParameters.Keys)
 $Script:ReleaseBase = "https://github.com/dagucloud/dagu/releases"
 $Script:ReleaseApi = "https://api.github.com/repos/dagucloud/dagu/releases/latest"
 $Script:WinSWVersion = "v2.12.0"
@@ -296,19 +297,19 @@ function Validate-UninstallArgs {
     if (-not $Uninstall) {
         return
     }
-    if ($PSBoundParameters.ContainsKey("Version")) {
+    if ($Script:InstallerBoundParameterNames -contains "Version") {
         throw "-Version is only supported during install."
     }
-    if ($PSBoundParameters.ContainsKey("HostAddress") -or $PSBoundParameters.ContainsKey("Port")) {
+    if (($Script:InstallerBoundParameterNames -contains "HostAddress") -or ($Script:InstallerBoundParameterNames -contains "Port")) {
         throw "-HostAddress and -Port are only supported during install."
     }
-    if ($PSBoundParameters.ContainsKey("AdminUsername") -or $PSBoundParameters.ContainsKey("AdminPassword")) {
+    if (($Script:InstallerBoundParameterNames -contains "AdminUsername") -or ($Script:InstallerBoundParameterNames -contains "AdminPassword")) {
         throw "Admin bootstrap flags are only supported during install."
     }
-    if ($PSBoundParameters.ContainsKey("OpenBrowser")) {
+    if ($Script:InstallerBoundParameterNames -contains "OpenBrowser") {
         throw "-OpenBrowser is only supported during install."
     }
-    if ($PSBoundParameters.ContainsKey("Service")) {
+    if ($Script:InstallerBoundParameterNames -contains "Service") {
         throw "-Service is only supported during install. Use -ServiceScope to narrow service uninstall discovery."
     }
     if ($ServiceScope -and $ServiceScope -ne "system") {

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -26,12 +26,43 @@ param(
     [switch]$VerboseMode
 )
 
+# Installer state requires a script-file scope.
+if ([string]::IsNullOrWhiteSpace($MyInvocation.MyCommand.Path)) {
+    $stagedInstaller = Join-Path ([IO.Path]::GetTempPath()) ("dagu-installer-" + [guid]::NewGuid().ToString("N") + ".ps1")
+    $forwardArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $stagedInstaller)
+    foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+        if ($entry.Value -is [System.Management.Automation.SwitchParameter]) {
+            if ($entry.Value.IsPresent) {
+                $forwardArgs += "-$($entry.Key)"
+            }
+            continue
+        }
+        foreach ($value in @($entry.Value)) {
+            $forwardArgs += @("-$($entry.Key)", [string]$value)
+        }
+    }
+
+    $exitCode = 0
+    try {
+        [IO.File]::WriteAllText($stagedInstaller, $MyInvocation.MyCommand.Definition, [Text.Encoding]::UTF8)
+        & powershell.exe @forwardArgs
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Remove-Item -LiteralPath $stagedInstaller -Force -ErrorAction SilentlyContinue
+    }
+    if ($exitCode -ne 0) {
+        throw "The Dagu installer exited with code $exitCode."
+    }
+    return
+}
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$Script:InstallerSource = $MyInvocation.MyCommand.Definition
+$Script:InstallerSource = [IO.File]::ReadAllText($MyInvocation.MyCommand.Path, [Text.Encoding]::UTF8)
 $Script:ReleaseBase = "https://github.com/dagucloud/dagu/releases"
 $Script:ReleaseApi = "https://api.github.com/repos/dagucloud/dagu/releases/latest"
 $Script:WinSWVersion = "v2.12.0"


### PR DESCRIPTION
## Summary

- replace the `irm | iex` command with an isolated ScriptBlock invocation
- stage downloaded ScriptBlocks as UTF-8 PowerShell files so installer state and defaults share one script scope
- preserve parameters when handing off to Windows PowerShell with execution-policy bypass
- retain the full installer source for elevation and validate uninstall flags against the original script arguments
- exercise caller-variable collisions, default path resolution, invalid uninstall flags, explicit install modes, and CMD launching in Windows CI

## Root cause

`Invoke-Expression` evaluates the installer in the caller's scope, where the validated `Service` parameter can collide with an existing variable. Calling the downloaded content as a ScriptBlock avoids that collision, but a dynamic ScriptBlock has no script-file scope. The installer wrote defaults through `$Script:` while its parameters remained in the child scope, so `InstallDir` was still empty when passed to `Join-Path`.

## Testing

- `git diff --check`
- parsed `.github/workflows/ci.yaml` as YAML
- Windows installer CI added for the reported invocation and default-resolution path

Follow-up to #2530

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows installer invocation by running the downloaded script in its own script-file scope to prevent variable collisions and ensure defaults resolve correctly. Tightens uninstall flag validation, updates docs, and expands Windows CI to assert caller scope is preserved.

- **Bug Fixes**
  - Replace `irm | iex` with an isolated ScriptBlock; stage as UTF‑8 `.ps1` so params and defaults share one scope.
  - Hand off via `powershell.exe -NoProfile -ExecutionPolicy Bypass -File`, preserve args, and surface non‑zero exit codes.
  - Record bound parameter names and block install‑only flags during `-Uninstall`.
  - Keep the full installer source for elevation; load from the script file path.
  - Update README Windows command to `& ([scriptblock]::Create((irm ...)))`.
  - Expand Windows CI: assert caller variables aren’t modified, and stage a temp installer to verify uninstall‑flag rejection and clean up.

<sup>Written for commit e2276999c99aafb134325ae7390cd0248420c4de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PowerShell installer execution and error handling.
  * Installer failures now report correctly and return the appropriate exit status.
  * Temporary installer files are cleaned up automatically.
  * Dry-run behavior now preserves existing service settings.
  * Invalid uninstall options, including install-only version settings, now produce clear validation errors.

* **Documentation**
  * Updated Windows installation instructions with the improved PowerShell invocation method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->