### PR TITLE
fix: restore notification event delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,9 @@ JSON or text format logging (`DAGU_LOG_FORMAT`). Logs are stored per-run with se
 
 - Email notifications on DAG success, failure, or wait status via SMTP
 - Per-DAG webhook endpoints with token authentication
+- Delivery requires the event store and writable notification state storage
+
+Scoped notification routing is broken in v2.11.0-v2.11.2. Use v2.11.3 or later.
 
 ## Artifacts
 

--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ JSON or text format logging (`DAGU_LOG_FORMAT`). Logs are stored per-run with se
 
 - Email notifications on DAG success, failure, or wait status via SMTP
 - Per-DAG webhook endpoints with token authentication
-- Delivery requires the event store and writable notification state storage
+- Delivery requires the event store, notification store, and writable notification state store
 
 Scoped notification routing is broken in v2.11.0-v2.11.2. Use v2.11.3 or later.
 

--- a/internal/eventstore/dagrun_events.go
+++ b/internal/eventstore/dagrun_events.go
@@ -20,19 +20,25 @@ const (
 )
 
 type DAGRunCursor struct {
-	LastInboxFile    string           `json:"last_inbox_file,omitempty"`
-	CommittedOffsets map[string]int64 `json:"committed_offsets,omitempty"`
+	LastInboxFile    string            `json:"last_inbox_file,omitempty"`
+	CommittedOffsets map[string]int64  `json:"committed_offsets,omitempty"`
+	InboxEventIDs    map[string]string `json:"inbox_event_ids,omitempty"`
 }
 
 func (c DAGRunCursor) Normalize() DAGRunCursor {
 	if c.CommittedOffsets == nil {
 		c.CommittedOffsets = make(map[string]int64)
 	}
+	if c.InboxEventIDs == nil {
+		c.InboxEventIDs = make(map[string]string)
+	}
 	return c
 }
 
 func (c DAGRunCursor) Equal(other DAGRunCursor) bool {
-	return c.LastInboxFile == other.LastInboxFile && maps.Equal(c.CommittedOffsets, other.CommittedOffsets)
+	return c.LastInboxFile == other.LastInboxFile &&
+		maps.Equal(c.CommittedOffsets, other.CommittedOffsets) &&
+		maps.Equal(c.InboxEventIDs, other.InboxEventIDs)
 }
 
 type DAGRunReader interface {

--- a/internal/eventstore/dagrun_events.go
+++ b/internal/eventstore/dagrun_events.go
@@ -41,10 +41,15 @@ type DAGRunReader interface {
 }
 
 type DAGRunNodeSnapshot struct {
-	StepName      string                `json:"step_name,omitempty"`
-	Status        ir.NodeStatus         `json:"status,omitempty"`
-	Error         string                `json:"error,omitempty"`
-	StatusDetails []ir.NodeStatusDetail `json:"status_details,omitempty"`
+	StepID            string                `json:"step_id,omitempty"`
+	StepName          string                `json:"step_name,omitempty"`
+	StartedAt         string                `json:"started_at,omitempty"`
+	Status            ir.NodeStatus         `json:"status,omitempty"`
+	Error             string                `json:"error,omitempty"`
+	StatusDetails     []ir.NodeStatusDetail `json:"status_details,omitempty"`
+	RetryCount        int                   `json:"retry_count,omitempty"`
+	DoneCount         int                   `json:"done_count,omitempty"`
+	ApprovalIteration int                   `json:"approval_iteration,omitempty"`
 }
 
 func newDAGRunNodeSnapshot(node *ir.Node) *DAGRunNodeSnapshot {
@@ -52,10 +57,15 @@ func newDAGRunNodeSnapshot(node *ir.Node) *DAGRunNodeSnapshot {
 		return nil
 	}
 	return &DAGRunNodeSnapshot{
-		StepName:      node.Step.Name,
-		Status:        node.Status,
-		Error:         node.Error,
-		StatusDetails: append([]ir.NodeStatusDetail(nil), node.StatusDetails...),
+		StepID:            node.Step.ID,
+		StepName:          node.Step.Name,
+		StartedAt:         node.StartedAt,
+		Status:            node.Status,
+		Error:             node.Error,
+		StatusDetails:     append([]ir.NodeStatusDetail(nil), node.StatusDetails...),
+		RetryCount:        node.RetryCount,
+		DoneCount:         node.DoneCount,
+		ApprovalIteration: node.ApprovalIteration,
 	}
 }
 
@@ -64,10 +74,14 @@ func (s *DAGRunNodeSnapshot) Node() *ir.Node {
 		return nil
 	}
 	return &ir.Node{
-		Step:          ir.Step{Name: s.StepName},
-		Status:        s.Status,
-		Error:         s.Error,
-		StatusDetails: append([]ir.NodeStatusDetail(nil), s.StatusDetails...),
+		Step:              ir.Step{ID: s.StepID, Name: s.StepName},
+		StartedAt:         s.StartedAt,
+		Status:            s.Status,
+		Error:             s.Error,
+		StatusDetails:     append([]ir.NodeStatusDetail(nil), s.StatusDetails...),
+		RetryCount:        s.RetryCount,
+		DoneCount:         s.DoneCount,
+		ApprovalIteration: s.ApprovalIteration,
 	}
 }
 

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
@@ -216,6 +218,39 @@ func DAGRunEventID(eventType EventType, dagName, dagRunID, attemptID string) str
 	return "dag_" + stableID(string(eventType), dagName, dagRunID, attemptID)
 }
 
+// DAGRunWaitingEventID identifies a waiting occurrence represented by a status snapshot.
+func DAGRunWaitingEventID(status *ir.DAGRunStatus) string {
+	if status == nil {
+		return ""
+	}
+
+	parts := []string{string(TypeDAGRunWaiting), status.Name, status.DAGRunID, status.AttemptID}
+	for _, node := range status.NodesInRunOrder() {
+		if node == nil || node.Status != ir.NodeWaiting {
+			continue
+		}
+
+		details := make([]string, 0, len(node.StatusDetails))
+		for _, detail := range node.StatusDetails {
+			if detail.Status == ir.NodeWaiting {
+				details = append(details, detail.Label)
+			}
+		}
+		slices.Sort(details)
+		parts = append(parts, stableID(
+			node.Step.ID,
+			node.Step.Name,
+			node.StartedAt,
+			strconv.Itoa(node.RetryCount),
+			strconv.Itoa(node.DoneCount),
+			strconv.Itoa(node.ApprovalIteration),
+			stableID(details...),
+		))
+	}
+
+	return "dag_" + stableID(parts...)
+}
+
 func DAGRunUpdateEventID(dagName, dagRunID, attemptID string, recordedAt time.Time) string {
 	// Same-status updates are invalidation edges. The file collector deduplicates
 	// by event ID globally, so update IDs must remain unique across writes.
@@ -239,6 +274,9 @@ func NewDAGRunEvent(source Source, eventType EventType, status *ir.DAGRunStatus,
 	source = normalizeSource(source)
 	recordedAt := time.Now().UTC()
 	eventID := DAGRunEventID(eventType, status.Name, status.DAGRunID, status.AttemptID)
+	if eventType == TypeDAGRunWaiting {
+		eventID = DAGRunWaitingEventID(status)
+	}
 	if eventType == TypeDAGRunUpdated {
 		eventID = DAGRunUpdateEventID(status.Name, status.DAGRunID, status.AttemptID, recordedAt)
 	}

--- a/internal/eventstore/eventstore_test.go
+++ b/internal/eventstore/eventstore_test.go
@@ -238,6 +238,40 @@ func TestDAGRunUpdateEventIDIncludesRecordedAt(t *testing.T) {
 	assert.NotEqual(t, first, second)
 }
 
+func TestNewDAGRunEventIdentifiesWaitingOccurrences(t *testing.T) {
+	t.Parallel()
+
+	status := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:   ir.Step{Name: "approve-build"},
+			Status: ir.NodeWaiting,
+		}},
+	}
+	first := NewDAGRunEvent(Source{Service: SourceServiceServer}, TypeDAGRunWaiting, status, nil)
+	repeated := NewDAGRunEvent(Source{Service: SourceServiceServer}, TypeDAGRunWaiting, status, nil)
+
+	status.Nodes[0].ApprovalIteration = 1
+	pushedBack := NewDAGRunEvent(Source{Service: SourceServiceServer}, TypeDAGRunWaiting, status, nil)
+
+	status.Nodes = []*ir.Node{{
+		Step:   ir.Step{Name: "approve-deploy"},
+		Status: ir.NodeWaiting,
+	}}
+	second := NewDAGRunEvent(Source{Service: SourceServiceServer}, TypeDAGRunWaiting, status, nil)
+
+	require.NotNil(t, first)
+	require.NotNil(t, repeated)
+	require.NotNil(t, pushedBack)
+	require.NotNil(t, second)
+	assert.Equal(t, first.ID, repeated.ID)
+	assert.NotEqual(t, first.ID, pushedBack.ID)
+	assert.NotEqual(t, first.ID, second.ID)
+}
+
 func TestNewDAGRunEventDeepClonesData(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/eventstore/dagrun_events.go
+++ b/internal/persis/file/eventstore/dagrun_events.go
@@ -25,6 +25,20 @@ var _ eventstore.DAGRunReader = (*Store)(nil)
 func (s *Store) DAGRunHeadCursor(_ context.Context) (eventstore.DAGRunCursor, error) {
 	cursor := eventstore.DAGRunCursor{
 		CommittedOffsets: make(map[string]int64),
+		InboxEventIDs:    make(map[string]string),
+	}
+
+	inboxFiles, err := s.listInboxFilenames()
+	if err != nil {
+		return cursor, err
+	}
+	for _, name := range inboxFiles {
+		cursor.LastInboxFile = name
+		event, err := s.readInboxDAGRunEvent(name)
+		if err != nil || event == nil {
+			continue
+		}
+		cursor.InboxEventIDs[name] = event.ID
 	}
 
 	files, err := s.listCommittedLogNames()
@@ -41,12 +55,6 @@ func (s *Store) DAGRunHeadCursor(_ context.Context) (eventstore.DAGRunCursor, er
 		}
 		cursor.CommittedOffsets[name] = info.Size()
 	}
-
-	lastInbox, err := s.latestInboxFilename()
-	if err != nil {
-		return cursor, err
-	}
-	cursor.LastInboxFile = lastInbox
 	return cursor.Normalize(), nil
 }
 
