### PR TITLE
fix(mcp): return dagu_read output as text content

### DIFF
--- a/conformance/spec021_mcp_read_tool/read_helpers_test.go
+++ b/conformance/spec021_mcp_read_tool/read_helpers_test.go
@@ -4,6 +4,7 @@
 package spec021_mcp_read_tool_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"testing"
@@ -105,14 +106,20 @@ func requireResultContent(t *testing.T, result *mcpsdk.CallToolResult, uri, link
 	t.Helper()
 
 	if uri == "" {
-		require.Len(t, result.Content, 1)
-	} else {
 		require.Len(t, result.Content, 2)
+	} else {
+		require.Len(t, result.Content, 3)
 	}
 
 	text, ok := result.Content[0].(*mcpsdk.TextContent)
 	require.True(t, ok)
 	require.Equal(t, "Dagu read completed.", text.Text)
+
+	payload, ok := result.Content[len(result.Content)-1].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	structured, err := json.Marshal(mcptest.StructuredMap(t, result))
+	require.NoError(t, err)
+	require.JSONEq(t, string(structured), payload.Text)
 
 	if uri == "" {
 		return

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -177,6 +177,12 @@ func (svc *Service) readTool(ctx context.Context, req *mcpsdk.CallToolRequest) (
 	if err != nil {
 		return readErrorResult(classifyReadToolError(input, err)), nil
 	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		return readErrorResult(classifyReadToolError(input, err)), nil
+	}
+	// Clients that render only content items would otherwise see the status message alone.
+	result.Content = append(result.Content, &mcpsdk.TextContent{Text: string(encoded)})
 	result.StructuredContent = output
 	return result, nil
 }

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -162,7 +162,7 @@ Query parameters:
 
 Output:
 
-- Successful result text is Dagu read completed.
+- Successful result text is Dagu read completed, followed by a text item holding the structured output as JSON.
 - Structured output has target, data, references, and uri when the read has a canonical resource URI.
 - Reference URIs in references point to built-in guidance resources.
 - Wiki list and search entries include canonical dagu://wiki/{workspace}/{path} URIs. Nested page paths are encoded as one URI segment.

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -435,6 +435,18 @@ func TestReadToolListsAndReadsAltDAGsDir(t *testing.T) {
 	require.Contains(t, structuredJSON(t, spec), "name: alt-dag")
 }
 
+func TestReadToolReturnsPayloadAsTextContent(t *testing.T) {
+	ctx := context.Background()
+	session := connectTestClient(t, ctx, NewServer(nil))
+
+	result := callTool(t, ctx, session, toolRead, readInput{Target: readTargetReferences})
+	require.False(t, result.IsError)
+
+	payload, ok := result.Content[len(result.Content)-1].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, structuredJSON(t, result), payload.Text)
+}
+
 func TestReadToolCanReadReferenceResource(t *testing.T) {
 	ctx := context.Background()
 	session := connectTestClient(t, ctx, NewServer(nil))

--- a/specs/021-mcp-read-tool.md
+++ b/specs/021-mcp-read-tool.md
@@ -174,11 +174,13 @@ Rules:
 - `references` contains exactly `dagu://reference/authoring`,
   `dagu://reference/tools`, and `dagu://reference/notifications`; order is not
   normative.
-- A result with `uri` has exactly two content items: `content[0]` is a text
-  content item with text `Dagu read completed.`, and `content[1]` is a
-  resource-link content item for that URI.
-- A result without `uri` has exactly one content item: `content[0]` is a text
-  content item with text `Dagu read completed.`.
+- A result with `uri` has exactly three content items: `content[0]` is a text
+  content item with text `Dagu read completed.`, `content[1]` is a
+  resource-link content item for that URI, and `content[2]` is a text content
+  item holding the structured output as JSON.
+- A result without `uri` has exactly two content items: `content[0]` is a text
+  content item with text `Dagu read completed.`, and `content[1]` is a text
+  content item holding the structured output as JSON.
 - URI path segments in returned URIs follow Spec 020 escaping.
 
 Resource-link content items have MCP content type `resource_link`. The required


### PR DESCRIPTION
## Summary

`dagu_read` returns its data only in `structuredContent`. Its content items are the status text `Dagu read completed.` and, in URI mode, a resource link. A client that reads content items gets the status line and nothing else, which is what #2604 shows for `target=dags`. The MCP spec asks a tool that returns structured content to also return the serialized JSON in a text content item.

`dagu_execute` already does. It is registered through the SDK's generic `AddTool`, which fills content from the marshalled output when the handler leaves it empty. `dagu_read` builds its own content, so that never runs.

Reading a single DAG spec worked in the report because `dagu://dags/{name}/spec` is a registered resource template and `resources/read` returns the YAML. There is no resource for the DAG list, so `dagu_read` is the only way to get it.

## Changes

- `readTool` appends the structured output, serialized as JSON, as a trailing text content item
- Spec 021 content rules and the conformance helper follow the new item count
- The `dagu://reference/read-tool` output description matches
- A unit test compares the last content item against the structured output

## Related Issues

Closes #2604

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `dagu_read` return its structured output as a trailing text content item. Old behavior returned only the status text and optional resource link; new behavior appends the serialized JSON payload so content-only clients see the data. Content counts now: 2 items without `uri`, 3 with `uri`.

**Review notes**
- Append JSON-encoded `StructuredContent` to `result.Content` in `readTool`.
- Update Spec 021 rules and conformance tests to the new content shape.
- Update `dagu://reference/read-tool` docs and add a test that asserts the last content item equals the structured output.

**Migration**
- If a client assumed the old item count, accept an added trailing text item containing the payload.

<sup>Written for commit 3d5be8e654a1b93e94ba97edf5185713b30b1cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Successful read-tool responses now include structured output as a JSON text item.
  * Responses with resource URIs continue to include resource-link items alongside completion text and structured output.
* **Documentation**
  * Updated read-tool documentation to describe the additional structured JSON response content.
* **Bug Fixes**
  * Improved consistency between structured response payloads and their text representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->