### PR TITLE
test: cover chat.completion tool-calling and max-iterations

### DIFF
--- a/conformance/spec059_chat/testdata/tool_calling_basic.yaml
+++ b/conformance/spec059_chat/testdata/tool_calling_basic.yaml
@@ -1,0 +1,19 @@
+working_dir: .
+env:
+  - LLM_BASE_URL: ${LLM_BASE_URL}
+steps:
+  - action: chat.completion
+    stdout: result.out
+    with:
+      prompt: "What is the weather in Paris?"
+      provider: local
+      model: test-model
+      base_url: $LLM_BASE_URL
+      tools:
+        - get-weather
+---
+name: get-weather
+params: CITY
+steps:
+  - command: 'echo "{\"temp_c\": 22, \"city\": \"$CITY\"}"'
+    output: WEATHER_JSON

--- a/conformance/spec059_chat/testdata/tool_calling_custom_max_iterations.yaml
+++ b/conformance/spec059_chat/testdata/tool_calling_custom_max_iterations.yaml
@@ -1,0 +1,18 @@
+working_dir: .
+env:
+  - LLM_BASE_URL: ${LLM_BASE_URL}
+steps:
+  - action: chat.completion
+    stdout: result.out
+    with:
+      prompt: "Keep calling the tool forever."
+      provider: local
+      model: test-model
+      base_url: $LLM_BASE_URL
+      tools:
+        - loop-tool
+      max_tool_iterations: 3
+---
+name: loop-tool
+steps:
+  - command: echo "ok"

--- a/conformance/spec059_chat/testdata/tool_calling_default_max_iterations.yaml
+++ b/conformance/spec059_chat/testdata/tool_calling_default_max_iterations.yaml
@@ -1,0 +1,17 @@
+working_dir: .
+env:
+  - LLM_BASE_URL: ${LLM_BASE_URL}
+steps:
+  - action: chat.completion
+    stdout: result.out
+    with:
+      prompt: "Keep calling the tool forever."
+      provider: local
+      model: test-model
+      base_url: $LLM_BASE_URL
+      tools:
+        - loop-tool
+---
+name: loop-tool
+steps:
+  - command: echo "ok"

--- a/conformance/spec059_chat/testdata/tool_calling_failed_tool.yaml
+++ b/conformance/spec059_chat/testdata/tool_calling_failed_tool.yaml
@@ -1,0 +1,17 @@
+working_dir: .
+env:
+  - LLM_BASE_URL: ${LLM_BASE_URL}
+steps:
+  - action: chat.completion
+    stdout: result.out
+    with:
+      prompt: "Run the broken tool."
+      provider: local
+      model: test-model
+      base_url: $LLM_BASE_URL
+      tools:
+        - broken-tool
+---
+name: broken-tool
+steps:
+  - command: exit 1

--- a/conformance/spec059_chat/testdata/tool_calling_unknown_tool.yaml
+++ b/conformance/spec059_chat/testdata/tool_calling_unknown_tool.yaml
@@ -1,0 +1,19 @@
+working_dir: .
+env:
+  - LLM_BASE_URL: ${LLM_BASE_URL}
+steps:
+  - action: chat.completion
+    stdout: result.out
+    with:
+      prompt: "Call a tool that isn't registered."
+      provider: local
+      model: test-model
+      base_url: $LLM_BASE_URL
+      tools:
+        - get-weather
+---
+name: get-weather
+params: CITY
+steps:
+  - command: echo done
+    output: WEATHER_JSON

