### PR TITLE
Resolve strict step-output references for every publishing mechanism

### DIFF
--- a/conformance/spec007_value_resolution_steps/testdata/object_output_publishes_step_outputs.yaml
+++ b/conformance/spec007_value_resolution_steps/testdata/object_output_publishes_step_outputs.yaml
@@ -1,0 +1,14 @@
+working_dir: .
+steps:
+  - id: build
+    run: printf '{"image":"object-v1"}'
+    output:
+      image:
+        from: stdout
+        decode: json
+        select: .image
+
+  - id: deploy
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.image}' > object-output.txt

--- a/conformance/spec007_value_resolution_steps/testdata/output_schema_publishes_step_outputs.yaml
+++ b/conformance/spec007_value_resolution_steps/testdata/output_schema_publishes_step_outputs.yaml
@@ -1,0 +1,16 @@
+working_dir: .
+steps:
+  - id: build
+    output_schema:
+      type: object
+      additionalProperties: false
+      required: [image]
+      properties:
+        image:
+          type: string
+    run: printf '{"image":"schema-v1"}'
+
+  - id: deploy
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.image}' > output-schema.txt

--- a/conformance/spec007_value_resolution_steps/testdata/outputs_write_publishes_step_outputs.yaml
+++ b/conformance/spec007_value_resolution_steps/testdata/outputs_write_publishes_step_outputs.yaml
@@ -1,0 +1,12 @@
+working_dir: .
+steps:
+  - id: build
+    action: outputs.write
+    with:
+      values:
+        image: write-v1
+
+  - id: deploy
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.image}' > outputs-write.txt

--- a/conformance/spec007_value_resolution_steps/testdata/runtime_notice_unresolved.yaml
+++ b/conformance/spec007_value_resolution_steps/testdata/runtime_notice_unresolved.yaml
@@ -1,0 +1,11 @@
+working_dir: .
+steps:
+  - id: build
+    run: printf 'image=v1.2.3\n' >> "$DAGU_OUTPUT_FILE"
+    outputs:
+      - name: image
+
+  - id: deploy
+    depends: build
+    run: |
+      printf '%s\n' '${steps.build.outputs.tag}' > runtime-notice.txt

--- a/conformance/spec007_value_resolution_steps/testdata/stdout_outputs_publish_step_outputs.yaml
+++ b/conformance/spec007_value_resolution_steps/testdata/stdout_outputs_publish_step_outputs.yaml
@@ -1,7 +1,7 @@
 working_dir: .
 steps:
   - id: build
-    run: printf '{"image":"legacy-v1"}'
+    run: printf '{"image":"published-v1"}'
     stdout:
       outputs:
         fields:
@@ -12,4 +12,4 @@ steps:
   - id: deploy
     depends: build
     run: |
-      printf '%s\n' '${steps.build.outputs.image}' > legacy-not-step-output.txt
+      printf '%s\n' '${steps.build.outputs.image}' > stdout-outputs.txt

