### PR TITLE
test: add spec conformance coverage for runtime profile layering

### DIFF
--- a/conformance/spec070_profiles/layered_defaults_test.go
+++ b/conformance/spec070_profiles/layered_defaults_test.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec070_profiles_test
+
+import (
+	"net/http"
+	"testing"
+
+	api "github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+// The three profile layers apply in order: global defaults, then workspace
+// defaults (overriding global), then the explicitly selected profile
+// (overriding workspace). A run only picks up workspace defaults when its
+// DAG carries a `workspace` label naming that workspace.
+func TestLayeredDefaultsPrecedence(t *testing.T) {
+	t.Parallel()
+
+	server := test.SetupServer(t)
+	const noAuth = ""
+
+	setVariable(t, server, noAuth, "_global", "PRECEDENCE_VAR", "global-value")
+	setVariable(t, server, noAuth, "_global", "GLOBAL_ONLY_VAR", "global-only-value")
+
+	withAuth(server.Client().Post("/api/v1/workspaces", api.CreateWorkspaceRequest{Name: "acme"}), noAuth).
+		ExpectStatus(http.StatusCreated).Send(t)
+	setVariable(t, server, noAuth, "_workspaces/acme", "PRECEDENCE_VAR", "workspace-value")
+	setVariable(t, server, noAuth, "_workspaces/acme", "WORKSPACE_ONLY_VAR", "workspace-only-value")
+
+	withAuth(server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "selected"}), noAuth).
+		ExpectStatus(http.StatusCreated).Send(t)
+	setVariable(t, server, noAuth, "selected", "WORKSPACE_ONLY_VAR", "selected-value")
+	setVariable(t, server, noAuth, "selected", "SELECTED_ONLY_VAR", "selected-only-value")
+
+	spec := "steps:\n  - command: echo \"$PRECEDENCE_VAR $GLOBAL_ONLY_VAR $WORKSPACE_ONLY_VAR $SELECTED_ONLY_VAR\"\n"
+	output := runInlineSpec(t, server, noAuth, spec, "layered-defaults-dag", "selected", []string{"workspace=acme"})
+
+	require.Contains(t, output, "workspace-value global-only-value selected-value selected-only-value")
+}
+
+// A run naming a workspace with no configured defaults, or naming none at
+// all, still applies global defaults and the selected profile.
+func TestLayeredDefaultsWithoutWorkspace(t *testing.T) {
+	t.Parallel()
+
+	server := test.SetupServer(t)
+	const noAuth = ""
+
+	setVariable(t, server, noAuth, "_global", "GLOBAL_VAR", "global-value")
+
+	spec := "steps:\n  - command: echo \"$GLOBAL_VAR\"\n"
+	output := runInlineSpec(t, server, noAuth, spec, "no-workspace-dag", "", nil)
+
+	require.Contains(t, output, "global-value")
+}
+
+// A profile secret entry resolves and is masked in run output the same way a
+// DAG-level secret is. Setting a profile secret requires the REST API (the
+// CLI's --value-stdin/interactive prompt has no black-box equivalent).
+func TestProfileSecretIsMasked(t *testing.T) {
+	t.Parallel()
+
+	server, token := setupBuiltinAuthServer(t)
+
+	withAuth(server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "secprof"}), token).
+		ExpectStatus(http.StatusCreated).Send(t)
+	setSecret(t, server, token, "secprof", "MY_PROF_SECRET", "profile-secret-value")
+
+	spec := "steps:\n  - command: echo \"value is $MY_PROF_SECRET\"\n"
+	output := runInlineSpec(t, server, token, spec, "profile-secret-dag", "secprof", nil)
+
+	require.Contains(t, output, "*******")
+	require.NotContains(t, output, "profile-secret-value")
+}

