### PR TITLE
feat: support opt-in DAG file symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,7 @@ The table lists the most common commands. The binary ships 31 in total, includin
 | `DAGU_HOME` | — | Overrides all path defaults |
 | `DAGU_DAGS_DIR` | `~/.config/dagu/dags` | DAG definitions directory |
 | `DAGU_DAG_DISCOVERY_RECURSIVE` | `false` | Discover DAGs in subdirectories |
+| `DAGU_DAG_DISCOVERY_SYMLINKS` | `false` | Include recursive file symlinks and allow external targets |
 | `DAGU_LOG_DIR` | `~/.local/share/dagu/logs` | Log files |
 | `DAGU_DATA_DIR` | `~/.local/share/dagu/data` | Application state |
 | `DAGU_TOOLS_DIR` | `{DAGU_DATA_DIR}/tools` | Managed DAG tool cache |
@@ -933,6 +934,15 @@ dag_discovery:
 ```
 
 It scans `paths.dags_dir`, excluding `workspaces/`, dot-directories, and symlinks. File stems and effective DAG names must each be unique, using case-sensitive comparison; conflicting files are excluded until the conflict is resolved. `paths.alt_dags_dir` remains lookup-only.
+
+Set `dag_discovery.symlinks: true` (or
+`DAGU_DAG_DISCOVERY_SYMLINKS=true`) to include YAML file symlinks in recursive
+discovery and to allow YAML file symlinks whose targets are outside
+`paths.dags_dir`. Symlinked directories are never traversed. External targets
+can be viewed, scheduled, and run, but cannot be updated, deleted, or renamed
+through Dagu. Without the opt-in, top-level YAML file symlinks whose targets
+remain inside `paths.dags_dir` continue to work. A symlink configured as
+`paths.dags_dir` itself is also supported.
 
 ### Authentication
 

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 // DAGDiscoveryConfig controls how DAG definitions are discovered.
 type DAGDiscoveryConfig struct {
 	Recursive bool
+	Symlinks  bool
 }
 
 const DefaultWebhookMaxPayloadSize = 1 * 1024 * 1024

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -99,6 +99,7 @@ type Definition struct {
 // DAGDiscoveryDef configures DAG definition discovery.
 type DAGDiscoveryDef struct {
 	Recursive *bool `mapstructure:"recursive"`
+	Symlinks  *bool `mapstructure:"symlinks"`
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -360,6 +360,7 @@ func (l *ConfigLoader) loadCoreConfig(cfg *Config, def Definition) error {
 	}
 	cfg.DAGDiscovery = DAGDiscoveryConfig{
 		Recursive: l.v.GetBool("dag_discovery.recursive"),
+		Symlinks:  l.v.GetBool("dag_discovery.symlinks"),
 	}
 
 	if err := setTimezone(&cfg.Core); err != nil {
@@ -1947,6 +1948,7 @@ func (l *ConfigLoader) setViperDefaultValues(paths Paths) {
 	// Paths
 	l.v.SetDefault("skip_examples", false)
 	l.v.SetDefault("dag_discovery.recursive", false)
+	l.v.SetDefault("dag_discovery.symlinks", false)
 	l.v.SetDefault("paths.dags_dir", paths.DAGsDir)
 	l.v.SetDefault("paths.suspend_flags_dir", paths.SuspendFlagsDir)
 	l.v.SetDefault("paths.data_dir", paths.DataDir)
@@ -2069,6 +2071,7 @@ var envBindings = []envBinding{
 	{key: "default_shell", env: "DEFAULT_SHELL"},
 	{key: "skip_examples", env: "SKIP_EXAMPLES"},
 	{key: "dag_discovery.recursive", env: "DAG_DISCOVERY_RECURSIVE"},
+	{key: "dag_discovery.symlinks", env: "DAG_DISCOVERY_SYMLINKS"},
 	{key: "env_passthrough", env: "ENV_PASSTHROUGH"},
 	{key: "env_passthrough_prefixes", env: "ENV_PASSTHROUGH_PREFIXES"},
 

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -35,22 +35,28 @@ func testLoadWithError(t *testing.T, opts ...ConfigLoaderOption) error {
 func TestLoad_DAGDiscovery(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		t.Setenv("DAGU_DAG_DISCOVERY_RECURSIVE", "")
+		t.Setenv("DAGU_DAG_DISCOVERY_SYMLINKS", "")
 		cfg := testLoad(t)
 		assert.False(t, cfg.DAGDiscovery.Recursive)
+		assert.False(t, cfg.DAGDiscovery.Symlinks)
 	})
 
 	t.Run("YAML", func(t *testing.T) {
 		cfg := loadFromYAML(t, `
 dag_discovery:
   recursive: true
