### PR TITLE
fix: bound pending notification state

### DIFF
--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -21,6 +21,7 @@ const (
 	DefaultNotificationSeenEvictInterval     = 10 * time.Minute
 	DefaultNotificationSeenTTL               = 2 * time.Hour
 	DefaultNotificationFlushTimeout          = 30 * time.Second
+	DefaultNotificationPendingLimit          = 1000
 	DefaultNotificationLockHeartbeatInterval = time.Second
 	DefaultNotificationLockRetryInterval     = 50 * time.Millisecond
 	DefaultNotificationLockStaleThreshold    = 45 * time.Second
@@ -43,6 +44,7 @@ type NotificationMonitorConfig struct {
 	FlushTimeout         time.Duration
 	UrgentWindow         time.Duration
 	SuccessWindow        time.Duration
+	PendingLimit         int
 	InterestedEventTypes []eventstore.EventType
 	BootstrapCursor      *eventstore.DAGRunCursor
 }
@@ -56,6 +58,7 @@ func DefaultNotificationMonitorConfig() NotificationMonitorConfig {
 		FlushTimeout:         DefaultNotificationFlushTimeout,
 		UrgentWindow:         DefaultUrgentNotificationWindow,
 		SuccessWindow:        DefaultSuccessNotificationWindow,
+		PendingLimit:         DefaultNotificationPendingLimit,
 		InterestedEventTypes: append([]eventstore.EventType(nil), defaultInterestedNotificationEventTypes...),
 	}
 }
@@ -137,6 +140,8 @@ type queuedNotification struct {
 	destination string
 	event       NotificationEvent
 }
+
+type pendingEvictions map[string]map[string]struct{}
 
 // NewNotificationMonitor creates a shared notification monitor.
 func NewNotificationMonitor(
@@ -265,13 +270,17 @@ func (m *NotificationMonitor) initializeSession(ctx context.Context) {
 	m.loadPersistedState(ctx)
 
 	destinations := m.transport.NotificationDestinations()
-	var removed []string
+	var (
+		removed []string
+		evicted pendingEvictions
+	)
 
 	m.stateMu.Lock()
 	persisted := m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
 		var changed bool
 		removed, changed = reconcileDestinations(candidate, destinations)
-		return changed
+		evicted = trimPendingNotifications(candidate, m.cfg.PendingLimit)
+		return changed || len(evicted) > 0
 	})
 	m.stateMu.Unlock()
 	if !persisted {
@@ -280,6 +289,7 @@ func (m *NotificationMonitor) initializeSession(ctx context.Context) {
 	if len(removed) > 0 {
 		m.discardPendingDestinations(removed)
 	}
+	m.discardEvictedNotifications(evicted)
 
 	m.ensureBootstrapped(ctx)
 	m.requeuePending(ctx, destinations)
@@ -554,8 +564,11 @@ func (m *NotificationMonitor) enqueueEvents(ctx context.Context, destinations []
 		return false
 	}
 
-	var queued []queuedNotification
-	accepted := false
+	var (
+		queued   []queuedNotification
+		evicted  pendingEvictions
+		accepted bool
+	)
 
 	m.stateMu.Lock()
 	persisted := m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
@@ -566,13 +579,17 @@ func (m *NotificationMonitor) enqueueEvents(ctx context.Context, destinations []
 		} else {
 			queued, enqueueChanged, accepted = enqueueNotifications(candidate, destinations, events)
 		}
-		return changed || enqueueChanged
+		evicted = trimPendingNotifications(candidate, m.cfg.PendingLimit)
+		queued = filterEvictedNotifications(queued, evicted)
+		accepted = len(queued) > 0
+		return changed || enqueueChanged || len(evicted) > 0
 	})
 	m.stateMu.Unlock()
 	if !persisted {
 		return false
 	}
 
+	m.discardEvictedNotifications(evicted)
 	for _, item := range queued {
 		m.enqueueBatch(item.destination, item.event)
 	}
@@ -595,7 +612,10 @@ func (m *NotificationMonitor) requeuePending(ctx context.Context, destinations [
 		allowed[destination] = struct{}{}
 	}
 
-	var queued []queuedNotification
+	var (
+		queued  []queuedNotification
+		evicted pendingEvictions
+	)
 
 	m.stateMu.Lock()
 	persisted := m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
@@ -611,7 +631,8 @@ func (m *NotificationMonitor) requeuePending(ctx context.Context, destinations [
 				}
 			}
 		}
