### PR TITLE
 test: add black-box coverage for source:<git-url>@version

### DIFF
--- a/conformance/spec048_duckdb/source_git_helper_test.go
+++ b/conformance/spec048_duckdb/source_git_helper_test.go
@@ -45,74 +45,19 @@ func stepStdout(t *testing.T, daguStartOutput string, n int) string {
 // configuration.
 var gitEnv = []string{"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull}
 
-// gitActionServer serves a real echo-action bundle (the same shape as
-// testdata/echo_action) over the git:// protocol via a real git daemon, so
-// tests can reference it with a genuine "source:git://...@version" URL --
-// a target resolveSourceBundle cannot mistake for a local directory (unlike
-// a plain path or a file:// URL), forcing it through the real
-// clone-over-network code path (cloneGitSource in
-// internal/runtime/builtin/action/resolver.go), the same as it would for
-// any non-official, custom git-hosted action.
-type gitActionServer struct {
-	Port int
-}
-
-// RepoURL returns the git:// URL for the named repo this server exports.
-func (s gitActionServer) RepoURL(name string) string {
-	return fmt.Sprintf("git://127.0.0.1:%d/%s", s.Port, name)
-}
-
-// startGitActionServer creates a one-commit, tag "v1" git repository shaped
-// like an echo-action bundle (dagu-action.yaml + workflow.yaml, requiring
-// with.message and echoing it back as outputs.echoed) under a fresh temp
-// directory, then serves it (and anything else placed under the same base
-// directory before this call returns) with a real "git daemon" process on
-// a free loopback port. The daemon is killed via t.Cleanup.
-func startGitActionServer(t *testing.T, repoName string) gitActionServer {
+// startGitActionServer serves the local action fixture over Git transport.
+func startGitActionServer(t *testing.T) int {
 	t.Helper()
 
 	basePath := t.TempDir()
-	repoDir := filepath.Join(basePath, repoName)
+	repoDir := filepath.Join(basePath, "echo-action")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))
 
 	runGit(t, repoDir, "init", "-q", "-b", "main")
 	runGit(t, repoDir, "config", "user.email", "conformance@example.com")
 	runGit(t, repoDir, "config", "user.name", "Conformance Test")
 
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "dagu-action.yaml"), []byte(`apiVersion: v1alpha1
-name: echo-action
-dag: workflow.yaml
-inputs:
-  type: object
-  additionalProperties: false
-  required: [message]
-  properties:
-    message:
-      type: string
-      minLength: 1
-outputs:
-  type: object
-  additionalProperties: false
-  required: [echoed]
-  properties:
-    echoed:
-      type: string
-`), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "workflow.yaml"), []byte(`type: graph
-params:
-  type: object
-  additionalProperties: false
-  required: [message]
-  properties:
-    message:
-      type: string
-steps:
-  - id: echo
-    run: printf '%s' "$message"
-    stdout:
-      outputs:
-        field: echoed
-`), 0o600))
+	require.NoError(t, os.CopyFS(repoDir, os.DirFS("testdata/echo_action")))
 
 	runGit(t, repoDir, "add", "-A")
 	runGit(t, repoDir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "initial")
@@ -136,7 +81,7 @@ steps:
 	})
 
 	waitForPort(t, port)