--- a/conformance/spec059_chat/tool_calling_test.go
+++ b/conformance/spec059_chat/tool_calling_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dagucloud/dagu/v2/conformance/harness"
@@ -24,8 +25,18 @@ func TestToolCallingBasic(t *testing.T) {
 	requests := make(chan toolChatRequest, 2)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req toolChatRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		requests <- req
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		select {
+		case requests <- req:
+		default:
+			t.Error("unexpected extra request")
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if len(req.Messages) == 1 {
@@ -63,6 +74,7 @@ func TestToolCallingBasic(t *testing.T) {
 
 	// Second request carries the assistant tool call and the tool's result,
 	// which is the sub-DAG's declared output JSON-encoded as the tool content.
+	require.Equal(t, captured[0].Tools, captured[1].Tools)
 	require.Len(t, captured[1].Messages, 3)
 	toolMsg := captured[1].Messages[2]
 	require.Equal(t, "tool", toolMsg.Role)
@@ -73,34 +85,40 @@ func TestToolCallingBasic(t *testing.T) {
 // A tool call naming a DAG outside with.tools is a non-fatal error: its
 // result content tells the LLM the tool was not found, and the loop
 // continues to a final response rather than failing the run.
-func TestToolCallingUnknownToolIsNonFatal(t *testing.T) {
+func TestUnknownTool(t *testing.T) {
 	t.Parallel()
 
-	requestCount := 0
+	var requestCount atomic.Int32
 	var secondRequest toolChatRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		count := requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		if requestCount == 1 {
+		if count == 1 {
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"",
 				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"not-a-real-tool","arguments":"{}"}}]},
 				"finish_reason":"tool_calls"}]}`))
 			return
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&secondRequest))
+		if err := json.NewDecoder(r.Body).Decode(&secondRequest); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"tool was unavailable"},"finish_reason":"stop"}]}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	dagu := harness.NewRunner(t)
 	result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", "tool_calling_unknown_tool.yaml")
+	srv.Close()
 	result.ExpectExitCode(0)
 
 	data, err := os.ReadFile(dagu.ProjectPath("result.out"))
 	require.NoError(t, err)
 	require.Equal(t, "tool was unavailable\n", string(data))
 
-	require.Equal(t, 2, requestCount)
+	require.EqualValues(t, 2, requestCount.Load())
+	require.Len(t, secondRequest.Messages, 3)
 	toolMsg := secondRequest.Messages[2]
 	require.Equal(t, "tool", toolMsg.Role)
 	require.Equal(t, `Error: tool "not-a-real-tool" not found`, toolMsg.Content)
@@ -108,34 +126,40 @@ func TestToolCallingUnknownToolIsNonFatal(t *testing.T) {
 
 // A tool DAG that itself fails is also non-fatal: the failure is reported as
 // the tool's result content, and the loop continues.
-func TestToolCallingFailedToolDAG(t *testing.T) {
+func TestFailedTool(t *testing.T) {
 	t.Parallel()
 
-	requestCount := 0
+	var requestCount atomic.Int32
 	var secondRequest toolChatRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		count := requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		if requestCount == 1 {
+		if count == 1 {
 			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"",
 				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"broken-tool","arguments":"{}"}}]},
 				"finish_reason":"tool_calls"}]}`))
 			return
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&secondRequest))
+		if err := json.NewDecoder(r.Body).Decode(&secondRequest); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"the tool failed"},"finish_reason":"stop"}]}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	dagu := harness.NewRunner(t)
 	result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", "tool_calling_failed_tool.yaml")
+	srv.Close()
 	result.ExpectExitCode(0)
 
 	data, err := os.ReadFile(dagu.ProjectPath("result.out"))
 	require.NoError(t, err)
 	require.Equal(t, "the tool failed\n", string(data))
 
-	require.Equal(t, 2, requestCount)
+	require.EqualValues(t, 2, requestCount.Load())
+	require.Len(t, secondRequest.Messages, 3)
 	toolMsg := secondRequest.Messages[2]
 	require.Equal(t, "tool", toolMsg.Role)
 	require.Equal(t, "Error: execution failed: exit status 1", toolMsg.Content)
