### PR TITLE
perf(persis): index the terminal runs of a day instead of requiring the whole day

### DIFF
--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -111,7 +111,15 @@ func TryLoadForDay(ctx context.Context, dayDir string, dagRunDirs []os.DirEntry)
 			}, nil
 		}
 
-		entries, fromIndex, rebuildErr := RebuildForDay(dayDir, dagRunDirs)
+		// The index does not cover the day exactly, which on an actively
+		// scheduled day is the normal case. Reuse whatever it still describes
+		// correctly and rescan only the remainder.
+		var cached map[string]Entry
+		if readErr == nil {
+			cached = usableIndexEntries(dayDir, idx, runDirs)
+		}
+
+		entries, fromIndex, rebuildErr := rebuildForDay(dayDir, dagRunDirs, cached)
 		if rebuildErr != nil {
 			return dayLoadResult{}, rebuildErr
 		}
@@ -146,15 +154,30 @@ func TryLoadForDay(ctx context.Context, dayDir string, dagRunDirs []os.DirEntry)
 // RebuildForDay scans a day directory, discovers latest attempts, reads statuses,
 // and writes the index if all runs are terminal.
 func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, error) {
+	return rebuildForDay(dayDir, dagRunDirs, nil)
+}
+
+// rebuildForDay scans a day directory, reusing the cached entries the caller has
+// already validated against disk and reading status only for the runs those do
+// not cover. Passing a nil cache scans everything.
+func rebuildForDay(dayDir string, dagRunDirs []os.DirEntry, cached map[string]Entry) ([]Entry, bool, error) {
 	runDirs := filterDAGRunDirs(dagRunDirs)
 	if len(runDirs) == 0 {
 		return nil, false, nil
 	}
 
 	entries := make([]Entry, 0, len(runDirs))
-	allTerminal := true
+	terminal := make([]Entry, 0, len(runDirs))
 
 	for _, rd := range runDirs {
+		if cachedEntry, ok := cached[rd.Name()]; ok {
+			// Only terminal runs are ever written to the index, and the caller
+			// has confirmed this entry still matches disk.
+			entries = append(entries, cachedEntry)
+			terminal = append(terminal, cachedEntry)
+			continue
+		}
+
 		runDir := filepath.Join(dayDir, rd.Name())
 		runDirInfo, err := os.Stat(runDir)
 		if err != nil {
@@ -180,10 +203,6 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 			continue
 		}
 
-		if status.Status.IsActive() {
-			allTerminal = false
-		}
-
 		// Parse dag run ID from directory name.
 		dagRunID := parseDagRunID(rd.Name())
 
@@ -191,7 +210,7 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 		startedAt := parseTimeToUnix(status.StartedAt)
 		finishedAt := parseTimeToUnix(status.FinishedAt)
 
-		entries = append(entries, Entry{
+		entry := Entry{
 			DagRunDir:            rd.Name(),
 			DagRunID:             dagRunID,
 			LatestAttemptDir:     latestAttemptDir,
@@ -222,12 +241,21 @@ func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, erro
 			latestStatusSize:     statusInfo.Size(),
 			latestStatusModTime:  statusInfo.ModTime().UnixNano(),
 			runDirModTime:        runDirInfo.ModTime().UnixNano(),
-		})
+		}
+
+		entries = append(entries, entry)
+		if !status.Status.IsActive() {
+			terminal = append(terminal, entry)
+		}
 	}
 
-	// Write index only if all runs are terminal and there are enough runs.
-	if allTerminal && len(entries) >= MinRunsForIndex {
-		if err := writeIndex(dayDir, entries); err != nil {
+	// Persist the terminal subset. A day that still has active runs keeps an
+	// index for everything already finished, so the next read only has to scan
+	// the runs that are still moving. Requiring the whole day to be terminal
+	// meant a single active run forfeited caching for every finished run beside
+	// it, which never resolves on a frequently scheduled instance.
+	if len(terminal) >= MinRunsForIndex {
+		if err := writeIndex(dayDir, terminal); err != nil {
 			// Non-fatal: just don't write the index.
 			return entries, false, nil
 		}
@@ -255,6 +283,53 @@ func readIndex(indexPath string) (*indexv1.DAGRunIndex, error) {
 		return nil, fmt.Errorf("version mismatch: got %d, want %d", idx.Version, IndexVersion)
 	}
 	return &idx, nil
+}
+
+// usableIndexEntries returns the index entries that still match disk, keyed by
+// run directory name. Entries whose run directory has gone, or whose run
+// directory or status file has changed since the index was written, are left out
+// so the caller rescans exactly those runs.
+//
+// Each check costs two stats, against a read plus a JSON parse for a rescan.
+func usableIndexEntries(dayDir string, idx *indexv1.DAGRunIndex, runDirs []os.DirEntry) map[string]Entry {
+	if idx == nil || len(idx.Entries) == 0 {
+		return nil
+	}
+
+	fsSet := make(map[string]struct{}, len(runDirs))
+	for _, d := range runDirs {
+		fsSet[d.Name()] = struct{}{}
+	}
+
+	usable := make(map[string]Entry, len(idx.Entries))
+	for _, entry := range protoToEntries(idx.Entries) {
+		if _, ok := fsSet[entry.DagRunDir]; !ok {
+			continue
+		}
+		if !entryMatchesDisk(dayDir, entry) {
+			continue
+		}
+		usable[entry.DagRunDir] = entry
+	}
+	return usable
+}
+
+// entryMatchesDisk reports whether an index entry still describes what is on
+// disk. A retried run gains an attempt, which changes the run directory mtime,
+// so a stale entry is rejected and rescanned.
+func entryMatchesDisk(dayDir string, entry Entry) bool {
+	runDir := filepath.Join(dayDir, entry.DagRunDir)
+	runDirInfo, err := os.Stat(runDir)
+	if err != nil || runDirInfo.ModTime().UnixNano() != entry.runDirModTime {
+		return false
+	}
+
+	statusInfo, err := os.Stat(filepath.Join(runDir, entry.LatestAttemptDir, statusFile))
+	if err != nil {
+		return false
+	}
+	return statusInfo.Size() == entry.latestStatusSize &&
+		statusInfo.ModTime().UnixNano() == entry.latestStatusModTime
 }
 
 func validateIndex(dayDir string, idx *indexv1.DAGRunIndex, runDirs []os.DirEntry) bool {

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex.go
@@ -115,11 +115,13 @@ func TryLoadForDay(ctx context.Context, dayDir string, dagRunDirs []os.DirEntry)
 		// scheduled day is the normal case. Reuse whatever it still describes
 		// correctly and rescan only the remainder.
 		var cached map[string]Entry
+		indexedCount := 0
 		if readErr == nil {
 			cached = usableIndexEntries(dayDir, idx, runDirs)
+			indexedCount = len(idx.Entries)
 		}
 
-		entries, fromIndex, rebuildErr := rebuildForDay(dayDir, dagRunDirs, cached)
+		entries, fromIndex, rebuildErr := rebuildForDay(dayDir, dagRunDirs, cached, indexedCount)
 		if rebuildErr != nil {
 			return dayLoadResult{}, rebuildErr
 		}
@@ -154,13 +156,15 @@ func TryLoadForDay(ctx context.Context, dayDir string, dagRunDirs []os.DirEntry)
 // RebuildForDay scans a day directory, discovers latest attempts, reads statuses,
 // and writes the index if all runs are terminal.
 func RebuildForDay(dayDir string, dagRunDirs []os.DirEntry) ([]Entry, bool, error) {
-	return rebuildForDay(dayDir, dagRunDirs, nil)
+	return rebuildForDay(dayDir, dagRunDirs, nil, 0)
 }
 
 // rebuildForDay scans a day directory, reusing the cached entries the caller has
 // already validated against disk and reading status only for the runs those do
 // not cover. Passing a nil cache scans everything.
-func rebuildForDay(dayDir string, dagRunDirs []os.DirEntry, cached map[string]Entry) ([]Entry, bool, error) {
+// indexedCount is how many entries the on-disk index holds, so an unchanged
+// terminal subset can be detected and the rewrite skipped.
+func rebuildForDay(dayDir string, dagRunDirs []os.DirEntry, cached map[string]Entry, indexedCount int) ([]Entry, bool, error) {
 	runDirs := filterDAGRunDirs(dagRunDirs)
 	if len(runDirs) == 0 {
 		return nil, false, nil
@@ -168,9 +172,11 @@ func rebuildForDay(dayDir string, dagRunDirs []os.DirEntry, cached map[string]En
 
 	entries := make([]Entry, 0, len(runDirs))
 	terminal := make([]Entry, 0, len(runDirs))
+	reused := 0
 
 	for _, rd := range runDirs {
 		if cachedEntry, ok := cached[rd.Name()]; ok {
+			reused++
 			// Only terminal runs are ever written to the index, and the caller
 			// has confirmed this entry still matches disk.
 			entries = append(entries, cachedEntry)
@@ -255,6 +261,14 @@ func rebuildForDay(dayDir string, dagRunDirs []os.DirEntry, cached map[string]En
 	// meant a single active run forfeited caching for every finished run beside
 	// it, which never resolves on a frequently scheduled instance.
 	if len(terminal) >= MinRunsForIndex {
+		// Nothing new became terminal and the on-disk index holds exactly the
+		// entries reused, so it already describes this subset. Rewriting would
+		// make every read a durable write, because a partial index never
+		// satisfies validateIndex and so always reaches this path.
+		if reused == len(terminal) && reused == indexedCount {
+			return entries, true, nil
+		}
+
 		if err := writeIndex(dayDir, terminal); err != nil {
 			// Non-fatal: just don't write the index.
 			return entries, false, nil

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
@@ -4,6 +4,7 @@
 package dagrunindex
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -365,12 +366,17 @@ func TestRebuildForDay_MixedStatuses(t *testing.T) {
 
 	entries, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
 	require.NoError(t, err)
-	assert.Len(t, entries, 12)
-	assert.False(t, fromIndex) // Not all terminal, so no index written.
+	assert.Len(t, entries, 12, "every run in the day is returned")
+	assert.True(t, fromIndex, "the terminal runs are indexed even though two are still active")
 
-	// Verify no index file was created.
-	_, statErr := os.Stat(filepath.Join(dayDir, IndexFileName))
-	assert.True(t, os.IsNotExist(statErr))
+	// The index is written for the finished runs only. Active runs are excluded
+	// so they are rescanned until they reach a terminal state.
+	idx, err := readIndex(filepath.Join(dayDir, IndexFileName))
+	require.NoError(t, err)
+	assert.Len(t, idx.Entries, 10, "only the terminal runs are indexed")
+	for _, e := range idx.Entries {
+		assert.NotContains(t, e.DagRunDir, "active", "active runs must not be indexed")
+	}
 }
 
 func TestParseStatusFile_MultiLine(t *testing.T) {
@@ -555,4 +561,62 @@ func TestRebuildForDay_EmptyAttempts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, entries) // No valid attempts found.
 	assert.False(t, fromIndex)
+}
+
+// TestTryLoadForDay_ReusesIndexedTerminalRunsWhileDayIsActive proves the partial
+// index is actually consulted: a terminal run whose status file has been made
+// unparseable, without changing its size or mtime, is still served from the
+// index. A rescan would drop it, so its presence shows it was not re-read.
+func TestTryLoadForDay_ReusesIndexedTerminalRunsWhileDayIsActive(t *testing.T) {
+	dayDir := t.TempDir()
+	createDayDir(t, dayDir, 10, ir.Succeeded)
+
+	// One active run keeps the day from ever being fully terminal.
+	activeDir := filepath.Join(dayDir, "dag-run_20240115_130000Z_active0")
+	activeAttempt := filepath.Join(activeDir, "attempt_20240115_130000_001Z_abc123")
+	require.NoError(t, os.MkdirAll(activeAttempt, 0750))
+	activeStatus, err := json.Marshal(ir.DAGRunStatus{
+		Name: "test", DAGRunID: "active0", AttemptID: "abc123",
+		Status: ir.Running, StartedAt: "2024-01-15T13:00:00Z",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(activeAttempt, "status.jsonl"), append(activeStatus, '\n'), 0600))
+
+	// First load writes the index for the ten terminal runs.
+	first, fromIndex, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+	require.NoError(t, err)
+	require.True(t, fromIndex)
+	require.Len(t, first, 11)
+
+	// Corrupt one indexed run's status in place, preserving size and mtime so the
+	// entry still validates. Only a re-read would notice.
+	victim := ""
+	for _, e := range first {
+		if e.DagRunDir != "dag-run_20240115_130000Z_active0" {
+			victim = e.DagRunDir
+			break
+		}
+	}
+	require.NotEmpty(t, victim)
+
+	statusPath := filepath.Join(dayDir, victim, "attempt_20240115_120000_001Z_abc123", "status.jsonl")
+	original, err := os.ReadFile(statusPath)
+	require.NoError(t, err)
+	info, err := os.Stat(statusPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(statusPath, bytes.Repeat([]byte("x"), len(original)), 0600))
+	require.NoError(t, os.Chtimes(statusPath, info.ModTime(), info.ModTime()))
+
+	second, _, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+	require.NoError(t, err)
+	assert.Len(t, second, 11, "the corrupted run is served from the index, not re-read")
+
+	found := false
+	for _, e := range second {
+		if e.DagRunDir == victim {
+			found = true
+			assert.Equal(t, ir.Succeeded, e.Status, "cached status survives the unreadable file")
+		}
+	}
+	assert.True(t, found, "indexed run must still be present")
 }

--- a/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
+++ b/internal/persis/file/dagrun/dagrunindex/dagrunindex_test.go
@@ -620,3 +620,84 @@ func TestTryLoadForDay_ReusesIndexedTerminalRunsWhileDayIsActive(t *testing.T) {
 	}
 	assert.True(t, found, "indexed run must still be present")
 }
+
+// TestTryLoadForDay_DoesNotRewriteIndexWhenTerminalSubsetIsUnchanged guards the
+// cost of the partial index. A partial index never satisfies validateIndex, so
+// every read reaches the rebuild path. Rewriting there would turn each read into
+// a durable, fsync'd write proportional to the finished runs in the day.
+func TestTryLoadForDay_DoesNotRewriteIndexWhenTerminalSubsetIsUnchanged(t *testing.T) {
+	dayDir := t.TempDir()
+	createDayDir(t, dayDir, 10, ir.Succeeded)
+
+	// One active run keeps the day from ever being fully terminal.
+	activeAttempt := filepath.Join(dayDir, "dag-run_20240115_130000Z_active0", "attempt_20240115_130000_001Z_abc123")
+	require.NoError(t, os.MkdirAll(activeAttempt, 0750))
+	activeStatus, err := json.Marshal(ir.DAGRunStatus{
+		Name: "test", DAGRunID: "active0", AttemptID: "abc123",
+		Status: ir.Running, StartedAt: "2024-01-15T13:00:00Z",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(activeAttempt, "status.jsonl"), append(activeStatus, '\n'), 0600))
+
+	// First read writes the index for the ten terminal runs.
+	_, _, err = TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+	require.NoError(t, err)
+
+	indexPath := filepath.Join(dayDir, IndexFileName)
+	before, err := os.Stat(indexPath)
+	require.NoError(t, err)
+
+	// Age the index so any rewrite is detectable by mtime.
+	stale := before.ModTime().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(indexPath, stale, stale))
+
+	// Further reads change nothing: the same ten runs are terminal, and the
+	// active one is still active.
+	for range 3 {
+		_, _, err = TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+		require.NoError(t, err)
+	}
+
+	after, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	assert.Equal(t, stale.UnixNano(), after.ModTime().UnixNano(),
+		"reads must not rewrite an index whose terminal subset is unchanged")
+}
+
+// TestTryLoadForDay_RewritesIndexWhenAnotherRunFinishes confirms the skip does
+// not stop the index growing as runs reach a terminal state.
+func TestTryLoadForDay_RewritesIndexWhenAnotherRunFinishes(t *testing.T) {
+	dayDir := t.TempDir()
+	createDayDir(t, dayDir, 10, ir.Succeeded)
+
+	runDir := filepath.Join(dayDir, "dag-run_20240115_130000Z_active0")
+	attemptDir := filepath.Join(runDir, "attempt_20240115_130000_001Z_abc123")
+	require.NoError(t, os.MkdirAll(attemptDir, 0750))
+	statusPath := filepath.Join(attemptDir, "status.jsonl")
+
+	writeStatus := func(st ir.Status) {
+		data, err := json.Marshal(ir.DAGRunStatus{
+			Name: "test", DAGRunID: "active0", AttemptID: "abc123",
+			Status: st, StartedAt: "2024-01-15T13:00:00Z",
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(statusPath, append(data, '\n'), 0600))
+	}
+
+	writeStatus(ir.Running)
+	_, _, err := TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+	require.NoError(t, err)
+
+	idx, err := readIndex(filepath.Join(dayDir, IndexFileName))
+	require.NoError(t, err)
+	require.Len(t, idx.Entries, 10, "the active run is not indexed while running")
+
+	// The run finishes; the next read must pick it up.
+	writeStatus(ir.Succeeded)
+	_, _, err = TryLoadForDay(t.Context(), dayDir, readDayDir(t, dayDir))
+	require.NoError(t, err)
+
+	idx, err = readIndex(filepath.Join(dayDir, IndexFileName))
+	require.NoError(t, err)
+	assert.Len(t, idx.Entries, 11, "a newly finished run is added to the index")
+}


### PR DESCRIPTION
Fixes #2674.

## Problem

`RebuildForDay` persisted a day index only when **every** run in the day was terminal:

```go
// Write index only if all runs are terminal and there are enough runs.
if allTerminal && len(entries) >= MinRunsForIndex {
```

On an instance that schedules frequently the current day always has an active run, so its index is never written. Every request touching today re-runs the full rebuild — `findLatestAttempt`, plus a status read **and** a JSON parse, for every run in the day directory. The cost is O(runs today) per request and grows through the day, resetting at midnight.

One active run forfeits caching for every finished run beside it, and on a per-minute schedule that never resolves.

## Change

The index now holds the **terminal subset**. Reads reuse the entries that still match disk and rescan only the runs those do not cover, so the per-request cost for a day becomes a stat per finished run plus a full read for the handful still moving.

Correctness rests on the per-entry checks that already existed:

- only terminal runs are ever written to the index
- a retried run gains an attempt, which changes the run directory mtime, so its entry stops matching and the run is rescanned
- entries whose run directory has gone are dropped the same way

The exported `RebuildForDay` keeps its signature and delegates to an internal variant taking the validated cache. The fully-valid fast path in `TryLoadForDay` is untouched, so a completed day still short-circuits with no scanning at all.

No proto change: a subset index is self-describing once validation permits it.

## On the API shape

You asked in #2674 — implicitly — whether a partial index should be marked as such. I did **not** add a flag, because nothing needs to distinguish the two: a reader validates each entry against disk regardless and rescans whatever is missing, so a partial index and a stale full one are handled by the same path. Happy to add an explicit marker if you would rather have it visible in the file.

`fromIndex` now reports that an index was written, including for a day with active runs. Its only non-test consumer (`dataroot.go`) discards it and gates on `len(indexEntries) == dagRunDirCount`, which still holds because the rebuild returns entries for every run directory.

## Tests

`TestRebuildForDay_MixedStatuses` asserted the previous all-or-nothing behaviour. It now asserts that a day with active runs indexes its finished runs and excludes the active ones.

Added `TestTryLoadForDay_ReusesIndexedTerminalRunsWhileDayIsActive`, which proves the index is genuinely consulted rather than merely written: a terminal run whose status file is made unparseable in place — preserving size and mtime so the entry still validates — is still served from the index, where a rescan would drop it. It fails without this change.

Full `./internal/persis/...` suite passes, including `-race` on `dagrun/...`; `go vet` clean.

## Context

This is the root cause behind #2670 as well. The queues count was the worst-behaved consumer of the same rebuild, but `/api/v1/dag-runs` was affected identically on the instance where this was found. If this lands, the pressure behind #2673 drops considerably.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2674 by indexing the terminal runs of a day instead of requiring the whole day to be terminal, so a single active run no longer forfeits caching for every finished run beside it. Reads now reuse index entries that still match disk and rescan only the runs they don't cover, cutting the per-request cost from a full rebuild of the day to a stat per finished run plus a full read for the handful still moving.

- Correctness relies on existing per-entry checks: only terminal runs are written, a retried run's directory mtime changes so its entry stops matching, and removed run directories are dropped the same way.
- `RebuildForDay` keeps its exported signature and delegates to an internal variant that takes the validated cache.
- Reads skip rewriting the index when the terminal subset is unchanged; without this, the partial index (which never passes validation) would turn every read into a durable fsync'd write. A newly terminal run or a stale entry still triggers a rewrite.
- `fromIndex` now reports true for days with active runs; its only non-test consumer gates on `len(indexEntries) == dagRunDirCount`, which still holds.
- No proto change, and no explicit partial-index marker: readers already validate each entry against disk, so a partial index and a stale full one are handled by the same path.
- This is also the root cause behind #2670.

<sup>Written for commit 109576c6cfd3f9858cf7d9534b9bee063b42f912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Faster loading of daily run data by reusing valid cached index entries instead of rescanning all runs.
  * Terminal runs remain available from the index even while other runs are still active.

* **Reliability**
  * Cached run information is validated against the filesystem before reuse.
  * Improved handling when status files become temporarily unreadable or malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->