-		return changed
+		evicted = trimPendingNotifications(candidate, m.cfg.PendingLimit)
+		return changed || len(evicted) > 0
 	})
 	if !persisted {
 		m.stateMu.Unlock()
@@ -636,6 +657,7 @@ func (m *NotificationMonitor) requeuePending(ctx context.Context, destinations [
 	}
 	m.stateMu.Unlock()
 
+	m.discardEvictedNotifications(evicted)
 	slices.SortFunc(queued, func(a, b queuedNotification) int {
 		if !a.event.ObservedAt.Equal(b.event.ObservedAt) {
 			if a.event.ObservedAt.Before(b.event.ObservedAt) {
@@ -915,6 +937,7 @@ func (m *NotificationMonitor) commitSourceProgress(ctx context.Context, destinat
 
 	var (
 		queued   []queuedNotification
+		evicted  pendingEvictions
 		accepted bool
 	)
 	persisted := m.applyStateTransitionLocked(ctx, func(candidate *notificationMonitorState) bool {
@@ -927,11 +950,15 @@ func (m *NotificationMonitor) commitSourceProgress(ctx context.Context, destinat
 		} else {
 			queued, enqueueChanged, accepted = enqueueNotifications(candidate, destinations, events)
 		}
-		return changed || cursorChanged || enqueueChanged
+		evicted = trimPendingNotifications(candidate, m.cfg.PendingLimit)
+		queued = filterEvictedNotifications(queued, evicted)
+		accepted = len(queued) > 0
+		return changed || cursorChanged || enqueueChanged || len(evicted) > 0
 	})
 	if !persisted {
 		return nil, false
 	}
+	m.discardEvictedNotifications(evicted)
 	if !accepted {
 		return nil, true
 	}
@@ -1160,6 +1187,17 @@ func (m *NotificationMonitor) discardPendingDestinations(destinations []string) 
 	m.currentBatcher().DiscardDestinations(destinations)
 }
 
+func (m *NotificationMonitor) discardEvictedNotifications(evicted pendingEvictions) {
+	for destination, keys := range evicted {
+		m.currentBatcher().discardEvents(destination, keys)
+		m.logger.Warn("Dropped pending notifications after backlog limit",
+			slog.String("destination", destination),
+			slog.Int("dropped_count", len(keys)),
+			slog.Int("limit", m.cfg.PendingLimit),
+		)
+	}
+}
+
 func normalizeNotificationMonitorConfig(cfg *NotificationMonitorConfig) {
 	defaults := DefaultNotificationMonitorConfig()
 	if cfg.PollInterval <= 0 {
@@ -1179,6 +1217,9 @@ func normalizeNotificationMonitorConfig(cfg *NotificationMonitorConfig) {
 	}
 	if cfg.SuccessWindow <= 0 {
 		cfg.SuccessWindow = defaults.SuccessWindow
+	}
+	if cfg.PendingLimit <= 0 {
+		cfg.PendingLimit = defaults.PendingLimit
 	}
 	if cfg.InterestedEventTypes == nil {
 		cfg.InterestedEventTypes = append([]eventstore.EventType(nil), defaults.InterestedEventTypes...)
@@ -1341,6 +1382,72 @@ func enqueueNotifications(state *notificationMonitorState, destinations []string
 	}
 
 	return queued, changed, accepted
+}
+
+func trimPendingNotifications(state *notificationMonitorState, limit int) pendingEvictions {
+	if state == nil || limit <= 0 {
+		return nil
+	}
+
+	type candidate struct {
+		key        string
+		observedAt time.Time
+	}
+
+	evicted := make(pendingEvictions)
+	for destination, destState := range state.Destinations {
+		if destState == nil || len(destState.Pending) <= limit {
+			continue
+		}
+
+		candidates := make([]candidate, 0, len(destState.Pending))
+		for key, event := range destState.Pending {
+			candidates = append(candidates, candidate{key: key, observedAt: event.ObservedAt})
+		}
+		slices.SortFunc(candidates, func(a, b candidate) int {
+			if !a.observedAt.Equal(b.observedAt) {
+				if a.observedAt.Before(b.observedAt) {
+					return -1
+				}
+				return 1
+			}
+			switch {
+			case a.key < b.key:
+				return -1
+			case a.key > b.key:
+				return 1
+			default:
+				return 0
+			}
+		})
+
+		keys := make(map[string]struct{}, len(candidates)-limit)
+		for _, candidate := range candidates[:len(candidates)-limit] {
+			delete(destState.Pending, candidate.key)
+			keys[candidate.key] = struct{}{}
+		}
+		evicted[destination] = keys
+	}
+	if len(evicted) == 0 {
+		return nil
+	}
+	return evicted
+}
+
+func filterEvictedNotifications(queued []queuedNotification, evicted pendingEvictions) []queuedNotification {
+	if len(queued) == 0 || len(evicted) == 0 {
+		return queued
+	}
+
+	filtered := queued[:0]
+	for _, item := range queued {
+		keys := evicted[item.destination]
+		if _, ok := keys[item.event.Key]; ok {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }
 
 func migrateWaitingDelivery(destState *notificationDestinationState, event NotificationEvent) bool {

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -4,13 +4,16 @@
 package chatbridge
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -220,6 +223,116 @@ func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {
 	defer mu.Unlock()
 	assert.GreaterOrEqual(t, calls, 1)
 	assert.True(t, secondMonitor.IsDelivered("dest-1", status))
+}
+
+func TestNotificationMonitor_BoundsFailedDeliveryBacklog(t *testing.T) {
+	t.Parallel()
+
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(_ context.Context, _ string, _ NotificationBatch, _ bool) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			calls++
+			return false
+		},
+	}
+	cfg := newTestNotificationMonitorConfig()
+	cfg.PendingLimit = 2
+	monitor := newFileBackedMonitor(nil, stateFile, transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
+	stopMonitor := testutil.StartContextRunner(t, monitor)
+	defer stopMonitor()
+	require.Eventually(t, func() bool {
+		monitor.stateMu.Lock()
+		defer monitor.stateMu.Unlock()
+		return monitor.state.Bootstrapped
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
+
+	base := time.Now().UTC()
+	events := make([]NotificationEvent, 0, 3)
+	for i := 1; i <= 3; i++ {
+		status := &ir.DAGRunStatus{
+			Name:      "briefing",
+			DAGRunID:  fmt.Sprintf("run-%d", i),
+			AttemptID: fmt.Sprintf("attempt-%d", i),
+			Status:    ir.Failed,
+			Error:     "boom",
+		}
+		event := testNotificationEvent(status)
+		event.ObservedAt = base.Add(time.Duration(i) * time.Second)
+		events = append(events, event)
+	}
+	require.True(t, monitor.enqueueEvents(context.Background(), nil, events))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls > 0
+	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
+
+	result := newNotificationStateStore(filemonitor.NewStateStore(stateFile)).Load(context.Background())
+	require.NoError(t, result.Warning)
+	pending := result.State.Destinations["dest-1"].Pending
+	require.Len(t, pending, 2)
+	assert.NotContains(t, pending, events[0].Key)
+	assert.Contains(t, pending, events[1].Key)
+	assert.Contains(t, pending, events[2].Key)
+}
+
+func TestNotificationMonitor_TrimsPersistedBacklogBeforeRequeue(t *testing.T) {
+	t.Parallel()
+
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	base := time.Now().UTC()
+	events := []NotificationEvent{
+		{Key: "event-a", Status: &ir.DAGRunStatus{Name: "a", DAGRunID: "run-a", AttemptID: "a1", Status: ir.Failed}, ObservedAt: base},
+		{Key: "event-b", Status: &ir.DAGRunStatus{Name: "b", DAGRunID: "run-b", AttemptID: "a1", Status: ir.Failed}, ObservedAt: base},
+		{Key: "event-c", Status: &ir.DAGRunStatus{Name: "c", DAGRunID: "run-c", AttemptID: "a1", Status: ir.Failed}, ObservedAt: base.Add(time.Second)},
+	}
+	state := newNotificationMonitorState()
+	state.Bootstrapped = true
+	state.Destinations["dest-1"] = &notificationDestinationState{
+		Pending: map[string]NotificationEvent{
+			events[0].Key: events[0],
+			events[1].Key: events[1],
+			events[2].Key: events[2],
+		},
+		Delivered: make(map[string]time.Time),
+	}
+	store := newNotificationStateStore(filemonitor.NewStateStore(stateFile))
+	require.NoError(t, store.Save(context.Background(), state))
+
+	var logs bytes.Buffer
+	cfg := newTestNotificationMonitorConfig()
+	cfg.PendingLimit = 2
+	cfg.UrgentWindow = time.Hour
+	monitor := newFileBackedMonitor(
+		nil,
+		stateFile,
+		&fakeNotificationTransport{destinations: []string{"dest-1"}},
+		slog.New(slog.NewTextHandler(&logs, nil)),
+		cfg,
+	)
+	monitor.lock = nil
+	defer monitor.currentBatcher().Stop()
+
+	monitor.initializeSession(context.Background())
+
+	result := store.Load(context.Background())
+	require.NoError(t, result.Warning)
+	pending := result.State.Destinations["dest-1"].Pending
+	require.Len(t, pending, 2)
+	assert.NotContains(t, pending, "event-a")
+	assert.Contains(t, pending, "event-b")
+	assert.Contains(t, pending, "event-c")
+	assert.Equal(t, 1, strings.Count(logs.String(), "Dropped pending notifications after backlog limit"))
+	assert.Contains(t, logs.String(), "destination=dest-1")
+	assert.Contains(t, logs.String(), "dropped_count=1")
+	assert.Contains(t, logs.String(), "limit=2")
 }
 
 func TestNotificationMonitor_StateLockAllowsSingleWriterAndTakeover(t *testing.T) {

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -6,6 +6,7 @@ package chatbridge
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -670,6 +671,58 @@ func TestEnqueueNotificationsByEventFiltersUnknownAndDuplicateRoutes(t *testing.
 	assert.Equal(t, "dest-a", queued[0].destination)
 	assert.Contains(t, state.Destinations, "dest-a")
 	assert.NotContains(t, state.Destinations, "unknown")
+}
+
+func TestNotificationMonitor_CommitSourceProgressDropsOldestPendingEvent(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.PendingLimit = 2
+	monitor := NewNotificationMonitor(
+		nil,
+		nil,
+		nil,
+		&fakeNotificationTransport{destinations: []string{"dest-1"}},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg,
+	)
+	monitor.state.Bootstrapped = true
+
+	base := time.Now().UTC()
+	events := make([]NotificationEvent, 0, 3)
+	for i := 1; i <= 3; i++ {
+		status := &ir.DAGRunStatus{
+			Name:      "briefing",
+			DAGRunID:  fmt.Sprintf("run-%d", i),
+			AttemptID: fmt.Sprintf("attempt-%d", i),
+			Status:    ir.Failed,
+		}
+		event := testNotificationEvent(status)
+		event.ObservedAt = base.Add(time.Duration(i) * time.Second)
+		events = append(events, event)
+	}
+	nextCursor := eventstore.DAGRunCursor{CommittedOffsets: map[string]int64{"events": 3}}
+
+	queued, committed := monitor.commitSourceProgress(context.Background(), nil, nextCursor, events)
+
+	require.True(t, committed)
+	require.Len(t, queued, 2)
+	assert.True(t, monitor.state.SourceCursor.Equal(nextCursor))
+	pending := monitor.state.Destinations["dest-1"].Pending
+	require.Len(t, pending, 2)
+	assert.NotContains(t, pending, events[0].Key)
+	assert.Contains(t, pending, events[1].Key)
+	assert.Contains(t, pending, events[2].Key)
+}
+
+func TestNormalizeNotificationMonitorConfig_DefaultsPendingLimit(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.PendingLimit = 0
+	normalizeNotificationMonitorConfig(&cfg)
+
+	assert.Equal(t, DefaultNotificationPendingLimit, cfg.PendingLimit)
 }
 
 func TestNotificationMonitor_RequeuePendingDropsFailedRunWithAutoRetryRemaining(t *testing.T) {

--- a/internal/service/chatbridge/notifications.go
+++ b/internal/service/chatbridge/notifications.go
@@ -364,6 +364,63 @@ func (b *NotificationBatcher) DiscardDestinations(destinations []string) {
 	}
 }
 
+func (b *NotificationBatcher) discardEvents(destination string, keys map[string]struct{}) {
+	if destination == "" || len(keys) == 0 {
+		return
+	}
+
+	b.mu.Lock()
+	if b.stopped {
+		b.mu.Unlock()
+		return
+	}
+
+	var timers []*time.Timer
+	for bucketKey, bucket := range b.buckets {
+		if bucket == nil || bucket.destination != destination {
+			continue
+		}
+		for runKey, event := range bucket.events {
+			if _, ok := keys[event.Key]; !ok {
+				continue
+			}
+			delete(bucket.events, runKey)
+			delete(b.runIndex, notificationDestinationRunKey(destination, runKey))
+		}
+		if len(bucket.events) == 0 {
+			if bucket.timer != nil {
+				timers = append(timers, bucket.timer)
+			}
+			delete(b.buckets, bucketKey)
+		}
+	}
+
+	filteredReady := b.ready[:0]
+	for _, pending := range b.ready {
+		if pending.Destination != destination {
+			filteredReady = append(filteredReady, pending)
+			continue
+		}
+		filteredEvents := pending.Batch.Events[:0]
+		for _, event := range pending.Batch.Events {
+			if _, ok := keys[event.Key]; ok {
+				continue
+			}
+			filteredEvents = append(filteredEvents, event)
+		}
+		pending.Batch.Events = filteredEvents
+		if len(filteredEvents) > 0 {
+			filteredReady = append(filteredReady, pending)
+		}
+	}
+	b.ready = filteredReady
+	b.mu.Unlock()
+
+	for _, timer := range timers {
+		timer.Stop()
+	}
+}
+
 // flushBucketsLocked synchronously moves buffered buckets of the given class
 // to the ready queue, stopping any pending timers. It is safe to call when the
 // batcher has not been stopped.

--- a/internal/service/chatbridge/notifications_test.go
+++ b/internal/service/chatbridge/notifications_test.go
@@ -240,6 +240,51 @@ func TestNotificationBatcher_DiscardDestinationsRemovesReadyAndBufferedBatches(t
 	}, 200*time.Millisecond, 20*time.Millisecond)
 }
 
+func TestNotificationBatcher_DiscardEventsRemovesReadyAndBufferedEvents(t *testing.T) {
+	t.Parallel()
+
+	batcher := NewNotificationBatcher(80*time.Millisecond, 20*time.Millisecond)
+	defer batcher.Stop()
+
+	readyEvent := testNotificationEvent(&ir.DAGRunStatus{
+		Name:      "ready",
+		DAGRunID:  "run-ready",
+		AttemptID: "a1",
+		Status:    ir.Succeeded,
+	})
+	bufferedDrop := testNotificationEvent(&ir.DAGRunStatus{
+		Name:      "buffered-drop",
+		DAGRunID:  "run-buffered-drop",
+		AttemptID: "a1",
+		Status:    ir.Failed,
+	})
+	bufferedKeep := testNotificationEvent(&ir.DAGRunStatus{
+		Name:      "buffered-keep",
+		DAGRunID:  "run-buffered-keep",
+		AttemptID: "a1",
+		Status:    ir.Failed,
+	})
+
+	require.True(t, batcher.Enqueue("dest-1", readyEvent))
+	batcher.flushBucketsLocked(NotificationClassSuccessDigest)
+	require.True(t, batcher.Enqueue("dest-1", bufferedDrop))
+	require.True(t, batcher.Enqueue("dest-1", bufferedKeep))
+
+	batcher.discardEvents("dest-1", map[string]struct{}{
+		readyEvent.Key:   {},
+		bufferedDrop.Key: {},
+	})
+
+	assert.Empty(t, batcher.TakeReady())
+	select {
+	case <-batcher.ReadyC():
+	default:
+	}
+	ready := waitForReadyBatch(t, batcher)
+	require.Len(t, ready.Batch.Events, 1)
+	assert.Equal(t, bufferedKeep.Key, ready.Batch.Events[0].Key)
+}
+
 func TestFormatNotificationBatch_CapsVisibleGroups(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- cap pending notifications at 1,000 per destination
- drop the oldest entries deterministically while advancing the source cursor
- remove evicted notifications from buffered and ready batches

## Testing
- go test -race ./internal/service/chatbridge
- related service tests
- make check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps pending notifications per destination at 1,000 so failed deliveries no longer accumulate run snapshots indefinitely. The monitor now trims the oldest pending entries deterministically and removes evicted notifications from buffered and ready batch queues.

- Adds `PendingLimit` config option (default 1,000), applied at startup, enqueue, requeue, and source cursor commit.
- Logs a warning with destination, dropped count, and limit whenever entries are evicted.
- Trimmed entries are dropped before send; no retry or recovery for evicted notifications.

<sup>Written for commit b16ee15c325a1a67e4a54d1ae6bd83c69efe650b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable limit for pending notifications per destination.
  - Pending backlogs now default to a maximum of 1,000 notifications when no limit is specified.
  - When the limit is exceeded, the oldest notifications are removed first.

- **Bug Fixes**
  - Persisted and repeatedly failed notification backlogs are now trimmed consistently.
  - Removed notifications no longer remain queued for delivery.
  - Source progress continues advancing while newer pending notifications are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->