### PR TITLE
test: cover value resolution escaping, coercion, and notice classification

### DIFF
--- a/conformance/spec003_value_resolution/testdata/escape_matrix_consts.yaml
+++ b/conformance/spec003_value_resolution/testdata/escape_matrix_consts.yaml
@@ -1,0 +1,10 @@
+consts:
+  - name: prod
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${consts.name}' > matrix.txt
+      printf '%s\n' '\${consts.name}' >> matrix.txt
+      printf '%s\n' '\\${consts.name}' >> matrix.txt
+      printf '%s\n' '\\\${consts.name}' >> matrix.txt

--- a/conformance/spec003_value_resolution/testdata/escape_matrix_env.yaml
+++ b/conformance/spec003_value_resolution/testdata/escape_matrix_env.yaml
@@ -1,0 +1,10 @@
+env:
+  - NAME=prod
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${env.NAME}' > matrix.txt
+      printf '%s\n' '\${env.NAME}' >> matrix.txt
+      printf '%s\n' '\\${env.NAME}' >> matrix.txt
+      printf '%s\n' '\\\${env.NAME}' >> matrix.txt

--- a/conformance/spec003_value_resolution/testdata/escape_matrix_params.yaml
+++ b/conformance/spec003_value_resolution/testdata/escape_matrix_params.yaml
@@ -1,0 +1,12 @@
+params:
+  - name: name
+    type: string
+    default: prod
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${params.name}' > matrix.txt
+      printf '%s\n' '\${params.name}' >> matrix.txt
+      printf '%s\n' '\\${params.name}' >> matrix.txt
+      printf '%s\n' '\\\${params.name}' >> matrix.txt

--- a/conformance/spec003_value_resolution/testdata/escape_matrix_steps.yaml
+++ b/conformance/spec003_value_resolution/testdata/escape_matrix_steps.yaml
@@ -1,0 +1,14 @@
+working_dir: .
+steps:
+  - id: build
+    run: |
+      printf 'image=v1.2.3\n' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: image
+  - id: check
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.image}' > matrix.txt
+      printf '%s\n' '\${steps.build.outputs.image}' >> matrix.txt
+      printf '%s\n' '\\${steps.build.outputs.image}' >> matrix.txt
+      printf '%s\n' '\\\${steps.build.outputs.image}' >> matrix.txt

--- a/conformance/spec003_value_resolution/testdata/insertion_boolean_and_integer.yaml
+++ b/conformance/spec003_value_resolution/testdata/insertion_boolean_and_integer.yaml
@@ -1,0 +1,17 @@
+params:
+  - name: enabled
+    type: boolean
+    default: true
+  - name: disabled
+    type: boolean
+    default: false
+  - name: count
+    type: integer
+    default: -7
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${params.enabled}' > insertion.txt
+      printf '%s\n' '${params.disabled}' >> insertion.txt
+      printf '%s\n' '${params.count}' >> insertion.txt

--- a/conformance/spec003_value_resolution/testdata/insertion_number_exponent_notation.yaml
+++ b/conformance/spec003_value_resolution/testdata/insertion_number_exponent_notation.yaml
@@ -1,0 +1,9 @@
+params:
+  - name: value
+    type: number
+    default: 1.5e2
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${params.value}' > insertion.txt

--- a/conformance/spec003_value_resolution/testdata/insertion_number_trailing_zeros.yaml
+++ b/conformance/spec003_value_resolution/testdata/insertion_number_trailing_zeros.yaml
@@ -1,0 +1,13 @@
+params:
+  - name: ratio
+    type: number
+    default: 3.140000
+  - name: whole
+    type: number
+    default: 2.0
+working_dir: .
+steps:
+  - id: check
+    run: |
+      printf '%s\n' '${params.ratio}' > insertion.txt
+      printf '%s\n' '${params.whole}' >> insertion.txt

--- a/conformance/spec003_value_resolution/testdata/notice_defect_missing_dependency.yaml
+++ b/conformance/spec003_value_resolution/testdata/notice_defect_missing_dependency.yaml
@@ -1,0 +1,11 @@
+working_dir: .
+steps:
+  - id: build
+    run: |
+      printf 'image=v1.2.3\n' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: image
+  - id: deploy
+    env:
+      IMAGE: ${steps.build.outputs.image}
+    run: printf '%s\n' "$IMAGE" > deploy.txt

--- a/conformance/spec003_value_resolution/testdata/notice_defect_unknown_const.yaml
+++ b/conformance/spec003_value_resolution/testdata/notice_defect_unknown_const.yaml
@@ -1,0 +1,6 @@
+consts:
+  - known: value
+working_dir: .
+steps:
+  - id: check
+    run: printf '%s\n' ${consts.unknown_name} > defect.txt

--- a/conformance/spec003_value_resolution/testdata/notice_runtime_only_missing_param.yaml
+++ b/conformance/spec003_value_resolution/testdata/notice_runtime_only_missing_param.yaml
@@ -1,0 +1,8 @@
+params:
+  - name: environment
+    type: string
+    required: true
+working_dir: .
+steps:
+  - id: check
+    run: printf '%s\n' ${params.environment} > runtime.txt

