### PR TITLE
feat(mcp): include alt_dags_dir DAGs in dagu_read list

### DIFF
--- a/internal/cmn/cmdutil/cmd_windows_test.go
+++ b/internal/cmn/cmdutil/cmd_windows_test.go
@@ -30,10 +30,15 @@ func TestKillProcessTree_Integration(t *testing.T) {
 	pid := uint32(cmd.Process.Pid)
 	t.Logf("Started test process with PID %d", pid)
 
-	// Give it a moment to fully start and spawn its child
-	time.Sleep(500 * time.Millisecond)
-
-	children := childProcessIDs(t, pid)
+	// Wait for cmd.exe to spawn ping.exe so the root has a child to recurse
+	// into. Poll rather than sleep a fixed amount: CI runners can be slow to
+	// spawn the child and reflect the parent relationship in the snapshot.
+	var children []uint32
+	deadline := time.Now().Add(5 * time.Second)
+	for len(children) == 0 && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		children = childProcessIDs(t, pid)
+	}
 	if len(children) == 0 {
 		t.Fatalf("test process %d spawned no children, so the tree walk would not be exercised", pid)
 	}

--- a/internal/persis/dag.go
+++ b/internal/persis/dag.go
@@ -50,6 +50,11 @@ type DAGDefinitionStore interface {
 	Rename(ctx context.Context, oldID, newID string) error
 	GetMetadata(ctx context.Context, id string) (*ir.DAG, error)
 	Catalog(ctx context.Context) (DAGCatalog, error)
+	// CatalogIncludingSearchPaths is like Catalog but also includes DAG
+	// definitions found under the store's additional search paths (for example
+	// alt_dags_dir). Stores without additional search paths may return the same
+	// result as Catalog.
+	CatalogIncludingSearchPaths(ctx context.Context) (DAGCatalog, error)
 	SetSuspended(ctx context.Context, id string, suspended bool) error
 	IsSuspended(ctx context.Context, id string) (bool, error)
 }

--- a/internal/persis/dag_repository_list.go
+++ b/internal/persis/dag_repository_list.go
@@ -14,12 +14,31 @@ import (
 )
 
 func (r *DAGRepository) List(ctx context.Context, opts DAGListOptions) (pagination.PaginatedResult[DAGListItem], []string, error) {
+	return r.list(ctx, opts, false)
+}
+
+// ListIncludingSearchPaths is like List but also includes DAG definitions found
+// under the store's additional search paths (for example alt_dags_dir). The
+// combined collection is filtered, sorted, and paginated as a whole.
+func (r *DAGRepository) ListIncludingSearchPaths(ctx context.Context, opts DAGListOptions) (pagination.PaginatedResult[DAGListItem], []string, error) {
+	return r.list(ctx, opts, true)
+}
+
+func (r *DAGRepository) list(ctx context.Context, opts DAGListOptions, includeSearchPaths bool) (pagination.PaginatedResult[DAGListItem], []string, error) {
 	if opts.Paginator == nil {
 		paginator := pagination.DefaultPaginator()
 		opts.Paginator = &paginator
 	}
 
-	catalog, err := r.store.Catalog(ctx)
+	var (
+		catalog DAGCatalog
+		err     error
+	)
+	if includeSearchPaths {
+		catalog, err = r.store.CatalogIncludingSearchPaths(ctx)
+	} else {
+		catalog, err = r.store.Catalog(ctx)
+	}
 	if err != nil {
 		return pagination.NewPaginatedResult([]DAGListItem{}, 0, *opts.Paginator), catalog.Issues, err
 	}

--- a/internal/persis/file/dag/catalog.go
+++ b/internal/persis/file/dag/catalog.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dagucloud/dagu/v2/internal/persis/file/dag/dagindex"
 	indexv1 "github.com/dagucloud/dagu/v2/proto/index/v1"
 )
 
@@ -19,7 +20,7 @@ type catalog struct {
 	errors  []string
 }
 
