### PR TITLE
fix: preserve running status writes during teardown

### DIFF
--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1020,11 +1020,11 @@ func (a *Agent) Run(ctx context.Context) (runErr error) {
 		case <-timer.C:
 		}
 
-		status := a.Status(runningStatusCtx)
+		status := a.Status(ctx)
 		if a.finished.Load() || a.shouldDelayTerminalStatus(status.Status) {
 			return
 		}
-		a.writeStatus(runningStatusCtx, attempt, status)
+		a.writeStatus(ctx, attempt, status)
 	})
 
 	// Start the dag-run.

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -135,8 +135,7 @@ type statusContextObserver struct {
 	runningStatusWritesObserved chan struct{}
 	expectedDone                <-chan struct{}
 	runningNodeWrites           int
-	canceledStatusWrite         bool
-	differentCancellationScope  bool
+	invalidContext              bool
 }
 
 func newStatusContextObserver() *statusContextObserver {
@@ -149,11 +148,9 @@ func (o *statusContextObserver) observe(ctx context.Context, status ir.DAGRunSta
 
 	if o.expectedDone == nil {
 		o.expectedDone = ctx.Done()
-	} else if o.expectedDone != ctx.Done() {
-		o.differentCancellationScope = true
 	}
-	if ctx.Err() != nil {
-		o.canceledStatusWrite = true
+	if o.expectedDone != ctx.Done() || ctx.Err() != nil {
+		o.invalidContext = true
 	}
 
 	if status.Status != ir.Running {
@@ -175,7 +172,7 @@ func (o *statusContextObserver) observe(ctx context.Context, status ir.DAGRunSta
 func (o *statusContextObserver) observedInvalidContext() bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.canceledStatusWrite || o.differentCancellationScope
+	return o.invalidContext
 }
 
 type observedRunStateStore struct {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -119,28 +119,41 @@ func agentRunStartTimeout() time.Duration {
 	return 5 * time.Second
 }
 
+func agentRunCompletionTimeout() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 3 * time.Minute
+	}
+	return 10 * time.Second
+}
+
 func pwdCommand() string {
 	return test.ForOS("pwd", "(Get-Location).Path")
 }
 
-type delayedStatusContextObserver struct {
-	mu                        sync.Mutex
-	delayedStatusStarted      chan struct{}
-	delayedStatusContext      context.Context
-	runningNodeWrites         int
-	canceledDuringStatusWrite bool
+type statusContextObserver struct {
+	mu                          sync.Mutex
+	runningStatusWritesObserved chan struct{}
+	expectedDone                <-chan struct{}
+	runningNodeWrites           int
+	canceledStatusWrite         bool
+	differentCancellationScope  bool
 }
 
-func newDelayedStatusContextObserver() *delayedStatusContextObserver {
-	return &delayedStatusContextObserver{delayedStatusStarted: make(chan struct{})}
+func newStatusContextObserver() *statusContextObserver {
+	return &statusContextObserver{runningStatusWritesObserved: make(chan struct{})}
 }
 
-func (o *delayedStatusContextObserver) observe(ctx context.Context, status ir.DAGRunStatus) {
+func (o *statusContextObserver) observe(ctx context.Context, status ir.DAGRunStatus) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	if o.delayedStatusContext != nil && o.delayedStatusContext.Err() != nil {
-		o.canceledDuringStatusWrite = true
+	if o.expectedDone == nil {
+		o.expectedDone = ctx.Done()
+	} else if o.expectedDone != ctx.Done() {
+		o.differentCancellationScope = true
+	}
+	if ctx.Err() != nil {
+		o.canceledStatusWrite = true
 	}
 
 	if status.Status != ir.Running {
@@ -152,23 +165,22 @@ func (o *delayedStatusContextObserver) observe(ctx context.Context, status ir.DA
 		}
 		o.runningNodeWrites++
 		if o.runningNodeWrites == 2 {
-			// The first running-node status is the progress update; the second is the delayed snapshot.
-			o.delayedStatusContext = ctx
-			close(o.delayedStatusStarted)
+			// Two running-node writes confirm that progress and delayed snapshots both occurred.
+			close(o.runningStatusWritesObserved)
 		}
 		return
 	}
 }
 
-func (o *delayedStatusContextObserver) wasCanceledDuringStatusWrite() bool {
+func (o *statusContextObserver) observedInvalidContext() bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.canceledDuringStatusWrite
+	return o.canceledStatusWrite || o.differentCancellationScope
 }
 
 type observedRunStateStore struct {
 	runstate.Store
-	observer *delayedStatusContextObserver
+	observer *statusContextObserver
 }
 
 func (s *observedRunStateStore) BeginAttempt(
@@ -184,7 +196,7 @@ func (s *observedRunStateStore) BeginAttempt(
 
 type observedRunStateAttempt struct {
 	runstate.Attempt
-	observer *delayedStatusContextObserver
+	observer *statusContextObserver
 }
 
 func (a *observedRunStateAttempt) RecordStatus(ctx context.Context, status ir.DAGRunStatus) error {
@@ -211,16 +223,11 @@ func TestAgent_Run(t *testing.T) {
 			runDone <- dagAgent.Run(th.Context)
 		}()
 
-		runTimeout := 10 * time.Second
-		if runtime.GOOS == "windows" {
-			runTimeout = 3 * time.Minute
-		}
-
 		select {
 		case err := <-runDone:
 			require.NoError(t, err)
-		case <-time.After(runTimeout):
-			t.Fatalf("timed out waiting for DAG run to finish after %s", runTimeout)
+		case <-time.After(agentRunCompletionTimeout()):
+			t.Fatalf("timed out waiting for DAG run to finish")
 		}
 
 		dag.AssertLatestStatus(t, ir.Succeeded)
@@ -236,7 +243,7 @@ func TestAgent_Run(t *testing.T) {
     run: %q
 `, waitForFileScript(releaseFile, 10*time.Millisecond)))
 
-		observer := newDelayedStatusContextObserver()
+		observer := newStatusContextObserver()
 		stateStore := &observedRunStateStore{
 			Store:    persis.NewRunStateStore(th.DAGRunRepository, nil),
 			observer: observer,
@@ -252,7 +259,7 @@ func TestAgent_Run(t *testing.T) {
 		}()
 
 		select {
-		case <-observer.delayedStatusStarted:
+		case <-observer.runningStatusWritesObserved:
 		case <-time.After(agentRunStartTimeout()):
 			require.FailNow(t, "timed out waiting for delayed running-status write")
 		}
@@ -261,11 +268,11 @@ func TestAgent_Run(t *testing.T) {
 		select {
 		case err := <-runDone:
 			require.NoError(t, err)
-		case <-time.After(agentRunStartTimeout()):
+		case <-time.After(agentRunCompletionTimeout()):
 			require.FailNow(t, "timed out waiting for DAG run to finish")
 		}
 
-		require.False(t, observer.wasCanceledDuringStatusWrite())
+		require.False(t, observer.observedInvalidContext())
 		dag.AssertLatestStatus(t, ir.Succeeded)
 	})
 	t.Run("RecordsTriggerActor", func(t *testing.T) {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/persis/testutil"
 	profilepkg "github.com/dagucloud/dagu/v2/internal/profile"
 	"github.com/dagucloud/dagu/v2/internal/runtime/agent"
+	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
 	secretpkg "github.com/dagucloud/dagu/v2/internal/secret"
 	"github.com/dagucloud/dagu/v2/internal/service/scheduler"
 	"github.com/dagucloud/dagu/v2/internal/test"
@@ -121,6 +123,75 @@ func pwdCommand() string {
 	return test.ForOS("pwd", "(Get-Location).Path")
 }
 
+type delayedStatusContextObserver struct {
+	mu                        sync.Mutex
+	delayedStatusStarted      chan struct{}
+	delayedStatusContext      context.Context
+	runningNodeWrites         int
+	canceledDuringStatusWrite bool
+}
+
+func newDelayedStatusContextObserver() *delayedStatusContextObserver {
+	return &delayedStatusContextObserver{delayedStatusStarted: make(chan struct{})}
+}
+
+func (o *delayedStatusContextObserver) observe(ctx context.Context, status ir.DAGRunStatus) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.delayedStatusContext != nil && o.delayedStatusContext.Err() != nil {
+		o.canceledDuringStatusWrite = true
+	}
+
+	if status.Status != ir.Running {
+		return
+	}
+	for _, node := range status.Nodes {
+		if node.Status != ir.NodeRunning {
+			continue
+		}
+		o.runningNodeWrites++
+		if o.runningNodeWrites == 2 {
+			// The first running-node status is the progress update; the second is the delayed snapshot.
+			o.delayedStatusContext = ctx
+			close(o.delayedStatusStarted)
+		}
+		return
+	}
+}
+
+func (o *delayedStatusContextObserver) wasCanceledDuringStatusWrite() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.canceledDuringStatusWrite
+}
+
+type observedRunStateStore struct {
+	runstate.Store
+	observer *delayedStatusContextObserver
+}
+
+func (s *observedRunStateStore) BeginAttempt(
+	ctx context.Context,
+	req runstate.BeginAttemptRequest,
+) (runstate.Attempt, error) {
+	attempt, err := s.Store.BeginAttempt(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &observedRunStateAttempt{Attempt: attempt, observer: s.observer}, nil
+}
+
+type observedRunStateAttempt struct {
+	runstate.Attempt
+	observer *delayedStatusContextObserver
+}
+
+func (a *observedRunStateAttempt) RecordStatus(ctx context.Context, status ir.DAGRunStatus) error {
+	a.observer.observe(ctx, status)
+	return a.Attempt.RecordStatus(ctx, status)
+}
+
 func TestAgent_Run(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
@@ -152,6 +223,49 @@ func TestAgent_Run(t *testing.T) {
 			t.Fatalf("timed out waiting for DAG run to finish after %s", runTimeout)
 		}
 
+		dag.AssertLatestStatus(t, ir.Succeeded)
+	})
+	t.Run("DelayedRunningStatusWriteRemainsActiveUntilTerminalStatus", func(t *testing.T) {
+		th := test.Setup(t)
+		releaseFile := filepath.Join(t.TempDir(), "release")
+		t.Cleanup(func() {
+			_ = os.WriteFile(releaseFile, []byte("done"), 0600)
+		})
+		dag := th.DAG(t, fmt.Sprintf(`steps:
+  - name: wait-until-released
+    run: %q
+`, waitForFileScript(releaseFile, 10*time.Millisecond)))
+
+		observer := newDelayedStatusContextObserver()
+		stateStore := &observedRunStateStore{
+			Store:    persis.NewRunStateStore(th.DAGRunRepository, nil),
+			observer: observer,
+		}
+		dagAgent := dag.Agent(test.WithAgentOptions(agent.Options{
+			RunStateStore:       stateStore,
+			SocketServerFactory: fakeSocketServerFactory(nil),
+		}))
+
+		runDone := make(chan error, 1)
+		go func() {
+			runDone <- dagAgent.Run(th.Context)
+		}()
+
+		select {
+		case <-observer.delayedStatusStarted:
+		case <-time.After(agentRunStartTimeout()):
+			require.FailNow(t, "timed out waiting for delayed running-status write")
+		}
+		require.NoError(t, os.WriteFile(releaseFile, []byte("done"), 0600))
+
+		select {
+		case err := <-runDone:
+			require.NoError(t, err)
+		case <-time.After(agentRunStartTimeout()):
+			require.FailNow(t, "timed out waiting for DAG run to finish")
+		}
+
+		require.False(t, observer.wasCanceledDuringStatusWrite())
 		dag.AssertLatestStatus(t, ir.Succeeded)
 	})
 	t.Run("RecordsTriggerActor", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep the delayed running-status child context scoped to canceling its timer
- allow an already-started status snapshot to finish before terminal persistence
- add deterministic coverage for the status-context lifecycle

## Root cause

Run teardown canceled the delayed running-status goroutine's child context while its local status write could still be in progress. The status record was persisted, but the latest-attempt pointer helper then observed the canceled context and emitted a misleading WARN. Terminal persistence subsequently corrected the pointer, so successful short runs produced warning noise without data loss.

The delayed write now uses the live run context after its timer fires. The child context still cancels snapshots whose timer has not fired, while the existing wait preserves terminal-status ordering.

## Testing

- `make fmt`
- `go test -race -count=3 -run 'TestAgent_Run/DelayedRunningStatusWriteRemainsActiveUntilTerminalStatus' ./internal/runtime/agent`
- `make test TEST_TARGET=./internal/runtime/agent/...`
- reproduced the previously warning-producing short run with the fixed binary; it completed successfully without the pointer warning

Closes #2571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves delayed running-status writes during agent teardown to eliminate misleading WARN logs on short successful runs. Previously the child context could be canceled mid-write; now the delayed write uses the live run context after the timer, while the child context only cancels snapshots whose timer has not fired.

- Switches the delayed running-status snapshot to call Status and writeStatus with the run context after the timer; retains the child context solely to gate the timer.
- Strengthens tests with an observed `runstate` store and a simplified status context observer to confirm two running-node writes (progress + delayed), assert consistent non-canceled context, and preserve terminal-status ordering.
- No data model or API changes.

<sup>Written for commit 0277f5869d302ca245b8ce4688f03a8e3a26ef4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delayed run-status updates so they complete successfully even after a workflow step finishes or is canceled.
  * Improved reliability of workflow completion and status persistence.

* **Tests**
  * Added regression coverage for delayed status updates during blocked workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->