### PR TITLE
test: add spec and conformance coverage for log.write

### DIFF
--- a/conformance/spec041_log_write/log_write_test.go
+++ b/conformance/spec041_log_write/log_write_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec041_log_write holds black-box conformance tests for
+// Spec 041: Log Write Action.
+package spec041_log_write_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches the per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// Captures through the line ending rather than \S+, so a project path
+// containing spaces isn't truncated.
+var stdoutLogPattern = regexp.MustCompile(`stdout: ([^\r\n]+)`)
+
+// stepStdout reads the exact bytes a step wrote to stdout, by locating its
+// captured-output log file from dagu start's own tree render and reading it
+// directly. Routing the message through a step output and a second step's
+// run: command instead would not prove this: capturing an output strips a
+// trailing newline, and re-interpolating a captured value containing a
+// newline into another step's command text escapes it to a literal \n --
+// both would mask whether log.write itself appended an extra newline.
+func stepStdout(t *testing.T, daguStartOutput string) string {
+	t.Helper()
+
+	match := stdoutLogPattern.FindStringSubmatch(daguStartOutput)
+	require.Lenf(t, match, 2, "expected a stdout log path in output:\n%s", daguStartOutput)
+	data, err := os.ReadFile(match[1]) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}
+
+// TestLogWriteRuntime proves log.write's message and trailing-newline
+// contract: a message resolved with the standard value substitution, with
+// exactly one newline appended when it lacks one, and no extra newline when
+// it already ends with one.
+func TestLogWriteRuntime(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		file    string
+		content string
+	}{
+		{
+			name:    "resolved message gets exactly one trailing newline",
+			file:    "basic.yaml",
+			content: "hello, world\n",
+		},
+		{
+			name:    "message already ending in a newline is not given a second one",
+			file:    "trailing_newline_preserved.yaml",
+			content: "line one\nline two\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("start", tc.file)
+			result.ExpectExitCode(0)
+			require.Equal(t, tc.content, stepStdout(t, result.Stdout()))
+		})
+	}
+}
+
+// TestLogWriteValidation proves the errors DAG-build-time validation
+// rejects before the DAG ever runs.
+func TestLogWriteValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		file        string
+		stderrParts []string
+	}{
+		{
+			name:        "missing with.message",
+			file:        "missing_message.yaml",
+			stderrParts: []string{"with.message is required"},
+		},
+		{
+			name:        "with.message is not a string",
+			file:        "non_string_message.yaml",
+			stderrParts: []string{"with.message must be a non-empty string"},
+		},
+		{
+			name:        "with.message is an empty string",
+			file:        "empty_message.yaml",
+			stderrParts: []string{"with.message must be a non-empty string"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("start", tc.file)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.stderrParts...)
+		})
+	}
+}

--- a/conformance/spec041_log_write/testdata/basic.yaml
+++ b/conformance/spec041_log_write/testdata/basic.yaml
@@ -1,0 +1,6 @@
+env:
+  - GREETING: hello
+steps:
+  - action: log.write
+    with:
+      message: "${GREETING}, world"

--- a/conformance/spec041_log_write/testdata/empty_message.yaml
+++ b/conformance/spec041_log_write/testdata/empty_message.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: log.write
+    with:
+      message: ""

--- a/conformance/spec041_log_write/testdata/missing_message.yaml
+++ b/conformance/spec041_log_write/testdata/missing_message.yaml
@@ -1,0 +1,3 @@
+steps:
+  - action: log.write
+    with: {}

--- a/conformance/spec041_log_write/testdata/non_string_message.yaml
+++ b/conformance/spec041_log_write/testdata/non_string_message.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: log.write
+    with:
+      message: 123

--- a/conformance/spec041_log_write/testdata/trailing_newline_preserved.yaml
+++ b/conformance/spec041_log_write/testdata/trailing_newline_preserved.yaml
@@ -1,0 +1,6 @@
+steps:
+  - action: log.write
+    with:
+      message: |
+        line one
+        line two

