### PR TITLE
test: add black-box conformance coverage for github-cli@v1

### DIFF
--- a/conformance/spec065_github_cli/github_cli_helper_test.go
+++ b/conformance/spec065_github_cli/github_cli_helper_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec065_github_cli_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// One match appears per step that wrote anything to stdout, in the order
+// dagu's tree render lists them (which, for both the sequential and the
+// independent-but-declared-in-order fixtures this package uses, matches
+// declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// or JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}

--- a/conformance/spec065_github_cli/github_cli_test.go
+++ b/conformance/spec065_github_cli/github_cli_test.go
@@ -1,0 +1,187 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec065_github_cli holds black-box conformance tests for Spec
+// 065: GitHub CLI Action (github-cli@v1).
+//
+// Like node-script@v1 (spec 060), python-script@v1 (spec 061), dbt@v1
+// (spec 062), and ffmpeg@v1 (spec 064), github-cli@v1 is a remote official
+// action: referencing it clones https://github.com/dagucloud/github-cli at
+// the given tag and provisions its own pinned gh CLI and Node.js toolchain
+// (via the project's aqua-based tool manager) into the isolated $HOME each
+// test run gets, on first use, then runs the real gh binary it installs.
+// This environment has no GitHub credentials configured, so every gh
+// subcommand that needs auth (almost all of them, including read-only ones
+// like "repo view") fails with a real, deterministic gh error -- this
+// package treats that as ground truth rather than a limitation: it proves
+// with.env/with.host/with.repo reach the real gh process by observing how
+// they change which real error gh reports, and reserves a successful
+// (ok: true) run for "gh --version", the one subcommand that needs neither
+// auth nor network. Steps that reach the wrapper are chained with
+// depends+continue_on: failed rather than left independent, to avoid several
+// concurrent cold invocations racing GitHub's aqua-registry API and hitting
+// its rate limit (this previously caused spec 064's suite to intermittently
+// stall on 403 responses).
+package spec065_github_cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubCliLive(t *testing.T) {
+	// No subtest below uses t.Parallel(): each calls t.Setenv to raise the
+	// harness's per-command timeout defensively, and t.Setenv itself
+	// forbids t.Parallel() in the same test.
+	t.Run("gh runs for real, and with.workdir/repo/host/env are all accepted without breaking a successful run", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		dagu.Mkdir("workdir")
+		env := []string{"HOST_WORK_DIR=" + dagu.ProjectPath("workdir")}
+		result := dagu.RunWithEnv(env, "start", "happy_path.yaml")
+		result.ExpectExitCode(0)
+
+		var version struct {
+			OK        bool   `json:"ok"`
+			ExitCode  int    `json:"exitCode"`
+			GhVersion string `json:"ghVersion"`
+			Stdout    string `json:"stdout"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &version))
+		require.True(t, version.OK)
+		require.Zero(t, version.ExitCode)
+		require.Contains(t, version.GhVersion, "gh version 2.92.0")
+		require.Contains(t, version.Stdout, "gh version 2.92.0")
+
+		var withFields struct {
+			OK       bool `json:"ok"`
+			ExitCode int  `json:"exitCode"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &withFields))
+		require.True(t, withFields.OK, "with.workdir/repo/host/env should not interfere with a command that ignores all of them")
+		require.Zero(t, withFields.ExitCode)
+	})
+
+	t.Run("a real gh failure (no auth, a bad token, an unreachable host) reports through exitCode/stderr, and a blackholed host times out", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "error_scenarios.yaml")
+		result.ExpectNonZeroExitCode()
+
+		// with.args missing, with.args an empty array, and with.timeoutSeconds
+		// out of range are all caught by the action's own input schema
+		// before the wrapper ever runs, so none of these three steps has a
+		// stdout log of its own to read.
+		require.Contains(t, result.Stdout(), `missing properties: ["args"]`)
+		require.Contains(t, result.Stdout(), "less than 1")
+		require.Contains(t, result.Stdout(), "greater than")
+
+		// This sandbox has no gh auth configured at all, so any command
+		// needing it (almost all of them) fails locally and immediately
+		// with gh's own "not authenticated" error -- a real, deterministic
+		// gh outcome, not a wrapper-level validation error.
+		var noAuth struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Stderr   string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &noAuth))
+		require.False(t, noAuth.OK)
+		require.Equal(t, 4, noAuth.ExitCode)
+		require.Contains(t, noAuth.Stderr, "gh auth login")
+
+		// with.env reaches the real gh process: a bogus GH_TOKEN clears
+		// gh's own local auth gate (a token is present) and gh attempts a
+		// real GitHub API call, which then fails with a real HTTP 401 --
+		// proof the token value itself made it to the process.
+		var badToken struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Stderr   string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &badToken))
+		require.False(t, badToken.OK)
+		require.Equal(t, 1, badToken.ExitCode)
+		require.Contains(t, badToken.Stderr, "Bad credentials")
+
+		// with.host reaches the real gh process too: gh attempts to
+		// resolve/connect to the given host instead of github.com.
+		var badHost struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Stderr   string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &badHost))
+		require.False(t, badHost.OK)
+		require.Equal(t, 1, badHost.ExitCode)
+		require.Contains(t, badHost.Stderr, "gh.invalid.example.test")
+
+		// with.timeoutSeconds: a host address that never responds (a
+		// TEST-NET-1 address, RFC 5737) blocks the real network connection
+		// well past the 2-second timeout, so the wrapper sends SIGTERM.
+		// The wrapper forces exitCode to 124 on any timeout, unlike
+		// ffmpeg@v1, which reports the real process's own signal-exit
+		// code. gh does not trap SIGTERM, so it is actually killed by the
+		// (unhandled) signal, and the wrapper synthesizes a "terminated by
+		// <signal>" stderr message since gh itself produced none.
+		var timedOut struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			TimedOut bool   `json:"timedOut"`
+			Stderr   string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &timedOut))
+		require.False(t, timedOut.OK)
+		require.Equal(t, 124, timedOut.ExitCode)
+		require.True(t, timedOut.TimedOut)
+		require.Contains(t, timedOut.Stderr, "terminated by SIGTERM")
+	})
+
+	// Like node-script@v1, python-script@v1, dbt@v1, and ffmpeg@v1, a later
+	// step reads a result field as ${<step id>.outputs.<name>} -- a
+	// bare-step-id reference, not ${steps.<step id>.outputs.<name>} --
+	// confirming this is a property of remote action:-type steps generally,
+	// not specific to one action.
+	t.Run("a later step reads a result field as ${<step id>.outputs.<name>}, but not via steps.<id>.outputs.<name>", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("start", "downstream_reference.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains("bad substitution")
+
+		require.Equal(t, "bare exit code is 0\n", stepStdout(t, result.Stdout(), 1))
+	})
+}
+
+// TestGithubCliValidation proves that dagu validate never resolves a remote
+// action reference (which would require network access): a github-cli@v1
+// step passes validate regardless of its with: content, and even with.args
+// -- required by the action's own inputs schema -- is enforced only once
+// the step actually runs and that schema is fetched. The one thing
+// validate does check locally is the action reference's own syntax.
+func TestGithubCliValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a github-cli@v1 step with no with.args passes validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "error_scenarios.yaml")
+		result.ExpectExitCode(0)
+	})
+
+	t.Run("an action reference missing its required @version suffix fails validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "no_version_suffix.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains(`unknown action "github-cli"`)
+	})
+}

