### PR TITLE
feat: run agent actions in parallel

### DIFF
--- a/internal/runtime/agent/progress_agent_dag.go
+++ b/internal/runtime/agent/progress_agent_dag.go
@@ -93,9 +93,10 @@ func (p *AgentDAGProgressDisplay) UpdateNode(node *ir.Node) {
 		return
 	}
 
-	if node.Status == ir.NodeRunning {
+	switch node.Status {
+	case ir.NodeRunning, ir.NodeRetrying, ir.NodeWaiting:
 		p.runningActions[node.Step.Name] = struct{}{}
-	} else {
+	default:
 		delete(p.runningActions, node.Step.Name)
 	}
 }

--- a/internal/runtime/agent/progress_agent_dag.go
+++ b/internal/runtime/agent/progress_agent_dag.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -33,14 +34,14 @@ type AgentDAGProgressDisplay struct {
 	dagRunID string
 	params   string
 
-	mu            sync.Mutex
-	status        ir.Status
-	state         agentloop.State
-	printedEvents int
-	runningAction string
-	spinnerIndex  int
-	startTime     time.Time
-	liveLineShown bool
+	mu             sync.Mutex
+	status         ir.Status
+	state          agentloop.State
+	printedEvents  int
+	runningActions map[string]struct{}
+	spinnerIndex   int
+	startTime      time.Time
+	liveLineShown  bool
 
 	stopOnce sync.Once
 	stopCh   chan struct{}
@@ -54,6 +55,7 @@ func NewAgentDAGProgressDisplay(dag *ir.DAG) *AgentDAGProgressDisplay {
 	return &AgentDAGProgressDisplay{
 		progressWriter: newProgressWriter(),
 		dag:            dag,
+		runningActions: make(map[string]struct{}),
 		stopCh:         make(chan struct{}),
 		done:           make(chan struct{}),
 	}
@@ -91,11 +93,10 @@ func (p *AgentDAGProgressDisplay) UpdateNode(node *ir.Node) {
 		return
 	}
 
-	switch {
-	case node.Status == ir.NodeRunning:
-		p.runningAction = node.Step.Name
-	case p.runningAction == node.Step.Name:
-		p.runningAction = ""
+	if node.Status == ir.NodeRunning {
+		p.runningActions[node.Step.Name] = struct{}{}
+	} else {
+		delete(p.runningActions, node.Step.Name)
 	}
 }
 
@@ -151,10 +152,8 @@ func (p *AgentDAGProgressDisplay) run() {
 // flushEventsLocked prints timeline entries in order, each exactly once. An
 // action entry is held back until its status is settled: a resumed run
 // finalizes a suspended action in place, so printing it as waiting would
-// freeze a stale mark into the scrollback. The agent runs one action per
-// turn, so at most the newest entry is held back and every entry behind it has
-// settled. With final set, held-back entries print as they stand, because
-// nothing will settle them in this process.
+// freeze a stale mark into the scrollback. With final set, held-back entries
+// print as they stand, because nothing will settle them in this process.
 func (p *AgentDAGProgressDisplay) flushEventsLocked(final bool) {
 	for ; p.printedEvents < len(p.state.Events); p.printedEvents++ {
 		event := p.state.Events[p.printedEvents]
@@ -233,8 +232,13 @@ func (p *AgentDAGProgressDisplay) renderLiveLine() {
 	p.spinnerIndex++
 
 	activity := "deciding"
-	if p.runningAction != "" {
-		activity = "running " + p.runningAction
+	if len(p.runningActions) > 0 {
+		actions := make([]string, 0, len(p.runningActions))
+		for action := range p.runningActions {
+			actions = append(actions, action)
+		}
+		sort.Strings(actions)
+		activity = "running " + strings.Join(actions, ", ")
 	}
 
 	elapsed := stringutil.FormatDuration(time.Since(p.startTime))

--- a/internal/runtime/agent/progress_agent_dag_test.go
+++ b/internal/runtime/agent/progress_agent_dag_test.go
@@ -145,19 +145,23 @@ func TestActionSettled(t *testing.T) {
 	assert.True(t, actionSettled("rejected"))
 }
 
-func TestAgentDAGProgressDisplay_UpdateNode_TracksRunningAction(t *testing.T) {
-	display, _ := newTestAgentDisplay(&ir.DAG{Name: "triage", Type: ir.TypeAgent})
+func TestAgentDAGProgressDisplay_UpdateNode_TracksRunningActions(t *testing.T) {
+	display, out := newTestAgentDisplay(&ir.DAG{Name: "triage", Type: ir.TypeAgent})
 
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeRunning})
-	assert.Equal(t, "disk", display.runningAction)
-
-	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeSucceeded})
-	assert.Equal(t, "", display.runningAction)
-
-	// A finished node that is not the one in flight leaves the marker alone.
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "load"}, Status: ir.NodeRunning})
+	assert.Equal(t, map[string]struct{}{"disk": {}, "load": {}}, display.runningActions)
+
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeSucceeded})
-	assert.Equal(t, "load", display.runningAction)
+	assert.Equal(t, map[string]struct{}{"load": {}}, display.runningActions)
+
+	// A finished node that is not in flight leaves the active set alone.
+	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeSucceeded})
+	assert.Equal(t, map[string]struct{}{"load": {}}, display.runningActions)
+
+	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeRunning})
+	display.renderLiveLine()
+	assert.Contains(t, out.String(), "running disk, load")
 }
 
 func TestAgentDAGProgressDisplay_UpdateNode_IgnoresBadState(t *testing.T) {

--- a/internal/runtime/agent/progress_agent_dag_test.go
+++ b/internal/runtime/agent/progress_agent_dag_test.go
@@ -151,6 +151,9 @@ func TestAgentDAGProgressDisplay_UpdateNode_TracksRunningActions(t *testing.T) {
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeRunning})
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "load"}, Status: ir.NodeRunning})
 	assert.Equal(t, map[string]struct{}{"disk": {}, "load": {}}, display.runningActions)
+	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeRetrying})
+	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "load"}, Status: ir.NodeWaiting})
+	assert.Equal(t, map[string]struct{}{"disk": {}, "load": {}}, display.runningActions)
 
 	display.UpdateNode(&ir.Node{Step: ir.Step{Name: "disk"}, Status: ir.NodeSucceeded})
 	assert.Equal(t, map[string]struct{}{"load": {}}, display.runningActions)

