### PR TITLE
fix: test remote node credentials instead of only reachability

### DIFF
--- a/internal/service/frontend/api/v1/remote_nodes.go
+++ b/internal/service/frontend/api/v1/remote_nodes.go
@@ -307,20 +307,9 @@ func (a *API) resolveRemoteNode(ctx context.Context, id string) (*remotenode.Rem
 	return a.remoteNodeStore.GetByID(ctx, id)
 }
 
-// testNodeConnection performs a health check against a remote node.
+// testNodeConnection checks that a remote node is reachable and that its
+// credentials are accepted. /health is a public path, so it cannot be used.
 func testNodeConnection(ctx context.Context, node *remotenode.RemoteNode) api.TestRemoteNodeConnectionResponse {
-	healthURL := fmt.Sprintf("%s/health", node.APIBaseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-	if err != nil {
-		return api.TestRemoteNodeConnectionResponse{
-			Success: false,
-			Error:   ptrOf(fmt.Sprintf("Failed to create request: %s", err.Error())),
-		}
-	}
-
-	node.ApplyAuth(req)
-
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
@@ -331,26 +320,67 @@ func testNodeConnection(ctx context.Context, node *remotenode.RemoteNode) api.Te
 		},
 	}
 
-	resp, err := client.Do(req)
+	probeURL := fmt.Sprintf("%s/dags?limit=1", node.APIBaseURL)
+
+	status, err := probeRemoteNode(ctx, client, probeURL, node)
 	if err != nil {
 		return api.TestRemoteNodeConnectionResponse{
 			Success: false,
 			Error:   ptrOf(fmt.Sprintf("Connection failed: %s", err.Error())),
 		}
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		return api.TestRemoteNodeConnectionResponse{
+			Success: false,
+			Error: ptrOf(fmt.Sprintf(
+				"Reachable, but the remote rejected the credentials (HTTP %d)", status)),
+		}
+
+	case status < 200 || status >= 300:
+		return api.TestRemoteNodeConnectionResponse{
+			Success: false,
+			Error:   ptrOf(fmt.Sprintf("Connection test returned HTTP %d", status)),
+		}
+	}
+
+	if anon, err := probeRemoteNode(ctx, client, probeURL, nil); err == nil &&
+		anon >= 200 && anon < 300 {
 		return api.TestRemoteNodeConnectionResponse{
 			Success: true,
-			Message: ptrOf(fmt.Sprintf("Connected successfully (HTTP %d)", resp.StatusCode)),
+			Message: ptrOf(fmt.Sprintf(
+				"Connected successfully (HTTP %d). The remote does not require "+
+					"authentication, so the credentials were not verified.", status)),
 		}
 	}
 
 	return api.TestRemoteNodeConnectionResponse{
-		Success: false,
-		Error:   ptrOf(fmt.Sprintf("Health check returned HTTP %d", resp.StatusCode)),
+		Success: true,
+		Message: ptrOf(fmt.Sprintf(
+			"Connected successfully (HTTP %d); credentials accepted.", status)),
 	}
+}
+
+// probeRemoteNode issues one GET and returns its status code.
+// A nil node probes anonymously.
+func probeRemoteNode(ctx context.Context, client *http.Client, url string, node *remotenode.RemoteNode) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if node != nil {
+		node.ApplyAuth(req)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
 }
 
 // toRemoteNodeResponse converts a resolved node to an API response.

