### PR TITLE
test: add black-box conformance coverage for ffmpeg@v1

### DIFF
--- a/conformance/spec064_ffmpeg/ffmpeg_helper_test.go
+++ b/conformance/spec064_ffmpeg/ffmpeg_helper_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec064_ffmpeg_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// One match appears per step that wrote anything to stdout, in the order
+// dagu's tree render lists them (which, for both the sequential and the
+// independent-but-declared-in-order fixtures this package uses, matches
+// declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// or JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}

--- a/conformance/spec064_ffmpeg/ffmpeg_test.go
+++ b/conformance/spec064_ffmpeg/ffmpeg_test.go
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec064_ffmpeg holds black-box conformance tests for Spec 064:
+// FFmpeg Action (ffmpeg@v1).
+//
+// Like node-script@v1 (spec 060), python-script@v1 (spec 061), and dbt@v1
+// (spec 062), ffmpeg@v1 is a remote official action: referencing it clones
+// https://github.com/dagucloud/ffmpeg at the given tag and provisions its
+// own pinned FFmpeg and Node.js toolchain (via the project's aqua-based
+// tool manager) into the isolated $HOME each test run gets, on first use,
+// then runs the real ffmpeg/ffprobe binary it installs. Unlike the
+// uv/Python-based actions, that first invocation is fast (a few seconds:
+// FFmpegBin and node are single prebuilt archives, not a package-resolver
+// graph), so this package does not need to raise the harness's per-command
+// timeout as aggressively as spec 061/062 do -- a modest bump is still
+// applied defensively for slower CI runners.
+package spec064_ffmpeg_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFfmpegLive(t *testing.T) {
+	// No subtest below uses t.Parallel(): each calls t.Setenv to raise the
+	// harness's per-command timeout defensively, and t.Setenv itself
+	// forbids t.Parallel() in the same test.
+	t.Run("ffmpeg and ffprobe run against a real media file, with structured args, workdir, and env", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		dagu.Mkdir("artifacts")
+		dagu.Mkdir("workdir")
+		env := []string{
+			"HOST_OUT_DIR=" + dagu.ProjectPath("artifacts"),
+			"HOST_WORK_DIR=" + dagu.ProjectPath("workdir"),
+		}
+		result := dagu.RunWithEnv(env, "start", "happy_path.yaml")
+		result.ExpectExitCode(0)
+
+		var convert struct {
+			OK       bool     `json:"ok"`
+			ExitCode int      `json:"exitCode"`
+			Command  string   `json:"command"`
+			Args     []string `json:"args"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &convert))
+		require.True(t, convert.OK)
+		require.Zero(t, convert.ExitCode)
+		require.Equal(t, "ffmpeg", convert.Command)
+		require.Equal(t, []string{"-hide_banner", "-nostdin", "-y"}, convert.Args[:3],
+			"ffmpeg gets -hide_banner/-nostdin (both default true) and -y (overwrite: true) prepended")
+		clipPath := filepath.Join(dagu.ProjectPath("artifacts"), "clip.mp4")
+		info, err := os.Stat(clipPath) // #nosec G304 -- path is this test's own known fixture output.
+		require.NoError(t, err, "convert should have written a real clip.mp4")
+		require.Positive(t, info.Size())
+
+		var probe struct {
+			OK      bool     `json:"ok"`
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+			Stdout  string   `json:"stdout"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &probe))
+		require.True(t, probe.OK)
+		require.Equal(t, "ffprobe", probe.Command)
+		require.Equal(t, []string{"-hide_banner", "-v", "error"}, probe.Args[:3],
+			"ffprobe does not get -nostdin or -y/-n, since those only apply to ffmpeg")
+		var probeReport struct {
+			Streams []struct {
+				Width  int `json:"width"`
+				Height int `json:"height"`
+			} `json:"streams"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(probe.Stdout), &probeReport),
+			"the wrapper's own stdout field should itself be ffprobe's -print_format json report")
+		require.Len(t, probeReport.Streams, 1)
+		require.Equal(t, 32, probeReport.Streams[0].Width)
+		require.Equal(t, 32, probeReport.Streams[0].Height)
+
+		var structured struct {
+			OK   bool     `json:"ok"`
+			Args []string `json:"args"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &structured))
+		require.True(t, structured.OK)
+		require.Equal(t, []string{
+			"-n", // overwrite defaults to false regardless of hideBanner/nostdin
+			"-f", "lavfi",
+			"-i", "color=c=red:s=16x16:d=1",
+			"-c:v", "libx264",
+			"rel_out.mp4",
+		}, structured.Args, "hideBanner: false and nostdin: false suppress -hide_banner/-nostdin; args as a JSON array string is taken as exact argv")
+		relOutPath := filepath.Join(dagu.ProjectPath("workdir"), "rel_out.mp4")
+		info, err = os.Stat(relOutPath) // #nosec G304 -- path is this test's own known fixture output.
+		require.NoError(t, err, "a relative output path should resolve against with.workdir")
+		require.Positive(t, info.Size())
+	})
+
+	t.Run("bad shell quoting, a malformed env line, a real ffmpeg failure, a timeout, and output truncation", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "error_scenarios.yaml")
+		result.ExpectNonZeroExitCode()
+
+		// with.args missing, an unsupported with.command, and with.env given
+		// as a native object (the action's own input schema types env as a
+		// string, unlike dbt@v1's with.env) are all caught by the action's
+		// own input schema before the wrapper ever runs, so none of these
+		// three steps has a stdout log of its own to read.
+		require.Contains(t, result.Stdout(), `missing properties: ["args"]`)
+		require.Contains(t, result.Stdout(), "does not equal any of")
+		require.Contains(t, result.Stdout(), `validating /properties/env`)
+		require.Contains(t, result.Stdout(), `has type "object"`)
+
+		// Bad shell quoting and a malformed env line both fail inside the
+		// wrapper itself (its own args/env parsing goes beyond what the
+		// input schema checks), so both report a populated "error" object
+		// with ok:false and exitCode:-1, unlike dbt@v1 where that path is
+		// effectively unreachable.
+		var badQuoting struct {
+			OK       bool `json:"ok"`
+			ExitCode int  `json:"exitCode"`
+			Error    struct {
+				Name    string `json:"name"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &badQuoting))
+		require.False(t, badQuoting.OK)
+		require.Equal(t, -1, badQuoting.ExitCode)
+		require.Equal(t, "ValidationError", badQuoting.Error.Name)
+		require.Contains(t, badQuoting.Error.Message, "unterminated")
+
+		var badEnvLine struct {
+			OK    bool `json:"ok"`
+			Error struct {
+				Name    string `json:"name"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &badEnvLine))
+		require.False(t, badEnvLine.OK)
+		require.Equal(t, "ValidationError", badEnvLine.Error.Name)
+		require.Contains(t, badEnvLine.Error.Message, "KEY=value syntax")
+
+		// A real ffmpeg failure (here, a nonexistent input file) reports
+		// through the ordinary exitCode/stderr fields, with no "error"
+		// object at all -- the process started and ran, it just failed.
+		var badInputFile map[string]any
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &badInputFile))
+		require.False(t, badInputFile["ok"].(bool))
+		require.EqualValues(t, 254, badInputFile["exitCode"])
+		require.NotContains(t, badInputFile, "error")
+		require.Contains(t, badInputFile["stderr"], "No such file or directory")
+
+		// with.timeoutSeconds sends SIGTERM; ffmpeg traps it and exits on
+		// its own with its conventional signal-exit code (255) rather than
+		// being killed outright, so exitCode is a real positive number even
+		// though timedOut is true and ok is false.
+		var timedOut struct {
+			OK       bool `json:"ok"`
+			ExitCode int  `json:"exitCode"`
+			TimedOut bool `json:"timedOut"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &timedOut))
+		require.False(t, timedOut.OK)
+		require.True(t, timedOut.TimedOut)
+		require.Equal(t, 255, timedOut.ExitCode)
+
+		var truncated struct {
+			OK        bool `json:"ok"`
+			Truncated struct {
+				Stdout bool `json:"stdout"`
+				Stderr bool `json:"stderr"`
+			} `json:"truncated"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 4)), &truncated))
+		require.True(t, truncated.OK, "the command itself still succeeds; only its captured output is capped")
+		require.True(t, truncated.Truncated.Stderr, "verbose ffmpeg logging should exceed the 1024-byte maxOutputBytes cap")
+		require.False(t, truncated.Truncated.Stdout)
+	})
+
+	// Like node-script@v1, python-script@v1, and dbt@v1, a later step reads
+	// a result field as ${<step id>.outputs.<name>} -- a bare-step-id
+	// reference, not ${steps.<step id>.outputs.<name>} -- confirming this
+	// is a property of remote action:-type steps generally, not specific to
+	// one action.
+	t.Run("a later step reads a result field as ${<step id>.outputs.<name>}, but not via steps.<id>.outputs.<name>", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "downstream_reference.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains("bad substitution")
+
+		require.Equal(t, "bare exit code is 0\n", stepStdout(t, result.Stdout(), 1))
+	})
+}
+
+// TestFfmpegValidation proves that dagu validate never resolves a remote
+// action reference (which would require network access): an ffmpeg@v1 step
+// passes validate regardless of its with: content, and even with.args --
+// required by the action's own inputs schema -- is enforced only once the
+// step actually runs and that schema is fetched. The one thing validate
+// does check locally is the action reference's own syntax.
+func TestFfmpegValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an ffmpeg@v1 step with no with.args passes validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "error_scenarios.yaml")
+		result.ExpectExitCode(0)
+	})
+
+	t.Run("an action reference missing its required @version suffix fails validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "no_version_suffix.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains(`unknown action "ffmpeg"`)
+	})
+}