--- a/conformance/spec070_profiles/layered_defaults_test.go
+++ b/conformance/spec070_profiles/layered_defaults_test.go
@@ -43,7 +43,7 @@ func TestLayeredDefaultsPrecedence(t *testing.T) {
 
 // A run naming a workspace with no configured defaults, or naming none at
 // all, still applies global defaults and the selected profile.
-func TestLayeredDefaultsWithoutWorkspace(t *testing.T) {
+func TestAbsentWorkspaceDefaults(t *testing.T) {
 	t.Parallel()
 
 	server := test.SetupServer(t)
@@ -51,10 +51,23 @@ func TestLayeredDefaultsWithoutWorkspace(t *testing.T) {
 
 	setVariable(t, server, noAuth, "_global", "GLOBAL_VAR", "global-value")
 
-	spec := "steps:\n  - command: echo \"$GLOBAL_VAR\"\n"
-	output := runInlineSpec(t, server, noAuth, spec, "no-workspace-dag", "", nil)
+	server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "selected"}).
+		ExpectStatus(http.StatusCreated).Send(t)
+	setVariable(t, server, noAuth, "selected", "SELECTED_VAR", "selected-value")
 
-	require.Contains(t, output, "global-value")
+	spec := "steps:\n  - command: echo \"$GLOBAL_VAR $SELECTED_VAR\"\n"
+	for _, tc := range []struct {
+		name   string
+		labels []string
+	}{
+		{"no-workspace", nil},
+		{"unconfigured-workspace", []string{"workspace=unconfigured"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := runInlineSpec(t, server, noAuth, spec, tc.name, "selected", tc.labels)
+			require.Contains(t, output, "global-value selected-value")
+		})
+	}
 }
 
 // A profile secret entry resolves and is masked in run output the same way a

--- a/conformance/spec070_profiles/profiles_test.go
+++ b/conformance/spec070_profiles/profiles_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package spec070_profiles holds black-box conformance tests for spec 070
+// (runtime profiles). CRUD, enable/disable, and basic variable application
+// already have CLI-level coverage in conformance/cli/profile_test.go; this
+// package covers the layered defaults (global/workspace/selected) precedence,
+// webhook-header profile selection, and how a selected profile's entries
+// interact with a DAG's own env: and secrets: fields.
+package spec070_profiles_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// sharedEnv gives every command invoked with it the same DAGU_HOME, so a
+// profile created by one command is visible to a later `start` in the same
+// test (the harness gives each call a fresh isolated home by default).
+func sharedEnv(t *testing.T) []string {
+	t.Helper()
+	return []string{"DAGU_HOME=" + filepath.Join(t.TempDir(), "dagu")}
+}
+
+// A selected profile's variable overrides a DAG's own env: entry of the same
+// name: profileValues.selectedEnvs is applied after the DAG's own env in the
+// final variable composition.
+func TestSelectedProfileOverridesDAGEnv(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	env := sharedEnv(t)
+
+	dagu.RunWithEnv(env, "profile", "create", "prof").ExpectExitCode(0)
+	dagu.RunWithEnv(env, "profile", "set-var", "prof", "SHARED", "from-profile").ExpectExitCode(0)
+
+	result := dagu.RunWithEnv(env, "start", "--profile=prof", "profile_overrides_dag_env.yaml")
+	result.ExpectExitCode(0)
+	require.Contains(t, result.Stdout(), "value is from-profile")
+	require.NotContains(t, result.Stdout(), "from-dag-env")
+}
+
+// A DAG's own secrets: entry overrides a selected profile's variable of the
+// same name: it is the last layer applied, and its resolved value is masked
+// like any other secret.
+func TestDAGSecretOverridesSelectedProfile(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	env := sharedEnv(t)
+
+	dagu.RunWithEnv(env, "profile", "create", "prof").ExpectExitCode(0)
+	dagu.RunWithEnv(env, "profile", "set-var", "prof", "SHARED", "from-profile").ExpectExitCode(0)
+
+	result := dagu.RunWithEnv(append(env, "SOURCE_VALUE=from-dag-secret"),
+		"start", "--profile=prof", "dag_secret_overrides_profile.yaml")
+	result.ExpectExitCode(0)
+	require.Contains(t, result.Stdout(), "*******")
+	require.NotContains(t, result.Stdout(), "from-dag-secret")
+	require.NotContains(t, result.Stdout(), "from-profile")
+}

--- a/conformance/spec070_profiles/server_helper_test.go
+++ b/conformance/spec070_profiles/server_helper_test.go
@@ -99,7 +99,15 @@ func waitForRun(t *testing.T, server test.Server, token, name, runID string) api
 		response := withAuth(server.Client().Get("/api/v1/dag-runs/"+name+"/"+runID), token).
 			ExpectStatus(http.StatusOK).Send(t)
 		response.Unmarshal(t, &details)
-		return details.DagRunDetails.FinishedAt != ""
+		switch details.DagRunDetails.StatusLabel {
+		case api.StatusLabelSucceeded, api.StatusLabelPartiallySucceeded,
+			api.StatusLabelFailed, api.StatusLabelAborted, api.StatusLabelRejected:
+			return true
+		case api.StatusLabelNotStarted, api.StatusLabelQueued,
+			api.StatusLabelRunning, api.StatusLabelWaiting:
+			return false
+		}
+		return false
 	}, harness.WaitTimeout(t), 50*time.Millisecond)
 	require.Equal(t, api.StatusLabelSucceeded, details.DagRunDetails.StatusLabel)
 	return details.DagRunDetails

