### PR TITLE
fix: extend distributed lease grace

### DIFF
--- a/internal/dagrun/lease.go
+++ b/internal/dagrun/lease.go
@@ -11,7 +11,7 @@ import (
 
 // DefaultStaleLeaseThreshold is the default interval after which an
 // unobserved distributed run is considered stale.
-const DefaultStaleLeaseThreshold = 30 * time.Second
+const DefaultStaleLeaseThreshold = 90 * time.Second
 
 // IsLeaseActive reports whether the coordinator has observed the run within
 // the stale threshold. A run without a lease timestamp is stale.

--- a/internal/dagrun/lease_test.go
+++ b/internal/dagrun/lease_test.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dagrun_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/internal/dagrun"
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLeaseActiveAllowsCoordinatorRestart(t *testing.T) {
+	status := &ir.DAGRunStatus{LeaseAt: time.Now().Add(-time.Minute).UnixMilli()}
+
+	assert.True(t, dagrun.IsLeaseActive(status, 0))
+}


### PR DESCRIPTION
## Summary
- extend the shared stale lease threshold from 30 seconds to 90 seconds
- give coordinator restarts more time before worker cancellation and stale-run cleanup race
- cover a one-minute restart window

Workers already retry coordinator calls with jittered backoff. This change only extends the lease grace period. Warning deduplication is separate from the run termination bug.

## Testing
- make fmt
- make test

Closes #2629