### PR TITLE
test: add black-box conformance coverage for the harness executor

### DIFF
--- a/conformance/spec067_harness/harness_helper_test.go
+++ b/conformance/spec067_harness/harness_helper_test.go
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec067_harness_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// requireLines asserts that content, split on newlines, equals exactly the
+// given lines (with a trailing empty line implied by the final newline, as
+// every fake_ok.sh invocation produces).
+func requireLines(t *testing.T, content string, lines ...string) {
+	t.Helper()
+	want := strings.Join(lines, "\n") + "\n"
+	require.Equal(t, want, content)
+}
+
+// requireContainsAll asserts that content contains every given substring.
+func requireContainsAll(t *testing.T, content string, substrings ...string) {
+	t.Helper()
+	for _, s := range substrings {
+		require.Contains(t, content, s)
+	}
+}
+
+// stdoutLogPattern and stderrLogPattern match a per-step captured-output log
+// path dagu start prints in its tree render, e.g.
+// "└─stdout: /path/to/step.<ts>.<run>.out". One match appears per step that
+// wrote anything to that stream, in the order dagu's tree render lists them
+// (which, for both the sequential and the independent-but-declared-in-order
+// fixtures this package uses, matches declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+var stderrLogPattern = regexp.MustCompile(`stderr: (.+)`)
+
+func readLoggedPath(t *testing.T, pattern *regexp.Regexp, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := pattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+	return readLoggedPath(t, stdoutLogPattern, daguStartOutput, n)
+}
+
+// stepStderr is stepStdout's counterpart for a step's captured stderr.
+func stepStderr(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+	return readLoggedPath(t, stderrLogPattern, daguStartOutput, n)
+}
+
+// fakeOkScript is a fake harness CLI: it prints one "ARG:<value>" line per
+// argv element it received (so an argument containing spaces, such as a
+// prompt, is unambiguous), then one "STDIN:<content>" line with whatever it
+// read from stdin (empty when nothing was piped), and exits 0.
+const fakeOkScript = `#!/bin/sh
+for a in "$@"; do printf 'ARG:%s\n' "$a"; done
+printf 'STDIN:%s\n' "$(cat)"
+exit 0
+`
+
+// fakeFailScript is a fake harness CLI that always fails: it writes a fixed
+// message to stderr and exits 7 (an arbitrary non-zero code distinct from
+// the wrapper's own forced exit codes elsewhere in this session's specs).
+const fakeFailScript = `#!/bin/sh
+echo "fake_fail: simulated failure" >&2
+exit 7
+`
+
+// writeFakeHarnessScripts writes the two fake CLI scripts this package's
+// live fixtures reference (as ./scripts/fake_ok.sh and
+// ./scripts/fake_fail.sh, relative to the DAG's own working_dir: field) and
+// returns the host environment entry the fixtures resolve their DAG-level
+// working_dir: from. A harnesses.<name>.binary value does not go through
+// Dagu's own value resolution (unlike almost every other field), so the
+// fixtures cannot embed the isolated project's own runtime path directly in
+// binary: -- only working_dir: does, which is why binary: is always a
+// static relative path here.
+func writeFakeHarnessScripts(dagu *harness.Runner) []string {
+	dagu.WriteExecutable("scripts/fake_ok.sh", fakeOkScript)
+	dagu.WriteExecutable("scripts/fake_fail.sh", fakeFailScript)
+	return []string{"HOST_PROJECT_DIR=" + dagu.ProjectPath("")}
+}

