### PR TITLE
Pull the MinIO test image from quay.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
             "alpine:3"
             "busybox:latest"
             "redis:7-alpine"
-            "minio/minio:RELEASE.2024-10-02T17-50-41Z"
+            "quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z"
           )
 
           for image in "${images[@]}"; do

--- a/internal/intg/s3_test.go
+++ b/internal/intg/s3_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const minioImage = "minio/minio:RELEASE.2024-10-02T17-50-41Z"
+const minioImage = "quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z"
 
 // TestMinIOContainer_WithMCCommands tests S3-like operations using MinIO's mc client
 // inside a container. This validates the container-based workflow pattern for object storage.


### PR DESCRIPTION
## Problem

CI is red on `Test on ubuntu-latest (2/2)` for every PR, at the `Pre-pull integration test images` step:

```
failed to pull minio/minio:RELEASE.2024-10-02T17-50-41Z
```

This is not rate limiting, credentials, or a transient flake:

- The `Login to Docker Hub` step succeeds, and the job fails only afterwards.
- The three other pre-pulled Docker Hub images in the same loop (`alpine:3`, `busybox:latest`, `redis:7-alpine`) resolve fine; the loop is sequential and only the MinIO entry fails, after all four retry attempts.
- A local pull reports `pull access denied for minio/minio, repository does not exist or may require 'docker login'`.
- The Docker Hub API reports the pinned tag as `object not found`, and anonymous manifest requests against `minio/minio` return 401 for **every** tag, including `latest`.

So MinIO has gated the repository on Docker Hub rather than retiring one tag. Nothing in this repository changed; main last went green on 2026-09-11.

## Fix

MinIO publishes the same releases to quay.io, which still serves them anonymously. The pin moves there and keeps the exact same version, so test behavior is unchanged.

Verified by pulling it:

```
$ docker pull quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z
Digest: sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
Status: Downloaded newer image for quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z
```

and running the suite that uses it:

```
$ go test ./internal/intg/ -run TestMinIO -count=1
ok    github.com/dagucloud/dagu/v2/internal/intg      2.938s
```

The Docker Hub login step stays as it is, since the other three images still come from there.

https://claude.ai/code/session_01XMjTvsP1wwFaoDbQyLxPVz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by moving the MinIO test image from Docker Hub to `quay.io`. Docker Hub no longer serves the pinned MinIO release, causing pull access denied. The same version is available on `quay.io` anonymously, so the tests now run without changing behavior.

<sup>Written for commit 08e8de2bca5666b9dd04fc26426f5c1f42f25772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MinIO image source used by integration testing to the Quay.io registry while retaining the same release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->