### PR TITLE
test: cover git worktree mutation serialization and branch conflicts

### DIFF
--- a/conformance/spec030_git_worktree_action/branch_conflict_test.go
+++ b/conformance/spec030_git_worktree_action/branch_conflict_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec030_git_worktree_action_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteBranchOtherGitRefused proves "delete_branch must not delete
+// a branch that is checked out in another worktree" for the linked-worktree
+// case, complementing the existing primary-tree case in
+// TestGitWorktreeRemoveRuntimeErrors ("checked-out primary branch cannot be
+// deleted").
+//
+// Two linked worktrees are forced to check out the same branch (git worktree
+// add --force permits this even though it's normally refused). Removing one
+// of them with delete_branch: true must be refused as a preflight failure --
+// "branch checkout conflicts" is one of the checks the Remove Operation
+// performs before changing the repository -- so the target worktree, its
+// registration, and the branch itself must all remain exactly as they were.
+func TestDeleteBranchOtherGitRefused(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	repo := initRepository(t, dagu)
+
+	targetPath := dagu.ProjectPath("wt/shared-target")
+	createLinkedWorktree(t, repo.path, targetPath, "shared", repo.baseCommit)
+
+	otherPath := dagu.ProjectPath("wt/shared-other")
+	createForcedLinkedWorktree(t, repo.path, otherPath, "shared")
+	requireLinkedWorktree(t, repo.path, otherPath, "shared", repo.baseCommit)
+
+	result := startWithParams(dagu, "runtime_remove_delete.yaml", "working_dir=./repo", "branch=shared")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrNotEmpty()
+
+	// A preflight failure must leave the worktree, its registration, and the
+	// branch unchanged, so no outputs are published for this attempt.
+	requireNoPublishedOutputs(t, dagu)
+
+	require.DirExists(t, targetPath)
+	requireLinkedWorktree(t, repo.path, targetPath, "shared", repo.baseCommit)
+
+	require.True(t, refExists(t, repo.path, "refs/heads/shared"))
+	requireLinkedWorktree(t, repo.path, otherPath, "shared", repo.baseCommit)
+}
+
+// createForcedLinkedWorktree registers a linked worktree checking out branch,
+// overriding Git's default refusal to check out a branch that is already
+// checked out in another worktree.
+func createForcedLinkedWorktree(t *testing.T, repoPath, path, branch string) {
+	t.Helper()
+	gitRun(t, repoPath, "worktree", "add", "--force", path, branch)
+}