--- a/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
+++ b/conformance/spec007_value_resolution_steps/value_resolution_steps_test.go
@@ -15,6 +15,10 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 	validCases := []string{
 		"valid_reference.yaml",
 		"quiet_unsupported_escaped.yaml",
+		"stdout_outputs_publish_step_outputs.yaml",
+		"output_schema_publishes_step_outputs.yaml",
+		"object_output_publishes_step_outputs.yaml",
+		"outputs_write_publishes_step_outputs.yaml",
 	}
 	for _, file := range validCases {
 		t.Run(file, func(t *testing.T) {
@@ -55,10 +59,6 @@ func TestValidateStepOutputReferenceNotices(t *testing.T) {
 		{
 			file:        "namespace_handler.yaml",
 			stderrParts: []string{"${steps.build.outputs.image}", "reason=namespace_unavailable", "handler_on.success.run"},
-		},
-		{
-			file:        "legacy_outputs_not_step_outputs.yaml",
-			stderrParts: []string{"${steps.build.outputs.image}", "reason=unknown_output_name", "steps[1].run"},
 		},
 	}
 	for _, tc := range noticeCases {
@@ -114,10 +114,28 @@ func TestRuntimeStepOutputReferenceResolution(t *testing.T) {
 			content: "${steps.build.outputs.image}\n",
 		},
 		{
-			name:    "legacy outputs are not spec 007 outputs",
-			file:    "legacy_outputs_not_step_outputs.yaml",
-			output:  "legacy-not-step-output.txt",
-			content: "${steps.build.outputs.image}\n",
+			name:    "stdout outputs publish step outputs",
+			file:    "stdout_outputs_publish_step_outputs.yaml",
+			output:  "stdout-outputs.txt",
+			content: "published-v1\n",
+		},
+		{
+			name:    "output schema publishes step outputs",
+			file:    "output_schema_publishes_step_outputs.yaml",
+			output:  "output-schema.txt",
+			content: "schema-v1\n",
+		},
+		{
+			name:    "object form output publishes step outputs",
+			file:    "object_output_publishes_step_outputs.yaml",
+			output:  "object-output.txt",
+			content: "object-v1\n",
+		},
+		{
+			name:    "outputs write publishes step outputs",
+			file:    "outputs_write_publishes_step_outputs.yaml",
+			output:  "outputs-write.txt",
+			content: "write-v1\n",
 		},
 		{
 			name:    "escaped and unsupported text is preserved",
@@ -136,4 +154,16 @@ func TestRuntimeStepOutputReferenceResolution(t *testing.T) {
 			dagu.ExpectFileContent(tc.output, tc.content)
 		})
 	}
+}
+
+// A preserved reference explains itself in the run log, so the failure a shell
+// reports later is traceable to the reference that never resolved.
+func TestRuntimeStepOutputReferenceNotice(t *testing.T) {
+	t.Parallel()
+
+	dagu := harness.NewRunner(t)
+	result := dagu.Run("start", "runtime_notice_unresolved.yaml")
+	result.ExpectExitCode(0)
+	result.ExpectStderrContains("${steps.build.outputs.tag}", "was left unchanged", "step=deploy")
+	dagu.ExpectFileContent("runtime-notice.txt", "${steps.build.outputs.tag}\n")
 }

--- a/conformance/spec014_step_run_command/step_run_command_test.go
+++ b/conformance/spec014_step_run_command/step_run_command_test.go
@@ -117,8 +117,8 @@ func TestCommandFormFailuresUnix(t *testing.T) {
 		dagu := harness.NewRunner(t)
 		result := dagu.Run("start", "array_outputs_failure.yaml")
 		result.ExpectExitCode(1)
-		result.ExpectStderrNotContains("value")
-		dagu.ExpectFileNotContains("array-output-failure.txt", "value")
+		result.ExpectStderrNotContains("leakedpayload")
+		dagu.ExpectFileNotContains("array-output-failure.txt", "leakedpayload")
 	})
 
 	t.Run("resolved command text with line break fails before shell starts", func(t *testing.T) {

--- a/conformance/spec014_step_run_command/testdata/array_outputs_failure.yaml
+++ b/conformance/spec014_step_run_command/testdata/array_outputs_failure.yaml
@@ -5,7 +5,7 @@ steps:
     outputs:
       - name: leaked
     run:
-      - printf 'leaked=value\n' >> "$DAGU_OUTPUT_FILE"
+      - printf 'leaked=leakedpayload\n' >> "$DAGU_OUTPUT_FILE"
       - false
   - id: consume
     depends: [produce]

--- a/conformance/spec033_build/build_test.go
+++ b/conformance/spec033_build/build_test.go
@@ -84,3 +84,22 @@ func TestBuildWorkflowRejectsDuplicateOutputProducers(t *testing.T) {
 	result.ExpectNonZeroExitCode()
 	result.ExpectStderrContains("multiple producers", "shared.txt")
 }
+
+// A build step may publish a materialized path alongside typed values captured
+// from its own output, so materialization must tolerate non-string entries.
+func TestBuildStepPublishesTypedCapturedOutputs(t *testing.T) {
+	dagu := harness.NewRunner(t)
+	dagu.Mkdir(".home")
+	dagu.Mkdir(".xdg")
+	env := []string{
+		"DAGU_HOME=" + dagu.ProjectPath(".dagu"),
+		"HOME=" + dagu.ProjectPath(".home"),
+		"XDG_CONFIG_HOME=" + dagu.ProjectPath(".xdg"),
+		"APPDATA=" + dagu.ProjectPath(".home"),
+		"USERPROFILE=" + dagu.ProjectPath(".home"),
+	}
+
+	result := dagu.RunWithEnv(env, "start", "typed-capture-output.yaml")
+	result.ExpectExitCode(0)
+	dagu.ExpectTextFileContent("typed-capture.txt", "3\n")
+}

--- a/conformance/spec033_build/testdata/typed-capture-output.yaml
+++ b/conformance/spec033_build/testdata/typed-capture-output.yaml
@@ -1,0 +1,27 @@
+type: build
+working_dir: .
+shell: [sh]
+
+steps:
+  - id: build
+    name: build
+    inputs:
+      - name: source
+        path: source.txt
+    outputs:
+      - name: artifact
+        path: artifact.txt
+    output_schema:
+      type: object
+      additionalProperties: false
+      required: [count]
+      properties:
+        count:
+          type: integer
+    script: |
+      printf 'built\n' > "${outputs.artifact}"
+      echo '{"count":3}'
+
+  - id: report
+    depends: build
+    run: printf '%s\n' '${steps.build.outputs.count}' > typed-capture.txt

--- a/conformance/spec050_outputs/outputs_test.go
+++ b/conformance/spec050_outputs/outputs_test.go
@@ -13,7 +13,7 @@ func TestOutputsWrite(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct{ file, want string }{
-		{"write_and_read.yaml", "greeting=hello count=3"},
+		{"write_and_read.yaml", "greeting=hello count=3 strict=hello"},
 		{"write_dynamic_value.yaml", "from-env"},
 		{"write_list_value.yaml", `["a","b"]`},
 	} {

--- a/conformance/spec050_outputs/testdata/write_and_read.yaml
+++ b/conformance/spec050_outputs/testdata/write_and_read.yaml
@@ -8,5 +8,5 @@ steps:
         count: 3
   - id: read
     depends: write
-    run: printf 'greeting=%s count=%s' "${write.outputs.greeting}" "${write.outputs.count}"
+    run: printf 'greeting=%s count=%s strict=%s' "${write.outputs.greeting}" "${write.outputs.count}" "${steps.write.outputs.greeting}"
     stdout: result.out

--- a/internal/ir/step.go
+++ b/internal/ir/step.go
@@ -504,6 +504,9 @@ const (
 
 	// ExecutorTypeAction is the executor type for external Dagu actions.
 	ExecutorTypeAction = "action"
+
+	// ExecutorTypeOutputs is the executor type for publishing named outputs.
+	ExecutorTypeOutputs = "outputs"
 )
 
 // RouterConfig contains routing configuration for router-type steps.

--- a/internal/ir/step.go
+++ b/internal/ir/step.go
@@ -138,6 +138,11 @@ const (
 
 	StepDeclaredOutputTypeString = "string"
 	StepDeclaredOutputTypeJSON   = "json"
+
+	// StepDeclaredOutputSourceCapture marks an output published from the step's
+	// captured output. An empty source means the step writes the value to
+	// DAGU_OUTPUT_FILE.
+	StepDeclaredOutputSourceCapture = "capture"
 )
 
 // StepOutputEntry defines one structured object-form output entry.
@@ -173,6 +178,9 @@ type StepOutputDeclaration struct {
 	Name string `json:"name"`
 	Type string `json:"type,omitempty"`
 	Path string `json:"path,omitempty"`
+	// Source names the channel that publishes the value. An empty source means
+	// the step writes the value to DAGU_OUTPUT_FILE.
+	Source string `json:"source,omitempty"`
 }
 
 // StepInputDeclaration defines one named regular-file input.
@@ -199,7 +207,7 @@ func (s Step) PathOutput() (StepOutputDeclaration, bool) {
 func (s Step) ValueOutputs() []StepOutputDeclaration {
 	outputs := make([]StepOutputDeclaration, 0, len(s.Outputs))
 	for _, output := range s.Outputs {
-		if output.Path == "" {
+		if output.Path == "" && output.Source == "" {
 			outputs = append(outputs, output)
 		}
 	}
@@ -474,6 +482,9 @@ type HumanTaskConfig struct {
 const (
 	// ExecutorTypeDAG is the executor type for a sub DAG.
 	ExecutorTypeDAG = "dag"
+
+	// ExecutorTypeSubworkflow is the legacy executor type name for a sub DAG.
+	ExecutorTypeSubworkflow = "subworkflow"
 
 	// ExecutorTypeDAGEnqueue is the executor type for asynchronously queueing a sub DAG.
 	ExecutorTypeDAGEnqueue = "dag_enqueue"

--- a/internal/runtime/build_execution.go
+++ b/internal/runtime/build_execution.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/runenv"
 
@@ -257,14 +256,18 @@ func publishBuildOutputs(ctx context.Context, node *Node, outputs map[string]str
 	if len(outputs) == 0 {
 		return nil
 	}
-	merged := make(map[string]string)
+	// Decode into any-valued entries because a step may also publish typed
+	// values from its captured output alongside these materialized paths.
+	merged := make(map[string]any, len(outputs))
 	if raw := node.State().StepOutputsValue; raw != nil && *raw != "" {
 		if err := json.Unmarshal([]byte(*raw), &merged); err != nil {
 			return fmt.Errorf("decode step outputs before publishing materialization: %w", err)
 		}
 	}
-	maps.Copy(merged, outputs)
-	serialized, err := serializeDeclaredStepOutputs(ctx, merged)
+	for name, path := range outputs {
+		merged[name] = path
+	}
+	serialized, err := serializeOutputsValue(ctx, merged)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/build_plan.go
+++ b/internal/runtime/build_plan.go
@@ -175,7 +175,12 @@ func validateBuildRedirectAliases(
 		redirects = append(redirects, buildRedirect{field: "stderr.artifact", path: step.StderrArtifact, artifact: true})
 	}
 
+	// A deferred alias may legitimately carry a reference that only resolves
+	// once the producing step has run, so it must not warn here.
 	resolver := resolverFromEnv(ctx, env)
+	if deferUnresolved {
+		resolver = resolverWithoutNotices(env)
+	}
 	for _, redirect := range redirects {
 		if redirect.path == "" {
 			continue

--- a/internal/runtime/build_plan.go
+++ b/internal/runtime/build_plan.go
@@ -36,7 +36,7 @@ func prepareBuildPlan(ctx context.Context, plan *Plan) error {
 		if err != nil {
 			return err
 		}
-		resolver := resolverFromEnv(env)
+		resolver := resolverFromEnv(ctx, env)
 		for idx := range step.Inputs {
 			resolved, err := resolver.String(ctx, step.Inputs[idx].Path, cmnvalue.WorkflowField(fmt.Sprintf("steps.%s.inputs.%s.path", step.Name, step.Inputs[idx].Name)))
 			if err != nil {
@@ -175,7 +175,7 @@ func validateBuildRedirectAliases(
 		redirects = append(redirects, buildRedirect{field: "stderr.artifact", path: step.StderrArtifact, artifact: true})
 	}
 
-	resolver := resolverFromEnv(env)
+	resolver := resolverFromEnv(ctx, env)
 	for _, redirect := range redirects {
 		if redirect.path == "" {
 			continue

--- a/internal/runtime/builtin/action/action.go
+++ b/internal/runtime/builtin/action/action.go
@@ -29,7 +29,7 @@ const (
 var _ runtimeexec.Executor = (*Executor)(nil)
 var _ runtimeexec.DAGExecutor = (*Executor)(nil)
 var _ runtimeexec.SubRunProvider = (*Executor)(nil)
-var _ runtimeexec.OutputsProvider = (*Executor)(nil)
+var _ runtimeexec.DeclaredOutputsProvider = (*Executor)(nil)
 
 type config struct {
 	Ref   string
@@ -303,6 +303,13 @@ func (e *Executor) setOutputs(outputs map[string]any) {
 	}
 	e.outputs = make(map[string]any, len(outputs))
 	maps.Copy(e.outputs, outputs)
+}
+
+// PublishesDeclaredOutputs exposes the action's published outputs to strict step
+// output references. The names come from the action manifest, which is resolved
+// during the run, so they are known only after the run.
+func (e *Executor) PublishesDeclaredOutputs() bool {
+	return true
 }
 
 func (e *Executor) GetOutputs() map[string]any {

--- a/internal/runtime/builtin/dag/dag.go
+++ b/internal/runtime/builtin/dag/dag.go
@@ -24,7 +24,7 @@ import (
 
 var _ executor.DAGExecutor = (*dagExecutor)(nil)
 var _ executor.NodeStatusDeterminer = (*dagExecutor)(nil)
-var _ executor.OutputsProvider = (*dagExecutor)(nil)
+var _ executor.DeclaredOutputsProvider = (*dagExecutor)(nil)
 
 type dagExecutor struct {
 	child     *executor.SubDAGExecutor
@@ -56,6 +56,13 @@ func (e *dagExecutor) setOutputs(outputs map[string]any) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	e.outputs = outputs
+}
+
+// PublishesDeclaredOutputs exposes the child run's published outputs to strict
+// step output references. The names come from the child DAG, so they are known
+// only after the run.
+func (e *dagExecutor) PublishesDeclaredOutputs() bool {
+	return true
 }
 
 // GetOutputs implements executor.OutputsProvider.
@@ -244,6 +251,6 @@ func init() {
 		SubDAG:         true,
 		WorkerSelector: true,
 	}
-	executor.RegisterExecutor("subworkflow", newDAGExecutor, nil, caps)
-	executor.RegisterExecutor("dag", newDAGExecutor, nil, caps)
+	executor.RegisterExecutor(ir.ExecutorTypeSubworkflow, newDAGExecutor, nil, caps)
+	executor.RegisterExecutor(ir.ExecutorTypeDAG, newDAGExecutor, nil, caps)
 }

--- a/internal/runtime/builtin/outputs/outputs.go
+++ b/internal/runtime/builtin/outputs/outputs.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	executorType = "outputs"
+	executorType = ir.ExecutorTypeOutputs
 	opWrite      = "write"
 )
 

--- a/internal/runtime/builtin/outputs/outputs.go
+++ b/internal/runtime/builtin/outputs/outputs.go
@@ -30,7 +30,7 @@ var (
 )
 
 var _ executor.Executor = (*executorImpl)(nil)
-var _ executor.OutputsProvider = (*executorImpl)(nil)
+var _ executor.DeclaredOutputsProvider = (*executorImpl)(nil)
 
 type executorImpl struct {
 	mu      sync.Mutex
@@ -140,6 +140,12 @@ func (e *executorImpl) Run(context.Context) error {
 	e.outputs = make(map[string]any, len(e.values))
 	maps.Copy(e.outputs, e.values)
 	return nil
+}
+
+// PublishesDeclaredOutputs exposes the written values to strict step output
+// references.
+func (e *executorImpl) PublishesDeclaredOutputs() bool {
+	return e.op == opWrite
 }
 
 func (e *executorImpl) GetOutputs() map[string]any {

--- a/internal/runtime/data.go
+++ b/internal/runtime/data.go
@@ -463,15 +463,25 @@ func (d NodeData) OutputsValueStringMap() map[string]string {
 	return result
 }
 
+// StepOutputsValueMap returns the step's published outputs as text. A published
+// value may be a number, a boolean, or a nested object, so each is rendered the
+// same way a strict step-output reference renders it.
 func (d NodeData) StepOutputsValueMap() map[string]string {
 	if d.State.StepOutputsValue == nil {
 		return nil
 	}
-	var values map[string]string
+	var values map[string]any
 	if err := json.Unmarshal([]byte(*d.State.StepOutputsValue), &values); err != nil {
 		return nil
 	}
-	return values
+	if len(values) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = outputValueToString(value)
+	}
+	return result
 }
 
 func outputValueToString(value any) string {

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -52,6 +52,11 @@ type Env struct {
 	// Outputs contains attempt staging paths scoped to the current step.
 	Outputs cmnvalue.Values
 
+	// reportedRefs records strict step-output references already warned about,
+	// so one unresolved reference in a step logs once even though the command
+	// text is resolved more than once. A nil map disables the deduplication.
+	reportedRefs map[string]struct{}
+
 	// Resolved absolute path for the step's working directory, determined by:
 	// 1. Step's Dir field if specified (resolved to absolute path)
 	// 2. Current working directory if Dir is not specified
@@ -118,12 +123,13 @@ func newEnv(ctx context.Context, step ir.Step, rCtx Context, workingDir string) 
 	scope = scope.WithEntries(stepEnvs, cmnvalue.EnvSourceStepEnv)
 
 	return Env{
-		Context:    rCtx,
-		Scope:      scope,
-		Step:       step,
-		StepMap:    make(map[string]cmnvalue.StepInfo),
-		Foreach:    foreach,
-		WorkingDir: workingDir,
+		Context:      rCtx,
+		Scope:        scope,
+		Step:         step,
+		StepMap:      make(map[string]cmnvalue.StepInfo),
+		Foreach:      foreach,
+		WorkingDir:   workingDir,
+		reportedRefs: make(map[string]struct{}),
 	}
 }
 
@@ -534,7 +540,7 @@ func (e Env) MailerConfig(ctx context.Context) (mailer.Config, error) {
 	if e.DAG.SMTP == nil {
 		return mailer.Config{}, nil
 	}
-	resolver := resolverFromEnv(e)
+	resolver := resolverFromEnv(ctx, e)
 	got, err := resolver.Object(ctx, *e.DAG.SMTP, cmnvalue.HostConfigObjectField("smtp"))
 	if err != nil {
 		return mailer.Config{}, err
@@ -550,7 +556,7 @@ func (e Env) MailerConfig(ctx context.Context) (mailer.Config, error) {
 func (e Env) EvalBool(ctx context.Context, value any) (bool, error) {
 	switch v := value.(type) {
 	case string:
-		s, err := resolverFromEnv(e).String(ctx, v, cmnvalue.WorkflowField("bool"))
+		s, err := resolverFromEnv(ctx, e).String(ctx, v, cmnvalue.WorkflowField("bool"))
 		if err != nil {
 			return false, err
 		}

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -59,6 +59,7 @@ func resolverWithoutNotices(env Env) cmnvalue.Resolver {
 	return newResolver(env)
 }
 
+// newResolver builds a resolver over the scopes reachable from env.
 func newResolver(env Env, opts ...cmnvalue.ResolverOption) cmnvalue.Resolver {
 	var consts cmnvalue.Values
 	var params cmnvalue.Values

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"log/slog"
 	"maps"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger"
+	"github.com/dagucloud/dagu/v2/internal/cmn/logger/tag"
 	"github.com/dagucloud/dagu/v2/internal/cmn/runenv"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/stringutil"
@@ -29,7 +32,7 @@ func EvalBool(ctx context.Context, value any) (bool, error) {
 // with the variables within the execution context.
 func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 	env := GetEnv(ctx)
-	resolver := resolverFromEnv(env)
+	resolver := resolverFromEnv(ctx, env)
 	got, err := resolver.Object(ctx, obj, cmnvalue.WorkflowObjectField("object"))
 	if err != nil {
 		return obj, err
@@ -41,7 +44,7 @@ func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 	return val, nil
 }
 
-func resolverFromEnv(env Env) cmnvalue.Resolver {
+func resolverFromEnv(ctx context.Context, env Env) cmnvalue.Resolver {
 	var consts cmnvalue.Values
 	var params cmnvalue.Values
 	var paramsJSON string
@@ -63,7 +66,37 @@ func resolverFromEnv(env Env) cmnvalue.Resolver {
 		Outputs:        env.Outputs,
 		BuiltinContext: builtinContextFromEnv(env),
 	}
-	return cmnvalue.NewResolver(cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations}, scope)
+	return cmnvalue.NewResolver(
+		cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations},
+		scope,
+		cmnvalue.WithValueReferenceNotices(stepOutputNoticeLogger{ctx: ctx, reported: env.reportedRefs}),
+	)
+}
+
+// stepOutputNoticeLogger warns when a strict step-output reference survives value
+// resolution. Without it a run only shows the shell error caused by the
+// reference text reaching the command unchanged.
+type stepOutputNoticeLogger struct {
+	ctx      context.Context
+	reported map[string]struct{}
+}
+
+func (l stepOutputNoticeLogger) Report(notice cmnvalue.ValueReferenceNotice) {
+	if notice.Message == "" || !cmnvalue.IsStepOutputReferenceToken(notice.Token) {
+		return
+	}
+	if l.reported != nil {
+		key := notice.FieldPath + "\x00" + notice.Token
+		if _, seen := l.reported[key]; seen {
+			return
+		}
+		l.reported[key] = struct{}{}
+	}
+	var fields []slog.Attr
+	if notice.Reason != "" {
+		fields = append(fields, tag.Reason(string(notice.Reason)))
+	}
+	logger.Warn(l.ctx, notice.Message, fields...)
 }
 
 func builtinContextFromEnv(env Env) cmnvalue.BuiltinContext {
@@ -137,33 +170,33 @@ func addBuiltinContextEnvValue(values map[string]string, path string, scope *cmn
 }
 
 func resolveRuntimeString(ctx context.Context, raw string, field cmnvalue.Field) (string, error) {
-	return resolverFromEnv(GetEnv(ctx)).String(ctx, raw, field)
+	return resolverFromEnv(ctx, GetEnv(ctx)).String(ctx, raw, field)
 }
 
 func resolveRuntimeObject(ctx context.Context, obj any, field cmnvalue.Field) (any, error) {
-	return resolverFromEnv(GetEnv(ctx)).Object(ctx, obj, field)
+	return resolverFromEnv(ctx, GetEnv(ctx)).Object(ctx, obj, field)
 }
 
 func resolveRuntimeInt(ctx context.Context, raw string, field cmnvalue.Field) (int, error) {
-	return resolverFromEnv(GetEnv(ctx)).Int(ctx, raw, field)
+	return resolverFromEnv(ctx, GetEnv(ctx)).Int(ctx, raw, field)
 }
 
 func resolveWithEnvScope(ctx context.Context, env Env, scope *cmnvalue.EnvScope, raw string, field cmnvalue.Field) (string, error) {
 	copy := env
 	copy.Scope = scope
-	return resolverFromEnv(copy).String(ctx, raw, field)
+	return resolverFromEnv(ctx, copy).String(ctx, raw, field)
 }
 
 // ValueResolver returns a semantic value resolver for the runtime environment in ctx.
 func ValueResolver(ctx context.Context) cmnvalue.Resolver {
-	return resolverFromEnv(GetEnv(ctx))
+	return resolverFromEnv(ctx, GetEnv(ctx))
 }
 
 // ValueResolverWithScope returns a semantic value resolver using scope as the runtime env scope.
 func ValueResolverWithScope(ctx context.Context, scope *cmnvalue.EnvScope) cmnvalue.Resolver {
 	env := GetEnv(ctx)
 	env.Scope = scope
-	return resolverFromEnv(env)
+	return resolverFromEnv(ctx, env)
 }
 
 // ResolveString resolves raw with the semantic field in the runtime environment.

--- a/internal/runtime/eval.go
+++ b/internal/runtime/eval.go
@@ -44,7 +44,22 @@ func EvalObject[T any](ctx context.Context, obj T) (T, error) {
 	return val, nil
 }
 
+// resolverFromEnv builds a resolver that reports preserved strict step-output
+// references. Use resolverWithoutNotices for phases where an unresolved
+// reference is expected.
 func resolverFromEnv(ctx context.Context, env Env) cmnvalue.Resolver {
+	return newResolver(env, cmnvalue.WithValueReferenceNotices(
+		stepOutputNoticeLogger{ctx: ctx, reported: env.reportedRefs},
+	))
+}
+
+// resolverWithoutNotices builds a resolver for phases that accept an unresolved
+// reference, so deferring one does not warn about a value that resolves later.
+func resolverWithoutNotices(env Env) cmnvalue.Resolver {
+	return newResolver(env)
+}
+
+func newResolver(env Env, opts ...cmnvalue.ResolverOption) cmnvalue.Resolver {
 	var consts cmnvalue.Values
 	var params cmnvalue.Values
 	var paramsJSON string
@@ -69,7 +84,7 @@ func resolverFromEnv(ctx context.Context, env Env) cmnvalue.Resolver {
 	return cmnvalue.NewResolver(
 		cmnvalue.StaticScope{Consts: consts, Params: paramDeclarations},
 		scope,
-		cmnvalue.WithValueReferenceNotices(stepOutputNoticeLogger{ctx: ctx, reported: env.reportedRefs}),
+		opts...,
 	)
 }
 

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -402,11 +402,14 @@ func (n *Node) publishCapturedStepOutputs(ctx context.Context, payload string) e
 		return nil
 	}
 
-	merged := make(map[string]any)
-	if err := json.Unmarshal([]byte(payload), &merged); err != nil {
+	var decoded any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
 		return fmt.Errorf("failed to decode captured step outputs: %w", err)
 	}
-	if len(merged) == 0 {
+	// A payload that is not an object carries no addressable names, so an
+	// unconstrained schema keeps validating whatever a step prints.
+	merged, ok := decoded.(map[string]any)
+	if !ok || len(merged) == 0 {
 		return nil
 	}
 

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -362,6 +362,10 @@ func (n *Node) captureOutput(ctx context.Context) error {
 		}
 	}
 
+	// The last mechanism to publish wins, matching the order the legacy outputs
+	// object is built below.
+	var capturedOutputs string
+
 	if step.HasStructuredOutput() {
 		value, err := n.evaluateStructuredOutput(ctx, stdout, stdoutCaptured)
 		if err != nil {
@@ -369,10 +373,12 @@ func (n *Node) captureOutput(ctx context.Context) error {
 		}
 		n.setOutputValue(value)
 		n.setOutputsValue(value)
+		capturedOutputs = value
 	}
 
 	if step.HasOutputSchema() && !step.HasStructuredOutput() {
 		n.setOutputValue(schemaOutput)
+		capturedOutputs = schemaOutput
 	}
 	if step.HasStdoutOutputs() {
 		value, err := n.evaluateStdoutOutputs(ctx, stdout, stdoutCaptured)
@@ -380,7 +386,40 @@ func (n *Node) captureOutput(ctx context.Context) error {
 			return fmt.Errorf("failed to evaluate stdout outputs: %w", err)
 		}
 		n.setOutputsValue(value)
+		capturedOutputs = value
 	}
+	return n.publishCapturedStepOutputs(ctx, capturedOutputs)
+}
+
+// publishCapturedStepOutputs merges capture-published values into the strict
+// step-output channel behind ${steps.<id>.outputs.<name>}. A failed attempt
+// publishes nothing, matching outputs declared through DAGU_OUTPUT_FILE.
+func (n *Node) publishCapturedStepOutputs(ctx context.Context, payload string) error {
+	if payload == "" || n.Error() != nil {
+		return nil
+	}
+
+	values := make(map[string]any)
+	if err := json.Unmarshal([]byte(payload), &values); err != nil {
+		return fmt.Errorf("failed to decode captured step outputs: %w", err)
+	}
+	if len(values) == 0 {
+		return nil
+	}
+
+	merged := make(map[string]any, len(values))
+	if raw := n.State().StepOutputsValue; raw != nil && *raw != "" {
+		if err := json.Unmarshal([]byte(*raw), &merged); err != nil {
+			return fmt.Errorf("failed to decode step outputs before publishing captured outputs: %w", err)
+		}
+	}
+	maps.Copy(merged, values)
+
+	serialized, err := serializeOutputsValue(ctx, merged)
+	if err != nil {
+		return err
+	}
+	n.setStepOutputsValue(serialized)
 	return nil
 }
 
@@ -931,7 +970,7 @@ func evalTemplateConfig(ctx context.Context, config map[string]any) (map[string]
 		return nil, fmt.Errorf("with.template_ref must be a string")
 	}
 	env.Scope = scope
-	templateText, err := resolverFromEnv(env).ResolveRef(
+	templateText, err := resolverFromEnv(ctx, env).ResolveRef(
 		ctx,
 		ref,
 		cmnvalue.TemplateConfigField("with.template_ref"),
@@ -957,7 +996,7 @@ func scriptField(ctx context.Context, step ir.Step) cmnvalue.Field {
 func resolveRuntimeObjectWithScope(ctx context.Context, env Env, scope *cmnvalue.EnvScope, obj any, field cmnvalue.Field) (any, error) {
 	copy := env
 	copy.Scope = scope
-	return resolverFromEnv(copy).Object(ctx, obj, field)
+	return resolverFromEnv(ctx, copy).Object(ctx, obj, field)
 }
 
 func objectAsConfig(obj any) (map[string]any, error) {

--- a/internal/runtime/node.go
+++ b/internal/runtime/node.go
@@ -391,29 +391,32 @@ func (n *Node) captureOutput(ctx context.Context) error {
 	return n.publishCapturedStepOutputs(ctx, capturedOutputs)
 }
 
-// publishCapturedStepOutputs merges capture-published values into the strict
+// publishCapturedStepOutputs adds capture-published values to the strict
 // step-output channel behind ${steps.<id>.outputs.<name>}. A failed attempt
 // publishes nothing, matching outputs declared through DAGU_OUTPUT_FILE.
+//
+// A name already published by the step's own output contract keeps its value,
+// so the contract the build derived and the values a run publishes agree.
 func (n *Node) publishCapturedStepOutputs(ctx context.Context, payload string) error {
 	if payload == "" || n.Error() != nil {
 		return nil
 	}
 
-	values := make(map[string]any)
-	if err := json.Unmarshal([]byte(payload), &values); err != nil {
+	merged := make(map[string]any)
+	if err := json.Unmarshal([]byte(payload), &merged); err != nil {
 		return fmt.Errorf("failed to decode captured step outputs: %w", err)
 	}
-	if len(values) == 0 {
+	if len(merged) == 0 {
 		return nil
 	}
 
-	merged := make(map[string]any, len(values))
 	if raw := n.State().StepOutputsValue; raw != nil && *raw != "" {
-		if err := json.Unmarshal([]byte(*raw), &merged); err != nil {
+		published := make(map[string]any)
+		if err := json.Unmarshal([]byte(*raw), &published); err != nil {
 			return fmt.Errorf("failed to decode step outputs before publishing captured outputs: %w", err)
 		}
+		maps.Copy(merged, published)
 	}
-	maps.Copy(merged, values)
 
 	serialized, err := serializeOutputsValue(ctx, merged)
 	if err != nil {

--- a/internal/runtime/node_structured_output_test.go
+++ b/internal/runtime/node_structured_output_test.go
@@ -694,3 +694,62 @@ func TestNodeEvaluateStructuredOutput(t *testing.T) {
 		assert.Contains(t, err.Error(), `payload: unsupported output source "network"`)
 	})
 }
+
+// Capture-published outputs must reach the strict ${steps.<id>.outputs.<name>}
+// channel, which reads StepOutputsValue, not just the legacy output channels.
+func TestNodeCaptureOutputPublishesStrictStepOutputs(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type":     "object",
+		"required": []any{"value"},
+		"properties": map[string]any{
+			"value": map[string]any{"type": "string"},
+		},
+	}
+
+	cases := []struct {
+		name   string
+		step   ir.Step
+		stdout string
+	}{
+		{
+			name:   "OutputSchema",
+			step:   ir.Step{OutputSchema: schema},
+			stdout: `{"value":"hello"}`,
+		},
+		{
+			name: "StructuredOutput",
+			step: ir.Step{StructuredOutput: map[string]ir.StepOutputEntry{
+				"value": {From: ir.StepOutputSourceStdout, Decode: ir.StepOutputDecodeJSON, Select: ".value"},
+			}},
+			stdout: `{"value":"hello"}`,
+		},
+		{
+			name: "StdoutOutputs",
+			step: ir.Step{StdoutOutputs: &ir.StepOutputsConfig{
+				Fields: map[string]ir.StepOutputEntry{
+					"value": {From: ir.StepOutputSourceStdout, Decode: ir.StepOutputDecodeJSON, Select: ".value"},
+				},
+			}},
+			stdout: `{"value":"hello"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			workDir := t.TempDir()
+			ctx := structuredOutputTestContext(t, nil, workDir)
+			node := NodeWithData(NodeData{Step: tc.step})
+			node.outputs.outputCaptured = true
+			node.outputs.outputData = tc.stdout
+
+			require.NoError(t, node.captureOutput(ctx))
+			state := node.State()
+			require.NotNil(t, state.StepOutputsValue)
+			assert.JSONEq(t, `{"value":"hello"}`, *state.StepOutputsValue)
+		})
+	}
+}

--- a/internal/runtime/node_structured_output_test.go
+++ b/internal/runtime/node_structured_output_test.go
@@ -780,3 +780,21 @@ func TestNodeCaptureOutputKeepsPublishedStepOutputs(t *testing.T) {
 	require.NotNil(t, state.StepOutputsValue)
 	assert.JSONEq(t, `{"value":"from-output-file","extra":"captured"}`, *state.StepOutputsValue)
 }
+
+// An unconstrained output schema accepts any JSON. A payload that is not an
+// object carries no addressable names, so the step still succeeds.
+func TestNodeCaptureOutputAcceptsNonObjectSchemaOutput(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	ctx := structuredOutputTestContext(t, nil, workDir)
+	node := NodeWithData(NodeData{Step: ir.Step{OutputSchema: map[string]any{}}})
+	node.outputs.outputCaptured = true
+	node.outputs.outputData = `[1,2,3]`
+
+	require.NoError(t, node.captureOutput(ctx))
+	state := node.State()
+	require.NotNil(t, state.OutputValue)
+	assert.JSONEq(t, `[1,2,3]`, *state.OutputValue)
+	assert.Nil(t, state.StepOutputsValue)
+}

--- a/internal/runtime/node_structured_output_test.go
+++ b/internal/runtime/node_structured_output_test.go
@@ -753,3 +753,30 @@ func TestNodeCaptureOutputPublishesStrictStepOutputs(t *testing.T) {
 		})
 	}
 }
+
+// A name already published by the step's own output contract keeps its value,
+// so the contract derived at build time and the run agree on where it came from.
+func TestNodeCaptureOutputKeepsPublishedStepOutputs(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	ctx := structuredOutputTestContext(t, nil, workDir)
+	node := NodeWithData(NodeData{
+		Step: ir.Step{
+			Outputs: []ir.StepOutputDeclaration{{Name: "value"}},
+			OutputSchema: map[string]any{
+				"type":       "object",
+				"required":   []any{"value", "extra"},
+				"properties": map[string]any{"value": map[string]any{"type": "string"}, "extra": map[string]any{"type": "string"}},
+			},
+		},
+	})
+	node.setStepOutputsValue(`{"value":"from-output-file"}`)
+	node.outputs.outputCaptured = true
+	node.outputs.outputData = `{"value":"from-stdout","extra":"captured"}`
+
+	require.NoError(t, node.captureOutput(ctx))
+	state := node.State()
+	require.NotNil(t, state.StepOutputsValue)
+	assert.JSONEq(t, `{"value":"from-output-file","extra":"captured"}`, *state.StepOutputsValue)
+}

--- a/internal/runtime/node_structured_output_test.go
+++ b/internal/runtime/node_structured_output_test.go
@@ -798,3 +798,19 @@ func TestNodeCaptureOutputAcceptsNonObjectSchemaOutput(t *testing.T) {
 	assert.JSONEq(t, `[1,2,3]`, *state.OutputValue)
 	assert.Nil(t, state.StepOutputsValue)
 }
+
+// A published output may be typed, so rendering the map must not drop entries
+// the way a string-only decode would.
+func TestStepOutputsValueMapRendersTypedValues(t *testing.T) {
+	t.Parallel()
+
+	value := `{"name":"api","count":3,"ready":true,"meta":{"tag":"v1"}}`
+	data := NodeData{State: NodeState{StepOutputsValue: &value}}
+
+	assert.Equal(t, map[string]string{
+		"name":  "api",
+		"count": "3",
+		"ready": "true",
+		"meta":  `{"tag":"v1"}`,
+	}, data.StepOutputsValueMap())
+}

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -981,7 +981,7 @@ func addResolvedEnvVars(ctx context.Context, env *Env, envList []string, fieldPr
 		if !found {
 			return fmt.Errorf("invalid environment variable format %q", v)
 		}
-		evaluatedValue, err := resolverFromEnv(*env).String(ctx, value, fieldForKey(fieldPrefix+key))
+		evaluatedValue, err := resolverFromEnv(ctx, *env).String(ctx, value, fieldForKey(fieldPrefix+key))
 		if err != nil {
 			return fmt.Errorf("failed to evaluate environment variable %q: %w", v, err)
 		}

--- a/internal/runtime/step_executor.go
+++ b/internal/runtime/step_executor.go
@@ -243,20 +243,18 @@ func (e *StepExecutor) captureExecutorSideChannels(
 		if declared, ok := cmd.(executor.DeclaredOutputsProvider); ok {
 			hasDeclaredOutputs = declared.PublishesDeclaredOutputs()
 		}
+		// An executor that published nothing declares nothing, so the step
+		// output channels stay empty rather than holding a null payload.
 		if len(outputs) == 0 {
 			node.clearOutputsValue()
-			if !hasDeclaredOutputs {
-				return "", false, nil
-			}
+			return "", false, nil
 		}
 
 		declaredOutputsValue, err := serializeOutputsValue(ctx, outputs)
 		if err != nil {
 			return "", false, err
 		}
-		if len(outputs) > 0 {
-			node.setOutputsValue(declaredOutputsValue)
-		}
+		node.setOutputsValue(declaredOutputsValue)
 		return declaredOutputsValue, hasDeclaredOutputs, nil
 	}
 

--- a/internal/runtime/step_executor_internal_test.go
+++ b/internal/runtime/step_executor_internal_test.go
@@ -45,6 +45,14 @@ func (e *declaredSideChannelExecutor) PublishesDeclaredOutputs() bool {
 	return true
 }
 
+type emptyDeclaredSideChannelExecutor struct {
+	emptySideChannelExecutor
+}
+
+func (e *emptyDeclaredSideChannelExecutor) PublishesDeclaredOutputs() bool {
+	return true
+}
+
 type invalidDeclaredSideChannelExecutor struct {
 	emptySideChannelExecutor
 }
@@ -171,4 +179,26 @@ func TestStepExecutorRecordsTimeoutBeforeCommandStarts(t *testing.T) {
 
 func newTestStepExecutorContext() context.Context {
 	return NewContext(context.Background(), &ir.DAG{}, "run-1", "dag.log")
+}
+
+// An executor that declares outputs but publishes none must leave the step
+// output channels empty rather than storing a null payload.
+func TestStepExecutorSkipsEmptyExecutorDeclaredOutputs(t *testing.T) {
+	executorType := "test-step-executor-empty-declared-outputs"
+	runtimeexec.RegisterExecutor(executorType, func(context.Context, ir.Step) (runtimeexec.Executor, error) {
+		return &emptyDeclaredSideChannelExecutor{}, nil
+	}, nil, registry.ExecutorCapabilities{})
+	t.Cleanup(func() { runtimeexec.UnregisterExecutor(executorType) })
+
+	node := NewNode(ir.Step{
+		Name: "empty-declared-outputs-step",
+		ExecutorConfig: ir.ExecutorConfig{
+			Type: executorType,
+		},
+	}, NodeState{})
+
+	require.NoError(t, NewStepExecutor().Execute(newTestStepExecutorContext(), node))
+
+	require.Nil(t, node.State().StepOutputsValue)
+	require.Nil(t, node.State().OutputsValue)
 }

--- a/internal/service/frontend/api/v1/transformer.go
+++ b/internal/service/frontend/api/v1/transformer.go
@@ -141,18 +141,10 @@ func toStep(obj ir.Step) api.Step {
 	if len(obj.Dependencies) > 0 {
 		step.Dependencies = ptrOf(obj.Dependencies)
 	}
-	if len(obj.Outputs) > 0 {
-		outputs := make([]api.StepOutputDeclaration, len(obj.Outputs))
-		for i, output := range obj.Outputs {
-			outputs[i].Name = output.Name
-			if output.Type != "" {
-				outputType := api.StepOutputDeclarationType(output.Type)
-				outputs[i].Type = &outputType
-			}
-			if output.Path != "" {
-				outputs[i].Path = &output.Path
-			}
-		}
+	// Only authored declarations belong here. Names derived from a step's
+	// capture configuration are not published through DAGU_OUTPUT_FILE and are
+	// already visible in the field that configures them.
+	if outputs := authoredOutputDeclarations(obj.Outputs); len(outputs) > 0 {
 		step.Outputs = &outputs
 	}
 
@@ -998,4 +990,23 @@ func toToolDefinitions(defs []ir.ToolDefinition) *[]api.ToolDefinition {
 	}
 
 	return &result
+}
+
+func authoredOutputDeclarations(declarations []ir.StepOutputDeclaration) []api.StepOutputDeclaration {
+	outputs := make([]api.StepOutputDeclaration, 0, len(declarations))
+	for _, declaration := range declarations {
+		if declaration.Source == ir.StepDeclaredOutputSourceCapture {
+			continue
+		}
+		output := api.StepOutputDeclaration{Name: declaration.Name}
+		if declaration.Type != "" {
+			outputType := api.StepOutputDeclarationType(declaration.Type)
+			output.Type = &outputType
+		}
+		if declaration.Path != "" {
+			output.Path = &declaration.Path
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs
 }

--- a/internal/service/frontend/api/v1/transformer.go
+++ b/internal/service/frontend/api/v1/transformer.go
@@ -992,6 +992,8 @@ func toToolDefinitions(defs []ir.ToolDefinition) *[]api.ToolDefinition {
 	return &result
 }
 
+// authoredOutputDeclarations converts the declarations a workflow author wrote,
+// dropping names the build derived from a step's capture configuration.
 func authoredOutputDeclarations(declarations []ir.StepOutputDeclaration) []api.StepOutputDeclaration {
 	outputs := make([]api.StepOutputDeclaration, 0, len(declarations))
 	for _, declaration := range declarations {

--- a/internal/service/frontend/api/v1/transformer_test.go
+++ b/internal/service/frontend/api/v1/transformer_test.go
@@ -668,3 +668,58 @@ func TestToDAGRunDetailsPrefersLegacyStateOverNullAgentState(t *testing.T) {
 	require.Len(t, *details.AgentTasks, 1)
 	assert.Equal(t, "vocabulary", (*details.AgentTasks)[0].Name)
 }
+
+// The step outputs field describes the authored output contract, so names
+// derived from a step's capture configuration must not appear there.
+func TestStepOutputsExcludeCapturedDeclarations(t *testing.T) {
+	t.Parallel()
+
+	status := ir.DAGRunStatus{
+		Name:     "capture-dag",
+		DAGRunID: "run-1",
+		Status:   ir.Succeeded,
+		Nodes: []*ir.Node{{
+			Step: ir.Step{
+				ID:   "build",
+				Name: "build",
+				Outputs: []ir.StepOutputDeclaration{
+					{Name: "authored"},
+					{Name: "derived", Source: ir.StepDeclaredOutputSourceCapture},
+				},
+			},
+			Status: ir.NodeSucceeded,
+		}},
+	}
+
+	details := ToDAGRunDetails(status)
+	require.Len(t, details.Nodes, 1)
+	require.NotNil(t, details.Nodes[0].Step.Outputs)
+	names := make([]string, 0, len(*details.Nodes[0].Step.Outputs))
+	for _, output := range *details.Nodes[0].Step.Outputs {
+		names = append(names, output.Name)
+	}
+	assert.Equal(t, []string{"authored"}, names)
+}
+
+// A step that only derives output names has no authored contract to report.
+func TestStepOutputsOmittedWhenOnlyCaptured(t *testing.T) {
+	t.Parallel()
+
+	status := ir.DAGRunStatus{
+		Name:     "capture-dag",
+		DAGRunID: "run-2",
+		Status:   ir.Succeeded,
+		Nodes: []*ir.Node{{
+			Step: ir.Step{
+				ID:      "build",
+				Name:    "build",
+				Outputs: []ir.StepOutputDeclaration{{Name: "derived", Source: ir.StepDeclaredOutputSourceCapture}},
+			},
+			Status: ir.NodeSucceeded,
+		}},
+	}
+
+	details := ToDAGRunDetails(status)
+	require.Len(t, details.Nodes, 1)
+	assert.Nil(t, details.Nodes[0].Step.Outputs)
+}

--- a/internal/spec/deprecation.go
+++ b/internal/spec/deprecation.go
@@ -135,7 +135,7 @@ func deprecatedSyntaxWarningsForStepMap(path string, step map[string]any) []stri
 	return warnings
 }
 
-func sortedKeys(m map[string]any) []string {
+func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -626,6 +626,8 @@ func (s *step) build(ctx stepBuildContext) (*ir.Step, error) {
 		errs = append(errs, err)
 	}
 
+	deriveCapturedStepOutputs(result)
+
 	if len(errs) > 0 {
 		return nil, errs
 	}

--- a/internal/spec/step_captured_outputs.go
+++ b/internal/spec/step_captured_outputs.go
@@ -5,9 +5,6 @@ package spec
 
 import "github.com/dagucloud/dagu/v2/internal/ir"
 
-// outputsExecutorType is the executor behind `action: outputs.write`.
-const outputsExecutorType = "outputs"
-
 // deriveCapturedStepOutputs records the names a step publishes outside
 // DAGU_OUTPUT_FILE so strict step-output references can be validated against
 // them. Declarations authored in YAML take precedence, and a step whose
@@ -83,7 +80,7 @@ func outputsWriteNames(config map[string]any) []string {
 }
 
 func isOutputsWriteStep(step *ir.Step) bool {
-	return step.ExecutorConfig.Type == outputsExecutorType
+	return step.ExecutorConfig.Type == ir.ExecutorTypeOutputs
 }
 
 // outputSchemaDeclarations reads the top-level property names of an output

--- a/internal/spec/step_captured_outputs.go
+++ b/internal/spec/step_captured_outputs.go
@@ -26,7 +26,7 @@ func deriveCapturedStepOutputs(result *ir.Step) {
 		taken[output.Name] = struct{}{}
 	}
 
-	for _, derived := range capturedOutputDeclarations(result) {
+	for _, derived := range capturedOutputs(result).declarations {
 		if _, exists := taken[derived.Name]; exists {
 			continue
 		}
@@ -41,57 +41,64 @@ func deriveCapturedStepOutputs(result *ir.Step) {
 	result.Outputs = authored
 }
 
-// capturedOutputDeclarations returns the names published by the mechanism that
-// wins at run time, mirroring the precedence in Node.captureOutput.
-func capturedOutputDeclarations(step *ir.Step) []ir.StepOutputDeclaration {
+// capturedOutputContract describes the names a step publishes outside
+// DAGU_OUTPUT_FILE.
+type capturedOutputContract struct {
+	declarations []ir.StepOutputDeclaration
+	// dynamic reports that the step publishes names inspection cannot list, so
+	// a reference to one of them cannot be checked before the step runs.
+	dynamic bool
+}
+
+// capturedOutputs describes the names published by the mechanism that wins at
+// run time, mirroring the precedence in Node.captureOutput.
+func capturedOutputs(step *ir.Step) capturedOutputContract {
 	switch {
 	case step.HasStdoutOutputs():
-		return capturedNames(stdoutOutputNames(step.StdoutOutputs))
+		names, ok := stdoutOutputNames(step.StdoutOutputs)
+		if !ok {
+			return capturedOutputContract{dynamic: true}
+		}
+		return capturedOutputContract{declarations: capturedNames(names)}
 	case step.HasStructuredOutput():
-		return capturedNames(sortedKeys(step.StructuredOutput))
+		return capturedOutputContract{declarations: capturedNames(sortedKeys(step.StructuredOutput))}
 	case step.HasOutputSchema():
-		return outputSchemaDeclarations(step.OutputSchema)
+		properties, ok := step.OutputSchema["properties"].(map[string]any)
+		if !ok {
+			return capturedOutputContract{dynamic: true}
+		}
+		return capturedOutputContract{declarations: outputSchemaDeclarations(properties)}
 	case isOutputsWriteStep(step):
-		return capturedNames(outputsWriteNames(step.ExecutorConfig.Config))
+		values, ok := step.ExecutorConfig.Config["values"].(map[string]any)
+		if !ok {
+			return capturedOutputContract{dynamic: true}
+		}
+		return capturedOutputContract{declarations: capturedNames(sortedKeys(values))}
 	}
-	return nil
+	return capturedOutputContract{}
 }
 
-// stdoutOutputNames returns the field names a stdout outputs config publishes,
-// or nil when the published object is only known after decoding stdout.
-func stdoutOutputNames(cfg *ir.StepOutputsConfig) []string {
+// stdoutOutputNames returns the field names a stdout outputs config publishes.
+// It reports false when the config decodes stdout into an object whose keys
+// only a run reveals.
+func stdoutOutputNames(cfg *ir.StepOutputsConfig) ([]string, bool) {
 	switch {
 	case len(cfg.Fields) > 0:
-		return sortedKeys(cfg.Fields)
+		return sortedKeys(cfg.Fields), true
 	case cfg.Field != "":
-		return []string{cfg.Field}
+		return []string{cfg.Field}, true
 	default:
-		return nil
+		return nil, false
 	}
-}
-
-// outputsWriteNames returns the keys an outputs.write step publishes.
-func outputsWriteNames(config map[string]any) []string {
-	values, ok := config["values"].(map[string]any)
-	if !ok {
-		return nil
-	}
-	return sortedKeys(values)
 }
 
 func isOutputsWriteStep(step *ir.Step) bool {
 	return step.ExecutorConfig.Type == ir.ExecutorTypeOutputs
 }
 
-// outputSchemaDeclarations reads the top-level property names of an output
-// schema. A schema without inline properties, such as one built from `$ref` or
-// a composition keyword, publishes names that are only known at run time.
-func outputSchemaDeclarations(schema map[string]any) []ir.StepOutputDeclaration {
-	properties, ok := schema["properties"].(map[string]any)
-	if !ok {
-		return nil
-	}
-
+// outputSchemaDeclarations converts the top-level property names of an output
+// schema into declarations.
+func outputSchemaDeclarations(properties map[string]any) []ir.StepOutputDeclaration {
 	declarations := make([]ir.StepOutputDeclaration, 0, len(properties))
 	for _, name := range sortedKeys(properties) {
 		if !declaredOutputNamePattern.MatchString(name) {

--- a/internal/spec/step_captured_outputs.go
+++ b/internal/spec/step_captured_outputs.go
@@ -67,7 +67,12 @@ func capturedOutputs(step *ir.Step) capturedOutputContract {
 		if !ok {
 			return capturedOutputContract{dynamic: true}
 		}
-		return capturedOutputContract{declarations: outputSchemaDeclarations(properties)}
+		// An open schema validates names it never lists, and a run publishes
+		// whatever it accepted, so the listed names are only a lower bound.
+		return capturedOutputContract{
+			declarations: outputSchemaDeclarations(properties),
+			dynamic:      !schemaForbidsExtraProperties(step.OutputSchema),
+		}
 	case isOutputsWriteStep(step):
 		values, ok := step.ExecutorConfig.Config["values"].(map[string]any)
 		if !ok {
@@ -111,6 +116,17 @@ func outputSchemaDeclarations(properties map[string]any) []ir.StepOutputDeclarat
 		})
 	}
 	return declarations
+}
+
+// schemaForbidsExtraProperties reports whether a schema accepts only the names
+// it lists. A pattern-matched property is unlisted, so it opens the schema the
+// same way an additional property does.
+func schemaForbidsExtraProperties(schema map[string]any) bool {
+	if _, ok := schema["patternProperties"]; ok {
+		return false
+	}
+	additional, ok := schema["additionalProperties"].(bool)
+	return ok && !additional
 }
 
 // schemaOutputType maps a schema property to a declared output type. Only a

--- a/internal/spec/step_captured_outputs.go
+++ b/internal/spec/step_captured_outputs.go
@@ -73,6 +73,7 @@ func stdoutOutputNames(cfg *ir.StepOutputsConfig) []string {
 	}
 }
 
+// outputsWriteNames returns the keys an outputs.write step publishes.
 func outputsWriteNames(config map[string]any) []string {
 	values, ok := config["values"].(map[string]any)
 	if !ok {
@@ -108,6 +109,8 @@ func outputSchemaDeclarations(schema map[string]any) []ir.StepOutputDeclaration 
 	return declarations
 }
 
+// schemaOutputType maps a schema property to a declared output type. Only a
+// string property carries a string value; every other shape is JSON text.
 func schemaOutputType(property any) string {
 	object, ok := property.(map[string]any)
 	if !ok {

--- a/internal/spec/step_captured_outputs.go
+++ b/internal/spec/step_captured_outputs.go
@@ -1,0 +1,134 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spec
+
+import "github.com/dagucloud/dagu/v2/internal/ir"
+
+// outputsExecutorType is the executor behind `action: outputs.write`.
+const outputsExecutorType = "outputs"
+
+// deriveCapturedStepOutputs records the names a step publishes outside
+// DAGU_OUTPUT_FILE so strict step-output references can be validated against
+// them. Declarations authored in YAML take precedence, and a step whose
+// published names are only known at run time contributes none.
+//
+// It is safe to call more than once: previously derived names are recomputed.
+func deriveCapturedStepOutputs(result *ir.Step) {
+	if result == nil {
+		return
+	}
+
+	authored := make([]ir.StepOutputDeclaration, 0, len(result.Outputs))
+	taken := make(map[string]struct{}, len(result.Outputs))
+	for _, output := range result.Outputs {
+		if output.Source == ir.StepDeclaredOutputSourceCapture {
+			continue
+		}
+		authored = append(authored, output)
+		taken[output.Name] = struct{}{}
+	}
+
+	for _, derived := range capturedOutputDeclarations(result) {
+		if _, exists := taken[derived.Name]; exists {
+			continue
+		}
+		taken[derived.Name] = struct{}{}
+		authored = append(authored, derived)
+	}
+
+	if len(authored) == 0 {
+		result.Outputs = nil
+		return
+	}
+	result.Outputs = authored
+}
+
+// capturedOutputDeclarations returns the names published by the mechanism that
+// wins at run time, mirroring the precedence in Node.captureOutput.
+func capturedOutputDeclarations(step *ir.Step) []ir.StepOutputDeclaration {
+	switch {
+	case step.HasStdoutOutputs():
+		return capturedNames(stdoutOutputNames(step.StdoutOutputs))
+	case step.HasStructuredOutput():
+		return capturedNames(sortedKeys(step.StructuredOutput))
+	case step.HasOutputSchema():
+		return outputSchemaDeclarations(step.OutputSchema)
+	case isOutputsWriteStep(step):
+		return capturedNames(outputsWriteNames(step.ExecutorConfig.Config))
+	}
+	return nil
+}
+
+// stdoutOutputNames returns the field names a stdout outputs config publishes,
+// or nil when the published object is only known after decoding stdout.
+func stdoutOutputNames(cfg *ir.StepOutputsConfig) []string {
+	switch {
+	case len(cfg.Fields) > 0:
+		return sortedKeys(cfg.Fields)
+	case cfg.Field != "":
+		return []string{cfg.Field}
+	default:
+		return nil
+	}
+}
+
+func outputsWriteNames(config map[string]any) []string {
+	values, ok := config["values"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return sortedKeys(values)
+}
+
+func isOutputsWriteStep(step *ir.Step) bool {
+	return step.ExecutorConfig.Type == outputsExecutorType
+}
+
+// outputSchemaDeclarations reads the top-level property names of an output
+// schema. A schema without inline properties, such as one built from `$ref` or
+// a composition keyword, publishes names that are only known at run time.
+func outputSchemaDeclarations(schema map[string]any) []ir.StepOutputDeclaration {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	declarations := make([]ir.StepOutputDeclaration, 0, len(properties))
+	for _, name := range sortedKeys(properties) {
+		if !declaredOutputNamePattern.MatchString(name) {
+			continue
+		}
+		declarations = append(declarations, ir.StepOutputDeclaration{
+			Name:   name,
+			Type:   schemaOutputType(properties[name]),
+			Source: ir.StepDeclaredOutputSourceCapture,
+		})
+	}
+	return declarations
+}
+
+func schemaOutputType(property any) string {
+	object, ok := property.(map[string]any)
+	if !ok {
+		return ir.StepDeclaredOutputTypeJSON
+	}
+	if object["type"] == "string" {
+		return ir.StepDeclaredOutputTypeString
+	}
+	return ir.StepDeclaredOutputTypeJSON
+}
+
+func capturedNames(names []string) []ir.StepOutputDeclaration {
+	declarations := make([]ir.StepOutputDeclaration, 0, len(names))
+	for _, name := range names {
+		if !declaredOutputNamePattern.MatchString(name) {
+			continue
+		}
+		declarations = append(declarations, ir.StepOutputDeclaration{
+			Name:   name,
+			Source: ir.StepDeclaredOutputSourceCapture,
+		})
+	}
+	return declarations
+}

--- a/internal/spec/step_outputs_external_test.go
+++ b/internal/spec/step_outputs_external_test.go
@@ -288,3 +288,61 @@ steps:
 		})
 	}
 }
+
+// A step whose published names only a run reveals declares none, so nothing
+// claims a contract the build cannot check.
+func TestStepCapturedOutputsStayUndeclaredWhenDynamic(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "stdout outputs decode whole object",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    stdout:
+      outputs:
+        decode: json
+`,
+		},
+		{
+			name: "output schema without inline properties",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema:
+      $ref: '#/$defs/result'
+      $defs:
+        result:
+          type: object
+          properties:
+            image: {type: string}
+`,
+		},
+		{
+			name: "unconstrained output schema",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema: {}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dag, err := spec.LoadYAML(context.Background(), []byte("name: test\n"+tc.yaml), spec.WithoutEval())
+			require.NoError(t, err)
+			require.Len(t, dag.Steps, 1)
+			require.Nil(t, dag.Steps[0].Outputs)
+		})
+	}
+}

--- a/internal/spec/step_outputs_external_test.go
+++ b/internal/spec/step_outputs_external_test.go
@@ -154,3 +154,137 @@ steps:
 		})
 	}
 }
+
+// Mechanisms that publish from captured output declare their names so strict
+// step-output references can be validated without running the workflow.
+func TestStepCapturedOutputsDeclaration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		yaml     string
+		expected []ir.StepOutputDeclaration
+	}{
+		{
+			name: "output schema",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema:
+      type: object
+      properties:
+        image: {type: string}
+        meta: {type: object}
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Type: ir.StepDeclaredOutputTypeString, Source: ir.StepDeclaredOutputSourceCapture},
+				{Name: "meta", Type: ir.StepDeclaredOutputTypeJSON, Source: ir.StepDeclaredOutputSourceCapture},
+			},
+		},
+		{
+			name: "object form output",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output:
+      image:
+        from: stdout
+        decode: json
+        select: .image
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Source: ir.StepDeclaredOutputSourceCapture},
+			},
+		},
+		{
+			name: "stdout outputs fields",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    stdout:
+      outputs:
+        fields:
+          image: {decode: json, select: .image}
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Source: ir.StepDeclaredOutputSourceCapture},
+			},
+		},
+		{
+			name: "outputs write values",
+			yaml: `
+steps:
+  - id: build
+    action: outputs.write
+    with:
+      values:
+        image: v1
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Source: ir.StepDeclaredOutputSourceCapture},
+			},
+		},
+		{
+			name: "custom action output schema",
+			yaml: `
+actions:
+  build.image:
+    input_schema: {type: object, additionalProperties: false, properties: {}}
+    output_schema:
+      type: object
+      properties:
+        image: {type: string}
+    template:
+      run: echo ok
+steps:
+  - id: build
+    action: build.image
+    with: {}
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Type: ir.StepDeclaredOutputTypeString, Source: ir.StepDeclaredOutputSourceCapture},
+			},
+		},
+		{
+			name: "authored declaration wins over derived name",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    outputs:
+      - name: image
+    output_schema:
+      type: object
+      properties:
+        image: {type: string}
+`,
+			expected: []ir.StepOutputDeclaration{
+				{Name: "image", Type: ir.StepDeclaredOutputTypeString},
+			},
+		},
+		{
+			name: "schema without inline properties declares nothing",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema: {}
+`,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dag, err := spec.LoadYAML(context.Background(), []byte("name: test\n"+tc.yaml), spec.WithoutEval())
+			require.NoError(t, err)
+			require.Len(t, dag.Steps, 1)
+			require.Equal(t, tc.expected, dag.Steps[0].Outputs)
+		})
+	}
+}

--- a/internal/spec/step_types.go
+++ b/internal/spec/step_types.go
@@ -984,6 +984,9 @@ func buildCustomStepFromSpecWithStack(
 	if customType.Description != "" && builtStep.Description == "" {
 		builtStep.Description = customType.Description
 	}
+	// The definition's output schema arrives after the expanded step was built,
+	// so its published names are derived here.
+	deriveCapturedStepOutputs(builtStep)
 	return builtStep, nil
 }
 

--- a/internal/spec/value_reference_notices_report.go
+++ b/internal/spec/value_reference_notices_report.go
@@ -322,6 +322,19 @@ func fixedActionOutputs(step ir.Step) []ir.StepOutputDeclaration {
 	}
 }
 
+// publishesRuntimeOnlyOutputs reports whether a step's published output names
+// come from a definition that inspection cannot read. A sub-DAG's names belong
+// to the child document, and an action's names come from a manifest resolved
+// during the run, so neither can be checked without executing the workflow.
+func publishesRuntimeOnlyOutputs(step ir.Step) bool {
+	switch step.ExecutorConfig.Type {
+	case ir.ExecutorTypeDAG, ir.ExecutorTypeSubworkflow, ir.ExecutorTypeAction:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *stepOutputNoticeContext) report(
 	fieldPath string,
 	value string,
@@ -361,8 +374,10 @@ func (c *stepOutputNoticeContext) reason(
 	if len(ref.Path) > 0 {
 		outputName = ref.Path[0]
 	}
-	if _, ok := c.outputNames[producer.ID][outputName]; !ok {
-		return cmnvalue.ValueReferenceReasonUnknownOutputName, true
+	if !publishesRuntimeOnlyOutputs(producer) {
+		if _, ok := c.outputNames[producer.ID][outputName]; !ok {
+			return cmnvalue.ValueReferenceReasonUnknownOutputName, true
+		}
 	}
 	if !c.dependsOn(ownerStepName, producer.Name) {
 		return cmnvalue.ValueReferenceReasonMissingDependency, true

--- a/internal/spec/value_reference_notices_report.go
+++ b/internal/spec/value_reference_notices_report.go
@@ -325,14 +325,14 @@ func fixedActionOutputs(step ir.Step) []ir.StepOutputDeclaration {
 // publishesRuntimeOnlyOutputs reports whether a step's published output names
 // come from a definition that inspection cannot read. A sub-DAG's names belong
 // to the child document, and an action's names come from a manifest resolved
-// during the run, so neither can be checked without executing the workflow.
+// during the run. A step that decodes its whole stdout into outputs, or whose
+// output schema carries no inline properties, reveals its names the same way.
 func publishesRuntimeOnlyOutputs(step ir.Step) bool {
 	switch step.ExecutorConfig.Type {
 	case ir.ExecutorTypeDAG, ir.ExecutorTypeSubworkflow, ir.ExecutorTypeAction:
 		return true
-	default:
-		return false
 	}
+	return capturedOutputs(&step).dynamic
 }
 
 func (c *stepOutputNoticeContext) report(

--- a/internal/spec/value_reference_notices_test.go
+++ b/internal/spec/value_reference_notices_test.go
@@ -293,3 +293,77 @@ steps:
 	require.NotNil(t, result.DAG)
 	assert.Empty(t, result.ValueReferenceNotices)
 }
+
+// A producer whose published names only a run reveals cannot be checked before
+// the run, so a reference to one must not be reported as an unknown name.
+func TestNoUnknownOutputNoticeForRuntimeOnlyProducers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "stdout outputs decode whole object",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    stdout:
+      outputs:
+        decode: json
+  - id: deploy
+    depends: build
+    run: echo ${steps.build.outputs.image}
+`,
+		},
+		{
+			name: "output schema without inline properties",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema:
+      $ref: '#/$defs/result'
+      $defs:
+        result:
+          type: object
+          properties:
+            image: {type: string}
+  - id: deploy
+    depends: build
+    run: echo ${steps.build.outputs.image}
+`,
+		},
+		{
+			name: "sub DAG child names",
+			yaml: `
+steps:
+  - id: build
+    action: dag.run
+    with: {dag: child}
+  - id: deploy
+    depends: build
+    run: echo ${steps.build.outputs.image}
+---
+name: child
+steps:
+  - id: emit
+    run: echo ok
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := spec.LoadYAMLWithResult(context.Background(), []byte("name: notices\n"+tc.yaml))
+			require.NoError(t, err)
+			for _, notice := range result.ValueReferenceNotices {
+				assert.NotEqual(t, cmnvalue.ValueReferenceReasonUnknownOutputName, notice.Reason,
+					"unexpected unknown output notice: %s", notice.Message)
+			}
+		})
+	}
+}

--- a/internal/spec/value_reference_notices_test.go
+++ b/internal/spec/value_reference_notices_test.go
@@ -336,6 +336,21 @@ steps:
 `,
 		},
 		{
+			name: "output schema accepting extra properties",
+			yaml: `
+steps:
+  - id: build
+    run: echo ok
+    output_schema:
+      type: object
+      properties:
+        image: {type: string}
+  - id: deploy
+    depends: build
+    run: echo ${steps.build.outputs.tag}
+`,
+		},
+		{
 			name: "sub DAG child names",
 			yaml: `
 steps:
@@ -366,4 +381,32 @@ steps:
 			}
 		})
 	}
+}
+
+// A schema that accepts only the names it lists is a complete contract, so a
+// misspelled name is still reported.
+func TestUnknownOutputNoticeForClosedOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	result, err := spec.LoadYAMLWithResult(context.Background(), []byte(`
+name: notices
+steps:
+  - id: build
+    run: echo ok
+    output_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        image: {type: string}
+  - id: deploy
+    depends: build
+    run: echo ${steps.build.outputs.tag}
+`))
+	require.NoError(t, err)
+
+	var reasons []cmnvalue.ValueReferenceNoticeReason
+	for _, notice := range result.ValueReferenceNotices {
+		reasons = append(reasons, notice.Reason)
+	}
+	assert.Contains(t, reasons, cmnvalue.ValueReferenceReasonUnknownOutputName)
 }

--- a/specs/007-value-resolution-steps.md
+++ b/specs/007-value-resolution-steps.md
@@ -83,9 +83,13 @@ Explicit inspection surfaces report a passive notice for that preserved referenc
 
 - Step output values are inserted into string fields according to Spec 003 string insertion rules.
 
-- Step output references read only top-level outputs declared by the referenced step and published through `DAGU_OUTPUT_FILE`.
+- Step output references read the named outputs a step publishes, whatever mechanism publishes them.
 
-- Step output references do not read singular `output`, `stdout.outputs`, legacy DAG/action outputs, stdout, stderr, logs, artifacts, or nested output paths.
+- A step publishes named outputs through its top-level `outputs` contract and `DAGU_OUTPUT_FILE`, through `output_schema`, through object-form `output`, through `stdout.outputs`, or through an action that publishes named outputs.
+
+- A failed attempt publishes no outputs, so its references stay unresolved.
+
+- Step output references do not read singular `output` captured into a variable, stdout, stderr, logs, artifacts, or nested output paths.
 
 ### Foreach Body Scope
 
@@ -127,7 +131,9 @@ Rules:
 
 - An unknown `steps.<step_id>` reference must use reason `unknown_step_id`.
 
-- An unknown `steps.<step_id>.outputs.<name>` reference must use reason `unknown_output_name` when the referenced step is known but the referenced output name is not declared by the step's top-level `outputs` contract, or the referenced step has no top-level `outputs` contract.
+- An unknown `steps.<step_id>.outputs.<name>` reference must use reason `unknown_output_name` when the referenced step is known, publishes a statically known output contract, and the referenced output name is not in it.
+
+- A step whose published output names are known only during a run has no statically known contract, so a reference to it must not use reason `unknown_output_name`. A sub-DAG step and an action step resolved from a manifest publish such names.
 
 - A step output reference without a direct or transitive dependency on the producing step must use reason `missing_dependency`.
 

--- a/specs/007-value-resolution-steps.md
+++ b/specs/007-value-resolution-steps.md
@@ -89,7 +89,7 @@ Explicit inspection surfaces report a passive notice for that preserved referenc
 
 - A failed attempt publishes no outputs, so its references stay unresolved.
 
-- Step output references do not read singular `output` captured into a variable, stdout, stderr, logs, artifacts, or nested output paths.
+- Step output references do not read string-form `output: VAR`, which captures a variable rather than a named output, nor stdout, stderr, logs, artifacts, or nested output paths.
 
 ### Foreach Body Scope
 

--- a/specs/012-step-outputs.md
+++ b/specs/012-step-outputs.md
@@ -17,7 +17,7 @@ steps:
       - name: image_tag
 ```
 
-It does not define the existing singular `output` field, `stdout.outputs`, `outputs.write`, or the `outputs` schema in `dagu-action.yaml`.
+It does not define the existing singular `output` field, `stdout.outputs`, `outputs.write`, or the `outputs` schema in `dagu-action.yaml`. Those mechanisms publish named outputs of their own, and Spec 007 defines how references read them.
 
 Value-resolution references to published outputs are defined by [Spec 007: Value Resolution Steps](007-value-resolution-steps.md).
 

--- a/specs/012-step-outputs.md
+++ b/specs/012-step-outputs.md
@@ -17,7 +17,9 @@ steps:
       - name: image_tag
 ```
 
-It does not define the existing singular `output` field, `stdout.outputs`, `outputs.write`, or the `outputs` schema in `dagu-action.yaml`. Those mechanisms publish named outputs of their own, and Spec 007 defines how references read them.
+It does not define the existing singular `output` field, `stdout.outputs`, `outputs.write`, or the `outputs` schema in `dagu-action.yaml`.
+
+Object-form `output`, `stdout.outputs`, `outputs.write`, and the `outputs` schema in `dagu-action.yaml` publish named outputs of their own, and Spec 007 defines how references read them. String-form `output: VAR` captures a variable rather than a named step output, so Spec 007 does not read it.
 
 Value-resolution references to published outputs are defined by [Spec 007: Value Resolution Steps](007-value-resolution-steps.md).
 

--- a/specs/050-outputs.md
+++ b/specs/050-outputs.md
@@ -19,6 +19,7 @@ This spec covers:
 - that each entry in `with.values` is resolved the same way any other
   `with:` field is (env vars, and so on), before being published
 - that the published values are readable from a later step as `${<step id>.outputs.<key>}`
+  and as `${steps.<step id>.outputs.<key>}`
 - that this spec's `dagu validate` checks are enforced at DAG-build time,
   not only at runtime
 - validation errors
@@ -43,7 +44,7 @@ is required (the object must be non-empty, and no key may be empty).
 Each value is resolved the same way any other `with:` field is (for
 example, a bare `$VAR` or `${VAR}` referencing an `env:` entry) before
 being published as that step's output. A later step reads a published
-value as `${<step id>.outputs.<name>}`.
+value as `${<step id>.outputs.<name>}` or as `${steps.<step id>.outputs.<name>}`.
 
 ## Errors
 


### PR DESCRIPTION
Fixes #2739.

## What was wrong

The reporter followed the documented custom-action output contract and got `bad substitution`. The cause is not specific to custom actions.

Values were not unreachable. Three reference roots existed, they look almost identical, and which one worked depended on the publishing mechanism. Measured by running one DAG per mechanism against the built binary:

| Mechanism | Form that worked before | `${steps.X.outputs.N}` after |
|---|---|---|
| `outputs:` + `DAGU_OUTPUT_FILE` | `${steps.X.outputs.N}` | resolves |
| `human.task`, `git.worktree.*`, build path outputs | `${steps.X.outputs.N}` | resolves |
| `output_schema` | `${X.output.N}` singular | resolves |
| object-form `output:` | `${X.outputs.N}` | resolves |
| `stdout.outputs` | `${X.outputs.N}` | resolves |
| `outputs.write` | `${X.outputs.N}` | resolves |
| sub-DAG `dag.run` | `${X.outputs.N}` | resolves |
| packaged / remote action | `${X.outputs.N}` | resolves |
| string-form `output: VAR` | `$VAR` | unchanged, out of scope |

`output_schema` was the only mechanism reachable solely through the singular `output`, which is exactly the trap the report fell into, because the documentation writes it as plural.

`dagu validate` already classified every failing case correctly. The run emitted nothing, so the user only saw the shell error.

## What changed

**Build time.** Steps whose published names are known before a run declare them, following the approach `human.task` already uses to derive names from its form schema. That covers `output_schema` properties (plain steps, `actions.<name>`, and the deprecated `step_types.<name>` alike), object-form `output` keys, `stdout.outputs` field names, and `outputs.write` values.

**Run time.** Those values are merged into the strict channel after capture. A failed attempt publishes nothing, matching outputs declared through `DAGU_OUTPUT_FILE`. Sub-DAG and packaged action steps opt into the existing `DeclaredOutputsProvider` interface, the same one `git.worktree.*` uses. Their names come from a child document or a manifest resolved during the run, so validation treats a reference to them as runtime-only instead of a defect.

**A trap worth calling out.** `ir.Step.Outputs` previously meant one thing: names the step must write to `DAGU_OUTPUT_FILE`. Reusing it for derived names would fail every such step with `declared step output "x" was not emitted`. `StepOutputDeclaration` therefore gains a source, and `ValueOutputs()` narrows to file-published names so the file contract still applies only to file-published outputs.

**Diagnostics.** A preserved strict reference now warns in the run log with the step and the reason, so the shell error that follows is traceable. It reports once per reference, since a command string is resolved more than once. Deferred build-plan validation resolves without the sink, because a reference there legitimately resolves later.

Existing `${<id>.outputs.<name>}` and `${<id>.output.<field>}` forms are unchanged. The change is additive.

## Defects found and fixed while building this

- **Empty executor outputs stored a null payload.** Opting three executors into declared outputs exposed a gap: an executor that declares outputs but returns none serialized a nil map, so the literal `null` reached the step output state and a later read saw a non-object payload instead of an absent one. A child DAG publishing only `output: NAME` variables hits this, which is how `TestAgentObservesChildVariablesWhenNothingIsDeclared` caught it on both platforms. Covered by `TestStepExecutorSkipsEmptyExecutorDeclaredOutputs`, confirmed to fail without the fix.
- **Runtime and build time disagreed on precedence.** A captured value could overwrite a name published by the step's own contract, so a step declaring `outputs:` alongside `output_schema` resolved to the schema value while the derived contract said the declaration owned the name.
- **Derived names leaked into the public API.** The step outputs field documents authored value outputs and build path outputs. Derived names are neither, and clients cannot tell them apart, so the transformer skips them.

## Specs and tests

Spec 007's exclusivity rule was the only place restricting lookup to `DAGU_OUTPUT_FILE`; its Reference Form section already said `name` must identify "an output value published by the referenced step". Specs 012 and 050 are updated to match, and all three now distinguish object-form `output` from string-form `output: VAR`.

Two conformance assertions encoded the behavior being changed. `legacy_outputs_not_step_outputs.yaml` is now a positive fixture and renamed. Separately, a leak check in spec 014 asserted that stderr must not contain the bare word `value`, which the new warning text trips without any leak; that fixture now uses a distinctive payload so the assertion tests what it means to test.

```
make conformance   1102 tests, 5 skipped, 0 failures
go test -race      internal/runtime, internal/intg    no data races
golangci-lint      0 issues (darwin and windows)
```

## Not included

`docs/` is a separate repository. A documentation audit found 22 published examples that fail as written. Eighteen become correct with this change and need no documentation edit, verified by running the `output_schema` and `outputs.write` examples verbatim.

The remaining four documented outputs that no code publishes: `http.request`, `redis.*`, `data.convert`, and `git.checkout` implement no output provider, so the reference could never resolve. Each writes its result to stdout instead, and both the HTTP and Redis pages already showed that form elsewhere, so those pages contradicted themselves. Fixed in dagucloud/docs@cdb5a05 by capturing with `output:` and reading fields from the captured value.

https://claude.ai/code/session_0176XJhVsH14fUuEhveqbANz
