### PR TITLE
Recover catchup after scheduler pauses

### DIFF
--- a/internal/intg/sched_test.go
+++ b/internal/intg/sched_test.go
@@ -52,18 +52,25 @@ steps:
 	require.NoError(t, err)
 
 	var dispatchCount atomic.Int32
-	schedulerInstance.SetDispatchFunc(func(_ context.Context, entry scheduler.DAGEntry, _ string, trigger ir.TriggerType, _ time.Time) error {
+	var dispatchMu sync.Mutex
+	var dispatchTimes []time.Time
+	schedulerInstance.SetDispatchFunc(func(_ context.Context, entry scheduler.DAGEntry, _ string, trigger ir.TriggerType, scheduled time.Time) error {
 		dag := entry.DAG
 		if dag != nil && dag.Name == "cron-test" && trigger == ir.TriggerTypeScheduler {
+			dispatchMu.Lock()
+			dispatchTimes = append(dispatchTimes, scheduled)
+			dispatchMu.Unlock()
 			dispatchCount.Add(1)
 		}
 		return nil
 	})
 
 	clockBase := time.Date(2026, 1, 1, 0, 0, 59, 0, time.UTC)
-	// Keep the simulated clock stable so scheduler startup latency cannot skip
-	// the initial tick. The cron loop advances its tick cursor independently.
+	// Keep startup time stable, then advance after the first scheduled dispatch.
 	schedulerInstance.SetClock(func() time.Time {
+		if dispatchCount.Load() > 0 {
+			return clockBase.Add(time.Minute)
+		}
 		return clockBase
 	})
 
@@ -81,7 +88,13 @@ steps:
 	})
 	probe.Stop(context.Background(), cancel, 5*time.Second)
 
-	require.GreaterOrEqual(t, dispatchCount.Load(), int32(2))
+	dispatchMu.Lock()
+	defer dispatchMu.Unlock()
+	require.Len(t, dispatchTimes, 2)
+	for i, scheduled := range dispatchTimes {
+		want := clockBase.Truncate(time.Minute).Add(time.Duration(i) * time.Minute)
+		require.True(t, want.Equal(scheduled), "unexpected scheduled time: %s", scheduled)
+	}
 }
 
 func TestScheduleEditWhileSuspendedDoesNotSuppressNewSlot(t *testing.T) {

--- a/internal/service/scheduler/scheduler.go
+++ b/internal/service/scheduler/scheduler.go
@@ -804,7 +804,13 @@ func (s *Scheduler) cronLoop(ctx context.Context, sig chan os.Signal) {
 	defer s.running.Store(false)
 
 	for s.waitForTick(ctx, sig, timer) {
-		s.runTickSafely(ctx, tickTime)
+		now := s.clock()
+		if now.Before(tickTime) {
+			// A clock adjustment must not dispatch a future scheduled slot.
+			timer.Reset(tickTime.Sub(now))
+			continue
+		}
+		tickTime = s.runTickSafely(ctx, tickTime)
 		tickTime = s.NextTick(tickTime)
 		timer.Reset(tickTime.Sub(s.clock()))
 	}
@@ -825,7 +831,8 @@ func (s *Scheduler) waitForTick(ctx context.Context, sig chan os.Signal, timer *
 	}
 }
 
-func (s *Scheduler) runTickSafely(ctx context.Context, tickTime time.Time) {
+func (s *Scheduler) runTickSafely(ctx context.Context, tickTime time.Time) (processed time.Time) {
+	processed = tickTime
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Error(ctx, "Scheduler tick panicked",
@@ -834,7 +841,13 @@ func (s *Scheduler) runTickSafely(ctx context.Context, tickTime time.Time) {
 			)
 		}
 	}()
-	s.runTick(ctx, tickTime)
+	if current := s.clock().Truncate(time.Minute); current.After(tickTime) {
+		// Recover missed slots before the next tick advances the checkpoint.
+		s.planner.resume(ctx, current)
+		processed = current
+	}
+	s.runTick(ctx, processed)
+	return processed
 }
 
 func (s *Scheduler) runTick(ctx context.Context, tickTime time.Time) {

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1468,14 +1468,17 @@ func (tp *TickPlanner) trimBuffer(buffer *ScheduleBuffer) bool {
 	slices.SortFunc(buffer.items, func(a, b QueueItem) int {
 		return a.ScheduledTime.Compare(b.ScheduledTime)
 	})
+	if buffer.overlapPolicy == ir.OverlapPolicyLatest && buffer.Len() > 1 {
+		dropped := buffer.DropAllButLast()
+		return tp.advanceDAGWatermark(buffer.dagName, dropped[len(dropped)-1].ScheduledTime)
+	}
 	if buffer.maxItems > 0 && buffer.Len() > buffer.maxItems {
-		buffer.items = slices.Delete(buffer.items, 0, buffer.Len()-buffer.maxItems)
+		dropped := buffer.Len() - buffer.maxItems
+		lastDropped := buffer.items[dropped-1].ScheduledTime
+		buffer.items = slices.Delete(buffer.items, 0, dropped)
+		return tp.advanceDAGWatermark(buffer.dagName, lastDropped)
 	}
-	if buffer.overlapPolicy != ir.OverlapPolicyLatest || buffer.Len() <= 1 {
-		return false
-	}
-	dropped := buffer.DropAllButLast()
-	return tp.advanceDAGWatermark(buffer.dagName, dropped[len(dropped)-1].ScheduledTime)
+	return false
 }
 
 // recomputeBuffer refreshes pending runs and adds missed slots from the watermark.

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -1447,28 +1447,33 @@ func (tp *TickPlanner) resume(ctx context.Context, now time.Time) {
 				from = last
 			}
 		}
-		for _, interval := range computeMissedScheduleIntervals(active.start, from.In(tp.cfg.Location), now) {
-			if buffer == nil {
-				buffer = NewScheduleBuffer(name, dag.OverlapPolicy)
-				tp.buffers[name] = buffer
-			}
-			if !buffer.Send(QueueItem{DAGEntry: entry.DAGEntry, ScheduledTime: interval.ScheduledTime,
-				TriggerType: ir.TriggerTypeCatchUp, ScheduleType: ScheduleTypeStart, Schedule: interval.Schedule}) {
-				logger.Warn(ctx, "Catch-up buffer full after scheduler pause", tag.DAG(name))
-				break
-			}
-			tp.trimLatest(buffer)
+		missed := computeMissedScheduleIntervals(active.start, from.In(tp.cfg.Location), now)
+		if len(missed) == 0 {
+			continue
 		}
+		if buffer == nil {
+			buffer = NewScheduleBuffer(name, dag.OverlapPolicy)
+			tp.buffers[name] = buffer
+		}
+		for _, interval := range missed {
+			buffer.items = append(buffer.items, QueueItem{DAGEntry: entry.DAGEntry, ScheduledTime: interval.ScheduledTime,
+				TriggerType: ir.TriggerTypeCatchUp, ScheduleType: ScheduleTypeStart, Schedule: interval.Schedule})
+		}
+		tp.trimBuffer(buffer)
 	}
 }
 
