### PR TITLE
fix: remove empty dag-run log directories

### DIFF
--- a/internal/persis/file/dagrun/dagrun.go
+++ b/internal/persis/file/dagrun/dagrun.go
@@ -350,8 +350,15 @@ func (dr DAGRun) removeLogFiles(ctx context.Context) error {
 		parentDirs[filepath.Dir(validDir)] = struct{}{}
 	}
 
-	// Remove parent dirs if they are empty.
+	// Remove deepest directories first so their ancestors can become empty.
+	dirs := make([]string, 0, len(parentDirs))
 	for p := range parentDirs {
+		dirs = append(dirs, p)
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		return len(dirs[i]) > len(dirs[j])
+	})
+	for _, p := range dirs {
 		_ = fileutil.Remove(p)
 	}
 

--- a/internal/persis/file/dagrun/dagrun_test.go
+++ b/internal/persis/file/dagrun/dagrun_test.go
@@ -411,13 +411,15 @@ func TestRemoveLogFiles(t *testing.T) {
 
 func TestDAGRunRemove(t *testing.T) {
 	t.Run("RemoveDAGRunWithLogFiles", func(t *testing.T) {
-		tmpDir := t.TempDir()
+		dagRunLogDir := filepath.Join(t.TempDir(), "dag-run")
+		attemptLogDir := filepath.Join(dagRunLogDir, "run-attempt")
+		require.NoError(t, os.MkdirAll(attemptLogDir, 0750))
 
 		// Create test log files
 		logFiles := []string{
-			filepath.Join(tmpDir, "dag-run.log"),
-			filepath.Join(tmpDir, "step1.out"),
-			filepath.Join(tmpDir, "step1.err"),
+			filepath.Join(dagRunLogDir, "dag-run.log"),
+			filepath.Join(attemptLogDir, "step1.out"),
+			filepath.Join(attemptLogDir, "step1.err"),
 		}
 
 		for _, logFile := range logFiles {
@@ -470,6 +472,8 @@ func TestDAGRunRemove(t *testing.T) {
 			_, err := os.Stat(logFile)
 			assert.True(t, os.IsNotExist(err), "log file should be removed: %s", logFile)
 		}
+		assert.NoDirExists(t, attemptLogDir)
+		assert.NoDirExists(t, dagRunLogDir)
 	})
 
 	t.Run("RemoveWithSubDAGRuns", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- remove empty per-run log directories in dependency-safe order
- cover the production layout where step logs live below the DAG-run log directory

## Root cause

Log cleanup collected the run directory and its nested attempt directory in a map, then removed them in unspecified map iteration order. When the run directory was visited first, its non-recursive removal failed because the attempt directory still existed, and the run directory was never retried.

## Testing

- `go test -race -run 'TestDAGRunRemove/RemoveDAGRunWithLogFiles' -count=100 ./internal/persis/file/dagrun`
- `go test -race ./internal/persis/file/dagrun/...`

Closes #2573


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove empty DAG-run log directories in dependency-safe order to avoid leaving behind parent directories. Previously, cleanup could try to remove the DAG-run directory before its attempt subdirectory and never retry; now we remove deeper dirs first. This also covers the production layout where step logs live under an attempt subdirectory within the DAG-run directory.

- In `removeLogFiles`, collect parent dirs, sort by path depth (longest first), then remove so ancestors become empty.
- Update `internal/persis/file/dagrun/dagrun_test.go` to create `dag-run/run-attempt` and assert both directories are removed.

<sup>Written for commit 08c966c30441f1037dc3886f2dfe9be26335053a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of DAG-run logs by reliably removing nested log directories and their parent directories when a DAG run is deleted.
  * Prevented leftover empty directories after log removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->