### PR TITLE
tools/aqua: serialize standard registry cache refreshes

### DIFF
--- a/internal/tools/aqua/registryref.go
+++ b/internal/tools/aqua/registryref.go
@@ -37,6 +37,11 @@ type latestRegistryRef struct {
 	FetchedAt time.Time `json:"fetchedAt"`
 }
 
+type latestRefCacheEntry struct {
+	latestRegistryRef
+	FailedAt time.Time `json:"failedAt,omitzero"`
+}
+
 type registryRefSource int
 
 const (
@@ -57,7 +62,9 @@ type resolvedRegistryRef struct {
 // previously cached ref of any age is used, then the compiled-in bootstrap
 // ref, so resolution never fails.
 func (i *Installer) resolveStandardRegistryRef(ctx context.Context, opts tools.InstallOptions, forceRefresh bool) resolvedRegistryRef {
+	startedAt := i.now()
 	cachePath := i.latestRefCachePath(opts)
+	cacheLockHeld := false
 	if !forceRefresh {
 		if cached, ok := readLatestRefCache(cachePath, i.now()); ok {
 			return resolvedRegistryRef{cached, registryRefSourceCache}
@@ -74,12 +81,18 @@ func (i *Installer) resolveStandardRegistryRef(ctx context.Context, opts tools.I
 			// resolution when the registry itself is reachable.
 			i.logger.Debug("lock aqua latest registry cache", "err", err)
 		} else {
+			cacheLockHeld = true
 			defer unlock()
 			// Another installer or process may have populated the shared cache
 			// while this caller waited. Explicit refreshes still bypass it.
 			if !forceRefresh {
 				if cached, ok := readLatestRefCache(cachePath, i.now()); ok {
 					return resolvedRegistryRef{cached, registryRefSourceCache}
+				}
+				if registryRefFailedSince(cachePath, startedAt, i.now()) {
+					// Share a failed attempt that completed after this call began.
+					// Later independent callers can retry immediately.
+					return i.fallbackRegistryRef(ctx, cachePath, fmt.Errorf("concurrent aqua registry resolution failed"))
 				}
 			}
 		}
@@ -89,6 +102,10 @@ func (i *Installer) resolveStandardRegistryRef(ctx context.Context, opts tools.I
 	if err == nil {
 		i.writeLatestRefCache(cachePath, ref)
 		return resolvedRegistryRef{ref, registryRefSourceLive}
+	}
+	if cacheLockHeld {
+		cached, _ := readLatestRefCacheAnyAge(cachePath)
+		i.writeLatestRefCacheEntry(cachePath, latestRefCacheEntry{latestRegistryRef: cached, FailedAt: i.now()})
 	}
 	return i.fallbackRegistryRef(ctx, cachePath, err)
 }
@@ -180,11 +197,24 @@ func readLatestRefCacheAnyAge(path string) (latestRegistryRef, bool) {
 	return cached, true
 }
 
+func registryRefFailedSince(path string, startedAt, now time.Time) bool {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return false
+	}
+	var entry latestRefCacheEntry
+	return json.Unmarshal(data, &entry) == nil && entry.FailedAt.After(startedAt) && !entry.FailedAt.After(now)
+}
+
 func (i *Installer) writeLatestRefCache(path string, ref latestRegistryRef) {
+	i.writeLatestRefCacheEntry(path, latestRefCacheEntry{latestRegistryRef: ref})
+}
+
+func (i *Installer) writeLatestRefCacheEntry(path string, entry latestRefCacheEntry) {
 	if path == "" {
 		return
 	}
-	data, err := json.Marshal(ref)
+	data, err := json.Marshal(entry)
 	if err != nil {
 		return
 	}

--- a/internal/tools/aqua/registryref.go
+++ b/internal/tools/aqua/registryref.go
@@ -89,11 +89,11 @@ func (i *Installer) resolveStandardRegistryRef(ctx context.Context, opts tools.I
 				if cached, ok := readLatestRefCache(cachePath, i.now()); ok {
 					return resolvedRegistryRef{cached, registryRefSourceCache}
 				}
-				if registryRefFailedSince(cachePath, startedAt, i.now()) {
-					// Share a failed attempt that completed after this call began.
-					// Later independent callers can retry immediately.
-					return i.fallbackRegistryRef(ctx, cachePath, fmt.Errorf("concurrent aqua registry resolution failed"))
-				}
+			}
+			if registryRefFailedSince(cachePath, startedAt, i.now()) {
+				// Share a failed attempt that completed after this call began.
+				// Later independent callers can retry immediately.
+				return i.fallbackRegistryRef(ctx, cachePath, fmt.Errorf("concurrent aqua registry resolution failed"))
 			}
 		}
 	}

--- a/internal/tools/aqua/registryref.go
+++ b/internal/tools/aqua/registryref.go
@@ -15,9 +15,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/fileutil"
 	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
 	"github.com/dagucloud/dagu/v2/internal/ir"
 	"github.com/dagucloud/dagu/v2/internal/tools"
+	"github.com/gofrs/flock"
 )
 
 const (
@@ -62,12 +64,59 @@ func (i *Installer) resolveStandardRegistryRef(ctx context.Context, opts tools.I
 		}
 	}
 
+	if cachePath != "" {
+		unlock, err := i.lockRegistryRef(ctx, cachePath)
+		if err != nil {
+			if ctx.Err() != nil {
+				return i.fallbackRegistryRef(ctx, cachePath, err)
+			}
+			// Caching is best-effort; an unwritable cache must not prevent
+			// resolution when the registry itself is reachable.
+			i.logger.Debug("lock aqua latest registry cache", "err", err)
+		} else {
+			defer unlock()
+			// Another installer or process may have populated the shared cache
+			// while this caller waited. Explicit refreshes still bypass it.
+			if !forceRefresh {
+				if cached, ok := readLatestRefCache(cachePath, i.now()); ok {
+					return resolvedRegistryRef{cached, registryRefSourceCache}
+				}
+			}
+		}
+	}
+
 	ref, err := i.fetchLatestRegistryRef(ctx)
 	if err == nil {
 		i.writeLatestRefCache(cachePath, ref)
 		return resolvedRegistryRef{ref, registryRefSourceLive}
 	}
+	return i.fallbackRegistryRef(ctx, cachePath, err)
+}
 
+func (i *Installer) lockRegistryRef(ctx context.Context, cachePath string) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o750); err != nil {
+		return nil, err
+	}
+	// Keep the lock file separate from the atomically replaced cache. The OS
+	// releases it on process exit, so no stale-lock reclamation is needed.
+	lock := flock.New(cachePath + ".lock")
+	locked, err := lock.TryLockContext(ctx, lockRetryInterval)
+	if err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	if !locked {
+		_ = lock.Close()
+		return nil, fmt.Errorf("aqua registry cache lock was not acquired")
+	}
+	return func() {
+		if err := lock.Close(); err != nil {
+			i.logger.Debug("unlock aqua latest registry cache", "err", err)
+		}
+	}, nil
+}
+
+func (i *Installer) fallbackRegistryRef(ctx context.Context, cachePath string, err error) resolvedRegistryRef {
 	if cached, ok := readLatestRefCacheAnyAge(cachePath); ok {
 		logger.Info(ctx, "Using the cached aqua registry release; latest release resolution failed",
 			slog.String("registry", cached.Tag), slog.Any("err", err))
@@ -143,12 +192,7 @@ func (i *Installer) writeLatestRefCache(path string, ref latestRegistryRef) {
 		i.logger.Debug("write aqua latest registry cache", "err", err)
 		return
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		i.logger.Debug("write aqua latest registry cache", "err", err)
-		return
-	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := fileutil.WriteFileAtomic(path, data, 0o600); err != nil {
 		i.logger.Debug("write aqua latest registry cache", "err", err)
 	}
 }

--- a/internal/tools/aqua/registryref_test.go
+++ b/internal/tools/aqua/registryref_test.go
@@ -32,6 +32,7 @@ type registryRequestCounts struct {
 type registryTestServer struct {
 	url     string
 	calls   *registryRequestCounts
+	fail    *atomic.Bool
 	started <-chan struct{}
 	finish  func()
 }
@@ -41,6 +42,7 @@ type registryTestServer struct {
 func blockedRegistryServer(t *testing.T, callers int) *registryTestServer {
 	t.Helper()
 	var calls registryRequestCounts
+	var fail atomic.Bool
 	started := make(chan struct{})
 	allStarted := make(chan struct{})
 	release := make(chan struct{})
@@ -59,6 +61,10 @@ func blockedRegistryServer(t *testing.T, callers int) *registryTestServer {
 			select {
 			case <-release:
 			case <-r.Context().Done():
+				return
+			}
+			if fail.Load() {
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 			_, _ = w.Write([]byte(`{"tag_name":"v4.999.0"}`))
@@ -80,7 +86,7 @@ func blockedRegistryServer(t *testing.T, callers int) *registryTestServer {
 		}
 		unblock()
 	}
-	return &registryTestServer{url: server.URL, calls: &calls, started: started, finish: finish}
+	return &registryTestServer{url: server.URL, calls: &calls, fail: &fail, started: started, finish: finish}
 }
 
 func TestRegistryRefConcurrent(t *testing.T) {
@@ -111,10 +117,100 @@ func TestRegistryRefConcurrent(t *testing.T) {
 	assert.EqualValues(t, 1, server.calls.commits.Load(), "cold callers must share the commit lookup")
 }
 
+func TestRegistryRefFailedConcurrent(t *testing.T) {
+	t.Parallel()
+	for _, stale := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stale=%t", stale), func(t *testing.T) {
+			const callers = 8
+			server := blockedRegistryServer(t, callers)
+			server.fail.Store(true)
+			opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+			installer := New()
+			installer.githubAPIBase = server.url
+			wantSHA := ir.DefaultAquaStandardRegistryRef
+			wantSource := registryRefSourceBootstrap
+			if stale {
+				installer.writeLatestRefCache(installer.latestRefCachePath(opts), latestRegistryRef{
+					Tag: "v4.999.0", SHA: testLatestSHA, FetchedAt: time.Now().Add(-48 * time.Hour),
+				})
+				wantSHA, wantSource = testLatestSHA, registryRefSourceStaleCache
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			results := make(chan resolvedRegistryRef, callers)
+			started := make(chan struct{}, callers)
+			start := make(chan struct{})
+			for range callers {
+				go func() {
+					caller := New()
+					caller.githubAPIBase = server.url
+					var first sync.Once
+					caller.now = func() time.Time {
+						now := time.Now()
+						first.Do(func() {
+							started <- struct{}{}
+							<-start
+						})
+						return now
+					}
+					results <- caller.resolveStandardRegistryRef(ctx, opts, false)
+				}()
+			}
+			for range callers {
+				select {
+				case <-started:
+				case <-ctx.Done():
+					close(start)
+					t.Fatal(ctx.Err())
+				}
+			}
+			close(start)
+			select {
+			case <-server.started:
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			server.finish()
+			for range callers {
+				resolved := <-results
+				assert.Equal(t, wantSHA, resolved.SHA)
+				assert.Equal(t, wantSource, resolved.Source)
+			}
+			assert.EqualValues(t, 1, server.calls.releases.Load(), "waiters must share a failed lookup too")
+			assert.EqualValues(t, 0, server.calls.commits.Load())
+			_, fresh := readLatestRefCache(installer.latestRefCachePath(opts), time.Now())
+			assert.False(t, fresh, "a failed lookup must not make the registry cache fresh")
+
+			server.fail.Store(false)
+			resolved := installer.resolveStandardRegistryRef(ctx, opts, false)
+			assert.Equal(t, registryRefSourceLive, resolved.Source, "a later independent caller must be able to retry")
+			assert.Equal(t, testLatestSHA, resolved.SHA)
+			assert.EqualValues(t, 2, server.calls.releases.Load())
+			assert.EqualValues(t, 1, server.calls.commits.Load())
+		})
+	}
+}
+
 func TestRegistryRefProcesses(t *testing.T) {
 	t.Parallel()
+	server := blockedRegistryServer(t, 4)
+	resolveRegistryProcesses(t, server, testLatestSHA)
+	assert.EqualValues(t, 1, server.calls.releases.Load(), "processes sharing a tools directory must resolve once")
+	assert.EqualValues(t, 1, server.calls.commits.Load())
+}
+
+func TestRegistryRefFailedProcesses(t *testing.T) {
+	t.Parallel()
+	server := blockedRegistryServer(t, 4)
+	server.fail.Store(true)
+	resolveRegistryProcesses(t, server, ir.DefaultAquaStandardRegistryRef)
+	assert.EqualValues(t, 1, server.calls.releases.Load(), "waiting processes must share a failed lookup")
+	assert.EqualValues(t, 0, server.calls.commits.Load())
+}
+
+func resolveRegistryProcesses(t *testing.T, server *registryTestServer, expectedSHA string) {
+	t.Helper()
 	const callers = 4
-	server := blockedRegistryServer(t, callers)
 	dir := t.TempDir()
 	start := filepath.Join(dir, "start")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -123,7 +219,7 @@ func TestRegistryRefProcesses(t *testing.T) {
 	for n := range callers {
 		ready := filepath.Join(dir, fmt.Sprintf("ready-%d", n))
 		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRegistryRefProcessHelper$", "--", server.url, dir, ready, start)
-		cmd.Env = append(os.Environ(), "DAGU_TEST_REGISTRY_HELPER=1", "GITHUB_TOKEN=", "GH_TOKEN=")
+		cmd.Env = append(os.Environ(), "DAGU_TEST_REGISTRY_HELPER=1", "DAGU_TEST_REGISTRY_EXPECTED_SHA="+expectedSHA, "GITHUB_TOKEN=", "GH_TOKEN=")
 		go func() {
 			output, err := cmd.CombinedOutput()
 			if err != nil {
@@ -150,8 +246,6 @@ func TestRegistryRefProcesses(t *testing.T) {
 	for range callers {
 		require.NoError(t, <-results)
 	}
-	assert.EqualValues(t, 1, server.calls.releases.Load(), "processes sharing a tools directory must resolve once")
-	assert.EqualValues(t, 1, server.calls.commits.Load())
 }
 
 func TestRegistryRefWaitCanceled(t *testing.T) {
@@ -196,6 +290,53 @@ func TestRegistryRefCacheUnavailable(t *testing.T) {
 	assert.Equal(t, 2, calls, "cache failure must not disable live resolution")
 }
 
+func TestRegistryRefCacheWriteUnavailable(t *testing.T) {
+	t.Parallel()
+	const callers = 4
+	server := blockedRegistryServer(t, callers)
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	require.NoError(t, os.MkdirAll(New().latestRefCachePath(opts), 0o750))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	results := make(chan resolvedRegistryRef, callers)
+	for range callers {
+		go func() {
+			installer := New()
+			installer.githubAPIBase = server.url
+			results <- installer.resolveStandardRegistryRef(ctx, opts, false)
+		}()
+	}
+	select {
+	case <-server.started:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	server.finish()
+	for range callers {
+		resolved := <-results
+		assert.Equal(t, registryRefSourceLive, resolved.Source)
+		assert.Equal(t, testLatestSHA, resolved.SHA)
+	}
+	assert.EqualValues(t, callers, server.calls.releases.Load(), "cache write failure must not become a registry failure")
+	assert.EqualValues(t, callers, server.calls.commits.Load())
+}
+
+func TestRegistryRefFutureFailure(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	server := newLatestRefServer(t, &calls)
+	installer := New()
+	installer.githubAPIBase = server.URL
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	installer.writeLatestRefCacheEntry(installer.latestRefCachePath(opts), latestRefCacheEntry{
+		FailedAt: time.Now().Add(time.Hour),
+	})
+	resolved := installer.resolveStandardRegistryRef(context.Background(), opts, false)
+	assert.Equal(t, registryRefSourceLive, resolved.Source)
+	assert.Equal(t, testLatestSHA, resolved.SHA)
+	assert.Equal(t, 2, calls, "a clock change must not suppress independent retries")
+}
+
 func TestRegistryRefLockUnavailable(t *testing.T) {
 	t.Parallel()
 	calls := 0
@@ -212,6 +353,35 @@ func TestRegistryRefLockUnavailable(t *testing.T) {
 	cached, ok := readLatestRefCache(cachePath, time.Now())
 	assert.True(t, ok, "a failed lock must not disable a writable cache")
 	assert.Equal(t, testLatestSHA, cached.SHA)
+}
+
+func TestRegistryRefFailureWithoutLock(t *testing.T) {
+	t.Parallel()
+	server := newFailingRefServer(t)
+	installer := New()
+	installer.githubAPIBase = server.URL
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	cachePath := installer.latestRefCachePath(opts)
+	installer.writeLatestRefCache(cachePath, latestRegistryRef{
+		Tag: "v4.999.0", SHA: testLatestSHA, FetchedAt: time.Now().Add(-48 * time.Hour),
+	})
+	before, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	// A directory can itself be flocked on Unix. A symlink loop makes opening
+	// the lock fail without making the registry cache unwritable.
+	if err := os.Symlink(cachePath+".lock", cachePath+".lock"); err != nil {
+		t.Skipf("cannot create a symlink loop on this platform: %v", err)
+	}
+	unlock, lockErr := installer.lockRegistryRef(context.Background(), cachePath)
+	if unlock != nil {
+		unlock()
+	}
+	require.Error(t, lockErr)
+	resolved := installer.resolveStandardRegistryRef(context.Background(), opts, false)
+	assert.Equal(t, registryRefSourceStaleCache, resolved.Source)
+	after, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "an unlocked failure must not overwrite another caller's cache")
 }
 
 func TestRegistryRefOwnerExit(t *testing.T) {
@@ -260,14 +430,25 @@ func TestRegistryRefProcessHelper(t *testing.T) {
 		<-ctx.Done()
 		return
 	}
-	require.NoError(t, os.WriteFile(args[2], nil, 0o600))
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(args[3])
-		return err == nil
-	}, 10*time.Second, 10*time.Millisecond)
+	var first sync.Once
+	installer.now = func() time.Time {
+		now := time.Now()
+		first.Do(func() {
+			require.NoError(t, os.WriteFile(args[2], nil, 0o600))
+			require.Eventually(t, func() bool {
+				_, err := os.Stat(args[3])
+				return err == nil
+			}, 10*time.Second, 10*time.Millisecond)
+		})
+		return now
+	}
 	installer.githubAPIBase = args[0]
 	resolved := installer.resolveStandardRegistryRef(ctx, opts, false)
-	require.Equal(t, testLatestSHA, resolved.SHA)
+	expectedSHA := os.Getenv("DAGU_TEST_REGISTRY_EXPECTED_SHA")
+	if expectedSHA == "" {
+		expectedSHA = testLatestSHA
+	}
+	require.Equal(t, expectedSHA, resolved.SHA)
 }
 
 func newLatestRefServer(t *testing.T, calls *int) *httptest.Server {

--- a/internal/tools/aqua/registryref_test.go
+++ b/internal/tools/aqua/registryref_test.go
@@ -119,8 +119,16 @@ func TestRegistryRefConcurrent(t *testing.T) {
 
 func TestRegistryRefFailedConcurrent(t *testing.T) {
 	t.Parallel()
-	for _, stale := range []bool{false, true} {
-		t.Run(fmt.Sprintf("stale=%t", stale), func(t *testing.T) {
+	for _, tc := range []struct {
+		stale        bool
+		forceRefresh bool
+	}{
+		{},
+		{stale: true},
+		{forceRefresh: true},
+		{stale: true, forceRefresh: true},
+	} {
+		t.Run(fmt.Sprintf("stale=%t/force=%t", tc.stale, tc.forceRefresh), func(t *testing.T) {
 			const callers = 8
 			server := blockedRegistryServer(t, callers)
 			server.fail.Store(true)
@@ -129,7 +137,7 @@ func TestRegistryRefFailedConcurrent(t *testing.T) {
 			installer.githubAPIBase = server.url
 			wantSHA := ir.DefaultAquaStandardRegistryRef
 			wantSource := registryRefSourceBootstrap
-			if stale {
+			if tc.stale {
 				installer.writeLatestRefCache(installer.latestRefCachePath(opts), latestRegistryRef{
 					Tag: "v4.999.0", SHA: testLatestSHA, FetchedAt: time.Now().Add(-48 * time.Hour),
 				})
@@ -153,7 +161,7 @@ func TestRegistryRefFailedConcurrent(t *testing.T) {
 						})
 						return now
 					}
-					results <- caller.resolveStandardRegistryRef(ctx, opts, false)
+					results <- caller.resolveStandardRegistryRef(ctx, opts, tc.forceRefresh)
 				}()
 			}
 			for range callers {
@@ -182,7 +190,7 @@ func TestRegistryRefFailedConcurrent(t *testing.T) {
 			assert.False(t, fresh, "a failed lookup must not make the registry cache fresh")
 
 			server.fail.Store(false)
-			resolved := installer.resolveStandardRegistryRef(ctx, opts, false)
+			resolved := installer.resolveStandardRegistryRef(ctx, opts, tc.forceRefresh)
 			assert.Equal(t, registryRefSourceLive, resolved.Source, "a later independent caller must be able to retry")
 			assert.Equal(t, testLatestSHA, resolved.SHA)
 			assert.EqualValues(t, 2, server.calls.releases.Load())

--- a/internal/tools/aqua/registryref_test.go
+++ b/internal/tools/aqua/registryref_test.go
@@ -300,11 +300,16 @@ func TestRegistryRefCacheUnavailable(t *testing.T) {
 
 func TestRegistryRefCacheWriteUnavailable(t *testing.T) {
 	t.Parallel()
-	const callers = 4
+	const (
+		callers        = 4
+		resolveTimeout = 30 * time.Second
+	)
 	server := blockedRegistryServer(t, callers)
 	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
 	require.NoError(t, os.MkdirAll(New().latestRefCachePath(opts), 0o750))
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Windows retries each failed replacement while holding the cache lock.
+	// Allow every caller to exhaust those retries before the test deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeout)
 	defer cancel()
 	results := make(chan resolvedRegistryRef, callers)
 	for range callers {

--- a/internal/tools/aqua/registryref_test.go
+++ b/internal/tools/aqua/registryref_test.go
@@ -5,10 +5,14 @@ package aqua
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +23,252 @@ import (
 )
 
 const testLatestSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type registryRequestCounts struct {
+	releases atomic.Int32
+	commits  atomic.Int32
+}
+
+type registryTestServer struct {
+	url     string
+	calls   *registryRequestCounts
+	started <-chan struct{}
+	finish  func()
+}
+
+// Hold the cold response until callers overlap, without making the test depend
+// on the resolver's synchronization implementation.
+func blockedRegistryServer(t *testing.T, callers int) *registryTestServer {
+	t.Helper()
+	var calls registryRequestCounts
+	started := make(chan struct{})
+	allStarted := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/aquaproj/aqua-registry/releases/latest":
+			n := calls.releases.Add(1)
+			if n == 1 {
+				close(started)
+			}
+			if n == int32(callers) {
+				close(allStarted)
+			}
+			select {
+			case <-release:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = w.Write([]byte(`{"tag_name":"v4.999.0"}`))
+		case "/repos/aquaproj/aqua-registry/commits/v4.999.0":
+			calls.commits.Add(1)
+			_, _ = w.Write([]byte(testLatestSHA))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(func() {
+		unblock()
+		server.Close()
+	})
+	finish := func() {
+		select {
+		case <-allStarted:
+		case <-time.After(250 * time.Millisecond):
+		}
+		unblock()
+	}
+	return &registryTestServer{url: server.URL, calls: &calls, started: started, finish: finish}
+}
+
+func TestRegistryRefConcurrent(t *testing.T) {
+	t.Parallel()
+	const callers = 8
+	server := blockedRegistryServer(t, callers)
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	results := make(chan resolvedRegistryRef, callers)
+	for range callers {
+		go func() {
+			installer := New()
+			installer.githubAPIBase = server.url
+			results <- installer.resolveStandardRegistryRef(ctx, opts, false)
+		}()
+	}
+	select {
+	case <-server.started:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	server.finish()
+	for range callers {
+		assert.Equal(t, testLatestSHA, (<-results).SHA)
+	}
+	assert.EqualValues(t, 1, server.calls.releases.Load(), "cold callers must share the release lookup")
+	assert.EqualValues(t, 1, server.calls.commits.Load(), "cold callers must share the commit lookup")
+}
+
+func TestRegistryRefProcesses(t *testing.T) {
+	t.Parallel()
+	const callers = 4
+	server := blockedRegistryServer(t, callers)
+	dir := t.TempDir()
+	start := filepath.Join(dir, "start")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	results := make(chan error, callers)
+	for n := range callers {
+		ready := filepath.Join(dir, fmt.Sprintf("ready-%d", n))
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRegistryRefProcessHelper$", "--", server.url, dir, ready, start)
+		cmd.Env = append(os.Environ(), "DAGU_TEST_REGISTRY_HELPER=1", "GITHUB_TOKEN=", "GH_TOKEN=")
+		go func() {
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				err = fmt.Errorf("registry helper: %w: %s", err, output)
+			}
+			results <- err
+		}()
+	}
+	require.Eventually(t, func() bool {
+		for n := range callers {
+			if _, err := os.Stat(filepath.Join(dir, fmt.Sprintf("ready-%d", n))); err != nil {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 10*time.Millisecond)
+	require.NoError(t, os.WriteFile(start, nil, 0o600))
+	select {
+	case <-server.started:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	server.finish()
+	for range callers {
+		require.NoError(t, <-results)
+	}
+	assert.EqualValues(t, 1, server.calls.releases.Load(), "processes sharing a tools directory must resolve once")
+	assert.EqualValues(t, 1, server.calls.commits.Load())
+}
+
+func TestRegistryRefWaitCanceled(t *testing.T) {
+	t.Parallel()
+	server := blockedRegistryServer(t, 2)
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	installer := New()
+	installer.githubAPIBase = server.url
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	first := make(chan resolvedRegistryRef, 1)
+	go func() { first <- installer.resolveStandardRegistryRef(ctx, opts, false) }()
+	select {
+	case <-server.started:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	waiter := New()
+	waiter.githubAPIBase = server.url
+	waitCtx, stopWaiting := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer stopWaiting()
+	resolved := waiter.resolveStandardRegistryRef(waitCtx, opts, false)
+	require.ErrorIs(t, waitCtx.Err(), context.DeadlineExceeded)
+	assert.Equal(t, registryRefSourceBootstrap, resolved.Source)
+	assert.EqualValues(t, 1, server.calls.releases.Load(), "a canceled waiter must not start another fetch")
+	server.finish()
+	assert.Equal(t, testLatestSHA, (<-first).SHA, "canceling a waiter must not cancel the owner")
+	assert.Equal(t, registryRefSourceCache, waiter.resolveStandardRegistryRef(ctx, opts, false).Source)
+}
+
+func TestRegistryRefCacheUnavailable(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	server := newLatestRefServer(t, &calls)
+	installer := New()
+	installer.githubAPIBase = server.URL
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o600))
+	resolved := installer.resolveStandardRegistryRef(context.Background(), tools.InstallOptions{ToolsDir: blocked}, false)
+	assert.Equal(t, registryRefSourceLive, resolved.Source)
+	assert.Equal(t, testLatestSHA, resolved.SHA)
+	assert.Equal(t, 2, calls, "cache failure must not disable live resolution")
+}
+
+func TestRegistryRefLockUnavailable(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	server := newLatestRefServer(t, &calls)
+	installer := New()
+	installer.githubAPIBase = server.URL
+	opts := tools.InstallOptions{ToolsDir: t.TempDir()}
+	cachePath := installer.latestRefCachePath(opts)
+	require.NoError(t, os.MkdirAll(cachePath+".lock", 0o750))
+	resolved := installer.resolveStandardRegistryRef(context.Background(), opts, false)
+	assert.Equal(t, registryRefSourceLive, resolved.Source)
+	assert.Equal(t, testLatestSHA, resolved.SHA)
+	assert.Equal(t, 2, calls)
+	cached, ok := readLatestRefCache(cachePath, time.Now())
+	assert.True(t, ok, "a failed lock must not disable a writable cache")
+	assert.Equal(t, testLatestSHA, cached.SHA)
+}
+
+func TestRegistryRefOwnerExit(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	server := newLatestRefServer(t, &calls)
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRegistryRefProcessHelper$", "--", "hold-lock", dir, ready, "unused")
+	cmd.Env = append(os.Environ(), "DAGU_TEST_REGISTRY_HELPER=1", "GITHUB_TOKEN=", "GH_TOKEN=")
+	require.NoError(t, cmd.Start())
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(ready)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond)
+	require.NoError(t, cmd.Process.Kill())
+	require.Error(t, <-done)
+	installer := New()
+	installer.githubAPIBase = server.URL
+	resolveCtx, stop := context.WithTimeout(ctx, 2*time.Second)
+	defer stop()
+	resolved := installer.resolveStandardRegistryRef(resolveCtx, tools.InstallOptions{ToolsDir: dir}, false)
+	assert.Equal(t, registryRefSourceLive, resolved.Source)
+	assert.Equal(t, testLatestSHA, resolved.SHA)
+	assert.Equal(t, 2, calls, "the next process must recover without a stale-lock delay")
+}
+
+func TestRegistryRefProcessHelper(t *testing.T) {
+	if os.Getenv("DAGU_TEST_REGISTRY_HELPER") != "1" {
+		return
+	}
+	args := os.Args[len(os.Args)-4:]
+	installer := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	opts := tools.InstallOptions{ToolsDir: args[1]}
+	if args[0] == "hold-lock" {
+		unlock, err := installer.lockRegistryRef(ctx, installer.latestRefCachePath(opts))
+		require.NoError(t, err)
+		defer unlock()
+		require.NoError(t, os.WriteFile(args[2], nil, 0o600))
+		<-ctx.Done()
+		return
+	}
+	require.NoError(t, os.WriteFile(args[2], nil, 0o600))
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(args[3])
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond)
+	installer.githubAPIBase = args[0]
+	resolved := installer.resolveStandardRegistryRef(ctx, opts, false)
+	require.Equal(t, testLatestSHA, resolved.SHA)
+}
 
 func newLatestRefServer(t *testing.T, calls *int) *httptest.Server {
 	t.Helper()


### PR DESCRIPTION
## Summary

Prevent concurrent installers sharing a tools directory from duplicating GitHub registry metadata requests on a cold cache.

## Changes

- Use the existing OS-backed file lock and recheck the cache after acquiring it.
- Write cache contents atomically; preserve explicit refresh and fallback behavior.
- Add concurrent installer, cross-process, cancellation, unavailable-cache/lock and process-exit regression coverage.

Validation on macOS with Go 1.27:
- Affected package tests with race detection and repository lint passed (including Windows lint).
- Real CLI cold/warm runs installed and executed jq successfully; the warm run reused the registry cache.
- An earlier patch's full suite had one cancellation-test failure. Baseline and final-patch isolated reruns each passed 10 times; the original failure remains unexplained. The final patch's full suite was not rerun. Three opt-in Aqua network integration tests were skipped.

## Related Issues

Closes #2727

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (not applicable to this internal cache change)
- [x] Changes have been tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where concurrent installers sharing a tools directory would each fetch the aqua registry metadata on a cold cache, duplicating network requests. Now installers take an OS-backed file lock, recheck the cache after acquiring it, and share a failed fetch with concurrent waiters, so only one process performs the lookup.

- Writes cache contents atomically and preserves explicit refresh and fallback behavior.
- Timestamps failed lookups so waiters, including forced refreshes, reuse a shared failure instead of retrying.
- Keeps the lock file separate from the cache, so the OS releases it on process exit without stale-lock reclamation.
- Adds regression tests for concurrent installers, cross-process sharing, cancellation, unavailable cache/lock, and process-exit scenarios.

Closes #2727.

<sup>Written for commit e5b16238c1d44867c071ea53f3e277315c36d74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple installations access the registry cache at the same time.
  * Prevented duplicate registry lookups during concurrent operations.
  * Added recovery when a previous process exits unexpectedly while holding the cache lock.
  * Preserved fallback behavior when the cache or lock is unavailable.
  * Improved safe writing of updated registry cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->