### PR TITLE
test: cover the agent DAG decision loop end to end

### DIFF
--- a/conformance/spec032_agent/fake_llm_test.go
+++ b/conformance/spec032_agent/fake_llm_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec032_agent_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// scriptedTurn is one canned reply from the fake OpenAI-compatible chat
+// completions endpoint. An agent turn is a strict request/response cycle, so
+// a call-order-indexed script is sufficient to drive a deterministic decision
+// loop without needing to parse the actual conversation each fake server
+// receives.
+type scriptedTurn struct {
+	// tool is the function name to call. Empty means a plain reply with no
+	// tool call (used to test stalling).
+	tool string
+	// args is the JSON-encoded arguments string for the tool call.
+	args string
+	// content is the assistant's text content.
+	content string
+}
+
+type fakeToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type fakeToolCall struct {
+	ID       string               `json:"id"`
+	Type     string               `json:"type"`
+	Function fakeToolCallFunction `json:"function"`
+}
+
+type fakeMessage struct {
+	Role      string         `json:"role"`
+	Content   string         `json:"content"`
+	ToolCalls []fakeToolCall `json:"tool_calls,omitempty"`
+}
+
+type fakeChoice struct {
+	Index        int         `json:"index"`
+	Message      fakeMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type fakeUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type fakeChatResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []fakeChoice `json:"choices"`
+	Usage   fakeUsage    `json:"usage"`
+}
+
+// fakeLLM is a minimal OpenAI-compatible chat-completions server driving the
+// "local" LLM provider, so the agent decision loop can be exercised
+// end-to-end through the real HTTP wire format without a live API key.
+type fakeLLM struct {
+	mu     sync.Mutex
+	turns  []scriptedTurn
+	calls  int
+	server *httptest.Server
+}
+
+func newFakeLLM(t *testing.T, turns []scriptedTurn) *fakeLLM {
+	t.Helper()
+
+	f := &fakeLLM{turns: turns}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeLLM) url() string {
+	return f.server.URL
+}
+
+// env returns the DAGU_TEST_LLM_URL override the fixtures resolve
+// llm.base_url against via ${env.DAGU_TEST_LLM_URL}.
+func (f *fakeLLM) env() []string {
+	return []string{"DAGU_TEST_LLM_URL=" + f.url()}
+}
+
+func (f *fakeLLM) handle(w http.ResponseWriter, _ *http.Request) {
+	f.mu.Lock()
+	idx := f.calls
+	f.calls++
+	f.mu.Unlock()
+
+	turn := scriptedTurn{content: "no more scripted turns"}
+	if idx < len(f.turns) {
+		turn = f.turns[idx]
+	}
+
+	msg := fakeMessage{Role: "assistant", Content: turn.content}
+	finishReason := "stop"
+	if turn.tool != "" {
+		msg.ToolCalls = []fakeToolCall{{
+			ID:   "call_" + strconv.Itoa(idx),
+			Type: "function",
+			Function: fakeToolCallFunction{
+				Name:      turn.tool,
+				Arguments: turn.args,
+			},
+		}}
+		finishReason = "tool_calls"
+	}
+
+	resp := fakeChatResponse{
+		ID:      "chatcmpl-fake-" + strconv.Itoa(idx),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   "fake-model",
+		Choices: []fakeChoice{{Index: 0, Message: msg, FinishReason: finishReason}},
+		Usage:   fakeUsage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// setTaskStatusArgs builds the JSON arguments string for a set_task_status
+// tool call.
+func setTaskStatusArgs(task, status, reason string) string {
+	b, err := json.Marshal(map[string]string{"task": task, "status": status, "reason": reason})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// askUserArgs builds the JSON arguments string for an ask_user tool call.
+func askUserArgs(question string) string {
+	b, err := json.Marshal(map[string]string{"question": question})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/conformance/spec032_agent/runtime_test.go
+++ b/conformance/spec032_agent/runtime_test.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec032_agent_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAgentBasicDecisionLoopSucceeds proves the core decision loop actually
+// runs end to end: the model selects a declared step's tool, observes its
+// outcome, then settles the one open task with set_task_status, and the run
+// concludes succeeded.
+func TestAgentBasicDecisionLoopSucceeds(t *testing.T) {
+	t.Parallel()
+
+	llm := newFakeLLM(t, []scriptedTurn{
+		{tool: "do_work", args: "{}"},
+		{tool: "set_task_status", args: setTaskStatusArgs("finish", "completed", "do_work ran")},
+	})
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(llm.env(), "start", "runtime_basic.yaml")
+	result.ExpectExitCode(0)
+	dagu.ExpectFileContent("work.out", "run\n")
+}
+
+// TestAgentToolErrorsDoNotFailRun proves that a set_task_status call naming
+// an unknown task is reported back as a tool error without failing the run,
+// per "Naming an unknown task ... is reported back as a tool error and the
+// loop continues; none of these fail the run."
+func TestAgentToolErrorsDoNotFailRun(t *testing.T) {
+	t.Parallel()
+
+	llm := newFakeLLM(t, []scriptedTurn{
+		{tool: "set_task_status", args: setTaskStatusArgs("no_such_task", "completed", "oops")},
+		{tool: "do_work", args: "{}"},
+		{tool: "set_task_status", args: setTaskStatusArgs("finish", "completed", "do_work ran")},
+	})
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(llm.env(), "start", "runtime_basic.yaml")
+	result.ExpectExitCode(0)
+	dagu.ExpectFileContent("work.out", "run\n")
+}
+
+// TestAgentRepetitionLimitRefusesSixthAttempt proves "A single action may run
+// at most 5 times per DAG run; beyond that, the request is refused as a tool
+// error and the agent must choose differently." The model selects the same
+// action 6 times in a row; only 5 real executions must land, the 6th must be
+// refused without failing the run, and the run must still be able to
+// complete afterward.
+func TestAgentRepetitionLimitRefusesSixthAttempt(t *testing.T) {
+	t.Parallel()
+
+	turns := make([]scriptedTurn, 0, 7)
+	for range 6 {
+		turns = append(turns, scriptedTurn{tool: "do_work", args: "{}"})
+	}
+	turns = append(turns, scriptedTurn{tool: "set_task_status", args: setTaskStatusArgs("finish", "completed", "enough attempts")})
+	llm := newFakeLLM(t, turns)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(llm.env(), "start", "runtime_basic.yaml")
+	result.ExpectExitCode(0)
+	// Exactly 5 real executions land; the 6th selection is refused as a tool
+	// error rather than actually re-running the step a 6th time.
+	dagu.ExpectFileContent("work.out", "run\nrun\nrun\nrun\nrun\n")
+}
+
+// TestAgentStallingFailsRun proves "A second consecutive reply without a
+// tool call fails the run." The first no-tool-call reply is only a reminder;
+// the second, consecutive one must fail the run outright, and the action
+// must never have run.
+func TestAgentStallingFailsRun(t *testing.T) {
+	t.Parallel()
+
+	llm := newFakeLLM(t, []scriptedTurn{
+		{content: "Thinking about it..."},
+		{content: "Still thinking..."},
+	})
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(llm.env(), "start", "runtime_basic.yaml")
+	result.ExpectNonZeroExitCode()
+	dagu.ExpectNoFile("work.out")
+}
+
+// TestAgentPartiallySucceededWhenActionLeftFailed proves terminal-status
+// derivation: "no task open and none failed, at least one action left
+// failed -> partially succeeded." The agent runs an action that always
+// fails, then settles the only task as completed anyway.
+func TestAgentPartiallySucceededWhenActionLeftFailed(t *testing.T) {
+	t.Parallel()
+
+	llm := newFakeLLM(t, []scriptedTurn{
+		{tool: "risky_action", args: "{}"},
+		{tool: "set_task_status", args: setTaskStatusArgs("finish", "completed", "accepted despite failure")},
+	})
+
+	dagu := harness.NewRunner(t)
+	env := append(llm.env(), "DAGU_HOME="+filepath.Join(t.TempDir(), "dagu"))
+	const runID = "spec032-partial"
+	result := dagu.RunWithEnv(env, "start", "--run-id="+runID, "runtime_partial_failure.yaml")
+	result.ExpectExitCode(0)
+
+	status := dagu.RunWithEnv(env, "status", "--run-id="+runID, "runtime_partial_failure.yaml")
+	status.ExpectExitCode(0)
+	require.Contains(t, status.Stdout(), "Partially Succeeded")
+}
+
+// TestAgentAskUserSuspendsAndResumes proves the hardest-to-verify-by-
+// inspection behavior in the spec: an ask_user action opens the agent's own
+// synthesized human task (id "ask_user"), the run releases its process and
+// reports waiting, completing that human task re-queues the same DAG run,
+// and the agent resumes with its conversation and goal progress intact,
+// receiving the answer as the next turn's observation.
+func TestAgentAskUserSuspendsAndResumes(t *testing.T) {
+	llm := newFakeLLM(t, []scriptedTurn{
+		{tool: "ask_user", args: askUserArgs("Proceed with the work?")},
+		{tool: "do_work", args: "{}"},
+		{tool: "set_task_status", args: setTaskStatusArgs("finish", "completed", "user approved and work ran")},
+	})
+
+	dagu := harness.NewRunner(t)
+	schedulerPort := harness.FreePort(t)
+	env := append(llm.env(),
+		"DAGU_HOME="+filepath.Join(t.TempDir(), "dagu"),
+		"DAGU_SCHEDULER_PORT="+strconv.Itoa(schedulerPort),
+	)
+	const runID = "spec032-ask-user"
+
+	scheduler := dagu.StartWithEnv(env, "scheduler", "--dags="+dagu.ProjectPath("."))
+	select {
+	case <-scheduler.Done():
+		t.Fatalf("scheduler exited during startup: %s", scheduler.FailureOutput())
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	start := dagu.RunWithEnv(env, "start", "--run-id="+runID, "runtime_ask_user.yaml")
+	start.ExpectExitCode(0)
+
+	waitingStatus := waitForAgentStatus(t, dagu, env, runID, "runtime_ask_user.yaml", "Waiting")
+	require.Contains(t, waitingStatus.Stdout(), "ask_user")
+	require.Contains(t, waitingStatus.Stdout(), "Proceed with the work?")
+
+	complete := dagu.RunWithEnv(env, "human-task", "complete",
+		"--run-id="+runID, "--step=ask_user", "--input=answer=yes", "spec032_runtime_ask_user")
+	complete.ExpectExitCode(0)
+
+	waitForAgentStatus(t, dagu, env, runID, "runtime_ask_user.yaml", "Succeeded")
+	waitForAgentFileContent(t, dagu.ProjectPath("work.out"), "run\n")
+}
+
+func waitForAgentStatus(
+	t *testing.T,
+	dagu *harness.Runner,
+	env []string,
+	runID, file, status string,
+) *harness.Result {
+	t.Helper()
+
+	deadline := time.Now().Add(harness.WaitTimeout(t))
+	var result *harness.Result
+	for time.Now().Before(deadline) {
+		result = dagu.RunWithEnv(env, "status", "--run-id="+runID, file)
+		if result.ExitCode() == 0 && strings.Contains(result.Stdout(), status) {
+			return result
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if result == nil {
+		t.Fatal("status command was not run")
+	}
+	t.Fatalf("DAG-run %s did not reach %s\nstdout:\n%s\nstderr:\n%s", runID, status, result.Stdout(), result.Stderr())
+	return nil
+}
+
+func waitForAgentFileContent(t *testing.T, path, expected string) {
+	t.Helper()
+
+	deadline := time.Now().Add(harness.WaitTimeout(t))
+	for time.Now().Before(deadline) {
+		actual, err := os.ReadFile(path) // #nosec G304 -- the caller supplies a test-project path.
+		if err == nil && string(actual) == expected {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("file %s never reached content %q", path, expected)
+}

--- a/conformance/spec032_agent/testdata/runtime_ask_user.yaml
+++ b/conformance/spec032_agent/testdata/runtime_ask_user.yaml
@@ -1,0 +1,13 @@
+name: spec032_runtime_ask_user
+type: agent
+working_dir: .
+llm:
+  provider: local
+  model: fake-model
+  base_url: ${env.DAGU_TEST_LLM_URL}
+steps:
+  - id: do_work
+    run: printf 'run\n' >> work.out
+tasks:
+  - name: finish
+    description: The user answered and the do_work action has run.

--- a/conformance/spec032_agent/testdata/runtime_basic.yaml
+++ b/conformance/spec032_agent/testdata/runtime_basic.yaml
@@ -1,0 +1,12 @@
+type: agent
+working_dir: .
+llm:
+  provider: local
+  model: fake-model
+  base_url: ${env.DAGU_TEST_LLM_URL}
+steps:
+  - id: do_work
+    run: printf 'run\n' >> work.out
+tasks:
+  - name: finish
+    description: The do_work action has run at least once.

--- a/conformance/spec032_agent/testdata/runtime_partial_failure.yaml
+++ b/conformance/spec032_agent/testdata/runtime_partial_failure.yaml
@@ -1,0 +1,12 @@
+type: agent
+working_dir: .
+llm:
+  provider: local
+  model: fake-model
+  base_url: ${env.DAGU_TEST_LLM_URL}
+steps:
+  - id: risky_action
+    run: exit 1
+tasks:
+  - name: finish
+    description: The risky action was attempted, whether or not it succeeded.


### PR DESCRIPTION
## Summary
conformance/spec032_agent only proved static YAML shape validation for type: agent DAGs; the actual LLM-driven decision loop had zero black-box coverage.
 
## Changes
Add a fake OpenAI-compatible chat-completions server (driven through the real "local" provider, not a Dagu-internal mock) and six scenarios: the basic action -> set_task_status loop, tool-error tolerance for a bad task name, the 5-run repetition limit, stalling on two consecutive no-tool-call replies, partially-succeeded terminal status, and the full ask_user suspend/resume bridge into human tasks.

The ask_user scenario starts its own scheduler process for the resume half of the flow; give it its own port via DAGU_SCHEDULER_PORT + harness.FreePort instead of the scheduler's hardcoded default (8090), so it can't collide with concurrent scheduler-starting tests elsewhere in the suite.
  
## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance coverage for agent runtime decision-making, including tool execution, errors, repetition limits, stalling, partial failures, and task completion.
  * Added coverage for suspending and resuming workflows when user input is requested.
  * Added realistic local-model test fixtures for successful, partially failed, and interactive agent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->