### PR TITLE
feat(ui): add MCP setup prompt to API key creation dialog

### DIFF
--- a/ui/src/i18n/staticMessages.ts
+++ b/ui/src/i18n/staticMessages.ts
@@ -2082,6 +2082,7 @@ const english = {
   'Click to update status': 'Click to update status',
   '(unchanged)': '(unchanged)',
   'Next run': 'Next run',
+  'Copy MCP setup prompt': 'Copy MCP setup prompt',
 } as const;
 
 export type StaticMessage = keyof typeof english;
@@ -4111,6 +4112,7 @@ const chinese = {
   'Click to update status': '单击以更新状态',
   '(unchanged)': '（不变）',
   'Next run': '下次运行',
+  'Copy MCP setup prompt': '复制 MCP 配置提示词',
 } as const satisfies Record<StaticMessage, string>;
 
 const japanese = {
@@ -6214,6 +6216,7 @@ const japanese = {
   'Click to update status': 'クリックしてステータスを更新',
   '(unchanged)': '（変更なし）',
   'Next run': '次の実行',
+  'Copy MCP setup prompt': 'MCP セットアップ用プロンプトをコピー',
 } as const satisfies Record<StaticMessage, string>;
 
 export const staticMessages = {

--- a/ui/src/pages/api-keys/APIKeyFormModal.tsx
+++ b/ui/src/pages/api-keys/APIKeyFormModal.tsx
@@ -59,6 +59,7 @@ export function APIKeyFormModal({
 }: APIKeyFormModalProps) {
   const config = useConfig();
   const appBarContext = useContext(AppBarContext);
+  const remoteNode = appBarContext.selectedRemoteNode || 'local';
   const isEditing = !!apiKey;
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -141,7 +142,6 @@ export function APIKeyFormModal({
 
     try {
       const token = localStorage.getItem(TOKEN_KEY);
-      const remoteNode = appBarContext.selectedRemoteNode || 'local';
       const url = isEditing
         ? `${config.apiURL}/api-keys/${apiKey.id}?remoteNode=${remoteNode}`
         : `${config.apiURL}/api-keys?remoteNode=${remoteNode}`;
@@ -206,6 +206,10 @@ export function APIKeyFormModal({
     });
   };
 
+  const canSetUpMCP =
+    remoteNode === 'local' &&
+    allowedSurfaces.includes(APIKeyAllowedSurfaces.mcp);
+
   // Show the key after creation
   if (createdKey) {
     return (
@@ -240,10 +244,11 @@ export function APIKeyFormModal({
                 )}
               </Button>
             </div>
-            {allowedSurfaces.includes(APIKeyAllowedSurfaces.mcp) && (
+            {canSetUpMCP && (
               <Button
                 variant="outline"
                 className="w-full"
+                aria-live="polite"
                 onClick={() =>
                   void promptCopy.copy(
                     buildMCPSetupPrompt(
@@ -258,7 +263,11 @@ export function APIKeyFormModal({
                 ) : (
                   <Copy className="h-4 w-4" />
                 )}
-                <I18nText text={'Copy MCP setup prompt'} />
+                {promptCopy.copied ? (
+                  <I18nText text={'Copied'} />
+                ) : (
+                  <I18nText text={'Copy MCP setup prompt'} />
+                )}
               </Button>
             )}
           </div>

--- a/ui/src/pages/api-keys/APIKeyFormModal.tsx
+++ b/ui/src/pages/api-keys/APIKeyFormModal.tsx
@@ -35,6 +35,8 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Copy, Check } from 'lucide-react';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { buildMCPServerURL, buildMCPSetupPrompt } from './mcpSetupPrompt';
 import { I18nText } from '@/i18n/I18nText';
 import { I18nProps } from '@/i18n/I18nProps';
 
@@ -75,7 +77,8 @@ export function APIKeyFormModal({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdKey, setCreatedKey] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const keyCopy = useCopyFeedback();
+  const promptCopy = useCopyFeedback();
 
   useEffect(() => {
     if (open) {
@@ -109,7 +112,6 @@ export function APIKeyFormModal({
       }
       setError(null);
       setCreatedKey(null);
-      setCopied(false);
     }
   }, [open, apiKey]);
 
@@ -189,14 +191,6 @@ export function APIKeyFormModal({
     }
   };
 
-  const handleCopy = async () => {
-    if (createdKey) {
-      await navigator.clipboard.writeText(createdKey);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
-
   const handleDone = () => {
     setCreatedKey(null);
     onSuccess();
@@ -234,14 +228,39 @@ export function APIKeyFormModal({
               <code className="flex-1 p-2 text-sm bg-muted rounded-md break-all font-mono">
                 {createdKey}
               </code>
-              <Button variant="outline" size="icon" onClick={handleCopy}>
-                {copied ? (
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => void keyCopy.copy(createdKey)}
+              >
+                {keyCopy.copied ? (
                   <Check className="h-4 w-4" />
                 ) : (
                   <Copy className="h-4 w-4" />
                 )}
               </Button>
             </div>
+            {allowedSurfaces.includes(APIKeyAllowedSurfaces.mcp) && (
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() =>
+                  void promptCopy.copy(
+                    buildMCPSetupPrompt(
+                      buildMCPServerURL(config.basePath),
+                      createdKey
+                    )
+                  )
+                }
+              >
+                {promptCopy.copied ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+                <I18nText text={'Copy MCP setup prompt'} />
+              </Button>
+            )}
           </div>
           <DialogFooter>
             <Button onClick={handleDone}>

--- a/ui/src/pages/api-keys/__tests__/index.test.tsx
+++ b/ui/src/pages/api-keys/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Yota Hamada
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -13,6 +13,8 @@ import {
 import { AppBarContext } from '@/contexts/AppBarContext';
 import { ConfigContext, type Config } from '@/contexts/ConfigContext';
 import APIKeysPage from '..';
+import { APIKeyFormModal } from '../APIKeyFormModal';
+import { buildMCPServerURL } from '../mcpSetupPrompt';
 
 vi.mock('@/contexts/AuthContext', () => ({
   TOKEN_KEY: 'daguToken',
@@ -20,6 +22,21 @@ vi.mock('@/contexts/AuthContext', () => ({
 }));
 
 type APIKey = components['schemas']['APIKey'];
+
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  'clipboard'
+);
+
+const appBarValue = {
+  title: '',
+  setTitle: () => undefined,
+  remoteNodes: ['local'],
+  setRemoteNodes: () => undefined,
+  selectedRemoteNode: 'local',
+  selectRemoteNode: () => undefined,
+  workspaces: [],
+};
 
 function makeConfig(licenseOverrides: Partial<Config['license']> = {}): Config {
   return {
@@ -112,17 +129,7 @@ function renderPage({
 
   render(
     <ConfigContext.Provider value={makeConfig(license)}>
-      <AppBarContext.Provider
-        value={{
-          title: '',
-          setTitle: () => undefined,
-          remoteNodes: ['local'],
-          setRemoteNodes: () => undefined,
-          selectedRemoteNode: 'local',
-          selectRemoteNode: () => undefined,
-          workspaces: [],
-        }}
-      >
+      <AppBarContext.Provider value={appBarValue}>
         <APIKeysPage />
       </AppBarContext.Provider>
     </ConfigContext.Provider>
@@ -194,5 +201,99 @@ describe('APIKeysPage', () => {
     expect(
       await screen.findByText(/Community installs can manage up to 2 API keys/i)
     ).toBeVisible();
+  });
+});
+
+describe('buildMCPServerURL', () => {
+  const origin = window.location.origin;
+
+  it.each([
+    ['/', `${origin}/mcp`],
+    ['', `${origin}/mcp`],
+    [undefined, `${origin}/mcp`],
+    ['/dagu', `${origin}/dagu/mcp`],
+    ['/dagu/', `${origin}/dagu/mcp`],
+  ])('resolves base path %o to %s', (basePath, expected) => {
+    expect(buildMCPServerURL(basePath)).toBe(expected);
+  });
+});
+
+describe('APIKeyFormModal', () => {
+  beforeEach(() => {
+    localStorage.setItem('daguToken', 'test-token');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard');
+    }
+  });
+
+  /**
+   * Drives the modal through a successful create so the tests can act on the
+   * one screen where the plaintext key exists.
+   */
+  async function createKey({ mcpSurface }: { mcpSurface: boolean }) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ key: 'dagu_test_secret' }),
+      })
+    );
+
+    render(
+      <ConfigContext.Provider value={makeConfig()}>
+        <AppBarContext.Provider value={appBarValue}>
+          <APIKeyFormModal
+            open
+            onClose={() => undefined}
+            onSuccess={() => undefined}
+          />
+        </AppBarContext.Provider>
+      </ConfigContext.Provider>
+    );
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'mcp-bot' },
+    });
+    if (!mcpSurface) {
+      fireEvent.click(screen.getByRole('checkbox', { name: 'MCP' }));
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Create Key' }));
+    await screen.findByText('API Key Created');
+  }
+
+  it('copies a setup prompt carrying the MCP URL and the new key', async () => {
+    await createKey({ mcpSurface: true });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy MCP setup prompt' })
+    );
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledOnce()
+    );
+    const prompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
+    expect(prompt).toContain(`${window.location.origin}/mcp`);
+    expect(prompt).toContain('Authorization: Bearer dagu_test_secret');
+  });
+
+  it('omits the setup prompt for a key that does not accept the MCP surface', async () => {
+    await createKey({ mcpSurface: false });
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy MCP setup prompt' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/src/pages/api-keys/__tests__/index.test.tsx
+++ b/ui/src/pages/api-keys/__tests__/index.test.tsx
@@ -243,7 +243,13 @@ describe('APIKeyFormModal', () => {
    * Drives the modal through a successful create so the tests can act on the
    * one screen where the plaintext key exists.
    */
-  async function createKey({ mcpSurface }: { mcpSurface: boolean }) {
+  async function createKey({
+    mcpSurface,
+    remoteNode = 'local',
+  }: {
+    mcpSurface: boolean;
+    remoteNode?: string;
+  }) {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -254,7 +260,9 @@ describe('APIKeyFormModal', () => {
 
     render(
       <ConfigContext.Provider value={makeConfig()}>
-        <AppBarContext.Provider value={appBarValue}>
+        <AppBarContext.Provider
+          value={{ ...appBarValue, selectedRemoteNode: remoteNode }}
+        >
           <APIKeyFormModal
             open
             onClose={() => undefined}
@@ -289,8 +297,14 @@ describe('APIKeyFormModal', () => {
     expect(prompt).toContain('Authorization: Bearer dagu_test_secret');
   });
 
-  it('omits the setup prompt for a key that does not accept the MCP surface', async () => {
-    await createKey({ mcpSurface: false });
+  it.each([
+    ['the key does not accept the MCP surface', { mcpSurface: false }],
+    [
+      'the key was created on a remote node',
+      { mcpSurface: true, remoteNode: 'worker-1' },
+    ],
+  ])('omits the setup prompt when %s', async (_label, options) => {
+    await createKey(options);
 
     expect(
       screen.queryByRole('button', { name: 'Copy MCP setup prompt' })

--- a/ui/src/pages/api-keys/mcpSetupPrompt.ts
+++ b/ui/src/pages/api-keys/mcpSetupPrompt.ts
@@ -25,7 +25,8 @@ export function buildMCPServerURL(basePath: string | undefined): string {
 export function buildMCPSetupPrompt(mcpURL: string, apiKey: string): string {
   return `Set up the Dagu MCP server for this project.
 
-- Transport: Streamable HTTP
+- Name: dagu
+- Transport: Streamable HTTP (Dagu exposes no SSE endpoint)
 - URL: ${mcpURL}
 - Auth header: Authorization: Bearer ${apiKey}
 

--- a/ui/src/pages/api-keys/mcpSetupPrompt.ts
+++ b/ui/src/pages/api-keys/mcpSetupPrompt.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Returns the absolute Streamable HTTP endpoint serving this instance's MCP
+ * surface, mounted under the server's base path.
+ *
+ * The endpoint is derived from the browsing origin, which is the address the
+ * server was actually reached on. The configured public URL is not published to
+ * the frontend.
+ */
+export function buildMCPServerURL(basePath: string | undefined): string {
+  const prefix = (basePath ?? '').replace(/\/+$/, '');
+  return `${window.location.origin}${prefix}/mcp`;
+}
+
+/**
+ * Returns instructions, addressed to an AI coding agent, for connecting its MCP
+ * client to the Dagu server at mcpURL using apiKey.
+ *
+ * The instructions name no particular client: each one states its server
+ * configuration differently, so the agent is left to translate the endpoint and
+ * the credential into its own format.
+ */
+export function buildMCPSetupPrompt(mcpURL: string, apiKey: string): string {
+  return `Set up the Dagu MCP server for this project.
+
+- Transport: Streamable HTTP
+- URL: ${mcpURL}
+- Auth header: Authorization: Bearer ${apiKey}
+
+Add it to my MCP client using that client's own configuration format. Keep the key out of version control: where the client supports environment variable expansion, store the key as DAGU_MCP_API_KEY and reference it from the config.
+
+Then confirm the server is connected and that the tools dagu_read, dagu_change, and dagu_execute are listed.
+
+Client setup reference: https://docs.dagu.sh/mcp/clients/
+`;
+}


### PR DESCRIPTION
## Summary

Dagu ships a built-in MCP server and API keys can be scoped to the `mcp` surface, but the two never met in the product. After creating a key, an admin saw the secret once and then had to go find the client docs and hand-translate the URL, the `Authorization` header, and the key into whatever their MCP client wanted.

This adds a **Copy MCP setup prompt** button to the "API Key Created" dialog. It copies a short natural-language prompt, with the resolved MCP endpoint and the new key already in it, to paste into Claude Code, Cursor, Codex, or any other agent. The agent then writes the config in its own format, which is why this is a client-agnostic prompt rather than a per-client snippet.

Scope is limited to the creation dialog, the one place the plaintext key exists. Dagu never stores the secret, so existing keys cannot be served this way.

## Changes

- Add `ui/src/pages/api-keys/mcpSetupPrompt.ts`, which resolves the MCP endpoint from the browsing origin plus the server base path and renders the prompt text
- Add the **Copy MCP setup prompt** button to the success dialog in `APIKeyFormModal`
- Replace the dialog's hand-rolled copy state and `setTimeout` with two `useCopyFeedback()` instances, so both copy buttons get independent feedback without duplicating a timer. This also routes the key copy through `lib/clipboard.ts`, whose `execCommand` fallback works outside secure contexts, where the previous raw `navigator.clipboard` call failed silently
- Add the button label to all three locale catalogs in `staticMessages.ts`
- Extend `ui/src/pages/api-keys/__tests__/index.test.tsx` with base-path resolution cases, a prompt-content case, and the two cases where the button must not appear

## When the button appears

Only for a local key that accepts the `mcp` surface. Both conditions are correctness rather than polish, and each has a test:

- **Surface.** The MCP route sets `RequiredAPIKeySurface = APIKeySurfaceMCP`, and `auth/middleware.go:183` answers 403 for a key without it. A prompt built from a REST-only key is a setup guaranteed to fail.
- **Remote node.** Creating a key with a remote node selected creates it on *that node's* server, since `WithRemoteNode` proxies the request. The endpoint, though, can only be derived from the browsing origin, which is the local server. The URL and the key would name different servers.

## Notes for reviewers

The endpoint comes from `window.location.origin` because the configured public URL is not published to the frontend. That is the address the operator actually reached the server on, and it handles a mounted base path (`/dagu` gives `/dagu/mcp`). If the MCP client runs somewhere that reaches Dagu at a different address, the URL needs editing after pasting; the docs say so.

The prompt names the server `dagu` and states that Dagu exposes no SSE endpoint, both of which head off documented per-client failure modes (Gemini CLI reserves `url` for SSE and needs `httpUrl`).

## Related Issues

N/A

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed (dagucloud/docs@160f08c, @f2ee61f)
- [x] Changes have been tested locally

https://claude.ai/code/session_01WwdRz7web6CqnyGk5xZv7D