### PR TITLE
test: add spec and conformance coverage for wait actions

### DIFF
--- a/conformance/spec039_wait/testdata/duration_basic.yaml
+++ b/conformance/spec039_wait/testdata/duration_basic.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.duration
+    with:
+      duration: 300ms

--- a/conformance/spec039_wait/testdata/duration_invalid.yaml
+++ b/conformance/spec039_wait/testdata/duration_invalid.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.duration
+    with:
+      duration: not-a-duration

--- a/conformance/spec039_wait/testdata/duration_missing.yaml
+++ b/conformance/spec039_wait/testdata/duration_missing.yaml
@@ -1,0 +1,3 @@
+steps:
+  - action: wait.duration
+    with: {}

--- a/conformance/spec039_wait/testdata/duration_zero.yaml
+++ b/conformance/spec039_wait/testdata/duration_zero.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.duration
+    with:
+      duration: 0s

--- a/conformance/spec039_wait/testdata/file_bad_state.yaml
+++ b/conformance/spec039_wait/testdata/file_bad_state.yaml
@@ -1,0 +1,5 @@
+steps:
+  - action: wait.file
+    with:
+      path: /tmp/dagu-wait-conformance-does-not-matter
+      state: bogus

--- a/conformance/spec039_wait/testdata/file_missing_path.yaml
+++ b/conformance/spec039_wait/testdata/file_missing_path.yaml
@@ -1,0 +1,3 @@
+steps:
+  - action: wait.file
+    with: {}

--- a/conformance/spec039_wait/testdata/file_wait_exists.yaml
+++ b/conformance/spec039_wait/testdata/file_wait_exists.yaml
@@ -1,0 +1,6 @@
+working_dir: .
+steps:
+  - action: wait.file
+    with:
+      path: ready.txt
+      poll_interval: 100ms

--- a/conformance/spec039_wait/testdata/file_wait_missing.yaml
+++ b/conformance/spec039_wait/testdata/file_wait_missing.yaml
@@ -1,0 +1,7 @@
+working_dir: .
+steps:
+  - action: wait.file
+    with:
+      path: present.txt
+      state: missing
+      poll_interval: 100ms

--- a/conformance/spec039_wait/testdata/http_bad_status.yaml
+++ b/conformance/spec039_wait/testdata/http_bad_status.yaml
@@ -1,0 +1,5 @@
+steps:
+  - action: wait.http
+    with:
+      url: http://127.0.0.1:1
+      status: 999

--- a/conformance/spec039_wait/testdata/http_bad_url.yaml
+++ b/conformance/spec039_wait/testdata/http_bad_url.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.http
+    with:
+      url: not-a-url

--- a/conformance/spec039_wait/testdata/http_missing_url.yaml
+++ b/conformance/spec039_wait/testdata/http_missing_url.yaml
@@ -1,0 +1,3 @@
+steps:
+  - action: wait.http
+    with: {}

--- a/conformance/spec039_wait/testdata/http_wait_ready.yaml
+++ b/conformance/spec039_wait/testdata/http_wait_ready.yaml
@@ -1,0 +1,5 @@
+steps:
+  - action: wait.http
+    with:
+      url: http://127.0.0.1:18923/
+      poll_interval: 100ms

--- a/conformance/spec039_wait/testdata/until_bad_format.yaml
+++ b/conformance/spec039_wait/testdata/until_bad_format.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.until
+    with:
+      until: not-a-date

--- a/conformance/spec039_wait/testdata/until_future_timeout.yaml
+++ b/conformance/spec039_wait/testdata/until_future_timeout.yaml
@@ -1,0 +1,5 @@
+steps:
+  - action: wait.until
+    timeout_sec: 2
+    with:
+      until: "2099-01-01T00:00:00Z"

--- a/conformance/spec039_wait/testdata/until_missing.yaml
+++ b/conformance/spec039_wait/testdata/until_missing.yaml
@@ -1,0 +1,3 @@
+steps:
+  - action: wait.until
+    with: {}

--- a/conformance/spec039_wait/testdata/until_past.yaml
+++ b/conformance/spec039_wait/testdata/until_past.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: wait.until
+    with:
+      until: "2020-01-01T00:00:00Z"

