### PR TITLE
fix: prevent scheduler memory growth during worker outages

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/proc"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -498,6 +499,7 @@ func (c *Context) NewCoordinatorClient() (coordinator.Client, error) {
 		return nil, nil
 	}
 	clientConfig := coordinator.ConfigFromPeer(c.Config.Core.Peer)
+	clientConfig.WorkspaceBundleDir = workspacebundle.StoreDir(c.Config.Paths.DataDir)
 	if err := clientConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid coordinator client configuration: %w", err)
 	}

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -65,6 +65,7 @@ func newScheduler(ctx *Context, deps scheduler.Dependencies) (*scheduler.Schedul
 	deps.SchedulerStateStore = ctx.Persistence.SchedulerStateStore
 	deps.DAGRunLeaseStore = ctx.Persistence.DAGRunLeaseStore
 	deps.DispatchTaskStore = ctx.Persistence.DispatchTaskStore
+	deps.WorkerHeartbeatStore = ctx.Persistence.WorkerHeartbeatStore
 	deps.LicenseManager = ctx.LicenseManager
 	return scheduler.New(ctx.Config, deps)
 }

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -403,7 +403,11 @@ func loadDAGWithParams(ctx *Context, args []string, isSubDAGRun bool) (*ir.DAG, 
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load DAG from %s: %w", dagPath, err)
 	}
-	if sourceFile, err := ctx.StringParam("source-file"); err == nil && sourceFile != "" {
+	if ctx.Command.Flags().Changed(sourceFileFlag.name) {
+		sourceFile, err := ctx.StringParam(sourceFileFlag.name)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get source file override: %w", err)
+		}
 		dag.SourceFile = sourceFile
 	}
 

--- a/internal/dispatch/distributed.go
+++ b/internal/dispatch/distributed.go
@@ -23,6 +23,10 @@ var (
 	ErrWorkerHeartbeatNotFound                = errors.New("worker heartbeat not found")
 )
 
+// DefaultStaleWorkerHeartbeatThreshold is the default duration after which a
+// worker heartbeat is no longer considered healthy.
+const DefaultStaleWorkerHeartbeatThreshold = 30 * time.Second
+
 // CoordinatorEndpoint identifies a coordinator instance that owns a
 // distributed task or run.
 type CoordinatorEndpoint struct {
@@ -137,6 +141,28 @@ func (r WorkerHeartbeatRecord) LastHeartbeatTime() time.Time {
 		return time.Time{}
 	}
 	return time.UnixMilli(r.LastHeartbeatAt).UTC()
+}
+
+// WorkerHeartbeatFresh reports whether a worker heartbeat is within the given freshness threshold.
+func WorkerHeartbeatFresh(record WorkerHeartbeatRecord, now time.Time, staleThreshold time.Duration) bool {
+	if staleThreshold <= 0 {
+		return false
+	}
+	lastHeartbeat := record.LastHeartbeatTime()
+	return !lastHeartbeat.IsZero() && now.Sub(lastHeartbeat) <= staleThreshold
+}
+
+// WorkerHeartbeatMatches reports whether a worker satisfies the selector and target worker requirements.
+func WorkerHeartbeatMatches(record WorkerHeartbeatRecord, selector map[string]string, targetWorkerID string) bool {
+	if targetWorkerID != "" && record.WorkerID != targetWorkerID {
+		return false
+	}
+	for key, value := range selector {
+		if record.Labels[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
 // WorkerHeartbeatStore persists shared worker presence across coordinators.

--- a/internal/dispatch/distributed_test.go
+++ b/internal/dispatch/distributed_test.go
@@ -5,6 +5,7 @@ package dispatch_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/dispatch"
 	"github.com/dagucloud/dagu/v2/internal/ir"
@@ -61,4 +62,67 @@ func TestDAGRunLeaseMatchesClaim(t *testing.T) {
 	assert.True(t, lease.MatchesClaim("claim-key", "worker-1"))
 	assert.False(t, lease.MatchesClaim("other-claim", "worker-1"))
 	assert.False(t, lease.MatchesClaim("claim-key", "worker-2"))
+}
+
+func TestWorkerHeartbeatFresh(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	threshold := 30 * time.Second
+	tests := []struct {
+		name              string
+		lastHeartbeatTime time.Time
+		threshold         time.Duration
+		want              bool
+	}{
+		{name: "fresh", lastHeartbeatTime: now.Add(-time.Second), threshold: threshold, want: true},
+		{name: "threshold boundary", lastHeartbeatTime: now.Add(-threshold), threshold: threshold, want: true},
+		{name: "stale", lastHeartbeatTime: now.Add(-threshold - time.Millisecond), threshold: threshold, want: false},
+		{name: "missing timestamp", threshold: threshold, want: false},
+		{name: "missing threshold", lastHeartbeatTime: now, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := dispatch.WorkerHeartbeatRecord{}
+			if !tt.lastHeartbeatTime.IsZero() {
+				record.LastHeartbeatAt = tt.lastHeartbeatTime.UnixMilli()
+			}
+			assert.Equal(t, tt.want, dispatch.WorkerHeartbeatFresh(record, now, tt.threshold))
+		})
+	}
+}
+
+func TestWorkerHeartbeatMatches(t *testing.T) {
+	t.Parallel()
+
+	record := dispatch.WorkerHeartbeatRecord{
+		WorkerID: "worker-1",
+		Labels: map[string]string{
+			"region": "east",
+			"type":   "gpu",
+		},
+	}
+	tests := []struct {
+		name           string
+		selector       map[string]string
+		targetWorkerID string
+		want           bool
+	}{
+		{name: "no requirements", want: true},
+		{name: "matching selector", selector: map[string]string{"type": "gpu"}, want: true},
+		{name: "matching target", targetWorkerID: "worker-1", want: true},
+		{name: "selector mismatch", selector: map[string]string{"type": "cpu"}, want: false},
+		{name: "missing label", selector: map[string]string{"pool": "batch"}, want: false},
+		{name: "target mismatch", targetWorkerID: "worker-2", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dispatch.WorkerHeartbeatMatches(record, tt.selector, tt.targetWorkerID))
+		})
+	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 	"github.com/dagucloud/dagu/v2/internal/serviceregistry"
 	"github.com/spf13/viper"
@@ -185,6 +186,7 @@ func (e *Engine) coordinatorClient(opts DistributedOptions) (coordinator.Client,
 		return nil, fmt.Errorf("distributed execution requires at least one coordinator address")
 	}
 	cfg := coordinator.DefaultConfig()
+	cfg.WorkspaceBundleDir = workspacebundle.StoreDir(e.cfg.Paths.DataDir)
 	cfg.CAFile = opts.TLS.ClientCAFile
 	cfg.CertFile = opts.TLS.CertFile
 	cfg.KeyFile = opts.TLS.KeyFile

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -778,16 +778,33 @@ steps:
 			return true
 		}
 	}
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(30 * time.Second)
+	f.requireEventuallyNoSchedulerError(
+		"DAG should remain queued while no worker is available",
+		executionStatusTimeout(),
+		100*time.Millisecond,
+		func() bool {
+			status, err := f.latestStoredStatus()
+			if err != nil || status.Status != ir.Queued {
+				return false
+			}
+			for _, condition := range status.Conditions {
+				if condition.Type == "WorkerReady" && condition.Status == "False" && condition.Reason == "NoAvailableWorker" {
+					return true
+				}
+			}
+			return false
+		},
+	)
+
 	f.workers = append(f.workers, f.setupWorkerWithAfterAckHook(
 		"worker-1",
 		map[string]string{"test": "true"},
 		"",
 		afterTaskAck,
 	))
-
-	require.NoError(t, f.enqueue())
-	f.waitForQueued()
-	f.startScheduler(30 * time.Second)
 
 	select {
 	case <-taskClaimed:

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -321,17 +321,18 @@ func (f *testFixture) startSchedulerWithOptions(
 	)
 
 	schedulerInst, err := scheduler.New(f.coord.Config, scheduler.Dependencies{
-		EntryReader:         em,
-		DAGRunManager:       f.coord.DAGRunMgr,
-		DAGRepository:       f.coord.DAGRepository,
-		DAGRunRepository:    f.coord.DAGRunRepository,
-		QueueStore:          f.coord.QueueStore,
-		ProcRepository:      f.coord.ProcRepository,
-		ServiceRegistry:     f.coord.ServiceRegistry,
-		CoordinatorClient:   f.coordinatorClient,
-		SchedulerStateStore: stateStore,
-		DAGRunLeaseStore:    f.coord.DAGRunLeaseStore,
-		DispatchTaskStore:   f.coord.DispatchTaskStore,
+		EntryReader:          em,
+		DAGRunManager:        f.coord.DAGRunMgr,
+		DAGRepository:        f.coord.DAGRepository,
+		DAGRunRepository:     f.coord.DAGRunRepository,
+		QueueStore:           f.coord.QueueStore,
+		ProcRepository:       f.coord.ProcRepository,
+		ServiceRegistry:      f.coord.ServiceRegistry,
+		CoordinatorClient:    f.coordinatorClient,
+		SchedulerStateStore:  stateStore,
+		DAGRunLeaseStore:     f.coord.DAGRunLeaseStore,
+		DispatchTaskStore:    f.coord.DispatchTaskStore,
+		WorkerHeartbeatStore: f.coord.WorkerHeartbeatStore,
 	})
 	require.NoError(f.t, err)
 	if clock != nil {

--- a/internal/intg/distr/fixtures_test.go
+++ b/internal/intg/distr/fixtures_test.go
@@ -333,6 +333,7 @@ func (f *testFixture) startSchedulerWithOptions(
 		DAGRunLeaseStore:     f.coord.DAGRunLeaseStore,
 		DispatchTaskStore:    f.coord.DispatchTaskStore,
 		WorkerHeartbeatStore: f.coord.WorkerHeartbeatStore,
+		WorkerStaleAfter:     f.coord.StaleHeartbeatThreshold,
 	})
 	require.NoError(f.t, err)
 	if clock != nil {

--- a/internal/intg/queue/queue_test.go
+++ b/internal/intg/queue/queue_test.go
@@ -266,7 +266,7 @@ steps:
 		f.th.DAGRunRepository,
 		f.th.ProcRepository,
 		scheduler.NewDAGExecutor(
-			coordinator.New(f.th.ServiceRegistry, coordinator.DefaultConfig()),
+			coordinator.New(f.th.ServiceRegistry, test.CoordinatorClientConfig(f.th.Config.Paths.DataDir)),
 			f.th.SubCmdBuilder,
 			f.th.Config.DefaultExecMode,
 			f.th.Config.Paths.BaseConfig,

--- a/internal/intg/reschedule_inline_api_test.go
+++ b/internal/intg/reschedule_inline_api_test.go
@@ -6,7 +6,6 @@ package intg_test
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/api/v1"
@@ -23,8 +22,7 @@ func TestAPIRescheduleInlineStartUsesStoredSnapshot(t *testing.T) {
 		}
 	}))
 
-	runID, location := test.CreateInlineDAGRunForReschedule(t, server, "intg_inline_reschedule_start", false)
-	requireMissingFile(t, location)
+	runID := test.CreateInlineDAGRunForReschedule(t, server, "intg_inline_reschedule_start", false)
 
 	newRunID := rescheduleServerInlineRun(t, server, "intg_inline_reschedule_start", runID)
 	test.ProcessQueuedInlineRun(t, server, "intg_inline_reschedule_start")
@@ -39,8 +37,7 @@ func TestAPIRescheduleInlineEnqueueUsesStoredSnapshot(t *testing.T) {
 		}
 	}))
 
-	runID, location := test.CreateInlineDAGRunForReschedule(t, server, "intg_inline_reschedule_enqueue", true)
-	requireMissingFile(t, location)
+	runID := test.CreateInlineDAGRunForReschedule(t, server, "intg_inline_reschedule_enqueue", true)
 
 	newRunID := rescheduleServerInlineRun(t, server, "intg_inline_reschedule_enqueue", runID)
 	test.ProcessQueuedInlineRun(t, server, "intg_inline_reschedule_enqueue")
@@ -60,12 +57,4 @@ func rescheduleServerInlineRun(t *testing.T, server test.Server, dagName, runID 
 	require.NotEmpty(t, body.DagRunId)
 	require.True(t, body.Queued)
 	return body.DagRunId
-}
-
-func requireMissingFile(t *testing.T, path string) {
-	t.Helper()
-
-	_, err := os.Stat(path)
-	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
 }

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -150,6 +150,9 @@ func (b *SubCmdBuilder) Start(dag *ir.DAG, opts StartOptions) CmdSpec {
 	if opts.FromRunID != "" {
 		args = append(args, fmt.Sprintf("--from-run-id=%s", opts.FromRunID))
 	}
+	if opts.SourceFile != nil {
+		args = append(args, fmt.Sprintf("--source-file=%s", *opts.SourceFile))
+	}
 	if opts.TriggerType != "" {
 		args = append(args, fmt.Sprintf("--trigger-type=%s", opts.TriggerType))
 	}
@@ -336,17 +339,18 @@ type StartOptions struct {
 	Quiet    bool   // Whether to run in quiet mode
 	DAGRunID string // ID for the dag-run
 
-	NameOverride string // Optional DAG name override
-	FromRunID    string // Historic dag-run ID to use as a template
-	Target       string // Optional CLI argument override (DAG name or file path)
-	TriggerType  string // How this DAG run was initiated (scheduler, manual, webhook, subdag)
-	TriggerActor string // Attributable actor that initiated the DAG run
-	Labels       string // Additional labels (comma-separated)
-	Tags         string // Deprecated: use Labels.
-	ScheduleTime string // RFC 3339 timestamp of when this run was scheduled
-	ProfileName  string // Runtime profile name
-	DefinitionID string // Stable DAG definition identity
-	NoReuse      bool   // Disable build materialization reuse
+	NameOverride string  // Optional DAG name override
+	FromRunID    string  // Historic dag-run ID to use as a template
+	Target       string  // Optional CLI argument override (DAG name or file path)
+	SourceFile   *string // Optional source provenance override, including an explicit empty value
+	TriggerType  string  // How this DAG run was initiated (scheduler, manual, webhook, subdag)
+	TriggerActor string  // Attributable actor that initiated the DAG run
+	Labels       string  // Additional labels (comma-separated)
+	Tags         string  // Deprecated: use Labels.
+	ScheduleTime string  // RFC 3339 timestamp of when this run was scheduled
+	ProfileName  string  // Runtime profile name
+	DefinitionID string  // Stable DAG definition identity
+	NoReuse      bool    // Disable build materialization reuse
 }
 
 // EnqueueOptions contains options for enqueuing a dag-run.

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -400,6 +400,14 @@ func TestStart(t *testing.T) {
 		assert.Contains(t, spec.Args, "--run-id=test-run-id")
 	})
 
