### PR TITLE
test: add black-box conformance coverage for rclone@v1

### DIFF
--- a/conformance/spec066_rclone/rclone_helper_test.go
+++ b/conformance/spec066_rclone/rclone_helper_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec066_rclone_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// One match appears per step that wrote anything to stdout, in the order
+// dagu's tree render lists them (which, for both the sequential and the
+// independent-but-declared-in-order fixtures this package uses, matches
+// declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// or JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}

--- a/conformance/spec066_rclone/rclone_test.go
+++ b/conformance/spec066_rclone/rclone_test.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec066_rclone holds black-box conformance tests for Spec 066:
+// Rclone Action (rclone@v1).
+//
+// Like node-script@v1 (spec 060), python-script@v1 (spec 061), dbt@v1
+// (spec 062), ffmpeg@v1 (spec 064), and github-cli@v1 (spec 065),
+// rclone@v1 is a remote official action: referencing it clones
+// https://github.com/dagucloud/rclone at the given tag and provisions its
+// own pinned rclone and Node.js toolchain (via the project's aqua-based
+// tool manager) into the isolated $HOME each test run gets, on first use,
+// then runs the real rclone binary it installs against a real local
+// directory (no external storage backend is needed to exercise copy/sync/
+// list). Steps that reach the wrapper are chained with depends +
+// continue_on: failed (set on the failing step itself, not its dependent --
+// continue_on on a step whose predecessor failed at schema-validation time
+// does not let it proceed, but does when the predecessor failed at
+// runtime), to avoid concurrent cold invocations racing GitHub's
+// aqua-registry API (see spec 064).
+package spec066_rclone_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func rcloneSrcDstEnv(dagu *harness.Runner) []string {
+	dagu.WriteFile("src/a.txt", "hello\n")
+	dagu.WriteFile("src/b.txt", "world\n")
+	dagu.Mkdir("dst")
+	return []string{
+		"HOST_SRC_DIR=" + dagu.ProjectPath("src"),
+		"HOST_DST_DIR=" + dagu.ProjectPath("dst"),
+	}
+}
+
+func TestRcloneLive(t *testing.T) {
+	// No subtest below uses t.Parallel(): each calls t.Setenv to raise the
+	// harness's per-command timeout defensively, and t.Setenv itself
+	// forbids t.Parallel() in the same test.
+	t.Run("rclone lists, dry-run previews, and a real copy actually copies files", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		env := rcloneSrcDstEnv(dagu)
+		result := dagu.RunWithEnv(env, "start", "happy_path.yaml")
+		result.ExpectExitCode(0)
+
+		var listFiles struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Command  string `json:"command"`
+			Stdout   string `json:"stdout"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &listFiles))
+		require.True(t, listFiles.OK)
+		require.Zero(t, listFiles.ExitCode)
+		require.Equal(t, "lsf", listFiles.Command)
+		require.Contains(t, listFiles.Stdout, "a.txt")
+		require.Contains(t, listFiles.Stdout, "b.txt")
+
+		var syncDryRun struct {
+			OK     bool   `json:"ok"`
+			Stderr string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &syncDryRun))
+		require.True(t, syncDryRun.OK)
+		require.Contains(t, syncDryRun.Stderr, "Skipped copy as --dry-run is set",
+			"dryRun: true must report what it would have copied without actually copying it")
+
+		var copyReal struct {
+			OK bool `json:"ok"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &copyReal))
+		require.True(t, copyReal.OK)
+		copied, err := os.ReadFile(filepath.Join(dagu.ProjectPath("dst"), "a.txt")) // #nosec G304 -- test's own known fixture output.
+		require.NoError(t, err, "allowDestructive: true should have actually copied a.txt")
+		require.Equal(t, "hello\n", string(copied))
+	})
+
+	t.Run("a missing path, a destructive command without allowDestructive, and a real rclone failure all populate a string error", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		env := rcloneSrcDstEnv(dagu)
+		result := dagu.RunWithEnv(env, "start", "error_scenarios.yaml")
+		result.ExpectNonZeroExitCode()
+
+		// with.command missing, an unsupported with.command, and an unknown
+		// with: field are all caught by the action's own input schema
+		// before the wrapper ever runs, so none of these three steps has a
+		// stdout log of its own to read. rclone@v1 has no with.timeoutSeconds
+		// field at all (unlike ffmpeg@v1/dbt@v1/github-cli@v1) -- the
+		// schema's additionalProperties: false rejects it outright.
+		require.Contains(t, result.Stdout(), `missing properties: ["command"]`)
+		require.Contains(t, result.Stdout(), "does not equal any of")
+		require.Contains(t, result.Stdout(), "unexpected additional properties")
+
+		// with.source/with.destination being required by the requested
+		// command, and a destructive command needing allowDestructive or
+		// dryRun, are all wrapper-level checks that go beyond what the
+		// input schema expresses (the schema cannot make a field's
+		// requiredness conditional on with.command's value) -- reachable
+		// through schema-valid input, unlike dbt@v1's near-unreachable
+		// error path. All three set exitCode: 2 and a plain string error,
+		// without ever invoking rclone.
+		var missingSource struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Error    string `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &missingSource))
+		require.False(t, missingSource.OK)
+		require.Equal(t, 2, missingSource.ExitCode)
+		require.Contains(t, missingSource.Error, "source is required")
+
+		var missingDestination struct {
+			OK    bool   `json:"ok"`
+			Error string `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &missingDestination))
+		require.False(t, missingDestination.OK)
+		require.Contains(t, missingDestination.Error, "destination is required")
+
+		var destructiveWithoutAllow struct {
+			OK    bool   `json:"ok"`
+			Error string `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &destructiveWithoutAllow))
+		require.False(t, destructiveWithoutAllow.OK)
+		require.Contains(t, destructiveWithoutAllow.Error, "allowDestructive")
+
+		// Unlike ffmpeg@v1/dbt@v1/github-cli@v1, rclone@v1 populates a
+		// string error field even for a real rclone process failure (not
+		// just a wrapper-level validation error) -- here, a nonexistent
+		// source directory.
+		var realFailure struct {
+			OK       bool   `json:"ok"`
+			ExitCode int    `json:"exitCode"`
+			Error    string `json:"error"`
+			Stderr   string `json:"stderr"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &realFailure))
+		require.False(t, realFailure.OK)
+		require.Equal(t, 3, realFailure.ExitCode)
+		require.Contains(t, realFailure.Error, "rclone exited with code 3")
+		require.Contains(t, realFailure.Stderr, "directory not found")
+	})
+
+	// Like node-script@v1, python-script@v1, dbt@v1, ffmpeg@v1, and
+	// github-cli@v1, a later step reads a result field as
+	// ${<step id>.outputs.<path>} -- a bare-step-id reference, not
+	// ${steps.<step id>.outputs.<name>} -- confirming this is a property
+	// of remote action:-type steps generally, not specific to one action.
+	t.Run("a later step reads a result field as ${<step id>.outputs.<name>}, but not via steps.<id>.outputs.<name>", func(t *testing.T) {
+		t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+		dagu := harness.NewRunner(t)
+		env := rcloneSrcDstEnv(dagu)
+		result := dagu.RunWithEnv(env, "start", "downstream_reference.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains("bad substitution")
+
+		require.Equal(t, "bare exit code is 0\n", stepStdout(t, result.Stdout(), 1))
+	})
+}
+
+// TestRcloneValidation proves that dagu validate never resolves a remote
+// action reference (which would require network access): a rclone@v1 step
+// passes validate regardless of its with: content, and even with.command --
+// required by the action's own inputs schema -- is enforced only once the
+// step actually runs and that schema is fetched. The one thing validate
+// does check locally is the action reference's own syntax.
+func TestRcloneValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a rclone@v1 step with no with.command passes validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "error_scenarios.yaml")
+		result.ExpectExitCode(0)
+	})
+
+	t.Run("an action reference missing its required @version suffix fails validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "no_version_suffix.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains(`unknown action "rclone"`)
+	})
+}

