### PR TITLE
feat(cli): add JSON output to dagu ps

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -414,6 +414,13 @@ var (
 		shorthand: "r",
 		usage:     "Filter by run ID (partial match supported)",
 	}
+
+	psFormatFlag = commandLineFlag{
+		name:         "format",
+		shorthand:    "f",
+		defaultValue: "table",
+		usage:        "Output format: table or json (default: table)",
+	}
 )
 
 // Tunnel flags

--- a/internal/cmd/ps.go
+++ b/internal/cmd/ps.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -25,13 +26,18 @@ func Ps() *cobra.Command {
 Flags:
   -d, --dag string      Filter by DAG name
   -r, --run-id string   Filter by run ID (partial match supported)
+  -f, --format string   Output format: table or json (default: table)
 
 Columns: DAG, RUN_ID, ATTEMPT, STARTED, GROUP, FRESH
+
+JSON output is a list, empty when nothing is running, so a script can read
+the result without parsing the table.
 
 Examples:
   dagu ps
   dagu ps -d my-workflow
   dagu ps -d my-workflow -r abc123
+  dagu ps --format json
 `,
 			Args: cobra.NoArgs,
 		},
@@ -43,6 +49,7 @@ Examples:
 var psFlags = []commandLineFlag{
 	psDAGFlag,
 	psRunIDFlag,
+	psFormatFlag,
 }
 
 func runPs(ctx *Context, args []string) error {
@@ -55,6 +62,13 @@ func runPs(ctx *Context, args []string) error {
 	runIDFilter, err := ctx.StringParam("run-id")
 	if err != nil {
 		return fmt.Errorf("failed to get run-id filter: %w", err)
+	}
+	format, err := ctx.StringParam("format")
+	if err != nil {
+		return fmt.Errorf("failed to get format: %w", err)
+	}
+	if err := validatePsFormat(format); err != nil {
+		return err
 	}
 
 	if ctx.Persistence.ProcRepository == nil {
@@ -80,6 +94,10 @@ func runPs(ctx *Context, args []string) error {
 		matched = append(matched, entry)
 	}
 
+	if format == "json" {
+		return renderPsJSON(ctx.Command.OutOrStdout(), matched)
+	}
+
 	if len(matched) == 0 {
 		if !ctx.Quiet {
 			if _, err := fmt.Fprintln(ctx.Command.OutOrStdout(), "No running processes"); err != nil {
@@ -90,6 +108,46 @@ func runPs(ctx *Context, args []string) error {
 	}
 
 	return renderPsTable(ctx.Command.OutOrStdout(), matched)
+}
+
+// validatePsFormat checks if the output format is valid.
+func validatePsFormat(format string) error {
+	switch format {
+	case "", "table", "json":
+		return nil
+	default:
+		return fmt.Errorf("invalid format '%s'. Valid formats: table, json", format)
+	}
+}
+
+// renderPsJSON writes live DAG processes as a list, which stays empty rather
+// than becoming a message when nothing is running.
+func renderPsJSON(out io.Writer, entries []proc.ProcEntry) error {
+	type psEntry struct {
+		Name      string `json:"name"`
+		DAGRunID  string `json:"dagRunId"`
+		AttemptID string `json:"attemptId,omitempty"`
+		StartedAt string `json:"startedAt,omitempty"`
+		Group     string `json:"group"`
+	}
+
+	listed := make([]psEntry, 0, len(entries))
+	for _, entry := range entries {
+		item := psEntry{
+			Name:      entry.Meta.Name,
+			DAGRunID:  entry.Meta.DAGRunID,
+			AttemptID: entry.Meta.AttemptID,
+			Group:     entry.GroupName,
+		}
+		if entry.Meta.StartedAt > 0 {
+			item.StartedAt = time.Unix(entry.Meta.StartedAt, 0).UTC().Format(time.RFC3339)
+		}
+		listed = append(listed, item)
+	}
+
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(listed)
 }
 
 func renderPsTable(out io.Writer, entries []proc.ProcEntry) error {

--- a/internal/cmd/ps_test.go
+++ b/internal/cmd/ps_test.go
@@ -5,6 +5,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -23,6 +24,33 @@ func TestPsCommand(t *testing.T) {
 		th := test.SetupCommand(t)
 		out := runPsWithStdout(t, th, cmd.Ps(), []string{"ps"})
 		assert.Contains(t, out, "No running processes")
+	})
+
+	t.Run("ReportsNothingRunningAsAnEmptyJSONList", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.SetupCommand(t)
+		out := runPsWithStdout(t, th, cmd.Ps(), []string{"ps", "--format", "json"})
+
+		var entries []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &entries))
+		assert.Empty(t, entries)
+	})
+
+	t.Run("RejectsAnUnknownFormat", func(t *testing.T) {
+		t.Parallel()
+
+		th := test.SetupCommand(t)
+		root := &cobra.Command{Use: "root"}
+		root.AddCommand(cmd.Ps())
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs(test.WithConfigFlag([]string{"ps", "--format", "yaml"}, th.Config))
+
+		err := root.ExecuteContext(th.Context)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "table")
 	})
 
 	t.Run("ListsAndFiltersAliveProcess", func(t *testing.T) {
@@ -61,6 +89,22 @@ steps:
 
 		out = runPsWithStdout(t, th, cmd.Ps(), []string{"ps", "-d", "other-dag"})
 		assert.Contains(t, out, "No running processes")
+
+		out = runPsWithStdout(t, th, cmd.Ps(), []string{"ps", "--format", "json"})
+		var entries []struct {
+			Name      string `json:"name"`
+			DAGRunID  string `json:"dagRunId"`
+			AttemptID string `json:"attemptId"`
+			StartedAt string `json:"startedAt"`
+			Group     string `json:"group"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &entries))
+		require.Len(t, entries, 1)
+		assert.Equal(t, dag.Name, entries[0].Name)
+		assert.Equal(t, runID, entries[0].DAGRunID)
+		assert.Equal(t, "attempt-1", entries[0].AttemptID)
+		assert.Equal(t, startedAt.Format(time.RFC3339), entries[0].StartedAt)
+		assert.Equal(t, dag.ProcGroup(), entries[0].Group)
 	})
 }
 


