### PR TITLE
fix(ui): restore semantic color utilities

### DIFF
--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded border border-border-bold bg-surface disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-text data-[state=checked]:text-bg",
+      "peer h-4 w-4 shrink-0 rounded border border-border-strong bg-surface disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=checked]:text-background",
       className
     )}
     {...props}

--- a/ui/src/features/dags/components/dag-details/WebhookTab.tsx
+++ b/ui/src/features/dags/components/dag-details/WebhookTab.tsx
@@ -555,7 +555,7 @@ function WebhookTab({ fileName }: WebhookTabProps) {
         </CardHeader>
         <CardContent className="px-4 pb-3 pt-3 space-y-3">
           <div className="p-3 bg-warning/10 border border-warning/20 rounded-md">
-            <p className="text-sm text-warning-foreground">{secretWarning}</p>
+            <p className="text-sm text-foreground">{secretWarning}</p>
           </div>
           <div className="flex items-center gap-2">
             <code className="flex-1 p-2 text-xs bg-muted rounded-md break-all font-mono">

--- a/ui/src/features/dags/components/dag-details/notifications/NotificationSections.tsx
+++ b/ui/src/features/dags/components/dag-details/notifications/NotificationSections.tsx
@@ -615,7 +615,7 @@ export function NotificationOverviewCard({
               runs. Send test verifies delivery now.
             </div>
             {!hasDAGDestinations && (
-              <div className="rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-sm text-warning-foreground">
+              <div className="rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-sm text-foreground">
                 This DAG override has no destinations. Inherited rules are not
                 used while the override exists.
               </div>

--- a/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpec.tsx
@@ -535,7 +535,7 @@ function DAGSpec({ fileName, localDags, editorHints }: Props) {
             {errors.map((e, i) => (
               <div
                 key={i}
-                className="p-3 bg-danger-highlight rounded-md text-danger font-mono text-sm break-words flex items-start gap-2"
+                className="p-3 bg-destructive/10 rounded-md text-destructive font-mono text-sm break-words flex items-start gap-2"
               >
                 <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                 {e}

--- a/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGSpecReadOnly.tsx
@@ -583,7 +583,7 @@ function DAGSpecReadOnly({
 
   if (error) {
     return (
-      <div className="text-sm text-danger p-4">
+      <div className="text-sm text-destructive p-4">
         Failed to load DAG spec: {error.message ?? 'Unknown error'}
       </div>
     );

--- a/ui/src/features/dags/components/dag-execution/StepLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/StepLog.tsx
@@ -640,7 +640,7 @@ function StepLog({
         className={`flex-1 rounded-lg bg-muted pt-4 pr-4 pb-4 relative ${preferences.logWrap ? 'overflow-auto' : 'overflow-x-auto overflow-y-auto'}`}
       >
         {isNavigating && (
-          <div className="absolute inset-0 bg-black bg-opacity-20 flex items-center justify-center z-10 pointer-events-none">
+          <div className="absolute inset-0 bg-black/20 flex items-center justify-center z-10 pointer-events-none">
             <div className="bg-card rounded-lg p-2">
               <div className="h-5 w-5 animate-spin rounded-full border-3 border-primary border-t-transparent"></div>
             </div>

--- a/ui/src/pages/api-keys/APIKeyFormModal.tsx
+++ b/ui/src/pages/api-keys/APIKeyFormModal.tsx
@@ -220,7 +220,7 @@ export function APIKeyFormModal({
           </DialogHeader>
           <div className="space-y-4">
             <div className="p-3 bg-warning/10 border border-warning/20 rounded-md">
-              <p className="text-sm text-warning-foreground">
+              <p className="text-sm text-foreground">
                 Copy this key now. You won&apos;t be able to see it again!
               </p>
             </div>

--- a/ui/src/pages/api-keys/index.tsx
+++ b/ui/src/pages/api-keys/index.tsx
@@ -171,7 +171,7 @@ export default function APIKeysPage() {
       {communityLimitReached && (
         <div
           role="alert"
-          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground"
+          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-foreground"
         >
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>

--- a/ui/src/pages/webhooks/index.tsx
+++ b/ui/src/pages/webhooks/index.tsx
@@ -428,7 +428,7 @@ export default function WebhooksPage() {
           </DialogHeader>
           <div className="space-y-4">
             <div className="p-3 bg-warning/10 border border-warning/20 rounded-md">
-              <p className="text-sm text-warning-foreground">
+              <p className="text-sm text-foreground">
                 Copy this token now. You won&apos;t be able to see it again!
               </p>
             </div>

--- a/ui/src/styles/__tests__/global.test.ts
+++ b/ui/src/styles/__tests__/global.test.ts
@@ -4,36 +4,59 @@
 import tailwindcss from '@tailwindcss/postcss';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import postcss from 'postcss';
+import postcss, { type Rule } from 'postcss';
 import { describe, expect, it } from 'vitest';
 
 const semanticUtilities = [
-  'bg-error/10',
-  'bg-error-muted',
-  'bg-info-muted',
-  'bg-success-muted',
-  'bg-surface-variant/60',
-  'bg-warning-muted',
-  'border-error/30',
-  'hover:bg-primary-hover',
-  'text-error',
-  'text-text-secondary',
-];
+  ['bg-error/10', 'background-color', '--status-error'],
+  ['bg-error-muted', 'background-color', '--error-muted'],
+  ['bg-info-muted', 'background-color', '--info-muted'],
+  ['bg-muted', 'background-color', '--muted'],
+  ['bg-success-muted', 'background-color', '--success-muted'],
+  ['bg-surface', 'background-color', '--surface'],
+  ['bg-surface-variant/60', 'background-color', '--surface-variant'],
+  ['bg-warning-muted', 'background-color', '--warning-muted'],
+  ['border-error/30', 'border-color', '--status-error'],
+  ['data-[state=checked]:bg-foreground', 'background-color', '--foreground'],
+  ['data-[state=checked]:text-background', 'color', '--background'],
+  ['hover:bg-primary-hover', 'background-color', '--primary-hover'],
+  ['text-error', 'color', '--status-error'],
+  ['text-muted-foreground', 'color', '--muted-foreground'],
+  ['text-text-secondary', 'color', '--text-secondary'],
+  ['bg-sidebar-active', 'background-color', '--sidebar-active'],
+  ['bg-sidebar-primary', 'background-color', '--sidebar-primary'],
+] as const;
 
 function selector(utility: string): string {
-  return `.${utility.replace(/:/g, '\\:').replace(/\//g, '\\/')}`;
+  return `.${utility.replace(/([:/[\]=])/g, '\\$1')}`;
 }
 
 describe('global styles', () => {
-  it('generates used semantic color utilities', async () => {
+  it('generates utilities from semantic tokens', async () => {
     const file = resolve('src/styles/global.css');
     const source = await readFile(file, 'utf8');
     const result = await postcss([tailwindcss()]).process(source, {
       from: file,
     });
 
-    for (const utility of semanticUtilities) {
-      expect(result.css).toContain(selector(utility));
+    for (const [utility, property, token] of semanticUtilities) {
+      let rule: Rule | undefined;
+      result.root.walkRules((candidate) => {
+        if (candidate.selector === selector(utility)) {
+          rule = candidate;
+        }
+      });
+
+      expect(rule, `${utility} should be generated`).toBeDefined();
+
+      const values: string[] = [];
+      rule?.walkDecls(property, (declaration) => {
+        values.push(declaration.value);
+      });
+      expect(
+        values.some((value) => value.includes(`var(${token})`)),
+        `${utility} should use ${token}`
+      ).toBe(true);
     }
   });
 });

--- a/ui/src/styles/__tests__/global.test.ts
+++ b/ui/src/styles/__tests__/global.test.ts
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import tailwindcss from '@tailwindcss/postcss';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import postcss from 'postcss';
+import { describe, expect, it } from 'vitest';
+
+const semanticUtilities = [
+  'bg-error/10',
+  'bg-error-muted',
+  'bg-info-muted',
+  'bg-success-muted',
+  'bg-surface-variant/60',
+  'bg-warning-muted',
+  'border-error/30',
+  'hover:bg-primary-hover',
+  'text-error',
+  'text-text-secondary',
+];
+
+function selector(utility: string): string {
+  return `.${utility.replace(/:/g, '\\:').replace(/\//g, '\\/')}`;
+}
+
+describe('global styles', () => {
+  it('generates used semantic color utilities', async () => {
+    const file = resolve('src/styles/global.css');
+    const source = await readFile(file, 'utf8');
+    const result = await postcss([tailwindcss()]).process(source, {
+      from: file,
+    });
+
+    for (const utility of semanticUtilities) {
+      expect(result.css).toContain(selector(utility));
+    }
+  });
+});

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -5,7 +5,7 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-@theme {
+@theme inline {
   /* Core Obsidian Semantic Colors */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -513,24 +513,6 @@
 .custom-sidebar-color,
 .custom-sidebar-color * {
   --sidebar-foreground: currentColor;
-}
-/* Tailwind v4 resolves the @theme bridge (--color-sidebar-*: var(--sidebar-*))
-   once at :root, so the per-element --sidebar-* overrides set inline by the
-   Layout never reach the utility classes. Re-declare the bridge here so it
-   re-resolves against the customized sidebar element. */
-.custom-sidebar-color {
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-hover: var(--sidebar-hover);
-  --color-sidebar-active: var(--sidebar-active);
-  /* Fills use the translucent active overlay so forced-inherit text stays
-     readable; the 3px indicator bar reads --sidebar-primary directly and
-     keeps the solid contrast color. */
-  --color-sidebar-primary: var(--sidebar-active);
-  --color-sidebar-primary-foreground: var(--sidebar-foreground);
-  --color-sidebar-accent: var(--sidebar-hover);
-  --color-sidebar-accent-foreground: var(--sidebar-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 .custom-sidebar-color .text-sidebar-foreground,
 .custom-sidebar-color .text-muted-foreground,

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -18,6 +18,7 @@
 
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+  --color-primary-hover: var(--primary-hover);
 
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
@@ -36,6 +37,8 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
   --color-surface: var(--surface);
+  --color-surface-variant: var(--surface-variant);
+  --color-text-secondary: var(--text-secondary);
 
   /* Sidebar */
   --color-sidebar: var(--sidebar);
@@ -57,8 +60,13 @@
 
   /* Status Colors */
   --color-success: var(--success);
+  --color-success-muted: var(--success-muted);
   --color-warning: var(--warning);
+  --color-warning-muted: var(--warning-muted);
+  --color-error: var(--status-error);
+  --color-error-muted: var(--error-muted);
   --color-info: var(--info);
+  --color-info-muted: var(--info-muted);
 
   /* Font Family */
   --font-sans:
@@ -112,13 +120,17 @@
     --destructive-foreground: #ffffff;
     --success: #178a44;
     --success-foreground: #ffffff;
+    --success-muted: color-mix(in srgb, var(--success) 10%, transparent);
     --warning: #b47110;
     --warning-foreground: #111827;
+    --warning-muted: color-mix(in srgb, var(--warning) 10%, transparent);
     --info: #5d4fe0;
     --info-foreground: #ffffff;
+    --info-muted: color-mix(in srgb, var(--info) 10%, transparent);
 
     --status-success: #178a44;
     --status-error: #c8382f;
+    --error-muted: color-mix(in srgb, var(--status-error) 10%, transparent);
     --status-running: #5d4fe0;
     --status-neutral: #83868f;
     --status-warning: #b47110;
@@ -186,13 +198,17 @@
     --destructive-foreground: #1f0909;
     --success: #22c55e;
     --success-foreground: #052e16;
+    --success-muted: color-mix(in srgb, var(--success) 15%, transparent);
     --warning: #d9a03c;
     --warning-foreground: #261a00;
+    --warning-muted: color-mix(in srgb, var(--warning) 15%, transparent);
     --info: #a89ff8;
     --info-foreground: #17123f;
+    --info-muted: color-mix(in srgb, var(--info) 15%, transparent);
 
     --status-success: #22c55e;
     --status-error: #ef5350;
+    --error-muted: color-mix(in srgb, var(--status-error) 15%, transparent);
     --status-running: #a89ff8;
     --status-neutral: #8a8d99;
     --status-warning: #d9a03c;


### PR DESCRIPTION
## Summary

Restore Tailwind semantic color mappings so workflow `ERROR` log levels and other status elements render their intended colors.

## Changes

- Add mode-aware semantic color bridges and a generated-CSS regression test
- Replace stale color utilities and preserve warning text contrast

## Related Issues

None.

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Tailwind semantic color utilities so workflow `ERROR` log levels, warning banners, and other status elements render their intended colors after Tailwind v4 stopped generating the old utility classes.

**Changes**
- Switches the `@theme` bridge to `@theme inline` so semantic utilities resolve at their use site, fixing nested themes and custom sidebar overrides (and removing the old `.custom-sidebar-color` re-declaration workaround).
- Adds mode-aware semantic tokens for error, warning, success, info, surface, and primary hover states in `global.css`.
- Replaces stale utility names with supported Tailwind v4 classes, including `border-border-strong`, `bg-foreground`, `text-destructive`, and `bg-black/20`.
- Preserves warning text contrast by using `text-foreground` on warning backgrounds.
- Adds a regression test that compiles `global.css` and checks semantic utilities are generated with the correct token source.

<sup>Written for commit 4e21c5074eccd586f6400c96938fc924a57490a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated checkbox, warning, error, and loading-state styling for improved theme consistency across light and dark modes.
  - Added semantic color variants for primary, surface, text, success, warning, error, and informational states.
  - Refined warning and error message contrast in DAG, API key, and webhook views.

- **Tests**
  - Added coverage verifying semantic theme colors are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->