--- a/internal/service/frontend/api/v1/remote_nodes_test.go
+++ b/internal/service/frontend/api/v1/remote_nodes_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/remotenode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func guardedRemote(t *testing.T, wantToken string) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if wantToken != "" && r.Header.Get("Authorization") != "Bearer "+wantToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestTestNodeConnection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidTokenSucceeds", func(t *testing.T) {
+		t.Parallel()
+
+		srv := guardedRemote(t, "good-token")
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "good-token",
+		})
+
+		assert.True(t, result.Success)
+		require.NotNil(t, result.Message)
+		assert.Contains(t, *result.Message, "credentials accepted")
+	})
+
+	// The regression: probing /health passed a node whose every real request 401s.
+	t.Run("RejectedTokenFails", func(t *testing.T) {
+		t.Parallel()
+
+		srv := guardedRemote(t, "good-token")
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "wrong-token",
+		})
+
+		assert.False(t, result.Success)
+		require.NotNil(t, result.Error)
+		assert.Contains(t, *result.Error, "rejected the credentials")
+		assert.Contains(t, *result.Error, "401")
+	})
+
+	t.Run("MissingCredentialsFail", func(t *testing.T) {
+		t.Parallel()
+
+		srv := guardedRemote(t, "good-token")
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeNone,
+		})
+
+		assert.False(t, result.Success)
+		require.NotNil(t, result.Error)
+		assert.Contains(t, *result.Error, "rejected the credentials")
+	})
+
+	t.Run("UnguardedRemoteReportsCredentialsUnverified", func(t *testing.T) {
+		t.Parallel()
+
+		srv := guardedRemote(t, "")
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "never-checked",
+		})
+
+		assert.True(t, result.Success)
+		require.NotNil(t, result.Message)
+		assert.Contains(t, *result.Message, "does not require authentication")
+	})
+
+	t.Run("UnreachableRemoteFails", func(t *testing.T) {
+		t.Parallel()
+
+		srv := guardedRemote(t, "good-token")
+		url := srv.URL
+		srv.Close()
+
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: url + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "good-token",
+		})
+
+		assert.False(t, result.Success)
+		require.NotNil(t, result.Error)
+		assert.Contains(t, *result.Error, "Connection failed")
+	})
+}

--- a/internal/service/frontend/api/v1/remote_nodes_test.go
+++ b/internal/service/frontend/api/v1/remote_nodes_test.go
@@ -33,6 +33,17 @@ func guardedRemote(t *testing.T, wantToken string) *httptest.Server {
 	return srv
 }
 
