### PR TITLE
fix: use stable DAG-run socket identity

### DIFF
--- a/internal/cmn/sock/client.go
+++ b/internal/cmn/sock/client.go
@@ -75,7 +75,8 @@ func normalizePath(path string) string {
 	return "/" + path
 }
 
-// Request sends a request to the frontend and returns the response.
+// Request sends a request to the frontend and returns the response body.
+// Non-successful HTTP responses are returned as errors.
 func (cl *Client) Request(method, path string) (string, error) {
 	requestURL := &url.URL{
 		Scheme: "http",
@@ -98,6 +99,9 @@ func (cl *Client) Request(method, path string) (string, error) {
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", wrapTimeout("read response body", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("unexpected HTTP status: %s", response.Status)
 	}
 
 	return string(body), nil

--- a/internal/cmn/sock/client.go
+++ b/internal/cmn/sock/client.go
@@ -16,7 +16,9 @@ import (
 )
 
 var (
-	ErrTimeout = errors.New("unix socket timeout")
+	ErrTimeout          = errors.New("unix socket timeout")
+	ErrTransport        = errors.New("unix socket transport error")
+	ErrUnexpectedStatus = errors.New("unexpected HTTP status")
 )
 
 // Client is a unix socket client that can send requests
@@ -45,7 +47,10 @@ func NewClient(addr string) *Client {
 	return cl
 }
 
-const defaultTimeout = 3 * time.Second
+const (
+	defaultTimeout               = 3 * time.Second
+	maxUnexpectedStatusBodyBytes = 256
+)
 
 // wrapTimeout normalizes timeout errors to the exported socket timeout sentinel.
 func wrapTimeout(op string, err error) error {
@@ -90,18 +95,24 @@ func (cl *Client) Request(method, path string) (string, error) {
 
 	response, err := cl.client.Do(request)
 	if err != nil {
-		return "", wrapTimeout("send request", err)
+		return "", fmt.Errorf("%w: %w", ErrTransport, wrapTimeout("send request", err))
 	}
 	defer func() {
 		_ = response.Body.Close()
 	}()
 
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, maxUnexpectedStatusBodyBytes))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			return "", fmt.Errorf("%w: %s", ErrUnexpectedStatus, response.Status)
+		}
+		return "", fmt.Errorf("%w: %s: %s", ErrUnexpectedStatus, response.Status, detail)
+	}
+
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", wrapTimeout("read response body", err)
-	}
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf("unexpected HTTP status: %s", response.Status)
+		return "", fmt.Errorf("%w: %w", ErrTransport, wrapTimeout("read response body", err))
 	}
 
 	return string(body), nil

--- a/internal/cmn/sock/client_test.go
+++ b/internal/cmn/sock/client_test.go
@@ -59,3 +59,35 @@ func TestDialTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, sock.ErrTimeout))
 }
+
+func TestRequestRejectsNonSuccessfulResponse(t *testing.T) {
+	f, err := os.CreateTemp("", "sock_client_http_error")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	srv, err := sock.NewServer(
+		f.Name(),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = w.Write([]byte("not accepted"))
+		},
+	)
+	require.NoError(t, err)
+
+	listen := make(chan error, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Serve(context.Background(), listen)
+	}()
+	require.NoError(t, <-listen)
+
+	body, err := sock.NewClient(f.Name()).Request(http.MethodPost, "/stop")
+	require.ErrorContains(t, err, "418 I'm a teapot")
+	require.Empty(t, body)
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+	require.True(t, errors.Is(<-done, sock.ErrServerRequestedShutdown))
+}

--- a/internal/cmn/sock/client_test.go
+++ b/internal/cmn/sock/client_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ func TestDialFail(t *testing.T) {
 	client := sock.NewClient(f.Name())
 	_, err = client.Request("GET", "/status")
 	require.Error(t, err)
+	require.ErrorIs(t, err, sock.ErrTransport)
 }
 
 func TestDialTimeout(t *testing.T) {
@@ -72,7 +74,7 @@ func TestRequestRejectsNonSuccessfulResponse(t *testing.T) {
 		f.Name(),
 		func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusTeapot)
-			_, _ = w.Write([]byte("not accepted"))
+			_, _ = w.Write([]byte("not accepted" + strings.Repeat("x", 1024)))
 		},
 	)
 	require.NoError(t, err)
