### PR TITLE
ci: fetch full history and tags in conformance checkout

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -55,6 +55,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
git describe --tags fails on GitHub Actions' default shallow, tag-less checkout, leaving BUILD_VERSION (and the version baked into the built binary via -X main.version=$(BUILD_VERSION)) empty. That made conformance/cli's TestVersionPrintsNonEmptyVersion fail against a binary built in CI, even though it passes locally where the clone already has full history and tags.


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conformance checks to retrieve the complete repository history and tags during runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->