### PR TITLE
fix(gitsync): avoid stale stat cache on rapid edits

### DIFF
--- a/internal/gitsync/pull_external_test.go
+++ b/internal/gitsync/pull_external_test.go
@@ -344,6 +344,32 @@ func TestPullPreservesModifiedSupportingFileDeletedRemotely(t *testing.T) {
 	assert.NotContains(t, status.Items, "scripts/run.sh")
 }
 
+func TestPullAfterRacyEdit(t *testing.T) {
+	t.Parallel()
+
+	env := newPullExternalPushTest(t, []pullExternalTestFile{
+		{path: "scripts/run.sh", content: "echo remote\n"},
+	})
+	localPath := filepath.Join(env.dagsDir, "scripts", "run.sh")
+	info, err := os.Stat(localPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(localPath, []byte("echo edited\n"), 0600))
+	require.NoError(t, os.Chtimes(localPath, info.ModTime(), info.ModTime()))
+
+	// The first check occurs after the racy-stat window has elapsed.
+	time.Sleep(time.Until(info.ModTime().Add(2 * time.Second)))
+	commitPullExternalTestFile(t, env.seedRepo, env.seedPath, "scripts/run.sh", "echo upstream change\n", "change script")
+	require.NoError(t, env.seedRepo.Push(&git.PushOptions{
+		RemoteName: "upstream",
+		RefSpecs:   []gitconfig.RefSpec{"refs/heads/main:refs/heads/main"},
+	}))
+
+	result, err := env.svc.Pull(env.ctx)
+	require.NoError(t, err)
+	assert.Contains(t, result.Conflicts, "scripts/run.sh")
+	assert.Equal(t, "echo edited\n", readPullExternalTestFile(t, localPath))
+}
+
 func TestPullPreservesPercentInSupportingFileNames(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gitsync/service.go
+++ b/internal/gitsync/service.go
@@ -930,9 +930,15 @@ func updateStatCache(dagState *SyncItemState, info os.FileInfo) {
 	dagState.LastStatSize = &size
 }
 
+// Recent mtimes can be shared by rapid same-size writes on coarse filesystems.
+const statCacheRacyWindow = time.Second
+
 // statMatchesCache returns true if the file info matches the cached stat values.
 func statMatchesCache(dagState *SyncItemState, info os.FileInfo) bool {
 	if dagState.LastStatModTime == nil || dagState.LastStatSize == nil {
+		return false
+	}
+	if time.Since(info.ModTime()) < statCacheRacyWindow {
 		return false
 	}
 	return info.ModTime().Equal(*dagState.LastStatModTime) && info.Size() == *dagState.LastStatSize

--- a/internal/gitsync/service.go
+++ b/internal/gitsync/service.go
@@ -275,6 +275,7 @@ type localSyncResult struct {
 }
 
 func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult, commitHash string) (localSyncResult, error) {
+	checkedAt := time.Now()
 	var synced []string
 	var deleted []string
 	var conflicts []string
@@ -407,7 +408,7 @@ func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult
 			now := time.Now()
 			newState := newItemState(item, pullResult.CurrentCommit, repoHash, now)
 			if fi, err := os.Stat(localPath); err == nil {
-				updateStatCache(newState, fi)
+				updateStatCache(newState, fi, checkedAt)
 			}
 			state.Items[item.id] = newState
 			synced = append(synced, item.id)
@@ -432,7 +433,7 @@ func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult
 				now := time.Now()
 				newState := newItemState(item, pullResult.CurrentCommit, repoHash, now)
 				if fi, err := os.Stat(localPath); err == nil {
-					updateStatCache(newState, fi)
+					updateStatCache(newState, fi, checkedAt)
 				}
 				state.Items[item.id] = newState
 				synced = append(synced, item.id)
@@ -481,7 +482,7 @@ func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult
 					ConflictDetectedAt:   &now,
 				}
 				if fi, err := os.Stat(localPath); err == nil {
-					updateStatCache(state.Items[item.id], fi)
+					updateStatCache(state.Items[item.id], fi, checkedAt)
 				}
 				conflicts = append(conflicts, item.id)
 			}
