### PR TITLE
feat: add server IP allowlist

### DIFF
--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -122,6 +122,23 @@ jobs:
           grep -Fq 'helm.sh/resource-policy: keep' /tmp/dagu-default-render.yaml
           grep -Fq 'kind: ServiceAccount' /tmp/dagu-default-render.yaml
           grep -Fq 'serviceAccountName: dagu' /tmp/dagu-default-render.yaml
+          test "$(grep -Fc 'httpGet:' /tmp/dagu-default-render.yaml)" -eq 2
+          grep -Fq "command: ['wget']" /tmp/dagu-default-render.yaml
+
+      - name: Render IP allowlist
+        run: |
+          helm template dagu ./charts/dagu \
+            --namespace dagu \
+            --kube-version 1.35.0 \
+            --set-string 'config.ipAccess.allowedIPs[0]=203.0.113.10' \
+            --set-string 'config.ipAccess.trustedProxies[0]=10.42.0.0/16' \
+            >/tmp/dagu-ip-access-render.yaml
+
+          grep -Fq 'ip_access:' /tmp/dagu-ip-access-render.yaml
+          grep -Fq 'allowed_ips: ["203.0.113.10"]' /tmp/dagu-ip-access-render.yaml
+          grep -Fq 'trusted_proxies: ["10.42.0.0/16"]' /tmp/dagu-ip-access-render.yaml
+          test "$(grep -Fc 'tcpSocket:' /tmp/dagu-ip-access-render.yaml)" -eq 2
+          grep -Fq "command: ['nc']" /tmp/dagu-ip-access-render.yaml
 
       - name: Render distributed mode
         run: |

--- a/README.md
+++ b/README.md
@@ -777,12 +777,31 @@ The table lists the most common commands. The binary ships 31 in total, includin
 | `DAGU_CERT_FILE` | — | TLS certificate |
 | `DAGU_KEY_FILE` | — | TLS private key |
 | `DAGU_CORS_ALLOWED_ORIGINS` | — | Comma-separated list of allowed CORS origins (e.g. `https://app.example.com`). When unset, cross-origin browser access is disabled. Exact origins enable credentials. An explicit `*` allows every origin without credentials and emits a security warning. |
+| `DAGU_IP_ACCESS_ALLOWED_IPS` | — | Comma-separated IPv4/IPv6 addresses and CIDR ranges allowed to access the HTTP server. Empty disables filtering. |
+| `DAGU_IP_ACCESS_TRUSTED_PROXIES` | — | Comma-separated proxy addresses and CIDR ranges permitted to supply forwarded client IP headers. |
 | `DAGU_PUBLIC_URL` | — | External Web UI URL used in generated links, including notification and incident DAG-run links |
 | `DAGU_SERVER_METRICS` | `private` | Metrics endpoint access: `private` or `public` |
 | `DAGU_TERMINAL_ENABLED` | `false` | Enable the web-based terminal |
 | `DAGU_DEFAULT_SHELL` | `$SHELL`, then `sh` | Default shell for command steps |
 | `DAGU_ENV_PASSTHROUGH_PREFIXES` | — | Comma-separated env var prefixes forwarded to step execution |
 | `DAGU_DEBUG` | — | Enable debug mode |
+
+The equivalent YAML protects every HTTP route, including health, metrics,
+webhooks, SSE, terminal, and MCP:
+
+```yaml
+ip_access:
+  allowed_ips:
+    - 203.0.113.10
+    - 10.0.0.0/8
+  trusted_proxies:
+    - 127.0.0.1
+    - 10.42.0.0/16
+```
+
+Forwarded addresses are used only when the direct peer matches
+`trusted_proxies`. The proxy must remove client-supplied forwarding headers and
+set or append the verified client address. Keep trusted proxy ranges narrow.
 
 ### Paths
 

--- a/charts/dagu/Chart.yaml
+++ b/charts/dagu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dagu
 description: A compact, self-contained workflow engine with a web UI
 type: application
-version: 2.0.2
+version: 2.0.3
 appVersion: "2.11.1"
 kubeVersion: ">=1.19.0-0"
 home: https://dagu.sh

--- a/charts/dagu/README.md
+++ b/charts/dagu/README.md
@@ -256,6 +256,30 @@ config:
 
 Set `config.corsAllowedOrigins: ["*"]` only when any website should be allowed to call the API. Wildcard CORS does not allow credentials and is especially risky with `auth.mode: none`.
 