--- a/internal/runtime/agent_batch.go
+++ b/internal/runtime/agent_batch.go
@@ -61,12 +61,22 @@ func (r *Runner) runAgentActionBatch(
 
 	var wg sync.WaitGroup
 	limit := r.maxActiveRuns
-	if limit == 0 || limit > len(runnable) {
+	if limit <= 0 || limit > len(runnable) {
 		limit = len(runnable)
 	}
 	semaphore := make(chan struct{}, limit)
-	for _, execution := range runnable {
+	firstUnstarted := len(runnable)
+	for i, execution := range runnable {
+		if r.isCanceled() {
+			firstUnstarted = i
+			break
+		}
 		semaphore <- struct{}{}
+		if r.isCanceled() {
+			<-semaphore
+			firstUnstarted = i
+			break
+		}
 		wg.Add(1)
 		go func(execution *agentActionExecution) {
 			defer wg.Done()
@@ -75,6 +85,10 @@ func (r *Runner) runAgentActionBatch(
 		}(execution)
 	}
 	wg.Wait()
+	for _, execution := range runnable[firstUnstarted:] {
+		execution.node.Cancel()
+		r.report(progressCh, execution.node)
+	}
 
 	for i := range executions {
 		execution := &executions[i]

--- a/internal/runtime/agent_batch.go
+++ b/internal/runtime/agent_batch.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/runtime/agentloop"
+)
+
+type agentActionExecution struct {
+	decision agentloop.Decision
+	node     *Node
+	ctx      context.Context
+	attempt  int
+}
+
+// runAgentActionBatch runs independent actions from one model turn together.
+func (r *Runner) runAgentActionBatch(
+	ctx context.Context,
+	plan *Plan,
+	state *agentloop.State,
+	decisions []agentloop.Decision,
+	progressCh chan *Node,
+) (suspended bool, err error) {
+	state.Nudges = 0
+	executions := make([]agentActionExecution, len(decisions))
+
+	// Every batch member enters Running before variables are resolved. This
+	// keeps sibling outputs out of the predecessor scope for the whole batch.
+	for i := range decisions {
+		decision := decisions[i]
+		node := plan.GetNodeByName(decision.Step)
+		prepareAgentActionNode(ctx, node, &decision)
+		executions[i] = agentActionExecution{
+			decision: decision,
+			node:     node,
+			attempt:  state.RecordStepRun(decision.Step),
+		}
+		logger.Info(ctx, "Agent running action", tag.Step(decision.Step))
+		node.SetStatus(ir.NodeRunning)
+	}
+
+	runnable := make([]*agentActionExecution, 0, len(executions))
+	for i := range executions {
+		execution := &executions[i]
+		actionCtx, setupErr := r.setupVariables(ctx, plan, execution.node)
+		if setupErr != nil {
+			execution.node.MarkError(setupErr)
+			r.report(progressCh, execution.node)
+			continue
+		}
+		execution.ctx = actionCtx
+		runnable = append(runnable, execution)
+	}
+
+	var wg sync.WaitGroup
+	limit := r.maxActiveRuns
+	if limit == 0 || limit > len(runnable) {
+		limit = len(runnable)
+	}
+	semaphore := make(chan struct{}, limit)
+	for _, execution := range runnable {
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go func(execution *agentActionExecution) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			r.executeAgentAction(execution.ctx, plan, execution.node, progressCh)
+		}(execution)
+	}
+	wg.Wait()
+
+	for i := range executions {
+		execution := &executions[i]
+		recordActionEvent(state, execution.decision.ToolCallID,
+			execution.decision.Step, execution.attempt, execution.node)
+		if execution.node.State().Status == ir.NodeWaiting {
+			suspended = true
+		}
+	}
+	r.setLastError(nil)
+
+	if suspended {
+		pending := make([]agentloop.PendingAction, len(executions))
+		for i := range executions {
+			pending[i] = agentloop.PendingAction{
+				ToolCallID: executions[i].decision.ToolCallID,
+				ToolName:   executions[i].decision.ToolName,
+				Step:       executions[i].decision.Step,
+			}
+		}
+		state.SetPendingBatch(pending)
+		return true, nil
+	}
+
+	for i := range executions {
+		execution := &executions[i]
+		state.Append(observe(ctx, execution.node, execution.decision.ToolCallID))
+	}
+	return false, nil
+}
+
+func prepareAgentActionNode(ctx context.Context, node *Node, decision *agentloop.Decision) {
+	step := declaredStep(ctx, decision.Step, node)
+	if node.State().Status != ir.NodeNotStarted {
+		previous := node.State().SubRuns
+		archived := node.State().SubRunsRepeated
+		node.ResetForRerun(step)
+		node.SetRepeated(true)
+		node.AddSubRunsRepeated(archived...)
+		node.AddSubRunsRepeated(previous...)
+	}
+	if step.SubDAG != nil {
+		params := agentloop.MergeParams(
+			step.SubDAG.Params, decision.Args, agentloop.PinnedParams(step))
+		node.SetSubDAG(ir.SubDAG{Name: step.SubDAG.Name, Params: params})
+	}
+}

--- a/internal/runtime/agent_loop.go
+++ b/internal/runtime/agent_loop.go
@@ -27,10 +27,10 @@ import (
 // agent as an observation.
 const observationLogLines = 40
 
-// runAgentLoop drives an agent DAG: the model picks one action per
-// turn, the runner carries it out, and the outcome is fed back as an
-// observation. The loop ends when every task is complete, when an action opens a
-// human task, or when a limit is reached.
+// runAgentLoop drives an agent DAG: the model picks actions, the runner carries
+// them out, and their outcomes are fed back as observations. The loop ends when
+// every task is complete, when an action opens a human task, or when a limit is
+// reached.
 func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *Node) {
 	dag := GetDAGContext(ctx).DAG
 
@@ -92,12 +92,25 @@ func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *
 			return MaskSecretsForProvider(agentCtx, msgs)
 		})
 
-	// A run that suspended mid-action resumes here: report what became of the
-	// action before asking for the next decision.
-	if pending := state.Pending; pending != nil {
-		answered := plan.GetNodeByName(pending.Step)
-		state.Append(observe(agentCtx, answered, pending.ToolCallID))
-		if answered != nil {
+	// A run that suspended mid-batch resumes here. No result from the batch is
+	// reported until every waiting member has finished.
+	if pending := state.PendingBatch(); len(pending) > 0 {
+		for _, action := range pending {
+			node := plan.GetNodeByName(action.Step)
+			if node != nil && node.State().Status == ir.NodeWaiting {
+				r.persistAgent(agentCtx, agentNode, state, progressCh)
+				agentNode.SetStatus(ir.NodeSucceeded)
+				r.report(progressCh, agentNode)
+				return
+			}
+		}
+
+		for _, action := range pending {
+			answered := plan.GetNodeByName(action.Step)
+			state.Append(observe(agentCtx, answered, action.ToolCallID))
+			if answered == nil {
+				continue
+			}
 			answeredState := answered.State()
 			finishedAt := ""
 			if !answeredState.FinishedAt.IsZero() {
@@ -107,16 +120,17 @@ func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *
 			if answeredState.Error != nil {
 				errText = answeredState.Error.Error()
 			}
-			state.FinalizeEvent(pending.Step, answeredState.Status.String(), finishedAt, errText)
+			state.FinalizeEvent(action.ToolCallID, action.Step,
+				answeredState.Status.String(), finishedAt, errText)
 
-			if pending.Question != "" {
+			if action.Question != "" {
 				if answer, ok := askUserAnswer(answered, answeredState.HumanTaskInput); ok {
-					state.RecordAnswer(pending.Question, limitAgentObservation(
+					state.RecordAnswer(action.Question, limitAgentObservation(
 						answer, dag.AgentObservationMaxBytes()))
 				}
 			}
 		}
-		state.Pending = nil
+		state.ClearPendingBatch()
 		r.persistAgent(agentCtx, agentNode, state, progressCh)
 	}
 
@@ -150,7 +164,7 @@ func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *
 				observationKeepRecent, dag.AgentObservationMaxBytes())
 		}
 
-		decision, err := planner.Next(
+		decisions, err := planner.Next(
 			agentCtx, state, observationKeepRecent, dag.AgentObservationMaxBytes())
 		if err != nil {
 			r.failAgent(agentCtx, plan, agentNode, err, progressCh)
@@ -168,7 +182,7 @@ func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *
 			return
 		}
 
-		suspended, err := r.applyDecision(agentCtx, plan, state, decision, progressCh)
+		suspended, err := r.applyDecisions(agentCtx, plan, state, decisions, progressCh)
 		if err != nil {
 			r.failAgent(agentCtx, plan, agentNode, err, progressCh)
 			return
@@ -201,6 +215,68 @@ func (r *Runner) runAgentLoop(ctx context.Context, plan *Plan, progressCh chan *
 	logger.Info(agentCtx, "Agent settled every task", slog.Int("turns", state.Turns))
 }
 
+func (r *Runner) applyDecisions(
+	ctx context.Context,
+	plan *Plan,
+	state *agentloop.State,
+	decisions []agentloop.Decision,
+	progressCh chan *Node,
+) (bool, error) {
+	if len(decisions) > 1 {
+		if problem := validateAgentActionBatch(plan, state, decisions); problem != "" {
+			state.Nudges = 0
+			for _, decision := range decisions {
+				state.RecordEvent(agentloop.Event{
+					Kind:       agentloop.EventRejected,
+					Name:       decision.ToolName,
+					Reason:     problem,
+					ToolCallID: decision.ToolCallID,
+				})
+				state.Append(toolResult(ctx, decision.ToolCallID,
+					"Error: action batch rejected: "+problem))
+			}
+			return false, nil
+		}
+		return r.runAgentActionBatch(ctx, plan, state, decisions, progressCh)
+	}
+	for i := range decisions {
+		suspended, err := r.applyDecision(ctx, plan, state, &decisions[i], progressCh)
+		if suspended || err != nil {
+			return suspended, err
+		}
+	}
+	return false, nil
+}
+
+func validateAgentActionBatch(
+	plan *Plan,
+	state *agentloop.State,
+	decisions []agentloop.Decision,
+) string {
+	seen := make(map[string]struct{}, len(decisions))
+	for _, decision := range decisions {
+		if decision.Kind != agentloop.DecideRunStep {
+			if decision.Kind == agentloop.DecideInvalid {
+				return decision.Problem
+			}
+			return "multiple tool calls may contain only workflow actions; " +
+				agentloop.AskUserTool + " and " + agentloop.SetTaskStatusTool + " must be called alone"
+		}
+		if _, ok := seen[decision.Step]; ok {
+			return fmt.Sprintf("action %q appears more than once", decision.Step)
+		}
+		seen[decision.Step] = struct{}{}
+		if plan.GetNodeByName(decision.Step) == nil {
+			return fmt.Sprintf("step %q is not part of this workflow", decision.Step)
+		}
+		if runs := state.StepRunCount(decision.Step); runs >= ir.DefaultAgentMaxStepRuns {
+			return fmt.Sprintf("action %q has already run %d times, which is its limit",
+				decision.Step, runs)
+		}
+	}
+	return ""
+}
+
 // applyDecision carries out one agent decision and appends the resulting
 // observation. It reports whether the run must suspend for human input.
 func (r *Runner) applyDecision(
@@ -226,19 +302,21 @@ func (r *Runner) applyDecision(
 			slog.String("status", string(decision.TaskStatus)),
 			slog.String("reason", decision.Reason))
 		state.RecordEvent(agentloop.Event{
-			Kind:   agentloop.EventTaskStatus,
-			Name:   decision.Task,
-			Status: string(decision.TaskStatus),
-			Reason: decision.Reason,
+			Kind:       agentloop.EventTaskStatus,
+			Name:       decision.Task,
+			Status:     string(decision.TaskStatus),
+			Reason:     decision.Reason,
+			ToolCallID: decision.ToolCallID,
 		})
 		state.Append(toolResult(ctx, decision.ToolCallID, taskStatusAck(state, decision)))
 		return false, nil
 
 	case agentloop.DecideInvalid:
 		state.RecordEvent(agentloop.Event{
-			Kind:   agentloop.EventRejected,
-			Name:   decision.ToolName,
-			Reason: decision.Problem,
+			Kind:       agentloop.EventRejected,
+			Name:       decision.ToolName,
+			Reason:     decision.Problem,
+			ToolCallID: decision.ToolCallID,
 		})
 		state.Append(toolResult(ctx, decision.ToolCallID, "Error: "+decision.Problem))
 		return false, nil
@@ -313,20 +391,21 @@ func (r *Runner) askUser(
 	logger.Info(ctx, "Agent is asking a question", slog.String("question", question))
 	node.OpenHumanTask(question, time.Now())
 	state.RecordEvent(agentloop.Event{
-		Kind:      agentloop.EventAskUser,
-		Name:      ir.AskUserStepName,
-		Status:    ir.NodeWaiting.String(),
-		Reason:    question,
-		StartedAt: stringutil.FormatTime(node.State().StartedAt),
+		Kind:       agentloop.EventAskUser,
+		Name:       ir.AskUserStepName,
+		Status:     ir.NodeWaiting.String(),
+		Reason:     question,
+		ToolCallID: decision.ToolCallID,
+		StartedAt:  stringutil.FormatTime(node.State().StartedAt),
 	})
 	r.report(progressCh, node)
 
-	state.Pending = &agentloop.PendingAction{
+	state.SetPendingBatch([]agentloop.PendingAction{{
 		ToolCallID: decision.ToolCallID,
 		ToolName:   decision.ToolName,
 		Step:       ir.AskUserStepName,
 		Question:   question,
-	}
+	}})
 	return true, nil
 }
 
@@ -377,26 +456,7 @@ func (r *Runner) runAgentAction(
 		return false, nil
 	}
 
-	// Reset against the declared step, not the node's current one, so arguments
-	// from an earlier invocation do not leak into this one.
-	step := declaredStep(ctx, decision.Step, node)
-	if node.State().Status != ir.NodeNotStarted {
-		// Re-running: clear the previous attempt and mark the node repeated so a
-		// child DAG run gets a fresh run ID instead of reusing the earlier one.
-		// Links to earlier attempts' child runs are carried across the reset, so
-		// every attempt stays reachable from the step.
-		previous := node.State().SubRuns
-		archived := node.State().SubRunsRepeated
-		node.ResetForRerun(step)
-		node.SetRepeated(true)
-		node.AddSubRunsRepeated(archived...)
-		node.AddSubRunsRepeated(previous...)
-	}
-	if step.SubDAG != nil {
-		params := agentloop.MergeParams(
-			step.SubDAG.Params, decision.Args, agentloop.PinnedParams(step))
-		node.SetSubDAG(ir.SubDAG{Name: step.SubDAG.Name, Params: params})
-	}
+	prepareAgentActionNode(ctx, node, decision)
 	attempt := state.RecordStepRun(decision.Step)
 
 	logger.Info(ctx, "Agent running action", tag.Step(decision.Step))
@@ -406,13 +466,13 @@ func (r *Runner) runAgentAction(
 	if err != nil {
 		node.MarkError(err)
 		r.report(progressCh, node)
-		recordActionEvent(state, decision.Step, attempt, node)
+		recordActionEvent(state, decision.ToolCallID, decision.Step, attempt, node)
 		state.Append(observe(ctx, node, decision.ToolCallID))
 		return false, nil
 	}
 
 	r.executeAgentAction(actionCtx, plan, node, progressCh)
-	recordActionEvent(state, decision.Step, attempt, node)
+	recordActionEvent(state, decision.ToolCallID, decision.Step, attempt, node)
 
 	// The agent has taken responsibility for the outcome: it is reported as
 	// an observation, not as a run-level error. Leaving the error set would make
@@ -420,11 +480,11 @@ func (r *Runner) runAgentAction(
 	r.setLastError(nil)
 
 	if node.State().Status == ir.NodeWaiting {
-		state.Pending = &agentloop.PendingAction{
+		state.SetPendingBatch([]agentloop.PendingAction{{
 			ToolCallID: decision.ToolCallID,
 			ToolName:   decision.ToolName,
 			Step:       decision.Step,
-		}
+		}})
 		return true, nil
 	}
 
@@ -434,14 +494,21 @@ func (r *Runner) runAgentAction(
 
 // recordActionEvent puts one run of a step on the decision timeline, carrying
 // the status and timing the UI needs to render it.
-func recordActionEvent(state *agentloop.State, step string, attempt int, node *Node) {
+func recordActionEvent(
+	state *agentloop.State,
+	toolCallID string,
+	step string,
+	attempt int,
+	node *Node,
+) {
 	nodeState := node.State()
 	event := agentloop.Event{
-		Kind:      agentloop.EventAction,
-		Name:      step,
-		Status:    nodeState.Status.String(),
-		Attempt:   attempt,
-		StartedAt: stringutil.FormatTime(nodeState.StartedAt),
+		Kind:       agentloop.EventAction,
+		Name:       step,
+		Status:     nodeState.Status.String(),
+		Attempt:    attempt,
+		ToolCallID: toolCallID,
+		StartedAt:  stringutil.FormatTime(nodeState.StartedAt),
 	}
 	if !nodeState.FinishedAt.IsZero() {
 		event.FinishedAt = stringutil.FormatTime(nodeState.FinishedAt)

--- a/internal/runtime/agent_loop_test.go
+++ b/internal/runtime/agent_loop_test.go
@@ -252,6 +252,12 @@ type agentHelper struct {
 	runErr error
 }
 
+const agentModelURLPlaceholder = "__DAGU_TEST_MODEL_URL__"
+
+func indentAgentScript(script string) string {
+	return "      " + strings.ReplaceAll(strings.TrimSpace(script), "\n", "\n      ")
+}
+
 func setupAgent(t *testing.T, yamlTemplate string, turns ...turn) *agentHelper {
 	t.Helper()
 
@@ -272,7 +278,7 @@ func setupAgentModels(
 	for _, model := range models {
 		server := httptest.NewServer(model)
 		t.Cleanup(server.Close)
-		formattedYAML = strings.Replace(formattedYAML, "%s", server.URL, 1)
+		formattedYAML = strings.Replace(formattedYAML, agentModelURLPlaceholder, server.URL, 1)
 	}
 
 	th := test.Setup(t)
@@ -332,7 +338,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
   system: drive the workflow
 steps:
   - name: alpha
@@ -399,7 +405,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %%s
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - name: alpha
     run: |
@@ -429,6 +435,44 @@ tasks:
 	assert.Equal(t, []string{"call_1_1", "call_1_2"}, observationIDs[:2])
 }
 
+func TestAgentLoop_ActionBatchToleratesNegativeRuntimeLimit(t *testing.T) {
+	t.Parallel()
+
+	readyDir := t.TempDir()
+	dagYAML := fmt.Sprintf(`
+type: agent
+llm:
+  provider: local
+  model: test-model
+  base_url: __DAGU_TEST_MODEL_URL__
+steps:
+  - name: alpha
+    run: |
+%s
+  - name: beta
+    run: |
+%s
+tasks:
+  - name: finished
+    description: done when both actions ran
+`, indentAgentScript(concurrentBarrierScript(
+		"alpha", readyDir, 2, platformTestDuration(3*time.Second, 10*time.Second))),
+		indentAgentScript(concurrentBarrierScript(
+			"beta", readyDir, 2, platformTestDuration(3*time.Second, 10*time.Second))))
+
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "both ran"}},
+	)
+	ch.cfg.MaxActiveSteps = -1
+	ch.runner = runtime.New(ch.cfg)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "alpha").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "beta").State().Status)
+}
+
 func TestAgentLoop_ActionBatchHonorsMaxActiveSteps(t *testing.T) {
 	t.Parallel()
 
@@ -439,7 +483,7 @@ max_active_steps: 1
 llm:
   provider: local
   model: test-model
-  base_url: %%s
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - name: alpha
     run: |
@@ -464,15 +508,65 @@ tasks:
 	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "beta").State().Status)
 }
 
-func TestAgentLoop_ActionBatchCannotReadSiblingOutputs(t *testing.T) {
+func TestAgentLoop_ActionBatchDoesNotStartQueuedActionAfterCancellation(t *testing.T) {
 	t.Parallel()
 
 	const dagYAML = `
 type: agent
+max_active_steps: 1
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
+steps:
+  - name: alpha
+    run: echo alpha
+  - id: beta
+    name: beta
+    action: human.task
+    with:
+      prompt: approve beta?
+tasks:
+  - name: finished
+    description: done when both actions ran
+`
+
+	executorType, started := registerStoppedStatusExecutor(t)
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+	)
+	alpha := ch.node(t, "alpha")
+	step := alpha.Step()
+	step.Commands = nil
+	step.Script = ""
+	step.ExecutorConfig.Type = executorType
+	alpha.SetStep(step)
+
+	canceled := make(chan error, 1)
+	go func() {
+		select {
+		case execution := <-started:
+			ch.runner.Cancel(ch.plan)
+			canceled <- execution.Kill(nil)
+		case <-time.After(10 * time.Second):
+			canceled <- fmt.Errorf("first action did not start")
+		}
+	}()
+
+	assert.Equal(t, ir.Aborted, ch.run(t))
+	require.NoError(t, <-canceled)
+	assert.Equal(t, ir.NodeAborted, ch.node(t, "beta").State().Status)
+}
+
+func TestAgentLoop_ActionBatchCannotReadSiblingOutputs(t *testing.T) {
+	t.Parallel()
+
+	dagYAML := fmt.Sprintf(`
+type: agent
+llm:
+  provider: local
+  model: test-model
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - name: produce
     id: produce
@@ -482,11 +576,11 @@ steps:
         VALUE: ready
   - name: consume
     id: consume
-    run: echo ${produce.outputs.VALUE}
+    run: %s
 tasks:
   - name: finished
     description: done when consume reads the prior output
-`
+`, test.Output("${produce.outputs.VALUE}"))
 
 	ch := setupAgent(t, dagYAML,
 		turn{calls: []scriptedToolCall{{tool: "produce"}, {tool: "consume"}}},
@@ -504,9 +598,14 @@ tasks:
 	assert.Equal(t, "produce", events[0].Name)
 	assert.Equal(t, ir.NodeSucceeded.String(), events[0].Status)
 	assert.Equal(t, "consume", events[1].Name)
-	assert.Equal(t, ir.NodeFailed.String(), events[1].Status)
+	assert.Equal(t, ir.NodeSucceeded.String(), events[1].Status)
 	assert.Equal(t, "consume", events[2].Name)
 	assert.Equal(t, ir.NodeSucceeded.String(), events[2].Status)
+
+	observations := ch.model.observations()
+	require.GreaterOrEqual(t, len(observations), 3)
+	assert.Contains(t, observations[1], "${produce.outputs.VALUE}")
+	assert.Contains(t, observations[2], "ready")
 }
 
 func TestAgentLoop_ActionBatchReportsFailuresWithoutCancelingSiblings(t *testing.T) {
@@ -533,10 +632,6 @@ func TestAgentLoop_ActionBatchReportsFailuresWithoutCancelingSiblings(t *testing
 	assert.Equal(t, ir.NodeFailed.String(), events[0].Status)
 	assert.Equal(t, "alpha", events[1].Name)
 	assert.Equal(t, ir.NodeSucceeded.String(), events[1].Status)
-}
-
-func indentAgentScript(script string) string {
-	return "      " + strings.ReplaceAll(strings.TrimSpace(script), "\n", "\n      ")
 }
 
 func TestAgentLoop_RejectsInvalidActionBatchesAtomically(t *testing.T) {
@@ -704,7 +799,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
   max_context_tokens: 10
   observation_keep_recent: 1
 steps:
@@ -724,7 +819,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - name: alpha
     run: echo alpha
@@ -820,7 +915,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
   max_context_tokens: 0
   observation_max_bytes: 0
   observation_keep_recent: 0
@@ -850,7 +945,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
   observation_max_bytes: 128
 steps:
   - name: produce
@@ -929,7 +1024,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - name: alpha
     run: echo alpha
@@ -1029,7 +1124,7 @@ type: agent
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
 steps:
   - id: review_alpha
     name: review_alpha
@@ -1144,7 +1239,8 @@ func resumeAgentWith(
 	server := httptest.NewServer(model)
 	t.Cleanup(server.Close)
 
-	dag, err := spec.LoadYAML(prev.Context, []byte(strings.Replace(yamlTemplate, "%s", server.URL, 1)))
+	dag, err := spec.LoadYAML(prev.Context, []byte(strings.Replace(
+		yamlTemplate, agentModelURLPlaceholder, server.URL, 1)))
 	require.NoError(t, err)
 	dag.WorkingDir = t.TempDir()
 
@@ -1370,7 +1466,7 @@ params:
 llm:
   provider: local
   model: test-model
-  base_url: %s
+  base_url: __DAGU_TEST_MODEL_URL__
   system: |
     The operator's instruction is ${params.GOAL}.
 steps:
@@ -1529,7 +1625,7 @@ llm:
   model:
     - provider: ${params.PROVIDER}
       name: test-model
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
   max_tool_iterations: 3
 steps:
   - name: alpha
@@ -1560,10 +1656,10 @@ llm:
   model:
     - provider: local
       name: primary-model
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
     - provider: local
       name: fallback-model
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
   max_tool_iterations: 5
 steps:
   - name: alpha
@@ -1581,13 +1677,13 @@ llm:
   model:
     - provider: local
       name: primary-model
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
     - provider: local
       name: fallback-one
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
     - provider: local
       name: fallback-two
-      base_url: %s
+      base_url: __DAGU_TEST_MODEL_URL__
   max_tool_iterations: 5
 steps:
   - name: alpha

--- a/internal/runtime/agent_loop_test.go
+++ b/internal/runtime/agent_loop_test.go
@@ -37,7 +37,13 @@ type turn struct {
 	// tool and args produce a tool call; leave tool empty to answer with prose.
 	tool    string
 	args    map[string]any
+	calls   []scriptedToolCall
 	content string
+}
+
+type scriptedToolCall struct {
+	tool string
+	args map[string]any
 }
 
 // fakeModel serves the OpenAI-compatible chat completions API, replying with a
@@ -53,6 +59,7 @@ type fakeModel struct {
 	promptTokens           int
 	system                 string
 	toolResults            []string
+	toolResultIDs          []string
 }
 
 // lastSystemPrompt returns the system message of the most recent request.
@@ -70,6 +77,12 @@ func (m *fakeModel) observations() []string {
 	return append([]string(nil), m.toolResults...)
 }
 
+func (m *fakeModel) observationIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.toolResultIDs...)
+}
+
 // captureSystem records the system message so tests can assert on the prompt.
 func (m *fakeModel) captureSystem(r *http.Request) {
 	body, err := io.ReadAll(r.Body)
@@ -78,8 +91,9 @@ func (m *fakeModel) captureSystem(r *http.Request) {
 	}
 	var req struct {
 		Messages []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
+			Role       string `json:"role"`
+			Content    string `json:"content"`
+			ToolCallID string `json:"tool_call_id"`
 		} `json:"messages"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -88,12 +102,14 @@ func (m *fakeModel) captureSystem(r *http.Request) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.toolResults = m.toolResults[:0]
+	m.toolResultIDs = m.toolResultIDs[:0]
 	for _, msg := range req.Messages {
 		switch msg.Role {
 		case "system":
 			m.system = msg.Content
 		case "tool":
 			m.toolResults = append(m.toolResults, msg.Content)
+			m.toolResultIDs = append(m.toolResultIDs, msg.ToolCallID)
 		}
 	}
 }
@@ -190,16 +206,28 @@ func (m *fakeModel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	message := map[string]any{"role": "assistant", "content": t.content}
 	finish := "stop"
-	if t.tool != "" {
-		args, _ := json.Marshal(t.args)
-		message["tool_calls"] = []map[string]any{{
-			"id":   fmt.Sprintf("call_%d", m.callCount()),
-			"type": "function",
-			"function": map[string]any{
-				"name":      t.tool,
-				"arguments": string(args),
-			},
-		}}
+	if t.tool != "" || len(t.calls) > 0 {
+		calls := t.calls
+		if len(calls) == 0 {
+			calls = []scriptedToolCall{{tool: t.tool, args: t.args}}
+		}
+		toolCalls := make([]map[string]any, len(calls))
+		for i, call := range calls {
+			args, _ := json.Marshal(call.args)
+			id := fmt.Sprintf("call_%d", m.callCount())
+			if len(calls) > 1 {
+				id = fmt.Sprintf("%s_%d", id, i+1)
+			}
+			toolCalls[i] = map[string]any{
+				"id":   id,
+				"type": "function",
+				"function": map[string]any{
+					"name":      call.tool,
+					"arguments": string(args),
+				},
+			}
+		}
+		message["tool_calls"] = toolCalls
 		finish = "tool_calls"
 	}
 
@@ -240,23 +268,24 @@ func setupAgentModels(
 	t.Helper()
 
 	models := append([]*fakeModel{primary}, fallbacks...)
-	formatArgs := make([]any, 0, len(models))
+	formattedYAML := yamlTemplate
 	for _, model := range models {
 		server := httptest.NewServer(model)
 		t.Cleanup(server.Close)
-		formatArgs = append(formatArgs, server.URL)
+		formattedYAML = strings.Replace(formattedYAML, "%s", server.URL, 1)
 	}
 
 	th := test.Setup(t)
-	dag, err := spec.LoadYAML(th.Context, fmt.Appendf(nil, yamlTemplate, formatArgs...))
+	dag, err := spec.LoadYAML(th.Context, []byte(formattedYAML))
 	require.NoError(t, err)
 
 	plan, err := runtime.NewPlan(dag.Steps...)
 	require.NoError(t, err)
 
 	cfg := &runtime.Config{
-		LogDir:   th.Config.Paths.LogDir,
-		DAGRunID: uuid.Must(uuid.NewV7()).String(),
+		LogDir:         th.Config.Paths.LogDir,
+		DAGRunID:       uuid.Must(uuid.NewV7()).String(),
+		MaxActiveSteps: dag.MaxActiveSteps,
 	}
 
 	return &agentHelper{
@@ -336,6 +365,273 @@ func TestAgentLoop_CompletesEveryTask(t *testing.T) {
 	// The agent never chose boom, so it is skipped rather than left pending.
 	assert.Equal(t, ir.NodeSkipped, ch.node(t, "boom").State().Status)
 	assert.Equal(t, ir.NodeSucceeded, ch.node(t, ir.AgentStepName).State().Status)
+}
+
+func TestAgentLoop_RunsEveryActionCallFromOneTurn(t *testing.T) {
+	t.Parallel()
+
+	ch := setupAgent(t, agentDAG,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "first", "status": "completed", "reason": "alpha ran"}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "second", "status": "completed", "reason": "beta ran"}},
+	)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "alpha").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "beta").State().Status)
+
+	events := agentloop.EventsFromState(ch.node(t, ir.AgentStepName).State().AgentState)
+	require.GreaterOrEqual(t, len(events), 2)
+	assert.Equal(t, 1, events[0].Turn)
+	assert.Equal(t, 1, events[1].Turn)
+	assert.Equal(t, "alpha", events[0].Name)
+	assert.Equal(t, "beta", events[1].Name)
+}
+
+func TestAgentLoop_RunsIndependentActionBatchConcurrently(t *testing.T) {
+	t.Parallel()
+
+	readyDir := t.TempDir()
+	dagYAML := fmt.Sprintf(`
+type: agent
+llm:
+  provider: local
+  model: test-model
+  base_url: %%s
+steps:
+  - name: alpha
+    run: |
+%s
+  - name: beta
+    run: |
+%s
+tasks:
+  - name: finished
+    description: done when both actions ran
+`, indentAgentScript(concurrentBarrierScript(
+		"alpha", readyDir, 2, platformTestDuration(3*time.Second, 10*time.Second))),
+		indentAgentScript(concurrentBarrierScript(
+			"beta", readyDir, 2, platformTestDuration(3*time.Second, 10*time.Second))))
+
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "both ran"}},
+	)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "alpha").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "beta").State().Status)
+	observationIDs := ch.model.observationIDs()
+	require.GreaterOrEqual(t, len(observationIDs), 2)
+	assert.Equal(t, []string{"call_1_1", "call_1_2"}, observationIDs[:2])
+}
+
+func TestAgentLoop_ActionBatchHonorsMaxActiveSteps(t *testing.T) {
+	t.Parallel()
+
+	lockDir := path.Join(t.TempDir(), "active")
+	dagYAML := fmt.Sprintf(`
+type: agent
+max_active_steps: 1
+llm:
+  provider: local
+  model: test-model
+  base_url: %%s
+steps:
+  - name: alpha
+    run: |
+%s
+  - name: beta
+    run: |
+%s
+tasks:
+  - name: finished
+    description: done when both actions ran
+`, indentAgentScript(sequentialGuardScript("alpha", lockDir)),
+		indentAgentScript(sequentialGuardScript("beta", lockDir)))
+
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "both ran"}},
+	)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "alpha").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "beta").State().Status)
+}
+
+func TestAgentLoop_ActionBatchCannotReadSiblingOutputs(t *testing.T) {
+	t.Parallel()
+
+	const dagYAML = `
+type: agent
+llm:
+  provider: local
+  model: test-model
+  base_url: %s
+steps:
+  - name: produce
+    id: produce
+    action: outputs.write
+    with:
+      values:
+        VALUE: ready
+  - name: consume
+    id: consume
+    run: echo ${produce.outputs.VALUE}
+tasks:
+  - name: finished
+    description: done when consume reads the prior output
+`
+
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "produce"}, {tool: "consume"}}},
+		turn{tool: "consume"},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "finished", "status": "completed", "reason": "output consumed"}},
+	)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "produce").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "consume").State().Status)
+
+	events := agentloop.EventsFromState(ch.node(t, ir.AgentStepName).State().AgentState)
+	require.GreaterOrEqual(t, len(events), 3)
+	assert.Equal(t, "produce", events[0].Name)
+	assert.Equal(t, ir.NodeSucceeded.String(), events[0].Status)
+	assert.Equal(t, "consume", events[1].Name)
+	assert.Equal(t, ir.NodeFailed.String(), events[1].Status)
+	assert.Equal(t, "consume", events[2].Name)
+	assert.Equal(t, ir.NodeSucceeded.String(), events[2].Status)
+}
+
+func TestAgentLoop_ActionBatchReportsFailuresWithoutCancelingSiblings(t *testing.T) {
+	t.Parallel()
+
+	ch := setupAgent(t, agentDAG,
+		turn{calls: []scriptedToolCall{{tool: "boom"}, {tool: "alpha"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "first", "status": "completed", "reason": "alpha ran"}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "second", "status": "skipped", "reason": "not needed"}},
+	)
+
+	require.Equal(t, ir.PartiallySucceeded, ch.run(t))
+	assert.Equal(t, ir.NodeFailed, ch.node(t, "boom").State().Status)
+	assert.Equal(t, ir.NodeSucceeded, ch.node(t, "alpha").State().Status)
+	observationIDs := ch.model.observationIDs()
+	require.GreaterOrEqual(t, len(observationIDs), 2)
+	assert.Equal(t, []string{"call_1_1", "call_1_2"}, observationIDs[:2])
+
+	events := agentloop.EventsFromState(ch.node(t, ir.AgentStepName).State().AgentState)
+	require.GreaterOrEqual(t, len(events), 2)
+	assert.Equal(t, "boom", events[0].Name)
+	assert.Equal(t, ir.NodeFailed.String(), events[0].Status)
+	assert.Equal(t, "alpha", events[1].Name)
+	assert.Equal(t, ir.NodeSucceeded.String(), events[1].Status)
+}
+
+func indentAgentScript(script string) string {
+	return "      " + strings.ReplaceAll(strings.TrimSpace(script), "\n", "\n      ")
+}
+
+func TestAgentLoop_RejectsInvalidActionBatchesAtomically(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		calls []scriptedToolCall
+	}{
+		{
+			name: "ControlCallMixedWithAction",
+			calls: []scriptedToolCall{
+				{tool: "alpha"},
+				{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+					"task": "first", "status": "completed", "reason": "too early"}},
+			},
+		},
+		{
+			name: "SameActionTwice",
+			calls: []scriptedToolCall{
+				{tool: "alpha"},
+				{tool: "alpha"},
+			},
+		},
+		{
+			name: "UnknownCallMixedWithAction",
+			calls: []scriptedToolCall{
+				{tool: "does_not_exist"},
+				{tool: "alpha"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ch := setupAgent(t, agentDAG,
+				turn{calls: tt.calls},
+				turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+					"task": "first", "status": "completed", "reason": "done later"}},
+				turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+					"task": "second", "status": "skipped", "reason": "not needed"}},
+			)
+
+			require.Equal(t, ir.Succeeded, ch.run(t))
+			assert.Equal(t, ir.NodeSkipped, ch.node(t, "alpha").State().Status)
+
+			events := agentloop.EventsFromState(
+				ch.node(t, ir.AgentStepName).State().AgentState)
+			require.GreaterOrEqual(t, len(events), len(tt.calls))
+			for i := range tt.calls {
+				assert.Equal(t, agentloop.EventRejected, events[i].Kind)
+				assert.Equal(t, 1, events[i].Turn)
+			}
+			observations := ch.model.observations()
+			require.GreaterOrEqual(t, len(observations), len(tt.calls))
+			for i := range tt.calls {
+				assert.Contains(t, observations[i], "action batch rejected")
+			}
+			assert.Contains(t,
+				transcript(ch.node(t, ir.AgentStepName).GetChatMessages()),
+				"action batch rejected")
+		})
+	}
+}
+
+func TestAgentLoop_RejectsWholeBatchWhenAnActionReachedItsRunLimit(t *testing.T) {
+	t.Parallel()
+
+	turns := make([]turn, 0, ir.DefaultAgentMaxStepRuns+3)
+	for range ir.DefaultAgentMaxStepRuns {
+		turns = append(turns, turn{tool: "alpha"})
+	}
+	turns = append(turns,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "beta"}}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "first", "status": "completed", "reason": "limit reached"}},
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "second", "status": "skipped", "reason": "batch rejected"}},
+	)
+	ch := setupAgent(t, agentDAG, turns...)
+
+	require.Equal(t, ir.Succeeded, ch.run(t))
+	assert.Equal(t, ir.NodeSkipped, ch.node(t, "beta").State().Status)
+	state, err := agentloop.LoadState(
+		ch.node(t, ir.AgentStepName).State().AgentState,
+		ch.node(t, ir.AgentStepName).GetChatMessages(), ch.dag)
+	require.NoError(t, err)
+	assert.Equal(t, ir.DefaultAgentMaxStepRuns, state.StepRunCount("alpha"))
+
+	events := agentloop.EventsFromState(ch.node(t, ir.AgentStepName).State().AgentState)
+	require.GreaterOrEqual(t, len(events), ir.DefaultAgentMaxStepRuns+2)
+	assert.Equal(t, agentloop.EventRejected, events[ir.DefaultAgentMaxStepRuns].Kind)
+	assert.Equal(t, agentloop.EventRejected, events[ir.DefaultAgentMaxStepRuns+1].Kind)
 }
 
 func TestAgentLoop_RecoversFromFailedAction(t *testing.T) {
@@ -690,36 +986,144 @@ func TestAgentLoop_SuspendsForHumanTaskAndResumes(t *testing.T) {
 		"the conversation from before the suspension is preserved")
 }
 