--- a/conformance/spec064_ffmpeg/testdata/downstream_reference.yaml
+++ b/conformance/spec064_ffmpeg/testdata/downstream_reference.yaml
@@ -1,0 +1,11 @@
+steps:
+  - id: convert
+    action: ffmpeg@v1
+    with:
+      args: -f lavfi -i "color=size=32x32:d=1" -c:v libx264 -f null -
+  - id: print_bare
+    depends: convert
+    run: echo "bare exit code is ${convert.outputs.exitCode}"
+  - id: print_strict
+    depends: convert
+    run: echo "strict=${steps.convert.outputs.exitCode}"

--- a/conformance/spec064_ffmpeg/testdata/error_scenarios.yaml
+++ b/conformance/spec064_ffmpeg/testdata/error_scenarios.yaml
@@ -1,0 +1,60 @@
+steps:
+  - id: missing_args
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      command: ffprobe
+
+  - id: bad_command
+    depends: missing_args
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      command: foobar
+      args: -version
+
+  - id: env_as_object
+    depends: bad_command
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      args: -version
+      env:
+        FOO: bar
+
+  - id: bad_quoting
+    depends: env_as_object
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      args: -i "unterminated
+
+  - id: bad_env_line
+    depends: bad_quoting
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      args: -version
+      env: "NOEQUALSIGN"
+
+  - id: bad_input_file
+    depends: bad_env_line
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      args: -i /tmp/does/not/exist-ffmpeg-conformance-xyz.mp4 -f null -
+
+  - id: times_out
+    depends: bad_input_file
+    action: ffmpeg@v1
+    continue_on: failed
+    with:
+      timeoutSeconds: 1
+      args: -f lavfi -i "color=size=1280x720:rate=25:duration=30" -c:v libx264 -preset veryslow -f null -
+
+  - id: truncated
+    depends: times_out
+    action: ffmpeg@v1
+    with:
+      maxOutputBytes: 1024
+      args: -f lavfi -i "color=size=32x32:d=1" -c:v libx264 -v verbose -f null -