--- a/conformance/spec070_profiles/server_helper_test.go
+++ b/conformance/spec070_profiles/server_helper_test.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec070_profiles_test
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	api "github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/internal/cmn/config"
+	"github.com/dagucloud/dagu/v2/internal/license"
+	"github.com/dagucloud/dagu/v2/internal/service/frontend"
+	"github.com/dagucloud/dagu/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+// Global and workspace default profile layers, and webhook profile
+// selection, are managed only through the HTTP API (no CLI command reaches
+// them). These tests exercise that API directly against a real in-process
+// server, the same way conformance/spec034_wiki_page_format and
+// conformance/mcptest already do for behavior a CLI process cannot reach.
+
+// withAuth adds a bearer token to a request when one is given. The
+// default-config server used for the layered-defaults test runs with no
+// auth configured, so an empty token is a no-op.
+func withAuth(r *test.Request, token string) *test.Request {
+	if token == "" {
+		return r
+	}
+	return r.WithBearerToken(token)
+}
+
+// setVariable sets a runtime profile (or inherited defaults layer) variable
+// through the REST API and requires the call to succeed. path is the
+// profile-path segment: a plain profile name, "_global", or
+// "_workspaces/<name>".
+func setVariable(t *testing.T, server test.Server, token, path, key, value string) {
+	t.Helper()
+
+	withAuth(server.Client().Put("/api/v1/profiles/"+path+"/variables/"+key,
+		api.SetRuntimeProfileVariableRequest{Value: value}), token).
+		ExpectStatus(http.StatusOK).Send(t)
+}
+
+// setSecret sets a runtime profile secret through the REST API and requires
+// the call to succeed.
+func setSecret(t *testing.T, server test.Server, token, profileName, key, value string) {
+	t.Helper()
+
+	withAuth(server.Client().Put("/api/v1/profiles/"+profileName+"/secrets/"+key,
+		api.SetRuntimeProfileSecretRequest{Value: &value}), token).
+		ExpectStatus(http.StatusOK).Send(t)
+}
+
+// runInlineSpec creates and immediately executes a DAG from a raw spec
+// string, optionally selecting a runtime profile and workspace labels, and
+// returns the content of its single step's stdout log file.
+func runInlineSpec(t *testing.T, server test.Server, token, spec, name, profile string, labels []string) string {
+	t.Helper()
+
+	body := api.ExecuteDAGRunFromSpecJSONRequestBody{
+		Spec: spec,
+		Name: &name,
+	}
+	if profile != "" {
+		override := api.RuntimeProfileOverride(profile)
+		body.Profile = &override
+	}
+	if len(labels) > 0 {
+		apiLabels := api.Labels(labels)
+		body.Labels = &apiLabels
+	}
+
+	startResp := withAuth(server.Client().Post("/api/v1/dag-runs", body), token).
+		ExpectStatus(http.StatusOK).Send(t)
+	var started struct {
+		DagRunID string `json:"dagRunId"`
+	}
+	startResp.Unmarshal(t, &started)
+
+	getResp := withAuth(server.Client().Get("/api/v1/dag-runs/"+name+"/"+started.DagRunID), token).
+		ExpectStatus(http.StatusOK).Send(t)
+	var details struct {
+		DAGRunDetails struct {
+			StatusLabel string `json:"statusLabel"`
+			Nodes       []struct {
+				Stdout string `json:"stdout"`
+			} `json:"nodes"`
+		} `json:"dagRunDetails"`
+	}
+	getResp.Unmarshal(t, &details)
+	require.Equal(t, "succeeded", details.DAGRunDetails.StatusLabel, "body: %s", getResp.Body)
+	require.Len(t, details.DAGRunDetails.Nodes, 1)
+
+	content, err := os.ReadFile(details.DAGRunDetails.Nodes[0].Stdout)
+	require.NoError(t, err)
+	return string(content)
+}
+
+// setupBuiltinAuthServer starts a server with builtin auth and webhook
+// management enabled (webhooks require both), creates the admin account, and
+// returns the server and an admin bearer token.
+func setupBuiltinAuthServer(t *testing.T) (test.Server, string) {
+	t.Helper()
+
+	server := test.SetupServer(t,
+		test.WithConfigMutator(func(cfg *config.Config) {
+			cfg.Server.Auth.Mode = config.AuthModeBuiltin
+			cfg.Server.Auth.Builtin.Token.Secret = "jwt-secret-key"
+			cfg.Server.Auth.Builtin.Token.TTL = 24 * time.Hour
+		}),
+		test.WithServerOptions(
+			frontend.WithLicenseManager(
+				license.NewTestManager(license.FeatureRBAC, license.FeatureAudit),
+			),
+		),
+	)
+
+	server.Client().Post("/api/v1/auth/setup", api.SetupRequest{
+		Username: "admin",
+		Password: "adminpass",
+	}).ExpectStatus(http.StatusOK).Send(t)
+
+	loginResp := server.Client().Post("/api/v1/auth/login", api.LoginRequest{
+		Username: "admin",
+		Password: "adminpass",
+	}).ExpectStatus(http.StatusOK).Send(t)
+	var login api.LoginResponse
+	loginResp.Unmarshal(t, &login)
+	require.NotEmpty(t, login.Token)
+
+	return server, login.Token
+}