+	t.Run("StartWithEmptySourceFileOverride", func(t *testing.T) {
+		t.Parallel()
+		sourceFile := ""
+		spec := builder.Start(dag, launcher.StartOptions{SourceFile: &sourceFile})
+
+		assert.Contains(t, spec.Args, "--source-file=")
+	})
+
 	t.Run("StartWithAllOptions", func(t *testing.T) {
 		t.Parallel()
 		opts := launcher.StartOptions{

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -27,30 +27,51 @@ func workspaceSeedFromContext(ctx context.Context) (WorkspaceSeed, bool) {
 
 // PrepareDAGWorkspace snapshots the files declared by a DAG for distributed execution.
 func PrepareDAGWorkspace(dag *ir.DAG) (*WorkspaceSeed, error) {
-	includes := dagFileDependencies(dag)
-	if len(includes) == 0 {
-		return nil, nil
+	root, opts, err := dagWorkspacePackOptions(dag)
+	if err != nil || opts == nil {
+		return nil, err
 	}
-	if dag == nil || strings.TrimSpace(dag.SourceFile) == "" {
-		return nil, fmt.Errorf("DAG file dependencies require a source file")
-	}
-	if dag.YamlData == nil {
-		return nil, fmt.Errorf("DAG file dependencies require the dispatched definition")
-	}
-
-	sourceFile, err := filepath.Abs(dag.SourceFile)
-	if err != nil {
-		return nil, fmt.Errorf("resolve DAG source file %q: %w", dag.SourceFile, err)
-	}
-	descriptor, archive, err := workspacebundle.PackDirectory(filepath.Dir(sourceFile), workspacebundle.PackOptions{
-		DAGPath:  filepath.Base(sourceFile),
-		DAGData:  dag.YamlData,
-		Includes: includes,
-	})
+	descriptor, archive, err := workspacebundle.PackDirectory(root, *opts)
 	if err != nil {
 		return nil, fmt.Errorf("prepare DAG file dependencies: %w", err)
 	}
 	return &WorkspaceSeed{Descriptor: *descriptor, Archive: archive}, nil
+}
+
+// PrepareDAGWorkspaceFile snapshots declared files into a staged archive.
+func PrepareDAGWorkspaceFile(dag *ir.DAG, stagingDir string) (*workspacebundle.Descriptor, string, error) {
+	root, opts, err := dagWorkspacePackOptions(dag)
+	if err != nil || opts == nil {
+		return nil, "", err
+	}
+	descriptor, archivePath, err := workspacebundle.PackDirectoryToFile(root, stagingDir, *opts)
+	if err != nil {
+		return nil, "", fmt.Errorf("prepare DAG file dependencies: %w", err)
+	}
+	return descriptor, archivePath, nil
+}
+
+func dagWorkspacePackOptions(dag *ir.DAG) (string, *workspacebundle.PackOptions, error) {
+	includes := dagFileDependencies(dag)
+	if len(includes) == 0 {
+		return "", nil, nil
+	}
+	if dag == nil || strings.TrimSpace(dag.SourceFile) == "" {
+		return "", nil, fmt.Errorf("DAG file dependencies require a source file")
+	}
+	if dag.YamlData == nil {
+		return "", nil, fmt.Errorf("DAG file dependencies require the dispatched definition")
+	}
+
+	sourceFile, err := filepath.Abs(dag.SourceFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve DAG source file %q: %w", dag.SourceFile, err)
+	}
+	return filepath.Dir(sourceFile), &workspacebundle.PackOptions{
+		DAGPath:  filepath.Base(sourceFile),
+		DAGData:  dag.YamlData,
+		Includes: includes,
+	}, nil
 }
 
 func dagFileDependencies(dag *ir.DAG) []string {

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -38,13 +38,16 @@ func PrepareDAGWorkspace(dag *ir.DAG) (*WorkspaceSeed, error) {
 	return &WorkspaceSeed{Descriptor: *descriptor, Archive: archive}, nil
 }
 
-// PrepareDAGWorkspaceFile snapshots declared files into a staged archive.
-func PrepareDAGWorkspaceFile(dag *ir.DAG, stagingDir string) (*workspacebundle.Descriptor, string, error) {
+// PrepareDAGWorkspaceFile snapshots declared files into a staged archive under bundleDir.
+func PrepareDAGWorkspaceFile(dag *ir.DAG, bundleDir string) (*workspacebundle.Descriptor, string, error) {
 	root, opts, err := dagWorkspacePackOptions(dag)
 	if err != nil || opts == nil {
 		return nil, "", err
 	}
-	descriptor, archivePath, err := workspacebundle.PackDirectoryToFile(root, stagingDir, *opts)
+	if strings.TrimSpace(bundleDir) == "" {
+		return nil, "", fmt.Errorf("workspace bundle directory is not configured")
+	}
+	descriptor, archivePath, err := workspacebundle.PackDirectoryToFile(root, filepath.Join(bundleDir, "staging"), *opts)
 	if err != nil {
 		return nil, "", fmt.Errorf("prepare DAG file dependencies: %w", err)
 	}

--- a/internal/runtime/workspacebundle/bundle.go
+++ b/internal/runtime/workspacebundle/bundle.go
@@ -402,35 +402,6 @@ func Verify(data []byte, digest string) error {
 	return nil
 }
 
-// VerifyFile verifies that a workspace bundle file matches its descriptor.
-func VerifyFile(filePath string, desc Descriptor, maxSize int64) error {
-	if !ValidDigest(desc.Digest) {
-		return fmt.Errorf("invalid workspace bundle digest %q", desc.Digest)
-	}
-	file, err := os.Open(filePath) //nolint:gosec // filePath is supplied by the caller.
-	if err != nil {
-		return fmt.Errorf("open workspace bundle: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	hasher := sha256.New()
-	written, err := io.Copy(hasher, io.LimitReader(file, maxSize+1))
-	if err != nil {
-		return fmt.Errorf("read workspace bundle: %w", err)
-	}
-	if written > maxSize {
-		return fmt.Errorf("workspace bundle exceeds compressed size limit %d", maxSize)
-	}
-	if desc.Size != 0 && desc.Size != written {
-		return fmt.Errorf("workspace bundle size mismatch: got %d, want %d", written, desc.Size)
-	}
-	actual := hex.EncodeToString(hasher.Sum(nil))
-	if actual != desc.Digest {
-		return fmt.Errorf("workspace bundle digest mismatch: got %s, want %s", actual, desc.Digest)
-	}
-	return nil
-}
-
 func ValidDigest(digest string) bool {
 	if len(digest) != sha256.Size*2 {
 		return false
@@ -678,15 +649,6 @@ func NewStore(dir string, limits Limits) *Store {
 func (s *Store) Put(ctx context.Context, desc Descriptor, data []byte) error {
 	if strings.TrimSpace(s.dir) == "" {
 		return fmt.Errorf("workspace bundle store is not configured")
-	}
-	if err := Verify(data, desc.Digest); err != nil {
-		return err
-	}
-	if int64(len(data)) > s.limits.MaxCompressedSize {
-		return fmt.Errorf("workspace bundle exceeds compressed size limit %d", s.limits.MaxCompressedSize)
-	}
-	if desc.Size != 0 && desc.Size != int64(len(data)) {
-		return fmt.Errorf("workspace bundle size mismatch: got %d, want %d", len(data), desc.Size)
 	}
 	return s.PutReader(ctx, desc, bytes.NewReader(data))
 }

--- a/internal/runtime/workspacebundle/bundle.go
+++ b/internal/runtime/workspacebundle/bundle.go
@@ -86,21 +86,62 @@ func normalizeLimits(l Limits) Limits {
 }
 
 func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
+	var buf bytes.Buffer
+	desc, err := packDirectory(root, opts, &buf)
+	if err != nil {
+		return nil, nil, err
+	}
+	return desc, buf.Bytes(), nil
+}
+
+// PackDirectoryToFile creates a workspace archive in stagingDir.
+func PackDirectoryToFile(root, stagingDir string, opts PackOptions) (*Descriptor, string, error) {
+	stagingDir = filepath.Clean(strings.TrimSpace(stagingDir))
+	if stagingDir == "." || stagingDir == "" {
+		return nil, "", fmt.Errorf("workspace bundle staging directory is required")
+	}
+	if err := os.MkdirAll(stagingDir, 0o750); err != nil {
+		return nil, "", fmt.Errorf("create workspace bundle staging directory: %w", err)
+	}
+	file, err := os.CreateTemp(stagingDir, ".workspace-*.tar.gz")
+	if err != nil {
+		return nil, "", fmt.Errorf("create workspace bundle: %w", err)
+	}
+	archivePath := file.Name()
+	cleanup := true
+	defer func() {
+		_ = file.Close()
+		if cleanup {
+			_ = fileutil.Remove(archivePath)
+		}
+	}()
+	desc, err := packDirectory(root, opts, file)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := file.Close(); err != nil {
+		return nil, "", fmt.Errorf("close workspace bundle: %w", err)
+	}
+	cleanup = false
+	return desc, archivePath, nil
+}
+
+func packDirectory(root string, opts PackOptions, dest io.Writer) (*Descriptor, error) {
 	root = filepath.Clean(strings.TrimSpace(root))
 	if root == "" {
-		return nil, nil, fmt.Errorf("workspace root is required")
+		return nil, fmt.Errorf("workspace root is required")
 	}
 	info, err := os.Stat(root)
 	if err != nil {
-		return nil, nil, fmt.Errorf("stat workspace root: %w", err)
+		return nil, fmt.Errorf("stat workspace root: %w", err)
 	}
 	if !info.IsDir() {
-		return nil, nil, fmt.Errorf("workspace root must be a directory")
+		return nil, fmt.Errorf("workspace root must be a directory")
 	}
 
 	dagPath, err := NormalizeRelativePath(opts.DAGPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid workspace DAG path: %w", err)
+		return nil, fmt.Errorf("invalid workspace DAG path: %w", err)
 	}
 
 	limits := normalizeLimits(opts.Limits)
@@ -111,15 +152,16 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 		files, err = collectFiles(root, limits)
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	files = appendUniquePath(files, dagPath)
 	if len(files) > limits.MaxFiles {
-		return nil, nil, fmt.Errorf("workspace bundle exceeds file count limit %d", limits.MaxFiles)
+		return nil, fmt.Errorf("workspace bundle exceeds file count limit %d", limits.MaxFiles)
 	}
 
-	var buf bytes.Buffer
-	gz := gzip.NewWriter(&limitedBufferWriter{w: &buf, max: limits.MaxCompressedSize})
+	hasher := sha256.New()
+	written := &limitedWriter{w: io.MultiWriter(dest, hasher), max: limits.MaxCompressedSize}
+	gz := gzip.NewWriter(written)
 	gz.Name = ""
 	gz.Comment = ""
 	gz.ModTime = zeroTime
@@ -132,7 +174,7 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 			if unpacked > limits.MaxUncompressedSize {
 				_ = tw.Close()
 				_ = gz.Close()
-				return nil, nil, fmt.Errorf("workspace bundle exceeds uncompressed size limit %d", limits.MaxUncompressedSize)
+				return nil, fmt.Errorf("workspace bundle exceeds uncompressed size limit %d", limits.MaxUncompressedSize)
 			}
 			header := &tar.Header{
 				Name:       rel,
@@ -147,12 +189,12 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 			if err := tw.WriteHeader(header); err != nil {
 				_ = tw.Close()
 				_ = gz.Close()
-				return nil, nil, fmt.Errorf("write tar header for %q: %w", rel, err)
+				return nil, fmt.Errorf("write tar header for %q: %w", rel, err)
 			}
 			if _, err := tw.Write(opts.DAGData); err != nil {
 				_ = tw.Close()
 				_ = gz.Close()
-				return nil, nil, fmt.Errorf("write bundle file %q: %w", rel, err)
+				return nil, fmt.Errorf("write bundle file %q: %w", rel, err)
 			}
 			continue
 		}
@@ -161,24 +203,24 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 		if err != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("stat bundle file %q: %w", rel, err)
+			return nil, fmt.Errorf("stat bundle file %q: %w", rel, err)
 		}
 		if err := validatePackFile(rel, info); err != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, err
+			return nil, err
 		}
 		unpacked += info.Size()
 		if unpacked > limits.MaxUncompressedSize {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("workspace bundle exceeds uncompressed size limit %d", limits.MaxUncompressedSize)
+			return nil, fmt.Errorf("workspace bundle exceeds uncompressed size limit %d", limits.MaxUncompressedSize)
 		}
 		header, err := tar.FileInfoHeader(info, "")
 		if err != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("create tar header for %q: %w", rel, err)
+			return nil, fmt.Errorf("create tar header for %q: %w", rel, err)
 		}
 		header.Name = rel
 		header.ModTime = zeroTime
@@ -192,7 +234,7 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 		if err := tw.WriteHeader(header); err != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("write tar header for %q: %w", rel, err)
+			return nil, fmt.Errorf("write tar header for %q: %w", rel, err)
 		}
 		if info.IsDir() {
 			continue
@@ -201,42 +243,37 @@ func PackDirectory(root string, opts PackOptions) (*Descriptor, []byte, error) {
 		if err != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("open bundle file %q: %w", rel, err)
+			return nil, fmt.Errorf("open bundle file %q: %w", rel, err)
 		}
 		_, copyErr := io.Copy(tw, file)
 		closeErr := file.Close()
 		if copyErr != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("write bundle file %q: %w", rel, copyErr)
+			return nil, fmt.Errorf("write bundle file %q: %w", rel, copyErr)
 		}
 		if closeErr != nil {
 			_ = tw.Close()
 			_ = gz.Close()
-			return nil, nil, fmt.Errorf("close bundle file %q: %w", rel, closeErr)
+			return nil, fmt.Errorf("close bundle file %q: %w", rel, closeErr)
 		}
 	}
 
 	if err := tw.Close(); err != nil {
 		_ = gz.Close()
-		return nil, nil, fmt.Errorf("close tar writer: %w", err)
+		return nil, fmt.Errorf("close tar writer: %w", err)
 	}
 	if err := gz.Close(); err != nil {
-		return nil, nil, fmt.Errorf("close gzip writer: %w", err)
+		return nil, fmt.Errorf("close gzip writer: %w", err)
 	}
 
-	data := buf.Bytes()
-	if int64(len(data)) > limits.MaxCompressedSize {
-		return nil, nil, fmt.Errorf("workspace bundle exceeds compressed size limit %d", limits.MaxCompressedSize)
-	}
-	digest := Digest(data)
 	return &Descriptor{
-		Digest:      digest,
-		Size:        int64(len(data)),
+		Digest:      hex.EncodeToString(hasher.Sum(nil)),
+		Size:        written.written,
 		DAGPath:     dagPath,
 		OriginalRef: strings.TrimSpace(opts.OriginalRef),
 		ResolvedRef: strings.TrimSpace(opts.ResolvedRef),
-	}, data, nil
+	}, nil
 }
 
 func Extract(data []byte, dest string, desc Descriptor, limits Limits) error {
@@ -361,6 +398,35 @@ func Verify(data []byte, digest string) error {
 	actual := Digest(data)
 	if actual != digest {
 		return fmt.Errorf("workspace bundle digest mismatch: got %s, want %s", actual, digest)
+	}
+	return nil
+}
+
+// VerifyFile verifies that a workspace bundle file matches its descriptor.
+func VerifyFile(filePath string, desc Descriptor, maxSize int64) error {
+	if !ValidDigest(desc.Digest) {
+		return fmt.Errorf("invalid workspace bundle digest %q", desc.Digest)
+	}
+	file, err := os.Open(filePath) //nolint:gosec // filePath is supplied by the caller.
+	if err != nil {
+		return fmt.Errorf("open workspace bundle: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	hasher := sha256.New()
+	written, err := io.Copy(hasher, io.LimitReader(file, maxSize+1))
+	if err != nil {
+		return fmt.Errorf("read workspace bundle: %w", err)
+	}
+	if written > maxSize {
+		return fmt.Errorf("workspace bundle exceeds compressed size limit %d", maxSize)
+	}
+	if desc.Size != 0 && desc.Size != written {
+		return fmt.Errorf("workspace bundle size mismatch: got %d, want %d", written, desc.Size)
+	}
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if actual != desc.Digest {
+		return fmt.Errorf("workspace bundle digest mismatch: got %s, want %s", actual, desc.Digest)
 	}
 	return nil
 }
@@ -569,18 +635,19 @@ func modePerm(mode fs.FileMode, fallback fs.FileMode) fs.FileMode {
 	return perm
 }
 
-type limitedBufferWriter struct {
-	w       *bytes.Buffer
+type limitedWriter struct {
+	w       io.Writer
 	max     int64
 	written int64
 }
 
-func (w *limitedBufferWriter) Write(p []byte) (int, error) {
-	w.written += int64(len(p))
-	if w.written > w.max {
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if int64(len(p)) > w.max-w.written {
 		return 0, fmt.Errorf("workspace bundle exceeds compressed size limit %d", w.max)
 	}
-	return w.w.Write(p)
+	n, err := w.w.Write(p)
+	w.written += int64(n)
+	return n, err
 }
 
 func StoreDir(dataDir string) string {
@@ -608,7 +675,7 @@ func NewStore(dir string, limits Limits) *Store {
 	}
 }
 
-func (s *Store) Put(_ context.Context, desc Descriptor, data []byte) error {
+func (s *Store) Put(ctx context.Context, desc Descriptor, data []byte) error {
 	if strings.TrimSpace(s.dir) == "" {
 		return fmt.Errorf("workspace bundle store is not configured")
 	}
@@ -621,14 +688,17 @@ func (s *Store) Put(_ context.Context, desc Descriptor, data []byte) error {
 	if desc.Size != 0 && desc.Size != int64(len(data)) {
 		return fmt.Errorf("workspace bundle size mismatch: got %d, want %d", len(data), desc.Size)
 	}
+	return s.PutReader(ctx, desc, bytes.NewReader(data))
+}
+
+// PutReader stores a workspace bundle read from reader.
+func (s *Store) PutReader(ctx context.Context, desc Descriptor, reader io.Reader) error {
+	if strings.TrimSpace(s.dir) == "" {
+		return fmt.Errorf("workspace bundle store is not configured")
+	}
 	path, err := s.path(desc.Digest)
 	if err != nil {
 		return err
-	}
-	if _, err := os.Stat(path); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat workspace bundle: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("create workspace bundle store: %w", err)
@@ -640,16 +710,37 @@ func (s *Store) Put(_ context.Context, desc Descriptor, data []byte) error {
 	tmpName := tmp.Name()
 	cleanup := true
 	defer func() {
+		_ = tmp.Close()
 		if cleanup {
 			_ = fileutil.Remove(tmpName)
 		}
 	}()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
+
+	hasher := sha256.New()
+	written, err := io.Copy(io.MultiWriter(tmp, hasher), io.LimitReader(reader, s.limits.MaxCompressedSize+1))
+	if err != nil {
 		return fmt.Errorf("write workspace bundle: %w", err)
+	}
+	if written > s.limits.MaxCompressedSize {
+		return fmt.Errorf("workspace bundle exceeds compressed size limit %d", s.limits.MaxCompressedSize)
+	}
+	if desc.Size != 0 && desc.Size != written {
+		return fmt.Errorf("workspace bundle size mismatch: got %d, want %d", written, desc.Size)
+	}
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if actual != desc.Digest {
+		return fmt.Errorf("workspace bundle digest mismatch: got %s, want %s", actual, desc.Digest)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close workspace bundle: %w", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat workspace bundle: %w", err)
 	}
 	if err := fileutil.ReplaceFile(tmpName, path); err != nil {
 		return fmt.Errorf("commit workspace bundle: %w", err)
@@ -658,22 +749,59 @@ func (s *Store) Put(_ context.Context, desc Descriptor, data []byte) error {
 	return nil
 }
 
-func (s *Store) Get(_ context.Context, digest string) ([]byte, error) {
-	if strings.TrimSpace(s.dir) == "" {
-		return nil, fmt.Errorf("workspace bundle store is not configured")
-	}
-	path, err := s.path(digest)
+func (s *Store) Get(ctx context.Context, digest string) ([]byte, error) {
+	file, _, err := s.Open(ctx, digest)
 	if err != nil {
 		return nil, err
 	}
-	data, err := fileutil.ReadFile(path)
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, fmt.Errorf("read workspace bundle: %w", err)
 	}
-	if err := Verify(data, digest); err != nil {
-		return nil, err
-	}
 	return data, nil
+}
+
+// Open opens a verified workspace bundle for reading.
+func (s *Store) Open(ctx context.Context, digest string) (*os.File, int64, error) {
+	if strings.TrimSpace(s.dir) == "" {
+		return nil, 0, fmt.Errorf("workspace bundle store is not configured")
+	}
+	path, err := s.path(digest)
+	if err != nil {
+		return nil, 0, err
+	}
+	file, err := os.Open(path) //nolint:gosec // path is derived from a validated digest and configured store directory.
+	if err != nil {
+		return nil, 0, fmt.Errorf("open workspace bundle: %w", err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = file.Close()
+		}
+	}()
+
+	hasher := sha256.New()
+	size, err := io.Copy(hasher, io.LimitReader(file, s.limits.MaxCompressedSize+1))
+	if err != nil {
+		return nil, 0, fmt.Errorf("read workspace bundle: %w", err)
+	}
+	if size > s.limits.MaxCompressedSize {
+		return nil, 0, fmt.Errorf("workspace bundle exceeds compressed size limit %d", s.limits.MaxCompressedSize)
+	}
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if actual != digest {
+		return nil, 0, fmt.Errorf("workspace bundle digest mismatch: got %s, want %s", actual, digest)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, fmt.Errorf("rewind workspace bundle: %w", err)
+	}
+	closeOnError = false
+	return file, size, nil
 }
 
 func (s *Store) Has(digest string) bool {

--- a/internal/runtime/workspacebundle/bundle_test.go
+++ b/internal/runtime/workspacebundle/bundle_test.go
@@ -4,7 +4,9 @@
 package workspacebundle
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +22,64 @@ func TestStoreRejectsEmptyDir(t *testing.T) {
 
 	err := store.Put(context.Background(), Descriptor{}, nil)
 	assert.ErrorContains(t, err, "workspace bundle store is not configured")
+}
+
+func TestPackDirectoryToFileCreatesVerifiedArchive(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "input.txt"), []byte("input"), 0o644))
+	stagingDir := filepath.Join(t.TempDir(), "staging")
+
+	desc, archivePath, err := PackDirectoryToFile(root, stagingDir, PackOptions{
+		DAGPath:  "dag.yaml",
+		DAGData:  []byte("steps: []\n"),
+		Includes: []string{"input.txt"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.Remove(archivePath)) })
+	assert.Equal(t, stagingDir, filepath.Dir(archivePath))
+
+	archive, err := os.ReadFile(archivePath)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(archive)), desc.Size)
+	require.NoError(t, Verify(archive, desc.Digest))
+}
+
+func TestPackDirectoryToFileRemovesPartialArchive(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "input.txt"), bytes.Repeat([]byte("input"), 128), 0o644))
+	stagingDir := filepath.Join(t.TempDir(), "staging")
+
+	_, _, err := PackDirectoryToFile(root, stagingDir, PackOptions{
+		DAGPath:  "dag.yaml",
+		DAGData:  []byte("steps: []\n"),
+		Includes: []string{"input.txt"},
+		Limits:   Limits{MaxCompressedSize: 1},
+	})
+	require.ErrorContains(t, err, "compressed size limit")
+	entries, readErr := os.ReadDir(stagingDir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries)
+}
+
+func TestStorePutReaderAndOpen(t *testing.T) {
+	t.Parallel()
+
+	data := bytes.Repeat([]byte("bundle"), 1024)
+	desc := Descriptor{Digest: Digest(data), Size: int64(len(data))}
+	store := NewStore(t.TempDir(), DefaultLimits())
+
+	require.NoError(t, store.PutReader(context.Background(), desc, bytes.NewReader(data)))
+	file, size, err := store.Open(context.Background(), desc.Digest)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, file.Close()) })
+	actual, err := io.ReadAll(file)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), size)
+	assert.Equal(t, data, actual)
 }
 
 func TestPackDirectorySelectsDependenciesAndInjectsDAGSnapshot(t *testing.T) {

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -16,6 +16,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -341,17 +342,18 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	if err != nil {
 		return fmt.Errorf("load DAG for file dependency snapshot: %w", err)
 	}
-	seed, err := runtimeexec.PrepareDAGWorkspace(dag)
+	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(dag, filepath.Join(cli.config.WorkspaceBundleDir, "staging"))
 	if err != nil {
 		return err
 	}
-	if seed == nil {
+	if desc == nil {
 		return nil
 	}
-	if err := cli.PutWorkspaceBundle(ctx, seed.Descriptor, seed.Archive); err != nil {
+	defer func() { _ = os.Remove(archivePath) }()
+	if err := cli.putWorkspaceBundleFile(ctx, *desc, archivePath); err != nil {
 		return fmt.Errorf("upload DAG file dependencies: %w", err)
 	}
-	runtimeexec.WithWorkspaceBundle(seed.Descriptor)(task)
+	runtimeexec.WithWorkspaceBundle(*desc)(task)
 	return nil
 }
 
@@ -1539,6 +1541,30 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 	if err := workspacebundle.Verify(data, desc.Digest); err != nil {
 		return err
 	}
+	return cli.putWorkspaceBundle(ctx, desc, int64(len(data)), func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	})
+}
+
+func (cli *clientImpl) putWorkspaceBundleFile(ctx context.Context, desc workspacebundle.Descriptor, archivePath string) error {
+	if err := workspacebundle.VerifyFile(archivePath, desc, workspacebundle.DefaultMaxCompressedSize); err != nil {
+		return err
+	}
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		return fmt.Errorf("stat workspace bundle: %w", err)
+	}
+	return cli.putWorkspaceBundle(ctx, desc, info.Size(), func() (io.ReadCloser, error) {
+		return os.Open(archivePath) //nolint:gosec // archivePath is created by PrepareDAGWorkspaceFile.
+	})
+}
+
+func (cli *clientImpl) putWorkspaceBundle(
+	ctx context.Context,
+	desc workspacebundle.Descriptor,
+	size int64,
+	open func() (io.ReadCloser, error),
+) error {
 	members, err := cli.getCoordinatorMembers(ctx)
 	if err != nil {
 		return err
@@ -1567,11 +1593,21 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 			continue
 		}
 
+		reader, err := open()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("open workspace bundle for coordinator %q: %w", member.ID, err))
+			continue
+		}
 		callCtx, cancel = context.WithTimeout(ctx, cli.config.RequestTimeout)
-		err = putWorkspaceBundleToMember(callCtx, memberClient, desc, data)
+		err = putWorkspaceBundleToMember(callCtx, memberClient, desc, reader, size)
 		cancel()
+		closeErr := reader.Close()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("upload workspace bundle to coordinator %q: %w", member.ID, err))
+			continue
+		}
+		if closeErr != nil {
+			errs = append(errs, fmt.Errorf("close workspace bundle for coordinator %q: %w", member.ID, closeErr))
 			continue
 		}
 		satisfied++