--- a/conformance/spec066_rclone/testdata/downstream_reference.yaml
+++ b/conformance/spec066_rclone/testdata/downstream_reference.yaml
@@ -1,0 +1,14 @@
+env:
+  - SRC_DIR: $HOST_SRC_DIR
+steps:
+  - id: list_files
+    action: rclone@v1
+    with:
+      command: lsf
+      source: $SRC_DIR
+  - id: print_bare
+    depends: list_files
+    run: echo "bare exit code is ${list_files.outputs.exitCode}"
+  - id: print_strict
+    depends: list_files
+    run: echo "strict=${steps.list_files.outputs.exitCode}"

--- a/conformance/spec066_rclone/testdata/error_scenarios.yaml
+++ b/conformance/spec066_rclone/testdata/error_scenarios.yaml
@@ -1,0 +1,49 @@
+env:
+  - SRC_DIR: $HOST_SRC_DIR
+  - DST_DIR: $HOST_DST_DIR
+steps:
+  - id: missing_command
+    action: rclone@v1
+    with: {}
+
+  - id: bad_command_enum
+    action: rclone@v1
+    with:
+      command: bogus
+
+  - id: unknown_field
+    action: rclone@v1
+    with:
+      command: lsf
+      source: $SRC_DIR
+      timeoutSeconds: 5
+
+  - id: missing_source
+    action: rclone@v1
+    continue_on: failed
+    with:
+      command: lsf
+
+  - id: missing_destination
+    depends: missing_source
+    action: rclone@v1
+    continue_on: failed
+    with:
+      command: copy
+      source: $SRC_DIR
+
+  - id: destructive_without_allow
+    depends: missing_destination
+    action: rclone@v1
+    continue_on: failed
+    with:
+      command: sync
+      source: $SRC_DIR
+      destination: $DST_DIR
+
+  - id: real_failure
+    depends: destructive_without_allow
+    action: rclone@v1
+    with:
+      command: lsf
+      source: /tmp/does/not/exist-rclone-conformance-xyz