--- a/conformance/spec003_value_resolution/value_resolution_test.go
+++ b/conformance/spec003_value_resolution/value_resolution_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec003_value_resolution_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+)
+
+// TestEscapeParityAcrossNamespaces proves the odd/even backslash-run escape
+// rule from the "Escaped Dagu References" section applies identically to
+// every Dagu-owned reference namespace, not just one of them:
+//
+//   - 0 backslashes: unescaped, the reference resolves normally.
+//   - 1 backslash (odd): the reference is escaped; it stays literal, with the
+//     escape marker itself removed.
+//   - 2 backslashes (even): unescaped again; the reference resolves and the
+//     backslash pair is preserved untouched ahead of the resolved value.
+//   - 3 backslashes (odd): escaped again; one marker is removed, leaving the
+//     remaining backslash pair ahead of the still-literal reference text.
+func TestEscapeParityAcrossNamespaces(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		file     string
+		refText  string
+		resolved string
+	}{
+		{name: "consts", file: "escape_matrix_consts.yaml", refText: "${consts.name}", resolved: "prod"},
+		{name: "params", file: "escape_matrix_params.yaml", refText: "${params.name}", resolved: "prod"},
+		{name: "env", file: "escape_matrix_env.yaml", refText: "${env.NAME}", resolved: "prod"},
+		{name: "steps", file: "escape_matrix_steps.yaml", refText: "${steps.build.outputs.image}", resolved: "v1.2.3"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("start", tc.file)
+			result.ExpectExitCode(0)
+
+			expected := tc.resolved + "\n" + // 0 backslashes: resolved
+				tc.refText + "\n" + // 1 backslash: escaped, marker removed, stays literal
+				`\\` + tc.resolved + "\n" + // 2 backslashes: unescaped, pair preserved, resolves
+				`\\` + tc.refText + "\n" // 3 backslashes: escaped, one pair remains, stays literal
+			dagu.ExpectFileContent("matrix.txt", expected)
+		})
+	}
+}
+
+// TestStringInsertionCoercion proves the "String Insertion" rules: booleans
+// insert as "true"/"false", integers insert in base-10 decimal, and
+// non-integer numbers insert using the shortest round-trippable decimal
+// representation rather than the author's original literal text.
+func TestStringInsertionCoercion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("boolean and integer", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "insertion_boolean_and_integer.yaml")
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContent("insertion.txt", "true\nfalse\n-7\n")
+	})
+
+	t.Run("number strips trailing zeros to shortest round-trippable form", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "insertion_number_trailing_zeros.yaml")
+		result.ExpectExitCode(0)
+		// Authored as 3.140000 and 2.0; the spec requires the shortest
+		// round-trippable text, not the author's original digit run.
+		dagu.ExpectFileContent("insertion.txt", "3.14\n2\n")
+	})
+
+	t.Run("number normalizes exponent notation to plain decimal", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "insertion_number_exponent_notation.yaml")
+		result.ExpectExitCode(0)
+		// Authored as 1.5e2; inserted text must be plain decimal, not the
+		// author's exponent-notation literal.
+		dagu.ExpectFileContent("insertion.txt", "150\n")
+	})
+}
+
+// TestDefectAndRuntimeOnlyNoticeClassification proves the two notice classes
+// from "Unresolved Supported References" are actually distinguished, not just
+// both labeled generically:
+//
+//   - A defect (a reference the spec statically cannot resolve — either an
+//     undeclared const name, or a step-output reference in a field whose
+//     owning spec does not provide the lookup scope because the consuming
+//     step never authored the dependency) must be reported by `dagu validate`
+//     even without `--show-unresolved`.
+//   - A runtime-only notice (a well-formed reference whose availability
+//     depends on a value only the caller can supply at run start, such as a
+//     required param not yet provided at validate time) must stay out of
+//     default `dagu validate` output and appear only under
+//     `--show-unresolved`.
+//
+// Neither class is a validation error: every case here still exits zero.
+func TestDefectAndRuntimeOnlyNoticeClassification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defect: unknown const is reported without --show-unresolved", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "notice_defect_unknown_const.yaml")
+		result.ExpectExitCode(0)
+		result.ExpectStderrContains("${consts.unknown_name}", "steps[0].run")
+	})
+
+	t.Run("defect: step-output reference missing its authored dependency is reported without --show-unresolved", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "notice_defect_missing_dependency.yaml")
+		result.ExpectExitCode(0)
+		result.ExpectStderrContains("${steps.build.outputs.image}", "does not depend on the producing step")
+	})
+
+	t.Run("runtime-only: missing required param stays quiet by default", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "notice_runtime_only_missing_param.yaml")
+		result.ExpectExitCode(0)
+		result.ExpectStderr("")
+	})
+
+	t.Run("runtime-only: missing required param is shown under --show-unresolved", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "--show-unresolved", "notice_runtime_only_missing_param.yaml")
+		result.ExpectExitCode(0)
+		result.ExpectStderrContains("${params.environment}")
+	})
+}


### PR DESCRIPTION
Add missing test in conformance/spec003_value_resolution 

## Summary

  conformance/spec003_value_resolution had zero black-box coverage despite
  Spec 003 being marked Implemented and being the foundational spec every
  other value-resolution spec depends on. Add coverage for:

  - the odd/even backslash escape rule proven across all four reference
    namespaces (consts, params, env, steps), not just one
  - string-insertion coercion for booleans/integers, plus the "shortest
    round-trippable" number rule (trailing zeros and exponent notation
    both normalize to plain minimal decimal text)
  - the defect-vs-runtime-only unresolved-reference split: an unknown
    const and a step-output reference missing its authored dependency
    are both defects shown by `dagu validate` without --show-unresolved;
    a required param missing at validate time is runtime-only and stays
    hidden until --show-unresolved is passed

  All cases pass against the current binary — this is regression coverage
  for already-correct behavior, not a claim of new functionality.

## Checklist

- [x ] Code follows the project style guidelines
- [ x] Self-review of the code has been performed
- [ x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [ x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance coverage for escaping behavior across constants, parameters, environment values, and step outputs.
  * Added validation for boolean, integer, decimal, trailing-zero, and exponent-form value insertion.
  * Added checks for defect and runtime-only notice classification, including missing dependencies, unknown constants, and unresolved parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->