### PR TITLE
 docs: require short Go test function names in project conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Distributed mode: Scheduler → Queue → dispatch policy → Coordinator (gRPC)
 - DAGs compose hierarchically — steps invoke other DAGs via the `dag` executor; `action:` is shorthand normalized at spec-build time.
 - Configuration uses `DAGU_*` environment variables, with fallback to `~/.config/dagu/config.yaml`.
 - Run `make fmt` before committing (lint also runs under `GOOS=windows` — keep Windows builds green).
+- Keep Go test function names short (e.g. `TestRouteExactMatch`, not `TestRouteExactMatchRunsOnlyMatchingTarget`); put the full explanation of what the test proves in a doc comment above the function, not in the name. Applies to `conformance/` black-box tests and other Go test packages alike.
 - License: GPL v3 (root module). License headers managed via `make addlicense`.
 - `AGENTS.md` is a symlink to this file.
 


### PR DESCRIPTION
Codify the short-test-name preference (surfaced repeatedly this session on conformance/ black-box tests) as a checked-in convention in CLAUDE.md, so it applies beyond a single assistant session.

## Summary

One line change to claude.md file.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [ ] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for keeping Go test names concise while documenting test intent in comments.
  * Clarified that this convention applies across black-box conformance tests and other Go test packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->