+  symlinks: true
 `)
 		assert.True(t, cfg.DAGDiscovery.Recursive)
+		assert.True(t, cfg.DAGDiscovery.Symlinks)
 	})
 
 	t.Run("Environment", func(t *testing.T) {
 		t.Setenv("DAGU_DAG_DISCOVERY_RECURSIVE", "true")
+		t.Setenv("DAGU_DAG_DISCOVERY_SYMLINKS", "true")
 		cfg := testLoad(t)
 		assert.True(t, cfg.DAGDiscovery.Recursive)
+		assert.True(t, cfg.DAGDiscovery.Symlinks)
 	})
 }
 

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -787,6 +787,11 @@
           "type": "boolean",
           "description": "Discover DAG definitions in subdirectories.",
           "default": false
+        },
+        "symlinks": {
+          "type": "boolean",
+          "description": "Include file symlinks in recursive DAG discovery and allow file symlinks whose targets are outside the configured DAG directory.",
+          "default": false
         }
       }
     },

--- a/internal/dagdiscovery/scan.go
+++ b/internal/dagdiscovery/scan.go
@@ -5,6 +5,7 @@
 package dagdiscovery
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -16,11 +17,29 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/workspace"
 )
 
+// ErrExternalSymlinkDisabled indicates that a DAG file symlink needs the discovery opt-in.
+var ErrExternalSymlinkDisabled = errors.New("external DAG file symlinks are disabled")
+
 // File describes a discovered DAG definition.
 type File struct {
-	RelPath string
-	Size    int64
-	ModTime int64
+	RelPath      string
+	ResolvedPath string
+	Size         int64
+	ModTime      int64
+}
+
+// Options controls which DAG definition files are discoverable.
+type Options struct {
+	Recursive bool
+	Symlinks  bool
+}
+
+// ResolvedFile describes a DAG file entry and its canonical read target.
+type ResolvedFile struct {
+	EntryPath       string
+	ResolvedPath    string
+	Symlink         bool
+	ExternalSymlink bool
 }
 
 // Result contains discoverable files, directories, and non-fatal traversal errors.
@@ -31,10 +50,10 @@ type Result struct {
 }
 
 // Scan enumerates DAG definitions beneath root.
-func Scan(root string, recursive bool) (Result, error) {
+func Scan(root string, opts Options) (Result, error) {
 	root = filepath.Clean(root)
-	if !recursive {
-		return scanRoot(root)
+	if !opts.Recursive {
+		return scanRoot(root, opts.Symlinks)
 	}
 
 	walkRoot, err := filepath.EvalSymlinks(root)
@@ -69,6 +88,21 @@ func Scan(root string, recursive bool) (Result, error) {
 		}
 
 		if path != walkRoot && entry.Type()&os.ModeSymlink != 0 {
+			if !fileutil.IsYAMLFile(entry.Name()) {
+				return nil
+			}
+			resolved, err := ResolveFile(root, relPath)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", relPath, err))
+				return nil
+			}
+			if !opts.Symlinks {
+				if resolved.ExternalSymlink {
+					result.Errors = append(result.Errors, externalSymlinkDisabledError(relPath))
+				}
+				return nil
+			}
+			appendResolvedFile(&result, relPath, resolved)
 			return nil
 		}
 
@@ -88,19 +122,12 @@ func Scan(root string, recursive bool) (Result, error) {
 			return nil
 		}
 
-		info, err := entry.Info()
+		resolved, err := ResolveFile(root, relPath)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", relPath, err))
 			return nil
 		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		result.Files = append(result.Files, File{
-			RelPath: relPath,
-			Size:    info.Size(),
-			ModTime: info.ModTime().UnixNano(),
-		})
+		appendResolvedFile(&result, relPath, resolved)
 		return nil
 	})
 	if err != nil {
@@ -111,7 +138,7 @@ func Scan(root string, recursive bool) (Result, error) {
 	return result, nil
 }
 
-func scanRoot(root string) (Result, error) {
+func scanRoot(root string, symlinks bool) (Result, error) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		return Result{}, err
@@ -122,20 +149,135 @@ func scanRoot(root string) (Result, error) {
 		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
 			continue
 		}
-		info, err := entry.Info()
+		resolved, err := ResolveFile(root, entry.Name())
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", entry.Name(), err))
 			continue
 		}
-		result.Files = append(result.Files, File{
-			RelPath: filepath.ToSlash(entry.Name()),
-			Size:    info.Size(),
-			ModTime: info.ModTime().UnixNano(),
-		})
+		if resolved.ExternalSymlink && !symlinks {
+			result.Errors = append(result.Errors, externalSymlinkDisabledError(entry.Name()))
+			continue
+		}
+		appendResolvedFile(&result, filepath.ToSlash(entry.Name()), resolved)
 	}
 
 	sortResult(&result)
 	return result, nil
+}
+
+// ResolveFile resolves one lexically contained DAG entry without allowing
+// symlinked directory components beneath root.
+func ResolveFile(root, relPath string) (ResolvedFile, error) {
+	entryPath, err := fileutil.ResolvePathWithinBase(root, relPath)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	if err := rejectSymlinkedParentDirectories(rootAbs, entryPath); err != nil {
+		return ResolvedFile{}, err
+	}
+
+	realRoot, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	realRoot, err = filepath.Abs(realRoot)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+
+	entryInfo, err := os.Lstat(entryPath)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	symlink := entryInfo.Mode()&os.ModeSymlink != 0
+
+	resolvedPath, err := filepath.EvalSymlinks(entryPath)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	resolvedPath, err = filepath.Abs(resolvedPath)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return ResolvedFile{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return ResolvedFile{}, fmt.Errorf("DAG definition is not a regular file")
+	}
+
+	external := !pathWithinRoot(resolvedPath, realRoot)
+	if external && !symlink {
+		return ResolvedFile{}, fileutil.ErrPathEscapesBase
+	}
+	return ResolvedFile{
+		EntryPath:       entryPath,
+		ResolvedPath:    resolvedPath,
+		Symlink:         symlink,
+		ExternalSymlink: external,
+	}, nil
+}
+
+func rejectSymlinkedParentDirectories(rootAbs, entryPath string) error {
+	relParent, err := filepath.Rel(rootAbs, filepath.Dir(entryPath))
+	if err != nil || relParent == ".." || strings.HasPrefix(relParent, ".."+string(filepath.Separator)) {
+		return fileutil.ErrPathEscapesBase
+	}
+	if relParent == "." {
+		return nil
+	}
+
+	current := rootAbs
+	for component := range strings.SplitSeq(relParent, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fileutil.ErrPathEscapesBase
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func appendResolvedFile(result *Result, relPath string, resolved ResolvedFile) {
+	info, err := os.Stat(resolved.ResolvedPath)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("%s: %w", relPath, err))
+		return
+	}
+	result.Files = append(result.Files, File{
+		RelPath:      filepath.ToSlash(relPath),
+		ResolvedPath: resolved.ResolvedPath,
+		Size:         info.Size(),
+		ModTime:      info.ModTime().UnixNano(),
+	})
+}
+
+func externalSymlinkDisabledError(relPath string) error {
+	return fmt.Errorf(
+		"%s: DAG file symlink resolves outside the configured DAG directory; enable dag_discovery.symlinks to load it: %w",
+		filepath.ToSlash(relPath),
+		ErrExternalSymlinkDisabled,
+	)
 }
 
 func sortResult(result *Result) {

--- a/internal/dagdiscovery/scan_test.go
+++ b/internal/dagdiscovery/scan_test.go
@@ -35,12 +35,15 @@ func TestScanRecursive(t *testing.T) {
 	require.NoError(t, os.MkdirAll(externalDir, 0750))
 	externalFile := filepath.Join(externalDir, "linked.yaml")
 	require.NoError(t, os.WriteFile(externalFile, []byte("steps: []\n"), 0600))
-	_ = os.Symlink(externalDir, filepath.Join(root, "linked-dir"))
-	_ = os.Symlink(externalFile, filepath.Join(root, "linked-file.yaml"))
+	if err := os.Symlink(externalDir, filepath.Join(root, "linked-dir")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+	require.NoError(t, os.Symlink(externalFile, filepath.Join(root, "linked-file.yaml")))
 
-	result, err := Scan(root, true)
+	result, err := Scan(root, Options{Recursive: true})
 	require.NoError(t, err)
-	require.Empty(t, result.Errors)
+	require.Len(t, result.Errors, 1)
+	assert.ErrorIs(t, result.Errors[0], ErrExternalSymlinkDisabled)
 
 	var files []string
 	for _, file := range result.Files {
@@ -56,6 +59,28 @@ func TestScanRecursive(t *testing.T) {
 		filepath.Join(root, "team"),
 		filepath.Join(root, "team", "nested"),
 	}, result.Dirs)
+
+	result, err = Scan(root, Options{Recursive: true, Symlinks: true})
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	files = files[:0]
+	for _, file := range result.Files {
+		files = append(files, file.RelPath)
+	}
+	assert.Equal(t, []string{
+		"linked-file.yaml",
+		"root.yaml",
+		"team/nested.yml",
+		"team/nested/deep.yaml",
+	}, files)
+	expectedExternalFile, err := filepath.EvalSymlinks(externalFile)
+	require.NoError(t, err)
+	assert.Equal(t, expectedExternalFile, result.Files[0].ResolvedPath)
+	assert.Equal(t, []string{
+		root,
+		filepath.Join(root, "team"),
+		filepath.Join(root, "team", "nested"),
+	}, result.Dirs)
 }
 
 func TestScanNonRecursiveOnlyReadsRoot(t *testing.T) {
@@ -64,12 +89,54 @@ func TestScanNonRecursiveOnlyReadsRoot(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "root.yaml"), []byte("steps: []\n"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "nested", "child.yaml"), []byte("steps: []\n"), 0600))
 
-	result, err := Scan(root, false)
+	result, err := Scan(root, Options{})
 	require.NoError(t, err)
 	require.Empty(t, result.Errors)
 	require.Len(t, result.Files, 1)
 	assert.Equal(t, "root.yaml", result.Files[0].RelPath)
 	assert.Equal(t, []string{root}, result.Dirs)
+}
+
+func TestScanNonRecursiveAllowsInternalFileSymlinkByDefault(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	targetPath := filepath.Join(nestedDir, "source.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte("steps: []\n"), 0600))
+	if err := os.Symlink(targetPath, filepath.Join(root, "linked.yaml")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	result, err := Scan(root, Options{})
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Files, 1)
+	assert.Equal(t, "linked.yaml", result.Files[0].RelPath)
+}
+
+func TestScanNonRecursiveExternalFileSymlink(t *testing.T) {
+	root := t.TempDir()
+	externalDir := t.TempDir()
+	externalFile := filepath.Join(externalDir, "external.yaml")
+	require.NoError(t, os.WriteFile(externalFile, []byte("steps: []\n"), 0600))
+	if err := os.Symlink(externalFile, filepath.Join(root, "external.yaml")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	result, err := Scan(root, Options{})
+	require.NoError(t, err)
+	require.Empty(t, result.Files)
+	require.Len(t, result.Errors, 1)
+	assert.ErrorIs(t, result.Errors[0], ErrExternalSymlinkDisabled)
+
+	result, err = Scan(root, Options{Symlinks: true})
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Files, 1)
+	assert.Equal(t, "external.yaml", result.Files[0].RelPath)
+	expectedExternalFile, err := filepath.EvalSymlinks(externalFile)
+	require.NoError(t, err)
+	assert.Equal(t, expectedExternalFile, result.Files[0].ResolvedPath)
 }
 
 func TestScanRecursiveAllowsConfiguredSymlinkRoot(t *testing.T) {
@@ -83,7 +150,7 @@ func TestScanRecursiveAllowsConfiguredSymlinkRoot(t *testing.T) {
 		t.Skipf("symlinks are unavailable: %v", err)
 	}
 
-	result, err := Scan(linkRoot, true)
+	result, err := Scan(linkRoot, Options{Recursive: true})
 	require.NoError(t, err)
 	require.Empty(t, result.Errors)
 	require.Len(t, result.Files, 1)

--- a/internal/dagstore/dag.go
+++ b/internal/dagstore/dag.go
@@ -25,6 +25,7 @@ type DAGLoadOptions struct {
 var (
 	ErrDAGAlreadyExists = errors.New("DAG already exists")
 	ErrDAGNotFound      = errors.New("DAG is not found")
+	ErrDAGReadOnly      = errors.New("DAG definition is read-only")
 )
 
 // DAGStore is an interface for interacting with underlying DAG storage systems.

--- a/internal/persis/file/dag/catalog.go
+++ b/internal/persis/file/dag/catalog.go
@@ -21,7 +21,10 @@ type catalog struct {
 }
 
 func (store *Storage) loadCatalog(ctx context.Context) (*catalog, error) {
-	scan, err := dagdiscovery.Scan(store.baseDir, store.recursive)
+	scan, err := dagdiscovery.Scan(store.baseDir, dagdiscovery.Options{
+		Recursive: store.recursive,
+		Symlinks:  store.symlinks,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +102,13 @@ func entryStem(entry *indexv1.DAGIndexEntry) string {
 	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
-func (store *Storage) entryPath(entry *indexv1.DAGIndexEntry) string {
-	return filepath.Join(store.baseDir, filepath.FromSlash(entry.FilePath))
+func (store *Storage) entryLoadPath(entry *indexv1.DAGIndexEntry) (string, error) {
+	resolved, err := dagdiscovery.ResolveFile(store.baseDir, filepath.FromSlash(entry.FilePath))
+	if err != nil {
+		return "", err
+	}
+	if resolved.ExternalSymlink && !store.symlinks {
+		return "", fmt.Errorf("DAG file symlink resolves outside the configured DAG directory")
+	}
+	return resolved.ResolvedPath, nil
 }

--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -23,7 +23,7 @@ const (
 	// IndexFileName is the name of the DAG definition index file.
 	IndexFileName = ".dag.index"
 	// IndexVersion is the current index format version.
-	IndexVersion = 2
+	IndexVersion = 3
 )
 
 // YAMLFileMeta holds stat metadata for a single YAML file.
@@ -69,7 +69,7 @@ func Load(indexPath string, yamlFiles []YAMLFileMeta, flags SuspendFlags) []*ind
 		if !ok {
 			return nil
 		}
-		if e.FileSize != f.Size || e.ModTime != f.ModTime {
+		if e.FileSize != f.Size || e.ModTime != f.ModTime || e.LoadPath != f.LoadPath {
 			return nil
 		}
 	}
@@ -108,6 +108,7 @@ func Build(
 			FilePath: f.Name,
 			FileSize: f.Size,
 			ModTime:  f.ModTime,
+			LoadPath: f.LoadPath,
 		}
 		buildEntry(ctx, yamlFilePath(dagDir, f), entry, flags, loadOpts...)
 		idx.Entries = append(idx.Entries, entry)
@@ -184,14 +185,15 @@ func RefreshFailures(
 		if ctx.Err() != nil {
 			break
 		}
+		file := filesByName[entry.FilePath]
+		if file.Name == "" {
+			file.Name = entry.FilePath
+		}
 		refreshed := &indexv1.DAGIndexEntry{
 			FilePath: entry.FilePath,
 			FileSize: entry.FileSize,
 			ModTime:  entry.ModTime,
-		}
-		file := filesByName[entry.FilePath]
-		if file.Name == "" {
-			file.Name = entry.FilePath
+			LoadPath: file.LoadPath,
 		}
 		buildEntry(ctx, yamlFilePath(dagDir, file), refreshed, flags, loadOpts...)
 		if proto.Equal(entry, refreshed) {

--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -28,9 +28,10 @@ const (
 
 // YAMLFileMeta holds stat metadata for a single YAML file.
 type YAMLFileMeta struct {
-	Name    string // Slash-normalized path relative to the DAG directory.
-	Size    int64
-	ModTime int64 // UnixNano
+	Name     string // Slash-normalized path relative to the DAG directory.
+	LoadPath string // Canonical path used to read the current file.
+	Size     int64
+	ModTime  int64 // UnixNano
 }
 
 // SuspendFlags is the set of suspend flag filenames present in flagsBaseDir.
@@ -108,7 +109,7 @@ func Build(
 			FileSize: f.Size,
 			ModTime:  f.ModTime,
 		}
-		buildEntry(ctx, dagDir, entry, flags, loadOpts...)
+		buildEntry(ctx, yamlFilePath(dagDir, f), entry, flags, loadOpts...)
 		idx.Entries = append(idx.Entries, entry)
 	}
 
@@ -119,7 +120,7 @@ func Build(
 // recording why the file could not be read when that happens.
 func buildEntry(
 	ctx context.Context,
-	dagDir string,
+	filePath string,
 	entry *indexv1.DAGIndexEntry,
 	flags SuspendFlags,
 	loadOpts ...spec.LoadOption,
@@ -133,7 +134,7 @@ func buildEntry(
 		spec.WithAllowBuildErrors(),
 	)
 
-	dag, err := spec.Load(ctx, filepath.Join(dagDir, filepath.FromSlash(entry.FilePath)), opts...)
+	dag, err := spec.Load(ctx, filePath, opts...)
 	if err != nil {
 		base := filepath.Base(filepath.FromSlash(entry.FilePath))
 		entry.Name = strings.TrimSuffix(base, filepath.Ext(base))
@@ -165,10 +166,16 @@ func buildEntry(
 func RefreshFailures(
 	ctx context.Context,
 	dagDir string,
+	yamlFiles []YAMLFileMeta,
 	entries []*indexv1.DAGIndexEntry,
 	flags SuspendFlags,
 	loadOpts ...spec.LoadOption,
 ) bool {
+	filesByName := make(map[string]YAMLFileMeta, len(yamlFiles))
+	for _, file := range yamlFiles {
+		filesByName[file.Name] = file
+	}
+
 	var changed bool
 	for i, entry := range entries {
 		if entry.LoadError == "" {
@@ -182,7 +189,11 @@ func RefreshFailures(
 			FileSize: entry.FileSize,
 			ModTime:  entry.ModTime,
 		}
-		buildEntry(ctx, dagDir, refreshed, flags, loadOpts...)
+		file := filesByName[entry.FilePath]
+		if file.Name == "" {
+			file.Name = entry.FilePath
+		}
+		buildEntry(ctx, yamlFilePath(dagDir, file), refreshed, flags, loadOpts...)
 		if proto.Equal(entry, refreshed) {
 			continue
 		}
@@ -190,6 +201,13 @@ func RefreshFailures(
 		changed = true
 	}
 	return changed
+}
+
+func yamlFilePath(dagDir string, file YAMLFileMeta) string {
+	if file.LoadPath != "" {
+		return file.LoadPath
+	}
+	return filepath.Join(dagDir, filepath.FromSlash(file.Name))
 }
 
 // NewIndex wraps entries in an index ready to be written.

--- a/internal/persis/file/dag/dagindex/refresh_test.go
+++ b/internal/persis/file/dag/dagindex/refresh_test.go
@@ -31,7 +31,7 @@ func TestRefreshFailures_ClearsAnErrorAnOlderBuildRecorded(t *testing.T) {
 		LoadError: "decoding failed due to the following error(s): 'spec.dag' has invalid keys: tasks",
 	}}
 
-	changed := dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+	changed := dagindex.RefreshFailures(t.Context(), dir, nil, entries, dagindex.SuspendFlags{})
 
 	assert.True(t, changed, "the correction must be persisted")
 	assert.Empty(t, entries[0].LoadError, "the stale error is dropped once the file parses")
@@ -53,7 +53,7 @@ func TestRefreshFailures_KeepsARealError(t *testing.T) {
 		LoadError: "some older message",
 	}}
 
-	dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+	dagindex.RefreshFailures(t.Context(), dir, nil, entries, dagindex.SuspendFlags{})
 	assert.NotEmpty(t, entries[0].LoadError)
 }
 
@@ -69,13 +69,13 @@ func TestRefreshFailures_ReportsMetadataChangesUnderAnUnchangedError(t *testing.
 		[]byte("type: nonsense\nsteps:\n  - name: a\n    run: echo a\n"), 0o600))
 
 	entries := []*indexv1.DAGIndexEntry{{FilePath: "bad.yaml", LoadError: "placeholder"}}
-	require.True(t, dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{}))
+	require.True(t, dagindex.RefreshFailures(t.Context(), dir, nil, entries, dagindex.SuspendFlags{}))
 	require.NotEmpty(t, entries[0].LoadError, "the file is expected to stay unloadable")
 
 	// Same error, metadata only the previous parser produced.
 	entries[0].Labels = []string{"team=infra"}
 
-	changed := dagindex.RefreshFailures(t.Context(), dir, entries, dagindex.SuspendFlags{})
+	changed := dagindex.RefreshFailures(t.Context(), dir, nil, entries, dagindex.SuspendFlags{})
 
 	assert.True(t, changed, "a metadata-only correction still has to be persisted")
 	assert.Empty(t, entries[0].Labels)
@@ -89,7 +89,7 @@ func TestRefreshFailures_LeavesHealthyEntriesAlone(t *testing.T) {
 	entries := []*indexv1.DAGIndexEntry{{FilePath: "gone.yaml", Name: "cached"}}
 
 	changed := dagindex.RefreshFailures(
-		t.Context(), t.TempDir(), entries, dagindex.SuspendFlags{})
+		t.Context(), t.TempDir(), nil, entries, dagindex.SuspendFlags{})
 
 	assert.False(t, changed)
 	assert.Equal(t, "cached", entries[0].Name, "a healthy entry is served from cache")

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -412,7 +412,7 @@ func (store *Storage) Delete(ctx context.Context, name string) error {
 	if resolved.ExternalSymlink {
 		return fmt.Errorf("%w: external DAG file symlink", dagstore.ErrDAGReadOnly)
 	}
-	if err := fileutil.Remove(resolved.ResolvedPath); err != nil {
+	if err := fileutil.Remove(resolved.EntryPath); err != nil {
 		return err
 	}
 	if store.fileCache != nil {
@@ -997,7 +997,7 @@ func (store *Storage) Rename(ctx context.Context, oldID, newID string) error {
 	if resolved.ExternalSymlink {
 		return fmt.Errorf("%w: external DAG file symlink", dagstore.ErrDAGReadOnly)
 	}
-	oldFilePath := resolved.ResolvedPath
+	oldFilePath := resolved.EntryPath
 	newFilePath := store.generateFilePath(newID)
 	exceptPath := ""
 	if store.recursive {

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -46,6 +46,7 @@ type Options struct {
 	WorkspaceBaseConfigDir string                   // Optional directory containing workspace base configs
 	SkipExamples           bool                     // Skip creating example DAGs
 	Recursive              bool                     // Discover DAG definitions in subdirectories
+	Symlinks               bool                     // Include recursive file symlinks and external targets
 	SkipDirectoryCreation  bool                     // Skip creating base directory for execution-scoped stores
 }
 
@@ -53,6 +54,13 @@ type Options struct {
 func WithRecursiveDiscovery(recursive bool) Option {
 	return func(o *Options) {
 		o.Recursive = recursive
+	}
+}
+
+// WithSymlinks includes file symlinks in recursive discovery and permits external targets.
+func WithSymlinks(enabled bool) Option {
+	return func(o *Options) {
+		o.Symlinks = enabled
 	}
 }
 
@@ -138,6 +146,7 @@ func New(baseDir string, opts ...Option) dagstore.DAGStore {
 		baseConfigState:        describeBaseConfigStateSet(options.BaseConfigPath, options.WorkspaceBaseConfigDir),
 		skipExamples:           options.SkipExamples,
 		recursive:              options.Recursive,
+		symlinks:               options.Symlinks,
 		skipDirectoryCreation:  options.SkipDirectoryCreation,
 	}
 }
@@ -153,6 +162,7 @@ type Storage struct {
 	baseConfigState        string                   // Last observed base config state for cache/index invalidation
 	skipExamples           bool                     // Skip creating example DAGs
 	recursive              bool                     // Discover DAG definitions in subdirectories
+	symlinks               bool                     // Include recursive file symlinks and external targets
 	skipDirectoryCreation  bool                     // Skip creating base directory for execution-scoped stores
 	baseConfigMu           sync.Mutex               // Protects base config state refresh and invalidation
 	indexMu                sync.Mutex               // Protects index load/rebuild/invalidate
@@ -279,7 +289,7 @@ func (store *Storage) Initialize() error {
 
 // GetMetadata retrieves the metadata of a DAG by its name.
 func (store *Storage) GetMetadata(ctx context.Context, name string) (*ir.DAG, error) {
-	filePath, err := store.locateDAG(ctx, name)
+	resolved, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate DAG %s in search paths (%v): %w", name, store.searchPaths, err)
 	}
@@ -290,10 +300,10 @@ func (store *Storage) GetMetadata(ctx context.Context, name string) (*ir.DAG, er
 		spec.SkipSchemaValidation(),
 	)
 	if !store.useCachedLoads() {
-		return spec.Load(ctx, filePath, loadOpts...)
+		return spec.Load(ctx, resolved.ResolvedPath, loadOpts...)
 	}
-	return store.fileCache.LoadLatest(filePath, func() (*ir.DAG, error) {
-		return spec.Load(ctx, filePath, loadOpts...)
+	return store.fileCache.LoadLatest(resolved.ResolvedPath, func() (*ir.DAG, error) {
+		return spec.Load(ctx, resolved.ResolvedPath, loadOpts...)
 	})
 }
 
@@ -307,14 +317,14 @@ func specLoadOptions(opts dagstore.DAGLoadOptions) []spec.LoadOption {
 
 // GetDetails retrieves the details of a DAG by its name.
 func (store *Storage) GetDetails(ctx context.Context, name string, opts dagstore.DAGLoadOptions) (*ir.DAG, error) {
-	filePath, err := store.locateDAG(ctx, name)
+	resolved, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
 	loadOpts := store.defaultLoadOptions(specLoadOptions(opts)...)
 	loadOpts = append(loadOpts, spec.WithoutEval())
 
-	dat, err := spec.Load(ctx, filePath, loadOpts...)
+	dat, err := spec.Load(ctx, resolved.ResolvedPath, loadOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load DAG %s: %w", name, err)
 	}
@@ -323,11 +333,11 @@ func (store *Storage) GetDetails(ctx context.Context, name string, opts dagstore
 
 // GetSpec retrieves the specification of a DAG by its name.
 func (store *Storage) GetSpec(ctx context.Context, name string) (string, error) {
-	filePath, err := store.locateDAG(ctx, name)
+	resolved, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return "", dagstore.ErrDAGNotFound
 	}
-	dat, err := fileutil.ReadFile(filePath)
+	dat, err := fileutil.ReadFile(resolved.ResolvedPath)
 	if err != nil {
 		return "", err
 	}
@@ -357,15 +367,18 @@ func (store *Storage) UpdateSpec(ctx context.Context, name string, yamlSpec []by
 	if err := dag.Validate(); err != nil {
 		return err
 	}
-	filePath, err := store.locateDAG(ctx, name)
+	resolved, err := store.locateDAG(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
-	if err := fileutil.WriteFileAtomic(filePath, yamlSpec, defaultPerm); err != nil {
+	if resolved.ExternalSymlink {
+		return fmt.Errorf("%w: external DAG file symlink", dagstore.ErrDAGReadOnly)
+	}
+	if err := fileutil.WriteFileAtomic(resolved.ResolvedPath, yamlSpec, defaultPerm); err != nil {
 		return err
 	}
 	if store.fileCache != nil {
-		store.fileCache.Invalidate(filePath)
+		store.fileCache.Invalidate(resolved.ResolvedPath)
 	}
 	store.invalidateIndex()
 	return nil
@@ -389,18 +402,21 @@ func (store *Storage) Create(_ context.Context, name string, spec []byte) error 
 
 // Delete deletes a DAG by its name.
 func (store *Storage) Delete(ctx context.Context, name string) error {
-	filePath, err := store.locateDAG(ctx, name)
+	resolved, err := store.locateDAG(ctx, name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
-	if err := fileutil.Remove(filePath); err != nil {
+	if resolved.ExternalSymlink {
+		return fmt.Errorf("%w: external DAG file symlink", dagstore.ErrDAGReadOnly)
+	}
+	if err := fileutil.Remove(resolved.ResolvedPath); err != nil {
 		return err
 	}
 	if store.fileCache != nil {
-		store.fileCache.Invalidate(filePath)
+		store.fileCache.Invalidate(resolved.ResolvedPath)
 	}
 	store.invalidateIndex()
 	return nil
@@ -419,7 +435,7 @@ func (store *Storage) ensureDirExist() error {
 		_ = store.createExampleDAGs() // Errors are logged internally
 	} else {
 		// Check if directory is empty and create examples if needed
-		if shouldCreateExamples(store.baseDir, store.recursive) {
+		if shouldCreateExamples(store.baseDir, store.recursive, store.symlinks) {
 			_ = store.createExampleDAGs() // Errors are logged internally
 		}
 	}
@@ -436,9 +452,10 @@ func (store *Storage) loadIndex(ctx context.Context, files []dagdiscovery.File) 
 	yamlFiles := make([]dagindex.YAMLFileMeta, 0, len(files))
 	for _, file := range files {
 		yamlFiles = append(yamlFiles, dagindex.YAMLFileMeta{
-			Name:    file.RelPath,
-			Size:    file.Size,
-			ModTime: file.ModTime,
+			Name:     file.RelPath,
+			LoadPath: file.ResolvedPath,
+			Size:     file.Size,
+			ModTime:  file.ModTime,
 		})
 	}
 
@@ -451,7 +468,7 @@ func (store *Storage) loadIndex(ctx context.Context, files []dagdiscovery.File) 
 	// current parser before it is served, so upgrading Dagu clears errors that
 	// only an older build produced.
 	if cached := dagindex.Load(indexPath, yamlFiles, flags); cached != nil {
-		if dagindex.RefreshFailures(ctx, store.baseDir, cached, flags, store.defaultLoadOptions()...) {
+		if dagindex.RefreshFailures(ctx, store.baseDir, yamlFiles, cached, flags, store.defaultLoadOptions()...) {
 			if err := dagindex.Write(indexPath, dagindex.NewIndex(cached)); err != nil {
 				logger.Warn(ctx, "Failed to write DAG definition index", tag.Error(err))
 			}
@@ -696,7 +713,11 @@ func (store *Storage) Grep(ctx context.Context, pattern string) (
 	errs = append(errs, catalog.errors...)
 
 	for _, entry := range catalog.entries {
-		filePath := store.entryPath(entry)
+		filePath, err := store.entryLoadPath(entry)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("resolve %s failed: %s", entry.FilePath, err))
+			continue
+		}
 		dat, err := fileutil.ReadFile(filePath)
 		if err != nil {
 			logger.Error(ctx, "Failed to read DAG file",
@@ -770,7 +791,11 @@ func (store *Storage) SearchCursor(ctx context.Context, opts dagstore.SearchDAGs
 			continue
 		}
 
-		filePath := store.entryPath(entry)
+		filePath, err := store.entryLoadPath(entry)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("resolve %s failed: %s", entry.FilePath, err))
+			continue
+		}
 		var dag *ir.DAG
 		if len(opts.Labels) > 0 || opts.WorkspaceFilter != nil {
 			dag, err = spec.Load(ctx, filePath, store.defaultLoadOptions(
@@ -880,12 +905,12 @@ func (store *Storage) SearchMatches(ctx context.Context, fileName string, opts d
 		return nil, err
 	}
 
-	filePath, err := store.locateDAG(ctx, fileName)
+	resolved, err := store.locateDAG(ctx, fileName)
 	if err != nil {
 		return nil, dagstore.ErrDAGNotFound
 	}
 
-	dat, err := fileutil.ReadFile(filePath)
+	dat, err := fileutil.ReadFile(resolved.ResolvedPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, dagstore.ErrDAGNotFound
@@ -893,7 +918,7 @@ func (store *Storage) SearchMatches(ctx context.Context, fileName string, opts d
 		return nil, err
 	}
 	if len(opts.Labels) > 0 || opts.WorkspaceFilter != nil {
-		dag, err := spec.Load(ctx, filePath, store.defaultLoadOptions(
+		dag, err := spec.Load(ctx, resolved.ResolvedPath, store.defaultLoadOptions(
 			spec.OnlyMetadata(),
 			spec.WithoutEval(),
 			spec.SkipSchemaValidation(),
@@ -965,10 +990,14 @@ func fileName(id string) string {
 
 // Rename renames a DAG from oldID to newID.
 func (store *Storage) Rename(ctx context.Context, oldID, newID string) error {
-	oldFilePath, err := store.locateDAG(ctx, oldID)
+	resolved, err := store.locateDAG(ctx, oldID)
 	if err != nil {
 		return fmt.Errorf("failed to locate DAG %s: %w", oldID, err)
 	}
+	if resolved.ExternalSymlink {
+		return fmt.Errorf("%w: external DAG file symlink", dagstore.ErrDAGReadOnly)
+	}
+	oldFilePath := resolved.ResolvedPath
 	newFilePath := store.generateFilePath(newID)
 	exceptPath := ""
 	if store.recursive {
@@ -1003,35 +1032,40 @@ func (store *Storage) generateFilePath(name string) string {
 }
 
 // locateDAG resolves a DAG beneath the configured DAG directories.
-func (store *Storage) locateDAG(ctx context.Context, nameOrPath string) (string, error) {
+func (store *Storage) locateDAG(ctx context.Context, nameOrPath string) (dagdiscovery.ResolvedFile, error) {
 	relativePath := filepath.FromSlash(nameOrPath)
 	explicitPath := filepath.IsAbs(relativePath) || strings.ContainsAny(nameOrPath, `/\`)
 
 	if store.recursive && !explicitPath {
 		catalog, err := store.loadCatalog(ctx)
 		if err != nil {
-			return "", fmt.Errorf("failed to discover DAGs: %w", err)
+			return dagdiscovery.ResolvedFile{}, fmt.Errorf("failed to discover DAGs: %w", err)
 		}
 		fileName := fileutil.TrimYAMLFileExtension(filepath.Base(relativePath))
 		if entry, ok := catalog.byStem[fileName]; ok {
-			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(
+			resolved, err := dagdiscovery.ResolveFile(
 				store.baseDir,
 				filepath.FromSlash(entry.FilePath),
 			)
-			if err == nil {
-				return resolvedPath, nil
+			if err == nil && (!resolved.ExternalSymlink || store.symlinks) {
+				return resolved, nil
 			}
 		}
 		if len(store.searchPaths) > 1 {
-			return locateDAGInDirectories(nameOrPath, store.searchPaths[1:])
+			return locateDAGInDirectories(nameOrPath, store.searchPaths[1:], store.symlinks)
 		}
-		return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
+		return dagdiscovery.ResolvedFile{}, fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
 	}
 
-	return locateDAGInDirectories(nameOrPath, store.searchPaths)
+	return locateDAGInDirectories(nameOrPath, store.searchPaths, store.symlinks)
 }
 
-func locateDAGInDirectories(nameOrPath string, directories []string) (string, error) {
+func locateDAGInDirectories(
+	nameOrPath string,
+	directories []string,
+	symlinks bool,
+) (dagdiscovery.ResolvedFile, error) {
+	var externalSymlinkDisabled bool
 	for _, dir := range directories {
 		absDir, err := filepath.Abs(dir)
 		if err != nil {
@@ -1047,19 +1081,35 @@ func locateDAGInDirectories(nameOrPath string, directories []string) (string, er
 		}
 
 		for _, candidatePath := range dagFileCandidates(relativePath) {
-			resolvedPath, err := fileutil.ResolveExistingPathWithinBase(absDir, candidatePath)
-			if err == nil {
-				return resolvedPath, nil
+			resolved, err := dagdiscovery.ResolveFile(absDir, candidatePath)
+			if err != nil {
+				continue
 			}
+			if resolved.ExternalSymlink && !symlinks {
+				externalSymlinkDisabled = true
+				continue
+			}
+			return resolved, nil
 		}
 	}
 
+	if externalSymlinkDisabled {
+		return dagdiscovery.ResolvedFile{}, fmt.Errorf(
+			"DAG %s uses an external file symlink; enable dag_discovery.symlinks: %w",
+			nameOrPath,
+			errors.Join(dagdiscovery.ErrExternalSymlinkDisabled, os.ErrNotExist),
+		)
+	}
+
 	// DAG not found
-	return "", fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
+	return dagdiscovery.ResolvedFile{}, fmt.Errorf("DAG %s not found: %w", nameOrPath, os.ErrNotExist)
 }
 
 func (store *Storage) stemExists(name, exceptPath string) bool {
-	scan, err := dagdiscovery.Scan(store.baseDir, true)
+	scan, err := dagdiscovery.Scan(store.baseDir, dagdiscovery.Options{
+		Recursive: true,
+		Symlinks:  store.symlinks,
+	})
 	if err != nil {
 		return false
 	}
@@ -1198,14 +1248,17 @@ func fileExists(file string) bool {
 }
 
 // shouldCreateExamples checks if we should create example DAGs
-func shouldCreateExamples(dir string, recursive bool) bool {
+func shouldCreateExamples(dir string, recursive, symlinks bool) bool {
 	// Check for marker file that indicates examples were already created
 	markerFile := filepath.Join(dir, ".examples-created")
 	if fileExists(markerFile) {
 		return false
 	}
 
-	scan, err := dagdiscovery.Scan(dir, recursive)
+	scan, err := dagdiscovery.Scan(dir, dagdiscovery.Options{
+		Recursive: recursive,
+		Symlinks:  symlinks,
+	})
 	if err != nil {
 		return false
 	}

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -489,6 +489,55 @@ func TestGetSpecRejectsSymlinkOutsideConfiguredDirectories(t *testing.T) {
 	assert.ErrorIs(t, err, dagstore.ErrDAGNotFound)
 }
 
+func TestExternalDAGFileSymlink(t *testing.T) {
+	baseDir := t.TempDir()
+	targetDir := t.TempDir()
+	const dagContent = "name: external\nsteps:\n  - run: echo external\n"
+	targetPath := filepath.Join(targetDir, "source.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte(dagContent), 0600))
+	linkPath := filepath.Join(baseDir, "external.yaml")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	t.Run("Disabled", func(t *testing.T) {
+		store := New(baseDir, WithSkipExamples(true))
+		result, issues, err := store.List(context.Background(), dagstore.ListDAGsOptions{})
+		require.NoError(t, err)
+		require.Empty(t, result.Items)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0], "dag_discovery.symlinks")
+
+		_, err = store.GetSpec(context.Background(), "external")
+		assert.ErrorIs(t, err, dagstore.ErrDAGNotFound)
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		store := New(baseDir, WithSkipExamples(true), WithSymlinks(true))
+		result, issues, err := store.List(context.Background(), dagstore.ListDAGsOptions{})
+		require.NoError(t, err)
+		require.Empty(t, issues)
+		require.Len(t, result.Items, 1)
+		assert.Equal(t, "external", result.Items[0].Name)
+
+		spec, err := store.GetSpec(context.Background(), "external")
+		require.NoError(t, err)
+		assert.Equal(t, dagContent, spec)
+		_, err = store.GetDetails(context.Background(), "external", dagstore.DAGLoadOptions{})
+		require.NoError(t, err)
+
+		assert.ErrorIs(t, store.UpdateSpec(context.Background(), "external", []byte(dagContent)), dagstore.ErrDAGReadOnly)
+		assert.ErrorIs(t, store.Delete(context.Background(), "external"), dagstore.ErrDAGReadOnly)
+		assert.ErrorIs(t, store.Rename(context.Background(), "external", "renamed"), dagstore.ErrDAGReadOnly)
+
+		_, err = os.Lstat(linkPath)
+		require.NoError(t, err)
+		content, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, dagContent, string(content))
+	})
+}
+
 func TestGetSpecAllowsExplicitSearchPaths(t *testing.T) {
 	baseDir := t.TempDir()
 	searchDir := t.TempDir()

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -538,6 +538,40 @@ func TestExternalDAGFileSymlink(t *testing.T) {
 	})
 }
 
+func TestListRebuildsIndexAfterSymlinkRepoint(t *testing.T) {
+	baseDir := t.TempDir()
+	targetDir := t.TempDir()
+	firstPath := filepath.Join(targetDir, "first.yaml")
+	secondPath := filepath.Join(targetDir, "second.yaml")
+	firstSpec := []byte("name: first\nsteps:\n  - run: echo one\n")
+	secondSpec := []byte("name: other\nsteps:\n  - run: echo two\n")
+	require.Len(t, secondSpec, len(firstSpec))
+	require.NoError(t, os.WriteFile(firstPath, firstSpec, 0600))
+	require.NoError(t, os.WriteFile(secondPath, secondSpec, 0600))
+	modTime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(firstPath, modTime, modTime))
+	require.NoError(t, os.Chtimes(secondPath, modTime, modTime))
+
+	linkPath := filepath.Join(baseDir, "linked.yaml")
+	if err := os.Symlink(firstPath, linkPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	store := New(baseDir, WithSkipExamples(true), WithSymlinks(true))
+	result, issues, err := store.List(context.Background(), dagstore.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, issues)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "first", result.Items[0].Name)
+
+	require.NoError(t, os.Remove(linkPath))
+	require.NoError(t, os.Symlink(secondPath, linkPath))
+	result, issues, err = store.List(context.Background(), dagstore.ListDAGsOptions{})
+	require.NoError(t, err)
+	require.Empty(t, issues)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "other", result.Items[0].Name)
+}
+
 func TestGetSpecAllowsExplicitSearchPaths(t *testing.T) {
 	baseDir := t.TempDir()
 	searchDir := t.TempDir()
@@ -939,6 +973,19 @@ steps:
 	// Test deleting non-existent DAG (should not error)
 	err = store.Delete(ctx, "non-existent")
 	require.NoError(t, err)
+
+	targetDir := filepath.Join(tmpDir, "targets")
+	require.NoError(t, os.MkdirAll(targetDir, 0750))
+	targetPath := filepath.Join(targetDir, "linked-delete.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte(dagContent), 0600))
+	linkPath := filepath.Join(tmpDir, "linked-delete.yaml")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	require.NoError(t, store.Delete(ctx, "linked-delete"))
+	_, err = os.Lstat(linkPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.FileExists(t, targetPath)
 }
 
 func TestRename(t *testing.T) {
@@ -986,6 +1033,23 @@ steps:
 	err = store.Rename(ctx, "new-name", "another-dag")
 	require.Error(t, err)
 	assert.Equal(t, dagstore.ErrDAGAlreadyExists, err)
+
+	targetDir := filepath.Join(tmpDir, "targets")
+	require.NoError(t, os.MkdirAll(targetDir, 0750))
+	targetPath := filepath.Join(targetDir, "linked-target.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte(dagContent), 0600))
+	linkPath := filepath.Join(tmpDir, "linked-old.yaml")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	require.NoError(t, store.Rename(ctx, "linked-old", "linked-new"))
+	_, err = os.Lstat(linkPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	renamedPath := filepath.Join(tmpDir, "linked-new.yaml")
+	info, err := os.Lstat(renamedPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	assert.FileExists(t, targetPath)
 }
 
 func TestGrep(t *testing.T) {

--- a/internal/persis/file/dag_store.go
+++ b/internal/persis/file/dag_store.go
@@ -22,6 +22,7 @@ type DAGStoreOptions struct {
 	Cache                 *fileutil.Cache[*ir.DAG]
 	SearchPaths           []string
 	SkipExamples          *bool
+	Symlinks              bool
 	SkipDirectoryCreation bool
 }
 
@@ -46,6 +47,13 @@ func WithDAGSkipExamples(skip bool) DAGStoreOption {
 	}
 }
 
+// WithDAGSymlinks includes file symlinks in recursive discovery and permits external targets.
+func WithDAGSymlinks(enabled bool) DAGStoreOption {
+	return func(o *DAGStoreOptions) {
+		o.Symlinks = enabled
+	}
+}
+
 // WithDAGSkipDirectoryCreation controls whether the DAG directory is created on startup.
 func WithDAGSkipDirectoryCreation(skip bool) DAGStoreOption {
 	return func(o *DAGStoreOptions) {
@@ -55,7 +63,7 @@ func WithDAGSkipDirectoryCreation(skip bool) DAGStoreOption {
 
 // NewDAGStore wires the file-backed DAG definition store from application config.
 func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (dagstore.DAGStore, error) {
-	options := DAGStoreOptions{}
+	options := DAGStoreOptions{Symlinks: cfg.DAGDiscovery.Symlinks}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&options)
@@ -75,6 +83,7 @@ func NewDAGStore(cfg *config.Config, opts ...DAGStoreOption) (dagstore.DAGStore,
 		filedag.WithFileCache(options.Cache),
 		filedag.WithSkipExamples(skipExamples),
 		filedag.WithRecursiveDiscovery(cfg.DAGDiscovery.Recursive),
+		filedag.WithSymlinks(options.Symlinks),
 		filedag.WithSkipDirectoryCreation(options.SkipDirectoryCreation),
 	)
 	if s, ok := store.(*filedag.Storage); ok {

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -768,6 +768,9 @@ func (a *API) resolveError(err error) (api.ErrorCode, string, int) {
 	if errors.Is(err, dagstore.ErrDAGAlreadyExists) {
 		return api.ErrorCodeAlreadyExists, "DAG already exists", http.StatusConflict
 	}
+	if errors.Is(err, dagstore.ErrDAGReadOnly) {
+		return api.ErrorCodeForbidden, "DAG definition is read-only because it is managed through an external file symlink", http.StatusForbidden
+	}
 
 	return api.ErrorCodeInternalError, "An unexpected error occurred", http.StatusInternalServerError
 }

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -942,6 +942,45 @@ steps:
 	}, dagRunEventuallyTimeout(5*time.Second), 200*time.Millisecond)
 }
 
+func TestExternalDAGFileSymlinkAPI(t *testing.T) {
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.DAGDiscovery.Symlinks = true
+	}))
+
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "source.yaml")
+	dagSpec := fmt.Sprintf(`
+name: external-link
+steps:
+  - %s
+`, test.ShellQuote("exit 0"))
+	require.NoError(t, os.WriteFile(targetPath, []byte(dagSpec), 0600))
+	if err := os.Symlink(targetPath, filepath.Join(server.Config.Paths.DAGsDir, "external-link.yaml")); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	server.Client().Get("/api/v1/dags/external-link").
+		ExpectStatus(http.StatusOK).Send(t)
+	resp := server.Client().Post(
+		"/api/v1/dags/external-link/enqueue",
+		api.EnqueueDAGDAGRunJSONRequestBody{},
+	).ExpectStatus(http.StatusOK).Send(t)
+	var enqueueBody api.EnqueueDAGDAGRun200JSONResponse
+	resp.Unmarshal(t, &enqueueBody)
+	require.NotEmpty(t, enqueueBody.DagRunId)
+
+	resp = server.Client().Put("/api/v1/dags/external-link/spec", api.UpdateDAGSpecJSONRequestBody{
+		Spec: dagSpec,
+	}).ExpectStatus(http.StatusForbidden).Send(t)
+	var errorBody api.Error
+	resp.Unmarshal(t, &errorBody)
+	assert.Equal(t, api.ErrorCodeForbidden, errorBody.Code)
+	assert.Contains(t, errorBody.Message, "external file symlink")
+
+	server.Client().Delete("/api/v1/dags/external-link").
+		ExpectStatus(http.StatusForbidden).Send(t)
+}
+
 type stubSchedulerStateStore struct {
 	state *scheduler.SchedulerState
 }

--- a/internal/service/scheduler/dag_file_source.go
+++ b/internal/service/scheduler/dag_file_source.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/dagdiscovery"
+	"github.com/dagucloud/dagu/v2/internal/dagstore"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/spec"
 )
@@ -38,10 +40,16 @@ type dagFileSnapshot struct {
 }
 
 // newDAGFileSource creates the production DAG file source for a watched directory.
-func newDAGFileSource(dir string) *dagFileSource {
+func newDAGFileSource(dir string, store dagstore.DAGStore) *dagFileSource {
+	load := loadDAGMetadata
+	if store != nil {
+		load = func(ctx context.Context, filePath string) (*ir.DAG, error) {
+			return store.GetMetadata(ctx, filePath)
+		}
+	}
 	return &dagFileSource{
 		dir:  dir,
-		load: loadDAGMetadata,
+		load: load,
 	}
 }
 
@@ -67,7 +75,7 @@ func (s *dagFileSource) snapshot(ctx context.Context, fileName string) (dagFileS
 			return dagFileSnapshot{dag: dag, exists: true}, nil
 		}
 
-		if !errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, dagdiscovery.ErrExternalSymlinkDisabled) || !errors.Is(err, os.ErrNotExist) {
 			return dagFileSnapshot{}, err
 		}
 		if attempt >= dagFileSnapshotRetries {

--- a/internal/service/scheduler/entryreader.go
+++ b/internal/service/scheduler/entryreader.go
@@ -81,7 +81,7 @@ func NewEntryReader(dir string, dagCli dagstore.DAGStore, recursive bool) EntryR
 		stamps:      make(map[string]dagFileStamp),
 		watchedDirs: make(map[string]struct{}),
 		dagStore:    dagCli,
-		dagSource:   newDAGFileSource(dir),
+		dagSource:   newDAGFileSource(dir, dagCli),
 		recursive:   recursive,
 		quit:        make(chan struct{}),
 	}
@@ -355,7 +355,7 @@ func (er *entryReaderImpl) DAGStore() dagstore.DAGStore {
 func (er *entryReaderImpl) initRecursive(ctx context.Context) error {
 	er.watcher = filenotify.New(time.Minute)
 
-	scan, err := dagdiscovery.Scan(er.targetDir, true)
+	scan, err := dagdiscovery.Scan(er.targetDir, dagdiscovery.Options{Recursive: true})
 	if err != nil {
 		_ = er.watcher.Close()
 		return fmt.Errorf("failed to initialize recursive DAGs: %w", err)
@@ -389,7 +389,7 @@ func (er *entryReaderImpl) initRecursive(ctx context.Context) error {
 }
 
 func (er *entryReaderImpl) refreshRecursive(ctx context.Context) error {
-	scan, err := dagdiscovery.Scan(er.targetDir, true)
+	scan, err := dagdiscovery.Scan(er.targetDir, dagdiscovery.Options{Recursive: true})
 	if err != nil {
 		return err
 	}

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -124,7 +124,7 @@ func newTestEntryReader(dir string, events chan DAGChangeEvent) *entryReaderImpl
 	return &entryReaderImpl{
 		targetDir: dir,
 		registry:  make(map[string]*ir.DAG),
-		dagSource: newDAGFileSource(dir),
+		dagSource: newDAGFileSource(dir, nil),
 		quit:      make(chan struct{}),
 		events:    events,
 	}
@@ -344,6 +344,52 @@ steps:
 		assert.Equal(t, "shared-name", event.DAGName)
 	case <-time.After(time.Second):
 		t.Fatal("expected the resolved DAG conflict to recover")
+	}
+}
+
+func TestEntryReaderExternalDAGFileSymlink(t *testing.T) {
+	tests := []struct {
+		name      string
+		recursive bool
+		symlinks  bool
+		expected  int
+	}{
+		{name: "NonRecursiveDisabled"},
+		{name: "NonRecursiveEnabled", symlinks: true, expected: 1},
+		{name: "RecursiveDisabled", recursive: true},
+		{name: "RecursiveEnabled", recursive: true, symlinks: true, expected: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			linkDir := root
+			if tc.recursive {
+				linkDir = filepath.Join(root, "nested")
+				require.NoError(t, os.MkdirAll(linkDir, 0750))
+			}
+			targetDir := t.TempDir()
+			targetPath := writeDAGFile(t, targetDir, "source.yaml", "external")
+			if err := os.Symlink(targetPath, filepath.Join(linkDir, "external.yaml")); err != nil {
+				t.Skipf("symlink creation is unavailable: %v", err)
+			}
+
+			store := filedag.New(
+				root,
+				filedag.WithSkipExamples(true),
+				filedag.WithRecursiveDiscovery(tc.recursive),
+				filedag.WithSymlinks(tc.symlinks),
+			)
+			reader := NewEntryReader(root, store, tc.recursive)
+			require.NoError(t, reader.Init(context.Background()))
+			t.Cleanup(reader.Stop)
+
+			dags := reader.DAGs()
+			require.Len(t, dags, tc.expected)
+			if tc.expected == 1 {
+				assert.Equal(t, "external", dags[0].Name)
+			}
+		})
 	}
 }
 

--- a/proto/index/v1/index.pb.go
+++ b/proto/index/v1/index.pb.go
@@ -98,6 +98,7 @@ type DAGIndexEntry struct {
 	Suspended     bool                   `protobuf:"varint,8,opt,name=suspended,proto3" json:"suspended,omitempty"`
 	Description   string                 `protobuf:"bytes,9,opt,name=description,proto3" json:"description,omitempty"`
 	LoadError     string                 `protobuf:"bytes,10,opt,name=load_error,json=loadError,proto3" json:"load_error,omitempty"`
+	LoadPath      string                 `protobuf:"bytes,11,opt,name=load_path,json=loadPath,proto3" json:"load_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -198,6 +199,13 @@ func (x *DAGIndexEntry) GetDescription() string {
 func (x *DAGIndexEntry) GetLoadError() string {
 	if x != nil {
 		return x.LoadError
+	}
+	return ""
+}
+
+func (x *DAGIndexEntry) GetLoadPath() string {
+	if x != nil {
+		return x.LoadPath
 	}
 	return ""
 }