--- a/conformance/spec065_github_cli/testdata/downstream_reference.yaml
+++ b/conformance/spec065_github_cli/testdata/downstream_reference.yaml
@@ -1,0 +1,11 @@
+steps:
+  - id: version
+    action: github-cli@v1
+    with:
+      args: ["--version"]
+  - id: print_bare
+    depends: version
+    run: echo "bare exit code is ${version.outputs.exitCode}"
+  - id: print_strict
+    depends: version
+    run: echo "strict=${steps.version.outputs.exitCode}"

--- a/conformance/spec065_github_cli/testdata/error_scenarios.yaml
+++ b/conformance/spec065_github_cli/testdata/error_scenarios.yaml
@@ -1,0 +1,52 @@
+steps:
+  - id: missing_args
+    action: github-cli@v1
+    continue_on: failed
+    with: {}
+
+  - id: empty_args
+    depends: missing_args
+    action: github-cli@v1
+    continue_on: failed
+    with:
+      args: []
+
+  - id: bad_timeout
+    depends: empty_args
+    action: github-cli@v1
+    continue_on: failed
+    with:
+      args: ["--version"]
+      timeoutSeconds: 9999
+
+  - id: no_auth
+    depends: bad_timeout
+    action: github-cli@v1
+    continue_on: failed
+    with:
+      args: ["repo", "view", "dagucloud/dagu", "--json", "name"]
+
+  - id: bad_token
+    depends: no_auth
+    action: github-cli@v1
+    continue_on: failed
+    with:
+      args: ["repo", "view", "dagucloud/dagu", "--json", "name"]
+      env:
+        GH_TOKEN: definitely-not-a-real-token-123
+
+  - id: bad_host
+    depends: bad_token
+    action: github-cli@v1
+    continue_on: failed
+    with:
+      host: gh.invalid.example.test
+      args: ["repo", "view", "dagucloud/dagu", "--json", "name"]
+
+  - id: times_out
+    depends: bad_host
+    action: github-cli@v1
+    with:
+      host: 192.0.2.1
+      timeoutSeconds: 2
+      args: ["repo", "view", "dagucloud/dagu", "--json", "name"]

