### PR TITLE
build: add common runtime tools to standard image

### DIFF
--- a/.github/workflows/image-security.yaml
+++ b/.github/workflows/image-security.yaml
@@ -66,6 +66,10 @@ jobs:
           provenance: false
           tags: ${{ matrix.tag }}
 
+      - name: Verify standard image runtime tools
+        if: matrix.dockerfile == 'Dockerfile'
+        run: docker run --rm "${{ matrix.tag }}" curl --version
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:

--- a/.github/workflows/image-security.yaml
+++ b/.github/workflows/image-security.yaml
@@ -66,10 +66,6 @@ jobs:
           provenance: false
           tags: ${{ matrix.tag }}
 
-      - name: Verify standard image runtime tools
-        if: matrix.dockerfile == 'Dockerfile'
-        run: docker run --rm "${{ matrix.tag }}" curl --version
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN set -eux; \
       sudo \
       tini \
       tzdata \
+      curl \
       jq \
       && break; \
       if [ "$attempt" = 5 ]; then exit 1; fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,10 @@ RUN set -eux; \
       tini \
       tzdata \
       curl \
+      git \
       jq \
+      openssh-client \
+      unzip \
       && break; \
       if [ "$attempt" = 5 ]; then exit 1; fi; \
       apt-get clean; \

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -15,4 +15,6 @@ docker build -f Dockerfile.alpine -t dagu:alpine .
 docker compose -f deploy/docker/compose.minimal.yaml up -d
 ```
 
+The standard Ubuntu image includes `curl` for shell-based HTTP requests. The Alpine image remains minimal, while the development image includes the broader build and language toolchain.
+
 The Compose stacks mount `deploy/docker/dags/` read-write so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -15,6 +15,6 @@ docker build -f Dockerfile.alpine -t dagu:alpine .
 docker compose -f deploy/docker/compose.minimal.yaml up -d
 ```
 
-The standard Ubuntu image includes `curl` for shell-based HTTP requests. The Alpine image remains minimal, while the development image includes the broader build and language toolchain.
+The standard Ubuntu image includes CA certificates and common runtime utilities such as `curl`, `git`, `jq`, the OpenSSH client, and `unzip`. The Alpine image remains minimal, while the development image includes the broader build and language toolchain.
 
 The Compose stacks mount `deploy/docker/dags/` read-write so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.


### PR DESCRIPTION
## Summary
- add curl, Git, the OpenSSH client, and unzip to the standard Ubuntu image
- keep CA certificates explicit and leave the Alpine image minimal
- document the tooling distinction between standard, Alpine, and development images

## Testing
- make test
- make check
- docker build -t dagu:runtime-tools-test .
- verified Git, SSH, unzip, and the CA bundle through the normal image entrypoint as the dagu user