### PR TITLE
fix: support nested source-less child DAGs

### DIFF
--- a/internal/intg/distr/subdag_test.go
+++ b/internal/intg/distr/subdag_test.go
@@ -445,6 +445,128 @@ steps:
 	require.Equal(t, leafContent, nodeOutputValue(t, requireNodeByID(t, *leafStatus, "read_leaf_dependency"), "CONTENT"))
 }
 
+func TestSubDAG_DispatchedParentRunsInlineNamedChild(t *testing.T) {
+	f := newTestFixture(t, `
+name: nested-inline-root
+worker_selector:
+  layer: root
+steps:
+  - id: call_parent
+    action: dag.run
+    with:
+      dag: nested-inline-parent
+`, withWorkerCount(0), withLogPersistence())
+	defer f.cleanup()
+
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "nested-inline-parent", []byte(`
+name: nested-inline-parent
+worker_selector:
+  layer: parent
+steps:
+  - id: call_child
+    action: dag.run
+    with:
+      dag: nested-inline-child
+`))
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "nested-inline-child", []byte(`
+name: nested-inline-child
+steps:
+  - id: complete
+    run: echo inline child completed
+`))
+
+	f.workers = append(f.workers,
+		f.setupWorkerMode("root-worker", map[string]string{"layer": "root"}, "", true, nil),
+		f.setupWorkerMode("parent-worker", map[string]string{"layer": "parent"}, "", true, nil),
+	)
+
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(30 * time.Second)
+
+	rootStatus := f.waitForStatus(ir.Succeeded, executionStatusTimeout())
+	require.Equal(t, "root-worker", rootStatus.WorkerID)
+	rootCall := requireNodeByID(t, rootStatus, "call_parent")
+	require.Len(t, rootCall.SubRuns, 1)
+
+	rootRef := ir.NewDAGRunRef(rootStatus.Name, rootStatus.DAGRunID)
+	parentStatus := readDistributedSubAttemptStatus(t, f, rootRef, rootCall.SubRuns[0].DAGRunID)
+	require.Equal(t, ir.Succeeded, parentStatus.Status)
+	require.Equal(t, "parent-worker", parentStatus.WorkerID)
+	parentCall := requireNodeByID(t, *parentStatus, "call_child")
+	require.Len(t, parentCall.SubRuns, 1)
+
+	childStatus := readDistributedSubAttemptStatus(t, f, rootRef, parentCall.SubRuns[0].DAGRunID)
+	require.Equal(t, ir.Succeeded, childStatus.Status)
+	require.Equal(t, "parent-worker", childStatus.WorkerID)
+	require.Equal(t, ir.NewDAGRunRef(parentStatus.Name, parentStatus.DAGRunID), childStatus.Parent)
+}
+
+func TestSubDAG_DispatchedParentDefersSourceLessNamedChildDependencies(t *testing.T) {
+	const (
+		childDependency = "nested-inline-child.txt"
+		childContent    = "dependency packaged by the coordinator"
+	)
+
+	f := newTestFixture(t, `
+name: nested-dependency-root
+worker_selector:
+  layer: root
+steps:
+  - id: call_parent
+    action: dag.run
+    with:
+      dag: nested-dependency-parent
+`, withWorkerCount(0), withLogPersistence())
+	defer f.cleanup()
+
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "nested-dependency-parent", []byte(`
+name: nested-dependency-parent
+worker_selector:
+  layer: parent
+steps:
+  - id: call_child
+    action: dag.run
+    with:
+      dag: nested-dependency-child
+`))
+	f.coord.CreateDAGFile(t, f.coord.Config.Paths.DAGsDir, "nested-dependency-child", []byte(`
+name: nested-dependency-child
+steps:
+  - id: read_dependency
+    dependencies:
+      - `+childDependency+`
+    action: file.read
+    with:
+      path: `+childDependency+`
+    output: CONTENT
+`))
+	require.NoError(t, os.WriteFile(filepath.Join(f.coord.Config.Paths.DAGsDir, childDependency), []byte(childContent), 0o600))
+
+	f.workers = append(f.workers,
+		f.setupWorkerMode("root-worker", map[string]string{"layer": "root"}, "", true, nil),
+		f.setupWorkerMode("parent-worker", map[string]string{"layer": "parent"}, "", true, nil),
+	)
+
+	require.NoError(t, f.enqueue())
+	f.waitForQueued()
+	f.startScheduler(30 * time.Second)
+
+	rootStatus := f.waitForStatus(ir.Succeeded, executionStatusTimeout())
+	rootCall := requireNodeByID(t, rootStatus, "call_parent")
+	require.Len(t, rootCall.SubRuns, 1)
+
+	rootRef := ir.NewDAGRunRef(rootStatus.Name, rootStatus.DAGRunID)
+	parentStatus := readDistributedSubAttemptStatus(t, f, rootRef, rootCall.SubRuns[0].DAGRunID)
+	parentCall := requireNodeByID(t, *parentStatus, "call_child")
+	require.Len(t, parentCall.SubRuns, 1)
+
+	childStatus := readDistributedSubAttemptStatus(t, f, rootRef, parentCall.SubRuns[0].DAGRunID)
+	require.Equal(t, ir.Succeeded, childStatus.Status)
+	require.Equal(t, ir.NewDAGRunRef(parentStatus.Name, parentStatus.DAGRunID), childStatus.Parent)
+	require.Equal(t, childContent, nodeOutputValue(t, requireNodeByID(t, *childStatus, "read_dependency"), "CONTENT"))
+}
+
 func TestSubDAG_InSameFile(t *testing.T) {
 	t.Run("parentAndChildInSameYAMLFile", func(t *testing.T) {
 		f := newTestFixture(t, `

--- a/internal/service/coordinator/distributed_attempts_test.go
+++ b/internal/service/coordinator/distributed_attempts_test.go
@@ -224,6 +224,31 @@ func TestAttemptOwnershipSyncFromStatus(t *testing.T) {
 	assert.ErrorIs(t, err, dispatch.ErrActiveRunNotFound)
 }
 
+func TestAttemptOwnershipSyncFromStatusPersistsUnsetRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	leaseStore := newTestDAGRunLeaseStore(filepath.Join(t.TempDir(), "distributed"))
+	ownership := newAttemptOwnership(attemptOwnershipConfig{
+		LeaseStore: leaseStore,
+		Now:        func() time.Time { return time.Unix(100, 0).UTC() },
+	})
+	root := ir.NewDAGRunRef("root", "root-run")
+
+	ownership.syncFromStatus(ctx, "worker-1", &ir.DAGRunStatus{
+		Name:       root.Name,
+		DAGRunID:   root.ID,
+		AttemptID:  "root-attempt",
+		AttemptKey: "root-claim",
+		Status:     ir.Running,
+		WorkerID:   "worker-1",
+	}, "")
+
+	lease, err := leaseStore.Get(ctx, "root-claim")
+	require.NoError(t, err)
+	assert.True(t, lease.Root.Zero())
+}
+
 func TestInlineRunSharesClaimLease(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/coordinator/remote_attempt.go
+++ b/internal/service/coordinator/remote_attempt.go
@@ -250,9 +250,7 @@ func (h *Handler) validateAttemptLease(lease *dispatch.DAGRunLease, identity att
 		return status.Error(codes.FailedPrecondition, remoteAttemptRejectedSuperseded)
 	}
 	if identity.claimKey != identity.attemptKey {
-		if lease.DAGRun != identity.root {
-			return status.Error(codes.FailedPrecondition, remoteAttemptRejectedSuperseded)
-		}
+		// Inline descendants inherit their dispatching ancestor's worker claim.
 		return nil
 	}
 	if lease.DAGRun != identity.dagRun ||

--- a/internal/service/coordinator/remote_attempt.go
+++ b/internal/service/coordinator/remote_attempt.go
@@ -245,8 +245,14 @@ func (h *Handler) attemptLease(ctx context.Context, identity attemptIdentity) (*
 }
 
 func (h *Handler) validateAttemptLease(lease *dispatch.DAGRunLease, identity attemptIdentity) error {
-	if !lease.MatchesClaim(identity.claimKey, identity.workerID) ||
-		(!lease.Root.Zero() && lease.Root != identity.root) {
+	if !lease.MatchesClaim(identity.claimKey, identity.workerID) {
+		return status.Error(codes.FailedPrecondition, remoteAttemptRejectedSuperseded)
+	}
+	leaseRoot := lease.Root
+	if leaseRoot.Zero() {
+		leaseRoot = lease.DAGRun
+	}
+	if leaseRoot != identity.root {
 		return status.Error(codes.FailedPrecondition, remoteAttemptRejectedSuperseded)
 	}
 	if identity.claimKey != identity.attemptKey {

--- a/internal/service/coordinator/remote_attempt_test.go
+++ b/internal/service/coordinator/remote_attempt_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/dispatch"
+	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestValidateAttemptLeaseAcceptsNestedInlineChild(t *testing.T) {
+	t.Parallel()
+
+	root := ir.NewDAGRunRef("root", "root-run")
+	parent := ir.NewDAGRunRef("parent", "parent-run")
+	child := ir.NewDAGRunRef("child", "child-run")
+	lease := &dispatch.DAGRunLease{
+		AttemptKey: "parent-claim",
+		DAGRun:     parent,
+		Root:       root,
+		AttemptID:  "parent-attempt",
+		WorkerID:   "worker-2",
+	}
+
+	err := (&Handler{}).validateAttemptLease(lease, attemptIdentity{
+		attemptKey: "child-attempt-key",
+		claimKey:   lease.AttemptKey,
+		workerID:   lease.WorkerID,
+		dagRun:     child,
+		root:       root,
+		attemptID:  "child-attempt",
+	})
+
+	require.NoError(t, err)
+}
+
+func TestValidateAttemptLeaseRejectsNestedInlineChildFromDifferentRoot(t *testing.T) {
+	t.Parallel()
+
+	root := ir.NewDAGRunRef("root", "root-run")
+	lease := &dispatch.DAGRunLease{
+		AttemptKey: "parent-claim",
+		DAGRun:     ir.NewDAGRunRef("parent", "parent-run"),
+		Root:       root,
+		AttemptID:  "parent-attempt",
+		WorkerID:   "worker-2",
+	}
+
+	err := (&Handler{}).validateAttemptLease(lease, attemptIdentity{
+		attemptKey: "child-attempt-key",
+		claimKey:   lease.AttemptKey,
+		workerID:   lease.WorkerID,
+		dagRun:     ir.NewDAGRunRef("child", "child-run"),
+		root:       ir.NewDAGRunRef("other-root", "other-root-run"),
+		attemptID:  "child-attempt",
+	})
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, remoteAttemptRejectedSuperseded, status.Convert(err).Message())
+}
+
+func TestValidateAttemptLeaseRejectsNestedInlineChildFromDifferentWorker(t *testing.T) {
+	t.Parallel()
+
+	root := ir.NewDAGRunRef("root", "root-run")
+	lease := &dispatch.DAGRunLease{
+		AttemptKey: "parent-claim",
+		DAGRun:     ir.NewDAGRunRef("parent", "parent-run"),
+		Root:       root,
+		AttemptID:  "parent-attempt",
+		WorkerID:   "worker-2",
+	}
+
+	err := (&Handler{}).validateAttemptLease(lease, attemptIdentity{
+		attemptKey: "child-attempt-key",
+		claimKey:   lease.AttemptKey,
+		workerID:   "worker-3",
+		dagRun:     ir.NewDAGRunRef("child", "child-run"),
+		root:       root,
+		attemptID:  "child-attempt",
+	})
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, remoteAttemptRejectedSuperseded, status.Convert(err).Message())
+}

--- a/internal/service/coordinator/remote_attempt_test.go
+++ b/internal/service/coordinator/remote_attempt_test.go
@@ -39,6 +39,29 @@ func TestValidateAttemptLeaseAcceptsNestedInlineChild(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateAttemptLeaseAcceptsNestedInlineChildWithUnsetLeaseRoot(t *testing.T) {
+	t.Parallel()
+
+	root := ir.NewDAGRunRef("root", "root-run")
+	lease := &dispatch.DAGRunLease{
+		AttemptKey: "root-claim",
+		DAGRun:     root,
+		AttemptID:  "root-attempt",
+		WorkerID:   "worker-2",
+	}
+
+	err := (&Handler{}).validateAttemptLease(lease, attemptIdentity{
+		attemptKey: "child-attempt-key",
+		claimKey:   lease.AttemptKey,
+		workerID:   lease.WorkerID,
+		dagRun:     ir.NewDAGRunRef("child", "child-run"),
+		root:       root,
+		attemptID:  "child-attempt",
+	})
+
+	require.NoError(t, err)
+}
+
 func TestValidateAttemptLeaseRejectsNestedInlineChildFromDifferentRoot(t *testing.T) {
 	t.Parallel()
 
@@ -48,6 +71,30 @@ func TestValidateAttemptLeaseRejectsNestedInlineChildFromDifferentRoot(t *testin
 		DAGRun:     ir.NewDAGRunRef("parent", "parent-run"),
 		Root:       root,
 		AttemptID:  "parent-attempt",
+		WorkerID:   "worker-2",
+	}
+
+	err := (&Handler{}).validateAttemptLease(lease, attemptIdentity{
+		attemptKey: "child-attempt-key",
+		claimKey:   lease.AttemptKey,
+		workerID:   lease.WorkerID,
+		dagRun:     ir.NewDAGRunRef("child", "child-run"),
+		root:       ir.NewDAGRunRef("other-root", "other-root-run"),
+		attemptID:  "child-attempt",
+	})
+
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, remoteAttemptRejectedSuperseded, status.Convert(err).Message())
+}
+
+func TestValidateAttemptLeaseRejectsNestedInlineChildFromDifferentRootWithUnsetLeaseRoot(t *testing.T) {
+	t.Parallel()
+
+	root := ir.NewDAGRunRef("root", "root-run")
+	lease := &dispatch.DAGRunLease{
+		AttemptKey: "root-claim",
+		DAGRun:     root,
+		AttemptID:  "root-attempt",
 		WorkerID:   "worker-2",
 	}
 

--- a/internal/service/coordinator/subflow/runner.go
+++ b/internal/service/coordinator/subflow/runner.go
@@ -130,6 +130,10 @@ func (r *Runner) ShouldRun(_ context.Context, req executor.SubWorkflowRequest) b
 	if len(req.WorkerSelector) > 0 {
 		return true
 	}
+	// A source-less child with dependencies must be packaged by the coordinator.
+	if req.Workspace == nil && strings.TrimSpace(req.DAG.SourceFile) == "" && executor.HasDAGFileDependencies(req.DAG) {
+		return true
+	}
 	return r.defaultMode == config.ExecutionModeDistributed
 }
 

--- a/internal/service/coordinator/subflow/runner_test.go
+++ b/internal/service/coordinator/subflow/runner_test.go
@@ -109,6 +109,37 @@ func TestRunnerShouldRun(t *testing.T) {
 			req:    validReq,
 			want:   false,
 		},
+		{
+			name:   "source-less dependencies use distributed path in local mode",
+			runner: subflow.New(dispatcher, config.ExecutionModeLocal),
+			req: runtimeexec.SubWorkflowRequest{
+				DAG: &ir.DAG{
+					Name: "child",
+					Steps: []ir.Step{{
+						Dependencies: []string{"input.txt"},
+					}},
+				},
+				RootDAGRun: ir.NewDAGRunRef("parent", "root-1"),
+				RunID:      "child-1",
+			},
+			want: true,
+		},
+		{
+			name:   "workspace keeps source-less dependencies local",
+			runner: subflow.New(dispatcher, config.ExecutionModeLocal),
+			req: runtimeexec.SubWorkflowRequest{
+				DAG: &ir.DAG{
+					Name: "child",
+					Steps: []ir.Step{{
+						Dependencies: []string{"input.txt"},
+					}},
+				},
+				RootDAGRun: ir.NewDAGRunRef("parent", "root-1"),
+				RunID:      "child-1",
+				Workspace:  &runtimeexec.SubWorkflowWorkspace{},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fix nested named child DAG execution when a worker-dispatched parent runs an inline child, including children whose file dependencies require a coordinator-owned workspace bundle.

## Changes

- Allow inline descendants to inherit their dispatching ancestor's valid worker claim.
- Keep inherited claims fenced to the same root DAG run and worker.
- Route source-less named children with file dependencies through the coordinator in local default mode.
- Keep children with an existing workspace on the local execution path.
- Add lease-validation unit tests and distributed nested child integration coverage.

## Related Issues

Closes #2671

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested inline child DAG execution when a worker-dispatched parent runs a source-less child by letting inline descendants inherit their dispatching ancestor's worker claim and routing source-less children with file dependencies through the coordinator in local default mode. Closes #2671.

- Inherited claims stay fenced to the same root DAG run and worker, using the lease's own run as the root when none is recorded.
- Children with an existing workspace keep the local execution path.
- Adds lease-validation unit tests and distributed nested child integration coverage.

<sup>Written for commit da9ed09c597766cd737fadc600900b8cea21ffa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved execution of nested distributed workflows, including source-less child workflows with packaged dependencies.
  - Child workflows without a worker selector now run correctly on their dispatched parent worker.
  - Added validation to prevent nested attempts from running under mismatched roots or workers.

- **Tests**
  - Added coverage for nested workflow execution, dependency handling, and lease validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->