--- a/conformance/spec066_rclone/testdata/happy_path.yaml
+++ b/conformance/spec066_rclone/testdata/happy_path.yaml
@@ -1,0 +1,36 @@
+env:
+  - SRC_DIR: $HOST_SRC_DIR
+  - DST_DIR: $HOST_DST_DIR
+steps:
+  - id: list_files
+    action: rclone@v1
+    with:
+      command: lsf
+      source: $SRC_DIR
+
+  - id: sync_dry_run
+    depends: list_files
+    action: rclone@v1
+    with:
+      command: sync
+      source: $SRC_DIR
+      destination: $DST_DIR
+      dryRun: true
+
+  - id: copy_real
+    depends: sync_dry_run
+    action: rclone@v1
+    with:
+      command: copy
+      source: $SRC_DIR
+      destination: $DST_DIR
+      allowDestructive: true
+      checksum: true
+      fastList: true
+      transfers: 2
+      checkers: 2
+      filter: ["+ *.txt", "- *"]
+      extraArgs: ["--create-empty-src-dirs"]
+      stats: "0"
+      env:
+        EXTRA_VAR: hello

--- a/conformance/spec066_rclone/testdata/no_version_suffix.yaml
+++ b/conformance/spec066_rclone/testdata/no_version_suffix.yaml
@@ -1,0 +1,5 @@
+steps:
+  - action: rclone
+    with:
+      command: lsf
+      source: /tmp

--- a/internal/spec/manifest_decoder.go
+++ b/internal/spec/manifest_decoder.go
@@ -111,6 +111,22 @@ func preserveEnvMappingOrder(data []byte, parsed map[string]any) error {
 	return nil
 }
 
