### PR TITLE
fix: reduce event replay allocations

### DIFF
--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -314,18 +314,19 @@ func (c *Collector) loadSeenIDsFromFile(filePath string) error {
 	for scanner.Scan() {
 		lineNum++
 		// Deduplication only needs the ID, so historical payloads stay unmaterialized.
-		var eventID struct {
-			ID string `json:"id"`
+		var event struct {
+			eventstore.Event
+			Data struct{} `json:"data"`
 		}
-		if err := json.Unmarshal(scanner.Bytes(), &eventID); err != nil {
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
 			slog.Warn("fileeventstore: skipping malformed committed event while loading seen-set",
 				slog.String("file", filePath),
 				slog.Int("line", lineNum),
 				slog.String("error", err.Error()))
 			continue
 		}
-		if eventID.ID != "" {
-			c.seenIDs[eventID.ID] = struct{}{}
+		if event.ID != "" {
+			c.seenIDs[event.ID] = struct{}{}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -313,16 +313,19 @@ func (c *Collector) loadSeenIDsFromFile(filePath string) error {
 	lineNum := 0
 	for scanner.Scan() {
 		lineNum++
-		event := new(eventstore.Event)
-		if err := json.Unmarshal(scanner.Bytes(), event); err != nil {
+		// Deduplication only needs the ID, so historical payloads stay unmaterialized.
+		var eventID struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &eventID); err != nil {
 			slog.Warn("fileeventstore: skipping malformed committed event while loading seen-set",
 				slog.String("file", filePath),
 				slog.Int("line", lineNum),
 				slog.String("error", err.Error()))
 			continue
 		}
-		if event.ID != "" {
-			c.seenIDs[event.ID] = struct{}{}
+		if eventID.ID != "" {
+			c.seenIDs[eventID.ID] = struct{}{}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -188,6 +189,44 @@ func TestCollectorLoadSeenIDsReadsLargeCommittedEventLine(t *testing.T) {
 	require.NoError(t, collector.loadSeenIDs())
 	_, ok := collector.seenIDs[event.ID]
 	require.True(t, ok)
+}
+
+func TestCollectorSeenIDAllocs(t *testing.T) {
+	const (
+		largeFieldCount   = 512
+		maxAllocationRate = 2
+	)
+
+	newCollector := func(data map[string]any) *Collector {
+		baseDir := t.TempDir()
+		event := testEvent("evt-allocs", time.Date(2026, 3, 29, 22, 0, 0, 0, time.UTC))
+		event.Data = data
+		writeCommittedEvents(t, baseDir, event.OccurredAt, [][]byte{mustMarshalEvent(t, event)})
+
+		collector, err := NewCollector(baseDir, 10)
+		require.NoError(t, err)
+		return collector
+	}
+
+	small := newCollector(map[string]any{"0": 0})
+	largeData := make(map[string]any, largeFieldCount)
+	for i := range largeFieldCount {
+		largeData[strconv.Itoa(i)] = i
+	}
+	large := newCollector(largeData)
+
+	var smallErr error
+	smallAllocs := testing.AllocsPerRun(5, func() {
+		smallErr = small.loadSeenIDs()
+	})
+	require.NoError(t, smallErr)
+
+	var largeErr error
+	largeAllocs := testing.AllocsPerRun(5, func() {
+		largeErr = large.loadSeenIDs()
+	})
+	require.NoError(t, largeErr)
+	require.LessOrEqual(t, largeAllocs, smallAllocs*maxAllocationRate)
 }
 
 func assertInboxCount(t *testing.T, dir string, count int) {

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -53,6 +53,36 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032823.jsonl"), 1)
 }
 
+func TestCollectorDrainOncePreservesInboxAfterMalformedCommittedEvent(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	event := testEvent("evt-after-malformed", time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC))
+	validJSON := string(mustMarshalEvent(t, event))
+	malformedJSON := strings.Replace(
+		validJSON,
+		`"schema_version":`+strconv.Itoa(event.SchemaVersion),
+		`"schema_version":"bad"`,
+		1,
+	)
+	require.NotEqual(t, validJSON, malformedJSON)
+	writeCommittedEvents(t, baseDir, event.OccurredAt, [][]byte{[]byte(malformedJSON)})
+
+	store, err := New(baseDir)
+	require.NoError(t, err)
+	require.NoError(t, store.Emit(context.Background(), event))
+
+	collector, err := NewCollector(baseDir, 10)
+	require.NoError(t, err)
+	require.NoError(t, collector.loadSeenIDs())
+	_, seen := collector.seenIDs[event.ID]
+	require.False(t, seen)
+
+	require.NoError(t, collector.DrainOnce(context.Background()))
+	assertInboxCount(t, store.inboxDir, 0)
+	assertLogLineCount(t, filepath.Join(baseDir, "_2026032912.jsonl"), 2)
+}
+
 func TestCollectorDrainOnceQuarantinesMalformedInbox(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- rebuild event deduplication state without decoding stored payloads
- keep replay allocations independent of payload size
- add allocation-scaling regression coverage

## Testing
- `go test -race ./internal/persis/file/eventstore -count=5`
- `make test`
- native and Windows `golangci-lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved event deduplication tracking to process large event payloads more efficiently.
  * Reduced unnecessary memory allocation when loading previously seen event IDs.

* **Reliability**
  * Malformed event records continue to be safely skipped while valid IDs remain available for deduplication.

* **Tests**
  * Added coverage to verify allocation efficiency for events with large data payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->