### PR TITLE
fix: compact retained event IDs

### DIFF
--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -6,6 +6,8 @@ package eventstore
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +26,15 @@ const (
 	defaultDrainInterval = time.Second
 	defaultCleanupEvery  = time.Hour
 	defaultBatchSize     = 256
+	dagEventIDPrefix     = "dag_"
+	dagUpdateIDPrefix    = "dag_update_"
+	llmEventIDPrefix     = "llm_"
+)
+
+const (
+	dagEventIDNamespace byte = iota + 1
+	dagUpdateIDNamespace
+	llmEventIDNamespace
 )
 
 type CollectorOption func(*Collector)
@@ -59,7 +70,83 @@ type Collector struct {
 	cleanupEvery  time.Duration
 	batchSize     int
 	now           func() time.Time
-	seenIDs       map[string]struct{}
+	seenIDs       seenSet
+}
+
+type eventIDKey [1 + sha256.Size]byte
+
+// seenSet compacts generated IDs while preserving unknown IDs exactly.
+type seenSet struct {
+	compact map[eventIDKey]struct{}
+	legacy  map[string]struct{}
+}
+
+func newSeenSet() seenSet {
+	return seenSet{
+		compact: make(map[eventIDKey]struct{}),
+		legacy:  make(map[string]struct{}),
+	}
+}
+
+func (s seenSet) has(id string) bool {
+	if key, ok := compactEventID(id); ok {
+		_, ok = s.compact[key]
+		return ok
+	}
+
+	_, ok := s.legacy[id]
+	return ok
+}
+
+func (s seenSet) add(id string) {
+	if key, ok := compactEventID(id); ok {
+		s.compact[key] = struct{}{}
+		return
+	}
+
+	s.legacy[id] = struct{}{}
+}
+
+func compactEventID(id string) (eventIDKey, bool) {
+	var key eventIDKey
+	var digest string
+	switch {
+	case strings.HasPrefix(id, dagUpdateIDPrefix):
+		key[0] = dagUpdateIDNamespace
+		digest = id[len(dagUpdateIDPrefix):]
+	case strings.HasPrefix(id, dagEventIDPrefix):
+		key[0] = dagEventIDNamespace
+		digest = id[len(dagEventIDPrefix):]
+	case strings.HasPrefix(id, llmEventIDPrefix):
+		key[0] = llmEventIDNamespace
+		digest = id[len(llmEventIDPrefix):]
+	default:
+		return eventIDKey{}, false
+	}
+
+	if len(digest) != hex.EncodedLen(sha256.Size) || !isLowerHex(digest) {
+		return eventIDKey{}, false
+	}
+	if _, err := hex.Decode(key[1:], []byte(digest)); err != nil {
+		return eventIDKey{}, false
+	}
+
+	return key, true
+}
+
+func isLowerHex(value string) bool {
+	for i := range len(value) {
+		char := value[i]
+		if char >= '0' && char <= '9' {
+			continue
+		}
+		if char >= 'a' && char <= 'f' {
+			continue
+		}
+		return false
+	}
+
+	return true
 }
 
 type pendingInboxEvent struct {
@@ -80,7 +167,7 @@ func NewCollector(baseDir string, retentionDays int, opts ...CollectorOption) (*
 		cleanupEvery:  defaultCleanupEvery,
 		batchSize:     defaultBatchSize,
 		now:           time.Now,
-		seenIDs:       make(map[string]struct{}),
+		seenIDs:       newSeenSet(),
 	}
 	for _, opt := range opts {
 		opt(collector)
@@ -151,7 +238,7 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 			c.quarantine(path, entry.Name(), err)
 			continue
 		}
-		if _, ok := c.seenIDs[pending.event.ID]; ok {
+		if c.seenIDs.has(pending.event.ID) {
 			if err := fileutil.Remove(path); err != nil && !os.IsNotExist(err) {
 				slog.Warn("fileeventstore: failed to delete duplicate inbox file",
 					slog.String("file", path),
@@ -201,7 +288,7 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 
 	removePersistedInboxFiles := func() {
 		for _, item := range group {
-			if _, ok := c.seenIDs[item.event.ID]; !ok {
+			if !c.seenIDs.has(item.event.ID) {
 				continue
 			}
 			if err := fileutil.Remove(item.path); err != nil && !os.IsNotExist(err) {
@@ -242,7 +329,7 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 	}
 
 	for _, item := range group {
-		c.seenIDs[item.event.ID] = struct{}{}
+		c.seenIDs.add(item.event.ID)
 	}
 	removePersistedInboxFiles()
 	return nil
@@ -330,7 +417,7 @@ func (c *Collector) loadSeenIDsFromFile(filePath string) error {
 			continue
 		}
 		if event.ID != "" {
-			c.seenIDs[event.ID] = struct{}{}
+			c.seenIDs.add(event.ID)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -403,7 +490,7 @@ func (c *Collector) cleanupExpired() {
 		}
 	}
 	if removedCommitted {
-		c.seenIDs = make(map[string]struct{})
+		c.seenIDs = newSeenSet()
 		if err := c.loadSeenIDs(); err != nil {
 			slog.Warn("fileeventstore: failed to rebuild seen-set after cleanup",
 				slog.String("dir", c.store.baseDir),

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -6,8 +6,10 @@ package eventstore
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,6 +18,59 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/stretchr/testify/require"
 )
+
+const benchmarkSeenIDCount = 100_000
+
+var benchmarkSeenIDs any
+
+func BenchmarkSeenIDsRetention(b *testing.B) {
+	for range b.N {
+		benchmarkSeenIDs = nil
+		runtime.GC()
+
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		seen := newSeenSet()
+		for i := range benchmarkSeenIDCount {
+			seen.add(fmt.Sprintf("dag_%064x", i))
+		}
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+		runtime.KeepAlive(seen)
+
+		bytesPerID := float64(after.HeapAlloc-before.HeapAlloc) / benchmarkSeenIDCount
+		b.ReportMetric(bytesPerID, "live-B/id")
+		benchmarkSeenIDs = seen
+	}
+}
+
+func TestSeenSetPreservesIDs(t *testing.T) {
+	t.Parallel()
+
+	digest := strings.Repeat("a", 64)
+	ids := []string{
+		"dag_" + digest,
+		"dag_update_" + digest,
+		"llm_" + digest,
+		"dag_" + strings.ToUpper(digest),
+		"dag_short",
+		"evt-legacy",
+	}
+
+	seen := newSeenSet()
+	for _, id := range ids {
+		require.False(t, seen.has(id), id)
+		seen.add(id)
+		require.True(t, seen.has(id), id)
+	}
+
+	for _, id := range ids {
+		require.True(t, seen.has(id), id)
+	}
+}
 
 func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.T) {
 	t.Parallel()
@@ -26,7 +81,7 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 
 	dayOne := time.Date(2026, 3, 28, 23, 0, 0, 0, time.UTC)
 	dayTwo := time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC)
-	eventOne := testEvent("evt-1", dayOne)
+	eventOne := testEvent("dag_"+strings.Repeat("a", 64), dayOne)
 	eventTwo := testEvent("evt-2", dayTwo)
 	eventTwo.DAGRunID = "run-2"
 
@@ -45,12 +100,13 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 	require.NoError(t, err)
 	require.NoError(t, restarted.loadSeenIDs())
 
-	duplicate := testEvent("evt-1", dayOne)
-	require.NoError(t, store.Emit(context.Background(), duplicate))
+	require.NoError(t, store.Emit(context.Background(), testEvent(eventOne.ID, dayOne)))
+	require.NoError(t, store.Emit(context.Background(), testEvent(eventTwo.ID, dayTwo)))
 	require.NoError(t, restarted.DrainOnce(context.Background()))
 
 	assertInboxCount(t, store.inboxDir, 0)
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032823.jsonl"), 1)
+	assertLogLineCount(t, filepath.Join(baseDir, "_2026032901.jsonl"), 1)
 }
 
 func TestCollectorDrainOncePreservesInboxAfterMalformedCommittedEvent(t *testing.T) {
@@ -75,8 +131,7 @@ func TestCollectorDrainOncePreservesInboxAfterMalformedCommittedEvent(t *testing
 	collector, err := NewCollector(baseDir, 10)
 	require.NoError(t, err)
 	require.NoError(t, collector.loadSeenIDs())
-	_, seen := collector.seenIDs[event.ID]
-	require.False(t, seen)
+	require.False(t, collector.seenIDs.has(event.ID))
 
 	require.NoError(t, collector.DrainOnce(context.Background()))
 	assertInboxCount(t, store.inboxDir, 0)
@@ -190,15 +245,15 @@ func TestCollectorCleanupExpiredRebuildsSeenIDs(t *testing.T) {
 	writeCommittedEvents(t, baseDir, recentEvent.OccurredAt, [][]byte{mustMarshalEvent(t, recentEvent)})
 
 	require.NoError(t, collector.loadSeenIDs())
-	_, hasExpired := collector.seenIDs[expiredEvent.ID]
-	_, hasRecent := collector.seenIDs[recentEvent.ID]
+	hasExpired := collector.seenIDs.has(expiredEvent.ID)
+	hasRecent := collector.seenIDs.has(recentEvent.ID)
 	require.True(t, hasExpired)
 	require.True(t, hasRecent)
 
 	collector.cleanupExpired()
 
-	_, hasExpired = collector.seenIDs[expiredEvent.ID]
-	_, hasRecent = collector.seenIDs[recentEvent.ID]
+	hasExpired = collector.seenIDs.has(expiredEvent.ID)
+	hasRecent = collector.seenIDs.has(recentEvent.ID)
 	require.False(t, hasExpired)
 	require.True(t, hasRecent)
 }
@@ -217,8 +272,7 @@ func TestCollectorLoadSeenIDsReadsLargeCommittedEventLine(t *testing.T) {
 	writeCommittedEvents(t, baseDir, event.OccurredAt, [][]byte{mustMarshalEvent(t, event)})
 
 	require.NoError(t, collector.loadSeenIDs())
-	_, ok := collector.seenIDs[event.ID]
-	require.True(t, ok)
+	require.True(t, collector.seenIDs.has(event.ID))
 }
 
 func TestCollectorSeenIDAllocs(t *testing.T) {


### PR DESCRIPTION
## Summary
- store canonical SHA-256 event IDs as compact comparable keys
- preserve exact handling for legacy and unknown IDs
- cover restart deduplication and retained heap usage

## Why
The collector retains one ID per event for the full retention window. Long string keys dominate its heap on high-volume stores.

## Testing
- `go test -race ./internal/persis/file/eventstore -count=1`
- `make test`
- `make fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores retained event IDs as compact binary keys to cut heap usage on high-volume stores. Generated IDs with known prefixes are compressed into a namespace byte plus SHA-256 digest; any other ID stays as the original string. Deduplication behavior and restart handling are unchanged.

<sup>Written for commit 358ed311c68005080933a58c1fdcaa82784211fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event deduplication to reliably recognize repeated event IDs, including after restarts and across multiple days.
  * Preserved compatibility with existing and legacy event IDs.
  * Reduced the storage overhead of tracking generated event IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->