### PR TITLE
test: add black-box conformance coverage for the state executor

### DIFF
--- a/conformance/spec068_state/state_helper_test.go
+++ b/conformance/spec068_state/state_helper_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec068_state_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+// One match appears per step that wrote anything to stdout, in the order
+// dagu's tree render lists them (which, for both the sequential and the
+// independent-but-declared-in-order fixtures this package uses, matches
+// declaration order).
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict content
+// or JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}

--- a/conformance/spec068_state/state_test.go
+++ b/conformance/spec068_state/state_test.go
@@ -1,0 +1,249 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec068_state holds black-box conformance tests for Spec 068:
+// State Executor (action: state.get/set/delete/list/diff).
+//
+// Unlike specs 060-067, state is a built-in Go executor with no external
+// process at all: it reads and writes Dagu's own persistent state store
+// directly, so every test here runs fully offline and fast. Its state is
+// durable across separate dagu invocations (not just across steps within
+// one run), which the harness's own per-invocation isolated $HOME would
+// normally hide -- TestStateGlobalPersistsAcrossSeparateRuns works around
+// that by pinning HOME/DAGU_HOME to a directory this test creates itself,
+// via RunWithEnv, across two separate dagu start invocations.
+package spec068_state_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateHappyPath(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "happy_path.yaml")
+	result.ExpectExitCode(0)
+
+	var setVal struct {
+		Operation string `json:"operation"`
+		Scope     string `json:"scope"`
+		Key       string `json:"key"`
+		Version   int64  `json:"version"`
+		Created   bool   `json:"created"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &setVal))
+	require.Equal(t, "set", setVal.Operation)
+	require.Equal(t, "dag", setVal.Scope)
+	require.Equal(t, "mykey", setVal.Key)
+	require.EqualValues(t, 1, setVal.Version)
+	require.True(t, setVal.Created)
+
+	var getVal struct {
+		Found bool           `json:"found"`
+		Value map[string]any `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &getVal))
+	require.True(t, getVal.Found)
+	require.EqualValues(t, map[string]any{"hello": "world", "n": float64(1)}, getVal.Value)
+
+	var getMissingDefault struct {
+		Found bool           `json:"found"`
+		Value map[string]any `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &getMissingDefault))
+	require.False(t, getMissingDefault.Found, "state.get on a missing key without required: true reports found: false, not an error")
+	require.EqualValues(t, map[string]any{"fallback": true}, getMissingDefault.Value)
+
+	var diffCreate struct {
+		Changed       bool `json:"changed"`
+		FoundPrevious bool `json:"foundPrevious"`
+		Version       int64
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &diffCreate))
+	require.True(t, diffCreate.Changed)
+	require.False(t, diffCreate.FoundPrevious, "the first state.diff against a new key has no previous value")
+
+	var diffSame struct {
+		Changed         bool  `json:"changed"`
+		FoundPrevious   bool  `json:"foundPrevious"`
+		PreviousVersion int64 `json:"previousVersion"`
+		Version         int64 `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 4)), &diffSame))
+	require.False(t, diffSame.Changed, "state.diff against an identical value reports changed: false")
+	require.True(t, diffSame.FoundPrevious)
+	require.Equal(t, diffSame.PreviousVersion, diffSame.Version, "an unchanged diff does not bump the version")
+
+	var diffNoUpdate struct {
+		Changed bool  `json:"changed"`
+		Version int64 `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 5)), &diffNoUpdate))
+	require.True(t, diffNoUpdate.Changed)
+	require.EqualValues(t, 1, diffNoUpdate.Version, "update: false reports the change but does not write it, so the version stays at its previous value")
+
+	var diffUpdate struct {
+		Changed bool  `json:"changed"`
+		Version int64 `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 6)), &diffUpdate))
+	require.True(t, diffUpdate.Changed)
+	require.EqualValues(t, 2, diffUpdate.Version, "without update: false, a changed diff writes the new value and bumps the version")
+
+	var listAll struct {
+		Entries []struct {
+			Key   string          `json:"key"`
+			Value json.RawMessage `json:"value"`
+		} `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 7)), &listAll))
+	require.Len(t, listAll.Entries, 2, "state.list without a prefix returns every entry in scope, and it defaults to omitting values")
+	for _, entry := range listAll.Entries {
+		require.Nil(t, entry.Value)
+	}
+
+	var listPrefixValues struct {
+		Entries []struct {
+			Key   string         `json:"key"`
+			Value map[string]any `json:"value"`
+		} `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 8)), &listPrefixValues))
+	require.Len(t, listPrefixValues.Entries, 1)
+	require.Equal(t, "diff_key", listPrefixValues.Entries[0].Key)
+	require.EqualValues(t, map[string]any{"v": float64(2)}, listPrefixValues.Entries[0].Value)
+}
+
+// TestStateScopeIsolation proves the difference between scope: dag (which
+// namespaces state under the current DAG's own name -- isolated per
+// sub-dag) and scope: root_dag (which namespaces state under the root
+// dag-run's name, shared by every DAG in that run's own nested-call tree).
+func TestStateScopeIsolation(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "scope_isolation_parent.yaml")
+	result.ExpectExitCode(0)
+
+	var dagScope struct {
+		Found bool   `json:"found"`
+		Value string `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 1)), &dagScope))
+	require.False(t, dagScope.Found,
+		"scope: dag namespaces by the current DAG's own name, so the parent cannot see a key the child wrote under its own dag scope")
+	require.Equal(t, "MISSING", dagScope.Value)
+
+	var rootScope struct {
+		Found bool   `json:"found"`
+		Value string `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 2)), &rootScope))
+	require.True(t, rootScope.Found,
+		"scope: root_dag namespaces by the root dag-run's name, so the parent sees what the child wrote under root_dag scope")
+	require.Equal(t, "from-child-root-scope", rootScope.Value)
+}
+
+func TestStateErrorScenarios(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "error_scenarios.yaml")
+	result.ExpectNonZeroExitCode()
+
+	require.Contains(t, result.Stdout(), "dag state: conflict",
+		"state.set create_only: true against an existing key, and a state.set with a stale expected_version, both fail with a conflict")
+	require.Contains(t, result.Stdout(), "dag state: not found",
+		"state.get required: true against a missing key fails instead of reporting found: false")
+	require.Contains(t, result.Stdout(), "namespace is required for custom")
+	require.Contains(t, result.Stdout(), `invalid key "../escape"`)
+}
+
+// Unlike the remote actions in specs 060-066, and like the harness executor
+// (spec 067), a state step publishes no .outputs.* at all: neither the
+// bare-step-id nor the strict form resolves. A later step reads its result
+// only via the standard declared output: NAME mechanism (Spec 012).
+func TestStateDownstreamReference(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "downstream_reference.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("bad substitution")
+
+	require.Equal(t, `named={"operation":"get","scope":"dag","namespace":"downstream_reference","key":"ref_key","found":true,"version":1,"hash":"`,
+		stepStdout(t, result.Stdout(), 3)[:len(`named={"operation":"get","scope":"dag","namespace":"downstream_reference","key":"ref_key","found":true,"version":1,"hash":"`)],
+		"output: NAME captures the step's full JSON line verbatim")
+}
+
+func TestStateGlobalPersistsAcrossSeparateRuns(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	fixedHome := t.TempDir()
+	env := []string{
+		"HOME=" + fixedHome,
+		"DAGU_HOME=" + filepath.Join(fixedHome, "dagu"),
+	}
+
+	writeResult := dagu.RunWithEnv(env, "start", "global_persistence_writer.yaml")
+	writeResult.ExpectExitCode(0)
+
+	// A separate dagu start invocation, pinned to the same HOME/DAGU_HOME,
+	// stands in for a genuinely separate process reading state a prior run
+	// wrote -- proving state.set's writes are durable, not scoped to the
+	// dag-run that created them.
+	readResult := dagu.RunWithEnv(env, "start", "global_persistence_reader.yaml")
+	readResult.ExpectExitCode(0)
+
+	var getVal struct {
+		Found bool   `json:"found"`
+		Value string `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, readResult.Stdout(), 0)), &getVal))
+	require.True(t, getVal.Found)
+	require.Equal(t, "persisted-across-runs", getVal.Value)
+}
+
+// TestStateValidation covers dagu validate for the state executor. Like
+// the harness executor (spec 067) and unlike the remote actions in specs
+// 060-066, state is a built-in executor: dagu validate resolves and checks
+// some of its configuration without running anything. It checks that
+// with.key is present (for get/set/delete/diff) and with.value is present
+// (for set/diff), but not scope-specific rules like a custom scope needing
+// with.namespace, or with.key's character restrictions -- those surface
+// only at run time (see TestStateErrorScenarios).
+func TestStateValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		file       string
+		wantStderr string
+	}{
+		{"invalid_missing_key.yaml", "key is required"},
+		{"invalid_missing_value.yaml", "value is required for set"},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", tc.file)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.wantStderr)
+		})
+	}
+
+	t.Run("a well-formed state step passes validate", func(t *testing.T) {
+		t.Parallel()
+
+		dagu := harness.NewRunner(t)
+		result := dagu.Run("validate", "happy_path.yaml")
+		result.ExpectExitCode(0)
+	})
+}

--- a/conformance/spec068_state/state_test.go
+++ b/conformance/spec068_state/state_test.go
@@ -1,22 +1,13 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Package spec068_state holds black-box conformance tests for Spec 068:
-// State Executor (action: state.get/set/delete/list/diff).
-//
-// Unlike specs 060-067, state is a built-in Go executor with no external
-// process at all: it reads and writes Dagu's own persistent state store
-// directly, so every test here runs fully offline and fast. Its state is
-// durable across separate dagu invocations (not just across steps within
-// one run), which the harness's own per-invocation isolated $HOME would
-// normally hide -- TestStateGlobalPersistsAcrossSeparateRuns works around
-// that by pinning HOME/DAGU_HOME to a directory this test creates itself,
-// via RunWithEnv, across two separate dagu start invocations.
+// Package spec068_state tests persistent state through the Dagu binary.
 package spec068_state_test
 
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/conformance/harness"
@@ -70,14 +61,16 @@ func TestStateHappyPath(t *testing.T) {
 	require.False(t, diffCreate.FoundPrevious, "the first state.diff against a new key has no previous value")
 
 	var diffSame struct {
-		Changed         bool  `json:"changed"`
-		FoundPrevious   bool  `json:"foundPrevious"`
-		PreviousVersion int64 `json:"previousVersion"`
-		Version         int64 `json:"version"`
+		Changed         bool            `json:"changed"`
+		FoundPrevious   bool            `json:"foundPrevious"`
+		PreviousVersion int64           `json:"previousVersion"`
+		Previous        json.RawMessage `json:"previous"`
+		Version         int64           `json:"version"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 4)), &diffSame))
 	require.False(t, diffSame.Changed, "state.diff against an identical value reports changed: false")
 	require.True(t, diffSame.FoundPrevious)
