### PR TITLE
fix: align file dependency workspaces across execution modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,7 +901,7 @@ OIDC variables: `DAGU_AUTH_OIDC_CLIENT_ID`, `DAGU_AUTH_OIDC_CLIENT_SECRET`, `DAG
 | `DAGU_WORKER_ID` | — | Worker instance ID |
 | `DAGU_WORKER_MAX_ACTIVE_RUNS` | `100` | Max concurrent runs per worker |
 | `DAGU_WORKER_HEALTH_PORT` | `8092` | Worker health check port |
-| `DAGU_WORKER_LABELS` | — | Worker labels (`key=value,key=value`) |
+| `DAGU_WORKER_LABELS` | — | Worker labels (`key=value,key=value`); `os` and `arch` are built in and cannot be overridden |
 | `DAGU_COORDINATOR_ADVERTISE` | auto-detected hostname | Address advertised in the service registry |
 | `DAGU_WORKER_COORDINATORS` | — | Explicit coordinator addresses for shared-nothing mode |
 

--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -13586,7 +13586,7 @@ components:
         dependencies:
           type: array
           minItems: 1
-          description: "DAG-local files, directories, or glob patterns to snapshot for distributed execution"
+          description: "Files, directories, or glob patterns relative to the DAG working directory to snapshot for local or distributed execution"
           items:
             type: string
         call:

--- a/conformance/spec035_file_dependencies/testdata/input.txt
+++ b/conformance/spec035_file_dependencies/testdata/input.txt
@@ -1,0 +1,1 @@
+local dependency

--- a/conformance/spec035_file_dependencies/testdata/local.yaml
+++ b/conformance/spec035_file_dependencies/testdata/local.yaml
@@ -1,13 +1,6 @@
 name: local-file-dependencies
 
 steps:
-  - id: scalar
-    run: test ! -e missing-scalar.txt
-    dependencies: missing-scalar.txt
-
-  - id: array
-    depends: scalar
-    run: test ! -e missing-array.txt
-    dependencies:
-      - missing-array.txt
-      - missing-dir/**
+  - id: consume
+    run: test "$(cat input.txt)" = "local dependency"
+    dependencies: input.txt

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -1781,7 +1781,7 @@
               }
             }
           ],
-          "description": "DAG-local files, directories, or glob patterns to snapshot for distributed execution."
+          "description": "Files, directories, or glob patterns relative to the DAG working directory to snapshot for local or distributed execution."
         },
         "depends": {
           "examples": ["build", ["build", "test"]],

--- a/internal/dispatch/contracts.go
+++ b/internal/dispatch/contracts.go
@@ -58,10 +58,11 @@ type DispatchTask struct {
 
 	PreviousStatus *ir.DAGRunStatus
 
-	BaseConfig   string
-	Labels       string
-	ScheduleTime string
-	SourceFile   string
+	BaseConfig    string
+	Labels        string
+	ScheduleTime  string
+	SourceFile    string
+	SourceWorkDir string
 
 	WorkerSelector map[string]string
 

--- a/internal/engine/run.go
+++ b/internal/engine/run.go
@@ -536,6 +536,8 @@ func (e *Engine) runDistributed(ctx context.Context, dag *ir.DAG, runID string, 
 	}
 	if dag.SourceFile != "" {
 		taskOpts = append(taskOpts, runtimeexec.WithSourceFile(dag.SourceFile))
+	} else if dag.WorkingDir != "" {
+		taskOpts = append(taskOpts, runtimeexec.WithSourceWorkDir(dag.WorkingDir))
 	}
 	task := runtimeexec.CreateTask(
 		dag.Name,

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -745,10 +745,14 @@ func TestExecution_FileDependencies(t *testing.T) {
 		dependencyPath    = "fixtures/message.txt"
 		dependencyContent = "dependency from coordinator"
 	)
+	dependencyRoot := t.TempDir()
 
-	f := newTestFixture(t, `
+	f := newTestFixture(t, fmt.Sprintf(`
 type: graph
 name: file-dependency-worker-test
+env:
+  DEPENDENCY_ROOT: %q
+working_dir: $DEPENDENCY_ROOT
 worker_selector:
   test: "true"
 steps:
@@ -759,10 +763,10 @@ steps:
     with:
       path: `+dependencyPath+`
     output: CONTENT
-`, withWorkerCount(0))
+`, dependencyRoot), withWorkerCount(0))
 	defer f.cleanup()
 
-	sourceDependency := filepath.Join(filepath.Dir(f.dagWrapper.SourceFile), filepath.FromSlash(dependencyPath))
+	sourceDependency := filepath.Join(dependencyRoot, filepath.FromSlash(dependencyPath))
 	require.NoError(t, os.MkdirAll(filepath.Dir(sourceDependency), 0o750))
 	require.NoError(t, os.WriteFile(sourceDependency, []byte(dependencyContent), 0o600))
 

--- a/internal/intg/distr/execution_test.go
+++ b/internal/intg/distr/execution_test.go
@@ -745,14 +745,15 @@ func TestExecution_FileDependencies(t *testing.T) {
 		dependencyPath    = "fixtures/message.txt"
 		dependencyContent = "dependency from coordinator"
 	)
+	defaultRoot := t.TempDir()
 	dependencyRoot := t.TempDir()
 
 	f := newTestFixture(t, fmt.Sprintf(`
 type: graph
 name: file-dependency-worker-test
-env:
+params:
   DEPENDENCY_ROOT: %q
-working_dir: $DEPENDENCY_ROOT
+working_dir: ${params.DEPENDENCY_ROOT}
 worker_selector:
   test: "true"
 steps:
@@ -763,7 +764,7 @@ steps:
     with:
       path: `+dependencyPath+`
     output: CONTENT
-`, dependencyRoot), withWorkerCount(0))
+`, defaultRoot), withWorkerCount(0))
 	defer f.cleanup()
 
 	sourceDependency := filepath.Join(dependencyRoot, filepath.FromSlash(dependencyPath))
@@ -782,7 +783,7 @@ steps:
 			return true
 		}
 	}
