### PR TITLE
fix: restore simple Windows installer command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -373,10 +373,20 @@ jobs:
             if (-not [Console]::IsInputRedirected) {
               throw "The test requires a non-interactive PowerShell host."
             }
-            $Service = "caller-value"
-            irm $installerUrl | iex
-            if ($Service -ne "caller-value") {
-              throw "The installer changed the caller Service variable."
+            $script:Service = "caller-script-service"
+            $script:DaguHome = "caller-script-home"
+            & {
+              $Service = "caller-local-service"
+              irm $installerUrl | iex
+              if ($Service -ne "caller-local-service") {
+                throw "The installer changed the caller Service variable."
+              }
+            }
+            if ($script:Service -ne "caller-script-service") {
+              throw "The installer changed the caller script Service variable."
+            }
+            if ($script:DaguHome -ne "caller-script-home") {
+              throw "The installer changed the caller script DaguHome variable."
             }
 
             if (-not (Test-Path $daguExe)) {
@@ -395,17 +405,10 @@ jobs:
             throw "The expression-based installer did not clean up dagu.exe."
           }
 
-          $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
-          [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)
-          try {
-            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $stagedInstaller `
-              -NoPrompt -DryRun -Uninstall -Version latest
-            if ($LASTEXITCODE -eq 0) {
-              throw "The installer accepted install-only flags during uninstall."
-            }
-          }
-          finally {
-            Remove-Item -LiteralPath $stagedInstaller -Force -ErrorAction SilentlyContinue
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -DryRun -Uninstall -Version latest
+          if ($LASTEXITCODE -eq 0) {
+            throw "The installer accepted install-only flags during uninstall."
           }
 
           & ([scriptblock]::Create($source)) `

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,11 +363,15 @@ jobs:
             [Text.Encoding]::UTF8
           )
 
-          $Service = "caller-value"
-          & ([scriptblock]::Create($source)) -NoPrompt -DryRun
-          if ($Service -ne "caller-value") {
-            throw "The installer changed the caller Service variable."
-          }
+          & {
+            param([string]$InstallerSource)
+            $Service = "caller-value"
+            $args = @("-NoPrompt", "-DryRun")
+            $InstallerSource | Invoke-Expression
+            if ($Service -ne "caller-value") {
+              throw "The installer changed the caller Service variable."
+            }
+          } $source
 
           $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
           [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -362,8 +362,13 @@ jobs:
             $installerPath,
             [Text.Encoding]::UTF8
           )
-          $installerRef = "${{ github.event.pull_request.head.sha || github.sha }}"
-          $installerUrl = "https://raw.githubusercontent.com/$env:GITHUB_REPOSITORY/$installerRef/scripts/installer.ps1"
+          $installerRepository = "${{ github.event.pull_request.head.repo.full_name }}"
+          $installerRef = "${{ github.event.pull_request.head.sha }}"
+          if (-not $installerRepository) {
+            $installerRepository = $env:GITHUB_REPOSITORY
+            $installerRef = $env:GITHUB_SHA
+          }
+          $installerUrl = "https://raw.githubusercontent.com/$installerRepository/$installerRef/scripts/installer.ps1"
           $originalLocalAppData = $env:LOCALAPPDATA
           $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "dagu-expression-home"
           $installDir = Join-Path $env:LOCALAPPDATA "Programs\dagu"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,7 +349,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.windows_installer == 'true'
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -362,16 +362,39 @@ jobs:
             $installerPath,
             [Text.Encoding]::UTF8
           )
+          $installerRef = "${{ github.event.pull_request.head.sha || github.sha }}"
+          $installerUrl = "https://raw.githubusercontent.com/$env:GITHUB_REPOSITORY/$installerRef/scripts/installer.ps1"
+          $installDir = Join-Path $env:RUNNER_TEMP "dagu-expression-install"
+          $daguExe = Join-Path $installDir "dagu.exe"
 