+	require.JSONEq(t, `{"v":1}`, string(diffSame.Previous))
 	require.Equal(t, diffSame.PreviousVersion, diffSame.Version, "an unchanged diff does not bump the version")
 
 	var diffNoUpdate struct {
@@ -118,6 +111,22 @@ func TestStateHappyPath(t *testing.T) {
 	require.Len(t, listPrefixValues.Entries, 1)
 	require.Equal(t, "diff_key", listPrefixValues.Entries[0].Key)
 	require.EqualValues(t, map[string]any{"v": float64(2)}, listPrefixValues.Entries[0].Value)
+
+	var deleted struct {
+		Deleted bool `json:"deleted"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 9)), &deleted))
+	require.True(t, deleted.Deleted)
+
+	var afterDelete struct {
+		Found bool `json:"found"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 10)), &afterDelete))
+	require.False(t, afterDelete.Found)
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 11)), &listAll))
+	require.Len(t, listAll.Entries, 1)
+	require.Equal(t, "diff_key", listAll.Entries[0].Key)
+
 }
 
 // TestStateScopeIsolation proves the difference between scope: dag (which
@@ -148,6 +157,17 @@ func TestStateScopeIsolation(t *testing.T) {
 	require.True(t, rootScope.Found,
 		"scope: root_dag namespaces by the root dag-run's name, so the parent sees what the child wrote under root_dag scope")
 	require.Equal(t, "from-child-root-scope", rootScope.Value)
+
+	for i, want := range []string{"first", "second"} {
+		var custom struct {
+			Found bool   `json:"found"`
+			Value string `json:"value"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 5+i)), &custom))
+		require.True(t, custom.Found)
+		require.Equal(t, want, custom.Value)
+	}
+
 }
 
 func TestStateErrorScenarios(t *testing.T) {
@@ -157,32 +177,34 @@ func TestStateErrorScenarios(t *testing.T) {
 	result := dagu.Run("start", "error_scenarios.yaml")
 	result.ExpectNonZeroExitCode()
 
-	require.Contains(t, result.Stdout(), "dag state: conflict",
-		"state.set create_only: true against an existing key, and a state.set with a stale expected_version, both fail with a conflict")
+	// Both writes must fail independently after the initial value is stored.
+	for _, step := range []string{"set_create_only_again", "set_bad_version"} {
+		require.Regexp(t, step+`[^\n]*\[failed\]`, result.Stdout())
+	}
+	require.Equal(t, 2, strings.Count(result.Stdout(), "dag state: conflict"))
 	require.Contains(t, result.Stdout(), "dag state: not found",
 		"state.get required: true against a missing key fails instead of reporting found: false")
 	require.Contains(t, result.Stdout(), "namespace is required for custom")
 	require.Contains(t, result.Stdout(), `invalid key "../escape"`)
 }
 
-// Unlike the remote actions in specs 060-066, and like the harness executor
-// (spec 067), a state step publishes no .outputs.* at all: neither the
-// bare-step-id nor the strict form resolves. A later step reads its result
-// only via the standard declared output: NAME mechanism (Spec 012).
 func TestStateDownstreamReference(t *testing.T) {
 	t.Parallel()
 
 	dagu := harness.NewRunner(t)
 	result := dagu.Run("start", "downstream_reference.yaml")
-	result.ExpectNonZeroExitCode()
-	result.ExpectStderrContains("bad substitution")
+	result.ExpectExitCode(0)
 
-	require.Equal(t, `named={"operation":"get","scope":"dag","namespace":"downstream_reference","key":"ref_key","found":true,"version":1,"hash":"`,
-		stepStdout(t, result.Stdout(), 3)[:len(`named={"operation":"get","scope":"dag","namespace":"downstream_reference","key":"ref_key","found":true,"version":1,"hash":"`)],
-		"output: NAME captures the step's full JSON line verbatim")
+	var output struct {
+		Found bool `json:"found"`
+		Value int  `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 3)), &output))
+	require.True(t, output.Found)
+	require.Equal(t, 42, output.Value)
 }
 
-func TestStateGlobalPersistsAcrossSeparateRuns(t *testing.T) {
+func TestStatePersistence(t *testing.T) {
 	t.Parallel()
 
 	dagu := harness.NewRunner(t)
@@ -228,6 +250,7 @@ func TestStateValidation(t *testing.T) {
 	}{
 		{"invalid_missing_key.yaml", "key is required"},
 		{"invalid_missing_value.yaml", "value is required for set"},
+		{"invalid_diff_value.yaml", "value is required for diff"},
 	} {
 		t.Run(tc.file, func(t *testing.T) {
 			t.Parallel()

--- a/conformance/spec068_state/testdata/downstream_reference.yaml
+++ b/conformance/spec068_state/testdata/downstream_reference.yaml
@@ -20,12 +20,5 @@ steps:
 
   - id: print_named
     depends: get_named
-    run: echo "named=${GET_RESULT}"
-
-  - id: print_bare
-    depends: get_val
-    run: echo "bare value is ${get_val.outputs.value}"
-
-  - id: print_strict
-    depends: get_val
-    run: echo "strict=${steps.get_val.outputs.value}"
+    run: |
+      printf '%s\n' "${GET_RESULT}"

--- a/conformance/spec068_state/testdata/downstream_reference.yaml
+++ b/conformance/spec068_state/testdata/downstream_reference.yaml
@@ -1,0 +1,31 @@
+steps:
+  - id: set_val
+    action: state.set
+    with:
+      key: ref_key
+      value: 42
+
+  - id: get_val
+    depends: set_val
+    action: state.get
+    with:
+      key: ref_key
+
+  - id: get_named
+    depends: get_val
+    action: state.get
+    with:
+      key: ref_key
+    output: GET_RESULT
+
+  - id: print_named
+    depends: get_named
+    run: echo "named=${GET_RESULT}"
+
+  - id: print_bare
+    depends: get_val
+    run: echo "bare value is ${get_val.outputs.value}"
+
+  - id: print_strict
+    depends: get_val
+    run: echo "strict=${steps.get_val.outputs.value}"

--- a/conformance/spec068_state/testdata/error_scenarios.yaml
+++ b/conformance/spec068_state/testdata/error_scenarios.yaml
@@ -1,0 +1,42 @@
+steps:
+  - id: set_create_only
+    action: state.set
+    with:
+      key: co_key
+      value: 1
+      create_only: true
+
+  - id: set_create_only_again
+    depends: set_create_only
+    action: state.set
+    with:
+      key: co_key
+      value: 2
+      create_only: true
+
+  - id: set_bad_version
+    depends: set_create_only
+    action: state.set
+    with:
+      key: co_key
+      value: 3
+      expected_version: 99
+
+  - id: get_required_missing
+    action: state.get
+    with:
+      key: does-not-exist
+      required: true
+
+  - id: custom_scope_missing_namespace
+    action: state.set
+    with:
+      scope: custom
+      key: k
+      value: 1
+
+  - id: invalid_key_chars
+    action: state.set
+    with:
+      key: "../escape"
+      value: 1

--- a/conformance/spec068_state/testdata/global_persistence_reader.yaml
+++ b/conformance/spec068_state/testdata/global_persistence_reader.yaml
@@ -1,0 +1,6 @@
+steps:
+  - id: get_val
+    action: state.get
+    with:
+      scope: global
+      key: shared_key

--- a/conformance/spec068_state/testdata/global_persistence_writer.yaml
+++ b/conformance/spec068_state/testdata/global_persistence_writer.yaml
@@ -1,0 +1,7 @@
+steps:
+  - id: set_val
+    action: state.set
+    with:
+      scope: global
+      key: shared_key
+      value: "persisted-across-runs"

--- a/conformance/spec068_state/testdata/happy_path.yaml
+++ b/conformance/spec068_state/testdata/happy_path.yaml
@@ -1,0 +1,59 @@
+steps:
+  - id: set_val
+    action: state.set
+    with:
+      key: mykey
+      value: {"hello": "world", "n": 1}
+
+  - id: get_val
+    depends: set_val
+    action: state.get
+    with:
+      key: mykey
+
+  - id: get_missing_default
+    depends: get_val
+    action: state.get
+    with:
+      key: does-not-exist
+      default: {"fallback": true}
+
+  - id: diff_create
+    depends: get_missing_default
+    action: state.diff
+    with:
+      key: diff_key
+      value: {"v": 1}
+
+  - id: diff_same
+    depends: diff_create
+    action: state.diff
+    with:
+      key: diff_key
+      value: {"v": 1}
+
+  - id: diff_changed_no_update
+    depends: diff_same
+    action: state.diff
+    with:
+      key: diff_key
+      value: {"v": 2}
+      update: false
+
+  - id: diff_changed_update
+    depends: diff_changed_no_update
+    action: state.diff
+    with:
+      key: diff_key
+      value: {"v": 2}
+
+  - id: list_all
+    depends: diff_changed_update
+    action: state.list
+
+  - id: list_prefix_values
+    depends: list_all
+    action: state.list
+    with:
+      prefix: diff
+      include_values: true

--- a/conformance/spec068_state/testdata/happy_path.yaml
+++ b/conformance/spec068_state/testdata/happy_path.yaml
@@ -57,3 +57,19 @@ steps:
     with:
       prefix: diff
       include_values: true
+
+  - id: delete_val
+    depends: list_prefix_values
+    action: state.delete
+    with:
+      key: mykey
+
+  - id: get_deleted
+    depends: delete_val
+    action: state.get
+    with:
+      key: mykey
+
+  - id: list_after_delete
+    depends: get_deleted
+    action: state.list

--- a/conformance/spec068_state/testdata/invalid_diff_value.yaml
+++ b/conformance/spec068_state/testdata/invalid_diff_value.yaml
@@ -1,0 +1,5 @@
+steps:
+  - id: missing_value_diff
+    action: state.diff
+    with:
+      key: k2

--- a/conformance/spec068_state/testdata/invalid_missing_key.yaml
+++ b/conformance/spec068_state/testdata/invalid_missing_key.yaml
@@ -1,0 +1,4 @@
+steps:
+  - id: missing_key_get
+    action: state.get
+    with: {}

--- a/conformance/spec068_state/testdata/invalid_missing_value.yaml
+++ b/conformance/spec068_state/testdata/invalid_missing_value.yaml
@@ -1,0 +1,5 @@
+steps:
+  - id: missing_value_set
+    action: state.set
+    with:
+      key: k2

--- a/conformance/spec068_state/testdata/scope_isolation_child.yaml
+++ b/conformance/spec068_state/testdata/scope_isolation_child.yaml
@@ -1,0 +1,16 @@
+name: scope_isolation_child
+steps:
+  - id: set_dag_scope
+    action: state.set
+    with:
+      scope: dag
+      key: k
+      value: "from-child"
+
+  - id: set_root_scope
+    depends: set_dag_scope
+    action: state.set
+    with:
+      scope: root_dag
+      key: k
+      value: "from-child-root-scope"

--- a/conformance/spec068_state/testdata/scope_isolation_parent.yaml
+++ b/conformance/spec068_state/testdata/scope_isolation_parent.yaml
@@ -20,3 +20,37 @@ steps:
       scope: root_dag
       key: k
       default: "MISSING"
+
+  - id: set_first
+    depends: get_root_scope
+    action: state.set
+    with:
+      scope: custom
+      namespace: first
+      key: k
+      value: first
+
+  - id: set_second
+    depends: set_first
+    action: state.set
+    with:
+      scope: custom
+      namespace: second
+      key: k
+      value: second
+
+  - id: get_first
+    depends: set_second
+    action: state.get
+    with:
+      scope: custom
+      namespace: first
+      key: k
+
+  - id: get_second
+    depends: get_first
+    action: state.get
+    with:
+      scope: custom
+      namespace: second
+      key: k

--- a/conformance/spec068_state/testdata/scope_isolation_parent.yaml
+++ b/conformance/spec068_state/testdata/scope_isolation_parent.yaml
@@ -1,0 +1,22 @@
+name: scope_isolation_parent
+steps:
+  - id: run_child
+    action: dag.run
+    with:
+      dag: scope_isolation_child
+
+  - id: get_dag_scope
+    depends: run_child
+    action: state.get
+    with:
+      scope: dag
+      key: k
+      default: "MISSING"
+
+  - id: get_root_scope
+    depends: get_dag_scope
+    action: state.get
+    with:
+      scope: root_dag
+      key: k
+      default: "MISSING"

--- a/specs/068-state.md
+++ b/specs/068-state.md
@@ -1,0 +1,181 @@
+# Spec: State Executor
+
+## Status
+
+Implemented.
+
+## Scope
+
+Like the harness executor ([Spec 067: Harness Executor](067-harness.md)),
+`state` is a built-in Go executor, not a remote action: it reads and
+writes Dagu's own persistent state store directly, with no external
+process and no network access at all.
+
+This spec covers:
+
+- the `action: state.get`/`state.set`/`state.delete`/`state.list`/
+  `state.diff` step shapes and their `with:` fields: `scope`, `namespace`,
+  `key`, `prefix`, `value`, `default`, `expected_version`, `create_only`,
+  `required`, `update`, `limit`, `include_values`
+- the four scopes state can live in -- `dag` (default), `root_dag`,
+  `global`, and `custom` -- and, specifically, that `dag` scope namespaces
+  state under the *current* DAG's own name (isolated per sub-dag), while
+  `root_dag` scope namespaces it under the *root* dag-run's name, shared by
+  every DAG in that run's own nested-call tree
+- that state written with `scope: global` is durable across entirely
+  separate `dagu start` invocations, not just across steps within one run
+- optimistic concurrency (`with.expected_version`, `with.create_only`) and
+  `state.diff`'s change-detection and conditional-write behavior
+  (`with.update`)
+- that a state step publishes no `.outputs.*` at all: it is a plain
+  Command-capable executor like an ordinary `run:` step, not one with a
+  JSON-decoded outputs contract; a later step reads its JSON result only
+  through the standard declared `output: NAME` mechanism ([Spec 012: Step
+  Outputs](012-step-outputs.md))
+- that, unlike the remote actions in specs 060-066 and like the harness
+  executor, `dagu validate` checks some of a state step's configuration
+  (that `with.key` is present for `get`/`set`/`delete`/`diff`, and
+  `with.value` is present for `set`/`diff`) without running anything --
+  but scope-specific rules (a `custom` scope needing `with.namespace`,
+  `with.key`'s character restrictions) surface only at run time
+
+This spec does not define:
+
+- the state store's own on-disk format, or how it composes with other
+  persisted DAG-run state
+- distributed/coordinator-mediated state access, or concurrent-writer
+  behavior beyond what `expected_version`/`create_only` establish
+
+## Goal
+
+Workflow authors share small pieces of JSON state between steps, between
+separate runs of the same DAG, or across a whole nested-call tree, without
+standing up an external store (Redis, a database, a file on a shared
+volume) for data that only needs to outlive one step.
+
+## Behavior
+
+### Operations
+
+- `state.get` reads `with.key`. If the key exists, the result reports
+  `found: true` with the entry's `value`, `version`, and `hash`. If it does
+  not exist: with `with.required: true`, the step fails; otherwise the
+  result reports `found: false`, with `value` set to `with.default` when
+  given (omitted otherwise).
+- `state.set` writes `with.value` at `with.key`. `with.create_only: true`
+  fails if the key already exists. `with.expected_version` fails
+  (a conflict) if the key's current version does not match. The result
+  reports the new `version`, `hash`, and `created` (`true` only when this
+  write created the key, that is, its resulting version is `1`).
+- `state.delete` removes `with.key` and reports whether it existed
+  (`deleted: true`/`false`) -- deleting a key that does not exist is not
+  an error.
+- `state.list` returns every entry in scope (optionally filtered by
+  `with.prefix`, and capped at `with.limit`), each with its `key`,
+  `version`, `hash`, `createdAt`, `updatedAt`, and, only when
+  `with.include_values: true`, its `value`.
+- `state.diff` compares `with.value` (normalized and hashed) against the
+  entry currently stored at `with.key`. The result reports `changed`
+  (`true` when the key did not exist yet, or its hash differs) and
+  `foundPrevious`, with `previous`/`previousVersion` when a prior entry
+  existed. When `changed` is `true` and `with.update` is not `false`
+  (the default), it also writes `with.value` as the new entry -- exactly
+  like `state.set` -- and the result's `version`/`hash` reflect that write.
+  With `with.update: false`, no write happens: `version`/`hash` still
+  describe whichever entry (previous or none) already existed.
+
+### Scope
+
+`with.scope` selects where a key lives, and defaults to `dag`:
+
+- `dag`: namespaced under the *current* DAG's own name. A parent DAG and a
+  child DAG it calls (`action: dag.run`) each get their own, isolated
+  `dag`-scoped namespace -- the parent cannot see a key its child wrote
+  under `dag` scope, and vice versa.
+- `root_dag`: namespaced under the *root* dag-run's own DAG name --shared
+  by every DAG in that run's nested-call tree, however deep. A child
+  writing under `root_dag` scope is visible to its parent (and any
+  sibling) reading the same key under `root_dag` scope.
+- `global`: namespaced under `with.namespace`, or a fixed default
+  namespace when `with.namespace` is not given. Not scoped to any DAG or
+  run at all -- entries persist across entirely separate `dagu start`
+  invocations, the same way a value in an external key-value store would.
+- `custom`: namespaced under `with.namespace`, which is required for this
+  scope.
+
+### Result
+
+A state step's stdout is one JSON object, its shape depending on the
+operation (`operation`, `scope`, `namespace`, `key`, plus the
+operation-specific fields listed above). There is no `.outputs.*`
+published for a state step at all: neither `${<step id>.outputs.<path>}`
+nor `${steps.<step id>.outputs.<name>}` resolves. A later step reads the
+result only by giving the state step its own `output: NAME` field (the
+standard declared-output mechanism; see [Spec 012: Step
+Outputs](012-step-outputs.md)), which captures the full JSON line.
+
+## Errors
+
+### Validation
+
+`dagu validate` checks, without running anything:
+
+- `with.key` missing for `state.get`/`state.set`/`state.delete`/
+  `state.diff`: `key is required`.
+- `with.value` missing for `state.set`/`state.diff`: `value is required
+  for <operation>`.
+- `with.limit` negative: `limit must be greater than or equal to zero`.
+
+It does not check `with.scope: custom` requiring `with.namespace`, or
+`with.key`/`with.namespace`'s character restrictions -- those are runtime
+checks (below).
+
+### Runtime
+
+- `with.scope: custom` without `with.namespace`: `namespace is required
+  for custom scope`.
+- `with.key` or `with.namespace` containing a path separator, or equal to
+  `.`/`..`, or (for `with.key`) starting or ending with `/`: `invalid key
+  "<value>"` / `invalid namespace "<value>"`.
+- `state.get` with `with.required: true` against a missing key: `dag
+  state: not found`.
+- `state.set`/`state.diff` with `with.create_only: true` against an
+  existing key, or a stale `with.expected_version`: `dag state: conflict`.
+
+## Related Specs
+
+- Harness executor, the other built-in executor in this family with no
+  `.outputs.*` contract: [Spec 067: Harness Executor](067-harness.md)
+- Step outputs and reference syntax, for the standard `output: NAME`
+  mechanism this executor uses instead of a JSON outputs contract: [Spec
+  012: Step Outputs](012-step-outputs.md)
+
+## Examples
+
+Share a value across separate runs with global scope:
+
+```yaml
+steps:
+  - id: record_last_run
+    action: state.set
+    with:
+      scope: global
+      key: last_successful_run
+      value: "${DAG_RUN_ID}"
+```
+
+Detect whether a value changed since the last run:
+
+```yaml
+steps:
+  - id: check_config
+    action: state.diff
+    with:
+      key: config_hash
+      value: ${CONFIG_JSON}
+    output: DIFF_RESULT
+
+  - id: print_diff
+    depends: check_config
+    run: echo "${DIFF_RESULT}"
+```

--- a/specs/068-state.md
+++ b/specs/068-state.md
@@ -27,11 +27,8 @@ This spec covers:
 - optimistic concurrency (`with.expected_version`, `with.create_only`) and
   `state.diff`'s change-detection and conditional-write behavior
   (`with.update`)
-- that a state step publishes no `.outputs.*` at all: it is a plain
-  Command-capable executor like an ordinary `run:` step, not one with a
-  JSON-decoded outputs contract; a later step reads its JSON result only
-  through the standard declared `output: NAME` mechanism ([Spec 012: Step
-  Outputs](012-step-outputs.md))
+- capturing JSON stdout through a declared `output: NAME` and consuming it
+  in a downstream step
 - that, unlike the remote actions in specs 060-066 and like the harness
   executor, `dagu validate` checks some of a state step's configuration
   (that `with.key` is present for `get`/`set`/`delete`/`diff`, and
@@ -105,14 +102,9 @@ volume) for data that only needs to outlive one step.
 
 ### Result
 
-A state step's stdout is one JSON object, its shape depending on the
-operation (`operation`, `scope`, `namespace`, `key`, plus the
-operation-specific fields listed above). There is no `.outputs.*`
-published for a state step at all: neither `${<step id>.outputs.<path>}`
-nor `${steps.<step id>.outputs.<name>}` resolves. A later step reads the
-result only by giving the state step its own `output: NAME` field (the
-standard declared-output mechanism; see [Spec 012: Step
-Outputs](012-step-outputs.md)), which captures the full JSON line.
+A state step writes one JSON object to stdout, containing the fields listed
+for its operation above. A declared `output: NAME` makes that JSON available
+to downstream steps, following [Spec 012: Step Outputs](012-step-outputs.md).
 
 ## Errors
 
@@ -144,8 +136,7 @@ checks (below).
 
 ## Related Specs
 
-- Harness executor, the other built-in executor in this family with no
-  `.outputs.*` contract: [Spec 067: Harness Executor](067-harness.md)
+- Harness executor: [Spec 067: Harness Executor](067-harness.md)
 - Step outputs and reference syntax, for the standard `output: NAME`
   mechanism this executor uses instead of a JSON outputs contract: [Spec
   012: Step Outputs](012-step-outputs.md)

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [068: State Executor](068-state.md) | Implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Add offline conformance coverage for state operations, namespace isolation, persistence across runs, and declared output. Deletion, custom scopes, previous diff values, and both conflict modes share the existing workflow runs.

Validation: focused conformance tests and make fmt pass locally. CI must pass before merge.