### PR TITLE
test: add live conformance coverage for duckdb@v1

### DIFF
--- a/conformance/spec048_duckdb/duckdb_helper_test.go
+++ b/conformance/spec048_duckdb/duckdb_helper_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec048_duckdb_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// One match appears per step that wrote anything to stdout, in the order
+// dagu's tree render lists them (which, for both the sequential and the
+// independent-but-declared-in-order fixtures this package uses, matches
+// declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// or JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}

--- a/conformance/spec048_duckdb/duckdb_live_test.go
+++ b/conformance/spec048_duckdb/duckdb_live_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This file adds live coverage for duckdb@v1: real network resolution of
+// the action (cloning https://github.com/dagucloud/duckdb and provisioning
+// its pinned duckdb/duckdb@v1.5.2 tool via the project's aqua-based tool
+// manager), running the real duckdb CLI it installs, and observing its
+// actual output and error behavior. TestLocalAction and TestActionBoundary
+// in duckdb_test.go continue to exercise the generic action-bundle
+// mechanism (input/output schema validation, source: references) against a
+// local bundle with no network access; this file complements that with the
+// specific dagucloud/duckdb action's own observed behavior, the same way
+// specs 060-066 cover their own remote actions. Unlike those actions'
+// Node.js wrappers, duckdb@v1's own workflow.yaml runs a plain shell script
+// that execs duckdb directly and captures its stdout via Dagu's own
+// declared stdout: {outputs: {field: result}} mechanism (Spec 012) -- there
+// is no ok/exitCode/error JSON wrapper at all, just {"result": "<raw duckdb
+// stdout>"}.
+package spec048_duckdb_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuckDBLiveBasicQuery(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "duckdb_live.yaml")
+	result.ExpectExitCode(0)
+
+	var output struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output.Result), &rows),
+		"result is duckdb's own -json stdout (the default format), not a Dagu-specific envelope")
+	require.Equal(t, []map[string]any{{"answer": float64(42), "engine": "duckdb"}}, rows)
+}
+
+func TestDuckDBLivePersistentDatabase(t *testing.T) {
+	t.Setenv("DAGU_CONFORMANCE_COMMAND_TIMEOUT", "2m")
+
+	dagu := harness.NewRunner(t)
+	dagu.Mkdir("data")
+	env := []string{
+		"HOST_DB_PATH=" + dagu.ProjectPath("data/test.duckdb"),
+		"HOST_DATA_DIR=" + dagu.ProjectPath("data"),
+	}
+	result := dagu.RunWithEnv(env, "start", "live_persistent_database.yaml")
+	result.ExpectExitCode(0)
+
+	var createTable struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &createTable))
+	require.Empty(t, createTable.Result, "a DDL/DML statement with no SELECT produces no duckdb stdout")
+
+	var readCSV struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &readCSV))
+	require.Equal(t, "id,name\n1,a\n2,b", readCSV.Result,
+		"with.readonly: true should see the previous step's own writes to the same with.database file")
+
+	var readTable struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &readTable))
+	require.Equal(t, "+---+\n| n |\n+---+\n| 2 |\n+---+", readTable.Result)
+
+	var workdirQuery struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &workdirQuery))
+	require.JSONEq(t, `[{"ok":1}]`, workdirQuery.Result, "with.workdir should not interfere with an unrelated query")
+}
+
+func TestDuckDBLiveSQLError(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "live_sql_error.yaml")
+	result.ExpectNonZeroExitCode()
+
+	// duckdb (run with -bail) exits non-zero and writes its own error to
+	// stderr, not stdout; the action's declared result output still
+	// captures whatever duckdb wrote to stdout, which is nothing.
+	var output struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
+	require.Empty(t, output.Result)
+	result.ExpectStderrContains("this_table_does_not_exist does not exist")
+}
+
+// Unlike node-script@v1's with.script, duckdb@v1's with.query is not
+// resolved by Dagu's own value resolution before it reaches the action: a
+// literal "$VAR"-shaped token in with.query survives unresolved into the
+// query duckdb actually runs.
+func TestDuckDBLiveQueryFieldNotResolved(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "live_query_not_resolved.yaml")
+	result.ExpectExitCode(0)
+
+	var output struct {
+		Result string `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
+	require.Contains(t, output.Result, "$MY_VAR")
+	require.NotContains(t, output.Result, "from-env")
+}
+
+// Like node-script@v1, python-script@v1, dbt@v1, ffmpeg@v1, github-cli@v1,
+// rclone@v1, and the harness executor's own output: NAME mechanism (specs
+// 060-067), a later step reads a result field as
+// ${<step id>.outputs.<name>} -- a bare-step-id reference -- and not via
+// ${steps.<step id>.outputs.<name>}, confirming duckdb@v1 follows the same
+// remote action:-type convention.
+func TestDuckDBLiveDownstreamReference(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "live_downstream_reference.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("bad substitution")
+
+	require.Equal(t, "bare result is [{answer:42}]\n", stepStdout(t, result.Stdout(), 1))
+}

--- a/conformance/spec048_duckdb/testdata/live_downstream_reference.yaml
+++ b/conformance/spec048_duckdb/testdata/live_downstream_reference.yaml
@@ -1,0 +1,11 @@
+steps:
+  - id: query
+    action: duckdb@v1
+    with:
+      query: "SELECT 42 AS answer;"
+  - id: print_bare
+    depends: query
+    run: echo "bare result is ${query.outputs.result}"
+  - id: print_strict
+    depends: query
+    run: echo "strict=${steps.query.outputs.result}"

--- a/conformance/spec048_duckdb/testdata/live_persistent_database.yaml
+++ b/conformance/spec048_duckdb/testdata/live_persistent_database.yaml
@@ -1,0 +1,34 @@
+env:
+  - DB_PATH: $HOST_DB_PATH
+  - DATA_DIR: $HOST_DATA_DIR
+steps:
+  - id: create_table
+    action: duckdb@v1
+    with:
+      database: $DB_PATH
+      query: "CREATE TABLE t(id INTEGER, name VARCHAR); INSERT INTO t VALUES (1,'a'),(2,'b');"
+
+  - id: read_csv
+    depends: create_table
+    action: duckdb@v1
+    with:
+      database: $DB_PATH
+      readonly: true
+      format: csv
+      query: "SELECT * FROM t ORDER BY id;"
+
+  - id: read_table_format
+    depends: read_csv
+    action: duckdb@v1
+    with:
+      database: $DB_PATH
+      readonly: true
+      format: table
+      query: "SELECT count(*) AS n FROM t;"
+
+  - id: workdir_query
+    depends: read_table_format
+    action: duckdb@v1
+    with:
+      workdir: $DATA_DIR
+      query: "SELECT 1 AS ok;"

--- a/conformance/spec048_duckdb/testdata/live_query_not_resolved.yaml
+++ b/conformance/spec048_duckdb/testdata/live_query_not_resolved.yaml
@@ -1,0 +1,8 @@
+env:
+  - MY_VAR: from-env
+steps:
+  - id: query
+    action: duckdb@v1
+    with:
+      format: list
+      query: "SELECT '$MY_VAR' AS val;"

--- a/conformance/spec048_duckdb/testdata/live_sql_error.yaml
+++ b/conformance/spec048_duckdb/testdata/live_sql_error.yaml
@@ -1,0 +1,5 @@
+steps:
+  - id: bad_sql
+    action: duckdb@v1
+    with:
+      query: "SELECT * FROM this_table_does_not_exist;"

--- a/specs/048-duckdb-action.md
+++ b/specs/048-duckdb-action.md
@@ -2,22 +2,73 @@
 
 ## Status
 
-Partially implemented.
-
-Conformance accepts a `duckdb@v1` reference and exercises Dagu's action
-input/output boundary with a local bundle. It does not download or run DuckDB.
-SQL behavior and tool provisioning belong in action and executor tests.
+Implemented.
 
 ## Scope
 
-This spec covers versioned action references and manifest input/output validation.
-It does not define DuckDB's SQL dialect, tool installation, Git transport, or
-remote repository availability.
+This spec covers two things:
+
+- versioned action references and manifest input/output validation, using
+  a local bundle (`source:./directory@version`), with no network access
+- the observed behavior of the official remote action `duckdb@v1`
+  (`dagucloud/duckdb`) itself, resolved and run for real, the same way
+  specs 060-067 cover their own remote actions or built-in executors
+
+Like `node-script@v1` ([Spec 060: Node Script Action](060-node-script.md))
+and the other remote actions in this family, `duckdb@v1` is not a built-in
+Go executor: referencing it clones `https://github.com/dagucloud/duckdb`
+at the given tag and provisions its own pinned `duckdb/duckdb@v1.5.2` tool
+via the project's aqua-based tool manager on first use. Unlike those
+actions' Node.js wrappers, `duckdb@v1`'s own `workflow.yaml` runs a plain
+POSIX shell script that `exec`s the real `duckdb` CLI directly and captures
+its stdout through Dagu's own declared `stdout: {outputs: {field:
+result}}` mechanism ([Spec 012: Step Outputs](012-step-outputs.md)) --
+there is no `ok`/`exitCode`/`error` JSON wrapper at all, just `{"result":
+"<raw duckdb stdout>"}`.
+
+This spec covers:
+
+- `with.query` (required), `with.database` (optional; omitted or
+  `:memory:` for a transient in-memory database), `with.workdir`,
+  `with.format` (one of `json`, `csv`, `table`, `markdown`, `line`,
+  `list`, `column`; default `json`), and `with.readonly`
+- that `with.database`, when it names a real file path, persists across
+  separate `duckdb@v1` invocations -- a later step with `with.readonly:
+  true` sees an earlier step's writes to the same file
+- that `with.query`'s text is not resolved by Dagu's own value resolution
+  before it reaches the action (unlike `node-script@v1`'s `with.script`):
+  a literal `$NAME`-shaped token in `with.query` survives unresolved into
+  the query `duckdb` actually runs
+- that a real `duckdb` SQL error reports through the ordinary
+  `result`/exit-code channel, not a wrapper error object: `duckdb` (run
+  with `-bail`) exits non-zero and writes its own error to stderr, while
+  `result` reflects whatever `duckdb` wrote to stdout (nothing, for a
+  failed query)
+- that a later step reads a result field as `${<step id>.outputs.<path>}`
+  (a bare-step-id reference), the same form confirmed for the other
+  remote actions and the harness executor in this family, and not via the
+  strict `${steps.<step id>.outputs.<name>}` form
+- that `dagu validate` never resolves the remote action reference: a
+  `duckdb@v1` step passes validate regardless of its `with:` content, and
+  `with.query` being required is enforced only once the step actually runs
+
+This spec does not define:
+
+- DuckDB's own SQL dialect or CLI output format details beyond what the
+  action surfaces (`with.format` selects one of `duckdb`'s own output
+  modes; this spec does not define each mode's exact formatting)
+- the duckdb action's own implementation, versioning, or release process --
+  this spec treats `duckdb@v1` as an external dependency and documents its
+  observed contract
+- the generic remote-action resolution mechanism itself, covered in more
+  depth by [Spec 060: Node Script Action](060-node-script.md)
+- performance or caching behavior of the action's own tool provisioning
 
 ## Goal
 
 Workflow authors can call reusable actions through a consistent input/output
-contract.
+contract, and specifically run real DuckDB SQL as a Dagu step without
+installing DuckDB or managing its provisioning themselves.
 
 ## Behavior
 
@@ -26,15 +77,36 @@ without fetching the action. Local bundles can be selected with
 `source:./directory@version`.
 
 Action fields appear directly under `with`, such as `with.query` or
-`with.message`. The action manifest validates that object against its `inputs`
-schema. Successful action results are validated against its `outputs` schema
-and emitted as JSON on stdout.
+`with.message`. The action manifest validates that object against its
+`inputs` schema. Successful action results are validated against its
+`outputs` schema and emitted as JSON on stdout.
+
+For `duckdb@v1` specifically: the result's `result` field is `duckdb`'s own
+raw stdout in the format `with.format` selected -- for the default `json`
+format, that is `duckdb`'s own `-json` output (a JSON array of row
+objects, as text), not a Dagu-specific envelope. A statement that produces
+no rows (a `CREATE TABLE`/`INSERT`, for example) leaves `result` empty.
+`with.workdir`, when set, is the directory `duckdb` runs in; it has no
+effect on the query itself unless the query depends on the working
+directory some other way (for example a relative `with.database` path).
 
 ## Errors
 
 A source reference without a version fails validation. Input and output schema
 violations fail execution with diagnostics identifying the corresponding action
 schema. Schema-library wording beyond that identification is not normative.
+
+For `duckdb@v1` specifically:
+
+- `with.query` missing, or `with.format` set to a value other than the six
+  named above: an error containing `missing properties: ["query"]` or
+  `does not equal any of`, raised when the action resolves its own input
+  schema against the step's `with:` content -- before `duckdb` is ever
+  invoked.
+- A real `duckdb` SQL error (a missing table, invalid syntax, and so on):
+  the step fails (a non-zero exit) with `duckdb`'s own error text on
+  stderr and an empty `result`, not a wrapper error object -- `duckdb`
+  itself ran and failed.
 
 ## Examples
 
@@ -43,4 +115,28 @@ steps:
   - action: duckdb@v1
     with:
       query: SELECT 42 AS answer
+```
+
+Persist data across steps and read it back read-only:
+
+```yaml
+steps:
+  - id: seed
+    action: duckdb@v1
+    with:
+      database: /data/warehouse.duckdb
+      query: "CREATE TABLE t(id INTEGER, name VARCHAR); INSERT INTO t VALUES (1,'a');"
+
+  - id: read
+    depends: seed
+    action: duckdb@v1
+    with:
+      database: /data/warehouse.duckdb
+      readonly: true
+      format: csv
+      query: "SELECT * FROM t ORDER BY id;"
+
+  - id: print
+    depends: read
+    run: echo "${read.outputs.result}"
 ```