@@ -55,9 +63,25 @@ func (s *Store) ReadDAGRunEvents(_ context.Context, cursor eventstore.DAGRunCurs
 	nextCursor := eventstore.DAGRunCursor{
 		LastInboxFile:    cursor.LastInboxFile,
 		CommittedOffsets: make(map[string]int64),
+		InboxEventIDs:    make(map[string]string),
 	}
 
 	eventsByID := make(map[string]*eventstore.Event)
+	inboxFiles, err := s.listInboxFilenames()
+	if err != nil {
+		return nil, nextCursor, err
+	}
+	inboxNames := make(map[string]struct{}, len(inboxFiles))
+	consumedIDs := make(map[string]struct{}, len(cursor.InboxEventIDs))
+	for _, name := range inboxFiles {
+		inboxNames[name] = struct{}{}
+	}
+	for name, id := range cursor.InboxEventIDs {
+		consumedIDs[id] = struct{}{}
+		if _, ok := inboxNames[name]; ok {
+			nextCursor.InboxEventIDs[name] = id
+		}
+	}
 
 	files, err := s.listCommittedLogNames()
 	if err != nil {
@@ -71,14 +95,13 @@ func (s *Store) ReadDAGRunEvents(_ context.Context, cursor eventstore.DAGRunCurs
 		}
 		nextCursor.CommittedOffsets[name] = size
 		for _, event := range events {
+			if _, ok := consumedIDs[event.ID]; ok {
+				continue
+			}
 			selectNewestDAGRunEvent(eventsByID, event)
 		}
 	}
 
-	inboxFiles, err := s.listInboxFilenames()
-	if err != nil {
-		return nil, nextCursor, err
-	}
 	for _, name := range inboxFiles {
 		if cursor.LastInboxFile != "" && name <= cursor.LastInboxFile {
 			continue
@@ -96,6 +119,9 @@ func (s *Store) ReadDAGRunEvents(_ context.Context, cursor eventstore.DAGRunCurs
 			continue
 		}
 		selectNewestDAGRunEvent(eventsByID, event)
+		if event != nil {
+			nextCursor.InboxEventIDs[name] = event.ID
+		}
 		nextCursor.LastInboxFile = name
 	}
 
@@ -156,14 +182,6 @@ func (s *Store) listInboxFilenames() ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
-}
-
-func (s *Store) latestInboxFilename() (string, error) {
-	names, err := s.listInboxFilenames()
-	if err != nil || len(names) == 0 {
-		return "", err
-	}
-	return names[len(names)-1], nil
 }
 
 func (s *Store) readCommittedEventsFromOffset(name string, offset int64) ([]*eventstore.Event, int64, error) {

--- a/internal/persis/file/eventstore/dagrun_events_test.go
+++ b/internal/persis/file/eventstore/dagrun_events_test.go
@@ -53,6 +53,33 @@ func TestStoreReadDAGRunEventsTracksCommittedOffsetsAndInbox(t *testing.T) {
 	assert.GreaterOrEqual(t, len(nextCursor.CommittedOffsets), len(cursor.CommittedOffsets))
 }
 
+func TestStoreReadDAGRunEventsTracksCollectedInboxEvents(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store, err := New(baseDir)
+	require.NoError(t, err)
+	collector, err := NewCollector(baseDir, 10)
+	require.NoError(t, err)
+
+	oldEvent := testEvent("evt-old", time.Date(2026, 3, 29, 9, 0, 0, 0, time.UTC))
+	require.NoError(t, store.Emit(context.Background(), oldEvent))
+	cursor, err := store.DAGRunHeadCursor(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, collector.DrainOnce(context.Background()))
+
+	newEvent := testEvent("evt-new", time.Date(2026, 3, 29, 9, 1, 0, 0, time.UTC))
+	require.NoError(t, store.Emit(context.Background(), newEvent))
+	events, nextCursor, err := store.ReadDAGRunEvents(context.Background(), cursor)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-new"}, dagRunEventIDs(events))
+
+	require.NoError(t, collector.DrainOnce(context.Background()))
+	events, _, err = store.ReadDAGRunEvents(context.Background(), nextCursor)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
 func TestStoreReadDAGRunEventsQuarantinesMalformedInboxFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/eventstore/dagrun_events_test.go
+++ b/internal/persis/file/eventstore/dagrun_events_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
+	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +82,63 @@ func TestStoreReadDAGRunEventsQuarantinesMalformedInboxFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, events)
 	assert.NotEmpty(t, nextCursor.LastInboxFile)
+}
+
+func TestStorePreservesWaitingEventIdentity(t *testing.T) {
+	t.Parallel()
+
+	store, err := New(t.TempDir())
+	require.NoError(t, err)
+	cursor, err := store.DAGRunHeadCursor(context.Background())
+	require.NoError(t, err)
+
+	mutations := []func(*ir.Node){
+		func(node *ir.Node) { node.Step.ID = "step-b" },
+		func(node *ir.Node) { node.StartedAt = "2026-08-26T01:00:01Z" },
+		func(node *ir.Node) { node.RetryCount = 1 },
+		func(node *ir.Node) { node.DoneCount = 1 },
+		func(node *ir.Node) { node.ApprovalIteration = 1 },
+	}
+	statuses := make([]*ir.DAGRunStatus, 0, len(mutations)+1)
+	statuses = append(statuses, waitingStatus())
+	for _, mutate := range mutations {
+		status := waitingStatus()
+		mutate(status.Nodes[0])
+		statuses = append(statuses, status)
+	}
+
+	for _, status := range statuses {
+		event := eventstore.NewDAGRunEvent(
+			eventstore.Source{Service: eventstore.SourceServiceScheduler},
+			eventstore.TypeDAGRunWaiting,
+			status,
+			nil,
+		)
+		require.NoError(t, store.Emit(context.Background(), event))
+	}
+
+	events, _, err := store.ReadDAGRunEvents(context.Background(), cursor)
+	require.NoError(t, err)
+	require.Len(t, events, len(statuses))
+	for _, event := range events {
+		status, err := eventstore.DAGRunStatusFromEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, event.ID, eventstore.DAGRunWaitingEventID(status))
+	}
+}
+
+func waitingStatus() *ir.DAGRunStatus {
+	return &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:      ir.Step{ID: "step-a", Name: "approve"},
+			StartedAt: "2026-08-26T01:00:00Z",
+			Status:    ir.NodeWaiting,
+		}},
+	}
 }
 
 func dagRunEventIDs(events []*eventstore.Event) []string {

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -444,7 +444,10 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 		}
 		status := snapshot.DAGRunStatus()
 		eventType := event.Type