--- a/specs/041-log-write.md
+++ b/specs/041-log-write.md
@@ -1,0 +1,101 @@
+# Spec: Log Write Action
+
+## Status
+
+Implemented.
+
+This spec defines conformance behavior for the built-in `log.write` action.
+
+## Scope
+
+This spec defines `log.write`, which writes a message to the step's stdout.
+
+This spec covers:
+
+- the `with.message` field
+- how the message is written, including trailing-newline handling
+- that `log.write`'s output participates in the standard step output
+  contract like any other step
+- validation errors
+
+This spec does not define:
+
+- value resolution syntax itself (see
+  [Spec 003: Value Resolution and Field Evaluation](003-value-resolution.md))
+- signal delivery and abort behavior beyond what already applies to any step
+  (see [Spec 017: Built-In Run Context](017-built-in-run-context.md))
+
+## Goal
+
+Workflow authors emit a message into a step's own output without shelling
+out to `echo` through a command executor.
+
+## Behavior
+
+### Message
+
+`with.message` (required) is a non-empty string, resolved the same way any
+other step field is resolved (see Spec 003) before it is written.
+
+### Writing and trailing newline
+
+The resolved message is written to the step's stdout as-is. If the message
+does not already end with a newline, `log.write` appends exactly one. A
+message that already ends with a newline (for example, a YAML block-scalar
+value with more than one line) is written unchanged, with no extra newline
+added.
+
+### Output capture
+
+`log.write`'s stdout is captured the same way as any other step: an
+`output` field on the step stores it as a step output, usable by later
+steps.
+
+## Errors
+
+The following are rejected by DAG-build-time validation, before the DAG
+starts running. Each condition's error text is normative and must contain
+the quoted wording below (exact surrounding phrasing may vary):
+
+- `with.message` is missing: `"with.message is required"`.
+- `with.message` is present but is not a string (for example, a bare
+  number): `"with.message must be a non-empty string"`.
+- `with.message` is an empty string: `"with.message must be a non-empty
+  string"`.
+
+`log.write` has no runtime error behavior of its own beyond what any step
+can fail with (signal delivery, cancellation; see
+[Spec 017: Built-In Run Context](017-built-in-run-context.md)).
+
+## Related Specs
+
+- Value resolution: [Spec 003: Value Resolution and Field Evaluation](003-value-resolution.md)
+- Step outputs: [Spec 012: Step Outputs](012-step-outputs.md)
+- Run context: [Spec 017: Built-In Run Context](017-built-in-run-context.md)
+
+## Examples
+
+Write a resolved message:
+
+```yaml
+env:
+  - GREETING: hello
+steps:
+  - action: log.write
+    with:
+      message: "${GREETING}, world"
+```
+
+Capture the message as a step output:
+
+```yaml
+steps:
+  - name: say
+    action: log.write
+    with:
+      message: "captured"
+    output: MSG
+  - name: use
+    depends: say
+    run: echo "${MSG}"
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -40,6 +40,7 @@ It must not be treated as product behavior until implementation catches up.
 | [035: File Dependencies](035-file-dependencies.md) | Implemented |
 | [036: MCP Execute Tool](036-mcp-execute-tool.md) | Implemented |
 | [039: Wait Actions](039-wait.md) | Implemented |
+| [041: Log Write Action](041-log-write.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

Document log.write's message and trailing-newline contract as Spec 041, then add table-driven black-box tests proving it and the validation errors on the real binary. Verify the newline rule via the step's raw captured stdout log file rather than round-tripping through output capture, which strips and escapes newlines in ways that would mask the behavior under test.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documented the `log.write` action for writing messages to step output.
  * Messages support value substitution and must be non-empty strings.
  * Output includes exactly one trailing newline when needed, while preserving existing trailing newlines.
  * Added the Log Write Action to the conformance status as implemented.

* **Tests**
  * Added conformance coverage for valid messages, substitutions, newline handling, and invalid message values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->