@@ -540,7 +548,7 @@ const file_proto_index_v1_index_proto_rawDesc = "" +
 	"\bDAGIndex\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\"\n" +
 	"\rbuilt_at_unix\x18\x02 \x01(\x03R\vbuiltAtUnix\x121\n" +
-	"\aentries\x18\x03 \x03(\v2\x17.index.v1.DAGIndexEntryR\aentries\"\xa1\x02\n" +
+	"\aentries\x18\x03 \x03(\v2\x17.index.v1.DAGIndexEntryR\aentries\"\xbe\x02\n" +
 	"\rDAGIndexEntry\x12\x1b\n" +
 	"\tfile_path\x18\x01 \x01(\tR\bfilePath\x12\x1b\n" +
 	"\tfile_size\x18\x02 \x01(\x03R\bfileSize\x12\x19\n" +
@@ -553,7 +561,8 @@ const file_proto_index_v1_index_proto_rawDesc = "" +
 	"\vdescription\x18\t \x01(\tR\vdescription\x12\x1d\n" +
 	"\n" +
 	"load_error\x18\n" +
-	" \x01(\tR\tloadError\"\x81\x01\n" +
+	" \x01(\tR\tloadError\x12\x1b\n" +
+	"\tload_path\x18\v \x01(\tR\bloadPath\"\x81\x01\n" +
 	"\vDAGRunIndex\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\"\n" +
 	"\rbuilt_at_unix\x18\x02 \x01(\x03R\vbuiltAtUnix\x124\n" +