-		if eventType == eventstore.TypeDAGRunUpdated && status.Status == ir.Waiting {
+		if eventType == eventstore.TypeDAGRunUpdated && status.Status == ir.Waiting &&
+			slices.ContainsFunc(status.Nodes, func(node *ir.Node) bool {
+				return node != nil && node.Status == ir.NodeWaiting
+			}) {
 			eventType = eventstore.TypeDAGRunWaiting
 		}
 		if !m.isInterestedEventType(eventType) {

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -1347,7 +1347,8 @@ func migrateWaitingDelivery(destState *notificationDestinationState, event Notif
 		return false
 	}
 	deliveredAt, ok := destState.Delivered[legacyKey]
-	if !ok {
+	// A later event cannot be the occurrence recorded by the legacy delivery.
+	if !ok || event.ObservedAt.IsZero() || deliveredAt.Before(event.ObservedAt) {
 		return false
 	}
 

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -152,6 +152,7 @@ func NewNotificationMonitor(
 	if cfg.BootstrapCursor != nil {
 		cursor := cfg.BootstrapCursor.Normalize()
 		cursor.CommittedOffsets = maps.Clone(cursor.CommittedOffsets)
+		cursor.InboxEventIDs = maps.Clone(cursor.InboxEventIDs)
 		bootstrap = &cursor
 	}
 
@@ -1192,6 +1193,7 @@ func cloneNotificationMonitorState(state notificationMonitorState) notificationM
 		Destinations: make(map[string]*notificationDestinationState, len(state.Destinations)),
 	}
 	clone.SourceCursor.CommittedOffsets = maps.Clone(state.SourceCursor.CommittedOffsets)
+	clone.SourceCursor.InboxEventIDs = maps.Clone(state.SourceCursor.InboxEventIDs)
 	for destination, destState := range state.Destinations {
 		if destState == nil {
 			clone.Destinations[destination] = &notificationDestinationState{

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -44,6 +44,7 @@ type NotificationMonitorConfig struct {
 	UrgentWindow         time.Duration
 	SuccessWindow        time.Duration
 	InterestedEventTypes []eventstore.EventType
+	BootstrapCursor      *eventstore.DAGRunCursor
 }
 
 // DefaultNotificationMonitorConfig returns the default monitor settings.
@@ -117,6 +118,7 @@ type NotificationMonitor struct {
 	logger       *slog.Logger
 	cfg          NotificationMonitorConfig
 	interested   map[eventstore.EventType]struct{}
+	bootstrap    *eventstore.DAGRunCursor
 
 	batcherMu sync.RWMutex
 	batcher   *NotificationBatcher
@@ -146,6 +148,12 @@ func NewNotificationMonitor(
 	cfg NotificationMonitorConfig,
 ) *NotificationMonitor {
 	normalizeNotificationMonitorConfig(&cfg)
+	var bootstrap *eventstore.DAGRunCursor
+	if cfg.BootstrapCursor != nil {
+		cursor := cfg.BootstrapCursor.Normalize()
+		cursor.CommittedOffsets = maps.Clone(cursor.CommittedOffsets)
+		bootstrap = &cursor
+	}
 
 	lockDir := ""
 	if lease != nil {
@@ -161,6 +169,7 @@ func NewNotificationMonitor(
 		logger:       logger,
 		cfg:          cfg,
 		interested:   interestedEventTypeSet(cfg.InterestedEventTypes),
+		bootstrap:    bootstrap,
 		batcher:      NewNotificationBatcher(cfg.UrgentWindow, cfg.SuccessWindow),
 		state:        newNotificationMonitorState(),
 	}
@@ -422,7 +431,7 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 
 	pending := make([]NotificationEvent, 0, len(events))
 	for _, event := range events {
-		if event == nil || !m.isInterestedEventType(event.Type) {
+		if event == nil {
 			continue
 		}
 		snapshot, err := eventstore.DAGRunSnapshotFromEvent(event)
@@ -434,13 +443,20 @@ func (m *NotificationMonitor) pollSource(ctx context.Context) {
 			continue
 		}
 		status := snapshot.DAGRunStatus()
+		eventType := event.Type
+		if eventType == eventstore.TypeDAGRunUpdated && status.Status == ir.Waiting {
+			eventType = eventstore.TypeDAGRunWaiting
+		}
+		if !m.isInterestedEventType(eventType) {
+			continue
+		}
 		observedAt := event.RecordedAt
 		if observedAt.IsZero() {
 			observedAt = time.Now().UTC()
 		}
 		pending = append(pending, NotificationEvent{
 			Key:        NotificationSeenKey(status),
-			Type:       event.Type,
+			Type:       eventType,
 			Status:     status,
 			DAGFile:    snapshot.DAGFile,
 			ObservedAt: observedAt.UTC(),
@@ -834,10 +850,16 @@ func (m *NotificationMonitor) ensureBootstrapped(ctx context.Context) bool {
 		return true
 	}
 
-	cursor, err := m.eventService.DAGRunHeadCursor(ctx)
-	if err != nil {
-		m.recordBootstrapFailure("Failed to bootstrap notification cursor: " + err.Error())
-		return false
+	var cursor eventstore.DAGRunCursor
+	if m.bootstrap != nil {
+		cursor = m.bootstrap.Normalize()
+	} else {
+		var err error
+		cursor, err = m.eventService.DAGRunHeadCursor(ctx)
+		if err != nil {
+			m.recordBootstrapFailure("Failed to bootstrap notification cursor: " + err.Error())
+			return false
+		}
 	}
 
 	m.stateMu.Lock()
@@ -1272,6 +1294,10 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 				}
 				continue
 			}
+			if migrateWaitingDelivery(destState, event) {
+				changed = true
+				continue
+			}
 			if _, ok := destState.Delivered[event.Key]; ok {
 				continue
 			}
@@ -1310,6 +1336,24 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 	}
 
 	return queued, changed, accepted
+}
+
+func migrateWaitingDelivery(destState *notificationDestinationState, event NotificationEvent) bool {
+	if event.Status.Status != ir.Waiting {
+		return false
+	}
+	legacyKey := legacyNotificationSeenKey(event.Status)
+	if legacyKey == event.Key {
+		return false
+	}
+	deliveredAt, ok := destState.Delivered[legacyKey]
+	if !ok {
+		return false
+	}
+
+	delete(destState.Delivered, legacyKey)
+	destState.Delivered[event.Key] = deliveredAt
+	return true
 }
 
 func enqueueNotificationsByEvent(

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -337,6 +337,182 @@ func TestNotificationMonitor_PollSourceRoutesEventsPerDestination(t *testing.T) 
 	assert.ElementsMatch(t, []string{"dest-a", "dest-b"}, destinations)
 }
 
+func TestNotificationMonitor_BootstrapCursorDeliversStartupEvent(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotificationStore{}
+	service := eventstore.New(store)
+	cursor, err := service.DAGRunHeadCursor(context.Background())
+	require.NoError(t, err)
+
+	status := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Failed,
+		Error:     "boom",
+	}
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceScheduler},
+		eventstore.TypeDAGRunFailed,
+		status,
+		nil,
+	)))
+
+	delivered := make(chan struct{}, 1)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(context.Context, string, NotificationBatch, bool) bool {
+			delivered <- struct{}{}
+			return true
+		},
+	}
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.BootstrapCursor = &cursor
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	cfg.UrgentWindow = 10 * time.Millisecond
+
+	monitor := NewNotificationMonitor(service, nil, nil, transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for startup event delivery")
+	}
+}
+
+func TestNotificationMonitor_PollSourceDeliversDistinctWaitingStates(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotificationStore{}
+	service := eventstore.New(store)
+	var (
+		mu        sync.Mutex
+		delivered []NotificationEvent
+	)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(_ context.Context, _ string, batch NotificationBatch, _ bool) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			delivered = append(delivered, batch.Events...)
+			return true
+		},
+	}
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	cfg.UrgentWindow = 10 * time.Millisecond
+	cfg.SuccessWindow = 10 * time.Millisecond
+
+	monitor := NewNotificationMonitor(service, nil, nil, transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	require.Eventually(t, func() bool {
+		headCalls, _ := store.stats()
+		return headCalls > 0
+	}, time.Second, 10*time.Millisecond)
+
+	status := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:   ir.Step{Name: "approve-build"},
+			Status: ir.NodeWaiting,
+		}},
+	}
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceServer},
+		eventstore.TypeDAGRunWaiting,
+		status,
+		nil,
+	)))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(delivered) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	status.Nodes = []*ir.Node{{
+		Step:              ir.Step{Name: "approve-deploy"},
+		Status:            ir.NodeWaiting,
+		ApprovalIteration: 1,
+	}}
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceServer},
+		eventstore.TypeDAGRunUpdated,
+		status,
+		nil,
+	)))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(delivered) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceServer},
+		eventstore.TypeDAGRunUpdated,
+		status,
+		nil,
+	)))
+	require.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(delivered) > 2
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, delivered, 2)
+	assert.Equal(t, eventstore.TypeDAGRunWaiting, delivered[0].Type)
+	assert.Equal(t, eventstore.TypeDAGRunWaiting, delivered[1].Type)
+	assert.NotEqual(t, delivered[0].Key, delivered[1].Key)
+}
+
+func TestNotificationMonitor_MigratesDeliveredWaitingKey(t *testing.T) {
+	t.Parallel()
+
+	status := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:   ir.Step{Name: "approve-build"},
+			Status: ir.NodeWaiting,
+		}},
+	}
+	deliveredAt := time.Now().UTC()
+	state := newNotificationMonitorState()
+	state.Destinations["dest-1"] = &notificationDestinationState{
+		Pending: make(map[string]NotificationEvent),
+		Delivered: map[string]time.Time{
+			legacyNotificationSeenKey(status): deliveredAt,
+		},
+	}
+	event := NotificationEvent{
+		Key:    NotificationSeenKey(status),
+		Type:   eventstore.TypeDAGRunWaiting,
+		Status: status,
+	}
+
+	queued, changed, accepted := enqueueNotifications(&state, []string{"dest-1"}, []NotificationEvent{event})
+
+	assert.Empty(t, queued)
+	assert.True(t, changed)
+	assert.False(t, accepted)
+	destination := state.Destinations["dest-1"]
+	assert.NotContains(t, destination.Delivered, legacyNotificationSeenKey(status))
+	assert.Equal(t, deliveredAt, destination.Delivered[event.Key])
+}
+
 func TestNotificationMonitor_PollSourceSkipsFailedRunWithAutoRetryRemaining(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -468,6 +468,7 @@ func TestNotificationMonitor_PollSourceDeliversDistinctWaitingStates(t *testing.
 		return len(delivered) == 3
 	}, time.Second, 10*time.Millisecond)
 