-	return gitActionServer{Port: port}
+	return port
 }
 
 func runGit(t *testing.T, dir string, args ...string) string {

--- a/conformance/spec048_duckdb/source_git_helper_test.go
+++ b/conformance/spec048_duckdb/source_git_helper_test.go
@@ -1,0 +1,167 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec048_duckdb_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// stdoutLogPattern matches a per-step captured-stdout log path dagu start
+// prints in its tree render, e.g. "└─stdout: /path/to/step.<ts>.<run>.out".
+var stdoutLogPattern = regexp.MustCompile(`stdout: (.+)`)
+
+// stepStdout reads the exact bytes the (0-indexed) nth step with logged
+// stdout wrote, by locating its captured-output log file from dagu start's
+// own tree render and reading it directly, since the tree render re-wraps
+// long lines with its own indentation, which would corrupt a strict
+// JSON-parse match.
+func stepStdout(t *testing.T, daguStartOutput string, n int) string {
+	t.Helper()
+
+	matches := stdoutLogPattern.FindAllStringSubmatch(daguStartOutput, -1)
+	require.Greaterf(t, len(matches), n, "expected at least %d stdout log paths in output:\n%s", n+1, daguStartOutput)
+	path := strings.TrimSpace(matches[n][1])
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from the harness's own trusted output.
+	require.NoError(t, err)
+	return string(data)
+}
+
+// gitEnv bypasses this machine's own global/system git config (some hosts
+// rewrite git:// to https://, or otherwise interfere) the same way
+// spec055_git's own git fixtures do, so the git commands this file's setup
+// and dagu's own action source resolver run see a clean, predictable git
+// configuration.
+var gitEnv = []string{"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull}
+
+// gitActionServer serves a real echo-action bundle (the same shape as
+// testdata/echo_action) over the git:// protocol via a real git daemon, so
+// tests can reference it with a genuine "source:git://...@version" URL --
+// a target resolveSourceBundle cannot mistake for a local directory (unlike
+// a plain path or a file:// URL), forcing it through the real
+// clone-over-network code path (cloneGitSource in
+// internal/runtime/builtin/action/resolver.go), the same as it would for
+// any non-official, custom git-hosted action.
+type gitActionServer struct {
+	Port int
+}
+
+// RepoURL returns the git:// URL for the named repo this server exports.
+func (s gitActionServer) RepoURL(name string) string {
+	return fmt.Sprintf("git://127.0.0.1:%d/%s", s.Port, name)
+}
+
+// startGitActionServer creates a one-commit, tag "v1" git repository shaped
+// like an echo-action bundle (dagu-action.yaml + workflow.yaml, requiring
+// with.message and echoing it back as outputs.echoed) under a fresh temp
+// directory, then serves it (and anything else placed under the same base
+// directory before this call returns) with a real "git daemon" process on
+// a free loopback port. The daemon is killed via t.Cleanup.
+func startGitActionServer(t *testing.T, repoName string) gitActionServer {
+	t.Helper()
+
+	basePath := t.TempDir()
+	repoDir := filepath.Join(basePath, repoName)
+	require.NoError(t, os.MkdirAll(repoDir, 0o750))
+
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "conformance@example.com")
+	runGit(t, repoDir, "config", "user.name", "Conformance Test")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "dagu-action.yaml"), []byte(`apiVersion: v1alpha1
+name: echo-action
+dag: workflow.yaml
+inputs:
+  type: object
+  additionalProperties: false
+  required: [message]
+  properties:
+    message:
+      type: string
+      minLength: 1
+outputs:
+  type: object
+  additionalProperties: false
+  required: [echoed]
+  properties:
+    echoed:
+      type: string
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "workflow.yaml"), []byte(`type: graph
+params:
+  type: object
+  additionalProperties: false
+  required: [message]
+  properties:
+    message:
+      type: string
+steps:
+  - id: echo
+    run: printf '%s' "$message"
+    stdout:
+      outputs:
+        field: echoed
+`), 0o600))
+
+	runGit(t, repoDir, "add", "-A")
+	runGit(t, repoDir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "initial")
+	runGit(t, repoDir, "tag", "v1")
+
+	port := harness.FreePort(t)
+	// #nosec G204 -- fixed args/port in test setup, not user input.
+	cmd := exec.Command("git", "daemon",
+		"--reuseaddr",
+		"--export-all",
+		"--listen=127.0.0.1",
+		fmt.Sprintf("--port=%d", port),
+		"--base-path="+basePath,
+		basePath,
+	)
+	cmd.Env = append(os.Environ(), gitEnv...)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	waitForPort(t, port)
+	return gitActionServer{Port: port}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...) // #nosec G204 -- fixed args/dir in test setup, not user input.
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), gitEnv...)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	return strings.TrimSpace(string(out))
+}
+
+func waitForPort(t *testing.T, port int) {
+	t.Helper()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(harness.WaitTimeout(t))
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("git daemon did not start listening on %s in time", addr)
+}

--- a/conformance/spec048_duckdb/source_git_helper_test.go
+++ b/conformance/spec048_duckdb/source_git_helper_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/dagucloud/dagu/v2/internal/cmn/cmdutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,7 +44,14 @@ func stepStdout(t *testing.T, daguStartOutput string, n int) string {
 // spec055_git's own git fixtures do, so the git commands this file's setup
 // and dagu's own action source resolver run see a clean, predictable git
 // configuration.
-var gitEnv = []string{"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull}
+var gitEnv = []string{
+	"GIT_CONFIG_NOSYSTEM=1",
+	"GIT_CONFIG_GLOBAL=" + os.DevNull,
+	// Git must support nested action-cache paths on Windows.
+	"GIT_CONFIG_COUNT=1",
+	"GIT_CONFIG_KEY_0=core.longpaths",
+	"GIT_CONFIG_VALUE_0=true",
+}
 
 // startGitActionServer serves the local action fixture over Git transport.
 func startGitActionServer(t *testing.T) int {
@@ -74,10 +82,15 @@ func startGitActionServer(t *testing.T) int {
 		basePath,
 	)
 	cmd.Env = append(os.Environ(), gitEnv...)
-	require.NoError(t, cmd.Start())
+	proc, err := cmdutil.StartManagedProcess(cmd)
+	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+		_, _ = proc.Stop(cmdutil.StopRequest{
+			Intent: cmdutil.ForceTermination(),
+			Reason: cmdutil.StopReasonShutdown,
+		})
+		_ = proc.Wait()
+		_ = proc.Release()
 	})
 
 	waitForPort(t, port)

--- a/conformance/spec048_duckdb/source_git_test.go
+++ b/conformance/spec048_duckdb/source_git_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This file covers the "source:<target>@version" action reference form
+// (resolveSourceBundle in internal/runtime/builtin/action/resolver.go)
+// against a genuine, custom, non-official git remote -- not the local
+// bundle testdata/echo_action/testdata/bad_output_action TestLocalAction/
+// TestActionBoundary already exercise, and not the official
+// dagucloud/duckdb short-name convention this package's other live tests
+// use. A target this specific ("git://host:port/name") is never mistaken
+// for a local directory by resolveSourceBundle (unlike a plain path or a
+// file:// URL, both of which short-circuit to reading a directory tree
+// directly), so it is forced through the same real
+// clone-over-network/checkout/cache-by-resolved-SHA code path
+// (cloneGitSource) any non-official git-hosted action would use.
+//
+// startGitActionServer (source_git_helper_test.go) builds a one-commit,
+// tag "v1" echo-action bundle and serves it with a real "git daemon"
+// process on a free loopback port, so this is a genuine git clone over a
+// real (if local) network transport, not a shortcut -- with no dependency
+// on any actual third-party git host.
+package spec048_duckdb_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// gitActionServerEnv returns the host environment entry
+// source_git_*.yaml's own env: block resolves with.SERVER_BASE from,
+// pointed at the given git daemon's own loopback port, plus the git config
+// overrides (see gitEnv) dagu's own git subprocess calls need on this
+// machine.
+func gitActionServerEnv(server gitActionServer) []string {
+	return append([]string{"HOST_SERVER_BASE=git://127.0.0.1:" + strconv.Itoa(server.Port)}, gitEnv...)
+}
+
+func TestSourceGitURLLiveClone(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	server := startGitActionServer(t, "echo-action")
+
+	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_success.yaml")
+	result.ExpectExitCode(0)
+
+	var output struct {
+		Echoed string `json:"echoed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
+	require.Equal(t, "hello-from-real-git-clone", output.Echoed)
+}
+
+func TestSourceGitURLBadVersion(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	server := startGitActionServer(t, "echo-action")
+
+	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_bad_version.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("did not match any file(s) known to git")
+}
+
+func TestSourceGitURLBadRepo(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	server := startGitActionServer(t, "echo-action")
+
+	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_bad_repo.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("repository not exported")
+}
+
+// dagu validate never resolves any action reference -- including a
+// source:git://... one -- so it never reaches the network at all. This
+// fixture points at an address nothing listens on (port 1, a reserved
+// port no process here can bind); if validate ever tried to resolve it,
+// it would hang or fail slowly instead of returning immediately.
+func TestSourceGitURLValidateNeverResolves(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("validate", "source_git_unreachable.yaml")
+	result.ExpectExitCode(0)
+}

--- a/conformance/spec048_duckdb/source_git_test.go
+++ b/conformance/spec048_duckdb/source_git_test.go
@@ -1,24 +1,6 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// This file covers the "source:<target>@version" action reference form
-// (resolveSourceBundle in internal/runtime/builtin/action/resolver.go)
-// against a genuine, custom, non-official git remote -- not the local
-// bundle testdata/echo_action/testdata/bad_output_action TestLocalAction/
-// TestActionBoundary already exercise, and not the official
-// dagucloud/duckdb short-name convention this package's other live tests
-// use. A target this specific ("git://host:port/name") is never mistaken
-// for a local directory by resolveSourceBundle (unlike a plain path or a
-// file:// URL, both of which short-circuit to reading a directory tree
-// directly), so it is forced through the same real
-// clone-over-network/checkout/cache-by-resolved-SHA code path
-// (cloneGitSource) any non-official git-hosted action would use.
-//
-// startGitActionServer (source_git_helper_test.go) builds a one-commit,
-// tag "v1" echo-action bundle and serves it with a real "git daemon"
-// process on a free loopback port, so this is a genuine git clone over a
-// real (if local) network transport, not a shortcut -- with no dependency
-// on any actual third-party git host.
 package spec048_duckdb_test
 
 import (
@@ -30,62 +12,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// gitActionServerEnv returns the host environment entry
-// source_git_*.yaml's own env: block resolves with.SERVER_BASE from,
-// pointed at the given git daemon's own loopback port, plus the git config
-// overrides (see gitEnv) dagu's own git subprocess calls need on this
-// machine.
-func gitActionServerEnv(server gitActionServer) []string {
-	return append([]string{"HOST_SERVER_BASE=git://127.0.0.1:" + strconv.Itoa(server.Port)}, gitEnv...)
-}
-
-func TestSourceGitURLLiveClone(t *testing.T) {
+func TestSourceGit(t *testing.T) {
 	t.Parallel()
 
-	dagu := harness.NewRunner(t)
-	server := startGitActionServer(t, "echo-action")
+	port := startGitActionServer(t)
+	env := append([]string{"HOST_SERVER_BASE=git://127.0.0.1:" + strconv.Itoa(port)}, gitEnv...)
+	for _, tc := range []struct {
+		fixture string
+		errText string
+	}{
+		{"source_git_success.yaml", ""},
+		{"source_git_bad_version.yaml", "checkout action source ref"},
+		{"source_git_bad_repo.yaml", "clone action source"},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
 
-	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_success.yaml")
-	result.ExpectExitCode(0)
+			dagu := harness.NewRunner(t)
+			result := dagu.RunWithEnv(env, "start", tc.fixture)
+			if tc.errText != "" {
+				result.ExpectNonZeroExitCode()
+				result.ExpectStderrContains(tc.errText)
+				return
+			}
+			result.ExpectExitCode(0)
 
-	var output struct {
-		Echoed string `json:"echoed"`
+			var output struct {
+				Echoed string `json:"echoed"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
+			require.Equal(t, "hello-from-real-git-clone", output.Echoed)
+		})
 	}
-	require.NoError(t, json.Unmarshal([]byte(stepStdout(t, result.Stdout(), 0)), &output))
-	require.Equal(t, "hello-from-real-git-clone", output.Echoed)
 }
 
-func TestSourceGitURLBadVersion(t *testing.T) {
+func TestSourceGitValidation(t *testing.T) {
 	t.Parallel()
 
 	dagu := harness.NewRunner(t)
-	server := startGitActionServer(t, "echo-action")
-
-	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_bad_version.yaml")
-	result.ExpectNonZeroExitCode()
-	result.ExpectStderrContains("did not match any file(s) known to git")
-}
-
-func TestSourceGitURLBadRepo(t *testing.T) {
-	t.Parallel()
-
-	dagu := harness.NewRunner(t)
-	server := startGitActionServer(t, "echo-action")
-
-	result := dagu.RunWithEnv(gitActionServerEnv(server), "start", "source_git_bad_repo.yaml")
-	result.ExpectNonZeroExitCode()
-	result.ExpectStderrContains("repository not exported")
-}
-
-// dagu validate never resolves any action reference -- including a
-// source:git://... one -- so it never reaches the network at all. This
-// fixture points at an address nothing listens on (port 1, a reserved
-// port no process here can bind); if validate ever tried to resolve it,
-// it would hang or fail slowly instead of returning immediately.
-func TestSourceGitURLValidateNeverResolves(t *testing.T) {
-	t.Parallel()
-
-	dagu := harness.NewRunner(t)
-	result := dagu.Run("validate", "source_git_unreachable.yaml")
-	result.ExpectExitCode(0)
+	dagu.Run("validate", "source_git_unreachable.yaml").ExpectExitCode(0)
 }

--- a/conformance/spec048_duckdb/testdata/source_git_bad_repo.yaml
+++ b/conformance/spec048_duckdb/testdata/source_git_bad_repo.yaml
@@ -1,0 +1,7 @@
+env:
+  - SERVER_BASE: $HOST_SERVER_BASE
+steps:
+  - id: bad_repo
+    action: "source:$SERVER_BASE/no-such-repo@v1"
+    with:
+      message: hi

--- a/conformance/spec048_duckdb/testdata/source_git_bad_version.yaml
+++ b/conformance/spec048_duckdb/testdata/source_git_bad_version.yaml
@@ -1,0 +1,7 @@
+env:
+  - SERVER_BASE: $HOST_SERVER_BASE
+steps:
+  - id: bad_version
+    action: "source:$SERVER_BASE/echo-action@v99-does-not-exist"
+    with:
+      message: hi

--- a/conformance/spec048_duckdb/testdata/source_git_success.yaml
+++ b/conformance/spec048_duckdb/testdata/source_git_success.yaml
@@ -1,0 +1,7 @@
+env:
+  - SERVER_BASE: $HOST_SERVER_BASE
+steps:
+  - id: run_action
+    action: "source:$SERVER_BASE/echo-action@v1"
+    with:
+      message: hello-from-real-git-clone

--- a/conformance/spec048_duckdb/testdata/source_git_unreachable.yaml
+++ b/conformance/spec048_duckdb/testdata/source_git_unreachable.yaml
@@ -1,0 +1,5 @@
+steps:
+  - id: run_action
+    action: "source:git://127.0.0.1:1/unreachable-host-should-not-be-hit@v1"
+    with:
+      message: hi

--- a/internal/runtime/builtin/action/action_test.go
+++ b/internal/runtime/builtin/action/action_test.go
@@ -86,6 +86,13 @@ func TestResolveSourceBundleCachesByResolvedSHA(t *testing.T) {
 	assert.Equal(t, filepath.Join(toolsDir, "actions", "source", repoKey, sha), root)
 	assert.Equal(t, sha, resolved)
 	assert.FileExists(t, filepath.Join(root, manifestFileName))
+
+	// A pinned commit remains usable when the source repository is unavailable.
+	require.NoError(t, os.Rename(filepath.Join(repoDir, ".git"), filepath.Join(repoDir, ".git-offline")))
+	cached, cachedSHA, err := cloneGitSource(ctx, repoDir, sha, resolveOptions{ToolsDir: toolsDir})
+	require.NoError(t, err)
+	assert.Equal(t, root, cached)
+	assert.Equal(t, sha, cachedSHA)
 }
 
 func TestResolvePackagePrefixRejectsTraversal(t *testing.T) {

--- a/specs/048-duckdb-action.md
+++ b/specs/048-duckdb-action.md
@@ -5,36 +5,79 @@
 Partially implemented.
 
 Conformance accepts a `duckdb@v1` reference and exercises Dagu's action
-input/output boundary with a local bundle. It does not download or run DuckDB.
-SQL behavior and tool provisioning belong in action and executor tests.
+input/output boundary with a local bundle. It does not download or run
+DuckDB itself. Conformance does exercise the generic `source:<target>@version`
+reference form's real git-clone transport, against a custom (non-official,
+non-`dagucloud/*`) git-hosted action -- not just the local-directory
+shortcut. SQL behavior and tool provisioning belong in action and executor
+tests.
 
 ## Scope
 
-This spec covers versioned action references and manifest input/output validation.
-It does not define DuckDB's SQL dialect, tool installation, Git transport, or
-remote repository availability.
+This spec covers versioned action references and manifest input/output
+validation, including:
+
+- `source:./directory@version` and `source:file://...@version`, both of
+  which resolve to a local directory tree directly, with no git operation
+  at all
+- `source:<git-url>@version`, where `<git-url>` is any git-clonable
+  target that does *not* resolve to an existing local directory (an
+  `http://`, `https://`, `ssh://`, `git://`, or SCP-like `user@host:path`
+  URL, or a bare `owner/repo`/`name` official short name) -- this clones
+  the repository for real, checks out the requested tag/branch/commit, and
+  caches the result by its resolved commit SHA, regardless of whether the
+  host is `github.com/dagucloud/*` or an arbitrary custom git remote
+
+It does not define DuckDB's SQL dialect, tool installation, or any specific
+git host's own availability or authentication requirements.
 
 ## Goal
 
 Workflow authors can call reusable actions through a consistent input/output
-contract.
+contract, whether the action is one of Dagu's own official actions or a
+custom action hosted in the workflow author's own git repository.
 
 ## Behavior
 
-`dagu validate` accepts an official versioned reference such as `duckdb@v1`
-without fetching the action. Local bundles can be selected with
-`source:./directory@version`.
+`dagu validate` accepts a versioned reference -- official
+(`duckdb@v1`), local bundle (`source:./directory@version`), or a custom
+git-hosted `source:<git-url>@version` -- without ever resolving it: it
+does not fetch, clone, or otherwise reach the network for any reference
+form, so validation completes regardless of whether the target host is
+even reachable.
 
 Action fields appear directly under `with`, such as `with.query` or
 `with.message`. The action manifest validates that object against its `inputs`
 schema. Successful action results are validated against its `outputs` schema
-and emitted as JSON on stdout.
+and emitted as JSON on stdout. This holds the same way for a custom
+git-hosted action as for an official one: the manifest and workflow files
+`dagu-action.yaml`/`dag:` name inside the cloned repository play the exact
+same role regardless of where the repository came from.
+
+For `source:<git-url>@version` specifically: the version is resolved to a
+commit the same way for any git host -- `git ls-remote` against
+`refs/tags/<version>` (preferring the peeled/annotated-tag commit),
+`refs/tags/<version>` unpeeled, then `refs/heads/<version>`, falling back to
+treating `<version>` itself as a full commit SHA. The resolved commit is
+then checked out and cached under a directory keyed by the repository URL
+and that commit SHA, so a later reference to the same repository and
+version reuses the cached checkout rather than cloning again.
 
 ## Errors
 
 A source reference without a version fails validation. Input and output schema
 violations fail execution with diagnostics identifying the corresponding action
 schema. Schema-library wording beyond that identification is not normative.
+
+For `source:<git-url>@version` specifically:
+
+- A version that names no tag, branch, or commit the repository has: the
+  step fails with an error containing `did not match any file(s) known to
+  git`.
+- A repository the git host does not export, or does not exist: the step
+  fails with an error containing `repository not exported` (or an
+  equivalent transport-level failure) -- not a Dagu-specific message, since
+  this is the underlying `git` command's own output.
 
 ## Examples
 
@@ -43,4 +86,14 @@ steps:
   - action: duckdb@v1
     with:
       query: SELECT 42 AS answer
+```
+
+Reference a custom action hosted in the workflow author's own git
+repository, not an official `dagucloud/*` one:
+
+```yaml
+steps:
+  - action: "source:https://github.com/myorg/my-dagu-action.git@v1"
+    with:
+      message: hello
 ```

--- a/specs/048-duckdb-action.md
+++ b/specs/048-duckdb-action.md
@@ -5,31 +5,18 @@
 Partially implemented.
 
 Conformance accepts a `duckdb@v1` reference and exercises Dagu's action
-input/output boundary with a local bundle. It does not download or run
-DuckDB itself. Conformance does exercise the generic `source:<target>@version`
-reference form's real git-clone transport, against a custom (non-official,
-non-`dagucloud/*`) git-hosted action -- not just the local-directory
-shortcut. SQL behavior and tool provisioning belong in action and executor
-tests.
+input/output boundary with local bundles and a loopback Git repository.
+It does not download or run DuckDB. SQL behavior, tool provisioning, Git
+server policy, and cache mechanics belong in action and executor tests.
 
 ## Scope
 
 This spec covers versioned action references and manifest input/output
-validation, including:
+validation. `source:./directory@version` selects a local bundle;
+`source:<git-url>@version` selects an action from a Git repository.
 
-- `source:./directory@version` and `source:file://...@version`, both of
-  which resolve to a local directory tree directly, with no git operation
-  at all
-- `source:<git-url>@version`, where `<git-url>` is any git-clonable
-  target that does *not* resolve to an existing local directory (an
-  `http://`, `https://`, `ssh://`, `git://`, or SCP-like `user@host:path`
-  URL, or a bare `owner/repo`/`name` official short name) -- this clones
-  the repository for real, checks out the requested tag/branch/commit, and
-  caches the result by its resolved commit SHA, regardless of whether the
-  host is `github.com/dagucloud/*` or an arbitrary custom git remote
-
-It does not define DuckDB's SQL dialect, tool installation, or any specific
-git host's own availability or authentication requirements.
+It does not define DuckDB's SQL dialect, tool installation, or a Git host's
+availability and authentication requirements.
 
 ## Goal
 
@@ -54,14 +41,8 @@ git-hosted action as for an official one: the manifest and workflow files
 `dagu-action.yaml`/`dag:` name inside the cloned repository play the exact
 same role regardless of where the repository came from.
 
-For `source:<git-url>@version` specifically: the version is resolved to a
-commit the same way for any git host -- `git ls-remote` against
-`refs/tags/<version>` (preferring the peeled/annotated-tag commit),
-`refs/tags/<version>` unpeeled, then `refs/heads/<version>`, falling back to
-treating `<version>` itself as a full commit SHA. The resolved commit is
-then checked out and cached under a directory keyed by the repository URL
-and that commit SHA, so a later reference to the same repository and
-version reuses the cached checkout rather than cloning again.
+A Git source action executes the requested tag, branch, or commit using the
+same manifest input/output contract as a local action.
 
 ## Errors
 
@@ -69,15 +50,9 @@ A source reference without a version fails validation. Input and output schema
 violations fail execution with diagnostics identifying the corresponding action
 schema. Schema-library wording beyond that identification is not normative.
 
-For `source:<git-url>@version` specifically:
-
-- A version that names no tag, branch, or commit the repository has: the
-  step fails with an error containing `did not match any file(s) known to
-  git`.
-- A repository the git host does not export, or does not exist: the step
-  fails with an error containing `repository not exported` (or an
-  equivalent transport-level failure) -- not a Dagu-specific message, since
-  this is the underlying `git` command's own output.
+An unavailable repository or revision fails execution with a diagnostic
+identifying the action clone or checkout failure. Git's diagnostic wording
+is not normative.
 
 ## Examples
 


### PR DESCRIPTION
Cover custom Git action dispatch, input/output wiring, and clone or checkout failures using one loopback Git server and the existing action bundle. Keep Git export policy outside conformance; verify offline cache reuse in the existing executor test.

Validation: conformance and executor package tests pass with race detection; make fmt passes. CI must pass before merge.