### PR TITLE
fix: make service shutdown interruptible

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -5,11 +5,13 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/agentsession"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
@@ -55,6 +57,8 @@ Example:
 
 var serverFlags = []commandLineFlag{dagsFlag, hostFlag, portFlag, tunnelFlag, tunnelTokenFlag, tunnelFunnelFlag, tunnelHTTPSFlag}
 
+const localAgentSessionShutdownTimeout = 10 * time.Second
+
 func newServer(ctx *Context, rs *resource.Service, stores frontend.Stores, opts ...frontend.ServerOption) (*frontend.Server, error) {
 	coordinatorClient, err := ctx.NewCoordinatorClient()
 	if err != nil {
@@ -95,10 +99,10 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 	openCodeHost := opencodehost.New(signalCtx, ctx.Config.OpenCode)
 	cleanupCancel, cleanupDone := startLocalAgentSessionCleanup(signalCtx, ctx.Persistence, openCodeHost)
 	defer func() {
-		cleanupCancel()
-		<-cleanupDone
-		if err := openCodeHost.Close(ctx); err != nil {
-			logger.Error(ctx, "Failed to stop OpenCode host", tag.Error(err))
+		shutdownCtx, shutdownCancel := localAgentSessionShutdownContext(ctx)
+		defer shutdownCancel()
+		if err := stopLocalAgentSessionCleanup(shutdownCtx, cleanupCancel, cleanupDone, openCodeHost); err != nil {
+			logger.Error(ctx, "Failed to stop local agent session services", tag.Error(err))
 		}
 	}()
 	serverOpts = append(serverOpts, frontend.WithAPIOption(apiv1.WithOpenCodeHost(openCodeHost)))
@@ -173,7 +177,9 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 		}
 	}
 
-	if err := server.Serve(serviceCtx); err != nil {
+	err = server.Serve(serviceCtx)
+	stop() // Restore default signal handling while deferred cleanup runs.
+	if err != nil {
 		return fmt.Errorf("failed to start server: %w", err)
 	}
 
@@ -198,6 +204,26 @@ func startLocalAgentSessionCleanup(ctx context.Context, persistence Persistence,
 			})
 	}()
 	return cancel, done