@@ -1593,29 +1629,32 @@ func hasWorkspaceBundleInMember(ctx context.Context, client *client, digest stri
 	return resp != nil && resp.Exists, nil
 }
 
-func putWorkspaceBundleToMember(ctx context.Context, client *client, desc workspacebundle.Descriptor, data []byte) error {
+func putWorkspaceBundleToMember(ctx context.Context, client *client, desc workspacebundle.Descriptor, reader io.Reader, size int64) error {
 	stream, err := client.client.PutWorkspaceBundle(ctx)
 	if err != nil {
 		return fmt.Errorf("open workspace bundle upload stream: %w", err)
 	}
 	protoDesc := descriptorToProto(desc)
-	for offset, sequence := 0, uint64(0); offset < len(data) || sequence == 0; sequence++ {
-		end := min(offset+workspaceBundleChunkSize, len(data))
+	for remaining, sequence := size, uint64(0); remaining > 0 || sequence == 0; sequence++ {
+		chunkSize := min(remaining, int64(workspaceBundleChunkSize))
 		chunk := &coordinatorv1.WorkspaceBundleChunk{
 			Sequence: sequence,
-			IsFinal:  end == len(data),
+			IsFinal:  chunkSize == remaining,
 		}
 		if sequence == 0 {
 			chunk.Bundle = protoDesc
 		}
-		if offset < len(data) {
-			chunk.Data = data[offset:end]
+		if chunkSize > 0 {
+			chunk.Data = make([]byte, chunkSize)
+			if _, err := io.ReadFull(reader, chunk.Data); err != nil {
+				return fmt.Errorf("read workspace bundle chunk: %w", err)
+			}
 		}
 		if err := stream.Send(chunk); err != nil {
 			return fmt.Errorf("send workspace bundle chunk: %w", err)
 		}
-		offset = end
-		if len(data) == 0 {
+		remaining -= chunkSize
+		if size == 0 {
 			break
 		}
 	}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -16,7 +16,6 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -342,7 +341,7 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	if err != nil {
 		return fmt.Errorf("load DAG for file dependency snapshot: %w", err)
 	}
-	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(dag, filepath.Join(cli.config.WorkspaceBundleDir, "staging"))
+	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(dag, cli.config.WorkspaceBundleDir)
 	if err != nil {
 		return err
 	}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/backoff"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/dispatch"
@@ -348,7 +349,7 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	if desc == nil {
 		return nil
 	}
-	defer func() { _ = os.Remove(archivePath) }()
+	defer func() { _ = fileutil.Remove(archivePath) }()
 	if err := cli.putWorkspaceBundleFile(ctx, *desc, archivePath); err != nil {
 		return fmt.Errorf("upload DAG file dependencies: %w", err)
 	}
@@ -1600,7 +1601,6 @@ func (cli *clientImpl) putWorkspaceBundle(
 		}
 		if closeErr != nil {
 			errs = append(errs, fmt.Errorf("close workspace bundle for coordinator %q: %w", member.ID, closeErr))
-			continue
 		}
 		satisfied++
 	}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -1547,14 +1547,7 @@ func (cli *clientImpl) PutWorkspaceBundle(ctx context.Context, desc workspacebun
 }
 
 func (cli *clientImpl) putWorkspaceBundleFile(ctx context.Context, desc workspacebundle.Descriptor, archivePath string) error {
-	if err := workspacebundle.VerifyFile(archivePath, desc, workspacebundle.DefaultMaxCompressedSize); err != nil {
-		return err
-	}
-	info, err := os.Stat(archivePath)
-	if err != nil {
-		return fmt.Errorf("stat workspace bundle: %w", err)
-	}
-	return cli.putWorkspaceBundle(ctx, desc, info.Size(), func() (io.ReadCloser, error) {
+	return cli.putWorkspaceBundle(ctx, desc, desc.Size, func() (io.ReadCloser, error) {
 		return os.Open(archivePath) //nolint:gosec // archivePath is created by PrepareDAGWorkspaceFile.
 	})
 }

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -281,6 +281,24 @@ func TestClientDispatch(t *testing.T) {
 	})
 }
 
+func TestClientDispatchRejectsFileDependenciesWithoutWorkspaceBundleDir(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "input.txt"), []byte("input"), 0o644))
+	dagFile := filepath.Join(root, "dag.yaml")
+	definition := "name: test\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n"
+
+	client := coordinator.New(&mockServiceMonitor{}, coordinator.DefaultConfig())
+	err := client.Dispatch(context.Background(), dispatch.DispatchRequest{Task: &dispatch.DispatchTask{
+		DAGRunID:   "run-1",
+		Target:     "test",
+		Definition: definition,
+		SourceFile: dagFile,
+	}})
+	require.ErrorContains(t, err, "workspace bundle directory is not configured")
+	assert.NoDirExists(t, filepath.Join(root, "staging"))
+}
+
 func TestClientPoll(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -5,6 +5,7 @@ package coordinator_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -73,6 +74,7 @@ func TestClientDispatch(t *testing.T) {
 		definition := "name: test\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n"
 		workspaceBundleDir := filepath.Join(t.TempDir(), "workspace-bundles")
 		stagingDir := filepath.Join(workspaceBundleDir, "staging")
+		dest := filepath.Join(t.TempDir(), "workspace")
 
 		var uploaded []byte
 		mockCoord := &mockCoordinatorService{
@@ -81,34 +83,47 @@ func TestClientDispatch(t *testing.T) {
 			},
 			putWorkspaceBundleFunc: func(stream coordinatorv1.CoordinatorService_PutWorkspaceBundleServer) error {
 				entries, err := os.ReadDir(stagingDir)
-				require.NoError(t, err)
-				require.Len(t, entries, 1)
+				if err != nil {
+					return fmt.Errorf("read workspace bundle staging directory: %w", err)
+				}
+				if len(entries) != 1 {
+					return fmt.Errorf("workspace bundle staging directory contains %d entries, want 1", len(entries))
+				}
 				for {
 					chunk, err := stream.Recv()
 					if err == io.EOF {
 						return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{Accepted: true})
 					}
-					require.NoError(t, err)
+					if err != nil {
+						return fmt.Errorf("receive workspace bundle chunk: %w", err)
+					}
 					uploaded = append(uploaded, chunk.Data...)
 				}
 			},
 			dispatchFunc: func(_ context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
-				assert.NotEmpty(t, req.Task.WorkspaceBundleDigest)
-				assert.Equal(t, int64(len(uploaded)), req.Task.WorkspaceBundleSize)
-				assert.Equal(t, "dag.yaml", req.Task.WorkspaceBundleDagPath)
 				if req.Task.WorkspaceBundleDigest == "" {
-					return &coordinatorv1.DispatchResponse{}, nil
+					return nil, fmt.Errorf("workspace bundle digest is empty")
 				}
-				dest := filepath.Join(t.TempDir(), "workspace")
-				require.NoError(t, workspacebundle.Extract(uploaded, dest, workspacebundle.Descriptor{
+				if req.Task.WorkspaceBundleSize != int64(len(uploaded)) {
+					return nil, fmt.Errorf("workspace bundle size is %d, want %d", req.Task.WorkspaceBundleSize, len(uploaded))
+				}
+				if req.Task.WorkspaceBundleDagPath != "dag.yaml" {
+					return nil, fmt.Errorf("workspace bundle DAG path is %q, want dag.yaml", req.Task.WorkspaceBundleDagPath)
+				}
+				if err := workspacebundle.Extract(uploaded, dest, workspacebundle.Descriptor{
 					Digest:  req.Task.WorkspaceBundleDigest,
 					Size:    req.Task.WorkspaceBundleSize,
 					DAGPath: req.Task.WorkspaceBundleDagPath,
-				}, workspacebundle.DefaultLimits()))
-				assert.FileExists(t, filepath.Join(dest, "input.txt"))
+				}, workspacebundle.DefaultLimits()); err != nil {
+					return nil, fmt.Errorf("extract uploaded workspace bundle: %w", err)
+				}
 				actualDAG, err := os.ReadFile(filepath.Join(dest, "dag.yaml"))
-				require.NoError(t, err)
-				assert.Equal(t, definition, string(actualDAG))
+				if err != nil {
+					return nil, fmt.Errorf("read uploaded DAG: %w", err)
+				}
+				if string(actualDAG) != definition {
+					return nil, fmt.Errorf("uploaded DAG does not match its definition")
+				}
 				return &coordinatorv1.DispatchResponse{}, nil
 			},
 		}
@@ -130,6 +145,7 @@ func TestClientDispatch(t *testing.T) {
 			SourceFile: dagFile,
 		}})
 		require.NoError(t, err)
