### PR TITLE
fix: make SSH timeout cancellation terminate promptly

### DIFF
--- a/internal/intg/sftp_test.go
+++ b/internal/intg/sftp_test.go
@@ -248,7 +248,7 @@ steps:
       command: |
         rm -f /tmp/dagu-sftp-timeout
         mkfifo /tmp/dagu-sftp-timeout
-        nohup sh -c 'sleep 5; echo released > /tmp/dagu-sftp-timeout' >/dev/null 2>&1 </dev/null &
+        nohup sh -c 'sleep 10; echo released > /tmp/dagu-sftp-timeout' >/dev/null 2>&1 </dev/null &
       host: 127.0.0.1
       port: "%s"
       user: %s
@@ -275,7 +275,7 @@ steps:
 		startedAt := time.Now()
 		err := dag.Agent().Run(th.Context)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.Less(t, time.Since(startedAt), 3*time.Second)
+		require.Less(t, time.Since(startedAt), 8*time.Second)
 		dag.AssertLatestStatus(t, ir.Failed)
 	})
 }

--- a/internal/intg/sftp_test.go
+++ b/internal/intg/sftp_test.go
@@ -4,10 +4,12 @@
 package intg_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -229,5 +231,51 @@ steps:
 		nested, err := os.ReadFile(filepath.Join(downloadPath, "subdir", "nested.txt"))
 		require.NoError(t, err, "failed to read downloaded nested.txt")
 		require.Equal(t, "remote nested\n", string(nested))
+	})
+
+	t.Run("StepTimeoutCancelsBlockedDownload", func(t *testing.T) {
+		th := test.Setup(t)
+		downloadPath := filepath.Join(t.TempDir(), "blocked-download.txt")
+		dagConfig := fmt.Sprintf(`
+type: graph
+retry_policy:
+  limit: 0
+  interval_sec: 1
+steps:
+  - name: create-blocking-source
+    action: ssh.run
+    with:
+      command: |
+        rm -f /tmp/dagu-sftp-timeout
+        mkfifo /tmp/dagu-sftp-timeout
+        nohup sh -c 'sleep 5; echo released > /tmp/dagu-sftp-timeout' >/dev/null 2>&1 </dev/null &
+      host: 127.0.0.1
+      port: "%s"
+      user: %s
+      key: "%s"
+      strict_host_key: false
+      shell: /bin/sh
+  - name: blocked-download
+    action: sftp.download
+    timeout_sec: 1
+    with:
+      host: 127.0.0.1
+      port: "%s"
+      user: %s
+      key: "%s"
+      strict_host_key: false
+      source: /tmp/dagu-sftp-timeout
+      destination: "%s"
+    depends:
+      - create-blocking-source
+`, sshServer.hostPort, sshTestUser, sshServer.keyPath,
+			sshServer.hostPort, sshTestUser, sshServer.keyPath, downloadPath)
+
+		dag := th.DAG(t, dagConfig)
+		startedAt := time.Now()
+		err := dag.Agent().Run(th.Context)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(startedAt), 3*time.Second)
+		dag.AssertLatestStatus(t, ir.Failed)
 	})
 }

--- a/internal/intg/ssh_test.go
+++ b/internal/intg/ssh_test.go
@@ -554,6 +554,83 @@ steps:
 		})
 	})
 
+	t.Run("DAGTimeoutCancelsRemoteCommand", func(t *testing.T) {
+		th := test.Setup(t)
+		dagConfig := sshServer.sshConfig("/bin/sh") + `
+timeout_sec: 1
+retry_policy:
+  limit: 0
+  interval_sec: 1
+steps:
+  - name: remote-timeout
+    action: ssh.run
+    with:
+      command: sleep 5
+`
+
+		dag := th.DAG(t, dagConfig)
+		startedAt := time.Now()
+		err := dag.Agent().Run(th.Context)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(startedAt), 3*time.Second)
+		dag.AssertLatestStatus(t, ir.Failed)
+	})
+
+	t.Run("StepTimeoutCancelsRemoteCommand", func(t *testing.T) {
+		th := test.Setup(t)
+		dagConfig := sshServer.sshConfig("/bin/sh") + `
+retry_policy:
+  limit: 0
+  interval_sec: 1
+steps:
+  - name: remote-timeout
+    action: ssh.run
+    timeout_sec: 1
+    with:
+      command: sleep 5
+`
+
+		dag := th.DAG(t, dagConfig)
+		startedAt := time.Now()
+		err := dag.Agent().Run(th.Context)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(startedAt), 3*time.Second)
+		dag.AssertLatestStatus(t, ir.Failed)
+	})
+
+	t.Run("DAGTimeoutCancelsRemoteCommandViaBastion", func(t *testing.T) {
+		th := test.Setup(t)
+		dagConfig := fmt.Sprintf(`timeout_sec: 1
+retry_policy:
+  limit: 0
+  interval_sec: 1
+ssh:
+  host: 127.0.0.1
+  port: "22"
+  user: %s
+  key: "%s"
+  strict_host_key: false
+  shell: /bin/sh
+  bastion:
+    host: 127.0.0.1
+    port: "%s"
+    user: %s
+    key: "%s"
+steps:
+  - name: bastion-timeout
+    action: ssh.run
+    with:
+      command: sleep 5
+`, sshTestUser, sshServer.keyPath, sshServer.hostPort, sshTestUser, sshServer.keyPath)
+
+		dag := th.DAG(t, dagConfig)
+		startedAt := time.Now()
+		err := dag.Agent().Run(th.Context)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(startedAt), 3*time.Second)
+		dag.AssertLatestStatus(t, ir.Failed)
+	})
+
 }
 
 // startSSHServer creates and starts an SSH server container
@@ -605,6 +682,7 @@ chown -R "$USER:$USER" "/home/$USER/.ssh"
 sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/' /etc/ssh/sshd_config
 
 exec /usr/sbin/sshd -D -e
 `, sshTestUser, sshTestPass, string(pubKey))

--- a/internal/intg/ssh_test.go
+++ b/internal/intg/ssh_test.go
@@ -565,14 +565,14 @@ steps:
   - name: remote-timeout
     action: ssh.run
     with:
-      command: sleep 5
+      command: sleep 10
 `
 
 		dag := th.DAG(t, dagConfig)
 		startedAt := time.Now()
 		err := dag.Agent().Run(th.Context)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.Less(t, time.Since(startedAt), 3*time.Second)
