### PR TITLE
fix: prevent scheduler memory retention during worker outages

### DIFF
--- a/internal/cmd/enqueue_internal_test.go
+++ b/internal/cmd/enqueue_internal_test.go
@@ -129,6 +129,10 @@ func (a *enqueueTrackingAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, 
 	return a.status, nil
 }
 
+func (a *enqueueTrackingAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
+
 func (a *enqueueTrackingAttempt) ReadDAG(context.Context) (*ir.DAG, error) {
 	return a.dag, nil
 }
@@ -199,6 +203,10 @@ func (s *enqueueObservingQueueStore) Len(context.Context, string) (int, error) {
 
 func (s *enqueueObservingQueueStore) List(context.Context, string) ([]queue.QueuedItemData, error) {
 	return nil, nil
+}
+
+func (s *enqueueObservingQueueStore) GetByItemID(context.Context, string, string) (queue.QueuedItemData, error) {
+	return nil, queue.ErrQueueItemNotFound
 }
 
 func (s *enqueueObservingQueueStore) ListCursor(context.Context, string, string, int) (pagination.CursorResult[queue.QueuedItemData], error) {

--- a/internal/cmd/human_task_test.go
+++ b/internal/cmd/human_task_test.go
@@ -405,6 +405,10 @@ func (a *humanTaskCompletionAttempt) ReadStatus(context.Context) (*ir.DAGRunStat
 	return a.status, nil
 }
 
+func (a *humanTaskCompletionAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
+
 type humanTaskCompletionStore struct {
 	testutil.DAGRunStoreStub
 	attempt      *humanTaskCompletionAttempt

--- a/internal/dagrun/dagrun_attempt.go
+++ b/internal/dagrun/dagrun_attempt.go
@@ -21,6 +21,8 @@ type Attempt interface {
 	Close(ctx context.Context) error
 	// ReadStatus retrieves the current status of the attempt
 	ReadStatus(ctx context.Context) (*ir.DAGRunStatus, error)
+	// ReadStatusUncached retrieves the current status without retaining it in a shared cache.
+	ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error)
 	// ReadDAG reads the DAG associated with this run attempt
 	ReadDAG(ctx context.Context) (*ir.DAG, error)
 	// SetDAG sets the DAG for this attempt (must be called before Open for DAG to be persisted)

--- a/internal/dagrun/noop_attempt.go
+++ b/internal/dagrun/noop_attempt.go
@@ -47,6 +47,10 @@ func (n *noopAttempt) ReadStatus(_ context.Context) (*ir.DAGRunStatus, error) {
 	return nil, ErrNoopAttemptNotSupported
 }
 
+func (n *noopAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return n.ReadStatus(ctx)
+}
+
 func (n *noopAttempt) ReadDAG(_ context.Context) (*ir.DAG, error) {
 	return n.dag, nil
 }

--- a/internal/humantask/service_test.go
+++ b/internal/humantask/service_test.go
@@ -423,10 +423,18 @@ func (a *sequenceAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error) 
 	return status, nil
 }
 
+func (a *sequenceAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
+
 func (a *serviceAttempt) ID() string                               { return a.status.AttemptID }
 func (a *serviceAttempt) ReadDAG(context.Context) (*ir.DAG, error) { return a.dag, nil }
 func (a *serviceAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error) {
 	return a.status, nil
+}
+
+func (a *serviceAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
 }
 
 type serviceDAGRunStore struct {

--- a/internal/intake/queue_test.go
+++ b/internal/intake/queue_test.go
@@ -203,6 +203,9 @@ func (a *queueAttempt) Close(context.Context) error {
 func (a *queueAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error) {
 	return a.status, nil
 }
+func (a *queueAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
 func (a *queueAttempt) ReadDAG(context.Context) (*ir.DAG, error) { return a.dag, nil }
 func (a *queueAttempt) SetDAG(dag *ir.DAG)                       { a.dag = dag }
 func (a *queueAttempt) Abort(context.Context) error              { return nil }
@@ -253,6 +256,9 @@ func (s *queueStore) DeleteByItemIDs(context.Context, string, []string) (int, er
 func (s *queueStore) Len(context.Context, string) (int, error) { return 0, nil }
 func (s *queueStore) List(context.Context, string) ([]queue.QueuedItemData, error) {
 	return nil, nil
+}
+func (s *queueStore) GetByItemID(context.Context, string, string) (queue.QueuedItemData, error) {
+	return nil, queue.ErrQueueItemNotFound
 }
 func (s *queueStore) ListCursor(context.Context, string, string, int) (pagination.CursorResult[queue.QueuedItemData], error) {
 	return pagination.CursorResult[queue.QueuedItemData]{}, nil

--- a/internal/persis/file/dagrun/attempt.go
+++ b/internal/persis/file/dagrun/attempt.go
@@ -427,7 +427,11 @@ func (att *Attempt) ReadStatus(ctx context.Context) (*ir.DAGRunStatus, error) {
 		}
 	}
 
-	// Cache miss or disabled, perform a direct read
+	return att.ReadStatusUncached(ctx)
+}
+
+// ReadStatusUncached reads the latest status without retaining it in the shared cache.
+func (att *Attempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
 	att.mu.RLock()
 	parsed, parseErr := att.parseLocked(ctx)
 	att.mu.RUnlock()
@@ -440,7 +444,6 @@ func (att *Attempt) ReadStatus(ctx context.Context) (*ir.DAGRunStatus, error) {
 	}
 
 	return parsed, nil
-
 }
 
 // parseLocked reads the status file and returns the last valid status.

--- a/internal/persis/file/dagrun/attempt_test.go
+++ b/internal/persis/file/dagrun/attempt_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
 	"github.com/dagucloud/dagu/v2/internal/dagrun"
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
@@ -151,6 +152,21 @@ func TestAttempt_ReadStatusHonorsCanceledContext(t *testing.T) {
 
 	_, err = att.ReadStatus(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAttempt_ReadStatusUncachedDoesNotPopulateCache(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(createTempDir(t), "status.dat")
+	writeJSONToFile(t, file, createTestStatus(ir.Queued))
+	cache := fileutil.NewCache[*ir.DAGRunStatus]("dag_run_status", 10, time.Hour)
+	att, err := NewAttempt(file, cache)
+	require.NoError(t, err)
+
+	status, err := att.ReadStatusUncached(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, ir.Queued, status.Status)
+	assert.Zero(t, cache.Size())
 }
 
 func TestAttempt_Compact(t *testing.T) {

--- a/internal/persis/runstate_test.go
+++ b/internal/persis/runstate_test.go
@@ -269,6 +269,10 @@ func (a *recordingAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error)
 	return a.status, nil
 }
 
+func (a *recordingAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
+
 func (a *recordingAttempt) ReadDAG(context.Context) (*ir.DAG, error) {
 	return a.dag, nil
 }

--- a/internal/persis/store/queue.go
+++ b/internal/persis/store/queue.go
@@ -179,6 +179,24 @@ func (s *QueueStore) List(ctx context.Context, name string) ([]queue.QueuedItemD
 	return queueItemsAsData(items), nil
 }
 
+// GetByItemID returns an exact queued item from the named queue.
+func (s *QueueStore) GetByItemID(ctx context.Context, name, itemID string) (queue.QueuedItemData, error) {
+	itemID = normalizeQueueItemID(itemID)
+	if name == "" || itemID == "" {
+		return nil, queue.ErrQueueItemNotFound
+	}
+
+	recordID := queueRecordID(name, itemID)
+	rec, err := s.col.Get(ctx, recordID)
+	if errors.Is(err, persis.ErrNotFound) {
+		return nil, queue.ErrQueueItemNotFound
+	}
+	if err != nil {
+		return invalidQueueItemFromRecordID(recordID, err)
+	}
+	return queueItemFromRecord(rec)
+}
+
 // ListCursor returns one forward-only page of queued items.
 func (s *QueueStore) ListCursor(ctx context.Context, name, cursor string, limit int) (pagination.CursorResult[queue.QueuedItemData], error) {
 	if limit <= 0 {

--- a/internal/persis/store/queue_test.go
+++ b/internal/persis/store/queue_test.go
@@ -75,6 +75,25 @@ func TestQueueStore_EnqueueListAndDequeue(t *testing.T) {
 	assert.Equal(t, 1, deleted)
 }
 
+func TestQueueStore_GetByItemID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := newQueueStore(t)
+	want := queueRef("dag", "run")
+	require.NoError(t, s.Enqueue(ctx, "main", queue.QueuePriorityLow, want))
+	items, err := s.List(ctx, "main")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	item, err := s.GetByItemID(ctx, "main", items[0].ID())
+	require.NoError(t, err)
+	assert.Equal(t, want, requireQueuedRef(t, item))
+
+	_, err = s.GetByItemID(ctx, "main", "missing-item")
+	assert.ErrorIs(t, err, queue.ErrQueueItemNotFound)
+}
+
 func TestQueueStore_EnqueueRejectsInvalidInputs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -29,6 +29,8 @@ type QueueStore interface {
 	Len(ctx context.Context, name string) (int, error)
 	// List returns all items in the queue with the given name
 	List(ctx context.Context, name string) ([]QueuedItemData, error)
+	// GetByItemID returns an exact item from the named queue.
+	GetByItemID(ctx context.Context, name, itemID string) (QueuedItemData, error)
 	// ListCursor returns one forward-only page of queued items for a specific queue.
 	ListCursor(ctx context.Context, name, cursor string, limit int) (pagination.CursorResult[QueuedItemData], error)
 	// All returns all items in the queue

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -407,6 +407,9 @@ func (m *mockAttempt) ReadStatus(_ context.Context) (*ir.DAGRunStatus, error) {
 	cloned := *m.status
 	return &cloned, nil
 }
+func (m *mockAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return m.ReadStatus(ctx)
+}
 func (m *mockAttempt) ReadDAG(_ context.Context) (*ir.DAG, error) { return m.dag, nil }
 func (m *mockAttempt) SetDAG(dag *ir.DAG) {
 	m.mu.Lock()

--- a/internal/service/frontend/api/v1/dagruns_internal_test.go
+++ b/internal/service/frontend/api/v1/dagruns_internal_test.go
@@ -112,6 +112,10 @@ func (a *stopDAGRunAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error
 	return a.status, nil
 }
 
+func (a *stopDAGRunAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
+
 func (a *stopDAGRunAttempt) Abort(context.Context) error {
 	a.aborted = true
 	return nil
@@ -456,6 +460,10 @@ func (a *manualStepAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error
 	}
 	a.reads++
 	return a.statuses[idx], nil
+}
+
+func (a *manualStepAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
 }
 
 type manualStepProcRepository struct {

--- a/internal/service/scheduler/queue_conditions_external_test.go
+++ b/internal/service/scheduler/queue_conditions_external_test.go
@@ -6,6 +6,7 @@ package scheduler_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/dagrun"
 	"github.com/dagucloud/dagu/v2/internal/dispatch"
 	"github.com/dagucloud/dagu/v2/internal/ir"
@@ -472,10 +474,110 @@ func TestQueueProcessorContinuesPastItemWithoutMatchingWorker(t *testing.T) {
 	require.Equal(t, int32(1), heartbeatStore.listCount.Load())
 }
 
-func TestQueueProcessorBatchesWorkerConditionQueueValidation(t *testing.T) {
+func TestQueueProcessorRotatesPastBoundedWorkerEligibilityWindow(t *testing.T) {
 	t.Parallel()
 
-	var queueStore *countingQueueStore
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	for i := range 100 {
+		f.enqueueRun(fmt.Sprintf("gpu-run-%03d", i), nil)
+	}
+	f.dag.WorkerSelector = map[string]string{"type": "cpu"}
+	f.enqueueRun("cpu-run", nil)
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Zero(t, dispatcher.callCount.Load())
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Equal(t, int32(1), dispatcher.callCount.Load())
+}
+
+func TestQueueProcessorChecksHeadBeforeRotatingWorkerEligibilityWindow(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := &queueConditionDispatcher{}
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithDispatcher(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		dispatcher,
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	f.enqueueRun("head-run", nil)
+	for i := range 100 {
+		f.enqueueRun(fmt.Sprintf("later-run-%03d", i), nil)
+	}
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Empty(t, dispatcher.dispatchedRunIDs())
+
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "gpu-worker",
+		Labels:          map[string]string{"type": "gpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Equal(t, []string{"head-run"}, dispatcher.dispatchedRunIDs())
+}
+
+func TestQueueProcessorWorkerEligibilityDoesNotRetainQueuedStatuses(t *testing.T) {
+	t.Parallel()
+
+	statusCache := fileutil.NewCache[*ir.DAGRunStatus]("dag_run_status", 100, time.Hour)
+	heartbeatStore := store.NewWorkerHeartbeatStore(
+		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
+	)
+	f := newQueueConditionFixtureWithConfig(
+		t,
+		config.ExecutionModeDistributed,
+		nil,
+		&queueConditionDispatcher{},
+		queueConditionFixtureConfig{statusCache: statusCache},
+		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+	)
+	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
+	for i := range 3 {
+		f.enqueueRun(fmt.Sprintf("gpu-run-%d", i), nil)
+	}
+	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "cpu-worker",
+		Labels:          map[string]string{"type": "cpu"},
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	require.Zero(t, statusCache.Size())
+}
+
+func TestQueueProcessorRecordsWorkerConditionWithoutFullQueueList(t *testing.T) {
+	t.Parallel()
+
 	heartbeatStore := store.NewWorkerHeartbeatStore(
 		file.NewCollection(filepath.Join(t.TempDir(), "worker-heartbeats")),
 	)
@@ -486,16 +588,13 @@ func TestQueueProcessorBatchesWorkerConditionQueueValidation(t *testing.T) {
 		&queueConditionDispatcher{},
 		queueConditionFixtureConfig{
 			queueStore: func(base queuedomain.QueueStore) queuedomain.QueueStore {
-				queueStore = &countingQueueStore{QueueStore: base}
-				return queueStore
+				return &fullListFailingQueueStore{QueueStore: base}
 			},
 		},
 		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
 	)
 	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
-	for _, runID := range []string{"first-run", "second-run", "third-run"} {
-		f.enqueueRun(runID, nil)
-	}
+	f.enqueueRun("waiting-run", nil)
 	require.NoError(t, heartbeatStore.Upsert(f.ctx, dispatch.WorkerHeartbeatRecord{
 		WorkerID:        "cpu-worker",
 		Labels:          map[string]string{"type": "cpu"},
@@ -503,11 +602,7 @@ func TestQueueProcessorBatchesWorkerConditionQueueValidation(t *testing.T) {
 	}))
 
 	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
-	require.Equal(t, int32(2), queueStore.listCount.Load())
-
-	queueStore.listCount.Store(0)
-	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
-	require.Equal(t, int32(2), queueStore.listCount.Load())
+	requireQueuedConditions(t, f.readStatus("waiting-run"), noMatchingWorkerConditions()...)
 }
 
 func TestQueueProcessorRecordsNoAvailableWorkerCondition(t *testing.T) {
@@ -748,6 +843,7 @@ type queueConditionFixtureConfig struct {
 	executable     string
 	procRepository func(processRepository) processRepository
 	queueStore     func(queuedomain.QueueStore) queuedomain.QueueStore
+	statusCache    *fileutil.Cache[*ir.DAGRunStatus]
 }
 
 func newQueueConditionFixture(
@@ -787,7 +883,11 @@ func newQueueConditionFixtureWithConfig(
 		Steps:    []ir.Step{{Name: "test", Command: "echo hello"}},
 	}
 	ir.InitializeDefaults(dag)
-	dagRunRepository := newCountingDAGRunStore(filedagrun.NewStore(filepath.Join(tmp, "dag-runs")))
+	storeOptions := make([]filedagrun.StoreOption, 0, 1)
+	if fixtureConfig.statusCache != nil {
+		storeOptions = append(storeOptions, filedagrun.WithHistoryFileCache(fixtureConfig.statusCache))
+	}
+	dagRunRepository := newCountingDAGRunStore(filedagrun.NewStore(filepath.Join(tmp, "dag-runs"), storeOptions...))
 	var queueStore queuedomain.QueueStore = store.NewQueueStore(file.NewCollection(filepath.Join(tmp, "queue")))
 	if fixtureConfig.queueStore != nil {
 		queueStore = fixtureConfig.queueStore(queueStore)
@@ -1204,11 +1304,24 @@ func (s *queueConditionDispatchTaskStore) HasOutstandingAttempt(_ context.Contex
 type queueConditionDispatcher struct {
 	dispatchErr error
 	callCount   atomic.Int32
+	mu          sync.Mutex
+	runIDs      []string
 }
 
-func (d *queueConditionDispatcher) Dispatch(context.Context, dispatch.DispatchRequest) error {
+func (d *queueConditionDispatcher) Dispatch(_ context.Context, req dispatch.DispatchRequest) error {
 	d.callCount.Add(1)
+	d.mu.Lock()
+	if req.Task != nil {
+		d.runIDs = append(d.runIDs, req.Task.DAGRunID)
+	}
+	d.mu.Unlock()
 	return d.dispatchErr
+}
+
+func (d *queueConditionDispatcher) dispatchedRunIDs() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.runIDs...)
 }
 
 func (d *queueConditionDispatcher) Cleanup(context.Context) error {
@@ -1242,14 +1355,12 @@ func (s *failingWorkerHeartbeatStore) List(context.Context) ([]dispatch.WorkerHe
 	return nil, s.err
 }
 
-type countingQueueStore struct {
+type fullListFailingQueueStore struct {
 	queuedomain.QueueStore
-	listCount atomic.Int32
 }
 
-func (s *countingQueueStore) List(ctx context.Context, queueName string) ([]queuedomain.QueuedItemData, error) {
-	s.listCount.Add(1)
-	return s.QueueStore.List(ctx, queueName)
+func (s *fullListFailingQueueStore) List(context.Context, string) ([]queuedomain.QueuedItemData, error) {
+	return nil, errors.New("full queue listing disabled")
 }
 
 type queueConditionQueueStore struct {

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	osexec "os/exec"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/backoff"
@@ -61,9 +60,6 @@ type queueDispatcher struct {
 	isClosed               func() bool
 	wakeUp                 func()
 	acquireDispatchHandoff func(context.Context) (func(), bool)
-
-	queuedConditionCursorMu sync.Mutex
-	queuedConditionCursor   map[string]int
 }
 
 type queueDispatchBatch struct {
@@ -341,7 +337,6 @@ func newQueueDispatcher(deps queueDispatchDeps) *queueDispatcher {
 		isClosed:               deps.isClosed,
 		wakeUp:                 deps.wakeUp,
 		acquireDispatchHandoff: deps.acquireDispatchHandoff,
-		queuedConditionCursor:  make(map[string]int),
 	}
 }
 
@@ -355,24 +350,11 @@ type queuedConditionStage struct {
 	flushed      bool
 }
 
-func (d *queueDispatcher) queuedConditionItemsForRefresh(
-	queueName string,
-	items []queuedomain.QueuedItemData,
-) []queuedomain.QueuedItemData {
+func queuedConditionItemsForRefresh(items []queuedomain.QueuedItemData) []queuedomain.QueuedItemData {
 	if len(items) <= queuedConditionRefreshBatchLimit {
 		return items
 	}
-
-	d.queuedConditionCursorMu.Lock()
-	start := d.queuedConditionCursor[queueName] % len(items)
-	d.queuedConditionCursor[queueName] = (start + queuedConditionRefreshBatchLimit) % len(items)
-	d.queuedConditionCursorMu.Unlock()
-
-	selected := make([]queuedomain.QueuedItemData, 0, queuedConditionRefreshBatchLimit)
-	for i := range queuedConditionRefreshBatchLimit {
-		selected = append(selected, items[(start+i)%len(items)])
-	}
-	return selected
+	return items[:queuedConditionRefreshBatchLimit]
 }
 
 func (d *queueDispatcher) newQueuedConditionStage(
@@ -463,7 +445,7 @@ func (d *queueDispatcher) readQueuedConditionStatus(
 	if attempt.Hidden() {
 		return nil, nil, false
 	}
-	status, err := attempt.ReadStatus(ctx)
+	status, err := attempt.ReadStatusUncached(ctx)
 	if err != nil {
 		if errors.Is(err, dagrun.ErrNoStatusData) || errors.Is(err, dagrun.ErrCorruptedStatusData) {
 			return nil, nil, false
@@ -499,19 +481,11 @@ func (s *queuedConditionStage) observe(defs ...queuedConditionDef) {
 }
 
 func (s *queuedConditionStage) flush(ctx context.Context) {
-	s.flushWithQueueCheck(ctx, true)
-}
-
-func (s *queuedConditionStage) flushWithoutQueueCheck(ctx context.Context) {
-	s.flushWithQueueCheck(ctx, false)
-}
-
-func (s *queuedConditionStage) flushWithQueueCheck(ctx context.Context, checkQueue bool) {
 	if s == nil || s.flushed || len(s.observations) == 0 {
 		return
 	}
 	s.flushed = true
-	if err := s.flushErr(ctx, checkQueue); err != nil {
+	if err := s.flushErr(ctx); err != nil {
 		logger.Warn(ctx, "Failed to update queued DAG-run condition",
 			tag.Error(err),
 			tag.RunID(s.runRef.ID),
@@ -519,8 +493,8 @@ func (s *queuedConditionStage) flushWithQueueCheck(ctx context.Context, checkQue
 	}
 }
 
-func (s *queuedConditionStage) flushErr(ctx context.Context, checkQueue bool) error {
-	if checkQueue && !s.itemStillQueued(ctx) {
+func (s *queuedConditionStage) flushErr(ctx context.Context) error {
+	if !s.itemStillQueued(ctx) {
 		return nil
 	}
 
@@ -563,7 +537,10 @@ func (s *queuedConditionStage) itemStillQueued(ctx context.Context) bool {
 	if s.dispatcher.queueStore == nil || s.queueName == "" || s.itemID == "" {
 		return true
 	}
-	items, err := s.dispatcher.queueStore.List(ctx, s.queueName)
+	item, err := s.dispatcher.queueStore.GetByItemID(ctx, s.queueName, s.itemID)
+	if errors.Is(err, queuedomain.ErrQueueItemNotFound) {
+		return false
+	}
 	if err != nil {
 		logger.Warn(ctx, "Failed to verify queued item before updating condition",
 			tag.Error(err),
@@ -571,21 +548,15 @@ func (s *queuedConditionStage) itemStillQueued(ctx context.Context) bool {
 		)
 		return false
 	}
-	for _, item := range items {
-		if item.ID() != s.itemID {
-			continue
-		}
-		runRef, err := item.Data()
-		if err != nil {
-			logger.Warn(ctx, "Failed to read queued item before updating condition",
-				tag.Error(err),
-				tag.RunID(s.runRef.ID),
-			)
-			return false
-		}
-		return runRef != nil && *runRef == s.runRef
+	runRef, err := item.Data()
+	if err != nil {
+		logger.Warn(ctx, "Failed to read queued item before updating condition",
+			tag.Error(err),
+			tag.RunID(s.runRef.ID),
+		)
+		return false
 	}
-	return false
+	return runRef != nil && *runRef == s.runRef
 }
 
 func (d *queueDispatcher) selectDispatchBatch(
@@ -1264,7 +1235,7 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 	workerSnapshot := workerHeartbeatSnapshot{}
 	var workerConditionStages []*queuedConditionStage
 	defer func() {
-		d.flushQueuedConditionStages(ctx, queueName, workerConditionStages)
+		flushQueuedConditionStages(ctx, workerConditionStages)
 	}()
 	for _, item := range items {
 		if len(runnable) >= freeSlots {
@@ -1320,7 +1291,7 @@ func (d *queueDispatcher) queueItemHasEligibleWorker(
 	if err != nil || attempt.Hidden() {
 		return true, nil
 	}
-	status, err := attempt.ReadStatus(ctx)
+	status, err := attempt.ReadStatusUncached(ctx)
 	if err != nil || status.Status != ir.Queued {
 		return true, nil
 	}
@@ -1349,46 +1320,15 @@ func (d *queueDispatcher) queueItemHasEligibleWorker(
 	return false, conditionStage
 }
 
-func (d *queueDispatcher) flushQueuedConditionStages(
+func flushQueuedConditionStages(
 	ctx context.Context,
-	queueName string,
 	stages []*queuedConditionStage,
 ) {
 	if len(stages) == 0 {
 		return
 	}
-	if d.queueStore == nil || queueName == "" {
-		for _, stage := range stages {
-			stage.flushWithoutQueueCheck(ctx)
-		}
-		return
-	}
-
-	items, err := d.queueStore.List(ctx, queueName)
-	if err != nil {
-		logger.Warn(ctx, "Failed to verify queued items before updating worker conditions", tag.Error(err))
-		return
-	}
-	stagesByItemID := make(map[string]*queuedConditionStage, len(stages))
 	for _, stage := range stages {
-		if stage != nil {
-			stagesByItemID[stage.itemID] = stage
-		}
-	}
-	for _, item := range items {
-		stage, ok := stagesByItemID[item.ID()]
-		if !ok {
-			continue
-		}
-		runRef, err := item.Data()
-		if err != nil {
-			logger.Warn(ctx, "Failed to read queued item before updating worker conditions", tag.Error(err))
-			continue
-		}
-		if runRef == nil || *runRef != stage.runRef {
-			continue
-		}
-		stage.flushWithoutQueueCheck(ctx)
+		stage.flush(ctx)
 	}
 }
 
@@ -1469,7 +1409,7 @@ func (d *queueDispatcher) recordCapacityUnavailableConditions(
 	items []queuedomain.QueuedItemData,
 	checkOutstandingDispatch bool,
 ) {
-	items = d.queuedConditionItemsForRefresh(queueName, items)
+	items = queuedConditionItemsForRefresh(items)
 	for _, item := range items {
 		conditionStage := d.newQueuedConditionStageFromItem(ctx, queueName, item)
 		if conditionStage == nil {
@@ -1497,7 +1437,7 @@ func (d *queueDispatcher) recordQueueStateUnavailableConditions(
 	queueName string,
 	items []queuedomain.QueuedItemData,
 ) {
-	items = d.queuedConditionItemsForRefresh(queueName, items)
+	items = queuedConditionItemsForRefresh(items)
 	for _, item := range items {
 		conditionStage := d.newQueuedConditionStageFromItem(ctx, queueName, item)
 		conditionStage.observe(queueStateUnavailableConditionDefs...)
@@ -1679,7 +1619,7 @@ func (d *queueDispatcher) hasOutstandingDispatchReservation(ctx context.Context,
 		return false, nil
 	}
 
-	status, err := attempt.ReadStatus(ctx)
+	status, err := attempt.ReadStatusUncached(ctx)
 	if err != nil {
 		if errors.Is(err, dagrun.ErrNoStatusData) || errors.Is(err, dagrun.ErrCorruptedStatusData) {
 			return false, nil

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -17,12 +18,16 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/dagrun"
 	"github.com/dagucloud/dagu/v2/internal/dispatch"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/pagination"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	queuedomain "github.com/dagucloud/dagu/v2/internal/queue"
 )
 
 const queueAgeWarningThreshold = 2 * time.Minute
 const queueProcessMinInterval = 3 * time.Second
+const queueScanItemLimit = 100
+const queueHeadItemLimit = 1
+const maxConcurrentQueueScans = 8
 const maxConcurrentDispatchHandoffs = 8
 
 var (
@@ -116,6 +121,7 @@ type QueueProcessor struct {
 type queue struct {
 	maxConcurrency int
 	isGlobal       bool // true if this queue is defined in config (global queue)
+	scanCursor     string
 	inflight       atomic.Int32
 	mu             sync.Mutex
 }
@@ -134,6 +140,18 @@ func (q *queue) isGlobalQueue() bool {
 
 func (q *queue) getInflight() int {
 	return int(q.inflight.Load())
+}
+
+func (q *queue) getScanCursor() string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.scanCursor
+}
+
+func (q *queue) setScanCursor(cursor string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.scanCursor = cursor
 }
 
 func (q *queue) incInflight() { q.inflight.Add(1) }
@@ -263,6 +281,7 @@ func (p *QueueProcessor) Start(ctx context.Context, notifyCh <-chan struct{}) {
 			case <-p.quit:
 				return
 			case <-notifyCh:
+				p.resetQueueScanCursors()
 				p.wakeUp()
 			}
 		}
@@ -326,26 +345,49 @@ func (p *QueueProcessor) loop(ctx context.Context) {
 		// Remove inactive non-global queues
 		p.removeInactiveQueues(activeQueues)
 
-		// Process each queue concurrently
-		var wg sync.WaitGroup
-		for name := range activeQueues {
-			wg.Add(1)
-			go func(queueName string) {
-				defer wg.Done()
-				defer func() {
-					if r := recover(); r != nil {
-						logger.Error(ctx, "Queue processing panicked",
-							tag.Queue(queueName),
-							tag.Error(panicToError(r)),
-						)
-					}
-				}()
-				queueCtx := logger.WithValues(ctx, tag.Queue(queueName))
-				p.ProcessQueueItems(queueCtx, queueName)
-			}(name)
-		}
-		wg.Wait()
+		p.processActiveQueues(ctx, activeQueues)
 	}
+}
+
+func (p *QueueProcessor) processActiveQueues(ctx context.Context, activeQueues map[string]struct{}) {
+	workerCount := min(len(activeQueues), maxConcurrentQueueScans)
+	if workerCount == 0 {
+		return
+	}
+
+	queueNames := make(chan string)
+	var wg sync.WaitGroup
+	for range workerCount {
+		wg.Go(func() {
+			for queueName := range queueNames {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							logger.Error(ctx, "Queue processing panicked",
+								tag.Queue(queueName),
+								tag.Error(panicToError(r)),
+							)
+						}
+					}()
+					queueCtx := logger.WithValues(ctx, tag.Queue(queueName))
+					p.ProcessQueueItems(queueCtx, queueName)
+				}()
+			}
+		})
+	}
+
+sendQueues:
+	for queueName := range activeQueues {
+		select {
+		case queueNames <- queueName:
+		case <-ctx.Done():
+			break sendQueues
+		case <-p.quit:
+			break sendQueues
+		}
+	}
+	close(queueNames)
+	wg.Wait()
 }
 
 func (p *QueueProcessor) isClosed() bool {
@@ -402,13 +444,19 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 	q := v.(*queue)
 	logger.Debug(ctx, "Processing queue", tag.MaxConcurrency(q.getMaxConcurrency()))
 
-	items, err := p.queueStore.List(ctx, queueName)
+	page, err := p.listQueueScanPage(ctx, queueName, q)
 	if err != nil {
 		logger.Error(ctx, "Failed to get queued items", tag.Error(err))
 		return
 	}
+	items := page.Items
+	logger.Debug(ctx, "Loaded bounded queue scan",
+		slog.Int("scanned_count", len(items)),
+		slog.Bool("has_more", page.HasMore),
+	)
 
 	if len(items) == 0 {
+		q.setScanCursor("")
 		logger.Debug(ctx, "No item found")
 		return
 	}
@@ -422,8 +470,10 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 		return
 	}
 	if len(batch.items) == 0 {
+		q.setScanCursor(page.NextCursor)
 		return
 	}
+	q.setScanCursor("")
 	logger.Info(ctx, "Processing batch of items",
 		tag.Count(len(batch.items)),
 		tag.MaxConcurrency(batch.maxConcurrency),
@@ -449,6 +499,67 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 		}(item)
 	}
 	wg.Wait()
+}
+
+func (p *QueueProcessor) listQueueScanPage(
+	ctx context.Context,
+	queueName string,
+	q *queue,
+) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
+	cursor := q.getScanCursor()
+	for attempt := range 2 {
+		head, err := p.queueStore.ListCursor(ctx, queueName, "", queueHeadItemLimit)
+		if err != nil || !head.HasMore || len(head.Items) == 0 {
+			return head, err
+		}
+
+		rotatingCursor := cursor
+		if rotatingCursor == "" {
+			rotatingCursor = head.NextCursor
+		}
+		rotating, err := p.queueStore.ListCursor(
+			ctx,
+			queueName,
+			rotatingCursor,
+			queueScanItemLimit-queueHeadItemLimit,
+		)
+		if errors.Is(err, pagination.ErrInvalidCursor) && attempt == 0 {
+			logger.Debug(ctx, "Queue scan cursor invalidated; restarting from head")
+			q.setScanCursor("")
+			cursor = ""
+			continue
+		}
+		if err != nil {
+			return pagination.CursorResult[queuedomain.QueuedItemData]{}, err
+		}
+
+		items := make([]queuedomain.QueuedItemData, 0, queueScanItemLimit)
+		items = append(items, head.Items...)
+		seen := map[string]struct{}{head.Items[0].ID(): {}}
+		for _, item := range rotating.Items {
+			if _, ok := seen[item.ID()]; ok {
+				continue
+			}
+			seen[item.ID()] = struct{}{}
+			items = append(items, item)
+		}
+		return pagination.CursorResult[queuedomain.QueuedItemData]{
+			Items:      items,
+			HasMore:    rotating.HasMore,
+			NextCursor: rotating.NextCursor,
+		}, nil
+	}
+
+	return pagination.CursorResult[queuedomain.QueuedItemData]{}, pagination.ErrInvalidCursor
+}
+
+func (p *QueueProcessor) resetQueueScanCursors() {
+	p.queues.Range(func(_, value any) bool {
+		if q, ok := value.(*queue); ok {
+			q.setScanCursor("")
+		}
+		return true
+	})
 }
 
 func currentStatusString(status *ir.DAGRunStatus) string {

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/dispatch"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/launcher"
+	"github.com/dagucloud/dagu/v2/internal/pagination"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	"github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/persis/file/proc"
@@ -586,6 +587,114 @@ func TestQueueProcessorLimitsConcurrentDispatchHandoffs(t *testing.T) {
 	release()
 	for _, release := range releases[1:] {
 		release()
+	}
+}
+
+func TestQueueProcessorLimitsConcurrentQueueScans(t *testing.T) {
+	t.Parallel()
+
+	const queueCount = 16
+	queueNames := make([]string, 0, queueCount)
+	for i := range queueCount {
+		queueNames = append(queueNames, fmt.Sprintf("queue-%02d", i))
+	}
+	queueStore := &blockingQueueScanStore{
+		queueNames: queueNames,
+		entered:    make(chan string, queueCount),
+		release:    make(chan struct{}, queueCount),
+	}
+	processor := NewQueueProcessor(queueStore, nil, nil, nil, config.Queues{})
+	ctx, cancel := context.WithCancel(context.Background())
+	processor.Start(ctx, nil)
+	t.Cleanup(func() {
+		for range queueCount {
+			queueStore.release <- struct{}{}
+		}
+		cancel()
+		processor.Stop()
+	})
+
+	for range maxConcurrentQueueScans {
+		select {
+		case <-queueStore.entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for queue scans to start")
+		}
+	}
+
+	select {
+	case queueName := <-queueStore.entered:
+		t.Fatalf("queue scan limit exceeded by %s", queueName)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestQueueProcessorRestartsBoundedScanAfterCursorInvalidation(t *testing.T) {
+	t.Parallel()
+
+	queueStore := &invalidatingCursorQueueStore{}
+	processor := NewQueueProcessor(queueStore, nil, nil, nil, config.Queues{})
+	page, err := processor.listQueueScanPage(t.Context(), "main", &queue{})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "new-head", page.Items[0].ID())
+}
+
+type invalidatingCursorQueueStore struct {
+	queuedomain.QueueStore
+	calls int
+}
+
+func (s *invalidatingCursorQueueStore) ListCursor(
+	context.Context,
+	string,
+	string,
+	int,
+) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
+	s.calls++
+	switch s.calls {
+	case 1:
+		return pagination.CursorResult[queuedomain.QueuedItemData]{
+			Items:      []queuedomain.QueuedItemData{testQueuedItem{id: "old-head"}},
+			HasMore:    true,
+			NextCursor: "stale-cursor",
+		}, nil
+	case 2:
+		return pagination.CursorResult[queuedomain.QueuedItemData]{}, pagination.ErrInvalidCursor
+	default:
+		return pagination.CursorResult[queuedomain.QueuedItemData]{
+			Items: []queuedomain.QueuedItemData{testQueuedItem{id: "new-head"}},
+		}, nil
+	}
+}
+
+type blockingQueueScanStore struct {
+	queuedomain.QueueStore
+	queueNames []string
+	entered    chan string
+	release    chan struct{}
+}
+
+func (s *blockingQueueScanStore) QueueList(context.Context) ([]string, error) {
+	return append([]string(nil), s.queueNames...), nil
+}
+
+func (s *blockingQueueScanStore) ListCursor(
+	ctx context.Context,
+	queueName string,
+	_ string,
+	_ int,
+) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
+	select {
+	case s.entered <- queueName:
+	case <-ctx.Done():
+		return pagination.CursorResult[queuedomain.QueuedItemData]{}, ctx.Err()
+	}
+	select {
+	case <-s.release:
+		return pagination.CursorResult[queuedomain.QueuedItemData]{}, nil
+	case <-ctx.Done():
+		return pagination.CursorResult[queuedomain.QueuedItemData]{}, ctx.Err()
 	}
 }
 

--- a/internal/service/scheduler/retry_scanner_test.go
+++ b/internal/service/scheduler/retry_scanner_test.go
@@ -820,6 +820,9 @@ func (a *retryScannerAttempt) Close(context.Context) error { return nil }
 func (a *retryScannerAttempt) ReadStatus(context.Context) (*ir.DAGRunStatus, error) {
 	return cloneRetryStatus(a.status), nil
 }
+func (a *retryScannerAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return a.ReadStatus(ctx)
+}
 func (a *retryScannerAttempt) ReadDAG(context.Context) (*ir.DAG, error) { return a.dag, nil }
 func (a *retryScannerAttempt) SetDAG(*ir.DAG)                           {}
 func (a *retryScannerAttempt) Abort(context.Context) error              { return nil }

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -100,6 +100,14 @@ func (m *mockQueueStore) List(ctx context.Context, name string) ([]queue.QueuedI
 	return args.Get(0).([]queue.QueuedItemData), args.Error(1)
 }
 
+func (m *mockQueueStore) GetByItemID(ctx context.Context, name, itemID string) (queue.QueuedItemData, error) {
+	args := m.Called(ctx, name, itemID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(queue.QueuedItemData), args.Error(1)
+}
+
 func (m *mockQueueStore) ListCursor(ctx context.Context, name, cursor string, limit int) (pagination.CursorResult[queue.QueuedItemData], error) {
 	args := m.Called(ctx, name, cursor, limit)
 	return args.Get(0).(pagination.CursorResult[queue.QueuedItemData]), args.Error(1)

--- a/internal/testutil/dagrun_attempt.go
+++ b/internal/testutil/dagrun_attempt.go
@@ -46,6 +46,10 @@ func (m *MockAttempt) ReadStatus(ctx context.Context) (*ir.DAGRunStatus, error) 
 	return args.Get(0).(*ir.DAGRunStatus), args.Error(1)
 }
 
+func (m *MockAttempt) ReadStatusUncached(ctx context.Context) (*ir.DAGRunStatus, error) {
+	return m.ReadStatus(ctx)
+}
+
 func (m *MockAttempt) ReadDAG(ctx context.Context) (*ir.DAG, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {

--- a/internal/testutil/queue_store.go
+++ b/internal/testutil/queue_store.go
@@ -49,6 +49,14 @@ func (m *MockQueueStore) List(ctx context.Context, name string) ([]queue.QueuedI
 	return args.Get(0).([]queue.QueuedItemData), args.Error(1)
 }
 
+func (m *MockQueueStore) GetByItemID(ctx context.Context, name, itemID string) (queue.QueuedItemData, error) {
+	args := m.Called(ctx, name, itemID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(queue.QueuedItemData), args.Error(1)
+}
+
 func (m *MockQueueStore) ListCursor(ctx context.Context, name, cursor string, limit int) (pagination.CursorResult[queue.QueuedItemData], error) {
 	args := m.Called(ctx, name, cursor, limit)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## Summary

Fix scheduler memory growth that remains after #2607 when distributed workers are unavailable.

## Root cause

The scheduler scanned every item in every active queue on each processing cycle. Worker eligibility checks called the cached status reader for each queued run, so the shared status cache retained large run snapshots for up to an hour even though the scheduler only needed them for one eligibility decision. An unavailable worker kept those runs queued and repeated the scan, allowing retained memory to grow with the queue. Full-queue condition validation and one goroutine per active queue added more allocation pressure.

PR #2607 prevented repeated workspace archive preparation and added worker eligibility checks. Those checks exposed this separate retention path because they read every queued status through the shared cache.

## Changes

- Scan at most 100 items per queue cycle
- Always inspect the queue head and rotate through the remaining items with a persistent cursor
- Read statuses without populating the shared cache during eligibility and reservation checks
- Validate condition updates with an exact queue-item lookup instead of loading the full queue
- Limit concurrent queue scans to eight
- Recover cleanly when queue mutation invalidates a scan cursor
- Add regression tests for scan bounds, rotation, head fairness, cache retention, exact validation, cursor invalidation, and concurrency

## Related Issues

Follow-up to #2607.

## Testing

- `make test`
- `go test -race ./internal/persis/file/dagrun ./internal/persis/store ./internal/service/scheduler -count=1`
- `make fmt`
- Native and Windows `golangci-lint`
- Package-boundary import checks

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents scheduler memory growth when workers are unavailable by bounding per-queue scans and bypassing the shared status cache. Previously the scheduler scanned every queued item and cached large run statuses; now it scans a small window (always includes the head, rotates the rest) and reads statuses uncached, with exact item validation for condition updates.

- Adds `ReadStatusUncached` to `dagrun.Attempt`; scheduler uses it for eligibility and reservation checks to avoid retaining statuses in the shared cache.
- Adds `GetByItemID` to `queue.QueueStore`; condition updates verify an item with an exact lookup instead of loading the full queue.
- Uses `ListCursor` to scan at most 100 items per cycle (1 head + up to 99 rotated), tracks a per-queue cursor, resets on notifications, and restarts scans on `pagination.ErrInvalidCursor`.
- Limits concurrent queue scans to eight; head is always checked first to preserve fairness.
- Regression tests cover scan bounds, rotation, head fairness, cursor invalidation, cache retention, and exact validation.

Required migrations:
- Implement `ReadStatusUncached` in custom `dagrun.Attempt` types (you may forward to `ReadStatus` if you do not cache).
- Implement `GetByItemID` in custom `queue.QueueStore` types; ensure `ListCursor` supports forward-only pagination and returns `pagination.ErrInvalidCursor` when a cursor is invalid.

<sup>Written for commit e29b8f815ba4e583031813fbf12c438dcc1dc99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exact queue-item lookup by item ID, including clear handling for missing items.
  * Added fresh status reads that bypass cached data when current DAG-run status is required.

* **Improvements**
  * Improved queue processing with bounded scans, pagination, prioritization of queue heads, and controlled concurrency.
  * Reduced stale-status effects during scheduling and condition evaluation.
  * Added safeguards for invalid scan cursors and missing queue items.

* **Tests**
  * Expanded coverage for queue scanning, pagination, status caching, and item retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->