### PR TITLE
fix: preserve monitor startup events

### DIFF
--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -6,6 +6,7 @@ package cmd_test
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/internal/cmd"
@@ -29,9 +30,9 @@ func TestServerCommand(t *testing.T) {
 		th := test.SetupCommand(t)
 		listener, port := test.ReserveServerListener(t)
 		configFile := th.TempFile(t, "server-config.yaml", fmt.Appendf(nil, "host: 127.0.0.1\nport: %s\n", port))
-		cancelWhenLogContains(t, th, port)
+		cancelWhenLogContains(t, th, "Server is starting")
 		th.RunCommand(t, cmd.Server(frontend.WithListener(listener)), test.CmdTest{
-			Args:        []string{"server", "--config", configFile},
+			Args:        []string{"server", "--config", configFile, "--dagu-home", filepath.Dir(th.Config.Paths.DataDir)},
 			ExpectedOut: []string{port},
 		})
 	})

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -192,6 +192,11 @@ func runStartAll(ctx *Context, _ []string) error {
 		logger.Info(serviceCtx, "Coordinator disabled via configuration")
 	}
 
+	// Persist monitor boundaries before any bundled service can emit DAG-run events.
+	if err := scheduler.BootstrapMonitors(serviceCtx); err != nil {
+		return fmt.Errorf("failed to bootstrap monitors: %w", err)
+	}
+
 	// Start resource monitoring service (starts its own goroutine internally)
 	if err := resourceService.Start(serviceCtx); err != nil {
 		return fmt.Errorf("failed to start resource service: %w", err)

--- a/internal/persis/file/monitor/store.go
+++ b/internal/persis/file/monitor/store.go
@@ -5,6 +5,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
+	"github.com/gofrs/flock"
 )
 
 // StateStore persists encoded monitor state in a file.
@@ -84,10 +86,12 @@ func (s *StateStore) Quarantine(_ context.Context) (string, error) {
 	return quarantinedPath, nil
 }
 
-// Lease coordinates one active monitor through a directory lock.
+// Lease coordinates one active monitor across processes.
 type Lease struct {
 	dirlock.DirLock
-	location string
+	processLock *flock.Flock
+	location    string
+	opts        *dirlock.LockOptions
 }
 
 // NewLease creates a file-backed monitor lease for a state file.
@@ -95,10 +99,82 @@ func NewLease(stateFile string, opts *dirlock.LockOptions) *Lease {
 	if stateFile == "" {
 		return nil
 	}
+	if opts == nil {
+		opts = &dirlock.LockOptions{}
+	}
 	location := filepath.Clean(stateFile) + ".lock"
-	return &Lease{DirLock: dirlock.New(location, opts), location: location}
+	return &Lease{
+		DirLock:     dirlock.New(location, opts),
+		processLock: flock.New(location + ".flock"),
+		location:    location,
+		opts:        opts,
+	}
 }
 
 func (l *Lease) Location() string {
 	return l.location
+}
+
+func (l *Lease) TryLock() error {
+	if err := fileutil.MkdirAll(filepath.Dir(l.location), 0o750); err != nil {
+		return fmt.Errorf("create monitor lock directory: %w", err)
+	}
+
+	// Prevent stale recovery from replacing a lease held by a live process.
+	locked, err := l.processLock.TryLock()
+	if err != nil {
+		return fmt.Errorf("acquire monitor process lock: %w", err)
+	}
+	if !locked {
+		return dirlock.ErrLockConflict
+	}
+
+	if err := l.DirLock.TryLock(); err != nil {
+		unlockErr := l.processLock.Unlock()
+		if unlockErr != nil {
+			unlockErr = fmt.Errorf("release monitor process lock: %w", unlockErr)
+		}
+		return errors.Join(err, unlockErr)
+	}
+	return nil
+}
+
+func (l *Lease) Lock(ctx context.Context) error {
+	if err := l.TryLock(); err == nil {
+		return nil
+	} else if !errors.Is(err, dirlock.ErrLockConflict) {
+		return err
+	}
+	if l.opts.OnWait != nil {
+		l.opts.OnWait()
+	}
+
+	ticker := time.NewTicker(l.opts.RetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := l.TryLock(); err == nil {
+				return nil
+			} else if !errors.Is(err, dirlock.ErrLockConflict) {
+				return err
+			}
+		}
+	}
+}
+
+func (l *Lease) Unlock() error {
+	directoryErr := l.DirLock.Unlock()
+	processErr := l.processLock.Unlock()
+	if processErr != nil {
+		processErr = fmt.Errorf("release monitor process lock: %w", processErr)
+	}
+	return errors.Join(directoryErr, processErr)
+}
+
+func (l *Lease) IsHeldByMe() bool {
+	return l.processLock.Locked() && l.DirLock.IsHeldByMe()
 }

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -196,7 +196,12 @@ func (m *NotificationMonitor) Bootstrap(ctx context.Context) error {
 		}
 
 		if err := m.lock.TryLock(); err == nil {
-			return m.bootstrapLocked(ctx)
+			bootstrapErr := m.bootstrapOwned(ctx)
+			unlockErr := m.lock.Unlock()
+			if unlockErr != nil {
+				unlockErr = fmt.Errorf("release notification bootstrap lock: %w", unlockErr)
+			}
+			return errors.Join(bootstrapErr, unlockErr)
 		} else if !errors.Is(err, dirlock.ErrLockConflict) {
 			return fmt.Errorf("acquire notification bootstrap lock: %w", err)
 		}
@@ -207,23 +212,6 @@ func (m *NotificationMonitor) Bootstrap(ctx context.Context) error {
 		case <-ticker.C:
 		}
 	}
