### PR TITLE
test: add spec conformance coverage for direct secret providers

### DIFF
--- a/conformance/spec069_secrets/secrets_test.go
+++ b/conformance/spec069_secrets/secrets_test.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec069_secrets_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// The env provider resolves from the real OS environment. The tree preview
+// is read back from the on-disk step log file, so the resolved value being
+// masked there proves the masking writer redacts the file itself, not just
+// the terminal display.
+func TestEnvProviderMasksValue(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"SOURCE_SECRET_VALUE=supersecret123"}, "start", "env_success.yaml")
+	result.ExpectExitCode(0)
+	require.Contains(t, result.Stdout(), "*******")
+	require.NotContains(t, result.Stdout(), "supersecret123")
+}
+
+func TestEnvProviderMissingVariable(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "env_missing.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains(`environment variable "DAGU_CONFORMANCE_UNSET_SECRET_VAR" is not set`)
+}
+
+// The file provider resolves relative paths against the DAG's own directory.
+func TestFileProviderResolvesAndMasksValue(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "file_success.yaml")
+	result.ExpectExitCode(0)
+	require.Contains(t, result.Stdout(), "*******")
+	require.NotContains(t, result.Stdout(), "filesecretvalue123")
+}
+
+func TestFileProviderMissingFile(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "file_missing.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("secret file not found")
+}
+
+func TestUnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "unknown_provider.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("unknown secret provider: nope")
+}
+
+// Build-time validation rejects malformed secret declarations before any
+// provider is contacted.
+func TestValidateRejectsMalformedSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		fixture string
+		errText string
+	}{
+		{"validate_missing_name.yaml", "'name' field is required"},
+		{"validate_invalid_name.yaml", "must be a valid environment variable name"},
+		{"validate_dagu_prefix.yaml", "must not start with DAGU_"},
+		{"validate_reserved_name.yaml", "collides with Dagu-managed runtime environment variable"},
+		{"validate_duplicate_name.yaml", `duplicate secret name "MY_SECRET"`},
+		{"validate_ref_and_provider.yaml", "exactly one of 'ref' or 'provider' plus 'key' is required"},
+		{"validate_neither.yaml", "exactly one of 'ref' or 'provider' plus 'key' is required"},
+		{"validate_options_with_ref.yaml", "'options' cannot be used with registry ref"},
+		{"validate_bad_ref_pattern.yaml", "registry ref must be a slash-separated lowercase slug path"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("validate", tc.fixture)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.errText)
+		})
+	}
+}
+
+// Providers whose parsing fails before any network client is created report
+// a provider-specific diagnostic. No provider here ever dials out.
+func TestProviderSpecificValidationFailsWithoutNetwork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		fixture string
+		errText string
+	}{
+		{"gcp_missing_project.yaml", `project ID is required for GCP Secret Manager secret "bare-id-no-options"`},
+		{"azure_bad_option.yaml", `unsupported option "bogus"`},
+		{"alibaba_bad_name.yaml", "secret name for Alibaba Cloud KMS contains unsupported characters"},
+		{"kubernetes_bad_key.yaml", "secret name and data key are required"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			result := dagu.Run("start", tc.fixture)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.errText)
+		})
+	}
+}
+
+// The AWS Secrets Manager provider uses the standard AWS SDK, which honors
+// AWS_ENDPOINT_URL. A local mock server proves the real client, request
+// signing, and JSON 1.1 response parsing all work end-to-end.
+func TestAWSProviderLiveResolve(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "secretsmanager.GetSecretValue", r.Header.Get("X-Amz-Target"))
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"mysecret","SecretString":"awssecretvalue456"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(awsMockEnv(server.URL), "start", "aws.yaml")
+	result.ExpectExitCode(0)
+	require.Contains(t, result.Stdout(), "*******")
+	require.NotContains(t, result.Stdout(), "awssecretvalue456")
+}
+
+func TestAWSProviderNotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		w.Header().Set("X-Amzn-Errortype", "ResourceNotFoundException")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"Message":"Secrets Manager can't find the specified secret."}`))
+	}))
+	t.Cleanup(server.Close)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv(awsMockEnv(server.URL), "start", "aws.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains(`AWS Secrets Manager secret "mysecret" was not found`)
+}
+
+func awsMockEnv(endpoint string) []string {
+	return []string{
+		"AWS_ENDPOINT_URL=" + endpoint,
+		"AWS_ACCESS_KEY_ID=conformance-test",
+		"AWS_SECRET_ACCESS_KEY=conformance-test",
+		"AWS_REGION=us-east-1",
+	}
+}

--- a/conformance/spec069_secrets/secrets_test.go
+++ b/conformance/spec069_secrets/secrets_test.go
@@ -4,11 +4,14 @@
 package spec069_secrets_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +39,7 @@ func TestEnvProviderMissingVariable(t *testing.T) {
 }
 
 // The file provider resolves relative paths against the DAG's own directory.
-func TestFileProviderResolvesAndMasksValue(t *testing.T) {
+func TestFileProviderMasksValue(t *testing.T) {
 	t.Parallel()
 
 	dagu := harness.NewRunner(t)
@@ -66,7 +69,7 @@ func TestUnknownProvider(t *testing.T) {
 
 // Build-time validation rejects malformed secret declarations before any
 // provider is contacted.
-func TestValidateRejectsMalformedSecrets(t *testing.T) {
+func TestSecretValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -82,6 +85,8 @@ func TestValidateRejectsMalformedSecrets(t *testing.T) {
 		{"validate_neither.yaml", "exactly one of 'ref' or 'provider' plus 'key' is required"},
 		{"validate_options_with_ref.yaml", "'options' cannot be used with registry ref"},
 		{"validate_bad_ref_pattern.yaml", "registry ref must be a slash-separated lowercase slug path"},
+		{"validate_empty_ref_segment.yaml", "registry ref must be a slash-separated lowercase slug path"},
+		{"validate_valid_ref.yaml", ""},
 	}
 
 	for _, tc := range tests {
@@ -90,6 +95,10 @@ func TestValidateRejectsMalformedSecrets(t *testing.T) {
 
 			dagu := harness.NewRunner(t)
 			result := dagu.Run("validate", tc.fixture)
+			if tc.errText == "" {
+				result.ExpectExitCode(0)
+				return
+			}
 			result.ExpectNonZeroExitCode()
 			result.ExpectStderrContains(tc.errText)
 		})
@@ -98,7 +107,7 @@ func TestValidateRejectsMalformedSecrets(t *testing.T) {
 
 // Providers whose parsing fails before any network client is created report
 // a provider-specific diagnostic. No provider here ever dials out.
-func TestProviderSpecificValidationFailsWithoutNetwork(t *testing.T) {
+func TestProviderValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -123,14 +132,12 @@ func TestProviderSpecificValidationFailsWithoutNetwork(t *testing.T) {
 	}
 }
 
-// The AWS Secrets Manager provider uses the standard AWS SDK, which honors
-// AWS_ENDPOINT_URL. A local mock server proves the real client, request
-// signing, and JSON 1.1 response parsing all work end-to-end.
+// A local endpoint checks AWS provider dispatch and secret masking.
 func TestAWSProviderLiveResolve(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "secretsmanager.GetSecretValue", r.Header.Get("X-Amz-Target"))
+		checkAWSRequest(t, r)
 		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
 		_, _ = w.Write([]byte(`{"Name":"mysecret","SecretString":"awssecretvalue456"}`))
 	}))
@@ -147,6 +154,7 @@ func TestAWSProviderNotFound(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkAWSRequest(t, r)
 		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
 		w.Header().Set("X-Amzn-Errortype", "ResourceNotFoundException")
 		w.WriteHeader(http.StatusBadRequest)
@@ -160,9 +168,28 @@ func TestAWSProviderNotFound(t *testing.T) {
 	result.ExpectStderrContains(`AWS Secrets Manager secret "mysecret" was not found`)
 }
 
+func checkAWSRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	assert.Equal(t, "secretsmanager.GetSecretValue", r.Header.Get("X-Amz-Target"))
+	var request struct {
+		SecretID string `json:"SecretId"`
+	}
+	if assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+		assert.Equal(t, "mysecret", request.SecretID)
+	}
+}
+
 func awsMockEnv(endpoint string) []string {
 	return []string{
 		"AWS_ENDPOINT_URL=" + endpoint,
+		"AWS_ENDPOINT_URL_SECRETS_MANAGER=" + endpoint,
+		"AWS_IGNORE_CONFIGURED_ENDPOINT_URLS=false",
+		"AWS_PROFILE=",
+		"AWS_DEFAULT_PROFILE=",
+		"AWS_CONFIG_FILE=" + os.DevNull,
+		"AWS_SHARED_CREDENTIALS_FILE=" + os.DevNull,
+		"AWS_SESSION_TOKEN=",
+		"AWS_EC2_METADATA_DISABLED=true",
 		"AWS_ACCESS_KEY_ID=conformance-test",
 		"AWS_SECRET_ACCESS_KEY=conformance-test",
 		"AWS_REGION=us-east-1",

--- a/conformance/spec069_secrets/testdata/alibaba_bad_name.yaml
+++ b/conformance/spec069_secrets/testdata/alibaba_bad_name.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: alibaba
+    key: "bad key!"
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/aws.yaml
+++ b/conformance/spec069_secrets/testdata/aws.yaml
@@ -1,0 +1,8 @@
+secrets:
+  - name: MY_SECRET
+    provider: aws
+    key: mysecret
+    options:
+      region: us-east-1
+steps:
+  - command: echo "value is $MY_SECRET"

--- a/conformance/spec069_secrets/testdata/azure_bad_option.yaml
+++ b/conformance/spec069_secrets/testdata/azure_bad_option.yaml
@@ -1,0 +1,8 @@
+secrets:
+  - name: MY_SECRET
+    provider: azure
+    key: my-secret
+    options:
+      bogus: x
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/env_missing.yaml
+++ b/conformance/spec069_secrets/testdata/env_missing.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: env
+    key: DAGU_CONFORMANCE_UNSET_SECRET_VAR
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/env_success.yaml
+++ b/conformance/spec069_secrets/testdata/env_success.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: env
+    key: SOURCE_SECRET_VALUE
+steps:
+  - command: echo "value is $MY_SECRET"

--- a/conformance/spec069_secrets/testdata/file_missing.yaml
+++ b/conformance/spec069_secrets/testdata/file_missing.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: file
+    key: does-not-exist.txt
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/file_secret.txt
+++ b/conformance/spec069_secrets/testdata/file_secret.txt
@@ -1,0 +1,1 @@
+filesecretvalue123

--- a/conformance/spec069_secrets/testdata/file_success.yaml
+++ b/conformance/spec069_secrets/testdata/file_success.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: file
+    key: file_secret.txt
+steps:
+  - command: echo "value is $MY_SECRET"

--- a/conformance/spec069_secrets/testdata/gcp_missing_project.yaml
+++ b/conformance/spec069_secrets/testdata/gcp_missing_project.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: gcp
+    key: bare-id-no-options
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/kubernetes_bad_key.yaml
+++ b/conformance/spec069_secrets/testdata/kubernetes_bad_key.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: kubernetes
+    key: no-slash-here
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/unknown_provider.yaml
+++ b/conformance/spec069_secrets/testdata/unknown_provider.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: MY_SECRET
+    provider: nope
+    key: something
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_bad_ref_pattern.yaml
+++ b/conformance/spec069_secrets/testdata/validate_bad_ref_pattern.yaml
@@ -1,0 +1,5 @@
+secrets:
+  - name: MY_SECRET
+    ref: Bad_Ref!
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_dagu_prefix.yaml
+++ b/conformance/spec069_secrets/testdata/validate_dagu_prefix.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: DAGU_FOO
+    provider: env
+    key: X
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_duplicate_name.yaml
+++ b/conformance/spec069_secrets/testdata/validate_duplicate_name.yaml
@@ -1,0 +1,9 @@
+secrets:
+  - name: MY_SECRET
+    provider: env
+    key: A
+  - name: MY_SECRET
+    provider: env
+    key: B
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_empty_ref_segment.yaml
+++ b/conformance/spec069_secrets/testdata/validate_empty_ref_segment.yaml
@@ -1,0 +1,5 @@
+secrets:
+  - name: MY_SECRET
+    ref: a//b
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_invalid_name.yaml
+++ b/conformance/spec069_secrets/testdata/validate_invalid_name.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: "123bad"
+    provider: env
+    key: X
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_missing_name.yaml
+++ b/conformance/spec069_secrets/testdata/validate_missing_name.yaml
@@ -1,0 +1,5 @@
+secrets:
+  - provider: env
+    key: X
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_neither.yaml
+++ b/conformance/spec069_secrets/testdata/validate_neither.yaml
@@ -1,0 +1,4 @@
+secrets:
+  - name: MY_SECRET
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_options_with_ref.yaml
+++ b/conformance/spec069_secrets/testdata/validate_options_with_ref.yaml
@@ -1,0 +1,7 @@
+secrets:
+  - name: MY_SECRET
+    ref: foo/bar
+    options:
+      x: "1"
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_ref_and_provider.yaml
+++ b/conformance/spec069_secrets/testdata/validate_ref_and_provider.yaml
@@ -1,0 +1,7 @@
+secrets:
+  - name: MY_SECRET
+    ref: foo/bar
+    provider: env
+    key: X
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_reserved_name.yaml
+++ b/conformance/spec069_secrets/testdata/validate_reserved_name.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: DAG_NAME
+    provider: env
+    key: X
+steps:
+  - command: echo hi

--- a/conformance/spec069_secrets/testdata/validate_valid_ref.yaml
+++ b/conformance/spec069_secrets/testdata/validate_valid_ref.yaml
@@ -1,0 +1,5 @@
+secrets:
+  - name: MY_SECRET
+    ref: 0/env-1-/2--x
+steps:
+  - command: echo hi

--- a/specs/069-secrets-providers.md
+++ b/specs/069-secrets-providers.md
@@ -1,0 +1,117 @@
+# Spec: Secrets Providers
+
+## Status
+
+Partially implemented.
+
+Conformance covers direct provider references declared on a DAG's `secrets:`
+field, build-time validation of that field, and live resolution for the
+`env`, `file`, and `aws` providers. It does not cover the workspace-managed
+secret registry (`ref:`-style references), which requires a running Dagu
+server and its secrets management API.
+
+## Scope
+
+This spec covers `secrets:` entries that resolve directly through a named
+provider (`provider:` plus `key:`), independent of any registry. It covers:
+
+- Build-time validation of the `secrets:` field shared by every provider.
+- Live resolution, failure, and masking behavior for the `env`, `file`, and
+  `aws` providers.
+- Provider-specific reference parsing for `gcp`, `azure`, `alibaba`, and
+  `kubernetes`, to the extent it fails before any network client is created.
+
+It does not define:
+
+- The workspace secret registry, its API, or `ref:`-style entries.
+- Live network resolution for `gcp`, `azure`, `alibaba`, `kubernetes`, or
+  `vault`. Each of these providers only accepts a server address or
+  credential file through `options.*` or workspace configuration, neither of
+  which a DAG's `secrets:` field can set dynamically (`key` and `options`
+  values are used literally and are not expanded like `with:` or `env:`
+  values). `aws` is the exception: its client honors `AWS_ENDPOINT_URL` and
+  the AWS credential environment variables directly, which lets a process
+  environment override it without any DAG-level indirection.
+- Secret value formatting beyond returning it as a single string (JSON field
+  extraction via `options.field` is provider plumbing, not normative here).
+
+## Goal
+
+Workflow authors can inject a value from an external secret store into a
+DAG's environment without writing that value into the DAG file, and without
+that value leaking into logs or run history.
+
+## Behavior
+
+A `secrets:` entry has a `name` (the environment variable step processes
+see) and either a registry `ref` or a `provider` plus `key`. `options` is a
+map of provider-specific strings.
+
+Build-time validation, independent of any provider:
+
+- `name` is required, must be a valid environment variable name
+  (`[A-Za-z_][A-Za-z0-9_]*`), must not start with `DAGU_`, and must not
+  collide with a Dagu-managed runtime environment variable (for example
+  `DAG_NAME`).
+- Names must be unique within a DAG.
+- Exactly one of `ref` or `provider` plus `key` must be set.
+- `options` is rejected alongside `ref`.
+- `ref` must be a slash-separated lowercase slug path.
+
+All secrets are resolved once, before any step runs. A DAG run fails
+immediately if any secret fails to resolve; no steps execute.
+
+An unregistered `provider` fails with `unknown secret provider: <name>`.
+
+Every resolved secret value is masked wherever Dagu writes run output: the
+step's stdout/stderr log files on disk, the rendered status tree, and stored
+run status (error messages, output variables, step configuration). The
+mask replaces the literal value with `*******`.
+
+Provider-specific behavior covered here:
+
+- `env`: resolves `key` from the DAG's own env scope first, then the real OS
+  environment. An unset variable fails with
+  `environment variable "<key>" is not set`.
+- `file`: resolves `key` as a file path. A relative path is resolved against
+  the DAG file's own directory. A missing file fails with
+  `secret file not found: <path>`.
+- `aws`: resolves `key` (a secret name or ARN) through AWS Secrets Manager
+  using the standard AWS SDK, which honors `AWS_ENDPOINT_URL` and the AWS
+  credential environment variables. A secret Secrets Manager reports as
+  missing fails with `AWS Secrets Manager secret "<key>" was not found`.
+- `gcp`, `azure`, `alibaba`, `kubernetes`: reference parsing runs before any
+  client is created and reports a provider-specific diagnostic for a
+  malformed reference (for example, `kubernetes` requires `key` to be
+  `secret-name/data-key` or for `options.secret_name` to be set).
+
+## Errors
+
+Build-time validation failures exit `dagu validate` (and `dagu start`)
+nonzero with a diagnostic naming the offending secret and field. Runtime
+resolution failures (unknown provider, provider-specific parse errors,
+provider fetch errors) fail the DAG run before any step starts, with an
+error identifying the secret name and provider.
+
+## Examples
+
+```yaml
+secrets:
+  - name: API_TOKEN
+    provider: env
+    key: SOURCE_API_TOKEN
+steps:
+  - command: curl -H "Authorization: Bearer $API_TOKEN" https://example.invalid
+```
+
+```yaml
+secrets:
+  - name: DB_PASSWORD
+    provider: aws
+    key: prod/db/password
+    options:
+      region: us-east-1
+      field: password
+steps:
+  - command: echo "$DB_PASSWORD" | psql-login
+```

--- a/specs/069-secrets-providers.md
+++ b/specs/069-secrets-providers.md
@@ -56,7 +56,11 @@ Build-time validation, independent of any provider:
 - Names must be unique within a DAG.
 - Exactly one of `ref` or `provider` plus `key` must be set.
 - `options` is rejected alongside `ref`.
-- `ref` must be a slash-separated lowercase slug path.
+- `ref` must match `[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)*` in full.
+  Each nonempty segment starts with an ASCII lowercase letter or digit,
+  followed by ASCII lowercase letters, digits, or hyphens. Internal and
+  trailing hyphens are allowed. Empty segments, leading or trailing slashes,
+  uppercase letters, underscores, and Unicode characters are rejected.
 
 All secrets are resolved once, before any step runs. A DAG run fails
 immediately if any secret fails to resolve; no steps execute.

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [069: Secrets Providers](069-secrets-providers.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Cover secret declaration validation, provider dispatch, resolution, and masking. AWS requests use a local endpoint isolated from host profiles and credentials; other provider checks require no network service.

Validation: package tests pass with race detection; make fmt passes. CI must pass before merge.