### PR TITLE
fix: decode snake_case SSH config

### DIFF
--- a/internal/runtime/builtin/ssh/config.go
+++ b/internal/runtime/builtin/ssh/config.go
@@ -51,10 +51,10 @@ type sshMapConfig struct {
 	Port          string
 	Key           string
 	Password      string
-	StrictHostKey bool
-	KnownHostFile string
+	StrictHostKey bool   `mapstructure:"strict_host_key"`
+	KnownHostFile string `mapstructure:"known_host_file"`
 	Shell         string
-	ShellArgs     []string
+	ShellArgs     []string `mapstructure:"shell_args"`
 	Timeout       string
 	Bastion       *struct {
 		Host     string
@@ -66,7 +66,7 @@ type sshMapConfig struct {
 }
 
 func FromMapConfig(_ context.Context, mapCfg map[string]any) (*Client, error) {
-	var def sshMapConfig
+	def := sshMapConfig{StrictHostKey: true}
 	md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:           &def,
 		WeaklyTypedInput: true,

--- a/internal/runtime/builtin/ssh/ssh_test.go
+++ b/internal/runtime/builtin/ssh/ssh_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,10 +32,11 @@ func TestNewSSHExecutor(t *testing.T) {
 		ExecutorConfig: ir.ExecutorConfig{
 			Type: "ssh",
 			Config: map[string]any{
-				"User":     "testuser",
-				"IP":       "testip",
-				"Port":     25,
-				"Password": "testpassword",
+				"User":            "testuser",
+				"IP":              "testip",
+				"Port":            25,
+				"Password":        "testpassword",
+				"strict_host_key": false,
 			},
 		},
 	}
@@ -55,22 +57,24 @@ func TestNewSSHExecutor_WithShellConfig(t *testing.T) {
 		{
 			name: "ShellFromConfig",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"port":     22,
-				"password": "testpassword",
-				"shell":    "/bin/bash",
+				"user":            "testuser",
+				"ip":              "testip",
+				"port":            22,
+				"password":        "testpassword",
+				"strict_host_key": false,
+				"shell":           "/bin/bash",
 			},
 			expectedShell: "/bin/bash",
 		},
 		{
 			name: "ShellFromConfigWithArgs",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"port":     22,
-				"password": "testpassword",
-				"shell":    "/bin/bash -e",
+				"user":            "testuser",
+				"ip":              "testip",
+				"port":            22,
+				"password":        "testpassword",
+				"strict_host_key": false,
+				"shell":           "/bin/bash -e",
 			},
 			expectedShell: "/bin/bash",
 			expectedArgs:  []string{"-e"},
@@ -78,10 +82,11 @@ func TestNewSSHExecutor_WithShellConfig(t *testing.T) {
 		{
 			name: "NoShellInConfig",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"port":     22,
-				"password": "testpassword",
+				"user":            "testuser",
+				"ip":              "testip",
+				"port":            22,
+				"password":        "testpassword",
+				"strict_host_key": false,
 			},
 			expectedShell: "/bin/sh", // Fallback to POSIX shell when no shell configured
 		},
@@ -144,11 +149,12 @@ func TestSSHExecutor_ShellPriority(t *testing.T) {
 				ExecutorConfig: ir.ExecutorConfig{
 					Type: "ssh",
 					Config: map[string]any{
-						"user":     "testuser",
-						"ip":       "testip",
-						"port":     22,
-						"password": "testpassword",
-						"shell":    "/bin/zsh -o pipefail",
+						"user":            "testuser",
+						"ip":              "testip",
+						"port":            22,
+						"password":        "testpassword",
+						"strict_host_key": false,
+						"shell":           "/bin/zsh -o pipefail",
 					},
 				},
 			},
@@ -197,10 +203,11 @@ func TestSSHExecutor_ShellPriority(t *testing.T) {
 				ExecutorConfig: ir.ExecutorConfig{
 					Type: "ssh",
 					Config: map[string]any{
-						"user":     "stepuser",
-						"ip":       "step-host",
-						"port":     22,
-						"password": "steppassword",
+						"user":            "stepuser",
+						"ip":              "step-host",
+						"port":            22,
+						"password":        "steppassword",
+						"strict_host_key": false,
 					},
 				},
 			},
@@ -510,39 +517,43 @@ func TestSSHExecutor_TimeoutConfig(t *testing.T) {
 		{
 			name: "DefaultTimeout",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"password": "testpassword",
+				"user":            "testuser",
+				"ip":              "testip",
+				"password":        "testpassword",
+				"strict_host_key": false,
 			},
 			expectedTimeout: 30 * time.Second, // Default timeout
 		},
 		{
 			name: "CustomTimeout",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"password": "testpassword",
-				"timeout":  "1m",
+				"user":            "testuser",
+				"ip":              "testip",
+				"password":        "testpassword",
+				"strict_host_key": false,
+				"timeout":         "1m",
 			},
 			expectedTimeout: 1 * time.Minute,
 		},
 		{
 			name: "ShortTimeout",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"password": "testpassword",
-				"timeout":  "5s",
+				"user":            "testuser",
+				"ip":              "testip",
+				"password":        "testpassword",
+				"strict_host_key": false,
+				"timeout":         "5s",
 			},
 			expectedTimeout: 5 * time.Second,
 		},
 		{
 			name: "InvalidTimeout",
 			config: map[string]any{
-				"user":     "testuser",
-				"ip":       "testip",
-				"password": "testpassword",
-				"timeout":  "invalid",
+				"user":            "testuser",
+				"ip":              "testip",
+				"password":        "testpassword",
+				"strict_host_key": false,
+				"timeout":         "invalid",
 			},
 			expectError: true,
 		},
@@ -564,6 +575,46 @@ func TestSSHExecutor_TimeoutConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedTimeout, client.cfg.Timeout)
 		})
 	}