--- a/conformance/spec067_harness/harness_helper_test.go
+++ b/conformance/spec067_harness/harness_helper_test.go
@@ -15,7 +15,7 @@ import (
 
 // requireLines asserts that content, split on newlines, equals exactly the
 // given lines (with a trailing empty line implied by the final newline, as
-// every fake_ok.sh invocation produces).
+// each fixture script produces).
 func requireLines(t *testing.T, content string, lines ...string) {
 	t.Helper()
 	want := strings.Join(lines, "\n") + "\n"
@@ -77,22 +77,13 @@ exit 0
 `
 
 // fakeFailScript is a fake harness CLI that always fails: it writes a fixed
-// message to stderr and exits 7 (an arbitrary non-zero code distinct from
-// the wrapper's own forced exit codes elsewhere in this session's specs).
+// message to stderr and exits 7 to exercise process failure.
 const fakeFailScript = `#!/bin/sh
 echo "fake_fail: simulated failure" >&2
 exit 7
 `
 
-// writeFakeHarnessScripts writes the two fake CLI scripts this package's
-// live fixtures reference (as ./scripts/fake_ok.sh and
-// ./scripts/fake_fail.sh, relative to the DAG's own working_dir: field) and
-// returns the host environment entry the fixtures resolve their DAG-level
-// working_dir: from. A harnesses.<name>.binary value does not go through
-// Dagu's own value resolution (unlike almost every other field), so the
-// fixtures cannot embed the isolated project's own runtime path directly in
-// binary: -- only working_dir: does, which is why binary: is always a
-// static relative path here.
+// writeFakeHarnessScripts supplies local scripts invoked through sh on every OS.
 func writeFakeHarnessScripts(dagu *harness.Runner) []string {
 	dagu.WriteExecutable("scripts/fake_ok.sh", fakeOkScript)
 	dagu.WriteExecutable("scripts/fake_fail.sh", fakeFailScript)

--- a/conformance/spec067_harness/harness_test.go
+++ b/conformance/spec067_harness/harness_test.go
@@ -1,22 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package spec067_harness holds black-box conformance tests for Spec 067:
-// Harness Executor (action: harness.run).
-//
-// Unlike specs 060-066, harness is a built-in Go executor, not a remote
-// action: it ships in this binary and never reaches the network to resolve
-// itself. Its whole point is to run a third-party AI coding agent CLI
-// (claude, codex, aider, cursor, and others named in the harnesses package's
-// builtin provider catalog) as a subprocess, but none of those CLIs are
-// installed in this environment. Instead, this package defines its own
-// custom top-level harnesses: entries (a first-class, documented mechanism
-// for wiring in a CLI the built-in provider catalog does not name) pointing
-// at two tiny fake scripts this package writes itself, which stand in for a
-// real agent CLI deterministically: fake_ok.sh echoes back its argv and
-// stdin and always succeeds; fake_fail.sh always fails. This exercises the
-// real invocation-building and fallback logic without needing network
-// access, a real agent CLI, or an API key.
+// Package spec067_harness tests the harness executor through the Dagu binary.
 package spec067_harness_test
 
 import (
@@ -29,7 +14,7 @@ import (
 func TestHarnessLive(t *testing.T) {
 	t.Parallel()
 
-	t.Run("prompt_mode/prompt_position/flag_style/option_flags/stdin all build the invocation as documented, and a failed primary falls back", func(t *testing.T) {
+	t.Run("invocation and fallback", func(t *testing.T) {
 		t.Parallel()
 
 		dagu := harness.NewRunner(t)
@@ -95,7 +80,7 @@ func TestHarnessLive(t *testing.T) {
 		)
 	})
 
-	t.Run("a real process failure with no fallback reports the real exit code, and an unresolvable binary reports a distinct error", func(t *testing.T) {
+	t.Run("process and binary errors", func(t *testing.T) {
 		t.Parallel()
 
 		dagu := harness.NewRunner(t)
@@ -118,21 +103,13 @@ func TestHarnessLive(t *testing.T) {
 		require.Contains(t, result.Stdout(), "does_not_exist.sh")
 	})
 
-	// Unlike node-script@v1/python-script@v1/dbt@v1/ffmpeg@v1/github-cli@v1/
-	// rclone@v1 (specs 060-066), a harness step publishes no .outputs.* at
-	// all -- it is a plain Command/Script-capable executor like an ordinary
-	// run: step, not one with a JSON-decoded outputs contract. A later step
-	// reads its result only via the standard declared output: NAME
-	// mechanism (Spec 012), not ${<id>.outputs.<path>} (bare) or
-	// ${steps.<id>.outputs.<name>} (strict) -- both fail identically here.
-	t.Run("a later step reads the result via output: NAME, not outputs.stdout in either bare or strict form", func(t *testing.T) {
+	t.Run("declared output", func(t *testing.T) {
 		t.Parallel()
 
 		dagu := harness.NewRunner(t)
 		env := writeFakeHarnessScripts(dagu)
 		result := dagu.RunWithEnv(env, "start", "downstream_reference.yaml")
-		result.ExpectNonZeroExitCode()
-		result.ExpectStderrContains("bad substitution")
+		result.ExpectExitCode(0)
 
 		require.Equal(t, "named=ARG:hello\nSTDIN:\n", stepStdout(t, result.Stdout(), 1),
 			"output: NAME trims one trailing newline from the captured stdout")

--- a/conformance/spec067_harness/harness_test.go
+++ b/conformance/spec067_harness/harness_test.go
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec067_harness holds black-box conformance tests for Spec 067:
+// Harness Executor (action: harness.run).
+//
+// Unlike specs 060-066, harness is a built-in Go executor, not a remote
+// action: it ships in this binary and never reaches the network to resolve
+// itself. Its whole point is to run a third-party AI coding agent CLI
+// (claude, codex, aider, cursor, and others named in the harnesses package's
+// builtin provider catalog) as a subprocess, but none of those CLIs are
+// installed in this environment. Instead, this package defines its own
+// custom top-level harnesses: entries (a first-class, documented mechanism
+// for wiring in a CLI the built-in provider catalog does not name) pointing
+// at two tiny fake scripts this package writes itself, which stand in for a
+// real agent CLI deterministically: fake_ok.sh echoes back its argv and
+// stdin and always succeeds; fake_fail.sh always fails. This exercises the
+// real invocation-building and fallback logic without needing network
+// access, a real agent CLI, or an API key.
+package spec067_harness_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHarnessLive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prompt_mode/prompt_position/flag_style/option_flags/stdin all build the invocation as documented, and a failed primary falls back", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		env := writeFakeHarnessScripts(dagu)
+		result := dagu.RunWithEnv(env, "start", "happy_path.yaml")
+		result.ExpectExitCode(0)
+
+		// arg_mode (prompt_mode: arg, default prompt_position: before_flags):
+		// the prompt comes first, then flags sorted by key -- "label" (mapped
+		// to --tag via option_flags) before "verbose" (a bare flag, since
+		// true).
+		argMode := stepStdout(t, result.Stdout(), 0)
+		requireLines(t, argMode,
+			"ARG:hello from arg mode",
+			"ARG:--tag",
+			"ARG:build",
+			"ARG:--verbose",
+			"STDIN:",
+		)
+
+		// flag_mode (prompt_mode: flag, prompt_position: after_flags):
+		// flags first, then --prompt <value>; with.stdin is piped to the
+		// process's stdin.
+		flagMode := stepStdout(t, result.Stdout(), 1)
+		requireLines(t, flagMode,
+			"ARG:--priority",
+			"ARG:5",
+			"ARG:--prompt",
+			"ARG:flag prompt text",
+			"STDIN:piped script text",
+		)
+
+		// stdin_mode (prompt_mode: stdin): no argv at all; the prompt and
+		// with.stdin are joined with a blank line and both piped to stdin.
+		stdinMode := stepStdout(t, result.Stdout(), 2)
+		requireLines(t, stdinMode,
+			"STDIN:stdin-mode prompt",
+			"",
+			"stdin-mode script",
+		)
+
+		// dash_mode (flag_style: single_dash): a custom flag becomes -count
+		// 3, not --count 3.
+		dashMode := stepStdout(t, result.Stdout(), 3)
+		requireLines(t, dashMode,
+			"ARG:dash prompt",
+			"ARG:-count",
+			"ARG:3",
+			"STDIN:",
+		)
+
+		// fallback_success: the primary provider (fake_fail.sh) fails, so
+		// the step retries with.fallback[0] (fake_backup, fake_ok.sh) and
+		// the step as a whole succeeds. The primary's own stderr and the
+		// wrapper's own "trying fallback" message both land in the step's
+		// stderr; the final stdout is the fallback provider's own output.
+		fallbackStdout := stepStdout(t, result.Stdout(), 4)
+		requireLines(t, fallbackStdout, "ARG:trying fallback", "STDIN:")
+		fallbackStderr := stepStderr(t, result.Stdout(), 0) // the only step in this fixture that writes any stderr
+		requireContainsAll(t, fallbackStderr,
+			"fake_fail: simulated failure",
+			"harness: attempt 1/2 with fake_primary failed; trying fallback 2/2 with fake_backup",
+		)
+	})
+
+	t.Run("a real process failure with no fallback reports the real exit code, and an unresolvable binary reports a distinct error", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		env := writeFakeHarnessScripts(dagu)
+		result := dagu.RunWithEnv(env, "start", "error_scenarios.yaml")
+		result.ExpectNonZeroExitCode()
+
+		// no_fallback_fail: fake_fail.sh's own exit code (7) becomes the
+		// step's exit code, and its stderr is captured as usual -- this is
+		// a real process that ran and failed, not a wrapper validation
+		// error.
+		require.Contains(t, stepStderr(t, result.Stdout(), 0), "fake_fail: simulated failure")
+		require.Contains(t, result.Stdout(), "exit status 7")
+
+		// missing_binary: the configured binary path does not exist, so the
+		// step fails before any process starts, with a distinct
+		// "harness: failed to resolve binary" error (no stdout/stderr log
+		// of a process that never ran).
+		require.Contains(t, result.Stdout(), "harness: failed to resolve binary")
+		require.Contains(t, result.Stdout(), "does_not_exist.sh")
+	})
+
+	// Unlike node-script@v1/python-script@v1/dbt@v1/ffmpeg@v1/github-cli@v1/
+	// rclone@v1 (specs 060-066), a harness step publishes no .outputs.* at
+	// all -- it is a plain Command/Script-capable executor like an ordinary
+	// run: step, not one with a JSON-decoded outputs contract. A later step
+	// reads its result only via the standard declared output: NAME
+	// mechanism (Spec 012), not ${<id>.outputs.<path>} (bare) or
+	// ${steps.<id>.outputs.<name>} (strict) -- both fail identically here.
+	t.Run("a later step reads the result via output: NAME, not outputs.stdout in either bare or strict form", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		env := writeFakeHarnessScripts(dagu)
+		result := dagu.RunWithEnv(env, "start", "downstream_reference.yaml")
+		result.ExpectNonZeroExitCode()
+		result.ExpectStderrContains("bad substitution")
+
+		require.Equal(t, "named=ARG:hello\nSTDIN:\n", stepStdout(t, result.Stdout(), 1),
+			"output: NAME trims one trailing newline from the captured stdout")
+	})
+}
+
+// TestHarnessValidation covers dagu validate for the harness executor.
+// Unlike the remote actions in specs 060-066, harness is a built-in
+// executor: dagu validate resolves its provider configuration (a known
+// built-in provider name, a defined custom harnesses entry, or an error) and
+// its harnesses: definitions fully, without any network access, since both
+// live in this binary and the DAG file itself. The one thing it does NOT
+// check is whether the configured binary actually exists -- that is a
+// runtime-only concern (see TestHarnessLive's missing_binary case).
+func TestHarnessValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a well-formed harness step and its custom harnesses: definitions pass validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "happy_path.yaml")
+		result.ExpectExitCode(0)
+	})
+
+	invalidCases := []struct {
+		name       string
+		file       string
+		wantStderr string
+	}{
+		{
+			name:       "with.prompt missing",
+			file:       "invalid_missing_prompt.yaml",
+			wantStderr: "with.prompt is required",
+		},
+		{
+			name:       "with.provider names neither a built-in nor a defined custom harness",
+			file:       "invalid_unknown_provider.yaml",
+			wantStderr: `unknown provider "totally-bogus-provider"`,
+		},
+		{
+			name:       "with.binary is rejected in favor of a named harnesses entry",
+			file:       "invalid_binary_in_with.yaml",
+			wantStderr: "config.binary is not supported",
+		},
+		{
+			name:       "with.prompt_args is rejected in favor of a named harnesses entry",
+			file:       "invalid_prompt_args_in_with.yaml",
+			wantStderr: "config.prompt_args is not supported",
+		},
+		{
+			name:       "a harnesses: definition missing binary",
+			file:       "invalid_harness_def_missing_binary.yaml",
+			wantStderr: "binary is required",
+		},
+		{
+			name:       "a harnesses: definition with an unsupported prompt_mode",
+			file:       "invalid_harness_def_bad_prompt_mode.yaml",
+			wantStderr: "prompt_mode must be one of: arg, flag, stdin",
+		},
+		{
+			name:       "prompt_mode: flag without prompt_flag",
+			file:       "invalid_harness_def_prompt_flag_required.yaml",
+			wantStderr: "prompt_flag is required when prompt_mode is flag",
+		},
+		{
+			name:       "prompt_flag set when prompt_mode is not flag",
+			file:       "invalid_harness_def_prompt_flag_not_allowed.yaml",
+			wantStderr: "prompt_flag is only valid when prompt_mode is flag",
+		},
+	}
+
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", tc.file)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.wantStderr)
+		})
+	}
+}

--- a/conformance/spec067_harness/testdata/downstream_reference.yaml
+++ b/conformance/spec067_harness/testdata/downstream_reference.yaml
@@ -3,7 +3,8 @@ env:
 working_dir: $PROJECT_DIR
 harnesses:
   fake_ok:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: arg
 steps:
   - id: run1
@@ -14,10 +15,5 @@ steps:
     output: RUN1_RESULT
   - id: print_named
     depends: run1
-    run: echo "named=${RUN1_RESULT}"
-  - id: print_bare
-    depends: run1
-    run: echo "bare=${run1.outputs.stdout}"
-  - id: print_strict
-    depends: run1
-    run: echo "strict=${steps.run1.outputs.stdout}"
+    run: |
+      echo "named=${RUN1_RESULT}"

--- a/conformance/spec067_harness/testdata/downstream_reference.yaml
+++ b/conformance/spec067_harness/testdata/downstream_reference.yaml
@@ -1,0 +1,23 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_ok:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - id: run1
+    action: harness.run
+    with:
+      provider: fake_ok
+      prompt: hello
+    output: RUN1_RESULT
+  - id: print_named
+    depends: run1
+    run: echo "named=${RUN1_RESULT}"
+  - id: print_bare
+    depends: run1
+    run: echo "bare=${run1.outputs.stdout}"
+  - id: print_strict
+    depends: run1
+    run: echo "strict=${steps.run1.outputs.stdout}"

--- a/conformance/spec067_harness/testdata/error_scenarios.yaml
+++ b/conformance/spec067_harness/testdata/error_scenarios.yaml
@@ -1,0 +1,22 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_fail:
+    binary: ./scripts/fake_fail.sh
+    prompt_mode: arg
+  missing_bin:
+    binary: ./scripts/does_not_exist.sh
+    prompt_mode: arg
+steps:
+  - id: no_fallback_fail
+    action: harness.run
+    with:
+      provider: fake_fail
+      prompt: this will fail
+
+  - id: missing_binary
+    action: harness.run
+    with:
+      provider: missing_bin
+      prompt: hi

--- a/conformance/spec067_harness/testdata/error_scenarios.yaml
+++ b/conformance/spec067_harness/testdata/error_scenarios.yaml
@@ -3,7 +3,8 @@ env:
 working_dir: $PROJECT_DIR
 harnesses:
   fake_fail:
-    binary: ./scripts/fake_fail.sh
+    binary: sh
+    prefix_args: [./scripts/fake_fail.sh]
     prompt_mode: arg
   missing_bin:
     binary: ./scripts/does_not_exist.sh

--- a/conformance/spec067_harness/testdata/happy_path.yaml
+++ b/conformance/spec067_harness/testdata/happy_path.yaml
@@ -1,0 +1,69 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_arg:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+    option_flags:
+      label: --tag
+  fake_flag:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: flag
+    prompt_flag: --prompt
+    prompt_position: after_flags
+  fake_stdin:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: stdin
+  fake_dash:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+    flag_style: single_dash
+  fake_primary:
+    binary: ./scripts/fake_fail.sh
+    prompt_mode: arg
+  fake_backup:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - id: arg_mode
+    action: harness.run
+    with:
+      provider: fake_arg
+      prompt: hello from arg mode
+      label: build
+      verbose: true
+
+  - id: flag_mode
+    depends: arg_mode
+    action: harness.run
+    with:
+      provider: fake_flag
+      prompt: flag prompt text
+      stdin: piped script text
+      priority: 5
+
+  - id: stdin_mode
+    depends: flag_mode
+    action: harness.run
+    with:
+      provider: fake_stdin
+      prompt: stdin-mode prompt
+      stdin: stdin-mode script
+
+  - id: dash_mode
+    depends: stdin_mode
+    action: harness.run
+    with:
+      provider: fake_dash
+      prompt: dash prompt
+      count: 3
+
+  - id: fallback_success
+    depends: dash_mode
+    action: harness.run
+    with:
+      provider: fake_primary
+      prompt: trying fallback
+      fallback:
+        - provider: fake_backup

--- a/conformance/spec067_harness/testdata/happy_path.yaml
+++ b/conformance/spec067_harness/testdata/happy_path.yaml
@@ -3,27 +3,33 @@ env:
 working_dir: $PROJECT_DIR
 harnesses:
   fake_arg:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: arg
     option_flags:
       label: --tag
   fake_flag:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: flag
     prompt_flag: --prompt
     prompt_position: after_flags
   fake_stdin:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: stdin
   fake_dash:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: arg
     flag_style: single_dash
   fake_primary:
-    binary: ./scripts/fake_fail.sh
+    binary: sh
+    prefix_args: [./scripts/fake_fail.sh]
     prompt_mode: arg
   fake_backup:
-    binary: ./scripts/fake_ok.sh
+    binary: sh
+    prefix_args: [./scripts/fake_ok.sh]
     prompt_mode: arg
 steps:
   - id: arg_mode

--- a/conformance/spec067_harness/testdata/invalid_binary_in_with.yaml
+++ b/conformance/spec067_harness/testdata/invalid_binary_in_with.yaml
@@ -1,0 +1,11 @@
+harnesses:
+  fake_ok:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - id: binary_in_with
+    action: harness.run
+    with:
+      provider: fake_ok
+      binary: /bin/true
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_harness_def_bad_prompt_mode.yaml
+++ b/conformance/spec067_harness/testdata/invalid_harness_def_bad_prompt_mode.yaml
@@ -1,0 +1,10 @@
+harnesses:
+  bad_mode:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: bogus
+steps:
+  - id: x
+    action: harness.run
+    with:
+      provider: bad_mode
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_harness_def_missing_binary.yaml
+++ b/conformance/spec067_harness/testdata/invalid_harness_def_missing_binary.yaml
@@ -1,0 +1,9 @@
+harnesses:
+  bad_def:
+    prompt_mode: arg
+steps:
+  - id: x
+    action: harness.run
+    with:
+      provider: bad_def
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_harness_def_prompt_flag_not_allowed.yaml
+++ b/conformance/spec067_harness/testdata/invalid_harness_def_prompt_flag_not_allowed.yaml
@@ -1,0 +1,11 @@
+harnesses:
+  bad_flag2:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+    prompt_flag: --prompt
+steps:
+  - id: x
+    action: harness.run
+    with:
+      provider: bad_flag2
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_harness_def_prompt_flag_required.yaml
+++ b/conformance/spec067_harness/testdata/invalid_harness_def_prompt_flag_required.yaml
@@ -1,0 +1,10 @@
+harnesses:
+  bad_flag:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: flag
+steps:
+  - id: x
+    action: harness.run
+    with:
+      provider: bad_flag
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_missing_prompt.yaml
+++ b/conformance/spec067_harness/testdata/invalid_missing_prompt.yaml
@@ -1,0 +1,9 @@
+harnesses:
+  fake_ok:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - id: missing_prompt
+    action: harness.run
+    with:
+      provider: fake_ok

--- a/conformance/spec067_harness/testdata/invalid_prompt_args_in_with.yaml
+++ b/conformance/spec067_harness/testdata/invalid_prompt_args_in_with.yaml
@@ -1,0 +1,11 @@
+harnesses:
+  fake_ok:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - id: prompt_args_in_with
+    action: harness.run
+    with:
+      provider: fake_ok
+      prompt_args: ["--foo"]
+      prompt: hi

--- a/conformance/spec067_harness/testdata/invalid_unknown_provider.yaml
+++ b/conformance/spec067_harness/testdata/invalid_unknown_provider.yaml
@@ -1,0 +1,6 @@
+steps:
+  - id: unknown_provider
+    action: harness.run
+    with:
+      provider: totally-bogus-provider
+      prompt: hi

--- a/specs/067-harness.md
+++ b/specs/067-harness.md
@@ -1,0 +1,212 @@
+# Spec: Harness Executor
+
+## Status
+
+Implemented.
+
+## Scope
+
+Unlike specs 060-066, `harness` is a built-in Go executor, not a remote
+action: it ships in the `dagu` binary and never reaches the network to
+resolve itself. Its purpose is to run a third-party AI coding agent CLI
+(for example `claude`, `codex`, `aider`, `cursor`, or a custom CLI) as a
+subprocess, feeding it a prompt and capturing its output like an ordinary
+command step.
+
+This spec covers:
+
+- the `action: harness.run` step shape: `with.prompt` (required, becomes
+  the step's command/prompt text), `with.stdin` (optional, piped to the
+  process's stdin), `with.provider` (required, selects a built-in CLI
+  provider or a custom `harnesses:` entry), and `with.fallback` (an
+  ordered list of alternative provider configs tried after the primary
+  fails)
+- any other `with:` key becomes a CLI flag passed to the provider's
+  binary: a boolean `true` becomes a bare flag, a string or number becomes
+  `--key value`, and an array repeats `--key` once per element
+- the top-level `harnesses:` block, which defines a named, reusable custom
+  provider (`binary`, `prefix_args`, `prompt_mode`, `prompt_flag`,
+  `prompt_position`, `flag_style`, `option_flags`) that a step selects via
+  `with.provider`, for a CLI the built-in provider catalog does not name
+- that a harness step publishes no `.outputs.*` at all: it is a plain
+  Command/Script-capable executor, like an ordinary `run:` step, not one
+  with a JSON-decoded outputs contract; a later step reads its result only
+  through the standard declared `output: NAME` mechanism ([Spec 012: Step
+  Outputs](012-step-outputs.md))
+- that, unlike the remote actions in specs 060-066, `dagu validate` fully
+  resolves and checks a harness step's provider configuration and any
+  `harnesses:` definitions it references, since both are local to the DAG
+  file and this binary -- the one thing it cannot check is whether the
+  configured binary actually exists, since that is a real filesystem/PATH
+  lookup deferred to run time
+- fallback behavior: when the primary provider's process exits non-zero,
+  the step retries with the next entry in `with.fallback`, in order, until
+  one succeeds or the list is exhausted; a message naming both providers is
+  written to the step's stderr before each retry
+
+This spec does not define:
+
+- the behavior of any specific built-in CLI provider (`claude`, `codex`,
+  `aider`, and so on) -- none is installed in this conformance
+  environment, so this spec exercises only custom `harnesses:` providers,
+  which share the same invocation-building and fallback code paths
+- containerized harness execution (`step.container` with a harness
+  provider), the managed OpenCode execution path, or `type: agent` DAGs'
+  own use of a harness step as one of several actions in a decision loop
+  ([Spec 032: Agent DAGs](032-agent-dag.md))
+- prompt engineering, model behavior, or the semantics of any particular
+  agent CLI's own flags
+
+## Goal
+
+Workflow authors give an AI coding agent CLI a task and capture its output
+as an ordinary Dagu step, whether that CLI is one of the built-in provider
+names or an arbitrary custom CLI wired in through `harnesses:`.
+
+## Behavior
+
+### Step shape and invocation building
+
+A harness step is written `action: harness.run` with `with.prompt`
+required; `with.prompt` becomes the step's command text (equivalent to a
+`run:` step's command), and `with.stdin`, when set, is piped to the
+process's stdin as a separate script body. `with.provider` selects either
+a built-in CLI provider name or a name defined under the DAG's top-level
+`harnesses:` block; an unknown name fails with `unknown provider`.
+
+For a custom (`harnesses:`-defined) provider, the invocation is built as:
+
+1. `prefix_args`, if any.
+2. The prompt and the flags built from the step's other `with:` keys, in
+   the order `prompt_position` says (`before_flags`, the default, or
+   `after_flags`), with the prompt delivered according to `prompt_mode`:
+   - `arg`: the prompt is a bare positional argument.
+   - `flag`: the prompt follows `prompt_flag` (required only for this
+     mode; setting it for any other mode is itself an error).
+   - `stdin`: no prompt argument at all; the prompt and `with.stdin` are
+     joined with a blank line (either half omitted if empty) and both
+     piped to the process's stdin instead.
+3. `with.stdin`, when set and `prompt_mode` is not `stdin`, is still piped
+   to the process's stdin as a separate stream from the argument-delivered
+   prompt.
+
+Flags built from `with:` keys other than `provider`/`fallback` are sorted
+by key for deterministic ordering. Each key becomes `--key` (or `-key`
+when the definition's `flag_style` is `single_dash`) unless
+`option_flags` maps that key to a different literal flag token. A boolean
+`true` value produces the bare flag with no value (`false` is omitted
+entirely); a string, integer, or float value produces `flag value`; an
+array value repeats `flag value` once per element.
+
+### Fallback
+
+`with.fallback` is an array of provider configs (each shaped like the
+step's own `provider` plus flags), tried in order after the primary
+config's process exits non-zero. Before each retry, the step's stderr
+receives a line naming both the failed and the next provider (`harness:
+attempt <n>/<total> with <name> failed; trying fallback <n+1>/<total> with
+<name>`). The step succeeds as a whole the moment any config succeeds, and
+that config's stdout becomes the step's stdout; each earlier attempt's own
+stderr remains part of the step's stderr. If every config fails, the step
+fails with the last config's own error.
+
+### Result
+
+A harness step's stdout and stderr are the underlying process's real
+stdout and stderr -- captured the same way an ordinary `run:` step's are,
+with no JSON decoding or structured outputs contract. There is no
+`.outputs.*` published for a harness step at all: neither
+`${<step id>.outputs.<path>}` nor `${steps.<step id>.outputs.<name>}`
+resolves, regardless of what the process wrote. A later step reads the
+result only by giving the harness step its own `output: NAME` field (the
+standard declared-output mechanism; see [Spec 012: Step
+Outputs](012-step-outputs.md)), which captures the process's stdout with
+one trailing newline trimmed.
+
+## Errors
+
+### Validation
+
+`dagu validate` resolves a harness step's provider configuration and any
+`harnesses:` definitions fully -- both are local to the DAG file and this
+binary, unlike a remote action's schema. It checks:
+
+- `with.prompt` missing: `with.prompt is required`.
+- `with.provider` missing, or naming neither a built-in provider nor a
+  defined `harnesses:` entry: `config.provider is required` or `unknown
+  provider "<name>"`.
+- `with.binary` or `with.prompt_args` present: both are rejected outright
+  (`config.binary is not supported...` / `config.prompt_args is not
+  supported...`) -- a custom CLI must be defined under `harnesses:` and
+  selected via `with.provider`, not configured inline on the step.
+- A `harnesses:` entry missing `binary`: `binary is required`.
+- A `harnesses:` entry's `prompt_mode` not one of `arg`, `flag`, `stdin`:
+  `prompt_mode must be one of: arg, flag, stdin`.
+- A `harnesses:` entry's `prompt_flag` set when `prompt_mode` is not
+  `flag`, or unset when it is: `prompt_flag is only valid when prompt_mode
+  is flag` / `prompt_flag is required when prompt_mode is flag`.
+
+`dagu validate` does not check whether the configured binary actually
+exists on disk or in `PATH` -- that is deferred to run time.
+
+### Runtime
+
+- The configured binary cannot be resolved (it does not exist, or is not
+  on `PATH`): the step fails with `harness: failed to resolve binary
+  "<name>": ...` before any process starts.
+- The provider's process exits non-zero, with no `with.fallback`
+  configured (or every fallback also fails): the step fails with that
+  process's own real exit code, and its own stdout/stderr are captured as
+  usual -- this is a real process failure, not a wrapper-level validation
+  error.
+
+## Related Specs
+
+- Step outputs and reference syntax, for the standard `output: NAME`
+  mechanism this executor uses instead of a JSON outputs contract: [Spec
+  012: Step Outputs](012-step-outputs.md)
+- Agent DAGs, which can use a harness step as one action among several in
+  an LLM-driven decision loop: [Spec 032: Agent DAGs](032-agent-dag.md)
+
+## Examples
+
+Define a custom CLI provider and use it with structured flags:
+
+```yaml
+harnesses:
+  my_agent:
+    binary: /usr/local/bin/my-agent
+    prompt_mode: flag
+    prompt_flag: --task
+    option_flags:
+      max_turns: --turns
+
+steps:
+  - id: review
+    action: harness.run
+    with:
+      provider: my_agent
+      prompt: Review this patch for correctness.
+      stdin: |
+        diff --git a/main.go b/main.go
+        ...
+      max_turns: 3
+    output: REVIEW_RESULT
+
+  - id: print
+    depends: review
+    run: echo "${REVIEW_RESULT}"
+```
+
+Fall back to a second provider if the first fails:
+
+```yaml
+steps:
+  - id: fix
+    action: harness.run
+    with:
+      provider: claude
+      prompt: Fix the failing test.
+      fallback:
+        - provider: codex
+```

--- a/specs/067-harness.md
+++ b/specs/067-harness.md
@@ -28,11 +28,8 @@ This spec covers:
   provider (`binary`, `prefix_args`, `prompt_mode`, `prompt_flag`,
   `prompt_position`, `flag_style`, `option_flags`) that a step selects via
   `with.provider`, for a CLI the built-in provider catalog does not name
-- that a harness step publishes no `.outputs.*` at all: it is a plain
-  Command/Script-capable executor, like an ordinary `run:` step, not one
-  with a JSON-decoded outputs contract; a later step reads its result only
-  through the standard declared `output: NAME` mechanism ([Spec 012: Step
-  Outputs](012-step-outputs.md))
+- capturing stdout through a declared `output: NAME` and reading it in a
+  downstream step ([Spec 012: Step Outputs](012-step-outputs.md))
 - that, unlike the remote actions in specs 060-066, `dagu validate` fully
   resolves and checks a harness step's provider configuration and any
   `harnesses:` definitions it references, since both are local to the DAG
@@ -90,7 +87,8 @@ For a custom (`harnesses:`-defined) provider, the invocation is built as:
    to the process's stdin as a separate stream from the argument-delivered
    prompt.
 
-Flags built from `with:` keys other than `provider`/`fallback` are sorted
+The input keys `prompt` and `stdin`, and executor options `provider`,
+`fallback`, and `managed`, do not become CLI flags. Other keys are sorted
 by key for deterministic ordering. Each key becomes `--key` (or `-key`
 when the definition's `flag_style` is `single_dash`) unless
 `option_flags` maps that key to a different literal flag token. A boolean
@@ -112,16 +110,9 @@ fails with the last config's own error.
 
 ### Result
 
-A harness step's stdout and stderr are the underlying process's real
-stdout and stderr -- captured the same way an ordinary `run:` step's are,
-with no JSON decoding or structured outputs contract. There is no
-`.outputs.*` published for a harness step at all: neither
-`${<step id>.outputs.<path>}` nor `${steps.<step id>.outputs.<name>}`
-resolves, regardless of what the process wrote. A later step reads the
-result only by giving the harness step its own `output: NAME` field (the
-standard declared-output mechanism; see [Spec 012: Step
-Outputs](012-step-outputs.md)), which captures the process's stdout with
-one trailing newline trimmed.
+A harness step captures the provider process's stdout and stderr. A declared
+`output: NAME` makes stdout available to downstream steps, following
+[Spec 012: Step Outputs](012-step-outputs.md).
 
 ## Errors
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [067: Harness Executor](067-harness.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Add binary-level coverage for harness provider invocation, prompt and stdin delivery, fallback, declared output, and configuration errors. Local fixture scripts run through sh on Linux and Windows.

Validation: focused conformance tests and make fmt pass locally. CI must pass before merge.