+### IP Access Allowlist
+
+Restrict every UI and API HTTP route to specific client addresses or networks:
+
+```yaml
+config:
+  ipAccess:
+    allowedIPs:
+      - 203.0.113.10
+      - 10.0.0.0/8
+    trustedProxies:
+      - 10.42.0.0/16
+```
+
+`allowedIPs` accepts IPv4 and IPv6 addresses or CIDR ranges. An empty list
+disables filtering. When Dagu runs behind an ingress or reverse proxy, list only
+the proxy network in `trustedProxies`; forwarding headers from all other peers
+are ignored. The proxy must remove client-supplied forwarding headers and set or
+append the verified client address.
+
+The allowlist covers health and metrics routes. When it is enabled, the chart
+uses TCP liveness, readiness, and connection checks so Kubernetes does not need
+an HTTP allowlist exemption for node or test-pod addresses.
+
 ### Environment Passthrough
 
 Dagu filters host/container environment variables before exposing them to workflow steps. To allow additional runtime env vars such as proxy or certificate settings, configure both:

--- a/charts/dagu/templates/configmap.yaml
+++ b/charts/dagu/templates/configmap.yaml
@@ -112,6 +112,9 @@ data:
     public_url: {{ . | quote }}
 {{- end }}
     cors_allowed_origins: {{ .Values.config.corsAllowedOrigins | toJson }}
+    ip_access:
+      allowed_ips: {{ .Values.config.ipAccess.allowedIPs | toJson }}
+      trusted_proxies: {{ .Values.config.ipAccess.trustedProxies | toJson }}
     default_execution_mode: {{ ternary "distributed" "local" (eq .Values.deploymentMode "distributed") | quote }}
 {{- with .Values.config.envPassthrough }}
     env_passthrough:

--- a/charts/dagu/templates/tests/test-connection.yaml
+++ b/charts/dagu/templates/tests/test-connection.yaml
@@ -17,6 +17,11 @@ spec:
     - name: wget
       image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+{{- if .Values.config.ipAccess.allowedIPs }}
+      command: ['nc']
+      args: ['-z', '-w', '5', '{{ include "dagu.componentName" (dict "root" . "component" "ui") }}', '{{ .Values.ui.service.port }}']
+{{- else }}
       command: ['wget']
       args: ['--spider', '-T', '5', 'http://{{ include "dagu.componentName" (dict "root" . "component" "ui") }}:{{ .Values.ui.service.port }}/api/v1/health']
+{{- end }}
   restartPolicy: Never

--- a/charts/dagu/templates/ui-deployment.yaml
+++ b/charts/dagu/templates/ui-deployment.yaml
@@ -96,15 +96,25 @@ spec:
 {{ toYaml . | nindent 12 }}
 {{- end }}
           livenessProbe:
+{{- if .Values.config.ipAccess.allowedIPs }}
+            tcpSocket:
+              port: http
+{{- else }}
             httpGet:
               path: /api/v1/health
               port: http
+{{- end }}
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
+{{- if .Values.config.ipAccess.allowedIPs }}
+            tcpSocket:
+              port: http
+{{- else }}
             httpGet:
               path: /api/v1/health
               port: http
+{{- end }}
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:

--- a/charts/dagu/values.schema.json
+++ b/charts/dagu/values.schema.json
@@ -212,6 +212,29 @@
             "minLength": 1
           }
         },
+        "ipAccess": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowedIPs": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "trustedProxies": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "required": ["allowedIPs", "trustedProxies"]
+        },
         "envPassthrough": {
           "type": "array",
           "items": {
@@ -225,7 +248,7 @@
           }
         }
       },
-      "required": ["publicUrl", "corsAllowedOrigins", "envPassthrough", "envPassthroughPrefixes"]
+      "required": ["publicUrl", "corsAllowedOrigins", "ipAccess", "envPassthrough", "envPassthroughPrefixes"]
     },
     "persistence": {
       "type": "object",

--- a/charts/dagu/values.yaml
+++ b/charts/dagu/values.yaml
@@ -47,6 +47,12 @@ config:
   # Browser origins allowed to make cross-origin API requests.
   # Empty disables CORS; same-origin UI access continues to work.
   corsAllowedOrigins: []
+  # Restrict every UI/API HTTP route to these client IP addresses or CIDR ranges.
+  # Empty preserves unrestricted access.
+  ipAccess:
+    allowedIPs: []
+    # Forwarded client IP headers are honored only from these proxy addresses or ranges.
+    trustedProxies: []
   envPassthrough: []
   envPassthroughPrefixes: []
 

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/netip"
 	"net/url"
 	"slices"
 	"strings"
@@ -177,6 +178,13 @@ type Server struct {
 	Terminal           TerminalConfig
 	Audit              AuditConfig
 	SSE                SSEConfig
+	IPAccess           IPAccessConfig
+}
+
+// IPAccessConfig restricts HTTP access by client network address.
+type IPAccessConfig struct {
+	AllowedIPs     []string
+	TrustedProxies []string
 }
 
 // TerminalConfig contains configuration for the web-based terminal feature.
@@ -740,6 +748,12 @@ func (c *Config) validateServer() error {
 		}
 		c.Server.PublicURL = normalized
 	}