@@ -85,7 +87,10 @@ func TestRequestRejectsNonSuccessfulResponse(t *testing.T) {
 	require.NoError(t, <-listen)
 
 	body, err := sock.NewClient(f.Name()).Request(http.MethodPost, "/stop")
+	require.ErrorIs(t, err, sock.ErrUnexpectedStatus)
 	require.ErrorContains(t, err, "418 I'm a teapot")
+	require.ErrorContains(t, err, "not accepted")
+	require.Less(t, len(err.Error()), 512)
 	require.Empty(t, body)
 
 	require.NoError(t, srv.Shutdown(context.Background()))

--- a/internal/ir/dag.go
+++ b/internal/ir/dag.go
@@ -70,8 +70,7 @@ type DAG struct {
 	// was auto-defaulted by the loader to the DAG file's parent directory.
 	// Not serialized — runtime-only flag.
 	WorkingDirExplicit bool `json:"-"`
-	// Location is the absolute path to the DAG file.
-	// It is used to generate unix socket name and can be blank
+	// Location is the absolute path to the DAG file and can be blank.
 	Location string `json:"location,omitempty"`
 	// SourceFile is the original DAG file path this run was loaded from.
 	// Unlike Location, it is provenance-only and is preserved even when queued

--- a/internal/proc/socket.go
+++ b/internal/proc/socket.go
@@ -10,15 +10,6 @@ import (
 )
 
 // DAGSocketAddr returns the control socket address for a DAG run.
-func DAGSocketAddr(dag *ir.DAG, runID string) string {
-	identity := dag.Location
-	if identity == "" {
-		identity = dag.Name
-	}
-	return sock.Addr(identity, runID)
-}
-
-// SubDAGSocketAddr returns the control socket address for a child DAG run.
-func SubDAGSocketAddr(dag *ir.DAG, runID string) string {
-	return sock.Addr(dag.GetName(), runID)
+func DAGSocketAddr(dagRun ir.DAGRunRef) string {
+	return sock.Addr(dagRun.Name, dagRun.ID)
 }

--- a/internal/proc/socket_test.go
+++ b/internal/proc/socket_test.go
@@ -14,10 +14,6 @@ import (
 func TestDAGSocketAddr(t *testing.T) {
 	t.Parallel()
 
-	dag := &ir.DAG{Name: "mydag", Location: "path/to/dag.yml"}
-	require.Equal(t, sock.Addr(dag.Location, "run123"), DAGSocketAddr(dag, "run123"))
-	require.Equal(t, sock.Addr(dag.Name, "child456"), SubDAGSocketAddr(dag, "child456"))
-
-	dag.Location = ""
-	require.Equal(t, sock.Addr(dag.Name, "run123"), DAGSocketAddr(dag, "run123"))
+	ref := ir.NewDAGRunRef("mydag", "run123")
+	require.Equal(t, sock.Addr("mydag", "run123"), DAGSocketAddr(ref))
 }

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -2352,10 +2352,7 @@ func (a *Agent) setupSocketServer(ctx context.Context) error {
 }
 
 func (a *Agent) socketAddr() string {
-	if a.isSubDAGRun.Load() {
-		return proc.SubDAGSocketAddr(a.dag, a.dagRunID)
-	}
-	return proc.DAGSocketAddr(a.dag, a.dagRunID)
+	return proc.DAGSocketAddr(ir.NewDAGRunRef(a.dag.Name, a.dagRunID))
 }
 
 // checkIsAlreadyRunning returns error if the DAG is already running.
@@ -2366,7 +2363,7 @@ func (a *Agent) checkIsAlreadyRunning(ctx context.Context) error {
 	if !a.dagRunMgr.IsRunning(ctx, a.dag, a.dagRunID) {
 		return nil
 	}
-	return fmt.Errorf("already running. dag-run ID=%s, socket=%s", a.dagRunID, proc.DAGSocketAddr(a.dag, a.dagRunID))
+	return fmt.Errorf("already running. dag-run ID=%s, socket=%s", a.dagRunID, a.socketAddr())
 }
 
 // execWithRecovery executes a function with panic recovery and logs any panics.

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -1081,6 +1081,40 @@ func TestAgent_HandleHTTP(t *testing.T) {
 	})
 }
 
+func TestAgent_SubDAGSocketUsesCurrentRunIdentity(t *testing.T) {
+	t.Parallel()
+
+	th := test.Setup(t)
+	dag := th.DAG(t, `name: child-dag
+steps:
+  - run: exit 0
+`)
+	const childRunID = "child-run"
+	bindErr := errors.New("stop after capturing socket address")
+	var socketAddr string
+	dagAgent := agent.New(
+		childRunID,
+		dag.DAG,
+		th.Config.Paths.LogDir,
+		filepath.Join(th.Config.Paths.LogDir, childRunID+".log"),
+		th.DAGRunMgr,
+		th.DAGRepository,
+		agent.Options{
+			RootDAGRun:   ir.NewDAGRunRef("root-dag", "root-run"),
+			ParentDAGRun: ir.NewDAGRunRef("root-dag", "root-run"),
+			SocketServerFactory: func(addr string, _ sock.HTTPHandlerFunc) (agent.SocketServer, error) {
+				socketAddr = addr
+				return nil, bindErr
+			},
+		},
+	)
+
+	err := dagAgent.Run(th.Context)
+
+	require.ErrorIs(t, err, bindErr)
+	require.Equal(t, sock.Addr("child-dag", childRunID), socketAddr)
+}
+
 // Assert that mockResponseWriter implements http.ResponseWriter
 var _ http.ResponseWriter = (*mockResponseWriter)(nil)
 

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -373,6 +374,9 @@ func (*Manager) currentStatus(_ context.Context, dagRun ir.DAGRunRef, dag *ir.DA
 		}
 		statusJSON, err := sock.NewClient(addr).Request("GET", "/status")
 		if err != nil {
+			if errors.Is(err, sock.ErrTransport) {
+				continue
+			}
 			return nil, fmt.Errorf("failed to get current status: %w", err)
 		}
 		return ir.StatusFromJSON(statusJSON)
@@ -510,7 +514,7 @@ func (m *Manager) repairStaleLocalRunIfDead(
 		return st, nil
 	}
 	procGroup := st.ProcGroup
-	if dag != nil {
+	if procGroup == "" && dag != nil {
 		procGroup = dag.ProcGroup()
 	}
 	if procGroup == "" {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -202,16 +202,19 @@ func (m *Manager) stopSingleDAGRun(ctx context.Context, dag *ir.DAG, dagRunID st
 				return err
 			}
 		}
-		addr := proc.DAGSocketAddr(dag, dagRunID)
-		if fileutil.FileExists(addr) {
-			// In case the socket exists, we try to send a stop request
+		for _, addr := range dagSocketCandidates(runRef, dag) {
+			if !fileutil.FileExists(addr) {
+				continue
+			}
 			client := sock.NewClient(addr)
-			if _, err := client.Request("POST", "/stop"); err == nil {
+			_, requestErr := client.Request("POST", "/stop")
+			if requestErr == nil {
 				logger.Info(ctx, "Successfully stopped DAG via socket")
 				return nil
 			}
-			logger.Debug(ctx, "Socket stop request failed, will use abort flag",
-				tag.Error(err))
+			logger.Debug(ctx, "Socket stop request failed",
+				tag.Addr(addr),
+				tag.Error(requestErr))
 		}
 	}
 
@@ -235,7 +238,8 @@ func (m *Manager) stopSingleDAGRun(ctx context.Context, dag *ir.DAG, dagRunID st
 // IsRunning checks if a dag-run is currently running. It prefers the live socket
 // status and falls back to a fresh proc heartbeat plus persisted running status.
 func (m *Manager) IsRunning(ctx context.Context, dag *ir.DAG, dagRunID string) bool {
-	st, _ := m.currentStatus(ctx, dag, dagRunID)
+	runRef := ir.NewDAGRunRef(dag.Name, dagRunID)
+	st, _ := m.currentStatus(ctx, runRef, dag)
 	if st != nil && st.DAGRunID == dagRunID && st.Status == ir.Running {
 		return true
 	}
@@ -243,7 +247,6 @@ func (m *Manager) IsRunning(ctx context.Context, dag *ir.DAG, dagRunID string) b
 		return false
 	}
 
-	runRef := ir.NewDAGRunRef(dag.Name, dagRunID)
 	if alive, err := m.procRepository.IsRunAlive(ctx, dag.ProcGroup(), runRef); err == nil && alive {
 		st, err := m.getPersistedOrCurrentStatus(ctx, dag, dagRunID)
 		if err != nil {
@@ -271,7 +274,7 @@ func (m *Manager) GetCurrentStatus(ctx context.Context, dag *ir.DAG, dagRunID st
 	if err == nil {
 		return status, nil
 	}
-	currentStatus, currentErr := m.currentStatus(ctx, dag, dagRunID)
+	currentStatus, currentErr := m.currentStatus(ctx, ir.NewDAGRunRef(dag.Name, dagRunID), dag)
 	if currentErr == nil {
 		return currentStatus, nil
 	}
@@ -363,20 +366,35 @@ func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun ir.DAGRunR
 
 // currentStatus retrieves the current status of a running DAG by querying its socket.
 // This is a private method used internally by other status-related methods.
-func (*Manager) currentStatus(_ context.Context, dag *ir.DAG, dagRunID string) (*ir.DAGRunStatus, error) {
-	client := sock.NewClient(proc.DAGSocketAddr(dag, dagRunID))
-
-	// Check if the socket file exists
-	if !fileutil.FileExists(client.SocketAddr()) {
-		return nil, fmt.Errorf("socket file does not exist for dag-run ID %s", dagRunID)
+func (*Manager) currentStatus(_ context.Context, dagRun ir.DAGRunRef, dag *ir.DAG) (*ir.DAGRunStatus, error) {
+	addrs := dagSocketCandidates(dagRun, dag)
+	addr := addrs[0]
+	if !fileutil.FileExists(addr) {
+		if len(addrs) == 1 || !fileutil.FileExists(addrs[1]) {
+			return nil, fmt.Errorf("socket file does not exist for dag-run ID %s", dagRun.ID)
+		}
+		addr = addrs[1]
 	}
 
-	statusJSON, err := client.Request("GET", "/status")
+	statusJSON, err := sock.NewClient(addr).Request("GET", "/status")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current status: %w", err)
 	}
 
 	return ir.StatusFromJSON(statusJSON)
+}
+
+func dagSocketCandidates(dagRun ir.DAGRunRef, dag *ir.DAG) []string {
+	canonical := proc.DAGSocketAddr(dagRun)
+	addrs := []string{canonical}
+	if dag == nil || dag.Location == "" {
+		return addrs
+	}
+	legacy := sock.Addr(dag.Location, dagRun.ID)
+	if legacy != canonical {
+		addrs = append(addrs, legacy)
+	}
+	return addrs
 }
 
 func isLocalWorkerID(workerID string) bool {
@@ -402,7 +420,7 @@ func (m *Manager) resolveRunningStatus(
 	}
 
 	if isRoot {
-		currentStatus, err := m.currentStatus(ctx, dag, status.DAGRunID)
+		currentStatus, err := m.currentStatus(ctx, status.DAGRun(), dag)
 		if err == nil {
 			return currentStatus
 		}
@@ -495,8 +513,15 @@ func (m *Manager) repairStaleLocalRunIfDead(
 	if m.procRepository == nil {
 		return st, nil
 	}
+	procGroup := st.ProcGroup
+	if dag != nil {
+		procGroup = dag.ProcGroup()
+	}
+	if procGroup == "" {
+		return st, nil
+	}
 
-	alive, err := m.procRepository.IsAttemptAlive(ctx, dag.ProcGroup(), st.DAGRun(), st.AttemptID)
+	alive, err := m.procRepository.IsAttemptAlive(ctx, procGroup, st.DAGRun(), st.AttemptID)
 	if err != nil {
 		return nil, fmt.Errorf("check alive: %w", err)
 	}
@@ -504,7 +529,7 @@ func (m *Manager) repairStaleLocalRunIfDead(
 		return st, nil
 	}
 
-	runAlive, err := m.procRepository.IsRunAlive(ctx, dag.ProcGroup(), st.DAGRun())
+	runAlive, err := m.procRepository.IsRunAlive(ctx, procGroup, st.DAGRun())
 	if err != nil {
 		return nil, fmt.Errorf("check run alive: %w", err)
 	}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -367,21 +367,17 @@ func (m *Manager) FindSubDAGRunStatus(ctx context.Context, rootDAGRun ir.DAGRunR
 // currentStatus retrieves the current status of a running DAG by querying its socket.
 // This is a private method used internally by other status-related methods.
 func (*Manager) currentStatus(_ context.Context, dagRun ir.DAGRunRef, dag *ir.DAG) (*ir.DAGRunStatus, error) {
-	addrs := dagSocketCandidates(dagRun, dag)
-	addr := addrs[0]
-	if !fileutil.FileExists(addr) {
-		if len(addrs) == 1 || !fileutil.FileExists(addrs[1]) {
-			return nil, fmt.Errorf("socket file does not exist for dag-run ID %s", dagRun.ID)
+	for _, addr := range dagSocketCandidates(dagRun, dag) {
+		if !fileutil.FileExists(addr) {
+			continue
 		}
-		addr = addrs[1]
+		statusJSON, err := sock.NewClient(addr).Request("GET", "/status")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current status: %w", err)
+		}
+		return ir.StatusFromJSON(statusJSON)
 	}
-
-	statusJSON, err := sock.NewClient(addr).Request("GET", "/status")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current status: %w", err)
-	}
-
-	return ir.StatusFromJSON(statusJSON)
+	return nil, fmt.Errorf("socket file does not exist for dag-run ID %s", dagRun.ID)
 }
 
 func dagSocketCandidates(dagRun ir.DAGRunRef, dag *ir.DAG) []string {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -6,6 +6,7 @@ package runtime_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"testing"
@@ -41,7 +42,7 @@ func TestManager(t *testing.T) {
 
 		dagRunID := uuid.Must(uuid.NewV7()).String()
 		socketServer, _ := sock.NewServer(
-			procctrl.DAGSocketAddr(dag.DAG, dagRunID),
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
 			func(w http.ResponseWriter, _ *http.Request) {
 				status := ir.NewStatusBuilder(dag.DAG).Create(
 					dagRunID, ir.Running, 0, time.Now(),
@@ -75,6 +76,122 @@ func TestManager(t *testing.T) {
 
 		dag.AssertCurrentStatus(t, ir.NotStarted)
 	})
+	t.Run("GetLatestStatusUsesCanonicalSocketForQueuedSnapshot", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		queuedDAG := *dag.DAG
+		queuedDAG.Location = ""
+		attempt := createLiveRootAttempt(t, th, &queuedDAG, dagRunID)
+
+		liveStatus := testNewStatus(&queuedDAG, dagRunID, ir.Waiting, ir.NodeWaiting)
+		liveStatus.AttemptID = attempt.ID()
+		stopSocket := startStatusSocketServer(
+			t,
+			ctx,
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
+			liveStatus,
+		)
+		defer stopSocket()
+
+		latest, err := th.DAGRunMgr.GetLatestStatus(ctx, dag.DAG)
+
+		require.NoError(t, err)
+		require.Equal(t, ir.Waiting, latest.Status)
+		require.Equal(t, attempt.ID(), latest.AttemptID)
+	})
+	t.Run("GetCurrentStatusFallsBackToLegacyRootSocket", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		legacyStatus := testNewStatus(dag.DAG, dagRunID, ir.Waiting, ir.NodeWaiting)
+		legacyStatus.Error = "legacy"
+		stopSocket := startStatusSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), legacyStatus)
+		defer stopSocket()
+
+		current, err := th.DAGRunMgr.GetCurrentStatus(ctx, dag.DAG, dagRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, ir.Waiting, current.Status)
+		require.Equal(t, "legacy", current.Error)
+	})
+	t.Run("GetCurrentStatusPrefersCanonicalSocket", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		canonicalStatus := testNewStatus(dag.DAG, dagRunID, ir.Waiting, ir.NodeWaiting)
+		canonicalStatus.Error = "canonical"
+		legacyStatus := canonicalStatus
+		legacyStatus.Error = "legacy"
+
+		stopCanonical := startStatusSocketServer(
+			t,
+			ctx,
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
+			canonicalStatus,
+		)
+		defer stopCanonical()
+		stopLegacy := startStatusSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), legacyStatus)
+		defer stopLegacy()
+
+		current, err := th.DAGRunMgr.GetCurrentStatus(ctx, dag.DAG, dagRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, "canonical", current.Error)
+	})
+	t.Run("IsRunningDoesNotMaskCanonicalSocketFailureWithLegacyStatus", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		mgr := runtime.NewManager(nil, nil, th.Config)
+		legacyStatus := testNewStatus(dag.DAG, "unused", ir.Running, ir.NodeRunning)
+
+		for _, tc := range []struct {
+			name    string
+			handler sock.HTTPHandlerFunc
+		}{
+			{
+				name: "HTTPError",
+				handler: func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				},
+			},
+			{
+				name: "MalformedStatus",
+				handler: func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{"))
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				dagRunID := uuid.Must(uuid.NewV7()).String()
+				legacyStatus.DAGRunID = dagRunID
+				stopCanonical := startSocketServer(
+					t,
+					ctx,
+					procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
+					tc.handler,
+				)
+				defer stopCanonical()
+				stopLegacy := startStatusSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), legacyStatus)
+				defer stopLegacy()
+
+				require.False(t, mgr.IsRunning(ctx, dag.DAG, dagRunID))
+			})
+		}
+	})
 	t.Run("StopViaSocketRequestsCancel", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
   - name: "1"
@@ -103,7 +220,7 @@ func TestManager(t *testing.T) {
 
 		stopRequested := make(chan struct{}, 1)
 		socketServer, err := sock.NewServer(
-			procctrl.DAGSocketAddr(dag.DAG, dagRunID),
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
 			func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost || r.URL.Path != "/stop" {
 					w.WriteHeader(http.StatusNotFound)
@@ -139,6 +256,76 @@ func TestManager(t *testing.T) {
 		aborting, err := attempt.IsAborting(ctx)
 		require.NoError(t, err)
 		require.True(t, aborting)
+	})
+	t.Run("StopFallsBackToLegacyRootSocket", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		attempt := createLiveRootAttempt(t, th, dag.DAG, dagRunID)
+		stopRequested := make(chan struct{}, 1)
+		stopSocket := startSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/stop" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			stopRequested <- struct{}{}
+			w.WriteHeader(http.StatusOK)
+		})
+		defer stopSocket()
+
+		require.NoError(t, th.DAGRunMgr.Stop(ctx, dag.DAG, dagRunID))
+
+		select {
+		case <-stopRequested:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "legacy socket stop request was not received")
+		}
+		aborting, err := attempt.IsAborting(ctx)
+		require.NoError(t, err)
+		require.True(t, aborting)
+	})
+	t.Run("StopContinuesToLegacySocketAfterCanonicalHTTPError", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		createLiveRootAttempt(t, th, dag.DAG, dagRunID)
+		canonicalRequested := make(chan struct{}, 1)
+		legacyRequested := make(chan struct{}, 1)
+
+		stopCanonical := startSocketServer(
+			t,
+			ctx,
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
+			func(w http.ResponseWriter, _ *http.Request) {
+				canonicalRequested <- struct{}{}
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+		)
+		defer stopCanonical()
+		stopLegacy := startSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), func(w http.ResponseWriter, _ *http.Request) {
+			legacyRequested <- struct{}{}
+			w.WriteHeader(http.StatusOK)
+		})
+		defer stopLegacy()
+
+		require.NoError(t, th.DAGRunMgr.Stop(ctx, dag.DAG, dagRunID))
+
+		select {
+		case <-canonicalRequested:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "canonical socket stop request was not received")
+		}
+		select {
+		case <-legacyRequested:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "legacy socket stop request was not received")
+		}
 	})
 	t.Run("UpdateStatus", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
@@ -420,7 +607,7 @@ steps:
 		require.NoError(t, att.Write(ctx, runningStatus))
 		require.NoError(t, att.Close(ctx))
 
-		stopSocket := startStatusSocketServer(t, ctx, dag.DAG, dagRunID, ir.NewStatusBuilder(dag.DAG).Create(
+		stopSocket := startStatusSocketServer(t, ctx, procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)), ir.NewStatusBuilder(dag.DAG).Create(
 			dagRunID, ir.Running, 0, time.Now(),
 		))
 		defer stopSocket()
@@ -544,6 +731,31 @@ steps:
 		require.Equal(t, ir.NodeFailed, saved.Nodes[0].Status)
 		require.Equal(t, "process terminated unexpectedly - stale local process detected", saved.Nodes[0].Error)
 	})