--- a/proto/index/v1/index.proto
+++ b/proto/index/v1/index.proto
@@ -27,6 +27,7 @@ message DAGIndexEntry {
   bool suspended = 8;
   string description = 9;
   string load_error = 10;
+  string load_path = 11;
 }
 
 // DAGRunIndex stores cached summaries for a single day's DAG runs.


### PR DESCRIPTION
## Summary

- add `dag_discovery.symlinks` and `DAGU_DAG_DISCOVERY_SYMLINKS` as an opt-in policy
- discover YAML file symlinks through canonical targets in flat and recursive modes without traversing symlinked directories
- allow external-target definitions to be viewed, scheduled, started, and enqueued while rejecting update, delete, and rename with HTTP 403
- preserve existing top-level internal symlink behavior and support a symlinked DAG root

## Root cause

DAG discovery and direct lookup used containment checks that rejected canonical targets outside the configured DAG directory. Discovery, indexing, scheduler metadata loading, and direct reads also did not share one canonical file resolution policy.

## User impact

External DAG definitions can now be mounted into the DAG directory with explicit administrator opt-in. The linked source stays read-only through Dagu, and directory symlinks are never traversed.

## Testing

- `make lint`
- `go test ./internal/cmn/config ./internal/cmn/schema ./internal/dagdiscovery ./internal/persis/file ./internal/persis/file/dag/dagindex ./internal/persis/file/dag ./internal/cmd/process ./internal/service/scheduler ./internal/service/frontend/api/v1`