--- a/conformance/spec070_profiles/server_helper_test.go
+++ b/conformance/spec070_profiles/server_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	api "github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/conformance/harness"
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/license"
 	"github.com/dagucloud/dagu/v2/internal/service/frontend"
@@ -81,23 +82,27 @@ func runInlineSpec(t *testing.T, server test.Server, token, spec, name, profile 
 	}
 	startResp.Unmarshal(t, &started)
 
-	getResp := withAuth(server.Client().Get("/api/v1/dag-runs/"+name+"/"+started.DagRunID), token).
-		ExpectStatus(http.StatusOK).Send(t)
-	var details struct {
-		DAGRunDetails struct {
-			StatusLabel string `json:"statusLabel"`
-			Nodes       []struct {
-				Stdout string `json:"stdout"`
-			} `json:"nodes"`
-		} `json:"dagRunDetails"`
-	}
-	getResp.Unmarshal(t, &details)
-	require.Equal(t, "succeeded", details.DAGRunDetails.StatusLabel, "body: %s", getResp.Body)
-	require.Len(t, details.DAGRunDetails.Nodes, 1)
+	details := waitForRun(t, server, token, name, started.DagRunID)
+	require.Len(t, details.Nodes, 1)
 
-	content, err := os.ReadFile(details.DAGRunDetails.Nodes[0].Stdout)
+	content, err := os.ReadFile(details.Nodes[0].Stdout)
 	require.NoError(t, err)
 	return string(content)
+}
+
+// waitForRun waits for asynchronous execution before reading its final output.
+func waitForRun(t *testing.T, server test.Server, token, name, runID string) api.DAGRunDetails {
+	t.Helper()
+
+	var details api.GetDAGRunDetails200JSONResponse
+	require.Eventually(t, func() bool {
+		response := withAuth(server.Client().Get("/api/v1/dag-runs/"+name+"/"+runID), token).
+			ExpectStatus(http.StatusOK).Send(t)
+		response.Unmarshal(t, &details)
+		return details.DagRunDetails.FinishedAt != ""
+	}, harness.WaitTimeout(t), 50*time.Millisecond)
+	require.Equal(t, api.StatusLabelSucceeded, details.DagRunDetails.StatusLabel)
+	return details.DagRunDetails
 }
 
 // setupBuiltinAuthServer starts a server with builtin auth and webhook

