### PR TITLE
fix: keep controller-era agent DAGs and runs readable

### DIFF
--- a/conformance/spec032_agent/testdata/legacy_controller_type.yaml
+++ b/conformance/spec032_agent/testdata/legacy_controller_type.yaml
@@ -1,0 +1,10 @@
+type: controller
+llm:
+  provider: anthropic
+  model: claude-opus-5
+steps:
+  - name: design
+    run: echo drafting
+tasks:
+  - name: designed
+    description: Finished when the design step ran.

--- a/conformance/spec032_agent/validation_test.go
+++ b/conformance/spec032_agent/validation_test.go
@@ -21,6 +21,16 @@ func TestAgentShapeValidation(t *testing.T) {
 		result.ExpectStderr("")
 	})
 
+	// type: controller is the pre-rename spelling of type: agent.
+	t.Run("legacy_controller_type.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "legacy_controller_type.yaml")
+		result.ExpectExitCode(0)
+		result.ExpectStderrContains("type: controller is deprecated", "use type: agent")
+	})
+
 	invalid := []struct {
 		file  string
 		parts []string

--- a/internal/ir/agent.go
+++ b/internal/ir/agent.go
@@ -66,16 +66,18 @@ func (d *DAG) IsAgent() bool {
 	return d != nil && d.Type == TypeAgent
 }
 
-// IsAgentStepName reports whether a step name identifies the synthesized step
-// that drives an agent DAG, in either the current or the legacy spelling.
-func IsAgentStepName(name string) bool {
+// IsPersistedAgentStepName reports whether a step name recorded in a run
+// status identifies the synthesized step that drives an agent DAG. It accepts
+// the legacy spelling, so it suits reading run history but not building or
+// validating a DAG, where only the current name is ever synthesized.
+func IsPersistedAgentStepName(name string) bool {
 	return name == AgentStepName || name == LegacyAgentStepName
 }
 
 // IsSynthesizedAgentStep reports whether a step name belongs to the
 // scaffolding an agent DAG is built with rather than to a declared action.
 func IsSynthesizedAgentStep(name string) bool {
-	return IsAgentStepName(name) || name == AskUserStepName
+	return name == AgentStepName || name == AskUserStepName
 }
 
 // AgentStep returns the synthesized agent step, or nil when the DAG is
@@ -85,7 +87,7 @@ func (d *DAG) AgentStep() *Step {
 		return nil
 	}
 	for i, step := range d.Steps {
-		if IsAgentStepName(step.Name) {
+		if step.Name == AgentStepName {
 			return &d.Steps[i]
 		}
 	}

--- a/internal/ir/agent.go
+++ b/internal/ir/agent.go
@@ -8,6 +8,11 @@ const (
 	// an agent DAG. It cannot be used as a step name or ID.
 	AgentStepName = "__agent__"
 
+	// LegacyAgentStepName is the name the synthesized agent step carried while
+	// agent DAGs were called controller DAGs. Run status files written then
+	// still name the step this way, so reading them keeps recognizing it.
+	LegacyAgentStepName = "__controller__"
+
 	// AskUserStepName is the reserved name and ID of the synthesized human task
 	// an agent opens when it needs to ask a question no declared step
 	// covers. It cannot be used as a step name or ID.
@@ -61,10 +66,16 @@ func (d *DAG) IsAgent() bool {
 	return d != nil && d.Type == TypeAgent
 }
 
+// IsAgentStepName reports whether a step name identifies the synthesized step
+// that drives an agent DAG, in either the current or the legacy spelling.
+func IsAgentStepName(name string) bool {
+	return name == AgentStepName || name == LegacyAgentStepName
+}
+
 // IsSynthesizedAgentStep reports whether a step name belongs to the
 // scaffolding an agent DAG is built with rather than to a declared action.
 func IsSynthesizedAgentStep(name string) bool {
-	return name == AgentStepName || name == AskUserStepName
+	return IsAgentStepName(name) || name == AskUserStepName
 }
 
 // AgentStep returns the synthesized agent step, or nil when the DAG is
@@ -74,7 +85,7 @@ func (d *DAG) AgentStep() *Step {
 		return nil
 	}
 	for i, step := range d.Steps {
-		if step.Name == AgentStepName {
+		if IsAgentStepName(step.Name) {
 			return &d.Steps[i]
 		}
 	}

--- a/internal/ir/run_node.go
+++ b/internal/ir/run_node.go
@@ -177,7 +177,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 		Step struct {
 			Preconditions []ConditionResult `json:"preconditions"`
 		} `json:"step"`
-		LegacyAgentState json.RawMessage `json:"controllerState,omitempty"`
+		LegacyAgentState json.RawMessage `json:"controllerState"`
 	}
 	if err := json.Unmarshal(data, &runtimeState); err != nil {
 		return err

--- a/internal/ir/run_node.go
+++ b/internal/ir/run_node.go
@@ -4,6 +4,7 @@
 package ir
 
 import (
+	"bytes"
 	"encoding/json"
 	"slices"
 
@@ -155,6 +156,19 @@ type Node struct {
 
 type nodeJSON Node
 
+// presentRawJSON returns the first candidate that carries a value, or nil when
+// none does. A literal JSON null counts as absent, so a field written as null
+// neither masks a later candidate nor reaches callers that test for emptiness.
+func presentRawJSON(candidates ...json.RawMessage) json.RawMessage {
+	for _, raw := range candidates {
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) {
+			return raw
+		}
+	}
+	return nil
+}
+
 // MarshalJSON keeps runtime condition results inside the persisted step object.
 func (n Node) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
@@ -183,9 +197,7 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*n = Node(decoded)
-	if len(n.AgentState) == 0 {
-		n.AgentState = runtimeState.LegacyAgentState
-	}
+	n.AgentState = presentRawJSON(n.AgentState, runtimeState.LegacyAgentState)
 	n.PreconditionResults = slices.Clone(runtimeState.Step.Preconditions)
 	if n.PreconditionResults != nil {
 		n.Step = newStepSnapshot(n.Step, n.PreconditionResults).definition()

--- a/internal/ir/run_node.go
+++ b/internal/ir/run_node.go
@@ -166,7 +166,8 @@ func (n Node) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// UnmarshalJSON restores the step definition and its runtime condition results.
+// UnmarshalJSON restores the step definition and its runtime condition results,
+// and keeps agent state written under its legacy name readable.
 func (n *Node) UnmarshalJSON(data []byte) error {
 	var decoded nodeJSON
 	if err := json.Unmarshal(data, &decoded); err != nil {
@@ -176,11 +177,15 @@ func (n *Node) UnmarshalJSON(data []byte) error {
 		Step struct {
 			Preconditions []ConditionResult `json:"preconditions"`
 		} `json:"step"`
+		LegacyAgentState json.RawMessage `json:"controllerState,omitempty"`
 	}
 	if err := json.Unmarshal(data, &runtimeState); err != nil {
 		return err
 	}
 	*n = Node(decoded)
+	if len(n.AgentState) == 0 {
+		n.AgentState = runtimeState.LegacyAgentState
+	}
 	n.PreconditionResults = slices.Clone(runtimeState.Step.Preconditions)
 	if n.PreconditionResults != nil {
 		n.Step = newStepSnapshot(n.Step, n.PreconditionResults).definition()

--- a/internal/runtime/agent/progress_agent_dag.go
+++ b/internal/runtime/agent/progress_agent_dag.go
@@ -80,7 +80,7 @@ func (p *AgentDAGProgressDisplay) UpdateNode(node *ir.Node) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if node.Step.Name == ir.AgentStepName {
+	if ir.IsAgentStepName(node.Step.Name) {
 		if len(node.AgentState) == 0 {
 			return
 		}

--- a/internal/runtime/agent/progress_agent_dag.go
+++ b/internal/runtime/agent/progress_agent_dag.go
@@ -80,7 +80,7 @@ func (p *AgentDAGProgressDisplay) UpdateNode(node *ir.Node) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if ir.IsAgentStepName(node.Step.Name) {
+	if node.Step.Name == ir.AgentStepName {
 		if len(node.AgentState) == 0 {
 			return
 		}

--- a/internal/service/frontend/api/v1/transformer.go
+++ b/internal/service/frontend/api/v1/transformer.go
@@ -734,7 +734,7 @@ func declaredAgentTasks(dag *ir.DAG) *[]api.AgentTask {
 // agentTimeline reports the ordered decisions an agent DAG-run made.
 func agentTimeline(nodes []*ir.Node) *[]api.AgentEvent {
 	for _, node := range nodes {
-		if node == nil || node.Step.Name != ir.AgentStepName {
+		if node == nil || !ir.IsAgentStepName(node.Step.Name) {
 			continue
 		}
 		recorded := agentloop.EventsFromState(node.AgentState)
@@ -765,7 +765,7 @@ func agentTimeline(nodes []*ir.Node) *[]api.AgentEvent {
 // of an agent DAG-run.
 func agentTaskProgress(nodes []*ir.Node) *[]api.AgentTask {
 	for _, node := range nodes {
-		if node == nil || node.Step.Name != ir.AgentStepName {
+		if node == nil || !ir.IsAgentStepName(node.Step.Name) {
 			continue
 		}
 		states := agentloop.TasksFromState(node.AgentState)

--- a/internal/service/frontend/api/v1/transformer.go
+++ b/internal/service/frontend/api/v1/transformer.go
@@ -734,7 +734,7 @@ func declaredAgentTasks(dag *ir.DAG) *[]api.AgentTask {
 // agentTimeline reports the ordered decisions an agent DAG-run made.
 func agentTimeline(nodes []*ir.Node) *[]api.AgentEvent {
 	for _, node := range nodes {
-		if node == nil || !ir.IsAgentStepName(node.Step.Name) {
+		if node == nil || !ir.IsPersistedAgentStepName(node.Step.Name) {
 			continue
 		}
 		recorded := agentloop.EventsFromState(node.AgentState)
@@ -765,7 +765,7 @@ func agentTimeline(nodes []*ir.Node) *[]api.AgentEvent {
 // of an agent DAG-run.
 func agentTaskProgress(nodes []*ir.Node) *[]api.AgentTask {
 	for _, node := range nodes {
-		if node == nil || !ir.IsAgentStepName(node.Step.Name) {
+		if node == nil || !ir.IsPersistedAgentStepName(node.Step.Name) {
 			continue
 		}
 		states := agentloop.TasksFromState(node.AgentState)

--- a/internal/service/frontend/api/v1/transformer_test.go
+++ b/internal/service/frontend/api/v1/transformer_test.go
@@ -624,3 +624,29 @@ func TestToDAGRunDetailsReadsLegacyControllerRunState(t *testing.T) {
 	require.Len(t, *details.AgentEvents, 1)
 	assert.Equal(t, "check_vocabulary", *(*details.AgentEvents)[0].Name)
 }
+
+// A node may carry agentState written as an explicit JSON null. That is no more
+// a value than a missing field, so legacy progress recorded alongside it still
+// has to reach the detail view.
+func TestToDAGRunDetailsPrefersLegacyStateOverNullAgentState(t *testing.T) {
+	legacyStatus := `{
+		"name": "cleanup",
+		"dagRunId": "run-1",
+		"nodes": [{
+			"step": {"name": "__controller__"},
+			"agentState": null,
+			"controllerState": {
+				"tasks": [{"name": "vocabulary", "description": "Completed when clean.", "status": "done"}]
+			}
+		}]
+	}`
+
+	status, err := ir.StatusFromJSON(legacyStatus)
+	require.NoError(t, err)
+
+	details := ToDAGRunDetails(*status)
+
+	require.NotNil(t, details.AgentTasks)
+	require.Len(t, *details.AgentTasks, 1)
+	assert.Equal(t, "vocabulary", (*details.AgentTasks)[0].Name)
+}

--- a/internal/service/frontend/api/v1/transformer_test.go
+++ b/internal/service/frontend/api/v1/transformer_test.go
@@ -593,3 +593,34 @@ func TestNodeStatusMappingIsExhaustive(t *testing.T) {
 	assert.Len(t, nodeStatusMapping, len(expected))
 	assert.Equal(t, expected, nodeStatusMapping)
 }
+
+// Agent DAGs were previously called controller DAGs. Run status files written
+// before the rename name the synthesized step __controller__ and store its
+// progress under controllerState; the agent detail view must still populate
+// from them.
+func TestToDAGRunDetailsReadsLegacyControllerRunState(t *testing.T) {
+	legacyStatus := `{
+		"name": "cleanup",
+		"dagRunId": "run-1",
+		"nodes": [{
+			"step": {"name": "__controller__", "executorConfig": {"type": "controller"}},
+			"controllerState": {
+				"tasks": [{"name": "vocabulary", "description": "Completed when clean.", "status": "done"}],
+				"events": [{"turn": 1, "kind": "action", "name": "check_vocabulary", "status": "succeeded"}]
+			}
+		}]
+	}`
+
+	status, err := ir.StatusFromJSON(legacyStatus)
+	require.NoError(t, err)
+
+	details := ToDAGRunDetails(*status)
+
+	require.NotNil(t, details.AgentTasks)
+	require.Len(t, *details.AgentTasks, 1)
+	assert.Equal(t, "vocabulary", (*details.AgentTasks)[0].Name)
+
+	require.NotNil(t, details.AgentEvents)
+	require.Len(t, *details.AgentEvents, 1)
+	assert.Equal(t, "check_vocabulary", *(*details.AgentEvents)[0].Name)
+}

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -510,8 +510,22 @@ func TestServerIPAccessProtectsAllRoutes(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: time.Second}
+
+	// The listener is bound before Serve runs, so a connection is accepted by
+	// the kernel backlog while the serving goroutine may not have reached its
+	// accept loop. Wait for a reply before asserting, so a slow start surfaces
+	// as its own failure instead of a request that never receives headers.
+	baseURL := "http://" + listener.Addr().String()
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(baseURL + "/api/v1/health")
+		if err != nil {
+			return false
+		}
+		return resp.Body.Close() == nil
+	}, 10*time.Second, 20*time.Millisecond, "server never started serving")
+
 	for _, requestPath := range []string{"/api/v1/health", "/extension"} {
-		resp, err := client.Get("http://" + listener.Addr().String() + requestPath)
+		resp, err := client.Get(baseURL + requestPath)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 		require.NoError(t, resp.Body.Close())

--- a/internal/spec/agent_test.go
+++ b/internal/spec/agent_test.go
@@ -402,3 +402,32 @@ func TestReservedAgentNamesAreRejectedInGraphDAGs(t *testing.T) {
 		})
 	}
 }
+
+// type: agent was called type: controller before the rename. Existing DAG files
+// still using the old spelling must keep loading as agent DAGs.
+func TestLegacyControllerTypeLoadsAsAgent(t *testing.T) {
+	t.Parallel()
+
+	const legacy = `
+type: controller
+llm:
+  provider: anthropic
+  model: claude-opus-5
+steps:
+  - name: design
+    run: echo design
+tasks:
+  - name: ship
+    description: done when design ran
+`
+
+	dag, err := spec.LoadYAML(t.Context(), []byte(legacy))
+	require.NoError(t, err)
+
+	assert.Equal(t, ir.TypeAgent, dag.Type)
+	require.True(t, dag.IsAgent())
+	require.NotNil(t, dag.AgentStep(), "an agent DAG carries a synthesized agent step")
+
+	warnings := spec.DeprecatedSyntaxWarnings([]byte(legacy))
+	assert.Contains(t, warnings, "Deprecated DAG syntax: type: controller is deprecated; use type: agent")
+}

--- a/internal/spec/dag.go
+++ b/internal/spec/dag.go
@@ -950,7 +950,7 @@ func applyHistoryRetentionOverride(effective *ir.DAG, authoredDays, authoredRuns
 // Builder functions - each returns a value instead of modifying result
 
 func buildType(_ buildContext, d *dag) (string, error) {
-	t := strings.TrimSpace(d.Type)
+	t := canonicalDAGType(d.Type)
 	if t == "" {
 		return ir.TypeGraph, nil
 	}
@@ -960,6 +960,18 @@ func buildType(_ buildContext, d *dag) (string, error) {
 	default:
 		return "", ir.NewValidationError("type", t, fmt.Errorf("invalid type: %s (must be one of: graph, chain, agent, build)", t))
 	}
+}
+
+// legacyAgentDAGType is what agent DAGs were called before the rename.
+const legacyAgentDAGType = "controller"
+
+// canonicalDAGType trims an authored type and resolves its legacy spelling.
+func canonicalDAGType(authored string) string {
+	t := strings.TrimSpace(authored)
+	if t == legacyAgentDAGType {
+		return ir.TypeAgent
+	}
+	return t
 }
 
 // Builder functions - all return values instead of modifying result
@@ -2537,7 +2549,7 @@ func buildLLM(_ buildContext, d *dag) (*ir.LLMConfig, error) {
 				fmt.Errorf("max_tokens must be at least 1"))
 		}
 	}
-	if err := validateAgentLLMLimits(cfg, strings.TrimSpace(d.Type) == ir.TypeAgent); err != nil {
+	if err := validateAgentLLMLimits(cfg, canonicalDAGType(d.Type) == ir.TypeAgent); err != nil {
 		return nil, err
 	}
 

--- a/internal/spec/deprecation.go
+++ b/internal/spec/deprecation.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 )
@@ -67,6 +68,9 @@ func deprecatedSyntaxWarningsForDocument(prefix string, doc map[string]any) []st
 	var warnings []string
 	if _, ok := doc["step_types"]; ok {
 		warnings = append(warnings, fmt.Sprintf("Deprecated DAG syntax: %sstep_types is deprecated; use actions", prefix))
+	}
+	if t, ok := doc["type"].(string); ok && strings.TrimSpace(t) == legacyAgentDAGType {
+		warnings = append(warnings, fmt.Sprintf("Deprecated DAG syntax: %stype: controller is deprecated; use type: agent", prefix))
 	}
 	warnings = append(warnings, deprecatedSyntaxWarningsForSteps(prefix+"steps", doc["steps"])...)
 	if handlerRaw, ok := doc["handler_on"].(map[string]any); ok {

--- a/specs/002-yaml-schema.md
+++ b/specs/002-yaml-schema.md
@@ -55,10 +55,12 @@ Output:
 
 | Condition | Exit code | Stdout | Stderr |
 | --- | --- | --- | --- |
-| Success | `0` | Empty. | Empty. |
+| Success | `0` | Empty. | Empty, or deprecation warnings. |
 | Failure | Non-zero | Empty. | Validation error. |
 
-Validation failures must not print command usage text.
+Validation failures must not print command usage text. A successful validation
+writes nothing to stderr beyond one deprecation warning for each deprecated
+construct the file uses, and each warning must name the replacement.
 
 ## Documents
 

--- a/specs/002-yaml-schema.md
+++ b/specs/002-yaml-schema.md
@@ -93,7 +93,7 @@ Accepted root fields:
 | `consts` | No | Immutable literal values. |
 | `defaults` | No | Default step settings. |
 | `steps` | Yes | Executable steps. |
-| `type` | No | Step scheduling mode: `graph`, `chain`, or `agent`. |
+| `type` | No | Step scheduling mode: `graph`, `chain`, or `agent`. `controller` is a deprecated alias for `agent`. |
 | `tasks` | Only with `type: agent` | Goals an Agent DAG run must satisfy. |
 | `handler_on` | No | Lifecycle handler steps. |
 | `preconditions` | No | Workflow start conditions. |

--- a/specs/032-agent-dag.md
+++ b/specs/032-agent-dag.md
@@ -72,8 +72,9 @@ tasks:
 ### Root fields
 
 Agent DAGs were previously called controller DAGs. `type: controller` remains
-accepted as a deprecated alias for `type: agent`, and loading a DAG that uses it
-reports a deprecation warning naming the replacement.
+accepted as a deprecated alias: it is canonicalized to `agent` before validation,
+so every rule stated for `type: agent` applies to it unchanged. Loading a DAG
+that uses it reports a deprecation warning naming the replacement.
 
 `tasks` is an array of objects with `name` and `description`. It is valid only
 when `type` is `agent`, and `type: agent` requires it.

--- a/specs/032-agent-dag.md
+++ b/specs/032-agent-dag.md
@@ -71,6 +71,10 @@ tasks:
 
 ### Root fields
 
+Agent DAGs were previously called controller DAGs. `type: controller` remains
+accepted as a deprecated alias for `type: agent`, and loading a DAG that uses it
+reports a deprecation warning naming the replacement.
+
 `tasks` is an array of objects with `name` and `description`. It is valid only
 when `type` is `agent`, and `type: agent` requires it.
 

--- a/ui/src/features/dags/components/DAGStatus.tsx
+++ b/ui/src/features/dags/components/DAGStatus.tsx
@@ -466,9 +466,12 @@ function DAGStatus({
   // Check if timeline should be shown (any status except not started)
   const showTimeline = displayDAGRun.status !== Status.NotStarted;
 
-  // Chat and agent steps both persist an LLM transcript.
+  // Chat and agent steps both persist an LLM transcript. Runs recorded before
+  // agent DAGs were renamed still carry the 'controller' executor type.
   const hasChatSteps = !!displayDAGRun.nodes?.some((node) =>
-    ['chat', 'agent'].includes(node.step.executorConfig?.type ?? '')
+    ['chat', 'agent', 'controller'].includes(
+      node.step.executorConfig?.type ?? ''
+    )
   );
   const agentNodes = (displayDAGRun.nodes || []).filter(
     (node) => !!node.agentSession

--- a/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
+++ b/ui/src/features/dags/components/__tests__/DAGStatus.test.tsx
@@ -765,4 +765,26 @@ describe('DAGStatus', () => {
       expect(await screen.findByLabelText('Human task draft')).toHaveValue('');
     }
   );
+
+  // Agent steps recorded before the rename carry the 'controller' executor
+  // type, and their LLM transcript still belongs on the Chat tab.
+  it('offers the chat transcript for a legacy controller step', () => {
+    const legacyRun = {
+      ...dagRun,
+      nodes: [
+        {
+          step: {
+            name: '__controller__',
+            executorConfig: { type: 'controller' },
+          },
+          status: NodeStatus.Success,
+          statusLabel: NodeStatusLabel.succeeded,
+        },
+      ],
+    } as unknown as components['schemas']['DAGRunDetails'];
+
+    render(dagStatusView(legacyRun));
+
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Problem

Renaming controller DAGs to agent DAGs (#2567) changed three on-disk names at once, with nothing translating the old spellings:

| Concept | Before | After |
|---|---|---|
| Authored DAG type | `type: controller` | `type: agent` |
| Synthesized step name | `__controller__` | `__agent__` |
| Persisted node field | `controllerState` | `agentState` |

Two things broke as a result.

**Authored DAGs stopped loading.** Any file still saying `type: controller` fails validation outright:

```
field 'type': invalid type: controller (must be one of: graph, chain, agent, build)
```

**Run history lost its agent view.** Runs recorded before the rename still carry a `__controller__` step holding `controllerState`. `agentTimeline` and `agentTaskProgress` match only `__agent__`, and `Node` decodes only `agentState`, so `agentTasks` and `agentEvents` came back `null`. With both empty, `isAgentRun` is false in `DAGStatus.tsx` and the page falls through to the ordinary dependency-graph layout instead of the agent decision timeline and task checklist. The old `controller` executor type also dropped the Chat tab.

## Fix

Compatibility handling at the seams that already own it, mirroring the existing legacy `onCancel`/`tags` handling in `DAGRunStatus.UnmarshalJSON`:

- `internal/spec/dag.go` resolves the legacy type to `agent` when building a DAG.
- `internal/ir/agent.go` adds `LegacyAgentStepName` and an `IsAgentStepName` helper, now used everywhere `__agent__` was matched literally (API transformer, runtime progress display).
- `internal/ir/run_node.go` reads `controllerState` as agent state in `Node.UnmarshalJSON`.
- `ui/.../DAGStatus.tsx` accepts the legacy `controller` executor type so old runs keep their Chat tab.

Loading a DAG that still says `type: controller` now warns rather than failing:

```
Deprecated DAG syntax: type: controller is deprecated; use type: agent
```

`internal/cmn/schema/dag.schema.json` deliberately keeps its `type` enum unchanged. That schema is only served to the YAML editor and is never enforced at load, so leaving `controller` out keeps the editor pointing at `agent` while existing files still run.

## Verification

Reproduced against real pre-rename run data served from a scratch data directory on a separate port.

Before: `agentTasks: null`, `agentEvents: null`, tabs `Status / Timeline / Outputs / Spec`, dependency graph rendered.
After: both populated, `Tasks` tab restored, decision timeline rendered in place of the graph, and a `type: controller` file validates with exit 0 plus the deprecation warning.

## Tests

Two regression tests, one per seam:

- `TestToDAGRunDetailsReadsLegacyControllerRunState` decodes a full pre-rename status document through `ir.StatusFromJSON` into `ToDAGRunDetails`, covering both the node decode and the step-name match. Confirmed it fails without the fix.
- `TestLegacyControllerTypeLoadsAsAgent` covers the type alias and its deprecation warning.

`ir`, `spec`, `runtime`, and the frontend API package pass; `make lint` reports 0 issues including the `GOOS=windows` pass; UI typecheck and Prettier are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps controller-era agent DAGs and runs readable by translating legacy names and treating a null agent state as absent. Previously, `type: controller` DAGs failed validation and old runs hid agent tasks/events; now they load as agent DAGs with a deprecation warning, and the agent timeline, Tasks, and Chat tabs are restored.

- Canonicalize `type: controller` to `agent` during DAG build and emit a deprecation warning; the served JSON schema remains unchanged.
- Read legacy run history by preferring `agentState` when present, falling back to `controllerState` if missing or null; match both `__agent__` and `__controller__` only when reading persisted runs.
- UI accepts legacy `executorConfig.type: controller` so old runs keep their Chat tab.
- Docs: specify `controller` as a deprecated alias for `agent`; allow deprecation warnings on successful `validate`.
- Tests: add conformance and unit coverage for legacy state and Chat tab; stabilize the server IP-access test by waiting for server startup before assertions.

**Migration**
- No action required. To silence warnings, change DAGs from `type: controller` to `type: agent`.

<sup>Written for commit 8d4ddebc9d4d268777d369d7fa20086f03814e78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved compatibility with legacy `controller` DAG configurations and persisted run states.
  * Correctly restores legacy controller state and displays associated agent tasks, events, and Chat tabs.
  * Normalized legacy configurations for agent-specific validation and processing.

* **Documentation**
  * Documented `controller` as a deprecated alias for `agent`, including the recommended replacement.

* **Tests**
  * Added regression and conformance coverage for legacy controller configurations and run-state data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->