+func TestAgentLoop_WaitsForAnEntireActionBatchBeforeReportingResults(t *testing.T) {
+	t.Parallel()
+
+	ch := setupAgent(t, agentHumanTaskDAG,
+		turn{calls: []scriptedToolCall{{tool: "alpha"}, {tool: "review"}}},
+	)
+
+	require.Equal(t, ir.Waiting, ch.run(t))
+	state, err := agentloop.LoadState(
+		ch.node(t, ir.AgentStepName).State().AgentState,
+		ch.node(t, ir.AgentStepName).GetChatMessages(), ch.dag)
+	require.NoError(t, err)
+	require.Len(t, state.PendingBatch(), 2)
+	for _, message := range state.Messages() {
+		assert.NotEqual(t, ir.LLMRoleTool, message.Role,
+			"batch results remain withheld while one action is waiting")
+	}
+
+	restored := roundTripNodes(t, ch, func(node *ir.Node) {
+		if node.Step.Name == "review" {
+			node.Status = ir.NodeSucceeded
+			node.HumanTaskInput = json.RawMessage(`{"approved":true}`)
+		}
+	})
+	resumed := resumeAgent(t, ch, restored,
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "shipped", "status": "completed", "reason": "approved"}},
+	)
+
+	require.Equal(t, ir.Succeeded, resumed.status)
+	assert.Equal(t, []string{"call_1_1", "call_1_2"}, resumed.model.observationIDs())
+	assert.Contains(t, resumed.transcript, "alpha")
+	assert.Contains(t, resumed.transcript, `{"approved":true}`)
+}
+
+func TestAgentLoop_DoesNotResumeModelUntilEveryWaitingBatchMemberFinishes(t *testing.T) {
+	t.Parallel()
+
+	const dagYAML = `
+type: agent
+llm:
+  provider: local
+  model: test-model
+  base_url: %s
+steps:
+  - id: review_alpha
+    name: review_alpha
+    action: human.task
+    with:
+      prompt: approve alpha?
+  - id: review_beta
+    name: review_beta
+    action: human.task
+    with:
+      prompt: approve beta?
+tasks:
+  - name: shipped
+    description: done when both reviews are approved
+`
+
+	ch := setupAgent(t, dagYAML,
+		turn{calls: []scriptedToolCall{{tool: "review_alpha"}, {tool: "review_beta"}}},
+	)
+	require.Equal(t, ir.Waiting, ch.run(t))
+
+	firstReview := roundTripNodes(t, ch, func(node *ir.Node) {
+		if node.Step.Name == "review_alpha" {
+			node.Status = ir.NodeSucceeded
+			node.HumanTaskInput = json.RawMessage(`{"approved":true}`)
+		}
+	})
+	stillWaiting := resumeAgentWith(t, ch, dagYAML, firstReview)
+	require.Equal(t, ir.Waiting, stillWaiting.status)
+	assert.Equal(t, 0, stillWaiting.model.callCount())
+
+	state, err := agentloop.LoadState(stillWaiting.agentState, nil, ch.dag)
+	require.NoError(t, err)
+	assert.Len(t, state.PendingBatch(), 2)
+
+	secondReview := roundTripRuntimeNodes(
+		t, ch.dag, ch.cfg.DAGRunID, stillWaiting.nodes, func(node *ir.Node) {
+			if node.Step.Name == "review_beta" {
+				node.Status = ir.NodeSucceeded
+				node.HumanTaskInput = json.RawMessage(`{"approved":true}`)
+			}
+		})
+	resumed := resumeAgentWith(t, ch, dagYAML, secondReview,
+		turn{tool: agentloop.SetTaskStatusTool, args: map[string]any{
+			"task": "shipped", "status": "completed", "reason": "both approved"}},
+	)
+
+	require.Equal(t, ir.Succeeded, resumed.status)
+	assert.Equal(t, []string{"call_1_1", "call_1_2"}, resumed.model.observationIDs())
+}
+
 // roundTripNodes serializes the plan's nodes the way a finished attempt is
 // persisted and reads them back, so the test exercises real persistence rather
 // than in-memory state.
 func roundTripNodes(t *testing.T, ch *agentHelper, complete func(*ir.Node)) []*runtime.Node {
 	t.Helper()
+	return roundTripRuntimeNodes(t, ch.dag, ch.cfg.DAGRunID, ch.plan.Nodes(), complete)
+}
 
