### PR TITLE
perf: cache retry candidate files

### DIFF
--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
@@ -32,7 +33,26 @@ type retryCandidateFile struct {
 	Status           ir.DAGRunStatus `json:"status"`
 }
 
+type retryCandidateCache struct {
+	mu      sync.Mutex
+	entries map[string]retryCandidateCacheEntry
+}
+
+type retryCandidateCacheEntry struct {
+	info      os.FileInfo
+	candidate retryCandidateFile
+}
+
+type retryCandidateScan struct {
+	previous map[string]retryCandidateCacheEntry
+	current  map[string]retryCandidateCacheEntry
+}
+
 func (store *Store) ListRetryCandidates(ctx context.Context, from persis.TimeInUTC) ([]*ir.DAGRunStatus, error) {
+	// A fresh snapshot drops candidate files no longer observed by the scan.
+	scan := store.retryCandidates.begin()
+	defer store.retryCandidates.finish(scan)
+
 	var candidates []*ir.DAGRunStatus
 
 	roots, err := store.listRoot(ctx, "")
@@ -49,7 +69,7 @@ func (store *Store) ListRetryCandidates(ctx context.Context, from persis.TimeInU
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			dayCandidates, err := store.listRetryCandidatesForDay(ctx, dayPath, from)
+			dayCandidates, err := store.listRetryCandidatesForDay(ctx, dayPath, from, scan)
 			if err != nil {
 				return nil, err
 			}
@@ -63,11 +83,11 @@ func (store *Store) ListRetryCandidates(ctx context.Context, from persis.TimeInU
 	return candidates, nil
 }
 
-func (store *Store) listRetryCandidatesForDay(ctx context.Context, dayPath string, from persis.TimeInUTC) ([]*ir.DAGRunStatus, error) {
-	return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, false)
+func (store *Store) listRetryCandidatesForDay(ctx context.Context, dayPath string, from persis.TimeInUTC, scan *retryCandidateScan) ([]*ir.DAGRunStatus, error) {
+	return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, scan, false)
 }
 
-func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, dayPath string, from persis.TimeInUTC, rebuiltCorruptCandidate bool) ([]*ir.DAGRunStatus, error) {
+func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, dayPath string, from persis.TimeInUTC, scan *retryCandidateScan, rebuiltCorruptCandidate bool) ([]*ir.DAGRunStatus, error) {
 	candidateDir := filepath.Join(dayPath, retryCandidateDirName)
 	needsRebuild, err := retryCandidatesNeedRebuild(dayPath)
 	if err != nil {
@@ -94,7 +114,7 @@ func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, d
 		}
 		candidateName := entry.Name()
 		candidatePath := filepath.Join(candidateDir, candidateName)
-		candidate, err := readRetryCandidateFile(candidateDir, candidateName)
+		candidate, err := scan.read(candidateDir, entry)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -111,13 +131,14 @@ func (store *Store) listRetryCandidatesForDayAfterRebuild(ctx context.Context, d
 			if err := rebuildRetryCandidatesForDay(ctx, dayPath, store.cache); err != nil {
 				return nil, err
 			}
-			return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, true)
+			return store.listRetryCandidatesForDayAfterRebuild(ctx, dayPath, from, scan, true)
 		}
 		exists, err := retryCandidateRunExists(dayPath, candidate)
 		if err != nil {
 			return nil, err
 		}
 		if !exists {
+			delete(scan.current, candidatePath)
 			if err := fileutil.Remove(candidatePath); err != nil && !os.IsNotExist(err) {
 				return nil, fmt.Errorf("remove stale retry candidate %s: %w", candidatePath, err)
 			}
@@ -261,13 +282,60 @@ func rebuildRetryCandidatesForDay(ctx context.Context, dayPath string, cache *fi
 	return nil
 }
 
-func readRetryCandidateFile(dir, name string) (*retryCandidateFile, error) {
+func (cache *retryCandidateCache) begin() *retryCandidateScan {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	return &retryCandidateScan{
+		previous: cache.entries,
+		current:  make(map[string]retryCandidateCacheEntry, len(cache.entries)),
+	}
+}
+
+func (cache *retryCandidateCache) finish(scan *retryCandidateScan) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	cache.entries = scan.current
+}
+
+func (scan *retryCandidateScan) read(dir string, entry os.DirEntry) (*retryCandidateFile, error) {
+	path := filepath.Join(dir, entry.Name())
+	info, err := entry.Info()
+	if err != nil {
+		return nil, err
+	}
+	if cached, ok := scan.previous[path]; ok && sameRetryCandidateFile(cached.info, info) {
+		scan.current[path] = cached
+		candidate := cached.candidate
+		return &candidate, nil
+	}
+
+	candidate, info, err := readRetryCandidateFile(dir, entry.Name())
+	if err != nil {
+		return nil, err
+	}
+	scan.current[path] = retryCandidateCacheEntry{
+		info:      info,
+		candidate: *candidate,
+	}
+	return candidate, nil
+}
+
+func sameRetryCandidateFile(cached, current os.FileInfo) bool {
+	return os.SameFile(cached, current) &&
+		cached.Size() == current.Size() &&
+		cached.Mode() == current.Mode() &&
+		cached.ModTime().Equal(current.ModTime())
+}
+
+func readRetryCandidateFile(dir, name string) (*retryCandidateFile, os.FileInfo, error) {
 	if filepath.Base(name) != name || !strings.HasSuffix(name, retryCandidateExt) {
-		return nil, fmt.Errorf("invalid retry candidate file name %q", name)
+		return nil, nil, fmt.Errorf("invalid retry candidate file name %q", name)
 	}
 	file, err := os.OpenInRoot(dir, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		_ = file.Close()
@@ -275,13 +343,17 @@ func readRetryCandidateFile(dir, name string) (*retryCandidateFile, error) {
 
 	data, err := io.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var candidate retryCandidateFile
 	if err := json.Unmarshal(data, &candidate); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &candidate, nil
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	return &candidate, info, nil
 }
 
 func retryCandidatePath(dayDir string, status ir.DAGRunStatus) string {

--- a/internal/persis/file/dagrun/retry_candidates_external_test.go
+++ b/internal/persis/file/dagrun/retry_candidates_external_test.go
@@ -5,6 +5,7 @@ package dagrun_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,6 +40,14 @@ func TestStoreListRetryCandidatesTracksFailedRunWrites(t *testing.T) {
 	assert.Equal(t, ir.Failed, candidates[0].Status)
 	assert.Equal(t, 2, candidates[0].AutoRetryLimit)
 	assert.NotEmpty(t, candidates[0].ProcGroup)
+
+	failedStatus.AutoRetryCount = 1
+	require.NoError(t, failedAttempt.Write(ctx, *failedStatus))
+
+	candidates, err = repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, 1, candidates[0].AutoRetryCount)
 
 	failedStatus.Status = ir.Queued
 	failedStatus.QueuedAt = now.Add(2 * time.Second).Format(time.RFC3339)
@@ -109,12 +118,16 @@ func TestStoreListRetryCandidatesRebuildsCorruptedCandidateFile(t *testing.T) {
 	attempt, _ := writeRetryCandidateStatus(t, ctx, repository, dag, now, "failed-run", ir.Failed)
 	defer func() { require.NoError(t, attempt.Close(ctx)) }()
 
+	candidates, err := repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+
 	entries, err := os.ReadDir(candidateDir)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	require.NoError(t, os.WriteFile(filepath.Join(candidateDir, entries[0].Name()), []byte("{"), 0600))
 
-	candidates, err := repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
+	candidates, err = repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
 	require.NoError(t, err)
 	require.Len(t, candidates, 1)
 	assert.Equal(t, "failed-run", candidates[0].DAGRunID)
@@ -132,11 +145,59 @@ func TestStoreListRetryCandidatesRemovesCandidateWhenRunIsGone(t *testing.T) {
 	attempt, _ := writeRetryCandidateStatus(t, ctx, repository, dag, now, "failed-run", ir.Failed)
 	require.NoError(t, attempt.Close(ctx))
 
-	require.NoError(t, repository.RemoveDAGRun(ctx, ir.NewDAGRunRef(dag.Name, "failed-run"), persis.DAGRunRemoveOptions{}))
-
 	candidates, err := repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
 	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+
+	require.NoError(t, repository.RemoveDAGRun(ctx, ir.NewDAGRunRef(dag.Name, "failed-run"), persis.DAGRunRemoveOptions{}))
+
+	candidates, err = repository.ListRetryCandidates(ctx, persis.NewUTC(now.Add(-time.Hour)))
+	require.NoError(t, err)
 	assert.Empty(t, candidates)
+}
+
+func TestStoreListRetryCandidatesCachesUnchangedFiles(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	repository := newFileRepository(baseDir, persis.DAGRunRepositoryOptions{LatestStatusToday: true})
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	dag := retryCandidateDAG()
+	for i := range 8 {
+		attempt, _ := writeRetryCandidateStatus(t, ctx, repository, dag, now.Add(time.Duration(i)*time.Second), fmt.Sprintf("failed-run-%d", i), ir.Failed)
+		require.NoError(t, attempt.Close(ctx))
+	}
+
+	candidateDir := filepath.Join(baseDir, dag.Name, "dag-runs", "2026", "06", "08", ".dagrun.retry-candidates")
+	entries, err := os.ReadDir(candidateDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 8)
+
+	var candidatePaths []string
+	for _, entry := range entries {
+		candidatePaths = append(candidatePaths, filepath.Join(candidateDir, entry.Name()))
+	}
+
+	from := persis.NewUTC(now.Add(-time.Hour))
+	var scanErr error
+	mtime := now
+	coldAllocs := testing.AllocsPerRun(5, func() {
+		mtime = mtime.Add(time.Second)
+		for _, path := range candidatePaths {
+			if err := os.Chtimes(path, mtime, mtime); err != nil {
+				scanErr = err
+				return
+			}
+		}
+		_, scanErr = repository.ListRetryCandidates(ctx, from)
+	})
+	require.NoError(t, scanErr)
+
+	warmAllocs := testing.AllocsPerRun(5, func() {
+		_, scanErr = repository.ListRetryCandidates(ctx, from)
+	})
+	require.NoError(t, scanErr)
+	assert.LessOrEqual(t, warmAllocs, coldAllocs*0.75)
 }
 
 func TestStoreListRetryCandidatesIgnoresChildAttemptStatusFiles(t *testing.T) {

--- a/internal/persis/file/dagrun/store.go
+++ b/internal/persis/file/dagrun/store.go
@@ -23,9 +23,10 @@ var _ persis.DAGRunStore = (*Store)(nil)
 
 // Store manages DAG run status files on the local filesystem.
 type Store struct {
-	baseDir     string
-	artifactDir string
-	cache       *fileutil.Cache[*ir.DAGRunStatus]
+	baseDir         string
+	artifactDir     string
+	cache           *fileutil.Cache[*ir.DAGRunStatus]
+	retryCandidates retryCandidateCache
 }
 
 // StoreOption configures filesystem DAG-run storage.


### PR DESCRIPTION
## Summary
- reuse unchanged retry candidate summaries across scans
- invalidate cached values when file identity or metadata changes
- bound the cache to candidate files seen by the latest scan

## Testing
- `go test -race ./internal/persis/file/dagrun -count=1`
- `make fmt`
- `make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches retry candidate file summaries across scans so unchanged files are not re-read from disk, reducing overhead on repeated listings.

- Cache entries are validated against file identity, size, mode, and modification time; any change invalidates the entry.
- Each scan starts with a fresh snapshot, so candidates no longer present are automatically dropped from the cache.

<sup>Written for commit d516fed9d0723362a45c5a6397466b197bb554a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry-candidate listings now reflect updated retry counts and remove entries for deleted runs.
  * Corrupted candidate files can be recovered during subsequent scans.
  * Unchanged candidate files are reused safely, improving repeated scan performance.

* **Tests**
  * Added coverage for status updates, corruption recovery, removed-run cleanup, and more efficient unchanged-file scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->