-	require.NoError(t, f.enqueue())
+	require.NoError(t, f.enqueueWithParams("DEPENDENCY_ROOT="+dependencyRoot))
 	f.waitForQueued()
 	f.startScheduler(30 * time.Second)
 	f.requireEventuallyNoSchedulerError(

--- a/internal/intg/embed/embed_test.go
+++ b/internal/intg/embed/embed_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"testing"
@@ -45,6 +46,8 @@ func TestEmbeddedLocalRunYAML(t *testing.T) {
 		require.NoError(t, engine.Close(context.Background()))
 	})
 
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte("input"), 0o600))
 	run, err := engine.RunYAML(ctx, []byte(`
 name: embedded-intg-local
 type: graph
@@ -54,7 +57,13 @@ steps:
   - name: second
     `+embeddedDirectCommandYAML(t, "whoami")+`
     depends: [first]
-`))
+  - name: dependency
+    dependencies: input.txt
+    action: file.read
+    with:
+      path: input.txt
+    depends: [second]
+`), dagu.WithDefaultWorkingDir(workDir))
 	require.NoError(t, err)
 
 	status, err := run.Wait(ctx)
@@ -159,13 +168,18 @@ func TestEmbeddedDistributedRunYAML(t *testing.T) {
 
 	require.NoError(t, worker.WaitReady(ctx))
 
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte("input"), 0o600))
 	run, err := engine.RunYAML(ctx, []byte(`
 name: embedded-intg-distributed
 type: graph
 steps:
   - name: worker-step