-func (tp *TickPlanner) trimLatest(buffer *ScheduleBuffer) bool {
-	if buffer.overlapPolicy != ir.OverlapPolicyLatest || buffer.Len() <= 1 {
-		return false
-	}
+// trimBuffer retains the newest slots after pending and recovered work are merged.
+func (tp *TickPlanner) trimBuffer(buffer *ScheduleBuffer) bool {
 	slices.SortFunc(buffer.items, func(a, b QueueItem) int {
 		return a.ScheduledTime.Compare(b.ScheduledTime)
 	})
+	if buffer.maxItems > 0 && buffer.Len() > buffer.maxItems {
+		buffer.items = slices.Delete(buffer.items, 0, buffer.Len()-buffer.maxItems)
+	}
+	if buffer.overlapPolicy != ir.OverlapPolicyLatest || buffer.Len() <= 1 {
+		return false
+	}
 	dropped := buffer.DropAllButLast()
 	return tp.advanceDAGWatermark(buffer.dagName, dropped[len(dropped)-1].ScheduledTime)
 }
@@ -1496,7 +1501,6 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, acti
 	replayFrom := ComputeReplayFrom(dag.CatchupWindow, lastTick, lastScheduledTime, now)
 	missed := computeMissedScheduleIntervals(active.start, replayFrom.In(tp.cfg.Location), now)
 
-	watermarkAdvanced := false
 	q := NewScheduleBuffer(dag.Name, dag.OverlapPolicy)
 	seen := make(map[time.Time]bool)
 	if pending := tp.buffers[dag.Name]; pending != nil {
@@ -1509,9 +1513,8 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, acti
 			if schedule, ok := schedules[item.Schedule.Fingerprint()]; ok {
 				item.DAGEntry = entry
 				item.Schedule = schedule
-				q.Send(item)
+				q.items = append(q.items, item)
 				seen[item.ScheduledTime.UTC()] = true
-				watermarkAdvanced = tp.trimLatest(q) || watermarkAdvanced
 			}
 		}
 	}
@@ -1519,24 +1522,19 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, acti
 		if seen[interval.ScheduledTime.UTC()] {
 			continue
 		}
-		if !q.Send(QueueItem{
+		q.items = append(q.items, QueueItem{
 			DAGEntry:      entry,
 			ScheduledTime: interval.ScheduledTime,
 			TriggerType:   ir.TriggerTypeCatchUp,
 			ScheduleType:  ScheduleTypeStart,
 			Schedule:      interval.Schedule,
-		}) {
-			break
-		}
-		watermarkAdvanced = tp.trimLatest(q) || watermarkAdvanced
+		})
 	}
 	if q.Len() == 0 {
 		delete(tp.buffers, dag.Name)
 		return false
 	}
