### PR TITLE
fix: bound retry candidate cache

### DIFF
--- a/internal/persis/file/dagrun/export_test.go
+++ b/internal/persis/file/dagrun/export_test.go
@@ -14,3 +14,11 @@ func UpdateLatestAttemptPointerForTest(ctx context.Context, statusFile string) e
 func LatestAttemptPointerPathForTest(dagRunsDir string) string {
 	return latestAttemptPointerPath(dagRunsDir)
 }
+
+// RetryCandidateCacheSizeForTest reports retained retry candidate summaries.
+func RetryCandidateCacheSizeForTest(store *Store) int {
+	store.retryCandidates.mu.Lock()
+	defer store.retryCandidates.mu.Unlock()
+
+	return len(store.retryCandidates.entries)
+}

--- a/internal/persis/file/dagrun/retry_candidates.go
+++ b/internal/persis/file/dagrun/retry_candidates.go
@@ -35,6 +35,7 @@ type retryCandidateFile struct {
 
 type retryCandidateCache struct {
 	mu      sync.Mutex
+	limit   int
 	entries map[string]retryCandidateCacheEntry
 }
 
@@ -44,6 +45,7 @@ type retryCandidateCacheEntry struct {
 }
 
 type retryCandidateScan struct {
+	limit    int
 	previous map[string]retryCandidateCacheEntry
 	current  map[string]retryCandidateCacheEntry
 }
@@ -286,9 +288,14 @@ func (cache *retryCandidateCache) begin() *retryCandidateScan {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
+	if cache.limit <= 0 {
+		return &retryCandidateScan{}
+	}
+
 	return &retryCandidateScan{
+		limit:    cache.limit,
 		previous: cache.entries,
-		current:  make(map[string]retryCandidateCacheEntry, len(cache.entries)),
+		current:  make(map[string]retryCandidateCacheEntry, min(len(cache.entries), cache.limit)),
 	}
 }
 
@@ -306,7 +313,7 @@ func (scan *retryCandidateScan) read(dir string, entry os.DirEntry) (*retryCandi
 		return nil, err
 	}
 	if cached, ok := scan.previous[path]; ok && sameRetryCandidateFile(cached.info, info) {
-		scan.current[path] = cached
+		scan.remember(path, cached)
 		candidate := cached.candidate
 		return &candidate, nil
 	}
@@ -315,11 +322,21 @@ func (scan *retryCandidateScan) read(dir string, entry os.DirEntry) (*retryCandi
 	if err != nil {
 		return nil, err
 	}
-	scan.current[path] = retryCandidateCacheEntry{
+	scan.remember(path, retryCandidateCacheEntry{
 		info:      info,
 		candidate: *candidate,
-	}
+	})
 	return candidate, nil
+}
+
+func (scan *retryCandidateScan) remember(path string, entry retryCandidateCacheEntry) {
+	if scan.limit <= 0 {
+		return
+	}
+	if _, exists := scan.current[path]; !exists && len(scan.current) >= scan.limit {
+		return
+	}
+	scan.current[path] = entry
 }
 
 func sameRetryCandidateFile(cached, current os.FileInfo) bool {

--- a/internal/persis/file/dagrun/retry_candidates_external_test.go
+++ b/internal/persis/file/dagrun/retry_candidates_external_test.go
@@ -200,6 +200,46 @@ func TestStoreListRetryCandidatesCachesUnchangedFiles(t *testing.T) {
 	assert.LessOrEqual(t, warmAllocs, coldAllocs*0.75)
 }
 
+func TestStoreListRetryCandidatesBoundsCache(t *testing.T) {
+	tests := []struct {
+		name           string
+		limit          int
+		candidateCount int
+		expectedCache  int
+	}{
+		{name: "bounded", limit: 2, candidateCount: 3, expectedCache: 2},
+		{name: "disabled", limit: 0, candidateCount: 1, expectedCache: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			baseDir := t.TempDir()
+			store := filedagrun.NewStore(baseDir, filedagrun.WithRetryCandidateCacheLimit(tt.limit))
+			repository := persis.NewDAGRunRepository(
+				store,
+				filedagrun.NewWorkDirStore(filepath.Join(baseDir, ".dag-run-work"), baseDir),
+				persis.DAGRunRepositoryOptions{LatestStatusToday: true},
+			)
+
+			now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+			dag := retryCandidateDAG()
+			for i := range tt.candidateCount {
+				attempt, _ := writeRetryCandidateStatus(t, ctx, repository, dag, now.Add(time.Duration(i)*time.Second), fmt.Sprintf("failed-run-%d", i), ir.Failed)
+				require.NoError(t, attempt.Close(ctx))
+			}
+
+			from := persis.NewUTC(now.Add(-time.Hour))
+			for range 2 {
+				candidates, err := repository.ListRetryCandidates(ctx, from)
+				require.NoError(t, err)
+				assert.Len(t, candidates, tt.candidateCount)
+				assert.Equal(t, tt.expectedCache, filedagrun.RetryCandidateCacheSizeForTest(store))
+			}
+		})
+	}
+}
+
 func TestStoreListRetryCandidatesIgnoresChildAttemptStatusFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persis/file/dagrun/store.go
+++ b/internal/persis/file/dagrun/store.go
@@ -21,6 +21,8 @@ import (
 
 var _ persis.DAGRunStore = (*Store)(nil)
 
+const defaultRetryCandidateCacheLimit = 2000
+
 // Store manages DAG run status files on the local filesystem.
 type Store struct {
 	baseDir         string
@@ -33,8 +35,9 @@ type Store struct {
 type StoreOption func(*options)
 
 type options struct {
-	fileCache   *fileutil.Cache[*ir.DAGRunStatus]
-	artifactDir string
+	fileCache                *fileutil.Cache[*ir.DAGRunStatus]
+	artifactDir              string
+	retryCandidateCacheLimit int
 }
 
 // WithHistoryFileCache sets the file cache for Store.
@@ -51,9 +54,17 @@ func WithArtifactDir(dir string) StoreOption {
 	}
 }
 
+// WithRetryCandidateCacheLimit limits retained retry candidate summaries.
+func WithRetryCandidateCacheLimit(limit int) StoreOption {
+	return func(o *options) {
+		o.retryCandidateCacheLimit = limit
+	}
+}
+
 func newOptions(baseDir string, opts []StoreOption) options {
 	cfg := options{
-		artifactDir: filepath.Join(filepath.Dir(filepath.Clean(baseDir)), "artifacts"),
+		artifactDir:              filepath.Join(filepath.Dir(filepath.Clean(baseDir)), "artifacts"),
+		retryCandidateCacheLimit: defaultRetryCandidateCacheLimit,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -67,9 +78,10 @@ func newOptions(baseDir string, opts []StoreOption) options {
 func NewStore(baseDir string, opts ...StoreOption) *Store {
 	cfg := newOptions(baseDir, opts)
 	return &Store{
-		baseDir:     baseDir,
-		artifactDir: cfg.artifactDir,
-		cache:       cfg.fileCache,
+		baseDir:         baseDir,
+		artifactDir:     cfg.artifactDir,
+		cache:           cfg.fileCache,
+		retryCandidates: retryCandidateCache{limit: cfg.retryCandidateCacheLimit},
 	}
 }
 

--- a/internal/persis/file/dagrun_repository.go
+++ b/internal/persis/file/dagrun_repository.go
@@ -54,6 +54,7 @@ func NewDAGRunRepository(cfg *config.Config, opts ...DAGRunRepositoryOption) *pe
 
 	storeOpts := []filedagrun.StoreOption{
 		filedagrun.WithArtifactDir(cfg.Paths.ArtifactDir),
+		filedagrun.WithRetryCandidateCacheLimit(cfg.Cache.Limits().DAGRun.Limit),
 	}
 	if options.HistoryFileCache != nil {
 		storeOpts = append(storeOpts, filedagrun.WithHistoryFileCache(options.HistoryFileCache))


### PR DESCRIPTION
## Summary
- cap retry candidate snapshots with existing DAG-run cache limits
- keep returning overflow candidates without retaining them
- allow non-positive limits to disable the cache

Follow-up to #2622.

## Testing
- `go test -race ./internal/persis/file/dagrun -count=1`
- `go test -race ./internal/service/scheduler -count=1`
- `make fmt`
- `make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the retry candidate cache to existing DAG-run cache limits so failure spikes can't leave unbounded heap behind; overflow candidates are still returned but not retained.

**Changes**
- Adds `WithRetryCandidateCacheLimit` to `Store`; the limit defaults to the DAG-run cache limit and non-positive values disable the cache.
- Updates the repository to pass the configured DAG-run cache limit as the retry candidate cache limit.

<sup>Written for commit 5b9f1fafa5dea0616d1cd1a77c90a091c23b1504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable limit for cached retry candidates, with a default maximum of 2,000 entries.
  - Cache limits can now be adjusted through application configuration.
  - Setting the limit to zero disables retry-candidate caching.
- **Improvements**
  - Retry-candidate cache usage is now bounded, helping control memory consumption during repeated DAG run listings.
  - Cache behavior is applied consistently to both previously cached and newly discovered candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->