+	status.Nodes[0].Status = ir.NodeSucceeded
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer},
 		eventstore.TypeDAGRunUpdated,

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -439,11 +439,7 @@ func TestNotificationMonitor_PollSourceDeliversDistinctWaitingStates(t *testing.
 		return len(delivered) == 1
 	}, time.Second, 10*time.Millisecond)
 
-	status.Nodes = []*ir.Node{{
-		Step:              ir.Step{Name: "approve-deploy"},
-		Status:            ir.NodeWaiting,
-		ApprovalIteration: 1,
-	}}
+	status.Nodes[0].ApprovalIteration = 1
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer},
 		eventstore.TypeDAGRunUpdated,
@@ -456,6 +452,22 @@ func TestNotificationMonitor_PollSourceDeliversDistinctWaitingStates(t *testing.
 		return len(delivered) == 2
 	}, time.Second, 10*time.Millisecond)
 
+	status.Nodes = []*ir.Node{{
+		Step:   ir.Step{Name: "approve-deploy"},
+		Status: ir.NodeWaiting,
+	}}
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceServer},
+		eventstore.TypeDAGRunUpdated,
+		status,
+		nil,
+	)))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(delivered) == 3
+	}, time.Second, 10*time.Millisecond)
+
 	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceServer},
 		eventstore.TypeDAGRunUpdated,