@@ -144,7 +168,7 @@ func TestToolCallingFailedToolDAG(t *testing.T) {
 // max_tool_iterations bounds the tool loop: reaching it still succeeds the
 // step (it is not a failure), stopping after exactly that many requests.
 // With no override, the default is 10.
-func TestToolCallingMaxIterationsReached(t *testing.T) {
+func TestToolIterationLimit(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -157,22 +181,23 @@ func TestToolCallingMaxIterationsReached(t *testing.T) {
 		t.Run(tc.fixture, func(t *testing.T) {
 			t.Parallel()
 
-			requestCount := 0
+			var requestCount atomic.Int32
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				requestCount++
+				requestCount.Add(1)
 				w.Header().Set("Content-Type", "application/json")
-				// Always request another tool call; the LLM never finishes on its own.
+				// Unknown calls keep the request loop active without spawning tool DAGs.
 				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"still working",
-					"tool_calls":[{"id":"call_X","type":"function","function":{"name":"loop-tool","arguments":"{}"}}]},
+					"tool_calls":[{"id":"call_X","type":"function","function":{"name":"unknown-tool","arguments":"{}"}}]},
 					"finish_reason":"tool_calls"}]}`))
 			}))
 			t.Cleanup(srv.Close)
 
 			dagu := harness.NewRunner(t)
 			result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", tc.fixture)
+			srv.Close()
 			result.ExpectExitCode(0)
 
-			require.Equal(t, tc.maxIterations, requestCount)
+			require.EqualValues(t, tc.maxIterations, requestCount.Load())
 
 			data, err := os.ReadFile(dagu.ProjectPath("result.out"))
 			require.NoError(t, err)

--- a/conformance/spec059_chat/tool_calling_test.go
+++ b/conformance/spec059_chat/tool_calling_test.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec059_chat_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// with.tools references another DAG as a callable function: the LLM is
+// offered its params as a JSON schema, a requested call runs it as a real
+// sub-DAG with the LLM's arguments as DAG params, and its declared outputs
+// are JSON-encoded back to the LLM as the tool result.
+func TestToolCallingBasic(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan toolChatRequest, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req toolChatRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		requests <- req
+
+		w.Header().Set("Content-Type", "application/json")
+		if len(req.Messages) == 1 {
+			// First turn: request the tool call.
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get-weather","arguments":"{\"CITY\":\"Paris\"}"}}]},
+				"finish_reason":"tool_calls"}]}`))
+			return
+		}
+		// Second turn: final answer using the tool result.
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"It is 22C in Paris."},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", "tool_calling_basic.yaml")
+	srv.Close()
+	close(requests)
+	result.ExpectExitCode(0)
+
+	data, err := os.ReadFile(dagu.ProjectPath("result.out"))
+	require.NoError(t, err)
+	require.Equal(t, "It is 22C in Paris.\n", string(data))
+
+	var captured []toolChatRequest
+	for req := range requests {
+		captured = append(captured, req)
+	}
+	require.Len(t, captured, 2)
+
+	// First request offers the tool DAG's params as a JSON schema.
+	require.Len(t, captured[0].Tools, 1)
+	require.Equal(t, "get-weather", captured[0].Tools[0].Function.Name)
+	require.Equal(t, []string{"CITY"}, captured[0].Tools[0].Function.Parameters.Required)
+
+	// Second request carries the assistant tool call and the tool's result,
+	// which is the sub-DAG's declared output JSON-encoded as the tool content.
+	require.Len(t, captured[1].Messages, 3)
+	toolMsg := captured[1].Messages[2]
+	require.Equal(t, "tool", toolMsg.Role)
+	require.Equal(t, "call_1", toolMsg.ToolCallID)
+	require.JSONEq(t, `{"WEATHER_JSON":"{\"temp_c\": 22, \"city\": \"Paris\"}"}`, toolMsg.Content)
+}
+
+// A tool call naming a DAG outside with.tools is a non-fatal error: its
+// result content tells the LLM the tool was not found, and the loop
+// continues to a final response rather than failing the run.
+func TestToolCallingUnknownToolIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	requestCount := 0
+	var secondRequest toolChatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"not-a-real-tool","arguments":"{}"}}]},
+				"finish_reason":"tool_calls"}]}`))
+			return
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&secondRequest))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"tool was unavailable"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", "tool_calling_unknown_tool.yaml")
+	result.ExpectExitCode(0)
+
+	data, err := os.ReadFile(dagu.ProjectPath("result.out"))
+	require.NoError(t, err)
+	require.Equal(t, "tool was unavailable\n", string(data))
+
+	require.Equal(t, 2, requestCount)
+	toolMsg := secondRequest.Messages[2]
+	require.Equal(t, "tool", toolMsg.Role)
+	require.Equal(t, `Error: tool "not-a-real-tool" not found`, toolMsg.Content)
+}
+
+// A tool DAG that itself fails is also non-fatal: the failure is reported as
+// the tool's result content, and the loop continues.
+func TestToolCallingFailedToolDAG(t *testing.T) {
+	t.Parallel()
+
+	requestCount := 0
+	var secondRequest toolChatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"",
+				"tool_calls":[{"id":"call_1","type":"function","function":{"name":"broken-tool","arguments":"{}"}}]},
+				"finish_reason":"tool_calls"}]}`))
+			return
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&secondRequest))
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"the tool failed"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	dagu := harness.NewRunner(t)
+	result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", "tool_calling_failed_tool.yaml")
+	result.ExpectExitCode(0)
+
+	data, err := os.ReadFile(dagu.ProjectPath("result.out"))
+	require.NoError(t, err)
+	require.Equal(t, "the tool failed\n", string(data))
+
+	require.Equal(t, 2, requestCount)
+	toolMsg := secondRequest.Messages[2]
+	require.Equal(t, "tool", toolMsg.Role)
+	require.Equal(t, "Error: execution failed: exit status 1", toolMsg.Content)
+}
+
+// max_tool_iterations bounds the tool loop: reaching it still succeeds the
+// step (it is not a failure), stopping after exactly that many requests.
+// With no override, the default is 10.
+func TestToolCallingMaxIterationsReached(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		fixture       string
+		maxIterations int
+	}{
+		{"tool_calling_default_max_iterations.yaml", 10},
+		{"tool_calling_custom_max_iterations.yaml", 3},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			requestCount := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				// Always request another tool call; the LLM never finishes on its own.
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"still working",
+					"tool_calls":[{"id":"call_X","type":"function","function":{"name":"loop-tool","arguments":"{}"}}]},
+					"finish_reason":"tool_calls"}]}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			dagu := harness.NewRunner(t)
+			result := dagu.RunWithEnv([]string{"LLM_BASE_URL=" + srv.URL}, "start", tc.fixture)
+			result.ExpectExitCode(0)
+
+			require.Equal(t, tc.maxIterations, requestCount)
+
+			data, err := os.ReadFile(dagu.ProjectPath("result.out"))
+			require.NoError(t, err)
+			require.Equal(t, "still working\n", string(data))
+		})
+	}
+}
+
+type toolChatRequest struct {
+	Model      string             `json:"model"`
+	Messages   []toolChatMessage  `json:"messages"`
+	Tools      []toolChatToolSpec `json:"tools"`
+	ToolChoice string             `json:"tool_choice"`
+}
+
+type toolChatMessage struct {
+	Role       string `json:"role"`
+	Content    string `json:"content"`
+	ToolCallID string `json:"tool_call_id"`
+}
+
+type toolChatToolSpec struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name       string `json:"name"`
+		Parameters struct {
+			Required []string `json:"required"`
+		} `json:"parameters"`
+	} `json:"function"`
+}

