### PR TITLE
fix: park unchanged scheduler queue scans

### DIFF
--- a/internal/cmd/enqueue_internal_test.go
+++ b/internal/cmd/enqueue_internal_test.go
@@ -213,6 +213,10 @@ func (s *enqueueObservingQueueStore) ListCursor(context.Context, string, string,
 	return pagination.CursorResult[queue.QueuedItemData]{}, nil
 }
 
+func (s *enqueueObservingQueueStore) Revision(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 func (s *enqueueObservingQueueStore) All(context.Context) ([]queue.QueuedItemData, error) {
 	return nil, nil
 }

--- a/internal/intake/queue_test.go
+++ b/internal/intake/queue_test.go
@@ -263,6 +263,7 @@ func (s *queueStore) GetByItemID(context.Context, string, string) (queue.QueuedI
 func (s *queueStore) ListCursor(context.Context, string, string, int) (pagination.CursorResult[queue.QueuedItemData], error) {
 	return pagination.CursorResult[queue.QueuedItemData]{}, nil
 }
+func (s *queueStore) Revision(context.Context, string) (int64, error)     { return 0, nil }
 func (s *queueStore) All(context.Context) ([]queue.QueuedItemData, error) { return nil, nil }
 func (s *queueStore) ListByDAGName(context.Context, string, string) ([]queue.QueuedItemData, error) {
 	return nil, nil

--- a/internal/intg/retry_test.go
+++ b/internal/intg/retry_test.go
@@ -182,12 +182,11 @@ if (-not (Test-Path marker)) {
 func TestStepRetryWithDownstreamResetsOnlyReachableDescendants(t *testing.T) {
 	th := test.SetupCommand(t)
 	workDir := t.TempDir()
-	seen := filepath.Join(workDir, "seen.txt")
 
 	appendLine := func(letter string) string {
 		return test.ForOS(
-			fmt.Sprintf("echo %s >> seen.txt", letter),
-			fmt.Sprintf("Add-Content -Path seen.txt -Value %s", letter),
+			fmt.Sprintf("echo %s >> seen-%s.txt", letter, letter),
+			fmt.Sprintf("Add-Content -Path seen-%s.txt -Value %s", letter, letter),
 		)
 	}
 	th.CreateDAGFile(t, "retry_downstream.yaml", fmt.Sprintf(`type: graph
@@ -218,17 +217,13 @@ steps:
 		Args: []string{"start", "--run-id", dagRunID, "retry_downstream"},
 	})
 
-	first, err := os.ReadFile(seen)
-	require.NoError(t, err)
-	require.Equal(t, map[string]int{"A": 1, "B": 1, "C": 1, "D": 1}, countOutputLines(string(first)))
+	require.Equal(t, map[string]int{"A": 1, "B": 1, "C": 1, "D": 1}, readStepExecutionCounts(t, workDir, "A", "B", "C", "D"))
 
 	th.RunCommand(t, cmd.Retry(), test.CmdTest{
 		Args: []string{"retry", "--run-id", dagRunID, "--step", "B", "--downstream", "retry_downstream"},
 	})
 
-	second, err := os.ReadFile(seen)
-	require.NoError(t, err)
-	require.Equal(t, map[string]int{"A": 1, "B": 2, "C": 2, "D": 1}, countOutputLines(string(second)))
+	require.Equal(t, map[string]int{"A": 1, "B": 2, "C": 2, "D": 1}, readStepExecutionCounts(t, workDir, "A", "B", "C", "D"))
 
 	ref := ir.NewDAGRunRef("retry_downstream", dagRunID)
 	attempt, err := th.DAGRunRepository.FindAttempt(th.Context, ref)
@@ -242,13 +237,14 @@ steps:
 	require.Equal(t, ir.NodeSucceeded, status.Nodes[3].Status)
 }
 
-func countOutputLines(s string) map[string]int {
+func readStepExecutionCounts(t *testing.T, workDir string, steps ...string) map[string]int {
+	t.Helper()
+
 	counts := map[string]int{}
-	for line := range strings.SplitSeq(strings.ReplaceAll(s, "\r\n", "\n"), "\n") {
-		if line == "" {
-			continue
-		}
-		counts[line]++
+	for _, step := range steps {
+		output, err := os.ReadFile(filepath.Join(workDir, "seen-"+step+".txt"))
+		require.NoError(t, err)
+		counts[step] = len(strings.Fields(string(output)))
 	}
 	return counts
 }

--- a/internal/persis/file/proc/store.go
+++ b/internal/persis/file/proc/store.go
@@ -206,6 +206,9 @@ func (s *Store) WithLock(ctx context.Context, groupName string, fn func() error)
 	}, policy, func(_ error) bool {
 		return ctx.Err() == nil
 	}); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
 		return persis.NewProcLockError(err)
 	}
 	defer func() {

--- a/internal/persis/file/proc/store_test.go
+++ b/internal/persis/file/proc/store_test.go
@@ -162,14 +162,13 @@ func TestStoreSkipsAbandonedDamagedProcFile(t *testing.T) {
 
 	ctx := context.Background()
 	root := t.TempDir()
-	s := New(root, WithHeartbeatInterval(10*time.Millisecond), WithStaleThreshold(time.Second))
+	s := New(root, WithStaleThreshold(time.Minute))
 	repository := persis.NewProcRepository(s)
 	ref := ir.NewDAGRunRef("healthy-dag", "run-1")
+	meta := testProcMeta(ref)
 
-	handle, err := s.Acquire(ctx, "queue-a", testProcMeta(ref))
-	require.NoError(t, err)
-	defer func() { _ = handle.Stop(ctx) }()
-	require.NotEmpty(t, waitForProcFile(t, root, "queue-a", "healthy-dag"))
+	now := time.Now().UTC()
+	require.NoError(t, writeProcFile(s.filePath("queue-a", meta, now), now.Unix(), meta))
 
 	writeDamagedProcFile(t, s, "queue-a", ir.NewDAGRunRef("healthy-dag", "abandoned-run"), time.Hour)
 

--- a/internal/persis/store/queue.go
+++ b/internal/persis/store/queue.go
@@ -212,6 +212,21 @@ func (s *QueueStore) ListCursor(ctx context.Context, name, cursor string, limit 
 	return s.listCursorLocked(ctx, name, decoded, limit)
 }
 
+// Revision returns the current ordered membership revision of the named queue.
+func (s *QueueStore) Revision(ctx context.Context, name string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadOrRebuildQueueIndexLocked(ctx, name)
+	if err != nil {
+		return 0, err
+	}
+	if idx.total() == 0 {
+		return 0, nil
+	}
+	return idx.Revision, nil
+}
+
 // All returns all queued items across all queues.
 func (s *QueueStore) All(ctx context.Context) ([]queue.QueuedItemData, error) {
 	items, err := s.listAllQueueItems(ctx, persis.ListQuery{})

--- a/internal/persis/store/queue_test.go
+++ b/internal/persis/store/queue_test.go
@@ -48,8 +48,22 @@ func TestQueueStore_EnqueueListAndDequeue(t *testing.T) {
 	ctx := context.Background()
 	s := newQueueStore(t)
 
+	revision, err := s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Zero(t, revision)
+
 	require.NoError(t, s.Enqueue(ctx, "main", queue.QueuePriorityLow, queueRef("dag-low", "run-low")))
+	firstRevision, err := s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Positive(t, firstRevision)
+
 	require.NoError(t, s.Enqueue(ctx, "main", queue.QueuePriorityHigh, queueRef("dag-high", "run-high")))
+	secondRevision, err := s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Greater(t, secondRevision, firstRevision)
+	stableRevision, err := s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Equal(t, secondRevision, stableRevision)
 
 	n, err := s.Len(ctx, "main")
 	require.NoError(t, err)
@@ -64,6 +78,9 @@ func TestQueueStore_EnqueueListAndDequeue(t *testing.T) {
 	deleted, err := s.DeleteByItemIDs(ctx, "main", []string{items[0].ID()})
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleted)
+	thirdRevision, err := s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Greater(t, thirdRevision, secondRevision)
 
 	items, err = s.List(ctx, "main")
 	require.NoError(t, err)
@@ -73,6 +90,9 @@ func TestQueueStore_EnqueueListAndDequeue(t *testing.T) {
 	deleted, err = s.DeleteByItemIDs(ctx, "main", []string{items[0].ID()})
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleted)
+	revision, err = s.Revision(ctx, "main")
+	require.NoError(t, err)
+	assert.Zero(t, revision)
 }
 
 func TestQueueStore_GetByItemID(t *testing.T) {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -33,6 +33,8 @@ type QueueStore interface {
 	GetByItemID(ctx context.Context, name, itemID string) (QueuedItemData, error)
 	// ListCursor returns one forward-only page of queued items for a specific queue.
 	ListCursor(ctx context.Context, name, cursor string, limit int) (pagination.CursorResult[QueuedItemData], error)
+	// Revision returns a value that changes when the ordered queue membership changes.
+	Revision(ctx context.Context, name string) (int64, error)
 	// All returns all items in the queue
 	All(ctx context.Context) ([]QueuedItemData, error)
 	// ListByDAGName returns all items that has a specific DAG name

--- a/internal/service/scheduler/queue_conditions_external_test.go
+++ b/internal/service/scheduler/queue_conditions_external_test.go
@@ -487,6 +487,7 @@ func TestQueueProcessorRotatesPastBoundedWorkerEligibilityWindow(t *testing.T) {
 		nil,
 		dispatcher,
 		scheduler.WithWorkerHeartbeatStore(heartbeatStore),
+		scheduler.WithWorkerHeartbeatStaleThreshold(conditionTestStaleThreshold),
 	)
 	f.dag.WorkerSelector = map[string]string{"type": "gpu"}
 	for i := range 100 {

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -67,6 +67,7 @@ type queueDispatchBatch struct {
 	maxConcurrency        int
 	aliveCount            int
 	nonAdmissionOccupancy int
+	retryScan             bool
 }
 
 type queueCapacityAvailability uint8
@@ -616,14 +617,14 @@ func (d *queueDispatcher) selectDispatchBatch(
 		return queueDispatchBatch{}, nil
 	}
 
-	runnableItems, err := d.selectRunnableQueueItemsInQueue(ctx, queueName, items, freeSlots, workerSnapshot)
+	runnableItems, retryScan, err := d.selectRunnableQueueItemsInQueue(ctx, queueName, items, freeSlots, workerSnapshot)
 	if err != nil {
 		logger.Error(ctx, "Failed to select runnable queue items", tag.Error(err), tag.Queue(queueName))
 		return queueDispatchBatch{}, fmt.Errorf("select runnable queue items: %w", err)
 	}
 	if len(runnableItems) == 0 {
 		logger.Debug(ctx, "No queue items eligible for a new dispatch attempt")
-		return queueDispatchBatch{}, nil
+		return queueDispatchBatch{retryScan: retryScan}, nil
 	}
 
 	return queueDispatchBatch{
@@ -631,6 +632,7 @@ func (d *queueDispatcher) selectDispatchBatch(
 		maxConcurrency:        capacity.maxConcurrency,
 		aliveCount:            aliveCount,
 		nonAdmissionOccupancy: nonAdmissionOccupancy,
+		retryScan:             retryScan,
 	}, nil
 }
 
@@ -1270,7 +1272,8 @@ func (d *queueDispatcher) selectRunnableQueueItems(
 	items []queuedomain.QueuedItemData,
 	freeSlots int,
 ) ([]queuedomain.QueuedItemData, error) {
-	return d.selectRunnableQueueItemsInQueue(ctx, "", items, freeSlots, &workerHeartbeatSnapshot{})
+	runnable, _, err := d.selectRunnableQueueItemsInQueue(ctx, "", items, freeSlots, &workerHeartbeatSnapshot{})
+	return runnable, err
 }
 
 func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
@@ -1279,12 +1282,13 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 	items []queuedomain.QueuedItemData,
 	freeSlots int,
 	workerSnapshot *workerHeartbeatSnapshot,
-) ([]queuedomain.QueuedItemData, error) {
+) ([]queuedomain.QueuedItemData, bool, error) {
 	if freeSlots <= 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	runnable := make([]queuedomain.QueuedItemData, 0, min(freeSlots, len(items)))
+	retryScan := false
 	var workerConditionStages []*queuedConditionStage
 	defer func() {
 		flushQueuedConditionStages(ctx, workerConditionStages)
@@ -1296,12 +1300,13 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 		runRef, err := item.Data()
 		if err != nil {
 			logger.Error(ctx, "Failed to get item data while selecting runnable queue items", tag.Error(err))
+			retryScan = true
 			continue
 		}
 		if d.dispatchAdmissionStore == nil && d.dispatchTaskStore != nil {
 			reserved, err := d.hasOutstandingDispatchReservation(ctx, *runRef)
 			if err != nil {
-				return nil, err
+				return nil, retryScan, err
 			}
 			if reserved {
 				conditionStage := d.newQueuedConditionStageFromItem(ctx, queueName, item)
@@ -1328,7 +1333,7 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 		runnable = append(runnable, item)
 	}
 
-	return runnable, nil
+	return runnable, retryScan, nil
 }
 
 func (d *queueDispatcher) queueItemHasEligibleWorker(

--- a/internal/service/scheduler/queue_dispatcher.go
+++ b/internal/service/scheduler/queue_dispatcher.go
@@ -69,10 +69,34 @@ type queueDispatchBatch struct {
 	nonAdmissionOccupancy int
 }
 
+type queueCapacityAvailability uint8
+
+const (
+	queueCapacityAvailable queueCapacityAvailability = iota
+	queueLocalStateUnavailable
+	queueDistributedStateUnavailable
+	queueDispatchStateUnavailable
+)
+
+type queueCapacityGeneration struct {
+	maxConcurrency           int
+	localAliveCount          int
+	distributedAliveCount    int
+	inflightCount            int
+	outstandingDispatchCount int
+	availability             queueCapacityAvailability
+}
+
+type queueCapacitySnapshot struct {
+	queueCapacityGeneration
+	err error
+}
+
 type workerHeartbeatSnapshot struct {
-	records []dispatch.WorkerHeartbeatRecord
-	err     error
-	loaded  bool
+	records    []dispatch.WorkerHeartbeatRecord
+	observedAt time.Time
+	err        error
+	loaded     bool
 }
 
 func (s *workerHeartbeatSnapshot) load(
@@ -81,6 +105,7 @@ func (s *workerHeartbeatSnapshot) load(
 ) ([]dispatch.WorkerHeartbeatRecord, error) {
 	if !s.loaded {
 		s.loaded = true
+		s.observedAt = time.Now().UTC()
 		s.records, s.err = store.List(ctx)
 		if s.err != nil {
 			logger.Error(ctx, "Failed to list worker heartbeats", tag.Error(s.err))
@@ -563,52 +588,35 @@ func (d *queueDispatcher) selectDispatchBatch(
 	ctx context.Context,
 	queueName string,
 	items []queuedomain.QueuedItemData,
-	maxConcurrency int,
-	inflightCount int,
+	capacity queueCapacitySnapshot,
+	workerSnapshot *workerHeartbeatSnapshot,
 ) (queueDispatchBatch, error) {
-	localAliveCount, err := d.procRepository.CountAlive(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count alive processes", tag.Error(err), tag.Queue(queueName))
+	if capacity.err != nil {
 		d.recordQueueStateUnavailableConditions(ctx, queueName, items)
-		return queueDispatchBatch{}, fmt.Errorf("count alive processes: %w", err)
+		return queueDispatchBatch{}, capacity.err
 	}
 
-	distributedAliveCount, err := d.countActiveDistributedRuns(ctx, queueName)
-	if err != nil {
-		logger.Error(ctx, "Failed to count distributed leases", tag.Error(err), tag.Queue(queueName))
-		d.recordQueueStateUnavailableConditions(ctx, queueName, items)
-		return queueDispatchBatch{}, fmt.Errorf("count distributed leases: %w", err)
-	}
-	aliveCount := localAliveCount + distributedAliveCount
-	outstandingDispatchCount := 0
-	if d.dispatchAdmissionStore == nil {
-		outstandingDispatchCount, err = d.countOutstandingDispatchReservations(ctx, queueName)
-		if err != nil {
-			logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
-			d.recordQueueStateUnavailableConditions(ctx, queueName, items)
-			return queueDispatchBatch{}, fmt.Errorf("count outstanding distributed dispatch reservations: %w", err)
-		}
-	}
-	nonAdmissionOccupancy := localAliveCount + inflightCount
-	freeSlots := maxConcurrency - aliveCount - inflightCount - outstandingDispatchCount
+	aliveCount := capacity.localAliveCount + capacity.distributedAliveCount
+	nonAdmissionOccupancy := capacity.localAliveCount + capacity.inflightCount
+	freeSlots := capacity.maxConcurrency - aliveCount - capacity.inflightCount - capacity.outstandingDispatchCount
 
 	logger.Debug(ctx, "Queue capacity check",
-		tag.MaxConcurrency(maxConcurrency),
+		tag.MaxConcurrency(capacity.maxConcurrency),
 		tag.Alive(aliveCount),
-		slog.Int("outstanding-dispatches", outstandingDispatchCount),
+		slog.Int("outstanding-dispatches", capacity.outstandingDispatchCount),
 		tag.Count(freeSlots),
 	)
 
 	if freeSlots <= 0 {
 		logger.Debug(ctx, "Max concurrency reached",
-			tag.MaxConcurrency(maxConcurrency),
+			tag.MaxConcurrency(capacity.maxConcurrency),
 			tag.Alive(aliveCount),
 		)
-		d.recordCapacityUnavailableConditions(ctx, queueName, items, outstandingDispatchCount > 0)
+		d.recordCapacityUnavailableConditions(ctx, queueName, items, capacity.outstandingDispatchCount > 0)
 		return queueDispatchBatch{}, nil
 	}
 
-	runnableItems, err := d.selectRunnableQueueItemsInQueue(ctx, queueName, items, freeSlots)
+	runnableItems, err := d.selectRunnableQueueItemsInQueue(ctx, queueName, items, freeSlots, workerSnapshot)
 	if err != nil {
 		logger.Error(ctx, "Failed to select runnable queue items", tag.Error(err), tag.Queue(queueName))
 		return queueDispatchBatch{}, fmt.Errorf("select runnable queue items: %w", err)
@@ -620,10 +628,54 @@ func (d *queueDispatcher) selectDispatchBatch(
 
 	return queueDispatchBatch{
 		items:                 runnableItems,
-		maxConcurrency:        maxConcurrency,
+		maxConcurrency:        capacity.maxConcurrency,
 		aliveCount:            aliveCount,
 		nonAdmissionOccupancy: nonAdmissionOccupancy,
 	}, nil
+}
+
+func (d *queueDispatcher) queueCapacity(
+	ctx context.Context,
+	queueName string,
+	maxConcurrency int,
+	inflightCount int,
+) queueCapacitySnapshot {
+	capacity := queueCapacitySnapshot{queueCapacityGeneration: queueCapacityGeneration{
+		maxConcurrency: maxConcurrency,
+		inflightCount:  inflightCount,
+	}}
+
+	if d.procRepository != nil {
+		localAliveCount, err := d.procRepository.CountAlive(ctx, queueName)
+		if err != nil {
+			logger.Error(ctx, "Failed to count alive processes", tag.Error(err), tag.Queue(queueName))
+			capacity.availability = queueLocalStateUnavailable
+			capacity.err = fmt.Errorf("count alive processes: %w", err)
+			return capacity
+		}
+		capacity.localAliveCount = localAliveCount
+	}
+
+	distributedAliveCount, err := d.countActiveDistributedRuns(ctx, queueName)
+	if err != nil {
+		logger.Error(ctx, "Failed to count distributed leases", tag.Error(err), tag.Queue(queueName))
+		capacity.availability = queueDistributedStateUnavailable
+		capacity.err = fmt.Errorf("count distributed leases: %w", err)
+		return capacity
+	}
+	capacity.distributedAliveCount = distributedAliveCount
+
+	if d.dispatchAdmissionStore == nil {
+		outstandingDispatchCount, err := d.countOutstandingDispatchReservations(ctx, queueName)
+		if err != nil {
+			logger.Error(ctx, "Failed to count outstanding distributed dispatch reservations", tag.Error(err), tag.Queue(queueName))
+			capacity.availability = queueDispatchStateUnavailable
+			capacity.err = fmt.Errorf("count outstanding distributed dispatch reservations: %w", err)
+			return capacity
+		}
+		capacity.outstandingDispatchCount = outstandingDispatchCount
+	}
+	return capacity
 }
 
 func (d *queueDispatcher) dispatchQueuedItem(
@@ -1218,7 +1270,7 @@ func (d *queueDispatcher) selectRunnableQueueItems(
 	items []queuedomain.QueuedItemData,
 	freeSlots int,
 ) ([]queuedomain.QueuedItemData, error) {
-	return d.selectRunnableQueueItemsInQueue(ctx, "", items, freeSlots)
+	return d.selectRunnableQueueItemsInQueue(ctx, "", items, freeSlots, &workerHeartbeatSnapshot{})
 }
 
 func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
@@ -1226,13 +1278,13 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 	queueName string,
 	items []queuedomain.QueuedItemData,
 	freeSlots int,
+	workerSnapshot *workerHeartbeatSnapshot,
 ) ([]queuedomain.QueuedItemData, error) {
 	if freeSlots <= 0 {
 		return nil, nil
 	}
 
 	runnable := make([]queuedomain.QueuedItemData, 0, min(freeSlots, len(items)))
-	workerSnapshot := workerHeartbeatSnapshot{}
 	var workerConditionStages []*queuedConditionStage
 	defer func() {
 		flushQueuedConditionStages(ctx, workerConditionStages)
@@ -1264,7 +1316,7 @@ func (d *queueDispatcher) selectRunnableQueueItemsInQueue(
 		if d.workerHeartbeatStore != nil {
 			recordCondition := len(workerConditionStages) < queuedConditionRefreshBatchLimit
 			eligible, conditionStage := d.queueItemHasEligibleWorker(
-				ctx, queueName, item, *runRef, &workerSnapshot, recordCondition,
+				ctx, queueName, item, *runRef, workerSnapshot, recordCondition,
 			)
 			if !eligible {
 				if conditionStage != nil {
@@ -1305,7 +1357,7 @@ func (d *queueDispatcher) queueItemHasEligibleWorker(
 	if err != nil {
 		conditionDefs = assignmentUnavailableConditionDefs
 	} else {
-		available, defs := workerAvailableInSnapshot(records, time.Now().UTC(), d.workerStaleAfter, dag, status)
+		available, defs := workerAvailableInSnapshot(records, workerSnapshot.observedAt, d.workerStaleAfter, dag, status)
 		if available {
 			return true, nil
 		}

--- a/internal/service/scheduler/queue_dispatcher_test.go
+++ b/internal/service/scheduler/queue_dispatcher_test.go
@@ -74,11 +74,12 @@ func TestQueueDispatcher_SelectRunnableQueueItemsSkipsInvalidItems(t *testing.T)
 	dispatcher := newQueueDispatcher(queueDispatchDeps{})
 	validRef := ir.NewDAGRunRef("dag", "run-ok")
 
-	runnable, err := dispatcher.selectRunnableQueueItems(t.Context(), []queuedomain.QueuedItemData{
+	runnable, retryScan, err := dispatcher.selectRunnableQueueItemsInQueue(t.Context(), "", []queuedomain.QueuedItemData{
 		testQueuedItem{id: "bad", err: fmt.Errorf("invalid queued item")},
 		testQueuedItem{id: "ok", ref: &validRef},
-	}, 1)
+	}, 1, &workerHeartbeatSnapshot{})
 	require.NoError(t, err)
 	require.Len(t, runnable, 1)
 	assert.Equal(t, "ok", runnable[0].ID())
+	assert.True(t, retryScan)
 }

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -124,15 +124,16 @@ type QueueProcessor struct {
 }
 
 type queue struct {
-	maxConcurrency int
-	isGlobal       bool // true if this queue is defined in config (global queue)
-	scanCursor     string
-	scanGeneration queueScanGeneration
-	scanRetryAt    time.Time
-	generationSet  bool
-	parked         bool
-	inflight       atomic.Int32
-	mu             sync.Mutex
+	maxConcurrency  int
+	isGlobal        bool // true if this queue is defined in config (global queue)
+	scanCursor      string
+	scanGeneration  queueScanGeneration
+	scanRetryAt     time.Time
+	scanRetryNeeded bool
+	generationSet   bool
+	parked          bool
+	inflight        atomic.Int32
+	mu              sync.Mutex
 }
 
 type workerEligibilityGeneration struct {
@@ -170,20 +171,26 @@ func (q *queue) scanPosition(generation queueScanGeneration, now time.Time) (str
 		q.scanCursor = ""
 		q.scanGeneration = generation
 		q.scanRetryAt = time.Time{}
+		q.scanRetryNeeded = false
 		q.generationSet = true
 		q.parked = false
 	} else if q.parked && !q.scanRetryAt.IsZero() && !now.Before(q.scanRetryAt) {
 		q.scanRetryAt = time.Time{}
+		q.scanRetryNeeded = false
 		q.parked = false
 	}
 	return q.scanCursor, q.parked
 }
 
-func (q *queue) advanceScan(generation queueScanGeneration, cursor string) {
+func (q *queue) advanceScan(generation queueScanGeneration, cursor string, retryNeeded bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if !q.generationSet || q.scanGeneration != generation {
+		q.scanRetryNeeded = false
+	}
 	q.scanGeneration = generation
 	q.scanRetryAt = time.Time{}
+	q.scanRetryNeeded = q.scanRetryNeeded || retryNeeded
 	q.generationSet = true
 	q.scanCursor = cursor
 	q.parked = false
@@ -194,6 +201,7 @@ func (q *queue) parkScan(generation queueScanGeneration) {
 	defer q.mu.Unlock()
 	q.scanGeneration = generation
 	q.scanRetryAt = time.Time{}
+	q.scanRetryNeeded = false
 	q.generationSet = true
 	q.scanCursor = ""
 	q.parked = true
@@ -204,9 +212,27 @@ func (q *queue) deferScan(generation queueScanGeneration, retryAt time.Time) {
 	defer q.mu.Unlock()
 	q.scanGeneration = generation
 	q.scanRetryAt = retryAt
+	q.scanRetryNeeded = false
 	q.generationSet = true
 	q.scanCursor = ""
 	q.parked = true
+}
+
+func (q *queue) finishScan(generation queueScanGeneration, retryNeeded bool, retryAt time.Time) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.generationSet && q.scanGeneration == generation {
+		retryNeeded = retryNeeded || q.scanRetryNeeded
+	}
+	q.scanGeneration = generation
+	q.scanRetryNeeded = false
+	q.generationSet = true
+	q.scanCursor = ""
+	q.parked = true
+	q.scanRetryAt = time.Time{}
+	if retryNeeded {
+		q.scanRetryAt = retryAt
+	}
 }
 
 func (q *queue) incInflight() { q.inflight.Add(1) }
@@ -546,7 +572,7 @@ func (p *QueueProcessor) processQueueItems(
 	)
 
 	if len(items) == 0 {
-		p.parkQueueScan(q, generation)
+		p.finishQueueScan(q, generation, false)
 		logger.Debug(ctx, "No item found")
 		return
 	}
@@ -560,10 +586,10 @@ func (p *QueueProcessor) processQueueItems(
 	}
 	if len(batch.items) == 0 {
 		if page.HasMore && page.NextCursor != "" {
-			q.advanceScan(generation, page.NextCursor)
+			q.advanceScan(generation, page.NextCursor, batch.retryScan)
 			p.wakeUp()
 		} else {
-			p.parkQueueScan(q, generation)
+			p.finishQueueScan(q, generation, batch.retryScan)
 		}
 		return
 	}
@@ -598,6 +624,11 @@ func (p *QueueProcessor) processQueueItems(
 
 func (p *QueueProcessor) parkQueueScan(q *queue, generation queueScanGeneration) {
 	q.parkScan(generation)
+	p.wakeUp()
+}
+
+func (p *QueueProcessor) finishQueueScan(q *queue, generation queueScanGeneration, retryNeeded bool) {
+	q.finishScan(generation, retryNeeded, time.Now().Add(queueProcessFallbackInterval))
 	p.wakeUp()
 }
 

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -400,6 +400,7 @@ func (p *QueueProcessor) processActiveQueues(ctx context.Context, activeQueues m
 		return
 	}
 	workerSnapshot := p.loadWorkerHeartbeatSnapshot(ctx)
+	workerGeneration := workerSnapshot.generation(p.workerHeartbeatStore != nil, p.workerStaleAfter)
 
 	queueNames := make(chan string)
 	var wg sync.WaitGroup
@@ -416,7 +417,7 @@ func (p *QueueProcessor) processActiveQueues(ctx context.Context, activeQueues m
 						}
 					}()
 					queueCtx := logger.WithValues(ctx, tag.Queue(queueName))
-					p.processQueueItems(queueCtx, queueName, workerSnapshot)
+					p.processQueueItems(queueCtx, queueName, workerSnapshot, workerGeneration)
 				}()
 			}
 		})
@@ -478,13 +479,20 @@ func (p *QueueProcessor) acquireDispatchHandoff(ctx context.Context) (func(), bo
 
 // ProcessQueueItems processes items in the specified queue.
 func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string) {
-	p.processQueueItems(ctx, queueName, p.loadWorkerHeartbeatSnapshot(ctx))
+	workerSnapshot := p.loadWorkerHeartbeatSnapshot(ctx)
+	p.processQueueItems(
+		ctx,
+		queueName,
+		workerSnapshot,
+		workerSnapshot.generation(p.workerHeartbeatStore != nil, p.workerStaleAfter),
+	)
 }
 
 func (p *QueueProcessor) processQueueItems(
 	ctx context.Context,
 	queueName string,
 	workerSnapshot *workerHeartbeatSnapshot,
+	workerGeneration workerEligibilityGeneration,
 ) {
 	if p.isClosed() {
 		return
@@ -507,11 +515,12 @@ func (p *QueueProcessor) processQueueItems(
 	capacity := dispatcher.queueCapacity(ctx, queueName, q.getMaxConcurrency(), q.getInflight())
 	generation := queueScanGeneration{
 		queueRevision: revision,
-		workers:       workerSnapshot.generation(p.workerHeartbeatStore != nil, p.workerStaleAfter),
+		workers:       workerGeneration,
 		capacity:      capacity.queueCapacityGeneration,
 	}
 	cursor, parked := q.scanPosition(generation)
 	if parked {
+		p.wakeUp()
 		logger.Debug(ctx, "Queue scan parked until relevant state changes")
 		return
 	}
@@ -528,7 +537,7 @@ func (p *QueueProcessor) processQueueItems(
 	)
 
 	if len(items) == 0 {
-		q.parkScan(generation)
+		p.parkQueueScan(q, generation)
 		logger.Debug(ctx, "No item found")
 		return
 	}
@@ -536,7 +545,7 @@ func (p *QueueProcessor) processQueueItems(
 	batch, err := dispatcher.selectDispatchBatch(ctx, queueName, items, capacity, workerSnapshot)
 	if err != nil {
 		if capacity.err != nil {
-			q.parkScan(generation)
+			p.parkQueueScan(q, generation)
 		}
 		return
 	}
@@ -545,7 +554,7 @@ func (p *QueueProcessor) processQueueItems(
 			q.advanceScan(generation, page.NextCursor)
 			p.wakeUp()
 		} else {
-			q.parkScan(generation)
+			p.parkQueueScan(q, generation)
 		}
 		return
 	}
@@ -575,6 +584,11 @@ func (p *QueueProcessor) processQueueItems(
 		}(item)
 	}
 	wg.Wait()
+	p.wakeUp()
+}
+
+func (p *QueueProcessor) parkQueueScan(q *queue, generation queueScanGeneration) {
+	q.parkScan(generation)
 	p.wakeUp()
 }
 

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -5,9 +5,13 @@ package scheduler
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"log/slog"
 	"runtime"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -122,8 +126,23 @@ type queue struct {
 	maxConcurrency int
 	isGlobal       bool // true if this queue is defined in config (global queue)
 	scanCursor     string
+	scanGeneration queueScanGeneration
+	generationSet  bool
+	parked         bool
 	inflight       atomic.Int32
 	mu             sync.Mutex
+}
+
+type workerEligibilityGeneration struct {
+	fingerprint [sha256.Size]byte
+	enabled     bool
+	available   bool
+}
+
+type queueScanGeneration struct {
+	queueRevision int64
+	workers       workerEligibilityGeneration
+	capacity      queueCapacityGeneration
 }
 
 func (q *queue) getMaxConcurrency() int {
@@ -142,16 +161,43 @@ func (q *queue) getInflight() int {
 	return int(q.inflight.Load())
 }
 
-func (q *queue) getScanCursor() string {
+func (q *queue) scanPosition(generation queueScanGeneration) (string, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return q.scanCursor
+	if !q.generationSet || q.scanGeneration != generation {
+		q.scanCursor = ""
+		q.scanGeneration = generation
+		q.generationSet = true
+		q.parked = false
+	}
+	return q.scanCursor, q.parked
 }
 
-func (q *queue) setScanCursor(cursor string) {
+func (q *queue) advanceScan(generation queueScanGeneration, cursor string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	q.scanGeneration = generation
+	q.generationSet = true
 	q.scanCursor = cursor
+	q.parked = false
+}
+
+func (q *queue) parkScan(generation queueScanGeneration) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.scanGeneration = generation
+	q.generationSet = true
+	q.scanCursor = ""
+	q.parked = true
+}
+
+func (q *queue) restartScan(generation queueScanGeneration) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.scanGeneration = generation
+	q.generationSet = true
+	q.scanCursor = ""
+	q.parked = false
 }
 
 func (q *queue) incInflight() { q.inflight.Add(1) }
@@ -281,7 +327,6 @@ func (p *QueueProcessor) Start(ctx context.Context, notifyCh <-chan struct{}) {
 			case <-p.quit:
 				return
 			case <-notifyCh:
-				p.resetQueueScanCursors()
 				p.wakeUp()
 			}
 		}
@@ -354,6 +399,7 @@ func (p *QueueProcessor) processActiveQueues(ctx context.Context, activeQueues m
 	if workerCount == 0 {
 		return
 	}
+	workerSnapshot := p.loadWorkerHeartbeatSnapshot(ctx)
 
 	queueNames := make(chan string)
 	var wg sync.WaitGroup
@@ -370,7 +416,7 @@ func (p *QueueProcessor) processActiveQueues(ctx context.Context, activeQueues m
 						}
 					}()
 					queueCtx := logger.WithValues(ctx, tag.Queue(queueName))
-					p.ProcessQueueItems(queueCtx, queueName)
+					p.processQueueItems(queueCtx, queueName, workerSnapshot)
 				}()
 			}
 		})
@@ -432,6 +478,14 @@ func (p *QueueProcessor) acquireDispatchHandoff(ctx context.Context) (func(), bo
 
 // ProcessQueueItems processes items in the specified queue.
 func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string) {
+	p.processQueueItems(ctx, queueName, p.loadWorkerHeartbeatSnapshot(ctx))
+}
+
+func (p *QueueProcessor) processQueueItems(
+	ctx context.Context,
+	queueName string,
+	workerSnapshot *workerHeartbeatSnapshot,
+) {
 	if p.isClosed() {
 		return
 	}
@@ -443,8 +497,26 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 	}
 	q := v.(*queue)
 	logger.Debug(ctx, "Processing queue", tag.MaxConcurrency(q.getMaxConcurrency()))
+	dispatcher := p.newQueueDispatcher()
 
-	page, err := p.listQueueScanPage(ctx, queueName, q)
+	revision, err := p.queueStore.Revision(ctx, queueName)
+	if err != nil {
+		logger.Error(ctx, "Failed to read queue revision", tag.Error(err))
+		return
+	}
+	capacity := dispatcher.queueCapacity(ctx, queueName, q.getMaxConcurrency(), q.getInflight())
+	generation := queueScanGeneration{
+		queueRevision: revision,
+		workers:       workerSnapshot.generation(p.workerHeartbeatStore != nil, p.workerStaleAfter),
+		capacity:      capacity.queueCapacityGeneration,
+	}
+	cursor, parked := q.scanPosition(generation)
+	if parked {
+		logger.Debug(ctx, "Queue scan parked until relevant state changes")
+		return
+	}
+
+	page, err := p.listQueueScanPage(ctx, queueName, cursor)
 	if err != nil {
 		logger.Error(ctx, "Failed to get queued items", tag.Error(err))
 		return
@@ -456,24 +528,28 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 	)
 
 	if len(items) == 0 {
-		q.setScanCursor("")
+		q.parkScan(generation)
 		logger.Debug(ctx, "No item found")
 		return
 	}
 
-	defer p.wakeUp()
-	dispatcher := p.newQueueDispatcher()
-
-	maxConcurrency := q.getMaxConcurrency()
-	batch, err := dispatcher.selectDispatchBatch(ctx, queueName, items, maxConcurrency, q.getInflight())
+	batch, err := dispatcher.selectDispatchBatch(ctx, queueName, items, capacity, workerSnapshot)
 	if err != nil {
+		if capacity.err != nil {
+			q.parkScan(generation)
+		}
 		return
 	}
 	if len(batch.items) == 0 {
-		q.setScanCursor(page.NextCursor)
+		if page.HasMore && page.NextCursor != "" {
+			q.advanceScan(generation, page.NextCursor)
+			p.wakeUp()
+		} else {
+			q.parkScan(generation)
+		}
 		return
 	}
-	q.setScanCursor("")
+	q.restartScan(generation)
 	logger.Info(ctx, "Processing batch of items",
 		tag.Count(len(batch.items)),
 		tag.MaxConcurrency(batch.maxConcurrency),
@@ -499,14 +575,14 @@ func (p *QueueProcessor) ProcessQueueItems(ctx context.Context, queueName string
 		}(item)
 	}
 	wg.Wait()
+	p.wakeUp()
 }
 
 func (p *QueueProcessor) listQueueScanPage(
 	ctx context.Context,
 	queueName string,
-	q *queue,
+	cursor string,
 ) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
-	cursor := q.getScanCursor()
 	for attempt := range 2 {
 		head, err := p.queueStore.ListCursor(ctx, queueName, "", queueHeadItemLimit)
 		if err != nil || !head.HasMore || len(head.Items) == 0 {
@@ -525,7 +601,6 @@ func (p *QueueProcessor) listQueueScanPage(
 		)
 		if errors.Is(err, pagination.ErrInvalidCursor) && attempt == 0 {
 			logger.Debug(ctx, "Queue scan cursor invalidated; restarting from head")
-			q.setScanCursor("")
 			cursor = ""
 			continue
 		}
@@ -553,13 +628,46 @@ func (p *QueueProcessor) listQueueScanPage(
 	return pagination.CursorResult[queuedomain.QueuedItemData]{}, pagination.ErrInvalidCursor
 }
 
-func (p *QueueProcessor) resetQueueScanCursors() {
-	p.queues.Range(func(_, value any) bool {
-		if q, ok := value.(*queue); ok {
-			q.setScanCursor("")
+func (p *QueueProcessor) loadWorkerHeartbeatSnapshot(ctx context.Context) *workerHeartbeatSnapshot {
+	snapshot := &workerHeartbeatSnapshot{observedAt: time.Now().UTC()}
+	if p.workerHeartbeatStore != nil {
+		_, _ = snapshot.load(ctx, p.workerHeartbeatStore)
+	}
+	return snapshot
+}
+
+func (s *workerHeartbeatSnapshot) generation(
+	enabled bool,
+	staleThreshold time.Duration,
+) workerEligibilityGeneration {
+	generation := workerEligibilityGeneration{enabled: enabled, available: s.err == nil}
+	if !enabled || s.err != nil {
+		return generation
+	}
+
+	entries := make([]string, 0, len(s.records))
+	for _, record := range s.records {
+		if !dispatch.WorkerHeartbeatFresh(record, s.observedAt, staleThreshold) {
+			continue
 		}
-		return true
-	})
+		keys := make([]string, 0, len(record.Labels))
+		for key := range record.Labels {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		var entry strings.Builder
+		entry.WriteString(strconv.Quote(record.WorkerID))
+		for _, key := range keys {
+			entry.WriteByte(':')
+			entry.WriteString(strconv.Quote(key))
+			entry.WriteByte('=')
+			entry.WriteString(strconv.Quote(record.Labels[key]))
+		}
+		entries = append(entries, entry.String())
+	}
+	sort.Strings(entries)
+	generation.fingerprint = sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return generation
 }
 
 func currentStatusString(status *ir.DAGRunStatus) string {

--- a/internal/service/scheduler/queue_processor.go
+++ b/internal/service/scheduler/queue_processor.go
@@ -29,6 +29,7 @@ import (
 
 const queueAgeWarningThreshold = 2 * time.Minute
 const queueProcessMinInterval = 3 * time.Second
+const queueProcessFallbackInterval = 30 * time.Second
 const queueScanItemLimit = 100
 const queueHeadItemLimit = 1
 const maxConcurrentQueueScans = 8
@@ -127,6 +128,7 @@ type queue struct {
 	isGlobal       bool // true if this queue is defined in config (global queue)
 	scanCursor     string
 	scanGeneration queueScanGeneration
+	scanRetryAt    time.Time
 	generationSet  bool
 	parked         bool
 	inflight       atomic.Int32
@@ -161,13 +163,17 @@ func (q *queue) getInflight() int {
 	return int(q.inflight.Load())
 }
 
-func (q *queue) scanPosition(generation queueScanGeneration) (string, bool) {
+func (q *queue) scanPosition(generation queueScanGeneration, now time.Time) (string, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if !q.generationSet || q.scanGeneration != generation {
 		q.scanCursor = ""
 		q.scanGeneration = generation
+		q.scanRetryAt = time.Time{}
 		q.generationSet = true
+		q.parked = false
+	} else if q.parked && !q.scanRetryAt.IsZero() && !now.Before(q.scanRetryAt) {
+		q.scanRetryAt = time.Time{}
 		q.parked = false
 	}
 	return q.scanCursor, q.parked
@@ -177,6 +183,7 @@ func (q *queue) advanceScan(generation queueScanGeneration, cursor string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.scanGeneration = generation
+	q.scanRetryAt = time.Time{}
 	q.generationSet = true
 	q.scanCursor = cursor
 	q.parked = false
@@ -186,18 +193,20 @@ func (q *queue) parkScan(generation queueScanGeneration) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.scanGeneration = generation
+	q.scanRetryAt = time.Time{}
 	q.generationSet = true
 	q.scanCursor = ""
 	q.parked = true
 }
 
-func (q *queue) restartScan(generation queueScanGeneration) {
+func (q *queue) deferScan(generation queueScanGeneration, retryAt time.Time) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.scanGeneration = generation
+	q.scanRetryAt = retryAt
 	q.generationSet = true
 	q.scanCursor = ""
-	q.parked = false
+	q.parked = true
 }
 
 func (q *queue) incInflight() { q.inflight.Add(1) }
@@ -354,7 +363,7 @@ func (p *QueueProcessor) loop(ctx context.Context) {
 		case <-p.quit:
 			return
 		case <-p.wakeUpCh:
-		case <-time.After(30 * time.Second):
+		case <-time.After(queueProcessFallbackInterval):
 			// wake up the queue processor on interval in case event is missed
 		}
 
@@ -518,7 +527,7 @@ func (p *QueueProcessor) processQueueItems(
 		workers:       workerGeneration,
 		capacity:      capacity.queueCapacityGeneration,
 	}
-	cursor, parked := q.scanPosition(generation)
+	cursor, parked := q.scanPosition(generation, time.Now())
 	if parked {
 		p.wakeUp()
 		logger.Debug(ctx, "Queue scan parked until relevant state changes")
@@ -558,7 +567,6 @@ func (p *QueueProcessor) processQueueItems(
 		}
 		return
 	}
-	q.restartScan(generation)
 	logger.Info(ctx, "Processing batch of items",
 		tag.Count(len(batch.items)),
 		tag.MaxConcurrency(batch.maxConcurrency),
@@ -584,6 +592,7 @@ func (p *QueueProcessor) processQueueItems(
 		}(item)
 	}
 	wg.Wait()
+	q.deferScan(generation, time.Now().Add(queueProcessFallbackInterval))
 	p.wakeUp()
 }
 

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -359,6 +359,35 @@ func TestQueueProcessor_CountsFreshDistributedRunsAgainstQueueConcurrency(t *tes
 	assert.Contains(t, f.logs(), "Max concurrency reached")
 }
 
+func TestQueueProcessor_RechecksDistributedCapacityAfterLeaseRelease(t *testing.T) {
+	f := newQueueFixture(t).withDAG("distributed-recheck-dag", 1).
+		withProcessor(config.Queues{}, WithLeaseStaleThreshold(freshDistributedTestThreshold)).
+		simulateQueue(1, false)
+	dispatcher := &mockDispatcher{}
+	f.processor.dagExecutor = NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "")
+
+	const activeAttemptKey = "active-attempt"
+	require.NoError(t, f.leaseStore.Upsert(f.ctx, dispatch.DAGRunLease{
+		AttemptKey:      activeAttemptKey,
+		QueueName:       f.dag.Name,
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+	f.enqueueRuns(1)
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	require.Zero(t, dispatcher.callCount.Load())
+	select {
+	case <-f.processor.wakeUpCh:
+	default:
+		t.Fatal("parked distributed queue did not schedule a capacity recheck")
+	}
+
+	require.NoError(t, f.leaseStore.Delete(f.ctx, activeAttemptKey))
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	assert.Equal(t, int32(1), dispatcher.callCount.Load())
+}
+
 func TestQueueProcessor_ProcessQueueItems_FailsClosedOnLeaseCountError(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-count-error-dag", 1).
 		withProcessor(config.Queues{}).
@@ -664,12 +693,17 @@ func TestQueueProcessorParksCompletedBlockedScanUntilGenerationChanges(t *testin
 	assert.Equal(t, int32(4), queueStore.scanCalls.Load())
 	select {
 	case <-processor.wakeUpCh:
-		t.Fatal("completed blocked scan scheduled another pass")
 	default:
+		t.Fatal("completed blocked scan did not schedule a state recheck")
 	}
 
 	processor.ProcessQueueItems(t.Context(), "main")
 	assert.Equal(t, int32(4), queueStore.scanCalls.Load(), "unchanged parked queue should not be scanned again")
+	select {
+	case <-processor.wakeUpCh:
+	default:
+		t.Fatal("unchanged parked queue did not schedule another state recheck")
+	}
 
 	procRepository.setAlive(2)
 	processor.ProcessQueueItems(t.Context(), "main")
@@ -690,12 +724,17 @@ func TestQueueProcessorParksQueueStateErrorsUntilGenerationChanges(t *testing.T)
 	assert.Equal(t, int32(1), queueStore.scanCalls.Load())
 	select {
 	case <-processor.wakeUpCh:
-		t.Fatal("queue state error scheduled another pass")
 	default:
+		t.Fatal("queue state error did not schedule a state recheck")
 	}
 
 	processor.ProcessQueueItems(t.Context(), "main")
 	assert.Equal(t, int32(1), queueStore.scanCalls.Load(), "unchanged queue state error should stay parked")
+	select {
+	case <-processor.wakeUpCh:
+	default:
+		t.Fatal("unchanged queue state error did not schedule another state recheck")
+	}
 
 	procRepository.setState(1, nil)
 	processor.ProcessQueueItems(t.Context(), "main")

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -634,10 +636,118 @@ func TestQueueProcessorRestartsBoundedScanAfterCursorInvalidation(t *testing.T) 
 
 	queueStore := &invalidatingCursorQueueStore{}
 	processor := NewQueueProcessor(queueStore, nil, nil, nil, config.Queues{})
-	page, err := processor.listQueueScanPage(t.Context(), "main", &queue{})
+	page, err := processor.listQueueScanPage(t.Context(), "main", "")
 	require.NoError(t, err)
 	require.Len(t, page.Items, 1)
 	assert.Equal(t, "new-head", page.Items[0].ID())
+}
+
+func TestQueueProcessorParksCompletedBlockedScanUntilGenerationChanges(t *testing.T) {
+	t.Parallel()
+
+	queueStore := &pagedQueueScanStore{itemCount: queueScanItemLimit + 1}
+	queueStore.revision.Store(1)
+	procRepository := &queueScanProcRepository{alive: 1}
+	processor := NewQueueProcessor(queueStore, nil, procRepository, nil, config.Queues{
+		Config: []config.QueueConfig{{Name: "main", MaxActiveRuns: 1}},
+	})
+
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(2), queueStore.scanCalls.Load())
+	select {
+	case <-processor.wakeUpCh:
+	default:
+		t.Fatal("incomplete scan did not schedule its next page")
+	}
+
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(4), queueStore.scanCalls.Load())
+	select {
+	case <-processor.wakeUpCh:
+		t.Fatal("completed blocked scan scheduled another pass")
+	default:
+	}
+
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(4), queueStore.scanCalls.Load(), "unchanged parked queue should not be scanned again")
+
+	procRepository.setAlive(2)
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(6), queueStore.scanCalls.Load(), "capacity changes should restart the scan")
+}
+
+func TestQueueProcessorParksQueueStateErrorsUntilGenerationChanges(t *testing.T) {
+	t.Parallel()
+
+	queueStore := &pagedQueueScanStore{itemCount: 1}
+	queueStore.revision.Store(1)
+	procRepository := &queueScanProcRepository{err: errors.New("process store unavailable")}
+	processor := NewQueueProcessor(queueStore, nil, procRepository, nil, config.Queues{
+		Config: []config.QueueConfig{{Name: "main", MaxActiveRuns: 1}},
+	})
+
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(1), queueStore.scanCalls.Load())
+	select {
+	case <-processor.wakeUpCh:
+		t.Fatal("queue state error scheduled another pass")
+	default:
+	}
+
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(1), queueStore.scanCalls.Load(), "unchanged queue state error should stay parked")
+
+	procRepository.setState(1, nil)
+	processor.ProcessQueueItems(t.Context(), "main")
+	assert.Equal(t, int32(2), queueStore.scanCalls.Load(), "queue state recovery should restart the scan")
+}
+
+func TestWorkerEligibilityGenerationTracksRoutingChanges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	record := dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		Labels:          map[string]string{"region": "east", "type": "gpu"},
+		Stats:           &dispatch.WorkerStats{BusyPollers: 1},
+		LastHeartbeatAt: now.UnixMilli(),
+	}
+	base := (&workerHeartbeatSnapshot{records: []dispatch.WorkerHeartbeatRecord{record}, observedAt: now}).generation(true, time.Minute)
+
+	updatedHeartbeat := record
+	updatedHeartbeat.LastHeartbeatAt = now.Add(time.Second).UnixMilli()
+	updatedHeartbeat.Stats = &dispatch.WorkerStats{BusyPollers: 2}
+	stable := (&workerHeartbeatSnapshot{records: []dispatch.WorkerHeartbeatRecord{updatedHeartbeat}, observedAt: now}).generation(true, time.Minute)
+	assert.Equal(t, base, stable, "heartbeat timestamps and worker stats do not affect routing")
+
+	changedLabels := record
+	changedLabels.Labels = map[string]string{"region": "west", "type": "gpu"}
+	labelsGeneration := (&workerHeartbeatSnapshot{records: []dispatch.WorkerHeartbeatRecord{changedLabels}, observedAt: now}).generation(true, time.Minute)
+	assert.NotEqual(t, base, labelsGeneration)
+
+	joinedGeneration := (&workerHeartbeatSnapshot{
+		records:    []dispatch.WorkerHeartbeatRecord{record, {WorkerID: "worker-2", LastHeartbeatAt: now.UnixMilli()}},
+		observedAt: now,
+	}).generation(true, time.Minute)
+	assert.NotEqual(t, base, joinedGeneration)
+
+	staleGeneration := (&workerHeartbeatSnapshot{records: []dispatch.WorkerHeartbeatRecord{record}, observedAt: now.Add(2 * time.Minute)}).generation(true, time.Minute)
+	assert.NotEqual(t, base, staleGeneration)
+}
+
+func TestQueueScanGenerationRestartsOnlyChangedQueue(t *testing.T) {
+	t.Parallel()
+
+	first := &queue{}
+	second := &queue{}
+	base := queueScanGeneration{queueRevision: 1}
+	first.parkScan(base)
+	second.parkScan(base)
+
+	_, firstParked := first.scanPosition(queueScanGeneration{queueRevision: 2})
+	_, secondParked := second.scanPosition(base)
+	assert.False(t, firstParked)
+	assert.True(t, secondParked)
 }
 
 type invalidatingCursorQueueStore struct {
@@ -675,8 +785,82 @@ type blockingQueueScanStore struct {
 	release    chan struct{}
 }
 
+type pagedQueueScanStore struct {
+	queuedomain.QueueStore
+	revision  atomic.Int64
+	scanCalls atomic.Int32
+	itemCount int
+}
+
+func (s *pagedQueueScanStore) Revision(context.Context, string) (int64, error) {
+	return s.revision.Load(), nil
+}
+
+func (s *pagedQueueScanStore) ListCursor(
+	_ context.Context,
+	_ string,
+	cursor string,
+	limit int,
+) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
+	s.scanCalls.Add(1)
+	start := 0
+	if cursor != "" {
+		var err error
+		start, err = strconv.Atoi(cursor)
+		if err != nil || start < 0 || start > s.itemCount {
+			return pagination.CursorResult[queuedomain.QueuedItemData]{}, pagination.ErrInvalidCursor
+		}
+	}
+	end := min(start+limit, s.itemCount)
+	items := make([]queuedomain.QueuedItemData, 0, end-start)
+	for i := start; i < end; i++ {
+		items = append(items, testQueuedItem{id: fmt.Sprintf("item-%03d", i)})
+	}
+	hasMore := end < s.itemCount
+	nextCursor := ""
+	if hasMore {
+		nextCursor = strconv.Itoa(end)
+	}
+	return pagination.CursorResult[queuedomain.QueuedItemData]{
+		Items:      items,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+type queueScanProcRepository struct {
+	mu    sync.Mutex
+	alive int
+	err   error
+}
+
+func (s *queueScanProcRepository) CountAlive(context.Context, string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.alive, s.err
+}
+
+func (s *queueScanProcRepository) IsRunAlive(context.Context, string, ir.DAGRunRef) (bool, error) {
+	return false, nil
+}
+
+func (s *queueScanProcRepository) setAlive(alive int) {
+	s.setState(alive, nil)
+}
+
+func (s *queueScanProcRepository) setState(alive int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.alive = alive
+	s.err = err
+}
+
 func (s *blockingQueueScanStore) QueueList(context.Context) ([]string, error) {
 	return append([]string(nil), s.queueNames...), nil
+}
+
+func (s *blockingQueueScanStore) Revision(context.Context, string) (int64, error) {
+	return 1, nil
 }
 
 func (s *blockingQueueScanStore) ListCursor(

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -388,6 +388,25 @@ func TestQueueProcessor_RechecksDistributedCapacityAfterLeaseRelease(t *testing.
 	assert.Equal(t, int32(1), dispatcher.callCount.Load())
 }
 
+func TestQueueProcessor_DefersUnchangedDistributedDispatchFailure(t *testing.T) {
+	f := newQueueFixture(t).withDAG("distributed-dispatch-error-dag", 1).
+		withProcessor(config.Queues{}).
+		simulateQueue(1, false)
+	dispatcher := &mockDispatcher{errFunc: func(int32) error {
+		return errors.New("dispatch unavailable")
+	}}
+	f.processor.dagExecutor = NewDAGExecutor(dispatcher, nil, config.ExecutionModeDistributed, "")
+	f.enqueueRuns(1)
+
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+	f.processor.ProcessQueueItems(f.ctx, f.dag.Name)
+
+	assert.Equal(t, int32(1), dispatcher.callCount.Load())
+	items, err := f.queueStore.List(f.ctx, f.dag.Name)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
 func TestQueueProcessor_ProcessQueueItems_FailsClosedOnLeaseCountError(t *testing.T) {
 	f := newQueueFixture(t).withDAG("distributed-count-error-dag", 1).
 		withProcessor(config.Queues{}).
@@ -777,16 +796,32 @@ func TestWorkerEligibilityGenerationTracksRoutingChanges(t *testing.T) {
 func TestQueueScanGenerationRestartsOnlyChangedQueue(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
 	first := &queue{}
 	second := &queue{}
 	base := queueScanGeneration{queueRevision: 1}
-	first.parkScan(base)
+	first.deferScan(base, now.Add(queueProcessFallbackInterval))
 	second.parkScan(base)
 
-	_, firstParked := first.scanPosition(queueScanGeneration{queueRevision: 2})
-	_, secondParked := second.scanPosition(base)
+	_, firstParked := first.scanPosition(queueScanGeneration{queueRevision: 2}, now)
+	_, secondParked := second.scanPosition(base, now)
 	assert.False(t, firstParked)
 	assert.True(t, secondParked)
+}
+
+func TestQueueScanDefersUnchangedGenerationUntilRetryDeadline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	generation := queueScanGeneration{queueRevision: 1}
+	q := &queue{}
+	q.deferScan(generation, now.Add(queueProcessFallbackInterval))
+
+	_, parked := q.scanPosition(generation, now.Add(queueProcessFallbackInterval-time.Second))
+	assert.True(t, parked)
+
+	_, parked = q.scanPosition(generation, now.Add(queueProcessFallbackInterval))
+	assert.False(t, parked)
 }
 
 type invalidatingCursorQueueStore struct {
@@ -960,15 +995,19 @@ func TestQueueProcessor_SuspendedSchedulerManagedQueuedRunsAreAbortedAndDequeued
 
 func TestQueueProcessor_LeavesSchedulerManagedRunQueuedWhenSuspensionReadFails(t *testing.T) {
 	dagName := "suspension-read-error-dag"
+	var suspensionReads atomic.Int32
 	f := newQueueFixture(t).
 		withDAG(dagName, 1).
 		withProcessor(config.Queues{}, WithIsSuspended(func(context.Context, string) (bool, error) {
+			suspensionReads.Add(1)
 			return false, errors.New("read suspend flag")
 		})).
 		simulateQueue(1, false)
 
 	f.enqueueRunWithTrigger("run-1", ir.TriggerTypeScheduler)
 	f.processor.ProcessQueueItems(f.ctx, dagName)
+	f.processor.ProcessQueueItems(f.ctx, dagName)
+	assert.Equal(t, int32(1), suspensionReads.Load())
 
 	items, err := f.queueStore.List(f.ctx, dagName)
 	require.NoError(t, err)

--- a/internal/service/scheduler/queue_processor_test.go
+++ b/internal/service/scheduler/queue_processor_test.go
@@ -824,9 +824,99 @@ func TestQueueScanDefersUnchangedGenerationUntilRetryDeadline(t *testing.T) {
 	assert.False(t, parked)
 }
 
+func TestQueueScanRetainsRetryAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	generation := queueScanGeneration{queueRevision: 1}
+	q := &queue{}
+	q.advanceScan(generation, "next-page", true)
+	q.finishScan(generation, false, now.Add(queueProcessFallbackInterval))
+
+	_, parked := q.scanPosition(generation, now.Add(queueProcessFallbackInterval-time.Second))
+	assert.True(t, parked)
+
+	_, parked = q.scanPosition(generation, now.Add(queueProcessFallbackInterval))
+	assert.False(t, parked)
+}
+
+func TestQueueProcessorRetriesUnreadableItemAfterFallback(t *testing.T) {
+	dagName := "unreadable-item-dag"
+	f := newQueueFixture(t).
+		withDAG(dagName, 1).
+		withProcessor(config.Queues{}).
+		simulateQueue(1, false)
+	f.enqueueRunWithTrigger("run-1", ir.TriggerTypeManual)
+	f.processor.dagExecutor = NewDAGExecutor(
+		nil,
+		launcher.NewSubCmdBuilder(&config.Config{
+			Paths: config.PathsConfig{Executable: filepath.Join(t.TempDir(), "missing-dagu")},
+		}),
+		config.ExecutionModeLocal,
+		"",
+	)
+
+	queueStore := &unreadableQueueScanStore{QueueStore: f.queueStore}
+	queueStore.unreadable.Store(true)
+	f.processor.queueStore = queueStore
+
+	f.processor.ProcessQueueItems(f.ctx, dagName)
+	assert.Equal(t, int32(1), queueStore.scanCalls.Load())
+
+	f.processor.ProcessQueueItems(f.ctx, dagName)
+	assert.Equal(t, int32(1), queueStore.scanCalls.Load(), "unreadable item should not be retried before the fallback deadline")
+
+	queueStore.unreadable.Store(false)
+	q := f.getQueue(dagName)
+	q.mu.Lock()
+	generation := q.scanGeneration
+	retryAt := q.scanRetryAt
+	q.mu.Unlock()
+	require.False(t, retryAt.IsZero())
+	_, parked := q.scanPosition(generation, retryAt)
+	require.False(t, parked)
+
+	f.processor.ProcessQueueItems(f.ctx, dagName)
+	assert.Equal(t, int32(2), queueStore.scanCalls.Load())
+	items, err := f.queueStore.List(f.ctx, dagName)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
 type invalidatingCursorQueueStore struct {
 	queuedomain.QueueStore
 	calls int
+}
+
+type unreadableQueueScanStore struct {
+	queuedomain.QueueStore
+	unreadable atomic.Bool
+	scanCalls  atomic.Int32
+}
+
+func (s *unreadableQueueScanStore) ListCursor(
+	ctx context.Context,
+	queueName string,
+	cursor string,
+	limit int,
+) (pagination.CursorResult[queuedomain.QueuedItemData], error) {
+	page, err := s.QueueStore.ListCursor(ctx, queueName, cursor, limit)
+	s.scanCalls.Add(1)
+	if err != nil || !s.unreadable.Load() {
+		return page, err
+	}
+	for i, item := range page.Items {
+		page.Items[i] = unreadableQueuedItem{QueuedItemData: item}
+	}
+	return page, nil
+}
+
+type unreadableQueuedItem struct {
+	queuedomain.QueuedItemData
+}
+
+func (unreadableQueuedItem) Data() (*ir.DAGRunRef, error) {
+	return nil, errors.New("queue item temporarily unreadable")
 }
 
 func (s *invalidatingCursorQueueStore) ListCursor(

--- a/internal/service/worker/remote_reporter.go
+++ b/internal/service/worker/remote_reporter.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	remoteSchedulerLogFinalizeTimeout = 3 * time.Minute
+	remoteSchedulerLogFinalizeTimeout = 10 * time.Second
 	remoteTerminalStatusReportTimeout = 3 * time.Minute
 )
 

--- a/internal/service/worker/remote_reporter.go
+++ b/internal/service/worker/remote_reporter.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// Remote scheduler logs are best effort. Terminal status reporting proceeds
+	// when this budget expires, and the remote log may be incomplete.
 	remoteSchedulerLogFinalizeTimeout = 10 * time.Second
 	remoteTerminalStatusReportTimeout = 3 * time.Minute
 )

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -113,6 +113,10 @@ func (m *mockQueueStore) ListCursor(ctx context.Context, name, cursor string, li
 	return args.Get(0).(pagination.CursorResult[queue.QueuedItemData]), args.Error(1)
 }
 
+func (m *mockQueueStore) Revision(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockQueueStore) All(ctx context.Context) ([]queue.QueuedItemData, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {

--- a/internal/testutil/queue_store.go
+++ b/internal/testutil/queue_store.go
@@ -65,6 +65,11 @@ func (m *MockQueueStore) ListCursor(ctx context.Context, name, cursor string, li
 	return args.Get(0).(pagination.CursorResult[queue.QueuedItemData]), args.Error(1)
 }
 
+func (m *MockQueueStore) Revision(ctx context.Context, name string) (int64, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockQueueStore) All(ctx context.Context) ([]queue.QueuedItemData, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## Summary
- expose the queue index revision through the queue store contract
- park completed bounded page scans until queue membership, worker routing, or capacity changes
- recheck parked generations on the existing scheduler cadence without rereading queue pages, statuses, or DAG snapshots
- defer unchanged dispatch failures until a relevant generation change or the scheduler fallback interval
- preserve deep cursors across unrelated notifications and compute worker eligibility once per scheduler pass
- isolate retry integration output and queue-rotation tests from unrelated timing
- preserve context cancellation errors from proc locks
- bound best-effort scheduler-log finalization before terminal status reporting

## Testing
- make fmt
- make test
- go test -race ./internal/service/worker ./internal/service/worker/coordreport ./internal/service/coordinator -count=1
- go test -race ./internal/persis/file/proc ./internal/service/scheduler -count=2
- go test -race ./internal/intg/distr -run 'TestExecution_QueuedDispatch_RecoversWhenMatchingWorkerRegistersLater|TestSubDAG_FileWorkerSelectorEnv' -count=3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved queue scheduling responsiveness by reusing queue and worker state during scans.
  - Reduced unnecessary rescanning while ensuring relevant changes trigger timely updates.
  - Improved handling of worker availability, queue capacity, and deferred dispatch conditions.
  - Added queue revision tracking to detect membership changes more reliably.
  - Improved recovery from temporary queue-state and scanning errors.
  - Strengthened retry behavior so only affected downstream steps are re-executed.
  - Improved cancellation handling and reduced delays when finalizing scheduler logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->