-    run: echo distributed
-`))
+    dependencies: input.txt
+    action: file.read
+    with:
+      path: input.txt
+`), dagu.WithDefaultWorkingDir(workDir))
 	require.NoError(t, err)
 
 	status, err := run.Wait(ctx)

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -1553,7 +1553,7 @@ func contextTimeString(t time.Time) string {
 
 func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (func(), error) {
 	if a.workDir != "" {
-		return nil, a.prepareWorkspace()
+		return nil, a.prepareWorkspace(ctx)
 	}
 	if attempt == nil {
 		return nil, nil
@@ -1565,7 +1565,7 @@ func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (f
 		return nil, fmt.Errorf("materialize DAG-run work directory: %w", err)
 	}
 	if a.workDir != "" {
-		return nil, a.prepareWorkspace()
+		return nil, a.prepareWorkspace(ctx)
 	}
 
 	a.workDir = filepath.Join(
@@ -1583,17 +1583,17 @@ func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (f
 			logger.Warn(ctx, "Failed to remove temp work dir", tag.Error(err))
 		}
 	}
-	if err := a.prepareWorkspace(); err != nil {
+	if err := a.prepareWorkspace(ctx); err != nil {
 		cleanup()
 		return nil, err
 	}
 	return cleanup, nil
 }
 
-func (a *Agent) prepareWorkspace() error {
+func (a *Agent) prepareWorkspace(ctx context.Context) error {
 	alreadyMaterialized := a.workspaceSeed != nil
 	if a.workspaceSeed == nil {
-		seed, err := runtimeexec.PrepareDAGWorkspace(a.dag)
+		seed, err := runtimeexec.PrepareDAGWorkspace(ctx, a.dag)
 		if err != nil {
 			return err
 		}

--- a/internal/runtime/agent/agent.go
+++ b/internal/runtime/agent/agent.go
@@ -52,6 +52,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/runtime/resourcelimit"
 	"github.com/dagucloud/dagu/v2/internal/runtime/runstate"
 	"github.com/dagucloud/dagu/v2/internal/runtime/transform"
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	"github.com/dagucloud/dagu/v2/internal/runtimeenv"
 	secretpkg "github.com/dagucloud/dagu/v2/internal/secret"
 	"github.com/dagucloud/dagu/v2/internal/secret/providers"
@@ -1552,7 +1553,7 @@ func contextTimeString(t time.Time) string {
 
 func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (func(), error) {
 	if a.workDir != "" {
-		return nil, nil
+		return nil, a.prepareWorkspace()
 	}
 	if attempt == nil {
 		return nil, nil
@@ -1564,7 +1565,7 @@ func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (f
 		return nil, fmt.Errorf("materialize DAG-run work directory: %w", err)
 	}
 	if a.workDir != "" {
-		return nil, nil
+		return nil, a.prepareWorkspace()
 	}
 
 	a.workDir = filepath.Join(
@@ -1574,14 +1575,51 @@ func (a *Agent) prepareWorkDir(ctx context.Context, attempt runstate.Attempt) (f
 	if err := os.MkdirAll(a.workDir, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create work directory: %w", err)
 	}
-	return func() {
+	cleanup := func() {
 		if a.workDir == "" {
 			return
 		}
 		if err := fileutil.RemoveAll(a.workDir); err != nil {
 			logger.Warn(ctx, "Failed to remove temp work dir", tag.Error(err))
 		}
-	}, nil
+	}
+	if err := a.prepareWorkspace(); err != nil {
+		cleanup()
+		return nil, err
+	}
+	return cleanup, nil
+}
+
+func (a *Agent) prepareWorkspace() error {
+	alreadyMaterialized := a.workspaceSeed != nil
+	if a.workspaceSeed == nil {
+		seed, err := runtimeexec.PrepareDAGWorkspace(a.dag)
+		if err != nil {
+			return err
+		}
+		a.workspaceSeed = seed
+	}
+	if a.workspaceSeed == nil {
+		return nil
+	}
+	if a.workDir == "" {
+		return fmt.Errorf("DAG file dependencies require a run working directory")
+	}
+	if !alreadyMaterialized {
+		if err := workspacebundle.Extract(
+			a.workspaceSeed.Archive,
+			a.workDir,
+			a.workspaceSeed.Descriptor,
+			workspacebundle.DefaultLimits(),
+		); err != nil {
+			return fmt.Errorf("materialize DAG file dependencies: %w", err)
+		}
+	}
+
+	a.dag = a.dag.Clone()
+	a.dag.WorkingDir = a.workDir
+	a.dag.WorkingDirExplicit = true
+	return nil
 }
 
 func appendDAGRunError(current string, err error) string {

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -1129,6 +1129,29 @@ steps:
 	dag.Agent(test.WithAgentOptions(agent.Options{WorkDir: workDir})).RunSuccess(t)
 }
 
+func TestAgentMaterializesLocalFileDependencies(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses POSIX shell commands")
+	}
+	t.Parallel()
+
+	th := test.Setup(t)
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "input.txt"), []byte("input"), 0o600))
+	dag := th.DAG(t, fmt.Sprintf(`
+name: local-workspace
+working_dir: %q
+steps:
+  - id: consume
+    run: |
+      test -f input.txt
+      test "$PWD" != %s
+    dependencies: input.txt
+`, sourceDir, test.PosixQuote(sourceDir)))
+
+	dag.Agent().RunSuccess(t)
+}
+
 // Assert that mockResponseWriter implements http.ResponseWriter
 var _ http.ResponseWriter = (*mockResponseWriter)(nil)
 

--- a/internal/runtime/agent/agent_test.go
+++ b/internal/runtime/agent/agent_test.go
@@ -1140,7 +1140,9 @@ func TestAgentMaterializesLocalFileDependencies(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "input.txt"), []byte("input"), 0o600))
 	dag := th.DAG(t, fmt.Sprintf(`
 name: local-workspace
-working_dir: %q
+env:
+  SOURCE_DIR: %q
+working_dir: $SOURCE_DIR
 steps:
   - id: consume
     run: |

--- a/internal/runtime/executor/task.go
+++ b/internal/runtime/executor/task.go
@@ -86,6 +86,13 @@ func WithSourceFile(sourceFile string) TaskOption {
 	}
 }
 
+// WithSourceWorkDir sets the source workspace for source-less DAG definitions.
+func WithSourceWorkDir(dir string) TaskOption {
+	return func(task *dispatch.DispatchTask) {
+		task.SourceWorkDir = dir
+	}
+}
+
 // WithWorkerSelector sets the worker selector labels for the task.
 func WithWorkerSelector(selector map[string]string) TaskOption {
 	return func(task *dispatch.DispatchTask) {

--- a/internal/runtime/executor/task_test.go
+++ b/internal/runtime/executor/task_test.go
@@ -73,13 +73,48 @@ func TestPrepareDAGWorkspaceUsesDAGWorkingDirectory(t *testing.T) {
 	dagDir := t.TempDir()
 	workDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte("input"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "dag.yaml"), []byte("dependency"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".dagu-workflow.yaml"), []byte("hidden dependency"), 0o644))
 
+	dagData := []byte("name: working-dir\nsteps:\n  - run: echo ok\n")
 	dag := &ir.DAG{
 		Name:               "working-dir",
 		SourceFile:         filepath.Join(dagDir, "dag.yaml"),
 		WorkingDir:         workDir,
 		WorkingDirExplicit: true,
-		YamlData:           []byte("name: working-dir\nsteps:\n  - run: echo ok\n"),
+		YamlData:           dagData,
+		Steps:              []ir.Step{{Dependencies: []string{"input.txt", "dag.yaml", ".dagu-workflow.yaml"}}},
+	}
+
+	seed, err := executor.PrepareDAGWorkspace(context.Background(), dag)
+	require.NoError(t, err)
+	require.NotNil(t, seed)
+
+	dest := filepath.Join(t.TempDir(), "workspace")
+	require.NoError(t, workspacebundle.Extract(seed.Archive, dest, seed.Descriptor, workspacebundle.DefaultLimits()))
+	assert.FileExists(t, filepath.Join(dest, "input.txt"))
+	dependency, err := os.ReadFile(filepath.Join(dest, "dag.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("dependency"), dependency)
+	hiddenDependency, err := os.ReadFile(filepath.Join(dest, ".dagu-workflow.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hidden dependency"), hiddenDependency)
+	transportedDAG, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(seed.Descriptor.DAGPath)))
+	require.NoError(t, err)
+	assert.Equal(t, dagData, transportedDAG)
+}
+
+func TestPrepareDAGWorkspaceSupportsInlineDAGWithWorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte("input"), 0o644))
+	dagData := []byte("name: inline\nsteps:\n  - run: cat input.txt\n")
+	dag := &ir.DAG{
+		Name:               "inline",
+		WorkingDir:         workDir,
+		WorkingDirExplicit: true,
+		YamlData:           dagData,
 		Steps:              []ir.Step{{Dependencies: []string{"input.txt"}}},
 	}
 
@@ -90,6 +125,9 @@ func TestPrepareDAGWorkspaceUsesDAGWorkingDirectory(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "workspace")
 	require.NoError(t, workspacebundle.Extract(seed.Archive, dest, seed.Descriptor, workspacebundle.DefaultLimits()))
 	assert.FileExists(t, filepath.Join(dest, "input.txt"))
+	transportedDAG, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(seed.Descriptor.DAGPath)))
+	require.NoError(t, err)
+	assert.Equal(t, dagData, transportedDAG)
 }
 
 func TestPrepareDAGWorkspaceRejectsEmptyResolvedWorkingDirectory(t *testing.T) {

--- a/internal/runtime/executor/task_test.go
+++ b/internal/runtime/executor/task_test.go
@@ -4,6 +4,7 @@
 package executor_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +45,7 @@ func TestPrepareDAGWorkspace(t *testing.T) {
 		},
 	}
 
-	seed, err := executor.PrepareDAGWorkspace(dag)
+	seed, err := executor.PrepareDAGWorkspace(context.Background(), dag)
 	require.NoError(t, err)
 	require.NotNil(t, seed)
 	assert.Equal(t, "dag.yaml", seed.Descriptor.DAGPath)
@@ -60,7 +61,7 @@ func TestPrepareDAGWorkspace(t *testing.T) {
 	assert.Equal(t, dagData, actualDAG)
 
 	require.NoError(t, os.WriteFile(filepath.Join(root, "root.txt"), []byte("updated"), 0o644))
-	updatedSeed, err := executor.PrepareDAGWorkspace(dag)
+	updatedSeed, err := executor.PrepareDAGWorkspace(context.Background(), dag)
 	require.NoError(t, err)
 	require.NotNil(t, updatedSeed)
 	assert.NotEqual(t, seed.Descriptor.Digest, updatedSeed.Descriptor.Digest)
@@ -82,13 +83,31 @@ func TestPrepareDAGWorkspaceUsesDAGWorkingDirectory(t *testing.T) {
 		Steps:              []ir.Step{{Dependencies: []string{"input.txt"}}},
 	}
 
-	seed, err := executor.PrepareDAGWorkspace(dag)
+	seed, err := executor.PrepareDAGWorkspace(context.Background(), dag)
 	require.NoError(t, err)
 	require.NotNil(t, seed)
 
 	dest := filepath.Join(t.TempDir(), "workspace")
 	require.NoError(t, workspacebundle.Extract(seed.Archive, dest, seed.Descriptor, workspacebundle.DefaultLimits()))
 	assert.FileExists(t, filepath.Join(dest, "input.txt"))
+}
+
+func TestPrepareDAGWorkspaceRejectsEmptyResolvedWorkingDirectory(t *testing.T) {
+	t.Setenv("DAGU_TEST_EMPTY_WORKSPACE_ROOT", "")
+
+	dagDir := t.TempDir()
+	dag := &ir.DAG{
+		Name:               "empty-working-dir",
+		SourceFile:         filepath.Join(dagDir, "dag.yaml"),
+		WorkingDir:         "$DAGU_TEST_EMPTY_WORKSPACE_ROOT",
+		WorkingDirExplicit: true,
+		YamlData:           []byte("name: empty-working-dir\nsteps:\n  - run: echo ok\n"),
+		Steps:              []ir.Step{{Dependencies: []string{"input.txt"}}},
+	}
+
+	_, err := executor.PrepareDAGWorkspace(context.Background(), dag)
+	require.ErrorContains(t, err, "working_dir")
+	require.ErrorContains(t, err, "DAGU_TEST_EMPTY_WORKSPACE_ROOT")
 }
 
 func TestDAG_CreateTask(t *testing.T) {

--- a/internal/runtime/executor/task_test.go
+++ b/internal/runtime/executor/task_test.go
@@ -66,6 +66,31 @@ func TestPrepareDAGWorkspace(t *testing.T) {
 	assert.NotEqual(t, seed.Descriptor.Digest, updatedSeed.Descriptor.Digest)
 }
 
+func TestPrepareDAGWorkspaceUsesDAGWorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	dagDir := t.TempDir()
+	workDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte("input"), 0o644))
+
+	dag := &ir.DAG{
+		Name:               "working-dir",
+		SourceFile:         filepath.Join(dagDir, "dag.yaml"),
+		WorkingDir:         workDir,
+		WorkingDirExplicit: true,
+		YamlData:           []byte("name: working-dir\nsteps:\n  - run: echo ok\n"),
+		Steps:              []ir.Step{{Dependencies: []string{"input.txt"}}},
+	}
+
+	seed, err := executor.PrepareDAGWorkspace(dag)
+	require.NoError(t, err)
+	require.NotNil(t, seed)
+
+	dest := filepath.Join(t.TempDir(), "workspace")
+	require.NoError(t, workspacebundle.Extract(seed.Archive, dest, seed.Descriptor, workspacebundle.DefaultLimits()))
+	assert.FileExists(t, filepath.Join(dest, "input.txt"))
+}
+
 func TestDAG_CreateTask(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -60,31 +61,68 @@ func dagWorkspacePackOptions(ctx context.Context, dag *ir.DAG) (string, *workspa
 	if len(includes) == 0 {
 		return "", nil, nil
 	}
-	if dag == nil || strings.TrimSpace(dag.SourceFile) == "" {
-		return "", nil, fmt.Errorf("DAG file dependencies require a source file")
-	}
 	if dag.YamlData == nil {
 		return "", nil, fmt.Errorf("DAG file dependencies require the dispatched definition")
 	}
 
-	sourceFile, err := filepath.Abs(dag.SourceFile)
-	if err != nil {
-		return "", nil, fmt.Errorf("resolve DAG source file %q: %w", dag.SourceFile, err)
+	var sourceFile string
+	if strings.TrimSpace(dag.SourceFile) != "" {
+		var err error
+		sourceFile, err = filepath.Abs(dag.SourceFile)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve DAG source file %q: %w", dag.SourceFile, err)
+		}
 	}
 	root := dag.WorkingDir
 	if strings.TrimSpace(root) == "" {
+		if sourceFile == "" {
+			return "", nil, fmt.Errorf("DAG file dependencies require a source file or working directory")
+		}
 		root = filepath.Dir(sourceFile)
 	} else {
+		var err error
 		root, err = runtimeenv.ResolveWorkingDir(ctx, dag)
 		if err != nil {
 			return "", nil, fmt.Errorf("resolve DAG working directory %q: %w", dag.WorkingDir, err)
 		}
 	}
+	dagPath, err := workspaceDAGPath(root, sourceFile)
+	if err != nil {
+		return "", nil, err
+	}
 	return root, &workspacebundle.PackOptions{
-		DAGPath:  filepath.Base(sourceFile),
+		DAGPath:  dagPath,
 		DAGData:  dag.YamlData,
 		Includes: includes,
 	}, nil
+}
+
+func workspaceDAGPath(root, sourceFile string) (string, error) {
+	if sourceFile != "" && workspacebundle.IsPathWithin(root, sourceFile) {
+		rel, err := filepath.Rel(root, sourceFile)
+		if err != nil {
+			return "", fmt.Errorf("resolve workspace DAG path: %w", err)
+		}
+		normalized, err := workspacebundle.NormalizeRelativePath(rel)
+		if err != nil {
+			return "", fmt.Errorf("normalize workspace DAG path: %w", err)
+		}
+		return normalized, nil
+	}
+
+	for suffix := 0; ; suffix++ {
+		name := ".dagu-workflow.yaml"
+		if suffix > 0 {
+			name = fmt.Sprintf(".dagu-workflow-%d.yaml", suffix)
+		}
+		_, err := os.Lstat(filepath.Join(root, name))
+		if os.IsNotExist(err) {
+			return name, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("inspect workspace DAG path %q: %w", name, err)
+		}
+	}
 }
 
 func dagFileDependencies(dag *ir.DAG) []string {

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
+	"github.com/dagucloud/dagu/v2/internal/runtimeenv"
 )
 
 type workspaceSeedKey struct{}
@@ -27,8 +27,8 @@ func workspaceSeedFromContext(ctx context.Context) (WorkspaceSeed, bool) {
 }
 
 // PrepareDAGWorkspace snapshots the files declared by a DAG.
-func PrepareDAGWorkspace(dag *ir.DAG) (*WorkspaceSeed, error) {
-	root, opts, err := dagWorkspacePackOptions(dag)
+func PrepareDAGWorkspace(ctx context.Context, dag *ir.DAG) (*WorkspaceSeed, error) {
+	root, opts, err := dagWorkspacePackOptions(ctx, dag)
 	if err != nil || opts == nil {
 		return nil, err
 	}
@@ -40,8 +40,8 @@ func PrepareDAGWorkspace(dag *ir.DAG) (*WorkspaceSeed, error) {
 }
 
 // PrepareDAGWorkspaceFile snapshots declared files into a staged archive under bundleDir.
-func PrepareDAGWorkspaceFile(dag *ir.DAG, bundleDir string) (*workspacebundle.Descriptor, string, error) {
-	root, opts, err := dagWorkspacePackOptions(dag)
+func PrepareDAGWorkspaceFile(ctx context.Context, dag *ir.DAG, bundleDir string) (*workspacebundle.Descriptor, string, error) {
+	root, opts, err := dagWorkspacePackOptions(ctx, dag)
 	if err != nil || opts == nil {
 		return nil, "", err
 	}
@@ -55,7 +55,7 @@ func PrepareDAGWorkspaceFile(dag *ir.DAG, bundleDir string) (*workspacebundle.De
 	return descriptor, archivePath, nil
 }
 
-func dagWorkspacePackOptions(dag *ir.DAG) (string, *workspacebundle.PackOptions, error) {
+func dagWorkspacePackOptions(ctx context.Context, dag *ir.DAG) (string, *workspacebundle.PackOptions, error) {
 	includes := dagFileDependencies(dag)
 	if len(includes) == 0 {
 		return "", nil, nil
@@ -74,10 +74,11 @@ func dagWorkspacePackOptions(dag *ir.DAG) (string, *workspacebundle.PackOptions,
 	root := dag.WorkingDir
 	if strings.TrimSpace(root) == "" {
 		root = filepath.Dir(sourceFile)
-	}
-	root, err = fileutil.ResolvePath(root)
-	if err != nil {
-		return "", nil, fmt.Errorf("resolve DAG working directory %q: %w", dag.WorkingDir, err)
+	} else {
+		root, err = runtimeenv.ResolveWorkingDir(ctx, dag)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve DAG working directory %q: %w", dag.WorkingDir, err)
+		}
 	}
 	return root, &workspacebundle.PackOptions{
 		DAGPath:  filepath.Base(sourceFile),

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 )
@@ -25,7 +26,7 @@ func workspaceSeedFromContext(ctx context.Context) (WorkspaceSeed, bool) {
 	return seed, ok
 }
 
-// PrepareDAGWorkspace snapshots the files declared by a DAG for distributed execution.
+// PrepareDAGWorkspace snapshots the files declared by a DAG.
 func PrepareDAGWorkspace(dag *ir.DAG) (*WorkspaceSeed, error) {
 	root, opts, err := dagWorkspacePackOptions(dag)
 	if err != nil || opts == nil {
@@ -70,7 +71,15 @@ func dagWorkspacePackOptions(dag *ir.DAG) (string, *workspacebundle.PackOptions,
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve DAG source file %q: %w", dag.SourceFile, err)
 	}
-	return filepath.Dir(sourceFile), &workspacebundle.PackOptions{
+	root := dag.WorkingDir
+	if strings.TrimSpace(root) == "" {
+		root = filepath.Dir(sourceFile)
+	}
+	root, err = fileutil.ResolvePath(root)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve DAG working directory %q: %w", dag.WorkingDir, err)
+	}
+	return root, &workspacebundle.PackOptions{
 		DAGPath:  filepath.Base(sourceFile),
 		DAGData:  dag.YamlData,
 		Includes: includes,

--- a/internal/runtimeenv/runtimeenv.go
+++ b/internal/runtimeenv/runtimeenv.go
@@ -59,6 +59,51 @@ func Resolve(ctx context.Context, dag *ir.DAG) (Result, error) {
 	return result, nil
 }
 
+// ResolveWorkingDir resolves a DAG working directory using values available before execution.
+func ResolveWorkingDir(ctx context.Context, dag *ir.DAG) (string, error) {
+	if dag == nil || strings.TrimSpace(dag.WorkingDir) == "" {
+		return "", nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	resolvedEnv, err := Resolve(ctx, dag)
+	if err != nil {
+		return "", err
+	}
+	resolvedDAG := dag.Clone()
+	resolvedDAG.Env = resolvedEnv.Env
+	scope := dotenvEnvScope(resolvedDAG)
+	var notices cmnvalue.ValueReferenceNoticeCollector
+	resolver := cmnvalue.NewResolver(
+		cmnvalue.StaticScope{
+			Consts: cmnvalue.Values(dag.Consts),
+			Params: dag.ParamDeclarations(),
+		},
+		cmnvalue.RuntimeScope{
+			Consts:     cmnvalue.Values(dag.Consts),
+			Params:     dag.ParamValues(),
+			ParamsJSON: dag.ParamsJSON,
+			Env:        scope,
+		},
+		cmnvalue.WithValueReferenceNotices(&notices),
+	)
+	workingDir, err := resolver.String(ctx, dag.WorkingDir, cmnvalue.DAGWorkingDirField("working_dir"))
+	if err != nil {
+		return "", err
+	}
+	workingDir = scope.Expand(workingDir)
+	cmnvalue.ReportUnresolvedEnvExpansionNotices(workingDir, "working_dir", scope, &notices)
+	if unresolved := notices.Notices(); len(unresolved) > 0 {
+		return "", fmt.Errorf("working_dir %q could not be resolved: %s", dag.WorkingDir, unresolved[0].Message)
+	}
+	if strings.TrimSpace(workingDir) == "" {
+		return "", fmt.Errorf("working_dir %q resolved to an empty path", dag.WorkingDir)
+	}
+	return fileutil.ResolvePath(workingDir)
+}
+
 func dotenvEnvScope(dag *ir.DAG) *cmnvalue.EnvScope {
 	scope := cmnvalue.NewEnvScope(nil, true)
 	if params := buildenv.ToMap(dag.Params); len(params) > 0 {

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -342,7 +342,7 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	if err != nil {
 		return fmt.Errorf("load DAG for file dependency snapshot: %w", err)
 	}
-	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(dag, cli.config.WorkspaceBundleDir)
+	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(ctx, dag, cli.config.WorkspaceBundleDir)
 	if err != nil {
 		return err
 	}

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -326,11 +326,16 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	loadOpts := []spec.LoadOption{
 		spec.WithName(task.Target),
 	}
+	if task.SourceWorkDir != "" {
+		loadOpts = append(loadOpts, spec.WithDefaultWorkingDir(task.SourceWorkDir))
+	}
 	if task.BaseConfig != "" {
 		loadOpts = append(loadOpts, spec.WithBaseConfigContent([]byte(task.BaseConfig)))
 	}
 	if task.Params != "" {
 		loadOpts = append(loadOpts, spec.WithParams(task.Params))
+	} else if task.Operation == dispatch.DispatchOperationRetry && task.PreviousStatus != nil && len(task.PreviousStatus.ParamsList) > 0 {
+		loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(task.PreviousStatus.ParamsList, nil)))
 	}
 	var dag *ir.DAG
 	var err error

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -68,10 +68,11 @@ func TestClientDispatch(t *testing.T) {
 	t.Run("UploadsDeclaredFileDependencies", func(t *testing.T) {
 		t.Parallel()
 
-		root := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(root, "input.txt"), []byte("input"), 0o644))
-		dagFile := filepath.Join(root, "dag.yaml")
-		definition := "name: test\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n"
+		dagRoot := t.TempDir()
+		dependencyRoot := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dependencyRoot, "input.txt"), []byte("input"), 0o644))
+		dagFile := filepath.Join(dagRoot, "dag.yaml")
+		definition := fmt.Sprintf("name: test\nparams:\n  WORKSPACE: %q\nworking_dir: ${params.WORKSPACE}\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n", dagRoot)
 		workspaceBundleDir := filepath.Join(t.TempDir(), "workspace-bundles")
 		stagingDir := filepath.Join(workspaceBundleDir, "staging")
 		dest := filepath.Join(t.TempDir(), "workspace")
@@ -107,8 +108,8 @@ func TestClientDispatch(t *testing.T) {
 				if req.Task.WorkspaceBundleSize != int64(len(uploaded)) {
 					return nil, fmt.Errorf("workspace bundle size is %d, want %d", req.Task.WorkspaceBundleSize, len(uploaded))
 				}
-				if req.Task.WorkspaceBundleDagPath != "dag.yaml" {
-					return nil, fmt.Errorf("workspace bundle DAG path is %q, want dag.yaml", req.Task.WorkspaceBundleDagPath)
+				if req.Task.WorkspaceBundleDagPath == "" {
+					return nil, fmt.Errorf("workspace bundle DAG path is empty")
 				}
 				if err := workspacebundle.Extract(uploaded, dest, workspacebundle.Descriptor{
 					Digest:  req.Task.WorkspaceBundleDigest,
@@ -117,7 +118,7 @@ func TestClientDispatch(t *testing.T) {
 				}, workspacebundle.DefaultLimits()); err != nil {
 					return nil, fmt.Errorf("extract uploaded workspace bundle: %w", err)
 				}
-				actualDAG, err := os.ReadFile(filepath.Join(dest, "dag.yaml"))
+				actualDAG, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(req.Task.WorkspaceBundleDagPath)))
 				if err != nil {
 					return nil, fmt.Errorf("read uploaded DAG: %w", err)
 				}
@@ -139,10 +140,14 @@ func TestClientDispatch(t *testing.T) {
 		}}}, config)
 
 		err := client.Dispatch(context.Background(), dispatch.DispatchRequest{Task: &dispatch.DispatchTask{
+			Operation:  dispatch.DispatchOperationRetry,
 			DAGRunID:   "run-1",
 			Target:     "test",
 			Definition: definition,
 			SourceFile: dagFile,
+			PreviousStatus: &ir.DAGRunStatus{
+				ParamsList: []string{"WORKSPACE=" + dependencyRoot},
+			},
 		}})
 		require.NoError(t, err)
 		assert.FileExists(t, filepath.Join(dest, "input.txt"))

--- a/internal/service/worker/worker.go
+++ b/internal/service/worker/worker.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -33,6 +35,7 @@ type Worker struct {
 	coordinatorCli coordinator.Client
 	handler        TaskHandler
 	labels         map[string]string
+	labelErr       error
 	cfg            *config.Config
 
 	// For tracking poller states and heartbeats
@@ -111,12 +114,14 @@ func NewWorker(
 		healthPort = cfg.Worker.HealthPort
 		openCodeConfig = cfg.OpenCode
 	}
+	labels, labelErr := workerLabels(labels)
 
 	return &Worker{
 		id:             workerID,
 		maxActiveRuns:  maxActiveRuns,
 		coordinatorCli: coordinatorClient,
 		labels:         labels,
+		labelErr:       labelErr,
 		cfg:            cfg,
 		runningTasks:   make(map[string]*runningTaskState),
 		pollerTasks:    make(map[string]string),
@@ -128,6 +133,9 @@ func NewWorker(
 
 // Start begins the worker's operation, launching multiple polling goroutines.
 func (w *Worker) Start(ctx context.Context) (err error) {
+	if w.labelErr != nil {
+		return w.labelErr
+	}
 	logger.Info(ctx, "Starting worker",
 		tag.WorkerID(w.id),
 		tag.MaxConcurrency(w.maxActiveRuns))
@@ -223,6 +231,30 @@ func (w *Worker) Start(ctx context.Context) (err error) {
 	<-w.stopDone
 
 	return nil
+}
+
+func workerLabels(configured map[string]string) (map[string]string, error) {
+	labels := maps.Clone(configured)
+	if labels == nil {
+		labels = make(map[string]string, 2)
+	}
+	for _, platform := range []struct {
+		key   string
+		value string
+	}{
+		{key: "os", value: runtime.GOOS},
+		{key: "arch", value: runtime.GOARCH},
+	} {
+		if configuredValue, ok := labels[platform.key]; ok && configuredValue != platform.value {
+			return nil, fmt.Errorf(
+				"worker label %q conflicts with built-in platform value %q",
+				platform.key,
+				platform.value,
+			)
+		}
+		labels[platform.key] = platform.value
+	}
+	return labels, nil
 }
 
 func (w *Worker) cleanupAgentSessions(ctx context.Context) {

--- a/internal/service/worker/worker_test.go
+++ b/internal/service/worker/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -387,6 +388,24 @@ func TestWorkerWithLabels(t *testing.T) {
 	})
 }
 
+func TestWorkerRejectsConflictingPlatformLabels(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w := worker.NewWorker(
+		"conflicting-platform",
+		1,
+		newMockCoordinatorCli(),
+		map[string]string{"os": "not-" + runtime.GOOS},
+		&config.Config{},
+	)
+	w.SetHandler(&mockHandler{})
+
+	err := w.Start(ctx)
+	require.ErrorContains(t, err, `worker label "os" conflicts with built-in platform value`)
+}
+
 func TestWorkerHeartbeat(t *testing.T) {
 	t.Run("SendsHeartbeats", func(t *testing.T) {
 		// Setup test environment
@@ -429,6 +448,8 @@ func TestWorkerHeartbeat(t *testing.T) {
 				found = true
 				assert.Equal(t, int32(3), wk.TotalPollers)
 				assert.NotZero(t, wk.LastHeartbeatAt)
+				assert.Equal(t, runtime.GOOS, wk.Labels["os"])
+				assert.Equal(t, runtime.GOARCH, wk.Labels["arch"])
 				break
 			}
 		}

--- a/llms.txt
+++ b/llms.txt
@@ -32,7 +32,7 @@ Load only the reference file that matches the task.
 - Prefer scoped Dagu references for named values: `${consts.NAME}`, `${params.NAME}`, and `${env.NAME}`. Avoid unscoped braced names in examples unless the example is intentionally showing shell syntax.
 - Declare portable external CLI dependencies in top-level `tools` using aqua shorthand when the binary version affects reproducibility, for example `tools: ["jqlang/jq@jq-1.7.1"]`. Append `#sha256:<64 hex>` to also pin the downloaded artifact content for the run platform, for example `jqlang/jq@jq-1.7.1#sha256:<hex>`.
 - For remote actions, put `tools` in the referenced action DAG file, not in `dagu-action.yaml`; caller DAG tools are not inherited across the action boundary.
-- Declare step-level `dependencies` when a distributed worker needs files stored beside the DAG. Use literal DAG-relative paths or glob patterns; do not use value references.
+- Declare step-level `dependencies` when a run needs files from the DAG working directory. Use literal working-directory-relative paths or glob patterns; do not use value references.
 - Use remote action packages (`dagu-action.yaml`) when reusable logic needs helper files, its own DAG, versioning, or an input/output schema contract.
 
 ## High-Signal Rules
@@ -64,7 +64,7 @@ Load only the reference file that matches the task.
 - Git worktree actions discover the repository from the step `working_dir`. Relative worktree paths resolve from the repository root, and the actions never fetch or push.
 - Remote action packages define `dagu-action.yaml` with `apiVersion: v1alpha1`, `name`, `dag`, and optional `inputs`/`outputs` JSON Schemas. `inputs` validates caller `with:` before the action DAG starts; `outputs` validates the final action output object after the action DAG returns.
 - Remote action manifests do not support `tools`. Declare external CLI tools in the action DAG itself so local and distributed workers prepare the right binaries for that action run.
-- `dependencies` snapshots files only for distributed execution. Local runs use the host filesystem without staging. The extracted bundle is available through `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}`.
+- `dependencies` snapshots files from the DAG working directory for both local and distributed execution. The materialized bundle is available through `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` and becomes the DAG process working directory.
 - In remote action examples, prefer `dag: workflow.yaml` for the action DAG filename. The `dag` field accepts any safe relative file path, but `workflow.yaml` avoids confusing the executable DAG with the `dagu-action.yaml` manifest.
 - Object-form `output:` with `decode: json` or `decode: yaml` can act as lightweight runtime validation. Malformed data or an unresolved `select:` path fails the step, so normal `retry_policy` applies.
 - Use DAG-level `shell` and `shell_args` only when every inherited `run:` step should use the same shell invocation. Use step-level `with.shell` and `with.shell_args` for a single step.
@@ -212,7 +212,7 @@ Load only the file you need:
 - `references/cli.md` when choosing or using Dagu CLI commands, including workflow inspection, execution, and cleanup operations
 - `references/context.md` when using `${context.*}` metadata references or declared step `outputs:`
 - `references/build.md` when creating or troubleshooting a `type: build` file workflow, path references, reuse decisions, or `--no-reuse`
-- `references/file-dependencies.md` when a distributed DAG needs scripts, configuration, or other files stored beside its YAML definition
+- `references/file-dependencies.md` when a DAG needs scripts, configuration, or other files from its working directory
 - `references/harnesses.md` only when the DAG invokes external CLI harnesses through `harness.run`
 
 ---
@@ -1372,7 +1372,7 @@ Start gRPC coordinator: `dagu coordinator [--coordinator.host/-H <host>] [--coor
 
 ### dagu worker
 
-Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`
+Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
 
 ## Git Sync
 

--- a/skills/dagu/SKILL.md
+++ b/skills/dagu/SKILL.md
@@ -29,7 +29,7 @@ Load only the reference file that matches the task.
 - Prefer scoped Dagu references for named values: `${consts.NAME}`, `${params.NAME}`, and `${env.NAME}`. Avoid unscoped braced names in examples unless the example is intentionally showing shell syntax.
 - Declare portable external CLI dependencies in top-level `tools` using aqua shorthand when the binary version affects reproducibility, for example `tools: ["jqlang/jq@jq-1.7.1"]`. Append `#sha256:<64 hex>` to also pin the downloaded artifact content for the run platform, for example `jqlang/jq@jq-1.7.1#sha256:<hex>`.
 - For remote actions, put `tools` in the referenced action DAG file, not in `dagu-action.yaml`; caller DAG tools are not inherited across the action boundary.
-- Declare step-level `dependencies` when a distributed worker needs files stored beside the DAG. Use literal DAG-relative paths or glob patterns; do not use value references.
+- Declare step-level `dependencies` when a run needs files from the DAG working directory. Use literal working-directory-relative paths or glob patterns; do not use value references.
 - Use remote action packages (`dagu-action.yaml`) when reusable logic needs helper files, its own DAG, versioning, or an input/output schema contract.
 
 ## High-Signal Rules
@@ -61,7 +61,7 @@ Load only the reference file that matches the task.
 - Git worktree actions discover the repository from the step `working_dir`. Relative worktree paths resolve from the repository root, and the actions never fetch or push.
 - Remote action packages define `dagu-action.yaml` with `apiVersion: v1alpha1`, `name`, `dag`, and optional `inputs`/`outputs` JSON Schemas. `inputs` validates caller `with:` before the action DAG starts; `outputs` validates the final action output object after the action DAG returns.
 - Remote action manifests do not support `tools`. Declare external CLI tools in the action DAG itself so local and distributed workers prepare the right binaries for that action run.
-- `dependencies` snapshots files only for distributed execution. Local runs use the host filesystem without staging. The extracted bundle is available through `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}`.
+- `dependencies` snapshots files from the DAG working directory for both local and distributed execution. The materialized bundle is available through `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` and becomes the DAG process working directory.
 - In remote action examples, prefer `dag: workflow.yaml` for the action DAG filename. The `dag` field accepts any safe relative file path, but `workflow.yaml` avoids confusing the executable DAG with the `dagu-action.yaml` manifest.
 - Object-form `output:` with `decode: json` or `decode: yaml` can act as lightweight runtime validation. Malformed data or an unresolved `select:` path fails the step, so normal `retry_policy` applies.
 - Use DAG-level `shell` and `shell_args` only when every inherited `run:` step should use the same shell invocation. Use step-level `with.shell` and `with.shell_args` for a single step.
@@ -209,5 +209,5 @@ Load only the file you need:
 - `references/cli.md` when choosing or using Dagu CLI commands, including workflow inspection, execution, and cleanup operations
 - `references/context.md` when using `${context.*}` metadata references or declared step `outputs:`
 - `references/build.md` when creating or troubleshooting a `type: build` file workflow, path references, reuse decisions, or `--no-reuse`
-- `references/file-dependencies.md` when a distributed DAG needs scripts, configuration, or other files stored beside its YAML definition
+- `references/file-dependencies.md` when a DAG needs scripts, configuration, or other files from its working directory
 - `references/harnesses.md` only when the DAG invokes external CLI harnesses through `harness.run`

--- a/skills/dagu/references/cli.md
+++ b/skills/dagu/references/cli.md
@@ -263,7 +263,7 @@ Start gRPC coordinator: `dagu coordinator [--coordinator.host/-H <host>] [--coor
 
 ### dagu worker
 
-Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`
+Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
 
 ## Git Sync
 

--- a/skills/dagu/references/file-dependencies.md
+++ b/skills/dagu/references/file-dependencies.md
@@ -1,6 +1,6 @@
 # File Dependencies
 
-Use step-level `dependencies` when a distributed worker needs files stored beside the authored DAG.
+Use step-level `dependencies` when a DAG run needs files from its working directory.
 
 ```yaml
 steps:
@@ -11,10 +11,10 @@ steps:
       - config/app.yaml
 ```
 
-The field accepts one string or an array. Each item is a literal path relative to the authored DAG file and may be an exact file, a recursively included directory, or a glob using `*`, `?`, character classes, or `**`.
+The field accepts one string or an array. Each item is a literal path relative to the DAG working directory and may be an exact file, a recursively included directory, or a glob using `*`, `?`, character classes, or `**`. When `working_dir` is omitted, the authored DAG file's directory is the source root.
 
-Every item must match during distributed dispatch. Do not use `${...}` references, absolute paths, parent traversal, `.git` paths, symlinks, or special files. All dependencies in the root DAG, lifecycle handlers, foreach bodies, and inline DAG documents share one bundle.
+Every item must match when the run workspace is prepared. Do not use `${...}` references, absolute paths, parent traversal, `.git` paths, symlinks, or special files. All dependencies in the root DAG, lifecycle handlers, foreach bodies, and inline DAG documents share one bundle.
 
-The worker extracts the bundle to `DAG_RUN_WORK_DIR`, also exposed as `${context.paths.work_dir}`. This is the default process working directory unless the DAG has an explicit working directory. Local execution does not stage dependencies.
+Local execution materializes the bundle directly; distributed execution transfers it through the coordinator before worker materialization. The result is exposed as `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` and becomes the DAG process working directory. An explicit step working directory retains its normal precedence.
 
 Retries create a new snapshot. Separately fetched named child DAGs cannot add dependencies from a remote worker; use an inline multi-document child DAG or keep that child local.

--- a/specs/035-file-dependencies.md
+++ b/specs/035-file-dependencies.md
@@ -22,7 +22,7 @@ This spec does not define:
 
 ## Goal
 
-A DAG dispatched to a worker can use scripts, configuration, and other files stored beside its authored YAML without requiring a shared filesystem.
+A DAG can use declared files from its working directory with the same isolated workspace behavior in local and distributed execution.
 
 ## Behavior
 
@@ -34,29 +34,28 @@ A DAG dispatched to a worker can use scripts, configuration, and other files sto
 
 ### Matching
 
-- Paths resolve relative to the authored DAG file.
+- Paths resolve relative to the DAG working directory. When `working_dir` is omitted, the authored DAG file's directory is the source root.
 - An exact regular file selects that file.
 - An exact directory selects the directory and its descendants recursively.
 - A glob may use `*`, `?`, character classes, and `**`.
 - Overlapping selections include each filesystem entry once.
-- Every declaration must match at least one filesystem entry at dispatch time.
+- Every declaration must match at least one filesystem entry when the run workspace is prepared.
 - Absolute paths, parent traversal, `.git` paths, symlinks, special files, and invalid glob patterns are invalid.
 
-### Distributed execution
+### Workspace execution
 
-- A distributed start or retry snapshots the current matching entries before task dispatch.
+- A local or distributed start or retry snapshots the current matching entries before execution.
 - The snapshot contains the exact DAG definition carried by the dispatched task.
-- The coordinator transports an immutable content-addressed bundle to the worker.
-- The worker materializes the bundle as `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` before execution.
-- The materialized directory is the implicit process working directory. An explicit DAG working directory remains the process working directory without changing `DAG_RUN_WORK_DIR`.
+- Local execution materializes the snapshot directly. Distributed execution transports the immutable content-addressed bundle through the coordinator before the worker materializes it.
+- The snapshot is materialized as `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` before execution.
+- The materialized directory is the process working directory for the DAG. An explicit step working directory retains its normal precedence.
 - The bundle must not exceed 64 MiB compressed, 256 MiB extracted, or 8192 entries.
 
 ### Child DAGs and retries
 
 - Inline multi-document child DAGs reuse the root DAG's snapshot.
 - A separately fetched named child DAG with file dependencies cannot be dispatched from a remote worker without an available source workspace.
-- Each independently dispatched retry creates a fresh snapshot from the authored DAG directory.
-- Local execution does not stage declared files.
+- Each independently executed retry creates a fresh snapshot from the DAG working directory.
 
 ## Errors
 

--- a/specs/035-file-dependencies.md
+++ b/specs/035-file-dependencies.md
@@ -10,7 +10,7 @@ This spec defines:
 
 - the step-level `dependencies` field
 - dependency path matching and validation
-- distributed workspace snapshot and materialization behavior
+- local and distributed workspace snapshot and materialization behavior
 - retry and inline child-DAG behavior
 
 This spec does not define:
@@ -62,10 +62,10 @@ A DAG can use declared files from its working directory with the same isolated w
 | Failure class | Required diagnostic |
 | --- | --- |
 | Value reference in a dependency | validation error naming `dependencies` |
-| Invalid or unsafe path | dispatch rejected with the dependency path and reason |
-| Declaration with no match | dispatch rejected naming the unmatched declaration |
-| Unsupported filesystem entry | dispatch rejected naming the entry type and path |
-| Bundle limit exceeded | dispatch rejected naming the exceeded limit |
+| Invalid or unsafe path | workspace preparation fails with the dependency path and reason |
+| Declaration with no match | workspace preparation fails naming the unmatched declaration |
+| Unsupported filesystem entry | workspace preparation fails naming the entry type and path |
+| Bundle limit exceeded | workspace preparation fails naming the exceeded limit |
 | Worker download, verification, or extraction failure | DAG-run fails before step execution |
 
 ## Examples


### PR DESCRIPTION
## Summary
- source file dependencies from the DAG working directory and materialize them for local runs
- use the same workspace snapshot semantics for coordinator/worker execution, including dynamically resolved working directories
- add built-in worker OS and architecture labels so the platform selectors reported in the #2581 follow-up can match compatible workers
- update the file dependency contract, schema descriptions, authoring guidance, and conformance fixtures

## Testing
- make fmt
- make test
- go test ./internal/runtimeenv ./internal/runtime/executor ./internal/runtime/agent ./internal/service/coordinator ./internal/intg/distr -count=1
- file dependency regression verified red against the old raw-path behavior and green with the resolver

Closes #2581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File dependencies now work consistently for local and distributed runs.
  - Dependencies are resolved from the DAG working directory and materialized into the execution workspace.
  - Inline and source-less DAGs support configured working directories.
  - Workers now advertise immutable `os` and `arch` platform labels.

- **Bug Fixes**
  - Improved workspace handling for retries, embedded DAGs, hidden files, and dependencies outside the DAG source directory.

- **Documentation**
  - Updated dependency, working-directory, worker-label, API, and CLI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->