### PR TITLE
fix(runtime): retry inferred build descendants

### DIFF
--- a/internal/runtime/plan.go
+++ b/internal/runtime/plan.go
@@ -33,12 +33,18 @@ type Plan struct {
 	nodeByID      map[int]*Node
 	nodeByName    map[string]*Node
 	inferredEdges map[[2]int]struct{}
+	stepRetry     *stepRetrySelection
 
 	// Adjacency lists (immutable after planning; exposed for unit tests)
 	DependencyMap map[int][]int // node ID -> list of dependency node IDs (upstream)
 	DependantMap  map[int][]int // node ID -> list of dependent node IDs (downstream)
 
 	mu sync.RWMutex
+}
+
+type stepRetrySelection struct {
+	targetID int
+	resetIDs map[int]struct{}
 }
 
 // NewPlan creates a new execution plan from the given steps.
@@ -173,37 +179,45 @@ func CreateStepRetryPlanWithOptions(dag *ir.DAG, nodes []*Node, stepName string,
 	if targetNode == nil {
 		return nil, fmt.Errorf("%w: %s", ErrMissingNode, stepName)
 	}
-	if err := resetStepRetryNode(targetNode, steps, targetNode.State().Status == ir.NodeRetrying); err != nil {
-		return nil, err
-	}
+	resetStepRetryNode(targetNode, targetNode.State().Status == ir.NodeRetrying)
 
 	if opts.IncludeDownstream {
-		resetIDs := map[int]struct{}{targetNode.id: {}}
-		for _, node := range p.reachableDescendants(targetNode) {
-			resetIDs[node.id] = struct{}{}
-			if err := resetStepRetryNode(node, steps, false); err != nil {
-				return nil, err
-			}
+		p.stepRetry = &stepRetrySelection{
+			targetID: targetNode.id,
+			resetIDs: map[int]struct{}{targetNode.id: {}},
 		}
-		p.markSkippedSidePrerequisites(resetIDs)
+		p.expandStepRetrySelection()
 	}
 
 	return p, nil
 }
 
-func resetStepRetryNode(node *Node, steps map[string]ir.Step, preserveRetryBudget bool) error {
-	step, err := retryStepForNode(node, steps)
-	if err != nil {
-		return err
-	}
-
+func resetStepRetryNode(node *Node, preserveRetryBudget bool) {
 	retryCount := node.GetRetryCount()
-	clearNodeForRetry(node, step)
+	clearNodeForRetry(node, node.Step())
 	node.SetRetryCount(retryCount)
 	if !preserveRetryBudget {
 		node.retryPolicy = RetryPolicy{} // manual step retries start with a fresh retry budget
 	}
-	return nil
+}
+
+func (p *Plan) expandStepRetrySelection() {
+	if p.stepRetry == nil {
+		return
+	}
+	for _, node := range p.reachableDescendants(p.nodeByID[p.stepRetry.targetID]) {
+		if _, reset := p.stepRetry.resetIDs[node.id]; reset {
+			continue
+		}
+		resetStepRetryNode(node, false)
+		p.stepRetry.resetIDs[node.id] = struct{}{}
+	}
+	p.markSkippedSidePrerequisites(p.stepRetry.resetIDs)
+}
+
+func (p *Plan) finalizeStepRetrySelection() {
+	p.expandStepRetrySelection()
+	p.stepRetry = nil
 }
 
 // reachableDescendants returns nodes reachable from the given node through

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -150,6 +150,7 @@ func (r *Runner) Run(ctx context.Context, plan *Plan, progressCh chan *Node) err
 	if err := prepareBuildPlan(ctx, plan); err != nil {
 		return err
 	}
+	plan.finalizeStepRetrySelection()
 	r.resetRunState(plan)
 
 	// Create a cancellable context for the entire execution

--- a/internal/runtime/runner_internal_test.go
+++ b/internal/runtime/runner_internal_test.go
@@ -193,6 +193,58 @@ func TestPrepareBuildPlanInfersFileDependency(t *testing.T) {
 	assert.Equal(t, producerNode.Step().Outputs[0].Path, consumerNode.Step().Inputs[0].Path)
 }
 
+func TestRunner_StepRetryWithDownstreamIncludesInferredBuildDescendant(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	producer := ir.Step{
+		ID:       "producer",
+		Name:     "producer",
+		Commands: []ir.CommandEntry{{Command: "echo", Args: []string{"producer"}}},
+		Outputs:  []ir.StepOutputDeclaration{{Name: "artifact", Path: "artifact.txt"}},
+	}
+	consumer := ir.Step{
+		ID:       "consumer",
+		Name:     "consumer",
+		Commands: []ir.CommandEntry{{Command: "echo", Args: []string{"consumer"}}},
+		Inputs:   []ir.StepInputDeclaration{{Name: "artifact", Path: "artifact.txt"}},
+	}
+	dag := &ir.DAG{
+		Name:               "build-test",
+		Type:               ir.TypeBuild,
+		WorkingDir:         workingDir,
+		WorkingDirExplicit: true,
+		Steps:              []ir.Step{producer, consumer},
+	}
+	nodes := []*Node{
+		NodeWithData(NodeData{Step: producer, State: NodeState{Status: ir.NodeSucceeded}}),
+		NodeWithData(NodeData{Step: consumer, State: NodeState{Status: ir.NodeSucceeded}}),
+	}
+	plan, err := CreateStepRetryPlanWithOptions(dag, nodes, producer.Name, StepRetryPlanOptions{
+		IncludeDownstream: true,
+	})
+	require.NoError(t, err)
+
+	runner := New(&Config{
+		DAGRunID:             "run-1",
+		Dry:                  true,
+		NoReuse:              true,
+		MaterializationStore: filematerialization.New(filepath.Join(t.TempDir(), "materializations")),
+	})
+	ctx := NewContext(
+		context.Background(),
+		dag,
+		"run-1",
+		filepath.Join(workingDir, "dag.log"),
+		WithAttemptID("attempt-1"),
+	)
+	require.NoError(t, runner.Run(ctx, plan, nil))
+
+	consumerBuild := plan.GetNodeByName(consumer.Name).State().Build
+	require.NotNil(t, consumerBuild)
+	assert.Equal(t, ir.BuildDecisionDeferred, consumerBuild.Decision)
+}
+
 func TestPrepareBuildPlanRejectsRedirectAlias(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fix downstream step retries in build workflows so consumers connected through inferred file dependencies rerun with the selected producer.

## Changes

- retain downstream retry selection until build dependency inference finishes
- reset only newly reachable descendants after inferred edges are added
- add a Runner-level regression test for inferred producer-consumer retries

## Related Issues

Follow-up to #2582

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step retry handling for workflows with downstream dependencies.
  * Preserved retry counts and policies while correctly resetting selected and dependent steps.
  * Ensured inferred downstream build steps are deferred appropriately during retries.

* **Tests**
  * Added coverage for retry plans involving downstream inferred build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->