-	slices.SortFunc(q.items, func(a, b QueueItem) int {
-		return a.ScheduledTime.Compare(b.ScheduledTime)
-	})
+	watermarkAdvanced := tp.trimBuffer(q)
 
 	tp.buffers[dag.Name] = q
 

--- a/internal/service/scheduler/tick_planner.go
+++ b/internal/service/scheduler/tick_planner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -433,7 +434,7 @@ func (tp *TickPlanner) initBuffers(ctx context.Context, entries []DAGEntry, acti
 		}
 
 		replayFrom := ComputeReplayFrom(dag.CatchupWindow, lastTick, lastScheduledTime, now)
-		missed := computeMissedScheduleIntervals(active.start, replayFrom, now)
+		missed := computeMissedScheduleIntervals(active.start, replayFrom.In(tp.cfg.Location), now)
 
 		if len(missed) == 0 {
 			continue
@@ -1235,10 +1236,10 @@ func (tp *TickPlanner) handleEvent(ctx context.Context, event DAGChangeEvent) {
 		active, activeOK := tp.activeDAGSchedules(ctx, event.DAGEntry)
 		delete(tp.deletedGrace, dagName)
 		tp.entries[dagName] = &plannerEntry{DAGEntry: event.DAGEntry}
-		// Remove existing buffer and recompute if catchupWindow > 0
-		delete(tp.buffers, dagName)
 		if activeOK && event.DAG.CatchupWindow > 0 {
 			flushNow = tp.recomputeBuffer(ctx, event.DAGEntry, active)
+		} else {
+			delete(tp.buffers, dagName)
 		}
 		if activeOK {
 			flushNow = tp.reconcileStartScheduleState(event.DAG, active) || flushNow
@@ -1418,15 +1419,67 @@ func (tp *TickPlanner) reinsertCatchupItem(ctx context.Context, run PlannedRun) 
 	}
 }
 
-// recomputeBuffer creates a new catch-up buffer for a DAG using the existing watermark.
-func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, active activeDAGSchedules) bool {
+// resume retains pending work and adds slots missed while the scheduler was paused.
+func (tp *TickPlanner) resume(ctx context.Context, now time.Time) {
+	tp.entryMu.Lock()
+	defer tp.entryMu.Unlock()
 	if !tp.cfg.QueuesEnabled {
+		return
+	}
+	for name, entry := range tp.entries {
+		dag := entry.DAG
+		if dag.CatchupWindow <= 0 {
+			continue
+		}
+		active, ok := tp.activeDAGSchedules(ctx, entry.DAGEntry)
+		if !ok {
+			continue
+		}
+		tp.mu.RLock()
+		from := ComputeReplayFrom(dag.CatchupWindow, tp.watermarkState.LastTick,
+			tp.watermarkState.DAGs[name].LastScheduledTime, now)
+		tp.mu.RUnlock()
+		buffer := tp.buffers[name]
+		if buffer != nil && buffer.Len() > 0 {
+			// Pending buffers already cover their interval, including gaps between cron slots.
+			last := buffer.items[len(buffer.items)-1].ScheduledTime
+			if last.After(from) {
+				from = last
+			}
+		}
+		for _, interval := range computeMissedScheduleIntervals(active.start, from.In(tp.cfg.Location), now) {
+			if buffer == nil {
+				buffer = NewScheduleBuffer(name, dag.OverlapPolicy)
+				tp.buffers[name] = buffer
+			}
+			if !buffer.Send(QueueItem{DAGEntry: entry.DAGEntry, ScheduledTime: interval.ScheduledTime,
+				TriggerType: ir.TriggerTypeCatchUp, ScheduleType: ScheduleTypeStart, Schedule: interval.Schedule}) {
+				logger.Warn(ctx, "Catch-up buffer full after scheduler pause", tag.DAG(name))
+				break
+			}
+			tp.trimLatest(buffer)
+		}
+	}
+}
+
+func (tp *TickPlanner) trimLatest(buffer *ScheduleBuffer) bool {
+	if buffer.overlapPolicy != ir.OverlapPolicyLatest || buffer.Len() <= 1 {
 		return false
 	}
-	if len(active.start) == 0 {
-		return false
-	}
+	slices.SortFunc(buffer.items, func(a, b QueueItem) int {
+		return a.ScheduledTime.Compare(b.ScheduledTime)
+	})
+	dropped := buffer.DropAllButLast()
+	return tp.advanceDAGWatermark(buffer.dagName, dropped[len(dropped)-1].ScheduledTime)
+}
+
+// recomputeBuffer refreshes pending runs and adds missed slots from the watermark.
+func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, active activeDAGSchedules) bool {
 	dag := entry.DAG
+	if !tp.cfg.QueuesEnabled || len(active.start) == 0 {
+		delete(tp.buffers, dag.Name)
+		return false
+	}
 
 	// Snapshot needed values under the lock to avoid reading the shared map
 	// after releasing it (Advance and handleEvent can modify DAGs concurrently).
@@ -1441,15 +1494,31 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, acti
 	now := tp.cfg.Clock().In(tp.cfg.Location)
 
 	replayFrom := ComputeReplayFrom(dag.CatchupWindow, lastTick, lastScheduledTime, now)
-	missed := computeMissedScheduleIntervals(active.start, replayFrom, now)
-
-	if len(missed) == 0 {
-		return false
-	}
+	missed := computeMissedScheduleIntervals(active.start, replayFrom.In(tp.cfg.Location), now)
 
 	watermarkAdvanced := false
 	q := NewScheduleBuffer(dag.Name, dag.OverlapPolicy)
+	seen := make(map[time.Time]bool)
+	if pending := tp.buffers[dag.Name]; pending != nil {
+		// Keep compatible pending slots and execute the updated definition.
+		schedules := make(map[string]ir.Schedule, len(active.start))
+		for _, schedule := range active.start {
+			schedules[schedule.Fingerprint()] = schedule
+		}
+		for _, item := range pending.items {
+			if schedule, ok := schedules[item.Schedule.Fingerprint()]; ok {
+				item.DAGEntry = entry
+				item.Schedule = schedule
+				q.Send(item)
+				seen[item.ScheduledTime.UTC()] = true
+				watermarkAdvanced = tp.trimLatest(q) || watermarkAdvanced
+			}
+		}
+	}
 	for _, interval := range missed {
+		if seen[interval.ScheduledTime.UTC()] {
+			continue
+		}
 		if !q.Send(QueueItem{
 			DAGEntry:      entry,
 			ScheduledTime: interval.ScheduledTime,
@@ -1459,12 +1528,15 @@ func (tp *TickPlanner) recomputeBuffer(ctx context.Context, entry DAGEntry, acti
 		}) {
 			break
 		}
+		watermarkAdvanced = tp.trimLatest(q) || watermarkAdvanced
 	}
-
-	if dag.OverlapPolicy == ir.OverlapPolicyLatest && q.Len() > 1 {
-		dropped := q.DropAllButLast()
-		watermarkAdvanced = tp.advanceDAGWatermark(dag.Name, dropped[len(dropped)-1].ScheduledTime)
+	if q.Len() == 0 {
+		delete(tp.buffers, dag.Name)
+		return false
 	}
+	slices.SortFunc(q.items, func(a, b QueueItem) int {
+		return a.ScheduledTime.Compare(b.ScheduledTime)
+	})
 
 	tp.buffers[dag.Name] = q
 

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -23,6 +23,7 @@ type mockStateStore struct {
 	saveErr error
 	mu      sync.Mutex
 	saved   []*schedulerstate.State
+	onSave  func(*schedulerstate.State)
 }
 
 func (m *mockStateStore) Load(_ context.Context) (*schedulerstate.State, error) {
@@ -46,6 +47,9 @@ func (m *mockStateStore) Save(_ context.Context, state *schedulerstate.State) er
 		return m.saveErr
 	}
 	m.saved = append(m.saved, schedulerstate.Clone(state))
+	if m.onSave != nil {
+		m.onSave(state)
+	}
 	return nil
 }
 
@@ -128,9 +132,90 @@ func newTestTickPlanner(store schedulerstate.Store) (*TickPlanner, chan DAGChang
 		Clock: func() time.Time {
 			return time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
 		},
-		Events: eventCh,
+		Location: time.UTC,
+		Events:   eventCh,
 	})
 	return tp, eventCh
+}
+
+func TestResumePreservesPending(t *testing.T) {
+	for _, policy := range []ir.OverlapPolicy{ir.OverlapPolicyAll, ir.OverlapPolicyLatest} {
+		t.Run(string(policy), func(t *testing.T) {
+			base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+			wake := base.Add(10 * time.Minute)
+			store := &mockStateStore{state: newMockState(base.Add(-2 * time.Minute))}
+			planner, _ := newTestTickPlanner(store)
+			planner.cfg.Clock = func() time.Time { return base }
+			planner.cfg.Location = time.UTC
+			running := true
+			planner.cfg.IsRunning = func(context.Context, *ir.DAG) (bool, error) { return running, nil }
+			planner.cfg.Enqueue = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error { return nil }
+			dag := &ir.DAG{Name: "pending", CatchupWindow: 3 * time.Minute, OverlapPolicy: policy,
+				Schedule: []ir.Schedule{mustParseSchedule(t, "* * * * *")}}
+			require.NoError(t, planner.Init(t.Context(), testDAGEntries(dag)))
+			planner.resume(t.Context(), wake)
+			planner.resume(t.Context(), wake)
+			require.Empty(t, planner.Plan(t.Context(), wake), "active work must defer catchup")
+			planner.Advance(wake)
+			running = false
+			want := []time.Time{base.Add(-time.Minute), base, wake.Add(-2 * time.Minute), wake.Add(-time.Minute), wake}
+			if policy == ir.OverlapPolicyLatest {
+				want = []time.Time{wake}
+			}
+			for i, scheduled := range want {
+				tick := wake.Add(time.Duration(i+1) * time.Minute)
+				runs := planner.Plan(t.Context(), tick)
+				require.Len(t, runs, 1)
+				require.Equal(t, ir.TriggerTypeCatchUp, runs[0].TriggerType)
+				require.True(t, scheduled.Equal(runs[0].ScheduledTime), "slot %d: %s", i, runs[0].ScheduledTime)
+				planner.DispatchRun(t.Context(), runs[0])
+				planner.Advance(tick)
+			}
+			// All recovered slots were consumed once; the next run is a new live slot.
+			next := wake.Add(time.Duration(len(want)+1) * time.Minute)
+			runs := planner.Plan(t.Context(), next)
+			require.Len(t, runs, 1)
+			require.Equal(t, ir.TriggerTypeScheduler, runs[0].TriggerType)
+			require.True(t, next.Equal(runs[0].ScheduledTime))
+		})
+	}
+}
+
+func TestCatchupTimezone(t *testing.T) {
+	location, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+	wake := time.Date(2026, 1, 2, 10, 0, 0, 0, location).UTC()
+	checkpoint := wake.Add(-2 * time.Hour)
+	for _, path := range []string{"init", "update", "resume"} {
+		for _, expression := range []string{"0 9 * * *", "CRON_TZ=UTC 0 0 * * *"} {
+			t.Run(path+"/"+expression, func(t *testing.T) {
+				now := checkpoint
+				if path == "init" {
+					now = wake
+				}
+				planner, _ := newTestTickPlanner(&mockStateStore{state: newMockState(checkpoint)})
+				planner.cfg.Clock = func() time.Time { return now }
+				planner.cfg.Location = location
+				dag := &ir.DAG{Name: "local-morning", CatchupWindow: 4 * time.Hour, OverlapPolicy: ir.OverlapPolicyLatest,
+					Schedule: []ir.Schedule{mustParseSchedule(t, expression)}}
+				require.NoError(t, planner.Init(t.Context(), testDAGEntries(dag)))
+				now = wake
+				switch path {
+				case "update":
+					planner.entryMu.Lock()
+					planner.handleEvent(t.Context(), DAGChangeEvent{Type: DAGChangeUpdated, DAGEntry: DAGEntry{DAG: dag}})
+					planner.entryMu.Unlock()
+				case "resume":
+					planner.resume(t.Context(), now)
+				}
+				// A UTC checkpoint at 08:00 JST must recover the missed 09:00 JST run.
+				runs := planner.Plan(t.Context(), now)
+				require.Len(t, runs, 1)
+				require.Equal(t, ir.TriggerTypeCatchUp, runs[0].TriggerType)
+				require.True(t, wake.Add(-time.Hour).Equal(runs[0].ScheduledTime))
+			})
+		}
+	}
 }
 
 func TestTickPlanner_InitNoStateStore(t *testing.T) {
@@ -605,6 +690,73 @@ func TestTickPlanner_HandleEvent_Updated(t *testing.T) {
 	entry, ok := tp.entries["upd-dag"]
 	require.True(t, ok)
 	assert.Equal(t, "*/30 * * * *", entry.DAG.Schedule[0].Expression)
+}
+
+func TestUpdatePreservesPending(t *testing.T) {
+	for _, change := range []string{"timeout", "latest", "latest-gap", "disabled", "removed", "schedule"} {
+		t.Run(change, func(t *testing.T) {
+			base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+			now := base
+			planner, _ := newTestTickPlanner(&mockStateStore{state: newMockState(base.Add(-2 * time.Minute))})
+			planner.cfg.Clock = func() time.Time { return now }
+			planner.cfg.Location = time.UTC
+			planner.cfg.Enqueue = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error { return nil }
+			dag := &ir.DAG{Name: "updated", CatchupWindow: time.Hour, OverlapPolicy: ir.OverlapPolicyAll,
+				Schedule: []ir.Schedule{mustParseSchedule(t, "* * * * *")}}
+			if change == "schedule" {
+				dag.Schedule = []ir.Schedule{mustParseSchedule(t, "59 * * * *"), mustParseSchedule(t, "0 * * * *")}
+			}
+			require.NoError(t, planner.Init(t.Context(), testDAGEntries(dag)))
+			// Pending work survives later global checkpoints and unrelated definition edits.
+			now = base.Add(time.Minute)
+			planner.Advance(now)
+			updated := *dag
+			updated.Timeout = 10 * time.Minute
+			want := []time.Time{base.Add(-time.Minute), base}
+			switch change {
+			case "latest":
+				updated.OverlapPolicy = ir.OverlapPolicyLatest
+				want = []time.Time{base}
+			case "latest-gap":
+				updated.OverlapPolicy = ir.OverlapPolicyLatest
+				updated.CatchupWindow = 48 * time.Hour
+				now = base.Add(updated.CatchupWindow)
+				want = []time.Time{now}
+			case "disabled":
+				updated.CatchupWindow = 0
+				want = nil
+			case "removed":
+				updated.Schedule = nil
+				want = nil
+			case "schedule":
+				updated.Schedule = []ir.Schedule{mustParseSchedule(t, "0 * * * *")}
+				want = []time.Time{base}
+			}
+			planner.entryMu.Lock()
+			planner.handleEvent(t.Context(), DAGChangeEvent{Type: DAGChangeUpdated,
+				DAGEntry: DAGEntry{DAG: &updated, DefinitionID: "updated"}})
+			planner.entryMu.Unlock()
+			for _, scheduled := range want {
+				now = now.Add(time.Minute)
+				runs := planner.Plan(t.Context(), now)
+				require.Len(t, runs, 1)
+				require.Equal(t, ir.TriggerTypeCatchUp, runs[0].TriggerType)
+				require.True(t, scheduled.Equal(runs[0].ScheduledTime))
+				require.Same(t, &updated, runs[0].DAG)
+				planner.DispatchRun(t.Context(), runs[0])
+				planner.Advance(now)
+			}
+			now = now.Add(time.Minute)
+			runs := planner.Plan(t.Context(), now)
+			if change == "removed" || change == "schedule" {
+				require.Empty(t, runs)
+			} else {
+				require.Len(t, runs, 1)
+				require.Equal(t, ir.TriggerTypeScheduler, runs[0].TriggerType)
+				require.True(t, now.Equal(runs[0].ScheduledTime))
+			}
+		})
+	}
 }
 
 func TestTickPlanner_HandleEvent_UpdatedFlushesWatermarkMutationsImmediately(t *testing.T) {
@@ -1717,6 +1869,7 @@ func TestTickPlanner_ProfileChangeDropsInactiveCatchupSchedules(t *testing.T) {
 		IsRunning: func(_ context.Context, _ *ir.DAG) (bool, error) { return false, nil },
 		GenRunID:  func(_ context.Context) (string, error) { return "run-1", nil },
 		Clock:     func() time.Time { return now },
+		Location:  time.UTC,
 		Events:    make(chan DAGChangeEvent, 1),
 	})
 	dag := &ir.DAG{
@@ -2109,7 +2262,8 @@ func TestTickPlanner_PlanLatestNotRunning(t *testing.T) {
 		Clock: func() time.Time {
 			return time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
 		},
-		Events: eventCh,
+		Location: time.UTC,
+		Events:   eventCh,
 	})
 
 	dag := &ir.DAG{
@@ -2163,7 +2317,8 @@ func TestTickPlanner_PlanLatestRunning(t *testing.T) {
 		Clock: func() time.Time {
 			return time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
 		},
-		Events: eventCh,
+		Location: time.UTC,
+		Events:   eventCh,
 	})
 
 	dag := &ir.DAG{

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -181,6 +181,68 @@ func TestResumePreservesPending(t *testing.T) {
 	}
 }
 
+func TestCatchupBufferLimit(t *testing.T) {
+	const gap = 10
+	for _, path := range []string{"resume", "update"} {
+		for _, policy := range []ir.OverlapPolicy{ir.OverlapPolicyAll, ir.OverlapPolicySkip, ir.OverlapPolicyLatest} {
+			for _, pending := range []int{2, DefaultMaxBufferItems - gap, DefaultMaxBufferItems - 1, DefaultMaxBufferItems} {
+				t.Run(fmt.Sprintf("%s/%s/%d", path, policy, pending), func(t *testing.T) {
+					base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+					now := base
+					planner, _ := newTestTickPlanner(&mockStateStore{state: newMockState(base.Add(-time.Duration(pending) * time.Minute))})
+					planner.cfg.Clock = func() time.Time { return now }
+					planner.cfg.Enqueue = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error {
+						return errors.New("enqueue failed")
+					}
+					dag := &ir.DAG{Name: "buffer-limit", CatchupWindow: 48 * time.Hour, OverlapPolicy: policy,
+						Schedule: []ir.Schedule{mustParseSchedule(t, "* * * * *")}}
+					require.NoError(t, planner.Init(t.Context(), testDAGEntries(dag)))
+					planner.Advance(base)
+					now = base.Add(gap * time.Minute)
+					for range 2 {
+						switch path {
+						case "resume":
+							planner.resume(t.Context(), now)
+						case "update":
+							updated := *dag
+							updated.Timeout = time.Minute
+							planner.entryMu.Lock()
+							planner.handleEvent(t.Context(), DAGChangeEvent{Type: DAGChangeUpdated, DAGEntry: DAGEntry{DAG: &updated}})
+							planner.entryMu.Unlock()
+						}
+					}
+
+					// Recovery retains the newest slots once, including when the buffer fills.
+					count := min(pending+gap, DefaultMaxBufferItems)
+					if policy == ir.OverlapPolicyLatest {
+						count = 1
+					}
+					// A failed enqueue must preserve the first retained slot for retry.
+					runs := planner.Plan(t.Context(), now)
+					require.Len(t, runs, 1)
+					planner.DispatchRun(t.Context(), runs[0])
+					planner.Advance(now)
+					planner.cfg.Enqueue = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error { return nil }
+
+					for i := range count {
+						tick := now.Add(time.Duration(i+1) * time.Minute)
+						runs := planner.Plan(t.Context(), tick)
+						require.Len(t, runs, 1)
+						require.Equal(t, ir.TriggerTypeCatchUp, runs[0].TriggerType)
+						want := now.Add(time.Duration(i-count+1) * time.Minute)
+						require.True(t, want.Equal(runs[0].ScheduledTime), "slot %d: got %s, want %s", i, runs[0].ScheduledTime, want)
+						planner.DispatchRun(t.Context(), runs[0])
+						planner.Advance(tick)
+					}
+					runs = planner.Plan(t.Context(), now.Add(time.Duration(count+1)*time.Minute))
+					require.Len(t, runs, 1)
+					require.Equal(t, ir.TriggerTypeScheduler, runs[0].TriggerType)
+				})
+			}
+		}
+	}
+}
+
 func TestCatchupTimezone(t *testing.T) {
 	location, err := time.LoadLocation("Asia/Tokyo")
 	require.NoError(t, err)

--- a/internal/service/scheduler/tick_planner_test.go
+++ b/internal/service/scheduler/tick_planner_test.go
@@ -189,7 +189,8 @@ func TestCatchupBufferLimit(t *testing.T) {
 				t.Run(fmt.Sprintf("%s/%s/%d", path, policy, pending), func(t *testing.T) {
 					base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
 					now := base
-					planner, _ := newTestTickPlanner(&mockStateStore{state: newMockState(base.Add(-time.Duration(pending) * time.Minute))})
+					store := &mockStateStore{state: newMockState(base.Add(-time.Duration(pending) * time.Minute))}
+					planner, _ := newTestTickPlanner(store)
 					planner.cfg.Clock = func() time.Time { return now }
 					planner.cfg.Enqueue = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error {
 						return errors.New("enqueue failed")
@@ -217,6 +218,15 @@ func TestCatchupBufferLimit(t *testing.T) {
 					if policy == ir.OverlapPolicyLatest {
 						count = 1
 					}
+					if path == "resume" {
+						planner.Flush(t.Context())
+					}
+					if count < pending+gap {
+						// Persist discarded slots without consuming the retained backlog.
+						want := now.Add(-time.Duration(count) * time.Minute)
+						require.True(t, want.Equal(store.lastSaved().DAGs[dag.Name].LastScheduledTime), "discarded slots must advance the checkpoint to %s", want)
+					}
+
 					// A failed enqueue must preserve the first retained slot for retry.
 					runs := planner.Plan(t.Context(), now)
 					require.Len(t, runs, 1)

--- a/internal/service/scheduler/wait_for_tick_test.go
+++ b/internal/service/scheduler/wait_for_tick_test.go
@@ -6,14 +6,103 @@ package scheduler
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/dagucloud/dagu/v2/internal/cmn/config"
 	"github.com/dagucloud/dagu/v2/internal/ir"
+	"github.com/dagucloud/dagu/v2/internal/schedulerstate"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCronLoopWakeGap(t *testing.T) {
+	for _, mode := range []string{"catchup", "disabled", "queues-disabled"} {
+		t.Run(mode, func(t *testing.T) {
+			base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+			wake := base.Add(5 * time.Minute)
+			var now atomic.Int64
+			now.Store(base.UnixNano())
+			clock := func() time.Time { return time.Unix(0, now.Load()).UTC() }
+			store := &mockStateStore{state: newMockState(base)}
+			planner, _ := newTestTickPlanner(store)
+			planner.cfg.Clock = clock
+			planner.cfg.Location = time.UTC
+			planner.cfg.QueuesEnabled = mode != "queues-disabled"
+			dag := &ir.DAG{Name: "wake", OverlapPolicy: ir.OverlapPolicyLatest,
+				Schedule: []ir.Schedule{mustParseSchedule(t, "2,4,5 * * * *")}}
+			if mode != "disabled" {
+				dag.CatchupWindow = time.Hour
+			}
+			require.NoError(t, planner.Init(t.Context(), testDAGEntries(dag)))
+			runs := make(chan PlannedRun, 10)
+			record := func(_ context.Context, entry DAGEntry, id string, trigger ir.TriggerType, scheduled time.Time) error {
+				runs <- PlannedRun{DAGEntry: entry, RunID: id, TriggerType: trigger, ScheduledTime: scheduled}
+				return nil
+			}
+			planner.cfg.Dispatch = record
+			planner.cfg.Enqueue = record
+			// Jump after the first completed tick, without waiting or suspending the host.
+			store.onSave = func(state *schedulerstate.State) {
+				if state.LastTick.Equal(base) {
+					now.Store(wake.UnixNano())
+				}
+			}
+			sc := &Scheduler{planner: planner, clock: clock, quit: make(chan any)}
+			ctx, cancel := context.WithCancel(t.Context())
+			done := make(chan struct{})
+			go func() { defer close(done); sc.cronLoop(ctx, make(chan os.Signal)) }()
+			t.Cleanup(func() { cancel(); <-done })
+			select {
+			case run := <-runs:
+				require.True(t, wake.Equal(run.ScheduledTime), "unexpected scheduled time: %s", run.ScheduledTime)
+				want := ir.TriggerTypeScheduler
+				if mode == "catchup" {
+					want = ir.TriggerTypeCatchUp
+				}
+				require.Equal(t, want, run.TriggerType)
+			case <-time.After(time.Second):
+				t.Fatal("scheduler did not process the wake gap")
+			}
+		})
+	}
+}
+
+func TestCronLoopBackwardClock(t *testing.T) {
+	base := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	planner, _ := newTestTickPlanner(&mockStateStore{state: newMockState(base)})
+	planner.cfg.Clock = func() time.Time { return base }
+	planner.cfg.Location = time.UTC
+	runs := make(chan struct{}, 10)
+	planner.cfg.Dispatch = func(context.Context, DAGEntry, string, ir.TriggerType, time.Time) error {
+		runs <- struct{}{}
+		return nil
+	}
+	require.NoError(t, planner.Init(t.Context(), testDAGEntries(&ir.DAG{Name: "backward",
+		Schedule: []ir.Schedule{mustParseSchedule(t, "* * * * *")}})))
+	var reads atomic.Int32
+	clock := func() time.Time {
+		if reads.Add(1) == 1 {
+			return base.Add(5 * time.Minute)
+		}
+		return base
+	}
+	sc := &Scheduler{planner: planner, clock: clock, quit: make(chan any)}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); sc.cronLoop(ctx, make(chan os.Signal)) }()
+	t.Cleanup(func() { cancel(); <-done })
+	select {
+	case <-runs:
+		t.Fatal("a clock rollback dispatched a future slot")
+	case <-time.After(50 * time.Millisecond):
+	}
+	// The planner checkpoint remains at the last real wall-clock slot.
+	planner.mu.RLock()
+	defer planner.mu.RUnlock()
+	require.True(t, planner.watermarkState.LastTick.Equal(base))
+}
 
 func TestWaitForTickSignalStopsScheduler(t *testing.T) {
 	t.Parallel()
@@ -109,7 +198,7 @@ func newPanickingScheduler(t *testing.T) (*Scheduler, <-chan struct{}) {
 	})
 	require.NoError(t, planner.Init(t.Context(), testDAGEntries(&ir.DAG{Name: "panic-dag"})))
 
-	return &Scheduler{planner: planner}, panicTriggered
+	return &Scheduler{planner: planner, clock: time.Now}, panicTriggered
 }
 
 func requirePanicTriggered(t *testing.T, panicTriggered <-chan struct{}) {


### PR DESCRIPTION
## Summary

Recover missed start schedules when the scheduler resumes after sleep or a long
pause. Previously, the cron loop drained old ticks as live runs, bypassing the
catchup window and overlap policy.

## Changes

- Replay missed starts through the existing catchup queue, then resume the
  current minute. Disabled catchup skips historical ticks.
- Preserve pending catchup work when workflow defaults or definitions change.
  Removed schedules and disabled catchup discard their pending entries.
- Interpret unzoned schedules in the configured timezone even when their
  persisted checkpoint is UTC. Explicit schedule timezones retain precedence.
- Keep active runs intact and defer queued catchup using existing overlap rules.
- Merge pending and recovered catchup slots before enforcing the buffer limit,
  retaining the newest 1,000 slots and checkpointing discarded slots.
- Advance the integration test's simulated clock between its two expected
  scheduled slots, and verify their timestamps.

## Validation

- Overflow regression tests fail before the fix and pass afterward. Coverage
  includes all overlap policies, capacity boundaries, repeated recovery, and
  enqueue retries, and persisted discard checkpoints.

- Reproduced wake-gap, pending-work loss, and timezone failures before fixing.
- Focused scheduler tests pass, including repeated recovery, all/latest policies,
  busy workflows, disabled queues, clock rollback, and Asia/Tokyo schedules.
- `make fmt` passes native and Windows lint.
- Full scheduler race tests pass. Conformance passes: 1,103 tests with five
  platform-specific skips on Mac.
- Integration race tests pass: 435 passed, 19 skipped. The frozen-clock fixture
  failure was reproduced before correcting it.
- Runstead's 84 UI/editor tests pass against the patched executable; a Mac
  development package builds with the same engine.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduler behavior when system time moves forward or backward, preventing incorrect future dispatches.
  - Ensured missed scheduled runs are recovered reliably after delays or scheduler restarts.
  - Preserved pending catch-up work when schedules are updated.
  - Improved catch-up accuracy for schedules configured in different time zones.
  - Removed stale queued work when scheduling is disabled or no active schedules remain.
  - Improved handling of duplicate and capacity-limited pending scheduled runs.
- **Tests**
  - Added coverage for clock changes, scheduler recovery, time zones, and schedule updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