--- a/conformance/spec039_wait/wait_test.go
+++ b/conformance/spec039_wait/wait_test.go
@@ -1,0 +1,262 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec039_wait holds black-box conformance tests for
+// Spec 039: Wait Actions (wait.duration, wait.until, wait.file, wait.http).
+package spec039_wait_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitDurationBlocks proves wait.duration actually
+// blocks for approximately the configured duration rather than returning
+// immediately.
+func TestWaitDurationBlocks(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	start := time.Now()
+	result := dagu.Run("start", "duration_basic.yaml")
+	elapsed := time.Since(start)
+	result.ExpectExitCode(0)
+	require.GreaterOrEqualf(t, elapsed, 300*time.Millisecond,
+		"expected at least the configured 300ms to elapse, took %s", elapsed)
+}
+
+func TestWaitDurationMissing(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "duration_missing.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("duration is required")
+}
+
+func TestWaitDurationInvalid(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "duration_invalid.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("duration must be a duration")
+}
+
+func TestWaitDurationZero(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "duration_zero.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("duration must be greater than 0")
+}
+
+// TestWaitUntilPast proves that a with.until
+// timestamp already in the past succeeds right away rather than being
+// treated as an error or hanging.
+func TestWaitUntilPast(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	start := time.Now()
+	result := dagu.Run("start", "until_past.yaml")
+	elapsed := time.Since(start)
+	result.ExpectExitCode(0)
+	require.Lessf(t, elapsed, 5*time.Second,
+		"expected an already-past until timestamp to succeed immediately, took %s", elapsed)
+}
+
+// TestWaitUntilFuture proves a with.until
+// timestamp far in the future genuinely blocks the step (rather than, say,
+// silently succeeding) by pairing it with a step timeout_sec and confirming
+// the step is cancelled instead of completing.
+func TestWaitUntilFuture(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "until_future_timeout.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("step timed out")
+}
+
+func TestWaitUntilMissing(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "until_missing.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("until is required")
+}
+
+func TestWaitUntilBadFormat(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "until_bad_format.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("until must be RFC3339 timestamp")
+}
+
+// TestWaitFileExists proves wait.file (default state:
+// exists) genuinely polls: the step is still running well after it starts
+// (the file does not exist yet), and only completes once the test creates
+// the file.
+func TestWaitFileExists(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	env := []string{"DAGU_HOME=" + filepath.Join(t.TempDir(), "dagu")}
+	const runID = "wait-file-exists"
+
+	proc := dagu.StartWithEnv(env, "start", "--run-id="+runID, "file_wait_exists.yaml")
+	defer proc.Stop()
+
+	select {
+	case <-proc.Done():
+		t.Fatalf("wait.file returned before the file existed: %s", proc.FailureOutput())
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	dagu.WriteFile("ready.txt", "")
+
+	select {
+	case <-proc.Done():
+	case <-time.After(harness.WaitTimeout(t)):
+		t.Fatal("wait.file did not complete after the file appeared")
+	}
+
+	status := dagu.RunWithEnv(env, "status", "--run-id="+runID, "file_wait_exists.yaml")
+	status.ExpectExitCode(0)
+	require.Containsf(t, status.Stdout(), "Result: Succeeded",
+		"expected the run to succeed, got:\n%s", status.Stdout())
+}
+
+// TestWaitFileGone proves the state: missing
+// variant: the step blocks while the file still exists and only completes
+// once the test removes it.
+func TestWaitFileGone(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	dagu.WriteFile("present.txt", "x")
+	env := []string{"DAGU_HOME=" + filepath.Join(t.TempDir(), "dagu")}
+	const runID = "wait-file-gone"
+
+	proc := dagu.StartWithEnv(env, "start", "--run-id="+runID, "file_wait_missing.yaml")
+	defer proc.Stop()
+
+	select {
+	case <-proc.Done():
+		t.Fatalf("wait.file returned before the file was removed: %s", proc.FailureOutput())
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	require.NoError(t, os.Remove(dagu.ProjectPath("present.txt")))
+
+	select {
+	case <-proc.Done():
+	case <-time.After(harness.WaitTimeout(t)):
+		t.Fatal("wait.file did not complete after the file was removed")
+	}
+
+	status := dagu.RunWithEnv(env, "status", "--run-id="+runID, "file_wait_missing.yaml")
+	status.ExpectExitCode(0)
+	require.Containsf(t, status.Stdout(), "Result: Succeeded",
+		"expected the run to succeed, got:\n%s", status.Stdout())
+}
+
+func TestWaitFileNoPath(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "file_missing_path.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("path is required")
+}
+
+func TestWaitFileBadState(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "file_bad_state.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("state")
+}
+
+// waitHTTPTestPort is fixed rather than dynamically allocated: with.url is a
+// plain string field, resolved only at execution time, so DAG-build-time
+// config-schema validation sees it unresolved -- a $VAR or ${VAR} reference
+// in with.url fails URL-format validation before the DAG ever runs. A
+// static fixture therefore needs a literal, fixed port.
+const waitHTTPTestPort = "18923"
+
+// TestWaitHTTPPolls proves wait.http genuinely polls: the
+// test server returns a non-matching status for the first two requests and
+// only starts returning the expected 200 afterward, so the step succeeding
+// proves it retried rather than checking once.
+func TestWaitHTTPPolls(t *testing.T) {
+	var requests atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:"+waitHTTPTestPort)
+	if err != nil {
+		t.Skipf("Skipping: could not bind fixed test port %s: %v", waitHTTPTestPort, err)
+	}
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	})
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "http_wait_ready.yaml")
+	result.ExpectExitCode(0)
+	require.GreaterOrEqualf(t, requests.Load(), int32(3),
+		"expected at least 3 requests (2 failing + 1 succeeding), got %d", requests.Load())
+}
+
+func TestWaitHTTPNoURL(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "http_missing_url.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("url is required")
+}
+
+func TestWaitHTTPBadURL(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "http_bad_url.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("must be an absolute HTTP URL")
+}
+
+func TestWaitHTTPBadStatus(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "http_bad_status.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("status")
+}

