### PR TITLE
Fix/named child file dependencies

### DIFF
--- a/internal/intg/distr/subdag_test.go
+++ b/internal/intg/distr/subdag_test.go
@@ -358,6 +358,93 @@ steps:
 	})
 }
 
+func TestSubDAG_SharedNothingNestedNamedFileDependencies(t *testing.T) {
+	const (
+		stageDependency = "stage-input.txt"
+		stageContent    = "dependency for stage worker"
+		leafDependency  = "leaf-input.txt"
+		leafContent     = "dependency for leaf worker"
+	)
+
+	f := newTestFixture(t, `
+name: shared-nothing-root
+worker_selector:
+  layer: root
+steps:
+  - id: call_stage
+    action: dag.run
+    with:
+      dag: shared-nothing-stage
+`, withWorkerCount(0), withLogPersistence())
+	defer f.cleanup()
+
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "shared-nothing-stage", []byte(`
+name: shared-nothing-stage
+worker_selector:
+  layer: stage
+steps:
+  - id: read_stage_dependency
+    dependencies:
+      - `+stageDependency+`
+    action: file.read
+    with:
+      path: `+stageDependency+`
+    output: CONTENT
+  - id: call_leaf
+    depends: [read_stage_dependency]
+    action: dag.run
+    with:
+      dag: shared-nothing-leaf
+`))
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "shared-nothing-leaf", []byte(`
+name: shared-nothing-leaf
+worker_selector:
+  layer: leaf
+steps:
+  - id: read_leaf_dependency
+    dependencies:
+      - `+leafDependency+`
+    action: file.read
+    with:
+      path: `+leafDependency+`
+    output: CONTENT
+`))
+	require.NoError(t, os.WriteFile(filepath.Join(f.coord.Config.Paths.DAGsDir, stageDependency), []byte(stageContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(f.coord.Config.Paths.DAGsDir, leafDependency), []byte(leafContent), 0o600))
+
+	f.workers = append(f.workers,
+		f.setupWorkerMode("root-worker", map[string]string{"layer": "root"}, "", true, nil),
+		f.setupWorkerMode("stage-worker", map[string]string{"layer": "stage"}, "", true, nil),
+		f.setupWorkerMode("leaf-worker", map[string]string{"layer": "leaf"}, "", true, nil),
+	)
+
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(30 * time.Second)
+
+	rootStatus := f.waitForStatus(ir.Succeeded, executionStatusTimeout())
+	require.Equal(t, "root-worker", rootStatus.WorkerID)
+	rootCall := requireNodeByID(t, rootStatus, "call_stage")
+	require.Len(t, rootCall.SubRuns, 1)
+
+	rootRef := ir.NewDAGRunRef(rootStatus.Name, rootStatus.DAGRunID)
+	stageStatus := readDistributedSubAttemptStatus(t, f, rootRef, rootCall.SubRuns[0].DAGRunID)
+	require.Equal(t, ir.Succeeded, stageStatus.Status)
+	require.Equal(t, "stage-worker", stageStatus.WorkerID)
+	require.Equal(t, rootRef, stageStatus.Root)
+	require.Equal(t, rootRef, stageStatus.Parent)
+	require.Equal(t, stageContent, nodeOutputValue(t, requireNodeByID(t, *stageStatus, "read_stage_dependency"), "CONTENT"))
+
+	stageCall := requireNodeByID(t, *stageStatus, "call_leaf")
+	require.Len(t, stageCall.SubRuns, 1)
+	leafStatus := readDistributedSubAttemptStatus(t, f, rootRef, stageCall.SubRuns[0].DAGRunID)
+	require.Equal(t, ir.Succeeded, leafStatus.Status)
+	require.Equal(t, "leaf-worker", leafStatus.WorkerID)
+	require.Equal(t, rootRef, leafStatus.Root)
+	require.Equal(t, ir.NewDAGRunRef(stageStatus.Name, stageStatus.DAGRunID), leafStatus.Parent)
+	require.Equal(t, leafContent, nodeOutputValue(t, requireNodeByID(t, *leafStatus, "read_leaf_dependency"), "CONTENT"))
+}
+
 func TestSubDAG_InSameFile(t *testing.T) {
 	t.Run("parentAndChildInSameYAMLFile", func(t *testing.T) {
 		f := newTestFixture(t, `

--- a/internal/runtime/executor/task_test.go
+++ b/internal/runtime/executor/task_test.go
@@ -148,6 +148,19 @@ func TestPrepareDAGWorkspaceRejectsEmptyResolvedWorkingDirectory(t *testing.T) {
 	require.ErrorContains(t, err, "DAGU_TEST_EMPTY_WORKSPACE_ROOT")
 }
 
+func TestPrepareDAGWorkspaceReportsUnavailableSource(t *testing.T) {
+	t.Parallel()
+
+	dag := &ir.DAG{
+		Name:     "remote-child",
+		YamlData: []byte("name: remote-child\nsteps:\n  - run: cat input.txt\n"),
+		Steps:    []ir.Step{{Dependencies: []string{"input.txt"}}},
+	}
+
+	_, err := executor.PrepareDAGWorkspace(context.Background(), dag)
+	require.ErrorIs(t, err, executor.ErrDAGWorkspaceSourceUnavailable)
+}
+
 func TestDAG_CreateTask(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -5,6 +5,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,10 @@ import (
 )
 
 type workspaceSeedKey struct{}
+
+// ErrDAGWorkspaceSourceUnavailable indicates that the current host cannot
+// resolve a dependency-bearing DAG's source workspace.
+var ErrDAGWorkspaceSourceUnavailable = errors.New("DAG file dependencies require a source file or working directory")
 
 // WithWorkspaceSeed carries an immutable workspace through inline child workflows.
 func WithWorkspaceSeed(ctx context.Context, seed WorkspaceSeed) context.Context {
@@ -76,7 +81,7 @@ func dagWorkspacePackOptions(ctx context.Context, dag *ir.DAG) (string, *workspa
 	root := dag.WorkingDir
 	if strings.TrimSpace(root) == "" {
 		if sourceFile == "" {
-			return "", nil, fmt.Errorf("DAG file dependencies require a source file or working directory")
+			return "", nil, ErrDAGWorkspaceSourceUnavailable
 		}
 		root = filepath.Dir(sourceFile)
 	} else {
@@ -123,6 +128,12 @@ func workspaceDAGPath(root, sourceFile string) (string, error) {
 			return "", fmt.Errorf("inspect workspace DAG path %q: %w", name, err)
 		}
 	}
+}
+
+// HasDAGFileDependencies reports whether a DAG or any inline child declares
+// files that must be included in its execution workspace.
+func HasDAGFileDependencies(dag *ir.DAG) bool {
+	return len(dagFileDependencies(dag)) > 0
 }
 
 func dagFileDependencies(dag *ir.DAG) []string {

--- a/internal/runtime/executor/workspace.go
+++ b/internal/runtime/executor/workspace.go
@@ -20,7 +20,7 @@ type workspaceSeedKey struct{}
 
 // ErrDAGWorkspaceSourceUnavailable indicates that the current host cannot
 // resolve a dependency-bearing DAG's source workspace.
-var ErrDAGWorkspaceSourceUnavailable = errors.New("DAG file dependencies require a source file or working directory")
+var ErrDAGWorkspaceSourceUnavailable = errors.New("DAG file dependencies require a local source workspace")
 
 // WithWorkspaceSeed carries an immutable workspace through inline child workflows.
 func WithWorkspaceSeed(ctx context.Context, seed WorkspaceSeed) context.Context {

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -350,6 +350,10 @@ func (cli *clientImpl) prepareTaskWorkspace(ctx context.Context, task *dispatch.
 	if err != nil {
 		return fmt.Errorf("load DAG for file dependency snapshot: %w", err)
 	}
+	// A configured working_dir does not establish that this host owns the DAG source.
+	if task.SourceFile == "" && task.SourceWorkDir == "" && runtimeexec.HasDAGFileDependencies(dag) {
+		return runtimeexec.ErrDAGWorkspaceSourceUnavailable
+	}
 	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(ctx, dag, cli.config.WorkspaceBundleDir)
 	if err != nil {
 		return err

--- a/internal/service/coordinator/client.go
+++ b/internal/service/coordinator/client.go
@@ -241,7 +241,9 @@ func (cli *clientImpl) Dispatch(ctx context.Context, req dispatch.DispatchReques
 		return fmt.Errorf("dispatch task is nil")
 	}
 	if err := cli.prepareTaskWorkspace(ctx, task); err != nil {
-		return err
+		if !errors.Is(err, runtimeexec.ErrDAGWorkspaceSourceUnavailable) {
+			return err
+		}
 	}
 	protoTask, err := convert.DispatchTaskToProto(task)
 	if err != nil {

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -185,7 +185,7 @@ func TestClientDispatch(t *testing.T) {
 		assert.Empty(t, entries)
 	})
 
-	t.Run("DefersSourceLessFileDependenciesToCoordinator", func(t *testing.T) {
+	t.Run("DefersSourceLessFileDependenciesWithWorkingDirToCoordinator", func(t *testing.T) {
 		t.Parallel()
 
 		mockCoord := &mockCoordinatorService{
@@ -200,14 +200,16 @@ func TestClientDispatch(t *testing.T) {
 		host, port := parseHostPort(addr)
 		config := coordinator.DefaultConfig()
 		config.MaxRetries = 0
+		config.WorkspaceBundleDir = filepath.Join(t.TempDir(), "workspace-bundles")
 		client := coordinator.New(&mockServiceMonitor{members: []serviceregistry.HostInfo{{
 			ID: "coord-1", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive,
 		}}}, config)
+		workerOnlyDir := filepath.Join(t.TempDir(), "missing-source-workspace")
 
 		err := client.Dispatch(context.Background(), dispatch.DispatchRequest{Task: &dispatch.DispatchTask{
 			DAGRunID:   "run-remote-child",
 			Target:     "remote-child",
-			Definition: "name: remote-child\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n",
+			Definition: fmt.Sprintf("name: remote-child\nworking_dir: %q\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n", workerOnlyDir),
 		}})
 		require.NoError(t, err)
 	})

--- a/internal/service/coordinator/client_test.go
+++ b/internal/service/coordinator/client_test.go
@@ -185,6 +185,33 @@ func TestClientDispatch(t *testing.T) {
 		assert.Empty(t, entries)
 	})
 
+	t.Run("DefersSourceLessFileDependenciesToCoordinator", func(t *testing.T) {
+		t.Parallel()
+
+		mockCoord := &mockCoordinatorService{
+			dispatchFunc: func(_ context.Context, req *coordinatorv1.DispatchRequest) (*coordinatorv1.DispatchResponse, error) {
+				assert.Empty(t, req.Task.WorkspaceBundleDigest)
+				return &coordinatorv1.DispatchResponse{}, nil
+			},
+		}
+		server, addr := startMockServer(t, mockCoord)
+		defer server.Stop()
+
+		host, port := parseHostPort(addr)
+		config := coordinator.DefaultConfig()
+		config.MaxRetries = 0
+		client := coordinator.New(&mockServiceMonitor{members: []serviceregistry.HostInfo{{
+			ID: "coord-1", Host: host, Port: port, Status: serviceregistry.ServiceStatusActive,
+		}}}, config)
+
+		err := client.Dispatch(context.Background(), dispatch.DispatchRequest{Task: &dispatch.DispatchTask{
+			DAGRunID:   "run-remote-child",
+			Target:     "remote-child",
+			Definition: "name: remote-child\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n",
+		}})
+		require.NoError(t, err)
+	})
+
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		config := coordinator.DefaultConfig()

--- a/internal/service/coordinator/handler.go
+++ b/internal/service/coordinator/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/proto/convert"
 	"github.com/dagucloud/dagu/v2/internal/queue"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
+	runtimeexec "github.com/dagucloud/dagu/v2/internal/runtime/executor"
 	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	secretpkg "github.com/dagucloud/dagu/v2/internal/secret"
 	"github.com/dagucloud/dagu/v2/internal/spec"
@@ -162,6 +163,7 @@ type Handler struct {
 	logDir                    string                             // For log storage
 	artifactDir               string                             // For artifact storage
 	stateStore                dagrun.StateStore                  // For persistent DAG state shared across DAG runs
+	workspaceBundleDir        string                             // Root for immutable task workspace bundles and staging
 	workspaceBundleStore      *workspacebundle.Store             // For immutable task workspace bundles
 	dispatchTaskStore         dispatch.DispatchTaskStore         // Shared distributed dispatch queue
 	dispatchAdmissionStore    dispatch.DispatchAdmissionStore    // Shared distributed admission state
@@ -299,6 +301,7 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		logDir:                    cfg.LogDir,
 		artifactDir:               cfg.ArtifactDir,
 		stateStore:                cfg.StateStore,
+		workspaceBundleDir:        cfg.WorkspaceBundleDir,
 		workspaceBundleStore:      bundleStore,
 		dispatchTaskStore:         cfg.DispatchTaskStore,
 		dispatchAdmissionStore:    dispatchAdmissionStore,
@@ -513,6 +516,9 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 		if err := h.ensureWaitingWorkerAvailability(req.Task.WorkerSelector, req.Task.TargetWorkerId); err != nil {
 			return nil, status.Error(dispatchErrorCode(err), err.Error())
 		}
+		if err := h.prepareDispatchTaskWorkspace(ctx, req.Task); err != nil {
+			return nil, err
+		}
 
 		var prepared *preparedDispatchAttempt
 		if h.dagRunRepository != nil {
@@ -547,6 +553,10 @@ func (h *Handler) Dispatch(ctx context.Context, req *coordinatorv1.DispatchReque
 	}
 	if !anyWorkerMatches(healthyWorkers, req.Task.WorkerSelector, req.Task.TargetWorkerId) {
 		return nil, status.Error(codes.FailedPrecondition, errNoMatchingWorkers.Error())
+	}
+	if err := h.prepareDispatchTaskWorkspace(ctx, req.Task); err != nil {
+		h.releaseAdmissionToken(ctx, admissionToken)
+		return nil, err
 	}
 
 	prepared, err := h.prepareAttemptForDispatch(ctx, req.Task)
@@ -603,6 +613,97 @@ func workspaceBundleTouchErrorCode(err error) codes.Code {
 	default:
 		return codes.Internal
 	}
+}
+
+func (h *Handler) prepareDispatchTaskWorkspace(ctx context.Context, task *coordinatorv1.Task) error {
+	if task == nil || task.WorkspaceBundleDigest != "" || strings.TrimSpace(task.Definition) == "" {
+		return nil
+	}
+
+	candidate, err := loadDispatchWorkspaceDAG(ctx, task, []byte(task.Definition), "")
+	if err != nil {
+		return status.Error(codes.InvalidArgument, "invalid dispatch DAG definition for workspace preparation: "+err.Error())
+	}
+	if !runtimeexec.HasDAGFileDependencies(candidate) {
+		return nil
+	}
+	if h.dagRepository == nil {
+		return status.Errorf(codes.FailedPrecondition, "DAG repository is not configured for dependency-bearing task %q", task.Target)
+	}
+	if h.workspaceBundleStore == nil || strings.TrimSpace(h.workspaceBundleDir) == "" {
+		return status.Error(codes.FailedPrecondition, "workspace bundle store is not configured")
+	}
+
+	authoritative, err := h.dagRepository.GetDetails(ctx, task.Target, persis.DAGLoadOptions{})
+	if err != nil {
+		code := codes.Internal
+		if errors.Is(err, persis.ErrDAGNotFound) {
+			code = codes.FailedPrecondition
+		}
+		return status.Error(code, fmt.Sprintf("failed to load authoritative DAG %q: %v", task.Target, err))
+	}
+	if !bytes.Equal(authoritative.YamlData, []byte(task.Definition)) {
+		return status.Errorf(codes.FailedPrecondition, "named DAG %q changed after remote resolution; reload the DAG and retry dispatch", task.Target)
+	}
+	authoritativeSource := strings.TrimSpace(authoritative.SourceFile)
+	if authoritativeSource == "" {
+		return status.Errorf(codes.FailedPrecondition, "authoritative DAG %q does not have a source file for dependency resolution", task.Target)
+	}
+
+	dag, err := loadDispatchWorkspaceDAG(ctx, task, authoritative.YamlData, authoritativeSource)
+	if err != nil {
+		return status.Error(codes.FailedPrecondition, "failed to rebuild authoritative DAG for workspace preparation: "+err.Error())
+	}
+	desc, archivePath, err := runtimeexec.PrepareDAGWorkspaceFile(ctx, dag, h.workspaceBundleDir)
+	if err != nil {
+		return status.Error(codes.FailedPrecondition, "failed to prepare authoritative DAG workspace: "+err.Error())
+	}
+	if desc == nil {
+		return nil
+	}
+	defer func() { _ = fileutil.Remove(archivePath) }()
+
+	archive, err := os.Open(archivePath) //nolint:gosec // archivePath is created by PrepareDAGWorkspaceFile.
+	if err != nil {
+		return status.Error(codes.Internal, "failed to open prepared DAG workspace: "+err.Error())
+	}
+	putErr := h.workspaceBundleStore.PutReader(ctx, *desc, archive)
+	closeErr := archive.Close()
+	if putErr != nil {
+		return status.Error(codes.Internal, "failed to store prepared DAG workspace: "+putErr.Error())
+	}
+	if closeErr != nil {
+		return status.Error(codes.Internal, "failed to close prepared DAG workspace: "+closeErr.Error())
+	}
+
+	task.WorkspaceBundleDigest = desc.Digest
+	task.WorkspaceBundleSize = desc.Size
+	task.WorkspaceBundleDagPath = desc.DAGPath
+	task.WorkspaceBundleOriginalRef = desc.OriginalRef
+	task.WorkspaceBundleResolvedRef = desc.ResolvedRef
+	return nil
+}
+
+func loadDispatchWorkspaceDAG(ctx context.Context, task *coordinatorv1.Task, definition []byte, sourceFile string) (*ir.DAG, error) {
+	loadOpts := []spec.LoadOption{spec.WithName(task.Target)}
+	if task.BaseConfig != "" {
+		loadOpts = append(loadOpts, spec.WithBaseConfigContent([]byte(task.BaseConfig)))
+	}
+	if task.Params != "" {
+		loadOpts = append(loadOpts, spec.WithParams(task.Params))
+	} else if task.Operation == coordinatorv1.Operation_OPERATION_RETRY && task.PreviousStatus != nil {
+		previousStatus, err := convert.ProtoToDAGRunStatus(task.PreviousStatus)
+		if err != nil {
+			return nil, fmt.Errorf("decode previous task status: %w", err)
+		}
+		if previousStatus != nil && len(previousStatus.ParamsList) > 0 {
+			loadOpts = append(loadOpts, spec.WithParams(spec.QuoteRuntimeParams(previousStatus.ParamsList, nil)))
+		}
+	}
+	if sourceFile != "" {
+		return spec.LoadYAMLAt(ctx, definition, sourceFile, loadOpts...)
+	}
+	return spec.LoadYAML(ctx, definition, loadOpts...)
 }
 
 func dispatchBindErrorCode(err error) codes.Code {

--- a/internal/service/coordinator/handler_test.go
+++ b/internal/service/coordinator/handler_test.go
@@ -6,6 +6,7 @@ package coordinator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	persistestutil "github.com/dagucloud/dagu/v2/internal/persis/testutil"
 	"github.com/dagucloud/dagu/v2/internal/proto/convert"
+	"github.com/dagucloud/dagu/v2/internal/runtime/workspacebundle"
 	coordinatorv1 "github.com/dagucloud/dagu/v2/proto/coordinator/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1187,6 +1189,170 @@ func TestHandler_DispatchRejectsStaleQueueDispatchRetry(t *testing.T) {
 	require.NoError(t, readErr)
 	require.Equal(t, "attempt-current", runStatus.AttemptID)
 	require.Equal(t, ir.Aborted, runStatus.Status)
+}
+
+func TestHandlerDispatchPreparesAuthoritativeDAGWorkspace(t *testing.T) {
+	registerCommandExecutorCapsForCoordinatorTest()
+
+	ctx := context.Background()
+	dagDir := t.TempDir()
+	definition := []byte("name: remote-child\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dagDir, "remote-child.yaml"), definition, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dagDir, "input.txt"), []byte("coordinator-owned"), 0o600))
+
+	distributedDir := filepath.Join(t.TempDir(), "distributed")
+	dispatchStore := newTestDispatchTaskStore(distributedDir)
+	heartbeatStore := newTestWorkerHeartbeatStore(distributedDir)
+	require.NoError(t, heartbeatStore.Upsert(ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+	dagRunStore := newMockDAGRunStore()
+	bundleDir := filepath.Join(t.TempDir(), "workspace-bundles")
+	h := NewHandler(HandlerConfig{
+		DAGRunRepository:     dagRunStore.repository,
+		DAGRepository:        testutil.NewFileDAGRepository(dagDir),
+		DispatchTaskStore:    dispatchStore,
+		WorkerHeartbeatStore: heartbeatStore,
+		WorkspaceBundleDir:   bundleDir,
+	})
+	t.Cleanup(func() { h.Close(context.Background()) })
+
+	_, err := h.Dispatch(ctx, &coordinatorv1.DispatchRequest{Task: &coordinatorv1.Task{
+		Operation:      coordinatorv1.Operation_OPERATION_START,
+		RootDagRunName: "remote-child",
+		RootDagRunId:   "run-remote-child",
+		DagRunId:       "run-remote-child",
+		Target:         "remote-child",
+		Definition:     string(definition),
+		QueueName:      "default",
+	}})
+	require.NoError(t, err)
+
+	claimed, err := dispatchStore.ClaimNext(ctx, dispatch.DispatchTaskClaim{
+		WorkerID:     "worker-1",
+		PollerID:     "poller-1",
+		ClaimTimeout: time.Minute,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.NotNil(t, claimed.Task)
+	require.NotEmpty(t, claimed.Task.WorkspaceBundleDigest)
+	assert.Empty(t, claimed.Task.SourceFile)
+
+	archive, err := h.workspaceBundleStore.Get(ctx, claimed.Task.WorkspaceBundleDigest)
+	require.NoError(t, err)
+	desc := workspacebundle.Descriptor{
+		Digest:      claimed.Task.WorkspaceBundleDigest,
+		Size:        claimed.Task.WorkspaceBundleSize,
+		DAGPath:     claimed.Task.WorkspaceBundleDAGPath,
+		OriginalRef: claimed.Task.WorkspaceBundleOriginalRef,
+		ResolvedRef: claimed.Task.WorkspaceBundleResolvedRef,
+	}
+	dest := filepath.Join(t.TempDir(), "workspace")
+	require.NoError(t, workspacebundle.Extract(archive, dest, desc, workspacebundle.DefaultLimits()))
+	assert.FileExists(t, filepath.Join(dest, "input.txt"))
+	actualDAG, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(desc.DAGPath)))
+	require.NoError(t, err)
+	assert.Equal(t, definition, actualDAG)
+	entries, err := os.ReadDir(filepath.Join(bundleDir, "staging"))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestHandlerDispatchRejectsChangedNamedDAGBeforeAttemptCreation(t *testing.T) {
+	registerCommandExecutorCapsForCoordinatorTest()
+
+	ctx := context.Background()
+	dagDir := t.TempDir()
+	authoritative := []byte("name: remote-child\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n")
+	stale := []byte("name: remote-child\nsteps:\n  - name: consume\n    run: cat stale.txt\n    dependencies: stale.txt\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dagDir, "remote-child.yaml"), authoritative, 0o600))
+
+	distributedDir := filepath.Join(t.TempDir(), "distributed")
+	dispatchStore := newTestDispatchTaskStore(distributedDir)
+	heartbeatStore := newTestWorkerHeartbeatStore(distributedDir)
+	require.NoError(t, heartbeatStore.Upsert(ctx, dispatch.WorkerHeartbeatRecord{
+		WorkerID:        "worker-1",
+		LastHeartbeatAt: time.Now().UTC().UnixMilli(),
+	}))
+	dagRunStore := newMockDAGRunStore()
+	h := NewHandler(HandlerConfig{
+		DAGRunRepository:     dagRunStore.repository,
+		DAGRepository:        testutil.NewFileDAGRepository(dagDir),
+		DispatchTaskStore:    dispatchStore,
+		WorkerHeartbeatStore: heartbeatStore,
+		WorkspaceBundleDir:   filepath.Join(t.TempDir(), "workspace-bundles"),
+	})
+
+	_, err := h.Dispatch(ctx, &coordinatorv1.DispatchRequest{Task: &coordinatorv1.Task{
+		DagRunId:   "run-stale-child",
+		Target:     "remote-child",
+		Definition: string(stale),
+		QueueName:  "default",
+	}})
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.ErrorContains(t, err, "changed after remote resolution")
+	assert.Empty(t, dagRunStore.attempts)
+	count, countErr := dispatchStore.CountOutstandingByQueue(ctx, "default", time.Minute)
+	require.NoError(t, countErr)
+	assert.Zero(t, count)
+}
+
+func TestPrepareDispatchTaskWorkspaceUsesRuntimeParams(t *testing.T) {
+	registerCommandExecutorCapsForCoordinatorTest()
+
+	for _, tc := range []struct {
+		name      string
+		configure func(*testing.T, *coordinatorv1.Task, string)
+	}{
+		{
+			name: "ExplicitParams",
+			configure: func(_ *testing.T, task *coordinatorv1.Task, workDir string) {
+				task.Params = "WORKSPACE=" + workDir
+			},
+		},
+		{
+			name: "RetryPreviousStatusParams",
+			configure: func(t *testing.T, task *coordinatorv1.Task, workDir string) {
+				task.Operation = coordinatorv1.Operation_OPERATION_RETRY
+				previousStatus, err := convert.DAGRunStatusToProto(&ir.DAGRunStatus{ParamsList: []string{"WORKSPACE=" + workDir}})
+				require.NoError(t, err)
+				task.PreviousStatus = previousStatus
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dagDir := t.TempDir()
+			workDir := t.TempDir()
+			definition := []byte(fmt.Sprintf("name: remote-child\nparams:\n  WORKSPACE: %q\nworking_dir: ${params.WORKSPACE}\nsteps:\n  - name: consume\n    run: cat input.txt\n    dependencies: input.txt\n", dagDir))
+			require.NoError(t, os.WriteFile(filepath.Join(dagDir, "remote-child.yaml"), definition, 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(workDir, "input.txt"), []byte(tc.name), 0o600))
+
+			h := NewHandler(HandlerConfig{
+				DAGRepository:      testutil.NewFileDAGRepository(dagDir),
+				WorkspaceBundleDir: filepath.Join(t.TempDir(), "workspace-bundles"),
+			})
+			task := &coordinatorv1.Task{Target: "remote-child", Definition: string(definition)}
+			tc.configure(t, task, workDir)
+
+			require.NoError(t, h.prepareDispatchTaskWorkspace(ctx, task))
+			require.NotEmpty(t, task.WorkspaceBundleDigest)
+			archive, err := h.workspaceBundleStore.Get(ctx, task.WorkspaceBundleDigest)
+			require.NoError(t, err)
+			dest := filepath.Join(t.TempDir(), "workspace")
+			require.NoError(t, workspacebundle.Extract(archive, dest, workspacebundle.Descriptor{
+				Digest:  task.WorkspaceBundleDigest,
+				Size:    task.WorkspaceBundleSize,
+				DAGPath: task.WorkspaceBundleDagPath,
+			}, workspacebundle.DefaultLimits()))
+			actual, err := os.ReadFile(filepath.Join(dest, "input.txt"))
+			require.NoError(t, err)
+			assert.Equal(t, tc.name, string(actual))
+		})
+	}
 }
 
 type failingDispatchTaskStore struct {

--- a/skills/dagu/references/file-dependencies.md
+++ b/skills/dagu/references/file-dependencies.md
@@ -17,4 +17,4 @@ Every item must match when the run workspace is prepared. Do not use `${...}` re
 
 Local execution materializes the bundle directly; distributed execution transfers it through the coordinator before worker materialization. The result is exposed as `DAG_RUN_WORK_DIR` and `${context.paths.work_dir}` and becomes the DAG process working directory. An explicit step working directory retains its normal precedence.
 
-Retries create a new snapshot. Separately fetched named child DAGs cannot add dependencies from a remote worker; use an inline multi-document child DAG or keep that child local.
+Retries create a new snapshot. Inline multi-document child DAGs reuse their parent's snapshot, while separately fetched named child DAGs create an independent snapshot from their authoritative source workspace. In shared-nothing distributed execution, the coordinator packages the named child's declared files before dispatch. If the named DAG changed after the worker fetched it, dispatch fails and instructs the caller to reload and retry.

--- a/specs/035-file-dependencies.md
+++ b/specs/035-file-dependencies.md
@@ -12,13 +12,13 @@ This spec defines:
 - dependency path matching and validation
 - local and distributed workspace snapshot and materialization behavior
 - retry and inline child-DAG behavior
+- coordinator-owned snapshots for separately fetched named child DAGs
 
 This spec does not define:
 
 - external tool installation
 - build-workflow input materialization or reuse
 - artifact persistence after a DAG-run finishes
-- remote retrieval of files belonging to a separately stored child DAG
 
 ## Goal
 
@@ -54,7 +54,8 @@ A DAG can use declared files from its working directory with the same isolated w
 ### Child DAGs and retries
 
 - Inline multi-document child DAGs reuse the root DAG's snapshot.
-- A separately fetched named child DAG with file dependencies cannot be dispatched from a remote worker without an available source workspace.
+- A separately fetched named child DAG creates an independent snapshot from its authoritative source workspace and does not inherit its parent's snapshot.
+- When the dispatching host cannot access that source workspace, the coordinator verifies that the fetched definition still matches the authoritative stored DAG before creating the snapshot. If the definition changed, dispatch fails so the caller can reload and retry.
 - Each independently executed retry creates a fresh snapshot from the DAG working directory.
 
 ## Errors
@@ -66,6 +67,8 @@ A DAG can use declared files from its working directory with the same isolated w
 | Declaration with no match | workspace preparation fails naming the unmatched declaration |
 | Unsupported filesystem entry | workspace preparation fails naming the entry type and path |
 | Bundle limit exceeded | workspace preparation fails naming the exceeded limit |
+| Named child changed after remote resolution | dispatch fails and instructs the caller to reload and retry |
+| Authoritative named-child source unavailable | dispatch fails before worker execution |
 | Worker download, verification, or extraction failure | DAG-run fails before step execution |
 
 ## Examples


### PR DESCRIPTION
## Summary

Enable separately stored named child DAGs with file dependencies to run across shared-nothing distributed workers.


## Changes

- Defer workspace preparation when a worker has a dependency-bearing DAG definition but no source workspace
- Prepare named child workspace bundles from the coordinator's current stored DAG definition and source files
- Reject dispatch when a remotely fetched DAG definition no longer matches the coordinator's stored definition
- Resolve explicit and retry parameters before packaging dependencies from parameterized working directories
- Exercise nested named DAG dependencies across three distinct shared-nothing workers
- Make distributed integration workers use coordinator DAG fallback instead of direct access to the coordinator's DAG repository
- Document coordinator-owned snapshots and failure behavior for named child dependencies

## Evidences

Before:
<img width="1632" height="1250" alt="image" src="https://github.com/user-attachments/assets/f5f77830-cf46-41c7-8f9a-89ac03f19219" />

After:
<img width="1626" height="1106" alt="image" src="https://github.com/user-attachments/assets/4958c110-c0f8-4c7e-aaf7-78713b1a885d" />

## Related Issues

Closes #2656


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dispatched named child DAGs with file dependencies failing in shared-nothing distributed runs when workers can't access the child's source workspace.

Before, a worker with a dependency-bearing DAG definition but no source workspace couldn't prepare the run workspace, so dispatch failed. Now the coordinator packages an authoritative workspace bundle from its stored DAG and source files and attaches it to the dispatched task, and workers defer their own packaging when no source is available. If the fetched definition no longer matches the coordinator's stored DAG, dispatch is rejected and the caller must reload and retry.

**Bug Fixes**
- Coordinator builds and stores named-child workspace bundles at dispatch time.
- Workers skip local workspace preparation when the dependency-bearing definition has no source workspace; a configured `working_dir` alone doesn't count as a source.
- Explicit and retry parameters are resolved before packaging dependencies from parameterized working directories.
- Nested named child DAGs with file dependencies run across multiple shared-nothing workers.
- Documents coordinator-owned snapshots and failure behavior for named child dependencies.

<sup>Written for commit 98131d9454829c2ed5ac823143b410f2f6d602dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Distributed tasks can now include named file dependencies, including dependencies in nested child workflows.
  - File dependencies are packaged from the authoritative workflow source before remote execution.
  - Remote workers can add and resolve file dependencies without requiring a local source workspace.

- **Bug Fixes**
  - Improved handling when workflow sources are unavailable during dispatch.
  - Added validation to detect changed workflow definitions before execution and provide actionable retry guidance.
  - Preserved dependency resolution across retries and runtime parameter variations.

- **Documentation**
  - Updated file-dependency guidance and specifications to reflect distributed execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->