### PR TITLE
feat(http): support multipart file uploads

### DIFF
--- a/internal/runtime/builtin/http/config.go
+++ b/internal/runtime/builtin/http/config.go
@@ -24,6 +24,16 @@ var configSchema = &jsonschema.Schema{
 			AdditionalProperties: &jsonschema.Schema{Type: "string"},
 			Description:          "Query parameters",
 		},
+		"form": {
+			Type:                 "object",
+			AdditionalProperties: &jsonschema.Schema{Type: "string"},
+			Description:          "Multipart form fields keyed by field name",
+		},
+		"files": {
+			Type:                 "object",
+			AdditionalProperties: &jsonschema.Schema{Type: "string"},
+			Description:          "Multipart file paths keyed by field name",
+		},
 		"body":            {Type: "string", Description: "Request body content"},
 		"silent":          {Type: "boolean", Description: "Suppress headers/status output on success"},
 		"debug":           {Type: "boolean", Description: "Enable debug mode"},

--- a/internal/runtime/builtin/http/http.go
+++ b/internal/runtime/builtin/http/http.go
@@ -43,6 +43,8 @@ type httpConfig struct {
 	Headers       map[string]string `json:"headers" mapstructure:"headers"`
 	Query         map[string]string `json:"query" mapstructure:"query"`
 	Body          string            `json:"body" mapstructure:"body"`
+	Form          map[string]string `json:"form" mapstructure:"form"`
+	Files         map[string]string `json:"files" mapstructure:"files"`
 	Silent        bool              `json:"silent" mapstructure:"silent"`
 	Debug         bool              `json:"debug" mapstructure:"debug"`
 	Format        string            `json:"format" mapstructure:"format"`
@@ -105,9 +107,13 @@ func newHTTP(ctx context.Context, step ir.Step) (executor.Executor, error) {
 	if method == "" {
 		return nil, fmt.Errorf("http executor: method is required (set via command or with.method)")
 	}
+	if reqCfg.Body != "" && (len(reqCfg.Form) > 0 || len(reqCfg.Files) > 0) {
+		return nil, fmt.Errorf("http executor: body cannot be combined with form or files")
+	}
 	if err := prepareHTTPOutputConfig(ctx, &reqCfg); err != nil {
 		return nil, err
 	}
+	prepareHTTPFilePaths(ctx, &reqCfg)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -130,7 +136,15 @@ func newHTTP(ctx context.Context, step ir.Step) (executor.Executor, error) {
 	if len(reqCfg.Query) > 0 {
 		req = req.SetQueryParams(reqCfg.Query)
 	}
-	req = req.SetBody([]byte(reqCfg.Body))
+	if len(reqCfg.Form) > 0 {
+		req = req.SetMultipartFormData(reqCfg.Form)
+	}
+	if len(reqCfg.Files) > 0 {
+		req = req.SetFiles(reqCfg.Files)
+	}
+	if len(reqCfg.Form) == 0 && len(reqCfg.Files) == 0 {
+		req = req.SetBody([]byte(reqCfg.Body))
+	}
 	if reqCfg.Output != "" {
 		req = req.SetDoNotParseResponse(true)
 	}
@@ -354,6 +368,15 @@ func prepareHTTPOutputConfig(ctx context.Context, cfg *httpConfig) error {
 	}
 	cfg.Output = filepath.Clean(output)
 	return nil
+}
+
+func prepareHTTPFilePaths(ctx context.Context, cfg *httpConfig) {
+	for field, path := range cfg.Files {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(runtime.GetEnv(ctx).WorkingDir, path)
+		}
+		cfg.Files[field] = filepath.Clean(path)
+	}
 }
 
 func decodeHTTPConfig(dat map[string]any, cfg *httpConfig) error {

--- a/internal/runtime/builtin/http/http_test.go
+++ b/internal/runtime/builtin/http/http_test.go
@@ -376,9 +376,10 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 	t.Run("BehaviorConsistencyAcrossPlatforms", func(t *testing.T) {
 		// Test data that should behave the same on all platforms
 		testCases := []struct {
-			name   string
-			method string
-			config map[string]any
+			name         string
+			method       string
+			config       map[string]any
+			expectedBody string
 		}{
 			{
 				name:   "SimpleGET",
@@ -386,8 +387,9 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 				config: map[string]any{"silent": true},
 			},
 			{
-				name:   "POSTWithJSON",
-				method: "POST",
+				name:         "POSTWithJSON",
+				method:       "POST",
+				expectedBody: `{"test": "data"}`,
 				config: map[string]any{
 					"headers": map[string]string{"Content-Type": "application/json"},
 					"body":    `{"test": "data"}`,
@@ -411,8 +413,15 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+						return
+					}
+
 					// Echo back some request info
 					response := map[string]any{
+						"body":     string(body),
 						"method":   r.Method,
 						"platform": runtime.GOOS,
 						"headers":  r.Header,
@@ -449,6 +458,7 @@ func TestHTTPExecutor_CrossPlatform(t *testing.T) {
 				var response map[string]any
 				err = json.Unmarshal([]byte(out.String()), &response)
 				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedBody, response["body"])
 				assert.Equal(t, tc.method, response["method"])
 				assert.Equal(t, runtime.GOOS, response["platform"])
 

--- a/internal/runtime/builtin/http/http_test.go
+++ b/internal/runtime/builtin/http/http_test.go
@@ -6,12 +6,18 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"maps"
 	nethttp "net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/dagucloud/dagu/v2/internal/executor/registry"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	daguruntime "github.com/dagucloud/dagu/v2/internal/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,6 +156,189 @@ func TestHTTPExecutor_StandardFeatures(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "test response", out.String())
 	})
+}
+
+func TestHTTPExecutor_MultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	type receivedRequest struct {
+		contentType string
+		fileName    string
+		fileBody    string
+		description string
+		err         error
+	}
+
+	received := make(chan receivedRequest, 1)
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		result := receivedRequest{contentType: r.Header.Get("Content-Type")}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			result.err = err
+			received <- result
+			nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+			return
+		}
+
+		file, header, err := r.FormFile("document")
+		if err != nil {
+			result.err = err
+			received <- result
+			nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		body, err := io.ReadAll(file)
+		if err != nil {
+			result.err = err
+			received <- result
+			nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+			return
+		}
+
+		result.fileName = header.Filename
+		result.fileBody = string(body)
+		result.description = r.FormValue("description")
+		received <- result
+		w.WriteHeader(nethttp.StatusOK)
+		_, _ = w.Write([]byte("uploaded"))
+	}))
+	defer server.Close()
+
+	filePath := filepath.Join(t.TempDir(), "report.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("report contents"), 0o600))
+
+	step := ir.Step{
+		Commands: []ir.CommandEntry{{Command: "POST", Args: []string{server.URL}}},
+		ExecutorConfig: ir.ExecutorConfig{
+			Type: "http",
+			Config: map[string]any{
+				"files":  map[string]string{"document": filePath},
+				"form":   map[string]string{"description": "nightly report"},
+				"silent": true,
+			},
+		},
+	}
+
+	exec, err := newHTTP(context.Background(), step)
+	require.NoError(t, err)
+
+	out := &testWriter{}
+	httpExec, ok := exec.(*http)
+	require.True(t, ok)
+	httpExec.SetStdout(out)
+	httpExec.SetStderr(&testWriter{})
+
+	require.NoError(t, httpExec.Run(context.Background()))
+	result := <-received
+	require.NoError(t, result.err)
+	assert.Contains(t, result.contentType, "multipart/form-data; boundary=")
+	assert.Equal(t, "report.txt", result.fileName)
+	assert.Equal(t, "report contents", result.fileBody)
+	assert.Equal(t, "nightly report", result.description)
+	assert.Equal(t, "uploaded", out.String())
+}
+
+func TestHTTPExecutor_MultipartUploadResolvesRelativeFilePath(t *testing.T) {
+	t.Parallel()
+
+	received := make(chan string, 1)
+	server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		file, _, err := r.FormFile("payload")
+		if err != nil {
+			nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		body, err := io.ReadAll(file)
+		if err != nil {
+			nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+			return
+		}
+		received <- string(body)
+		w.WriteHeader(nethttp.StatusNoContent)
+	}))
+	defer server.Close()
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workingDir, "inputs"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, "inputs", "payload.txt"), []byte("payload contents"), 0o600))
+
+	ctx := daguruntime.WithEnv(context.Background(), daguruntime.Env{WorkingDir: workingDir})
+	step := ir.Step{
+		Commands: []ir.CommandEntry{{Command: "POST", Args: []string{server.URL}}},
+		ExecutorConfig: ir.ExecutorConfig{
+			Type: "http",
+			Config: map[string]any{
+				"files":  map[string]string{"payload": filepath.Join("inputs", "payload.txt")},
+				"silent": true,
+			},
+		},
+	}
+
+	exec, err := newHTTP(ctx, step)
+	require.NoError(t, err)
+
+	httpExec, ok := exec.(*http)
+	require.True(t, ok)
+	httpExec.SetStdout(&testWriter{})
+	httpExec.SetStderr(&testWriter{})
+
+	require.NoError(t, httpExec.Run(context.Background()))
+	assert.Equal(t, "payload contents", <-received)
+}
+
+func TestHTTPExecutor_MultipartUploadRejectsBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		multipart map[string]any
+	}{
+		{
+			name:      "File",
+			multipart: map[string]any{"files": map[string]string{"document": "report.txt"}},
+		},
+		{
+			name:      "FormField",
+			multipart: map[string]any{"form": map[string]string{"description": "report"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := map[string]any{"body": `{"name":"report"}`}
+			maps.Copy(config, tt.multipart)
+
+			_, err := newHTTP(context.Background(), ir.Step{
+				Commands: []ir.CommandEntry{{Command: "POST", Args: []string{"https://example.com/upload"}}},
+				ExecutorConfig: ir.ExecutorConfig{
+					Type:   "http",
+					Config: config,
+				},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "body cannot be combined with form or files")
+		})
+	}
+}
+
+func TestHTTPExecutor_MultipartSchemaRejectsNonStringValues(t *testing.T) {
+	t.Parallel()
+
+	for _, field := range []string{"form", "files"} {
+		t.Run(field, func(t *testing.T) {
+			t.Parallel()
+
+			err := registry.ValidateExecutorConfig("http", map[string]any{
+				field: map[string]any{"document": 123},
+			})
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestHTTPExecutor_MissingMethodOrURLReturnsConfigError(t *testing.T) {

--- a/llms.txt
+++ b/llms.txt
@@ -646,7 +646,24 @@ steps:
       timeout: 30
 ```
 
-`with` fields: `method`, `url`, `timeout`, `headers`, `query`, `body`, `silent`, `debug`, `json`, `skip_tls_verify`.
+Upload files as multipart form data by mapping server field names to local paths. Relative paths resolve from the step working directory:
+
+```yaml
+steps:
+  - id: upload
+    action: http.request
+    with:
+      method: POST
+      url: https://api.example.com/uploads
+      form:
+        description: nightly-report
+      files:
+        document: ./report.pdf
+```
+
+Do not set the multipart `Content-Type` header manually. `body` cannot be combined with `form` or `files`.
+
+`with` fields: `method`, `url`, `timeout`, `headers`, `query`, `body`, `form`, `files`, `silent`, `debug`, `format`, `output`, `json`, `skip_tls_verify`.
 
 ## jq.filter
 
@@ -1153,8 +1170,10 @@ Stop and restart a DAG run: `dagu restart <dag-name> [--run-id/-r <id>]`
 Retry a previous DAG run using the same run ID.
 
 ```sh
-dagu retry <dag> --run-id/-r <id> [--step <name>] [--worker-id <id>]
+dagu retry <dag> --run-id/-r <id> [--step <name>] [--downstream] [--worker-id <id>]
 ```
+
+`--step` retries only the selected step. Add `--downstream` to also reset every reachable descendant; unrelated branches keep their current status. `--downstream` requires `--step`.
 
 ### dagu human-task complete
 

--- a/skills/dagu/references/steptypes.md
+++ b/skills/dagu/references/steptypes.md
@@ -430,7 +430,24 @@ steps:
       timeout: 30
 ```
 
-`with` fields: `method`, `url`, `timeout`, `headers`, `query`, `body`, `silent`, `debug`, `json`, `skip_tls_verify`.
+Upload files as multipart form data by mapping server field names to local paths. Relative paths resolve from the step working directory:
+
+```yaml
+steps:
+  - id: upload
+    action: http.request
+    with:
+      method: POST
+      url: https://api.example.com/uploads
+      form:
+        description: nightly-report
+      files:
+        document: ./report.pdf
+```
+
+Do not set the multipart `Content-Type` header manually. `body` cannot be combined with `form` or `files`.
+
+`with` fields: `method`, `url`, `timeout`, `headers`, `query`, `body`, `form`, `files`, `silent`, `debug`, `format`, `output`, `json`, `skip_tls_verify`.
 
 ## jq.filter
 


### PR DESCRIPTION
## Summary
- add multipart text fields and file uploads to http.request
- resolve relative upload paths from the step working directory and reject raw body/multipart conflicts
- validate multipart configuration and document the new fields in the bundled Dagu authoring reference
- regenerate llms.txt from the current skill sources

## Testing
- make test TEST_TARGET=./internal/runtime/builtin/http
- make test
- make lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multipart form and file upload support to `http.request` so users can send standard file uploads. Previously only a raw `body` was supported; now `form` and `files` trigger multipart encoding, with relative paths resolved from the step working directory.

- Behavior changes:
  - New config keys: `form` and `files` (both maps of strings). Schema rejects non-string values.
  - `body` cannot be combined with `form` or `files`; the executor returns a config error.
  - Do not set a multipart `Content-Type` header; it is generated automatically.
  - When `form` and `files` are empty, raw-body requests behave exactly as before.

- Documentation:
  - Updated `skills/dagu/references/steptypes.md` and `llms.txt` with examples and the new `with` fields.

<sup>Written for commit cd3a4158600b1f10476ad8000dffc3fa9ee80bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HTTP requests now support multipart form submissions and file uploads.
  - File paths may be specified relative to the working directory.
  - Added a `--downstream` option to retry a selected step and its dependent steps.

- **Bug Fixes**
  - Improved validation for multipart request fields and incompatible body settings.

- **Documentation**
  - Updated HTTP request references with multipart usage, file-path behavior, and request restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->