+		assert.FileExists(t, filepath.Join(dest, "input.txt"))
 		entries, err := os.ReadDir(stagingDir)
 		require.NoError(t, err)
 		assert.Empty(t, entries)

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -71,6 +71,8 @@ func TestClientDispatch(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(root, "input.txt"), []byte("input"), 0o644))
 		dagFile := filepath.Join(root, "dag.yaml")
 		definition := "name: test\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n"
+		workspaceBundleDir := filepath.Join(t.TempDir(), "workspace-bundles")
+		stagingDir := filepath.Join(workspaceBundleDir, "staging")
 
 		var uploaded []byte
 		mockCoord := &mockCoordinatorService{
@@ -78,6 +80,9 @@ func TestClientDispatch(t *testing.T) {
 				return &coordinatorv1.HasWorkspaceBundleResponse{}, nil
 			},
 			putWorkspaceBundleFunc: func(stream coordinatorv1.CoordinatorService_PutWorkspaceBundleServer) error {
+				entries, err := os.ReadDir(stagingDir)
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
 				for {
 					chunk, err := stream.Recv()
 					if err == io.EOF {
@@ -113,6 +118,7 @@ func TestClientDispatch(t *testing.T) {
 		host, port := parseHostPort(addr)
 		config := coordinator.DefaultConfig()
 		config.MaxRetries = 0
+		config.WorkspaceBundleDir = workspaceBundleDir
 		client := coordinator.New(&mockServiceMonitor{members: []serviceregistry.HostInfo{{
 			ID: "coord-1", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive,
 		}}}, config)
@@ -124,6 +130,9 @@ func TestClientDispatch(t *testing.T) {
 			SourceFile: dagFile,
 		}})
 		require.NoError(t, err)
+		entries, err := os.ReadDir(stagingDir)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
 	})
 
 	t.Run("Success", func(t *testing.T) {

--- a/internal/service/coordinator/config.go
+++ b/internal/service/coordinator/config.go
@@ -11,6 +11,8 @@ import (
 
 // Config holds configuration for the coordinator client
 type Config struct {
+	WorkspaceBundleDir string
+
 	// TLS configuration
 	Insecure      bool   // Use insecure connection (default: true)
 	CertFile      string // Client certificate

--- a/internal/service/coordinator/config.go
+++ b/internal/service/coordinator/config.go
@@ -11,6 +11,7 @@ import (
 
 // Config holds configuration for the coordinator client
 type Config struct {
+	// WorkspaceBundleDir is required when dispatching DAGs with file dependencies.
 	WorkspaceBundleDir string
 
 	// TLS configuration

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -56,7 +56,7 @@ type heartbeatInfo struct {
 }
 
 // defaultStaleHeartbeatThreshold is the default duration after which a worker's heartbeat is considered stale.
-const defaultStaleHeartbeatThreshold = 30 * time.Second
+const defaultStaleHeartbeatThreshold = dispatch.DefaultStaleWorkerHeartbeatThreshold
 
 // defaultStaleLeaseThreshold is the shared default duration after which a
 // distributed run's lease is considered stale.
@@ -1477,7 +1477,7 @@ func (h *Handler) listHealthyWorkers(ctx context.Context) ([]dispatch.WorkerHear
 	now := time.Now().UTC()
 	healthy := make([]dispatch.WorkerHeartbeatRecord, 0, len(records))
 	for _, record := range records {
-		if now.Sub(record.LastHeartbeatTime()) <= h.staleHeartbeatThreshold {
+		if dispatch.WorkerHeartbeatFresh(record, now, h.staleHeartbeatThreshold) {
 			healthy = append(healthy, record)
 		}
 	}
@@ -1592,10 +1592,7 @@ func (h *Handler) leaseRefreshWriteInterval() time.Duration {
 
 func anyWorkerMatches(workers []dispatch.WorkerHeartbeatRecord, selector map[string]string, targetWorkerID string) bool {
 	for _, worker := range workers {
-		if targetWorkerID != "" && worker.WorkerID != targetWorkerID {
-			continue
-		}
-		if matchesSelector(worker.Labels, selector) {
+		if dispatch.WorkerHeartbeatMatches(worker, selector, targetWorkerID) {
 			return true
 		}
 	}

--- a/internal/service/coordinator/workspace_bundle_handler.go
+++ b/internal/service/coordinator/workspace_bundle_handler.go
@@ -4,7 +4,6 @@
 package coordinator
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -23,57 +22,81 @@ func (h *Handler) PutWorkspaceBundle(stream coordinatorv1.CoordinatorService_Put
 		return status.Error(codes.FailedPrecondition, "workspace bundle store is not configured")
 	}
 
-	limits := workspacebundle.DefaultLimits()
-	var desc workspacebundle.Descriptor
-	var buf bytes.Buffer
-	var sequence uint64
+	first, err := stream.Recv()
+	if errors.Is(err, io.EOF) {
+		return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{
+			Accepted: false,
+			Error:    "workspace bundle descriptor is required",
+		})
+	}
+	if err != nil {
+		return status.Error(codes.Internal, "failed to receive workspace bundle: "+err.Error())
+	}
+	if first == nil || first.Sequence != 0 {
+		return status.Error(codes.InvalidArgument, "workspace bundle upload must start at sequence 0")
+	}
+	if first.Bundle == nil {
+		return status.Error(codes.InvalidArgument, "workspace bundle descriptor is required")
+	}
 
-	for {
-		chunk, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			if desc.Digest == "" {
-				return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{
-					Accepted: false,
-					Error:    "workspace bundle descriptor is required",
-				})
-			}
-			data := buf.Bytes()
-			if err := h.workspaceBundleStore.Put(stream.Context(), desc, data); err != nil {
-				return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{
-					Accepted: false,
-					Error:    err.Error(),
-				})
-			}
-			return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{Accepted: true})
+	reader := &workspaceBundleUploadReader{
+		stream:   stream,
+		pending:  first.Data,
+		sequence: 1,
+		read:     int64(len(first.Data)),
+		max:      workspacebundle.DefaultMaxCompressedSize,
+	}
+	if reader.read > reader.max {
+		return status.Error(codes.InvalidArgument, fmt.Sprintf("workspace bundle exceeds compressed size limit %d", reader.max))
+	}
+	if err := h.workspaceBundleStore.PutReader(stream.Context(), descriptorFromProto(first.Bundle), reader); err != nil {
+		if status.Code(err) != codes.Unknown {
+			return err
 		}
+		return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{
+			Accepted: false,
+			Error:    err.Error(),
+		})
+	}
+	return stream.SendAndClose(&coordinatorv1.PutWorkspaceBundleResponse{Accepted: true})
+}
+
+type workspaceBundleUploadReader struct {
+	stream   coordinatorv1.CoordinatorService_PutWorkspaceBundleServer
+	pending  []byte
+	sequence uint64
+	read     int64
+	max      int64
+}
+
+func (r *workspaceBundleUploadReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for len(r.pending) == 0 {
+		chunk, err := r.stream.Recv()
 		if err != nil {
-			return status.Error(codes.Internal, "failed to receive workspace bundle: "+err.Error())
+			return 0, err
 		}
 		if chunk == nil {
 			continue
 		}
-		if chunk.Sequence != sequence {
-			return status.Error(codes.InvalidArgument, fmt.Sprintf("workspace bundle sequence mismatch: got %d, want %d", chunk.Sequence, sequence))
+		if chunk.Sequence != r.sequence {
+			return 0, status.Error(codes.InvalidArgument, fmt.Sprintf("workspace bundle sequence mismatch: got %d, want %d", chunk.Sequence, r.sequence))
 		}
-		sequence++
+		r.sequence++
 		if chunk.Bundle != nil {
-			next := descriptorFromProto(chunk.Bundle)
-			if desc.Digest == "" {
-				desc = next
-			} else if desc.Digest != next.Digest {
-				return status.Error(codes.InvalidArgument, "workspace bundle descriptor changed during upload")
-			}
+			return 0, status.Error(codes.InvalidArgument, "workspace bundle descriptor is only allowed in the first chunk")
 		}
-		if len(chunk.Data) == 0 {
-			continue
+		r.read += int64(len(chunk.Data))
+		if r.read > r.max {
+			return 0, status.Error(codes.InvalidArgument, fmt.Sprintf("workspace bundle exceeds compressed size limit %d", r.max))
 		}
-		if int64(buf.Len()+len(chunk.Data)) > limits.MaxCompressedSize {
-			return status.Error(codes.InvalidArgument, fmt.Sprintf("workspace bundle exceeds compressed size limit %d", limits.MaxCompressedSize))
-		}
-		if _, err := buf.Write(chunk.Data); err != nil {
-			return status.Error(codes.Internal, "failed to buffer workspace bundle: "+err.Error())
-		}
+		r.pending = chunk.Data
 	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
 }
 
 func (h *Handler) HasWorkspaceBundle(_ context.Context, req *coordinatorv1.HasWorkspaceBundleRequest) (*coordinatorv1.HasWorkspaceBundleResponse, error) {
@@ -95,31 +118,35 @@ func (h *Handler) GetWorkspaceBundle(req *coordinatorv1.GetWorkspaceBundleReques
 	if req == nil || !workspacebundle.ValidDigest(req.Digest) {
 		return status.Error(codes.InvalidArgument, "valid workspace bundle digest is required")
 	}
-	data, err := h.workspaceBundleStore.Get(stream.Context(), req.Digest)
+	file, size, err := h.workspaceBundleStore.Open(stream.Context(), req.Digest)
 	if err != nil {
 		return status.Error(codes.NotFound, "workspace bundle not found: "+err.Error())
 	}
+	defer func() { _ = file.Close() }()
 	desc := &coordinatorv1.WorkspaceBundle{
 		Digest: req.Digest,
-		Size:   int64(len(data)),
+		Size:   size,
 	}
-	for offset, sequence := 0, uint64(0); offset < len(data) || sequence == 0; sequence++ {
-		end := min(offset+workspaceBundleChunkSize, len(data))
+	for remaining, sequence := size, uint64(0); remaining > 0 || sequence == 0; sequence++ {
+		chunkSize := min(remaining, int64(workspaceBundleChunkSize))
 		chunk := &coordinatorv1.WorkspaceBundleChunk{
 			Sequence: sequence,
-			IsFinal:  end == len(data),
+			IsFinal:  chunkSize == remaining,
 		}
 		if sequence == 0 {
 			chunk.Bundle = desc
 		}
-		if offset < len(data) {
-			chunk.Data = data[offset:end]
+		if chunkSize > 0 {
+			chunk.Data = make([]byte, chunkSize)
+			if _, err := io.ReadFull(file, chunk.Data); err != nil {
+				return status.Error(codes.Internal, "failed to read workspace bundle: "+err.Error())
+			}
 		}
 		if err := stream.Send(chunk); err != nil {
 			return status.Error(codes.Internal, "failed to send workspace bundle: "+err.Error())
 		}
-		offset = end
-		if len(data) == 0 {
+		remaining -= chunkSize
+		if size == 0 {
 			break
 		}
 	}

--- a/internal/service/coordinator/workspace_bundle_handler.go
+++ b/internal/service/coordinator/workspace_bundle_handler.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	coordinatorv1 "github.com/dagucloud/dagu/v2/proto/coordinator/v1"
@@ -120,7 +121,10 @@ func (h *Handler) GetWorkspaceBundle(req *coordinatorv1.GetWorkspaceBundleReques
 	}
 	file, size, err := h.workspaceBundleStore.Open(stream.Context(), req.Digest)
 	if err != nil {
-		return status.Error(codes.NotFound, "workspace bundle not found: "+err.Error())
+		if errors.Is(err, fs.ErrNotExist) {
+			return status.Errorf(codes.NotFound, "workspace bundle not found: %v", err)
+		}
+		return status.Errorf(codes.Internal, "failed to open workspace bundle: %v", err)
 	}
 	defer func() { _ = file.Close() }()
 	desc := &coordinatorv1.WorkspaceBundle{

--- a/internal/service/coordinator/workspace_bundle_handler_test.go
+++ b/internal/service/coordinator/workspace_bundle_handler_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"testing"
+
+	coordinatorv1 "github.com/dagucloud/dagu/v2/proto/coordinator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestWorkspaceBundleUploadAndDownloadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	data := bytes.Repeat([]byte("workspace"), workspaceBundleChunkSize/len("workspace")+1)
+	digest := workspaceBundleDigest(data)
+	handler := NewHandler(HandlerConfig{WorkspaceBundleDir: t.TempDir()})
+	upload := &workspaceBundleUploadStream{
+		ctx: context.Background(),
+		chunks: []*coordinatorv1.WorkspaceBundleChunk{
+			{Sequence: 0, Bundle: &coordinatorv1.WorkspaceBundle{Digest: digest, Size: int64(len(data))}, Data: data[:workspaceBundleChunkSize]},
+			{Sequence: 1, Data: data[workspaceBundleChunkSize:], IsFinal: true},
+		},
+	}
+	require.NoError(t, handler.PutWorkspaceBundle(upload))
+	require.True(t, upload.response.Accepted)
+
+	download := &workspaceBundleDownloadStream{ctx: context.Background()}
+	require.NoError(t, handler.GetWorkspaceBundle(&coordinatorv1.GetWorkspaceBundleRequest{Digest: digest}, download))
+	require.Len(t, download.chunks, 2)
+	assert.Equal(t, byte('w'), download.chunks[0].Data[0])
+	assert.Equal(t, data, append(download.chunks[0].Data, download.chunks[1].Data...))
+}
+
+func TestPutWorkspaceBundleRejectsDescriptorAfterFirstChunk(t *testing.T) {
+	t.Parallel()
+
+	digest := workspaceBundleDigest(nil)
+	handler := NewHandler(HandlerConfig{WorkspaceBundleDir: t.TempDir()})
+	upload := &workspaceBundleUploadStream{
+		ctx: context.Background(),
+		chunks: []*coordinatorv1.WorkspaceBundleChunk{
+			{Sequence: 0, Bundle: &coordinatorv1.WorkspaceBundle{Digest: digest}},
+			{Sequence: 1, Bundle: &coordinatorv1.WorkspaceBundle{Digest: digest}},
+		},
+	}
+
+	err := handler.PutWorkspaceBundle(upload)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func workspaceBundleDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+type workspaceBundleUploadStream struct {
+	grpc.ServerStream
+	ctx      context.Context
+	chunks   []*coordinatorv1.WorkspaceBundleChunk
+	index    int
+	response *coordinatorv1.PutWorkspaceBundleResponse
+}
+
+func (s *workspaceBundleUploadStream) Context() context.Context { return s.ctx }
+
+func (s *workspaceBundleUploadStream) Recv() (*coordinatorv1.WorkspaceBundleChunk, error) {
+	if s.index == len(s.chunks) {
+		return nil, io.EOF
+	}
+	chunk := s.chunks[s.index]
+	s.index++
+	return chunk, nil
+}
+
+func (s *workspaceBundleUploadStream) SendAndClose(response *coordinatorv1.PutWorkspaceBundleResponse) error {
+	s.response = response
+	return nil
+}
+
+type workspaceBundleDownloadStream struct {
+	grpc.ServerStream
+	ctx    context.Context
+	chunks []*coordinatorv1.WorkspaceBundleChunk
+}
+
+func (s *workspaceBundleDownloadStream) Context() context.Context { return s.ctx }
+
+func (s *workspaceBundleDownloadStream) Send(chunk *coordinatorv1.WorkspaceBundleChunk) error {
+	s.chunks = append(s.chunks, chunk)
+	return nil
+}

--- a/internal/service/coordinator/workspace_bundle_handler_test.go
+++ b/internal/service/coordinator/workspace_bundle_handler_test.go
@@ -9,8 +9,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	coordinatorv1 "github.com/dagucloud/dagu/v2/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,6 +61,43 @@ func TestPutWorkspaceBundleRejectsDescriptorAfterFirstChunk(t *testing.T) {
 	err := handler.PutWorkspaceBundle(upload)
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestGetWorkspaceBundleReportsCorruptStoredBundle(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("workspace")
+	digest := workspaceBundleDigest(data)
+	dir := t.TempDir()
+	store := workspacebundle.NewStore(dir, workspacebundle.DefaultLimits())
+	require.NoError(t, store.Put(t.Context(), workspacebundle.Descriptor{
+		Digest: digest,
+		Size:   int64(len(data)),
+	}, data))
+	paths, err := filepath.Glob(filepath.Join(dir, "*", "*"))
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	require.NoError(t, os.WriteFile(paths[0], []byte("corrupt"), 0o600))
+
+	handler := NewHandler(HandlerConfig{WorkspaceBundleDir: dir})
+	err = handler.GetWorkspaceBundle(
+		&coordinatorv1.GetWorkspaceBundleRequest{Digest: digest},
+		&workspaceBundleDownloadStream{ctx: context.Background()},
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestGetWorkspaceBundleReportsMissingBundle(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHandler(HandlerConfig{WorkspaceBundleDir: t.TempDir()})
+	err := handler.GetWorkspaceBundle(
+		&coordinatorv1.GetWorkspaceBundleRequest{Digest: workspaceBundleDigest([]byte("missing"))},
+		&workspaceBundleDownloadStream{ctx: context.Background()},
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func workspaceBundleDigest(data []byte) string {

--- a/internal/service/frontend/api/v1/dagruns.go
+++ b/internal/service/frontend/api/v1/dagruns.go
@@ -209,7 +209,12 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
+	cleanupOnReturn := true
+	defer func() {
+		if cleanupOnReturn {
+			cleanup()
+		}
+	}()
 
 	if err := a.requireDAGWriteForWorkspace(ctx, runtimeWorkspaceName(dag, labels)); err != nil {
 		return nil, err
@@ -230,7 +235,16 @@ func (a *API) ExecuteDAGRunFromSpec(ctx context.Context, request api.ExecuteDAGR
 		return nil, err
 	}
 
-	if err := a.startDAGRun(ctx, dag, params, dagRunId, valueOf(request.Body.Name), labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
+	started, err := a.startDAGRun(ctx, dag, params, dagRunId, valueOf(request.Body.Name), labels, profileName, valueOf(request.Body.NoReuse))
+	if started != nil {
+		cleanupOnReturn = false
+		go func() {
+			for range started.Done {
+			}
+			cleanup()
+		}()
+	}
+	if err != nil {
 		return nil, &Error{
 			HTTPStatus: http.StatusInternalServerError,
 			Code:       api.ErrorCodeInternalError,

--- a/internal/service/frontend/api/v1/dagruns_test.go
+++ b/internal/service/frontend/api/v1/dagruns_test.go
@@ -1445,8 +1445,7 @@ func TestRescheduleDAGRunFromInlineStartUsesPersistedSnapshot(t *testing.T) {
 		}
 	}))
 
-	runID, dagLocation := test.CreateInlineDAGRunForReschedule(t, server, "inline_reschedule_start", false)
-	require.NoFileExists(t, dagLocation)
+	runID := test.CreateInlineDAGRunForReschedule(t, server, "inline_reschedule_start", false)
 	assertRescheduleSpecSourceFlag(t, server, "inline_reschedule_start", runID, false)
 
 	rescheduledRunID := rescheduleInlineDAGRun(t, server, "inline_reschedule_start", runID)
@@ -1462,8 +1461,7 @@ func TestRescheduleDAGRunFromInlineEnqueueUsesPersistedSnapshot(t *testing.T) {
 		}
 	}))
 
-	runID, dagLocation := test.CreateInlineDAGRunForReschedule(t, server, "inline_reschedule_enqueue", true)
-	require.NoFileExists(t, dagLocation)
+	runID := test.CreateInlineDAGRunForReschedule(t, server, "inline_reschedule_enqueue", true)
 	assertRescheduleSpecSourceFlag(t, server, "inline_reschedule_enqueue", runID, false)
 
 	rescheduledRunID := rescheduleInlineDAGRun(t, server, "inline_reschedule_enqueue", runID)

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1604,6 +1604,7 @@ func (a *API) startPreparedDAGRunWithOptions(
 		NameOverride: opts.nameOverride,
 		FromRunID:    fromRunID,
 		Target:       target,
+		SourceFile:   &dag.SourceFile,
 		TriggerType:  triggerTypeStr,
 		TriggerActor: opts.triggerActor,
 		Labels:       opts.labels,

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -1066,7 +1066,7 @@ func (a *API) ExecuteDAG(ctx context.Context, request api.ExecuteDAGRequestObjec
 		return nil, err
 	}
 
-	if err := a.startDAGRun(ctx, dag, params, dagRunId, nameOverride, labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
+	if _, err := a.startDAGRun(ctx, dag, params, dagRunId, nameOverride, labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
 		return nil, fmt.Errorf("error starting dag-run: %w", err)
 	}
 
@@ -1163,7 +1163,7 @@ func (a *API) ExecuteDAGSync(ctx context.Context, request api.ExecuteDAGSyncRequ
 		return nil, err
 	}
 
-	if err := a.startDAGRun(ctx, dag, params, dagRunId, nameOverride, labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
+	if _, err := a.startDAGRun(ctx, dag, params, dagRunId, nameOverride, labels, profileName, valueOf(request.Body.NoReuse)); err != nil {
 		return nil, fmt.Errorf("error starting dag-run: %w", err)
 	}
 
@@ -1264,7 +1264,12 @@ func (a *API) readDAGRunStatusForSync(ctx context.Context, dag *ir.DAG, dagRunID
 	return status, nil
 }
 
-func (a *API) startDAGRun(ctx context.Context, dag *ir.DAG, params, dagRunID, nameOverride, labels, profileName string, noReuse bool) error {
+func (a *API) startDAGRun(
+	ctx context.Context,
+	dag *ir.DAG,
+	params, dagRunID, nameOverride, labels, profileName string,
+	noReuse bool,
+) (*launcher.StartResult, error) {
 	return a.startDAGRunWithOptions(ctx, dag, startDAGRunOptions{
 		params:       params,
 		dagRunID:     dagRunID,
@@ -1526,12 +1531,12 @@ func (a *API) dispatchStartToCoordinator(ctx context.Context, dag *ir.DAG, opts 
 	return nil
 }
 
-func (a *API) startDAGRunWithOptions(ctx context.Context, dag *ir.DAG, opts startDAGRunOptions) error {
+func (a *API) startDAGRunWithOptions(ctx context.Context, dag *ir.DAG, opts startDAGRunOptions) (*launcher.StartResult, error) {
 	resolvedDAG, err := spec.ResolveRuntimeParams(ctx, dag, opts.params, spec.ResolveRuntimeParamsOptions{
 		BaseConfig: a.config.Paths.BaseConfig,
 	})
 	if err != nil {
-		return &Error{
+		return nil, &Error{
 			HTTPStatus: http.StatusBadRequest,
 			Code:       api.ErrorCodeBadRequest,
 			Message:    err.Error(),
@@ -1540,13 +1545,13 @@ func (a *API) startDAGRunWithOptions(ctx context.Context, dag *ir.DAG, opts star
 	dag = resolvedDAG
 
 	if err := buildErrorsToAPIError(dag.BuildErrors); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := spec.ValidateStartParams(dag.DefaultParams, spec.StartParamInput{
 		RawParams: opts.params,
 	}); err != nil {
-		return &Error{
+		return nil, &Error{
 			HTTPStatus: http.StatusBadRequest,
 			Code:       api.ErrorCodeBadRequest,
 			Message:    err.Error(),
@@ -1561,17 +1566,17 @@ func (a *API) startPreparedDAGRunWithOptions(
 	dag *ir.DAG,
 	opts startDAGRunOptions,
 	dispatchParams string,
-) error {
+) (*launcher.StartResult, error) {
 	// Check if this DAG should be dispatched to the coordinator for distributed execution
 	if dispatch.ShouldDispatchToCoordinator(dag, a.coordinatorCli != nil, a.defaultExecMode) {
 		if dag.Type == ir.TypeBuild {
-			return buildRequiresLocalAPIError()
+			return nil, buildRequiresLocalAPIError()
 		}
 		timeout := 10 * time.Second
 		if osrt.GOOS == "windows" {
 			timeout = 20 * time.Second
 		}
-		return a.dispatchStartToCoordinator(ctx, dag, opts, dispatchParams, timeout)
+		return nil, a.dispatchStartToCoordinator(ctx, dag, opts, dispatchParams, timeout)
 	}
 
 	// Only pass trigger type if it's a known value (not TriggerTypeUnknown)
@@ -1585,7 +1590,7 @@ func (a *API) startPreparedDAGRunWithOptions(
 		if dag.Location == "" || fileMissing(dag.Location) {
 			tempPath, err := writeInlineRescheduleSpec(dag.Name, opts.dagRunID, dag.YamlData)
 			if err != nil {
-				return fmt.Errorf("error preparing inline dag snapshot: %w", err)
+				return nil, fmt.Errorf("error preparing inline dag snapshot: %w", err)
 			}
 			dag.Location = tempPath
 			target = tempPath
@@ -1608,7 +1613,7 @@ func (a *API) startPreparedDAGRunWithOptions(
 	spec.Env = append(spec.Env, a.managedOpenCodeEnv(ctx, dag)...)
 	started, err := launcher.StartProcess(ctx, spec)
 	if err != nil {
-		return fmt.Errorf("error starting DAG: %w", err)
+		return nil, fmt.Errorf("error starting DAG: %w", err)
 	}
 
 	timeout := 10 * time.Second
@@ -1616,7 +1621,7 @@ func (a *API) startPreparedDAGRunWithOptions(
 		timeout = 20 * time.Second
 	}
 
-	return a.waitForLocalDAGStart(ctx, dag, opts.dagRunID, started, timeout)
+	return started, a.waitForLocalDAGStart(ctx, dag, opts.dagRunID, started, timeout)
 }
 
 func buildRequiresLocalAPIError() *Error {

--- a/internal/service/frontend/api/v1/dags_test.go
+++ b/internal/service/frontend/api/v1/dags_test.go
@@ -838,7 +838,7 @@ steps:
 			server.DAGRunRepository,
 			server.ProcRepository,
 			scheduler.NewDAGExecutor(
-				coordinator.New(server.ServiceRegistry, coordinator.DefaultConfig()),
+				coordinator.New(server.ServiceRegistry, test.CoordinatorClientConfig(server.Config.Paths.DataDir)),
 				server.SubCmdBuilder,
 				server.Config.DefaultExecMode,
 				server.Config.Paths.BaseConfig,

--- a/internal/service/scheduler/dag_executor_test.go
+++ b/internal/service/scheduler/dag_executor_test.go
@@ -26,7 +26,7 @@ steps:
   - name: test-step
     run: echo "test"
 `)
-	coordinatorCli := coordinator.New(th.ServiceRegistry, coordinator.DefaultConfig())
+	coordinatorCli := coordinator.New(th.ServiceRegistry, test.CoordinatorClientConfig(th.Config.Paths.DataDir))
 
 	dagExecutor := scheduler.NewDAGExecutor(coordinatorCli, th.SubCmdBuilder, config.ExecutionModeLocal, "")
 	t.Cleanup(func() {

--- a/internal/service/scheduler/queue_conditions_external_test.go
+++ b/internal/service/scheduler/queue_conditions_external_test.go
@@ -396,6 +396,32 @@ func TestQueueProcessorWaitsForFreshWorkerBeforeDispatch(t *testing.T) {
 	require.Zero(t, dispatcher.callCount.Load())
 }
 
+func TestQueueProcessorUsesConfiguredWorkerHeartbeatFreshness(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+		scheduler.WithWorkerHeartbeatStaleThreshold(time.Minute),
+	)
+	f.enqueueRun("waiting-run", nil)
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().Add(-45 * time.Second).UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	require.Equal(t, int32(1), dispatcher.callCount.Load())
+}
+
 func TestQueueProcessorRecordsAssignmentUnavailableWhenWorkerHeartbeatsCannotBeRead(t *testing.T) {
 	t.Parallel()
 
@@ -444,6 +470,44 @@ func TestQueueProcessorContinuesPastItemWithoutMatchingWorker(t *testing.T) {
 	requireQueuedConditions(t, f.readStatus("gpu-run"), noMatchingWorkerConditions()...)
 	require.Equal(t, int32(1), dispatcher.callCount.Load())
 	require.Equal(t, int32(1), heartbeatStore.listCount.Load())
+}
+
+func TestQueueProcessorBatchesWorkerConditionQueueValidation(t *testing.T) {
+	t.Parallel()
+
+	var queueStore *countingQueueStore
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithConfig(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		&queueConditionDispatcher{},
+		queueConditionFixtureConfig{
+			queueStore: func(base queuedomain.QueueStore) queuedomain.QueueStore {
+				queueStore = &countingQueueStore{QueueStore: base}
+				return queueStore
+			},
+		},
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	for _, runID := range []string{"first-run", "second-run", "third-run"} {
+		f.enqueueRun(runID, nil)
+	}
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Equal(t, int32(2), queueStore.listCount.Load())
+
+	queueStore.listCount.Store(0)
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Equal(t, int32(2), queueStore.listCount.Load())
 }
 
 func TestQueueProcessorRecordsNoAvailableWorkerCondition(t *testing.T) {
@@ -1176,6 +1240,16 @@ type failingWorkerHeartbeatStore struct {
 
 func (s *failingWorkerHeartbeatStore) List(context.Context) ([]dispatch.WorkerHeartbeatRecord, error) {
 	return nil, s.err
+}
+
+type countingQueueStore struct {
+	queuedomain.QueueStore
+	listCount atomic.Int32
+}
+
+func (s *countingQueueStore) List(ctx context.Context, queueName string) ([]queuedomain.QueuedItemData, error) {
+	s.listCount.Add(1)
+	return s.QueueStore.List(ctx, queueName)
 }
 
 type queueConditionQueueStore struct {

--- a/internal/service/scheduler/queue_conditions_external_test.go
+++ b/internal/service/scheduler/queue_conditions_external_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -334,6 +335,115 @@ func TestQueueProcessorRecordsNoMatchingWorkerCondition(t *testing.T) {
 	status := f.readStatus("waiting-run")
 	requireQueuedConditions(t, status, noMatchingWorkerConditions()...)
 	require.Equal(t, 1, f.casCount("waiting-run"))
+}
+
+func TestQueueProcessorWaitsForMatchingWorkerBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	f.dag.SourceFile = filepath.Join(t.TempDir(), "dag.yaml")
+	f.dag.Steps[0].Dependencies = []string{"large-dependency.bin"}
+	f.enqueueRun("waiting-run", nil)
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	requireQueuedConditions(t, f.readStatus("waiting-run"), noMatchingWorkerConditions()...)
+	require.Zero(t, dispatcher.callCount.Load())
+	items, err := f.queueStore.List(f.ctx, f.dag.Name)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
+func TestQueueProcessorWaitsForFreshWorkerBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.enqueueRun("waiting-run", nil)
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "stale-worker",
+		LastHeartbeatAt: time.Now().Add(-2 * dispatch.DefaultStaleWorkerHeartbeatThreshold).UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	requireQueuedConditions(t, f.readStatus("waiting-run"), noAvailableWorkerConditions()...)
+	require.Zero(t, dispatcher.callCount.Load())
+}
+
+func TestQueueProcessorRecordsAssignmentUnavailableWhenWorkerHeartbeatsCannotBeRead(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(&failingWorkerHeartbeatStore{err: errors.New("heartbeat store unavailable")}),
+	)
+	f.enqueueRun("waiting-run", nil)
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	requireQueuedConditions(t, f.readStatus("waiting-run"), assignmentUnavailableConditions()...)
+	require.Zero(t, dispatcher.callCount.Load())
+}
+
+func TestQueueProcessorContinuesPastItemWithoutMatchingWorker(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := &countingWorkerHeartbeatStore{WorkerHeartbeatStore: store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)}
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	f.enqueueRun("gpu-run", nil)
+	f.dag.WorkerSelector = map[string]string{"type": "cpu"}
+	f.enqueueRun("cpu-run", nil)
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	requireQueuedConditions(t, f.readStatus("gpu-run"), noMatchingWorkerConditions()...)
+	require.Equal(t, int32(1), dispatcher.callCount.Load())
+	require.Equal(t, int32(1), heartbeatStore.listCount.Load())
 }
 
 func TestQueueProcessorRecordsNoAvailableWorkerCondition(t *testing.T) {
@@ -1029,9 +1139,11 @@ func (s *queueConditionDispatchTaskStore) HasOutstandingAttempt(_ context.Contex
 
 type queueConditionDispatcher struct {
 	dispatchErr error
+	callCount   atomic.Int32
 }
 
 func (d *queueConditionDispatcher) Dispatch(context.Context, dispatch.DispatchRequest) error {
+	d.callCount.Add(1)
 	return d.dispatchErr
 }
 
@@ -1045,6 +1157,25 @@ func (d *queueConditionDispatcher) GetDAGRunStatus(context.Context, string, stri
 
 func (d *queueConditionDispatcher) RequestCancel(context.Context, string, string, *ir.DAGRunRef) error {
 	return nil
+}
+
+type countingWorkerHeartbeatStore struct {
+	dispatch.WorkerHeartbeatStore
+	listCount atomic.Int32
+}
+
+func (s *countingWorkerHeartbeatStore) List(ctx context.Context) ([]dispatch.WorkerHeartbeatRecord, error) {
+	s.listCount.Add(1)
+	return s.WorkerHeartbeatStore.List(ctx)
+}
+
+type failingWorkerHeartbeatStore struct {
+	dispatch.WorkerHeartbeatStore
+	err error
+}
+
+func (s *failingWorkerHeartbeatStore) List(context.Context) ([]dispatch.WorkerHeartbeatRecord, error) {
+	return nil, s.err
 }
 
 type queueConditionQueueStore struct {

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -39,6 +39,7 @@ type queueDispatchDeps struct {
 	leaseStaleThreshold    time.Duration
 	isClosed               func() bool
 	wakeUp                 func()
+	acquireDispatchHandoff func(context.Context) (func(), bool)
 }
 
 // queueDispatcher owns queue-item dispatch decisions after a queue has capacity.
@@ -55,6 +56,7 @@ type queueDispatcher struct {
 	leaseStaleThreshold    time.Duration
 	isClosed               func() bool
 	wakeUp                 func()
+	acquireDispatchHandoff func(context.Context) (func(), bool)
 
 	queuedConditionCursorMu sync.Mutex
 	queuedConditionCursor   map[string]int
@@ -294,6 +296,11 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 	if deps.wakeUp == nil {
 		deps.wakeUp = func() {}
 	}
+	if deps.acquireDispatchHandoff == nil {
+		deps.acquireDispatchHandoff = func(context.Context) (func(), bool) {
+			return func() {}, true
+		}
+	}
 	return &queueDispatcher{
 		queueStore:             deps.queueStore,
 		dagRunRepository:       deps.dagRunRepository,
@@ -307,6 +314,7 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 		leaseStaleThreshold:    deps.leaseStaleThreshold,
 		isClosed:               deps.isClosed,
 		wakeUp:                 deps.wakeUp,
+		acquireDispatchHandoff: deps.acquireDispatchHandoff,
 		queuedConditionCursor:  make(map[string]int),
 	}
 }
@@ -827,49 +835,11 @@ func (d *queueDispatcher) dispatchAndWaitForStartupWithConditions(
 	admissionReservationToken string,
 	conditionStage *queuedConditionStage,
 ) bool {
-	policy := backoff.NewExponentialBackoffPolicy(d.backoffConfig.InitialInterval)
-	policy.MaxInterval = d.backoffConfig.MaxInterval
-	policy.MaxRetries = d.backoffConfig.MaxRetries
-	retryCtx := backoff.WithRetryFailureLogLevel(ctx, slog.LevelInfo)
-
 	launchedAt := time.Now()
-	var started bool
-	dispatched := false
+	defer d.wakeUp()
 
-	operation := func(ctx context.Context) error {
-		if err := d.checkContextAndQuit(ctx); err != nil {
-			return err
-		}
-
-		if !dispatched {
-			err := d.dagExecutor.ExecuteDAGWithAdmission(ctx, dag, dispatch.DispatchOperationRetry,
-				runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime, admissionReservationToken)
-			if err != nil {
-				if _, ok := errors.AsType[*queuedomain.StaleQueueDispatchError](err); ok {
-					return backoff.PermanentError(err)
-				}
-				if errors.Is(err, backoff.ErrPermanent) {
-					logger.Error(ctx, "Permanent dispatch failure", tag.Error(err))
-					return err
-				}
-				logger.Warn(ctx, "Transient dispatch failure, will retry", tag.Error(err))
-				return err
-			}
-			dispatched = true
-			if admissionReservationToken != "" {
-				started = true
-				return nil
-			}
-		}
-
-		var err error
-		started, err = d.checkStartupStatus(ctx, queueName, runRef, startupWaitState{
-			launchedAt: launchedAt,
-		})
-		return err
-	}
-
-	if err := backoff.Retry(retryCtx, operation, policy, nil); err != nil {
+	err := d.executeDistributedHandoff(ctx, dag, runID, dagStatus, admissionReservationToken)
+	if err != nil {
 		d.releaseAdmissionToken(ctx, admissionReservationToken)
 		if staleErr, ok := errors.AsType[*queuedomain.StaleQueueDispatchError](err); ok {
 			logger.Info(ctx, "Discarding stale distributed queue dispatch",
@@ -880,21 +850,36 @@ func (d *queueDispatcher) dispatchAndWaitForStartupWithConditions(
 			)
 			return true
 		}
-		logger.Error(ctx, "Failed to dispatch DAG after retries", tag.Error(err))
+		logger.Warn(ctx, "Failed to dispatch DAG; leaving it queued for the next scan", tag.Error(err))
 		if shouldRecordStartupCondition(err) {
-			if errors.Is(err, errRunLivenessUnavailable) {
-				conditionStage.observe(runLivenessUnavailableConditionDefs...)
-			} else if dispatched && startupNotObserved(err) {
-				conditionStage.observe(startupNotObservedConditionDefs...)
-			} else {
-				conditionStage.observe(queuedDispatchCondition(err)...)
-			}
+			conditionStage.observe(queuedDispatchCondition(err)...)
 			conditionStage.flush(ctx)
 		}
+		return false
 	}
 
-	defer d.wakeUp()
-	return started
+	if admissionReservationToken != "" {
+		return true
+	}
+	return d.waitForStartupWithConditions(ctx, queueName, runRef, startupWaitState{
+		launchedAt: launchedAt,
+	}, conditionStage)
+}
+
+func (d *queueDispatcher) executeDistributedHandoff(
+	ctx context.Context,
+	dag *ir.DAG,
+	runID string,
+	dagStatus *ir.DAGRunStatus,
+	admissionReservationToken string,
+) error {
+	release, acquired := d.acquireDispatchHandoff(ctx)
+	if !acquired {
+		return d.checkContextAndQuit(ctx)
+	}
+	defer release()
+	return d.dagExecutor.ExecuteDAGWithAdmission(ctx, dag, dispatch.DispatchOperationRetry,
+		runID, dagStatus, dagStatus.TriggerType, dagStatus.ScheduleTime, admissionReservationToken)
 }
 
 func (d *queueDispatcher) reserveDistributedAdmission(

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -33,6 +33,7 @@ type queueDispatchDeps struct {
 	dagRunLeaseStore       dispatch.DAGRunLeaseStore
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
+	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	backoffConfig          BackoffConfig
@@ -50,6 +51,7 @@ type queueDispatcher struct {
 	dagRunLeaseStore       dispatch.DAGRunLeaseStore
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
+	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	backoffConfig          BackoffConfig
@@ -67,6 +69,26 @@ type queueDispatchBatch struct {
 	maxConcurrency        int
 	aliveCount            int
 	nonAdmissionOccupancy int
+}
+
+type workerHeartbeatSnapshot struct {
+	records []dispatch.WorkerHeartbeatRecord
+	err     error
+	loaded  bool
+}
+
+func (s *workerHeartbeatSnapshot) load(
+	ctx context.Context,
+	store dispatch.WorkerHeartbeatStore,
+) ([]dispatch.WorkerHeartbeatRecord, error) {
+	if !s.loaded {
+		s.loaded = true
+		s.records, s.err = store.List(ctx)
+		if s.err != nil {
+			logger.Error(ctx, "Failed to list worker heartbeats", tag.Error(s.err))
+		}
+	}
+	return s.records, s.err
 }
 
 type dispatchAdmissionInput struct {
@@ -308,6 +330,7 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 		dagRunLeaseStore:       deps.dagRunLeaseStore,
 		dispatchTaskStore:      deps.dispatchTaskStore,
 		dispatchAdmissionStore: deps.dispatchAdmissionStore,
+		workerHeartbeatStore:   deps.workerHeartbeatStore,
 		dagExecutor:            deps.dagExecutor,
 		isSuspended:            deps.isSuspended,
 		backoffConfig:          deps.backoffConfig,
@@ -1227,6 +1250,7 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 	}
 
 	runnable := make([]queuedomain.QueuedItemData, 0, min(freeSlots, len(items)))
+	workerSnapshot := workerHeartbeatSnapshot{}
 	for _, item := range items {
 		if len(runnable) >= freeSlots {
 			break
@@ -1251,10 +1275,74 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 				continue
 			}
 		}
+		if d.workerHeartbeatStore != nil && !d.queueItemHasEligibleWorker(ctx, queueName, item, *runRef, &workerSnapshot) {
+			continue
+		}
 		runnable = append(runnable, item)
 	}
 
 	return runnable, nil
+}
+
+func (d *queueDispatcher) queueItemHasEligibleWorker(
+	ctx context.Context,
+	queueName string,
+	item queuedomain.QueuedItemData,
+	runRef ir.DAGRunRef,
+	workerSnapshot *workerHeartbeatSnapshot,
+) bool {
+	attempt, err := d.dagRunRepository.FindAttempt(ctx, runRef)
+	if err != nil || attempt.Hidden() {
+		return true
+	}
+	status, err := attempt.ReadStatus(ctx)
+	if err != nil || status.Status != ir.Queued {
+		return true
+	}
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil || !d.dagExecutor.IsDistributed(dag) {
+		return true
+	}
+
+	records, err := workerSnapshot.load(ctx, d.workerHeartbeatStore)
+	var conditionDefs []queuedConditionDef
+	if err != nil {
+		conditionDefs = assignmentUnavailableConditionDefs
+	} else {
+		available, defs := workerAvailableInSnapshot(records, time.Now().UTC(), dag, status)
+		if available {
+			return true
+		}
+		conditionDefs = defs
+	}
+
+	conditionStage := d.newQueuedConditionStage(runRef, queueName, item.ID(), attempt, status)
+	conditionStage.observe(conditionDefs...)
+	conditionStage.flush(ctx)
+	return false
+}
+
+func workerAvailableInSnapshot(
+	records []dispatch.WorkerHeartbeatRecord,
+	now time.Time,
+	dag *ir.DAG,
+	status *ir.DAGRunStatus,
+) (bool, []queuedConditionDef) {
+	targetWorkerID := ir.RetryAgentOwnerWorkerID(status, false)
+	healthyWorkers := 0
+	for _, record := range records {
+		if !dispatch.WorkerHeartbeatFresh(record, now, dispatch.DefaultStaleWorkerHeartbeatThreshold) {
+			continue
+		}
+		healthyWorkers++
+		if dispatch.WorkerHeartbeatMatches(record, dag.WorkerSelector, targetWorkerID) {
+			return true, nil
+		}
+	}
+	if healthyWorkers == 0 {
+		return false, noAvailableWorkerConditionDefs
+	}
+	return false, noMatchingWorkerConditionDefs
 }
 
 func dispatchAdmissionWaitingCondition(decision *dispatch.DispatchAdmissionDecision) []queuedConditionDef {

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -34,6 +34,7 @@ type queueDispatchDeps struct {
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
 	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
+	workerStaleAfter       time.Duration
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	backoffConfig          BackoffConfig
@@ -52,6 +53,7 @@ type queueDispatcher struct {
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
 	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
+	workerStaleAfter       time.Duration
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	backoffConfig          BackoffConfig
@@ -331,6 +333,7 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 		dispatchTaskStore:      deps.dispatchTaskStore,
 		dispatchAdmissionStore: deps.dispatchAdmissionStore,
 		workerHeartbeatStore:   deps.workerHeartbeatStore,
+		workerStaleAfter:       deps.workerStaleAfter,
 		dagExecutor:            deps.dagExecutor,
 		isSuspended:            deps.isSuspended,
 		backoffConfig:          deps.backoffConfig,
@@ -496,11 +499,19 @@ func (s *queuedConditionStage) observe(defs ...queuedConditionDef) {
 }
 
 func (s *queuedConditionStage) flush(ctx context.Context) {
+	s.flushWithQueueCheck(ctx, true)
+}
+
+func (s *queuedConditionStage) flushWithoutQueueCheck(ctx context.Context) {
+	s.flushWithQueueCheck(ctx, false)
+}
+
+func (s *queuedConditionStage) flushWithQueueCheck(ctx context.Context, checkQueue bool) {
 	if s == nil || s.flushed || len(s.observations) == 0 {
 		return
 	}
 	s.flushed = true
-	if err := s.flushErr(ctx); err != nil {
+	if err := s.flushErr(ctx, checkQueue); err != nil {
 		logger.Warn(ctx, "Failed to update queued DAG-run condition",
 			tag.Error(err),
 			tag.RunID(s.runRef.ID),
@@ -508,8 +519,8 @@ func (s *queuedConditionStage) flush(ctx context.Context) {
 	}
 }
 
-func (s *queuedConditionStage) flushErr(ctx context.Context) error {
-	if !s.itemStillQueued(ctx) {
+func (s *queuedConditionStage) flushErr(ctx context.Context, checkQueue bool) error {
+	if checkQueue && !s.itemStillQueued(ctx) {
 		return nil
 	}
 
@@ -1251,6 +1262,10 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 
 	runnable := make([]queuedomain.QueuedItemData, 0, min(freeSlots, len(items)))
 	workerSnapshot := workerHeartbeatSnapshot{}
+	var workerConditionStages []*queuedConditionStage
+	defer func() {
+		d.flushQueuedConditionStages(ctx, queueName, workerConditionStages)
+	}()
 	for _, item := range items {
 		if len(runnable) >= freeSlots {
 			break
@@ -1275,8 +1290,17 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 				continue
 			}
 		}
-		if d.workerHeartbeatStore != nil && !d.queueItemHasEligibleWorker(ctx, queueName, item, *runRef, &workerSnapshot) {
-			continue
+		if d.workerHeartbeatStore != nil {
+			recordCondition := len(workerConditionStages) < queuedConditionRefreshBatchLimit
+			eligible, conditionStage := d.queueItemHasEligibleWorker(
+				ctx, queueName, item, *runRef, &workerSnapshot, recordCondition,
+			)
+			if !eligible {
+				if conditionStage != nil {
+					workerConditionStages = append(workerConditionStages, conditionStage)
+				}
+				continue
+			}
 		}
 		runnable = append(runnable, item)
 	}
@@ -1290,18 +1314,19 @@ func (d *queueDispatcher) queueItemHasEligibleWorker(
 	item queuedomain.QueuedItemData,
 	runRef ir.DAGRunRef,
 	workerSnapshot *workerHeartbeatSnapshot,
-) bool {
+	recordCondition bool,
+) (bool, *queuedConditionStage) {
 	attempt, err := d.dagRunRepository.FindAttempt(ctx, runRef)
 	if err != nil || attempt.Hidden() {
-		return true
+		return true, nil
 	}
 	status, err := attempt.ReadStatus(ctx)
 	if err != nil || status.Status != ir.Queued {
-		return true
+		return true, nil
 	}
 	dag, err := attempt.ReadDAG(ctx)
 	if err != nil || !d.dagExecutor.IsDistributed(dag) {
-		return true
+		return true, nil
 	}
 
 	records, err := workerSnapshot.load(ctx, d.workerHeartbeatStore)
@@ -1309,29 +1334,75 @@ func (d *queueDispatcher) queueItemHasEligibleWorker(
 	if err != nil {
 		conditionDefs = assignmentUnavailableConditionDefs
 	} else {
-		available, defs := workerAvailableInSnapshot(records, time.Now().UTC(), dag, status)
+		available, defs := workerAvailableInSnapshot(records, time.Now().UTC(), d.workerStaleAfter, dag, status)
 		if available {
-			return true
+			return true, nil
 		}
 		conditionDefs = defs
+	}
+	if !recordCondition {
+		return false, nil
 	}
 
 	conditionStage := d.newQueuedConditionStage(runRef, queueName, item.ID(), attempt, status)
 	conditionStage.observe(conditionDefs...)
-	conditionStage.flush(ctx)
-	return false
+	return false, conditionStage
+}
+
+func (d *queueDispatcher) flushQueuedConditionStages(
+	ctx context.Context,
+	queueName string,
+	stages []*queuedConditionStage,
+) {
+	if len(stages) == 0 {
+		return
+	}
+	if d.queueStore == nil || queueName == "" {
+		for _, stage := range stages {
+			stage.flushWithoutQueueCheck(ctx)
+		}
+		return
+	}
+
+	items, err := d.queueStore.List(ctx, queueName)
+	if err != nil {
+		logger.Warn(ctx, "Failed to verify queued items before updating worker conditions", tag.Error(err))
+		return
+	}
+	stagesByItemID := make(map[string]*queuedConditionStage, len(stages))
+	for _, stage := range stages {
+		if stage != nil {
+			stagesByItemID[stage.itemID] = stage
+		}
+	}
+	for _, item := range items {
+		stage, ok := stagesByItemID[item.ID()]
+		if !ok {
+			continue
+		}
+		runRef, err := item.Data()
+		if err != nil {
+			logger.Warn(ctx, "Failed to read queued item before updating worker conditions", tag.Error(err))
+			continue
+		}
+		if runRef == nil || *runRef != stage.runRef {
+			continue
+		}
+		stage.flushWithoutQueueCheck(ctx)
+	}
 }
 
 func workerAvailableInSnapshot(
 	records []dispatch.WorkerHeartbeatRecord,
 	now time.Time,
+	staleThreshold time.Duration,
 	dag *ir.DAG,
 	status *ir.DAGRunStatus,
 ) (bool, []queuedConditionDef) {
 	targetWorkerID := ir.RetryAgentOwnerWorkerID(status, false)
 	healthyWorkers := 0
 	for _, record := range records {
-		if !dispatch.WorkerHeartbeatFresh(record, now, dispatch.DefaultStaleWorkerHeartbeatThreshold) {
+		if !dispatch.WorkerHeartbeatFresh(record, now, staleThreshold) {
 			continue
 		}
 		healthyWorkers++

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -1106,10 +1106,6 @@ func localLaunchFailed(err error) bool {
 	return !errors.As(err, &exitErr)
 }
 
-func startupNotObserved(err error) bool {
-	return errors.Is(err, errNotStarted) || errors.Is(err, errExecutionExitedBeforeStartup)
-}
-
 func shouldBoundLocalStartupError(waitState startupWaitState, err error) bool {
 	return waitState.execDone != nil &&
 		err != nil &&

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -97,6 +97,7 @@ type QueueProcessor struct {
 	dagRunLeaseStore       dispatch.DAGRunLeaseStore
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
+	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	queues                 sync.Map // map[string]*queue
@@ -159,6 +160,13 @@ func WithLeaseStaleThreshold(threshold time.Duration) QueueProcessorOption {
 func WithDAGRunLeaseStore(store dispatch.DAGRunLeaseStore) QueueProcessorOption {
 	return func(p *QueueProcessor) {
 		p.dagRunLeaseStore = store
+	}
+}
+
+// WithWorkerHeartbeatStore sets the shared worker heartbeat store.
+func WithWorkerHeartbeatStore(store dispatch.WorkerHeartbeatStore) QueueProcessorOption {
+	return func(p *QueueProcessor) {
+		p.workerHeartbeatStore = store
 	}
 }
 
@@ -348,6 +356,7 @@ func (p *QueueProcessor) newQueueDispatcher() *queueDispatcher {
 		dagRunLeaseStore:       p.dagRunLeaseStore,
 		dispatchTaskStore:      p.dispatchTaskStore,
 		dispatchAdmissionStore: p.dispatchAdmissionStore,
+		workerHeartbeatStore:   p.workerHeartbeatStore,
 		dagExecutor:            p.dagExecutor,
 		isSuspended:            p.isSuspended,
 		backoffConfig:          p.backoffConfig,

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -98,6 +98,7 @@ type QueueProcessor struct {
 	dispatchTaskStore      dispatch.DispatchTaskStore
 	dispatchAdmissionStore dispatch.DispatchAdmissionStore
 	workerHeartbeatStore   dispatch.WorkerHeartbeatStore
+	workerStaleAfter       time.Duration
 	dagExecutor            *DAGExecutor
 	isSuspended            IsSuspendedFunc
 	queues                 sync.Map // map[string]*queue
@@ -170,6 +171,13 @@ func WithWorkerHeartbeatStore(store dispatch.WorkerHeartbeatStore) QueueProcesso
 	}
 }
 
+// WithWorkerHeartbeatStaleThreshold sets the worker heartbeat freshness threshold.
+func WithWorkerHeartbeatStaleThreshold(threshold time.Duration) QueueProcessorOption {
+	return func(p *QueueProcessor) {
+		p.workerStaleAfter = threshold
+	}
+}
+
 // WithDispatchTaskStore sets the shared distributed dispatch reservation store.
 func WithDispatchTaskStore(store dispatch.DispatchTaskStore) QueueProcessorOption {
 	return func(p *QueueProcessor) {
@@ -218,6 +226,7 @@ func NewQueueProcessor(
 		prevTime:            time.Now().Add(-queueProcessMinInterval),
 		backoffConfig:       DefaultBackoffConfig(),
 		leaseStaleThreshold: dagrun.DefaultStaleLeaseThreshold,
+		workerStaleAfter:    dispatch.DefaultStaleWorkerHeartbeatThreshold,
 		isSuspended:         func(context.Context, string) (bool, error) { return false, nil },
 	}
 
@@ -357,6 +366,7 @@ func (p *QueueProcessor) newQueueDispatcher() *queueDispatcher {
 		dispatchTaskStore:      p.dispatchTaskStore,
 		dispatchAdmissionStore: p.dispatchAdmissionStore,
 		workerHeartbeatStore:   p.workerHeartbeatStore,
+		workerStaleAfter:       p.workerStaleAfter,
 		dagExecutor:            p.dagExecutor,
 		isSuspended:            p.isSuspended,
 		backoffConfig:          p.backoffConfig,

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -23,6 +23,7 @@ import (
 
 const queueAgeWarningThreshold = 2 * time.Minute
 const queueProcessMinInterval = 3 * time.Second
+const maxConcurrentDispatchHandoffs = 8
 
 var (
 	errProcessorClosed              = errors.New("processor closed")
@@ -100,6 +101,7 @@ type QueueProcessor struct {
 	isSuspended            IsSuspendedFunc
 	queues                 sync.Map // map[string]*queue
 	wakeUpCh               chan struct{}
+	dispatchHandoffs       chan struct{}
 	quit                   chan struct{}
 	wg                     sync.WaitGroup
 	stopOnce               sync.Once
@@ -201,6 +203,7 @@ func NewQueueProcessor(
 		procRepository:   procRepository,
 		dagExecutor:      dagExecutor,
 		wakeUpCh:         make(chan struct{}, 1),
+		dispatchHandoffs: make(chan struct{}, maxConcurrentDispatchHandoffs),
 		quit:             make(chan struct{}),
 		// Seed prevTime in the past so Start()'s initial wake-up is not
 		// throttled by the minimum processing interval.
@@ -351,7 +354,19 @@ func (p *QueueProcessor) newQueueDispatcher() *queueDispatcher {
 		leaseStaleThreshold:    p.leaseStaleThreshold,
 		isClosed:               p.isClosed,
 		wakeUp:                 p.wakeUp,
+		acquireDispatchHandoff: p.acquireDispatchHandoff,
 	})
+}
+
+func (p *QueueProcessor) acquireDispatchHandoff(ctx context.Context) (func(), bool) {
+	select {
+	case p.dispatchHandoffs <- struct{}{}:
+		return func() { <-p.dispatchHandoffs }, true
+	case <-ctx.Done():
+		return nil, false
+	case <-p.quit:
+		return nil, false
+	}
 }
 
 // ProcessQueueItems processes items in the specified queue.

--- a/internal/service/scheduler/queue_processor_startup_test.go
+++ b/internal/service/scheduler/queue_processor_startup_test.go
@@ -328,18 +328,13 @@ func (m *mockDispatcher) RequestCancel(_ context.Context, _, _ string, _ *ir.DAG
 	return nil
 }
 
-func TestQueueDispatcher_DispatchAndWaitForStartup_TransientRetryThenSuccess(t *testing.T) {
-	dagRunRepository := &mockDAGRunStore{}
+func TestQueueDispatcher_DispatchFailureReturnsToQueueScan(t *testing.T) {
 	procRepository := &mockProcRepository{}
 	runRef := ir.NewDAGRunRef("test-dag", "run-1")
 
-	// Dispatcher fails twice with a transient error, then succeeds.
 	disp := &mockDispatcher{
-		errFunc: func(n int32) error {
-			if n <= 2 {
-				return errors.New("no available workers")
-			}
-			return nil
+		errFunc: func(int32) error {
+			return errors.New("no available workers")
 		},
 	}
 
@@ -347,13 +342,9 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_TransientRetryThenSuccess(t *
 	dag := &ir.DAG{Name: "test-dag"}
 	status := &ir.DAGRunStatus{Status: ir.Queued, TriggerType: ir.TriggerTypeScheduler}
 
-	// After dispatch succeeds, the process should become alive.
-	procRepository.On("IsRunAlive", mock.Anything, "test-queue", runRef).Return(true, nil).Once()
-
 	dispatcher := newQueueDispatcher(queueDispatchDeps{
-		dagRunRepository: dagRunRepository.repository(),
-		procRepository:   procRepository,
-		dagExecutor:      dagExec,
+		procRepository: procRepository,
+		dagExecutor:    dagExec,
 		backoffConfig: BackoffConfig{
 			InitialInterval:    10 * time.Millisecond,
 			MaxInterval:        50 * time.Millisecond,
@@ -363,9 +354,9 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_TransientRetryThenSuccess(t *
 	})
 
 	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
-	require.True(t, started)
-	require.GreaterOrEqual(t, disp.callCount.Load(), int32(3))
-	procRepository.AssertExpectations(t)
+	require.False(t, started)
+	require.Equal(t, int32(1), disp.callCount.Load())
+	procRepository.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestQueueDispatcher_DispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded(t *testing.T) {
@@ -403,7 +394,7 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_StaleQueueDispatchIsDiscarded
 	procRepository.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestQueueDispatcher_DispatchAndWaitForStartup_RawStaleQueueDispatchStopsRetry(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_RawStaleQueueDispatchIsDiscarded(t *testing.T) {
 	dagRunRepository := &mockDAGRunStore{}
 	procRepository := &mockProcRepository{}
 
@@ -436,12 +427,11 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_RawStaleQueueDispatchStopsRet
 	procRepository.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestQueueDispatcher_DispatchAndWaitForStartup_PermanentErrorStopsRetry(t *testing.T) {
+func TestQueueDispatcher_DispatchAndWaitForStartup_PermanentErrorLeavesRunQueued(t *testing.T) {
 	dagRunRepository := &mockDAGRunStore{}
 	procRepository := &mockProcRepository{}
 	attempt := &testutil.MockAttempt{}
 
-	// Dispatcher always returns a permanent error (selector mismatch).
 	disp := &mockDispatcher{
 		errFunc: func(_ int32) error {
 			return backoff.PermanentError(errors.New("no workers match the required selector"))
@@ -484,7 +474,6 @@ func TestQueueDispatcher_DispatchAndWaitForStartup_PermanentErrorStopsRetry(t *t
 
 	started := dispatcher.dispatchAndWaitForStartup(context.Background(), "test-queue", runRef, dag, "run-1", status, "")
 	require.False(t, started)
-	// Should have been called exactly once (permanent error stops retries).
 	require.Equal(t, int32(1), disp.callCount.Load())
 	procRepository.AssertNotCalled(t, "IsRunAlive", mock.Anything, mock.Anything, mock.Anything)
 	dagRunRepository.AssertExpectations(t)

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -564,6 +564,31 @@ func TestQueueDispatcher_DistributedDispatchHandsOffWithAdmissionToken(t *testin
 	procRepository.AssertExpectations(t)
 }
 
+func TestQueueProcessorLimitsConcurrentDispatchHandoffs(t *testing.T) {
+	t.Parallel()
+
+	processor := NewQueueProcessor(nil, nil, nil, nil, config.Queues{})
+	releases := make([]func(), 0, maxConcurrentDispatchHandoffs)
+	for range maxConcurrentDispatchHandoffs {
+		release, acquired := processor.acquireDispatchHandoff(context.Background())
+		require.True(t, acquired)
+		releases = append(releases, release)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, acquired := processor.acquireDispatchHandoff(canceled)
+	require.False(t, acquired)
+
+	releases[0]()
+	release, acquired := processor.acquireDispatchHandoff(context.Background())
+	require.True(t, acquired)
+	release()
+	for _, release := range releases[1:] {
+		release()
+	}
+}
+
 func TestQueueProcessor_SuspendedSchedulerManagedQueuedRunsAreAbortedAndDequeued(t *testing.T) {
 	triggers := []ir.TriggerType{
 		ir.TriggerTypeScheduler,

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -108,6 +108,7 @@ type Dependencies struct {
 	SchedulerStateStore  schedulerstate.Store
 	DAGRunLeaseStore     dispatch.DAGRunLeaseStore
 	DispatchTaskStore    dispatch.DispatchTaskStore
+	WorkerHeartbeatStore dispatch.WorkerHeartbeatStore
 	DAGSettingsStore     dagsettings.Store
 	ProfileStore         profile.Store
 	EventService         *eventstore.Service
@@ -166,6 +167,7 @@ func New(cfg *config.Config, deps Dependencies) (*Scheduler, error) {
 	scheduler.queueProcessor.dagRunLeaseStore = deps.DAGRunLeaseStore
 	scheduler.queueProcessor.dispatchTaskStore = deps.DispatchTaskStore
 	scheduler.queueProcessor.dispatchAdmissionStore = dispatchAdmissionStoreFromTaskStore(deps.DispatchTaskStore)
+	scheduler.queueProcessor.workerHeartbeatStore = deps.WorkerHeartbeatStore
 	return scheduler, nil
 }
 

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -109,6 +109,7 @@ type Dependencies struct {
 	DAGRunLeaseStore     dispatch.DAGRunLeaseStore
 	DispatchTaskStore    dispatch.DispatchTaskStore
 	WorkerHeartbeatStore dispatch.WorkerHeartbeatStore
+	WorkerStaleAfter     time.Duration
 	DAGSettingsStore     dagsettings.Store
 	ProfileStore         profile.Store
 	EventService         *eventstore.Service
@@ -168,6 +169,9 @@ func New(cfg *config.Config, deps Dependencies) (*Scheduler, error) {
 	scheduler.queueProcessor.dispatchTaskStore = deps.DispatchTaskStore
 	scheduler.queueProcessor.dispatchAdmissionStore = dispatchAdmissionStoreFromTaskStore(deps.DispatchTaskStore)
 	scheduler.queueProcessor.workerHeartbeatStore = deps.WorkerHeartbeatStore
+	if deps.WorkerStaleAfter != 0 {
+		scheduler.queueProcessor.workerStaleAfter = deps.WorkerStaleAfter
+	}
 	return scheduler, nil
 }
 

--- a/internal/service/worker/coordinator_client.go
+++ b/internal/service/worker/coordinator_client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/v2/internal/service/coordinator"
 )
 
@@ -20,6 +21,7 @@ func NewCoordinatorClient(ctx context.Context, cfg *config.Config) (coordinator.
 	}
 
 	clientConfig := coordinator.ConfigFromPeer(cfg.Core.Peer)
+	clientConfig.WorkspaceBundleDir = workspacebundle.StoreDir(cfg.Paths.DataDir)
 	if err := clientConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid coordinator client configuration: %w", err)
 	}

--- a/internal/spec/dparams_runtime.go
+++ b/internal/spec/dparams_runtime.go
@@ -57,14 +57,20 @@ func ResolveRuntimeParams(ctx context.Context, dag *ir.DAG, params any, opts Res
 		return nil, err
 	}
 
+	var resolved *ir.DAG
 	switch {
 	case dag.Location != "":
-		return Load(ctx, dag.Location, loadOpts...)
+		resolved, err = Load(ctx, dag.Location, loadOpts...)
 	case len(dag.YamlData) > 0:
-		return LoadYAML(ctx, dag.YamlData, loadOpts...)
+		resolved, err = LoadYAML(ctx, dag.YamlData, loadOpts...)
 	default:
 		return nil, fmt.Errorf("DAG source is required to resolve runtime params")
 	}
+	if err != nil {
+		return nil, err
+	}
+	resolved.SourceFile = dag.SourceFile
+	return resolved, nil
 }
 
 // ReloadRuntimeSnapshot reloads a DAG from its captured source with runtime

--- a/internal/spec/runtime_params_test.go
+++ b/internal/spec/runtime_params_test.go
@@ -160,10 +160,12 @@ params:
 	require.NoError(t, err)
 	require.NotEmpty(t, dag.Location)
 	require.NotEmpty(t, dag.YamlData)
+	dag.SourceFile = filepath.Join(dir, "authored.yaml")
 
 	resolved, err := ResolveRuntimeParams(context.Background(), dag, "region=us-east-1", ResolveRuntimeParamsOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"region=us-east-1"}, resolved.Params)
+	assert.Equal(t, dag.SourceFile, resolved.SourceFile)
 }
 
 func TestResolveRuntimeParams_LegacyNamedParamsPreservePositionalOverrides(t *testing.T) {

--- a/internal/test/coordinator.go
+++ b/internal/test/coordinator.go
@@ -240,14 +240,14 @@ func (c *Coordinator) DispatchTask(t *testing.T, task *coordinatorv1.Task) error
 // GetCoordinatorClient returns a coordinator client for this coordinator
 func (c *Coordinator) GetCoordinatorClient(t *testing.T) coordinator.Client {
 	t.Helper()
+	return coordinator.New(c.ServiceRegistry, CoordinatorClientConfig(c.Config.Paths.DataDir))
+}
 
-	// Create coordinator client config
+// CoordinatorClientConfig returns coordinator client settings backed by the test data directory.
+func CoordinatorClientConfig(dataDir string) *coordinator.Config {
 	config := coordinator.DefaultConfig()
-	config.Insecure = true
-	config.WorkspaceBundleDir = workspacebundle.StoreDir(c.Config.Paths.DataDir)
-
-	// Create coordinator client - cast to Client interface
-	return coordinator.New(c.ServiceRegistry, config)
+	config.WorkspaceBundleDir = workspacebundle.StoreDir(dataDir)
+	return config
 }
 
 // Handler returns the coordinator handler for direct testing

--- a/internal/test/coordinator.go
+++ b/internal/test/coordinator.go
@@ -244,6 +244,7 @@ func (c *Coordinator) GetCoordinatorClient(t *testing.T) coordinator.Client {
 	// Create coordinator client config
 	config := coordinator.DefaultConfig()
 	config.Insecure = true
+	config.WorkspaceBundleDir = workspacebundle.StoreDir(c.Config.Paths.DataDir)
 
 	// Create coordinator client - cast to Client interface
 	return coordinator.New(c.ServiceRegistry, config)

--- a/internal/test/reschedule_inline_helpers.go
+++ b/internal/test/reschedule_inline_helpers.go
@@ -4,10 +4,7 @@
 package test
 
 import (
-	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -36,7 +33,7 @@ func rescheduleEventuallyTimeout(base time.Duration) time.Duration {
 	return SubprocessRunTimeout(base)
 }
 
-func CreateInlineDAGRunForReschedule(t *testing.T, server Server, dagName string, enqueue bool) (string, string) {
+func CreateInlineDAGRunForReschedule(t *testing.T, server Server, dagName string, enqueue bool) string {
 	t.Helper()
 
 	inlineSpec := `params:
@@ -88,12 +85,7 @@ steps:
 	require.NoError(t, err)
 	require.Equal(t, []string{"KEY=hello world", "COUNT=3"}, status.ParamsList)
 
-	location := dag.Location
-	if location == "" {
-		location = ExpectedInlineTempPath(dagName, dagRunID)
-	}
-
-	return dagRunID, location
+	return dagRunID
 }
 
 func AssertInlineRescheduledRunParams(t *testing.T, server Server, dagName, dagRunID string) {
@@ -151,10 +143,6 @@ func WaitForAttemptSnapshotWithDAG(t *testing.T, server Server, dagName, dagRunI
 	}, rescheduleEventuallyTimeout(10*time.Second), 100*time.Millisecond)
 
 	return attempt, dag
-}
-
-func ExpectedInlineTempPath(name, dagRunID string) string {
-	return filepath.Join(os.TempDir(), name, dagRunID, fmt.Sprintf("%s.yaml", name))
 }
 
 func ProcessQueuedInlineRun(t *testing.T, server Server, queueName string) {

--- a/internal/test/reschedule_inline_helpers.go
+++ b/internal/test/reschedule_inline_helpers.go
@@ -166,7 +166,7 @@ func ProcessQueuedInlineRun(t *testing.T, server Server, queueName string) {
 		server.DAGRunRepository,
 		server.ProcRepository,
 		scheduler.NewDAGExecutor(
-			coordinator.New(server.ServiceRegistry, coordinator.DefaultConfig()),
+			coordinator.New(server.ServiceRegistry, CoordinatorClientConfig(server.Config.Paths.DataDir)),
 			server.SubCmdBuilder,
 			server.Config.DefaultExecMode,
 			server.Config.Paths.BaseConfig,

--- a/internal/test/scheduler.go
+++ b/internal/test/scheduler.go
@@ -70,7 +70,7 @@ func SetupScheduler(t *testing.T, opts ...HelperOption) *Scheduler {
 	drm := runtime.NewManager(dagRunRepository, ps, helper.Config)
 
 	// Create entry reader
-	coordinatorCli := coordinator.New(helper.ServiceRegistry, coordinator.DefaultConfig())
+	coordinatorCli := coordinator.New(helper.ServiceRegistry, CoordinatorClientConfig(helper.Config.Paths.DataDir))
 	em := scheduler.NewFileEntryReader(
 		helper.Config.Paths.DAGsDir,
 		ds,

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -89,7 +89,7 @@ func SetupServer(t *testing.T, opts ...HelperOption) Server {
 
 // newFrontendServer constructs the HTTP server with the provided listener.
 func (srv *Server) newFrontendServer(listener net.Listener) (*frontend.Server, error) {
-	cc := coordinator.New(srv.ServiceRegistry, coordinator.DefaultConfig())
+	cc := coordinator.New(srv.ServiceRegistry, CoordinatorClientConfig(srv.Config.Paths.DataDir))
 
 	// Pass the pre-bound listener to the server to avoid port race conditions
 	serverOpts := append([]frontend.ServerOption{


### PR DESCRIPTION
## Summary

Fix scheduler memory growth when a distributed worker is unavailable and queued DAGs include file dependencies.

## Root cause

The scheduler prepared and uploaded each dependency workspace before the coordinator discovered that no matching worker was available. Every queue scan repeated that work, so large archives and concurrent dispatch attempts caused retained heap growth and repeated allocation pressure. Restarting the scheduler released the accumulated memory but did not remove the retry cycle.

## Changes

- Stream workspace archives through disk-backed staging files instead of materializing complete archives in Go byte slices
- Check the shared worker heartbeat state before distributed dispatch, keeping runs queued until a healthy matching worker is available
- Resume dispatch on a later queue scan when the worker returns, without re-packing or uploading during the outage
- Bound concurrent dispatch handoffs and batch queue-condition persistence to prevent unbounded outage fan-out
- Share worker eligibility semantics between the scheduler and coordinator, including configured heartbeat freshness
- Preserve normal parsing and execution for DAGs without dependencies; those DAGs simply skip workspace bundle preparation
- Add unit and distributed integration coverage for streaming, worker outages, selector matching, recovery, and dependency transfer

## Testing

- `make fmt`
- `go test -race ./internal/service/frontend/api/v1 -count=1`
- `make test GO_TEST_FLAGS='-v --race -p=4 -ldflags=-extldflags=-Wl,-ld_classic'`
- Focused scheduler, coordinator, dispatch, command, worker-recovery, and distributed file-dependency tests

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents scheduler memory growth during distributed worker outages by staging workspace bundles on disk and deferring dispatch until a healthy, matching worker is available. Previously we repacked and uploaded dependencies each scan; now we stream staged archives, check heartbeats/selectors first, and resume without re-packing. Also preserves inline DAG source provenance and retains inline snapshots for the life of local runs.

- Streams workspace bundles from disk: adds `workspacebundle.PackDirectoryToFile` and store `PutReader`/`Open`; the coordinator client uploads chunks from files; the server streams to the store with digest/size verification and cleans partial archives.
- Waits for eligible workers before dispatch: shares `DefaultStaleWorkerHeartbeatThreshold` and `WorkerHeartbeatFresh`/`WorkerHeartbeatMatches`; the scheduler queries a shared `WorkerHeartbeatStore`, records `NoAvailableWorker`/`NoMatchingWorker`/`AssignmentUnavailable` conditions, limits concurrent handoffs to 8, and lets failed handoffs return to the next scan.
- Local/inline runs: retain inline DAG snapshot files until the run completes; propagate `SourceFile` through runtime param resolution and pass it via launcher `--source-file` to preserve provenance.
- Wiring: coordinator clients in CLI/engine/worker set `WorkspaceBundleDir` to `workspacebundle.StoreDir(dataDir)`; the scheduler accepts `WorkerHeartbeatStore` and optional `WorkerStaleAfter`.
- Required: deployments dispatching DAGs with file dependencies must configure a writable `WorkspaceBundleDir`; ensure workers emit fresh heartbeats; tune `WorkerStaleAfter` if needed.

<sup>Written for commit bacc197b70e0d576078f28378604ebfb84cf5574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for staging and transferring file-based workspace bundles during DAG dispatch.
  * Workspace bundles now upload and download efficiently in chunks, including large bundles.
  * Added worker availability checks using heartbeat freshness, worker IDs, and labels.
  * Limited concurrent dispatch handoffs to improve scheduler stability.
  * Added support for explicitly passing DAG source files when starting runs.

* **Bug Fixes**
  * Runs remain queued when no eligible worker is available.
  * Improved handling of failed dispatches and incomplete bundle transfers.
  * Temporary bundle files are cleaned up after transfers or failures.
  * Inline DAG resources now remain available until startup completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->