### PR TITLE
fix(ui): remove status-based row tint from the step table

### DIFF
--- a/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
+++ b/ui/src/features/dags/components/dag-details/NodeStatusTableRow.tsx
@@ -495,22 +495,6 @@ function NodeStatusTableRow({
     subDAGRunId: isSubDAGRun ? dagRun.dagRunId : undefined,
   });
 
-  // Determine row highlight based on status
-  const getRowHighlight = () => {
-    switch (node.status) {
-      case NodeStatus.Running:
-        return 'bg-success-muted';
-      case NodeStatus.Retrying:
-        return 'bg-warning-muted';
-      case NodeStatus.Failed:
-        return 'bg-error-muted';
-      case NodeStatus.Waiting:
-        return 'bg-warning/5';
-      default:
-        return '';
-    }
-  };
-
   // Handle sub dagRun navigation
   const handleSubDAGRunNavigation = (
     subRunIndex: number = 0,
@@ -858,10 +842,7 @@ function NodeStatusTableRow({
     return (
       <>
         <StyledTableRow
-          className={cn(
-            'hover:bg-muted/50 transition-colors duration-200 h-auto cursor-pointer',
-            getRowHighlight()
-          )}
+          className="hover:bg-muted/50 transition-colors duration-200 h-auto cursor-pointer"
           onClick={() => {
             if (hasLogs) {
               setIsLogExpanded(!isLogExpanded);
@@ -1279,12 +1260,7 @@ function NodeStatusTableRow({
 
   // Render mobile view (card)
   return (
-    <div
-      className={cn(
-        'p-4 rounded-2xl border border-border bg-card hover:',
-        getRowHighlight()
-      )}
-    >
+    <div className="p-4 rounded-2xl border border-border bg-card">
       {/* Header with number and status */}
       <div className="flex justify-between items-center mb-3">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## What

The per-step table on the DAG status detail painted each row's background from its node status:

| Status | Background |
| --- | --- |
| Running | `bg-success-muted` |
| Retrying | `bg-warning-muted` |
| Failed | `bg-error-muted` |
| Waiting | `bg-warning/5` |

With a run in flight the table read as an arbitrary patchwork of green, amber and red bands that shifted as steps progressed. This drops the tint so every row sits on the normal row background.

## How

Removed `getRowHighlight()` from `NodeStatusTableRow` and both of its call sites — the desktop `StyledTableRow` and the mobile card. The mobile card's `className` also carried a stranded `'hover:'` fragment, which went with it.

Status is unaffected: every row already renders a `NodeStatusChip` with the status label, and active nodes still get the pulsing dot next to the duration.

## Testing

- `pnpm vitest run src/features/dags/components/dag-details/__tests__/NodeStatusTableRow.test.tsx` — 18 passed
- `pnpm typecheck` — clean

No new test. The only thing left to assert is that a CSS class is no longer emitted, which is the kind of implementation-absence test this repo avoids.

https://claude.ai/code/session_01XK4y3tWJ62bu6LEsWfMa16

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the status-based background tint from the step table rows so the table no longer reads as a shifting patchwork of green, amber, and red bands during a run.

Status is unaffected: each row still shows a status chip, and active nodes keep the pulsing dot next to the duration. Also drops a stranded `'hover:'` fragment from the mobile card's class name.

<sup>Written for commit fc176254d9e5625d469823fa54d4e906f6076a0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified DAG task status table rows by removing status-based background highlighting.
  * Desktop and mobile task entries now use consistent static styling regardless of status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->