### PR TITLE
test: cover step run array-form validation and shell selection

### DIFF
--- a/conformance/spec013_step_run/step_run_test.go
+++ b/conformance/spec013_step_run/step_run_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec013_step_run_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+)
+
+// TestArrayFormMalformedEntriesAreRejected proves the "Field Shape" rules for
+// array-form `run`: a mapping item with more than one key, and a single-key
+// mapping item whose value is itself a nested mapping or a nested array,
+// must all fail validation rather than being silently coerced.
+func TestArrayFormMalformedEntriesAreRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		file string
+	}{
+		{name: "multi-key mapping item", file: "array_form_multi_key_mapping_invalid.yaml"},
+		{name: "nested mapping value", file: "array_form_nested_mapping_value_invalid.yaml"},
+		{name: "nested array item", file: "array_form_nested_array_item_invalid.yaml"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", tc.file)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains("command")
+		})
+	}
+}
+
+// TestArrayFormSingleKeyScalarMappingIsAccepted proves the companion positive
+// rule: a single-key mapping item whose value is a primitive scalar is valid
+// and converts to a "key: value" command string, run in order alongside
+// plain string entries.
+func TestArrayFormSingleKeyScalarMappingIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "array_form_single_key_scalar_valid.yaml")
+	result.ExpectExitCode(0)
+	dagu.ExpectFileContent("out.txt", "first\nhello: world\n")
+}
+
+// TestShellSelectionPrecedence proves the full selection order from "Shell
+// Selection": step with.shell beats root shell, root shell beats
+// DAGU_DEFAULT_SHELL, and DAGU_DEFAULT_SHELL beats the platform discovery
+// fallback (here poisoned via $SHELL). Each fixture poisons every lower-
+// precedence source with a nonexistent path, so the run only succeeds if the
+// higher-precedence source was actually the one selected.
+func TestShellSelectionPrecedence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixtures assume a POSIX sh is available")
+	}
+	t.Parallel()
+
+	t.Run("step with.shell overrides root shell and DAGU_DEFAULT_SHELL", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.RunWithEnv(
+			[]string{"DAGU_DEFAULT_SHELL=/nonexistent/poison-default-shell"},
+			"start", "shell_step_overrides_root_default.yaml",
+		)
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContent("result.out", "ok\n")
+	})
+
+	t.Run("root shell overrides DAGU_DEFAULT_SHELL", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.RunWithEnv(
+			[]string{"DAGU_DEFAULT_SHELL=/nonexistent/poison-default-shell"},
+			"start", "shell_selection_root_overrides_default.yaml",
+		)
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContent("result.out", "ok\n")
+	})
+
+	t.Run("DAGU_DEFAULT_SHELL overrides the platform fallback", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.RunWithEnv(
+			[]string{"SHELL=/nonexistent/poison-shell-env", "DAGU_DEFAULT_SHELL=sh"},
+			"start", "shell_default_overrides_platform.yaml",
+		)
+		result.ExpectExitCode(0)
+		dagu.ExpectFileContent("result.out", "ok\n")
+	})
+}

--- a/conformance/spec013_step_run/testdata/array_form_multi_key_mapping_invalid.yaml
+++ b/conformance/spec013_step_run/testdata/array_form_multi_key_mapping_invalid.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - id: bad
+    run:
+      - echo one
+      - key1: value1
+        key2: value2

--- a/conformance/spec013_step_run/testdata/array_form_nested_array_item_invalid.yaml
+++ b/conformance/spec013_step_run/testdata/array_form_nested_array_item_invalid.yaml
@@ -1,0 +1,6 @@
+working_dir: .
+steps:
+  - id: bad
+    run:
+      - echo one
+      - [echo, two]

--- a/conformance/spec013_step_run/testdata/array_form_nested_mapping_value_invalid.yaml
+++ b/conformance/spec013_step_run/testdata/array_form_nested_mapping_value_invalid.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - id: bad
+    run:
+      - echo one
+      - key:
+          nested: value

--- a/conformance/spec013_step_run/testdata/array_form_single_key_scalar_valid.yaml
+++ b/conformance/spec013_step_run/testdata/array_form_single_key_scalar_valid.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - id: check
+    stdout: out.txt
+    run:
+      - echo first
+      - echo hello: world

--- a/conformance/spec013_step_run/testdata/shell_default_overrides_platform.yaml
+++ b/conformance/spec013_step_run/testdata/shell_default_overrides_platform.yaml
@@ -1,0 +1,4 @@
+working_dir: .
+steps:
+  - id: check
+    run: printf 'ok\n' > result.out

--- a/conformance/spec013_step_run/testdata/shell_selection_root_overrides_default.yaml
+++ b/conformance/spec013_step_run/testdata/shell_selection_root_overrides_default.yaml
@@ -1,0 +1,5 @@
+shell: sh
+working_dir: .
+steps:
+  - id: check
+    run: printf 'ok\n' > result.out

--- a/conformance/spec013_step_run/testdata/shell_step_overrides_root_default.yaml
+++ b/conformance/spec013_step_run/testdata/shell_step_overrides_root_default.yaml
@@ -1,0 +1,7 @@
+shell: /nonexistent/poison-root-shell
+working_dir: .
+steps:
+  - id: check
+    with:
+      shell: sh
+    run: printf 'ok\n' > result.out


### PR DESCRIPTION
## Summary
conformance/spec013_step_run had zero black-box coverage despite Spec013 depending specs 014/015 build on. 
  
## Changes
Add green regression coverage for the parts already correctly implemented:

  - malformed array-form `run` entries (multi-key mapping items, nested
    mapping/array values) are rejected at validate time, and the
    single-key scalar mapping form is correctly accepted and reconstructed
  - shell selection precedence (step with.shell > root shell >
    DAGU_DEFAULT_SHELL > platform fallback) holds end to end

Two rules from the spec were investigated and found not implemented as specified — `shell: direct` rejection for `run` steps, and  `with.shell_args` without `with.shell` — and are intentionally left untested here rather than covered with red tests.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance coverage for valid and invalid array-form `run` entries.
  * Added validation checks for malformed mappings and nested arrays.
  * Added coverage for shell selection precedence across step, root, environment, and platform defaults.
  * Added scenarios confirming valid commands execute and produce expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->