### PR TITLE
Fix remote context and worker deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,10 +746,11 @@ Operational detail for the [distributed workers](#how-you-run-dagu) topology:
 
 ```sh
 # Start coordinator
-dagu coordinator
+dagu coordinator --coordinator.host=0.0.0.0 --coordinator.advertise=coordinator.internal
 
 # Start workers (on separate machines)
-DAGU_WORKER_LABELS=gpu=true,memory=64G dagu worker
+DAGU_WORKER_COORDINATORS=coordinator.internal:50055 \
+  DAGU_WORKER_LABELS=gpu=true,memory=64G dagu worker
 ```
 
 See the [distributed execution documentation](https://docs.dagu.sh/server-admin/distributed/) for setup details.
@@ -906,7 +907,7 @@ OIDC variables: `DAGU_AUTH_OIDC_CLIENT_ID`, `DAGU_AUTH_OIDC_CLIENT_SECRET`, `DAG
 | `DAGU_WORKER_HEALTH_PORT` | `8092` | Worker health check port |
 | `DAGU_WORKER_LABELS` | — | Worker labels (`key=value,key=value`); `os` and `arch` are built in and cannot be overridden |
 | `DAGU_COORDINATOR_ADVERTISE` | auto-detected hostname | Address advertised in the service registry |
-| `DAGU_WORKER_COORDINATORS` | — | Explicit coordinator addresses for shared-nothing mode |
+| `DAGU_WORKER_COORDINATORS` | — | Coordinator addresses required by `dagu worker` (`host:port,...`) |
 
 ### Peer TLS (gRPC)
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory hosts Docker-centric deployment assets for Dagu.
 
-- `compose.minimal.yaml` – lightweight stack with scheduler, worker, and UI for local experiments.
+- `compose.minimal.yaml` – lightweight stack with the web UI, scheduler, and coordinator for local experiments.
 - `compose.prod.yaml` – production-like stack including OpenTelemetry collector and Prometheus.
 - `otel-collector.yaml` – default collector configuration used by `compose.prod.yaml`.
 - `prometheus.yaml` – scrape configuration paired with the production-like compose stack.
@@ -17,4 +17,8 @@ docker compose -f deploy/docker/compose.minimal.yaml up -d
 
 The standard Ubuntu image includes CA certificates and common runtime utilities such as `curl`, `git`, `jq`, the OpenSSH client, and `unzip`. The Alpine image remains minimal, while the development image includes the broader build and language toolchain.
 
-The Compose stacks mount `deploy/docker/dags/` read-write so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.
+The Compose stacks mount `deploy/docker/dags/` read-write on server-side Dagu services so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.
+
+Remote CLI contexts use the HTTP API on port `8080`. Include the API path in the context URL, for example `http://host:8080/api/v1`.
+
+The production stack keeps coordinator port `50055` inside `dagu-net`. External workers require publishing that port and setting `DAGU_COORDINATOR_ADVERTISE` to a hostname or IP they can reach.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -19,6 +19,6 @@ The standard Ubuntu image includes CA certificates and common runtime utilities 
 
 The Compose stacks mount `deploy/docker/dags/` read-write on server-side Dagu services so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.
 
-Remote CLI contexts use the HTTP API on port `8080`. Include the API path in the context URL, for example `http://host:8080/api/v1`.
+Remote CLI contexts use the web/API endpoint, not the coordinator port. Prefer an HTTPS endpoint and include the API path, for example `https://dagu.example.com/api/v1`. A direct `http://host:8080/api/v1` URL sends the API key without transport encryption; use it only on a trusted or encrypted network.
 
-The production stack keeps coordinator port `50055` inside `dagu-net`. External workers require publishing that port and setting `DAGU_COORDINATOR_ADVERTISE` to a hostname or IP they can reach.
+The production stack keeps coordinator port `50055` inside `dagu-net`. Before connecting external workers, set `DAGU_COORDINATOR_ADVERTISE` to an address they can reach and configure peer TLS or mTLS on the coordinator and workers. Publish port `50055` only to the restricted worker network. See the [transport security guide](https://docs.dagu.sh/server-admin/distributed/transport-security).

--- a/deploy/docker/compose.prod.yaml
+++ b/deploy/docker/compose.prod.yaml
@@ -110,6 +110,8 @@ services:
       # OTel: point DAGs to collector via per-DAG otel.endpoint: "otel-collector:4317"
     depends_on:
       - dagu-coordinator
+    volumes:
+      - dagu-data:/var/lib/dagu
     networks: [dagu-net]
 
   # Grafana: visualize Prometheus metrics

--- a/deploy/docker/compose.prod.yaml
+++ b/deploy/docker/compose.prod.yaml
@@ -1,5 +1,4 @@
 # Example production Docker Compose setup for Dagu with OpenTelemetry, Prometheus, and Grafana
-version: "3.9"
 
 services:
   # OpenTelemetry stack for tracing (from docs/features/opentelemetry-testing.md)
@@ -41,11 +40,10 @@ services:
     environment:
       # Peer config: insecure by default; set TLS envs if needed
       - DAGU_PEER_INSECURE=true
-      # Bind and advertise on container IP/DNS so workers can reach it
-      - DAGU_COORDINATOR_HOST=dagu-coordinator
+      # Bind on the container network and advertise stable Compose DNS
+      - DAGU_COORDINATOR_HOST=0.0.0.0
+      - DAGU_COORDINATOR_ADVERTISE=dagu-coordinator
       - DAGU_COORDINATOR_PORT=50055
-    ports:
-      - "50055:50055"
     volumes:
       - dagu-data:/var/lib/dagu
       - ./dags:/var/lib/dagu/dags
@@ -105,18 +103,13 @@ services:
     image: ghcr.io/dagucloud/dagu:latest
     command: ["dagu", "worker"]
     environment:
-      - DAGU_COORDINATOR_HOST=dagu-coordinator
-      - DAGU_COORDINATOR_PORT=50055
+      - DAGU_WORKER_COORDINATORS=dagu-coordinator:50055
       # Optional worker tuning and labels
       # - DAGU_WORKER_MAX_ACTIVE_RUNS=100
       # - DAGU_WORKER_LABELS=region=us-east-1,instance-type=m5.large
       # OTel: point DAGs to collector via per-DAG otel.endpoint: "otel-collector:4317"
     depends_on:
       - dagu-coordinator
-    volumes:
-      - dagu-data:/var/lib/dagu
-      # Workers typically don't need DAG definitions, but sharing is harmless
-      - ./dags:/var/lib/dagu/dags
     networks: [dagu-net]
 
   # Grafana: visualize Prometheus metrics

--- a/internal/cmd/context_command.go
+++ b/internal/cmd/context_command.go
@@ -40,7 +40,7 @@ var contextManageFlags = []commandLineFlag{
 }
 
 var (
-	contextServerFlag        = commandLineFlag{name: "server", usage: "Base URL of the remote Dagu server"}
+	contextServerFlag        = commandLineFlag{name: "server", usage: "API base URL of the remote Dagu server (for example, https://dagu.example.com/api/v1)"}
 	contextAPIKeyFlag        = commandLineFlag{name: "api-key", usage: "API key to use for the context"}
 	contextDescriptionFlag   = commandLineFlag{name: "description", usage: "Optional human-readable description"}
 	contextSkipTLSVerifyFlag = commandLineFlag{name: "skip-tls-verify", usage: "Skip TLS certificate verification", isBool: true}

--- a/internal/cmd/context_command_test.go
+++ b/internal/cmd/context_command_test.go
@@ -49,6 +49,15 @@ func TestReadContextInput_RequiresServerAndAPIKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "--api-key is required")
 }
 
+func TestContextServerFlagDescribesAPIBaseURL(t *testing.T) {
+	t.Parallel()
+
+	command := contextAddCommand()
+	flag := command.Flags().Lookup("server")
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "API base URL")
+}
+
 func TestContextUpdate_CanClearDescriptionWithoutOverwritingOtherFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -276,7 +276,7 @@ var (
 
 	workerCoordinatorsFlag = commandLineFlag{
 		name:      "worker.coordinators",
-		usage:     "Coordinator addresses for static discovery (format: host1:port1,host2:port2)",
+		usage:     "Required coordinator addresses (format: host1:port1,host2:port2)",
 		bindViper: true,
 	}
 )

--- a/internal/cmd/worker_test.go
+++ b/internal/cmd/worker_test.go
@@ -36,6 +36,9 @@ func TestWorkerCommand(t *testing.T) {
 		// The actual flag names depend on how they're registered
 		assert.NotEmpty(t, cli.Long, "Long description should be set")
 		require.NotNil(t, flags.Lookup("worker.health-port"))
+		coordinatorsFlag := flags.Lookup("worker.coordinators")
+		require.NotNil(t, coordinatorsFlag)
+		assert.Contains(t, coordinatorsFlag.Usage, "Required")
 	})
 
 	t.Run("WorkerCommandLongDescriptionContainsUsageInfo", func(t *testing.T) {

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -151,7 +151,7 @@ func TestDockerComposeWorkerUsesCoordinatorRPC(t *testing.T) {
 
 	worker := compose.Services["dagu-worker"]
 	require.Contains(t, worker.Environment, "DAGU_WORKER_COORDINATORS=dagu-coordinator:50055")
-	require.Empty(t, worker.Volumes)
+	require.Equal(t, []string{"dagu-data:/var/lib/dagu"}, worker.Volumes)
 }
 
 func repoRoot(t *testing.T) string {

--- a/internal/packaging/container_init_test.go
+++ b/internal/packaging/container_init_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,7 +114,7 @@ func TestDockerComposeDAGMountsStayWritable(t *testing.T) {
 
 	expectedMountCounts := map[string]int{
 		"deploy/docker/compose.minimal.yaml": 1,
-		"deploy/docker/compose.prod.yaml":    4,
+		"deploy/docker/compose.prod.yaml":    3,
 	}
 
 	root := repoRoot(t)
@@ -127,6 +128,30 @@ func TestDockerComposeDAGMountsStayWritable(t *testing.T) {
 			require.Equal(t, expectedCount, strings.Count(content, "./dags:/var/lib/dagu/dags"), "%s must keep DAG mounts on all expected services", file)
 		})
 	}
+}
+
+func TestDockerComposeWorkerUsesCoordinatorRPC(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	content := readFile(t, filepath.Join(root, "deploy/docker/compose.prod.yaml"))
+	var compose struct {
+		Services map[string]struct {
+			Environment []string `yaml:"environment"`
+			Ports       []string `yaml:"ports"`
+			Volumes     []string `yaml:"volumes"`
+		} `yaml:"services"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(content), &compose))
+
+	coordinator := compose.Services["dagu-coordinator"]
+	require.Contains(t, coordinator.Environment, "DAGU_COORDINATOR_HOST=0.0.0.0")
+	require.Contains(t, coordinator.Environment, "DAGU_COORDINATOR_ADVERTISE=dagu-coordinator")
+	require.Empty(t, coordinator.Ports)
+
+	worker := compose.Services["dagu-worker"]
+	require.Contains(t, worker.Environment, "DAGU_WORKER_COORDINATORS=dagu-coordinator:50055")
+	require.Empty(t, worker.Volumes)
 }
 
 func repoRoot(t *testing.T) string {

--- a/internal/runtime/workspacebundle/bundle_test.go
+++ b/internal/runtime/workspacebundle/bundle_test.go
@@ -439,16 +439,16 @@ func TestStoreHeartbeatPreventsLockSteal(t *testing.T) {
 	dir := t.TempDir()
 	first := NewStore(dir, DefaultLimits())
 	second := NewStore(dir, DefaultLimits())
-	first.lock = dirlock.New(dir, &dirlock.LockOptions{
-		StaleThreshold: 100 * time.Millisecond,
-		RetryInterval:  time.Millisecond,
-	})
-	second.lock = dirlock.New(dir, &dirlock.LockOptions{
-		StaleThreshold: 100 * time.Millisecond,
-		RetryInterval:  time.Millisecond,
-	})
-	first.lockHeartbeatInterval = 10 * time.Millisecond
-	second.lockHeartbeatInterval = 10 * time.Millisecond
+	lockOptions := &dirlock.LockOptions{StaleThreshold: time.Minute}
+	firstLock := &gatedHeartbeatLock{
+		DirLock: dirlock.New(dir, lockOptions),
+		started: make(chan struct{}),
+		resume:  make(chan struct{}),
+		done:    make(chan error),
+	}
+	first.lock = firstLock
+	second.lock = dirlock.New(dir, lockOptions)
+	first.lockHeartbeatInterval = time.Millisecond
 
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
@@ -462,32 +462,50 @@ func TestStoreHeartbeatPreventsLockSteal(t *testing.T) {
 	}()
 	<-firstEntered
 
-	secondEntered := make(chan struct{})
-	secondDone := make(chan error, 1)
-	go func() {
-		secondDone <- second.withLock(t.Context(), func(context.Context) error {
-			close(secondEntered)
-			return nil
-		})
-	}()
-
 	select {
-	case <-secondEntered:
+	case <-firstLock.started:
+	case <-time.After(time.Second):
 		close(releaseFirst)
 		require.NoError(t, <-firstDone)
-		require.NoError(t, <-secondDone)
-		t.Fatal("second store stole a live lock")
-	case <-time.After(300 * time.Millisecond):
+		t.Fatal("workspace bundle store heartbeat did not start")
 	}
+
+	// Force the lease stale while its heartbeat is paused.
+	lockPath := filepath.Join(dir, dirlock.LockDirectoryName)
+	staleTime := time.Now().Add(-2 * lockOptions.StaleThreshold)
+	require.NoError(t, os.Chtimes(lockPath, staleTime, staleTime))
+	close(firstLock.resume)
+	require.NoError(t, <-firstLock.done)
+	require.ErrorIs(t, second.lock.TryLock(), dirlock.ErrLockConflict)
 
 	close(releaseFirst)
 	require.NoError(t, <-firstDone)
-	select {
-	case <-secondEntered:
-	case <-time.After(time.Second):
-		t.Fatal("second store did not acquire the released lock")
+	require.NoError(t, second.lock.TryLock())
+	require.NoError(t, second.lock.Unlock())
+}
+
+type gatedHeartbeatLock struct {
+	dirlock.DirLock
+	started chan struct{}
+	resume  chan struct{}
+	done    chan error
+	once    sync.Once
+}
+
+func (l *gatedHeartbeatLock) Heartbeat(ctx context.Context) error {
+	first := false
+	l.once.Do(func() {
+		first = true
+		close(l.started)
+	})
+	if !first {
+		return l.DirLock.Heartbeat(ctx)
 	}
-	require.NoError(t, <-secondDone)
+
+	<-l.resume
+	err := l.DirLock.Heartbeat(ctx)
+	l.done <- err
+	return err
 }
 
 type heartbeatLock struct {

--- a/llms.txt
+++ b/llms.txt
@@ -1372,7 +1372,7 @@ Start gRPC coordinator: `dagu coordinator [--coordinator.host/-H <host>] [--coor
 
 ### dagu worker
 
-Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
+Start distributed worker: `dagu worker --worker.coordinators <host:port,...> [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--peer.*]`. Coordinator addresses are required. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
 
 ## Git Sync
 

--- a/skills/dagu/references/cli.md
+++ b/skills/dagu/references/cli.md
@@ -263,7 +263,7 @@ Start gRPC coordinator: `dagu coordinator [--coordinator.host/-H <host>] [--coor
 
 ### dagu worker
 
-Start distributed worker: `dagu worker [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--worker.coordinators <addrs>] [--peer.*]`. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
+Start distributed worker: `dagu worker --worker.coordinators <host:port,...> [--worker.id/-w <id>] [--worker.max-active-runs/-m <n>] [--worker.labels/-l <k=v,...>] [--peer.*]`. Coordinator addresses are required. Every worker advertises immutable `os` and `arch` platform labels in addition to configured labels.
 
 ## Git Sync
 


### PR DESCRIPTION
## Summary
- clarify that remote CLI contexts require the full REST API base URL
- configure production workers with explicit coordinator addresses
- keep coordinator traffic private
- retain shared worker runtime data for profiles and secrets while fetching DAGs through the coordinator
- update README and bundled skill guidance
- stabilize the workspace lock heartbeat test

## Testing
- go test ./internal/cmd ./internal/packaging
- docker compose -f deploy/docker/compose.prod.yaml config --quiet
- GitHub CI and conformance matrix