--- a/conformance/spec065_github_cli/testdata/happy_path.yaml
+++ b/conformance/spec065_github_cli/testdata/happy_path.yaml
@@ -1,0 +1,18 @@
+env:
+  - WORK_DIR: $HOST_WORK_DIR
+steps:
+  - id: version
+    action: github-cli@v1
+    with:
+      args: ["--version"]
+
+  - id: version_with_fields
+    depends: version
+    action: github-cli@v1
+    with:
+      args: ["--version"]
+      workdir: $WORK_DIR
+      repo: dagucloud/dagu
+      host: github.com
+      env:
+        EXTRA_VAR: hello

--- a/conformance/spec065_github_cli/testdata/no_version_suffix.yaml
+++ b/conformance/spec065_github_cli/testdata/no_version_suffix.yaml
@@ -1,0 +1,4 @@
+steps:
+  - action: github-cli
+    with:
+      args: ["--version"]

--- a/internal/spec/manifest_decoder.go
+++ b/internal/spec/manifest_decoder.go
@@ -111,6 +111,22 @@ func preserveEnvMappingOrder(data []byte, parsed map[string]any) error {
 	return nil
 }
 
+// opaqueDataKeys holds step/DAG fields whose value is data owned by
+// something other than dagu's own DAG/step schema: an executor's with:
+// config, a step's or the DAG's own inline params: JSON Schema, and the
+// legacy config: field. None of dagu's own env: declarations (DAG-level,
+// defaults.env, step-level, or container.env) are ever nested inside one of
+// these, but arbitrary executor- or schema-owned data underneath them can
+// coincidentally use "env" as a field or property name (for example, a
+// remote action's own with.env input, or a params: schema property named
+// "env"). patchOrderedEnvValues must not descend into these keys, or it
+// rewrites that unrelated mapping into dagu's ordered env-list shape too.
+var opaqueDataKeys = map[string]bool{
+	"with":   true,
+	"params": true,
+	"config": true,
+}
+
 func patchOrderedEnvValues(node ast.Node, target any) error {
 	switch value := node.(type) {
 	case *ast.MappingNode:
@@ -133,6 +149,9 @@ func patchOrderedEnvValues(node ast.Node, target any) error {
 					targetMap[key] = env
 					continue
 				}
+			}
+			if opaqueDataKeys[key] {
+				continue
 			}
 			if err := patchOrderedEnvValues(item.Value, targetMap[key]); err != nil {
 				return err

--- a/internal/spec/manifest_decoder_regression_test.go
+++ b/internal/spec/manifest_decoder_regression_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for patchOrderedEnvValues rewriting any mapping keyed
+// "env" into the DAG's own ordered env-list shape, even when that mapping
+// belongs to unrelated data nested under a step's with:/params: field (see
+// internal/spec/manifest_decoder.go's opaqueDataKeys).
+
+func TestPreserveEnvMappingOrder_ParamsSchemaEnvPropertyDoesNotBreakDecode(t *testing.T) {
+	t.Parallel()
+
+	_, err := spec.LoadYAML(context.Background(), []byte(`
+name: params-schema-env-property
+params:
+  type: object
+  properties:
+    env:
+      type: string
+      default: ""
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+}
+
+func TestPreserveEnvMappingOrder_WithEnvStaysPlainObject(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: with-env-plain-object
+steps:
+  - name: run
+    action: node-script@v1
+    with:
+      script: return 1
+      env:
+        FOO: bar
+`))
+	require.NoError(t, err)
+	input, ok := dag.Steps[0].ExecutorConfig.Config["input"].(map[string]any)
+	require.True(t, ok, "action executor config should nest with: under input")
+	require.Equal(t, map[string]any{"FOO": "bar"}, input["env"])
+}
+
+func TestPreserveEnvMappingOrder_RootEnvOrderStillPreserved(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: root-env-order
+env:
+  FIRST: one
+  SECOND: ${env.FIRST}-two
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"FIRST=one", "SECOND=one-two"}, dag.Env)
+}