-	nodeData := make([]runtime.NodeData, 0, len(ch.plan.Nodes()))
-	for _, node := range ch.plan.Nodes() {
+func roundTripRuntimeNodes(
+	t *testing.T,
+	dag *ir.DAG,
+	dagRunID string,
+	nodes []*runtime.Node,
+	complete func(*ir.Node),
+) []*runtime.Node {
+	t.Helper()
+
+	nodeData := make([]runtime.NodeData, 0, len(nodes))
+	for _, node := range nodes {
 		nodeData = append(nodeData, node.NodeData())
 	}
-	status := ir.NewStatusBuilder(ch.dag).Create(
-		ch.cfg.DAGRunID, ir.Waiting, 0, time.Now(), transform.WithNodes(nodeData))
+	status := ir.NewStatusBuilder(dag).Create(
+		dagRunID, ir.Waiting, 0, time.Now(), transform.WithNodes(nodeData))
 
 	encoded, err := json.Marshal(status)
 	require.NoError(t, err)
 	var decoded ir.DAGRunStatus
 	require.NoError(t, json.Unmarshal(encoded, &decoded))
 
-	nodes := make([]*runtime.Node, 0, len(decoded.Nodes))
+	restoredNodes := make([]*runtime.Node, 0, len(decoded.Nodes))
 	for _, node := range decoded.Nodes {
 		complete(node)
-		nodes = append(nodes, transform.ToNode(node))
+		restoredNodes = append(restoredNodes, transform.ToNode(node))
 	}
-	return nodes
+	return restoredNodes
 }
 
 type resumeResult struct {
 	status     ir.Status
 	transcript string
 	agentState json.RawMessage
+	model      *fakeModel
+	nodes      []*runtime.Node
 }
 
 func resumeAgent(t *testing.T, prev *agentHelper, nodes []*runtime.Node, turns ...turn) resumeResult {
@@ -740,14 +1144,18 @@ func resumeAgentWith(
 	server := httptest.NewServer(model)
 	t.Cleanup(server.Close)
 
-	dag, err := spec.LoadYAML(prev.Context, fmt.Appendf(nil, yamlTemplate, server.URL))
+	dag, err := spec.LoadYAML(prev.Context, []byte(strings.Replace(yamlTemplate, "%s", server.URL, 1)))
 	require.NoError(t, err)
 	dag.WorkingDir = t.TempDir()
 
 	plan, err := runtime.NewPlanFromNodes(nodes...)
 	require.NoError(t, err)
 
-	cfg := &runtime.Config{LogDir: prev.cfg.LogDir, DAGRunID: prev.cfg.DAGRunID}
+	cfg := &runtime.Config{
+		LogDir:         prev.cfg.LogDir,
+		DAGRunID:       prev.cfg.DAGRunID,
+		MaxActiveSteps: dag.MaxActiveSteps,
+	}
 	runner := runtime.New(cfg)
 
 	logPath := path.Join(cfg.LogDir, fmt.Sprintf("%s_resume.log", dag.Name))
@@ -770,6 +1178,8 @@ func resumeAgentWith(
 		status:     runner.Status(context.Background(), plan),
 		transcript: transcript(agent.GetChatMessages()),
 		agentState: agent.State().AgentState,
+		model:      model,
+		nodes:      plan.Nodes(),
 	}
 }
 

--- a/internal/runtime/agent_models.go
+++ b/internal/runtime/agent_models.go
@@ -54,7 +54,7 @@ func (p *agentModelPlanner) Next(
 	state *agentloop.State,
 	observationKeepRecent int,
 	observationMaxBytes int,
-) (*agentloop.Decision, error) {
+) ([]agentloop.Decision, error) {
 	recoveryAttempted := false
 
 	for {
@@ -117,7 +117,7 @@ func (p *agentModelPlanner) Next(
 func (c *agentModelCandidate) Next(
 	ctx context.Context,
 	state *agentloop.State,
-) (*agentloop.Decision, error) {
+) ([]agentloop.Decision, error) {
 	if c.setupErr != nil {
 		return nil, c.setupErr
 	}

--- a/internal/runtime/agentloop/agentloop_test.go
+++ b/internal/runtime/agentloop/agentloop_test.go
@@ -102,6 +102,40 @@ func TestLoadState_PreservesProgressAcrossAttempts(t *testing.T) {
 	assert.Equal(t, messages, restored.Messages())
 }
 
+func TestState_PendingBatchRoundTripsAndReadsLegacyState(t *testing.T) {
+	t.Parallel()
+
+	dag := testDAG()
+	legacy, err := agentloop.LoadState(json.RawMessage(`{
+  "tasks": [],
+  "pending": {
+    "toolCallId": "legacy_call",
+    "toolName": "alpha",
+    "step": "alpha"
+  }
+}`), nil, dag)
+	require.NoError(t, err)
+	assert.Equal(t, []agentloop.PendingAction{{
+		ToolCallID: "legacy_call",
+		ToolName:   "alpha",
+		Step:       "alpha",
+	}}, legacy.PendingBatch())
+
+	want := []agentloop.PendingAction{
+		{ToolCallID: "call_alpha", ToolName: "alpha", Step: "alpha"},
+		{ToolCallID: "call_beta", ToolName: "beta", Step: "beta"},
+	}
+	legacy.SetPendingBatch(want)
+	raw, err := legacy.Marshal()
+	require.NoError(t, err)
+
+	restored, err := agentloop.LoadState(raw, nil, dag)
+	require.NoError(t, err)
+	assert.Equal(t, want, restored.PendingBatch())
+	restored.ClearPendingBatch()
+	assert.Empty(t, restored.PendingBatch())
+}
+
 func TestLoadState_ReconcilesAnEditedTaskList(t *testing.T) {
 	t.Parallel()
 
@@ -403,16 +437,75 @@ func TestParamString_SurvivesTheChildParser(t *testing.T) {
 	}
 }
 
-// stubProvider records the request it was handed and answers with no tool call.
-type stubProvider struct{ got *llm.ChatRequest }
+// stubProvider records the request it was handed and returns a scripted response.
+type stubProvider struct {
+	got      *llm.ChatRequest
+	response *llm.ChatResponse
+}
 
 func (p *stubProvider) Name() string { return "stub" }
 func (p *stubProvider) Chat(_ context.Context, req *llm.ChatRequest) (*llm.ChatResponse, error) {
 	p.got = req
+	if p.response != nil {
+		return p.response, nil
+	}
 	return &llm.ChatResponse{Content: "done", FinishReason: "stop"}, nil
 }
 func (p *stubProvider) ChatStream(context.Context, *llm.ChatRequest) (<-chan llm.StreamEvent, error) {
 	return nil, nil
+}
+
+func TestPlanner_PreservesEveryActionCallInOneTurn(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{response: &llm.ChatResponse{
+		FinishReason: "tool_calls",
+		ToolCalls: []llm.ToolCall{
+			{
+				ID:   "call_alpha",
+				Type: "function",
+				Function: llm.ToolCallFunction{
+					Name:      "alpha",
+					Arguments: `{}`,
+				},
+			},
+			{
+				ID:   "call_beta",
+				Type: "function",
+				Function: llm.ToolCallFunction{
+					Name:      "beta",
+					Arguments: `{"target":"second"}`,
+				},
+			},
+		},
+	}}
+	dag := &ir.DAG{
+		Type: ir.TypeAgent,
+		Steps: []ir.Step{
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+		Tasks: []ir.AgentTask{{Name: "done", Description: "Both actions ran."}},
+	}
+	catalog, err := agentloop.NewCatalog(t.Context(), dag)
+	require.NoError(t, err)
+	planner := agentloop.NewPlanner(
+		provider, &ir.LLMConfig{Model: "test"}, catalog, "", nil)
+	state := agentloop.NewState(dag)
+
+	decisions, err := planner.Next(t.Context(), state)
+	require.NoError(t, err)
+	require.Len(t, decisions, 2)
+	assert.Equal(t, "alpha", decisions[0].Step)
+	assert.Equal(t, "beta", decisions[1].Step)
+	assert.Equal(t, map[string]any{"target": "second"}, decisions[1].Args)
+
+	messages := state.Messages()
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ToolCalls, 2)
+	assert.Equal(t, "call_alpha", messages[0].ToolCalls[0].ID)
+	assert.Equal(t, "call_beta", messages[0].ToolCalls[1].ID)
+	assert.Equal(t, 1, state.Turns)
 }
 
 // TestPlanner_MasksTheOutboundCopy covers an outbound leak. The system prompt and

--- a/internal/runtime/agentloop/agentloop_test.go
+++ b/internal/runtime/agentloop/agentloop_test.go
@@ -136,6 +136,21 @@ func TestState_PendingBatchRoundTripsAndReadsLegacyState(t *testing.T) {
 	assert.Empty(t, restored.PendingBatch())
 }
 
+func TestState_FinalizeEventFallsBackToLegacyStep(t *testing.T) {
+	t.Parallel()
+
+	state := agentloop.State{Events: []agentloop.Event{
+		{Name: "alpha", Status: ir.NodeWaiting.String()},
+		{Name: "alpha", ToolCallID: "new_call", Status: ir.NodeWaiting.String()},
+	}}
+
+	state.FinalizeEvent("legacy_call", "alpha", ir.NodeSucceeded.String(), "finished", "")
+
+	assert.Equal(t, ir.NodeSucceeded.String(), state.Events[0].Status)
+	assert.Equal(t, "finished", state.Events[0].FinishedAt)
+	assert.Equal(t, ir.NodeWaiting.String(), state.Events[1].Status)
+}
+
 func TestLoadState_ReconcilesAnEditedTaskList(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/agentloop/compaction.go
+++ b/internal/runtime/agentloop/compaction.go
@@ -69,16 +69,24 @@ func (s *State) compactObservations(keepRecent, maxBytes int, onlyIfSmaller bool
 	}
 
 	references := decisionReferences(s.messages)
-	events := make(map[int]Event, len(s.Events))
+	eventsByCall := make(map[string]Event, len(s.Events))
+	legacyEventsByTurn := make(map[int]Event, len(s.Events))
 	for _, event := range s.Events {
-		events[event.Turn] = event
+		if event.ToolCallID != "" {
+			eventsByCall[event.ToolCallID] = event
+		}
+		legacyEventsByTurn[event.Turn] = event
 	}
 
 	changed := 0
 	for _, index := range toolIndices[:compactCount] {
 		msg := &s.messages[index]
 		ref := references[msg.ToolCallID]
-		summary := observationSummary(ref, events[ref.turn], msg.Content)
+		event, ok := eventsByCall[msg.ToolCallID]
+		if !ok {
+			event = legacyEventsByTurn[ref.turn]
+		}
+		summary := observationSummary(ref, event, msg.Content)
 		if maxBytes > 0 {
 			summary = stringutil.TruncUTF8Bytes(summary, maxBytes)
 		}

--- a/internal/runtime/agentloop/compaction_test.go
+++ b/internal/runtime/agentloop/compaction_test.go
@@ -56,6 +56,38 @@ func TestState_CompactsOldObservationsFromDecisionTimeline(t *testing.T) {
 	assert.Equal(t, state.Messages(), restored.Messages())
 }
 
+func TestState_CompactsParallelObservationsAgainstTheirOwnEvents(t *testing.T) {
+	t.Parallel()
+
+	state := agentloop.NewState(&ir.DAG{})
+	state.Events = []agentloop.Event{
+		{
+			Turn: 1, Kind: agentloop.EventAction, Name: "alpha", Status: "succeeded",
+			ToolCallID: "call_alpha",
+		},
+		{
+			Turn: 1, Kind: agentloop.EventAction, Name: "beta", Status: "failed",
+			Reason: "exit status 2", ToolCallID: "call_beta",
+		},
+	}
+	state.Append(
+		ir.LLMMessage{
+			Role: ir.LLMRoleAssistant,
+			ToolCalls: []ir.ToolCall{
+				{ID: "call_alpha", Function: ir.ToolCallFunction{Name: "alpha"}},
+				{ID: "call_beta", Function: ir.ToolCallFunction{Name: "beta"}},
+			},
+		},
+		toolMessage("call_alpha", "status: succeeded\n"+strings.Repeat("alpha output ", 20)),
+		toolMessage("call_beta", "status: failed\n"+strings.Repeat("beta output ", 20)),
+	)
+
+	assert.Equal(t, 2, state.CompactAllObservations(ir.DefaultAgentObservationMaxBytes))
+	messages := state.Messages()
+	assert.Equal(t, "turn 1: alpha → succeeded", messages[1].Content)
+	assert.Equal(t, "turn 1: beta → failed (exit status 2)", messages[2].Content)
+}
+
 func TestState_CompactsObservationWithoutTimelineEvent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/agentloop/planner.go
+++ b/internal/runtime/agentloop/planner.go
@@ -33,7 +33,7 @@ const (
 	DecideInvalid
 )
 
-// Decision is the single action the agent chose for this turn.
+// Decision is one tool call the agent chose for this turn.
 type Decision struct {
 	Kind       DecisionKind
 	ToolCallID string
@@ -89,7 +89,7 @@ func NewPlanner(
 // Next runs one turn of the decision loop. The conversation in st is extended
 // with the model's reply; the caller is responsible for appending the tool
 // result once the decision has been carried out.
-func (p *Planner) Next(ctx context.Context, st *State) (*Decision, error) {
+func (p *Planner) Next(ctx context.Context, st *State) ([]Decision, error) {
 	msgs := make([]ir.LLMMessage, 0, len(st.Messages())+1)
 	msgs = append(msgs, ir.LLMMessage{Role: ir.LLMRoleSystem, Content: p.systemPrompt(st)})
 	msgs = append(msgs, st.Messages()...)
@@ -125,33 +125,42 @@ func (p *Planner) Next(ctx context.Context, st *State) (*Decision, error) {
 			Content:  resp.Content,
 			Metadata: p.metadata(&resp.Usage),
 		})
-		return &Decision{Kind: DecideStop, Content: resp.Content}, nil
+		return []Decision{{Kind: DecideStop, Content: resp.Content}}, nil
 	}
 
-	// One action per turn: the conversation records only the call that runs, so
-	// history never references a tool result that was never produced.
-	call := resp.ToolCalls[0]
-	st.Append(ir.LLMMessage{
-		Role:    ir.LLMRoleAssistant,
-		Content: resp.Content,
-		ToolCalls: []ir.ToolCall{{
+	toolCalls := make([]ir.ToolCall, len(resp.ToolCalls))
+	for i, call := range resp.ToolCalls {
+		toolCalls[i] = ir.ToolCall{
 			ID:   call.ID,
 			Type: call.Type,
 			Function: ir.ToolCallFunction{
 				Name:      call.Function.Name,
 				Arguments: call.Function.Arguments,
 			},
-		}},
-		Metadata: p.metadata(&resp.Usage),
+		}
+	}
+	st.Append(ir.LLMMessage{
+		Role:      ir.LLMRoleAssistant,
+		Content:   resp.Content,
+		ToolCalls: toolCalls,
+		Metadata:  p.metadata(&resp.Usage),
 	})
 
-	decision := &Decision{ToolCallID: call.ID, ToolName: call.Function.Name}
+	decisions := make([]Decision, len(resp.ToolCalls))
+	for i, call := range resp.ToolCalls {
+		decisions[i] = p.decision(call)
+	}
+	return decisions, nil
+}
+
+func (p *Planner) decision(call llmpkg.ToolCall) Decision {
+	decision := Decision{ToolCallID: call.ID, ToolName: call.Function.Name}
 
 	args, err := decodeArgs(call.Function.Arguments)
 	if err != nil {
 		decision.Kind = DecideInvalid
 		decision.Problem = fmt.Sprintf("could not decode arguments: %v", err)
-		return decision, nil
+		return decision
 	}
 
 	if call.Function.Name == AskUserTool {
@@ -159,11 +168,11 @@ func (p *Planner) Next(ctx context.Context, st *State) (*Decision, error) {
 		if strings.TrimSpace(question) == "" {
 			decision.Kind = DecideInvalid
 			decision.Problem = AskUserTool + " requires a question"
-			return decision, nil
+			return decision
 		}
 		decision.Kind = DecideAskUser
 		decision.Question = question
-		return decision, nil
+		return decision
 	}
 
 	if call.Function.Name == SetTaskStatusTool {
@@ -173,19 +182,19 @@ func (p *Planner) Next(ctx context.Context, st *State) (*Decision, error) {
 		if task == "" {
 			decision.Kind = DecideInvalid
 			decision.Problem = SetTaskStatusTool + " requires a task name"
-			return decision, nil
+			return decision
 		}
 		if !ValidTaskStatus(status) {
 			decision.Kind = DecideInvalid
 			decision.Problem = fmt.Sprintf(
 				"%q is not a task status; use completed, skipped, failed, or open", status)
-			return decision, nil
+			return decision
 		}
 		decision.Kind = DecideSetTaskStatus
 		decision.Task = task
 		decision.TaskStatus = TaskStatus(status)
 		decision.Reason = reason
-		return decision, nil
+		return decision
 	}
 
 	step, ok := p.catalog.StepFor(call.Function.Name)
@@ -193,13 +202,13 @@ func (p *Planner) Next(ctx context.Context, st *State) (*Decision, error) {
 		decision.Kind = DecideInvalid
 		decision.Problem = fmt.Sprintf("no such action %q; available actions are %s",
 			call.Function.Name, strings.Join(p.catalog.ToolNames(), ", "))
-		return decision, nil
+		return decision
 	}
 
 	decision.Kind = DecideRunStep
 	decision.Step = step
 	decision.Args = args
-	return decision, nil
+	return decision
 }
 
 // systemPrompt states the agent's job, the actions available to it, and the
@@ -212,8 +221,9 @@ func (p *Planner) systemPrompt(st *State) string {
 		sb.WriteString("\n\n")
 	}
 
-	sb.WriteString("You are the agent of this workflow. Each turn you choose exactly one action ")
-	sb.WriteString("by calling exactly one tool. You observe the result, then choose again.\n\n")
+	sb.WriteString("You are the agent of this workflow. Each turn, call one or more independent ")
+	sb.WriteString("action tools, or call exactly one control tool. Actions chosen together run as ")
+	sb.WriteString("one batch. You observe every result, then choose again.\n\n")
 
 	sb.WriteString("Tasks — the run ends once none is open, and fails if any is failed:\n")
 	for _, task := range st.Tasks {
@@ -239,7 +249,10 @@ func (p *Planner) systemPrompt(st *State) string {
 	}
 
 	sb.WriteString("\nRules:\n")
-	sb.WriteString("- Call exactly one tool per turn.\n")
+	sb.WriteString("- Call one or more action tools in the same turn only when they are independent. ")
+	sb.WriteString("Actions in one batch cannot use each other's outputs.\n")
+	fmt.Fprintf(&sb, "- Call %s and %s alone; do not combine either with another tool call.\n",
+		SetTaskStatusTool, AskUserTool)
 	fmt.Fprintf(&sb, "- Call %s to settle a task: completed once its criteria are met, "+
 		"skipped when it turns out nothing needs doing, failed when it cannot be achieved.\n",
 		SetTaskStatusTool)

--- a/internal/runtime/agentloop/state.go
+++ b/internal/runtime/agentloop/state.go
@@ -249,19 +249,29 @@ func (s *State) RecordEvent(e Event) {
 // FinalizeEvent updates the event for a suspended tool call with the outcome it
 // reached. The step name supports state written before tool-call IDs were kept.
 func (s *State) FinalizeEvent(toolCallID, step, status, finishedAt, reason string) {
+	match := -1
 	for i := len(s.Events) - 1; i >= 0; i-- {
-		if toolCallID != "" && s.Events[i].ToolCallID != toolCallID {
-			continue
+		if toolCallID != "" && s.Events[i].ToolCallID == toolCallID {
+			match = i
+			break
 		}
-		if toolCallID == "" && s.Events[i].Name != step {
-			continue
+	}
+	if match < 0 {
+		for i := len(s.Events) - 1; i >= 0; i-- {
+			if s.Events[i].Name == step && (toolCallID == "" || s.Events[i].ToolCallID == "") {
+				match = i
+				break
+			}
 		}
-		s.Events[i].Status = status
-		s.Events[i].FinishedAt = finishedAt
-		if reason != "" {
-			s.Events[i].Reason = reason
-		}
+	}
+	if match < 0 {
 		return
+	}
+
+	s.Events[match].Status = status
+	s.Events[match].FinishedAt = finishedAt
+	if reason != "" {
+		s.Events[match].Reason = reason
 	}
 }
 

--- a/internal/runtime/agentloop/state.go
+++ b/internal/runtime/agentloop/state.go
@@ -9,6 +9,7 @@ package agentloop
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/dagucloud/dagu/v2/internal/ir"
 )
@@ -87,6 +88,9 @@ const (
 type Event struct {
 	Turn int    `json:"turn"`
 	Kind string `json:"kind"`
+	// ToolCallID ties this event to its observation when a turn contains
+	// multiple action calls.
+	ToolCallID string `json:"toolCallId,omitempty"`
 	// Name is the step or task the event concerns.
 	Name string `json:"name,omitempty"`
 	// Status is the resulting node status, for action events.
@@ -114,8 +118,12 @@ type State struct {
 	StepRuns map[string]int `json:"stepRuns,omitempty"`
 	// Turns counts LLM decisions made so far.
 	Turns int `json:"turns,omitempty"`
-	// Pending is set while an action is in flight.
+	// Pending is the legacy single action awaiting an observation. It is retained
+	// for runs persisted before action batches were supported.
 	Pending *PendingAction `json:"pending,omitempty"`
+	// PendingActions is the ordered action batch whose observations have not
+	// been reported to the model yet.
+	PendingActions []PendingAction `json:"pendingActions,omitempty"`
 	// Nudges counts consecutive turns where the LLM declined to act while tasks
 	// were still open.
 	Nudges int `json:"nudges,omitempty"`
@@ -178,11 +186,35 @@ func LoadState(raw json.RawMessage, messages []ir.LLMMessage, dag *ir.DAG) (*Sta
 	fresh.Turns = stored.Turns
 	fresh.Nudges = stored.Nudges
 	fresh.Pending = stored.Pending
+	fresh.PendingActions = slices.Clone(stored.PendingActions)
 	if stored.StepRuns != nil {
 		fresh.StepRuns = stored.StepRuns
 	}
 	fresh.messages = messages
 	return fresh, nil
+}
+
+// PendingBatch returns the ordered tool calls awaiting observations.
+func (s *State) PendingBatch() []PendingAction {
+	if len(s.PendingActions) > 0 {
+		return slices.Clone(s.PendingActions)
+	}
+	if s.Pending != nil {
+		return []PendingAction{*s.Pending}
+	}
+	return nil
+}
+
+// SetPendingBatch records an ordered batch awaiting observations.
+func (s *State) SetPendingBatch(actions []PendingAction) {
+	s.Pending = nil
+	s.PendingActions = slices.Clone(actions)
+}
+
+// ClearPendingBatch removes every pending-action representation.
+func (s *State) ClearPendingBatch() {
+	s.Pending = nil
+	s.PendingActions = nil
 }
 
 // RecordAnswer stores a reply so the same question is not put to a person twice.
@@ -214,12 +246,14 @@ func (s *State) RecordEvent(e Event) {
 	s.Events = append(s.Events, e)
 }
 
-// FinalizeEvent updates the most recent event for a step with the outcome it
-// reached. An action that suspended was recorded as waiting, and only the run
-// that resumes knows how it ended.
-func (s *State) FinalizeEvent(step, status, finishedAt, reason string) {
+// FinalizeEvent updates the event for a suspended tool call with the outcome it
+// reached. The step name supports state written before tool-call IDs were kept.
+func (s *State) FinalizeEvent(toolCallID, step, status, finishedAt, reason string) {
 	for i := len(s.Events) - 1; i >= 0; i-- {
-		if s.Events[i].Name != step {
+		if toolCallID != "" && s.Events[i].ToolCallID != toolCallID {
+			continue
+		}
+		if toolCallID == "" && s.Events[i].Name != step {
 			continue
 		}
 		s.Events[i].Status = status

--- a/internal/runtime/runner_helper_test.go
+++ b/internal/runtime/runner_helper_test.go
@@ -117,6 +117,71 @@ func withCommand(command string) stepOption {
 	}
 }
 
+func sequentialGuardScript(name, lockDir string) string {
+	if windowsShellTest() {
+		return fmt.Sprintf(`
+			$lockDir = %s
+			if (-not (New-Item -ItemType Directory -Path $lockDir -ErrorAction SilentlyContinue)) {
+				Write-Error "sequential step %s overlapped another active step"
+				exit 1
+			}
+			try {
+				%s
+			} finally {
+				Remove-Item -LiteralPath $lockDir -Force
+			}
+		`, test.PowerShellQuote(shellTestPath(lockDir)), name,
+			test.Sleep(platformTestDuration(300*time.Millisecond, 600*time.Millisecond)))
+	}
+
+	return fmt.Sprintf(`
+		lock_dir=%s
+		if ! mkdir "$lock_dir"; then
+			echo "sequential step %s overlapped another active step" >&2
+			exit 1
+		fi
+		trap 'rmdir "$lock_dir"' EXIT
+		%s
+	`, test.PosixQuote(lockDir), name, test.Sleep(300*time.Millisecond))
+}
+
+func concurrentBarrierScript(name, readyDir string, readyCount int, timeout time.Duration) string {
+	if windowsShellTest() {
+		return fmt.Sprintf(`
+			$readyDir = %s
+			New-Item -ItemType Directory -Path $readyDir -Force | Out-Null
+			New-Item -ItemType File -Path (Join-Path $readyDir %s) -Force | Out-Null
+			$deadline = (Get-Date).AddSeconds(%d)
+			while (@(Get-ChildItem -LiteralPath $readyDir -File).Count -lt %d) {
+				if ((Get-Date) -ge $deadline) {
+					Write-Error "concurrent step %s did not observe all active steps"
+					exit 1
+				}
+				Start-Sleep -Milliseconds 50
+			}
+		`, test.PowerShellQuote(shellTestPath(readyDir)), test.PowerShellQuote(name),
+			int(timeout/time.Second), readyCount, name)
+	}
+
+	return fmt.Sprintf(`
+		ready_dir=%s
+		mkdir -p "$ready_dir"
+		: > "$ready_dir/%s"
+		deadline=$(( $(date +%%s) + %d ))
+		while true; do
+			ready_count=$(find "$ready_dir" -type f | wc -l | tr -d '[:space:]')
+			if [ "$ready_count" -ge %d ]; then
+				break
+			fi
+			if [ "$(date +%%s)" -ge "$deadline" ]; then
+				echo "concurrent step %s did not observe all active steps" >&2
+				exit 1
+			fi
+			sleep 0.05
+		done
+	`, test.PosixQuote(readyDir), name, int(timeout/time.Second), readyCount, name)
+}
+
 func withID(id string) stepOption {
 	return func(step *ir.Step) {
 		step.ID = id

--- a/internal/runtime/runner_helper_test.go
+++ b/internal/runtime/runner_helper_test.go
@@ -120,15 +120,18 @@ func withCommand(command string) stepOption {
 func sequentialGuardScript(name, lockDir string) string {
 	if windowsShellTest() {
 		return fmt.Sprintf(`
-			$lockDir = %s
-			if (-not (New-Item -ItemType Directory -Path $lockDir -ErrorAction SilentlyContinue)) {
+			$lockFile = %s
+			try {
+				$lock = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+			} catch [System.IO.IOException] {
 				Write-Error "sequential step %s overlapped another active step"
 				exit 1
 			}
 			try {
 				%s
 			} finally {
-				Remove-Item -LiteralPath $lockDir -Force
+				$lock.Dispose()
+				Remove-Item -LiteralPath $lockFile -Force -ErrorAction SilentlyContinue
 			}
 		`, test.PowerShellQuote(shellTestPath(lockDir)), name,
 			test.Sleep(platformTestDuration(300*time.Millisecond, 600*time.Millisecond)))
@@ -146,6 +149,10 @@ func sequentialGuardScript(name, lockDir string) string {
 }
 
 func concurrentBarrierScript(name, readyDir string, readyCount int, timeout time.Duration) string {
+	timeoutSeconds := int(timeout / time.Second)
+	if timeout%time.Second != 0 {
+		timeoutSeconds++
+	}
 	if windowsShellTest() {
 		return fmt.Sprintf(`
 			$readyDir = %s
@@ -160,7 +167,7 @@ func concurrentBarrierScript(name, readyDir string, readyCount int, timeout time
 				Start-Sleep -Milliseconds 50
 			}
 		`, test.PowerShellQuote(shellTestPath(readyDir)), test.PowerShellQuote(name),
-			int(timeout/time.Second), readyCount, name)
+			timeoutSeconds, readyCount, name)
 	}
 
 	return fmt.Sprintf(`
@@ -177,9 +184,10 @@ func concurrentBarrierScript(name, readyDir string, readyCount int, timeout time
 				echo "concurrent step %s did not observe all active steps" >&2
 				exit 1
 			fi
-			sleep 0.05
+			%s
 		done
-	`, test.PosixQuote(readyDir), name, int(timeout/time.Second), readyCount, name)
+	`, test.PosixQuote(readyDir), name, timeoutSeconds, readyCount, name,
+		test.Sleep(50*time.Millisecond))
 }
 
 func withID(id string) stepOption {

--- a/internal/runtime/runner_test.go
+++ b/internal/runtime/runner_test.go
@@ -1914,69 +1914,6 @@ func TestRunner_DryRunWithHandlers(t *testing.T) {
 }
 
 func TestRunner_ConcurrentExecution(t *testing.T) {
-	sequentialGuardScript := func(name, lockDir string) string {
-		if windowsShellTest() {
-			return fmt.Sprintf(`
-				$lockDir = %s
-				if (-not (New-Item -ItemType Directory -Path $lockDir -ErrorAction SilentlyContinue)) {
-					Write-Error "sequential step %s overlapped another active step"
-					exit 1
-				}
-				try {
-					%s
-				} finally {
-					Remove-Item -LiteralPath $lockDir -Force
-				}
-			`, test.PowerShellQuote(shellTestPath(lockDir)), name, test.Sleep(platformTestDuration(300*time.Millisecond, 600*time.Millisecond)))
-		}
-
-		return fmt.Sprintf(`
-			lock_dir=%s
-			if ! mkdir "$lock_dir"; then
-				echo "sequential step %s overlapped another active step" >&2
-				exit 1
-			fi
-			trap 'rmdir "$lock_dir"' EXIT
-			%s
-		`, test.PosixQuote(lockDir), name, test.Sleep(300*time.Millisecond))
-	}
-
-	concurrentBarrierScript := func(name, readyDir string, readyCount int, timeout time.Duration) string {
-		if windowsShellTest() {
-			return fmt.Sprintf(`
-				$readyDir = %s
-				New-Item -ItemType Directory -Path $readyDir -Force | Out-Null
-				New-Item -ItemType File -Path (Join-Path $readyDir %s) -Force | Out-Null
-				$deadline = (Get-Date).AddSeconds(%d)
-				while (@(Get-ChildItem -LiteralPath $readyDir -File).Count -lt %d) {
-					if ((Get-Date) -ge $deadline) {
-						Write-Error "concurrent step %s did not observe all active steps"
-						exit 1
-					}
-					Start-Sleep -Milliseconds 50
-				}
-			`, test.PowerShellQuote(shellTestPath(readyDir)), test.PowerShellQuote(name), int(timeout/time.Second), readyCount, name)
-		}
-
-		return fmt.Sprintf(`
-			ready_dir=%s
-			mkdir -p "$ready_dir"
-			: > "$ready_dir/%s"
-			deadline=$(( $(date +%%s) + %d ))
-			while true; do
-				ready_count=$(find "$ready_dir" -type f | wc -l | tr -d '[:space:]')
-				if [ "$ready_count" -ge %d ]; then
-					break
-				fi
-				if [ "$(date +%%s)" -ge "$deadline" ]; then
-					echo "concurrent step %s did not observe all active steps" >&2
-					exit 1
-				fi
-				sleep 0.05
-			done
-		`, test.PosixQuote(readyDir), name, int(timeout/time.Second), readyCount, name)
-	}
-
 	steps := func(script func(string) string) []ir.Step {
 		return []ir.Step{
 			newStep("1", withScript(script("1"))),

--- a/llms.txt
+++ b/llms.txt
@@ -13,7 +13,7 @@ Load only the reference file that matches the task.
 ## Default Approach
 
 - Prefer `type: graph` for new DAGs. It supports both sequential flow via `depends:` and parallel flow.
-- Use an Agent DAG (`type: agent`) only when the step order cannot be written down in advance and an LLM must choose it. It requires `llm:` and a `tasks:` list stating when the run is finished.
+- Use an Agent DAG (`type: agent`) only when the step order cannot be written down in advance and an LLM must choose it. It requires `llm:` and a `tasks:` list stating when the run is finished. The model may select multiple distinct, independent actions in one turn; Dagu runs them concurrently up to `max_active_steps` (`0` is unlimited, `1` is serial). Same-batch actions cannot consume sibling outputs, while failures do not cancel siblings. `set_task_status` and `ask_user` must be called alone.
 - Use `type: build` only for local regular-file pipelines whose unchanged transformations should be reused across runs.
 - Prefer `id` on every step. Omit `name` unless the display label must differ from the step ID.
 - Prefer `dagu schema ...` and `dagu validate ...` over guessing field names or shapes.

--- a/skills/dagu/SKILL.md
+++ b/skills/dagu/SKILL.md
@@ -10,7 +10,7 @@ Load only the reference file that matches the task.
 ## Default Approach
 
 - Prefer `type: graph` for new DAGs. It supports both sequential flow via `depends:` and parallel flow.
-- Use an Agent DAG (`type: agent`) only when the step order cannot be written down in advance and an LLM must choose it. It requires `llm:` and a `tasks:` list stating when the run is finished.
+- Use an Agent DAG (`type: agent`) only when the step order cannot be written down in advance and an LLM must choose it. It requires `llm:` and a `tasks:` list stating when the run is finished. The model may select multiple distinct, independent actions in one turn; Dagu runs them concurrently up to `max_active_steps` (`0` is unlimited, `1` is serial). Same-batch actions cannot consume sibling outputs, while failures do not cancel siblings. `set_task_status` and `ask_user` must be called alone.
 - Use `type: build` only for local regular-file pipelines whose unchanged transformations should be reused across runs.
 - Prefer `id` on every step. Omit `name` unless the display label must differ from the step ID.
 - Prefer `dagu schema ...` and `dagu validate ...` over guessing field names or shapes.


### PR DESCRIPTION
## Summary

- preserve every action tool call returned in an Agent DAG model turn and reject invalid multi-call batches atomically
- run independent action batches concurrently up to `max_active_steps`, with same-batch output isolation and ordered observations
- persist complete waiting batches across suspension and resume only after every waiting member resolves
- correlate timeline compaction by tool-call ID and show all concurrently running actions in CLI progress
- update the bundled Dagu authoring guidance and generated `llms.txt`

## Why

Agent DAG planning previously kept and executed only the first tool call from a model response. Models that selected multiple independent actions silently lost the remaining calls and could not use the workflow's existing step concurrency limit.

## Impact

Agent DAGs can now execute independent actions from one model decision in parallel. Existing single-action and control-call behavior remains unchanged, and persisted single pending actions remain readable.

## Testing

- `make fmt`
- `make lint`
- `make test`
- focused Agent DAG concurrency, ordering, atomic rejection, output isolation, failure, suspension, resume, compaction, and CLI progress tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Independent actions selected in the same turn can run concurrently, subject to the configured activity limit.
  - Multiple pending actions are preserved across pauses and resumes.
  - Individual action results and failures are tracked separately, so one failure does not interrupt unrelated actions.
  - Live progress displays all currently running actions.

- **Bug Fixes**
  - Improved event matching and observation summaries for parallel actions.

- **Documentation**
  - Added guidance on concurrency limits, action dependencies, failure isolation, and control-action requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->