### PR TITLE
test: cover harness container failures

### DIFF
--- a/conformance/spec067_harness/harness_container_test.go
+++ b/conformance/spec067_harness/harness_container_test.go
@@ -9,15 +9,8 @@ import (
 	"github.com/dagucloud/dagu/v2/conformance/harness"
 )
 
-// Containerized harness execution (a harness.run step with a step-level
-// container: block) is excluded from live coverage: it requires a working
-// container daemon and an image, neither guaranteed in every environment
-// this suite runs in. These tests instead cover the deterministic
-// configuration and dispatch failures that are reachable without ever
-// reaching a daemon (or, for the last case, reachable identically whether or
-// not one is even installed), matching the same restraint spec037/spec038
-// already apply to their own container-dependent behavior.
-func TestHarnessContainerConfigErrors(t *testing.T) {
+// Container configuration failures require no daemon or downloaded image.
+func TestContainerConfig(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -47,9 +40,7 @@ func TestHarnessContainerConfigErrors(t *testing.T) {
 		})
 	}
 
-	// None of the above is caught at validate time: provider resolution (and
-	// so the container-specific checks above) happens only once the step
-	// actually runs.
+	// General validation accepts these runtime-only container restrictions.
 	for _, fixture := range []string{
 		"container_stdin_prompt_mode.yaml",
 		"container_name_image_mode.yaml",
@@ -65,15 +56,8 @@ func TestHarnessContainerConfigErrors(t *testing.T) {
 	}
 }
 
-// A containerized harness step's daemon dispatch is real: pointing the
-// engine's container-runtime selection at a socket that does not exist
-// fails the step with a connection error, proving the container path
-// genuinely attempts to reach a daemon rather than silently no-op'ing.
-// DAGU_CONTAINER_RUNTIME/DAGU_PODMAN_HOST select the daemon socket from the
-// engine's own process environment (never overridable by DAG/step env:), so
-// this reproduces the same way whether or not a real container daemon is
-// installed on the machine running this test.
-func TestHarnessContainerDaemonUnreachable(t *testing.T) {
+// An unavailable daemon must fail dispatch without pulling an image.
+func TestContainerUnavailable(t *testing.T) {
 	t.Parallel()
 
 	dagu := harness.NewRunner(t)

--- a/conformance/spec067_harness/harness_container_test.go
+++ b/conformance/spec067_harness/harness_container_test.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec067_harness_test
+
+import (
+	"testing"
+
+	"github.com/dagucloud/dagu/v2/conformance/harness"
+)
+
+// Containerized harness execution (a harness.run step with a step-level
+// container: block) is excluded from live coverage: it requires a working
+// container daemon and an image, neither guaranteed in every environment
+// this suite runs in. These tests instead cover the deterministic
+// configuration and dispatch failures that are reachable without ever
+// reaching a daemon (or, for the last case, reachable identically whether or
+// not one is even installed), matching the same restraint spec037/spec038
+// already apply to their own container-dependent behavior.
+func TestHarnessContainerConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		fixture string
+		errText string
+	}{
+		// A custom provider whose prompt_mode is stdin has no argument form:
+		// the SDK container client has no stdin, so this can only be caught
+		// once the provider is resolved, at run time.
+		{"container_stdin_prompt_mode.yaml", "harness: containerized harness does not support stdin input"},
+		// container.name targets an existing container by name, which has no
+		// image ENTRYPOINT to override with the agent binary; only exec mode
+		// (container.exec) may target one.
+		{"container_name_image_mode.yaml", "harness: container.name is not supported for an image-mode container step"},
+		// managed: true OpenCode runs against a Dagu-hosted session, which a
+		// containerized step has no access to.
+		{"container_managed_opencode.yaml", "harness: managed OpenCode is not supported inside containers"},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			env := writeFakeHarnessScripts(dagu)
+			result := dagu.RunWithEnv(env, "start", tc.fixture)
+			result.ExpectNonZeroExitCode()
+			result.ExpectStderrContains(tc.errText)
+		})
+	}
+
+	// None of the above is caught at validate time: provider resolution (and
+	// so the container-specific checks above) happens only once the step
+	// actually runs.
+	for _, fixture := range []string{
+		"container_stdin_prompt_mode.yaml",
+		"container_name_image_mode.yaml",
+		"container_managed_opencode.yaml",
+	} {
+		t.Run("validate accepts "+fixture, func(t *testing.T) {
+			t.Parallel()
+
+			dagu := harness.NewRunner(t)
+			env := writeFakeHarnessScripts(dagu)
+			dagu.RunWithEnv(env, "validate", fixture).ExpectExitCode(0)
+		})
+	}
+}
+
+// A containerized harness step's daemon dispatch is real: pointing the
+// engine's container-runtime selection at a socket that does not exist
+// fails the step with a connection error, proving the container path
+// genuinely attempts to reach a daemon rather than silently no-op'ing.
+// DAGU_CONTAINER_RUNTIME/DAGU_PODMAN_HOST select the daemon socket from the
+// engine's own process environment (never overridable by DAG/step env:), so
+// this reproduces the same way whether or not a real container daemon is
+// installed on the machine running this test.
+func TestHarnessContainerDaemonUnreachable(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	env := writeFakeHarnessScripts(dagu)
+	env = append(env,
+		"DAGU_CONTAINER_RUNTIME=podman",
+		"DAGU_PODMAN_HOST=unix:///nonexistent-dagu-conformance-podman.sock",
+	)
+	result := dagu.RunWithEnv(env, "start", "container_daemon_unreachable.yaml")
+	result.ExpectNonZeroExitCode()
+	result.ExpectStderrContains("harness: failed to initialize container client")
+}