+}
+
+func stopLocalAgentSessionCleanup(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	done <-chan struct{},
+	host *opencodehost.Host,
+) error {
+	cancel()
+	var cleanupErr error
+	select {
+	case <-done:
+	case <-ctx.Done():
+		cleanupErr = fmt.Errorf("wait for agent session cleanup: %w", ctx.Err())
+	}
+	return errors.Join(cleanupErr, host.Close(ctx))
+}
+
+func localAgentSessionShutdownContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), localAgentSessionShutdownTimeout)
 }
 
 // initTunnelService creates and returns a tunnel service based on configuration.

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -99,6 +99,7 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 	openCodeHost := opencodehost.New(signalCtx, ctx.Config.OpenCode)
 	cleanupCancel, cleanupDone := startLocalAgentSessionCleanup(signalCtx, ctx.Persistence, openCodeHost)
 	defer func() {
+		stop()
 		shutdownCtx, shutdownCancel := localAgentSessionShutdownContext(ctx)
 		defer shutdownCancel()
 		if err := stopLocalAgentSessionCleanup(shutdownCtx, cleanupCancel, cleanupDone, openCodeHost); err != nil {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -98,8 +98,23 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 	serviceCtx := ctx.WithContext(signalCtx)
 	openCodeHost := opencodehost.New(signalCtx, ctx.Config.OpenCode)
 	cleanupCancel, cleanupDone := startLocalAgentSessionCleanup(signalCtx, ctx.Persistence, openCodeHost)
+	var tunnelService *tunnel.Service
+	var resourceService *resource.Service
 	defer func() {
 		stop()
+		if resourceService != nil {
+			if err := resourceService.Stop(ctx); err != nil {
+				logger.Error(ctx, "Failed to stop resource service", tag.Error(err))
+			}
+		}
+		if tunnelService != nil {
+			if err := tunnelService.Stop(ctx); err != nil {
+				logger.Error(ctx, "Failed to stop tunnel service", tag.Error(err))
+			}
+		}
+		if ctx.LicenseManager != nil {
+			ctx.LicenseManager.Stop()
+		}
 		shutdownCtx, shutdownCancel := localAgentSessionShutdownContext(ctx)
 		defer shutdownCancel()
 		if err := stopLocalAgentSessionCleanup(shutdownCtx, cleanupCancel, cleanupDone, openCodeHost); err != nil {
@@ -107,11 +122,6 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 		}
 	}()
 	serverOpts = append(serverOpts, frontend.WithAPIOption(apiv1.WithOpenCodeHost(openCodeHost)))
-
-	// Stop license manager on shutdown
-	if ctx.LicenseManager != nil {
-		defer ctx.LicenseManager.Stop()
-	}
 
 	stores, err := frontendfile.NewStores(serviceCtx, serviceCtx.Config, serviceCtx.backend)
 	if err != nil {
@@ -125,27 +135,15 @@ func runServer(ctx *Context, _ []string, serverOpts ...frontend.ServerOption) er
 	)
 
 	// Initialize tunnel service if enabled
-	tunnelService, err := initTunnelService(ctx.Config)
+	tunnelService, err = initTunnelService(ctx.Config)
 	if err != nil {
 		return fmt.Errorf("failed to initialize tunnel: %w", err)
 	}
-	if tunnelService != nil {
-		defer func() {
-			if err := tunnelService.Stop(ctx); err != nil {
-				logger.Error(ctx, "Failed to stop tunnel service", tag.Error(err))
-			}
-		}()
-	}
 
-	// Initialize resource monitoring service (defer cleanup, but don't start yet).
+	// Initialize resource monitoring service, but don't start it yet.
 	// Resource monitoring must start AFTER server init to avoid race condition
 	// with auth provider initialization (gopsutil conflicts with net/http dial).
-	resourceService := resource.NewService(ctx.Config)
-	defer func() {
-		if err := resourceService.Stop(ctx); err != nil {
-			logger.Error(ctx, "Failed to stop resource service", tag.Error(err))
-		}
-	}()
+	resourceService = resource.NewService(ctx.Config)
 
 	serverOpts = append([]frontend.ServerOption(nil), serverOpts...)
 	if tunnelService != nil {

--- a/internal/cmd/server_internal_test.go
+++ b/internal/cmd/server_internal_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopLocalAgentSessionCleanupHonorsShutdownContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	done := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- stopLocalAgentSessionCleanup(ctx, func() {}, done, nil)
+	}()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(100 * time.Millisecond):
+		close(done)
+		<-result
+		t.Fatal("agent session cleanup did not honor the shutdown context")
+	}
+}

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -37,6 +37,10 @@ func TestServerCommand(t *testing.T) {
 	})
 }
 
