### PR TITLE
docs: clarify shared-nothing Compose worker

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -19,8 +19,20 @@ The standard Ubuntu image includes CA certificates and common runtime utilities 
 
 The Compose stacks mount `deploy/docker/dags/` read-write on server-side Dagu services so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.
 
-The production worker intentionally has no `dagu-data` or DAG-directory mount. It receives DAG definitions, runtime profiles, and Dagu-managed secrets from the coordinator, then returns status, logs, artifacts, and persistent-state operations over gRPC. Add only workflow-specific mounts, credentials, and network access required by the steps or direct secret providers.
+The production worker intentionally has no `dagu-data` or DAG-directory mount. It receives DAG definitions, runtime profiles, and Dagu-managed secrets from the coordinator, then returns status, logs, artifacts, and persistent-state operations over gRPC. Its TLS credential mount is not Dagu storage. Add only other mounts, credentials, and network access required by the workflow or direct secret providers.
 
 Remote CLI contexts use the web/API endpoint, not the coordinator port. Prefer an HTTPS endpoint and include the API path, for example `https://dagu.example.com/api/v1`. A direct `http://host:8080/api/v1` URL sends the API key without transport encryption; use it only on a trusted or encrypted network.
 
-The production stack keeps coordinator port `50055` inside `dagu-net`. Before connecting external workers, set `DAGU_COORDINATOR_ADVERTISE` to an address they can reach and configure peer TLS or mTLS on the coordinator and workers. Publish port `50055` only to the restricted worker network. See the [transport security guide](https://docs.dagu.sh/server-admin/distributed/transport-security).
+The production stack requires these CA-issued mTLS files under `deploy/docker/tls/` before startup:
+
+```text
+ca.crt
+coordinator.crt
+coordinator.key
+client.crt
+client.key
+```
+
+The coordinator certificate must cover the `dagu-coordinator` DNS name. Missing or invalid files prevent Dagu from starting or connecting. Keep private keys readable only by the container user. See the [transport security guide](https://docs.dagu.sh/server-admin/distributed/transport-security) for certificate requirements.
+
+Coordinator port `50055` remains inside `dagu-net`. Before connecting external workers, set `DAGU_COORDINATOR_ADVERTISE` to an address covered by the coordinator certificate and reachable by those workers. Publish port `50055` only to the restricted worker network.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -19,6 +19,8 @@ The standard Ubuntu image includes CA certificates and common runtime utilities 
 
 The Compose stacks mount `deploy/docker/dags/` read-write on server-side Dagu services so Dagu can seed first-run examples and save DAG edits. Add `:ro` to that mount only when using immutable DAG sources.
 
+The production worker intentionally has no `dagu-data` or DAG-directory mount. It receives DAG definitions, runtime profiles, and Dagu-managed secrets from the coordinator, then returns status, logs, artifacts, and persistent-state operations over gRPC. Add only workflow-specific mounts, credentials, and network access required by the steps or direct secret providers.
+
 Remote CLI contexts use the web/API endpoint, not the coordinator port. Prefer an HTTPS endpoint and include the API path, for example `https://dagu.example.com/api/v1`. A direct `http://host:8080/api/v1` URL sends the API key without transport encryption; use it only on a trusted or encrypted network.
 
 The production stack keeps coordinator port `50055` inside `dagu-net`. Before connecting external workers, set `DAGU_COORDINATOR_ADVERTISE` to an address they can reach and configure peer TLS or mTLS on the coordinator and workers. Publish port `50055` only to the restricted worker network. See the [transport security guide](https://docs.dagu.sh/server-admin/distributed/transport-security).

--- a/deploy/docker/compose.prod.yaml
+++ b/deploy/docker/compose.prod.yaml
@@ -38,8 +38,11 @@ services:
     image: ghcr.io/dagucloud/dagu:latest
     command: ["dagu", "coordinator"]
     environment:
-      # Peer config: insecure by default; set TLS envs if needed
-      - DAGU_PEER_INSECURE=true
+      # Mutual TLS for coordinator clients
+      - DAGU_PEER_INSECURE=false
+      - DAGU_PEER_CERT_FILE=/etc/dagu/tls/coordinator.crt
+      - DAGU_PEER_KEY_FILE=/etc/dagu/tls/coordinator.key
+      - DAGU_PEER_CLIENT_CA_FILE=/etc/dagu/tls/ca.crt
       # Bind on the container network and advertise stable Compose DNS
       - DAGU_COORDINATOR_HOST=0.0.0.0
       - DAGU_COORDINATOR_ADVERTISE=dagu-coordinator
@@ -47,6 +50,7 @@ services:
     volumes:
       - dagu-data:/var/lib/dagu
       - ./dags:/var/lib/dagu/dags
+      - ./tls:/etc/dagu/tls:ro
     networks: [dagu-net]
 
   # Dagu scheduler service (reads DAGs and enqueues runs)
@@ -58,6 +62,10 @@ services:
       - DAGU_COORDINATOR_PORT=50055
       - DAGU_SCHEDULER_PORT=8090
       - DAGU_DAGS_DIR=/var/lib/dagu/dags
+      - DAGU_PEER_INSECURE=false
+      - DAGU_PEER_CERT_FILE=/etc/dagu/tls/client.crt
+      - DAGU_PEER_KEY_FILE=/etc/dagu/tls/client.key
+      - DAGU_PEER_CLIENT_CA_FILE=/etc/dagu/tls/ca.crt
       # Optional: set timezone, logging, etc
       # - DAGU_TZ=UTC
       # - DAGU_LOG_FORMAT=json
@@ -68,6 +76,7 @@ services:
     volumes:
       - dagu-data:/var/lib/dagu
       - ./dags:/var/lib/dagu/dags
+      - ./tls:/etc/dagu/tls:ro
     networks: [dagu-net]
 
   # Dagu web UI / API server
@@ -80,6 +89,10 @@ services:
       - DAGU_HOST=0.0.0.0
       - DAGU_PORT=8080
       - DAGU_DAGS_DIR=/var/lib/dagu/dags
+      - DAGU_PEER_INSECURE=false
+      - DAGU_PEER_CERT_FILE=/etc/dagu/tls/client.crt
+      - DAGU_PEER_KEY_FILE=/etc/dagu/tls/client.key
+      - DAGU_PEER_CLIENT_CA_FILE=/etc/dagu/tls/ca.crt
       # Builtin authentication (RBAC) - CHANGE TOKEN_SECRET IN PRODUCTION
       - DAGU_AUTH_MODE=builtin
       # Token secret: auto-generated if not set (persisted to {dataDir}/auth/token_secret)
@@ -96,6 +109,7 @@ services:
     volumes:
       - dagu-data:/var/lib/dagu
       - ./dags:/var/lib/dagu/dags
+      - ./tls:/etc/dagu/tls:ro
     networks: [dagu-net]
 
   # Dagu worker (polls coordinator and executes tasks)
@@ -104,6 +118,10 @@ services:
     command: ["dagu", "worker"]
     environment:
       - DAGU_WORKER_COORDINATORS=dagu-coordinator:50055
+      - DAGU_PEER_INSECURE=false
+      - DAGU_PEER_CERT_FILE=/etc/dagu/tls/client.crt
+      - DAGU_PEER_KEY_FILE=/etc/dagu/tls/client.key
+      - DAGU_PEER_CLIENT_CA_FILE=/etc/dagu/tls/ca.crt
       # Optional worker tuning and labels
       # - DAGU_WORKER_MAX_ACTIVE_RUNS=100
       # - DAGU_WORKER_LABELS=region=us-east-1,instance-type=m5.large
@@ -111,6 +129,8 @@ services:
     # No Dagu data volume: DAGs and control-plane state flow through the coordinator.
     depends_on:
       - dagu-coordinator
+    volumes:
+      - ./tls:/etc/dagu/tls:ro
     networks: [dagu-net]
 
   # Grafana: visualize Prometheus metrics

--- a/deploy/docker/compose.prod.yaml
+++ b/deploy/docker/compose.prod.yaml
@@ -108,6 +108,7 @@ services:
       # - DAGU_WORKER_MAX_ACTIVE_RUNS=100
       # - DAGU_WORKER_LABELS=region=us-east-1,instance-type=m5.large
       # OTel: point DAGs to collector via per-DAG otel.endpoint: "otel-collector:4317"
+    # No Dagu data volume: DAGs and control-plane state flow through the coordinator.
     depends_on:
       - dagu-coordinator
     networks: [dagu-net]


### PR DESCRIPTION
## Summary

Clarify and secure the shared-nothing worker setup after #2641.

## Changes

- document the intentional absence of Dagu worker storage
- require mTLS for production Compose peer traffic
- document required certificates and workflow-specific resources

## Related Issues

Follow-up to #2641.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- `docker compose -f deploy/docker/compose.prod.yaml config --format json`
- `make bin`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled mutual TLS authentication for all production services.
  * Added certificate, private-key, and client-CA configuration with read-only TLS mounts.
  * Documented certificate validation, hostname, permissions, and networking requirements.

* **Documentation**
  * Clarified that workers receive definitions, profiles, and secrets from the coordinator and exchange status, logs, artifacts, and persistent-state operations over gRPC.
  * Documented that production workers do not mount Dagu data or DAG directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->