### PR TITLE
feat: add MCP DAG rename and delete

### DIFF
--- a/conformance/spec022_mcp_change_tool/change_errors_test.go
+++ b/conformance/spec022_mcp_change_tool/change_errors_test.go
@@ -165,13 +165,13 @@ func TestChangeInputValidationErrors(t *testing.T) {
 		{
 			name: "unsupported type",
 			arguments: map[string]any{
-				"type": "delete_dag",
+				"type": "archive_dag",
 				"name": "mcp_change_error_type",
 				"spec": validSpec,
 			},
 			code:       "unsupported_change_type",
 			field:      "type",
-			changeType: "delete_dag",
+			changeType: "archive_dag",
 			dagName:    "mcp_change_error_type",
 			dagURI:     changeDAGSpecURI("mcp_change_error_type"),
 		},

--- a/conformance/spec022_mcp_change_tool/change_identity_test.go
+++ b/conformance/spec022_mcp_change_tool/change_identity_test.go
@@ -40,7 +40,7 @@ func TestChangeToolIdentityAndInputSchema(t *testing.T) {
 
 	properties, ok := schema["properties"].(map[string]any)
 	require.True(t, ok)
-	for _, field := range []string{"mode", "type", "name", "spec", "workspace", "path", "content", "newPath"} {
+	for _, field := range []string{"mode", "type", "name", "spec", "newName", "workspace", "path", "content", "newPath"} {
 		property, ok := properties[field].(map[string]any)
 		require.True(t, ok)
 		require.Equal(t, "string", property["type"])
@@ -54,6 +54,14 @@ func TestChangeToolIdentityAndInputSchema(t *testing.T) {
 		"upsert_dag": {
 			types:    []any{"upsert_dag"},
 			required: []any{"name", "spec"},
+		},
+		"rename_dag": {
+			types:    []any{"rename_dag"},
+			required: []any{"type", "name", "newName"},
+		},
+		"delete_dag": {
+			types:    []any{"delete_dag"},
+			required: []any{"type", "name"},
 		},
 		"upsert_wiki_page": {
 			types:    []any{"upsert_wiki_page", "upsert_doc"},

--- a/internal/service/mcp/audit.go
+++ b/internal/service/mcp/audit.go
@@ -245,8 +245,9 @@ func changeAuditMetadata(input changeInput) toolAuditMetadata {
 	}
 	changeType := strings.TrimSpace(input.Type)
 	if changeType == "" {
-		changeType = "upsert_dag"
+		changeType = changeTypeUpsertDAG
 	}
+	canonicalType := canonicalChangeType(changeType)
 	resourceType := "dag"
 	resourceID := input.Name
 	attributes := map[string]any{
@@ -254,10 +255,16 @@ func changeAuditMetadata(input changeInput) toolAuditMetadata {
 		"type": changeType,
 	}
 	workspace := ""
-	if changeType == changeTypeUpsertDAG {
+	switch canonicalType {
+	case changeTypeUpsertDAG:
 		attributes["dag_name"] = input.Name
 		attributes["spec_bytes"] = len(input.Spec)
-	} else {
+	case changeTypeRenameDAG:
+		attributes["dag_name"] = input.Name
+		attributes["new_dag_name"] = input.NewName
+	case changeTypeDeleteDAG:
+		attributes["dag_name"] = input.Name
+	default:
 		resourceType = "doc"
 		resourceID = input.Path
 		workspace = input.Workspace
@@ -265,7 +272,7 @@ func changeAuditMetadata(input changeInput) toolAuditMetadata {
 		if input.NewPath != "" {
 			attributes["new_path"] = input.NewPath
 		}
-		if changeType == changeTypeUpsertWikiPage || changeType == legacyChangeTypeUpsertDoc {
+		if canonicalType == changeTypeUpsertWikiPage {
 			attributes["content_bytes"] = len(input.Content)
 		}
 	}

--- a/internal/service/mcp/audit_test.go
+++ b/internal/service/mcp/audit_test.go
@@ -75,3 +75,43 @@ func TestDocumentChangeAuditMetadataUsesWorkspaceAndContentSize(t *testing.T) {
 	require.Equal(t, "operations", metadata.Workspace)
 	require.Equal(t, len("# Restart"), metadata.Attributes["content_bytes"])
 }
+
+func TestDAGChangeAuditMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   changeInput
+		wantNew string
+	}{
+		{
+			name: "rename",
+			input: changeInput{
+				Mode:    changeModeApply,
+				Type:    changeTypeRenameDAG,
+				Name:    "old",
+				NewName: "new",
+			},
+			wantNew: "new",
+		},
+		{
+			name: "delete",
+			input: changeInput{
+				Mode: changeModeApply,
+				Type: changeTypeDeleteDAG,
+				Name: "old",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := changeAuditMetadata(test.input)
+
+			require.Equal(t, "dag", metadata.ResourceType)
+			require.Equal(t, test.input.Name, metadata.ResourceID)
+			require.Equal(t, test.input.Name, metadata.Attributes["dag_name"])
+			if test.wantNew != "" {
+				require.Equal(t, test.wantNew, metadata.Attributes["new_dag_name"])
+			}
+		})
+	}
+}

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -254,6 +254,7 @@ func (svc *Service) changeRenameDAG(ctx context.Context, input changeInput) (*mc
 		return nil, nil, err
 	}
 	output["applied"] = true
+	delete(output, "dagUri")
 	return resultWithLinks("DAG rename applied.", linkForDAGSpec(input.NewName)), output, nil
 }
 

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dagucloud/dagu/v2/internal/dagstore"
+	"github.com/dagucloud/dagu/v2/internal/ir"
 	frontendapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/wiki"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -21,6 +23,8 @@ const (
 	changeModeApply   = "apply"
 
 	changeTypeUpsertDAG      = "upsert_dag"
+	changeTypeRenameDAG      = "rename_dag"
+	changeTypeDeleteDAG      = "delete_dag"
 	changeTypeUpsertWikiPage = "upsert_wiki_page"
 	changeTypeRenameWikiPage = "rename_wiki_page"
 	changeTypeDeleteWikiPage = "delete_wiki_page"
@@ -41,6 +45,7 @@ const (
 	changeFieldMode                  = "mode"
 	changeFieldType                  = "type"
 	changeFieldName                  = "name"
+	changeFieldNewName               = "newName"
 	changeFieldSpec                  = "spec"
 	changeFieldWorkspace             = "workspace"
 	changeFieldPath                  = "path"
@@ -76,7 +81,7 @@ func changeToolInputSchema() json.RawMessage {
 			},
 			"type": {
 				"type": "string",
-				"description": "Change type: upsert_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. The legacy page aliases remain available for compatibility."
+				"description": "Change type: upsert_dag, rename_dag, delete_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. The legacy page aliases remain available for compatibility."
 			},
 			"name": {
 				"type": "string",
@@ -85,6 +90,10 @@ func changeToolInputSchema() json.RawMessage {
 			"spec": {
 				"type": "string",
 				"description": "DAG YAML document to validate and optionally store."
+			},
+			"newName": {
+				"type": "string",
+				"description": "Destination DAG name for rename_dag."
 			},
 			"workspace": {
 				"type": "string",
@@ -107,6 +116,14 @@ func changeToolInputSchema() json.RawMessage {
 			{
 				"properties": {"type": {"enum": ["upsert_dag"]}},
 				"required": ["name", "spec"]
+			},
+			{
+				"properties": {"type": {"enum": ["rename_dag"]}},
+				"required": ["type", "name", "newName"]
+			},
+			{
+				"properties": {"type": {"enum": ["delete_dag"]}},
+				"required": ["type", "name"]
 			},
 			{
 				"properties": {"type": {"enum": ["upsert_wiki_page", "upsert_doc"]}},
@@ -153,6 +170,10 @@ func (svc *Service) changeToolImpl(ctx context.Context, input changeInput) (*mcp
 	switch canonicalChangeType(input.Type) {
 	case changeTypeUpsertDAG:
 		return svc.changeDAG(ctx, input)
+	case changeTypeRenameDAG:
+		return svc.changeRenameDAG(ctx, input)
+	case changeTypeDeleteDAG:
+		return svc.changeDeleteDAG(ctx, input)
 	case changeTypeUpsertWikiPage:
 		return svc.changeUpsertWikiPage(ctx, input)
 	case changeTypeRenameWikiPage:
@@ -203,6 +224,62 @@ func (svc *Service) changeDAG(ctx context.Context, input changeInput) (*mcpsdk.C
 	output["updated"] = !created
 
 	return resultWithLinks("DAG change applied.", linkForDAGSpec(input.Name)), output, nil
+}
+
+func (svc *Service) changeRenameDAG(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
+	if _, err := svc.getDAGSpec(ctx, input.Name); err != nil {
+		return nil, nil, err
+	}
+	if _, err := svc.getDAGSpec(ctx, input.NewName); err == nil {
+		return nil, nil, dagstore.ErrDAGAlreadyExists
+	} else if !isDAGNotFound(err) {
+		return nil, nil, err
+	}
+
+	output := map[string]any{
+		"mode":       input.Mode,
+		"type":       input.Type,
+		"dagName":    input.Name,
+		"newDagName": input.NewName,
+		"valid":      true,
+		"applied":    false,
+		"references": defaultReferenceURIs(),
+		"dagUri":     dagSpecURI(input.Name),
+		"newDagUri":  dagSpecURI(input.NewName),
+	}
+	if input.Mode == changeModePreview {
+		return resultWithLinks("DAG rename is valid. Re-run with mode=apply to rename it.", linkForDAGSpec(input.Name)), output, nil
+	}
+	if err := svc.renameDAG(ctx, input.Name, input.NewName); err != nil {
+		return nil, nil, err
+	}
+	output["applied"] = true
+	return resultWithLinks("DAG rename applied.", linkForDAGSpec(input.NewName)), output, nil
+}
+
+func (svc *Service) changeDeleteDAG(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
+	if _, err := svc.getDAGSpec(ctx, input.Name); err != nil {
+		return nil, nil, err
+	}
+
+	output := map[string]any{
+		"mode":       input.Mode,
+		"type":       input.Type,
+		"dagName":    input.Name,
+		"valid":      true,
+		"applied":    false,
+		"references": defaultReferenceURIs(),
+		"dagUri":     dagSpecURI(input.Name),
+	}
+	if input.Mode == changeModePreview {
+		return resultWithLinks("DAG deletion is valid. Re-run with mode=apply to delete it.", linkForDAGSpec(input.Name)), output, nil
+	}
+	if err := svc.deleteDAG(ctx, input.Name); err != nil {
+		return nil, nil, err
+	}
+	output["applied"] = true
+	delete(output, "dagUri")
+	return resultWithLinks("DAG deletion applied."), output, nil
 }
 
 func (svc *Service) changeUpsertWikiPage(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
@@ -373,6 +450,8 @@ func parseChangeToolInput(raw json.RawMessage) (changeInput, *changeToolError) {
 			input.Type = strings.TrimSpace(text)
 		case changeFieldName:
 			input.Name = strings.TrimSpace(text)
+		case changeFieldNewName:
+			input.NewName = strings.TrimSpace(text)
 		case changeFieldSpec:
 			input.Spec = text
 		case changeFieldWorkspace:
@@ -414,6 +493,7 @@ func isChangeInputField(field string) bool {
 	case changeFieldMode,
 		changeFieldType,
 		changeFieldName,
+		changeFieldNewName,
 		changeFieldSpec,
 		changeFieldWorkspace,
 		changeFieldPath,
@@ -428,6 +508,8 @@ func isChangeInputField(field string) bool {
 func isSupportedChangeType(changeType string) bool {
 	switch canonicalChangeType(changeType) {
 	case changeTypeUpsertDAG,
+		changeTypeRenameDAG,
+		changeTypeDeleteDAG,
 		changeTypeUpsertWikiPage,
 		changeTypeRenameWikiPage,
 		changeTypeDeleteWikiPage:
@@ -462,6 +544,13 @@ func validateChangeInput(input changeInput, fields map[string]json.RawMessage) *
 		allowed[changeFieldName] = true
 		allowed[changeFieldSpec] = true
 		required = []string{changeFieldName, changeFieldSpec}
+	case changeTypeRenameDAG:
+		allowed[changeFieldName] = true
+		allowed[changeFieldNewName] = true
+		required = []string{changeFieldName, changeFieldNewName}
+	case changeTypeDeleteDAG:
+		allowed[changeFieldName] = true
+		required = []string{changeFieldName}
 	case changeTypeUpsertWikiPage:
 		allowed[changeFieldWorkspace] = true
 		allowed[changeFieldPath] = true
@@ -503,6 +592,24 @@ func validateChangeInput(input changeInput, fields map[string]json.RawMessage) *
 		}
 		if strings.TrimSpace(input.Spec) == "" {
 			return changeInputError(input, "The spec field is required.", changeFieldSpec)
+		}
+	case changeTypeRenameDAG, changeTypeDeleteDAG:
+		if input.Name == "" {
+			return changeInputError(input, "The name field is required.", changeFieldName)
+		}
+		if err := ir.ValidateDAGName(input.Name); err != nil {
+			return changeInputError(input, "Invalid DAG name: "+err.Error(), changeFieldName)
+		}
+		if changeType == changeTypeRenameDAG {
+			if input.NewName == "" {
+				return changeInputError(input, "The newName field is required.", changeFieldNewName)
+			}
+			if err := ir.ValidateDAGName(input.NewName); err != nil {
+				return changeInputError(input, "Invalid destination DAG name: "+err.Error(), changeFieldNewName)
+			}
+			if input.Name == input.NewName {
+				return changeInputError(input, "The newName field must differ from name.", changeFieldNewName)
+			}
 		}
 	default:
 		if input.Workspace == "" {
@@ -591,8 +698,13 @@ func classifyChangeToolError(input changeInput, err error) *changeToolError {
 	}
 
 	if isDAGNotFound(err) {
-		out.Code = changeErrorResourceUnavailable
-		out.Message = "The requested DAG resource is unavailable."
+		out.Code = changeErrorResourceNotFound
+		out.Message = "The requested DAG was not found."
+		return out
+	}
+	if errors.Is(err, dagstore.ErrDAGAlreadyExists) {
+		out.Code = changeErrorConflict
+		out.Message = "A DAG with the requested name already exists."
 		return out
 	}
 

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -184,13 +184,15 @@ Errors:
 			description: "Detailed dagu_change input, output, and error reference.",
 			text: `# dagu_change reference
 
-Purpose: validate or write DAG YAML and Markdown Wiki changes.
+Purpose: validate or apply DAG definition and Markdown Wiki changes.
 
 Fields:
 
 - mode: preview or apply. Defaults to preview.
-- type: upsert_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. Defaults to upsert_dag. The upsert_doc, rename_doc, and delete_doc aliases are deprecated.
-- name and spec: required for upsert_dag.
+- type: upsert_dag, rename_dag, delete_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. Defaults to upsert_dag. The upsert_doc, rename_doc, and delete_doc aliases are deprecated.
+- name: DAG name. Required for DAG changes.
+- spec: complete DAG YAML. Required for upsert_dag.
+- newName: destination DAG name. Required for rename_dag.
 - workspace: default or a named workspace. Required for Wiki changes; all is not allowed.
 - path: Wiki page or directory path without .md. Required for Wiki changes.
 - content: full Markdown content. Required for upsert_wiki_page; empty content is allowed.
@@ -198,15 +200,17 @@ Fields:
 
 Mode behavior:
 
-- preview validates the requested operation and reads enough current state to report whether it can target a file or directory, without writing.
-- apply repeats validation and performs the requested operation through Dagu's workspace-aware Wiki API.
+- preview validates the requested operation and reads the required current state without writing.
+- apply repeats validation and performs the requested operation through Dagu's API; Wiki operations remain workspace-aware.
+- rename_dag changes the stored DAG identifier without rewriting the YAML name or historical runs.
+- delete_dag removes the DAG definition using Dagu's existing deletion behavior.
 - upsert_wiki_page creates a missing page or updates an existing page.
 - rename_wiki_page and delete_wiki_page support pages and directories.
 
 Output:
 
-- Successful result text is Dagu change completed.
-- DAG output has dagName, valid, errors, applied, and dagUri.
+- Successful result text describes the previewed or applied change.
+- DAG output has dagName, valid, applied, and dagUri while the target exists. Upsert output also has errors; rename output has newDagName and newDagUri.
 - Wiki output has workspace, path, valid, applied, and wikiPageUri when the target is a page. docUri remains as a compatibility alias.
 
 Errors:
@@ -214,7 +218,7 @@ Errors:
 - invalid_tool_input for missing or incompatible fields, invalid paths, unknown mode, unknown type, or malformed input.
 - unauthorized when the caller cannot perform the requested write.
 - resource_not_found when a rename or delete source does not exist.
-- conflict when a Wiki path conflicts with another file or directory.
+- conflict when a DAG rename destination exists or a Wiki path conflicts with another file or directory.
 - internal_error for unexpected failures.`,
 		},
 		{

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -210,7 +210,7 @@ Mode behavior:
 Output:
 
 - Successful result text describes the previewed or applied change.
-- DAG output has dagName, valid, applied, and dagUri while the target exists. Upsert output also has errors; rename output has newDagName and newDagUri.
+- DAG output has dagName, valid, applied, and dagUri while the target exists. Upsert output also has errors; rename output has newDagName and newDagUri, and omits the stale source dagUri after apply.
 - Wiki output has workspace, path, valid, applied, and wikiPageUri when the target is a page. docUri remains as a compatibility alias.
 
 Errors:

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -99,8 +99,9 @@ func NewServer(api *frontendapi.API) *mcpsdk.Server {
 
 type changeInput struct {
 	Mode      string `json:"mode,omitempty" jsonschema:"preview or apply. Defaults to preview."`
-	Type      string `json:"type,omitempty" jsonschema:"Change type: upsert_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page."`
-	Name      string `json:"name,omitempty" jsonschema:"DAG name for upsert_dag."`
+	Type      string `json:"type,omitempty" jsonschema:"Change type: upsert_dag, rename_dag, delete_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page."`
+	Name      string `json:"name,omitempty" jsonschema:"DAG name for DAG changes."`
+	NewName   string `json:"newName,omitempty" jsonschema:"Destination DAG name for rename_dag."`
 	Spec      string `json:"spec,omitempty" jsonschema:"DAG YAML specification for upsert_dag."`
 	Workspace string `json:"workspace,omitempty" jsonschema:"Wiki workspace for Wiki changes: default or a named workspace."`
 	Path      string `json:"path,omitempty" jsonschema:"Wiki page or directory path for Wiki changes."`
@@ -142,7 +143,7 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 	server.AddTool(&mcpsdk.Tool{
 		Name:        toolChange,
 		Title:       "Preview or apply Dagu changes",
-		Description: "Validate and optionally apply DAG YAML or Markdown Wiki changes. Wiki changes are workspace-aware. Use mode=preview before mode=apply unless the user explicitly asked to write immediately.",
+		Description: "Validate and optionally apply DAG definition or Markdown Wiki changes. Wiki changes are workspace-aware. Use mode=preview before mode=apply unless the user explicitly asked to write immediately.",
 		InputSchema: changeToolInputSchema(),
 		Annotations: &mcpsdk.ToolAnnotations{
 			DestructiveHint: truePtr,
@@ -503,6 +504,39 @@ func (svc *Service) upsertDAG(ctx context.Context, name, spec string) (bool, err
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected update DAG response %T", resp)
+	}
+}
+
+func (svc *Service) renameDAG(ctx context.Context, name, newName string) error {
+	resp, err := svc.api.RenameDAG(ctx, daguapi.RenameDAGRequestObject{
+		FileName: daguapi.DAGFileName(name),
+		Body: &daguapi.RenameDAGJSONRequestBody{
+			NewFileName: newName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	switch resp.(type) {
+	case *daguapi.RenameDAG200Response, daguapi.RenameDAG200Response:
+		return nil
+	default:
+		return fmt.Errorf("unexpected rename DAG response %T", resp)
+	}
+}
+
+func (svc *Service) deleteDAG(ctx context.Context, name string) error {
+	resp, err := svc.api.DeleteDAG(ctx, daguapi.DeleteDAGRequestObject{
+		FileName: daguapi.DAGFileName(name),
+	})
+	if err != nil {
+		return err
+	}
+	switch resp.(type) {
+	case *daguapi.DeleteDAG204Response, daguapi.DeleteDAG204Response:
+		return nil
+	default:
+		return fmt.Errorf("unexpected delete DAG response %T", resp)
 	}
 }
 

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -95,6 +95,7 @@ steps:
 	require.False(t, applied.IsError)
 	require.Equal(t, true, structuredMap(t, applied)["applied"])
 	require.Equal(t, dagSpecURI(rename.NewName), structuredMap(t, applied)["newDagUri"])
+	require.NotContains(t, structuredMap(t, applied), "dagUri")
 	_, err = store.GetSpec(ctx, rename.Name)
 	require.ErrorIs(t, err, dagstore.ErrDAGNotFound)
 	spec, err := store.GetSpec(ctx, rename.NewName)
@@ -111,6 +112,7 @@ steps:
 	deleted := callTool(t, ctx, session, toolChange, remove)
 	require.False(t, deleted.IsError)
 	require.Equal(t, true, structuredMap(t, deleted)["applied"])
+	require.NotContains(t, structuredMap(t, deleted), "dagUri")
 	_, err = store.GetSpec(ctx, remove.Name)
 	require.ErrorIs(t, err, dagstore.ErrDAGNotFound)
 

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -12,7 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/dagstore"
+	filedag "github.com/dagucloud/dagu/v2/internal/persis/file/dag"
+	"github.com/dagucloud/dagu/v2/internal/runtime"
+	frontendapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +38,141 @@ func TestServerExposesCompactToolSurface(t *testing.T) {
 	slices.Sort(names)
 
 	require.Equal(t, []string{toolChange, toolExecute, toolRead}, names)
+}
+
+func TestChangeToolRenamesAndDeletesDAG(t *testing.T) {
+	ctx := context.Background()
+	store := filedag.New(t.TempDir(), filedag.WithSkipExamples(true))
+	require.NoError(t, store.Create(ctx, "mcp-original", []byte(`
+name: mcp-original
+steps:
+  - run: echo hello
+`)))
+	require.NoError(t, store.Create(ctx, "mcp-existing", []byte(`
+name: mcp-existing
+steps:
+  - run: echo existing
+`)))
+	cfg := &config.Config{}
+	cfg.Server.Permissions = map[config.Permission]bool{config.PermissionWriteDAGs: true}
+	api := frontendapi.New(
+		store,
+		nil,
+		nil,
+		nil,
+		runtime.Manager{},
+		cfg,
+		nil,
+		nil,
+		prometheus.NewRegistry(),
+		nil,
+	)
+	session := connectTestClient(t, ctx, NewServer(api))
+
+	conflict := callTool(t, ctx, session, toolChange, changeInput{
+		Type:    changeTypeRenameDAG,
+		Name:    "mcp-original",
+		NewName: "mcp-existing",
+	})
+	require.True(t, conflict.IsError)
+	require.Equal(t, changeErrorConflict, structuredMap(t, conflict)["code"])
+
+	rename := changeInput{
+		Type:    changeTypeRenameDAG,
+		Name:    "mcp-original",
+		NewName: "mcp-renamed",
+	}
+	preview := callTool(t, ctx, session, toolChange, rename)
+	require.False(t, preview.IsError)
+	require.Equal(t, false, structuredMap(t, preview)["applied"])
+	_, err := store.GetSpec(ctx, rename.Name)
+	require.NoError(t, err)
+	_, err = store.GetSpec(ctx, rename.NewName)
+	require.ErrorIs(t, err, dagstore.ErrDAGNotFound)
+
+	rename.Mode = changeModeApply
+	applied := callTool(t, ctx, session, toolChange, rename)
+	require.False(t, applied.IsError)
+	require.Equal(t, true, structuredMap(t, applied)["applied"])
+	require.Equal(t, dagSpecURI(rename.NewName), structuredMap(t, applied)["newDagUri"])
+	_, err = store.GetSpec(ctx, rename.Name)
+	require.ErrorIs(t, err, dagstore.ErrDAGNotFound)
+	spec, err := store.GetSpec(ctx, rename.NewName)
+	require.NoError(t, err)
+	require.Contains(t, spec, "name: mcp-original")
+
+	remove := changeInput{Type: changeTypeDeleteDAG, Name: rename.NewName}
+	preview = callTool(t, ctx, session, toolChange, remove)
+	require.False(t, preview.IsError)
+	_, err = store.GetSpec(ctx, remove.Name)
+	require.NoError(t, err)
+
+	remove.Mode = changeModeApply
+	deleted := callTool(t, ctx, session, toolChange, remove)
+	require.False(t, deleted.IsError)
+	require.Equal(t, true, structuredMap(t, deleted)["applied"])
+	_, err = store.GetSpec(ctx, remove.Name)
+	require.ErrorIs(t, err, dagstore.ErrDAGNotFound)
+
+	missing := callTool(t, ctx, session, toolChange, remove)
+	require.True(t, missing.IsError)
+	require.Equal(t, changeErrorResourceNotFound, structuredMap(t, missing)["code"])
+}
+
+func TestDAGChangeInputValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantField string
+	}{
+		{
+			name:  "rename",
+			input: `{"type":"rename_dag","name":"old","newName":"new"}`,
+		},
+		{
+			name:  "delete",
+			input: `{"type":"delete_dag","name":"old"}`,
+		},
+		{
+			name:      "rename requires destination",
+			input:     `{"type":"rename_dag","name":"old"}`,
+			wantField: changeFieldNewName,
+		},
+		{
+			name:      "rename rejects blank destination",
+			input:     `{"type":"rename_dag","name":"old","newName":" "}`,
+			wantField: changeFieldNewName,
+		},
+		{
+			name:      "rename requires different destination",
+			input:     `{"type":"rename_dag","name":"old","newName":"old"}`,
+			wantField: changeFieldNewName,
+		},
+		{
+			name:      "rename validates destination",
+			input:     `{"type":"rename_dag","name":"old","newName":"bad name"}`,
+			wantField: changeFieldNewName,
+		},
+		{
+			name:      "delete rejects spec",
+			input:     `{"type":"delete_dag","name":"old","spec":"steps: []"}`,
+			wantField: changeFieldSpec,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input, changeErr := parseChangeToolInput(json.RawMessage(test.input))
+			if test.wantField == "" {
+				require.Nil(t, changeErr)
+				require.Equal(t, changeModePreview, input.Mode)
+				return
+			}
+			require.NotNil(t, changeErr)
+			require.Equal(t, changeErrorInvalidToolInput, changeErr.Code)
+			require.Equal(t, test.wantField, changeErr.Field)
+		})
+	}
 }
 
 func TestExecuteToolSupportsNoReuse(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `rename_dag` and `delete_dag` operations to the existing `dagu_change` MCP tool
- preserve preview-by-default behavior and delegate applies to the frontend API
- add validation, structured errors, audit metadata, reference docs, and integration coverage

## Behavior

- rename changes the stored DAG identifier without rewriting the YAML `name:` or historical runs
- delete uses the existing API deletion behavior
- the MCP tool surface remains `dagu_read`, `dagu_change`, and `dagu_execute`

## Testing

- `make test TEST_TARGET=./internal/service/mcp/...`
- native `golangci-lint run --timeout=10m ./...`
- Windows `golangci-lint run --timeout=10m ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DAG rename and delete to the MCP `dagu_change` tool with preview-by-default and apply via the frontend API. Includes strict validation, clearer errors, updated audit metadata, reference docs, and refreshed MCP conformance tests; also removes stale `dagUri` after apply.

- **New Features**
  - Added `rename_dag` and `delete_dag` to `dagu_change` with `newName` and strict name validation.
  - Rename updates the stored DAG identifier only; it does not rewrite the YAML `name:` or historical runs.
  - Delete uses existing API behavior; preview validates, apply performs the operation.
  - Errors: `resource_not_found` for missing DAGs; `conflict` when a rename target already exists.
  - Output: rename returns `newDagName`/`newDagUri`; delete omits `dagUri` after apply. Tool surface remains `dagu_read`, `dagu_change`, `dagu_execute`.

- **Bug Fixes**
  - Omit stale `dagUri` after rename apply.

<sup>Written for commit 44ecb77b191dcf5eec2e444985b7e8b711b73ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for renaming and deleting DAGs.
  - Added preview and apply workflows for DAG changes.
  - Added validation for required, invalid, conflicting, and restricted inputs.
  - Improved handling and reporting of missing DAGs and name conflicts.

- **Documentation**
  - Updated change-operation documentation with DAG-specific fields, outputs, validation rules, and errors.

- **Bug Fixes**
  - Improved audit details for DAG creation, renaming, and deletion operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->