### PR TITLE
fix: preserve DAG names for external symlink entries

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/buildenv"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
@@ -350,6 +351,11 @@ func loadDAGWithParams(ctx *Context, args []string, isSubDAGRun bool) (*ir.DAG, 
 		spec.WithBaseConfig(ctx.Config.Paths.BaseConfig),
 		spec.WithWorkspaceBaseConfigDir(workspace.BaseConfigDir(ctx.Config.Paths.DAGsDir)),
 		spec.WithDAGsDir(ctx.Config.Paths.DAGsDir),
+	}
+	if definitionID := dagDefinitionIDFromEnv(); definitionID != "" {
+		loadOpts = append(loadOpts, spec.WithDefaultName(
+			fileutil.TrimYAMLFileExtension(filepath.Base(definitionID)),
+		))
 	}
 
 	if isSubDAGRun {

--- a/internal/cmn/fileutil/cache.go
+++ b/internal/cmn/fileutil/cache.go
@@ -84,13 +84,20 @@ func (c *Cache[T]) InvalidateAll() {
 func (c *Cache[T]) LoadLatest(
 	filePath string, loader func() (T, error),
 ) (T, error) {
-	stale, fi, err := c.isStale(filePath)
+	return c.LoadLatestByKey(filePath, filePath, loader)
+}
+
+// LoadLatestByKey gets the latest version of an item under a caller-provided cache key.
+func (c *Cache[T]) LoadLatestByKey(
+	key, filePath string, loader func() (T, error),
+) (T, error) {
+	stale, fi, err := c.isStaleByKey(key, filePath)
 	if err != nil {
 		var zero T
 		return zero, err
 	}
 	if !stale {
-		if e, ok := c.lru.Get(filePath); ok {
+		if e, ok := c.lru.Get(key); ok {
 			return e.data, nil
 		}
 	}
@@ -99,7 +106,7 @@ func (c *Cache[T]) LoadLatest(
 		var zero T
 		return zero, err
 	}
-	c.Store(filePath, data, fi)
+	c.Store(key, data, fi)
 	return data, nil
 }
 
@@ -120,11 +127,15 @@ func (c *Cache[T]) IsStale(fileName string) (bool, os.FileInfo, error) {
 }
 
 func (c *Cache[T]) isStale(fileName string) (bool, os.FileInfo, error) {
-	fi, err := os.Stat(fileName)
+	return c.isStaleByKey(fileName, fileName)
+}
+
+func (c *Cache[T]) isStaleByKey(key, filePath string) (bool, os.FileInfo, error) {
+	fi, err := os.Stat(filePath)
 	if err != nil {
-		return true, fi, fmt.Errorf("failed to stat file %s: %w", fileName, err)
+		return true, fi, fmt.Errorf("failed to stat file %s: %w", filePath, err)
 	}
-	e, ok := c.lru.Peek(fileName)
+	e, ok := c.lru.Peek(key)
 	if !ok {
 		return true, fi, nil
 	}

--- a/internal/persis/dag_repository.go
+++ b/internal/persis/dag_repository.go
@@ -66,6 +66,7 @@ func (r *DAGRepository) GetDetails(ctx context.Context, id string, opts DAGLoadO
 	loadOpts = append(loadOpts, spec.WithoutEval())
 	var dag *ir.DAG
 	if definition.SourcePath != "" {
+		loadOpts = append(loadOpts, spec.WithDefaultName(definition.ID))
 		dag, err = spec.LoadYAMLAt(ctx, definition.Source, definition.SourcePath, loadOpts...)
 	} else {
 		loadOpts = append(loadOpts, spec.WithName(definition.ID))
@@ -100,6 +101,7 @@ func (r *DAGRepository) UpdateSpec(ctx context.Context, id string, source []byte
 	loadOpts := r.loadOptions(spec.WithoutEval())
 	var dag *ir.DAG
 	if definition.SourcePath != "" {
+		loadOpts = append(loadOpts, spec.WithDefaultName(definition.ID))
 		dag, err = spec.LoadYAMLAt(ctx, source, definition.SourcePath, loadOpts...)
 	} else {
 		loadOpts = append(loadOpts, spec.WithName(id))

--- a/internal/persis/dag_repository_test.go
+++ b/internal/persis/dag_repository_test.go
@@ -54,7 +54,7 @@ func TestDAGRepositoryLoadsDefinitionWithoutSourcePath(t *testing.T) {
 }
 
 func TestDAGRepositoryLoadsStoredSourceWithAuthoredPath(t *testing.T) {
-	sourcePath := filepath.Join(t.TempDir(), "stored.yaml")
+	sourcePath := filepath.Join(t.TempDir(), "resolved-target-name-that-is-not-the-entry.yaml")
 	repository := NewDAGRepository(dagDefinitionStoreStub{
 		definition: DAGDefinition{
 			ID:         "stored",
@@ -75,7 +75,7 @@ func TestDAGRepositoryUpdateValidatesFromStoredSourcePath(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sourcePath := filepath.Join(dir, "stored.yaml")
+	sourcePath := filepath.Join(dir, "resolved-target-name-that-is-not-the-entry.yaml")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "params.schema.json"), []byte(`{"type":"object"}`), 0o600))
 
 	updated := false
@@ -90,7 +90,6 @@ func TestDAGRepositoryUpdateValidatesFromStoredSourcePath(t *testing.T) {
 	}, DAGRepositoryOptions{})
 
 	err := repository.UpdateSpec(context.Background(), "stored", []byte(`
-name: stored
 params:
   schema: params.schema.json
 steps: []

--- a/internal/persis/file/dag/dagindex/dagindex.go
+++ b/internal/persis/file/dag/dagindex/dagindex.go
@@ -23,7 +23,7 @@ const (
 	// IndexFileName is the name of the DAG definition index file.
 	IndexFileName = ".dag.index"
 	// IndexVersion is the current index format version.
-	IndexVersion = 3
+	IndexVersion = 4
 )
 
 // YAMLFileMeta holds stat metadata for a single YAML file.
@@ -126,9 +126,10 @@ func buildEntry(
 	flags SuspendFlags,
 	loadOpts ...spec.LoadOption,
 ) {
-	opts := make([]spec.LoadOption, 0, len(loadOpts)+4)
+	opts := make([]spec.LoadOption, 0, len(loadOpts)+5)
 	opts = append(opts, loadOpts...)
 	opts = append(opts,
+		spec.WithDefaultName(entryFileName(entry.FilePath)),
 		spec.OnlyMetadata(),
 		spec.WithoutEval(),
 		spec.SkipSchemaValidation(),

--- a/internal/persis/file/dag/dagindex/dagindex_test.go
+++ b/internal/persis/file/dag/dagindex/dagindex_test.go
@@ -198,6 +198,25 @@ func TestBuild_BasicDAGs(t *testing.T) {
 	assert.Empty(t, legacyEntry.LoadError)
 }
 
+func TestBuild_UsesEntryNameForResolvedLoadPath(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(t.TempDir(), "resolved-target-name-that-is-not-the-entry.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte("steps: []\n"), 0600))
+
+	info, err := os.Stat(targetPath)
+	require.NoError(t, err)
+	idx := Build(context.Background(), dir, []YAMLFileMeta{{
+		Name:     "entry-name.yaml",
+		LoadPath: targetPath,
+		Size:     info.Size(),
+		ModTime:  info.ModTime().UnixNano(),
+	}}, nil)
+
+	require.Len(t, idx.Entries, 1)
+	assert.Equal(t, "entry-name", idx.Entries[0].Name)
+	assert.Empty(t, idx.Entries[0].LoadError)
+}
+
 func TestBuild_WithBuildErrors(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -355,9 +355,13 @@ func (store *Store) GetMetadata(ctx context.Context, name string) (*ir.DAG, erro
 	if store.fileCache == nil {
 		return spec.Load(ctx, resolved.ResolvedPath, loadOpts...)
 	}
-	return store.fileCache.LoadLatest(resolved.ResolvedPath, func() (*ir.DAG, error) {
+	return store.fileCache.LoadLatestByKey(metadataCacheKey(resolved), resolved.ResolvedPath, func() (*ir.DAG, error) {
 		return spec.Load(ctx, resolved.ResolvedPath, loadOpts...)
 	})
+}
+
+func metadataCacheKey(resolved ResolvedFile) string {
+	return resolved.EntryPath + "\x00" + resolved.ResolvedPath
 }
 
 // FileMode used for newly created DAG files
@@ -375,7 +379,7 @@ func (store *Store) Update(ctx context.Context, name string, yamlSpec []byte) er
 		return err
 	}
 	if store.fileCache != nil {
-		store.fileCache.Invalidate(resolved.ResolvedPath)
+		store.fileCache.Invalidate(metadataCacheKey(resolved))
 	}
 	store.invalidateIndex()
 	return nil
@@ -413,7 +417,7 @@ func (store *Store) Delete(ctx context.Context, name string) error {
 		return err
 	}
 	if store.fileCache != nil {
-		store.fileCache.Invalidate(resolved.ResolvedPath)
+		store.fileCache.Invalidate(metadataCacheKey(resolved))
 	}
 	store.invalidateIndex()
 	return nil

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -173,7 +173,8 @@ func (store *Store) Get(ctx context.Context, id string) (persis.DAGDefinition, e
 		}
 		return persis.DAGDefinition{}, err
 	}
-	return persis.DAGDefinition{ID: id, Source: source, SourcePath: resolved.ResolvedPath}, nil
+	entryName := fileutil.TrimYAMLFileExtension(filepath.Base(resolved.EntryPath))
+	return persis.DAGDefinition{ID: entryName, Source: source, SourcePath: resolved.ResolvedPath}, nil
 }
 
 func (store *Store) Catalog(ctx context.Context) (persis.DAGCatalog, error) {
@@ -346,6 +347,7 @@ func (store *Store) GetMetadata(ctx context.Context, name string) (*ir.DAG, erro
 	}
 	store.refreshBaseConfigState()
 	loadOpts := store.defaultLoadOptions(
+		spec.WithDefaultName(fileutil.TrimYAMLFileExtension(filepath.Base(resolved.EntryPath))),
 		spec.OnlyMetadata(),
 		spec.WithoutEval(),
 		spec.SkipSchemaValidation(),

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -375,6 +375,32 @@ steps:
 	assert.Equal(t, `batch_size="10" debug="false"`, dag.DefaultParams)
 }
 
+func TestGetMetadataCachesSharedSymlinkTargetsByEntry(t *testing.T) {
+	dagDir := t.TempDir()
+	targetPath := filepath.Join(t.TempDir(), "shared.yaml")
+	require.NoError(t, os.WriteFile(targetPath, []byte("steps: []\n"), 0600))
+	for _, name := range []string{"first", "second"} {
+		if err := os.Symlink(targetPath, filepath.Join(dagDir, name+".yaml")); err != nil {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+	}
+
+	store := newRepository(
+		dagDir,
+		WithFileCache(fileutil.NewCache[*ir.DAG]("dag_definition", 16, time.Hour)),
+		WithSkipExamples(true),
+		WithSymlinks(true),
+	)
+	ctx := context.Background()
+
+	first, err := store.GetMetadata(ctx, "first")
+	require.NoError(t, err)
+	second, err := store.GetMetadata(ctx, "second")
+	require.NoError(t, err)
+	assert.Equal(t, "first", first.Name)
+	assert.Equal(t, "second", second.Name)
+}
+
 func TestGetDetails(t *testing.T) {
 	tmpDir := fileutil.MustTempDir("test-get-details")
 	defer func() {

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -533,7 +533,7 @@ func TestGetSpecRejectsSymlinkOutsideConfiguredDirectories(t *testing.T) {
 func TestExternalDAGFileSymlink(t *testing.T) {
 	baseDir := t.TempDir()
 	targetDir := t.TempDir()
-	const dagContent = "name: external\nsteps:\n  - run: echo external\n"
+	const dagContent = "steps:\n  - run: echo external\n"
 	targetPath := filepath.Join(targetDir, "source.yaml")
 	require.NoError(t, os.WriteFile(targetPath, []byte(dagContent), 0600))
 	linkPath := filepath.Join(baseDir, "external.yaml")
@@ -560,12 +560,18 @@ func TestExternalDAGFileSymlink(t *testing.T) {
 		require.Empty(t, issues)
 		require.Len(t, result.Items, 1)
 		assert.Equal(t, "external", result.Items[0].Name)
+		assert.Empty(t, result.Items[0].BuildErrors)
+
+		metadata, err := store.GetMetadata(context.Background(), "external")
+		require.NoError(t, err)
+		assert.Equal(t, "external", metadata.Name)
 
 		spec, err := store.GetSpec(context.Background(), "external")
 		require.NoError(t, err)
 		assert.Equal(t, dagContent, spec)
-		_, err = store.GetDetails(context.Background(), "external", persis.DAGLoadOptions{})
+		details, err := store.GetDetails(context.Background(), "external", persis.DAGLoadOptions{})
 		require.NoError(t, err)
+		assert.Equal(t, "external", details.Name)
 
 		assert.ErrorIs(t, store.UpdateSpec(context.Background(), "external", []byte(dagContent)), persis.ErrDAGReadOnly)
 		assert.ErrorIs(t, store.Delete(context.Background(), "external"), persis.ErrDAGReadOnly)
@@ -584,8 +590,8 @@ func TestListRebuildsIndexAfterSymlinkRepoint(t *testing.T) {
 	targetDir := t.TempDir()
 	firstPath := filepath.Join(targetDir, "first.yaml")
 	secondPath := filepath.Join(targetDir, "second.yaml")
-	firstSpec := []byte("name: first\nsteps:\n  - run: echo one\n")
-	secondSpec := []byte("name: other\nsteps:\n  - run: echo two\n")
+	firstSpec := []byte("description: first\nsteps:\n  - run: echo one\n")
+	secondSpec := []byte("description: other\nsteps:\n  - run: echo two\n")
 	require.Len(t, secondSpec, len(firstSpec))
 	require.NoError(t, os.WriteFile(firstPath, firstSpec, 0600))
 	require.NoError(t, os.WriteFile(secondPath, secondSpec, 0600))
@@ -602,7 +608,8 @@ func TestListRebuildsIndexAfterSymlinkRepoint(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, issues)
 	require.Len(t, result.Items, 1)
-	assert.Equal(t, "first", result.Items[0].Name)
+	assert.Equal(t, "linked", result.Items[0].Name)
+	assert.Equal(t, "first", result.Items[0].Description)
 
 	require.NoError(t, os.Remove(linkPath))
 	require.NoError(t, os.Symlink(secondPath, linkPath))
@@ -610,7 +617,8 @@ func TestListRebuildsIndexAfterSymlinkRepoint(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, issues)
 	require.Len(t, result.Items, 1)
-	assert.Equal(t, "other", result.Items[0].Name)
+	assert.Equal(t, "linked", result.Items[0].Name)
+	assert.Equal(t, "other", result.Items[0].Description)
 }
 
 func TestGetSpecAllowsExplicitSearchPaths(t *testing.T) {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -336,7 +336,7 @@ func (a *API) EnqueueDAGRunFromSpec(ctx context.Context, request api.EnqueueDAGR
 		}
 	}
 
-	if err := a.enqueueDAGRun(ctx, dag, params, dagRunId, valueOf(request.Body.Name), ir.TriggerTypeManual, "", profileName, valueOf(request.Body.NoReuse)); err != nil {
+	if err := a.enqueueDAGRun(ctx, dag, params, dagRunId, valueOf(request.Body.Name), ir.TriggerTypeManual, "", profileName, valueOf(request.Body.NoReuse), ""); err != nil {
 		return nil, fmt.Errorf("error enqueuing dag-run: %w", err)
 	}
 
@@ -3494,7 +3494,7 @@ func (a *API) rescheduleDAGRun(ctx context.Context, dagName, dagRunID string, op
 	}
 	var enqueueErr error
 	if opts.useCurrentDAGFile {
-		enqueueErr = a.enqueueDAGRun(ctx, dag, paramsToUse, newDagRunID, "", ir.TriggerTypeManual, "", profileName, status.NoReuse)
+		enqueueErr = a.enqueueDAGRun(ctx, dag, paramsToUse, newDagRunID, "", ir.TriggerTypeManual, "", profileName, status.NoReuse, status.DAGDefinitionID())
 	} else {
 		enqueueErr = a.enqueuePreparedDAGRun(ctx, dag, paramsToUse, newDagRunID, ir.TriggerTypeManual, profileName, status.NoReuse)
 	}

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1730,7 +1730,7 @@ func (a *API) EnqueueDAGDAGRun(ctx context.Context, request api.EnqueueDAGDAGRun
 		return nil, err
 	}
 
-	if err := a.enqueueDAGRun(ctx, dag, valueOf(request.Body.Params), dagRunId, nameOverride, ir.TriggerTypeManual, labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
+	if err := a.enqueueDAGRun(ctx, dag, valueOf(request.Body.Params), dagRunId, nameOverride, ir.TriggerTypeManual, labels, profileName, valueOf(request.Body.NoReuse), request.FileName); err != nil {
 		return nil, fmt.Errorf("error enqueuing dag-run: %w", err)
 	}
 
@@ -1748,7 +1748,7 @@ func (a *API) EnqueueDAGDAGRun(ctx context.Context, request api.EnqueueDAGDAGRun
 	}, nil
 }
 
-func (a *API) enqueueDAGRun(ctx context.Context, dag *ir.DAG, params, dagRunID, nameOverride string, triggerType ir.TriggerType, labels, profileName string, noReuse bool) error {
+func (a *API) enqueueDAGRun(ctx context.Context, dag *ir.DAG, params, dagRunID, nameOverride string, triggerType ir.TriggerType, labels, profileName string, noReuse bool, definitionID string) error {
 	resolvedDAG, err := spec.ResolveRuntimeParams(ctx, dag, params, spec.ResolveRuntimeParamsOptions{
 		BaseConfig: a.config.Paths.BaseConfig,
 	})
@@ -1788,6 +1788,7 @@ func (a *API) enqueueDAGRun(ctx context.Context, dag *ir.DAG, params, dagRunID, 
 		TriggerActor: triggerActorFromContext(ctx),
 		Labels:       labels,
 		ProfileName:  profileName,
+		DefinitionID: definitionID,
 		NoReuse:      noReuse,
 	}
 	if dag.Queue != "" {

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -947,9 +947,8 @@ func TestExternalDAGFileSymlinkAPI(t *testing.T) {
 	}))
 
 	targetDir := t.TempDir()
-	targetPath := filepath.Join(targetDir, "source.yaml")
+	targetPath := filepath.Join(targetDir, "resolved-target-name-that-is-not-the-entry.yaml")
 	dagSpec := fmt.Sprintf(`
-name: external-link
 steps:
   - %s
 `, test.ShellQuote("exit 0"))
@@ -958,9 +957,21 @@ steps:
 		t.Skipf("symlink creation is unavailable: %v", err)
 	}
 
-	server.Client().Get("/api/v1/dags/external-link").
+	resp := server.Client().Get("/api/v1/dags?name=external-link").
 		ExpectStatus(http.StatusOK).Send(t)
-	resp := server.Client().Post(
+	var listBody api.ListDAGs200JSONResponse
+	resp.Unmarshal(t, &listBody)
+	require.Len(t, listBody.Dags, 1)
+	assert.Equal(t, "external-link", listBody.Dags[0].Dag.Name)
+
+	resp = server.Client().Get("/api/v1/dags/external-link").
+		ExpectStatus(http.StatusOK).Send(t)
+	var details api.GetDAGDetails200JSONResponse
+	resp.Unmarshal(t, &details)
+	require.NotNil(t, details.Dag)
+	assert.Equal(t, "external-link", details.Dag.Name)
+
+	resp = server.Client().Post(
 		"/api/v1/dags/external-link/enqueue",
 		api.EnqueueDAGDAGRunJSONRequestBody{},
 	).ExpectStatus(http.StatusOK).Send(t)

--- a/internal/service/scheduler/entryreader_internal_test.go
+++ b/internal/service/scheduler/entryreader_internal_test.go
@@ -370,7 +370,8 @@ func TestEntryReaderExternalDAGFileSymlink(t *testing.T) {
 				require.NoError(t, os.MkdirAll(linkDir, 0750))
 			}
 			targetDir := t.TempDir()
-			targetPath := writeDAGFile(t, targetDir, "source.yaml", "external")
+			targetPath := filepath.Join(targetDir, "resolved-target-name-that-is-not-the-entry.yaml")
+			require.NoError(t, os.WriteFile(targetPath, []byte("steps:\n  - run: echo external\n"), 0644))
 			if err := os.Symlink(targetPath, filepath.Join(linkDir, "external.yaml")); err != nil {
 				t.Skipf("symlink creation is unavailable: %v", err)
 			}

--- a/internal/spec/builder.go
+++ b/internal/spec/builder.go
@@ -119,8 +119,10 @@ type buildOpts struct {
 	Parameters string
 	// ParametersList specifies the parameters to the DAG.
 	ParametersList []string
-	// Name of the ir.DAG if it's not defined in the spec
+	// Name overrides the entrypoint DAG name.
 	Name string
+	// DefaultName is used when the entrypoint manifest omits a name.
+	DefaultName string
 	// DAGsDir is the directory containing the ir.DAG files.
 	DAGsDir string
 	// DefaultWorkingDir is the default working directory for DAGs without explicit workingDir.

--- a/internal/spec/dag.go
+++ b/internal/spec/dag.go
@@ -974,6 +974,9 @@ func buildName(ctx buildContext, d *dag) (string, error) {
 	// Fallback to filename without extension only for the main DAG (index 0)
 	// Sub-DAGs in multi-DAG files must have explicit names
 	if ctx.index == 0 {
+		if ctx.opts.DefaultName != "" {
+			return strings.TrimSpace(ctx.opts.DefaultName), nil
+		}
 		return defaultName(ctx.file), nil
 	}
 	return "", nil

--- a/internal/spec/dag_test.go
+++ b/internal/spec/dag_test.go
@@ -539,7 +539,7 @@ func TestBuildName(t *testing.T) {
 		{
 			name:     "FromDAGName",
 			dag:      &dag{Name: "  my-dag  "},
-			ctx:      testBuildContext(),
+			ctx:      buildContext{opts: buildOpts{DefaultName: "default-name"}},
 			expected: "my-dag",
 		},
 		{
@@ -551,6 +551,12 @@ func TestBuildName(t *testing.T) {
 				index: 0,
 			},
 			expected: "override-name",
+		},
+		{
+			name:     "FromDefaultName",
+			dag:      &dag{},
+			ctx:      buildContext{file: "/test/target.yaml", opts: buildOpts{DefaultName: "entry-name"}},
+			expected: "entry-name",
 		},
 		{
 			name:     "FallbackToFilenameForIndex0",

--- a/internal/spec/loader.go
+++ b/internal/spec/loader.go
@@ -101,6 +101,13 @@ func WithName(name string) LoadOption {
 	}
 }
 
+// WithDefaultName sets the entrypoint DAG name when the manifest omits it.
+func WithDefaultName(name string) LoadOption {
+	return func(o *buildOpts) {
+		o.DefaultName = name
+	}
+}
+
 // WithDAGsDir sets the directory containing the ir.DAG files.
 // This directory is used as the base path for resolving relative ir.DAG file paths.
 // When a ir.DAG is loaded by name rather than absolute path, the system will look
@@ -363,6 +370,9 @@ func buildLoadErrorDAG(opts buildOpts, filePath string, err error) *ir.DAG {
 	}
 
 	name := opts.Name
+	if name == "" {
+		name = opts.DefaultName
+	}
 	if name == "" {
 		name = defaultName(filePath)
 	}

--- a/internal/spec/loader.go
+++ b/internal/spec/loader.go
@@ -104,7 +104,7 @@ func WithName(name string) LoadOption {
 // WithDefaultName sets the entrypoint DAG name when the manifest omits it.
 func WithDefaultName(name string) LoadOption {
 	return func(o *buildOpts) {
-		o.DefaultName = name
+		o.DefaultName = strings.TrimSpace(name)
 	}
 }
 

--- a/internal/spec/loader_test.go
+++ b/internal/spec/loader_test.go
@@ -2446,10 +2446,16 @@ this is not valid yaml: [unterminated
 		require.Error(t, err)
 
 		// With AllowBuildErrors, it should return a DAG with errors captured
-		dag, err := spec.Load(context.Background(), testDAG, spec.WithAllowBuildErrors())
+		dag, err := spec.Load(
+			context.Background(),
+			testDAG,
+			spec.WithAllowBuildErrors(),
+			spec.WithDefaultName("entry-name"),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, dag)
 		assert.NotEmpty(t, dag.BuildErrors)
+		assert.Equal(t, "entry-name", dag.Name)
 		assert.Equal(t, testDAG, dag.Location)
 	})
 

--- a/internal/spec/loader_test.go
+++ b/internal/spec/loader_test.go
@@ -2450,7 +2450,7 @@ this is not valid yaml: [unterminated
 			context.Background(),
 			testDAG,
 			spec.WithAllowBuildErrors(),
-			spec.WithDefaultName("entry-name"),
+			spec.WithDefaultName("  entry-name  "),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, dag)


### PR DESCRIPTION
## Summary
- preserve DAG identity from the configured symlink entry while continuing to read from the canonical resolved target
- add a missing-name fallback that keeps explicit authored names and explicit overrides authoritative
- propagate the stable definition identity through API and scheduler subprocess reloads
- invalidate cached DAG indexes created with resolved-target-derived names

## Root cause
External DAG symlink support changed indexing, metadata, and execution reloads to use the resolved target path. The spec loader also derives a missing DAG name from the path it loads, so Nix/store and dotfile target basenames leaked into DAG identity. Long target names then exceeded the 40-character DAG-name limit, and content-addressed hashes made names unstable across edits.

## Impact
A symlink such as `wiki-digest.yml -> /nix/store/<hash>-hm_wikidigest.yml` now remains `wiki-digest` throughout listing, details, scheduling, and enqueue. The resolved target remains authoritative for reads, relative-file resolution, and cache invalidation.

## Testing
- `make fmt`
- `make lint`
- `make test` (13,669 tests passed; 37 environment/platform-specific tests skipped)
- targeted race-enabled symlink index, persistence, scheduler, and API enqueue regressions

Closes #2578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DAG names from symlink entry files and isolates metadata cache by entry. Previously, missing names were derived from the resolved target path and cached by target, causing long/unstable names and cross-entry bleed; now the default name uses the entry basename and metadata is cached per entry.

- Adds `spec.WithDefaultName` and applies it to metadata-only loads, load-error DAGs, index build, repository details/update, and CLI start (env-provided definition ID) so resolved-target loads retain the entry identity.
- Bumps `dagindex.IndexVersion` to 4; indexes built with target-derived names are invalidated and rebuilt.
- Isolates metadata cache by entry: the cache key is `entryPath + "\x00" + resolvedPath`, and update/delete invalidate using this key, so multiple entries pointing to the same target don’t share cached metadata or names.
- API change: `enqueueDAGRun` accepts a `definitionID`; callers in `internal/service/frontend/api/v1` pass the entry identity (reschedule uses the prior definition), so runs retain their originating definition.
- No user migration; symlinked DAGs now list, show details, schedule, and enqueue under their entry names.

<sup>Written for commit b7da15ded358b80b5220efa9e988cb80af830006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DAGs now receive consistent default names based on their source or entry filename when no name is specified.
  * DAG identity is preserved when loading through alternate paths or symlinks.
  * Enqueued and rescheduled runs retain the originating DAG definition.

* **Bug Fixes**
  * Improved DAG listing, details, loading, updating, and persistence when source filenames differ from displayed names.
  * Malformed DAG files now retain the appropriate fallback name in error results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->