### PR TITLE
fix: route nested worker sub-DAGs through coordinator

### DIFF
--- a/internal/service/coordinator/subflow/local.go
+++ b/internal/service/coordinator/subflow/local.go
@@ -49,6 +49,7 @@ type Local struct {
 	logWriterFactory         runctx.LogWriterFactory
 	artifactFinalizer        runtime.ArtifactFinalizer
 	subWorkflowRunnerFactory rtagent.SubWorkflowRunnerFactory
+	remoteDAGLoader          rtagent.RemoteDAGLoader
 	workerID                 string
 	dagRunLogDir             string
 	dagRunArtifactDir        string
@@ -145,6 +146,13 @@ func WithLocalArtifactFinalizer(finalizer runtime.ArtifactFinalizer) LocalOption
 func WithLocalSubWorkflowRunnerFactory(factory rtagent.SubWorkflowRunnerFactory) LocalOption {
 	return func(r *Local) {
 		r.subWorkflowRunnerFactory = factory
+	}
+}
+
+// WithLocalRemoteDAGLoader sets the remote fallback used by nested child workflows.
+func WithLocalRemoteDAGLoader(loader rtagent.RemoteDAGLoader) LocalOption {
+	return func(r *Local) {
+		r.remoteDAGLoader = loader
 	}
 }
 
@@ -449,6 +457,7 @@ func (r *Local) newAgent(
 	opts.WorkerID = r.workerID
 	opts.StatusPusher = r.statusPusher
 	opts.SubWorkflowRunnerFactory = r.subWorkflowRunnerFactory
+	opts.RemoteDAGLoader = r.remoteDAGLoader
 	opts.LogWriterFactory = r.logWriterFactory
 	opts.RunStateStore = r.runStateStoreFromContext(ctx)
 	opts.StateStore = r.stateStoreFromContext(ctx)

--- a/internal/service/coordinator/subflow/runner.go
+++ b/internal/service/coordinator/subflow/runner.go
@@ -48,6 +48,7 @@ var _ executor.SubWorkflowRunner = (*Runner)(nil)
 // Runner executes child workflows through Dagu's distributed coordinator.
 type Runner struct {
 	dispatcher           dispatch.Dispatcher
+	cleanupDispatcher    bool
 	defaultMode          config.ExecutionMode
 	pollInterval         time.Duration
 	logInterval          time.Duration
@@ -79,10 +80,18 @@ func WithCancellationTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithoutDispatcherCleanup marks the dispatcher as caller-owned.
+func WithoutDispatcherCleanup() Option {
+	return func(r *Runner) {
+		r.cleanupDispatcher = false
+	}
+}
+
 // New creates a coordinator-backed child workflow runner.
 func New(dispatcher dispatch.Dispatcher, defaultMode config.ExecutionMode, opts ...Option) *Runner {
 	r := &Runner{
 		dispatcher:           dispatcher,
+		cleanupDispatcher:    true,
 		defaultMode:          defaultMode,
 		pollInterval:         defaultPollInterval,
 		logInterval:          defaultLogInterval,
@@ -203,7 +212,7 @@ func (r *Runner) Cancel(ctx context.Context, req executor.SubWorkflowCancelReque
 
 // Cleanup releases resources held by the underlying dispatcher.
 func (r *Runner) Cleanup(ctx context.Context) error {
-	if r == nil || r.dispatcher == nil {
+	if r == nil || r.dispatcher == nil || !r.cleanupDispatcher {
 		return nil
 	}
 	return r.dispatcher.Cleanup(ctx)

--- a/internal/service/coordinator/subflow/runner_test.go
+++ b/internal/service/coordinator/subflow/runner_test.go
@@ -411,6 +411,30 @@ func TestRunnerCancelRequestsDispatcherCancel(t *testing.T) {
 	assert.Equal(t, root, *cancel.root)
 }
 
+func TestRunnerCleanupDispatcherOwnership(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owned dispatcher", func(t *testing.T) {
+		dispatcher := &mockDispatcher{}
+		runner := subflow.New(dispatcher, config.ExecutionModeDistributed)
+
+		require.NoError(t, runner.Cleanup(context.Background()))
+		assert.Equal(t, 1, dispatcher.cleanupCalls)
+	})
+
+	t.Run("caller-owned dispatcher", func(t *testing.T) {
+		dispatcher := &mockDispatcher{}
+		runner := subflow.New(
+			dispatcher,
+			config.ExecutionModeDistributed,
+			subflow.WithoutDispatcherCleanup(),
+		)
+
+		require.NoError(t, runner.Cleanup(context.Background()))
+		assert.Zero(t, dispatcher.cleanupCalls)
+	})
+}
+
 func newFastRunner(dispatcher dispatch.Dispatcher) *subflow.Runner {
 	return subflow.New(
 		dispatcher,
@@ -421,9 +445,10 @@ func newFastRunner(dispatcher dispatch.Dispatcher) *subflow.Runner {
 }
 
 type mockDispatcher struct {
-	dispatches []*dispatch.DispatchTask
-	statuses   []*dispatch.DAGRunStatusResult
-	cancels    []cancelRequest
+	dispatches   []*dispatch.DispatchTask
+	statuses     []*dispatch.DAGRunStatusResult
+	cancels      []cancelRequest
+	cleanupCalls int
 }
 
 type cancelRequest struct {
@@ -438,6 +463,7 @@ func (m *mockDispatcher) Dispatch(_ context.Context, req dispatch.DispatchReques
 }
 
 func (m *mockDispatcher) Cleanup(context.Context) error {
+	m.cleanupCalls++
 	return nil
 }
 

--- a/internal/service/coordinator/subworkflow.go
+++ b/internal/service/coordinator/subworkflow.go
@@ -24,6 +24,7 @@ import (
 
 // SubWorkflowRunnerConfig contains dependencies for child workflow execution.
 type SubWorkflowRunnerConfig struct {
+	// Dispatcher is caller-owned and remains live after a child runner is cleaned up.
 	Dispatcher        dispatch.Dispatcher
 	DAGRunMgr         runtime.Manager
 	DAGRepository     *persis.DAGRepository
@@ -50,15 +51,18 @@ func NewSubWorkflowRunnerFactory(cfg SubWorkflowRunnerConfig) func(context.Conte
 	var factory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
 	factory = func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
 		dispatcher := cfg.Dispatcher
+		var runnerOpts []subflow.Option
 		if dispatcher == nil {
 			var err error
 			dispatcher, err = NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			runnerOpts = append(runnerOpts, subflow.WithoutDispatcherCleanup())
 		}
 		return subflow.NewRouter(
-			subflow.New(dispatcher, cfg.DefaultExecMode),
+			subflow.New(dispatcher, cfg.DefaultExecMode, runnerOpts...),
 			subflow.NewLocal(
 				cfg.DAGRunMgr,
 				cfg.DAGRepository,

--- a/internal/service/coordinator/subworkflow.go
+++ b/internal/service/coordinator/subworkflow.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/dagrun"
+	"github.com/dagucloud/dagu/v2/internal/dispatch"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	"github.com/dagucloud/dagu/v2/internal/profile"
 	"github.com/dagucloud/dagu/v2/internal/queue"
 	"github.com/dagucloud/dagu/v2/internal/runctx"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
+	rtagent "github.com/dagucloud/dagu/v2/internal/runtime/agent"
 	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/v2/internal/secret"
@@ -22,6 +24,7 @@ import (
 
 // SubWorkflowRunnerConfig contains dependencies for child workflow execution.
 type SubWorkflowRunnerConfig struct {
+	Dispatcher        dispatch.Dispatcher
 	DAGRunMgr         runtime.Manager
 	DAGRepository     *persis.DAGRepository
 	DAGRunRepository  *persis.DAGRunRepository
@@ -36,6 +39,7 @@ type SubWorkflowRunnerConfig struct {
 	StatusPusher      runtime.StatusPusher
 	LogWriterFactory  runctx.LogWriterFactory
 	ArtifactFinalizer runtime.ArtifactFinalizer
+	RemoteDAGLoader   rtagent.RemoteDAGLoader
 	WorkerID          string
 	DAGRunLogDir      string
 	DAGRunArtifactDir string
@@ -45,9 +49,13 @@ type SubWorkflowRunnerConfig struct {
 func NewSubWorkflowRunnerFactory(cfg SubWorkflowRunnerConfig) func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
 	var factory func(context.Context) (runtimeexec.SubWorkflowRunner, error)
 	factory = func(context.Context) (runtimeexec.SubWorkflowRunner, error) {
-		dispatcher, err := NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
-		if err != nil {
-			return nil, err
+		dispatcher := cfg.Dispatcher
+		if dispatcher == nil {
+			var err error
+			dispatcher, err = NewRuntimeDispatcher(cfg.ServiceRegistry, cfg.PeerConfig)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return subflow.NewRouter(
 			subflow.New(dispatcher, cfg.DefaultExecMode),
@@ -65,6 +73,7 @@ func NewSubWorkflowRunnerFactory(cfg SubWorkflowRunnerConfig) func(context.Conte
 				subflow.WithLocalLogWriterFactory(cfg.LogWriterFactory),
 				subflow.WithLocalArtifactFinalizer(cfg.ArtifactFinalizer),
 				subflow.WithLocalSubWorkflowRunnerFactory(factory),
+				subflow.WithLocalRemoteDAGLoader(cfg.RemoteDAGLoader),
 				subflow.WithLocalWorkerID(cfg.WorkerID),
 				subflow.WithLocalDAGRunDirs(cfg.DAGRunLogDir, cfg.DAGRunArtifactDir),
 			),

--- a/internal/service/coordinator/subworkflow_test.go
+++ b/internal/service/coordinator/subworkflow_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/dispatch"
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubWorkflowRunnerFactoryDoesNotCleanInjectedDispatcher(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &borrowedDispatcher{}
+	factory := coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
+		Dispatcher:      dispatcher,
+		DefaultExecMode: config.ExecutionModeDistributed,
+	})
+	runner, err := factory(context.Background())
+	require.NoError(t, err)
+
+	cleaner, ok := runner.(interface{ Cleanup(context.Context) error })
+	require.True(t, ok)
+	require.NoError(t, cleaner.Cleanup(context.Background()))
+	assert.Zero(t, dispatcher.cleanupCalls)
+}
+
+type borrowedDispatcher struct {
+	cleanupCalls int
+}
+
+func (*borrowedDispatcher) Dispatch(context.Context, dispatch.DispatchRequest) error {
+	return nil
+}
+
+func (d *borrowedDispatcher) Cleanup(context.Context) error {
+	d.cleanupCalls++
+	return nil
+}
+
+func (*borrowedDispatcher) GetDAGRunStatus(
+	context.Context,
+	string,
+	string,
+	*ir.DAGRunRef,
+) (*dispatch.DAGRunStatusResult, error) {
+	return &dispatch.DAGRunStatusResult{}, nil
+}
+
+func (*borrowedDispatcher) RequestCancel(context.Context, string, string, *ir.DAGRunRef) error {
+	return nil
+}

--- a/internal/service/worker/remote_handler.go
+++ b/internal/service/worker/remote_handler.go
@@ -673,23 +673,6 @@ func (h *remoteTaskHandler) executeDAGRun(
 	}
 	extraEnvs := append(taskExtraEnvs(task), toolEnvs...)
 
-	subWorkflowRunnerFactory := coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
-		DAGRunMgr:         h.dagRunMgr,
-		DAGRepository:     h.dagRepository,
-		StateStore:        h.stateStore,
-		SecretStore:       runtimeStores.SecretStore,
-		ProfileStore:      runtimeStores.ProfileStore,
-		ServiceRegistry:   h.serviceRegistry,
-		PeerConfig:        h.peerConfig,
-		DefaultExecMode:   h.config.DefaultExecMode,
-		StatusPusher:      statusPusher,
-		LogWriterFactory:  logStreamer,
-		ArtifactFinalizer: artifactUploader,
-		WorkerID:          h.workerID,
-		DAGRunLogDir:      h.config.Paths.LogDir,
-		DAGRunArtifactDir: h.config.Paths.ArtifactDir,
-	})
-
 	// Create a remote DAG loader that fetches DAG definitions from the coordinator
 	// as a fallback when the local DAG repository misses.
 	remoteDAGLoader := rtagent.RemoteDAGLoader(func(ctx context.Context, name string) (*ir.DAG, error) {
@@ -705,6 +688,25 @@ func (h *remoteTaskHandler) executeDAGRun(
 			return nil, fmt.Errorf("failed to parse DAG from remote: %w", loadErr)
 		}
 		return dag, nil
+	})
+
+	subWorkflowRunnerFactory := coordinator.NewSubWorkflowRunnerFactory(coordinator.SubWorkflowRunnerConfig{
+		Dispatcher:        h.coordinatorClient,
+		DAGRunMgr:         h.dagRunMgr,
+		DAGRepository:     h.dagRepository,
+		StateStore:        h.stateStore,
+		SecretStore:       runtimeStores.SecretStore,
+		ProfileStore:      runtimeStores.ProfileStore,
+		ServiceRegistry:   h.serviceRegistry,
+		PeerConfig:        h.peerConfig,
+		DefaultExecMode:   h.config.DefaultExecMode,
+		StatusPusher:      statusPusher,
+		LogWriterFactory:  logStreamer,
+		ArtifactFinalizer: artifactUploader,
+		RemoteDAGLoader:   remoteDAGLoader,
+		WorkerID:          h.workerID,
+		DAGRunLogDir:      h.config.Paths.LogDir,
+		DAGRunArtifactDir: h.config.Paths.ArtifactDir,
 	})
 
 	// Build agent options

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -2480,6 +2480,145 @@ steps:
 	require.Equal(t, 1, terminalStatusReports)
 }
 
+func TestExecuteDAGRun_DispatchesRemoteSubDAGThroughCoordinatorClient(t *testing.T) {
+	th := test.Setup(t)
+
+	rootDAG := th.DAG(t, `name: worker-parent
+steps:
+  - name: run-child
+    action: dag.run
+    with:
+      dag: worker-child
+`)
+	childDAG := `name: worker-child
+worker_selector:
+  os: windows
+steps:
+  - name: child-step
+    run: echo child
+`
+
+	dispatched := false
+	client := newMockRemoteCoordinatorClient()
+	client.GetDAGFunc = func(_ context.Context, name string) (string, error) {
+		require.Equal(t, "worker-child", name)
+		return childDAG, nil
+	}
+	client.DispatchFunc = func(_ context.Context, task *dispatch.DispatchTask) error {
+		require.Equal(t, "worker-child", task.Target)
+		require.Equal(t, map[string]string{"os": "windows"}, task.WorkerSelector)
+		dispatched = true
+		return nil
+	}
+	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, _ *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
+		if !dispatched {
+			return &dispatch.DAGRunStatusResult{Found: false}, nil
+		}
+		return &dispatch.DAGRunStatusResult{
+			Found: true,
+			Status: &ir.DAGRunStatus{
+				Name:     dagName,
+				DAGRunID: dagRunID,
+				Status:   ir.Succeeded,
+			},
+		}, nil
+	}
+
+	handler := &remoteTaskHandler{
+		workerID:          "integration-test-worker",
+		coordinatorClient: client,
+		dagRunMgr:         th.DAGRunMgr,
+		config:            th.Config,
+	}
+
+	root := ir.NewDAGRunRef(rootDAG.Name, "run-remote-subdag-dispatch")
+	run := remoteRun{
+		task: &coordinatorv1.Task{DagRunId: root.ID},
+		root: root,
+	}
+	run.handlers = handler.createRemoteHandlers(run, rootDAG.Name)
+
+	err := handler.executeDAGRun(th.Context, rootDAG.DAG, run)
+	require.NoError(t, err)
+	require.True(t, dispatched)
+}
+
+func TestExecuteDAGRun_LocalSubDAGKeepsRemoteLoaderForNestedDispatch(t *testing.T) {
+	th := test.Setup(t)
+
+	rootDAG := th.DAG(t, `name: worker-root
+steps:
+  - name: run-stage
+    action: dag.run
+    with:
+      dag: worker-stage
+`)
+	stageDAG := `name: worker-stage
+steps:
+  - name: run-child
+    action: dag.run
+    with:
+      dag: worker-child
+`
+	childDAG := `name: worker-child
+worker_selector:
+  os: windows
+steps:
+  - name: child-step
+    run: echo child
+`
+
+	dispatched := false
+	client := newMockRemoteCoordinatorClient()
+	client.GetDAGFunc = func(_ context.Context, name string) (string, error) {
+		switch name {
+		case "worker-stage":
+			return stageDAG, nil
+		case "worker-child":
+			return childDAG, nil
+		default:
+			return "", fmt.Errorf("unexpected DAG %q", name)
+		}
+	}
+	client.DispatchFunc = func(_ context.Context, task *dispatch.DispatchTask) error {
+		require.Equal(t, "worker-child", task.Target)
+		require.Equal(t, map[string]string{"os": "windows"}, task.WorkerSelector)
+		dispatched = true
+		return nil
+	}
+	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, _ *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
+		if !dispatched {
+			return &dispatch.DAGRunStatusResult{Found: false}, nil
+		}
+		return &dispatch.DAGRunStatusResult{
+			Found: true,
+			Status: &ir.DAGRunStatus{
+				Name:     dagName,
+				DAGRunID: dagRunID,
+				Status:   ir.Succeeded,
+			},
+		}, nil
+	}
+
+	handler := &remoteTaskHandler{
+		workerID:          "integration-test-worker",
+		coordinatorClient: client,
+		dagRunMgr:         th.DAGRunMgr,
+		config:            th.Config,
+	}
+
+	root := ir.NewDAGRunRef(rootDAG.Name, "run-nested-remote-subdag")
+	run := remoteRun{
+		task: &coordinatorv1.Task{DagRunId: root.ID},
+		root: root,
+	}
+	run.handlers = handler.createRemoteHandlers(run, rootDAG.Name)
+
+	err := handler.executeDAGRun(th.Context, rootDAG.DAG, run)
+	require.NoError(t, err)
+	require.True(t, dispatched)
+}
+
 func TestExecuteDAGRun_FinalSchedulerLogUsesChildMetadataForLocalSubDAG(t *testing.T) {
 	th := test.Setup(t)
 

--- a/internal/service/worker/remote_handler_test.go
+++ b/internal/service/worker/remote_handler_test.go
@@ -2498,7 +2498,8 @@ steps:
     run: echo child
 `
 
-	dispatched := false
+	root := ir.NewDAGRunRef(rootDAG.Name, "run-remote-subdag-dispatch")
+	var dispatchedTask *dispatch.DispatchTask
 	client := newMockRemoteCoordinatorClient()
 	client.GetDAGFunc = func(_ context.Context, name string) (string, error) {
 		require.Equal(t, "worker-child", name)
@@ -2507,13 +2508,20 @@ steps:
 	client.DispatchFunc = func(_ context.Context, task *dispatch.DispatchTask) error {
 		require.Equal(t, "worker-child", task.Target)
 		require.Equal(t, map[string]string{"os": "windows"}, task.WorkerSelector)
-		dispatched = true
+		require.Equal(t, root.Name, task.RootDAGRunName)
+		require.Equal(t, root.ID, task.RootDAGRunID)
+		require.Equal(t, root.Name, task.ParentDAGRunName)
+		require.Equal(t, root.ID, task.ParentDAGRunID)
+		dispatchedTask = task
 		return nil
 	}
-	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, _ *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
-		if !dispatched {
+	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, rootRef *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
+		if dispatchedTask == nil {
 			return &dispatch.DAGRunStatusResult{Found: false}, nil
 		}
+		require.Equal(t, dispatchedTask.Target, dagName)
+		require.Equal(t, dispatchedTask.DAGRunID, dagRunID)
+		require.Equal(t, &root, rootRef)
 		return &dispatch.DAGRunStatusResult{
 			Found: true,
 			Status: &ir.DAGRunStatus{
@@ -2531,7 +2539,6 @@ steps:
 		config:            th.Config,
 	}
 
-	root := ir.NewDAGRunRef(rootDAG.Name, "run-remote-subdag-dispatch")
 	run := remoteRun{
 		task: &coordinatorv1.Task{DagRunId: root.ID},
 		root: root,
@@ -2540,7 +2547,7 @@ steps:
 
 	err := handler.executeDAGRun(th.Context, rootDAG.DAG, run)
 	require.NoError(t, err)
-	require.True(t, dispatched)
+	require.NotNil(t, dispatchedTask)
 }
 
 func TestExecuteDAGRun_LocalSubDAGKeepsRemoteLoaderForNestedDispatch(t *testing.T) {
@@ -2568,7 +2575,8 @@ steps:
     run: echo child
 `
 
-	dispatched := false
+	root := ir.NewDAGRunRef(rootDAG.Name, "run-nested-remote-subdag")
+	var dispatchedTask *dispatch.DispatchTask
 	client := newMockRemoteCoordinatorClient()
 	client.GetDAGFunc = func(_ context.Context, name string) (string, error) {
 		switch name {
@@ -2583,13 +2591,21 @@ steps:
 	client.DispatchFunc = func(_ context.Context, task *dispatch.DispatchTask) error {
 		require.Equal(t, "worker-child", task.Target)
 		require.Equal(t, map[string]string{"os": "windows"}, task.WorkerSelector)
-		dispatched = true
+		require.Equal(t, root.Name, task.RootDAGRunName)
+		require.Equal(t, root.ID, task.RootDAGRunID)
+		require.Equal(t, "worker-stage", task.ParentDAGRunName)
+		require.NotEmpty(t, task.ParentDAGRunID)
+		require.NotEqual(t, root.ID, task.ParentDAGRunID)
+		dispatchedTask = task
 		return nil
 	}
-	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, _ *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
-		if !dispatched {
+	client.GetDAGRunStatusFunc = func(_ context.Context, dagName, dagRunID string, rootRef *ir.DAGRunRef) (*dispatch.DAGRunStatusResult, error) {
+		if dispatchedTask == nil {
 			return &dispatch.DAGRunStatusResult{Found: false}, nil
 		}
+		require.Equal(t, dispatchedTask.Target, dagName)
+		require.Equal(t, dispatchedTask.DAGRunID, dagRunID)
+		require.Equal(t, &root, rootRef)
 		return &dispatch.DAGRunStatusResult{
 			Found: true,
 			Status: &ir.DAGRunStatus{
@@ -2607,7 +2623,6 @@ steps:
 		config:            th.Config,
 	}
 
-	root := ir.NewDAGRunRef(rootDAG.Name, "run-nested-remote-subdag")
 	run := remoteRun{
 		task: &coordinatorv1.Task{DagRunId: root.ID},
 		root: root,
@@ -2616,7 +2631,7 @@ steps:
 
 	err := handler.executeDAGRun(th.Context, rootDAG.DAG, run)
 	require.NoError(t, err)
-	require.True(t, dispatched)
+	require.NotNil(t, dispatchedTask)
 }
 
 func TestExecuteDAGRun_FinalSchedulerLogUsesChildMetadataForLocalSubDAG(t *testing.T) {


### PR DESCRIPTION
## Summary

Allow `dag.run` chains that execute inside shared-nothing workers to continue dispatching and resolving nested DAGs through the coordinator.

## Changes

- Reuse the worker's live coordinator client when recursive sub-workflow runners dispatch a worker-selected child.
- Propagate the remote DAG loader through locally executed intermediate children so deeper DAGs can still be fetched.
- Add regressions for worker-to-worker dispatch and worker-to-local-to-worker nesting.

## Related Issues

Closes #2591

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (no user-facing documentation change required)
- [x] Changes have been tested locally

## Regression evidence

- Before: the two focused tests failed with `no sub-workflow runner accepted request` and `no local DAG store and no remote loader configured`.
- After: `go test ./internal/service/worker -run '^(TestExecuteDAGRun_DispatchesRemoteSubDAGThroughCoordinatorClient|TestExecuteDAGRun_LocalSubDAGKeepsRemoteLoaderForNestedDispatch)$' -count=1` passes.

## Verification

- `go test -race -count=1 -v ./internal/service/worker`
- Nine focused distributed sub-DAG scenarios under `./internal/intg/distr` with `-race -count=1`
- `make lint`

Full-suite note: `GOFLAGS='-p=2' make test` completed 13,732 tests with 65 skips and 10 failures in timing-sensitive integration/service cases under the constrained local runner. These were an approval-history integration timeout, distributed parallel/bulk-queue lease expiries, and worker polling deadlines. The worker package passed in isolation, and all focused distributed sub-DAG scenarios passed in isolation. A separate earlier full-suite attempt also exhausted local linker disk space; neither full-suite attempt is reported as passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes nested worker sub-DAGs through the coordinator and preserves dispatcher ownership so shared clients aren’t closed. Previously nested sub-DAGs in workers could fail to dispatch or fetch DAGs and `Cleanup` always closed the dispatcher; now workers reuse their coordinator client, propagate a remote DAG loader to local children, and only clean up dispatchers they created.

- Worker (`internal/service/worker/remote_handler.go`): create `coordinator.NewSubWorkflowRunnerFactory` with `Dispatcher: coordinatorClient` and a coordinator-backed `RemoteDAGLoader` fallback.
- Coordinator/subflow (`internal/service/coordinator/subworkflow.go`, `.../subflow/local.go`): extend `SubWorkflowRunnerConfig` with `Dispatcher` and `RemoteDAGLoader`; if `Dispatcher` is nil use `NewRuntimeDispatcher`, otherwise pass `subflow.WithoutDispatcherCleanup()`; plumb loader via `WithLocalRemoteDAGLoader`.
- Subflow runner (`internal/service/coordinator/subflow/runner.go`): add `WithoutDispatcherCleanup`; `Cleanup` now skips caller-owned dispatchers.
- Tests: add regressions for worker→worker and worker→local→worker nesting and a dispatcher-ownership test; assert root/parent DAG run identities.

<sup>Written for commit 440eed7aef6e8d0aeba94b47e1064ff0955d5290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and executing remote sub-workflows within local workflow execution.
  * Remote sub-workflows now preserve worker selection settings during dispatch.
  * Nested local sub-workflows can continue dispatching remote workflow segments.

* **Bug Fixes**
  * Improved remote sub-workflow coordination and polling until successful completion.

* **Tests**
  * Added integration coverage for remote dispatch and nested workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->