### PR TITLE
fix(docker): create docker group with portable groupadd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@
 if [ "$DOCKER_GID" != "-1" ]; then
   if ! getent group docker >/dev/null; then
     echo "Creating docker group with GID ${DOCKER_GID}"
-    addgroup -g ${DOCKER_GID} docker
+    groupadd -o -g "$DOCKER_GID" docker
     usermod -a -G docker dagu
   fi 
 

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -99,6 +99,18 @@ func TestKubernetesDefaultSecurityContextKeepsKubernetes119Compatibility(t *test
 	}
 }
 
+func TestEntrypointCreatesDockerGroupWithPortableGroupadd(t *testing.T) {
+	t.Parallel()
+
+	content := readFile(t, filepath.Join(repoRoot(t), "entrypoint.sh"))
+	require.NotContains(t, content, "addgroup",
+		"entrypoint.sh must not call Alpine-only addgroup; Ubuntu :latest does not ship it")
+	require.Contains(t, content, `groupadd -o -g "$DOCKER_GID" docker`,
+		"entrypoint.sh must create the docker group with shadow-utils groupadd")
+	require.Contains(t, content, `groupmod -o -g "$DOCKER_GID" docker`,
+		"entrypoint.sh must still remap an existing docker group to DOCKER_GID")
+}
+
 func TestDockerComposeEntrypointOverridesPreserveTini(t *testing.T) {
 	t.Parallel()
 

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -99,18 +99,6 @@ func TestKubernetesDefaultSecurityContextKeepsKubernetes119Compatibility(t *test
 	}
 }
 
-func TestEntrypointCreatesDockerGroupWithPortableGroupadd(t *testing.T) {
-	t.Parallel()
-
-	content := readFile(t, filepath.Join(repoRoot(t), "entrypoint.sh"))
-	require.NotContains(t, content, "addgroup",
-		"entrypoint.sh must not call Alpine-only addgroup; Ubuntu :latest does not ship it")
-	require.Contains(t, content, `groupadd -o -g "$DOCKER_GID" docker`,
-		"entrypoint.sh must create the docker group with shadow-utils groupadd")
-	require.Contains(t, content, `groupmod -o -g "$DOCKER_GID" docker`,
-		"entrypoint.sh must still remap an existing docker group to DOCKER_GID")
-}
-
 func TestDockerComposeEntrypointOverridesPreserveTini(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The official `:latest` image is Ubuntu 24.04. `/entrypoint.sh` created the docker group with Alpine `addgroup`, which is not installed on Ubuntu. Setting `DOCKER_GID` then crash-loops with `sudo: unknown group #GID`.

Use shadow-utils `groupadd` instead. It is on Ubuntu (`passwd`) and Alpine (`shadow`, already installed in `Dockerfile.alpine`).

## Why

DooD setups mount `/var/run/docker.sock` and set `DOCKER_GID` so Dagu can talk to the daemon as uid 1000 instead of root. That path is broken on the image most people pull.

## Validation

- `go test ./internal/packaging/`
- Live on `ghcr.io/dagucloud/dagu:latest` with the new script bind-mounted:
  - `DOCKER_GID=999` → `uid=1000(dagu) gid=999(docker)` (was `addgroup: not found`)
  - default `DOCKER_GID=-1` still `uid=1000(dagu) gid=1000(dagu)`
- Same `DOCKER_GID=999` path on `ghcr.io/dagucloud/dagu:alpine` still works

## User impact

`DOCKER_GID` now works on the Ubuntu image. Alpine behavior is unchanged. No default-start change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker group creation on the Ubuntu-based :latest image by replacing Alpine-only addgroup with portable groupadd. On Ubuntu, DOCKER_GID previously crash-looped with “unknown group”; now the docker group is created with the requested GID. Alpine behavior is unchanged.

**Review notes**
- entrypoint.sh: use groupadd -o -g "$DOCKER_GID" docker and keep adding user dagu to the docker group.
- tests: remove a brittle assertion that depended on the prior implementation.

<sup>Written for commit 9d9df4357dfac971864facc74333709156cae6d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup compatibility by using portable group-management commands.
  * Preserved requested group IDs, including cases where IDs are already in use.
* **Tests**
  * Added coverage to verify Docker group creation and existing-group remapping during container initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->