### PR TITLE
docs: simplify first-time contributor onboarding

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,9 @@ Closes #issue_number (if applicable)
 - [ ] Documentation has been updated as needed
 - [ ] Changes have been tested locally
 
-## First-PR validation
+<!--
+First-PR validation
 
 - For a focused code change, run the smallest package-scoped check for the package you touched (for example, `make test TEST_TARGET=./path/to/package`). A full `make test` run is not required before opening a first PR; CI and maintainers run the full suite.
 - For docs-only or example-only changes, Go setup and Go tests are not required. Note any relevant documentation or example validation in the PR description.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,8 @@ Closes #issue_number (if applicable)
 - [ ] Tests have been added or updated as needed
 - [ ] Documentation has been updated as needed
 - [ ] Changes have been tested locally
+
+## First-PR validation
+
+- For a focused code change, run the smallest package-scoped check for the package you touched (for example, `make test TEST_TARGET=./path/to/package`). A full `make test` run is not required before opening a first PR; CI and maintainers run the full suite.
+- For docs-only or example-only changes, Go setup and Go tests are not required. Note any relevant documentation or example validation in the PR description.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,12 +35,11 @@ validators are registered through `internal/executor/registry/`.
 ## Ignore until needed
 
 For a first contribution, leave the distributed and optional subsystems alone:
-`internal/service/coordinator/`, `internal/service/worker/`, `llm/`, `tunnel/`,
-`license/`, `cloud/`, `proto/`, and most of `internal/cmn/`.
+`internal/service/coordinator/`, `internal/service/worker/`, `internal/llm/`,
+`internal/tunnel/`, `internal/license/`, `proto/`, and most of `internal/cmn/`.
 
 ## Import rules
 
-`internal/persis/` must not import `internal/service/*`; service handlers stay
-above persistence and domain layers. Keep `internal/cmn/*` domain-independent:
-`internal/cmn/config` may import `internal/auth` and `internal/workspace`, but
-other domain imports do not belong in `internal/cmn/`.
+`internal/persis/` must not import `internal/service/*`, and `internal/cmn/*`
+stays domain-independent. `CLAUDE.md` has the full set under "Architecture
+rules".

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,46 @@
+# Dagu architecture
+
+This is a short map for contributors. Start with the package that owns the
+change; you do not need to understand the whole repository before opening a
+focused PR.
+
+```text
+YAML / spec  ->  IR  ->  intake  ->  runtime  ->  executor
+                                                   |
+                                                   v
+                                             files (persis)
+                                                   |
+                                                   v
+                                             API / UI
+
+internal/spec -> internal/ir -> internal/intake -> internal/runtime
+                                      -> internal/runtime/builtin
+                                      -> internal/persis
+                                      -> internal/service/frontend -> ui/
+```
+
+## Day-one packages
+
+- `internal/spec/` decodes authored YAML and validates it.
+- `internal/ir/` holds canonical DAG definitions and persisted run state.
+- `internal/intake/` admits local and queued runs.
+- `internal/runtime/` plans and runs workflows, including retries and lifecycle.
+- `internal/persis/` defines persistence contracts and file-backed adapters.
+- `internal/service/frontend/` serves the HTTP API, SSE, MCP, and embedded UI assets.
+- `ui/` is the React and TypeScript frontend.
+
+Executors live under `internal/runtime/builtin/`; their metadata, schemas, and
+validators are registered through `internal/executor/registry/`.
+
+## Ignore until needed
+
+For a first contribution, leave the distributed and optional subsystems alone:
+`internal/service/coordinator/`, `internal/service/worker/`, `llm/`, `tunnel/`,
+`license/`, `cloud/`, `proto/`, and most of `internal/cmn/`.
+
+## Import rules
+
+`internal/persis/` must not import `internal/service/*`; service handlers stay
+above persistence and domain layers. Keep `internal/cmn/*` domain-independent:
+`internal/cmn/config` may import `internal/auth` and `internal/workspace`, but
+other domain imports do not belong in `internal/cmn/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ You do not need to understand the whole repository before making a useful first 
 | Track | Start with | First check |
 | --- | --- | --- |
 | Docs / examples | A Markdown file or `examples/` | No build is required; validate a changed DAG with `dagu validate` if you have the binary available |
-| UI | `ui/` | Start the backend with `make run-server`, then run `cd ui && pnpm install --frozen-lockfile && pnpm dev` |
+| UI | `ui/` | Start the backend with `make run-server`, then run `cd ui && pnpm install && pnpm dev` |
 | One executor | `internal/runtime/builtin/EXECUTOR_PACKAGE` | `make test TEST_TARGET=./internal/runtime/builtin/EXECUTOR_PACKAGE` (replace `EXECUTOR_PACKAGE` with the package name) |
 | API / CLI | `internal/service/frontend/api/v1` or `internal/cmd` | `make test TEST_TARGET=./internal/service/frontend/api/v1` or the matching package |
 
@@ -65,11 +65,11 @@ For UI changes:
 
 ```bash
 cd ui