--- a/conformance/spec064_ffmpeg/testdata/happy_path.yaml
+++ b/conformance/spec064_ffmpeg/testdata/happy_path.yaml
@@ -1,0 +1,28 @@
+env:
+  - OUT_DIR: $HOST_OUT_DIR
+  - WORK_DIR: $HOST_WORK_DIR
+steps:
+  - id: convert
+    action: ffmpeg@v1
+    with:
+      overwrite: true
+      args: -f lavfi -i "color=c=blue:s=32x32:d=1" -c:v libx264 -t 1 $OUT_DIR/clip.mp4
+
+  - id: probe
+    depends: convert
+    action: ffmpeg@v1
+    with:
+      command: ffprobe
+      args: -v error -print_format json -show_format -show_streams $OUT_DIR/clip.mp4
+
+  - id: structured
+    depends: probe
+    action: ffmpeg@v1
+    with:
+      workdir: $WORK_DIR
+      hideBanner: false
+      nostdin: false
+      env: |
+        FOO=bar
+        BAZ=qux
+      args: '["-f","lavfi","-i","color=c=red:s=16x16:d=1","-c:v","libx264","rel_out.mp4"]'

--- a/conformance/spec064_ffmpeg/testdata/no_version_suffix.yaml
+++ b/conformance/spec064_ffmpeg/testdata/no_version_suffix.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: ffmpeg
+    with:
+      args: -version