--- a/specs/039-wait.md
+++ b/specs/039-wait.md
@@ -1,0 +1,160 @@
+# Spec: Wait Actions
+
+## Status
+
+Implemented.
+
+This spec defines conformance behavior for the built-in `wait.duration`,
+`wait.until`, `wait.file`, and `wait.http` actions.
+
+## Scope
+
+This spec defines four actions that block a step until a condition becomes
+true, then succeed:
+
+- `wait.duration`: waits for a fixed length of time.
+- `wait.until`: waits until an absolute point in time.
+- `wait.file`: polls a filesystem path until it exists or stops existing.
+- `wait.http`: polls an HTTP URL until it returns an expected status.
+
+This spec covers:
+
+- the `with` fields each action accepts, and their defaults
+- how each action determines the condition is satisfied
+- validation and runtime errors
+- how these actions interact with a step's own `timeout_sec`
+
+This spec does not define:
+
+- signal delivery and abort behavior beyond what already applies to any step
+  (see [Spec 017: Built-In Run Context](017-built-in-run-context.md))
+- retry or `precondition` behavior
+- authentication for `wait.http` requests
+
+## Goal
+
+Workflow authors pause a DAG-run until an external condition holds --
+a fixed delay, a wall-clock deadline, a file appearing or disappearing, or
+an HTTP endpoint becoming ready -- without writing a polling script by hand.
+
+## Behavior
+
+### wait.duration
+
+`with.duration` (required) is a Go-style duration string (for example
+`30s`, `5m`) and must be greater than zero. The step blocks for that long,
+then succeeds.
+
+### wait.until
+
+`with.until` (required) is an RFC3339 timestamp. The step blocks until that
+point in time, then succeeds. If the timestamp is already in the past when
+the step starts, the step succeeds immediately rather than failing or
+blocking.
+
+### wait.file
+
+`with.path` (required) is a file or directory path, resolved relative to
+the step's working directory when not absolute. `with.state` selects the
+condition:
+
+- `exists` (default): succeeds once something exists at that path.
+- `missing`: succeeds once nothing exists at that path.
+
+The action polls at `with.poll_interval` (default `1s`).
+
+### wait.http
+
+`with.url` (required) must be an absolute `http://` or `https://` URL.
+`with.method` defaults to `GET`. `with.headers` and `with.body` set the
+request's headers and body. The action polls at `with.poll_interval`
+(default `1s`), giving each individual request `with.request_timeout`
+(default `10s`) to complete. A request that fails outright (connection
+refused, timeout, and similar) counts as a non-matching poll rather than an
+error and is retried on the next interval. The step succeeds once a
+response's status code equals `with.status` (default `200`).
+
+Config-schema validation for `with.url` (and `with.status`) runs before a
+step's `with` values are resolved, so `with.url` must be a literal,
+already-valid absolute URL in the DAG file; a `${...}`/`$VAR`-style
+reference that would only become a valid URL after resolution fails
+validation before the DAG ever runs.
+
+`with.headers` and `with.body` are sent exactly as given, with no scheme
+enforcement: a `with.url` using `http://` sends them in cleartext the same
+as any other `http://` request. A workflow author who puts a credential in
+`with.headers` is responsible for using an `https://` URL.
+
+### Interaction with timeout_sec
+
+All four actions poll or sleep against the step's own context, so a step
+`timeout_sec` set on any of them cancels the wait once it elapses, the same
+way it cancels any other step.
+
+## Errors
+
+### Validation
+
+All of the following are rejected by DAG-build-time validation, before the
+DAG starts running:
+
+- `wait.duration`: `with.duration` is empty, is not a parseable duration, or
+  is not greater than zero.
+- `wait.until`: `with.until` is empty or is not a valid RFC3339 timestamp.
+- `wait.file`: `with.path` is empty, or `with.state` is a value other than
+  `exists` or `missing`.
+- `wait.http`: `with.url` is empty or is not an absolute `http://`/`https://`
+  URL, or `with.status` is outside `100`-`599`.
+
+### Timeout and abort
+
+All four actions block by sleeping or polling against the step's own
+context (see "Interaction with timeout_sec" above), so a step `timeout_sec`
+elapsing, or the DAG-run being stopped (`dagu stop` or an equivalent
+cancellation), cancels the wait immediately with the same step-timeout or
+abort result any other step gets; none of these actions has its own
+distinct timeout or abort error shape.
+
+### Cleanup
+
+None of the four actions creates an external resource (a container, a job,
+a connection held open past the request) that needs cleanup on completion,
+failure, timeout, or abort. A `wait.http` request in flight when the step
+is cancelled is simply abandoned; the action does not need to release
+anything afterward.
+
+## Related Specs
+
+- Run context: [Spec 017: Built-In Run Context](017-built-in-run-context.md)
+- Value resolution: [Spec 003: Value Resolution and Field Evaluation](003-value-resolution.md)
+
+## Examples
+
+Wait for a fixed delay:
+
+```yaml
+steps:
+  - action: wait.duration
+    with:
+      duration: 30s
+```
+
+Wait for a file to appear, polling every 500ms:
+
+```yaml
+steps:
+  - action: wait.file
+    with:
+      path: ready.flag
+      poll_interval: 500ms
+```
+
+Wait for an HTTP health check to return 200:
+
+```yaml
+steps:
+  - action: wait.http
+    with:
+      url: http://localhost:8080/healthz
+      poll_interval: 1s
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -39,6 +39,7 @@ It must not be treated as product behavior until implementation catches up.
 | [034: Wiki Page File Format](034-wiki-page-format.md) | Implemented |
 | [035: File Dependencies](035-file-dependencies.md) | Implemented |
 | [036: MCP Execute Tool](036-mcp-execute-tool.md) | Implemented |
+| [039: Wait Actions](039-wait.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Document wait.duration, wait.until, wait.file, and wait.http as Spec 039, then add black-box tests proving each action's polling/blocking behavior and validation errors on the real binary.


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support documentation for wait actions based on durations, dates, files, and HTTP readiness.
  * Documented validation, polling behavior, timeouts, success conditions, and configuration examples.

* **Tests**
  * Added comprehensive conformance coverage for valid, invalid, missing, zero-duration, timeout, polling, and error scenarios across all wait actions.
  * Marked the wait-actions specification as implemented in the conformance status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->