### PR TITLE
fix(schema): allow output, form and files on action http.request

### DIFF
--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -3558,6 +3558,20 @@
     "httpExecutorConfig": {
       "type": "object",
       "additionalProperties": false,
+      "allOf": [
+        {
+          "$comment": "body cannot be combined with the multipart fields; the executor rejects that combination at runtime.",
+          "if": {
+            "anyOf": [
+              { "required": ["form"] },
+              { "required": ["files"] }
+            ]
+          },
+          "then": {
+            "not": { "required": ["body"] }
+          }
+        }
+      ],
       "properties": {
         "method": {
           "type": "string",

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -3586,6 +3586,16 @@
           "type": "string",
           "description": "Request body content. Can be JSON, XML, or plain text depending on Content-Type header."
         },
+        "form": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Multipart form fields mapping server field names to values. Cannot be combined with body."
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Files to upload as multipart form data, mapping server field names to local paths. Relative paths resolve from the step working directory. Cannot be combined with body."
+        },
         "silent": {
           "type": "boolean",
           "description": "When true, suppresses response headers and status in output on success."
@@ -3606,6 +3616,11 @@
         "skip_tls_verify": {
           "type": "boolean",
           "description": "Skip TLS certificate verification. WARNING: Only use for testing with self-signed certificates."
+        },
+        "output": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to write the response body to (file output mode)."
         }
       },
       "description": "Configuration options for HTTP executor requests."

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -2422,6 +2422,35 @@ steps:
 `,
 		},
 		{
+			// The executor rejects body combined with the multipart fields;
+			// the schema mirrors that (#2602 review).
+			name: "RejectHTTPRequestBodyWithForm",
+			spec: `
+steps:
+  - id: upload
+    action: http.request
+    with:
+      method: POST
+      url: https://api.example.com/uploads
+      body: '{"key": "value"}'
+      form:
+        description: nightly-report
+`,
+			wantErr: "did not validate",
+		},
+		{
+			name: "HTTPRequestBodyOnly",
+			spec: `
+steps:
+  - id: fetch
+    action: http.request
+    with:
+      method: POST
+      url: https://api.example.com/data
+      body: '{"key": "value"}'
+`,
+		},
+		{
 			name: "HTTPRequestOutputOnly",
 			spec: `
 steps:
@@ -2440,7 +2469,13 @@ steps:
 			t.Parallel()
 
 			doc := mustParseYAMLDocument(t, tt.spec)
-			require.NoError(t, resolved.Validate(doc))
+			err := resolved.Validate(doc)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
 }

--- a/internal/cmn/schema/dag_schema_test.go
+++ b/internal/cmn/schema/dag_schema_test.go
@@ -2391,3 +2391,56 @@ func firstStepConfig(t *testing.T, doc map[string]any) map[string]any {
 	require.True(t, ok)
 	return config
 }
+
+func TestDAGSchemaHTTPRequestWithFields(t *testing.T) {
+	t.Parallel()
+
+	resolved := mustResolveDAGSchema(t)
+
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			// Regression (#2602): output, form and files are documented `with`
+			// fields of http.request and supported by the executor, but the
+			// schema rejected them (additionalProperties: false).
+			name: "HTTPRequestOutputFormFiles",
+			spec: `
+steps:
+  - id: fetch
+    action: http.request
+    with:
+      method: POST
+      url: https://api.example.com/uploads
+      form:
+        description: nightly-report
+      files:
+        document: ./report.pdf
+      output: ./response.json
+`,
+		},
+		{
+			name: "HTTPRequestOutputOnly",
+			spec: `
+steps:
+  - id: fetch
+    action: http.request
+    with:
+      method: GET
+      url: https://api.example.com/data
+      output: ./data.json
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := mustParseYAMLDocument(t, tt.spec)
+			require.NoError(t, resolved.Validate(doc))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2602.

## Summary

The HTTP executor accepts `output` (file output mode), `form` and `files` (multipart upload) — all three documented `with` fields of `action: http.request` (llms.txt / docs.dagu.sh, and the runtime struct in `internal/runtime/builtin/http/http.go`) — but the schema's `httpExecutorConfig` listed none of them while setting `additionalProperties: false`. The editor squiggle reported *Property output is not allowed* and schema validation rejected valid DAGs even though execution worked.

The three properties are added to `httpExecutorConfig`:

- `output` — string, path to write the response body to;
- `form` — map of string→string, multipart form fields;
- `files` — map of string→string, multipart upload field→local path.

## Testing

Added `TestDAGSchemaHTTPRequestWithFields` to the schema test suite: a step combining `form` + `files` + `output` (the multipart upload example from the docs, plus file output mode) and a minimal `output`-only step both validate.

- With the fix: the new tests pass.
- Differential (schema reverted, tests kept): both fail validation — the reported behavior.
- Note: `TestDAGSchemaRepoCopyMatchesEmbeddedSchema` fails on this Windows checkout both with and without the change — `schemas/dag.schema.json` is a relative symlink, which git materializes as a plain text file here (environment, unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `output`, `form`, and `files` in `action: http.request` and enforce that `body` cannot be combined with multipart fields, matching executor behavior and docs. Previously, the schema rejected these fields and allowed `body` with multipart (failing at runtime); now valid DAGs pass and invalid combinations fail during validation.

- Add `output` (string path), `form` (map string→string), and `files` (map string→string) to `httpExecutorConfig`.
- Reject `body` when `form` or `files` is present via a schema `if/then` rule.
- Add tests for multipart + `output`, `output`-only, `body`-only, and invalid `body` + `form`.

<sup>Written for commit 7e24c24e23bf6c9643a2ed464e4111ce45f1ed5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP requests now support multipart form fields and file uploads.
  * Response bodies can be saved directly to a file.
  * Uploaded file paths are resolved relative to the step’s working directory.
  * Form and file uploads cannot be combined with a request body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->