### PR TITLE
fix: preserve rescheduled file dependencies

### DIFF
--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -207,9 +207,12 @@ func runRetry(ctx *Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to restore DAG from status: %w", err)
 	}
-	workDirRef := retryWorkDirRef(status, ref, rootRun)
-	if err := restoreRetryExecutionContext(ctx.Context, ctx.Persistence.DAGRunRepository, dag, status, workDirRef); err != nil {
-		return err
+	// Fresh queue dispatches stage dependencies from the source workspace.
+	if !queueDispatchRetry || !shouldUseQueuedDispatchAttempt(status) {
+		workDirRef := retryWorkDirRef(status, ref, rootRun)
+		if err := restoreRetryExecutionContext(ctx.Context, ctx.Persistence.DAGRunRepository, dag, status, workDirRef); err != nil {
+			return err
+		}
 	}
 	if err := applyRetryDefaultWorkingDir(ctx, dag, status); err != nil {
 		return err

--- a/internal/cmd/retry_test.go
+++ b/internal/cmd/retry_test.go
@@ -269,16 +269,22 @@ steps:
 		dagFile := th.DAG(t, `name: queue-dispatch-existing-attempt
 steps:
   - name: "1"
-    run: echo queued dispatch
+    run: cat templates/input.txt
+    dependencies: templates/**
 `)
+		templateDir := filepath.Join(dagFile.WorkingDir, "templates")
+		require.NoError(t, os.MkdirAll(templateDir, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(templateDir, "input.txt"), []byte("queued dispatch"), 0o600))
 
 		runID := "queue-dispatch-run"
-		attempt, err := th.DAGRunRepository.CreateAttempt(th.Context, dagFile.DAG, time.Now(), runID, persis.DAGRunCreateAttemptOptions{})
+		queuedDAG := dagFile.Clone()
+		queuedDAG.Location = ""
+		attempt, err := th.DAGRunRepository.CreateAttempt(th.Context, queuedDAG, time.Now(), runID, persis.DAGRunCreateAttemptOptions{})
 		require.NoError(t, err)
 		logPath := filepath.Join(th.Config.Paths.LogDir, "queue-dispatch-test.log")
 		require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o750))
 
-		status := ir.NewStatusBuilder(dagFile.DAG).Create(
+		status := ir.NewStatusBuilder(queuedDAG).Create(
 			runID,
 			ir.Queued,
 			0,

--- a/internal/cmd/retry_test.go
+++ b/internal/cmd/retry_test.go
@@ -266,12 +266,12 @@ steps:
 		th := test.SetupCommand(t)
 		t.Setenv(runenv.EnvKeyQueueDispatchRetry, "1")
 
-		dagFile := th.DAG(t, `name: queue-dispatch-existing-attempt
+		dagFile := th.DAG(t, fmt.Sprintf(`name: queue-dispatch-existing-attempt
 steps:
   - name: "1"
-    run: cat templates/input.txt
+    run: %s
     dependencies: templates/**
-`)
+`, test.ForOS("cat templates/input.txt", "type templates/input.txt")))
 		templateDir := filepath.Join(dagFile.WorkingDir, "templates")
 		require.NoError(t, os.MkdirAll(templateDir, 0o750))
 		require.NoError(t, os.WriteFile(filepath.Join(templateDir, "input.txt"), []byte("queued dispatch"), 0o600))


### PR DESCRIPTION
## Summary

Fresh queued DAG runs restored a new empty run workspace before dependency capture. Keep the source working directory until dependencies are staged.

## Changes

- Skip retry workspace restoration for fresh queue dispatches
- Preserve workspace restoration for actual retries
- Cover cleared-location DAG snapshots with file dependencies

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Regression test updated
- [x] Documentation unchanged; this fixes existing behavior
- [x] Full Go test suite passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for queued executions by preserving the existing execution context.
  * Ensured queued retries can correctly access files from declared template dependencies.
  * Maintained working-directory restoration for other retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->