+func remoteReturning(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
 func TestTestNodeConnection(t *testing.T) {
 	t.Parallel()
 
@@ -80,6 +91,37 @@ func TestTestNodeConnection(t *testing.T) {
 		assert.False(t, result.Success)
 		require.NotNil(t, result.Error)
 		assert.Contains(t, *result.Error, "rejected the credentials")
+	})
+
+	t.Run("ForbiddenIsRejected", func(t *testing.T) {
+		t.Parallel()
+
+		srv := remoteReturning(t, http.StatusForbidden)
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "good-token",
+		})
+
+		assert.False(t, result.Success)
+		require.NotNil(t, result.Error)
+		assert.Contains(t, *result.Error, "rejected the credentials")
+		assert.Contains(t, *result.Error, "403")
+	})
+
+	t.Run("ServerErrorFails", func(t *testing.T) {
+		t.Parallel()
+
+		srv := remoteReturning(t, http.StatusInternalServerError)
+		result := testNodeConnection(context.Background(), &remotenode.RemoteNode{
+			APIBaseURL: srv.URL + "/api/v1",
+			AuthType:   remotenode.AuthTypeToken,
+			AuthToken:  "good-token",
+		})
+
+		assert.False(t, result.Success)
+		require.NotNil(t, result.Error)
+		assert.Contains(t, *result.Error, "Connection test returned HTTP 500")
 	})
 
 	t.Run("UnguardedRemoteReportsCredentialsUnverified", func(t *testing.T) {


### PR DESCRIPTION
## Problem

A remote node's **Test Connection** button reports success without ever testing the credential.

Configure a remote node with a wrong bearer token, then:

```console
$ curl -s -X POST -H "Authorization: Bearer $HUB_JWT" \
    "$HUB/api/v1/remote-nodes/cfg:my-node/test-connection"
{"message":"Connected successfully (HTTP 200)","success":true}

$ curl -s -H "Authorization: Bearer $HUB_JWT" \
    "$HUB/api/v1/dags?remoteNode=my-node"
{"code":"bad_gateway","message":"remote node responded with status 401"}
```

The node shows healthy and every DAG listing under it fails. The one affordance in the product for "did I wire this up right" is green precisely when the answer is no — and it points the user away from the cause, which is the credential.

It is not only a *wrong* token that passes. A node configured with `auth_type: none`, pointed at a remote that requires auth, is also reported green. The check distinguishes exactly one thing: whether DNS/TCP works.

## Cause

`testNodeConnection` probes `{api_base_url}/health`. That path is on the frontend's public-path allowlist (`buildAuthOptions`, alongside `auth/login` and `auth/setup`), so it is excluded from the auth middleware in every auth mode and answers 200 to anyone:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' \
    -H 'Authorization: Bearer totally-wrong-token' http://remote:8080/api/v1/health
200
$ curl -s -o /dev/null -w '%{http_code}\n' http://remote:8080/api/v1/dags
401
```

The handler does call `node.ApplyAuth(req)` — it sends the credential to an endpoint structurally unable to check it.

## Change

Probe `GET {api_base_url}/dags?limit=1`, an endpoint the remote guards:

- transport error → `Connection failed: …` (unchanged behaviour);
- **401/403 → failure**, `Reachable, but the remote rejected the credentials (HTTP 401)`;
- other non-2xx → failure, with the status reported verbatim;
- 2xx → success.

On success the same GET is repeated **anonymously**. If that also returns 2xx the remote is running `auth.mode: none`, and the message says the credentials were not verified rather than passing the 200 off as proof they are good — otherwise a green button would again mean less than it appears to. That second request only happens on the success path.

## Verification

Two 2.11.2 instances on a Docker network, plus a third running `auth.mode: none`; a hub with five `remote_nodes` entries pointed at them. Every cell below was observed — the "before" column against the stock `ghcr.io/dagucloud/dagu:2.11.2` image, the "after" column against a locally built binary carrying this change.

| node | before | after |
|---|---|---|
| correct token | ✅ `Connected successfully (HTTP 200)` | ✅ `Connected successfully (HTTP 200); credentials accepted.` |
| **wrong token** | ✅ `Connected successfully (HTTP 200)` | ❌ `Reachable, but the remote rejected the credentials (HTTP 401)` |
| **`auth_type: none`, guarded remote** | ✅ `Connected successfully (HTTP 200)` | ❌ `Reachable, but the remote rejected the credentials (HTTP 401)` |
| remote with `auth.mode: none` | ✅ `Connected successfully (HTTP 200)` | ✅ `Connected successfully (HTTP 200). The remote does not require authentication, so the credentials were not verified.` |
| unreachable host | ❌ `Connection failed: …` | ❌ `Connection failed: …` |

Rows 2 and 3 are the bug. Row 4 is the case the fix must not get wrong: the remote accepts anything, so the credentials genuinely are untested, and the message now says so instead of implying they were checked.

After the change, `test-connection` agrees with `GET /dags?remoteNode=` in all five rows, and reachable-but-unauthenticated stays distinguishable from unreachable.

## Tests

`remote_nodes.go` had no test file. This adds `TestTestNodeConnection` covering all five cases above, against an `httptest` remote that mirrors the real one: `/health` open to everyone, every other path requiring the bearer token.

Four of the five subtests fail against the previous implementation — verified by reverting the handler and re-running. The unreachable case passes both ways, since that path is unchanged.

`gofmt`, `go vet` and `go test ./internal/service/frontend/api/v1/` are clean.

## Related Issues

Closes #2576

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates remote node credentials in Test Connection by probing a guarded endpoint instead of public `/health`. Previously it reported success with wrong or missing tokens; now it succeeds only when the credential is accepted and flags unguarded remotes as “credentials not verified.”

- Behavior: 401/403 → failure “remote rejected the credentials”; other non-2xx → failure “Connection test returned HTTP <code>”; 2xx → success. On success, an anonymous retry that also returns 2xx reports “does not require authentication.”
- Implementation: replace `/health` with authenticated `GET /dags?limit=1`; add `probeRemoteNode`; keep timeout and transport unchanged.
- Tests: add `internal/service/frontend/api/v1/remote_nodes_test.go` covering valid token, wrong token, missing credentials, unguarded remote, unreachable host, explicit 403, and 500.
- Impact: UI messages change; API shape unchanged; distinguishes unreachable from unauthenticated. No migration required.

<sup>Written for commit 8f388fb434e4a6ced62e99910299912c0a64ba9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote-node connection validation by checking access to a protected endpoint.
  * Credentials are now clearly distinguished between accepted, rejected, missing, or unverified.
  * Connection failures provide more accurate results for unreachable or unavailable remote nodes.
  * Added validation for remotes that do not require authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->