### PR TITLE
fix: show harness prompts in step details

### DIFF
--- a/internal/cmd/startall_test.go
+++ b/internal/cmd/startall_test.go
@@ -28,7 +28,7 @@ func TestStartAllCommand(t *testing.T) {
 	})
 	t.Run("StartAllWithConfig", func(t *testing.T) {
 		th := test.SetupCommand(t)
-		cancelWhenLogContains(t, th, "Coordinator initialization")
+		cancelWhenLogContains(t, th, "Scheduler initialization", "Coordinator initialization")
 		th.RunCommand(t, cmd.StartAll(), test.CmdTest{
 			Args: []string{
 				"start-all",

--- a/internal/cmn/dirlock/dirlock_test.go
+++ b/internal/cmn/dirlock/dirlock_test.go
@@ -131,9 +131,8 @@ func TestTryLock(t *testing.T) {
 }
 
 func TestLock(t *testing.T) {
-	tmpDir := t.TempDir()
-
 	t.Run("AcquireImmediately", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		lock := New(tmpDir, nil)
 
 		ctx := context.Background()
@@ -147,38 +146,33 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("WaitForLock", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		waiting := make(chan struct{})
 		lock1 := New(tmpDir, &LockOptions{
 			RetryInterval: 10 * time.Millisecond,
 		})
 
 		lock2 := New(tmpDir, &LockOptions{
 			RetryInterval: 10 * time.Millisecond,
+			OnWait: func() {
+				close(waiting)
+			},
 		})
 
 		// First lock acquired
 		err := lock1.TryLock()
 		require.NoError(t, err)
 
-		// Start goroutine to release lock after delay
-		released := make(chan bool)
+		ctx := t.Context()
+
+		lockErr := make(chan error, 1)
 		go func() {
-			time.Sleep(30 * time.Millisecond)
-			_ = lock1.Unlock()
-			released <- true
+			lockErr <- lock2.Lock(ctx)
 		}()
 
-		// Second lock should wait and then acquire
-		ctx := context.Background()
-		err = lock2.Lock(ctx)
-		require.NoError(t, err)
-
-		// Verify the lock was released before we acquired it
-		select {
-		case <-released:
-			// Good, lock was released
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("Lock was not released in time")
-		}
+		<-waiting
+		require.NoError(t, lock1.Unlock())
+		require.NoError(t, <-lockErr)
 
 		// Cleanup
 		err = lock2.Unlock()
@@ -186,6 +180,7 @@ func TestLock(t *testing.T) {
 	})
 
 	t.Run("ContextCancellation", func(t *testing.T) {
+		tmpDir := t.TempDir()
 		lock1 := New(tmpDir, nil)
 		lock2 := New(tmpDir, nil)
 
@@ -193,13 +188,12 @@ func TestLock(t *testing.T) {
 		err := lock1.TryLock()
 		require.NoError(t, err)
 
-		// Try to acquire with context that gets cancelled
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-		defer cancel()
+		// Try to acquire with a canceled context.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
 		err = lock2.Lock(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "context deadline exceeded")
+		require.ErrorIs(t, err, context.Canceled)
 		require.False(t, lock2.IsHeldByMe())
 
 		// Cleanup

--- a/internal/service/frontend/api/v1/transformer.go
+++ b/internal/service/frontend/api/v1/transformer.go
@@ -106,10 +106,16 @@ func toStep(obj ir.Step) api.Step {
 
 	commands := make([]api.CommandEntry, len(obj.Commands))
 	for i, cmd := range obj.Commands {
-		commands[i] = api.CommandEntry{
+		entry := api.CommandEntry{
 			Command: cmd.Command,
 			Args:    ptrOf(cmd.Args),
 		}
+		// Harness prompts live in CmdWithArgs to preserve multiline text.
+		if obj.ExecutorConfig.Type == "harness" && cmd.CmdWithArgs != "" {
+			entry.Command = cmd.CmdWithArgs
+			entry.Args = nil
+		}
+		commands[i] = entry
 	}
 
 	step := api.Step{

--- a/internal/service/frontend/api/v1/transformer_test.go
+++ b/internal/service/frontend/api/v1/transformer_test.go
@@ -27,6 +27,21 @@ func writeArtifactFile(t *testing.T) string {
 	return dir
 }
 
+func TestToStepIncludesHarnessPrompt(t *testing.T) {
+	prompt := "Review the implementation.\nReport every finding.\n"
+	step := toStep(ir.Step{
+		Commands: []ir.CommandEntry{{CmdWithArgs: prompt}},
+		ExecutorConfig: ir.ExecutorConfig{
+			Type: "harness",
+		},
+	})
+
+	require.NotNil(t, step.Commands)
+	require.Len(t, *step.Commands, 1)
+	assert.Equal(t, prompt, (*step.Commands)[0].Command)
+	assert.Nil(t, (*step.Commands)[0].Args)
+}
+
 func TestToDAGRunSummaryIncludesScheduleTime(t *testing.T) {
 	status := ir.DAGRunStatus{
 		Name:           "test-dag",

--- a/ui/src/features/dags/components/dag-details/__tests__/DAGStepTableRow.test.tsx
+++ b/ui/src/features/dags/components/dag-details/__tests__/DAGStepTableRow.test.tsx
@@ -59,5 +59,6 @@ describe('DAGStepTableRow', () => {
     );
 
     expect(screen.getByText('Script defined')).toBeInTheDocument();
+    expect(screen.getByText('Review the repository')).toBeInTheDocument();
   });
 });

--- a/ui/src/features/dags/components/step-details/StepDetails.tsx
+++ b/ui/src/features/dags/components/step-details/StepDetails.tsx
@@ -5,6 +5,7 @@ import { components } from '@/api/v1/schema';
 import { Badge } from '@/components/ui/badge';
 import BorderedBox from '@/components/ui/bordered-box';
 import { getLogMessageFromConfig } from '@/lib/executor-utils';
+import { getHarnessStepSummary } from '@/lib/harness-step';
 import React from 'react';
 import { LogStepMessage } from '../dag-details/LogStepMessage';
 
@@ -55,6 +56,7 @@ const STEP_FIELD_LABELS: Record<string, string> = {
 };
 
 export function StepDetails({ step }: { step: Step }) {
+  const harnessPrompt = getHarnessStepSummary(step)?.prompt ?? null;
   const fields = React.useMemo(() => {
     const entries = Object.entries(step)
       .filter(([key]) => key !== 'name')
@@ -82,14 +84,21 @@ export function StepDetails({ step }: { step: Step }) {
 
   return (
     <div className="space-y-4">
-      {fields.map(([key, value]) => (
-        <StepField
-          key={key}
-          label={STEP_FIELD_LABELS[key] || toTitleLabel(key)}
-          name={key}
-          value={value}
-        />
-      ))}
+      {fields.map(([key, value]) => {
+        const isHarnessPrompt = key === 'commands' && harnessPrompt !== null;
+        return (
+          <StepField
+            key={key}
+            label={
+              isHarnessPrompt
+                ? 'Prompt'
+                : STEP_FIELD_LABELS[key] || toTitleLabel(key)
+            }
+            name={isHarnessPrompt ? 'prompt' : key}
+            value={isHarnessPrompt ? harnessPrompt : value}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/ui/src/features/dags/components/step-details/__tests__/StepDetails.test.tsx
+++ b/ui/src/features/dags/components/step-details/__tests__/StepDetails.test.tsx
@@ -8,6 +8,27 @@ import type { components } from '@/api/v1/schema';
 import { StepDetails } from '../StepDetails';
 
 describe('StepDetails', () => {
+  it('renders harness commands as a prompt', () => {
+    const prompt = 'Review the implementation.\nReport every finding.';
+    const step = {
+      name: 'review',
+      commands: [{ command: prompt }],
+      executorConfig: {
+        type: 'harness',
+        config: {
+          provider: 'claude',
+        },
+      },
+    } as components['schemas']['Step'];
+
+    render(<StepDetails step={step} />);
+
+    expect(screen.getByText('Prompt')).toBeInTheDocument();
+    expect(screen.getByText(/Review the implementation/).textContent).toBe(
+      prompt
+    );
+  });
+
   it('renders log executor messages as a first-class message field', () => {
     const step = {
       name: 'announce',


### PR DESCRIPTION
## Summary

Show multiline harness prompts in DAG step details.

## Changes

- Preserve harness prompts in REST step responses
- Render harness command input as Prompt
- Keep other command rendering unchanged
- Add backend and frontend regression coverage
- Stabilize start-all and directory-lock tests exposed by Windows CI

## Related Issues

None.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally