### PR TITLE
Fix Git sync authorization

### DIFF
--- a/internal/service/chatbridge/monitor_external_test.go
+++ b/internal/service/chatbridge/monitor_external_test.go
@@ -171,9 +171,10 @@ func TestNotificationMonitorWithoutDestinationsAdvancesCursorWithoutReadingEvent
 	cfg.UrgentWindow = 5 * time.Millisecond
 	cfg.SuccessWindow = 5 * time.Millisecond
 
-	monitor := newFileNotificationMonitor(
+	monitor := chatbridge.NewNotificationMonitor(
 		service,
-		filepath.Join(t.TempDir(), "state.json"),
+		nil,
+		nil,
 		transport,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		cfg,

--- a/internal/service/chatbridge/monitor_test.go
+++ b/internal/service/chatbridge/monitor_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	filemonitor "github.com/dagucloud/dagu/v2/internal/persis/file/monitor"
 	"github.com/dagucloud/dagu/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -357,9 +358,10 @@ func TestNotificationMonitor_BootstrapDeliversStartupEvent(t *testing.T) {
 	cfg.PollInterval = 10 * time.Millisecond
 	cfg.SeenEvictInterval = time.Hour
 	cfg.UrgentWindow = 10 * time.Millisecond
-	monitor := newFileBackedMonitor(
+	monitor := NewNotificationMonitor(
 		service,
-		filepath.Join(t.TempDir(), "state.json"),
+		filemonitor.NewStateStore(filepath.Join(t.TempDir(), "state.json")),
+		nil,
 		transport,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		cfg,

--- a/internal/service/frontend/api/v1/api.go
+++ b/internal/service/frontend/api/v1/api.go
@@ -462,6 +462,7 @@ func (a *API) ConfigureRoutes(ctx context.Context, r chi.Router, writeTimeout ti
 		r.Use(frontendauth.LoginRateLimitMiddleware(loginPath))
 		r.Use(frontendauth.Middleware(authOptions))
 		r.Use(a.restAuditSubjectMiddleware())
+		r.Use(a.syncProxyAuthorization(mountedAPIPath))
 		r.Use(humanTaskInputMiddleware(mountedAPIPath))
 		if a.config.Server.StrictValidation {
 			r.Use(a.createValidatorMiddleware(swagger))

--- a/internal/service/frontend/api/v1/remote_test.go
+++ b/internal/service/frontend/api/v1/remote_test.go
@@ -4,17 +4,141 @@
 package api
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/remotenode"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type remoteSyncAuthService struct {
+	AuthService
+	user *auth.User
+}
+
+func (s remoteSyncAuthService) GetUserFromToken(context.Context, string) (*auth.User, error) {
+	return s.user, nil
+}
+
+func (s remoteSyncAuthService) HasAPIKeyStore() bool {
+	return false
+}
+
+func TestRemoteSyncAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		user       *auth.User
+		wantStatus int
+		wantCall   bool
+	}{
+		{
+			name:   "scoped user cannot read",
+			method: http.MethodGet,
+			path:   "/api/v1/sync/status",
+			user: &auth.User{
+				Role: auth.RoleViewer,
+				WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{
+					{Workspace: "ops", Role: auth.RoleDeveloper},
+				}},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "operator cannot write",
+			method:     http.MethodPost,
+			path:       "/api/v1/sync/pull",
+			user:       &auth.User{Role: auth.RoleOperator, WorkspaceAccess: auth.AllWorkspaceAccess()},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "developer cannot test connection",
+			method:     http.MethodPost,
+			path:       "/api/v1/sync/test-connection",
+			user:       &auth.User{Role: auth.RoleDeveloper, WorkspaceAccess: auth.AllWorkspaceAccess()},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "viewer can read",
+			method:     http.MethodGet,
+			path:       "/api/v1/sync/status",
+			user:       &auth.User{Role: auth.RoleViewer, WorkspaceAccess: auth.AllWorkspaceAccess()},
+			wantStatus: http.StatusOK,
+			wantCall:   true,
+		},
+		{
+			name:       "developer can write",
+			method:     http.MethodPost,
+			path:       "/api/v1/sync/pull",
+			user:       &auth.User{Role: auth.RoleDeveloper, WorkspaceAccess: auth.AllWorkspaceAccess()},
+			wantStatus: http.StatusOK,
+			wantCall:   true,
+		},
+		{
+			name:       "admin can test connection",
+			method:     http.MethodPost,
+			path:       "/api/v1/sync/test-connection",
+			user:       &auth.User{Role: auth.RoleAdmin, WorkspaceAccess: auth.AllWorkspaceAccess()},
+			wantStatus: http.StatusOK,
+			wantCall:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var remoteCalled atomic.Bool
+			remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				remoteCalled.Store(true)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true}`))
+			}))
+			t.Cleanup(remoteServer.Close)
+
+			resolver := remotenode.NewResolver([]config.RemoteNode{{
+				Name:       "edge",
+				APIBaseURL: remoteServer.URL + "/api/v1",
+			}}, nil)
+			cfg := &config.Config{
+				Server: config.Server{
+					APIBasePath:      "/api/v1",
+					StrictValidation: true,
+					Auth: config.Auth{
+						Mode: config.AuthModeBuiltin,
+					},
+					Permissions: map[config.Permission]bool{
+						config.PermissionWriteDAGs: true,
+					},
+				},
+			}
+			a := &API{
+				config:             cfg,
+				authService:        remoteSyncAuthService{user: test.user},
+				remoteNodeResolver: resolver,
+			}
+			router := chi.NewRouter()
+			require.NoError(t, a.ConfigureRoutes(t.Context(), router, time.Second))
+
+			request := httptest.NewRequest(test.method, test.path+"?remoteNode=edge", nil)
+			request.Header.Set("Authorization", "Bearer caller-token")
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, request)
+
+			assert.Equal(t, test.wantStatus, recorder.Code)
+			assert.Equal(t, test.wantCall, remoteCalled.Load())
+		})
+	}
+}
 
 func TestRemoteNodeProxyPreservesHumanTaskCompletionRequest(t *testing.T) {
 	const rawBody = "{\n  \"count\": 9007199254740993\n}\n"

--- a/internal/service/frontend/api/v1/sync.go
+++ b/internal/service/frontend/api/v1/sync.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dagucloud/dagu/v2/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/audit"
+	"github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/gitsync"
 )
 
@@ -51,6 +52,60 @@ func (a *API) requireSyncService() error {
 	return nil
 }
 
+func (a *API) requireSyncRead(ctx context.Context) error {
+	if a.authService == nil {
+		return nil
+	}
+	user, ok := auth.UserFromContext(ctx)
+	if !ok {
+		return errAuthRequired
+	}
+	if !auth.NormalizeWorkspaceAccess(user.WorkspaceAccess).All {
+		return errInsufficientPermissions
+	}
+	return nil
+}
+
+func (a *API) requireSyncWrite(ctx context.Context) error {
+	if err := a.requireDAGWrite(ctx); err != nil {
+		return err
+	}
+	return a.requireSyncRead(ctx)
+}
+
+// syncProxyAuthorization checks local permissions before remote node credentials are applied.
+func (a *API) syncProxyAuthorization(apiBasePath string) func(http.Handler) http.Handler {
+	syncPath := strings.TrimRight(apiBasePath, "/") + "/sync"
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			remoteNode := r.URL.Query().Get("remoteNode")
+			if remoteNode == "" || remoteNode == "local" ||
+				(r.URL.Path != syncPath && !strings.HasPrefix(r.URL.Path, syncPath+"/")) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			var err error
+			switch {
+			case r.Method == http.MethodGet:
+				err = a.requireSyncRead(r.Context())
+			case r.Method == http.MethodPut && r.URL.Path == syncPath+"/config":
+				err = a.requireAdmin(r.Context())
+			case r.Method == http.MethodPost && r.URL.Path == syncPath+"/test-connection":
+				err = a.requireAdmin(r.Context())
+			default:
+				err = a.requireSyncWrite(r.Context())
+			}
+			if err != nil {
+				WriteErrorResponse(w, err)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // internalError creates an internal server error from an error.
 func internalError(err error) *Error {
 	return &Error{
@@ -62,6 +117,9 @@ func internalError(err error) *Error {
 
 // GetSyncStatus returns the overall Git sync status.
 func (a *API) GetSyncStatus(ctx context.Context, _ api.GetSyncStatusRequestObject) (api.GetSyncStatusResponseObject, error) {
+	if err := a.requireSyncRead(ctx); err != nil {
+		return nil, err
+	}
 	if a.syncService == nil {
 		return disabledSyncStatusResponse(), nil
 	}
@@ -103,10 +161,10 @@ func disabledSyncStatusResponse() api.GetSyncStatus200JSONResponse {
 
 // SyncPull pulls changes from the remote repository.
 func (a *API) SyncPull(ctx context.Context, _ api.SyncPullRequestObject) (api.SyncPullResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -127,10 +185,10 @@ func (a *API) SyncPull(ctx context.Context, _ api.SyncPullRequestObject) (api.Sy
 
 // SyncPublishAll publishes selected sync items.
 func (a *API) SyncPublishAll(ctx context.Context, req api.SyncPublishAllRequestObject) (api.SyncPublishAllResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 	if req.Body == nil {
@@ -200,6 +258,9 @@ func collectPublishableItemIDs(status *gitsync.OverallStatus) []string {
 
 // SyncTestConnection tests the connection to the remote repository.
 func (a *API) SyncTestConnection(ctx context.Context, _ api.SyncTestConnectionRequestObject) (api.SyncTestConnectionResponseObject, error) {
+	if err := a.requireAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if a.syncService == nil {
 		return api.SyncTestConnection200JSONResponse{
 			Success: false,
@@ -229,6 +290,9 @@ func (a *API) SyncTestConnection(ctx context.Context, _ api.SyncTestConnectionRe
 
 // GetSyncConfig returns the Git sync configuration.
 func (a *API) GetSyncConfig(ctx context.Context, _ api.GetSyncConfigRequestObject) (api.GetSyncConfigResponseObject, error) {
+	if err := a.requireSyncRead(ctx); err != nil {
+		return nil, err
+	}
 	if a.syncService == nil {
 		return api.GetSyncConfig200JSONResponse{Enabled: false}, nil
 	}
@@ -243,6 +307,9 @@ func (a *API) GetSyncConfig(ctx context.Context, _ api.GetSyncConfigRequestObjec
 
 // GetSyncItemDiff returns the diff between local and remote versions of a sync item.
 func (a *API) GetSyncItemDiff(ctx context.Context, req api.GetSyncItemDiffRequestObject) (api.GetSyncItemDiffResponseObject, error) {
+	if err := a.requireSyncRead(ctx); err != nil {
+		return nil, err
+	}
 	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
@@ -284,10 +351,10 @@ func (a *API) GetSyncItemDiff(ctx context.Context, req api.GetSyncItemDiffReques
 
 // UpdateSyncConfig updates the Git sync configuration.
 func (a *API) UpdateSyncConfig(ctx context.Context, req api.UpdateSyncConfigRequestObject) (api.UpdateSyncConfigResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireAdmin(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -322,10 +389,10 @@ func (a *API) UpdateSyncConfig(ctx context.Context, req api.UpdateSyncConfigRequ
 
 // PublishSyncItem publishes a single sync item.
 func (a *API) PublishSyncItem(ctx context.Context, req api.PublishSyncItemRequestObject) (api.PublishSyncItemResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -347,10 +414,10 @@ func (a *API) PublishSyncItem(ctx context.Context, req api.PublishSyncItemReques
 
 // DiscardSyncItemChanges discards local changes for a DAG.
 func (a *API) DiscardSyncItemChanges(ctx context.Context, req api.DiscardSyncItemChangesRequestObject) (api.DiscardSyncItemChangesResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -373,10 +440,10 @@ func (a *API) DiscardSyncItemChanges(ctx context.Context, req api.DiscardSyncIte
 
 // ForgetSyncItem removes a DAG's sync state entry.
 func (a *API) ForgetSyncItem(ctx context.Context, req api.ForgetSyncItemRequestObject) (api.ForgetSyncItemResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -409,10 +476,10 @@ func (a *API) ForgetSyncItem(ctx context.Context, req api.ForgetSyncItemRequestO
 
 // SyncCleanup removes all missing entries from sync state.
 func (a *API) SyncCleanup(ctx context.Context, _ api.SyncCleanupRequestObject) (api.SyncCleanupResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -434,10 +501,10 @@ func (a *API) SyncCleanup(ctx context.Context, _ api.SyncCleanupRequestObject) (
 
 // DeleteSyncItem deletes a sync item from remote, local, and state.
 func (a *API) DeleteSyncItem(ctx context.Context, req api.DeleteSyncItemRequestObject) (api.DeleteSyncItemResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -487,10 +554,10 @@ func (a *API) DeleteSyncItem(ctx context.Context, req api.DeleteSyncItemRequestO
 
 // SyncDeleteMissing deletes all missing sync items from remote, local, and state.
 func (a *API) SyncDeleteMissing(ctx context.Context, req api.SyncDeleteMissingRequestObject) (api.SyncDeleteMissingResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -526,10 +593,10 @@ func (a *API) SyncDeleteMissing(ctx context.Context, req api.SyncDeleteMissingRe
 
 // SyncDeleteBatch deletes multiple sync items in a single commit.
 func (a *API) SyncDeleteBatch(ctx context.Context, req api.SyncDeleteBatchRequestObject) (api.SyncDeleteBatchResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 
@@ -597,10 +664,10 @@ func (a *API) SyncDeleteBatch(ctx context.Context, req api.SyncDeleteBatchReques
 
 // MoveSyncItem renames a tracked sync item.
 func (a *API) MoveSyncItem(ctx context.Context, req api.MoveSyncItemRequestObject) (api.MoveSyncItemResponseObject, error) {
-	if err := a.requireSyncService(); err != nil {
+	if err := a.requireSyncWrite(ctx); err != nil {
 		return nil, err
 	}
-	if err := a.requireDAGWrite(ctx); err != nil {
+	if err := a.requireSyncService(); err != nil {
 		return nil, err
 	}
 	if req.Body == nil {

--- a/internal/service/frontend/api/v1/sync_test.go
+++ b/internal/service/frontend/api/v1/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	apigen "github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/gitsync"
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,8 @@ func (m *mockSyncService) TestConnection(_ context.Context) (*gitsync.Connection
 	return nil, nil
 }
 
+type syncAuthService struct{ AuthService }
+
 func newSyncAPIForTest(syncSvc SyncService) *API {
 	return &API{
 		config: &config.Config{
@@ -121,6 +124,156 @@ func newSyncAPIForTest(syncSvc SyncService) *API {
 			},
 		},
 		syncService: syncSvc,
+	}
+}
+
+func TestSyncAuthorizationPolicy(t *testing.T) {
+	t.Parallel()
+
+	a := newSyncAPIForTest(&mockSyncService{})
+	a.authService = syncAuthService{}
+	tests := []struct {
+		name      string
+		user      *auth.User
+		read      bool
+		write     bool
+		admin     bool
+		unauthErr error
+	}{
+		{name: "admin", user: &auth.User{Role: auth.RoleAdmin, WorkspaceAccess: auth.AllWorkspaceAccess()}, read: true, write: true, admin: true},
+		{name: "manager", user: &auth.User{Role: auth.RoleManager, WorkspaceAccess: auth.AllWorkspaceAccess()}, read: true, write: true},
+		{name: "developer", user: &auth.User{Role: auth.RoleDeveloper, WorkspaceAccess: auth.AllWorkspaceAccess()}, read: true, write: true},
+		{name: "operator", user: &auth.User{Role: auth.RoleOperator, WorkspaceAccess: auth.AllWorkspaceAccess()}, read: true},
+		{name: "viewer", user: &auth.User{Role: auth.RoleViewer, WorkspaceAccess: auth.AllWorkspaceAccess()}, read: true},
+		{
+			name: "scoped developer",
+			user: &auth.User{
+				Role: auth.RoleViewer,
+				WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{
+					{Workspace: "ops", Role: auth.RoleDeveloper},
+				}},
+			},
+		},
+		{name: "unauthenticated", unauthErr: errAuthRequired},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			if test.user != nil {
+				ctx = auth.WithUser(ctx, test.user)
+			}
+
+			assertSyncPermission(t, a.requireSyncRead(ctx), test.read, test.unauthErr)
+			assertSyncPermission(t, a.requireSyncWrite(ctx), test.write, test.unauthErr)
+			assertSyncPermission(t, a.requireAdmin(ctx), test.admin, test.unauthErr)
+		})
+	}
+}
+
+func assertSyncPermission(t *testing.T, err error, allowed bool, unauthErr error) {
+	t.Helper()
+	if allowed {
+		require.NoError(t, err)
+		return
+	}
+	if unauthErr != nil {
+		require.ErrorIs(t, err, unauthErr)
+		return
+	}
+	require.ErrorIs(t, err, errInsufficientPermissions)
+}
+
+func TestSyncHandlerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	a := newSyncAPIForTest(&mockSyncService{})
+	a.authService = syncAuthService{}
+	allWorkspaceOperator := auth.WithUser(t.Context(), &auth.User{
+		Role:            auth.RoleOperator,
+		WorkspaceAccess: auth.AllWorkspaceAccess(),
+	})
+	allWorkspaceDeveloper := auth.WithUser(t.Context(), &auth.User{
+		Role:            auth.RoleDeveloper,
+		WorkspaceAccess: auth.AllWorkspaceAccess(),
+	})
+	scopedViewer := auth.WithUser(t.Context(), &auth.User{
+		Role: auth.RoleViewer,
+		WorkspaceAccess: &auth.WorkspaceAccess{Grants: []auth.WorkspaceGrant{
+			{Workspace: "ops", Role: auth.RoleViewer},
+		}},
+	})
+
+	tests := map[string]struct {
+		ctx  context.Context
+		call func(context.Context) error
+	}{
+		"get status": {ctx: scopedViewer, call: func(ctx context.Context) error {
+			_, err := a.GetSyncStatus(ctx, apigen.GetSyncStatusRequestObject{})
+			return err
+		}},
+		"get config": {ctx: scopedViewer, call: func(ctx context.Context) error {
+			_, err := a.GetSyncConfig(ctx, apigen.GetSyncConfigRequestObject{})
+			return err
+		}},
+		"get diff": {ctx: scopedViewer, call: func(ctx context.Context) error {
+			_, err := a.GetSyncItemDiff(ctx, apigen.GetSyncItemDiffRequestObject{ItemId: "task"})
+			return err
+		}},
+		"test connection": {ctx: allWorkspaceDeveloper, call: func(ctx context.Context) error {
+			_, err := a.SyncTestConnection(ctx, apigen.SyncTestConnectionRequestObject{})
+			return err
+		}},
+		"update config": {ctx: allWorkspaceDeveloper, call: func(ctx context.Context) error {
+			_, err := a.UpdateSyncConfig(ctx, apigen.UpdateSyncConfigRequestObject{})
+			return err
+		}},
+		"pull": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.SyncPull(ctx, apigen.SyncPullRequestObject{})
+			return err
+		}},
+		"publish all": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.SyncPublishAll(ctx, apigen.SyncPublishAllRequestObject{})
+			return err
+		}},
+		"publish item": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.PublishSyncItem(ctx, apigen.PublishSyncItemRequestObject{ItemId: "task"})
+			return err
+		}},
+		"discard item": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.DiscardSyncItemChanges(ctx, apigen.DiscardSyncItemChangesRequestObject{ItemId: "task"})
+			return err
+		}},
+		"forget item": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.ForgetSyncItem(ctx, apigen.ForgetSyncItemRequestObject{ItemId: "task"})
+			return err
+		}},
+		"cleanup": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.SyncCleanup(ctx, apigen.SyncCleanupRequestObject{})
+			return err
+		}},
+		"delete item": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.DeleteSyncItem(ctx, apigen.DeleteSyncItemRequestObject{ItemId: "task"})
+			return err
+		}},
+		"delete missing": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.SyncDeleteMissing(ctx, apigen.SyncDeleteMissingRequestObject{})
+			return err
+		}},
+		"delete batch": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.SyncDeleteBatch(ctx, apigen.SyncDeleteBatchRequestObject{})
+			return err
+		}},
+		"move item": {ctx: allWorkspaceOperator, call: func(ctx context.Context) error {
+			_, err := a.MoveSyncItem(ctx, apigen.MoveSyncItemRequestObject{ItemId: "task"})
+			return err
+		}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, test.call(test.ctx), errInsufficientPermissions)
+		})
 	}
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,7 +19,7 @@ import { QueryFeedback } from './components/QueryFeedback';
 import { ErrorModalProvider } from '@/components/ui/error-modal';
 import { ToastProvider } from '@/components/ui/simple-toast';
 import { AppBarContext } from './contexts/AppBarContext';
-import { AuthProvider } from './contexts/AuthContext';
+import { AuthProvider, useCanAccessGitSync } from './contexts/AuthContext';
 import {
   Config,
   ConfigContext,
@@ -167,6 +167,16 @@ function AdminElement({
   return (
     <ProtectedRoute requiredRole={UserRole.admin}>{children}</ProtectedRoute>
   );
+}
+
+function GitSyncElement({
+  children,
+}: {
+  children: React.ReactElement;
+}): React.ReactElement {
+  const canAccess = useCanAccessGitSync();
+  if (!canAccess) return <Navigate to="/" replace />;
+  return children;
 }
 
 function ManagerElement({
@@ -860,9 +870,9 @@ function AppInner({ config: initialConfig }: Props): React.ReactElement {
                                       <Route
                                         path="/git-sync"
                                         element={
-                                          <AdminElement>
+                                          <GitSyncElement>
                                             <GitSyncPage />
-                                          </AdminElement>
+                                          </GitSyncElement>
                                         }
                                       />
                                     </LazyRoutes>

--- a/ui/src/__tests__/menu.test.tsx
+++ b/ui/src/__tests__/menu.test.tsx
@@ -14,6 +14,7 @@ import { defaultWorkspaceSelection } from '@/lib/workspace';
 const useAuthMock = vi.fn();
 const useIsAdminMock = vi.fn();
 const useCanAccessSystemStatusMock = vi.fn();
+const useCanAccessGitSyncMock = vi.fn();
 const useCanViewEventLogsMock = vi.fn();
 const useCanManageWebhooksMock = vi.fn();
 const useCanManageProfilesMock = vi.fn();
@@ -26,6 +27,7 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => useAuthMock(),
   useIsAdmin: () => useIsAdminMock(),
   useCanAccessSystemStatus: () => useCanAccessSystemStatusMock(),
+  useCanAccessGitSync: () => useCanAccessGitSyncMock(),
   useCanViewEventLogs: () => useCanViewEventLogsMock(),
   useCanManageWebhooks: () => useCanManageWebhooksMock(),
   useCanManageProfiles: () => useCanManageProfilesMock(),
@@ -149,6 +151,7 @@ beforeEach(() => {
   });
   useIsAdminMock.mockReturnValue(true);
   useCanAccessSystemStatusMock.mockReturnValue(true);
+  useCanAccessGitSyncMock.mockReturnValue(true);
   useCanViewEventLogsMock.mockReturnValue(true);
   useCanManageWebhooksMock.mockReturnValue(true);
   useCanManageProfilesMock.mockReturnValue(true);
@@ -288,6 +291,37 @@ describe('sidebar menu', () => {
       expect(item).toBeVisible();
       expect(item.querySelector('svg')).toBeNull();
     }
+  });
+
+  it('shows Git Sync to all-workspace viewers', () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        id: 'viewer-1',
+        username: 'viewer',
+        role: UserRole.viewer,
+        workspaceAccess: { all: true, grants: [] },
+      },
+    });
+
+    renderMenu('/git-sync');
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle Workflows section' })
+    );
+
+    expect(screen.getByRole('link', { name: 'Git Sync' })).toBeVisible();
+  });
+
+  it('hides Git Sync from workspace-scoped users', () => {
+    useCanAccessGitSyncMock.mockReturnValue(false);
+
+    renderMenu('/git-sync');
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle Workflows section' })
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Git Sync' })
+    ).not.toBeInTheDocument();
   });
 
   it('expands the executions section', () => {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/authSession';
 import {
   effectiveWorkspaceRole,
+  normalizeAccess,
   roleAtLeast,
   workspaceRoleTarget,
 } from '@/lib/workspaceAccess';
@@ -248,6 +249,24 @@ export function useCanWriteForWorkspace(workspace?: string | null): boolean {
   return roleAtLeast(
     effectiveWorkspaceRole(user, workspace ?? ''),
     UserRole.developer
+  );
+}
+
+export function useCanAccessGitSync(): boolean {
+  const { user } = useAuth();
+  const config = useConfig();
+  if (config.authMode !== 'builtin') return true;
+  return !!user && normalizeAccess(user.workspaceAccess).all;
+}
+
+export function useCanWriteGitSync(): boolean {
+  const { user } = useAuth();
+  const config = useConfig();
+  if (config.authMode !== 'builtin') return config.permissions.writeDags;
+  return (
+    !!user &&
+    normalizeAccess(user.workspaceAccess).all &&
+    roleAtLeast(user.role, UserRole.developer)
   );
 }
 

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -8,6 +8,7 @@ import {
 import { UserMenu } from '@/components/UserMenu';
 import {
   useCanAccessSystemStatus,
+  useCanAccessGitSync,
   useCanViewEventLogs,
   useCanManageWebhooks,
   useCanManageProfiles,
@@ -505,6 +506,7 @@ export const mainListItems = React.forwardRef<
       : roleAtLeast(user?.role ?? null, UserRole.developer);
   const canManageIncidents = canManageNotifications;
   const canAccessSystemStatus = useCanAccessSystemStatus();
+  const canAccessGitSync = useCanAccessGitSync();
   const canManageWebhooks = useCanManageWebhooks();
   const canManageProfiles = useCanManageProfiles();
   const canViewEventLogs = useCanViewEventLogs();
@@ -732,7 +734,7 @@ export const mainListItems = React.forwardRef<
               onClick={onNavItemClick}
               customColor={customColor}
             />
-            {canWrite && config.gitSyncEnabled && (
+            {canAccessGitSync && config.gitSyncEnabled && (
               <NavItem
                 to="/git-sync"
                 text="Git Sync"

--- a/ui/src/pages/git-sync/__tests__/index.test.tsx
+++ b/ui/src/pages/git-sync/__tests__/index.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  isAdmin: false,
   mutateStatus: vi.fn(),
   post: vi.fn(),
   showError: vi.fn(),
@@ -22,7 +23,8 @@ vi.mock('@/hooks/api', () => ({
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
-  useCanWrite: () => true,
+  useCanWriteGitSync: () => true,
+  useIsAdmin: () => mocks.isAdmin,
 }));
 
 vi.mock('@/contexts/UserPreference', () => ({
@@ -93,6 +95,17 @@ beforeEach(() => {
 });
 
 describe('GitSyncPage', () => {
+  it('hides connection testing from non-admin users', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByTitle('Configuration'));
+
+    expect(
+      screen.queryByRole('button', { name: 'Test Connection' })
+    ).not.toBeInTheDocument();
+  });
+
   it('batch publishes comma-containing item IDs unchanged', async () => {
     const user = userEvent.setup();
     renderPage();

--- a/ui/src/pages/git-sync/index.tsx
+++ b/ui/src/pages/git-sync/index.tsx
@@ -25,7 +25,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { AppBarContext } from '@/contexts/AppBarContext';
-import { useCanWrite } from '@/contexts/AuthContext';
+import { useCanWriteGitSync, useIsAdmin } from '@/contexts/AuthContext';
 import { useClient, useQuery } from '@/hooks/api';
 import dayjs from '@/lib/dayjs';
 import { cn } from '@/lib/utils';
@@ -146,7 +146,8 @@ export default function GitSyncPage() {
   const appBarContext = useContext(AppBarContext);
   const { setTitle } = appBarContext;
   const client = useClient();
-  const canWrite = useCanWrite();
+  const canWrite = useCanWriteGitSync();
+  const isAdmin = useIsAdmin();
   const { showToast } = useSimpleToast();
   const { showError } = useErrorModal();
 
@@ -999,14 +1000,16 @@ export default function GitSyncPage() {
                   : 'Never'}
               </span>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full mt-2"
-              onClick={handleTestConnection}
-            >
-              Test Connection
-            </Button>
+            {isAdmin && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full mt-2"
+                onClick={handleTestConnection}
+              >
+                Test Connection
+              </Button>
+            )}
           </div>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary

Guard Git Sync API and UI operations by workspace scope and role.

## Changes

- Require all-workspace access for Git Sync reads
- Require DAG write permission for mutations
- Require admin access for configuration changes
- Authorize remote-node requests before proxying
- Align route, menu, and action visibility with API policy
- Remove unrelated lease work from chatbridge timing tests

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

## Testing

- Targeted Git Sync API race tests
- Targeted chatbridge monitor race tests
- API v1 package race tests
- UI unit tests
- UI typecheck
- `make check`
- GitHub CI: all required checks passed