### PR TITLE
Show run parameters in workflow run lists

### DIFF
--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunGroupedView.tsx
@@ -336,6 +336,14 @@ function DAGRunGroupedView({
                               <div className="font-mono text-muted-foreground truncate">
                                 {dagRun.dagRunId}
                               </div>
+                              {dagRun.params && (
+                                <div
+                                  className="truncate font-mono text-[11px] text-muted-foreground"
+                                  title={dagRun.params}
+                                >
+                                  {dagRun.params}
+                                </div>
+                              )}
                               <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
                                 {dagRun.scheduleTime && (
                                   <div className="whitespace-nowrap">

--- a/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/DAGRunTable.tsx
@@ -384,6 +384,15 @@ function DAGRunTable({
               </div>
             </div>
 
+            {dagRun.params && (
+              <div
+                className="mb-2 truncate font-mono text-[11px] text-muted-foreground"
+                title={dagRun.params}
+              >
+                {dagRun.params}
+              </div>
+            )}
+
             {/* DAG-run ID and Trigger */}
             <div className="flex items-center justify-between text-xs mb-2 min-w-0">
               <span className="font-mono text-muted-foreground truncate">
@@ -564,14 +573,24 @@ function DAGRunTable({
                 </TableCell>
               )}
               <TableCell className="py-1 px-2 font-normal">
-                <div className="flex items-center gap-2">
-                  <Link
-                    to={`/dag-runs/${dagRun.name}/${dagRun.dagRunId}`}
-                    className="min-w-0 truncate hover:underline"
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    {dagRun.name}
-                  </Link>
+                <div className="flex min-w-0 items-start gap-2">
+                  <div className="min-w-0">
+                    <Link
+                      to={`/dag-runs/${dagRun.name}/${dagRun.dagRunId}`}
+                      className="block truncate hover:underline"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {dagRun.name}
+                    </Link>
+                    {dagRun.params && (
+                      <div
+                        className="max-w-[320px] truncate font-mono text-[11px] text-muted-foreground"
+                        title={dagRun.params}
+                      >
+                        {dagRun.params}
+                      </div>
+                    )}
+                  </div>
                   {onViewArtifacts && (
                     <DAGRunArtifactsButton
                       dagRun={dagRun}

--- a/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunGroupedView.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunGroupedView.test.tsx
@@ -69,6 +69,37 @@ describe('DAGRunGroupedView', () => {
     expect(runIds).toEqual(['run-scheduled-later', 'run-queued-later']);
   });
 
+  it('shows parameters for expanded runs', () => {
+    render(
+      <DAGRunGroupedView
+        dagRuns={[
+          {
+            dagRunId: 'run-1',
+            name: 'parameterized-dag',
+            params: 'PR_URL=https://github.com/example/project/pull/123',
+            status: Status.Success,
+            statusLabel: StatusLabel.succeeded,
+            artifactsAvailable: false,
+            autoRetryCount: 0,
+            triggerType: TriggerType.manual,
+            queuedAt: '2026-03-13T10:00:00Z',
+            startedAt: '2026-03-13T10:01:00Z',
+            finishedAt: '2026-03-13T10:02:00Z',
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('parameterized-dag'));
+
+    expect(
+      screen.getByText('PR_URL=https://github.com/example/project/pull/123')
+    ).toHaveAttribute(
+      'title',
+      'PR_URL=https://github.com/example/project/pull/123'
+    );
+  });
+
   it('toggles grouped bulk selection without opening the details panel', () => {
     const onSelectDAGRun = vi.fn();
     const onToggleBulkSelect = vi.fn();

--- a/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
+++ b/ui/src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx
@@ -93,6 +93,84 @@ describe('DAGRunTable', () => {
     expect(screen.getByText('No DAG runs found')).toBeInTheDocument();
   });
 
+  it('shows run parameters below the DAG name', () => {
+    render(
+      <MemoryRouter>
+        <ConfigContext.Provider value={config}>
+          <DAGRunTable
+            dagRuns={[
+              {
+                dagRunId: 'run-1',
+                name: 'parameterized-dag',
+                params: 'PR_URL=https://github.com/example/project/pull/123',
+                status: Status.Success,
+                statusLabel: StatusLabel.succeeded,
+                artifactsAvailable: false,
+                autoRetryCount: 0,
+                triggerType: TriggerType.manual,
+                queuedAt: '2026-03-13T10:00:30Z',
+                startedAt: '2026-03-13T10:01:00Z',
+                finishedAt: '2026-03-13T10:02:00Z',
+              },
+            ]}
+          />
+        </ConfigContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText('PR_URL=https://github.com/example/project/pull/123')
+    ).toHaveAttribute(
+      'title',
+      'PR_URL=https://github.com/example/project/pull/123'
+    );
+  });
+
+  it('shows run parameters on small screens', () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 500,
+    });
+
+    try {
+      render(
+        <MemoryRouter>
+          <ConfigContext.Provider value={config}>
+            <DAGRunTable
+              dagRuns={[
+                {
+                  dagRunId: 'run-1',
+                  name: 'mobile-dag',
+                  params: 'TICKET=INB-4303',
+                  status: Status.Success,
+                  statusLabel: StatusLabel.succeeded,
+                  artifactsAvailable: false,
+                  autoRetryCount: 0,
+                  triggerType: TriggerType.manual,
+                  queuedAt: '2026-03-13T10:00:30Z',
+                  startedAt: '2026-03-13T10:01:00Z',
+                  finishedAt: '2026-03-13T10:02:00Z',
+                },
+              ]}
+            />
+          </ConfigContext.Provider>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('TICKET=INB-4303')).toHaveAttribute(
+        'title',
+        'TICKET=INB-4303'
+      );
+      expect(screen.queryByText('DAG Name')).not.toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalWidth,
+      });
+    }
+  });
+
   it('shows the scheduled at column and value when schedule time exists', () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary

Show each DAG run's parameters below its run identity in the list, mobile, and expanded grouped views. Long values stay on one truncated line, with the full value available from the element title and the run details page.

## Changes

- Render `dagRun.params` below the DAG name in desktop and mobile lists
- Render parameters for expanded runs in the grouped view
- Test the desktop, mobile, and grouped presentations

## Related Issues

Closes #2744

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [ ] Documentation has been updated as needed
- [x] Changes have been tested locally

Validation:

- `pnpm exec vitest run src/features/dag-runs/components/dag-run-list/__tests__/DAGRunTable.test.tsx src/features/dag-runs/components/dag-run-list/__tests__/DAGRunGroupedView.test.tsx`
- `pnpm typecheck`
- ESLint on the four changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows each DAG run's parameters in the run list views so you can tell runs apart at a glance. Parameters now appear below the run identity in desktop, mobile, and expanded grouped views; previously they were only on the run details page.

- Truncates long parameter values to one line, with the full value available on hover and in the run details page.
- Adds tests covering the desktop, mobile, and grouped presentations.
- Closes #2744.

<sup>Written for commit 9883ee4ef67038f652d9ebfecdeeca8ff9531aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

