### PR TITLE
feat(chart): add priorityClassName support

### DIFF
--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -178,12 +178,13 @@ jobs:
             --set deploymentMode=distributed \
             --set persistence.accessMode=ReadWriteMany \
             --set persistence.storageClass=nfs-client \
-            --set-string priorityClassName=dagu-global \
-            --set-string 'workerPools.general.priorityClassName=dagu-worker-high' \
+            --set-string priorityClassName=true \
+            --set-string 'workerPools.general.priorityClassName=null' \
             >/tmp/dagu-priority-render.yaml
 
-          test "$(grep -Fc 'priorityClassName: dagu-global' /tmp/dagu-priority-render.yaml)" -eq 3
-          grep -Fq 'priorityClassName: dagu-worker-high' /tmp/dagu-priority-render.yaml
+          # Class names that resemble YAML literals must remain strings.
+          test "$(grep -Fc 'priorityClassName: "true"' /tmp/dagu-priority-render.yaml)" -eq 3
+          grep -Fq 'priorityClassName: "null"' /tmp/dagu-priority-render.yaml
 
       - name: Smoke-render optional configurations
         run: |

--- a/.github/workflows/chart-ci.yaml
+++ b/.github/workflows/chart-ci.yaml
@@ -172,6 +172,19 @@ jobs:
           grep -Fq 'maxUnavailable: 1' /tmp/dagu-coordinator-render.yaml
           grep -Fq 'maxSurge: 0' /tmp/dagu-coordinator-render.yaml
 
+          helm template dagu ./charts/dagu \
+            --namespace dagu \
+            --kube-version 1.35.0 \
+            --set deploymentMode=distributed \
+            --set persistence.accessMode=ReadWriteMany \
+            --set persistence.storageClass=nfs-client \
+            --set-string priorityClassName=dagu-global \
+            --set-string 'workerPools.general.priorityClassName=dagu-worker-high' \
+            >/tmp/dagu-priority-render.yaml
+
+          test "$(grep -Fc 'priorityClassName: dagu-global' /tmp/dagu-priority-render.yaml)" -eq 3
+          grep -Fq 'priorityClassName: dagu-worker-high' /tmp/dagu-priority-render.yaml
+
       - name: Smoke-render optional configurations
         run: |
           helm template dagu ./charts/dagu \

--- a/charts/dagu/Chart.yaml
+++ b/charts/dagu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dagu
 description: A compact, self-contained workflow engine with a web UI
 type: application
-version: 2.0.3
+version: 2.0.4
 appVersion: "2.11.1"
 kubeVersion: ">=1.19.0-0"
 home: https://dagu.sh