Closes #2544

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in support for DAG YAML file symlinks (including external targets) and unifies canonical file resolution across discovery, indexing, scheduler, and reads. Also tracks each DAG’s symlink entry and target so deletes/renames affect the link safely, and external targets are read-only with clear 403 errors.

- New Features
  - Add `dag_discovery.symlinks` and `DAGU_DAG_DISCOVERY_SYMLINKS` (default false).
  - Include YAML file symlinks in recursive discovery; never traverse directory symlinks.
  - Allow external-target symlinks to be listed, viewed, scheduled, started, and enqueued; block update/delete/rename with HTTP 403 (`ErrDAGReadOnly`).
  - Clear errors when an external file symlink is found but the opt-in is disabled.

- Refactors
  - Unify canonical resolution in `dagdiscovery`, `dagindex`, and `dagstore`; index v3 stores each file’s canonical load path, and the scheduler loads metadata via the store so policy is enforced end-to-end.
  - Resolve and expose both symlink entry and resolved target; internal symlink deletes/renames act on the link, not the target.
  - Preserve existing top-level internal symlink behavior and allow a symlinked `paths.dags_dir`.

<sup>Written for commit 160b635be02feb8c36b534ca85a9421db48b1500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional symlink support for recursive DAG discovery.
  * External symlink targets can be discovered and read when enabled.
  * Added configuration through `dag_discovery.symlinks` or `DAGU_DAG_DISCOVERY_SYMLINKS`.

* **Bug Fixes**
  * Prevented modifications, deletion, or renaming of DAGs managed through external symlinks.
  * Improved handling and reporting of unsupported symlink configurations.

* **Documentation**
  * Documented symlink discovery behavior, restrictions, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->