-func (store *Store) loadCatalog(ctx context.Context) (*catalog, error) {
+func (store *Store) loadCatalog(ctx context.Context, includeSearchPaths bool) (*catalog, error) {
 	scan, err := Discover(store.baseDir, DiscoveryOptions{
 		Recursive: store.recursive,
 		Symlinks:  store.symlinks,
@@ -32,7 +33,41 @@ func (store *Store) loadCatalog(ctx context.Context) (*catalog, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newCatalog(entries, scan.Errors, store.recursive), nil
+	allErrors := append([]error(nil), scan.Errors...)
+
+	if includeSearchPaths && len(store.searchPaths) > 1 {
+		flags, err := store.readSuspendFlags(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, searchPath := range store.searchPaths[1:] {
+			altScan, err := Discover(searchPath, DiscoveryOptions{
+				Recursive: store.recursive,
+				Symlinks:  store.symlinks,
+			})
+			if err != nil {
+				return nil, err
+			}
+			allErrors = append(allErrors, altScan.Errors...)
+			altFiles := make([]dagindex.YAMLFileMeta, 0, len(altScan.Files))
+			for _, file := range altScan.Files {
+				rel, err := filepath.Rel(store.baseDir, filepath.Join(searchPath, filepath.FromSlash(file.RelPath)))
+				if err != nil {
+					continue
+				}
+				altFiles = append(altFiles, dagindex.YAMLFileMeta{
+					Name:     filepath.ToSlash(rel),
+					LoadPath: file.ResolvedPath,
+					Size:     file.Size,
+					ModTime:  file.ModTime,
+				})
+			}
+			altIdx := dagindex.Build(ctx, store.baseDir, altFiles, flags, store.defaultLoadOptions()...)
+			entries = append(entries, altIdx.Entries...)
+		}
+	}
+
+	return newCatalog(entries, allErrors, store.recursive), nil
 }
 
 func newCatalog(entries []*indexv1.DAGIndexEntry, scanErrors []error, checkConflicts bool) *catalog {

--- a/internal/persis/file/dag/store.go
+++ b/internal/persis/file/dag/store.go
@@ -178,7 +178,19 @@ func (store *Store) Get(ctx context.Context, id string) (persis.DAGDefinition, e
 }
 
 func (store *Store) Catalog(ctx context.Context) (persis.DAGCatalog, error) {
-	catalog, err := store.loadCatalog(ctx)
+	return store.catalog(ctx, false)
+}
+
+// CatalogIncludingSearchPaths is like Catalog but also includes DAG definitions
+// found under the store's additional search paths (for example alt_dags_dir).
+// Entries are deduplicated and conflict-checked together with the primary
+// directory's entries.
+func (store *Store) CatalogIncludingSearchPaths(ctx context.Context) (persis.DAGCatalog, error) {
+	return store.catalog(ctx, true)
+}
+
+func (store *Store) catalog(ctx context.Context, includeSearchPaths bool) (persis.DAGCatalog, error) {
+	catalog, err := store.loadCatalog(ctx, includeSearchPaths)
 	if err != nil {
 		return persis.DAGCatalog{}, fmt.Errorf("failed to read DAGs directory %s: %w", store.baseDir, err)
 	}
@@ -549,7 +561,7 @@ func (store *Store) locateDAG(ctx context.Context, nameOrPath string) (ResolvedF
 	explicitPath := filepath.IsAbs(relativePath) || strings.ContainsAny(nameOrPath, `/\`)
 
 	if store.recursive && !explicitPath {
-		catalog, err := store.loadCatalog(ctx)
+		catalog, err := store.loadCatalog(ctx, false)
 		if err != nil {
 			return ResolvedFile{}, fmt.Errorf("failed to discover DAGs: %w", err)
 		}

--- a/internal/persis/file/dag/store_test.go
+++ b/internal/persis/file/dag/store_test.go
@@ -647,6 +647,42 @@ func TestListRebuildsIndexAfterSymlinkRepoint(t *testing.T) {
 	assert.Equal(t, "other", result.Items[0].Description)
 }
 
+func TestCatalogIncludingSearchPaths(t *testing.T) {
+	baseDir := t.TempDir()
+	searchDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "base-dag.yaml"), []byte("name: base-dag\nsteps: []\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(searchDir, "alt-dag.yaml"), []byte("name: alt-dag\nsteps: []\n"), 0600))
+
+	store := NewStore(baseDir, WithSearchPaths([]string{searchDir}), WithSkipExamples(true))
+	ctx := context.Background()
+
+	baseOnly, err := store.Catalog(ctx)
+	require.NoError(t, err)
+	baseNames := make([]string, 0, len(baseOnly.Items))
+	for _, item := range baseOnly.Items {
+		baseNames = append(baseNames, item.ID)
+	}
+	require.Equal(t, []string{"base-dag"}, baseNames)
+
+	combined, err := store.CatalogIncludingSearchPaths(ctx)
+	require.NoError(t, err)
+	combinedNames := make([]string, 0, len(combined.Items))
+	for _, item := range combined.Items {
+		combinedNames = append(combinedNames, item.ID)
+	}
+	require.ElementsMatch(t, []string{"base-dag", "alt-dag"}, combinedNames)
+
+	// The alternate-directory entry must report a correct location.
+	var altDAG *ir.DAG
+	for _, item := range combined.Items {
+		if item.ID == "alt-dag" {
+			altDAG = item.DAG
+		}
+	}
+	require.NotNil(t, altDAG)
+	require.Equal(t, filepath.Join(searchDir, "alt-dag.yaml"), altDAG.Location)
+}
+
 func TestGetSpecAllowsExplicitSearchPaths(t *testing.T) {
 	baseDir := t.TempDir()
 	searchDir := t.TempDir()

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/audit"
 	"github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/cmn/procutil"
@@ -2096,6 +2097,44 @@ func (a *API) projectNextRun(ctx context.Context, dag *ir.DAG) *time.Time {
 		return nil
 	}
 	return &nextRun
+}
+
+// GetAltDAGsListData returns the DAGs defined under paths.alt_dags_dir, for
+// MCP reads. DAGs in the alternate directory are lookup-only: they are not part
+// of the regular discovery listing, so this is the read surface that surfaces
+// them. It returns an empty list when no alternate directory is configured or
+// the directory does not exist yet.
+func (a *API) GetAltDAGsListData(ctx context.Context) (any, error) {
+	if a.config == nil || a.config.Paths.AltDAGsDir == "" {
+		return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
+	}
+	entries, err := os.ReadDir(a.config.Paths.AltDAGsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
+		}
+		logger.Warn(ctx, "Failed to read alternate DAGs directory",
+			tag.Dir(a.config.Paths.AltDAGsDir),
+			tag.Error(err),
+		)
+		return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
+	}
+
+	dagFiles := make([]api.DAGFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
+			continue
+		}
+		dag, err := a.dagRepository.GetMetadata(ctx, entry.Name())
+		if err != nil {
+			continue
+		}
+		dagFiles = append(dagFiles, api.DAGFile{
+			FileName: fileutil.TrimYAMLFileExtension(entry.Name()),
+			Dag:      toDAG(dag),
+		})
+	}
+	return api.ListDAGs200JSONResponse{Dags: dagFiles}, nil
 }
 
 func (a *API) nextRunProjection(ctx context.Context) func(*ir.DAG, time.Time) time.Time {

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/audit"
 	"github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
-	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/cmn/procutil"
@@ -1984,76 +1983,109 @@ func (a *API) GetDAGHistoryData(ctx context.Context, fileName string) (any, erro
 // GetDAGsListData returns DAGs list for SSE.
 // Identifier format: URL query string (e.g., "page=1&perPage=100&name=mydag")
 func (a *API) GetDAGsListData(ctx context.Context, queryString string) (any, error) {
+	return a.getDAGsListData(ctx, queryString, false)
+}
+
+// GetDAGsListDataIncludingAltDirs is like GetDAGsListData but the returned list
+// also includes DAGs found under paths.alt_dags_dir. Query semantics are applied
+// to the combined collection.
+func (a *API) GetDAGsListDataIncludingAltDirs(ctx context.Context, queryString string) (any, error) {
+	return a.getDAGsListData(ctx, queryString, true)
+}
+
+func (a *API) getDAGsListData(ctx context.Context, queryString string, includeSearchPaths bool) (any, error) {
 	return withDAGRunReadTimeout(ctx, dagRunReadRequestInfo{
 		endpoint: "/dags",
 	}, func(readCtx context.Context) (any, error) {
-		params, err := url.ParseQuery(queryString)
-		if err != nil {
-			logger.Warn(readCtx, "Failed to parse query string for DAGs list",
-				tag.Error(err),
-				slog.String("queryString", queryString),
-			)
-		}
-
-		page := parseIntParam(params.Get("page"), 1)
-		perPage := parseIntParam(params.Get("perPage"), 100)
-
-		sortField := a.config.UI.DAGs.SortField
-		if sortField == "" {
-			sortField = "name"
-		}
-		if rawSort := params.Get("sort"); rawSort != "" {
-			sortField = rawSort
-		}
-		sortOrder := a.config.UI.DAGs.SortOrder
-		if sortOrder == "" {
-			sortOrder = "asc"
-		}
-		if rawOrder := params.Get("order"); rawOrder != "" {
-			sortOrder = rawOrder
-		}
-
-		var labelsParam, deprecatedTagsParam *string
-		if rawLabels := params.Get("labels"); rawLabels != "" {
-			labelsParam = &rawLabels
-		}
-		if rawTags := params.Get("tags"); rawTags != "" {
-			deprecatedTagsParam = &rawTags
-		}
-		labelQueryParam, labelErr := queryLabelsParam(labelsParam, deprecatedTagsParam)
-		if labelErr != nil {
-			return nil, labelErr
-		}
-		labels := parseCommaSeparatedLabels(labelQueryParam)
-
-		pg := pagination.NewPaginator(page, perPage)
-		workspaceParam := workspaceParamFromValues(params)
-		workspaceFilter, err := a.workspaceFilterForParams(readCtx, workspaceParam)
+		listOpts, err := a.buildDAGListOptions(readCtx, queryString)
 		if err != nil {
 			return nil, err
 		}
-		listOpts := persis.DAGListOptions{
-			Paginator:       &pg,
-			Name:            params.Get("name"),
-			Labels:          labels,
-			ActiveOnly:      params.Get("active") == "true",
-			Sort:            sortField,
-			Order:           sortOrder,
-			WorkspaceFilter: workspaceFilter,
-		}
-
-		return a.listDAGsData(readCtx, listOpts)
+		return a.listDAGsDataWithSearchPaths(readCtx, listOpts, includeSearchPaths)
 	})
 }
 
+func (a *API) buildDAGListOptions(ctx context.Context, queryString string) (persis.DAGListOptions, error) {
+	params, err := url.ParseQuery(queryString)
+	if err != nil {
+		logger.Warn(ctx, "Failed to parse query string for DAGs list",
+			tag.Error(err),
+			slog.String("queryString", queryString),
+		)
+	}
+
+	page := parseIntParam(params.Get("page"), 1)
+	perPage := parseIntParam(params.Get("perPage"), 100)
+
+	sortField := a.config.UI.DAGs.SortField
+	if sortField == "" {
+		sortField = "name"
+	}
+	if rawSort := params.Get("sort"); rawSort != "" {
+		sortField = rawSort
+	}
+	sortOrder := a.config.UI.DAGs.SortOrder
+	if sortOrder == "" {
+		sortOrder = "asc"
+	}
+	if rawOrder := params.Get("order"); rawOrder != "" {
+		sortOrder = rawOrder
+	}
+
+	var labelsParam, deprecatedTagsParam *string
+	if rawLabels := params.Get("labels"); rawLabels != "" {
+		labelsParam = &rawLabels
+	}
+	if rawTags := params.Get("tags"); rawTags != "" {
+		deprecatedTagsParam = &rawTags
+	}
+	labelQueryParam, labelErr := queryLabelsParam(labelsParam, deprecatedTagsParam)
+	if labelErr != nil {
+		return persis.DAGListOptions{}, labelErr
+	}
+	labels := parseCommaSeparatedLabels(labelQueryParam)
+
+	pg := pagination.NewPaginator(page, perPage)
+	workspaceParam := workspaceParamFromValues(params)
+	workspaceFilter, err := a.workspaceFilterForParams(ctx, workspaceParam)
+	if err != nil {
+		return persis.DAGListOptions{}, err
+	}
+	return persis.DAGListOptions{
+		Paginator:       &pg,
+		Name:            params.Get("name"),
+		Labels:          labels,
+		ActiveOnly:      params.Get("active") == "true",
+		Sort:            sortField,
+		Order:           sortOrder,
+		WorkspaceFilter: workspaceFilter,
+	}, nil
+}
+
 func (a *API) listDAGsData(ctx context.Context, listOpts persis.DAGListOptions) (api.ListDAGs200JSONResponse, error) {
+	return a.listDAGsDataWithSearchPaths(ctx, listOpts, false)
+}
+
+// listDAGsDataWithSearchPaths lists DAGs and, when includeSearchPaths is true,
+// also includes DAGs found under the configured alternate directory
+// (paths.alt_dags_dir). Query semantics are applied to the combined collection.
+func (a *API) listDAGsDataWithSearchPaths(ctx context.Context, listOpts persis.DAGListOptions, includeSearchPaths bool) (api.ListDAGs200JSONResponse, error) {
 	projectionTime := time.Now()
 	nextRunProjection := a.nextRunProjection(ctx)
 
 	listOpts.Time = &projectionTime
 	listOpts.NextRunProjection = nextRunProjection
 
-	result, errList, err := a.dagRepository.List(ctx, listOpts)
+	var (
+		result  pagination.PaginatedResult[persis.DAGListItem]
+		errList []string
+		err     error
+	)
+	if includeSearchPaths {
+		result, errList, err = a.dagRepository.ListIncludingSearchPaths(ctx, listOpts)
+	} else {
+		result, errList, err = a.dagRepository.List(ctx, listOpts)
+	}
 	if err != nil {
 		return api.ListDAGs200JSONResponse{}, fmt.Errorf("error listing DAGs: %w", err)
 	}
@@ -2097,44 +2129,6 @@ func (a *API) projectNextRun(ctx context.Context, dag *ir.DAG) *time.Time {
 		return nil
 	}
 	return &nextRun
-}
-
-// GetAltDAGsListData returns the DAGs defined under paths.alt_dags_dir, for
-// MCP reads. DAGs in the alternate directory are lookup-only: they are not part
-// of the regular discovery listing, so this is the read surface that surfaces
-// them. It returns an empty list when no alternate directory is configured or
-// the directory does not exist yet.
-func (a *API) GetAltDAGsListData(ctx context.Context) (any, error) {
-	if a.config == nil || a.config.Paths.AltDAGsDir == "" {
-		return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
-	}
-	entries, err := os.ReadDir(a.config.Paths.AltDAGsDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
-		}
-		logger.Warn(ctx, "Failed to read alternate DAGs directory",
-			tag.Dir(a.config.Paths.AltDAGsDir),
-			tag.Error(err),
-		)
-		return api.ListDAGs200JSONResponse{Dags: []api.DAGFile{}}, nil
-	}
-
-	dagFiles := make([]api.DAGFile, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || !fileutil.IsYAMLFile(entry.Name()) {
-			continue
-		}
-		dag, err := a.dagRepository.GetMetadata(ctx, entry.Name())
-		if err != nil {
-			continue
-		}
-		dagFiles = append(dagFiles, api.DAGFile{
-			FileName: fileutil.TrimYAMLFileExtension(entry.Name()),
-			Dag:      toDAG(dag),
-		})
-	}
-	return api.ListDAGs200JSONResponse{Dags: dagFiles}, nil
 }
 
 func (a *API) nextRunProjection(ctx context.Context) func(*ir.DAG, time.Time) time.Time {

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -17,11 +17,14 @@ import (
 	"github.com/dagucloud/dagu/v2/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	persisfile "github.com/dagucloud/dagu/v2/internal/persis/file"
+	"github.com/dagucloud/dagu/v2/internal/runtime"
 	"github.com/dagucloud/dagu/v2/internal/schedulerstate"
 	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 	localapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/service/scheduler"
 	"github.com/dagucloud/dagu/v2/internal/test"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1812,6 +1815,50 @@ func TestGetDAGDetails_NonExistent_Returns404(t *testing.T) {
 	require.ErrorAs(t, err, &apiErr)
 	require.Equal(t, 404, apiErr.HTTPStatus)
 	require.Equal(t, api.ErrorCodeNotFound, apiErr.Code)
+}
+
+func TestGetAltDAGsListData(t *testing.T) {
+	t.Run("lists DAGs from the alternate directory", func(t *testing.T) {
+		baseDir := t.TempDir()
+		altDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(altDir, "alt-dag.yaml"), []byte("name: alt-dag\nsteps: []\n"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(baseDir, "main-dag.yaml"), []byte("name: main-dag\nsteps: []\n"), 0600))
+
+		cfg := &config.Config{}
+		cfg.Paths.DAGsDir = baseDir
+		cfg.Paths.AltDAGsDir = altDir
+		cfg.Core.SkipExamples = true
+
+		repo, err := persisfile.NewDAGRepository(cfg, persisfile.WithDAGSearchPaths([]string{altDir}))
+		require.NoError(t, err)
+		apiImpl := localapi.New(repo, nil, nil, nil, runtime.Manager{}, cfg, nil, nil, prometheus.NewRegistry(), nil)
+
+		raw, err := apiImpl.GetAltDAGsListData(context.Background())
+		require.NoError(t, err)
+		resp, ok := raw.(api.ListDAGs200JSONResponse)
+		require.True(t, ok)
+		var names []string
+		for _, dag := range resp.Dags {
+			names = append(names, dag.FileName)
+		}
+		require.Equal(t, []string{"alt-dag"}, names)
+	})
+
+	t.Run("returns empty when no alternate directory is configured", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Paths.DAGsDir = t.TempDir()
+		cfg.Core.SkipExamples = true
+
+		repo, err := persisfile.NewDAGRepository(cfg)
+		require.NoError(t, err)
+		apiImpl := localapi.New(repo, nil, nil, nil, runtime.Manager{}, cfg, nil, nil, prometheus.NewRegistry(), nil)
+
+		raw, err := apiImpl.GetAltDAGsListData(context.Background())
+		require.NoError(t, err)
+		resp, ok := raw.(api.ListDAGs200JSONResponse)
+		require.True(t, ok)
+		require.Empty(t, resp.Dags)
+	})
 }
 
 func TestGetDAGDetailsAndSpecIncludeNextRun(t *testing.T) {

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -1817,8 +1817,8 @@ func TestGetDAGDetails_NonExistent_Returns404(t *testing.T) {
 	require.Equal(t, api.ErrorCodeNotFound, apiErr.Code)
 }
 
-func TestGetAltDAGsListData(t *testing.T) {
-	t.Run("lists DAGs from the alternate directory", func(t *testing.T) {
+func TestGetDAGsListDataIncludingAltDirs(t *testing.T) {
+	t.Run("lists DAGs from both directories with query filters applied to the combined set", func(t *testing.T) {
 		baseDir := t.TempDir()
 		altDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(altDir, "alt-dag.yaml"), []byte("name: alt-dag\nsteps: []\n"), 0600))
@@ -1833,7 +1833,7 @@ func TestGetAltDAGsListData(t *testing.T) {
 		require.NoError(t, err)
 		apiImpl := localapi.New(repo, nil, nil, nil, runtime.Manager{}, cfg, nil, nil, prometheus.NewRegistry(), nil)
 
-		raw, err := apiImpl.GetAltDAGsListData(context.Background())
+		raw, err := apiImpl.GetDAGsListDataIncludingAltDirs(context.Background(), "")
 		require.NoError(t, err)
 		resp, ok := raw.(api.ListDAGs200JSONResponse)
 		require.True(t, ok)
@@ -1841,10 +1841,20 @@ func TestGetAltDAGsListData(t *testing.T) {
 		for _, dag := range resp.Dags {
 			names = append(names, dag.FileName)
 		}
-		require.Equal(t, []string{"alt-dag"}, names)
+		require.ElementsMatch(t, []string{"alt-dag", "main-dag"}, names)
+
+		rawFiltered, err := apiImpl.GetDAGsListDataIncludingAltDirs(context.Background(), "name=alt-dag")
+		require.NoError(t, err)
+		filtered, ok := rawFiltered.(api.ListDAGs200JSONResponse)
+		require.True(t, ok)
+		var filteredNames []string
+		for _, dag := range filtered.Dags {
+			filteredNames = append(filteredNames, dag.FileName)
+		}
+		require.Equal(t, []string{"alt-dag"}, filteredNames)
 	})
 
-	t.Run("returns empty when no alternate directory is configured", func(t *testing.T) {
+	t.Run("matches regular listing when no alternate directory is configured", func(t *testing.T) {
 		cfg := &config.Config{}
 		cfg.Paths.DAGsDir = t.TempDir()
 		cfg.Core.SkipExamples = true
@@ -1853,7 +1863,7 @@ func TestGetAltDAGsListData(t *testing.T) {
 		require.NoError(t, err)
 		apiImpl := localapi.New(repo, nil, nil, nil, runtime.Manager{}, cfg, nil, nil, prometheus.NewRegistry(), nil)
 
-		raw, err := apiImpl.GetAltDAGsListData(context.Background())
+		raw, err := apiImpl.GetDAGsListDataIncludingAltDirs(context.Background(), "")
 		require.NoError(t, err)
 		resp, ok := raw.(api.ListDAGs200JSONResponse)
 		require.True(t, ok)

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -199,14 +199,7 @@ func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.
 	case readTargetDAGs:
 		if err = svc.requireAPI(); err == nil {
 			var raw any
-			raw, err = svc.api.GetDAGsListData(ctx, input.Query)
-			if err == nil {
-				var alt any
-				alt, err = svc.api.GetAltDAGsListData(ctx)
-				if err == nil {
-					raw, err = mergeDAGLists(raw, alt)
-				}
-			}
+			raw, err = svc.api.GetDAGsListDataIncludingAltDirs(ctx, input.Query)
 			if err == nil {
 				data, err = normalizeDAGList(raw)
 			}
@@ -963,52 +956,6 @@ func readReferenceCollection() map[string]any {
 		})
 	}
 	return map[string]any{"items": items}
-}
-
-// mergeDAGLists appends the alternate-directory DAGs to the regular discovery
-// list, dropping any name already present so a DAG that exists in both
-// directories is reported once.
-func mergeDAGLists(baseRaw, altRaw any) (any, error) {
-	base, err := dagListResponse(baseRaw)
-	if err != nil {
-		return nil, err
-	}
-	alt, err := dagListResponse(altRaw)
-	if err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]struct{}, len(base.Dags))
-	for _, dag := range base.Dags {
-		seen[dagListKey(dag)] = struct{}{}
-	}
-	for _, dag := range alt.Dags {
-		key := dagListKey(dag)
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
-		base.Dags = append(base.Dags, dag)
-	}
-	return base, nil
-}
-
-func dagListResponse(raw any) (daguapi.ListDAGs200JSONResponse, error) {
-	switch data := raw.(type) {
-	case daguapi.ListDAGs200JSONResponse:
-		return data, nil
-	case *daguapi.ListDAGs200JSONResponse:
-		return *data, nil
-	default:
-		return daguapi.ListDAGs200JSONResponse{}, fmt.Errorf("unexpected DAG list response %T", raw)
-	}
-}
-
-func dagListKey(dag daguapi.DAGFile) string {
-	if dag.FileName != "" {
-		return dag.FileName
-	}
-	return dag.Dag.Name
 }
 
 func normalizeDAGList(raw any) (map[string]any, error) {

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -201,6 +201,13 @@ func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.
 			var raw any
 			raw, err = svc.api.GetDAGsListData(ctx, input.Query)
 			if err == nil {
+				var alt any
+				alt, err = svc.api.GetAltDAGsListData(ctx)
+				if err == nil {
+					raw, err = mergeDAGLists(raw, alt)
+				}
+			}
+			if err == nil {
 				data, err = normalizeDAGList(raw)
 			}
 		}
@@ -956,6 +963,52 @@ func readReferenceCollection() map[string]any {
 		})
 	}
 	return map[string]any{"items": items}
+}
+
+// mergeDAGLists appends the alternate-directory DAGs to the regular discovery
+// list, dropping any name already present so a DAG that exists in both
+// directories is reported once.
+func mergeDAGLists(baseRaw, altRaw any) (any, error) {
+	base, err := dagListResponse(baseRaw)
+	if err != nil {
+		return nil, err
+	}
+	alt, err := dagListResponse(altRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(base.Dags))
+	for _, dag := range base.Dags {
+		seen[dagListKey(dag)] = struct{}{}
+	}
+	for _, dag := range alt.Dags {
+		key := dagListKey(dag)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		base.Dags = append(base.Dags, dag)
+	}
+	return base, nil
+}
+
+func dagListResponse(raw any) (daguapi.ListDAGs200JSONResponse, error) {
+	switch data := raw.(type) {
+	case daguapi.ListDAGs200JSONResponse:
+		return data, nil
+	case *daguapi.ListDAGs200JSONResponse:
+		return *data, nil
+	default:
+		return daguapi.ListDAGs200JSONResponse{}, fmt.Errorf("unexpected DAG list response %T", raw)
+	}
+}
+
+func dagListKey(dag daguapi.DAGFile) string {
+	if dag.FileName != "" {
+		return dag.FileName
+	}
+	return dag.Dag.Name
 }
 
 func normalizeDAGList(raw any) (map[string]any, error) {

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -379,6 +379,7 @@ func TestReadToolListsAndReadsAltDAGsDir(t *testing.T) {
 	baseDir := t.TempDir()
 	altDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(altDir, "alt-dag.yaml"), []byte("name: alt-dag\nsteps: []\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "main-dag.yaml"), []byte("name: main-dag\nsteps: []\n"), 0600))
 
 	cfg := &config.Config{}
 	cfg.Paths.DAGsDir = baseDir
@@ -392,7 +393,15 @@ func TestReadToolListsAndReadsAltDAGsDir(t *testing.T) {
 
 	list := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGs})
 	require.False(t, list.IsError)
-	require.Contains(t, structuredJSON(t, list), "dagu://dags/alt-dag/spec")
+	listJSON := structuredJSON(t, list)
+	require.Contains(t, listJSON, "dagu://dags/alt-dag/spec")
+	require.Contains(t, listJSON, "dagu://dags/main-dag/spec")
+
+	filtered := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGs, Query: "name=alt-dag"})
+	require.False(t, filtered.IsError)
+	filteredJSON := structuredJSON(t, filtered)
+	require.Contains(t, filteredJSON, "dagu://dags/alt-dag/spec")
+	require.NotContains(t, filteredJSON, "dagu://dags/main-dag/spec")
 
 	spec := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGSpec, Name: "alt-dag"})
 	require.False(t, spec.IsError)

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/persis"
+	persisfile "github.com/dagucloud/dagu/v2/internal/persis/file"
 	filedag "github.com/dagucloud/dagu/v2/internal/persis/file/dag"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	frontendapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
@@ -369,6 +372,31 @@ func TestServerExposesReferenceResourcesAndPrompts(t *testing.T) {
 	require.Contains(t, names, "dagu_create_doc")
 	require.Contains(t, names, "dagu_edit_doc")
 	require.Contains(t, names, "dagu_debug_failed_run")
+}
+
+func TestReadToolListsAndReadsAltDAGsDir(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	altDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(altDir, "alt-dag.yaml"), []byte("name: alt-dag\nsteps: []\n"), 0600))
+
+	cfg := &config.Config{}
+	cfg.Paths.DAGsDir = baseDir
+	cfg.Paths.AltDAGsDir = altDir
+	cfg.Core.SkipExamples = true
+
+	repo, err := persisfile.NewDAGRepository(cfg, persisfile.WithDAGSearchPaths([]string{altDir}))
+	require.NoError(t, err)
+	api := frontendapi.New(repo, nil, nil, nil, runtime.Manager{}, cfg, nil, nil, prometheus.NewRegistry(), nil)
+	session := connectTestClient(t, ctx, NewServer(api))
+
+	list := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGs})
+	require.False(t, list.IsError)
+	require.Contains(t, structuredJSON(t, list), "dagu://dags/alt-dag/spec")
+
+	spec := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGSpec, Name: "alt-dag"})
+	require.False(t, spec.IsError)
+	require.Contains(t, structuredJSON(t, spec), "name: alt-dag")
 }
 
 func TestReadToolCanReadReferenceResource(t *testing.T) {

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -101,7 +101,7 @@ Minimum `data` models:
 | --- | --- |
 | Reference collection | `data.items` is an array. Each item has `name` string, `uri` string, and `mimeType` string. The array includes `authoring`, `tools`, `read-tool`, `change-tool`, `execute-tool`, and `notifications`. |
 | Reference topic | `data.mimeType` is `text/markdown`; `data.text` is the Markdown content string. |
-| DAG collection | `data.items` is an array. Each item has `name` string and `uri` string. `uri` is the canonical `dagu://dags/{name}/spec` URI for that DAG. |
+| DAG collection | `data.items` is an array. Each item has `name` string and `uri` string. `uri` is the canonical `dagu://dags/{name}/spec` URI for that DAG. The collection includes DAGs defined under `paths.alt_dags_dir` in addition to those discovered under `paths.dags_dir`. |
 | DAG detail | `data.name` is the DAG name string. `data.specUri` is the canonical `dagu://dags/{name}/spec` URI. |
 | DAG spec | `data.name` is the DAG name string. `data.mimeType` is `application/yaml`. `data.spec` is the YAML document string. `data.errors` is an array of strings. |
 | Run collection | `data.items` is an array. Each item has `name` string, `dagRunId` string, `uri` string, `status` number, and `statusLabel` string. `uri` is the canonical `dagu://runs/{name}/{dagRunId}` URI. |


### PR DESCRIPTION
## Summary

The MCP `dagu_read` tool's `dags` collection only reflected DAGs discovered under `paths.dags_dir`. DAGs defined under `paths.alt_dags_dir` were already readable by name (`target=dag`, `target=dag_spec`, `dagu://dags/{name}/spec`) because those resolve through the repository's search paths, but they were invisible to discovery — the `dags` collection was empty for them. This makes the alternate directory's DAGs appear in the `dagu_read` discovery list too.

Implements issue #2589.

## Changes

- **`internal/persis/file/dag`** — the file store gains `CatalogIncludingSearchPaths`, which additionally discovers the configured search paths (`alt_dags_dir`) and builds index entries whose locations are relative to the primary directory. The primary directory's cached index is left untouched.
- **`internal/persis`** — `DAGRepository` exposes `ListIncludingSearchPaths`, which runs the combined collection through the same filtering, sorting, and pagination as the regular `List`.
- **`internal/service/frontend/api/v1/dags.go`** — adds `GetDAGsListDataIncludingAltDirs`, which lists the combined collection with the query (`name`, `labels`, `active`, `sort`, `order`, `page`, `perPage`) applied once.
- **`internal/service/mcp/read_tool.go`** — the `dagu_read dags` target calls `GetDAGsListDataIncludingAltDirs`.

## Tests

- **`internal/service/mcp/server_test.go`**: `TestReadToolListsAndReadsAltDAGsDir` — a DAG in the base dir and one in the alt dir both appear in `dags`; a `name=` filtered request is selected from the combined collection; a `dag_spec` read by name resolves the alt-dir DAG.
- **`internal/service/frontend/api/v1/dags_test.go`**: `TestGetDAGsListDataIncludingAltDirs` — the combined list includes both directories and applies `name=` filtering to the combined set; matches the regular listing when no alternate directory is configured.
- **`internal/persis/file/dag/store_test.go`**: `TestCatalogIncludingSearchPaths` — the combined catalog includes alt-dir DAGs with a correct `Location`, while the regular catalog remains base-only.
- **`specs/021-mcp-read-tool.md`**: document that the DAG collection includes alt-dir DAGs.

## Scope note

`paths.alt_dags_dir` remains lookup-only for the general discovery/UI listing (unchanged). This only surfaces the alternate directory's DAGs through the `dagu_read` tool.