### PR TITLE
feat(windows): publish the Inno Setup installer with each release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,3 +53,75 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.DAGU_GITHUB_TOKEN}}
+
+  # The Inno Setup compiler is Windows-only, so the installer cannot be produced
+  # in the GoReleaser job. It wraps the amd64 binary that job already published,
+  # so the installer and the archive ship identical bytes.
+  windows-installer:
+    name: Publish Windows installer
+    needs: goreleaser
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download the published Windows binary
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Context values are passed via env so they're treated as data, not code.
+          # Writing ${{ expr }} directly inside `run:` would let a crafted value
+          # execute arbitrary shell commands before the runner sees the script.
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          asset="dagu_${version}_windows_amd64.tar.gz"
+          mkdir -p dist
+          for i in {1..30}; do
+            if gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$asset" \
+              --dir dist; then
+              break
+            fi
+            echo "Attempt ${i}/30: release asset not available yet, waiting 10 seconds..."
+            sleep 10
+          done
+          if [ ! -f "dist/${asset}" ]; then
+            echo "::error::Release asset ${asset} was not available for ${RELEASE_TAG}"
+            exit 1
+          fi
+          tar -xzf "dist/${asset}" -C dist dagu.exe
+          mv dist/dagu.exe dist/dagu-windows-amd64.exe
+
+      - name: Build the installer
+        shell: powershell
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          $version = $env:RELEASE_TAG -replace '^v', ''
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            Write-Host "Inno Setup 6 is not preinstalled on this image; installing it."
+            choco install innosetup --no-progress --yes
+          }
+          & $iscc /DAppVersion=$version /DBinaryPath=dist\dagu-windows-amd64.exe scripts\installer.iss
+          if ($LASTEXITCODE -ne 0) {
+            throw "Inno Setup compilation failed with exit code $LASTEXITCODE."
+          }
+
+      - name: Attach the installer to the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          installer="dist/dagu-${version}-setup.exe"
+          if [ ! -f "$installer" ]; then
+            echo "::error::${installer} was not produced by the Inno Setup compiler"
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "$installer" \
+            --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
## Summary

Attach the Windows Inno Setup installer to every GitHub Release.

#2743 added `scripts/installer.iss`, but nothing publishes the result. GoReleaser runs on `ubuntu-latest` and the Inno Setup compiler `ISCC.exe` is Windows-only, so the only `setup.exe` produced today is the one the CI test compiles and discards. Users currently have no way to obtain the installer.

## Changes

- Add a `windows-installer` job to `release.yaml` that runs after `goreleaser`.
- Download the `dagu_<version>_windows_amd64.tar.gz` asset that job published and extract `dagu.exe` from it.
- Compile `scripts/installer.iss` against that binary and upload `dagu-<version>-setup.exe` to the same release.

Wrapping the published archive rather than rebuilding keeps the installer and the archive byte-identical, so both distribution paths ship the same binary.

## Related Issues

Refs #1429. Follows #2743.

## Notes

The installer is not listed in `checksums.txt`. GoReleaser generates and uploads that file before this job runs, and rewriting a published checksum file afterwards is worse than omitting the entry. Worth a follow-up if per-asset checksums matter for Windows.

## Testing

Verified against the real `v2.16.3` assets, since `ISCC.exe` cannot run on this host:

- `dagu_2.16.3_windows_amd64.tar.gz` contains `dagu.exe` at the archive root.
- `tar -xzf ... -C dist dagu.exe` extracts a valid `PE32+ executable (console) x86-64`.
- Tag to version to asset name derivation checked for both `v2.16.3` and a prerelease shape `v2.17.0-rc1`.
- `release.yaml` parsed with PyYAML.

The `ISCC.exe` invocation and the Chocolatey fallback match the already-passing `Test Windows installer` job in `ci.yaml`, including the working directory and both `/D` defines.

The job only exercises on a real tag push, so the first release after this merges is the actual verification.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [ ] Tests have been added or updated as needed — release workflows have no test harness in this repo; the job is validated by the next tag push
- [ ] Documentation has been updated as needed — no user-facing docs reference the installer yet
- [x] Changes have been tested locally — download, extraction and naming verified against real release assets; Inno Setup compilation cannot run on a non-Windows host

https://claude.ai/code/session_01M2GSWYZzr5MZFpiqkXdn9C