+		require.Less(t, time.Since(startedAt), 8*time.Second)
 		dag.AssertLatestStatus(t, ir.Failed)
 	})
 
@@ -587,14 +587,14 @@ steps:
     action: ssh.run
     timeout_sec: 1
     with:
-      command: sleep 5
+      command: sleep 10
 `
 
 		dag := th.DAG(t, dagConfig)
 		startedAt := time.Now()
 		err := dag.Agent().Run(th.Context)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.Less(t, time.Since(startedAt), 3*time.Second)
+		require.Less(t, time.Since(startedAt), 8*time.Second)
 		dag.AssertLatestStatus(t, ir.Failed)
 	})
 
@@ -620,14 +620,14 @@ steps:
   - name: bastion-timeout
     action: ssh.run
     with:
-      command: sleep 5
+      command: sleep 10
 `, sshTestUser, sshServer.keyPath, sshServer.hostPort, sshTestUser, sshServer.keyPath)
 
 		dag := th.DAG(t, dagConfig)
 		startedAt := time.Now()
 		err := dag.Agent().Run(th.Context)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		require.Less(t, time.Since(startedAt), 3*time.Second)
+		require.Less(t, time.Since(startedAt), 8*time.Second)
 		dag.AssertLatestStatus(t, ir.Failed)
 	})
 
@@ -682,7 +682,7 @@ chown -R "$USER:$USER" "/home/$USER/.ssh"
 sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
-sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/' /etc/ssh/sshd_config
+printf 'AllowTcpForwarding yes\n' > /etc/ssh/sshd_config.d/00-dagu-test.conf
 
 exec /usr/sbin/sshd -D -e
 `, sshTestUser, sshTestPass, string(pubKey))

--- a/internal/persis/file/baseconfig/default_base_config.go
+++ b/internal/persis/file/baseconfig/default_base_config.go
@@ -51,12 +51,11 @@ max_output_size: 1048576  # 1MB (bytes)
 # Duration string: e.g. "6h", "24h", "2d12h". Empty = no catchup (missed runs discarded).
 catchup_window: "6h"
 
-# Retry the entire DAG after a terminal failure.
-# This absorbs transient infrastructure or dependency failures by default.
-# Override or disable per DAG if the workflow is intentionally non-idempotent.
-retry_policy:
-  limit: 3
-  interval_sec: 5
+# Retry the entire DAG after a terminal failure. Retries are opt-in because
+# workflows may have non-idempotent side effects.
+# retry_policy:
+#   limit: 3
+#   interval_sec: 5
 
 # -- Shell --
 # Shell interpreter for command steps.

--- a/internal/persis/file/baseconfig/store_test.go
+++ b/internal/persis/file/baseconfig/store_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/internal/persis/testutil"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,7 +131,12 @@ func TestInitialize(t *testing.T) {
 		assert.Contains(t, string(data), "type: graph")
 		assert.Contains(t, string(data), "catchup_window")
 		assert.Contains(t, string(data), "hist_retention_days")
-		assert.Contains(t, string(data), "\nretry_policy:\n  limit: 3\n  interval_sec: 5\n")
+
+		var config struct {
+			RetryPolicy *struct{} `yaml:"retry_policy"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &config))
+		assert.Nil(t, config.RetryPolicy)
 	})
 
 	t.Run("skips when file already exists", func(t *testing.T) {

--- a/internal/runtime/builtin/ssh/client.go
+++ b/internal/runtime/builtin/ssh/client.go
@@ -4,12 +4,14 @@
 package ssh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
@@ -84,33 +86,41 @@ func defaultIfEmpty(val, defaultVal string) string {
 	return val
 }
 
-func (c *Client) NewSession() (*ssh.Client, *ssh.Session, error) {
-	conn, err := c.dial()
+func (c *Client) NewSession(ctx context.Context) (*ssh.Client, *ssh.Session, error) {
+	conn, err := c.dial(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	session, err := conn.NewSession()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
 		return nil, nil, err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		_ = session.Close()
+		_ = conn.Close()
+		return nil, nil, ctxErr
 	}
 
 	return conn, session, nil
 }
 
 // dial establishes an SSH connection either directly or via bastion host.
-func (c *Client) dial() (*ssh.Client, error) {
+func (c *Client) dial(ctx context.Context) (*ssh.Client, error) {
 	if c.bastionCfg != nil {
-		return c.dialViaBastion()
+		return c.dialViaBastion(ctx)
 	}
-	return ssh.Dial("tcp", c.hostPort, c.cfg)
+	return dialContext(ctx, c.hostPort, c.cfg)
 }
 
 // dialViaBastion establishes an SSH connection through a bastion/jump host.
-func (c *Client) dialViaBastion() (*ssh.Client, error) {
+func (c *Client) dialViaBastion(ctx context.Context) (*ssh.Client, error) {
 	// Connect to bastion host first
-	bastionConn, err := ssh.Dial("tcp", c.bastionCfg.hostPort, c.bastionCfg.cfg)
+	bastionConn, err := dialContext(ctx, c.bastionCfg.hostPort, c.bastionCfg.cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to bastion host: %w", err)
 	}
@@ -118,15 +128,21 @@ func (c *Client) dialViaBastion() (*ssh.Client, error) {
 	// Create a tunnel through bastion to the target host
 	targetConn, err := bastionConn.Dial("tcp", c.hostPort)
 	if err != nil {
-		bastionConn.Close()
+		_ = bastionConn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("failed to dial target through bastion: %w", err)
 	}
 
 	// Perform SSH handshake over the tunnel
 	ncc, chans, reqs, err := ssh.NewClientConn(targetConn, c.hostPort, c.cfg)
 	if err != nil {
-		targetConn.Close()
-		bastionConn.Close()
+		_ = targetConn.Close()
+		_ = bastionConn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("failed to establish SSH connection through bastion: %w", err)
 	}
 
@@ -136,7 +152,65 @@ func (c *Client) dialViaBastion() (*ssh.Client, error) {
 		bastion: bastionConn,
 	}
 
-	return ssh.NewClient(wrappedConn, chans, reqs), nil
+	client := ssh.NewClient(wrappedConn, chans, reqs)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		_ = client.Close()
+		return nil, ctxErr
+	}
+	return client, nil
+}
+
+func dialContext(ctx context.Context, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
+	dialer := net.Dialer{Timeout: cfg.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+
+	contextConn := newContextConn(ctx, conn)
+	ncc, chans, reqs, err := ssh.NewClientConn(contextConn, addr, cfg)
+	if err != nil {
+		_ = contextConn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+
+	client := ssh.NewClient(ncc, chans, reqs)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		_ = client.Close()
+		return nil, ctxErr
+	}
+	return client, nil
+}
+
+type contextConn struct {
+	net.Conn
+	stop     func() bool
+	closeErr error
+	close    sync.Once
+}
+
+func newContextConn(ctx context.Context, conn net.Conn) *contextConn {
+	ret := &contextConn{Conn: conn}
+	ret.stop = context.AfterFunc(ctx, ret.closeConn)
+	return ret
+}
+
+func (c *contextConn) Close() error {
+	c.stop()
+	c.closeConn()
+	return c.closeErr
+}
+
+func (c *contextConn) closeConn() {
+	c.close.Do(func() {
+		c.closeErr = c.Conn.Close()
+	})
 }
 
 // bastionWrappedConn wraps an SSH client connection and ensures the bastion

--- a/internal/runtime/builtin/ssh/lifecycle.go
+++ b/internal/runtime/builtin/ssh/lifecycle.go
@@ -23,7 +23,7 @@ func (l *executorLifecycle) begin(ctx context.Context) (context.Context, bool) {
 	runCtx, cancel := context.WithCancel(ctx)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.closed {
+	if l.closed || l.cancel != nil {
 		cancel()
 		return runCtx, false
 	}
@@ -34,7 +34,7 @@ func (l *executorLifecycle) begin(ctx context.Context) (context.Context, bool) {
 func (l *executorLifecycle) registerTransport(transport io.Closer) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.closed {
+	if l.closed || l.transport != nil {
 		return false
 	}
 	l.transport = transport
@@ -44,7 +44,7 @@ func (l *executorLifecycle) registerTransport(transport io.Closer) bool {
 func (l *executorLifecycle) registerResource(resource io.Closer) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.closed {
+	if l.closed || l.resource != nil {
 		return false
 	}
 	l.resource = resource
@@ -70,13 +70,14 @@ func (l *executorLifecycle) shutdown(force bool) error {
 		if cancel != nil {
 			cancel()
 		}
+		var transportErr, resourceErr error
 		if transport != nil {
-			return unexpectedCloseError(transport.Close())
+			transportErr = unexpectedCloseError(transport.Close())
 		}
 		if resource != nil {
-			return unexpectedCloseError(resource.Close())
+			resourceErr = unexpectedCloseError(resource.Close())
 		}
-		return nil
+		return errors.Join(transportErr, resourceErr)
 	}
 
 	var resourceErr, transportErr error

--- a/internal/runtime/builtin/ssh/lifecycle.go
+++ b/internal/runtime/builtin/ssh/lifecycle.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+)
+
+type executorLifecycle struct {
+	mu        sync.Mutex
+	cancel    context.CancelFunc
+	transport io.Closer
+	resource  io.Closer
+	closed    bool
+}
+
+func (l *executorLifecycle) begin(ctx context.Context) (context.Context, bool) {
+	runCtx, cancel := context.WithCancel(ctx)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		cancel()
+		return runCtx, false
+	}
+	l.cancel = cancel
+	return runCtx, true
+}
+
+func (l *executorLifecycle) registerTransport(transport io.Closer) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return false
+	}
+	l.transport = transport
+	return true
+}
+
+func (l *executorLifecycle) registerResource(resource io.Closer) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return false
+	}
+	l.resource = resource
+	return true
+}
+
+func (l *executorLifecycle) shutdown(force bool) error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil
+	}
+	l.closed = true
+	cancel := l.cancel
+	l.cancel = nil
+	transport := l.transport
+	l.transport = nil
+	resource := l.resource
+	l.resource = nil
+	l.mu.Unlock()
+
+	if force {
+		if cancel != nil {
+			cancel()
+		}
+		if transport != nil {
+			return unexpectedCloseError(transport.Close())
+		}
+		if resource != nil {
+			return unexpectedCloseError(resource.Close())
+		}
+		return nil
+	}
+
+	var resourceErr, transportErr error
+	if resource != nil {
+		resourceErr = unexpectedCloseError(resource.Close())
+	}
+	if transport != nil {
+		transportErr = unexpectedCloseError(transport.Close())
+	}
+	if cancel != nil {
+		cancel()
+	}
+	return errors.Join(resourceErr, transportErr)
+}
+
+func unexpectedCloseError(err error) error {
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		unexpected := make([]error, 0, len(joined.Unwrap()))
+		for _, child := range joined.Unwrap() {
+			if child = unexpectedCloseError(child); child != nil {
+				unexpected = append(unexpected, child)
+			}
+		}
+		return errors.Join(unexpected...)
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}

--- a/internal/runtime/builtin/ssh/sftp.go
+++ b/internal/runtime/builtin/ssh/sftp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/dagucloud/dagu/v2/internal/executor/registry"
 
@@ -22,17 +24,23 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 var _ executor.Executor = (*sftpExecutor)(nil)
 
 type sftpExecutor struct {
+	mu          sync.Mutex
 	client      *Client
 	direction   string // "upload" or "download"
 	source      string
 	destination string
 	stdout      io.Writer
 	stderr      io.Writer
+	cancel      context.CancelFunc
+	conn        *ssh.Client
+	sftpClient  *sftp.Client
+	closed      bool
 }
 
 // NewSFTPExecutor creates a new SFTP executor for file transfers.
@@ -96,33 +104,121 @@ func (e *sftpExecutor) SetStderr(out io.Writer) {
 }
 
 func (e *sftpExecutor) Kill(_ os.Signal) error {
-	// SFTP operations are not interruptible in the same way as SSH commands.
-	// The operation will complete or fail on its own.
-	return nil
+	return e.shutdown(true)
 }
 
 func (e *sftpExecutor) Run(ctx context.Context) error {
+	runCtx, cancel := context.WithCancel(ctx)
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		cancel()
+		return context.Canceled
+	}
+	e.cancel = cancel
+	e.mu.Unlock()
+	defer func() { _ = e.shutdown(false) }()
+
 	// Dial SSH connection directly - SFTP doesn't need a session, just the connection
-	conn, err := e.client.dial()
+	conn, err := e.client.dial(runCtx)
 	if err != nil {
 		return fmt.Errorf("failed to connect to SSH server: %w", err)
 	}
-	defer conn.Close()
+	if !e.setConn(conn) {
+		_ = conn.Close()
+		return context.Canceled
+	}
 
 	sftpClient, err := sftp.NewClient(conn)
 	if err != nil {
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("failed to create SFTP client: %w", err)
 	}
-	defer sftpClient.Close()
-
-	if e.direction == "download" {
-		return e.download(ctx, sftpClient)
+	if !e.setSFTPClient(sftpClient) {
+		_ = sftpClient.Close()
+		return context.Canceled
 	}
-	return e.upload(ctx, sftpClient)
+
+	var runErr error
+	if e.direction == "download" {
+		runErr = e.download(runCtx, sftpClient)
+	} else {
+		runErr = e.upload(runCtx, sftpClient)
+	}
+	if ctxErr := runCtx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return runErr
+}
+
+func (e *sftpExecutor) setConn(conn *ssh.Client) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return false
+	}
+	e.conn = conn
+	return true
+}
+
+func (e *sftpExecutor) setSFTPClient(client *sftp.Client) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return false
+	}
+	e.sftpClient = client
+	return true
+}
+
+func (e *sftpExecutor) shutdown(force bool) error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	cancel := e.cancel
+	e.cancel = nil
+	conn := e.conn
+	e.conn = nil
+	client := e.sftpClient
+	e.sftpClient = nil
+	e.mu.Unlock()
+
+	if force {
+		if cancel != nil {
+			cancel()
+		}
+		if conn != nil {
+			return conn.Close()
+		}
+		if client != nil {
+			return client.Close()
+		}
+		return nil
+	}
+
+	var clientErr, connErr error
+	if client != nil {
+		clientErr = client.Close()
+	}
+	if conn != nil {
+		connErr = conn.Close()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	return errors.Join(clientErr, connErr)
 }
 
 // upload transfers files from local to remote.
 func (e *sftpExecutor) upload(ctx context.Context, sftpClient *sftp.Client) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Check if source is a file or directory
 	info, err := os.Stat(e.source)
 	if err != nil {
@@ -139,6 +235,9 @@ func (e *sftpExecutor) upload(ctx context.Context, sftpClient *sftp.Client) erro
 // It writes to a temp file first, then renames to the final destination.
 // This prevents partial files from being left on the remote server if the upload fails.
 func (e *sftpExecutor) uploadFile(ctx context.Context, sftpClient *sftp.Client, localPath, remotePath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	logger.Info(ctx, "Uploading file",
 		slog.String("source", localPath),
 		slog.String("destination", remotePath),
@@ -218,6 +317,9 @@ func (e *sftpExecutor) uploadDir(ctx context.Context, sftpClient *sftp.Client, l
 	)
 
 	return filepath.Walk(localDir, func(localPath string, info os.FileInfo, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return err
 		}
@@ -245,6 +347,9 @@ func (e *sftpExecutor) uploadDir(ctx context.Context, sftpClient *sftp.Client, l
 
 // download transfers files from remote to local.
 func (e *sftpExecutor) download(ctx context.Context, sftpClient *sftp.Client) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Check if source is a file or directory
 	info, err := sftpClient.Stat(e.source)
 	if err != nil {
@@ -259,6 +364,9 @@ func (e *sftpExecutor) download(ctx context.Context, sftpClient *sftp.Client) er
 
 // downloadFile downloads a single file.
 func (e *sftpExecutor) downloadFile(ctx context.Context, sftpClient *sftp.Client, remotePath, localPath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	logger.Info(ctx, "Downloading file",
 		slog.String("source", remotePath),
 		slog.String("destination", localPath),
@@ -314,6 +422,9 @@ func (e *sftpExecutor) downloadDir(ctx context.Context, sftpClient *sftp.Client,
 
 	walker := sftpClient.Walk(remoteDir)
 	for walker.Step() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := walker.Err(); err != nil {
 			return fmt.Errorf("error walking remote directory: %w", err)
 		}

--- a/internal/runtime/builtin/ssh/sftp.go
+++ b/internal/runtime/builtin/ssh/sftp.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,7 +14,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/dagucloud/dagu/v2/internal/executor/registry"
 
@@ -24,23 +22,18 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/pkg/sftp"
-	"golang.org/x/crypto/ssh"
 )
 
 var _ executor.Executor = (*sftpExecutor)(nil)
 
 type sftpExecutor struct {
-	mu          sync.Mutex
+	executorLifecycle
 	client      *Client
 	direction   string // "upload" or "download"
 	source      string
 	destination string
 	stdout      io.Writer
 	stderr      io.Writer
-	cancel      context.CancelFunc
-	conn        *ssh.Client
-	sftpClient  *sftp.Client
-	closed      bool
 }
 
 // NewSFTPExecutor creates a new SFTP executor for file transfers.
@@ -108,24 +101,26 @@ func (e *sftpExecutor) Kill(_ os.Signal) error {
 }
 
 func (e *sftpExecutor) Run(ctx context.Context) error {
-	runCtx, cancel := context.WithCancel(ctx)
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
-		cancel()
+	runCtx, ok := e.begin(ctx)
+	if !ok {
 		return context.Canceled
 	}
-	e.cancel = cancel
-	e.mu.Unlock()
-	defer func() { _ = e.shutdown(false) }()
+	defer func() {
+		if closeErr := e.shutdown(false); closeErr != nil {
+			logger.Warn(ctx, "SFTP cleanup error", tag.Error(closeErr))
+		}
+	}()
 
 	// Dial SSH connection directly - SFTP doesn't need a session, just the connection
 	conn, err := e.client.dial(runCtx)
 	if err != nil {
 		return fmt.Errorf("failed to connect to SSH server: %w", err)
 	}
-	if !e.setConn(conn) {
+	if !e.registerTransport(conn) {
 		_ = conn.Close()
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return context.Canceled
 	}
 
@@ -136,8 +131,11 @@ func (e *sftpExecutor) Run(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to create SFTP client: %w", err)
 	}
-	if !e.setSFTPClient(sftpClient) {
+	if !e.registerResource(sftpClient) {
 		_ = sftpClient.Close()
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return context.Canceled
 	}
 
@@ -151,67 +149,6 @@ func (e *sftpExecutor) Run(ctx context.Context) error {
 		return ctxErr
 	}
 	return runErr
-}
-
-func (e *sftpExecutor) setConn(conn *ssh.Client) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.closed {
-		return false
-	}
-	e.conn = conn
-	return true
-}
-
-func (e *sftpExecutor) setSFTPClient(client *sftp.Client) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.closed {
-		return false
-	}
-	e.sftpClient = client
-	return true
-}
-
-func (e *sftpExecutor) shutdown(force bool) error {
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
-		return nil
-	}
-	e.closed = true
-	cancel := e.cancel
-	e.cancel = nil
-	conn := e.conn
-	e.conn = nil
-	client := e.sftpClient
-	e.sftpClient = nil
-	e.mu.Unlock()
-
-	if force {
-		if cancel != nil {
-			cancel()
-		}
-		if conn != nil {
-			return conn.Close()
-		}
-		if client != nil {
-			return client.Close()
-		}
-		return nil
-	}
-
-	var clientErr, connErr error
-	if client != nil {
-		clientErr = client.Close()
-	}
-	if conn != nil {
-		connErr = conn.Close()
-	}
-	if cancel != nil {
-		cancel()
-	}
-	return errors.Join(clientErr, connErr)
 }
 
 // upload transfers files from local to remote.

--- a/internal/runtime/builtin/ssh/ssh.go
+++ b/internal/runtime/builtin/ssh/ssh.go
@@ -5,13 +5,11 @@ package ssh
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/dagucloud/dagu/v2/internal/executor/registry"
 
@@ -42,15 +40,11 @@ func getSSHClientFromContext(ctx context.Context) *Client {
 }
 
 type sshExecutor struct {
-	mu        sync.Mutex
+	executorLifecycle
 	step      ir.Step
 	client    *Client
 	stdout    io.Writer
 	stderr    io.Writer
-	cancel    context.CancelFunc
-	conn      *ssh.Client  // SSH connection (must be closed after session)
-	session   *ssh.Session // SSH session
-	closed    bool         // Whether session/conn have been closed
 	shell     string
 	shellArgs []string
 }
@@ -88,61 +82,15 @@ func (e *sshExecutor) Kill(_ os.Signal) error {
 	return e.shutdown(true)
 }
 
-func (e *sshExecutor) shutdown(force bool) error {
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
-		return nil
-	}
-	e.closed = true
-	cancel := e.cancel
-	e.cancel = nil
-	conn := e.conn
-	e.conn = nil
-	session := e.session
-	e.session = nil
-	e.mu.Unlock()
-
-	if force {
-		if cancel != nil {
-			cancel()
-		}
-		if conn != nil {
-			return conn.Close()
-		}
-		if session != nil {
-			return session.Close()
-		}
-		return nil
-	}
-
-	var sessionErr, connErr error
-	if session != nil {
-		sessionErr = session.Close()
-	}
-	if conn != nil {
-		connErr = conn.Close()
-	}
-	if cancel != nil {
-		cancel()
-	}
-	return errors.Join(sessionErr, connErr)
-}
-
 func (e *sshExecutor) Run(ctx context.Context) error {
 	if len(e.step.Commands) == 0 && e.step.Script == "" {
 		return nil
 	}
 
-	runCtx, cancel := context.WithCancel(ctx)
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
-		cancel()
+	runCtx, ok := e.begin(ctx)
+	if !ok {
 		return context.Canceled
 	}
-	e.cancel = cancel
-	e.mu.Unlock()
 
 	defer func() {
 		if closeErr := e.shutdown(false); closeErr != nil {
@@ -155,9 +103,7 @@ func (e *sshExecutor) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
+	if !e.registerTransport(conn) {
 		_ = session.Close()
 		_ = conn.Close()
 		if ctxErr := runCtx.Err(); ctxErr != nil {
@@ -165,9 +111,13 @@ func (e *sshExecutor) Run(ctx context.Context) error {
 		}
 		return context.Canceled
 	}
-	e.conn = conn
-	e.session = session
-	e.mu.Unlock()
+	if !e.registerResource(session) {
+		_ = session.Close()
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return context.Canceled
+	}
 
 	session.Stdout = e.stdout
 	session.Stderr = e.stderr

--- a/internal/runtime/builtin/ssh/ssh.go
+++ b/internal/runtime/builtin/ssh/ssh.go
@@ -47,6 +47,7 @@ type sshExecutor struct {
 	client    *Client
 	stdout    io.Writer
 	stderr    io.Writer
+	cancel    context.CancelFunc
 	conn      *ssh.Client  // SSH connection (must be closed after session)
 	session   *ssh.Session // SSH session
 	closed    bool         // Whether session/conn have been closed
@@ -84,20 +85,46 @@ func (e *sshExecutor) SetStderr(out io.Writer) {
 }
 
 func (e *sshExecutor) Kill(_ os.Signal) error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	return e.shutdown(true)
+}
 
+func (e *sshExecutor) shutdown(force bool) error {
+	e.mu.Lock()
 	if e.closed {
+		e.mu.Unlock()
 		return nil
 	}
 	e.closed = true
+	cancel := e.cancel
+	e.cancel = nil
+	conn := e.conn
+	e.conn = nil
+	session := e.session
+	e.session = nil
+	e.mu.Unlock()
+
+	if force {
+		if cancel != nil {
+			cancel()
+		}
+		if conn != nil {
+			return conn.Close()
+		}
+		if session != nil {
+			return session.Close()
+		}
+		return nil
+	}
 
 	var sessionErr, connErr error
-	if e.session != nil {
-		sessionErr = e.session.Close()
+	if session != nil {
+		sessionErr = session.Close()
 	}
-	if e.conn != nil {
-		connErr = e.conn.Close()
+	if conn != nil {
+		connErr = conn.Close()
+	}
+	if cancel != nil {
+		cancel()
 	}
 	return errors.Join(sessionErr, connErr)
 }
@@ -107,39 +134,46 @@ func (e *sshExecutor) Run(ctx context.Context) error {
 		return nil
 	}
 
-	conn, session, err := e.client.NewSession()
+	runCtx, cancel := context.WithCancel(ctx)
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		cancel()
+		return context.Canceled
+	}
+	e.cancel = cancel
+	e.mu.Unlock()
+
+	defer func() {
+		if closeErr := e.shutdown(false); closeErr != nil {
+			logger.Warn(ctx, "SSH cleanup error", tag.Error(closeErr))
+		}
+	}()
+
+	conn, session, err := e.client.NewSession(runCtx)
 	if err != nil {
 		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 
 	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		_ = session.Close()
+		_ = conn.Close()
+		if ctxErr := runCtx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return context.Canceled
+	}
 	e.conn = conn
 	e.session = session
 	e.mu.Unlock()
-
-	defer func() {
-		e.mu.Lock()
-		defer e.mu.Unlock()
-
-		if e.closed {
-			return
-		}
-
-		// Close session first, then the underlying connection
-		if closeErr := session.Close(); closeErr != nil {
-			logger.Warn(ctx, "SSH session close error", tag.Error(closeErr))
-		}
-		if closeErr := conn.Close(); closeErr != nil {
-			logger.Warn(ctx, "SSH connection close error", tag.Error(closeErr))
-		}
-		e.closed = true
-	}()
 
 	session.Stdout = e.stdout
 	session.Stderr = e.stderr
 	session.Stdin = strings.NewReader(e.buildScript())
 
-	return e.runWithCancellation(ctx, session, e.buildShellCommand())
+	return e.runWithCancellation(runCtx, session, e.buildShellCommand())
 }
 
 // runWithCancellation executes the session command with context cancellation support.
@@ -151,13 +185,17 @@ func (e *sshExecutor) runWithCancellation(ctx context.Context, session *ssh.Sess
 
 	select {
 	case err := <-done:
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err == nil {
 			return nil
 		}
 		return fmt.Errorf("ssh execution failed: %w", err)
 	case <-ctx.Done():
-		// Close session to unblock the goroutine, then wait for it to finish
-		_ = session.Close()
+		// Closing the transport unblocks Session.Wait even when the server keeps
+		// the channel open until the remote process exits.
+		_ = e.shutdown(true)
 		<-done
 		return ctx.Err()
 	}

--- a/internal/runtime/builtin/ssh/ssh_test.go
+++ b/internal/runtime/builtin/ssh/ssh_test.go
@@ -6,6 +6,7 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -865,22 +866,23 @@ func TestExecutorCancellationInterruptsSSHHandshake(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Run("ContextDeadline", func(t *testing.T) {
+			t.Run("ContextCancellation", func(t *testing.T) {
 				addr, accepted := startBlackholeSSHServer(t)
 				exec := tt.newExec(newBlackholeSSHClient(addr))
-				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
 				errCh := make(chan error, 1)
 				go func() { errCh <- exec.Run(ctx) }()
 				conn := receiveAcceptedConnection(t, accepted)
+				cancel()
 				assertConnectionCloses(t, conn)
 
 				select {
 				case err := <-errCh:
-					require.ErrorIs(t, err, context.DeadlineExceeded)
+					require.ErrorIs(t, err, context.Canceled)
 				case <-time.After(2 * time.Second):
-					t.Fatal("executor did not return after context deadline")
+					t.Fatal("executor did not return after context cancellation")
 				}
 			})
 
@@ -904,6 +906,36 @@ func TestExecutorCancellationInterruptsSSHHandshake(t *testing.T) {
 			})
 		})
 	}
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error {
+	return f()
+}
+
+func TestExecutorLifecycleForcedShutdown(t *testing.T) {
+	t.Parallel()
+
+	var events []string
+	unexpectedErr := errors.New("unexpected close error")
+	lifecycle := executorLifecycle{
+		cancel: func() { events = append(events, "cancel") },
+		transport: closerFunc(func() error {
+			events = append(events, "transport")
+			return errors.Join(net.ErrClosed, unexpectedErr)
+		}),
+		resource: closerFunc(func() error {
+			events = append(events, "resource")
+			return io.EOF
+		}),
+	}
+
+	err := lifecycle.shutdown(true)
+	assert.Equal(t, []string{"cancel", "transport", "resource"}, events)
+	require.ErrorIs(t, err, unexpectedErr)
+	require.NotErrorIs(t, err, net.ErrClosed)
+	require.NotErrorIs(t, err, io.EOF)
 }
 
 func startBlackholeSSHServer(t *testing.T) (string, <-chan net.Conn) {

--- a/internal/runtime/builtin/ssh/ssh_test.go
+++ b/internal/runtime/builtin/ssh/ssh_test.go
@@ -6,6 +6,8 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"io"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -14,8 +16,10 @@ import (
 
 	cmnvalue "github.com/dagucloud/dagu/v2/internal/cmn/value"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 func TestNewSSHExecutor(t *testing.T) {
@@ -593,17 +597,6 @@ func TestSSHExecutor_SetStdout_SetStderr(t *testing.T) {
 	assert.Equal(t, stderr, exec.stderr)
 }
 
-func TestSSHExecutor_Kill_NoSession(t *testing.T) {
-	t.Parallel()
-
-	// Create executor without session
-	exec := &sshExecutor{}
-
-	// Kill should return nil when there's no session
-	err := exec.Kill(nil)
-	require.NoError(t, err)
-}
-
 func TestNewSSHExecutor_NoConfig(t *testing.T) {
 	t.Parallel()
 
@@ -620,24 +613,6 @@ func TestNewSSHExecutor_NoConfig(t *testing.T) {
 	_, err := NewSSHExecutor(ctx, step)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ssh configuration is not found")
-}
-
-func TestSSHExecutor_ClosedFlag(t *testing.T) {
-	t.Parallel()
-
-	// Verify that closed flag prevents double close issues
-	exec := &sshExecutor{
-		closed: false,
-	}
-
-	// First Kill should work (no session, so just returns nil)
-	err := exec.Kill(nil)
-	require.NoError(t, err)
-	assert.True(t, exec.closed)
-
-	// Second Kill should be no-op due to closed flag
-	err = exec.Kill(nil)
-	require.NoError(t, err)
 }
 
 func TestFromMapConfig_WithBastion(t *testing.T) {
@@ -856,14 +831,133 @@ func TestSFTPExecutor_SetStdout_SetStderr(t *testing.T) {
 	assert.Equal(t, stderr, exec.stderr)
 }
 
-func TestSFTPExecutor_Kill(t *testing.T) {
-	t.Parallel()
+func TestExecutorCancellationInterruptsSSHHandshake(t *testing.T) {
+	tests := []struct {
+		name    string
+		newExec func(*Client) runtimeexec.Executor
+	}{
+		{
+			name: "SSH",
+			newExec: func(client *Client) runtimeexec.Executor {
+				return &sshExecutor{
+					step:   ir.Step{Commands: []ir.CommandEntry{{Command: "true", CmdWithArgs: "true"}}},
+					client: client,
+					shell:  "/bin/sh",
+					stdout: io.Discard,
+					stderr: io.Discard,
+				}
+			},
+		},
+		{
+			name: "SFTP",
+			newExec: func(client *Client) runtimeexec.Executor {
+				return &sftpExecutor{
+					client:      client,
+					direction:   "download",
+					source:      "/remote/file",
+					destination: "/local/file",
+					stdout:      io.Discard,
+					stderr:      io.Discard,
+				}
+			},
+		},
+	}
 
-	exec := &sftpExecutor{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("ContextDeadline", func(t *testing.T) {
+				addr, accepted := startBlackholeSSHServer(t)
+				exec := tt.newExec(newBlackholeSSHClient(addr))
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
 
-	// Kill always returns nil for SFTP executor
-	err := exec.Kill(nil)
+				errCh := make(chan error, 1)
+				go func() { errCh <- exec.Run(ctx) }()
+				conn := receiveAcceptedConnection(t, accepted)
+				assertConnectionCloses(t, conn)
+
+				select {
+				case err := <-errCh:
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+				case <-time.After(2 * time.Second):
+					t.Fatal("executor did not return after context deadline")
+				}
+			})
+
+			t.Run("Kill", func(t *testing.T) {
+				addr, accepted := startBlackholeSSHServer(t)
+				exec := tt.newExec(newBlackholeSSHClient(addr))
+				errCh := make(chan error, 1)
+				go func() { errCh <- exec.Run(context.Background()) }()
+				conn := receiveAcceptedConnection(t, accepted)
+
+				require.NoError(t, exec.Kill(nil))
+				require.NoError(t, exec.Kill(nil))
+				assertConnectionCloses(t, conn)
+
+				select {
+				case err := <-errCh:
+					require.ErrorIs(t, err, context.Canceled)
+				case <-time.After(2 * time.Second):
+					t.Fatal("executor did not return after Kill")
+				}
+			})
+		})
+	}
+}
+
+func startBlackholeSSHServer(t *testing.T) (string, <-chan net.Conn) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+	return listener.Addr().String(), accepted
+}
+
+func newBlackholeSSHClient(addr string) *Client {
+	return &Client{
+		hostPort: addr,
+		cfg: &gossh.ClientConfig{
+			User:            "test",
+			Auth:            []gossh.AuthMethod{gossh.Password("test")},
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec
+			Timeout:         time.Second,
+		},
+	}
+}
+
+func receiveAcceptedConnection(t *testing.T, accepted <-chan net.Conn) net.Conn {
+	t.Helper()
+	select {
+	case conn := <-accepted:
+		t.Cleanup(func() { _ = conn.Close() })
+		return conn
+	case <-time.After(2 * time.Second):
+		t.Fatal("executor did not connect to test server")
+		return nil
+	}
+}
+
+func assertConnectionCloses(t *testing.T, conn net.Conn) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, conn)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("executor did not close the underlying connection")
+	}
 }
 
 func TestGetStringConfig(t *testing.T) {

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -153,6 +153,7 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	r.resetRunState(plan)
 
 	// Create a cancellable context for the entire execution
+	parentCtx := ctx
 	var cancel context.CancelFunc
 	if r.timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, r.timeout)
@@ -215,6 +216,11 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	// Collect final metrics
 	r.metrics.totalExecutionTime = time.Since(r.metrics.startTime)
 
+	handlerCtx := ctx
+	if r.timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) && parentCtx.Err() == nil {
+		handlerCtx = parentCtx
+	}
+
 	var eventHandlers []ir.HandlerType
 	finalStatus := r.Status(ctx, plan)
 	switch finalStatus {
@@ -230,7 +236,7 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 		if r.shouldRunFailureHandler(finalStatus) {
 			eventHandlers = append(eventHandlers, ir.HandlerOnFailure)
 		} else {
-			logger.Info(ctx, "Skipping failure handler while DAG auto-retry is pending",
+			logger.Info(ctx, "Skipping failure handler while effective DAG retry policy is pending",
 				slog.Int("autoRetryCount", r.dagRunAutoRetryCount),
 				slog.Int("autoRetryLimit", r.dagRunAutoRetryLimit),
 			)
@@ -252,15 +258,15 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 			// Set DAG_WAITING_STEPS environment variable
 			waitingSteps := strings.Join(plan.WaitingStepNames(), ",")
 
-			logger.Info(ctx, "Executing onWait handler",
+			logger.Info(handlerCtx, "Executing onWait handler",
 				slog.String("waitingSteps", waitingSteps),
 			)
 
-			if err := r.runEventHandler(ctx, plan, handlerNode, map[string]string{
+			if err := r.runEventHandler(handlerCtx, plan, handlerNode, map[string]string{
 				runenv.EnvKeyDAGWaitingSteps: waitingSteps,
 			}); err != nil {
 				// Log error but don't fail - notification failure shouldn't block Wait status
-				logger.Error(ctx, "onWait handler failed", tag.Error(err))
+				logger.Error(handlerCtx, "onWait handler failed", tag.Error(err))
 			}
 
 			if progressCh != nil {
@@ -289,10 +295,10 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 
 	for _, handler := range eventHandlers {
 		if handlerNode := r.handlers[handler]; handlerNode != nil {
-			logger.Debug(ctx, "Handler execution started",
+			logger.Debug(handlerCtx, "Handler execution started",
 				tag.Handler(handlerNode.Name()),
 			)
-			if err := r.runEventHandler(ctx, plan, handlerNode, nil); err != nil {
+			if err := r.runEventHandler(handlerCtx, plan, handlerNode, nil); err != nil {
 				r.setLastError(err)
 			}
 
@@ -302,8 +308,8 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 		}
 	}
 
-	logger.Debug(ctx, "Runner execution complete",
-		tag.Status(r.Status(ctx, plan).String()),
+	logger.Debug(handlerCtx, "Runner execution complete",
+		tag.Status(r.Status(handlerCtx, plan).String()),
 		tag.Error(r.lastError),
 	)
 

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -973,6 +973,57 @@ func TestRunner(t *testing.T) {
 		result.assertNodeStatus(t, "1", ir.NodeFailed)
 		result.assertNodeStatus(t, "onFailure", ir.NodeSucceeded)
 	})
+	t.Run("TerminalHandlersRunAfterDAGTimeout", func(t *testing.T) {
+		executorType, _ := registerStoppedStatusExecutor(t)
+		r := setupRunner(t,
+			withTimeout(platformTestDuration(100*time.Millisecond, time.Second)),
+			withOnFailure(successStep("onFailure")),
+			withOnExit(successStep("onExit")),
+		)
+
+		plan := r.newPlan(t, newStep("1", withExecutorType(executorType)))
+		result := plan.assertRun(t, ir.Failed)
+
+		require.ErrorIs(t, result.Error, context.DeadlineExceeded)
+		result.assertNodeStatus(t, "onFailure", ir.NodeSucceeded)
+		result.assertNodeStatus(t, "onExit", ir.NodeSucceeded)
+	})
+	t.Run("TerminalHandlerTimeoutDoesNotBlockOnExit", func(t *testing.T) {
+		executorType, _ := registerStoppedStatusExecutor(t)
+		handlerTimeout := platformTestDuration(100*time.Millisecond, time.Second)
+		r := setupRunner(t,
+			withTimeout(handlerTimeout),
+			withOnFailure(newStep("onFailure",
+				withCommand(test.Sleep(5*handlerTimeout)),
+				withStepTimeout(handlerTimeout),
+			)),
+			withOnExit(successStep("onExit")),
+		)
+
+		plan := r.newPlan(t, newStep("1", withExecutorType(executorType)))
+		result := plan.assertRun(t, ir.Failed)
+
+		require.ErrorIs(t, result.Error, context.DeadlineExceeded)
+		result.assertNodeStatus(t, "onFailure", ir.NodeFailed)
+		result.assertNodeStatus(t, "onExit", ir.NodeSucceeded)
+	})
+	t.Run("TerminalHandlersRetainParentCancellation", func(t *testing.T) {
+		executorType, execCh := registerStoppedStatusExecutor(t)
+		r := setupRunner(t, withOnExit(successStep("onExit")))
+		parentCtx, cancel := context.WithCancel(r.Context)
+		r.Context = parentCtx
+
+		plan := r.newPlan(t, newStep("1", withExecutorType(executorType)))
+		go func() {
+			<-execCh
+			cancel()
+		}()
+
+		result := plan.assertRun(t, ir.Failed)
+
+		require.ErrorIs(t, result.Error, context.Canceled)
+		result.assertNodeStatus(t, "onExit", ir.NodeFailed)
+	})
 	t.Run("OnFailureHandlerSkippedWhileRootDAGAutoRetryPending", func(t *testing.T) {
 		r := setupRunner(t,
 			withDAGAutoRetry(0, 2, true),


### PR DESCRIPTION
## Summary

- make SSH and SFTP cancellation close the underlying transport during dialing, handshake, bastion setup, command execution, and file transfer
- run terminal lifecycle handlers after Dagu's DAG timeout while preserving cancellation from the external caller
- make root DAG retries opt-in for newly generated `base.yaml` files without rewriting existing installations

## Root cause

SSH cancellation closed the session channel and then waited for `Session.Wait`, but the underlying SSH connection was deferred until after that wait. OpenSSH can keep the channel open until the remote command exits, so the timeout path waited for the command it was intended to interrupt. The same transport lifecycle also left SSH handshake and SFTP operations without a reliable cancellation path.

After the graph returned, terminal handlers received the same expired DAG timeout context, causing failure and exit handlers to fail immediately. Separately, the generated base configuration enabled scheduler-issued root DAG retries for every new installation, which could repeat non-idempotent timed-out workflows.

## Validation

- `go test -race ./internal/runtime/builtin/ssh`
- `go test -race ./internal/runtime`
- `go test -race ./internal/persis/file/baseconfig`
- full Docker-backed SSH and SFTP integration suite
- affected-package Linux and Windows lint checks

Fixes #2561

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SSH and SFTP cancellation close the underlying TCP/SSH transport so timeouts and Kill terminate promptly across dial, handshake (including bastion), command execution, and file transfer. Previously we closed only the session and could hang until the remote process exited; now cancellation unblocks immediately, and terminal handlers run after DAG timeouts with a valid parent context.

- Dial and handshake are context-aware for direct and bastion paths; a connection wrapper closes the socket on ctx cancel. Kill is idempotent, force-closes transport, and suppresses expected close errors.
- `ssh.run` and `sftp.*` honor step/DAG timeouts and external Kill; SFTP Kill is no longer a no-op. Blocked downloads and long-running commands terminate quickly.
- Terminal handlers after a DAG timeout run with the parent context; a handler’s timeout does not block `onExit`, and external cancellation is preserved.
- Adds unit and integration tests covering handshake cancellation, bastion timeouts, step/DAG timeouts for SSH/SFTP, idempotent Kill, and lifecycle cleanup.

**Rollout and migration**
- New installations: generated `base.yaml` no longer includes a root DAG `retry_policy`. Action: add `retry_policy` explicitly if you need automatic root DAG retries.
- Existing installations: no changes.

<sup>Written for commit dac2a7644404614a2f9cf1f6a092e1489e3b3319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SSH and SFTP operations now respond reliably to timeouts and cancellation, including bastion connections.
  - Workflow terminal handlers continue running appropriately after workflow timeouts while respecting parent cancellation.

- **Changes**
  - DAG-level retries are now opt-in by default, reducing unintended repeats for workflows with non-idempotent side effects.

- **Bug Fixes**
  - Improved cleanup of interrupted SSH/SFTP sessions and transfers.
  - Timed-out workflows now report accurate failure status and cancellation errors.
  - Repeated cancellation requests are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->