@@ -494,7 +495,7 @@ func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult
 		now := time.Now()
 		newState := newItemState(item, pullResult.CurrentCommit, repoHash, now)
 		if fi, err := os.Stat(localPath); err == nil {
-			updateStatCache(newState, fi)
+			updateStatCache(newState, fi, checkedAt)
 		}
 		state.Items[item.id] = newState
 		synced = append(synced, item.id)
@@ -637,6 +638,7 @@ func (s *serviceImpl) localItemMatchesBase(itemID string, itemState *SyncItemSta
 		return false, err
 	}
 
+	checkedAt := time.Now()
 	localHash, info, err := s.hashItemFileInfo(itemID, itemState.Kind, filePath)
 	if os.IsNotExist(err) {
 		return true, nil
@@ -648,7 +650,7 @@ func (s *serviceImpl) localItemMatchesBase(itemID string, itemState *SyncItemSta
 	localExecutable := itemState.Kind == SyncItemKindFile && executableMode(info.Mode(), itemState.LastSyncedExecutable)
 	itemState.LocalHash = localHash
 	itemState.LocalExecutable = localExecutable
-	updateStatCache(itemState, info)
+	updateStatCache(itemState, info, checkedAt)
 
 	matchesBase := localHash == itemState.LastSyncedHash &&
 		(itemState.Kind != SyncItemKindFile || localExecutable == itemState.LastSyncedExecutable)
@@ -737,6 +739,7 @@ func (s *serviceImpl) scanLocalItems(state *State) error {
 		if err != nil {
 			continue
 		}
+		checkedAt := time.Now()
 		content, err := safeReadFileWithinBase(s.dagsDir, filePath)
 		if err != nil {
 			continue
@@ -751,7 +754,7 @@ func (s *serviceImpl) scanLocalItems(state *State) error {
 			ModifiedAt:    &now,
 		}
 		if fi, err := os.Stat(filePath); err == nil {
-			updateStatCache(ds, fi)
+			updateStatCache(ds, fi, checkedAt)
 		}
 		state.Items[dagID] = ds
 	}
@@ -784,6 +787,7 @@ func (s *serviceImpl) scanWikiPageFiles(state *State) {
 		if _, exists := state.Items[itemID]; exists {
 			return nil
 		}
+		checkedAt := time.Now()
 		content, err := safeReadFileWithinBase(wikiRoot, filePath)
 		if err != nil {
 			return nil
@@ -797,7 +801,7 @@ func (s *serviceImpl) scanWikiPageFiles(state *State) {
 			ModifiedAt:    &now,
 		}
 		if info, err := os.Stat(filePath); err == nil {
-			updateStatCache(itemState, info)
+			updateStatCache(itemState, info, checkedAt)
 		}
 		state.Items[itemID] = itemState
 		return nil
@@ -842,6 +846,7 @@ func (s *serviceImpl) scanWikiPageAssetFiles(state *State) {
 		if _, exists := state.Items[itemID]; exists {
 			return nil
 		}
+		checkedAt := time.Now()
 		content, err := safeReadFileWithinBase(s.localWikiDir(), filePath)
 		if err != nil {
 			return nil
@@ -854,7 +859,7 @@ func (s *serviceImpl) scanWikiPageAssetFiles(state *State) {
 			ModifiedAt: &now,
 		}
 		if info, err := os.Stat(filePath); err == nil {
-			updateStatCache(itemState, info)
+			updateStatCache(itemState, info, checkedAt)
 		}
 		state.Items[itemID] = itemState
 		return nil
@@ -885,7 +890,7 @@ func (s *serviceImpl) refreshLocalHashes(state *State, now time.Time) bool {
 		}
 
 		localExecutable := dagState.Kind == SyncItemKindFile && executableMode(info.Mode(), dagState.LastSyncedExecutable)
-		if statMatchesCache(dagState, info, now) && dagState.LocalExecutable == localExecutable {
+		if statMatchesCache(dagState, info) && dagState.LocalExecutable == localExecutable {
 			continue
 		}
 
@@ -894,7 +899,7 @@ func (s *serviceImpl) refreshLocalHashes(state *State, now time.Time) bool {
 			continue
 		}
 
-		updateStatCache(dagState, info)
+		updateStatCache(dagState, info, now)
 
 		// Update LocalHash if changed
 		if dagState.LocalHash != currentHash {
@@ -922,8 +927,16 @@ func (s *serviceImpl) refreshLocalHashes(state *State, now time.Time) bool {
 	return changed
 }
 
-// updateStatCache updates the stat cache fields on a SyncItemState from file info.
-func updateStatCache(dagState *SyncItemState, info os.FileInfo) {
+// updateStatCache caches metadata that was stable at checkedAt.
+// checkedAt must precede the content read or write associated with LocalHash.
+func updateStatCache(dagState *SyncItemState, info os.FileInfo, checkedAt time.Time) {
+	// Leave recent stats uncached so same-tick edits remain detectable on later checks.
+	if checkedAt.Sub(info.ModTime()) < statCacheRacyWindow {
+		dagState.LastStatModTime = nil
+		dagState.LastStatSize = nil
+		return
+	}
+
 	modTime := info.ModTime()
 	size := info.Size()
 	dagState.LastStatModTime = &modTime
@@ -934,11 +947,8 @@ func updateStatCache(dagState *SyncItemState, info os.FileInfo) {
 const statCacheRacyWindow = time.Second
 
 // statMatchesCache returns true if the file info matches the cached stat values.
-func statMatchesCache(dagState *SyncItemState, info os.FileInfo, now time.Time) bool {
+func statMatchesCache(dagState *SyncItemState, info os.FileInfo) bool {
 	if dagState.LastStatModTime == nil || dagState.LastStatSize == nil {
-		return false
-	}
-	if now.Sub(info.ModTime()) < statCacheRacyWindow {
 		return false
 	}
 	return info.ModTime().Equal(*dagState.LastStatModTime) && info.Size() == *dagState.LastStatSize
@@ -964,6 +974,7 @@ func (s *serviceImpl) reconcile(state *State) bool {
 		case StatusMissing:
 			if fileExists {
 				// File reappeared — hash it and decide new status
+				checkedAt := time.Now()
 				currentHash, err := s.hashItemFile(dagID, dagState.Kind, filePath)
 				if err != nil {
 					continue
@@ -979,7 +990,7 @@ func (s *serviceImpl) reconcile(state *State) bool {
 				}
 				dagState.LocalHash = currentHash
 				dagState.LocalExecutable = localExecutable
-				updateStatCache(dagState, info)
+				updateStatCache(dagState, info, checkedAt)
 				dagState.PreviousStatus = ""
 				dagState.MissingAt = nil
 				changed = true
@@ -1063,6 +1074,7 @@ func (s *serviceImpl) Publish(ctx context.Context, dagID, message string, force 
 		}
 	}
 
+	checkedAt := time.Now()
 	content, err := s.readItemFile(dagID, dagState.Kind, dagFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read sync item file: %w", err)
@@ -1096,7 +1108,7 @@ func (s *serviceImpl) Publish(ctx context.Context, dagID, message string, force 
 	contentHash := ComputeContentHash(content)
 	newState := s.newSyncedItemState(dagState.Kind, fileExtension, commitHash, contentHash, executable)
 	if fi, err := os.Stat(dagFilePath); err == nil {
-		updateStatCache(newState, fi)
+		updateStatCache(newState, fi, checkedAt)
 	}
 	state.Items[dagID] = newState
 	s.updateSuccessStateWithCommit(state, commitHash)
@@ -1193,6 +1205,7 @@ func (s *serviceImpl) PublishAll(ctx context.Context, message string, dagIDs []s
 		if err != nil {
 			return nil, err
 		}
+		checkedAt := time.Now()
 		content, _ := s.readItemFile(dagID, dagState.Kind, dagFilePath)
 		contentHash := ComputeContentHash(content)
 		executable := dagState.Kind == SyncItemKindFile && dagState.LastSyncedExecutable
@@ -1201,7 +1214,7 @@ func (s *serviceImpl) PublishAll(ctx context.Context, message string, dagIDs []s
 		}
 		newState := s.newSyncedItemState(dagState.Kind, fileExtension, commitHash, contentHash, executable)
 		if fi, err := os.Stat(dagFilePath); err == nil {
-			updateStatCache(newState, fi)
+			updateStatCache(newState, fi, checkedAt)
 		}
 		state.Items[dagID] = newState
 		result.Synced = append(result.Synced, dagID)
@@ -1272,6 +1285,7 @@ func (s *serviceImpl) Discard(_ context.Context, dagID string) error {
 		executable = dagState.RemoteExecutable
 		commitHash = dagState.RemoteCommit
 	}
+	checkedAt := time.Now()
 	if err := s.writeItemFile(dagID, dagState.Kind, dagFilePath, repoContent, executable); err != nil {
 		return fmt.Errorf("failed to write sync item file: %w", err)
 	}
@@ -1280,7 +1294,7 @@ func (s *serviceImpl) Discard(_ context.Context, dagID string) error {
 	contentHash := ComputeContentHash(repoContent)
 	newState := s.newSyncedItemState(dagState.Kind, fileExtension, commitHash, contentHash, executable)
 	if fi, err := os.Stat(dagFilePath); err == nil {
-		updateStatCache(newState, fi)
+		updateStatCache(newState, fi, checkedAt)
 	}
 	state.Items[dagID] = newState
 	_ = s.stateManager.Save(state) // Best effort - discard was successful, state will sync on next operation
@@ -1801,6 +1815,7 @@ func (s *serviceImpl) Move(ctx context.Context, oldID, newID, message string, fo
 	}
 
 	// Read through the no-follow path before changing local or Git state.
+	checkedAt := time.Now()
 	content, fileInfo, readErr := s.readItemFileInfo(oldID, oldState.Kind, oldLocalPath)
 	oldFileExists := readErr == nil
 	if readErr != nil && !os.IsNotExist(readErr) {
@@ -1862,7 +1877,7 @@ func (s *serviceImpl) Move(ctx context.Context, oldID, newID, message string, fo
 	contentHash := ComputeContentHash(content)
 	newItemState := s.newSyncedItemState(oldState.Kind, fileExtension, commitHash, contentHash, executable)
 	if fi, _, err := s.inspectItemFile(newID, oldState.Kind, newLocalPath, false); err == nil {
-		updateStatCache(newItemState, fi)
+		updateStatCache(newItemState, fi, checkedAt)
 	}
 
 	// If destination was untracked, remove the old untracked entry

--- a/internal/gitsync/service.go
+++ b/internal/gitsync/service.go
@@ -308,7 +308,7 @@ func (s *serviceImpl) syncFilesToLocal(_ context.Context, pullResult *PullResult
 	s.reconcile(state)
 
 	// Refresh hashes to detect local modifications before checking for conflicts
-	s.refreshLocalHashes(state)
+	s.refreshLocalHashes(state, time.Now())
 
 	repoFileSet := make(map[string]struct{}, len(items))
 	for _, item := range items {
@@ -862,7 +862,7 @@ func (s *serviceImpl) scanWikiPageAssetFiles(state *State) {
 }
 
 // refreshLocalHashes recalculates hashes for tracked items and updates modified status.
-func (s *serviceImpl) refreshLocalHashes(state *State) bool {
+func (s *serviceImpl) refreshLocalHashes(state *State, now time.Time) bool {
 	changed := false
 	for dagID, dagState := range state.Items {
 		// Skip untracked (no remote to compare), conflict (already detected), and missing (file absent)
@@ -885,7 +885,7 @@ func (s *serviceImpl) refreshLocalHashes(state *State) bool {
 		}
 
 		localExecutable := dagState.Kind == SyncItemKindFile && executableMode(info.Mode(), dagState.LastSyncedExecutable)
-		if statMatchesCache(dagState, info) && dagState.LocalExecutable == localExecutable {
+		if statMatchesCache(dagState, info, now) && dagState.LocalExecutable == localExecutable {
 			continue
 		}
 
@@ -934,11 +934,11 @@ func updateStatCache(dagState *SyncItemState, info os.FileInfo) {
 const statCacheRacyWindow = time.Second
 
 // statMatchesCache returns true if the file info matches the cached stat values.
-func statMatchesCache(dagState *SyncItemState, info os.FileInfo) bool {
+func statMatchesCache(dagState *SyncItemState, info os.FileInfo, now time.Time) bool {
 	if dagState.LastStatModTime == nil || dagState.LastStatSize == nil {
 		return false
 	}
-	if time.Since(info.ModTime()) < statCacheRacyWindow {
+	if now.Sub(info.ModTime()) < statCacheRacyWindow {
 		return false
 	}
 	return info.ModTime().Equal(*dagState.LastStatModTime) && info.Size() == *dagState.LastStatSize
@@ -1915,7 +1915,7 @@ func (s *serviceImpl) GetStatus(_ context.Context) (*OverallStatus, error) {
 	reconciled := s.reconcile(state)
 
 	// Refresh hashes for tracked items to detect local modifications.
-	hashesChanged := s.refreshLocalHashes(state)
+	hashesChanged := s.refreshLocalHashes(state, time.Now())
 
 	// Save state if anything changed (best effort - read-only operation)
 	if extensionsChanged || newItems || hashesChanged || reconciled {

--- a/internal/gitsync/service_test.go
+++ b/internal/gitsync/service_test.go
@@ -873,6 +873,43 @@ func TestStatBeforeHash_DetectsChangedFile(t *testing.T) {
 	assert.NotNil(t, state.Items["my-dag"].LastStatSize)
 }
 
+func TestStatBeforeHash_DetectsRecentSameStatContentChange(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	dagsDir := filepath.Join(tempDir, "dags")
+	require.NoError(t, os.MkdirAll(dagsDir, 0755))
+
+	originalContent := []byte("echo remote\n")
+	newContent := []byte("echo edited\n")
+	filePath := filepath.Join(dagsDir, "my-dag.yaml")
+	require.NoError(t, os.WriteFile(filePath, originalContent, 0600))
+
+	oldHash := ComputeContentHash(originalContent)
+	recent := time.Now()
+	require.NoError(t, os.WriteFile(filePath, newContent, 0600))
+	require.NoError(t, os.Chtimes(filePath, recent, recent))
+	fi, err := os.Stat(filePath)
+	require.NoError(t, err)
+	modTime := fi.ModTime()
+	size := fi.Size()
+
+	s := &serviceImpl{dagsDir: dagsDir, cfg: &Config{}}
+	state := &State{Items: map[string]*SyncItemState{
+		"my-dag": {
+			Status:          StatusSynced,
+			LastSyncedHash:  oldHash,
+			LocalHash:       oldHash,
+			LastStatModTime: &modTime,
+			LastStatSize:    &size,
+		},
+	}}
+
+	changed := s.refreshLocalHashes(state)
+	require.True(t, changed)
+	assert.Equal(t, StatusModified, state.Items["my-dag"].Status)
+	assert.Equal(t, ComputeContentHash(newContent), state.Items["my-dag"].LocalHash)
+}
+
 func TestStatBeforeHash_BackwardCompatibility(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()

--- a/internal/gitsync/service_test.go
+++ b/internal/gitsync/service_test.go
@@ -827,7 +827,7 @@ func TestStatBeforeHash_SkipsUnchangedFile(t *testing.T) {
 	}}
 
 	// File hasn't changed — refreshLocalHashes should skip it
-	changed := s.refreshLocalHashes(state)
+	changed := s.refreshLocalHashes(state, time.Now())
 	require.False(t, changed)
 	assert.Equal(t, StatusSynced, state.Items["my-dag"].Status)
 }
@@ -864,7 +864,7 @@ func TestStatBeforeHash_DetectsChangedFile(t *testing.T) {
 		},
 	}}
 
-	changed := s.refreshLocalHashes(state)
+	changed := s.refreshLocalHashes(state, time.Now())
 	require.True(t, changed)
 	assert.Equal(t, StatusModified, state.Items["my-dag"].Status)
 	assert.Equal(t, ComputeContentHash(newContent), state.Items["my-dag"].LocalHash)
@@ -885,7 +885,7 @@ func TestStatBeforeHash_DetectsRecentSameStatContentChange(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, originalContent, 0600))
 
 	oldHash := ComputeContentHash(originalContent)
-	recent := time.Now()
+	recent := time.Unix(1_700_000_000, 0)
 	require.NoError(t, os.WriteFile(filePath, newContent, 0600))
 	require.NoError(t, os.Chtimes(filePath, recent, recent))
 	fi, err := os.Stat(filePath)
@@ -904,7 +904,7 @@ func TestStatBeforeHash_DetectsRecentSameStatContentChange(t *testing.T) {
 		},
 	}}
 
-	changed := s.refreshLocalHashes(state)
+	changed := s.refreshLocalHashes(state, recent.Add(statCacheRacyWindow/2))
 	require.True(t, changed)
 	assert.Equal(t, StatusModified, state.Items["my-dag"].Status)
 	assert.Equal(t, ComputeContentHash(newContent), state.Items["my-dag"].LocalHash)
@@ -933,7 +933,7 @@ func TestStatBeforeHash_BackwardCompatibility(t *testing.T) {
 	}}
 
 	// Nil cache fields → should read file and populate cache
-	changed := s.refreshLocalHashes(state)
+	changed := s.refreshLocalHashes(state, time.Now())
 	// No status change since content matches
 	require.False(t, changed)
 	// But stat cache should now be populated

--- a/internal/gitsync/service_test.go
+++ b/internal/gitsync/service_test.go
@@ -798,7 +798,7 @@ func TestSummaryPriority_MissingBetweenConflictAndPending(t *testing.T) {
 
 // --- Phase 2: Stat-before-hash tests ---
 
-func TestStatBeforeHash_SkipsUnchangedFile(t *testing.T) {
+func TestStatCacheUnchanged(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()
 	dagsDir := filepath.Join(tempDir, "dags")
@@ -807,6 +807,8 @@ func TestStatBeforeHash_SkipsUnchangedFile(t *testing.T) {
 	content := []byte("steps: []")
 	filePath := filepath.Join(dagsDir, "my-dag.yaml")
 	require.NoError(t, os.WriteFile(filePath, content, 0600))
+	mtime := time.Now().Add(-2 * statCacheRacyWindow)
+	require.NoError(t, os.Chtimes(filePath, mtime, mtime))
 
 	fi, err := os.Stat(filePath)
 	require.NoError(t, err)
@@ -826,13 +828,14 @@ func TestStatBeforeHash_SkipsUnchangedFile(t *testing.T) {
 		},
 	}}
 
-	// File hasn't changed — refreshLocalHashes should skip it
+	// Stable metadata permits the unchanged file to use the cache.
+	assert.True(t, statMatchesCache(state.Items["my-dag"], fi))
 	changed := s.refreshLocalHashes(state, time.Now())
 	require.False(t, changed)
 	assert.Equal(t, StatusSynced, state.Items["my-dag"].Status)
 }
 
-func TestStatBeforeHash_DetectsChangedFile(t *testing.T) {
+func TestStatCacheChanged(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()
 	dagsDir := filepath.Join(tempDir, "dags")
@@ -852,6 +855,8 @@ func TestStatBeforeHash_DetectsChangedFile(t *testing.T) {
 	// Write different content
 	newContent := []byte("steps: [a, b, c]")
 	require.NoError(t, os.WriteFile(filePath, newContent, 0600))
+	mtime := time.Now().Add(-2 * statCacheRacyWindow)
+	require.NoError(t, os.Chtimes(filePath, mtime, mtime))
 
 	s := &serviceImpl{dagsDir: dagsDir, cfg: &Config{}}
 	state := &State{Items: map[string]*SyncItemState{
@@ -873,44 +878,95 @@ func TestStatBeforeHash_DetectsChangedFile(t *testing.T) {
 	assert.NotNil(t, state.Items["my-dag"].LastStatSize)
 }
 
-func TestStatBeforeHash_DetectsRecentSameStatContentChange(t *testing.T) {
+func TestStatCacheRacyEdit(t *testing.T) {
 	t.Parallel()
-	tempDir := t.TempDir()
-	dagsDir := filepath.Join(tempDir, "dags")
-	require.NoError(t, os.MkdirAll(dagsDir, 0755))
 
-	originalContent := []byte("echo remote\n")
-	newContent := []byte("echo edited\n")
+	for _, tc := range []struct {
+		name  string
+		delay time.Duration
+	}{
+		{name: "future", delay: -statCacheRacyWindow / 2},
+		{name: "recent", delay: 3 * statCacheRacyWindow / 4},
+		{name: "boundary", delay: statCacheRacyWindow},
+		{name: "delayed", delay: 2 * statCacheRacyWindow},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, dagsDir := newTestService(t, testCfgReadOnly)
+			original := []byte("echo remote\n")
+			edited := []byte("echo edited\n")
+			filePath := filepath.Join(dagsDir, "my-dag.yaml")
+			require.NoError(t, os.WriteFile(filePath, original, 0600))
+
+			mtime := time.Unix(1_700_000_000, 0)
+			oldTime := mtime.Add(-2 * statCacheRacyWindow)
+			require.NoError(t, os.Chtimes(filePath, oldTime, oldTime))
+			hash := ComputeContentHash(original)
+			state := &State{Items: map[string]*SyncItemState{
+				"my-dag": {
+					Status:         StatusSynced,
+					LastSyncedHash: hash,
+					LocalHash:      hash,
+				},
+			}}
+			require.False(t, s.refreshLocalHashes(state, mtime))
+
+			// Refreshes inside the timestamp tick must leave the next edit detectable.
+			require.NoError(t, os.Chtimes(filePath, mtime, mtime))
+			require.False(t, s.refreshLocalHashes(state, mtime.Add(statCacheRacyWindow/4)))
+			require.False(t, s.refreshLocalHashes(state, mtime.Add(statCacheRacyWindow/2)))
+			require.NoError(t, os.WriteFile(filePath, edited, 0600))
+			require.NoError(t, os.Chtimes(filePath, mtime, mtime))
+
+			require.True(t, s.refreshLocalHashes(state, mtime.Add(tc.delay)))
+			assert.Equal(t, StatusModified, state.Items["my-dag"].Status)
+			assert.Equal(t, ComputeContentHash(edited), state.Items["my-dag"].LocalHash)
+
+			// A later stable read restores the cache without changing sync status.
+			require.False(t, s.refreshLocalHashes(state, mtime.Add(3*statCacheRacyWindow)))
+			info, err := os.Stat(filePath)
+			require.NoError(t, err)
+			assert.True(t, statMatchesCache(state.Items["my-dag"], info))
+		})
+	}
+}
+
+func TestStatCacheRestart(t *testing.T) {
+	t.Parallel()
+
+	s, dagsDir := newTestService(t, testCfgReadOnly)
+	original := []byte("echo remote\n")
+	edited := []byte("echo edited\n")
 	filePath := filepath.Join(dagsDir, "my-dag.yaml")
-	require.NoError(t, os.WriteFile(filePath, originalContent, 0600))
-
-	oldHash := ComputeContentHash(originalContent)
-	recent := time.Unix(1_700_000_000, 0)
-	require.NoError(t, os.WriteFile(filePath, newContent, 0600))
-	require.NoError(t, os.Chtimes(filePath, recent, recent))
+	require.NoError(t, os.WriteFile(filePath, original, 0600))
+	mtime := time.Unix(1_700_000_000, 0)
+	require.NoError(t, os.Chtimes(filePath, mtime, mtime))
 	fi, err := os.Stat(filePath)
 	require.NoError(t, err)
 	modTime := fi.ModTime()
 	size := fi.Size()
+	hash := ComputeContentHash(original)
 
-	s := &serviceImpl{dagsDir: dagsDir, cfg: &Config{}}
-	state := &State{Items: map[string]*SyncItemState{
+	// Older versions can persist an unverified stat alongside the synced hash.
+	require.NoError(t, s.stateManager.Save(&State{Version: 1, Items: map[string]*SyncItemState{
 		"my-dag": {
 			Status:          StatusSynced,
-			LastSyncedHash:  oldHash,
-			LocalHash:       oldHash,
+			LastSyncedHash:  hash,
+			LocalHash:       hash,
 			LastStatModTime: &modTime,
 			LastStatSize:    &size,
 		},
-	}}
+	}}))
+	require.NoError(t, os.WriteFile(filePath, edited, 0600))
+	require.NoError(t, os.Chtimes(filePath, modTime, modTime))
 
-	changed := s.refreshLocalHashes(state, recent.Add(statCacheRacyWindow/2))
-	require.True(t, changed)
-	assert.Equal(t, StatusModified, state.Items["my-dag"].Status)
-	assert.Equal(t, ComputeContentHash(newContent), state.Items["my-dag"].LocalHash)
+	restarted := NewService(s.cfg, dagsDir, s.wikiDir, s.dataDir)
+	status, err := restarted.GetStatus(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusModified, status.Items["my-dag"].Status)
+	assert.Equal(t, ComputeContentHash(edited), status.Items["my-dag"].LocalHash)
 }
 
-func TestStatBeforeHash_BackwardCompatibility(t *testing.T) {
+func TestStatCacheRebuild(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()
 	dagsDir := filepath.Join(tempDir, "dags")
@@ -919,6 +975,8 @@ func TestStatBeforeHash_BackwardCompatibility(t *testing.T) {
 	content := []byte("steps: []")
 	filePath := filepath.Join(dagsDir, "my-dag.yaml")
 	require.NoError(t, os.WriteFile(filePath, content, 0600))
+	mtime := time.Now().Add(-2 * statCacheRacyWindow)
+	require.NoError(t, os.Chtimes(filePath, mtime, mtime))
 
 	hash := ComputeContentHash(content)
 
@@ -941,13 +999,16 @@ func TestStatBeforeHash_BackwardCompatibility(t *testing.T) {
 	assert.NotNil(t, state.Items["my-dag"].LastStatSize)
 }
 
-func TestStatBeforeHash_PopulatedDuringScan(t *testing.T) {
+func TestStatCacheScan(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()
 	dagsDir := tempDir
 
-	// Create a DAG file
-	require.NoError(t, os.WriteFile(filepath.Join(dagsDir, "new-dag.yaml"), []byte("steps: []"), 0600))
+	// Stable files can populate the cache during discovery.
+	filePath := filepath.Join(dagsDir, "new-dag.yaml")
+	require.NoError(t, os.WriteFile(filePath, []byte("steps: []"), 0600))
+	mtime := time.Now().Add(-2 * statCacheRacyWindow)
+	require.NoError(t, os.Chtimes(filePath, mtime, mtime))
 
 	s := &serviceImpl{dagsDir: dagsDir, cfg: &Config{}}
 	state := &State{Items: make(map[string]*SyncItemState)}

--- a/internal/gitsync/state.go
+++ b/internal/gitsync/state.go
@@ -253,6 +253,12 @@ func (m *StateManager) Load() (*State, error) {
 	}
 	normalizeTrackedItems(&state)
 
+	// Recheck content after loading; persisted stats may predate a same-tick edit.
+	for _, itemState := range state.Items {
+		itemState.LastStatModTime = nil
+		itemState.LastStatSize = nil
+	}
+
 	m.state = &state
 	return m.state, nil
 }


### PR DESCRIPTION
## Summary
Prevent same-size rapid edits from being missed by the gitsync stat cache on filesystems with coarse or shared modification times.

## Changes
- Treat files with a modification time inside a one-second racy-stat window as requiring content hashing.
- Add a regression test covering a same-size edit with an unchanged cached stat.

## Related Issues
Closes #2749

## Checklist
- [x] Tests added or updated
- [x] Targeted Go tests pass
- [x] `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `internal/gitsync` stat cache missing rapid same-size edits on filesystems with coarse modification times. Stat metadata is now cached only when it was stable before the content read; recent stats stay uncached so later checks re-hash the file, adding a small hashing cost in exchange for accurate status rather than stale sync state. Loaded state now rebuilds cached stats after restart, and tests cover delayed status checks, pull conflicts, and restart recovery; closes #2749.

<sup>Written for commit d93a2ba049ab163048202dbe3528863bfc1de7a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for rapid same-size file updates, including cases where modification times are reused by the filesystem.
  * Local file status and content hashes now update correctly when recent content changes might otherwise go undetected.

* **Tests**
  * Added coverage for detecting content changes when file metadata remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->