### PR TITLE
Show schedule aliases in workflow examples

### DIFF
--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -71,9 +71,9 @@ steps:
 	{
 		ID:          3,
 		Name:        "schedule-params-env",
-		Description: "Schedule a DAG with params and env vars",
+		Description: "Schedule a daily DAG with params and env vars",
 		Content: `type: graph
-schedule: "0 2 * * *"
+schedule: "@daily" # Midnight; equivalent to "0 0 * * *"
 catchup_window: "12h"
 defaults:
   retry_policy:

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -72,11 +72,11 @@
       }
     },
     "schedule": {
-      "examples": ["0 * * * *", "*/15 8-18 * * MON-FRI"],
+      "examples": ["@daily", "0 * * * *", "*/15 8-18 * * MON-FRI"],
       "oneOf": [
         {
           "type": "string",
-          "description": "Single cron expression for starting the DAG (e.g., '5 4 * * *' runs daily at 04:05)"
+          "description": "Single cron expression or schedule alias for starting the DAG (e.g., '@daily' runs at midnight)"
         },
         {
           "type": "array",

--- a/internal/cmn/schema/dag.schema.json
+++ b/internal/cmn/schema/dag.schema.json
@@ -142,7 +142,7 @@
           "description": "Advanced scheduling with separate start, stop, and restart schedules."
         }
       ],
-      "description": "Schedule configuration for the DAG. Start schedules support cron expressions, profile-scoped cron object entries, and one-off RFC 3339 timestamps with explicit offsets. Stop and restart remain cron-only but may still use profile-scoped cron objects."
+      "description": "Schedule configuration for the DAG. Start schedules support cron expressions and schedule aliases, profile-scoped cron object entries, and one-off RFC 3339 timestamps with explicit offsets. Stop and restart remain cron-only but may still use profile-scoped cron objects."
     },
     "skip_if_successful": {
       "type": "boolean",


### PR DESCRIPTION
Show `@daily` in `dagu example 3` and the editor's schedule schema examples. Explain its midnight timing and equivalent cron expression.

Validation: Go formatting and schema JSON checks passed. The existing example loader test and full checks run in CI. The scheduling guide, YAML reference, API docs, and documentation example were updated separately in dagucloud/docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows schedule aliases in workflow examples so the supported shorthand is discoverable. `dagu example 3` now uses `@daily` instead of a raw cron expression, with a comment noting its midnight timing and equivalent cron, and the editor schema lists `@daily` as an example and clarifies that aliases are accepted alongside cron expressions.

<sup>Written for commit a2f31576e1ace2e779b807592c7c4b3ccebfdffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Schedule configuration now supports aliases such as `@daily` in addition to standard cron expressions.
  - The `@daily` alias represents a schedule that runs at midnight.

- **Documentation**
  - Updated scheduling examples and descriptions to clarify the supported schedule formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->