-pnpm install --frozen-lockfile
+pnpm install
 pnpm test
 ```
 
-Docs-only and example-only changes do not need Go tests. If an example changes a DAG, validate it with the `dagu` binary when available. CI and maintainers run the full suite; you do not need to run it before opening a focused first PR.
+Docs-only and example-only changes do not need Go tests. If an example changes a DAG, validate it with the `dagu` binary when available.
 
 The full repository check is primarily for CI and maintainers. Run it locally
 when practical:
@@ -85,9 +85,7 @@ To run tests with code coverage analysis:
 make test-coverage
 ```
 
-After changing Go files, format the files you touched before opening the PR.
-`make fmt` runs the repository-wide Go fix, formatting, and lint-fix pass; use
-it when that broader pass is appropriate for the change.
+After changing Go files, run `make fmt` and check the diff before opening the PR.
 
 
 
@@ -103,7 +101,7 @@ Starting the development server:
 
 ```bash
 cd ui
-pnpm install --frozen-lockfile
+pnpm install
 pnpm dev
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,22 @@
 
 Thank you for considering to help improve Dagu! We welcome contributions from anyone on the internet.
 
-## Quick Start
+You do not need to understand the whole repository before making a useful first change.
 
-- Browse [`good first issue`](https://github.com/dagucloud/dagu/labels/good%20first%20issue) or [`help wanted`](https://github.com/dagucloud/dagu/labels/help%20wanted) labels and comment to claim.
-- Join the [Discord server](https://discord.gg/gpahPUjGRk) for questions or to share progress.
+## First 15 Minutes
 
-## Getting Started
+1. Fork the repository and clone it locally.
+2. Pick a small issue, then comment on it to claim the work. Use the [Discord server](https://discord.gg/gpahPUjGRk) if you have questions or get stuck for 20 minutes; that is expected.
+3. Choose the track closest to your change:
 
-- Fork the repository and clone it locally
-- Look for any issue that interests you
-- Make your changes and test them
-- Ask questions if anything is unclear
+| Track | Start with | First check |
+| --- | --- | --- |
+| Docs / examples | A Markdown file or `examples/` | No build is required; validate a changed DAG with `dagu validate` if you have the binary available |
+| UI | `ui/` | Start the backend with `make run-server`, then run `cd ui && pnpm install && pnpm dev` |
+| One executor | `internal/runtime/builtin/<name>` | `make test TEST_TARGET=./internal/runtime/builtin/<name>` |
+| API / CLI | `internal/service/frontend/api/v1` or `internal/cmd` | `make test TEST_TARGET=./internal/service/frontend/api/v1` or the matching package |
+
+For a first PR, change only the files needed for the issue. You do not need to learn every package or run the full test suite before opening a focused PR.
 
 ## How to Contribute
 
@@ -28,11 +33,11 @@ We welcome contributions of all kinds, including:
 
 ## Development
 
-Prerequisites:
+Prerequisites depend on your track:
 
-- [Go (latest stable)](https://go.dev/doc/install)
-- [Node.js](https://nodejs.org/en/download/)
-- [pnpm](https://pnpm.io/installation)
+- Go 1.27 or newer for Go and backend changes ([install Go](https://go.dev/doc/install)).
+- Node.js 18.18 or newer and [pnpm](https://pnpm.io/installation) for UI changes.
+- Docs-only changes do not require the Go toolchain.
 
 Building frontend assets:
 
@@ -48,9 +53,22 @@ make bin
 
 ## Running Tests
 
-To ensure the integrity of the go code, you can run all Go unit and integration tests.
+Run the smallest relevant check first. For a Go package, pass its path through `TEST_TARGET`:
 
-Run all tests from the project root directory:
+```bash
+make test TEST_TARGET=./path/to/changed/package
+```
+
+For UI changes:
+
+```bash
+cd ui
+pnpm test
+```
+
+Docs-only and example-only changes do not need Go tests. If an example changes a DAG, validate it with the `dagu` binary when available. CI and maintainers run the full suite; you do not need to run it before opening a focused first PR.
+
+For the full local Go check:
 
 ```bash
 make lint