+	if err := validateIPAccessEntries("ip_access.allowed_ips", c.Server.IPAccess.AllowedIPs); err != nil {
+		return err
+	}
+	if err := validateIPAccessEntries("ip_access.trusted_proxies", c.Server.IPAccess.TrustedProxies); err != nil {
+		return err
+	}
 
 	if c.Server.TLS != nil {
 		if c.Server.TLS.CertFile == "" || c.Server.TLS.KeyFile == "" {
@@ -775,6 +789,21 @@ func (c *Config) validateServer() error {
 		return fmt.Errorf("sse.slow_client_timeout must be >= 0")
 	}
 
+	return nil
+}
+
+func validateIPAccessEntries(path string, entries []string) error {
+	for i, entry := range entries {
+		var err error
+		if strings.Contains(entry, "/") {
+			_, err = netip.ParsePrefix(entry)
+		} else {
+			_, err = netip.ParseAddr(entry)
+		}
+		if err != nil {
+			return fmt.Errorf("invalid %s[%d] %q: %w", path, i, entry, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/cmn/config/config.go
+++ b/internal/cmn/config/config.go
@@ -796,7 +796,11 @@ func validateIPAccessEntries(path string, entries []string) error {
 	for i, entry := range entries {
 		var err error
 		if strings.Contains(entry, "/") {
-			_, err = netip.ParsePrefix(entry)
+			prefix, parseErr := netip.ParsePrefix(entry)
+			err = parseErr
+			if err == nil && prefix.Addr().Is4In6() && prefix.Bits() < 96 {
+				err = fmt.Errorf("mapped IPv4 prefix length must be at least 96")
+			}
 		} else {
 			_, err = netip.ParseAddr(entry)
 		}

--- a/internal/cmn/config/config_test.go
+++ b/internal/cmn/config/config_test.go
@@ -640,6 +640,55 @@ func TestConfig_Validate(t *testing.T) {
 	})
 }
 
+func TestConfigValidateIPAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		wantError string
+	}{
+		{
+			name: "ValidAddressesAndNetworks",
+			configure: func(cfg *Config) {
+				cfg.Server.IPAccess = IPAccessConfig{
+					AllowedIPs:     []string{"203.0.113.10", "10.0.0.0/8", "2001:db8::/32"},
+					TrustedProxies: []string{"127.0.0.1", "::1"},
+				}
+			},
+		},
+		{
+			name: "InvalidAllowedIP",
+			configure: func(cfg *Config) {
+				cfg.Server.IPAccess.AllowedIPs = []string{"not-an-ip"}
+			},
+			wantError: `ip_access.allowed_ips[0] "not-an-ip"`,
+		},
+		{
+			name: "InvalidTrustedProxy",
+			configure: func(cfg *Config) {
+				cfg.Server.IPAccess.TrustedProxies = []string{"10.0.0.0/99"}
+			},
+			wantError: `ip_access.trusted_proxies[0] "10.0.0.0/99"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := validBaseConfig()
+			tt.configure(cfg)
+
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantError)
+		})
+	}
+}
+
 func TestConfig_ValidateOIDCWorkspaceMappings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmn/config/config_test.go
+++ b/internal/cmn/config/config_test.go
@@ -665,6 +665,13 @@ func TestConfigValidateIPAccess(t *testing.T) {
 			wantError: `ip_access.allowed_ips[0] "not-an-ip"`,
 		},
 		{
+			name: "IPv4MappedNetworkBelowMappedPrefix",
+			configure: func(cfg *Config) {
+				cfg.Server.IPAccess.AllowedIPs = []string{"::ffff:192.0.2.0/95"}
+			},
+			wantError: `ip_access.allowed_ips[0] "::ffff:192.0.2.0/95"`,
+		},
+		{
 			name: "InvalidTrustedProxy",
 			configure: func(cfg *Config) {
 				cfg.Server.IPAccess.TrustedProxies = []string{"10.0.0.0/99"}

--- a/internal/cmn/config/definition.go
+++ b/internal/cmn/config/definition.go
@@ -7,16 +7,17 @@ package config
 // Fields are organized into logical groups for clarity.
 type Definition struct {
 	// Server settings
-	Host               string   `mapstructure:"host"`
-	Port               int      `mapstructure:"port"`
-	PublicURL          string   `mapstructure:"public_url"`
-	BasePath           string   `mapstructure:"base_path"`
-	APIBasePath        string   `mapstructure:"api_base_path"`
-	APIBaseURL         string   `mapstructure:"api_base_url"` // Deprecated: use APIBasePath
-	Headless           *bool    `mapstructure:"headless"`
-	CheckUpdates       *bool    `mapstructure:"check_updates"`
-	TLS                *TLSDef  `mapstructure:"tls"`
-	CORSAllowedOrigins []string `mapstructure:"cors_allowed_origins"`
+	Host               string       `mapstructure:"host"`
+	Port               int          `mapstructure:"port"`
+	PublicURL          string       `mapstructure:"public_url"`
+	BasePath           string       `mapstructure:"base_path"`
+	APIBasePath        string       `mapstructure:"api_base_path"`
+	APIBaseURL         string       `mapstructure:"api_base_url"` // Deprecated: use APIBasePath
+	Headless           *bool        `mapstructure:"headless"`
+	CheckUpdates       *bool        `mapstructure:"check_updates"`
+	TLS                *TLSDef      `mapstructure:"tls"`
+	CORSAllowedOrigins []string     `mapstructure:"cors_allowed_origins"`
+	IPAccess           *IPAccessDef `mapstructure:"ip_access"`
 
 	// Core settings
 	Debug                  bool         `mapstructure:"debug"`
@@ -118,6 +119,12 @@ type TLSDef struct {
 	CertFile string `mapstructure:"cert_file"`
 	KeyFile  string `mapstructure:"key_file"`
 	CAFile   string `mapstructure:"ca_file"`
+}
+
+// IPAccessDef configures server-wide HTTP client IP filtering.
+type IPAccessDef struct {
+	AllowedIPs     []string `mapstructure:"allowed_ips"`
+	TrustedProxies []string `mapstructure:"trusted_proxies"`
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/cmn/config/key_hints.go
+++ b/internal/cmn/config/key_hints.go
@@ -77,6 +77,8 @@ var legacyToSnakeCaseKey = map[string]string{
 	"auth.proxy.rolemapping.defaultworkspaceaccess": "auth.proxy.role_mapping.default_workspace_access",
 	"auth.proxy.rolemapping.requiremapping":         "auth.proxy.role_mapping.require_mapping",
 	"auth.proxy.rolemapping.skiporgrolesync":        "auth.proxy.role_mapping.skip_org_role_sync",
+	"ipaccess.allowedips":                           "ip_access.allowed_ips",
+	"ipaccess.trustedproxies":                       "ip_access.trusted_proxies",
 
 	// Permissions
 	"permissions.writedags": "permissions.write_dags",

--- a/internal/cmn/config/loader.go
+++ b/internal/cmn/config/loader.go
@@ -1167,6 +1167,10 @@ func (l *ConfigLoader) loadServerDefaults(cfg *Config, def Definition) {
 	cfg.Server.BasePath = cleanServerBasePath(cfg.Server.BasePath)
 	cfg.Server.CheckUpdates = l.v.GetBool("check_updates")
 	cfg.Server.CORSAllowedOrigins = parseStringList(l.v.Get("cors_allowed_origins"))
+	cfg.Server.IPAccess = IPAccessConfig{
+		AllowedIPs:     parseStringList(l.v.Get("ip_access.allowed_ips")),
+		TrustedProxies: parseStringList(l.v.Get("ip_access.trusted_proxies")),
+	}
 	for _, origin := range cfg.Server.CORSAllowedOrigins {
 		if strings.TrimSpace(origin) != "*" {
 			continue
@@ -2059,6 +2063,8 @@ var envBindings = []envBinding{
 	{key: "headless", env: "HEADLESS"},
 	{key: "check_updates", env: "CHECK_UPDATES"},
 	{key: "cors_allowed_origins", env: "CORS_ALLOWED_ORIGINS"},
+	{key: "ip_access.allowed_ips", env: "IP_ACCESS_ALLOWED_IPS", requires: SectionServer},
+	{key: "ip_access.trusted_proxies", env: "IP_ACCESS_TRUSTED_PROXIES", requires: SectionServer},
 	{key: "latest_status_today", env: "LATEST_STATUS_TODAY"},
 	{key: "metrics", env: "SERVER_METRICS"},
 	{key: "cache", env: "CACHE"},

--- a/internal/cmn/config/loader_test.go
+++ b/internal/cmn/config/loader_test.go
@@ -2016,6 +2016,40 @@ cors_allowed_origins:
 	})
 }
 
+func TestLoad_IPAccess(t *testing.T) {
+	t.Run("DefaultDisabled", func(t *testing.T) {
+		cfg := loadFromYAML(t, "# empty")
+
+		assert.Empty(t, cfg.Server.IPAccess.AllowedIPs)
+		assert.Empty(t, cfg.Server.IPAccess.TrustedProxies)
+	})
+
+	t.Run("YAML", func(t *testing.T) {
+		cfg := loadFromYAML(t, `
+ip_access:
+  allowed_ips:
+    - 203.0.113.10
+    - 10.0.0.0/8
+  trusted_proxies:
+    - 127.0.0.1
+    - 10.42.0.0/16
+`)
+
+		assert.Equal(t, []string{"203.0.113.10", "10.0.0.0/8"}, cfg.Server.IPAccess.AllowedIPs)
+		assert.Equal(t, []string{"127.0.0.1", "10.42.0.0/16"}, cfg.Server.IPAccess.TrustedProxies)
+	})
+
+	t.Run("Environment", func(t *testing.T) {
+		cfg := loadWithEnv(t, "# empty", map[string]string{
+			"DAGU_IP_ACCESS_ALLOWED_IPS":     "203.0.113.10, 2001:db8::/32",
+			"DAGU_IP_ACCESS_TRUSTED_PROXIES": "127.0.0.1, ::1",
+		})
+
+		assert.Equal(t, []string{"203.0.113.10", "2001:db8::/32"}, cfg.Server.IPAccess.AllowedIPs)
+		assert.Equal(t, []string{"127.0.0.1", "::1"}, cfg.Server.IPAccess.TrustedProxies)
+	})
+}
+
 func TestLoad_AccessLogMode(t *testing.T) {
 	t.Run("AccessLogAll", func(t *testing.T) {
 		cfg := loadFromYAML(t, `

--- a/internal/cmn/schema/config.schema.json
+++ b/internal/cmn/schema/config.schema.json
@@ -47,6 +47,9 @@
       "items": { "type": "string" },
       "description": "Origins allowed to make cross-origin requests. When unset or empty, cross-origin browser access is disabled. Exact origins enable credentials. An explicit '*' allows every origin without credentials and emits a security warning."
     },
+    "ip_access": {
+      "$ref": "#/definitions/IPAccessDef"
+    },
     "debug": {
       "type": "boolean",
       "description": "Enable debug mode with verbose logging."
@@ -245,6 +248,31 @@
     }
   },
   "definitions": {
+    "IPAccessDef": {
+      "type": "object",
+      "description": "Server-wide HTTP client IP filtering.",
+      "additionalProperties": false,
+      "properties": {
+        "allowed_ips": {
+          "type": "array",
+          "description": "IPv4 or IPv6 addresses and CIDR ranges allowed to access the HTTP server. Empty disables filtering.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "trusted_proxies": {
+          "type": "array",
+          "description": "Proxy addresses and CIDR ranges permitted to supply forwarded client IP headers.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "TLSDef": {
       "type": "object",
       "description": "TLS/SSL encryption configuration.",

--- a/internal/cmn/schema/config_schema_test.go
+++ b/internal/cmn/schema/config_schema_test.go
@@ -76,6 +76,52 @@ check_updates: false
 	}
 }
 
+func TestConfigSchemaIPAccess(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveConfigSchema(t)
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr bool
+	}{
+		{
+			name: "AddressesAndNetworks",
+			spec: `
+ip_access:
+  allowed_ips:
+    - 203.0.113.10
+    - 10.0.0.0/8
+  trusted_proxies:
+    - 127.0.0.1
+    - 2001:db8::/32
+`,
+		},
+		{
+			name: "RejectsNonStringEntry",
+			spec: `
+ip_access:
+  allowed_ips:
+    - 42
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc := mustParseYAMLDocument(t, tt.spec)
+			err := resolved.Validate(doc)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestConfigSchemaOIDCWorkspaceMappings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/frontend/ipaccess.go
+++ b/internal/service/frontend/ipaccess.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"fmt"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+)
+
+type ipAccessPolicy struct {
+	allowedIPs     []netip.Prefix
+	trustedProxies []netip.Prefix
+}
+
+func newIPAccessPolicy(cfg config.IPAccessConfig) (*ipAccessPolicy, error) {
+	allowedIPs, err := parseIPAccessPrefixes("allowed IP", cfg.AllowedIPs)
+	if err != nil {
+		return nil, err
+	}
+	trustedProxies, err := parseIPAccessPrefixes("trusted proxy", cfg.TrustedProxies)
+	if err != nil {
+		return nil, err
+	}
+	return &ipAccessPolicy{allowedIPs: allowedIPs, trustedProxies: trustedProxies}, nil
+}
+
+func parseIPAccessPrefixes(kind string, values []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(values))
+	for _, value := range values {
+		prefix, err := parseIPAccessPrefix(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s %q: %w", kind, value, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+func parseIPAccessPrefix(value string) (netip.Prefix, error) {
+	if strings.Contains(value, "/") {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		if prefix.Addr().Is4In6() {
+			if prefix.Bits() < 96 {
+				return netip.Prefix{}, fmt.Errorf("mapped IPv4 prefix length must be at least 96")
+			}
+			prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
+		}
+		return prefix.Masked(), nil
+	}
+
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	addr = addr.Unmap()
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+func (p *ipAccessPolicy) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(p.allowedIPs) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		clientIP, err := p.clientIP(r)
+		if err != nil || !prefixesContain(p.allowedIPs, clientIP) {
+			http.Error(w, "access denied", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (p *ipAccessPolicy) clientIP(r *http.Request) (netip.Addr, error) {
+	peer, err := parseRequestIP(r.RemoteAddr)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if !prefixesContain(p.trustedProxies, peer) {
+		return peer, nil
+	}
+
+	if values := r.Header.Values("X-Forwarded-For"); len(values) > 0 {
+		chain := make([]netip.Addr, 0, len(values)+1)
+		for _, value := range values {
+			for part := range strings.SplitSeq(value, ",") {
+				addr, err := parseRequestIP(part)
+				if err != nil {
+					return netip.Addr{}, err
+				}
+				chain = append(chain, addr)
+			}
+		}
+		if len(chain) == 0 {
+			return netip.Addr{}, fmt.Errorf("empty X-Forwarded-For header")
+		}
+		chain = append(chain, peer)
+		index := len(chain) - 1
+		for index > 0 && prefixesContain(p.trustedProxies, chain[index]) {
+			index--
+		}
+		return chain[index], nil
+	}
+
+	if values := r.Header.Values("X-Real-IP"); len(values) > 0 {
+		if len(values) != 1 {
+			return netip.Addr{}, fmt.Errorf("multiple X-Real-IP headers")
+		}
+		return parseRequestIP(values[0])
+	}
+	return peer, nil
+}
+
+func parseRequestIP(value string) (netip.Addr, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return netip.Addr{}, fmt.Errorf("empty IP address")
+	}
+	if addr, err := netip.ParseAddr(value); err == nil {
+		return addr.Unmap(), nil
+	}
+	addrPort, err := netip.ParseAddrPort(value)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("invalid IP address %q: %w", value, err)
+	}
+	return addrPort.Addr().Unmap(), nil
+}
+
+func prefixesContain(prefixes []netip.Prefix, addr netip.Addr) bool {
+	for _, prefix := range prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/frontend/ipaccess_test.go
+++ b/internal/service/frontend/ipaccess_test.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+)
+
+func TestIPAccessPolicyDirectPeer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		allowedIPs []string
+		remoteAddr string
+		wantStatus int
+	}{
+		{name: "Disabled", remoteAddr: "invalid", wantStatus: http.StatusNoContent},
+		{name: "ExactIPv4", allowedIPs: []string{"203.0.113.10"}, remoteAddr: "203.0.113.10:1234", wantStatus: http.StatusNoContent},
+		{name: "IPv4CIDR", allowedIPs: []string{"203.0.113.0/24"}, remoteAddr: "203.0.113.10:1234", wantStatus: http.StatusNoContent},
+		{name: "IPv6CIDR", allowedIPs: []string{"2001:db8::/32"}, remoteAddr: "[2001:db8::10]:1234", wantStatus: http.StatusNoContent},
+		{name: "IPv4MappedIPv6", allowedIPs: []string{"203.0.113.10"}, remoteAddr: "[::ffff:203.0.113.10]:1234", wantStatus: http.StatusNoContent},
+		{name: "Denied", allowedIPs: []string{"203.0.113.10"}, remoteAddr: "198.51.100.7:1234", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			policy, err := newIPAccessPolicy(config.IPAccessConfig{AllowedIPs: tt.allowedIPs})
+			require.NoError(t, err)
+
+			called := false
+			handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+			assert.Equal(t, tt.wantStatus == http.StatusNoContent, called)
+			if tt.wantStatus == http.StatusForbidden {
+				assert.Equal(t, "access denied\n", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestIPAccessPolicyTrustedProxy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    http.Header
+		wantStatus int
+	}{
+		{
+			name:       "ForwardedClient",
+			remoteAddr: "10.0.0.2:1234",
+			headers:    http.Header{"X-Forwarded-For": []string{"198.51.100.25, 10.0.0.1"}},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "ForwardedClientWithPort",
+			remoteAddr: "10.0.0.2:1234",
+			headers:    http.Header{"X-Forwarded-For": []string{"198.51.100.25:4567"}},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "RealIPFallback",
+			remoteAddr: "10.0.0.2:1234",
+			headers:    http.Header{"X-Real-Ip": []string{"198.51.100.25"}},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "SpoofedLeftmostForwardedAddress",
+			remoteAddr: "10.0.0.2:1234",
+			headers:    http.Header{"X-Forwarded-For": []string{"198.51.100.25, 203.0.113.7, 10.0.0.1"}},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "MalformedForwardedAddress",
+			remoteAddr: "10.0.0.2:1234",
+			headers:    http.Header{"X-Forwarded-For": []string{"198.51.100.25, invalid"}},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "TrustedPeerWithoutHeaders",
+			remoteAddr: "10.0.0.2:1234",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			policy, err := newIPAccessPolicy(config.IPAccessConfig{
+				AllowedIPs:     []string{"198.51.100.25"},
+				TrustedProxies: []string{"10.0.0.0/8"},
+			})
+			require.NoError(t, err)
+
+			handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			req.Header = tt.headers
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func TestIPAccessPolicyIgnoresForwardedHeadersFromUntrustedPeer(t *testing.T) {
+	t.Parallel()
+
+	policy, err := newIPAccessPolicy(config.IPAccessConfig{
+		AllowedIPs:     []string{"198.51.100.25"},
+		TrustedProxies: []string{"10.0.0.0/8"},
+	})
+	require.NoError(t, err)
+	handler := policy.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.7:1234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.25")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+func TestNewIPAccessPolicyRejectsInvalidNetworks(t *testing.T) {
+	t.Parallel()
+
+	_, err := newIPAccessPolicy(config.IPAccessConfig{AllowedIPs: []string{"invalid"}})
+
+	require.ErrorContains(t, err, `allowed IP "invalid"`)
+}

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -826,6 +826,10 @@ func skipPathsMiddleware(mw func(http.Handler) http.Handler, skip map[string]str
 func (srv *Server) Serve(ctx context.Context) error {
 	r := chi.NewMux()
 	apiV1BasePath := srv.configureAPIPath(ctx)
+	ipAccessPolicy, err := newIPAccessPolicy(srv.config.Server.IPAccess)
+	if err != nil {
+		return fmt.Errorf("configure IP access: %w", err)
+	}
 	r.Use(auth.PreserveRawRemoteAddr)
 	r.Use(middleware.Compress(5))
 	if srv.config.Server.AccessLog != config.AccessLogNone {
@@ -858,6 +862,7 @@ func (srv *Server) Serve(ctx context.Context) error {
 	}
 	r.Use(middleware.Recoverer)
 	r.Use(securityHeadersMiddleware(srv.config.Server.TLS != nil))
+	r.Use(ipAccessPolicy.middleware)
 	r.Use(corsPolicy{
 		allowedOrigins: srv.config.Server.CORSAllowedOrigins,
 		publicURL:      srv.config.Server.PublicURL,

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -6,6 +6,7 @@ package frontend
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -460,6 +461,61 @@ func TestServerAuthRoutesUseEvaluatedBasePathAndKeepProxyHeadersScoped(t *testin
 	assert.Equal(t, http.StatusFound, proxyRecorder.Code)
 	assert.Equal(t, "/dagu/login?welcome=true#token=proxy-token", proxyRecorder.Header().Get("Location"))
 	assert.Equal(t, int64(1), proxyProvision.calls.Load())
+}
+
+func TestServerIPAccessProtectsAllRoutes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		DefaultExecMode: config.ExecutionModeLocal,
+		Server: config.Server{
+			APIBasePath: "/api/v1",
+			Auth:        config.Auth{Mode: config.AuthModeNone},
+			AccessLog:   config.AccessLogNone,
+			IPAccess: config.IPAccessConfig{
+				AllowedIPs: []string{"192.0.2.10"},
+			},
+			Terminal: config.TerminalConfig{MaxSessions: 5},
+			SSE: config.SSEConfig{
+				MaxTopicsPerConnection: 20,
+				MaxClients:             100,
+				HeartbeatInterval:      time.Hour,
+			},
+		},
+		UI:       config.UI{MaxDashboardPageLimit: 100},
+		Webhooks: config.WebhooksConfig{MaxPayloadSize: config.DefaultWebhookMaxPayloadSize},
+	}
+	srv, err := NewServer(ServerConfig{Context: ctx, Config: cfg}, WithListener(listener))
+	require.NoError(t, err)
+	srv.RegisterRoutes(func(_ context.Context, router chi.Router, _ string) {
+		router.Get("/extension", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.Serve(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-serveDone:
+			require.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Error("server did not shut down")
+		}
+	})
+
+	client := &http.Client{Timeout: time.Second}
+	for _, requestPath := range []string{"/api/v1/health", "/extension"} {
+		resp, err := client.Get("http://" + listener.Addr().String() + requestPath)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
 }
 
 func TestEvaluateConfiguredBasePathKeepsRedirectsLocal(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a server-wide IP allowlist so operators can restrict every HTTP endpoint to approved IPv4 or IPv6 addresses and CIDR ranges.

## Changes

- Add `ip_access.allowed_ips` and `ip_access.trusted_proxies` YAML and environment configuration
- Enforce the allowlist with global frontend middleware, including trusted proxy address resolution
- Cover direct, proxied, IPv4, IPv6, CIDR, malformed-header, and full-router behavior
- Add Helm values, schema, rendered configuration, TCP probes for restricted deployments, and chart CI assertions
- Document standalone and Helm configuration

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Validation

- `make fmt`
- `make test` — 13,698 tests passed; 37 platform or integration tests skipped
- `helm lint --strict ./charts/dagu`
- Default and allowlist-enabled Helm render assertions
- Configuration schema validation and package boundary checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-wide IP allowlist that restricts all HTTP endpoints to approved IPv4/IPv6 addresses and CIDR ranges. Previously all clients were allowed; now, when configured, only allowed clients succeed and others receive 403. Forwarded client IPs are used only when the peer is a trusted proxy.

**Rollout and review notes**
- Configure `ip_access.allowed_ips` and `ip_access.trusted_proxies` (or env `DAGU_IP_ACCESS_ALLOWED_IPS`, `DAGU_IP_ACCESS_TRUSTED_PROXIES`). Empty `allowed_ips` disables filtering.
- Enforcement is a global middleware covering health, metrics, webhooks, SSE, terminal, and extension routes. The Helm chart switches probes and test hooks to TCP/`nc` when the allowlist is enabled.
- Proxy trust: honor `X-Forwarded-For`/`X-Real-IP` only from `trusted_proxies`; walk the chain from the right; unmap IPv4-mapped IPv6; reject malformed or ambiguous headers; fall back to the direct peer when untrusted or missing.
- Config validation rejects invalid addresses/networks and too-short IPv4-mapped prefixes, aligning loader and runtime parsing.
- Charts: `config.ipAccess` is now in the values schema (chart v2.0.3) and included in defaults. If you override `config`, include `ipAccess` to satisfy the schema.
- Review focus: `internal/service/frontend/ipaccess.go` for prefix parsing and trust-chain logic and `internal/cmn/config` for validation; tests cover direct, proxied, IPv4/IPv6/CIDR, mapped IPv4, malformed headers, and full-router behavior.

<sup>Written for commit 29efb562ebd16b07b07b4197e636b325f61cccb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable IP allowlisting for UI and API routes using individual addresses or CIDR ranges.
  - Added trusted-proxy support for safely resolving forwarded client IPs.
  - Requests from unauthorized addresses now receive a 403 response.

- **Enhancements**
  - Kubernetes health checks automatically use TCP probes when IP restrictions are enabled.
  - Added Helm and environment-variable configuration options.

- **Documentation**
  - Expanded server and Helm documentation with configuration examples and proxy requirements.

- **Tests**
  - Added coverage for allowlisting, proxy handling, validation, and Helm rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->