### PR TITLE
fix: refresh DAG list after scheduler changes

### DIFF
--- a/internal/persis/file/backend.go
+++ b/internal/persis/file/backend.go
@@ -28,6 +28,13 @@ type collectionSpec struct {
 
 var _ persis.Backend = (*Backend)(nil)
 
+const schedulerStateDirName = "scheduler"
+
+// SchedulerStateDir returns the file-backend directory for scheduler state.
+func SchedulerStateDir(paths config.PathsConfig) string {
+	return filepath.Join(paths.DataDir, schedulerStateDirName)
+}
+
 // NewBackend creates a file backend from the configured persistence paths.
 // It does not access the filesystem; collections create directories lazily.
 func NewBackend(paths config.PathsConfig) *Backend {
@@ -51,7 +58,7 @@ func NewBackend(paths config.PathsConfig) *Backend {
 			persis.CollectionProfiles:         {dir: filepath.Join(paths.DataDir, "profiles"), indented: true},
 			persis.CollectionQueue:            {dir: paths.QueueDir},
 			persis.CollectionRemoteNodes:      {dir: paths.RemoteNodesDir, indented: true},
-			persis.CollectionSchedulerState:   {dir: filepath.Join(paths.DataDir, "scheduler"), indented: true},
+			persis.CollectionSchedulerState:   {dir: SchedulerStateDir(paths), indented: true},
 			persis.CollectionSecrets:          {dir: filepath.Join(paths.DataDir, "secrets"), indented: true},
 			persis.CollectionUpgradeCheck:     {dir: filepath.Join(paths.DataDir, "upgrade"), indented: true},
 			persis.CollectionUsers:            {dir: paths.UsersDir, indented: true},

--- a/internal/service/frontend/server.go
+++ b/internal/service/frontend/server.go
@@ -1302,6 +1302,8 @@ func (srv *Server) wakeMultiplexedTopicsForAppEvent(event sse.AppEvent) {
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAG)
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGHistory)
+	case sse.AppEventTypeScheduler:
+		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeDAGsList)
 	case sse.AppEventTypeQueue:
 		srv.sseMultiplexer.WakeTopicType(sse.TopicTypeQueues)
 		if event.QueueName != "" {

--- a/internal/service/frontend/server_test.go
+++ b/internal/service/frontend/server_test.go
@@ -24,6 +24,7 @@ import (
 
 	authmodel "github.com/dagucloud/dagu/v2/internal/auth"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/eventstore"
 	authservice "github.com/dagucloud/dagu/v2/internal/service/auth"
 	apiv1 "github.com/dagucloud/dagu/v2/internal/service/frontend/api/v1"
@@ -288,6 +289,93 @@ steps:
 
 	require.Eventually(t, func() bool {
 		return fetches.Load() >= 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+// TestSchedulerStateWake verifies durable scheduler projection changes refresh
+// DAG-list SSE while checkpoint-only writes stay silent.
+func TestSchedulerStateWake(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	schedulerDir := filepath.Join(dataDir, "scheduler")
+	require.NoError(t, os.MkdirAll(schedulerDir, 0750))
+
+	srv := &Server{
+		config: &config.Config{
+			Paths: config.PathsConfig{
+				DataDir: dataDir,
+			},
+		},
+		apiV1:        &apiv1.API{},
+		eventService: eventstore.New(nil),
+	}
+
+	router := chi.NewMux()
+	srv.setupSSERoute(testContext(t), router, "/api/v1")
+	require.NotNil(t, srv.appStream)
+	require.NotNil(t, srv.sseMultiplexer)
+	t.Cleanup(func() {
+		if srv.appStream != nil {
+			srv.appStream.Shutdown()
+		}
+		if srv.sseMultiplexer != nil {
+			srv.sseMultiplexer.Shutdown()
+		}
+	})
+
+	var fetches atomic.Int64
+	srv.sseMultiplexer.RegisterFetcher(sse.TopicTypeDAGsList, func(context.Context, string) (any, error) {
+		return map[string]any{
+			"fetches": fetches.Add(1),
+		}, nil
+	})
+
+	handler := sse.NewMultiplexHandler(srv.sseMultiplexer, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/events/stream?topic="+url.QueryEscape("dagslist:page=1&perPage=100"),
+			nil,
+		).WithContext(ctx)
+		handler.HandleStream(httptest.NewRecorder(), req)
+	}()
+
+	require.Eventually(t, func() bool {
+		return fetches.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, fileutil.WriteFileAtomic(
+		filepath.Join(schedulerDir, "checkpoint.json"),
+		[]byte(`{"lastTick":"2026-09-01T00:00:00Z"}`),
+		0600,
+	))
+	require.Never(t, func() bool {
+		return fetches.Load() > 1
+	}, 500*time.Millisecond, 20*time.Millisecond)
+
+	require.NoError(t, fileutil.WriteFileAtomic(
+		filepath.Join(schedulerDir, "state.json"),
+		[]byte(`{"records":[]}`),
+		0600,
+	))
+	require.Eventually(t, func() bool {
+		return fetches.Load() == 2
 	}, 3*time.Second, 20*time.Millisecond)
 
 	cancel()

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	persisfile "github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/service/scheduler/filenotify"
 	"github.com/fsnotify/fsnotify"
 )
@@ -22,7 +23,6 @@ const (
 	defaultAppStreamBufferSize = 32
 	appStreamDebounceInterval  = 200 * time.Millisecond
 	wikiPollingInterval        = 30 * time.Second
-	schedulerStateDirName      = "scheduler"
 	schedulerStateFileName     = "state.json"
 )
 
@@ -663,7 +663,7 @@ func NewAppStreamService(cfg AppStreamConfig) (*AppStreamService, error) {
 	}
 	if cfg.Paths.DataDir != "" {
 		service.watchers = append(service.watchers, newDirectoryWatcher(
-			filepath.Join(cfg.Paths.DataDir, schedulerStateDirName),
+			persisfile.SchedulerStateDir(cfg.Paths),
 			true,
 			service.handleSchedulerStateEvent,
 			service.publishReset,

--- a/internal/service/frontend/sse/app_stream.go
+++ b/internal/service/frontend/sse/app_stream.go
@@ -22,6 +22,8 @@ const (
 	defaultAppStreamBufferSize = 32
 	appStreamDebounceInterval  = 200 * time.Millisecond
 	wikiPollingInterval        = 30 * time.Second
+	schedulerStateDirName      = "scheduler"
+	schedulerStateFileName     = "state.json"
 )
 
 type AppEventType string
@@ -30,6 +32,7 @@ const (
 	AppEventTypeReset      AppEventType = "reset"
 	AppEventTypeDAGChanged AppEventType = "dag.changed"
 	AppEventTypeQueue      AppEventType = "queue.changed"
+	AppEventTypeScheduler  AppEventType = "scheduler.state.changed"
 	AppEventTypeWiki       AppEventType = "wiki.page.changed"
 )
 
@@ -658,6 +661,14 @@ func NewAppStreamService(cfg AppStreamConfig) (*AppStreamService, error) {
 			service.publishReset,
 		))
 	}
+	if cfg.Paths.DataDir != "" {
+		service.watchers = append(service.watchers, newDirectoryWatcher(
+			filepath.Join(cfg.Paths.DataDir, schedulerStateDirName),
+			true,
+			service.handleSchedulerStateEvent,
+			service.publishReset,
+		))
+	}
 	service.watchers = append(service.watchers,
 		newWikiDirectoryWatcher(cfg.Paths.WikiDir, true, service.handleWikiPageEvent, service.publishReset),
 		newDirectoryWatcher(cfg.Paths.SuspendFlagsDir, true, service.handleSuspendFlagEvent, service.publishReset),
@@ -732,6 +743,16 @@ func (s *AppStreamService) handleSuspendFlagEvent(_, relPath string, op fsnotify
 	s.coalescer.Enqueue(AppEvent{
 		Type:   AppEventTypeDAGChanged,
 		Reason: "suspend_flag_" + fileEventReason(op),
+	})
+}
+
+func (s *AppStreamService) handleSchedulerStateEvent(_, relPath string, op fsnotify.Op) {
+	if filepath.ToSlash(relPath) != schedulerStateFileName {
+		return
+	}
+	s.coalescer.Enqueue(AppEvent{
+		Type:   AppEventTypeScheduler,
+		Reason: fileEventReason(op),
 	})
 }
 

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dagucloud/dagu/v2/internal/notification"
 	"github.com/dagucloud/dagu/v2/internal/opencodehost"
 	"github.com/dagucloud/dagu/v2/internal/persis"
+	persisfile "github.com/dagucloud/dagu/v2/internal/persis/file"
 	"github.com/dagucloud/dagu/v2/internal/proc"
 	"github.com/dagucloud/dagu/v2/internal/profile"
 	queuedomain "github.com/dagucloud/dagu/v2/internal/queue"
@@ -204,7 +205,7 @@ func newScheduler(
 		RetryInterval:  cfg.Scheduler.LockRetryInterval,
 		OnWait:         hooks.onLockWait,
 	}
-	lockDir := filepath.Join(cfg.Paths.DataDir, "scheduler", "locks")
+	lockDir := filepath.Join(persisfile.SchedulerStateDir(cfg.Paths), "locks")
 	dirLock := dirlock.New(lockDir, lockOpts)
 	subCmdBuilder := launcher.NewSubCmdBuilder(cfg)
 	workspaceBaseConfigDir := workspace.BaseConfigDir(cfg.Paths.DAGsDir)


### PR DESCRIPTION
## Summary

- watch durable scheduler state changes
- refresh only the DAG-list SSE projection
- ignore checkpoint and atomic temporary file churn

## Root cause

The DAG list switches to on-demand SSE refresh while scheduler next-run state is written outside the existing DAG-file invalidation path. The browser therefore retained a stale projection.

## Testing

- regression failed before the fix and passed afterward
- go test -race ./internal/service/frontend/sse ./internal/service/frontend ./internal/persis/store
- go test ./internal/service/frontend -run TestSchedulerStateWake -count=10
- golangci-lint on native and Windows targets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DAG list not refreshing after scheduler next-run state changes, so the browser no longer shows a stale projection.

- Watches the scheduler data directory for `state.json` writes only, ignoring checkpoint and atomic temporary file churn.
- Wakes only the DAG-list SSE topic on scheduler state changes, leaving other topics untouched.
- Uses one shared scheduler-state path helper so the SSE watcher and scheduler lock directory stay aligned with the backend layout.

<sup>Written for commit 61191ddc64b5b4b317d907702642866e95f0eb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DAG lists now refresh automatically when scheduler state changes.
  - Updates are detected promptly without requiring a manual page reload.

- **Bug Fixes**
  - Improved refresh behavior so meaningful scheduler state changes are reflected in the DAG list.
  - Routine checkpoint updates no longer trigger unnecessary refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->