### PR TITLE
Fix MCP profile-scoped schedule setup

### DIFF
--- a/conformance/spec022_mcp_change_tool/change_identity_test.go
+++ b/conformance/spec022_mcp_change_tool/change_identity_test.go
@@ -40,7 +40,7 @@ func TestChangeToolIdentityAndInputSchema(t *testing.T) {
 
 	properties, ok := schema["properties"].(map[string]any)
 	require.True(t, ok)
-	for _, field := range []string{"mode", "type", "name", "spec", "newName", "workspace", "path", "content", "newPath"} {
+	for _, field := range []string{"mode", "type", "name", "spec", "newName", "profile", "workspace", "path", "content", "newPath"} {
 		property, ok := properties[field].(map[string]any)
 		require.True(t, ok)
 		require.Equal(t, "string", property["type"])
@@ -61,6 +61,14 @@ func TestChangeToolIdentityAndInputSchema(t *testing.T) {
 		},
 		"delete_dag": {
 			types:    []any{"delete_dag"},
+			required: []any{"type", "name"},
+		},
+		"set_dag_profile": {
+			types:    []any{"set_dag_profile"},
+			required: []any{"type", "name", "profile"},
+		},
+		"clear_dag_profile": {
+			types:    []any{"clear_dag_profile"},
 			required: []any{"type", "name"},
 		},
 		"upsert_wiki_page": {

--- a/internal/service/frontend/api/v1/dags.go
+++ b/internal/service/frontend/api/v1/dags.go
@@ -96,10 +96,14 @@ func (a *API) ValidateDAGSpec(ctx context.Context, request api.ValidateDAGSpecRe
 	if request.Body.Name != nil {
 		name = *request.Body.Name
 	}
+	response, _, err := a.ValidateDAGSpecData(ctx, name, request.Body.Spec)
+	return response, err
+}
 
-	// Load the DAG spec
+// ValidateDAGSpecData validates a DAG spec and returns its canonical form.
+func (a *API) ValidateDAGSpecData(ctx context.Context, name, spec string) (*api.ValidateDAGSpec200JSONResponse, *ir.DAG, error) {
 	dag, err := a.dagRepository.LoadSpec(ctx,
-		[]byte(request.Body.Spec),
+		[]byte(spec),
 		name,
 		persis.DAGLoadOptions{AllowBuildErrors: true},
 	)
@@ -108,8 +112,7 @@ func (a *API) ValidateDAGSpec(ctx context.Context, request api.ValidateDAGSpecRe
 	if loadErrs, ok := errors.AsType[ir.ErrorList](err); ok {
 		errs = loadErrs.ToStringList()
 	} else if err != nil {
-		// Unexpected fatal error
-		return nil, err
+		return nil, nil, err
 	}
 
 	if dag != nil && len(dag.BuildErrors) > 0 {
@@ -124,7 +127,7 @@ func (a *API) ValidateDAGSpec(ctx context.Context, request api.ValidateDAGSpecRe
 		Valid:  len(errs) == 0,
 		Dag:    details,
 		Errors: errs,
-	}, nil
+	}, dag, nil
 }
 
 func (a *API) CreateNewDAG(ctx context.Context, request api.CreateNewDAGRequestObject) (api.CreateNewDAGResponseObject, error) {

--- a/internal/service/frontend/api/v1/dagsettings.go
+++ b/internal/service/frontend/api/v1/dagsettings.go
@@ -36,6 +36,12 @@ func dagSettingsBadRequest(message string) api.Error {
 	}
 }
 
+// DAGProfileSelection reports the configured and effective profiles for a DAG.
+type DAGProfileSelection struct {
+	Configured string
+	Effective  string
+}
+
 func (a *API) GetDAGSettings(ctx context.Context, request api.GetDAGSettingsRequestObject) (api.GetDAGSettingsResponseObject, error) {
 	if a.dagSettingsStore == nil {
 		return nil, dagSettingsStoreUnavailable()
@@ -67,20 +73,13 @@ func (a *API) UpdateDAGSettings(ctx context.Context, request api.UpdateDAGSettin
 	if request.Body == nil {
 		return api.UpdateDAGSettings400JSONResponse(dagSettingsBadRequest("request body is required")), nil
 	}
-	if err := a.requireManagerOrAbove(ctx); err != nil {
-		return nil, err
-	}
-	if _, err := a.getDAGForSettings(ctx, request.FileName); err != nil {
-		return nil, err
-	}
-
 	profileName := ""
 	if request.Body.Profile != nil {
-		resolved, err := a.ensureRunnableRuntimeProfile(ctx, string(*request.Body.Profile))
-		if err != nil {
-			return nil, err
-		}
-		profileName = resolved
+		profileName = string(*request.Body.Profile)
+	}
+	profileName, err := a.ValidateDAGProfileUpdate(ctx, request.FileName, profileName)
+	if err != nil {
+		return nil, err
 	}
 
 	if profileName == "" {
@@ -132,13 +131,7 @@ func (a *API) UpdateDAGSettings(ctx context.Context, request api.UpdateDAGSettin
 }
 
 func (a *API) DeleteDAGSettings(ctx context.Context, request api.DeleteDAGSettingsRequestObject) (api.DeleteDAGSettingsResponseObject, error) {
-	if a.dagSettingsStore == nil {
-		return nil, dagSettingsStoreUnavailable()
-	}
-	if err := a.requireManagerOrAbove(ctx); err != nil {
-		return nil, err
-	}
-	if _, err := a.getDAGForSettings(ctx, request.FileName); err != nil {
+	if _, err := a.ValidateDAGProfileUpdate(ctx, request.FileName, ""); err != nil {
 		return nil, err
 	}
 
@@ -149,6 +142,44 @@ func (a *API) DeleteDAGSettings(ctx context.Context, request api.DeleteDAGSettin
 		"dag_name": request.FileName,
 	})
 	return api.DeleteDAGSettings204Response{}, nil
+}
+
+// ValidateDAGProfileUpdate validates access and a selectable profile name.
+func (a *API) ValidateDAGProfileUpdate(ctx context.Context, fileName, profileName string) (string, error) {
+	if a.dagSettingsStore == nil {
+		return "", dagSettingsStoreUnavailable()
+	}
+	if err := a.requireManagerOrAbove(ctx); err != nil {
+		return "", err
+	}
+	if _, err := a.getDAGForSettings(ctx, fileName); err != nil {
+		return "", err
+	}
+	return a.ensureRunnableRuntimeProfile(ctx, profileName)
+}
+
+// GetDAGProfileSelection returns the stored selection and resolved default.
+func (a *API) GetDAGProfileSelection(ctx context.Context, fileName string) (DAGProfileSelection, error) {
+	if a.dagSettingsStore == nil {
+		return DAGProfileSelection{}, dagSettingsStoreUnavailable()
+	}
+	dag, err := a.getDAGForSettings(ctx, fileName)
+	if err != nil {
+		return DAGProfileSelection{}, err
+	}
+
+	selection := DAGProfileSelection{}
+	settings, err := a.dagSettingsStore.Get(ctx, fileName)
+	if err == nil {
+		selection.Configured = settings.Profile
+	} else if !errors.Is(err, dagsettings.ErrNotFound) {
+		return DAGProfileSelection{}, fmt.Errorf("failed to get DAG settings: %w", err)
+	}
+	selection.Effective, err = a.defaultRunProfileName(ctx, fileName, dagWorkspaceName(dag))
+	if err != nil {
+		return DAGProfileSelection{}, err
+	}
+	return selection, nil
 }
 
 func (a *API) defaultRunProfileName(ctx context.Context, dagName string, workspaceName string) (string, error) {

--- a/internal/service/mcp/audit.go
+++ b/internal/service/mcp/audit.go
@@ -263,6 +263,11 @@ func changeAuditMetadata(input changeInput) toolAuditMetadata {
 		attributes["new_dag_name"] = input.NewName
 	case changeTypeDeleteDAG:
 		attributes["dag_name"] = input.Name
+	case changeTypeSetDAGProfile, changeTypeClearDAGProfile:
+		attributes["dag_name"] = input.Name
+		if input.Profile != "" {
+			attributes["profile"] = input.Profile
+		}
 	default:
 		resourceType = "doc"
 		resourceID = input.Path

--- a/internal/service/mcp/audit_test.go
+++ b/internal/service/mcp/audit_test.go
@@ -100,6 +100,15 @@ func TestDAGChangeAuditMetadata(t *testing.T) {
 				Name: "old",
 			},
 		},
+		{
+			name: "set profile",
+			input: changeInput{
+				Mode:    changeModeApply,
+				Type:    changeTypeSetDAGProfile,
+				Name:    "old",
+				Profile: "fudosan",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -111,6 +120,9 @@ func TestDAGChangeAuditMetadata(t *testing.T) {
 			require.Equal(t, test.input.Name, metadata.Attributes["dag_name"])
 			if test.wantNew != "" {
 				require.Equal(t, test.wantNew, metadata.Attributes["new_dag_name"])
+			}
+			if test.input.Profile != "" {
+				require.Equal(t, test.input.Profile, metadata.Attributes["profile"])
 			}
 		})
 	}

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 
+	daguapi "github.com/dagucloud/dagu/v2/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	frontendapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
@@ -22,12 +24,14 @@ const (
 	changeModePreview = "preview"
 	changeModeApply   = "apply"
 
-	changeTypeUpsertDAG      = "upsert_dag"
-	changeTypeRenameDAG      = "rename_dag"
-	changeTypeDeleteDAG      = "delete_dag"
-	changeTypeUpsertWikiPage = "upsert_wiki_page"
-	changeTypeRenameWikiPage = "rename_wiki_page"
-	changeTypeDeleteWikiPage = "delete_wiki_page"
+	changeTypeUpsertDAG       = "upsert_dag"
+	changeTypeRenameDAG       = "rename_dag"
+	changeTypeDeleteDAG       = "delete_dag"
+	changeTypeSetDAGProfile   = "set_dag_profile"
+	changeTypeClearDAGProfile = "clear_dag_profile"
+	changeTypeUpsertWikiPage  = "upsert_wiki_page"
+	changeTypeRenameWikiPage  = "rename_wiki_page"
+	changeTypeDeleteWikiPage  = "delete_wiki_page"
 
 	legacyChangeTypeUpsertDoc = "upsert_doc"
 	legacyChangeTypeRenameDoc = "rename_doc"
@@ -47,6 +51,7 @@ const (
 	changeFieldName                  = "name"
 	changeFieldNewName               = "newName"
 	changeFieldSpec                  = "spec"
+	changeFieldProfile               = "profile"
 	changeFieldWorkspace             = "workspace"
 	changeFieldPath                  = "path"
 	changeFieldContent               = "content"
@@ -82,7 +87,7 @@ func changeToolInputSchema() json.RawMessage {
 			},
 			"type": {
 				"type": "string",
-				"enum": ["upsert_dag", "rename_dag", "delete_dag", "upsert_wiki_page", "rename_wiki_page", "delete_wiki_page"],
+				"enum": ["upsert_dag", "rename_dag", "delete_dag", "set_dag_profile", "clear_dag_profile", "upsert_wiki_page", "rename_wiki_page", "delete_wiki_page"],
 				"description": "Change type. Defaults to upsert_dag."
 			},
 			"name": {
@@ -96,6 +101,10 @@ func changeToolInputSchema() json.RawMessage {
 			"newName": {
 				"type": "string",
 				"description": "Destination DAG name for rename_dag."
+			},
+			"profile": {
+				"type": "string",
+				"description": "Runtime profile name for set_dag_profile."
 			},
 			"workspace": {
 				"type": "string",
@@ -125,6 +134,14 @@ func changeToolInputSchema() json.RawMessage {
 			},
 			{
 				"properties": {"type": {"enum": ["delete_dag"]}},
+				"required": ["type", "name"]
+			},
+			{
+				"properties": {"type": {"enum": ["set_dag_profile"]}},
+				"required": ["type", "name", "profile"]
+			},
+			{
+				"properties": {"type": {"enum": ["clear_dag_profile"]}},
 				"required": ["type", "name"]
 			},
 			{
@@ -180,6 +197,8 @@ func (svc *Service) changeToolImpl(ctx context.Context, input changeInput) (*mcp
 		return svc.changeRenameDAG(ctx, input)
 	case changeTypeDeleteDAG:
 		return svc.changeDeleteDAG(ctx, input)
+	case changeTypeSetDAGProfile, changeTypeClearDAGProfile:
+		return svc.changeDAGProfile(ctx, input)
 	case changeTypeUpsertWikiPage:
 		return svc.changeUpsertWikiPage(ctx, input)
 	case changeTypeRenameWikiPage:
@@ -212,6 +231,9 @@ func (svc *Service) changeDAG(ctx context.Context, input changeInput) (*mcpsdk.C
 	}
 	if validation.Valid && validation.Dag != nil {
 		output["dag"] = validation.Dag
+		if warnings := profileScheduleWarnings(validation.Dag.Schedule); len(warnings) > 0 {
+			output["warnings"] = warnings
+		}
 	}
 
 	if !validation.Valid {
@@ -230,6 +252,90 @@ func (svc *Service) changeDAG(ctx context.Context, input changeInput) (*mcpsdk.C
 	output["updated"] = !created
 
 	return resultWithLinks("DAG change applied.", linkForDAGSpec(input.Name)), output, nil
+}
+
+func (svc *Service) changeDAGProfile(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
+	profileName := input.Profile
+	if canonicalChangeType(input.Type) == changeTypeClearDAGProfile {
+		profileName = ""
+	}
+	output := map[string]any{
+		"mode":       input.Mode,
+		"type":       input.Type,
+		"dagName":    input.Name,
+		"profile":    nullableString(profileName),
+		"valid":      true,
+		"applied":    false,
+		"references": defaultReferenceURIs(),
+	}
+	if input.Mode == changeModePreview {
+		resolved, err := svc.api.ValidateDAGProfileUpdate(ctx, input.Name, profileName)
+		if err != nil {
+			return nil, nil, err
+		}
+		output["profile"] = nullableString(resolved)
+		return resultWithLinks("DAG profile change is valid. Re-run with mode=apply to write it."), output, nil
+	}
+
+	if profileName == "" {
+		resp, err := svc.api.DeleteDAGSettings(ctx, daguapi.DeleteDAGSettingsRequestObject{
+			FileName: daguapi.DAGFileName(input.Name),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, ok := resp.(daguapi.DeleteDAGSettings204Response); !ok {
+			return nil, nil, fmt.Errorf("unexpected delete DAG settings response %T", resp)
+		}
+	} else {
+		profile := daguapi.RuntimeProfileName(profileName)
+		resp, err := svc.api.UpdateDAGSettings(ctx, daguapi.UpdateDAGSettingsRequestObject{
+			FileName: daguapi.DAGFileName(input.Name),
+			Body:     &daguapi.UpdateDAGSettingsJSONRequestBody{Profile: &profile},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		switch resp.(type) {
+		case daguapi.UpdateDAGSettings200JSONResponse, *daguapi.UpdateDAGSettings200JSONResponse:
+		default:
+			return nil, nil, fmt.Errorf("unexpected update DAG settings response %T", resp)
+		}
+	}
+	output["applied"] = true
+	return resultWithLinks("DAG profile change applied. The scheduler will use it on its next minute tick."), output, nil
+}
+
+func profileScheduleWarnings(schedule *[]daguapi.Schedule) []map[string]any {
+	if schedule == nil {
+		return nil
+	}
+	profiles := make(map[string]struct{})
+	for _, entry := range *schedule {
+		if entry.Profile != nil && *entry.Profile != "" {
+			profiles[string(*entry.Profile)] = struct{}{}
+		}
+	}
+	if len(profiles) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(profiles))
+	for name := range profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return []map[string]any{{
+		"code":     "profile_scoped_schedule_requires_default",
+		"profiles": names,
+		"message":  "Profile-scoped schedules require a matching effective DAG default profile.",
+	}}
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 func (svc *Service) changeRenameDAG(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
@@ -461,6 +567,8 @@ func parseChangeToolInput(raw json.RawMessage) (changeInput, *changeToolError) {
 			input.NewName = strings.TrimSpace(text)
 		case changeFieldSpec:
 			input.Spec = text
+		case changeFieldProfile:
+			input.Profile = strings.TrimSpace(text)
 		case changeFieldWorkspace:
 			input.Workspace = strings.TrimSpace(text)
 		case changeFieldPath:
@@ -502,6 +610,7 @@ func isChangeInputField(field string) bool {
 		changeFieldName,
 		changeFieldNewName,
 		changeFieldSpec,
+		changeFieldProfile,
 		changeFieldWorkspace,
 		changeFieldPath,
 		changeFieldContent,
@@ -517,6 +626,8 @@ func isSupportedChangeType(changeType string) bool {
 	case changeTypeUpsertDAG,
 		changeTypeRenameDAG,
 		changeTypeDeleteDAG,
+		changeTypeSetDAGProfile,
+		changeTypeClearDAGProfile,
 		changeTypeUpsertWikiPage,
 		changeTypeRenameWikiPage,
 		changeTypeDeleteWikiPage:
@@ -556,6 +667,13 @@ func validateChangeInput(input changeInput, fields map[string]json.RawMessage) *
 		allowed[changeFieldNewName] = true
 		required = []string{changeFieldName, changeFieldNewName}
 	case changeTypeDeleteDAG:
+		allowed[changeFieldName] = true
+		required = []string{changeFieldName}
+	case changeTypeSetDAGProfile:
+		allowed[changeFieldName] = true
+		allowed[changeFieldProfile] = true
+		required = []string{changeFieldName, changeFieldProfile}
+	case changeTypeClearDAGProfile:
 		allowed[changeFieldName] = true
 		required = []string{changeFieldName}
 	case changeTypeUpsertWikiPage:
@@ -600,7 +718,7 @@ func validateChangeInput(input changeInput, fields map[string]json.RawMessage) *
 		if strings.TrimSpace(input.Spec) == "" {
 			return changeInputError(input, "The spec field is required.", changeFieldSpec)
 		}
-	case changeTypeRenameDAG, changeTypeDeleteDAG:
+	case changeTypeRenameDAG, changeTypeDeleteDAG, changeTypeSetDAGProfile, changeTypeClearDAGProfile:
 		if input.Name == "" {
 			return changeInputError(input, "The name field is required.", changeFieldName)
 		}
@@ -617,6 +735,9 @@ func validateChangeInput(input changeInput, fields map[string]json.RawMessage) *
 			if input.Name == input.NewName {
 				return changeInputError(input, "The newName field must differ from name.", changeFieldNewName)
 			}
+		}
+		if changeType == changeTypeSetDAGProfile && input.Profile == "" {
+			return changeInputError(input, "The profile field is required.", changeFieldProfile)
 		}
 	default:
 		if input.Workspace == "" {

--- a/internal/service/mcp/change_tool.go
+++ b/internal/service/mcp/change_tool.go
@@ -211,7 +211,7 @@ func (svc *Service) changeToolImpl(ctx context.Context, input changeInput) (*mcp
 }
 
 func (svc *Service) changeDAG(ctx context.Context, input changeInput) (*mcpsdk.CallToolResult, map[string]any, error) {
-	validation, err := svc.validateDAGSpec(ctx, input.Name, input.Spec)
+	validation, dag, err := svc.validateDAGSpec(ctx, input.Name, input.Spec)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -231,7 +231,7 @@ func (svc *Service) changeDAG(ctx context.Context, input changeInput) (*mcpsdk.C
 	}
 	if validation.Valid && validation.Dag != nil {
 		output["dag"] = validation.Dag
-		if warnings := profileScheduleWarnings(validation.Dag.Schedule); len(warnings) > 0 {
+		if warnings := profileScheduleWarnings(dag.Schedule, dag.StopSchedule, dag.RestartSchedule); len(warnings) > 0 {
 			output["warnings"] = warnings
 		}
 	}
@@ -306,14 +306,13 @@ func (svc *Service) changeDAGProfile(ctx context.Context, input changeInput) (*m
 	return resultWithLinks("DAG profile change applied. The scheduler will use it on its next minute tick."), output, nil
 }
 
-func profileScheduleWarnings(schedule *[]daguapi.Schedule) []map[string]any {
-	if schedule == nil {
-		return nil
-	}
+func profileScheduleWarnings(schedules ...[]ir.Schedule) []map[string]any {
 	profiles := make(map[string]struct{})
-	for _, entry := range *schedule {
-		if entry.Profile != nil && *entry.Profile != "" {
-			profiles[string(*entry.Profile)] = struct{}{}
+	for _, schedule := range schedules {
+		for _, entry := range schedule {
+			if entry.Profile != "" {
+				profiles[entry.Profile] = struct{}{}
+			}
 		}
 	}
 	if len(profiles) == 0 {

--- a/internal/service/mcp/read_tool.go
+++ b/internal/service/mcp/read_tool.go
@@ -28,6 +28,7 @@ const (
 	readTargetDAGs       = "dags"
 	readTargetDAG        = "dag"
 	readTargetDAGSpec    = "dag_spec"
+	readTargetDAGProfile = "dag_profile"
 	readTargetDAGSearch  = "dag_search"
 	readTargetWiki       = "wiki"
 	readTargetWikiPage   = "wiki_page"
@@ -75,8 +76,8 @@ const (
 )
 
 type readInput struct {
-	Target    string `json:"target" jsonschema:"Read target: dags, dag, dag_spec, dag_search, wiki, wiki_page, wiki_search, runs, run, run_logs, step_log, or reference."`
-	Name      string `json:"name,omitempty" jsonschema:"DAG name for dag, dag_spec, run, run_logs, and step_log targets."`
+	Target    string `json:"target" jsonschema:"Read target: dags, dag, dag_spec, dag_profile, dag_search, wiki, wiki_page, wiki_search, runs, run, run_logs, step_log, or reference."`
+	Name      string `json:"name,omitempty" jsonschema:"DAG name for dag, dag_spec, dag_profile, run, run_logs, and step_log targets."`
 	DAGRunID  string `json:"dagRunId,omitempty" jsonschema:"DAG-run ID for run, run_logs, and step_log targets. The value latest is accepted where Dagu accepts it."`
 	SubRunID  string `json:"subRunId,omitempty" jsonschema:"Child DAG-run ID for run and step_log targets, addressed under the root run identified by name and dagRunId."`
 	StepName  string `json:"stepName,omitempty" jsonschema:"Step name for the step_log target."`
@@ -96,7 +97,7 @@ func readToolInputSchema() json.RawMessage {
 		"properties": {
 			"target": {
 				"type": "string",
-				"enum": ["references", "reference", "dags", "dag", "dag_spec", "dag_search", "wiki", "wiki_page", "wiki_search", "runs", "run", "run_logs", "step_log"],
+				"enum": ["references", "reference", "dags", "dag", "dag_spec", "dag_profile", "dag_search", "wiki", "wiki_page", "wiki_search", "runs", "run", "run_logs", "step_log"],
 				"description": "Read target."
 			},
 			"name": {
@@ -233,6 +234,14 @@ func (svc *Service) readToolImpl(ctx context.Context, input readInput) (*mcpsdk.
 				data = normalizeDAGSpec(raw, input.Name)
 			}
 		}
+	case readTargetDAGProfile:
+		if err = svc.requireAPI(); err == nil {
+			var selection frontendapi.DAGProfileSelection
+			selection, err = svc.api.GetDAGProfileSelection(ctx, input.Name)
+			if err == nil {
+				data = dagProfileData(input.Name, selection)
+			}
+		}
 	case readTargetDAGSearch:
 		if err = svc.requireAPI(); err == nil {
 			data, err = svc.searchDAGs(ctx, input.Workspace, input.Search, input.Cursor, input.Limit)
@@ -347,6 +356,21 @@ func readResultMessage(input readInput, data any) string {
 		return "Dagu read completed."
 	}
 	return "Dagu read completed.\n\n" + string(payload)
+}
+
+func dagProfileData(name string, selection frontendapi.DAGProfileSelection) map[string]any {
+	source := "none"
+	if selection.Configured != "" {
+		source = "dag"
+	} else if selection.Effective != "" {
+		source = "workspace"
+	}
+	return map[string]any{
+		"dagName":           name,
+		"configuredProfile": nullableString(selection.Configured),
+		"effectiveProfile":  nullableString(selection.Effective),
+		"source":            source,
+	}
 }
 
 func parseReadToolInput(raw json.RawMessage) (readInput, *readToolError) {
@@ -753,7 +777,7 @@ func validateTargetReadInput(input *readInput) *readToolError {
 		if err := validateReadQuery(input.Target, input.Query, false, ""); err != nil {
 			return err
 		}
-	case readTargetDAG:
+	case readTargetDAG, readTargetDAGProfile:
 		if input.Name == "" {
 			return missingTargetField(input.Target, readFieldName)
 		}

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -228,7 +228,7 @@ Errors:
 
 - invalid_tool_input for missing or incompatible fields, invalid paths, unknown mode, unknown type, or malformed input.
 - unauthorized when the caller cannot perform the requested write.
-- resource_not_found when a rename or delete source does not exist. A misspelled DAG name carries close existing names under details.didYouMean.
+- resource_not_found when a rename or delete source does not exist, or when set_dag_profile names a missing profile. A misspelled DAG name carries close existing names under details.didYouMean.
 - conflict when a DAG rename destination exists or a Wiki path conflicts with another file or directory.
 - internal_error for unexpected failures.`,
 		},

--- a/internal/service/mcp/reference.go
+++ b/internal/service/mcp/reference.go
@@ -13,7 +13,7 @@ import (
 const instructions = `Dagu exposes a compact MCP surface for DAG workflow operations.
 
 Use dagu_read for current state, Wiki pages, and trusted reference resources.
-Use dagu_change with mode=preview before mode=apply when editing DAG YAML or Wiki pages.
+Use dagu_change with mode=preview before mode=apply when editing DAG YAML, DAG default profiles, or Wiki pages.
 Use dagu_execute for start, enqueue, retry, and stop. retry and stop are actions inside dagu_execute.
 MCP Apps hosts can render run-related dagu_read and dagu_execute results in Dagu's interactive run inspector.
 To follow a run to completion, pass wait=true to dagu_execute, or read the returned dagu://runs/... resource, or subscribe to it to receive a resource update notification when the run reaches a terminal state.`
@@ -52,6 +52,8 @@ Authoring rules:
 - Use shell $NAME only when the target shell or process should read the variable at execution time.
 - Single-line run values are shell commands. Array-form run entries run one by one. Multi-line run values are scripts.
 - Dagu does not split shell syntax such as pipes, redirects, &&, or ; into separate Dagu commands.
+- DAG YAML does not contain the server-side default runtime profile. A schedule profile is an activation filter: the schedule runs only when it matches the DAG's effective default profile. Read it with dagu_read target=dag_profile. Set or clear it with dagu_change type=set_dag_profile or clear_dag_profile.
+- A DAG profile change is visible to the scheduler on its next minute tick. Time spent under a non-matching profile is not scheduler downtime, so catch-up does not replay those schedule slots.
 - Declared value outputs use a step-level outputs field and write records to DAGU_OUTPUT_FILE. Later steps read them as ${steps.step_id.outputs.name}.
 - type: build is for local workflows that transform stable regular-file inputs into reusable file outputs.
 - A build path step declares named inputs entries with path and at most one outputs entry with path. Only host command or shell steps without containers may declare build paths. Matching canonical producer-output and consumer-input paths infer dependencies, and each output path must have one producer.
@@ -80,14 +82,14 @@ Authoring rules:
 
 The server intentionally exposes three tools.
 
-- dagu_read: read DAGs, DAG specs, Wiki pages, DAG-runs, logs, list views, and reference resources.
-- dagu_change: preview or apply DAG YAML and workspace-aware Wiki changes.
+- dagu_read: read DAGs, DAG specs, DAG default profiles, Wiki pages, DAG-runs, logs, list views, and reference resources.
+- dagu_change: preview or apply DAG YAML, DAG default profile, and workspace-aware Wiki changes.
 - dagu_execute: start, enqueue, retry, or stop a DAG-run.
 
 Detailed tool references:
 
 - dagu://reference/read-tool: dagu_read inputs, targets, URI mode, query parameters, outputs, and errors.
-- dagu://reference/change-tool: dagu_change preview and apply contract for DAG YAML and Wiki changes.
+- dagu://reference/change-tool: dagu_change preview and apply contract for DAG YAML, DAG profiles, and Wiki changes.
 - dagu://reference/execute-tool: dagu_execute start, enqueue, retry, and stop contract.
 - dagu://reference/apps: interactive run inspector behavior for MCP Apps hosts.
 
@@ -124,8 +126,8 @@ Addressing:
 
 Fields:
 
-- target: required in target mode. Values are references, reference, dags, dag, dag_spec, dag_search, wiki, wiki_page, wiki_search, runs, run, run_logs, and step_log.
-- name: DAG name or reference topic name. Required for dag, dag_spec, run, run_logs, and step_log. Optional for reference; defaults to authoring. Forbidden for references, dags, and runs.
+- target: required in target mode. Values are references, reference, dags, dag, dag_spec, dag_profile, dag_search, wiki, wiki_page, wiki_search, runs, run, run_logs, and step_log.
+- name: DAG name or reference topic name. Required for dag, dag_spec, dag_profile, run, run_logs, and step_log. Optional for reference; defaults to authoring. Forbidden for references, dags, and runs.
 - dagRunId: required for run, run_logs, and step_log. Forbidden for other targets.
 - subRunId: optional child DAG-run ID for run and step_log. The name and dagRunId fields identify its root run.
 - stepName: required for step_log. Forbidden for other targets.
@@ -145,6 +147,7 @@ Targets:
 - dags lists DAGs.
 - dag reads DAG details.
 - dag_spec reads the current DAG YAML.
+- dag_profile reads the DAG's configured profile, effective profile, and source. The source is dag, workspace, or none.
 - dag_search searches DAG definition content and returns matching DAGs with line-level snippets. Continue with nextCursor while keeping search and workspace unchanged.
 - wiki lists the Wiki tree or a flat page list. In tree mode, page and perPage select direct children of the workspace or prefix, and each returned directory includes its descendants. In flat mode, they select individual pages.
 - wiki_page reads one Markdown Wiki page.
@@ -189,15 +192,16 @@ Errors:
 			description: "Detailed dagu_change input, output, and error reference.",
 			text: `# dagu_change reference
 
-Purpose: validate or apply DAG definition and Markdown Wiki changes.
+Purpose: validate or apply DAG definition, DAG default profile, and Markdown Wiki changes.
 
 Fields:
 
 - mode: preview or apply. Defaults to preview.
-- type: upsert_dag, rename_dag, delete_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. Defaults to upsert_dag.
+- type: upsert_dag, rename_dag, delete_dag, set_dag_profile, clear_dag_profile, upsert_wiki_page, rename_wiki_page, or delete_wiki_page. Defaults to upsert_dag.
 - name: DAG name. Required for DAG changes.
 - spec: complete DAG YAML. Required for upsert_dag.
 - newName: destination DAG name. Required for rename_dag.
+- profile: selectable runtime profile name. Required for set_dag_profile and forbidden for clear_dag_profile.
 - workspace: default or a named workspace. Required for Wiki changes; all is not allowed.
 - path: Wiki page or directory path without .md. Required for Wiki changes.
 - content: full Markdown content. Required for upsert_wiki_page; empty content is allowed.
@@ -207,6 +211,7 @@ Mode behavior:
 
 - preview validates the requested operation and reads the required current state without writing.
 - apply repeats validation and performs the requested operation through Dagu's API; Wiki operations remain workspace-aware.
+- set_dag_profile and clear_dag_profile change server-side DAG settings, not YAML. The scheduler reads the change on its next minute tick.
 - rename_dag changes the stored DAG identifier without rewriting the YAML name or historical runs.
 - delete_dag removes the DAG definition using Dagu's existing deletion behavior.
 - upsert_wiki_page creates a missing page or updates an existing page.
@@ -215,7 +220,8 @@ Mode behavior:
 Output:
 
 - Successful result text describes the previewed or applied change.
-- DAG output has dagName, valid, applied, and dagUri while the target exists. Upsert output also has errors; rename output has newDagName and newDagUri, and omits the stale source dagUri after apply.
+- DAG output has dagName, valid, and applied. Definition changes include dagUri while the target exists. Profile changes include profile, which is null when clearing.
+- A valid upsert with profile-scoped schedules includes warning code profile_scoped_schedule_requires_default and the sorted profile names. Set a matching effective default with set_dag_profile when the schedule should be active.
 - Wiki output has workspace, path, valid, applied, and wikiPageUri when the target is a page. docUri remains as a compatibility alias.
 
 Errors:

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -99,10 +99,11 @@ func NewServer(api *frontendapi.API) *mcpsdk.Server {
 
 type changeInput struct {
 	Mode      string `json:"mode,omitempty" jsonschema:"preview or apply. Defaults to preview."`
-	Type      string `json:"type,omitempty" jsonschema:"Change type: upsert_dag, rename_dag, delete_dag, upsert_wiki_page, rename_wiki_page, or delete_wiki_page."`
+	Type      string `json:"type,omitempty" jsonschema:"DAG definition, DAG profile, or Wiki change type."`
 	Name      string `json:"name,omitempty" jsonschema:"DAG name for DAG changes."`
 	NewName   string `json:"newName,omitempty" jsonschema:"Destination DAG name for rename_dag."`
 	Spec      string `json:"spec,omitempty" jsonschema:"DAG YAML specification for upsert_dag."`
+	Profile   string `json:"profile,omitempty" jsonschema:"Runtime profile name for set_dag_profile."`
 	Workspace string `json:"workspace,omitempty" jsonschema:"Wiki workspace for Wiki changes: default or a named workspace."`
 	Path      string `json:"path,omitempty" jsonschema:"Wiki page or directory path for Wiki changes."`
 	Content   string `json:"content,omitempty" jsonschema:"Markdown content for upsert_wiki_page."`
@@ -117,7 +118,7 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 		Meta:        runInspectorToolMeta(),
 		Name:        toolRead,
 		Title:       "Read Dagu state",
-		Description: "Read DAG specs, workspace-aware Wiki pages, DAG-run details, logs, list views, and Dagu MCP reference resources.",
+		Description: "Read DAG specs and default profiles, workspace-aware Wiki pages, DAG-run details, logs, list views, and Dagu MCP reference resources.",
 		InputSchema: readToolInputSchema(),
 		Annotations: &mcpsdk.ToolAnnotations{
 			OpenWorldHint: falsePtr,
@@ -129,7 +130,7 @@ func registerTools(server *mcpsdk.Server, svc *Service) {
 	server.AddTool(&mcpsdk.Tool{
 		Name:        toolChange,
 		Title:       "Preview or apply Dagu changes",
-		Description: "Validate and optionally apply DAG definition or Markdown Wiki changes. Wiki changes are workspace-aware. Use mode=preview before mode=apply unless the user explicitly asked to write immediately.",
+		Description: "Validate and optionally apply DAG definitions, DAG default profiles, or Markdown Wiki changes. Wiki changes are workspace-aware. Use mode=preview before mode=apply unless the user explicitly asked to write immediately.",
 		InputSchema: changeToolInputSchema(),
 		Annotations: &mcpsdk.ToolAnnotations{
 			DestructiveHint: truePtr,
@@ -176,7 +177,7 @@ func registerResources(server *mcpsdk.Server, svc *Service) {
 		URITemplate: "dagu://dags/{name}/spec",
 		Name:        "dag_spec",
 		Title:       "DAG spec",
-		Description: "Current YAML spec for a DAG.",
+		Description: "Current YAML spec for a DAG. Server-side settings such as the default runtime profile are separate; read target=dag_profile.",
 		MIMEType:    resourceMIMEYAML,
 	}, svc.readResource)
 

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -375,23 +375,8 @@ func (svc *Service) searchDAGs(ctx context.Context, workspace, search, cursor st
 	return output, nil
 }
 
-func (svc *Service) validateDAGSpec(ctx context.Context, name, spec string) (*daguapi.ValidateDAGSpec200JSONResponse, error) {
-	body := &daguapi.ValidateDAGSpecJSONRequestBody{
-		Name: &name,
-		Spec: spec,
-	}
-	resp, err := svc.api.ValidateDAGSpec(ctx, daguapi.ValidateDAGSpecRequestObject{Body: body})
-	if err != nil {
-		return nil, err
-	}
-	switch r := resp.(type) {
-	case *daguapi.ValidateDAGSpec200JSONResponse:
-		return r, nil
-	case daguapi.ValidateDAGSpec200JSONResponse:
-		return &r, nil
-	default:
-		return nil, fmt.Errorf("unexpected validate DAG spec response %T", resp)
-	}
+func (svc *Service) validateDAGSpec(ctx context.Context, name, spec string) (*daguapi.ValidateDAGSpec200JSONResponse, *ir.DAG, error) {
+	return svc.api.ValidateDAGSpecData(ctx, name, spec)
 }
 
 func (svc *Service) upsertDAG(ctx context.Context, name, spec string) (bool, error) {

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -16,9 +16,13 @@ import (
 
 	daguapi "github.com/dagucloud/dagu/v2/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/dagsettings"
 	"github.com/dagucloud/dagu/v2/internal/persis"
 	persisfile "github.com/dagucloud/dagu/v2/internal/persis/file"
 	filedag "github.com/dagucloud/dagu/v2/internal/persis/file/dag"
+	persiststore "github.com/dagucloud/dagu/v2/internal/persis/store"
+	persisttestutil "github.com/dagucloud/dagu/v2/internal/persis/testutil"
+	"github.com/dagucloud/dagu/v2/internal/profile"
 	"github.com/dagucloud/dagu/v2/internal/runtime"
 	frontendapi "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
 	"github.com/dagucloud/dagu/v2/internal/testutil"
@@ -141,6 +145,34 @@ func TestDAGChangeInputValidation(t *testing.T) {
 			input: `{"type":"delete_dag","name":"old"}`,
 		},
 		{
+			name:  "set profile",
+			input: `{"type":"set_dag_profile","name":"old","profile":"fudosan"}`,
+		},
+		{
+			name:  "clear profile",
+			input: `{"type":"clear_dag_profile","name":"old"}`,
+		},
+		{
+			name:      "set profile requires profile",
+			input:     `{"type":"set_dag_profile","name":"old"}`,
+			wantField: changeFieldProfile,
+		},
+		{
+			name:      "set profile rejects blank profile",
+			input:     `{"type":"set_dag_profile","name":"old","profile":" "}`,
+			wantField: changeFieldProfile,
+		},
+		{
+			name:      "clear profile rejects profile",
+			input:     `{"type":"clear_dag_profile","name":"old","profile":"fudosan"}`,
+			wantField: changeFieldProfile,
+		},
+		{
+			name:      "set profile rejects spec",
+			input:     `{"type":"set_dag_profile","name":"old","profile":"fudosan","spec":"steps: []"}`,
+			wantField: changeFieldSpec,
+		},
+		{
 			name:      "rename requires destination",
 			input:     `{"type":"rename_dag","name":"old"}`,
 			wantField: changeFieldNewName,
@@ -180,6 +212,178 @@ func TestDAGChangeInputValidation(t *testing.T) {
 			require.Equal(t, test.wantField, changeErr.Field)
 		})
 	}
+}
+
+func TestDAGProfileChanges(t *testing.T) {
+	ctx := context.Background()
+	dagStore := testutil.NewFileDAGRepository(t.TempDir(), filedag.WithSkipExamples(true))
+	require.NoError(t, dagStore.Create(ctx, "profile-dag", []byte("name: profile-dag\nsteps: []\n")))
+	backend := persisttestutil.NewMemoryBackend()
+	settingsStore, err := persiststore.NewDAGSettingsStore(backend.Collection(persis.CollectionDAGSettings))
+	require.NoError(t, err)
+	profileStore, err := persiststore.NewProfileStore(backend.Collection(persis.CollectionProfiles))
+	require.NoError(t, err)
+	runtimeProfile, err := profile.New(profile.CreateInput{Name: "fudosan"}, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, profileStore.Create(ctx, runtimeProfile))
+
+	api := frontendapi.New(
+		dagStore,
+		nil,
+		nil,
+		nil,
+		runtime.Manager{},
+		&config.Config{},
+		nil,
+		nil,
+		prometheus.NewRegistry(),
+		nil,
+		frontendapi.WithDAGSettingsStore(settingsStore),
+		frontendapi.WithProfileStore(profileStore),
+	)
+	session := connectTestClient(t, ctx, NewServer(api))
+	missing := callTool(t, ctx, session, toolChange, changeInput{
+		Type:    changeTypeSetDAGProfile,
+		Name:    "profile-dag",
+		Profile: "missing",
+	})
+	require.True(t, missing.IsError)
+	require.Equal(t, changeErrorResourceNotFound, structuredMap(t, missing)["code"])
+
+	set := changeInput{
+		Type:    changeTypeSetDAGProfile,
+		Name:    "profile-dag",
+		Profile: "fudosan",
+	}
+	preview := callTool(t, ctx, session, toolChange, set)
+	require.False(t, preview.IsError)
+	require.Equal(t, false, structuredMap(t, preview)["applied"])
+	_, err = settingsStore.Get(ctx, set.Name)
+	require.ErrorIs(t, err, dagsettings.ErrNotFound)
+
+	set.Mode = changeModeApply
+	applied := callTool(t, ctx, session, toolChange, set)
+	require.False(t, applied.IsError)
+	require.Equal(t, true, structuredMap(t, applied)["applied"])
+	settings, err := settingsStore.Get(ctx, set.Name)
+	require.NoError(t, err)
+	require.Equal(t, set.Profile, settings.Profile)
+
+	read := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGProfile, Name: set.Name})
+	require.False(t, read.IsError)
+	data, ok := structuredMap(t, read)["data"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"dagName":           set.Name,
+		"configuredProfile": set.Profile,
+		"effectiveProfile":  set.Profile,
+		"source":            "dag",
+	}, data)
+
+	clear := changeInput{Type: changeTypeClearDAGProfile, Name: set.Name}
+	preview = callTool(t, ctx, session, toolChange, clear)
+	require.False(t, preview.IsError)
+	settings, err = settingsStore.Get(ctx, set.Name)
+	require.NoError(t, err)
+	require.Equal(t, set.Profile, settings.Profile)
+
+	clear.Mode = changeModeApply
+	applied = callTool(t, ctx, session, toolChange, clear)
+	require.False(t, applied.IsError)
+	_, err = settingsStore.Get(ctx, set.Name)
+	require.ErrorIs(t, err, dagsettings.ErrNotFound)
+
+	read = callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGProfile, Name: set.Name})
+	require.False(t, read.IsError)
+	data, ok = structuredMap(t, read)["data"].(map[string]any)
+	require.True(t, ok)
+	require.Nil(t, data["configuredProfile"])
+	require.Nil(t, data["effectiveProfile"])
+	require.Equal(t, "none", data["source"])
+}
+
+func TestReadDAGProfileUsesWorkspaceDefault(t *testing.T) {
+	ctx := context.Background()
+	dagStore := testutil.NewFileDAGRepository(t.TempDir(), filedag.WithSkipExamples(true))
+	require.NoError(t, dagStore.Create(ctx, "workspace-dag", []byte("name: workspace-dag\nlabels: [workspace=ops]\nsteps: []\n")))
+	backend := persisttestutil.NewMemoryBackend()
+	settingsStore, err := persiststore.NewDAGSettingsStore(backend.Collection(persis.CollectionDAGSettings))
+	require.NoError(t, err)
+	profileStore, err := persiststore.NewProfileStore(backend.Collection(persis.CollectionProfiles))
+	require.NoError(t, err)
+	runtimeProfile, err := profile.New(profile.CreateInput{Name: "fudosan"}, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, profileStore.Create(ctx, runtimeProfile))
+	ref, err := profile.WorkspaceInheritedRef("ops")
+	require.NoError(t, err)
+	defaults, err := profile.NewInherited(ref, profile.InheritedCreateInput{}, time.Now())
+	require.NoError(t, err)
+	defaults.DefaultProfile = runtimeProfile.Name
+	require.NoError(t, profileStore.Create(ctx, defaults))
+
+	api := frontendapi.New(
+		dagStore,
+		nil,
+		nil,
+		nil,
+		runtime.Manager{},
+		&config.Config{},
+		nil,
+		nil,
+		prometheus.NewRegistry(),
+		nil,
+		frontendapi.WithDAGSettingsStore(settingsStore),
+		frontendapi.WithProfileStore(profileStore),
+	)
+	session := connectTestClient(t, ctx, NewServer(api))
+
+	result := callTool(t, ctx, session, toolRead, readInput{Target: readTargetDAGProfile, Name: "workspace-dag"})
+	require.False(t, result.IsError)
+	data, ok := structuredMap(t, result)["data"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "workspace-dag", data["dagName"])
+	require.Nil(t, data["configuredProfile"])
+	require.Equal(t, "fudosan", data["effectiveProfile"])
+	require.Equal(t, "workspace", data["source"])
+}
+
+func TestProfileScopedScheduleWarning(t *testing.T) {
+	ctx := context.Background()
+	dagStore := testutil.NewFileDAGRepository(t.TempDir(), filedag.WithSkipExamples(true))
+	api := frontendapi.New(dagStore, nil, nil, nil, runtime.Manager{}, &config.Config{}, nil, nil, prometheus.NewRegistry(), nil)
+	session := connectTestClient(t, ctx, NewServer(api))
+
+	result := callTool(t, ctx, session, toolChange, changeInput{
+		Type: changeTypeUpsertDAG,
+		Name: "scheduled-dag",
+		Spec: `name: scheduled-dag
+schedule:
+  - expression: "0 * * * *"
+    profile: zeta
+  - expression: "30 * * * *"
+    profile: alpha
+  - expression: "45 * * * *"
+    profile: zeta
+steps:
+  - run: echo ok
+`,
+	})
+	require.False(t, result.IsError)
+	warnings, ok := structuredMap(t, result)["warnings"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{map[string]any{
+		"code":     "profile_scoped_schedule_requires_default",
+		"profiles": []any{"alpha", "zeta"},
+		"message":  "Profile-scoped schedules require a matching effective DAG default profile.",
+	}}, warnings)
+
+	result = callTool(t, ctx, session, toolChange, changeInput{
+		Type: changeTypeUpsertDAG,
+		Name: "scheduled-dag",
+		Spec: "name: scheduled-dag\nschedule: [\"0 * * * *\"]\nsteps:\n  - run: echo ok\n",
+	})
+	require.False(t, result.IsError)
+	require.NotContains(t, structuredMap(t, result), "warnings")
 }
 
 func TestRetryRequiresStepNameForIncludeDownstream(t *testing.T) {
@@ -514,6 +718,8 @@ func TestServerExposesReferenceResourcesAndPrompts(t *testing.T) {
 	require.Contains(t, authoring.Contents[0].Text, "type: build")
 	require.Contains(t, authoring.Contents[0].Text, "${outputs.name}")
 	require.Contains(t, authoring.Contents[0].Text, "Build workflows are local-only")
+	require.Contains(t, authoring.Contents[0].Text, "schedule profile is an activation filter")
+	require.Contains(t, authoring.Contents[0].Text, "target=dag_profile")
 
 	prompts, err := session.ListPrompts(ctx, nil)
 	require.NoError(t, err)

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -358,12 +358,12 @@ func TestProfileScopedScheduleWarning(t *testing.T) {
 		Name: "scheduled-dag",
 		Spec: `name: scheduled-dag
 schedule:
-  - expression: "0 * * * *"
-    profile: zeta
-  - expression: "30 * * * *"
-    profile: alpha
-  - expression: "45 * * * *"
-    profile: zeta
+  stop:
+    - expression: "15 * * * *"
+      profile: zeta
+  restart:
+    - expression: "45 * * * *"
+      profile: alpha
 steps:
   - run: echo ok
 `,


### PR DESCRIPTION
## Summary

- expose configured and effective DAG profiles through `dagu_read`
- add preview/apply operations to set or clear a DAG profile
- warn when an upsert contains profile-scoped schedules
- document profile matching and catch-up behavior for MCP agents

## Testing

- `make test`
- native and Windows `golangci-lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP support for DAG runtime profiles so agents can inspect and change the server-side default that profile-scoped schedules rely on. Previously MCP could neither read nor write this setting; now `dagu_read target=dag_profile` exposes it and `dagu_change` can set or clear it, with upserts warning when schedules are profile-scoped. Profile changes take effect on the scheduler's next minute tick, and time under a non-matching profile is not replayed by catch-up.

**New Features**
- `dagu_read target=dag_profile` returns the configured and effective profile plus its source.
- `dagu_change` gains `set_dag_profile` and `clear_dag_profile` types with preview/apply support; setting a missing profile fails with `resource_not_found`.
- Upserts with profile-scoped start, stop, or restart schedules return a `profile_scoped_schedule_requires_default` warning.
- Profile set/clear operations now include the DAG name and profile in audit metadata.

<sup>Written for commit 8afdbb22af35a264ff19971682cfb836e7ee7137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for assigning, changing, and clearing a DAG’s default runtime profile.
  - Added profile inspection showing both the configured and currently effective profile.
  - Added profile management and lookup through available tools and workflows.
  - Added validation for profile availability, permissions, visibility, and runnable status.
  - Added warnings for schedules whose profiles do not match the effective DAG default.

- **Documentation**
  - Updated guidance for reading and managing DAG profiles, including preview/apply behavior and scheduler timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->