--- a/conformance/spec067_harness/testdata/container_daemon_unreachable.yaml
+++ b/conformance/spec067_harness/testdata/container_daemon_unreachable.yaml
@@ -1,0 +1,14 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_arg:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - action: harness.run
+    container:
+      image: alpine:3
+    with:
+      provider: fake_arg
+      prompt: hello

--- a/conformance/spec067_harness/testdata/container_managed_opencode.yaml
+++ b/conformance/spec067_harness/testdata/container_managed_opencode.yaml
@@ -1,0 +1,8 @@
+steps:
+  - action: harness.run
+    container:
+      image: alpine:3
+    with:
+      provider: opencode
+      managed: true
+      prompt: hello

--- a/conformance/spec067_harness/testdata/container_name_image_mode.yaml
+++ b/conformance/spec067_harness/testdata/container_name_image_mode.yaml
@@ -1,0 +1,15 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_arg:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: arg
+steps:
+  - action: harness.run
+    container:
+      image: alpine:3
+      name: mycontainer
+    with:
+      provider: fake_arg
+      prompt: hello

--- a/conformance/spec067_harness/testdata/container_stdin_prompt_mode.yaml
+++ b/conformance/spec067_harness/testdata/container_stdin_prompt_mode.yaml
@@ -1,0 +1,14 @@
+env:
+  - PROJECT_DIR: $HOST_PROJECT_DIR
+working_dir: $PROJECT_DIR
+harnesses:
+  fake_stdin:
+    binary: ./scripts/fake_ok.sh
+    prompt_mode: stdin
+steps:
+  - action: harness.run
+    container:
+      image: alpine:3
+    with:
+      provider: fake_stdin
+      prompt: hello

--- a/specs/067-harness.md
+++ b/specs/067-harness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented.
+Partially implemented.
 
 ## Scope
 
@@ -41,15 +41,23 @@ This spec covers:
   one succeeds or the list is exhausted; a message naming both providers is
   written to the step's stderr before each retry
 
+This spec also covers the configuration and dispatch failures of
+containerized harness execution (a step-level `container:` block on a
+`harness.run` step) that are reachable without a working container daemon
+or a pulled image -- neither guaranteed in every environment this suite
+runs in, so a step's *successful* containerized execution is not itself
+covered here.
+
 This spec does not define:
 
 - the behavior of any specific built-in CLI provider (`claude`, `codex`,
   `aider`, and so on) -- none is installed in this conformance
   environment, so this spec exercises only custom `harnesses:` providers,
   which share the same invocation-building and fallback code paths
-- containerized harness execution (`step.container` with a harness
-  provider), the managed OpenCode execution path, or `type: agent` DAGs'
-  own use of a harness step as one of several actions in a decision loop
+- a containerized harness step's successful execution (the actual agent CLI
+  running inside a real container and producing output), the managed
+  OpenCode execution path's successful session, or `type: agent` DAGs' own
+  use of a harness step as one of several actions in a decision loop
   ([Spec 032: Agent DAGs](032-agent-dag.md))
 - prompt engineering, model behavior, or the semantics of any particular
   agent CLI's own flags
@@ -95,6 +103,28 @@ when the definition's `flag_style` is `single_dash`) unless
 `true` value produces the bare flag with no value (`false` is omitted
 entirely); a string, integer, or float value produces `flag value`; an
 array value repeats `flag value` once per element.
