### PR TITLE
feat(windows): add Inno Setup installer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -545,6 +545,59 @@ jobs:
             throw "Service-only uninstall removed the Dagu binary."
           }
 
+          # A busy port must be reported before any service is registered, so a
+          # failed setup cannot leave one behind restarting a process that dies.
+          $blocker = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 18081)
+          $blocker.Start()
+          try {
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+              -NoPrompt -ServiceOnly -Service yes -ServiceScope system `
+              -Port 18081 -OpenBrowser no -InstallDir $installDir
+            if ($LASTEXITCODE -eq 0) {
+              throw "Service-only install ignored a busy web server port."
+            }
+            if (Get-Service -Name Dagu -ErrorAction SilentlyContinue) {
+              throw "A rejected port left the Dagu service registered."
+            }
+          }
+          finally {
+            $blocker.Stop()
+          }
+
+      # Exercises the [Code] section of installer.iss, which compilation alone
+      # never runs: the machine PATH must be added on install and restored on
+      # uninstall. The service task is left off; it is covered by the step above.
+      - name: Test Inno Setup installer
+        shell: powershell
+        run: |
+          $installDir = "$env:ProgramFiles\Dagu"
+          $before = [Environment]::GetEnvironmentVariable("Path", "Machine")
+
+          Start-Process -Wait -FilePath "dist\dagu-0.0.0-setup.exe" -ArgumentList @(
+            "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/TASKS=path"
+          )
+          if (-not (Test-Path "$installDir\dagu.exe")) {
+            throw "The installer did not place dagu.exe in $installDir."
+          }
+          if (([Environment]::GetEnvironmentVariable("Path", "Machine") -split ';') -notcontains $installDir) {
+            throw "The installer did not add $installDir to the machine PATH."
+          }
+
+          Start-Process -Wait -FilePath "$installDir\unins000.exe" -ArgumentList @(
+            "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART"
+          )
+          # The uninstaller restarts itself from a temporary copy, so the wait above returns early.
+          $deadline = (Get-Date).AddSeconds(60)
+          while ((Test-Path $installDir) -and ((Get-Date) -lt $deadline)) {
+            Start-Sleep -Seconds 1
+          }
+          if (Test-Path $installDir) {
+            throw "The uninstaller did not remove $installDir."
+          }
+          if ([Environment]::GetEnvironmentVariable("Path", "Machine") -ne $before) {
+            throw "The uninstaller did not restore the machine PATH."
+          }
+
       - name: Test CMD installer
         shell: cmd
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
             esac
 
             case "${file}" in
-              scripts/installer.cmd|scripts/installer.ps1|.github/workflows/ci.yaml)
+              scripts/installer.cmd|scripts/installer.ps1|scripts/installer.iss|.github/workflows/ci.yaml)
                 windows_installer_changed=true
                 ;;
             esac
@@ -449,6 +449,25 @@ jobs:
           & ([scriptblock]::Create($source)) `
             -NoPrompt -DryRun -Uninstall `
             -InstallDir "$env:RUNNER_TEMP\dagu-uninstall"
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build Inno Setup installer
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          go build -trimpath -o dist\dagu-windows-amd64.exe .\cmd
+          choco install innosetup --no-progress --yes
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=0.0.0 `
+            /DBinaryPath=dist\dagu-windows-amd64.exe `
+            scripts\installer.iss
+          if ($LASTEXITCODE -ne 0) {
+            throw "Inno Setup compilation failed with exit code $LASTEXITCODE."
+          }
 
       - name: Test CMD installer
         shell: cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -563,6 +563,9 @@ jobs:
           finally {
             $blocker.Stop()
           }
+          # A rejected install is the expected outcome above. The step would
+          # otherwise exit with the code that rejection left behind.
+          $global:LASTEXITCODE = 0
 
       # Exercises the [Code] section of installer.iss, which compilation alone
       # never runs: the machine PATH must be added on install and restored on

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ on:
       - "proto/**"
       - "scripts/e2e/**"
       - "scripts/installer.cmd"
+      - "scripts/installer.iss"
       - "scripts/installer.ps1"
       - "ui/**"
       - ".github/workflows/ci.yaml"
@@ -41,6 +42,7 @@ on:
       - "proto/**"
       - "scripts/e2e/**"
       - "scripts/installer.cmd"
+      - "scripts/installer.iss"
       - "scripts/installer.ps1"
       - "ui/**"
       - ".github/workflows/ci.yaml"
@@ -120,7 +122,7 @@ jobs:
             esac
 
             case "${file}" in
-              scripts/installer.cmd|scripts/installer.ps1|scripts/installer.iss|.github/workflows/ci.yaml)
+              scripts/installer.cmd|scripts/installer.iss|scripts/installer.ps1|.github/workflows/ci.yaml)
                 windows_installer_changed=true
                 ;;
             esac
@@ -371,7 +373,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.windows_installer == 'true'
     runs-on: windows-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -460,8 +462,12 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           go build -trimpath -o dist\dagu-windows-amd64.exe .\cmd
-          choco install innosetup --no-progress --yes
-          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            Write-Host "Inno Setup 6 is not preinstalled on this image; installing it."
+            choco install innosetup --no-progress --yes
+          }
+          & $iscc `
             /DAppVersion=0.0.0 `
             /DBinaryPath=dist\dagu-windows-amd64.exe `
             scripts\installer.iss

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -452,6 +452,33 @@ jobs:
             -NoPrompt -DryRun -Uninstall `
             -InstallDir "$env:RUNNER_TEMP\dagu-uninstall"
 
+          $serviceOnlyDir = "$env:RUNNER_TEMP\dagu-service-only"
+          New-Item -ItemType Directory -Force -Path $serviceOnlyDir | Out-Null
+          Set-Content -Path "$serviceOnlyDir\dagu.exe" -Value "stub"
+
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -DryRun -ServiceOnly -Service no -InstallDir $serviceOnlyDir
+          if ($LASTEXITCODE -eq 0) {
+            throw "-ServiceOnly was accepted without -Service yes."
+          }
+
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -DryRun -ServiceOnly -Service yes -Version latest -InstallDir $serviceOnlyDir
+          if ($LASTEXITCODE -eq 0) {
+            throw "-ServiceOnly was accepted together with -Version."
+          }
+
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -DryRun -ServiceOnly -Service yes `
+            -InstallDir "$env:RUNNER_TEMP\dagu-service-only-missing"
+          if ($LASTEXITCODE -eq 0) {
+            throw "-ServiceOnly was accepted without an installed Dagu binary."
+          }
+
+          & ([scriptblock]::Create($source)) `
+            -NoPrompt -DryRun -ServiceOnly -Service yes -OpenBrowser no `
+            -InstallDir $serviceOnlyDir
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -473,6 +500,49 @@ jobs:
             scripts\installer.iss
           if ($LASTEXITCODE -ne 0) {
             throw "Inno Setup compilation failed with exit code $LASTEXITCODE."
+          }
+
+      # Mirrors how the Inno Setup installer drives the script: the binary is
+      # already in place and only the Windows service should be configured.
+      - name: Test installer service-only mode
+        shell: powershell
+        run: |
+          $installerPath = (Resolve-Path "scripts/installer.ps1").Path
+          $installDir = "$env:RUNNER_TEMP\dagu-service-live"
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          Copy-Item dist\dagu-windows-amd64.exe "$installDir\dagu.exe"
+          $binaryHash = (Get-FileHash "$installDir\dagu.exe").Hash
+          $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -ServiceOnly -Service yes -ServiceScope system `
+            -Port 18080 -OpenBrowser no -InstallDir $installDir
+          if ($LASTEXITCODE -ne 0) {
+            throw "Service-only install failed with exit code $LASTEXITCODE."
+          }
+
+          if ((Get-FileHash "$installDir\dagu.exe").Hash -ne $binaryHash) {
+            throw "Service-only install replaced the existing Dagu binary."
+          }
+          if ([Environment]::GetEnvironmentVariable("Path", "Machine") -ne $machinePath) {
+            throw "Service-only install modified the machine PATH."
+          }
+          $service = Get-Service -Name Dagu -ErrorAction SilentlyContinue
+          if (-not $service -or $service.Status -ne "Running") {
+            throw "The Dagu service is not running after a service-only install."
+          }
+          Invoke-WebRequest -Uri "http://127.0.0.1:18080/api/v1/health" -UseBasicParsing | Out-Null
+
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installerPath `
+            -NoPrompt -Uninstall -ServiceOnly -InstallDir $installDir
+          if ($LASTEXITCODE -ne 0) {
+            throw "Service-only uninstall failed with exit code $LASTEXITCODE."
+          }
+          if (Get-Service -Name Dagu -ErrorAction SilentlyContinue) {
+            throw "The Dagu service survived a service-only uninstall."
+          }
+          if (-not (Test-Path "$installDir\dagu.exe")) {
+            throw "Service-only uninstall removed the Dagu binary."
           }
 
       - name: Test CMD installer

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ prd.json
 
 # Compiled integration test binary
 intg.test
+
+# Build output
+dist/

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -41,6 +41,7 @@ WizardStyle=modern
 [Tasks]
 Name: "path"; Description: "Add Dagu to the system PATH"; GroupDescription: "Additional options:"
 Name: "service"; Description: "Install Dagu as a Windows service (runs start-all in the background)"; GroupDescription: "Background service:"
+Name: "startall"; Description: "Add a Dagu start-all shortcut (not needed when the service is installed)"; GroupDescription: "Dagu commands:"; Flags: unchecked
 Name: "server"; Description: "Add a Dagu server shortcut"; GroupDescription: "Dagu commands:"
 Name: "scheduler"; Description: "Add a Dagu scheduler shortcut"; GroupDescription: "Dagu commands:"
 Name: "coordinator"; Description: "Add a Dagu coordinator shortcut"; GroupDescription: "Dagu commands:"
@@ -51,7 +52,7 @@ Source: "{#BinaryPath}"; DestDir: "{app}"; DestName: "{#AppExeName}"; Flags: ign
 Source: "scripts\installer.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\Dagu start-all"; Filename: "{app}\{#AppExeName}"; Parameters: "start-all"; WorkingDir: "{app}"; Tasks: service
+Name: "{group}\Dagu start-all"; Filename: "{app}\{#AppExeName}"; Parameters: "start-all"; WorkingDir: "{app}"; Tasks: startall
 Name: "{group}\Dagu server"; Filename: "{app}\{#AppExeName}"; Parameters: "server"; WorkingDir: "{app}"; Tasks: server
 Name: "{group}\Dagu scheduler"; Filename: "{app}\{#AppExeName}"; Parameters: "scheduler"; WorkingDir: "{app}"; Tasks: scheduler
 Name: "{group}\Dagu coordinator"; Filename: "{app}\{#AppExeName}"; Parameters: "coordinator"; WorkingDir: "{app}"; Tasks: coordinator

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -15,6 +15,9 @@
 #define AppExeName "dagu.exe"
 #define ServiceWrapper "dagu-service.exe"
 #define ServiceConfig "dagu-service.xml"
+; Mirrors the installer.ps1 defaults so the retry command shows the ports it used.
+#define DefaultPort "8080"
+#define DefaultCoordinatorPort "50055"
 
 [Setup]
 SourceDir=..
@@ -183,7 +186,9 @@ function RetryCommand: string;
 begin
   Result := 'powershell -ExecutionPolicy Bypass -File "' +
     ExpandConstant('{app}\') + InstallerScript +
-    '" -ServiceOnly -Service yes -InstallDir "' + ExpandConstant('{app}') + '"';
+    '" -ServiceOnly -Service yes -Port {#DefaultPort}' +
+    ' -CoordinatorPort {#DefaultCoordinatorPort}' +
+    ' -InstallDir "' + ExpandConstant('{app}') + '"';
 end;
 
 procedure InstallService;
@@ -206,7 +211,9 @@ begin
     SuppressibleMsgBox(
       'Dagu was installed, but the Windows service setup failed (exit code ' +
       IntToStr(ResultCode) + ').' + #13#10#13#10 +
-      'Retry from an elevated PowerShell prompt to see the error:' + #13#10 + RetryCommand,
+      'The usual cause is that port {#DefaultPort} or {#DefaultCoordinatorPort} is ' +
+      'already in use. Retry from an elevated PowerShell prompt to see the error, ' +
+      'changing -Port or -CoordinatorPort if needed:' + #13#10 + RetryCommand,
       mbError, MB_OK, IDOK);
   end;
 end;

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -13,6 +13,8 @@
 #define AppPublisher "Dagu"
 #define AppURL "https://github.com/dagucloud/dagu"
 #define AppExeName "dagu.exe"
+#define ServiceWrapper "dagu-service.exe"
+#define ServiceConfig "dagu-service.xml"
 
 [Setup]
 SourceDir=..
@@ -38,7 +40,7 @@ WizardStyle=modern
 
 [Tasks]
 Name: "path"; Description: "Add Dagu to the system PATH"; GroupDescription: "Additional options:"
-Name: "startall"; Description: "Install Dagu as a Windows service (start-all)"; GroupDescription: "Background service:"
+Name: "service"; Description: "Install Dagu as a Windows service (runs start-all in the background)"; GroupDescription: "Background service:"
 Name: "server"; Description: "Add a Dagu server shortcut"; GroupDescription: "Dagu commands:"
 Name: "scheduler"; Description: "Add a Dagu scheduler shortcut"; GroupDescription: "Dagu commands:"
 Name: "coordinator"; Description: "Add a Dagu coordinator shortcut"; GroupDescription: "Dagu commands:"
@@ -49,23 +51,22 @@ Source: "{#BinaryPath}"; DestDir: "{app}"; DestName: "{#AppExeName}"; Flags: ign
 Source: "scripts\installer.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\Dagu start-all"; Filename: "{app}\{#AppExeName}"; Parameters: "start-all"; WorkingDir: "{app}"; Tasks: startall
+Name: "{group}\Dagu start-all"; Filename: "{app}\{#AppExeName}"; Parameters: "start-all"; WorkingDir: "{app}"; Tasks: service
 Name: "{group}\Dagu server"; Filename: "{app}\{#AppExeName}"; Parameters: "server"; WorkingDir: "{app}"; Tasks: server
 Name: "{group}\Dagu scheduler"; Filename: "{app}\{#AppExeName}"; Parameters: "scheduler"; WorkingDir: "{app}"; Tasks: scheduler
 Name: "{group}\Dagu coordinator"; Filename: "{app}\{#AppExeName}"; Parameters: "coordinator"; WorkingDir: "{app}"; Tasks: coordinator
 Name: "{group}\Dagu worker"; Filename: "{app}\{#AppExeName}"; Parameters: "worker"; WorkingDir: "{app}"; Tasks: worker
 
-[Run]
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer.ps1"" -NoPrompt -Service yes -ServiceScope system -Version ""{#AppVersion}"" -InstallDir ""{app}"" -OpenBrowser no"; WorkingDir: "{app}"; StatusMsg: "Installing the Dagu Windows service..."; Tasks: startall; Flags: runhidden waituntilterminated
-
-[UninstallRun]
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer.ps1"" -NoPrompt -Uninstall -InstallDir ""{app}"""; WorkingDir: "{app}"; Flags: runhidden waituntilterminated
+[UninstallDelete]
+Type: files; Name: "{app}\{#ServiceConfig}.*.bak"
 
 [Code]
 const
   EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
   InstallerKey = 'Software\Dagu\InnoSetup';
   PathMarker = 'SystemPathAdded';
+  ServiceWrapper = '{#ServiceWrapper}';
+  InstallerScript = 'installer.ps1';
 
 function PathHasEntry(const Value, Entry: string): Boolean;
 var
@@ -160,16 +161,113 @@ begin
   RegDeleteKeyIfEmpty(HKLM, InstallerKey);
 end;
 
+function PowerShellPath: string;
+begin
+  { Setup runs as a 32-bit process, so resolving by name alone can reach the
+    WOW64 PowerShell, which reports the x86 Program Files directory. }
+  Result := ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe');
+  if not FileExists(Result) then begin
+    Result := 'powershell.exe';
+  end;
+end;
+
+function InstallerScriptArgs(const Extra: string): string;
+begin
+  Result := '-NoProfile -ExecutionPolicy Bypass -File "' +
+    ExpandConstant('{app}\') + InstallerScript + '" -NoPrompt -ServiceOnly ' +
+    Extra + ' -InstallDir "' + ExpandConstant('{app}') + '"';
+end;
+
+function RetryCommand: string;
+begin
+  Result := 'powershell -ExecutionPolicy Bypass -File "' +
+    ExpandConstant('{app}\') + InstallerScript +
+    '" -ServiceOnly -Service yes -InstallDir "' + ExpandConstant('{app}') + '"';
+end;
+
+procedure InstallService;
+var
+  ResultCode: Integer;
+begin
+  if not Exec(PowerShellPath,
+              InstallerScriptArgs('-Service yes -ServiceScope system -OpenBrowser no'),
+              ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+    Log('Dagu service setup could not be started: ' + SysErrorMessage(ResultCode));
+    SuppressibleMsgBox(
+      'Dagu was installed, but the Windows service could not be configured.' + #13#10#13#10 +
+      SysErrorMessage(ResultCode) + #13#10#13#10 +
+      'Retry from an elevated PowerShell prompt:' + #13#10 + RetryCommand,
+      mbError, MB_OK, IDOK);
+    exit;
+  end;
+  if ResultCode <> 0 then begin
+    Log('Dagu service setup failed with exit code ' + IntToStr(ResultCode) + '.');
+    SuppressibleMsgBox(
+      'Dagu was installed, but the Windows service setup failed (exit code ' +
+      IntToStr(ResultCode) + ').' + #13#10#13#10 +
+      'Retry from an elevated PowerShell prompt to see the error:' + #13#10 + RetryCommand,
+      mbError, MB_OK, IDOK);
+  end;
+end;
+
+procedure RemoveService;
+var
+  ResultCode: Integer;
+  Wrapper: string;
+begin
+  Wrapper := ExpandConstant('{app}\') + ServiceWrapper;
+  if not FileExists(Wrapper) then begin
+    exit;
+  end;
+  if not FileExists(ExpandConstant('{app}\') + InstallerScript) then begin
+    Exec(Wrapper, 'stop', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(Wrapper, 'uninstall', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    exit;
+  end;
+  if (not Exec(PowerShellPath, InstallerScriptArgs('-Uninstall'),
+               ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode))
+     or (ResultCode <> 0) then begin
+    Log('Dagu service removal failed with code ' + IntToStr(ResultCode) + '.');
+    SuppressibleMsgBox(
+      'The Dagu Windows service could not be removed automatically.' + #13#10#13#10 +
+      'Remove it manually from an elevated prompt:' + #13#10 +
+      '"' + Wrapper + '" stop' + #13#10 +
+      '"' + Wrapper + '" uninstall',
+      mbError, MB_OK, IDOK);
+  end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+  Wrapper: string;
+begin
+  Result := '';
+  { A running service holds dagu.exe open, which would block the file copy.
+    The wrapper returns only once the service has actually stopped. }
+  Wrapper := ExpandConstant('{app}\') + ServiceWrapper;
+  if FileExists(Wrapper) then begin
+    Exec(Wrapper, 'stop', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
-  if (CurStep = ssPostInstall) and WizardIsTaskSelected('path') then begin
+  if CurStep <> ssPostInstall then begin
+    exit;
+  end;
+  if WizardIsTaskSelected('path') then begin
     AddInstallPath;
+  end;
+  if WizardIsTaskSelected('service') then begin
+    InstallService;
   end;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usUninstall then begin
+    RemoveService;
     RemoveInstallPath;
   end;
 end;

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -27,10 +27,12 @@ DefaultDirName={autopf}\Dagu
 DefaultGroupName={#AppName}
 DisableProgramGroupPage=yes
 PrivilegesRequired=admin
+ChangesEnvironment=yes
 ArchitecturesInstallIn64BitMode=x64compatible
 ArchitecturesAllowed=x64compatible
 OutputBaseFilename=dagu-{#AppVersion}-setup
 Uninstallable=yes
+UninstallDisplayIcon={app}\{#AppExeName}
 WizardStyle=modern
 
 [Tasks]
@@ -112,11 +114,6 @@ begin
   end;
 end;
 
-procedure BroadcastEnvironmentChange;
-begin
-  SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 'Environment');
-end;
-
 procedure AddInstallPath;
 var
   Path, InstallPath, PreviousPath: string;
@@ -130,7 +127,6 @@ begin
     Path := RemovePathEntry(Path, PreviousPath);
     RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path);
     RegDeleteValue(HKLM, InstallerKey, PathMarker);
-    BroadcastEnvironmentChange;
   end;
   if PathHasEntry(Path, InstallPath) then begin
     RegDeleteValue(HKLM, InstallerKey, PathMarker);
@@ -143,7 +139,6 @@ begin
     end;
     RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path + InstallPath);
     RegWriteStringValue(HKLM, InstallerKey, PathMarker, InstallPath);
-    BroadcastEnvironmentChange;
   end;
 end;
 
@@ -156,7 +151,6 @@ begin
   end;
   if RegQueryStringValue(HKLM, EnvironmentKey, 'Path', Path) then begin
     RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', RemovePathEntry(Path, InstallPath));
-    BroadcastEnvironmentChange;
   end;
   RegDeleteValue(HKLM, InstallerKey, PathMarker);
   RegDeleteKeyIfEmpty(HKLM, InstallerKey);

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -118,29 +118,32 @@ end;
 procedure AddInstallPath;
 var
   Path, InstallPath, PreviousPath: string;
+  Owned: Boolean;
 begin
   InstallPath := ExpandConstant('{app}');
   if not RegQueryStringValue(HKLM, EnvironmentKey, 'Path', Path) then begin
     Path := '';
   end;
-  if RegQueryStringValue(HKLM, InstallerKey, PathMarker, PreviousPath) and
-     (CompareText(PreviousPath, InstallPath) <> 0) then begin
+  Owned := RegQueryStringValue(HKLM, InstallerKey, PathMarker, PreviousPath);
+  if Owned and (CompareText(PreviousPath, InstallPath) <> 0) then begin
     Path := RemovePathEntry(Path, PreviousPath);
     RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path);
     RegDeleteValue(HKLM, InstallerKey, PathMarker);
+    Owned := False;
   end;
   if PathHasEntry(Path, InstallPath) then begin
-    RegDeleteValue(HKLM, InstallerKey, PathMarker);
-    RegDeleteKeyIfEmpty(HKLM, InstallerKey);
+    if not Owned then begin
+      { The entry predates this installer, so it must not be removed on uninstall. }
+      RegDeleteValue(HKLM, InstallerKey, PathMarker);
+      RegDeleteKeyIfEmpty(HKLM, InstallerKey);
+    end;
     exit;
   end;
-  if not PathHasEntry(Path, InstallPath) then begin
-    if Path <> '' then begin
-      Path := Path + ';';
-    end;
-    RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path + InstallPath);
-    RegWriteStringValue(HKLM, InstallerKey, PathMarker, InstallPath);
+  if Path <> '' then begin
+    Path := Path + ';';
   end;
+  RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path + InstallPath);
+  RegWriteStringValue(HKLM, InstallerKey, PathMarker, InstallPath);
 end;
 
 procedure RemoveInstallPath;

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -15,6 +15,7 @@
 #define AppExeName "dagu.exe"
 
 [Setup]
+SourceDir=..
 AppId={{A7E7B5F3-93B2-4D5E-9D7A-5A4A96D2B8A3}
 AppName={#AppName}
 AppVersion={#AppVersion}
@@ -27,6 +28,7 @@ DefaultGroupName={#AppName}
 DisableProgramGroupPage=yes
 PrivilegesRequired=admin
 ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
 OutputBaseFilename=dagu-{#AppVersion}-setup
 Uninstallable=yes
 WizardStyle=modern
@@ -117,11 +119,23 @@ end;
 
 procedure AddInstallPath;
 var
-  Path, InstallPath: string;
+  Path, InstallPath, PreviousPath: string;
 begin
   InstallPath := ExpandConstant('{app}');
   if not RegQueryStringValue(HKLM, EnvironmentKey, 'Path', Path) then begin
     Path := '';
+  end;
+  if RegQueryStringValue(HKLM, InstallerKey, PathMarker, PreviousPath) and
+     (CompareText(PreviousPath, InstallPath) <> 0) then begin
+    Path := RemovePathEntry(Path, PreviousPath);
+    RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path);
+    RegDeleteValue(HKLM, InstallerKey, PathMarker);
+    BroadcastEnvironmentChange;
+  end;
+  if PathHasEntry(Path, InstallPath) then begin
+    RegDeleteValue(HKLM, InstallerKey, PathMarker);
+    RegDeleteKeyIfEmpty(HKLM, InstallerKey);
+    exit;
   end;
   if not PathHasEntry(Path, InstallPath) then begin
     if Path <> '' then begin

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -30,6 +30,7 @@ PrivilegesRequired=admin
 ChangesEnvironment=yes
 ArchitecturesInstallIn64BitMode=x64compatible
 ArchitecturesAllowed=x64compatible
+OutputDir=dist
 OutputBaseFilename=dagu-{#AppVersion}-setup
 Uninstallable=yes
 UninstallDisplayIcon={app}\{#AppExeName}

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -211,8 +211,9 @@ begin
     SuppressibleMsgBox(
       'Dagu was installed, but the Windows service setup failed (exit code ' +
       IntToStr(ResultCode) + ').' + #13#10#13#10 +
-      'The usual cause is that port {#DefaultPort} or {#DefaultCoordinatorPort} is ' +
-      'already in use. Retry from an elevated PowerShell prompt to see the error, ' +
+      'Common causes are no network access to download the service wrapper, ' +
+      'or port {#DefaultPort} or {#DefaultCoordinatorPort} already being in use. ' +
+      'Retry from an elevated PowerShell prompt to see the actual error, ' +
       'changing -Port or -CoordinatorPort if needed:' + #13#10 + RetryCommand,
       mbError, MB_OK, IDOK);
   end;

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -1,0 +1,163 @@
+; Copyright (C) 2026 Yota Hamada
+; SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef AppVersion
+#define AppVersion "0.0.0"
+#endif
+
+#ifndef BinaryPath
+#define BinaryPath "dist\dagu-windows-amd64.exe"
+#endif
+
+#define AppName "Dagu"
+#define AppPublisher "Dagu"
+#define AppURL "https://github.com/dagucloud/dagu"
+#define AppExeName "dagu.exe"
+
+[Setup]
+AppId={{A7E7B5F3-93B2-4D5E-9D7A-5A4A96D2B8A3}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}
+AppUpdatesURL={#AppURL}/releases
+DefaultDirName={autopf}\Dagu
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=admin
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputBaseFilename=dagu-{#AppVersion}-setup
+Uninstallable=yes
+WizardStyle=modern
+
+[Tasks]
+Name: "path"; Description: "Add Dagu to the system PATH"; GroupDescription: "Additional options:"
+Name: "startall"; Description: "Install Dagu as a Windows service (start-all)"; GroupDescription: "Background service:"
+Name: "server"; Description: "Add a Dagu server shortcut"; GroupDescription: "Dagu commands:"
+Name: "scheduler"; Description: "Add a Dagu scheduler shortcut"; GroupDescription: "Dagu commands:"
+Name: "coordinator"; Description: "Add a Dagu coordinator shortcut"; GroupDescription: "Dagu commands:"
+Name: "worker"; Description: "Add a Dagu worker shortcut"; GroupDescription: "Dagu commands:"
+
+[Files]
+Source: "{#BinaryPath}"; DestDir: "{app}"; DestName: "{#AppExeName}"; Flags: ignoreversion
+Source: "scripts\installer.ps1"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\Dagu start-all"; Filename: "{app}\{#AppExeName}"; Parameters: "start-all"; WorkingDir: "{app}"; Tasks: startall
+Name: "{group}\Dagu server"; Filename: "{app}\{#AppExeName}"; Parameters: "server"; WorkingDir: "{app}"; Tasks: server
+Name: "{group}\Dagu scheduler"; Filename: "{app}\{#AppExeName}"; Parameters: "scheduler"; WorkingDir: "{app}"; Tasks: scheduler
+Name: "{group}\Dagu coordinator"; Filename: "{app}\{#AppExeName}"; Parameters: "coordinator"; WorkingDir: "{app}"; Tasks: coordinator
+Name: "{group}\Dagu worker"; Filename: "{app}\{#AppExeName}"; Parameters: "worker"; WorkingDir: "{app}"; Tasks: worker
+
+[Run]
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer.ps1"" -NoPrompt -Service yes -ServiceScope system -Version ""{#AppVersion}"" -InstallDir ""{app}"" -OpenBrowser no"; WorkingDir: "{app}"; StatusMsg: "Installing the Dagu Windows service..."; Tasks: startall; Flags: runhidden waituntilterminated
+
+[UninstallRun]
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer.ps1"" -NoPrompt -Uninstall -InstallDir ""{app}"""; WorkingDir: "{app}"; Flags: runhidden waituntilterminated
+
+[Code]
+const
+  EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+  InstallerKey = 'Software\Dagu\InnoSetup';
+  PathMarker = 'SystemPathAdded';
+
+function PathHasEntry(const Value, Entry: string): Boolean;
+var
+  Remaining, Segment: string;
+  Separator: Integer;
+begin
+  Remaining := Value;
+  while Remaining <> '' do begin
+    Separator := Pos(';', Remaining);
+    if Separator = 0 then begin
+      Segment := Remaining;
+      Remaining := '';
+    end else begin
+      Segment := Copy(Remaining, 1, Separator - 1);
+      Delete(Remaining, 1, Separator);
+    end;
+    if CompareText(Trim(Segment), Entry) = 0 then begin
+      Result := True;
+      exit;
+    end;
+  end;
+  Result := False;
+end;
+
+function RemovePathEntry(const Value, Entry: string): string;
+var
+  Remaining, Segment: string;
+  Separator: Integer;
+begin
+  Result := '';
+  Remaining := Value;
+  while Remaining <> '' do begin
+    Separator := Pos(';', Remaining);
+    if Separator = 0 then begin
+      Segment := Remaining;
+      Remaining := '';
+    end else begin
+      Segment := Copy(Remaining, 1, Separator - 1);
+      Delete(Remaining, 1, Separator);
+    end;
+    if (Trim(Segment) <> '') and (CompareText(Trim(Segment), Entry) <> 0) then begin
+      if Result <> '' then begin
+        Result := Result + ';';
+      end;
+      Result := Result + Segment;
+    end;
+  end;
+end;
+
+procedure BroadcastEnvironmentChange;
+begin
+  SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 'Environment');
+end;
+
+procedure AddInstallPath;
+var
+  Path, InstallPath: string;
+begin
+  InstallPath := ExpandConstant('{app}');
+  if not RegQueryStringValue(HKLM, EnvironmentKey, 'Path', Path) then begin
+    Path := '';
+  end;
+  if not PathHasEntry(Path, InstallPath) then begin
+    if Path <> '' then begin
+      Path := Path + ';';
+    end;
+    RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', Path + InstallPath);
+    RegWriteStringValue(HKLM, InstallerKey, PathMarker, InstallPath);
+    BroadcastEnvironmentChange;
+  end;
+end;
+
+procedure RemoveInstallPath;
+var
+  Path, InstallPath: string;
+begin
+  if not RegQueryStringValue(HKLM, InstallerKey, PathMarker, InstallPath) then begin
+    exit;
+  end;
+  if RegQueryStringValue(HKLM, EnvironmentKey, 'Path', Path) then begin
+    RegWriteExpandStringValue(HKLM, EnvironmentKey, 'Path', RemovePathEntry(Path, InstallPath));
+    BroadcastEnvironmentChange;
+  end;
+  RegDeleteValue(HKLM, InstallerKey, PathMarker);
+  RegDeleteKeyIfEmpty(HKLM, InstallerKey);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if (CurStep = ssPostInstall) and WizardIsTaskSelected('path') then begin
+    AddInstallPath;
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then begin
+    RemoveInstallPath;
+  end;
+end;

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -15,6 +15,7 @@ param(
     [string]$ServiceScope = "",
     [string]$HostAddress = "",
     [string]$Port = "",
+    [string]$CoordinatorPort = "",
     [string[]]$SkillsDir = @(),
     [string]$AdminUsername = "",
     [string]$AdminPassword = "",
@@ -72,6 +73,8 @@ $Script:ReleaseApi = "https://api.github.com/repos/dagucloud/dagu/releases/lates
 $Script:WinSWVersion = "v2.12.0"
 $Script:WinSWBase = "https://github.com/winsw/winsw/releases/download/$($Script:WinSWVersion)"
 $Script:ServiceName = "Dagu"
+# start-all leaves the coordinator on its own default host, so only the port is configurable here.
+$Script:CoordinatorHost = "127.0.0.1"
 $Script:ServiceWrapperExe = $null
 $Script:ServiceConfigXml = $null
 $Script:DaguExe = $null
@@ -306,8 +309,10 @@ function Validate-UninstallArgs {
     if ($Script:InstallerBoundParameterNames -contains "Version") {
         throw "-Version is only supported during install."
     }
-    if (($Script:InstallerBoundParameterNames -contains "HostAddress") -or ($Script:InstallerBoundParameterNames -contains "Port")) {
-        throw "-HostAddress and -Port are only supported during install."
+    if (($Script:InstallerBoundParameterNames -contains "HostAddress") -or
+        ($Script:InstallerBoundParameterNames -contains "Port") -or
+        ($Script:InstallerBoundParameterNames -contains "CoordinatorPort")) {
+        throw "-HostAddress, -Port, and -CoordinatorPort are only supported during install."
     }
     if (($Script:InstallerBoundParameterNames -contains "AdminUsername") -or ($Script:InstallerBoundParameterNames -contains "AdminPassword")) {
         throw "Admin bootstrap flags are only supported during install."
@@ -353,6 +358,9 @@ function Resolve-Defaults {
     }
     if (-not $Port) {
         $script:Port = "8080"
+    }
+    if (-not $CoordinatorPort) {
+        $script:CoordinatorPort = "50055"
     }
     if (-not $OpenBrowser) {
         $script:OpenBrowser = "yes"
@@ -808,6 +816,7 @@ function Show-Plan {
         Write-Host ("Service scope".PadRight(20) + $ServiceScope)
         Write-Host ("Dagu home".PadRight(20) + $DaguHome)
         Write-Host ("Web URL".PadRight(20) + $ServiceUrl)
+        Write-Host ("Coordinator port".PadRight(20) + $CoordinatorPort)
         Write-Host ("Admin bootstrap".PadRight(20) + $(if ($AdminUsername) { $AdminUsername } else { "disabled" }))
     }
     if (-not $ServiceOnly) {
@@ -868,6 +877,7 @@ function Get-ForwardArgs {
     if ($ServiceScope) { $argsList += @("-ServiceScope", $ServiceScope) }
     if ($HostAddress) { $argsList += @("-HostAddress", $HostAddress) }
     if ($Port) { $argsList += @("-Port", $Port) }
+    if ($CoordinatorPort) { $argsList += @("-CoordinatorPort", $CoordinatorPort) }
     foreach ($dir in $SkillsDir) { $argsList += @("-SkillsDir", $dir) }
     if ($AdminUsername) { $argsList += @("-AdminUsername", $AdminUsername) }
     if ($AdminPassword) { $argsList += @("-AdminPassword", $AdminPassword) }
@@ -1075,6 +1085,7 @@ function Write-ServiceXml {
   <env name="DAGU_HOME" value="$(Escape-XmlValue $Script:DaguHome)" />
   <env name="DAGU_HOST" value="$(Escape-XmlValue $Script:HostAddress)" />
   <env name="DAGU_PORT" value="$(Escape-XmlValue $Script:Port)" />
+  <env name="DAGU_COORDINATOR_PORT" value="$(Escape-XmlValue $Script:CoordinatorPort)" />
 "@
     if ($IncludeBootstrap -and (Has-AdminBootstrap)) {
         $xml += @"
@@ -1104,6 +1115,47 @@ function Invoke-WinSW {
         return
     }
     & $ServiceWrapperExe $Command | Out-Null
+}
+
+function Test-PortFree {
+    param(
+        [string]$Address,
+        [string]$PortNumber
+    )
+    try {
+        $listener = New-Object System.Net.Sockets.TcpListener -ArgumentList `
+            ([Net.IPAddress]::Parse($Address)), ([int]$PortNumber)
+    }
+    catch {
+        # A non-literal host or port cannot be probed, so leave the report to the service start.
+        return $true
+    }
+    try {
+        $listener.Start()
+        $listener.Stop()
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+# start-all binds the web server and the coordinator, and a failure on either one
+# stops the whole service. Report the conflict before a service is registered.
+function Validate-ServicePorts {
+    if ($Service -ne "yes") {
+        return
+    }
+    # An upgrade replaces a service that still holds its own ports.
+    if (Get-Service -Name $Script:ServiceName -ErrorAction SilentlyContinue) {
+        return
+    }
+    if (-not (Test-PortFree -Address $HostAddress -PortNumber $Port)) {
+        throw "Port $Port on $HostAddress is already in use. Rerun with -Port to pick another port for the Dagu web server."
+    }
+    if (-not (Test-PortFree -Address $Script:CoordinatorHost -PortNumber $CoordinatorPort)) {
+        throw "Port $CoordinatorPort on $($Script:CoordinatorHost) is already in use. Rerun with -CoordinatorPort to pick another port for the Dagu coordinator."
+    }
 }
 
 function Install-WindowsService {
@@ -1160,7 +1212,9 @@ function Verify-Bootstrap {
     }
     if (-not (Has-AdminBootstrap)) {
         if ($ServiceOnly -and -not (Wait-ForHealth -Attempts 30)) {
-            throw "The Dagu service started, but $ServiceUrl did not become healthy."
+            # Leave the service registered but stopped so it stops restarting a failing process.
+            try { Invoke-WinSW stop } catch {}
+            throw "The Dagu service did not become healthy at $ServiceUrl and has been stopped. Check the logs in $(Join-Path $DaguHome 'logs')."
         }
         Write-WarnMessage "No initial admin credentials were provided. Open $ServiceUrl/setup to finish the first-time setup."
         return
@@ -1304,6 +1358,7 @@ if ($DryRun) {
 
 Install-DaguBinary
 Ensure-PathEntry
+Validate-ServicePorts
 Install-WindowsService
 Verify-Bootstrap
 Install-AISkill

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -318,6 +318,9 @@ function Validate-UninstallArgs {
     if ($Script:InstallerBoundParameterNames -contains "Service") {
         throw "-Service is only supported during install. Use -ServiceScope to narrow service uninstall discovery."
     }
+    if ($ServiceOnly -and ($PurgeData -or $RemoveSkill)) {
+        throw "-ServiceOnly cannot be combined with -PurgeData or -RemoveSkill."
+    }
     if ($ServiceScope -and $ServiceScope -ne "system") {
         Write-WarnMessage "Windows uninstall ignores -ServiceScope user. The Dagu service is machine-scoped when installed."
     }
@@ -523,6 +526,14 @@ function Discover-UninstallArtifacts {
             $script:ServiceConfigXml = Join-Path $InstallDir "dagu-service.xml"
             $script:DaguExe = $explicitExe
         }
+    }
+
+    if ($ServiceOnly) {
+        $script:UninstallInstallPaths = @()
+        $script:UninstallPathScopes = @()
+        $script:UninstallDaguHomes = @()
+        $script:UninstallSkillDirs = @()
+        $script:UninstallCopilotFiles = @()
     }
 }
 

--- a/scripts/installer.ps1
+++ b/scripts/installer.ps1
@@ -20,6 +20,7 @@ param(
     [string]$AdminPassword = "",
     [ValidateSet("yes", "no")]
     [string]$OpenBrowser = "",
+    [switch]$ServiceOnly,
     [switch]$Uninstall,
     [switch]$PurgeData,
     [switch]$RemoveSkill,
@@ -170,7 +171,7 @@ function Join-Values {
 }
 
 function Choose-OperationMode {
-    if ($Uninstall) {
+    if ($Uninstall -or $ServiceOnly) {
         return
     }
     if (-not (Test-Interactive)) {
@@ -234,6 +235,9 @@ function Read-PasswordConfirm {
 }
 
 function Get-LatestVersion {
+    if ($ServiceOnly) {
+        return
+    }
     if ($Version) {
         if ($Version -ieq "latest") {
             $script:Version = ""
@@ -319,6 +323,24 @@ function Validate-UninstallArgs {
     }
 }
 
+function Validate-ServiceOnlyArgs {
+    if (-not $ServiceOnly) {
+        return
+    }
+    if ($Service -ne "yes") {
+        throw "-ServiceOnly requires -Service yes."
+    }
+    if ($Script:InstallerBoundParameterNames -contains "Version") {
+        throw "-Version is not supported with -ServiceOnly. The Dagu binary must already be installed."
+    }
+    if ($SkillsDir.Count -gt 0) {
+        throw "-SkillsDir is not supported with -ServiceOnly."
+    }
+    if (-not (Test-Path $DaguExe)) {
+        throw "-ServiceOnly requires an existing Dagu binary at $DaguExe."
+    }
+}
+
 function Resolve-Defaults {
     if (-not $Service) {
         $script:Service = if (Test-Interactive) { "yes" } else { "no" }
@@ -368,6 +390,9 @@ function Resolve-Defaults {
 }
 
 function Detect-SkillTargets {
+    if ($ServiceOnly) {
+        return
+    }
     $userHome = [Environment]::GetFolderPath("UserProfile")
     $count = 0
     $agentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $userHome ".agents" }
@@ -762,8 +787,10 @@ function Show-UninstallSummary {
 }
 
 function Show-Plan {
-    Write-Section "Install plan"
-    Write-Host ("Version".PadRight(20) + $Version)
+    Write-Section $(if ($ServiceOnly) { "Service setup plan" } else { "Install plan" })
+    if (-not $ServiceOnly) {
+        Write-Host ("Version".PadRight(20) + $Version)
+    }
     Write-Host ("Install directory".PadRight(20) + $InstallDir)
     Write-Host ("Background service".PadRight(20) + $Service)
     if ($Service -eq "yes") {
@@ -772,14 +799,16 @@ function Show-Plan {
         Write-Host ("Web URL".PadRight(20) + $ServiceUrl)
         Write-Host ("Admin bootstrap".PadRight(20) + $(if ($AdminUsername) { $AdminUsername } else { "disabled" }))
     }
-    Write-Host ("Skill install".PadRight(20) + $(if ($SkillMode -eq "explicit") { "custom" } elseif ($SkillMode -eq "auto") { "detected tools" } else { "skip" }))
+    if (-not $ServiceOnly) {
+        Write-Host ("Skill install".PadRight(20) + $(if ($SkillMode -eq "explicit") { "custom" } elseif ($SkillMode -eq "auto") { "detected tools" } else { "skip" }))
+    }
     if ($DryRun) {
         Write-Host ("Dry run".PadRight(20) + "yes")
     }
 }
 
 function Invoke-InstallerWizard {
-    if (-not (Test-Interactive)) {
+    if ($ServiceOnly -or -not (Test-Interactive)) {
         return
     }
 
@@ -832,6 +861,7 @@ function Get-ForwardArgs {
     if ($AdminUsername) { $argsList += @("-AdminUsername", $AdminUsername) }
     if ($AdminPassword) { $argsList += @("-AdminPassword", $AdminPassword) }
     if ($OpenBrowser) { $argsList += @("-OpenBrowser", $OpenBrowser) }
+    if ($ServiceOnly) { $argsList += "-ServiceOnly" }
     if ($Uninstall) { $argsList += "-Uninstall" }
     if ($PurgeData) { $argsList += "-PurgeData" }
     if ($RemoveSkill) { $argsList += "-RemoveSkill" }
@@ -852,6 +882,9 @@ function Ensure-ElevatedForService {
         throw "Service installation on Windows requires running PowerShell as Administrator."
     }
     if (-not (Confirm-Choice "Windows service installation needs Administrator rights. Elevate now?" $true)) {
+        if ($ServiceOnly) {
+            throw "-ServiceOnly requires Administrator rights to configure the Windows service."
+        }
         $script:Service = "no"
         Resolve-Defaults
         return
@@ -940,6 +973,10 @@ function New-TempDir {
 }
 
 function Install-DaguBinary {
+    if ($ServiceOnly) {
+        Write-Info "Using the existing Dagu binary at $DaguExe"
+        return
+    }
     $arch = Get-WindowsArch
     $tmpDir = New-TempDir
     try {
@@ -969,6 +1006,9 @@ function Install-DaguBinary {
 }
 
 function Ensure-PathEntry {
+    if ($ServiceOnly) {
+        return
+    }
     if ($DryRun) {
         Write-Info "Would update PATH to include $InstallDir"
         return
@@ -1108,6 +1148,9 @@ function Verify-Bootstrap {
         return
     }
     if (-not (Has-AdminBootstrap)) {
+        if ($ServiceOnly -and -not (Wait-ForHealth -Attempts 30)) {
+            throw "The Dagu service started, but $ServiceUrl did not become healthy."
+        }
         Write-WarnMessage "No initial admin credentials were provided. Open $ServiceUrl/setup to finish the first-time setup."
         return
     }
@@ -1201,7 +1244,7 @@ function Open-BrowserIfRequested {
 
 function Show-Summary {
     Write-Section "Success"
-    Write-Host ("Installed".PadRight(20) + $DaguExe)
+    Write-Host ($(if ($ServiceOnly) { "Dagu binary" } else { "Installed" }).PadRight(20) + $DaguExe)
     if ($Service -eq "yes") {
         Write-Host ("Service URL".PadRight(20) + $ServiceUrl)
         Write-Host ("Service".PadRight(20) + $Script:ServiceName)
@@ -1238,6 +1281,7 @@ Detect-SkillTargets
 Resolve-Defaults
 Invoke-InstallerWizard
 Resolve-Defaults
+Validate-ServiceOnlyArgs
 Validate-AdminBootstrap
 Ensure-ElevatedForService
 Show-Plan


### PR DESCRIPTION
## Summary

Add a Windows Inno Setup package for Dagu.

## Changes

- Install the Windows binary under `%ProgramFiles%\\Dagu` with administrator privileges.
- Let users add the install directory to the machine PATH safely and remove only the entry managed by this installer.
- Offer Start Menu launchers for `start-all`, `server`, `scheduler`, `coordinator`, and `worker`.
- Reuse the existing PowerShell installer for the optional `start-all` Windows service and uninstall cleanup.
- Compile the Inno Setup script in the Windows CI installer job.

## Related Issues

Refs #1429

## Testing

- `git diff --check`
- `go build -trimpath -o /tmp/dagu-campaign-windows-check ./cmd`
- `go test ./internal/cmd ./internal/service/frontend/api/v1`
- `.github/workflows/ci.yaml` parsed with PyYAML
- Inno Setup compilation runs in Windows CI; `iscc` is unavailable on this Linux host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows Inno Setup installer for Dagu and checks service ports up front so a conflict is reported before anything is registered.

- Installs to `%ProgramFiles%\Dagu` with administrator privileges; a running service is stopped before upgrades so the binary is never left locked.
- Optionally adds the install directory to the machine PATH and removes only its own entry on uninstall, preserving ownership across reinstalls.
- Creates Start Menu shortcuts for `server`, `scheduler`, `coordinator`, and `worker`; the `start-all` shortcut is separate and unchecked by default so it cannot bind the port the service uses.
- Reuses `installer.ps1 -ServiceOnly` for the optional service, which skips the release download and, on uninstall, removes only the service; setup failures show the exact retry command and name the wrapper download as a common cause.
- Probes the web server and coordinator ports before the service is registered and adds `-CoordinatorPort` to change the latter; a service that never becomes healthy is stopped instead of left restarting.
- Compiles and tests the Inno Setup script, PATH handling, and port conflicts in the Windows CI installer job, clearing the rejected install's exit code so the busy-port test doesn't spuriously fail.

Refs #1429.

<sup>Written for commit fba1311dc97cc38c02dc280a05e6649fa3099ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Windows installer for Dagu with optional PATH configuration, Windows service installation, and shortcuts for key commands.
  - Added support for installing and uninstalling the service through the installer.

- **Tests**
  - Added automated Windows installer compilation checks to verify the installer builds successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
