### PR TITLE
fix: release coordinator run resources

### DIFF
--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1038,7 +1038,10 @@ func (h *Handler) markPreparedAttemptDispatchFailed(ctx context.Context, task *c
 	if prepared == nil || prepared.attempt == nil {
 		return
 	}
-	defer h.releasePreparedDispatchAttempt(context.WithoutCancel(ctx), task.GetDagRunId(), prepared.attempt)
+	dagRunID := task.GetDagRunId()
+	held := h.runLocks.lock(dagRunID)
+	defer h.runLocks.unlock(dagRunID, held)
+	defer h.releasePreparedDispatchAttempt(context.WithoutCancel(ctx), dagRunID, prepared.attempt)
 
 	if !prepared.newlyCreated {
 		return
@@ -1559,7 +1562,10 @@ func (h *Handler) refreshLeaseForRunningTask(ctx context.Context, workerID strin
 		return
 	}
 
-	attempt, err := h.getOrOpenAttemptForRunningTask(ctx, task)
+	held := h.runLocks.lock(task.DagRunId)
+	defer h.runLocks.unlock(task.DagRunId, held)
+
+	attempt, err := h.openRunningAttemptLocked(ctx, task)
 	if err != nil {
 		logger.Warn(ctx, "Failed to resolve running task for lease refresh",
 			tag.RunID(task.DagRunId),
@@ -1568,9 +1574,6 @@ func (h *Handler) refreshLeaseForRunningTask(ctx context.Context, workerID strin
 		)
 		return
 	}
-
-	held := h.runLocks.lock(task.DagRunId)
-	defer h.runLocks.unlock(task.DagRunId, held)
 
 	runStatus, err := attempt.ReadStatus(ctx)
 	if err != nil {
@@ -1605,7 +1608,7 @@ func (h *Handler) refreshLeaseForRunningTask(ctx context.Context, workerID strin
 	}
 }
 
-func (h *Handler) getOrOpenAttemptForRunningTask(ctx context.Context, task *coordinatorv1.RunningTask) (dagrun.Attempt, error) {
+func (h *Handler) openRunningAttemptLocked(ctx context.Context, task *coordinatorv1.RunningTask) (dagrun.Attempt, error) {
 	if task == nil {
 		return nil, fmt.Errorf("running task is nil")
 	}
@@ -1615,13 +1618,13 @@ func (h *Handler) getOrOpenAttemptForRunningTask(ctx context.Context, task *coor
 		if task.RootDagRunName == "" {
 			return nil, fmt.Errorf("missing root dag run name for sub-dag %s", task.DagRunId)
 		}
-		return h.getOrOpenSubAttempt(ctx, ir.DAGRunRef{
+		return h.getOrOpenSubLocked(ctx, ir.DAGRunRef{
 			Name: task.RootDagRunName,
 			ID:   task.RootDagRunId,
 		}, task.DagRunId)
 	}
 
-	return h.getOrOpenAttempt(ctx, task.DagName, task.DagRunId)
+	return h.getOrOpenRootLocked(ctx, task.DagName, task.DagRunId)
 }
 
 func (h *Handler) shouldThrottleLeaseRefresh(status *ir.DAGRunStatus, observedAt time.Time) bool {
@@ -2294,10 +2297,16 @@ func (h *Handler) persistChatMessages(ctx context.Context, attempt dagrun.Attemp
 }
 
 // getOrOpenAttempt retrieves an open attempt from cache or opens a new one.
-// Uses double-check locking to avoid holding the mutex during blocking I/O.
 func (h *Handler) getOrOpenAttempt(ctx context.Context, dagName, dagRunID string) (dagrun.Attempt, error) {
+	held := h.runLocks.lock(dagRunID)
+	defer h.runLocks.unlock(dagRunID, held)
+
+	return h.getOrOpenRootLocked(ctx, dagName, dagRunID)
+}
+
+func (h *Handler) getOrOpenRootLocked(ctx context.Context, dagName, dagRunID string) (dagrun.Attempt, error) {
 	ref := ir.DAGRunRef{Name: dagName, ID: dagRunID}
-	return h.getOrOpenAttemptWithFinder(ctx, dagRunID, func() (dagrun.Attempt, error) {
+	return h.getOrOpenLocked(ctx, dagRunID, func() (dagrun.Attempt, error) {
 		return h.dagRunRepository.FindAttempt(ctx, ref)
 	})
 }
@@ -2379,17 +2388,20 @@ func (h *Handler) replaceOpenAttempt(
 // getOrOpenSubAttempt retrieves an open sub-attempt from cache or opens a new one.
 // This is used for sub-DAG status reporting in distributed execution.
 func (h *Handler) getOrOpenSubAttempt(ctx context.Context, rootRef ir.DAGRunRef, subDAGRunID string) (dagrun.Attempt, error) {
-	return h.getOrOpenAttemptWithFinder(ctx, subDAGRunID, func() (dagrun.Attempt, error) {
+	held := h.runLocks.lock(subDAGRunID)
+	defer h.runLocks.unlock(subDAGRunID, held)
+
+	return h.getOrOpenSubLocked(ctx, rootRef, subDAGRunID)
+}
+
+func (h *Handler) getOrOpenSubLocked(ctx context.Context, rootRef ir.DAGRunRef, subDAGRunID string) (dagrun.Attempt, error) {
+	return h.getOrOpenLocked(ctx, subDAGRunID, func() (dagrun.Attempt, error) {
 		return h.dagRunRepository.FindSubAttempt(ctx, rootRef, subDAGRunID)
 	})
 }
 
-// getOrOpenAttemptWithFinder is a generic helper that retrieves an open attempt from cache
-// or uses the provided finder function to locate and open a new one.
-// Uses per-run mutex to prevent concurrent I/O operations on the same DAG run,
-// avoiding races between ReportStatus and markRunFailed.
-func (h *Handler) getOrOpenAttemptWithFinder(ctx context.Context, cacheKey string, finder func() (dagrun.Attempt, error)) (dagrun.Attempt, error) {
-	// First check: fast path with read lock (no per-run mutex needed for cache hit)
+// getOrOpenLocked retrieves or opens an attempt while its run lock is held.
+func (h *Handler) getOrOpenLocked(ctx context.Context, cacheKey string, finder func() (dagrun.Attempt, error)) (dagrun.Attempt, error) {
 	h.attemptsMu.RLock()
 	if attempt, ok := h.openAttempts[cacheKey]; ok {
 		h.attemptsMu.RUnlock()
@@ -2397,19 +2409,6 @@ func (h *Handler) getOrOpenAttemptWithFinder(ctx context.Context, cacheKey strin
 	}
 	h.attemptsMu.RUnlock()
 
-	// Acquire per-run mutex to serialize I/O operations for this DAG run
-	held := h.runLocks.lock(cacheKey)
-	defer h.runLocks.unlock(cacheKey, held)
-
-	// Re-check cache after acquiring per-run mutex (another goroutine may have opened it)
-	h.attemptsMu.RLock()
-	if attempt, ok := h.openAttempts[cacheKey]; ok {
-		h.attemptsMu.RUnlock()
-		return attempt, nil
-	}
-	h.attemptsMu.RUnlock()
-
-	// Perform I/O with per-run mutex held
 	attempt, err := finder()
 	if err != nil {
 		return nil, err
@@ -2419,18 +2418,8 @@ func (h *Handler) getOrOpenAttemptWithFinder(ctx context.Context, cacheKey strin
 		return nil, err
 	}
 
-	// Add to cache under write lock
 	h.attemptsMu.Lock()
 	defer h.attemptsMu.Unlock()
-
-	// Final check: if somehow another goroutine got through, use theirs
-	if existing, ok := h.openAttempts[cacheKey]; ok {
-		if err := attempt.Close(ctx); err != nil {
-			logger.Warn(ctx, "Failed to close duplicate opened attempt", tag.Error(err))
-		}
-		return existing, nil
-	}
-
 	h.openAttempts[cacheKey] = attempt
 	return attempt, nil
 }

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -103,6 +103,45 @@ type runClaim struct {
 	lease      *dispatch.DAGRunLease
 }
 
+// runLockSet retains a per-run lock only while callers hold or wait for it.
+type runLockSet struct {
+	mu      sync.Mutex
+	entries map[string]*runLock
+}
+
+type runLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (s *runLockSet) lock(dagRunID string) *runLock {
+	s.mu.Lock()
+	if s.entries == nil {
+		s.entries = make(map[string]*runLock)
+	}
+	entry := s.entries[dagRunID]
+	if entry == nil {
+		entry = &runLock{}
+		s.entries[dagRunID] = entry
+	}
+	entry.refs++
+	s.mu.Unlock()
+
+	entry.mu.Lock()
+	return entry
+}
+
+func (s *runLockSet) unlock(dagRunID string, entry *runLock) {
+	entry.mu.Unlock()
+
+	s.mu.Lock()
+	entry.refs--
+	if entry.refs == 0 {
+		delete(s.entries, dagRunID)
+	}
+	s.mu.Unlock()
+}
+
 type Handler struct {
 	coordinatorv1.UnimplementedCoordinatorServiceServer
 
@@ -136,10 +175,8 @@ type Handler struct {
 	attemptsMu   sync.RWMutex
 	openAttempts map[string]dagrun.Attempt // dagRunID -> open attempt
 
-	// Per-run mutexes to prevent concurrent access to the same DAG run
-	// This prevents races between ReportStatus and markRunFailed
-	runMutexesMu sync.Mutex
-	runMutexes   map[string]*sync.Mutex // dagRunID -> per-run mutex
+	// Serializes status writes and repairs for each DAG run.
+	runLocks runLockSet
 
 	// Stale heartbeat threshold - configurable
 	staleHeartbeatThreshold time.Duration
@@ -251,7 +288,6 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		dispatchPollInitialWait:   defaultDispatchPollInitialWait,
 		dispatchPollMaxWait:       defaultDispatchPollMaxWait,
 		openAttempts:              make(map[string]dagrun.Attempt),
-		runMutexes:                make(map[string]*sync.Mutex),
 		owner:                     cfg.Owner,
 		dagRunRepository:          cfg.DAGRunRepository,
 		logDir:                    cfg.LogDir,
@@ -361,22 +397,6 @@ func (h *Handler) Close(ctx context.Context) {
 		}
 		delete(h.openAttempts, dagRunID)
 	}
-}
-
-// getRunMutex returns a mutex for the given DAG run ID.
-// This ensures serialized access to operations on the same DAG run
-// across ReportStatus and zombie cleanup to prevent data races.
-func (h *Handler) getRunMutex(dagRunID string) *sync.Mutex {
-	h.runMutexesMu.Lock()
-	defer h.runMutexesMu.Unlock()
-
-	if mu, ok := h.runMutexes[dagRunID]; ok {
-		return mu
-	}
-
-	mu := &sync.Mutex{}
-	h.runMutexes[dagRunID] = mu
-	return mu
 }
 
 // Poll implements long polling - workers wait until a task is available
@@ -928,9 +948,8 @@ func (h *Handler) prepareAttemptForDispatch(ctx context.Context, task *coordinat
 		return nil, nil
 	}
 
-	runMu := h.getRunMutex(task.DagRunId)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(task.DagRunId)
+	defer h.runLocks.unlock(task.DagRunId, held)
 
 	isRootRun := task.ParentDagRunId == "" &&
 		(task.RootDagRunId == "" || task.RootDagRunId == task.DagRunId)
@@ -1550,9 +1569,8 @@ func (h *Handler) refreshLeaseForRunningTask(ctx context.Context, workerID strin
 		return
 	}
 
-	runMu := h.getRunMutex(task.DagRunId)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(task.DagRunId)
+	defer h.runLocks.unlock(task.DagRunId, held)
 
 	runStatus, err := attempt.ReadStatus(ctx)
 	if err != nil {
@@ -1781,9 +1799,8 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	}
 
 	// Acquire per-run mutex to serialize with markRunFailed
-	runMu := h.getRunMutex(dagRunStatus.DAGRunID)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(dagRunStatus.DAGRunID)
+	defer h.runLocks.unlock(dagRunStatus.DAGRunID, held)
 
 	latestAttempt, latestStatus, err := h.resolveLatestAttempt(ctx, dagRunStatus.Name, dagRunStatus.DAGRunID, dagRunStatus.Root)
 	if err != nil {
@@ -1807,7 +1824,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 			// reporting worker disconnects.
 			ownership.syncFromStatus(context.WithoutCancel(ctx), req.WorkerId, dagRunStatus, bootstrappedAttempt.ID())
 			h.finalizeAdmissionForStatus(ctx, dagRunStatus, bootstrappedAttempt.ID())
-			h.closeCachedWaitingAttempt(ctx, dagRunStatus, bootstrappedAttempt)
+			h.closeCachedInactiveAttempt(ctx, dagRunStatus, bootstrappedAttempt)
 
 			return &coordinatorv1.ReportStatusResponse{Accepted: true}, nil
 		}
@@ -1895,11 +1912,8 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 	// worker disconnects.
 	ownership.syncFromStatus(context.WithoutCancel(ctx), req.WorkerId, dagRunStatus, attempt.ID())
 	h.finalizeAdmissionForStatus(ctx, dagRunStatus, attempt.ID())
-	h.closeCachedWaitingAttempt(ctx, dagRunStatus, attempt)
+	h.closeCachedInactiveAttempt(ctx, dagRunStatus, attempt)
 
-	// Note: We don't close the attempt immediately on terminal status because
-	// the agent may push the same terminal status multiple times from different
-	// code paths. Attempts are cleaned up during coordinator shutdown.
 	return &coordinatorv1.ReportStatusResponse{Accepted: true}, nil
 }
 
@@ -1972,12 +1986,15 @@ func equalOptionalString(left, right *string) bool {
 	return *left == *right
 }
 
-func (h *Handler) closeCachedWaitingAttempt(
+func (h *Handler) closeCachedInactiveAttempt(
 	ctx context.Context,
 	status *ir.DAGRunStatus,
 	attempt dagrun.Attempt,
 ) {
-	if status == nil || attempt == nil || status.Status != ir.Waiting {
+	if status == nil || attempt == nil {
+		return
+	}
+	if status.Status != ir.Waiting && !isTerminalRunStatus(status.Status) {
 		return
 	}
 	h.closeCachedAttemptForRun(ctx, context.WithoutCancel(ctx), status.DAGRunID, attempt.ID())
@@ -2379,9 +2396,8 @@ func (h *Handler) getOrOpenAttemptWithFinder(ctx context.Context, cacheKey strin
 	h.attemptsMu.RUnlock()
 
 	// Acquire per-run mutex to serialize I/O operations for this DAG run
-	runMu := h.getRunMutex(cacheKey)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(cacheKey)
+	defer h.runLocks.unlock(cacheKey, held)
 
 	// Re-check cache after acquiring per-run mutex (another goroutine may have opened it)
 	h.attemptsMu.RLock()
@@ -2812,9 +2828,8 @@ func (h *Handler) repairStaleRun(
 ) (*ir.DAGRunStatus, bool, error) {
 	repairCtx := context.WithoutCancel(ctx)
 	if status != nil && status.DAGRunID != "" {
-		runMu := h.getRunMutex(status.DAGRunID)
-		runMu.Lock()
-		defer runMu.Unlock()
+		held := h.runLocks.lock(status.DAGRunID)
+		defer h.runLocks.unlock(status.DAGRunID, held)
 
 		attemptID := status.AttemptID
 		if attemptID == "" {
@@ -3102,9 +3117,8 @@ func (h *Handler) failCurrentRemoteAttempt(
 	expectedStatuses ...ir.Status,
 ) {
 	storeCtx := context.WithoutCancel(ctx)
-	runMu := h.getRunMutex(dagRun.ID)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(dagRun.ID)
+	defer h.runLocks.unlock(dagRun.ID, held)
 
 	if attemptID == "" {
 		logger.Error(ctx, "Skipping distributed stale-run repair due to missing attempt ID",
@@ -3236,9 +3250,8 @@ func (h *Handler) markRunFailed(ctx context.Context, dagName, dagRunID, reason s
 	}
 	storeCtx := context.WithoutCancel(ctx)
 
-	runMu := h.getRunMutex(dagRunID)
-	runMu.Lock()
-	defer runMu.Unlock()
+	held := h.runLocks.lock(dagRunID)
+	defer h.runLocks.unlock(dagRunID, held)
 
 	var attempt dagrun.Attempt
 	var needsOpen bool

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -1814,6 +1814,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 				return nil, status.Error(codes.Internal, "failed to resolve artifact path: "+err.Error())
 			}
 			if err := bootstrappedAttempt.Write(ctx, *dagRunStatus); err != nil {
+				h.closeCachedAttemptForRun(ctx, context.WithoutCancel(ctx), dagRunStatus.DAGRunID, bootstrappedAttempt.ID())
 				return nil, status.Error(codes.Internal, "failed to write status: "+err.Error())
 			}
 
@@ -1901,6 +1902,7 @@ func (h *Handler) ReportStatus(ctx context.Context, req *coordinatorv1.ReportSta
 			return nil, status.Error(codes.Internal, "failed to get/open latest attempt: "+err.Error())
 		}
 		if err := attempt.Write(ctx, *dagRunStatus); err != nil {
+			h.closeCachedAttemptForRun(ctx, context.WithoutCancel(ctx), dagRunStatus.DAGRunID, attempt.ID())
 			return nil, status.Error(codes.Internal, "failed to write status: "+err.Error())
 		}
 	}
@@ -3273,6 +3275,9 @@ func (h *Handler) markRunFailed(ctx context.Context, dagName, dagRunID, reason s
 		}
 		attempt = foundAttempt
 		needsOpen = true
+	}
+	if !needsOpen {
+		defer h.closeCachedAttemptForRun(ctx, storeCtx, dagRunID, attempt.ID())
 	}
 
 	dagRunStatus, err := attempt.ReadStatus(storeCtx)

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -2296,14 +2296,6 @@ func (h *Handler) persistChatMessages(ctx context.Context, attempt dagrun.Attemp
 	persistNode(status.OnWait, "on_wait")
 }
 
-// getOrOpenAttempt retrieves an open attempt from cache or opens a new one.
-func (h *Handler) getOrOpenAttempt(ctx context.Context, dagName, dagRunID string) (dagrun.Attempt, error) {
-	held := h.runLocks.lock(dagRunID)
-	defer h.runLocks.unlock(dagRunID, held)
-
-	return h.getOrOpenRootLocked(ctx, dagName, dagRunID)
-}
-
 func (h *Handler) getOrOpenRootLocked(ctx context.Context, dagName, dagRunID string) (dagrun.Attempt, error) {
 	ref := ir.DAGRunRef{Name: dagName, ID: dagRunID}
 	return h.getOrOpenLocked(ctx, dagRunID, func() (dagrun.Attempt, error) {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -408,6 +408,8 @@ type mockAttempt struct {
 	releaseWrite           chan struct{}
 	stepMessages           map[string][]ir.LLMMessage // stepName -> messages
 	writeStepMessagesError error                      // injected error for WriteStepMessages
+	requireOpenForRead     bool
+	isOpen                 bool
 	mu                     sync.Mutex
 }
 
@@ -426,6 +428,7 @@ func (m *mockAttempt) Open(_ context.Context) error {
 		return m.openError
 	}
 	m.opened = true
+	m.isOpen = true
 	return nil
 }
 func (m *mockAttempt) Write(_ context.Context, s ir.DAGRunStatus) error {
@@ -457,11 +460,15 @@ func (m *mockAttempt) Close(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.closed = true
+	m.isOpen = false
 	return nil
 }
 func (m *mockAttempt) ReadStatus(_ context.Context) (*ir.DAGRunStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.requireOpenForRead && !m.isOpen {
+		return nil, errors.New("attempt is closed")
+	}
 	if m.readStatusError != nil {
 		return nil, m.readStatusError
 	}
@@ -1329,6 +1336,50 @@ func TestHandler_Heartbeat(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, attempt.WasWritten())
 		assert.Greater(t, status.LeaseAt, initialLease)
+	})
+
+	t.Run("HeartbeatKeepsAttemptOpenDuringRefresh", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunRepository: store.repository, StaleLeaseThreshold: 10 * time.Second})
+		ctx := context.Background()
+
+		ref := ir.NewDAGRunRef("test-dag", "run-123")
+		attempt := store.addAttempt(ref, &ir.DAGRunStatus{
+			Name:       ref.Name,
+			DAGRunID:   ref.ID,
+			AttemptID:  "attempt-1",
+			AttemptKey: "attempt-key-1",
+			Status:     ir.Running,
+			WorkerID:   "worker-1",
+			LeaseAt:    time.Now().Add(-time.Minute).UnixMilli(),
+		})
+		attempt.requireOpenForRead = true
+		require.NoError(t, attempt.Open(ctx))
+		h.openAttempts[ref.ID] = attempt
+
+		held := h.runLocks.lock(ref.ID)
+		done := make(chan struct{})
+		go func() {
+			h.refreshLeaseForRunningTask(ctx, "worker-1", &coordinatorv1.RunningTask{
+				DagRunId:   ref.ID,
+				DagName:    ref.Name,
+				AttemptKey: "attempt-key-1",
+			}, time.Now())
+			close(done)
+		}()
+		waitForRunLockRefs(t, &h.runLocks, ref.ID, 2)
+
+		h.closeCachedAttemptForRun(ctx, ctx, ref.ID, attempt.ID())
+		h.runLocks.unlock(ref.ID, held)
+		select {
+		case <-done:
+		case <-time.After(coordinatorTestTimeout(time.Second)):
+			require.FailNow(t, "heartbeat lease refresh did not finish")
+		}
+
+		assert.True(t, attempt.WasWritten())
 	})
 
 	t.Run("HeartbeatRefreshesLeaseForRunningSubDAG", func(t *testing.T) {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -2039,6 +2039,8 @@ func TestHandler_ZombieDetection(t *testing.T) {
 			},
 		}
 		attempt := store.addAttempt(ref, initialStatus)
+		require.NoError(t, attempt.Open(ctx))
+		h.openAttempts[ref.ID] = attempt
 
 		// Mark the run as failed
 		h.markRunFailed(ctx, "test-dag", "run-123", "worker crashed")
@@ -2047,6 +2049,8 @@ func TestHandler_ZombieDetection(t *testing.T) {
 		require.True(t, attempt.WasOpened())
 		require.True(t, attempt.WasWritten())
 		require.True(t, attempt.WasClosed())
+		_, cached := h.openAttempts[ref.ID]
+		assert.False(t, cached)
 
 		// Check the status
 		status, err := attempt.ReadStatus(ctx)
@@ -3868,6 +3872,47 @@ func TestHandler_ReportStatus(t *testing.T) {
 		assert.False(t, cached)
 	})
 
+	t.Run("ClosesBootstrappedAttemptAfterWriteError", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		store.attemptWriteErr = errors.New("status write failed")
+		h := NewHandler(HandlerConfig{DAGRunRepository: store.repository})
+		ctx := context.Background()
+
+		rootRef := ir.NewDAGRunRef("root-dag", "root-run-123")
+		store.addAttempt(rootRef, &ir.DAGRunStatus{
+			Name:     rootRef.Name,
+			DAGRunID: rootRef.ID,
+			Status:   ir.Running,
+		})
+		incoming, convErr := convert.DAGRunStatusToProto(&ir.DAGRunStatus{
+			Name:      "child-dag",
+			DAGRunID:  "child-run-123",
+			Root:      rootRef,
+			AttemptID: "child-attempt-1",
+			WorkerID:  "worker-1",
+			Status:    ir.Failed,
+		})
+		require.NoError(t, convErr)
+
+		_, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{
+			Status:   incoming,
+			WorkerId: "worker-1",
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+
+		attempt := store.subAttempts[rootRef.ID+":child-run-123"]
+		require.NotNil(t, attempt)
+		assert.True(t, attempt.WasClosed())
+
+		h.attemptsMu.RLock()
+		_, cached := h.openAttempts["child-run-123"]
+		h.attemptsMu.RUnlock()
+		assert.False(t, cached)
+	})
+
 	t.Run("RejectsMissingSubAttemptWithoutRootLease", func(t *testing.T) {
 		t.Parallel()
 
@@ -4278,6 +4323,42 @@ func TestHandler_ReportStatus(t *testing.T) {
 
 		_, err = activeStore.Get(ctx, "attempt-key-1")
 		assert.ErrorIs(t, err, dispatch.ErrActiveRunNotFound)
+	})
+
+	t.Run("ClosesAttemptAfterStatusWriteError", func(t *testing.T) {
+		t.Parallel()
+
+		store := newMockDAGRunStore()
+		h := NewHandler(HandlerConfig{DAGRunRepository: store.repository})
+		ctx := context.Background()
+
+		ref := ir.NewDAGRunRef("test-dag", "run-123")
+		attempt := store.addAttempt(ref, &ir.DAGRunStatus{
+			Name:       ref.Name,
+			DAGRunID:   ref.ID,
+			AttemptID:  "attempt-1",
+			AttemptKey: "attempt-key-1",
+			Status:     ir.Running,
+		})
+		attempt.writeError = errors.New("status write failed")
+		incoming, convErr := convert.DAGRunStatusToProto(&ir.DAGRunStatus{
+			Name:       ref.Name,
+			DAGRunID:   ref.ID,
+			AttemptID:  "attempt-1",
+			AttemptKey: "attempt-key-1",
+			Status:     ir.Failed,
+		})
+		require.NoError(t, convErr)
+
+		_, err := h.ReportStatus(ctx, &coordinatorv1.ReportStatusRequest{Status: incoming})
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.True(t, attempt.WasClosed())
+
+		h.attemptsMu.RLock()
+		_, cached := h.openAttempts[ref.ID]
+		h.attemptsMu.RUnlock()
+		assert.False(t, cached)
 	})
 
 	t.Run("MissingStatusReturnsError", func(t *testing.T) {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -60,6 +60,70 @@ func TestDispatchBindErrorCode(t *testing.T) {
 	assert.Equal(t, codes.Internal, dispatchBindErrorCode(errors.New("disk full")))
 }
 
+func TestRunLockSet(t *testing.T) {
+	t.Parallel()
+
+	var locks runLockSet
+	first := locks.lock("run-a")
+
+	woken := make(chan *runLock, 1)
+	go func() {
+		woken <- locks.lock("run-a")
+	}()
+	waitForRunLockRefs(t, &locks, "run-a", 2)
+
+	other := make(chan *runLock, 1)
+	go func() {
+		other <- locks.lock("run-b")
+	}()
+	select {
+	case held := <-other:
+		locks.unlock("run-b", held)
+	case <-time.After(coordinatorTestTimeout(time.Second)):
+		require.FailNow(t, "different run lock was blocked")
+	}
+
+	locks.unlock("run-a", first)
+	var second *runLock
+	select {
+	case second = <-woken:
+	case <-time.After(coordinatorTestTimeout(time.Second)):
+		require.FailNow(t, "waiting run lock was not acquired")
+	}
+
+	third := make(chan *runLock, 1)
+	go func() {
+		third <- locks.lock("run-a")
+	}()
+	waitForRunLockRefs(t, &locks, "run-a", 2)
+	select {
+	case held := <-third:
+		locks.unlock("run-a", held)
+		require.FailNow(t, "same run lock was acquired concurrently")
+	default:
+	}
+
+	locks.unlock("run-a", second)
+	select {
+	case held := <-third:
+		locks.unlock("run-a", held)
+	case <-time.After(coordinatorTestTimeout(time.Second)):
+		require.FailNow(t, "second waiting run lock was not acquired")
+	}
+}
+
+func waitForRunLockRefs(t *testing.T, locks *runLockSet, dagRunID string, want int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		locks.mu.Lock()
+		defer locks.mu.Unlock()
+
+		entry := locks.entries[dagRunID]
+		return entry != nil && entry.refs == want
+	}, coordinatorTestTimeout(time.Second), 10*time.Millisecond)
+}
+
 type mockDAGRunStore struct {
 	testutil.DAGRunStoreStub
 	repository          *persis.DAGRunRepository
@@ -3739,6 +3803,8 @@ func TestHandler_ReportStatus(t *testing.T) {
 
 		attempt, err := store.FindSubAttempt(ctx, rootRef, "child-run-123")
 		require.NoError(t, err)
+		storedAttempt, ok := attempt.(*mockAttempt)
+		require.True(t, ok)
 		current, err := attempt.ReadStatus(ctx)
 		require.NoError(t, err)
 
@@ -3794,6 +3860,12 @@ func TestHandler_ReportStatus(t *testing.T) {
 
 		_, err = activeStore.Get(ctx, attemptKey)
 		assert.ErrorIs(t, err, dispatch.ErrActiveRunNotFound)
+		assert.True(t, storedAttempt.WasClosed())
+
+		h.attemptsMu.RLock()
+		_, cached := h.openAttempts["child-run-123"]
+		h.attemptsMu.RUnlock()
+		assert.False(t, cached)
 	})
 
 	t.Run("RejectsMissingSubAttemptWithoutRootLease", func(t *testing.T) {
@@ -4190,6 +4262,12 @@ func TestHandler_ReportStatus(t *testing.T) {
 		current, readErr := attempt.ReadStatus(ctx)
 		require.NoError(t, readErr)
 		assert.Equal(t, "duplicate terminal payload", current.Error)
+		assert.True(t, attempt.WasClosed())
+
+		h.attemptsMu.RLock()
+		_, cached := h.openAttempts[ref.ID]
+		h.attemptsMu.RUnlock()
+		assert.False(t, cached)
 
 		messages := attempt.GetStepMessages("chat-step")
 		require.Len(t, messages, 1)
@@ -4544,7 +4622,7 @@ func TestHandler_ReportStatus(t *testing.T) {
 		ctx := context.Background()
 
 		ref := ir.DAGRunRef{Name: "test-dag", ID: "run-123"}
-		store.addAttempt(ref, &ir.DAGRunStatus{
+		attempt := store.addAttempt(ref, &ir.DAGRunStatus{
 			Name:       "test-dag",
 			DAGRunID:   "run-123",
 			AttemptID:  "attempt-1",
@@ -4598,6 +4676,12 @@ func TestHandler_ReportStatus(t *testing.T) {
 
 		_, err = activeStore.Get(ctx, "attempt-key-1")
 		assert.ErrorIs(t, err, dispatch.ErrActiveRunNotFound)
+		assert.True(t, attempt.WasClosed())
+
+		h.attemptsMu.RLock()
+		_, cached := h.openAttempts[ref.ID]
+		h.attemptsMu.RUnlock()
+		assert.False(t, cached)
 	})
 
 	t.Run("AckTaskClaimCreatesLeaseAndDeletesClaim", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Release coordinator resources when distributed runs stop using them.

## Changes

- Close and evict waiting or terminal attempts after persistence
- Close cached attempts after failed status writes and zombie cleanup
- Remove per-run lock entries after the last holder or waiter exits
- Serialize heartbeat use and cleanup across each attempt lifetime
- Preserve duplicate terminal updates and cross-run concurrency

## Testing

- `make fmt`
- `make check`
- `make test`
- `go test -race ./internal/service/coordinator -count=1`

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation is unchanged because no user-facing contract changed
- [x] Changes have been tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of completed and failed runs by promptly closing and removing cached attempts.
  * Ensured cleanup also occurs when status updates or dispatch processing encounter errors.
  * Improved coordination of concurrent operations on the same run.
  * Kept active attempts available during lease refreshes and related run operations.
  * Reduced stale run locks and improved synchronization across run activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->