@@ -70,7 +88,7 @@ make test-coverage
 Starting the backend server on port 8080:
 
 ```bash
-DAGU_PORT=8080 make
+make run-server
 ```
 
 Starting the development server:
@@ -93,9 +111,9 @@ Navigate to [http://localhost:8081](http://localhost:8081) to view hot-reloading
 
 Before submitting:
 
-- [ ] Tests pass (`make test`)
-- [ ] Linter passes (`make lint`)
-- [ ] New code includes tests
+- [ ] The smallest relevant test or validation command passes
+- [ ] `make lint` passes for Go changes when practical
+- [ ] New code includes tests when behavior changes
 - [ ] Documentation updated if applicable
 - [ ] Commit messages following the [Go Commit Message Guidelines](https://go.dev/wiki/CommitMessage)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ We welcome contributions of all kinds, including:
 
 Prerequisites depend on your track:
 
-- Go 1.27.0 or newer for Go and backend changes ([install Go](https://go.dev/doc/install)).
-- Node.js 18.18 or newer and [pnpm](https://pnpm.io/installation) for UI changes.
-- Go 1.27.0 or newer is also required for the UI development loop because `make run-server` builds the backend.
+- [Go (latest stable)](https://go.dev/doc/install) for Go and backend changes.
+- [Node.js (latest stable)](https://nodejs.org/en/download/) and [pnpm](https://pnpm.io/installation) for UI changes.
+- Go is also needed for the UI development loop, since starting the backend builds it.
 - Docs-only changes do not require the Go toolchain.
 
 Building frontend assets:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ You do not need to understand the whole repository before making a useful first 
 | Track | Start with | First check |
 | --- | --- | --- |
 | Docs / examples | A Markdown file or `examples/` | No build is required; validate a changed DAG with `dagu validate` if you have the binary available |
-| UI | `ui/` | Start the backend with `make run-server`, then run `cd ui && pnpm install && pnpm dev` |
-| One executor | `internal/runtime/builtin/<name>` | `make test TEST_TARGET=./internal/runtime/builtin/<name>` |
+| UI | `ui/` | Start the backend with `make run-server`, then run `cd ui && pnpm install --frozen-lockfile && pnpm dev` |
+| One executor | `internal/runtime/builtin/EXECUTOR_PACKAGE` | `make test TEST_TARGET=./internal/runtime/builtin/EXECUTOR_PACKAGE` (replace `EXECUTOR_PACKAGE` with the package name) |
 | API / CLI | `internal/service/frontend/api/v1` or `internal/cmd` | `make test TEST_TARGET=./internal/service/frontend/api/v1` or the matching package |
 
 For a first PR, change only the files needed for the issue. You do not need to learn every package or run the full test suite before opening a focused PR.
@@ -35,8 +35,9 @@ We welcome contributions of all kinds, including:
 
 Prerequisites depend on your track:
 
-- Go 1.27 or newer for Go and backend changes ([install Go](https://go.dev/doc/install)).
+- Go 1.27.0 or newer for Go and backend changes ([install Go](https://go.dev/doc/install)).
 - Node.js 18.18 or newer and [pnpm](https://pnpm.io/installation) for UI changes.
+- Go 1.27.0 or newer is also required for the UI development loop because `make run-server` builds the backend.
 - Docs-only changes do not require the Go toolchain.
 
 Building frontend assets:
@@ -53,7 +54,8 @@ make bin
 
 ## Running Tests
 
-Run the smallest relevant check first. For a Go package, pass its path through `TEST_TARGET`:
+Run the smallest relevant check first. For a first code change, pass the Go
+package you touched through `TEST_TARGET`:
 
 ```bash
 make test TEST_TARGET=./path/to/changed/package
@@ -63,12 +65,14 @@ For UI changes:
 
 ```bash
 cd ui
+pnpm install --frozen-lockfile
 pnpm test
 ```
 
 Docs-only and example-only changes do not need Go tests. If an example changes a DAG, validate it with the `dagu` binary when available. CI and maintainers run the full suite; you do not need to run it before opening a focused first PR.
 
-For the full local Go check:
+The full repository check is primarily for CI and maintainers. Run it locally
+when practical:
 
 ```bash
 make lint
@@ -80,6 +84,10 @@ To run tests with code coverage analysis:
 ```bash
 make test-coverage
 ```
+
+After changing Go files, format the files you touched before opening the PR.
+`make fmt` runs the repository-wide Go fix, formatting, and lint-fix pass; use
+it when that broader pass is appropriate for the change.
 
 
 
@@ -95,7 +103,7 @@ Starting the development server:
 
 ```bash
 cd ui
-pnpm install
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ run: ${FE_BUNDLE_JS}
 
 # server build the binary and start the server.
 .PHONY: run-server
-run-server: golangci-lint bin
+run-server: bin
 	@printf '%b\n' "${COLOR_GREEN}Starting the server...${COLOR_RESET}"
 	${LOCAL_BIN_DIR}/${APP_BIN_NAME} server
 

--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ The embedded API is experimental and may change. See the [embedded API documenta
 
 ## Development
 
-**Prerequisites:** [Go 1.27+](https://go.dev/doc/install), [Node.js](https://nodejs.org/en/download/), [pnpm](https://pnpm.io/installation)
+**Prerequisites:** [Go 1.27.0+](https://go.dev/doc/install), [Node.js 18.18+](https://nodejs.org/en/download/), [pnpm](https://pnpm.io/installation)
 
 ```sh
 git clone https://github.com/dagucloud/dagu.git && cd dagu
@@ -1027,7 +1027,11 @@ make test     # Run tests with race detection
 make lint     # Run golangci-lint
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development workflow and code standards.
+For the local UI development loop, run `make run-server` from the repository
+root, then follow [`ui/README.md`](./ui/README.md). See
+[`ARCHITECTURE.md`](./ARCHITECTURE.md) for a human-oriented repository map and
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the focused first-PR workflow and
+code standards.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ The embedded API is experimental and may change. See the [embedded API documenta
 
 ## Development
 
-**Prerequisites:** [Go 1.27.0+](https://go.dev/doc/install), [Node.js 18.18+](https://nodejs.org/en/download/), [pnpm](https://pnpm.io/installation)
+**Prerequisites:** [Go (latest stable)](https://go.dev/doc/install), [Node.js (latest stable)](https://nodejs.org/en/download/), [pnpm](https://pnpm.io/installation)
 
 ```sh
 git clone https://github.com/dagucloud/dagu.git && cd dagu

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- Go 1.27.0 or newer
-- Node.js 18.18 or newer
+- Go (latest stable)
+- Node.js (latest stable)
 - pnpm
 
 ## Development Instructions

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,19 +2,18 @@
 
 ## Prerequisites
 
-- Node.js (latest stable version)
+- Go 1.27.0 or newer
+- Node.js 18.18 or newer
 - pnpm
 
 ## Development Instructions
 
 ### 1. Starting the Backend Server
 
-The Dagu UI relies on a backend server that provides the necessary data for the UI to function properly. To start the backend server, navigate to the project root directory and execute the following command:
+The Dagu UI relies on a backend server that provides the necessary data for the UI to function properly. From the repository root, run:
 
 ```bash
-git clone git@github.com:dagucloud/dagu.git
-cd dagu
-make server
+make run-server
 ```
 
 This command will start the backend server at 127.0.0.1:8080 by default. If you need to use a different address or port, you can modify the appropriate settings in the backend configuration file.
@@ -25,7 +24,7 @@ Once the backend server is up and running, you can start the Webpack dev server 
 
 ```bash
 cd ui/
-pnpm install
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -24,7 +24,7 @@ Once the backend server is up and running, you can start the Webpack dev server 
 
 ```bash
 cd ui/
-pnpm install --frozen-lockfile
+pnpm install
 pnpm dev
 ```
 
@@ -39,4 +39,4 @@ cd ../
 make ui
 ```
 
-This command will build the `bundle.js` file and copy it to dagu/frontend/assets/js/bundle.js. This is necessary for the Go backend to include the JavaScript within the binary.
+This command will build the `bundle.js` file and copy it to `internal/service/frontend/assets/`. This is necessary for the Go backend to include the JavaScript within the binary.

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "description": "Web UI for Dagu",
   "private": true,
   "engines": {
-    "node": ">=18.18.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "webpack --config webpack.prod.js",


### PR DESCRIPTION
## Summary

Complete the bounded first-contributor onboarding requested in #2569 without adding a handbook. No product code changes; two build-config files are touched, see the maintainer follow-up below.

## Changes

- Add a one-page human architecture map covering YAML/spec, IR, intake, runtime, executors, persistence, and API/UI, with day-one packages, an ignore list, and import rules.
- Link `ARCHITECTURE.md`, `CONTRIBUTING.md`, and the UI development guide from the README development section.
- Add package-scoped first-PR and docs-only validation guidance to the pull request template.
- Reconcile Go, Node.js, pnpm, and backend startup instructions across `CONTRIBUTING.md`, `ui/README.md`, and the README source-development section.
- Fix the shell-unsafe executor placeholder and document that the UI loop requires Go because `make run-server` builds the backend.

The public `docs.dagu.sh` contributing page is maintained in the separate `dagucloud/docs` repository and is intentionally not changed by this Dagu PR.

## Maintainer follow-up

Pushed to this branch after review. Nothing here changes the direction of the PR.

- **Start the server without a full-repo lint.** `run-server` depended on the `golangci-lint` target, which runs `golangci-lint run --fix ./...` twice, once natively and once under `GOOS=windows`. Starting the backend for UI work waited on a full lint, rewrote Go files in the working tree, and aborted before the server came up if anything was not auto-fixable. `run-scheduler` still has the same prerequisite and is left for a separate change.
- **Stop pinning toolchain versions in docs.** Pinned Go and Node numbers duplicate `go.mod` and `ui/package.json`, so a toolchain bump becomes a multi-file prose edit and the prose is what gets forgotten. Back to "latest stable", which is what `CONTRIBUTING.md` and `ui/README.md` said before this branch.
- **Fix `ARCHITECTURE.md` paths.** The ignore list named `llm/`, `tunnel/` and `license/` as repository-root directories when they live under `internal/`, and `cloud/` does not exist here. The import rules were a verbatim second copy of the `CLAUDE.md` architecture rules, so they are now summarised with a pointer.
- **Require Node 20 in `ui/package.json` engines.** The declared floor of 18.18 is below what the toolchain runs on: the lockfile pins vitest at `^20.0.0 || ^22.0.0 || >=24.0.0`, and react-router and @rjsf/core both need `>=20`. CI already uses Node 20 everywhere.
- **Hide the first-PR guidance from rendered PR bodies.** It is guidance for the author rather than something they fill in, so as plain Markdown it shipped as boilerplate in every merged description. Now an HTML comment.
- **Tidy remaining drift.** Plain `pnpm install` instead of the CI `--frozen-lockfile` flag, which fails with `ERR_PNPM_OUTDATED_LOCKFILE` the moment a contributor adds a dependency. Name `make fmt` instead of describing it. Drop a sentence that repeated the point two lines above. Correct the asset destination `make ui` writes to.

Verified that `make run-server` builds, starts, binds its port and returns 200 with no lint step.

You were right that the `docs.dagu.sh` contributing page is out of scope; it lives in `dagu-org/docs`, not here.

## Related Issues

Closes #2569

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of the code has been performed
- [x] Tests have been added or updated as needed
- [x] Documentation has been updated as needed
- [x] Changes have been tested locally (`git diff --check`, local Markdown-link check, and Make target dry-runs)