--- a/conformance/spec070_profiles/testdata/dag_secret_overrides_profile.yaml
+++ b/conformance/spec070_profiles/testdata/dag_secret_overrides_profile.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: SHARED
+    provider: env
+    key: SOURCE_VALUE
+steps:
+  - command: echo "value is $SHARED"

--- a/conformance/spec070_profiles/testdata/profile_overrides_dag_env.yaml
+++ b/conformance/spec070_profiles/testdata/profile_overrides_dag_env.yaml
@@ -1,0 +1,4 @@
+env:
+  - SHARED: from-dag-env
+steps:
+  - command: echo "value is $SHARED"

--- a/conformance/spec070_profiles/webhook_profile_test.go
+++ b/conformance/spec070_profiles/webhook_profile_test.go
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec070_profiles_test
+
+import (
+	"net/http"
+	"testing"
+
+	api "github.com/dagucloud/dagu/v2/api/v1"
+	"github.com/dagucloud/dagu/v2/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+// A webhook caller selects a runtime profile with the X-Dagu-Profile header,
+// restricted to the profiles ConfigureDAGWebhookProfileSelection allowed for
+// that webhook.
+func TestWebhookProfileSelectionApplies(t *testing.T) {
+	t.Parallel()
+
+	server, adminToken := setupBuiltinAuthServer(t)
+
+	const dagName = "webhook-profile-dag"
+	spec := "steps:\n  - command: echo \"$WEBHOOK_VAR\"\n"
+	server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &spec,
+	}).WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+
+	server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "webhookprof"}).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+	setVariable(t, server, adminToken, "webhookprof", "WEBHOOK_VAR", "from-webhook-profile")
+
+	createHookResp := server.Client().Post("/api/v1/dags/"+dagName+"/webhook", nil).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+	var hookCreate api.WebhookCreateResponse
+	createHookResp.Unmarshal(t, &hookCreate)
+
+	server.Client().Put("/api/v1/dags/"+dagName+"/webhook/profile-selection",
+		api.WebhookProfileSelectionRequest{AllowedProfiles: []api.RuntimeProfileName{"webhookprof"}}).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
+
+	triggerResp := server.Client().Post("/api/v1/webhooks/"+dagName, api.WebhookRequest{}).
+		WithBearerToken(hookCreate.Token).
+		WithHeader("X-Dagu-Profile", "webhookprof").
+		ExpectStatus(http.StatusOK).Send(t)
+	var trigger api.WebhookResponse
+	triggerResp.Unmarshal(t, &trigger)
+
+	test.ProcessQueuedInlineRun(t, server, dagName)
+
+	getResp := server.Client().Get("/api/v1/dag-runs/" + dagName + "/" + string(trigger.DagRunId)).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
+	var details struct {
+		DAGRunDetails struct {
+			StatusLabel string `json:"statusLabel"`
+			ProfileName string `json:"profileName"`
+		} `json:"dagRunDetails"`
+	}
+	getResp.Unmarshal(t, &details)
+	require.Equal(t, "succeeded", details.DAGRunDetails.StatusLabel, "body: %s", getResp.Body)
+	require.Equal(t, "webhookprof", details.DAGRunDetails.ProfileName)
+}
+
+// A webhook caller naming a profile outside the configured allow-list is
+// rejected before any DAG-run is created.
+func TestWebhookProfileSelectionRejectsDisallowedProfile(t *testing.T) {
+	t.Parallel()
+
+	server, adminToken := setupBuiltinAuthServer(t)
+
+	const dagName = "webhook-profile-reject-dag"
+	spec := "steps:\n  - command: echo hi\n"
+	server.Client().Post("/api/v1/dags", api.CreateNewDAGJSONRequestBody{
+		Name: dagName,
+		Spec: &spec,
+	}).WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+
+	server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "allowedprof"}).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+
+	createHookResp := server.Client().Post("/api/v1/dags/"+dagName+"/webhook", nil).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+	var hookCreate api.WebhookCreateResponse
+	createHookResp.Unmarshal(t, &hookCreate)
+
+	server.Client().Put("/api/v1/dags/"+dagName+"/webhook/profile-selection",
+		api.WebhookProfileSelectionRequest{AllowedProfiles: []api.RuntimeProfileName{"allowedprof"}}).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
+
+	rejectResp := server.Client().Post("/api/v1/webhooks/"+dagName, api.WebhookRequest{}).
+		WithBearerToken(hookCreate.Token).
+		WithHeader("X-Dagu-Profile", "not-allowed").
+		ExpectStatus(http.StatusForbidden).Send(t)
+	require.Contains(t, rejectResp.Body, "runtime profile selection is not allowed for this webhook")
+}