### PR DESCRIPTION
## What

`dagu ps` gains `--format json` (`-f json`), alongside the existing table output:

```console
$ dagu ps --format json
[]

$ dagu ps --format json
[
  {
    "name": "sleeper",
    "dagRunId": "json-probe",
    "attemptId": "c9f6ec",
    "startedAt": "2026-09-12T13:37:47Z",
    "group": "sleeper"
  }
]
```

The table remains the default, so nothing changes for anyone reading `ps` by eye.

## Why

`ps` is the only way to ask "is anything running here?" without a server, since it reads the local process store. But a program asking that question today has to parse a space-padded table and tell the `No running processes` line apart from a data row — so it depends on wording and column layout that are free to change, and it breaks silently when they do.

JSON answers the same question as a list that is empty when nothing is running.

## Notes

- The flag follows `dagu history`, which already takes `--format table|json|csv`. `ps` accepts `table` and `json`, and rejects anything else with `invalid format 'yaml'. Valid formats: table, json` (exit 1).
- Output goes to the command's writer, like the table, so it is captured the same way in tests.
- Only fresh entries are listed, exactly as the table does, so the JSON omits the always-true `FRESH` column.

## Tests

`internal/cmd/ps_test.go` covers an empty list when nothing is running, the fields of a live entry, and the rejected format. Verified against a real run with a built binary; `go test ./internal/cmd/` and `go vet ./internal/cmd/...` pass.

https://claude.ai/code/session_018P1FBQPvwgTVE7eiqcvUH7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--format json` to `dagu ps` so scripts can read running processes as a parsed list instead of a space-padded table.

The table output remains the default, and JSON is an empty list when nothing is running. The flag accepts `table` or `json`, rejects anything else with an error, and mirrors the field naming and UTC timestamps used elsewhere in the CLI.

<sup>Written for commit a87ba98c71ad321e3bf5db34aa0abbcca295ce89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dagucloud/dagu/pull/2757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `table` and `json` output formats to the `ps` command.
  * JSON output presents process information as an indented list, including when no processes are running.
  * Added command help and validation for supported format values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->