### PR TITLE
Refine language selector styling

### DIFF
--- a/ui/src/__tests__/menu.test.tsx
+++ b/ui/src/__tests__/menu.test.tsx
@@ -211,6 +211,17 @@ describe('sidebar menu', () => {
     expect(languageSelector.className).toContain('[&>svg:last-child]:hidden');
   });
 
+  it('uses the sidebar color for the language icon', () => {
+    renderMenu('/cockpit');
+
+    const languageSelector = screen.getByRole('combobox', {
+      name: 'Language',
+    });
+    expect(languageSelector.querySelector('svg')).toHaveClass(
+      'text-sidebar-foreground'
+    );
+  });
+
   it('hides the remote node selector when local is the only option', () => {
     renderMenu('/cockpit', {}, { remoteNodes: ['local'] });
 

--- a/ui/src/__tests__/menu.test.tsx
+++ b/ui/src/__tests__/menu.test.tsx
@@ -211,12 +211,14 @@ describe('sidebar menu', () => {
     expect(languageSelector.className).toContain('[&>svg:last-child]:hidden');
   });
 
-  it('uses the sidebar color for the language icon', () => {
+  it('styles the sidebar language selector', () => {
     renderMenu('/cockpit');
 
     const languageSelector = screen.getByRole('combobox', {
       name: 'Language',
     });
+    expect(languageSelector).toHaveClass('justify-start');
+    expect(languageSelector.className).toContain('[&>svg:last-child]:ml-auto');
     expect(languageSelector.querySelector('svg')).toHaveClass(
       'text-sidebar-foreground'
     );

--- a/ui/src/components/LanguageSelector.tsx
+++ b/ui/src/components/LanguageSelector.tsx
@@ -38,7 +38,12 @@ export function LanguageSelector({
           compact && 'w-7 justify-center px-1 [&>svg:last-child]:hidden'
         )}
       >
-        <Languages className="h-4 w-4 shrink-0" />
+        <Languages
+          className={cn(
+            'h-4 w-4 shrink-0',
+            variant === 'sidebar' && 'text-sidebar-foreground'
+          )}
+        />
         {!compact && <SelectValue />}
       </SelectTrigger>
       <SelectContent>

--- a/ui/src/components/LanguageSelector.tsx
+++ b/ui/src/components/LanguageSelector.tsx
@@ -1,5 +1,6 @@
 import { Languages } from 'lucide-react';
 import { useI18n } from '@/i18n/I18nProvider';
+import { cn } from '@/lib/utils';
 import {
   Select,
   SelectContent,
@@ -8,8 +9,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-export function LanguageSelector({ compact = false }: { compact?: boolean }) {
+type LanguageSelectorProps = {
+  compact?: boolean;
+  variant?: 'login' | 'sidebar';
+};
+
+export function LanguageSelector({
+  compact = false,
+  variant = 'login',
+}: LanguageSelectorProps) {
   const { locale, setLocale, t } = useI18n();
+  const language =
+    locale === 'en' ? t('language.english') : t('language.chinese');
+
   return (
     <Select
       value={locale}
@@ -17,11 +29,14 @@ export function LanguageSelector({ compact = false }: { compact?: boolean }) {
     >
       <SelectTrigger
         aria-label={t('language.select')}
-        className={
-          compact
-            ? 'h-7 w-7 border-transparent px-1 py-1 [&>svg:last-child]:hidden'
-            : 'h-7 w-full py-1'
-        }
+        title={compact ? language : undefined}
+        className={cn(
+          'h-7 border-transparent bg-transparent px-2 py-1 text-xs shadow-none hover:border-transparent',
+          variant === 'sidebar'
+            ? 'w-full text-sidebar-foreground hover:bg-sidebar-hover focus-visible:border-sidebar-ring'
+            : 'w-auto text-muted-foreground hover:bg-muted hover:text-foreground',
+          compact && 'w-7 justify-center px-1 [&>svg:last-child]:hidden'
+        )}
       >
         <Languages className="h-4 w-4 shrink-0" />
         {!compact && <SelectValue />}

--- a/ui/src/components/LanguageSelector.tsx
+++ b/ui/src/components/LanguageSelector.tsx
@@ -33,7 +33,7 @@ export function LanguageSelector({
         className={cn(
           'h-7 border-transparent bg-transparent px-2 py-1 text-xs shadow-none hover:border-transparent',
           variant === 'sidebar'
-            ? 'w-full text-sidebar-foreground hover:bg-sidebar-hover focus-visible:border-sidebar-ring'
+            ? 'w-full justify-start text-sidebar-foreground hover:bg-sidebar-hover focus-visible:border-sidebar-ring [&>svg:last-child]:ml-auto'
             : 'w-auto text-muted-foreground hover:bg-muted hover:text-foreground',
           compact && 'w-7 justify-center px-1 [&>svg:last-child]:hidden'
         )}

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -1004,7 +1004,7 @@ export const mainListItems = React.forwardRef<
             }
             isOpen={isOpen}
           />
-          <LanguageSelector compact={!isOpen} />
+          <LanguageSelector variant="sidebar" compact={!isOpen} />
           <UserMenu isCollapsed={!isOpen} />
         </div>
         {config.version && (

--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -102,11 +102,6 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-muted/50">
       <div className="w-full max-w-sm p-6 space-y-6">
-        <div className="flex justify-end">
-          <div className="w-48">
-            <LanguageSelector />
-          </div>
-        </div>
         <div className="text-center space-y-2">
           <h1 className="text-2xl font-bold">{config.title || 'Dagu'}</h1>
           <p className="text-sm text-muted-foreground">
@@ -202,6 +197,9 @@ export default function LoginPage() {
               )}
             </>
           )}
+        </div>
+        <div className="flex justify-center">
+          <LanguageSelector />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the prominent language select surface with a ghost utility control
- move the login selector below authentication actions
- preserve compact sidebar and locale behavior

## Testing
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm exec prettier --check src/components/LanguageSelector.tsx src/pages/login.tsx src/menu.tsx
- browser verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the language selector so it reads as a quiet utility control instead of a prominent form field. The login page selector moves below the authentication actions, and the sidebar variant now matches surrounding utility controls with sidebar-specific icon color and label alignment; compact mode shows a localized tooltip instead of the label.

<sup>Written for commit d03e57adea12ebfc31a0dbd240b67cf992bc1646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated language selector styling for login and sidebar layouts.
  * Added localized language labels to compact-mode tooltips.
  * Moved the language selector to the bottom center of the login card.
  * Improved sidebar behavior across expanded and collapsed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->