### PR TITLE
fix: reduce pending event allocations

### DIFF
--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -253,8 +253,12 @@ func (c *Collector) readPendingEvent(path string) (pendingInboxEvent, error) {
 	if err != nil {
 		return pendingInboxEvent{}, err
 	}
-	event := new(eventstore.Event)
-	if err := json.Unmarshal(data, event); err != nil {
+	// Draining needs event metadata; raw preserves the payload for persistence.
+	var event struct {
+		eventstore.Event
+		Data struct{} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
 		return pendingInboxEvent{}, err
 	}
 	event.Normalize()
@@ -264,7 +268,7 @@ func (c *Collector) readPendingEvent(path string) (pendingInboxEvent, error) {
 	return pendingInboxEvent{
 		path:  path,
 		raw:   data,
-		event: event,
+		event: &event.Event,
 	}, nil
 }
 

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -259,6 +259,45 @@ func TestCollectorSeenIDAllocs(t *testing.T) {
 	require.LessOrEqual(t, largeAllocs, smallAllocs*maxAllocationRate)
 }
 
+func TestCollectorPendingEventAllocs(t *testing.T) {
+	const (
+		largeFieldCount   = 512
+		maxAllocationRate = 2
+	)
+
+	newPendingEvent := func(data map[string]any) (*Collector, string) {
+		collector, err := NewCollector(t.TempDir(), 10)
+		require.NoError(t, err)
+
+		event := testEvent("evt-allocs", time.Date(2026, 3, 29, 22, 0, 0, 0, time.UTC))
+		event.Data = data
+		path := filepath.Join(collector.store.inboxDir, "pending.json")
+		require.NoError(t, os.WriteFile(path, mustMarshalEvent(t, event), filePermissions))
+
+		return collector, path
+	}
+
+	small, smallPath := newPendingEvent(map[string]any{"0": 0})
+	largeData := make(map[string]any, largeFieldCount)
+	for i := range largeFieldCount {
+		largeData[strconv.Itoa(i)] = i
+	}
+	large, largePath := newPendingEvent(largeData)
+
+	var smallErr error
+	smallAllocs := testing.AllocsPerRun(5, func() {
+		_, smallErr = small.readPendingEvent(smallPath)
+	})
+	require.NoError(t, smallErr)
+
+	var largeErr error
+	largeAllocs := testing.AllocsPerRun(5, func() {
+		_, largeErr = large.readPendingEvent(largePath)
+	})
+	require.NoError(t, largeErr)
+	require.LessOrEqual(t, largeAllocs, smallAllocs*maxAllocationRate)
+}
+
 func assertInboxCount(t *testing.T, dir string, count int) {
 	t.Helper()
 	entries, err := os.ReadDir(dir)


### PR DESCRIPTION
## Summary

Reduce collector memory pressure when draining inbox events with large payloads.

## Changes

- Decode pending event metadata without materializing the data map
- Preserve raw event JSON for append and full payload queries
- Add an allocation-scaling regression test

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved processing efficiency for pending events, including large event payloads.
  * Added safeguards to help maintain consistent resource usage as event size increases.

* **Tests**
  * Added coverage validating pending event processing for both small and large payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->