+}
+
+func TestFromMapConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HostKey", func(t *testing.T) {
+		knownHostFile := filepath.Join(t.TempDir(), "known_hosts")
+		_, err := FromMapConfig(context.Background(), map[string]any{
+			"user":            "testuser",
+			"host":            "testhost",
+			"password":        "testpass",
+			"strict_host_key": true,
+			"known_host_file": knownHostFile,
+		})
+		require.ErrorContains(t, err, knownHostFile)
+	})
+
+	t.Run("DefaultHostKey", func(t *testing.T) {
+		knownHostFile := filepath.Join(t.TempDir(), "known_hosts")
+		_, err := FromMapConfig(context.Background(), map[string]any{
+			"user":            "testuser",
+			"host":            "testhost",
+			"password":        "testpass",
+			"known_host_file": knownHostFile,
+		})
+		require.ErrorContains(t, err, knownHostFile)
+	})
+
+	t.Run("ShellArgs", func(t *testing.T) {
+		client, err := FromMapConfig(context.Background(), map[string]any{
+			"user":            "testuser",
+			"host":            "testhost",
+			"password":        "testpass",
+			"strict_host_key": false,
+			"shell":           "/bin/bash",
+			"shell_args":      []any{"-x"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"-x"}, client.ShellArgs)
+	})
 }
 
 func TestSSHExecutor_Run_NoCommands(t *testing.T) {
@@ -662,10 +713,11 @@ func TestFromMapConfig_WithBastion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := map[string]any{
-				"user":     "testuser",
-				"host":     "target.example.com",
-				"password": "targetpass",
-				"bastion":  tt.bastion,
+				"user":            "testuser",
+				"host":            "target.example.com",
+				"password":        "targetpass",
+				"strict_host_key": false,
+				"bastion":         tt.bastion,
 			}
 
 			client, err := FromMapConfig(context.Background(), config)
@@ -711,12 +763,13 @@ func TestNewSFTPExecutor(t *testing.T) {
 		ExecutorConfig: ir.ExecutorConfig{
 			Type: "sftp",
 			Config: map[string]any{
-				"user":        "testuser",
-				"host":        "testhost",
-				"password":    "testpass",
-				"direction":   "upload",
-				"source":      "/local/path",
-				"destination": "/remote/path",
+				"user":            "testuser",
+				"host":            "testhost",
+				"password":        "testpass",
+				"strict_host_key": false,
+				"direction":       "upload",
+				"source":          "/local/path",
+				"destination":     "/remote/path",
 			},
 		},
 	}
@@ -744,34 +797,37 @@ func TestNewSFTPExecutor_ValidationErrors(t *testing.T) {
 		{
 			name: "MissingSource",
 			config: map[string]any{
-				"user":        "testuser",
-				"host":        "testhost",
-				"password":    "testpass",
-				"direction":   "upload",
-				"destination": "/remote/path",
+				"user":            "testuser",
+				"host":            "testhost",
+				"password":        "testpass",
+				"strict_host_key": false,
+				"direction":       "upload",
+				"destination":     "/remote/path",
 			},
 			expectedErr: "source path is required",
 		},
 		{
 			name: "MissingDestination",
 			config: map[string]any{
-				"user":      "testuser",
-				"host":      "testhost",
-				"password":  "testpass",
-				"direction": "download",
-				"source":    "/remote/path",
+				"user":            "testuser",
+				"host":            "testhost",
+				"password":        "testpass",
+				"strict_host_key": false,
+				"direction":       "download",
+				"source":          "/remote/path",
 			},
 			expectedErr: "destination path is required",
 		},
 		{
 			name: "InvalidDirection",
 			config: map[string]any{
-				"user":        "testuser",
-				"host":        "testhost",
-				"password":    "testpass",
-				"direction":   "invalid",
-				"source":      "/local/path",
-				"destination": "/remote/path",
+				"user":            "testuser",
+				"host":            "testhost",
+				"password":        "testpass",
+				"strict_host_key": false,
+				"direction":       "invalid",
+				"source":          "/local/path",
+				"destination":     "/remote/path",
 			},
 			expectedErr: "invalid direction",
 		},
@@ -798,11 +854,12 @@ func TestNewSFTPExecutor_DefaultDirection(t *testing.T) {
 		ExecutorConfig: ir.ExecutorConfig{
 			Type: "sftp",
 			Config: map[string]any{
-				"user":        "testuser",
-				"host":        "testhost",
-				"password":    "testpass",
-				"source":      "/local/path",
-				"destination": "/remote/path",
+				"user":            "testuser",
+				"host":            "testhost",
+				"password":        "testpass",
+				"strict_host_key": false,
+				"source":          "/local/path",
+				"destination":     "/remote/path",
 				// direction not specified - should default to upload
 			},
 		},


### PR DESCRIPTION
## Summary

Decode snake_case SSH action config and restore the secure host-key default.

## Changes

- Bind `strict_host_key`, `known_host_file`, and `shell_args` to decoder fields
- Default omitted `strict_host_key` to `true` while preserving explicit `false`
- Add focused regressions and explicit insecure settings to unrelated fixtures

## Tests

- `make test TEST_TARGET=./internal/runtime/builtin/ssh`
- `make check`

## Related Issues

Closes #2692

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes snake_case SSH config decoding so host-key settings and shell arguments are applied, and restores the secure host-key default.

- Binds `strict_host_key`, `known_host_file`, and `shell_args` to the map decoder.
- Omitted `strict_host_key` now defaults to `true`; explicit `false` remains honored.
- Adds regression coverage for key binding and host-key defaults.

Closes #2692.

<sup>Written for commit 94346586849ad78236cceac9c3dc38511bdeb22d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH configuration now correctly recognizes host-key verification and known-host file settings.
  * Host-key verification is enabled by default when no setting is provided.
  * Shell argument configuration is now parsed correctly.
* **Tests**
  * Added coverage for SSH configuration parsing and host-key verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->