### PR TITLE
fix: bound event deduplication memory

### DIFF
--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -130,6 +130,7 @@ func runStartAll(ctx *Context, _ []string) error {
 		eventCollector, err := fileeventstore.NewCollector(
 			serviceCtx.Config.Paths.EventStoreDir,
 			serviceCtx.Config.EventStore.RetentionDays,
+			fileeventstore.WithDedupeCacheBytes(serviceCtx.Config.Cache.Limits().EventStoreBytes),
 		)
 		if err != nil {
 			logger.Warn(serviceCtx, "Failed to initialize event collector; continuing without collection", tag.Error(err))

--- a/internal/cmn/config/cache.go
+++ b/internal/cmn/config/cache.go
@@ -12,15 +12,20 @@ const (
 	CacheModeLow    CacheMode = "low"
 	CacheModeNormal CacheMode = "normal"
 	CacheModeHigh   CacheMode = "high"
+
+	eventStoreCacheLowBytes    = 8 << 20
+	eventStoreCacheNormalBytes = 16 << 20
+	eventStoreCacheHighBytes   = 32 << 20
 )
 
 // CacheLimits contains the cache limits for each cache type
 type CacheLimits struct {
-	DAG     CacheEntryLimits
-	DAGRun  CacheEntryLimits
-	User    CacheEntryLimits
-	APIKey  CacheEntryLimits
-	Webhook CacheEntryLimits
+	DAG             CacheEntryLimits
+	DAGRun          CacheEntryLimits
+	User            CacheEntryLimits
+	APIKey          CacheEntryLimits
+	Webhook         CacheEntryLimits
+	EventStoreBytes int
 }
 
 // CacheEntryLimits contains limit and TTL for a cache
@@ -34,27 +39,30 @@ func (m CacheMode) Limits() CacheLimits {
 	switch m {
 	case CacheModeLow:
 		return CacheLimits{
-			DAG:     CacheEntryLimits{Limit: 500, TTL: 12 * time.Hour},
-			DAGRun:  CacheEntryLimits{Limit: 1000, TTL: time.Hour},
-			User:    CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
-			APIKey:  CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
-			Webhook: CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
+			DAG:             CacheEntryLimits{Limit: 500, TTL: 12 * time.Hour},
+			DAGRun:          CacheEntryLimits{Limit: 1000, TTL: time.Hour},
+			User:            CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
+			APIKey:          CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
+			Webhook:         CacheEntryLimits{Limit: 100, TTL: 15 * time.Minute},
+			EventStoreBytes: eventStoreCacheLowBytes,
 		}
 	case CacheModeHigh:
 		return CacheLimits{
-			DAG:     CacheEntryLimits{Limit: 5000, TTL: 12 * time.Hour},
-			DAGRun:  CacheEntryLimits{Limit: 5000, TTL: time.Hour},
-			User:    CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
-			APIKey:  CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
-			Webhook: CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
+			DAG:             CacheEntryLimits{Limit: 5000, TTL: 12 * time.Hour},
+			DAGRun:          CacheEntryLimits{Limit: 5000, TTL: time.Hour},
+			User:            CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
+			APIKey:          CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
+			Webhook:         CacheEntryLimits{Limit: 1000, TTL: 15 * time.Minute},
+			EventStoreBytes: eventStoreCacheHighBytes,
 		}
 	default: // CacheModeNormal or any invalid value defaults to normal
 		return CacheLimits{
-			DAG:     CacheEntryLimits{Limit: 1000, TTL: 12 * time.Hour},
-			DAGRun:  CacheEntryLimits{Limit: 2000, TTL: time.Hour},
-			User:    CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
-			APIKey:  CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
-			Webhook: CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
+			DAG:             CacheEntryLimits{Limit: 1000, TTL: 12 * time.Hour},
+			DAGRun:          CacheEntryLimits{Limit: 2000, TTL: time.Hour},
+			User:            CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
+			APIKey:          CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
+			Webhook:         CacheEntryLimits{Limit: 500, TTL: 15 * time.Minute},
+			EventStoreBytes: eventStoreCacheNormalBytes,
 		}
 	}
 }

--- a/internal/cmn/config/cache_test.go
+++ b/internal/cmn/config/cache_test.go
@@ -48,6 +48,7 @@ func TestCacheMode_Limits_Low(t *testing.T) {
 
 	assert.Equal(t, 100, limits.Webhook.Limit)
 	assert.Equal(t, 15*time.Minute, limits.Webhook.TTL)
+	assert.Equal(t, 8<<20, limits.EventStoreBytes)
 }
 
 func TestCacheMode_Limits_Normal(t *testing.T) {
@@ -66,6 +67,7 @@ func TestCacheMode_Limits_Normal(t *testing.T) {
 
 	assert.Equal(t, 500, limits.Webhook.Limit)
 	assert.Equal(t, 15*time.Minute, limits.Webhook.TTL)
+	assert.Equal(t, 16<<20, limits.EventStoreBytes)
 }
 
 func TestCacheMode_Limits_High(t *testing.T) {
@@ -84,6 +86,7 @@ func TestCacheMode_Limits_High(t *testing.T) {
 
 	assert.Equal(t, 1000, limits.Webhook.Limit)
 	assert.Equal(t, 15*time.Minute, limits.Webhook.TTL)
+	assert.Equal(t, 32<<20, limits.EventStoreBytes)
 }
 
 func TestCacheMode_Limits_Invalid_DefaultsToNormal(t *testing.T) {
@@ -97,6 +100,7 @@ func TestCacheMode_Limits_Invalid_DefaultsToNormal(t *testing.T) {
 	assert.Equal(t, normalLimits.DAGRun.Limit, limits.DAGRun.Limit)
 	assert.Equal(t, normalLimits.APIKey.Limit, limits.APIKey.Limit)
 	assert.Equal(t, normalLimits.Webhook.Limit, limits.Webhook.Limit)
+	assert.Equal(t, normalLimits.EventStoreBytes, limits.EventStoreBytes)
 }
 
 func TestCacheMode_Constants(t *testing.T) {

--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -6,6 +6,8 @@ package eventstore
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,9 +23,11 @@ import (
 )
 
 const (
-	defaultDrainInterval = time.Second
-	defaultCleanupEvery  = time.Hour
-	defaultBatchSize     = 256
+	defaultDrainInterval    = time.Second
+	defaultCleanupEvery     = time.Hour
+	defaultBatchSize        = 256
+	defaultDedupeCacheBytes = 16 << 20
+	dedupeHashCount         = 7
 )
 
 type CollectorOption func(*Collector)
@@ -52,13 +56,59 @@ func WithNow(now func() time.Time) CollectorOption {
 	}
 }
 
+func WithDedupeCacheBytes(size int) CollectorOption {
+	return func(c *Collector) {
+		if size > 0 {
+			c.dedupeCacheBytes = size
+		}
+	}
+}
+
 type Collector struct {
-	store         *Store
-	retentionDays int
-	drainInterval time.Duration
-	cleanupEvery  time.Duration
-	batchSize     int
-	now           func() time.Time
+	store            *Store
+	retentionDays    int
+	drainInterval    time.Duration
+	cleanupEvery     time.Duration
+	batchSize        int
+	dedupeCacheBytes int
+	now              func() time.Time
+	committedIDs     *eventIDFilter
+}
+
+type eventIDFilter struct {
+	bits []byte
+}
+
+func newEventIDFilter(size int) *eventIDFilter {
+	return &eventIDFilter{bits: make([]byte, max(size, 1))}
+}
+
+func (f *eventIDFilter) add(id string) {
+	for _, bit := range f.positions(id) {
+		f.bits[bit/8] |= 1 << uint(bit%8)
+	}
+}
+
+func (f *eventIDFilter) mayContain(id string) bool {
+	for _, bit := range f.positions(id) {
+		if f.bits[bit/8]&(1<<uint(bit%8)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *eventIDFilter) positions(id string) [dedupeHashCount]uint64 {
+	sum := sha256.Sum256([]byte(id))
+	first := binary.LittleEndian.Uint64(sum[:8])
+	second := binary.LittleEndian.Uint64(sum[8:16]) | 1
+	bitCount := uint64(len(f.bits)) * 8
+
+	var positions [dedupeHashCount]uint64
+	for i := range positions {
+		positions[i] = (first + uint64(i)*second) % bitCount
+	}
+	return positions
 }
 
 type pendingInboxEvent struct {
@@ -73,12 +123,13 @@ func NewCollector(baseDir string, retentionDays int, opts ...CollectorOption) (*
 		return nil, err
 	}
 	collector := &Collector{
-		store:         store,
-		retentionDays: retentionDays,
-		drainInterval: defaultDrainInterval,
-		cleanupEvery:  defaultCleanupEvery,
-		batchSize:     defaultBatchSize,
-		now:           time.Now,
+		store:            store,
+		retentionDays:    retentionDays,
+		drainInterval:    defaultDrainInterval,
+		cleanupEvery:     defaultCleanupEvery,
+		batchSize:        defaultBatchSize,
+		dedupeCacheBytes: defaultDedupeCacheBytes,
+		now:              time.Now,
 	}
 	for _, opt := range opts {
 		opt(collector)
@@ -116,6 +167,10 @@ func (c *Collector) Start(ctx context.Context) {
 }
 
 func (c *Collector) DrainOnce(_ context.Context) error {
+	if err := c.ensureCommittedIDs(); err != nil {
+		return err
+	}
+
 	entries, err := os.ReadDir(c.store.inboxDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -124,7 +179,7 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 		return fmt.Errorf("read inbox directory: %w", err)
 	}
 
-	var pendingByHour = make(map[string][]pendingInboxEvent)
+	var pendingEvents []pendingInboxEvent
 	queuedIDs := make(map[string]struct{})
 	processed := 0
 	for _, entry := range entries {
@@ -152,13 +207,41 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 			}
 			continue
 		}
-		hour := pending.event.OccurredAt.UTC().Format(hourFormat)
-		pendingByHour[hour] = append(pendingByHour[hour], pending)
+		pendingEvents = append(pendingEvents, pending)
 		queuedIDs[pending.event.ID] = struct{}{}
 	}
 
-	if len(pendingByHour) == 0 {
+	if len(pendingEvents) == 0 {
 		return nil
+	}
+
+	// Filter matches require exact verification because false positives are possible.
+	possibleDuplicates := make(map[string]struct{})
+	for _, item := range pendingEvents {
+		if c.committedIDs.mayContain(item.event.ID) {
+			possibleDuplicates[item.event.ID] = struct{}{}
+		}
+	}
+	committedIDs := make(map[string]struct{})
+	if len(possibleDuplicates) > 0 {
+		files, err := c.store.listCommittedFiles(time.Time{}, time.Time{})
+		if err != nil {
+			return err
+		}
+		committedIDs, err = c.findCommittedIDsInFiles(files, possibleDuplicates)
+		if err != nil {
+			return err
+		}
+	}
+
+	pendingByHour := make(map[string][]pendingInboxEvent)
+	for _, item := range pendingEvents {
+		if _, ok := committedIDs[item.event.ID]; ok {
+			c.removeInboxFile(item.path)
+			continue
+		}
+		hour := item.event.OccurredAt.UTC().Format(hourFormat)
+		pendingByHour[hour] = append(pendingByHour[hour], item)
 	}
 
 	hours := make([]string, 0, len(pendingByHour))
@@ -183,23 +266,6 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 		pendingIDs[item.event.ID] = struct{}{}
 	}
 
-	// Deduplication stays bounded by the current batch and its hourly log.
-	committedIDs, err := c.findCommittedIDs(logPath, pendingIDs)
-	if err != nil {
-		return err
-	}
-	remaining := group[:0]
-	for _, item := range group {
-		if _, ok := committedIDs[item.event.ID]; ok {
-			c.removeInboxFile(item.path)
-			continue
-		}
-		remaining = append(remaining, item)
-	}
-	if len(remaining) == 0 {
-		return nil
-	}
-
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, filePermissions) //nolint:gosec // controlled path
 	if err != nil {
 		return fmt.Errorf("open event log %s: %w", logPath, err)
@@ -209,20 +275,22 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 	removePersistedInboxFiles := func() {
 		ids, err := c.findCommittedIDs(logPath, pendingIDs)
 		if err != nil {
+			c.committedIDs = nil
 			slog.Warn("fileeventstore: failed to check persisted events after append error",
 				slog.String("file", logPath),
 				slog.String("error", err.Error()))
 			return
 		}
-		for _, item := range remaining {
+		for _, item := range group {
 			if _, ok := ids[item.event.ID]; ok {
+				c.committedIDs.add(item.event.ID)
 				c.removeInboxFile(item.path)
 			}
 		}
 	}
 
 	writer := bufio.NewWriter(f)
-	for _, item := range remaining {
+	for _, item := range group {
 		if _, err := writer.Write(item.raw); err != nil {
 			removePersistedInboxFiles()
 			return fmt.Errorf("append event log %s: %w", logPath, err)
@@ -241,20 +309,44 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 		return fmt.Errorf("sync event log %s: %w", logPath, err)
 	}
 
-	for _, item := range remaining {
+	for _, item := range group {
+		c.committedIDs.add(item.event.ID)
 		c.removeInboxFile(item.path)
 	}
 	return nil
 }
 
 func (c *Collector) findCommittedIDs(filePath string, pendingIDs map[string]struct{}) (map[string]struct{}, error) {
+	return c.findCommittedIDsInFiles([]string{filePath}, pendingIDs)
+}
+
+func (c *Collector) findCommittedIDsInFiles(filePaths []string, pendingIDs map[string]struct{}) (map[string]struct{}, error) {
 	committedIDs := make(map[string]struct{}, len(pendingIDs))
+	for _, filePath := range filePaths {
+		err := c.scanCommittedIDs(filePath, func(id string) bool {
+			if _, ok := pendingIDs[id]; !ok {
+				return true
+			}
+			committedIDs[id] = struct{}{}
+			return len(committedIDs) < len(pendingIDs)
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(committedIDs) == len(pendingIDs) {
+			break
+		}
+	}
+	return committedIDs, nil
+}
+
+func (c *Collector) scanCommittedIDs(filePath string, visit func(string) bool) error {
 	f, err := os.Open(filePath) //nolint:gosec // controlled path
 	if err != nil {
 		if os.IsNotExist(err) {
-			return committedIDs, nil
+			return nil
 		}
-		return nil, fmt.Errorf("open event log %s: %w", filePath, err)
+		return fmt.Errorf("open event log %s: %w", filePath, err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -274,18 +366,39 @@ func (c *Collector) findCommittedIDs(filePath string, pendingIDs map[string]stru
 				slog.String("error", err.Error()))
 			continue
 		}
-		if _, ok := pendingIDs[event.ID]; !ok {
-			continue
-		}
-		committedIDs[event.ID] = struct{}{}
-		if len(committedIDs) == len(pendingIDs) {
+		if event.ID != "" && !visit(event.ID) {
 			break
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan event log %s: %w", filePath, err)
+		return fmt.Errorf("scan event log %s: %w", filePath, err)
 	}
-	return committedIDs, nil
+	return nil
+}
+
+func (c *Collector) ensureCommittedIDs() error {
+	if c.committedIDs != nil {
+		return nil
+	}
+	return c.rebuildCommittedIDs()
+}
+
+func (c *Collector) rebuildCommittedIDs() error {
+	files, err := c.store.listCommittedFiles(time.Time{}, time.Time{})
+	if err != nil {
+		return err
+	}
+	filter := newEventIDFilter(c.dedupeCacheBytes)
+	for _, filePath := range files {
+		if err := c.scanCommittedIDs(filePath, func(id string) bool {
+			filter.add(id)
+			return true
+		}); err != nil {
+			return err
+		}
+	}
+	c.committedIDs = filter
+	return nil
 }
 
 func (c *Collector) removeInboxFile(path string) {
@@ -344,6 +457,7 @@ func (c *Collector) cleanupExpired() {
 	now := c.now().UTC()
 	cutoff := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).
 		AddDate(0, 0, -c.retentionDays)
+	removedCommitted := false
 	baseEntries, err := os.ReadDir(c.store.baseDir)
 	if err == nil {
 		for _, entry := range baseEntries {
@@ -359,12 +473,22 @@ func (c *Collector) cleanupExpired() {
 				slog.Warn("fileeventstore: failed to remove expired event log",
 					slog.String("file", path),
 					slog.String("error", err.Error()))
+			} else {
+				removedCommitted = true
 			}
 		}
 	} else if !os.IsNotExist(err) {
 		slog.Warn("fileeventstore: failed to read event store directory for cleanup",
 			slog.String("dir", c.store.baseDir),
 			slog.String("error", err.Error()))
+	}
+
+	if removedCommitted {
+		if err := c.rebuildCommittedIDs(); err != nil {
+			slog.Warn("fileeventstore: failed to rebuild committed event filter after cleanup",
+				slog.String("dir", c.store.baseDir),
+				slog.String("error", err.Error()))
+		}
 	}
 
 	quarantineEntries, err := os.ReadDir(c.store.quarantineDir)

--- a/internal/persis/file/eventstore/collector.go
+++ b/internal/persis/file/eventstore/collector.go
@@ -6,8 +6,6 @@ package eventstore
 import (
 	"bufio"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,15 +24,6 @@ const (
 	defaultDrainInterval = time.Second
 	defaultCleanupEvery  = time.Hour
 	defaultBatchSize     = 256
-	dagEventIDPrefix     = "dag_"
-	dagUpdateIDPrefix    = "dag_update_"
-	llmEventIDPrefix     = "llm_"
-)
-
-const (
-	dagEventIDNamespace byte = iota + 1
-	dagUpdateIDNamespace
-	llmEventIDNamespace
 )
 
 type CollectorOption func(*Collector)
@@ -70,83 +59,6 @@ type Collector struct {
 	cleanupEvery  time.Duration
 	batchSize     int
 	now           func() time.Time
-	seenIDs       seenSet
-}
-
-type eventIDKey [1 + sha256.Size]byte
-
-// seenSet compacts generated IDs while preserving unknown IDs exactly.
-type seenSet struct {
-	compact map[eventIDKey]struct{}
-	legacy  map[string]struct{}
-}
-
-func newSeenSet() seenSet {
-	return seenSet{
-		compact: make(map[eventIDKey]struct{}),
-		legacy:  make(map[string]struct{}),
-	}
-}
-
-func (s seenSet) has(id string) bool {
-	if key, ok := compactEventID(id); ok {
-		_, ok = s.compact[key]
-		return ok
-	}
-
-	_, ok := s.legacy[id]
-	return ok
-}
-
-func (s seenSet) add(id string) {
-	if key, ok := compactEventID(id); ok {
-		s.compact[key] = struct{}{}
-		return
-	}
-
-	s.legacy[id] = struct{}{}
-}
-
-func compactEventID(id string) (eventIDKey, bool) {
-	var key eventIDKey
-	var digest string
-	switch {
-	case strings.HasPrefix(id, dagUpdateIDPrefix):
-		key[0] = dagUpdateIDNamespace
-		digest = id[len(dagUpdateIDPrefix):]
-	case strings.HasPrefix(id, dagEventIDPrefix):
-		key[0] = dagEventIDNamespace
-		digest = id[len(dagEventIDPrefix):]
-	case strings.HasPrefix(id, llmEventIDPrefix):
-		key[0] = llmEventIDNamespace
-		digest = id[len(llmEventIDPrefix):]
-	default:
-		return eventIDKey{}, false
-	}
-
-	if len(digest) != hex.EncodedLen(sha256.Size) || !isLowerHex(digest) {
-		return eventIDKey{}, false
-	}
-	if _, err := hex.Decode(key[1:], []byte(digest)); err != nil {
-		return eventIDKey{}, false
-	}
-
-	return key, true
-}
-
-func isLowerHex(value string) bool {
-	for i := range len(value) {
-		char := value[i]
-		if char >= '0' && char <= '9' {
-			continue
-		}
-		if char >= 'a' && char <= 'f' {
-			continue
-		}
-		return false
-	}
-
-	return true
 }
 
 type pendingInboxEvent struct {
@@ -167,7 +79,6 @@ func NewCollector(baseDir string, retentionDays int, opts ...CollectorOption) (*
 		cleanupEvery:  defaultCleanupEvery,
 		batchSize:     defaultBatchSize,
 		now:           time.Now,
-		seenIDs:       newSeenSet(),
 	}
 	for _, opt := range opts {
 		opt(collector)
@@ -177,11 +88,6 @@ func NewCollector(baseDir string, retentionDays int, opts ...CollectorOption) (*
 
 func (c *Collector) Start(ctx context.Context) {
 	c.cleanupExpired()
-	if err := c.loadSeenIDs(); err != nil {
-		slog.Warn("fileeventstore: failed to initialize seen-set",
-			slog.String("dir", c.store.baseDir),
-			slog.String("error", err.Error()))
-	}
 	if err := c.DrainOnce(ctx); err != nil {
 		slog.Warn("fileeventstore: initial drain failed",
 			slog.String("dir", c.store.baseDir),
@@ -238,14 +144,6 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 			c.quarantine(path, entry.Name(), err)
 			continue
 		}
-		if c.seenIDs.has(pending.event.ID) {
-			if err := fileutil.Remove(path); err != nil && !os.IsNotExist(err) {
-				slog.Warn("fileeventstore: failed to delete duplicate inbox file",
-					slog.String("file", path),
-					slog.String("error", err.Error()))
-			}
-			continue
-		}
 		if _, ok := queuedIDs[pending.event.ID]; ok {
 			if err := fileutil.Remove(path); err != nil && !os.IsNotExist(err) {
 				slog.Warn("fileeventstore: failed to delete duplicate inbox file",
@@ -280,6 +178,28 @@ func (c *Collector) DrainOnce(_ context.Context) error {
 
 func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 	logPath := filepath.Join(c.store.baseDir, logPrefix+hour+logSuffix)
+	pendingIDs := make(map[string]struct{}, len(group))
+	for _, item := range group {
+		pendingIDs[item.event.ID] = struct{}{}
+	}
+
+	// Deduplication stays bounded by the current batch and its hourly log.
+	committedIDs, err := c.findCommittedIDs(logPath, pendingIDs)
+	if err != nil {
+		return err
+	}
+	remaining := group[:0]
+	for _, item := range group {
+		if _, ok := committedIDs[item.event.ID]; ok {
+			c.removeInboxFile(item.path)
+			continue
+		}
+		remaining = append(remaining, item)
+	}
+	if len(remaining) == 0 {
+		return nil
+	}
+
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, filePermissions) //nolint:gosec // controlled path
 	if err != nil {
 		return fmt.Errorf("open event log %s: %w", logPath, err)
@@ -287,52 +207,93 @@ func (c *Collector) appendGroup(hour string, group []pendingInboxEvent) error {
 	defer func() { _ = f.Close() }()
 
 	removePersistedInboxFiles := func() {
-		for _, item := range group {
-			if !c.seenIDs.has(item.event.ID) {
-				continue
-			}
-			if err := fileutil.Remove(item.path); err != nil && !os.IsNotExist(err) {
-				slog.Warn("fileeventstore: failed to delete processed inbox file",
-					slog.String("file", item.path),
-					slog.String("error", err.Error()))
-			}
-		}
-	}
-	reloadSeenIDs := func() {
-		if err := c.loadSeenIDsFromFile(logPath); err != nil {
-			slog.Warn("fileeventstore: failed to reload seen-set after append error",
+		ids, err := c.findCommittedIDs(logPath, pendingIDs)
+		if err != nil {
+			slog.Warn("fileeventstore: failed to check persisted events after append error",
 				slog.String("file", logPath),
 				slog.String("error", err.Error()))
 			return
 		}
-		removePersistedInboxFiles()
+		for _, item := range remaining {
+			if _, ok := ids[item.event.ID]; ok {
+				c.removeInboxFile(item.path)
+			}
+		}
 	}
 
 	writer := bufio.NewWriter(f)
-	for _, item := range group {
+	for _, item := range remaining {
 		if _, err := writer.Write(item.raw); err != nil {
-			reloadSeenIDs()
+			removePersistedInboxFiles()
 			return fmt.Errorf("append event log %s: %w", logPath, err)
 		}
 		if err := writer.WriteByte('\n'); err != nil {
-			reloadSeenIDs()
+			removePersistedInboxFiles()
 			return fmt.Errorf("append newline %s: %w", logPath, err)
 		}
 	}
 	if err := writer.Flush(); err != nil {
-		reloadSeenIDs()
+		removePersistedInboxFiles()
 		return fmt.Errorf("flush event log %s: %w", logPath, err)
 	}
 	if err := f.Sync(); err != nil {
-		reloadSeenIDs()
+		removePersistedInboxFiles()
 		return fmt.Errorf("sync event log %s: %w", logPath, err)
 	}
 
-	for _, item := range group {
-		c.seenIDs.add(item.event.ID)
+	for _, item := range remaining {
+		c.removeInboxFile(item.path)
 	}
-	removePersistedInboxFiles()
 	return nil
+}
+
+func (c *Collector) findCommittedIDs(filePath string, pendingIDs map[string]struct{}) (map[string]struct{}, error) {
+	committedIDs := make(map[string]struct{}, len(pendingIDs))
+	f, err := os.Open(filePath) //nolint:gosec // controlled path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return committedIDs, nil
+		}
+		return nil, fmt.Errorf("open event log %s: %w", filePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	fileutil.ConfigureScanner(scanner)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		var event struct {
+			eventstore.Event
+			Data struct{} `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			slog.Warn("fileeventstore: skipping malformed committed event while checking duplicates",
+				slog.String("file", filePath),
+				slog.Int("line", lineNum),
+				slog.String("error", err.Error()))
+			continue
+		}
+		if _, ok := pendingIDs[event.ID]; !ok {
+			continue
+		}
+		committedIDs[event.ID] = struct{}{}
+		if len(committedIDs) == len(pendingIDs) {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan event log %s: %w", filePath, err)
+	}
+	return committedIDs, nil
+}
+
+func (c *Collector) removeInboxFile(path string) {
+	if err := fileutil.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("fileeventstore: failed to delete processed inbox file",
+			slog.String("file", path),
+			slog.String("error", err.Error()))
+	}
 }
 
 func (c *Collector) readPendingEvent(path string) (pendingInboxEvent, error) {
@@ -375,57 +336,6 @@ func (c *Collector) quarantine(path, name string, parseErr error) {
 		slog.String("error", parseErr.Error()))
 }
 
-func (c *Collector) loadSeenIDs() error {
-	files, err := c.store.listCommittedFiles(time.Time{}, time.Time{})
-	if err != nil {
-		return err
-	}
-
-	for _, file := range files {
-		if err := c.loadSeenIDsFromFile(file); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *Collector) loadSeenIDsFromFile(filePath string) error {
-	f, err := os.Open(filePath) //nolint:gosec // controlled path
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("open event log %s: %w", filePath, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	fileutil.ConfigureScanner(scanner)
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		// Deduplication only needs the ID, so historical payloads stay unmaterialized.
-		var event struct {
-			eventstore.Event
-			Data struct{} `json:"data"`
-		}
-		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
-			slog.Warn("fileeventstore: skipping malformed committed event while loading seen-set",
-				slog.String("file", filePath),
-				slog.Int("line", lineNum),
-				slog.String("error", err.Error()))
-			continue
-		}
-		if event.ID != "" {
-			c.seenIDs.add(event.ID)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan event log %s: %w", filePath, err)
-	}
-	return nil
-}
-
 func (c *Collector) cleanupExpired() {
 	if c.retentionDays <= 0 {
 		return
@@ -434,8 +344,6 @@ func (c *Collector) cleanupExpired() {
 	now := c.now().UTC()
 	cutoff := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).
 		AddDate(0, 0, -c.retentionDays)
-	removedCommitted := false
-
 	baseEntries, err := os.ReadDir(c.store.baseDir)
 	if err == nil {
 		for _, entry := range baseEntries {
@@ -451,8 +359,6 @@ func (c *Collector) cleanupExpired() {
 				slog.Warn("fileeventstore: failed to remove expired event log",
 					slog.String("file", path),
 					slog.String("error", err.Error()))
-			} else {
-				removedCommitted = true
 			}
 		}
 	} else if !os.IsNotExist(err) {
@@ -486,14 +392,6 @@ func (c *Collector) cleanupExpired() {
 		if err := fileutil.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			slog.Warn("fileeventstore: failed to remove expired quarantined event file",
 				slog.String("file", path),
-				slog.String("error", err.Error()))
-		}
-	}
-	if removedCommitted {
-		c.seenIDs = newSeenSet()
-		if err := c.loadSeenIDs(); err != nil {
-			slog.Warn("fileeventstore: failed to rebuild seen-set after cleanup",
-				slog.String("dir", c.store.baseDir),
 				slog.String("error", err.Error()))
 		}
 	}

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -6,10 +6,8 @@ package eventstore
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,59 +16,6 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/stretchr/testify/require"
 )
-
-const benchmarkSeenIDCount = 100_000
-
-var benchmarkSeenIDs any
-
-func BenchmarkSeenIDsRetention(b *testing.B) {
-	for range b.N {
-		benchmarkSeenIDs = nil
-		runtime.GC()
-
-		var before runtime.MemStats
-		runtime.ReadMemStats(&before)
-
-		seen := newSeenSet()
-		for i := range benchmarkSeenIDCount {
-			seen.add(fmt.Sprintf("dag_%064x", i))
-		}
-
-		runtime.GC()
-		var after runtime.MemStats
-		runtime.ReadMemStats(&after)
-		runtime.KeepAlive(seen)
-
-		bytesPerID := float64(after.HeapAlloc-before.HeapAlloc) / benchmarkSeenIDCount
-		b.ReportMetric(bytesPerID, "live-B/id")
-		benchmarkSeenIDs = seen
-	}
-}
-
-func TestSeenSetPreservesIDs(t *testing.T) {
-	t.Parallel()
-
-	digest := strings.Repeat("a", 64)
-	ids := []string{
-		"dag_" + digest,
-		"dag_update_" + digest,
-		"llm_" + digest,
-		"dag_" + strings.ToUpper(digest),
-		"dag_short",
-		"evt-legacy",
-	}
-
-	seen := newSeenSet()
-	for _, id := range ids {
-		require.False(t, seen.has(id), id)
-		seen.add(id)
-		require.True(t, seen.has(id), id)
-	}
-
-	for _, id := range ids {
-		require.True(t, seen.has(id), id)
-	}
-}
 
 func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.T) {
 	t.Parallel()
@@ -88,7 +33,7 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 	require.NoError(t, store.Emit(context.Background(), eventOne))
 	require.NoError(t, store.Emit(context.Background(), eventTwo))
 
-	collector, err := NewCollector(baseDir, 10)
+	collector, err := NewCollector(baseDir, 0)
 	require.NoError(t, err)
 	require.NoError(t, collector.DrainOnce(context.Background()))
 
@@ -96,9 +41,8 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032823.jsonl"), 1)
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032901.jsonl"), 1)
 
-	restarted, err := NewCollector(baseDir, 10)
+	restarted, err := NewCollector(baseDir, 0)
 	require.NoError(t, err)
-	require.NoError(t, restarted.loadSeenIDs())
 
 	require.NoError(t, store.Emit(context.Background(), testEvent(eventOne.ID, dayOne)))
 	require.NoError(t, store.Emit(context.Background(), testEvent(eventTwo.ID, dayTwo)))
@@ -130,8 +74,6 @@ func TestCollectorDrainOncePreservesInboxAfterMalformedCommittedEvent(t *testing
 
 	collector, err := NewCollector(baseDir, 10)
 	require.NoError(t, err)
-	require.NoError(t, collector.loadSeenIDs())
-	require.False(t, collector.seenIDs.has(event.ID))
 
 	require.NoError(t, collector.DrainOnce(context.Background()))
 	assertInboxCount(t, store.inboxDir, 0)
@@ -231,37 +173,13 @@ func TestCollectorCleanupExpiredPreservesInbox(t *testing.T) {
 	assertFileExists(t, inboxFile, true)
 }
 
-func TestCollectorCleanupExpiredRebuildsSeenIDs(t *testing.T) {
+func TestCollectorDrainOnceReadsLargeCommittedEventLine(t *testing.T) {
 	t.Parallel()
 
 	baseDir := t.TempDir()
-	now := time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)
-	collector, err := NewCollector(baseDir, 10, WithNow(func() time.Time { return now }))
+	store, err := New(baseDir)
 	require.NoError(t, err)
 
-	expiredEvent := testEvent("evt-expired", now.AddDate(0, 0, -20))
-	recentEvent := testEvent("evt-recent", now.Add(-time.Hour))
-	writeCommittedEvents(t, baseDir, expiredEvent.OccurredAt, [][]byte{mustMarshalEvent(t, expiredEvent)})
-	writeCommittedEvents(t, baseDir, recentEvent.OccurredAt, [][]byte{mustMarshalEvent(t, recentEvent)})
-
-	require.NoError(t, collector.loadSeenIDs())
-	hasExpired := collector.seenIDs.has(expiredEvent.ID)
-	hasRecent := collector.seenIDs.has(recentEvent.ID)
-	require.True(t, hasExpired)
-	require.True(t, hasRecent)
-
-	collector.cleanupExpired()
-
-	hasExpired = collector.seenIDs.has(expiredEvent.ID)
-	hasRecent = collector.seenIDs.has(recentEvent.ID)
-	require.False(t, hasExpired)
-	require.True(t, hasRecent)
-}
-
-func TestCollectorLoadSeenIDsReadsLargeCommittedEventLine(t *testing.T) {
-	t.Parallel()
-
-	baseDir := t.TempDir()
 	collector, err := NewCollector(baseDir, 10)
 	require.NoError(t, err)
 
@@ -270,18 +188,20 @@ func TestCollectorLoadSeenIDsReadsLargeCommittedEventLine(t *testing.T) {
 		"payload": strings.Repeat("x", 128*1024),
 	}
 	writeCommittedEvents(t, baseDir, event.OccurredAt, [][]byte{mustMarshalEvent(t, event)})
+	require.NoError(t, store.Emit(context.Background(), event))
 
-	require.NoError(t, collector.loadSeenIDs())
-	require.True(t, collector.seenIDs.has(event.ID))
+	require.NoError(t, collector.DrainOnce(context.Background()))
+	assertInboxCount(t, store.inboxDir, 0)
+	assertLogLineCount(t, filepath.Join(baseDir, "_2026032922.jsonl"), 1)
 }
 
-func TestCollectorSeenIDAllocs(t *testing.T) {
+func TestCollectorCommittedIDAllocs(t *testing.T) {
 	const (
 		largeFieldCount   = 512
 		maxAllocationRate = 2
 	)
 
-	newCollector := func(data map[string]any) *Collector {
+	newCollector := func(data map[string]any) (*Collector, string, map[string]struct{}) {
 		baseDir := t.TempDir()
 		event := testEvent("evt-allocs", time.Date(2026, 3, 29, 22, 0, 0, 0, time.UTC))
 		event.Data = data
@@ -289,25 +209,26 @@ func TestCollectorSeenIDAllocs(t *testing.T) {
 
 		collector, err := NewCollector(baseDir, 10)
 		require.NoError(t, err)
-		return collector
+		path := filepath.Join(baseDir, "_2026032922.jsonl")
+		return collector, path, map[string]struct{}{event.ID: {}}
 	}
 
-	small := newCollector(map[string]any{"0": 0})
+	small, smallPath, smallIDs := newCollector(map[string]any{"0": 0})
 	largeData := make(map[string]any, largeFieldCount)
 	for i := range largeFieldCount {
 		largeData[strconv.Itoa(i)] = i
 	}
-	large := newCollector(largeData)
+	large, largePath, largeIDs := newCollector(largeData)
 
 	var smallErr error
 	smallAllocs := testing.AllocsPerRun(5, func() {
-		smallErr = small.loadSeenIDs()
+		_, smallErr = small.findCommittedIDs(smallPath, smallIDs)
 	})
 	require.NoError(t, smallErr)
 
 	var largeErr error
 	largeAllocs := testing.AllocsPerRun(5, func() {
-		largeErr = large.loadSeenIDs()
+		_, largeErr = large.findCommittedIDs(largePath, largeIDs)
 	})
 	require.NoError(t, largeErr)
 	require.LessOrEqual(t, largeAllocs, smallAllocs*maxAllocationRate)

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
+	coreeventstore "github.com/dagucloud/dagu/v2/internal/eventstore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,13 +45,85 @@ func TestCollectorDrainOnceAppendsByHourAndDeduplicatesAcrossRestart(t *testing.
 	restarted, err := NewCollector(baseDir, 0)
 	require.NoError(t, err)
 
-	require.NoError(t, store.Emit(context.Background(), testEvent(eventOne.ID, dayOne)))
+	require.NoError(t, store.Emit(context.Background(), testEvent(eventOne.ID, dayOne.Add(time.Hour))))
 	require.NoError(t, store.Emit(context.Background(), testEvent(eventTwo.ID, dayTwo)))
 	require.NoError(t, restarted.DrainOnce(context.Background()))
 
 	assertInboxCount(t, store.inboxDir, 0)
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032823.jsonl"), 1)
+	assertFileExists(t, filepath.Join(baseDir, "_2026032900.jsonl"), false)
 	assertLogLineCount(t, filepath.Join(baseDir, "_2026032901.jsonl"), 1)
+	result, err := store.Query(context.Background(), coreeventstore.QueryFilter{})
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 2)
+}
+
+func TestCollectorDrainOnceDeduplicatesAcrossHours(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store, err := New(baseDir)
+	require.NoError(t, err)
+	collector, err := NewCollector(baseDir, 0)
+	require.NoError(t, err)
+
+	firstHour := time.Date(2026, 3, 29, 10, 59, 0, 0, time.UTC)
+	event := testEvent("evt-cross-hour", firstHour)
+	require.NoError(t, store.Emit(context.Background(), event))
+	require.NoError(t, collector.DrainOnce(context.Background()))
+
+	require.NoError(t, store.Emit(context.Background(), testEvent(event.ID, firstHour.Add(time.Hour))))
+	require.NoError(t, collector.DrainOnce(context.Background()))
+
+	result, err := store.Query(context.Background(), coreeventstore.QueryFilter{})
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 1)
+	assertFileExists(t, filepath.Join(baseDir, "_2026032911.jsonl"), false)
+}
+
+func TestCollectorDrainOnceVerifiesFilterMatches(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	hour := time.Date(2026, 3, 29, 10, 0, 0, 0, time.UTC)
+	committed := testEvent("evt-committed", hour)
+	writeCommittedEvents(t, baseDir, hour, [][]byte{mustMarshalEvent(t, committed)})
+
+	store, err := New(baseDir)
+	require.NoError(t, err)
+	collector, err := NewCollector(baseDir, 0, WithDedupeCacheBytes(1))
+	require.NoError(t, err)
+	require.NoError(t, collector.ensureCommittedIDs())
+
+	var unique *coreeventstore.Event
+	for i := range 1000 {
+		candidate := testEvent("evt-unique-"+strconv.Itoa(i), hour.Add(time.Hour))
+		if collector.committedIDs.mayContain(candidate.ID) {
+			unique = candidate
+			break
+		}
+	}
+	require.NotNil(t, unique)
+
+	require.NoError(t, store.Emit(context.Background(), unique))
+	require.NoError(t, collector.DrainOnce(context.Background()))
+
+	result, err := store.Query(context.Background(), coreeventstore.QueryFilter{})
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 2)
+}
+
+func TestEventIDFilterUsesBudget(t *testing.T) {
+	t.Parallel()
+
+	const budget = 128
+	collector, err := NewCollector(t.TempDir(), 0, WithDedupeCacheBytes(budget))
+	require.NoError(t, err)
+	require.NoError(t, collector.ensureCommittedIDs())
+	collector.committedIDs.add("evt-filtered")
+
+	require.Len(t, collector.committedIDs.bits, budget)
+	require.True(t, collector.committedIDs.mayContain("evt-filtered"))
 }
 
 func TestCollectorDrainOncePreservesInboxAfterMalformedCommittedEvent(t *testing.T) {

--- a/internal/persis/file/eventstore/collector_test.go
+++ b/internal/persis/file/eventstore/collector_test.go
@@ -270,8 +270,9 @@ func TestCollectorDrainOnceReadsLargeCommittedEventLine(t *testing.T) {
 
 func TestCollectorCommittedIDAllocs(t *testing.T) {
 	const (
-		largeFieldCount   = 512
-		maxAllocationRate = 2
+		baselineFieldCount = 64
+		largeFieldCount    = 512
+		maxAllocationRate  = 2
 	)
 
 	newCollector := func(data map[string]any) (*Collector, string, map[string]struct{}) {
@@ -286,12 +287,8 @@ func TestCollectorCommittedIDAllocs(t *testing.T) {
 		return collector, path, map[string]struct{}{event.ID: {}}
 	}
 
-	small, smallPath, smallIDs := newCollector(map[string]any{"0": 0})
-	largeData := make(map[string]any, largeFieldCount)
-	for i := range largeFieldCount {
-		largeData[strconv.Itoa(i)] = i
-	}
-	large, largePath, largeIDs := newCollector(largeData)
+	small, smallPath, smallIDs := newCollector(testEventData(baselineFieldCount))
+	large, largePath, largeIDs := newCollector(testEventData(largeFieldCount))
 
 	var smallErr error
 	smallAllocs := testing.AllocsPerRun(5, func() {
@@ -309,8 +306,9 @@ func TestCollectorCommittedIDAllocs(t *testing.T) {
 
 func TestCollectorPendingEventAllocs(t *testing.T) {
 	const (
-		largeFieldCount   = 512
-		maxAllocationRate = 2
+		baselineFieldCount = 64
+		largeFieldCount    = 512
+		maxAllocationRate  = 2
 	)
 
 	newPendingEvent := func(data map[string]any) (*Collector, string) {
@@ -325,12 +323,8 @@ func TestCollectorPendingEventAllocs(t *testing.T) {
 		return collector, path
 	}
 
-	small, smallPath := newPendingEvent(map[string]any{"0": 0})
-	largeData := make(map[string]any, largeFieldCount)
-	for i := range largeFieldCount {
-		largeData[strconv.Itoa(i)] = i
-	}
-	large, largePath := newPendingEvent(largeData)
+	small, smallPath := newPendingEvent(testEventData(baselineFieldCount))
+	large, largePath := newPendingEvent(testEventData(largeFieldCount))
 
 	var smallErr error
 	smallAllocs := testing.AllocsPerRun(5, func() {
@@ -344,6 +338,14 @@ func TestCollectorPendingEventAllocs(t *testing.T) {
 	})
 	require.NoError(t, largeErr)
 	require.LessOrEqual(t, largeAllocs, smallAllocs*maxAllocationRate)
+}
+
+func testEventData(fieldCount int) map[string]any {
+	data := make(map[string]any, fieldCount)
+	for i := range fieldCount {
+		data[strconv.Itoa(i)] = i
+	}
+	return data
 }
 
 func assertInboxCount(t *testing.T, dir string, count int) {

--- a/internal/service/scheduler/file/stores.go
+++ b/internal/service/scheduler/file/stores.go
@@ -36,7 +36,11 @@ func NewDependencies(ctx context.Context, cfg *config.Config, backend persis.Bac
 		}
 	}
 	if deps.EventService != nil {
-		collector, err := fileeventstore.NewCollector(cfg.Paths.EventStoreDir, cfg.EventStore.RetentionDays)
+		collector, err := fileeventstore.NewCollector(
+			cfg.Paths.EventStoreDir,
+			cfg.EventStore.RetentionDays,
+			fileeventstore.WithDedupeCacheBytes(cfg.Cache.Limits().EventStoreBytes),
+		)
 		if err != nil {
 			logger.Warn(ctx, "Failed to initialize event collector; continuing without collection", tag.Error(err))
 		} else {


### PR DESCRIPTION
## Summary

Restore global event ID deduplication while capping memory by cache mode.

## Changes

- preserve deduplication across hourly log boundaries
- cap the filter at 8 MiB, 16 MiB, or 32 MiB by cache mode
- verify probable matches against retained logs
- rebuild the filter after restart and retention cleanup
- stabilize allocation regression tests under coverage

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `go test -race ./internal/persis/file/eventstore -count=1`
- `go test ./internal/cmn/config ./internal/service/scheduler/file ./internal/cmd -count=1`
- `GOOS=windows go vet ./internal/persis/file/eventstore ./internal/cmn/config ./internal/service/scheduler/file ./internal/cmd`
- `make fmt`
- `make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds event deduplication memory with a fixed-size filter while restoring global deduplication. The earlier hourly-only check allowed a repeated event ID to be committed again when its timestamp changed; dedupe now verifies possible matches against retained logs before appending.

- The filter is sized by cache mode (`EventStoreBytes`: 8 MB low, 16 MB normal, 32 MB high) and rebuilt from all retained committed logs.
- Possible filter matches are confirmed against the logs, so memory stays bounded regardless of the retention window.
- Duplicate inbox files are removed without affecting already-persisted events; restart and partial-append recovery are preserved.
- Expired-log cleanup rebuilds the filter.

<sup>Written for commit 8662cf84db0b0de60bcdf4b9f4322267c0e471b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate event handling across processing batches and hourly event logs.
  * Prevented duplicate events from being reprocessed after collector restarts.
  * Improved handling of large committed event records.

* **Improvements**
  * Added configurable event-store cache limits for low, normal, and high cache modes.
  * Added automatic cache sizing based on the selected cache mode.
  * Improved cleanup and tracking of committed events as records expire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->