### PR TITLE
fix(docker): decode embedded HostConfig.Resources fields in host config

### DIFF
--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -51,10 +51,6 @@ func mustAddr(s string) netip.Addr {
 	return netip.MustParseAddr(s)
 }
 
-// TestLoadConfigFromMap covers LoadConfigFromMap with 92.7% coverage.
-// The uncovered lines (7.3%) are error handling for mapstructure.NewDecoder failures
-// which cannot be triggered in practice because we always pass valid struct pointers.
-// These error checks exist as defensive programming for potential future changes.
 func TestLoadConfigFromMap(t *testing.T) {
 	hostWorkPath := testAbsoluteVolumePath("/workhost", "C:/workhost")
 	t.Setenv("DAGU_TEST_WORKHOST", hostWorkPath)

--- a/internal/runtime/builtin/docker/client_test.go
+++ b/internal/runtime/builtin/docker/client_test.go
@@ -66,6 +66,7 @@ func TestLoadConfigFromMap(t *testing.T) {
 	hostPath := absVolumeSource("/host/path")
 	dataPath := absVolumeSource("/data")
 	newPath := absVolumeSource("/new")
+	pidsLimit := int64(128)
 
 	tests := []struct {
 		name        string
@@ -147,6 +148,94 @@ func TestLoadConfigFromMap(t *testing.T) {
 				Network: &network.NetworkingConfig{
 					EndpointsConfig: map[string]*network.EndpointSettings{},
 				},
+				ExecOptions: &client.ExecCreateOptions{},
+			},
+		},
+		{
+			name: "HostConfigWithFlatResources",
+			input: map[string]any{
+				"image": "alpine",
+				"host": map[string]any{
+					"NetworkMode": "bridge",
+					"SecurityOpt": []string{"seccomp=unconfined"},
+					"Memory":      536870912,
+					"CPUShares":   512,
+					"NanoCPUs":    1_000_000_000,
+					"PidsLimit":   128,
+					"Devices": []map[string]any{{
+						"PathOnHost":        "/dev/fuse",
+						"PathInContainer":   "/dev/fuse",
+						"CgroupPermissions": "rwm",
+					}},
+				},
+			},
+			expected: &Config{
+				Image:     "alpine",
+				Pull:      ir.PullPolicyMissing,
+				Container: &container.Config{},
+				Host: &container.HostConfig{
+					NetworkMode: "bridge",
+					SecurityOpt: []string{"seccomp=unconfined"},
+					Resources: container.Resources{
+						CPUShares: 512,
+						Memory:    536870912,
+						NanoCPUs:  1_000_000_000,
+						Devices: []container.DeviceMapping{{
+							PathOnHost:        "/dev/fuse",
+							PathInContainer:   "/dev/fuse",
+							CgroupPermissions: "rwm",
+						}},
+						PidsLimit: &pidsLimit,
+					},
+				},
+				Network:     &network.NetworkingConfig{},
+				ExecOptions: &client.ExecCreateOptions{},
+			},
+		},
+		{
+			name: "HostConfigWithNestedResources",
+			input: map[string]any{
+				"image": "alpine",
+				"host": map[string]any{
+					"resources": map[string]any{
+						"Memory": 268435456,
+					},
+				},
+			},
+			expected: &Config{
+				Image:     "alpine",
+				Pull:      ir.PullPolicyMissing,
+				Container: &container.Config{},
+				Host: &container.HostConfig{
+					Resources: container.Resources{Memory: 268435456},
+				},
+				Network:     &network.NetworkingConfig{},
+				ExecOptions: &client.ExecCreateOptions{},
+			},
+		},
+		{
+			name: "FlatHostResourcesOverrideNested",
+			input: map[string]any{
+				"image": "alpine",
+				"host": map[string]any{
+					"resources": map[string]any{
+						"Memory":    64,
+						"CPUShares": 256,
+					},
+					"Memory": 128,
+				},
+			},
+			expected: &Config{
+				Image:     "alpine",
+				Pull:      ir.PullPolicyMissing,
+				Container: &container.Config{},
+				Host: &container.HostConfig{
+					Resources: container.Resources{
+						CPUShares: 256,
+						Memory:    128,
+					},
+				},
+				Network:     &network.NetworkingConfig{},
 				ExecOptions: &client.ExecCreateOptions{},
 			},
 		},
@@ -775,6 +864,9 @@ func TestLoadConfigFromMap(t *testing.T) {
 			assert.Equal(t, tt.expected.Host.AutoRemove, result.Host.AutoRemove)
 			assert.Equal(t, tt.expected.Host.Privileged, result.Host.Privileged)
 			assert.Equal(t, tt.expected.Host.Binds, result.Host.Binds)
+			assert.Equal(t, tt.expected.Host.Resources, result.Host.Resources)
+			assert.Equal(t, tt.expected.Host.NetworkMode, result.Host.NetworkMode)
+			assert.Equal(t, tt.expected.Host.SecurityOpt, result.Host.SecurityOpt)
 
 			// Compare exec options
 			assert.Equal(t, tt.expected.ExecOptions.User, result.ExecOptions.User)

--- a/internal/runtime/builtin/docker/config.go
+++ b/internal/runtime/builtin/docker/config.go
@@ -92,6 +92,14 @@ func LoadConfigFromMapWithWorkDir(workDir string, data map[string]any, registryA
 	md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:           &ret,
 		WeaklyTypedInput: true,
+		// Squash embedded structs so the documented flat `host:` shape
+		// works: container.HostConfig EMBEDS container.Resources, which
+		// holds Memory, CPUShares, NanoCPUs, PidsLimit, Devices and every
+		// other cgroup field. Without Squash, mapstructure fills them only
+		// from a nested `host: {resources: {...}}` key — the flat form the
+		// docs show (`host: {Memory: 536870912}`) decoded to zero values
+		// silently, so containers ran without their resource limits.
+		Squash: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create decoder: %w", err)

--- a/internal/runtime/builtin/docker/config.go
+++ b/internal/runtime/builtin/docker/config.go
@@ -89,23 +89,19 @@ func LoadConfigFromMapWithWorkDir(workDir string, data map[string]any, registryA
 		Shell      []string `mapstructure:"shell"`
 	}{}
 
-	md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Result:           &ret,
-		WeaklyTypedInput: true,
-		// Squash embedded structs so the documented flat `host:` shape
-		// works: container.HostConfig EMBEDS container.Resources, which
-		// holds Memory, CPUShares, NanoCPUs, PidsLimit, Devices and every
-		// other cgroup field. Without Squash, mapstructure fills them only
-		// from a nested `host: {resources: {...}}` key — the flat form the
-		// docs show (`host: {Memory: 536870912}`) decoded to zero values
-		// silently, so containers ran without their resource limits.
-		Squash: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create decoder: %w", err)
-	}
-	if err := md.Decode(data); err != nil {
-		return nil, fmt.Errorf("failed to decode config: %w", err)
+	// Decode legacy nested Resources first, then overlay Docker's flat JSON shape.
+	for _, squash := range []bool{false, true} {
+		md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result:           &ret,
+			WeaklyTypedInput: true,
+			Squash:           squash,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create decoder: %w", err)
+		}
+		if err := md.Decode(data); err != nil {
+			return nil, fmt.Errorf("failed to decode config: %w", err)
+		}
 	}
 
 	var autoRemove bool

--- a/internal/runtime/builtin/docker/config_test.go
+++ b/internal/runtime/builtin/docker/config_test.go
@@ -154,3 +154,38 @@ func TestApplyResourceLimits(t *testing.T) {
 	require.Equal(t, int64(1_500_000_000), cfg.Host.Resources.NanoCPUs)
 	require.Equal(t, int64(512*1024*1024), cfg.Host.Resources.Memory)
 }
+
+func TestLoadConfigFromMap_HostEmbeddedResources(t *testing.T) {
+	// container.HostConfig EMBEDS container.Resources (Memory, CPUShares,
+	// NanoCPUs, PidsLimit, Devices, …). The docs show the flat form —
+	// host: {Memory: 536870912} — which requires DecoderConfig.Squash:
+	// without it, every Resources field silently decoded to its zero value
+	// while sibling direct fields (NetworkMode, SecurityOpt) worked, so
+	// containers ran WITHOUT their configured resource limits.
+	cfg, err := LoadConfigFromMap(map[string]any{
+		"image": "alpine",
+		"host": map[string]any{
+			"NetworkMode": "bridge",
+			"SecurityOpt": []string{"seccomp=unconfined"},
+			"Memory":      536870912,
+			"CPUShares":   512,
+			"PidsLimit":   128,
+			"Devices": []map[string]any{{
+				"PathOnHost":        "/dev/fuse",
+				"PathInContainer":   "/dev/fuse",
+				"CgroupPermissions": "rwm",
+			}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Host)
+	require.Equal(t, int64(536870912), cfg.Host.Memory)
+	require.Equal(t, int64(512), cfg.Host.CPUShares)
+	require.NotNil(t, cfg.Host.PidsLimit)
+	require.Equal(t, int64(128), *cfg.Host.PidsLimit)
+	require.Len(t, cfg.Host.Devices, 1)
+	require.Equal(t, "/dev/fuse", cfg.Host.Devices[0].PathOnHost)
+	// direct HostConfig fields keep working alongside the squash
+	require.Equal(t, "bridge", string(cfg.Host.NetworkMode))
+	require.Equal(t, []string{"seccomp=unconfined"}, cfg.Host.SecurityOpt)
+}

--- a/internal/runtime/builtin/docker/config_test.go
+++ b/internal/runtime/builtin/docker/config_test.go
@@ -154,38 +154,3 @@ func TestApplyResourceLimits(t *testing.T) {
 	require.Equal(t, int64(1_500_000_000), cfg.Host.Resources.NanoCPUs)
 	require.Equal(t, int64(512*1024*1024), cfg.Host.Resources.Memory)
 }
-
-func TestLoadConfigFromMap_HostEmbeddedResources(t *testing.T) {
-	// container.HostConfig EMBEDS container.Resources (Memory, CPUShares,
-	// NanoCPUs, PidsLimit, Devices, …). The docs show the flat form —
-	// host: {Memory: 536870912} — which requires DecoderConfig.Squash:
-	// without it, every Resources field silently decoded to its zero value
-	// while sibling direct fields (NetworkMode, SecurityOpt) worked, so
-	// containers ran WITHOUT their configured resource limits.
-	cfg, err := LoadConfigFromMap(map[string]any{
-		"image": "alpine",
-		"host": map[string]any{
-			"NetworkMode": "bridge",
-			"SecurityOpt": []string{"seccomp=unconfined"},
-			"Memory":      536870912,
-			"CPUShares":   512,
-			"PidsLimit":   128,
-			"Devices": []map[string]any{{
-				"PathOnHost":        "/dev/fuse",
-				"PathInContainer":   "/dev/fuse",
-				"CgroupPermissions": "rwm",
-			}},
-		},
-	}, nil)
-	require.NoError(t, err)
-	require.NotNil(t, cfg.Host)
-	require.Equal(t, int64(536870912), cfg.Host.Memory)
-	require.Equal(t, int64(512), cfg.Host.CPUShares)
-	require.NotNil(t, cfg.Host.PidsLimit)
-	require.Equal(t, int64(128), *cfg.Host.PidsLimit)
-	require.Len(t, cfg.Host.Devices, 1)
-	require.Equal(t, "/dev/fuse", cfg.Host.Devices[0].PathOnHost)
-	// direct HostConfig fields keep working alongside the squash
-	require.Equal(t, "bridge", string(cfg.Host.NetworkMode))
-	require.Equal(t, []string{"seccomp=unconfined"}, cfg.Host.SecurityOpt)
-}


### PR DESCRIPTION
## The bug

The docker executor's `host:` block silently drops every field that lives in `container.HostConfig`'s **embedded `Resources` struct** — `Memory`, `CPUShares`, `NanoCPUs`, `PidsLimit`, `Devices`, and the rest of the cgroup fields — while sibling *direct* fields (`NetworkMode`, `SecurityOpt`, `Binds`) decode fine.

The docs' own example does not work today:

```yaml
steps:
  - id: with_resource_limits
    action: docker.run
    with:
      image: alpine:3
      host:
        Memory: 536870912   # <- decodes to 0
        CPUShares: 512      # <- decodes to 0
```

Measured on **v2.13.0** against a real daemon (`docker inspect` on the created container): `Memory=0`, `CPUShares=0`, `PidsLimit=nil`, `Devices=[]` — no warning anywhere, so containers run **without their configured resource limits**.

## Root cause

`LoadConfigFromMapWithWorkDir` decodes with mapstructure but without `DecoderConfig.Squash`. mapstructure therefore treats the embedded `Resources` struct as a *nested* field: only the (undocumented) `host: {resources: {Memory: ...}}` shape reaches those fields — verified live on v2.13.0, that nested form lands everything, which pinpoints the missing squash.

## Fix

`LoadConfigFromMapWithWorkDir` now decodes the map twice. The first pass keeps the previously working nested `host.resources` shape. The second pass enables `Squash`, which applies Docker's flat JSON shape and gives flat fields precedence when both forms set the same field.

Regression coverage is consolidated in the existing `LoadConfigFromMap` table. It covers the embedded fields, including `NanoCPUs`, the `Devices` object array, and the `*int64 PidsLimit`; direct host fields; the legacy nested form; and mixed-shape precedence.

Validation:

```text
make test TEST_TARGET=./internal/runtime/builtin/docker/...
make check
```

**Behavior note:** Both the documented flat form and the legacy nested `resources:` form remain accepted. Flat fields win when both forms set the same option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker executor configuration parsing so flat host resource settings are correctly applied.
  * Memory, CPU, PID limits, devices, and other host settings now load as expected.

* **Tests**
  * Added coverage to verify decoding of embedded Docker host resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2558
