### PR TITLE
docs: add missing spec 036 row to the status table

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -38,6 +38,7 @@ It must not be treated as product behavior until implementation catches up.
 | [033: Build Workflows](033-build-workflows.md) | Implemented |
 | [034: Wiki Page File Format](034-wiki-page-format.md) | Implemented |
 | [035: File Dependencies](035-file-dependencies.md) | Implemented |
+| [036: MCP Execute Tool](036-mcp-execute-tool.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

specs/README.md's status table was never updated when
  036-mcp-execute-tool.md was added in #2608 — the spec, its
  implementation, and its conformance suite all shipped, but the table's
  own row was skipped. It already self-declares "Status: Implemented"
  and has full black-box coverage in conformance/spec036_mcp_execute_tool,
  so the table should say the same.
  
## Related Issues

Refs #2608 

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the conformance status table to mark “036: MCP Execute Tool” as implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->