--- a/internal/spec/manifest_decoder.go
+++ b/internal/spec/manifest_decoder.go
@@ -111,6 +111,22 @@ func preserveEnvMappingOrder(data []byte, parsed map[string]any) error {
 	return nil
 }
 
+// opaqueDataKeys holds step/DAG fields whose value is data owned by
+// something other than dagu's own DAG/step schema: an executor's with:
+// config, a step's or the DAG's own inline params: JSON Schema, and the
+// legacy config: field. None of dagu's own env: declarations (DAG-level,
+// defaults.env, step-level, or container.env) are ever nested inside one of
+// these, but arbitrary executor- or schema-owned data underneath them can
+// coincidentally use "env" as a field or property name (for example, a
+// remote action's own with.env input, or a params: schema property named
+// "env"). patchOrderedEnvValues must not descend into these keys, or it
+// rewrites that unrelated mapping into dagu's ordered env-list shape too.
+var opaqueDataKeys = map[string]bool{
+	"with":   true,
+	"params": true,
+	"config": true,
+}
+
 func patchOrderedEnvValues(node ast.Node, target any) error {
 	switch value := node.(type) {
 	case *ast.MappingNode:
@@ -133,6 +149,9 @@ func patchOrderedEnvValues(node ast.Node, target any) error {
 					targetMap[key] = env
 					continue
 				}
+			}
+			if opaqueDataKeys[key] {
+				continue
 			}
 			if err := patchOrderedEnvValues(item.Value, targetMap[key]); err != nil {
 				return err

--- a/internal/spec/manifest_decoder_regression_test.go
+++ b/internal/spec/manifest_decoder_regression_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for patchOrderedEnvValues rewriting any mapping keyed
+// "env" into the DAG's own ordered env-list shape, even when that mapping
+// belongs to unrelated data nested under a step's with:/params: field (see
+// internal/spec/manifest_decoder.go's opaqueDataKeys).
+
+func TestPreserveEnvMappingOrder_ParamsSchemaEnvPropertyDoesNotBreakDecode(t *testing.T) {
+	t.Parallel()
+
+	_, err := spec.LoadYAML(context.Background(), []byte(`
+name: params-schema-env-property
+params:
+  type: object
+  properties:
+    env:
+      type: string
+      default: ""
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+}
+
+func TestPreserveEnvMappingOrder_WithEnvStaysPlainObject(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: with-env-plain-object
+steps:
+  - name: run
+    action: node-script@v1
+    with:
+      script: return 1
+      env:
+        FOO: bar
+`))
+	require.NoError(t, err)
+	input, ok := dag.Steps[0].ExecutorConfig.Config["input"].(map[string]any)
+	require.True(t, ok, "action executor config should nest with: under input")
+	require.Equal(t, map[string]any{"FOO": "bar"}, input["env"])
+}
+
+func TestPreserveEnvMappingOrder_RootEnvOrderStillPreserved(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: root-env-order
+env:
+  FIRST: one
+  SECOND: ${env.FIRST}-two
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"FIRST=one", "SECOND=one-two"}, dag.Env)
+}