--- a/specs/059-chat-completion.md
+++ b/specs/059-chat-completion.md
@@ -7,11 +7,12 @@ Partially implemented.
 ## Scope
 
 This spec covers `chat.completion` request construction, response output,
-stream selection, and model fallback using a local OpenAI-compatible
-endpoint. No external model service is required.
+stream selection, model fallback, and the `with.tools` agentic tool-calling
+loop, using a local OpenAI-compatible endpoint. No external model service is
+required.
 
-Provider-specific parameters, tool execution, timeout, abort, and tool
-sub-DAG cleanup belong to executor and lifecycle coverage.
+Provider-specific parameters, timeout, abort, and UI-facing tool sub-DAG
+drill-down tracking belong to executor and lifecycle coverage.
 
 ## Goal
 
@@ -32,6 +33,30 @@ followed by a newline.
 A `with.model` array with multiple entries tries the models in order until
 one succeeds. Requests for these fallback models disable streaming. A
 single model does not activate fallback.
+
+### Tool calling
+
+`with.tools` names other DAGs as callable functions. Each named DAG's
+declared parameters become the tool's JSON Schema (offered to the model as
+`tools` on every request), and its name becomes the tool name. A tool-calling
+request always uses a non-streaming call, regardless of `with.stream`.
+
+When the model's response includes tool calls, each one runs the
+corresponding DAG as a sub-DAG-run, passing the model's JSON arguments as
+DAG params. The sub-DAG's declared outputs (`output:`) are JSON-encoded and
+returned to the model as the tool result content, in a `tool` role message
+addressed to the tool call's ID. The loop then sends another request
+including that tool result, repeating until a response has no tool calls.
+
+A tool call naming a DAG outside `with.tools`, or whose sub-DAG-run itself
+fails, is not fatal to the step: the result content reports the problem to
+the model (`tool "<name>" not found`, or the execution error), and the loop
+continues to request another response.
+
+`with.max_tool_iterations` bounds how many such request/tool-call rounds
+run, default 10. Reaching the limit does not fail the step: it is a second,
+equally successful termination path alongside the model responding with no
+further tool calls.
 
 ## Errors
 
@@ -55,4 +80,25 @@ steps:
       base_url: http://localhost:8080
       prompt: Summarize the supplied text.
       stream: false
+```
+
+Tool calling, using another DAG in the same file as a tool:
+
+```yaml
+steps:
+  - action: chat.completion
+    with:
+      provider: local
+      model: local-model
+      base_url: http://localhost:8080
+      prompt: What is the weather in Paris?
+      tools:
+        - get-weather
+      max_tool_iterations: 5
+---
+name: get-weather
+params: CITY
+steps:
+  - command: fetch-weather.sh "$CITY"
+    output: WEATHER_JSON
 ```


### PR DESCRIPTION
Cover chat tool definitions, tool DAG invocation and results, unknown or failed tools, and iteration limits through a local model endpoint. Iteration-limit tests use unknown-tool responses to avoid repeated tool subprocesses.

Validation: package tests pass with race detection; make fmt passes. CI must pass before merge.