--- a/specs/065-github-cli.md
+++ b/specs/065-github-cli.md
@@ -1,0 +1,229 @@
+# Spec: GitHub CLI Action
+
+## Status
+
+Implemented.
+
+This spec defines conformance behavior for the official remote action
+`github-cli@v1` (`dagucloud/github-cli`).
+
+## Scope
+
+Like `node-script@v1` ([Spec 060: Node Script Action](060-node-script.md)),
+`python-script@v1` ([Spec 061: Python Script Action](061-python-script.md)),
+`dbt@v1` ([Spec 062: DBT Action](062-dbt.md)), and `ffmpeg@v1` ([Spec 064:
+FFmpeg Action](064-ffmpeg.md)), `github-cli@v1` is not a built-in Go
+executor. It is an official remote action: a git repository
+(`dagucloud/github-cli`) containing a `dagu-action.yaml` manifest and a DAG
+that runs a real `gh` binary the action provisions via the project's
+aqua-based tool manager (`cli/cli@v2.92.0` and `nodejs/node@v22.21.1`; the
+action's own wrapper is a Node.js script). Referencing `github-cli@v1`
+resolves through Dagu's generic remote-action mechanism, which clones the
+action's repository and provisions its pinned tools on first use.
+
+This spec covers:
+
+- the required `with.args` (an array of strings passed to `gh` verbatim,
+  with no shell parsing) and the optional `with.stdin`, `with.env`,
+  `with.repo`, `with.host`, `with.workdir`, and `with.timeoutSeconds`
+- that `with.repo` and `with.host` map to the `GH_REPO` and `GH_HOST`
+  environment variables the real `gh` process reads, and `with.env` is
+  merged on top of a fixed set of automation-safe defaults
+  (`GH_PROMPT_DISABLED`, `GH_NO_UPDATE_NOTIFIER`, `GH_SPINNER_DISABLED`,
+  `GH_TELEMETRY=false`) the action sets unless already present in the
+  process environment
+- the result object: `ok`, `exitCode`, `stdout`/`stderr`, `durationMs`,
+  `ghVersion`, `timedOut`, and `error`
+- that exceeding `with.timeoutSeconds` always reports `exitCode: 124`
+  (forced by the wrapper, unlike `ffmpeg@v1`, which reports the real
+  process's own signal-exit code) and, when the underlying process has no
+  output of its own at the point it is killed, a synthesized
+  `terminated by <signal>` `stderr` message
+- that a real `gh` failure (missing authentication, a bad token, an
+  unreachable host) reports through the ordinary `exitCode`/`stdout`/
+  `stderr` fields with `ok: false` and no `error` object -- the process
+  started and ran, it just exited non-zero
+- that a later step reads a result field as `${<step id>.outputs.<path>}`
+  (a bare-step-id reference), the same form confirmed for `node-script@v1`,
+  `python-script@v1`, `dbt@v1`, and `ffmpeg@v1`, and not via the strict
+  `${steps.<step id>.outputs.<name>}` form
+- that `dagu validate` never resolves a remote action reference: a
+  `github-cli@v1` step passes validate regardless of its `with:` content,
+  and `with.args` being required is enforced only once the step actually
+  runs
+
+This spec does not define:
+
+- the github-cli action's own implementation, versioning, or release
+  process -- this spec treats `github-cli@v1` as an external dependency and
+  documents its observed contract
+- `gh`'s own command-line semantics, authentication model, or exit code
+  conventions beyond how the action surfaces them
+- the generic remote-action resolution mechanism itself, or the
+  `${<step id>.outputs.<path>}` reference form's own resolution mechanism --
+  both are covered in more depth by [Spec 060: Node Script
+  Action](060-node-script.md) and [Spec 007: Value Resolution
+  Steps](007-value-resolution-steps.md)
+- performance or caching behavior of the action's own tool provisioning
+
+## Goal
+
+Workflow authors automate GitHub repository, issue, pull request, release,
+or API operations through the real `gh` CLI, without installing or
+authenticating it outside the workflow.
+
+## Behavior
+
+### Input
+
+`with.args` is required: a non-empty array of non-empty strings passed to
+`gh` as its argument vector, excluding the executable name -- unlike
+`ffmpeg@v1`'s `with.args`, there is no shell-style string form and no
+shell-style parsing to get wrong. `with.stdin`, when set, is text written to
+`gh`'s stdin.
+
+`with.env`, when set, is an object of extra environment variables for the
+`gh` process (unlike `ffmpeg@v1`'s `with.env`, this one is a plain object,
+not a string). `with.repo` (`[HOST/]OWNER/REPO`) and `with.host` map to the
+`GH_REPO` and `GH_HOST` environment variables `gh` itself reads to select a
+repository or host without an explicit `--repo`/`--hostname` flag on every
+command. `with.workdir`, when set, is the working directory the `gh`
+process runs in. `with.timeoutSeconds` (default `300`, maximum `1800`)
+bounds how long the process may run.
+
+The action always sets `GH_PROMPT_DISABLED=1`, `GH_NO_UPDATE_NOTIFIER=1`,
+`GH_SPINNER_DISABLED=1`, and `GH_TELEMETRY=false` for the `gh` process,
+unless the parent process environment already defines them -- these keep
+`gh` from blocking on an interactive prompt or spinner in an unattended
+run. `with.env` entries are applied after these defaults and after
+`with.repo`/`with.host`, so they can override any of them.
+
+### Result
+
+The step's stdout is one JSON object:
+
+- `ok`: `true` when `gh` exited with code `0` before `with.timeoutSeconds`
+  was reached.
+- `exitCode`: `gh`'s real exit code, `124` when `with.timeoutSeconds` was
+  reached (regardless of how `gh` itself responded to being signaled), or
+  `-1` when the process never started.
+- `stdout`/`stderr`: text `gh` wrote to stdout and stderr. If the process
+  was killed by a signal and produced no stderr of its own, this field is
+  synthesized as `terminated by <signal>` instead of being left empty.
+- `durationMs`: wrapper-measured process duration.
+- `ghVersion`: the first line of `gh --version`, captured independently of
+  `with.args` -- it is present even when the requested command itself
+  fails.
+- `timedOut`: `true` when `with.timeoutSeconds` was reached.
+- `error`: present only when the action's own wrapper rejects the resolved
+  input before ever invoking `gh` (for example, `with.timeoutSeconds` not
+  an integer) or fails to start the process at all. As with `dbt@v1`, this
+  is not reached in practice for a step that already passed the action's
+  input schema: every wrapper-level check duplicates a constraint the
+  schema already enforces (an array-of-strings `args`, a plain-object
+  `env`, an in-range integer `timeoutSeconds`), so schema-valid input never
+  reaches the wrapper's own validation code.
+
+On `with.timeoutSeconds` being reached, the wrapper sends `SIGTERM`; if the
+process is still running two seconds later, it sends `SIGKILL`. Unlike
+`ffmpeg@v1` (which traps `SIGTERM` and exits with a real, positive exit
+code), `gh` does not trap it and is actually killed by the signal -- but
+the result's `exitCode` is still reported as `124` either way, since the
+wrapper forces that value whenever `timedOut` is `true`.
+
+A real `gh` failure -- missing authentication, an invalid token, an
+unreachable host -- reports through the ordinary `exitCode`/`stdout`/
+`stderr` fields with `ok: false` and no `error` object: the process started
+and ran, it just exited non-zero. This includes `gh`'s own "not
+authenticated" failure (exit code `4`), which every read or write command
+in this spec's environment produces, since no `GH_TOKEN`/`GITHUB_TOKEN` is
+ever configured -- `gh` refuses to attempt any API call at all without one,
+regardless of whether the target data would otherwise be public.
+
+### Downstream references
+
+A later step reads a field of the result as `${<step id>.outputs.<path>}`
+-- the step ID used directly as the reference's namespace. This matches
+the behavior [Spec 060: Node Script Action](060-node-script.md), [Spec
+061: Python Script Action](061-python-script.md), [Spec 062: DBT
+Action](062-dbt.md), and [Spec 064: FFmpeg Action](064-ffmpeg.md) document,
+confirming it is a property of remote action:-type steps generally, not
+specific to one action. The strict `${steps.<step id>.outputs.<name>}`
+form documented for declared step outputs (see [Spec 012: Step
+Outputs](012-step-outputs.md)) -- and used in this action's own published
+example -- does not resolve for a `github-cli@v1` step, for the same
+reason it does not for the other remote actions above.
+
+## Errors
+
+### Validation
+
+- An action reference missing its required `@version` suffix (for example,
+  `github-cli` instead of `github-cli@v1`): an error containing `unknown
+  action`. This is enforced generically for any action reference, not
+  specifically for `github-cli`.
+
+`dagu validate` does not resolve the remote action reference at all, so it
+cannot check `github-cli@v1`'s own requirements (such as `with.args` being
+required) -- a step missing `with.args` passes validate.
+
+### Runtime
+
+- `with.args` missing, or an empty array: an error containing `missing
+  properties: ["args"]` or `less than 1`, raised when the action resolves
+  its own input schema against the step's `with:` content -- before `gh`
+  is ever invoked.
+- `with.timeoutSeconds` outside `1`-`1800`: an error containing `greater
+  than` or a comparable bound violation, raised by the same input-schema
+  check.
+- A real `gh` failure (missing authentication, a bad token, an unreachable
+  host): the step fails (a non-zero exit), with the diagnostic JSON result
+  described above still written to stdout, and no `error` object.
+- Exceeding `with.timeoutSeconds`: the step fails (a non-zero exit) with
+  `exitCode: 124` and `timedOut: true`.
+
+## Related Specs
+
+- Node script action, Python script action, DBT action, and FFmpeg action,
+  for the equivalent remote-action execution model and downstream-reference
+  behavior this action shares: [Spec 060: Node Script Action](060-node-script.md),
+  [Spec 061: Python Script Action](061-python-script.md), [Spec 062: DBT
+  Action](062-dbt.md), [Spec 064: FFmpeg Action](064-ffmpeg.md)
+- Step outputs and reference syntax, for contrast with the bare-step-id
+  reference form this action's result uses: [Spec 012: Step
+  Outputs](012-step-outputs.md)
+
+## Examples
+
+Read a public repository's metadata and print it from a later step:
+
+```yaml
+steps:
+  - id: repo
+    action: github-cli@v1
+    with:
+      repo: dagucloud/dagu
+      args: ["repo", "view", "--json", "name,description,url"]
+
+  - id: print
+    depends: repo
+    run: echo "${repo.outputs.stdout}"
+```
+
+Pass a token for an authenticated call:
+
+```yaml
+secrets:
+  - name: GH_TOKEN
+    provider: env
+    key: GH_TOKEN
+
+steps:
+  - id: latest_release
+    action: github-cli@v1
+    with:
+      repo: dagucloud/dagu
+      args: ["api", "repos/{owner}/{repo}/releases/latest", "--jq", ".tag_name"]
+      env:
+        GH_TOKEN: ${env.GH_TOKEN}
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [065: GitHub CLI Action](065-github-cli.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

Cover the official remote action github-cli@v1 against a real gh
  binary: with.args (array form, no shell parsing), with.stdin/env/repo/
  host/workdir/timeoutSeconds, and the ok/exitCode/stdout/stderr/
  durationMs/ghVersion/timedOut/error result shape.

  This sandbox has no GitHub credentials, so every gh command needing
  auth fails deterministically -- treated as ground truth: with.env/
  with.host/with.repo are proven to reach the real gh process by how
  they change which real gh error is reported (no-auth -> exit 4, a bad
  token -> HTTP 401, an unreachable host -> connection error), and
  gh --version covers the one successful (ok: true) path. Confirms
  with.timeoutSeconds always forces exitCode 124 regardless of how gh
  itself responds to SIGTERM (unlike ffmpeg@v1's real signal-exit code),
  and that the bare-step-id ${<id>.outputs.<path>} downstream reference
  form generalizes to a fifth remote action -- contradicting this
  action's own published example, which uses the strict form.
## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conformance coverage for the GitHub CLI remote action, including configuration, validation, authentication, host, timeout, and output-reference scenarios.
  - Documented the GitHub CLI action’s inputs, results, error handling, and usage examples.
  - Listed the GitHub CLI action as partially implemented in the specification status.

- **Bug Fixes**
  - Prevented nested executor-specific `env` fields from being incorrectly transformed during manifest processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->