--- a/specs/064-ffmpeg.md
+++ b/specs/064-ffmpeg.md
@@ -1,0 +1,237 @@
+# Spec: FFmpeg Action
+
+## Status
+
+Implemented.
+
+This spec defines conformance behavior for the official remote action
+`ffmpeg@v1` (`dagucloud/ffmpeg`).
+
+## Scope
+
+Like `node-script@v1` ([Spec 060: Node Script Action](060-node-script.md)),
+`python-script@v1` ([Spec 061: Python Script Action](061-python-script.md)),
+and `dbt@v1` ([Spec 062: DBT Action](062-dbt.md)), `ffmpeg@v1` is not a
+built-in Go executor. It is an official remote action: a git repository
+(`dagucloud/ffmpeg`) containing a `dagu-action.yaml` manifest and a DAG that
+runs a real `ffmpeg`/`ffprobe` binary the action provisions via the
+project's aqua-based tool manager (`Tyrrrz/FFmpegBin@8.1` and
+`nodejs/node@v22.21.1`; the action's own wrapper is a Node.js script).
+Referencing `ffmpeg@v1` resolves through Dagu's generic remote-action
+mechanism, which clones the action's repository and provisions its pinned
+tools on first use.
+
+This spec covers:
+
+- the required `with.args` (a shell-style argument string, or a JSON array
+  string for exact argv boundaries) and `with.command` (`ffmpeg` or
+  `ffprobe`, defaulting to `ffmpeg`)
+- the automation-safe options the action prepends to `with.args`:
+  `-hide_banner` (unless `hideBanner: false`), and, for `ffmpeg` only,
+  `-nostdin` (unless `nostdin: false`) and `-y`/`-n` (`with.overwrite`)
+- `with.workdir`, `with.env` (a newline-delimited `KEY=value` string or a
+  JSON object string -- not a native YAML mapping), `with.timeoutSeconds`,
+  and `with.maxOutputBytes`
+- the result object: `ok`, `exitCode`, `signal`, `command`, `args`,
+  `stdout`/`stderr`, `durationMs`, `timedOut`, `truncated`, and `error`
+- that bad shell quoting or a malformed `with.env` line -- caught by the
+  action's own wrapper, not its input schema -- report a populated `error`
+  object with `ok: false` and `exitCode: -1`, while a real `ffmpeg`/
+  `ffprobe` process failure (a bad input file, exceeding
+  `with.timeoutSeconds`) reports through the ordinary `exitCode`/`stdout`/
+  `stderr` fields instead, with no `error` object
+- that exceeding `with.timeoutSeconds` sends `SIGTERM`, and `ffmpeg` traps
+  it and exits with its own conventional signal-exit code (`255`) rather
+  than being killed outright, so `exitCode` is a real positive number even
+  though `timedOut` is `true`
+- that a later step reads a result field as `${<step id>.outputs.<path>}`
+  (a bare-step-id reference), the same form confirmed for `node-script@v1`,
+  `python-script@v1`, and `dbt@v1`, and not via the strict
+  `${steps.<step id>.outputs.<name>}` form
+- that `dagu validate` never resolves a remote action reference: an
+  `ffmpeg@v1` step passes validate regardless of its `with:` content, and
+  `with.args` being required is enforced only once the step actually runs
+
+This spec does not define:
+
+- the ffmpeg action's own implementation, versioning, or release process --
+  this spec treats `ffmpeg@v1` as an external dependency and documents its
+  observed contract
+- `ffmpeg`/`ffprobe`'s own command-line semantics, codec behavior, or exit
+  code conventions beyond how the action surfaces them
+- the generic remote-action resolution mechanism itself, or the
+  `${<step id>.outputs.<path>}` reference form's own resolution mechanism --
+  both are covered in more depth by [Spec 060: Node Script
+  Action](060-node-script.md) and [Spec 007: Value Resolution
+  Steps](007-value-resolution-steps.md)
+- performance or caching behavior of the action's own tool provisioning
+
+## Goal
+
+Workflow authors transcode, inspect, or otherwise process media files with
+real `ffmpeg`/`ffprobe`, without baking FFmpeg into worker images or
+managing its installation themselves.
+
+## Behavior
+
+### Input
+
+`with.args` is required: a shell-style argument string (parsed by the
+action's own wrapper, not a shell -- it supports single and double quotes
+and backslash escapes) excluding the executable name. A string starting
+with `[` is instead parsed as a JSON array, giving exact argv boundaries
+without shell-style quoting ambiguity. `with.command` selects `ffmpeg` or
+`ffprobe` and defaults to `ffmpeg`.
+
+`with.hideBanner` (default `true`) and, for `ffmpeg` only, `with.nostdin`
+(default `true`) and `with.overwrite` (default `false`) control automation-
+safe options the action prepends to `with.args`, in this order:
+`-hide_banner`, `-nostdin`, then `-y` (`overwrite: true`) or `-n`
+(`overwrite: false`). `ffprobe` never gets `-nostdin` or `-y`/`-n` -- only
+`-hide_banner` applies to both commands.
+
+`with.workdir`, when set, is the working directory the `ffmpeg`/`ffprobe`
+process runs in; a relative path in `with.args` resolves against it.
+`with.env`, when set, is extra environment variables exposed to the
+process, as a newline-delimited `KEY=value` string or a JSON object
+string -- the action's own input schema types this field as a string, so a
+native YAML mapping for `with.env` fails validation (`want "string"`),
+unlike `dbt@v1`'s `with.env`, which is a plain object. `with.timeoutSeconds`
+(default `3600`) bounds how long the process may run; `with.maxOutputBytes`
+(default `1048576`) caps how much of the process's stdout and stderr are
+captured for the result.
+
+### Result
+
+The step's stdout is one JSON object:
+
+- `ok`: `true` when the process exited with code `0` before
+  `with.timeoutSeconds` was reached.
+- `exitCode`: the real process exit code, or `-1` when the process never
+  produced one (a wrapper-level validation failure, or a failure to even
+  start the process).
+- `signal`: present only when the process was terminated by a signal the
+  process itself did not handle (rare for `ffmpeg`; see below).
+- `command`: `ffmpeg` or `ffprobe`.
+- `args`: the full argv passed to the process, including the automation-
+  safe options the action prepended.
+- `stdout`/`stderr`: captured process output, truncated to
+  `with.maxOutputBytes`.
+- `durationMs`: wrapper-measured process duration.
+- `timedOut`: `true` when `with.timeoutSeconds` was reached.
+- `truncated`: `{stdout, stderr}` booleans, each `true` when that stream
+  was cut off at `with.maxOutputBytes`.
+- `error`: present only when the action's own wrapper rejects the resolved
+  input (for example, unparseable shell quoting in `with.args`, or a
+  `with.env` line not in `KEY=value` form) before ever invoking
+  `ffmpeg`/`ffprobe`. It has `name` (for example, `ValidationError`) and
+  `message`. This differs from `dbt@v1`, where the equivalent path is
+  effectively unreachable through schema-valid input -- here, several of
+  the wrapper's own checks (shell-quoting validity, `env` line syntax) go
+  beyond what the input schema can express, so they are reachable in
+  practice.
+
+A real `ffmpeg`/`ffprobe` failure -- a bad input file, an unresolvable
+codec, a profile mismatch -- reports through the ordinary `exitCode`/
+`stdout`/`stderr` fields with `ok: false` and no `error` object: the
+process started and ran, it just exited non-zero.
+
+Exceeding `with.timeoutSeconds` sends the process `SIGTERM`; if it is still
+running 5 seconds later, the action sends `SIGKILL`. In practice, `ffmpeg`
+traps `SIGTERM` and exits on its own with its conventional signal-exit code
+(`255`) rather than being killed outright, so a timed-out result typically
+has `timedOut: true`, `ok: false`, and a real positive `exitCode` (`255`),
+with no `signal` field -- `signal` is populated only when the process is
+actually killed by an unhandled signal (for example, after the `SIGKILL`
+grace period elapses).
+
+### Downstream references
+
+A later step reads a field of the result as `${<step id>.outputs.<path>}`
+-- the step ID used directly as the reference's namespace. This matches
+the behavior [Spec 060: Node Script Action](060-node-script.md), [Spec 061:
+Python Script Action](061-python-script.md), and [Spec 062: DBT
+Action](062-dbt.md) document, confirming it is a property of remote
+action:-type steps generally, not specific to one action. The strict
+`${steps.<step id>.outputs.<name>}` form documented for declared step
+outputs (see [Spec 012: Step Outputs](012-step-outputs.md)) does not
+resolve for an `ffmpeg@v1` step, for the same reason it does not for the
+other remote actions above.
+
+## Errors
+
+### Validation
+
+- An action reference missing its required `@version` suffix (for example,
+  `ffmpeg` instead of `ffmpeg@v1`): an error containing `unknown action`.
+  This is enforced generically for any action reference, not specifically
+  for `ffmpeg`.
+
+`dagu validate` does not resolve the remote action reference at all, so it
+cannot check `ffmpeg@v1`'s own requirements (such as `with.args` being
+required) -- a step missing `with.args` passes validate.
+
+### Runtime
+
+- `with.args` missing: an error containing `missing properties:
+  ["args"]`, raised when the action resolves its own input schema against
+  the step's `with:` content -- before `ffmpeg`/`ffprobe` is ever invoked.
+- `with.command` set to a value other than `ffmpeg`/`ffprobe`: an error
+  containing `does not equal any of`, raised by the same input-schema
+  check.
+- `with.env` given as a native YAML mapping rather than a string: an error
+  containing `has type "object"` (the schema requires a string), raised by
+  the same input-schema check.
+- Unparseable shell quoting in `with.args` (for example, an unterminated
+  quote), or a `with.env` line not in `KEY=value` form: the step fails (a
+  non-zero exit) with a populated `error` object (`name: "ValidationError"`)
+  in the JSON result, `ok: false`, and `exitCode: -1` -- the process is
+  never started.
+- A real `ffmpeg`/`ffprobe` failure, or exceeding `with.timeoutSeconds`:
+  the step fails (a non-zero exit), with the diagnostic JSON result
+  described above still written to stdout.
+
+## Related Specs
+
+- Node script action, DBT action, and Python script action, for the
+  equivalent remote-action execution model and downstream-reference
+  behavior this action shares: [Spec 060: Node Script Action](060-node-script.md),
+  [Spec 061: Python Script Action](061-python-script.md), [Spec 062: DBT
+  Action](062-dbt.md)
+- Step outputs and reference syntax, for contrast with the bare-step-id
+  reference form this action's result uses: [Spec 012: Step
+  Outputs](012-step-outputs.md)
+
+## Examples
+
+Convert a media file and inspect it with `ffprobe`:
+
+```yaml
+steps:
+  - id: convert
+    action: ffmpeg@v1
+    with:
+      overwrite: true
+      args: -i input.mov -c:v libx264 -c:a aac output.mp4
+
+  - id: inspect
+    depends: convert
+    action: ffmpeg@v1
+    with:
+      command: ffprobe
+      args: -v error -print_format json -show_format -show_streams output.mp4
+
+  - id: print_probe
+    depends: inspect
+    run: echo "${inspect.outputs.stdout}"
+```
+
+Bound a run with a timeout:
+
+```yaml
+steps:
+  - action: ffmpeg@v1
+    with:
+      timeoutSeconds: 30
+      args: -i input.mov -c:v libx264 output.mp4
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [064: FFmpeg Action](064-ffmpeg.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

Cover the official remote action ffmpeg@v1 against a real FFmpeg/
  ffprobe binary: with.args (shell-style and JSON-array forms) and
  with.command, the automation-safe -hide_banner/-nostdin/-y/-n options
  the action prepends, with.workdir/env/timeoutSeconds/maxOutputBytes,
  and the ok/exitCode/signal/command/args/stdout/stderr/durationMs/
  timedOut/truncated/error result shape.

  Unlike dbt@v1, confirms ffmpeg@v1's error object is reachable through
  schema-valid input: bad shell quoting and a malformed with.env line
  fail inside the wrapper itself (checks beyond what the input schema
  expresses) and report a populated ValidationError object, while a real
  ffmpeg failure or a timeout (ffmpeg traps SIGTERM and exits with its
  own conventional code 255) report through the ordinary exitCode field
  instead. Also confirms the bare-step-id ${<id>.outputs.<path>}
  downstream reference form generalizes to a fourth remote action.
## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conformance coverage for the FFmpeg remote action, including media conversion, probing, environment variables, timeouts, output limits, and failure handling.
  - Added support documentation for FFmpeg action inputs, outputs, execution options, and downstream result references.

- **Bug Fixes**
  - Prevented nested executor-specific environment settings from being incorrectly rewritten during manifest decoding.
  - Preserved environment variable objects and root-level ordering during YAML processing.

- **Documentation**
  - Added FFmpeg Action specification and included it in the specifications status list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->