+// opaqueDataKeys holds step/DAG fields whose value is data owned by
+// something other than dagu's own DAG/step schema: an executor's with:
+// config, a step's or the DAG's own inline params: JSON Schema, and the
+// legacy config: field. None of dagu's own env: declarations (DAG-level,
+// defaults.env, step-level, or container.env) are ever nested inside one of
+// these, but arbitrary executor- or schema-owned data underneath them can
+// coincidentally use "env" as a field or property name (for example, a
+// remote action's own with.env input, or a params: schema property named
+// "env"). patchOrderedEnvValues must not descend into these keys, or it
+// rewrites that unrelated mapping into dagu's ordered env-list shape too.
+var opaqueDataKeys = map[string]bool{
+	"with":   true,
+	"params": true,
+	"config": true,
+}
+
 func patchOrderedEnvValues(node ast.Node, target any) error {
 	switch value := node.(type) {
 	case *ast.MappingNode:
@@ -133,6 +149,9 @@ func patchOrderedEnvValues(node ast.Node, target any) error {
 					targetMap[key] = env
 					continue
 				}
+			}
+			if opaqueDataKeys[key] {
+				continue
 			}
 			if err := patchOrderedEnvValues(item.Value, targetMap[key]); err != nil {
 				return err

--- a/internal/spec/manifest_decoder_regression_test.go
+++ b/internal/spec/manifest_decoder_regression_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for patchOrderedEnvValues rewriting any mapping keyed
+// "env" into the DAG's own ordered env-list shape, even when that mapping
+// belongs to unrelated data nested under a step's with:/params: field (see
+// internal/spec/manifest_decoder.go's opaqueDataKeys).
+
+func TestPreserveEnvMappingOrder_ParamsSchemaEnvPropertyDoesNotBreakDecode(t *testing.T) {
+	t.Parallel()
+
+	_, err := spec.LoadYAML(context.Background(), []byte(`
+name: params-schema-env-property
+params:
+  type: object
+  properties:
+    env:
+      type: string
+      default: ""
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+}
+
+func TestPreserveEnvMappingOrder_WithEnvStaysPlainObject(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: with-env-plain-object
+steps:
+  - name: run
+    action: node-script@v1
+    with:
+      script: return 1
+      env:
+        FOO: bar
+`))
+	require.NoError(t, err)
+	input, ok := dag.Steps[0].ExecutorConfig.Config["input"].(map[string]any)
+	require.True(t, ok, "action executor config should nest with: under input")
+	require.Equal(t, map[string]any{"FOO": "bar"}, input["env"])
+}
+
+func TestPreserveEnvMappingOrder_RootEnvOrderStillPreserved(t *testing.T) {
+	t.Parallel()
+
+	dag, err := spec.LoadYAML(context.Background(), []byte(`
+name: root-env-order
+env:
+  FIRST: one
+  SECOND: ${env.FIRST}-two
+steps:
+  - name: run
+    run: echo hi
+`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"FIRST=one", "SECOND=one-two"}, dag.Env)
+}

--- a/specs/066-rclone.md
+++ b/specs/066-rclone.md
@@ -1,0 +1,240 @@
+# Spec: Rclone Action
+
+## Status
+
+Implemented.
+
+This spec defines conformance behavior for the official remote action
+`rclone@v1` (`dagucloud/rclone`).
+
+## Scope
+
+Like `node-script@v1` ([Spec 060: Node Script Action](060-node-script.md)),
+`python-script@v1` ([Spec 061: Python Script Action](061-python-script.md)),
+`dbt@v1` ([Spec 062: DBT Action](062-dbt.md)), `ffmpeg@v1` ([Spec 064:
+FFmpeg Action](064-ffmpeg.md)), and `github-cli@v1` ([Spec 065: GitHub CLI
+Action](065-github-cli.md)), `rclone@v1` is not a built-in Go executor. It
+is an official remote action: a git repository (`dagucloud/rclone`)
+containing a `dagu-action.yaml` manifest and a DAG that runs a real
+`rclone` binary the action provisions via the project's aqua-based tool
+manager (`rclone/rclone@v1.74.1` and `nodejs/node@v22.21.1`; the action's
+own wrapper is a Node.js script). Referencing `rclone@v1` resolves through
+Dagu's generic remote-action mechanism, which clones the action's
+repository and provisions its pinned tools on first use.
+
+This spec covers:
+
+- the required `with.command` (one of a fixed set of `rclone` subcommands)
+  and the `with.source`/`with.destination` paths each subcommand needs,
+  which the action's own wrapper -- not its input schema -- enforces
+  based on the specific command
+- that `sync`, `move`, `moveto`, `rmdir`, `delete`, and `purge` are treated
+  as destructive: the wrapper refuses to run them unless `with.dryRun:
+  true` or `with.allowDestructive: true` is set, again a wrapper-level
+  check the input schema cannot express
+- `with.configPath`, `with.workdir`, `with.checksum`, `with.fastList`,
+  `with.verbose`, `with.stats`, `with.logLevel`, `with.transfers`,
+  `with.checkers`, `with.include`/`with.exclude`/`with.filter`,
+  `with.extraArgs`, `with.env`, and `with.maxOutputBytes`
+- the result object: `ok`, `command`, `stdout`/`stderr`,
+  `stdoutTruncated`/`stderrTruncated`, `durationMs`, `exitCode`, and
+  `error`
+- that, unlike `ffmpeg@v1`/`dbt@v1`/`github-cli@v1`, this action's `error`
+  field is a plain string, and is populated for **every** failure --
+  including a real `rclone` process failure, not only a wrapper-level
+  validation error
+- that this action has no `with.timeoutSeconds` field at all: the action's
+  input schema forbids any property it does not declare
+  (`additionalProperties: false`), so a step cannot bound how long
+  `rclone` may run
+- that a later step reads a result field as `${<step id>.outputs.<path>}`
+  (a bare-step-id reference), the same form confirmed for `node-script@v1`,
+  `python-script@v1`, `dbt@v1`, `ffmpeg@v1`, and `github-cli@v1`, and not
+  via the strict `${steps.<step id>.outputs.<name>}` form
+- that `dagu validate` never resolves a remote action reference: a
+  `rclone@v1` step passes validate regardless of its `with:` content, and
+  `with.command` being required is enforced only once the step actually
+  runs
+
+This spec does not define:
+
+- the rclone action's own implementation, versioning, or release process --
+  this spec treats `rclone@v1` as an external dependency and documents its
+  observed contract
+- `rclone`'s own command-line semantics, backend/remote configuration, or
+  exit code conventions beyond how the action surfaces them
+- the generic remote-action resolution mechanism itself, or the
+  `${<step id>.outputs.<path>}` reference form's own resolution mechanism --
+  both are covered in more depth by [Spec 060: Node Script
+  Action](060-node-script.md) and [Spec 007: Value Resolution
+  Steps](007-value-resolution-steps.md)
+- performance or caching behavior of the action's own tool provisioning
+
+## Goal
+
+Workflow authors copy, sync, check, list, or manage files across any
+rclone-supported storage backend as a Dagu step, without installing or
+configuring `rclone` outside the workflow.
+
+## Behavior
+
+### Input
+
+`with.command` is required and must be one of `copy`, `copyto`, `sync`,
+`move`, `moveto`, `check`, `ls`, `lsf`, `lsd`, `tree`, `size`, `about`,
+`mkdir`, `rmdir`, `delete`, `purge`, or `cat`. Each command has an arity the
+wrapper enforces: `copy`, `copyto`, `sync`, `move`, `moveto`, and `check`
+need both `with.source` and `with.destination`; every other command needs
+only `with.source`. A command missing a path it needs fails with `source
+is required for rclone <command>` or `destination is required for rclone
+<command>` -- the input schema only requires `with.command` and cannot
+make `with.source`/`with.destination` conditionally required based on its
+value.
+
+`with.dryRun` adds `--dry-run`; `with.allowDestructive` explicitly permits
+a destructive command to run for real. `sync`, `move`, `moveto`, `rmdir`,
+`delete`, and `purge` fail immediately (before `rclone` is ever invoked)
+with `rclone <command> can delete or move data; set allowDestructive: true
+or dryRun: true` unless one of those two is set -- this is, again, a
+wrapper-level check the schema cannot express as a value constraint.
+
+`with.checksum`, `with.fastList`, and `with.verbose` add `--checksum`,
+`--fast-list`, and `-v`. `with.stats` and `with.logLevel` add `--stats
+<value>` and `--log-level <value>` (`with.logLevel` must be one of
+`DEBUG`, `INFO`, `NOTICE`, `ERROR`). `with.transfers`/`with.checkers` add
+`--transfers`/`--checkers <value>`. `with.include`/`with.exclude`/
+`with.filter` each add one `--include`/`--exclude`/`--filter <value>` per
+array entry. `with.extraArgs` appends raw flags after the command and
+before its path arguments. `with.configPath` adds `--config <value>`.
+`with.workdir`, when set, is the working directory `rclone` runs in.
+`with.env`, when set, is an object of extra environment variables for the
+`rclone` process (a plain object, like `dbt@v1`'s `with.env`, not a string
+like `ffmpeg@v1`'s). `with.maxOutputBytes` (default `1048576`) caps how
+much of `rclone`'s stdout and stderr are captured into the result.
+
+There is no `with.timeoutSeconds` field, and the action's input schema
+sets `additionalProperties: false`, so a step cannot bound `rclone`'s
+runtime at all -- a long-running `rclone` invocation runs until it exits
+on its own.
+
+### Result
+
+The step's stdout is one JSON object:
+
+- `ok`: `true` when `rclone` exited with code `0`.
+- `command`: the `with.command` value that was run (not a full argv --
+  unlike `ffmpeg@v1`/`dbt@v1`/`github-cli@v1`, this action's outputs
+  schema exposes no argv/args field at all).
+- `stdout`/`stderr`: text `rclone` wrote to stdout and stderr, each
+  truncated to `with.maxOutputBytes`.
+- `stdoutTruncated`/`stderrTruncated`: `true` when that stream was cut off
+  at `with.maxOutputBytes`.
+- `durationMs`: wrapper-measured process duration.
+- `exitCode`: `rclone`'s real exit code, or a wrapper-forced `2` when the
+  wrapper rejects the input or fails to start `rclone` at all.
+- `error`: a plain string (not an object with `name`/`message`, unlike the
+  other remote actions in this family). Unlike `ffmpeg@v1`/`dbt@v1`/
+  `github-cli@v1`, this field is populated for every failure, not only a
+  wrapper-level one: a missing required path, a destructive command
+  without `allowDestructive`/`dryRun`, and a real non-zero `rclone` exit
+  all set `error` (for a real `rclone` failure, to `rclone exited with
+  code <n>`).
+
+### Downstream references
+
+A later step reads a field of the result as `${<step id>.outputs.<path>}`
+-- the step ID used directly as the reference's namespace. This matches
+the behavior [Spec 060: Node Script Action](060-node-script.md), [Spec
+061: Python Script Action](061-python-script.md), [Spec 062: DBT
+Action](062-dbt.md), [Spec 064: FFmpeg Action](064-ffmpeg.md), and [Spec
+065: GitHub CLI Action](065-github-cli.md) document, confirming it is a
+property of remote action:-type steps generally, not specific to one
+action. The strict `${steps.<step id>.outputs.<name>}` form documented for
+declared step outputs (see [Spec 012: Step Outputs](012-step-outputs.md))
+does not resolve for a `rclone@v1` step, for the same reason it does not
+for the other remote actions above.
+
+## Errors
+
+### Validation
+
+- An action reference missing its required `@version` suffix (for example,
+  `rclone` instead of `rclone@v1`): an error containing `unknown action`.
+  This is enforced generically for any action reference, not specifically
+  for `rclone`.
+- Any `with:` field not declared by the input schema (there is no
+  `with.timeoutSeconds`, for example): an error containing `unexpected
+  additional properties`.
+
+`dagu validate` does not resolve the remote action reference at all, so it
+cannot check `rclone@v1`'s own requirements (such as `with.command` being
+required, or `with.source`/`with.destination` being required for a
+specific command) -- a step missing `with.command` passes validate.
+
+### Runtime
+
+- `with.command` missing: an error containing `missing properties:
+  ["command"]`, raised when the action resolves its own input schema
+  against the step's `with:` content -- before `rclone` is ever invoked.
+- `with.command` set to an unsupported value: an error containing `does
+  not equal any of`, raised by the same input-schema check.
+- `with.source`/`with.destination` missing for a command that needs it, or
+  a destructive command (`sync`, `move`, `moveto`, `rmdir`, `delete`,
+  `purge`) without `with.allowDestructive`/`with.dryRun`: the step fails
+  with `ok: false`, `exitCode: 2`, and a populated string `error` -- before
+  `rclone` is ever invoked.
+- A real `rclone` process failure: the step fails (a non-zero exit) with
+  `rclone`'s own real `exitCode`, its own `stdout`/`stderr`, and `error`
+  set to `rclone exited with code <n>`.
+
+## Related Specs
+
+- Node script action, Python script action, DBT action, FFmpeg action, and
+  GitHub CLI action, for the equivalent remote-action execution model and
+  downstream-reference behavior this action shares: [Spec 060: Node
+  Script Action](060-node-script.md), [Spec 061: Python Script
+  Action](061-python-script.md), [Spec 062: DBT Action](062-dbt.md),
+  [Spec 064: FFmpeg Action](064-ffmpeg.md), [Spec 065: GitHub CLI
+  Action](065-github-cli.md)
+- Step outputs and reference syntax, for contrast with the bare-step-id
+  reference form this action's result uses: [Spec 012: Step
+  Outputs](012-step-outputs.md)
+
+## Examples
+
+Preview a sync, then run it for real:
+
+```yaml
+steps:
+  - id: preview_sync
+    action: rclone@v1
+    with:
+      command: sync
+      source: /data/reports
+      destination: backup:reports
+      dryRun: true
+
+  - id: run_sync
+    depends: preview_sync
+    action: rclone@v1
+    with:
+      command: sync
+      source: /data/reports
+      destination: backup:reports
+      allowDestructive: true
+```
+
+List files and print the listing from a later step:
+
+```yaml
+steps:
+  - id: list_files
+    action: rclone@v1
+    with:
+      command: lsf
+      source: /data/input
+
+  - id: print
+    depends: list_files
+    run: echo "${list_files.outputs.stdout}"
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [066: Rclone Action](066-rclone.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
## Summary

Cover the official remote action rclone@v1 against a real rclone
  binary and a real local directory tree: with.command (list/copy/sync
  arity), with.source/destination requiredness (enforced by the wrapper,
  not the schema, since it depends on with.command's value),
  destructive-command gating (sync/move/moveto/rmdir/delete/purge refuse
  to run without dryRun/allowDestructive), with.checksum/fastList/
  transfers/checkers/include/exclude/filter/extraArgs/env/maxOutputBytes,
  and the ok/command/stdout/stderr/*Truncated/durationMs/exitCode/error
  result shape.## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conformance coverage and documentation for the `rclone@v1` remote action, including file listing, dry-run synchronization, copying, validation, error handling, and downstream result references.
  * Added the Rclone Action to the conformance status table.

* **Bug Fixes**
  * Prevented nested `env` fields in action configuration and parameters from being incorrectly transformed during workflow decoding.
  * Preserved root-level environment variable expansion and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->