@@ -465,15 +477,17 @@ func TestNotificationMonitor_PollSourceDeliversDistinctWaitingStates(t *testing.
 	require.Never(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(delivered) > 2
+		return len(delivered) > 3
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
-	require.Len(t, delivered, 2)
+	require.Len(t, delivered, 3)
 	assert.Equal(t, eventstore.TypeDAGRunWaiting, delivered[0].Type)
 	assert.Equal(t, eventstore.TypeDAGRunWaiting, delivered[1].Type)
+	assert.Equal(t, eventstore.TypeDAGRunWaiting, delivered[2].Type)
 	assert.NotEqual(t, delivered[0].Key, delivered[1].Key)
+	assert.NotEqual(t, delivered[1].Key, delivered[2].Key)
 }
 
 func TestNotificationMonitor_MigratesDeliveredWaitingKey(t *testing.T) {

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -512,9 +512,10 @@ func TestNotificationMonitor_MigratesDeliveredWaitingKey(t *testing.T) {
 		},
 	}
 	event := NotificationEvent{
-		Key:    NotificationSeenKey(status),
-		Type:   eventstore.TypeDAGRunWaiting,
-		Status: status,
+		Key:        NotificationSeenKey(status),
+		Type:       eventstore.TypeDAGRunWaiting,
+		Status:     status,
+		ObservedAt: deliveredAt.Add(-time.Minute),
 	}
 
 	queued, changed, accepted := enqueueNotifications(&state, []string{"dest-1"}, []NotificationEvent{event})
@@ -525,6 +526,52 @@ func TestNotificationMonitor_MigratesDeliveredWaitingKey(t *testing.T) {
 	destination := state.Destinations["dest-1"]
 	assert.NotContains(t, destination.Delivered, legacyNotificationSeenKey(status))
 	assert.Equal(t, deliveredAt, destination.Delivered[event.Key])
+}
+
+func TestNotificationMonitor_DoesNotMigrateLaterWaitingKey(t *testing.T) {
+	t.Parallel()
+
+	deliveredAt := time.Now().UTC()
+	legacyStatus := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:   ir.Step{Name: "approve-build"},
+			Status: ir.NodeWaiting,
+		}},
+	}
+	status := &ir.DAGRunStatus{
+		Name:      "briefing",
+		DAGRunID:  "run-1",
+		AttemptID: "attempt-1",
+		Status:    ir.Waiting,
+		Nodes: []*ir.Node{{
+			Step:   ir.Step{Name: "approve-deploy"},
+			Status: ir.NodeWaiting,
+		}},
+	}
+	state := newNotificationMonitorState()
+	state.Destinations["dest-1"] = &notificationDestinationState{
+		Pending: make(map[string]NotificationEvent),
+		Delivered: map[string]time.Time{
+			legacyNotificationSeenKey(legacyStatus): deliveredAt,
+		},
+	}
+	event := NotificationEvent{
+		Key:        NotificationSeenKey(status),
+		Type:       eventstore.TypeDAGRunWaiting,
+		Status:     status,
+		ObservedAt: deliveredAt.Add(time.Minute),
+	}
+
+	queued, changed, accepted := enqueueNotifications(&state, []string{"dest-1"}, []NotificationEvent{event})
+
+	require.Len(t, queued, 1)
+	assert.True(t, changed)
+	assert.True(t, accepted)
+	assert.Equal(t, event.Key, queued[0].event.Key)
 }
 
 func TestNotificationMonitor_PollSourceSkipsFailedRunWithAutoRetryRemaining(t *testing.T) {

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -461,6 +461,16 @@ func NotificationSeenKey(status *ir.DAGRunStatus) string {
 	if status == nil {
 		return ""
 	}
+	if status.Status == ir.Waiting {
+		return eventstore.DAGRunWaitingEventID(status)
+	}
+	return NotificationRunKey(status) + ":" + status.Status.String()
+}
+
+func legacyNotificationSeenKey(status *ir.DAGRunStatus) string {
+	if status == nil {
+		return ""
+	}
 	return NotificationRunKey(status) + ":" + status.Status.String()
 }
 

--- a/internal/service/frontend/api/v1/notification_channels_license_test.go
+++ b/internal/service/frontend/api/v1/notification_channels_license_test.go
@@ -46,6 +46,8 @@ func TestNotificationChannels_UnavailableWithoutEventStore(t *testing.T) {
 	var result api.Error
 	resp.Unmarshal(t, &result)
 	assert.Contains(t, result.Message, "Notification delivery is unavailable")
+	assert.Contains(t, result.Message, "notification store")
+	assert.Contains(t, result.Message, "notification state")
 }
 
 func TestNotificationChannels_AcceptExistingLicenseWithoutFeatureClaim(t *testing.T) {

--- a/internal/service/frontend/api/v1/notification_channels_license_test.go
+++ b/internal/service/frontend/api/v1/notification_channels_license_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	dagucrypto "github.com/dagucloud/dagu/v2/internal/cmn/crypto"
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
 	"github.com/dagucloud/dagu/v2/internal/license"
@@ -31,6 +32,20 @@ func TestNotificationChannels_AvailableWithoutLicense(t *testing.T) {
 	var result api.NotificationChannelListResponse
 	resp.Unmarshal(t, &result)
 	assert.Empty(t, result.Channels)
+}
+
+func TestNotificationChannels_UnavailableWithoutEventStore(t *testing.T) {
+	t.Parallel()
+
+	server := test.SetupServer(t, test.WithConfigMutator(func(cfg *config.Config) {
+		cfg.EventStore.Enabled = false
+	}))
+	resp := server.Client().Get("/api/v1/notification-channels").
+		ExpectStatus(http.StatusServiceUnavailable).Send(t)
+
+	var result api.Error
+	resp.Unmarshal(t, &result)
+	assert.Contains(t, result.Message, "Notification delivery is unavailable")
 }
 
 func TestNotificationChannels_AcceptExistingLicenseWithoutFeatureClaim(t *testing.T) {

--- a/internal/service/frontend/api/v1/notifications.go
+++ b/internal/service/frontend/api/v1/notifications.go
@@ -21,9 +21,9 @@ import (
 )
 
 var errNotificationManagementNotAvailable = &Error{
-	HTTPStatus: http.StatusNotFound,
-	Code:       api.ErrorCodeNotFound,
-	Message:    "Notification management is not available",
+	HTTPStatus: http.StatusServiceUnavailable,
+	Code:       api.ErrorCodeInternalError,
+	Message:    "Notification delivery is unavailable; enable the event store and verify notification state storage",
 }
 
 func (a *API) GetNotificationSettings(ctx context.Context, _ api.GetNotificationSettingsRequestObject) (api.GetNotificationSettingsResponseObject, error) {

--- a/internal/service/frontend/api/v1/notifications.go
+++ b/internal/service/frontend/api/v1/notifications.go
@@ -23,7 +23,7 @@ import (
 var errNotificationManagementNotAvailable = &Error{
 	HTTPStatus: http.StatusServiceUnavailable,
 	Code:       api.ErrorCodeInternalError,
-	Message:    "Notification delivery is unavailable; enable the event store and verify notification state storage",
+	Message:    "Notification delivery is unavailable; verify the event store, notification store, and notification state store",
 }
 
 func (a *API) GetNotificationSettings(ctx context.Context, _ api.GetNotificationSettingsRequestObject) (api.GetNotificationSettingsResponseObject, error) {

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -531,13 +531,15 @@ func NewServer(setup ServerConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	var notificationSvc *notificationservice.Service
-	if stores.Notification != nil {
+	if stores.Notification != nil && eventSvc != nil && stores.NotificationState != nil {
 		notificationSvc = notificationservice.New(
 			stores.Notification,
 			dr,
 			notificationservice.WithPublicURL(cfg.Server.PublicURL),
 		)
 		apiOpts = append(apiOpts, apiv1.WithNotificationService(notificationSvc))
+	} else if stores.Notification != nil {
+		slog.Default().Warn("Notification delivery is unavailable because the event or state store is disabled")
 	}
 
 	var incidentSvc *incidentservice.Service
@@ -902,8 +904,9 @@ func (srv *Server) Serve(ctx context.Context) error {
 	metrics.StartUptime(ctx)
 	logger.Info(ctx, "Server is starting", tag.Addr(addr))
 
-	srv.startNotificationMonitor(ctx)
-	srv.startIncidentMonitor(ctx)
+	monitorCursor := srv.captureMonitorCursor(ctx)
+	srv.startNotificationMonitor(ctx, monitorCursor)
+	srv.startIncidentMonitor(ctx, monitorCursor)
 	srv.startPeriodicUpdateCheck(ctx)
 
 	go srv.startServer(ctx)
@@ -926,7 +929,7 @@ func trustedProxyRequestHeaders(cfg config.AuthTrustedProxy) []string {
 	return headers
 }
 
-func (srv *Server) startNotificationMonitor(ctx context.Context) {
+func (srv *Server) startNotificationMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
 	if srv.notificationService == nil || srv.eventService == nil {
 		return
 	}
@@ -937,18 +940,20 @@ func (srv *Server) startNotificationMonitor(ctx context.Context) {
 	if srv.newNotificationLease != nil {
 		lease = srv.newNotificationLease()
 	}
+	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
+	monitorConfig.BootstrapCursor = cursor
 	monitor := chatbridge.NewNotificationMonitor(
 		srv.eventService,
 		srv.notificationState,
 		lease,
 		srv.notificationService,
 		slog.Default(),
-		chatbridge.DefaultNotificationMonitorConfig(),
+		monitorConfig,
 	)
 	go monitor.Run(ctx)
 }
 
-func (srv *Server) startIncidentMonitor(ctx context.Context) {
+func (srv *Server) startIncidentMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
 	if srv.incidentService == nil || srv.eventService == nil {
 		return
 	}
@@ -959,15 +964,29 @@ func (srv *Server) startIncidentMonitor(ctx context.Context) {
 	if srv.newIncidentLease != nil {
 		lease = srv.newIncidentLease()
 	}
+	monitorConfig := incidentMonitorConfig()
+	monitorConfig.BootstrapCursor = cursor
 	monitor := chatbridge.NewNotificationMonitor(
 		srv.eventService,
 		srv.incidentState,
 		lease,
 		srv.incidentService,
 		slog.Default(),
-		incidentMonitorConfig(),
+		monitorConfig,
 	)
 	go monitor.Run(ctx)
+}
+
+func (srv *Server) captureMonitorCursor(ctx context.Context) *eventstore.DAGRunCursor {
+	if srv.eventService == nil || (srv.notificationService == nil && srv.incidentService == nil) {
+		return nil
+	}
+	cursor, err := srv.eventService.DAGRunHeadCursor(ctx)
+	if err != nil {
+		slog.Default().Warn("Failed to capture notification cursor", slog.String("error", err.Error()))
+		return nil
+	}
+	return &cursor
 }
 
 func incidentMonitorConfig() chatbridge.NotificationMonitorConfig {

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -284,38 +284,38 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 func TestService_DeliversLifecycleEvent(t *testing.T) {
 	t.Parallel()
 
-	delivered := make(chan struct{}, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		delivered <- struct{}{}
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer server.Close()
+	smtpServer := newRecordingSMTPServer(t)
 
 	settings := mustNormalizeSettings(t, &notificationmodel.Settings{
 		DAGName: "daily-report",
 		Enabled: true,
 		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed},
 		Targets: []notificationmodel.Target{{
-			ID:      "webhook-1",
-			Type:    notificationmodel.ProviderWebhook,
+			ID:      "email-1",
+			Type:    notificationmodel.ProviderEmail,
 			Enabled: true,
-			Webhook: &notificationmodel.WebhookTarget{
-				URL:                 server.URL,
-				AllowInsecureHTTP:   true,
-				AllowPrivateNetwork: true,
-			},
+			Email:   &notificationmodel.EmailTarget{To: []string{"ops@example.com"}},
 		}},
 	})
+	notificationStore := newMemoryStore(settings)
+	workspaceSettings, err := notificationmodel.NormalizeWorkspaceSettings(&notificationmodel.WorkspaceSettings{
+		SMTP: &notificationmodel.SMTPConfig{
+			Host: smtpServer.host,
+			Port: smtpServer.port,
+			From: "dagu@example.com",
+		},
+	}, "tester")
+	require.NoError(t, err)
+	require.NoError(t, notificationStore.SaveWorkspaceSettings(context.Background(), workspaceSettings))
 	svc := New(
-		newMemoryStore(settings),
+		notificationStore,
 		nil,
-		WithDeliveryRetry(DeliveryRetryConfig{MaxAttempts: 1}),
 		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 	)
 
-	store, err := fileeventstore.New(t.TempDir())
+	eventStore, err := fileeventstore.New(t.TempDir())
 	require.NoError(t, err)
-	eventService := eventstore.New(store)
+	eventService := eventstore.New(eventStore)
 	cursor, err := eventService.DAGRunHeadCursor(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, eventService.Emit(context.Background(), eventstore.NewDAGRunEvent(
@@ -347,11 +347,11 @@ func TestService_DeliversLifecycleEvent(t *testing.T) {
 	stopMonitor := testutil.StartContextRunner(t, monitor)
 	defer stopMonitor()
 
-	select {
-	case <-delivered:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for lifecycle notification")
-	}
+	require.Eventually(t, func() bool {
+		return smtpServer.data.Load() != nil
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "dagu@example.com", smtpServer.mailFrom.Load())
+	assert.Equal(t, "ops@example.com", smtpServer.rcptTo.Load())
 }
 
 func TestService_SendTestReturnsProviderError(t *testing.T) {

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +26,9 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	notificationmodel "github.com/dagucloud/dagu/v2/internal/notification"
 	"github.com/dagucloud/dagu/v2/internal/persis"
+	fileeventstore "github.com/dagucloud/dagu/v2/internal/persis/file/eventstore"
 	"github.com/dagucloud/dagu/v2/internal/service/chatbridge"
+	"github.com/dagucloud/dagu/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -276,6 +279,79 @@ func TestService_SendTestWebhookIncludesPayloadHeadersAndSignature(t *testing.T)
 	assert.Equal(t, "sha256="+hex.EncodeToString(mac.Sum(nil)), receivedSignature)
 	assert.Contains(t, string(receivedBody), `"dagName":"daily-report"`)
 	assert.Contains(t, string(receivedBody), `"dagRunId":"notification-test"`)
+}
+
+func TestService_DeliversLifecycleEvent(t *testing.T) {
+	t.Parallel()
+
+	delivered := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		delivered <- struct{}{}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	settings := mustNormalizeSettings(t, &notificationmodel.Settings{
+		DAGName: "daily-report",
+		Enabled: true,
+		Events:  []eventstore.EventType{eventstore.TypeDAGRunFailed},
+		Targets: []notificationmodel.Target{{
+			ID:      "webhook-1",
+			Type:    notificationmodel.ProviderWebhook,
+			Enabled: true,
+			Webhook: &notificationmodel.WebhookTarget{
+				URL:                 server.URL,
+				AllowInsecureHTTP:   true,
+				AllowPrivateNetwork: true,
+			},
+		}},
+	})
+	svc := New(
+		newMemoryStore(settings),
+		nil,
+		WithDeliveryRetry(DeliveryRetryConfig{MaxAttempts: 1}),
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
+	)
+
+	store, err := fileeventstore.New(t.TempDir())
+	require.NoError(t, err)
+	eventService := eventstore.New(store)
+	cursor, err := eventService.DAGRunHeadCursor(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, eventService.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceScheduler},
+		eventstore.TypeDAGRunFailed,
+		&ir.DAGRunStatus{
+			Name:      "daily-report",
+			DAGRunID:  "run-1",
+			AttemptID: "attempt-1",
+			Status:    ir.Failed,
+			Error:     "boom",
+		},
+		nil,
+	)))
+
+	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
+	monitorConfig.BootstrapCursor = &cursor
+	monitorConfig.PollInterval = 10 * time.Millisecond
+	monitorConfig.UrgentWindow = 10 * time.Millisecond
+	monitorConfig.SeenEvictInterval = time.Hour
+	monitor := chatbridge.NewNotificationMonitor(
+		eventService,
+		nil,
+		nil,
+		svc,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		monitorConfig,
+	)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle notification")
+	}
 }
 
 func TestService_SendTestReturnsProviderError(t *testing.T) {

--- a/internal/service/scheduler/monitors.go
+++ b/internal/service/scheduler/monitors.go
@@ -18,7 +18,7 @@ import (
 	notificationservice "github.com/dagucloud/dagu/v2/internal/service/notification"
 )
 
-func newNotificationMonitor(cfg *config.Config, deps Dependencies) func(context.Context) {
+func newNotificationMonitor(cfg *config.Config, deps Dependencies) func(context.Context, *eventstore.DAGRunCursor) {
 	if deps.NotificationStore == nil || deps.NotificationState == nil {
 		return nil
 	}
@@ -27,14 +27,18 @@ func newNotificationMonitor(cfg *config.Config, deps Dependencies) func(context.
 		lease = deps.NewNotificationLease()
 	}
 	service := newNotificationService(cfg, deps.NotificationStore, deps.DAGRepository)
-	return chatbridge.NewNotificationMonitor(
-		deps.EventService,
-		deps.NotificationState,
-		lease,
-		service,
-		slog.Default(),
-		chatbridge.DefaultNotificationMonitorConfig(),
-	).Run
+	return func(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+		monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
+		monitorConfig.BootstrapCursor = cursor
+		chatbridge.NewNotificationMonitor(
+			deps.EventService,
+			deps.NotificationState,
+			lease,
+			service,
+			slog.Default(),
+			monitorConfig,
+		).Run(ctx)
+	}
 }
 
 func newNotificationService(
@@ -49,7 +53,7 @@ func newNotificationService(
 	return notificationservice.New(store, dagRepository, opts...)
 }
 
-func newIncidentMonitor(cfg *config.Config, deps Dependencies) func(context.Context) {
+func newIncidentMonitor(cfg *config.Config, deps Dependencies) func(context.Context, *eventstore.DAGRunCursor) {
 	if deps.IncidentStore == nil || deps.IncidentState == nil {
 		return nil
 	}
@@ -76,12 +80,15 @@ func newIncidentMonitor(cfg *config.Config, deps Dependencies) func(context.Cont
 		eventstore.TypeDAGRunSucceeded,
 		eventstore.TypeDAGRunPartiallySucceeded,
 	}
-	return chatbridge.NewNotificationMonitor(
-		deps.EventService,
-		deps.IncidentState,
-		lease,
-		service,
-		slog.Default(),
-		monitorConfig,
-	).Run
+	return func(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+		monitorConfig.BootstrapCursor = cursor
+		chatbridge.NewNotificationMonitor(
+			deps.EventService,
+			deps.IncidentState,
+			lease,
+			service,
+			slog.Default(),
+			monitorConfig,
+		).Run(ctx)
+	}
 }

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -86,9 +86,10 @@ type Scheduler struct {
 	startupCancel       context.CancelFunc
 	lockHeld            atomic.Bool
 	clock               Clock // Clock function for getting current time
+	eventService        *eventstore.Service
 	eventCollector      func(context.Context)
-	notificationMonitor func(context.Context)
-	incidentMonitor     func(context.Context)
+	notificationMonitor func(context.Context, *eventstore.DAGRunCursor)
+	incidentMonitor     func(context.Context, *eventstore.DAGRunCursor)
 }
 
 type schedulerHooks struct {
@@ -161,6 +162,7 @@ func New(cfg *config.Config, deps Dependencies) (*Scheduler, error) {
 		return nil, err
 	}
 	scheduler.eventCollector = deps.EventCollector
+	scheduler.eventService = deps.EventService
 	if deps.EventService != nil {
 		scheduler.notificationMonitor = newNotificationMonitor(cfg, deps)
 		scheduler.incidentMonitor = newIncidentMonitor(cfg, deps)
@@ -589,6 +591,7 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	}
 
 	s.updateServiceStatus(ctx, serviceregistry.ServiceStatusActive, "Failed to update status to active", "Updated scheduler status to active")
+	monitorCursor := s.captureMonitorCursor(ctx)
 
 	sig := make(chan os.Signal, 1)
 
@@ -642,11 +645,11 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	})
 
 	wg.Go(func() {
-		s.startNotificationMonitor(ctx)
+		s.startNotificationMonitor(ctx, monitorCursor)
 	})
 
 	wg.Go(func() {
-		s.startIncidentMonitor(ctx)
+		s.startIncidentMonitor(ctx, monitorCursor)
 	})
 
 	wg.Go(func() {
@@ -709,18 +712,30 @@ func (s *Scheduler) startEventCollector(ctx context.Context) {
 	s.eventCollector(ctx)
 }
 
-func (s *Scheduler) startNotificationMonitor(ctx context.Context) {
+func (s *Scheduler) startNotificationMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
 	if s.notificationMonitor == nil {
 		return
 	}
-	s.notificationMonitor(ctx)
+	s.notificationMonitor(ctx, cursor)
 }
 
-func (s *Scheduler) startIncidentMonitor(ctx context.Context) {
+func (s *Scheduler) startIncidentMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
 	if s.incidentMonitor == nil {
 		return
 	}
-	s.incidentMonitor(ctx)
+	s.incidentMonitor(ctx, cursor)
+}
+
+func (s *Scheduler) captureMonitorCursor(ctx context.Context) *eventstore.DAGRunCursor {
+	if s.eventService == nil || (s.notificationMonitor == nil && s.incidentMonitor == nil) {
+		return nil
+	}
+	cursor, err := s.eventService.DAGRunHeadCursor(ctx)
+	if err != nil {
+		logger.Warn(ctx, "Failed to capture notification cursor", tag.Error(err))
+		return nil
+	}
+	return &cursor
 }
 
 func (s *Scheduler) startHeartbeat(ctx context.Context) {

--- a/ui/src/features/dags/components/dag-details/NotificationsTab.tsx
+++ b/ui/src/features/dags/components/dag-details/NotificationsTab.tsx
@@ -192,6 +192,7 @@ function NotificationsTab({ fileName, workspaceName }: NotificationsTabProps) {
     effectiveRouteSourceLabel,
     isLoading,
     error,
+    loadError,
     setError,
     testResults,
     setTestResults,
@@ -449,6 +450,16 @@ function NotificationsTab({ fileName, workspaceName }: NotificationsTabProps) {
     }));
     setDeleteSubscriptionIndex(null);
   };
+
+  if (loadError && !isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-4 text-sm text-destructive">
+          {loadError}
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/ui/src/features/dags/components/dag-details/NotificationsTab.tsx
+++ b/ui/src/features/dags/components/dag-details/NotificationsTab.tsx
@@ -55,6 +55,7 @@ type NotificationsTabProps = {
 
 type DAGNotificationHeaderProps = {
   isDAGConfigured: boolean;
+  loadFailed: boolean;
   hasUnsavedChanges: boolean;
   isSaving: boolean;
   isResetting: boolean;
@@ -69,6 +70,7 @@ type DAGNotificationHeaderProps = {
 
 function DAGNotificationHeader({
   isDAGConfigured,
+  loadFailed,
   hasUnsavedChanges,
   isSaving,
   isResetting,
@@ -97,56 +99,60 @@ function DAGNotificationHeader({
             <RefreshCw className="h-4 w-4" />
             Refresh
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onTestAll}
-            disabled={
-              hasUnsavedChanges ||
-              testableDestinationCount === 0 ||
-              testingTargetId !== null
-            }
-          >
-            {testingTargetId === '__all__' ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <FlaskConical className="h-4 w-4" />
-            )}
-            Send test
-          </Button>
-          {isDAGConfigured ? (
+          {!loadFailed && (
             <>
               <Button
                 variant="outline"
                 size="sm"
-                onClick={onResetDAG}
-                disabled={isResetting || isSaving}
+                onClick={onTestAll}
+                disabled={
+                  hasUnsavedChanges ||
+                  testableDestinationCount === 0 ||
+                  testingTargetId !== null
+                }
               >
-                {isResetting ? (
+                {testingTargetId === '__all__' ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  <RotateCcw className="h-4 w-4" />
+                  <FlaskConical className="h-4 w-4" />
                 )}
-                Reset to inherit
+                Send test
               </Button>
-              <Button
-                size="sm"
-                onClick={onSave}
-                disabled={!hasUnsavedChanges || isSaving}
-              >
-                {isSaving ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Save className="h-4 w-4" />
-                )}
-                Save changes
-              </Button>
+              {isDAGConfigured ? (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onResetDAG}
+                    disabled={isResetting || isSaving}
+                  >
+                    {isResetting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <RotateCcw className="h-4 w-4" />
+                    )}
+                    Reset to inherit
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={onSave}
+                    disabled={!hasUnsavedChanges || isSaving}
+                  >
+                    {isSaving ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Save className="h-4 w-4" />
+                    )}
+                    Save changes
+                  </Button>
+                </>
+              ) : (
+                <Button size="sm" onClick={onConfigureDAG}>
+                  <Settings className="h-4 w-4" />
+                  Configure DAG override
+                </Button>
+              )}
             </>
-          ) : (
-            <Button size="sm" onClick={onConfigureDAG}>
-              <Settings className="h-4 w-4" />
-              Configure DAG override
-            </Button>
           )}
         </div>
       </div>
@@ -451,31 +457,40 @@ function NotificationsTab({ fileName, workspaceName }: NotificationsTabProps) {
     setDeleteSubscriptionIndex(null);
   };
 
-  if (loadError && !isLoading) {
+  const loadFailed = !!loadError && !isLoading;
+  const header = (
+    <DAGNotificationHeader
+      isDAGConfigured={hasDAGSettings}
+      loadFailed={loadFailed}
+      hasUnsavedChanges={hasUnsavedChanges}
+      isSaving={isSaving}
+      isResetting={isResetting}
+      testingTargetId={testingTargetId}
+      testableDestinationCount={testableDestinationCount}
+      onRefresh={refreshSettings}
+      onTestAll={() => testNotifications()}
+      onConfigureDAG={configureDAGOverride}
+      onResetDAG={() => setResetVisible(true)}
+      onSave={saveSettings}
+    />
+  );
+
+  if (loadFailed) {
     return (
-      <Card>
-        <CardContent className="py-4 text-sm text-destructive">
-          {loadError}
-        </CardContent>
-      </Card>
+      <div className="space-y-4">
+        {header}
+        <Card>
+          <CardContent className="py-4 text-sm text-destructive">
+            {loadError}
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
   return (
     <div className="space-y-4">
-      <DAGNotificationHeader
-        isDAGConfigured={hasDAGSettings}
-        hasUnsavedChanges={hasUnsavedChanges}
-        isSaving={isSaving}
-        isResetting={isResetting}
-        testingTargetId={testingTargetId}
-        testableDestinationCount={testableDestinationCount}
-        onRefresh={refreshSettings}
-        onTestAll={() => testNotifications()}
-        onConfigureDAG={configureDAGOverride}
-        onResetDAG={() => setResetVisible(true)}
-        onSave={saveSettings}
-      />
+      {header}
 
       {isLoading && (
         <Card>

--- a/ui/src/features/dags/components/dag-details/__tests__/NotificationsTab.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NotificationsTab.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -171,6 +171,50 @@ describe('NotificationsTab', () => {
     expect(
       screen.queryByRole('button', { name: /send test/i })
     ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeVisible();
+  });
+
+  it('ignores a stale load failure after refresh succeeds', async () => {
+    const user = userEvent.setup();
+    const defaultFetch = fetchMock.getMockImplementation();
+    let resolveFirst: (response: Response) => void = () => {};
+    const firstRequest = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let settingsRequests = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      if (
+        String(input) === '/api/v1/dags/example/notifications?remoteNode=local'
+      ) {
+        settingsRequests++;
+        if (settingsRequests === 1) {
+          return firstRequest;
+        }
+      }
+      return defaultFetch?.(input);
+    });
+
+    renderTab();
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(await screen.findByText('Inherited')).toBeVisible();
+
+    await act(async () => {
+      resolveFirst(
+        new Response(
+          JSON.stringify({ message: 'Notification delivery is unavailable' }),
+          {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      );
+      await firstRequest;
+    });
+
+    expect(
+      screen.queryByText('Notification delivery is unavailable')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Inherited')).toBeVisible();
   });
 
   it('shows inherited rules instead of silently creating a DAG override', async () => {

--- a/ui/src/features/dags/components/dag-details/__tests__/NotificationsTab.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/NotificationsTab.test.tsx
@@ -156,6 +156,23 @@ afterEach(() => {
 });
 
 describe('NotificationsTab', () => {
+  it('blocks DAG controls when delivery is unavailable', async () => {
+    dagSettingsResponse = () =>
+      jsonResponse({ message: 'Notification delivery is unavailable' }, 503);
+
+    renderTab();
+
+    expect(
+      await screen.findByText('Notification delivery is unavailable')
+    ).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: /configure dag override/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /send test/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('shows inherited rules instead of silently creating a DAG override', async () => {
     renderTab();
 

--- a/ui/src/features/dags/components/dag-details/notifications/useNotificationSettings.ts
+++ b/ui/src/features/dags/components/dag-details/notifications/useNotificationSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   components,
@@ -55,8 +55,10 @@ export function useNotificationSettings({
   const [error, setError] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<TestResult[]>([]);
+  const requestSequence = useRef(0);
 
   const fetchData = useCallback(async () => {
+    const requestID = ++requestSequence.current;
     setIsLoading(true);
     setError(null);
     setLoadError(null);
@@ -92,6 +94,10 @@ export function useNotificationSettings({
         workspaceRoutesRequest,
       ]);
 
+      if (requestID !== requestSequence.current) {
+        return;
+      }
+
       if (settingsResponse.status === 404) {
         setDraft(defaultDraft());
         setHasDAGSettings(false);
@@ -101,6 +107,9 @@ export function useNotificationSettings({
         );
       } else {
         const data = (await settingsResponse.json()) as NotificationSettings;
+        if (requestID !== requestSequence.current) {
+          return;
+        }
         setDraft(draftFromAPI(data));
         setHasDAGSettings(true);
       }
@@ -112,6 +121,9 @@ export function useNotificationSettings({
       }
       const channelData =
         (await channelsResponse.json()) as components['schemas']['NotificationChannelListResponse'];
+      if (requestID !== requestSequence.current) {
+        return;
+      }
       setChannels(channelData.channels.map(draftChannelFromAPI));
 
       if (!globalRoutesResponse.ok) {
@@ -122,9 +134,12 @@ export function useNotificationSettings({
           )
         );
       }
-      setGlobalRoutes(
-        (await globalRoutesResponse.json()) as NotificationRouteSet
-      );
+      const nextGlobalRoutes =
+        (await globalRoutesResponse.json()) as NotificationRouteSet;
+      if (requestID !== requestSequence.current) {
+        return;
+      }
+      setGlobalRoutes(nextGlobalRoutes);
 
       if (workspaceRoutesResponse) {
         if (!workspaceRoutesResponse.ok) {
@@ -135,20 +150,28 @@ export function useNotificationSettings({
             )
           );
         }
-        setWorkspaceRoutes(
-          (await workspaceRoutesResponse.json()) as NotificationRouteSet
-        );
+        const nextWorkspaceRoutes =
+          (await workspaceRoutesResponse.json()) as NotificationRouteSet;
+        if (requestID !== requestSequence.current) {
+          return;
+        }
+        setWorkspaceRoutes(nextWorkspaceRoutes);
       } else {
         setWorkspaceRoutes(null);
       }
       setTestResults([]);
     } catch (err) {
+      if (requestID !== requestSequence.current) {
+        return;
+      }
       const message =
         err instanceof Error ? err.message : 'Failed to load notifications';
       setError(message);
       setLoadError(message);
     } finally {
-      setIsLoading(false);
+      if (requestID === requestSequence.current) {
+        setIsLoading(false);
+      }
     }
   }, [apiURL, fileName, query, workspaceName]);
 

--- a/ui/src/features/dags/components/dag-details/notifications/useNotificationSettings.ts
+++ b/ui/src/features/dags/components/dag-details/notifications/useNotificationSettings.ts
@@ -53,11 +53,13 @@ export function useNotificationSettings({
     useState<NotificationRouteSet | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<TestResult[]>([]);
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    setLoadError(null);
     try {
       const settingsRequest = fetch(
         `${apiURL}/dags/${encodeURIComponent(fileName)}/notifications${query}`,
@@ -72,13 +74,12 @@ export function useNotificationSettings({
           headers: authHeaders(),
         }
       );
-      const workspaceRoutesRequest =
-        workspaceName
-          ? fetch(
-              `${apiURL}/notification-routes/workspaces/${encodeURIComponent(workspaceName)}${query}`,
-              { headers: authHeaders() }
-            )
-          : Promise.resolve<Response | null>(null);
+      const workspaceRoutesRequest = workspaceName
+        ? fetch(
+            `${apiURL}/notification-routes/workspaces/${encodeURIComponent(workspaceName)}${query}`,
+            { headers: authHeaders() }
+          )
+        : Promise.resolve<Response | null>(null);
       const [
         settingsResponse,
         channelsResponse,
@@ -142,9 +143,10 @@ export function useNotificationSettings({
       }
       setTestResults([]);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to load notifications'
-      );
+      const message =
+        err instanceof Error ? err.message : 'Failed to load notifications';
+      setError(message);
+      setLoadError(message);
     } finally {
       setIsLoading(false);
     }
@@ -198,6 +200,7 @@ export function useNotificationSettings({
     effectiveRouteSourceLabel,
     isLoading,
     error,
+    loadError,
     setError,
     testResults,
     setTestResults,

--- a/ui/src/pages/notifications/__tests__/index.test.tsx
+++ b/ui/src/pages/notifications/__tests__/index.test.tsx
@@ -115,6 +115,33 @@ describe('NotificationsPage', () => {
 });
 
 describe('NotificationChannelsPage', () => {
+  it('blocks channel controls when delivery is unavailable', () => {
+    mocks.useQuery.mockReturnValue({
+      data: undefined,
+      error: new Error('Notification delivery is unavailable'),
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AppBarContext.Provider value={{ setTitle: vi.fn() } as never}>
+          <NotificationChannelsPage />
+        </AppBarContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText('Notification delivery is unavailable')
+    ).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: /^save$/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /add channel/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('preserves the configured password indicator when toggling authentication modes', async () => {
     const user = userEvent.setup();
     renderChannelsPage({

--- a/ui/src/pages/notifications/index.tsx
+++ b/ui/src/pages/notifications/index.tsx
@@ -14,12 +14,7 @@ import {
   Save,
   Trash2,
 } from 'lucide-react';
-import {
-  type ReactElement,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { type ReactElement, useContext, useEffect, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -705,9 +700,7 @@ function RouteBuilder({
                   : 'border-border hover:bg-muted'
               )}
             >
-              <span className="block text-sm font-medium">
-                Inherit Global
-              </span>
+              <span className="block text-sm font-medium">Inherit Global</span>
               <span className="mt-1 block text-xs text-muted-foreground">
                 Use the Global rules for this workspace.
               </span>
@@ -1228,10 +1221,11 @@ export function NotificationRulesPage() {
     if (workspaceRoutesData) {
       setWorkspaceRoutes(routeSetDraftFromAPI(workspaceRoutesData));
     }
-  }, [
-    canConfigureWorkspaceRoutes,
-    workspaceRoutesData,
-  ]);
+  }, [canConfigureWorkspaceRoutes, workspaceRoutesData]);
+
+  if (loadError && !isLoading) {
+    return <StatusCard error={loadError} notice={null} />;
+  }
 
   const saveGlobalRoutes = async () => {
     setIsSavingGlobalRoutes(true);
@@ -1248,9 +1242,7 @@ export function NotificationRulesPage() {
         }
       );
       if (apiError) {
-        throw new Error(
-          apiError.message || 'Failed to save Global rules'
-        );
+        throw new Error(apiError.message || 'Failed to save Global rules');
       }
       if (routeSet) {
         setGlobalRoutes(routeSetDraftFromAPI(routeSet));
@@ -1259,9 +1251,7 @@ export function NotificationRulesPage() {
       setNotice('Global rules saved');
     } catch (err) {
       setError(
-        err instanceof Error
-          ? err.message
-          : 'Failed to save Global rules'
+        err instanceof Error ? err.message : 'Failed to save Global rules'
       );
     } finally {
       setIsSavingGlobalRoutes(false);
@@ -1285,9 +1275,7 @@ export function NotificationRulesPage() {
         }
       );
       if (apiError) {
-        throw new Error(
-          apiError.message || 'Failed to save workspace rules'
-        );
+        throw new Error(apiError.message || 'Failed to save workspace rules');
       }
       if (routeSet) {
         setWorkspaceRoutes(routeSetDraftFromAPI(routeSet));
@@ -1493,6 +1481,10 @@ export function NotificationChannelsPage() {
     }
   }, [channelsData]);
 
+  if (loadError && !isLoading) {
+    return <StatusCard error={loadError} notice={null} />;
+  }
+
   const saveSettings = async () => {
     setIsSavingSettings(true);
     setError(null);
@@ -1508,9 +1500,7 @@ export function NotificationChannelsPage() {
         }
       );
       if (apiError) {
-        throw new Error(
-          apiError.message || 'Failed to save email delivery'
-        );
+        throw new Error(apiError.message || 'Failed to save email delivery');
       }
       if (settings) {
         setSMTPDraft(smtpDraftFromAPI(settings));
@@ -1622,9 +1612,7 @@ export function NotificationChannelsPage() {
   return (
     <div className="space-y-4">
       <StatusCard error={error ?? loadError} notice={notice} />
-      {isLoading && (
-        <LoadingCard label="Refreshing notification channels..." />
-      )}
+      {isLoading && <LoadingCard label="Refreshing notification channels..." />}
 
       <Card>
         <CardHeader className="grid-cols-[1fr_auto]">


### PR DESCRIPTION
## Summary

- Fail closed when notification delivery dependencies are unavailable.
- Preserve startup events and deliver distinct waiting occurrences.
- Block unsafe UI controls and migrate legacy waiting delivery state.

## Testing

- `make test`
- `make lint`
- `cd ui && pnpm typecheck`
- `cd ui && pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification delivery reliability with distinct waiting-event handling and prevention of duplicate startup notifications.
  - Notification services now require event and notification-state storage.
  - Unavailable notification features return clear HTTP 503 errors instead of appearing missing.

- **User Interface**
  - Added clear error states when notification settings or channels cannot load.
  - Hide save, add-channel, testing, and configuration controls when delivery is unavailable.
  - Prevented stale requests from overwriting refreshed notification data.

- **Documentation**
  - Documented notification storage requirements and advised using v2.11.3 or later for scoped notification routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->