--- a/conformance/spec030_git_worktree_action/serialization_test.go
+++ b/conformance/spec030_git_worktree_action/serialization_test.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec030_git_worktree_action_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGitMutationSerialization exercises "Mutation Serialization": add and
+// remove operations resolving to the same common Git directory must execute
+// their inspect-and-mutate sequences serially, including across different
+// DAG runs.
+//
+// This is inherently a stress test, not a deterministic proof: without
+// serialization a race here would surface as flaky corruption under
+// concurrent load, not as a guaranteed failure on any single run. The test
+// launches several add and several remove operations against the same
+// repository as separate, concurrently-running `dagu start` processes (real
+// separate DAG runs, not goroutines sharing one run), each targeting its own
+// distinct branch and path so no operation's target legitimately conflicts
+// with another's. If mutation serialization is missing or broken, this
+// concurrent load is expected to eventually surface as an operation failing
+// outright or as corrupted, inconsistent, or lost worktree registrations in
+// the shared repository afterward -- not necessarily on every run.
+func TestGitMutationSerialization(t *testing.T) {
+	dagu := harness.NewRunner(t)
+	repo := initRepository(t, dagu)
+
+	const addCount = 6
+	const removeCount = 6
+
+	// Pre-create the worktrees the concurrent phase will remove, before the
+	// race starts, so only the mutation itself -- not fixture setup -- is
+	// under contention.
+	removePaths := make([]string, removeCount)
+	for i := range removeCount {
+		branch := fmt.Sprintf("concurrent-remove-%d", i)
+		path := dagu.ProjectPath(fmt.Sprintf("wt/remove-%d", i))
+		createLinkedWorktree(t, repo.path, path, branch, repo.baseCommit)
+		removePaths[i] = path
+	}
+
+	type job struct {
+		fixture string
+		params  []string
+	}
+	jobs := make([]job, 0, addCount+removeCount)
+	for i := range addCount {
+		branch := fmt.Sprintf("concurrent-add-%d", i)
+		path := fmt.Sprintf("../wt/add-%d", i)
+		jobs = append(jobs, job{
+			fixture: "runtime_add.yaml",
+			params:  []string{"working_dir=./repo", "branch=" + branch, "path=" + path},
+		})
+	}
+	for i := range removeCount {
+		branch := fmt.Sprintf("concurrent-remove-%d", i)
+		jobs = append(jobs, job{
+			fixture: "runtime_remove_branch.yaml",
+			params:  []string{"working_dir=./repo", "branch=" + branch},
+		})
+	}
+
+	// A closed start gate lets every goroutine race to invoke dagu at
+	// (as close to) the same instant as possible, maximizing overlap between
+	// the concurrent operations' inspect-and-mutate sequences.
+	ready := make(chan struct{})
+	results := make([]*harness.Result, len(jobs))
+	var wg sync.WaitGroup
+	for i, j := range jobs {
+		wg.Add(1)
+		go func(i int, j job) {
+			defer wg.Done()
+			<-ready
+			results[i] = startWithParams(dagu, j.fixture, j.params...)
+		}(i, j)
+	}
+	close(ready)
+	wg.Wait()
+
+	for i, result := range results {
+		require.Equalf(t, 0, result.ExitCode(), "job %d (%s %v) failed:\nstdout:\n%s\nstderr:\n%s",
+			i, jobs[i].fixture, jobs[i].params, result.Stdout(), result.Stderr())
+	}
+
+	for i := range addCount {
+		branch := fmt.Sprintf("concurrent-add-%d", i)
+		path := dagu.ProjectPath(fmt.Sprintf("wt/add-%d", i))
+		require.True(t, refExists(t, repo.path, "refs/heads/"+branch), "branch %s was not created", branch)
+		requireLinkedWorktree(t, repo.path, path, branch, repo.baseCommit)
+	}
+
+	for i := range removeCount {
+		branch := fmt.Sprintf("concurrent-remove-%d", i)
+		require.NoDirExists(t, removePaths[i])
+		require.True(t, refExists(t, repo.path, "refs/heads/"+branch), "branch %s was unexpectedly deleted", branch)
+		requireNoLinkedWorktree(t, repo.path, removePaths[i], branch)
+	}
+
+	// The repository's own worktree registry must be exactly the primary
+	// tree plus the surviving "add" worktrees: no duplicate, missing, or
+	// stray entry left by a lost update under concurrent mutation.
+	entries := listWorktrees(t, repo.path)
+	require.Len(t, entries, 1+addCount)
+
+	// No leftover Git administrative lock file from an interrupted or
+	// unsynchronized concurrent mutation.
+	lockMatches, err := filepath.Glob(filepath.Join(repo.path, ".git", "worktrees", "*", "*.lock"))
+	require.NoError(t, err)
+	require.Empty(t, lockMatches, "stale worktree admin lock files: %v", lockMatches)
+}


### PR DESCRIPTION
## Summary
  conformance/spec030_git_worktree_action was the most thoroughly tested spec audited, but had two real gaps: no proof that add/remove operations against the same common Git directory execute serially across concurrent DAG runs, and delete_branch was only tested refusing a branch checked out in the primary working tree, not one checked out in another linked worktree.

## Changes

-   conformance/spec030_git_worktree_action was the most thoroughly tested
  spec audited, but had two real gaps: no proof that add/remove
  operations against the same common Git directory execute serially
  across concurrent DAG runs, and delete_branch was only tested refusing
  a branch checked out in the primary working tree, not one checked out
  in another linked worktree.
-   conformance/spec030_git_worktree_action was the most thoroughly tested
  spec audited, but had two real gaps: no proof that add/remove
  operations against the same common Git directory execute serially
  across concurrent DAG runs, and delete_branch was only tested refusing
  a branch checked out in the primary working tree, not one checked out
  in another linked worktree.
## Related Issues

Closes #issue_number (if applicable)

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming branch deletion is refused when the branch is checked out in another linked worktree, preserving all existing worktree and branch state.
  - Added concurrency coverage for simultaneous worktree creation and removal, verifying successful execution, accurate registrations, and cleanup of temporary lock files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->