### PR TITLE
Check file rather than the interface in walkArchive

### DIFF
--- a/internal/runtime/builtin/archive/operations.go
+++ b/internal/runtime/builtin/archive/operations.go
@@ -518,7 +518,7 @@ func (e *executorImpl) walkArchive(ctx context.Context, file *os.File, path stri
 		needsClose bool
 	)
 
-	if reader == nil {
+	if file == nil {
 		var err error
 		file, err = os.Open(path)
 		if err != nil {


### PR DESCRIPTION
## The problem

`walkArchive` takes a concrete `*os.File` and assigns it into an interface before testing it:

```go
func (e *executorImpl) walkArchive(ctx context.Context, file *os.File, path string, format archives.Format) ([]listEntry, error) {
	var (
		reader     archives.ReaderAtSeeker = file
		needsClose bool
	)

	if reader == nil {
		file, err = os.Open(path)
		...
	}
```

An interface holding a nil pointer of a concrete type is not itself nil, so `reader == nil` is always false. The open-from-path fallback cannot run. A caller passing `nil` for `file` gets a nil `*os.File` boxed in the interface, and `needsClose` stays false so nothing is closed either.

`staticcheck` reports it as SA4023, "this comparison is never true".

## Why the two neighbouring checks are fine

The same file has two more `if reader == nil` guards and neither has this problem, because both take the interface as a parameter rather than boxing a pointer:

- `determineFormat(ctx, path, reader archives.ReaderAtSeeker)` at line 404
- `verifyArchiveReadable(ctx, path, stream archives.ReaderAtSeeker, format)` at line 465

`walkArchive` is the only one of the three that takes `*os.File`, which is why it is the only one affected.

## Scope

The current sole caller at line 371 always passes a file that was opened and error-checked at line 350, so this is not reachable today. It is a guard that cannot do what it is written to do, and the next caller that passes `nil` gets a nil file rather than the documented fallback.

One line changed, `go build ./...` clean, `go test ./internal/runtime/builtin/archive/...` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `walkArchive` so it checks the concrete `*os.File` before treating it as an `archives.ReaderAtSeeker`. Previously, a nil file became a non-nil interface and skipped the path fallback; it now opens `path` when needed and closes that file afterward.

<sup>Written for commit c3896a8734d746e8750e6fec18767ff08e16a878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified an internal archive-processing condition without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->