--- a/specs/README.md
+++ b/specs/README.md
@@ -50,7 +50,7 @@ It must not be treated as product behavior until implementation catches up.
 | [045: HTTP Request Action](045-http-request.md) | Partially implemented |
 | [046: PostgreSQL Actions](046-postgres.md) | Partially implemented |
 | [047: SQLite Actions](047-sqlite.md) | Partially implemented |
-| [048: DuckDB and Action Bundles](048-duckdb-action.md) | Partially implemented |
+| [048: DuckDB and Action Bundles](048-duckdb-action.md) | Implemented |
 | [049: Data Convert and Pick Actions](049-data.md) | Partially implemented |
 | [050: Outputs Write Action](050-outputs.md) | Implemented |
 | [051: Artifact Actions](051-artifact.md) | Partially implemented |


### PR DESCRIPTION
## Summary

Extend spec 048 beyond the local-bundle-only mechanism test: resolve
  the real dagucloud/duckdb action over the network and run its real
  duckdb CLI. Covers with.query/database/workdir/format/readonly, that
  with.database persists across separate invocations (a later
  readonly: true step sees an earlier step's writes), that with.query is
  not resolved by Dagu's own value resolution (unlike node-script@v1's
  with.script), and that a real duckdb SQL error reports through the
  ordinary result/exit-code channel with no wrapper error object, since
  duckdb@v1's own workflow.yaml is a plain shell script with no
  ok/exitCode/error JSON envelope at all.
  
  
## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the DuckDB action specification to reflect implemented behavior, supported options, persistence, output handling, and error scenarios.
  - Marked the DuckDB and Action Bundles specification as implemented.

- **Tests**
  - Added live conformance coverage for queries, persistent databases, formats, SQL errors, unresolved variables, and cross-step references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->