### PR TITLE
Fix router diagnostic value resolution

### DIFF
--- a/internal/intg/router_test.go
+++ b/internal/intg/router_test.go
@@ -4,6 +4,7 @@
 package intg_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/internal/ir"
@@ -246,6 +247,80 @@ steps:
 			dag.AssertLatestStatus(t, tc.expectedStatus)
 			if tc.expectedOutputs != nil {
 				dag.AssertOutputs(t, tc.expectedOutputs)
+			}
+		})
+	}
+}
+
+func TestRouterLogsResolvedValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dagYAML string
+	}{
+		{
+			name: "DAGRunID",
+			dagYAML: `
+type: graph
+steps:
+  - id: route
+    action: router.route
+    with:
+      value: ${env.DAG_RUN_ID}
+      routes:
+        "TEST_ROUTE": [target]
+
+  - id: target
+    run: echo routed
+`,
+		},
+		{
+			name: "DeclaredStepOutput",
+			dagYAML: `
+type: graph
+steps:
+  - id: extract_properties
+    run: ` + test.ForOS(
+				`printf 'routing_value=TEST_ROUTE\n' >> "$DAGU_OUTPUT_FILE"`,
+				`Set-Content -Path $env:DAGU_OUTPUT_FILE -Value 'routing_value=TEST_ROUTE'`,
+			) + `
+    outputs:
+      - name: routing_value
+
+  - id: route
+    depends: [extract_properties]
+    action: router.route
+    with:
+      value: ${steps.extract_properties.outputs.routing_value}
+      routes:
+        "TEST_ROUTE": [target]
+
+  - id: target
+    run: echo routed
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := test.Setup(t)
+			dag := th.DAG(t, tc.dagYAML)
+			agent := dag.Agent(test.WithDAGRunID("TEST_ROUTE"))
+			agent.RunSuccess(t)
+
+			status := agent.Status(agent.Context)
+			for _, node := range status.Nodes {
+				switch node.Step.ID {
+				case "route":
+					stdout, err := os.ReadFile(node.Stdout)
+					require.NoError(t, err)
+					require.Contains(t, string(stdout), "Router evaluating: TEST_ROUTE\n")
+				case "target":
+					require.Equal(t, ir.NodeSucceeded, node.Status)
+				}
 			}
 		})
 	}

--- a/internal/runtime/builtin/router/router.go
+++ b/internal/runtime/builtin/router/router.go
@@ -9,9 +9,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/masking"
+	cmnvalue "github.com/dagucloud/dagu/v2/internal/cmn/value"
 	"github.com/dagucloud/dagu/v2/internal/executor/registry"
-
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/runtime"
 	"github.com/dagucloud/dagu/v2/internal/runtime/executor"
 )
 
@@ -33,14 +35,33 @@ func (e *routerExecutor) SetStdout(out io.Writer) { e.stdout = out }
 func (e *routerExecutor) SetStderr(_ io.Writer)   {}
 func (*routerExecutor) Kill(_ os.Signal) error    { return nil }
 
-func (e *routerExecutor) Run(_ context.Context) error {
+func (e *routerExecutor) Run(ctx context.Context) error {
 	if e.step.Router != nil {
-		_, _ = fmt.Fprintf(e.stdout, "Router evaluating: %s\n", e.step.Router.Value)
+		// Resolve the diagnostic with the same value policy used by route preconditions.
+		value, err := runtime.ResolveString(ctx, e.step.Router.Value, cmnvalue.ConditionRuntimeValueField("with.value"))
+		if err != nil {
+			return fmt.Errorf("failed to evaluate router value: %w", err)
+		}
+
+		// Mask before writing so every output backend receives safe diagnostics.
+		masker := secretMasker(ctx)
+		_, _ = fmt.Fprintf(e.stdout, "Router evaluating: %s\n", masker.MaskString(value))
 		for _, route := range e.step.Router.Routes {
-			_, _ = fmt.Fprintf(e.stdout, "  %s -> %v\n", route.Pattern, route.Targets)
+			line := fmt.Sprintf("  %s -> %v\n", route.Pattern, route.Targets)
+			_, _ = fmt.Fprint(e.stdout, masker.MaskString(line))
 		}
 	}
 	return nil
+}
+
+func secretMasker(ctx context.Context) *masking.Masker {
+	secrets := runtime.GetDAGContext(ctx).EnvScope.AllSecrets()
+	envs := make([]string, 0, len(secrets))
+	for name, value := range secrets {
+		envs = append(envs, name+"="+value)
+	}
+
+	return masking.NewMasker(masking.SourcedEnvVars{Secrets: envs})
 }
 
 func init() {

--- a/internal/runtime/builtin/router/router_test.go
+++ b/internal/runtime/builtin/router/router_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMasksResolvedSecret(t *testing.T) {
+	t.Parallel()
+
+	const secret = "router-secret-value"
+
+	ctx := runtime.NewContext(
+		context.Background(),
+		&ir.DAG{Name: "router-secret"},
+		"run-id",
+		"dag.log",
+		runtime.WithSecrets([]string{"ROUTE_SECRET=" + secret}),
+	)
+	exec, err := newRouter(ctx, ir.Step{
+		Router: &ir.RouterConfig{
+			Value: "${ROUTE_SECRET}",
+			Routes: []ir.RouteEntry{
+				{Pattern: secret, Targets: []string{secret}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	exec.SetStdout(&stdout)
+	require.NoError(t, exec.Run(ctx))
+
+	require.Equal(t, "Router evaluating: *******\n  ******* -> [*******]\n", stdout.String())
+}


### PR DESCRIPTION
## Summary

- Resolve router diagnostics with the same runtime policy as route preconditions.
- Mask declared secrets before writing router diagnostics.
- Cover DAG run IDs, declared step outputs, and secret masking.

## Testing

- make fmt
- make test
- go test ./internal/runtime/builtin/router -count=1
- go test ./internal/intg -run TestRouter -count=1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves router diagnostic values before printing so stdout shows the actual runtime value (e.g., DAG run ID or declared step output) instead of the raw `${...}` expression. Declared secrets are masked before diagnostics are written.

- Added tests covering DAG run IDs, declared step outputs, and secret masking.

<sup>Written for commit 8fdb5d79bccb9f8a2c990544feaad131ca579d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Router evaluations now consistently resolve configured values before selecting a route.
  - Clear evaluation errors are reported when a value cannot be resolved.
  - Sensitive values are masked in router diagnostics, evaluation output, and route details.
  - Improved cross-platform behavior for router execution on Unix and Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->