+func TestServerSecondInterruptTerminatesBlockedCleanup(t *testing.T) {
+	assertSecondInterruptTerminatesBlockedCleanup(t, "server", "Resource monitoring service stopped")
+}
+
 // findPort finds an available port.
 func findPort(t *testing.T) string {
 	t.Helper()

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -153,10 +153,10 @@ func runStartAll(ctx *Context, _ []string) error {
 	openCodeHost := opencodehost.New(signalCtx, ctx.Config.OpenCode)
 	cleanupCancel, cleanupDone := startLocalAgentSessionCleanup(signalCtx, ctx.Persistence, openCodeHost)
 	defer func() {
-		cleanupCancel()
-		<-cleanupDone
-		if err := openCodeHost.Close(ctx); err != nil {
-			logger.Error(ctx, "Failed to stop OpenCode host", tag.Error(err))
+		shutdownCtx, shutdownCancel := localAgentSessionShutdownContext(ctx)
+		defer shutdownCancel()
+		if err := stopLocalAgentSessionCleanup(shutdownCtx, cleanupCancel, cleanupDone, openCodeHost); err != nil {
+			logger.Error(ctx, "Failed to stop local agent session services", tag.Error(err))
 		}
 	}()
 
@@ -258,8 +258,8 @@ func runStartAll(ctx *Context, _ []string) error {
 			firstErr = err
 			logger.Error(ctx, "Service failed, shutting down", tag.Error(err))
 		}
-		stop() // Cancel the signal context to trigger shutdown of other services
 	}
+	stop() // Restore default signal handling while graceful shutdown runs.
 
 	// Stop all services gracefully
 	logger.Info(ctx, "Stopping all services")

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -153,6 +153,7 @@ func runStartAll(ctx *Context, _ []string) error {
 	openCodeHost := opencodehost.New(signalCtx, ctx.Config.OpenCode)
 	cleanupCancel, cleanupDone := startLocalAgentSessionCleanup(signalCtx, ctx.Persistence, openCodeHost)
 	defer func() {
+		stop()
 		shutdownCtx, shutdownCancel := localAgentSessionShutdownContext(ctx)
 		defer shutdownCancel()
 		if err := stopLocalAgentSessionCleanup(shutdownCtx, cleanupCancel, cleanupDone, openCodeHost); err != nil {

--- a/internal/cmd/startall_test.go
+++ b/internal/cmd/startall_test.go
@@ -5,17 +5,10 @@ package cmd_test
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmd"
 	"github.com/dagucloud/dagu/v2/internal/test"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStartAllCommand(t *testing.T) {
@@ -48,76 +41,5 @@ func TestStartAllCommand(t *testing.T) {
 }
 
 func TestStartAllSecondInterruptTerminatesBlockedCleanup(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("named pipes are not available on Windows")
-	}
-
-	th := test.SetupCommand(t, test.WithBuiltExecutable())
-	cleanupDir := filepath.Join(th.Config.Paths.DataDir, "agent-session-cleanups")
-	require.NoError(t, os.MkdirAll(cleanupDir, 0o750))
-	blockedRecord := filepath.Join(cleanupDir, "blocked.json")
-	require.NoError(t, exec.Command("mkfifo", blockedRecord).Run())
-
-	args := test.WithConfigFlag([]string{
-		"start-all",
-		fmt.Sprintf("--port=%s", findPort(t)),
-	}, th.Config)
-	command := exec.Command(th.Config.Paths.Executable, args...) //nolint:gosec // Test executes the binary built from this repository.
-	command.Env = th.ChildEnv
-	output := th.LoggingOutput
-	command.Stdout = output
-	command.Stderr = output
-	require.NoError(t, command.Start())
-
-	waitCh := make(chan error, 1)
-	go func() {
-		waitCh <- command.Wait()
-	}()
-	exited := false
-	defer func() {
-		if exited {
-			return
-		}
-		unblockCleanupRecord(t, blockedRecord)
-		select {
-		case <-waitCh:
-		case <-time.After(5 * time.Second):
-			_ = command.Process.Kill()
-			<-waitCh
-		}
-	}()
-
-	require.Eventually(t, func() bool {
-		return strings.Contains(output.String(), "Server is starting")
-	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
-	require.NoError(t, command.Process.Signal(os.Interrupt))
-	require.Eventually(t, func() bool {
-		return strings.Contains(output.String(), "All services stopped gracefully")
-	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
-	require.NoError(t, command.Process.Signal(os.Interrupt))
-
-	select {
-	case <-waitCh:
-		exited = true
-	case <-time.After(2 * time.Second):
-		unblockCleanupRecord(t, blockedRecord)
-		select {
-		case <-waitCh:
-		case <-time.After(5 * time.Second):
-			_ = command.Process.Kill()
-			<-waitCh
-		}
-		exited = true
-		t.Fatalf("second interrupt did not terminate blocked cleanup; output: %s", output.String())
-	}
-}
-
-func unblockCleanupRecord(t *testing.T, path string) {
-	t.Helper()
-
-	file, err := os.OpenFile(path, os.O_WRONLY, 0)
-	require.NoError(t, err)
-	_, err = file.WriteString("{}")
-	require.NoError(t, err)
-	require.NoError(t, file.Close())
+	assertSecondInterruptTerminatesBlockedCleanup(t, "start-all", "All services stopped gracefully")
 }

--- a/internal/cmd/startall_test.go
+++ b/internal/cmd/startall_test.go
@@ -5,10 +5,17 @@ package cmd_test
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmd"
 	"github.com/dagucloud/dagu/v2/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStartAllCommand(t *testing.T) {
@@ -38,4 +45,79 @@ func TestStartAllCommand(t *testing.T) {
 			ExpectedOut: []string{"54322", "dagu_test", "Coordinator initialization"},
 		})
 	})
+}
+
+func TestStartAllSecondInterruptTerminatesBlockedCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("named pipes are not available on Windows")
+	}
+
+	th := test.SetupCommand(t, test.WithBuiltExecutable())
+	cleanupDir := filepath.Join(th.Config.Paths.DataDir, "agent-session-cleanups")
+	require.NoError(t, os.MkdirAll(cleanupDir, 0o750))
+	blockedRecord := filepath.Join(cleanupDir, "blocked.json")
+	require.NoError(t, exec.Command("mkfifo", blockedRecord).Run())
+
+	args := test.WithConfigFlag([]string{
+		"start-all",
+		fmt.Sprintf("--port=%s", findPort(t)),
+	}, th.Config)
+	command := exec.Command(th.Config.Paths.Executable, args...) //nolint:gosec // Test executes the binary built from this repository.
+	command.Env = th.ChildEnv
+	output := th.LoggingOutput
+	command.Stdout = output
+	command.Stderr = output
+	require.NoError(t, command.Start())
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- command.Wait()
+	}()
+	exited := false
+	defer func() {
+		if exited {
+			return
+		}
+		unblockCleanupRecord(t, blockedRecord)
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+			_ = command.Process.Kill()
+			<-waitCh
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), "Server is starting")
+	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
+	require.NoError(t, command.Process.Signal(os.Interrupt))
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), "All services stopped gracefully")
+	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
+	require.NoError(t, command.Process.Signal(os.Interrupt))
+
+	select {
+	case <-waitCh:
+		exited = true
+	case <-time.After(2 * time.Second):
+		unblockCleanupRecord(t, blockedRecord)
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+			_ = command.Process.Kill()
+			<-waitCh
+		}
+		exited = true
+		t.Fatalf("second interrupt did not terminate blocked cleanup; output: %s", output.String())
+	}
+}
+
+func unblockCleanupRecord(t *testing.T, path string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	_, err = file.WriteString("{}")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
 }