+
+### Containerized execution
+
+A step-level `container:` block runs the resolved provider's binary inside a
+container (via Dagu's own Moby SDK client; no `docker`/`podman` CLI
+subprocess is involved), with the agent binary as the container's
+entrypoint. This is resolved only once the step actually runs, after the
+provider is known, so `dagu validate` accepts a harness step with
+`container:` regardless of the provider's configuration -- the checks below
+are all runtime-only.
+
+A provider whose `prompt_mode` is `stdin` has no way to deliver the prompt
+inside a container (the SDK's `Client.Run` has no stdin), so it fails with
+`harness: containerized harness does not support stdin input`.
+`container.name` (targeting an already-running container by name) is
+rejected for a harness step -- an image-mode container has no ENTRYPOINT to
+override with the agent binary the way a fresh, image-created container
+does, so only `container.exec` (executing inside an existing container) is
+supported. A `provider: opencode` step with `managed: true` fails with
+`harness: managed OpenCode is not supported inside containers`, since the
+managed execution path depends on a Dagu-hosted session a containerized
+step has no access to.
 
 ### Fallback
 
@@ -150,6 +180,15 @@ exists on disk or in `PATH` -- that is deferred to run time.
   process's own real exit code, and its own stdout/stderr are captured as
   usual -- this is a real process failure, not a wrapper-level validation
   error.
+- A containerized step (`container:` set) whose provider's `prompt_mode` is
+  `stdin`, whose `container.name` is set (image mode), or whose
+  `provider: opencode` step sets `managed: true`: each fails as described
+  above in Containerized execution, before any container daemon is
+  contacted.
+- A containerized step whose configured container daemon cannot be reached
+  (wrong socket, daemon not running): the step fails with `harness: failed
+  to initialize container client: ...`, proving the containerized path
+  genuinely attempts to dispatch to a daemon.
 
 ## Related Specs
 

--- a/specs/067-harness.md
+++ b/specs/067-harness.md
@@ -106,25 +106,17 @@ array value repeats `flag value` once per element.
 
 ### Containerized execution
 
-A step-level `container:` block runs the resolved provider's binary inside a
-container (via Dagu's own Moby SDK client; no `docker`/`podman` CLI
-subprocess is involved), with the agent binary as the container's
-entrypoint. This is resolved only once the step actually runs, after the
-provider is known, so `dagu validate` accepts a harness step with
-`container:` regardless of the provider's configuration -- the checks below
-are all runtime-only.
+A step-level `container:` block runs the resolved provider's binary inside
+an image-created container, using that binary as its entrypoint.
+`dagu validate` checks the general harness configuration. The following
+container-specific restrictions are checked at runtime:
 
-A provider whose `prompt_mode` is `stdin` has no way to deliver the prompt
-inside a container (the SDK's `Client.Run` has no stdin), so it fails with
-`harness: containerized harness does not support stdin input`.
-`container.name` (targeting an already-running container by name) is
-rejected for a harness step -- an image-mode container has no ENTRYPOINT to
-override with the agent binary the way a fresh, image-created container
-does, so only `container.exec` (executing inside an existing container) is
-supported. A `provider: opencode` step with `managed: true` fails with
-`harness: managed OpenCode is not supported inside containers`, since the
-managed execution path depends on a Dagu-hosted session a containerized
-step has no access to.
+- `prompt_mode: stdin` fails with `harness: containerized harness does not
+  support stdin input`.
+- `container.name` is rejected for image-mode harness steps. Running inside
+  an existing container uses `container.exec`.
+- `provider: opencode` with `managed: true` fails with `harness: managed
+  OpenCode is not supported inside containers`.
 
 ### Fallback
 
@@ -187,8 +179,7 @@ exists on disk or in `PATH` -- that is deferred to run time.
   contacted.
 - A containerized step whose configured container daemon cannot be reached
   (wrong socket, daemon not running): the step fails with `harness: failed
-  to initialize container client: ...`, proving the containerized path
-  genuinely attempts to dispatch to a daemon.
+  to initialize container client: ...`.
 
 ## Related Specs
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -67,6 +67,9 @@ It must not be treated as product behavior until implementation catches up.
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
 | [067: Harness Executor](067-harness.md) | Partially implemented |
+| [068: State Executor](068-state.md) | Implemented |
+| [069: Secrets Providers](069-secrets-providers.md) | Partially implemented |
+| [070: Runtime Profiles](070-runtime-profiles.md) | Partially implemented |
 
 **Writing guidelines:**
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,7 +66,7 @@ It must not be treated as product behavior until implementation catches up.
 | [061: Python Script Action](061-python-script.md) | Partially implemented |
 | [062: dbt Action](062-dbt.md) | Partially implemented |
 | [063: Schedule Descriptors](063-schedule.md) | Implemented |
-| [067: Harness Executor](067-harness.md) | Implemented |
+| [067: Harness Executor](067-harness.md) | Partially implemented |
 
 **Writing guidelines:**
 


### PR DESCRIPTION
Extend harness conformance with container configuration and unavailable-daemon errors. No container daemon, image download, or agent service is required.

Consolidate the new specification-index entries here to avoid conflicts between independent test additions. Merge after #2729, #2731, and #2732.

Validation: the harness package passes with race detection; make fmt passes. CI must pass before merge.