-          & {
-            param([string]$InstallerSource)
-            $Service = "caller-value"
-            $args = @("-NoPrompt", "-DryRun")
-            $InstallerSource | Invoke-Expression
-            if ($Service -ne "caller-value") {
-              throw "The installer changed the caller Service variable."
+          try {
+            & {
+              param([string]$InstallerUrl, [string]$InstallDir)
+              $Service = "caller-value"
+              $args = @(
+                "-NoPrompt", "-Service", "no", "-OpenBrowser", "no",
+                "-InstallDir", $InstallDir
+              )
+              irm $InstallerUrl | iex
+              if ($Service -ne "caller-value") {
+                throw "The installer changed the caller Service variable."
+              }
+            } $installerUrl $installDir
+
+            if (-not (Test-Path $daguExe)) {
+              throw "The expression-based installer did not install dagu.exe."
             }
-          } $source
+            & $daguExe version
+            if ($LASTEXITCODE -ne 0) {
+              throw "The installed Dagu binary failed its version check."
+            }
+          }
+          finally {
+            & $installerPath -NoPrompt -Uninstall -InstallDir $installDir
+          }
+          if (Test-Path $daguExe) {
+            throw "The expression-based installer did not clean up dagu.exe."
+          }
 
           $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
           [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)
@@ -407,10 +430,14 @@ jobs:
         shell: cmd
         env:
           _DAGU_INSTALLER_PS1_PATH: ${{ github.workspace }}\scripts\installer.ps1
-        run: >-
-          scripts\installer.cmd
-          -NoPrompt -DryRun -Service no -OpenBrowser no
-          -InstallDir "%RUNNER_TEMP%\dagu-cmd-install"
+        run: |
+          scripts\installer.cmd -NoPrompt -Service no -OpenBrowser no -InstallDir "%RUNNER_TEMP%\dagu-cmd-install"
+          if errorlevel 1 exit /b 1
+          "%RUNNER_TEMP%\dagu-cmd-install\dagu.exe" version
+          if errorlevel 1 exit /b 1
+          scripts\installer.cmd -NoPrompt -Uninstall -InstallDir "%RUNNER_TEMP%\dagu-cmd-install"
+          if errorlevel 1 exit /b 1
+          if exist "%RUNNER_TEMP%\dagu-cmd-install\dagu.exe" exit /b 1
 
   test-windows:
     name: Test on windows-latest (${{ matrix.suite_index }}/${{ matrix.suite_total }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -398,15 +398,10 @@ jobs:
           $stagedInstaller = Join-Path $env:RUNNER_TEMP "dagu-validation-installer.ps1"
           [IO.File]::WriteAllText($stagedInstaller, $source, [Text.Encoding]::UTF8)
           try {
-            & $stagedInstaller -NoPrompt -DryRun -Uninstall -Version latest
-            throw "The installer accepted install-only flags during uninstall."
-          }
-          catch {
-            if ($_.Exception.Message -eq "The installer accepted install-only flags during uninstall.") {
-              throw
-            }
-            if ($_.Exception.Message -ne "-Version is only supported during install.") {
-              throw
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $stagedInstaller `
+              -NoPrompt -DryRun -Uninstall -Version latest
+            if ($LASTEXITCODE -eq 0) {
+              throw "The installer accepted install-only flags during uninstall."
             }
           }
           finally {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -388,7 +388,7 @@ jobs:
             }
           }
           finally {
-            & $installerPath -NoPrompt -Uninstall -InstallDir $installDir
+            & ([scriptblock]::Create($source)) -NoPrompt -Uninstall -InstallDir $installDir
             $env:LOCALAPPDATA = $originalLocalAppData
           }
           if (Test-Path $daguExe) {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,22 +364,20 @@ jobs:
           )
           $installerRef = "${{ github.event.pull_request.head.sha || github.sha }}"
           $installerUrl = "https://raw.githubusercontent.com/$env:GITHUB_REPOSITORY/$installerRef/scripts/installer.ps1"
-          $installDir = Join-Path $env:RUNNER_TEMP "dagu-expression-install"
+          $originalLocalAppData = $env:LOCALAPPDATA
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP "dagu-expression-home"
+          $installDir = Join-Path $env:LOCALAPPDATA "Programs\dagu"
           $daguExe = Join-Path $installDir "dagu.exe"
 
           try {
-            & {
-              param([string]$InstallerUrl, [string]$InstallDir)
-              $Service = "caller-value"
-              $args = @(
-                "-NoPrompt", "-Service", "no", "-OpenBrowser", "no",
-                "-InstallDir", $InstallDir
-              )
-              irm $InstallerUrl | iex
-              if ($Service -ne "caller-value") {
-                throw "The installer changed the caller Service variable."
-              }
-            } $installerUrl $installDir
+            if (-not [Console]::IsInputRedirected) {
+              throw "The test requires a non-interactive PowerShell host."
+            }
+            $Service = "caller-value"
+            irm $installerUrl | iex
+            if ($Service -ne "caller-value") {
+              throw "The installer changed the caller Service variable."
+            }
 
             if (-not (Test-Path $daguExe)) {
               throw "The expression-based installer did not install dagu.exe."
@@ -391,6 +389,7 @@ jobs:
           }
           finally {
             & $installerPath -NoPrompt -Uninstall -InstallDir $installDir
+            $env:LOCALAPPDATA = $originalLocalAppData
           }
           if (Test-Path $daguExe) {
             throw "The expression-based installer did not clean up dagu.exe."

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm install -g --ignore-scripts=false @dagucloud/dagu
 **Windows (PowerShell):**
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/dagucloud/dagu/main/scripts/installer.ps1)))
+irm https://raw.githubusercontent.com/dagucloud/dagu/main/scripts/installer.ps1 | iex
 ```
 
 **Docker:**

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -361,7 +361,7 @@ func (s *Store) ListAllAlive(ctx context.Context) (map[string][]dagrun.DAGRunRef
 // Validate fails if the proc directory cannot be read. Individual proc files
 // are not decoded here, so a damaged one does not make the store unusable.
 func (s *Store) Validate(_ context.Context) error {
-	if _, err := os.ReadDir(s.root); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if _, err := fileutil.ReadDir(s.root); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("validate proc store: %w", err)
 	}
 	return nil
@@ -511,7 +511,7 @@ func removeProcFile(path string) error {
 }
 
 func removeEmptyProcDirs(dir string) {
-	entries, err := os.ReadDir(dir)
+	entries, err := fileutil.ReadDir(dir)
 	if err != nil || len(entries) > 0 {
 		return
 	}
@@ -521,7 +521,7 @@ func removeEmptyProcDirs(dir string) {
 // ListEntries returns proc entries for a group.
 func (s *Store) ListEntries(_ context.Context, groupName string) ([]proc.ProcEntry, error) {
 	groupDir := filepath.Join(s.root, groupName)
-	if _, err := os.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
+	if _, err := fileutil.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	files, err := procFilesInGroup(groupDir)
@@ -533,7 +533,7 @@ func (s *Store) ListEntries(_ context.Context, groupName string) ([]proc.ProcEnt
 
 // ListAllEntries returns all proc entries under the store root.
 func (s *Store) ListAllEntries(_ context.Context) ([]proc.ProcEntry, error) {
-	dirEntries, err := os.ReadDir(s.root)
+	dirEntries, err := fileutil.ReadDir(s.root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
@@ -563,7 +563,7 @@ func (s *Store) ListAllEntries(_ context.Context) ([]proc.ProcEntry, error) {
 // LatestHeartbeat returns the latest heartbeat for dagRun.
 func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun dagrun.DAGRunRef) (*proc.ProcHeartbeat, error) {
 	groupDir := filepath.Join(s.root, groupName)
-	if _, err := os.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
+	if _, err := fileutil.Stat(groupDir); errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	files, err := procFilesInGroup(groupDir)
@@ -601,7 +601,7 @@ func (s *Store) LatestHeartbeat(_ context.Context, groupName string, dagRun dagr
 }
 
 func procFilesInGroup(groupDir string) ([]string, error) {
-	dagEntries, err := os.ReadDir(groupDir)
+	dagEntries, err := fileutil.ReadDir(groupDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
@@ -613,7 +613,7 @@ func procFilesInGroup(groupDir string) ([]string, error) {
 		if !dagEntry.IsDir() || dagEntry.Name() == "" || dagEntry.Name()[0] == '.' {
 			continue
 		}
-		procEntries, err := os.ReadDir(filepath.Join(groupDir, dagEntry.Name()))
+		procEntries, err := fileutil.ReadDir(filepath.Join(groupDir, dagEntry.Name()))
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
@@ -669,7 +669,7 @@ func procFileMayBelongTo(path string, dagRun dagrun.DAGRunRef) bool {
 // threshold. A damaged file that is still being written may belong to a run
 // that is alive, and reporting the group without it would undercount.
 func (s *Store) abandoned(path string, now time.Time) bool {
-	info, err := os.Stat(path)
+	info, err := fileutil.Stat(path)
 	return err == nil && now.Sub(info.ModTime()) >= s.staleTime
 }
 
@@ -721,7 +721,7 @@ func readProcEntryObserved(path, groupName string, staleTime time.Duration, now 
 		return observedProcEntry{}, err
 	}
 
-	info, err := os.Stat(path)
+	info, err := fileutil.Stat(path)
 	if err != nil {
 		return observedProcEntry{}, err
 	}

--- a/internal/persis/file/proc/store_windows_test.go
+++ b/internal/persis/file/proc/store_windows_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build windows
+
+package proc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
+	"github.com/dagucloud/dagu/v2/internal/dagrun"
+)
+
+func TestStoreListEntriesWaitsForTransientDirectorySharingViolation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store := New(root)
+	ref := dagrun.NewDAGRunRef("shared-dag", "run-1")
+	meta := testProcMeta(ref)
+	require.NoError(t, writeProcFile(store.filePath("queue-a", meta, time.Now().UTC()), time.Now().UTC().Unix(), meta))
+
+	dagDir := filepath.Join(root, "queue-a", ref.Name)
+	path, err := windows.UTF16PtrFromString(dagDir)
+	require.NoError(t, err)
+	handle, err := windows.CreateFile(
+		path,
+		windows.GENERIC_READ,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = windows.CloseHandle(handle) })
+
+	_, err = os.ReadDir(dagDir)
+	require.Error(t, err)
+	require.True(t, fileutil.IsTransientFileError(err), "expected a transient sharing violation, got %v", err)
+
+	released := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		released <- windows.CloseHandle(handle)
+	}()
+
+	entries, err := store.ListEntries(t.Context(), "queue-a")
+	require.NoError(t, <-released)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, ref, entries[0].Meta.DAGRun())
+}

--- a/internal/persis/file/proc/store_windows_test.go
+++ b/internal/persis/file/proc/store_windows_test.go
@@ -8,6 +8,7 @@ package proc
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +41,12 @@ func TestStoreListEntriesWaitsForTransientDirectorySharingViolation(t *testing.T
 		0,
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = windows.CloseHandle(handle) })
+	var closeOnce sync.Once
+	closeHandle := func() (err error) {
+		closeOnce.Do(func() { err = windows.CloseHandle(handle) })
+		return err
+	}
+	t.Cleanup(func() { _ = closeHandle() })
 
 	_, err = os.ReadDir(dagDir)
 	require.Error(t, err)
@@ -49,7 +55,7 @@ func TestStoreListEntriesWaitsForTransientDirectorySharingViolation(t *testing.T
 	released := make(chan error, 1)
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		released <- windows.CloseHandle(handle)
+		released <- closeHandle()
 	}()
 
 	entries, err := store.ListEntries(t.Context(), "queue-a")

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -847,7 +847,7 @@ func (cli *clientImpl) Heartbeat(ctx context.Context, req *coordinatorv1.Heartbe
 
 	members, err := cli.getCoordinatorMembers(ctx)
 	if err != nil {
-		return nil, err
+		return nil, heartbeatContextError(ctx, err)
 	}
 
 	var resp *coordinatorv1.HeartbeatResponse
@@ -863,7 +863,7 @@ func (cli *clientImpl) Heartbeat(ctx context.Context, req *coordinatorv1.Heartbe
 	deadline, hasDeadline := ctx.Deadline()
 	if !hasDeadline || len(members) == 1 {
 		err = cli.attemptCall(ctx, members, call)
-		return resp, err
+		return resp, heartbeatContextError(ctx, err)
 	}
 
 	rand.Shuffle(len(members), func(i, j int) {
@@ -885,7 +885,20 @@ func (cli *clientImpl) Heartbeat(ctx context.Context, req *coordinatorv1.Heartbe
 			return resp, nil
 		}
 	}
-	return nil, lastErr
+	return nil, heartbeatContextError(ctx, lastErr)
+}
+
+func heartbeatContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+		return context.DeadlineExceeded
+	}
+	return err
 }
 
 func (cli *clientImpl) AckTaskClaimTo(ctx context.Context, owner serviceregistry.HostInfo, req *coordinatorv1.AckTaskClaimRequest) (*coordinatorv1.AckTaskClaimResponse, error) {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1404,8 +1404,10 @@ func TestClientHeartbeatReturnsDeadlineAfterFailoverExhaustion(t *testing.T) {
 	config := coordinator.DefaultConfig()
 	config.HeartbeatTimeout = 400 * time.Millisecond
 
+	var heartbeatCalls atomic.Int32
 	mockCoord := &mockCoordinatorService{
 		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			heartbeatCalls.Add(1)
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},
@@ -1427,6 +1429,7 @@ func TestClientHeartbeatReturnsDeadlineAfterFailoverExhaustion(t *testing.T) {
 
 	_, err := client.Heartbeat(t.Context(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(2), heartbeatCalls.Load())
 }
 
 func TestClientHeartbeatReturnsCallerCancellation(t *testing.T) {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1251,14 +1251,11 @@ func TestClientRPCFailuresPreserveActiveLogStream(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
-	config.MaxRetries = 0
-	config.HeartbeatTimeout = 100 * time.Millisecond
 
 	received := make(chan string, 2)
 	mockCoord := &mockCoordinatorService{
-		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
+		heartbeatFunc: func(context.Context, *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			return nil, status.Error(codes.DeadlineExceeded, "heartbeat deadline exceeded")
 		},
 		reportStatusFunc: func(context.Context, *coordinatorv1.ReportStatusRequest) (*coordinatorv1.ReportStatusResponse, error) {
 			return nil, status.Error(codes.Unavailable, "report unavailable")
@@ -1341,21 +1338,13 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
-	config.MaxRetries = 0
 	config.HeartbeatTimeout = 50 * time.Millisecond
 
-	mockCoord := &mockCoordinatorService{
-		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+	monitor := &mockServiceMonitor{
+		getMembers: func(ctx context.Context) ([]serviceregistry.HostInfo, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},
-	}
-	server, addr := startMockServer(t, mockCoord)
-	defer server.Stop()
-
-	host, port := parseHostPort(addr)
-	monitor := &mockServiceMonitor{
-		members: []serviceregistry.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive}},
 	}
 	client := coordinator.New(monitor, config)
 
@@ -1369,7 +1358,7 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 
 	select {
 	case err := <-result:
-		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	case <-time.After(500 * time.Millisecond):
 		cancel()
 		t.Fatal("Heartbeat did not respect its configured timeout")
@@ -1380,21 +1369,13 @@ func TestClientHeartbeatHonorsCallerDeadline(t *testing.T) {
 	t.Parallel()
 
 	config := coordinator.DefaultConfig()
-	config.MaxRetries = 0
 	config.HeartbeatTimeout = time.Second
 
-	mockCoord := &mockCoordinatorService{
-		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+	monitor := &mockServiceMonitor{
+		getMembers: func(ctx context.Context) ([]serviceregistry.HostInfo, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},
-	}
-	server, addr := startMockServer(t, mockCoord)
-	defer server.Stop()
-
-	host, port := parseHostPort(addr)
-	monitor := &mockServiceMonitor{
-		members: []serviceregistry.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive}},
 	}
 	client := coordinator.New(monitor, config)
 
@@ -1408,7 +1389,7 @@ func TestClientHeartbeatHonorsCallerDeadline(t *testing.T) {
 
 	select {
 	case err := <-result:
-		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Heartbeat did not respect the caller deadline")
 	}
@@ -1675,18 +1656,22 @@ func TestClientDispatch_NoCoordinators(t *testing.T) {
 var _ serviceregistry.ServiceRegistry = (*mockServiceMonitor)(nil)
 
 type mockServiceMonitor struct {
-	members   []serviceregistry.HostInfo
-	err       error
-	onMembers func()
+	members    []serviceregistry.HostInfo
+	err        error
+	onMembers  func()
+	getMembers func(context.Context) ([]serviceregistry.HostInfo, error)
 }
 
 func (m *mockServiceMonitor) Register(_ context.Context, _ serviceregistry.ServiceName, _ serviceregistry.HostInfo) error {
 	return nil
 }
 
-func (m *mockServiceMonitor) GetServiceMembers(_ context.Context, _ serviceregistry.ServiceName) ([]serviceregistry.HostInfo, error) {
+func (m *mockServiceMonitor) GetServiceMembers(ctx context.Context, _ serviceregistry.ServiceName) ([]serviceregistry.HostInfo, error) {
 	if m.onMembers != nil {
 		m.onMembers()
+	}
+	if m.getMembers != nil {
+		return m.getMembers(ctx)
 	}
 	if m.err != nil {
 		return nil, m.err

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -1335,16 +1335,21 @@ func TestClientRPCFailuresPreserveActiveLogStream(t *testing.T) {
 }
 
 func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
-	t.Parallel()
-
 	config := coordinator.DefaultConfig()
-	config.HeartbeatTimeout = 50 * time.Millisecond
+	config.HeartbeatTimeout = 200 * time.Millisecond
 
-	monitor := &mockServiceMonitor{
-		getMembers: func(ctx context.Context) ([]serviceregistry.HostInfo, error) {
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		},
+	}
+	server, addr := startMockServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []serviceregistry.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive}},
 	}
 	client := coordinator.New(monitor, config)
 
@@ -1359,7 +1364,7 @@ func TestClientHeartbeatUsesConfiguredTimeout(t *testing.T) {
 	select {
 	case err := <-result:
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		cancel()
 		t.Fatal("Heartbeat did not respect its configured timeout")
 	}
@@ -1392,6 +1397,76 @@ func TestClientHeartbeatHonorsCallerDeadline(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Heartbeat did not respect the caller deadline")
+	}
+}
+
+func TestClientHeartbeatReturnsDeadlineAfterFailoverExhaustion(t *testing.T) {
+	config := coordinator.DefaultConfig()
+	config.HeartbeatTimeout = 400 * time.Millisecond
+
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	firstServer, firstAddr := startMockServer(t, mockCoord)
+	defer firstServer.Stop()
+	secondServer, secondAddr := startMockServer(t, mockCoord)
+	defer secondServer.Stop()
+
+	firstHost, firstPort := parseHostPort(firstAddr)
+	secondHost, secondPort := parseHostPort(secondAddr)
+	monitor := &mockServiceMonitor{
+		members: []serviceregistry.HostInfo{
+			{ID: "coord-a", Host: firstHost, Port: firstPort, Status: serviceregistry.ServiceStatusActive},
+			{ID: "coord-b", Host: secondHost, Port: secondPort, Status: serviceregistry.ServiceStatusActive},
+		},
+	}
+	client := coordinator.New(monitor, config)
+
+	_, err := client.Heartbeat(t.Context(), &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestClientHeartbeatReturnsCallerCancellation(t *testing.T) {
+	started := make(chan struct{})
+	mockCoord := &mockCoordinatorService{
+		heartbeatFunc: func(ctx context.Context, _ *coordinatorv1.HeartbeatRequest) (*coordinatorv1.HeartbeatResponse, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	server, addr := startMockServer(t, mockCoord)
+	defer server.Stop()
+
+	host, port := parseHostPort(addr)
+	monitor := &mockServiceMonitor{
+		members: []serviceregistry.HostInfo{{ID: "coord-a", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive}},
+	}
+	client := coordinator.New(monitor, coordinator.DefaultConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.Heartbeat(ctx, &coordinatorv1.HeartbeatRequest{WorkerId: "test-worker"})
+		result <- err
+	}()
+
+	select {
+	case <-started:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("Heartbeat RPC did not start")
+	}
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Heartbeat did not respect caller cancellation")
 	}
 }
 

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (C) 2026 Yota Hamada
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -1,4 +1,4 @@
-﻿#
+#
 # Copyright (C) 2026 Yota Hamada
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -95,7 +95,7 @@ function Write-Section {
 
 function Write-Info {
     param([string]$Message)
-    Write-Host "· $Message" -ForegroundColor DarkGray
+    Write-Host "- $Message" -ForegroundColor DarkGray
 }
 
 function Write-WarnMessage {
@@ -105,12 +105,12 @@ function Write-WarnMessage {
 
 function Write-Success {
     param([string]$Message)
-    Write-Host "✓ $Message" -ForegroundColor Cyan
+    Write-Host "+ $Message" -ForegroundColor Cyan
 }
 
 function Write-ErrorMessage {
     param([string]$Message)
-    Write-Host "✗ $Message" -ForegroundColor Red
+    Write-Host "x $Message" -ForegroundColor Red
 }
 
 function Show-Banner {

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -119,7 +119,7 @@ function Show-Banner {
 }
 
 function Test-Interactive {
-    if ($NoPrompt) { return $false }
+    if ($NoPrompt -or [Console]::IsInputRedirected) { return $false }
     return ($Host.Name -ne "ServerRemoteHost")
 }
 

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# Keep installer parameters and state isolated from the calling session.
+& {
 [CmdletBinding()]
 param(
     [string]$Version = "",
@@ -1252,3 +1254,4 @@ Verify-Bootstrap
 Install-AISkill
 Show-Summary
 Open-BrowserIfRequested
+} @args


### PR DESCRIPTION
## Summary

- isolate the PowerShell installer from caller variables while preserving the simple `irm ... | iex` command
- perform real PowerShell and CMD install, version, uninstall, and cleanup checks in Windows CI
- make heartbeat deadline reporting consistent and replace transport-racy timeout tests with deterministic context tests

## Root cause

`Invoke-Expression` evaluates downloaded code in the caller's scope. The installer's top-level parameter metadata could therefore collide with an existing caller variable such as `$Service`. Renaming that parameter would only move the collision risk.

The installer now creates its own child scope and forwards direct script arguments with `@args`. Its source remains ASCII-safe so Windows PowerShell can execute both a downloaded file and the direct `irm ... | iex` pipeline.

## Testing

- `GOCACHE=/private/tmp/dagu6-go-cache GOLANGCI_LINT_CACHE=/private/tmp/dagu6-golangci-cache make check`
- `GOCACHE=/private/tmp/dagu6-go-cache go test -race ./internal/service/coordinator -count=10`
- Windows CI downloads this PR's exact installer revision with the no-argument `irm ... | iex` pipeline, installs Dagu, runs `dagu.exe version`, uninstalls it, and verifies cleanup
- Windows CI performs the same lifecycle checks through `installer.cmd`

Closes #2530


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and cancellation error reporting for service heartbeats.
  * Enhanced installer behavior in redirected or noninteractive environments.
  * Replaced installer status symbols with broadly compatible text characters.
  * Improved Windows process-record listing during temporary file-sharing conflicts.

* **Installation**
  * Windows PowerShell installation now runs more reliably without affecting the calling session.
  * Expanded Windows installer validation, including installation, version checks, cleanup, and uninstall options.
  * Added comprehensive command-line installer checks for installation and removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->