-}
-
-func (m *NotificationMonitor) bootstrapLocked(ctx context.Context) error {
-	bootstrapCtx, cancel := context.WithCancel(ctx)
-	m.beginNotificationSession(cancel)
-	heartbeatDone := m.startNotificationLockHeartbeat(bootstrapCtx)
-
-	bootstrapErr := m.bootstrapOwned(bootstrapCtx)
-	cancel()
-	<-heartbeatDone
-	m.endNotificationSession()
-
-	unlockErr := m.lock.Unlock()
-	if unlockErr != nil {
-		unlockErr = fmt.Errorf("release notification bootstrap lock: %w", unlockErr)
-	}
-	return errors.Join(bootstrapErr, unlockErr)
 }
 
 func (m *NotificationMonitor) bootstrapOwned(ctx context.Context) error {
@@ -248,14 +236,6 @@ func (m *NotificationMonitor) bootstrapOwned(ctx context.Context) error {
 		}
 	}
 
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if m.lock != nil {
-		if err := m.lock.Heartbeat(ctx); err != nil {
-			return fmt.Errorf("renew notification bootstrap lock: %w", err)
-		}
-	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -1086,7 +1066,7 @@ func (m *NotificationMonitor) acquireNotificationLock(ctx context.Context) bool 
 }
 
 func (m *NotificationMonitor) releaseNotificationLock() {
-	if m.lock == nil || !m.lock.IsHeldByMe() {
+	if m.lock == nil {
 		return
 	}
 	if err := m.lock.Unlock(); err != nil {

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -196,12 +196,7 @@ func (m *NotificationMonitor) Bootstrap(ctx context.Context) error {
 		}
 
 		if err := m.lock.TryLock(); err == nil {
-			bootstrapErr := m.bootstrapOwned(ctx)
-			unlockErr := m.lock.Unlock()
-			if unlockErr != nil {
-				unlockErr = fmt.Errorf("release notification bootstrap lock: %w", unlockErr)
-			}
-			return errors.Join(bootstrapErr, unlockErr)
+			return m.bootstrapLocked(ctx)
 		} else if !errors.Is(err, dirlock.ErrLockConflict) {
 			return fmt.Errorf("acquire notification bootstrap lock: %w", err)
 		}
@@ -212,6 +207,23 @@ func (m *NotificationMonitor) Bootstrap(ctx context.Context) error {
 		case <-ticker.C:
 		}
 	}
+}
+
+func (m *NotificationMonitor) bootstrapLocked(ctx context.Context) error {
+	bootstrapCtx, cancel := context.WithCancel(ctx)
+	m.beginNotificationSession(cancel)
+	heartbeatDone := m.startNotificationLockHeartbeat(bootstrapCtx)
+
+	bootstrapErr := m.bootstrapOwned(bootstrapCtx)
+	cancel()
+	<-heartbeatDone
+	m.endNotificationSession()
+
+	unlockErr := m.lock.Unlock()
+	if unlockErr != nil {
+		unlockErr = fmt.Errorf("release notification bootstrap lock: %w", unlockErr)
+	}
+	return errors.Join(bootstrapErr, unlockErr)
 }
 
 func (m *NotificationMonitor) bootstrapOwned(ctx context.Context) error {
@@ -236,6 +248,14 @@ func (m *NotificationMonitor) bootstrapOwned(ctx context.Context) error {
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if m.lock != nil {
+		if err := m.lock.Heartbeat(ctx); err != nil {
+			return fmt.Errorf("renew notification bootstrap lock: %w", err)
+		}
+	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/internal/service/chatbridge/monitor.go
+++ b/internal/service/chatbridge/monitor.go
@@ -5,12 +5,15 @@ package chatbridge
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
 	"sync"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
 	"github.com/dagucloud/dagu/v2/internal/ir"
@@ -46,7 +49,6 @@ type NotificationMonitorConfig struct {
 	SuccessWindow        time.Duration
 	PendingLimit         int
 	InterestedEventTypes []eventstore.EventType
-	BootstrapCursor      *eventstore.DAGRunCursor
 }
 
 // DefaultNotificationMonitorConfig returns the default monitor settings.
@@ -104,6 +106,7 @@ type StateStore interface {
 
 // Lease coordinates a single active monitor across processes.
 type Lease interface {
+	TryLock() error
 	Lock(ctx context.Context) error
 	Unlock() error
 	Heartbeat(ctx context.Context) error
@@ -121,7 +124,6 @@ type NotificationMonitor struct {
 	logger       *slog.Logger
 	cfg          NotificationMonitorConfig
 	interested   map[eventstore.EventType]struct{}
-	bootstrap    *eventstore.DAGRunCursor
 
 	batcherMu sync.RWMutex
 	batcher   *NotificationBatcher
@@ -153,13 +155,6 @@ func NewNotificationMonitor(
 	cfg NotificationMonitorConfig,
 ) *NotificationMonitor {
 	normalizeNotificationMonitorConfig(&cfg)
-	var bootstrap *eventstore.DAGRunCursor
-	if cfg.BootstrapCursor != nil {
-		cursor := cfg.BootstrapCursor.Normalize()
-		cursor.CommittedOffsets = maps.Clone(cursor.CommittedOffsets)
-		cursor.InboxEventIDs = maps.Clone(cursor.InboxEventIDs)
-		bootstrap = &cursor
-	}
 
 	lockDir := ""
 	if lease != nil {
@@ -175,10 +170,84 @@ func NewNotificationMonitor(
 		logger:       logger,
 		cfg:          cfg,
 		interested:   interestedEventTypeSet(cfg.InterestedEventTypes),
-		bootstrap:    bootstrap,
 		batcher:      NewNotificationBatcher(cfg.UrgentWindow, cfg.SuccessWindow),
 		state:        newNotificationMonitorState(),
 	}
+}
+
+// Bootstrap persists the shared event boundary before producers start.
+func (m *NotificationMonitor) Bootstrap(ctx context.Context) error {
+	if m.stateStore == nil {
+		return errors.New("notification monitor state store is not configured")
+	}
+	if m.lock == nil {
+		return m.bootstrapOwned(ctx)
+	}
+
+	ticker := time.NewTicker(DefaultNotificationLockRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if m.stateStore.IsBootstrapped(ctx) {
+			return nil
+		}
+
+		if err := m.lock.TryLock(); err == nil {
+			bootstrapErr := m.bootstrapOwned(ctx)
+			unlockErr := m.lock.Unlock()
+			if unlockErr != nil {
+				unlockErr = fmt.Errorf("release notification bootstrap lock: %w", unlockErr)
+			}
+			return errors.Join(bootstrapErr, unlockErr)
+		} else if !errors.Is(err, dirlock.ErrLockConflict) {
+			return fmt.Errorf("acquire notification bootstrap lock: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *NotificationMonitor) bootstrapOwned(ctx context.Context) error {
+	loadResult := m.stateStore.Load(ctx)
+	if loadResult.Warning != nil {
+		attrs := []any{slog.String("error", loadResult.Warning.Error())}
+		if loadResult.QuarantinedPath != "" {
+			attrs = append(attrs, slog.String("quarantined_path", loadResult.QuarantinedPath))
+		}
+		m.logger.Warn("Notification state was invalid; starting fresh", attrs...)
+	}
+	if loadResult.State.Bootstrapped {
+		return nil
+	}
+
+	var cursor eventstore.DAGRunCursor
+	if m.eventService != nil {
+		var err error
+		cursor, err = m.eventService.DAGRunHeadCursor(ctx)
+		if err != nil {
+			return fmt.Errorf("capture notification bootstrap cursor: %w", err)
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	state := loadResult.State
+	state.SourceCursor = cursor.Normalize()
+	state.Bootstrapped = true
+
+	if err := m.stateStore.Save(ctx, state); err != nil {
+		return fmt.Errorf("persist notification bootstrap state: %w", err)
+	}
+	return nil
 }
 
 // Run starts the shared notification monitor loop.
@@ -876,16 +945,10 @@ func (m *NotificationMonitor) ensureBootstrapped(ctx context.Context) bool {
 		return true
 	}
 
-	var cursor eventstore.DAGRunCursor
-	if m.bootstrap != nil {
-		cursor = m.bootstrap.Normalize()
-	} else {
-		var err error
-		cursor, err = m.eventService.DAGRunHeadCursor(ctx)
-		if err != nil {
-			m.recordBootstrapFailure("Failed to bootstrap notification cursor: " + err.Error())
-			return false
-		}
+	cursor, err := m.eventService.DAGRunHeadCursor(ctx)
+	if err != nil {
+		m.recordBootstrapFailure("Failed to bootstrap notification cursor: " + err.Error())
+		return false
 	}
 
 	m.stateMu.Lock()

--- a/internal/service/chatbridge/monitor_state.go
+++ b/internal/service/chatbridge/monitor_state.go
@@ -92,23 +92,28 @@ func (s *notificationStateStore) Load(ctx context.Context) notificationStateLoad
 		return result
 	}
 
-	state := newNotificationMonitorState()
-	if err := json.Unmarshal(data, &state); err != nil {
+	state, err := decodeNotificationMonitorState(data)
+	if err != nil {
 		result.Recovered = true
-		result.QuarantinedPath, result.Warning = s.recoverUnreadableState(ctx, fmt.Errorf("decode notification state: %w", err))
+		result.QuarantinedPath, result.Warning = s.recoverUnreadableState(ctx, err)
 		return result
 	}
-	switch state.Version {
-	case 0, notificationMonitorStateVersion:
-	default:
-		result.Recovered = true
-		result.QuarantinedPath, result.Warning = s.recoverUnreadableState(ctx, fmt.Errorf("unsupported notification state version %d", state.Version))
-		return result
-	}
-
-	state.normalize()
 	result.State = state
 	return result
+}
+
+func (s *notificationStateStore) IsBootstrapped(ctx context.Context) bool {
+	if s == nil {
+		return false
+	}
+
+	data, found, err := s.store.Load(ctx)
+	if err != nil || !found {
+		return false
+	}
+
+	state, err := decodeNotificationMonitorState(data)
+	return err == nil && state.Bootstrapped
 }
 
 func (s *notificationStateStore) Save(ctx context.Context, state notificationMonitorState) error {
@@ -131,4 +136,19 @@ func (s *notificationStateStore) recoverUnreadableState(ctx context.Context, err
 		return "", fmt.Errorf("%w (quarantine failed: %v)", err, quarantineErr)
 	}
 	return quarantinedPath, err
+}
+
+func decodeNotificationMonitorState(data []byte) (notificationMonitorState, error) {
+	state := newNotificationMonitorState()
+	if err := json.Unmarshal(data, &state); err != nil {
+		return state, fmt.Errorf("decode notification state: %w", err)
+	}
+	switch state.Version {
+	case 0, notificationMonitorStateVersion:
+	default:
+		return state, fmt.Errorf("unsupported notification state version %d", state.Version)
+	}
+
+	state.normalize()
+	return state, nil
 }

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -43,6 +43,22 @@ func (failingBootstrapStateStore) Quarantine(context.Context) (string, error) {
 	return "", nil
 }
 
+type blockingHeadStore struct {
+	*stubNotificationStore
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingHeadStore) DAGRunHeadCursor(ctx context.Context) (eventstore.DAGRunCursor, error) {
+	close(s.started)
+	select {
+	case <-ctx.Done():
+		return eventstore.DAGRunCursor{}, ctx.Err()
+	case <-s.release:
+		return s.stubNotificationStore.DAGRunHeadCursor(ctx)
+	}
+}
+
 func newTestNotificationMonitorConfig() NotificationMonitorConfig {
 	cfg := DefaultNotificationMonitorConfig()
 	cfg.PollInterval = 10 * time.Millisecond
@@ -258,6 +274,42 @@ func TestNotificationMonitor_ConcurrentBootstrapCapturesHeadOnce(t *testing.T) {
 	}
 	headCalls, _ := store.stats()
 	assert.Equal(t, 1, headCalls)
+}
+
+func TestNotificationMonitor_BootstrapDoesNotPersistAfterLeaseLoss(t *testing.T) {
+	t.Parallel()
+
+	store := &blockingHeadStore{
+		stubNotificationStore: &stubNotificationStore{},
+		started:               make(chan struct{}),
+		release:               make(chan struct{}),
+	}
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	lease := filemonitor.NewLease(stateFile, &dirlock.LockOptions{})
+	monitor := NewNotificationMonitor(
+		eventstore.New(store),
+		filemonitor.NewStateStore(stateFile),
+		lease,
+		&fakeNotificationTransport{destinations: []string{"dest-1"}},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		newTestNotificationMonitorConfig(),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- monitor.Bootstrap(context.Background())
+	}()
+	<-store.started
+	require.NoError(t, os.RemoveAll(filepath.Join(lease.Location(), dirlock.LockDirectoryName)))
+	replacement := filemonitor.NewLease(stateFile, &dirlock.LockOptions{})
+	require.NoError(t, replacement.TryLock())
+	defer func() {
+		require.NoError(t, replacement.Unlock())
+	}()
+	close(store.release)
+
+	require.Error(t, <-errCh)
+	assert.False(t, newNotificationStateStore(filemonitor.NewStateStore(stateFile)).IsBootstrapped(context.Background()))
 }
 
 func TestNotificationMonitor_BootstrapReturnsErrors(t *testing.T) {

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -276,7 +276,7 @@ func TestNotificationMonitor_ConcurrentBootstrapCapturesHeadOnce(t *testing.T) {
 	assert.Equal(t, 1, headCalls)
 }
 
-func TestNotificationMonitor_BootstrapDoesNotPersistAfterLeaseLoss(t *testing.T) {
+func TestNotificationMonitor_BootstrapLeaseCannotBeReplaced(t *testing.T) {
 	t.Parallel()
 
 	store := &blockingHeadStore{
@@ -285,7 +285,11 @@ func TestNotificationMonitor_BootstrapDoesNotPersistAfterLeaseLoss(t *testing.T)
 		release:               make(chan struct{}),
 	}
 	stateFile := filepath.Join(t.TempDir(), "state.json")
-	lease := filemonitor.NewLease(stateFile, &dirlock.LockOptions{})
+	lockOpts := &dirlock.LockOptions{
+		StaleThreshold: time.Millisecond,
+		RetryInterval:  DefaultNotificationLockRetryInterval,
+	}
+	lease := filemonitor.NewLease(stateFile, lockOpts)
 	monitor := NewNotificationMonitor(
 		eventstore.New(store),
 		filemonitor.NewStateStore(stateFile),
@@ -300,16 +304,19 @@ func TestNotificationMonitor_BootstrapDoesNotPersistAfterLeaseLoss(t *testing.T)
 		errCh <- monitor.Bootstrap(context.Background())
 	}()
 	<-store.started
-	require.NoError(t, os.RemoveAll(filepath.Join(lease.Location(), dirlock.LockDirectoryName)))
-	replacement := filemonitor.NewLease(stateFile, &dirlock.LockOptions{})
-	require.NoError(t, replacement.TryLock())
+	stale := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(filepath.Join(lease.Location(), dirlock.LockDirectoryName), stale, stale))
+	replacement := filemonitor.NewLease(stateFile, lockOpts)
+	replacementErr := replacement.TryLock()
 	defer func() {
 		require.NoError(t, replacement.Unlock())
 	}()
 	close(store.release)
 
-	require.Error(t, <-errCh)
-	assert.False(t, newNotificationStateStore(filemonitor.NewStateStore(stateFile)).IsBootstrapped(context.Background()))
+	bootstrapErr := <-errCh
+	require.ErrorIs(t, replacementErr, dirlock.ErrLockConflict)
+	require.NoError(t, bootstrapErr)
+	assert.True(t, newNotificationStateStore(filemonitor.NewStateStore(stateFile)).IsBootstrapped(context.Background()))
 }
 
 func TestNotificationMonitor_BootstrapReturnsErrors(t *testing.T) {

--- a/internal/service/chatbridge/monitor_state_test.go
+++ b/internal/service/chatbridge/monitor_state_test.go
@@ -6,6 +6,7 @@ package chatbridge
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,6 +28,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingBootstrapStateStore struct{}
+
+func (failingBootstrapStateStore) Load(context.Context) ([]byte, bool, error) {
+	return nil, false, nil
+}
+
+func (failingBootstrapStateStore) Save(context.Context, []byte) error {
+	return errors.New("save failed")
+}
+
+func (failingBootstrapStateStore) Quarantine(context.Context) (string, error) {
+	return "", nil
+}
 
 func newTestNotificationMonitorConfig() NotificationMonitorConfig {
 	cfg := DefaultNotificationMonitorConfig()
@@ -158,6 +173,143 @@ func TestNotificationMonitor_BootstrapsFromCurrentHeadAndOnlyDeliversFutureEvent
 	require.Eventually(t, func() bool {
 		return !monitor.IsDelivered("dest-1", oldStatus) && monitor.IsDelivered("dest-1", newStatus)
 	}, notificationMonitorEventuallyTimeout(time.Second), 10*time.Millisecond)
+}
+
+func TestNotificationMonitor_CompetingBootstrapPreservesStartupEvent(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store, err := fileeventstore.New(baseDir)
+	require.NoError(t, err)
+	service := eventstore.New(store)
+
+	delivered := make(chan string, 1)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(_ context.Context, _ string, batch NotificationBatch, _ bool) bool {
+			for _, event := range batch.Events {
+				if event.Status != nil {
+					delivered <- event.Status.DAGRunID
+				}
+			}
+			return true
+		},
+	}
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	earlierMonitor := newFileBackedMonitor(service, stateFile, transport, logger, newTestNotificationMonitorConfig())
+	require.NoError(t, earlierMonitor.Bootstrap(context.Background()))
+
+	status := &ir.DAGRunStatus{
+		Name:       "briefing",
+		DAGRunID:   "run-startup",
+		AttemptID:  "attempt-startup",
+		Status:     ir.Failed,
+		Error:      "startup failure",
+		FinishedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	require.NoError(t, service.Emit(context.Background(), eventstore.NewDAGRunEvent(
+		eventstore.Source{Service: eventstore.SourceServiceScheduler, Instance: "test"},
+		eventstore.TypeDAGRunFailed,
+		status,
+		nil,
+	)))
+
+	laterMonitor := newFileBackedMonitor(service, stateFile, transport, logger, newTestNotificationMonitorConfig())
+	require.NoError(t, laterMonitor.Bootstrap(context.Background()))
+	stopLaterMonitor := testutil.StartContextRunner(t, laterMonitor)
+	defer stopLaterMonitor()
+
+	select {
+	case runID := <-delivered:
+		assert.Equal(t, status.DAGRunID, runID)
+	case <-time.After(notificationMonitorEventuallyTimeout(time.Second)):
+		t.Fatal("timed out waiting for startup event delivery")
+	}
+}
+
+func TestNotificationMonitor_ConcurrentBootstrapCapturesHeadOnce(t *testing.T) {
+	t.Parallel()
+
+	store := &stubNotificationStore{}
+	service := eventstore.New(store)
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	transport := &fakeNotificationTransport{destinations: []string{"dest-1"}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	monitors := []*NotificationMonitor{
+		newFileBackedMonitor(service, stateFile, transport, logger, newTestNotificationMonitorConfig()),
+		newFileBackedMonitor(service, stateFile, transport, logger, newTestNotificationMonitorConfig()),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), notificationMonitorEventuallyTimeout(time.Second))
+	defer cancel()
+	start := make(chan struct{})
+	errs := make(chan error, len(monitors))
+	for _, monitor := range monitors {
+		go func() {
+			<-start
+			errs <- monitor.Bootstrap(ctx)
+		}()
+	}
+	close(start)
+
+	for range monitors {
+		require.NoError(t, <-errs)
+	}
+	headCalls, _ := store.stats()
+	assert.Equal(t, 1, headCalls)
+}
+
+func TestNotificationMonitor_BootstrapReturnsErrors(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	transport := &fakeNotificationTransport{destinations: []string{"dest-1"}}
+
+	t.Run("head", func(t *testing.T) {
+		store := &stubNotificationStore{failHead: true}
+		stateFile := filepath.Join(t.TempDir(), "state.json")
+		monitor := newFileBackedMonitor(eventstore.New(store), stateFile, transport, logger, newTestNotificationMonitorConfig())
+
+		err := monitor.Bootstrap(context.Background())
+
+		require.ErrorContains(t, err, "capture notification bootstrap cursor")
+		assert.False(t, newNotificationStateStore(filemonitor.NewStateStore(stateFile)).IsBootstrapped(context.Background()))
+	})
+
+	t.Run("save", func(t *testing.T) {
+		monitor := NewNotificationMonitor(
+			eventstore.New(&stubNotificationStore{}),
+			failingBootstrapStateStore{},
+			nil,
+			transport,
+			logger,
+			newTestNotificationMonitorConfig(),
+		)
+
+		err := monitor.Bootstrap(context.Background())
+
+		require.ErrorContains(t, err, "persist notification bootstrap state")
+	})
+
+	t.Run("lease", func(t *testing.T) {
+		blockedPath := filepath.Join(t.TempDir(), "blocked")
+		require.NoError(t, os.WriteFile(blockedPath, []byte("file"), 0o600))
+		stateFile := filepath.Join(t.TempDir(), "state.json")
+		leaseFile := filepath.Join(blockedPath, "state.json")
+		monitor := NewNotificationMonitor(
+			eventstore.New(&stubNotificationStore{}),
+			filemonitor.NewStateStore(stateFile),
+			filemonitor.NewLease(leaseFile, &dirlock.LockOptions{}),
+			transport,
+			logger,
+			newTestNotificationMonitorConfig(),
+		)
+
+		err := monitor.Bootstrap(context.Background())
+
+		require.ErrorContains(t, err, "acquire notification bootstrap lock")
+	})
 }
 
 func TestNotificationMonitor_RestartRequeuesPersistedPending(t *testing.T) {

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -338,13 +339,32 @@ func TestNotificationMonitor_PollSourceRoutesEventsPerDestination(t *testing.T) 
 	assert.ElementsMatch(t, []string{"dest-a", "dest-b"}, destinations)
 }
 
-func TestNotificationMonitor_BootstrapCursorDeliversStartupEvent(t *testing.T) {
+func TestNotificationMonitor_BootstrapDeliversStartupEvent(t *testing.T) {
 	t.Parallel()
 
 	store := &stubNotificationStore{}
 	service := eventstore.New(store)
-	cursor, err := service.DAGRunHeadCursor(context.Background())
-	require.NoError(t, err)
+
+	delivered := make(chan struct{}, 1)
+	transport := &fakeNotificationTransport{
+		destinations: []string{"dest-1"},
+		flushFn: func(context.Context, string, NotificationBatch, bool) bool {
+			delivered <- struct{}{}
+			return true
+		},
+	}
+	cfg := DefaultNotificationMonitorConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.SeenEvictInterval = time.Hour
+	cfg.UrgentWindow = 10 * time.Millisecond
+	monitor := newFileBackedMonitor(
+		service,
+		filepath.Join(t.TempDir(), "state.json"),
+		transport,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg,
+	)
+	require.NoError(t, monitor.Bootstrap(context.Background()))
 
 	status := &ir.DAGRunStatus{
 		Name:      "briefing",
@@ -360,21 +380,6 @@ func TestNotificationMonitor_BootstrapCursorDeliversStartupEvent(t *testing.T) {
 		nil,
 	)))
 
-	delivered := make(chan struct{}, 1)
-	transport := &fakeNotificationTransport{
-		destinations: []string{"dest-1"},
-		flushFn: func(context.Context, string, NotificationBatch, bool) bool {
-			delivered <- struct{}{}
-			return true
-		},
-	}
-	cfg := DefaultNotificationMonitorConfig()
-	cfg.BootstrapCursor = &cursor
-	cfg.PollInterval = 10 * time.Millisecond
-	cfg.SeenEvictInterval = time.Hour
-	cfg.UrgentWindow = 10 * time.Millisecond
-
-	monitor := NewNotificationMonitor(service, nil, nil, transport, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg)
 	stopMonitor := testutil.StartContextRunner(t, monitor)
 	defer stopMonitor()
 

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -901,12 +901,12 @@ func (srv *Server) Serve(ctx context.Context) error {
 		WriteTimeout:      httpWriteTimeout,
 	}
 
+	if err := srv.startMonitors(ctx); err != nil {
+		return err
+	}
+
 	metrics.StartUptime(ctx)
 	logger.Info(ctx, "Server is starting", tag.Addr(addr))
-
-	monitorCursor := srv.captureMonitorCursor(ctx)
-	srv.startNotificationMonitor(ctx, monitorCursor)
-	srv.startIncidentMonitor(ctx, monitorCursor)
 	srv.startPeriodicUpdateCheck(ctx)
 
 	go srv.startServer(ctx)
@@ -929,64 +929,72 @@ func trustedProxyRequestHeaders(cfg config.AuthTrustedProxy) []string {
 	return headers
 }
 
-func (srv *Server) startNotificationMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+func (srv *Server) startMonitors(ctx context.Context) error {
+	notificationMonitor := srv.newNotificationMonitor()
+	incidentMonitor := srv.newIncidentMonitor()
+
+	if notificationMonitor != nil {
+		if err := notificationMonitor.Bootstrap(ctx); err != nil {
+			return fmt.Errorf("bootstrap notification monitor: %w", err)
+		}
+	}
+
+	if incidentMonitor != nil {
+		if err := incidentMonitor.Bootstrap(ctx); err != nil {
+			return fmt.Errorf("bootstrap incident monitor: %w", err)
+		}
+	}
+
+	if notificationMonitor != nil {
+		go notificationMonitor.Run(ctx)
+	}
+
+	if incidentMonitor != nil {
+		go incidentMonitor.Run(ctx)
+	}
+	return nil
+}
+
+func (srv *Server) newNotificationMonitor() *chatbridge.NotificationMonitor {
 	if srv.notificationService == nil || srv.eventService == nil {
-		return
+		return nil
 	}
 	if srv.notificationState == nil {
-		return
+		return nil
 	}
 	var lease chatbridge.Lease
 	if srv.newNotificationLease != nil {
 		lease = srv.newNotificationLease()
 	}
-	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
-	monitorConfig.BootstrapCursor = cursor
-	monitor := chatbridge.NewNotificationMonitor(
+	return chatbridge.NewNotificationMonitor(
 		srv.eventService,
 		srv.notificationState,
 		lease,
 		srv.notificationService,
 		slog.Default(),
-		monitorConfig,
+		chatbridge.DefaultNotificationMonitorConfig(),
 	)
-	go monitor.Run(ctx)
 }
 
-func (srv *Server) startIncidentMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+func (srv *Server) newIncidentMonitor() *chatbridge.NotificationMonitor {
 	if srv.incidentService == nil || srv.eventService == nil {
-		return
+		return nil
 	}
 	if srv.incidentState == nil {
-		return
+		return nil
 	}
 	var lease chatbridge.Lease
 	if srv.newIncidentLease != nil {
 		lease = srv.newIncidentLease()
 	}
-	monitorConfig := incidentMonitorConfig()
-	monitorConfig.BootstrapCursor = cursor
-	monitor := chatbridge.NewNotificationMonitor(
+	return chatbridge.NewNotificationMonitor(
 		srv.eventService,
 		srv.incidentState,
 		lease,
 		srv.incidentService,
 		slog.Default(),
-		monitorConfig,
+		incidentMonitorConfig(),
 	)
-	go monitor.Run(ctx)
-}
-
-func (srv *Server) captureMonitorCursor(ctx context.Context) *eventstore.DAGRunCursor {
-	if srv.eventService == nil || (srv.notificationService == nil && srv.incidentService == nil) {
-		return nil
-	}
-	cursor, err := srv.eventService.DAGRunHeadCursor(ctx)
-	if err != nil {
-		slog.Default().Warn("Failed to capture notification cursor", slog.String("error", err.Error()))
-		return nil
-	}
-	return &cursor
 }
 
 func incidentMonitorConfig() chatbridge.NotificationMonitorConfig {

--- a/internal/service/notification/service_test.go
+++ b/internal/service/notification/service_test.go
@@ -16,17 +16,20 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/dirlock"
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	notificationmodel "github.com/dagucloud/dagu/v2/internal/notification"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	fileeventstore "github.com/dagucloud/dagu/v2/internal/persis/file/eventstore"
+	filemonitor "github.com/dagucloud/dagu/v2/internal/persis/file/monitor"
 	"github.com/dagucloud/dagu/v2/internal/service/chatbridge"
 	"github.com/dagucloud/dagu/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -316,8 +319,25 @@ func TestService_DeliversLifecycleEvent(t *testing.T) {
 	eventStore, err := fileeventstore.New(t.TempDir())
 	require.NoError(t, err)
 	eventService := eventstore.New(eventStore)
-	cursor, err := eventService.DAGRunHeadCursor(context.Background())
-	require.NoError(t, err)
+
+	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
+	monitorConfig.PollInterval = 10 * time.Millisecond
+	monitorConfig.UrgentWindow = 10 * time.Millisecond
+	monitorConfig.SeenEvictInterval = time.Hour
+	stateFile := filepath.Join(t.TempDir(), "monitor-state.json")
+	monitor := chatbridge.NewNotificationMonitor(
+		eventService,
+		filemonitor.NewStateStore(stateFile),
+		filemonitor.NewLease(stateFile, &dirlock.LockOptions{
+			StaleThreshold: chatbridge.DefaultNotificationLockStaleThreshold,
+			RetryInterval:  chatbridge.DefaultNotificationLockRetryInterval,
+		}),
+		svc,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		monitorConfig,
+	)
+	require.NoError(t, monitor.Bootstrap(context.Background()))
+
 	require.NoError(t, eventService.Emit(context.Background(), eventstore.NewDAGRunEvent(
 		eventstore.Source{Service: eventstore.SourceServiceScheduler},
 		eventstore.TypeDAGRunFailed,
@@ -331,19 +351,6 @@ func TestService_DeliversLifecycleEvent(t *testing.T) {
 		nil,
 	)))
 
-	monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
-	monitorConfig.BootstrapCursor = &cursor
-	monitorConfig.PollInterval = 10 * time.Millisecond
-	monitorConfig.UrgentWindow = 10 * time.Millisecond
-	monitorConfig.SeenEvictInterval = time.Hour
-	monitor := chatbridge.NewNotificationMonitor(
-		eventService,
-		nil,
-		nil,
-		svc,
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
-		monitorConfig,
-	)
 	stopMonitor := testutil.StartContextRunner(t, monitor)
 	defer stopMonitor()
 

--- a/internal/service/scheduler/monitors.go
+++ b/internal/service/scheduler/monitors.go
@@ -4,7 +4,6 @@
 package scheduler
 
 import (
-	"context"
 	"log/slog"
 	"time"
 
@@ -18,7 +17,7 @@ import (
 	notificationservice "github.com/dagucloud/dagu/v2/internal/service/notification"
 )
 
-func newNotificationMonitor(cfg *config.Config, deps Dependencies) func(context.Context, *eventstore.DAGRunCursor) {
+func newNotificationMonitor(cfg *config.Config, deps Dependencies) *chatbridge.NotificationMonitor {
 	if deps.NotificationStore == nil || deps.NotificationState == nil {
 		return nil
 	}
@@ -27,18 +26,14 @@ func newNotificationMonitor(cfg *config.Config, deps Dependencies) func(context.
 		lease = deps.NewNotificationLease()
 	}
 	service := newNotificationService(cfg, deps.NotificationStore, deps.DAGRepository)
-	return func(ctx context.Context, cursor *eventstore.DAGRunCursor) {
-		monitorConfig := chatbridge.DefaultNotificationMonitorConfig()
-		monitorConfig.BootstrapCursor = cursor
-		chatbridge.NewNotificationMonitor(
-			deps.EventService,
-			deps.NotificationState,
-			lease,
-			service,
-			slog.Default(),
-			monitorConfig,
-		).Run(ctx)
-	}
+	return chatbridge.NewNotificationMonitor(
+		deps.EventService,
+		deps.NotificationState,
+		lease,
+		service,
+		slog.Default(),
+		chatbridge.DefaultNotificationMonitorConfig(),
+	)
 }
 
 func newNotificationService(
@@ -53,7 +48,7 @@ func newNotificationService(
 	return notificationservice.New(store, dagRepository, opts...)
 }
 
-func newIncidentMonitor(cfg *config.Config, deps Dependencies) func(context.Context, *eventstore.DAGRunCursor) {
+func newIncidentMonitor(cfg *config.Config, deps Dependencies) *chatbridge.NotificationMonitor {
 	if deps.IncidentStore == nil || deps.IncidentState == nil {
 		return nil
 	}
@@ -80,15 +75,12 @@ func newIncidentMonitor(cfg *config.Config, deps Dependencies) func(context.Cont
 		eventstore.TypeDAGRunSucceeded,
 		eventstore.TypeDAGRunPartiallySucceeded,
 	}
-	return func(ctx context.Context, cursor *eventstore.DAGRunCursor) {
-		monitorConfig.BootstrapCursor = cursor
-		chatbridge.NewNotificationMonitor(
-			deps.EventService,
-			deps.IncidentState,
-			lease,
-			service,
-			slog.Default(),
-			monitorConfig,
-		).Run(ctx)
-	}
+	return chatbridge.NewNotificationMonitor(
+		deps.EventService,
+		deps.IncidentState,
+		lease,
+		service,
+		slog.Default(),
+		monitorConfig,
+	)
 }

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -86,10 +86,9 @@ type Scheduler struct {
 	startupCancel       context.CancelFunc
 	lockHeld            atomic.Bool
 	clock               Clock // Clock function for getting current time
-	eventService        *eventstore.Service
 	eventCollector      func(context.Context)
-	notificationMonitor func(context.Context, *eventstore.DAGRunCursor)
-	incidentMonitor     func(context.Context, *eventstore.DAGRunCursor)
+	notificationMonitor *chatbridge.NotificationMonitor
+	incidentMonitor     *chatbridge.NotificationMonitor
 }
 
 type schedulerHooks struct {
@@ -162,7 +161,6 @@ func New(cfg *config.Config, deps Dependencies) (*Scheduler, error) {
 		return nil, err
 	}
 	scheduler.eventCollector = deps.EventCollector
-	scheduler.eventService = deps.EventService
 	if deps.EventService != nil {
 		scheduler.notificationMonitor = newNotificationMonitor(cfg, deps)
 		scheduler.incidentMonitor = newIncidentMonitor(cfg, deps)
@@ -591,7 +589,9 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	}
 
 	s.updateServiceStatus(ctx, serviceregistry.ServiceStatusActive, "Failed to update status to active", "Updated scheduler status to active")
-	monitorCursor := s.captureMonitorCursor(ctx)
+	if err := s.BootstrapMonitors(ctx); err != nil {
+		return err
+	}
 
 	sig := make(chan os.Signal, 1)
 
@@ -645,11 +645,11 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	})
 
 	wg.Go(func() {
-		s.startNotificationMonitor(ctx, monitorCursor)
+		s.startNotificationMonitor(ctx)
 	})
 
 	wg.Go(func() {
-		s.startIncidentMonitor(ctx, monitorCursor)
+		s.startIncidentMonitor(ctx)
 	})
 
 	wg.Go(func() {
@@ -712,30 +712,34 @@ func (s *Scheduler) startEventCollector(ctx context.Context) {
 	s.eventCollector(ctx)
 }
 
-func (s *Scheduler) startNotificationMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+// BootstrapMonitors persists the shared event boundary before producers start.
+func (s *Scheduler) BootstrapMonitors(ctx context.Context) error {
+	if s.notificationMonitor != nil {
+		if err := s.notificationMonitor.Bootstrap(ctx); err != nil {
+			return fmt.Errorf("bootstrap notification monitor: %w", err)
+		}
+	}
+
+	if s.incidentMonitor != nil {
+		if err := s.incidentMonitor.Bootstrap(ctx); err != nil {
+			return fmt.Errorf("bootstrap incident monitor: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Scheduler) startNotificationMonitor(ctx context.Context) {
 	if s.notificationMonitor == nil {
 		return
 	}
-	s.notificationMonitor(ctx, cursor)
+	s.notificationMonitor.Run(ctx)
 }
 
-func (s *Scheduler) startIncidentMonitor(ctx context.Context, cursor *eventstore.DAGRunCursor) {
+func (s *Scheduler) startIncidentMonitor(ctx context.Context) {
 	if s.incidentMonitor == nil {
 		return
 	}
-	s.incidentMonitor(ctx, cursor)
-}
-
-func (s *Scheduler) captureMonitorCursor(ctx context.Context) *eventstore.DAGRunCursor {
-	if s.eventService == nil || (s.notificationMonitor == nil && s.incidentMonitor == nil) {
-		return nil
-	}
-	cursor, err := s.eventService.DAGRunHeadCursor(ctx)
-	if err != nil {
-		logger.Warn(ctx, "Failed to capture notification cursor", tag.Error(err))
-		return nil
-	}
-	return &cursor
+	s.incidentMonitor.Run(ctx)
 }
 
 func (s *Scheduler) startHeartbeat(ctx context.Context) {


### PR DESCRIPTION
## Summary

- persist one shared notification and incident cursor under the monitor lease
- establish the boundary before standalone or bundled services emit DAG-run events
- fail startup when the boundary cannot be captured or saved

## Testing

- go test -race ./internal/service/chatbridge ./internal/service/scheduler ./internal/service/frontend ./internal/service/notification ./internal/service/incident ./internal/cmd -count=1
- make fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup race where notification and incident monitors captured separate event cursors before competing for the shared lease, letting a later winner persist a newer cursor and skip startup events. Each monitor now persists one shared boundary under the lease before DAG-run event producers start.

**Refactors**
- Startup now fails fast if the boundary can't be captured or saved, instead of logging a warning and continuing.
- Removes the `BootstrapCursor` config option; the persisted state file serves as the single bootstrap source.
- Keeps the lease alive during capture and renews it right before persistence, so a replacement owner can't be overwritten by a stale bootstrap.
- Adds a process-backed lock to the lease so a stale directory timestamp can't displace a live owner during a state write.

<sup>Written for commit 5a24c059781e00ee7bfe77c4c792d5415474d0e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification and incident monitor startup to reliably capture events without missing events during initialization.
  * Prevented services from starting when monitor initialization fails.
  * Improved recovery and validation of saved monitor state, including corrupted or unsupported state.

* **Reliability**
  * Coordinated monitor initialization across the frontend and scheduler to preserve startup events.
  * Strengthened monitor locking to support safe concurrent startup and retries.

* **Tests**
  * Expanded coverage for concurrent startup, event delivery, state-saving failures, and lock-acquisition errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->