--- a/internal/cmd/test_helpers_test.go
+++ b/internal/cmd/test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -98,8 +99,14 @@ func assertSecondInterruptTerminatesBlockedCleanup(t *testing.T, commandName, sh
 	require.NoError(t, command.Process.Signal(os.Interrupt))
 
 	select {
-	case <-waitCh:
+	case err := <-waitCh:
 		exited = true
+		exitErr, ok := err.(*exec.ExitError)
+		require.True(t, ok, "expected signal exit, got %v", err)
+		waitStatus, ok := exitErr.Sys().(syscall.WaitStatus)
+		require.True(t, ok, "expected Unix wait status, got %T", exitErr.Sys())
+		require.True(t, waitStatus.Signaled(), "expected signal exit, got %v", waitStatus)
+		require.Equal(t, syscall.SIGINT, waitStatus.Signal())
 	case <-time.After(2 * time.Second):
 		terminateTestCommand(command, waitCh)
 		exited = true

--- a/internal/cmd/test_helpers_test.go
+++ b/internal/cmd/test_helpers_test.go
@@ -6,6 +6,7 @@ package cmd_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -52,6 +53,66 @@ func commandLogWaitTimeout() time.Duration {
 		return 30 * time.Second
 	}
 	return 10 * time.Second
+}
+
+func assertSecondInterruptTerminatesBlockedCleanup(t *testing.T, commandName, shutdownLog string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("named pipes are not available on Windows")
+	}
+
+	th := test.SetupCommand(t, test.WithBuiltExecutable())
+	cleanupDir := filepath.Join(th.Config.Paths.DataDir, "agent-session-cleanups")
+	require.NoError(t, os.MkdirAll(cleanupDir, 0o750))
+	require.NoError(t, exec.Command("mkfifo", filepath.Join(cleanupDir, "blocked.json")).Run())
+
+	args := test.WithConfigFlag([]string{
+		commandName,
+		fmt.Sprintf("--port=%s", findPort(t)),
+	}, th.Config)
+	command := exec.Command(th.Config.Paths.Executable, args...) //nolint:gosec // Test executes the binary built from this repository.
+	command.Env = th.ChildEnv
+	output := th.LoggingOutput
+	command.Stdout = output
+	command.Stderr = output
+	require.NoError(t, command.Start())
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- command.Wait()
+	}()
+	exited := false
+	defer func() {
+		if !exited {
+			terminateTestCommand(command, waitCh)
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), "Server is starting")
+	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
+	require.NoError(t, command.Process.Signal(os.Interrupt))
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), shutdownLog)
+	}, commandLogWaitTimeout(), 50*time.Millisecond, "output: %s", output.String())
+	require.NoError(t, command.Process.Signal(os.Interrupt))
+
+	select {
+	case <-waitCh:
+		exited = true
+	case <-time.After(2 * time.Second):
+		terminateTestCommand(command, waitCh)
+		exited = true
+		t.Fatalf("second interrupt did not terminate blocked cleanup; output: %s", output.String())
+	}
+}
+
+func terminateTestCommand(command *exec.Cmd, waitCh <-chan error) {
+	_ = command.Process.Kill()
+	select {
+	case <-waitCh:
+	case <-time.After(5 * time.Second):
+	}
 }
 
 func newHoldFile(t *testing.T) string {


### PR DESCRIPTION
## Summary
- restore default signal handling before shutdown cleanup can block, so a second interrupt terminates the process
- give local agent-session cleanup its own bounded shutdown context
- preserve server teardown order and add subprocess regressions for both `server` and `start-all`

## Testing
- `make fmt`
- `go test -race ./internal/cmd ./internal/opencodehost -count=1 -timeout=180s`
- `make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make shutdown of `server` and `start-all` interruptible and bounded. Previously, after the first SIGINT, deferred cleanup could block and a second SIGINT did nothing; now we restore default signal handling before long-running cleanup so a second SIGINT terminates the process. Local agent-session cleanup now uses a 10s bounded shutdown context.

- Restore default signal handling by calling `stop()` before deferred cleanup runs in `server` and `start-all`. New behavior: a second SIGINT exits with SIGINT instead of waiting on cleanup.
- Bound local agent-session cleanup: `localAgentSessionShutdownTimeout = 10s`; `stopLocalAgentSessionCleanup` cancels, waits with context, and joins errors with `openCodeHost.Close`.
- Preserve teardown order: explicitly stop resource and tunnel services, then license manager, then agent-session cleanup.
- Tests: add `TestServerSecondInterruptTerminatesBlockedCleanup`, `TestStartAllSecondInterruptTerminatesBlockedCleanup`, an internal test for honoring the shutdown context, and helpers that simulate blocked cleanup via `mkfifo` (skipped on Windows).

<sup>Written for commit 6f4cc61ecb408f3b289bd204530a43676c578bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown for server and start-all commands.
  * Ensured cleanup completes reliably when services stop or errors occur.
  * Restored interrupt handling consistently after shutdown.
  * A second interrupt now terminates stalled cleanup promptly.

* **Tests**
  * Added coverage for canceled shutdowns and interrupted cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->