--- a/conformance/spec070_profiles/webhook_profile_test.go
+++ b/conformance/spec070_profiles/webhook_profile_test.go
@@ -5,6 +5,7 @@ package spec070_profiles_test
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	api "github.com/dagucloud/dagu/v2/api/v1"
@@ -15,7 +16,7 @@ import (
 // A webhook caller selects a runtime profile with the X-Dagu-Profile header,
 // restricted to the profiles ConfigureDAGWebhookProfileSelection allowed for
 // that webhook.
-func TestWebhookProfileSelectionApplies(t *testing.T) {
+func TestWebhookProfile(t *testing.T) {
 	t.Parallel()
 
 	server, adminToken := setupBuiltinAuthServer(t)
@@ -49,22 +50,18 @@ func TestWebhookProfileSelectionApplies(t *testing.T) {
 
 	test.ProcessQueuedInlineRun(t, server, dagName)
 
-	getResp := server.Client().Get("/api/v1/dag-runs/" + dagName + "/" + string(trigger.DagRunId)).
-		WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
-	var details struct {
-		DAGRunDetails struct {
-			StatusLabel string `json:"statusLabel"`
-			ProfileName string `json:"profileName"`
-		} `json:"dagRunDetails"`
-	}
-	getResp.Unmarshal(t, &details)
-	require.Equal(t, "succeeded", details.DAGRunDetails.StatusLabel, "body: %s", getResp.Body)
-	require.Equal(t, "webhookprof", details.DAGRunDetails.ProfileName)
+	details := waitForRun(t, server, adminToken, dagName, string(trigger.DagRunId))
+	require.NotNil(t, details.ProfileName)
+	require.Equal(t, api.RuntimeProfileName("webhookprof"), *details.ProfileName)
+	require.Len(t, details.Nodes, 1)
+	output, err := os.ReadFile(details.Nodes[0].Stdout)
+	require.NoError(t, err)
+	require.Contains(t, string(output), "from-webhook-profile")
 }
 
 // A webhook caller naming a profile outside the configured allow-list is
 // rejected before any DAG-run is created.
-func TestWebhookProfileSelectionRejectsDisallowedProfile(t *testing.T) {
+func TestDisallowedWebhookProfile(t *testing.T) {
 	t.Parallel()
 
 	server, adminToken := setupBuiltinAuthServer(t)
@@ -79,6 +76,9 @@ func TestWebhookProfileSelectionRejectsDisallowedProfile(t *testing.T) {
 	server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "allowedprof"}).
 		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
 
+	server.Client().Post("/api/v1/profiles", api.CreateRuntimeProfileRequest{Name: "disallowedprof"}).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
+
 	createHookResp := server.Client().Post("/api/v1/dags/"+dagName+"/webhook", nil).
 		WithBearerToken(adminToken).ExpectStatus(http.StatusCreated).Send(t)
 	var hookCreate api.WebhookCreateResponse
@@ -90,7 +90,13 @@ func TestWebhookProfileSelectionRejectsDisallowedProfile(t *testing.T) {
 
 	rejectResp := server.Client().Post("/api/v1/webhooks/"+dagName, api.WebhookRequest{}).
 		WithBearerToken(hookCreate.Token).
-		WithHeader("X-Dagu-Profile", "not-allowed").
+		WithHeader("X-Dagu-Profile", "disallowedprof").
 		ExpectStatus(http.StatusForbidden).Send(t)
 	require.Contains(t, rejectResp.Body, "runtime profile selection is not allowed for this webhook")
+
+	response := server.Client().Get("/api/v1/dag-runs/" + dagName).
+		WithBearerToken(adminToken).ExpectStatus(http.StatusOK).Send(t)
+	var runs api.DAGRunsPageResponse
+	response.Unmarshal(t, &runs)
+	require.Empty(t, runs.DagRuns)
 }

--- a/specs/070-runtime-profiles.md
+++ b/specs/070-runtime-profiles.md
@@ -1,0 +1,88 @@
+# Spec: Runtime Profiles
+
+## Status
+
+Partially implemented.
+
+Conformance covers CRUD, enable/disable, and basic variable application at
+the CLI level (`conformance/cli/profile_test.go`). This spec adds the layered
+defaults precedence (global, workspace, and selected profile), webhook-header
+profile selection, and how a selected profile's entries interact with a
+DAG's own `env:` and `secrets:` fields.
+
+## Scope
+
+This spec covers how a runtime profile's variables and secrets are composed
+into a DAG-run's environment, across three layers:
+
+- Global defaults, set once for the whole server.
+- Workspace defaults, set per workspace and applied only to runs whose DAG
+  carries a matching `workspace` label.
+- The explicitly selected profile, named by `--profile`, the `profile` field
+  on `POST /dag-runs`, or (for a webhook-triggered run) the `X-Dagu-Profile`
+  header.
+
+It also covers precedence against a DAG's own `env:` and `secrets:` fields,
+and masking of profile secret values.
+
+It does not define the workspace-managed secret registry (`ref:`-style
+secret entries, see spec 069), profile CRUD/enable-disable/basic variable
+application (already covered by `conformance/cli/profile_test.go`), or
+webhook HMAC signing.
+
+## Goal
+
+Workflow authors and operators can supply shared configuration and secrets
+to DAG-runs from outside the DAG file, at different scopes (global,
+workspace, or per-run), without editing every DAG that needs them.
+
+## Behavior
+
+A run's final environment composes, in order (later entries override
+earlier ones with the same name):
+
+1. Global default profile variables.
+2. Global default profile secrets.
+3. Workspace default profile variables and secrets, applied only when the
+   DAG's `labels` include a `workspace` entry naming a workspace with
+   configured defaults.
+4. The DAG's own `env:` field.
+5. The selected profile's variables.
+6. The selected profile's secrets.
+7. The DAG's own `secrets:` field.
+
+A DAG's own `secrets:` field is therefore the final, highest-precedence
+layer: it overrides a same-named entry from any profile layer. The selected
+profile overrides the DAG's own `env:` field. Global and workspace defaults
+are managed only through the HTTP API (`/profiles/_global/...` and
+`/profiles/_workspaces/{name}/...`); no CLI command reaches them.
+
+A webhook-triggered run selects a profile with the `X-Dagu-Profile` request
+header, restricted to the profiles an admin allow-listed for that webhook
+(`PUT /dags/{fileName}/webhook/profile-selection`). A run with no explicit
+profile selection uses the webhook's configured default profile, if any.
+
+A resolved profile secret is masked in run output exactly like a DAG-level
+secret: the literal value is replaced with `*******` in the step's stdout
+and stderr log files, the rendered status tree, and stored run status.
+
+## Errors
+
+A webhook request naming a profile outside its configured allow-list is
+rejected with `403` and does not create a DAG-run. An unresolvable selected
+profile (unknown name, or disabled) fails the run before any step starts.
+
+## Examples
+
+```yaml
+labels:
+  - workspace: acme
+steps:
+  - command: echo "$SHARED_VAR"
+```
+
+Selecting a profile for a local run:
+
+```sh
+dagu start --profile=deploy-prod my-dag.yaml
+```

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
+| [070: Runtime Profiles](070-runtime-profiles.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Cover runtime profile layering, profile-secret masking, and webhook profile selection through CLI and HTTP interfaces. Wait for asynchronous run completion before reading results. Verify selected-profile values without workspace defaults and reject existing disallowed profiles without creating runs.

Validation: package tests pass normally and with race detection; make fmt passes. CI must pass before merge.