### PR TITLE
fix: skip sub-DAG calls when root preconditions are unmet

### DIFF
--- a/internal/intg/distr/subdag_test.go
+++ b/internal/intg/distr/subdag_test.go
@@ -242,6 +242,53 @@ steps:
 	})
 }
 
+func TestSubDAG_UnmetChildPreconditionContinuesOnSkipped(t *testing.T) {
+	f := newTestFixture(t, `
+steps:
+  - id: call_child
+    action: dag.run
+    with:
+      dag: guarded-child
+    continue_on: skipped
+  - id: after_child
+    depends: [call_child]
+    run: echo "continued"
+
+---
+name: guarded-child
+worker_selector:
+  type: test-worker
+preconditions:
+  - condition: "blocked"
+    expected: "ready"
+steps:
+  - id: should_not_run
+    run: echo "should not run"
+`, withLabels(map[string]string{"type": "test-worker"}))
+
+	f.dagWrapper.Agent().RunSuccess(t)
+	parentStatus, err := f.latestStatus()
+	require.NoError(t, err)
+	require.Equal(t, ir.Succeeded, parentStatus.Status)
+
+	callChild := requireNodeByID(t, parentStatus, "call_child")
+	require.Equal(t, ir.NodeSkipped, callChild.Status)
+	require.Len(t, callChild.SubRuns, 1)
+	require.Equal(t, ir.NodeSucceeded, requireNodeByID(t, parentStatus, "after_child").Status)
+
+	subAttempt, err := f.coord.DAGRunRepository.FindSubAttempt(
+		f.coord.Context,
+		ir.NewDAGRunRef(parentStatus.Name, parentStatus.DAGRunID),
+		callChild.SubRuns[0].DAGRunID,
+	)
+	require.NoError(t, err)
+
+	childStatus, err := subAttempt.ReadStatus(f.coord.Context)
+	require.NoError(t, err)
+	require.Equal(t, ir.Aborted, childStatus.Status)
+	require.Equal(t, ir.NodeNotStarted, requireNodeByID(t, *childStatus, "should_not_run").Status)
+}
+
 func TestSubDAG_NoMatchingWorker(t *testing.T) {
 	t.Run("failsWhenNoWorkerMatchesSelector", func(t *testing.T) {
 		f := newTestFixture(t, `

--- a/internal/ir/run_result.go
+++ b/internal/ir/run_result.go
@@ -68,6 +68,7 @@ type RunStatus struct {
 	Outputs            map[string]string
 	OutputValues       map[string]any
 	Status             Status
+	PreconditionNotMet bool `json:"-"`
 	PendingStepRetries []PendingStepRetry
 }
 

--- a/internal/runtime/builtin/dag/dag.go
+++ b/internal/runtime/builtin/dag/dag.go
@@ -196,7 +196,12 @@ func (e *dagExecutor) DetermineNodeStatus() (ir.NodeStatus, error) {
 		// Sub-DAG is waiting for human approval
 		// Propagate the waiting status to the parent
 		return ir.NodeWaiting, nil
-	case ir.NotStarted, ir.Running, ir.Failed, ir.Aborted, ir.Queued:
+	case ir.Aborted:
+		if e.result.PreconditionNotMet {
+			return ir.NodeSkipped, nil
+		}
+		return ir.NodeFailed, fmt.Errorf("sub DAG run %s failed with status: %s", e.result.DAGRunID, e.result.Status)
+	case ir.NotStarted, ir.Running, ir.Failed, ir.Queued:
 		return ir.NodeFailed, fmt.Errorf("sub DAG run %s failed with status: %s", e.result.DAGRunID, e.result.Status)
 	default:
 		// This should never happen, but satisfies the exhaustive check

--- a/internal/runtime/builtin/dag/dag_test.go
+++ b/internal/runtime/builtin/dag/dag_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dag
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAGExecutorDetermineNodeStatusAborted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		preconditionNotMet bool
+		wantStatus         ir.NodeStatus
+		wantError          bool
+	}{
+		{
+			name:               "root precondition not met",
+			preconditionNotMet: true,
+			wantStatus:         ir.NodeSkipped,
+		},
+		{
+			name:       "run aborted",
+			wantStatus: ir.NodeFailed,
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			executor := &dagExecutor{
+				result: &ir.RunStatus{
+					DAGRunID:           "child-1",
+					Status:             ir.Aborted,
+					PreconditionNotMet: tt.preconditionNotMet,
+				},
+			}
+
+			status, err := executor.DetermineNodeStatus()
+			assert.Equal(t, tt.wantStatus, status)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/service/coordinator/subflow/runner.go
+++ b/internal/service/coordinator/subflow/runner.go
@@ -566,8 +566,21 @@ func statusToRunStatus(status *ir.DAGRunStatus, runID string) *ir.RunStatus {
 		Outputs:            outputVariablesFromNodes(nodes),
 		OutputValues:       outputValuesFromNodes(nodes),
 		Status:             status.Status,
+		PreconditionNotMet: preconditionNotMet(status),
 		PendingStepRetries: ir.PendingStepRetriesFromStatus(status),
 	}
+}
+
+func preconditionNotMet(status *ir.DAGRunStatus) bool {
+	if status.Status != ir.Aborted {
+		return false
+	}
+	for _, result := range status.Preconditions {
+		if result.Error != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func outputVariablesFromNodes(nodes []*ir.Node) map[string]string {

--- a/internal/service/coordinator/subflow/runner_test.go
+++ b/internal/service/coordinator/subflow/runner_test.go
@@ -190,6 +190,68 @@ func TestRunnerRunDispatchesWorkflowRequest(t *testing.T) {
 	assert.Equal(t, true, result.OutputValues["typed"])
 }
 
+func TestRunnerRunReportsUnmetRootPrecondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status ir.DAGRunStatus
+		want   bool
+	}{
+		{
+			name: "aborted because precondition was not met",
+			status: ir.DAGRunStatus{
+				Status: ir.Aborted,
+				Preconditions: []ir.ConditionResult{
+					{Error: "condition was not met"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "aborted after preconditions passed",
+			status: ir.DAGRunStatus{
+				Status: ir.Aborted,
+				Preconditions: []ir.ConditionResult{
+					{Condition: ir.Condition{Condition: "ready", Expected: "ready"}},
+				},
+			},
+		},
+		{
+			name: "precondition evaluation failed",
+			status: ir.DAGRunStatus{
+				Status: ir.Failed,
+				Preconditions: []ir.ConditionResult{
+					{Error: "failed to evaluate condition"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dispatcher := &mockDispatcher{
+				statuses: []*dispatch.DAGRunStatusResult{
+					{Found: false},
+					{Found: true, Status: &tt.status},
+				},
+			}
+			runner := newFastRunner(dispatcher)
+
+			result, err := runner.Run(context.Background(), runtimeexec.SubWorkflowRequest{
+				DAG:        &ir.DAG{Name: "child", YamlData: []byte("name: child")},
+				RootDAGRun: ir.NewDAGRunRef("parent", "root-1"),
+				RunID:      "child-1",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.want, result.PreconditionNotMet)
+		})
+	}
+}
+
 func TestRunnerRunPreservesDAGBaseConfigWithWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/specs/023-preconditions.md
+++ b/specs/023-preconditions.md
@@ -408,6 +408,11 @@ Rules:
   normal step.
 - If any DAG-level precondition is not met, the DAG run reaches terminal status
   `aborted`.
+- When a DAG invoked by a `dag.run` step is aborted because a DAG-level
+  precondition is not met, the child run remains `aborted` and the invoking
+  step reaches terminal status `skipped`.
+- A skipped `dag.run` invocation follows the normal skipped-step continuation
+  rules, including `continue_on: skipped`.
 - A DAG-level precondition not-met result is an abort event for lifecycle
   handler selection.
 - If a DAG-level precondition has an evaluation error, the DAG run reaches


### PR DESCRIPTION
## Summary

Preserve why a child DAG was aborted when a root precondition is not met, so the child run remains aborted while its direct invocation step is skipped.

## Changes

- propagate the root-precondition cause through the internal subflow result used by local and distributed execution
- map only that aborted cause to a skipped dag/subworkflow step; genuine aborts and evaluation errors still fail
- add focused unit and distributed regression coverage and document the status contract

## Related Issues

Closes #2611

## Testing

- make test
- focused runtime and subflow tests with the race detector
- distributed sub-DAG regression and failure-propagation tests
- native and Windows golangci-lint

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `dag.run` steps when the child DAG aborts due to an unmet root precondition. Previously these steps failed; now they are marked skipped while the child run stays aborted, enabling normal skipped-step continuation (e.g., `continue_on: skipped`).

- Map child status `aborted` + root precondition not met to parent node status `skipped`; other `aborted` or evaluation-error cases still fail.
- Preserve the child run as `aborted`; parent continues based on skipped-step rules.
- Propagate the cause via `RunStatus.PreconditionNotMet`, set by the subflow coordinator from `DAGRunStatus.Preconditions`.
- Add unit and distributed tests for sub-DAG continuation and status mapping; update preconditions spec to document the contract.

<sup>Written for commit cd09d08d14d780b8b09167da2897788080614945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of child workflows blocked by unmet preconditions.
  * Invoking steps are now marked as skipped, allowing workflows configured with `continue_on: skipped` to proceed.
  * Child workflow runs remain correctly marked as aborted without executing tasks.
  * Ordinary aborted workflows continue to be reported as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->