+	t.Run("GetSavedStatusUsesPersistedProcGroupWhenDAGReadFails", func(t *testing.T) {
+		ctx := th.Context
+		ref := ir.NewDAGRunRef("unreadable-dag", uuid.Must(uuid.NewV7()).String())
+		status := testNewStatus(&ir.DAG{Name: ref.Name}, ref.ID, ir.Running, ir.NodeRunning)
+		status.AttemptID = "attempt-1"
+		status.ProcGroup = "persisted-group"
+		staleAt := time.Now().Add(-3 * time.Second)
+		status.StartedAt = stringutil.FormatTime(staleAt)
+		status.CreatedAt = staleAt.UnixMilli()
+
+		attempt := new(testutil.MockAttempt)
+		attempt.On("ReadStatus", ctx).Return(&status, nil).Once()
+		attempt.On("ReadDAG", ctx).Return(nil, errors.New("dag unavailable")).Once()
+		store := &managerDAGRunStore{rootAttempt: attempt}
+		repository := persis.NewDAGRunRepository(store, nil, persis.DAGRunRepositoryOptions{})
+		processes := &managerProcessRepository{attemptAlive: true}
+		mgr := runtime.NewManager(repository, processes, th.Config)
+
+		saved, err := mgr.GetSavedStatus(ctx, ref)
+
+		require.NoError(t, err)
+		require.Equal(t, ir.Running, saved.Status)
+		require.Equal(t, "persisted-group", processes.attemptGroup)
+		attempt.AssertExpectations(t)
+	})
 	t.Run("GetLatestStatusKeepsFreshRunDuringStartupGrace", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
   - name: "1"
@@ -663,7 +875,7 @@ steps:
 		runningStatus.WorkerID = "worker-1"
 		require.NoError(t, att.Write(ctx, runningStatus))
 		require.NoError(t, att.Close(ctx))
-		stopSocket := startStatusSocketServer(t, ctx, dag.DAG, dagRunID, ir.NewStatusBuilder(dag.DAG).Create(
+		stopSocket := startStatusSocketServer(t, ctx, procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)), ir.NewStatusBuilder(dag.DAG).Create(
 			dagRunID, ir.Failed, 0, time.Now(),
 		))
 		defer stopSocket()
@@ -693,7 +905,7 @@ steps:
 		runningStatus.WorkerID = "worker-1"
 		require.NoError(t, att.Write(ctx, runningStatus))
 		require.NoError(t, att.Close(ctx))
-		stopSocket := startStatusSocketServer(t, ctx, dag.DAG, dagRunID, ir.NewStatusBuilder(dag.DAG).Create(
+		stopSocket := startStatusSocketServer(t, ctx, procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)), ir.NewStatusBuilder(dag.DAG).Create(
 			dagRunID, ir.Failed, 0, time.Now(),
 		))
 		defer stopSocket()
@@ -886,7 +1098,15 @@ func createRunningSubAttempt(
 
 type managerDAGRunStore struct {
 	testutil.DAGRunStoreStub
-	subAttempt dagrun.Attempt
+	rootAttempt dagrun.Attempt
+	subAttempt  dagrun.Attempt
+}
+
+func (s *managerDAGRunStore) FindAttempt(context.Context, ir.DAGRunRef) (dagrun.Attempt, error) {
+	if s.rootAttempt == nil {
+		return nil, dagrun.ErrDAGRunIDNotFound
+	}
+	return s.rootAttempt, nil
 }
 
 func (s *managerDAGRunStore) FindSubAttempt(context.Context, ir.DAGRunRef, string) (dagrun.Attempt, error) {
@@ -896,30 +1116,82 @@ func (s *managerDAGRunStore) FindSubAttempt(context.Context, ir.DAGRunRef, strin
 	return s.subAttempt, nil
 }
 
-// startStatusSocketServer serves a fixed status over the DAG run socket.
-func startStatusSocketServer(t *testing.T, ctx context.Context, dag *ir.DAG, dagRunID string, status ir.DAGRunStatus) func() {
+func createLiveRootAttempt(t *testing.T, th test.Helper, dag *ir.DAG, dagRunID string) dagrun.Attempt {
 	t.Helper()
 
-	socketServer, err := sock.NewServer(
-		procctrl.DAGSocketAddr(dag, dagRunID),
-		func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			jsonData, marshalErr := json.Marshal(status)
-			if marshalErr != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			_, _ = w.Write(jsonData)
-		},
-	)
+	ctx := th.Context
+	attempt, err := th.DAGRunRepository.CreateAttempt(ctx, dag, time.Now(), dagRunID, persis.DAGRunCreateAttemptOptions{})
+	require.NoError(t, err)
+	require.NoError(t, attempt.Open(ctx))
+	status := testNewStatus(dag, dagRunID, ir.Running, ir.NodeRunning)
+	status.AttemptID = attempt.ID()
+	require.NoError(t, attempt.Write(ctx, status))
+	require.NoError(t, attempt.Close(ctx))
+
+	process, err := th.ProcRepository.Acquire(ctx, dag.ProcGroup(), procctrl.ProcMeta{
+		StartedAt:    time.Now().Unix(),
+		Name:         dag.Name,
+		DAGRunID:     dagRunID,
+		AttemptID:    attempt.ID(),
+		RootName:     dag.Name,
+		RootDAGRunID: dagRunID,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = process.Stop(ctx)
+	})
+
+	return attempt
+}
+
+// startStatusSocketServer serves a fixed status over the requested socket.
+func startStatusSocketServer(t *testing.T, ctx context.Context, addr string, status ir.DAGRunStatus) func() {
+	t.Helper()
+
+	jsonData, err := json.Marshal(status)
+	require.NoError(t, err)
+	return startSocketServer(t, ctx, addr, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(jsonData)
+	})
+}
+
+func startSocketServer(t *testing.T, ctx context.Context, addr string, handler sock.HTTPHandlerFunc) func() {
+	t.Helper()
+
+	socketServer, err := sock.NewServer(addr, handler)
 	require.NoError(t, err)
 
+	listen := make(chan error, 1)
 	go func() {
-		_ = socketServer.Serve(ctx, nil)
+		_ = socketServer.Serve(ctx, listen)
 		_ = socketServer.Shutdown(ctx)
 	}()
+	require.NoError(t, <-listen)
 
 	return func() {
 		_ = socketServer.Shutdown(ctx)
 	}
+}
+
+type managerProcessRepository struct {
+	attemptAlive bool
+	attemptGroup string
+}
+
+func (*managerProcessRepository) ListAlive(context.Context, string) ([]ir.DAGRunRef, error) {
+	return nil, nil
+}
+
+func (*managerProcessRepository) IsRunAlive(context.Context, string, ir.DAGRunRef) (bool, error) {
+	return false, nil
+}
+
+func (r *managerProcessRepository) IsAttemptAlive(_ context.Context, group string, _ ir.DAGRunRef, _ string) (bool, error) {
+	r.attemptGroup = group
+	return r.attemptAlive, nil
+}
+
+func (*managerProcessRepository) LatestFreshEntryByDAGName(context.Context, string, string) (*procctrl.ProcEntry, error) {
+	return nil, nil
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -41,28 +41,15 @@ func TestManager(t *testing.T) {
 		ctx := th.Context
 
 		dagRunID := uuid.Must(uuid.NewV7()).String()
-		socketServer, _ := sock.NewServer(
-			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
-			func(w http.ResponseWriter, _ *http.Request) {
-				status := ir.NewStatusBuilder(dag.DAG).Create(
-					dagRunID, ir.Running, 0, time.Now(),
-				)
-				jsonData, err := json.Marshal(status)
-				if err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(jsonData)
-			},
+		status := ir.NewStatusBuilder(dag.DAG).Create(
+			dagRunID, ir.Running, 0, time.Now(),
 		)
-
-		listen := make(chan error, 1)
-		go func() {
-			_ = socketServer.Serve(ctx, listen)
-			_ = socketServer.Shutdown(ctx)
-		}()
-		require.NoError(t, <-listen)
+		stopSocket := startStatusSocketServer(
+			t,
+			ctx,
+			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
+			status,
+		)
 
 		require.Eventually(t, func() bool {
 			curr, err := th.DAGRunMgr.GetCurrentStatus(ctx, dag.DAG, dagRunID)
@@ -72,7 +59,7 @@ func TestManager(t *testing.T) {
 			return curr.Status == ir.Running
 		}, platformTestDuration(10*time.Second, 30*time.Second), 100*time.Millisecond)
 
-		_ = socketServer.Shutdown(ctx)
+		stopSocket()
 
 		dag.AssertCurrentStatus(t, ir.NotStarted)
 	})
@@ -155,7 +142,6 @@ func TestManager(t *testing.T) {
 `)
 		ctx := th.Context
 		mgr := runtime.NewManager(nil, nil, th.Config)
-		legacyStatus := testNewStatus(dag.DAG, "unused", ir.Running, ir.NodeRunning)
 
 		for _, tc := range []struct {
 			name    string
@@ -177,7 +163,7 @@ func TestManager(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				dagRunID := uuid.Must(uuid.NewV7()).String()
-				legacyStatus.DAGRunID = dagRunID
+				legacyStatus := testNewStatus(dag.DAG, dagRunID, ir.Running, ir.NodeRunning)
 				stopCanonical := startSocketServer(
 					t,
 					ctx,
@@ -199,27 +185,12 @@ func TestManager(t *testing.T) {
 `)
 		ctx := th.Context
 		dagRunID := uuid.Must(uuid.NewV7()).String()
-		attempt, err := th.DAGRunRepository.CreateAttempt(ctx, dag.DAG, time.Now(), dagRunID, persis.DAGRunCreateAttemptOptions{})
-		require.NoError(t, err)
-		require.NoError(t, attempt.Open(ctx))
-		require.NoError(t, attempt.Write(ctx, testNewStatus(dag.DAG, dagRunID, ir.Running, ir.NodeRunning)))
-		require.NoError(t, attempt.Close(ctx))
-
-		proc, err := th.ProcRepository.Acquire(ctx, dag.ProcGroup(), procctrl.ProcMeta{
-			StartedAt:    time.Now().Unix(),
-			Name:         dag.Name,
-			DAGRunID:     dagRunID,
-			AttemptID:    attempt.ID(),
-			RootName:     dag.Name,
-			RootDAGRunID: dagRunID,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_ = proc.Stop(ctx)
-		})
+		attempt := createLiveRootAttempt(t, th, dag.DAG, dagRunID)
 
 		stopRequested := make(chan struct{}, 1)
-		socketServer, err := sock.NewServer(
+		stopSocket := startSocketServer(
+			t,
+			ctx,
 			procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID)),
 			func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost || r.URL.Path != "/stop" {
@@ -234,17 +205,7 @@ func TestManager(t *testing.T) {
 				_, _ = w.Write([]byte("OK"))
 			},
 		)
-		require.NoError(t, err)
-
-		listen := make(chan error, 1)
-		go func() {
-			_ = socketServer.Serve(ctx, listen)
-			_ = socketServer.Shutdown(ctx)
-		}()
-		require.NoError(t, <-listen)
-		t.Cleanup(func() {
-			_ = socketServer.Shutdown(ctx)
-		})
+		defer stopSocket()
 
 		require.NoError(t, th.DAGRunMgr.Stop(ctx, dag.DAG, dagRunID))
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -108,6 +108,27 @@ func TestManager(t *testing.T) {
 		require.Equal(t, ir.Waiting, current.Status)
 		require.Equal(t, "legacy", current.Error)
 	})
+	t.Run("GetCurrentStatusSkipsStaleCanonicalSocket", func(t *testing.T) {
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    run: "exit 0"
+`)
+		ctx := th.Context
+		dagRunID := uuid.Must(uuid.NewV7()).String()
+		canonicalAddr := procctrl.DAGSocketAddr(ir.NewDAGRunRef(dag.Name, dagRunID))
+		require.NoError(t, os.WriteFile(canonicalAddr, nil, 0o600))
+		t.Cleanup(func() { _ = os.Remove(canonicalAddr) })
+
+		legacyStatus := testNewStatus(dag.DAG, dagRunID, ir.Waiting, ir.NodeWaiting)
+		legacyStatus.Error = "legacy"
+		stopSocket := startStatusSocketServer(t, ctx, sock.Addr(dag.Location, dagRunID), legacyStatus)
+		defer stopSocket()
+
+		current, err := th.DAGRunMgr.GetCurrentStatus(ctx, dag.DAG, dagRunID)
+
+		require.NoError(t, err)
+		require.Equal(t, "legacy", current.Error)
+	})
 	t.Run("GetCurrentStatusPrefersCanonicalSocket", func(t *testing.T) {
 		dag := th.DAG(t, `steps:
   - name: "1"
@@ -715,6 +736,31 @@ steps:
 		require.NoError(t, err)
 		require.Equal(t, ir.Running, saved.Status)
 		require.Equal(t, "persisted-group", processes.attemptGroup)
+		attempt.AssertExpectations(t)
+	})
+	t.Run("GetSavedStatusUsesPersistedProcGroupAfterDAGQueueChange", func(t *testing.T) {
+		ctx := th.Context
+		ref := ir.NewDAGRunRef("changed-dag", uuid.Must(uuid.NewV7()).String())
+		status := testNewStatus(&ir.DAG{Name: ref.Name}, ref.ID, ir.Running, ir.NodeRunning)
+		status.AttemptID = "attempt-1"
+		status.ProcGroup = "original-group"
+		staleAt := time.Now().Add(-3 * time.Second)
+		status.StartedAt = stringutil.FormatTime(staleAt)
+		status.CreatedAt = staleAt.UnixMilli()
+
+		attempt := new(testutil.MockAttempt)
+		attempt.On("ReadStatus", ctx).Return(&status, nil).Once()
+		attempt.On("ReadDAG", ctx).Return(&ir.DAG{Name: ref.Name, Queue: "updated-group"}, nil).Once()
+		store := &managerDAGRunStore{rootAttempt: attempt}
+		repository := persis.NewDAGRunRepository(store, nil, persis.DAGRunRepositoryOptions{})
+		processes := &managerProcessRepository{attemptAlive: true}
+		mgr := runtime.NewManager(repository, processes, th.Config)
+
+		saved, err := mgr.GetSavedStatus(ctx, ref)
+
+		require.NoError(t, err)
+		require.Equal(t, ir.Running, saved.Status)
+		require.Equal(t, "original-group", processes.attemptGroup)
 		attempt.AssertExpectations(t)
 	})
 	t.Run("GetLatestStatusKeepsFreshRunDuringStartupGrace", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- derive every DAG-run control socket from the stable DAG name and run ID
- prefer the canonical address while retaining fallback support for legacy root sockets
- reject non-successful socket HTTP responses and keep stale-status repair safe when a persisted DAG cannot be read
- add regression coverage for queued snapshots, legacy compatibility, stop behavior, malformed responses, and child DAGs

## Root cause

Queued and retry snapshots clear `DAG.Location`. The runtime agent could therefore bind a name-based socket while the manager, using a freshly loaded DAG, looked for a location-based socket. A fresh process heartbeat kept the persisted run in `Running`, so status polling retried the nonexistent socket indefinitely.

## Validation

- `go test -race -count=1 ./internal/cmn/sock ./internal/proc ./internal/runtime ./internal/runtime/agent`
- focused distributed queue, heartbeat, and retry integration tests
- native and Windows lint
- Windows compilation for all changed packages
- `git diff --check main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes DAG-run socket identity to DAG name + run ID and hardens manager fallback so status polling and stop requests work even when `DAG.Location` is empty or changes.

All sockets now use `proc.DAGSocketAddr(ir.DAGRunRef)`; the agent binds this for both root and child DAGs, with legacy location-based sockets kept as a fallback. Manager status lookup prefers the canonical socket and falls back to the legacy root socket only on transport errors or stale files; non-2xx or malformed responses surface errors, and `IsRunning` no longer treats legacy status as success when canonical fails. Stop requests try the canonical socket, then legacy. Stale-status repair uses the persisted proc group when the DAG cannot be read or its queue changes. `sock.Client.Request` returns errors on non-2xx and wraps I/O failures with `sock.ErrTransport`; unexpected statuses return `sock.ErrUnexpectedStatus`.

**Migration**
- Update call sites to `proc.DAGSocketAddr(ir.NewDAGRunRef(name, id))`.
- Remove any `SubDAGSocketAddr` usage.
- Expect `sock.Client.Request` to error on non-2xx responses.

<sup>Written for commit 3e743293ad0f0c828b78c159521990c718008b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed HTTP requests now return clear errors instead of being treated as successful responses.
  * Improved reliability when checking status or stopping workflow runs, including compatibility with older run endpoints.
  * Corrected socket handling for nested workflow runs so each run uses its own identity.
  * Improved recovery of stale run status when workflow definitions are unavailable or process information is incomplete.

* **Documentation**
  * Clarified behavior for unsuccessful HTTP responses and missing workflow file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->