--- a/charts/dagu/README.md
+++ b/charts/dagu/README.md
@@ -507,7 +507,7 @@ workerPools:
         ephemeral-storage: "2Gi"
 ```
 
-Use `nodeSelector`, `tolerations`, and `affinity` for scheduling all Dagu pods. Non-empty scheduling values on a worker pool override the corresponding global value for that pool. `imagePullSecrets` and `podAnnotations` are also applied to every Dagu pod.
+Use `nodeSelector`, `tolerations`, `affinity`, and `priorityClassName` for scheduling all Dagu pods. Non-empty scheduling values on a worker pool override the corresponding global value for that pool. `priorityClassName` names an existing PriorityClass; the chart does not create it. `imagePullSecrets` and `podAnnotations` are also applied to every Dagu pod.
 
 `worker.maxActiveRuns` controls the maximum concurrent runs handled by each distributed worker process.
 

--- a/charts/dagu/templates/coordinator-deployment.yaml
+++ b/charts/dagu/templates/coordinator-deployment.yaml
@@ -104,7 +104,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
         - name: data

--- a/charts/dagu/templates/coordinator-deployment.yaml
+++ b/charts/dagu/templates/coordinator-deployment.yaml
@@ -103,6 +103,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/dagu/templates/scheduler-deployment.yaml
+++ b/charts/dagu/templates/scheduler-deployment.yaml
@@ -90,6 +90,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/dagu/templates/scheduler-deployment.yaml
+++ b/charts/dagu/templates/scheduler-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
         - name: data

--- a/charts/dagu/templates/ui-deployment.yaml
+++ b/charts/dagu/templates/ui-deployment.yaml
@@ -132,7 +132,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
         - name: data

--- a/charts/dagu/templates/ui-deployment.yaml
+++ b/charts/dagu/templates/ui-deployment.yaml
@@ -131,6 +131,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/dagu/templates/worker-deployment.yaml
+++ b/charts/dagu/templates/worker-deployment.yaml
@@ -5,6 +5,7 @@
 {{- $nodeSelector := default $.Values.nodeSelector $pool.nodeSelector }}
 {{- $tolerations := default $.Values.tolerations $pool.tolerations }}
 {{- $affinity := default $.Values.affinity $pool.affinity }}
+{{- $priorityClassName := default $.Values.priorityClassName $pool.priorityClassName }}
 {{- $podAnnotations := deepCopy $.Values.podAnnotations }}
 {{- $_ := set $podAnnotations "checksum/config" (include "dagu.distributedConfigChecksum" $) }}
 {{- if $.Values.serviceAccount.create }}
@@ -117,6 +118,9 @@ spec:
       {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       volumes:
         - name: data

--- a/charts/dagu/templates/worker-deployment.yaml
+++ b/charts/dagu/templates/worker-deployment.yaml
@@ -120,7 +120,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       volumes:
         - name: data

--- a/charts/dagu/values.schema.json
+++ b/charts/dagu/values.schema.json
@@ -38,6 +38,9 @@
       "type": "object",
       "additionalProperties": true
     },
+    "priorityClassName": {
+      "type": "string"
+    },
     "volumeName": {
       "type": "string",
       "minLength": 1,
@@ -147,6 +150,9 @@
     },
     "affinity": {
       "$ref": "#/definitions/affinity"
+    },
+    "priorityClassName": {
+      "$ref": "#/definitions/priorityClassName"
     },
     "extraVolumes": {
       "type": "array",
@@ -377,6 +383,9 @@
           },
           "affinity": {
             "$ref": "#/definitions/affinity"
+          },
+          "priorityClassName": {
+            "$ref": "#/definitions/priorityClassName"
           }
         },
         "required": ["replicas"]

--- a/charts/dagu/values.yaml
+++ b/charts/dagu/values.yaml
@@ -33,6 +33,7 @@ podAnnotations: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+priorityClassName: ""
 
 # Additional Kubernetes volumes and mounts applied to every Dagu container.
 # Use these for file-backed configuration such as custom CA certificates,
@@ -126,6 +127,7 @@ workerPools:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    priorityClassName: ""
 
 # Server and UI configuration. In standalone mode this configures the combined
 # start-all pod and replicas must remain 1.


### PR DESCRIPTION
## Summary

Add a `priorityClassName` to the chart so the pods can reference a PriorityClass instead of always running at the default priority. Wired up like `nodeSelector`/`tolerations`/`affinity`, with a per worker pool override.

## Changes

Add top-level `priorityClassName` value, empty by default  
Add per-pool `workerPools.<pool>.priorityClassName` override  
Render it into the ui, scheduler, coordinator and worker deployments  
Document it in the chart README and add a chart CI render assertion

## Related Issues

Closes #2736

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `priorityClassName` support to the Dagu Helm chart so pods can use a configured PriorityClass. The value is empty by default, so existing installs are unaffected. Names are quoted so values that look like YAML literals (`true`, `null`) render as strings.

- Adds a global `priorityClassName` value and a per-pool `workerPools.<pool>.priorityClassName` override.
- Applies to ui, scheduler, coordinator, and worker deployments; per-pool overrides win for workers.
- Does not create the PriorityClass; it must already exist in the cluster.
- Updates the values schema, README, chart version, and chart CI render check to cover literal-like class names.

<sup>Written for commit 7432e53fcf263ac31f360002ea16fcf1924f54ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Helm chart support for configuring Kubernetes `priorityClassName` across Dagu components.
  - Apply a global priority class to pods, with optional overrides for individual worker pools.
  - Added configuration validation for global and worker-pool priority class settings.

- **Documentation**
  - Updated scheduling guidance to document `priorityClassName` and note that the referenced Kubernetes PriorityClass must already exist.

- **Chores**
  - Updated the Helm chart version to 2.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->