### PR TITLE
fix(queue): bound capped queue item loading

### DIFF
--- a/internal/service/frontend/api/v1/queues.go
+++ b/internal/service/frontend/api/v1/queues.go
@@ -27,6 +27,9 @@ const (
 	queueCursorScanBatch  = 64
 )
 
+// queueItemsScanCap bounds records scanned by one item-list request.
+var queueItemsScanCap = 500
+
 // queuedCountScanCap bounds how many queued items a single count may scan.
 // Counting is O(items) with a status read per item, so an uncapped scan on a
 // deep queue can take tens of seconds and stall both GET /queues and the queues
@@ -383,8 +386,9 @@ func (a *API) listVisibleQueuedItems(ctx context.Context, queueName string, limi
 
 	items := make([]api.DAGRunSummary, 0, limit)
 	currentCursor := cursor
-	for len(items) < limit {
-		batchSize := min(max(limit-len(items), 1), queueCursorScanBatch)
+	scanned := 0
+	for len(items) < limit && scanned < queueItemsScanCap {
+		batchSize := min(max(limit-len(items), 1), queueCursorScanBatch, queueItemsScanCap-scanned)
 		page, err := a.queueStore.ListCursor(ctx, queueName, currentCursor, batchSize)
 		if err != nil {
 			return nil, "", err
@@ -392,6 +396,7 @@ func (a *API) listVisibleQueuedItems(ctx context.Context, queueName string, limi
 		if len(page.Items) == 0 {
 			return items, "", nil
 		}
+		scanned += len(page.Items)
 
 		for _, queuedItem := range page.Items {
 			dagRunRef, err := queuedItem.Data()

--- a/internal/service/frontend/api/v1/queues_internal_test.go
+++ b/internal/service/frontend/api/v1/queues_internal_test.go
@@ -222,6 +222,78 @@ func TestListQueueItemsUsesCursorPaginationAndSkipsRunningEntries(t *testing.T) 
 	assert.Nil(t, secondPage.NextCursor)
 }
 
+func TestListQueueItemsCapsScannedEntries(t *testing.T) {
+	// Not parallel: this test temporarily lowers the package-level scan cap.
+	originalCap := queueItemsScanCap
+	queueItemsScanCap = 3
+	t.Cleanup(func() { queueItemsScanCap = originalCap })
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dagRunRepository := testutil.NewFileDAGRunRepository(filepath.Join(tmpDir, "dag-runs"), persis.DAGRunRepositoryOptions{LatestStatusToday: true})
+	queueStore := store.NewQueueStore(file.NewCollection(filepath.Join(tmpDir, "queue")))
+	procRepository := newTestProcRepository(filepath.Join(tmpDir, "proc"))
+
+	for i := range 4 {
+		createQueuedQueueRun(t, ctx, dagRunRepository, queueStore, "scan-cap-q", fmt.Sprintf("running-run-%d", i), ir.Running)
+	}
+	for i := range 2 {
+		createQueuedQueueRun(t, ctx, dagRunRepository, queueStore, "scan-cap-q", fmt.Sprintf("queued-run-%d", i), ir.Queued)
+	}
+	for i := range 3 {
+		createQueuedQueueRun(t, ctx, dagRunRepository, queueStore, "exact-cap-q", fmt.Sprintf("running-run-%d", i), ir.Running)
+	}
+
+	a := &API{
+		dagRunRepository: dagRunRepository,
+		queueStore:       queueStore,
+		procRepository:   procRepository,
+		config:           &config.Config{},
+	}
+
+	firstResp, err := a.ListQueueItems(ctx, openapiv1.ListQueueItemsRequestObject{
+		Name: "scan-cap-q",
+		Params: openapiv1.ListQueueItemsParams{
+			Limit: queueListLimitPtr(2),
+		},
+	})
+	require.NoError(t, err)
+
+	firstPage, ok := firstResp.(openapiv1.ListQueueItems200JSONResponse)
+	require.True(t, ok)
+	assert.Empty(t, firstPage.Items)
+	require.NotNil(t, firstPage.NextCursor)
+
+	secondResp, err := a.ListQueueItems(ctx, openapiv1.ListQueueItemsRequestObject{
+		Name: "scan-cap-q",
+		Params: openapiv1.ListQueueItemsParams{
+			Limit:  queueListLimitPtr(2),
+			Cursor: firstPage.NextCursor,
+		},
+	})
+	require.NoError(t, err)
+
+	secondPage, ok := secondResp.(openapiv1.ListQueueItems200JSONResponse)
+	require.True(t, ok)
+	require.Len(t, secondPage.Items, 2)
+	assert.Equal(t, "queued-run-0", secondPage.Items[0].DagRunId)
+	assert.Equal(t, "queued-run-1", secondPage.Items[1].DagRunId)
+	assert.Nil(t, secondPage.NextCursor)
+
+	exactResp, err := a.ListQueueItems(ctx, openapiv1.ListQueueItemsRequestObject{
+		Name: "exact-cap-q",
+		Params: openapiv1.ListQueueItemsParams{
+			Limit: queueListLimitPtr(2),
+		},
+	})
+	require.NoError(t, err)
+
+	exactPage, ok := exactResp.(openapiv1.ListQueueItems200JSONResponse)
+	require.True(t, ok)
+	assert.Empty(t, exactPage.Items)
+	assert.Nil(t, exactPage.NextCursor)
+}
+
 func TestListQueuesReturnsDeterministicQueueOrder(t *testing.T) {
 	t.Parallel()
 

--- a/ui/src/pages/queues/queue/__tests__/index.test.tsx
+++ b/ui/src/pages/queues/queue/__tests__/index.test.tsx
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { components, QueueType } from '@/api/v1/schema';
+import { AppBarContext } from '@/contexts/AppBarContext';
+import QueueDetailsPage from '..';
+
+const { clientMock, getMock, useQueryMock } = vi.hoisted(() => {
+  const get = vi.fn();
+  return {
+    clientMock: { GET: get },
+    getMock: get,
+    useQueryMock: vi.fn(),
+  };
+});
+
+vi.mock('@/hooks/api', () => ({
+  useClient: () => clientMock,
+  useQuery: useQueryMock,
+}));
+
+vi.mock('@/features/dag-runs/components/dag-run-details', () => ({
+  DAGRunDetailsModal: () => null,
+}));
+
+const cappedZeroQueue: components['schemas']['Queue'] = {
+  name: 'running-heavy-q',
+  type: QueueType.dag_based,
+  maxConcurrency: 1,
+  runningCount: 0,
+  queuedCount: 0,
+  queuedCountCapped: true,
+  running: [],
+};
+
+function renderPage(queue: components['schemas']['Queue']): void {
+  useQueryMock.mockReturnValue({
+    data: queue,
+    error: null,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  });
+
+  render(
+    <MemoryRouter initialEntries={[`/queues/${queue.name}`]}>
+      <AppBarContext.Provider
+        value={
+          {
+            selectedRemoteNode: 'local',
+            setTitle: vi.fn(),
+          } as never
+        }
+      >
+        <Routes>
+          <Route path="/queues/:name" element={<QueueDetailsPage />} />
+        </Routes>
+      </AppBarContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('QueueDetailsPage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    useQueryMock.mockReset();
+    getMock.mockResolvedValue({
+      data: { items: [] },
+      error: undefined,
+    });
+  });
+
+  it('loads items when a capped lower-bound count is zero', async () => {
+    renderPage(cappedZeroQueue);
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledWith(
+        '/queues/{name}/items',
+        expect.any(Object)
+      );
+    });
+    expect(
+      await screen.findByText(
+        'No visible queued items were returned for this queue.'
+      )
+    ).toBeVisible();
+    expect(
+      screen.queryByText('No queued items in this queue.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not load items when an exact count is zero', async () => {
+    renderPage({ ...cappedZeroQueue, queuedCountCapped: undefined });
+
+    expect(
+      await screen.findByText('No queued items in this queue.')
+    ).toBeVisible();
+    expect(getMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/queues/queue/__tests__/index.test.tsx
+++ b/ui/src/pages/queues/queue/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { components, QueueType } from '@/api/v1/schema';
@@ -74,6 +74,11 @@ describe('QueueDetailsPage', () => {
   });
 
   it('loads items when a capped lower-bound count is zero', async () => {
+    getMock.mockResolvedValueOnce({
+      data: { items: [], nextCursor: 'cursor-1' },
+      error: undefined,
+    });
+
     renderPage(cappedZeroQueue);
 
     await waitFor(() => {
@@ -90,6 +95,22 @@ describe('QueueDetailsPage', () => {
     expect(
       screen.queryByText('No queued items in this queue.')
     ).not.toBeInTheDocument();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Continue scanning' }));
+
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalledTimes(2);
+    });
+    expect(getMock).toHaveBeenNthCalledWith(
+      2,
+      '/queues/{name}/items',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          query: expect.objectContaining({ cursor: 'cursor-1' }),
+        }),
+      })
+    );
   });
 
   it('does not load items when an exact count is zero', async () => {

--- a/ui/src/pages/queues/queue/index.tsx
+++ b/ui/src/pages/queues/queue/index.tsx
@@ -128,6 +128,8 @@ function QueueDetailsPage() {
   );
 
   const refreshToken = React.useMemo(() => queueRefreshToken(queue), [queue]);
+  const mayHaveQueuedItems =
+    (queue?.queuedCount ?? 0) > 0 || queue?.queuedCountCapped === true;
   const {
     items: queuedItems,
     error: queuedItemsError,
@@ -137,7 +139,7 @@ function QueueDetailsPage() {
     loadMore,
     reload,
   } = useQueuedItemsFeed({
-    enabled: Boolean(queue && (queue.queuedCount || 0) > 0),
+    enabled: mayHaveQueuedItems,
     queueName,
     refreshToken,
   });
@@ -439,7 +441,7 @@ function QueueDetailsPage() {
                     </div>
                   )}
                 </>
-              ) : queue && queue.queuedCount > 0 ? (
+              ) : mayHaveQueuedItems ? (
                 <div className="space-y-3 rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
                   <div>
                     No visible queued items were returned for this queue.

--- a/ui/src/pages/queues/queue/index.tsx
+++ b/ui/src/pages/queues/queue/index.tsx
@@ -454,6 +454,19 @@ function QueueDetailsPage() {
                       </Button>
                     </div>
                   )}
+                  {!queuedItemsError && hasMore && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleLoadMore}
+                      disabled={isLoadingMore}
+                    >
+                      {isLoadingMore && (
+                        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      )}
+                      {isLoadingMore ? 'Scanning...' : 'Continue scanning'}
+                    </Button>
+                  )}
                 </div>
               ) : (
                 <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">


### PR DESCRIPTION
Follow-up to #2673.

## Summary

- Bound each queued-items request by scanned queue records, including hidden running entries.
- Return a cursor when the scan budget ends before queue exhaustion.
- Let capped-zero queues continue past an empty bounded page.
- Keep exact-zero queues idle.

## Testing

- `go test -race ./internal/service/frontend/api/v1`
- `pnpm --dir ui test`
- `pnpm --dir ui typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes queue details hiding the feed when a capped queue count is zero, and bounds how many records each item-list request scans.

- Item-list requests stop after `queueItemsScanCap` scanned records and keep the cursor, so later queued runs remain reachable.
- The UI treats a capped zero count as possibly nonempty and shows a "Continue scanning" action when a bounded scan may have skipped queued runs.
- Adds regression tests for capped-zero and exact-zero counts on both the frontend and backend.

<sup>Written for commit 30066a3026923e01fb94c2725f5ba82afa730916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue details behavior when the queued item count is capped.
  * Queues with potentially hidden items now load the queued-items feed and display the appropriate empty-state message.
  * Added a “Continue scanning” option when more queued items may exist.
  * Queues confirmed to have no items avoid unnecessary loading and show a clear “No queued items in this queue.” message.

* **Tests**
  * Added coverage for capped and exact zero queued-count scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
